### PR TITLE
Bound the cache-index (.ndx) parser to its buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,9 @@ Makefile
 *.so.*
 *.a
 
-# make dist output.
+# make dist output; dist/ holds httrack-gh-release staging artifacts.
 /httrack-*.tar.gz
+/dist/
 
 # Editor / autotools backup files.
 *~

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -1938,15 +1938,17 @@ void cache_init(cache_back * cache, httrackp * opt) {
             char linepos[256];
             int pos;
 
-            while((a != NULL) && (a < (cache->use + buffl))) {
+            const char *const end = cache->use + buffl;
+
+            while ((a != NULL) && (a < end)) {
               a = strchr(a + 1, '\n');  /* start of line */
               if (a) {
                 a++;
                 /* read "host/file" */
-                a += binput(a, line, HTS_URLMAXSIZE);
-                a += binput(a, line + strlen(line), HTS_URLMAXSIZE);
+                a += cache_binput(a, end, line, HTS_URLMAXSIZE);
+                a += cache_binput(a, end, line + strlen(line), HTS_URLMAXSIZE);
                 /* read position */
-                a += binput(a, linepos, 200);
+                a += cache_binput(a, end, linepos, 200);
                 sscanf(linepos, "%d", &pos);
                 coucal_add(cache->hashtable, line, pos);
               }
@@ -2291,21 +2293,38 @@ int cache_brstr(char *adr, char *s, size_t s_size) {
   char buff[256 + 4];
 
   off = binput(adr, buff, 256);
-  adr += off;
-  sscanf(buff, "%d", &i);
-  if (i < 0 || i > 32768) /* guard a corrupt length */
+  /* binput stops at the buffer's terminating NUL; a value can only follow a
+     real line terminator, so never step past end-of-buffer. */
+  if (adr[off - 1] == '\0') {
+    s[0] = '\0';
+    return off - 1;
+  }
+  /* an empty/non-numeric field leaves i unset: treat as length 0 */
+  if (sscanf(buff, "%d", &i) != 1 || i < 0 || i > 32768)
     i = 0;
   if (i > 0) {
-    /* copy at most s_size-1 bytes; advance past the full field regardless */
-    const size_t store = (size_t) i < s_size ? (size_t) i : s_size - 1;
+    /* A corrupt/truncated cache may declare a length past the buffer end;
+       bound both the copy and the advance to the bytes actually present. */
+    const size_t avail = strnlen(adr + off, (size_t) i);
+    const size_t store = avail < s_size ? avail : s_size - 1;
 
-    strncpy(s, adr, store);
+    memcpy(s, adr + off, store);
     s[store] = '\0';
+    off += (int) avail;
   } else {
     s[0] = '\0';
   }
-  off += i;
   return off;
+}
+
+/* binput bounded to a NUL-terminated buffer: refuse to start a read at or
+   past `end`, so a prior over-advance can't walk a cache-index parse OOB. */
+int cache_binput(char *adr, const char *end, char *s, int max) {
+  if (adr >= end) {
+    s[0] = '\0';
+    return 0;
+  }
+  return binput(adr, s, max);
 }
 
 /* idem, mais en int */

--- a/src/htscache.h
+++ b/src/htscache.h
@@ -97,6 +97,8 @@ int cache_readdata(cache_back * cache, const char *str1, const char *str2,
 void cache_rstr(FILE *fp, char *s, size_t s_size);
 char *cache_rstr_addr(FILE * fp);
 int cache_brstr(char *adr, char *s, size_t s_size);
+/* binput over a NUL-terminated buffer, bounded: no read starts at/past end. */
+int cache_binput(char *adr, const char *end, char *s, int max);
 int cache_brint(char *adr, int *i);
 void cache_rint(FILE * fp, int *i);
 void cache_rLLint(FILE * fp, LLint * i);

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -1953,18 +1953,20 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                     char BIGSTK url[HTS_URLMAXSIZE * 2];
                     char linepos[256];
                     int pos;
-                    char *cacheNdx =
-                      readfile(fconcat
-                               (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                                "hts-cache/new.ndx"));
+                    LLint cacheNdxLen = 0;
+                    char *cacheNdx = readfile2(
+                        fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                StringBuff(opt->path_log), "hts-cache/new.ndx"),
+                        &cacheNdxLen);
                     cache_init(&cache, opt);    /* load cache */
                     if (cacheNdx != NULL) {
                       char firstline[256];
                       char *a = cacheNdx;
+                      const char *const end = cacheNdx + cacheNdxLen;
 
                       a += cache_brstr(a, firstline, sizeof(firstline));
                       a += cache_brstr(a, firstline, sizeof(firstline));
-                      while(a != NULL) {
+                      while (a != NULL && a < end) {
                         a = strchr(a + 1, '\n');        /* start of line */
                         if (a) {
                           htsblk r;
@@ -1972,15 +1974,15 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                           /* */
                           a++;
                           /* read "host/file" */
-                          a += binput(a, afs.af.adr, HTS_URLMAXSIZE);
-                          a += binput(a, afs.af.fil, HTS_URLMAXSIZE);
+                          a += cache_binput(a, end, afs.af.adr, HTS_URLMAXSIZE);
+                          a += cache_binput(a, end, afs.af.fil, HTS_URLMAXSIZE);
                           url[0] = '\0';
                           if (!link_has_authority(afs.af.adr))
                             strcatbuff(url, "http://");
                           strcatbuff(url, afs.af.adr);
                           strcatbuff(url, afs.af.fil);
                           /* read position */
-                          a += binput(a, linepos, 200);
+                          a += cache_binput(a, end, linepos, 200);
                           sscanf(linepos, "%d", &pos);
                           if (!hasFilter
                               || (strjoker(url, filter, NULL, NULL) != NULL)

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -46,6 +46,7 @@ Please visit our Website: http://www.httrack.com
 #include "htsdefines.h"
 #include "htslib.h"
 #include "htsparse.h"
+#include "htscache.h"
 #include "htscache_selftest.h"
 #include "htsdns_selftest.h"
 #include "htscharset.h"
@@ -1390,6 +1391,78 @@ static int st_cache(httrackp *opt, int argc, char **argv) {
   return err;
 }
 
+/* A corrupt cache index (.ndx) must not walk the length-prefixed scan past
+   the buffer. Checks the two primitives the loader is built from. */
+static int st_cacheindex(httrackp *opt, int argc, char **argv) {
+  int fail = 0;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+
+  /* A length prefix that overstates the bytes present must bound the advance
+     to the buffer, not trust the declared length. */
+  {
+    static const char src[] = "32768\nCACHE-1.1";
+    const size_t len = sizeof(src) - 1;
+    char *buf = malloct(len + 1);
+    char s[256];
+    int off;
+
+    memcpy(buf, src, len + 1);
+    off = cache_brstr(buf, s, sizeof(s));
+    if (off > (int) len) {
+      printf("cacheindex: over-advance off=%d len=%d\n", off, (int) len);
+      fail = 1;
+    }
+    if (strcmp(s, "CACHE-1.1") != 0) {
+      printf("cacheindex: value=%s\n", s);
+      fail = 1;
+    }
+    freet(buf);
+  }
+
+  /* cache_binput reads a field while in bounds, but refuses one starting at
+     or past end-of-buffer. */
+  {
+    char buf[8] = "ab\ncd";
+    const char *const end = buf + 5;
+    char s[16];
+
+    if (cache_binput(buf, end, s, sizeof(s)) != 3 || strcmp(s, "ab") != 0)
+      fail = 1; /* normal read: "ab" then the '\n', 3 bytes consumed */
+    if (cache_binput(end, end, s, sizeof(s)) != 0 || s[0] != '\0')
+      fail = 1;
+  }
+
+  /* Drive the full loader scan over a truncated index: a declared length that
+     overshoots plus a half-written entry. ASan aborts here on the pre-fix
+     scan; the cursor must never leave the buffer. */
+  {
+    static const char src[] = "9\nCACHE-1.1\n99\nwww.example.com\n/a";
+    const size_t len = sizeof(src) - 1;
+    char *buf = malloct(len + 1);
+    const char *const end = buf + len;
+    char line[256];
+    char *a = buf;
+
+    memcpy(buf, src, len + 1);
+    a += cache_brstr(a, line, sizeof(line));
+    a += cache_brstr(a, line, sizeof(line));
+    while (a != NULL && a < end) {
+      a = strchr(a + 1, '\n');
+      if (a == NULL)
+        break;
+      a++;
+      a += cache_binput(a, end, line, sizeof(line));
+    }
+    freet(buf);
+  }
+
+  printf("cacheindex: %s\n", fail ? "FAIL" : "OK");
+  return fail;
+}
+
 static int st_cache_golden(httrackp *opt, int argc, char **argv) {
   int regen, err;
 
@@ -2213,6 +2286,8 @@ static const struct selftest_entry {
     {"sniff", "<content-type> <hex:..|text>", "MIME magic consistency",
      st_sniff},
     {"cache", "<dir>", "cache read/write round-trip self-test", st_cache},
+    {"cacheindex", "", "cache-index (.ndx) parse must stay in bounds",
+     st_cacheindex},
     {"cache-golden", "<dir> [regen]", "frozen cache-format read self-test",
      st_cache_golden},
     {"cache-writefail", "<dir>", "cache write-failure handling self-test",

--- a/tests/01_engine-cacheindex.test
+++ b/tests/01_engine-cacheindex.test
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# Cache-index (.ndx) parse must stay inside the buffer on a corrupt length
+# prefix (ASan aborts here on the pre-fix binary; the OK check gates the
+# non-sanitized build too).
+
+test "$(httrack -O /dev/null -#test=cacheindex)" == 'cacheindex: OK'

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -38,6 +38,7 @@ TESTS = \
 	01_engine-filterdual.test \
 	01_engine-ftp-line.test \
 	01_engine-ftp-userpass.test \
+	01_engine-cacheindex.test \
 	01_engine-hashtable.test \
 	01_engine-header.test \
 	01_engine-idna.test \


### PR DESCRIPTION
A corrupt or truncated `hts-cache/*.ndx` walked the cache loader's length-prefixed scan past the end of the `readfile()` buffer: an out-of-bounds read reachable on `--update`/`--continue`, or from a cache truncated by a crash or a full disk.

`cache_brstr` advanced its cursor by the on-disk length prefix (clamped only to 32768) without checking those bytes were actually present, so a short file whose declared length overstates it sent the cursor past the terminating NUL; the next `binput()`/`strchr()` in the loader then read out of bounds. The fix bounds both the copy and the advance to the bytes actually there (`strnlen` up to the NUL), and adds `cache_binput()`, a `binput()` that refuses to start a read at or past end-of-buffer, for the two loader scan loops. The listing loop in htscoremain.c also picks up the `a < end` guard the main htscache.c loop already had.

`-#test=cacheindex` gates it: the deterministic bound check fails on the old advance, and the ASan CI jobs exercise the scan itself. Found with the cache-index fuzz harness in the follow-up PR.

Also adds dist/ to .gitignore: httrack-gh-release stages signed tarballs there, and the missing rule let them slip into an earlier revision of this PR.