### PR TITLE
mkdeb: drop the redundant pre-build test pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,13 +158,13 @@ jobs:
       # debuild builds every package, then lintian gates on errors.
       #
       # DEB_BUILD_OPTIONS trims work CI does not need (release builds via
-      # mkdeb.sh are untouched): nocheck skips debuild's make check, redundant
-      # here since the build matrix and mkdeb's own pre-build already run the
-      # suite; noautodbgsym drops the -dbgsym packages whose LTO payloads are
-      # slow to compress and that CI never ships; parallel uses every core.
+      # mkdeb.sh are untouched): noautodbgsym drops the -dbgsym packages whose
+      # LTO payloads are slow to compress and that CI never ships; parallel uses
+      # every core. We let debuild run its test pass -- the only one now that
+      # mkdeb no longer runs its own -- so CI exercises the packaged tests.
       - name: Build Debian packages
         run: |
-          export DEB_BUILD_OPTIONS="nocheck noautodbgsym parallel=$(nproc)"
+          export DEB_BUILD_OPTIONS="noautodbgsym parallel=$(nproc)"
           bash tools/mkdeb.sh --unsigned --no-release-artifacts
 
   dco:

--- a/tools/mkdeb.sh
+++ b/tools/mkdeb.sh
@@ -118,7 +118,10 @@ main() {
     git -C "$repo/src/coucal" archive --format=tar --prefix=src/coucal/ HEAD |
         tar -x -C "$export_dir"
 
-    # Refresh build system and man page, then build and validate the tarball.
+    # Refresh build system and man page, then build the tarball. We build here
+    # only because regen-man needs the compiled binaries; the test suite is not
+    # run in this pass. debuild (below) runs the full suite once, with the online
+    # tests enabled, so a check here would just be a slower, offline-only repeat.
     info "regenerating build system and man page"
     (
         cd "$export_dir"
@@ -126,8 +129,6 @@ main() {
         ./configure --quiet
         make -s -j"$(nproc)"
         make -s -C man regen-man
-        info "running test suite"
-        make -s check
         # Build the tarball from a clean tree so no object files leak into it.
         make -s clean
         make -s dist


### PR DESCRIPTION
mkdeb.sh built and tested the sources twice: once in its own export-tree pre-build (`make check`, offline), then again under `debuild`, whose `dh_auto_test` runs the suite with the online tests enabled (`debian/rules` configures with `--enable-online-unit-tests=auto`). The first run was just a slower, offline-only subset of the second, so a full release build via `~/httrack.maketar` ran the whole test suite twice.

This drops mkdeb's own `make check`. The export-tree build stays, since `regen-man` needs the compiled binaries, but the suite now runs once under debuild as the superset. (Building still happens twice and that part is structural: the export tree builds to regenerate the man page and `make dist` a clean tarball, then debuild builds the actual `.deb`s from the pristine orig tarball.)

Same redundancy CI #352 removed with `DEB_BUILD_OPTIONS=nocheck` on the CI step; fixing it in mkdeb.sh applies it to release builds too instead of working around it per-environment.

The deb CI job also drops its `nocheck`: with mkdeb no longer running its own check, debuild's pass is the only one, so `nocheck` would suppress the test run entirely. Removing it makes CI exercise the packaged build's tests; `noautodbgsym` and `parallel` stay.

shfmt and shellcheck pass.