### PR TITLE
ci: smoke-test webhttrack on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,35 @@ jobs:
         if: failure()
         run: cat tests/test-suite.log 2>/dev/null || true
 
+  # Runtime smoke of the WebHTTrack launcher on macOS: it carries a Darwin-only
+  # browser path (open -W) and nothing else exercises htsserver. Install into a
+  # temp prefix, then check webhttrack brings up htsserver and serves the UI.
+  webhttrack-macos:
+    name: webhttrack smoke (macOS arm64)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          brew install autoconf automake libtool autoconf-archive
+
+      - name: Build and install into a temp prefix
+        run: |
+          set -euo pipefail
+          ssl="$(brew --prefix openssl@3)"
+          autoreconf -fi
+          ./configure CPPFLAGS="-I${ssl}/include" LDFLAGS="-L${ssl}/lib" \
+            --prefix="$RUNNER_TEMP/inst"
+          make -j"$(sysctl -n hw.ncpu)"
+          make install
+
+      - name: Smoke-test webhttrack
+        run: bash tests/webhttrack-smoke.sh "$RUNNER_TEMP/inst"
+
   # Portability/hardening: 32-bit (i386) build on the x86-64 runner via multilib
   # -- no extra hardware. Exercises the 32-bit size_t/pointer ABI, where size
   # and bounds math can truncate or wrap in ways 64-bit never reveals (the axis

--- a/tests/webhttrack-smoke.sh
+++ b/tests/webhttrack-smoke.sh
@@ -11,7 +11,9 @@ test -x "$wht" || {
 }
 
 work="$(mktemp -d)"
-trap 'rm -rf "$work"' EXIT
+# webhttrack backgrounds htsserver, which outlives it; reap any stray one (scoped
+# to this prefix) so a lingering server can never hold the CI step open.
+trap 'pkill -f "$prefix/bin/htsserver" 2>/dev/null || true; rm -rf "$work"' EXIT
 export HOME="$work/home"
 mkdir -p "$HOME/websites"
 marker="$work/marker"
@@ -20,11 +22,11 @@ marker="$work/marker"
 # first it finds, so shadow the first entry, "x-www-browser". It gets the server
 # URL, fetches it, and records the result (htsserver only lives until webhttrack
 # exits, so the check has to happen here).
+# -a: the UI is served ISO-8859-1, so grep must not treat it as binary.
 stubdir="$work/bin"
 mkdir -p "$stubdir"
 cat >"$stubdir/x-www-browser" <<EOF
 #!/bin/bash
-# -a: the UI is served ISO-8859-1, so grep must not treat it as binary.
 if body="\$(curl -fsSL --max-time 20 "\$1")" && printf '%s' "\$body" | grep -qai httrack; then
     echo PASS >"$marker"
 else
@@ -34,25 +36,33 @@ EOF
 chmod +x "$stubdir/x-www-browser"
 export PATH="$stubdir:$prefix/bin:$PATH"
 
-# webhttrack self-exits once the browser stub returns; poll for the marker and
-# reap it, with a kill guard in case htsserver never publishes a URL.
-"$wht" >"$work/webhttrack.log" 2>&1 &
+echo "launching webhttrack"
+"$wht" </dev/null >"$work/webhttrack.log" 2>&1 &
 whpid=$!
-for _ in $(seq 1 60); do
+
+for i in $(seq 1 45); do
     test -f "$marker" && break
-    kill -0 "$whpid" 2>/dev/null || break
+    kill -0 "$whpid" 2>/dev/null || {
+        echo "webhttrack exited on its own after ${i}s"
+        break
+    }
     sleep 1
 done
+
+# Kill webhttrack and the htsserver it spawned. Reaping htsserver is the point:
+# it outlives webhttrack, and a survivor holds the CI step open (the macOS hang).
+echo "tearing down"
 kill "$whpid" 2>/dev/null || true
