### PR TITLE
Support servers with SNI extension

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -2536,6 +2536,9 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
               // new session
               back[i].r.ssl_con = SSL_new(openssl_ctx);
               if (back[i].r.ssl_con) {
+                const char* hostname = jump_protocol_const(back[i].url_adr);
+                // some servers expect the hostname on the clienthello (SNI TLS extension)
+                SSL_set_tlsext_host_name(back[i].r.ssl_con, hostname);
                 SSL_clear(back[i].r.ssl_con);
                 if (SSL_set_fd(back[i].r.ssl_con, (int) back[i].r.soc) == 1) {
                   SSL_set_connect_state(back[i].r.ssl_con);


### PR DESCRIPTION
Some servers require [SNI extension](https://www.networking4all.com/en/ssl+certificates/faq/server+name+indication/) to work.

For reference httrack was displaying the following error when attempting to access such a server:
> Error:  "error:00000001:lib(0):func(0):reason(1)" (-5) after 2 retries at link