### PR TITLE
Add htsbuff: a bounded string builder over a fixed buffer

### DIFF
--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -193,6 +193,37 @@ static int string_safety_selftests(void) {
 #pragma GCC diagnostic pop
 #endif
 
+  /* htsbuff: bounded builder over a fixed array (append, truncating append,
+     reset, and length tracking) */
+  {
+    char dst[8];
+    htsbuff b = htsbuff_array(dst);
+
+    htsbuff_cat(&b, "ab");
+    htsbuff_cat(&b, "cd");
+    if (strcmp(htsbuff_str(&b), "abcd") != 0 || b.len != 4)
+      return 1;
+
+    htsbuff_catn(&b, "efghij", 2);      /* append at most 2 */
+    if (strcmp(htsbuff_str(&b), "abcdef") != 0)
+      return 1;
+
+    htsbuff_cpy(&b, "xyz");             /* reset */
+    if (strcmp(htsbuff_str(&b), "xyz") != 0 || b.len != 3)
+      return 1;
+  }
+
+  /* boundary: filling to exactly cap-1 must succeed (one more aborts, which the
+     -#8 overflow-buff mode checks) */
+  {
+    char d2[4];
+    htsbuff c = htsbuff_array(d2);
+
+    htsbuff_cat(&c, "abc");
+    if (strcmp(htsbuff_str(&c), "abc") != 0 || c.len != 3)
+      return 1;
+  }
+
   return 0;
 }
 
@@ -2494,16 +2525,23 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                 return 0;
                 break;
               case '8':        /* string-safety selftest: httrack -#8 [overflow <bigstr>] */
-                if (na + 1 < argc && strcmp(argv[na + 1], "overflow") == 0) {
-                  /* Deliberately exceed a sized buffer: the bounded macro must
+                if (na + 1 < argc
+                    && strncmp(argv[na + 1], "overflow", 8) == 0) {
+                  /* Deliberately exceed a sized buffer: the bounded op must
                      abort. The source comes from argv so its length is opaque
                      to the compiler (no static -Wstringop-overflow, genuine
-                     runtime check). */
+                     runtime check). "overflow-buff" exercises htsbuff. */
                   char small[4];
                   const char *const src =
                     (na + 2 < argc) ? argv[na + 2] : "overflowing";
 
-                  strcpybuff(small, src);
+                  if (strcmp(argv[na + 1], "overflow-buff") == 0) {
+                    htsbuff b = htsbuff_array(small);
+
+                    htsbuff_cat(&b, src);
+                  } else {
+                    strcpybuff(small, src);
+                  }
                   printf("strsafe: NOT aborted\n");     /* must be unreachable */
                   htsmain_free();
                   return 1;

--- a/src/htssafe.h
+++ b/src/htssafe.h
@@ -287,6 +287,81 @@ static HTS_INLINE HTS_UNUSED char* strcpy_safe_(char *const dest, const size_t s
   return strncat_safe_(dest, sizeof_dest, source, sizeof_source, (size_t) -1, exp, file, line);
 }
 
