### PR TITLE
Cap the wildcard matcher's recursion depth

### DIFF
--- a/src/htsfilters.c
+++ b/src/htsfilters.c
@@ -122,8 +122,11 @@ int fa_strjoker_dual(int type, char **filters, int nfil, const char *nom1,
 }
 
 /* Real filters/URLs fit HTS_URLMAXSIZE*2; past it a hostile pattern recurses
-   O(len) deep or runs O(n^2*stars). Cap length (depth) and steps (work). */
+   O(len) deep or runs O(n^2*stars). Cap length, recursion depth and steps
+   (work): the length cap alone still allows ~2000 frames, ~900KB of stack,
+   which overflows the 1MB a Windows thread gets (#574). */
 #define STRJOKER_MAXLEN (HTS_URLMAXSIZE * 2)
+#define STRJOKER_MAXDEPTH 256u
 #define STRJOKER_MAXSTEPS 2000000u
 
 /* Failure memo for the recursive matcher: one bit per (chaine, joker) offset
@@ -133,20 +136,28 @@ typedef struct strjoker_memo {
   size_t stride;                /* strlen(joker0) + 1 */
   unsigned char *failed;        /* failed-pair bitmap; NULL: no memo */
   size_t *nsteps; /* shared work counter; NULL: unbounded (oracle) */
+  size_t maxdepth; /* deepest recursion reached */
+  hts_boolean cut; /* a branch hit the depth cap: its failures are not final */
 } strjoker_memo;
 
-static const char *strjoker_impl(const strjoker_memo *memo, const char *chaine,
-                                 const char *joker, LLint *size,
-                                 int *size_flag);
+static const char *strjoker_impl(strjoker_memo *memo, const char *chaine,
+                                 const char *joker, LLint *size, int *size_flag,
+                                 size_t depth);
 
 /* A pair that failed once fails forever (*size is only written on the success
    path), so record NULL results and cut the re-exploration. */
