### PR TITLE
Type LLint/TStamp as int64_t and drop the per-platform boilerplate

### DIFF
--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -56,6 +56,10 @@ Please visit our Website: http://www.httrack.com
 // Platform detection (sizes, feature macros)
 #include "htsconfig.h"
 
+// Fixed-width integer types + PRI* format macros for the LLint/TStamp typedefs
+#include <stdint.h>
+#include <inttypes.h>
+
 // WIN32 types
 #ifdef _WIN32
 #ifndef SIZEOF_LONG
@@ -109,29 +113,6 @@ Please visit our Website: http://www.httrack.com
 
 #ifndef SETUID
 #define HTS_DO_NOT_USE_UID
-#endif
-
-#ifndef HTS_LONGLONG
-#ifdef SIZEOF_LONG_LONG
-#if SIZEOF_LONG_LONG == 8
-#define HTS_LONGLONG 1
-#endif
-#endif
-
-#ifndef HTS_LONGLONG
-#ifdef __sun
-#define HTS_LONGLONG 0
-#endif
-#ifdef __osf__
-#define HTS_LONGLONG 0
-#endif
-#ifdef __linux
-#define HTS_LONGLONG 1
-#endif
-#ifdef _WIN32
-#define HTS_LONGLONG 1
-#endif
-#endif
 #endif
 
 #ifdef DLLIB
@@ -326,66 +307,14 @@ typedef int hts_tristate;
 #define HTS_DEPRECATED(msg)
 #endif
 
-#ifndef HTS_LONGLONG
-#ifdef HTS_NO_64_BIT
-#define HTS_LONGLONG 0
-#else
-#define HTS_LONGLONG 1
-#endif
-#endif
-
-/* Wide integer types, chosen per platform.
-   LLint:  signed 64-bit counter for byte counts and large sizes (falls back to
-           plain int where 64-bit is unavailable).
-   TStamp: timestamp/duration in the same width (a double in the no-64-bit
-           fallback).
-   LLintP: the printf conversion for an LLint. */
-#if HTS_LONGLONG
-#ifdef LLINT_FORMAT
-typedef LLINT_TYPE LLint;
-
-typedef LLINT_TYPE TStamp;
-
-#define LLintP LLINT_FORMAT
-#else
-
-#ifdef _WIN32
-typedef __int64 LLint;
-
-typedef __int64 TStamp;
-
-#define LLintP "%I64d"
-/* x32/ILP32 sets __x86_64__ but long is 32-bit; exclude it so LLint stays
- * 64-bit. */
-#elif (defined(_LP64) || defined(__x86_64__) || defined(__powerpc64__) ||      \
-       defined(__64BIT__)) &&                                                  \
-    !defined(__ILP32__)
-
-typedef long int LLint;
-
-typedef long int TStamp;
-
-#define LLintP "%ld"
-#else
-typedef long long int LLint;
-
-typedef long long int TStamp;
-
-#define LLintP "%lld"
-#endif
-
-#endif /* HTS_LONGLONG */
-
-/* Claiming long-long support must yield a real 64-bit LLint (x32 regressed:
-   __x86_64__ set but long is 32-bit). Compile-time trip, portable to C90. */
-typedef char hts_assert_llint_is_64bit[sizeof(LLint) == 8 ? 1 : -1];
-
-#else
-typedef int LLint;
-
-#define LLintP "%d"
-typedef double TStamp;
-#endif
+/* LLint: signed 64-bit byte/size counter (-1 is a sentinel engine-wide);
+   TStamp: timestamp/duration in the same width; LLintP: its printf conversion.
+   int64_t/PRId64 give an exact width and the right format on every C99 target,
+   so no per-platform ladder is needed. */
+typedef int64_t LLint;
+typedef int64_t TStamp;
+/* PRId64 has no '%'; callers use LLintP as a full conversion ("X: " LLintP). */
+#define LLintP "%" PRId64
 
 /* Integer type for file offsets/sizes passed to the C library. Widens to
    LLint (with HTS_FSEEKO for fseeko/ftello) under large-file support, plain

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -307,13 +307,10 @@ typedef int hts_tristate;
 #define HTS_DEPRECATED(msg)
 #endif
 
-/* LLint: signed 64-bit byte/size counter (-1 is a sentinel engine-wide);
-   TStamp: timestamp/duration in the same width; LLintP: its printf conversion.
-   int64_t/PRId64 give an exact width and the right format on every C99 target,
-   so no per-platform ladder is needed. */
+/* LLint/TStamp: signed exact-width 64-bit; -1 is a sentinel engine-wide. */
 typedef int64_t LLint;
 typedef int64_t TStamp;
