### PR TITLE
tests: skip connect-fallback test on GNU/Hurd

### DIFF
--- a/tests/19_local-connect-fallback.test
+++ b/tests/19_local-connect-fallback.test
@@ -20,6 +20,14 @@ if ! command -v python3 >/dev/null 2>&1; then
     echo "python3 missing, skipping"
     exit 77
 fi
+# The fixture needs a second loopback IP (dead 127.0.0.2 + live 127.0.0.1) for
+# the fallback to have a target; GNU/Hurd has only 127.0.0.1, so skip there.
+case "$(uname -s)" in
+GNU | GNU/*)
+    echo "GNU/Hurd: single loopback IP, connect-fallback fixture unbuildable, skipping"
+    exit 77
+    ;;
+esac
 
 server="$top_srcdir/tests/local-server.py"
 root="$top_srcdir/tests/server-root"


### PR DESCRIPTION
`19_local-connect-fallback` fakes a multi-address host by pinning "deadhost" to a dead 127.0.0.2 then the live 127.0.0.1, so httrack's per-address connect fallback has a target to fall back to. The fixture needs a second loopback IP: the dead and live addresses share the URL's port (`htslib.c` applies it to every resolved address at `SOCaddr_initport`), so they can only differ by IP. Linux and macOS route all of 127/8 to loopback, so 127.0.0.2 works as the dead address; GNU/Hurd has only 127.0.0.1, so the dead address fails synchronously, the per-address fallback never engages, and the test fails on hurd-i386.

This is a fixture limitation, not a bug in the fallback code, so the fix is to skip on GNU/Hurd (`uname -s` = `GNU`). I tried a runtime bind probe and then a connect probe first, but both wrongly skipped macOS, which connects to 127.0.0.2 fine yet will not let you bind it and does not cleanly refuse it; the single-loopback-IP fact is what actually distinguishes Hurd, and a one-line `uname` skip states it directly. hurd-i386 is a non-release port, so this did not block migration; the Debian buildd caught it.