### PR TITLE
LLint silently truncates to 32-bit on the x32 ABI

### DIFF
--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -355,8 +355,11 @@ typedef __int64 LLint;
 typedef __int64 TStamp;
 
 #define LLintP "%I64d"
+/* x32/ILP32 sets __x86_64__ but long is 32-bit; exclude it so LLint stays
+ * 64-bit. */
 #elif (defined(_LP64) || defined(__x86_64__) || defined(__powerpc64__) ||      \
-       defined(__64BIT__))
+       defined(__64BIT__)) &&                                                  \
+    !defined(__ILP32__)
 
 typedef long int LLint;
 
@@ -372,6 +375,10 @@ typedef long long int TStamp;
 #endif
 
 #endif /* HTS_LONGLONG */
+
+/* Claiming long-long support must yield a real 64-bit LLint (x32 regressed:
+   __x86_64__ set but long is 32-bit). Compile-time trip, portable to C90. */
+typedef char hts_assert_llint_is_64bit[sizeof(LLint) == 8 ? 1 : -1];
 
 #else
 typedef int LLint;


### PR DESCRIPTION
On the x32 ABI (x86-64 hardware, ILP32 data model) `__x86_64__` is defined but `long` is 32-bit. The wide-integer typedef in `htsglobal.h` picked `long` for `LLint` whenever `__x86_64__` was set, so on x32 `LLint`, the project's signed 64-bit type for byte counts and file sizes, quietly became 32-bit. Any value past `INT_MAX` overflowed: a >2GB entry wrapped negative and `cache_add` dropped it entirely.

Debian's x32 buildd surfaced it once the cache selftests started exercising the >2GB path. `01_zlib-cache-writefail` (oversize degrade) and `01_zlib-cache-corrupt` both failed on x32 while passing everywhere else. This is a deterministic architecture bug, not a flaky test.

The fix excludes `__ILP32__` from that branch, so x32 falls through to `long long`. Normal x86-64/ppc64 define `_LP64`/`__LP64__` and not `__ILP32__`, so their selection is unchanged. A compile-time guard now trips wherever long-long support is claimed but `LLint` ends up under 64-bit, so the same silent truncation can't come back.

Checked with the x32 multilib compiler: `LLint` is 32-bit before the fix and 64-bit after, with the native selection unchanged; native build and `make check` stay green.