### PR TITLE
Fix Android build

### DIFF
--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -30,9 +30,6 @@ Please visit our Website: http://www.httrack.com
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#ifdef __ANDROID__
-static long int  timezone = 0;
-#endif
 
 /* Locking */
 #ifdef _WIN32


### PR DESCRIPTION
The NDK headers nowadays has timezone in time.h, so trying to redefine it
causes the build to fail with:

```
proxy/store.c:34:18: error: static declaration of 'timezone' follows non-static declaration
static long int  timezone = 0;
                 ^
include/time.h:42:17: note: previous declaration is here
extern long int timezone;
```

This patch is used when building httrack for [Termux[(https://termux.com/).