### PR TITLE
Fuzz the real HTML parser (htsparse) with a mocked engine

### DIFF
--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -1,7 +1,8 @@
 # libFuzzer harnesses; built only with --enable-fuzzers (requires clang).
 if FUZZERS
 noinst_PROGRAMS = fuzz-charset fuzz-meta fuzz-idna fuzz-entities \
-	fuzz-unescape fuzz-filters fuzz-url fuzz-header fuzz-cachendx
+	fuzz-unescape fuzz-filters fuzz-url fuzz-header fuzz-cachendx \
+	fuzz-htsparse
 endif
 
 AM_CPPFLAGS = \
@@ -25,6 +26,7 @@ fuzz_filters_SOURCES = fuzz-filters.c fuzz.h
 fuzz_url_SOURCES = fuzz-url.c fuzz.h
 fuzz_header_SOURCES = fuzz-header.c fuzz.h
 fuzz_cachendx_SOURCES = fuzz-cachendx.c fuzz.h
+fuzz_htsparse_SOURCES = fuzz-htsparse.c fuzz.h
 
 # List corpus files explicitly: automake does not expand EXTRA_DIST globs.
 EXTRA_DIST = README.md run-fuzzers.sh \
@@ -42,4 +44,6 @@ EXTRA_DIST = README.md run-fuzzers.sh \
 	corpus/header/full-response.txt corpus/header/redirect.txt \
 	corpus/cachendx/new-format.txt corpus/cachendx/old-format.txt \
 	corpus/cachendx/regress-overadvance.bin \
-	corpus/cachendx/regress-truncated-entry.bin
+	corpus/cachendx/regress-truncated-entry.bin \
+	corpus/htsparse/basic.html corpus/htsparse/script-inscript.html \
+	corpus/htsparse/meta-usemap.html corpus/htsparse/malformed.html

--- a/fuzz/corpus/htsparse/basic.html
+++ b/fuzz/corpus/htsparse/basic.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html><head>
+<meta charset="utf-8">
+<base href="http://example.com/dir/">
+<title>Seed</title>
+<link rel="stylesheet" href="style.css">
+<script src="app.js"></script>
+</head><body>
+<h1>Hi</h1>
+<a href="page2.html">next</a>
+<a href="http://other.example.org/x?y=1#frag">abs</a>
+<img src="pic.png" srcset="a.png 1x, b.png 2x">
+<script>var u="inline.html"; document.write('<a href="gen.html">g</a>');</script>
+<form action="/cgi/submit"><input name="q"></form>
+</body></html>

--- a/fuzz/corpus/htsparse/malformed.html
+++ b/fuzz/corpus/htsparse/malformed.html
@@ -1,0 +1,8 @@
+<a href="unclosed.html
+<img src='mix"ed.png>
+<a href=noquote.html >bare</a>
+<!-- comment <a href="incomment.html"> -->
+<a href="tab	newline
+.html">wsp</a>
+<script>unterminated "string and <a href=
+<a href=

--- a/fuzz/corpus/htsparse/meta-usemap.html
+++ b/fuzz/corpus/htsparse/meta-usemap.html
@@ -1,0 +1,11 @@
+<html><head>
+<meta http-equiv="refresh" content="0; url=redir.html">
+<base href="http://h/b/">
+<link rel="alternate" href="feed.xml">
+</head><body background="page-bg.jpg">
+<img src="map.png" usemap="#m">
+<map name="m"><area href="area1.html" coords="0,0,10,10"></map>
+<applet code="A.class" codebase="applets/"><param name="src" value="p.dat"></applet>
+<object data="o.swf"><embed src="e.svg"></object>
+<a href="&#104;ttp://ent/e.html">entity</a>
+</body></html>

--- a/fuzz/corpus/htsparse/script-inscript.html
+++ b/fuzz/corpus/htsparse/script-inscript.html
@@ -1,0 +1,13 @@
+<html><body>
+<script type="text/javascript">
+var a = "http://x/1.html", b = 'q\'uote', c = "/*not*/comment";
+// line "with" quotes and http://y/2.html
+/* block 'with' <a href="notparsed"> */
+var re = /a\/b\//g;
+document.write('<img src="w1.png">');
+document.writeln("<a href='w2.html'>k</a>");
+element.onclick = "location='onh.html'";
+</script>
+<a href="after.html" onmouseover="go('ev.html')">x</a>
+<div style="background:url(bg.png)">z</div>
+</body></html>

