### PR TITLE
Lock --tolerant (-%B) on broken Content-Length, and fix an OOB it surfaced (#32/#41)

### DIFF
--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -353,6 +353,14 @@ static void basic_selftests(void) {
     assertf(get_httptype_sized(opt, r.contenttype, sizeof(r.contenttype),
                                "noextfile", 1) == 1);
     assertf(strcmp(r.contenttype, "application/octet-stream") == 0);
+    // empty fil: no extension to scan; must not over-read before the string.
+    // flag==0 -> 0 (nothing written), flag==1 -> octet-stream.
+    assertf(get_httptype_sized(opt, r.contenttype, sizeof(r.contenttype), "",
+                               0) == 0);
+    assertf(r.contenttype[0] == '\0');
+    assertf(get_httptype_sized(opt, r.contenttype, sizeof(r.contenttype), "",
+                               1) == 1);
+    assertf(strcmp(r.contenttype, "application/octet-stream") == 0);
     // a user --assume rule with an empty value matches but writes nothing:
     // get_userhttptype returns 1 with the buffer empty, so get_httptype_sized
     // must still report 0 (callers test the return like the old

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -4177,9 +4177,10 @@ HTSEXT_API hts_boolean get_httptype_sized(httrackp *opt, char *s, size_t ssize,
     /* Check html -> text/html */
     const char *a = fil + strlen(fil) - 1;
 
-    while((*a != '.') && (*a != '/') && (a > fil))
+    /* a < fil when fil is empty: bound before dereferencing */
+    while ((a > fil) && (*a != '.') && (*a != '/'))
       a--;
-    if (*a == '.' && strlen(a) < 32) {
+    if (a >= fil && *a == '.' && strlen(a) < 32) {
       int j = 0;
 
       a++;

--- a/tests/22_local-broken-size.test
+++ b/tests/22_local-broken-size.test
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Issues #32/#41: a Content-Length that disagrees with the body warns "bogus
+# state (broken size)" and skips the cache; -%B (tolerant) accepts it.
+
+: "${top_srcdir:=..}"
+
+# Default: warn, but the file is still written.
+bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
+    --found 'size/oversize.bin' \
+    --log-found 'bogus state \(broken size' \
+    httrack 'BASEURL/size/index.html'
+
+# -%B (tolerant): no warning, file written.
+bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
+    --found 'size/oversize.bin' \
+    --log-not-found 'bogus state' \
+    httrack 'BASEURL/size/index.html' '-%B'

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -61,6 +61,7 @@ TESTS = \
 	18_local-update.test \
 	19_local-connect-fallback.test \
 	20_local-resume-loop.test \
-	21_local-intl-update.test
+	21_local-intl-update.test \
+	22_local-broken-size.test
 
 CLEANFILES = check-network_sh.cache

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -14,7 +14,9 @@
 # Usage:
 #   bash local-crawl.sh [--tls] [--root DIR] \
 #       --errors N --files N --found PATH ... --directory PATH ... \
+#       --log-found REGEX ... --log-not-found REGEX ... \
 #       httrack BASEURL/some/path [httrack-args...]
+# --log-found/--log-not-found grep (ERE) the crawl's hts-log.txt.
 
 set -u
 
@@ -107,7 +109,7 @@ while test "$pos" -lt "$nargs"; do
         audit+=("${args[$pos]}" "${args[$((pos + 1))]}")
         pos=$((pos + 1))
         ;;
-    --found | --not-found | --directory)
+    --found | --not-found | --directory | --log-found | --log-not-found)
         audit+=("${args[$pos]}" "${args[$((pos + 1))]}")
         pos=$((pos + 1))
         ;;
@@ -256,6 +258,22 @@ while test "$i" -lt "${#audit[@]}"; do
             result "not found"
             exit 1
         fi
+        ;;
+    --log-found)
+        i=$((i + 1))
+        info "checking log matches ${audit[$i]}"
+        if grep -aqE "${audit[$i]}" "${out}/hts-log.txt"; then result "OK"; else
+            result "not in log"
+            exit 1
+        fi
+        ;;
+    --log-not-found)
+        i=$((i + 1))
+        info "checking log lacks ${audit[$i]}"
+        if grep -aqE "${audit[$i]}" "${out}/hts-log.txt"; then
+            result "present in log"
+            exit 1
+        else result "OK"; fi
         ;;
     esac
     i=$((i + 1))

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -225,6 +225,21 @@ class Handler(SimpleHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
+    # broken Content-Length (#32/#41): declared size != bytes sent. httrack
+    # warns "bogus state (broken size)" and skips the cache unless -%B.
+    def route_size_index(self):
+        self.send_html('\t<a href="oversize.bin">over</a>\n')
+
+    def route_size_oversize(self):
+        body = b"A" * 100
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(len(body) - 2))  # lie: too short
+        self.send_header("Connection", "close")
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
     ROUTES = {
         "/cookies/entrance.php": route_entrance,
         "/cookies/second.php": route_second,
@@ -248,6 +263,8 @@ class Handler(SimpleHTTPRequestHandler):
         "/intl/" + INTL_NAME: route_intl_page,
         "/resume/index.html": route_resume_index,
         "/resume/blob.txt": route_resume,
+        "/size/index.html": route_size_index,
+        "/size/oversize.bin": route_size_oversize,
     }
 
     # --- dispatch ----------------------------------------------------------


### PR DESCRIPTION
A response whose Content-Length disagrees with the bytes received already has a switch: -%B/--tolerant accepts it. Without it, such a response warns "bogus state (broken size)" and is skipped from the cache, so it is re-fetched and re-warned on every run (the "same files every run" complaint in #32). The file itself reaches disk in both cases. The test pins that contract so a regression in the size check or the tolerant gate fails in make check.

The local server gains a /size route that declares a length two bytes short of the body; the test asserts the warning fires by default, is silent under -%B, and the file is present in both passes. local-crawl.sh gets --log-found/--log-not-found to grep hts-log.txt. #41 is the same path with a truncated (rather than over-long) body, a genuinely incomplete download that the size check rightly rejects; -%B will force-store it if you accept the partial data.

That new test surfaced a latent global-buffer-overflow. get_httptype_sized scanned for the extension with a = fil + strlen(fil) - 1 and dereferenced *a before checking the a > fil bound, so an empty filename read one byte before the string. istoobig passes a literal "" to is_hypertext_mime when it classifies by mime alone (the quota check in back_checksize), so any octet-stream-ish download triggered it. Only ASan caught the stray .rodata read; the second commit bounds the scan before the dereference.

Closes #32
Closes #41