### PR TITLE
Un-isolate bigcrawl on macOS and bump it to -c16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,15 +136,9 @@ jobs:
         run: make -j"$(sysctl -n hw.ncpu)"
 
       - name: Test
-        # bigcrawl's sustained -c8 crawl drops fetches on macOS's loopback when
-        # it competes with other crawls, flaking its exact file count (the #527
-        # macOS drop). Run everything else in parallel, then bigcrawl alone (its
-        # serial-safe condition). Linux tolerates the full parallel run.
         run: |
           jobs=$(( $(sysctl -n hw.ncpu) * 2 )); [ "$jobs" -le 16 ] || jobs=16
-          rest=$(cd tests && ls *.test | grep -v '^36_local-bigcrawl\.test$' | tr '\n' ' ')
-          make check -j"$jobs" TESTS="$rest"
-          make check TESTS=36_local-bigcrawl.test
+          make check -j"$jobs"
 
       - name: Print the test log on failure
         if: failure()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,10 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   automatically; only a test slower than the current longest raises the floor.
   On a few-core Linux box, `-j` at 2x the core count is faster still: the tests
   spend much of their wall time asleep (server trickles, httrack self-pacing),
-  so an idle core covers a sleeping one. CI uses `min(2*cores, 16)`. macOS runs
-  36_local-bigcrawl alone in a second pass: its sustained `-c8` crawl overloads
-  the macOS loopback when it competes with other crawls and flakes its exact
-  file count (Linux tolerates the full parallel run).
+  so an idle core covers a sleeping one. CI uses `min(2*cores, 16)` on every
+  platform, macOS included: the test server raises its listen backlog
+  (`request_queue_size`) so macOS/BSD don't drop connections under a parallel
+  `-c16` bigcrawl the way Python's default backlog of 5 did.
   Or run `sh build.sh` to do bootstrap + configure + make in one shot.
 
 ## Hard invariants

--- a/tests/36_local-bigcrawl.test
+++ b/tests/36_local-bigcrawl.test
@@ -53,4 +53,4 @@ bash "$top_srcdir/tests/local-crawl.sh" --rerun \
     --log-found ', no files updated' \
     --max-mirror-bytes 700000 \
     --min-mirror-bytes 500000 \
-    httrack 'BASEURL/big/index.html' --retries=0 -c8 -%c100 -A100000000
+    httrack 'BASEURL/big/index.html' --retries=0 -c16 -%c100 -A100000000


### PR DESCRIPTION
With #538's listen-backlog fix in place, the actual cause of the macOS bigcrawl file-count flake is gone (Python's default 5-slot accept queue overflowed under parallel CPU contention, and macOS drops SYNs on overflow). Two follow-ups fall out.

macOS no longer needs the "run `36_local-bigcrawl` alone in a second pass" workaround, so its Test step runs the full suite in parallel like Linux.

The crawl can also open more connections now: `-c8` becomes `-c16`. Locally that trims bigcrawl about 14% (33.4s to 28.6s; the `-%c100` establishment-rate cap holds back the rest) and stresses the engine harder. 128 backlog slots hold 16 connections easily.

Un-isolating and `-c16` both lean harder on the path #538 fixed, so I'll watch several macOS runs before calling it good.
