### PR TITLE
Prune signals that can't fire from the webhttrack and engine cleanup handlers

### DIFF
--- a/src/httrack.c
+++ b/src/httrack.c
@@ -919,7 +919,6 @@ static void signal_handlers(void) {
 #ifdef SIGSEGV
   signal(SIGSEGV, sig_fatal);   // segmentation violation
 #endif
-  // No SIGSTKFLT: Linux marks it unused; stack overflow raises SIGSEGV.
 }
 
 // fin routines de détournement de SIGHUP & co

--- a/src/httrack.c
+++ b/src/httrack.c
@@ -919,9 +919,7 @@ static void signal_handlers(void) {
 #ifdef SIGSEGV
   signal(SIGSEGV, sig_fatal);   // segmentation violation
 #endif
-#ifdef SIGSTKFLT
-  signal(SIGSTKFLT, sig_fatal); // stack fault
-#endif
+  // No SIGSTKFLT: Linux marks it unused; stack overflow raises SIGSEGV.
 }
 
 // fin routines de détournement de SIGHUP & co

--- a/src/webhttrack
+++ b/src/webhttrack
@@ -132,12 +132,12 @@ function cleanup {
 }
 
 # Cleanup in case of emergency
-trap "cleanup now; exit" HUP INT QUIT ILL TRAP ABRT BUS FPE SEGV PIPE ALRM TERM XCPU XFSZ
+trap "cleanup now; exit" HUP INT QUIT PIPE TERM
 
 # Got SRVURL, launch browser
 launch_browser "${BROWSEREXE}" "${SRVURL}"
 
 # That's all, folks!
-trap "" HUP INT QUIT ILL TRAP ABRT BUS FPE SEGV PIPE ALRM TERM XCPU XFSZ
+trap "" HUP INT QUIT PIPE TERM
 cleanup
 exit 0


### PR DESCRIPTION
Follow-up to #547.

The `webhttrack` cleanup trap listed the whole CPU/program-fault class (`ILL TRAP ABRT BUS FPE SEGV`, and until #547 also `STKFLT`) plus `ALRM XCPU XFSZ`. None of these help in a shell wrapper: bash does not raise them during normal execution, and when the `htsserver` child crashes the parent receives `SIGCHLD`, not the fault signal, so trapping `SEGV` there never catches a server crash. #547 dropped `STKFLT` because it broke the trap install on macOS/BSD; this finishes the cleanup. The trap now keeps only the signals that actually ask the wrapper to quit and warrant killing the server: `HUP INT QUIT PIPE TERM`, all POSIX.

In the engine, `signal_handlers()` registered `SIGSTKFLT`, which Linux marks unused (a legacy x87 coprocessor fault) and never raises; a real stack overflow arrives as `SIGSEGV`, already handled by `sig_fatal`. That handler was dead code. The `SEGV`/`BUS`/`ILL`/`ABRT` handlers are untouched: those are the real crash reporter (backtrace plus report URL).

Verified the webhttrack smoke test still passes with the trimmed trap.