### PR TITLE
Give the Windows binaries a version resource

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Resource scripts are Windows tooling input and must stay CRLF: the engine has no
+# encoding guard, so an autocrlf checkout could otherwise flatten them silently.
+*.rc text eol=crlf

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -83,6 +83,9 @@ libhttrack_la_CFLAGS = $(AM_CFLAGS) -DLIBHTTRACK_EXPORTS -DZLIB_CONST
 libhttrack_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(VERSION_INFO)
 
 EXTRA_DIST = httrack.h webhttrack \
+		version.rc \
+		libhttrack.rc \
+		httrack.rc \
 		coucal/murmurhash3.h.diff \
 		coucal/murmurhash3.h.orig \
 		minizip/iowin32.c \

--- a/src/httrack.rc
+++ b/src/httrack.rc
@@ -1,0 +1,5 @@
+// Version resource for httrack.exe, the command line program. See version.rc.
+#define VER_FILE_DESCRIPTION "HTTrack Website Copier (command line)"
+#define VER_ORIGINAL_FILENAME "httrack.exe"
+#define VER_FILETYPE VFT_APP
+#include "version.rc"

--- a/src/httrack.vcxproj
+++ b/src/httrack.vcxproj
@@ -108,6 +108,9 @@
       <Project>{e76ad871-54c1-45e8-a657-6117adeffb46}</Project>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="httrack.rc" />
+  </ItemGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/src/libhttrack.rc
+++ b/src/libhttrack.rc
@@ -1,0 +1,5 @@
+// Version resource for libhttrack.dll. See version.rc.
+#define VER_FILE_DESCRIPTION "HTTrack Website Copier engine"
+#define VER_ORIGINAL_FILENAME "libhttrack.dll"
+#define VER_FILETYPE VFT_DLL
+#include "version.rc"

--- a/src/libhttrack.vcxproj
+++ b/src/libhttrack.vcxproj
@@ -138,6 +138,9 @@
     <ClCompile Include="minizip\zip.c" />
     <ClCompile Include="punycode.c" />
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="libhttrack.rc" />
+  </ItemGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/src/version.rc
+++ b/src/version.rc
@@ -1,0 +1,50 @@
+// Version resource for libhttrack.dll and httrack.exe. Signing enforces that every
+// binary in a release names the same product and version, so both need one.
+// Spelled out here because a VERSIONINFO cannot take a version string apart;
+// tests/01_engine-version-macros.test fails if this drifts from htsglobal.h.
+// The per-binary parts come from libhttrack.rc / httrack.rc.
+
+#include <winver.h>
+
+#ifndef VER_FILE_DESCRIPTION
+#define VER_FILE_DESCRIPTION "HTTrack Website Copier"
+#endif
+#ifndef VER_ORIGINAL_FILENAME
+#define VER_ORIGINAL_FILENAME ""
+#endif
+#ifndef VER_FILETYPE
+#define VER_FILETYPE VFT_APP
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+  FILEVERSION 3, 49, 12, 0
+  PRODUCTVERSION 3, 49, 12, 0
+  FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+#ifdef _DEBUG
+  FILEFLAGS VS_FF_DEBUG
+#else
+  FILEFLAGS 0x0L
+#endif
+  FILEOS VOS_NT_WINDOWS32
+  FILETYPE VER_FILETYPE
+  FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "040904b0"  // U.S. English, Unicode
+    BEGIN
+      VALUE "CompanyName", "Xavier Roche"
+      VALUE "FileDescription", VER_FILE_DESCRIPTION
+      VALUE "FileVersion", "3.49.12"
+      VALUE "InternalName", VER_ORIGINAL_FILENAME
+      VALUE "LegalCopyright", "Copyright (C) 1998-2026 Xavier Roche and other contributors. GNU GPL v3 or later."
+      VALUE "OriginalFilename", VER_ORIGINAL_FILENAME
+      VALUE "ProductName", "HTTrack Website Copier"
+      VALUE "ProductVersion", "3.49-12"
+    END
+  END
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x409, 1200
+  END
+END

