### PR TITLE
Lint every shell script with shfmt and shellcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,10 @@ jobs:
   lint:
     name: lint (shellcheck, shfmt)
     runs-on: ubuntu-24.04
+    # Every tracked shell script; the globs expand at run time. Kept here so the
+    # shellcheck and shfmt steps below cannot drift apart.
+    env:
+      SHELL_SCRIPTS: bootstrap build.sh .githooks/pre-commit html/div/search.sh man/makeman.sh src/htsbasiccharsets.sh src/htsentities.sh src/webhttrack tools/mkdeb.sh tests/*.test tests/*.sh
     steps:
       - uses: actions/checkout@v6
 
@@ -332,12 +336,11 @@ jobs:
           sudo apt-get install -y --no-install-recommends shellcheck shfmt
           shfmt --version
 
-      # Lint the scripts we maintain; the legacy scripts are a separate cleanup.
       - name: shellcheck
-        run: shellcheck man/makeman.sh tools/mkdeb.sh .githooks/pre-commit tests/*.test tests/check-network.sh
+        run: shellcheck $SHELL_SCRIPTS
 
       - name: shfmt
-        run: shfmt -d -i 4 man/makeman.sh tools/mkdeb.sh .githooks/pre-commit
+        run: shfmt -d -i 4 $SHELL_SCRIPTS
 
   # Check clang-format on CHANGED LINES ONLY. The engine predates clang-format
   # (it was shaped by an old Visual Studio formatter) and does not round-trip,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,18 @@ jobs:
     # Every tracked shell script; the globs expand at run time. Kept here so the
     # shellcheck and shfmt steps below cannot drift apart.
     env:
-      SHELL_SCRIPTS: bootstrap build.sh .githooks/pre-commit html/div/search.sh man/makeman.sh src/htsbasiccharsets.sh src/htsentities.sh src/webhttrack tools/mkdeb.sh tests/*.test tests/*.sh
+      SHELL_SCRIPTS: >-
+        .githooks/pre-commit
+        bootstrap
+        build.sh
+        html/div/search.sh
+        man/makeman.sh
+        src/htsbasiccharsets.sh
+        src/htsentities.sh
+        src/webhttrack
+        tests/*.sh
+        tests/*.test
+        tools/mkdeb.sh
     steps:
       - uses: actions/checkout@v6
 

--- a/html/div/search.sh
+++ b/html/div/search.sh
@@ -1,8 +1,7 @@
-
 #!/bin/sh
 
 # Simple indexing test using HTTrack
-# A "real" script/program would use advanced search, and 
+# A "real" script/program would use advanced search, and
 # use dichotomy to find the word in the index.txt file
 # This script is really basic and NOT optimized, and
 # should not be used for professional purpose :)
@@ -11,50 +10,49 @@ TESTSITE="http://localhost/"
 
 # Create an index if necessary
 if ! test -f "index.txt"; then
-	echo "Building the index .."
-	rm -rf test
-	httrack --display "$TESTSITE"  -%I -O test
-	mv test/index.txt ./
+    echo "Building the index .."
+    rm -rf test
+    httrack --display "$TESTSITE" -%I -O test
+    mv test/index.txt ./
 fi
 
 # Convert crlf to lf
-if test "`head index.txt -n 1 | tr '\r' '#' | grep -c '#'`" = "1"; then
-	echo "Converting index to Unix LF style (not CR/LF) .."
-	mv -f index.txt index.txt.old
-	cat index.txt.old|tr -d '\r' > index.txt
+if test "$(head index.txt -n 1 | tr '\r' '#' | grep -c '#')" = "1"; then
+    echo "Converting index to Unix LF style (not CR/LF) .."
+    mv -f index.txt index.txt.old
+    cat index.txt.old | tr -d '\r' >index.txt
 fi
 
 keyword=-
 while test -n "$keyword"; do
-	printf "Enter a keyword: "
-	read keyword
+    printf "Enter a keyword: "
+    read keyword
 
-	if test -n "$keyword"; then
-		FOUNDK="`grep -niE \"^$keyword\" index.txt`"
+    if test -n "$keyword"; then
+        FOUNDK="$(grep -niE \"^$keyword\" index.txt)"
 
-		if test -n "$FOUNDK"; then	
-			if ! test `echo "$FOUNDK"|wc -l` = "1"; then
-				# Multiple matches
-				printf "Found multiple keywords: "
-				echo "$FOUNDK"|cut -f2 -d':'|tr '\n' ' '
-				echo ""
-				echo "Use keyword$ to find only one"
-			else
-				# One match
-				N=`echo "$FOUNDK"|cut -f1 -d':'`
-				PM=`tail +$N index.txt|grep -nE "\("|head -n 1`
-				if ! echo "$PM"|grep "ignored">/dev/null; then
-					M=`echo $PM|cut -f1 -d':'`
-					echo "Found in:"
-					cat index.txt | tail "+$N" | head -n "$M" | grep -E "[0-9]* " | cut -f2 -d' '
-				else
-					echo "keyword ignored (too many hits)"
-				fi
-					fi
-		else
-			echo "not found"
-		fi
+        if test -n "$FOUNDK"; then
+            if ! test $(echo "$FOUNDK" | wc -l) = "1"; then
+                # Multiple matches
+                printf "Found multiple keywords: "
+                echo "$FOUNDK" | cut -f2 -d':' | tr '\n' ' '
+                echo ""
+                echo "Use keyword$ to find only one"
+            else
+                # One match
+                N=$(echo "$FOUNDK" | cut -f1 -d':')
+                PM=$(tail +$N index.txt | grep -nE "\(" | head -n 1)
+                if ! echo "$PM" | grep "ignored" >/dev/null; then
+                    M=$(echo $PM | cut -f1 -d':')
+                    echo "Found in:"
+                    cat index.txt | tail "+$N" | head -n "$M" | grep -E "[0-9]* " | cut -f2 -d' '
+                else
+                    echo "keyword ignored (too many hits)"
+                fi
+            fi
+        else
+            echo "not found"
+        fi
 
-	fi
+    fi
 done
-

--- a/html/div/search.sh
+++ b/html/div/search.sh
@@ -20,19 +20,19 @@ fi
 if test "$(head index.txt -n 1 | tr '\r' '#' | grep -c '#')" = "1"; then
     echo "Converting index to Unix LF style (not CR/LF) .."
     mv -f index.txt index.txt.old
-    cat index.txt.old | tr -d '\r' >index.txt
+    tr -d '\r' <index.txt.old >index.txt
 fi
 
 keyword=-
 while test -n "$keyword"; do
     printf "Enter a keyword: "
-    read keyword
+    read -r keyword
 
     if test -n "$keyword"; then
-        FOUNDK="$(grep -niE \"^$keyword\" index.txt)"
+        FOUNDK="$(grep -niE "^$keyword" index.txt)"
 
         if test -n "$FOUNDK"; then
-            if ! test $(echo "$FOUNDK" | wc -l) = "1"; then
+            if ! test "$(echo "$FOUNDK" | wc -l)" = "1"; then
                 # Multiple matches
                 printf "Found multiple keywords: "
                 echo "$FOUNDK" | cut -f2 -d':' | tr '\n' ' '
@@ -41,11 +41,11 @@ while test -n "$keyword"; do
             else
                 # One match
                 N=$(echo "$FOUNDK" | cut -f1 -d':')
-                PM=$(tail +$N index.txt | grep -nE "\(" | head -n 1)
+                PM=$(tail "+$N" index.txt | grep -nE "\(" | head -n 1)
                 if ! echo "$PM" | grep "ignored" >/dev/null; then
-                    M=$(echo $PM | cut -f1 -d':')
+                    M=$(echo "$PM" | cut -f1 -d':')
                     echo "Found in:"
-                    cat index.txt | tail "+$N" | head -n "$M" | grep -E "[0-9]* " | cut -f2 -d' '
+                    tail "+$N" index.txt | head -n "$M" | grep -E "[0-9]* " | cut -f2 -d' '
                 else
                     echo "keyword ignored (too many hits)"
                 fi

--- a/src/htsbasiccharsets.sh
+++ b/src/htsbasiccharsets.sh
@@ -13,14 +13,14 @@ if false; then
 fi
 
 # Produce code
-printf "/** GENERATED FILE ($0), DO NOT EDIT **/\n\n"
+printf '/** GENERATED FILE (%s), DO NOT EDIT **/\n\n' "$0"
 for i in *.TXT; do
     echo "processing $i" >&2
-    grep -vE "^(#|$)" $i | grep -E "^0x" | sed -e 's/[[:space:]]/ /g' | cut -f1,2 -d' ' |
+    grep -vE "^(#|$)" "$i" | grep -E "^0x" | sed -e 's/[[:space:]]/ /g' | cut -f1,2 -d' ' |
         (
             unset arr
-            while read LINE; do
-                from=$(($(echo $LINE | cut -f1 -d' ')))
+            while read -r LINE; do
+                from=$(($(echo "$LINE" | cut -f1 -d' ')))
                 if ! test -n "$from"; then
                     echo "error with $i" >&2
                     exit 1
@@ -28,22 +28,23 @@ for i in *.TXT; do
                     echo "out-of-range ($LINE) with $i" >&2
                     exit 1
                 fi
-                to=$(echo $LINE | cut -f2 -d' ')
-                arr[$from]=$to
+                to=$(echo "$LINE" | cut -f2 -d' ')
+                arr[from]=$to
             done
-            name=$(echo $i | tr 'A-Z' 'a-z' | tr '-' '_' | sed -e 's/\.txt//' -e 's/8859/iso_8859/')
-            printf "/* Table for $i */\nstatic const hts_UCS4 table_${name}[256] = {\n  "
-            i=0
-            while test "$i" -lt 256; do
-                if test "$i" -gt 0; then
+            # shellcheck disable=SC2018,SC2019 # charset filenames are ASCII; keep C-locale A-Z/a-z
+            name=$(echo "$i" | tr 'A-Z' 'a-z' | tr '-' '_' | sed -e 's/\.txt//' -e 's/8859/iso_8859/')
+            printf '/* Table for %s */\nstatic const hts_UCS4 table_%s[256] = {\n  ' "$i" "$name"
+            idx=0
+            while test "$idx" -lt 256; do
+                if test "$idx" -gt 0; then
                     printf ", "
-                    if test $((${i} % 8)) -eq 0; then
+                    if test $((idx % 8)) -eq 0; then
                         printf "\n  "
                     fi
                 fi
-                value=${arr[$i]:-0}
-                printf "0x%04x" $value
-                i=$((${i} + 1))
+                value=${arr[$idx]:-0}
+                printf "0x%04x" "$value"
+                idx=$((idx + 1))
             done
             printf " };\n\n"
         )
@@ -53,7 +54,8 @@ done
 # Indexes
 printf "static const struct {\n  const char *name;\n  const hts_UCS4 *table;\n} table_mappings[] = {\n"
 for i in *.TXT; do
