### PR TITLE
Raise the test server listen backlog to stop macOS bigcrawl flakes

### DIFF
--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1645,7 +1645,12 @@ def main():
     def factory(*a, **kw):
         return Handler(*a, directory=root, **kw)
 
-    httpd = ThreadingHTTPServer((args.bind, 0), factory)
+    # macOS/BSD drop SYNs when the listen backlog overflows (Linux is lenient);
+    # raise it from Python's default 5 so a busy -c8 crawl can't lose fetches.
+    class BacklogHTTPServer(ThreadingHTTPServer):
+        request_queue_size = 128
+
+    httpd = BacklogHTTPServer((args.bind, 0), factory)
 
     if args.tls:
         import ssl


### PR DESCRIPTION
`36_local-bigcrawl` flakes on macOS CI: its exact file count drops (e.g. 361 to 283) and the test fails. The cause is our test server, not the crawl. `local-server.py` is a plain `ThreadingHTTPServer` and inherits Python's default listen backlog of 5. macOS and BSD drop SYNs when the accept queue overflows, while Linux shrugs off a small backlog, so the same server that never flakes on Linux loses connections on macOS. With `--retries=0`, a dropped connection is a permanently lost file. Under a parallel `make check` the single-threaded accept loop is starved for CPU, drains the 5-slot queue slowly, and an `-c8` burst overflows it.

Raising `request_queue_size` to 128 leaves plenty of headroom for the 8 connections `-c8` opens, even when the accept loop stalls briefly. `-c8` is unchanged, so Linux keeps full concurrency coverage at no cost.

This only reproduces on macOS (Linux tolerates any backlog, so it can't be triggered locally), so I want to watch several macOS CI runs before calling it fixed. If it holds, the macOS "run bigcrawl alone in a second pass" workaround can probably be reverted as a follow-up.
