### PR TITLE
debian: lead webhttrack browser dep with chromium to dodge firefox-esr autoremoval

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,7 @@ Description: Copy websites to your computer (Offline browser)
 Package: webhttrack
 Architecture: any
 Multi-Arch: foreign
-Depends: ${misc:Depends}, ${shlibs:Depends}, webhttrack-common, sensible-utils, firefox-esr | chromium | www-browser
+Depends: ${misc:Depends}, ${shlibs:Depends}, webhttrack-common, sensible-utils, chromium | firefox-esr | www-browser
 Replaces: webhttrack-common (<< 3.43.9-2)
 Breaks: webhttrack-common (<< 3.43.9-2)
 Suggests: httrack, httrack-doc


### PR DESCRIPTION
The Debian tracker has httrack scheduled for autoremoval on 22 July 2026: "depends (transitively) on firefox-esr, affected by #1127569". That transitive dependency comes only from webhttrack's `firefox-esr | chromium | www-browser`, and webhttrack stays installable through any of the alternatives. The mark is an artifact of britney keying off the first alternative of a disjunction: with firefox-esr first, the whole httrack source inherits firefox-esr's removal clock every time Firefox catches an RC bug.

Leading with `chromium` makes britney track chromium instead of the RC-bug-prone firefox-esr. The virtual `www-browser` can't go first: lintian requires a real package as the first alternative (`virtual-package-depends-without-real-package-depends`), so chromium is the lintian-clean way to displace firefox-esr from the front. apt still resolves a concrete browser the same way in practice.