-    name=$(echo $i | tr 'A-Z' 'a-z' | tr '-' '_' | sed -e 's/\.txt//' -e 's/8859/iso_8859/')
-    printf "  { \"$(echo $name | tr -d '_')\", table_${name} },\n"
+    # shellcheck disable=SC2018,SC2019 # charset filenames are ASCII; keep C-locale A-Z/a-z
+    name=$(echo "$i" | tr 'A-Z' 'a-z' | tr '-' '_' | sed -e 's/\.txt//' -e 's/8859/iso_8859/')
+    printf '  { "%s", table_%s },\n' "$(echo "$name" | tr -d '_')" "$name"
 done
 printf "  { NULL, NULL }\n};\n"

--- a/src/htsbasiccharsets.sh
+++ b/src/htsbasiccharsets.sh
@@ -3,57 +3,57 @@
 
 # Change this to download files
 if false; then
-echo "mget ftp://ftp.unicode.org/Public/MAPPINGS/ISO8859/8859-*.TXT" | lftp
-echo "mget ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/PC/CP*.TXT" | lftp
-echo "mget ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/CP*.TXT" | lftp
-echo "mget ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/EBCDIC/CP*.TXT" | lftp
-echo "mget ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/MISC/CP*.TXT" | lftp
-echo "mget ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/MISC/KOI8*.TXT" | lftp
-rm -f CP932.TXT CP936.TXT CP949.TXT CP950.TXT
+    echo "mget ftp://ftp.unicode.org/Public/MAPPINGS/ISO8859/8859-*.TXT" | lftp
+    echo "mget ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/PC/CP*.TXT" | lftp
+    echo "mget ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/CP*.TXT" | lftp
+    echo "mget ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/EBCDIC/CP*.TXT" | lftp
+    echo "mget ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/MISC/CP*.TXT" | lftp
+    echo "mget ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/MISC/KOI8*.TXT" | lftp
+    rm -f CP932.TXT CP936.TXT CP949.TXT CP950.TXT
 fi
 
 # Produce code
 printf "/** GENERATED FILE ($0), DO NOT EDIT **/\n\n"
-for i in *.TXT ; do
-  echo "processing $i" >&2
-  grep -vE "^(#|$)" $i | grep -E "^0x" | sed -e 's/[[:space:]]/ /g' | cut -f1,2 -d' ' | \
-  (
-    unset arr
-    while read LINE ; do
-      from=$[$(echo $LINE | cut -f1 -d' ')]
-      if ! test -n "$from"; then
-        echo "error with $i" >&2
-        exit 1
-      elif test $from -ge 256; then
-        echo "out-of-range ($LINE) with $i" >&2
-        exit 1
-      fi
-      to=$(echo $LINE | cut -f2 -d' ') 
-      arr[$from]=$to
-    done
-    name=$(echo $i | tr 'A-Z' 'a-z' | tr '-' '_' | sed -e 's/\.txt//' -e 's/8859/iso_8859/')
-    printf "/* Table for $i */\nstatic const hts_UCS4 table_${name}[256] = {\n  "
-    i=0
-    while test "$i" -lt 256; do
-      if test "$i" -gt 0; then
-        printf ", "
-        if test $[${i}%8] -eq 0; then
-          printf "\n  "
-        fi
-      fi
-      value=${arr[$i]:-0}
-      printf "0x%04x" $value
-      i=$[${i}+1]
-    done
-    printf " };\n\n"
-  )
-  echo "processed $i" >&2
+for i in *.TXT; do
+    echo "processing $i" >&2
+    grep -vE "^(#|$)" $i | grep -E "^0x" | sed -e 's/[[:space:]]/ /g' | cut -f1,2 -d' ' |
+        (
+            unset arr
+            while read LINE; do
+                from=$(($(echo $LINE | cut -f1 -d' ')))
+                if ! test -n "$from"; then
+                    echo "error with $i" >&2
+                    exit 1
+                elif test $from -ge 256; then
+                    echo "out-of-range ($LINE) with $i" >&2
+                    exit 1
+                fi
+                to=$(echo $LINE | cut -f2 -d' ')
+                arr[$from]=$to
+            done
+            name=$(echo $i | tr 'A-Z' 'a-z' | tr '-' '_' | sed -e 's/\.txt//' -e 's/8859/iso_8859/')
+            printf "/* Table for $i */\nstatic const hts_UCS4 table_${name}[256] = {\n  "
+            i=0
+            while test "$i" -lt 256; do
+                if test "$i" -gt 0; then
+                    printf ", "
+                    if test $((${i} % 8)) -eq 0; then
+                        printf "\n  "
+                    fi
+                fi
+                value=${arr[$i]:-0}
+                printf "0x%04x" $value
+                i=$((${i} + 1))
+            done
+            printf " };\n\n"
+        )
+    echo "processed $i" >&2
 done
 
 # Indexes
 printf "static const struct {\n  const char *name;\n  const hts_UCS4 *table;\n} table_mappings[] = {\n"
-for i in *.TXT ; do
-  name=$(echo $i | tr 'A-Z' 'a-z' | tr '-' '_' | sed -e 's/\.txt//' -e 's/8859/iso_8859/')
-  printf "  { \"$(echo $name | tr -d '_')\", table_${name} },\n"
+for i in *.TXT; do
+    name=$(echo $i | tr 'A-Z' 'a-z' | tr '-' '_' | sed -e 's/\.txt//' -e 's/8859/iso_8859/')
+    printf "  { \"$(echo $name | tr -d '_')\", table_${name} },\n"
 done
 printf "  { NULL, NULL }\n};\n"

--- a/src/htsentities.sh
+++ b/src/htsentities.sh
@@ -40,7 +40,7 @@ EOF
             -e 's/-->$//' \
             -e 's/\([^ ]*\) CDATA "&#\([^\"]*\);" -- \(.*\)/\1 \2 \3/' |
         (
-            read A
+            read -r A
             while test -n "$A"; do
                 ent="${A%% *}"
                 code=$(echo "$A" | cut -f2 -d' ')
@@ -52,8 +52,8 @@ EOF
                 m="$((1 << 32))"
                 while test "$i" -lt ${#ent}; do
                     d="$(echo -n "${ent:${i}:1}" | hexdump -v -e '/1 "%d"')"
-                    hash="$((((${hash} * ${a}) % (${m}) + ${d} + ${c}) % (${m})))"
-                    i=$((${i} + 1))
+                    hash="$((((hash * a) % (m) + d + c) % (m)))"
+                    i=$((i + 1))
                 done
                 echo -e "    /* $A */"
                 echo -e "  case ${hash}u:"
@@ -63,7 +63,7 @@ EOF
                 echo -e "    break;"
 
                 # next
-                read A
+                read -r A
             done
         )
     cat <<EOF

--- a/src/htsentities.sh
+++ b/src/htsentities.sh
@@ -33,43 +33,43 @@ EOF
         else
             GET "${url}"
         fi
-    ) \
-        | grep -E '^<!ENTITY [a-zA-Z0-9_]' \
-        | sed \
-        -e 's/<!ENTITY //' -e "s/[[:space:]][[:space:]]*/ /g" \
-        -e 's/-->$//' \
-        -e 's/\([^ ]*\) CDATA "&#\([^\"]*\);" -- \(.*\)/\1 \2 \3/'\
-| ( \
-        read A
-        while test -n "$A"; do
-            ent="${A%% *}"
-            code=$(echo "$A"|cut -f2 -d' ')
-            # compute hash
-            hash=0
-            i=0
-            a=1664525
-            c=1013904223
-            m="$[1 << 32]"
-            while test "$i" -lt ${#ent}; do
-                d="$(echo -n "${ent:${i}:1}"|hexdump -v -e '/1 "%d"')"
-                hash="$[((${hash}*${a})%(${m})+${d}+${c})%(${m})]"
-                i=$[${i}+1]
-            done
-            echo -e "    /* $A */"
-            echo -e "  case ${hash}u:"
-            echo -e "    if (len == ${#ent} /* && strncmp(ent, \"${ent}\") == 0 */) {"
-            echo -e "      return ${code};"
-            echo -e "    }"
-            echo -e "    break;"
-
-            # next
+    ) |
+        grep -E '^<!ENTITY [a-zA-Z0-9_]' |
+        sed \
+            -e 's/<!ENTITY //' -e "s/[[:space:]][[:space:]]*/ /g" \
+            -e 's/-->$//' \
+            -e 's/\([^ ]*\) CDATA "&#\([^\"]*\);" -- \(.*\)/\1 \2 \3/' |
+        (
             read A
-        done
-    )
+            while test -n "$A"; do
+                ent="${A%% *}"
+                code=$(echo "$A" | cut -f2 -d' ')
+                # compute hash
+                hash=0
+                i=0
+                a=1664525
+                c=1013904223
+                m="$((1 << 32))"
+                while test "$i" -lt ${#ent}; do
+                    d="$(echo -n "${ent:${i}:1}" | hexdump -v -e '/1 "%d"')"
+                    hash="$((((${hash} * ${a}) % (${m}) + ${d} + ${c}) % (${m})))"
+                    i=$((${i} + 1))
+                done
+                echo -e "    /* $A */"
+                echo -e "  case ${hash}u:"
+                echo -e "    if (len == ${#ent} /* && strncmp(ent, \"${ent}\") == 0 */) {"
+                echo -e "      return ${code};"
+                echo -e "    }"
+                echo -e "    break;"
+
+                # next
+                read A
+            done
+        )
     cat <<EOF
   }
   /* unknown */
   return -1;
 }
 EOF
-) > ${dest}
+) >${dest}

--- a/src/webhttrack
+++ b/src/webhttrack
@@ -4,10 +4,11 @@
 # Initializes the htsserver GUI frontend and launch the default browser
 
 BROWSEREXE=
-SRCHBROWSEREXE="x-www-browser www-browser iceape mozilla firefox-developer-edition firefox icecat iceweasel abrowser firebird galeon konqueror midori opera google-chrome chrome chromium chromium-browser netscape firefox-developer-edition"
+SRCHBROWSEREXE=(x-www-browser www-browser iceape mozilla firefox-developer-edition firefox icecat iceweasel abrowser firebird galeon konqueror midori opera google-chrome chrome chromium chromium-browser netscape firefox-developer-edition)
+# shellcheck disable=SC2153 # BROWSER is the standard freedesktop env var, not a typo
 if test -n "${BROWSER}"; then
     # sensible-browser will f up if BROWSER is not set
-    SRCHBROWSEREXE="xdg-open sensible-browser ${SRCHBROWSEREXE}"
+    SRCHBROWSEREXE=(xdg-open sensible-browser "${SRCHBROWSEREXE[@]}")
 fi
 # Patch for Darwin/Mac by Ross Williams
 if test "$(uname -s)" == "Darwin"; then
@@ -17,15 +18,16 @@ if test "$(uname -s)" == "Darwin"; then
     BROWSEREXE="/usr/bin/open -W"
 fi
 BINWD=$(dirname "$0")
