### PR TITLE
tests: exercise the strjoker work budget, not just the length cap

### DIFF
--- a/src/htsfilters.c
+++ b/src/htsfilters.c
@@ -213,6 +213,20 @@ const char *strjoker_nomemo(const char *chaine, const char *joker, LLint *size,
   return strjoker_rec(&memo, chaine, joker, size, size_flag);
 }
 
+/* Test-only: strjoker() reporting the work-budget steps spent and the cap, so a
+   self-test can prove the budget bounds a hostile pattern's work. */
+const char *strjoker_steps(const char *chaine, const char *joker,
+                           size_t *nsteps_out, size_t *maxsteps_out) {
+  size_t nsteps = 0;
+  const char *r = strjoker_bounded(chaine, joker, NULL, NULL, &nsteps);
+
+  if (nsteps_out != NULL)
+    *nsteps_out = nsteps;
+  if (maxsteps_out != NULL)
+    *maxsteps_out = STRJOKER_MAXSTEPS;
+  return r;
+}
+
 static const char *strjoker_impl(const strjoker_memo *memo, const char *chaine,
                                  const char *joker, LLint *size,
                                  int *size_flag) {

--- a/src/htsfilters.h
+++ b/src/htsfilters.h
@@ -52,6 +52,10 @@ HTS_INLINE const char *strjoker(const char *chaine, const char *joker, LLint * s
    oracle for the memoized matcher. */
 const char *strjoker_nomemo(const char *chaine, const char *joker, LLint *size,
                             int *size_flag);
+/* strjoker() reporting the work-budget steps it spent and the cap; test-only,
+   lets a self-test assert the budget bounds a hostile pattern's work. */
+const char *strjoker_steps(const char *chaine, const char *joker,
+                           size_t *nsteps_out, size_t *maxsteps_out);
 const char *strjokerfind(const char *chaine, const char *joker);
 #endif
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -744,29 +744,33 @@ static int st_filterdual(httrackp *opt, int argc, char **argv) {
    process (OSS-Fuzz 5060751291908096 / 5745936014573568). */
 static int st_filterbounds(httrackp *opt, int argc, char **argv) {
   const size_t big = 100000; /* well past the length cap */
-  const size_t stars = 900;  /* star-heavy pattern, under the cap */
+  const size_t stars = 1023; /* pattern len 2047, under the length cap */
+  const size_t subjlen = 2048;
   char *subj = malloct(big + 1);
   char *pat = malloct(2 * stars + 2);
-  size_t i;
+  size_t steps = 0, maxsteps = 0, i;
 
   (void) opt;
   (void) argc;
   (void) argv;
   memset(subj, 'a', big);
   subj[big] = '\0';
-  /* '*' matches anything, but an over-length subject is refused by the cap */
+  /* '*' matches anything, but an over-length subject trips the length cap */
   assertf(strjoker(subj, "*", NULL, NULL) == NULL);
   assertf(strjokerfind(subj, "*") == NULL);
-  /* within-cap star-heavy dead-end: the step budget keeps it bounded (a hang
-     would time the test out) */
+  /* Star-heavy dead-end at the length cap: unbounded it runs ~1.26e9 memo-steps
+     (~6s). */
   for (i = 0; i < stars; i++) {
     pat[2 * i] = '*';
     pat[2 * i + 1] = 'a';
   }
   pat[2 * stars] = 'b'; /* never matches an all-'a' subject */
   pat[2 * stars + 1] = '\0';
-  subj[stars] = '\0';
-  assertf(strjoker(subj, pat, NULL, NULL) == NULL);
+  subj[subjlen] = '\0';
+  /* Budget must bound the work; NULL alone wouldn't prove it (a cheap mismatch
+     is NULL too). */
+  assertf(strjoker_steps(subj, pat, &steps, &maxsteps) == NULL);
+  assertf(steps < 10 * maxsteps);
   assertf(strjokerfind(subj, pat) == NULL);
   freet(pat);
   freet(subj);


### PR DESCRIPTION
The strjoker filter matcher has two guards against hostile patterns: a length cap and a shared work budget (`STRJOKER_MAXSTEPS`, #542). The `filterbounds` self-test only exercised the length cap. Its star-heavy case (900 stars against a 900-char subject) stays under the 2M-step budget on its own, because the #501 failure memo already bounds it, so the budget never fired. The assertion was a bare `strjoker(...) == NULL`, and a genuine non-match returns NULL whether or not the budget exists. Only a harness timeout would have caught the budget being deleted, which is exactly the confirmation-biased shape the tree's test guidance warns against.

This sizes the dead-end pattern to the length cap (1023 stars, 2048-char subject), where the memoized matcher runs about 1.26 billion steps (~6s) with the budget removed, and asserts through a new test-only `strjoker_steps()` accessor that the work stays within a small multiple of the cap. I verified it both ways: with the budget the test finishes in ~30ms; remove the budget and it fails the bound in milliseconds instead of timing the suite out. `strjoker_steps()` is hidden by `-fvisibility=hidden`, so there is no ABI change, and no engine behavior changes.