### PR TITLE
Bound htscoremain.c pointer-destination buffer writes (batch 13)

### DIFF
--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -69,23 +69,23 @@ Please visit our Website: http://www.httrack.com
 /* Resolver */
 extern int IPV6_resolver;
 
-// Add a command in the argc/argv
-#define cmdl_add(token,argc,argv,buff,ptr) \
-  argv[argc]=(buff+ptr); \
-  strcpybuff(argv[argc],token); \
-  ptr += (int) (strlen(argv[argc])+2); \
+// Add a command in the argc/argv (buff has total capacity bufsize)
+#define cmdl_add(token, argc, argv, buff, bufsize, ptr)                        \
+  argv[argc] = (buff + ptr);                                                   \
+  strlcpybuff(argv[argc], token, (bufsize) - (ptr));                           \
+  ptr += (int) (strlen(argv[argc]) + 2);                                       \
   argc++
 
-// Insert a command in the argc/argv
-#define cmdl_ins(token,argc,argv,buff,ptr) \
-  { \
-  int i; \
-  for(i=argc;i>0;i--)\
-  argv[i]=argv[i-1];\
-  } \
-  argv[0]=(buff+ptr); \
-  strcpybuff(argv[0],token); \
-  ptr += (int) (strlen(argv[0])+2); \
+// Insert a command in the argc/argv (buff has total capacity bufsize)
+#define cmdl_ins(token, argc, argv, buff, bufsize, ptr)                        \
+  {                                                                            \
+    int i;                                                                     \
+    for (i = argc; i > 0; i--)                                                 \
+      argv[i] = argv[i - 1];                                                   \
+  }                                                                            \
+  argv[0] = (buff + ptr);                                                      \
+  strlcpybuff(argv[0], token, (bufsize) - (ptr));                              \
+  ptr += (int) (strlen(argv[0]) + 2);                                          \
   argc++
 
 #define htsmain_free() do { \
@@ -592,6 +592,7 @@ HTSEXT_API int hts_main2(int argc, char **argv, httrackp * opt) {
 static int hts_main_internal(int argc, char **argv, httrackp * opt) {
   char **x_argv = NULL;         // Patch pour argv et argc: en cas de récupération de ligne de commande
   char *x_argvblk = NULL;       // (reprise ou update)
+  size_t x_argvblk_size = 0;    // total capacity of x_argvblk
   int x_ptr = 0;                // offset
 
   //
@@ -669,7 +670,8 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
         *a = ' ';
       /* equivalent to "empty parameter" */
       if ((strcmp(argv[na], HTS_NOPARAM) == 0) || (strcmp(argv[na], HTS_NOPARAM2) == 0))        // (none)
-        strcpybuff(argv[na], "\"\"");
+        /* replacing "(none)"/"\"(none)\"" with "\"\"" always fits in place */
+        strlcpybuff(argv[na], "\"\"", strlen(argv[na]) + 1);
       if (strncmp(argv[na], "-&", 2) == 0)
         argv[na][1] = '%';
     }
@@ -691,6 +693,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
       htsmain_free();
       return -1;
     }
+    x_argvblk_size = (size_t) (current_size + 32768);
     x_argvblk[0] = '\0';
     x_ptr = 0;
 
@@ -712,7 +715,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
     //
     argv_url = 0;               /* pour comptage */
     //
-    cmdl_add(argv[0], x_argc, x_argv, x_argvblk, x_ptr);
+    cmdl_add(argv[0], x_argc, x_argv, x_argvblk, x_argvblk_size, x_ptr);
     na = 1;                     /* commencer après nom_prg */
     while(na < argc) {
       int result = 1;
@@ -733,9 +736,10 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
         }
 
         /* Copier */
-        cmdl_add(tmp_argv[0], x_argc, x_argv, x_argvblk, x_ptr);
+        cmdl_add(tmp_argv[0], x_argc, x_argv, x_argvblk, x_argvblk_size, x_ptr);
         if (tmp_argc > 1) {
-          cmdl_add(tmp_argv[1], x_argc, x_argv, x_argvblk, x_ptr);
+          cmdl_add(tmp_argv[1], x_argc, x_argv, x_argvblk, x_argvblk_size,
+                   x_ptr);
         }
 
         /* Compter URLs et détecter -i,-q.. */
@@ -816,7 +820,9 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
             return -1;
           }
           tempo[strlen(tempo) - 1] = '\0';