-SRCHPATH="$BINWD /usr/local/bin /usr/share/bin /usr/bin /usr/lib/httrack /usr/local/lib/httrack /usr/local/share/httrack /opt/local/bin /sw/bin ${HOME}/usr/bin ${HOME}/bin"
-SRCHPATH="$SRCHPATH "$(echo $PATH | tr ":" " ")
-SRCHDISTPATH="$BINWD/../share $BINWD/.. /usr/share /usr/local /usr /local /usr/local/share ${HOME}/usr ${HOME}/usr/share /opt/local/share /sw ${HOME}/usr/local ${HOME}/usr/share"
+SRCHPATH=("$BINWD" /usr/local/bin /usr/share/bin /usr/bin /usr/lib/httrack /usr/local/lib/httrack /usr/local/share/httrack /opt/local/bin /sw/bin "${HOME}/usr/bin" "${HOME}/bin")
+IFS=':' read -ra pathdirs <<<"$PATH"
+SRCHPATH+=("${pathdirs[@]}")
+SRCHDISTPATH=("$BINWD/../share" "$BINWD/.." /usr/share /usr/local /usr /local /usr/local/share "${HOME}/usr" "${HOME}/usr/share" /opt/local/share /sw "${HOME}/usr/local" "${HOME}/usr/share")
 
 ###
 # And now some famous cuisine
 
 function log {
-    echo "$0($$): $@" >&2
+    echo "$0($$): $*" >&2
     return 0
 }
 
@@ -42,35 +44,35 @@ function launch_browser {
 
 # First ensure that we can launch the server
 BINPATH=
-for i in ${SRCHPATH}; do
-    ! test -n "${BINPATH}" && test -x ${i}/htsserver && BINPATH=${i}
+for i in "${SRCHPATH[@]}"; do
+    ! test -n "${BINPATH}" && test -x "${i}/htsserver" && BINPATH="${i}"
 done
-for i in ${SRCHDISTPATH}; do
+for i in "${SRCHDISTPATH[@]}"; do
     ! test -n "${DISTPATH}" && test -f "${i}/httrack/lang.def" && DISTPATH="${i}/httrack"
 done
 test -n "${BINPATH}" || ! log "Could not find htsserver" || exit 1
 test -n "${DISTPATH}" || ! log "Could not find httrack directory" || exit 1
-test -f ${DISTPATH}/lang.def || ! log "Could not find ${DISTPATH}/lang.def" || exit 1
-test -f ${DISTPATH}/lang.indexes || ! log "Could not find ${DISTPATH}/lang.indexes" || exit 1
-test -d ${DISTPATH}/lang || ! log "Could not find ${DISTPATH}/lang" || exit 1
-test -d ${DISTPATH}/html || ! log "Could not find ${DISTPATH}/html" || exit 1
+test -f "${DISTPATH}/lang.def" || ! log "Could not find ${DISTPATH}/lang.def" || exit 1
+test -f "${DISTPATH}/lang.indexes" || ! log "Could not find ${DISTPATH}/lang.indexes" || exit 1
+test -d "${DISTPATH}/lang" || ! log "Could not find ${DISTPATH}/lang" || exit 1
+test -d "${DISTPATH}/html" || ! log "Could not find ${DISTPATH}/html" || exit 1
 
 # Locale
 HTSLANG="${LC_MESSAGES}"
 ! test -n "${HTSLANG}" && HTSLANG="${LC_ALL}"
 ! test -n "${HTSLANG}" && HTSLANG="${LANG}"
-HTSLANG="$(echo $LANG | cut -f1 -d'.' | cut -f1 -d'_')"
-LANGN=$(grep -E "^${HTSLANG}:" ${DISTPATH}/lang.indexes | cut -f2 -d':')
+HTSLANG="$(echo "$LANG" | cut -f1 -d'.' | cut -f1 -d'_')"
+LANGN=$(grep -E "^${HTSLANG}:" "${DISTPATH}/lang.indexes" | cut -f2 -d':')
 ! test -n "${LANGN}" && LANGN=1
 
 # Find the browser
 # note: not all systems have sensible-browser or www-browser alternative
 # thefeore, we have to find a bit more if sensible-browser could not be found
 
-for i in ${SRCHBROWSEREXE}; do
-    for j in ${SRCHPATH}; do
-        if test -x ${j}/${i}; then
-            BROWSEREXE=${j}/${i}
+for i in "${SRCHBROWSEREXE[@]}"; do
+    for j in "${SRCHPATH[@]}"; do
+        if test -x "${j}/${i}"; then
+            BROWSEREXE="${j}/${i}"
         fi
         test -n "$BROWSEREXE" && break
     done
@@ -81,7 +83,7 @@ test -n "$BROWSEREXE" || ! log "Could not find any suitable browser" || exit 1
 # "browse" command
 if test "$1" = "browse"; then
     if test -f "${HOME}/.httrack.ini"; then
-        INDEXF=$(cat ${HOME}/.httrack.ini | tr '\r' '\n' | grep -E "^path=" | cut -f2- -d'=')
+        INDEXF=$(tr '\r' '\n' <"${HOME}/.httrack.ini" | grep -E "^path=" | cut -f2- -d'=')
         if test -n "${INDEXF}" -a -d "${INDEXF}" -a -f "${INDEXF}/index.html"; then
             INDEXF="${INDEXF}/index.html"
         else
@@ -96,42 +98,43 @@ if test "$1" = "browse"; then
 fi
 
 # Create a temporary filename
-TMPSRVFILE="$(mktemp ${TMPDIR:-/tmp}/.webhttrack.XXXXXXXX)" || ! log "Could not create the temporary file ${TMPSRVFILE}" || exit 1
+TMPSRVFILE="$(mktemp "${TMPDIR:-/tmp}/.webhttrack.XXXXXXXX")" || ! log "Could not create the temporary file ${TMPSRVFILE}" || exit 1
 # Launch htsserver binary and setup the server
 (
-    ${BINPATH}/htsserver "${DISTPATH}/" --ppid "$$" path "${HOME}/websites" lang "${LANGN}" $@
+    "${BINPATH}/htsserver" "${DISTPATH}/" --ppid "$$" path "${HOME}/websites" lang "${LANGN}" "$@"
     echo SRVURL=error
-) >${TMPSRVFILE} &
+) >"${TMPSRVFILE}" &
 # Find the generated SRVURL
 SRVURL=
 MAXCOUNT=60
 while ! test -n "$SRVURL"; do
-    MAXCOUNT=$(($MAXCOUNT - 1))
+    MAXCOUNT=$((MAXCOUNT - 1))
     test $MAXCOUNT -gt 0 || exit 1
     test $MAXCOUNT -lt 50 && echo "waiting for server to reply.."
-    SRVURL=$(grep -E URL= ${TMPSRVFILE} | cut -f2- -d=)
+    SRVURL=$(grep -E URL= "${TMPSRVFILE}" | cut -f2- -d=)
     test ! "$SRVURL" = "error" || ! log "Could not spawn htsserver" || exit 1
     test -n "$SRVURL" || sleep 1
 done
 
 # Cleanup function
+# shellcheck disable=SC2120 # $1 is an optional "signal caught" marker; bare calls are intentional
 function cleanup {
     test -n "$1" && log "Nasty signal caught, cleaning up.."
     # Do not kill if browser exited (chrome bug issue) ; server will die itself
-    test -n "$1" && test -f ${TMPSRVFILE} && SRVPID=$(grep -E PID= ${TMPSRVFILE} | cut -f2- -d=)
-    test -n "${SRVPID}" && kill -9 ${SRVPID}
-    test -f ${TMPSRVFILE} && rm ${TMPSRVFILE}
+    test -n "$1" && test -f "${TMPSRVFILE}" && SRVPID=$(grep -E PID= "${TMPSRVFILE}" | cut -f2- -d=)
+    test -n "${SRVPID}" && kill -9 "${SRVPID}"
+    test -f "${TMPSRVFILE}" && rm "${TMPSRVFILE}"
     test -n "$1" && log "..Done"
     return 0
 }
 
 # Cleanup in case of emergency
-trap "cleanup now; exit" 1 2 3 4 5 6 7 8 9 11 13 14 15 16 19 24 25
+trap "cleanup now; exit" HUP INT QUIT ILL TRAP ABRT BUS FPE SEGV PIPE ALRM TERM STKFLT XCPU XFSZ
 
 # Got SRVURL, launch browser
 launch_browser "${BROWSEREXE}" "${SRVURL}"
 
 # That's all, folks!
-trap "" 1 2 3 4 5 6 7 8 9 11 13 14 15 16 19 24 25
+trap "" HUP INT QUIT ILL TRAP ABRT BUS FPE SEGV PIPE ALRM TERM STKFLT XCPU XFSZ
 cleanup
 exit 0

--- a/src/webhttrack
+++ b/src/webhttrack
@@ -6,47 +6,47 @@
 BROWSEREXE=
 SRCHBROWSEREXE="x-www-browser www-browser iceape mozilla firefox-developer-edition firefox icecat iceweasel abrowser firebird galeon konqueror midori opera google-chrome chrome chromium chromium-browser netscape firefox-developer-edition"
 if test -n "${BROWSER}"; then
-# sensible-browser will f up if BROWSER is not set
-SRCHBROWSEREXE="xdg-open sensible-browser ${SRCHBROWSEREXE}"
+    # sensible-browser will f up if BROWSER is not set
+    SRCHBROWSEREXE="xdg-open sensible-browser ${SRCHBROWSEREXE}"
 fi
 # Patch for Darwin/Mac by Ross Williams
-if test "`uname -s`" == "Darwin"; then
-# Darwin/Mac OS X uses a system 'open' command to find
-# the default browser. The -W flag causes it to wait for
-# the browser to exit
-BROWSEREXE="/usr/bin/open -W"
+if test "$(uname -s)" == "Darwin"; then
+    # Darwin/Mac OS X uses a system 'open' command to find
+    # the default browser. The -W flag causes it to wait for
+    # the browser to exit
+    BROWSEREXE="/usr/bin/open -W"
 fi
-BINWD=`dirname "$0"`
+BINWD=$(dirname "$0")
 SRCHPATH="$BINWD /usr/local/bin /usr/share/bin /usr/bin /usr/lib/httrack /usr/local/lib/httrack /usr/local/share/httrack /opt/local/bin /sw/bin ${HOME}/usr/bin ${HOME}/bin"
-SRCHPATH="$SRCHPATH "`echo $PATH | tr ":" " "`
+SRCHPATH="$SRCHPATH "$(echo $PATH | tr ":" " ")
 SRCHDISTPATH="$BINWD/../share $BINWD/.. /usr/share /usr/local /usr /local /usr/local/share ${HOME}/usr ${HOME}/usr/share /opt/local/share /sw ${HOME}/usr/local ${HOME}/usr/share"
 
 ###
 # And now some famous cuisine
 
 function log {
-echo "$0($$): $@" >&2
-return 0
+    echo "$0($$): $@" >&2
+    return 0
 }
 
 function launch_browser {
-log "Launching $1"
-browser=$1
-url=$2
-log "Spawning browser.."
-${browser} "${url}"
-# note: browser can hiddenly use the -remote feature of
-# mozilla and therefore return immediately
-log "Browser (or helper) exited"
+    log "Launching $1"
+    browser=$1
+    url=$2
+    log "Spawning browser.."
+    ${browser} "${url}"
+    # note: browser can hiddenly use the -remote feature of
+    # mozilla and therefore return immediately
+    log "Browser (or helper) exited"
 }
 
 # First ensure that we can launch the server
 BINPATH=
 for i in ${SRCHPATH}; do
