### PR TITLE
ci: speed up the deb package job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,16 @@ jobs:
 
       # --unsigned: CI has no GPG key (also skips the release sig/checksums).
       # debuild builds every package, then lintian gates on errors.
+      #
+      # DEB_BUILD_OPTIONS trims work CI does not need (release builds via
+      # mkdeb.sh are untouched): nocheck skips debuild's make check, redundant
+      # here since the build matrix and mkdeb's own pre-build already run the
+      # suite; noautodbgsym drops the -dbgsym packages whose LTO payloads are
+      # slow to compress and that CI never ships; parallel uses every core.
       - name: Build Debian packages
-        run: bash tools/mkdeb.sh --unsigned --no-release-artifacts
+        run: |
+          export DEB_BUILD_OPTIONS="nocheck noautodbgsym parallel=$(nproc)"
+          bash tools/mkdeb.sh --unsigned --no-release-artifacts
 
   dco:
     name: DCO sign-off


### PR DESCRIPTION
The `deb package` job's build step took ~3m19s, and about half of that was work CI doesn't need. `mkdeb.sh` builds the tree once for the dist tarball and then `debuild` builds it again; that second pass ran the full test suite a second time with online/network unit tests enabled (~54s) and xz-compressed the large LTO `-dbgsym` packages that CI immediately discards (~48s).

This sets `DEB_BUILD_OPTIONS="nocheck noautodbgsym parallel=$(nproc)"` on the CI step only:

- `nocheck` skips debuild's `make check`. It's redundant here — the build matrix already runs the suite on every config, and `mkdeb.sh`'s own pre-build runs the offline tests before packaging. Only `dh_auto_test` honours the flag, so that pre-build coverage stays.
- `noautodbgsym` drops the `-dbgsym` packages whose fat-LTO payloads dominate the compression time. CI never ships them; lintian still gates the real `.deb`s.
- `parallel=$(nproc)` builds across every runner core.

`mkdeb.sh` is untouched, so release builds still produce LTO-optimized, fully-tested packages with debug symbols — only the CI environment differs. Expected step time drops to roughly 1m30s.