### PR TITLE
Fix four fuzzer-found over-reads and a leak in the filter, URL, and IDNA parsers

### DIFF
--- a/src/htscharset.c
+++ b/src/htscharset.c
@@ -910,19 +910,19 @@ char *hts_convertStringUTF8ToIDNA(const char *s, size_t size) {
                 /* Reader: can read bytes up to j */
 #define RD ( utfSeq < j ? segData[utfSeq++] : -1 )
 
-                /* Writer: upon error, return FFFD (replacement character) */
-#define WR(C) do { \
-  if ((C) != -1) { \
-    /* copy character */ \
-    assertf(segOutputSize < segSize); \
-    segInt[segOutputSize++] = (C); \
-  } \
-  /* In case of error, abort. */ \
-  else { \
-    FREE_BUFFER(); \
-    return NULL; \
-  } \
-} while(0)
+                /* Writer: a malformed sequence abandons the encode (NULL) */
+#define WR(C)                                                                  \
+  do {                                                                         \
+    if ((C) != -1) {                                                           \
+      /* copy character */                                                     \
+      assertf(segOutputSize < segSize);                                        \
+      segInt[segOutputSize++] = (C);                                           \
+    } else {                                                                   \
+      freet(segInt);                                                           \
+      FREE_BUFFER();                                                           \
+      return NULL;                                                             \
+    }                                                                          \
+  } while (0)
 
                 /* Read/Write Unicode character. */
                 READ_UNICODE(RD, WR);
