### PR TITLE
Fix never-matching wildcard cookie domain comparison

### DIFF
--- a/src/htsbauth.c
+++ b/src/htsbauth.c
@@ -133,8 +133,8 @@ static int cookie_cmp_wildcard_domain(const char *chk_dom, const char *domain) {
   const size_t n = strlen(chk_dom);
   const size_t m = strlen(domain);
   const size_t l = n < m ? n : m;
-  size_t i;
-  for (i = l - 1; i >= 0; i--) {
+  int i;
+  for (i = (int) l - 1; i >= 0; i--) {
     if (chk_dom[n - i - 1] != domain[m - i - 1]) {
       return 1;
     }


### PR DESCRIPTION
cookie_cmp_wildcard_domain (src/htsbauth.c) used an unsigned `size_t` loop counter, so `i >= 0` was always true: an infinite loop with out-of-bounds reads, and wildcard cookie-domain matching never returned correctly. An empty domain also underflowed `l - 1` to SIZE_MAX. Switching to a signed counter fixes both.

The actual fix from #172 by @greenrd, applied directly because that PR also carried 8-year-old regenerated build files that can't merge. closes #171