### PR TITLE
tests: assert the strjoker budget fired, not just that work stayed bounded

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -767,10 +767,10 @@ static int st_filterbounds(httrackp *opt, int argc, char **argv) {
   pat[2 * stars] = 'b'; /* never matches an all-'a' subject */
   pat[2 * stars + 1] = '\0';
   subj[subjlen] = '\0';
-  /* Budget must bound the work; NULL alone wouldn't prove it (a cheap mismatch
-     is NULL too). */
+  /* Budget must fire and hold: steps > cap (deleting the budget zeroes the
+     counter that is the enforcement), steps < 10*cap (unbudgeted ~1.26e9). */
   assertf(strjoker_steps(subj, pat, &steps, &maxsteps) == NULL);
-  assertf(steps < 10 * maxsteps);
+  assertf(steps > maxsteps && steps < 10 * maxsteps);
   assertf(strjokerfind(subj, pat) == NULL);
   freet(pat);
   freet(subj);


### PR DESCRIPTION
Follow-up to #551. That PR asserted `steps < 10*maxsteps` on the strjoker work-budget self-test. That catches a budget whose enforcement is dropped but whose counter still runs (steps climb to about 1.26 billion), but it misses the more natural regression: deleting the budget line entirely. The counter increment and the enforcement are the same statement, so with it gone `steps` stays 0, `0 < 10*maxsteps` holds, and the probe passes. Only the following `strjokerfind` call then catches the missing budget, by hanging into a harness timeout, which is the exact failure mode #551 set out to remove.

This adds the floor `steps > maxsteps`: the budget must push the counter past the cap. I verified both regression shapes (budget line deleted; enforcement dropped with the counter kept) now trip an assertion in milliseconds instead of timing the suite out. The gap was found by a doubled adversarial review of #551.