### PR TITLE
Run the loopback crawl tests on Windows

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -123,9 +123,14 @@ jobs:
       # is Linux/macOS only. These are the offline ones, driven from Git Bash
       # against the native httrack.exe. They subsume the self-tests this step
       # used to run inline (codecs, cache, fsize).
+      #
+      # The *_local-* ones crawl the bundled Python server over loopback: the
+      # real TLS handshake, cache, and file writer, i.e. what HTTrack actually
+      # does, none of which any other Windows check exercises.
       - name: Run the engine test suite (offline tests)
         shell: bash
         working-directory: tests
+        timeout-minutes: 45
         run: |
           set -u
           bin="$(cygpath -u "$GITHUB_WORKSPACE")/src/${{ matrix.platform }}/${{ matrix.configuration }}"
@@ -141,10 +146,21 @@ jobs:
           TMPDIR="$(cygpath -m "$RUNNER_TEMP")"
           export TMPDIR
 
+          # Mirror what configure hands the suite; the crawl tests gate on these.
+          # LC_ALL fixes the codeset MSYS uses to map a UTF-8 mirror name onto
+          # UTF-16, which the international crawls assert with "test -f".
+          export HTTPS_SUPPORT=yes BROTLI_ENABLED=yes ZSTD_ENABLED=yes
+          export LC_ALL=C.UTF-8
+
+          # A wedged crawl must not eat the job's whole timeout budget.
+          watchdog=""
+          command -v timeout >/dev/null && watchdog="timeout 600"
+
           pass=0 fail=0 skip=0 failed=""
-          for t in 00_runnable.test 01_engine-*.test 01_zlib-*.test; do
+          for t in 00_runnable.test 01_engine-*.test 01_zlib-*.test *_local-*.test; do
             rc=0
-            bash "$t" >"$t.log" 2>&1 || rc=$?
+            # shellcheck disable=SC2086
+            $watchdog bash "$t" >"$t.log" 2>&1 || rc=$?
             case "$rc" in
               0) pass=$((pass + 1)); echo "PASS $t" ;;
               77) skip=$((skip + 1)); echo "SKIP $t" ;;
@@ -164,7 +180,7 @@ jobs:
           # Every gate in these scripts exits 77, so a suite that degraded to
           # all-skipped would report green having tested nothing: assert a floor
           # on what actually ran, not just the absence of failures.
-          [ "$pass" -ge 45 ] || { echo "::error::only $pass tests passed ($skip skipped)"; exit 1; }
+          [ "$pass" -ge 90 ] || { echo "::error::only $pass tests passed ($skip skipped)"; exit 1; }
           [ "$fail" -eq 0 ] || { echo "::error::failing:$failed"; exit 1; }
 
       - name: Upload the test logs

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -156,14 +156,15 @@ jobs:
           watchdog=""
           command -v timeout >/dev/null && watchdog="timeout 600"
 
-          pass=0 fail=0 skip=0 failed=""
-          for t in 00_runnable.test 01_engine-*.test 01_zlib-*.test *_local-*.test; do
+          pass=0 fail=0 skip=0 failed="" skipped=""
+          for t in 00_runnable.test 01_engine-*.test 01_zlib-*.test \
+                   *_local-*.test 13_crawl_proxy_https.test; do
             rc=0
             # shellcheck disable=SC2086
             $watchdog bash "$t" >"$t.log" 2>&1 || rc=$?
             case "$rc" in
               0) pass=$((pass + 1)); echo "PASS $t" ;;
-              77) skip=$((skip + 1)); echo "SKIP $t" ;;
+              77) skip=$((skip + 1)) skipped="$skipped $t"; echo "SKIP $t" ;;
               *)
                 fail=$((fail + 1)) failed="$failed $t"
                 echo "FAIL $t (exit $rc)"
@@ -178,9 +179,12 @@ jobs:
             tee -a "$GITHUB_STEP_SUMMARY"
 
           # Every gate in these scripts exits 77, so a suite that degraded to
-          # all-skipped would report green having tested nothing: assert a floor
-          # on what actually ran, not just the absence of failures.
+          # all-skipped would report green having tested nothing. Nothing here is
+          # expected to skip on Windows, so a skip is a gate that silently turned
+          # a test off (no python, no openssl, a codec disabled); the floor is the
+          # backstop for the glob itself going empty.
           [ "$pass" -ge 90 ] || { echo "::error::only $pass tests passed ($skip skipped)"; exit 1; }
+          [ "$skip" -eq 0 ] || { echo "::error::skipped:$skipped"; exit 1; }
           [ "$fail" -eq 0 ] || { echo "::error::failing:$failed"; exit 1; }
 
       - name: Upload the test logs

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -177,7 +177,8 @@ jobs:
 
           # Every gate here exits 77, so an all-skipped suite would report green having
           # tested nothing: pin the skips, and floor the passes in case the glob empties.
-          expected_skips=" 19_local-connect-fallback.test"  # pending #579
+          # pending #579, #581
+          expected_skips=" 19_local-connect-fallback.test 48_local-crange-memresume.test"
           [ "$pass" -ge 90 ] || { echo "::error::only $pass tests passed ($skip skipped)"; exit 1; }
           [ "$skipped" = "$expected_skips" ] || { echo "::error::unexpected skips:$skipped"; exit 1; }
           [ "$fail" -eq 0 ] || { echo "::error::failing:$failed"; exit 1; }

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -179,12 +179,13 @@ jobs:
             tee -a "$GITHUB_STEP_SUMMARY"
 
           # Every gate in these scripts exits 77, so a suite that degraded to
-          # all-skipped would report green having tested nothing. Nothing here is
-          # expected to skip on Windows, so a skip is a gate that silently turned
-          # a test off (no python, no openssl, a codec disabled); the floor is the
-          # backstop for the glob itself going empty.
+          # all-skipped would report green having tested nothing. Pin the skips
+          # rather than count them: an unexpected one is a gate that silently
+          # turned a test off (no python, no openssl, a codec disabled). The floor
+          # is the backstop for the glob itself going empty.
+          expected_skips=" 19_local-connect-fallback.test"  # pending #579
           [ "$pass" -ge 90 ] || { echo "::error::only $pass tests passed ($skip skipped)"; exit 1; }
-          [ "$skip" -eq 0 ] || { echo "::error::skipped:$skipped"; exit 1; }
+          [ "$skipped" = "$expected_skips" ] || { echo "::error::unexpected skips:$skipped"; exit 1; }
           [ "$fail" -eq 0 ] || { echo "::error::failing:$failed"; exit 1; }
 
       - name: Upload the test logs

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -123,10 +123,8 @@ jobs:
       # is Linux/macOS only. These are the offline ones, driven from Git Bash
       # against the native httrack.exe. They subsume the self-tests this step
       # used to run inline (codecs, cache, fsize).
