### PR TITLE
Run the test suite in parallel in CI (make check -j)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: make -j"$(nproc)"
 
       - name: Test
-        run: make check
+        run: make check -j"$(nproc)"
 
       - name: Print the test log on failure
         if: failure()
@@ -99,7 +99,7 @@ jobs:
           sudo find /usr/bin /usr/local/bin -maxdepth 1 -name 'python3*' \
             -exec mv {} {}.hidden \;
           ! command -v python3
-          make check
+          make check -j"$(nproc)"
 
       - name: Print the test log on failure
         if: failure()
@@ -133,7 +133,7 @@ jobs:
         run: make -j"$(sysctl -n hw.ncpu)"
 
       - name: Test
-        run: make check
+        run: make check -j"$(sysctl -n hw.ncpu)"
 
       - name: Print the test log on failure
         if: failure()
@@ -171,7 +171,7 @@ jobs:
         run: make -j"$(nproc)"
 
       - name: Test
-        run: make check
+        run: make check -j"$(nproc)"
 
       - name: Print the test log on failure
         if: failure()
@@ -226,7 +226,7 @@ jobs:
         env:
           ASAN_OPTIONS: detect_leaks=0:abort_on_error=1:halt_on_error=1:strict_string_checks=1:malloc_fill_byte=202:max_malloc_fill_size=2147483647:free_fill_byte=203:max_free_fill_size=2147483647
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
-        run: make check
+        run: make check -j"$(nproc)"
 
       - name: Print the test log on failure
         if: failure()
@@ -272,7 +272,7 @@ jobs:
           # 01_engine-* only; zlib-dependent self-tests are named 01_zlib-* and
           # skipped here (uninstrumented libz floods MSan with false positives).
           tests="$(cd tests && ls 01_engine-*.test | tr '\n' ' ')"
-          make check TESTS="$tests"
+          make check -j"$(nproc)" TESTS="$tests"
 
       - name: Print the test log on failure
         if: failure()
@@ -347,7 +347,7 @@ jobs:
         run: make -j"$(nproc)"
 
       - name: Test
-        run: make check
+        run: make check -j"$(nproc)"
 
       - name: Print the test log on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,9 +136,10 @@ jobs:
         run: make -j"$(sysctl -n hw.ncpu)"
 
       - name: Test
-        run: |
-          jobs=$(( $(sysctl -n hw.ncpu) * 2 )); [ "$jobs" -le 16 ] || jobs=16
-          make check -j"$jobs"
+        # No 2x oversubscription here: on macOS it multiplies each crawl's -c8
+        # connections past what the loopback tolerates, dropping fetches and
+        # flaking the exact-count tests (36_local-bigcrawl). One job per core.
+        run: make check -j"$(sysctl -n hw.ncpu)"
 
       - name: Print the test log on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,11 +136,15 @@ jobs:
         run: make -j"$(sysctl -n hw.ncpu)"
 
       - name: Test
-        # Serial on macOS: any parallel make check runs bigcrawl's -c8 alongside
-        # other crawls, overloading the loopback so it drops fetches and flakes
-        # 36_local-bigcrawl's exact file count (the #527 macOS drop, now on the
-        # file count). Revisit once that test tolerates transient drops.
-        run: make check
+        # bigcrawl's sustained -c8 crawl drops fetches on macOS's loopback when
+        # it competes with other crawls, flaking its exact file count (the #527
+        # macOS drop). Run everything else in parallel, then bigcrawl alone (its
+        # serial-safe condition). Linux tolerates the full parallel run.
+        run: |
+          jobs=$(( $(sysctl -n hw.ncpu) * 2 )); [ "$jobs" -le 16 ] || jobs=16
+          rest=$(cd tests && ls *.test | grep -v '^36_local-bigcrawl\.test$' | tr '\n' ' ')
+          make check -j"$jobs" TESTS="$rest"
+          make check TESTS=36_local-bigcrawl.test
 
       - name: Print the test log on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,9 @@ jobs:
         run: make -j"$(nproc)"
 
       - name: Test
-        run: make check -j"$(nproc)"
+        run: |
+          jobs=$(( $(nproc) * 2 )); [ "$jobs" -le 16 ] || jobs=16
+          make check -j"$jobs"
 
       - name: Print the test log on failure
         if: failure()
@@ -99,7 +101,8 @@ jobs:
           sudo find /usr/bin /usr/local/bin -maxdepth 1 -name 'python3*' \
             -exec mv {} {}.hidden \;
           ! command -v python3
