### PR TITLE
Give the option fields named enum types and flag macros

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -2779,7 +2779,7 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                     if (strcmp(back[i].url_fil, "/robots.txt")) {
                       if (back[i].r.statuscode == HTTP_OK) {    // 'OK'
                         if (!is_hypertext_mime(opt, back[i].r.contenttype, back[i].url_fil)) {  // pas HTML
-                          if (opt->getmode & 2) {       // on peut ecrire des non html
+                          if (opt->getmode & HTS_GETMODE_NONHTML) {
                             int fcheck = 0;
                             int last_errno = 0;
 
@@ -2852,7 +2852,7 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                                 }
                               }
                             }
-                          } else {      // on coupe tout!
+                          } else { // on coupe tout!
                             hts_log_print(opt, LOG_DEBUG,
                                           "File cancelled (non HTML): %s%s",
                                           back[i].url_adr, back[i].url_fil);
@@ -3661,7 +3661,7 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
 #endif
                       if (sz >= 0) {
                         if (!is_hypertext_mime(opt, back[i].r.contenttype, back[i].url_sav)) {  // pas HTML
-                          if (opt->getmode & 2) {       // on peut ecrire des non html  **sinon ben euhh sera intercepté plus loin, donc rap sur ce qui va sortir**
+                          if (opt->getmode & HTS_GETMODE_NONHTML) {
                             filenote(&opt->state.strc, back[i].url_sav, NULL);  // noter fichier comme connu
                             file_notify(opt, back[i].url_adr, back[i].url_fil,
                                         back[i].url_sav, 0, 1,

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -370,7 +370,7 @@ int cache_selftests(httrackp *opt, const char *dir) {
     StringCopy(opt->path_html, base);
     StringCopy(opt->path_html_utf8, base);
   }
-  opt->cache = 1;
+  opt->cache = HTS_CACHE_PRIORITY;
 
   /* pass 1: create everything in a single write session */
   selftest_open_for_write(&cache, opt);
@@ -547,7 +547,7 @@ static void golden_setup(httrackp *opt, const char *dir) {
   StringCopy(opt->path_log, base);
   StringCopy(opt->path_html, base);
   StringCopy(opt->path_html_utf8, base);
-  opt->cache = 1;
+  opt->cache = HTS_CACHE_PRIORITY;
 }
 
 int cache_golden_selftest(httrackp *opt, const char *dir, int regen) {

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -1835,9 +1835,10 @@ int httpmirror(char *url1, httrackp * opt) {
                       a++;      // sauter espace(s)
                     if (strnotempty(a)) {
 #ifdef IGNORE_RESTRICTIVE_ROBOTS
-                      if (strcmp(a, "/") != 0 || opt->robots >= 3)
+                      if (strcmp(a, "/") != 0 ||
+                          opt->robots >= HTS_ROBOTS_ALWAYS_STRICT)
 #endif
-                      {         /* ignoring disallow: / */
+                      { /* ignoring disallow: / */
                         if ((strlen(buff) + strlen(a) + 8) < sizeof(buff)) {
                           strcatbuff(buff, a);
                           strcatbuff(buff, "\n");
@@ -1932,10 +1933,10 @@ int httpmirror(char *url1, httrackp * opt) {
                           "Warning: store %s without scan: %s", r.contenttype,
                           savename());
           } else {
-            if ((opt->getmode & 2) != 0) {      // ok autorisé
+            if ((opt->getmode & HTS_GETMODE_NONHTML) != 0) {
               hts_log_print(opt, LOG_DEBUG, "Store %s: %s", r.contenttype,
                             savename());
-            } else {            // lien non autorisé! (ex: cgi-bin en html)
+            } else { // lien non autorisé! (ex: cgi-bin en html)
               hts_log_print(opt, LOG_DEBUG,
                             "non-html file ignored after upload at %s : %s",
                             urladr(), urlfil());
@@ -2052,7 +2053,7 @@ int httpmirror(char *url1, httrackp * opt) {
     ptr++;
 
     // faut-il sauter le(s) lien(s) suivant(s)? (fichiers images à passer après les html)
-    if (opt->getmode & 4) {     // sauver les non html après
+    if (opt->getmode & HTS_GETMODE_HTML_FIRST) {
       // sauter les fichiers selon la passe
       if (!numero_passe) {
         while((ptr < opt->lien_tot) ? (heap(ptr)->pass2) : 0)
@@ -3736,10 +3737,10 @@ HTSEXT_API int copy_htsopt(const httrackp * from, httrackp * to) {
 
   // test all: bit 8 de travel
   if (from->travel > -1) {
-    if (from->travel & 256)
-      to->travel |= 256;
+    if (from->travel & HTS_TRAVEL_TEST_ALL)
+      to->travel |= HTS_TRAVEL_TEST_ALL;
     else
-      to->travel &= 255;
+      to->travel &= HTS_TRAVEL_SCOPE_MASK;
   }
 
   return 0;

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -1431,7 +1431,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
       StringBuff(opt->path_log), "hts-in_progress.lock"))) {        // fichier lock?
       //char s[32];
 
-      opt->cache = 1;           // cache prioritaire
+      opt->cache = HTS_CACHE_PRIORITY; // cache prioritaire
       if (opt->quiet == 0) {
         if ((fexist
              (fconcat
@@ -1465,7 +1465,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
           (fconcat
            (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_html), "index.html"))) {
       //char s[32];
-      opt->cache = 2;           // cache vient après test de validité
+      opt->cache = HTS_CACHE_TEST_UPDATE;
       if (opt->quiet == 0) {
         if ((fexist
              (fconcat
@@ -1558,25 +1558,25 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
             return 0;           // déja fait normalement
             //
           case 'g':            // récupérer un (ou plusieurs) fichiers isolés
-            opt->wizard = 2;    // le wizard on peut plus s'en passer..
+            opt->wizard = HTS_WIZARD_AUTO;
             //opt->wizard=0;             // pas de wizard
-            opt->cache = 0;     // ni de cache
+            opt->cache = HTS_CACHE_NONE; // ni de cache
             opt->makeindex = 0; // ni d'index
             httrack_logmode = 1;        // erreurs à l'écran
             opt->savename_type = 1003;  // mettre dans le répertoire courant
             opt->depth = 0;     // ne pas explorer la page
             opt->accept_cookie = 0;     // pas de cookies
-            opt->robots = 0;    // pas de robots
+            opt->robots = HTS_ROBOTS_NEVER; // pas de robots
             break;
           case 'w':
-            opt->wizard = 2;    // wizard 'soft' (ne pose pas de questions)
-            opt->travel = 0;
-            opt->seeker = 1;
+            opt->wizard = HTS_WIZARD_AUTO;
+            opt->travel = HTS_TRAVEL_SAME_ADDRESS;
+            opt->seeker = HTS_SEEKER_DOWN;
             break;
           case 'W':
-            opt->wizard = 1;    // Wizard-Help (pose des questions)
-            opt->travel = 0;
-            opt->seeker = 1;
+            opt->wizard = HTS_WIZARD_ASK; // Wizard-Help (pose des questions)
+            opt->travel = HTS_TRAVEL_SAME_ADDRESS;
+            opt->seeker = HTS_SEEKER_DOWN;
             break;
           case 'r':            // n'est plus le recurse get bestial mais wizard itou!
             if (isdigit((unsigned char) *(com + 1))) {
@@ -1598,19 +1598,23 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
             // note: les tests opt->depth sont pour éviter de faire
             // un miroir du web (:-O) accidentelement ;-)
           case 'a':            /*if (opt->depth==9999) opt->depth=3; */
-            opt->travel = 0 + (opt->travel & 256);
+            opt->travel =
+                HTS_TRAVEL_SAME_ADDRESS + (opt->travel & HTS_TRAVEL_TEST_ALL);
             break;
           case 'd':            /*if (opt->depth==9999) opt->depth=3; */
-            opt->travel = 1 + (opt->travel & 256);
+            opt->travel =
+                HTS_TRAVEL_SAME_DOMAIN + (opt->travel & HTS_TRAVEL_TEST_ALL);
             break;
           case 'l':            /*if (opt->depth==9999) opt->depth=3; */
-            opt->travel = 2 + (opt->travel & 256);
+            opt->travel =
+                HTS_TRAVEL_SAME_TLD + (opt->travel & HTS_TRAVEL_TEST_ALL);
             break;
           case 'e':            /*if (opt->depth==9999) opt->depth=3; */
-            opt->travel = 7 + (opt->travel & 256);
+            opt->travel =
+                HTS_TRAVEL_EVERYWHERE + (opt->travel & HTS_TRAVEL_TEST_ALL);
             break;
           case 't':
-            opt->travel |= 256;
+            opt->travel |= HTS_TRAVEL_TEST_ALL;
             break;
           case 'n':
             opt->nearlink = 1;
@@ -1620,16 +1624,16 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
             break;
             //
           case 'U':
-            opt->seeker = 2;
+            opt->seeker = HTS_SEEKER_UP;
             break;
           case 'D':
-            opt->seeker = 1;
+            opt->seeker = HTS_SEEKER_DOWN;
             break;
           case 'S':
             opt->seeker = 0;
             break;
           case 'B':
-            opt->seeker = 3;
+            opt->seeker = HTS_SEEKER_DOWN | HTS_SEEKER_UP;
             break;
             //
           case 'Y':
@@ -1659,12 +1663,12 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
             //case 'A': opt->urlmode=1; break;
             //case 'R': opt->urlmode=2; break;
           case 'K':
-            opt->urlmode = 0;
+            opt->urlmode = HTS_URLMODE_ABSOLUTE;
             if (isdigit((unsigned char) *(com + 1))) {
-              sscanf(com + 1, "%d", &opt->urlmode);
-              if (opt->urlmode == 0) {  // in fact K0 ==> K2
+              sscanf(com + 1, "%d", (int *) &opt->urlmode);
+              if (opt->urlmode == HTS_URLMODE_ABSOLUTE) { // in fact K0 ==> K2
                 // and K ==> K0
-                opt->urlmode = 2;
+                opt->urlmode = HTS_URLMODE_RELATIVE;
               }
               while(isdigit((unsigned char) *(com + 1)))
                 com++;
@@ -1831,11 +1835,11 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
             break;
           case 's':
             if (isdigit((unsigned char) *(com + 1))) {
-              sscanf(com + 1, "%d", &opt->robots);
+              sscanf(com + 1, "%d", (int *) &opt->robots);
               while(isdigit((unsigned char) *(com + 1)))
                 com++;
             } else
-              opt->robots = 1;
+              opt->robots = HTS_ROBOTS_SOMETIMES;
 #if DEBUG_ROBOTS
             printf("robots.txt mode set to %d\n", opt->robots);
 #endif
@@ -1853,11 +1857,11 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
             //
           case 'C':
             if (isdigit((unsigned char) *(com + 1))) {
-              sscanf(com + 1, "%d", &opt->cache);
+              sscanf(com + 1, "%d", (int *) &opt->cache);
               while(isdigit((unsigned char) *(com + 1)))
                 com++;
             } else
-              opt->cache = 1;
+              opt->cache = HTS_CACHE_PRIORITY;
             break;
           case 'k':
             opt->all_in_cache = 1;
@@ -2045,7 +2049,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                 // preserve: no footer, original links
               case 'p':
                 StringClear(opt->footer);
-                opt->urlmode = 4;
+                opt->urlmode = HTS_URLMODE_KEEP_ORIGINAL;
                 break;
               case 'L':        // URL list
                 if ((na + 1 >= argc) || (argv[na + 1][0] == '-')) {
@@ -3610,12 +3614,12 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
         printf("Mirror launched on %s by HTTrack Website Copier/"
                HTTRACK_VERSION "%s " HTTRACK_AFF_AUTHORS "" LF, t,
                hts_get_version_info(opt));
-        if (opt->wizard == 0) {
+        if (opt->wizard == HTS_WIZARD_NONE) {
           printf
             ("mirroring %s with %d levels, %d sockets,t=%d,s=%d,logm=%d,lnk=%d,mdg=%d\n",
              url, opt->depth, opt->maxsoc, opt->travel, opt->seeker,
              httrack_logmode, opt->urlmode, opt->getmode);
-        } else {                // the magic wizard
+        } else { // the magic wizard
           printf("mirroring %s with the wizard help..\n", url);
         }
       }

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -5434,17 +5434,17 @@ HTSEXT_API httrackp *hts_create_opt(void) {
 
   /* default settings */
 
-  opt->wizard = 2;              // wizard automatique
+  opt->wizard = HTS_WIZARD_AUTO; // wizard automatique
   opt->quiet = 0;               // questions
-  //  
-  opt->travel = 0;              // même adresse
+  //
+  opt->travel = HTS_TRAVEL_SAME_ADDRESS; // même adresse
   opt->depth = 9999;            // mirror total par défaut
   opt->extdepth = 0;            // mais pas à l'extérieur
-  opt->seeker = 1;              // down 
-  opt->urlmode = 2;             // relatif par défaut
+  opt->seeker = HTS_SEEKER_DOWN;       // down
+  opt->urlmode = HTS_URLMODE_RELATIVE; // relatif par défaut
   opt->no_type_change = 0;      // change file types
   opt->debug = LOG_NOTICE;      // small log
-  opt->getmode = 3;             // linear scan
+  opt->getmode = HTS_GETMODE_HTML | HTS_GETMODE_NONHTML;
   opt->maxsite = -1;            // taille max site (aucune)
   opt->maxfile_nonhtml = -1;    // taille max fichier non html
   opt->maxfile_html = -1;       // idem pour html
@@ -5458,7 +5458,7 @@ HTSEXT_API httrackp *hts_create_opt(void) {
   opt->makestat = 0;            // pas de fichier de stats
   opt->maketrack = 0;           // ni de tracking
   opt->timeout = 120;           // timeout par défaut (2 minutes)
-  opt->cache = 1;               // cache prioritaire
+  opt->cache = HTS_CACHE_PRIORITY; // cache prioritaire
   opt->shell = 0;               // pas de shell par defaut
   opt->proxy.active = 0;        // pas de proxy
   opt->user_agent_send = 1;     // envoyer un user-agent
@@ -5477,7 +5477,7 @@ HTSEXT_API httrackp *hts_create_opt(void) {
   opt->errpage = 1;             // copier ou générer une page d'erreur en cas d'erreur (404 etc.)
   opt->check_type = 1;          // vérifier type si inconnu (cgi,asp..) SAUF / considéré comme html
   opt->all_in_cache = 0;        // ne pas tout stocker en cache
-  opt->robots = 2;              // traiter les robots.txt
+  opt->robots = HTS_ROBOTS_ALWAYS; // traiter les robots.txt
   opt->external = 0;            // liens externes normaux
   opt->passprivacy = 0;         // mots de passe dans les fichiers
   opt->includequery = 1;        // include query-string par défaut

--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -285,6 +285,75 @@ typedef enum htsparsejava_flags {
   HTSPARSE_NO_AGGRESSIVE = 8    // don't aggressively parse .js or .java
 } htsparsejava_flags;
 
+/* Link-rewriting style for saved pages (opt->urlmode). */
+#ifndef HTS_DEF_DEFSTRUCT_hts_urlmode
+#define HTS_DEF_DEFSTRUCT_hts_urlmode
+typedef enum hts_urlmode {
+  HTS_URLMODE_ABSOLUTE = 0, /**< absolute URL (http://host/path) everywhere */
+  HTS_URLMODE_ABSOLUTE_FILE = 1, /**< legacy file: form, unused */
+  HTS_URLMODE_RELATIVE = 2,      /**< relative link (default) */
+  HTS_URLMODE_ABSOLUTE_URI = 3,  /**< absolute URI from root (/path) */
+  HTS_URLMODE_KEEP_ORIGINAL = 4, /**< keep the original link, do not rewrite */
+  HTS_URLMODE_TRANSPARENT_PROXY = 5 /**< transparent-proxy URL */
+} hts_urlmode;
+#endif
+
+/* Cache policy for updates and retries (opt->cache). */
+#ifndef HTS_DEF_DEFSTRUCT_hts_cachemode
+#define HTS_DEF_DEFSTRUCT_hts_cachemode
+typedef enum hts_cachemode {
+  HTS_CACHE_NONE = 0,       /**< no cache */
+  HTS_CACHE_PRIORITY = 1,   /**< cache takes priority over the network */
+  HTS_CACHE_TEST_UPDATE = 2 /**< check for update before reuse (default) */
+} hts_cachemode;
+#endif
+
+/* Interactive wizard level (opt->wizard). */
+#ifndef HTS_DEF_DEFSTRUCT_hts_wizard
+#define HTS_DEF_DEFSTRUCT_hts_wizard
+typedef enum hts_wizard {
+  HTS_WIZARD_NONE = 0, /**< no wizard */
+  HTS_WIZARD_ASK = 1,  /**< wizard asks questions */
+  HTS_WIZARD_AUTO = 2  /**< wizard runs without asking */
+} hts_wizard;
+#endif
+
+/* robots.txt / meta-robots obedience level (opt->robots). */
+#ifndef HTS_DEF_DEFSTRUCT_hts_robots
+#define HTS_DEF_DEFSTRUCT_hts_robots
+typedef enum hts_robots {
+  HTS_ROBOTS_NEVER = 0,        /**< ignore robots rules */
+  HTS_ROBOTS_SOMETIMES = 1,    /**< partial obedience (default) */
+  HTS_ROBOTS_ALWAYS = 2,       /**< obey robots rules */
+  HTS_ROBOTS_ALWAYS_STRICT = 3 /**< obey even strict rules */
+} hts_robots;
+#endif
+
+/* What to fetch (opt->getmode bitmask). */
+typedef enum hts_getmode {
+  HTS_GETMODE_HTML = 1 << 0,      /**< save HTML files */
+  HTS_GETMODE_NONHTML = 1 << 1,   /**< save non-HTML files */
+  HTS_GETMODE_HTML_FIRST = 1 << 2 /**< fetch HTML first, then the other files */
+} hts_getmode;
+
+/* Allowed directions in the directory tree (opt->seeker bitmask). */
+typedef enum hts_seeker {
+  HTS_SEEKER_DOWN = 1 << 0, /**< may descend into subdirectories */
+  HTS_SEEKER_UP = 1 << 1    /**< may ascend to parent directories */
+} hts_seeker;
+
+/* Link-following scope, stored in the low byte of opt->travel. */
+typedef enum hts_travel_scope {
+  HTS_TRAVEL_SAME_ADDRESS = 0, /**< stay on the same address (host) */
+  HTS_TRAVEL_SAME_DOMAIN = 1,  /**< stay on the same principal domain */
+  HTS_TRAVEL_SAME_TLD = 2,     /**< stay on the same TLD (e.g. .com) */
+  HTS_TRAVEL_EVERYWHERE = 7    /**< follow links anywhere on the web */
+} hts_travel_scope;
+
+/* Flags OR'd into opt->travel above the scope value. */
+#define HTS_TRAVEL_SCOPE_MASK 0xff   /**< mask selecting the scope value */
+#define HTS_TRAVEL_TEST_ALL (1 << 8) /**< also test forbidden URLs (-t) */
+
 #ifndef HTS_DEF_FWSTRUCT_lien_buffers
 #define HTS_DEF_FWSTRUCT_lien_buffers
 typedef struct lien_buffers lien_buffers;
@@ -308,13 +377,14 @@ typedef struct httrackp httrackp;
 struct httrackp {
   size_t size_httrackp; /**< size of this structure (version/ABI guard) */
   /* */
-  int wizard;   /**< interactive wizard level (none/full/light) */
+  hts_wizard wizard; /**< interactive wizard level (none/ask/auto) */
   int flush;    /**< fflush() log files after each write */
   int travel;   /**< link-following scope (same domain, etc.) */
   int seeker;   /**< allowed direction: go up and/or down the tree */
   int depth;    /**< maximum recursion depth (-rN) */
   int extdepth; /**< maximum recursion depth outside the start domain */
-  int urlmode;  /**< saved-link rewriting style (relative, absolute, etc.) */
+  hts_urlmode
+      urlmode; /**< saved-link rewriting style (relative, absolute, etc.) */
   int no_type_change;           // do not change file type according to MIME
   int debug;                    /**< debug logging level */
   int getmode;           /**< what to fetch (HTML, images, ...) bitmask */
@@ -335,7 +405,7 @@ struct httrackp {
   int maxrate;    /**< max transfer rate cap (bytes/s) */
   float maxconn;  /**< max connections per second */
   int waittime;   /**< scheduled start time (wall-clock seconds) */
-  int cache;      /**< cache generation mode */
+  hts_cachemode cache; /**< cache generation mode */
   // int aff_progress;     // progress bar
   int shell;         /**< driven by a shell over stdin/stdout pipes */
   t_proxy proxy;     /**< proxy configuration */
@@ -363,7 +433,7 @@ struct httrackp {
   int check_type;   /**< probe unknown-type links (cgi/asp/dir) and follow moves
                      */
   int all_in_cache; /**< keep all retrieved data in the cache */
-  int robots;       /**< robots.txt handling level */
+  hts_robots robots; /**< robots.txt handling level */
   int external;     /**< render external links as error pages */
   int passprivacy;  /**< strip passwords from external links */
   int includequery; /**< include the query string in saved names */

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -349,7 +349,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
 #endif
 
     // Now, parsing
-    if ((opt->getmode & 1) && (ptr > 0)) {      // récupérer les html sur disque       
+    if ((opt->getmode & HTS_GETMODE_HTML) && (ptr > 0)) {
       // créer le fichier html local
       HT_ADD_FOP;               // écrire peu à peu le fichier
     }
@@ -553,7 +553,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
             if (opt->depth == heap(ptr)->depth) {      // on note toujours les premiers liens
               if (!in_media) {
                 if (opt->makeindex && (ptr > 0)) {
-                  if (opt->getmode & 1) {       // autorisation d'écrire
+                  if (opt->getmode & HTS_GETMODE_HTML) {
                     p = strfield(html, "title");
                     if (p) {
                       if (*(html - 1) == '/')
@@ -704,7 +704,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
             }
           }
 
-          if (opt->getmode & 1) {       // sauver html
+          if (opt->getmode & HTS_GETMODE_HTML) { // sauver html
             p = 0;
             switch (emited_footer) {
             case 0:
@@ -740,7 +740,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
 
               if (strchr(r->adr, '\r'))
                 eol = "\r\n";
-              if (StringNotEmpty(opt->footer) || opt->urlmode != 4) {   /* != preserve */
+              if (StringNotEmpty(opt->footer) ||
+                  opt->urlmode != HTS_URLMODE_KEEP_ORIGINAL) {
                 if (StringNotEmpty(opt->footer)) {
                   char BIGSTK tempo[1024 + HTS_URLMAXSIZE * 2];
                   char gmttime[256];
@@ -1746,7 +1747,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
 
             // écrire codebase avant, flusher avant code
             if ((p_type == -1) || (p_type == -2)) {
-              if ((opt->getmode & 1) && (ptr > 0)) {
+              if ((opt->getmode & HTS_GETMODE_HTML) && (ptr > 0)) {
                 HT_add_adr;     // refresh
               }
               lastsaved = html;  // dernier écrit+1
@@ -1837,7 +1838,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
 
             // ne pas flusher après code si on doit écrire le codebase avant!
             if ((p_type != -1) && (p_type != 2) && (p_type != -2)) {
-              if ((opt->getmode & 1) && (ptr > 0)) {
+              if ((opt->getmode & HTS_GETMODE_HTML) && (ptr > 0)) {
                 HT_add_adr;     // refresh
               }
               lastsaved = html;  // dernier écrit+1
@@ -1914,7 +1915,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                 if (*html != '#') {      // Not empty+unique #
                   if (eadr - html == 1) {    // 1=link empty with delim (end_adr-start_adr)
                     if (quote) {
-                      if ((opt->getmode & 1) && (ptr > 0)) {
+                      if ((opt->getmode & HTS_GETMODE_HTML) && (ptr > 0)) {
                         HT_ADD("#");    // We add this for a <href="">
                       }
                     }
@@ -2569,7 +2570,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                         if ((p_type == 2) || (p_type == -2)) {  // base href ou codebase, pas un lien
                           hts_log_print(opt, LOG_DEBUG, "Code/Codebase: %s%s",
                                         afs.af.adr, afs.af.fil);
-                        } else if ((opt->getmode & 4) == 0) {
+                        } else if ((opt->getmode & HTS_GETMODE_HTML_FIRST) ==
+                                   0) {
                           hts_log_print(opt, LOG_DEBUG, "Record: %s%s -> %s",
                                         afs.af.adr, afs.af.fil, afs.save);
                         } else {
@@ -2592,8 +2594,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                       lastsaved = eadr - 1 + 1; // sauter "
                     }
                     /* */
-                    else if (opt->urlmode == 0) {       // URL absolue dans tous les cas
-                      if ((opt->getmode & 1) && (ptr > 0)) {    // ecrire les html
+                    else if (opt->urlmode == HTS_URLMODE_ABSOLUTE) {
+                      if ((opt->getmode & HTS_GETMODE_HTML) && (ptr > 0)) {
                         if (!link_has_authority(afs.af.adr)) {
                           HT_ADD("http://");
                         } else {
@@ -2620,12 +2622,14 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                       }
                       lastsaved = eadr - 1;     // dernier écrit+1 (enfin euh apres on fait un ++ alors hein)
                       /* */
-                    } else if (opt->urlmode == 4) {     // ne rien faire!
+                    } else if (opt->urlmode == HTS_URLMODE_KEEP_ORIGINAL) {
                       /* */
                       /* leave the link 'as is' */
                       /* Sinon, dépend de interne/externe */
-                    } else if (forbidden_url == 1) {    // le lien ne sera pas chargé, référence externe!
-                      if ((opt->getmode & 1) && (ptr > 0)) {
+                    } else if (forbidden_url ==
+                               1) { // le lien ne sera pas chargé, référence
+                                    // externe!
+                      if ((opt->getmode & HTS_GETMODE_HTML) && (ptr > 0)) {
                         if (p_type != -1) {     // pas que le nom de fichier (pas classe java)
                           if (!opt->external) {
                             if (!link_has_authority(afs.af.adr)) {
@@ -2674,7 +2678,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                         '/') ? 1 : (ishtml(opt, afs.af.fil)))) {
                             case 1:
                             case -2:   // html ou répertoire
-                              if (opt->getmode & 1) {   // sauver html
+                              if (opt->getmode & HTS_GETMODE_HTML) {
                                 patch_it = 1;   // redirect
                                 add_url = 1;    // avec link?
                                 cat_name = "external.html";
@@ -2847,7 +2851,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                             }
 
                             // érire codebase="chemin"
-                            if ((opt->getmode & 1) && (ptr > 0)) {
+                            if ((opt->getmode & HTS_GETMODE_HTML) &&
+                                (ptr > 0)) {
                               char BIGSTK tempo4[HTS_URLMAXSIZE * 2];
 
                               tempo4[0] = '\0';
@@ -2875,9 +2880,11 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                       lastsaved = eadr - 1;
                     }
                     /*
-                       else if (opt->urlmode==1) {    // ABSOLU, c'est le cas le moins courant
+                       else if (opt->urlmode==1) {    // ABSOLU, c'est le cas le
+                       moins courant
                        //  NE FONCTIONNE PAS!!  (et est inutile)
-                       if ((opt->getmode & 1) && (ptr>0)) {    // ecrire les html
+                       if ((opt->getmode & 1) && (ptr>0)) {    // ecrire les
+                       html
                        // écrire le lien modifié, absolu
                        HT_ADD("file:");
                        if (*save=='/')
@@ -2885,7 +2892,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                        else
                        HT_ADD(save)
                        }
-                       lastsaved=eadr-1;    // dernier écrit+1 (enfin euh apres on fait un ++ alors hein)
+                       lastsaved=eadr-1;    // dernier écrit+1 (enfin euh apres
+                       on fait un ++ alors hein)
                        }
                      */
                     else if (opt->mimehtml) {
@@ -2895,18 +2903,18 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                       make_content_id(afs.af.adr, afs.af.fil, cid, sizeof(cid));
                       HT_ADD_HTMLESCAPED(cid);
                       lastsaved = eadr - 1;     // dernier écrit+1 (enfin euh apres on fait un ++ alors hein)
-                    } else if (opt->urlmode == 3) {     // URI absolue /
-                      if ((opt->getmode & 1) && (ptr > 0)) {    // ecrire les html
+                    } else if (opt->urlmode == HTS_URLMODE_ABSOLUTE_URI) {
+                      if ((opt->getmode & HTS_GETMODE_HTML) && (ptr > 0)) {
                         HT_ADD_HTMLESCAPED(afs.af.fil);
                       }
                       lastsaved = eadr - 1;     // dernier écrit+1 (enfin euh apres on fait un ++ alors hein)
-                    } else if (opt->urlmode == 5) {     // transparent proxy URL
+                    } else if (opt->urlmode == HTS_URLMODE_TRANSPARENT_PROXY) {
                       char BIGSTK tempo[HTS_URLMAXSIZE * 2];
                       const char *uri;
                       int i;
                       char *pos;
 
-                      if ((opt->getmode & 1) && (ptr > 0)) {    // ecrire les html
+                      if ((opt->getmode & HTS_GETMODE_HTML) && (ptr > 0)) {
                         if (!link_has_authority(afs.af.adr)) {
                           HT_ADD("http://");
                         } else {
@@ -2947,7 +2955,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                         HT_ADD_HTMLESCAPED(tempo);
                       }
                       lastsaved = eadr - 1;     // dernier écrit+1 (enfin euh apres on fait un ++ alors hein)
-                    } else if (opt->urlmode == 2) {     // RELATIF
+                    } else if (opt->urlmode == HTS_URLMODE_RELATIVE) {
                       char BIGSTK tempo[HTS_URLMAXSIZE * 2];
 
                       tempo[0] = '\0';
@@ -3009,7 +3017,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                             }
 
                             // érire codebase="chemin"
-                            if ((opt->getmode & 1) && (ptr > 0)) {
+                            if ((opt->getmode & HTS_GETMODE_HTML) &&
+                                (ptr > 0)) {
                               char BIGSTK tempo4[HTS_URLMAXSIZE * 2];
 
                               tempo4[0] = '\0';
@@ -3027,7 +3036,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                           //lastsaved=adr;    // dernier écrit+1
                         }
 
-                        if ((opt->getmode & 1) && (ptr > 0)) {
+                        if ((opt->getmode & HTS_GETMODE_HTML) && (ptr > 0)) {
                           // convert to local codepage - NOT, already converted into %NN, and passed to the remote server so we do not have anything to do
                           //if (str->page_charset_ != NULL && *str->page_charset_ != '\0') {
                           //  char *const local_save = hts_convertStringFromUTF8(tempo, strlen(tempo), str->page_charset_);
@@ -3061,7 +3070,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                       "Error building relative link %s and %s",
                                       afs.save, relativesavename());
                       }
-                    }           // sinon le lien sera écrit normalement
+                    } // sinon le lien sera écrit normalement
 
 #if 0
                     if (fexist(save)) { // le fichier existe..
@@ -3089,7 +3098,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                       opt->maxlink);
                         hts_log_print(opt, LOG_INFO,
                                       "To avoid that: use #L option for more links (example: -#L1000000)");
-                        if ((opt->getmode & 1) && (ptr > 0)) {
+                        if ((opt->getmode & HTS_GETMODE_HTML) && (ptr > 0)) {
                           if (fp) {
                             fclose(fp);
                             fp = NULL;
@@ -3101,9 +3110,9 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                         int pass_fix, dejafait = 0;
 
                         // Calculer la priorité de ce lien
-                        if ((opt->getmode & 4) == 0) {  // traiter html après
+                        if ((opt->getmode & HTS_GETMODE_HTML_FIRST) == 0) {
                           pass_fix = 0;
-                        } else {        // vérifier que ce n'est pas un !html
+                        } else { // vérifier que ce n'est pas un !html
                           if (!ishtml(opt, afs.af.fil))
                             pass_fix = 1;       // priorité inférieure (traiter après)
                           else
@@ -3167,7 +3176,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                     if (checkrobots(_ROBOTS, afs.af.adr, "") == -1) {  // robots.txt ?
                                       // enregistrer robots.txt (MACRO)
                                       if (!hts_record_link(opt, afs.af.adr, "/robots.txt", "", "", "", NULL)) {
-                                        if ((opt->getmode & 1) && (ptr > 0)) {
+                                        if ((opt->getmode & HTS_GETMODE_HTML) &&
+                                            (ptr > 0)) {
                                           if (fp) {
                                             fclose(fp);
                                             fp = NULL;
@@ -3206,7 +3216,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                           // enregistrer
                           if (!hts_record_link(opt, afs.af.adr, afs.af.fil, afs.save, 
                                                former.adr, former.fil, codebase)) {
-                            if ((opt->getmode & 1) && (ptr > 0)) {
+                            if ((opt->getmode & HTS_GETMODE_HTML) &&
+                                (ptr > 0)) {
                               if (fp) {
                                 fclose(fp);
                                 fp = NULL;
@@ -3351,7 +3362,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
         }
         // ----------
         // écrire peu à peu
-        if ((opt->getmode & 1) && (ptr > 0))
+        if ((opt->getmode & HTS_GETMODE_HTML) && (ptr > 0))
           HT_add_adr;
         lastsaved = html;        // dernier écrit+1
         // ----------
@@ -3411,7 +3422,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
       opt->state._hts_in_html_parsing = 0;      // flag
       opt->state._hts_cancel = 0;       // pas de cancel
 
-      if ((opt->getmode & 1) && (ptr > 0)) {
+      if ((opt->getmode & HTS_GETMODE_HTML) && (ptr > 0)) {
         {
           char *cAddr = TypedArrayElts(output_buffer);
           int cSize = (int) TypedArraySize(output_buffer);
@@ -3443,7 +3454,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
       //
     }                           // if !error
 
-    if (opt->getmode & 1) {
+    if (opt->getmode & HTS_GETMODE_HTML) {
       if (fp) {
         fclose(fp);
         fp = NULL;

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -178,7 +178,7 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
   // -------------------- PHASE 1 --------------------
 
   /* Doit-on traiter les non html? */
-  if ((opt->getmode & 2) == 0) {        // non on ne doit pas
+  if ((opt->getmode & HTS_GETMODE_NONHTML) == 0) { // non on ne doit pas
     if (!ishtml(opt, fil)) {    // non il ne faut pas
       //adr[0]='\0';    // ne pas traiter ce lien, pas traiter
       forbidden_url = 1;        // interdire récupération du lien
@@ -266,11 +266,11 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
               test2 =
                 (strchr(tempo2 + ((*tempo2 == '/') ? 1 : 0), '/') != NULL);
             if ((test1) && (test2)) {   // on ne peut que descendre
-              if ((opt->seeker & 1) == 0) {     // interdiction de descendre
+              if ((opt->seeker & HTS_SEEKER_DOWN) == 0) {
                 forbidden_url = 1;
                 hts_log_print(opt, LOG_DEBUG, "lower link canceled: %s%s", adr,
                               fil);
-              } else {          // autorisé à priori - NEW
+              } else {                         // autorisé à priori - NEW
                 if (!heap(ptr)->link_import) { // ne résulte pas d'un 'moved'
                   forbidden_url = 0;
                   hts_log_print(opt, LOG_DEBUG, "lower link authorized: %s%s",
@@ -278,7 +278,7 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
                 }
               }
             } else if ((test1) || (test2)) {    // on peut descendre pour accéder au lien
-              if ((opt->seeker & 1) != 0) {     // on peut descendre - NEW
+              if ((opt->seeker & HTS_SEEKER_DOWN) != 0) {
                 if (!heap(ptr)->link_import) { // ne résulte pas d'un 'moved'
                   forbidden_url = 0;
                   hts_log_print(opt, LOG_DEBUG, "lower link authorized: %s%s",
@@ -290,11 +290,11 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
 
           // up
           if ((!strncmp(tempo, "../", 3)) && (!strncmp(tempo2, "../", 3))) {    // impossible sans monter
-            if ((opt->seeker & 2) == 0) {       // interdiction de monter
+            if ((opt->seeker & HTS_SEEKER_UP) == 0) {
               forbidden_url = 1;
               hts_log_print(opt, LOG_DEBUG, "upper link canceled: %s%s", adr,
                             fil);
-            } else {            // autorisé à monter - NEW
+            } else {                           // autorisé à monter - NEW
               if (!heap(ptr)->link_import) {   // ne résulte pas d'un 'moved'
                 forbidden_url = 0;
                 hts_log_print(opt, LOG_DEBUG, "upper link authorized: %s%s",
@@ -302,13 +302,13 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
               }
             }
           } else if ((!strncmp(tempo, "../", 3)) || (!strncmp(tempo2, "../", 3))) {     // Possible en montant
-            if ((opt->seeker & 2) != 0) {       // autorisé à monter - NEW
+            if ((opt->seeker & HTS_SEEKER_UP) != 0) {
               if (!heap(ptr)->link_import) {   // ne résulte pas d'un 'moved'
                 forbidden_url = 0;
                 hts_log_print(opt, LOG_DEBUG, "upper link authorized: %s%s",
                               adr, fil);
               }
-            }                   // sinon autorisé en descente
+            } // sinon autorisé en descente
           }
 
         } else {
@@ -345,83 +345,81 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
 
     //if (!opt->wizard) {    // mode non wizard
     // doit-on traiter ce lien?.. vérifier droits de sortie
-    switch ((opt->travel & 255)) {
-    case 0:
+    switch ((opt->travel & HTS_TRAVEL_SCOPE_MASK)) {
+    case HTS_TRAVEL_SAME_ADDRESS:
       if (!opt->wizard)         // mode non wizard
         forbidden_url = 1;
       break;                    // interdicton de sortir au dela de l'adresse
-    case 1:{                   // sortie sur le même dom.xxx
-        size_t i = strlen(adr) - 1;
-        size_t j = strlen(urladr()) - 1;
+    case HTS_TRAVEL_SAME_DOMAIN: {
+      size_t i = strlen(adr) - 1;
+      size_t j = strlen(urladr()) - 1;
 
-        if ((i > 0) && (j > 0)) {
-          while((i > 0) && (adr[i] != '.'))
-            i--;
-          while((j > 0) && (urladr()[j] != '.'))
-            j--;
-          if ((i > 0) && (j > 0)) {
-            i--;
-            j--;
-            while((i > 0) && (adr[i] != '.'))
-              i--;
-            while((j > 0) && (urladr()[j] != '.'))
-              j--;
-          }
-        }
-        if ((i > 0) && (j > 0)) {
-          if (!strfield2(adr + i, urladr() + j)) {        // !=
-            if (!opt->wizard) { // mode non wizard
-              //printf("refused: %s\n",adr);
-              forbidden_url = 1;        // pas même domaine  
-              hts_log_print(opt, LOG_DEBUG,
-                            "foreign domain link canceled: %s%s", adr, fil);
-            }
-
-          } else {
-            if (opt->wizard) {  // mode wizard
-              forbidden_url = 0;        // même domaine  
-              hts_log_print(opt, LOG_DEBUG, "same domain link authorized: %s%s",
-                            adr, fil);
-            }
-          }
-
-        } else
-          forbidden_url = 1;
-      }
-      break;
-    case 2:{                   // sortie sur le même .xxx
-        size_t i = strlen(adr) - 1;
-        size_t j = strlen(urladr()) - 1;
-
-        while((i > 0) && (adr[i] != '.'))
+      if ((i > 0) && (j > 0)) {
+        while ((i > 0) && (adr[i] != '.'))
           i--;
-        while((j > 0) && (urladr()[j] != '.'))
+        while ((j > 0) && (urladr()[j] != '.'))
           j--;
         if ((i > 0) && (j > 0)) {
-          if (!strfield2(adr + i, urladr() + j)) {        // !-
-            if (!opt->wizard) { // mode non wizard
-              //printf("refused: %s\n",adr);
-              forbidden_url = 1;        // pas même .xx  
-              hts_log_print(opt, LOG_DEBUG,
-                            "foreign location link canceled: %s%s", adr, fil);
-            }
-          } else {
-            if (opt->wizard) {  // mode wizard
-              forbidden_url = 0;        // même domaine  
-              hts_log_print(opt, LOG_DEBUG,
-                            "same location link authorized: %s%s", adr, fil);
-            }
-          }
-        } else
-          forbidden_url = 1;
+          i--;
+          j--;
+          while ((i > 0) && (adr[i] != '.'))
+            i--;
+          while ((j > 0) && (urladr()[j] != '.'))
+            j--;
+        }
       }
-      break;
-    case 7:                    // everywhere!!
+      if ((i > 0) && (j > 0)) {
+        if (!strfield2(adr + i, urladr() + j)) { // !=
+          if (!opt->wizard) {                    // mode non wizard
+            // printf("refused: %s\n",adr);
+            forbidden_url = 1; // pas même domaine
+            hts_log_print(opt, LOG_DEBUG, "foreign domain link canceled: %s%s",
+                          adr, fil);
+          }
+
+        } else {
+          if (opt->wizard) {   // mode wizard
+            forbidden_url = 0; // même domaine
+            hts_log_print(opt, LOG_DEBUG, "same domain link authorized: %s%s",
+                          adr, fil);
+          }
+        }
+
+      } else
+        forbidden_url = 1;
+    } break;
+    case HTS_TRAVEL_SAME_TLD: {
+      size_t i = strlen(adr) - 1;
+      size_t j = strlen(urladr()) - 1;
+
+      while ((i > 0) && (adr[i] != '.'))
+        i--;
+      while ((j > 0) && (urladr()[j] != '.'))
+        j--;
+      if ((i > 0) && (j > 0)) {
+        if (!strfield2(adr + i, urladr() + j)) { // !-
+          if (!opt->wizard) {                    // mode non wizard
+            // printf("refused: %s\n",adr);
+            forbidden_url = 1; // pas même .xx
+            hts_log_print(opt, LOG_DEBUG,
+                          "foreign location link canceled: %s%s", adr, fil);
+          }
+        } else {
+          if (opt->wizard) {   // mode wizard
+            forbidden_url = 0; // même domaine
+            hts_log_print(opt, LOG_DEBUG, "same location link authorized: %s%s",
+                          adr, fil);
+          }
+        }
+      } else
+        forbidden_url = 1;
+    } break;
+    case HTS_TRAVEL_EVERYWHERE:
       if (opt->wizard) {        // mode wizard
         forbidden_url = 0;
         break;
       }
-    }                           // switch
+    } // switch
 
     // ANCIENNE POS -- récupérer les liens à côtés d'un lien (nearlink)
 
@@ -583,7 +581,7 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
     // on doit poser la question.. peut on la poser?
     // (oui je sais quel preuve de délicatesse, merci merci)      
     if ((question) && (ptr > 0) && (!force_mirror)) {
-      if (opt->wizard == 2) {   // éliminer tous les liens non répertoriés comme autorisés (ou inconnus)
+      if (opt->wizard == HTS_WIZARD_AUTO) {
         question = 0;
         forbidden_url = 1;
         hts_log_print(opt, LOG_DEBUG,
@@ -600,8 +598,8 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
         printf("robots.txt forbidden: %s%s\n", adr, fil);
 #endif
         // question résolue, par les filtres, et mode robot non strict
-        if ((!question) && (filters_answer) && (opt->robots == 1)
-            && (forbidden_url != 1)) {
+        if ((!question) && (filters_answer) &&
+            (opt->robots == HTS_ROBOTS_SOMETIMES) && (forbidden_url != 1)) {
           r = 0;                // annuler interdiction des robots
           if (!forbidden_url) {
             hts_log_print(opt, LOG_DEBUG,
@@ -685,7 +683,7 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
         io_flush;
       } else {                  // lien primaire: autoriser répertoire entier       
         if (!force_mirror) {
-          if ((opt->seeker & 1) == 0) { // interdiction de descendre
+          if ((opt->seeker & HTS_SEEKER_DOWN) == 0) {
             n = 7;
           } else {
             n = 5;              // autoriser miroir répertoires descendants (lien primaire)
@@ -712,7 +710,7 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
       switch (n) {
       case -1:                 // sauter tout le reste
         forbidden_url = 1;
-        opt->wizard = 2;        // sauter tout le reste
+        opt->wizard = HTS_WIZARD_AUTO; // sauter tout le reste
         break;
       case 0: // forbid the same link: adr/fil
         forbidden_url = 1;
@@ -796,7 +794,7 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
         break;
 
       case 5: // allow the whole directory and its children
-        if ((opt->seeker & 2) == 0) { // not allowed to go up
+        if ((opt->seeker & HTS_SEEKER_UP) == 0) { // not allowed to go up
           size_t i = strlen(fil) - 1;
 
           while((fil[i] != '/') && (i > 0))
@@ -872,7 +870,7 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
   // lien non autorisé, peut-on juste le tester?
   if (just_test_it) {
     if (forbidden_url == 1) {
-      if (opt->travel & 256) {  // tester tout de même
+      if (opt->travel & HTS_TRAVEL_TEST_ALL) { // tester tout de même
         if (strfield(adr, "ftp://") == 0) {                   // PAS ftp!
           forbidden_url = 1;    // oui oui toujours interdit (note: sert à rien car ==1 mais c pour comprendre)
           *just_test_it = 1;    // mais on teste


### PR DESCRIPTION
The per-mirror option fields in the installed `htsopt.h` carried bare `int`s whose values were scattered magic numbers (`opt->urlmode == 2`, `opt->getmode & 1`, `opt->travel & 256`, …) that you could only decode by reading the parser. This types the four single-valued fields as enums — `urlmode`→`hts_urlmode`, `cache`→`hts_cachemode`, `wizard`→`hts_wizard`, `robots`→`hts_robots` — and names the bitmask bits as enums too (`hts_getmode`, `hts_seeker`, `hts_travel_scope`, with `HTS_TRAVEL_SCOPE_MASK`/`HTS_TRAVEL_TEST_ALL` as macros), following the existing `htsparsejava_flags` style where the flag bits are an enum but the field stays `int`. Every use site moves to the named value. Flag bits use `(1 << N)` like `LOG_ERRNO` already does; no `0b…` literals, which aren't standard C before C23.

Not an ABI break: a C enum is int-sized and represented identically, so the struct layout, field offsets and `sizeof(httrackp)` are unchanged, the `size_httrackp` guard value still holds, and there's no soname bump.

The change is value-preserving, and rather than trust that, I compared per-object disassembly against `master`: 98 of 103 objects are byte-identical, `htscore`/`htscoremain`/`htsparse` have identical opcode sequences (the only deltas are `__LINE__` immediates nudged by clang-format wrapping a few now-longer lines), and `htslib`/`htswizard` differ only in instruction selection from the `int`→`enum` field types — every `hts_create_opt` default confirmed unchanged. `make check` passes. Redundant French trailing comments that the named macros made self-explanatory were dropped along the way.

A natural follow-up, kept separate: the `int`-used-as-bool fields could become a two-value `hts_boolean` enum — also int-sized, so bool-like readability with no repack.