### PR TITLE
Remove the pre-3.31 (.dat/.ndx) cache import

### DIFF
--- a/fuzz/fuzz-cachendx.c
+++ b/fuzz/fuzz-cachendx.c
@@ -27,7 +27,7 @@ Please visit our Website: http://www.httrack.com
 
 /* Fuzz the cache-index (.ndx) parser: a corrupt or truncated index must not
    walk the length-prefixed cache_brstr/cache_binput scan past the buffer.
-   Mirrors the loader in cache_readex_new (htscache.c). */
+   Mirrors the -#C cache-listing scan (htscoremain.c). */
 #include "fuzz.h"
 #include "htscache.h"
 #include "htslib.h"
@@ -42,9 +42,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   a += cache_brstr(a, firstline, sizeof(firstline));
   a += cache_brstr(a, firstline, sizeof(firstline));
 
-  /* body: newline-delimited host/file/position triples. The coucal insert
-     the real loader ends with is a separate library's concern; this harness
-     targets the length-prefixed scan that must stay inside the buffer. */
+  /* body: newline-delimited host/file/position triples; the length-prefixed
+     scan must stay inside the buffer */
   while (a != NULL && a < end) {
     char BIGSTK line[HTS_URLMAXSIZE * 2];
     char linepos[256];

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -46,61 +46,8 @@ Please visit our Website: http://www.httrack.com
 #include "htszlib.h"
 /* END specific definitions */
 
-// routines de mise en cache
-
-/*
-  VERSION 1.0 :
-  -----------
-
-.ndx file
- file with data
-   <string>(date/time) [ <string>(hostname+filename) (datfile_position_ascii) ] * number_of_links
- file without data
-   <string>(date/time) [ <string>(hostname+filename) (-datfile_position_ascii) ] * number_of_links
-
-.dat file
- [ file ] * 
-with
-  file= (with data)
-   [ bytes ] * sizeof(htsblk header) [ bytes ] * n(length of file given in htsblk header)
- file= (without data)
-   [ bytes ] * sizeof(htsblk header)
-with
- <string>(name) = <length in ascii>+<lf>+<data>
-
-  VERSION 1.1/1.2 :
-  ---------------
-
-.ndx file
- file with data
-   <string>("CACHE-1.1") <string>(date/time) [ <string>(hostname+filename) (datfile_position_ascii) ] * number_of_links
- file without data
-   <string>("CACHE-1.1") <string>(date/time) [ <string>(hostname+filename) (-datfile_position_ascii) ] * number_of_links
-
-.dat file
-   <string>("CACHE-1.1") [ [Header_1.1] [bytes] * n(length of file given in header) ] *
-with
- Header_1.1=
-   <int>(statuscode)
-   <int>(size)
-   <string>(msg)
-   <string>(contenttype)
-   <string>(charset) [version 3]
-   <string>(last-modified)
-   <string>(Etag)
-   <string>location
-   <string>Content-disposition [version 2]
-   <string>hostname [version 4]
-   <string>URI filename [version 4]
-   <string>local filename [version 4]
-   [<string>"SD" <string>(supplemental data)]
-   [<string>"SD" <string>(supplemental data)]
-   ...
-   <string>"HTS" (end of header)
-   <int>(number of bytes of data) (0 if no data written)
-*/
-
-// Nouveau: si != text/html ne stocke que la taille
+/* Cache backend (zip-based since 3.31; the pre-3.31 .dat/.ndx import was
+   removed, such caches are detected and refused in cache_init). */
 
 void cache_mayadd(httrackp * opt, cache_back * cache, htsblk * r,
                   const char *url_adr, const char *url_fil,
@@ -171,8 +118,6 @@ void cache_mayadd(httrackp * opt, cache_back * cache, htsblk * r,
   }
   // ---fin stockage en cache---
 }
-
-#if 1
 
 #define ZIP_FIELD_STRING(headers, headersSize, field, value) do { \
   if ( (value != NULL) && (value)[0] != '\0') { \
@@ -457,162 +402,6 @@ void cache_add(httrackp * opt, cache_back * cache, const htsblk * r,
   cache->zipWriteFailures = 0; /* entry stored: reset the failure streak */
 }
 
-#else
-
-/* Ajout d'un fichier en cache */
-void cache_add(httrackp * opt, cache_back * cache, const htsblk * r,
-               char *url_adr, char *url_fil, char *url_save, int all_in_cache) {
-  int pos;
-  char s[256];
-  char BIGSTK buff[HTS_URLMAXSIZE * 4];
-  int ok = 1;
-  int dataincache = 0;          // donnée en cache?
-  FILE *cache_ndx = cache->ndx;
-  FILE *cache_dat = cache->dat;
-
-  /*char digest[32+2]; */
-  /*digest[0]='\0'; */
-
-  // Longueur url_save==0?
-  if ((strnotempty(url_save) == 0)) {
-    if (strcmp(url_fil, "/robots.txt") == 0)    // robots.txt
-      dataincache = 1;
-    else if (strcmp(url_fil, "/test") == 0)     // testing links
-      dataincache = 0;
-    else
-      return;                   // erreur (sauf robots.txt)
-  }
-
-  /*
-     if (r->size <= 0)   // taille <= 0 
-     return;          // refusé..
-   */
-
-  // Mettre les *donées* en cache ?
-  if (is_hypertext_mime(opt, r->contenttype, url_fil))  // html, mise en cache des données et 
-    dataincache = 1;            // pas uniquement de l'en tête
-  else if (all_in_cache)
-    dataincache = 1;            // forcer tout en cache
-
-  /* calcul md5 ? */
-  /*
-     if (is_hypertext_mime(opt,r->contenttype)) {    // html, calcul MD5
-     if (r->adr) {
-     domd5mem(r->adr,r->size,digest,1);
-     }
-     } */
-
-  // Position
-  fflush(cache_dat);
-  fflush(cache_ndx);
-  pos = ftell(cache_dat);
-  // écrire pointeur seek, adresse, fichier
-  if (dataincache)              // patcher
-    sprintf(s, "%d\n", pos);    // ecrire tel que (eh oui évite les \0..)
-  else
-    sprintf(s, "%d\n", -pos);   // ecrire tel que (eh oui évite les \0..)
-
-  // data
-  // écrire données en-tête, données fichier
-  /*if (!dataincache) {   // patcher
-     r->size=-r->size;  // négatif
-     } */
-
-  // Construction header
-  ok = 0;
-  if (cache_wint(cache_dat, r->statuscode) != -1        // statuscode
-      && cache_wLLint(cache_dat, r->size) != -1 // size
-      && cache_wstr(cache_dat, r->msg) != -1    // msg
-      && cache_wstr(cache_dat, r->contenttype) != -1    // contenttype
-      && cache_wstr(cache_dat, r->charset) != -1        // contenttype
-      && cache_wstr(cache_dat, r->lastmodified) != -1   // last-modified
-      && cache_wstr(cache_dat, r->etag) != -1   // Etag
-      && cache_wstr(cache_dat, (r->location != NULL) ? r->location : "") != -1  // 'location' pour moved
-      && cache_wstr(cache_dat, r->cdispo) != -1 // Content-disposition
-      && cache_wstr(cache_dat, url_adr) != -1   // Original address
-      && cache_wstr(cache_dat, url_fil) != -1   // Original URI filename
-      && cache_wstr(cache_dat, url_save) != -1  // Original save filename
-      && cache_wstr(cache_dat, r->headers) != -1        // Full HTTP Headers
-      && cache_wstr(cache_dat, "HTS") != -1     // end of header
-    ) {
-    ok = 1;                     /* ok */
-  }
-  // Fin construction header
-
-  /*if ((int) fwrite((char*) &r,1,sizeof(htsblk),cache_dat) == sizeof(htsblk)) { */
-  if (ok) {
-    if (dataincache) {          // mise en cache?
-      if (!r->adr) {            /* taille nulle (parfois en cas de 301 */
-        if (cache_wLLint(cache_dat, 0) == -1)   /* 0 bytes */
-          ok = 0;
-      } else if (r->is_write == 0) {    // en mémoire, recopie directe
-        if (cache_wLLint(cache_dat, r->size) != -1) {
-          if (r->size > 0) {    // taille>0
-            if (fwrite(r->adr, 1, r->size, cache_dat) != r->size)
-              ok = 0;
-          } else                // taille=0, ne rien écrire
-            ok = 0;
-        } else
-          ok = 0;
-      } else {                  // recopier fichier dans cache
-        FILE *fp;
-
-        // On recopie le fichier->.
-        off_t file_size = fsize_utf8(fconv(catbuff, url_save));
-
-        if (file_size >= 0) {
-          if (cache_wLLint(cache_dat, file_size) != -1) {
-            fp = FOPEN(fconv(catbuff, url_save), "rb");
-            if (fp != NULL) {
-              char BIGSTK buff[32768];
-              ssize_t nl;
-
-              do {
-                nl = fread(buff, 1, 32768, fp);
-                if (nl > 0) {
-                  if (fwrite(buff, 1, nl, cache_dat) != nl) {   // erreur
-                    nl = -1;
-                    ok = 0;
-                  }
-                }
-              } while(nl > 0);
-              fclose(fp);
-            } else
-              ok = 0;
-          } else
-            ok = 0;
-        } else
-          ok = 0;
-      }
-    } else {
-      if (cache_wLLint(cache_dat, 0) == -1)     /* 0 bytes */
-        ok = 0;
-    }
-  } else
-    ok = 0;
-  /*if (!dataincache) {   // dépatcher
-     r->size=-r->size;
-     } */
-
-  // index
-  // adresse+cr+fichier+cr
-  if (ok) {
-    buff[0] = '\0';
-    strcatbuff(buff, url_adr);
-    strcatbuff(buff, "\n");
-    strcatbuff(buff, url_fil);
-    strcatbuff(buff, "\n");
-    cache_wstr(cache_ndx, buff);
-    fwrite(s, 1, strlen(s), cache_ndx);
-  }                             // si ok=0 on a peut être écrit des données pour rien mais on s'en tape
-
-  // en cas de plantage, on aura au moins le cache!
-  fflush(cache_dat);
-  fflush(cache_ndx);
-}
-
-#endif
-
 htsblk cache_read(httrackp * opt, cache_back * cache, const char *adr,
                   const char *fil, const char *save, char *location) {
   return cache_readex(opt, cache, adr, fil, save, location, NULL, 0);
@@ -645,11 +434,6 @@ htsblk cache_read_including_broken(httrackp *opt, cache_back *cache,
   return r;
 }
 
-static htsblk cache_readex_old(httrackp * opt, cache_back * cache,
-                               const char *adr, const char *fil,
-                               const char *save, char *location,
-                               char *return_save, int readonly);
-
 static htsblk cache_readex_new(httrackp * opt, cache_back * cache,
                                const char *adr, const char *fil,
                                const char *save, char *location,
@@ -663,9 +447,16 @@ htsblk cache_readex(httrackp * opt, cache_back * cache, const char *adr,
   if (cache->zipInput != NULL) {
     return cache_readex_new(opt, cache, adr, fil, save, location, return_save,
                             readonly);
-  } else {
-    return cache_readex_old(opt, cache, adr, fil, save, location, return_save,
-                            readonly);
+  } else { /* no cache loaded */
+    htsblk r;
+
+    hts_init_htsblk(&r);
+    strcpybuff(r.msg, "File Cache Entry Not Found");
+    if (location != NULL) {
+      r.location = location;
+      r.location[0] = '\0';
+    }
+    return r;
   }
 }
 
@@ -1067,382 +858,6 @@ static htsblk cache_readex_new(httrackp * opt, cache_back * cache,
 
 // lecture d'un fichier dans le cache
 // si save==null alors test unqiquement
-static htsblk cache_readex_old(httrackp * opt, cache_back * cache,
-                               const char *adr, const char *fil,
-                               const char *save, char *location,
-                               char *return_save, int readonly) {
-#if HTS_FAST_CACHE
-  intptr_t hash_pos;
-  int hash_pos_return;
-#else
-  char *a;
-#endif
-  char BIGSTK buff[HTS_URLMAXSIZE * 2];
-  char BIGSTK location_default[HTS_URLMAXSIZE * 2];
-  char BIGSTK previous_save[HTS_URLMAXSIZE * 2];
-  char catbuff[CATBUFF_SIZE];
-  htsblk r;
-  int ok = 0;
-  int header_only = 0;
-
-  hts_init_htsblk(&r);
-  //memset(&r, 0, sizeof(htsblk)); r.soc=INVALID_SOCKET;
-  if (location) {
-    r.location = location;
-  } else {
-    r.location = location_default;
-  }
-  r.location[0] = '\0';
-#if HTS_FAST_CACHE
-  strcpybuff(buff, adr);
-  strcatbuff(buff, fil);
-  hash_pos_return = coucal_read(cache->hashtable, buff, &hash_pos);
-#else
-  buff[0] = '\0';
-  strcatbuff(buff, "\n");
-  strcatbuff(buff, adr);
-  strcatbuff(buff, "\n");
-  strcatbuff(buff, fil);
-  strcatbuff(buff, "\n");
-  if (cache->use)
-    a = strstr(cache->use, buff);
-  else
-    a = NULL;                   // forcer erreur
-#endif
-
-  /* avoid errors on data entries */
-  if (adr[0] == '/' && adr[1] == '/' && adr[2] == '[') {
-#if HTS_FAST_CACHE
-    hash_pos_return = 0;
-#else
-    a = NULL;
-#endif
-  }
-  // en cas de succès
-#if HTS_FAST_CACHE
-  if (hash_pos_return != 0) {
-#else
-  if (a != NULL) {              // OK existe en cache!
-#endif
-    intptr_t pos;
-
-#if DEBUGCA
-    fprintf(stdout, "..cache: %s%s at ", adr, fil);
-#endif
-
-#if HTS_FAST_CACHE
-    pos = hash_pos;             /* simply */
-#else
-    a += strlen(buff);
-    sscanf(a, "%d", &pos);      // lire position
-#endif
-#if DEBUGCA
-    printf("%d\n", pos);
-#endif
-
-    fflush(cache->olddat);
-    if (fseek(cache->olddat, (long) ((pos > 0) ? pos : (-pos)), SEEK_SET) == 0) {
-      /* Importer cache1.0 */
-      if (cache->version == 0) {
-        OLD_htsblk old_r;
-
-        if (fread((char *) &old_r, 1, sizeof(old_r), cache->olddat) == sizeof(old_r)) { // lire tout (y compris statuscode etc)
-          r.statuscode = old_r.statuscode;
-          r.size = old_r.size;  // taille fichier
-          strcpybuff(r.msg, old_r.msg);
-          strcpybuff(r.contenttype, old_r.contenttype);
-          ok = 1;               /* import  ok */
-        }
-        /* */
-        /* Cache 1.1 */
-      } else {
-        char check[256];
-        LLint size_read;
-
-        check[0] = '\0';
-        //
-        cache_rint(cache->olddat, &r.statuscode);
-        cache_rLLint(cache->olddat, &r.size);
-        cache_rstr(cache->olddat, r.msg, sizeof(r.msg));
-        cache_rstr(cache->olddat, r.contenttype, sizeof(r.contenttype));
-        if (cache->version >= 3)
-          cache_rstr(cache->olddat, r.charset, sizeof(r.charset));
-        cache_rstr(cache->olddat, r.lastmodified, sizeof(r.lastmodified));
-        cache_rstr(cache->olddat, r.etag, sizeof(r.etag));
-        // r.location points into a HTS_URLMAXSIZE*2 buffer
-        cache_rstr(cache->olddat, r.location, HTS_URLMAXSIZE * 2);
-        if (cache->version >= 2)
-          cache_rstr(cache->olddat, r.cdispo, sizeof(r.cdispo));
-        if (cache->version >= 4) {
-          cache_rstr(cache->olddat, previous_save,
-                     sizeof(previous_save)); // adr
-          cache_rstr(cache->olddat, previous_save,
-                     sizeof(previous_save)); // fil
-          previous_save[0] = '\0';
-          cache_rstr(cache->olddat, previous_save,
-                     sizeof(previous_save)); // save
-          if (return_save != NULL) {
-            strlcpybuff(return_save, previous_save, HTS_URLMAXSIZE * 2);
-          }
-        }
-        if (cache->version >= 5) {
-          r.headers = cache_rstr_addr(cache->olddat);
-        }
-        //
-        cache_rstr(cache->olddat, check, sizeof(check));
-        if (strcmp(check, "HTS") == 0) { /* integrity OK */
-          ok = 1;
-        }
-        cache_rLLint(cache->olddat, &size_read);        /* lire size pour être sûr de la taille déclarée (réécrire) */
-        if (size_read > 0) {    /* si inscrite ici */
-          r.size = size_read;
-        } else {                /* pas de données directement dans le cache, fichier présent? */
-          if (r.statuscode != HTTP_OK)
-            header_only = 1;    /* que l'en tête ici! */
-        }
-      }
-
-      /* Remplir certains champs */
-      r.totalsize = r.size;
-
-      // lecture du header (y compris le statuscode)
-      /*if (fread((char*) &r,1,sizeof(htsblk),cache->olddat)==sizeof(htsblk)) { // lire tout (y compris statuscode etc) */
-      if (ok) {
-        // sécurité
-        r.adr = NULL;
-        r.out = NULL;
-        r.fp = NULL;
-
-        if ((r.statuscode >= 0) && (r.statuscode <= 999)
-            && (r.notmodified >= 0) && (r.notmodified <= 9)) {  // petite vérif intégrité
-          if ((save) && (!header_only)) { /* ne pas lire uniquement header */
-
-            r.adr = NULL;
-            r.soc = INVALID_SOCKET;
-
-#if HTS_DIRECTDISK
-            // Court-circuit:
-            // Peut-on stocker le fichier directement sur disque?
-            if (!readonly && r.statuscode == HTTP_OK && !is_hypertext_mime(opt, r.contenttype, fil) && strnotempty(save)) {     // pas HTML, écrire sur disk directement
-              int ok = 0;
-
-              r.is_write = 1;   // écrire
-              if (fexist_utf8(fconv(catbuff, sizeof(catbuff),
-                                    save))) { // un fichier existe déja
-                ok = 1;         // plus rien à faire
-                filenote(&opt->state.strc, save, NULL); // noter comme connu
-                file_notify(opt, adr, fil, save, 0, 0, 0);
-              }
-
-              if ((pos < 0) && (!ok)) { // Pas de donnée en cache et fichier introuvable : erreur!
-                if (opt->norecatch) {
-                  file_notify(opt, adr, fil, save, 1, 0, 0);
-                  filecreateempty(&opt->state.strc, save);
-                  //
-                  r.statuscode = STATUSCODE_INVALID;
-                  strcpybuff(r.msg, "File deleted by user not recaught");
-                  ok = 1;       // ne pas récupérer (et pas d'erreur)
-                } else {
-                  r.statuscode = STATUSCODE_INVALID;
-                  strcpybuff(r.msg, "Previous cache file not found");
-                  ok = 1;       // ne pas récupérer
-                }
-              }
-
-              if (!ok) {
-                r.out = filecreate(&opt->state.strc, save);
-#if HDEBUG
-                printf("direct-disk: %s\n", save);
-#endif
-                if (r.out != NULL) {
-                  char BIGSTK buff[32768 + 4];
-                  size_t size = (size_t) r.size;
-
-                  if (size > 0) {
-                    size_t nl;
-
-                    do {
-                      nl = fread(buff, 1, minimum(size, 32768), cache->olddat);
-                      if (nl > 0) {
-                        size -= nl;
-                        if (fwrite(buff, 1, nl, r.out) != nl) { // erreur
-                          r.statuscode = STATUSCODE_INVALID;
-                          strcpybuff(r.msg, "Cache Read Error : Read To Disk");
-                        }
-                      }
-                    } while((nl > 0) && (size > 0) && (r.statuscode != -1));
-                  }
-
-                  fclose(r.out);
-                  r.out = NULL;
-#ifndef _WIN32
-                  chmod(save, HTS_ACCESS_FILE);
-#endif
-                } else {
-                  r.statuscode = STATUSCODE_INVALID;
-                  strcpybuff(r.msg,
-                             "Cache Write Error : Unable to Create File");
-                }
-              }
-
-            } else
-#endif
-            {                   // lire en mémoire
-
-              if (pos < 0) {
-                if (strnotempty(save)) {        // Pas de donnée en cache, bizarre car html!!!
-                  r.statuscode = STATUSCODE_INVALID;
-                  strcpybuff(r.msg, "Previous cache file not found (2)");
-                } else {        /* Read in memory from cache */
-                  if (strnotempty(return_save) && fexist_utf8(return_save)) {
-                    FILE *fp = FOPEN(fconv(catbuff, sizeof(catbuff), return_save), "rb");
-
-                    if (fp != NULL) {
-                      r.adr = (char *) malloct((size_t) r.size + 1);
-                      if (r.adr != NULL) {
-                        if (r.size > 0
-                            && fread(r.adr, 1, (size_t) r.size, fp) != r.size) {
-                          r.statuscode = STATUSCODE_INVALID;
-                          strcpybuff(r.msg, "Read error in cache disk data");
-                        } else if (r.size >= 0)
-                          *(r.adr + r.size) = '\0';
-                      } else {
-                        r.statuscode = STATUSCODE_INVALID;
-                        strcpybuff(r.msg,
-                                   "Read error (memory exhausted) from cache");
-                      }
-                      fclose(fp);
-                    }
-                  } else {
-                    r.statuscode = STATUSCODE_INVALID;
-                    strcpybuff(r.msg, "Cache file not found on disk");
-                  }
-                }
-              } else {
-                // lire fichier (d'un coup)
-                r.adr = (char *) malloct((size_t) r.size + 1);
-                if (r.adr != NULL) {
-                  if (fread(r.adr, 1, (size_t) r.size, cache->olddat) != r.size) {      // erreur
-                    freet(r.adr);
-                    r.adr = NULL;
-                    r.statuscode = STATUSCODE_INVALID;
-                    strcpybuff(r.msg, "Cache Read Error : Read Data");
-                  } else
-                    *(r.adr + r.size) = '\0';
-                } else {        // erreur
-                  r.statuscode = STATUSCODE_INVALID;
-                  strcpybuff(r.msg, "Cache Memory Error");
-                }
-              }
-            }
-          } // si save==null, ne rien charger (juste en tête)
-        } else {
-#if DEBUGCA
-          printf("Cache Read Error : Bad Data");
-#endif
-          r.statuscode = STATUSCODE_INVALID;
-          strcpybuff(r.msg, "Cache Read Error : Bad Data");
-        }
-      } else {                  // erreur
-#if DEBUGCA
-        printf("Cache Read Error : Read Header");
-#endif
-        r.statuscode = STATUSCODE_INVALID;
-        strcpybuff(r.msg, "Cache Read Error : Read Header");
-      }
-    } else {
-#if DEBUGCA
-      printf("Cache Read Error : Seek Failed");
-#endif
-      r.statuscode = STATUSCODE_INVALID;
-      strcpybuff(r.msg, "Cache Read Error : Seek Failed");
-    }
-  } else {
-#if DEBUGCA
-    printf("File Cache Not Found");
-#endif
-    r.statuscode = STATUSCODE_INVALID;
-    strcpybuff(r.msg, "File Cache Entry Not Found");
-  }
-  if (!location) {              /* don't export internal buffer */
-    r.location = NULL;
-  }
-  return r;
-}
-
-/* write (string1-string2)-data in cache */
-/* 0 if failed */
-int cache_writedata(FILE * cache_ndx, FILE * cache_dat, const char *str1,
-                    const char *str2, char *outbuff, int len) {
-  if (cache_dat) {
-    char BIGSTK buff[HTS_URLMAXSIZE * 4];
-    char s[256];
-    int pos;
-
-    fflush(cache_dat);
-    fflush(cache_ndx);
-    pos = ftell(cache_dat);
-    /* first write data */
-    if (cache_wint(cache_dat, len) != -1) {     // length
-      if (fwrite(outbuff, 1, len, cache_dat) == len) {  // data
-        /* then write index */
-        sprintf(s, "%d\n", pos);
-        buff[0] = '\0';
-        strcatbuff(buff, str1);
-        strcatbuff(buff, "\n");
-        strcatbuff(buff, str2);
-        strcatbuff(buff, "\n");
-        cache_wstr(cache_ndx, buff);
-        if (fwrite(s, 1, strlen(s), cache_ndx) == strlen(s)) {
-          fflush(cache_dat);
-          fflush(cache_ndx);
-          return 1;
-        }
-      }
-    }
-  }
-  return 0;
-}
-
-/* read the data corresponding to (string1-string2) in cache */
-/* 0 if failed */
-int cache_readdata(cache_back * cache, const char *str1, const char *str2,
-                   char **inbuff, int *inlen) {
-#if HTS_FAST_CACHE
-  if (cache->hashtable) {
-    char BIGSTK buff[HTS_URLMAXSIZE * 4];
-    intptr_t pos;
-
-    strcpybuff(buff, str1);
-    strcatbuff(buff, str2);
-    if (coucal_read(cache->hashtable, buff, &pos)) {
-      if (fseek(cache->olddat, (long) ((pos > 0) ? pos : (-pos)), SEEK_SET) ==
-          0) {
-        INTsys len;
-
-        cache_rint(cache->olddat, &len);
-        if (len > 0) {
-          char *mem_buff = (char *) malloct(len + 1); /* trailing \0 */
-
-          if (mem_buff) {
-            if (fread(mem_buff, 1, len, cache->olddat) == len) {        // lire tout (y compris statuscode etc)*/
-              mem_buff[len] = '\0';
-              *inbuff = mem_buff;
-              *inlen = len;
-              return 1;
-            } else
-              freet(mem_buff);
-          }
-        }
-      }
-    }
-  }
-#endif
-  *inbuff = NULL;
-  *inlen = 0;
-  return 0;
-}
-
 static int hts_rename(httrackp * opt, const char *a, const char *b) {
   hts_log_print(opt, LOG_DEBUG, "Cache: rename %s -> %s (%p %p)", a, b, a, b);
   return rename(a, b);
@@ -1476,13 +891,6 @@ void hts_cache_reconcile(httrackp *opt, hts_cache_reconcile_mode mode) {
        the old generation back, whichever format it uses. */
     if (!fexist(reconcile_path(opt, "hts-cache/new.zip")))
       reconcile_promote(opt, "hts-cache/old.zip", "hts-cache/new.zip");
-    if ((!fexist(reconcile_path(opt, "hts-cache/new.dat")) ||
-         !fexist(reconcile_path(opt, "hts-cache/new.ndx"))) &&
-        fexist(reconcile_path(opt, "hts-cache/old.dat")) &&
-        fexist(reconcile_path(opt, "hts-cache/old.ndx"))) {
-      reconcile_promote(opt, "hts-cache/old.dat", "hts-cache/new.dat");
-      reconcile_promote(opt, "hts-cache/old.ndx", "hts-cache/new.ndx");
-    }
     break;
   case CACHE_RECONCILE_INTERRUPTED:
     /* Aborted run: keep the larger generation when the new cache is
@@ -1501,27 +909,10 @@ void hts_cache_reconcile(httrackp *opt, hts_cache_reconcile_mode mode) {
         fsize(reconcile_path(opt, "hts-cache/old.zip")) >
             fsize(reconcile_path(opt, "hts-cache/new.zip")))
       reconcile_promote(opt, "hts-cache/old.zip", "hts-cache/new.zip");
-    if (fexist(reconcile_path(opt, "hts-cache/new.dat")) &&
-        fexist(reconcile_path(opt, "hts-cache/old.dat")) &&
-        fexist(reconcile_path(opt, "hts-cache/old.ndx")) &&
-        fsize(reconcile_path(opt, "hts-cache/new.dat")) <
-            CACHE_RECONCILE_NEW_TINY &&
-        fsize(reconcile_path(opt, "hts-cache/old.dat")) >
-            CACHE_RECONCILE_OLD_SOLID &&
-        fsize(reconcile_path(opt, "hts-cache/old.dat")) >
-            fsize(reconcile_path(opt, "hts-cache/new.dat"))) {
-      reconcile_promote(opt, "hts-cache/old.dat", "hts-cache/new.dat");
-      reconcile_promote(opt, "hts-cache/old.ndx", "hts-cache/new.ndx");
-    }
     break;
   case CACHE_RECONCILE_ROLLBACK:
     /* Nothing transferred: restore the previous generation and sidecars. */
     reconcile_promote(opt, "hts-cache/old.zip", "hts-cache/new.zip");
-    if (fexist(reconcile_path(opt, "hts-cache/old.dat")) &&
-        fexist(reconcile_path(opt, "hts-cache/old.ndx"))) {
-      reconcile_promote(opt, "hts-cache/old.dat", "hts-cache/new.dat");
-      reconcile_promote(opt, "hts-cache/old.ndx", "hts-cache/new.ndx");
-    }
     reconcile_promote(opt, "hts-cache/old.lst", "hts-cache/new.lst");
     reconcile_promote(opt, "hts-cache/old.txt", "hts-cache/new.txt");
     break;
@@ -1562,20 +953,6 @@ void cache_init(cache_back * cache, httrackp * opt) {
               OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
               StringBuff(opt->path_log),
               "hts-cache/new.zip")))) { // a previous cache exists.. rename it
-        /* Previous cache version */
-        if ((fexist(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log), "hts-cache/new.dat"))) && (fexist(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log), "hts-cache/new.ndx")))) {     // il existe déja un cache précédent.. renommer
-          rename(fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/new.dat"), fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-                                                StringBuff(opt->path_log),
-                                                "hts-cache/old.dat"));
-          rename(fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/new.ndx"), fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-                                                StringBuff(opt->path_log),
-                                                "hts-cache/old.ndx"));
-        }
-
         /* Remove OLD cache */
         if (fexist
             (fconcat
@@ -1602,59 +979,6 @@ void cache_init(cache_back * cache, httrackp * opt) {
         } else {
           hts_log_print(opt, LOG_DEBUG, "Cache: successfully renamed");
         }
-      } else if ((fexist(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-                                 StringBuff(opt->path_log),
-                                 "hts-cache/new.dat"))) &&
-                 (fexist(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-                                 StringBuff(opt->path_log),
-                                 "hts-cache/new.ndx")))) { // a previous cache
-                                                           // exists.. rename it
-#if DEBUGCA
-        printf("work with former cache\n");
-#endif
-        if (fexist
-            (fconcat
-             (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-              "hts-cache/old.dat")))
-          remove(fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/old.dat"));
-        if (fexist
-            (fconcat
-             (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-              "hts-cache/old.ndx")))
-          remove(fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/old.ndx"));
-
-        rename(fconcat
-               (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                "hts-cache/new.dat"), fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-                                              StringBuff(opt->path_log),
-                                              "hts-cache/old.dat"));
-        rename(fconcat
-               (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                "hts-cache/new.ndx"), fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-                                              StringBuff(opt->path_log),
-                                              "hts-cache/old.ndx"));
-      } else { // one or both cache files missing: remove the remaining one
-#if DEBUGCA
-        printf("new cache\n");
-#endif
-        if (fexist
-            (fconcat
-             (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-              "hts-cache/new.dat")))
-          remove(fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/new.dat"));
-        if (fexist
-            (fconcat
-             (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-              "hts-cache/new.ndx")))
-          remove(fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/new.ndx"));
       }
     } else {
       hts_log_print(opt, LOG_DEBUG, "Cache: no cache found");
@@ -1813,153 +1137,12 @@ void cache_init(cache_back * cache, httrackp * opt) {
                       "Cache: error trying to open the cache");
       }
 
-    } else
-      if ((!cache->ro
-           &&
-           fsize(fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/old.dat")) >= 0
-           &&
-           fsize(fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/old.ndx")) > 0)
-          || (cache->ro
-              &&
-              fsize(fconcat
-                    (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                     "hts-cache/new.dat")) >= 0
-              &&
-              fsize(fconcat
-                    (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                     "hts-cache/new.ndx")) > 0)
-      ) {
-      FILE *oldndx = NULL;
-
-#if DEBUGCA
-      printf("..load cache\n");
-#endif
-      if (!cache->ro) {
-        cache->olddat =
-          fopen(fconcat
-                (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                 "hts-cache/old.dat"), "rb");
-        oldndx =
-          fopen(fconcat
-                (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                 "hts-cache/old.ndx"), "rb");
-      } else {
-        cache->olddat =
-          fopen(fconcat
-                (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                 "hts-cache/new.dat"), "rb");
-        oldndx =
-          fopen(fconcat
-                (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                 "hts-cache/new.ndx"), "rb");
-      }
-      // les deux doivent être ouvrables
-      if ((cache->olddat == NULL) && (oldndx != NULL)) {
-        fclose(oldndx);
-        oldndx = NULL;
-      }
-      if ((cache->olddat != NULL) && (oldndx == NULL)) {
-        fclose(cache->olddat);
-        cache->olddat = NULL;
-      }
-      // lire index
-      if (oldndx != NULL) {
-        int buffl;
-
-        fclose(oldndx);
-        oldndx = NULL;
-        // lire ndx, et lastmodified
-        if (!cache->ro) {
-          buffl =
-            fsize(fconcat
-                  (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                   "hts-cache/old.ndx"));
-          cache->use =
-            readfile(fconcat
-                     (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                      "hts-cache/old.ndx"));
-        } else {
-          buffl =
-            fsize(fconcat
-                  (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                   "hts-cache/new.ndx"));
-          cache->use =
-            readfile(fconcat
-                     (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                      "hts-cache/new.ndx"));
-        }
-        if (cache->use != NULL) {
-          char firstline[256];
-          char *a = cache->use;
-
-          a += cache_brstr(a, firstline, sizeof(firstline));
-          if (strncmp(firstline, "CACHE-", 6) == 0) {     // new cache format
-            if (strncmp(firstline, "CACHE-1.", 8) == 0) { // version 1.1x
-              cache->version = (int) (firstline[8] - '0');      // cache 1.x
-              if (cache->version <= 5) {
-                a += cache_brstr(a, firstline, sizeof(firstline));
-                strcpybuff(cache->lastmodified, firstline);
-              } else {
-                hts_log_print(opt, LOG_ERROR,
-                              "Cache: version 1.%d not supported, ignoring current cache",
-                              cache->version);
-                fclose(cache->olddat);
-                cache->olddat = NULL;
-                freet(cache->use);
-                cache->use = NULL;
-              }
-            } else { // non supporté
-              hts_log_print(opt, LOG_ERROR,
-                            "Cache: %s not supported, ignoring current cache",
-                            firstline);
-              fclose(cache->olddat);
-              cache->olddat = NULL;
-              freet(cache->use);
-              cache->use = NULL;
-            }
-            /* */
-          } else { // Vieille version du cache
-            /* */
-            hts_log_print(opt, LOG_WARNING,
-                          "Cache: importing old cache format");
-            cache->version = 0; // cache 1.0
-            strcpybuff(cache->lastmodified, firstline);
-          }
-          opt->is_update = 1;   // signaler comme update
-
-          /* Create hash table for the cache (MUCH FASTER!) */
-#if HTS_FAST_CACHE
-          if (cache->use) {
-            char BIGSTK line[HTS_URLMAXSIZE * 2];
-            char linepos[256];
-            int pos;
-
-            const char *const end = cache->use + buffl;
-
-            while ((a != NULL) && (a < end)) {
-              a = strchr(a + 1, '\n');  /* start of line */
-              if (a) {
-                a++;
-                /* read "host/file" */
-                a += cache_binput(a, end, line, HTS_URLMAXSIZE);
-                a += cache_binput(a, end, line + strlen(line), HTS_URLMAXSIZE);
-                /* read position */
-                a += cache_binput(a, end, linepos, 200);
-                sscanf(linepos, "%d", &pos);
-                coucal_add(cache->hashtable, line, pos);
-              }
-            }
-            /* Not needed anymore! */
-            freet(cache->use);
-            cache->use = NULL;
-          }
-#endif
-        }
-      }
+    } else if (fsize(reconcile_path(opt, "hts-cache/old.ndx")) > 0 ||
+               fsize(reconcile_path(opt, "hts-cache/new.ndx")) > 0) {
+      /* pre-3.31 (2003) .dat/.ndx cache: import support removed */
+      hts_log_print(opt, LOG_ERROR,
+                    "Cache: the pre-3.31 .dat/.ndx cache format is no longer "
+                    "supported; ignoring it (the site will be re-crawled)");
     } else {
       hts_log_print(opt, LOG_DEBUG, "Cache: no cache found in %s",
                     fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
@@ -1974,7 +1157,7 @@ void cache_init(cache_back * cache, httrackp * opt) {
       structcheck(fconcat
                   (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log), "hts-cache/"));
 
-      if (1) {
+      {
         /* Create ZIP file cache */
         cache->zipOutput =
           (void *)
@@ -2040,98 +1223,10 @@ void cache_init(cache_back * cache, httrackp * opt) {
                     LF);
           }
         }
-      } else {
-        cache->dat =
-          fopen(fconcat
-                (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                 "hts-cache/new.dat"), "wb");
-        cache->ndx =
-          fopen(fconcat
-                (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                 "hts-cache/new.ndx"), "wb");
-        // les deux doivent être ouvrables
-        if ((cache->dat == NULL) && (cache->ndx != NULL)) {
-          fclose(cache->ndx);
-          cache->ndx = NULL;
-        }
-        if ((cache->dat != NULL) && (cache->ndx == NULL)) {
-          fclose(cache->dat);
-          cache->dat = NULL;
-        }
-
-        if (cache->ndx != NULL) {
-          char s[256];
-
-          cache_wstr(cache->dat, "CACHE-1.5");
-          fflush(cache->dat);
-          cache_wstr(cache->ndx, "CACHE-1.5");
-          fflush(cache->ndx);
-          //
-          time_gmt_rfc822(s);   // date et heure actuelle GMT pour If-Modified-Since..
-          cache_wstr(cache->ndx, s);
-          fflush(cache->ndx);   // un petit fflush au cas où
-
-          // supprimer old.lst
-          if (fexist
-              (fconcat
-               (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                "hts-cache/old.lst")))
-            remove(fconcat
-                   (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                    "hts-cache/old.lst"));
-          // renommer
-          if (fexist
-              (fconcat
-               (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                "hts-cache/new.lst")))
-            rename(fconcat
-                   (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                    "hts-cache/new.lst"), fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-                                                  StringBuff(opt->path_log),
-                                                  "hts-cache/old.lst"));
-          // ouvrir
-          cache->lst =
-            fopen(fconcat
-                  (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                   "hts-cache/new.lst"), "wb");
-          strcpybuff(opt->state.strc.path, StringBuff(opt->path_html));
-          opt->state.strc.lst = cache->lst;
-
-          // supprimer old.txt
-          if (fexist
-              (fconcat
-               (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                "hts-cache/old.txt")))
-            remove(fconcat
-                   (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                    "hts-cache/old.txt"));
-          // renommer
-          if (fexist
-              (fconcat
-               (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                "hts-cache/new.txt")))
-            rename(fconcat
-                   (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                    "hts-cache/new.txt"), fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-                                                  StringBuff(opt->path_log),
-                                                  "hts-cache/old.txt"));
-          // ouvrir
-          cache->txt =
-            fopen(fconcat
-                  (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                   "hts-cache/new.txt"), "wb");
-          if (cache->txt) {
-            fprintf(cache->txt,
-                    "date\tsize'/'remotesize\tflags(request:Update,Range state:File response:Modified,Chunked,gZipped)\t");
-            fprintf(cache->txt,
-                    "statuscode\tstatus ('servermsg')\tMIME\tEtag|Date\tURL\tlocalfile\t(from URL)"
-                    LF);
-          }
-        }                       // cache->ndx!=NULL
-      }                         //cache->zipOutput != NULL
+      }
 
     } else {
-      cache->lst = cache->dat = cache->ndx = NULL;
+      cache->lst = NULL;
     }
 
   } else {

--- a/src/htscache.h
+++ b/src/htscache.h
@@ -89,11 +89,6 @@ typedef enum {
    the involved files are absent. */
 void hts_cache_reconcile(httrackp *opt, hts_cache_reconcile_mode mode);
 
-int cache_writedata(FILE * cache_ndx, FILE * cache_dat, const char *str1,
-                    const char *str2, char *outbuff, int len);
-int cache_readdata(cache_back * cache, const char *str1, const char *str2,
-                   char **inbuff, int *len);
-
 void cache_rstr(FILE *fp, char *s, size_t s_size);
 char *cache_rstr_addr(FILE * fp);
 int cache_brstr(char *adr, char *s, size_t s_size);

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -78,14 +78,6 @@ static void selftest_open_for_read(cache_back *cache, httrackp *opt) {
 }
 
 static void selftest_close(cache_back *cache) {
-  if (cache->dat != NULL) {
-    fclose(cache->dat);
-    cache->dat = NULL;
-  }
-  if (cache->ndx != NULL) {
-    fclose(cache->ndx);
-    cache->ndx = NULL;
-  }
   if (cache->zipOutput != NULL) {
     zipClose(cache->zipOutput,
              "Created by HTTrack Website Copier (cache self-test)");
@@ -989,26 +981,15 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   failures +=
       reconcile_expect(opt, "hts-cache/old.zip", SOLID, "promote-zip-noop");
 
-  /* PROMOTE: a pure-legacy old generation is promoted too (was dead when no
-     zip cache existed) */
+  /* PROMOTE: the removed pre-3.31 legacy pair is left alone */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-cache/old.dat", SOLID);
   reconcile_put(opt, "hts-cache/old.ndx", TINY);
   hts_cache_reconcile(opt, CACHE_RECONCILE_PROMOTE);
-  failures += reconcile_expect(opt, "hts-cache/new.dat", SOLID, "promote-dat");
-  failures += reconcile_expect(opt, "hts-cache/new.ndx", TINY, "promote-dat");
-  failures += reconcile_expect(opt, "hts-cache/old.dat", -1, "promote-dat");
-
-  /* PROMOTE: a half-written legacy new pair is replaced by the old pair */
-  reconcile_wipe(opt);
-  reconcile_put(opt, "hts-cache/new.dat", TINY);
-  reconcile_put(opt, "hts-cache/old.dat", SOLID);
-  reconcile_put(opt, "hts-cache/old.ndx", TINY);
-  hts_cache_reconcile(opt, CACHE_RECONCILE_PROMOTE);
-  failures +=
-      reconcile_expect(opt, "hts-cache/new.dat", SOLID, "promote-dat-partial");
-  failures +=
-      reconcile_expect(opt, "hts-cache/new.ndx", TINY, "promote-dat-partial");
+  failures += reconcile_expect(opt, "hts-cache/new.dat", -1, "promote-dat");
+  failures += reconcile_expect(opt, "hts-cache/new.ndx", -1, "promote-dat");
+  failures += reconcile_expect(opt, "hts-cache/old.dat", SOLID, "promote-dat");
+  failures += reconcile_expect(opt, "hts-cache/old.ndx", TINY, "promote-dat");
 
   /* INTERRUPTED: no lock file, no action */
   reconcile_wipe(opt);
@@ -1058,7 +1039,7 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   failures +=
       reconcile_expect(opt, "hts-cache/new.zip", MID, "interrupted-bignew");
 
-  /* INTERRUPTED: the legacy pair follows the same size rule (was dead code) */
+  /* INTERRUPTED: the removed pre-3.31 legacy pair is left alone */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
   reconcile_put(opt, "hts-cache/new.dat", TINY);
@@ -1067,9 +1048,13 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   reconcile_put(opt, "hts-cache/old.ndx", MID);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
   failures +=
-      reconcile_expect(opt, "hts-cache/new.dat", SOLID, "interrupted-dat");
+      reconcile_expect(opt, "hts-cache/new.dat", TINY, "interrupted-dat");
   failures +=
-      reconcile_expect(opt, "hts-cache/new.ndx", MID, "interrupted-dat");
+      reconcile_expect(opt, "hts-cache/new.ndx", TINY, "interrupted-dat");
+  failures +=
+      reconcile_expect(opt, "hts-cache/old.dat", SOLID, "interrupted-dat");
+  failures +=
+      reconcile_expect(opt, "hts-cache/old.ndx", MID, "interrupted-dat");
 
   /* ROLLBACK: the old zip generation is restored (a zip cache used to lose
      its only good generation here) */
@@ -1089,17 +1074,18 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   failures += reconcile_expect(opt, "hts-cache/new.lst", MID, "rollback-lst");
   failures += reconcile_expect(opt, "hts-cache/new.txt", MID, "rollback-txt");
 
-  /* ROLLBACK: full legacy generation incl. sidecars (historical behavior) */
+  /* ROLLBACK: sidecars restored, the removed pre-3.31 pair left alone */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-cache/new.dat", TINY);
-  reconcile_put(opt, "hts-cache/new.ndx", TINY);
   reconcile_put(opt, "hts-cache/old.dat", SOLID);
   reconcile_put(opt, "hts-cache/old.ndx", MID);
   reconcile_put(opt, "hts-cache/old.lst", MID);
   reconcile_put(opt, "hts-cache/old.txt", MID);
   hts_cache_reconcile(opt, CACHE_RECONCILE_ROLLBACK);
-  failures += reconcile_expect(opt, "hts-cache/new.dat", SOLID, "rollback-dat");
-  failures += reconcile_expect(opt, "hts-cache/new.ndx", MID, "rollback-dat");
+  failures += reconcile_expect(opt, "hts-cache/new.dat", TINY, "rollback-dat");
+  failures += reconcile_expect(opt, "hts-cache/new.ndx", -1, "rollback-dat");
+  failures += reconcile_expect(opt, "hts-cache/old.dat", SOLID, "rollback-dat");
+  failures += reconcile_expect(opt, "hts-cache/old.ndx", MID, "rollback-dat");
   failures += reconcile_expect(opt, "hts-cache/new.lst", MID, "rollback-dat");
   failures += reconcile_expect(opt, "hts-cache/new.txt", MID, "rollback-dat");
 
@@ -1108,6 +1094,101 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   reconcile_put(opt, "hts-cache/new.zip", TINY);
   hts_cache_reconcile(opt, CACHE_RECONCILE_ROLLBACK);
   failures += reconcile_expect(opt, "hts-cache/new.zip", TINY, "rollback-noop");
+
+  reconcile_wipe(opt);
+  return failures;
+}
+
+/* The pre-3.31 .dat/.ndx import was removed: cache_init must refuse the
+   legacy pair, leave the files in place, and not flag an update run. */
+int cache_legacy_refused_selftest(httrackp *opt, const char *dir) {
+  int failures = 0;
+  int variant;
+
+  selftest_tag = "cache-legacy";
+  golden_setup(opt, dir);
+#ifdef _WIN32
+  mkdir(reconcile_st_path(opt, "hts-cache"));
+#else
+  mkdir(reconcile_st_path(opt, "hts-cache"), HTS_PROTECT_FOLDER);
+#endif
+
+  /* variant 0: old.dat/old.ndx (--update layout); 1: new.dat/new.ndx (ro) */
+  for (variant = 0; variant < 2; variant++) {
+    cache_back cache;
+    const char *const dat =
+        variant == 0 ? "hts-cache/old.dat" : "hts-cache/new.dat";
+    const char *const ndx =
+        variant == 0 ? "hts-cache/old.ndx" : "hts-cache/new.ndx";
+
+    reconcile_wipe(opt);
+    reconcile_put(opt, dat, 4096);
+    reconcile_put(opt, ndx, 4096);
+    opt->is_update = 0;
+    selftest_open(&cache, opt, /*ro*/ variant == 1);
+    if (cache_readable(&cache)) {
+      printf("cache-legacy: variant %d imported a removed format\n", variant);
+      failures++;
+    }
+    if (coucal_nitems(cache.hashtable) != 0) { /* no phantom index entries */
+      printf("cache-legacy: variant %d imported index entries\n", variant);
+      failures++;
+    }
+    if (opt->is_update) {
+      printf("cache-legacy: variant %d flagged an update\n", variant);
+      failures++;
+    }
+    if (fsize(reconcile_st_path(opt, dat)) != 4096 ||
+        fsize(reconcile_st_path(opt, ndx)) != 4096) {
+      printf("cache-legacy: variant %d touched the legacy files\n", variant);
+      failures++;
+    }
+    if (cache.lst != NULL) {
+      fclose(cache.lst);
+      cache.lst = NULL;
+    }
+    if (cache.txt != NULL) {
+      fclose(cache.txt);
+      cache.txt = NULL;
+    }
+    selftest_close(&cache);
+  }
+
+  /* a healthy zip must win over stray legacy files, with no refusal */
+  {
+    cache_back cache;
+    const char *const body = "<html>zip wins</html>";
+
+    reconcile_wipe(opt);
+    selftest_open_for_write(&cache, opt);
+    store_entry(opt, &cache, "example.com", "/", "example.com/index.html", 200,
+                "OK", "text/html", "utf-8", "", "", "", "", body, strlen(body));
+    selftest_close(&cache);
+    reconcile_put(opt, "hts-cache/old.ndx", 4096);
+    reconcile_put(opt, "hts-cache/old.dat", 4096);
+    selftest_open_for_read(&cache, opt);
+    if (!cache_readable(&cache)) {
+      printf("cache-legacy: stray legacy files shadowed the zip cache\n");
+      failures++;
+    }
+    failures +=
+        check_entry(opt, &cache, "example.com", "/", 200, "OK", "text/html",
+                    "utf-8", "", "", "", "", body, strlen(body));
+    if (fsize(reconcile_st_path(opt, "hts-cache/old.ndx")) != 4096 ||
+        fsize(reconcile_st_path(opt, "hts-cache/old.dat")) != 4096) {
+      printf("cache-legacy: zip-wins pass touched the legacy files\n");
+      failures++;
+    }
+    if (cache.lst != NULL) {
+      fclose(cache.lst);
+      cache.lst = NULL;
+    }
+    if (cache.txt != NULL) {
+      fclose(cache.txt);
+      cache.txt = NULL;
+    }
+    selftest_close(&cache);
+  }
 
   reconcile_wipe(opt);
   return failures;

--- a/src/htscache_selftest.h
+++ b/src/htscache_selftest.h
@@ -60,6 +60,10 @@ int cache_write_failure_selftest(httrackp *opt, const char *dir);
    under <dir>. Returns the failed-check count. */
 int cache_reconcile_selftest(httrackp *opt, const char *dir);
 
+/* Verify cache_init refuses a pre-3.31 .dat/.ndx cache without touching it.
+   Returns the number of failed checks (0 = pass). */
+int cache_legacy_refused_selftest(httrackp *opt, const char *dir);
+
 /* Inject read-side corruption (zip byte surgery: bad size, header, deflate)
    under <dir> and assert every case degrades to STATUSCODE_INVALID without
    tainting a sibling entry. */

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -138,14 +138,6 @@ RUN_CALLBACK0(opt, end); \
       freet(cache.use);                                                        \
       cache.use = NULL;                                                        \
     }                                                                          \
-    if (cache.dat) {                                                           \
-      fclose(cache.dat);                                                       \
-      cache.dat = NULL;                                                        \
-    }                                                                          \
-    if (cache.ndx) {                                                           \
-      fclose(cache.ndx);                                                       \
-      cache.ndx = NULL;                                                        \
-    }                                                                          \
     if (cache.zipOutput) {                                                     \
       zipClose(cache.zipOutput,                                                \
                "Created by HTTrack Website Copier/" HTTRACK_VERSION);          \
@@ -154,10 +146,6 @@ RUN_CALLBACK0(opt, end); \
     if (cache.zipInput) {                                                      \
       unzClose(cache.zipInput);                                                \
       cache.zipInput = NULL;                                                   \
-    }                                                                          \
-    if (cache.olddat) {                                                        \
-      fclose(cache.olddat);                                                    \
-      cache.olddat = NULL;                                                     \
     }                                                                          \
     if (cache.lst) {                                                           \
       fclose(cache.lst);                                                       \
@@ -488,32 +476,11 @@ void hts_finish_makeindex(httrackp *opt, int *makeindex_done,
   *makeindex_done = 1;
 }
 
-/* Flush the parsed HTML output buffer to disk, skipping the rewrite when the
- * on-disk MD5 is unchanged. */
+/* Flush the parsed HTML output buffer to disk. */
 void hts_finish_html_file(httrackp *opt, cache_back *cache, htsblk *r,
                           FILE **fp, const char *ht_buff, size_t ht_len,
                           const char *adr, const char *fil, const char *save) {
-  char digest[32 + 2];
-  off_t fsize_old =
-      fsize(fconv(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), save));
-  int ok = 0;
-
-  digest[0] = '\0';
-  domd5mem(ht_buff, ht_len, digest, 1);
-  if (fsize_old == (off_t) ht_len) {
-    int mlen = 0;
-    char *mbuff;
-
-    cache_readdata(cache, "//[HTML-MD5]//", save, &mbuff, &mlen);
-    if (mlen)
-      mbuff[mlen] = '\0';
-    if ((mlen == 32) && (strcmp(((mbuff != NULL) ? mbuff : ""), digest) == 0)) {
-      ok = 1;
-      hts_log_print(opt, LOG_DEBUG, "File not re-written (md5): %s", save);
-    }
-    freet(mbuff);
-  }
-  if (!ok) {
+  {
     file_notify(opt, adr, fil, save, 1, 1, r->notmodified);
     *fp = filecreate(&opt->state.strc, save);
     if (*fp) {
@@ -545,13 +512,7 @@ void hts_finish_html_file(httrackp *opt, cache_back *cache, htsblk *r,
       if (fcheck)
         hts_log_print(opt, LOG_ERROR, "* * Fatal write error, giving up");
     }
-  } else {
-    file_notify(opt, adr, fil, save, 0, 0, r->notmodified);
-    filenote(&opt->state.strc, save, NULL);
   }
-  if (cache->ndx)
-    cache_writedata(cache->ndx, cache->dat, "//[HTML-MD5]//", save, digest,
-                    (int) strlen(digest));
 }
 
 /* does it look like XML ? (SVG et al.) */

--- a/src/htscore.h
+++ b/src/htscore.h
@@ -193,7 +193,7 @@ struct cache_back {
   /* */
   int type;
   int ro;                   /**< read-only: no new cache is written */
-  FILE *dat, *ndx, *olddat; /**< new data, new index, old data files */
+
   char *use;                /**< in-memory list of cached adr+fil keys */
   FILE *lst;                /**< file list, used for purge */
   FILE *txt;                /**< human-readable file list (info) */
@@ -288,12 +288,12 @@ struct filecreate_params {
 
 /* True if a new cache is being written (plain or zip backend). */
 HTS_STATIC int cache_writable(cache_back * cache) {
-  return (cache != NULL && (cache->dat != NULL || cache->zipOutput != NULL));
+  return (cache != NULL && cache->zipOutput != NULL);
 }
 
 /* True if an old cache is available to read (plain or zip backend). */
 HTS_STATIC int cache_readable(cache_back * cache) {
-  return (cache != NULL && (cache->olddat != NULL || cache->zipInput != NULL));
+  return (cache != NULL && cache->zipInput != NULL);
 }
 
 #endif

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1500,6 +1500,18 @@ static int st_cache_corrupt(httrackp *opt, int argc, char **argv) {
   return err;
 }
 
+static int st_cache_legacy(httrackp *opt, int argc, char **argv) {
+  int err;
+
+  if (argc < 1) {
+    fprintf(stderr, "cache-legacy: needs a directory\n");
+    return 1;
+  }
+  err = cache_legacy_refused_selftest(opt, argv[0]);
+  printf("cache-legacy: %s\n", err ? "FAIL" : "OK");
+  return err;
+}
+
 static int st_reconcile(httrackp *opt, int argc, char **argv) {
   int err;
 
@@ -2294,6 +2306,8 @@ static const struct selftest_entry {
      st_cache_writefail},
     {"reconcile", "<dir>", "cache generation reconcile policy self-test",
      st_reconcile},
+    {"cache-legacy", "<dir>", "pre-3.31 legacy cache refusal self-test",
+     st_cache_legacy},
     {"cache-corrupt", "<dir>", "cache read-side corruption self-test",
      st_cache_corrupt},
     {"dns", "", "DNS resolver/cache self-test", st_dns},

--- a/tests/01_zlib-cache-legacy.test
+++ b/tests/01_zlib-cache-legacy.test
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# The pre-3.31 .dat/.ndx cache import was removed: cache_init must refuse the
+# legacy pair and leave the files untouched (httrack -#test=cache-legacy <dir>).
+
+set -eu
+
+dir=$(mktemp -d)
+trap 'rm -rf "$dir"' EXIT
+
+# the refusal errors land on stdout (no log file); pin them and the verdict
+out=$(httrack -#test=cache-legacy "$dir" 2>/dev/null)
+cnt=$(printf '%s\n' "$out" | grep -c 'no longer supported' || true)
+test "$cnt" = 2 || {
+    echo "expected 2 refusal messages, got $cnt" >&2
+    exit 1
+}
+out=$(printf '%s\n' "$out" | tail -n1)
+
+test "$out" = "cache-legacy: OK" || {
+    echo "expected 'cache-legacy: OK', got: $out" >&2
+    exit 1
+}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -68,6 +68,7 @@ TESTS = \
 	01_zlib-acceptencoding.test \
 	01_zlib-cache.test \
 	01_zlib-cache-corrupt.test \
+	01_zlib-cache-legacy.test \
 	01_zlib-cache-golden.test \
 	01_zlib-cache-writefail.test \
 	01_zlib-savename-cached.test \


### PR DESCRIPTION
The zip cache replaced the `.dat`/`.ndx` format in 3.31 (2003). What remained was an import-only parser for hostile input, compiled unconditionally (the origin of #507's bounds fix and #510's original OOB), plus dead code keyed to it: the CACHE-1.5 writer behind `if (1)`, the cross-session HTML-MD5 dedup whose store was never written in the zip era, and the legacy legs of the startup rotation and `hts_cache_reconcile`, which silently renamed or even deleted a user's `.dat`/`.ndx` pair. Net -1010 lines.

On a pre-3.31 cache, `cache_init` now logs a clear refusal, leaves the files in place, and the site is re-crawled rather than aborting. The new `-#test=cache-legacy` self-test pins the refusal for both layouts (`--update` old.* and read-only new.*) and that the files stay untouched; the reconcile self-test now pins that legacy pairs are left alone. Verified end-to-end against the local test server. `cache_brstr`/`cache_binput` and their cacheindex self-test/fuzzer stay: they still back the `-#C` cache listing, which turns out to have been broken for zip caches since 3.31 (it only ever enumerated via `new.ndx`; follow-up to file).
