### PR TITLE
Collapse the 5 identical inplace_escape_* bodies into one helper

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -4131,24 +4131,32 @@ DECLARE_APPEND_ESCAPE_VERSION(escape_uri)
 
 #undef DECLARE_APPEND_ESCAPE_VERSION
 
-// Same as above, but in-place
-#undef DECLARE_INPLACE_ESCAPE_VERSION
-#define DECLARE_INPLACE_ESCAPE_VERSION(NAME) \
-HTSEXT_API size_t inplace_ ##NAME(char *const dest, const size_t size) { \
-  char buffer[256]; \
-  const size_t len = strnlen(dest, size); \
-  const int in_buffer = len + 1 < sizeof(buffer); \
-  char *src = in_buffer ? buffer : malloct(len + 1); \
-  size_t ret; \
-  assertf(src != NULL); \
-  assertf(len < size); \
-  memcpy(src, dest, len + 1); \
-  ret = NAME(src, dest, size); \
-  if (!in_buffer) { \
-    freet(src); \
-  } \
-  return ret; \
+// In-place escaping: copy dest aside, then escape that copy back into dest.
+typedef size_t (*escape_fn_t)(const char *src, char *dest, size_t size);
+
+static size_t inplace_escape(char *const dest, const size_t size,
+                             escape_fn_t escape) {
+  char buffer[256];
+  const size_t len = strnlen(dest, size);
+  const int in_buffer = len + 1 < sizeof(buffer);
+  char *src = in_buffer ? buffer : malloct(len + 1);
+  size_t ret;
+  assertf(src != NULL);
+  assertf(len < size);
+  memcpy(src, dest, len + 1);
+  ret = escape(src, dest, size);
+  if (!in_buffer) {
+    freet(src);
+  }
+  return ret;
 }
+
+// Thin exported wrappers binding inplace_escape() to each escaper (ABI).
+#undef DECLARE_INPLACE_ESCAPE_VERSION
+#define DECLARE_INPLACE_ESCAPE_VERSION(NAME)                                   \
+  HTSEXT_API size_t inplace_##NAME(char *const dest, const size_t size) {      \
+    return inplace_escape(dest, size, NAME);                                   \
+  }
 
 DECLARE_INPLACE_ESCAPE_VERSION(escape_in_url)
 DECLARE_INPLACE_ESCAPE_VERSION(escape_spc_url)

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1389,6 +1389,41 @@ static int st_makeindex(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* Each inplace_escape_*() must equal escape_*() on a copy. */
+static int st_inplace_escape(httrackp *opt, int argc, char **argv) {
+  /* >255 bytes forces the helper's malloct path, not the stack buffer */
+  static char longstr[600];
+  static const char *const samples[] = {
+      "",          "abc",           "a b/c?d=e&f", "h\x8ello w\x94rld",
+      "a%b\"c<d>", "/path to/file", longstr};
+  static size_t (*const inplace[])(char *, size_t) = {
+      inplace_escape_in_url, inplace_escape_spc_url, inplace_escape_uri_utf,
+      inplace_escape_check_url, inplace_escape_uri};
+  static size_t (*const plain[])(const char *, char *, size_t) = {
+      escape_in_url, escape_spc_url, escape_uri_utf, escape_check_url,
+      escape_uri};
+  size_t i, f;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+
+  memset(longstr, 'a', sizeof(longstr) - 1);
+  for (f = 0; f < sizeof(inplace) / sizeof(inplace[0]); f++) {
+    for (i = 0; i < sizeof(samples) / sizeof(samples[0]); i++) {
+      char ref[4096], work[4096];
+      size_t rret, iret;
+      rret = plain[f](samples[i], ref, sizeof(ref));
+      strcpybuff(work, samples[i]);
+      iret = inplace[f](work, sizeof(work));
+      assertf(iret == rret);
+      assertf(strcmp(work, ref) == 0);
+    }
+  }
+  printf("inplace-escape self-test OK\n");
+  return 0;
+}
+
 /* Default User-Agent: honest HTTrack token, no resurrected Windows 98. */
 static int st_useragent(httrackp *opt, int argc, char **argv) {
   const char *ua = StringBuff(opt->user_agent);
@@ -1707,6 +1742,8 @@ static const struct selftest_entry {
     {"useragent", "", "default User-Agent self-test", st_useragent},
     {"makeindex", "[dir]", "hts_finish_makeindex footer/refresh self-test",
      st_makeindex},
+    {"inplace-escape", "", "inplace_escape_* vs escape_* equivalence self-test",
+     st_inplace_escape},
     {"status", "", "HTTP status code -> reason phrase self-test", st_status},
     {"acceptencoding", "[dir]",
      "Accept-Encoding advertises gzip+deflate, both decode", st_acceptencoding},

--- a/tests/01_engine-inplace-escape.test
+++ b/tests/01_engine-inplace-escape.test
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# inplace_escape_*() must match escape_*() on a copy: guards the shared helper.
+httrack -O /dev/null -#test=inplace-escape run | grep -q "inplace-escape self-test OK"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -36,6 +36,7 @@ TESTS = \
 	01_engine-filter.test \
 	01_engine-hashtable.test \
 	01_engine-idna.test \
+	01_engine-inplace-escape.test \
 	01_engine-makeindex.test \
 	01_engine-mime.test \
 	01_engine-parse.test \


### PR DESCRIPTION
`DECLARE_INPLACE_ESCAPE_VERSION` stamped the same body five times, once per escaper. This moves that body into a single `static size_t inplace_escape(char *dest, size_t size, escape_fn_t escape)` helper that takes a pointer to the underlying `escape_*()`; the five exported `inplace_escape_*` symbols become thin wrappers that call it. The exported ABI is unchanged: all five `HTSEXT_API` symbols are still present with their original signatures, and the helper is `static`, so `nm -D` still lists exactly those five and not the helper.

Codegen now routes through a function pointer, so this is not a byte-identical object. A new `-#test=inplace-escape` engine self-test (driven by `tests/01_engine-inplace-escape.test`) proves equivalence at runtime: for each escaper it asserts `inplace_escape_*(copy)` equals `escape_*(src)` across several samples, including a >255-byte one that forces the helper's `malloct` path rather than the stack buffer.