### PR TITLE
Run the engine test suite on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 # Resource scripts are Windows tooling input and must stay CRLF: the engine has no
 # encoding guard, so an autocrlf checkout could otherwise flatten them silently.
 *.rc text eol=crlf
+
+# The test scripts run under Git Bash on the Windows CI; a CRLF checkout makes
+# bash die on $'\r' on every line of them.
+*.test text eol=lf
+*.sh text eol=lf

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -119,38 +119,61 @@ jobs:
             throw "CRT mismatch across the boundary: libhttrack.dll=$a httrack.exe=$b"
           }
 
-      # The engine self-tests exercise the codecs the DLL was linked with: a
-      # missing brotli/zstd decoder shows up here, not just at link time.
-      - name: Run the content-coding self-tests
-        shell: pwsh
+      # The engine ships ~90 tests and none had ever run on Windows: "make check"
+      # is Linux/macOS only. These are the offline ones, driven from Git Bash
+      # against the native httrack.exe. They subsume the self-tests this step
+      # used to run inline (codecs, cache, fsize).
+      - name: Run the engine test suite (offline tests)
+        shell: bash
+        working-directory: tests
         run: |
-          $ErrorActionPreference = "Stop"
-          $exe = "src\${{ matrix.platform }}\${{ matrix.configuration }}\httrack.exe"
-          $tmp = New-Item -ItemType Directory -Path (Join-Path $env:RUNNER_TEMP "st")
-          foreach ($t in @("acceptencoding", "contentcodings")) {
-            $out = & $exe -O NUL "-#test=$t" $tmp.FullName run
-            if ($LASTEXITCODE -ne 0) { throw "$t failed" }
-            if (-not ($out | Select-String -SimpleMatch "$t self-test OK")) {
-              throw "$t did not report OK: $out"
-            }
-            Write-Host ($out -join "`n")
-          }
+          set -u
+          bin="$(cygpath -u "$GITHUB_WORKSPACE")/src/${{ matrix.platform }}/${{ matrix.configuration }}"
+          export PATH="$bin:$PATH"
+          command -v httrack >/dev/null || { echo "::error::no httrack.exe in $bin"; exit 1; }
 
-      # These fail only on Windows: the cache ones on a DOS-ified save name (fconv
-      # is a no-op on POSIX, so make check cannot see it), fsize on a 32-bit
-      # st_size/off_t. They report failure by exit code, not an "OK" line.
-      - name: Run the Windows-sensitive self-tests
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          $exe = "src\${{ matrix.platform }}\${{ matrix.configuration }}\httrack.exe"
-          foreach ($t in @("cache", "cache-corrupt", "fsize")) {
-            $tmp = New-Item -ItemType Directory -Force `
-              -Path (Join-Path $env:RUNNER_TEMP "st-$t")
-            $out = & $exe -O NUL "-#test=$t" $tmp.FullName run 2>&1
-            Write-Host ($out -join "`n")
-            if ($LASTEXITCODE -ne 0) { throw "$t failed (exit $LASTEXITCODE)" }
-          }
+          # httrack.exe is native, so MSYS rewrites any argument shaped like a
+          # POSIX path, and a URL path is shaped exactly like one: "/a/b.html"
+          # reached the engine as "C:/Program Files/Git/a/b.html". Switch that
+          # off, and hand the tests a TMPDIR that is already a Windows path.
+          export MSYS_NO_PATHCONV=1
+          export MSYS2_ARG_CONV_EXCL='*'
+          TMPDIR="$(cygpath -m "$RUNNER_TEMP")"
+          export TMPDIR
+
+          pass=0 fail=0 skip=0 failed=""
+          for t in 00_runnable.test 01_engine-*.test 01_zlib-*.test; do
+            rc=0
+            bash "$t" >"$t.log" 2>&1 || rc=$?
+            case "$rc" in
+              0) pass=$((pass + 1)); echo "PASS $t" ;;
+              77) skip=$((skip + 1)); echo "SKIP $t" ;;
+              *)
+                fail=$((fail + 1)) failed="$failed $t"
+                echo "FAIL $t (exit $rc)"
+                # These assert with `test "$(...)" == "..." || exit 1`, which
+                # says nothing at all on failure. Re-run traced.
+                bash -x "$t" >>"$t.log" 2>&1 || true
+                tail -n 25 "$t.log" | sed 's/^/      /'
+                ;;
+            esac
+          done
+          echo "ran=$((pass + fail + skip)) pass=$pass fail=$fail skip=$skip" |
+            tee -a "$GITHUB_STEP_SUMMARY"
+
+          # Every gate in these scripts exits 77, so a suite that degraded to
+          # all-skipped would report green having tested nothing: assert a floor
+          # on what actually ran, not just the absence of failures.
+          [ "$pass" -ge 45 ] || { echo "::error::only $pass tests passed ($skip skipped)"; exit 1; }
+          [ "$fail" -eq 0 ] || { echo "::error::failing:$failed"; exit 1; }
+
+      - name: Upload the test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: engine-tests-${{ matrix.platform }}-${{ matrix.configuration }}
+          path: tests/*.log
+          if-no-files-found: warn
 
       - name: Upload MSBuild logs
         if: always()

--- a/src/htscharset.c
+++ b/src/htscharset.c
@@ -31,6 +31,9 @@ Please visit our Website: http://www.httrack.com
 /* ------------------------------------------------------------ */
 
 #include "htscharset.h"
