### PR TITLE
Put the robots.txt "(default)" label on the option that is the default

### DIFF
--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -328,8 +328,8 @@ typedef enum hts_wizard {
 
 typedef enum hts_robots {
   HTS_ROBOTS_NEVER = 0,        /**< ignore robots rules */
-  HTS_ROBOTS_SOMETIMES = 1,    /**< partial obedience (default) */
-  HTS_ROBOTS_ALWAYS = 2,       /**< obey robots rules */
+  HTS_ROBOTS_SOMETIMES = 1,    /**< partial obedience, set by -s */
+  HTS_ROBOTS_ALWAYS = 2,       /**< obey robots rules (default) */
   HTS_ROBOTS_ALWAYS_STRICT = 3 /**< obey even strict rules */
 } hts_robots;
 #endif


### PR DESCRIPTION
## What

One comment, two lines. `HTS_ROBOTS_ALWAYS` is the default, not `HTS_ROBOTS_SOMETIMES`.

## Why

`src/htsopt.h` said:

```c
HTS_ROBOTS_SOMETIMES = 1,    /**< partial obedience (default) */
HTS_ROBOTS_ALWAYS = 2,       /**< obey robots rules */
```

It is the other way round. `hts_init_opt` sets `opt->robots = HTS_ROBOTS_ALWAYS` (`src/htslib.c:5990`); `SOMETIMES` is what `-s` selects when a user asks for it (`src/htscoremain.c:1234`), and `NEVER` likewise (`:968`).

So HTTrack obeys robots.txt fully by default, and the header stated the opposite. That matters beyond tidiness: "does this crawler respect robots.txt by default" is a question people actually ask of a site copier, and the enum is the first place they look for the answer. We are about to make exactly that claim to SignPath Foundation in a code-signing application, and a reviewer who greps the header would have found the project contradicting itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)