@@ -1144,7 +1144,7 @@ int hts_isStringUTF8(const char *s, size_t size) {
     /* Reader: can read bytes up to j */
 #define RD ( i < size ? data[i++] : -1 )
 
-    /* Writer: upon error, return FFFD (replacement character) */
+    /* Writer: a malformed sequence means the string is not UTF-8 (return 0) */
 #define WR(C) if ((C) == -1) { return 0; }
 
     /* Read Unicode character. */

--- a/src/htsfilters.c
+++ b/src/htsfilters.c
@@ -286,7 +286,7 @@ HTS_INLINE const char *strjoker(const char *chaine, const char *joker,
       if (!unique)
         max = (int) strlen(chaine);
       else                      /* *(a) only match a (not aaaaa) */
-        max = 1;
+        max = strnotempty(chaine) ? 1 : 0; /* empty chaine: no char to eat */
       while(i < (int) max) {
         if (pass[(int) (unsigned char) chaine[i]]) {    // caractère autorisé
           if ((adr = strjoker(chaine + i + 1, joker + jmp, size, size_flag))) {

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -2497,6 +2497,10 @@ int ident_url_absolute(const char *url, lien_adrfil *adrfil) {
   // effacer adrfil->adr et adrfil->fil
   adrfil->adr[0] = adrfil->fil[0] = '\0';
 
+  // Reject an over-long URL: a root-relative path is copied whole into fil[].
+  if (strlen(url) >= HTS_URLMAXSIZE * 2)
+    return -1;
+
 #if HDEBUG
   printf("protocol: %s\n", url);
 #endif
@@ -2572,7 +2576,7 @@ int ident_url_absolute(const char *url, lien_adrfil *adrfil) {
     if (*p == '/' || *p == '\\') {      /* adrfil->file:///.. */
       strcatbuff(adrfil->fil, p);       // fichier local ; adrfil->adr="#"
     } else {
-      if (p[1] != ':') {
+      if (*p == '\0' || p[1] != ':') {  /* empty path: not a DOS drive letter */
         strcatbuff(adrfil->fil, "//");  /* adrfil->file://server/foo */
         strcatbuff(adrfil->fil, p);
       } else {

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -579,15 +579,16 @@ static int st_filter(httrackp *opt, int argc, char **argv) {
   int matched;
 
   (void) opt;
-  if (argc < 2) {
+  if (argc < 1) {
     fprintf(stderr, "filter: needs a filter pattern and a string\n");
     return 1;
   }
-  /* exact-size heap copies so a sanitizer traps any over-read of the pattern */
-  str = strdupt(argv[1]);
+  /* exact-size heap copies so a sanitizer traps an over-read; a missing
+     subject means "" (not reachable as a CLI arg) */
+  str = strdupt(argc >= 2 ? argv[1] : "");
   pat = strdupt(argv[0]);
   matched = strjoker(str, pat, NULL, NULL) != NULL;
-  printf("%s does %s %s\n", argv[1], matched ? "match" : "NOT match", argv[0]);
+  printf("%s does %s %s\n", str, matched ? "match" : "NOT match", argv[0]);
   freet(str);
   freet(pat);
   return 0;
@@ -1091,6 +1092,33 @@ static int st_resolve(httrackp *opt, int argc, char **argv) {
     printf("adr=%s fil=%s\n", af.adr, af.fil);
   else
     printf("error=%d\n", r);
+  return 0;
+}
+
+/* Split a URL into (adr, fil), or print "error" if rejected. A second arg pads
+   the URL with that many 'a's to reach lengths a CLI arg can't. */
+static int st_identurl(httrackp *opt, int argc, char **argv) {
+  lien_adrfil af;
+  char *url;
+  size_t len, pad = 0;
+
+  (void) opt;
+  if (argc < 1) {
+    fprintf(stderr, "identurl: needs a URL\n");
+    return 1;
+  }
+  if (argc >= 2)
+    pad = (size_t) atoi(argv[1]);
+  len = strlen(argv[0]);
+  url = malloct(len + pad + 1);
+  memcpy(url, argv[0], len);
+  memset(url + len, 'a', pad);
+  url[len + pad] = '\0';
+  if (ident_url_absolute(url, &af) >= 0)
+    printf("adr=%s fil=%s\n", af.adr, af.fil);
+  else
+    printf("error\n");
+  freet(url);
   return 0;
 }
 
@@ -2132,6 +2160,7 @@ static const struct selftest_entry {
      st_relative},
     {"resolve", "<link> <adr> <fil>", "resolve a link against an origin",
      st_resolve},
+    {"identurl", "<url>", "split an absolute URL into (adr, fil)", st_identurl},
     {"header", "<raw-header-line> ...", "response header-line parsing",
      st_header},
     {"savename", "<fil> <content-type> [key=value ...]",

--- a/tests/01_engine-filter.test
+++ b/tests/01_engine-filter.test
@@ -12,6 +12,11 @@ match() {
 nomatch() {
     test "$(httrack -O /dev/null -#test=filter "$1" "$2")" == "$2 does NOT match $1" || exit 1
 }
+# single-arg call means an empty subject (unreachable as a CLI arg); '*(' used
+# to force max=1 and over-read past it.
+nomatch_empty() {
+    test "$(httrack -O /dev/null -#test=filter "$1")" == " does NOT match $1" || exit 1
+}
 
 # bare star matches everything
 match '*' 'anything/at/all'
@@ -122,3 +127,7 @@ nomatch '*[file]end' 'foo?xend'
 nomatch '*[name]X' 'abc?X'
 match '*[file]' 'foo?x=1' # trailing query: tolerated, as for *.aspx
 match '*.aspx' 'page.aspx?y=2'
+
+# empty subject against a unique-match allow-all pattern (heap over-read regress)
+nomatch_empty '*(('
+nomatch_empty '**(('

--- a/tests/01_engine-identurl.test
+++ b/tests/01_engine-identurl.test
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# ident_url_absolute splits a raw URL into (adr, fil), the first parser to touch
+# it. -#test=identurl <url> [pad] prints "adr=.. fil=.." or "error"; pad appends
+# N 'a's, reaching lengths a CLI arg can't.
+
+split() {
+    test "$(httrack -O /dev/null -#test=identurl "$1")" == "$2" || exit 1
+}
+
+split 'http://www.example.com/a/b/../c.html' 'adr=www.example.com fil=/a/c.html'
+split 'ftp://ftp.example.com/pub/file.txt' 'adr=ftp://ftp.example.com fil=/pub/file.txt'
+split 'file:///etc/hostname' 'adr=file:// fil=/etc/hostname'
+
+# empty-path file:// used to read one byte past the URL (p[1] with *p=0)
+split 'file://' 'adr=file:// fil=//'
+
+# a root-relative path is copied whole into fil[HTS_URLMAXSIZE*2], so a URL at
+# the buffer size is the tightest overflow; it must be rejected, not abort.
+split_pad() {
+    test "$(httrack -O /dev/null -#test=identurl "$1" "$2")" == "$3" || exit 1
+}
+split_pad '/' 2047 'error' # 1 + 2047 = 2048 = HTS_URLMAXSIZE*2
+split_pad 'http://h/' 3000 'error'

--- a/tests/01_engine-idna.test
+++ b/tests/01_engine-idna.test
@@ -8,8 +8,8 @@ set -euo pipefail
 
 enc() { test "$(httrack -O /dev/null -#test=idna-encode "$1")" == "$2" || exit 1; }
 dec() { test "$(httrack -O /dev/null -#test=idna-decode "$1")" == "$2" || exit 1; }
-# crash probe: malformed ACE input must exit cleanly, not abort.
-runs() { httrack -O /dev/null -#test=idna-decode "$1" >/dev/null 2>&1 || exit 1; }
+# a malformed encode input must be rejected (empty output), not encoded or leaked.
+enc_bad() { test -z "$(httrack -O /dev/null -#test=idna-encode "$1" 2>/dev/null)" || exit 1; }
 
 # encode
 enc 'www.café.com' 'www.xn--caf-dma.com'
@@ -33,6 +33,9 @@ enc 'xn--already-encoded.com' 'xn--already-encoded.com'
 # an empty punycode payload decodes back to the bare xn-- label
 dec 'xn--' 'xn--'
 
-# malformed ACE payloads (invalid base-36, garbage) must not crash
-runs 'xn--!!!'
-runs 'xn--already-encoded.com'
+# malformed ACE payloads decode to a stable (garbage) string, not a crash
+dec 'xn--!!!' '㚯'
+dec 'xn--already-encoded.com' 'ǮalǭǮreaǭǫdy.com'
+
+# second label has a truncated UTF-8 sequence: used to leak the segment buffer.
+enc_bad "$(printf 'b\xc3\xbcchev.\xe4\xbe\x8b\xe5\xad\x62\xc3\xbccheple')"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -40,6 +40,7 @@ TESTS = \
 	01_engine-hashtable.test \
 	01_engine-header.test \
 	01_engine-idna.test \
+	01_engine-identurl.test \
 	01_engine-escape-room.test \
 	01_engine-inplace-escape.test \
 	01_engine-java.test \


### PR DESCRIPTION
libFuzzer harnesses over the pure hostile-input parsers turned up four pre-existing bugs, all reachable from crawled content: `strjoker` read a byte past an empty subject on a `*(...)` pattern; `ident_url_absolute` read past a bare `file://` URL and copied an over-long path into the fixed `fil[]` (aborting through the htssafe guard); and the IDNA encoder leaked a segment buffer on malformed UTF-8. Each is a small bounds or cleanup fix to an internal parser, with no API or format change.

Tests: a new `identurl` self-test, empty-subject filter cases, and an IDNA malformed-encode check. The over-reads trap under ASan, the over-long URL aborts on any build, and the leak is caught by the fuzz PR's LeakSanitizer job.