### PR TITLE
Build Debian packages in-tree via tools/mkdeb.sh

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,4 +5,13 @@ ACLOCAL_AMFLAGS = -I m4
 
 EXTRA_DIST = INSTALL.Linux \
 		gpl-fr.txt license.txt greetings.txt history.txt \
-		httrack-doc.html lang.def README.md
+		httrack-doc.html lang.def README.md tools/mkdeb.sh
+
+# Build the signed Debian packages from a clean source export. Pass the signing
+# key and other options through DEB_FLAGS, e.g.:
+#   make deb DEB_FLAGS="--key BB71C7E6CB1AD8FAF53FE42A60C3AA7180598EFB"
+# See tools/mkdeb.sh --help for all options.
+DEB_FLAGS =
+deb:
+	$(SHELL) $(top_srcdir)/tools/mkdeb.sh $(DEB_FLAGS)
+.PHONY: deb

--- a/Makefile.in
+++ b/Makefile.in
@@ -160,7 +160,7 @@ am__define_uniq_tagged_files = \
 DIST_SUBDIRS = $(SUBDIRS)
 am__DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/config.h.in AUTHORS \
 	COPYING ChangeLog INSTALL NEWS README compile config.guess \
-	config.sub depcomp install-sh ltmain.sh missing
+	config.sub install-sh ltmain.sh missing
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 distdir = $(PACKAGE)-$(VERSION)
 top_distdir = $(distdir)
@@ -349,8 +349,14 @@ SUBDIRS = src man m4 libtest templates lang html tests
 ACLOCAL_AMFLAGS = -I m4
 EXTRA_DIST = INSTALL.Linux \
 		gpl-fr.txt license.txt greetings.txt history.txt \
-		httrack-doc.html lang.def README.md
+		httrack-doc.html lang.def README.md tools/mkdeb.sh
 
+
+# Build the signed Debian packages from a clean source export. Pass the signing
+# key and other options through DEB_FLAGS, e.g.:
+#   make deb DEB_FLAGS="--key BB71C7E6CB1AD8FAF53FE42A60C3AA7180598EFB"
+# See tools/mkdeb.sh --help for all options.
+DEB_FLAGS = 
 all: config.h
 	$(MAKE) $(AM_MAKEFLAGS) all-recursive
 
@@ -841,6 +847,9 @@ uninstall-am:
 
 .PRECIOUS: Makefile
 
+deb:
+	$(SHELL) $(top_srcdir)/tools/mkdeb.sh $(DEB_FLAGS)
+.PHONY: deb
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/debian/changelog
+++ b/debian/changelog
@@ -11,7 +11,7 @@ httrack (3.49.6-1) unstable; urgency=medium
   * Updated to 3.49.6 (3.49-6)
     Fixed CVE-2017-14062
 
- -- Xavier Roche <roche@proliant.localnet>  Tue, 11 Mar 2025 19:43:39 +0100
+ -- Xavier Roche <xavier@debian.org>  Tue, 11 Mar 2025 19:43:39 +0100
 
 httrack (3.49.5-1) unstable; urgency=medium
 

--- a/man/makeman.sh
+++ b/man/makeman.sh
@@ -21,23 +21,23 @@
 set -eu
 
 httrack=${1:-httrack}
-script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-topdir=${TOPDIR:-$(CDPATH= cd -- "$script_dir/.." && pwd)}
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+topdir=${TOPDIR:-$(CDPATH='' cd -- "$script_dir/.." && pwd)}
 readme=${README:-$topdir/README}
 
 # Reproducible date when SOURCE_DATE_EPOCH is set, otherwise today.
 if [ -n "${SOURCE_DATE_EPOCH:-}" ]; then
-  date_str=$(LC_ALL=C date -u -d "@${SOURCE_DATE_EPOCH}" '+%d %B %Y' 2>/dev/null \
-           || LC_ALL=C date -u -r "${SOURCE_DATE_EPOCH}" '+%d %B %Y')
+    date_str=$(LC_ALL=C date -u -d "@${SOURCE_DATE_EPOCH}" '+%d %B %Y' 2>/dev/null ||
+        LC_ALL=C date -u -r "${SOURCE_DATE_EPOCH}" '+%d %B %Y')
 else
