### PR TITLE
Type the boolean option fields as a named enum

### DIFF
--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -1783,7 +1783,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
             break;
             //
           case 'b':
-            sscanf(com + 1, "%d", &opt->accept_cookie);
+            sscanf(com + 1, "%d", (int *) &opt->accept_cookie);
             while(isdigit((unsigned char) *(com + 1)))
               com++;
             break;
@@ -1845,12 +1845,12 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
 #endif
             break;
           case 'o':
-            sscanf(com + 1, "%d", &opt->errpage);
+            sscanf(com + 1, "%d", (int *) &opt->errpage);
             while(isdigit((unsigned char) *(com + 1)))
               com++;
             break;
           case 'u':
-            sscanf(com + 1, "%d", &opt->check_type);
+            sscanf(com + 1, "%d", (int *) &opt->check_type);
             while(isdigit((unsigned char) *(com + 1)))
               com++;
             break;
@@ -1917,7 +1917,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
               case 'I':
                 opt->kindex = 1;
                 if (isdigit((unsigned char) *(com + 1))) {
-                  sscanf(com + 1, "%d", &opt->kindex);
+                  sscanf(com + 1, "%d", (int *) &opt->kindex);
                   while(isdigit((unsigned char) *(com + 1)))
                     com++;
                 }

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -5435,14 +5435,14 @@ HTSEXT_API httrackp *hts_create_opt(void) {
   /* default settings */
 
   opt->wizard = HTS_WIZARD_AUTO; // wizard automatique
-  opt->quiet = 0;               // questions
+  opt->quiet = HTS_FALSE;
   //
   opt->travel = HTS_TRAVEL_SAME_ADDRESS; // même adresse
   opt->depth = 9999;            // mirror total par défaut
   opt->extdepth = 0;            // mais pas à l'extérieur
   opt->seeker = HTS_SEEKER_DOWN;       // down
   opt->urlmode = HTS_URLMODE_RELATIVE; // relatif par défaut
-  opt->no_type_change = 0;      // change file types
+  opt->no_type_change = HTS_FALSE;
   opt->debug = LOG_NOTICE;      // small log
   opt->getmode = HTS_GETMODE_HTML | HTS_GETMODE_NONHTML;
   opt->maxsite = -1;            // taille max site (aucune)
@@ -5450,18 +5450,18 @@ HTSEXT_API httrackp *hts_create_opt(void) {
   opt->maxfile_html = -1;       // idem pour html
   opt->maxsoc = 4;              // nbre socket max
   opt->fragment = -1;           // pas de fragmentation
-  opt->nearlink = 0;            // ne pas prendre les liens non-html "adjacents"
-  opt->makeindex = 1;           // faire un index
-  opt->kindex = 0;              // index 'keyword'
-  opt->delete_old = 1;          // effacer anciens fichiers
-  opt->background_on_suspend = 1;       // Background the process if Control Z calls signal suspend.
-  opt->makestat = 0;            // pas de fichier de stats
-  opt->maketrack = 0;           // ni de tracking
+  opt->nearlink = HTS_FALSE;
+  opt->makeindex = HTS_TRUE;
+  opt->kindex = HTS_FALSE;
+  opt->delete_old = HTS_TRUE;
+  opt->background_on_suspend = HTS_TRUE;
+  opt->makestat = HTS_FALSE;
+  opt->maketrack = HTS_FALSE;
   opt->timeout = 120;           // timeout par défaut (2 minutes)
   opt->cache = HTS_CACHE_PRIORITY; // cache prioritaire
-  opt->shell = 0;               // pas de shell par defaut
+  opt->shell = HTS_FALSE;
   opt->proxy.active = 0;        // pas de proxy
-  opt->user_agent_send = 1;     // envoyer un user-agent
+  opt->user_agent_send = HTS_TRUE;
   StringCopy(opt->user_agent,
              "Mozilla/4.5 (compatible; HTTrack 3.0x; Windows 98)");
   StringCopy(opt->referer, "");
@@ -5469,34 +5469,36 @@ HTSEXT_API httrackp *hts_create_opt(void) {
   opt->savename_83 = 0;         // noms longs par défaut
   opt->savename_type = 0;       // avec structure originale
   opt->savename_delayed = 2;    // hard delayed type (default)
-  opt->delayed_cached = 1;      // cached delayed type (default)
-  opt->mimehtml = 0;            // pas MIME-html
+  opt->delayed_cached = HTS_TRUE;
+  opt->mimehtml = HTS_FALSE;
   opt->parsejava = HTSPARSE_DEFAULT;    // parser classes
   opt->hostcontrol = 0;         // PAS de control host pour timeout et traffic jammer
   opt->retry = 2;               // 2 retry par défaut
-  opt->errpage = 1;             // copier ou générer une page d'erreur en cas d'erreur (404 etc.)
-  opt->check_type = 1;          // vérifier type si inconnu (cgi,asp..) SAUF / considéré comme html
-  opt->all_in_cache = 0;        // ne pas tout stocker en cache
+  opt->errpage = HTS_TRUE;
+  // d'erreur (404 etc.)
+  opt->check_type = HTS_TRUE;
+  // considéré comme html
+  opt->all_in_cache = HTS_FALSE;
   opt->robots = HTS_ROBOTS_ALWAYS; // traiter les robots.txt
-  opt->external = 0;            // liens externes normaux
-  opt->passprivacy = 0;         // mots de passe dans les fichiers
-  opt->includequery = 1;        // include query-string par défaut
-  opt->mirror_first_page = 0;   // pas mode mirror links
-  opt->accept_cookie = 1;       // gérer les cookies
+  opt->external = HTS_FALSE;
+  opt->passprivacy = HTS_FALSE;
+  opt->includequery = HTS_TRUE;
+  opt->mirror_first_page = HTS_FALSE;
+  opt->accept_cookie = HTS_TRUE;
   opt->cookie = NULL;
-  opt->http10 = 0;              // laisser http/1.1
-  opt->nokeepalive = 0;         // pas keep-alive
-  opt->nocompression = 0;       // pas de compression
-  opt->tolerant = 0;            // ne pas accepter content-length incorrect
-  opt->parseall = 1;            // tout parser (tags inconnus, par exemple)
-  opt->parsedebug = 0;          // pas de mode débuggage
-  opt->norecatch = 0;           // ne pas reprendre les fichiers effacés par l'utilisateur
+  opt->http10 = HTS_FALSE;
+  opt->nokeepalive = HTS_FALSE;
+  opt->nocompression = HTS_FALSE;
+  opt->tolerant = HTS_FALSE;
+  opt->parseall = HTS_TRUE;
+  opt->parsedebug = HTS_FALSE;
+  opt->norecatch = HTS_FALSE;
   opt->verbosedisplay = 0;      // pas d'animation texte
-  opt->sizehack = 0;            // size hack
-  opt->urlhack = 1;             // url hack (normalizer)
+  opt->sizehack = HTS_FALSE;
+  opt->urlhack = HTS_TRUE;
   StringCopy(opt->footer, HTS_DEFAULT_FOOTER);
-  opt->ftp_proxy = 1;           // proxy http pour ftp
-  opt->convert_utf8 = 1;        // convert html to UTF-8
+  opt->ftp_proxy = HTS_TRUE;
+  opt->convert_utf8 = HTS_TRUE;
   StringCopy(opt->filelist, "");
   StringCopy(opt->lang_iso, "en, *");
   StringCopy(opt->accept,
@@ -5507,9 +5509,9 @@ HTSEXT_API httrackp *hts_create_opt(void) {
   //
   opt->log = stdout;
   opt->errlog = stderr;
-  opt->flush = 1;               // flush sur les fichiers log
-  //opt->aff_progress=0;
-  opt->keyboard = 0;
+  opt->flush = HTS_TRUE;
+  // opt->aff_progress=0;
+  opt->keyboard = HTS_FALSE;
   //
   StringCopy(opt->path_html, "");
   StringCopy(opt->path_html_utf8, "");
@@ -5526,10 +5528,10 @@ HTSEXT_API httrackp *hts_create_opt(void) {
   opt->waittime = -1;           // wait until.. hh*3600+mm*60+ss
   //
   opt->exec = "";
-  opt->is_update = 0;           // not an update (yet)
-  opt->dir_topindex = 0;        // do not built top index (yet)
+  opt->is_update = HTS_FALSE;
+  opt->dir_topindex = HTS_FALSE;
   //
-  opt->bypass_limits = 0;       // enforce limits by default
+  opt->bypass_limits = HTS_FALSE;
   opt->state.stop = 0;          // stopper
   opt->state.exit_xh = 0;       // abort
   //

--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -354,6 +354,13 @@ typedef enum hts_travel_scope {
 #define HTS_TRAVEL_SCOPE_MASK 0xff   /**< mask selecting the scope value */
 #define HTS_TRAVEL_TEST_ALL (1 << 8) /**< also test forbidden URLs (-t) */
 
+/* Boolean option flag. An enum (not C bool) so the option fields stay int-sized
+   and the httrackp layout/ABI is unchanged. */
+#ifndef HTS_DEF_DEFSTRUCT_hts_boolean
+#define HTS_DEF_DEFSTRUCT_hts_boolean
+typedef enum hts_boolean { HTS_FALSE = 0, HTS_TRUE = 1 } hts_boolean;
+#endif
+
 #ifndef HTS_DEF_FWSTRUCT_lien_buffers
 #define HTS_DEF_FWSTRUCT_lien_buffers
 typedef struct lien_buffers lien_buffers;
@@ -378,14 +385,14 @@ struct httrackp {
   size_t size_httrackp; /**< size of this structure (version/ABI guard) */
   /* */
   hts_wizard wizard; /**< interactive wizard level (none/ask/auto) */
-  int flush;    /**< fflush() log files after each write */
+  hts_boolean flush; /**< fflush() log files after each write */
   int travel;   /**< link-following scope (same domain, etc.) */
   int seeker;   /**< allowed direction: go up and/or down the tree */
   int depth;    /**< maximum recursion depth (-rN) */
   int extdepth; /**< maximum recursion depth outside the start domain */
   hts_urlmode
       urlmode; /**< saved-link rewriting style (relative, absolute, etc.) */
-  int no_type_change;           // do not change file type according to MIME
+  hts_boolean no_type_change;   // do not change file type according to MIME
   int debug;                    /**< debug logging level */
   int getmode;           /**< what to fetch (HTML, images, ...) bitmask */
   FILE *log;             /**< informational log stream; NULL mutes it */
@@ -395,10 +402,11 @@ struct httrackp {
   LLint maxfile_html;    /**< max bytes per HTML file */
   int maxsoc;            /**< max simultaneous sockets (-cN) */
   LLint fragment;        /**< split site after this many bytes */
-  int nearlink;   /**< also fetch images/data adjacent to a page but off-site */
-  int makeindex;  /**< build a top-level index.html */
-  int kindex;     /**< build a keyword index */
-  int delete_old; /**< delete locally obsolete files after update */
+  hts_boolean
+      nearlink; /**< also fetch images/data adjacent to a page but off-site */
+  hts_boolean makeindex;  /**< build a top-level index.html */
+  hts_boolean kindex;     /**< build a keyword index */
+  hts_boolean delete_old; /**< delete locally obsolete files after update */
   int timeout;    /**< connection timeout in seconds */
   int rateout;    /**< minimum transfer rate (bytes/s) before abort */
   int maxtime;    /**< max total mirror duration in seconds */
@@ -407,16 +415,17 @@ struct httrackp {
   int waittime;   /**< scheduled start time (wall-clock seconds) */
   hts_cachemode cache; /**< cache generation mode */
   // int aff_progress;     // progress bar
-  int shell;         /**< driven by a shell over stdin/stdout pipes */
+  hts_boolean shell; /**< driven by a shell over stdin/stdout pipes */
   t_proxy proxy;     /**< proxy configuration */
   int savename_83;   /**< force 8.3 (DOS) file names */
   int savename_type; /**< saved-name layout (original tree, flat, ...) */
   String
       savename_userdef; /**< user-defined name template (e.g. %h%p/%n%q.%t) */
   int savename_delayed;         // delayed type check
-  int delayed_cached;           // delayed type check can be cached to speedup updates
-  int mimehtml;                 /**< produce a single MIME/MHTML archive */
-  int user_agent_send;          /**< send a User-Agent header */
+  hts_boolean
+      delayed_cached;   // delayed type check can be cached to speedup updates
+  hts_boolean mimehtml; /**< produce a single MIME/MHTML archive */
+  hts_boolean user_agent_send;  /**< send a User-Agent header */
   String user_agent;            /**< User-Agent value (e.g. httrack/1.0) */
   String referer;               /**< Referer value to send */
   String from;                  /**< From value to send */
@@ -425,37 +434,39 @@ struct httrackp {
   String path_html_utf8; /**< output directory for the mirror, UTF-8 form */
   String path_bin;       /**< directory for HTML templates */
   int retry;             /**< extra retries on a failed transfer */
-  int makestat;          /**< maintain a transfer-statistics log */
-  int maketrack;         /**< maintain an operations-statistics log */
+  hts_boolean makestat;  /**< maintain a transfer-statistics log */
+  hts_boolean maketrack; /**< maintain an operations-statistics log */
   int parsejava;         /**< Java/JS parsing mode; see htsparsejava_flags */
   int hostcontrol;       /**< drop hosts that are too slow, etc. */
-  int errpage;           /**< generate an error page on 404 and similar */
-  int check_type;   /**< probe unknown-type links (cgi/asp/dir) and follow moves
-                     */
-  int all_in_cache; /**< keep all retrieved data in the cache */
+  hts_boolean errpage;   /**< generate an error page on 404 and similar */
+  hts_boolean
+      check_type; /**< probe unknown-type links (cgi/asp/dir) and follow moves
+                   */
+  hts_boolean all_in_cache; /**< keep all retrieved data in the cache */
   hts_robots robots; /**< robots.txt handling level */
-  int external;     /**< render external links as error pages */
-  int passprivacy;  /**< strip passwords from external links */
-  int includequery; /**< include the query string in saved names */
-  int mirror_first_page;        /**< only mirror the links of the first page */
+  hts_boolean external;          /**< render external links as error pages */
+  hts_boolean passprivacy;       /**< strip passwords from external links */
+  hts_boolean includequery;      /**< include the query string in saved names */
+  hts_boolean mirror_first_page; /**< only mirror the links of the first page */
   String sys_com;               /**< system command to run */
-  int sys_com_exec;             /**< actually execute sys_com */
-  int accept_cookie;            /**< accept and send cookies */
+  hts_boolean sys_com_exec;     /**< actually execute sys_com */
+  hts_boolean accept_cookie;    /**< accept and send cookies */
   t_cookie *cookie;             /**< cookie store */
-  int http10;                   /**< force HTTP/1.0 */
-  int nokeepalive;              /**< disable keep-alive */
-  int nocompression;            /**< disable content compression */
-  int sizehack;                 /**< treat same-size response as "updated" */
-  int urlhack;                  // force "url normalization" to avoid loops
-  int tolerant;                 /**< accept an incorrect Content-Length */
-  int parseall;   /**< parse aggressively, including unknown tags with links */
-  int parsedebug; /**< parser debug mode */
-  int norecatch;  /**< do not re-fetch files the user deleted locally */
+  hts_boolean http10;           /**< force HTTP/1.0 */
+  hts_boolean nokeepalive;      /**< disable keep-alive */
+  hts_boolean nocompression;    /**< disable content compression */
+  hts_boolean sizehack;         /**< treat same-size response as "updated" */
+  hts_boolean urlhack;          // force "url normalization" to avoid loops
+  hts_boolean tolerant;         /**< accept an incorrect Content-Length */
+  hts_boolean
+      parseall; /**< parse aggressively, including unknown tags with links */
+  hts_boolean parsedebug; /**< parser debug mode */
+  hts_boolean norecatch;  /**< do not re-fetch files the user deleted locally */
   int verbosedisplay; /**< animated text progress display */
   String footer;      /**< footer/info line injected into pages */
   int maxcache;       /**< in-memory cache backing limit (bytes) */
   // int maxcache_anticipate; // maximum links to anticipate (upper bound)
-  int ftp_proxy;                /**< use the HTTP proxy for FTP too */
+  hts_boolean ftp_proxy;        /**< use the HTTP proxy for FTP too */
   String filelist;              /**< file listing URLs to include */
   String urllist;               /**< file listing filters to include */
   htsfilters filters;           /**< filter pointers (+/-pattern rules) */
@@ -469,20 +480,20 @@ struct httrackp {
   String headers;               // Additional headers
   String mimedefs;              // ext1=mimetype1\next2=mimetype2..
   String mod_blacklist;         /**< blacklisted modules */
-  int convert_utf8;             // filenames UTF-8 conversion (3.46)
+  hts_boolean convert_utf8;     // filenames UTF-8 conversion (3.46)
   //
   int maxlink;   /**< max number of links */
   int maxfilter; /**< max number of filters */
   //
   const char *exec; /**< path of the running executable */
   //
-  int quiet;                    /**< suppress non-wizard questions */
-  int keyboard;                 /**< poll stdin for keyboard input */
-  int bypass_limits;            // bypass built-in limits
-  int background_on_suspend;    // background process on suspend signal
+  hts_boolean quiet;                 /**< suppress non-wizard questions */
+  hts_boolean keyboard;              /**< poll stdin for keyboard input */
+  hts_boolean bypass_limits;         // bypass built-in limits
+  hts_boolean background_on_suspend; // background process on suspend signal
   //
-  int is_update;    /**< this run is an update (show "File updated...") */
-  int dir_topindex; /**< rebuild the top index afterwards */
+  hts_boolean is_update; /**< this run is an update (show "File updated...") */
+  hts_boolean dir_topindex; /**< rebuild the top index afterwards */
   //
   // callbacks
   t_hts_htmlcheck_callbacks


### PR DESCRIPTION
Follow-up to #385. The `httrackp` option fields that are pure on/off toggles were declared as bare `int`. This introduces a two-value `hts_boolean { HTS_FALSE, HTS_TRUE }` and uses it as the type of the 38 boolean fields, so each documents its nature at the declaration, and converts the `hts_create_opt()` defaults block to read `HTS_TRUE`/`HTS_FALSE`.

It's an enum rather than C `bool` deliberately: a C enum is int-sized and represented like `int`, so the struct layout, every field offset and `sizeof(httrackp)` are unchanged (verified: 141648 bytes before and after), the `size_httrackp` guard value still holds, and there's no soname bump. A `bool` field would be one byte and would repack the whole struct, breaking the ABI for no real gain.

Scope is `httrackp` only. Fields that look boolean but aren't were left as `int` — `savename_delayed` is tri-state, `hostcontrol` is a bitmask — as was the unrelated `is_update` in the `lien_back` struct. The four CLI sites that `sscanf("%d")` straight into a boolean field now cast to `int*` to keep the read well-defined.

Value-preserving, and checked rather than assumed: built against `master` and compared per-object disassembly. 40 of 45 objects are byte-identical; the five that differ (`htscore`/`htslib`/`htsname`/`htsparse`/`htswizard`) differ only in instruction selection from the `int`→`enum` field types, with every `hts_create_opt` default confirmed unchanged. `make check` passes. Runtime assignments stay plain `0`/`1` (valid C, compile identically), so the diff is confined to the header, the defaults block and the four casts.