### PR TITLE
Bound htsalias.c config-file alias buffer writes (batch 14)

### DIFF
--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -41,19 +41,24 @@ Please visit our Website: http://www.httrack.com
 
 #define _NOT_NULL(a) ( (a!=NULL) ? (a) : "" )
 
-// COPY OF cmdl_ins in htsmain.c
-// Insert a command in the argc/argv
-#define cmdl_ins(token,argc,argv,buff,ptr) \
-  { \
-  int i; \
-  for(i=argc;i>0;i--)\
-  argv[i]=argv[i-1];\
-  } \
-  argv[0]=(buff+ptr); \
-  strcpybuff(argv[0],token); \
-  ptr += (int) (strlen(argv[0])+1); \
+// COPY OF cmdl_ins in htscoremain.c
+/* Bytes left in x_argvblk from offset ptr. The offset can in principle outrun
+   the block (alias/doit.log expansion), so the copy aborts cleanly instead of
+   the subtraction wrapping to a huge unbounded size. */
+#define cmdl_room(bufsize, ptr)                                                \
+  ((ptr) < (size_t) (bufsize) ? (size_t) (bufsize) - (ptr) : 0)
+// Insert a command in the argc/argv (buff has total capacity bufsize)
+#define cmdl_ins(token, argc, argv, buff, bufsize, ptr)                        \
+  {                                                                            \
+    int i;                                                                     \
+    for (i = argc; i > 0; i--)                                                 \
+      argv[i] = argv[i - 1];                                                   \
+  }                                                                            \
+  argv[0] = (buff + ptr);                                                      \
+  strlcpybuff(argv[0], token, cmdl_room(bufsize, ptr));                        \
+  ptr += (int) (strlen(argv[0]) + 1);                                          \
   argc++
-// END OF COPY OF cmdl_ins in htsmain.c
+// END OF COPY OF cmdl_ins in htscoremain.c
 
 /*
   Aliases for command-line and config file definitions
@@ -468,7 +473,7 @@ const char *optalias_help(const char *token) {
 */
 /* Note: NOT utf-8 */
 int optinclude_file(const char *name, int *argc, char **argv, char *x_argvblk,
-                    int *x_ptr) {
+                    size_t x_argvblk_size, int *x_ptr) {
   FILE *fp;
 
   fp = fopen(name, "rb");
@@ -542,14 +547,15 @@ int optinclude_file(const char *name, int *argc, char **argv, char *x_argvblk,
               /* temporary argc: Number of parameters after minus insert_after_argc */
               insert_after_argc = (*argc) - insert_after;
               cmdl_ins((tmp_argv[2]), insert_after_argc, (argv + insert_after),
-                       x_argvblk, (*x_ptr));
+                       x_argvblk, x_argvblk_size, (*x_ptr));
               *argc = insert_after_argc + insert_after;
               insert_after++;
               /* Second one */
               if (return_argc > 1) {
                 insert_after_argc = (*argc) - insert_after;
                 cmdl_ins((tmp_argv[3]), insert_after_argc,
-                         (argv + insert_after), x_argvblk, (*x_ptr));
+                         (argv + insert_after), x_argvblk, x_argvblk_size,
+                         (*x_ptr));
                 *argc = insert_after_argc + insert_after;
                 insert_after++;
               }

