### PR TITLE
ci: ASan/UBSan, no-openssl, and distcheck jobs (plus the bugs they found)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,89 @@ jobs:
         if: failure()
         run: cat tests/test-suite.log 2>/dev/null || true
 
+  # Memory safety: build and run the suite under AddressSanitizer +
+  # UndefinedBehaviorSanitizer. The offline engine self-tests drive the parsers
+  # that chew on untrusted crawled input (charset, mime, HTML, entities, IDNA,
+  # filters, cache) straight through the sanitizers, so a buffer overrun,
+  # use-after-free, or signed overflow there fails the build instead of slipping
+  # past a plain -O2 build. gcc's runtimes; one job is enough (the bug class is
+  # arch-independent and the matrix already covers compile portability).
+  sanitize:
+    name: sanitize (ASan+UBSan, gcc)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential autoconf automake libtool autoconf-archive \
+            zlib1g-dev libssl-dev
+
+      - name: Configure (sanitized)
+        run: |
+          set -euo pipefail
+          autoreconf -fi
+          ./configure CC=gcc \
+            CFLAGS="-fsanitize=address,undefined -fno-sanitize-recover=all -g -O1 -fno-omit-frame-pointer" \
+            LDFLAGS="-fsanitize=address,undefined"
+
+      - name: Build
+        run: make -j"$(nproc)"
+
+      - name: Test (sanitized)
+        # Leaks at exit are out of scope (the CLI frees little on the way out);
+        # we want memory-safety errors, so turn leak detection off and make every
+        # other finding abort the run.
+        env:
+          ASAN_OPTIONS: detect_leaks=0:abort_on_error=1:halt_on_error=1:strict_string_checks=1
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: make check
+
+      - name: Print the test log on failure
+        if: failure()
+        run: cat tests/test-suite.log 2>/dev/null || true
+
+  # Optional-dependency build: compile and test with HTTPS/OpenSSL disabled --
+  # the configuration users on minimal systems build, and one libssl is not even
+  # installed here so configure cannot silently re-enable it. The matrix above
+  # always has libssl, so the #if HTS_USEOPENSSL branches would otherwise never
+  # be compiled and could rot unnoticed.
+  no-ssl:
+    name: build (no openssl, --disable-https)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies (no libssl)
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential autoconf automake libtool autoconf-archive zlib1g-dev
+
+      - name: Configure (https disabled)
+        run: |
+          set -euo pipefail
+          autoreconf -fi
+          ./configure --disable-https
+
+      - name: Build
+        run: make -j"$(nproc)"
+
+      - name: Test
+        run: make check
+
+      - name: Print the test log on failure
+        if: failure()
+        run: cat tests/test-suite.log 2>/dev/null || true
+
   # Validate the Debian packaging via the same script maintainers release with.
   # One amd64/gcc run is enough: packaging (control/rules/manifest/lintian/quilt
   # source build) is arch- and compiler-independent, and the build matrix above
@@ -166,6 +249,34 @@ jobs:
         run: |
           export DEB_BUILD_OPTIONS="noautodbgsym parallel=$(nproc)"
           bash tools/mkdeb.sh --unsigned --no-release-artifacts
+
+  # Release-tarball integrity: `make distcheck` rolls the dist tarball, then
+  # configures, builds and tests it out-of-tree from a read-only source tree and
+  # checks nothing is left behind. Catches a file referenced in *_SOURCES or
+  # EXTRA_DIST but missing from the tarball -- the same "ships broken to users"
+  # class as a stale committed Makefile.in.
+  distcheck:
+    name: distcheck (release tarball)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential autoconf automake libtool autoconf-archive \
+            zlib1g-dev libssl-dev
+
+      - name: distcheck
+        run: |
+          set -euo pipefail
+          autoreconf -fi
+          ./configure
+          make -j"$(nproc)" distcheck
 
   dco:
     name: DCO sign-off

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -114,5 +114,12 @@ EXTRA_DIST = httrack.h webhttrack \
 		proxy/proxytrack.h \
 		proxy/store.h \
 		proxy/proxytrack.vcproj \
