### PR TITLE
Fix remote stack overflow and uninitialized read in Content-Type/Content-Encoding parsing

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -1562,7 +1562,7 @@ void treathead(t_cookie * cookie, const char *adr, const char *fil, htsblk * ret
       }
       // An empty/whitespace Content-Type value yields no token: keep the
       // sentinel default rather than reading an uninitialized tempo.
-      if (sscanf(rcvd + p, "%s", tempo) == 1) {
+      if (sscanf(rcvd + p, "%1099s", tempo) == 1) { // tempo[1100], server data
         if (strlen(tempo) < sizeof(retour->contenttype) - 2) // pas trop long!!
           strcpybuff(retour->contenttype, tempo);
         else
@@ -1657,11 +1657,11 @@ void treathead(t_cookie * cookie, const char *adr, const char *fil, htsblk * ret
         if (a)
           *a = '\0';
       }
-      sscanf(a, "%s", tempo);
-      if (strlen(tempo) < 64)   // pas trop long!!
+      // Bound to tempo[1100]; no token => leave empty, don't read uninit tempo.
+      if (sscanf(a, "%1099s", tempo) == 1 && strlen(tempo) < 64)
         strcpybuff(retour->contentencoding, tempo);
       else
-        retour->contentencoding[0] = '\0';      // erreur
+        retour->contentencoding[0] = '\0';
 #if HTS_USEZLIB
       /* Check known encodings */
       if (retour->contentencoding[0]) {

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1163,6 +1163,26 @@ static int st_header(httrackp *opt, int argc, char **argv) {
     treathead(NULL, "www.example.com", "/", &r, line);
   }
   printf("contenttype=%s cdispo=%s\n", r.contenttype, r.cdispo);
+  printf("contentencoding=%s\n", r.contentencoding);
+  return 0;
+}
+
+/* An over-long header value must not overflow treathead's tempo[1100]. */
+static int st_headerlong(httrackp *opt, int argc, char **argv) {
+  htsblk r;
+  char BIGSTK line[HTS_URLMAXSIZE * 2];
+  const char *const name = argc >= 1 ? argv[0] : "Content-Type:";
+  const int pad = 1500; /* > tempo[1100] */
+  size_t n;
+
+  (void) opt;
+  memset(&r, 0, sizeof(r));
+  n = (size_t) snprintf(line, sizeof(line), "%s ", name);
+  memset(line + n, 'a', pad);
+  line[n + pad] = '\0';
+  treathead(NULL, "www.example.com", "/", &r, line);
+  printf("contenttype_len=%d contentencoding_len=%d\n",
+         (int) strlen(r.contenttype), (int) strlen(r.contentencoding));
   return 0;
 }
 
@@ -2185,6 +2205,9 @@ static const struct selftest_entry {
     {"identurl", "<url>", "split an absolute URL into (adr, fil)", st_identurl},
     {"header", "<raw-header-line> ...", "response header-line parsing",
      st_header},
+    {"headerlong", "[header-name:]",
+     "over-long header value must not overflow the parse scratch",
+     st_headerlong},
     {"savename", "<fil> <content-type> [key=value ...]",
      "local save-name for a URL", st_savename},
     {"sniff", "<content-type> <hex:..|text>", "MIME magic consistency",

--- a/tests/01_engine-header.test
+++ b/tests/01_engine-header.test
@@ -27,3 +27,16 @@ hdr 'contenttype= cdispo=report.pdf' \
 # Path components in the filename are dropped on the wire (RFC 2616).
 hdr 'contenttype= cdispo=evil.pdf' \
     'Content-Disposition: attachment; filename="../../evil.pdf"'
+
+# An over-long header value must not overflow the parse scratch (ASan aborts
+# here on the pre-fix binary).
+test "$(httrack -O /dev/null -#test=headerlong 'Content-Type:')" \
+    == 'contenttype_len=32 contentencoding_len=0'
+test "$(httrack -O /dev/null -#test=headerlong 'Content-Encoding:')" \
+    == 'contenttype_len=0 contentencoding_len=0'
+
+# An empty Content-Encoding yields no token: leave it empty, don't read the
+# uninitialized scratch (MSan aborts here on the pre-fix binary).
+enc() { httrack -O /dev/null -#test=header "$1" | grep '^contentencoding='; }
+test "$(enc 'Content-Encoding:')" == 'contentencoding='
+test "$(enc 'Content-Encoding: gzip')" == 'contentencoding=gzip'


### PR DESCRIPTION
Two memory-safety bugs in the HTTP response-header parser `treathead()`, both reachable from any crawl that fetches a URL from a hostile or compromised server.

First, a remote stack buffer overflow: `Content-Type` and `Content-Encoding` values are read with a width-less `sscanf("%s")` into an 1100-byte stack scratch buffer, with the length check happening only after the copy. The `back_wait` receive path hands `treathead` a line buffer of up to 2000 bytes (`htsback.c` `rcvd[2048]`, `binput` capped at 2000), so a header value longer than 1099 non-whitespace bytes smashes the stack. Both scans are now bounded to the buffer (`%1099s`), matching the `%31s`/`%255s` idiom already used in the request-line parsers.

Second, the `Content-Encoding` branch ignored the `sscanf` return value, so an empty value (e.g. a bare `Content-Encoding:` header) left the scratch buffer uninitialized and then ran `strlen()` over it, an uninitialized read that can also over-read past the buffer. The `Content-Type` branch already guarded this case; this mirrors the guard.

Found via the P3-3 static-analysis baseline. The new `-#test=headerlong` self-test plus empty-value cases in `01_engine-header.test` build the hostile inputs inside the handler (the CLI caps argument length) and abort on the pre-fix binary under AddressSanitizer (the overflow) and MemorySanitizer (the uninitialized read); both sanitizer CI jobs cover the regression.