### PR TITLE
Deduplicate the wait-for-socket macros and the stats-refresh loop tick

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -3371,6 +3371,33 @@ int back_pluggable_sockets_strict(struct_back * sback, httrackp * opt) {
   return n;
 }
 
+/* Single implementation of the historical WAIT_FOR_AVAILABLE_SOCKET macros. */
+hts_boolean hts_wait_available_socket(struct_back *sback, httrackp *opt,
+                                      cache_back *cache, int ptr) {
+  const int prev = opt->state._hts_in_html_parsing;
+
+  while (back_pluggable_sockets_strict(sback, opt) <= 0) {
+    opt->state._hts_in_html_parsing = 6;
+    back_wait(sback, opt, cache, 0);
+    /* time limit (-E) exceeded: stop waiting for a socket (#481) */
+    if (!back_checkmirror(opt))
+      break;
+    engine_stats();
+    HTS_STAT.stat_nsocket = back_nsoc(sback);
+    HTS_STAT.stat_errors = fspc(opt, NULL, "error");
+    HTS_STAT.stat_warnings = fspc(opt, NULL, "warning");
+    HTS_STAT.stat_infos = fspc(opt, NULL, "info");
+    HTS_STAT.nbk = backlinks_done(sback, opt->liens, opt->lien_tot, ptr);
+    HTS_STAT.nb = back_transferred(HTS_STAT.stat_bytes, sback);
+    if (!RUN_CALLBACK7(
+            opt, loop, sback->lnk, sback->count, -1, ptr, opt->lien_tot,
+            (int) (time_local() - HTS_STAT.stat_timestart), &HTS_STAT))
+      return HTS_FALSE;
+  }
+  opt->state._hts_in_html_parsing = prev;
+  return HTS_TRUE;
+}
+
 int back_pluggable_sockets(struct_back * sback, httrackp * opt) {
   int n;
 

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -3371,6 +3371,23 @@ int back_pluggable_sockets_strict(struct_back * sback, httrackp * opt) {
   return n;
 }
 
+/* One engine-loop tick: refresh the transfer stats and run the loop callback
+   for slot b (-1 = none). HTS_FALSE = the callback requested an abort. */
+hts_boolean hts_loop_tick(struct_back *sback, httrackp *opt, int b, int ptr) {
+  engine_stats();
+  HTS_STAT.stat_nsocket = back_nsoc(sback);
+  HTS_STAT.stat_errors = fspc(opt, NULL, "error");
+  HTS_STAT.stat_warnings = fspc(opt, NULL, "warning");
+  HTS_STAT.stat_infos = fspc(opt, NULL, "info");
+  HTS_STAT.nbk = backlinks_done(sback, opt->liens, opt->lien_tot, ptr);
+  HTS_STAT.nb = back_transferred(HTS_STAT.stat_bytes, sback);
+  return RUN_CALLBACK7(
+             opt, loop, sback->lnk, sback->count, b, ptr, opt->lien_tot,
+             (int) (time_local() - HTS_STAT.stat_timestart), &HTS_STAT)
+             ? HTS_TRUE
+             : HTS_FALSE;
+}
+
 /* Single implementation of the historical WAIT_FOR_AVAILABLE_SOCKET macros. */
 hts_boolean hts_wait_available_socket(struct_back *sback, httrackp *opt,
                                       cache_back *cache, int ptr) {
@@ -3382,16 +3399,7 @@ hts_boolean hts_wait_available_socket(struct_back *sback, httrackp *opt,
     /* time limit (-E) exceeded: stop waiting for a socket (#481) */
     if (!back_checkmirror(opt))
       break;
-    engine_stats();
-    HTS_STAT.stat_nsocket = back_nsoc(sback);
-    HTS_STAT.stat_errors = fspc(opt, NULL, "error");
-    HTS_STAT.stat_warnings = fspc(opt, NULL, "warning");
-    HTS_STAT.stat_infos = fspc(opt, NULL, "info");
-    HTS_STAT.nbk = backlinks_done(sback, opt->liens, opt->lien_tot, ptr);
-    HTS_STAT.nb = back_transferred(HTS_STAT.stat_bytes, sback);
-    if (!RUN_CALLBACK7(
-            opt, loop, sback->lnk, sback->count, -1, ptr, opt->lien_tot,
-            (int) (time_local() - HTS_STAT.stat_timestart), &HTS_STAT))
+    if (!hts_loop_tick(sback, opt, -1, ptr))
       return HTS_FALSE;
   }
   opt->state._hts_in_html_parsing = prev;

--- a/src/htscore.h
+++ b/src/htscore.h
@@ -432,6 +432,11 @@ int back_pluggable_sockets(struct_back * sback, httrackp * opt);
 
 int back_pluggable_sockets_strict(struct_back * sback, httrackp * opt);
 
+/* Wait until a test socket can be plugged, pumping transfers, stats and the
+   loop callback; gives up past the -E deadline. HTS_FALSE = callback abort. */
+hts_boolean hts_wait_available_socket(struct_back *sback, httrackp *opt,
+                                      cache_back *cache, int ptr);
+
 /* Randomized inter-file pause target in [min_ms,max_ms] (#185), derived from a
    timestamp seed so it is stable within one gap and rerolls per launch. */
 int hts_pause_target_ms(TStamp seed, int min_ms, int max_ms);

--- a/src/htscore.h
+++ b/src/htscore.h
@@ -432,6 +432,10 @@ int back_pluggable_sockets(struct_back * sback, httrackp * opt);
 
 int back_pluggable_sockets_strict(struct_back * sback, httrackp * opt);
 
+/* One engine-loop tick: refresh the transfer stats and run the loop callback
+   for slot b (-1 = none). HTS_FALSE = the callback requested an abort. */
+hts_boolean hts_loop_tick(struct_back *sback, httrackp *opt, int b, int ptr);
+
 /* Wait until a test socket can be plugged, pumping transfers, stats and the
    loop callback; gives up past the -E deadline. HTS_FALSE = callback abort. */
 hts_boolean hts_wait_available_socket(struct_back *sback, httrackp *opt,

--- a/src/htsname.c
+++ b/src/htsname.c
@@ -660,24 +660,11 @@ int url_savename(lien_adrfilsave *const afs,
                   if (ptr >= 0) {
                     back_fillmax(sback, opt, cache, ptr, numero_passe);
                   }
-                  // on est obligé d'appeler le shell pour le refresh..
-                  // Transfer rate
-                  engine_stats();
-
-                  // Refresh various stats
-                  HTS_STAT.stat_nsocket = back_nsoc(sback);
-                  HTS_STAT.stat_errors = fspc(opt, NULL, "error");
-                  HTS_STAT.stat_warnings = fspc(opt, NULL, "warning");
-                  HTS_STAT.stat_infos = fspc(opt, NULL, "info");
-                  HTS_STAT.nbk = backlinks_done(sback, opt->liens, opt->lien_tot, ptr);
-                  HTS_STAT.nb = back_transferred(HTS_STAT.stat_bytes, sback);
-
-                  if (!RUN_CALLBACK7
-                      (opt, loop, sback->lnk, sback->count, b, ptr, opt->lien_tot,
-                       (int) (time_local() - HTS_STAT.stat_timestart),
-                       &HTS_STAT)) {
+                  if (!hts_loop_tick(sback, opt, b, ptr)) {
                     return -1;
-                  } else if (opt->state._hts_cancel || !back_checkmirror(opt)) {        // cancel 2 ou 1 (cancel parsing)
+                  } else if (opt->state._hts_cancel ||
+                             !back_checkmirror(
+                                 opt)) { // cancel level 2 or 1 (cancel parsing)
                     back_delete(opt, cache, sback, b);  // cancel test
                     stop_looping = 1;
                   }

--- a/src/htsname.c
+++ b/src/htsname.c
@@ -74,37 +74,6 @@ static const char *hts_tbdev[] = {
   ""
 };
 
-#define URLSAVENAME_WAIT_FOR_AVAILABLE_SOCKET()                                \
-  do {                                                                         \
-    int prev = opt->state._hts_in_html_parsing;                                \
-    while (back_pluggable_sockets_strict(sback, opt) <= 0) {                   \
-      opt->state._hts_in_html_parsing = 6;                                     \
-      /* Wait .. */                                                            \
-      back_wait(sback, opt, cache, 0);                                         \
-      /* time limit (-E) exceeded: stop waiting for a socket (#481) */         \
-      if (!back_checkmirror(opt))                                              \
-        break;                                                                 \
-      /* Transfer rate */                                                      \
-      engine_stats();                                                          \
-      /* Refresh various stats */                                              \
-      HTS_STAT.stat_nsocket = back_nsoc(sback);                                \
-      HTS_STAT.stat_errors = fspc(opt, NULL, "error");                         \
-      HTS_STAT.stat_warnings = fspc(opt, NULL, "warning");                     \
-      HTS_STAT.stat_infos = fspc(opt, NULL, "info");                           \
-      HTS_STAT.nbk = backlinks_done(sback, opt->liens, opt->lien_tot, ptr);    \
-      HTS_STAT.nb = back_transferred(HTS_STAT.stat_bytes, sback);              \
-      /* Check */                                                              \
-      {                                                                        \
-        if (!RUN_CALLBACK7(                                                    \
-                opt, loop, sback->lnk, sback->count, -1, ptr, opt->lien_tot,   \
-                (int) (time_local() - HTS_STAT.stat_timestart), &HTS_STAT)) {  \
-          return -1;                                                           \
-        }                                                                      \
-      }                                                                        \
-    }                                                                          \
-    opt->state._hts_in_html_parsing = prev;                                    \
-  } while (0)
-
 /* Strip all // */
 static void cleanDoubleSlash(char *s) {
   int i, j;
@@ -658,11 +627,10 @@ int url_savename(lien_adrfilsave *const afs,
             int has_been_moved = 0;
             lien_adrfil current;
 
-            /* Ensure we don't use too many sockets by using a "testing" one
-               If we have only 1 simultaneous connection authorized, wait for pending download
-               Wait for an available slot 
+            /* Wait for an available test slot, honoring the connection limits
              */
-            URLSAVENAME_WAIT_FOR_AVAILABLE_SOCKET();
+            if (!hts_wait_available_socket(sback, opt, cache, ptr))
+              return -1;
 
             /* Rock'in */
             current.adr[0] = current.fil[0] = '\0';
@@ -774,8 +742,9 @@ int url_savename(lien_adrfilsave *const afs,
                                                 "Loop with HEAD request (during prefetch) at %s%s",
                                                 current.adr, current.fil);
                                 }
-                                // Ajouter
-                                URLSAVENAME_WAIT_FOR_AVAILABLE_SOCKET();
+                                if (!hts_wait_available_socket(sback, opt,
+                                                               cache, ptr))
+                                  return -1;
                                 if (back_add(sback, opt, cache, moved.adr, moved.fil, methode, referer_adr, referer_fil, 1) != -1) {        // OK
                                   hts_log_print(opt, LOG_DEBUG,
                                                 "(during prefetch) %s (%d) to link %s at %s%s",

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -3399,20 +3399,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
           back_wait(sback, opt, cache, HTS_STAT.stat_timestart);
           back_fillmax(sback, opt, cache, ptr, numero_passe);
 
-          // Transfer rate
-          engine_stats();
-
-          // Refresh various stats
-          HTS_STAT.stat_nsocket = back_nsoc(sback);
-          HTS_STAT.stat_errors = fspc(opt, NULL, "error");
-          HTS_STAT.stat_warnings = fspc(opt, NULL, "warning");
-          HTS_STAT.stat_infos = fspc(opt, NULL, "info");
-          HTS_STAT.nbk = backlinks_done(sback, opt->liens, opt->lien_tot, ptr);
-          HTS_STAT.nb = back_transferred(HTS_STAT.stat_bytes, sback);
-
-          if (!RUN_CALLBACK7
-              (opt, loop, sback->lnk, sback->count, 0, ptr, opt->lien_tot,
-               (int) (time_local() - HTS_STAT.stat_timestart), &HTS_STAT)) {
+          if (!hts_loop_tick(sback, opt, 0, ptr)) {
             hts_log_print(opt, LOG_ERROR, "Exit requested by shell or user");
             *stre->exit_xh_ = 1;        // exit requested
             XH_uninit;
@@ -3423,7 +3410,6 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
             nofollow = 1;       // moins violent
             opt->state._hts_cancel = 0;
           }
-
         }
         // refresh the backing system each 2 seconds
         if (engine_stats()) {
@@ -3960,22 +3946,8 @@ void hts_mirror_process_user_interaction(htsmoduleStruct * str,
         {
           back_wait(sback, opt, cache, HTS_STAT.stat_timestart);
 
-          // Transfer rate
-          engine_stats();
-
-          // Refresh various stats
-          HTS_STAT.stat_nsocket = back_nsoc(sback);
-          HTS_STAT.stat_errors = fspc(opt, NULL, "error");
-          HTS_STAT.stat_warnings = fspc(opt, NULL, "warning");
-          HTS_STAT.stat_infos = fspc(opt, NULL, "info");
-          HTS_STAT.nbk = backlinks_done(sback, opt->liens, opt->lien_tot, ptr);
-          HTS_STAT.nb = back_transferred(HTS_STAT.stat_bytes, sback);
-
           b = 0;
-          if (!RUN_CALLBACK7
-              (opt, loop, sback->lnk, sback->count, b, ptr, opt->lien_tot,
-               (int) (time_local() - HTS_STAT.stat_timestart), &HTS_STAT)
-              || !back_checkmirror(opt)) {
+          if (!hts_loop_tick(sback, opt, b, ptr) || !back_checkmirror(opt)) {
             hts_log_print(opt, LOG_ERROR, "Exit requested by shell or user");
             *stre->exit_xh_ = 1;        // exit requested
             XH_uninit;
@@ -4081,20 +4053,7 @@ void hts_mirror_process_user_interaction(htsmoduleStruct * str,
       if (!back_checkmirror(opt))
         break;
 
-      // Transfer rate
-      engine_stats();
-
-      // Refresh various stats
-      HTS_STAT.stat_nsocket = back_nsoc(sback);
-      HTS_STAT.stat_errors = fspc(opt, NULL, "error");
-      HTS_STAT.stat_warnings = fspc(opt, NULL, "warning");
-      HTS_STAT.stat_infos = fspc(opt, NULL, "info");
-      HTS_STAT.nbk = backlinks_done(sback, opt->liens, opt->lien_tot, ptr);
-      HTS_STAT.nb = back_transferred(HTS_STAT.stat_bytes, sback);
-
-      if (!RUN_CALLBACK7
-          (opt, loop, sback->lnk, sback->count, b, ptr, opt->lien_tot,
-           (int) (time_local() - HTS_STAT.stat_timestart), &HTS_STAT)) {
+      if (!hts_loop_tick(sback, opt, b, ptr)) {
         hts_log_print(opt, LOG_ERROR, "Exit requested by shell or user");
         *stre->exit_xh_ = 1;    // exit requested
         XH_uninit;
@@ -4281,26 +4240,12 @@ int hts_mirror_wait_for_next_file(htsmoduleStruct * str,
           freet(s);
         }
 
-        // Transfer rate
-        engine_stats();
-
-        // Refresh various stats
-        HTS_STAT.stat_nsocket = back_nsoc(sback);
-        HTS_STAT.stat_errors = fspc(opt, NULL, "error");
-        HTS_STAT.stat_warnings = fspc(opt, NULL, "warning");
-        HTS_STAT.stat_infos = fspc(opt, NULL, "info");
-        HTS_STAT.nbk = backlinks_done(sback, opt->liens, opt->lien_tot, ptr);
-        HTS_STAT.nb = back_transferred(HTS_STAT.stat_bytes, sback);
-
-        if (!RUN_CALLBACK7
-            (opt, loop, sback->lnk, sback->count, b, ptr, opt->lien_tot,
-             (int) (time_local() - HTS_STAT.stat_timestart), &HTS_STAT)) {
+        if (!hts_loop_tick(sback, opt, b, ptr)) {
           hts_log_print(opt, LOG_ERROR, "Exit requested by shell or user");
           *stre->exit_xh_ = 1;  // exit requested
           XH_uninit;
           return 0;
         }
-
       }
 
 #if HTS_POLL
@@ -4681,29 +4626,14 @@ int hts_wait_delayed(htsmoduleStruct * str, lien_adrfilsave *afs,
           if (ptr >= 0) {
             back_fillmax(sback, opt, cache, ptr, numero_passe);
           }
-          // on est obligé d'appeler le shell pour le refresh..
-          {
-
-            // Transfer rate
-            engine_stats();
-
-            // Refresh various stats
-            HTS_STAT.stat_nsocket = back_nsoc(sback);
-            HTS_STAT.stat_errors = fspc(opt, NULL, "error");
-            HTS_STAT.stat_warnings = fspc(opt, NULL, "warning");
-            HTS_STAT.stat_infos = fspc(opt, NULL, "info");
-            HTS_STAT.nbk = backlinks_done(sback, opt->liens, opt->lien_tot, ptr);
-            HTS_STAT.nb = back_transferred(HTS_STAT.stat_bytes, sback);
-
-            if (!RUN_CALLBACK7
-                (opt, loop, sback->lnk, sback->count, b, ptr, opt->lien_tot,
-                 (int) (time_local() - HTS_STAT.stat_timestart), &HTS_STAT)) {
-              back_set_unlocked(sback, b);
-              return -1;
-            } else if (opt->state._hts_cancel || !back_checkmirror(opt)) {      // cancel 2 ou 1 (cancel parsing)
-              back_delete(opt, cache, sback, b);        // cancel test
-              break;
-            }
+          if (!hts_loop_tick(sback, opt, b, ptr)) {
+            back_set_unlocked(sback, b);
+            return -1;
+          } else if (opt->state._hts_cancel ||
+                     !back_checkmirror(
+                         opt)) { // cancel level 2 or 1 (cancel parsing)
+            back_delete(opt, cache, sback, b); // cancel test
+            break;
           }
         } while (
             /* dns/connect/request */

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -4533,10 +4533,9 @@ int hts_wait_delayed(htsmoduleStruct * str, lien_adrfilsave *afs,
         IS_DELAYED_EXT(afs->save) && continue_loop && loops < 7; loops++) {
       continue_loop = 0;
 
-      /*
-         Wait for an available slot 
-       */
-      WAIT_FOR_AVAILABLE_SOCKET();
+      /* Wait for an available slot */
+      if (!hts_wait_available_socket(sback, opt, cache, ptr))
+        return -1;
 
       /* We can lookup directly in the cache to speedup this mess */
       if (opt->delayed_cached) {

--- a/src/htsparse.h
+++ b/src/htsparse.h
@@ -175,33 +175,4 @@ int hts_wait_delayed(htsmoduleStruct * str, lien_adrfilsave *afs,
   /* Apply changes */ \
   * str->ptr_ = ptr
 
-#define WAIT_FOR_AVAILABLE_SOCKET()                                            \
-  do {                                                                         \
-    int prev = opt->state._hts_in_html_parsing;                                \
-    while (back_pluggable_sockets_strict(sback, opt) <= 0) {                   \
-      opt->state._hts_in_html_parsing = 6;                                     \
-      /* Wait .. */                                                            \
-      back_wait(sback, opt, cache, 0);                                         \
-      /* time limit (-E) exceeded: stop waiting for a socket (#481) */         \
-      if (!back_checkmirror(opt))                                              \
-        break;                                                                 \
-      /* Transfer rate */                                                      \
-      engine_stats();                                                          \
-      /* Refresh various stats */                                              \
-      HTS_STAT.stat_nsocket = back_nsoc(sback);                                \
-      HTS_STAT.stat_errors = fspc(opt, NULL, "error");                         \
-      HTS_STAT.stat_warnings = fspc(opt, NULL, "warning");                     \
-      HTS_STAT.stat_infos = fspc(opt, NULL, "info");                           \
-      HTS_STAT.nbk = backlinks_done(sback, opt->liens, opt->lien_tot, ptr);    \
-      HTS_STAT.nb = back_transferred(HTS_STAT.stat_bytes, sback);              \
-      /* Check */                                                              \
-      if (!RUN_CALLBACK7(                                                      \
-              opt, loop, sback->lnk, sback->count, -1, ptr, opt->lien_tot,     \
-              (int) (time_local() - HTS_STAT.stat_timestart), &HTS_STAT)) {    \
-        return -1;                                                             \
-      }                                                                        \
-    }                                                                          \
-    opt->state._hts_in_html_parsing = prev;                                    \
-  } while (0)
-
 #endif


### PR DESCRIPTION
Follow-up to #482, which had to patch the same -E checkmirror break into two byte-for-byte copies of the wait-for-socket macro (`URLSAVENAME_WAIT_FOR_AVAILABLE_SOCKET` in htsname.c, `WAIT_FOR_AVAILABLE_SOCKET` in htsparse.h). The first commit folds them into a single `hts_wait_available_socket()`.

The core of the macro body, refreshing the transfer stats and running the loop callback, also existed open-coded at six more sites in htsname.c and htsparse.c, differing only in the slot index passed to the callback and the abort action. The second commit collapses them onto a shared `hts_loop_tick()`; each caller keeps its own abort path. No behavior change, net -100 lines, and make check stays green.