-  date_str=$(LC_ALL=C date '+%d %B %Y')
+    date_str=$(LC_ALL=C date '+%d %B %Y')
 fi
 year=${date_str##* }
 
 help=$("$httrack" --quiet --help 2>/dev/null)
 
-st=$(printf '%s\n' "$help" | grep -n 'General options'   | head -1 | cut -d: -f1)
-en=$(printf '%s\n' "$help" | grep -nE '^example'         | head -1 | cut -d: -f1)
+st=$(printf '%s\n' "$help" | grep -n 'General options' | head -1 | cut -d: -f1)
+en=$(printf '%s\n' "$help" | grep -nE '^example' | head -1 | cut -d: -f1)
 en2=$(printf '%s\n' "$help" | grep -nE '^HTTrack version' | tail -1 | cut -d: -f1)
 
 # SYNOPSIS: one "[ -x, --long ]" per option carrying a long name (skip "#" guru

--- a/tests/02_manpage-regen.test
+++ b/tests/02_manpage-regen.test
@@ -10,23 +10,30 @@ gen="$top_srcdir/man/makeman.sh"
 committed="$top_srcdir/man/httrack.1"
 
 # Need the generator and a runnable httrack.
-test -f "$gen" || { echo "makeman.sh not found; skipping" >&2; exit 77; }
-command -v httrack >/dev/null 2>&1 || { echo "httrack not in PATH; skipping" >&2; exit 77; }
+test -f "$gen" || {
+    echo "makeman.sh not found; skipping" >&2
+    exit 77
+}
+command -v httrack >/dev/null 2>&1 || {
+    echo "httrack not in PATH; skipping" >&2
+    exit 77
+}
 
 tmp=$(mktemp) || exit 1
 trap 'rm -f "$tmp"' EXIT
 
-README="$top_srcdir/README" bash "$gen" httrack > "$tmp" 2>/dev/null || {
-  echo "makeman.sh failed" >&2; exit 1
+README="$top_srcdir/README" bash "$gen" httrack >"$tmp" 2>/dev/null || {
+    echo "makeman.sh failed" >&2
+    exit 1
 }
 
 # Ignore the two intentionally date-dependent lines (page date, copyright year).
 strip_volatile() { grep -vE '^\.TH httrack |^Copyright \(C\) 1998-'; }
 
-if diff <(strip_volatile < "$committed") <(strip_volatile < "$tmp") >/dev/null; then
-  exit 0
+if diff <(strip_volatile <"$committed") <(strip_volatile <"$tmp") >/dev/null; then
+    exit 0
 fi
 
 echo "man/httrack.1 is out of date. Regenerate with: make -C man regen-man" >&2
-diff <(strip_volatile < "$committed") <(strip_volatile < "$tmp") | head -40 >&2
+diff <(strip_volatile <"$committed") <(strip_volatile <"$tmp") | head -40 >&2
 exit 1

--- a/tools/mkdeb.sh
+++ b/tools/mkdeb.sh
@@ -48,7 +48,10 @@ usage() {
 }
 
 need() {
-    command -v "$1" >/dev/null 2>&1 || die "required tool not found: $1"
+    local tool
+    for tool in "$@"; do
+        command -v "$tool" >/dev/null 2>&1 || die "required tool not found: $tool"
+    done
 }
 
 main() {
@@ -92,10 +95,7 @@ main() {
         esac
     done
 
-    need git
-    need autoreconf
-    need debuild
-    need dpkg-parsechangelog
+    need git autoreconf debuild dcmd
     if [[ $unsigned -eq 0 ]]; then
         need gpg
         [[ -n $key ]] || die "no signing key (pass --key or set DEBSIGN_KEYID, or use --unsigned)"
@@ -168,15 +168,14 @@ main() {
         debuild "${build_opts[@]}" "${debuild_opts[@]}"
     )
 
-    # Collect artifacts.
+    # Collect every file the .changes references (orig, dsc, debs, ddebs, buildinfo).
     info "collecting artifacts into $outdir"
-    cp -- "$scratch/$orig" "$outdir/"
-    local f
-    for f in "$scratch"/httrack_"$ver"*.dsc "$scratch"/httrack_"$ver"*.debian.tar.* \
-        "$scratch"/*.deb "$scratch"/httrack_"$ver"*.changes \
-        "$scratch"/httrack_"$ver"*.buildinfo; do
-        [[ -e $f ]] && cp -- "$f" "$outdir/"
-    done
+    local -a changes
+    shopt -s nullglob
+    changes=("$scratch"/*.changes)
+    shopt -u nullglob
+    [[ ${#changes[@]} -ge 1 ]] || die "debuild produced no .changes file"
+    dcmd cp -- "${changes[@]}" "$outdir/"
 
     # Release artifacts for the upstream tarball (detached sig + checksums).
     if [[ $release_artifacts -eq 1 && $unsigned -eq 0 ]]; then

--- a/tools/mkdeb.sh
+++ b/tools/mkdeb.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+#
+# Build the httrack Debian packages from a clean, committed source export.
+#
+# It exports HEAD (plus the coucal submodule) into a scratch directory, refreshes
+# the build system and man page, builds the upstream tarball, overlays debian/,
+# and runs debuild (which builds, runs lintian, and signs). Nothing is built in
+# the working tree, and no hard-coded paths are used.
+#
+# Output (in --outdir, default <repo>/dist):
+#   httrack_<ver>.orig.tar.gz            upstream tarball (Debian orig name)
+#   httrack_<ver>-*.dsc / .debian.tar.*  source package
+#   *.deb                                binary packages
+#   *.changes / *.buildinfo              build metadata
+#   httrack_<ver>.orig.tar.gz.{asc,md5,sha1}   release artifacts (unless disabled)
+#
+# Usage:
+#   tools/mkdeb.sh [options]
+#
+# Options:
+#   -k, --key KEYID            GPG key for signing (default: $DEBSIGN_KEYID)
+#   -o, --outdir DIR           output directory (default: <repo>/dist)
+#   -s, --source-only          build only the source package
+#   -u, --unsigned             do not sign anything (implies no release sigs)
+#       --no-release-artifacts skip the orig tarball .asc/.md5/.sha1
+#   -h, --help                 show this help
+#
+# SOURCE_DATE_EPOCH is honored for reproducible output.
+
+set -euo pipefail
+
+readonly PROGNAME=${0##*/}
+
+# Scratch dir, global so the EXIT trap can see it.
+scratch=""
+
+die() {
+    printf '%s: error: %s\n' "$PROGNAME" "$*" >&2
+    exit 1
+}
+
+info() {
+    printf '==> %s\n' "$*" >&2
+}
+
+usage() {
+    sed -n '2,/^set -euo/{/^set -euo/!p}' "$0" | sed 's/^# \{0,1\}//'
+}
+
+need() {
+    command -v "$1" >/dev/null 2>&1 || die "required tool not found: $1"
+}
+
+main() {
+    local key=${DEBSIGN_KEYID:-}
+    local outdir=""
+    local source_only=0
+    local unsigned=0
+    local release_artifacts=1
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+        -k | --key)
+            [[ $# -ge 2 ]] || die "missing argument for $1"
+            key=$2
+            shift 2
+            ;;
+        -o | --outdir)
+            [[ $# -ge 2 ]] || die "missing argument for $1"
+            outdir=$2
+            shift 2
+            ;;
+        -s | --source-only)
+            source_only=1
+            shift
+            ;;
+        -u | --unsigned)
+            unsigned=1
+            shift
+            ;;
+        --no-release-artifacts)
+            release_artifacts=0
+            shift
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown option: $1 (try --help)"
+            ;;
+        esac
+    done
+
+    need git
+    need autoreconf
+    need debuild
+    need dpkg-parsechangelog
+    if [[ $unsigned -eq 0 ]]; then
+        need gpg
+        [[ -n $key ]] || die "no signing key (pass --key or set DEBSIGN_KEYID, or use --unsigned)"
+    fi
+
+    local repo
+    repo=$(git rev-parse --show-toplevel) || die "not inside a git repository"
+    : "${outdir:=$repo/dist}"
+    mkdir -p "$outdir"
+    outdir=$(cd "$outdir" && pwd)
+
+    scratch=$(mktemp -d "${TMPDIR:-/tmp}/httrack-mkdeb.XXXXXX")
+    trap 'rm -rf -- "$scratch"' EXIT
+
+    # Pristine export of committed HEAD plus the coucal submodule.
+    info "exporting committed sources"
+    local export_dir=$scratch/src
+    mkdir -p "$export_dir"
+    git -C "$repo" archive --format=tar HEAD | tar -x -C "$export_dir"
+    git -C "$repo/src/coucal" archive --format=tar --prefix=src/coucal/ HEAD |
+        tar -x -C "$export_dir"
+
+    # Refresh build system and man page, then build and validate the tarball.
+    info "regenerating build system and man page"
+    (
+        cd "$export_dir"
+        autoreconf -fi
+        ./configure --quiet
+        make -s -j"$(nproc)"
+        make -s -C man regen-man
+        info "running test suite"
+        make -s check
+        # Build the tarball from a clean tree so no object files leak into it.
+        make -s clean
+        make -s dist
+    )
+
+    local tarball ver
+    local -a tarballs
+    shopt -s nullglob
+    tarballs=("$export_dir"/httrack-*.tar.gz)
+    shopt -u nullglob
+    [[ ${#tarballs[@]} -ge 1 ]] || die "make dist produced no tarball"
+    tarball=${tarballs[0]##*/}
+    ver=${tarball#httrack-}
+    ver=${ver%.tar.gz}
+    info "version $ver"
+
+    # 3.0 (quilt): orig tarball is upstream-only; debian/ is overlaid on top.
+    local orig=httrack_${ver}.orig.tar.gz
+    cp -- "$export_dir/$tarball" "$scratch/$orig"
+    (
+        cd "$scratch"
+        tar -xf "$orig"
+        cp -a "$export_dir/debian" "httrack-$ver/debian"
+    )
+
+    # Build (debuild also runs lintian and signs).
+    local -a debuild_opts=(--lintian-opts -I -i)
+    local -a build_opts=()
+    [[ $source_only -eq 1 ]] && build_opts+=(-S)
+    if [[ $unsigned -eq 1 ]]; then
+        build_opts+=(-us -uc)
+    else
+        build_opts+=("-k$key")
+    fi
+    info "building packages with debuild"
+    (
+        cd "$scratch/httrack-$ver"
+        debuild "${build_opts[@]}" "${debuild_opts[@]}"
+    )
+
+    # Collect artifacts.
+    info "collecting artifacts into $outdir"
+    cp -- "$scratch/$orig" "$outdir/"
+    local f
+    for f in "$scratch"/httrack_"$ver"*.dsc "$scratch"/httrack_"$ver"*.debian.tar.* \
+        "$scratch"/*.deb "$scratch"/httrack_"$ver"*.changes \
+        "$scratch"/httrack_"$ver"*.buildinfo; do
+        [[ -e $f ]] && cp -- "$f" "$outdir/"
+    done
+
+    # Release artifacts for the upstream tarball (detached sig + checksums).
+    if [[ $release_artifacts -eq 1 && $unsigned -eq 0 ]]; then
+        info "signing upstream tarball"
+        (
+            cd "$outdir"
+            gpg --armor --detach-sign --yes -u "$key" -- "$orig"
+            md5sum -- "$orig" >"$orig.md5"
+            sha1sum -- "$orig" >"$orig.sha1"
+        )
+    fi
+
+    info "done. artifacts in $outdir:"
+    ls -1 "$outdir" >&2
+}
+
+main "$@"


### PR DESCRIPTION
Brings Debian package building into the tree, replacing an external workstation script full of dead code and hard-coded paths.

`tools/mkdeb.sh` exports committed HEAD plus the coucal submodule to a scratch dir, refreshes the build system and man page (reusing `make -C man regen-man`), builds a clean upstream tarball, overlays `debian/` for the `3.0 (quilt)` format, and runs `debuild` (build, lintian, signing). It takes the GPG key and options as arguments (`--key`, `--source-only`, `--unsigned`, `--outdir`, `--no-release-artifacts`), defaults the key from `$DEBSIGN_KEYID`, honors `SOURCE_DATE_EPOCH`, and writes nothing in the working tree. `make deb DEB_FLAGS="--key <id>"` is a thin wrapper.

What the old script did that is dropped on purpose: dos2unix juggling, `/temp` and `/e` paths, website mirroring, svn, rewriting the version and changelog at build time, and the dead flash/apt-archive blocks. Version and changelog are authoritative in-tree.

Also here: fix a bogus `roche@proliant.localnet` maintainer email in the 3.49.6-1 changelog entry (lintian `bogus-mail-host`, previously masked by the old script's `sed`), and a shellcheck/`shfmt -i 4` pass on the shell scripts.

Validated by building all packages unsigned end to end: the six `.deb`s, source package, and object-free orig tarball are produced and lintian runs. Two pre-existing items are left as follow-ups: `libtest/Makefile.am` uses `-I../src` so `make distcheck` fails on VPATH (hence `make check` is used here), and the `libtest` example `.so` trip `library-not-linked-against-libc`.
