### PR TITLE
New stup in INSTALL, use:  git clone --recursive

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -50,31 +50,36 @@ of `autoconf'.
 
    The simplest way to compile this package is:
 
-  1. `cd' to the directory containing the package's source code and type
+  1. From a shell command prompt, retrieve the latest source from the
+     git repository and sub repositories by typing:
+     
+     `git clone --recursive https://github.com/xroche/httrack.git'
+
+  2. `cd' to the directory containing the package's source code and type
      `./configure' to configure the package for your system.
 
      Running `configure' might take a while.  While running, it prints
      some messages telling which features it is checking for.
 
-  2. Type `make' to compile the package.
+  3. Type `make' to compile the package.
 
-  3. Optionally, type `make check' to run any self-tests that come with
+  4. Optionally, type `make check' to run any self-tests that come with
      the package, generally using the just-built uninstalled binaries.
 
-  4. Type `make install' to install the programs and any data files and
+  5. Type `make install' to install the programs and any data files and
      documentation.  When installing into a prefix owned by root, it is
      recommended that the package be configured and built as a regular
      user, and only the `make install' phase executed with root
      privileges.
 
-  5. Optionally, type `make installcheck' to repeat any self-tests, but
+  6. Optionally, type `make installcheck' to repeat any self-tests, but
      this time using the binaries in their final installed location.
      This target does not install anything.  Running this target as a
      regular user, particularly if the prior `make install' required
      root privileges, verifies that the installation completed
      correctly.
 
-  6. You can remove the program binaries and object files from the
+  7. You can remove the program binaries and object files from the
      source code directory by typing `make clean'.  To also remove the
      files that `configure' created (so you can compile the package for
      a different kind of computer), type `make distclean'.  There is
@@ -83,12 +88,12 @@ of `autoconf'.
      all sorts of other programs in order to regenerate files that came
      with the distribution.
 
-  7. Often, you can also type `make uninstall' to remove the installed
+  8. Often, you can also type `make uninstall' to remove the installed
      files again.  In practice, not all packages have tested that
      uninstallation works correctly, even though it is required by the
      GNU Coding Standards.
 
-  8. Some packages, particularly those that use Automake, provide `make
+  9. Some packages, particularly those that use Automake, provide `make
      distcheck', which can by used by developers to test that all other
      targets like `make install' and `make uninstall' work correctly.
      This target is generally not run by end users.


### PR DESCRIPTION
Add inorder to use git submodules.  Build fails mysteriously if you try using just {{git clone.}}

My personal experience has been that git submodules are often more trouble than they're 
worth.  But INSTALL should be updated with the correct method to get compilable source what ever that method is.

