### PR TITLE
Add and translate the new WinHTTrack GUI option strings

### DIFF
--- a/lang.def
+++ b/lang.def
@@ -1006,3 +1006,31 @@ LANG_SERVEND
 Server terminated
 LANG_FATALERR
 A fatal error has occurred during this mirror
+LANG_PROXYTYPE
+Proxy type:
+LANG_PROXYTYPETIP
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+LANG_COOKIEFILE
+Load cookies from file:
+LANG_COOKIEFILETIP
+Preload cookies from a Netscape cookies.txt file before crawling.
+LANG_PAUSEFILES
+Pause between files:
+LANG_PAUSEFILESTIP
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+LANG_KEEPWWW
+Keep the www. prefix (do not merge www.host with host)
+LANG_KEEPWWWTIP
+Do not treat www.host and host as the same site.
+LANG_KEEPSLASHES
+Keep double slashes in URLs
+LANG_KEEPSLASHESTIP
+Do not collapse duplicate slashes in URLs.
+LANG_KEEPQUERYORDER
+Keep the original query-string order
+LANG_KEEPQUERYORDERTIP
+Do not reorder query-string parameters when deduplicating URLs.
+LANG_STRIPQUERY
+Strip query keys:
+LANG_STRIPQUERYTIP
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).

--- a/lang/Bulgarian.txt
+++ b/lang/Bulgarian.txt
@@ -928,3 +928,31 @@ Server terminated
 Сървърът не отговаря
 A fatal error has occurred during this mirror
 Фатална грешка при създаването на този огледален сайт
