### PR TITLE
Bound strjoker recursion depth and work to stop OSS-Fuzz stack-overflow and timeout

### DIFF
--- a/src/htsfilters.c
+++ b/src/htsfilters.c
@@ -121,12 +121,18 @@ int fa_strjoker_dual(int type, char **filters, int nfil, const char *nom1,
   return use1 ? jok1 : jok2;
 }
 
+/* Real filters/URLs fit HTS_URLMAXSIZE*2; past it a hostile pattern recurses
+   O(len) deep or runs O(n^2*stars). Cap length (depth) and steps (work). */
+#define STRJOKER_MAXLEN (HTS_URLMAXSIZE * 2)
+#define STRJOKER_MAXSTEPS 2000000u
+
 /* Failure memo for the recursive matcher: one bit per (chaine, joker) offset
    pair keeps star-heavy patterns polynomial instead of exponential (#501). */
 typedef struct strjoker_memo {
   const char *chaine0, *joker0; /* offsets are relative to these bases */
   size_t stride;                /* strlen(joker0) + 1 */
   unsigned char *failed;        /* failed-pair bitmap; NULL: no memo */
+  size_t *nsteps; /* shared work counter; NULL: unbounded (oracle) */
 } strjoker_memo;
 
 static const char *strjoker_impl(const strjoker_memo *memo, const char *chaine,
@@ -141,6 +147,8 @@ static const char *strjoker_rec(const strjoker_memo *memo, const char *chaine,
   size_t bit = 0;
   const char *adr;
 
+  if (memo->nsteps != NULL && ++*memo->nsteps > STRJOKER_MAXSTEPS)
+    return NULL; /* work budget spent: fail the match safely */
   if (memo->failed) {
     bit = (size_t) (chaine - memo->chaine0) * memo->stride +
           (size_t) (joker - memo->joker0);
@@ -153,22 +161,24 @@ static const char *strjoker_rec(const strjoker_memo *memo, const char *chaine,
   return adr;
 }
 
-// wildcard comparator: match chaine against joker (pattern), case-insensitive
-// returns the address of the first matched letter past any leading joker
-// (ie. *[..]toto.. returns the address of toto within chaine), NULL on mismatch
-HTS_INLINE const char *strjoker(const char *chaine, const char *joker,
-                                LLint *size, int *size_flag) {
-  strjoker_memo memo = {chaine, joker, 0, NULL};
+/* Match chaine against joker with a shared work budget *nsteps (a strjokerfind
+   sweep passes one counter, bounding the whole scan). */
+static const char *strjoker_bounded(const char *chaine, const char *joker,
+                                    LLint *size, int *size_flag,
+                                    size_t *nsteps) {
+  strjoker_memo memo = {chaine, joker, 0, NULL, nsteps};
   unsigned char stackbits[2048];
   hts_boolean onheap = HTS_FALSE;
   const char *adr;
 
   if (chaine != NULL && joker != NULL) {
-    const size_t n1 = strlen(chaine) + 1;
+    const size_t l1 = strlen(chaine), l2 = strlen(joker);
 
-    memo.stride = strlen(joker) + 1;
-    if (n1 <= (SIZE_MAX - 7) / memo.stride) { // overflow-safe bitmap size
-      const size_t bytes = (n1 * memo.stride + 7) / 8;
+    if (l1 > STRJOKER_MAXLEN || l2 > STRJOKER_MAXLEN)
+      return NULL; /* beyond any real filter/URL: bound depth+work */
+    memo.stride = l2 + 1;
+    if (l1 + 1 <= (SIZE_MAX - 7) / memo.stride) { // overflow-safe bitmap size
+      const size_t bytes = ((l1 + 1) * memo.stride + 7) / 8;
 
       if (bytes <= sizeof(stackbits)) {
         memset(stackbits, 0, bytes);
@@ -183,6 +193,16 @@ HTS_INLINE const char *strjoker(const char *chaine, const char *joker,
   if (onheap)
     freet(memo.failed);
   return adr;
+}
+
+// wildcard comparator: match chaine against joker (pattern), case-insensitive
+// returns the address of the first matched letter past any leading joker
+// (ie. *[..]toto.. returns the address of toto within chaine), NULL on mismatch
+HTS_INLINE const char *strjoker(const char *chaine, const char *joker,
+                                LLint *size, int *size_flag) {
+  size_t nsteps = 0;
+
+  return strjoker_bounded(chaine, joker, size, size_flag, &nsteps);
 }
 
 /* Test-only oracle: the same matcher without the failure memo. */
@@ -431,12 +451,18 @@ static const char *strjoker_impl(const strjoker_memo *memo, const char *chaine,
 // d'un strcpy sur une variable ayant un nom en lettres et copiant une chaine de chiffres
 // ATTENTION!! Eviter les jokers en début, où gare au temps machine!
 const char *strjokerfind(const char *chaine, const char *joker) {
+  size_t nsteps = 0; /* one budget for the whole scan */
   const char *adr;
 
+  if (chaine != NULL && strlen(chaine) > STRJOKER_MAXLEN)
+    return NULL;
   while(*chaine) {
-    if ((adr = strjoker(chaine, joker, NULL, NULL))) {  // ok trouvé
+    if ((adr = strjoker_bounded(chaine, joker, NULL, NULL,
+                                &nsteps))) { // ok trouvé
       return adr;
     }
+    if (nsteps > STRJOKER_MAXSTEPS) // scan budget spent: no match
+      return NULL;
     chaine++;
   }
   return NULL;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -740,6 +740,40 @@ static int st_filterdual(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* Length/work caps stop a hostile pattern stack-overflowing or hanging the
+   process (OSS-Fuzz 5060751291908096 / 5745936014573568). */
+static int st_filterbounds(httrackp *opt, int argc, char **argv) {
+  const size_t big = 100000; /* well past the length cap */
+  const size_t stars = 900;  /* star-heavy pattern, under the cap */
+  char *subj = malloct(big + 1);
+  char *pat = malloct(2 * stars + 2);
+  size_t i;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+  memset(subj, 'a', big);
+  subj[big] = '\0';
+  /* '*' matches anything, but an over-length subject is refused by the cap */
+  assertf(strjoker(subj, "*", NULL, NULL) == NULL);
+  assertf(strjokerfind(subj, "*") == NULL);
+  /* within-cap star-heavy dead-end: the step budget keeps it bounded (a hang
+     would time the test out) */
+  for (i = 0; i < stars; i++) {
+    pat[2 * i] = '*';
+    pat[2 * i + 1] = 'a';
+  }
+  pat[2 * stars] = 'b'; /* never matches an all-'a' subject */
+  pat[2 * stars + 1] = '\0';
+  subj[stars] = '\0';
+  assertf(strjoker(subj, pat, NULL, NULL) == NULL);
+  assertf(strjokerfind(subj, pat) == NULL);
+  freet(pat);
+  freet(subj);
+  printf("filterbounds: OK\n");
+  return 0;
+}
+
 static int st_simplify(httrackp *opt, int argc, char **argv) {
   (void) opt;
   if (argc < 1) {
@@ -2537,6 +2571,8 @@ static const struct selftest_entry {
      "memoized vs unmemoized matcher differential", st_filtermemo},
     {"filterdual", "<string1> <string2> <filter>...",
      "merged two-form filter verdict (fa_strjoker_dual)", st_filterdual},
+    {"filterbounds", "", "matcher length/work caps reject hostile patterns",
+     st_filterbounds},
     {"simplify", "<path>", "collapse ./ and ../ in a path", st_simplify},
     {"stripquery", "", "--strip-query pattern/key stripping self-test",
      st_stripquery},

--- a/tests/01_engine-filter.test
+++ b/tests/01_engine-filter.test
@@ -192,3 +192,6 @@ test "$(with_timeout httrack -O /dev/null -#test=filter "$pat" "$subj")" == "$su
 # (guards against a single-backtrack-point matcher rewrite)
 match '*[aX]X*[a]Y' 'aXaXaY'
 nomatch '*[aX]X*[a]Y' 'aXbXaY'
+
+# hostile patterns must not stack-overflow or hang: length + work caps
+test "$(with_timeout httrack -O /dev/null -#test=filterbounds)" == "filterbounds: OK" || exit 1


### PR DESCRIPTION
OSS-Fuzz found two ways to abuse the wildcard filter matcher. A pattern of 16000 stars overflows the call stack, since the matcher recurses one frame per star group. A star-heavy pattern against a long subject runs for minutes, because `strjokerfind` re-runs the polynomial matcher at every subject position. The #501 failure memo made a single match polynomial but bounds neither recursion depth nor that outer sweep.

The fix caps matcher input at `HTS_URLMAXSIZE*2`, the length the engine already bounds URLs to, which holds recursion depth far below the overflow point and leaves real crawls unaffected. It also adds a work budget that `strjokerfind` shares across its whole scan, so the per-position cost no longer multiplies. Both limits fail the match safely once exceeded. A `filterbounds` self-test covers each, and fails without the fix.