### PR TITLE
Fix for handling changes introduced in postprocess

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -3341,12 +3341,10 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
           hts_log_print(opt, LOG_DEBUG, "engine: postprocess-html: %s%s",
                         urladr(), urlfil());
           if (RUN_CALLBACK4(opt, postprocess, &cAddr, &cSize, urladr(), urlfil()) == 1) {
-            if (cAddr != TypedArrayElts(output_buffer)) {
-              hts_log_print(opt, LOG_DEBUG, 
-                "engine: postprocess-html: callback modified data, applying %d bytes", cSize);
-              TypedArraySize(output_buffer) = 0;
-              TypedArrayAppend(output_buffer, cAddr, cSize);
-            }
+            hts_log_print(opt, LOG_DEBUG,
+              "engine: postprocess-html: callback modified data, applying %d bytes", cSize);
+            TypedArraySize(output_buffer) = 0;
+            TypedArrayAppend(output_buffer, cAddr, cSize);
           }
         }
 


### PR DESCRIPTION
Plugin postprocessing didn't introduce changes in files if string chain pointer didn't change. I removed additional check for that so HTTrack will now depend only on return value from plugin to apply changes.
Let me know if you need tests for this fix.