-static const char *strjoker_rec(const strjoker_memo *memo, const char *chaine,
-                                const char *joker, LLint *size,
-                                int *size_flag) {
+static const char *strjoker_rec(strjoker_memo *memo, const char *chaine,
+                                const char *joker, LLint *size, int *size_flag,
+                                size_t depth) {
   size_t bit = 0;
   const char *adr;
 
+  if (depth > memo->maxdepth)
+    memo->maxdepth = depth;
+  if (depth >= STRJOKER_MAXDEPTH) {
+    memo->cut = HTS_TRUE;
+    return NULL; /* nesting beyond any real filter: fail the branch safely */
+  }
   if (memo->nsteps != NULL && ++*memo->nsteps > STRJOKER_MAXSTEPS)
     return NULL; /* work budget spent: fail the match safely */
   if (memo->failed) {
@@ -155,8 +166,9 @@ static const char *strjoker_rec(const strjoker_memo *memo, const char *chaine,
     if (memo->failed[bit >> 3] & (unsigned char) (1u << (bit & 7)))
       return NULL;
   }
-  adr = strjoker_impl(memo, chaine, joker, size, size_flag);
-  if (adr == NULL && memo->failed)
+  adr = strjoker_impl(memo, chaine, joker, size, size_flag, depth + 1);
+  /* a cut branch may fail here yet match when reached at a shallower depth */
+  if (adr == NULL && memo->failed && !memo->cut)
     memo->failed[bit >> 3] |= (unsigned char) (1u << (bit & 7));
   return adr;
 }
@@ -164,13 +176,15 @@ static const char *strjoker_rec(const strjoker_memo *memo, const char *chaine,
 /* Match chaine against joker with a shared work budget *nsteps (a strjokerfind
    sweep passes one counter, bounding the whole scan). */
 static const char *strjoker_bounded(const char *chaine, const char *joker,
-                                    LLint *size, int *size_flag,
-                                    size_t *nsteps) {
-  strjoker_memo memo = {chaine, joker, 0, NULL, nsteps};
+                                    LLint *size, int *size_flag, size_t *nsteps,
+                                    size_t *maxdepth) {
+  strjoker_memo memo = {chaine, joker, 0, NULL, nsteps, 0, HTS_FALSE};
   unsigned char stackbits[2048];
   hts_boolean onheap = HTS_FALSE;
   const char *adr;
 
+  if (maxdepth != NULL)
+    *maxdepth = 0;
   if (chaine != NULL && joker != NULL) {
     const size_t l1 = strlen(chaine), l2 = strlen(joker);
 
@@ -189,9 +203,11 @@ static const char *strjoker_bounded(const char *chaine, const char *joker,
       }
     }
   }
-  adr = strjoker_rec(&memo, chaine, joker, size, size_flag);
+  adr = strjoker_rec(&memo, chaine, joker, size, size_flag, 0);
   if (onheap)
     freet(memo.failed);
+  if (maxdepth != NULL)
+    *maxdepth = memo.maxdepth;
   return adr;
 }
 
@@ -202,34 +218,39 @@ HTS_INLINE const char *strjoker(const char *chaine, const char *joker,
                                 LLint *size, int *size_flag) {
   size_t nsteps = 0;
 
-  return strjoker_bounded(chaine, joker, size, size_flag, &nsteps);
+  return strjoker_bounded(chaine, joker, size, size_flag, &nsteps, NULL);
 }
 
 /* Test-only oracle: the same matcher without the failure memo. */
 const char *strjoker_nomemo(const char *chaine, const char *joker, LLint *size,
                             int *size_flag) {
-  const strjoker_memo memo = {chaine, joker, 0, NULL};
+  strjoker_memo memo = {chaine, joker, 0, NULL, NULL, 0, HTS_FALSE};
 
-  return strjoker_rec(&memo, chaine, joker, size, size_flag);
+  return strjoker_rec(&memo, chaine, joker, size, size_flag, 0);
 }
 
-/* Test-only: strjoker() reporting the work-budget steps spent and the cap, so a
-   self-test can prove the budget bounds a hostile pattern's work. */
-const char *strjoker_steps(const char *chaine, const char *joker,
-                           size_t *nsteps_out, size_t *maxsteps_out) {
-  size_t nsteps = 0;
-  const char *r = strjoker_bounded(chaine, joker, NULL, NULL, &nsteps);
+/* Test-only: strjoker() reporting the work and depth spent and their caps, so a
+   self-test can prove both bound a hostile pattern. */
+const char *strjoker_bounds(const char *chaine, const char *joker,
+                            size_t *nsteps_out, size_t *maxsteps_out,
+                            size_t *depth_out, size_t *maxdepth_out) {
+  size_t nsteps = 0, depth = 0;
+  const char *r = strjoker_bounded(chaine, joker, NULL, NULL, &nsteps, &depth);
 
   if (nsteps_out != NULL)
     *nsteps_out = nsteps;
   if (maxsteps_out != NULL)
     *maxsteps_out = STRJOKER_MAXSTEPS;
+  if (depth_out != NULL)
+    *depth_out = depth;
+  if (maxdepth_out != NULL)
+    *maxdepth_out = STRJOKER_MAXDEPTH;
   return r;
 }
 
-static const char *strjoker_impl(const strjoker_memo *memo, const char *chaine,
-                                 const char *joker, LLint *size,
-                                 int *size_flag) {
+static const char *strjoker_impl(strjoker_memo *memo, const char *chaine,
+                                 const char *joker, LLint *size, int *size_flag,
+                                 size_t depth) {
   if (strnotempty(joker) == 0) {        // fin de chaine joker
     if (strnotempty(chaine) == 0)       // fin aussi pour la chaine: ok
       return chaine;
@@ -403,7 +424,8 @@ static const char *strjoker_impl(const strjoker_memo *memo, const char *chaine,
 
       // tester sans le joker (pas ()+ mais ()*)
       if (!unique) {
-        if ((adr = strjoker_rec(memo, chaine, joker + jmp, size, size_flag))) {
+        if ((adr = strjoker_rec(memo, chaine, joker + jmp, size, size_flag,
+                                depth))) {
           return adr;
         }
       }
@@ -416,7 +438,7 @@ static const char *strjoker_impl(const strjoker_memo *memo, const char *chaine,
       while(i < (int) max) {
         if (pass[(int) (unsigned char) chaine[i]]) {    // caractère autorisé
           if ((adr = strjoker_rec(memo, chaine + i + 1, joker + jmp, size,
-                                  size_flag))) {
+                                  size_flag, depth))) {
             return adr;
           }
           i++;
@@ -427,7 +449,7 @@ static const char *strjoker_impl(const strjoker_memo *memo, const char *chaine,
       // tester chaîne vide
       if (i != max + 2)         // avant c'est ok
         if ((adr = strjoker_rec(memo, chaine + max, joker + jmp, size,
-                                size_flag)))
+                                size_flag, depth)))
           return adr;
 
       return NULL;              // perdu
@@ -449,7 +471,8 @@ static const char *strjoker_impl(const strjoker_memo *memo, const char *chaine,
       // comparaison ok?
       if (ok) {
         // continuer la comparaison.
-        if (strjoker_rec(memo, chaine + jmp, joker + jmp, size, size_flag))
+        if (strjoker_rec(memo, chaine + jmp, joker + jmp, size, size_flag,
+                         depth))
           return chaine;        // retourner 1e lettre
       }
 
@@ -471,8 +494,8 @@ const char *strjokerfind(const char *chaine, const char *joker) {
   if (chaine != NULL && strlen(chaine) > STRJOKER_MAXLEN)
     return NULL;
   while(*chaine) {
-    if ((adr = strjoker_bounded(chaine, joker, NULL, NULL,
-                                &nsteps))) { // ok trouvé
+    if ((adr = strjoker_bounded(chaine, joker, NULL, NULL, &nsteps,
+                                NULL))) { // ok trouvé
       return adr;
     }
     if (nsteps > STRJOKER_MAXSTEPS) // scan budget spent: no match

--- a/src/htsfilters.h
+++ b/src/htsfilters.h
@@ -52,10 +52,12 @@ HTS_INLINE const char *strjoker(const char *chaine, const char *joker, LLint * s
    oracle for the memoized matcher. */
 const char *strjoker_nomemo(const char *chaine, const char *joker, LLint *size,
                             int *size_flag);
-/* strjoker() reporting the work-budget steps it spent and the cap; test-only,
-   lets a self-test assert the budget bounds a hostile pattern's work. */
-const char *strjoker_steps(const char *chaine, const char *joker,
-                           size_t *nsteps_out, size_t *maxsteps_out);
+/* strjoker() reporting the work-budget steps and the recursion depth it spent,
+   with their caps; test-only, lets a self-test assert both bound a hostile
+   pattern (depth bounds the stack: an uncapped one overflows Windows' 1MB). */
+const char *strjoker_bounds(const char *chaine, const char *joker,
+                            size_t *nsteps_out, size_t *maxsteps_out,
+                            size_t *depth_out, size_t *maxdepth_out);
 const char *strjokerfind(const char *chaine, const char *joker);
 #endif
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -784,6 +784,16 @@ static int st_filterbounds(httrackp *opt, int argc, char **argv) {
   /* Depth caps the stack: uncapped this recurses 2046 frames, ~900KB (#574). */
   assertf(depth == maxdepth);
   assertf(strjokerfind(subj, pat) == NULL);
+  /* Pin the cap from below: 32 segments must still match, so a cap set so low
+     it would break real multi-segment filters (which use far fewer) fails. */
+  for (i = 0; i < 32; i++) {
+    pat[2 * i] = '*';
+    pat[2 * i + 1] = 'a';
+  }
+  pat[64] = '\0';
+  memset(subj, 'a', 32);
+  subj[32] = '\0';
+  assertf(strjoker(subj, pat, NULL, NULL) != NULL);
   freet(pat);
   freet(subj);
   printf("filterbounds: OK\n");

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -757,7 +757,7 @@ static int st_filterbounds(httrackp *opt, int argc, char **argv) {
   const size_t subjlen = 2048;
   char *subj = malloct(big + 1);
   char *pat = malloct(2 * stars + 2);
-  size_t steps = 0, maxsteps = 0, i;
+  size_t steps = 0, maxsteps = 0, depth = 0, maxdepth = 0, i;
 
   (void) opt;
   (void) argc;
@@ -778,8 +778,11 @@ static int st_filterbounds(httrackp *opt, int argc, char **argv) {
   subj[subjlen] = '\0';
   /* Budget must fire and hold: steps > cap (deleting the budget zeroes the
      counter that is the enforcement), steps < 10*cap (unbudgeted ~1.26e9). */
-  assertf(strjoker_steps(subj, pat, &steps, &maxsteps) == NULL);
+  assertf(strjoker_bounds(subj, pat, &steps, &maxsteps, &depth, &maxdepth) ==
+          NULL);
   assertf(steps > maxsteps && steps < 10 * maxsteps);
+  /* Depth caps the stack: uncapped this recurses 2046 frames, ~900KB (#574). */
+  assertf(depth == maxdepth);
   assertf(strjokerfind(subj, pat) == NULL);
   freet(pat);
   freet(subj);

--- a/tests/01_engine-filter.test
+++ b/tests/01_engine-filter.test
@@ -193,5 +193,13 @@ test "$(with_timeout httrack -O /dev/null -#test=filter "$pat" "$subj")" == "$su
 match '*[aX]X*[a]Y' 'aXaXaY'
 nomatch '*[aX]X*[a]Y' 'aXbXaY'
 
-# hostile patterns must not stack-overflow or hang: length + work caps
+# hostile patterns must not stack-overflow or hang: length + depth + work caps
 test "$(with_timeout httrack -O /dev/null -#test=filterbounds)" == "filterbounds: OK" || exit 1
+
+# and the depth cap must hold on the 1MB stack a Windows thread gets (#574):
+# uncapped, the same pattern recursed ~900KB deep. Skipped where 512K is too
+# small to even start the binary.
+if (ulimit -s 512 && httrack --version >/dev/null 2>&1); then
+    out=$(ulimit -s 512 && with_timeout httrack -O /dev/null -#test=filterbounds)
+    test "$out" == "filterbounds: OK" || exit 1
+fi


### PR DESCRIPTION
The filter matcher recursed once per pattern segment, bounded only by the pattern-length cap: a hostile filter of 1023 stars reached 2046 frames, about 900KB of stack. That fits Linux's 8MB but not the 1MB a Windows thread gets, so `httrack -#test=filterbounds` died silently on MSVC x64 and Win32 instead of rejecting the pattern. The step budget from #551 caps work, not depth, so it never fired in time.

Depth is now capped at 256; real filters use fewer than ten. A branch cut by the cap does not memoize its failure, since the same pair may still match when reached at a shallower depth.

This reproduces on Linux, which is how it was diagnosed and how the test guards it: the self-test asserts the depth reached equals the cap, and 01_engine-filter re-runs it under a 512K stack, which segfaults on master.

Closes #574.