### PR TITLE
Keep size-based filter rules neutral until the file size is known (#143)

### DIFF
--- a/src/htsfilters.c
+++ b/src/htsfilters.c
@@ -76,7 +76,8 @@ int fa_strjoker(int type, char **filters, int nfil, const char *nom, LLint * siz
     }
     if (size)
       sz = *size;
-    if (strjoker(nom, filters[i] + filteroffs, &sz, size_flag)) {       // reconnu
+    /* size unknown (scan time): no size pointer => size tests stay neutral */
+    if (strjoker(nom, filters[i] + filteroffs, size ? &sz : NULL, size_flag)) {
       if (size)
         if (sz != *size)
           sizelimit = sz;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -524,6 +524,30 @@ static int st_filter(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* Size-aware filter verdict via fa_strjoker: a negative <size> means the size
+   is still unknown (scan time), so a size rule like -*.jpg*[<10] must stay
+   neutral. */
+static int st_filtersize(httrackp *opt, int argc, char **argv) {
+  LLint sz;
+  int size_flag = 0, verdict, known;
+
+  (void) opt;
+  if (argc < 3) {
+    fprintf(stderr, "filtersize: needs <size> <string> <filter> [filter...]\n");
+    return 1;
+  }
+  known = (argv[0][0] != '-'); /* "-1"/"-" => size unknown */
+  sz = known ? (LLint) strtoll(argv[0], NULL, 10) : -1;
+  verdict = fa_strjoker(0, &argv[2], argc - 2, argv[1], known ? &sz : NULL,
+                        known ? &size_flag : NULL, NULL);
+  printf("verdict=%s size_flag=%d\n",
+         verdict > 0   ? "allowed"
+         : verdict < 0 ? "forbidden"
+                       : "unknown",
+         size_flag);
+  return 0;
+}
+
 static int st_simplify(httrackp *opt, int argc, char **argv) {
   (void) opt;
   if (argc < 1) {
@@ -1038,6 +1062,9 @@ static const struct selftest_entry {
 } selftests[] = {
     {"filter", "<pattern> <string>", "match a string against a wildcard filter",
      st_filter},
+    {"filtersize", "<size> <string> <filter>...",
+     "size-aware filter verdict (negative size = unknown/scan time)",
+     st_filtersize},
     {"simplify", "<path>", "collapse ./ and ../ in a path", st_simplify},
     {"mime", "<filename>", "MIME type for a filename", st_mime},
     {"charset", "<charset> <string>",

--- a/tests/01_engine-filter.test
+++ b/tests/01_engine-filter.test
@@ -71,3 +71,24 @@ nomatch '*[\[\]]' '[' # not matched, despite the docs
 match '*[\[\]]' ']'   # only via the empty class-match + trailing ']'
 match '*[\[\]]' '[]'  # one of {'[','\'} then the trailing ']'
 nomatch '*[\[\]]' '[]x'
+
+# Size-based rules (-#test=filtersize <size> <string> <filter...>): a negative size
+# means the size is still unknown (scan time). A size exclusion must stay neutral
+# then, so the file is fetched and only cancelled once its size is known (#143).
+fsize() {
+    local want="$1"
+    shift
+    test "$(httrack -O /dev/null -#test=filtersize "$@")" == "$want" || exit 1
+}
+fsize 'verdict=allowed size_flag=0' -1 foo.jpg -* '+*.jpg' '-*.jpg*[<10]'   # scan time: keep
+fsize 'verdict=forbidden size_flag=1' 5 foo.jpg -* '+*.jpg' '-*.jpg*[<10]'  # <10KB: cancel
+fsize 'verdict=allowed size_flag=1' 20 foo.jpg -* '+*.jpg' '-*.jpg*[<10]'   # >=10KB: keep
+fsize 'verdict=forbidden size_flag=0' -1 foo.txt -* '+*.jpg' '-*.jpg*[<10]' # not a jpg
+
+# [name]/[file]/[path] never span '?' mid-string; a trailing query is still
+# tolerated by the global '?' rule (same as plain *.aspx), not the class (#144).
+nomatch '*[path]/end' 'a?b/end'
+nomatch '*[file]end' 'foo?xend'
+nomatch '*[name]X' 'abc?X'
+match '*[file]' 'foo?x=1' # trailing query: tolerated, as for *.aspx
+match '*.aspx' 'page.aspx?y=2'


### PR DESCRIPTION
A scan rule like `-*.jpg*[<10]` should fetch every JPG and then drop the ones under 10KB once their size is known. Instead it could forbid all of them before anything was downloaded, logging `(wizard) explicit forbidden (-*.jpg*[<10])`. At scan time the size is not known yet, so the wizard calls `fa_strjoker` with no size, but `fa_strjoker` always handed `strjoker` the address of an uninitialized local `sz`. The `*[<10]` predicate then compared against stack garbage, and whenever that garbage fell in `[0,10)` the rule matched and the link was dropped up front. The size-aware second pass (after download) already worked.

The fix passes no size pointer when the size is unknown, reusing `strjoker`'s existing "test impossible, no match" path so size rules stay neutral at scan time and only fire once the real size is in. The size-known path is untouched. A new `filtersize` engine self-test drives `fa_strjoker` through both phases, and a block in `01_engine-filter.test` pins the scenario (scan time keeps the JPG, under 10KB cancels it, 10KB or more keeps it); forcing the old uninitialized read into the `[0,10)` regime makes the scan-time case forbid and the test fail.

This also locks #144 as working-as-intended. The `*[name]`/`*[file]`/`*[path]` classes never span `?` mid-string; the query string the reporter saw is tolerated by the same global rule that lets `*.aspx` match `page.aspx?y=2`, not by the class. Tests pin that too.

Closes #143