--- a/src/htsalias.h
+++ b/src/htsalias.h
@@ -45,7 +45,7 @@ int optalias_find(const char *token);
 const char *optalias_help(const char *token);
 int optreal_find(const char *token);
 int optinclude_file(const char *name, int *argc, char **argv, char *x_argvblk,
-                    int *x_ptr);
+                    size_t x_argvblk_size, int *x_ptr);
 const char *optreal_value(int p);
 const char *optalias_value(int p);
 const char *opttype_value(int p);

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -929,18 +929,19 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
               (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
               StringBuff(opt->path_log),
                "hts-cache/doit.log"))) || (argv_url > 0)) {
-          if (!optinclude_file
-              (fconcat
-               (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-               StringBuff(opt->path_log), HTS_HTTRACKRC),
-               &argc, argv, x_argvblk, &x_ptr))
-            if (!optinclude_file(HTS_HTTRACKRC, &argc, argv, x_argvblk, &x_ptr)) {
-              if (!optinclude_file
-                  (fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-                  hts_gethome(), "/" HTS_HTTRACKRC),
-                   &argc, argv, x_argvblk, &x_ptr)) {
+          if (!optinclude_file(
+                  fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                          StringBuff(opt->path_log), HTS_HTTRACKRC),
+                  &argc, argv, x_argvblk, x_argvblk_size, &x_ptr))
+            if (!optinclude_file(HTS_HTTRACKRC, &argc, argv, x_argvblk,
+                                 x_argvblk_size, &x_ptr)) {
+              if (!optinclude_file(
+                      fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                              hts_gethome(), "/" HTS_HTTRACKRC),
+                      &argc, argv, x_argvblk, x_argvblk_size, &x_ptr)) {
 #ifdef HTS_HTTRACKCNF
-                optinclude_file(HTS_HTTRACKCNF, &argc, argv, x_argvblk, &x_ptr);
+                optinclude_file(HTS_HTTRACKCNF, &argc, argv, x_argvblk,
+                                x_argvblk_size, &x_ptr);
 #endif
               }
             }

