### PR TITLE
test: characterize wildcard class escape behavior

### DIFF
--- a/tests/01_engine-filter.test
+++ b/tests/01_engine-filter.test
@@ -47,3 +47,25 @@ match '*foo*bar' 'foozbar'
 
 # '?' is the query-string marker, not a single-char wildcard
 nomatch 'a?c' 'abc'
+
+# backslash escapes a metacharacter inside a class so it is matched literally.
+# Quirk: the decoder also adds the backslash itself to the set, so '\X' matches
+# both X and '\'. These assertions pin that behavior.
+match '*[\*]' '*'
+match '*[\*]' "\\"
+nomatch '*[\*]' 'a'
+match '*[\\]' "\\"
+nomatch '*[\\]' 'a'
+match '*[\[]' '['
+match '*[\[]' "\\"
+nomatch '*[\[]' 'a'
+
+# A literal ']' cannot be a class member: the class parser stops at the first
+# ']', escaped or not. So '*[\[\]]' does NOT mean "the [ or ] character" as the
+# filter guide claims (GitHub #148); it parses as the class {'[','\'} followed
+# by a trailing literal ']'. These assertions document the current (buggy)
+# behavior so any future matcher fix is a deliberate, visible change.
+nomatch '*[\[\]]' '['   # not matched, despite the docs
+match '*[\[\]]' ']'     # only via the empty class-match + trailing ']'
+match '*[\[\]]' '[]'    # one of {'[','\'} then the trailing ']'
+nomatch '*[\[\]]' '[]x'


### PR DESCRIPTION
Adds `-#0` self-test cases to `tests/01_engine-filter.test` for backslash escapes inside a `*[...]` character class.

These are characterization tests: they assert the matcher's *current* behavior, not the ideal behavior. Two quirks are pinned:

- `\X` inside a class matches both `X` and the backslash itself (e.g. `*[\*]` matches `*` and `\`).
- A literal `]` cannot be a class member. The class parser stops at the first `]`, escaped or not, so `*[\[\]]` does not mean "the `[` or `]` character" as `fcguide`/`filters.html` claim. It parses as the class `{[,\}` followed by a trailing literal `]`. That makes the documented `*[\[\]]` (and the `*[\[,\]]` form suggested in #148) match only `]`, never `[`.

This is the matcher bug behind #148. Fixing it changes filter-match semantics in security-sensitive parsing code, so it belongs in a separate, deliberate change. Landing these tests first means that fix shows up as a clear diff in the expected results.

refs #148