### PR TITLE
Alias 127.0.0.2/.3 on macOS so the connect-fallback test stops flaking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,14 @@ jobs:
       - name: Build
         run: make -j"$(sysctl -n hw.ncpu)"
 
+      - name: Add loopback aliases (macOS lacks 127.0.0.2/.3)
+        # 19_local-connect-fallback needs the dead 127.0.0.2/.3 to refuse
+        # instantly like Linux; alias them onto lo0 so they don't stall to timeout.
+        run: |
+          set -euo pipefail
+          sudo ifconfig lo0 alias 127.0.0.2 up
+          sudo ifconfig lo0 alias 127.0.0.3 up
+
       - name: Test
         run: |
           jobs=$(( $(sysctl -n hw.ncpu) * 2 )); [ "$jobs" -le 16 ] || jobs=16


### PR DESCRIPTION
`19_local-connect-fallback` flakes on the macOS CI runner (about one run in six): the crawl logs `Error: "Connect Time Out" (-2)` and the zero-errors assertion fails.

The test drives httrack's address fallback with `HTTRACK_DEBUG_RESOLVE`, pinning a dead address (127.0.0.2) ahead of the live server (127.0.0.1) and expecting the dead connect to refuse instantly so the crawl falls back cleanly. That holds on Linux, where all of 127.0.0.0/8 is loopback and an unbound port refuses at once. macOS configures only 127.0.0.1 as loopback, so a connect to 127.0.0.2 has no fast-refuse path and sometimes stalls to the timeout, logging the error the test forbids. #531's `--timeout`/`--retries` bounded the stall but not the spurious error.

This aliases 127.0.0.2 and 127.0.0.3 onto lo0 in the macOS test job, so the dead connects refuse instantly like Linux and the fallback runs clean. CI-only; no test or engine code touched.