### PR TITLE
Fix one-byte fil[] overflow in ident_url_absolute on hostless `?`-URLs

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -2575,6 +2575,11 @@ int ident_url_absolute(const char *url, lien_adrfil *adrfil) {
     // recopier adrfil->adresse www..
     strncatbuff(adrfil->adr, p, ((int) (q - p)));
     // *( adrfil->adr+( ((int) q) - ((int) p) ) )=0;  // faut arrêter la fumette!
+
+    // fil[] holds the path plus a possible leading '/' the top strlen() misses.
+    if (strlen(q) >= sizeof(adrfil->fil) - (q[0] != '/' ? 1 : 0))
+      return -1;
+
     // recopier chemin /pub/..
     if (q[0] != '/')            // page par défaut (/)
       strcatbuff(adrfil->fil, "/");

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1266,6 +1266,30 @@ static int st_identurl(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* Regression for the one-byte fil[] overflow: a 2047-byte hostless "?"-URL used
+   to abort in strncat_safe_ when the missing leading '/' pushed fil to 2048. */
+static int st_identabs(httrackp *opt, int argc, char **argv) {
+  lien_adrfil af;
+  const size_t len =
+      sizeof(af.fil) - 1; /* 2047: max URL the top guard admits */
+  char *url = malloct(len + 1);
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+  url[0] = '?';
+  memset(url + 1, 'a', len - 1);
+  url[len] = '\0';
+  assertf(ident_url_absolute(url, &af) == -1);
+  freet(url);
+  /* valid URLs still parse, so the guard is not over-rejecting */
+  assertf(ident_url_absolute("http://www.example.com/a/b/c.html?x=1", &af) ==
+          0);
+  assertf(ident_url_absolute("www.foo.com?bar=1", &af) == 0);
+  printf("identabs self-test OK\n");
+  return 0;
+}
+
 /* Extra args are key=value: adr= cdispo= statuscode= status= strip= urlhack=
    no-www= no-slash= no-query= n83= type=, plus repeatable prior=adr|fil|sav
    registering an already-crawled link (dedup/collision paths). */
@@ -2567,6 +2591,8 @@ static const struct selftest_entry {
     {"resolve", "<link> <adr> <fil>", "resolve a link against an origin",
      st_resolve},
     {"identurl", "<url>", "split an absolute URL into (adr, fil)", st_identurl},
+    {"identabs", "", "ident_url_absolute one-byte fil[] overflow self-test",
+     st_identabs},
     {"header", "<raw-header-line> ...", "response header-line parsing",
      st_header},
     {"headerlong", "[header-name:]",

--- a/tests/01_engine-identabs.test
+++ b/tests/01_engine-identabs.test
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# A 2047-byte hostless "?"-URL used to overflow fil[] by one byte and abort in
+# strncat_safe_; the guard now returns -1 while valid URLs still parse.
+test "$(httrack -O /dev/null -#test=identabs)" == "identabs self-test OK" || exit 1

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -44,6 +44,7 @@ TESTS = \
 	01_engine-header.test \
 	01_engine-idna.test \
 	01_engine-identurl.test \
+	01_engine-identabs.test \
 	01_engine-escape-room.test \
 	01_engine-inplace-escape.test \
 	01_engine-java.test \


### PR DESCRIPTION
OSS-Fuzz caught an abort in `ident_url_absolute`: the `strncat_safe_` bounds check fired on a one-byte overflow of the 2048-byte `fil[]` path buffer. URLs of 2048 bytes or more are already rejected, so the path suffix is at most 2047 bytes. But when the path has no leading slash, one gets prepended before the copy, pushing the result to exactly 2048. A hostless URL starting with `?` and 2047 bytes long reaches that copy before the empty-host check at the end of the function rejects it. The guard now subtracts the possible slash from the limit and returns -1 for those inputs, leaving valid URLs untouched. A `-#test` self-test feeds the 2047-byte trigger and asserts a clean -1.