### PR TITLE
Export hts_convertStringSystemToUTF8 from the DLL

### DIFF
--- a/src/htscharset.c
+++ b/src/htscharset.c
@@ -385,7 +385,7 @@ char *hts_convertStringFromUTF8(const char *s, size_t size, const char *charset)
   return hts_convertStringCPFromUTF8(s, size, cp);
 }
 
-char *hts_convertStringSystemToUTF8(const char *s, size_t size) {
+HTSEXT_API char *hts_convertStringSystemToUTF8(const char *s, size_t size) {
   return hts_convertStringCPToUTF8(s, size, GetACP());
 }
 

--- a/src/htscharset.h
+++ b/src/htscharset.h
@@ -175,7 +175,7 @@ extern char *hts_convertUCS2StringToUTF8(LPWSTR woutput, int wsize);
  * Convert current system codepage to UTF-8.
  * This function is WIN32 specific.
  **/
-extern char *hts_convertStringSystemToUTF8(const char *s, size_t size);
+HTSEXT_API char *hts_convertStringSystemToUTF8(const char *s, size_t size);
 
 /**
  * Replace the CRT's ANSI argv by a UTF-8 one decoded from the real UTF-16


### PR DESCRIPTION
WinHTTrack builds its own argv from MFC dialog strings and calls `hts_main2()` directly, bypassing `hts_argv_utf8()`, so it needs the same CP_ACP-to-UTF-8 conversion the CLI gets for free. Today it carries a private reimplementation (`strdupt_utf8` in `Shell.cpp`). Exporting `hts_convertStringSystemToUTF8`, the exact converter that helper duplicates, lets the GUI delete its copy and share one code path.

The symbol lives inside the `_WIN32` block, so this only adds a DLL export on Windows; the POSIX ABI and soname are untouched. `hts_argv_utf8` right beside it is already exported the same way.