### PR TITLE
webhttrack: drop Linux-only SIGSTKFLT from the cleanup trap

### DIFF
--- a/src/webhttrack
+++ b/src/webhttrack
@@ -132,12 +132,12 @@ function cleanup {
 }
 
 # Cleanup in case of emergency
-trap "cleanup now; exit" HUP INT QUIT ILL TRAP ABRT BUS FPE SEGV PIPE ALRM TERM STKFLT XCPU XFSZ
+trap "cleanup now; exit" HUP INT QUIT ILL TRAP ABRT BUS FPE SEGV PIPE ALRM TERM XCPU XFSZ
 
 # Got SRVURL, launch browser
 launch_browser "${BROWSEREXE}" "${SRVURL}"
 
 # That's all, folks!
-trap "" HUP INT QUIT ILL TRAP ABRT BUS FPE SEGV PIPE ALRM TERM STKFLT XCPU XFSZ
+trap "" HUP INT QUIT ILL TRAP ABRT BUS FPE SEGV PIPE ALRM TERM XCPU XFSZ
 cleanup
 exit 0


### PR DESCRIPTION
webhttrack's cleanup trap listed `SIGSTKFLT`, which is Linux-only. On macOS/BSD bash rejects the trap command, so the cleanup may not install and a Ctrl-C can leave `htsserver` and the temp server file behind. Drop `STKFLT`; the rest of the list is POSIX.

Closes #545