### PR TITLE
debian: convert copyright to DEP-5 and credit all bundled authors

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -1,21 +1,109 @@
-This package was debianized by Xavier Roche <roche@httrack.com> on
-Fri, 27 Sep 2002 16:42:26 +0200
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: httrack
+Upstream-Contact: Xavier Roche <roche@httrack.com>
+Source: https://www.httrack.com/
 
-The current Debian maintainer is Xavier Roche <xavier@debian.org>
+Files: *
+Copyright: 1998-2026 Xavier Roche and other contributors
+License: GPL-3+
+Comment:
+ The engine includes contributions from Yann Philippot (src/htsjava.c,
+ src/htsjava.h). htsbasenet.h links against the system OpenSSL library
+ (originally by Eric Young); no OpenSSL/SSLeay code is bundled here.
 
-Upstream author: Xavier Roche <roche@httrack.com>
+Files: src/minizip/*
+Copyright: 1998-2010 Gilles Vollant
+           2007-2008 Even Rouault
+           2009-2010 Mathias Svensson
+           1990-2000 Info-ZIP
+License: Zlib
+Comment:
+ The decryption code in src/minizip/crypt.h and src/minizip/unzip.c derives
+ from the Info-ZIP distribution, distributed under the same terms.
 
-Copyright: 1998-2014 Xavier Roche and other contributors
+Files: src/md5.c
+Copyright: 1993 Colin Plumb
+License: public-domain-md5
+ This code implements the MD5 message-digest algorithm, due to Ron Rivest.
+ It was written by Colin Plumb in 1993, no copyright is claimed. This code
+ is in the public domain; do with it what you wish.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+Files: src/coucal/*
+Copyright: 2013-2014 Xavier Roche
+License: BSD-3-clause
 
-On Debian systems, the complete text of the GNU General Public
-License version 3 can be found in /usr/share/common-licenses/GPL-3 file.
+Files: src/coucal/murmurhash3.h*
+Copyright: Austin Appleby
+License: public-domain-murmurhash3
+ MurmurHash3 was written by Austin Appleby, and is placed in the public
+ domain. The author hereby disclaims copyright to this source code.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Files: html/server/div/com.httrack.WebHTTrack.metainfo.xml
+Copyright: 1998-2026 Xavier Roche and other contributors
+License: FSFAP
+ Copying and distribution of this file, with or without modification, are
+ permitted in any medium without royalty provided the copyright notice and
+ this notice are preserved. This file is offered as-is, without any warranty.
+
+Files: debian/*
+Copyright: 2002-2026 Xavier Roche <xavier@debian.org>
+License: GPL-3+
+
+License: GPL-3+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ .
+ On Debian systems, the complete text of the GNU General Public License
+ version 3 can be found in /usr/share/common-licenses/GPL-3.
+
+License: Zlib
+ This software is provided 'as-is', without any express or implied warranty.
+ In no event will the authors be held liable for any damages arising from the
+ use of this software.
+ .
+ Permission is granted to anyone to use this software for any purpose,
+ including commercial applications, and to alter it and redistribute it
+ freely, subject to the following restrictions:
+ .
+ 1. The origin of this software must not be misrepresented; you must not claim
+    that you wrote the original software. If you use this software in a product,
+    an acknowledgment in the product documentation would be appreciated but is
+    not required.
+ 2. Altered source versions must be plainly marked as such, and must not be
+    misrepresented as being the original software.
+ 3. This notice may not be removed or altered from any source distribution.
+
+License: BSD-3-clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ .
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+ 3. Neither the name of the copyright holder nor the names of its contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
The Debian NEW review of httrack 3.49.9-1 was ACCEPTED, with a request to credit some uncredited authors and to move `debian/copyright` to DEP-5 format.

The old free-form file credited only Xavier Roche. The source tree actually ships code from several other authors under three additional licenses, none of which were mentioned: Yann Philippot's `src/htsjava.*` (GPL-3+), the minizip code by Gilles Vollant, Mathias Svensson, Even Rouault and Info-ZIP (Zlib), Colin Plumb's `src/md5.c` (public domain), and the bundled coucal library — `coucal.{c,h}` (BSD-3-clause) and Austin Appleby's `murmurhash3.h` (public domain). All ship in the `make dist` tarball via `src/Makefile.am`, so they belong in `debian/copyright`.

This rewrites the file as machine-readable DEP-5 with one `Files` stanza per component and the full license texts. The `Eric Young` line in `htsbasenet.h` is only an attribution comment for the system OpenSSL the binary links against (no SSLeay code is bundled), so it gets no stanza.

Packaging-only change, confined to `debian/`. No `debian/changelog` entry here; add the `-2` at upload time if a separate upload is wanted rather than folding this into the next release.