### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/src/punycode.c
+++ b/src/punycode.c
@@ -31,9 +31,9 @@ enum { base = 36, tmin = 1, tmax = 26, skew = 38, damp = 700,
 /* point (for use in representing integers) in the range 0 to */
 /* base-1, or base if cp is does not represent a value.       */
 
-static punycode_uint decode_digit(punycode_uint cp) {
-  return cp - 48 < 10 ? cp - 22 : cp - 65 < 26 ? cp - 65 : cp - 97 <
-    26 ? cp - 97 : base;
+static unsigned decode_digit(int cp) {
+  return (unsigned) (cp - 48 < 10 ? cp - 22 : cp - 65 < 26 ? cp - 65 : cp - 97 <
+    26 ? cp - 97 : base);
 }
 
 /* encode_digit(d,flag) returns the basic code point whose value      */


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in decode_digit() that was cloned from libidn2 but did not receive the security patch. The original issue was reported and fixed under https://github.com/libidn/libidn2/commit/3284eb342cd0ed1a18786e3fcdf0cdd7e76676bd.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2017-14062
https://github.com/libidn/libidn2/commit/3284eb342cd0ed1a18786e3fcdf0cdd7e76676bd
