### PR TITLE
docs: add CI and license badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # HTTrack Website Copier - Development Repository
 
+[![CI](https://github.com/xroche/httrack/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/xroche/httrack/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/xroche/httrack)](COPYING)
+
 ## About
 _Copy websites to your computer (Offline browser)_
 


### PR DESCRIPTION
Adds the GitHub Actions CI status badge and a license badge (now GPL-3.0) to the top of README.md. The CI badge tracks the workflow merged in #314.