### PR TITLE
build: make out-of-tree builds and "make check" work from a read-only/noexec tree

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,9 @@ LT_INIT
 AC_PROG_LN_S
 LT_INIT
 
+# bash, used to run the test scripts (see tests/Makefile.am TEST_LOG_COMPILER)
+AC_PATH_PROGS([BASH], [bash], [/bin/bash])
+
 # Export LD_LIBRARY_PATH name or equivalent.
 AC_SUBST(SHLIBPATH_VAR,$shlibpath_var)
 

--- a/html/Makefile.am
+++ b/html/Makefile.am
@@ -13,22 +13,26 @@ WebIcon32x32dir = $(datadir)/icons/hicolor/32x32/apps
 WebIcon48x48dir = $(datadir)/icons/hicolor/48x48/apps
 VFolderEntrydir = $(prefix)/share/applications
 
+# Wildcards are globbed against $(srcdir): a bare "*.html" is resolved against
+# the build dir and stays unexpanded (breaking "make") in an out-of-tree build.
+# Explicit filenames (e.g. ../history.txt, div/search.sh) resolve via VPATH and
+# need no prefix.
 HelpHtmlroot_DATA = ../httrack-doc.html ../history.txt
-HelpHtml_DATA = *.html
+HelpHtml_DATA = $(srcdir)/*.html
 HelpHtmldiv_DATA = div/search.sh
-HelpHtmlimg_DATA  = img/*
-HelpHtmlimages_DATA = images/*
+HelpHtmlimg_DATA  = $(srcdir)/img/*
+HelpHtmlimages_DATA = $(srcdir)/images/*
 HelpHtmlTxt_DATA = ../greetings.txt ../history.txt ../license.txt
-WebHtml_DATA = server/*.html server/*.js server/*.css
-WebHtmlimages_DATA = server/images/*
+WebHtml_DATA = $(srcdir)/server/*.html $(srcdir)/server/*.js $(srcdir)/server/*.css
+WebHtmlimages_DATA = $(srcdir)/server/images/*
 # note: converted & normalized by
 # ico2xpm favicon.ico -o httrack.xpm
 # mogrify -format xpm -map /usr/share/doc/menu/examples/cmap.xpm httrack.xpm
-WebPixmap_DATA = server/div/*.xpm
-WebIcon16x16_DATA = server/div/16x16/*.png
-WebIcon32x32_DATA = server/div/32x32/*.png
-WebIcon48x48_DATA = server/div/48x48/*.png
-VFolderEntry_DATA = server/div/*.desktop
+WebPixmap_DATA = $(srcdir)/server/div/*.xpm
+WebIcon16x16_DATA = $(srcdir)/server/div/16x16/*.png
+WebIcon32x32_DATA = $(srcdir)/server/div/32x32/*.png
+WebIcon48x48_DATA = $(srcdir)/server/div/48x48/*.png
+VFolderEntry_DATA = $(srcdir)/server/div/*.desktop
 
 EXTRA_DIST = $(HelpHtml_DATA) $(HelpHtmlimg_DATA) $(HelpHtmlimages_DATA) \
 	$(HelpHtmldiv_DATA) $(WebHtml_DATA) $(WebHtmlimages_DATA) \

--- a/lang/Makefile.am
+++ b/lang/Makefile.am
@@ -1,6 +1,8 @@
 
 langdir = $(datadir)/httrack/lang
-lang_DATA = *.txt
+# Glob against $(srcdir): a bare "*.txt" is resolved against the build dir and
+# stays unexpanded (breaking "make") in an out-of-tree build.
+lang_DATA = $(srcdir)/*.txt
 langrootdir = $(datadir)/httrack
 langroot_DATA = ../lang.def ../lang.indexes
 

--- a/libtest/Makefile.am
+++ b/libtest/Makefile.am
@@ -1,6 +1,8 @@
 
 exemplesdir = $(datadir)/httrack/libtest
-exemples_DATA = *.c *.h *.txt
+# Glob against $(srcdir), not the build dir: a bare "*.c" is resolved relative to
+# the build dir and stays unexpanded (breaking "make") in an out-of-tree build.
+exemples_DATA = $(srcdir)/*.c $(srcdir)/*.h $(srcdir)/*.txt
 EXTRA_DIST = $(exemples_DATA) libtest.mak libtest.vcproj
 
 AM_CPPFLAGS = \
@@ -12,7 +14,9 @@ AM_CPPFLAGS = \
 	-DSYSCONFDIR=\""$(sysconfdir)"\" \
 	-DDATADIR=\""$(datadir)"\" \
 	-DLIBDIR=\""$(libdir)"\"
-AM_CPPFLAGS += -I../src
+# Use $(top_srcdir)/src, not ../src: the latter is relative to the build dir and
+# misses the source headers (e.g. httrack-library.h) in an out-of-tree build.
+AM_CPPFLAGS += -I$(top_srcdir)/src
 
 # The callback examples reference libc only through libhttrack, so the direct
 # libc edge gets dropped from DT_NEEDED (library-not-linked-against-libc).

--- a/m4/Makefile.am
+++ b/m4/Makefile.am
@@ -1,1 +1,3 @@
-EXTRA_DIST = *.m4
+# Glob against $(srcdir) so "make dist" works out-of-tree (a bare "*.m4" is
+# resolved against the build dir, where there are no sources).
+EXTRA_DIST = $(srcdir)/*.m4

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -9,6 +9,11 @@ TESTS_ENVIRONMENT += HTTPS_SUPPORT=$(HTTPS_SUPPORT)
 TESTS_ENVIRONMENT += top_srcdir=$(top_srcdir)
 
 TEST_EXTENSIONS = .test
+# Run each .test through bash instead of execve()ing it. This lets "make check"
+# work when the source tree sits on a noexec filesystem (the driver would
+# otherwise fail with "Permission denied"), and removes any reliance on the
+# scripts' executable bit. The scripts are #!/bin/bash and use bash features.
+TEST_LOG_COMPILER = $(BASH)
 TESTS = \
 	00_runnable.test \
 	01_engine-cache.test \


### PR DESCRIPTION
Building in this repo currently forces a full copy of the tree to a writable, exec location first: out-of-tree builds fail, and `make check` can't run when the source sits on a noexec mount. This makes a plain out-of-tree build work straight from the source tree, with no copy.

There are three independent fixes. libtest set `-I../src`, which is relative to the build dir, so an out-of-tree build looked in `build/src` (generated files only) and never found the source header `httrack-library.h`; it now uses `-I$(top_srcdir)/src`. The wildcard `_DATA` lists in libtest, lang, html and m4 were bare globs like `*.html`; make expands a wildcard prerequisite against the build dir, so out-of-tree the glob matched nothing and stayed literal, giving `No rule to make target '*.html'`. Those now glob against `$(srcdir)`, while explicit filenames are left as they were since VPATH already finds them. Finally, automake's test driver execve's each `tests/*.test`, which fails with Permission denied on a noexec tree; setting `TEST_LOG_COMPILER = $(BASH)` runs them through bash instead, which also removes any dependence on the scripts' executable bit.

Verified end to end from a noexec source tree, out-of-tree, with no copy: `make` builds the whole tree including libtest, and `make check` reports 14 pass, 7 online crawl tests skipped offline, 0 fail. In-tree builds are unchanged (`$(srcdir)` is `.` in-tree, and running tests through bash behaves the same), so CI is unaffected.