### PR TITLE
Bound the in-memory 206-resume allocation to a 32-bit size

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -3908,10 +3908,11 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                           if (fp) {
                             LLint alloc_mem = resume + 1;
 
-                            // Reject a hostile Content-Length that would
-                            // overflow the buffer size: drop the partial and
-                            // refetch.
-                            if (back[i].r.totalsize > INT64_MAX - alloc_mem) {
+                            // Bound the in-memory buffer to a 32-bit size (real
+                            // in-RAM resources are far smaller); a hostile
+                            // Content-Length that would overflow the add or the
+                            // (size_t) cast is dropped and refetched instead.
+                            if (back[i].r.totalsize > INT32_MAX - alloc_mem) {
                               url_savename_refname_remove(opt, back[i].url_adr,
                                                           back[i].url_fil);
                               UNLINK(back[i].url_sav);


### PR DESCRIPTION
CodeQL alert #46 (`cpp/uncontrolled-allocation-size`, high) flags the in-memory 206-resume buffer in `htsback.c`: `malloct(resume + 1 + totalsize)` sizes the allocation from the server's Content-Length. #534 stopped the int64 add from overflowing but left the allocation itself unbounded, and on a 32-bit build the `(size_t)` cast still truncated. This caps the buffer at `INT32_MAX` (a resource held whole in RAM is far smaller) and routes an over-large or overflowing size to the drop-and-refetch path #534 added. `48_local-crange-memresume` already drives that path.
