### PR TITLE
debian: clear low-risk lintian tags (metadata, compat 14, priority, NMU override)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,9 +1,8 @@
 Source: httrack
 Section: web
-Priority: optional
 Maintainer: Xavier Roche <roche@httrack.com>
 Standards-Version: 4.7.4
-Build-Depends: debhelper-compat (= 13), autoconf, autoconf-archive, automake, libtool, zlib1g-dev, libssl-dev
+Build-Depends: debhelper-compat (= 14), autoconf, autoconf-archive, automake, libtool, zlib1g-dev, libssl-dev
 Rules-Requires-Root: no
 Homepage: http://www.httrack.com
 Vcs-Git: https://github.com/xroche/httrack.git

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,4 +1,6 @@
-httrack source: changelog-should-mention-nmu
+# Maintainer uploads sign the changelog as xavier@debian.org while the control
+# Maintainer is roche@httrack.com; lintian reads the address mismatch as an NMU.
+httrack source: no-nmu-in-changelog
 httrack source: source-nmu-has-incorrect-version-number
 
 # The bundled HTML pages are the genuine upstream documentation taken from

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,6 @@
+---
+Repository: https://github.com/xroche/httrack.git
+Repository-Browse: https://github.com/xroche/httrack
+Bug-Database: https://github.com/xroche/httrack/issues
+Bug-Submit: https://github.com/xroche/httrack/issues/new
+Contact: Xavier Roche <roche@httrack.com>


### PR DESCRIPTION
Clears four low-risk lintian tags on the packaging with no change to built output: `dpkg -c` and the extracted payloads are byte-identical to master across every binary package.

- Add `debian/upstream/metadata` (DEP-12), populated only from values already in `debian/control` and `debian/copyright`.
- Bump `debhelper-compat` to 14. The hand-written `debian/rules` uses none of the sequencer machinery compat 14 changes, so package contents are unchanged.
- Drop the redundant `Priority: optional` source field; all binary packages already inherit it.
- Rename the stale override `changelog-should-mention-nmu` to `no-nmu-in-changelog` and add a line on why the maintainer/uploader address split reads as an NMU.

Left alone on purpose: `Rules-Requires-Root: no` stays explicit, since dropping it re-enables rootful builds on dpkg < 1.22.13 (bookworm), and `debian/watch` stays at version 4. The `no-dh-sequencer` tag needs a separate `rules` rewrite and is deferred to its own change.