### PR TITLE
Stop test 36 flaking on macOS when loopback drops connections

### DIFF
--- a/tests/36_local-bigcrawl.test
+++ b/tests/36_local-bigcrawl.test
@@ -9,7 +9,7 @@ set -euo pipefail
 : "${top_srcdir:=..}"
 
 bash "$top_srcdir/tests/local-crawl.sh" --rerun \
-    --errors 4 --files 361 \
+    --errors-content 4 --files 361 \
     --found 'big/p/95.html' \
     --found 'big/a/d1/d2/d3/d4/d5/d6/d7/d8/deep.png' \
     --found 'big/a/f2-2x.png' \

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -20,7 +20,7 @@
 #       --file-min-bytes PATH N --max-mirror-bytes N \
 #       httrack BASEURL/some/path [httrack-args...]
 # --errors counts every "Error:" log line; --errors-content drops transient
-# network failures (codes -2..-7) that flake on busy loopback under -c8.
+# network failures (codes -2..-6) that flake on busy loopback under -c8.
 # --log-found/--log-not-found grep (ERE) the crawl's hts-log.txt.
 # --max/--min-mirror-bytes bound the mirrored content bytes (host root).
 # --file-matches/--file-not-matches grep (ERE) a mirrored file (PATH under the
@@ -339,8 +339,9 @@ while test "$i" -lt "${#audit[@]}"; do
     --errors-content)
         i=$((i + 1))
         total=$(grep -icE "^[0-9:]*[[:space:]]Error:" "${out}/hts-log.txt")
-        # transient network failures (statuscode -2..-7) flake on busy loopback
-        transient=$(grep -cE '\(-[2-7]\) at link ' "${out}/hts-log.txt" || true)
+        # transient network failures (statuscode -2..-6) flake on busy loopback;
+        # the code parens are followed by " at link" or " after N retries at link"
+        transient=$(grep -cE '\(-[2-6]\) (at link|after )' "${out}/hts-log.txt" || true)
         assert_equals "checking content errors" "${audit[$i]}" "$((total - transient))"
         ;;
     --files)

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -14,11 +14,13 @@
 # Usage:
 #   bash local-crawl.sh [--tls] [--root DIR] [--cookie NAME=VALUE ...] \
 #       [--rerun-args 'ARGS'] \
-#       --errors N --files N --found PATH ... --directory PATH ... \
+#       --errors N --errors-content N --files N --found PATH ... --directory PATH ... \
 #       --log-found REGEX ... --log-not-found REGEX ... \
 #       --file-matches PATH REGEX ... --file-not-matches PATH REGEX ... \
 #       --file-min-bytes PATH N --max-mirror-bytes N \
 #       httrack BASEURL/some/path [httrack-args...]
+# --errors counts every "Error:" log line; --errors-content drops transient
+# network failures (codes -2..-7) that flake on busy loopback under -c8.
 # --log-found/--log-not-found grep (ERE) the crawl's hts-log.txt.
 # --max/--min-mirror-bytes bound the mirrored content bytes (host root).
 # --file-matches/--file-not-matches grep (ERE) a mirrored file (PATH under the
@@ -131,7 +133,7 @@ while test "$pos" -lt "$nargs"; do
         pos=$((pos + 1))
         rerun_args="${args[$pos]}"
         ;;
-    --errors | --files)
+    --errors | --errors-content | --files)
         audit+=("${args[$pos]}" "${args[$((pos + 1))]}")
         pos=$((pos + 1))
         ;;
@@ -333,6 +335,13 @@ while test "$i" -lt "${#audit[@]}"; do
         i=$((i + 1))
         assert_equals "checking errors" "${audit[$i]}" \
             "$(grep -iEc "^[0-9:]*[[:space:]]Error:" "${out}/hts-log.txt")"
+        ;;
+    --errors-content)
+        i=$((i + 1))
+        total=$(grep -icE "^[0-9:]*[[:space:]]Error:" "${out}/hts-log.txt")
+        # transient network failures (statuscode -2..-7) flake on busy loopback
+        transient=$(grep -cE '\(-[2-7]\) at link ' "${out}/hts-log.txt" || true)
+        assert_equals "checking content errors" "${audit[$i]}" "$((total - transient))"
         ;;
     --files)
         i=$((i + 1))


### PR DESCRIPTION
Test 36 (`36_local-bigcrawl`) asserted its error count exactly, the four planted 404/410/500/gztrunc pages, on a high-concurrency `-c8` crawl of 361 files. On the macOS CI runner the loopback network occasionally resets a few in-flight connections under that load, so the count came back as 7 and the job failed. The Linux jobs passed.

That exact count exists to catch a regression that errors on a page which should have succeeded. It doesn't need to count transient network drops, which are a property of the runner, not the crawl. So this adds an `--errors-content` harness assertion: every `Error:` line minus the transient-network family (httrack statuscodes -2..-7, timeout/slow/connect/reset/SSL), and switches test 36 to it. The four planted content errors still count exactly (the HTTP codes plus the `-1` decompression failure), so a real extra content or HTTP error still fails the test; only loopback flakiness is tolerated.