### PR TITLE
Phase 0 follow-ups: residual unescape OOB, dead java plugin, FTP test strength

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,12 @@ AC_SUBST(LT_CV_OBJDIR,$lt_cv_objdir)
 # Export version info
 AC_SUBST(VERSION_INFO)
 
+# Versioned plugin name for dlopen() in hts_create_opt(); soname major is
+# libtool's current - age, so this tracks VERSION_INFO bumps automatically.
+HTS_SONAME_MAJOR=$((${VERSION_INFO%%:*} - ${VERSION_INFO##*:}))
+AC_DEFINE_UNQUOTED([HTS_LIBHTSJAVA_NAME], ["libhtsjava.so.$HTS_SONAME_MAJOR"],
+  [Versioned libhtsjava runtime name, derived from VERSION_INFO])
+
 ### Default CFLAGS
 DEFAULT_CFLAGS="-Wall -Wformat -Wformat-security \
 -Wmultichar -Wwrite-strings -Wcast-qual -Wcast-align \

--- a/configure.ac
+++ b/configure.ac
@@ -66,7 +66,11 @@ AC_SUBST(VERSION_INFO)
 # Versioned plugin name for dlopen() in hts_create_opt(); soname major is
 # libtool's current - age, so this tracks VERSION_INFO bumps automatically.
 HTS_SONAME_MAJOR=$((${VERSION_INFO%%:*} - ${VERSION_INFO##*:}))
-AC_DEFINE_UNQUOTED([HTS_LIBHTSJAVA_NAME], ["libhtsjava.so.$HTS_SONAME_MAJOR"],
+case "$host_os" in
+darwin*) HTS_LIBHTSJAVA_NAME="libhtsjava.$HTS_SONAME_MAJOR.dylib" ;;
+*) HTS_LIBHTSJAVA_NAME="libhtsjava.so.$HTS_SONAME_MAJOR" ;;
+esac
+AC_DEFINE_UNQUOTED([HTS_LIBHTSJAVA_NAME], ["$HTS_LIBHTSJAVA_NAME"],
   [Versioned libhtsjava runtime name, derived from VERSION_INFO])
 
 ### Default CFLAGS

--- a/src/htsdefines.h
+++ b/src/htsdefines.h
@@ -69,11 +69,15 @@ typedef struct t_hts_callbackarg t_hts_callbackarg;
 typedef struct t_hts_callbackarg t_hts_callbackarg;
 #endif
 
-/* Marks a symbol an external wrapper module exports back to the engine
-   (dllexport on Windows, nothing elsewhere). */
+/* Marks a symbol an external wrapper module exports back to the engine.
+   Must override -fvisibility=hidden on ELF, or dlopen()ed plugins (htsjava)
+   hide their own hts_plug()/hts_unplug() entry points. */
 #ifndef EXTERNAL_FUNCTION
 #ifdef _WIN32
 #define EXTERNAL_FUNCTION __declspec(dllexport)
+#elif ((defined(__GNUC__) && (__GNUC__ >= 4)) ||                               \
+       (defined(HAVE_VISIBILITY) && HAVE_VISIBILITY))
+#define EXTERNAL_FUNCTION __attribute__((visibility("default")))
 #else
 #define EXTERNAL_FUNCTION
 #endif

--- a/src/htsencoding.c
+++ b/src/htsencoding.c
@@ -300,6 +300,11 @@ int hts_unescapeUrlSpecial(const char *src, char *dest, const size_t max,
 
           /* Was the character read successfully ? */
           if (nRead == utfBufferSize) {
+            /* the 'continue' below skips the NUL-reserve guard: re-check */
+            if (utfBufferJ + utfBufferSize >= max) {
+              return -1;
+            }
+
             /* Rollback write position to sequence start write position */
             j = utfBufferJ;
 

--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -133,6 +133,8 @@ void ftp_split_userpass(const char *src, const char *end, char *user,
                         size_t user_size, char *pass, size_t pass_size) {
   size_t n = 0;
 
+  assertf(user_size > 0 && pass_size > 0); /* the size-1 math underflows on 0 */
+
   while (src[n] != '\0' && src[n] != ':') {
     if (n < user_size - 1)
       user[n] = src[n];

--- a/src/htsftp.h
+++ b/src/htsftp.h
@@ -71,7 +71,8 @@ int run_launch_ftp(FTPDownloadStruct * params);
 int send_line(T_SOC soc, const char *data);
 int get_ftp_line(T_SOC soc, char *line, size_t line_size, int timeout);
 /* Split a "user[:pass]@" prefix (end = jump_identification result) into
-   bounded, NUL-terminated user/pass buffers, truncating to fit. */
+   bounded, NUL-terminated user/pass buffers, truncating to fit.
+   Both sizes must be nonzero. */
 void ftp_split_userpass(const char *src, const char *end, char *user,
                         size_t user_size, char *pass, size_t pass_size);
 T_SOC get_datasocket(char *to_send, size_t to_send_size);

--- a/src/htsjava.h
+++ b/src/htsjava.h
@@ -33,15 +33,19 @@ Please visit our Website: http://www.httrack.com
 #ifndef HTSJAVA_DEFH
 #define HTSJAVA_DEFH
 
+#include <stdint.h>
+
 #ifndef HTS_DEF_FWSTRUCT_JAVA_HEADER
 #define HTS_DEF_FWSTRUCT_JAVA_HEADER
 typedef struct JAVA_HEADER JAVA_HEADER;
 #endif
+/* 10-byte on-disk .class header image, fread() directly: fields need exact
+   widths (LP64's 8-byte 'unsigned long' magic never matched 0xCAFEBABE). */
 struct JAVA_HEADER {
-  unsigned long int magic;
-  unsigned short int minor;
-  unsigned short int major;
-  unsigned short int count;
+  uint32_t magic;
+  uint16_t minor;
+  uint16_t major;
+  uint16_t count;
 };
 
 #ifndef HTS_DEF_FWSTRUCT_RESP_STRUCT

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -6023,9 +6023,11 @@ HTSEXT_API httrackp *hts_create_opt(void) {
     "htsswf", "htsjava", "httrack-plugin", NULL
   };
 #else
-  static const char *defaultModules[] = {
-    "libhtsswf.so.1", "libhtsjava.so.2", "httrack-plugin", NULL
-  };
+#ifndef HTS_LIBHTSJAVA_NAME
+#define HTS_LIBHTSJAVA_NAME "libhtsjava.so" /* non-autoconf fallback */
+#endif
+  static const char *defaultModules[] = {"libhtsswf.so.1", HTS_LIBHTSJAVA_NAME,
+                                         "httrack-plugin", NULL};
 #endif
   httrackp *opt = malloc(sizeof(httrackp));
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -736,6 +736,10 @@ static int st_unescape_bounds(httrackp *opt, int argc, char **argv) {
   assertf(hts_unescapeUrl("abcd", dest, sizeof(dest)) == -1);
   assertf(hts_unescapeEntities("abc", dest, sizeof(dest)) == 0);
   assertf(strcmp(dest, "abc") == 0);
+  /* raw multi-byte UTF-8 flush path (bypasses the per-byte guard) */
+  assertf(hts_unescapeUrl("ab\xC3\xA9", dest, sizeof(dest)) == -1);
+  assertf(hts_unescapeUrl("a\xC3\xA9", dest, sizeof(dest)) == 0);
+  assertf(strcmp(dest, "a\xC3\xA9") == 0);
   printf("unescape-bounds self-test OK\n");
   return 0;
 }

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -740,6 +740,13 @@ static int st_unescape_bounds(httrackp *opt, int argc, char **argv) {
   assertf(hts_unescapeUrl("ab\xC3\xA9", dest, sizeof(dest)) == -1);
   assertf(hts_unescapeUrl("a\xC3\xA9", dest, sizeof(dest)) == 0);
   assertf(strcmp(dest, "a\xC3\xA9") == 0);
+  {
+    /* %xx-encoded flush path (utfBufferJ = lastJ rollback) */
+    char wide[8];
+
+    assertf(hts_unescapeUrl("%C3%A9", wide, sizeof(wide)) == 0);
+    assertf(strcmp(wide, "\xC3\xA9") == 0);
+  }
   printf("unescape-bounds self-test OK\n");
   return 0;
 }

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1846,6 +1846,17 @@ static int st_ftpuser(httrackp *opt, int argc, char **argv) {
   ftp_split_userpass(in, in + 802, user, sizeof(user), pass, sizeof(pass));
   assertf(strlen(user) == sizeof(user) - 1);
   assertf(strlen(pass) == sizeof(pass) - 1);
+  {
+    /* tight sizes + guard byte catch an off-by-one the 256 case can't */
+    char ubuf[16], pbuf[16];
+
+    memset(ubuf, 'Z', sizeof(ubuf));
+    memset(pbuf, 'Z', sizeof(pbuf));
+    ftp_split_userpass(in, in + 802, ubuf, 8, pbuf, 8);
+    assertf(strcmp(ubuf, "uuuuuuu") == 0);
+    assertf(strcmp(pbuf, "ppppppp") == 0);
+    assertf(ubuf[8] == 'Z' && pbuf[8] == 'Z');
+  }
   printf("ftp-userpass self-test OK\n");
   return 0;
 }

--- a/tests/31_local-javaclass.test
+++ b/tests/31_local-javaclass.test
@@ -1,0 +1,23 @@
+#!/bin/bash
+# The java plugin must load (versioned dlopen name) and parse a .class
+# constant pool: a resource named only inside Foo.class gets crawled.
+set -e
+
+: "${top_srcdir:=..}"
+
+tmproot=$(mktemp -d)
+trap 'rm -rf "$tmproot"' EXIT
+mkdir "$tmproot/javaclass"
+
+cat >"$tmproot/javaclass/index.html" <<'EOF'
+<html><body><a href="Foo.class">applet</a></body></html>
+EOF
+printf 'GIF89a' >"$tmproot/javaclass/hello.gif"
+# magic/minor/major, count=2, one CONSTANT_Utf8 "hello.gif", class/superclass
+printf '\xCA\xFE\xBA\xBE\x00\x00\x00\x32\x00\x02\x01\x00\x09hello.gif\x00\x00\x00\x00' \
+    >"$tmproot/javaclass/Foo.class"
+
+bash "$top_srcdir/tests/local-crawl.sh" --root "$tmproot" --errors 0 \
+    --found 'javaclass/Foo.class' \
+    --found 'javaclass/hello.gif' \
+    httrack 'BASEURL/javaclass/index.html'

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -90,6 +90,7 @@ TESTS = \
 	27_local-cookies-file.test \
 	28_local-pause.test \
 	29_local-redirect-fragment.test \
-	30_local-fragment-link.test
+	30_local-fragment-link.test \
+	31_local-javaclass.test
 
 CLEANFILES = check-network_sh.cache


### PR DESCRIPTION
Follow-ups from the #473/#474 review pass, plus what fell out of testing them.

The completed-UTF-8 flush in `hts_unescapeUrlSpecial` ends with a `continue` that bypasses the NUL-reserve guard, so a raw multi-byte character landing at the exact end of dest wrote `dest[max]`. Now guarded, and `-#test=unescape-bounds` covers the flush path (ASan fires on the unguarded code).

While fixing the known LP64 header bug (8-byte `unsigned long` magic under a 10-byte fread), it turned out the java plugin is dead on any modern Unix build for two more reasons: `hts_plug` is compiled hidden since -fvisibility=hidden, and `hts_create_opt()` still dlopens `libhtsjava.so.2` after the soname moved to 3. All three are fixed: `EXTERNAL_FUNCTION` forces default visibility on ELF, the dlopen name is derived from `VERSION_INFO` at configure time, and the header fields are fixed-width. A new local crawl test fetches a resource named only inside a `.class` constant pool and fails if any of the three regresses.

`ftp_split_userpass` now asserts nonzero buffer sizes (the size-1 math underflows on 0), and its self-test adds a tight-size run with guard bytes and exact-content checks, per the review's confirmation-bias finding.