### PR TITLE
Bound htsname.c pointer-destination buffer writes (batch 11)

### DIFF
--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -393,6 +393,44 @@ static void basic_selftests(void) {
     assertf(strcmp(adr_normalized_sized("example.com", n, sizeof(n)),
                    "example.com") == 0);
   }
+  // standard_name(): builds "<name><md5?>.<ext>" into a bounded buffer. The md5
+  // is appended (4 chars) only when the URL has a query string (see url_md5),
+  // so test both; pin the structure (name + ext, lengths), not the md5 chars.
+  {
+    char b[HTS_URLMAXSIZE * 2];
+    const char *nom = "index.html"; // name part
+    const char *dot = nom + 5;      // points at ".html"
+    size_t len;
+
+    // no query -> no md5: "index" + ".html"
+    standard_name(b, sizeof(b), dot, nom, "http://example.com/index.html", 0);
+    assertf(strcmp(b, "index.html") == 0);
+    // query -> 4 md5 chars between name and ext: "index" + md5(4) + ".html"
+    standard_name(b, sizeof(b), dot, nom, "http://example.com/index.html?v=1",
+                  0);
+    len = strlen(b);
+    assertf(len == 5 + 4 + 5);
+    assertf(strncmp(b, "index", 5) == 0);
+    assertf(strcmp(b + len - 5, ".html") == 0);
+    // short names: name kept (<=8), the extension is clamped to 3 -> ".htm"
+    standard_name(b, sizeof(b), dot, nom, "http://example.com/index.html?v=1",
+                  1);
+    len = strlen(b);
+    assertf(len == 5 + 4 + 4);
+    assertf(strcmp(b + len - 4, ".htm") == 0);
+    // short names with a >8-char name: the name is clamped to 8 ("indexpag")
+    {
+      const char *lnom = "indexpage.html";
+      const char *ldot = lnom + 9; // points at ".html"
+
+      standard_name(b, sizeof(b), ldot, lnom,
+                    "http://example.com/indexpage.html?v=1", 1);
+      len = strlen(b);
+      assertf(len == 8 + 4 + 4);
+      assertf(strncmp(b, "indexpag", 8) == 0);
+      assertf(strcmp(b + len - 4, ".htm") == 0);
+    }
+  }
 }
 
 /* Self-tests for the htssafe.h bounded string ops (driven by httrack -#8).

--- a/src/htsname.c
+++ b/src/htsname.c
@@ -51,12 +51,13 @@ Please visit our Website: http://www.httrack.com
       url_savename_addstr(afs->save, buff);\
     }
 
-#define ADD_STANDARD_NAME(shortname) \
-    {  /* ajout nom */\
-      char BIGSTK buff[HTS_URLMAXSIZE*2];\
-      standard_name(buff,dot_pos,nom_pos,fil_complete,(shortname));\
-      url_savename_addstr(afs->save, buff);\
-    }
+#define ADD_STANDARD_NAME(shortname)                                           \
+  { /* add name */                                                             \
+    char BIGSTK buff[HTS_URLMAXSIZE * 2];                                      \
+    standard_name(buff, sizeof(buff), dot_pos, nom_pos, fil_complete,          \
+                  (shortname));                                                \
+    url_savename_addstr(afs->save, buff);                                      \
+  }
 
 /* Avoid stupid DOS system folders/file such as 'nul' */
 /* Based on linux/fs/umsdos/mangle.c */
@@ -1377,7 +1378,9 @@ int url_savename(lien_adrfilsave *const afs,
     if (lastDot == NULL) {
       strcatbuff(afs->save, "." DELAYED_EXT);
     } else if (!IS_DELAYED_EXT(afs->save)) {
-      strcatbuff(lastDot, "." DELAYED_EXT);
+      /* lastDot points within afs->save; bound by the remaining capacity */
+      strlcatbuff(lastDot, "." DELAYED_EXT,
+                  sizeof(afs->save) - (size_t) (lastDot - afs->save));
     }
   }
   // enforce 260-character path limit before inserting destination path