-/* PRId64 has no '%'; callers use LLintP as a full conversion ("X: " LLintP). */
+/* Full printf conversion, '%' included (PRId64 has none): "X: " LLintP. */
 #define LLintP "%" PRId64
 
 /* Integer type for file offsets/sizes passed to the C library. Widens to

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -3038,12 +3038,11 @@ HTSEXT_API char *int2char(strc_int2bytes2 * strc, int n) {
 /* See http://physics.nist.gov/cuu/Units/binary.html */
 #define ToLLint(a) ((LLint)(a))
 #define ToLLintKiB (ToLLint(1024))
-#define ToLLintMiB (ToLLintKiB*ToLLintKiB)
-#ifdef HTS_LONGLONG
-#define ToLLintGiB (ToLLintKiB*ToLLintKiB*ToLLintKiB)
-#define ToLLintTiB (ToLLintKiB*ToLLintKiB*ToLLintKiB*ToLLintKiB)
-#define ToLLintPiB (ToLLintKiB*ToLLintKiB*ToLLintKiB*ToLLintKiB*ToLLintKiB)
-#endif
+#define ToLLintMiB (ToLLintKiB * ToLLintKiB)
+#define ToLLintGiB (ToLLintKiB * ToLLintKiB * ToLLintKiB)
+#define ToLLintTiB (ToLLintKiB * ToLLintKiB * ToLLintKiB * ToLLintKiB)
+#define ToLLintPiB                                                             \
+  (ToLLintKiB * ToLLintKiB * ToLLintKiB * ToLLintKiB * ToLLintKiB)
 HTSEXT_API char **int2bytes2(strc_int2bytes2 * strc, LLint n) {
   if (n < ToLLintKiB) {
     sprintf(strc->buff1, "%d", (int) (LLint) n);
@@ -3052,9 +3051,7 @@ HTSEXT_API char **int2bytes2(strc_int2bytes2 * strc, LLint n) {
     sprintf(strc->buff1, "%d,%02d", (int) ((LLint) (n / ToLLintKiB)),
             (int) ((LLint) ((n % ToLLintKiB) * 100) / ToLLintKiB));
     strcpybuff(strc->buff2, "KiB");
-  }
-#ifdef HTS_LONGLONG
-  else if (n < ToLLintGiB) {
+  } else if (n < ToLLintGiB) {
     sprintf(strc->buff1, "%d,%02d", (int) ((LLint) (n / (ToLLintMiB))),
             (int) ((LLint) (((n % (ToLLintMiB)) * 100) / (ToLLintMiB))));
     strcpybuff(strc->buff2, "MiB");
@@ -3071,13 +3068,6 @@ HTSEXT_API char **int2bytes2(strc_int2bytes2 * strc, LLint n) {
             (int) ((LLint) (((n % (ToLLintPiB)) * 100) / (ToLLintPiB))));
     strcpybuff(strc->buff2, "PiB");
   }
-#else
-  else {
-    sprintf(strc->buff1, "%d,%02d", (int) ((LLint) (n / (ToLLintMiB))),
-            (int) ((LLint) (((n % (ToLLintMiB)) * 100) / (ToLLintMiB))));
-    strcpybuff(strc->buff2, "MiB");
-  }
-#endif
   strc->buffadr[0] = strc->buff1;
   strc->buffadr[1] = strc->buff2;
   return strc->buffadr;


### PR DESCRIPTION
Follow-up to #524. `LLint` and `TStamp` were typedef'd per platform (`long` / `long long` / `__int64`) behind a matching printf-format ladder and the `HTS_LONGLONG` capability macro. That is the machinery that let x32 pick a 32-bit `long` for a nominally 64-bit `LLint`. `int64_t` removes the guessing: exactly 64-bit signed with defined wraparound, and `"%" PRId64` is its conversion, so the per-platform ladder and `HTS_LONGLONG` both go away. The `LLint`/`TStamp`/`LLintP` names stay, so the ~70 call sites are untouched.

The type stays signed on purpose: `-1` is a size/range sentinel across the engine (`totalsize=-1` means unknown, `size<0` means error), so `uint64_t` would silently break every `< 0` check. A 64-bit integer is already a hard C99 dependency here (`md5.h` includes `<stdint.h>`, the installed `httrack-library.h` includes `<inttypes.h>`), so nothing regresses and pre-C99 builds were already impossible. No ABI change: on LP64 `int64_t` is `long`, so `httrackp`/`htsblk` stay byte-identical and the exported symbol set is unchanged (checked with `nm -D`). Native build and `make check` stay green.