### PR TITLE
-M overall-size cap never bounds the overshoot under a slow server

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -2384,8 +2384,8 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
   back_clean(opt, cache, sback);
 #endif
 
-  /* Time limit exceeded past grace: abort in-flight transfers so no wait loop
-     starves (#481). FTP slots stay, their thread owns the socket. */
+  /* Time/size limit exceeded past grace: abort in-flight transfers so no wait
+     loop starves (#481, #77). FTP slots stay, their thread owns the socket. */
   if (!back_checkmirror(opt)) {
     int aborted = 0;
     unsigned int i;
@@ -2408,7 +2408,7 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
     }
     if (aborted > 0)
       hts_log_print(opt, LOG_WARNING,
-                    "time limit reached, %d transfer(s) aborted", aborted);
+                    "mirror limit reached, %d transfer(s) aborted", aborted);
     return;
   }
 
@@ -4113,6 +4113,9 @@ static int back_maxtime_grace(const int maxtime) {
   return maximum(5, minimum(30, maxtime / 10));
 }
 
+/* Bytes the smooth stop may overrun before in-flight transfers are aborted. */
+static LLint back_maxsize_grace(const LLint maxsite) { return maxsite / 10; }
+
 int back_checkmirror(httrackp * opt) {
   // Check max size
   if ((opt->maxsite > 0) && (HTS_STAT.stat_bytes >= opt->maxsite)) {
@@ -4124,9 +4127,9 @@ int back_checkmirror(httrackp * opt) {
       /* cancel mirror smoothly */
       hts_request_stop(opt, 0);
     }
-    return 1;                   /* don'k break mirror too sharply for size limits, but stop requested */
-    /*return 0;
-     */
+    /* smooth stop overran the grace margin: stop waiting (#77) */
+    if (HTS_STAT.stat_bytes - opt->maxsite >= back_maxsize_grace(opt->maxsite))
+      return 0;
   }
   // Check max time
   if (opt->maxtime > 0) {

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -68,6 +68,15 @@ static int slot_can_be_cached_on_disk(const lien_back * back);
 static int slot_can_be_cleaned(const lien_back * back);
 static int slot_can_be_finalized(httrackp * opt, const lien_back * back);
 
+/* Which hard quota, if any, is currently aborting the mirror. */
+typedef enum {
+  HTS_MIRROR_LIMIT_NONE = 0,
+  HTS_MIRROR_LIMIT_SIZE,
+  HTS_MIRROR_LIMIT_TIME,
+} hts_mirror_limit;
+
+static hts_mirror_limit back_mirror_limit(httrackp *opt);
+
 struct_back *back_new(httrackp *opt, int back_max) {
   int i;
   struct_back *sback = calloct(1, sizeof(struct_back));
@@ -2387,6 +2396,12 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
   /* Time/size limit exceeded past grace: abort in-flight transfers so no wait
      loop starves (#481, #77). FTP slots stay, their thread owns the socket. */
   if (!back_checkmirror(opt)) {
+    const hts_mirror_limit limit = back_mirror_limit(opt);
+    const char *const reason =
+        (limit == HTS_MIRROR_LIMIT_SIZE) ? "size limit" : "time limit";
+    const char *const slotmsg = (limit == HTS_MIRROR_LIMIT_SIZE)
+                                    ? "Mirror Size Limit"
+                                    : "Mirror Time Out";
     int aborted = 0;
     unsigned int i;
 
@@ -2400,15 +2415,15 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
         if (back[i].r.is_write && IS_DELAYED_EXT(back[i].url_sav))
           back_delayed_discard(opt, &back[i]);
         back[i].r.statuscode = STATUSCODE_TIMEOUT;
-        strcpybuff(back[i].r.msg, "Mirror Time Out");
+        strcpybuff(back[i].r.msg, slotmsg);
         back[i].status = STATUS_READY;
         back_set_finished(sback, i);
         aborted++;
       }
     }
     if (aborted > 0)
-      hts_log_print(opt, LOG_WARNING,
-                    "mirror limit reached, %d transfer(s) aborted", aborted);
+      hts_log_print(opt, LOG_WARNING, "%s reached, %d transfer(s) aborted",
+                    reason, aborted);
     return;
   }
 
@@ -4113,41 +4128,43 @@ static int back_maxtime_grace(const int maxtime) {
   return maximum(5, minimum(30, maxtime / 10));
 }
 
-/* Bytes the smooth stop may overrun before in-flight transfers are aborted. */
+/* Bytes the smooth stop may overrun before in-flight transfers are aborted.
+   No floor (unlike the time grace): a size overrun should abort promptly. */
 static LLint back_maxsize_grace(const LLint maxsite) { return maxsite / 10; }
 
-int back_checkmirror(httrackp * opt) {
-  // Check max size
-  if ((opt->maxsite > 0) && (HTS_STAT.stat_bytes >= opt->maxsite)) {
-    if (!opt->state.stop) {     /* not yet stopped */
-      hts_log_print(opt, LOG_ERROR,
-                    "More than " LLintP
-                    " bytes have been transferred.. giving up",
-                    (LLint) opt->maxsite);
-      /* cancel mirror smoothly */
-      hts_request_stop(opt, 0);
-    }
-    /* smooth stop overran the grace margin: stop waiting (#77) */
-    if (HTS_STAT.stat_bytes - opt->maxsite >= back_maxsize_grace(opt->maxsite))
-      return 0;
-  }
-  // Check max time
+/* Which cap has overrun its grace and must hard-stop the mirror (#77, #481). */
+static hts_mirror_limit back_mirror_limit(httrackp *opt) {
+  if (opt->maxsite > 0 && HTS_STAT.stat_bytes >= opt->maxsite &&
+      HTS_STAT.stat_bytes - opt->maxsite >= back_maxsize_grace(opt->maxsite))
+    return HTS_MIRROR_LIMIT_SIZE;
   if (opt->maxtime > 0) {
     const TStamp elapsed = time_local() - HTS_STAT.stat_timestart;
 
-    if (elapsed >= opt->maxtime) {
-      if (!opt->state.stop) { /* not yet stopped */
-        hts_log_print(opt, LOG_ERROR, "More than %d seconds passed.. giving up",
-                      opt->maxtime);
-        /* cancel mirror smoothly */
-        hts_request_stop(opt, 0);
-      }
-      /* smooth stop starved past the grace period: stop waiting (#481) */
-      if (elapsed - opt->maxtime >= back_maxtime_grace(opt->maxtime))
-        return 0;
-    }
+    if (elapsed >= opt->maxtime &&
+        elapsed - opt->maxtime >= back_maxtime_grace(opt->maxtime))
+      return HTS_MIRROR_LIMIT_TIME;
   }
-  return 1;                     /* Ok, go on */
+  return HTS_MIRROR_LIMIT_NONE;
+}
+
+int back_checkmirror(httrackp *opt) {
+  /* request a smooth stop the first time each cap is reached */
+  if (opt->maxsite > 0 && HTS_STAT.stat_bytes >= opt->maxsite &&
+      !opt->state.stop) {
+    hts_log_print(opt, LOG_ERROR,
+                  "More than " LLintP
+                  " bytes have been transferred.. giving up",
+                  (LLint) opt->maxsite);
+    hts_request_stop(opt, 0);
+  }
+  if (opt->maxtime > 0 && !opt->state.stop &&
+      (time_local() - HTS_STAT.stat_timestart) >= opt->maxtime) {
+    hts_log_print(opt, LOG_ERROR, "More than %d seconds passed.. giving up",
+                  opt->maxtime);
+    hts_request_stop(opt, 0);
+  }
+  /* hard stop once a cap overruns its grace (callers must stop waiting) */
+  return back_mirror_limit(opt) == HTS_MIRROR_LIMIT_NONE;
 }
 
 // octets transférés + add

--- a/src/htsback.h
+++ b/src/htsback.h
@@ -141,8 +141,8 @@ LLint back_transferred(LLint add, struct_back * sback);
 int host_wait(httrackp * opt, lien_back * sback);
 #endif
 int back_checksize(httrackp * opt, lien_back * eback, int check_only_totalsize);
-/* Enforce -M/-E quotas: requests a smooth stop when reached; returns 0 once
-   the -E deadline overran its grace period (callers must stop waiting). */
+/* Enforce -M/-E quotas: smooth-stops when reached; returns 0 once the -M cap
+   or -E deadline overruns its grace period (callers must stop waiting). */
 int back_checkmirror(httrackp * opt);
 
 #endif

--- a/tests/42_local-maxsize-slow.test
+++ b/tests/42_local-maxsize-slow.test
@@ -11,10 +11,10 @@ set -euo pipefail
 start=$(date +%s)
 bash "$top_srcdir/tests/local-crawl.sh" \
     --log-found 'More than 400000 bytes have been transferred.. giving up' \
-    --found bigtrickle/p0.bin \
     httrack 'BASEURL/bigtrickle/index.html' -M400000 -c4
 wall=$(($(date +%s) - start))
-# trickle runs 60s; a smooth-only stop waits it out, the hard stop lands near 8s
+# trickle runs 60s; a smooth-only stop waits it out, the hard stop lands near 8s.
+# Wall clock is the discriminating check: the log line above fires either way.
 if [ "$wall" -ge 30 ]; then
     echo "crawl took ${wall}s, -M hard stop did not engage" >&2
     exit 1

--- a/tests/42_local-maxsize-slow.test
+++ b/tests/42_local-maxsize-slow.test
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# -M byte cap under a slow server (#77): p0 overruns -M at once while p1..p3
+# trickle for a minute; the cap must abort the in-flight transfers, not wait
+# them out. Unfixed, the smooth stop drains the trickle at server pace.
+
+set -euo pipefail
+
+: "${top_srcdir:=..}"
+
+start=$(date +%s)
+bash "$top_srcdir/tests/local-crawl.sh" \
+    --log-found 'More than 400000 bytes have been transferred.. giving up' \
+    --found bigtrickle/p0.bin \
+    httrack 'BASEURL/bigtrickle/index.html' -M400000 -c4
+wall=$(($(date +%s) - start))
+# trickle runs 60s; a smooth-only stop waits it out, the hard stop lands near 8s
+if [ "$wall" -ge 30 ]; then
+    echo "crawl took ${wall}s, -M hard stop did not engage" >&2
+    exit 1
+fi

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -110,6 +110,7 @@ TESTS = \
 	38_local-update-304.test \
 	39_local-delayed-cancel.test \
 	40_local-why.test \
-	41_local-utf8-link.test
+	41_local-utf8-link.test \
+	42_local-maxsize-slow.test
 
 CLEANFILES = check-network_sh.cache

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1035,6 +1035,14 @@ class Handler(SimpleHTTPRequestHandler):
     def route_bigfile(self):
         self.send_raw(b"x" * self.BIGFILE_BYTES, "application/octet-stream")
 
+    # -M under a slow server (#77): p0 is a fast 640KB file that alone overruns
+    # -M; p1..p3 trickle for a minute. The cap must abort those in-flight
+    # transfers, not wait them out.
+    def route_bigtrickle_index(self):
+        self.send_html(
+            "".join('\t<a href="p%d.bin">p%d</a>\n' % (i, i) for i in range(4))
+        )
+
     ROUTES = {
         "/cookies/entrance.php": route_entrance,
         "/cookies/second.php": route_second,
@@ -1107,6 +1115,11 @@ class Handler(SimpleHTTPRequestHandler):
         "/bigfiles/p5.bin": route_bigfile,
         "/bigfiles/p6.bin": route_bigfile,
         "/bigfiles/p7.bin": route_bigfile,
+        "/bigtrickle/index.html": route_bigtrickle_index,
+        "/bigtrickle/p0.bin": route_bigfile,
+        "/bigtrickle/p1.bin": route_trickle_page,
+        "/bigtrickle/p2.bin": route_trickle_page,
+        "/bigtrickle/p3.bin": route_trickle_page,
         "/delayed/noloc.php": route_delayed_noloc,
         "/delayed/selfloop.php": route_delayed_selfloop,
         "/delayed/redir.php": route_delayed_redir,


### PR DESCRIPTION
`-M` (maximum overall size) only ever asked for a smooth stop once the cap was reached: `back_checkmirror()` always returned 1, so a slow or throttling server drained its in-flight transfers at its own pace and the wait loops starved on them. The original report is exactly that, a bot-throttled archive that ran for over an hour and finished well past the 3 MB cap. #482 fixed the same failure for the `-E` time limit but left the size branch alone.

This gives `-M` the grace-then-abort exit that `-E` got. Once saved bytes overrun the cap by `maxsite/10`, `back_checkmirror()` returns 0 and the existing #482 abort path tears down the in-flight HTTP transfers (FTP slots stay with their owning thread; real-named partials survive for `--continue`). `42_local-maxsize-slow.test` crawls a server whose files trickle for a minute under `-M400000`: the fixed engine stops in about 8 seconds, the unfixed binary waits out the full 60.

The `-M` meter is left as is. It counts saved bytes (`stat_bytes`), which undercounts the real downloaded volume on redirect- or plugin-heavy crawls, the other half of the original report. Changing what a documented option measures deserves its own review, tracked as #520.

Closes #77