### PR TITLE
htsparse: fix buffer underflow reading *(html-1) at offset 0 (#396)

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -296,6 +296,12 @@ static const char *html_inline_safe(const char *src, char *dst, size_t size) {
   return dst;
 }
 
+/* Byte before html, or a space sentinel at the buffer start where html[-1]
+   would underflow; space reads as the word boundary the guards want there. */
+static HTS_INLINE char html_prevc(const char *html, const char *start) {
+  return html > start ? html[-1] : ' ';
+}
+
 /* Main parser */
 int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
   char catbuff[CATBUFF_SIZE];
@@ -556,7 +562,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                   if (opt->getmode & HTS_GETMODE_HTML) {
                     p = strfield(html, "title");
                     if (p) {
-                      if (*(html - 1) == '/')
+                      if (html_prevc(html, r->adr) == '/')
                         p = 0;  // /title
                     } else {
                       if (strfield(html, "/html"))
@@ -1360,9 +1366,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                       if (!nc)
                         nc = strfield(html, ":location");        // javascript:location="doc"
                       if (!nc) {        // location="doc"
-                        if ((nc = strfield(html, "location"))
-                            && !isspace(*(html - 1))
-                          )
+                        if ((nc = strfield(html, "location")) &&
+                            !isspace(html_prevc(html, r->adr)))
                           nc = 0;
                       }
                       if (!nc)
@@ -1383,7 +1388,9 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                           expected = '(';       // parenthèse
                           expected_end = ")";   // fin: parenthèse
                         }
-                      if (!nc && (nc = strfield(html, "url")) && (!isalnum(*(html - 1))) && *(html - 1) != '_') {  // url(url)
+                      if (!nc && (nc = strfield(html, "url")) &&
+                          (!isalnum(html_prevc(html, r->adr))) &&
+                          html_prevc(html, r->adr) != '_') { // url(url)
                         expected = '('; // parenthèse
                         expected_end = ")";     // fin: parenthèse
                         can_avoid_quotes = 1;

--- a/tests/01_engine-parse.test
+++ b/tests/01_engine-parse.test
@@ -220,4 +220,15 @@ crawl "$site5/main.css" "$out5"
 found "good.css" "$out5"
 notfound "trunc" "$out5"
 
+# Offset-0 underflow (#396): a token at the buffer start makes the detector's
+# word-boundary guard read *(html-1) one byte early (aborts under ASan). The
+# url() target is still captured; here it just must not underflow.
+site6="$tmp/parse-off0"
+mkdir -p "$site6"
+printf 'body{}\n' >"$site6/off0.css"
+printf 'url(off0.css)\n' >"$site6/main.css"
+out6="$tmp/parse-off0-out"
+crawl "$site6/main.css" "$out6"
+found "off0.css" "$out6"
+
 exit 0


### PR DESCRIPTION
The link detector in `htsparse()` checks the byte before a matched token (`*(html-1)`) to require a word boundary, e.g. so `url(` is a real token and not the tail of `myurl(`. When the token is at the very start of the parse buffer, `html-1` points one byte before the allocation and the guard reads out of bounds. A stylesheet that begins with a bare `url(` is enough; ASan reports a one-byte heap underflow at the `url()` detection, and a normal build reads adjacent heap silently.

The fix routes the three guards reachable at offset 0 (the `url()` detection, the `location=` check, and the makeindex `/title` check) through a small `html_prevc()` helper that returns a space sentinel when `html` is at the buffer start. Space is the semantically correct stand-in: a token at offset 0 sits at a word boundary, so it stays a valid match rather than being rejected by a stray preceding byte. The remaining `*(html-1)` sites only run after `html` has already advanced past an opening tag or quote, so they can't underflow.

This is the follow-up to #94: that one fixed a read *past* the buffer on truncated tokens; this one fixes a read *before* the start.

The offset-0 case is now a fixture in `01_engine-parse.test` (a `.css` whose first byte begins a `url()` token). It aborts at `htsparse.c:1386` under the sanitizer job without the fix and passes clean with it; I confirmed both directions locally under ASan+UBSan.

Closes #396