### PR TITLE
CSS @import: capture URLs that carry a media/supports/layer condition (#94)

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -1341,6 +1341,9 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                     int can_avoid_quotes = 0;
                     char quotes_replacement = '\0';
                     int ensure_not_mime = 0;
+                    // @import: the quoted token is the URL; a trailing
+                    // media/supports/layer condition is not part of it
+                    int is_import = 0;
 
                     if (inscript_tag)
                       expected_end = ";\"\'";   // voir a href="javascript:doc.location='foo'"
@@ -1390,6 +1393,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                         if ((nc = strfield(html, "import"))) {   // import "url"
                           if (is_space(*(html + nc))) {
                             expected = 0;       // no char expected
+                            is_import = 1;
                           } else
                             nc = 0;
                         }
@@ -1425,8 +1429,10 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                             while(*c == ' ')
                               c++;
                             if ((strchr(expected_end, *c)) || (*c == '\n')
-                                || (*c == '\r')) {
-                              c -= (ndelim + 1);
+                                || (*c == '\r')
+                                || (is_import && *(b + 1 + ndelim) == ' ')) {
+                              // URL end = last char (b), not the delimiter
+                              c = b;
                               if ((int) (c - a + 1)) {
                                 if (ensure_not_mime) {
                                   int i = 0;

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -1411,6 +1411,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                           if ((*a == 34) || (*a == '\'') || (can_avoid_quotes)) {
                             const char *b, *c;
                             int ndelim = 1;
+                            int valid_url = 0;
 
                             if ((*a == 34) || (*a == '\''))
                               a++;
@@ -1425,12 +1426,18 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                 b++;
                             }
                             c = b--;
-                            c += ndelim;
-                            while(*c == ' ')
-                              c++;
-                            if ((strchr(expected_end, *c)) || (*c == '\n')
-                                || (*c == '\r')
-                                || (is_import && *(b + 1 + ndelim) == ' ')) {
+                            // no closing delimiter here (truncated input):
+                            // Don't scan past the buffer NUL or capture it.
+                            if (*c != '\0') {
+                              c += ndelim;
+                              while (*c == ' ')
+                                c++;
+                              valid_url =
+                                  (strchr(expected_end, *c)) || (*c == '\n') ||
+                                  (*c == '\r') ||
+                                  (is_import && *(b + 1 + ndelim) == ' ');
+                            }
+                            if (valid_url) {
                               // URL end = last char (b), not the delimiter
                               c = b;
                               if ((int) (c - a + 1)) {
@@ -1491,7 +1498,6 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                 }
                               }
                             }
-
                           }
                         }
                       }

--- a/tests/01_engine-parse.test
+++ b/tests/01_engine-parse.test
@@ -176,4 +176,27 @@ notfound "ns.gif" "$out3"
 notfound "og.gif" "$out3"
 notfound "rdfs.gif" "$out3"
 
+# CSS @import (#94): every form's target is captured, crawling the .css directly.
+# The "cond"/"sup"/"spc" cases carry a trailing media/supports/layer condition (or
+# a space before ';'); they are the negative controls: without the parser fix the
+# URL is dropped, so a regression fails these found() checks.
+site4="$tmp/cssimport"
+mkdir -p "$site4"
+for f in nq dqu squ dqs sqs med cond sup lay spc; do printf 'body{}\n' >"$site4/$f.css"; done
+cat >"$site4/main.css" <<'EOF'
+@import url(nq.css);
+@import url("dqu.css");
+@import url('squ.css');
+@import "dqs.css";
+@import 'sqs.css';
+@import url(med.css) screen and (min-width: 400px);
+@import "cond.css" screen;
+@import "sup.css" supports(display: flex);
+@import url(lay.css) layer(base);
+@import "spc.css" ;
+EOF
+out4="$tmp/cssimport-out"
+crawl "$site4/main.css" "$out4"
+for f in nq dqu squ dqs sqs med cond sup lay spc; do found "$f.css" "$out4"; done
+
 exit 0

--- a/tests/01_engine-parse.test
+++ b/tests/01_engine-parse.test
@@ -199,4 +199,25 @@ out4="$tmp/cssimport-out"
 crawl "$site4/main.css" "$out4"
 for f in nq dqu squ dqs sqs med cond sup lay spc; do found "$f.css" "$out4"; done
 
+# Over-capture guard: the trailing condition is not part of the URL, so it must
+# survive the rewrite verbatim. A regression that grabs it would mangle these.
+m4=$(find "$out4" -type f -path '*/file/*' -name main.css -print -quit)
+test -n "$m4" || ! echo "FAIL: saved main.css not found" || exit 1
+for cond in '@import "cond.css" screen;' 'supports(display: flex)' 'layer(base)'; do
+    grep -Fq "$cond" "$m4" ||
+        ! echo "FAIL #94: '$cond' altered on rewrite (condition captured as URL?)" || exit 1
+done
+
+# Malformed input: an unterminated @import quote (truncated CSS) must not crash or
+# capture a bogus link; a valid sibling import is still captured. Guards a heap
+# overflow on the URL-end scan that aborts under ASan (CI sanitizer job).
+site5="$tmp/cssimport-trunc"
+mkdir -p "$site5"
+printf 'body{}\n' >"$site5/good.css"
+printf '@import "good.css";\n@import "trunc' >"$site5/main.css"
+out5="$tmp/cssimport-trunc-out"
+crawl "$site5/main.css" "$out5"
+found "good.css" "$out5"
+notfound "trunc" "$out5"
+
 exit 0


### PR DESCRIPTION
httrack already mirrors plain `@import url(x)` and quoted `@import "x"`, so the original report was mostly fixed-but-unreleased. The real gap was a bare-quoted import carrying a trailing condition, e.g. `@import "theme.css" screen;` or `@import "x.css" supports(...)`, which the link detector dropped: it required the closing quote to be immediately followed by the statement terminator, while the `url(...)` form escaped this by terminating at the paren. The fix accepts a whitespace-separated trailing condition after a quoted @import URL, and bounds the captured URL at its last content char rather than recomputing from the terminator. The old recompute mishandled spaces skipped before the terminator, which also silently broke `foo="url" ;` (a space before the semicolon) for every quoted detection, not just @import.

Reviewing this with ASan turned up a pre-existing heap buffer overflow on the same code: a truncated token with no closing delimiter before the buffer ends (`@import "x`, `url("x`) let the URL-end scan step past the buffer NUL, so crawling such input aborts under ASan on master. The second commit guards it by skipping the scan and capture when no closing delimiter is found; well-formed tokens are unaffected. A truncated-@import fixture exercises it under the CI sanitizer job, and the @import test section also asserts the trailing condition survives the rewrite verbatim (no over-capture).

A separate, distinct underflow is left for a focused follow-up (#396): `*(html - 1)` reads one byte before the buffer when a detected token sits at offset 0, e.g. a stylesheet whose entire content is `url(`. Different root cause and direction from the overflow fixed here.

Closes #94