-	! test -n "${BINPATH}" && test -x ${i}/htsserver && BINPATH=${i}
+    ! test -n "${BINPATH}" && test -x ${i}/htsserver && BINPATH=${i}
 done
 for i in ${SRCHDISTPATH}; do
-	! test -n "${DISTPATH}" && test -f "${i}/httrack/lang.def" && DISTPATH="${i}/httrack"
+    ! test -n "${DISTPATH}" && test -f "${i}/httrack/lang.def" && DISTPATH="${i}/httrack"
 done
 test -n "${BINPATH}" || ! log "Could not find htsserver" || exit 1
 test -n "${DISTPATH}" || ! log "Could not find httrack directory" || exit 1
@@ -59,8 +59,8 @@ test -d ${DISTPATH}/html || ! log "Could not find ${DISTPATH}/html" || exit 1
 HTSLANG="${LC_MESSAGES}"
 ! test -n "${HTSLANG}" && HTSLANG="${LC_ALL}"
 ! test -n "${HTSLANG}" && HTSLANG="${LANG}"
-HTSLANG="`echo $LANG | cut -f1 -d'.' | cut -f1 -d'_'`"
-LANGN=`grep -E "^${HTSLANG}:" ${DISTPATH}/lang.indexes | cut -f2 -d':'`
+HTSLANG="$(echo $LANG | cut -f1 -d'.' | cut -f1 -d'_')"
+LANGN=$(grep -E "^${HTSLANG}:" ${DISTPATH}/lang.indexes | cut -f2 -d':')
 ! test -n "${LANGN}" && LANGN=1
 
 # Find the browser
@@ -68,58 +68,61 @@ LANGN=`grep -E "^${HTSLANG}:" ${DISTPATH}/lang.indexes | cut -f2 -d':'`
 # thefeore, we have to find a bit more if sensible-browser could not be found
 
 for i in ${SRCHBROWSEREXE}; do
-for j in ${SRCHPATH}; do
-if test -x ${j}/${i}; then
-BROWSEREXE=${j}/${i}
-fi
-test -n "$BROWSEREXE" && break
-done
-test -n "$BROWSEREXE" && break
+    for j in ${SRCHPATH}; do
+        if test -x ${j}/${i}; then
+            BROWSEREXE=${j}/${i}
+        fi
+        test -n "$BROWSEREXE" && break
+    done
+    test -n "$BROWSEREXE" && break
 done
 test -n "$BROWSEREXE" || ! log "Could not find any suitable browser" || exit 1
 
 # "browse" command
 if test "$1" = "browse"; then
-if test -f "${HOME}/.httrack.ini"; then
-INDEXF=`cat ${HOME}/.httrack.ini | tr '\r' '\n' | grep -E "^path=" | cut -f2- -d'='`
-if test -n "${INDEXF}" -a -d "${INDEXF}" -a -f "${INDEXF}/index.html"; then
-INDEXF="${INDEXF}/index.html"
-else
-INDEXF=""
-fi
-fi
-if ! test -n "$INDEXF"; then 
-INDEXF="${HOME}/websites/index.html"
-fi
-launch_browser "${BROWSEREXE}" "file://${INDEXF}"
-exit $?
+    if test -f "${HOME}/.httrack.ini"; then
+        INDEXF=$(cat ${HOME}/.httrack.ini | tr '\r' '\n' | grep -E "^path=" | cut -f2- -d'=')
+        if test -n "${INDEXF}" -a -d "${INDEXF}" -a -f "${INDEXF}/index.html"; then
+            INDEXF="${INDEXF}/index.html"
+        else
+            INDEXF=""
+        fi
+    fi
+    if ! test -n "$INDEXF"; then
+        INDEXF="${HOME}/websites/index.html"
+    fi
+    launch_browser "${BROWSEREXE}" "file://${INDEXF}"
+    exit $?
 fi
 
 # Create a temporary filename
 TMPSRVFILE="$(mktemp ${TMPDIR:-/tmp}/.webhttrack.XXXXXXXX)" || ! log "Could not create the temporary file ${TMPSRVFILE}" || exit 1
 # Launch htsserver binary and setup the server
-(${BINPATH}/htsserver "${DISTPATH}/" --ppid "$$" path "${HOME}/websites" lang "${LANGN}" $@; echo SRVURL=error) > ${TMPSRVFILE}&
+(
+    ${BINPATH}/htsserver "${DISTPATH}/" --ppid "$$" path "${HOME}/websites" lang "${LANGN}" $@
+    echo SRVURL=error
+) >${TMPSRVFILE} &
 # Find the generated SRVURL
 SRVURL=
 MAXCOUNT=60
 while ! test -n "$SRVURL"; do
-MAXCOUNT=$[$MAXCOUNT - 1]
-test $MAXCOUNT -gt 0 || exit 1
-test $MAXCOUNT -lt 50 && echo "waiting for server to reply.."
-SRVURL=`grep -E URL= ${TMPSRVFILE} | cut -f2- -d=`
-test ! "$SRVURL" = "error" || ! log "Could not spawn htsserver" || exit 1
-test -n "$SRVURL" || sleep 1
+    MAXCOUNT=$(($MAXCOUNT - 1))
+    test $MAXCOUNT -gt 0 || exit 1
+    test $MAXCOUNT -lt 50 && echo "waiting for server to reply.."
+    SRVURL=$(grep -E URL= ${TMPSRVFILE} | cut -f2- -d=)
+    test ! "$SRVURL" = "error" || ! log "Could not spawn htsserver" || exit 1
+    test -n "$SRVURL" || sleep 1
 done
 
 # Cleanup function
 function cleanup {
-test -n "$1" && log "Nasty signal caught, cleaning up.."
-# Do not kill if browser exited (chrome bug issue) ; server will die itself
-test -n "$1" && test -f ${TMPSRVFILE} && SRVPID=`grep -E PID= ${TMPSRVFILE} | cut -f2- -d=`
-test -n "${SRVPID}" && kill -9 ${SRVPID}
-test -f ${TMPSRVFILE} && rm ${TMPSRVFILE}
-test -n "$1" && log "..Done"
-return 0
+    test -n "$1" && log "Nasty signal caught, cleaning up.."
+    # Do not kill if browser exited (chrome bug issue) ; server will die itself
+    test -n "$1" && test -f ${TMPSRVFILE} && SRVPID=$(grep -E PID= ${TMPSRVFILE} | cut -f2- -d=)
+    test -n "${SRVPID}" && kill -9 ${SRVPID}
+    test -f ${TMPSRVFILE} && rm ${TMPSRVFILE}
+    test -n "$1" && log "..Done"
+    return 0
 }
 
 # Cleanup in case of emergency

--- a/src/webhttrack
+++ b/src/webhttrack
@@ -20,7 +20,10 @@ fi
 BINWD=$(dirname "$0")
 SRCHPATH=("$BINWD" /usr/local/bin /usr/share/bin /usr/bin /usr/lib/httrack /usr/local/lib/httrack /usr/local/share/httrack /opt/local/bin /sw/bin "${HOME}/usr/bin" "${HOME}/bin")
 IFS=':' read -ra pathdirs <<<"$PATH"
-SRCHPATH+=("${pathdirs[@]}")
+for d in "${pathdirs[@]}"; do
+    # drop empty PATH fields, matching the old echo|tr word-split
+    test -n "$d" && SRCHPATH+=("$d")
+done
 SRCHDISTPATH=("$BINWD/../share" "$BINWD/.." /usr/share /usr/local /usr /local /usr/local/share "${HOME}/usr" "${HOME}/usr/share" /opt/local/share /sw "${HOME}/usr/local" "${HOME}/usr/share")
 
 ###

--- a/tests/01_engine-charset.test
+++ b/tests/01_engine-charset.test
@@ -6,11 +6,11 @@ set -euo pipefail
 # charset -> UTF-8 conversion (hts_convertStringToUTF8).
 # -#3 <charset> <string> prints the string re-decoded from <charset> as UTF-8.
 conv() {
-	test "$(httrack -O /dev/null -#3 "$1" "$2")" == "$3" || exit 1
+    test "$(httrack -O /dev/null -#3 "$1" "$2")" == "$3" || exit 1
 }
 # crash probe: malformed input must exit cleanly, not abort.
 runs() {
-	httrack -O /dev/null -#3 "$1" "$2" >/dev/null 2>&1 || exit 1
+    httrack -O /dev/null -#3 "$1" "$2" >/dev/null 2>&1 || exit 1
 }
 
 # the source bytes below are UTF-8 (this file is UTF-8); "café" is 0x63 61 66 C3 A9.

--- a/tests/01_engine-entities.test
+++ b/tests/01_engine-entities.test
@@ -6,11 +6,11 @@ set -euo pipefail
 # HTML entity unescaping (hts_unescapeEntitiesWithCharset).
 # -#6 <string> prints the string with entities decoded (UTF-8 output).
 ent() {
-	test "$(httrack -O /dev/null -#6 "$1")" == "$2" || exit 1
+    test "$(httrack -O /dev/null -#6 "$1")" == "$2" || exit 1
 }
 # crash probe: malformed input must exit cleanly, not abort.
 runs() {
-	httrack -O /dev/null -#6 "$1" >/dev/null 2>&1 || exit 1
+    httrack -O /dev/null -#6 "$1" >/dev/null 2>&1 || exit 1
 }
 
 # named entities

--- a/tests/01_engine-filter.test
+++ b/tests/01_engine-filter.test
@@ -7,10 +7,10 @@ set -euo pipefail
 # -#0 <filter> <string> prints "<string> does match <filter>" or "... does NOT match ...".
 
 match() {
-	test "$(httrack -O /dev/null -#0 "$1" "$2")" == "$2 does match $1" || exit 1
+    test "$(httrack -O /dev/null -#0 "$1" "$2")" == "$2 does match $1" || exit 1
 }
 nomatch() {
-	test "$(httrack -O /dev/null -#0 "$1" "$2")" == "$2 does NOT match $1" || exit 1
+    test "$(httrack -O /dev/null -#0 "$1" "$2")" == "$2 does NOT match $1" || exit 1
 }
 
 # bare star matches everything
@@ -67,7 +67,7 @@ nomatch '*[\[]' 'a'
 # filter guide claims (GitHub #148); it parses as the class {'[','\'} followed
 # by a trailing literal ']'. These assertions document the current (buggy)
 # behavior so any future matcher fix is a deliberate, visible change.
-nomatch '*[\[\]]' '['   # not matched, despite the docs
-match '*[\[\]]' ']'     # only via the empty class-match + trailing ']'
-match '*[\[\]]' '[]'    # one of {'[','\'} then the trailing ']'
+nomatch '*[\[\]]' '[' # not matched, despite the docs
+match '*[\[\]]' ']'   # only via the empty class-match + trailing ']'
+match '*[\[\]]' '[]'  # one of {'[','\'} then the trailing ']'
 nomatch '*[\[\]]' '[]x'

