### PR TITLE
webhttrack: let a configured browser win over Darwin's open -W

### DIFF
--- a/src/webhttrack
+++ b/src/webhttrack
@@ -12,10 +12,9 @@ if test -n "${BROWSER}"; then
 fi
 # Patch for Darwin/Mac by Ross Williams
 if test "$(uname -s)" == "Darwin"; then
-    # Darwin/Mac OS X uses a system 'open' command to find
-    # the default browser. The -W flag causes it to wait for
-    # the browser to exit
-    BROWSEREXE="/usr/bin/open -W"
+    # Darwin's 'open -W' launches the default browser and waits for it to quit.
+    # Keep it only as a fallback so a configured $BROWSER still wins the search.
+    BROWSEREXEFALLBACK="/usr/bin/open -W"
 fi
 BINWD=$(dirname "$0")
 SRCHPATH=("$BINWD" /usr/local/bin /usr/share/bin /usr/bin /usr/lib/httrack /usr/local/lib/httrack /usr/local/share/httrack /opt/local/bin /sw/bin "${HOME}/usr/bin" "${HOME}/bin")
@@ -81,6 +80,7 @@ for i in "${SRCHBROWSEREXE[@]}"; do
     done
     test -n "$BROWSEREXE" && break
 done
+test -n "$BROWSEREXE" || BROWSEREXE="${BROWSEREXEFALLBACK}"
 test -n "$BROWSEREXE" || ! log "Could not find any suitable browser" || exit 1
 
 # "browse" command


### PR DESCRIPTION
On macOS webhttrack ignored `$BROWSER` and any installed browser, always launching `open -W`. The Darwin block set `BROWSEREXE` to `open -W` before the browser-search loop, and the loop breaks as soon as `BROWSEREXE` is non-empty, so the search never ran. `open -W` opens the system default browser and blocks until the whole app quits.

This keeps `open -W` as the fallback after the search instead of the preset, so a configured browser wins and macOS drops to `open -W` only when nothing else is found.

Closes #544