### PR TITLE
Re-fetch a self-redirect cookie wall instead of dropping it

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -1059,10 +1059,10 @@ static int append_cookie_header(buff_struct *bstr, t_cookie *cookie,
   return cook;
 }
 
-/* Self-test entry for append_cookie_header(): build the request Cookie line
-   into dst (always NUL-terminated). Returns the number of cookies emitted. */
-int http_cookie_header_selftest(t_cookie *cookie, const char *domain,
-                                const char *path, char *dst, size_t dst_size) {
+/* Build the request Cookie line for domain/path into dst (always
+   NUL-terminated). Returns the number of cookies emitted. */
+int http_cookie_header(t_cookie *cookie, const char *domain, const char *path,
+                       char *dst, size_t dst_size) {
   buff_struct bstr = {dst, dst_size, 0};
 
   assertf(dst != NULL && dst_size > 0);

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -184,10 +184,10 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode, const char *xsend
                   const char *referer_adr, const char *referer_fil,
                   htsblk * retour);
 /* Build the request "Cookie:" header line for stored cookies matching
-   domain/path into dst (NUL-terminated). Exposed for the -#Q self-test;
-   wraps the same logic http_sendhead() uses. Returns cookies emitted. */
-int http_cookie_header_selftest(t_cookie *cookie, const char *domain,
-                                const char *path, char *dst, size_t dst_size);
+   domain/path into dst (NUL-terminated), wrapping the logic http_sendhead()
+   uses. Returns cookies emitted. */
+int http_cookie_header(t_cookie *cookie, const char *domain, const char *path,
+                       char *dst, size_t dst_size);
 
 T_SOC newhttp(httrackp * opt, const char *iadr, htsblk * retour, int port,
               int waitconnect);

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -4311,6 +4311,7 @@ int hts_wait_delayed(htsmoduleStruct * str, lien_adrfilsave *afs,
       *forbidden_url == 0 && IS_DELAYED_EXT(afs->save) && !opt->state.stop) {
     int loops;
     int continue_loop;
+    char BIGSTK jar_snapshot[sizeof(((t_cookie *) 0)->data)]; /* #15 */
 
     hts_log_print(opt, LOG_DEBUG, "Waiting for type to be known: %s%s", afs->af.adr,
                   afs->af.fil);
@@ -4319,6 +4320,10 @@ int hts_wait_delayed(htsmoduleStruct * str, lien_adrfilsave *afs,
     for(loops = 0, continue_loop = 1;
         IS_DELAYED_EXT(afs->save) && continue_loop && loops < 7; loops++) {
       continue_loop = 0;
+      /* #15: snapshot jar to detect a Set-Cookie set by a self-redirect */
+      jar_snapshot[0] = '\0';
+      if (opt->accept_cookie && opt->cookie != NULL)
+        strlcpybuff(jar_snapshot, opt->cookie->data, sizeof(jar_snapshot));
 
       /* Wait for an available slot */
       if (!hts_wait_available_socket(sback, opt, cache, ptr))
@@ -4516,6 +4521,11 @@ int hts_wait_delayed(htsmoduleStruct * str, lien_adrfilsave *afs,
           /* Moved! */
           else if (HTTP_IS_REDIRECT(back[b].r.statuscode)) {
             char BIGSTK mov_url[HTS_URLMAXSIZE * 2];
+            /* #15: raw headers are gone here, but a Set-Cookie was folded into
+             * the jar; a changed jar is the cookie-wall signal. */
+            const hts_boolean jar_changed =
+                opt->accept_cookie && opt->cookie != NULL &&
+                strcmp(jar_snapshot, opt->cookie->data) != 0;
 
             mov_url[0] = '\0';
             strcpybuff(mov_url, back[b].r.location);    // copier URL
@@ -4585,11 +4595,24 @@ int hts_wait_delayed(htsmoduleStruct * str, lien_adrfilsave *afs,
                   url_savename(afs, former, heap(ptr)->adr, heap(ptr)->fil, 
                                opt, sback, cache, hash, ptr, numero_passe,
                                &delayed_back);
+                } else if (jar_changed) {
+                  // #15: cookie-wall self-redirect; evict the cached
+                  // fast-header so the re-issue refetches with the cookie.
+                  if (cache->cached_tests != NULL)
+                    coucal_remove(cache->cached_tests,
+                                  concat(OPT_GET_BUFF(opt),
+                                         OPT_GET_BUFF_SIZE(opt), afs->af.adr,
+                                         afs->af.fil));
+                  afs->save[0] = '\0';
+                  url_savename(afs, former, heap(ptr)->adr, heap(ptr)->fil, opt,
+                               sback, cache, hash, ptr, numero_passe,
+                               &delayed_back);
+                  continue_loop = 1;
                 } else {
                   hts_log_print(opt, LOG_WARNING,
                                 "Unable to test %s%s (loop to same filename)",
                                 afs->af.adr, afs->af.fil);
-                }               // loop to same location
+                } // loop to same location
               }                 // ident_url_relatif()
             }                   // location
           }                     // redirect

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -4311,7 +4311,8 @@ int hts_wait_delayed(htsmoduleStruct * str, lien_adrfilsave *afs,
       *forbidden_url == 0 && IS_DELAYED_EXT(afs->save) && !opt->state.stop) {
     int loops;
     int continue_loop;
-    char BIGSTK jar_snapshot[sizeof(((t_cookie *) 0)->data)]; /* #15 */
+    char BIGSTK
+        cookie_before[16384]; /* #15: this URL's Cookie header, pre-request */
 
     hts_log_print(opt, LOG_DEBUG, "Waiting for type to be known: %s%s", afs->af.adr,
                   afs->af.fil);
@@ -4320,10 +4321,12 @@ int hts_wait_delayed(htsmoduleStruct * str, lien_adrfilsave *afs,
     for(loops = 0, continue_loop = 1;
         IS_DELAYED_EXT(afs->save) && continue_loop && loops < 7; loops++) {
       continue_loop = 0;
-      /* #15: snapshot jar to detect a Set-Cookie set by a self-redirect */
-      jar_snapshot[0] = '\0';
+      /* #15: snapshot the Cookie header THIS url would send, so only its own
+         self-redirect Set-Cookie trips the retry, not a concurrent slot's. */
+      cookie_before[0] = '\0';
       if (opt->accept_cookie && opt->cookie != NULL)
-        strlcpybuff(jar_snapshot, opt->cookie->data, sizeof(jar_snapshot));
+        http_cookie_header(opt->cookie, jump_identification_const(afs->af.adr),
+                           afs->af.fil, cookie_before, sizeof(cookie_before));
 
       /* Wait for an available slot */
       if (!hts_wait_available_socket(sback, opt, cache, ptr))
@@ -4521,11 +4524,17 @@ int hts_wait_delayed(htsmoduleStruct * str, lien_adrfilsave *afs,
           /* Moved! */
           else if (HTTP_IS_REDIRECT(back[b].r.statuscode)) {
             char BIGSTK mov_url[HTS_URLMAXSIZE * 2];
-            /* #15: raw headers are gone here, but a Set-Cookie was folded into
-             * the jar; a changed jar is the cookie-wall signal. */
-            const hts_boolean jar_changed =
-                opt->accept_cookie && opt->cookie != NULL &&
-                strcmp(jar_snapshot, opt->cookie->data) != 0;
+            char BIGSTK cookie_after[16384];
+            hts_boolean cookies_changed;
+
+            /* #15: cookie-wall signal: this URL's own Cookie header changed
+               across its self-redirect (a Set-Cookie it just set). */
+            cookie_after[0] = '\0';
+            if (opt->accept_cookie && opt->cookie != NULL)
+              http_cookie_header(
+                  opt->cookie, jump_identification_const(afs->af.adr),
+                  afs->af.fil, cookie_after, sizeof(cookie_after));
+            cookies_changed = strcmp(cookie_before, cookie_after) != 0;
 
             mov_url[0] = '\0';
             strcpybuff(mov_url, back[b].r.location);    // copier URL
@@ -4595,7 +4604,7 @@ int hts_wait_delayed(htsmoduleStruct * str, lien_adrfilsave *afs,
                   url_savename(afs, former, heap(ptr)->adr, heap(ptr)->fil, 
                                opt, sback, cache, hash, ptr, numero_passe,
                                &delayed_back);
-                } else if (jar_changed) {
+                } else if (cookies_changed) {
                   // #15: cookie-wall self-redirect; evict the cached
                   // fast-header so the re-issue refetches with the cookie.
                   if (cache->cached_tests != NULL)

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1755,7 +1755,7 @@ static int st_cookies(httrackp *opt, int argc, char **argv) {
     return 1;
   }
 
-  http_cookie_header_selftest(&cookie, dom, "/", hdr, sizeof(hdr));
+  http_cookie_header(&cookie, dom, "/", hdr, sizeof(hdr));
   if (strcmp(hdr, expected) != 0)
     err = 1;
   if (strstr(hdr, "$Version") != NULL || strstr(hdr, "$Path") != NULL)

--- a/tests/49_local-cookiewall.test
+++ b/tests/49_local-cookiewall.test
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Cookie-wall self-redirect (#15): a page 302s to itself with a Set-Cookie;
+# httrack must replay the cookie and mirror the real page (unknown- and known-ext).
+
+set -euo pipefail
+
+: "${top_srcdir:=..}"
+
+bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
+    --found 'cookiewall/wall.html' \
+    --file-matches 'cookiewall/wall.html' 'REAL-CONTENT-BEHIND-COOKIE-WALL' \
+    httrack 'BASEURL/cookiewall/index.html'
+
+bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
+    --found 'cookiewall2/wall.html' \
+    --file-matches 'cookiewall2/wall.html' 'REAL-CONTENT-BEHIND-COOKIE-WALL' \
+    httrack 'BASEURL/cookiewall2/index.html'

--- a/tests/49_local-cookiewall.test
+++ b/tests/49_local-cookiewall.test
@@ -1,12 +1,14 @@
 #!/bin/bash
 #
-# Cookie-wall self-redirect (#15): a page 302s to itself with a Set-Cookie;
-# httrack must replay the cookie and mirror the real page (unknown- and known-ext).
+# Cookie-wall self-redirect (#15): httrack replays a Set-Cookie to mirror the
+# real page, gives up when nothing changes, and stays bounded when it never does.
 
 set -euo pipefail
 
 : "${top_srcdir:=..}"
 
+# Unknown-ext (wall.php) and known-ext (wall.html): the wall sets the cookie once,
+# then serves real content; httrack must replay it and mirror that content.
 bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
     --found 'cookiewall/wall.html' \
     --file-matches 'cookiewall/wall.html' 'REAL-CONTENT-BEHIND-COOKIE-WALL' \
@@ -16,3 +18,17 @@ bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
     --found 'cookiewall2/wall.html' \
     --file-matches 'cookiewall2/wall.html' 'REAL-CONTENT-BEHIND-COOKIE-WALL' \
     httrack 'BASEURL/cookiewall2/index.html'
+
+# No Set-Cookie: the jar never changes, so httrack must give up at once (retry
+# stays gated) and not mirror the wall. A dropped gate would skip this log line.
+bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
+    --not-found 'cookiewall3/wall.html' \
+    --log-found 'loop to same filename' \
+    httrack 'BASEURL/cookiewall3/index.html'
+
+# Ever-changing cookie never satisfies the wall: httrack must stop at the retry
+# cap (bounded, no early give-up) and not mirror it.
+bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
+    --not-found 'cookiewall4/wall.html' \
+    --log-not-found 'loop to same filename' \
+    httrack 'BASEURL/cookiewall4/index.html'

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -119,6 +119,7 @@ TESTS = \
 	45_local-maxsize-recv.test \
 	46_local-update-304-resume.test \
 	47_local-crange-overflow.test \
-	48_local-crange-memresume.test
+	48_local-crange-memresume.test \
+	49_local-cookiewall.test
 
 CLEANFILES = check-network_sh.cache

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1143,6 +1143,35 @@ class Handler(SimpleHTTPRequestHandler):
     def route_delayed_empty(self):
         self.send_raw(b"", "text/html")  # 200 + Content-Length: 0
 
+    # --- /cookiewall/ (#15): a self-redirect that only sets a cookie is a
+    # consent wall; httrack must replay the cookie and fetch the real page.
+    WALL_MARK = b"REAL-CONTENT-BEHIND-COOKIE-WALL"
+
+    def route_cookiewall_index(self):
+        self.send_html('\t<a href="wall.php">wall</a>')
+
+    def route_cookiewall_wall(self):
+        self._cookiewall_reply("wall.php")
+
+    # Known-extension twin: .html so the type is not delayed-resolved.
+    def route_cookiewall2_index(self):
+        self.send_html('\t<a href="wall.html">wall</a>')
+
+    def route_cookiewall2_wall(self):
+        self._cookiewall_reply("wall.html")
+
+    def _cookiewall_reply(self, location):
+        if self.request_cookies().get("gate") == "1":
+            self.send_raw(
+                b"<html><body>" + self.WALL_MARK + b"</body></html>\n", "text/html"
+            )
+        else:
+            self.send_response(302, "Found")
+            self.send_header("Location", location)
+            self.send_header("Set-Cookie", "gate=1; Path=/")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
     # -E time-limit (#481): pages that trickle far longer than any -E budget,
     # so only an engine-side abort can end the crawl.
     TRICKLE_SECONDS = 60
@@ -1359,6 +1388,10 @@ class Handler(SimpleHTTPRequestHandler):
         "/delayed/chain7.php": route_delayed_chain,
         "/delayed/chain8.php": route_delayed_chain,
         "/delayed/chain9.php": route_delayed_chain,
+        "/cookiewall/index.html": route_cookiewall_index,
+        "/cookiewall/wall.php": route_cookiewall_wall,
+        "/cookiewall2/index.html": route_cookiewall2_index,
+        "/cookiewall2/wall.html": route_cookiewall2_wall,
         "/redir/index.html": route_redir_index,
         "/redir/go.php": route_redir_go,
         "/redir/target.html": route_redir_target,

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1166,11 +1166,32 @@ class Handler(SimpleHTTPRequestHandler):
                 b"<html><body>" + self.WALL_MARK + b"</body></html>\n", "text/html"
             )
         else:
-            self.send_response(302, "Found")
-            self.send_header("Location", location)
-            self.send_header("Set-Cookie", "gate=1; Path=/")
-            self.send_header("Content-Length", "0")
-            self.end_headers()
+            self._wall_redirect(location, "gate=1; Path=/")
+
+    # No-cookie self-redirect: the jar never changes, so httrack must give up at
+    # once rather than re-fetch (proves the cookie-wall retry stays gated on #15).
+    def route_cookiewall3_index(self):
+        self.send_html('\t<a href="wall.php">wall</a>')
+
+    def route_cookiewall3_wall(self):
+        self._wall_redirect("wall.php", None)
+
+    # Ever-changing cookie: every hit sets a fresh value, so the jar keeps
+    # changing; httrack must stop at the loops<7 cap, not spin forever.
+    def route_cookiewall4_index(self):
+        self.send_html('\t<a href="wall.php">wall</a>')
+
+    def route_cookiewall4_wall(self):
+        nonce = int(self.request_cookies().get("gate", "0")) + 1
+        self._wall_redirect("wall.php", f"gate={nonce}; Path=/")
+
+    def _wall_redirect(self, location, set_cookie):
+        self.send_response(302, "Found")
+        self.send_header("Location", location)
+        if set_cookie is not None:
+            self.send_header("Set-Cookie", set_cookie)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
 
     # -E time-limit (#481): pages that trickle far longer than any -E budget,
     # so only an engine-side abort can end the crawl.
@@ -1392,6 +1413,10 @@ class Handler(SimpleHTTPRequestHandler):
         "/cookiewall/wall.php": route_cookiewall_wall,
         "/cookiewall2/index.html": route_cookiewall2_index,
         "/cookiewall2/wall.html": route_cookiewall2_wall,
+        "/cookiewall3/index.html": route_cookiewall3_index,
+        "/cookiewall3/wall.php": route_cookiewall3_wall,
+        "/cookiewall4/index.html": route_cookiewall4_index,
+        "/cookiewall4/wall.php": route_cookiewall4_wall,
         "/redir/index.html": route_redir_index,
         "/redir/go.php": route_redir_go,
         "/redir/target.html": route_redir_target,


### PR DESCRIPTION
A page that 302-redirects to itself just to set a cookie, a consent or session "cookie wall", was silently lost. HTTrack's self-redirect guard treated the loop as a misbehaving server and never re-issued the request, so the real content behind the cookie never reached the mirror. Issue #15, filed in 2013.

The redirect's `Set-Cookie` is already folded into the shared cookie jar by the time the guard runs, so a re-issued request would carry it; the engine just never issued one. The delayed-type loop (`hts_wait_delayed`) snapshots the Cookie header this URL would send, and when its own self-redirect changes that header, evicts the cached fast-header for the URL and re-fetches once with the new cookie. Scoping the compare to the URL means a concurrent fetch of another host cannot trip it. Termination is bounded: the header stops changing once the cookie is satisfied, so a real wall resolves in two requests, and the existing `loops < 7` cap backstops a server that mints a fresh cookie on every hit. No struct, ABI, or cache-format change; the trigger is a per-URL cookie-header diff plus the fast-header eviction.

Under the default delayed-type mode (`-%N2`, HARD) every URL routes through this loop, so both dynamic (`wall.php`) and static-looking (`wall.html`) walls are covered. A wall reached only after opting out with `-%N0`/`-%N1` still takes the `hts_mirror_check_moved` path, which cannot see the `Set-Cookie` there without an ABI change; that narrow case is left as a known limitation. The redirect-to-a-different-already-crawled-page variant is a separate, deferred follow-up.

Verified at runtime with a cookie-wall test server: a real wall is captured in two requests, an always-redirecting adversary stops at the loop cap, and reverting only the engine change makes the new test fail.

Closes #15.
