### PR TITLE
Test the relative-link engine; collapse ../ in file:// URLs

### DIFF
--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -2787,6 +2787,47 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                   return 0;
                 }
                 break;
+              case 'l': /* lienrelatif: relative link from curr_fil to link */
+                if (na + 2 >= argc) {
+                  HTS_PANIC_PRINTF(
+                      "Option #l needs a link and a current-file path");
+                  printf(
+                      "Example: '-#l' 'host/dir/img.gif' 'host/dir/p.html'\n");
+                  htsmain_free();
+                  return -1;
+                } else {
+                  char s[HTS_URLMAXSIZE * 2];
+
+                  if (lienrelatif(s, sizeof(s), argv[na + 1], argv[na + 2]) ==
+                      0)
+                    printf("relative=%s\n", s);
+                  else
+                    printf("relative=<ERROR>\n");
+                  htsmain_free();
+                  return 0;
+                }
+                break;
+              case 'i': /* ident_url_relatif: resolve a link -> adr/fil */
+                if (na + 3 >= argc) {
+                  HTS_PANIC_PRINTF(
+                      "Option #i needs a link, an origin address and file");
+                  printf("Example: '-#i' '../img.gif' 'www.foo.com' "
+                         "'/d/p.html'\n");
+                  htsmain_free();
+                  return -1;
+                } else {
+                  lien_adrfil af;
+                  const int r = ident_url_relatif(argv[na + 1], argv[na + 2],
+                                                  argv[na + 3], &af);
+
+                  if (r == 0)
+                    printf("adr=%s fil=%s\n", af.adr, af.fil);
+                  else
+                    printf("error=%d\n", r);
+                  htsmain_free();
+                  return 0;
+                }
+                break;
               case '2':        // mimedefs
                 if (na + 1 >= argc) {
                   HTS_PANIC_PRINTF("Option #2 needs to be followed by an URL");

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -2605,6 +2605,8 @@ int ident_url_absolute(const char *url, lien_adrfil *adrfil) {
     for(i = 0; adrfil->fil[i] != '\0'; i++)
       if (adrfil->fil[i] == '\\')
         adrfil->fil[i] = '/';
+    // collapse ../ like the http branch above (path-traversal safety)
+    fil_simplifie(adrfil->fil);
   }
 
   // no hostname

--- a/tests/01_engine-relative.test
+++ b/tests/01_engine-relative.test
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# lienrelatif (build relative path) + ident_url_relatif (resolve a link, collapse
+# ./ and ../). Regression net for #137/#162; expected values hand-computed.
+
+set -euo pipefail
+
+# relative path from <curr>'s directory to <link>
+rel() {
+	local got
+	got=$(httrack -O /dev/null -#l "$1" "$2")
+	test "$got" == "relative=$3" ||
+		{ echo "FAIL rel($1, $2): got '$got' want 'relative=$3'"; exit 1; }
+}
+
+# resolve <link> against origin <adr>/<fil> -> adr=.. fil=..
+ident() {
+	local got
+	got=$(httrack -O /dev/null -#i "$1" "$2" "$3")
+	test "$got" == "$4" ||
+		{ echo "FAIL ident($1, $2, $3): got '$got' want '$4'"; exit 1; }
+}
+
+### lienrelatif
+
+rel 'dir/page.html'        'dir/index.html'        'page.html'
+rel 'dir/page.html'        'dir/page.html'         'page.html'   # self-link
+rel 'a.html'               'dir/index.html'        '../a.html'
+rel 'x.html'               'a/b/c/index.html'      '../../../x.html'
+rel 'h/a/x.jpg'            'h/a/sub/page.html'     '../x.jpg'
+rel 'a/b/c/x.html'         'index.html'            'a/b/c/x.html'
+rel 'h/sub/x.jpg'          'h/page.html'           'sub/x.jpg'
+rel 'h/dir2/x.jpg'         'h/dir1/page.html'      '../dir2/x.jpg'   # sibling dir
+rel 'h/bc/x.jpg'           'h/b/page.html'         '../bc/x.jpg'     # b/bc prefix trap
+rel 'h/b/x.jpg'            'h/bc/page.html'        '../b/x.jpg'
+rel 'h2/img/x.jpg'         'h1/p/page.html'        '../../h2/img/x.jpg'   # cross-host
+rel 'img.cdn/photo.jpg'    'www.site/articles/2020/post.html' '../../../img.cdn/photo.jpg'
+rel 'h/a/'                 'h/a/sub/page.html'     '../'             # link is ancestor dir
+rel 'x.html'               'page.html'             'x.html'
+rel 'dir/page.html?x=1'    'dir/index.html?y=2'    'page.html'       # ? stripped
+
+### ident_url_relatif
+
+ident 'img.gif'      'www.foo.com' '/dir/page.html'     'adr=www.foo.com fil=/dir/img.gif'
+ident 'sub/img.gif'  'www.foo.com' '/dir/page.html'     'adr=www.foo.com fil=/dir/sub/img.gif'
+ident '/img.gif'     'www.foo.com' '/dir/page.html'     'adr=www.foo.com fil=/img.gif'
+# embedded ../ collapses (#137)
+ident '../img.gif'             'www.foo.com' '/dir/sub/page.html'        'adr=www.foo.com fil=/dir/img.gif'
+ident 'sub/../logo.png'        'www.foo.com' '/articles/2020/post.html' 'adr=www.foo.com fil=/articles/2020/logo.png'
+ident '../../pix/sub/../logo.png' 'www.foo.com' '/articles/2020/post.html' 'adr=www.foo.com fil=/pix/logo.png'
+ident '../../../../x.gif'      'www.foo.com' '/a/b/page.html'           'adr=www.foo.com fil=/x.gif'   # above-root clamp
+ident '?page=2'      'www.foo.com' '/dir/index.html?old=1' 'adr=www.foo.com fil=/dir/index.html?page=2'
+ident 'http://other.com/a/b/../c/index.html' 'www.foo.com' '/p.html' 'adr=other.com fil=/a/c/index.html'
+# file:// collapses ../ like the other schemes; traversal contained, // authority kept
+ident 'file:///var/data/pix/sub/../logo.png' 'www.foo.com' '/p.html' 'adr=file:// fil=/var/data/pix/logo.png'
+ident 'file:///a/b/c/../../d/e.gif'          'www.foo.com' '/p.html' 'adr=file:// fil=/a/d/e.gif'
+ident 'file:///a/../../b'        'www.foo.com' '/p.html' 'adr=file:// fil=/b'
+ident 'file://srv/share/../x'    'www.foo.com' '/p.html' 'adr=file:// fil=//srv/x'
+ident 'mailto:foo@bar.com'   'www.foo.com' '/p.html'    'error=-1'   # unsupported scheme
+ident 'javascript:void(0)'   'www.foo.com' '/p.html'    'error=-1'
+
+echo "OK"

--- a/tests/01_engine-simplify.test
+++ b/tests/01_engine-simplify.test
@@ -26,3 +26,17 @@ simp './a/../../b' 'b'
 
 # empty segments ('//') are not dot-segments and are preserved, per RFC 3986
 simp 'a//b' 'a//b'
+simp 'a//b/../c' 'a//c'
+
+# absolute paths keep the leading '/'; above-root '..' is clamped to it
+simp '/a/../b' '/b'
+simp '/a/../../b' '/b'
+simp '/../x' '/x'
+
+# collapses to nothing -> './' (relative) or '/' (absolute)
+simp '..' './'
+simp 'a/..' './'
+simp '/' '/'
+
+simp 'a/b/..' 'a/'              # trailing bare '..'
+simp 'a/../b?x=../y' 'b?x=../y' # '?' freezes simplification

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -35,6 +35,7 @@ TESTS = \
 	01_engine-mime.test \
 	01_engine-parse.test \
 	01_engine-rcfile.test \
+	01_engine-relative.test \
 	01_engine-simplify.test \
 	01_engine-strsafe.test \
 	02_manpage-regen.test \


### PR DESCRIPTION
The relative-link engine handles `../` correctly (embedded, cross-host, out-of-scope, above-root, every `-N` structure) on master and on the released 3.49.x alike, yet it had almost no direct coverage: two trivial `lienrelatif` assertions and none for `ident_url_relatif`, despite both feeding link rewriting and crawl-scope decisions. This adds a regression net.

Two hidden debug probes (`-#l` for `lienrelatif`, `-#i` for `ident_url_relatif`, alongside the existing `-#1` for `fil_simplifie`) drive `tests/01_engine-relative.test`: tens of cases across same-dir, multi-level, sibling and partial-prefix directories, cross-host depth, ancestor links, above-root clamping, query stripping, and scheme handling. `01_engine-simplify.test` gains the `fil_simplifie` edge cases it was missing (absolute paths, the root clamp, the `?`-query freeze). Expected values are computed by hand, not echoed back from the binary, so a regression actually fails.

Covering this surfaced one real gap, fixed here: the `file://` branch of `ident_url_absolute` skipped the `fil_simplifie` its http/https/ftp sibling runs a few lines up, so a `file://` URL kept its `../` in the resolved path while the save path was already collapsed (htsname.c). Collapsing it matches the other schemes, contains traversal at the file:// root (a `//server` authority is preserved), and lets `a/../b` and `b` dedup.

On #137 and #162: neither reproduces here. I chased #137's actual reproducer; famo.us is a parking page now, but the Wayback snapshot shows the broken iframe was built at runtime by the page's JavaScript, not present as static HTML, so it is the JS-generated-URL limitation rather than relative-path math. #162 is a 2014 Windows report whose cross-host case is correct on Linux; it likely needs a current Windows repro. Refs #137, #162.
