### PR TITLE
Flag unchecked pointer-destination uses of the buff() string macros

### DIFF
--- a/src/htscatchurl.c
+++ b/src/htscatchurl.c
@@ -201,8 +201,8 @@ HTSEXT_API int catch_url(T_SOC soc, char *url, char *method, char *data) {
             while(strnotempty(line)) {
               socinput(soc, line, 1000);
               treathead(NULL, NULL, NULL, &blkretour, line);    // traiter
-              strcatbuff(data, line);
-              strcatbuff(data, "\r\n");
+              strlcatbuff(data, line, CATCH_URL_DATA_SIZE);
+              strlcatbuff(data, "\r\n", CATCH_URL_DATA_SIZE);
             }
             // CR/LF final de l'en tête inutile car déja placé via la ligne vide juste au dessus
             //strcatbuff(data,"\r\n");

--- a/src/htscatchurl.h
+++ b/src/htscatchurl.h
@@ -40,6 +40,9 @@ Please visit our Website: http://www.httrack.com
 /* Library internal definictions */
 #ifdef HTS_INTERNAL_BYTECODE
 
+// Capacity contract for the catch_url() 'data' buffer (32 Kb).
+#define CATCH_URL_DATA_SIZE 32768
+
 // Fonctions
 void socinput(T_SOC soc, char *s, int max);
 

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -140,6 +140,62 @@ static void basic_selftests(void) {
   md5selftest();
 }
 
+/* Self-tests for the htssafe.h bounded string ops (driven by httrack -#8).
+   Returns 0 if every bounded operation behaved correctly, 1 otherwise.
+   The abort-on-overflow guarantee is checked separately by the -#8 "overflow"
+   sub-mode (it aborts the process by design). */
+static int string_safety_selftests(void) {
+  char buf[8];
+
+  /* strcpybuff into a sized array: exact copy */
+  strcpybuff(buf, "abc");
+  if (strcmp(buf, "abc") != 0)
+    return 1;
+
+  /* strcatbuff append within capacity */
+  strcatbuff(buf, "de");
+  if (strcmp(buf, "abcde") != 0)
+    return 1;
+
+  /* strncatbuff appends at most N source chars */
+  strcpybuff(buf, "ab");
+  strncatbuff(buf, "cdef", 2);
+  if (strcmp(buf, "abcd") != 0)
+    return 1;
+
+  /* strlcpybuff: explicit-capacity copy into a pointer destination, the form
+     the migration moves toward */
+  {
+    char storage[8];
+    char *const p = storage;
+
+    strlcpybuff(p, "hello", sizeof(storage));
+    if (strcmp(p, "hello") != 0)
+      return 1;
+  }
+
+  /* strcpybuff into a pointer destination: routes through the unchecked
+     strcpybuff_ptr_ fallback (the path the -#8 warning flags). The warning is
+     intentional here; we only verify the fallback still copies correctly. */
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattribute-warning"
+#endif
+  {
+    char storage[8];
+    char *const p = storage;
+
+    strcpybuff(p, "ptr");
+    if (strcmp(p, "ptr") != 0)
+      return 1;
+  }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+  return 0;
+}
+
 static int hts_main_internal(int argc, char **argv, httrackp * opt);
 
 // Main, récupère les paramètres et appelle le robot
@@ -2436,6 +2492,28 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                 }
                 htsmain_free();
                 return 0;
+                break;
+              case '8':        /* string-safety selftest: httrack -#8 [overflow <bigstr>] */
+                if (na + 1 < argc && strcmp(argv[na + 1], "overflow") == 0) {
+                  /* Deliberately exceed a sized buffer: the bounded macro must
+                     abort. The source comes from argv so its length is opaque
+                     to the compiler (no static -Wstringop-overflow, genuine
+                     runtime check). */
+                  char small[4];
+                  const char *const src =
+                    (na + 2 < argc) ? argv[na + 2] : "overflowing";
+
+                  strcpybuff(small, src);
+                  printf("strsafe: NOT aborted\n");     /* must be unreachable */
+                  htsmain_free();
+                  return 1;
+                } else {
+                  const int err = string_safety_selftests();
+
+                  printf("strsafe: %s\n", err ? "FAIL" : "OK");
+                  htsmain_free();
+                  return err;
+                }
                 break;
               case '7':  // hashtable selftest: httrack -#7 nb_entries
                 basic_selftests();

