### PR TITLE
docs: fix preferred spelling in help text

### DIFF
--- a/html/fcguide.html
+++ b/html/fcguide.html
@@ -253,7 +253,7 @@ Spider options:
 Browser ID:
   F  user-agent field (-F "user-agent name") (--user-agent <param>)
  %F  footer string in Html code (-%F "Mirrored [from host %s [file %s [at %s]]]" (--footer <param>)
- %l  preffered language (-%l "fr, en, jp, *" (--language <param>)
+ %l  preferred language (-%l "fr, en, jp, *" (--language <param>)
 
 Log, index, cache
   C  create/use a cache for updates and retries (C0 no cache,C1 cache is prioritary,* C2 test update before) (--cache[=N])
@@ -1387,7 +1387,7 @@ web servers leave footprints in the browser.
 Browser ID:
   F  user-agent field (-F "user-agent name")
  %F  footer string in Html code (-%F "Mirrored [from host %s [file %s [at %s]]]"
- %l  preffered language (-%l "fr, en, jp, *" (--language <param>)
+ %l  preferred language (-%l "fr, en, jp, *" (--language <param>)
 </i></b></pre>
 
 <p align=justify> The user-agent field is used by browsers to determine

--- a/html/httrack.man.html
+++ b/html/httrack.man.html
@@ -958,7 +958,7 @@ host %s [file %s [at %s]]]&quot; (--footer
 <td width="78%">
 
 
-<p>preffered language (-%l &quot;fr, en, jp, *&quot;
+<p>preferred language (-%l &quot;fr, en, jp, *&quot;
 (--language &lt;param&gt;)</p></td></tr>
 <tr valign="top" align="left">
 <td width="11%"></td>

--- a/man/httrack.1
+++ b/man/httrack.1
@@ -345,7 +345,7 @@ from email address sent in HTTP headers (\-\-from <param>)
 .IP \-%F
 footer string in Html code (\-%F "Mirrored [from host %s [file %s [at %s]]]" (\-\-footer <param>)
 .IP \-%l
-preffered language (\-%l "fr, en, jp, *" (\-\-language <param>)
+preferred language (\-%l "fr, en, jp, *" (\-\-language <param>)
 .IP \-%a
 accepted formats (\-%a "text/html,image/png;q=0.9,*/*;q=0.1" (\-\-accept <param>)
 .IP \-%X

--- a/src/htshelp.c
+++ b/src/htshelp.c
@@ -604,7 +604,7 @@ void help(const char *app, int more) {
   infomsg(" %E  from email address sent in HTTP headers");
   infomsg
     (" %F  footer string in Html code (-%F \"Mirrored [from host %s [file %s [at %s]]]\"");
-  infomsg(" %l  preffered language (-%l \"fr, en, jp, *\"");
+  infomsg(" %l  preferred language (-%l \"fr, en, jp, *\"");
   infomsg(" %a  accepted formats (-%a \"text/html,image/png;q=0.9,*/*;q=0.1\"");
   infomsg(" %X  additional HTTP header line (-%X \"X-Magic: 42\"");
   infomsg("");


### PR DESCRIPTION
Fixes #253

Changes:
- `preffered language` -> `preferred language` in `html/fcguide.html` (2 occurrence(s))
- `preffered language` -> `preferred language` in `html/httrack.man.html` (1 occurrence(s))
- `preffered language` -> `preferred language` in `man/httrack.1` (1 occurrence(s))
- `preffered language` -> `preferred language` in `src/htshelp.c` (1 occurrence(s))

Verification:
- Applied exact text replacements against the current upstream base branch.
- Confirmed the pull request diff contains only the intended documentation typo fix(es).
