### PR TITLE
Cap the chunked-transfer buffer at 2GB before realloc

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -3310,16 +3310,29 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                         back[i].chunk_blocksize = -1;   /* ending */
                       back[i].r.totalsize += chunk_size;        // noter taille
                       if (back[i].r.adr != NULL || !back[i].r.is_write) {       // Not to disk
-                        back[i].r.adr =
-                          (char *) realloct(back[i].r.adr,
-                                            (size_t) back[i].r.totalsize + 1);
-                        if (!back[i].r.adr) {
-                          if (cache->log != NULL) {
-                            hts_log_print(opt, LOG_ERROR,
-                                          "not enough memory (" LLintP
-                                          ") for %s%s",
-                                          (LLint) back[i].r.totalsize,
-                                          back[i].url_adr, back[i].url_fil);
+                        // totalsize sums attacker-declared chunk sizes; cap the
+                        // in-RAM buffer at 2GB so the (size_t) cast can't
+                        // truncate on 32-bit and under-allocate.
+                        if (back[i].r.totalsize > INT32_MAX) {
+                          back[i].r.statuscode = STATUSCODE_INVALID;
+                          strcpybuff(back[i].r.msg,
+                                     "Chunked resource too large");
+                          back[i].status = STATUS_READY;
+                          back_set_finished(sback, i);
+                          hts_log_print(opt, LOG_WARNING,
+                                        "Chunked resource too large for %s%s",
+                                        back[i].url_adr, back[i].url_fil);
+                        } else {
+                          back[i].r.adr = (char *) realloct(
+                              back[i].r.adr, (size_t) back[i].r.totalsize + 1);
+                          if (!back[i].r.adr) {
+                            if (cache->log != NULL) {
+                              hts_log_print(opt, LOG_ERROR,
+                                            "not enough memory (" LLintP
+                                            ") for %s%s",
+                                            (LLint) back[i].r.totalsize,
+                                            back[i].url_adr, back[i].url_fil);
+                            }
                           }
                         }
                       }

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -3310,18 +3310,15 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                         back[i].chunk_blocksize = -1;   /* ending */
                       back[i].r.totalsize += chunk_size;        // noter taille
                       if (back[i].r.adr != NULL || !back[i].r.is_write) {       // Not to disk
-                        // totalsize sums attacker-declared chunk sizes; cap the
-                        // in-RAM buffer at 2GB so the (size_t) cast can't
-                        // truncate on 32-bit and under-allocate.
+                        // totalsize sums attacker-declared chunk sizes; past
+                        // 2GB the (size_t) cast below truncates on 32-bit and
+                        // under-allocates. Mark the chunk invalid so the shared
+                        // error path tears the transfer down.
                         if (back[i].r.totalsize > INT32_MAX) {
-                          back[i].r.statuscode = STATUSCODE_INVALID;
-                          strcpybuff(back[i].r.msg,
-                                     "Chunked resource too large");
-                          back[i].status = STATUS_READY;
-                          back_set_finished(sback, i);
                           hts_log_print(opt, LOG_WARNING,
                                         "Chunked resource too large for %s%s",
                                         back[i].url_adr, back[i].url_fil);
+                          chunk_size = -1;
                         } else {
                           back[i].r.adr = (char *) realloct(
                               back[i].r.adr, (size_t) back[i].r.totalsize + 1);

--- a/tests/55_local-chunked.test
+++ b/tests/55_local-chunked.test
@@ -1,7 +1,8 @@
 #!/bin/bash
 # A well-formed Transfer-Encoding: chunked response mirrors intact: the chunk
 # automaton (htsback.c) joins the bodies and the 2GB in-RAM cap stays quiet.
-# '^40$' would be a leftover 64-byte chunk-size line if decoding didn't happen.
+# The 76-char run spans a 64-byte chunk boundary (only contiguous once joined);
+# a CR anywhere would be leftover framing; '</body>' proves no truncation.
 
 set -euo pipefail
 
@@ -9,7 +10,9 @@ set -euo pipefail
 
 bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
     --found 'chunked/page.html' \
-    --file-matches 'chunked/page.html' 'chunk-body chunk-body' \
-    --file-not-matches 'chunked/page.html' '^40$' \
+    --file-matches 'chunked/page.html' \
+    'chunk-body chunk-body chunk-body chunk-body chunk-body chunk-body chunk-body' \
+    --file-matches 'chunked/page.html' '</body>' \
+    --file-not-matches 'chunked/page.html' $'\r' \
     --log-not-found 'too large' \
     httrack 'BASEURL/chunked/index.html'

--- a/tests/55_local-chunked.test
+++ b/tests/55_local-chunked.test
@@ -1,0 +1,15 @@
+#!/bin/bash
+# A well-formed Transfer-Encoding: chunked response mirrors intact: the chunk
+# automaton (htsback.c) joins the bodies and the 2GB in-RAM cap stays quiet.
+# '^40$' would be a leftover 64-byte chunk-size line if decoding didn't happen.
+
+set -euo pipefail
+
+: "${top_srcdir:=..}"
+
+bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
+    --found 'chunked/page.html' \
+    --file-matches 'chunked/page.html' 'chunk-body chunk-body' \
+    --file-not-matches 'chunked/page.html' '^40$' \
+    --log-not-found 'too large' \
+    httrack 'BASEURL/chunked/index.html'

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -131,6 +131,7 @@ TESTS = \
 	51_local-update-codec.test \
 	52_local-socks5.test \
 	53_local-proxytrack-cache-corrupt.test \
-	54_local-update-truncate-purge.test
+	54_local-update-truncate-purge.test \
+	55_local-chunked.test
 
 CLEANFILES = check-network_sh.cache

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1215,6 +1215,28 @@ class Handler(SimpleHTTPRequestHandler):
         if self.command != "HEAD":
             self.wfile.write(body)
 
+    def route_chunked_index(self):
+        self.send_html('\t<a href="page.html">chunked</a>\n')
+
+    def route_chunked_page(self):
+        # Transfer-Encoding: chunked over many small chunks: drives the engine's
+        # chunk automaton (htsback.c). The mirrored file must equal the joined
+        # chunk bodies, so the 2GB in-RAM cap doesn't fire on ordinary traffic.
+        blob = big_html("chunked", "<p>" + "chunk-body " * 300 + "</p>")
+        self.protocol_version = "HTTP/1.1"
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Transfer-Encoding", "chunked")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        if self.command == "HEAD":
+            return
+        step = 64
+        for off in range(0, len(blob), step):
+            piece = blob[off : off + step]
+            self.wfile.write(b"%X\r\n" % len(piece) + piece + b"\r\n")
+        self.wfile.write(b"0\r\n\r\n")
+
     # Content-Disposition naming: the attachment filename replaces the
     # URL-derived name; path components in it are stripped (RFC 2616).
     CDISPO_NAMES = {
@@ -1554,6 +1576,8 @@ class Handler(SimpleHTTPRequestHandler):
         "/crange206mem/blob.bin": route_crange206mem,
         "/size/index.html": route_size_index,
         "/size/oversize.bin": route_size_oversize,
+        "/chunked/index.html": route_chunked_index,
+        "/chunked/page.html": route_chunked_page,
         "/errpage/index.html": route_errpage_index,
         "/errpage/good.html": route_errpage_good,
         "/errpage/missing.html": route_errpage_missing,


### PR DESCRIPTION
The chunked-transfer automaton in `htsback.c` reallocs the in-memory buffer to fit each declared chunk before its body arrives, and `back[i].r.totalsize` (a 64-bit accumulator of the attacker-declared chunk sizes) had no upper bound. Once it passes 2GB, the value cast to a 32-bit `size_t` truncates and under-allocates the buffer, so the next chunk's data overflows the heap. The sibling in-memory Content-Length path already caps at `INT32_MAX`; this applies the same bound and aborts the transfer (refetchable) when it trips.

Reaching the threshold needs a peer streaming gigabytes, so a runtime test can't get there. The added test pins the non-regression side: a normal chunked response mirrors intact and the cap stays quiet. The abort path was checked by hand with a lowered cap. Surfaced by the CodeQL uncontrolled-allocation-size query.