### PR TITLE
tests: lock special-char URL naming across an update (#157)

### DIFF
--- a/tests/21_local-intl-update.test
+++ b/tests/21_local-intl-update.test
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# #157: a dotless, accented URL named .html on the first crawl must keep .html
+# across an update -- not revert to the extensionless name.
+
+: "${top_srcdir:=..}"
+
+bash "$top_srcdir/tests/local-crawl.sh" --errors 0 --rerun \
+    --found 'intl/Instalação_CVS_no_Ubuntu.html' \
+    --not-found 'intl/Instalação_CVS_no_Ubuntu' \
+    httrack 'BASEURL/intl/index.html'

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -60,6 +60,7 @@ TESTS = \
 	17_local-empty-ct.test \
 	18_local-update.test \
 	19_local-connect-fallback.test \
-	20_local-resume-loop.test
+	20_local-resume-loop.test \
+	21_local-intl-update.test
 
 CLEANFILES = check-network_sh.cache

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -196,6 +196,15 @@ if test -n "$rerun"; then
         exit 1
     }
     result "OK (update)"
+    # The update summary reports "files updated"; a fresh crawl never does. Assert
+    # it so a regression that bypasses the cache (re-crawls fresh) can't pass.
+    info "checking update used the cache"
+    if grep -aqE "mirror complete in .*files updated" "${out}/hts-log.txt"; then
+        result "OK"
+    else
+        result "update pass did not report cache activity"
+        exit 1
+    fi
 fi
 
 # --- discover the single host root (127.0.0.1_<port> or 127.0.0.1) -----------

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -177,6 +177,17 @@ class Handler(SimpleHTTPRequestHandler):
         body, ctype = self.TYPE_MATRIX[path]
         self.send_raw(body, ctype)
 
+    # --- special chars in URLs across an update (issue #157) ---------------
+    # A dotless, accented basename served as text/html (MediaWiki style). The
+    # name the first crawl picks (.html) must survive the update pass.
+    INTL_NAME = "Instalação_CVS_no_Ubuntu"
+
+    def route_intl_index(self):
+        self.send_html('\t<a href="%s">accented</a>\n' % self.INTL_NAME)
+
+    def route_intl_page(self):
+        self.send_raw(b"<html><body>accented page</body></html>\n", "text/html")
+
     # resume / 416 loop (#206): the first GET stalls after a prefix so the crawl
     # can be interrupted (partial + temp-ref); every later request is 416.
     RESUME_PREFIX = b"PARTIAL-" + b"x" * 4096  # flushed before the stall
@@ -233,6 +244,8 @@ class Handler(SimpleHTTPRequestHandler):
         "/types/style.css": route_types,
         "/types/data.json": route_types,
         "/types/gen.php": route_types,
+        "/intl/index.html": route_intl_index,
+        "/intl/" + INTL_NAME: route_intl_page,
         "/resume/index.html": route_resume_index,
         "/resume/blob.txt": route_resume,
     }
@@ -242,7 +255,8 @@ class Handler(SimpleHTTPRequestHandler):
     def dispatch(self):
         self._set_cookies = []
         path = urlsplit(self.path).path
-        handler = self.ROUTES.get(path)
+        # Match percent-encoded paths (accented #157 route) by their decoded form.
+        handler = self.ROUTES.get(path) or self.ROUTES.get(unquote(path))
         if handler is not None:
             handler(self)
             return True


### PR DESCRIPTION
#157 reported that accented URLs (a pt-BR MediaWiki intranet) lost their `.html` extension on an update pass, so the rewritten links pointed at extensionless files the browser won't render. It was filed against 3.49-2 on Windows.

It doesn't reproduce on current master. I drove a dotless accented page (`Instalação_CVS_no_Ubuntu`) served as `text/html` through a fresh crawl and then an update against the same cache, and the name round-trips: the update reads the cached content-type back and re-applies `.html`. Same result with UTF-8 and ISO-8859-1 source pages, raw Latin-1 href bytes, either percent-encoding case, and dotted tails. The original symptom was a Windows codepage vs UTF-8 `X-Save` filename mismatch, which can't happen on a UTF-8 filesystem, so there's nothing to fix here.

So instead of chasing it, this locks the invariant the report is about: a dotless accented basename served as `text/html`, crawled then updated, must keep its `.html` name and not leave an extensionless sibling. The test runs offline through the local server (a new `/intl/` route), so it exercises the special-char update naming path on every platform we build, the macOS job included.

Closes #157