### PR TITLE
Meter -M against received volume, not saved bytes

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -4178,10 +4178,13 @@ static int back_maxtime_grace(const int maxtime) {
    No floor (unlike the time grace): a size overrun should abort promptly. */
 static LLint back_maxsize_grace(const LLint maxsite) { return maxsite / 10; }
 
-/* Which cap has overrun its grace and must hard-stop the mirror (#77, #481). */
+/* Which cap has overrun its grace and must hard-stop the mirror (#77, #481).
+   -M measures received volume (HTS_TOTAL_RECV), not saved 200-only stat_bytes
+   which undercounts redirect/error-heavy crawls (#520). */
 static hts_mirror_limit back_mirror_limit(httrackp *opt) {
-  if (opt->maxsite > 0 && HTS_STAT.stat_bytes >= opt->maxsite &&
-      HTS_STAT.stat_bytes - opt->maxsite >= back_maxsize_grace(opt->maxsite))
+  if (opt->maxsite > 0 && HTS_STAT.HTS_TOTAL_RECV >= opt->maxsite &&
+      HTS_STAT.HTS_TOTAL_RECV - opt->maxsite >=
+          back_maxsize_grace(opt->maxsite))
     return HTS_MIRROR_LIMIT_SIZE;
   if (opt->maxtime > 0) {
     const TStamp elapsed = time_local() - HTS_STAT.stat_timestart;
@@ -4195,7 +4198,7 @@ static hts_mirror_limit back_mirror_limit(httrackp *opt) {
 
 int back_checkmirror(httrackp *opt) {
   /* request a smooth stop the first time each cap is reached */
-  if (opt->maxsite > 0 && HTS_STAT.stat_bytes >= opt->maxsite &&
+  if (opt->maxsite > 0 && HTS_STAT.HTS_TOTAL_RECV >= opt->maxsite &&
       !opt->state.stop) {
     hts_log_print(opt, LOG_ERROR,
                   "More than " LLintP

--- a/tests/45_local-maxsize-recv.test
+++ b/tests/45_local-maxsize-recv.test
@@ -7,8 +7,10 @@ set -euo pipefail
 
 : "${top_srcdir:=..}"
 
-# Saved stays ~700 B (index only); received crosses -M after the first 404 body,
-# so the cap fires. Metering saved bytes never trips and fetches all 16 links.
+# The mirror bound is the load-bearing half: it fires while <100 KB is saved,
+# so the cap can only have tripped on received volume, not saved bytes (which
+# would exceed the cap and fetch all 16 links).
 bash "$top_srcdir/tests/local-crawl.sh" \
     --log-found 'More than 500000 bytes have been transferred.. giving up' \
+    --max-mirror-bytes 100000 \
     httrack 'BASEURL/maxrecv/index.html' -M500000 -c4

--- a/tests/45_local-maxsize-recv.test
+++ b/tests/45_local-maxsize-recv.test
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# -M caps received volume, not saved 200-only bytes (#520): links to large 404
+# bodies pump received >> saved; the cap must trip though little lands on disk.
+
+set -euo pipefail
+
+: "${top_srcdir:=..}"
+
+# Saved stays ~700 B (index only); received crosses -M after the first 404 body,
+# so the cap fires. Metering saved bytes never trips and fetches all 16 links.
+bash "$top_srcdir/tests/local-crawl.sh" \
+    --log-found 'More than 500000 bytes have been transferred.. giving up' \
+    httrack 'BASEURL/maxrecv/index.html' -M500000 -c4

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -113,6 +113,7 @@ TESTS = \
 	41_local-utf8-link.test \
 	42_local-maxsize-slow.test \
 	43_local-update-truncate.test \
-	44_local-update-errormask.test
+	44_local-update-errormask.test \
+	45_local-maxsize-recv.test
 
 CLEANFILES = check-network_sh.cache

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1104,6 +1104,22 @@ class Handler(SimpleHTTPRequestHandler):
         except OSError:
             pass
 
+    # -M received-volume cap (#520): links to large 404 bodies. httrack receives
+    # each (HTS_TOTAL_RECV climbs) but saves none, so saved stays far below -M.
+    def route_maxrecv_index(self):
+        self.send_html(
+            "".join('\t<a href="r%d.bin">r%d</a>\n' % (i, i) for i in range(16))
+        )
+
+    def route_maxrecv_404(self):
+        body = b"x" * self.BIGFILE_BYTES
+        self.send_response(404, "Not Found")
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
     ROUTES = {
         "/cookies/entrance.php": route_entrance,
         "/cookies/second.php": route_second,
@@ -1206,6 +1222,23 @@ class Handler(SimpleHTTPRequestHandler):
         "/mini304/page.html": route_mini304_page,
         "/errmask/index.html": route_errmask_index,
         "/errmask/keep.dat": route_errmask_keep,
+        "/maxrecv/index.html": route_maxrecv_index,
+        "/maxrecv/r0.bin": route_maxrecv_404,
+        "/maxrecv/r1.bin": route_maxrecv_404,
+        "/maxrecv/r2.bin": route_maxrecv_404,
+        "/maxrecv/r3.bin": route_maxrecv_404,
+        "/maxrecv/r4.bin": route_maxrecv_404,
+        "/maxrecv/r5.bin": route_maxrecv_404,
+        "/maxrecv/r6.bin": route_maxrecv_404,
+        "/maxrecv/r7.bin": route_maxrecv_404,
+        "/maxrecv/r8.bin": route_maxrecv_404,
+        "/maxrecv/r9.bin": route_maxrecv_404,
+        "/maxrecv/r10.bin": route_maxrecv_404,
+        "/maxrecv/r11.bin": route_maxrecv_404,
+        "/maxrecv/r12.bin": route_maxrecv_404,
+        "/maxrecv/r13.bin": route_maxrecv_404,
+        "/maxrecv/r14.bin": route_maxrecv_404,
+        "/maxrecv/r15.bin": route_maxrecv_404,
     }
 
     # --- /big/ seeded pseudo-site ------------------------------------------


### PR DESCRIPTION
The `-M` cap ("maximum overall size that can be uploaded/scanned") was enforced against `stat_bytes`, which counts only saved HTTP 200 bodies minus robots.txt. On crawls dominated by redirects, error bodies, or plugin-written files that counter trails the volume actually pulled off the network, so the cap barely engaged. In #77 the reporter saw about 12.5 MB on disk while "Bytes saved" hovered near a 3 MB cap.

This meters against `HTS_TOTAL_RECV`, the real received volume, incremented on every recv/fread and matching the option's "scanned" wording. #519's smooth-stop, grace, and hard-abort path is untouched; only the metered quantity moves. It is still monotonic, so the sticky size-branch invariant #519 relies on holds. Received is credited live per-chunk rather than at transfer completion, so the cap now bounds overshoot slightly earlier.

Test 45 drives a fixture of large 404 bodies that are received but never saved: the cap fires though only the index page lands on disk. It fails on master, where `stat_bytes` never reaches the cap and every link is fetched.

The display half of #520, where "Bytes saved" dips when an in-flight transfer resolves as a redirect or error, is cosmetic and left alone.

Closes #520