-          strcpybuff(argv[na], tempo);
+          /* tempo is argv[na] minus its surrounding quotes, so it fits in place
+           */
+          strlcpybuff(argv[na], tempo, strlen(argv[na]) + 1);
         }
 
         if (cmdl_opt(argv[na])) {       // option
@@ -981,7 +987,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
           if (strnotempty(lastp)) {
             insert_after_argc = argc - insert_after;
             cmdl_ins(lastp, insert_after_argc, (argv + insert_after), x_argvblk,
-                     x_ptr);
+                     x_argvblk_size, x_ptr);
             argc = insert_after_argc + insert_after;
             insert_after++;
           }
@@ -1101,7 +1107,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
       if (argv[i][0] == '-') {
         if (argv[i][1] == '-') {        // --xxx
           if ((strfield2(argv[i] + 2, "clean")) || (strfield2(argv[i] + 2, "tide"))) {  // nettoyer
-            strcpybuff(argv[i] + 1, "");
+            argv[i][1] = '\0';
             if (fexist
                 (fconcat
                  (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log), "hts-log.txt")))
@@ -1210,7 +1216,8 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
             //
           } else if (strfield2(argv[i] + 2, "catchurl")) {      // capture d'URL via proxy temporaire!
             argv_url = 1;       // forcer a passer les parametres
-            strcpybuff(argv[i] + 1, "#P");
+            /* argv[i] is "--catchurl"; "#P" fits after its first char */
+            strlcpybuff(argv[i] + 1, "#P", strlen(argv[i] + 1) + 1);
             //
           } else if (strfield2(argv[i] + 2, "updatehttrack")) {
 #ifdef _WIN32
@@ -1547,7 +1554,9 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
           return -1;
         }
         tempo[strlen(tempo) - 1] = '\0';
-        strcpybuff(argv[na], tempo);
+        /* tempo is argv[na] minus its surrounding quotes, so it fits in place
+         */
+        strlcpybuff(argv[na], tempo, strlen(argv[na]) + 1);
       }
 
       if (cmdl_opt(argv[na])) { // option
@@ -3206,7 +3215,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
         if (urlSize < HTS_URLMAXSIZE) {
           ensureUrlCapacity(url, url_sz, capa);
           if (strnotempty(url))
-            strcatbuff(url, " ");       // espace de séparation
+            strlcatbuff(url, " ", url_sz); // separator space
           append_escape_spc_url(unescape_http_unharm(catbuff, sizeof(catbuff), argv[na], 1), url, url_sz);
         }
       }                         // if argv=- etc. 

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -69,10 +69,16 @@ Please visit our Website: http://www.httrack.com
 /* Resolver */
 extern int IPV6_resolver;
 
+/* Remaining room in the argv block; 0 once it is exhausted (alias expansion or
+   doit.log insertion can outrun the +32768 slack), so the copy aborts cleanly
+   instead of the subtraction wrapping to a huge unbounded size. */
+#define cmdl_room(bufsize, ptr)                                                \
+  ((ptr) < (size_t) (bufsize) ? (size_t) (bufsize) - (ptr) : 0)
+
 // Add a command in the argc/argv (buff has total capacity bufsize)
 #define cmdl_add(token, argc, argv, buff, bufsize, ptr)                        \
   argv[argc] = (buff + ptr);                                                   \
-  strlcpybuff(argv[argc], token, (bufsize) - (ptr));                           \
+  strlcpybuff(argv[argc], token, cmdl_room(bufsize, ptr));                     \
   ptr += (int) (strlen(argv[argc]) + 2);                                       \
   argc++
 
@@ -84,7 +90,7 @@ extern int IPV6_resolver;
       argv[i] = argv[i - 1];                                                   \
   }                                                                            \
   argv[0] = (buff + ptr);                                                      \
-  strlcpybuff(argv[0], token, (bufsize) - (ptr));                              \
+  strlcpybuff(argv[0], token, cmdl_room(bufsize, ptr));                        \
   ptr += (int) (strlen(argv[0]) + 2);                                          \
   argc++
 
@@ -811,7 +817,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
           char BIGSTK tempo[HTS_CDLMAXSIZE];
 
           strcpybuff(tempo, argv[na] + 1);
