### PR TITLE
Source-only package build fails on a host older than the declared compat

### DIFF
--- a/tools/mkdeb.sh
+++ b/tools/mkdeb.sh
@@ -211,7 +211,9 @@ main() {
     # lintian ourselves below as the real gate.
     local -a debuild_opts=(--no-lintian)
     local -a build_opts=()
-    [[ $source_only -eq 1 ]] && build_opts+=(-S)
+    # -d: a source build runs no debhelper, so don't require Build-Depends
+    # locally (the buildds and the --sbuild gate enforce them).
+    [[ $source_only -eq 1 ]] && build_opts+=(-S -d)
     if [[ $unsigned -eq 1 ]]; then
         build_opts+=(-us -uc)
     else


### PR DESCRIPTION
Source-only builds broke on a stable host once #466 moved the package to debhelper compat 14: dpkg-checkbuilddeps aborts before dpkg-source even runs, although a source build never executes debhelper (trixie ships 13.24, sid has 14). Pass -d on the source-only path so the local debhelper version no longer matters; the buildds and the --sbuild gate still enforce Build-Depends. Hit while cutting 3.49.11-1.