### PR TITLE
tests: skip 28_local-pause without python3; add a buildd-reproducing CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,50 @@ jobs:
         if: failure()
         run: cat tests/test-suite.log 2>/dev/null || true
 
+  # Reproduce the Debian buildds: they build in a minimal chroot with no
+  # python3, so the local-server tests must SKIP (exit 77), not fail. GitHub
+  # runners ship python3, so every other job hides this path; here we remove it
+  # before `make check`. This is the guard that would have caught the 3.49.10-1
+  # FTBFS (28_local-pause failed instead of skipping when python3 was absent).
+  buildd-no-python3:
+    name: build (no python3, Debian buildd)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential autoconf automake libtool autoconf-archive \
+            zlib1g-dev libssl-dev
+
+      - name: Configure
+        run: |
+          set -euo pipefail
+          autoreconf -fi
+          ./configure
+
+      - name: Build
+        run: make -j"$(nproc)"
+
+      - name: Test without python3
+        run: |
+          set -euo pipefail
+          # Hide every python3* so `command -v python3` fails like it does in the
+          # buildd chroot; masking with /bin/false would still resolve.
+          sudo find /usr/bin /usr/local/bin -maxdepth 1 -name 'python3*' \
+            -exec mv {} {}.hidden \;
+          ! command -v python3
+          make check
+
+      - name: Print the test log on failure
+        if: failure()
+        run: cat tests/test-suite.log 2>/dev/null || true
+
   # Portability: build and test on macOS (Darwin/clang) on a native runner --
   # no VM. The tree has no __APPLE__ branches, so Darwin exercises the
   # generic-Unix path on a second libc and kernel. brew's openssl@3 is keg-only,

--- a/tests/28_local-pause.test
+++ b/tests/28_local-pause.test
@@ -9,6 +9,13 @@ set -e
 
 : "${top_srcdir:=..}"
 
+# python3 runs the local server (mirror local-crawl.sh); skip when absent, else
+# run() swallows its exit-77 and the serverless 0s/0s crawl looks like a fail.
+command -v python3 >/dev/null || {
+    echo "python3 not found; skipping local crawl tests"
+    exit 77
+}
+
 run() { # echoes the wall-clock seconds of one crawl
     local t0 t1
     t0=$(date +%s)


### PR DESCRIPTION
httrack 3.49.10-1 failed to build on every Debian buildd. `28_local-pause` failed where every other local-server test skipped. The buildds build in a minimal chroot with no python3, so `local-crawl.sh` exits 77 (skip). But `28_local-pause` runs `local-crawl.sh` inside a `$(...)` with output redirected to `/dev/null`, which swallows that exit-77. With no server, both the baseline and the `--pause` crawl finish in 0s, and the test reads the 0s delta as a failure.

The first commit adds the python3 guard up front, the same one the sibling tests inherit from `local-crawl.sh`, so it skips cleanly.

The second commit fixes the gap that hid this from us: GitHub runners ship python3, so every `make check` job ran the python3-present path and the local tests never skipped. A new `buildd-no-python3` job builds, removes python3, then runs `make check`, reproducing the buildd chroot so the skip path is exercised on every PR. Verified it fails on the pre-fix tree and passes after.