-          if (tempo[strlen(tempo) - 1] != '"') {
+          if (tempo[0] == '\0' || tempo[strlen(tempo) - 1] != '"') {
             char BIGSTK s[HTS_CDLMAXSIZE];
 
             sprintf(s, "Missing quote in %s", argv[na]);
@@ -1545,7 +1551,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
         char BIGSTK tempo[HTS_CDLMAXSIZE + 256];
 
         strcpybuff(tempo, argv[na] + 1);
-        if (tempo[strlen(tempo) - 1] != '"') {
+        if (tempo[0] == '\0' || tempo[strlen(tempo) - 1] != '"') {
           char s[HTS_CDLMAXSIZE + 256];
 
           sprintf(s, "Missing quote in %s", argv[na]);

--- a/tests/01_engine-cmdline.test
+++ b/tests/01_engine-cmdline.test
@@ -30,6 +30,17 @@ run() {
     RC=$?
 }
 
+# crawl using exactly the given args as the only URL(s), no implicit primary URL;
+# leaves the exit status in RC
+run_only() {
+    local out="$1"
+    shift
+    rm -rf "$out"
+    mkdir -p "$out"
+    httrack -O "$out" --quiet -n "$@" >"$out/.log" 2>&1
+    RC=$?
+}
+
 # assert the value was accepted: clean exit and the fixture was mirrored
 accepted() {
     { test "$RC" -eq 0 && test -n "$(find "$1" -type f -path '*/index.html' -print -quit)"; } ||
@@ -68,12 +79,15 @@ refused "#152: over-cap -F not refused cleanly"
 run "$tmp/ov-l" --user-agent "$over"
 refused "#152: over-cap --user-agent not refused cleanly"
 
-# a fully "-quoted argument has its surrounding quotes stripped in place (the
-# parser's quote handling), so a quoted URL is mirrored; a dangling opening quote
-# is refused cleanly, never a crash. Exercises the in-place argv quote-strip.
-run "$tmp/q-ok" "\"file://$tmp/index.html\""
-accepted "$tmp/q-ok" "quoted URL: surrounding quotes not stripped in place"
-run "$tmp/q-bad" '"foo'
-refused "quoted argument with a missing closing quote not refused cleanly"
+# Quote handling on the sole URL (run_only, so the quoted arg is the only URL and
+# can't be masked by an implicit one). A fully "-quoted URL has its surrounding
+# quotes stripped in place and is mirrored; a dangling opening quote, and a lone
+# quote (empty after the opening "), are refused cleanly and never crash.
+run_only "$tmp/q-ok" "\"file://$tmp/index.html\""
+accepted "$tmp/q-ok" "quoted URL not stripped/mirrored"
+run_only "$tmp/q-bad" '"foo'
+refused "dangling-quote argument not refused cleanly"
+run_only "$tmp/q-lone" '"'
+refused "lone-quote argument not refused cleanly"
 
 exit 0

--- a/tests/01_engine-cmdline.test
+++ b/tests/01_engine-cmdline.test
@@ -68,4 +68,12 @@ refused "#152: over-cap -F not refused cleanly"
 run "$tmp/ov-l" --user-agent "$over"
 refused "#152: over-cap --user-agent not refused cleanly"
 
+# a fully "-quoted argument has its surrounding quotes stripped in place (the
+# parser's quote handling), so a quoted URL is mirrored; a dangling opening quote
+# is refused cleanly, never a crash. Exercises the in-place argv quote-strip.
+run "$tmp/q-ok" "\"file://$tmp/index.html\""
+accepted "$tmp/q-ok" "quoted URL: surrounding quotes not stripped in place"
+run "$tmp/q-bad" '"foo'
+refused "quoted argument with a missing closing quote not refused cleanly"
+
 exit 0


### PR DESCRIPTION
Batch 13 of the htssafe.h pointer-destination migration, in the CLI parser (hts_main_internal). Clears htscoremain.c from 10 sites to 0.

The cmdl_add()/cmdl_ins() macros build argv entries into the x_argvblk block (malloc'd as the command-line size + 32768); they now take the block's total capacity (tracked in a new x_argvblk_size) and bound the copy with strlcpybuff. A cmdl_room() helper yields 0 once the block is exhausted (alias expansion or doit.log insertion can outrun the slack) so the copy aborts cleanly instead of the size_t subtraction wrapping to a huge unbounded value. The in-place argv rewrites each write no more than the slot already holds, so they are bounded by strlen(dest)+1 (provably sufficient): "(none)" -> "\"\"", the two quote-strip copies (tempo is argv[na] minus its quotes), and "--catchurl" -> "-#P"; the empty "--clean"/"--tide" rewrite becomes a direct argv[i][1]='\0'. The URL accumulator append uses strlcatbuff against the tracked url_sz. Also guards a pre-existing out-of-bounds read: a lone '"' argument left tempo empty and read tempo[-1]; it now takes the missing-quote error path.

Not -#7 unit-testable (macros/locals in hts_main_internal): cmdl_add runs on every invocation (the whole suite covers it), and new 01_engine-cmdline.test cases exercise the quote-strip as the sole URL (a quoted URL is mirrored; dangling- and lone-quote arguments are refused cleanly, never a crash).
