### PR TITLE
Bound the in-memory receive buffer against a hostile Content-Length

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -2004,6 +2004,15 @@ LLint http_xfread1(htsblk * r, int bufl) {
 
   if (bufl > 0) {
     if (!r->is_write) {         // stocker en mémoire
+      // In-memory content must fit a 32-bit size (int offsets below): reject a
+      // hostile Content-Length or endless stream instead of allocating >2 GiB.
+      const LLint inmem_want =
+          (r->totalsize >= 0) ? r->totalsize : (r->size + bufl);
+      if (inmem_want > INT32_MAX) {
+        r->statuscode = STATUSCODE_INVALID;
+        strcpybuff(r->msg, "In-memory content too large");
+        return READ_ERROR;
+      }
       if (r->totalsize >= 0) {  // totalsize déterminé ET ALLOUE
         if (r->adr == NULL) {
           r->adr = (char *) malloct((size_t) r->totalsize + 1);

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -2004,11 +2004,11 @@ LLint http_xfread1(htsblk * r, int bufl) {
 
   if (bufl > 0) {
     if (!r->is_write) {         // stocker en mémoire
-      // In-memory content must fit a 32-bit size (int offsets below): reject a
-      // hostile Content-Length or endless stream instead of allocating >2 GiB.
+      // In-memory content must fit a 32-bit index (allocs below add 1, reads
+      // use int offsets): reject a hostile Content-Length or endless stream.
       const LLint inmem_want =
           (r->totalsize >= 0) ? r->totalsize : (r->size + bufl);
-      if (inmem_want > INT32_MAX) {
+      if (inmem_want >= INT32_MAX) {
         r->statuscode = STATUSCODE_INVALID;
         strcpybuff(r->msg, "In-memory content too large");
         return READ_ERROR;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1340,6 +1340,26 @@ static int st_xfread_limit(httrackp *opt, int argc, char **argv) {
          r.msg);
   if (r.adr != NULL)
     freet(r.adr);
+
+  // Exactly at the 2 GiB index (size + bufl == INT32_MAX): must also be
+  // refused, since the reallocs below add 1 (a `> INT32_MAX` check would let
+  // this through and overflow the int realloc size).
+  memset(&r, 0, sizeof(r));
+  r.soc = INVALID_SOCKET;
+  r.totalsize = -1;
+  r.size = (LLint) INT32_MAX - 8192;
+  http_xfread1(&r, 8192);
+  printf("boundary: msg=%s\n", r.msg);
+
+  // A legitimate small size must NOT be refused by the guard (the read then
+  // fails on the invalid socket, but the size-too-large msg must not be set).
+  memset(&r, 0, sizeof(r));
+  r.soc = INVALID_SOCKET;
+  r.totalsize = 1000;
+  http_xfread1(&r, 8192);
+  printf("accept: msg=%s\n", r.msg);
+  if (r.adr != NULL)
+    freet(r.adr);
   return 0;
 }
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1310,6 +1310,39 @@ static int st_headerlong(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* http_xfread1 must refuse an in-memory buffer whose size would exceed a 32-bit
+   index (hostile Content-Length or endless stream) rather than allocate it.
+   The guard returns before any socket read, so no real connection is needed. */
+static int st_xfread_limit(httrackp *opt, int argc, char **argv) {
+  htsblk r;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+
+  // Content-Length just over 2 GiB.
+  memset(&r, 0, sizeof(r));
+  r.soc = INVALID_SOCKET;
+  r.totalsize = (LLint) INT32_MAX + 1;
+  printf("bylen: refused=%d adr=%s msg=%s\n",
+         http_xfread1(&r, 8192) == READ_ERROR, r.adr != NULL ? "alloc" : "null",
+         r.msg);
+  if (r.adr != NULL)
+    freet(r.adr);
+
+  // Unknown length, buffer already at the limit: the next read would exceed it.
+  memset(&r, 0, sizeof(r));
+  r.soc = INVALID_SOCKET;
+  r.totalsize = -1;
+  r.size = (LLint) INT32_MAX;
+  printf("bygrow: refused=%d adr=%s msg=%s\n",
+         http_xfread1(&r, 8192) == READ_ERROR, r.adr != NULL ? "alloc" : "null",
+         r.msg);
+  if (r.adr != NULL)
+    freet(r.adr);
+  return 0;
+}
+
 /* Parse a Content-Range header and print the sanitized triple. A hostile value
    (negative or INT64 extreme) must clamp to 0 without signed-overflow UB. */
 static int st_crange(httrackp *opt, int argc, char **argv) {
@@ -2521,6 +2554,8 @@ static const struct selftest_entry {
      st_headerlong},
     {"crange", "<raw-content-range-line> ...",
      "Content-Range parse integer safety", st_crange},
+    {"xfread-limit", "", "in-memory receive buffer size bound",
+     st_xfread_limit},
     {"savename", "<fil> <content-type> [key=value ...]",
      "local save-name for a URL", st_savename},
     {"sniff", "<content-type> <hex:..|text>", "MIME magic consistency",

--- a/tests/01_engine-xfread.test
+++ b/tests/01_engine-xfread.test
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# http_xfread1 must refuse an in-memory receive buffer that would exceed a
+# 32-bit index (hostile Content-Length, or an endless stream) rather than
+# allocate it. -#test=xfread-limit drives both paths.
+
+out="$(httrack -O /dev/null -#test=xfread-limit)"
+for case in bylen bygrow; do
+    echo "$out" | grep -q "${case}: refused=1 adr=null msg=In-memory content too large" || {
+        echo "FAIL ${case}: $out"
+        exit 1
+    }
+done

--- a/tests/01_engine-xfread.test
+++ b/tests/01_engine-xfread.test
@@ -5,7 +5,8 @@ set -euo pipefail
 
 # http_xfread1 must refuse an in-memory receive buffer that would exceed a
 # 32-bit index (hostile Content-Length, or an endless stream) rather than
-# allocate it. -#test=xfread-limit drives both paths.
+# allocate it, while still accepting a normal small size. -#test=xfread-limit
+# drives both refusal paths and the accept path.
 
 out="$(httrack -O /dev/null -#test=xfread-limit)"
 for case in bylen bygrow; do
@@ -14,3 +15,15 @@ for case in bylen bygrow; do
         exit 1
     }
 done
+
+# Exactly INT32_MAX must be refused too (the reallocs add 1).
+echo "$out" | grep -q 'boundary: msg=In-memory content too large' || {
+    echo "FAIL boundary: $out"
+    exit 1
+}
+
+# The guard must NOT fire for a legitimate small size.
+if echo "$out" | grep -q 'accept: msg=In-memory content too large'; then
+    echo "FAIL accept (guard fired on a legit size): $out"
+    exit 1
+fi

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -66,6 +66,7 @@ TESTS = \
 	01_engine-urlhack.test \
 	01_engine-unescape-bounds.test \
 	01_engine-useragent.test \
+	01_engine-xfread.test \
 	01_zlib-acceptencoding.test \
 	01_zlib-cache.test \
 	01_zlib-cache-corrupt.test \


### PR DESCRIPTION
httrack buffers a hypertext (non-disk) response whole in RAM in `http_xfread1`, sizing the buffer straight from the server's `Content-Length`, or growing it without limit for a chunked/unknown-length stream. The reads there already assume the buffer fits a 32-bit index (the "no 4GB html" comment, the `int` offsets), but nothing enforced it, so a hostile `text/html` with a multi-GB `Content-Length` drove an unbounded allocation on the first fetch. This rejects an in-memory size over `INT32_MAX` with a clean error.

Nothing legitimate is refused: only hypertext (HTML/JS/CSS/SVG) is held whole in RAM, and that is small. Binary content (video, archives, images) is detected by the default delayed type resolution and streamed to disk, so it never reaches this branch. This is the initial-fetch companion to #535, which bounded the same allocation on the 206-resume path. `-#test=xfread-limit` drives both the Content-Length and the stream-growth guards.
