### PR TITLE
Fix double-eval and duplicate-definition macro hazards in htsstrings.h

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -524,6 +524,41 @@ static int string_safety_selftests(void) {
       return 1;
   }
 
+  /* StringCatN/StringSetLength must eval SIZE once: (n_eval++, V) leaves
+     n_eval == 2 on a double-eval macro. */
+  {
+    String s = STRING_EMPTY;
+    int n_eval = 0;
+
+    StringCat(s, "hello");
+    StringCatN(s, "world", (n_eval++, 3)); /* strlen>SIZE so the clamp runs */
+    if (n_eval != 1 || strcmp(StringBuff(s), "hellowor") != 0) {
+      StringFree(s);
+      return 1;
+    }
+
+    n_eval = 0;
+    StringSetLength(s, (n_eval++, 5));
+    if (n_eval != 1 || StringLength(s) != 5) {
+      StringFree(s);
+      return 1;
+    }
+    StringFree(s);
+  }
+
+  /* StringSubRW still reads/writes after dropping its duplicate definition. */
+  {
+    String s = STRING_EMPTY;
+
+    StringCat(s, "abc");
+    StringSubRW(s, 1) = 'X';
+    if (StringSub(s, 1) != 'X' || strcmp(StringBuff(s), "aXc") != 0) {
+      StringFree(s);
+      return 1;
+    }
+    StringFree(s);
+  }
+
   return 0;
 }
 

--- a/src/htsstrings.h
+++ b/src/htsstrings.h
@@ -121,9 +121,6 @@ struct String {
 /** Byte at POS (read/write). No bounds check; POS must be < StringLength. **/
 #define StringSubRW(BLK, POS) (StringBuffRW(BLK)[POS])
 
-/** Subcharacter (read/write) **/
-#define StringSubRW(BLK, POS) (StringBuffRW(BLK)[POS])
-
 /** Byte POS positions from the end (read). POS==1 is the last byte. **/
 #define StringRight(BLK, POS) (StringBuff(BLK)[StringLength(BLK) - POS])
 
@@ -191,8 +188,9 @@ HTS_STATIC char *StringBuffN_(String *blk, int size) {
     asserts SIZE fits the existing content; does not (re)allocate. **/
 #define StringSetLength(BLK, SIZE)                                             \
   do {                                                                         \
-    if (SIZE >= 0) {                                                           \
-      (BLK).length_ = SIZE;                                                    \
+    const int len__ = (SIZE); /* signed: negative means strlen(buffer_) */     \
+    if (len__ >= 0) {                                                          \
+      (BLK).length_ = len__;                                                   \
     } else {                                                                   \
       (BLK).length_ = strlen((BLK).buffer_);                                   \
     }                                                                          \
@@ -308,10 +306,11 @@ HTS_STATIC void StringAttach(String *blk, char **str) {
 #define StringCatN(BLK, STR, SIZE)                                             \
   do {                                                                         \
     const char *str__ = (STR);                                                 \
+    const size_t usize__ = (SIZE);                                             \
     if (str__ != NULL) {                                                       \
       size_t size__ = strlen(str__);                                           \
-      if (size__ > (SIZE)) {                                                   \
-        size__ = (SIZE);                                                       \
+      if (size__ > usize__) {                                                  \
+        size__ = usize__;                                                      \
       }                                                                        \
       StringMemcat(BLK, str__, size__);                                        \
     }                                                                          \


### PR DESCRIPTION
Three macro-hygiene fixes in `src/htsstrings.h`.

`StringSubRW` was defined twice, identically, the second copy under a redundant comment. The duplicate is gone. `StringCatN` and `StringSetLength` each expanded their `SIZE` argument twice, so a side-effecting argument would run twice and a wrapping expression could be clamped inconsistently between the comparison and the assignment. Both now capture `SIZE` once into a local, the way `StringCopyN` already does. `StringSetLength` keeps the local signed so its "negative means `strlen(buffer_)`" contract is unchanged.

No current call site passes a side-effecting `SIZE`, so this is behavior-preserving; the unsafety was latent. To keep it that way, the `strsafe` engine self-test (`httrack -#test=strsafe`, driven by `tests/01_engine-strsafe.test`) now passes a `(counter++, V)` argument to `StringCatN` and `StringSetLength` and asserts the counter ends at 1. That assertion fails on the old double-eval macros and passes on the fixed ones.