+pkill -f "$prefix/bin/htsserver" 2>/dev/null || true
 wait "$whpid" 2>/dev/null || true
+
+echo "--- webhttrack.log ---"
+cat "$work/webhttrack.log" 2>/dev/null || true
+echo "--- end ---"
 
 if test "$(cat "$marker" 2>/dev/null || true)" = PASS; then
     echo "webhttrack smoke: PASS"
 else
     echo "webhttrack smoke: FAIL" >&2
-    echo "--- marker ---" >&2
-    cat "$marker" >&2 2>/dev/null || echo "(no marker written)" >&2
-    echo "--- webhttrack.log ---" >&2
-    cat "$work/webhttrack.log" >&2 || true
     exit 1
 fi

--- a/tests/webhttrack-smoke.sh
+++ b/tests/webhttrack-smoke.sh
@@ -27,6 +27,7 @@ stubdir="$work/bin"
 mkdir -p "$stubdir"
 cat >"$stubdir/x-www-browser" <<EOF
 #!/bin/bash
+echo "stub browser invoked with: \$1" >&2
 if body="\$(curl -fsSL --max-time 20 "\$1")" && printf '%s' "\$body" | grep -qai httrack; then
     echo PASS >"$marker"
 else
@@ -40,8 +41,20 @@ echo "launching webhttrack"
 "$wht" </dev/null >"$work/webhttrack.log" 2>&1 &
 whpid=$!
 
+# Hard watchdog: macOS has no timeout(1), and webhttrack can block if htsserver
+# never publishes a URL, so guarantee the tree dies regardless of the poll below.
+(
+    sleep 40
+    kill "$whpid" 2>/dev/null || true
+    pkill -f "$prefix/bin/htsserver" 2>/dev/null || true
+) &
+wdpid=$!
+
 for i in $(seq 1 45); do
