### PR TITLE
Make test 31 fail loudly when the java plugin doesn't load

### DIFF
--- a/tests/31_local-javaclass.test
+++ b/tests/31_local-javaclass.test
@@ -17,7 +17,10 @@ printf 'GIF89a' >"$tmproot/javaclass/hello.gif"
 printf '\xCA\xFE\xBA\xBE\x00\x00\x00\x32\x00\x02\x01\x00\x09hello.gif\x00\x00\x00\x00' \
     >"$tmproot/javaclass/Foo.class"
 
+# --log-found first: a plugin-load failure (wrong soname, shadowing system
+# libhtsjava) trips here on the banner suffix, not as an opaque "not found".
 bash "$top_srcdir/tests/local-crawl.sh" --root "$tmproot" --errors 0 \
+    --log-found '\+libhtsjava' \
     --found 'javaclass/Foo.class' \
     --found 'javaclass/hello.gif' \
     httrack 'BASEURL/javaclass/index.html'


### PR DESCRIPTION
`31_local-javaclass` proves the java plugin parses a `.class` constant pool: it asserts a resource named only inside `Foo.class` gets crawled. The weak point is the failure message. When the plugin doesn't load, the crawl just misses `hello.gif` and the test reports a bare "not found", with nothing pointing at the plugin. That opacity is why an intermittent local failure sat uninvestigated.

The failure itself is a shadowing system `libhtsjava`. On a machine with httrack installed, if the soname httrack dlopens is absent from the fresh build but present in `/usr/lib`, the loader resolves the system plugin (a mismatched, non-instrumented build) and it silently parses nothing. It read as ASan-specific only because that was the build in use; clean CI runners carry no system plugin, so they never reproduced it. #475 already closed the gap by deriving the dlopen name from the build's own `VERSION_INFO`, so this is not reproducible on current master.

This adds one assertion: the plugin's launched-banner suffix (`+libhtsjava`), checked before the file assertions so a load failure trips there with a clear message rather than the opaque `hello.gif` miss. Test-only, no engine change. The `+libhtsjava` prefix survives future soname bumps.