--- a/fuzz/fuzz-htsparse.c
+++ b/fuzz/fuzz-htsparse.c
@@ -1,0 +1,179 @@
+/* ------------------------------------------------------------ */
+/*
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) 2026 Xavier Roche and other contributors
+
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Please visit our Website: http://www.httrack.com
+*/
+
+/* Fuzz the real HTML parser htsparse() (htsparse.c) over a mocked engine: the
+   tag/attribute/JS-inscript scanner, the link rewriter, and the
+   accept -> url_savename -> hts_record_link path, on every crawled page. The
+   coupling is state, not network, so we build the minimal crawl state
+   httpmirror() sets up and let the page walk it, then discard.
+   The str/stre wiring below mirrors the htsparse() call site in htscore.c; keep
+   it in sync if those structs gain a field the parser reads. */
+#include "fuzz.h"
+
+#include "httrack-library.h" /* hts_init, hts_create_opt, hts_free_opt */
+#include "htscore.h"   /* heap(), hts_record_*, filters_init, cache_back */
+#include "htsback.h"   /* back_new, back_free, back_delete_all */
+#include "htshash.h"   /* hash_init, hash_free */
+#include "htsrobots.h" /* checkrobots_free, robots_wizard */
+#include "htsparse.h"  /* htsparse, htsmoduleStructExtended */
+#include "htsmodules.h"
+#include "coucal.h"
+
+/* htsparse never calls the module addLink on the internal parse; stub anyway.
+ */
+static int fuzz_addlink(htsmoduleStruct *str, char *link) {
+  (void) str;
+  (void) link;
+  return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static int inited = 0;
+
+  httrackp *opt;
+  cache_back cache;
+  hash_struct hash;
+  robots_wizard robots;
+  struct_back *sback;
+  char **filters = NULL;
+  int filptr = 0;
+
+  htsblk r;
+  htsmoduleStruct str;
+  htsmoduleStructExtended stre;
+  int ptr, error = 0, store_errpage = 0;
+  int makeindex_done = 0, makeindex_links = 0;
+  FILE *makeindex_fp = NULL;
+  char makeindex_firstlink[HTS_URLMAXSIZE * 2] = "";
+  LLint stat_fragment = 0, makestat_total = 0;
+  int makestat_lnk = 0;
+  char base[HTS_URLMAXSIZE * 2] = "";
+  char codebase[HTS_URLMAXSIZE * 2] = "";
+
+  if (!inited) {
+    hts_init();
+    inited = 1;
+  }
+
+  opt = hts_create_opt();
+  opt->log = opt->errlog = NULL;
+  opt->robots = 0; /* skip the robots.txt fetch path */
+
+  memset(&cache, 0, sizeof(cache));
+  cache.type = 0; /* no on-disk cache */
+  cache.hashtable = coucal_new(0);
+  cache.cached_tests = coucal_new(0);
+  coucal_value_is_malloc(cache.cached_tests, 1);
+
+  memset(&robots, 0, sizeof(robots));
+  strcpybuff(robots.adr, "!");
+  opt->robotsptr = &robots;
+
+  opt->maxfilter = maximum(opt->maxfilter, 128);
+  filters_init(&filters, opt->maxfilter, 0);
+  opt->filters.filters = &filters;
+  opt->filters.filptr = &filptr;
+
+  opt->hash = &hash;
+  hts_record_init(opt);
+  hash_init(opt, &hash, opt->urlhack);
+  hash.liens = (const lien_url *const *const *) &opt->liens;
+
+  sback = back_new(opt, opt->maxsoc * 32 + 1024);
+
+  /* Seed the link heap: idx 0 primary, idx 1 the parsed page; ptr>0 selects
+     full HTML parsing + the rewriter. urladr()/urlfil()/savename() alias
+     heap(ptr); save=/dev/null makes the end-of-parse flush hermetic. */
+  hts_record_link(opt, "example.com", "/", "/dev/null", "", "", NULL);
+  hts_record_link(opt, "example.com", "/index.html", "/dev/null", "", "", NULL);
+  ptr = 1;
+
+  /* The downloaded object: NUL-terminated, size bytes in a size+1 allocation
+     (htsparse one-past-reads onto the terminator). */
+  hts_init_htsblk(&r);
+  r.statuscode = 200;
+  r.size = (LLint) size;
+  r.adr = malloct(size + 1);
+  memcpy(r.adr, data, size);
+  r.adr[size] = '\0';
+  strcpybuff(r.contenttype, "text/html");
+
+  memset(&str, 0, sizeof(str));
+  memset(&stre, 0, sizeof(stre));
+  str.err_msg = codebase; /* scratch; htsparse writes it only on error */
+  str.filename = heap(ptr)->sav;
+  str.mime = r.contenttype;
+  str.url_host = heap(ptr)->adr;
+  str.url_file = heap(ptr)->fil;
+  str.size = (int) r.size;
+  str.addLink = fuzz_addlink;
+  str.opt = opt;
+  str.sback = sback;
+  str.cache = &cache;
+  str.hashptr = &hash;
+  str.numero_passe = 0;
+  str.ptr_ = &ptr;
+  str.page_charset_ = NULL;
+
+  stre.r_ = &r;
+  stre.error_ = &error;
+  stre.exit_xh_ = &opt->state.exit_xh;
+  stre.store_errpage_ = &store_errpage;
+  stre.base = base;
+  stre.codebase = codebase;
+  stre.filters_ = &filters;
+  stre.filptr_ = &filptr;
+  stre.robots_ = &robots;
+  stre.hash_ = &hash;
+  stre.makeindex_done_ = &makeindex_done;
+  stre.makeindex_fp_ = &makeindex_fp;
+  stre.makeindex_links_ = &makeindex_links;
+  stre.makeindex_firstlink_ = makeindex_firstlink;
+  stre.template_header_ = "";
+  stre.template_body_ = "";
+  stre.template_footer_ = "";
+  stre.stat_fragment_ = &stat_fragment;
+  stre.makestat_time = 0;
+  stre.makestat_fp = NULL;
+  stre.makestat_total_ = &makestat_total;
+  stre.makestat_lnk_ = &makestat_lnk;
+  stre.maketrack_fp = NULL;
+
+  (void) htsparse(&str, &stre);
+
+  freet(r.adr);
+  back_delete_all(opt, &cache, sback);
+  back_free(&sback);
+  hash_free(&hash);
+  coucal_delete(&cache.hashtable);
+  coucal_delete(&cache.cached_tests);
+  checkrobots_free(&robots);
+  if (filters != NULL) {
+    if (filters[0] != NULL)
+      freet(filters[0]);
+    freet(filters);
+  }
+  hts_record_free(opt);
+  hts_free_opt(opt);
+  return 0;
+}