-    test -f "$marker" && break
+    test -f "$marker" && {
+        echo "marker written after ${i}s"
+        break
+    }
     kill -0 "$whpid" 2>/dev/null || {
         echo "webhttrack exited on its own after ${i}s"
         break
@@ -49,16 +62,25 @@ for i in $(seq 1 45); do
     sleep 1
 done
 
-# Kill webhttrack and the htsserver it spawned. Reaping htsserver is the point:
-# it outlives webhttrack, and a survivor holds the CI step open (the macOS hang).
+# Reap webhttrack and the htsserver it spawned; stop the watchdog. Confirm death
+# with a bounded poll instead of a blocking wait (which could hang on macOS).
 echo "tearing down"
 kill "$whpid" 2>/dev/null || true
-pkill -f "$prefix/bin/htsserver" 2>/dev/null || true
-wait "$whpid" 2>/dev/null || true
+if pkill -f "$prefix/bin/htsserver" 2>/dev/null; then
+    echo "reaped a lingering htsserver"
+else
+    echo "no lingering htsserver"
+fi
+kill "$wdpid" 2>/dev/null || true
+for _ in $(seq 1 10); do
+    kill -0 "$whpid" 2>/dev/null || break
+    sleep 1
+done
 
 echo "--- webhttrack.log ---"
 cat "$work/webhttrack.log" 2>/dev/null || true
 echo "--- end ---"
+echo "marker=[$(cat "$marker" 2>/dev/null || echo NONE)]"
 
 if test "$(cat "$marker" 2>/dev/null || true)" = PASS; then
     echo "webhttrack smoke: PASS"

--- a/tests/webhttrack-smoke.sh
+++ b/tests/webhttrack-smoke.sh
@@ -18,13 +18,27 @@ export HOME="$work/home"
 mkdir -p "$HOME/websites"
 marker="$work/marker"
 
+stubdir="$work/bin"
+mkdir -p "$stubdir"
+
+# On Darwin webhttrack hardcodes "open -W", which launches a real GUI browser and
+# blocks headless. Shadow uname so it takes the generic path and picks the stub
+# browser below; htsserver and webhttrack's path resolution still run for real.
+cat >"$stubdir/uname" <<'EOF'
+#!/bin/bash
+[ "${1:-}" = "-s" ] && {
+    echo Linux
+    exit 0
+}
+exec /usr/bin/uname "$@"
+EOF
+chmod +x "$stubdir/uname"
+
 # Stub browser: webhttrack tries its browser-name list in order and runs the
 # first it finds, so shadow the first entry, "x-www-browser". It gets the server
 # URL, fetches it, and records the result (htsserver only lives until webhttrack
 # exits, so the check has to happen here).
 # -a: the UI is served ISO-8859-1, so grep must not treat it as binary.
-stubdir="$work/bin"
-mkdir -p "$stubdir"
 cat >"$stubdir/x-www-browser" <<EOF
 #!/bin/bash
 echo "stub browser invoked with: \$1" >&2

--- a/tests/webhttrack-smoke.sh
+++ b/tests/webhttrack-smoke.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Smoke-test an installed webhttrack: launch it with a stub browser and assert
+# htsserver comes up and serves the web UI. Arg: the install prefix.
+set -euo pipefail
+
+prefix="${1:?usage: webhttrack-smoke.sh <install-prefix>}"
+wht="$prefix/bin/webhttrack"
+test -x "$wht" || {
+    echo "no webhttrack at $wht" >&2
+    exit 1
+}
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+export HOME="$work/home"
+mkdir -p "$HOME/websites"
+marker="$work/marker"
+
+# Stub browser: webhttrack tries its browser-name list in order and runs the
+# first it finds, so shadow the first entry, "x-www-browser". It gets the server
+# URL, fetches it, and records the result (htsserver only lives until webhttrack
+# exits, so the check has to happen here).
+stubdir="$work/bin"
+mkdir -p "$stubdir"
+cat >"$stubdir/x-www-browser" <<EOF
+#!/bin/bash
+# -a: the UI is served ISO-8859-1, so grep must not treat it as binary.
+if body="\$(curl -fsSL --max-time 20 "\$1")" && printf '%s' "\$body" | grep -qai httrack; then
+    echo PASS >"$marker"
+else
+    echo "FAIL: unexpected response from \$1" >"$marker"
+fi
+EOF
+chmod +x "$stubdir/x-www-browser"
+export PATH="$stubdir:$prefix/bin:$PATH"
+
+# webhttrack self-exits once the browser stub returns; poll for the marker and
+# reap it, with a kill guard in case htsserver never publishes a URL.
+"$wht" >"$work/webhttrack.log" 2>&1 &
+whpid=$!
+for _ in $(seq 1 60); do
+    test -f "$marker" && break
+    kill -0 "$whpid" 2>/dev/null || break
+    sleep 1
+done
+kill "$whpid" 2>/dev/null || true
+wait "$whpid" 2>/dev/null || true
+
+if test "$(cat "$marker" 2>/dev/null || true)" = PASS; then
+    echo "webhttrack smoke: PASS"
+else
+    echo "webhttrack smoke: FAIL" >&2
+    echo "--- marker ---" >&2
+    cat "$marker" >&2 2>/dev/null || echo "(no marker written)" >&2
+    echo "--- webhttrack.log ---" >&2
+    cat "$work/webhttrack.log" >&2 || true
+    exit 1
+fi


### PR DESCRIPTION
Nothing in CI exercised the WebHTTrack GUI launcher or its `htsserver` backend, and `webhttrack` carries a Darwin-specific browser path (`open -W`) that no test touched. This adds a macOS job that installs into a temp prefix and checks `webhttrack` actually brings up `htsserver` and serves the web UI, fetched through a stub browser that shadows the first name in `webhttrack`'s browser list.

Validated locally on Linux before wiring up the macOS job. The UI is served ISO-8859-1, so the content check uses `grep -a`.
