### PR TITLE
feature: Support data-src and data-srcset

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -115,6 +115,8 @@ const char *hts_detect[] = {
   "archive",
   "background",
   "data",                       // OBJECT
+  "data-src",
+  "data-srcset",
   "dynsrc",
   "lowsrc",
   "profile",                    // element META


### PR DESCRIPTION
Increasingly HTML5 sites use a number of mechanisms for responsive
image loading.  Many of these mechanisms revolve around the use of
`data-src` and `data-srcset` attributes within an img tag to provide a
list of valid images to display, along with their relevant sizes (e.g.
https://github.com/aFarkas/lazysizes, https://github.com/malchata/yall.js).

This change adds the two previously mentioned tags to the list in
`hts_detect[]`, resulting in httrack detecting them correctly.

Initially an attempt was made at using `hts_detectbeg[]` with the
potential of resolving #203.  Unfortunately it became apparent that the
implementation of `hts_detectbeg[]` only supports a suffix of integers
(see `src/htstools.h#rech_tageqbegdigits` for more information).