--- a/fuzz/fuzz-htsparse.c
+++ b/fuzz/fuzz-htsparse.c
@@ -65,6 +65,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   int makestat_lnk = 0;
   char base[HTS_URLMAXSIZE * 2] = "";
   char codebase[HTS_URLMAXSIZE * 2] = "";
+  char err_msg[1024] = "";
 
   if (!inited) {
     hts_init();
@@ -108,13 +109,14 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   r.statuscode = 200;
   r.size = (LLint) size;
   r.adr = malloct(size + 1);
-  memcpy(r.adr, data, size);
+  if (size)
+    memcpy(r.adr, data, size);
   r.adr[size] = '\0';
   strcpybuff(r.contenttype, "text/html");
 
   memset(&str, 0, sizeof(str));
   memset(&stre, 0, sizeof(stre));
-  str.err_msg = codebase; /* scratch; htsparse writes it only on error */
+  str.err_msg = err_msg;
   str.filename = heap(ptr)->sav;
   str.mime = r.contenttype;
   str.url_host = heap(ptr)->adr;

--- a/fuzz/fuzz-htsparse.c
+++ b/fuzz/fuzz-htsparse.c
@@ -21,26 +21,22 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 Please visit our Website: http://www.httrack.com
 */
 
-/* Fuzz the real HTML parser htsparse() (htsparse.c) over a mocked engine: the
-   tag/attribute/JS-inscript scanner, the link rewriter, and the
-   accept -> url_savename -> hts_record_link path, on every crawled page. The
-   coupling is state, not network, so we build the minimal crawl state
-   httpmirror() sets up and let the page walk it, then discard.
-   The str/stre wiring below mirrors the htsparse() call site in htscore.c; keep
-   it in sync if those structs gain a field the parser reads. */
+/* Fuzz the real htsparse() over a mocked engine: the minimal crawl state
+   httpmirror() builds, then a page walked through the parser and discarded. The
+   str/stre wiring below mirrors htsparse()'s call site in htscore.c; update it
+   in lockstep if those structs gain a field the parser reads. */
 #include "fuzz.h"
 
-#include "httrack-library.h" /* hts_init, hts_create_opt, hts_free_opt */
-#include "htscore.h"   /* heap(), hts_record_*, filters_init, cache_back */
-#include "htsback.h"   /* back_new, back_free, back_delete_all */
-#include "htshash.h"   /* hash_init, hash_free */
-#include "htsrobots.h" /* checkrobots_free, robots_wizard */
-#include "htsparse.h"  /* htsparse, htsmoduleStructExtended */
+#include "httrack-library.h"
+#include "htscore.h"
+#include "htsback.h"
+#include "htshash.h"
+#include "htsrobots.h"
+#include "htsparse.h"
 #include "htsmodules.h"
 #include "coucal.h"
 
-/* htsparse never calls the module addLink on the internal parse; stub anyway.
- */
+/* htsparse ignores str.addLink on the internal parse; stub it. */
 static int fuzz_addlink(htsmoduleStruct *str, char *link) {
   (void) str;
   (void) link;
@@ -77,7 +73,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   opt = hts_create_opt();
   opt->log = opt->errlog = NULL;
-  opt->robots = 0; /* skip the robots.txt fetch path */
+  opt->robots = 0;
 
   memset(&cache, 0, sizeof(cache));
   cache.type = 0; /* no on-disk cache */
@@ -101,15 +97,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   sback = back_new(opt, opt->maxsoc * 32 + 1024);
 
-  /* Seed the link heap: idx 0 primary, idx 1 the parsed page; ptr>0 selects
-     full HTML parsing + the rewriter. urladr()/urlfil()/savename() alias
-     heap(ptr); save=/dev/null makes the end-of-parse flush hermetic. */
+  /* ptr=1 (index 1 is the parsed page) selects full HTML parsing + the
+     rewriter; urladr()/urlfil()/savename() alias heap(ptr), save=/dev/null. */
   hts_record_link(opt, "example.com", "/", "/dev/null", "", "", NULL);
   hts_record_link(opt, "example.com", "/index.html", "/dev/null", "", "", NULL);
   ptr = 1;
 
-  /* The downloaded object: NUL-terminated, size bytes in a size+1 allocation
-     (htsparse one-past-reads onto the terminator). */
+  /* NUL-terminated in a size+1 alloc: htsparse one-past-reads onto the NUL. */
   hts_init_htsblk(&r);
   r.statuscode = 200;
   r.size = (LLint) size;


### PR DESCRIPTION
Adds `fuzz-htsparse`, a libFuzzer harness that drives the real `htsparse()`, the HTML parser run over every crawled page and the largest hostile-input surface with no direct fuzz coverage until now. The 9 existing harnesses all fuzz pure `(buf,len)` parsers; the tag/attribute/JS-inscript scanner, the link rewriter, and the `accept -> url_savename -> hts_record_link` path were reached only by slow full-crawl tests.

`htsparse()` is not a pure function, but its coupling is state, not network: the in-parse `back_wait()` is gated behind flags a zeroed `opt` never sets. The harness builds the minimal crawl state `httpmirror()` sets up (opt, cache, hash, filters, robots, backing, plus a seeded two-entry link heap with `ptr=1` so the page walks full HTML parsing and the rewriter), NUL-terminates the input as the receive path does, runs the parser, flushes the rewritten page to `/dev/null`, and tears everything down per input for full isolation. Four seeds cover links, srcset, base/meta/usemap, a script/`document.write` body, and malformed tags. Clean under ASan+UBSan+LeakSanitizer across seed replay and a 90s mutation run: no crash or leak, flat RSS, growing coverage.

Bundles the `src/coucal` bump to `ab59c6a` (coucal#13): this harness is the first fuzzer to hash keys through coucal under UBSan, which tripped a pre-existing `getblock32` pointer-overflow. Stacked on #585 (the `opt->accept`/`opt->headers` leak fix), because the fuzz job runs `detect_leaks=1` and the harness builds an `opt`, so without that fix the leak surfaces here. Both drop out of the diff once #585 merges and this rebases onto master.

One caveat: the `str`/`stre` wiring mirrors the `htsparse()` call site in htscore.c by hand, so if those structs gain a field the parser reads, the harness needs the same update. It is flagged in a comment.