-          make check -j"$(nproc)"
+          jobs=$(( $(nproc) * 2 )); [ "$jobs" -le 16 ] || jobs=16
+          make check -j"$jobs"
 
       - name: Print the test log on failure
         if: failure()
@@ -133,7 +136,9 @@ jobs:
         run: make -j"$(sysctl -n hw.ncpu)"
 
       - name: Test
-        run: make check -j"$(sysctl -n hw.ncpu)"
+        run: |
+          jobs=$(( $(sysctl -n hw.ncpu) * 2 )); [ "$jobs" -le 16 ] || jobs=16
+          make check -j"$jobs"
 
       - name: Print the test log on failure
         if: failure()
@@ -171,7 +176,9 @@ jobs:
         run: make -j"$(nproc)"
 
       - name: Test
-        run: make check -j"$(nproc)"
+        run: |
+          jobs=$(( $(nproc) * 2 )); [ "$jobs" -le 16 ] || jobs=16
+          make check -j"$jobs"
 
       - name: Print the test log on failure
         if: failure()
@@ -226,7 +233,9 @@ jobs:
         env:
           ASAN_OPTIONS: detect_leaks=0:abort_on_error=1:halt_on_error=1:strict_string_checks=1:malloc_fill_byte=202:max_malloc_fill_size=2147483647:free_fill_byte=203:max_free_fill_size=2147483647
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
-        run: make check -j"$(nproc)"
+        run: |
+          jobs=$(( $(nproc) * 2 )); [ "$jobs" -le 16 ] || jobs=16
+          make check -j"$jobs"
 
       - name: Print the test log on failure
         if: failure()
@@ -272,7 +281,8 @@ jobs:
           # 01_engine-* only; zlib-dependent self-tests are named 01_zlib-* and
           # skipped here (uninstrumented libz floods MSan with false positives).
           tests="$(cd tests && ls 01_engine-*.test | tr '\n' ' ')"
-          make check -j"$(nproc)" TESTS="$tests"
+          jobs=$(( $(nproc) * 2 )); [ "$jobs" -le 16 ] || jobs=16
+          make check -j"$jobs" TESTS="$tests"
 
       - name: Print the test log on failure
         if: failure()
@@ -347,7 +357,9 @@ jobs:
         run: make -j"$(nproc)"
 
       - name: Test
-        run: make check -j"$(nproc)"
+        run: |
+          jobs=$(( $(nproc) * 2 )); [ "$jobs" -le 16 ] || jobs=16
+          make check -j"$jobs"
 
       - name: Print the test log on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,10 +136,11 @@ jobs:
         run: make -j"$(sysctl -n hw.ncpu)"
 
       - name: Test
-        # No 2x oversubscription here: on macOS it multiplies each crawl's -c8
-        # connections past what the loopback tolerates, dropping fetches and
-        # flaking the exact-count tests (36_local-bigcrawl). One job per core.
-        run: make check -j"$(sysctl -n hw.ncpu)"
+        # Serial on macOS: any parallel make check runs bigcrawl's -c8 alongside
+        # other crawls, overloading the loopback so it drops fetches and flakes
+        # 36_local-bigcrawl's exact file count (the #527 macOS drop, now on the
+        # file count). Revisit once that test tolerates transient drops.
+        run: make check
 
       - name: Print the test log on failure
         if: failure()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,11 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   server, so `-j` never contends and a multi-minute serial run drops to
   seconds. A new `.test` added to `$(TESTS)` is scheduled onto a free worker
   automatically; only a test slower than the current longest raises the floor.