@@ -1582,41 +1585,41 @@ int url_savename(lien_adrfilsave *const afs,
   return 0;
 }
 
-/* nom avec md5 urilisé partout */
-void standard_name(char *b, const char *dot_pos, const char *nom_pos, const char *fil,
-                   int short_ver) {
+/* md5-based name used everywhere; builds into b (capacity bsize) */
+void standard_name(char *b, size_t bsize, const char *dot_pos,
+                   const char *nom_pos, const char *fil, int short_ver) {
   char md5[32 + 2];
+  htsbuff bb = htsbuff_ptr(b, bsize);
 
-  b[0] = '\0';
-  /* Nom */
+  /* Name */
   if (dot_pos) {
-    if (!short_ver)             // Noms longs
-      strncatbuff(b, nom_pos, (dot_pos - nom_pos));
+    if (!short_ver) // long names
+      htsbuff_catn(&bb, nom_pos, (size_t) (dot_pos - nom_pos));
     else
-      strncatbuff(b, nom_pos, min(dot_pos - nom_pos, 8));
+      htsbuff_catn(&bb, nom_pos, (size_t) min(dot_pos - nom_pos, 8));
   } else {
-    if (!short_ver)             // Noms longs
-      strcatbuff(b, nom_pos);
+    if (!short_ver) // long names
+      htsbuff_cat(&bb, nom_pos);
     else
-      strncatbuff(b, nom_pos, 8);
+      htsbuff_catn(&bb, nom_pos, 8);
   }
   /* MD5 - 16 bits */
-  strncatbuff(b, url_md5(md5, fil), 4);
+  htsbuff_catn(&bb, url_md5(md5, fil), 4);
   /* Ext */
   if (dot_pos) {
-    strcatbuff(b, ".");
-    if (!short_ver)             // Noms longs
-      strcatbuff(b, dot_pos + 1);
+    htsbuff_catc(&bb, '.');
+    if (!short_ver) // long names
+      htsbuff_cat(&bb, dot_pos + 1);
     else
-      strncatbuff(b, dot_pos + 1, 3);
+      htsbuff_catn(&bb, dot_pos + 1, 3);
   }
   // Allow extensionless
 #ifdef DO_NOT_ALLOW_EXTENSIONLESS
   else {
-    if (!short_ver)             // Noms longs
-      strcatbuff(b, DEFAULT_EXT);
+    if (!short_ver) // long names
+      htsbuff_cat(&bb, DEFAULT_EXT);
     else
-      strcatbuff(b, DEFAULT_EXT_SHORT);
+      htsbuff_cat(&bb, DEFAULT_EXT_SHORT);
   }
 #endif
 }

--- a/src/htsname.h
+++ b/src/htsname.h
@@ -96,8 +96,8 @@ int url_savename(lien_adrfilsave *const afs,
                  httrackp * opt, struct_back * sback, cache_back * cache,
                  hash_struct * hash, int ptr, int numero_passe,
                  const lien_back * headers);
-void standard_name(char *b, const char *dot_pos, const char *nom_pos,
-                   const char *fil_complete,
+void standard_name(char *b, size_t bsize, const char *dot_pos,
+                   const char *nom_pos, const char *fil_complete,
                    int short_ver);
 void url_savename_addstr(char *d, const char *s);
 char *url_md5(char *digest_buffer, const char *fil_complete);


### PR DESCRIPTION
Batch 11 of the htssafe.h pointer-destination migration (the buff() macros silently fall back to a raw strcpy/strcat when the destination is a bare char* instead of a sized array). Clears htsname.c from 12 sites to 0.

standard_name() builds the md5-based filename into a buffer it received as a char* (so the macros couldn't bound it); it is internal (hidden, not HTSEXT_API), so it now takes an explicit destination size and builds through an htsbuff bounded builder, with its one caller (the ADD_STANDARD_NAME macro) passing sizeof(buff). url_savename()'s delayed-extension append into lastDot (a pointer into the afs->save[HTS_URLMAXSIZE*2] array) is bounded with strlcatbuff against the remaining capacity. A -#7 self-test covers standard_name's no-md5, md5, and short-name paths.
