### PR TITLE
Run the connect-fallback crawl on Windows

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -177,8 +177,7 @@ jobs:
 
           # Every gate here exits 77, so an all-skipped suite would report green having
           # tested nothing: pin the skips, and floor the passes in case the glob empties.
-          # pending #579, #581
-          expected_skips=" 19_local-connect-fallback.test 48_local-crange-memresume.test"
+          expected_skips=" 48_local-crange-memresume.test"  # pending #581
           [ "$pass" -ge 90 ] || { echo "::error::only $pass tests passed ($skip skipped)"; exit 1; }
           [ "$skipped" = "$expected_skips" ] || { echo "::error::unexpected skips:$skipped"; exit 1; }
           [ "$fail" -eq 0 ] || { echo "::error::failing:$failed"; exit 1; }

--- a/tests/19_local-connect-fallback.test
+++ b/tests/19_local-connect-fallback.test
@@ -31,11 +31,6 @@ GNU | GNU/*)
     exit 77
     ;;
 esac
-# TODO: drop once https://github.com/xroche/httrack/issues/579 is fixed.
-if is_windows; then
-    echo "Windows: the connect fallback never runs (#579), skipping"
-    exit 77
-fi
 
 server=$(nativepath "$top_srcdir/tests/local-server.py")
 root=$(nativepath "$top_srcdir/tests/server-root")


### PR DESCRIPTION
Now that #580 fixed the Winsock connect fallback (a failed connect landing in `select()`'s exception set), `19_local-connect-fallback` can run for real on Windows. This drops its Windows skip and removes it from the tier-2 workflow's expected-skips list, so the Windows CI leg exercises the fallback instead of asserting the skip. Behaviour on POSIX is unchanged; the test already ran there.