### PR TITLE
htsopt: fold HTS_TRAVEL_TEST_ALL into the hts_travel_scope enum

### DIFF
--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -342,17 +342,17 @@ typedef enum hts_seeker {
   HTS_SEEKER_UP = 1 << 1    /**< may ascend to parent directories */
 } hts_seeker;
 
-/* Link-following scope, stored in the low byte of opt->travel. */
+/* opt->travel: link-following scope in the low byte, flags OR'd in above it. */
 typedef enum hts_travel_scope {
   HTS_TRAVEL_SAME_ADDRESS = 0, /**< stay on the same address (host) */
   HTS_TRAVEL_SAME_DOMAIN = 1,  /**< stay on the same principal domain */
   HTS_TRAVEL_SAME_TLD = 2,     /**< stay on the same TLD (e.g. .com) */
-  HTS_TRAVEL_EVERYWHERE = 7    /**< follow links anywhere on the web */
+  HTS_TRAVEL_EVERYWHERE = 7,   /**< follow links anywhere on the web */
+  HTS_TRAVEL_TEST_ALL = 1 << 8 /**< also test forbidden URLs (-t) */
 } hts_travel_scope;
 
-/* Flags OR'd into opt->travel above the scope value. */
-#define HTS_TRAVEL_SCOPE_MASK 0xff   /**< mask selecting the scope value */
-#define HTS_TRAVEL_TEST_ALL (1 << 8) /**< also test forbidden URLs (-t) */
+/* Mask selecting the scope value out of opt->travel. */
+#define HTS_TRAVEL_SCOPE_MASK 0xff
 
 /* Text progress display detail (opt->verbosedisplay). */
 typedef enum hts_verbosedisplay {


### PR DESCRIPTION
Follow-up to #388. The `-t` "test all" flag was a stray `#define` sitting next to `hts_travel_scope`; this promotes it to an enum constant so the named travel values live in one place. `HTS_TRAVEL_SCOPE_MASK` deliberately stays a `#define` — it selects the scope out of the low byte of `opt->travel`, it is not a member of the value set, so naming it in the enum would just be debugger noise.

Name and value (`1 << 8`) are unchanged, so all nine use sites compile identically and `opt->travel` stays a plain `int`. No struct layout or `sizeof` change, no ABI impact. The only source-visible difference is that `HTS_TRAVEL_TEST_ALL` is no longer a preprocessor macro (an `#ifdef`/`#if` on it would now behave differently), matching how the other travel/scope constants already work after #388.

Build and `make check` green; clang-format diff gate clean.