--- a/tests/01_engine-rcfile.test
+++ b/tests/01_engine-rcfile.test
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+
+# Config-file alias loading (no network). A .httrackrc in the working directory
+# is read by optinclude_file(), whose cmdl_ins macro inserts each alias-expanded
+# token into the x_argvblk block. That macro used to copy with an unbounded
+# strcpy on a bare char*; it is now bounded (strlcpybuff + cmdl_room over the
+# block capacity). Two properties are checked:
+#   1. The bound does not truncate: a long user-agent alias reaches doit.log
+#      intact. user-agent expands to two tokens (-F <value>), so it exercises
+#      both cmdl_ins insertions.
+#   2. The bound holds under exhaustion: a pathological .httrackrc whose alias
+#      expansions overflow the block aborts cleanly through the htssafe bounds
+#      check (a message naming htsalias.c) instead of overrunning the heap. The
+#      unbounded version segfaulted here.
+
+# set -e with the intentional-nonzero httrack runs guarded explicitly (the
+# crawls below are expected to fail/abort and their status is inspected by hand).
+set -euo pipefail
+
+# Resolve httrack to an absolute path before we cd: PATH may hold a build-relative
+# entry that would not resolve from the temp directory.
+bin=$(command -v httrack) || {
+    echo "FAIL: httrack not found on PATH"
+    exit 1
+}
+case "$bin" in
+/*) ;;
+*) bin="$(cd "$(dirname "$bin")" && pwd)/$(basename "$bin")" ;;
+esac
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_rcfile.XXXXXX") || exit 1
+trap 'rm -rf "$tmp"' EXIT HUP INT QUIT PIPE TERM
+
+# --- 1. alias token survives the bound intact -------------------------------
+d1="$tmp/intact"
+mkdir -p "$d1"
+echo '<html><body>hello</body></html>' >"$d1/index.html"
+
+# optinclude_file() lowercases each config line, so the marker is lowercase to
+# survive the comparison verbatim.
+marker='zzz_rcfile_marker_0123456789_abcdefghijklmnopqrstuvwxyz_intact'
+printf 'user-agent=%s\n' "$marker" >"$d1/.httrackrc"
+
+# Run with no -O so the working-directory .httrackrc is loaded (an -O path makes
+# the engine skip the rc files). Output lands in the temp dir. Guard the run so a
+# nonzero exit is captured for the assertion instead of tripping set -e.
+rc=0
+(cd "$d1" && "$bin" "file://$d1/index.html" --quiet -n >.log 2>&1) || rc=$?
+
+test "$rc" -eq 0 || {
+    echo "FAIL: rc-file crawl exited $rc"
+    exit 1
+}
+test -f "$d1/hts-cache/doit.log" || {
+    echo "FAIL: doit.log not written (rc file not processed)"
+    exit 1
+}
+# A truncated copy would cut the token; require the full -F value.
+grep -q -- "-F $marker" "$d1/hts-cache/doit.log" || {
+    echo "FAIL: user-agent alias missing or truncated in doit.log"
+    head -1 "$d1/hts-cache/doit.log"
+    exit 1
+}
+
+# --- 2. block exhaustion aborts through the bound, not the heap -------------
+d2="$tmp/exhaust"
+mkdir -p "$d2"
+echo '<html><body>hi</body></html>' >"$d2/index.html"
+
+# Each line inserts ~two tokens of ~200 bytes; 400 lines overflow the block's
+# fixed slack (current_size + 32768) many times over, deterministically.
+val=$(printf 'a%.0s' $(seq 1 200))
+for _ in $(seq 1 400); do
+    printf 'user-agent=%s\n' "$val"
+done >"$d2/.httrackrc"
+
+# The process aborts (httrack turns the fatal signal into exit 134 either way),
+# so the exit code does not distinguish the bounded abort from a heap overflow;
+# the stderr diagnostic does. The htssafe bounds check names the offending file.
+# Expected to fail, so the nonzero exit is swallowed; only the log is inspected.
+(cd "$d2" && "$bin" "file://$d2/index.html" --quiet -n >.log 2>&1) || true
+
+grep -Eq "overflow while copying.*htsalias\.c" "$d2/.log" || {
+    echo "FAIL: exhausted rc file did not abort through the htsalias.c bound"
+    echo "(an unbounded copy would overrun the heap here)"
+    tail -3 "$d2/.log"
+    exit 1
+}
+
+exit 0

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -25,6 +25,7 @@ TESTS = \
 	01_engine-idna.test \
 	01_engine-mime.test \
 	01_engine-parse.test \
+	01_engine-rcfile.test \
 	01_engine-simplify.test \
 	01_engine-strsafe.test \
 	02_manpage-regen.test \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -499,6 +499,7 @@ TESTS = \
 	01_engine-idna.test \
 	01_engine-mime.test \
 	01_engine-parse.test \
+	01_engine-rcfile.test \
 	01_engine-simplify.test \
 	01_engine-strsafe.test \
 	02_manpage-regen.test \


### PR DESCRIPTION
htsalias.c keeps its own copy of htscoremain.c's `cmdl_ins` macro, which `optinclude_file` uses to splice config-file (`.httrackrc`) alias expansions into argv. The copy still wrote each alias-expanded token into the argv block with an unbounded `strcpybuff` on a bare `char*`. Those were the last two pointer-destination warnings outside htsparse.c and htsserver.c. This threads the block capacity (`x_argvblk_size`) through `optinclude_file` and bounds the insert with `strlcpybuff` + `cmdl_room`, the same guard batch 13 (#370) applied to the original macro in htscoremain.c. When the write offset outruns the block, `cmdl_room` returns 0 instead of wrapping the size_t subtraction, so a config or doit.log expansion that exhausts the +32768 slack aborts through the bounds check rather than overrunning the heap.

`optinclude_file` is internal (`HTS_INTERNAL_BYTECODE`, hidden under `-fvisibility=hidden`), so adding the size parameter in place is not an ABI change.

The config-file alias path had no test coverage, since every existing test passes `-O`, which makes the engine skip the rc files. The new `01_engine-rcfile.test` checks both directions. A long user-agent alias has to reach `hts-cache/doit.log` intact, so the bound must not truncate a legitimate token (user-agent expands to two tokens, exercising both insertions). A pathological rc file whose expansions overflow the block has to abort through the htsalias.c bounds check rather than segfault, which is what the unbounded copy did here. Reverting the bound makes each check fail.

That leaves htsparse.c (6) and htsserver.c (5) as the last pointer-destination sites.