### PR TITLE
Gate htssafe pointer-dest regressions at build time

### DIFF
--- a/configure
+++ b/configure
@@ -15541,6 +15541,91 @@ else case e in #(
 esac
 fi
 
+# Make htssafe.h's pointer-dest 'warning' attribute a hard error in our build
+# (migration is at zero; a new char* dest is a regression). gcc/clang each take
+# only their own spelling; downstream keeps the plain warning, not a build break.
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -Werror=attribute-warning" >&5
+printf %s "checking whether C compiler accepts -Werror=attribute-warning... " >&6; }
+if test ${ax_cv_check_cflags___Werror_attribute_warning+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e)
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS  -Werror=attribute-warning"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ax_cv_check_cflags___Werror_attribute_warning=yes
+else case e in #(
+  e) ax_cv_check_cflags___Werror_attribute_warning=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___Werror_attribute_warning" >&5
+printf "%s\n" "$ax_cv_check_cflags___Werror_attribute_warning" >&6; }
+if test "x$ax_cv_check_cflags___Werror_attribute_warning" = xyes
+then :
+  DEFAULT_CFLAGS="$DEFAULT_CFLAGS -Werror=attribute-warning"
+else case e in #(
+  e) : ;;
+esac
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -Werror=user-defined-warnings" >&5
+printf %s "checking whether C compiler accepts -Werror=user-defined-warnings... " >&6; }
+if test ${ax_cv_check_cflags___Werror_user_defined_warnings+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e)
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS  -Werror=user-defined-warnings"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ax_cv_check_cflags___Werror_user_defined_warnings=yes
+else case e in #(
+  e) ax_cv_check_cflags___Werror_user_defined_warnings=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___Werror_user_defined_warnings" >&5
+printf "%s\n" "$ax_cv_check_cflags___Werror_user_defined_warnings" >&6; }
+if test "x$ax_cv_check_cflags___Werror_user_defined_warnings" = xyes
+then :
+  DEFAULT_CFLAGS="$DEFAULT_CFLAGS -Werror=user-defined-warnings"
+else case e in #(
+  e) : ;;
+esac
+fi
+
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -fstrict-aliasing -Wstrict-aliasing" >&5
 printf %s "checking whether C compiler accepts -fstrict-aliasing -Wstrict-aliasing... " >&6; }
 if test ${ax_cv_check_cflags___fstrict_aliasing__Wstrict_aliasing+y}

--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,11 @@ AX_CHECK_COMPILE_FLAG([-Wformat-nonliteral], [DEFAULT_CFLAGS="$DEFAULT_CFLAGS -W
 AX_CHECK_COMPILE_FLAG([-Wmissing-parameter-type], [DEFAULT_CFLAGS="$DEFAULT_CFLAGS -Wmissing-parameter-type"])
 AX_CHECK_COMPILE_FLAG([-Wold-style-definition], [DEFAULT_CFLAGS="$DEFAULT_CFLAGS -Wold-style-definition"])
 AX_CHECK_COMPILE_FLAG([-Wignored-qualifiers], [DEFAULT_CFLAGS="$DEFAULT_CFLAGS -Wignored-qualifiers"])
+# Make htssafe.h's pointer-dest 'warning' attribute a hard error in our build
+# (migration is at zero; a new char* dest is a regression). gcc/clang each take
+# only their own spelling; downstream keeps the plain warning, not a build break.
+AX_CHECK_COMPILE_FLAG([-Werror=attribute-warning], [DEFAULT_CFLAGS="$DEFAULT_CFLAGS -Werror=attribute-warning"])
+AX_CHECK_COMPILE_FLAG([-Werror=user-defined-warnings], [DEFAULT_CFLAGS="$DEFAULT_CFLAGS -Werror=user-defined-warnings"])
 AX_CHECK_COMPILE_FLAG([-fstrict-aliasing -Wstrict-aliasing], [DEFAULT_CFLAGS="$DEFAULT_CFLAGS -fstrict-aliasing -Wstrict-aliasing"])
 AX_CHECK_COMPILE_FLAG([-fstack-protector], [DEFAULT_CFLAGS="$DEFAULT_CFLAGS -fstack-protector"])
 AX_CHECK_COMPILE_FLAG([-fstack-clash-protection], [DEFAULT_CFLAGS="$DEFAULT_CFLAGS -fstack-clash-protection"])


### PR DESCRIPTION
This is the endgame of the htssafe pointer-destination migration. `strcpybuff`/`strcatbuff`/`strncatbuff` silently fall back to an unchecked `strcpy`/`strcat`/`strncat` when the destination is a bare `char*` (capacity unknown), and the fallback stubs in `htssafe.h` already carry a function `warning` attribute marking every such call. With all 241 pointer-dest sites converted (PRs #330–#374), any new `char*` destination is now a regression.

This promotes that warning to a hard error in our own build via `-Werror=attribute-warning` (gcc) / `-Werror=user-defined-warnings` (clang), probed with `AX_CHECK_COMPILE_FLAG` so each compiler only picks up the spelling it accepts.

I scoped it to the build flag rather than flipping the attribute to `error` in the header on purpose: `htssafe.h` is installed (`DevIncludes_DATA`), so an unconditional `error` would break the build for any downstream consumer that passes a `char*` dest. Keeping the attribute a `warning` and promoting it in our CFLAGS gives us the regression gate without changing the contract for anyone who includes the header.

Verified the tree still builds clean under the flag and `make check` passes (15 PASS, 7 SKIP). Teeth-checked the gate both ways on a throwaway snippet: a `char*` dest is a hard error with the flag and a plain warning without it.

configure.ac is the toolchain, so the regenerated `configure` is committed alongside.