### PR TITLE
Regression test for anchored (#fragment) links (#279)

### DIFF
--- a/tests/30_local-fragment-link.test
+++ b/tests/30_local-fragment-link.test
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Issue #279: an anchored link (target.html#sec, quoted or bare) fetches the
+# target with the fragment dropped (strict server 400s on a '#' in the request)
+# but keeps it in the rewritten local link so the anchor still works.
+set -e
+
+: "${top_srcdir:=..}"
+
+bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
+    --found 'fraglink/target.html' \
+    --file-matches 'fraglink/index.html' 'href=target\.html#sec' \
+    --file-matches 'fraglink/index.html' 'href="target\.html#sec2"' \
+    httrack 'BASEURL/fraglink/index.html'

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,6 +6,7 @@ EXTRA_DIST = $(TESTS) crawl-test.sh run-all-tests.sh check-network.sh \
 	local-crawl.sh local-server.py server.crt server.key \
 	server-root/simple/basic.html server-root/simple/link.html \
 	server-root/stripquery/index.html server-root/stripquery/a.html \
+	server-root/fraglink/index.html server-root/fraglink/target.html \
 	fixtures/cache-golden/hts-cache/new.zip
 
 TESTS_ENVIRONMENT =
@@ -83,6 +84,7 @@ TESTS = \
 	26_local-strip-query.test \
 	27_local-cookies-file.test \
 	28_local-pause.test \
-	29_local-redirect-fragment.test
+	29_local-redirect-fragment.test \
+	30_local-fragment-link.test
 
 CLEANFILES = check-network_sh.cache

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -15,8 +15,11 @@
 #   bash local-crawl.sh [--tls] [--root DIR] [--cookie NAME=VALUE ...] \
 #       --errors N --files N --found PATH ... --directory PATH ... \
 #       --log-found REGEX ... --log-not-found REGEX ... \
+#       --file-matches PATH REGEX ... --file-not-matches PATH REGEX ... \
 #       httrack BASEURL/some/path [httrack-args...]
 # --log-found/--log-not-found grep (ERE) the crawl's hts-log.txt.
+# --file-matches/--file-not-matches grep (ERE) a mirrored file (PATH under the
+# host root), to assert rewritten link/content survived the crawl.
 # --cookie writes a Netscape cookies.txt (scoped to the discovered host:port,
 # which the ephemeral port forces into the cookie domain) and passes it to
 # httrack via --cookies-file, to exercise preloaded cookies.
@@ -120,6 +123,10 @@ while test "$pos" -lt "$nargs"; do
     --found | --not-found | --directory | --log-found | --log-not-found)
         audit+=("${args[$pos]}" "${args[$((pos + 1))]}")
         pos=$((pos + 1))
+        ;;
+    --file-matches | --file-not-matches)
+        audit+=("${args[$pos]}" "${args[$((pos + 1))]}" "${args[$((pos + 2))]}")
+        pos=$((pos + 2))
         ;;
     httrack)
         pos=$((pos + 1))
@@ -291,6 +298,24 @@ while test "$i" -lt "${#audit[@]}"; do
         info "checking log lacks ${audit[$i]}"
         if grep -aqE "${audit[$i]}" "${out}/hts-log.txt"; then
             result "present in log"
+            exit 1
+        else result "OK"; fi
+        ;;
+    --file-matches)
+        path="${audit[$((i + 1))]}"
+        i=$((i + 2))
+        info "checking ${path} matches ${audit[$i]}"
+        if grep -aqE "${audit[$i]}" "${hostroot}/${path}"; then result "OK"; else
+            result "no match"
+            exit 1
+        fi
+        ;;
+    --file-not-matches)
+        path="${audit[$((i + 1))]}"
+        i=$((i + 2))
+        info "checking ${path} lacks ${audit[$i]}"
+        if grep -aqE "${audit[$i]}" "${hostroot}/${path}"; then
+            result "matched"
             exit 1
         else result "OK"; fi
         ;;

--- a/tests/server-root/fraglink/index.html
+++ b/tests/server-root/fraglink/index.html
@@ -1,0 +1,4 @@
+<html><body>
+<a href=target.html#sec>unquoted fragment link</a>
+<a href="target.html#sec2">quoted fragment link</a>
+</body></html>

--- a/tests/server-root/fraglink/target.html
+++ b/tests/server-root/fraglink/target.html
@@ -1,0 +1,1 @@
+<html><body><a name="sec"></a><a name="sec2"></a>target</body></html>


### PR DESCRIPTION
#279 reports that links of the form `target.html#sec` don't open in the mirror. On current master they do. httrack fetches the target with the fragment stripped from the request, then re-emits `#sec` on the rewritten local link, so the anchor still resolves. I reproduced against the reporter's example (clerus.org bibliaclerusonline, whose links use the bare `href=x.htm#f` form) and a synthetic fixture covering the unquoted and quoted variants; both are correct. The report predates the git history, a stale Google Code-era issue with no live repro.

Rather than close it blind, this pins the behavior. The local test server already answers 400 on a `#` in the request-target, so a regression that leaked the fragment into the fetch fails outright. A new `--file-matches` audit in local-crawl.sh then asserts the mirrored link still carries `#sec`. Both halves have teeth: I checked that the assertions fail on a fragment-stripped mirror.

Closes #279.