+#ifdef _WIN32
+#include <shellapi.h>
+#endif
 #include "htsbase.h"
 #include "punycode.h"
 #include "htssafe.h"
@@ -384,6 +387,40 @@ char *hts_convertStringFromUTF8(const char *s, size_t size, const char *charset)
 
 char *hts_convertStringSystemToUTF8(const char *s, size_t size) {
   return hts_convertStringCPToUTF8(s, size, GetACP());
+}
+
+HTSEXT_API void hts_argv_utf8(int *pargc, char ***pargv) {
+  int wargc = 0;
+  LPWSTR *const wargv = CommandLineToArgvW(GetCommandLineW(), &wargc);
+  char **argv;
+  int i;
+
+  // On any failure keep the CRT's ANSI argv: lossy, but never half-converted.
+  if (wargv == NULL)
+    return;
+  if (wargc <= 0 ||
+      (argv = calloct((size_t) wargc + 1, sizeof(char *))) == NULL) {
+    LocalFree(wargv);
+    return;
+  }
+  for (i = 0; i < wargc; i++) {
+    const int wsize = (int) wcslen(wargv[i]);
+
+    // hts_convertUCS2StringToUTF8() returns NULL on an empty string
+    argv[i] =
+        wsize != 0 ? hts_convertUCS2StringToUTF8(wargv[i], wsize) : strdupt("");
+    if (argv[i] == NULL) {
+      while (i-- != 0)
+        freet(argv[i]);
+      freet(argv);
+      LocalFree(wargv);
+      return;
+    }
+  }
+  argv[wargc] = NULL; // callers may rely on argv[argc] == NULL
+  LocalFree(wargv);
+  *pargc = wargc;
+  *pargv = argv; // never freed: argv lives for the process
 }
 
 #else

--- a/src/htscharset.h
+++ b/src/htscharset.h
@@ -34,6 +34,7 @@ Please visit our Website: http://www.httrack.com
 #define HTS_CHARSET_DEFH
 
 /** Standard includes. **/
+#include "htsglobal.h"
 #include <stdlib.h>
 #include <string.h>
 #ifdef _WIN32
@@ -175,6 +176,15 @@ extern char *hts_convertUCS2StringToUTF8(LPWSTR woutput, int wsize);
  * This function is WIN32 specific.
  **/
 extern char *hts_convertStringSystemToUTF8(const char *s, size_t size);
