### PR TITLE
configure: Avoid implicit declaration of exit, strcmp in snprintf probes

### DIFF
--- a/configure
+++ b/configure
@@ -15111,6 +15111,8 @@ else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 int main(void)
 {
@@ -15150,6 +15152,8 @@ else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <stdarg.h>
 
 int my_vsnprintf (char *buf, const char *tmpl, ...)

--- a/m4/snprintf.m4
+++ b/m4/snprintf.m4
@@ -4,6 +4,8 @@ AC_MSG_CHECKING(for working snprintf)
 AC_CACHE_VAL(ac_cv_have_working_snprintf,
 [AC_TRY_RUN(
 [#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 int main(void)
 {
@@ -23,6 +25,8 @@ AC_MSG_CHECKING(for working vsnprintf)
 AC_CACHE_VAL(ac_cv_have_working_vsnprintf,
 [AC_TRY_RUN(
 [#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <stdarg.h>
 
 int my_vsnprintf (char *buf, const char *tmpl, ...)


### PR DESCRIPTION
Future compilers will not support implicit function declarations by default, so add the additional #include directives for the appropriate function prototypes.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
