### PR TITLE
fuzz-header: the harness feeds a header shape the engine never sees

### DIFF
--- a/fuzz/fuzz-header.c
+++ b/fuzz/fuzz-header.c
@@ -50,9 +50,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   while (p != NULL && *p != '\0') {
     char *nl = strchr(p, '\n');
     size_t n = (nl != NULL) ? (size_t) (nl - p) : strlen(p);
+    size_t i, len = 0;
 
-    memcpy(line, p, n);
-    line[n] = '\0';
+    /* binput drops every '\r' on the wire; mirror it */
+    for (i = 0; i < n; i++)
+      if (p[i] != '\r')
+        line[len++] = p[i];
+    line[len] = '\0';
     if (first) {
       treatfirstline(&r, line);
       first = 0;


### PR DESCRIPTION
The engine's header receive loop reads through `cache_binput`, which drops every `\r`; the harness fed raw corpus lines, so bytes with `\r` exercised a shape production code never sees. Strip them per line.

This PR originally also fixed a 1-byte OOB write in the old-format (pre-3.31) `.ndx` cache import. That format is scheduled for removal within days, which deletes the parser wholesale; the fix, its selftest, and the `fuzz-cachendx` seed changes were dropped from here rather than landing code the removal erases.