--- a/tests/01_engine-mime.test
+++ b/tests/01_engine-mime.test
@@ -7,10 +7,10 @@ set -euo pipefail
 # -#2 <path> prints "<path> is '<mime>'" then "and its local type is '.<ext>'".
 
 mime() {
-	test "$(httrack -O /dev/null -#2 "$1" | head -1)" == "$1 is '$2'" || exit 1
+    test "$(httrack -O /dev/null -#2 "$1" | head -1)" == "$1 is '$2'" || exit 1
 }
 unknown() {
-	test "$(httrack -O /dev/null -#2 "$1" | head -1)" == "$1 is of an unknown MIME type" || exit 1
+    test "$(httrack -O /dev/null -#2 "$1" | head -1)" == "$1 is of an unknown MIME type" || exit 1
 }
 
 mime '/a/b.html' 'text/html'

--- a/tests/01_engine-relative.test
+++ b/tests/01_engine-relative.test
@@ -7,56 +7,62 @@ set -euo pipefail
 
 # relative path from <curr>'s directory to <link>
 rel() {
-	local got
-	got=$(httrack -O /dev/null -#l "$1" "$2")
-	test "$got" == "relative=$3" ||
-		{ echo "FAIL rel($1, $2): got '$got' want 'relative=$3'"; exit 1; }
+    local got
+    got=$(httrack -O /dev/null -#l "$1" "$2")
+    test "$got" == "relative=$3" ||
+        {
+            echo "FAIL rel($1, $2): got '$got' want 'relative=$3'"
+            exit 1
+        }
 }
 
 # resolve <link> against origin <adr>/<fil> -> adr=.. fil=..
 ident() {
-	local got
-	got=$(httrack -O /dev/null -#i "$1" "$2" "$3")
-	test "$got" == "$4" ||
-		{ echo "FAIL ident($1, $2, $3): got '$got' want '$4'"; exit 1; }
+    local got
+    got=$(httrack -O /dev/null -#i "$1" "$2" "$3")
+    test "$got" == "$4" ||
+        {
+            echo "FAIL ident($1, $2, $3): got '$got' want '$4'"
+            exit 1
+        }
 }
 
 ### lienrelatif
 
-rel 'dir/page.html'        'dir/index.html'        'page.html'
-rel 'dir/page.html'        'dir/page.html'         'page.html'   # self-link
-rel 'a.html'               'dir/index.html'        '../a.html'
-rel 'x.html'               'a/b/c/index.html'      '../../../x.html'
-rel 'h/a/x.jpg'            'h/a/sub/page.html'     '../x.jpg'
-rel 'a/b/c/x.html'         'index.html'            'a/b/c/x.html'
-rel 'h/sub/x.jpg'          'h/page.html'           'sub/x.jpg'
-rel 'h/dir2/x.jpg'         'h/dir1/page.html'      '../dir2/x.jpg'   # sibling dir
-rel 'h/bc/x.jpg'           'h/b/page.html'         '../bc/x.jpg'     # b/bc prefix trap
-rel 'h/b/x.jpg'            'h/bc/page.html'        '../b/x.jpg'
-rel 'h2/img/x.jpg'         'h1/p/page.html'        '../../h2/img/x.jpg'   # cross-host
-rel 'img.cdn/photo.jpg'    'www.site/articles/2020/post.html' '../../../img.cdn/photo.jpg'
-rel 'h/a/'                 'h/a/sub/page.html'     '../'             # link is ancestor dir
-rel 'x.html'               'page.html'             'x.html'
-rel 'dir/page.html?x=1'    'dir/index.html?y=2'    'page.html'       # ? stripped
+rel 'dir/page.html' 'dir/index.html' 'page.html'
+rel 'dir/page.html' 'dir/page.html' 'page.html' # self-link
+rel 'a.html' 'dir/index.html' '../a.html'
+rel 'x.html' 'a/b/c/index.html' '../../../x.html'
+rel 'h/a/x.jpg' 'h/a/sub/page.html' '../x.jpg'
+rel 'a/b/c/x.html' 'index.html' 'a/b/c/x.html'
+rel 'h/sub/x.jpg' 'h/page.html' 'sub/x.jpg'
+rel 'h/dir2/x.jpg' 'h/dir1/page.html' '../dir2/x.jpg' # sibling dir
+rel 'h/bc/x.jpg' 'h/b/page.html' '../bc/x.jpg'        # b/bc prefix trap
+rel 'h/b/x.jpg' 'h/bc/page.html' '../b/x.jpg'
+rel 'h2/img/x.jpg' 'h1/p/page.html' '../../h2/img/x.jpg' # cross-host
+rel 'img.cdn/photo.jpg' 'www.site/articles/2020/post.html' '../../../img.cdn/photo.jpg'
+rel 'h/a/' 'h/a/sub/page.html' '../' # link is ancestor dir
+rel 'x.html' 'page.html' 'x.html'
+rel 'dir/page.html?x=1' 'dir/index.html?y=2' 'page.html' # ? stripped
 
 ### ident_url_relatif
 
-ident 'img.gif'      'www.foo.com' '/dir/page.html'     'adr=www.foo.com fil=/dir/img.gif'
-ident 'sub/img.gif'  'www.foo.com' '/dir/page.html'     'adr=www.foo.com fil=/dir/sub/img.gif'
-ident '/img.gif'     'www.foo.com' '/dir/page.html'     'adr=www.foo.com fil=/img.gif'
+ident 'img.gif' 'www.foo.com' '/dir/page.html' 'adr=www.foo.com fil=/dir/img.gif'
+ident 'sub/img.gif' 'www.foo.com' '/dir/page.html' 'adr=www.foo.com fil=/dir/sub/img.gif'
+ident '/img.gif' 'www.foo.com' '/dir/page.html' 'adr=www.foo.com fil=/img.gif'
 # embedded ../ collapses (#137)
-ident '../img.gif'             'www.foo.com' '/dir/sub/page.html'        'adr=www.foo.com fil=/dir/img.gif'
-ident 'sub/../logo.png'        'www.foo.com' '/articles/2020/post.html' 'adr=www.foo.com fil=/articles/2020/logo.png'
+ident '../img.gif' 'www.foo.com' '/dir/sub/page.html' 'adr=www.foo.com fil=/dir/img.gif'
+ident 'sub/../logo.png' 'www.foo.com' '/articles/2020/post.html' 'adr=www.foo.com fil=/articles/2020/logo.png'
 ident '../../pix/sub/../logo.png' 'www.foo.com' '/articles/2020/post.html' 'adr=www.foo.com fil=/pix/logo.png'
-ident '../../../../x.gif'      'www.foo.com' '/a/b/page.html'           'adr=www.foo.com fil=/x.gif'   # above-root clamp
-ident '?page=2'      'www.foo.com' '/dir/index.html?old=1' 'adr=www.foo.com fil=/dir/index.html?page=2'
+ident '../../../../x.gif' 'www.foo.com' '/a/b/page.html' 'adr=www.foo.com fil=/x.gif' # above-root clamp
+ident '?page=2' 'www.foo.com' '/dir/index.html?old=1' 'adr=www.foo.com fil=/dir/index.html?page=2'
 ident 'http://other.com/a/b/../c/index.html' 'www.foo.com' '/p.html' 'adr=other.com fil=/a/c/index.html'
 # file:// collapses ../ like the other schemes; traversal contained, // authority kept
 ident 'file:///var/data/pix/sub/../logo.png' 'www.foo.com' '/p.html' 'adr=file:// fil=/var/data/pix/logo.png'
-ident 'file:///a/b/c/../../d/e.gif'          'www.foo.com' '/p.html' 'adr=file:// fil=/a/d/e.gif'
-ident 'file:///a/../../b'        'www.foo.com' '/p.html' 'adr=file:// fil=/b'
-ident 'file://srv/share/../x'    'www.foo.com' '/p.html' 'adr=file:// fil=//srv/x'
-ident 'mailto:foo@bar.com'   'www.foo.com' '/p.html'    'error=-1'   # unsupported scheme
-ident 'javascript:void(0)'   'www.foo.com' '/p.html'    'error=-1'
+ident 'file:///a/b/c/../../d/e.gif' 'www.foo.com' '/p.html' 'adr=file:// fil=/a/d/e.gif'
+ident 'file:///a/../../b' 'www.foo.com' '/p.html' 'adr=file:// fil=/b'
+ident 'file://srv/share/../x' 'www.foo.com' '/p.html' 'adr=file:// fil=//srv/x'
+ident 'mailto:foo@bar.com' 'www.foo.com' '/p.html' 'error=-1' # unsupported scheme
+ident 'javascript:void(0)' 'www.foo.com' '/p.html' 'error=-1'
 
 echo "OK"

--- a/tests/01_engine-simplify.test
+++ b/tests/01_engine-simplify.test
@@ -5,7 +5,7 @@ set -euo pipefail
 
 # path simplify engine (fil_simplifie): collapses ./ and ../ segments.
 simp() {
-	test "$(httrack -O /dev/null -#1 "$1")" == "simplified=$2" || exit 1
+    test "$(httrack -O /dev/null -#1 "$1")" == "simplified=$2" || exit 1
 }
 
 simp './foo/bar/' 'foo/bar/'

--- a/tests/01_engine-strsafe.test
+++ b/tests/01_engine-strsafe.test
@@ -21,9 +21,15 @@ test "$out" == "strsafe: OK" || exit 1
 # the bounded macro aborts (non-zero exit), so don't let set -e trip on it
 err=$(httrack -#8 overflow "this string is far too long for the buffer" 2>&1) || true
 case "$err" in
-	*"strsafe: NOT aborted"*) echo "over-capacity write was NOT caught" >&2; exit 1 ;;
-	*"overflow while copying"*) ;;
-	*) echo "expected htssafe overflow abort, got: $err" >&2; exit 1 ;;
+*"strsafe: NOT aborted"*)
+    echo "over-capacity write was NOT caught" >&2
+    exit 1
+    ;;
+*"overflow while copying"*) ;;
+*)
+    echo "expected htssafe overflow abort, got: $err" >&2
+    exit 1
+    ;;
 esac
 
 # Same guarantee for the htsbuff builder. The source is exactly the buffer
@@ -32,7 +38,13 @@ esac
 # aborted"). Match the specific htsbuff abort message, not just any assert.
 err=$(httrack -#8 overflow-buff "abcd" 2>&1) || true
 case "$err" in
-	*"strsafe: NOT aborted"*) echo "htsbuff over-capacity write was NOT caught" >&2; exit 1 ;;
-	*"htsbuff append overflow"*) ;;
-	*) echo "expected htsbuff overflow abort, got: $err" >&2; exit 1 ;;
+*"strsafe: NOT aborted"*)
+    echo "htsbuff over-capacity write was NOT caught" >&2
+    exit 1
+    ;;
+*"htsbuff append overflow"*) ;;
+*)
+    echo "expected htsbuff overflow abort, got: $err" >&2
+    exit 1
+    ;;
 esac

--- a/tests/10_crawl-simple.test
+++ b/tests/10_crawl-simple.test
@@ -3,6 +3,6 @@
 
 set -euo pipefail
 
-bash check-network.sh ||  ! echo "skipping online unit tests" || exit 77
+bash check-network.sh || ! echo "skipping online unit tests" || exit 77
 
 bash crawl-test.sh --errors 0 --files 5 httrack http://ut.httrack.com/simple/basic.html