-      #
-      # The *_local-* ones crawl the bundled Python server over loopback: the
-      # real TLS handshake, cache, and file writer, i.e. what HTTrack actually
-      # does, none of which any other Windows check exercises.
+      # The *_local-* ones crawl the bundled Python server over loopback: the real
+      # TLS handshake, cache and file writer, which nothing else on Windows covers.
       - name: Run the engine test suite (offline tests)
         shell: bash
         working-directory: tests
@@ -146,9 +144,8 @@ jobs:
           TMPDIR="$(cygpath -m "$RUNNER_TEMP")"
           export TMPDIR
 
-          # Mirror what configure hands the suite; the crawl tests gate on these.
-          # LC_ALL fixes the codeset MSYS uses to map a UTF-8 mirror name onto
-          # UTF-16, which the international crawls assert with "test -f".
+          # Mirror what configure hands the suite. LC_ALL sets the codeset MSYS maps
+          # a UTF-8 mirror name onto UTF-16 with, which the intl crawls "test -f".
           export HTTPS_SUPPORT=yes BROTLI_ENABLED=yes ZSTD_ENABLED=yes
           export LC_ALL=C.UTF-8
 
@@ -178,11 +175,8 @@ jobs:
           echo "ran=$((pass + fail + skip)) pass=$pass fail=$fail skip=$skip" |
             tee -a "$GITHUB_STEP_SUMMARY"
 
-          # Every gate in these scripts exits 77, so a suite that degraded to
-          # all-skipped would report green having tested nothing. Pin the skips
-          # rather than count them: an unexpected one is a gate that silently
-          # turned a test off (no python, no openssl, a codec disabled). The floor
-          # is the backstop for the glob itself going empty.
+          # Every gate here exits 77, so an all-skipped suite would report green having
+          # tested nothing: pin the skips, and floor the passes in case the glob empties.
           expected_skips=" 19_local-connect-fallback.test"  # pending #579
           [ "$pass" -ge 90 ] || { echo "::error::only $pass tests passed ($skip skipped)"; exit 1; }
           [ "$skipped" = "$expected_skips" ] || { echo "::error::unexpected skips:$skipped"; exit 1; }

--- a/tests/13_crawl_proxy_https.test
+++ b/tests/13_crawl_proxy_https.test
@@ -27,7 +27,7 @@ pids=
 
 cleanup() {
     for pid in $pids; do
-        kill "$pid" 2>/dev/null || true
+        stop_server "$pid"
     done
     rm -rf "$tmpdir"
 }

--- a/tests/13_crawl_proxy_https.test
+++ b/tests/13_crawl_proxy_https.test
@@ -8,11 +8,15 @@ set -euo pipefail
 
 : "${top_srcdir:=..}"
 
+# shellcheck source=tests/testlib.sh
+. "$top_srcdir/tests/testlib.sh"
+
 if test "${HTTPS_SUPPORT:-}" == "no"; then
     echo "no https support compiled, skipping"
     exit 77
 fi
-if ! command -v python3 >/dev/null 2>&1 || ! command -v openssl >/dev/null 2>&1; then
+python=$(find_python) || python=
+if test -z "$python" || ! command -v openssl >/dev/null 2>&1; then
     echo "python3/openssl missing, skipping"
     exit 77
 fi
