### PR TITLE
debian: restore the 3.49.10-2 changelog entry omitted from 3.49.11-1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -10,6 +10,15 @@ httrack (3.49.11-1) unstable; urgency=medium
 
  -- Xavier Roche <xavier@debian.org>  Sun, 05 Jul 2026 00:03:18 +0200
 
+httrack (3.49.10-2) unstable; urgency=medium
+
+  * Fix FTBFS: tests/28_local-pause failed instead of skipping when python3 is
+    absent (the local-server tests need python3, which the buildds lack). Add
+    patches/skip-local-pause-test-without-python3.patch to guard the test on
+    python3 up front, like its siblings, so it skips cleanly.
+
+ -- Xavier Roche <xavier@debian.org>  Sun, 28 Jun 2026 20:18:46 +0200
+
 httrack (3.49.10-1) unstable; urgency=medium
 
   * New upstream release: new download-pacing and URL-handling options plus a


### PR DESCRIPTION
The 3.49.10-2 upload (the FTBFS fix for Debian bug #1140983) went straight to the archive and its changelog entry was never committed back, so the 3.49.11-1 changelog jumps from 3.49.10-1 to 3.49.11-1. The BTS builds its version graph from upload changelogs, so it counts the bug as still present in 3.49.11-1, and britney now blocks migration with "Updating httrack would introduce bugs in testing: #1140983".

This restores the missing entry verbatim from the archive so future uploads carry the full history. The BTS metadata itself is corrected separately with a `fixed 1140983 3.49.11-1` control message.