### PR TITLE
debian: bump Standards-Version to 4.7.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+httrack (3.49.7-2) unstable; urgency=medium
+
+  * Bump Standards-Version to 4.7.0 (no changes needed).
+
+ -- Xavier Roche <xavier@debian.org>  Sun, 07 Jun 2026 13:05:53 +0200
+
 httrack (3.49.7-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: httrack
 Section: web
 Priority: optional
 Maintainer: Xavier Roche <roche@httrack.com>
-Standards-Version: 4.6.2
+Standards-Version: 4.7.0
 Build-Depends: debhelper (>= 12.0.0), dh-autoreconf, autotools-dev, autoconf, autoconf-archive, automake, libtool, zlib1g-dev, libssl-dev
 Homepage: http://www.httrack.com
 Vcs-Git: https://github.com/xroche/httrack.git


### PR DESCRIPTION
Bumps `Standards-Version` from 4.6.2 to 4.7.0 (current policy).

Reviewed the 4.6.2 to 4.7.0 upgrading checklist; none of the normative changes touch httrack, so the version line is the only change:

- §3.9 (maintainer scripts must not divert or use alternatives for systemd config files): httrack ships no maintainer scripts.
- §6.3 (packages that start/stop services must ship systemd units): httrack packages no services or init scripts.
- §4.9 (no network in rules targets for contrib/non-free): httrack is in main.
- §4.8 (hard links now allowed) and the §2.2/§5.6 items are relaxations or informational.

Recorded as a packaging-only 3.49.7-2 revision.
