### PR TITLE
Add an opt-in pre-commit hook that auto-formats changed C lines

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,35 @@
+# Git hooks
+
+Versioned hooks for this repo. Enable them once per clone:
+
+```sh
+git config core.hooksPath .githooks
+```
+
+## pre-commit: auto-format changed C lines
+
+Runs `git-clang-format` (clang-format 19, using the repo `.clang-format`) on the
+**staged lines only** and re-stages the result, so every commit is
+clang-format-clean and the CI `format` check passes. It never reformats the
+whole tree, only the lines you changed.
+
+- Disable for a single commit: `HTTRACK_NO_AUTOFORMAT=1 git commit ...`
+- If clang-format 19 isn't installed, the hook skips silently (CI still
+  enforces). Install it with your distro's `clang-format-19`, or from
+  apt.llvm.org.
+- If a file has *both* staged and unstaged changes, the hook does not
+  auto-mutate it (that would commit the unstaged part); it instead reports
+  whether its staged lines need formatting and asks you to stage/stash the rest.
+
+### noexec working trees
+
+Git executes the hook directly, so if your working tree is on a `noexec` mount
+git cannot run `.githooks/pre-commit`. Point `core.hooksPath` at a copy on an
+exec filesystem instead:
+
+```sh
+mkdir -p ~/.httrack-hooks && cp .githooks/pre-commit ~/.httrack-hooks/
+chmod +x ~/.httrack-hooks/pre-commit
+git config core.hooksPath ~/.httrack-hooks
+```
+</content>

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Auto-format the staged C lines with clang-format (touched lines only), then
+# re-stage them, so commits stay clang-format-clean and CI's format check passes.
+#
+# Enable once per clone:  git config core.hooksPath .githooks
+# Skip for one commit:    HTTRACK_NO_AUTOFORMAT=1 git commit ...
+#
+# Matches the CI gate (.clang-format, clang-format 19). It only ever touches the
+# lines a commit changes; it never reformats the whole tree.
+
+set -euo pipefail
+
+[ "${HTTRACK_NO_AUTOFORMAT:-}" = "1" ] && exit 0
+
+# Staged C/H files (added/copied/modified/renamed).
+mapfile -t files < <(git diff --cached --name-only --diff-filter=ACMR -- '*.c' '*.h')
+[ "${#files[@]}" -eq 0 ] && exit 0
+
+# Locate clang-format 19 and the git driver; if absent, skip (CI is the backstop).
+cf=""
+for c in clang-format-19 clang-format; do
+    if command -v "$c" >/dev/null 2>&1; then
+        case "$("$c" --version)" in *"version 19."*)
+            cf="$c"
+            break
+            ;;
+        esac
+    fi
+done
+gcf=""
+for g in git-clang-format-19 git-clang-format; do
+    command -v "$g" >/dev/null 2>&1 && {
+        gcf="$g"
+        break
+    }
+done
+if [ -z "$cf" ] || [ -z "$gcf" ]; then
+    echo "pre-commit: clang-format 19 not found; skipping auto-format (CI still checks)." >&2
+    exit 0
+fi
+
+# Files that are staged AND also have unstaged changes: re-staging them would
+# pull in the unstaged work, so don't auto-mutate. Check instead and let the
+# author resolve it.
+partial=()
+for f in "${files[@]}"; do
+    if ! git diff --quiet -- "$f"; then partial+=("$f"); fi
+done
+
+if [ "${#partial[@]}" -ne 0 ]; then
+    d="$("$gcf" --binary "$cf" --style=file --staged --diff --extensions c,h || true)"
+    case "$d" in
+    "" | "no modified files to format" | *"did not modify any files"*)
+        exit 0
+        ;; # staged lines already clean
+    *)
+        echo "pre-commit: these files have both staged and unstaged changes, so" >&2
+        echo "auto-format was skipped to avoid committing unstaged work:" >&2
+        printf '  %s\n' "${partial[@]}" >&2
+        echo "Their staged lines need formatting. Stage the rest (or stash it)," >&2
+        echo "or run: $gcf --binary $cf --staged" >&2
+        exit 1
+        ;;
+    esac
+fi
+
+# Clean-staged files: format the staged lines in the working tree, then re-stage.
+"$gcf" --binary "$cf" --style=file --staged --extensions c,h >/dev/null || true
+git add -- "${files[@]}"
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,10 @@ jobs:
 
       # Lint the scripts we maintain; the legacy scripts are a separate cleanup.
       - name: shellcheck
-        run: shellcheck man/makeman.sh tools/mkdeb.sh tests/*.test tests/check-network.sh
+        run: shellcheck man/makeman.sh tools/mkdeb.sh .githooks/pre-commit tests/*.test tests/check-network.sh
 
       - name: shfmt
-        run: shfmt -d -i 4 man/makeman.sh tools/mkdeb.sh
+        run: shfmt -d -i 4 man/makeman.sh tools/mkdeb.sh .githooks/pre-commit
 
   # Check clang-format on CHANGED LINES ONLY. The engine predates clang-format
   # (it was shaped by an old Visual Studio formatter) and does not round-trip,


### PR DESCRIPTION
## What

A versioned `pre-commit` hook (`.githooks/pre-commit`) that auto-formats the
**staged C lines only** with clang-format 19, plus `.githooks/README.md`.

## Why

We enforce clang-format on changed lines in CI (#333). This closes the loop
locally: the hook keeps commits clang-format-clean automatically, so
contributors don't discover formatting nits only after a failed CI run, and the
codebase converges to a uniform style over time. Touched-lines-only, never a
whole-tree reformat.

## How

`.git/hooks` isn't tracked, so the hook is shipped via `core.hooksPath`:

```sh
git config core.hooksPath .githooks
```

The hook runs `git-clang-format` (pinned to clang-format 19, repo `.clang-format`)
on the staged lines and re-stages the result. It is safe by construction:

- **No tool installed** -> skips silently (CI is the backstop).
- **Mixed staged + unstaged changes** in a file -> does *not* auto-mutate (that
  would commit the unstaged part); it reports and asks the author to stage/stash.
- `HTTRACK_NO_AUTOFORMAT=1 git commit ...` skips it for one commit.

Verified locally against clang-format 19.1.7: clean-staged mis-formatted code is
reformatted and re-staged with no unstaged leakage; mixed-state commits are
rejected without mutation; already-clean commits are a no-op.

### noexec working trees

Git execs the hook directly, so on a `noexec` working tree it can't run from
`.githooks`. The README shows how to point `core.hooksPath` at a copy on an
exec filesystem.