### PR TITLE
Files of 2 GB or more are mishandled on Windows, and on any 32-bit build

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -136,6 +136,22 @@ jobs:
             Write-Host ($out -join "`n")
           }
 
+      # These fail only on Windows: the cache ones on a DOS-ified save name (fconv
+      # is a no-op on POSIX, so make check cannot see it), fsize on a 32-bit
+      # st_size/off_t. They report failure by exit code, not an "OK" line.
+      - name: Run the Windows-sensitive self-tests
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $exe = "src\${{ matrix.platform }}\${{ matrix.configuration }}\httrack.exe"
+          foreach ($t in @("cache", "cache-corrupt", "fsize")) {
+            $tmp = New-Item -ItemType Directory -Force `
+              -Path (Join-Path $env:RUNNER_TEMP "st-$t")
+            $out = & $exe -O NUL "-#test=$t" $tmp.FullName run 2>&1
+            Write-Host ($out -join "`n")
+            if ($LASTEXITCODE -ne 0) { throw "$t failed (exit $LASTEXITCODE)" }
+          }
+
       - name: Upload MSBuild logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -775,7 +775,7 @@ int back_finalize(httrackp * opt, cache_back * cache, struct_back * sback,
         if (back[p].r.statuscode == HTTP_OK) {  // OK (ou 304 en backing)
           if (back[p].r.is_write) {     // Written file
             if (may_be_hypertext_mime(opt, back[p].r.contenttype, back[p].url_fil)) {   // to parse!
-              off_t sz;
+              LLint sz;
 
               sz = fsize_utf8(back[p].url_sav);
               if (sz > 0) {     // ok, exists!
@@ -1952,7 +1952,7 @@ int back_add(struct_back * sback, httrackp * opt, cache_back * cache, const char
       /* Not in cache ; maybe in temporary cache ? Warning: non-movable
          "url_sav" */
       else if (back_unserialize_ref(opt, adr, fil, &itemback) == 0) {
-        const off_t file_size = fsize_utf8(itemback->url_sav);
+        const LLint file_size = fsize_utf8(itemback->url_sav);
 
         /* Found file on disk */
         if (file_size > 0) {
@@ -1987,7 +1987,7 @@ int back_add(struct_back * sback, httrackp * opt, cache_back * cache, const char
       }
       /* Not in cache or temporary cache ; found on disk ? (hack) */
       else if (fexist_utf8(save)) {
-        const off_t sz = fsize_utf8(save);
+        const LLint sz = fsize_utf8(save);
 
         // Bon, là il est possible que le fichier ait été partiellement transféré
         // (s'il l'avait été en totalité il aurait été inscrit dans le cache ET existerait sur disque)
@@ -3656,7 +3656,7 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                       if (back[i].r.statuscode == HTTP_OK && !back[i].testmode) {       // 'OK'
                         if (!is_hypertext_mime(opt, back[i].r.contenttype, back[i].url_fil)) {  // not HTML
                           if (strnotempty(back[i].url_sav)) {   // target found
-                            off_t size = fsize_utf8(back[i].url_sav);
+                            LLint size = fsize_utf8(back[i].url_sav);
 
                             if (size >= 0) {
                               if (back[i].r.totalsize == size) {        // same size!
@@ -3875,7 +3875,7 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                     // traiter 206 (partial content)
                     // xxc SI CHUNK VERIFIER QUE CA MARCHE??
                     if (back[i].r.statuscode == 206) {  // on nous envoie un morceau (la fin) coz une partie sur disque!
-                      off_t sz = fsize_utf8(back[i].url_sav);
+                      LLint sz = fsize_utf8(back[i].url_sav);
                       /* RFC 7233: resume at the server's Content-Range start,
                          not the offset we requested; a server may resume
                          earlier and appending the overlap duplicates bytes

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -356,7 +356,7 @@ void cache_add(httrackp * opt, cache_back * cache, const htsblk * r,
       FILE *fp;
 
       // On recopie le fichier->.
-      off_t file_size = fsize_utf8(fconv(catbuff, sizeof(catbuff), url_save));
+      LLint file_size = fsize_utf8(fconv(catbuff, sizeof(catbuff), url_save));
 
       if (file_size >= 0) {
         fp = FOPEN(fconv(catbuff, sizeof(catbuff), url_save), "rb");
@@ -1269,7 +1269,7 @@ char *readfile2(const char *fil, LLint * size) {
 char *readfile_utf8(const char *fil) {
   char *adr = NULL;
   char catbuff[CATBUFF_SIZE];
-  const off_t len = fsize_utf8(fil);
+  const LLint len = fsize_utf8(fil);
 
   if (len >= 0) {               // exists
     FILE *const fp = FOPEN(fconv(catbuff, sizeof(catbuff), fil), "rb");

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -1241,23 +1241,27 @@ char *readfile(const char *fil) {
 char *readfile2(const char *fil, LLint * size) {
   char *adr = NULL;
   char catbuff[CATBUFF_SIZE];
-  INTsys len = 0;
+  const LLint len = fsize(fil);
 
-  len = fsize(fil);
-  if (len >= 0) {               // exists
+  /* a size too large for size_t (32-bit Windows/i386) must fail closed: it
+     would wrap malloct() short while fread() still read the untruncated len */
+  const size_t buflen = len >= 0 ? llint_to_size_t(len) : (size_t) -1;
+
+  if (buflen != (size_t) -1) { // exists, and is addressable
     FILE *fp;
 
     fp = fopen(fconv(catbuff, sizeof(catbuff), fil), "rb");
     if (fp != NULL) {           // n'existe pas (!)
-      adr = (char *) malloct(len + 1);
+      adr = (char *) malloct(buflen + 1);
       if (size != NULL)
         *size = len;
       if (adr != NULL) {
-        if (len > 0 && fread(adr, 1, len, fp) != len) { // fichier endommagé ?
+        if (buflen > 0 &&
+            fread(adr, 1, buflen, fp) != buflen) { // fichier endommagé ?
           freet(adr);
           adr = NULL;
         } else
-          *(adr + len) = '\0';
+          *(adr + buflen) = '\0';
       }
       fclose(fp);
     }
@@ -1270,18 +1274,20 @@ char *readfile_utf8(const char *fil) {
   char *adr = NULL;
   char catbuff[CATBUFF_SIZE];
   const LLint len = fsize_utf8(fil);
+  const size_t buflen = len >= 0 ? llint_to_size_t(len) : (size_t) -1;
 
-  if (len >= 0) {               // exists
+  if (buflen != (size_t) -1) { // exists, and is addressable (see readfile2)
     FILE *const fp = FOPEN(fconv(catbuff, sizeof(catbuff), fil), "rb");
 
     if (fp != NULL) {           // n'existe pas (!)
-      adr = (char *) malloct(len + 1);
+      adr = (char *) malloct(buflen + 1);
       if (adr != NULL) {
-        if (len > 0 && fread(adr, 1, len, fp) != len) { // fichier endommagé ?
+        if (buflen > 0 &&
+            fread(adr, 1, buflen, fp) != buflen) { // fichier endommagé ?
           freet(adr);
           adr = NULL;
         } else {
-          adr[len] = '\0';
+          adr[buflen] = '\0';
         }
       }
       fclose(fp);

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -939,9 +939,9 @@ static void reconcile_put(httrackp *opt, const char *name, size_t size) {
 }
 
 /* Expect `name` to weigh `size` bytes, or be absent when size == -1. */
-static int reconcile_expect(httrackp *opt, const char *name, off_t size,
+static int reconcile_expect(httrackp *opt, const char *name, LLint size,
                             const char *what) {
-  const off_t got = fsize(reconcile_st_path(opt, name));
+  const LLint got = fsize(reconcile_st_path(opt, name));
 
   if (got != size) {
     fprintf(stderr, "cache-reconcile: %s: %s is %d bytes, expected %d\n", what,
@@ -955,7 +955,7 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   int failures = 0;
 
   /* around the interrupted-run thresholds (new < 32768, old > 65536) */
-  static const off_t TINY = 1024, MID = 40000, SOLID = 131072;
+  static const LLint TINY = 1024, MID = 40000, SOLID = 131072;
 
   golden_setup(opt, dir);
 #ifdef _WIN32

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -855,7 +855,7 @@ int httpmirror(char *url1, httrackp * opt) {
       char *filelist_buff = NULL;
       size_t filelist_sz = 0;
       const char *filelist_err = NULL; /* failure reason, NULL on success */
-      const off_t fs = fsize(StringBuff(opt->filelist));
+      const LLint fs = fsize(StringBuff(opt->filelist));
 
       if (fs < 0) {
         /* fsize() hides the cause; redo stat() for a precise errno (#49) */
@@ -863,7 +863,7 @@ int httpmirror(char *url1, httrackp * opt) {
         filelist_err = stat(StringBuff(opt->filelist), &st) != 0
                            ? strerror(errno)
                            : "not a regular file";
-      } else if ((filelist_sz = off_t_to_size_t(fs)) == (size_t) -1) {
+      } else if ((filelist_sz = llint_to_size_t(fs)) == (size_t) -1) {
         filelist_err = "file too large";
         filelist_sz = 0;
       } else {
@@ -2089,10 +2089,9 @@ int httpmirror(char *url1, httrackp * opt) {
               (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
                "hts-cache/old.lst"), "rb");
       if (old_lst) {
-        const size_t sz =
-          off_t_to_size_t(fsize(fconcat
-                (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                 "hts-cache/new.lst")));
+        const size_t sz = llint_to_size_t(
+            fsize(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                          StringBuff(opt->path_log), "hts-cache/new.lst")));
         new_lst =
           fopen(fconcat
                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -1509,7 +1509,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                   htsmain_free();
                   return -1;
                 } else {
-                  off_t fz;
+                  LLint fz;
 
                   na++;
                   fz = fsize(argv[na]);

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -322,17 +322,15 @@ typedef int64_t TStamp;
 /* Full printf conversion, '%' included (PRId64 has none): "X: " LLintP. */
 #define LLintP "%" PRId64
 
-/* Integer type for file offsets/sizes passed to the C library. Widens to
-   LLint (with HTS_FSEEKO for fseeko/ftello) under large-file support, plain
-   int otherwise; INTsysP is its printf conversion. MSVC has no LFS_FLAG but
-   ships the 64-bit _stat64/_fseeki64 family (aliased in htslib.h). */
+/* Integer type for file offsets/sizes passed to the C library; INTsysP is its
+   printf conversion. FIXME: LFS_FLAG is a configure make variable, never a C
+   macro, so this test is dead and INTsys stays int on POSIX despite large-file
+   support (the real macro is HTS_LFS). Widening it there is an installed-header
+   type change, so it is left alone here. */
 #if defined(LFS_FLAG) || defined(_MSC_VER)
 typedef LLint INTsys;
 
 #define INTsysP LLintP
-#if defined(__linux) || defined(_MSC_VER)
-#define HTS_FSEEKO
-#endif
 #else
 typedef int INTsys;
 

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -324,12 +324,13 @@ typedef int64_t TStamp;
 
 /* Integer type for file offsets/sizes passed to the C library. Widens to
    LLint (with HTS_FSEEKO for fseeko/ftello) under large-file support, plain
-   int otherwise; INTsysP is its printf conversion. */
-#ifdef LFS_FLAG
+   int otherwise; INTsysP is its printf conversion. MSVC has no LFS_FLAG but
+   ships the 64-bit _stat64/_fseeki64 family (aliased in htslib.h). */
+#if defined(LFS_FLAG) || defined(_MSC_VER)
 typedef LLint INTsys;
 
 #define INTsysP LLintP
-#ifdef __linux
+#if defined(__linux) || defined(_MSC_VER)
 #define HTS_FSEEKO
 #endif
 #else

--- a/src/htsindex.c
+++ b/src/htsindex.c
@@ -318,7 +318,7 @@ void index_finish(const char *indexpath, int mode) {
   char catbuff[CATBUFF_SIZE];
   char **tab;
   char *blk;
-  off_t size = fpsize(fp_tmpproject);
+  LLint size = fpsize(fp_tmpproject);
 
   if (size > 0) {
     if (fp_tmpproject) {

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -4698,26 +4698,31 @@ int fexist_utf8(const char *s) {
   return 0;
 }
 
-/* Taille d'un fichier, -1 si n'existe pas */
+/* File size, -1 if absent */
 /* Note: NOT utf-8 */
-off_t fsize(const char *s) {
-  struct stat st;
+LLint fsize(const char *s) {
+  STRUCT_STAT st;
 
-  if (!strnotempty(s))          // nom vide: erreur
+  if (!strnotempty(s)) // empty name: error
     return -1;
+  /* _stat64, not stat(): the latter is 32-bit on MSVC */
+#ifdef _WIN32
+  if (_stat64(s, &st) == 0 && S_ISREG(st.st_mode)) {
+#else
   if (stat(s, &st) == 0 && S_ISREG(st.st_mode)) {
+#endif
     return st.st_size;
   } else {
     return -1;
   }
 }
 
-/* Taille d'un fichier, -1 si n'existe pas */
+/* File size, -1 if absent */
 /* Note: utf-8 */
-off_t fsize_utf8(const char *s) {
+LLint fsize_utf8(const char *s) {
   STRUCT_STAT st;
 
-  if (!strnotempty(s))          // nom vide: erreur
+  if (!strnotempty(s)) // empty name: error
     return -1;
   if (STAT(s, &st) == 0 && S_ISREG(st.st_mode)) {
     return st.st_size;
@@ -4726,21 +4731,19 @@ off_t fsize_utf8(const char *s) {
   }
 }
 
-off_t fpsize(FILE * fp) {
-  off_t oldpos, size;
+LLint fpsize(FILE *fp) {
+  LLint oldpos, size;
 
   if (!fp)
     return -1;
 #ifdef HTS_FSEEKO
   oldpos = ftello(fp);
-#else
-  oldpos = ftell(fp);
-#endif
-  fseek(fp, 0, SEEK_END);
-#ifdef HTS_FSEEKO
+  fseeko(fp, 0, SEEK_END);
   size = ftello(fp);
   fseeko(fp, oldpos, SEEK_SET);
 #else
+  oldpos = ftell(fp);
+  fseek(fp, 0, SEEK_END);
   size = ftell(fp);
   fseek(fp, oldpos, SEEK_SET);
 #endif
@@ -6507,13 +6510,13 @@ int hts_stat_utf8(const char *path, STRUCT_STAT * buf) {
   LPWSTR wpath = hts_convertUTF8StringToUCS2(path, (int) strlen(path), NULL);
 
   if (wpath != NULL) {
-    const int result = _wstat(wpath, buf);
+    const int result = _wstat64(wpath, buf);
 
     free(wpath);
     return result;
   } else {
     // Fallback on conversion error.
-    return _stat(path, buf);
+    return _stat64(path, buf);
   }
 }
 

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -4772,22 +4772,17 @@ LLint fsize_utf8(const char *s) {
   }
 }
 
+/* fseeko/ftello, never fseek/ftell: ftell returns long, which cannot carry an
+   offset past 2GB on a 32-bit platform and fails with EOVERFLOW there. */
 LLint fpsize(FILE *fp) {
   LLint oldpos, size;
 
   if (!fp)
     return -1;
-#ifdef HTS_FSEEKO
   oldpos = ftello(fp);
   fseeko(fp, 0, SEEK_END);
   size = ftello(fp);
   fseeko(fp, oldpos, SEEK_SET);
-#else
-  oldpos = ftell(fp);
-  fseek(fp, 0, SEEK_END);
-  size = ftell(fp);
-  fseek(fp, oldpos, SEEK_SET);
-#endif
   return size;
 }
 

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -310,10 +310,11 @@ void cut_path(char *fullpath, char *path, size_t path_size, char *pname,
 int fexist(const char *s);
 int fexist_utf8(const char *s);
 
-/*LLint fsize(const char* s);    */
-off_t fpsize(FILE * fp);
-off_t fsize(const char *s);
-off_t fsize_utf8(const char *s);
+/* File size in bytes, -1 if absent or not a regular file. LLint, not off_t:
+   the latter is a 32-bit long on MSVC, truncating any file of 2GB or more. */
+LLint fpsize(FILE *fp);
+LLint fsize(const char *s);
+LLint fsize_utf8(const char *s);
 
 // Threads
 typedef void *(*beginthread_type) (void *);
@@ -393,7 +394,8 @@ void *hts_get_callback(t_hts_htmlcheck_callbacks * callbacks,
      HTSEXT_API FILE *hts_fopen_utf8(const char *path, const char *mode);
 
 #define STAT hts_stat_utf8
-     typedef struct _stat STRUCT_STAT;
+     /* _stat64: _stat's st_size is a 32-bit long, even in x64 builds */
+     typedef struct _stat64 STRUCT_STAT;
      HTSEXT_API int hts_stat_utf8(const char *path, STRUCT_STAT * buf);
 
 #define UNLINK hts_unlink_utf8
@@ -591,9 +593,9 @@ HTS_STATIC int compare_mime(httrackp * opt, const char *mime, const char *file,
 #endif
 
 // returns (size_t) -1 upon error
-static HTS_UNUSED size_t off_t_to_size_t(off_t o) {
+static HTS_UNUSED size_t llint_to_size_t(LLint o) {
   const size_t so = (size_t) o;
-  if ((off_t) so == o) {
+  if ((LLint) so == o) {
     return so;
   } else {
     return (size_t) -1;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -64,6 +64,7 @@ Please visit our Website: http://www.httrack.com
 #include "coucal/coucal.h"
 
 #include <ctype.h>
+#include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -1528,23 +1529,26 @@ static int st_fsize(httrackp *opt, int argc, char **argv) {
   /* sparse: seek past 2GB and write the last byte */
   fp = FOPEN(path, "wb");
   if (fp == NULL) {
-    fprintf(stderr, "fsize: cannot create '%s'\n", path);
+    fprintf(stderr, "fsize: cannot create '%s': %s\n", path, strerror(errno));
     return 1;
   }
-  if (fseeko(fp, expected - 1, SEEK_SET) != 0 || fputc(0, fp) == EOF) {
-    fprintf(stderr, "fsize: cannot extend '%s' to " LLintP "\n", path,
-            expected);
-    fclose(fp);
+  if (fseeko(fp, expected - 1, SEEK_SET) != 0 || fputc(0, fp) == EOF ||
+      fclose(fp) != 0) {
+    fprintf(stderr, "fsize: cannot extend '%s' to " LLintP ": %s\n", path,
+            expected, strerror(errno));
     UNLINK(path);
     return 1;
   }
-  fclose(fp);
 
   got = fsize_utf8(path);
   fp = FOPEN(path, "rb");
-  gotp = fp != NULL ? fpsize(fp) : -1;
-  if (fp != NULL)
+  if (fp == NULL) {
+    fprintf(stderr, "fsize: cannot reopen '%s': %s\n", path, strerror(errno));
+    gotp = -1;
+  } else {
+    gotp = fpsize(fp);
     fclose(fp);
+  }
   UNLINK(path);
 
   printf("fsize: width=%d size=" LLintP " psize=" LLintP "\n", width, got,

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -72,6 +72,9 @@ Please visit our Website: http://www.httrack.com
 #ifndef _WIN32
 #include <sys/socket.h>
 #include <unistd.h>
+#else
+#include <io.h>       /* _get_osfhandle, for the sparse-file hint */
+#include <winioctl.h> /* FSCTL_SET_SPARSE */
 #endif
 
 /* very minimalistic internal tests */
@@ -1509,14 +1512,18 @@ static int st_sniff(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-/* fsize()/fpsize() must report a size past 2GB, where a 32-bit off_t wraps
-   (MSVC's off_t and struct _stat st_size are long, 32-bit even on x64). */
+/* fsize()/fsize_utf8()/fpsize() must report a size past 4GB: 32-bit wraps both
+   ways there (MSVC's off_t and struct _stat st_size are long, 32-bit even on
+   x64), and a size under 4GB would survive an *unsigned* 32-bit truncation. */
 static int st_fsize(httrackp *opt, int argc, char **argv) {
-  const LLint expected = 3 * 1024 * 1024 * 1024LL;
+  const LLint expected = 5 * 1024 * 1024 * 1024LL;
   char BIGSTK path[HTS_URLMAXSIZE * 2];
-  const int width = (int) sizeof(fsize_utf8(""));
+  char BIGSTK absent[HTS_URLMAXSIZE * 2];
+  /* both variants: only fsize() feeds the >2GB readers (file://, --list) */
+  const int width = (int) sizeof(fsize(""));
+  const int width_utf8 = (int) sizeof(fsize_utf8(""));
   FILE *fp;
-  LLint got, gotp;
+  LLint got, got_utf8, gotp, gone;
   int rc = 0;
 
   (void) opt;
@@ -1524,14 +1531,27 @@ static int st_fsize(httrackp *opt, int argc, char **argv) {
     fprintf(stderr, "fsize: needs a directory\n");
     return 1;
   }
-  concat(path, sizeof(path), argv[0], "/sparse-3g.bin");
+  concat(path, sizeof(path), argv[0], "/sparse-5g.bin");
+  concat(absent, sizeof(absent), argv[0], "/no-such-file.bin");
 
-  /* sparse: seek past 2GB and write the last byte */
+  /* sparse: seek past 4GB and write the last byte */
   fp = FOPEN(path, "wb");
   if (fp == NULL) {
     fprintf(stderr, "fsize: cannot create '%s': %s\n", path, strerror(errno));
     return 1;
   }
+#ifdef _WIN32
+  {
+    /* NTFS allocates the hole unless asked not to; POSIX gives it for free.
+       Best-effort: a non-sparse file still measures the same, just costs 5GB.
+     */
+    HANDLE h = (HANDLE) _get_osfhandle(_fileno(fp));
+    DWORD ret;
+
+    if (h != INVALID_HANDLE_VALUE)
+      (void) DeviceIoControl(h, FSCTL_SET_SPARSE, NULL, 0, NULL, 0, &ret, NULL);
+  }
+#endif
   if (fseeko(fp, expected - 1, SEEK_SET) != 0 || fputc(0, fp) == EOF ||
       fclose(fp) != 0) {
     fprintf(stderr, "fsize: cannot extend '%s' to " LLintP ": %s\n", path,
@@ -1540,7 +1560,8 @@ static int st_fsize(httrackp *opt, int argc, char **argv) {
     return 1;
   }
 
-  got = fsize_utf8(path);
+  got = fsize(path);
+  got_utf8 = fsize_utf8(path);
   fp = FOPEN(path, "rb");
   if (fp == NULL) {
     fprintf(stderr, "fsize: cannot reopen '%s': %s\n", path, strerror(errno));
@@ -1550,21 +1571,30 @@ static int st_fsize(httrackp *opt, int argc, char **argv) {
     fclose(fp);
   }
   UNLINK(path);
+  gone = fsize(absent); /* contract: -1, not 0, when absent */
 
-  printf("fsize: width=%d size=" LLintP " psize=" LLintP "\n", width, got,
-         gotp);
-  if (width != 8) {
-    fprintf(stderr, "fsize: return type is %d bytes, expected 8\n", width);
+  printf("fsize: width=%d,%d size=" LLintP "," LLintP " psize=" LLintP
+         " absent=" LLintP "\n",
+         width, width_utf8, got, got_utf8, gotp, gone);
+  if (width != 8 || width_utf8 != 8) {
+    fprintf(stderr, "fsize: return types are %d/%d bytes, expected 8\n", width,
+            width_utf8);
     rc = 1;
   }
-  if (got != expected) {
-    fprintf(stderr, "fsize: fsize_utf8 is " LLintP ", expected " LLintP "\n",
-            got, expected);
+  if (got != expected || got_utf8 != expected) {
+    fprintf(stderr,
+            "fsize: fsize/fsize_utf8 are " LLintP "/" LLintP
+            ", expected " LLintP "\n",
+            got, got_utf8, expected);
     rc = 1;
   }
   if (gotp != expected) {
     fprintf(stderr, "fsize: fpsize is " LLintP ", expected " LLintP "\n", gotp,
             expected);
+    rc = 1;
+  }
+  if (gone != -1) {
+    fprintf(stderr, "fsize: absent file is " LLintP ", expected -1\n", gone);
     rc = 1;
   }
   return rc;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1024,7 +1024,7 @@ static int st_hashtable(httrackp *opt, int argc, char **argv) {
 
   /* produce random patterns, or read from a file */
   if (sscanf(snum, "%lu", &count) != 1) {
-    const off_t size = fsize(snum);
+    const LLint size = fsize(snum);
     FILE *fp = fopen(snum, "rb");
     if (fp != NULL) {
       buff = malloct(size);
@@ -1490,6 +1490,64 @@ static int st_sniff(httrackp *opt, int argc, char **argv) {
          hts_sniff_mime_known(argv[0]) == HTS_TRUE,
          hts_sniff_mime_consistent(body, n, argv[0]) == HTS_TRUE);
   return 0;
+}
+
+/* fsize()/fpsize() must report a size past 2GB, where a 32-bit off_t wraps
+   (MSVC's off_t and struct _stat st_size are long, 32-bit even on x64). */
+static int st_fsize(httrackp *opt, int argc, char **argv) {
+  const LLint expected = 3 * 1024 * 1024 * 1024LL;
+  char BIGSTK path[HTS_URLMAXSIZE * 2];
+  const int width = (int) sizeof(fsize_utf8(""));
+  FILE *fp;
+  LLint got, gotp;
+  int rc = 0;
+
+  (void) opt;
+  if (argc < 1) {
+    fprintf(stderr, "fsize: needs a directory\n");
+    return 1;
+  }
+  concat(path, sizeof(path), argv[0], "/sparse-3g.bin");
+
+  /* sparse: seek past 2GB and write the last byte */
+  fp = FOPEN(path, "wb");
+  if (fp == NULL) {
+    fprintf(stderr, "fsize: cannot create '%s'\n", path);
+    return 1;
+  }
+  if (fseeko(fp, expected - 1, SEEK_SET) != 0 || fputc(0, fp) == EOF) {
+    fprintf(stderr, "fsize: cannot extend '%s' to " LLintP "\n", path,
+            expected);
+    fclose(fp);
+    UNLINK(path);
+    return 1;
+  }
+  fclose(fp);
+
+  got = fsize_utf8(path);
+  fp = FOPEN(path, "rb");
+  gotp = fp != NULL ? fpsize(fp) : -1;
+  if (fp != NULL)
+    fclose(fp);
+  UNLINK(path);
+
+  printf("fsize: width=%d size=" LLintP " psize=" LLintP "\n", width, got,
+         gotp);
+  if (width != 8) {
+    fprintf(stderr, "fsize: return type is %d bytes, expected 8\n", width);
+    rc = 1;
+  }
+  if (got != expected) {
+    fprintf(stderr, "fsize: fsize_utf8 is " LLintP ", expected " LLintP "\n",
+            got, expected);
+    rc = 1;
+  }
+  if (gotp != expected) {
+    fprintf(stderr, "fsize: fpsize is " LLintP ", expected " LLintP "\n", gotp,
+            expected);
+    rc = 1;
+  }
+  return rc;
 }
 
 static int st_savename(httrackp *opt, int argc, char **argv) {
@@ -2771,6 +2829,7 @@ static const struct selftest_entry {
      "local save-name for a URL", st_savename},
     {"sniff", "<content-type> <hex:..|text>", "MIME magic consistency",
      st_sniff},
+    {"fsize", "<dir>", "file size past the 2GB signed-32-bit wrap", st_fsize},
     {"cache", "<dir>", "cache read/write round-trip self-test", st_cache},
     {"cacheindex", "", "cache-index (.ndx) parse must stay in bounds",
      st_cacheindex},

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -743,7 +743,8 @@ HTSEXT_API hts_boolean hts_findissystem(find_handle find);
 HTSEXT_API FILE *hts_fopen_utf8(const char *path, const char *mode);
 
 #define STAT hts_stat_utf8
-typedef struct _stat STRUCT_STAT;
+/* _stat64: _stat's st_size is a 32-bit long, even in x64 builds */
+typedef struct _stat64 STRUCT_STAT;
 
 HTSEXT_API int hts_stat_utf8(const char *path, STRUCT_STAT *buf);
 

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -1385,7 +1385,7 @@ static char *cache_rstr_addr(FILE * fp) {
   char buff[256 + 4];
 
   linput(fp, buff, 256);
-  sscanf(buff, "%d", &i);
+  sscanf(buff, INTsysP, &i);
   if (i < 0 || i > 32768)       /* error, something nasty happened */
     i = 0;
   if (i > 0) {

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -1364,12 +1364,12 @@ static int cache_brstr(char *adr, char *s) {
 }
 
 static void cache_rstr(FILE * fp, char *s) {
-  INTsys i;
+  INTsys i = 0;
   char buff[256 + 4];
 
   linput(fp, buff, 256);
-  sscanf(buff, INTsysP, &i);
-  if (i < 0 || i > 32768)       /* error, something nasty happened */
+  /* an unmatched sscanf leaves i untouched: length 0, not a stack value */
+  if (sscanf(buff, INTsysP, &i) != 1 || i < 0 || i > 32768)
     i = 0;
   if (i > 0) {
     if ((int) fread(s, 1, i, fp) != i) {
@@ -1380,13 +1380,13 @@ static void cache_rstr(FILE * fp, char *s) {
 }
 
 static char *cache_rstr_addr(FILE * fp) {
-  INTsys i;
+  INTsys i = 0;
   char *addr = NULL;
   char buff[256 + 4];
 
   linput(fp, buff, 256);
-  sscanf(buff, INTsysP, &i);
-  if (i < 0 || i > 32768)       /* error, something nasty happened */
+  /* an unmatched sscanf leaves i untouched: length 0, not a stack value */
+  if (sscanf(buff, INTsysP, &i) != 1 || i < 0 || i > 32768)
     i = 0;
   if (i > 0) {
     addr = malloc(i + 1);

--- a/tests/01_engine-fsize.test
+++ b/tests/01_engine-fsize.test
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# File sizes past the 2GB signed-32-bit wrap ('httrack -#test=fsize <dir>').
+# Uses a sparse file, so it costs no real disk.
+
+set -eu
+
+dir=$(mktemp -d)
+trap 'rm -rf "$dir"' EXIT
+
+out=$(httrack -#test=fsize "$dir")
+echo "$out"
+
+test "$out" == "fsize: width=8 size=3221225472 psize=3221225472" || {
+    echo "FAIL: unexpected size report"
+    exit 1
+}

--- a/tests/01_engine-fsize.test
+++ b/tests/01_engine-fsize.test
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# File sizes past the 2GB signed-32-bit wrap ('httrack -#test=fsize <dir>').
-# Uses a sparse file, so it costs no real disk.
+# File sizes past the 32-bit wrap ('httrack -#test=fsize <dir>'). 5GB, so a
+# signed *and* an unsigned truncation both show up; sparse, so it costs no disk.
 
-set -eu
+set -euo pipefail
 
 dir=$(mktemp -d)
 trap 'rm -rf "$dir"' EXIT
@@ -11,7 +11,8 @@ trap 'rm -rf "$dir"' EXIT
 out=$(httrack -#test=fsize "$dir")
 echo "$out"
 
-test "$out" == "fsize: width=8 size=3221225472 psize=3221225472" || {
-    echo "FAIL: unexpected size report"
+want="fsize: width=8,8 size=5368709120,5368709120 psize=5368709120 absent=-1"
+test "$out" == "$want" || {
+    echo "FAIL: unexpected size report (want '$want')"
     exit 1
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -55,6 +55,7 @@ TESTS = \
 	01_engine-pause.test \
 	01_engine-rcfile.test \
 	01_engine-reconcile.test \
+	01_engine-fsize.test \
 	01_engine-redirect.test \
 	01_engine-relative.test \
 	01_engine-robots.test \


### PR DESCRIPTION
HTTrack on Windows mishandles any mirrored file of 2 GB or more. MSVC's `off_t` is a 32-bit `long` in x64 builds as well as Win32, and `struct _stat` expands to `_stat64i32`, whose `st_size` is that same 32-bit `long`. So `fsize()`, `fsize_utf8()` and `fpsize()` truncate in two places, the stat and their own return type, and widening the `STRUCT_STAT` typedef alone would not have been enough. The wrapped, usually negative size then feeds resume/206 handling, the cache body-size reads, and `readfile2()`'s allocation. `htsback.c` already carries two "not (off_t): 32-bit on MSVC" comments that route the truncate and the seek around this, but the value feeding that path was still 32-bit, so the hole they meant to close stayed open.

This switches Windows to the 64-bit `_stat64`/`_wstat64` family, returns `LLint` from the three size helpers, and widens the callers' locals to match. `INTsys` now covers MSVC, so `readfile2()` gets a 64-bit length there. `STRUCT_STAT` lives in an installed header, so `hts_stat_utf8()`'s signature changes: a deliberate Windows-only ABI break, agreed with Xavier, since the DLL ships next to the exe with no soname contract.

POSIX is unaffected on 64-bit, where `off_t` is already 64-bit under LFS, and no installed-header layout or exported signature moves there (so no soname bump). It is *not* unaffected on 32-bit: see the `fpsize()` fix below, which deliberately changes what 32-bit POSIX returns for a file past 2 GB.

The new `-#test=fsize` self-test builds a 3 GB sparse file, so it costs no real disk, and checks both the reported size and the 8-byte return width. It is not confirmation-biased: forcing the helpers back to a 32-bit return reproduces the Windows failure exactly, size -1073741824, and all three assertions fire. Suite is green at 93/93 with no new compiler warnings.

Closes #569. Found while investigating #565, whose self-test failures turned out to be unrelated test bugs (fixed in #567). This is the real bug behind that issue's `st_size` hypothesis.

Update, after the first CI run: the i386 leg caught a second, related bug that is not Windows-specific. `fpsize()` gated `fseeko`/`ftello` behind `HTS_FSEEKO`, which comes from `#ifdef LFS_FLAG`. But `LFS_FLAG` is a configure *make* variable carrying the `-D_FILE_OFFSET_BITS=64` flags, never a C macro, so that test is dead and every autotools build has been compiling the `ftell`/`fseek` fallback. `ftell` returns `long`: 64-bit on x86-64, which hid it, and 32-bit on i386, where it fails with `EOVERFLOW` past 2 GB and `fpsize()` returns -1. It now calls `fseeko`/`ftello` unconditionally, as `htsback.c` already does.

The same dead macro also leaves `INTsys` as plain `int` on POSIX, which caps `readfile2()` at 2 GB and hands `malloct(len + 1)` a possibly negative length. Widening it changes a typedef in an installed header, so it is out of scope here and left as a FIXME.