### PR TITLE
CodeQL: stop scanning libtest demos and ProxyTrack

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,6 +46,12 @@ jobs:
           # fopen's umask-controlled 0666 is intended for mirror/cache/log
           # output; the one credential file (cookies.txt) is kept 0600 on Unix.
           config: |
+            paths-ignore:
+              # Demo callback samples, not part of libhttrack.
+              - libtest
+              # ProxyTrack: a separate legacy binary with no auth surface; its
+              # recv/cache-parse code trips taint queries by design.
+              - src/proxy
             query-filters:
               - exclude:
                   id: cpp/world-writable-file-creation


### PR DESCRIPTION
The code-scanning dashboard carries a large backlog dominated by two areas that aren't the engine: `libtest/` demo callbacks (not part of libhttrack) and `src/proxy/` (ProxyTrack, a separate legacy binary with no authentication surface, whose `recv` and cache-parse code the taint queries flag by design). About 26 of the open alerts live there and are false-positive or by-design.

This adds a `paths-ignore` for both to the inline CodeQL config so the dashboard tracks the engine, where the queries are worth acting on. Genuine bugs found in that code get fixed on their own, independent of scanning.