--- a/tests/11_crawl-cookies.test
+++ b/tests/11_crawl-cookies.test
@@ -3,10 +3,10 @@
 
 set -euo pipefail
 
-bash check-network.sh ||  ! echo "skipping online unit tests" || exit 77
+bash check-network.sh || ! echo "skipping online unit tests" || exit 77
 
 bash crawl-test.sh --errors 0 --files 3 \
-	--found ut.httrack.com/cookies/third.html \
-	--found ut.httrack.com/cookies/second.html \
-	--found ut.httrack.com/cookies/entrance.html \
-	httrack http://ut.httrack.com/cookies/entrance.php
+    --found ut.httrack.com/cookies/third.html \
+    --found ut.httrack.com/cookies/second.html \
+    --found ut.httrack.com/cookies/entrance.html \
+    httrack http://ut.httrack.com/cookies/entrance.php

--- a/tests/11_crawl-idna.test
+++ b/tests/11_crawl-idna.test
@@ -3,21 +3,21 @@
 
 set -euo pipefail
 
-bash check-network.sh ||  ! echo "skipping online unit tests" || exit 77
+bash check-network.sh || ! echo "skipping online unit tests" || exit 77
 
 # unicode tests
 bash crawl-test.sh \
-	--errors 1 --files 5 \
-	--found 'café.ut.httrack.com/unicode-links/café3860.html' \
-	--found 'café.ut.httrack.com/unicode-links/café30f4.html' \
-	--found 'café.ut.httrack.com/unicode-links/café5e1f.html' \
-	--found 'café.ut.httrack.com/unicode-links/café7b30.html' \
-	httrack 'http://ut.httrack.com/unicode-links/idna.html' \
-	'+*.ut.httrack.com/*' --robots=0
+    --errors 1 --files 5 \
+    --found 'café.ut.httrack.com/unicode-links/café3860.html' \
+    --found 'café.ut.httrack.com/unicode-links/café30f4.html' \
+    --found 'café.ut.httrack.com/unicode-links/café5e1f.html' \
+    --found 'café.ut.httrack.com/unicode-links/café7b30.html' \
+    httrack 'http://ut.httrack.com/unicode-links/idna.html' \
+    '+*.ut.httrack.com/*' --robots=0
 
 # unicode tests (bogus links)
 bash crawl-test.sh \
-	--errors 0 --files 1 \
-	--found 'ut.httrack.com/unicode-links/idna_bogus.html' \
-	httrack 'http://ut.httrack.com/unicode-links/idna_bogus.html' \
-	'-*' --robots=0
+    --errors 0 --files 1 \
+    --found 'ut.httrack.com/unicode-links/idna_bogus.html' \
+    httrack 'http://ut.httrack.com/unicode-links/idna_bogus.html' \
+    '-*' --robots=0

--- a/tests/11_crawl-international.test
+++ b/tests/11_crawl-international.test
@@ -3,67 +3,67 @@
 
 set -euo pipefail
 
-bash check-network.sh ||  ! echo "skipping online unit tests" || exit 77
+bash check-network.sh || ! echo "skipping online unit tests" || exit 77
 
 # unicode tests
 bash crawl-test.sh \
-	--errors 1 --files 10 \
-	--found ut.httrack.com/unicode-links/caf%a91bce.html \
-	--found ut.httrack.com/unicode-links/café30f4.html \
-	--found ut.httrack.com/unicode-links/café3860.html \
-	--found ut.httrack.com/unicode-links/café463e.html \
-	--found ut.httrack.com/unicode-links/café5e1f.html \
-	--found ut.httrack.com/unicode-links/café7b30.html \
-	--found ut.httrack.com/unicode-links/café8007.html \
-	--found ut.httrack.com/unicode-links/café9fa8.html \
-	--found ut.httrack.com/unicode-links/caféae52.html \
-	--found ut.httrack.com/unicode-links/caféc009.html \
-	--found ut.httrack.com/unicode-links/utf8.html \
-	httrack http://ut.httrack.com/unicode-links/utf8.html
+    --errors 1 --files 10 \
+    --found ut.httrack.com/unicode-links/caf%a91bce.html \
+    --found ut.httrack.com/unicode-links/café30f4.html \
+    --found ut.httrack.com/unicode-links/café3860.html \
+    --found ut.httrack.com/unicode-links/café463e.html \
+    --found ut.httrack.com/unicode-links/café5e1f.html \
+    --found ut.httrack.com/unicode-links/café7b30.html \
+    --found ut.httrack.com/unicode-links/café8007.html \
+    --found ut.httrack.com/unicode-links/café9fa8.html \
+    --found ut.httrack.com/unicode-links/caféae52.html \
+    --found ut.httrack.com/unicode-links/caféc009.html \
+    --found ut.httrack.com/unicode-links/utf8.html \
+    httrack http://ut.httrack.com/unicode-links/utf8.html
 
 bash crawl-test.sh \
-	--errors 4 --files  7 \
-	--found ut.httrack.com/unicode-links/cafÃ©3860.html \
-	--found ut.httrack.com/unicode-links/cafÃ©9fa8.html \
-	--found ut.httrack.com/unicode-links/café30f4.html \
-	--found ut.httrack.com/unicode-links/café5e1f.html \
-	--found ut.httrack.com/unicode-links/café7b30.html \
-	--found ut.httrack.com/unicode-links/café8007.html \
-	--found ut.httrack.com/unicode-links/caf%e939bd.html \
-	--found ut.httrack.com/unicode-links/caf%e9ae52.html \
-	--found ut.httrack.com/unicode-links/caféaec2.html \
-	--found ut.httrack.com/unicode-links/caféfad6.html \
-	--found ut.httrack.com/unicode-links/default.html \
-	httrack http://ut.httrack.com/unicode-links/default.html
+    --errors 4 --files 7 \
+    --found ut.httrack.com/unicode-links/cafÃ©3860.html \
+    --found ut.httrack.com/unicode-links/cafÃ©9fa8.html \
+    --found ut.httrack.com/unicode-links/café30f4.html \
+    --found ut.httrack.com/unicode-links/café5e1f.html \
+    --found ut.httrack.com/unicode-links/café7b30.html \
+    --found ut.httrack.com/unicode-links/café8007.html \
+    --found ut.httrack.com/unicode-links/caf%e939bd.html \
+    --found ut.httrack.com/unicode-links/caf%e9ae52.html \
+    --found ut.httrack.com/unicode-links/caféaec2.html \
+    --found ut.httrack.com/unicode-links/caféfad6.html \
+    --found ut.httrack.com/unicode-links/default.html \
+    httrack http://ut.httrack.com/unicode-links/default.html
 
 bash crawl-test.sh \
-	--errors 2 --files  9 \
-	--found ut.httrack.com/unicode-links/caf%a9ae52.html \
-	--found ut.httrack.com/unicode-links/caf%a9bf59.html \
-	--found ut.httrack.com/unicode-links/café30f4.html \
-	--found ut.httrack.com/unicode-links/café3860.html \
-	--found ut.httrack.com/unicode-links/café5e1f.html \
-	--found ut.httrack.com/unicode-links/café647f.html \
-	--found ut.httrack.com/unicode-links/café7b30.html \
-	--found ut.httrack.com/unicode-links/café8007.html \
-	--found ut.httrack.com/unicode-links/caféaec2.html \
-	--found ut.httrack.com/unicode-links/caféfad6.html \
-	--found ut.httrack.com/unicode-links/iso88591.html \
-	httrack http://ut.httrack.com/unicode-links/iso88591.html
+    --errors 2 --files 9 \
+    --found ut.httrack.com/unicode-links/caf%a9ae52.html \
+    --found ut.httrack.com/unicode-links/caf%a9bf59.html \
+    --found ut.httrack.com/unicode-links/café30f4.html \
+    --found ut.httrack.com/unicode-links/café3860.html \
+    --found ut.httrack.com/unicode-links/café5e1f.html \
+    --found ut.httrack.com/unicode-links/café647f.html \
+    --found ut.httrack.com/unicode-links/café7b30.html \
+    --found ut.httrack.com/unicode-links/café8007.html \
+    --found ut.httrack.com/unicode-links/caféaec2.html \
+    --found ut.httrack.com/unicode-links/caféfad6.html \
+    --found ut.httrack.com/unicode-links/iso88591.html \
+    httrack http://ut.httrack.com/unicode-links/iso88591.html
 
 bash crawl-test.sh \
-	--errors 4 --files  9 \
-	--found ut.httrack.com/unicode-links/caf%a8%a6c72a.html \
-	--found ut.httrack.com/unicode-links/caf%a9bf59.html \
-	--found ut.httrack.com/unicode-links/café8007.html \
-	--found ut.httrack.com/unicode-links/cafébf43.html \
-	--found ut.httrack.com/unicode-links/cafédcd8.html \
-	--found ut.httrack.com/unicode-links/café2461.html \
-	--found ut.httrack.com/unicode-links/caf%a8%a61bce.html \
-	--found ut.httrack.com/unicode-links/caf%a9ae52.html \
-	--found ut.httrack.com/unicode-links/café7b30.html \
-	--found ut.httrack.com/unicode-links/café30f4.html \
-	--found ut.httrack.com/unicode-links/café5e1f.html \
-	--found ut.httrack.com/unicode-links/café3860.html \
-	--found ut.httrack.com/unicode-links/gb18030.html \
-	httrack http://ut.httrack.com/unicode-links/gb18030.html
+    --errors 4 --files 9 \
+    --found ut.httrack.com/unicode-links/caf%a8%a6c72a.html \
+    --found ut.httrack.com/unicode-links/caf%a9bf59.html \
+    --found ut.httrack.com/unicode-links/café8007.html \
+    --found ut.httrack.com/unicode-links/cafébf43.html \
+    --found ut.httrack.com/unicode-links/cafédcd8.html \
+    --found ut.httrack.com/unicode-links/café2461.html \
+    --found ut.httrack.com/unicode-links/caf%a8%a61bce.html \
+    --found ut.httrack.com/unicode-links/caf%a9ae52.html \
+    --found ut.httrack.com/unicode-links/café7b30.html \
+    --found ut.httrack.com/unicode-links/café30f4.html \
+    --found ut.httrack.com/unicode-links/café5e1f.html \
+    --found ut.httrack.com/unicode-links/café3860.html \
+    --found ut.httrack.com/unicode-links/gb18030.html \
+    httrack http://ut.httrack.com/unicode-links/gb18030.html

--- a/tests/11_crawl-longurl.test
+++ b/tests/11_crawl-longurl.test
@@ -3,10 +3,10 @@
 
 set -euo pipefail
 
-bash check-network.sh ||  ! echo "skipping online unit tests" || exit 77
+bash check-network.sh || ! echo "skipping online unit tests" || exit 77
 
 # http://code.google.com/p/httrack/issues/detail?id=42&can=1
 # we expect 2 errors only because other links are too longs (to be modified if suitable)
 bash crawl-test.sh --errors 2 --files 1 \
