### PR TITLE
Tunnel https through the proxy via CONNECT (#85)

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -2534,8 +2534,7 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
           if (back[i].r.ssl) {
             int tunnel_ok = 1;
 
-            // https through a proxy: open a CONNECT tunnel before the TLS
-            // handshake so TLS runs end-to-end with the origin (issue #85)
+            // https via proxy: CONNECT-tunnel before TLS (#85)
             if (back[i].r.req.proxy.active && back[i].r.ssl_con == NULL) {
               const int timeout = back[i].timeout > 0 ? back[i].timeout : 30;
 

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -2532,8 +2532,27 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
 #if HTS_USEOPENSSL
           /* SSL mode */
           if (back[i].r.ssl) {
+            int tunnel_ok = 1;
+
+            // https through a proxy: open a CONNECT tunnel before the TLS
+            // handshake so TLS runs end-to-end with the origin (issue #85)
+            if (back[i].r.req.proxy.active && back[i].r.ssl_con == NULL) {
+              const int timeout = back[i].timeout > 0 ? back[i].timeout : 30;
+
+              tunnel_ok =
+                  http_proxy_tunnel(opt, &back[i].r, back[i].url_adr, timeout);
+              if (!tunnel_ok) {
+                if (!strnotempty(back[i].r.msg))
+                  strcpybuff(back[i].r.msg, "proxy CONNECT failed");
+                deletehttp(&back[i].r);
+                back[i].r.soc = INVALID_SOCKET;
+                back[i].r.statuscode = STATUSCODE_NON_FATAL;
+                back[i].status = STATUS_READY;
+                back_set_finished(sback, i);
+              }
+            }
             // handshake not yet launched
-            if (!back[i].r.ssl_con) {
+            if (tunnel_ok && !back[i].r.ssl_con) {
               SSL_CTX_set_options(openssl_ctx, SSL_OP_ALL);
               // new session
               back[i].r.ssl_con = SSL_new(openssl_ctx);
@@ -2551,7 +2570,7 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                 back[i].r.statuscode = STATUSCODE_SSL_HANDSHAKE;
             }
             /* Error */
-            if (back[i].r.statuscode == STATUSCODE_SSL_HANDSHAKE) {
+            if (tunnel_ok && back[i].r.statuscode == STATUSCODE_SSL_HANDSHAKE) {
               strcpybuff(back[i].r.msg, "bad SSL/TLS handshake");
               deletehttp(&back[i].r);
               back[i].r.soc = INVALID_SOCKET;

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -644,9 +644,8 @@ T_SOC http_fopen(httrackp * opt, const char *adr, const char *fil, htsblk * reto
   return http_xfopen(opt, 0, 1, 1, NULL, adr, fil, retour);
 }
 
-// Read one CRLF-terminated line from a non-blocking socket, waiting up to
-// timeout seconds for each chunk. Strips CR, stops at LF. Returns the line
-// length (0 for an empty line), or -1 on timeout/EOF/error.
+// Read a CRLF line from a non-blocking socket (waits up to timeout per recv).
+// Returns the line length (0 = empty), or -1 on timeout/EOF/error.
 static int proxy_getline(T_SOC soc, char *s, int max, int timeout) {
   int j = 0;
 
@@ -662,8 +661,9 @@ static int proxy_getline(T_SOC soc, char *s, int max, int timeout) {
         continue;
       if (ch == 10) // LF: end of line
         break;
-      if (j < max - 1)
-        s[j++] = (char) ch;
+      if (j >= max - 1)
+        return -1; // line too long: bound the read against a hostile proxy
+      s[j++] = (char) ch;
     } else if (n == 0) {
       return -1; // connection closed
     } else {
@@ -686,25 +686,38 @@ int http_proxy_tunnel(httrackp *opt, htsblk *retour, const char *adr,
   const T_SOC soc = retour->soc;
   const char *const host = jump_identification_const(adr); // host[:port]
   const char *const portsep = jump_toport_const(adr);      // ":port" or NULL
-  char BIGSTK authority[HTS_URLMAXSIZE];
-  char BIGSTK req[HTS_URLMAXSIZE * 2 + 1100];
+  char BIGSTK authority[HTS_URLMAXSIZE * 2];
+  char BIGSTK req[HTS_URLMAXSIZE * 4 + 1100];
   char line[1024];
   int code;
 
   if (soc == INVALID_SOCKET)
     return 0;
 
-  // CONNECT needs an explicit "host:port" authority; default the https port
+  // CONNECT needs an explicit host:port; default the https port
   authority[0] = '\0';
   if (portsep != NULL)
     strlcatbuff(authority, host, sizeof(authority)); // already host:port
   else
     snprintf(authority, sizeof(authority), "%s:%d", host, 443);
 
+  // backstop: never let a stray CR/LF in the host smuggle a second line into
+  // the CONNECT request (the host is already sanitized upstream)
+  {
+    const char *c;
+
+    for (c = authority; *c != '\0'; c++) {
+      if ((unsigned char) *c < ' ') {
+        strcpybuff(retour->msg, "proxy CONNECT: invalid host");
+        return 0;
+      }
+    }
+  }
+
   snprintf(req, sizeof(req), "CONNECT %s HTTP/1.0" H_CRLF "Host: %s" H_CRLF,
            authority, authority);
 
-  // proxy credentials ride the CONNECT request, not the tunneled origin request
+  // creds go on the CONNECT, not the tunneled origin request
   if (link_has_authorization(retour->req.proxy.name)) {
     const char *a = jump_identification_const(retour->req.proxy.name);
     const char *astart = jump_protocol_const(retour->req.proxy.name);
@@ -723,10 +736,11 @@ int http_proxy_tunnel(httrackp *opt, htsblk *retour, const char *adr,
   }
   strlcatbuff(req, H_CRLF, sizeof(req)); // end of request headers
 
-  // send the request (raw: retour->ssl is set, so sendc() would route to TLS)
+  // raw send: ssl is set, so sendc() would route to TLS
   {
     const char *p = req;
     size_t remain = strlen(req);
+    int stalls = 0;
 
     while (remain > 0) {
       const int n = (int) send(soc, p, (int) remain, 0);
@@ -734,6 +748,7 @@ int http_proxy_tunnel(httrackp *opt, htsblk *retour, const char *adr,
       if (n > 0) {
         p += n;
         remain -= (size_t) n;
+        stalls = 0;
       } else {
 #ifdef _WIN32
         const int wouldblock = (WSAGetLastError() == WSAEWOULDBLOCK);
@@ -741,8 +756,9 @@ int http_proxy_tunnel(httrackp *opt, htsblk *retour, const char *adr,
         const int wouldblock =
             (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR);
 #endif
-        // a fatal send error must not spin against an always-writable select
-        if (!wouldblock || !check_writeinput_t(soc, timeout)) {
+        // don't spin forever on a fatal error or an unwritable socket
+        if (!wouldblock || !check_writeinput_t(soc, timeout) ||
+            ++stalls > 100) {
           strcpybuff(retour->msg, "proxy CONNECT: write error");
           return 0;
         }
@@ -763,17 +779,25 @@ int http_proxy_tunnel(httrackp *opt, htsblk *retour, const char *adr,
     return 0;
   }
 
-  // drain the proxy response headers up to the blank line, so the TLS
-  // handshake starts at the first tunneled byte
-  for (;;) {
-    const int n = proxy_getline(soc, line, sizeof(line), timeout);
+  // drain headers to the blank line; cap the count so a flooding proxy can't
+  // stall the crawl
+  {
+    int headers = 0;
 
-    if (n < 0) {
-      strcpybuff(retour->msg, "proxy CONNECT: truncated response");
-      return 0;
+    for (;;) {
+      const int n = proxy_getline(soc, line, sizeof(line), timeout);
+
+      if (n < 0) {
+        strcpybuff(retour->msg, "proxy CONNECT: truncated response");
+        return 0;
+      }
+      if (n == 0)
+        break; // blank line: tunnel ready
+      if (++headers > 64) {
+        strcpybuff(retour->msg, "proxy CONNECT: too many response headers");
+        return 0;
+      }
     }
-    if (n == 0)
-      break; // blank line: tunnel ready
   }
 
   return 1;
@@ -819,8 +843,8 @@ T_SOC http_xfopen(httrackp * opt, int mode, int treat, int waitconnect,
     if ((!(retour->req.proxy.active)) || (strcmp(adr, "file://") == 0)) {
       soc = newhttp(opt, adr, retour, -1, waitconnect);
     } else {
-      // open to the proxy instead; https reaches the origin through a CONNECT
-      // tunnel set up in back_wait once this connection is up (issue #85)
+      // to the proxy; https tunnels to the origin via CONNECT in back_wait
+      // (#85)
       soc = newhttp(opt, retour->req.proxy.name, retour, retour->req.proxy.port,
                     waitconnect);
     }
@@ -1178,8 +1202,7 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
     if (xsend)
       print_buffer(&bstr, "%s", xsend);  // éventuelles autres lignes
 
-    // proxy authentication (for https it rides the CONNECT request instead, so
-    // it is not leaked to the origin through the tunnel)
+    // for https, auth rides the CONNECT (the tunneled GET would leak it)
     if (retour->req.proxy.active && strncmp(adr, "https://", 8) != 0) {
       if (link_has_authorization(retour->req.proxy.name)) {     // et hop, authentification proxy!
         const char *a = jump_identification_const(retour->req.proxy.name);

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -644,6 +644,141 @@ T_SOC http_fopen(httrackp * opt, const char *adr, const char *fil, htsblk * reto
   return http_xfopen(opt, 0, 1, 1, NULL, adr, fil, retour);
 }
 
+// Read one CRLF-terminated line from a non-blocking socket, waiting up to
+// timeout seconds for each chunk. Strips CR, stops at LF. Returns the line
+// length (0 for an empty line), or -1 on timeout/EOF/error.
+static int proxy_getline(T_SOC soc, char *s, int max, int timeout) {
+  int j = 0;
+
+  for (;;) {
+    unsigned char ch;
+    int n;
+
+    if (!check_readinput_t(soc, timeout))
+      return -1; // timed out waiting for data
+    n = (int) recv(soc, &ch, 1, 0);
+    if (n == 1) {
+      if (ch == 13) // CR
+        continue;
+      if (ch == 10) // LF: end of line
+        break;
+      if (j < max - 1)
+        s[j++] = (char) ch;
+    } else if (n == 0) {
+      return -1; // connection closed
+    } else {
+#ifdef _WIN32
+      if (WSAGetLastError() == WSAEWOULDBLOCK)
+        continue;
+#else
+      if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
+        continue;
+#endif
+      return -1;
+    }
+  }
+  s[j] = '\0';
+  return j;
+}
+
+int http_proxy_tunnel(httrackp *opt, htsblk *retour, const char *adr,
+                      int timeout) {
+  const T_SOC soc = retour->soc;
+  const char *const host = jump_identification_const(adr); // host[:port]
+  const char *const portsep = jump_toport_const(adr);      // ":port" or NULL
+  char BIGSTK authority[HTS_URLMAXSIZE];
+  char BIGSTK req[HTS_URLMAXSIZE * 2 + 1100];
+  char line[1024];
+  int code;
+
+  if (soc == INVALID_SOCKET)
+    return 0;
+
+  // CONNECT needs an explicit "host:port" authority; default the https port
+  authority[0] = '\0';
+  if (portsep != NULL)
+    strlcatbuff(authority, host, sizeof(authority)); // already host:port
+  else
+    snprintf(authority, sizeof(authority), "%s:%d", host, 443);
+
+  snprintf(req, sizeof(req), "CONNECT %s HTTP/1.0" H_CRLF "Host: %s" H_CRLF,
+           authority, authority);
+
+  // proxy credentials ride the CONNECT request, not the tunneled origin request
+  if (link_has_authorization(retour->req.proxy.name)) {
+    const char *a = jump_identification_const(retour->req.proxy.name);
+    const char *astart = jump_protocol_const(retour->req.proxy.name);
+    char autorisation[1100];
+    char user_pass[256];
+
+    autorisation[0] = user_pass[0] = '\0';
+    strncatbuff(user_pass, astart, (int) (a - astart) - 1);
+    strcpybuff(user_pass, unescape_http(OPT_GET_BUFF(opt),
+                                        OPT_GET_BUFF_SIZE(opt), user_pass));
+    code64((unsigned char *) user_pass, (int) strlen(user_pass),
+           (unsigned char *) autorisation, 0);
+    strlcatbuff(req, "Proxy-Authorization: Basic ", sizeof(req));
+    strlcatbuff(req, autorisation, sizeof(req));
+    strlcatbuff(req, H_CRLF, sizeof(req));
+  }
+  strlcatbuff(req, H_CRLF, sizeof(req)); // end of request headers
+
+  // send the request (raw: retour->ssl is set, so sendc() would route to TLS)
+  {
+    const char *p = req;
+    size_t remain = strlen(req);
+
+    while (remain > 0) {
+      const int n = (int) send(soc, p, (int) remain, 0);
+
+      if (n > 0) {
+        p += n;
+        remain -= (size_t) n;
+      } else {
+#ifdef _WIN32
+        const int wouldblock = (WSAGetLastError() == WSAEWOULDBLOCK);
+#else
+        const int wouldblock =
+            (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR);
+#endif
+        // a fatal send error must not spin against an always-writable select
+        if (!wouldblock || !check_writeinput_t(soc, timeout)) {
+          strcpybuff(retour->msg, "proxy CONNECT: write error");
+          return 0;
+        }
+      }
+    }
+  }
+
+  // proxy status line: "HTTP/1.x <code> ..."
+  if (proxy_getline(soc, line, sizeof(line), timeout) < 0) {
+    strcpybuff(retour->msg, "proxy CONNECT: no response");
+    return 0;
+  }
+  if (sscanf(line, "HTTP/%*d.%*d %d", &code) < 1)
+    code = 0;
+  if (code < 200 || code >= 300) {
+    snprintf(retour->msg, sizeof(retour->msg), "proxy CONNECT refused: %s",
+             strnotempty(line) ? line : "(no status)");
+    return 0;
+  }
+
+  // drain the proxy response headers up to the blank line, so the TLS
+  // handshake starts at the first tunneled byte
+  for (;;) {
+    const int n = proxy_getline(soc, line, sizeof(line), timeout);
+
+    if (n < 0) {
+      strcpybuff(retour->msg, "proxy CONNECT: truncated response");
+      return 0;
+    }
+    if (n == 0)
+      break; // blank line: tunnel ready
+  }
+
+  return 1;
+}
+
 // ouverture d'une liaison http, envoi d'une requète
 // mode: 0 GET  1 HEAD  [2 POST]
 // treat: traiter header?
@@ -680,14 +815,14 @@ T_SOC http_xfopen(httrackp * opt, int mode, int treat, int waitconnect,
 
   /* connexion */
   if (retour) {
-    if ((!(retour->req.proxy.active))
-        || ((strcmp(adr, "file://") == 0)
-            || (strncmp(adr, "https://", 8) == 0)
-        )
-      ) {                       /* pas de proxy, ou non utilisable ici */
+    /* no proxy, or proxy not usable here (local file) */
+    if ((!(retour->req.proxy.active)) || (strcmp(adr, "file://") == 0)) {
       soc = newhttp(opt, adr, retour, -1, waitconnect);
     } else {
-      soc = newhttp(opt, retour->req.proxy.name, retour, retour->req.proxy.port, waitconnect);  // ouvrir sur le proxy à la place
+      // open to the proxy instead; https reaches the origin through a CONNECT
+      // tunnel set up in back_wait once this connection is up (issue #85)
+      soc = newhttp(opt, retour->req.proxy.name, retour, retour->req.proxy.port,
+                    waitconnect);
     }
   } else {
     soc = newhttp(opt, adr, NULL, -1, waitconnect);
@@ -1043,8 +1178,9 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
     if (xsend)
       print_buffer(&bstr, "%s", xsend);  // éventuelles autres lignes
 
-    // tester proxy authentication
-    if (retour->req.proxy.active) {
+    // proxy authentication (for https it rides the CONNECT request instead, so
+    // it is not leaked to the origin through the tunnel)
+    if (retour->req.proxy.active && strncmp(adr, "https://", 8) != 0) {
       if (link_has_authorization(retour->req.proxy.name)) {     // et hop, authentification proxy!
         const char *a = jump_identification_const(retour->req.proxy.name);
         const char *astart = jump_protocol_const(retour->req.proxy.name);
@@ -1823,6 +1959,24 @@ int check_readinput_t(T_SOC soc, int timeout) {
       return 1;
     else
       return 0;
+  } else
+    return 0;
+}
+
+// wait until the socket is writable, up to timeout seconds
+int check_writeinput_t(T_SOC soc, int timeout) {
+  if (soc != INVALID_SOCKET) {
+    fd_set fds;
+    struct timeval tv;
+    const int isoc = (int) soc;
+
+    assertf(isoc == soc);
+    FD_ZERO(&fds);
+    FD_SET(isoc, &fds);
+    tv.tv_sec = timeout;
+    tv.tv_usec = 0;
+    select(isoc + 1, NULL, &fds, NULL, &tv);
+    return FD_ISSET(isoc, &fds) ? 1 : 0;
   } else
     return 0;
 }

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -198,6 +198,17 @@ HTS_INLINE void deletesoc_r(htsblk * r);
 htsblk http_test(httrackp * opt, const char *adr, const char *fil, char *loc);
 int check_readinput(htsblk * r);
 int check_readinput_t(T_SOC soc, int timeout);
+int check_writeinput_t(T_SOC soc, int timeout);
+
+/* Open an HTTP CONNECT tunnel through the active proxy for an https request:
+   `retour->soc` must already be TCP-connected to the proxy, and `adr` is the
+   origin authority (url_adr, e.g. "https://host:port"). Sends the CONNECT
+   request (with Proxy-Authorization when the proxy carries credentials) and
+   reads the proxy's status line, so the caller's TLS handshake then runs
+   end-to-end with the origin. Blocks up to `timeout` seconds. Returns 1 on a
+   2xx tunnel, 0 on failure (retour->msg/statuscode set). */
+int http_proxy_tunnel(httrackp *opt, htsblk *retour, const char *adr,
+                      int timeout);
 void treathead(t_cookie * cookie, const char *adr, const char *fil, htsblk * retour,
                char *rcvd);
 void treatfirstline(htsblk * retour, const char *rcvd);

--- a/tests/13_crawl_proxy_https.test
+++ b/tests/13_crawl_proxy_https.test
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# Issue #85: an https crawl must go through the configured proxy (CONNECT
+# tunnel), not bypass it and hit the origin directly. Fully local: a self-signed
+# TLS origin plus a logging CONNECT proxy, so no network access is needed.
+
+set -euo pipefail
+
+: "${top_srcdir:=..}"
+
+if test "${HTTPS_SUPPORT:-}" == "no"; then
+    echo "no https support compiled, skipping"
+    exit 77
+fi
+if ! command -v python3 >/dev/null 2>&1 || ! command -v openssl >/dev/null 2>&1; then
+    echo "python3/openssl missing, skipping"
+    exit 77
+fi
+
+server="$top_srcdir/tests/proxy-https-server.py"
+tmpdir=$(mktemp -d)
+serverpid=
+
+cleanup() {
+    if test -n "$serverpid"; then
+        kill "$serverpid" 2>/dev/null || true
+    fi
+    rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+# self-signed cert for the local TLS origin (httrack does not verify certs)
+openssl req -x509 -newkey rsa:2048 -keyout "$tmpdir/key.pem" \
+    -out "$tmpdir/cert.pem" -days 2 -nodes -subj "/CN=127.0.0.1" \
+    >/dev/null 2>&1
+cat "$tmpdir/key.pem" "$tmpdir/cert.pem" >"$tmpdir/both.pem"
+
+log="$tmpdir/proxy.log"
+ports="$tmpdir/ports.txt"
+python3 "$server" "$tmpdir/both.pem" "$log" >"$ports" 2>"$tmpdir/server.err" &
+serverpid=$!
+for _ in $(seq 1 100); do
+    grep -q "^ready" "$ports" 2>/dev/null && break
+    sleep 0.1
+done
+grep -q "^ready" "$ports" 2>/dev/null || {
+    echo "server did not start" >&2
+    cat "$tmpdir/server.err" >&2
+    exit 1
+}
+origin_port=$(awk '/^ORIGIN/{print $2}' "$ports")
+proxy_port=$(awk '/^PROXY/{print $2}' "$ports")
+
+run_crawl() {
+    local out="$1" proxy="$2"
+    rm -rf "$out"
+    httrack "https://127.0.0.1:${origin_port}/" --proxy "$proxy" \
+        -O "$out" -r1 -s0 --timeout=10 >"$tmpdir/ht.log" 2>&1
+}
+
+# 1. plain proxy: page retrieved AND the proxy saw a CONNECT to the origin
+run_crawl "$tmpdir/out" "127.0.0.1:${proxy_port}"
+grep -rq "ORIGIN-PAGE-85" "$tmpdir/out" || {
+    echo "FAIL: origin page not downloaded through proxy" >&2
+    cat "$tmpdir/ht.log" >&2
+    exit 1
+}
+grep -q "^CONNECT 127.0.0.1:${origin_port} " "$log" || {
+    echo "FAIL: proxy never received a CONNECT (https bypassed the proxy)" >&2
+    cat "$log" >&2
+    exit 1
+}
+echo "OK: https tunneled through proxy via CONNECT"
+
+# 2. proxy with credentials: auth must ride the CONNECT, not the tunneled GET
+: >"$log"
+run_crawl "$tmpdir/out2" "user:secret@127.0.0.1:${proxy_port}"
+grep -rq "ORIGIN-PAGE-85" "$tmpdir/out2" || {
+    echo "FAIL: origin page not downloaded through authenticated proxy" >&2
+    exit 1
+}
+got=$(awk '/^AUTH Basic /{print $3}' "$log" | head -1 | base64 -d 2>/dev/null || true)
+test "$got" == "user:secret" || {
+    echo "FAIL: Proxy-Authorization not carried on CONNECT (got '$got')" >&2
+    cat "$log" >&2
+    exit 1
+}
+echo "OK: proxy credentials carried on CONNECT"

--- a/tests/13_crawl_proxy_https.test
+++ b/tests/13_crawl_proxy_https.test
@@ -19,12 +19,12 @@ fi
 
 server="$top_srcdir/tests/proxy-https-server.py"
 tmpdir=$(mktemp -d)
-serverpid=
+pids=
 
 cleanup() {
-    if test -n "$serverpid"; then
-        kill "$serverpid" 2>/dev/null || true
-    fi
+    for pid in $pids; do
+        kill "$pid" 2>/dev/null || true
+    done
     rm -rf "$tmpdir"
 }
 trap cleanup EXIT
@@ -35,54 +35,102 @@ openssl req -x509 -newkey rsa:2048 -keyout "$tmpdir/key.pem" \
     >/dev/null 2>&1
 cat "$tmpdir/key.pem" "$tmpdir/cert.pem" >"$tmpdir/both.pem"
 
-log="$tmpdir/proxy.log"
-ports="$tmpdir/ports.txt"
-python3 "$server" "$tmpdir/both.pem" "$log" >"$ports" 2>"$tmpdir/server.err" &
-serverpid=$!
-for _ in $(seq 1 100); do
-    grep -q "^ready" "$ports" 2>/dev/null && break
-    sleep 0.1
-done
-grep -q "^ready" "$ports" 2>/dev/null || {
-    echo "server did not start" >&2
-    cat "$tmpdir/server.err" >&2
-    exit 1
+# start_server <logdir> <mode>: launches a proxy+origin pair, sets $origin_port
+# and $proxy_port from its announced ephemeral ports.
+start_server() {
+    local dir="$1" mode="$2" ports
+    mkdir -p "$dir"
+    ports="$dir/ports.txt"
+    python3 "$server" "$tmpdir/both.pem" "$dir" "$mode" \
+        >"$ports" 2>"$dir/server.err" &
+    pids="$pids $!"
+    for _ in $(seq 1 100); do
+        grep -q "^ready" "$ports" 2>/dev/null && break
+        sleep 0.1
+    done
+    grep -q "^ready" "$ports" 2>/dev/null || {
+        echo "server ($mode) did not start" >&2
+        cat "$dir/server.err" >&2
+        exit 1
+    }
+    origin_port=$(awk '/^ORIGIN/{print $2}' "$ports")
+    proxy_port=$(awk '/^PROXY/{print $2}' "$ports")
 }
-origin_port=$(awk '/^ORIGIN/{print $2}' "$ports")
-proxy_port=$(awk '/^PROXY/{print $2}' "$ports")
 
+# Run httrack, but kill it after a deadline so a hang (e.g. a missing bound on
+# the proxy response) surfaces as the kill code $HANG_RC instead of stalling the
+# whole job. A portable stand-in for `timeout`, which macOS lacks.
+HANG_RC=137 # 128 + SIGKILL
 run_crawl() {
-    local out="$1" proxy="$2"
+    local out="$1" proxy="$2" port="$3"
     rm -rf "$out"
-    httrack "https://127.0.0.1:${origin_port}/" --proxy "$proxy" \
-        -O "$out" -r1 -s0 --timeout=10 >"$tmpdir/ht.log" 2>&1
+    httrack "https://127.0.0.1:${port}/" --proxy "$proxy" \
+        -O "$out" -r1 -s0 --timeout=10 >"$out.log" 2>&1 &
+    local pid=$!
+    (sleep 60 && kill -9 "$pid" 2>/dev/null) &
+    local guard=$!
+    local rc=0
+    wait "$pid" 2>/dev/null || rc=$?
+    kill "$guard" 2>/dev/null || true
+    wait "$guard" 2>/dev/null || true
+    return "$rc"
 }
 
-# 1. plain proxy: page retrieved AND the proxy saw a CONNECT to the origin
-run_crawl "$tmpdir/out" "127.0.0.1:${proxy_port}"
-grep -rq "ORIGIN-PAGE-85" "$tmpdir/out" || {
+# --- working proxy ----------------------------------------------------------
+ok="$tmpdir/ok"
+start_server "$ok" ok
+
+# 1. page retrieved AND the proxy saw a CONNECT to the origin
+run_crawl "$ok/out" "127.0.0.1:${proxy_port}" "$origin_port"
+grep -rq "ORIGIN-PAGE-85" "$ok/out" || {
     echo "FAIL: origin page not downloaded through proxy" >&2
-    cat "$tmpdir/ht.log" >&2
+    cat "$ok/out.log" >&2
     exit 1
 }
-grep -q "^CONNECT 127.0.0.1:${origin_port} " "$log" || {
+grep -q "^CONNECT 127.0.0.1:${origin_port} " "$ok/proxy.log" || {
     echo "FAIL: proxy never received a CONNECT (https bypassed the proxy)" >&2
-    cat "$log" >&2
+    cat "$ok/proxy.log" >&2
     exit 1
 }
 echo "OK: https tunneled through proxy via CONNECT"
 
-# 2. proxy with credentials: auth must ride the CONNECT, not the tunneled GET
-: >"$log"
-run_crawl "$tmpdir/out2" "user:secret@127.0.0.1:${proxy_port}"
-grep -rq "ORIGIN-PAGE-85" "$tmpdir/out2" || {
+# 2. authenticated proxy: creds ride the CONNECT, and NEVER reach the origin
+: >"$ok/proxy.log"
+: >"$ok/origin-headers.log"
+run_crawl "$ok/out2" "user:secret@127.0.0.1:${proxy_port}" "$origin_port"
+grep -rq "ORIGIN-PAGE-85" "$ok/out2" || {
     echo "FAIL: origin page not downloaded through authenticated proxy" >&2
     exit 1
 }
-got=$(awk '/^AUTH Basic /{print $3}' "$log" | head -1 | base64 -d 2>/dev/null || true)
-test "$got" == "user:secret" || {
+got=$(awk '/^AUTH Basic /{print $3}' "$ok/proxy.log" | head -1)
+# base64("user:secret"); compared as a literal to stay portable (no base64 -d,
+# which differs between GNU and BSD)
+test "$got" == "dXNlcjpzZWNyZXQ=" || {
     echo "FAIL: Proxy-Authorization not carried on CONNECT (got '$got')" >&2
-    cat "$log" >&2
+    cat "$ok/proxy.log" >&2
     exit 1
 }
-echo "OK: proxy credentials carried on CONNECT"
+if grep -qi "proxy-authorization" "$ok/origin-headers.log"; then
+    echo "FAIL: proxy credentials leaked to the origin through the tunnel" >&2
+    cat "$ok/origin-headers.log" >&2
+    exit 1
+fi
+echo "OK: proxy credentials carried on CONNECT, not leaked to origin"
+
+# --- hostile proxy ----------------------------------------------------------
+# A proxy that answers 200 then streams headers forever must not hang the crawl:
+# the client bounds the response. run_crawl kills a hung httrack after 60s, so a
+# missing bound surfaces as $HANG_RC here.
+flood="$tmpdir/flood"
+start_server "$flood" flood
+rc=0
+run_crawl "$flood/out" "127.0.0.1:${proxy_port}" "$origin_port" || rc=$?
+test "$rc" -ne "$HANG_RC" || {
+    echo "FAIL: crawl hung on a flooding proxy (bounded read missing)" >&2
+    exit 1
+}
+grep -rq "ORIGIN-PAGE-85" "$flood/out" 2>/dev/null && {
+    echo "FAIL: flooding proxy unexpectedly served the page" >&2
+    exit 1
+}
+echo "OK: bounded proxy response, no hang on a flooding proxy"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,6 +2,7 @@
 # explicitly: automake does not expand wildcards in EXTRA_DIST, so a glob would
 # silently drop it from the dist tarball and break "make distcheck".
 EXTRA_DIST = $(TESTS) crawl-test.sh run-all-tests.sh check-network.sh \
+	proxy-https-server.py \
 	fixtures/cache-golden/hts-cache/new.zip
 
 TESTS_ENVIRONMENT =
@@ -44,6 +45,7 @@ TESTS = \
 	11_crawl-international.test \
 	11_crawl-longurl.test \
 	11_crawl-parsing.test \
-	12_crawl_https.test
+	12_crawl_https.test \
+	13_crawl_proxy_https.test
 
 CLEANFILES = check-network_sh.cache

--- a/tests/proxy-https-server.py
+++ b/tests/proxy-https-server.py
@@ -3,13 +3,20 @@
 
 Starts a TLS origin server and an HTTP proxy that honours CONNECT, on ephemeral
 ports. Every request line the proxy receives (and any Proxy-Authorization) is
-appended to the log file, so the test can assert that an https crawl really
-tunneled through the proxy instead of bypassing it.
+appended to the proxy log; every header the origin receives over the tunnel is
+appended to the origin log. That lets the test assert both that an https crawl
+tunneled through the proxy and that proxy credentials never leaked to the origin.
 
-Usage: proxy-https-server.py <cert.pem> <logfile>
+Proxy modes (argv[3], default "ok"):
+  ok    - honour CONNECT and tunnel to the origin
+  flood - answer 200 then stream headers forever with no blank line, to exercise
+          the client's bound on the proxy response (must not hang the crawl)
+
+Usage: proxy-https-server.py <cert.pem> <logdir> [mode]
 Prints "ORIGIN <port>", "PROXY <port>", then "ready" (one per line) on stdout.
 """
 import http.server
+import os
 import socket
 import socketserver
 import ssl
@@ -17,22 +24,30 @@ import sys
 import threading
 
 ORIGIN_BODY = b"<html><body>ORIGIN-PAGE-85</body></html>"
+PROXY_LOG = "proxy.log"
+ORIGIN_LOG = "origin-headers.log"
 
 
-class Origin(http.server.BaseHTTPRequestHandler):
-    def do_GET(self):
-        self.send_response(200)
-        self.send_header("Content-Type", "text/html")
-        self.send_header("Content-Length", str(len(ORIGIN_BODY)))
-        self.end_headers()
-        self.wfile.write(ORIGIN_BODY)
+def make_origin(logdir):
+    class Origin(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            with open(os.path.join(logdir, ORIGIN_LOG), "a") as handle:
+                for key in self.headers.keys():
+                    handle.write(key + "\n")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(ORIGIN_BODY)))
+            self.end_headers()
+            self.wfile.write(ORIGIN_BODY)
 
-    def log_message(self, *args):
-        pass
+        def log_message(self, *args):
+            pass
+
+    return Origin
 
 
-def start_origin(certfile):
-    httpd = socketserver.TCPServer(("127.0.0.1", 0), Origin)
+def start_origin(certfile, logdir):
+    httpd = socketserver.TCPServer(("127.0.0.1", 0), make_origin(logdir))
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     ctx.load_cert_chain(certfile)
     httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
@@ -58,7 +73,7 @@ def pipe(src, dst):
                 pass
 
 
-def handle_client(conn, logfile):
+def handle_client(conn, logdir, mode):
     rfile = conn.makefile("rb")
     request_line = rfile.readline().decode("latin-1").strip()
     auth = None
@@ -69,28 +84,39 @@ def handle_client(conn, logfile):
         key, _, value = line.partition(":")
         if key.strip().lower() == "proxy-authorization":
             auth = value.strip()
-    with open(logfile, "a") as handle:
+    with open(os.path.join(logdir, PROXY_LOG), "a") as handle:
         handle.write(request_line + "\n")
         if auth is not None:
             handle.write("AUTH " + auth + "\n")
     parts = request_line.split()
-    if len(parts) >= 2 and parts[0] == "CONNECT":
-        host, _, port = parts[1].partition(":")
-        try:
-            upstream = socket.create_connection((host, int(port or 443)))
-        except OSError:
-            conn.sendall(b"HTTP/1.0 502 Bad Gateway\r\n\r\n")
-            conn.close()
-            return
-        conn.sendall(b"HTTP/1.0 200 Connection established\r\n\r\n")
-        threading.Thread(target=pipe, args=(conn, upstream), daemon=True).start()
-        pipe(upstream, conn)
-    else:
+    if not (len(parts) >= 2 and parts[0] == "CONNECT"):
         conn.sendall(b"HTTP/1.0 501 Not Implemented\r\n\r\n")
         conn.close()
+        return
+    if mode == "flood":
+        # 200, then an endless header stream with no terminating blank line: the
+        # client must bound this and give up, not hang.
+        try:
+            conn.sendall(b"HTTP/1.0 200 Connection established\r\n")
+            while True:
+                conn.sendall(b"X-Pad: 0123456789\r\n")
+        except OSError:
+            pass
+        conn.close()
+        return
+    host, _, port = parts[1].partition(":")
+    try:
+        upstream = socket.create_connection((host, int(port or 443)))
+    except OSError:
+        conn.sendall(b"HTTP/1.0 502 Bad Gateway\r\n\r\n")
+        conn.close()
+        return
+    conn.sendall(b"HTTP/1.0 200 Connection established\r\n\r\n")
+    threading.Thread(target=pipe, args=(conn, upstream), daemon=True).start()
+    pipe(upstream, conn)
 
 
-def start_proxy(logfile):
+def start_proxy(logdir, mode):
     srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     srv.bind(("127.0.0.1", 0))
@@ -101,7 +127,7 @@ def start_proxy(logfile):
         while True:
             conn, _ = srv.accept()
             threading.Thread(
-                target=handle_client, args=(conn, logfile), daemon=True
+                target=handle_client, args=(conn, logdir, mode), daemon=True
             ).start()
 
     threading.Thread(target=serve, daemon=True).start()
@@ -109,10 +135,12 @@ def start_proxy(logfile):
 
 
 def main():
-    certfile, logfile = sys.argv[1], sys.argv[2]
-    open(logfile, "w").close()
-    origin_port = start_origin(certfile)
-    proxy_port = start_proxy(logfile)
+    certfile, logdir = sys.argv[1], sys.argv[2]
+    mode = sys.argv[3] if len(sys.argv) > 3 else "ok"
+    for name in (PROXY_LOG, ORIGIN_LOG):
+        open(os.path.join(logdir, name), "w").close()
+    origin_port = start_origin(certfile, logdir)
+    proxy_port = start_proxy(logdir, mode)
     print("ORIGIN %d" % origin_port, flush=True)
     print("PROXY %d" % proxy_port, flush=True)
     print("ready", flush=True)

--- a/tests/proxy-https-server.py
+++ b/tests/proxy-https-server.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Local CONNECT proxy + self-signed HTTPS origin for the issue #85 test.
+
+Starts a TLS origin server and an HTTP proxy that honours CONNECT, on ephemeral
+ports. Every request line the proxy receives (and any Proxy-Authorization) is
+appended to the log file, so the test can assert that an https crawl really
+tunneled through the proxy instead of bypassing it.
+
+Usage: proxy-https-server.py <cert.pem> <logfile>
+Prints "ORIGIN <port>", "PROXY <port>", then "ready" (one per line) on stdout.
+"""
+import http.server
+import socket
+import socketserver
+import ssl
+import sys
+import threading
+
+ORIGIN_BODY = b"<html><body>ORIGIN-PAGE-85</body></html>"
+
+
+class Origin(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.send_header("Content-Length", str(len(ORIGIN_BODY)))
+        self.end_headers()
+        self.wfile.write(ORIGIN_BODY)
+
+    def log_message(self, *args):
+        pass
+
+
+def start_origin(certfile):
+    httpd = socketserver.TCPServer(("127.0.0.1", 0), Origin)
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(certfile)
+    httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
+    port = httpd.socket.getsockname()[1]
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return port
+
+
+def pipe(src, dst):
+    try:
+        while True:
+            data = src.recv(65536)
+            if not data:
+                break
+            dst.sendall(data)
+    except OSError:
+        pass
+    finally:
+        for sock in (src, dst):
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+
+
+def handle_client(conn, logfile):
+    rfile = conn.makefile("rb")
+    request_line = rfile.readline().decode("latin-1").strip()
+    auth = None
+    while True:
+        line = rfile.readline().decode("latin-1")
+        if line in ("\r\n", "\n", ""):
+            break
+        key, _, value = line.partition(":")
+        if key.strip().lower() == "proxy-authorization":
+            auth = value.strip()
+    with open(logfile, "a") as handle:
+        handle.write(request_line + "\n")
+        if auth is not None:
+            handle.write("AUTH " + auth + "\n")
+    parts = request_line.split()
+    if len(parts) >= 2 and parts[0] == "CONNECT":
+        host, _, port = parts[1].partition(":")
+        try:
+            upstream = socket.create_connection((host, int(port or 443)))
+        except OSError:
+            conn.sendall(b"HTTP/1.0 502 Bad Gateway\r\n\r\n")
+            conn.close()
+            return
+        conn.sendall(b"HTTP/1.0 200 Connection established\r\n\r\n")
+        threading.Thread(target=pipe, args=(conn, upstream), daemon=True).start()
+        pipe(upstream, conn)
+    else:
+        conn.sendall(b"HTTP/1.0 501 Not Implemented\r\n\r\n")
+        conn.close()
+
+
+def start_proxy(logfile):
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(16)
+    port = srv.getsockname()[1]
+
+    def serve():
+        while True:
+            conn, _ = srv.accept()
+            threading.Thread(
+                target=handle_client, args=(conn, logfile), daemon=True
+            ).start()
+
+    threading.Thread(target=serve, daemon=True).start()
+    return port
+
+
+def main():
+    certfile, logfile = sys.argv[1], sys.argv[2]
+    open(logfile, "w").close()
+    origin_port = start_origin(certfile)
+    proxy_port = start_proxy(logfile)
+    print("ORIGIN %d" % origin_port, flush=True)
+    print("PROXY %d" % proxy_port, flush=True)
+    print("ready", flush=True)
+    threading.Event().wait()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
httrack ignored `--proxy` for `https://` URLs: it connected straight to the origin and used the real IP, so the proxy was never touched (confirmed across 3.48–3.49 on Windows and Linux). `http_xfopen` had an explicit carve-out that bypassed the proxy for any https URL, because the absolute-URI form it sends to a proxy for plain http cannot carry https, and the real alternative — a CONNECT tunnel — was never implemented.

This connects to the proxy for https too, then opens an HTTP CONNECT tunnel before the TLS handshake so TLS runs end-to-end with the origin. Proxy credentials move onto the CONNECT request; on the old path they rode the inner GET, which over a tunnel would hand them to the origin instead of the proxy.

The tunnel is a bounded blocking exchange in the existing `back_wait` connect path rather than a new async state. A non-blocking version would need to persist a partial-read buffer on `htsblk`/`lien_back`, which live in the installed header — an ABI break for a few-byte proxy reply. The helpers stay visibility-hidden, so there is no struct change and no soname bump.

`13_crawl_proxy_https.test` covers it locally: a self-signed https origin behind a logging CONNECT proxy, asserting the proxy actually saw the CONNECT and that credentials ride it. The assertion fails on the pre-fix bypass.

Closes #85.