### PR TITLE
debian: 3.49.10-2, fix buildd FTBFS via quilt patch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+httrack (3.49.10-2) unstable; urgency=medium
+
+  * Fix FTBFS: tests/28_local-pause failed instead of skipping when python3 is
+    absent (the local-server tests need python3, which the buildds lack). Add
+    patches/skip-local-pause-test-without-python3.patch to guard the test on
+    python3 up front, like its siblings, so it skips cleanly.
+
+ -- Xavier Roche <xavier@debian.org>  Sun, 28 Jun 2026 20:18:46 +0200
+
 httrack (3.49.10-1) unstable; urgency=medium
 
   * New upstream release: new download-pacing and URL-handling options plus a

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+skip-local-pause-test-without-python3.patch

--- a/debian/patches/skip-local-pause-test-without-python3.patch
+++ b/debian/patches/skip-local-pause-test-without-python3.patch
@@ -1,0 +1,29 @@
+Description: skip 28_local-pause when python3 is absent (fixes FTBFS on buildds)
+ The local-server tests skip (exit 77) when python3 is missing, but
+ 28_local-pause wrapped local-crawl.sh in a command substitution that swallowed
+ that skip. On the python3-less buildd chroot the test then ran serverless, both
+ crawls finished in 0s, and the 0s delta was reported as a failure. Guard the
+ test on python3 up front, like its siblings, so it skips cleanly.
+Author: Xavier Roche <roche@httrack.com>
+Origin: upstream, https://github.com/xroche/httrack/pull/445
+Applied-Upstream: https://github.com/xroche/httrack/commit/45279d7
+Forwarded: not-needed
+Last-Update: 2026-06-28
+diff --git a/tests/28_local-pause.test b/tests/28_local-pause.test
+index 8505a75..add95d1 100755
+--- a/tests/28_local-pause.test
++++ b/tests/28_local-pause.test
+@@ -9,6 +9,13 @@ set -e
+ 
+ : "${top_srcdir:=..}"
+ 
++# python3 runs the local server (mirror local-crawl.sh); skip when absent, else
++# run() swallows its exit-77 and the serverless 0s/0s crawl looks like a fail.
++command -v python3 >/dev/null || {
++    echo "python3 not found; skipping local crawl tests"
++    exit 77
++}
++
+ run() { # echoes the wall-clock seconds of one crawl
+     local t0 t1
+     t0=$(date +%s)


### PR DESCRIPTION
3.49.10-1 failed to build on every Debian buildd. `tests/28_local-pause` failed instead of skipping when python3 is absent, and the local-server tests need python3, which the minimal buildd chroot does not have. The fix is already upstream (#445), but the `-1` orig is frozen in the archive, so this carries it as a quilt patch against the released 3.49.10 source and bumps to `-2`.

Packaging-only: no upstream code changes, `VERSION_INFO` and the soname untouched. The patch applies cleanly to the frozen orig and reproduces the upstream fix exactly. I verified it by assembling the source the way the signed upload does (frozen 3.49.10 tree plus this `debian/`, then `quilt push -a`). Drop the patch at the next upstream release, which already includes the fix.