### PR TITLE
debian: rename libhttrack2 to libhttrack3 to follow the SONAME

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,8 @@ httrack (3.49.8-2) unstable; urgency=medium
     libraries fell through into the httrack package and libhttrack2 shipped no
     library. The new .files uses a .so.3* wildcard so a future SONAME bump no
     longer silently misplaces the libraries. New binary package, via NEW.
+  * Drop the stale debian/libhttrack-swf1.files: the swf module is no longer
+    built and no libhttrack-swf1 package exists.
 
  -- Xavier Roche <xavier@debian.org>  Sat, 20 Jun 2026 14:42:13 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+httrack (3.49.8-2) unstable; urgency=medium
+
+  * Rename libhttrack2 to libhttrack3 to follow the SONAME, which the 3.49.8
+    ABI bump moved to libhttrack.so.3 (package-name-doesnt-match-sonames). In
+    3.49.8-1 the libhttrack2.files glob still matched .so.2, so the runtime
+    libraries fell through into the httrack package and libhttrack2 shipped no
+    library. The new .files uses a .so.3* wildcard so a future SONAME bump no
+    longer silently misplaces the libraries. New binary package, via NEW.
+
+ -- Xavier Roche <xavier@debian.org>  Sat, 20 Jun 2026 14:42:13 +0200
+
 httrack (3.49.8-1) unstable; urgency=medium
 
   * New upstream release: HTTPS-proxy CONNECT tunnelling and wider srcset

--- a/debian/control
+++ b/debian/control
@@ -58,13 +58,13 @@ Description: webhttrack common files
  This package is the common files of webhttrack, website copier and
  mirroring utility
 
-Package: libhttrack2
+Package: libhttrack3
 Architecture: any
 Multi-Arch: same
 Section: libs
-Replaces: libhttrack1
-Conflicts: libhttrack1
 Depends: ${misc:Depends}, ${shlibs:Depends}
+Replaces: libhttrack2, httrack (<< 3.49.8-2~)
+Breaks: libhttrack2, httrack (<< 3.49.8-2~)
 Description: Httrack website copier library
  This package is the library part of httrack, website copier and mirroring
  utility

--- a/debian/libhttrack-swf1.files
+++ b/debian/libhttrack-swf1.files
@@ -1,2 +1,0 @@
-usr/lib/*/libhtsswf.so.1.0.0
-usr/lib/*/libhtsswf.so.1

--- a/debian/libhttrack2.files
+++ b/debian/libhttrack2.files
@@ -1,5 +1,0 @@
-usr/lib/*/libhttrack.so.2.0.49
-usr/lib/*/libhttrack.so.2
-usr/lib/*/libhtsjava.so.2.0.49
-usr/lib/*/libhtsjava.so.2
-usr/share/httrack/templates

--- a/debian/libhttrack3.files
+++ b/debian/libhttrack3.files
@@ -1,0 +1,3 @@
+usr/lib/*/libhttrack.so.3*
+usr/lib/*/libhtsjava.so.3*
+usr/share/httrack/templates

--- a/debian/libhttrack3.lintian-overrides
+++ b/debian/libhttrack3.lintian-overrides
@@ -1,3 +1,3 @@
 # The shared libraries ship without a versioned symbols control file (ABI is
 # tracked via the SONAME and a strict =version dependency, see debian/rules).
-libhttrack2: no-symbols-control-file usr/lib/*
+libhttrack3: no-symbols-control-file usr/lib/*

--- a/debian/libhttrack3.lintian-overrides
+++ b/debian/libhttrack3.lintian-overrides
@@ -1,3 +1,3 @@
 # The shared libraries ship without a versioned symbols control file (ABI is
-# tracked via the SONAME and a strict =version dependency, see debian/rules).
+# tracked via the SONAME plus a >= upstream-version dependency, see debian/rules).
 libhttrack3: no-symbols-control-file usr/lib/*

--- a/debian/rules
+++ b/debian/rules
@@ -135,7 +135,7 @@ binary-arch: build install
 	dh_makeshlibs -a -X/usr/lib/$(DEB_HOST_MULTIARCH)/httrack/libtest --version-info
 	dh_installdeb -a
 	# we depend on the current version (ABI may change)
-	dh_shlibdeps -a -ldebian/libhttrack2/usr/lib/$(DEB_HOST_MULTIARCH)
+	dh_shlibdeps -a -ldebian/libhttrack3/usr/lib/$(DEB_HOST_MULTIARCH)
 	dh_gencontrol -a
 	dh_md5sums -a
 	dh_builddeb -a


### PR DESCRIPTION
The 3.49.8 ABI bump moved the library soname to libhttrack.so.3, but the Debian packaging never followed. debian/libhttrack2.files still globbed usr/lib/*/libhttrack.so.2*, which now matches nothing, so the runtime libraries fell through into the catch-all httrack package and libhttrack2 shipped empty (lintian package-name-doesnt-match-sonames). 3.49.8-1 already went to unstable with this layout; the new tools/mkdeb.sh --sbuild gate caught it post-upload.

This renames the binary package to libhttrack3, reclaims the misplaced libraries from httrack and the old libhttrack2 via Breaks/Replaces, and switches the .files globs to a .so.3* wildcard so the next soname bump no longer silently misplaces the libraries. The ancient libhttrack1 relations (2008) are dropped along the way. Ships as 3.49.8-2; the new binary name goes through Debian NEW.

Validated with a real binary build: libhttrack3 now ships libhttrack.so.3.0.0/.so.3 and libhtsjava equivalents plus the templates, httrack carries no stray libraries, libhttrack-dev keeps only the unversioned .so symlinks, and no libhttrack2 package is produced. lintian no longer reports package-name-doesnt-match-sonames.