### PR TITLE
Add AGENTS.md operational checklist for AI-assisted contributions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS.md — working in the HTTrack tree
+
+Policy and PR etiquette live in [CONTRIBUTING.md](CONTRIBUTING.md). This file is
+the operational checklist: toolchain, invariants, and how to ship a change.
+
+## Build & test
+- Fresh clone first: `git submodule update --init src/coucal`
+- `bash configure && make && make check`
+
+## Hard invariants
+- **Toolchain edit** (`configure.ac`, any `Makefile.am`, `m4/`) → run
+  `autoreconf -fi` and commit the regenerated tracked files. The repo ships the
+  generated `configure`/`Makefile.in` so users build without autotools; CI does
+  **not** catch staleness.
+- **Format only changed lines** with `git clang-format` (clang-format 19). Never
+  reformat untouched code: the engine was formatted by an old tool and won't
+  round-trip.
+- **Byte-safe edits.** Files with raw high bytes are ISO-8859-1 (French
+  comments). Edit them byte-wise (`perl -0pi`, `sed`), not through a tool that
+  re-encodes to UTF-8 and corrupts them.
+
+## Security (HTTrack parses hostile input off the network)
+- Bounds-check every copy. Overflow-safe form: put the untrusted value alone,
+  `untrusted < limit - controlled` — never `controlled + untrusted < limit`,
+  which can wrap and pass.
+
+## Code & prose
+- Be terse. Comment the why, in English; translate French comments you touch.
+- Strip AI tells from prose (em-dash overuse, rule-of-three, filler, vague
+  attributions). Ref: Wikipedia "Signs of AI writing". Claude Code: `/humanizer`.
+- Behavior change → add a test. Fast path: a hidden `httrack -#N` debug
+  subcommand (`htscoremain.c`) driven by a `tests/NN_*.test`, over a slow crawl.
+
+## Review your change adversarially (strongly suggested)
+Before pushing, and when reviewing others, don't skim for bugs:
+- **One invariant at a time.** Name a property the diff must preserve (bounds
+  hold, cache/wire format unchanged, no use-after-free, ABI stable), then
+  construct inputs that would break it. "General correctness" is not a charter.
+- **Audit tests against the spec, not the code.** For each new test ask: "what
+  buggy path would still pass this?" If you can build one, the test is
+  confirmation-biased: assertions copied from observed output lock bugs in.
+- **Risk areas need runtime probes.** Touching hostile-input parsing, struct
+  layout/ABI, cache/wire format, or a security path? A static or unit check
+  isn't enough; exercise the wrong behavior at runtime. Claude Code:
+  `/review-recipe`.
+
+## Commits
+- **Sign-off is mandatory.** Every commit carries a `Signed-off-by` trailer:
+  `git commit -s` (DCO, CI-enforced — unsigned commits are rejected).
+- **Co-Authored-By is mandatory for AI-assisted commits.** Carry a
+  `Co-Authored-By:` trailer naming the assistant. Attribute there, never in a
+  PR-body footer.
+- PRs land as a merge commit; every commit on the branch goes onto master, so
+  keep each commit message clean and meaningful.
+
+## PR descriptions
+- Plain concise prose; lead with what changed and why. No What/Why/How template.
+- Title names the problem, not the implementation.
+- Don't restate the diff — give what it can't show: motivation, context,
+  tradeoffs, risk.
+- Length tracks the change: a typo is one sentence; a security fix earns a writeup.
+- Verify claims against the code before you write them; flag drift, don't repeat it.
+- Don't hard-wrap (GitHub reflows). No "Generated with Claude" footer. Run the
+  prose through `/humanizer`.
+
+## Toolchain
+C · clang-format-19 · autoreconf · shfmt + shellcheck (shell) · black + flake8 (Python)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,15 @@
 # Contributing to HTTrack
 
-HTTrack is small and old. Keep changes easy to review and safe to merge.
+HTTrack is small and old. Keep changes easy to review and safe to merge. Working
+with an AI assistant? The operational checklist is [AGENTS.md](AGENTS.md).
 
 ## Pull requests
 
 - One change per PR. Small diffs merge fast.
-- PRs are squash-merged: the title and description become the commit message, so
-  explain *why*.
+- PRs land as a merge commit, so the branch's commits go onto master as-is: keep
+  each commit message clean and explain *why*.
+- Be terse in the PR title and description: name the problem, not the fix, don't
+  restate the diff, and calibrate length to the change.
 - Add or update tests for engine changes (`tests/`), and keep CI green.
 
 ## Style
@@ -30,6 +33,9 @@ Welcome, and nothing to disclose. Two rules:
 - **Own every line** as if you wrote it. Can't explain it in review? Not ready.
 - **Don't push your work onto reviewers.** A raw generated patch a maintainer has
   to vet from scratch will be closed.
+- **Attribution is mandatory.** AI-assisted commits must carry a
+  `Co-Authored-By:` trailer naming the assistant, not a footer in the PR
+  description.
 
 The sign-off covers AI-assisted code too.
 


### PR DESCRIPTION
LLM-assisted PRs are starting to land, so give agents one compact, tool-neutral file that captures how this repo expects work to be done. The aim is contributions that arrive review-ready instead of making a maintainer reconstruct the conventions every time.

AGENTS.md is the operational checklist: build/test, the autotools-regen invariant, touched-lines-only formatting, byte-safe Latin-1 edits, overflow-safe bounds, adversarial self-review, and commit/PR discipline. It defers policy to CONTRIBUTING.md rather than restating it. CLAUDE.md is a one-line `@AGENTS.md` import so Claude Code auto-loads the same source, no second copy to drift.

CONTRIBUTING.md keeps the policy and gains two lines: Co-Authored-By attribution is mandatory for AI-assisted commits (DCO sign-off already was), and a terseness rule for PR descriptions.