### PR TITLE
ci: build and lintian-gate the Debian packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,32 @@ jobs:
         if: failure()
         run: cat tests/test-suite.log 2>/dev/null || true
 
+  # Validate the Debian packaging via the same script maintainers release with.
+  # One amd64/gcc run is enough: packaging (control/rules/manifest/lintian/quilt
+  # source build) is arch- and compiler-independent, and the build matrix above
+  # already covers compile portability. lintian runs with --fail-on=error.
+  deb:
+    name: deb package (lintian)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install packaging toolchain
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential autoconf automake libtool autoconf-archive \
+            zlib1g-dev libssl-dev \
+            debhelper devscripts lintian fakeroot
+
+      # --unsigned: CI has no GPG key (also skips the release sig/checksums).
+      # debuild builds every package, then lintian gates on errors.
+      - name: Build Debian packages
+        run: bash tools/mkdeb.sh --unsigned --no-release-artifacts
+
   dco:
     name: DCO sign-off
     # Only checkable on a PR, where we have the base..head commit range.

--- a/debian/httrack-doc.lintian-overrides
+++ b/debian/httrack-doc.lintian-overrides
@@ -1,2 +1,6 @@
-httrack-doc: extra-license-file usr/share/httrack/html/license.txt
-httrack-doc: package-contains-documentation-outside-usr-share-doc usr/share/httrack/*
+# httrack ships its HTML manual (and the bundled license) under
+# /usr/share/httrack/html by design; /usr/share/doc/httrack/html symlinks into
+# it (see debian/rules). These are pointed hints whose match context is empty,
+# so the path lives in the display pointer, not the override -- match with '*'.
+httrack-doc: extra-license-file *
+httrack-doc: package-contains-documentation-outside-usr-share-doc *

--- a/debian/libhttrack-dev.lintian-overrides
+++ b/debian/libhttrack-dev.lintian-overrides
@@ -1,4 +1,7 @@
-libhttrack-dev: breakout-link *
-libhttrack-dev: hardening-no-fortify-functions usr/lib/x86_64-linux-gnu/httrack/libtest/*
-libhttrack-dev: package-contains-documentation-outside-usr-share-doc usr/share/httrack/libtest/readme.txt
+# The libtest example shared objects are unhardened test fixtures shipped for
+# the test harness, and their readme sits beside them under /usr/share/httrack.
+# Both are pointed hints with an empty match context, so match with '*'.
+libhttrack-dev: hardening-no-fortify-functions *
+libhttrack-dev: package-contains-documentation-outside-usr-share-doc *
+# config.h is installed as a public dev header; the package-name match is expected.
 libhttrack-dev: package-name-defined-in-config-h usr/include/httrack/config.h

--- a/debian/libhttrack2.lintian-overrides
+++ b/debian/libhttrack2.lintian-overrides
@@ -1,2 +1,3 @@
+# The shared libraries ship without a versioned symbols control file (ABI is
+# tracked via the SONAME and a strict =version dependency, see debian/rules).
 libhttrack2: no-symbols-control-file usr/lib/*
-libhttrack2: spelling-error-in-binary usr/lib/*/libhttrack.so.* updat update

--- a/tools/mkdeb.sh
+++ b/tools/mkdeb.sh
@@ -153,8 +153,9 @@ main() {
         cp -a "$export_dir/debian" "httrack-$ver/debian"
     )
 
-    # Build (debuild also runs lintian and signs).
-    local -a debuild_opts=(--lintian-opts -I -i)
+    # Build (debuild also runs lintian and signs). --fail-on aborts on a lintian
+    # error or warning, so neither a release nor CI produces an unclean package.
+    local -a debuild_opts=(--lintian-opts -I -i "--fail-on=error,warning")
     local -a build_opts=()
     [[ $source_only -eq 1 ]] && build_opts+=(-S)
     if [[ $unsigned -eq 1 ]]; then


### PR DESCRIPTION
CI never exercised the Debian packaging, so a stale `debian/control`, `rules`, file manifest, or lintian override could rot unnoticed until release time. This adds a `deb` job that builds the packages on every push/PR through the same `tools/mkdeb.sh` maintainers release with, and makes that script fail on any lintian error or warning.

One `amd64`/`gcc` run covers it: packaging is arch- and compiler-independent, and the existing build matrix already covers compile portability. The job is unsigned and uploads nothing; its value is the pass/fail and the lintian gate.

Getting to a warning-clean package meant refreshing the overrides, which had silently drifted: modern lintian turned several file tags into "pointed hints" whose override match-context is now empty (the path shows only as a display pointer), so the old `tag path` overrides no longer matched and showed up as `mismatched-override`. Rewrote those to match with `*` (the form webhttrack-common already used), and dropped two overrides whose tags lintian no longer emits at all.

Verified end-to-end from a committed HEAD: `mkdeb.sh --unsigned` builds all 12 packages and exits clean at `--fail-on=error,warning`, with zero mismatched or unused overrides.