### PR TITLE
Make lintian actually gate the Debian package build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,8 @@ jobs:
   # Validate the Debian packaging via the same script maintainers release with.
   # One amd64/gcc run is enough: packaging (control/rules/manifest/lintian/quilt
   # source build) is arch- and compiler-independent, and the build matrix above
-  # already covers compile portability. lintian runs with --fail-on=error.
+  # already covers compile portability. mkdeb.sh runs lintian as an explicit gate
+  # (debuild does not propagate lintian's exit) with --fail-on=error,warning.
   deb:
     name: deb package (lintian)
     runs-on: ubuntu-24.04

--- a/debian/httrack-doc.lintian-overrides
+++ b/debian/httrack-doc.lintian-overrides
@@ -4,3 +4,6 @@
 # so the path lives in the display pointer, not the override -- match with '*'.
 httrack-doc: extra-license-file *
 httrack-doc: package-contains-documentation-outside-usr-share-doc *
+# search.sh is a sample CGI shipped alongside the HTML manual, not meant to be
+# run from the package tree; it stays non-executable by design.
+httrack-doc: script-not-executable *

--- a/tools/mkdeb.sh
+++ b/tools/mkdeb.sh
@@ -206,9 +206,10 @@ main() {
         cp -a "$export_dir/debian" "httrack-$ver/debian"
     )
 
-    # Build (debuild also runs lintian and signs). --fail-on aborts on a lintian
-    # error or warning, so neither a release nor CI produces an unclean package.
-    local -a debuild_opts=(--lintian-opts -I -i "--fail-on=error,warning")
+    # Build and sign. debuild runs lintian too but does NOT propagate its exit
+    # status, so a broken package would pass unnoticed; disable it here and run
+    # lintian ourselves below as the real gate.
+    local -a debuild_opts=(--no-lintian)
     local -a build_opts=()
     [[ $source_only -eq 1 ]] && build_opts+=(-S)
     if [[ $unsigned -eq 1 ]]; then
@@ -219,7 +220,8 @@ main() {
     info "building packages with debuild"
     (
         cd "$scratch/httrack-$ver"
-        debuild "${build_opts[@]}" "${debuild_opts[@]}"
+        # debuild options (--no-lintian) must precede the dpkg-buildpackage ones
+        debuild "${debuild_opts[@]}" "${build_opts[@]}"
     )
 
     # Collect every file the .changes references (orig, dsc, debs, ddebs, buildinfo).
@@ -229,6 +231,16 @@ main() {
     changes=("$scratch"/*.changes)
     shopt -u nullglob
     [[ ${#changes[@]} -ge 1 ]] || die "debuild produced no .changes file"
+
+    # The real lintian gate (debuild only reports, it does not fail on tags).
+    # --profile debian: CI runners are Ubuntu, whose vendor data would wrongly
+    # reject the Debian "unstable" distribution. newer-standards-version only
+    # means the local lintian is older than the buildds', not a package
+    # defect, so suppress it. set -e turns any error/warning tag into a failure.
+    info "running lintian gate (--fail-on=error,warning)"
+    lintian --profile debian -I -i --fail-on=error,warning \
+        --suppress-tags newer-standards-version "${changes[@]}"
+
     dcmd cp -- "${changes[@]}" "$outdir/"
 
     # Clean-room build gate: rebuild the source package in a minimal chroot that


### PR DESCRIPTION
The deb CI job and `mkdeb.sh` ran lintian through `debuild` with `--fail-on=error,warning` and were assumed to gate on it. They did not: `debuild` only *reports* lintian, it does not propagate lintian's exit status, so a package lintian flags with errors or warnings still built green. This was demonstrated by the SONAME bump in #409 landing (briefly) without the matching `libhttrack3` → `libhttrack4` package rename: lintian emitted `E: shared-library-is-multi-arch-foreign …libhttrack.so.4` and `W: package-name-doesnt-match-sonames libhttrack4` (the libraries had fallen through into the catch-all `httrack` package), yet the job passed.

This disables `debuild`'s own lintian run and runs lintian on the produced `.changes` under `set -e`, so any error or warning fails the build. Two adjustments keep a clean package green on the CI runners: `--profile debian` (the Ubuntu runners' vendor data would otherwise reject the Debian `unstable` distribution with `bad-distribution-in-changes-file`), and `--suppress-tags newer-standards-version` (that tag only reflects the runner's lintian being older than the buildds', not a package defect). The long-standing `script-not-executable` hint on the sample `search.sh` gets an override.

I will verify the gate actually fails by temporarily forcing a SONAME mismatch on this branch, confirming the deb job goes red, then reverting before merge.