-		coucal/* \
-		*.dsw *.dsp *.vcproj
+		coucal/LICENSE \
+		coucal/Makefile \
+		coucal/README.md \
+		coucal/sample.c \
+		coucal/tests.c \
+		htsjava.vcproj \
+		httrack.dsp httrack.dsw httrack.vcproj \
+		libhttrack.dsp libhttrack.dsw libhttrack.vcproj \
+		webhttrack.dsp webhttrack.dsw webhttrack.vcproj

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -565,8 +565,15 @@ EXTRA_DIST = httrack.h webhttrack \
 		proxy/proxytrack.h \
 		proxy/store.h \
 		proxy/proxytrack.vcproj \
-		coucal/* \
-		*.dsw *.dsp *.vcproj
+		coucal/LICENSE \
+		coucal/Makefile \
+		coucal/README.md \
+		coucal/sample.c \
+		coucal/tests.c \
+		htsjava.vcproj \
+		httrack.dsp httrack.dsw httrack.vcproj \
+		libhttrack.dsp libhttrack.dsw libhttrack.vcproj \
+		webhttrack.dsp webhttrack.dsw webhttrack.vcproj
 
 all: all-am
 

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -2193,16 +2193,19 @@ int httpmirror(char *url1, httrackp * opt) {
                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
                  "hts-cache/new.lst"), "rb");
         if (new_lst != NULL && sz != (size_t) -1) {
-          char *adr = (char *) malloct(sz);
+          /* +1 for the NUL below: new.lst is read raw, and the strstr()
+             that follows needs a terminated C string. */
+          char *adr = (char *) malloct(sz + 1);
 
           if (adr) {
             if (fread(adr, 1, sz, new_lst) == sz) {
+              adr[sz] = '\0';
               char line[1100];
               int purge = 0;
 
               while(!feof(old_lst)) {
                 linput(old_lst, line, 1000);
-                if (!strstr(adr, line)) {       // fichier non trouvé dans le nouveau?
+                if (!strstr(adr, line)) { // not found in the new list?
                   char BIGSTK file[HTS_URLMAXSIZE * 2];
 
                   strcpybuff(file, StringBuff(opt->path_html));

--- a/src/htsencoding.c
+++ b/src/htsencoding.c
@@ -145,8 +145,13 @@ int hts_unescapeEntitiesWithCharset(const char *src, char *dest, const size_t ma
         if (!hex) {
           if (src[i] >= '0' && src[i] <= '9') {
             const int h = src[i] - '0';
-            uc *= 10;
-            uc += h;
+            /* Guard before multiplying: a codepoint past the Unicode max
+               (0x10FFFF) is invalid anyway, so stop rather than overflow uc. */
+            if (uc > (0x10FFFF - h) / 10) {
+              ampStart = (size_t) -1;
+            } else {
+              uc = uc * 10 + h;
+            }
           } else {
             /* abandon */
             ampStart = (size_t) -1;
@@ -156,8 +161,11 @@ int hts_unescapeEntitiesWithCharset(const char *src, char *dest, const size_t ma
         else {
           const int h = get_hex_value(src[i]);
           if (h != -1) {
-            uc *= 16;
-            uc += h;
+            if (uc > (0x10FFFF - h) / 16) {
+              ampStart = (size_t) -1;
+            } else {
+              uc = uc * 16 + h;
+            }
           } else {
             /* abandon */
             ampStart = (size_t) -1;

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -3416,8 +3416,17 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
           if (RUN_CALLBACK4(opt, postprocess, &cAddr, &cSize, urladr(), urlfil()) == 1) {
             hts_log_print(opt, LOG_DEBUG,
               "engine: postprocess-html: callback modified data, applying %d bytes", cSize);
-            TypedArraySize(output_buffer) = 0;
-            TypedArrayAppend(output_buffer, cAddr, cSize);
+            /* The callback either edits output_buffer in place (cAddr
+               unchanged) or hands back its own buffer (cAddr changed). Only
+               the latter needs a copy: re-appending output_buffer onto itself
+               would read freed memory, as the append's realloc can relocate
+               the block out from under cAddr. */
+            if (cAddr != TypedArrayElts(output_buffer)) {
+              TypedArraySize(output_buffer) = 0;
+              TypedArrayAppend(output_buffer, cAddr, cSize);
+            } else {
+              TypedArraySize(output_buffer) = (size_t) cSize;
+            }
           }
         }
 


### PR DESCRIPTION
Adds three CI jobs and fixes the bugs they surfaced.

Checks added:
- sanitize: ASan+UBSan over `make check`
- no-ssl: `--disable-https` build and test, no libssl present
- distcheck: out-of-tree release-tarball build and test

Bugs fixed:
- Use-after-free in the HTML post-process path (`output_buffer` re-appended onto itself across a realloc).
- Signed overflow decoding numeric HTML entities (`&#9999999999;`).
- Heap-buffer-overflow in the update path: `hts-cache/new.lst` read into `malloc(sz)` then `strstr()`d without a NUL terminator.
- Misaligned MurmurHash3 load in coucal (submodule bump).
- `EXTRA_DIST` wildcards (`coucal/*`, `*.dsp`) broke `make dist`; files now listed explicitly.