+Proxy type:
+Тип на прокси:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Протокол на прокси: HTTP или SOCKS5 (стандартният порт на SOCKS5 е 1080).
+Load cookies from file:
+Зареждане на 'бисквитки' от файл:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Предварително зареждане на 'бисквитки' от файл Netscape cookies.txt преди обхождането.
+Pause between files:
+Пауза между файловете:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Случайно забавяне между изтеглянията на файлове, в секунди. Използвайте MIN:MAX за случаен диапазон (например 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Запазване на префикса www. (без сливане на www.host с host)
+Do not treat www.host and host as the same site.
+www.host и host да не се третират като един и същ сайт.
+Keep double slashes in URLs
+Запазване на двойните наклонени черти в URL
+Do not collapse duplicate slashes in URLs.
+Без премахване на повтарящите се наклонени черти в URL.
+Keep the original query-string order
+Запазване на оригиналния ред на параметрите в заявката
+Do not reorder query-string parameters when deduplicating URLs.
+Без пренареждане на параметрите на заявката при премахване на дублирани URL.
+Strip query keys:
+Премахване на ключове от заявката:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Ключове от заявката, разделени със запетая, които да се премахнат от името на записания файл (например sid,utm_source).

--- a/lang/Castellano.txt
+++ b/lang/Castellano.txt
@@ -928,3 +928,31 @@ Server terminated
 Servidor desconectado
 A fatal error has occurred during this mirror
 Ha ocurrido un error fatal durante esta copia
+Proxy type:
+Tipo de proxy:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Protocolo del proxy: HTTP o SOCKS5 (el puerto SOCKS5 predeterminado es 1080).
+Load cookies from file:
+Cargar cookies desde un archivo:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Precargar cookies desde un archivo Netscape cookies.txt antes de comenzar la descarga.
+Pause between files:
+Pausa entre archivos:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Retardo aleatorio entre descargas de archivos, en segundos. Use MIN:MAX para un rango aleatorio (p. ej. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Mantener el prefijo www. (no combinar www.host con host)
+Do not treat www.host and host as the same site.
+No tratar www.host y host como el mismo sitio.
+Keep double slashes in URLs
+Mantener las barras dobles en las URL
+Do not collapse duplicate slashes in URLs.
+No colapsar las barras duplicadas en las URL.
+Keep the original query-string order
+Mantener el orden original de la query string
+Do not reorder query-string parameters when deduplicating URLs.
+No reordenar los parámetros de la query string al deduplicar las URL.
+Strip query keys:
+Eliminar claves de query string:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Claves de query string, separadas por comas, que se eliminarán del nombre de los archivos guardados (p. ej. sid,utm_source).

--- a/lang/Cesky.txt
+++ b/lang/Cesky.txt
@@ -928,3 +928,31 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+Proxy type:
+Typ proxy:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Protokol proxy: HTTP nebo SOCKS5 (výchozí port SOCKS5 je 1080).
+Load cookies from file:
+Naèíst cookies ze souboru:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Naèíst cookies ze souboru Netscape cookies.txt pøed zahájením stahování.
+Pause between files:
+Prodleva mezi soubory:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Náhodná prodleva mezi stahováním souborù, v sekundách. Pro náhodný rozsah použijte MIN:MAX (napø. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Zachovat pøedponu www. (nesluèovat www.host s host)
+Do not treat www.host and host as the same site.
+Nepovažovat www.host a host za stejný web.
+Keep double slashes in URLs
+Zachovat dvojitá lomítka v URL
+Do not collapse duplicate slashes in URLs.
+Nesluèovat opakovaná lomítka v URL.
+Keep the original query-string order
+Zachovat pùvodní poøadí øetìzce dotazu
+Do not reorder query-string parameters when deduplicating URLs.
+Nemìnit poøadí parametrù øetìzce dotazu pøi odstraòování duplicitních URL.
+Strip query keys:
+Odebrat klíèe dotazu:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Klíèe dotazu oddìlené èárkami, které se vynechají z pojmenování ukládaných souborù (napø. sid,utm_source).

--- a/lang/Chinese-BIG5.txt
+++ b/lang/Chinese-BIG5.txt
@@ -928,3 +928,31 @@ Server terminated
 伺服器已終止
 A fatal error has occurred during this mirror
 這鏡像發生了不可回復的錯誤
+Proxy type:
+proxy 類型:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+proxy 協定: HTTP 或 SOCKS5 (SOCKS5 的預設連接埠為 1080)。
+Load cookies from file:
+從檔案載入 cookies:
+Preload cookies from a Netscape cookies.txt file before crawling.
+在抓取前從 Netscape 格式的 cookies.txt 檔案預先載入 cookies。
+Pause between files:
+檔案之間暫停:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+檔案下載之間的隨機延遲（秒）。使用 MIN:MAX 指定隨機範圍 (例如 2:8)。
+Keep the www. prefix (do not merge www.host with host)
+保留 www. 前綴 (不將 www.host 與 host 合併)
+Do not treat www.host and host as the same site.
+不將 www.host 與 host 視為同一站點。
+Keep double slashes in URLs
+保留 URL 中的雙斜線
+Do not collapse duplicate slashes in URLs.
+不合併 URL 中重複的斜線。
+Keep the original query-string order
+保留查詢字串的原始順序
+Do not reorder query-string parameters when deduplicating URLs.
+在對 URL 去重時不重新排列查詢字串參數。
+Strip query keys:
+移除查詢鍵:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+以逗號分隔的查詢鍵，將其從儲存檔案的命名中移除 (例如 sid,utm_source)。

--- a/lang/Chinese-Simplified.txt
+++ b/lang/Chinese-Simplified.txt
@@ -928,3 +928,31 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+Proxy type:
+代理类型:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+代理协议: HTTP 或 SOCKS5 (SOCKS5 的默认端口为 1080)。
+Load cookies from file:
+从文件加载 cookies:
+Preload cookies from a Netscape cookies.txt file before crawling.
+在抓取前从 Netscape 格式的 cookies.txt 文件预加载 cookies。
+Pause between files:
+文件间暂停:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+文件下载之间的随机延迟（秒）。使用 MIN:MAX 指定随机范围 (例如 2:8)。
+Keep the www. prefix (do not merge www.host with host)
+保留 www. 前缀 (不将 www.host 与 host 合并)
+Do not treat www.host and host as the same site.
+不把 www.host 和 host 视为同一站点。
+Keep double slashes in URLs
+保留 URL 中的双斜杠
+Do not collapse duplicate slashes in URLs.
+不合并 URL 中重复的斜杠。
+Keep the original query-string order
+保留查询字符串的原始顺序
+Do not reorder query-string parameters when deduplicating URLs.
+在对 URL 去重时不重新排列查询字符串参数。
+Strip query keys:
+剥离查询键:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+用逗号分隔的查询键，将其从保存文件的命名中删除 (例如 sid,utm_source)。

--- a/lang/Croatian.txt
+++ b/lang/Croatian.txt
@@ -930,3 +930,31 @@ Server terminated
 Poslužitelj je razriješen
 A fatal error has occurred during this mirror
 Tijekom ovog zrcaljenja je nastala fatalna pogreška
+Proxy type:
+Vrsta posrednika:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Protokol posrednika: HTTP ili SOCKS5 (zadani port za SOCKS5 je 1080).
+Load cookies from file:
+Uèitati kolaèiæe iz datoteke:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Prije zrcaljenja uèitati kolaèiæe iz datoteke Netscape cookies.txt.
+Pause between files:
+Stanka izmeðu datoteka:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Nasumièna odgoda izmeðu preuzimanja datoteka, u sekundama. Za nasumièni raspon koristiti MIN:MAX (npr. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Zadr¾ati www. predmetak (ne spajati www.host s host)
+Do not treat www.host and host as the same site.
+www.host i host ne smatrati istim web-mjestom.
+Keep double slashes in URLs
+Zadr¾ati dvostruke kose crte u URL-ovima
+Do not collapse duplicate slashes in URLs.
+Ne sa¾imati ponovljene kose crte u URL-ovima.
+Keep the original query-string order
+Zadr¾ati izvorni redoslijed teksta za upite
+Do not reorder query-string parameters when deduplicating URLs.
+Ne mijenjati redoslijed parametara teksta za upite pri uklanjanju dvostrukih URL-ova.
+Strip query keys:
+Ukloniti kljuèeve upita:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Zarezom odvojeni kljuèevi upita koji se izostavljaju iz naziva spremljenih datoteka (npr. sid,utm_source).

--- a/lang/Dansk.txt
+++ b/lang/Dansk.txt
@@ -976,3 +976,31 @@ Click on this notification to restart the interrupted mirror
 Klik på denne notifikation for at genstarte den afbrudte spejlkopiering
 HTTrack: could not save profile for '%s'!
 HTTrack: kunne ikke gemme profil for '%s'!
+Proxy type:
+Proxytype:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Proxyprotokol: HTTP eller SOCKS5 (SOCKS5 bruger som standard port 1080).
+Load cookies from file:
+Indlæs cookies fra fil:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Indlæs cookies fra en Netscape cookies.txt-fil, før crawlingen starter.
+Pause between files:
+Pause mellem filer:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Tilfældig forsinkelse mellem filoverførsler, i sekunder. Brug MIN:MAX for et tilfældigt interval (f.eks. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Behold www.-præfikset (sammenlæg ikke www.host med host)
+Do not treat www.host and host as the same site.
+Behandl ikke www.host og host som det samme websted.
+Keep double slashes in URLs
+Behold dobbelte skråstreger i URL'er
+Do not collapse duplicate slashes in URLs.
+Sammenfold ikke gentagne skråstreger i URL'er.
+Keep the original query-string order
+Behold den oprindelige rækkefølge i forespørgselsstrengen
+Do not reorder query-string parameters when deduplicating URLs.
+Omorden ikke forespørgselsstrengens parametre, når dublerede URL'er fjernes.
+Strip query keys:
+Fjern forespørgselsnøgler:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Kommaseparerede forespørgselsnøgler, der udelades i navngivningen af gemte filer (f.eks. sid,utm_source).

--- a/lang/Deutsch.txt
+++ b/lang/Deutsch.txt
@@ -928,3 +928,31 @@ Server terminated
 Der Server wurde beendet
 A fatal error has occurred during this mirror
 Fataler Fehler während der Webseiten-Kopie
+Proxy type:
+Proxy-Typ:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Proxy-Protokoll: HTTP oder SOCKS5 (Standardport von SOCKS5 ist 1080).
+Load cookies from file:
+Cookies aus Datei laden:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Cookies aus einer Netscape-cookies.txt-Datei laden, bevor das Crawlen beginnt.
+Pause between files:
+Pause zwischen Dateien:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Zufällige Verzögerung zwischen Datei-Downloads, in Sekunden. MIN:MAX für einen Zufallsbereich verwenden (z. B. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+www.-Präfix beibehalten (www.host nicht mit host zusammenführen)
+Do not treat www.host and host as the same site.
+www.host und host nicht als dieselbe Website behandeln.
+Keep double slashes in URLs
+Doppelte Schrägstriche in URLs beibehalten
+Do not collapse duplicate slashes in URLs.
+Doppelte Schrägstriche in URLs nicht zusammenführen.
+Keep the original query-string order
+Ursprüngliche Reihenfolge des Query-Strings beibehalten
+Do not reorder query-string parameters when deduplicating URLs.
+Query-String-Parameter beim Entfernen doppelter URLs nicht neu anordnen.
+Strip query keys:
+Query-Schlüssel entfernen:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Kommagetrennte Query-Schlüssel, die bei der Benennung gespeicherter Dateien entfallen (z. B. sid,utm_source).

--- a/lang/Eesti.txt
+++ b/lang/Eesti.txt
@@ -928,3 +928,31 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+Proxy type:
+Proxy tüüp:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Proxy protokoll: HTTP või SOCKS5 (SOCKS5 vaikeport on 1080).
+Load cookies from file:
+Lae küpsised failist:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Lae küpsised eelnevalt Netscape cookies.txt failist enne kopeerimist.
+Pause between files:
+Paus failide vahel:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Juhuslik viivitus failide allalaadimiste vahel, sekundites. Juhusliku vahemiku jaoks kasuta MIN:MAX (nt 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Säilita www. eesliide (ära ühenda www.host ja host)
+Do not treat www.host and host as the same site.
+Ära käsitle www.host ja host sama saidina.
+Keep double slashes in URLs
+Säilita topeltkaldkriipsud URL-ides
+Do not collapse duplicate slashes in URLs.
+Ära ühenda korduvaid kaldkriipse URL-ides.
+Keep the original query-string order
+Säilita päringustringi algne järjekord
+Do not reorder query-string parameters when deduplicating URLs.
+Ära järjesta päringustringi parameetreid ümber URL-ide korduste eemaldamisel.
+Strip query keys:
+Eemalda päringuvõtmed:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Komadega eraldatud päringuvõtmed, mis jäetakse salvestatud faili nimest välja (nt sid,utm_source).

--- a/lang/English.txt
+++ b/lang/English.txt
@@ -976,3 +976,31 @@ Click on this notification to restart the interrupted mirror
 Click on this notification to restart the interrupted mirror
 HTTrack: could not save profile for '%s'!
 HTTrack: could not save profile for '%s'!
+Proxy type:
+Proxy type:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Load cookies from file:
+Load cookies from file:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Preload cookies from a Netscape cookies.txt file before crawling.
+Pause between files:
+Pause between files:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Keep the www. prefix (do not merge www.host with host)
+Do not treat www.host and host as the same site.
+Do not treat www.host and host as the same site.
+Keep double slashes in URLs
+Keep double slashes in URLs
+Do not collapse duplicate slashes in URLs.
+Do not collapse duplicate slashes in URLs.
+Keep the original query-string order
+Keep the original query-string order
+Do not reorder query-string parameters when deduplicating URLs.
+Do not reorder query-string parameters when deduplicating URLs.
+Strip query keys:
+Strip query keys:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).

--- a/lang/Finnish.txt
+++ b/lang/Finnish.txt
@@ -931,3 +931,31 @@ Palvelin lopetettu
 A fatal error has occurred during this mirror
 Tällä peilillä tapahtui vakava virhe
 
+Proxy type:
+Välityspalvelimen tyyppi:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Välityspalvelimen protokolla: HTTP tai SOCKS5 (SOCKS5:n oletusportti on 1080).
+Load cookies from file:
+Lataa evästeet tiedostosta:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Lataa evästeet Netscape cookies.txt -tiedostosta ennen sivuston läpikäyntiä.
+Pause between files:
+Tauko tiedostojen välillä:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Satunnainen viive tiedostolatausten välillä, sekunteina. Käytä muotoa MIN:MAX satunnaista väliä varten (esim. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Säilytä www.-etuliite (älä yhdistä www.host- ja host-osoitteita)
+Do not treat www.host and host as the same site.
+Älä käsittele www.host- ja host-osoitteita samana sivustona.
+Keep double slashes in URLs
+Säilytä kaksoiskenoviivat URL-osoitteissa
+Do not collapse duplicate slashes in URLs.
+Älä yhdistä toistuvia kenoviivoja URL-osoitteissa.
+Keep the original query-string order
+Säilytä kyselymerkkijonon alkuperäinen järjestys
+Do not reorder query-string parameters when deduplicating URLs.
+Älä järjestä kyselymerkkijonon parametreja uudelleen, kun URL-osoitteiden kaksoiskappaleet poistetaan.
+Strip query keys:
+Poista kyselyavaimet:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Pilkuin erotellut kyselyavaimet, jotka jätetään pois tallennettujen tiedostojen nimeämisestä (esim. sid,utm_source).

--- a/lang/Francais.txt
+++ b/lang/Francais.txt
@@ -976,3 +976,31 @@ Build a mail archive
 Construire une archive mail
 Default referer URL
 Champ referer par défaut
+Proxy type:
+Type de proxy :
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Protocole du proxy : HTTP ou SOCKS5 (le port SOCKS5 par défaut est 1080).
+Load cookies from file:
+Charger les cookies depuis un fichier :
+Preload cookies from a Netscape cookies.txt file before crawling.
+Précharger les cookies depuis un fichier Netscape cookies.txt avant la copie du site.
+Pause between files:
+Pause entre les fichiers :
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Délai aléatoire entre les téléchargements de fichiers, en secondes. Utilisez MIN:MAX pour une plage aléatoire (par ex. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Conserver le préfixe www. (ne pas fusionner www.host avec host)
+Do not treat www.host and host as the same site.
+Ne pas traiter www.host et host comme le même site.
+Keep double slashes in URLs
+Conserver les doubles barres obliques dans les URL
+Do not collapse duplicate slashes in URLs.
+Ne pas réduire les barres obliques en double dans les URL.
+Keep the original query-string order
+Conserver l'ordre d'origine de la query string
+Do not reorder query-string parameters when deduplicating URLs.
+Ne pas réordonner les paramètres de la query string lors de la déduplication des URL.
+Strip query keys:
+Supprimer les clés de query string :
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Clés de query string à retirer du nommage des fichiers enregistrés, séparées par des virgules (par ex. sid,utm_source).

--- a/lang/Greek.txt
+++ b/lang/Greek.txt
@@ -930,3 +930,31 @@ Server terminated
 Ακυρώθηκε από τον εξυπηρετητή
 A fatal error has occurred during this mirror
 Ένα καταστροφικό σφάλμα προκλήθηκε κατά την αντιγραφή αυτού του τόπου
+Proxy type:
+Τύπος proxy:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Πρωτόκολλο proxy: HTTP ή SOCKS5 (η προεπιλεγμένη θύρα του SOCKS5 είναι 1080).
+Load cookies from file:
+Φόρτωση cookies από αρχείο:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Προφόρτωση των cookies από ένα αρχείο Netscape cookies.txt πριν την ανίχνευση.
+Pause between files:
+Παύση μεταξύ αρχείων:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Τυχαία καθυστέρηση μεταξύ των λήψεων αρχείων, σε δευτερόλεπτα. Χρησιμοποιήστε MIN:MAX για τυχαίο εύρος (π.χ. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Διατήρηση του προθέματος www. (χωρίς συγχώνευση του www.host με το host)
+Do not treat www.host and host as the same site.
+Να μην θεωρούνται τα www.host και host ως ο ίδιος ιστότοπος.
+Keep double slashes in URLs
+Διατήρηση των διπλών καθέτων στα URL
+Do not collapse duplicate slashes in URLs.
+Να μην συμπτύσσονται οι διπλές κάθετοι στα URL.
+Keep the original query-string order
+Διατήρηση της αρχικής σειράς του ερωτήματος αναζήτησης
+Do not reorder query-string parameters when deduplicating URLs.
+Να μην αναδιατάσσονται οι παράμετροι του ερωτήματος αναζήτησης κατά την αφαίρεση διπλότυπων URL.
+Strip query keys:
+Αφαίρεση κλειδιών ερωτήματος:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Κλειδιά ερωτήματος χωρισμένα με κόμμα, που θα αφαιρεθούν από την ονομασία των αποθηκευμένων αρχείων (π.χ. sid,utm_source).

--- a/lang/Italiano.txt
+++ b/lang/Italiano.txt
@@ -928,3 +928,31 @@ Server terminated
 Server disconnesso
 A fatal error has occurred during this mirror
 Si è verificato un errore fatale durante la copia
+Proxy type:
+Tipo di proxy:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Protocollo del proxy: HTTP o SOCKS5 (la porta SOCKS5 predefinita è 1080).
+Load cookies from file:
+Carica i cookie da un file:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Precarica i cookie da un file Netscape cookies.txt prima della copia.
+Pause between files:
+Pausa tra i file:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Ritardo casuale tra i download dei file, in secondi. Usa MIN:MAX per un intervallo casuale (ad es. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Mantieni il prefisso www. (non unire www.host con host)
+Do not treat www.host and host as the same site.
+Non trattare www.host e host come lo stesso sito.
+Keep double slashes in URLs
+Mantieni le doppie barre negli URL
+Do not collapse duplicate slashes in URLs.
+Non ridurre le barre duplicate negli URL.
+Keep the original query-string order
+Mantieni l'ordine originale della query string
+Do not reorder query-string parameters when deduplicating URLs.
+Non riordinare i parametri della query string durante la deduplicazione degli URL.
+Strip query keys:
+Rimuovi chiavi della query string:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Chiavi della query string, separate da virgole, da rimuovere dai nomi dei file salvati (ad es. sid,utm_source).

--- a/lang/Japanese.txt
+++ b/lang/Japanese.txt
@@ -928,3 +928,31 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+Proxy type:
+プロキシの種類:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+プロキシのプロトコル: HTTP または SOCKS5 (SOCKS5 の既定ポートは 1080)。
+Load cookies from file:
+クッキーをファイルから読み込む:
+Preload cookies from a Netscape cookies.txt file before crawling.
+クロールを開始する前に Netscape の cookies.txt ファイルからクッキーを読み込みます。
+Pause between files:
+ファイル間の待機:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+ファイルのダウンロード間のランダムな遅延（秒）。範囲を指定するには MIN:MAX を使用します (例: 2:8)。
+Keep the www. prefix (do not merge www.host with host)
+www. プレフィックスを保持する (www.host と host を統合しない)
+Do not treat www.host and host as the same site.
+www.host と host を同じサイトとして扱いません。
+Keep double slashes in URLs
+URL 内の二重スラッシュを保持する
+Do not collapse duplicate slashes in URLs.
+URL 内の連続したスラッシュをまとめません。
+Keep the original query-string order
+クエリ文字列の元の順序を保持する
+Do not reorder query-string parameters when deduplicating URLs.
+URL の重複排除時にクエリ文字列のパラメータを並べ替えません。
+Strip query keys:
+削除するクエリキー:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+保存ファイル名の生成から除外するクエリキーをカンマ区切りで指定します (例: sid,utm_source)。

--- a/lang/Macedonian.txt
+++ b/lang/Macedonian.txt
@@ -928,3 +928,31 @@ Server terminated
 бх№тх№юђ х я№хъшэрђ
 A fatal error has occurred during this mirror
 Эрёђрэр єрђрыэр у№хјър я№ш ютюМ mirror
+Proxy type:
+Тип на прокси:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Протокол на прокси: HTTP или SOCKS5 (стандардната порта на SOCKS5 е 1080).
+Load cookies from file:
+Вчитај колачиња од датотека:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Однапред вчитај колачиња од датотека Netscape cookies.txt пред преземањето.
+Pause between files:
+Пауза меѓу датотеки:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Случајно доцнење меѓу преземањата на датотеки, во секунди. Користи MIN:MAX за случаен опсег (на пример 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Задржи го префиксот www. (не спојувај www.host со host)
+Do not treat www.host and host as the same site.
+Не третирај ги www.host и host како ист сајт.
+Keep double slashes in URLs
+Задржи ги двојните коси црти во URL
+Do not collapse duplicate slashes in URLs.
+Не отстранувај ги повторените коси црти во URL.
+Keep the original query-string order
+Задржи го изворниот редослед на параметрите во барањето
+Do not reorder query-string parameters when deduplicating URLs.
+Не менувај го редоследот на параметрите на барањето при отстранување дупликати URL.
+Strip query keys:
+Отстрани клучеви од барањето:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Клучеви од барањето, одделени со запирка, што се отстрануваат од името на зачуваната датотека (на пример sid,utm_source).

--- a/lang/Magyar.txt
+++ b/lang/Magyar.txt
@@ -928,3 +928,31 @@ Server terminated
 A kiszolgáló befejezte a kapcsolatot
 A fatal error has occurred during this mirror
 Végzetes hiba történt a tükrözés közben
+Proxy type:
+Proxy típusa:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Proxy protokoll: HTTP vagy SOCKS5 (a SOCKS5 alapértelmezett portja 1080).
+Load cookies from file:
+Sütik betöltése fájlból:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Sütik elõzetes betöltése egy Netscape cookies.txt fájlból a tükrözés elõtt.
+Pause between files:
+Szünet a fájlok között:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Véletlenszerû késleltetés a fájlletöltések között, másodpercben. Véletlen tartományhoz használja a MIN:MAX formát (pl. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+A www. elõtag megtartása (ne vonja össze a www.host és a host címet)
+Do not treat www.host and host as the same site.
+Ne kezelje a www.host és a host címet ugyanazon webhelyként.
+Keep double slashes in URLs
+Dupla perjelek megtartása az URL-ekben
+Do not collapse duplicate slashes in URLs.
+Ne vonja össze az ismétlõdõ perjeleket az URL-ekben.
+Keep the original query-string order
+Az eredeti lekérdezési szöveg sorrendjének megtartása
+Do not reorder query-string parameters when deduplicating URLs.
+Ne rendezze át a lekérdezési szöveg paramétereit az ismétlõdõ URL-ek kiszûrésekor.
+Strip query keys:
+Lekérdezési kulcsok eltávolítása:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Vesszõvel elválasztott lekérdezési kulcsok, amelyeket el kell hagyni a mentett fájl elnevezésébõl (pl. sid,utm_source).

--- a/lang/Nederlands.txt
+++ b/lang/Nederlands.txt
@@ -928,3 +928,31 @@ Server terminated
 Server beeindigd
 A fatal error has occurred during this mirror
 Een fatale fout is opgetreden tijdens deze spiegeling
+Proxy type:
+Proxytype:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Proxyprotocol: HTTP of SOCKS5 (standaardpoort van SOCKS5 is 1080).
+Load cookies from file:
+Cookies uit bestand laden:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Cookies vooraf laden uit een Netscape cookies.txt-bestand voordat het crawlen begint.
+Pause between files:
+Pauze tussen bestanden:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Willekeurige vertraging tussen bestandsdownloads, in seconden. Gebruik MIN:MAX voor een willekeurig bereik (bijv. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+www.-voorvoegsel behouden (www.host niet samenvoegen met host)
+Do not treat www.host and host as the same site.
+Behandel www.host en host niet als dezelfde site.
+Keep double slashes in URLs
+Dubbele schuine strepen in URL's behouden
+Do not collapse duplicate slashes in URLs.
+Dubbele schuine strepen in URL's niet samenvoegen.
+Keep the original query-string order
+Oorspronkelijke volgorde van de query string behouden
+Do not reorder query-string parameters when deduplicating URLs.
+Query string-parameters niet herordenen bij het ontdubbelen van URL's.
+Strip query keys:
+Query-sleutels verwijderen:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Door komma's gescheiden query-sleutels die bij het benoemen van opgeslagen bestanden worden weggelaten (bijv. sid,utm_source).

--- a/lang/Norsk.txt
+++ b/lang/Norsk.txt
@@ -928,3 +928,31 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+Proxy type:
+Proxytype:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Proxyprotokoll: HTTP eller SOCKS5 (SOCKS5 bruker som standard port 1080).
+Load cookies from file:
+Last inn cookies fra fil:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Last inn cookies fra en Netscape cookies.txt-fil før crawlingen starter.
+Pause between files:
+Pause mellom filer:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Tilfeldig forsinkelse mellom filnedlastinger, i sekunder. Bruk MIN:MAX for et tilfeldig intervall (f.eks. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Behold www.-prefikset (slå ikke sammen www.host med host)
+Do not treat www.host and host as the same site.
+Behandle ikke www.host og host som samme nettsted.
+Keep double slashes in URLs
+Behold doble skråstreker i URL-er
+Do not collapse duplicate slashes in URLs.
+Slå ikke sammen gjentatte skråstreker i URL-er.
+Keep the original query-string order
+Behold den opprinnelige rekkefølgen i spørrestrengen
+Do not reorder query-string parameters when deduplicating URLs.
+Endre ikke rekkefølgen på spørrestrengens parametere når dupliserte URL-er fjernes.
+Strip query keys:
+Fjern spørrenøkler:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Kommaseparerte spørrenøkler som utelates i navngivingen av lagrede filer (f.eks. sid,utm_source).

--- a/lang/Polski.txt
+++ b/lang/Polski.txt
@@ -928,3 +928,31 @@ Server terminated
 Serwer zakonczyl prace
 A fatal error has occurred during this mirror
 Podczas tworzenia lustra wydarzyl sie fatalny blad.
+Proxy type:
+Typ proxy:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Protokó³ proxy: HTTP lub SOCKS5 (domy¶lny port SOCKS5 to 1080).
+Load cookies from file:
+Wczytaj ciasteczka z pliku:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Wczytaj ciasteczka z pliku Netscape cookies.txt przed rozpoczêciem pobierania.
+Pause between files:
+Pauza miêdzy plikami:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Losowe opó¼nienie miêdzy pobieraniem plików, w sekundach. U¿yj MIN:MAX dla losowego zakresu (np. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Zachowaj przedrostek www. (nie ³±cz www.host z host)
+Do not treat www.host and host as the same site.
+Nie traktuj www.host i host jako tej samej witryny.
+Keep double slashes in URLs
+Zachowaj podwójne uko¶niki w adresach URL
+Do not collapse duplicate slashes in URLs.
+Nie scalaj powtórzonych uko¶ników w adresach URL.
+Keep the original query-string order
+Zachowaj oryginaln± kolejno¶æ ci±gu zapytania
+Do not reorder query-string parameters when deduplicating URLs.
+Nie zmieniaj kolejno¶ci parametrów zapytania podczas usuwania duplikatów adresów URL.
+Strip query keys:
+Usuñ klucze zapytania:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Rozdzielone przecinkami klucze zapytania pomijane przy nazywaniu zapisanych plików (np. sid,utm_source).

--- a/lang/Portugues-Brasil.txt
+++ b/lang/Portugues-Brasil.txt
@@ -976,3 +976,31 @@ Click on this notification to restart the interrupted mirror
 Clique nesta notificação para reiniciar o espelho interrompido
 HTTrack: could not save profile for '%s'!
 HTTrack: não foi possível salvar o perfil para '%s'!
+Proxy type:
+Tipo de proxy:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Protocolo do proxy: HTTP ou SOCKS5 (a porta SOCKS5 padrão é 1080).
+Load cookies from file:
+Carregar cookies de um arquivo:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Pré-carregar cookies de um arquivo Netscape cookies.txt antes de iniciar a cópia.
+Pause between files:
+Pausa entre arquivos:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Atraso aleatório entre downloads de arquivos, em segundos. Use MIN:MAX para um intervalo aleatório (ex.: 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Manter o prefixo www. (não mesclar www.host com host)
+Do not treat www.host and host as the same site.
+Não tratar www.host e host como o mesmo site.
+Keep double slashes in URLs
+Manter as barras duplas nas URLs
+Do not collapse duplicate slashes in URLs.
+Não reduzir as barras duplicadas nas URLs.
+Keep the original query-string order
+Manter a ordem original da query string
+Do not reorder query-string parameters when deduplicating URLs.
+Não reordenar os parâmetros da query string ao remover URLs duplicadas.
+Strip query keys:
+Remover chaves da query string:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Chaves da query string, separadas por vírgulas, a serem removidas da nomeação dos arquivos salvos (ex.: sid,utm_source).

--- a/lang/Portugues.txt
+++ b/lang/Portugues.txt
@@ -928,3 +928,31 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+Proxy type:
+Tipo de proxy:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Protocolo do proxy: HTTP ou SOCKS5 (a porta SOCKS5 predefinida é 1080).
+Load cookies from file:
+Carregar cookies de um ficheiro:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Pré-carregar cookies de um ficheiro Netscape cookies.txt antes de iniciar a cópia.
+Pause between files:
+Pausa entre ficheiros:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Atraso aleatório entre transferências de ficheiros, em segundos. Utilize MIN:MAX para um intervalo aleatório (por ex. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Manter o prefixo www. (não combinar www.host com host)
+Do not treat www.host and host as the same site.
+Não tratar www.host e host como o mesmo site.
+Keep double slashes in URLs
+Manter as barras duplas nos URL
+Do not collapse duplicate slashes in URLs.
+Não reduzir as barras duplicadas nos URL.
+Keep the original query-string order
+Manter a ordem original da query string
+Do not reorder query-string parameters when deduplicating URLs.
+Não reordenar os parâmetros da query string ao eliminar URL duplicados.
+Strip query keys:
+Remover chaves da query string:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Chaves da query string, separadas por vírgulas, a remover da nomeação dos ficheiros guardados (por ex. sid,utm_source).

--- a/lang/Romanian.txt
+++ b/lang/Romanian.txt
@@ -928,3 +928,31 @@ Server terminated
 Server terminat
 A fatal error has occurred during this mirror
 A survenit o eroare fatalã în timpul acestei clonãri.
+Proxy type:
+Tip proxy:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Protocol proxy: HTTP sau SOCKS5 (portul SOCKS5 implicit este 1080).
+Load cookies from file:
+Încarca cookies dintr-un fisier:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Preîncarca cookies dintr-un fisier Netscape cookies.txt înainte de copiere.
+Pause between files:
+Pauza între fisiere:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Întârziere aleatoare între descarcari de fisiere, în secunde. Folositi MIN:MAX pentru un interval aleatoriu (de ex. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Pastreaza prefixul www. (nu combina www.host cu host)
+Do not treat www.host and host as the same site.
+Nu trata www.host si host ca fiind acelasi site.
+Keep double slashes in URLs
+Pastreaza barele duble din URL-uri
+Do not collapse duplicate slashes in URLs.
+Nu comprima barele duplicate din URL-uri.
+Keep the original query-string order
+Pastreaza ordinea originala din query string
+Do not reorder query-string parameters when deduplicating URLs.
+Nu reordona parametrii din query string la eliminarea URL-urilor duplicate.
+Strip query keys:
+Elimina cheile din query string:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Chei din query string, separate prin virgula, de eliminat din denumirea fisierelor salvate (de ex. sid,utm_source).

--- a/lang/Russian.txt
+++ b/lang/Russian.txt
@@ -928,3 +928,31 @@ Server terminated
 Server terminated
 A fatal error has occurred during this mirror
 Во время текущей закачки произошла фатальная ошибка
+Proxy type:
+Тип прокси:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Протокол прокси: HTTP или SOCKS5 (по умолчанию SOCKS5 использует порт 1080).
+Load cookies from file:
+Загрузить cookies из файла:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Предварительно загрузить cookies из файла Netscape cookies.txt перед закачкой.
+Pause between files:
+Пауза между файлами:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Случайная задержка между закачками файлов, в секундах. Используйте MIN:MAX для случайного диапазона (например, 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Сохранять префикс www. (не объединять www.host с host)
+Do not treat www.host and host as the same site.
+Не считать www.host и host одним и тем же сайтом.
+Keep double slashes in URLs
+Сохранять двойные слэши в URL
+Do not collapse duplicate slashes in URLs.
+Не удалять повторяющиеся слэши в URL.
+Keep the original query-string order
+Сохранять исходный порядок параметров запроса
+Do not reorder query-string parameters when deduplicating URLs.
+Не менять порядок параметров строки запроса при удалении дубликатов URL.
+Strip query keys:
+Удалять ключи запроса:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Ключи запроса через запятую, удаляемые из имени сохраняемого файла (например, sid,utm_source).

--- a/lang/Slovak.txt
+++ b/lang/Slovak.txt
@@ -928,3 +928,31 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+Proxy type:
+Typ proxy:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Protokol proxy: HTTP alebo SOCKS5 (predvolený port SOCKS5 je 1080).
+Load cookies from file:
+Naèíta» cookies zo súboru:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Naèíta» cookies zo súboru Netscape cookies.txt pred zaèatím s»ahovania.
+Pause between files:
+Prestávka medzi súbormi:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Náhodné oneskorenie medzi s»ahovaním súborov, v sekundách. Pre náhodný rozsah pou¾ite MIN:MAX (napr. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Zachova» predponu www. (nezluèova» www.host s host)
+Do not treat www.host and host as the same site.
+Nepova¾ova» www.host a host za tú istú lokalitu.
+Keep double slashes in URLs
+Zachova» dvojité lomky v URL
+Do not collapse duplicate slashes in URLs.
+Nezluèova» opakované lomky v URL.
+Keep the original query-string order
+Zachova» pôvodné poradie re»azca dotazu
+Do not reorder query-string parameters when deduplicating URLs.
+Nemeni» poradie parametrov re»azca dotazu pri odstraòovaní duplicitných URL.
+Strip query keys:
+Odstráni» kµúèe dotazu:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Kµúèe dotazu oddelené èiarkami, ktoré sa vynechajú z pomenovania ukladaných súborov (napr. sid,utm_source).

--- a/lang/Slovenian.txt
+++ b/lang/Slovenian.txt
@@ -928,3 +928,31 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+Proxy type:
+Vrsta proxyja:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Protokol proxy: HTTP ali SOCKS5 (privzeta vrata SOCKS5 so 1080).
+Load cookies from file:
+Nalozi piskotke iz datoteke:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Predhodno nalozi piskotke iz datoteke Netscape cookies.txt pred zajemanjem.
+Pause between files:
+Premor med datotekami:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Nakljucni zamik med prenosi datotek, v sekundah. Za nakljucni obseg uporabite MIN:MAX (npr. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Ohrani predpono www. (ne zdruzi www.host z host)
+Do not treat www.host and host as the same site.
+www.host in host ne obravnavaj kot isto spletno mesto.
+Keep double slashes in URLs
+Ohrani dvojne posevnice v URL-jih
+Do not collapse duplicate slashes in URLs.
+Ne zdruzuj podvojenih posevnic v URL-jih.
+Keep the original query-string order
+Ohrani izvirni vrstni red poizvedovalnega niza
+Do not reorder query-string parameters when deduplicating URLs.
+Pri odstranjevanju podvojenih URL-jev ne spreminjaj vrstnega reda parametrov poizvedbe.
+Strip query keys:
+Odstrani kljuce poizvedbe:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Z vejicami loceni kljuci poizvedbe, ki se izpustijo pri poimenovanju shranjenih datotek (npr. sid,utm_source).

--- a/lang/Svenska.txt
+++ b/lang/Svenska.txt
@@ -928,3 +928,31 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+Proxy type:
+Proxytyp:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Proxyprotokoll: HTTP eller SOCKS5 (SOCKS5 använder som standard port 1080).
+Load cookies from file:
+Läs in cookies från fil:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Läs in cookies från en Netscape cookies.txt-fil innan crawlningen börjar.
+Pause between files:
+Paus mellan filer:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Slumpmässig fördröjning mellan filnedladdningar, i sekunder. Använd MIN:MAX för ett slumpmässigt intervall (t.ex. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Behåll www.-prefixet (slå inte ihop www.host med host)
+Do not treat www.host and host as the same site.
+Behandla inte www.host och host som samma webbplats.
+Keep double slashes in URLs
+Behåll dubbla snedstreck i URL:er
+Do not collapse duplicate slashes in URLs.
+Slå inte ihop upprepade snedstreck i URL:er.
+Keep the original query-string order
+Behåll frågesträngens ursprungliga ordning
+Do not reorder query-string parameters when deduplicating URLs.
+Ändra inte ordningen på frågesträngens parametrar när dubbletter av URL:er tas bort.
+Strip query keys:
+Ta bort frågenycklar:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Kommaseparerade frågenycklar som utelämnas vid namngivningen av sparade filer (t.ex. sid,utm_source).

--- a/lang/Turkish.txt
+++ b/lang/Turkish.txt
@@ -928,3 +928,31 @@ Server terminated
 Sunucu sonlandýrdý
 A fatal error has occurred during this mirror
 Bu yansýlama iþlemi sýrasýnda ölümcül bir hata oluþtu
+Proxy type:
+Proxy türü:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Proxy protokolü: HTTP veya SOCKS5 (SOCKS5 varsayýlan portu 1080).
+Load cookies from file:
+Çerezleri dosyadan yükle:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Taramadan önce bir Netscape cookies.txt dosyasýndan çerezleri önceden yükle.
+Pause between files:
+Dosyalar arasýnda bekleme:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Dosya indirmeleri arasýnda saniye cinsinden rastgele gecikme. Rastgele bir aralýk için MIN:MAX kullanýn (örn. 2:8).
+Keep the www. prefix (do not merge www.host with host)
+www. önekini koru (www.host ile host'u birleþtirme)
+Do not treat www.host and host as the same site.
+www.host ve host'u ayný site olarak deðerlendirme.
+Keep double slashes in URLs
+URL'lerdeki çift eðik çizgileri koru
+Do not collapse duplicate slashes in URLs.
+URL'lerdeki yinelenen eðik çizgileri birleþtirme.
+Keep the original query-string order
+Özgün sorgu dizesi sýrasýný koru
+Do not reorder query-string parameters when deduplicating URLs.
+URL'lerin yinelenenlerini ayýklarken sorgu dizesi parametrelerini yeniden sýralama.
+Strip query keys:
+Sorgu anahtarlarýný çýkar:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Kaydedilen dosya adlandýrmasýndan çýkarýlacak, virgülle ayrýlmýþ sorgu anahtarlarý (örn. sid,utm_source).

--- a/lang/Ukrainian.txt
+++ b/lang/Ukrainian.txt
@@ -928,3 +928,31 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+Proxy type:
+Тип проксі:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Протокол проксі: HTTP або SOCKS5 (за замовчуванням SOCKS5 використовує порт 1080).
+Load cookies from file:
+Завантажити cookies з файлу:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Попередньо завантажити cookies з файлу Netscape cookies.txt перед завантаженням.
+Pause between files:
+Пауза між файлами:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Випадкова затримка між завантаженнями файлів, у секундах. Використовуйте MIN:MAX для випадкового діапазону (наприклад, 2:8).
+Keep the www. prefix (do not merge www.host with host)
+Зберігати префікс www. (не об'єднувати www.host з host)
+Do not treat www.host and host as the same site.
+Не вважати www.host і host одним і тим самим сайтом.
+Keep double slashes in URLs
+Зберігати подвійні слеші в URL
+Do not collapse duplicate slashes in URLs.
+Не видаляти повторювані слеші в URL.
+Keep the original query-string order
+Зберігати початковий порядок параметрів запиту
+Do not reorder query-string parameters when deduplicating URLs.
+Не змінювати порядок параметрів рядка запиту під час усунення дублікатів URL.
+Strip query keys:
+Вилучати ключі запиту:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Ключі запиту через кому, які вилучаються з імені збереженого файлу (наприклад, sid,utm_source).

--- a/lang/Uzbek.txt
+++ b/lang/Uzbek.txt
@@ -928,3 +928,31 @@ Server terminated
 Server terminated
 A fatal error has occurred during this mirror
 Joriy ko’chirish vaqtida jiddiy xatolik yuz berdi
+Proxy type:
+Proksi turi:
+Proxy protocol: HTTP, or SOCKS5 (SOCKS5 default port is 1080).
+Proksi protokoli: HTTP yoki SOCKS5 (SOCKS5 ning standart porti 1080).
+Load cookies from file:
+Fayldan cookies yuklamoq:
+Preload cookies from a Netscape cookies.txt file before crawling.
+Ko’chirib olishdan oldin Netscape cookies.txt faylidan cookies’ni oldindan yuklamoq.
+Pause between files:
+Fayllar orasidagi pauza:
+Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
+Fayllarni ko’chirib olish orasidagi tasodifiy kechikish, soniyalarda. Tasodifiy diapazon uchun MIN:MAX dan foydalaning (masalan, 2:8).
+Keep the www. prefix (do not merge www.host with host)
+www. prefiksini saqlash (www.host ni host bilan birlashtirmaslik)
+Do not treat www.host and host as the same site.
+www.host va host ni bir xil sayt deb hisoblamaslik.
+Keep double slashes in URLs
+URL lardagi qo’sh sleshlarni saqlash
+Do not collapse duplicate slashes in URLs.
+URL lardagi takroriy sleshlarni olib tashlamaslik.
+Keep the original query-string order
+So’rov satrining asl tartibini saqlash
+Do not reorder query-string parameters when deduplicating URLs.
+URL dublikatlarini olib tashlashda so’rov satri parametrlari tartibini o’zgartirmaslik.
+Strip query keys:
+Olib tashlanadigan so’rov kalitlari:
+Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Saqlangan fayl nomidan olib tashlanadigan, vergul bilan ajratilgan so’rov kalitlari (masalan, sid,utm_source).


### PR DESCRIPTION
The GUI's 3.49-options work references 14 new LANG_ keys whose string values live in the engine tree. This adds them (proxy type, cookies-file, pause-between-files, the three URL-hack opt-outs keep-www / keep-double-slashes / keep-query-order, and strip-query, each with a tooltip) to lang.def and English.txt, and translates them across all 30 language files.

The change only appends. No existing entry is touched, and any key a translator has not filled still falls back to English through the two-pass loader. Each file keeps its own on-disk encoding (windows-1251 / ISO-8859-5 for Cyrillic, shift-jis / gb2312 / cp950 for CJK, ISO-8859-x for the rest), and every new string was checked to round-trip in it. Two files carry a mislabeled LANGUAGE_CHARSET header, so their new lines match the actual bytes rather than the header: Svenska stores Latin-1 (å is 0xE5, absent from Latin-2), and Uzbek is Latin-script and LF-terminated where the others are CRLF.

Translations are best-effort. Charset-limited files (Romanian, Slovenian under ISO-8859-1) drop unavailable diacritics to base letters, matching how those files already approximate.