### PR TITLE
tests: run the test scripts under strict mode (set -euo pipefail)

### DIFF
--- a/tests/00_runnable.test
+++ b/tests/00_runnable.test
@@ -1,5 +1,7 @@
 #!/bin/bash
 #
 
+set -euo pipefail
+
 # check that httrack starts
 httrack --version >/dev/null

--- a/tests/01_engine-charset.test
+++ b/tests/01_engine-charset.test
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 
+set -euo pipefail
+
 # charset -> UTF-8 conversion (hts_convertStringToUTF8).
 # -#3 <charset> <string> prints the string re-decoded from <charset> as UTF-8.
 conv() {

--- a/tests/01_engine-cmdline.test
+++ b/tests/01_engine-cmdline.test
@@ -8,7 +8,7 @@
 # --headers) forms, and an over-cap value is refused cleanly rather than
 # overrunning a fixed scratch buffer.
 
-set -u
+set -euo pipefail
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_cmdline.XXXXXX") || exit 1
 trap 'rm -rf "$tmp"' EXIT HUP INT QUIT PIPE TERM
@@ -26,8 +26,8 @@ run() {
     shift
     rm -rf "$out"
     mkdir -p "$out"
-    httrack "file://$tmp/index.html" -O "$out" --quiet -n "$@" >"$out/.log" 2>&1
-    RC=$?
+    RC=0
+    httrack "file://$tmp/index.html" -O "$out" --quiet -n "$@" >"$out/.log" 2>&1 || RC=$?
 }
 
 # crawl using exactly the given args as the only URL(s), no implicit primary URL;
@@ -37,8 +37,8 @@ run_only() {
     shift
     rm -rf "$out"
     mkdir -p "$out"
-    httrack -O "$out" --quiet -n "$@" >"$out/.log" 2>&1
-    RC=$?
+    RC=0
+    httrack -O "$out" --quiet -n "$@" >"$out/.log" 2>&1 || RC=$?
 }
 
 # assert the value was accepted: clean exit and the fixture was mirrored

--- a/tests/01_engine-entities.test
+++ b/tests/01_engine-entities.test
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 
+set -euo pipefail
+
 # HTML entity unescaping (hts_unescapeEntitiesWithCharset).
 # -#6 <string> prints the string with entities decoded (UTF-8 output).
 ent() {

--- a/tests/01_engine-filter.test
+++ b/tests/01_engine-filter.test
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 
+set -euo pipefail
+
 # wildcard filter engine (strjoker), the core of +/- include/exclude rules.
 # -#0 <filter> <string> prints "<string> does match <filter>" or "... does NOT match ...".
 

--- a/tests/01_engine-hashtable.test
+++ b/tests/01_engine-hashtable.test
@@ -1,5 +1,7 @@
 #!/bin/bash
 #
 
+set -euo pipefail
+
 # httrack internal hashtable autotest on 100K keys
 httrack -#7 100000

--- a/tests/01_engine-idna.test
+++ b/tests/01_engine-idna.test
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 
+set -euo pipefail
+
 # IDNA / punycode encode (-#4) and decode (-#5). This code has a CVE history,
 # so the edge cases below cover passthrough, round-trips, and malformed input.
 

--- a/tests/01_engine-mime.test
+++ b/tests/01_engine-mime.test
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 
+set -euo pipefail
+
 # MIME type guessing from extension (get_httptype / give_mimext).
 # -#2 <path> prints "<path> is '<mime>'" then "and its local type is '.<ext>'".
 

--- a/tests/01_engine-parse.test
+++ b/tests/01_engine-parse.test
@@ -4,7 +4,7 @@
 # Offline HTML parser tests: each section crawls a file:// fixture (no network)
 # and checks which assets the parser captured and how it rewrote the links.
 
-set -u
+set -euo pipefail
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_parse.XXXXXX") || exit 1
 trap 'rm -rf "$tmp"' EXIT HUP INT QUIT PIPE TERM
@@ -19,7 +19,9 @@ crawl() {
     local html="$1" out="$2"
     rm -rf "$out"
     mkdir -p "$out"
-    httrack "file://$html" -O "$out" --quiet --near -n >"$out/.log" 2>&1
+    # the crawl's own exit status is irrelevant here; the assertions below check
+    # the mirrored files, so don't let set -e trip on a non-zero httrack exit
+    httrack "file://$html" -O "$out" --quiet --near -n >"$out/.log" 2>&1 || true
 }
 
 # assert a file with the given basename was saved somewhere under <out>

--- a/tests/01_engine-simplify.test
+++ b/tests/01_engine-simplify.test
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 
+set -euo pipefail
+
 # path simplify engine (fil_simplifie): collapses ./ and ../ segments.
 simp() {
 	test "$(httrack -O /dev/null -#1 "$1")" == "simplified=$2" || exit 1

--- a/tests/01_engine-strsafe.test
+++ b/tests/01_engine-strsafe.test
@@ -1,13 +1,16 @@
 #!/bin/bash
 #
 
+set -euo pipefail
+
 # htssafe.h bounded string operations (driven by 'httrack -#8').
 
 # Success path: every bounded op (strcpybuff/strcatbuff/strncatbuff/strlcpybuff)
 # must behave correctly. Like the other -# debug modes, a trailing token is
 # required (a bare '-#8' falls through to the usage screen).
-out=$(httrack -#8 run)
-test $? -eq 0 || exit 1
+rc=0
+out=$(httrack -#8 run) || rc=$?
+test "$rc" -eq 0 || exit 1
 test "$out" == "strsafe: OK" || exit 1
 
 # Overflow path: an over-capacity write into a sized buffer must be caught by
@@ -15,7 +18,8 @@ test "$out" == "strsafe: OK" || exit 1
 # Assert the htssafe abort signature specifically, so the test cannot pass for
 # an unrelated reason (e.g. the -#8 mode being gone and falling through to the
 # usage screen, which also exits non-zero).
-err=$(httrack -#8 overflow "this string is far too long for the buffer" 2>&1)
+# the bounded macro aborts (non-zero exit), so don't let set -e trip on it
+err=$(httrack -#8 overflow "this string is far too long for the buffer" 2>&1) || true
 case "$err" in
 	*"strsafe: NOT aborted"*) echo "over-capacity write was NOT caught" >&2; exit 1 ;;
 	*"overflow while copying"*) ;;
@@ -26,7 +30,7 @@ esac
 # capacity (4 bytes into a 4-byte buffer), so this also pins the boundary: a
 # '<=' off-by-one in the capacity check would let it through (and print "NOT
 # aborted"). Match the specific htsbuff abort message, not just any assert.
-err=$(httrack -#8 overflow-buff "abcd" 2>&1)
+err=$(httrack -#8 overflow-buff "abcd" 2>&1) || true
 case "$err" in
 	*"strsafe: NOT aborted"*) echo "htsbuff over-capacity write was NOT caught" >&2; exit 1 ;;
 	*"htsbuff append overflow"*) ;;

--- a/tests/02_manpage-regen.test
+++ b/tests/02_manpage-regen.test
@@ -8,6 +8,9 @@
 # POSIX /bin/sh on some platforms (e.g. macOS), so avoid bashisms (such as
 # process substitution) despite the #!/bin/bash above.
 
+# pipefail is a bashism; keep to POSIX set flags ($(BASH) may be /bin/sh here).
+set -eu
+
 : "${top_srcdir:=..}"
 
 gen="$top_srcdir/man/makeman.sh"

--- a/tests/02_update-cache.test
+++ b/tests/02_update-cache.test
@@ -10,7 +10,7 @@
 #   2. change a source file, re-mirror -> the update must pick up the new content
 #      (guards the update decision that reads the cached metadata).
 
-set -eu
+set -euo pipefail
 
 site=$(mktemp -d)
 out=$(mktemp -d)
@@ -42,7 +42,7 @@ test "$(errors)" = 0 || {
     exit 1
 }
 for suffix in a.html sub/b.html; do
-    find "$out" -path "*/$suffix" | grep -q . || {
+    test -n "$(find "$out" -path "*/$suffix" -print -quit)" || {
         echo "missing $suffix after update" >&2
         exit 1
     }

--- a/tests/10_crawl-simple.test
+++ b/tests/10_crawl-simple.test
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 
+set -euo pipefail
+
 bash check-network.sh ||  ! echo "skipping online unit tests" || exit 77
 
 bash crawl-test.sh --errors 0 --files 5 httrack http://ut.httrack.com/simple/basic.html

--- a/tests/11_crawl-cookies.test
+++ b/tests/11_crawl-cookies.test
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 
+set -euo pipefail
+
 bash check-network.sh ||  ! echo "skipping online unit tests" || exit 77
 
 bash crawl-test.sh --errors 0 --files 3 \

--- a/tests/11_crawl-idna.test
+++ b/tests/11_crawl-idna.test
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 
+set -euo pipefail
+
 bash check-network.sh ||  ! echo "skipping online unit tests" || exit 77
 
 # unicode tests

--- a/tests/11_crawl-international.test
+++ b/tests/11_crawl-international.test
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 
+set -euo pipefail
+
 bash check-network.sh ||  ! echo "skipping online unit tests" || exit 77
 
 # unicode tests

--- a/tests/11_crawl-longurl.test
+++ b/tests/11_crawl-longurl.test
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 
+set -euo pipefail
+
 bash check-network.sh ||  ! echo "skipping online unit tests" || exit 77
 
 # http://code.google.com/p/httrack/issues/detail?id=42&can=1

--- a/tests/11_crawl-parsing.test
+++ b/tests/11_crawl-parsing.test
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 
+set -euo pipefail
+
 bash check-network.sh ||  ! echo "skipping online unit tests" || exit 77
 
 # http://code.google.com/p/httrack/issues/detail?id=4&can=1

--- a/tests/12_crawl_https.test
+++ b/tests/12_crawl_https.test
@@ -1,9 +1,11 @@
 #!/bin/bash
 #
 
+set -euo pipefail
+
 bash check-network.sh ||  ! echo "skipping online unit tests" || exit 77
 
-if test "$HTTPS_SUPPORT" == "no"; then
+if test "${HTTPS_SUPPORT:-}" == "no"; then
 	echo "no https support compiled, skipping"
 	exit 77
 fi


### PR DESCRIPTION
Most of the tests/*.test scripts ran with no error flags, so a command that failed partway through was silently ignored and the script limped on to a misleading verdict. This turns on strict mode across the suite and guards the few spots that legitimately expect a non-zero exit.

The careful bits:

- The htssafe overflow probes (`-#8`) deliberately abort, and the strsafe/cmdline crawls capture an exit code to assert on; those run with `|| true` / `|| rc=$?` so set -e does not kill the script before the assertion. The parser fixture crawl ignores httrack's own exit (it inspects the mirrored files), so it keeps `|| true`.
- `02_update-cache` swapped `find ... | grep -q .` for a `-print -quit` command substitution. Under pipefail, `grep -q` can close the pipe on the first match and leave `find` killed by SIGPIPE, which would spuriously fail the check even though the file exists.
- `12_crawl_https` guards `$HTTPS_SUPPORT` with `${...:-}` for set -u.
- `02_manpage-regen` and `01_engine-cache` stay on `set -eu` (no pipefail): both are run via `$(BASH)`, which can be a plain POSIX /bin/sh where `set -o pipefail` does not exist.

The engine/crawl files keep their existing tab indentation (CI runs shfmt only on the three maintained scripts, not tests/*.test), so this stays diff-scoped. shellcheck clean; `make check` gives 15 PASS, 7 SKIP offline.