### PR TITLE
Fix abort on long log path (lock-file buffer too small)

### DIFF
--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -2899,7 +2899,9 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
   }
 
   {
-    char n_lock[256];
+    /* Sized to the concat-buffer capacity so it can always hold the lock-file
+       path produced by fconcat(), even with a long log path (issue #183). */
+    char n_lock[OPT_GET_BUFF_SIZE(opt)];
 
     // on peut pas avoir un affichage ET un fichier log
     // ca sera pour la version 2


### PR DESCRIPTION
## What
Size the `n_lock` lock-file-path buffer to the concat-buffer capacity instead of a fixed 256 bytes.

## Why
With a long log path, the lock-file path overran the 256-byte buffer and the guarded copy aborted the process with signal 6 (#183). The reporter hit it near a 236-character path and worked around it with a symlink.

## How
`n_lock` is now `char n_lock[OPT_GET_BUFF_SIZE(opt)]`, a compile-time constant matching the buffer `fconcat` writes into, so it holds any path the concatenation can produce. The guard caught the overflow before any out-of-bounds write, so the effect was a denial of service rather than memory corruption.

## Classification
- [CWE-131: Incorrect Calculation of Buffer Size](https://cwe.mitre.org/data/definitions/131.html)
- [CWE-617: Reachable Assertion](https://cwe.mitre.org/data/definitions/617.html)
