### PR TITLE
copy_htsopt silently drops boolean option fields

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -3702,7 +3702,9 @@ HTSEXT_API int copy_htsopt(const httrackp * from, httrackp * to) {
   if (from->maxsoc > 0)
     to->maxsoc = from->maxsoc;
 
-  if (from->nearlink > -1)
+  /* hts_boolean/enum fields are unsigned (GCC), so a bare `> -1` unset-guard
+     is always false; cast to int to keep the -1 "unset" sentinel test. */
+  if ((int) from->nearlink > -1)
     to->nearlink = from->nearlink;
 
   if (from->timeout > -1)
@@ -3729,10 +3731,10 @@ HTSEXT_API int copy_htsopt(const httrackp * from, httrackp * to) {
   if (from->hostcontrol > -1)
     to->hostcontrol = from->hostcontrol;
 
-  if (from->errpage > -1)
+  if ((int) from->errpage > -1)
     to->errpage = from->errpage;
 
-  if (from->parseall > -1)
+  if ((int) from->parseall > -1)
     to->parseall = from->parseall;
 
   // test all: bit 8 de travel

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -3096,6 +3096,41 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                 htsmain_free();
                 return 0;
                 break;
+              case '9': { // copy_htsopt selftest: httrack -#9
+                httrackp *from = hts_create_opt();
+                httrackp *to = hts_create_opt();
+                int err = 0;
+
+                /* from-values differ from both the to-values and the
+                   hts_create_opt() defaults (nearlink FALSE, errpage/parseall
+                   TRUE), so a copy that no-ops or just resets to defaults is
+                   caught too, not only the unsigned-guard bug. */
+                from->retry = 7; /* int field: positive control */
+                to->retry = 0;
+                from->nearlink = HTS_TRUE;
+                to->nearlink = HTS_FALSE;
+                from->errpage = HTS_FALSE;
+                to->errpage = HTS_TRUE;
+                from->parseall = HTS_FALSE;
+                to->parseall = HTS_TRUE;
+
+                copy_htsopt(from, to);
+
+                if (to->retry != 7)
+                  err = 1;
+                if (to->nearlink != HTS_TRUE)
+                  err = 1;
+                if (to->errpage != HTS_FALSE)
+                  err = 1;
+                if (to->parseall != HTS_FALSE)
+                  err = 1;
+
+                hts_free_opt(from);
+                hts_free_opt(to);
+                printf("copy-htsopt: %s\n", err ? "FAIL" : "OK");
+                htsmain_free();
+                return err;
+              } break;
               case '!':
                 HTS_PANIC_PRINTF
                   ("Option #! is disabled for security reasons");

--- a/tests/01_engine-copyopt.test
+++ b/tests/01_engine-copyopt.test
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Regression guard for the unsigned-enum sentinel trap: copy_htsopt's
+# `if (from->X > -1)` guard is always false for unsigned hts_boolean fields, so
+# they silently stop being copied. Driven by the in-process 'httrack -#9' test.
+# Keep POSIX-portable (harness runs it via $(BASH), a plain /bin/sh on macOS).
+
+set -eu
+
+# A trailing token is required; a bare '-#9' falls through to the usage screen.
+out=$(httrack -#9 run)
+
+# Exact-match the success line so a fall-through to usage can't pass the test.
+test "$out" = "copy-htsopt: OK" || {
+    echo "expected 'copy-htsopt: OK', got: $out" >&2
+    exit 1
+}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -24,6 +24,7 @@ TESTS = \
 	01_engine-cache-golden.test \
 	01_engine-charset.test \
 	01_engine-cmdline.test \
+	01_engine-copyopt.test \
 	01_engine-doitlog.test \
 	01_engine-entities.test \
 	01_engine-filter.test \


### PR DESCRIPTION
copy_htsopt copies each option field only when it is not the "-1 means unset" sentinel, written as `if (from->X > -1)`. The boolean/enum option-field migrations turned nearlink, errpage and parseall into hts_boolean, which GCC backs with unsigned int, so `unsigned > -1` is always false and those three fields quietly stopped being copied. copy_htsopt is exported (HTSEXT_API) but its only internal call site is commented out, so the regression reaches library consumers rather than internal crawls.

The fix casts those three guards to int, restoring the signed sentinel test. A hidden `httrack -#9` self-test (tests/01_engine-copyopt.test) runs copy_htsopt over distinct boolean values plus an int positive control; each from-value is chosen to differ from the field hts_create_opt default, so a no-op or reset-to-default copy is caught too, not only the unsigned-guard bug. The test prints FAIL on the unfixed guard.

travel and hostcontrol are still int, so their `> -1` guards work today; they are slated to become enums in a later change, at which point their guards need the same cast.