### PR TITLE
Bound htsback backing-info and fast-cache copies

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -1518,9 +1518,11 @@ int back_add(struct_back * sback, httrackp * opt, cache_back * cache, const char
 
           if (sscanf(text, "%d", &code) == 1) { // got code
             back[p].r.statuscode = code;
-            back[p].status = STATUS_READY;      // terminé
+            back[p].status = STATUS_READY;      // done
             if (lf != NULL && *lf != '\0') {    // got location ?
-              strcpybuff(back[p].r.location, lf + 1);
+              // r.location aliases location_buffer (set above); write the array
+              // so the bounded macro picks up its capacity.
+              strcpybuff(back[p].location_buffer, lf + 1);
             }
             return 0;
           }
@@ -3998,26 +4000,30 @@ LLint back_transferred(LLint nb, struct_back * sback) {
   return nb;
 }
 
-// infos backing
-// j: 1 afficher sockets 2 afficher autres 3 tout afficher
+// backing info
+// j: 1=show sockets 2=show others 3=show all
 void back_info(struct_back * sback, int i, int j, FILE * fp) {
   lien_back *const back = sback->lnk;
   const int back_max = sback->count;
 
   assertf(i >= 0 && i < back_max);
   if (back[i].status >= 0) {
-    char BIGSTK s[HTS_URLMAXSIZE * 2 + 1024];
+    // Holds the status tag plus the full URL: url_adr and url_fil are each
+    // HTS_URLMAXSIZE*2, so reserve room for both (*4) plus framing/trailer.
+    // Undersizing would make back_infostr's bounded appends abort on a long
+    // URL.
+    char BIGSTK s[HTS_URLMAXSIZE * 4 + 1024];
 
     s[0] = '\0';
-    back_infostr(sback, i, j, s);
+    back_infostr(sback, i, j, s, sizeof(s));
     strcatbuff(s, LF);
     fprintf(fp, "%s", s);
   }
 }
 
-// infos backing
-// j: 1 afficher sockets 2 afficher autres 3 tout afficher
-void back_infostr(struct_back * sback, int i, int j, char *s) {
+// backing info
+// j: 1=show sockets 2=show others 3=show all
+void back_infostr(struct_back *sback, int i, int j, char *s, size_t size) {
   lien_back *const back = sback->lnk;
   const int back_max = sback->count;
 
@@ -4027,16 +4033,16 @@ void back_infostr(struct_back * sback, int i, int j, char *s) {
 
     if (j & 1) {
       if (back[i].status == STATUS_CONNECTING) {
-        strcatbuff(s, "CONNECT ");
+        strlcatbuff(s, "CONNECT ", size);
       } else if (back[i].status == STATUS_WAIT_HEADERS) {
-        strcatbuff(s, "INFOS ");
+        strlcatbuff(s, "INFOS ", size);
         aff = 1;
       } else if (back[i].status == STATUS_CHUNK_WAIT
                  || back[i].status == STATUS_CHUNK_CR) {
-        strcatbuff(s, "INFOSC");        // infos chunk
+        strlcatbuff(s, "INFOSC", size); // chunk info
         aff = 1;
       } else if (back[i].status > 0) {
-        strcatbuff(s, "RECEIVE ");
+        strlcatbuff(s, "RECEIVE ", size);
         aff = 1;
       }
     }
@@ -4044,44 +4050,44 @@ void back_infostr(struct_back * sback, int i, int j, char *s) {
       if (back[i].status == STATUS_READY) {
         switch (back[i].r.statuscode) {
         case 200:
-          strcatbuff(s, "READY ");
+          strlcatbuff(s, "READY ", size);
           aff = 1;
           break;
         case -1:
-          strcatbuff(s, "ERROR ");
+          strlcatbuff(s, "ERROR ", size);
           aff = 1;
           break;
         case -2:
-          strcatbuff(s, "TIMEOUT ");
+          strlcatbuff(s, "TIMEOUT ", size);
           aff = 1;
           break;
         case -3:
-          strcatbuff(s, "TOOSLOW ");
+          strlcatbuff(s, "TOOSLOW ", size);
           aff = 1;
           break;
         case 400:
-          strcatbuff(s, "BADREQUEST ");
+          strlcatbuff(s, "BADREQUEST ", size);
           aff = 1;
           break;
         case 401:
         case 403:
-          strcatbuff(s, "FORBIDDEN ");
+          strlcatbuff(s, "FORBIDDEN ", size);
           aff = 1;
           break;
         case 404:
-          strcatbuff(s, "NOT FOUND ");
+          strlcatbuff(s, "NOT FOUND ", size);
           aff = 1;
           break;
         case 500:
-          strcatbuff(s, "SERVERROR ");
+          strlcatbuff(s, "SERVERROR ", size);
           aff = 1;
           break;
         default:
           {
             char s2[256];
 
-            sprintf(s2, "ERROR(%d)", back[i].r.statuscode);
-            strcatbuff(s, s2);
+            snprintf(s2, sizeof(s2), "ERROR(%d)", back[i].r.statuscode);
+            strlcatbuff(s, s2, size);
           }
           aff = 1;
         }
@@ -4092,16 +4098,18 @@ void back_infostr(struct_back * sback, int i, int j, char *s) {
       {
         char BIGSTK s2[HTS_URLMAXSIZE * 2 + 1024];
 
-        sprintf(s2, "\"%s", back[i].url_adr);
-        strcatbuff(s, s2);
+        snprintf(s2, sizeof(s2), "\"%s", back[i].url_adr);
+        strlcatbuff(s, s2, size);
 
         if (back[i].url_fil[0] != '/')
-          strcatbuff(s, "/");
-        sprintf(s2, "%s\" ", back[i].url_fil);
-        strcatbuff(s, s2);
-        sprintf(s, LLintP " " LLintP " ", (LLint) back[i].r.size,
-                (LLint) back[i].r.totalsize);
-        strcatbuff(s, s2);
+          strlcatbuff(s, "/", size);
+        snprintf(s2, sizeof(s2), "%s\" ", back[i].url_fil);
+        strlcatbuff(s, s2, size);
+        // size/totalsize trailer: build in s2, then append (the old code wrote
+        // straight into s here, clobbering the URL it had just assembled).
+        snprintf(s2, sizeof(s2), LLintP " " LLintP " ", (LLint) back[i].r.size,
+                 (LLint) back[i].r.totalsize);
+        strlcatbuff(s, s2, size);
       }
     }
   }

--- a/src/htsback.h
+++ b/src/htsback.h
@@ -129,7 +129,7 @@ int back_trylive(httrackp * opt, cache_back * cache, struct_back * sback,
 int back_finalize(httrackp * opt, cache_back * cache, struct_back * sback,
                   const int p);
 void back_info(struct_back * sback, int i, int j, FILE * fp);
-void back_infostr(struct_back * sback, int i, int j, char *s);
+void back_infostr(struct_back *sback, int i, int j, char *s, size_t size);
 LLint back_transferred(LLint add, struct_back * sback);
 
 // hostback

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -155,6 +155,89 @@ static void basic_selftests(void) {
     assertf(strcmp(cookie_get(cbuf, "a\t\tc", 1), "") == 0);  // empty field
     assertf(strcmp(cookie_get(cbuf, "a\tb\tc", 9), "") == 0); // beyond last
   }
+  // back_infostr() status-line formatting (no sockets: pure formatting over
+  // in-memory slots). Stresses a few thousand entries across every status-code
+  // arm. Regression for a clobber bug where the size/totalsize trailer was
+  // written straight into the destination, wiping the URL it had just built.
+  {
+    static const struct {
+      int code;
+      const char *tag;
+    } cases[] = {
+        {200, "READY "},     {-1, "ERROR "},       {-2, "TIMEOUT "},
+        {-3, "TOOSLOW "},    {400, "BADREQUEST "}, {403, "FORBIDDEN "},
+        {404, "NOT FOUND "}, {500, "SERVERROR "},  {999, "ERROR(999)"},
+    };
+    const int ncases = (int) (sizeof(cases) / sizeof(cases[0]));
+    const int n = 2000;
+    lien_back *slots = calloct(n, sizeof(lien_back));
+    char line[HTS_URLMAXSIZE * 4 + 1024];
+    char expect[HTS_URLMAXSIZE * 4 + 1024];
+    struct_back sb;
+    int idx;
+
+    sb.lnk = slots;
+    sb.count = n;
+    sb.ready = NULL;
+    sb.ready_size_bytes = 0;
+    for (idx = 0; idx < n; idx++) {
+      lien_back *const slot = &slots[idx];
+
+      slot->r.location = slot->location_buffer;
+      slot->status = STATUS_READY;
+      slot->r.statuscode = cases[idx % ncases].code;
+      slot->r.size = idx;
+      slot->r.totalsize = idx + 1;
+      snprintf(slot->url_adr, sizeof(slot->url_adr), "http://h%d.example", idx);
+      snprintf(slot->url_fil, sizeof(slot->url_fil), "/p/%d.html", idx);
+    }
+    for (idx = 0; idx < n; idx++) {
+      line[0] = '\0';
+      back_infostr(&sb, idx, 3, line, sizeof(line));
+      // Exact match (not substring): pins tag/URL/trailer order and rejects a
+      // partial clobber, duplication, or truncation that a presence check would
+      // let through. The expected format is stated here independently.
+      snprintf(expect, sizeof(expect),
+               "%s\"http://h%d.example/p/%d.html\" " LLintP " " LLintP " ",
+               cases[idx % ncases].tag, idx, idx, (LLint) idx,
+               (LLint) (idx + 1));
+      assertf(strcmp(line, expect) == 0);
+    }
+    // Near-maximal URL, driven through back_info() (which owns the status
+    // buffer internally and prints to a FILE*). url_adr + url_fil together
+    // overrun the old HTS_URLMAXSIZE*2+1024 buffer, so the bounded appends
+    // would abort unless that buffer is sized to hold both fields. Regression
+    // for that sizing -- exercising back_infostr() directly would miss it,
+    // since the caller's buffer is what matters.
+    {
+      lien_back *const slot = &slots[0];
+      const size_t adrlen = sizeof(slot->url_adr) - 8;
+      const size_t fillen = sizeof(slot->url_fil) - 8;
+      FILE *const fp = tmpfile();
+      size_t got;
+
+      assertf(fp != NULL);
+      slot->status = STATUS_READY;
+      slot->r.statuscode = 200;
+      slot->r.size = 1;
+      slot->r.totalsize = 2;
+      memset(slot->url_adr, 'a', adrlen);
+      slot->url_adr[adrlen] = '\0';
+      slot->url_fil[0] = '/';
+      memset(slot->url_fil + 1, 'b', fillen - 1);
+      slot->url_fil[fillen] = '\0';
+      back_info(&sb, 0, 3, fp);
+      rewind(fp);
+      got = fread(line, 1, sizeof(line) - 1, fp);
+      line[got] = '\0';
+      fclose(fp);
+      snprintf(expect, sizeof(expect),
+               "READY \"%s%s\" " LLintP " " LLintP " " LF, slot->url_adr,
+               slot->url_fil, (LLint) 1, (LLint) 2);
+      assertf(strcmp(line, expect) == 0);
+    }
+    freet(slots);
+  }
 }
 
 /* Self-tests for the htssafe.h bounded string ops (driven by httrack -#8).


### PR DESCRIPTION
Next batch of the htssafe.h pointer-destination migration, clearing htsback.c.

`back_infostr()` formatted its status line into a bare `char*` through the unchecked `strcatbuff()` path. This threads the destination capacity through the function and switches to `strlcatbuff()`. While in there it also fixes a latent clobber bug: the size/totalsize trailer was `sprintf`'d straight into the destination buffer, wiping the URL the function had just assembled, instead of being built in the scratch buffer and appended. The fixed-size `sprintf()` calls become `snprintf()`.

In `back_add()`'s fast-header cache path, the cached location is now copied into its backing array (`location_buffer`) instead of through the `r.location` alias, so the bounded macro sees the real capacity.

A new `back_infostr()` self-test runs under `-#7`: it formats 2000 in-memory slots across every status-code arm (pure formatting, no sockets) and checks that the URL, status tag, and size trailer all survive. It aborts on the clobber bug above, so it has teeth as a regression guard.

After this, htsback.c is free of pointer-destination `buff()` warnings.