### PR TITLE
Silence coucal hashtable stats on the default log handler

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -5305,6 +5305,11 @@ static int get_loglevel_from_coucal(coucal_loglevel level) {
 static void default_coucal_loghandler(void *arg, coucal_loglevel level, 
                                        const char* format, va_list args) {
 
+  /* informational chatter (hashtable stats on delete, etc.) only when
+     debugging; keep warnings and critical errors always visible. */
+  if (level > coucal_log_warning && hts_dgb_init <= 0) {
+    return;
+  }
   if (level <= coucal_log_warning) {
     fprintf(stderr, "** warning: ");
   }


### PR DESCRIPTION
Starting `webhttrack` prints two stray lines to the console:

```
hashtable "NewLangStr" summary: size=1024 ...
hashtable "NewLangStrKeys" summary: size=1024 ...
```

These come from coucal: `coucal_delete()` logs a per-table stats summary at info level. Tables that have their own handler route to the project log, but the webhttrack language tables (`NewLangStr`/`NewLangStrKeys`) fall through to `default_coucal_loghandler`, which printed every level regardless of severity.

This drops info-and-below messages in that handler unless debugging is enabled (`hts_dgb_init`, set via `HTS_LOG` or `hts_debug`). Warnings and critical errors still always print, and the stats remain available when you actually want them.

No test: asserting this means driving webhttrack`s lang-loading path and grepping stderr for the absence of a log line, which is brittle and outside the crawl test harness. Verified manually that the lines are gone on a normal start.