### PR TITLE
filters: fix escaped brackets inside *[...] character classes

### DIFF
--- a/html/filters.html
+++ b/html/filters.html
@@ -247,7 +247,7 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
         <td>the \ character</td>
       </tr>
       <tr>
-        <td nowrap><tt>*[\[\]]</tt></td>
+        <td nowrap><tt>*[\[,\]]</tt></td>
         <td>the [ or ] character</td>
       </tr>
       <tr>

--- a/src/htsfilters.c
+++ b/src/htsfilters.c
@@ -193,7 +193,12 @@ HTS_INLINE const char *strjoker(const char *chaine, const char *joker, LLint * s
           int len = (int) strlen(joker);
 
           while((joker[i] != RIGHT) && (joker[i]) && (i < len)) {
-            if ((joker[i] == '<') || (joker[i] == '>')) {       // *[<10]
+            // '\' escapes the next char as a literal member, e.g. *[\[\]]
+            if (joker[i] == '\\' && joker[i + 1] != '\0') {
+              i++;
+              pass[(int) (unsigned char) joker[i]] = 1;
+              i++;
+            } else if ((joker[i] == '<') || (joker[i] == '>')) { // *[<10]
               int lsize = 0;
               int lverdict;
 
@@ -221,7 +226,7 @@ HTS_INLINE const char *strjoker(const char *chaine, const char *joker, LLint * s
                 while(isdigit((unsigned char) joker[i]))
                   i++;
               }
-            } else if (joker[i + 1] == '-') {   // 2 car, ex: *[A-Z]
+            } else if (joker[i + 1] == '-') { // 2 car, ex: *[A-Z]
               if ((int) (unsigned char) joker[i + 2] >
                   (int) (unsigned char) joker[i]) {
                 int j;
@@ -233,10 +238,7 @@ HTS_INLINE const char *strjoker(const char *chaine, const char *joker, LLint * s
               }
               // else err=1;
               i += 3;
-            } else {            // 1 car, ex: *[ ]
-              if (joker[i + 2] == '\\' && joker[i + 3] != 0) {  // escaped char, such as *[\[] or *[\]]
-                i++;
-              }
+            } else { // 1 car, ex: *[ ]
               pass[(int) (unsigned char) joker[i]] = 1;
               i++;
             }

--- a/src/htsfilters.c
+++ b/src/htsfilters.c
@@ -226,7 +226,9 @@ HTS_INLINE const char *strjoker(const char *chaine, const char *joker, LLint * s
                 while(isdigit((unsigned char) joker[i]))
                   i++;
               }
-            } else if (joker[i + 1] == '-') { // 2 car, ex: *[A-Z]
+            } else if (joker[i + 1] == '-' && joker[i + 2] != '\0') {
+              // range *[A-Z]; the '\0' guard rejects a truncated *[a- (else
+              // i+=3 overshoots the NUL)
               if ((int) (unsigned char) joker[i + 2] >
                   (int) (unsigned char) joker[i]) {
                 int j;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -512,15 +512,21 @@ static int string_safety_selftests(void) {
 /* ------------------------------------------------------------ */
 
 static int st_filter(httrackp *opt, int argc, char **argv) {
+  char *str, *pat;
+  int matched;
+
   (void) opt;
   if (argc < 2) {
     fprintf(stderr, "filter: needs a filter pattern and a string\n");
     return 1;
   }
-  if (strjoker(argv[1], argv[0], NULL, NULL))
-    printf("%s does match %s\n", argv[1], argv[0]);
-  else
-    printf("%s does NOT match %s\n", argv[1], argv[0]);
+  /* exact-size heap copies so a sanitizer traps any over-read of the pattern */
+  str = strdupt(argv[1]);
+  pat = strdupt(argv[0]);
+  matched = strjoker(str, pat, NULL, NULL) != NULL;
+  printf("%s does %s %s\n", argv[1], matched ? "match" : "NOT match", argv[0]);
+  freet(str);
+  freet(pat);
   return 0;
 }
 

--- a/tests/01_engine-filter.test
+++ b/tests/01_engine-filter.test
@@ -50,27 +50,47 @@ match '*foo*bar' 'foozbar'
 # '?' is the query-string marker, not a single-char wildcard
 nomatch 'a?c' 'abc'
 
-# backslash escapes a metacharacter inside a class so it is matched literally.
-# Quirk: the decoder also adds the backslash itself to the set, so '\X' matches
-# both X and '\'. These assertions pin that behavior.
+# Inside a class, backslash escapes the next char as a literal member (#148):
+# '\X' matches X only (not '\'), and an escaped ']' is a member, not the terminator.
 match '*[\*]' '*'
-match '*[\*]' "\\"
-nomatch '*[\*]' 'a'
+nomatch '*[\*]' "\\"
 match '*[\\]' "\\"
-nomatch '*[\\]' 'a'
+nomatch '*[\\]' '*'
 match '*[\[]' '['
-match '*[\[]' "\\"
-nomatch '*[\[]' 'a'
+nomatch '*[\[]' "\\"
+match '*[\]]' ']'
+nomatch '*[\]]' "\\"
 
-# A literal ']' cannot be a class member: the class parser stops at the first
-# ']', escaped or not. So '*[\[\]]' does NOT mean "the [ or ] character" as the
-# filter guide claims (GitHub #148); it parses as the class {'[','\'} followed
-# by a trailing literal ']'. These assertions document the current (buggy)
-# behavior so any future matcher fix is a deliberate, visible change.
-nomatch '*[\[\]]' '[' # not matched, despite the docs
-match '*[\[\]]' ']'   # only via the empty class-match + trailing ']'
-match '*[\[\]]' '[]'  # one of {'[','\'} then the trailing ']'
-nomatch '*[\[\]]' '[]x'
+# '*[\[\]]' is "the [ or ] character", as the filter guide documents.
+match '*[\[\]]' '['
+match '*[\[\]]' ']'
+nomatch '*[\[\]]' 'a'
+match '*[\[,\]]' '['   # comma between members is optional
+match '*[\[,\]]' ']'
+match '*[a,\[]' 'a'    # an escaped member no longer eats the preceding one
+match '*[a,\[]' '['
+
+# Escape is decoded before the range/separator/size checks, so '\-' '\,' '\<'
+# are literal members, not operators.
+match '*[a\-z]' 'a'
+match '*[a\-z]' 'z'
+nomatch '*[a\-z]' 'b'  # not the a..z range
+match '*[\,]' ','
+match '*[\<]' '<'
+match '*[\[,\],a]' '['
+match '*[\[,\],a]' ']'
+match '*[\[,\],a]' 'a'
+
+# *(...) matches exactly one char from the class; *[...] matches a run.
+match '*(a,b)' 'a'
+nomatch '*(a,b)' 'aa'
+nomatch '*(a,b)' 'c'
+
+# documented composite filters (filters.html)
+match 'www.*[path].com/*[path].zip' 'www.foo.com/a/b.zip'
+nomatch 'www.*[path].com/*[path].zip' 'www.foo.com/a/b.tar'
+match '*.html*[]' 'page.html'
+nomatch '*.html*[]' 'page.html?x=1'  # *[] forbids the trailing query
 
 # Size-based rules (-#test=filtersize <size> <string> <filter...>): a negative size
 # means the size is still unknown (scan time). A size exclusion must stay neutral

--- a/tests/01_engine-filter.test
+++ b/tests/01_engine-filter.test
@@ -65,21 +65,28 @@ nomatch '*[\]]' "\\"
 match '*[\[\]]' '['
 match '*[\[\]]' ']'
 nomatch '*[\[\]]' 'a'
-match '*[\[,\]]' '['   # comma between members is optional
+match '*[\[,\]]' '[' # comma between members is optional
 match '*[\[,\]]' ']'
-match '*[a,\[]' 'a'    # an escaped member no longer eats the preceding one
+match '*[a,\[]' 'a' # an escaped member no longer eats the preceding one
 match '*[a,\[]' '['
 
 # Escape is decoded before the range/separator/size checks, so '\-' '\,' '\<'
 # are literal members, not operators.
 match '*[a\-z]' 'a'
 match '*[a\-z]' 'z'
-nomatch '*[a\-z]' 'b'  # not the a..z range
+nomatch '*[a\-z]' 'b' # not the a..z range
 match '*[\,]' ','
+nomatch '*[\,]' "\\" # the escape must not leak '\' into the class
 match '*[\<]' '<'
+nomatch '*[\<]' "\\"
 match '*[\[,\],a]' '['
 match '*[\[,\],a]' ']'
 match '*[\[,\],a]' 'a'
+
+# A truncated range '*[a-' is the literal members {a,-}; the parser must not
+# read past the end decoding it (was a 1-byte heap over-read in the range arm).
+match '*[a-' 'a'
+nomatch '*[a-' 'b'
 
 # *(...) matches exactly one char from the class; *[...] matches a run.
 match '*(a,b)' 'a'
@@ -90,7 +97,7 @@ nomatch '*(a,b)' 'c'
 match 'www.*[path].com/*[path].zip' 'www.foo.com/a/b.zip'
 nomatch 'www.*[path].com/*[path].zip' 'www.foo.com/a/b.tar'
 match '*.html*[]' 'page.html'
-nomatch '*.html*[]' 'page.html?x=1'  # *[] forbids the trailing query
+nomatch '*.html*[]' 'page.html?x=1' # *[] forbids the trailing query
 
 # Size-based rules (-#test=filtersize <size> <string> <filter...>): a negative size
 # means the size is still unknown (scan time). A size exclusion must stay neutral


### PR DESCRIPTION
Escaping a bracket inside a `*[...]` filter class was broken: the matcher's escape branch read two chars ahead of the current position, so a backslash only took effect on the first class member. The documented `*[\[\]]` ("the [ or ] character") matched only `]`, `*[a,\[]` silently dropped the `a`, and because the loop stopped at the first `]` even when escaped, an escaped `]` could never be a member. The fix decodes the escape first in the loop body, so a backslash takes the next char as a literal member, an escaped `]` is consumed before the terminator check, and escaping runs ahead of the range and size checks (`\-`, `\,`, `\<` are literal). `*[\[\]]` now matches both brackets as the guide claims.

A self-test already exercised this corner, but its assertions pinned the buggy output as expected (it even flagged #148 as a known quirk). They now assert the documented behavior and fail against the old matcher; the guide example moves to the comma form it documents.

Reviewing this with review-recipe surfaced a separate, pre-existing 1-byte heap over-read in the same loop: a truncated range like `*[a-` ran `i += 3` off the end and then read past the NUL. The second commit guards the range arm on a non-NUL third char, and reworks the filter self-test to copy patterns and strings into exact-size heap buffers so a sanitizer catches that class of over-read (it was invisible before because the pattern came straight from argv, which has no redzone). A `*[a-` case exercises it.

Closes #148