### PR TITLE
Fix mtime_local sub-second precision loss on POSIX

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -2580,8 +2580,8 @@ HTSEXT_API TStamp mtime_local(void) {
     assert(! "gettimeofday");
   }
 
-  return (TStamp) (((TStamp) tv.tv_sec * (TStamp) 1000)
-                   + ((TStamp) tv.tv_usec / (TStamp) 1000000));
+  return (TStamp) (((TStamp) tv.tv_sec * (TStamp) 1000) +
+                   ((TStamp) tv.tv_usec / (TStamp) 1000));
 #else
   struct timeb B;
   ftime(&B);


### PR DESCRIPTION
mtime_local() returns milliseconds since the epoch, but the POSIX branch divided tv_usec (microseconds) by 1000000 instead of 1000, dropping the whole millisecond term. The clock only ticked at whole-second boundaries, so every sub-second interval the callers measure read as zero: request and connect timing, and the transfer-rate smoothing in the engine. The Windows ftime() branch was always correct, which is why this stayed hidden.

The fix is the one-token divisor correction. Verified by reverting it on a local build and watching the engine's rate computation collapse to second granularity.

Surfaced while reading the implementations for the API documentation pass (#382), which flagged it as a likely real bug.