### PR TITLE
Lock "no error pages" (-o0) write-suppression, and confirm #17 non-reproducible

### DIFF
--- a/tests/23_local-errpage.test
+++ b/tests/23_local-errpage.test
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Issue #17: with "no error pages" (-o0), 4xx/5xx bodies must not be written;
+# a genuine 0-byte 200 stays. Default (-o1) writes the error page. (#17's purge
+# half also does not reproduce; the purge path is not exercised here.)
+set -e
+
+: "${top_srcdir:=..}"
+
+# -o0: 404 suppressed, good page and the legit 0-byte 200 kept.
+bash "$top_srcdir/tests/local-crawl.sh" --errors 1 \
+    --found 'errpage/good.html' \
+    --found 'errpage/empty.html' \
+    --not-found 'errpage/missing.html' \
+    httrack 'BASEURL/errpage/index.html' '-o0'
+
+# Control -o1 (default): the 404 error page is written.
+bash "$top_srcdir/tests/local-crawl.sh" --errors 1 \
+    --found 'errpage/missing.html' \
+    httrack 'BASEURL/errpage/index.html' '-o1'

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -62,6 +62,7 @@ TESTS = \
 	19_local-connect-fallback.test \
 	20_local-resume-loop.test \
 	21_local-intl-update.test \
-	22_local-broken-size.test
+	22_local-broken-size.test \
+	23_local-errpage.test
 
 CLEANFILES = check-network_sh.cache

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -225,6 +225,24 @@ class Handler(SimpleHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
+    # error pages / 0-byte files (#17): -o0 ("no error pages") must keep 4xx/5xx
+    # bodies off disk; a genuine 0-byte 200 is a valid file and stays.
+    def route_errpage_index(self):
+        self.send_html(
+            '\t<a href="good.html">good</a>\n'
+            '\t<a href="missing.html">missing</a>\n'
+            '\t<a href="empty.html">empty</a>\n'
+        )
+
+    def route_errpage_good(self):
+        self.send_raw(b"<html><body>good page</body></html>\n", "text/html")
+
+    def route_errpage_missing(self):
+        self.send_html("\t404 error body", status=404, extra_status="Not Found")
+
+    def route_errpage_empty(self):
+        self.send_raw(b"", "text/html")
+
     # broken Content-Length (#32/#41): declared size != bytes sent. httrack
     # warns "bogus state (broken size)" and skips the cache unless -%B.
     def route_size_index(self):
@@ -265,6 +283,10 @@ class Handler(SimpleHTTPRequestHandler):
         "/resume/blob.txt": route_resume,
         "/size/index.html": route_size_index,
         "/size/oversize.bin": route_size_oversize,
+        "/errpage/index.html": route_errpage_index,
+        "/errpage/good.html": route_errpage_good,
+        "/errpage/missing.html": route_errpage_missing,
+        "/errpage/empty.html": route_errpage_empty,
     }
 
     # --- dispatch ----------------------------------------------------------


### PR DESCRIPTION
#17 (WinHTTrack 3.47-19, 2013) reported that 404 error pages and 0-byte files stayed on disk and were never purged, even with "No error pages" set and purge enabled. Like #137/#162/#157, it does not reproduce on current master/Linux.

With `-o0` ("no error pages"), a 4xx/5xx response has its body freed and is flagged as an error before the write section (htsparse.c:3943), so it never reaches disk or the purge list. A genuine 0-byte 200 is a valid resource and is still saved, which is correct and not the reported bug. On update, purge removes files that are no longer fetched; they survive only when purge is explicitly off (`-X0`), the documented "do not purge" behavior. I checked this by building master and crawling a local server with 404, empty-body, and good routes under `-o0`/`-o1` with purge on and off, including two-run update cases.

The report's `.html` names are the extension-mangle bug (Defect A, fixed in #408; the reporter switched to HTTP/1.0 precisely because binaries were being renamed `.html`), and the settings-revert-on-update path is closed by the hts_tristate option work (4549ec3, #413).

Test-only: adds an `/errpage/` route group to local-server.py and `23_local-errpage.test`, locking the `-o0` suppression (404 not written, 0-byte 200 kept) with an `-o1` control that proves the error page is otherwise written. Negative control verified: neutering the errpage gate at htsparse.c:3902 makes the test fail.

Closes #17
