### PR TITLE
htsparse: don't treat XHR.open's method argument as a URL (#218)

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -302,6 +302,21 @@ static HTS_INLINE char html_prevc(const char *html, const char *start) {
   return html > start ? html[-1] : ' ';
 }
 
+/* True if [s, s+len) is exactly an HTTP method token (XHR.open's first
+   argument is a method, not a URL: #218). Case-insensitive. */
+static int is_http_method(const char *s, size_t len) {
+  static const char *const methods[] = {"GET",    "POST",  "PUT",
+                                        "DELETE", "HEAD",  "OPTIONS",
+                                        "PATCH",  "TRACE", NULL};
+  int i;
+
+  for (i = 0; methods[i] != NULL; i++) {
+    if (strlen(methods[i]) == len && strfield(s, methods[i]) == (int) len)
+      return 1;
+  }
+  return 0;
+}
+
 /* Main parser */
 int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
   char catbuff[CATBUFF_SIZE];
@@ -1347,6 +1362,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                     int can_avoid_quotes = 0;
                     char quotes_replacement = '\0';
                     int ensure_not_mime = 0;
+                    // .open(method,url): reject an HTTP-method first arg (#218)
+                    int ensure_not_method = 0;
                     // @import: the quoted token is the URL; a trailing
                     // media/supports/layer condition is not part of it
                     int is_import = 0;
@@ -1377,6 +1394,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                           expected = '(';       // parenthèse
                           expected_end = "),";  // fin: virgule ou parenthèse
                           ensure_not_mime = 1;  //* ensure the url is not a mime type */
+                          ensure_not_method = 1; // xhr.open: don't grab method
                         }
                       if (!nc)
                         if ((nc = strfield(html, ".replace"))) { // window.replace("url")
@@ -1461,6 +1479,11 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                     }
                                     i++;
                                   }
+                                }
+                                // XHR.open's "GET" etc. is a method, not a URL
+                                if (a != NULL && ensure_not_method &&
+                                    is_http_method(a, (size_t) (c - a + 1))) {
+                                  a = NULL;
                                 }
                                 // Check for bogus links (Vasiliy)
                                 if (a != NULL) {

--- a/tests/01_engine-parse.test
+++ b/tests/01_engine-parse.test
@@ -231,4 +231,37 @@ out6="$tmp/parse-off0-out"
 crawl "$site6/main.css" "$out6"
 found "off0.css" "$out6"
 
+# XMLHttpRequest.open(method, url) (#218): the first argument is an HTTP method,
+# not a URL. Without the fix "GET" is captured as a link and fetched (the offline
+# fixture saves a bare file named GET; a live server mangles it to GET.html).
+# window.open(url) detection must be unaffected.
+site7="$tmp/xhropen"
+mkdir -p "$site7"
+gif "$site7/winopen.gif"
+cat >"$site7/index.html" <<EOF
+<html><body><script>
+var x = new XMLHttpRequest();
+x.open("GET", "ajax_info.txt");
+var y = new XMLHttpRequest();
+y.open("Post", "submit.cgi");
+window.open("file://$site7/winopen.gif");
+</script></body></html>
+EOF
+out7="$tmp/xhropen-out"
+crawl "$site7/index.html" "$out7"
+# negative control: without the fix a file named exactly GET is downloaded
+notfound "GET" "$out7"
+# methods are matched case-insensitively (XHR spec normalizes them): a mixed-case
+# method is rejected too, so a file named Post must not appear either
+notfound "Post" "$out7"
+# regression guard: window.open(url) is still detected, so its absolute URL is
+# rewritten to a local link. The rewrite only happens if the parser saw it, so
+# these two assertions fail if .open detection broke (not a trivial --near save).
+saved7=$(savedhtml "$out7")
+test -n "$saved7" || ! echo "FAIL: saved xhr page not found" || exit 1
+grep -Fq 'window.open("winopen.gif")' "$saved7" ||
+    ! echo "FAIL #218: window.open(url) no longer detected/rewritten" || exit 1
+! grep -Fq 'window.open("file://' "$saved7" ||
+    ! echo "FAIL #218: window.open URL left absolute (not rewritten)" || exit 1
+
 exit 0


### PR DESCRIPTION
HTTrack scans JavaScript for URLs and matches `.open(` to catch `window.open("url", ...)`, capturing the first argument. `XMLHttpRequest.open(method, url)` shares that token but puts the HTTP method first, so `xhr.open("GET", "ajax_info.txt")` made `"GET"` a link and rewrote it to `"GET.html"` (the symptom in the report, seen all over w3schools example pages), corrupting the page's script.

The fix rejects a first argument that is exactly an HTTP method, mirroring the existing `ensure_not_mime` guard a couple of lines up. `window.open(url)` is untouched, and the real XHR target (the second argument) is still picked up by the aggressive parser, so nothing useful is lost. Worst case is a `window.open("post")` to a page literally named like a method no longer being mirrored, which is rare and at least non-destructive, unlike the corruption it replaces.

Tested in `01_engine-parse.test`: an XHR.open page no longer downloads a `GET` file and keeps the method token verbatim on rewrite, while `window.open(url)` still resolves. Negative control confirmed (the `GET` file appears without the guard).

Closes #218