--- a/tests/01_engine-version-macros.test
+++ b/tests/01_engine-version-macros.test
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# version.rc repeats the version that htsglobal.h declares. Signing enforces that
+# every binary in a release reports the same one, so a drift fails the signing
+# request on release day rather than the build. Assert the two agree.
+
+set -euo pipefail
+
+src="${top_srcdir:-..}/src"
+h="$src/htsglobal.h"
+rc="$src/version.rc"
+for f in "$h" "$rc"; do
+    [ -f "$f" ] || {
+        echo "cannot find $f"
+        exit 1
+    }
+done
+
+# 3.49-12 (display) and 3.49.12 (dotted).
+version=$(sed -n 's/^#define HTTRACK_VERSION[[:space:]][[:space:]]*"\([^"]*\)".*/\1/p' "$h")
+versionid=$(sed -n 's/^#define HTTRACK_VERSIONID[[:space:]][[:space:]]*"\([^"]*\)".*/\1/p' "$h")
+if [ -z "$version" ] || [ -z "$versionid" ]; then
+    echo "could not read the version from $h"
+    exit 1
+fi
+
+# The same version, as version.rc states it.
+fileversion=$(sed -n 's/^[[:space:]]*FILEVERSION[[:space:]][[:space:]]*\(.*\)$/\1/p' "$rc" | tr -d ' \r')
+productversion=$(sed -n 's/^[[:space:]]*PRODUCTVERSION[[:space:]][[:space:]]*\(.*\)$/\1/p' "$rc" | tr -d ' \r')
+rc_fileversion=$(sed -n 's/.*VALUE "FileVersion",[[:space:]]*"\([^"]*\)".*/\1/p' "$rc")
+rc_productversion=$(sed -n 's/.*VALUE "ProductVersion",[[:space:]]*"\([^"]*\)".*/\1/p' "$rc")
+rc_productname=$(sed -n 's/.*VALUE "ProductName",[[:space:]]*"\([^"]*\)".*/\1/p' "$rc")
+
+# 3.49.12 -> 3,49,12,0
+expected_numeric="$(echo "$versionid" | tr '.' ','),0"
+
+fail=0
+check() { # what expected actual
+    if [ "$2" != "$3" ]; then
+        echo "version.rc $1 is \"$3\", but htsglobal.h says it should be \"$2\""
+        fail=1
+    fi
+}
+check FILEVERSION "$expected_numeric" "$fileversion"
+check PRODUCTVERSION "$expected_numeric" "$productversion"
+check FileVersion "$versionid" "$rc_fileversion"
+check ProductVersion "$version" "$rc_productversion"
+
+# Signing pins the product name too.
+check ProductName "HTTrack Website Copier" "$rc_productname"
+
+[ "$fail" -eq 0 ] || exit 1
+
+# And the shipped binary must agree with the header it was built from.
+out=$(httrack --version)
+case "$out" in
+*"$version"*) ;;
+*)
+    echo "httrack --version says \"$out\", which does not mention $version"
+    exit 1
+    ;;
+esac
+
+echo "version resource agrees with htsglobal.h: $version ($expected_numeric)"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -66,6 +66,7 @@ TESTS = \
 	01_engine-urlhack.test \
 	01_engine-unescape-bounds.test \
 	01_engine-useragent.test \
+	01_engine-version-macros.test \
 	01_engine-xfread.test \
 	01_zlib-acceptencoding.test \
 	01_zlib-cache.test \


### PR DESCRIPTION
## What

`libhttrack.dll` and `httrack.exe` gain a `VERSIONINFO` resource. They have never had one: no product name, no version, no copyright.

## Why

We are applying to SignPath Foundation to sign the Windows builds, and they enforce file metadata restrictions: every binary in a release must carry the same product name and the same product version. A binary that carries none cannot satisfy that. It would fail the signing request on release day, not the build.

It is also just correct. Properties on either file currently shows nothing.

## How

`src/version.rc` holds the resource; `libhttrack.rc` and `httrack.rc` set the three things that differ per binary (description, original filename, and app versus DLL) and include it.

The version is spelled out in `version.rc` rather than derived from `htsglobal.h`, because a `VERSIONINFO` needs `3,49,12,0` and cannot take a string apart, and because `htsglobal.h` pulls in C declarations the resource compiler has no business parsing.

That means the version now lives in two files, which is exactly how a version resource starts quietly lying about which release it is. `tests/01_engine-version-macros.test` fails if the two ever disagree, on any of `FILEVERSION`, `PRODUCTVERSION`, `FileVersion`, `ProductVersion`, or the product name. I confirmed it fires rather than assuming so: drifting the numbers fails the test, restoring them passes it.

Product name is `HTTrack Website Copier` throughout. WinHTTrack is the name of the Windows GUI, not of the command line program or the engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)