### PR TITLE
debian: refresh stale webhttrack browser dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -8,6 +8,11 @@ httrack (3.49.8-1) unstable; urgency=medium
     common-licenses/GPL-3, use a secure version=4 watch file, add
     Rules-Requires-Root and Vcs-Browser, and override the false-positive
     source-is-missing on the bundled HTML documentation.
+  * Refresh the webhttrack browser dependency: drop the removed alternatives
+    (iceape-browser, iceweasel, icecat, mozilla, firefox, mozilla-firefox)
+    that no longer exist in Debian and triggered half-broken relationships on
+    the QA debcheck page. Depend on firefox-esr | chromium | www-browser
+    instead.
 
  -- Xavier Roche <xavier@debian.org>  Sun, 07 Jun 2026 14:29:24 +0200
 

--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,7 @@ Description: Copy websites to your computer (Offline browser)
 Package: webhttrack
 Architecture: any
 Multi-Arch: foreign
-Depends: ${misc:Depends}, ${shlibs:Depends}, webhttrack-common, sensible-utils, iceape-browser | iceweasel | icecat | mozilla | firefox | mozilla-firefox | www-browser
+Depends: ${misc:Depends}, ${shlibs:Depends}, webhttrack-common, sensible-utils, firefox-esr | chromium | www-browser
 Replaces: webhttrack-common (<< 3.43.9-2)
 Breaks: webhttrack-common (<< 3.43.9-2)
 Suggests: httrack, httrack-doc


### PR DESCRIPTION
The `webhttrack` package depended on `iceape-browser | iceweasel | icecat | mozilla | firefox | mozilla-firefox | www-browser`. The first six are all gone from Debian (iceweasel was only ever a `firefox-esr` transitional stub; `firefox` isn't in Debian main), so [qa.debian.org/debcheck](https://qa.debian.org/debcheck.php?dist=testing&package=httrack) flags every one of them as a half-broken relationship. It's noise rather than a real failure since the trailing `www-browser` virtual package keeps the OR-chain satisfiable, but it sits on the QA page and is worth clearing.

This swaps the dead list for `firefox-esr | chromium | www-browser`: the two real browsers that actually ship in Debian today, plus the virtual fallback that every other browser provides. `google-chrome` is deliberately left out — it's not in the Debian archive (it comes from Google's own apt repo), so depending on it would just recreate the same half-broken relationship.

Folded into the existing `3.49.8-1` changelog entry (no version bump, since that revision hasn't been uploaded yet).