### PR TITLE
htsserver: bound LANG_LIST's lang_str copy by its own size

### DIFF
--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -1783,7 +1783,7 @@ static int LANG_LIST(const char *path, char *buffer, size_t buffer_size) {
   buffer[0] = '\0';
   do {
     QLANG_T(i);
-    strlcpybuff(lang_str, "LANGUAGE_NAME", buffer_size);
+    strlcpybuff(lang_str, "LANGUAGE_NAME", sizeof(lang_str));
     htslang_load(lang_str, sizeof(lang_str), path);
     if (strlen(lang_str) > 0) {
       if (buffer[0])


### PR DESCRIPTION
`LANG_LIST` copies the fixed literal `"LANGUAGE_NAME"` into a local `lang_str[1024]` but passed `buffer_size` — the capacity of the *output* `buffer` parameter, not `lang_str` — as the `strlcpybuff` bound. It's harmless today because the source is a 13-byte constant, but it's the wrong size argument for that destination and would turn into an out-of-bounds write the moment the source string grew. Bound it by `sizeof(lang_str)`, matching the `htslang_load(lang_str, sizeof(lang_str), ...)` call right below it.

Pre-existing latent mismatch surfaced during the #374 review.