### PR TITLE
Make the connect-fallback test fast on macOS

### DIFF
--- a/tests/19_local-connect-fallback.test
+++ b/tests/19_local-connect-fallback.test
@@ -66,9 +66,12 @@ test -n "$port" || {
 }
 
 out="$tmpdir/crawl"
+# macOS has only 127.0.0.1, so the dead 127.0.0.x connects block to the timeout
+# instead of refusing instantly (as on Linux); a small --timeout + --retries=0
+# bound the stall without changing what the fallback exercises.
 HTTRACK_DEBUG_RESOLVE="deadhost:127.0.0.2,127.0.0.1" \
     httrack "http://deadhost:$port/simple/basic.html" -O "$out" \
-    -c1 --robots=0 --timeout=30 --quiet -Z >"$tmpdir/log" 2>&1
+    -c1 --robots=0 --timeout=5 --retries=0 --quiet -Z >"$tmpdir/log" 2>&1
 
 log="$out/hts-log.txt"
 
@@ -92,12 +95,12 @@ test -f "$out/deadhost_$port/simple/basic.html" || {
     exit 1
 }
 
-# every address refused: the slot exhausts the list, then errors out (the
-# harness timeout would catch a hang/loop; refused connects are instant)
+# every address dead: the slot exhausts the list, then errors out (the harness
+# timeout would catch a hang/loop)
 out2="$tmpdir/crawl2"
 HTTRACK_DEBUG_RESOLVE="alldead:127.0.0.2,127.0.0.3" \
     httrack "http://alldead:$port/simple/basic.html" -O "$out2" \
-    -c1 --robots=0 --timeout=30 --quiet -Z >"$tmpdir/log2" 2>&1
+    -c1 --robots=0 --timeout=5 --retries=0 --quiet -Z >"$tmpdir/log2" 2>&1
 log2="$out2/hts-log.txt"
 
 grep -q "trying next address" "$log2" || {


### PR DESCRIPTION
Test 19 (`19_local-connect-fallback`) pins dead loopback addresses (`127.0.0.2`, then `127.0.0.3`) ahead of the live `127.0.0.1` to check that httrack falls back to the next address when a connect fails. On Linux the whole `127.0.0.0/8` block is loopback, so those dead addresses refuse instantly. macOS configures only `127.0.0.1`, so a connect to `127.0.0.2/.3` has no host to refuse it and blocks until the timeout; with default retries replaying the whole crawl, the all-dead case ran about two minutes. The test passed, but that stall dominated the macOS suite once the other tests run in parallel (the single longest thing on the runner after bigcrawl was isolated).

The fix drops `--timeout` to 5s and sets `--retries=0` for both crawls in the test. The non-last dead address already falls back at `min(timeout, 10s)` via the existing connect-fallback cap; the 5s timeout bounds the last candidate stall, and `--retries=0` removes the 3x replay. Linux behavior is unchanged, since a refused connect never reaches the timeout. On macOS the test drops from ~2 minutes to ~15s.

Follow-up to the CI test-parallelization work (#528): with the suite now parallel, per-test wall time is what bounds the macOS runner, and this test was the biggest remaining pole.