### PR TITLE
ci: poison the ASan allocator to surface missing-NUL bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,8 +171,16 @@ jobs:
         # Leaks at exit are out of scope (the CLI frees little on the way out);
         # we want memory-safety errors, so turn leak detection off and make every
         # other finding abort the run.
+        #
+        # Poison fresh allocations with 0xCA and freed blocks with 0xCB (decimal
+        # 202/203) so memory never reads back as accidental zeros: a missing-NUL
+        # fread buffer then runs strlen off into the redzone instead of stopping
+        # at a lucky zero. Distinct bytes tell the two apart in a dump (0xCA =
+        # uninitialized, 0xCB = use-after-free). ASan caps its malloc fill at 4096
+        # bytes by default, so max_malloc_fill_size lifts it to cover large cache
+        # buffers; free_fill flags use-after-free reads.
         env:
-          ASAN_OPTIONS: detect_leaks=0:abort_on_error=1:halt_on_error=1:strict_string_checks=1
+          ASAN_OPTIONS: detect_leaks=0:abort_on_error=1:halt_on_error=1:strict_string_checks=1:malloc_fill_byte=202:max_malloc_fill_size=2147483647:free_fill_byte=203:max_free_fill_size=2147483647
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         run: make check
 


### PR DESCRIPTION
Fill malloc'd and freed memory with 0xCA in the sanitize job so the missing-NUL bug class we just spent a series of fixes on fails loudly instead of slipping through. A buffer fread into without termination, then used as a C string, now runs strlen/strstr off into the 0xCA fill and into ASan's redzone rather than stopping at an accidental zero byte.

The one load-bearing option is `max_malloc_fill_size`: ASan already fills malloc'd memory (with 0xBE), but only the first 4096 bytes, so larger cache buffers escape and their tail reads back as fresh-mmap zeros, silently terminating the string and masking the bug. Lifting the cap covers them. The `*_fill_byte=202` (0xCA) settings are recognizability only — 0xCA is non-canonical as a pointer and obvious in a dump — and `max_free_fill_size` poisons freed blocks so use-after-free reads come back as a clear sentinel.

No rebuild and no source change: this is purely the sanitize job's test environment. Verified locally that an over-4KB buffer with a missing NUL goes from a silent `strlen` to a hard heap-buffer-overflow abort under the new options.