### PR TITLE
Harden Content-Range integer handling against hostile and oversize values

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -3908,11 +3908,19 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                           if (fp) {
                             LLint alloc_mem = resume + 1;
 
-                            if (back[i].r.totalsize >= 0)
+                            // Reject a hostile Content-Length that would
+                            // overflow the buffer size: drop the partial and
+                            // refetch.
+                            if (back[i].r.totalsize > INT64_MAX - alloc_mem) {
+                              url_savename_refname_remove(opt, back[i].url_adr,
+                                                          back[i].url_fil);
+                              UNLINK(back[i].url_sav);
+                              alloc_mem = -1;
+                            } else if (back[i].r.totalsize >= 0)
                               alloc_mem += back[i].r.totalsize; // AJOUTER RESTANT!
-                            if (deleteaddr(&back[i].r)
-                                && (back[i].r.adr =
-                                    (char *) malloct((size_t) alloc_mem))) {
+                            if (alloc_mem >= 0 && deleteaddr(&back[i].r) &&
+                                (back[i].r.adr =
+                                     (char *) malloct((size_t) alloc_mem))) {
                               back[i].r.size = resume;
                               if (back[i].r.totalsize >= 0)
                                 back[i].r.totalsize += resume; // -> full size

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -3611,7 +3611,7 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                       if (back[i].r.statuscode == HTTP_OK && !back[i].testmode) {       // 'OK'
                         if (!is_hypertext_mime(opt, back[i].r.contenttype, back[i].url_fil)) {  // not HTML
                           if (strnotempty(back[i].url_sav)) {   // target found
-                            int size = fsize_utf8(back[i].url_sav);     // target size
+                            off_t size = fsize_utf8(back[i].url_sav);
 
                             if (size >= 0) {
                               if (back[i].r.totalsize == size) {        // same size!
@@ -3839,7 +3839,7 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                       const hts_boolean range_ok =
                           back[i].r.crange > 0 && resume >= 0 &&
                           resume <= (LLint) sz &&
-                          back[i].r.crange_end + 1 == back[i].r.crange &&
+                          back[i].r.crange_end == back[i].r.crange - 1 &&
                           (back[i].r.totalsize < 0 ||
                            back[i].r.totalsize ==
                                back[i].r.crange_end - resume + 1);

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -1586,13 +1586,19 @@ void treathead(t_cookie * cookie, const char *adr, const char *fil, htsblk * ret
         a = strchr(rcvd + p, '/');
         if (a != NULL) {
           a++;
-          if (sscanf(a, LLintP, &retour->crange) == 1) {
+          if (sscanf(a, LLintP, &retour->crange) == 1 && retour->crange >= 0) {
             retour->crange_start = 0;
             retour->crange_end = retour->crange - 1;
           } else {
             retour->crange = 0;
           }
         }
+      }
+      // A valid Content-Range has no negative field; reject hostile values so
+      // the crange +/- 1 arithmetic downstream cannot sign-overflow (UB).
+      if (retour->crange_start < 0 || retour->crange_end < 0 ||
+          retour->crange < 0) {
+        retour->crange_start = retour->crange_end = retour->crange = 0;
       }
     }
   } else if ((p = strfield(rcvd, "Connection:")) != 0) {

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1310,6 +1310,29 @@ static int st_headerlong(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* Parse a Content-Range header and print the sanitized triple. A hostile value
+   (negative or INT64 extreme) must clamp to 0 without signed-overflow UB. */
+static int st_crange(httrackp *opt, int argc, char **argv) {
+  int i;
+
+  (void) opt;
+  if (argc < 1) {
+    fprintf(stderr, "crange: needs at least one raw Content-Range line\n");
+    return 1;
+  }
+  for (i = 0; i < argc; i++) {
+    htsblk r;
+    char BIGSTK line[HTS_URLMAXSIZE * 2];
+
+    memset(&r, 0, sizeof(r));
+    strcpybuff(line, argv[i]);
+    treathead(NULL, "www.example.com", "/", &r, line);
+    printf("crange_start=" LLintP " crange_end=" LLintP " crange=" LLintP "\n",
+           (LLint) r.crange_start, (LLint) r.crange_end, (LLint) r.crange);
+  }
+  return 0;
+}
+
 /* Decode a body argument ("hex:FFD8.." or literal text) into buf. */
 static size_t st_decode_body(const char *arg, char *buf, size_t size) {
   size_t n = 0;
@@ -2496,6 +2519,8 @@ static const struct selftest_entry {
     {"headerlong", "[header-name:]",
      "over-long header value must not overflow the parse scratch",
      st_headerlong},
+    {"crange", "<raw-content-range-line> ...",
+     "Content-Range parse integer safety", st_crange},
     {"savename", "<fil> <content-type> [key=value ...]",
      "local save-name for a URL", st_savename},
     {"sniff", "<content-type> <hex:..|text>", "MIME magic consistency",

--- a/tests/01_engine-crange.test
+++ b/tests/01_engine-crange.test
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# Content-Range parse (treathead via -#test=crange). Hostile values must clamp
+# to 0, and the crange +/- 1 arithmetic must not sign-overflow (UBSan aborts on
+# the pre-fix binary at the INT64_MIN cases).
+
+cr() {
+    local want="$1"
+    shift
+    out="$(httrack -O /dev/null -#test=crange "$@")"
+    test "$out" == "$want" || {
+        echo "FAIL: $* -> '$out' (want '$want')"
+        exit 1
+    }
+}
+
+# Normal range and the '*/N' fallback both parse through unchanged.
+cr 'crange_start=0 crange_end=70870 crange=70871' 'Content-Range: bytes 0-70870/70871'
+cr 'crange_start=0 crange_end=70870 crange=70871' 'Content-Range: bytes */70871'
+
+# INT64_MIN total in the fallback would make crange-1 overflow: clamp to 0.
+cr 'crange_start=0 crange_end=0 crange=0' 'Content-Range: bytes */-9223372036854775808'
+
+# Any negative field in the 3-field form clamps the whole triple to 0.
+cr 'crange_start=0 crange_end=0 crange=0' 'Content-Range: bytes -1--1/-1'
+
+# INT64_MAX is non-negative: it passes through, the parse must not mangle it.
+cr 'crange_start=0 crange_end=9223372036854775807 crange=9223372036854775807' \
+    'Content-Range: bytes 0-9223372036854775807/9223372036854775807'

--- a/tests/01_engine-crange.test
+++ b/tests/01_engine-crange.test
@@ -24,8 +24,10 @@ cr 'crange_start=0 crange_end=70870 crange=70871' 'Content-Range: bytes */70871'
 # INT64_MIN total in the fallback would make crange-1 overflow: clamp to 0.
 cr 'crange_start=0 crange_end=0 crange=0' 'Content-Range: bytes */-9223372036854775808'
 
-# Any negative field in the 3-field form clamps the whole triple to 0.
+# Any negative field in the 3-field form clamps the whole triple to 0 (each
+# field independently: a leading negative start/end alone still zeroes all).
 cr 'crange_start=0 crange_end=0 crange=0' 'Content-Range: bytes -1--1/-1'
+cr 'crange_start=0 crange_end=0 crange=0' 'Content-Range: bytes -5-10/20'
 
 # INT64_MAX is non-negative: it passes through, the parse must not mangle it.
 cr 'crange_start=0 crange_end=9223372036854775807 crange=9223372036854775807' \

--- a/tests/47_local-crange-overflow.test
+++ b/tests/47_local-crange-overflow.test
@@ -1,0 +1,95 @@
+#!/bin/bash
+# C2: a resume whose 206 carries a Content-Range end of INT64_MAX must not
+# sign-overflow the crange+1 range check (UBSan aborts on the pre-fix binary).
+# Pass 1 leaves a partial + temp-ref; pass 2 resumes, gets the hostile 206, and
+# must reject the range and refetch the whole file rather than overflow.
+set -u
+
+: "${top_srcdir:=..}"
+testdir=$(cd "$(dirname "$0")" && pwd)
+server="${testdir}/local-server.py"
+
+command -v python3 >/dev/null || ! echo "python3 not found; skipping" || exit 77
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_crange.XXXXXX") || exit 1
+serverpid=
+crawlpid=
+cleanup() {
+    test -n "$crawlpid" && kill -9 "$crawlpid" 2>/dev/null
+    if test -n "$serverpid"; then
+        kill "$serverpid" 2>/dev/null
+        wait "$serverpid" 2>/dev/null
+    fi
+    rm -rf "$tmpdir"
+}
+trap cleanup EXIT HUP INT QUIT PIPE TERM
+
+serverlog="${tmpdir}/server.log"
+python3 "$server" --root "${testdir}/server-root" >"$serverlog" 2>&1 &
+serverpid=$!
+port=
+for _ in $(seq 1 50); do
+    line=$(head -n1 "$serverlog" 2>/dev/null)
+    if test "${line%% *}" == "PORT"; then
+        port="${line#PORT }"
+        break
+    fi
+    kill -0 "$serverpid" 2>/dev/null || {
+        echo "server exited early: $(cat "$serverlog")"
+        exit 1
+    }
+    sleep 0.1
+done
+test -n "$port" || {
+    echo "could not discover server port"
+    exit 1
+}
+base="http://127.0.0.1:${port}"
+
+which httrack >/dev/null || {
+    echo "could not find httrack"
+    exit 1
+}
+out="${tmpdir}/crawl"
+mkdir "$out"
+common=(-O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 --retries=1 -c1)
+refdir="${out}/hts-cache/ref"
+
+# --- pass 1: crawl, interrupt once the blob download is underway -------------
+printf '[pass 1: interrupt mid-download] ..\t'
+httrack "${common[@]}" "${base}/crange206/index.html" >"${tmpdir}/log1" 2>&1 &
+crawlpid=$!
+for _ in $(seq 1 300); do
+    test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" && break
+    kill -0 "$crawlpid" 2>/dev/null || break
+    sleep 0.1
+done
+sleep 0.3
+kill -TERM "$crawlpid" 2>/dev/null
+wait "$crawlpid" 2>/dev/null
+crawlpid=
+test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" || {
+    echo "FAIL: no temp-ref survived pass 1; cannot drive the resume"
+    exit 1
+}
+echo "OK (temp-ref present)"
+
+# --- pass 2: --continue -> resume -> hostile INT64_MAX Content-Range ----------
+printf '[pass 2: hostile 206, no overflow, refetch] ..\t'
+httrack "${common[@]}" --continue "${base}/crange206/index.html" >"${tmpdir}/log2" 2>&1
+echo "OK (terminated)"
+
+blob=$(find "$out" -name blob.bin 2>/dev/null | head -1)
+full=6008 # len(CRANGE206_BODY) = len("CR206DAT") + 6000
+
+printf '[file recovered whole] ..\t'
+test -s "$blob" || {
+    echo "FAIL: blob.bin missing after the hostile 206"
+    exit 1
+}
+got=$(wc -c <"$blob")
+test "$got" -eq "$full" || {
+    echo "FAIL: blob.bin is ${got} bytes, expected ${full}"
+    exit 1
+}
+echo "OK (${got} bytes)"

--- a/tests/48_local-crange-memresume.test
+++ b/tests/48_local-crange-memresume.test
@@ -1,9 +1,9 @@
 #!/bin/bash
-# C2: a resume whose 206 carries a Content-Range end of INT64_MAX must not
-# sign-overflow the crange+1 range check (UBSan aborts on the pre-fix binary).
-# Pass 1 leaves a partial + temp-ref; pass 2 resumes, gets the hostile 206, and
-# must reject the range and refetch the whole file rather than overflow. Teeth
-# are UBSan-only: a normal build wraps to the same reject+restart.
+# C2 (memory branch): a resume whose 206 lies text/html with a matching
+# INT64_MAX Content-Length must not overflow the resume buffer-size add
+# (UBSan aborts on the pre-fix binary at alloc_mem += totalsize). Pass 1 leaves
+# a partial + temp-ref; pass 2 resumes and must reject and refetch the whole
+# file. Teeth are UBSan-only: a normal build wraps to the same reject+restart.
 set -u
 
 : "${top_srcdir:=..}"
@@ -12,7 +12,7 @@ server="${testdir}/local-server.py"
 
 command -v python3 >/dev/null || ! echo "python3 not found; skipping" || exit 77
 
-tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_crange.XXXXXX") || exit 1
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_crangemem.XXXXXX") || exit 1
 serverpid=
 crawlpid=
 cleanup() {
@@ -58,7 +58,7 @@ refdir="${out}/hts-cache/ref"
 
 # --- pass 1: crawl, interrupt once the blob download is underway -------------
 printf '[pass 1: interrupt mid-download] ..\t'
-httrack "${common[@]}" "${base}/crange206/index.html" >"${tmpdir}/log1" 2>&1 &
+httrack "${common[@]}" "${base}/crange206mem/index.html" >"${tmpdir}/log1" 2>&1 &
 crawlpid=$!
 for _ in $(seq 1 300); do
     test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" && break
@@ -77,7 +77,7 @@ echo "OK (temp-ref present)"
 
 # --- pass 2: --continue -> resume -> hostile INT64_MAX Content-Range ----------
 printf '[pass 2: hostile 206, no overflow, refetch] ..\t'
-httrack "${common[@]}" --continue "${base}/crange206/index.html" >"${tmpdir}/log2" 2>&1
+httrack "${common[@]}" --continue "${base}/crange206mem/index.html" >"${tmpdir}/log2" 2>&1
 echo "OK (terminated)"
 
 blob=$(find "$out" -name blob.bin 2>/dev/null | head -1)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -117,6 +117,7 @@ TESTS = \
 	44_local-update-errormask.test \
 	45_local-maxsize-recv.test \
 	46_local-update-304-resume.test \
-	47_local-crange-overflow.test
+	47_local-crange-overflow.test \
+	48_local-crange-memresume.test
 
 CLEANFILES = check-network_sh.cache

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -30,6 +30,7 @@ TESTS = \
 	01_engine-cmdline.test \
 	01_engine-cookies.test \
 	01_engine-copyopt.test \
+	01_engine-crange.test \
 	01_engine-dns.test \
 	01_engine-doitlog.test \
 	01_engine-entities.test \
@@ -115,6 +116,7 @@ TESTS = \
 	43_local-update-truncate.test \
 	44_local-update-errormask.test \
 	45_local-maxsize-recv.test \
-	46_local-update-304-resume.test
+	46_local-update-304-resume.test \
+	47_local-crange-overflow.test
 
 CLEANFILES = check-network_sh.cache

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -950,6 +950,49 @@ class Handler(SimpleHTTPRequestHandler):
         if self.command != "HEAD":
             self.wfile.write(self.CRANGE206_BODY)
 
+    # C2 memory branch: a resume answered with a 206 that lies text/html (so the
+    # resume buffers in memory) plus a matching INT64_MAX Content-Length would
+    # overflow the buffer-size add. Stall first, then send that hostile 206.
+    _crange206mem_started = False
+
+    def route_crange206mem_index(self):
+        self.send_html('\t<a href="blob.bin">blob</a>')
+
+    def route_crange206mem(self):
+        rng = self.headers.get("Range")
+        if not Handler._crange206mem_started:
+            Handler._crange206mem_started = True
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(self.CRANGE206_BODY)))
+            self.send_header("Accept-Ranges", "bytes")
+            self.end_headers()
+            if self.command != "HEAD":
+                self.wfile.write(self.CRANGE206_BODY[:3000])
+                self.wfile.flush()
+                try:
+                    while True:
+                        time.sleep(3600)
+                except OSError:
+                    pass
+            return
+        if rng is not None:  # resume: text/html + matching INT64_MAX Content-Length
+            self.send_response(206, "Partial Content")
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", "9223372036854775807")
+            self.send_header(
+                "Content-Range", "bytes 0-9223372036854775806/9223372036854775807"
+            )
+            self.end_headers()
+            return  # the overflow is computed before any body read
+        # range-less refetch after the resume is rejected: whole file.
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(len(self.CRANGE206_BODY)))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(self.CRANGE206_BODY)
+
     # error pages / 0-byte files (#17): -o0 ("no error pages") must keep 4xx/5xx
     # bodies off disk; a genuine 0-byte 200 is a valid file and stays.
     def route_errpage_index(self):
@@ -1251,6 +1294,8 @@ class Handler(SimpleHTTPRequestHandler):
         "/overlap/full.bin": route_overlap_full,
         "/crange206/index.html": route_crange206_index,
         "/crange206/blob.bin": route_crange206,
+        "/crange206mem/index.html": route_crange206mem_index,
+        "/crange206mem/blob.bin": route_crange206mem,
         "/size/index.html": route_size_index,
         "/size/oversize.bin": route_size_oversize,
         "/errpage/index.html": route_errpage_index,

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -905,6 +905,51 @@ class Handler(SimpleHTTPRequestHandler):
         if self.command != "HEAD":
             self.wfile.write(part)
 
+    # C2: a resume answered with a 206 whose Content-Range end is INT64_MAX would
+    # sign-overflow the crange+1 range check (UBSan abort). Stall first (partial +
+    # ref), then answer the resume Range with that hostile 206; httrack must reject
+    # the range and refetch, never overflow.
+    CRANGE206_BODY = b"CR206DAT" + bytes((i * 5 + 1) % 256 for i in range(6000))
+    _crange206_started = False
+
+    def route_crange206_index(self):
+        self.send_html('\t<a href="blob.bin">blob</a>')
+
+    def route_crange206(self):
+        rng = self.headers.get("Range")
+        if not Handler._crange206_started:
+            Handler._crange206_started = True
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(self.CRANGE206_BODY)))
+            self.send_header("Accept-Ranges", "bytes")
+            self.end_headers()
+            if self.command != "HEAD":
+                self.wfile.write(self.CRANGE206_BODY[:3000])
+                self.wfile.flush()
+                try:
+                    while True:
+                        time.sleep(3600)
+                except OSError:
+                    pass
+            return
+        if rng is not None:  # resume: hostile 206, Content-Range end = INT64_MAX
+            self.send_response(206, "Partial Content")
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(self.CRANGE206_BODY)))
+            self.send_header("Content-Range", "bytes 0-9223372036854775807/1")
+            self.end_headers()
+            if self.command != "HEAD":
+                self.wfile.write(self.CRANGE206_BODY)
+            return
+        # range-less refetch after the bad range is rejected: whole file.
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(len(self.CRANGE206_BODY)))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(self.CRANGE206_BODY)
+
     # error pages / 0-byte files (#17): -o0 ("no error pages") must keep 4xx/5xx
     # bodies off disk; a genuine 0-byte 200 is a valid file and stays.
     def route_errpage_index(self):
@@ -1204,6 +1249,8 @@ class Handler(SimpleHTTPRequestHandler):
         "/overlap/index.html": route_overlap_index,
         "/overlap/flaky.bin": route_overlap,
         "/overlap/full.bin": route_overlap_full,
+        "/crange206/index.html": route_crange206_index,
+        "/crange206/blob.bin": route_crange206,
         "/size/index.html": route_size_index,
         "/size/oversize.bin": route_size_oversize,
         "/errpage/index.html": route_errpage_index,


### PR DESCRIPTION
Two integer-safety defects in the Content-Range and size path, both reachable from a hostile or buggy server and abort-worthy under the UBSan/OSS-Fuzz CI. A crafted `Content-Range` drives the signed int64 `crange` fields to their extremes, where the `crange +/- 1` range checks sign-overflow (undefined behavior). The parse now clamps any negative field to the zero "no range" sentinel, and the 206-resume check becomes `crange_end == crange - 1` (guarded by the preceding `crange > 0`) so an INT64_MAX end cannot overflow. On a normal two's-complement build these just wrap and the surrounding guards still reject the range, so there was never data loss; the fix is about the UB. Separately, the sizehack read the on-disk size into a 32-bit `int`, truncating it for files >= 2 GiB and letting a same-size match record a wrong size (a cache/disk metadata desync, never a truncated file); widened to `off_t` like every sibling call site.

An adversarial re-review then found a third overflow in the same 206-resume path: the in-memory branch sizes its buffer as `resume + 1 + totalsize`, and `totalsize` (Content-Length) is attacker-controlled and unclamped. A resume answered with a 206 that lies `text/html` (so it buffers in memory) plus a matching INT64_MAX Content-Length overflows the add to INT64_MAX + 1. It is rejected the same way: drop the partial and refetch.

Runtime probes: `-#test=crange` drives the parser and aborts pre-fix under UBSan on the INT64_MIN fallback; `47_local-crange-overflow` and `48_local-crange-memresume` drive the 206-resume path (INT64_MAX Content-Range end, and the in-memory buffer add) and abort pre-fix under UBSan. Found by the same conditional-request audit as #533.
