### PR TITLE
Free opt->accept and opt->headers in hts_free_opt

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -6030,6 +6030,8 @@ HTSEXT_API void hts_free_opt(httrackp * opt) {
     StringFree(opt->referer);
     StringFree(opt->from);
     StringFree(opt->lang_iso);
+    StringFree(opt->accept);
+    StringFree(opt->headers);
     StringFree(opt->sys_com);
     StringFree(opt->mimedefs);
     StringFree(opt->filelist);


### PR DESCRIPTION
`hts_free_opt` frees about twenty of the option struct's `String` fields but omits `opt->accept` and `opt->headers`, both allocated in `hts_create_opt` (htslib.c:5900/5902). Every opt create/free cycle leaks the two, roughly 144 bytes.

Harmless for the CLI, which uses one `opt` per process and reclaims it at exit, but real, and it makes LeakSanitizer noisy. The fuzz job runs with `detect_leaks=1`, so any harness that constructs an `opt` trips over it (this surfaced while prototyping an `htsparse` fuzzer). Verified with the `copyopt` self-test under LeakSanitizer: the two leaks reachable from `hts_create_opt` at :5900/:5902 disappear with this change, leaving only the pre-existing, out-of-scope CLI argv buffers.