### PR TITLE
build: symlink ChangeLog and NEWS to history.txt

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,1 @@
+history.txt

--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,1 @@
+history.txt


### PR DESCRIPTION
The empty ChangeLog and NEWS files were placeholders to satisfy automake's GNU strictness. Symlinking them to history.txt keeps automake happy, removes the confusing empty files, and produces a real populated changelog in the dist tarball (make dist follows the link), with no content duplicated in git.

Verified: autoreconf is clean and make dist emits both as real 40 KB files. The only caveat is Windows git checkouts without symlink support, where they materialize as small text stubs; harmless, since the Windows build uses the MSVC projects (not automake) and release tarballs are built on Linux.