### PR TITLE
Cache and sniff self-tests fail on Windows: DOS-ified X-Save, and a BOM through argv

### DIFF
--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -232,11 +232,10 @@ static int disk_fallback_selftest(httrackp *opt) {
   static const char body[] = "BINARY-on-disk-body-0123456789-no-trailing-nul";
   const size_t body_len = sizeof(body) - 1;
 
-  /* X-Save must start with path_html_utf8 so the reader resolves it verbatim
-     (otherwise it re-roots it as a pre-3.40 relative path); then the body we
-     create at fconv(save) is exactly where cache_readex looks for it. */
-  fconcat(save, sizeof(save), StringBuff(opt->path_html_utf8),
-          "example.com/blob.bin");
+  /* a DOS-ified X-Save loses the path_html_utf8 prefix the reader matches on,
+     and gets re-rooted as a pre-3.40 relative path; fconv() only on access */
+  concat(save, sizeof(save), StringBuff(opt->path_html_utf8),
+         "example.com/blob.bin");
 
   /* write only the header (X-In-Cache: 0); the body stays on disk */
   selftest_open_for_write(&cache, opt);
@@ -1253,8 +1252,9 @@ static void corrupt_build_disk(httrackp *opt) {
   memset(corrupt_body_a, 'a', sizeof(corrupt_body_a) - 1);
   remove(reconcile_st_path(opt, "hts-cache/new.zip"));
   remove(reconcile_st_path(opt, "hts-cache/old.zip"));
-  fconcat(save, sizeof(save), StringBuff(opt->path_html_utf8),
-          CORRUPT_ADR "/victim.bin");
+  /* X-Save stored verbatim: see disk_fallback_selftest */
+  concat(save, sizeof(save), StringBuff(opt->path_html_utf8),
+         CORRUPT_ADR "/victim.bin");
   selftest_open_for_write(&cache, opt);
   store_entry(opt, &cache, CORRUPT_ADR, "/canary.html", "canary.html", 200,
               "OK", "text/html", "utf-8", "", "", "", "", corrupt_body_a,

--- a/tests/01_engine-sniff.test
+++ b/tests/01_engine-sniff.test
@@ -35,7 +35,8 @@ chk image/avif hex:0000001C6674797061766966 "$yes"
 chk image/avif hex:0000001C6674797068656963 "$no" # heic brand is not avif
 chk image/heic hex:0000001C6674797068656963 "$yes"
 chk image/svg+xml '<svg xmlns="x">' "$yes"
-chk image/svg+xml $'\xef\xbb\xbf  <?xml version="1.0"?>' "$yes" # BOM+ws skip
+# BOM+ws skip; hex, as Windows argv cannot carry the raw BOM through the ANSI codepage
+chk image/svg+xml hex:EFBBBF20203C3F786D6C2076657273696F6E3D22312E30223F3E "$yes"
 
 # audio / video
 chk audio/mpeg 'ID3xxx' "$yes"


### PR DESCRIPTION
All three self-test failures on MSVC are bugs in the self-tests, not the engine, and the 2 GB boundary they sit near is a coincidence.

Both cache failures come from one call. The self-tests built the stored `X-Save` with `fconcat()`, which rewrites every `/` to `\` on Windows, including the `path_html_utf8` prefix. `cache_readex` resolves an `X-Save` verbatim only when it starts with that prefix; otherwise it takes it for a pre-3.40 relative name and re-roots it into a path that does not exist. That single cause produces both reported symptoms at once, `statuscode -1` and a NULL body, and the same call in `corrupt_build_disk` is why `-#test=cache-corrupt` fails too. Those cases never create a large file (the victim body is 0 bytes and the `X-Size` values are faked header fields), so a 32-bit `st_size` cannot be what breaks them. The engine keeps save names slash-separated and DOS-ifies only at the syscall boundary; the self-tests now do the same. The sniff failure is an argv artifact: the test passed a UTF-8 BOM as raw bytes, and Windows hands argv down through the ANSI codepage, where U+FEFF has no mapping and arrives as `?`. It now uses the `hex:` body form the self-test already accepts.

One thing this PR cannot show: on POSIX `fconv()` is a no-op, so `concat` and `fconcat` are the same code there. `make check` stays green (92/92), which proves no regression but says nothing about Windows. Confirming these needs a run against an MSVC build.

The `st_size` hypothesis in the issue is a real bug, just not this one. MSVC's `struct _stat` carries a 32-bit `st_size`, and `off_t` is a 32-bit `long` there as well, so `fsize()`/`fsize_utf8()`/`fpsize()` truncate at their own return type and any mirrored file of 2 GB or more is mishandled on Windows regardless of the tests. That needs an engine change and a Windows ABI break, so it lands separately.

Closes #565