-	--found ut.httrack.com/overflow/longquerywithaccents.html \
-	httrack http://ut.httrack.com/overflow/longquerywithaccents.php
+    --found ut.httrack.com/overflow/longquerywithaccents.html \
+    httrack http://ut.httrack.com/overflow/longquerywithaccents.php

--- a/tests/11_crawl-parsing.test
+++ b/tests/11_crawl-parsing.test
@@ -3,45 +3,45 @@
 
 set -euo pipefail
 
-bash check-network.sh ||  ! echo "skipping online unit tests" || exit 77
+bash check-network.sh || ! echo "skipping online unit tests" || exit 77
 
 # http://code.google.com/p/httrack/issues/detail?id=4&can=1
 bash crawl-test.sh --errors 0 --files 4 \
-	--found ut.httrack.com/parsing/back5e1f.gif \
-	--found ut.httrack.com/parsing/events.html \
-	--found ut.httrack.com/parsing/fade230f4.gif \
-	--found ut.httrack.com/parsing/fade3860.gif \
-	httrack http://ut.httrack.com/parsing/events.html
+    --found ut.httrack.com/parsing/back5e1f.gif \
+    --found ut.httrack.com/parsing/events.html \
+    --found ut.httrack.com/parsing/fade230f4.gif \
+    --found ut.httrack.com/parsing/fade3860.gif \
+    httrack http://ut.httrack.com/parsing/events.html
 
 # http://code.google.com/p/httrack/issues/detail?id=2&can=1
 bash crawl-test.sh --errors 0 --files 3 \
-	--found ut.httrack.com/parsing/background-image.css \
-	--found ut.httrack.com/parsing/background-image.html \
-	--found ut.httrack.com/parsing/fade.gif \
-	httrack http://ut.httrack.com/parsing/background-image.html
+    --found ut.httrack.com/parsing/background-image.css \
+    --found ut.httrack.com/parsing/background-image.html \
+    --found ut.httrack.com/parsing/fade.gif \
+    httrack http://ut.httrack.com/parsing/background-image.html
 
 # javascript parsing
 bash crawl-test.sh --errors 0 --files 3 \
-	--found ut.httrack.com/parsing/back.gif \
-	--found ut.httrack.com/parsing/fade.gif \
-	--found ut.httrack.com/parsing/javascript.html \
-	httrack http://ut.httrack.com/parsing/javascript.html
+    --found ut.httrack.com/parsing/back.gif \
+    --found ut.httrack.com/parsing/fade.gif \
+    --found ut.httrack.com/parsing/javascript.html \
+    httrack http://ut.httrack.com/parsing/javascript.html
 
 # handling of + before query string
 bash crawl-test.sh --errors 0 --files 6 \
-	--found ut.httrack.com/parsing/escaping.html \
-	--found "ut.httrack.com/parsing/foo bar30f4.html" \
-	--found "ut.httrack.com/parsing/foo bar5e1f.html" \
-	--found "ut.httrack.com/parsing/foo+bar+plus3860.html" \
-	--found "ut.httrack.com/parsing/foo barae52.html" \
-	--found "ut.httrack.com/parsing/foo bar7b30.html" \
-	httrack http://ut.httrack.com/parsing/escaping.html
+    --found ut.httrack.com/parsing/escaping.html \
+    --found "ut.httrack.com/parsing/foo bar30f4.html" \
+    --found "ut.httrack.com/parsing/foo bar5e1f.html" \
+    --found "ut.httrack.com/parsing/foo+bar+plus3860.html" \
+    --found "ut.httrack.com/parsing/foo barae52.html" \
+    --found "ut.httrack.com/parsing/foo bar7b30.html" \
+    httrack http://ut.httrack.com/parsing/escaping.html
 
 # handling of # encoded in filename
 # see http://code.google.com/p/httrack/issues/detail?id=25
 bash crawl-test.sh --errors 2 --files 4 \
-	--found "ut.httrack.com/parsing/escaping2.html" \
-	--found "ut.httrack.com/parsing/++foo++bar++plus++.html" \
-	--found "ut.httrack.com/parsing/foo#bar#.html" \
-	--found "ut.httrack.com/parsing/foo bar.html" \
-	httrack http://ut.httrack.com/parsing/escaping2.html
+    --found "ut.httrack.com/parsing/escaping2.html" \
+    --found "ut.httrack.com/parsing/++foo++bar++plus++.html" \
+    --found "ut.httrack.com/parsing/foo#bar#.html" \
+    --found "ut.httrack.com/parsing/foo bar.html" \
+    httrack http://ut.httrack.com/parsing/escaping2.html

--- a/tests/12_crawl_https.test
+++ b/tests/12_crawl_https.test
@@ -3,11 +3,11 @@
 
 set -euo pipefail
 
-bash check-network.sh ||  ! echo "skipping online unit tests" || exit 77
+bash check-network.sh || ! echo "skipping online unit tests" || exit 77
 
 if test "${HTTPS_SUPPORT:-}" == "no"; then
-	echo "no https support compiled, skipping"
-	exit 77
+    echo "no https support compiled, skipping"
+    exit 77
 fi
 
 bash crawl-test.sh --errors 0 --files 5 httrack https://ut.httrack.com/simple/basic.html

--- a/tests/check-network.sh
+++ b/tests/check-network.sh
@@ -6,39 +6,39 @@
 
 # do not enable online tests (./configure --disable-online-unit-tests)
 if test "$ONLINE_UNIT_TESTS" == "no"; then
-echo "online tests are disabled" >&2
-exit 1
+    echo "online tests are disabled" >&2
+    exit 1
 
 # enable online tests (--enable-online-unit-tests)
 elif test "$ONLINE_UNIT_TESTS" == "yes"; then
-exit 0
+    exit 0
 
 # check if online tests are reachable
 else
 
-# test url
-url=http://ut.httrack.com/enabled
+    # test url
+    url=http://ut.httrack.com/enabled
 
-# cache file name
-cache=check-network_sh.cache
+    # cache file name
+    cache=check-network_sh.cache
 
-# cached result ?
-if test -f $cache ; then
-	if grep -q "ok" $cache ; then
-		exit 0
-	else
-		echo "online tests are disabled (cached)" >&2
-		exit 1
-	fi
+    # cached result ?
+    if test -f $cache; then
+        if grep -q "ok" $cache; then
+            exit 0
+        else
+            echo "online tests are disabled (cached)" >&2
+            exit 1
+        fi
 
-# fetch single file
-elif bash crawl-test.sh --errors 0 --files 1 httrack --timeout=3 --max-time=3 "$url" 2>/dev/null >/dev/null ; then
-	echo "ok" > $cache
-	exit 0
-else
-	echo "error" > $cache
-	echo "online tests are disabled (auto)" >&2
-	exit 1
-fi
+    # fetch single file
+    elif bash crawl-test.sh --errors 0 --files 1 httrack --timeout=3 --max-time=3 "$url" 2>/dev/null >/dev/null; then
+        echo "ok" >$cache
+        exit 0
+    else
+        echo "error" >$cache
+        echo "online tests are disabled (auto)" >&2
+        exit 1
+    fi
 
 fi

--- a/tests/crawl-test.sh
+++ b/tests/crawl-test.sh
@@ -18,7 +18,7 @@ function debug {
 }
 
 function info {
-    printf "[$*] ..\t" >&2
+    printf '[%s] ..\t' "$*" >&2
 }
 
 function result {
@@ -68,11 +68,11 @@ function start-crawl {
             ;;
         --no-purge | --summary | --print-files) ;;
         --errors | --files | --found | --not-found | --directory)
-            pos=$((${pos} + 1))
+            pos=$((pos + 1))
             test "$#" -ge "$pos" || warning "missing argument" || return 1
             ;;
         httrack)
-            pos=$((${pos} + 1))
+            pos=$((pos + 1))
             break
             ;;
         *)
@@ -80,16 +80,16 @@ function start-crawl {
             return 1
             ;;
         esac
-        pos=$((${pos} + 1))
+        pos=$((pos + 1))
     done
-    debug "remaining args: ${@:${pos}}"
+    debug "remaining args: ${*:pos}"
 
     # ut/ won't exceed 2 minutes
-    moreargs="--quiet --max-time=120 --timeout=30 --connection-per-second=5"
+    moreargs=(--quiet --max-time=120 --timeout=30 --connection-per-second=5)
 
     # proxy environment ?
-    if test -n "$http_proxy"; then
-        moreargs="$moreargs --proxy $http_proxy"
+    if test -n "${http_proxy:-}"; then
+        moreargs+=(--proxy "$http_proxy")
     fi
 
     test -n "$tmpdir" || ! warning "no tmpdir" || return 1
@@ -103,9 +103,9 @@ function start-crawl {
 
     # start crawl
     log="${tmp}/log"
-    debug starting httrack -O "${tmp}" ${moreargs} ${@:${pos}}
-    info "running httrack ${@:${pos}}"
-    httrack -O "${tmp}" --user-agent="httrack $ver ut ($(uname -omrs))" ${moreargs} ${@:${pos}} >"${log}" 2>&1 &
+    debug starting httrack -O "${tmp}" "${moreargs[@]}" "${@:pos}"
+    info "running httrack ${*:pos}"
+    httrack -O "${tmp}" --user-agent="httrack $ver ut ($(uname -omrs))" "${moreargs[@]}" "${@:pos}" >"${log}" 2>&1 &
     crawlpid="$!"
     debug "started cralwer on pid $crawlpid"
     wait "$crawlpid"
@@ -194,7 +194,7 @@ tmpdir=
 crawlpid=
 nopurge=
 verbose=
-trap "cleanup" 0 1 2 3 4 5 6 7 8 9 11 13 14 15 16 19 24 25
+trap cleanup EXIT HUP INT QUIT ILL TRAP ABRT BUS FPE SEGV PIPE ALRM TERM STKFLT XCPU XFSZ
 
 # working directory
 tmpdir="${tmptopdir}/httrack_ut.$$"

--- a/tests/crawl-test.sh
+++ b/tests/crawl-test.sh
@@ -2,185 +2,184 @@
 #
 
 function warning {
-  echo "** $*" >&2
-  return 0
+    echo "** $*" >&2
+    return 0
 }
 
 function die {
-  warning "$*"
-  exit 1
+    warning "$*"
+    exit 1
 }
 
 function debug {
-  if test -n "$verbose"; then
-    echo "$*" >&2
-  fi
+    if test -n "$verbose"; then
+        echo "$*" >&2
+    fi
 }
 
 function info {
-  printf "[$*] ..\t" >&2
+    printf "[$*] ..\t" >&2
 }
 
 function result {
-  echo "$*" >&2
+    echo "$*" >&2
 }
 
 function cleanup {
-  debug "cleaning function called"
-  if test -n "$tmpdir"; then
-    if test -d "$tmpdir"; then
-      if test -z "$nopurge"; then
-        debug "cleaning up $tmpdir"
-        rm -rf "$tmpdir"
-      fi
+    debug "cleaning function called"
+    if test -n "$tmpdir"; then
+        if test -d "$tmpdir"; then
+            if test -z "$nopurge"; then
+                debug "cleaning up $tmpdir"
+                rm -rf "$tmpdir"
+            fi
+        fi
     fi
-  fi
-  if test -n "$crawlpid"; then
-    debug "killing $crawlpid"
-    kill -9 "$crawlpid"
-    crawlpid=
-  fi
+    if test -n "$crawlpid"; then
+        debug "killing $crawlpid"
+        kill -9 "$crawlpid"
+        crawlpid=
+    fi
 }
 
 function usage {
-  cat << EOF
+    cat <<EOF
 usage: $0
 EOF
 }
 
 function assert_equals {
-  info "$1"
-  if test ! "$2" == "$3"; then
-    result "expected '$2', got '$3'"
-    exit 1
-  else
-    result "OK ($2)"
-  fi
+    info "$1"
+    if test ! "$2" == "$3"; then
+        result "expected '$2', got '$3'"
+        exit 1
+    else
+        result "OK ($2)"
+    fi
 }
 
 function start-crawl {
-  # parse args
-  pos=1
-  while test "$#" -ge "$pos" ; do
-    case "${!pos}" in
-    --debug)
-      verbose=1
-      ;;
-    --no-purge|--summary|--print-files)
-      ;;
-    --errors|--files|--found|--not-found|--directory)
-      pos=$[${pos}+1]
-      test "$#" -ge "$pos" || warning "missing argument" || return 1
-      ;;
-    httrack)
-      pos=$[${pos}+1]
-      break;
-      ;;
-    *)
-      warning "unrecognized option ${!pos}"
-      return 1
-      ;;
-    esac
-    pos=$[${pos}+1]
-  done
-  debug "remaining args: ${@:${pos}}"
+    # parse args
+    pos=1
+    while test "$#" -ge "$pos"; do
+        case "${!pos}" in
+        --debug)
+            verbose=1
+            ;;
+        --no-purge | --summary | --print-files) ;;
+        --errors | --files | --found | --not-found | --directory)
+            pos=$((${pos} + 1))
+            test "$#" -ge "$pos" || warning "missing argument" || return 1
+            ;;
+        httrack)
+            pos=$((${pos} + 1))
+            break
+            ;;
+        *)
+            warning "unrecognized option ${!pos}"
+            return 1
+            ;;
+        esac
+        pos=$((${pos} + 1))
+    done
+    debug "remaining args: ${@:${pos}}"
 
