### PR TITLE
Don't crawl xmlns namespace declarations

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -1692,6 +1692,24 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                                               hts_nodetect[i -
                                                                            1]);
                                               }
+                                              // xmlns / xmlns:prefix declare
+                                              // XML namespaces, not resources
+                                              // (#191)
+                                              else {
+                                                const int xl = strfield(
+                                                    intag_startattr, "xmlns");
+                                                const char xc =
+                                                    intag_startattr[xl];
+                                                if (xl &&
+                                                    (xc == ':' || xc == '=' ||
+                                                     is_space(xc))) {
+                                                  url_ok = 0;
+                                                  hts_log_print(
+                                                      opt, LOG_DEBUG,
+                                                      "dirty parsing: xmlns "
+                                                      "namespace avoided");
+                                                }
+                                              }
                                             }
                                   }
 

--- a/tests/01_engine-parse.test
+++ b/tests/01_engine-parse.test
@@ -154,4 +154,26 @@ grep -Eq "style=\"background-image:url\('ibgs\.gif'\)\"" "$saved2" ||
 grep -q 'title="file://' "$saved2" ||
     ! echo "FAIL: a no-detect attribute (title) was wrongly rewritten" || exit 1
 
+# xmlns / xmlns:prefix decls must not be crawled (#191). Local file:// targets so a
+# regression downloads them; each is the LAST attr (heuristic only scans a value before '>').
+site3="$tmp/xmlns"
+mkdir -p "$site3"
+for f in ns og rdfs real; do gif "$site3/$f.gif"; done
+cat >"$site3/index.html" <<EOF
+<html xmlns="file://$site3/ns.gif"><body>
+<svg xmlns:og="file://$site3/og.gif"></svg>
+<div class="c" xmlns:rdfs="file://$site3/rdfs.gif"></div>
+<a href="file://$site3/real.gif">real link</a>
+</body></html>
+EOF
+out3="$tmp/xmlns-out"
+crawl "$site3/index.html" "$out3"
+
+# the real link is still captured
+found "real.gif" "$out3"
+# namespace-declaration targets must not be fetched (default + prefixed forms)
+notfound "ns.gif" "$out3"
+notfound "og.gif" "$out3"
+notfound "rdfs.gif" "$out3"
+
 exit 0


### PR DESCRIPTION
HTTrack treated `xmlns` and `xmlns:prefix` attributes on tags as ordinary links. Their values are namespace URIs (`xmlns:og="http://ogp.me/ns#"`, `xmlns:rdfs=...`), not resources, so the crawler queued and fetched them, spending its time on unrelated spec URLs instead of the site. The reporter saw this on pages like `ethnologue.com` and could not suppress it with `--priority`, `--stay-on-same-address`, or robots settings, because the URIs were being discovered as real links before any domain rule applied.

The culprit is the "dirty parsing" heuristic, which accepts any attribute value that looks like a URL unless the attribute is on the no-detect list. The fix rejects `xmlns`/`xmlns:prefix` at that same point, so namespace declarations are never queued.

The parser only inspects an attribute whose value is immediately followed by `>` (or `,;)/` + newline), so the parse self-test fixture places each form (default and prefixed) as the last attribute of its element; otherwise the assertion would pass regardless of the fix. Targets are local `file://` gifs so a regression actually downloads them, and reverting the guard fetches all three.

Closes #191