### PR TITLE
Assert kept content in the #176 update-error test, not just its size

### DIFF
--- a/tests/44_local-update-errormask.test
+++ b/tests/44_local-update-errormask.test
@@ -8,4 +8,6 @@ set -euo pipefail
 bash "$top_srcdir/tests/local-crawl.sh" --rerun \
     --found 'errmask/keep.dat' \
     --file-min-bytes 'errmask/keep.dat' 1024 \
+    --file-matches 'errmask/keep.dat' '^KEEP' \
+    --file-not-matches 'errmask/keep.dat' 'error 403' \
     httrack 'BASEURL/errmask/index.html'


### PR DESCRIPTION
Follow-up to #176. Test 44 only checked that keep.dat survived at 1024+ bytes, but the good body carries a `KEEP` marker no assertion looked at, so a same-size wrong-content overwrite would have passed. This adds two content checks (the file matches `^KEEP` and lacks the `error 403` body), so the test tells the real fix apart from an equal-size clobber the size check alone misses. Test-only; verified 3/3 against the merged fix.