--- a/src/htshelp.c
+++ b/src/htshelp.c
@@ -409,7 +409,7 @@ void help_catchurl(const char *dest_path) {
   if (soc != INVALID_SOCKET) {
     char BIGSTK url[HTS_URLMAXSIZE * 2];
     char method[32];
-    char BIGSTK data[32768];
+    char BIGSTK data[CATCH_URL_DATA_SIZE];
 
     url[0] = method[0] = data[0] = '\0';
     //

--- a/src/htssafe.h
+++ b/src/htssafe.h
@@ -123,41 +123,111 @@ static HTS_UNUSED void htssafe_compile_time_check_(void) {
   (void) check_pointer;
 }
 
+/*
+ * Pointer-destination diagnostics for the buff() macros (GCC/Clang, C only).
+ *
+ * strcpybuff()/strcatbuff()/strncatbuff() bounds-check only when the
+ * destination is a sized char[] array (HTS_IS_CHAR_BUFFER). For a bare char*
+ * the capacity is unknown, so the macro silently falls back to plain
+ * strcpy()/strcat()/strncat() while still looking like a checked call.
+ *
+ * These stubs route that pointer case through __builtin_choose_expr() so the
+ * 'warning' attribute fires only at pointer-destination sites; array sites use
+ * the bounded *_safe_ helpers and stay quiet. The warning names the
+ * explicit-size replacement (strlcpybuff/strlcatbuff). Diagnostic only: no
+ * runtime or ABI change, built only on GCC/Clang in C mode. Other compilers
+ * (MSVC, ...) keep the previous behavior via the #else branches.
+ */
+#if (defined(__GNUC__) && !defined(__cplusplus))
+#if defined(__has_attribute)
+#if __has_attribute(warning)
+#define HTS_BUFF_PTR_ATTR(msg) __attribute__((unused, noinline, warning(msg)))
+#endif
+#endif
+#ifndef HTS_BUFF_PTR_ATTR
+/* 'warning' attribute unavailable: keep noinline so the migration can still
+   grep for these symbols, but no compile-time diagnostic is emitted. */
+#define HTS_BUFF_PTR_ATTR(msg) __attribute__((unused, noinline))
+#endif
+
+HTS_BUFF_PTR_ATTR("strcpybuff() destination is a pointer (capacity unknown): "
+                  "NOT bounds-checked; use strlcpybuff(dst, src, size)")
+static char *strcpybuff_ptr_(char *dest, const char *src) {
+  return strcpy(dest, src);
+}
+
+HTS_BUFF_PTR_ATTR("strcatbuff() destination is a pointer (capacity unknown): "
+                  "NOT bounds-checked; use strlcatbuff(dst, src, size)")
+static char *strcatbuff_ptr_(char *dest, const char *src) {
+  return strcat(dest, src);
+}
+
+HTS_BUFF_PTR_ATTR("strncatbuff() destination is a pointer (capacity unknown): "
+                  "NOT bounds-checked; use strlcatbuff(dst, src, size)")
+static char *strncatbuff_ptr_(char *dest, const char *src, size_t n) {
+  return strncat(dest, src, n);
+}
+#endif
+
 /**
  * Append at most N characters from "B" to "A".
  * If "A" is a char[] variable whose size is not sizeof(char*), then the size 
  * is assumed to be the capacity of this array.
  */
+#if (defined(__GNUC__) && !defined(__cplusplus))
+#define strncatbuff(A, B, N) __builtin_choose_expr( HTS_IS_CHAR_BUFFER(A), \
+  strncat_safe_(A, sizeof(A), B, \
+  HTS_IS_NOT_CHAR_BUFFER(B) ? (size_t) -1 : sizeof(B), N, \
+  "overflow while appending '" #B "' to '"#A"'", __FILE__, __LINE__), \
+  strncatbuff_ptr_((A), (B), (N)) )
+#else
 #define strncatbuff(A, B, N) \
   ( HTS_IS_NOT_CHAR_BUFFER(A) \
   ? strncat(A, B, N) \
   : strncat_safe_(A, sizeof(A), B, \
   HTS_IS_NOT_CHAR_BUFFER(B) ? (size_t) -1 : sizeof(B), N, \
   "overflow while appending '" #B "' to '"#A"'", __FILE__, __LINE__) )
+#endif
 
 /**
  * Append characters of "B" to "A".
  * If "A" is a char[] variable whose size is not sizeof(char*), then the size 
  * is assumed to be the capacity of this array.
  */
+#if (defined(__GNUC__) && !defined(__cplusplus))
+#define strcatbuff(A, B) __builtin_choose_expr( HTS_IS_CHAR_BUFFER(A), \
+  strncat_safe_(A, sizeof(A), B, \
+  HTS_IS_NOT_CHAR_BUFFER(B) ? (size_t) -1 : sizeof(B), (size_t) -1, \
+  "overflow while appending '" #B "' to '"#A"'", __FILE__, __LINE__), \
+  strcatbuff_ptr_((A), (B)) )
+#else
 #define strcatbuff(A, B) \
   ( HTS_IS_NOT_CHAR_BUFFER(A) \
   ? strcat(A, B) \
   : strncat_safe_(A, sizeof(A), B, \
   HTS_IS_NOT_CHAR_BUFFER(B) ? (size_t) -1 : sizeof(B), (size_t) -1, \
   "overflow while appending '" #B "' to '"#A"'", __FILE__, __LINE__) )
+#endif
 
 /**
  * Copy characters from "B" to "A".
  * If "A" is a char[] variable whose size is not sizeof(char*), then the size 
  * is assumed to be the capacity of this array.
  */
+#if (defined(__GNUC__) && !defined(__cplusplus))
+#define strcpybuff(A, B) __builtin_choose_expr( HTS_IS_CHAR_BUFFER(A), \
+  strcpy_safe_(A, sizeof(A), B, \
+  HTS_IS_NOT_CHAR_BUFFER(B) ? (size_t) -1 : sizeof(B), \
+  "overflow while copying '" #B "' to '"#A"'", __FILE__, __LINE__), \
+  strcpybuff_ptr_((A), (B)) )
+#else
 #define strcpybuff(A, B) \
   ( HTS_IS_NOT_CHAR_BUFFER(A) \
   ? strcpy(A, B) \
   : strcpy_safe_(A, sizeof(A), B, \
   HTS_IS_NOT_CHAR_BUFFER(B) ? (size_t) -1 : sizeof(B), \
   "overflow while copying '" #B "' to '"#A"'", __FILE__, __LINE__) )
+#endif
 
 /**
  * Append characters of "B" to "A", "A" having a maximum capacity of "S".

--- a/tests/01_engine-strsafe.test
+++ b/tests/01_engine-strsafe.test
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+
+# htssafe.h bounded string operations (driven by 'httrack -#8').
+
+# Success path: every bounded op (strcpybuff/strcatbuff/strncatbuff/strlcpybuff)
+# must behave correctly. Like the other -# debug modes, a trailing token is
+# required (a bare '-#8' falls through to the usage screen).
+out=$(httrack -#8 run)
+test $? -eq 0 || exit 1
+test "$out" == "strsafe: OK" || exit 1
+
+# Overflow path: an over-capacity write into a sized buffer must be caught by
+# the bounded macro and abort the process, not be silently truncated/completed.
+# Assert the htssafe abort signature specifically, so the test cannot pass for
+# an unrelated reason (e.g. the -#8 mode being gone and falling through to the
+# usage screen, which also exits non-zero).
+err=$(httrack -#8 overflow "this string is far too long for the buffer" 2>&1)
+case "$err" in
+	*"strsafe: NOT aborted"*) echo "over-capacity write was NOT caught" >&2; exit 1 ;;
+	*"overflow while copying"*) ;;
+	*) echo "expected htssafe overflow abort, got: $err" >&2; exit 1 ;;
+esac

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -20,6 +20,7 @@ TESTS = \
 	01_engine-mime.test \
 	01_engine-parse.test \
 	01_engine-simplify.test \
+	01_engine-strsafe.test \
 	02_manpage-regen.test \
 	10_crawl-simple.test \
 	11_crawl-cookies.test \


### PR DESCRIPTION
## What

Add a compile-time diagnostic (GCC/Clang) that flags every call to
`strcpybuff`/`strcatbuff`/`strncatbuff` whose destination is a bare `char*`
pointer, where the macro cannot bounds-check. Adds a runtime self-test for the
bounded ops, and migrates the first consumer (`catch_url`) as a demonstrator.

## Why

The `htssafe.h` `buff()` macros only bounds-check when the destination is a
sized `char[]` array (the size comes from `sizeof`). For a `char*` the capacity
is unknown, so the macro silently falls back to plain `strcpy`/`strcat`/
`strncat` while still looking like a checked call. A build-wide sweep found
**241** such pointer-destination sites that look hardened but are not.

## How

On GCC/Clang in C mode, the pointer case is routed through
`__builtin_choose_expr()` to a stub carrying `__attribute__((warning))`, so the
warning fires only at pointer-destination sites; array sites keep using the
bounded `_safe_` helpers and stay quiet. The warning names the explicit-size
replacement (`strlcpybuff`/`strlcatbuff`).

This is diagnostic only: no runtime or ABI change, and the default build has no
`-Werror`, so the warnings do not break the build. Other compilers (MSVC, C++
TUs) keep the previous behavior via the existing `#else` path.

Also:
- `-#8` runs `string_safety_selftests()`, and `tests/01_engine-strsafe.test`
  covers both correct copies and the abort-on-overflow guarantee.
- `catch_url` now appends its response headers with `strlcatbuff` bounded to the
  documented 32Kb `data` contract (`CATCH_URL_DATA_SIZE`), fixing an unchecked
  append and bringing the file to zero warnings.

The plan is to migrate the remaining sites file by file, then flip the stub to
`__attribute__((error))` once a file reaches zero so regressions cannot return.