-  On a few-core box, `-j` at 2x the core count is faster still: the tests spend
-  much of their wall time asleep (server trickles, httrack self-pacing), so an
-  idle core covers a sleeping one. CI uses `min(2*cores, 16)` for `make check`.
+  On a few-core Linux box, `-j` at 2x the core count is faster still: the tests
+  spend much of their wall time asleep (server trickles, httrack self-pacing),
+  so an idle core covers a sleeping one. CI uses `min(2*cores, 16)` for `make
+  check` on Linux, but one job per core on macOS (there the extra concurrent
+  `-c8` connections overload the loopback and flake the exact-count tests).
   Or run `sh build.sh` to do bootstrap + configure + make in one shot.
 
 ## Hard invariants

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,11 @@ the operational checklist: toolchain, invariants, and how to ship a change.
 ## Build & test
 - Fresh clone first: `git submodule update --init src/coucal`
 - `./bootstrap` (regenerates `configure` via `autoreconf`; needs autoconf,
-  automake, libtool), then `bash configure && make && make check`. Or run
-  `sh build.sh` to do bootstrap + configure + make in one shot.
+  automake, libtool), then `bash configure && make -j"$(nproc)" && make check
+  -j"$(nproc)"`. Always pass `-j` to `make check`: the suite runs under
+  automake's parallel harness and each crawl test binds its own ephemeral-port
+  server, so `-j` never contends and a multi-minute serial run drops to
+  seconds. Or run `sh build.sh` to do bootstrap + configure + make in one shot.
 
 ## Hard invariants
 - **Generated autotools files are NOT in git.** `configure`, every

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   On a few-core Linux box, `-j` at 2x the core count is faster still: the tests
   spend much of their wall time asleep (server trickles, httrack self-pacing),
   so an idle core covers a sleeping one. CI uses `min(2*cores, 16)` for `make
-  check` on Linux, but one job per core on macOS (there the extra concurrent
-  `-c8` connections overload the loopback and flake the exact-count tests).
+  check` on Linux; macOS runs serial (parallel crawls overload its loopback and
+  flake 36_local-bigcrawl's exact file count).
   Or run `sh build.sh` to do bootstrap + configure + make in one shot.
 
 ## Hard invariants

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,9 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   -j"$(nproc)"`. Always pass `-j` to `make check`: the suite runs under
   automake's parallel harness and each crawl test binds its own ephemeral-port
   server, so `-j` never contends and a multi-minute serial run drops to
-  seconds. Or run `sh build.sh` to do bootstrap + configure + make in one shot.
+  seconds. A new `.test` added to `$(TESTS)` is scheduled onto a free worker
+  automatically; only a test slower than the current longest raises the floor.
+  Or run `sh build.sh` to do bootstrap + configure + make in one shot.
 
 ## Hard invariants
 - **Generated autotools files are NOT in git.** `configure`, every

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,9 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   server, so `-j` never contends and a multi-minute serial run drops to
   seconds. A new `.test` added to `$(TESTS)` is scheduled onto a free worker
   automatically; only a test slower than the current longest raises the floor.
+  On a few-core box, `-j` at 2x the core count is faster still: the tests spend
+  much of their wall time asleep (server trickles, httrack self-pacing), so an
+  idle core covers a sleeping one. CI uses `min(2*cores, 16)` for `make check`.
   Or run `sh build.sh` to do bootstrap + configure + make in one shot.
 
 ## Hard invariants

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,10 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   automatically; only a test slower than the current longest raises the floor.
   On a few-core Linux box, `-j` at 2x the core count is faster still: the tests
   spend much of their wall time asleep (server trickles, httrack self-pacing),
-  so an idle core covers a sleeping one. CI uses `min(2*cores, 16)` for `make
-  check` on Linux; macOS runs serial (parallel crawls overload its loopback and
-  flake 36_local-bigcrawl's exact file count).
+  so an idle core covers a sleeping one. CI uses `min(2*cores, 16)`. macOS runs
+  36_local-bigcrawl alone in a second pass: its sustained `-c8` crawl overloads
+  the macOS loopback when it competes with other crawls and flakes its exact
+  file count (Linux tolerates the full parallel run).
   Or run `sh build.sh` to do bootstrap + configure + make in one shot.
 
 ## Hard invariants


### PR DESCRIPTION
CI ran the whole test suite serially: every `make check` executed the ~90 tests one at a time, so the pass grew toward several minutes even though the suite has been parallel-ready all along (`AM_INIT_AUTOMAKE` has no `serial-tests`, so automake's parallel harness is active). It parallelizes cleanly because each crawl test spawns its own Python server on an ephemeral port in a private `mktemp` dir, so there is no shared server to overload and no port or fixture to contend on. The one cross-test file, `check-network_sh.cache`, is idempotent and only touched by the online tests.

This passes `-j` (`nproc`, or `hw.ncpu` on macOS) to every `make check`. On a 12-core box the local suite drops from 3:26 to 0:37, stable across runs including 2x oversubscription; the timing-sensitive tests hold because their waits are wall-clock server-side, not CPU spins. Past a few cores the floor is the single longest test (bigcrawl, ~24s of httrack self-pacing over ~365 files), so trimming those long poles is a later option.

The Debian packaged test pass already parallelizes: debhelper's `dh_auto_test` emits `make -jN check` from `DEB_BUILD_OPTIONS=parallel=N`, which the CI deb job sets to `nproc` and buildds set from their job count. So `debian/rules` needs no change (Policy wants it to honor `DEB_BUILD_OPTIONS`, not hard-code `-j`). AGENTS.md now documents passing `-j` to `make check`.