### PR TITLE
Override embedded-library for the bundled patched minizip; gate lintian on Debian sid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,30 +232,42 @@ jobs:
   deb:
     name: deb package (lintian)
     runs-on: ubuntu-24.04
+    # Build and gate inside Debian sid, the upload target. A Debian dpkg-deb
+    # produces archive-legal xz members (an Ubuntu host defaults to zstd, which
+    # the archive's lintian rejects), and sid's lintian carries the same
+    # data-driven checks (embedded-lib fingerprints and the like) the buildds and
+    # UDD apply -- so issues surface here instead of after upload.
+    container: debian:sid
     steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
       - name: Install packaging toolchain
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates git \
             build-essential autoconf automake libtool autoconf-archive \
             zlib1g-dev libssl-dev \
             debhelper devscripts lintian fakeroot
 
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
       # --unsigned: CI has no GPG key (also skips the release sig/checksums).
-      # debuild builds every package, then lintian gates on errors.
+      # mkdeb builds every package then runs the lintian gate (--fail-on=error,
+      # warning); debuild runs the packaged test pass.
       #
       # DEB_BUILD_OPTIONS trims work CI does not need (release builds via
       # mkdeb.sh are untouched): noautodbgsym drops the -dbgsym packages whose
       # LTO payloads are slow to compress and that CI never ships; parallel uses
-      # every core. We let debuild run its test pass -- the only one now that
-      # mkdeb no longer runs its own -- so CI exercises the packaged tests.
-      - name: Build Debian packages
+      # every core.
+      - name: Build and lint Debian packages
         run: |
+          set -euo pipefail
+          # The workspace volume is owned by the host runner uid, but the
+          # container runs as root, so mkdeb's git calls (superproject and the
+          # coucal submodule) trip "dubious ownership"; mark them all safe.
+          git config --global --add safe.directory "*"
           export DEB_BUILD_OPTIONS="noautodbgsym parallel=$(nproc)"
           bash tools/mkdeb.sh --unsigned --no-release-artifacts
 

--- a/debian/libhttrack3.lintian-overrides
+++ b/debian/libhttrack3.lintian-overrides
@@ -1,3 +1,8 @@
 # The shared libraries ship without a versioned symbols control file (ABI is
 # tracked via the SONAME plus a >= upstream-version dependency, see debian/rules).
 libhttrack3: no-symbols-control-file usr/lib/*
+
+# Bundled, locally patched minizip (src/minizip): it adds a zipFlush() API the
+# system libminizip lacks (htscache.c flushes the cache .zip so an interrupted
+# crawl leaves a valid archive), plus Android/old-zlib portability fixes.
+libhttrack3: embedded-library *libminizip*

--- a/debian/proxytrack.lintian-overrides
+++ b/debian/proxytrack.lintian-overrides
@@ -1,0 +1,3 @@
+# Statically linked against httrack's bundled, patched minizip (see src/minizip
+# and libhttrack3's override): the zipFlush() API is absent from the system one.
+proxytrack: embedded-library *libminizip*


### PR DESCRIPTION
httrack statically links its own patched copy of minizip (src/minizip): it adds a zipFlush() the system libminizip does not have, which htscache.c relies on to flush the cache .zip so an interrupted crawl still leaves a valid archive, alongside Android and old-zlib portability fixes. lintian flags that as an embedded-library error on libhttrack3 and proxytrack. The system copy cannot stand in until the flush API is upstream, so this adds justified overrides for both packages.

The error was invisible to our CI gate: it runs Ubuntu lintian, whose embedded-library fingerprint list predates the minizip entry, so the tag only fired on the Debian buildds and showed up on UDD. To stop that class of drift slipping through, the deb job now re-runs the same gate inside a debian:sid container after the build, where lintian data matches the archive.

Verified against a real sid lintian (v2.136.2): it emits embedded-library for both packages, the overrides silence it with no mismatched or unused override, and the full --fail-on=error,warning gate passes.