@@ -41,7 +45,7 @@ start_server() {
     local dir="$1" mode="$2" ports
     mkdir -p "$dir"
     ports="$dir/ports.txt"
-    python3 "$server" "$tmpdir/both.pem" "$dir" "$mode" \
+    "$python" "$(nativepath "$server")" "$(nativepath "$tmpdir/both.pem")" "$(nativepath "$dir")" "$mode" \
         >"$ports" 2>"$dir/server.err" &
     pids="$pids $!"
     for _ in $(seq 1 100); do

--- a/tests/13_crawl_proxy_https.test
+++ b/tests/13_crawl_proxy_https.test
@@ -21,7 +21,7 @@ if test -z "$python" || ! command -v openssl >/dev/null 2>&1; then
     exit 77
 fi
 
-server="$top_srcdir/tests/proxy-https-server.py"
+server=$(nativepath "$top_srcdir/tests/proxy-https-server.py")
 tmpdir=$(mktemp -d)
 pids=
 
@@ -42,10 +42,13 @@ cat "$tmpdir/key.pem" "$tmpdir/cert.pem" >"$tmpdir/both.pem"
 # start_server <logdir> <mode>: launches a proxy+origin pair, sets $origin_port
 # and $proxy_port from its announced ephemeral ports.
 start_server() {
-    local dir="$1" mode="$2" ports
+    local dir="$1" mode="$2" ports pem
     mkdir -p "$dir"
     ports="$dir/ports.txt"
-    "$python" "$(nativepath "$server")" "$(nativepath "$tmpdir/both.pem")" "$(nativepath "$dir")" "$mode" \
+    pem=$(nativepath "$tmpdir/both.pem")
+    dir_native=$(nativepath "$dir")
+    : >"$ports"
+    "$python" "$server" "$pem" "$dir_native" "$mode" \
         >"$ports" 2>"$dir/server.err" &
     pids="$pids $!"
     for _ in $(seq 1 100); do

--- a/tests/19_local-connect-fallback.test
+++ b/tests/19_local-connect-fallback.test
@@ -32,8 +32,8 @@ GNU | GNU/*)
     ;;
 esac
 
-server="$top_srcdir/tests/local-server.py"
-root="$top_srcdir/tests/server-root"
+server=$(nativepath "$top_srcdir/tests/local-server.py")
+root=$(nativepath "$top_srcdir/tests/server-root")
 tmpdir=$(mktemp -d)
 serverpid=
 
@@ -45,7 +45,7 @@ cleanup() {
 trap cleanup EXIT
 
 # bind the live server to 127.0.0.1 only, so 127.0.0.2 refuses the connect
-"$python" "$(nativepath "$server")" --root "$(nativepath "$root")" --bind 127.0.0.1 >"$tmpdir/srv.out" 2>"$tmpdir/srv.err" &
+"$python" "$server" --root "$root" --bind 127.0.0.1 >"$tmpdir/srv.out" 2>"$tmpdir/srv.err" &
 serverpid=$!
 port=
 for _ in $(seq 1 50); do

--- a/tests/19_local-connect-fallback.test
+++ b/tests/19_local-connect-fallback.test
@@ -38,10 +38,7 @@ tmpdir=$(mktemp -d)
 serverpid=
 
 cleanup() {
-    if test -n "$serverpid"; then
-        kill "$serverpid" 2>/dev/null || true
-        wait "$serverpid" 2>/dev/null || true
-    fi
+    stop_server "$serverpid"
     rm -rf "$tmpdir"
     return 0
 }

--- a/tests/19_local-connect-fallback.test
+++ b/tests/19_local-connect-fallback.test
@@ -31,6 +31,11 @@ GNU | GNU/*)
     exit 77
     ;;
 esac
+# TODO: drop once https://github.com/xroche/httrack/issues/579 is fixed.
+if is_windows; then
+    echo "Windows: the connect fallback never runs (#579), skipping"
+    exit 77
+fi
 
 server=$(nativepath "$top_srcdir/tests/local-server.py")
 root=$(nativepath "$top_srcdir/tests/server-root")

--- a/tests/19_local-connect-fallback.test
+++ b/tests/19_local-connect-fallback.test
@@ -12,14 +12,17 @@ set -euo pipefail
 
 : "${top_srcdir:=..}"
 
+# shellcheck source=tests/testlib.sh
+. "$top_srcdir/tests/testlib.sh"
+
 if test "${V6_SUPPORT:-}" == "no"; then
     echo "no IPv6 support (resolver list/override is IPv6-only), skipping"
     exit 77
 fi
-if ! command -v python3 >/dev/null 2>&1; then
+python=$(find_python) || {
     echo "python3 missing, skipping"
     exit 77
-fi
+}
 # The fixture needs a second loopback IP (dead 127.0.0.2 + live 127.0.0.1) for
 # the fallback to have a target; GNU/Hurd has only 127.0.0.1, so skip there.
 case "$(uname -s)" in
@@ -45,7 +48,7 @@ cleanup() {
 trap cleanup EXIT
 
 # bind the live server to 127.0.0.1 only, so 127.0.0.2 refuses the connect
-python3 "$server" --root "$root" --bind 127.0.0.1 >"$tmpdir/srv.out" 2>"$tmpdir/srv.err" &
+"$python" "$(nativepath "$server")" --root "$(nativepath "$root")" --bind 127.0.0.1 >"$tmpdir/srv.out" 2>"$tmpdir/srv.err" &
 serverpid=$!
 port=
 for _ in $(seq 1 50); do

--- a/tests/20_local-resume-loop.test
+++ b/tests/20_local-resume-loop.test
@@ -5,9 +5,11 @@ set -u
 
 : "${top_srcdir:=..}"
 testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
 server="${testdir}/local-server.py"
 
-command -v python3 >/dev/null || ! echo "python3 not found; skipping" || exit 77
+python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_206.XXXXXX") || exit 1
 serverpid=
@@ -26,7 +28,7 @@ trap cleanup EXIT HUP INT QUIT PIPE TERM
 # RESUME_COUNTER gets a byte per /resume/blob.txt request (pass-2 delta bounds re-gets).
 serverlog="${tmpdir}/server.log"
 counter="${tmpdir}/blobcount"
-RESUME_COUNTER="$counter" python3 "$server" --root "${testdir}/server-root" >"$serverlog" 2>&1 &
+RESUME_COUNTER="$counter" "$python" "$(nativepath "$server")" --root "$(nativepath "${testdir}/server-root")" >"$serverlog" 2>&1 &
 serverpid=$!
 port=
 for _ in $(seq 1 50); do

--- a/tests/20_local-resume-loop.test
+++ b/tests/20_local-resume-loop.test
@@ -16,10 +16,7 @@ serverpid=
 crawlpid=
 cleanup() {
     test -n "$crawlpid" && kill -9 "$crawlpid" 2>/dev/null
-    if test -n "$serverpid"; then
-        kill "$serverpid" 2>/dev/null
-        wait "$serverpid" 2>/dev/null
-    fi
+    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 trap cleanup EXIT HUP INT QUIT PIPE TERM

--- a/tests/20_local-resume-loop.test
+++ b/tests/20_local-resume-loop.test
@@ -7,7 +7,8 @@ set -u
 testdir=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=tests/testlib.sh
 . "${testdir}/testlib.sh"
-server="${testdir}/local-server.py"
+server=$(nativepath "${testdir}/local-server.py")
+root=$(nativepath "${testdir}/server-root")
 
 python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
 
@@ -24,8 +25,9 @@ trap cleanup EXIT HUP INT QUIT PIPE TERM
 # --- start the server, discover its ephemeral port --------------------------
 # RESUME_COUNTER gets a byte per /resume/blob.txt request (pass-2 delta bounds re-gets).
 serverlog="${tmpdir}/server.log"
+: >"$serverlog"
 counter="${tmpdir}/blobcount"
-RESUME_COUNTER="$counter" "$python" "$(nativepath "$server")" --root "$(nativepath "${testdir}/server-root")" >"$serverlog" 2>&1 &
+RESUME_COUNTER="$counter" "$python" "$server" --root "$root" >"$serverlog" 2>&1 &
 serverpid=$!
 port=
 for _ in $(seq 1 50); do

--- a/tests/24_local-resume-overlap.test
+++ b/tests/24_local-resume-overlap.test
@@ -9,9 +9,11 @@ set -eu
 
 : "${top_srcdir:=..}"
 testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
 server="${testdir}/local-server.py"
 
-command -v python3 >/dev/null || ! echo "python3 not found; skipping" || exit 77
+python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_198.XXXXXX") || exit 1
 serverpid=
@@ -31,7 +33,7 @@ serverlog="${tmpdir}/server.log"
 counter="${tmpdir}/hits"
 resumed="${tmpdir}/resumed" # gets a byte when the server serves a resume 206
 OVERLAP_COUNTER="$counter" OVERLAP_RESUMED="$resumed" \
-    python3 "$server" --root "${testdir}/server-root" \
+    "$python" "$(nativepath "$server")" --root "$(nativepath "${testdir}/server-root")" \
     >"$serverlog" 2>&1 &
 serverpid=$!
 port=

--- a/tests/24_local-resume-overlap.test
+++ b/tests/24_local-resume-overlap.test
@@ -20,10 +20,7 @@ serverpid=
 crawlpid=
 cleanup() {
     if test -n "$crawlpid"; then kill -9 "$crawlpid" 2>/dev/null || true; fi
-    if test -n "$serverpid"; then
-        kill "$serverpid" 2>/dev/null || true
-        wait "$serverpid" 2>/dev/null || true
-    fi
+    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 trap cleanup EXIT HUP INT QUIT PIPE TERM

--- a/tests/24_local-resume-overlap.test
+++ b/tests/24_local-resume-overlap.test
@@ -11,7 +11,8 @@ set -eu
 testdir=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=tests/testlib.sh
 . "${testdir}/testlib.sh"
-server="${testdir}/local-server.py"
+server=$(nativepath "${testdir}/local-server.py")
+root=$(nativepath "${testdir}/server-root")
 
 python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
 
@@ -27,10 +28,11 @@ trap cleanup EXIT HUP INT QUIT PIPE TERM
 
 # OVERLAP_COUNTER gets a byte per flaky.bin request so pass 1 knows when to interrupt.
 serverlog="${tmpdir}/server.log"
+: >"$serverlog"
 counter="${tmpdir}/hits"
 resumed="${tmpdir}/resumed" # gets a byte when the server serves a resume 206
 OVERLAP_COUNTER="$counter" OVERLAP_RESUMED="$resumed" \
-    "$python" "$(nativepath "$server")" --root "$(nativepath "${testdir}/server-root")" \
+    "$python" "$server" --root "$root" \
     >"$serverlog" 2>&1 &
 serverpid=$!
 port=

--- a/tests/28_local-pause.test
+++ b/tests/28_local-pause.test
@@ -9,9 +9,12 @@ set -e
 
 : "${top_srcdir:=..}"
 
+# shellcheck source=tests/testlib.sh
+. "$top_srcdir/tests/testlib.sh"
+
 # python3 runs the local server (mirror local-crawl.sh); skip when absent, else
 # run() swallows its exit-77 and the serverless 0s/0s crawl looks like a fail.
-command -v python3 >/dev/null || {
+find_python >/dev/null || {
     echo "python3 not found; skipping local crawl tests"
     exit 77
 }

--- a/tests/46_local-update-304-resume.test
+++ b/tests/46_local-update-304-resume.test
@@ -9,7 +9,8 @@ set -u
 testdir=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=tests/testlib.sh
 . "${testdir}/testlib.sh"
-server="${testdir}/local-server.py"
+server=$(nativepath "${testdir}/local-server.py")
+root=$(nativepath "${testdir}/server-root")
 
 python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
 
@@ -24,9 +25,10 @@ cleanup() {
 trap cleanup EXIT HUP INT QUIT PIPE TERM
 
 serverlog="${tmpdir}/server.log"
+: >"$serverlog"
 counter="${tmpdir}/reqcount"
 mark="${tmpdir}/got304"
-RESUME304_COUNTER="$counter" RESUME304_MARK="$mark" "$python" "$(nativepath "$server")" --root "$(nativepath "${testdir}/server-root")" >"$serverlog" 2>&1 &
+RESUME304_COUNTER="$counter" RESUME304_MARK="$mark" "$python" "$server" --root "$root" >"$serverlog" 2>&1 &
 serverpid=$!
 port=
 for _ in $(seq 1 50); do

--- a/tests/46_local-update-304-resume.test
+++ b/tests/46_local-update-304-resume.test
@@ -18,10 +18,7 @@ serverpid=
 crawlpid=
 cleanup() {
     test -n "$crawlpid" && kill -9 "$crawlpid" 2>/dev/null
-    if test -n "$serverpid"; then
-        kill "$serverpid" 2>/dev/null
-        wait "$serverpid" 2>/dev/null
-    fi
+    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 trap cleanup EXIT HUP INT QUIT PIPE TERM

--- a/tests/46_local-update-304-resume.test
+++ b/tests/46_local-update-304-resume.test
@@ -7,9 +7,11 @@ set -u
 
 : "${top_srcdir:=..}"
 testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
 server="${testdir}/local-server.py"
 
-command -v python3 >/dev/null || ! echo "python3 not found; skipping" || exit 77
+python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_c7.XXXXXX") || exit 1
 serverpid=
@@ -27,7 +29,7 @@ trap cleanup EXIT HUP INT QUIT PIPE TERM
 serverlog="${tmpdir}/server.log"
 counter="${tmpdir}/reqcount"
 mark="${tmpdir}/got304"
-RESUME304_COUNTER="$counter" RESUME304_MARK="$mark" python3 "$server" --root "${testdir}/server-root" >"$serverlog" 2>&1 &
+RESUME304_COUNTER="$counter" RESUME304_MARK="$mark" "$python" "$(nativepath "$server")" --root "$(nativepath "${testdir}/server-root")" >"$serverlog" 2>&1 &
 serverpid=$!
 port=
 for _ in $(seq 1 50); do

--- a/tests/47_local-crange-overflow.test
+++ b/tests/47_local-crange-overflow.test
@@ -8,9 +8,11 @@ set -u
 
 : "${top_srcdir:=..}"
 testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
 server="${testdir}/local-server.py"
 
-command -v python3 >/dev/null || ! echo "python3 not found; skipping" || exit 77
+python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_crange.XXXXXX") || exit 1
 serverpid=
@@ -26,7 +28,7 @@ cleanup() {
 trap cleanup EXIT HUP INT QUIT PIPE TERM
 
 serverlog="${tmpdir}/server.log"
-python3 "$server" --root "${testdir}/server-root" >"$serverlog" 2>&1 &
+"$python" "$(nativepath "$server")" --root "$(nativepath "${testdir}/server-root")" >"$serverlog" 2>&1 &
 serverpid=$!
 port=
 for _ in $(seq 1 50); do

--- a/tests/47_local-crange-overflow.test
+++ b/tests/47_local-crange-overflow.test
@@ -19,10 +19,7 @@ serverpid=
 crawlpid=
 cleanup() {
     test -n "$crawlpid" && kill -9 "$crawlpid" 2>/dev/null
-    if test -n "$serverpid"; then
-        kill "$serverpid" 2>/dev/null
-        wait "$serverpid" 2>/dev/null
-    fi
+    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 trap cleanup EXIT HUP INT QUIT PIPE TERM

--- a/tests/47_local-crange-overflow.test
+++ b/tests/47_local-crange-overflow.test
@@ -10,7 +10,8 @@ set -u
 testdir=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=tests/testlib.sh
 . "${testdir}/testlib.sh"
-server="${testdir}/local-server.py"
+server=$(nativepath "${testdir}/local-server.py")
+root=$(nativepath "${testdir}/server-root")
 
 python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
 
@@ -25,7 +26,8 @@ cleanup() {
 trap cleanup EXIT HUP INT QUIT PIPE TERM
 
 serverlog="${tmpdir}/server.log"
-"$python" "$(nativepath "$server")" --root "$(nativepath "${testdir}/server-root")" >"$serverlog" 2>&1 &
+: >"$serverlog"
+"$python" "$server" --root "$root" >"$serverlog" 2>&1 &
 serverpid=$!
 port=
 for _ in $(seq 1 50); do

--- a/tests/48_local-crange-memresume.test
+++ b/tests/48_local-crange-memresume.test
@@ -87,7 +87,7 @@ full=6008 # len(CRANGE206_BODY) = len("CR206DAT") + 6000
 printf '[file recovered whole] ..\t'
 test -s "$blob" || {
     echo "FAIL: blob.bin missing after the hostile 206"
-    grep -aE "Error:|Warning:|restarting" "${out}/hts-log.txt" >&2 || true
+    tail -40 "${out}/hts-log.txt" >&2
     find "$out" -type f >&2
     exit 1
 }

--- a/tests/48_local-crange-memresume.test
+++ b/tests/48_local-crange-memresume.test
@@ -15,6 +15,14 @@ root=$(nativepath "${testdir}/server-root")
 
 python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
 
+# The resume needs a graceful pass-1 interrupt (a clean cache), which MSYS can't
+# deliver to a native exe, and the restart-whole path fails on a repaired cache
+# (#581); TODO: drop once that lands.
+if is_windows; then
+    echo "Windows: interrupted-resume restart fails on a repaired cache (#581), skipping"
+    exit 77
+fi
+
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_crangemem.XXXXXX") || exit 1
 serverpid=
 crawlpid=
@@ -54,7 +62,6 @@ which httrack >/dev/null || {
 }
 out="${tmpdir}/crawl"
 mkdir "$out"
-is_windows && CRANGE_DEBUG=1 # dump pass-1 state while investigating the Windows failure
 common=(-O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 --retries=1 -c1)
 refdir="${out}/hts-cache/ref"
 
@@ -76,12 +83,6 @@ test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" || {
     exit 1
 }
 echo "OK (temp-ref present)"
-if test -n "${CRANGE_DEBUG:-}"; then
-    echo "--- after pass 1: mirror ---" >&2
-    find "$out" -type f -printf '%s\t%p\n' >&2
-    echo "--- pass 1 log ---" >&2
-    cat "${tmpdir}/log1" >&2
-fi
 
 # --- pass 2: --continue -> resume -> hostile INT64_MAX Content-Range ----------
 printf '[pass 2: hostile 206, no overflow, refetch] ..\t'
@@ -101,12 +102,6 @@ full=6008 # len(CRANGE206_BODY) = len("CR206DAT") + 6000
 printf '[file recovered whole] ..\t'
 test -s "$blob" || {
     echo "FAIL: blob.bin missing after the hostile 206"
-    echo "--- pass 2 stdout (log2) ---" >&2
-    cat "${tmpdir}/log2" >&2
-    echo "--- pass 2 hts-log.txt ---" >&2
-    cat "${out}/hts-log.txt" >&2
-    echo "--- pass 2 mirror ---" >&2
-    find "$out" -type f -printf '%s\t%p\n' >&2
     exit 1
 }
 got=$(wc -c <"$blob")

--- a/tests/48_local-crange-memresume.test
+++ b/tests/48_local-crange-memresume.test
@@ -19,10 +19,7 @@ serverpid=
 crawlpid=
 cleanup() {
     test -n "$crawlpid" && kill -9 "$crawlpid" 2>/dev/null
-    if test -n "$serverpid"; then
-        kill "$serverpid" 2>/dev/null
-        wait "$serverpid" 2>/dev/null
-    fi
+    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 trap cleanup EXIT HUP INT QUIT PIPE TERM

--- a/tests/48_local-crange-memresume.test
+++ b/tests/48_local-crange-memresume.test
@@ -78,7 +78,14 @@ echo "OK (temp-ref present)"
 
 # --- pass 2: --continue -> resume -> hostile INT64_MAX Content-Range ----------
 printf '[pass 2: hostile 206, no overflow, refetch] ..\t'
-httrack "${common[@]}" --continue "${base}/crange206mem/index.html" >"${tmpdir}/log2" 2>&1
+rc=0
+httrack "${common[@]}" --continue "${base}/crange206mem/index.html" >"${tmpdir}/log2" 2>&1 || rc=$?
+# a crash here would otherwise read as a clean "terminated"
+test "$rc" -eq 0 || {
+    echo "FAIL: httrack exited $rc"
+    cat "${tmpdir}/log2" >&2
+    exit 1
+}
 echo "OK (terminated)"
 
 blob=$(find "$out" -name blob.bin 2>/dev/null | head -1)
@@ -88,6 +95,7 @@ printf '[file recovered whole] ..\t'
 test -s "$blob" || {
     echo "FAIL: blob.bin missing after the hostile 206"
     tail -40 "${out}/hts-log.txt" >&2
+    cat "${tmpdir}/log2" >&2
     find "$out" -type f >&2
     exit 1
 }

--- a/tests/48_local-crange-memresume.test
+++ b/tests/48_local-crange-memresume.test
@@ -8,9 +8,11 @@ set -u
 
 : "${top_srcdir:=..}"
 testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
 server="${testdir}/local-server.py"
 
-command -v python3 >/dev/null || ! echo "python3 not found; skipping" || exit 77
+python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_crangemem.XXXXXX") || exit 1
 serverpid=
@@ -26,7 +28,7 @@ cleanup() {
 trap cleanup EXIT HUP INT QUIT PIPE TERM
 
 serverlog="${tmpdir}/server.log"
-python3 "$server" --root "${testdir}/server-root" >"$serverlog" 2>&1 &
+"$python" "$(nativepath "$server")" --root "$(nativepath "${testdir}/server-root")" >"$serverlog" 2>&1 &
 serverpid=$!
 port=
 for _ in $(seq 1 50); do

--- a/tests/48_local-crange-memresume.test
+++ b/tests/48_local-crange-memresume.test
@@ -87,6 +87,8 @@ full=6008 # len(CRANGE206_BODY) = len("CR206DAT") + 6000
 printf '[file recovered whole] ..\t'
 test -s "$blob" || {
     echo "FAIL: blob.bin missing after the hostile 206"
+    grep -aE "Error:|Warning:|restarting" "${out}/hts-log.txt" >&2 || true
+    find "$out" -type f >&2
     exit 1
 }
 got=$(wc -c <"$blob")

--- a/tests/48_local-crange-memresume.test
+++ b/tests/48_local-crange-memresume.test
@@ -10,7 +10,8 @@ set -u
 testdir=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=tests/testlib.sh
 . "${testdir}/testlib.sh"
-server="${testdir}/local-server.py"
+server=$(nativepath "${testdir}/local-server.py")
+root=$(nativepath "${testdir}/server-root")
 
 python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
 
@@ -25,7 +26,8 @@ cleanup() {
 trap cleanup EXIT HUP INT QUIT PIPE TERM
 
 serverlog="${tmpdir}/server.log"
-"$python" "$(nativepath "$server")" --root "$(nativepath "${testdir}/server-root")" >"$serverlog" 2>&1 &
+: >"$serverlog"
+"$python" "$server" --root "$root" >"$serverlog" 2>&1 &
 serverpid=$!
 port=
 for _ in $(seq 1 50); do

--- a/tests/48_local-crange-memresume.test
+++ b/tests/48_local-crange-memresume.test
@@ -54,6 +54,7 @@ which httrack >/dev/null || {
 }
 out="${tmpdir}/crawl"
 mkdir "$out"
+is_windows && CRANGE_DEBUG=1 # dump pass-1 state while investigating the Windows failure
 common=(-O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 --retries=1 -c1)
 refdir="${out}/hts-cache/ref"
 
@@ -75,6 +76,12 @@ test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" || {
     exit 1
 }
 echo "OK (temp-ref present)"
+if test -n "${CRANGE_DEBUG:-}"; then
+    echo "--- after pass 1: mirror ---" >&2
+    find "$out" -type f -printf '%s\t%p\n' >&2
+    echo "--- pass 1 log ---" >&2
+    cat "${tmpdir}/log1" >&2
+fi
 
 # --- pass 2: --continue -> resume -> hostile INT64_MAX Content-Range ----------
 printf '[pass 2: hostile 206, no overflow, refetch] ..\t'
@@ -94,9 +101,12 @@ full=6008 # len(CRANGE206_BODY) = len("CR206DAT") + 6000
 printf '[file recovered whole] ..\t'
 test -s "$blob" || {
     echo "FAIL: blob.bin missing after the hostile 206"
-    tail -40 "${out}/hts-log.txt" >&2
+    echo "--- pass 2 stdout (log2) ---" >&2
     cat "${tmpdir}/log2" >&2
-    find "$out" -type f >&2
+    echo "--- pass 2 hts-log.txt ---" >&2
+    cat "${out}/hts-log.txt" >&2
+    echo "--- pass 2 mirror ---" >&2
+    find "$out" -type f -printf '%s\t%p\n' >&2
     exit 1
 }
 got=$(wc -c <"$blob")

--- a/tests/52_local-socks5.test
+++ b/tests/52_local-socks5.test
@@ -30,7 +30,7 @@ pids=
 
 cleanup() {
     for pid in $pids; do
-        kill "$pid" 2>/dev/null || true
+        stop_server "$pid"
     done
     rm -rf "$tmpdir"
 }

--- a/tests/52_local-socks5.test
+++ b/tests/52_local-socks5.test
@@ -8,11 +8,15 @@ set -euo pipefail
 
 : "${top_srcdir:=..}"
 
+# shellcheck source=tests/testlib.sh
+. "$top_srcdir/tests/testlib.sh"
+
 if test "${HTTPS_SUPPORT:-}" == "no"; then
     echo "no https support compiled, skipping"
     exit 77
 fi
-if ! command -v python3 >/dev/null 2>&1 || ! command -v openssl >/dev/null 2>&1; then
+python=$(find_python) || python=
+if test -z "$python" || ! command -v openssl >/dev/null 2>&1; then
     echo "python3/openssl missing, skipping"
     exit 77
 fi
@@ -42,7 +46,7 @@ start_server() {
     local dir="$1" mode="$2" ports
     mkdir -p "$dir"
     ports="$dir/ports.txt"
-    python3 "$server" "$tmpdir/both.pem" "$dir" "$mode" \
+    "$python" "$(nativepath "$server")" "$(nativepath "$tmpdir/both.pem")" "$(nativepath "$dir")" "$mode" \
         >"$ports" 2>"$dir/server.err" &
     pids="$pids $!"
     for _ in $(seq 1 100); do

--- a/tests/52_local-socks5.test
+++ b/tests/52_local-socks5.test
@@ -24,7 +24,7 @@ fi
 # a .invalid name never resolves (RFC 6761): reaching the page at all proves the
 # proxy did the DNS
 host="socks-origin.invalid"
-server="$top_srcdir/tests/socks5-server.py"
+server=$(nativepath "$top_srcdir/tests/socks5-server.py")
 tmpdir=$(mktemp -d)
 pids=
 
@@ -43,10 +43,13 @@ cat "$tmpdir/key.pem" "$tmpdir/cert.pem" >"$tmpdir/both.pem"
 
 # start_server <logdir> <mode>: sets $tls_port/$http_port/$socks_port
 start_server() {
-    local dir="$1" mode="$2" ports
+    local dir="$1" mode="$2" ports pem
     mkdir -p "$dir"
     ports="$dir/ports.txt"
-    "$python" "$(nativepath "$server")" "$(nativepath "$tmpdir/both.pem")" "$(nativepath "$dir")" "$mode" \
+    pem=$(nativepath "$tmpdir/both.pem")
+    dir_native=$(nativepath "$dir")
+    : >"$ports"
+    "$python" "$server" "$pem" "$dir_native" "$mode" \
         >"$ports" 2>"$dir/server.err" &
     pids="$pids $!"
     for _ in $(seq 1 100); do

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,7 +3,7 @@
 # silently drop it from the dist tarball and break "make distcheck".
 EXTRA_DIST = $(TESTS) crawl-test.sh run-all-tests.sh check-network.sh \
 	proxy-https-server.py socks5-server.py \
-	local-crawl.sh local-server.py server.crt server.key \
+	local-crawl.sh local-server.py testlib.sh server.crt server.key \
 	server-root/simple/basic.html server-root/simple/link.html \
 	server-root/stripquery/index.html server-root/stripquery/a.html \
 	server-root/fraglink/index.html server-root/fraglink/target.html \

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -69,24 +69,13 @@ function debug {
 function info { printf "[%s] ..\t" "$*" >&2; }
 function result { echo "$*" >&2; }
 
-function stop_server {
-    test -n "$serverpid" || return 0
-    kill "$serverpid" 2>/dev/null
-    # MSYS cannot deliver a signal to a native python.exe; -9 maps to
-    # TerminateProcess, which does land, so the wait below always has a corpse.
-    is_windows && kill -9 "$serverpid" 2>/dev/null
-    # Reap it so the port is released before we rm the tmpdir/log.
-    wait "$serverpid" 2>/dev/null
-    serverpid=
-    return 0
-}
-
 function cleanup {
     if test -n "$crawlpid"; then
         kill -9 "$crawlpid" 2>/dev/null
         crawlpid=
     fi
-    stop_server
+    stop_server "$serverpid"
+    serverpid=
     if test -n "$tmpdir" && test -d "$tmpdir"; then
         test -n "$nopurge" || rm -rf "$tmpdir"
     fi
@@ -288,7 +277,8 @@ if test -n "$rerun_dead"; then
     test -s "$zip" || die "no cache was written by the first pass"
     cp "$zip" "${tmpdir}/cache-before.zip"
     cp "${out}/hts-log.txt" "${tmpdir}/log-before.txt"
-    stop_server
+    stop_server "$serverpid"
+    serverpid=
     info "re-running httrack against the stopped server"
     httrack -O "$out" --user-agent="httrack $ver local ($(uname -mrs))" \
         "${moreargs[@]}" "${hts[@]}" >"${log}.dead" 2>&1 &

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -38,6 +38,8 @@
 set -u
 
 testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
 server="${testdir}/local-server.py"
 root="${LOCAL_SERVER_ROOT:-${testdir}/server-root}"
 cert="${testdir}/server.crt"
@@ -67,17 +69,24 @@ function debug {
 function info { printf "[%s] ..\t" "$*" >&2; }
 function result { echo "$*" >&2; }
 
+function stop_server {
+    test -n "$serverpid" || return 0
+    kill "$serverpid" 2>/dev/null
+    # MSYS cannot deliver a signal to a native python.exe; -9 maps to
+    # TerminateProcess, which does land, so the wait below always has a corpse.
+    is_windows && kill -9 "$serverpid" 2>/dev/null
+    # Reap it so the port is released before we rm the tmpdir/log.
+    wait "$serverpid" 2>/dev/null
+    serverpid=
+    return 0
+}
+
 function cleanup {
     if test -n "$crawlpid"; then
         kill -9 "$crawlpid" 2>/dev/null
         crawlpid=
     fi
-    if test -n "$serverpid"; then
-        kill "$serverpid" 2>/dev/null
-        # Reap it so the port is released before we rm the tmpdir/log.
-        wait "$serverpid" 2>/dev/null
-        serverpid=
-    fi
+    stop_server
     if test -n "$tmpdir" && test -d "$tmpdir"; then
         test -n "$nopurge" || rm -rf "$tmpdir"
     fi
@@ -96,7 +105,7 @@ nopurge=
 trap cleanup EXIT HUP INT QUIT PIPE TERM
 
 # python3 is required; mirror check-network.sh's skip-with-77 convention.
-command -v python3 >/dev/null || ! echo "python3 not found; skipping local crawl tests" || exit 77
+python=$(find_python) || ! echo "python3 not found; skipping local crawl tests" >&2 || exit 77
 
 tmptopdir=${TMPDIR:-/tmp}
 test -d "$tmptopdir" || mkdir -p "$tmptopdir" || die "no temporary directory; set TMPDIR"
@@ -158,12 +167,13 @@ done
 # --- start the server --------------------------------------------------------
 test -r "$server" || die "cannot read $server"
 serverlog="${tmpdir}/server.log"
-serverargs=(--root "$root")
+# python.exe is native and cannot resolve the /d/a/... paths Git Bash hands out.
+serverargs=(--root "$(nativepath "$root")")
 if test -n "$tls"; then
-    serverargs+=(--tls --cert "$cert" --key "$key")
+    serverargs+=(--tls --cert "$(nativepath "$cert")" --key "$(nativepath "$key")")
 fi
-debug "starting python3 $server ${serverargs[*]}"
-python3 "$server" "${serverargs[@]}" >"$serverlog" 2>&1 &
+debug "starting $python $server ${serverargs[*]}"
+"$python" "$(nativepath "$server")" "${serverargs[@]}" >"$serverlog" 2>&1 &
 serverpid=$!
 
 # Wait for the "PORT <n>" line (server prints it once bound).
@@ -203,7 +213,7 @@ if test "${#cookies[@]}" -gt 0; then
 fi
 
 # --- run httrack -------------------------------------------------------------
-which httrack >/dev/null || die "could not find httrack"
+command -v httrack >/dev/null || die "could not find httrack"
 ver=$(httrack -O /dev/null --version | sed -e 's/HTTrack version //')
 test -n "$ver" || die "could not run httrack"
 
@@ -278,9 +288,7 @@ if test -n "$rerun_dead"; then
     test -s "$zip" || die "no cache was written by the first pass"
     cp "$zip" "${tmpdir}/cache-before.zip"
     cp "${out}/hts-log.txt" "${tmpdir}/log-before.txt"
-    kill "$serverpid" 2>/dev/null
-    wait "$serverpid" 2>/dev/null
-    serverpid=
+    stop_server
     info "re-running httrack against the stopped server"
     httrack -O "$out" --user-agent="httrack $ver local ($(uname -mrs))" \
         "${moreargs[@]}" "${hts[@]}" >"${log}.dead" 2>&1 &
@@ -441,12 +449,18 @@ while test "$i" -lt "${#audit[@]}"; do
     --file-mode)
         path="${audit[$((i + 1))]}"
         i=$((i + 2))
-        mode=$(stat -c '%a' "${hostroot}/${path}" 2>/dev/null ||
-            stat -f '%Lp' "${hostroot}/${path}" 2>/dev/null)
-        info "checking ${path} mode ${mode:-none} is ${audit[$i]}"
-        if test "$mode" = "${audit[$i]}"; then result "OK"; else
-            result "wrong mode"
-            exit 1
+        if is_windows; then
+            # No POSIX modes, and the engine only chmods #ifndef _WIN32.
+            info "checking ${path} mode"
+            result "SKIP (no POSIX modes)"
+        else
+            mode=$(stat -c '%a' "${hostroot}/${path}" 2>/dev/null ||
+                stat -f '%Lp' "${hostroot}/${path}" 2>/dev/null)
+            info "checking ${path} mode ${mode:-none} is ${audit[$i]}"
+            if test "$mode" = "${audit[$i]}"; then result "OK"; else
+                result "wrong mode"
+                exit 1
+            fi
         fi
         ;;
     esac

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -156,7 +156,6 @@ done
 # --- start the server --------------------------------------------------------
 test -r "$server" || die "cannot read $server"
 serverlog="${tmpdir}/server.log"
-# python.exe is native and cannot resolve the /d/a/... paths Git Bash hands out.
 serverargs=(--root "$(nativepath "$root")")
 if test -n "$tls"; then
     serverargs+=(--tls --cert "$(nativepath "$cert")" --key "$(nativepath "$key")")

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -18,6 +18,7 @@ import base64
 import gzip
 import hashlib
 import os
+import sys
 import time
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import quote, unquote, urlsplit
@@ -1817,7 +1818,9 @@ def main():
         httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
 
     port = httpd.socket.getsockname()[1]
-    # The launcher reads this line to discover the ephemeral port.
+    # The launcher reads this line to discover the ephemeral port; keep it LF, as
+    # Windows would otherwise translate the \n and the \r would land in the port.
+    sys.stdout.reconfigure(newline="\n")
     print(f"PORT {port}", flush=True)
 
     try:

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1818,8 +1818,7 @@ def main():
         httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
 
     port = httpd.socket.getsockname()[1]
-    # The launcher reads this line to discover the ephemeral port; keep it LF, as
-    # Windows would otherwise translate the \n and the \r would land in the port.
+    # Keep the port line the launcher parses LF: Windows would emit \r\n.
     sys.stdout.reconfigure(newline="\n")
     print(f"PORT {port}", flush=True)
 

--- a/tests/proxy-https-server.py
+++ b/tests/proxy-https-server.py
@@ -141,6 +141,9 @@ def main():
         open(os.path.join(logdir, name), "w").close()
     origin_port = start_origin(certfile, logdir)
     proxy_port = start_proxy(logdir, mode)
+    # Keep the discovery lines LF: Windows would translate the \n, and the \r
+    # would land in the ports the caller parses out.
+    sys.stdout.reconfigure(newline="\n")
     print("ORIGIN %d" % origin_port, flush=True)
     print("PROXY %d" % proxy_port, flush=True)
     print("ready", flush=True)

--- a/tests/proxy-https-server.py
+++ b/tests/proxy-https-server.py
@@ -141,8 +141,7 @@ def main():
         open(os.path.join(logdir, name), "w").close()
     origin_port = start_origin(certfile, logdir)
     proxy_port = start_proxy(logdir, mode)
-    # Keep the discovery lines LF: Windows would translate the \n, and the \r
-    # would land in the ports the caller parses out.
+    # Keep the port lines the caller parses LF: Windows would emit \r\n.
     sys.stdout.reconfigure(newline="\n")
     print("ORIGIN %d" % origin_port, flush=True)
     print("PROXY %d" % proxy_port, flush=True)

--- a/tests/socks5-server.py
+++ b/tests/socks5-server.py
@@ -217,8 +217,7 @@ def main():
     tls_port = start_origin(logdir, certfile)
     http_port = start_origin(logdir, None)
     socks_port = start_socks(logdir, mode)
-    # Keep the discovery lines LF: Windows would translate the \n, and the \r
-    # would land in the ports the caller parses out.
+    # Keep the port lines the caller parses LF: Windows would emit \r\n.
     sys.stdout.reconfigure(newline="\n")
     print("TLS %d" % tls_port, flush=True)
     print("HTTP %d" % http_port, flush=True)

--- a/tests/socks5-server.py
+++ b/tests/socks5-server.py
@@ -217,6 +217,9 @@ def main():
     tls_port = start_origin(logdir, certfile)
     http_port = start_origin(logdir, None)
     socks_port = start_socks(logdir, mode)
+    # Keep the discovery lines LF: Windows would translate the \n, and the \r
+    # would land in the ports the caller parses out.
+    sys.stdout.reconfigure(newline="\n")
     print("TLS %d" % tls_port, flush=True)
     print("HTTP %d" % http_port, flush=True)
     print("SOCKS %d" % socks_port, flush=True)

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Helpers shared by the crawl tests. Sourced, not run.
+
+# Python 3 interpreter, or empty. Windows installs it as python.exe only, and a
+# bare "python" may be 2.x or the Store stub, so probe rather than trust the name.
+find_python() {
+    local py
+    for py in "${PYTHON:-}" python3 python; do
+        test -n "$py" || continue
+        "$py" -c 'import sys; sys.exit(sys.version_info[0] != 3)' 2>/dev/null || continue
+        printf '%s\n' "$py"
+        return 0
+    done
+    return 1
+}
+
+# Native form of a path, for arguments handed to a non-MSYS binary: httrack.exe
+# and python.exe cannot resolve the /d/a/... paths Git Bash hands out.
+nativepath() {
+    if command -v cygpath >/dev/null 2>&1; then
+        cygpath -m "$1"
+    else
+        printf '%s\n' "$1"
+    fi
+}
+
+is_windows() {
+    case "$(uname -s)" in
+    MINGW* | MSYS* | CYGWIN*) return 0 ;;
+    *) return 1 ;;
+    esac
+}

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -31,3 +31,18 @@ is_windows() {
     *) return 1 ;;
     esac
 }
+
+# Stop a backgrounded test server and reap it, so the port is released and the
+# tmpdir can be removed. MSYS cannot deliver a signal to a native python.exe, so
+# only -9 (TerminateProcess) lands there; without it the wait below never returns.
+# Every step is "|| true": the caller runs under set -e, and reaping a server we
+# just signalled makes wait return 143.
+stop_server() {
+    test -n "${1:-}" || return 0
+    kill "$1" 2>/dev/null || true
+    if is_windows; then
+        kill -9 "$1" 2>/dev/null || true
+    fi
+    wait "$1" 2>/dev/null || true
+    return 0
+}

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -18,7 +18,7 @@ find_python() {
 # Native form of a path, for arguments handed to a non-MSYS binary: httrack.exe
 # and python.exe cannot resolve the /d/a/... paths Git Bash hands out.
 nativepath() {
-    if command -v cygpath >/dev/null 2>&1; then
+    if is_windows && command -v cygpath >/dev/null 2>&1; then
         cygpath -m "$1"
     else
         printf '%s\n' "$1"

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -2,8 +2,8 @@
 #
 # Helpers shared by the crawl tests. Sourced, not run.
 
-# Python 3 interpreter, or empty. Windows installs it as python.exe only, and a
-# bare "python" may be 2.x or the Store stub, so probe rather than trust the name.
+# Python 3 interpreter, or empty: Windows only installs python.exe, and a bare
+# "python" may be 2.x or the Store stub.
 find_python() {
     local py
     for py in "${PYTHON:-}" python3 python; do
@@ -15,8 +15,7 @@ find_python() {
     return 1
 }
 
-# Native form of a path, for arguments handed to a non-MSYS binary: httrack.exe
-# and python.exe cannot resolve the /d/a/... paths Git Bash hands out.
+# Native form of a path: a non-MSYS binary cannot resolve Git Bash's /d/a/... ones.
 nativepath() {
     if is_windows && command -v cygpath >/dev/null 2>&1; then
         cygpath -m "$1"
@@ -32,11 +31,9 @@ is_windows() {
     esac
 }
 
-# Stop a backgrounded test server and reap it, so the port is released and the
-# tmpdir can be removed. MSYS cannot deliver a signal to a native python.exe, so
-# only -9 (TerminateProcess) lands there; without it the wait below never returns.
-# Every step is "|| true": the caller runs under set -e, and reaping a server we
-# just signalled makes wait return 143.
+# Stop a backgrounded server and reap it; MSYS cannot signal a native python.exe,
+# so only -9 lands. Every step is "|| true": callers run under set -e, and reaping
+# a server we just signalled makes wait return 143.
 stop_server() {
     test -n "${1:-}" || return 0
     kill "$1" 2>/dev/null || true


### PR DESCRIPTION
Tier 2 of the Windows test work. The ~40 `*_local-*` tests crawl the bundled Python server over loopback: the real TLS handshake, the real cache, the real file writer, the `/MD` cross-DLL heap boundary. None of that had ever run on Windows, so a Windows-only regression there stayed invisible until a user hit it. Tier 1 (the engine self-tests, #577) is green, so these are next.

Three dull things stopped them running at all. `python3` is `python.exe` on Windows. MSYS hands out `/d/a/...` paths that a native `python.exe` cannot resolve, and the suite deliberately turns arg rewriting off, so nothing fixed them up. And Python's text layer turns the `PORT <n>` discovery line into CRLF, so a stray `\r` ended up in the parsed port, and from there in every crawled URL and the mirror directory name. The python lookup, the path conversion and the server shutdown move into a new `tests/testlib.sh`; the newline is fixed at the source in the three servers. `--file-mode` is skipped on Windows, where the engine never chmods. POSIX behaviour is unchanged and `make check` still passes 97/0.

93 of the 95 pass on Windows, x64 and Win32 both, and the run pins its expected skips rather than counting them so a suite that quietly degraded to all-skipped can't report green. The two skips are real Windows engine bugs the crawls surfaced, each with its own issue and a follow-up fix: #579 (a failed connect never falls back to the next address, because Winsock reports it in `select()`'s exception set) and #581 (an interrupted resume into an unusable 206 loses the file when the cache had to be repaired). Both are skipped here behind a TODO.
