### PR TITLE
Int-back the exported hts_boolean (and tri-state fields) for C++ source-compat

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -3703,9 +3703,9 @@ HTSEXT_API int copy_htsopt(const httrackp * from, httrackp * to) {
   if (from->maxsoc > 0)
     to->maxsoc = from->maxsoc;
 
-  /* hts_boolean/enum fields are unsigned (GCC), so a bare `> -1` unset-guard
-     is always false; cast to int to keep the -1 "unset" sentinel test. */
-  if ((int) from->nearlink > -1)
+  /* hts_tristate fields use HTS_DEFAULT (-1) for "unspecified": copy_htsopt
+     skips them so the target keeps its value. */
+  if (from->nearlink > -1)
     to->nearlink = from->nearlink;
 
   if (from->timeout > -1)
@@ -3732,10 +3732,10 @@ HTSEXT_API int copy_htsopt(const httrackp * from, httrackp * to) {
   if (from->hostcontrol > -1)
     to->hostcontrol = from->hostcontrol;
 
-  if ((int) from->errpage > -1)
+  if (from->errpage > -1)
     to->errpage = from->errpage;
 
-  if ((int) from->parseall > -1)
+  if (from->parseall > -1)
     to->parseall = from->parseall;
 
   // test all: bit 8 de travel

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -3166,6 +3166,16 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                 if (to->parseall != HTS_FALSE)
                   err = 1;
 
+                /* HTS_DEFAULT (-1) is "unspecified": copy_htsopt must skip it,
+                   leaving the target intact. Only a signed (int-backed) field
+                   can hold -1, so this also guards the type against regressing
+                   to an unsigned hts_boolean. */
+                from->parseall = HTS_DEFAULT;
+                to->parseall = HTS_TRUE;
+                copy_htsopt(from, to);
+                if (to->parseall != HTS_TRUE)
+                  err = 1;
+
                 hts_free_opt(from);
                 hts_free_opt(to);
                 printf("copy-htsopt: %s\n", err ? "FAIL" : "OK");

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -247,13 +247,23 @@ Please visit our Website: http://www.httrack.com
 #define HTS_NOPARAM "(none)"
 #define HTS_NOPARAM2 "\"(none)\""
 
-/* Boolean flag for option fields and API yes/no returns. An enum (not C bool)
-   so it stays int-sized: option fields keep the httrackp layout/ABI, and a
-   return type stays compatible with the int it replaces. */
+/* Boolean flag for option fields and API yes/no returns. Int-backed, not an
+   enum: an enum makes C++ reject `field = 1` / `f(0)` on the exported fields
+   and params. Int-sized, so the httrackp layout and the ABI are unchanged. */
 #ifndef HTS_DEF_DEFSTRUCT_hts_boolean
 #define HTS_DEF_DEFSTRUCT_hts_boolean
 
-typedef enum hts_boolean { HTS_FALSE = 0, HTS_TRUE = 1 } hts_boolean;
+typedef int hts_boolean;
+#define HTS_FALSE 0
+#define HTS_TRUE 1
+#endif
+
+#ifndef HTS_DEF_DEFSTRUCT_hts_tristate
+#define HTS_DEF_DEFSTRUCT_hts_tristate
+/* Tri-state hts_boolean: HTS_DEFAULT (-1) = "unspecified" (copy_htsopt leaves
+   the target untouched); HTS_FALSE/HTS_TRUE = off/on. */
+typedef int hts_tristate;
+#define HTS_DEFAULT (-1)
 #endif
 
 /* Larger/smaller of two values. Macros: arguments are evaluated twice. */

--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -428,11 +428,11 @@ struct httrackp {
   LLint maxfile_html;         /**< max bytes per HTML file */
   int maxsoc;                 /**< max simultaneous sockets (-cN) */
   LLint fragment;             /**< split site after this many bytes */
-  hts_boolean
+  hts_tristate
       nearlink; /**< also fetch images/data adjacent to a page but off-site */
   hts_boolean makeindex;  /**< build a top-level index.html */
   hts_boolean kindex;     /**< build a keyword index */
-  hts_boolean delete_old; /**< delete locally obsolete files after update */
+  hts_tristate delete_old; /**< delete locally obsolete files after update */
   int timeout;            /**< connection timeout in seconds */
   int rateout;            /**< minimum transfer rate (bytes/s) before abort */
   int maxtime;            /**< max total mirror duration in seconds */
@@ -465,13 +465,13 @@ struct httrackp {
   hts_boolean maketrack; /**< maintain an operations-statistics log */
   int parsejava;         /**< Java/JS parsing mode; see htsparsejava_flags */
   int hostcontrol; /**< ban slow/timing-out hosts; see hts_hostcontrol bits */
-  hts_boolean errpage; /**< generate an error page on 404 and similar */
+  hts_tristate errpage; /**< generate an error page on 404 and similar */
   hts_boolean
       check_type; /**< probe unknown-type links (cgi/asp/dir) and follow moves
                    */
   hts_boolean all_in_cache;      /**< keep all retrieved data in the cache */
   hts_robots robots;             /**< robots.txt handling level */
-  hts_boolean external;          /**< render external links as error pages */
+  hts_tristate external;         /**< render external links as error pages */
   hts_boolean passprivacy;       /**< strip passwords from external links */
   hts_boolean includequery;      /**< include the query string in saved names */
   hts_boolean mirror_first_page; /**< only mirror the links of the first page */
@@ -485,7 +485,7 @@ struct httrackp {
   hts_boolean sizehack;          /**< treat same-size response as "updated" */
   hts_boolean urlhack;           // force "url normalization" to avoid loops
   hts_boolean tolerant;          /**< accept an incorrect Content-Length */
-  hts_boolean
+  hts_tristate
       parseall; /**< parse aggressively, including unknown tags with links */
   hts_boolean parsedebug; /**< parser debug mode */
   hts_boolean norecatch;  /**< do not re-fetch files the user deleted locally */


### PR DESCRIPTION
`hts_boolean` is a real `enum {HTS_FALSE=0, HTS_TRUE=1}`. C is fine with it, but C++ forbids assigning a plain int to an enum, so every C++ consumer of the public API breaks on `opt->field = 1` or `f(opt, 0)`. The exported surface that trips this is wide: 33 `hts_boolean` fields in `struct httrackp`, plus two exported parameters (`unescape_http_unharm`'s `no_high`, `get_httptype_sized`'s `flag`). httraqt, libhttrack's one reverse-dependency, fails to build against the installed headers because of it, which blocks the libhttrack.so.2 to .so.3 binNMU.

Make `hts_boolean` an int-backed typedef (HTS_FALSE/HTS_TRUE become macros). That fixes the whole exported boolean surface in one place: an int is assignable from an int in both C and C++. It is safe here because `hts_boolean` has a single definition, nothing uses the `enum hts_boolean` form anywhere, and HTS_FALSE/HTS_TRUE are only ever used as 0/1 values. The ABI is unchanged: an int-sized enum and an int have identical size and alignment, so `sizeof(struct httrackp)` stays 141648 and the soname is untouched.

Five of those fields are not booleans but tri-state {-1 unspecified, 0 off, 1 on}: the -1 is `copy_htsopt()`'s "leave the target's value" sentinel, set so a partially-filled options struct can be merged onto a fully-initialised one. The old unsigned enum could not hold -1, so the `copy_htsopt` `> -1` guard was always true and the field was always overwritten (a latent bug). Give them a named `hts_tristate` (also int-backed, with `HTS_DEFAULT = -1`) so the sentinel works and reads honestly, drop the now-pointless `(int)` casts, and extend the `-#9` copy_htsopt self-test to assert an `HTS_DEFAULT` source is skipped.

Verified: the engine builds and `-#9` passes (including the new sentinel case); `sizeof(struct httrackp)` is unchanged; and httraqt 1.4.11 rebuilds cleanly against the patched headers with zero int-to-enum errors and links libhttrack.so.3.
