### PR TITLE
ci: cache pinned tool downloads (git-clang-format, shfmt)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The git-clang-format driver is pinned to an immutable release tag, so the
+      # fetched file never changes: cache it keyed on the tag. raw.githubusercontent.com
+      # 429-rate-limits the shared runner egress IPs, and re-downloading an unchanging
+      # file every run was the only thing that could (and did) hit that limit.
+      - name: Cache git-clang-format driver
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/git-clang-format/git-clang-format
+          key: git-clang-format-llvmorg-19.1.7
+
       - name: Install clang-format 19 (pinned, from apt.llvm.org)
         run: |
           set -euo pipefail
@@ -364,11 +374,14 @@ jobs:
             | sudo tee /etc/apt/sources.list.d/llvm-19.list >/dev/null
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends clang-format-19
-          # git-clang-format driver, pinned to an immutable release tag (not a
-          # moving branch) since we curl and then execute it.
-          sudo curl -fsSL -o /usr/local/bin/git-clang-format \
-            https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-19.1.7/clang/tools/clang-format/git-clang-format
-          sudo chmod 0755 /usr/local/bin/git-clang-format
+          # Cold cache only: fetch the driver, retrying through transient 429s.
+          driver="$HOME/.cache/git-clang-format/git-clang-format"
+          if [ ! -s "$driver" ]; then
+            mkdir -p "$(dirname "$driver")"
+            curl --retry 5 --retry-all-errors -fsSL -o "$driver" \
+              https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-19.1.7/clang/tools/clang-format/git-clang-format
+          fi
+          sudo install -m 0755 "$driver" /usr/local/bin/git-clang-format
           clang-format-19 --version
 
       - name: Check formatting of changed lines

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,9 @@ jobs:
     name: format (clang-format-19, changed lines)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
+    env:
+      # Single-source the tag so the cache key and the fetch URL can never drift.
+      LLVM_TAG: llvmorg-19.1.7
     steps:
       - uses: actions/checkout@v6
         with:
@@ -379,7 +382,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/git-clang-format/git-clang-format
-          key: git-clang-format-llvmorg-19.1.7
+          key: git-clang-format-${{ env.LLVM_TAG }}
 
       - name: Install clang-format 19 (pinned, from apt.llvm.org)
         run: |
@@ -394,12 +397,12 @@ jobs:
           # Cold cache only: fetch the driver, retrying through transient 429s.
           driver="$HOME/.cache/git-clang-format/git-clang-format"
           if [ ! -s "$driver" ]; then
-            echo "git-clang-format cache MISS: fetching llvmorg-19.1.7 from raw.githubusercontent.com"
+            echo "git-clang-format cache MISS: fetching ${LLVM_TAG} from raw.githubusercontent.com"
             mkdir -p "$(dirname "$driver")"
             curl --retry 5 --retry-all-errors -fsSL -o "$driver" \
-              https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-19.1.7/clang/tools/clang-format/git-clang-format
+              "https://raw.githubusercontent.com/llvm/llvm-project/${LLVM_TAG}/clang/tools/clang-format/git-clang-format"
           else
-            echo "git-clang-format cache HIT: using cached llvmorg-19.1.7"
+            echo "git-clang-format cache HIT: using cached ${LLVM_TAG}"
           fi
           sudo install -m 0755 "$driver" /usr/local/bin/git-clang-format
           clang-format-19 --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,9 +343,12 @@ jobs:
           # cache only), retrying through transient errors.
           shfmt="$HOME/.cache/shfmt/shfmt"
           if [ ! -s "$shfmt" ]; then
+            echo "shfmt cache MISS: fetching ${SHFMT_VERSION} from github.com"
             mkdir -p "$(dirname "$shfmt")"
             curl --retry 5 --retry-all-errors -fsSL -o "$shfmt" \
               "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_linux_$(dpkg --print-architecture)"
+          else
+            echo "shfmt cache HIT: using cached ${SHFMT_VERSION}"
           fi
           sudo install -m 0755 "$shfmt" /usr/local/bin/shfmt
 
@@ -391,9 +394,12 @@ jobs:
           # Cold cache only: fetch the driver, retrying through transient 429s.
           driver="$HOME/.cache/git-clang-format/git-clang-format"
           if [ ! -s "$driver" ]; then
+            echo "git-clang-format cache MISS: fetching llvmorg-19.1.7 from raw.githubusercontent.com"
             mkdir -p "$(dirname "$driver")"
             curl --retry 5 --retry-all-errors -fsSL -o "$driver" \
               https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-19.1.7/clang/tools/clang-format/git-clang-format
+          else
+            echo "git-clang-format cache HIT: using cached llvmorg-19.1.7"
           fi
           sudo install -m 0755 "$driver" /usr/local/bin/git-clang-format
           clang-format-19 --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,20 +320,34 @@ jobs:
   lint:
     name: lint (shellcheck, shfmt)
     runs-on: ubuntu-24.04
+    env:
+      SHFMT_VERSION: v3.8.0
     steps:
       - uses: actions/checkout@v6
 
+      # shfmt is a pinned release binary, so it never changes: cache it keyed on
+      # the version. Same rationale as the git-clang-format driver below -- avoid
+      # re-downloading an unchanging file from github.com on every run.
+      - name: Cache shfmt binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/shfmt/shfmt
+          key: shfmt-${{ env.SHFMT_VERSION }}-${{ runner.arch }}
+
       - name: Install linters
-        env:
-          SHFMT_VERSION: v3.8.0
         run: |
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends shellcheck
-          # shfmt is not packaged in apt; fetch a pinned release binary.
-          curl -fsSL -o /tmp/shfmt \
-            "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_linux_$(dpkg --print-architecture)"
-          sudo install -m 0755 /tmp/shfmt /usr/local/bin/shfmt
+          # shfmt is not packaged in apt; fetch a pinned release binary (cold
+          # cache only), retrying through transient errors.
+          shfmt="$HOME/.cache/shfmt/shfmt"
+          if [ ! -s "$shfmt" ]; then
+            mkdir -p "$(dirname "$shfmt")"
+            curl --retry 5 --retry-all-errors -fsSL -o "$shfmt" \
+              "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_linux_$(dpkg --print-architecture)"
+          fi
+          sudo install -m 0755 "$shfmt" /usr/local/bin/shfmt
 
       # Lint the scripts we maintain; the legacy scripts are a separate cleanup.
       - name: shellcheck


### PR DESCRIPTION
The format and lint jobs each downloaded a pinned, immutable tool binary on every run -- `git-clang-format` (tag `llvmorg-19.1.7`) from raw.githubusercontent.com, and `shfmt` (`v3.8.0`) from github.com. Neither file ever changes, yet re-fetching them was the only thing in those jobs that could hit those hosts' per-IP rate limits. On shared runner egress IPs the git-clang-format fetch did, failing the format job with `curl: (22) ... 429` (the `apt.llvm.org` install in the same step succeeded; only the step name pointed the finger the wrong way). shfmt has the identical exposure.

Both are now cached with `actions/cache` keyed on the pinned version, fetched at most once per cache lifetime, with the cold fetch retried through transient errors (`curl --retry 5 --retry-all-errors`). The apt/brew installs are left alone -- those hit robust package mirrors, a different risk class.