+/**
+ * htsbuff: a non-owning bounded string builder over a fixed buffer.
+ *
+ * Companion to the strcpybuff()/strcatbuff() macros for the common case of a
+ * cursor walking a buffer of known capacity (building a name into a fixed
+ * array, assembling a status line, etc.). It tracks the write position, bounds
+ * every write against the real capacity, and aborts on overflow (same contract
+ * as the *_safe_ helpers), so the error-prone manual "p += strlen(p)" dance
+ * goes away.
+ *
+ * Build one from an in-scope array with htsbuff_array() (capacity via sizeof,
+ * so pass an array, not a pointer), or from a pointer of known capacity with
+ * htsbuff_ptr(). The buffer is kept NUL-terminated; htsbuff_str() returns it.
+ */
+typedef struct {
+  char *buf;        /* backing buffer (kept NUL-terminated) */
+  size_t cap;       /* total capacity of buf, including the NUL */
+  size_t len;       /* current length, excluding the NUL */
+} htsbuff;
+
+static HTS_INLINE HTS_UNUSED htsbuff htsbuff_ptr_(char *buf, size_t cap) {
+  htsbuff b;
+  b.buf = buf;
+  b.cap = cap;
+  b.len = 0;
+  assertf(cap != 0);
+  buf[0] = '\0';
+  return b;
+}
+
+/**
+ * Builder over the in-scope array ARR (capacity = sizeof(ARR)).
+ * On GCC/Clang this rejects a non-array (e.g. a char* pointer), whose sizeof
+ * would be the pointer size and silently wrong; use htsbuff_ptr() for pointers.
+ * On other compilers there is no such guard, so pass only true arrays there.
+ */
+#if (defined(__GNUC__) && !defined(__cplusplus))
+/* 0 for an array, a -1 array-size compile error for a pointer. */
+#define htsbuff_must_be_array_(A) \
+  (sizeof(char[1 - 2 * !!__builtin_types_compatible_p(typeof(A), typeof(&(A)[0]))]) - 1)
+#define htsbuff_array(ARR) htsbuff_ptr_((ARR), sizeof(ARR) + htsbuff_must_be_array_(ARR))
+#else
+#define htsbuff_array(ARR) htsbuff_ptr_((ARR), sizeof(ARR))
+#endif
+/** Builder over pointer P of known capacity N (N includes the NUL). */
+#define htsbuff_ptr(P, N)  htsbuff_ptr_((P), (N))
+
+/** Append at most n characters of s (stopping at its NUL). Aborts on overflow. */
+static HTS_INLINE HTS_UNUSED void htsbuff_catn(htsbuff *b, const char *s, size_t n) {
+  const size_t add = strnlen(s, n);
+  /* Overflow-safe: keep the (potentially huge) 'add' alone on one side. The
+     maintained invariant len < cap makes 'cap - len' >= 1 (no underflow), so
+     'add < cap - len' cannot wrap the way 'len + add < cap' could. */
+  assertf__(add < b->cap - b->len, "htsbuff append overflow", __FILE__, __LINE__);
+  memcpy(b->buf + b->len, s, add);
+  b->len += add;
+  b->buf[b->len] = '\0';
+}
+
+/** Append s. Aborts on overflow. */
+static HTS_INLINE HTS_UNUSED void htsbuff_cat(htsbuff *b, const char *s) {
+  htsbuff_catn(b, s, (size_t) -1);
+}
+
+/** Reset content to s. Aborts on overflow. */
+static HTS_INLINE HTS_UNUSED void htsbuff_cpy(htsbuff *b, const char *s) {
+  b->len = 0;
+  htsbuff_catn(b, s, (size_t) -1);
+}
+
+/** Current NUL-terminated content. */
+static HTS_INLINE HTS_UNUSED const char *htsbuff_str(const htsbuff *b) {
+  return b->buf;
+}
+
 #define malloct(A)          malloc(A)
 #define calloct(A,B)        calloc((A), (B))
 #define freet(A)            do { if ((A) != NULL) { free(A); (A) = NULL; } } while(0)

--- a/tests/01_engine-strsafe.test
+++ b/tests/01_engine-strsafe.test
@@ -21,3 +21,14 @@ case "$err" in
 	*"overflow while copying"*) ;;
 	*) echo "expected htssafe overflow abort, got: $err" >&2; exit 1 ;;
 esac
+
+# Same guarantee for the htsbuff builder. The source is exactly the buffer
+# capacity (4 bytes into a 4-byte buffer), so this also pins the boundary: a
+# '<=' off-by-one in the capacity check would let it through (and print "NOT
+# aborted"). Match the specific htsbuff abort message, not just any assert.
+err=$(httrack -#8 overflow-buff "abcd" 2>&1)
+case "$err" in
+	*"strsafe: NOT aborted"*) echo "htsbuff over-capacity write was NOT caught" >&2; exit 1 ;;
+	*"htsbuff append overflow"*) ;;
+	*) echo "expected htsbuff overflow abort, got: $err" >&2; exit 1 ;;
+esac


### PR DESCRIPTION
## What

Add `htsbuff`, a non-owning bounded string builder over a fixed buffer, in
`htssafe.h`. No call sites are converted yet; this lands the helper and its
tests so the upcoming pointer-destination migrations can use it.

## Why

Auditing the ~214 pointer-destination `buff()` sites flagged by #330 showed most
are not unknown-size: they are cursors walking a buffer of known capacity, with
a manual `p += strlen(p)` after each write. The `url_savename` renderer does
this ~40 times, and that hand-rolled pointer math is where several off-by-one
hazards live. Mechanically rewriting each to `strlcpybuff(p, x, CAP - (p-base))`
would be verbose and easy to get wrong.

## How

`htsbuff` holds `{ buf, cap, len }` and is built from an in-scope array
(`htsbuff_array`, capacity via `sizeof`) or a pointer of known capacity
(`htsbuff_ptr`). `htsbuff_cat`/`htsbuff_catn`/`htsbuff_cpy` bound every write
against the real capacity and abort on overflow, the same contract as the
existing `*_safe_` helpers. The position tracking removes the manual
`p += strlen(p)` dance, e.g.:

    htsbuff out = htsbuff_ptr(afs->save, HTS_URLMAXSIZE);
    htsbuff_cat(&out, digest);
    htsbuff_cat(&out, ext);

The `-#8` self-test and `tests/01_engine-strsafe.test` gain builder correctness
checks (append, truncating append, reset, length) and an overflow-abort case
(`-#8 overflow-buff`).

Next: convert `url_savename` to `htsbuff` (batch 1), which also retires that
function's off-by-one findings.