### PR TITLE
Modernize the default User-Agent (#449)

### DIFF
--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -229,6 +229,10 @@ Please visit our Website: http://www.httrack.com
 #define HTS_DEFAULT_FOOTER                                                     \
   "<!-- Mirrored from %s%s by HTTrack Website Copier/" HTTRACK_AFF_VERSION     \
   " " HTTRACK_AFF_AUTHORS ", %s -->"
+/* Honest crawler User-Agent; no fake OS/browser to go stale. */
+#define HTS_DEFAULT_USER_AGENT                                                 \
+  "Mozilla/5.0 (compatible; HTTrack/" HTTRACK_AFF_VERSION                      \
+  "; +https://www.httrack.com/)"
 #define HTTRACK_WEB "http://www.httrack.com"
 #define HTS_UPDATE_WEBSITE                                                     \
   "http://www.httrack.com/"                                                    \

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -6048,8 +6048,7 @@ HTSEXT_API httrackp *hts_create_opt(void) {
   opt->shell = HTS_FALSE;
   opt->proxy.active = 0;        // pas de proxy
   opt->user_agent_send = HTS_TRUE;
-  StringCopy(opt->user_agent,
-             "Mozilla/4.5 (compatible; HTTrack 3.0x; Windows 98)");
+  StringCopy(opt->user_agent, HTS_DEFAULT_USER_AGENT);
   StringCopy(opt->referer, "");
   StringCopy(opt->from, "");
   opt->savename_83 = HTS_SAVENAME_83_LONG; // long names by default

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1302,6 +1302,22 @@ static int st_urlhack(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* Default User-Agent: honest HTTrack token, no resurrected Windows 98. */
+static int st_useragent(httrackp *opt, int argc, char **argv) {
+  const char *ua = StringBuff(opt->user_agent);
+  (void) argc;
+  (void) argv;
+  assertf(ua != NULL);
+  assertf(strcmp(ua, HTS_DEFAULT_USER_AGENT) == 0);
+  /* Teeth independent of the macro: honest token + self-identifier, and no
+     legacy Mozilla/4.x fake-browser string (rejects the whole relic family). */
+  assertf(strstr(ua, "HTTrack/") != NULL);
+  assertf(strstr(ua, "+https://www.httrack.com/") != NULL);
+  assertf(strstr(ua, "Mozilla/4.") == NULL);
+  printf("useragent self-test OK: %s\n", ua);
+  return 0;
+}
+
 /* ------------------------------------------------------------ */
 /* Registry: name -> handler, with a usage hint and a one-line description. */
 /* ------------------------------------------------------------ */
@@ -1348,6 +1364,7 @@ static const struct selftest_entry {
      st_cache_writefail},
     {"dns", "", "DNS resolver/cache self-test", st_dns},
     {"cookies", "", "cookie request-header self-test", st_cookies},
+    {"useragent", "", "default User-Agent self-test", st_useragent},
 };
 
 static void list_selftests(void) {

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -358,12 +358,12 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
       {NULL, 0}
     };
     initStrElt initStr[] = {
-      {"user", "Mozilla/4.5 (compatible; HTTrack 3.0x; Windows 98)"},
-      {"footer",
-       "<!-- Mirrored from %s%s by HTTrack Website Copier/3.x [XR&CO'2014], %s -->"},
-      {"url2", "+*.png +*.gif +*.jpg +*.jpeg +*.css +*.js -ad.doubleclick.net/*"},
-      {NULL, NULL}
-    };
+        {"user", HTS_DEFAULT_USER_AGENT},
+        {"footer", "<!-- Mirrored from %s%s by HTTrack Website Copier/3.x "
+                   "[XR&CO'2014], %s -->"},
+        {"url2",
+         "+*.png +*.gif +*.jpg +*.jpeg +*.css +*.js -ad.doubleclick.net/*"},
+        {NULL, NULL}};
     int i = 0;
 
     for(i = 0; initInt[i].name; i++) {

--- a/tests/01_engine-useragent.test
+++ b/tests/01_engine-useragent.test
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# Default User-Agent (#449): honest HTTrack token, no Windows 98 relic.
+httrack -O /dev/null -#test=useragent run | grep -q "useragent self-test OK"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -50,6 +50,7 @@ TESTS = \
 	01_engine-stripquery.test \
 	01_engine-strsafe.test \
 	01_engine-urlhack.test \
+	01_engine-useragent.test \
 	02_manpage-regen.test \
 	02_update-cache.test \
 	10_crawl-simple.test \


### PR DESCRIPTION
The default User-Agent was `Mozilla/4.5 (compatible; HTTrack 3.0x; Windows 98)`, a 25-year-old string naming a dead OS that modern bot filters fingerprint immediately. It now sends an honest crawler UA, `Mozilla/5.0 (compatible; HTTrack/3.x; +https://www.httrack.com/)`, keeping an HTTrack token and a reference URL and dropping the fake browser/OS so nothing goes stale per release.

The engine default and the webhttrack server config default carried the same literal in two spots; both now share one `HTS_DEFAULT_USER_AGENT` macro built from `HTTRACK_AFF_VERSION`. This is outward-facing wire behavior (some users key allowlists off the current UA), so the replacement was deliberate: honest-crawler form with the stable `3.x` major rather than the exact patch version.

A `-#test=useragent` engine self-test pins the new default and rejects the Windows 98 relic.

Closes #449