### PR TITLE
Bound the cookie default-domain against a hostile over-long host

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -1708,6 +1708,9 @@ void treathead(t_cookie * cookie, const char *adr, const char *fil, htsblk * ret
 #if DEBUG_COOK
     printf("set-cookie detected\n");
 #endif
+    /* Over-long host overflows the fail-safe domain[] copy (abort); drop it. */
+    if (adr && strlen(jump_identification_const(adr)) >= sizeof(domain))
+      return;
     while(*a) {
       char *token_st, *token_end;
       char *value_st, *value_end;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1816,6 +1816,27 @@ static int st_cookies(httrackp *opt, int argc, char **argv) {
   http_cookie_header(&cookie, dom, "/", hdr, sizeof(hdr));
   if (strcmp(hdr, expected) != 0)
     err = 1;
+
+  /* A hostile over-long request host must not overflow domain[256] in
+     treathead's default-domain copy (that would abort the mirror). */
+  {
+    static t_cookie ck2;
+    htsblk r;
+    char host[600];
+
+    memset(&r, 0, sizeof(r));
+    memset(host, 'a', sizeof(host) - 1);
+    host[sizeof(host) - 1] = '\0';
+    ck2.max_len = (int) sizeof(ck2.data);
+    ck2.data[0] = '\0';
+    treathead(&ck2, host, "/", &r, "Set-Cookie: SID=1; path=/");
+    if (strnotempty(ck2.data)) // oversize-host cookie was not dropped
+      err = 1;
+    /* control: a normal host still yields a cookie through treathead */
+    treathead(&ck2, dom, "/", &r, "Set-Cookie: SID=1; path=/");
+    if (strstr(ck2.data, "SID") == NULL) // guard wrongly dropped a valid cookie
+      err = 1;
+  }
   if (strstr(hdr, "$Version") != NULL || strstr(hdr, "$Path") != NULL)
     err = 1;
   if (strstr(hdr, "junk") != NULL) // wrong-domain cookie leaked


### PR DESCRIPTION
`treathead` seeds each Set-Cookie's default domain from the request host by copying it into a fixed `domain[256]`. That copy was unguarded, and the host can exceed 256 bytes (a redirect Location is sized `HTS_URLMAXSIZE`), so a hostile server can hand back an over-long host and trip HTTrack's fail-safe string copy, aborting the whole mirror. It's a remote DoS, not memory corruption. The fix drops such a Set-Cookie, reusing the too-long-ignore handling the parser already applies to an explicit `domain=` attribute; every other copy in the cookie loop was already bounded.

Found during a broader audit, not a filed issue. The new cookies self-test drives `treathead` with a 599-byte host, which aborts the unpatched engine, plus a normal-host control so an over-eager guard can't silently drop valid cookies.