+
+/**
+ * Replace the CRT's ANSI argv by a UTF-8 one decoded from the real UTF-16
+ * command line: every char* is UTF-8 on Windows (FOPEN, STAT, ... convert at
+ * the syscall boundary). Keeps the CRT's argv on failure; the new array is
+ * writable, NULL-terminated, and lives for the process.
+ * This function is WIN32 specific.
+ **/
+HTSEXT_API void hts_argv_utf8(int *pargc, char ***pargv);
 #endif
 
 #endif

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -2584,21 +2584,11 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                 hts_get_version_info(opt), t, url);
         fprintf(opt->log, "(");
         for(i = 0; i < argc; i++) {
-#ifdef _WIN32
-          char *carg =
-            hts_convertStringSystemToUTF8(argv[i], (int) strlen(argv[i]));
-          char *arg = carg != NULL ? carg : argv[i];
-#else
-          const char *arg = argv[i];
-#endif
+          const char *arg = argv[i]; // already UTF-8 on every platform
           if (strchr(arg, ' ') == NULL || strchr(arg, '\"') != NULL)
             fprintf(opt->log, "%s ", arg);
           else                  // entre "" (si espace(s) et pas déja de ")
             fprintf(opt->log, "\"%s\" ", arg);
-#ifdef _WIN32
-          if (carg != NULL)
-            free(carg);
-#endif
         }
         fprintf(opt->log, ")" LF);
         fprintf(opt->log, LF);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -820,7 +820,11 @@ static int st_mime(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+static size_t st_decode_body(const char *arg, char *buf, size_t size);
+
 static int st_charset(httrackp *opt, int argc, char **argv) {
+  char buf[512];
+  size_t len;
   char *s;
 
   (void) opt;
@@ -828,7 +832,8 @@ static int st_charset(httrackp *opt, int argc, char **argv) {
     fprintf(stderr, "charset: needs a charset and a string\n");
     return 1;
   }
-  s = hts_convertStringToUTF8(argv[1], strlen(argv[1]), argv[0]);
+  len = st_decode_body(argv[1], buf, sizeof(buf));
+  s = hts_convertStringToUTF8(buf, len, argv[0]);
   if (s != NULL) {
     printf("%s\n", s);
     freet(s);
@@ -853,12 +858,16 @@ static int st_metacharset(httrackp *opt, int argc, char **argv) {
 }
 
 static int st_isutf8(httrackp *opt, int argc, char **argv) {
+  char buf[512];
+  size_t len;
+
   (void) opt;
   if (argc < 1) {
     fprintf(stderr, "isutf8: needs a string\n");
     return 1;
   }
-  printf("%d\n", hts_isStringUTF8(argv[0], strlen(argv[0])) ? 1 : 0);
+  len = st_decode_body(argv[0], buf, sizeof(buf));
+  printf("%d\n", hts_isStringUTF8(buf, len) ? 1 : 0);
   return 0;
 }
 
@@ -1616,7 +1625,8 @@ static int st_crange(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-/* Decode a body argument ("hex:FFD8.." or literal text) into buf. */
+/* Decode an argument ("hex:FFD8.." or literal text) into buf. Raw non-UTF-8
+   bytes cannot survive a Windows command line, so hostile inputs go as hex. */
 static size_t st_decode_body(const char *arg, char *buf, size_t size) {
   size_t n = 0;
 
@@ -2890,11 +2900,43 @@ static int st_robots(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* Connected stream pair over loopback; Windows has no socketpair(). */
+static int st_socketpair(T_SOC sv[2]) {
+  struct sockaddr_in sa;
+  socklen_t len = sizeof(sa);
+  T_SOC srv, cli, acc;
+
+  memset(&sa, 0, sizeof(sa));
+  sa.sin_family = AF_INET;
+  sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  if ((srv = (T_SOC) socket(AF_INET, SOCK_STREAM, 0)) == INVALID_SOCKET)
+    return -1;
+  if (bind(srv, (struct sockaddr *) &sa, sizeof(sa)) != 0 ||
+      listen(srv, 1) != 0 ||
+      getsockname(srv, (struct sockaddr *) &sa, &len) != 0) {
+    deletesoc(srv);
+    return -1;
+  }
+  if ((cli = (T_SOC) socket(AF_INET, SOCK_STREAM, 0)) == INVALID_SOCKET) {
+    deletesoc(srv);
+    return -1;
+  }
+  if (connect(cli, (struct sockaddr *) &sa, sizeof(sa)) != 0 ||
+      (acc = (T_SOC) accept(srv, NULL, NULL)) == INVALID_SOCKET) {
+    deletesoc(cli);
+    deletesoc(srv);
+    return -1;
+  }
+  deletesoc(srv);
+  sv[0] = acc;
+  sv[1] = cli;
+  return 0;
+}
+
 /* get_ftp_line must bound a hostile, CRLF-less reply into its internal
    1024-byte buffer; ASan turns the pre-fix overflow into an abort here. */
-#ifndef _WIN32
 static int st_ftpline(httrackp *opt, int argc, char **argv) {
-  int sv[2];
+  T_SOC sv[2];
   char line[2048];
   char flood[4096];
 
@@ -2902,19 +2944,19 @@ static int st_ftpline(httrackp *opt, int argc, char **argv) {
   (void) argc;
   (void) argv;
   memset(flood, 'x', sizeof(flood));
-  assertf(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
-  assertf(write(sv[1], "220 ", 4) == 4); // valid 3-digit code
-  assertf(write(sv[1], flood, sizeof(flood)) == (ssize_t) sizeof(flood));
-  assertf(write(sv[1], "\r\n", 2) == 2); // end the line so we return
-  close(sv[1]);
+  assertf(st_socketpair(sv) == 0);
+  // the 4102-byte reply fits the loopback send buffer, so no reader is needed
+  assertf(send(sv[1], "220 ", 4, 0) == 4); // valid 3-digit code
+  assertf(send(sv[1], flood, (int) sizeof(flood), 0) == (int) sizeof(flood));
+  assertf(send(sv[1], "\r\n", 2, 0) == 2); // end the line so we return
+  deletesoc(sv[1]);
   line[0] = '\0';
   get_ftp_line(sv[0], line, sizeof(line), 5);
-  close(sv[0]);
+  deletesoc(sv[0]);
   printf("ftp-line self-test OK (bounded %d-byte reply)\n",
          (int) sizeof(flood));
   return 0;
 }
-#endif
 
 /* ftp_split_userpass: well-formed split, plus a hostile over-long userinfo
    that pre-fix overran user[256]/pass[256]. */
@@ -2986,11 +3028,11 @@ static const struct selftest_entry {
     {"redirect-samefile", "", "same-file redirect detection self-test (#159)",
      st_redirect_samefile},
     {"mime", "<filename>", "MIME type for a filename", st_mime},
-    {"charset", "<charset> <string>",
+    {"charset", "<charset> <hex:..|string>",
      "convert a string to UTF-8 from a charset", st_charset},
     {"metacharset", "<html>", "extract the <meta> charset from an HTML page",
      st_metacharset},
-    {"isutf8", "<string>", "is the string valid UTF-8 (1/0)", st_isutf8},
+    {"isutf8", "<hex:..|string>", "is the string valid UTF-8 (1/0)", st_isutf8},
     {"idna-encode", "<host>", "encode a hostname to IDNA/punycode",
      st_idna_encode},
     {"idna-decode", "<host>", "decode an IDNA/punycode hostname",
@@ -3058,10 +3100,8 @@ static const struct selftest_entry {
      st_contentcodings},
     {"robots", "", "robots.txt RFC 9309 Allow/Disallow precedence self-test",
      st_robots},
-#ifndef _WIN32
     {"ftp-line", "", "get_ftp_line bounds a hostile FTP reply line",
      st_ftpline},
-#endif
     {"ftp-userpass", "", "ftp_split_userpass bounds URL userinfo", st_ftpuser},
 };
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -872,6 +872,8 @@ static int st_isutf8(httrackp *opt, int argc, char **argv) {
 }
 
 static int st_idna_encode(httrackp *opt, int argc, char **argv) {
+  char buf[512];
+  size_t len;
   char *s;
 
   (void) opt;
@@ -879,7 +881,8 @@ static int st_idna_encode(httrackp *opt, int argc, char **argv) {
     fprintf(stderr, "idna-encode: needs a hostname\n");
     return 1;
   }
-  s = hts_convertStringUTF8ToIDNA(argv[0], strlen(argv[0]));
+  len = st_decode_body(argv[0], buf, sizeof(buf));
+  s = hts_convertStringUTF8ToIDNA(buf, len);
   if (s != NULL) {
     printf("%s\n", s);
     freet(s);
@@ -1141,7 +1144,10 @@ static int st_strsafe(httrackp *opt, int argc, char **argv) {
        comes from argv so its length is opaque to the compiler (no static
        -Wstringop-overflow, genuine runtime check). "overflow-buff" exercises
        htsbuff. */
-    char small[4];
+    /* Not sizeof(char*): on ILP32 a char[4] equals the pointer size, and the
+       MSVC array-vs-pointer heuristic (sizeof(A) != sizeof(char*)) then reads
+       it as a pointer and silently skips the bound. */
+    char small[6];
     const char *const src = (argc >= 2) ? argv[1] : "overflowing";
 
     if (strcmp(argv[0], "overflow-buff") == 0) {

--- a/src/httrack.c
+++ b/src/httrack.c
@@ -40,6 +40,7 @@ Please visit our Website: http://www.httrack.com
 #include "httrack-library.h"
 
 #include "htsglobal.h"
+#include "htscharset.h"
 #include "htsbase.h"
 #include "htsopt.h"
 #include "htsdefines.h"
@@ -206,6 +207,7 @@ int main(int argc, char **argv) {
   httrackp *opt;
 
 #ifdef _WIN32
+  hts_argv_utf8(&argc, &argv);
   {
     WORD wVersionRequested;     // requested version WinSock API
     WSADATA wsadata;            // Windows Sockets API data

--- a/src/httrack.c
+++ b/src/httrack.c
@@ -40,12 +40,12 @@ Please visit our Website: http://www.httrack.com
 #include "httrack-library.h"
 
 #include "htsglobal.h"
-#include "htscharset.h"
 #include "htsbase.h"
 #include "htsopt.h"
 #include "htsdefines.h"
 #include "httrack.h"
 #include "htslib.h"
+#include "htscharset.h" // after htslib.h: winsock2.h must precede windows.h
 
 /* Static definitions */
 static int fexist(const char *s);

--- a/src/libhttrack.vcxproj
+++ b/src/libhttrack.vcxproj
@@ -70,7 +70,7 @@
     <Link>
       <!-- vcpkg auto-links libssl/libcrypto/zlib/brotli/zstd; only the OS import
            lib is explicit. -->
-      <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Ws2_32.lib;Shell32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>

--- a/tests/01_engine-charset.test
+++ b/tests/01_engine-charset.test
@@ -23,7 +23,7 @@ conv 'iso-8859-1' 'café' 'cafÃ©'
 
 # windows-1252 is NOT latin-1: 0x80 is the euro sign, not U+0080. This is the
 # case that actually exercises the cp1252 table (the 0x80-0x9F range).
-conv 'windows-1252' $'\x80' '€'
+conv 'windows-1252' 'hex:80' '€'
 
 # pure ASCII is charset-invariant
 conv 'us-ascii' 'hello' 'hello'
@@ -34,8 +34,8 @@ conv 'no-such-charset-xyz' 'abc' 'abc'
 test "$(httrack -O /dev/null -#test=charset 'no-such-charset-xyz' 'café' 2>/dev/null)" == "" || exit 1
 
 # malformed UTF-8 (lone continuation byte, truncated lead byte) must not crash
-runs 'utf-8' $'\x80'
-runs 'utf-8' $'\xc3'
+runs 'utf-8' 'hex:80'
+runs 'utf-8' 'hex:c3'
 
 # hts_getCharsetFromMeta: <meta> charset extraction, HTML5 and legacy forms.
 # -#test=metacharset <html> prints the charset, or "(none)".
@@ -89,11 +89,11 @@ utf8() {
 utf8 'plain' '1'
 utf8 'café' '1'
 utf8 '统计' '1'
-utf8 "$(printf 'caf\xe9')" '0'              # latin-1 accent
-utf8 "$(printf '\xc3')" '0'                 # truncated lead byte
-utf8 "$(printf '\xa9')" '0'                 # lone continuation byte
-utf8 "$(printf '\xf0\x9f\x98\x80')" '1'     # 4-byte emoji
-utf8 "$(printf '\xc0\xaf')" '0'             # overlong (latin-1 "À¯" must stay convertible)
-utf8 "$(printf '\xed\xa0\x80')" '0'         # UTF-16 surrogate
-utf8 "$(printf '\xf4\x90\x80\x80')" '0'     # above U+10FFFF
-utf8 "$(printf '\xf8\x88\x80\x80\x80')" '0' # legacy 5-byte form
+utf8 'hex:636166e9' '0'   # latin-1 accent
+utf8 'hex:c3' '0'         # truncated lead byte
+utf8 'hex:a9' '0'         # lone continuation byte
+utf8 'hex:f09f9880' '1'   # 4-byte emoji
+utf8 'hex:c0af' '0'       # overlong (latin-1 "À¯" must stay convertible)
+utf8 'hex:eda080' '0'     # UTF-16 surrogate
+utf8 'hex:f4908080' '0'   # above U+10FFFF
+utf8 'hex:f888808080' '0' # legacy 5-byte form

--- a/tests/01_engine-filelist.test
+++ b/tests/01_engine-filelist.test
@@ -52,14 +52,15 @@ run "$tmp/dir" "$tmp/adir"
 loghas 'Could not include URL list "[^"]+": not a regular file'
 
 # unreadable regular file: the fopen() errno arm fires, distinct from the
-# directory branch. Root bypasses mode 000, so skip it there.
-if test "$(id -u)" -ne 0; then
-    : >"$tmp/noperm.txt"
-    chmod 000 "$tmp/noperm.txt"
+# directory branch. Needs an OS that enforces mode 000: root bypasses it, and
+# Windows ignores chmod entirely, so probe rather than assume.
+: >"$tmp/noperm.txt"
+chmod 000 "$tmp/noperm.txt"
+if ! cat "$tmp/noperm.txt" >/dev/null 2>&1; then
     run "$tmp/perm" "$tmp/noperm.txt"
-    chmod 644 "$tmp/noperm.txt"
     loghas 'Could not include URL list "[^"]+": .+'
     lognot 'not a regular file'
 fi
+chmod 644 "$tmp/noperm.txt"
 
 exit 0

--- a/tests/01_engine-idna.test
+++ b/tests/01_engine-idna.test
@@ -38,4 +38,7 @@ dec 'xn--!!!' '㚯'
 dec 'xn--already-encoded.com' 'ǮalǭǮreaǭǫdy.com'
 
 # second label has a truncated UTF-8 sequence: used to leak the segment buffer.
-enc_bad "$(printf 'b\xc3\xbcchev.\xe4\xbe\x8b\xe5\xad\x62\xc3\xbccheple')"
+# Fed as hex: the raw bytes must reach the encoder intact, but invalid UTF-8
+# cannot survive a Windows command line (it round-trips through UTF-16 to valid
+# U+FFFD, which then encodes fine instead of being rejected).
+enc_bad 'hex:62c3bc636865762ee4be8be5ad62c3bc636865706c65'

--- a/tests/01_engine-rcfile.test
+++ b/tests/01_engine-rcfile.test
@@ -32,6 +32,13 @@ esac
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_rcfile.XXXXXX") || exit 1
 trap 'rm -rf "$tmp"' EXIT HUP INT QUIT PIPE TERM
 
+# HTS_HTTRACKRC is ".httrackrc" on POSIX but "httrackrc" on Windows: write both,
+# each platform reads the one it knows.
+write_rc() {
+    cat >"$1/.httrackrc"
+    cp "$1/.httrackrc" "$1/httrackrc"
+}
+
 # --- 1. alias token survives the bound intact -------------------------------
 d1="$tmp/intact"
 mkdir -p "$d1"
@@ -40,7 +47,7 @@ echo '<html><body>hello</body></html>' >"$d1/index.html"
 # optinclude_file() lowercases each config line, so the marker is lowercase to
 # survive the comparison verbatim.
 marker='zzz_rcfile_marker_0123456789_abcdefghijklmnopqrstuvwxyz_intact'
-printf 'user-agent=%s\n' "$marker" >"$d1/.httrackrc"
+printf 'user-agent=%s\n' "$marker" | write_rc "$d1"
 
 # Run with no -O so the working-directory .httrackrc is loaded (an -O path makes
 # the engine skip the rc files). Output lands in the temp dir. Guard the run so a
@@ -73,7 +80,7 @@ echo '<html><body>hi</body></html>' >"$d2/index.html"
 val=$(printf 'a%.0s' $(seq 1 200))
 for _ in $(seq 1 400); do
     printf 'user-agent=%s\n' "$val"
-done >"$d2/.httrackrc"
+done | write_rc "$d2"
 
 # The process aborts (httrack turns the fatal signal into exit 134 either way),
 # so the exit code does not distinguish the bounded abort from a heap overflow;

--- a/tests/01_engine-strsafe.test
+++ b/tests/01_engine-strsafe.test
@@ -32,10 +32,10 @@ case "$err" in
 esac
 
 # Same guarantee for the htsbuff builder. The source is exactly the buffer
-# capacity (4 bytes into a 4-byte buffer), so this also pins the boundary: a
+# capacity (6 bytes into a 6-byte buffer), so this also pins the boundary: a
 # '<=' off-by-one in the capacity check would let it through (and print "NOT
 # aborted"). Match the specific htsbuff abort message, not just any assert.
-err=$(httrack -#test=strsafe overflow-buff "abcd" 2>&1) || true
+err=$(httrack -#test=strsafe overflow-buff "abcdef" 2>&1) || true
 case "$err" in
 *"strsafe: NOT aborted"*)
     echo "htsbuff over-capacity write was NOT caught" >&2


### PR DESCRIPTION
The engine ships around 90 tests and none had ever run on Windows, since `make check` is Linux and macOS only. This runs the offline ones from Git Bash against the native MSVC `httrack.exe`, and fixes what they found.

The user-facing bug is #573. `httrack.exe` is an MBCS build, so the CRT transcodes the UTF-16 command line down to the machine's ANSI codepage before producing `char **argv`: non-ASCII arguments are lossy, and anything outside that codepage is destroyed, so a Cyrillic or CJK URL on a Western-codepage box arrives as `?`. The engine already treats `char*` as UTF-8 on Windows everywhere else (`FOPEN`, `STAT` and `UNLINK` are `hts_*_utf8` wrappers that convert at the syscall boundary); argv is the one thing that never got the memo. It now decodes the real UTF-16 command line at the entry point. Windows-only, so no POSIX symbol and no soname change. The manifest's `activeCodePage` would have fixed this in one line, but it needs Windows 10 1903+ and is silently ignored below that, which is exactly the population running the codepages that mangle non-Latin URLs today.

The rest were test bugs, not engine bugs: rcfile wrote `.httrackrc`, but `HTS_HTTRACKRC` is `httrackrc` on Windows; filelist relied on `chmod 000`, which Windows ignores; ftp-line was excluded from Windows for its `socketpair()`, though `get_ftp_line()` is portable, so it now pairs over loopback TCP. The charset self-tests fed raw non-UTF-8 bytes through argv to probe the decoders, and those cannot survive any Windows command line whatever argv does, so they go as hex, which keeps the coverage on every platform.

Stacked on #575: 01_engine-filter fails on Windows without the matcher depth cap. Closes #573.