-  # ut/ won't exceed 2 minutes
-  moreargs="--quiet --max-time=120 --timeout=30 --connection-per-second=5"
+    # ut/ won't exceed 2 minutes
+    moreargs="--quiet --max-time=120 --timeout=30 --connection-per-second=5"
 
-  # proxy environment ?
-  if test -n "$http_proxy"; then
-    moreargs="$moreargs --proxy $http_proxy"
-  fi
+    # proxy environment ?
+    if test -n "$http_proxy"; then
+        moreargs="$moreargs --proxy $http_proxy"
+    fi
 
-  test -n "$tmpdir" || ! warning "no tmpdir" || return 1
-  tmp="${tmpdir}/crawl"
-  rm -rf "$tmp"
-  mkdir "$tmp" || ! warning "could not create $tmp" || return 1
-
-  which httrack >/dev/null || ! warning "could not find httrack" || return 1
-  ver=$(httrack -O /dev/null --version | sed -e 's/HTTrack version //')
-  test -n "$ver" || ! warning "could not run httrack" || return 1
-
-  # start crawl
-  log="${tmp}/log"
-  debug starting httrack -O "${tmp}" ${moreargs} ${@:${pos}}
-  info "running httrack ${@:${pos}}"
-  httrack -O "${tmp}" --user-agent="httrack $ver ut ($(uname -omrs))" ${moreargs} ${@:${pos}} >"${log}" 2>&1 &
-  crawlpid="$!"
-  debug "started cralwer on pid $crawlpid"
-  wait "$crawlpid"
-  result="$?"
-  crawlpid=
-  test "$result" -eq 0 || ! result "error code $result" || return 1
-  result "OK"
-  grep -iE "^[0-9\:]*[[:space:]]Error:" "${tmp}/hts-log.txt" >&2
-
-  # now audit
-  while test "$#" -gt 0; do
-    case "$1" in
-    --no-purge)
-      nopurge=1
-      ;;
-    --summary)
-      grep -E "^HTTrack Website Copier/[^ ]* mirror complete in " "${tmp}/hts-log.txt"
-      ;;
-    --print-files)
-      find "${tmp}" -mindepth 1 -type f
-      ;;
-    --errors)
-      shift
-      assert_equals "checking errors" "$1" "$(grep -iEc "^[0-9\:]*[[:space:]]Error:" "${tmp}/hts-log.txt")"
-      ;;
-    --found)
-      shift
-      info "checking for $1"
-      if test -f "${tmp}/$1" ; then
-        result "OK"
-      else
-        result "not found"
-        exit 1
-      fi
-      ;;
-    --not-found)
-      shift
-      info "checking for $1"
-      if test -f "${tmp}/$1" ; then
-        result "OK"
-      else
-        result "not found"
-        exit 1
-      fi
-      ;;
-    --directory)
-      shift
-      info "checking for $1"
-      if test -d "${tmp}/$1" ; then
-        result "OK"
-      else
-        result "not found"
-        exit 1
-      fi
-      ;;
-    --files)
-      shift
-      nFiles=$(grep -E "^HTTrack Website Copier/[^ ]* mirror complete in " "${tmp}/hts-log.txt" \
-        | sed -e 's/.*[[:space:]]\([^ ]*\)[[:space:]]files written.*/\1/g')
-      assert_equals "checking files" "$1" "$nFiles"
-      ;;
-    httrack)
-      break;
-      ;;
-    esac
-    shift
-  done
-
-  # cleanup
-  if test -z "$nopurge"; then
+    test -n "$tmpdir" || ! warning "no tmpdir" || return 1
+    tmp="${tmpdir}/crawl"
     rm -rf "$tmp"
-  else
-    tmpdir=
-  fi
+    mkdir "$tmp" || ! warning "could not create $tmp" || return 1
+
+    which httrack >/dev/null || ! warning "could not find httrack" || return 1
+    ver=$(httrack -O /dev/null --version | sed -e 's/HTTrack version //')
+    test -n "$ver" || ! warning "could not run httrack" || return 1
+
+    # start crawl
+    log="${tmp}/log"
+    debug starting httrack -O "${tmp}" ${moreargs} ${@:${pos}}
+    info "running httrack ${@:${pos}}"
+    httrack -O "${tmp}" --user-agent="httrack $ver ut ($(uname -omrs))" ${moreargs} ${@:${pos}} >"${log}" 2>&1 &
+    crawlpid="$!"
+    debug "started cralwer on pid $crawlpid"
+    wait "$crawlpid"
+    result="$?"
+    crawlpid=
+    test "$result" -eq 0 || ! result "error code $result" || return 1
+    result "OK"
+    grep -iE "^[0-9\:]*[[:space:]]Error:" "${tmp}/hts-log.txt" >&2
+
+    # now audit
+    while test "$#" -gt 0; do
+        case "$1" in
+        --no-purge)
+            nopurge=1
+            ;;
+        --summary)
+            grep -E "^HTTrack Website Copier/[^ ]* mirror complete in " "${tmp}/hts-log.txt"
+            ;;
+        --print-files)
+            find "${tmp}" -mindepth 1 -type f
+            ;;
+        --errors)
+            shift
+            assert_equals "checking errors" "$1" "$(grep -iEc "^[0-9\:]*[[:space:]]Error:" "${tmp}/hts-log.txt")"
+            ;;
+        --found)
+            shift
+            info "checking for $1"
+            if test -f "${tmp}/$1"; then
+                result "OK"
+            else
+                result "not found"
+                exit 1
+            fi
+            ;;
+        --not-found)
+            shift
+            info "checking for $1"
+            if test -f "${tmp}/$1"; then
+                result "OK"
+            else
+                result "not found"
+                exit 1
+            fi
+            ;;
+        --directory)
+            shift
+            info "checking for $1"
+            if test -d "${tmp}/$1"; then
+                result "OK"
+            else
+                result "not found"
+                exit 1
+            fi
+            ;;
+        --files)
+            shift
+            nFiles=$(grep -E "^HTTrack Website Copier/[^ ]* mirror complete in " "${tmp}/hts-log.txt" |
+                sed -e 's/.*[[:space:]]\([^ ]*\)[[:space:]]files written.*/\1/g')
+            assert_equals "checking files" "$1" "$nFiles"
+            ;;
+        httrack)
+            break
+            ;;
+        esac
+        shift
+    done
+
+    # cleanup
+    if test -z "$nopurge"; then
+        rm -rf "$tmp"
+    else
+        tmpdir=
+    fi
 }
 
 # check args

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -2,19 +2,19 @@
 #
 
 error=0
-for i in *.test ; do
-	if bash $i ; then
-		echo "$i: passed" >&2
-	else
-		echo "$i: ERROR" >&2
-		error=$[${error}+1]
-	fi
+for i in *.test; do
+    if bash $i; then
+        echo "$i: passed" >&2
+    else
+        echo "$i: ERROR" >&2
+        error=$((${error} + 1))
+    fi
 done
 
 if test "$error" -eq 0; then
-	echo "all tests passed" >&2
+    echo "all tests passed" >&2
 else
-	echo "${error} test(s) failed" >&2
+    echo "${error} test(s) failed" >&2
 fi
 
 exit $error

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -3,11 +3,11 @@
 
 error=0
 for i in *.test; do
-    if bash $i; then
+    if bash "$i"; then
         echo "$i: passed" >&2
     else
         echo "$i: ERROR" >&2
-        error=$((${error} + 1))
+        error=$((error + 1))
     fi
 done
 


### PR DESCRIPTION
The lint job only checked a handful of scripts. This runs shfmt and shellcheck over the whole tracked shell tree and fixes everything they flag, then widens the CI gate so it stays that way.

Three commits, separated so the wide mechanical diff stays reviewable: a shfmt -i 4 reformat (which also turned backticks into $(...) and $[..] into $((..))), then the shellcheck fixes, then the CI change. The two CI steps now share one job-level `SHELL_SCRIPTS` list so they can't drift apart; 40 scripts are gated.

Most of the shellcheck work is quoting, `read -r`, and arithmetic tidy-ups, but two scripts got real changes worth a look. `crawl-test.sh` and `webhttrack` carried their search paths as space-separated strings that were deliberately word-split; those became bash arrays, which is space-safe and drops the need for scattered disables. Their `trap` lines listed signals by number, including KILL (9) and STOP (19) that bash can't trap and silently ignored, so those are gone and the rest are now names. `search.sh` had a couple of `\"` escapes that made grep search for a literal-quoted pattern; removed.

No behaviour change, and the risk areas were exercised rather than eyeballed. The two generators ship committed output (htsentities.h, htscodepages.h); a differential run on synthetic input is byte-identical before and after. crawl-test.sh was run end to end against a local server. webhttrack was run end to end in browse mode against a faked install, which also confirmed the array search now survives spaces in install paths where the old string-split would have broken. The full make check suite stays green.

One thing left intentionally: webhttrack's launch_browser keeps `${browser}` unquoted, because BROWSEREXE can be `/usr/bin/open -W` on Darwin and has to word-split.