### PR TITLE
Add contributor governance: CONTRIBUTING, COC, SECURITY, DCO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,37 @@ jobs:
         if: failure()
         run: cat tests/test-suite.log 2>/dev/null || true
 
+  dco:
+    name: DCO sign-off
+    # Only checkable on a PR, where we have the base..head commit range.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Every commit must be signed off
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          fail=0
+          # --no-merges: merge commits are GitHub-generated and carry no sign-off.
+          for sha in $(git rev-list --no-merges "$BASE..$HEAD"); do
+            if [ -z "$(git log -1 --format='%(trailers:key=Signed-off-by)' "$sha")" ]; then
+              echo "Missing Signed-off-by: $(git log -1 --format='%h %s' "$sha")"
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo
+            echo "Sign commits with 'git commit -s'; fix a branch with 'git rebase --signoff $BASE'."
+            echo "See CONTRIBUTING.md (Developer Certificate of Origin)."
+            exit 1
+          fi
+
   lint:
     name: lint (shellcheck, shfmt)
     runs-on: ubuntu-24.04

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <roche@httrack.com>. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to HTTrack
+
+HTTrack is small and old. Keep changes easy to review and safe to merge.
+
+## Pull requests
+
+- One change per PR. Small diffs merge fast.
+- PRs are squash-merged: the title and description become the commit message, so
+  explain *why*.
+- Add or update tests for engine changes (`tests/`), and keep CI green.
+
+## Style
+
+- C, matching nearby code. **Format only the lines you change** (`git
+  clang-format` against the repo `.clang-format`). Never reformat untouched code.
+- Comment the *why*, in English.
+- HTTrack parses hostile input off the network. Check bounds, avoid unchecked
+  copies, and never let an attacker-controlled length drive arithmetic unchecked.
+
+## Sign your work
+
+Every commit needs a `Signed-off-by` line, the
+[DCO](https://developercertificate.org/): `git commit -s`. CI rejects unsigned
+commits; fix a branch with `git rebase --signoff master`.
+
+## AI assistants
+
+Welcome, and nothing to disclose. Two rules:
+
+- **Own every line** as if you wrote it. Can't explain it in review? Not ready.
+- **Don't push your work onto reviewers.** A raw generated patch a maintainer has
+  to vet from scratch will be closed.
+
+The sign-off covers AI-assisted code too.
+
+## Bugs
+
+Open an issue with the version, OS, command used, and expected vs actual result.
+For security issues see [SECURITY.md](SECURITY.md), not a public issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Report privately, not in a public issue or PR: use GitHub
 [private advisories](https://github.com/xroche/httrack/security/advisories/new)
-or email <roche@httrack.com>.
+or email <roche@httrack.com> (alternate: `xroche at gmail dot com`).
 
 Include the HTTrack version and platform, a concrete reproduction (command line,
 a sample page or server response, or a small proof of concept), and what an

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting
+
+Report privately, not in a public issue or PR: use GitHub
+[private advisories](https://github.com/xroche/httrack/security/advisories/new)
+or email <roche@httrack.com>.
+
+Include the HTTrack version and platform, a concrete reproduction (command line,
+a sample page or server response, or a small proof of concept), and what an
+attacker gains. We'll acknowledge it and keep you posted. Please allow time for a
+release before disclosing publicly.
+
+## Supported versions
+
+Fixes land on `master` and ship in the next release; older releases aren't
+maintained. Confirm against current `master` when you can.
+
+## AI-assisted findings
+
+Scanners and LLMs are fine, but only send reports you have verified yourself. A
+confirmed, reproducible issue is worth our time; a plausible one that doesn't
+reproduce is not, and will be closed. If a report is AI-assisted, say so.


### PR DESCRIPTION
## What

First community-health files for the project:

- **CONTRIBUTING.md** — PR/style basics, a note that the engine parses hostile network input, and an outcome-only AI-assistance policy (own every line, don't push review work onto maintainers; nothing to disclose).
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1, contact `roche@httrack.com`.
- **SECURITY.md** — private reporting, supported = `master`, and a verified-reproduction bar so AI-assisted reports don't become triage noise.
- **DCO** — require `Signed-off-by` on every commit, enforced by a new pull_request-only CI job.

## Why

The project predates the community-health era and had none of these. After a lot of LLM-assisted work, the goal is contribution standards that are tool-agnostic and enforceable, without a separate "LLM code of conduct" that would date instantly and can't be verified. The SECURITY bar reflects what AI slop actually costs a C network tool: the security-report channel, not code PRs (see curl, early 2026).

Kept deliberately short so people actually read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)