### PR TITLE
filtersize self-test: portable LLint parse and lock the '>' size operator

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -537,7 +537,9 @@ static int st_filtersize(httrackp *opt, int argc, char **argv) {
     return 1;
   }
   known = (argv[0][0] != '-'); /* "-1"/"-" => size unknown */
-  sz = known ? (LLint) strtoll(argv[0], NULL, 10) : -1;
+  sz = -1;
+  if (known)
+    sscanf(argv[0], LLintP, &sz);
   verdict = fa_strjoker(0, &argv[2], argc - 2, argv[1], known ? &sz : NULL,
                         known ? &size_flag : NULL, NULL);
   printf("verdict=%s size_flag=%d\n",

--- a/tests/01_engine-filter.test
+++ b/tests/01_engine-filter.test
@@ -84,6 +84,9 @@ fsize 'verdict=allowed size_flag=0' -1 foo.jpg -* '+*.jpg' '-*.jpg*[<10]'   # sc
 fsize 'verdict=forbidden size_flag=1' 5 foo.jpg -* '+*.jpg' '-*.jpg*[<10]'  # <10KB: cancel
 fsize 'verdict=allowed size_flag=1' 20 foo.jpg -* '+*.jpg' '-*.jpg*[<10]'   # >=10KB: keep
 fsize 'verdict=forbidden size_flag=0' -1 foo.txt -* '+*.jpg' '-*.jpg*[<10]' # not a jpg
+# the '>' operator is just as neutral at scan time, and fires once size is known
+fsize 'verdict=allowed size_flag=0' -1 foo.jpg -* '+*.jpg' '-*.jpg*[>10]'   # scan time: keep
+fsize 'verdict=forbidden size_flag=1' 20 foo.jpg -* '+*.jpg' '-*.jpg*[>10]' # >10KB: cancel
 
 # [name]/[file]/[path] never span '?' mid-string; a trailing query is still
 # tolerated by the global '?' rule (same as plain *.aspx), not the class (#144).


### PR DESCRIPTION
Follow-up from a review of #431. Two test-only tweaks, no behavior change. The `filtersize` self-test parsed its size argument with `strtoll`; switch to the `sscanf(argv[0], LLintP, &sz)` idiom the rest of the tree uses, since `LLint` is not always `long long` (MSVC `__int64`, plus narrower fallbacks) and `strtoll` is missing on old MSVC. Also add two cases so the scan-time neutrality of size rules is pinned for the `>` operator, not just `<`.
