### PR TITLE
Drop dead and duplicate function declarations

### DIFF
--- a/src/htscore.h
+++ b/src/htscore.h
@@ -369,10 +369,6 @@ char *readfile_or(const char *fil, const char *defaultdata);
 void check_rate(TStamp stat_timestart, int maxrate);
 #endif
 
-// links
-int liens_record(char *adr, char *fil, char *save, char *former_adr,
-                 char *former_fil, char *codebase);
-
 /* Backing (download-slot) scheduler. Operate on the back[] ring (struct_back).
    Not thread-safe; call from the single crawl loop. */
 

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -254,15 +254,6 @@ HTSEXT_API int htswrap_add(httrackp * opt, const char *name, void *fct);
    or 0 if none or unknown. */
 HTSEXT_API uintptr_t htswrap_read(httrackp * opt, const char *name);
 
-/** @warning No implementation is linked into the library; calling this fails to
-    link. For per-callback user data use the CHAIN_FUNCTION() ARGUMENT and
-    CALLBACKARG_USERDEF() instead. */
-HTSEXT_API int htswrap_set_userdef(httrackp * opt, void *userdef);
-
-/** @warning No implementation is linked into the library; calling this fails to
-    link. Read per-callback user data with CALLBACKARG_USERDEF() instead. */
-HTSEXT_API void *htswrap_get_userdef(httrackp * opt);
-
 /* Internal library allocators, if a different libc is being used by the client */
 /** strdup() through the library allocator. Returns a heap copy freed with
     hts_free(), or NULL on failure. */
@@ -583,12 +574,6 @@ HTSEXT_API char *unescape_http(char *const catbuff, const size_t size, const cha
    1 also decodes high (>= 128) bytes; @p no_high & 2 also decodes an escaped
     space. Returns @p catbuff. */
 HTSEXT_API char *unescape_http_unharm(char *const catbuff, const size_t size, const char *s, const int no_high);
-
-/** @warning No implementation is linked into the library; calling this fails to
-    link. */
-HTSEXT_API char *antislash_unescaped(char *catbuff, const char *s);
-
-HTSEXT_API void escape_remove_control(char *s);
 
 /** Determine the MIME type of local file name @p fil into @p s (capacity
     @p ssize): user --assume rules, then ".html", then the built-in extension


### PR DESCRIPTION
Five declarations in the public and internal headers that no longer (or never did) point at real code. htswrap_set_userdef, htswrap_get_userdef, antislash_unescaped and the internal liens_record each name a function with no definition anywhere in the tree, so they were never exported (nm -D confirms they are absent from libhttrack.so) and any caller would simply fail to link. The userdef pair is doubly vestigial: per-callback user data has long gone through the CHAIN_FUNCTION ARGUMENT and CALLBACKARG_USERDEF. escape_remove_control was also declared twice in httrack-library.h, once with a doc comment and once bare; the documented one stays.

This is a header-only change. The exported symbol set is byte-for-byte identical before and after (diffed nm -D output), so it is not an ABI break and carries no soname bump.

Last of the low-risk findings from the #382 API documentation pass; the remaining ones (hts_errmsg export, hts_get_stats thread-safety) are genuine ABI decisions and will come separately.