### PR TITLE
debian: clean up lintian tags

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -934,7 +934,7 @@ httrack (3.39.6-1) unstable; urgency=low
 
 httrack (3.39.5-1) unstable; urgency=low
 
-  * Updated to 3.39.5 (3.40-alpha-5) 
+  * Updated to 3.39.5 (3.40-alpha-5)
 
  -- Xavier Roche <xavier@debian.org>  Fri, 29 Jul 2005 20:57:44 +0200
 
@@ -1616,4 +1616,3 @@ httrack (3.22-1) unstable; urgency=low
   * Initial Release.
 
  -- Xavier Roche <xavier@debian.org>  Fri, 27 Sep 2002 16:42:25 +0200
-

--- a/debian/control
+++ b/debian/control
@@ -4,8 +4,10 @@ Priority: optional
 Maintainer: Xavier Roche <roche@httrack.com>
 Standards-Version: 4.7.0
 Build-Depends: debhelper-compat (= 13), autoconf, autoconf-archive, automake, libtool, zlib1g-dev, libssl-dev
+Rules-Requires-Root: no
 Homepage: http://www.httrack.com
 Vcs-Git: https://github.com/xroche/httrack.git
+Vcs-Browser: https://github.com/xroche/httrack
 
 Package: httrack
 Architecture: any
@@ -23,12 +25,12 @@ Description: Copy websites to your computer (Offline browser)
  browse the site from link to link, as if you were viewing it online.
  HTTrack can also update an existing mirrored site, and resume
  interrupted downloads. HTTrack is fully configurable, and has an
- integrated help system. 
+ integrated help system.
 
 Package: webhttrack
 Architecture: any
 Multi-Arch: foreign
-Depends: ${misc:Depends}, ${shlibs:Depends}, webhttrack-common, iceape-browser | iceweasel | icecat | mozilla | firefox | mozilla-firefox | www-browser | sensible-utils
+Depends: ${misc:Depends}, ${shlibs:Depends}, webhttrack-common, sensible-utils, iceape-browser | iceweasel | icecat | mozilla | firefox | mozilla-firefox | www-browser
 Replaces: webhttrack-common (<< 3.43.9-2)
 Breaks: webhttrack-common (<< 3.43.9-2)
 Suggests: httrack, httrack-doc

--- a/debian/copyright
+++ b/debian/copyright
@@ -13,7 +13,7 @@ the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
 On Debian systems, the complete text of the GNU General Public
-License can be found in /usr/share/common-licenses/GPL file.
+License version 3 can be found in /usr/share/common-licenses/GPL-3 file.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/debian/libhttrack-dev.lintian-overrides
+++ b/debian/libhttrack-dev.lintian-overrides
@@ -1,5 +1,4 @@
 libhttrack-dev: breakout-link *
 libhttrack-dev: hardening-no-fortify-functions usr/lib/x86_64-linux-gnu/httrack/libtest/*
-libhttrack-dev: library-not-linked-against-libc usr/lib/*/httrack/libtest/*
 libhttrack-dev: package-contains-documentation-outside-usr-share-doc usr/share/httrack/libtest/readme.txt
 libhttrack-dev: package-name-defined-in-config-h usr/include/httrack/config.h

--- a/debian/rules
+++ b/debian/rules
@@ -44,7 +44,7 @@ build-indep:
 
 build-arch: build-stamp
 
-build-stamp: configure-stamp 
+build-stamp: configure-stamp
 	dh_testdir
 	dh_auto_build
 	dh_auto_test

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,2 +1,8 @@
 httrack source: changelog-should-mention-nmu
 httrack source: source-nmu-has-incorrect-version-number
+
+# The bundled HTML pages are the genuine upstream documentation taken from
+# the httrack.com website. lintian's long-line heuristic mistakes them for
+# minified or generated content, but they are the actual source.
+httrack source: source-is-missing [html/*]
+httrack source: source-is-missing [templates/*]

--- a/debian/watch
+++ b/debian/watch
@@ -1,7 +1,6 @@
-# format version number, currently 3; this line is compulsory!
-version=3
+# format version number; this line is compulsory!
+version=4
 
 # main httrack.com download page ; fetch the mirror version number
-http://www.httrack.com/page/2/en/index.html\
-	.*/httrack-([\d\.]+).tar.gz
-
+https://www.httrack.com/page/2/en/index.html \
+	.*/httrack-([\d\.]+)\.tar\.gz

--- a/debian/webhttrack.lintian-overrides
+++ b/debian/webhttrack.lintian-overrides
@@ -1,1 +1,0 @@
-webhttrack: missing-depends-on-sensible-utils sensible-browser usr/bin/webhttrack

--- a/libtest/Makefile.am
+++ b/libtest/Makefile.am
@@ -14,9 +14,13 @@ AM_CPPFLAGS = \
 	-DLIBDIR=\""$(libdir)"\"
 AM_CPPFLAGS += -I../src
 
+# The callback examples reference libc only through libhttrack, so the direct
+# libc edge gets dropped from DT_NEEDED (library-not-linked-against-libc).
+# Force libc to be recorded as a dependency.
 AM_LDFLAGS = \
 	@DEFAULT_LDFLAGS@ \
-	-L../src
+	-L../src \
+	-Wl,--push-state,--no-as-needed,-lc,--pop-state
 
 # Examples
 libbaselinks_la_SOURCES =  callbacks-example-baselinks.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -83,7 +83,10 @@ libhttrack_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(VERSION_INFO)
 
 libhtsjava_la_SOURCES = htsjava.c htsjava.h
 libhtsjava_la_LIBADD = $(THREADS_LIBS) $(DL_LIBS) libhttrack.la
-libhtsjava_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(VERSION_INFO)
+# This thin JNI wrapper reaches libc only through libhttrack, so the direct
+# libc edge is dropped from DT_NEEDED (library-not-linked-against-libc). Force
+# libc to be recorded as a dependency.
+libhtsjava_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(VERSION_INFO) -Wl,--push-state,--no-as-needed,-lc,--pop-state
 
 EXTRA_DIST = httrack.h webhttrack \
 		coucal/murmurhash3.h.diff \


### PR DESCRIPTION
Clears most lintian errors and warnings on the Debian package.

A real build fix: libhtsjava and the libtest examples reached libc only through libhttrack, so the linker dropped the direct libc dependency. They now link libc explicitly.

The rest is packaging metadata: a firm sensible-utils dependency, the GPL-3 license path in copyright, https and version=4 in the watch file, Rules-Requires-Root and Vcs-Browser fields, and trailing-whitespace cleanup. The bundled html/ and templates/ docs are genuine upstream pages, so source-is-missing is overridden as a false positive.

Lintian errors go from 38 to 1. The remaining one (bad-distribution unstable) is an Ubuntu-only artifact. No version bump.