### PR TITLE
Strip the #fragment from a redirect Location before fetching (#204)

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -302,6 +302,14 @@ static HTS_INLINE char html_prevc(const char *html, const char *start) {
   return html > start ? html[-1] : ' ';
 }
 
+/* Drop a redirect Location's #fragment: a UA anchor, never part of the fetched
+ * resource (#204). */
+static void url_drop_fragment(char *const url) {
+  char *const frag = strchr(url, '#');
+  if (frag != NULL)
+    *frag = '\0';
+}
+
 /* True if [s, s+len) is exactly an HTTP method token (XHR.open's first
    argument is a method, not a URL: #218). Case-insensitive. */
 static int is_http_method(const char *s, size_t len) {
@@ -3596,6 +3604,7 @@ int hts_mirror_check_moved(htsmoduleStruct * str,
         //
 
         strcpybuff(mov_url, r->location);
+        url_drop_fragment(mov_url);
 
         // url qque -> adresse+fichier
         if ((reponse =
@@ -4803,6 +4812,7 @@ int hts_wait_delayed(htsmoduleStruct * str, lien_adrfilsave *afs,
 
             mov_url[0] = '\0';
             strcpybuff(mov_url, back[b].r.location);    // copier URL
+            url_drop_fragment(mov_url);
 
             /* Remove (temporarily created) file if it was created */
             UNLINK(fconv(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), back[b].url_sav));

--- a/tests/29_local-redirect-fragment.test
+++ b/tests/29_local-redirect-fragment.test
@@ -1,12 +1,11 @@
 #!/bin/bash
 # Issue #204: a 302 Location with a #fragment must drop the fragment before the
-# target is fetched; else the request-target carries '#' (strict servers 400)
-# and the mirror lands under a fragment-polluted name.
+# target is fetched. The server is strict (400 on a '#' in the request-target),
+# so a leaked fragment logs an error and the target is never saved.
 set -e
 
 : "${top_srcdir:=..}"
 
 bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
     --found 'redir/target.html' \
-    --not-found 'redir/target.html#section.html' \
     httrack 'BASEURL/redir/index.html'

--- a/tests/29_local-redirect-fragment.test
+++ b/tests/29_local-redirect-fragment.test
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Issue #204: a 302 Location with a #fragment must drop the fragment before the
+# target is fetched; else the request-target carries '#' (strict servers 400)
+# and the mirror lands under a fragment-polluted name.
+set -e
+
+: "${top_srcdir:=..}"
+
+bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
+    --found 'redir/target.html' \
+    --not-found 'redir/target.html#section.html' \
+    httrack 'BASEURL/redir/index.html'

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -75,6 +75,7 @@ TESTS = \
 	25_local-mime-exclude.test \
 	26_local-strip-query.test \
 	27_local-cookies-file.test \
-	28_local-pause.test
+	28_local-pause.test \
+	29_local-redirect-fragment.test
 
 CLEANFILES = check-network_sh.cache

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -355,7 +355,8 @@ class Handler(SimpleHTTPRequestHandler):
             self.wfile.write(body)
 
     # 302 whose Location carries a #fragment (#204): the fragment is a UA anchor
-    # and must be dropped before the target is fetched/saved.
+    # that must be dropped before the target is fetched. A leaked '#' reaches the
+    # strict-server guard below and 400s.
     def route_redir_index(self):
         self.send_html('\t<a href="go.php">go</a>')
 
@@ -412,6 +413,16 @@ class Handler(SimpleHTTPRequestHandler):
 
     # --- dispatch ----------------------------------------------------------
 
+    def reject_fragment(self):
+        # Strict server: a '#' in the request-target is the client failing to
+        # drop a fragment (#204). RFC 3986 forbids it on the wire; answer 400.
+        if "#" in self.path:
+            self.send_response(400, "Bad Request")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return True
+        return False
+
     def dispatch(self):
         self._set_cookies = []
         path = urlsplit(self.path).path
@@ -423,10 +434,14 @@ class Handler(SimpleHTTPRequestHandler):
         return False
 
     def do_GET(self):
+        if self.reject_fragment():
+            return
         if not self.dispatch():
             super().do_GET()
 
     def do_HEAD(self):
+        if self.reject_fragment():
+            return
         if not self.dispatch():
             super().do_HEAD()
 

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -354,6 +354,20 @@ class Handler(SimpleHTTPRequestHandler):
         if self.command != "HEAD":
             self.wfile.write(body)
 
+    # 302 whose Location carries a #fragment (#204): the fragment is a UA anchor
+    # and must be dropped before the target is fetched/saved.
+    def route_redir_index(self):
+        self.send_html('\t<a href="go.php">go</a>')
+
+    def route_redir_go(self):
+        self.send_response(302, "Found")
+        self.send_header("Location", "target.html#section")
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def route_redir_target(self):
+        self.send_raw(b"<html><body>redirect target</body></html>\n", "text/html")
+
     ROUTES = {
         "/cookies/entrance.php": route_entrance,
         "/cookies/second.php": route_second,
@@ -391,6 +405,9 @@ class Handler(SimpleHTTPRequestHandler):
         "/mimex/index.html": route_mimex_index,
         "/mimex/blob.pdf": route_mimex_blob,
         "/mimex/real.html": route_mimex_real,
+        "/redir/index.html": route_redir_index,
+        "/redir/go.php": route_redir_go,
+        "/redir/target.html": route_redir_target,
     }
 
     # --- dispatch ----------------------------------------------------------


### PR DESCRIPTION
A 302/30x Location is dereferenced, not displayed, so a `#fragment` in it is a client-side anchor with no role in fetching the resource. httrack kept it: both redirect followers in htsparse.c copied `r.location` verbatim, so the re-request went out as `GET /page.html#frag` (strict servers answer 400) and the target was saved under a polluted name like `page.html#frag.html`. HTML links are already cut at the `#` during parsing; only the two Location followers were missed.

The fix drops the fragment in a small helper called right after each Location copy, covering both the live and cached-redirect paths.

Test: a new local-server route plus `29_local-redirect-fragment.test`, where a 302 whose Location carries `#section` must save `redir/target.html`, not `redir/target.html#section.html`. It fails on the unpatched binary.

Closes #204