### PR TITLE
Cancelling a crawl mid delayed-type-check orphans .delayed placeholders

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -1366,6 +1366,8 @@ int back_flush_output(httrackp * opt, cache_back * cache, struct_back * sback,
    placeholder: move the on-disk file to newname, following with the stream. */
 hts_boolean back_delayed_rename(httrackp *opt, lien_back *back,
                                 const char *newname) {
+  hts_boolean renamed;
+
   if (!back->r.is_write || back->tmpfile != NULL ||
       !IS_DELAYED_EXT(back->url_sav) || strcmp(back->url_sav, newname) == 0)
     return HTS_TRUE; /* nothing bound to the placeholder name */
@@ -1373,22 +1375,22 @@ hts_boolean back_delayed_rename(httrackp *opt, lien_back *back,
     fclose(back->r.out);
     back->r.out = NULL;
   }
-  if (RENAME(back->url_sav, newname) == 0 &&
-      (back->status == STATUS_READY ||
-       (back->r.out = FOPEN(newname, "ab")) != NULL)) {
+  renamed = RENAME(back->url_sav, newname) == 0 ? HTS_TRUE : HTS_FALSE;
+  if (renamed && (back->status == STATUS_READY ||
+                  (back->r.out = FOPEN(newname, "ab")) != NULL)) {
     filenote(&opt->state.strc, newname, NULL);
     hts_log_print(opt, LOG_DEBUG, "moved placeholder %s to %s", back->url_sav,
                   newname);
     return HTS_TRUE;
   }
-  /* the partial is unreachable under either name: flag the slot and drop it */
+  /* the partial is lost: flag the slot and drop only what we own, never a
+     pre-existing newname (Windows rename does not overwrite) */
   hts_log_print(opt, LOG_WARNING | LOG_ERRNO, "unable to move %s to %s",
                 back->url_sav, newname);
   back->r.statuscode = STATUSCODE_INVALID;
   strcpybuff(back->r.msg, "Write error on disk");
   back->r.is_write = 0;
-  (void) UNLINK(back->url_sav);
-  (void) UNLINK(newname);
+  (void) UNLINK(renamed ? newname : back->url_sav);
   return HTS_FALSE;
 }
 

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -1362,9 +1362,39 @@ int back_flush_output(httrackp * opt, cache_back * cache, struct_back * sback,
   return 0;
 }
 
+/* The final type was resolved while the transfer still writes to the .delayed
+   placeholder: move the on-disk file to newname, following with the stream. */
+hts_boolean back_delayed_rename(httrackp *opt, lien_back *back,
+                                const char *newname) {
+  if (!back->r.is_write || back->tmpfile != NULL ||
+      !IS_DELAYED_EXT(back->url_sav) || strcmp(back->url_sav, newname) == 0)
+    return HTS_TRUE; /* nothing bound to the placeholder name */
+  if (back->r.out != NULL) {
+    fclose(back->r.out);
+    back->r.out = NULL;
+  }
+  if (RENAME(back->url_sav, newname) == 0 &&
+      (back->status == STATUS_READY ||
+       (back->r.out = FOPEN(newname, "ab")) != NULL)) {
+    filenote(&opt->state.strc, newname, NULL);
+    hts_log_print(opt, LOG_DEBUG, "moved placeholder %s to %s", back->url_sav,
+                  newname);
+    return HTS_TRUE;
+  }
+  /* the partial is unreachable under either name: flag the slot and drop it */
+  hts_log_print(opt, LOG_WARNING | LOG_ERRNO, "unable to move %s to %s",
+                back->url_sav, newname);
+  back->r.statuscode = STATUSCODE_INVALID;
+  strcpybuff(back->r.msg, "Write error on disk");
+  back->r.is_write = 0;
+  (void) UNLINK(back->url_sav);
+  (void) UNLINK(newname);
+  return HTS_FALSE;
+}
+
 // effacer entrée
 /* Discard a cancelled mid-write .delayed placeholder (unusable across runs). */
-static void back_delayed_discard(httrackp *opt, lien_back *back) {
+void back_delayed_discard(httrackp *opt, lien_back *back) {
   if (back->r.out != NULL) {
     fclose(back->r.out);
     back->r.out = NULL;

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -1362,8 +1362,7 @@ int back_flush_output(httrackp * opt, cache_back * cache, struct_back * sback,
   return 0;
 }
 
-/* The final type was resolved while the transfer still writes to the .delayed
-   placeholder: move the on-disk file to newname, following with the stream. */
+/* Move a still-writing .delayed placeholder to its final name (#483). */
 hts_boolean back_delayed_rename(httrackp *opt, lien_back *back,
                                 const char *newname) {
   hts_boolean renamed;
@@ -1383,8 +1382,7 @@ hts_boolean back_delayed_rename(httrackp *opt, lien_back *back,
                   newname);
     return HTS_TRUE;
   }
-  /* the partial is lost: flag the slot and drop only what we own, never a
-     pre-existing newname (Windows rename does not overwrite) */
+  /* partial lost: drop only what we own (Windows rename won't overwrite) */
   hts_log_print(opt, LOG_WARNING | LOG_ERRNO, "unable to move %s to %s",
                 back->url_sav, newname);
   back->r.statuscode = STATUSCODE_INVALID;

--- a/src/htsback.h
+++ b/src/htsback.h
@@ -113,6 +113,14 @@ void back_set_locked(struct_back * sback, const int p);
 void back_set_unlocked(struct_back * sback, const int p);
 int back_delete(httrackp * opt, cache_back * cache, struct_back * sback,
                 const int p);
+/* Discard back's on-disk .delayed placeholder and its refname; closes any
+   open output stream. Safe on a back_copy_static() copy. */
+void back_delayed_discard(httrackp *opt, lien_back *back);
+/* Move back's on-disk .delayed placeholder to newname before url_sav is
+   patched; reopens a mid-transfer stream on the new name. HTS_FALSE = the
+   file was lost and the slot flagged in error. */
+hts_boolean back_delayed_rename(httrackp *opt, lien_back *back,
+                                const char *newname);
 void back_index_unlock(struct_back * sback, const int p);
 int back_clear_entry(lien_back * back);
 int back_flush_output(httrackp * opt, cache_back * cache, struct_back * sback,

--- a/src/htsback.h
+++ b/src/htsback.h
@@ -113,12 +113,10 @@ void back_set_locked(struct_back * sback, const int p);
 void back_set_unlocked(struct_back * sback, const int p);
 int back_delete(httrackp * opt, cache_back * cache, struct_back * sback,
                 const int p);
-/* Discard back's on-disk .delayed placeholder and its refname; closes any
-   open output stream. Safe on a back_copy_static() copy. */
+/* Discard back's on-disk .delayed placeholder and its refname. */
 void back_delayed_discard(httrackp *opt, lien_back *back);
-/* Move back's on-disk .delayed placeholder to newname before url_sav is
-   patched; reopens a mid-transfer stream on the new name. HTS_FALSE = the
-   file was lost and the slot flagged in error. */
+/* Move back's .delayed placeholder (and open stream) to newname;
+   HTS_FALSE = file lost, slot flagged in error. */
 hts_boolean back_delayed_rename(httrackp *opt, lien_back *back,
                                 const char *newname);
 void back_index_unlock(struct_back * sback, const int p);

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -4566,8 +4566,8 @@ int hts_wait_delayed(htsmoduleStruct * str, lien_adrfilsave *afs,
           back_maydelete(opt, cache, sback, b);    // cancel
           b = -1;
 
-          /* Nothing references the on-disk placeholder anymore; if the
-             cancel left it behind (is_write already cleared), drop it (#483) */
+          /* the cancel may leave the now-unreferenced placeholder on disk
+           * (#483) */
           if (fexist_utf8(delayed_back.url_sav)) {
             back_delayed_discard(opt, &delayed_back);
           }
@@ -4788,8 +4788,8 @@ int hts_wait_delayed(htsmoduleStruct * str, lien_adrfilsave *afs,
 
           /* Still have a back reference */
           if (b >= 0) {
-            /* a direct-to-disk transfer still writes to the placeholder path:
-               once url_sav is patched no cleanup can see that file (#483) */
+            /* move a still-writing placeholder before the url_sav patch
+               blinds every cleanup to it (#483) */
             back_delayed_rename(opt, &back[b], afs->save);
             /* patch url_sav BEFORE finalize: it records/caches under this name
              */

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -4566,6 +4566,12 @@ int hts_wait_delayed(htsmoduleStruct * str, lien_adrfilsave *afs,
           back_maydelete(opt, cache, sback, b);    // cancel
           b = -1;
 
+          /* Nothing references the on-disk placeholder anymore; if the
+             cancel left it behind (is_write already cleared), drop it (#483) */
+          if (fexist_utf8(delayed_back.url_sav)) {
+            back_delayed_discard(opt, &delayed_back);
+          }
+
           /* Recompute filename with MIME type */
           afs->save[0] = '\0';
           url_savename(afs, former, heap(ptr)->adr,
@@ -4782,6 +4788,9 @@ int hts_wait_delayed(htsmoduleStruct * str, lien_adrfilsave *afs,
 
           /* Still have a back reference */
           if (b >= 0) {
+            /* a direct-to-disk transfer still writes to the placeholder path:
+               once url_sav is patched no cleanup can see that file (#483) */
+            back_delayed_rename(opt, &back[b], afs->save);
             /* patch url_sav BEFORE finalize: it records/caches under this name
              */
             strcpybuff(back[b].url_sav, afs->save);

--- a/tests/34_local-maxtime.test
+++ b/tests/34_local-maxtime.test
@@ -7,10 +7,8 @@ set -euo pipefail
 
 : "${top_srcdir:=..}"
 
-# cancelled crawls can orphan .delayed placeholders (#483): skip that audit
 start=$(date +%s)
 bash "$top_srcdir/tests/local-crawl.sh" \
-    --skip-delayed-audit \
     --log-found 'More than 2 seconds passed' \
     httrack 'BASEURL/trickle/index.html' -E2 -c4
 wall=$(($(date +%s) - start))

--- a/tests/39_local-delayed-cancel.test
+++ b/tests/39_local-delayed-cancel.test
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Cancelling mid delayed-type-check must not orphan .delayed placeholders
+# (#483): timing-dependent (~1 in 6 crawls on a buggy tree, hence two tries),
+# never false-fails. -A keeps reads throttled so the window stays reachable.
+
+set -euo pipefail
+
+: "${top_srcdir:=..}"
+
+for _ in 1 2; do
+    bash "$top_srcdir/tests/local-crawl.sh" \
+        httrack 'BASEURL/dcancel/index.html' -E1 -c4 -A25000
+done

--- a/tests/39_local-delayed-cancel.test
+++ b/tests/39_local-delayed-cancel.test
@@ -1,8 +1,7 @@
 #!/bin/bash
 #
-# Cancelling mid delayed-type-check must not orphan .delayed placeholders
-# (#483): timing-dependent (~1 in 6 crawls on a buggy tree, hence two tries),
-# never false-fails. -A keeps reads throttled so the window stays reachable.
+# Cancelled delayed-type-checks must not orphan .delayed placeholders (#483).
+# Timing-dependent (hence two tries); -A keeps the window reachable.
 
 set -euo pipefail
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -103,6 +103,7 @@ TESTS = \
 	35_local-maxsize.test \
 	36_local-bigcrawl.test \
 	37_local-cache-outage.test \
-	38_local-update-304.test
+	38_local-update-304.test \
+	39_local-delayed-cancel.test
 
 CLEANFILES = check-network_sh.cache

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -97,7 +97,6 @@ tmpdir=$(mktemp -d "${tmptopdir}/httrack_local.XXXXXX") || die "could not create
 # --- parse leading control flags --------------------------------------------
 declare -a audit=()
 declare -a cookies=()
-skip_delayed_audit=""
 scheme=http
 pos=0
 args=("$@")
@@ -122,9 +121,6 @@ while test "$pos" -lt "$nargs"; do
     --cookie)
         pos=$((pos + 1))
         cookies+=("${args[$pos]}")
-        ;;
-    --skip-delayed-audit)
-        skip_delayed_audit=1
         ;;
     --errors | --files)
         audit+=("${args[$pos]}" "${args[$((pos + 1))]}")
@@ -293,15 +289,12 @@ done
 test -n "$hostroot" || die "could not find host root under $out"
 debug "host root: $hostroot"
 
-# A completed crawl must leave no .delayed temporaries (issue #107).
-# --skip-delayed-audit: a cancelled crawl can orphan placeholders (issue #483)
-if test -z "$skip_delayed_audit"; then
-    info "checking for leftover .delayed files"
-    leftovers=$(find "$out" -name '*.delayed' 2>/dev/null | head -5)
-    if test -z "$leftovers"; then result "OK"; else
-        result "leftover: $leftovers"
-        exit 1
-    fi
+# No crawl, even a cancelled one, may leave .delayed temporaries (#107, #483).
+info "checking for leftover .delayed files"
+leftovers=$(find "$out" -name '*.delayed' 2>/dev/null | head -5)
+if test -z "$leftovers"; then result "OK"; else
+    result "leftover: $leftovers"
+    exit 1
 fi
 
 # --- audit -------------------------------------------------------------------

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -913,8 +913,8 @@ class Handler(SimpleHTTPRequestHandler):
         except OSError:
             pass
 
-    # Cancel mid delayed-type-check (#483): trickled .bin pages so the -E stop
-    # lands in the type waiter's unlock-to-patch window with body bytes pending.
+    # #483: trickled .bin pages so the -E stop lands in the type waiter's
+    # unlock-to-patch window with body bytes pending.
     def route_dcancel_index(self):
         self.send_bin_index()
 

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -913,6 +913,26 @@ class Handler(SimpleHTTPRequestHandler):
         except OSError:
             pass
 
+    # Cancel mid delayed-type-check (#483): trickled .bin pages so the -E stop
+    # lands in the type waiter's unlock-to-patch window with body bytes pending.
+    def route_dcancel_index(self):
+        self.send_bin_index()
+
+    def route_dcancel_page(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", "4096")
+        self.end_headers()
+        if self.command == "HEAD":
+            return
+        try:
+            for _ in range(32):
+                self.wfile.write(b"z" * 128)
+                self.wfile.flush()
+                time.sleep(0.05)
+        except OSError:
+            pass
+
     # -M byte cap (#77): large fast files so a crawl overruns -M immediately.
     BIGFILE_BYTES = 640 * 1024
 
@@ -976,6 +996,15 @@ class Handler(SimpleHTTPRequestHandler):
         "/trickle/p5.bin": route_trickle_page,
         "/trickle/p6.bin": route_trickle_page,
         "/trickle/p7.bin": route_trickle_page,
+        "/dcancel/index.html": route_dcancel_index,
+        "/dcancel/p0.bin": route_dcancel_page,
+        "/dcancel/p1.bin": route_dcancel_page,
+        "/dcancel/p2.bin": route_dcancel_page,
+        "/dcancel/p3.bin": route_dcancel_page,
+        "/dcancel/p4.bin": route_dcancel_page,
+        "/dcancel/p5.bin": route_dcancel_page,
+        "/dcancel/p6.bin": route_dcancel_page,
+        "/dcancel/p7.bin": route_dcancel_page,
         "/bigfiles/index.html": route_bigfiles_index,
         "/bigfiles/p0.bin": route_bigfile,
         "/bigfiles/p1.bin": route_bigfile,


### PR DESCRIPTION
Cancelling a crawl mid delayed-type-check leaves `X.N.delayed` partials in the mirror (#483): `hts_wait_delayed()` patches `url_sav` to the final name while the transfer can still be writing to the placeholder path, and every cleanup keyed on `IS_DELAYED_EXT(url_sav)` then misses the file. Fix: `back_delayed_rename()` moves the placeholder to the final name right before the patch; the cache-miss re-add path discards its placeholder when a cancel drops the last reference.

The `.delayed` leftover audit now runs for every local crawl, and the new `39_local-delayed-cancel` test pins the scenario (timing-dependent: 4/10 failing on master, 10/10 clean here; 0 orphans in 35 harness crawls vs about 1 in 6 before).

Closes #483.