### PR TITLE
Release 3.49.9

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.71])
 
-AC_INIT([httrack], [3.49.8], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
+AC_INIT([httrack], [3.49.9], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
 AC_COPYRIGHT([
 HTTrack Website Copier, Offline Browser for Windows and Unix
 Copyright (C) 1998-2015 Xavier Roche and other contributors
@@ -29,9 +29,10 @@ AC_CONFIG_SRCDIR(src/httrack.c)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
-# 3:0:0: htsblk layout changed (contenttype/charset/contentencoding widened to
-# 128), an incompatible ABI break, so bump current and reset revision/age.
-VERSION_INFO="3:0:0"
+# 3:1:0: 3.49.9 changed code but not the exported interface vs 3.49.8 (same 164
+# symbols, no struct-layout change), so bump revision only. (3:0:0 was the htsblk
+# mime-buffer widening, an ABI break that moved the soname .so.2 -> .so.3.)
+VERSION_INFO="3:1:0"
 AM_MAINTAINER_MODE
 AC_USE_SYSTEM_EXTENSIONS
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+httrack (3.49.9-1) unstable; urgency=medium
+
+  * New upstream release: Content-Type and file-type detection fixes (trust a
+    declared Content-Type over a binary URL extension, honor --assume under the
+    delayed type check, keep a known extension against a bogus or empty
+    Content-Type, and avoid an uninitialised read on an empty Content-Type), and
+    restored C++ source-compatibility of the installed headers so reverse
+    dependencies (httraqt) build again.
+
+ -- Xavier Roche <xavier@debian.org>  Sun, 21 Jun 2026 17:59:38 +0200
+
 httrack (3.49.8-2) unstable; urgency=medium
 
   * Rename libhttrack2 to libhttrack3 to follow the SONAME, which the 3.49.8

--- a/history.txt
+++ b/history.txt
@@ -4,6 +4,12 @@ HTTrack Website Copier release history:
 
 This file lists all changes and fixes that have been made for HTTrack
 
+3.49-9
++ Fixed: file-type detection from the Content-Type header: trust a declared type over a binary URL extension, honor --assume under the delayed type check, and keep a known extension against a bogus or empty Content-Type (#267, #29, #56)
++ Fixed: an uninitialized-buffer read when the Content-Type is empty (#411)
++ Fixed: restored C++ source-compatibility of the installed headers so reverse dependencies (httraqt) build again (#413)
++ Changed: multiple internal build, packaging and test-harness improvements
+
 3.49-8
 + New: tunnel HTTPS downloads through the configured HTTP proxy via CONNECT (#85)
 + New: parse every candidate URL in <img> and <source> srcset lists (#326)

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -43,8 +43,8 @@ Please visit our Website: http://www.httrack.com
    configure.ac, decoupled from these). VERSION is the display form, VERSIONID
    the dotted numeric form, AFF_VERSION the short form shown in footers,
    LIB_VERSION the data/cache format generation. */
-#define HTTRACK_VERSION "3.49-8"
-#define HTTRACK_VERSIONID "3.49.8"
+#define HTTRACK_VERSION "3.49-9"
+#define HTTRACK_VERSIONID "3.49.9"
 #define HTTRACK_AFF_VERSION "3.x"
 #define HTTRACK_LIB_VERSION "2.0"
 


### PR DESCRIPTION
Bumps to 3.49.9. Since 3.49.8 this gathers the Content-Type and file-type detection fixes (trust a declared Content-Type over a binary URL extension, honor --assume under the delayed type check, keep a known extension against a bogus or empty Content-Type, and avoid an uninitialised read on an empty Content-Type) and the restoration of C++ source-compatibility of the installed headers (int-backed `hts_boolean`/`hts_tristate`, #413) that lets the reverse-dependency httraqt build again. The rest is internal build, packaging and test-harness work, folded into a single history.txt line.

The exported interface is unchanged versus 3.49.8 (same 164 symbols, no struct-layout change), so `VERSION_INFO` is a revision bump (`3:0:0` to `3:1:0`) and the soname stays `libhttrack.so.3`.

Release notes are curated by audience: upstream-facing items in `history.txt` (the `3.49-9` block), a brief overview in `debian/changelog` (`3.49.9-1`). Verified by a full mkdeb build (lintian-gated) and by rebuilding httraqt 1.4.11 unchanged against the produced `libhttrack-dev`: it compiles clean, links `libhttrack.so.3`, and depends on `libhttrack3 (>= 3.49.9)` — the binNMU outcome.
