### PR TITLE
webhttrack: show option tooltips as native title attributes

### DIFF
--- a/html/server/about.html
+++ b/html/server/about.html
@@ -69,7 +69,7 @@ ${LANG_K3} : ${HTTRACK_WEB}
 
 <form>
 <input type="button" value="OK" onClick="window.close();"
-			onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPOK}' onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </form>
 

--- a/html/server/addurl.html
+++ b/html/server/addurl.html
@@ -73,7 +73,7 @@ function info(str) {
 	<td id="subTitle" align="right">
 		<a href="/server/file.html" target="_blank"
 			onClick="window.open('/server/file.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_O1}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_O1}' onMouseOver="info('${html:LANG_O1}'); return true" onMouseOut="info('&nbsp;'); return true"
 			style="color:#FFFFFF"
 		>
 		${LANG_O1}
@@ -85,7 +85,7 @@ ${do:if-file-exists:html/index.html}
 	<td id="subTitle" align="right">
 		<a href="/index.html" target="_blank"
 			onClick="window.open('/server/help.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 			style="color:#FFFFFF"
 		>
 		${LANG_O5}
@@ -118,20 +118,20 @@ ${do:end-if}
 <form action="${thisfile}" name="form">
 <table width="100%">
 <tr><td>${LANG_T2}</td><td>http://<input name="urladr"
-			onMouseOver="info('${html:LANG_T10}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_T10}' onMouseOver="info('${html:LANG_T10}'); return true" onMouseOut="info('&nbsp;'); return true"
 ></td></tr>
 <tr><td colspan=2>
 
 <table width="100%">
 <th>${LANG_T4}</th>
 <tr><td>${LANG_T5}:</td><td><input name="urllogin"
-			onMouseOver="info('${html:LANG_T12}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_T12}' onMouseOver="info('${html:LANG_T12}'); return true" onMouseOut="info('&nbsp;'); return true"
 ></td></tr>
 <tr><td>${LANG_T6}:</td><td><input name="urlpass"
-			onMouseOver="info('${html:LANG_T13}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_T13}' onMouseOver="info('${html:LANG_T13}'); return true" onMouseOut="info('&nbsp;'); return true"
 ></td></tr>
 <tr><td>${LANG_T7}:</td><td><input type="button" value="${LANG_T8}" onClick="alert('not yet implemented!')"
-			onMouseOver="info('${html:LANG_T14}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_T14}' onMouseOver="info('${html:LANG_T14}'); return true" onMouseOut="info('&nbsp;'); return true"
 ></td></tr>
 </table>
 
@@ -139,7 +139,7 @@ ${do:end-if}
 
 <tr><td>
 <input type="button" value="OK" onClick="if (do_add()) { window.close(); }"
-			onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPOK}' onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 

--- a/html/server/finished.html
+++ b/html/server/finished.html
@@ -36,7 +36,7 @@ function info(str) {
 	<td id="subTitle" align="right">
 		<a href="/server/file.html" target="_blank"
 			onClick="window.open('/server/file.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_O1}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_O1}' onMouseOver="info('${html:LANG_O1}'); return true" onMouseOut="info('&nbsp;'); return true"
 			style="color:#FFFFFF"
 		>
 		${LANG_O1}
@@ -48,7 +48,7 @@ ${do:if-file-exists:html/index.html}
 	<td id="subTitle" align="right">
 		<a href="/index.html" target="_blank"
 			onClick="window.open('/server/help.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 			style="color:#FFFFFF"
 		>
 		${LANG_O5}

--- a/html/server/help.html
+++ b/html/server/help.html
@@ -58,7 +58,7 @@ function info(str) {
 <table class="tableWidth" border="0" width="100%" cellspacing="0">
 <tr><td class="tabCtrl" align="left">
 <a style="background:black;color: white" href="about.html" target="_new"
-			onMouseOver="info('${html:LANG_G21}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_G21}' onMouseOver="info('${html:LANG_G21}'); return true" onMouseOut="info('&nbsp;'); return true"
 			>
 ${LANG_O16}...
 </a>
@@ -67,7 +67,7 @@ ${LANG_O16}...
 <tr><td class="tabCtrl" align="left">
 <a style="background:black;color: white" 
    href="http://www.httrack.com/update.php3?Product=HTTrack&Version=${HTTRACK_VERSIONID}&VersionStr=${HTTRACK_VERSION}&Platform=${HTS_PLATFORM}&LanguageId=${lang}" target="_new"
-			onMouseOver="info('${html:LANG_O17}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_O17}' onMouseOver="info('${html:LANG_O17}'); return true" onMouseOut="info('&nbsp;'); return true"
    >
 ${LANG_O17}...
 </a>
@@ -78,7 +78,7 @@ ${do:if-file-exists:html/index.html}
 <tr><td class="tabCtrl" align="left">
 <a style="background:black;color: white" 
    href="/index.html" target="_new"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
    >
 ${LANG_P16}
 </a>

--- a/html/server/index.html
+++ b/html/server/index.html
@@ -43,7 +43,7 @@ function info(str) {
 	<td id="subTitle" align="right">
 		<a href="/server/file.html" target="_blank"
 			onClick="window.open('/server/file.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_O1}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_O1}' onMouseOver="info('${html:LANG_O1}'); return true" onMouseOut="info('&nbsp;'); return true"
 			style="color:#FFFFFF"
 		>
 		${LANG_O1}
@@ -55,7 +55,7 @@ ${do:if-file-exists:html/index.html}
 	<td id="subTitle" align="right">
 		<a href="/index.html" target="_blank"
 			onClick="window.open('/server/help.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 			style="color:#FFFFFF"
 		>
 		${LANG_O5}
@@ -113,7 +113,7 @@ ${LANG_THANKYOU}!
 
 	<tr><td align="right">
 		<input name="nextBtn" type="submit" value=" ${LANG_NEXT} >> "
-			onMouseOver="info('${html:LANG_TIPNEXT}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPNEXT}' onMouseOver="info('${html:LANG_TIPNEXT}'); return true" onMouseOut="info('&nbsp;'); return true"
 		>
 	</td></tr>
 </table>

--- a/html/server/option1.html
+++ b/html/server/option1.html
@@ -60,7 +60,7 @@ ${do:if-file-exists:html/index.html}
 <td>
 	<a href="/step9_opt1.html" target="_blank"
 		onClick="window.open('/step9_opt1.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>${LANG_TIPHELP}</a>
 </td>
 ${do:end-if}
@@ -71,18 +71,18 @@ ${do:end-if}
 <table class="tableWidth" border="0" width="100%" cellspacing="0">
 <tr>
 
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT1}' onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT2}' onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT3}' onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT4}' onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT5}' onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT11}' onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
 </tr><tr>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT6}' onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT7}' onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT8}' onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT9}' onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT10}' onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
 <td class="tabCtrl" align="center">&nbsp;</td>
 
 </tr>
@@ -107,16 +107,16 @@ ${do:end-if}
 <!-- checkboxes -->
 <table border="0" width="100%" cellspacing="0">
 <tr><td><input type="checkbox" name="parseall"  ${checked:parseall} 
-			onMouseOver="info('${html:LANG_I1}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I1}' onMouseOver="info('${html:LANG_I1}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I31}</td></tr>
 <tr><td><input type="checkbox" name="link"      ${checked:link}     
-			onMouseOver="info('${html:LANG_I2}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I2}' onMouseOver="info('${html:LANG_I2}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I32}</td></tr>
 <tr><td><input type="checkbox" name="testall"   ${checked:testall}  
-			onMouseOver="info('${html:LANG_I2b}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I2b}' onMouseOver="info('${html:LANG_I2b}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I32b}</td></tr>
 <tr><td><input type="checkbox" name="htmlfirst" ${checked:htmlfirst}
-			onMouseOver="info('${html:LANG_I2c}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I2c}' onMouseOver="info('${html:LANG_I2c}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I32c}</td></tr>
 </table>
 
@@ -125,12 +125,12 @@ ${do:end-if}
 	<tr><td align="left">
 	<input type="submit" value="${LANG_OK}"
 				onClick="form.closeme.value=1; form.submit(); return false;"
-				onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPOK}' onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td><td align="right">
 	<input type="button" value="${LANG_CANCEL}"
 				onClick="window.close();"
-				onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPCANCEL}' onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td></tr>
 	</table>

--- a/html/server/option10.html
+++ b/html/server/option10.html
@@ -60,7 +60,7 @@ ${do:if-file-exists:html/index.html}
 <td>
 	<a href="/step9_opt7.html" target="_blank"
 		onClick="window.open('/step9_opt7.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>${LANG_TIPHELP}</a>
 </td>
 ${do:end-if}
@@ -71,18 +71,18 @@ ${do:end-if}
 <table class="tableWidth" border="0" width="100%" cellspacing="0">
 <tr>
 
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT1}' onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT2}' onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT3}' onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT4}' onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT5}' onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT11}' onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
 </tr><tr>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT6}' onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT7}' onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT8}' onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT9}' onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT10}' onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
 <td class="tabCtrl" align="center">&nbsp;</td>
 
 </tr>
@@ -100,7 +100,7 @@ ${do:end-if}
 
 ${LANG_PROXYTYPE}
 <select name="proxytype"
-			onMouseOver="info('${html:LANG_PROXYTYPETIP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_PROXYTYPETIP}' onMouseOver="info('${html:LANG_PROXYTYPETIP}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 <option value=""${ztest:proxytype: selected:}>HTTP</option>
 <option value="1"${test:proxytype:: selected}>SOCKS5</option>
@@ -109,15 +109,15 @@ ${LANG_PROXYTYPE}
 
 ${LANG_IOPT10}:
 <input name="prox" value="${prox}" size="32"
-			onMouseOver="info('${html:LANG_G14}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_G14}' onMouseOver="info('${html:LANG_G14}'); return true" onMouseOut="info('&nbsp;'); return true"
 >:
 <input name="portprox" value="${portprox}" size="4"
-			onMouseOver="info('${html:LANG_G15}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_G15}' onMouseOver="info('${html:LANG_G15}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 <br>
 
 <input type="checkbox" name="ftpprox" ${checked:ftpprox}
-			onMouseOver="info('${html:LANG_G15c}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_G15c}' onMouseOver="info('${html:LANG_G15c}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I47c}
 <br><br>
 
@@ -126,12 +126,12 @@ ${LANG_IOPT10}:
 	<tr><td align="left">
 	<input type="submit" value="${LANG_OK}"
 				onClick="form.closeme.value=1; form.submit(); return false;"
-				onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPOK}' onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td><td align="right">
 	<input type="button" value="${LANG_CANCEL}"
 				onClick="window.close();"
-				onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPCANCEL}' onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td></tr>
 	</table>

--- a/html/server/option11.html
+++ b/html/server/option11.html
@@ -60,7 +60,7 @@ ${do:if-file-exists:html/index.html}
 <td>
 	<a href="/step9_opt9.html" target="_blank"
 		onClick="window.open('/step9_opt9.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>${LANG_TIPHELP}</a>
 </td>
 ${do:end-if}
@@ -71,18 +71,18 @@ ${do:end-if}
 <table class="tableWidth" border="0" width="100%" cellspacing="0">
 <tr>
 
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT1}' onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT2}' onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT3}' onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT4}' onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT5}' onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT11}' onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
 </tr><tr>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT6}' onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT7}' onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT8}' onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT9}' onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT10}' onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
 <td class="tabCtrl" align="center">&nbsp;</td>
 
 </tr>
@@ -112,97 +112,97 @@ ${LANG_W3}
 
 <td align="left">
 <input name="ext1" value="${ext1}"
-			onMouseOver="info('${html:LANG_W4}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_W4}' onMouseOver="info('${html:LANG_W4}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td><td align="left">
 &#x21d4;
 </td><td align="left">
 <input name="mime1" value="${mime1}"
-			onMouseOver="info('${html:LANG_W5}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_W5}' onMouseOver="info('${html:LANG_W5}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 <!-- -->
 <td align="left">
 <input name="ext2" value="${ext2}"
-			onMouseOver="info('${html:LANG_W4}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_W4}' onMouseOver="info('${html:LANG_W4}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td><td align="left">
 &#x21d4;
 </td><td align="left">
 <input name="mime2" value="${mime2}"
-			onMouseOver="info('${html:LANG_W5}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_W5}' onMouseOver="info('${html:LANG_W5}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 <!-- -->
 <td align="left">
 <input name="ext3" value="${ext3}"
-			onMouseOver="info('${html:LANG_W4}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_W4}' onMouseOver="info('${html:LANG_W4}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td><td align="left">
 &#x21d4;
 </td><td align="left">
 <input name="mime3" value="${mime3}"
-			onMouseOver="info('${html:LANG_W5}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_W5}' onMouseOver="info('${html:LANG_W5}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 <!-- -->
 <td align="left">
 <input name="ext4" value="${ext4}"
-			onMouseOver="info('${html:LANG_W4}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_W4}' onMouseOver="info('${html:LANG_W4}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td><td align="left">
 &#x21d4;
 </td><td align="left">
 <input name="mime4" value="${mime4}"
-			onMouseOver="info('${html:LANG_W5}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_W5}' onMouseOver="info('${html:LANG_W5}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 <!-- -->
 <td align="left">
 <input name="ext5" value="${ext5}"
-			onMouseOver="info('${html:LANG_W4}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_W4}' onMouseOver="info('${html:LANG_W4}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td><td align="left">
 &#x21d4;
 </td><td align="left">
 <input name="mime5" value="${mime5}"
-			onMouseOver="info('${html:LANG_W5}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_W5}' onMouseOver="info('${html:LANG_W5}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 <!-- -->
 <td align="left">
 <input name="ext6" value="${ext6}"
-			onMouseOver="info('${html:LANG_W4}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_W4}' onMouseOver="info('${html:LANG_W4}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td><td align="left">
 &#x21d4;
 </td><td align="left">
 <input name="mime6" value="${mime6}"
-			onMouseOver="info('${html:LANG_W5}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_W5}' onMouseOver="info('${html:LANG_W5}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 <!-- -->
 <td align="left">
 <input name="ext7" value="${ext7}"
-			onMouseOver="info('${html:LANG_W4}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_W4}' onMouseOver="info('${html:LANG_W4}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td><td align="left">
 &#x21d4;
 </td><td align="left">
 <input name="mime7" value="${mime7}"
-			onMouseOver="info('${html:LANG_W5}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_W5}' onMouseOver="info('${html:LANG_W5}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 <!-- -->
 <td align="left">
 <input name="ext8" value="${ext8}"
-			onMouseOver="info('${html:LANG_W4}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_W4}' onMouseOver="info('${html:LANG_W4}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td><td align="left">
 &#x21d4;
 </td><td align="left">
 <input name="mime8" value="${mime8}"
-			onMouseOver="info('${html:LANG_W5}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_W5}' onMouseOver="info('${html:LANG_W5}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 <!-- -->
@@ -217,12 +217,12 @@ ${LANG_W3}
 	<tr><td align="left">
 	<input type="submit" value="${LANG_OK}"
 				onClick="form.closeme.value=1; form.submit(); return false;"
-				onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPOK}' onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td><td align="right">
 	<input type="button" value="${LANG_CANCEL}"
 				onClick="window.close();"
-				onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPCANCEL}' onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td></tr>
 	</table>

--- a/html/server/option2.html
+++ b/html/server/option2.html
@@ -60,7 +60,7 @@ ${do:if-file-exists:html/index.html}
 <td>
 	<a href="/step9_opt5.html" target="_blank"
 		onClick="window.open('/step9_opt5.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>${LANG_TIPHELP}</a>
 </td>
 ${do:end-if}
@@ -71,18 +71,18 @@ ${do:end-if}
 <table class="tableWidth" border="0" width="100%" cellspacing="0">
 <tr>
 
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT1}' onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT2}' onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT3}' onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT4}' onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT5}' onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT11}' onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
 </tr><tr>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT6}' onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT7}' onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT8}' onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT9}' onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT10}' onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
 <td class="tabCtrl" align="center">&nbsp;</td>
 
 </tr>
@@ -101,20 +101,20 @@ ${do:end-if}
 ${LANG_I33}
 <br>
 <select name="build"
-			onMouseOver="info('${html:LANG_I3}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I3}' onMouseOver="info('${html:LANG_I3}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 ${listid:build:LISTDEF_3}
 </select>
 <input type="button" value="${LANG_O2}" 
 	onClick="form.build.selectedIndex=14; window.open('option2b.html', 'option2b', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480').wparent=document; form.submit();"
-		onMouseOver="info('${html:LANG_I4}'); return true" onMouseOut="info('&nbsp;'); return true"
+		title='${html:LANG_I4}' onMouseOver="info('${html:LANG_I4}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 
 <!-- checkboxes -->
 <table border="0" width="100%" cellspacing="0">
 <tr><td>
 <select name="dos"
-			onMouseOver="info('${html:LANG_I8}\r\n${LANG_I8b}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I8} ${html:LANG_I8b}' onMouseOver="info('${html:LANG_I8}\r\n${LANG_I8b}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 <option value="0"${ztest:dos: selected::}>&nbsp;</option>
 <option value="1"${ztest:dos:: selected:}>${LANG_I37}</option>
@@ -122,19 +122,19 @@ ${listid:build:LISTDEF_3}
 </select>
 </td></tr>
 <tr><td><input type="checkbox" name="errpage"   ${checked:errpage}  
-			onMouseOver="info('${html:LANG_I9}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I9}' onMouseOver="info('${html:LANG_I9}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I38}</td></tr>
 <tr><td><input type="checkbox" name="external"  ${checked:external} 
-			onMouseOver="info('${html:LANG_I29}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I29}' onMouseOver="info('${html:LANG_I29}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I56}</td></tr>
 <tr><td><input type="checkbox" name="hidepwd"   ${checked:hidepwd}  
-			onMouseOver="info('${html:LANG_I30}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I30}' onMouseOver="info('${html:LANG_I30}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I66}</td></tr>
 <tr><td><input type="checkbox" name="hidequery" ${checked:hidequery}
-			onMouseOver="info('${html:LANG_I30b}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I30b}' onMouseOver="info('${html:LANG_I30b}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I67}</td></tr>
 <tr><td><input type="checkbox" name="nopurge"   ${checked:nopurge}  
-			onMouseOver="info('${html:LANG_I1a}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I1a}' onMouseOver="info('${html:LANG_I1a}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I57}</td></tr>
 </table>
 
@@ -143,12 +143,12 @@ ${listid:build:LISTDEF_3}
 	<tr><td align="left">
 	<input type="submit" value="${LANG_OK}"
 				onClick="form.closeme.value=1; form.submit(); return false;"
-				onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPOK}' onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td><td align="right">
 	<input type="button" value="${LANG_CANCEL}"
 				onClick="window.close();"
-				onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPCANCEL}' onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td></tr>
 	</table>

--- a/html/server/option2b.html
+++ b/html/server/option2b.html
@@ -70,7 +70,7 @@ ${do:if-file-exists:html/index.html}
 <td>
 	<a href="/step9_opt5.html" target="_blank"
 		onClick="window.open('/step9_opt5.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>${LANG_TIPHELP}</a>
 </td>
 ${do:end-if}
@@ -107,12 +107,12 @@ ${LANG_Q3}
 ${do:output-mode:html-urlescaped}
 		onClick="if (confirm(str_replace(str_replace('${LANG_DIAL7}', '%20', ' '), '%0a', ' '))) { form.closeme.value=1; form.submit(); } return false;"
 ${do:output-mode:}
-				onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPOK}' onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td><td align="right">
 	<input type="button" value="${LANG_CANCEL}"
 				onClick="window.close();"
-				onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPCANCEL}' onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td></tr>
 	</table>

--- a/html/server/option3.html
+++ b/html/server/option3.html
@@ -60,7 +60,7 @@ ${do:if-file-exists:html/index.html}
 <td>
 	<a href="/step9_opt10.html" target="_blank"
 		onClick="window.open('/step9_opt10.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>${LANG_TIPHELP}</a>
 </td>
 ${do:end-if}
@@ -71,18 +71,18 @@ ${do:end-if}
 <table class="tableWidth" border="0" width="100%" cellspacing="0">
 <tr>
 
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT1}' onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT2}' onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT3}' onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT4}' onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT5}' onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT11}' onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
 </tr><tr>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT6}' onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT7}' onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT8}' onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT9}' onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT10}' onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
 <td class="tabCtrl" align="center">&nbsp;</td>
 
 </tr>
@@ -104,7 +104,7 @@ ${LANG_I40c}
 <!-- checkboxes -->
 <table border="0" width="100%" cellspacing="0">
 <tr><td><input type="checkbox" name="cache" ${checked:cache}
-			onMouseOver="info('${html:LANG_I5}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I5}' onMouseOver="info('${html:LANG_I5}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I34}</td></tr>
 </table>
 <br>
@@ -112,7 +112,7 @@ ${LANG_I40c}
 ${LANG_I39}
 <br>
 <select name="filter"
-			onMouseOver="info('${html:LANG_I29}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I29}' onMouseOver="info('${html:LANG_I29}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 ${listid:filter:LISTDEF_4}
 </select>
@@ -121,7 +121,7 @@ ${listid:filter:LISTDEF_4}
 ${LANG_I40}
 <br>
 <select name="travel"
-			onMouseOver="info('${html:LANG_I11}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I11}' onMouseOver="info('${html:LANG_I11}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 ${listid:travel:LISTDEF_5}
 </select>
@@ -130,7 +130,7 @@ ${listid:travel:LISTDEF_5}
 ${LANG_I40b}
 <br>
 <select name="travel2"
-			onMouseOver="info('${html:LANG_I11b}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I11b}' onMouseOver="info('${html:LANG_I11b}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 ${listid:travel2:LISTDEF_6}
 </select>
@@ -139,7 +139,7 @@ ${listid:travel2:LISTDEF_6}
 ${LANG_I40e}
 <br>
 <select name="travel3"
-			onMouseOver="info('${html:LANG_I11c}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I11c}' onMouseOver="info('${html:LANG_I11c}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 ${listid:travel3:LISTDEF_11}
 </select>
@@ -148,7 +148,7 @@ ${listid:travel3:LISTDEF_11}
 <!-- checkboxes -->
 <table border="0" width="100%" cellspacing="0">
 <tr><td><input type="checkbox" name="windebug" ${checked:windebug} 
-			onMouseOver="info('${html:LANG_I1h}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I1h}' onMouseOver="info('${html:LANG_I1h}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I40d}</td></tr>
 </table>
 <br>
@@ -158,12 +158,12 @@ ${listid:travel3:LISTDEF_11}
 	<tr><td align="left">
 	<input type="submit" value="${LANG_OK}"
 				onClick="form.closeme.value=1; form.submit(); return false;"
-				onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPOK}' onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td><td align="right">
 	<input type="button" value="${LANG_CANCEL}"
 				onClick="window.close();"
-				onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPCANCEL}' onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td></tr>
 	</table>

--- a/html/server/option4.html
+++ b/html/server/option4.html
@@ -60,7 +60,7 @@ ${do:if-file-exists:html/index.html}
 <td>
 	<a href="/step9_opt3.html" target="_blank"
 		onClick="window.open('/step9_opt3.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>${LANG_TIPHELP}</a>
 </td>
 ${do:end-if}
@@ -71,18 +71,18 @@ ${do:end-if}
 <table class="tableWidth" border="0" width="100%" cellspacing="0">
 <tr>
 
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT1}' onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT2}' onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT3}' onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT4}' onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT5}' onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT11}' onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
 </tr><tr>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT6}' onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT7}' onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT8}' onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT9}' onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT10}' onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
 <td class="tabCtrl" align="center">&nbsp;</td>
 
 </tr>
@@ -104,11 +104,11 @@ ${do:end-if}
 ${LANG_I44}
 </td><td>
 <input name="connexion" value="${connexion}" size="4"
-			onMouseOver="info('${html:LANG_I12}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I12}' onMouseOver="info('${html:LANG_I12}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr><tr><td></td><td>
 <input type="checkbox" name="ka" ${checked:ka} 
-			onMouseOver="info('${html:LANG_I47f}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I47f}' onMouseOver="info('${html:LANG_I47f}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I47e}
 </td></tr>
 
@@ -116,11 +116,11 @@ ${LANG_I44}
 ${LANG_I47d}
 </td><td>
 <input name="timeout" value="${timeout}" size="4"
-			onMouseOver="info('${html:LANG_I13}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I13}' onMouseOver="info('${html:LANG_I13}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr><tr><td></td><td>
 <input type="checkbox" name="remt" ${checked:remt} 
-			onMouseOver="info('${html:LANG_I14}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I14}' onMouseOver="info('${html:LANG_I14}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I45}
 </td></tr>
 
@@ -128,7 +128,7 @@ ${LANG_I47d}
 ${LANG_I48}
 </td><td>
 <input name="retry" value="${retry}" size="4"
-			onMouseOver="info('${html:LANG_I17}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I17}' onMouseOver="info('${html:LANG_I17}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 
@@ -136,11 +136,11 @@ ${LANG_I48}
 ${LANG_I46}
 </td><td>
 <input name="rate" value="${rate}" size="4"
-			onMouseOver="info('${html:LANG_I15}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I15}' onMouseOver="info('${html:LANG_I15}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr><tr><td></td><td>
 <input type="checkbox" name="rems" ${checked:rems} 
-			onMouseOver="info('${html:LANG_I16}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I16}' onMouseOver="info('${html:LANG_I16}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I47}
 </td></tr>
 
@@ -151,12 +151,12 @@ ${LANG_I46}
 	<tr><td align="left">
 	<input type="submit" value="${LANG_OK}"
 				onClick="form.closeme.value=1; form.submit(); return false;"
-				onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPOK}' onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td><td align="right">
 	<input type="button" value="${LANG_CANCEL}"
 				onClick="window.close();"
-				onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPCANCEL}' onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td></tr>
 	</table>

--- a/html/server/option5.html
+++ b/html/server/option5.html
@@ -60,7 +60,7 @@ ${do:if-file-exists:html/index.html}
 <td>
 	<a href="/step9_opt2.html" target="_blank"
 		onClick="window.open('/step9_opt2.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>${LANG_TIPHELP}</a>
 </td>
 ${do:end-if}
@@ -71,18 +71,18 @@ ${do:end-if}
 <table class="tableWidth" border="0" width="100%" cellspacing="0">
 <tr>
 
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT1}' onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT2}' onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT3}' onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT4}' onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT5}' onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT11}' onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
 </tr><tr>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT6}' onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT7}' onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT8}' onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT9}' onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT10}' onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
 <td class="tabCtrl" align="center">&nbsp;</td>
 
 </tr>
@@ -104,7 +104,7 @@ ${do:end-if}
 ${LANG_G32}
 </td><td>
 <input name="depth" value="${depth}" size="4"
-			onMouseOver="info('${html:LANG_I1g}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I1g}' onMouseOver="info('${html:LANG_I1g}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 
@@ -112,7 +112,7 @@ ${LANG_G32}
 ${LANG_G32b}
 </td><td>
 <input name="depth2" value="${depth2}" size="4"
-			onMouseOver="info('${html:LANG_I1g2}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I1g2}' onMouseOver="info('${html:LANG_I1g2}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 
@@ -120,7 +120,7 @@ ${LANG_G32b}
 ${LANG_I50}
 </td><td>
 <input name="maxhtml" value="${maxhtml}" size="4"
-			onMouseOver="info('${html:LANG_I18}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I18}' onMouseOver="info('${html:LANG_I18}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 
@@ -128,7 +128,7 @@ ${LANG_I50}
 ${LANG_I50b}
 </td><td>
 <input name="othermax" value="${othermax}" size="4"
-			onMouseOver="info('${html:LANG_I19}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I19}' onMouseOver="info('${html:LANG_I19}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 
@@ -136,7 +136,7 @@ ${LANG_I50b}
 ${LANG_I51}
 </td><td>
 <input name="sizemax" value="${sizemax}" size="4"
-			onMouseOver="info('${html:LANG_I20}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I20}' onMouseOver="info('${html:LANG_I20}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 
@@ -144,7 +144,7 @@ ${LANG_I51}
 ${LANG_I65}
 </td><td>
 <input name="pausebytes" value="${pausebytes}" size="4"
-			onMouseOver="info('${html:LANG_I20b}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I20b}' onMouseOver="info('${html:LANG_I20b}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 
@@ -152,7 +152,7 @@ ${LANG_I65}
 ${LANG_PAUSEFILES}
 </td><td>
 <input name="pausefiles" value="${pausefiles}" size="8"
-			onMouseOver="info('${html:LANG_PAUSEFILESTIP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_PAUSEFILESTIP}' onMouseOver="info('${html:LANG_PAUSEFILESTIP}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 
@@ -160,7 +160,7 @@ ${LANG_PAUSEFILES}
 ${LANG_I52}
 </td><td>
 <input name="maxtime" value="${maxtime}" size="4"
-			onMouseOver="info('${html:LANG_I21}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I21}' onMouseOver="info('${html:LANG_I21}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 
@@ -168,7 +168,7 @@ ${LANG_I52}
 ${LANG_I54}
 </td><td>
 <input name="maxrate" value="${maxrate}" size="4"
-			onMouseOver="info('${html:LANG_I22}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I22}' onMouseOver="info('${html:LANG_I22}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 
@@ -176,7 +176,7 @@ ${LANG_I54}
 ${LANG_I64}
 </td><td>
 <input name="maxconn" value="${maxconn}" size="4"
-			onMouseOver="info('${html:LANG_I22b}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I22b}' onMouseOver="info('${html:LANG_I22b}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 
@@ -184,7 +184,7 @@ ${LANG_I64}
 ${LANG_I64b}
 </td><td>
 <input name="maxlinks" value="${maxlinks}" size="4"
-			onMouseOver="info('${html:LANG_I22c}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I22c}' onMouseOver="info('${html:LANG_I22c}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 
@@ -193,12 +193,12 @@ ${LANG_I64b}
 	<tr><td align="left">
 	<input type="submit" value="${LANG_OK}"
 				onClick="form.closeme.value=1; form.submit(); return false;"
-				onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPOK}' onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td><td align="right">
 	<input type="button" value="${LANG_CANCEL}"
 				onClick="window.close();"
-				onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPCANCEL}' onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td></tr>
 	</table>

--- a/html/server/option6.html
+++ b/html/server/option6.html
@@ -60,7 +60,7 @@ ${do:if-file-exists:html/index.html}
 <td>
 	<a href="/step9_opt8.html" target="_blank"
 		onClick="window.open('/step9_opt8.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>${LANG_TIPHELP}</a>
 </td>
 ${do:end-if}
@@ -71,18 +71,18 @@ ${do:end-if}
 <table class="tableWidth" border="0" width="100%" cellspacing="0">
 <tr>
 
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT1}' onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT2}' onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT3}' onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT4}' onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT5}' onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT11}' onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
 </tr><tr>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT6}' onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT7}' onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT8}' onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT9}' onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT10}' onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
 <td class="tabCtrl" align="center">&nbsp;</td>
 
 </tr>
@@ -104,7 +104,7 @@ ${do:end-if}
 ${LANG_I43}
 </td><td>
 <input name="user" value="${user}" size="60"
-			onMouseOver="info('${html:LANG_I23}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I23}' onMouseOver="info('${html:LANG_I23}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 
@@ -112,7 +112,7 @@ ${LANG_I43}
 ${LANG_I43b}
 </td><td>
 <input name="footer" value="${footer}" size="60"
-			onMouseOver="info('${html:LANG_I23b}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I23b}' onMouseOver="info('${html:LANG_I23b}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 </td></tr>
 
@@ -123,12 +123,12 @@ ${LANG_I43b}
 	<tr><td align="left">
 	<input type="submit" value="${LANG_OK}"
 				onClick="form.closeme.value=1; form.submit(); return false;"
-				onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPOK}' onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td><td align="right">
 	<input type="button" value="${LANG_CANCEL}"
 				onClick="window.close();"
-				onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPCANCEL}' onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td></tr>
 	</table>

--- a/html/server/option7.html
+++ b/html/server/option7.html
@@ -60,7 +60,7 @@ ${do:if-file-exists:html/index.html}
 <td>
 	<a href="/step9_opt4.html" target="_blank"
 		onClick="window.open('/step9_opt4.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>${LANG_TIPHELP}</a>
 </td>
 ${do:end-if}
@@ -71,18 +71,18 @@ ${do:end-if}
 <table class="tableWidth" border="0" width="100%" cellspacing="0">
 <tr>
 
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT1}' onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT2}' onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT3}' onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT4}' onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT5}' onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT11}' onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
 </tr><tr>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT6}' onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT7}' onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT8}' onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT9}' onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT10}' onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
 <td class="tabCtrl" align="center">&nbsp;</td>
 
 </tr>
@@ -102,7 +102,7 @@ ${do:end-if}
 ${LANG_B10}
 </tt>
 <textarea name="url2" cols="60" rows="8"
-			onMouseOver="info('${html:LANG_C3}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_C3}' onMouseOver="info('${html:LANG_C3}'); return true" onMouseOut="info('&nbsp;'); return true"
 >${url2}</textarea>
 
 <br>
@@ -115,12 +115,12 @@ ${LANG_B13}
 	<tr><td align="left">
 	<input type="submit" value="${LANG_OK}"
 				onClick="form.closeme.value=1; form.submit(); return false;"
-				onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPOK}' onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td><td align="right">
 	<input type="button" value="${LANG_CANCEL}"
 				onClick="window.close();"
-				onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPCANCEL}' onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td></tr>
 	</table>

--- a/html/server/option8.html
+++ b/html/server/option8.html
@@ -60,7 +60,7 @@ ${do:if-file-exists:html/index.html}
 <td>
 	<a href="/step9_opt6.html" target="_blank"
 		onClick="window.open('/step9_opt6.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>${LANG_TIPHELP}</a>
 </td>
 ${do:end-if}
@@ -71,18 +71,18 @@ ${do:end-if}
 <table class="tableWidth" border="0" width="100%" cellspacing="0">
 <tr>
 
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT1}' onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT2}' onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT3}' onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT4}' onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT5}' onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT11}' onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
 </tr><tr>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT6}' onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT7}' onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT8}' onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT9}' onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT10}' onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
 <td class="tabCtrl" align="center">&nbsp;</td>
 
 </tr>
@@ -99,77 +99,77 @@ ${do:end-if}
 <input type="hidden" name="closeme" value="">
 
 <input type="checkbox" name="cookies" ${checked:cookies}
-			onMouseOver="info('${html:LANG_I1b}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I1b}' onMouseOver="info('${html:LANG_I1b}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I58}
 <br><br>
 
 ${LANG_COOKIEFILE}
 <input name="cookiesfile" value="${cookiesfile}" size="40"
-			onMouseOver="info('${html:LANG_COOKIEFILETIP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_COOKIEFILETIP}' onMouseOver="info('${html:LANG_COOKIEFILETIP}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 <br><br>
 
 ${LANG_I59}
 <br>
 <select name="checktype"
-			onMouseOver="info('${html:LANG_I1c}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I1c}' onMouseOver="info('${html:LANG_I1c}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 ${listid:checktype:LISTDEF_7}
 </select>
 <br><br>
 
 <input type="checkbox" name="parsejava" ${checked:parsejava}
-			onMouseOver="info('${html:LANG_I1d}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I1d}' onMouseOver="info('${html:LANG_I1d}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I60}
 <br><br>
 
 ${LANG_I55}
 <br>
 <select name="robots"
-			onMouseOver="info('${html:LANG_I28}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I28}' onMouseOver="info('${html:LANG_I28}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 ${listid:robots:LISTDEF_8}
 </select>
 <br><br>
 
 <input type="checkbox" name="updhack" ${checked:updhack}
-			onMouseOver="info('${html:LANG_I1k}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I1k}' onMouseOver="info('${html:LANG_I1k}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I62b}
 <br><br>
 
 <input type="checkbox" name="urlhack" ${checked:urlhack}
-			onMouseOver="info('${html:LANG_I1k2}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I1k2}' onMouseOver="info('${html:LANG_I1k2}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I62b2}
 <br><br>
 
 <input type="checkbox" name="keepwww" ${checked:keepwww}
-			onMouseOver="info('${html:LANG_KEEPWWWTIP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_KEEPWWWTIP}' onMouseOver="info('${html:LANG_KEEPWWWTIP}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_KEEPWWW}
 <br><br>
 
 <input type="checkbox" name="keepslashes" ${checked:keepslashes}
-			onMouseOver="info('${html:LANG_KEEPSLASHESTIP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_KEEPSLASHESTIP}' onMouseOver="info('${html:LANG_KEEPSLASHESTIP}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_KEEPSLASHES}
 <br><br>
 
 <input type="checkbox" name="keepqueryorder" ${checked:keepqueryorder}
-			onMouseOver="info('${html:LANG_KEEPQUERYORDERTIP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_KEEPQUERYORDERTIP}' onMouseOver="info('${html:LANG_KEEPQUERYORDERTIP}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_KEEPQUERYORDER}
 <br><br>
 
 ${LANG_STRIPQUERY}
 <input name="stripquery" value="${stripquery}" size="40"
-			onMouseOver="info('${html:LANG_STRIPQUERYTIP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_STRIPQUERYTIP}' onMouseOver="info('${html:LANG_STRIPQUERYTIP}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 <br><br>
 
 <input type="checkbox" name="toler" ${checked:toler}
-			onMouseOver="info('${html:LANG_I1i}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I1i}' onMouseOver="info('${html:LANG_I1i}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I62}
 <br><br>
 
 <input type="checkbox" name="http10" ${checked:http10}
-			onMouseOver="info('${html:LANG_I1j}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I1j}' onMouseOver="info('${html:LANG_I1j}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I63}
 <br><br>
 
@@ -179,12 +179,12 @@ ${LANG_STRIPQUERY}
 	<tr><td align="left">
 	<input type="submit" value="${LANG_OK}"
 				onClick="form.closeme.value=1; form.submit(); return false;"
-				onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPOK}' onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td><td align="right">
 	<input type="button" value="${LANG_CANCEL}"
 				onClick="window.close();"
-				onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPCANCEL}' onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td></tr>
 	</table>

--- a/html/server/option9.html
+++ b/html/server/option9.html
@@ -60,7 +60,7 @@ ${do:if-file-exists:html/index.html}
 <td>
 	<a href="/step9_opt9.html" target="_blank"
 		onClick="window.open('/step9_opt9.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>${LANG_TIPHELP}</a>
 </td>
 ${do:end-if}
@@ -71,18 +71,18 @@ ${do:end-if}
 <table class="tableWidth" border="0" width="100%" cellspacing="0">
 <tr>
 
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option1.html" onClick="form.redirect.value='option1.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT1}' onMouseOver="info('${html:LANG_IOPT1}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT1}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option2.html" onClick="form.redirect.value='option2.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT2}' onMouseOver="info('${html:LANG_IOPT2}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT2}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option3.html" onClick="form.redirect.value='option3.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT3}' onMouseOver="info('${html:LANG_IOPT3}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT3}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option4.html" onClick="form.redirect.value='option4.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT4}' onMouseOver="info('${html:LANG_IOPT4}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT4}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option5.html" onClick="form.redirect.value='option5.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT5}' onMouseOver="info('${html:LANG_IOPT5}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT5}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option11.html" onClick="form.redirect.value='option11.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT11}' onMouseOver="info('${html:LANG_IOPT11}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT11}</a></td>
 </tr><tr>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
-<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option6.html" onClick="form.redirect.value='option6.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT6}' onMouseOver="info('${html:LANG_IOPT6}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT6}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option7.html" onClick="form.redirect.value='option7.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT7}' onMouseOver="info('${html:LANG_IOPT7}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT7}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option8.html" onClick="form.redirect.value='option8.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT8}' onMouseOver="info('${html:LANG_IOPT8}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT8}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option9.html" onClick="form.redirect.value='option9.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT9}' onMouseOver="info('${html:LANG_IOPT9}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT9}</a></td>
+<td class="tabCtrl" align="center"><a style="background:black;color: white" href="option10.html" onClick="form.redirect.value='option10.html'; form.submit(); return false;" align="center" title='${html:LANG_IOPT10}' onMouseOver="info('${html:LANG_IOPT10}'); return true" onMouseOut="info('&nbsp;'); return true">${LANG_IOPT10}</a></td>
 <td class="tabCtrl" align="center">&nbsp;</td>
 
 </tr>
@@ -99,32 +99,32 @@ ${do:end-if}
 <input type="hidden" name="closeme" value="">
 
 <input type="checkbox" name="cache2" ${checked:cache2}
-			onMouseOver="info('${html:LANG_I1e}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I1e}' onMouseOver="info('${html:LANG_I1e}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I61}
 <br><br>
 
 <input type="checkbox" name="norecatch" ${checked:norecatch}
-			onMouseOver="info('${html:LANG_I5b}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I5b}' onMouseOver="info('${html:LANG_I5b}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I34b}
 <br><br>
 
 <input type="checkbox" name="logf" ${checked:logf}
-			onMouseOver="info('${html:LANG_I7}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I7}' onMouseOver="info('${html:LANG_I7}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I36}
 <select name="logtype"
-			onMouseOver="info('${html:LANG_I1f}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I1f}' onMouseOver="info('${html:LANG_I1f}'); return true" onMouseOut="info('&nbsp;'); return true"
 >
 ${listid:logtype:LISTDEF_9}
 </select>
 <br><br>
 
 <input type="checkbox" name="index" ${checked:index}
-			onMouseOver="info('${html:LANG_I6}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I6}' onMouseOver="info('${html:LANG_I6}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I35}
 <br><br>
 
 <input type="checkbox" name="index2" ${checked:index2}
-			onMouseOver="info('${html:LANG_I6b}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_I6b}' onMouseOver="info('${html:LANG_I6b}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I35b}
 <br><br>
 
@@ -133,12 +133,12 @@ ${listid:logtype:LISTDEF_9}
 	<tr><td align="left">
 	<input type="submit" value="${LANG_OK}"
 				onClick="form.closeme.value=1; form.submit(); return false;"
-				onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPOK}' onMouseOver="info('${html:LANG_TIPOK}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td><td align="right">
 	<input type="button" value="${LANG_CANCEL}"
 				onClick="window.close();"
-				onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
+				title='${html:LANG_TIPCANCEL}' onMouseOver="info('${html:LANG_TIPCANCEL}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>
 	</td></tr>
 	</table>

--- a/html/server/refresh.html
+++ b/html/server/refresh.html
@@ -73,7 +73,7 @@ function no_refresh() {
 	<td id="subTitle" align="right">
 		<a href="/server/file.html" target="_blank"
 			onClick="window.open('/server/file.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_O1}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_O1}' onMouseOver="info('${html:LANG_O1}'); return true" onMouseOut="info('&nbsp;'); return true"
 			style="color:#FFFFFF"
 		>
 		${LANG_O1}
@@ -85,7 +85,7 @@ ${do:if-file-exists:html/index.html}
 	<td id="subTitle" align="right">
 		<a href="/index.html" target="_blank"
 			onClick="window.open('/server/help.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 			style="color:#FFFFFF"
 		>
 		${LANG_O5}
@@ -152,20 +152,20 @@ ${LANG_H20} ${info.currentjob}
 
 <table border="0" width="100%">
 
-<tr><td>${info.state[0]}</td><td>${info.name[0]}</td><td>${info.file[0]}</td><td>${info.size[0]}/${info.sizetot[0]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[0]}'; form.submit()" onMouseOver="info('${html:LANG_H6}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
-<tr><td>${info.state[1]}</td><td>${info.name[1]}</td><td>${info.file[1]}</td><td>${info.size[1]}/${info.sizetot[1]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[1]}'; form.submit()" onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
-<tr><td>${info.state[2]}</td><td>${info.name[2]}</td><td>${info.file[2]}</td><td>${info.size[2]}/${info.sizetot[2]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[2]}'; form.submit()" onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
-<tr><td>${info.state[3]}</td><td>${info.name[3]}</td><td>${info.file[3]}</td><td>${info.size[3]}/${info.sizetot[3]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[3]}'; form.submit()" onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
-<tr><td>${info.state[4]}</td><td>${info.name[4]}</td><td>${info.file[4]}</td><td>${info.size[4]}/${info.sizetot[4]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[4]}'; form.submit()" onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
-<tr><td>${info.state[5]}</td><td>${info.name[5]}</td><td>${info.file[5]}</td><td>${info.size[5]}/${info.sizetot[5]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[5]}'; form.submit()" onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
-<tr><td>${info.state[6]}</td><td>${info.name[6]}</td><td>${info.file[6]}</td><td>${info.size[6]}/${info.sizetot[6]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[6]}'; form.submit()" onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
-<tr><td>${info.state[7]}</td><td>${info.name[7]}</td><td>${info.file[7]}</td><td>${info.size[7]}/${info.sizetot[7]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[7]}'; form.submit()" onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
-<tr><td>${info.state[8]}</td><td>${info.name[8]}</td><td>${info.file[8]}</td><td>${info.size[8]}/${info.sizetot[8]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[8]}'; form.submit()" onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
-<tr><td>${info.state[9]}</td><td>${info.name[9]}</td><td>${info.file[9]}</td><td>${info.size[9]}/${info.sizetot[9]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[9]}'; form.submit()" onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
-<tr><td>${info.state[10]}</td><td>${info.name[10]}</td><td>${info.file[10]}</td><td>${info.size[10]}/${info.sizetot[10]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[10]}'; form.submit()" onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
-<tr><td>${info.state[11]}</td><td>${info.name[11]}</td><td>${info.file[11]}</td><td>${info.size[11]}/${info.sizetot[11]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[11]}'; form.submit()" onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
-<tr><td>${info.state[12]}</td><td>${info.name[12]}</td><td>${info.file[12]}</td><td>${info.size[12]}/${info.sizetot[12]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[12]}'; form.submit()" onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
-<tr><td>${info.state[13]}</td><td>${info.name[13]}</td><td>${info.file[13]}</td><td>${info.size[13]}/${info.sizetot[13]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[13]}'; form.submit()" onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
+<tr><td>${info.state[0]}</td><td>${info.name[0]}</td><td>${info.file[0]}</td><td>${info.size[0]}/${info.sizetot[0]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[0]}'; form.submit()" title='${html:LANG_H6}' onMouseOver="info('${html:LANG_H6}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
+<tr><td>${info.state[1]}</td><td>${info.name[1]}</td><td>${info.file[1]}</td><td>${info.size[1]}/${info.sizetot[1]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[1]}'; form.submit()" title='${html:LANG_H7}' onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
+<tr><td>${info.state[2]}</td><td>${info.name[2]}</td><td>${info.file[2]}</td><td>${info.size[2]}/${info.sizetot[2]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[2]}'; form.submit()" title='${html:LANG_H7}' onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
+<tr><td>${info.state[3]}</td><td>${info.name[3]}</td><td>${info.file[3]}</td><td>${info.size[3]}/${info.sizetot[3]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[3]}'; form.submit()" title='${html:LANG_H7}' onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
+<tr><td>${info.state[4]}</td><td>${info.name[4]}</td><td>${info.file[4]}</td><td>${info.size[4]}/${info.sizetot[4]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[4]}'; form.submit()" title='${html:LANG_H7}' onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
+<tr><td>${info.state[5]}</td><td>${info.name[5]}</td><td>${info.file[5]}</td><td>${info.size[5]}/${info.sizetot[5]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[5]}'; form.submit()" title='${html:LANG_H7}' onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
+<tr><td>${info.state[6]}</td><td>${info.name[6]}</td><td>${info.file[6]}</td><td>${info.size[6]}/${info.sizetot[6]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[6]}'; form.submit()" title='${html:LANG_H7}' onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
+<tr><td>${info.state[7]}</td><td>${info.name[7]}</td><td>${info.file[7]}</td><td>${info.size[7]}/${info.sizetot[7]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[7]}'; form.submit()" title='${html:LANG_H7}' onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
+<tr><td>${info.state[8]}</td><td>${info.name[8]}</td><td>${info.file[8]}</td><td>${info.size[8]}/${info.sizetot[8]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[8]}'; form.submit()" title='${html:LANG_H7}' onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
+<tr><td>${info.state[9]}</td><td>${info.name[9]}</td><td>${info.file[9]}</td><td>${info.size[9]}/${info.sizetot[9]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[9]}'; form.submit()" title='${html:LANG_H7}' onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
+<tr><td>${info.state[10]}</td><td>${info.name[10]}</td><td>${info.file[10]}</td><td>${info.size[10]}/${info.sizetot[10]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[10]}'; form.submit()" title='${html:LANG_H7}' onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
+<tr><td>${info.state[11]}</td><td>${info.name[11]}</td><td>${info.file[11]}</td><td>${info.size[11]}/${info.sizetot[11]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[11]}'; form.submit()" title='${html:LANG_H7}' onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
+<tr><td>${info.state[12]}</td><td>${info.name[12]}</td><td>${info.file[12]}</td><td>${info.size[12]}/${info.sizetot[12]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[12]}'; form.submit()" title='${html:LANG_H7}' onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
+<tr><td>${info.state[13]}</td><td>${info.name[13]}</td><td>${info.file[13]}</td><td>${info.size[13]}/${info.sizetot[13]}</td><td><input type="submit" value="${LANG_H15}" onClick="form.command.value='cancel-file=${info.url_sav[13]}'; form.submit()" title='${html:LANG_H7}' onMouseOver="info('${html:LANG_H7}'); return true" onMouseOut="info('&nbsp;'); return true"></td></tr>
 
 </table>
 
@@ -180,7 +180,7 @@ ${LANG_H20} ${info.currentjob}
 		&nbsp;
 		</td><td align="right">
 			<input type="submit" value=" ${LANG_V4} " 
-				onMouseOver="disable_timer(); info('${LANG_D3}'); return true" 
+				title='${html:LANG_D3}' onMouseOver="disable_timer(); info('${LANG_D3}'); return true" 
 				onMouseOut="info('&nbsp;'); enable_timer(); return true"
 				onClick="if (do_confirm('${LANG_G1}')) { form.command.value='cancel'; form.submit(); } return false"
 			>

--- a/html/server/step2.html
+++ b/html/server/step2.html
@@ -52,7 +52,7 @@ function info(str) {
 	<td id="subTitle" align="right">
 		<a href="/server/file.html" target="_blank"
 			onClick="window.open('/server/file.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:html:LANG_O1}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_O1}' onMouseOver="info('${html:html:LANG_O1}'); return true" onMouseOut="info('&nbsp;'); return true"
 			style="color:#FFFFFF"
 		>
 		${LANG_O1}
@@ -64,7 +64,7 @@ ${do:if-file-exists:html/index.html}
 	<td id="subTitle" align="right">
 		<a href="/index.html" target="_blank"
 			onClick="window.open('/server/help.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 			style="color:#FFFFFF"
 		>
 		${LANG_O5}
@@ -93,7 +93,7 @@ ${do:if-file-exists:html/index.html}
 <td>
 	<a href="/step1.html" target="_blank"
 		onClick="window.open('/step1.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>${LANG_TIPHELP}</a>
 </td>
 ${do:end-if}
@@ -218,7 +218,7 @@ ${do:loadhash}
 
 		${LANG_S11}
 		<input name="projname" value="${projname}"
-			onMouseOver="info('${html:html:LANG_S1}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_S1}' onMouseOver="info('${html:html:LANG_S1}'); return true" onMouseOut="info('&nbsp;'); return true"
 		>
 
 <br>
@@ -233,7 +233,7 @@ ${do:loadhash}
 		</select>
 </td><td>
 		<input name="projcateg" value="${projcateg}"
-			onMouseOver="info('${html:html:LANG_S5}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_S5}' onMouseOver="info('${html:html:LANG_S5}'); return true" onMouseOut="info('&nbsp;'); return true"
 		>
 
 </td></tr></table>
@@ -241,7 +241,7 @@ ${do:loadhash}
 <br>
 		${LANG_S12}
 		<input name="path" value="${path}"
-			onMouseOver="info('${html:html:LANG_S2}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_S2}' onMouseOver="info('${html:html:LANG_S2}'); return true" onMouseOut="info('&nbsp;'); return true"
 		>
 		<input type="button" value="refresh" onClick="form.redirect.value='step2.html'; form.submit()">
 
@@ -250,11 +250,11 @@ ${do:loadhash}
 	<tr><td>
 		<table width="100%" border="0"><tr><td align="left">
 			<input type="submit" value=" << ${LANG_PREVIOUS} " onClick="form.redirect.value='index.html'; form.submit()"
-			onMouseOver="info('${html:html:LANG_TIPPREV}'); return true" onMouseOut="info('&nbsp;'); return true"			
+			title='${html:LANG_TIPPREV}' onMouseOver="info('${html:html:LANG_TIPPREV}'); return true" onMouseOut="info('&nbsp;'); return true"			
 			>
 		</td><td align="right">
 			<input name="nextBtn" type="submit" value=" ${LANG_NEXT} >> " onClick="return checkname();" default
-			onMouseOver="info('${html:html:LANG_TIPNEXT}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPNEXT}' onMouseOver="info('${html:html:LANG_TIPNEXT}'); return true" onMouseOut="info('&nbsp;'); return true"
 			>
 		</td></tr></table>
 

--- a/html/server/step3.html
+++ b/html/server/step3.html
@@ -61,7 +61,7 @@ function do_check_child() {
 	<td id="subTitle" align="right">
 		<a href="/server/file.html" target="_blank"
 			onClick="window.open('/server/file.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_O1}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_O1}' onMouseOver="info('${html:LANG_O1}'); return true" onMouseOut="info('&nbsp;'); return true"
 			style="color:#FFFFFF"
 		>
 		${LANG_O1}
@@ -73,7 +73,7 @@ ${do:if-file-exists:html/index.html}
 	<td id="subTitle" align="right">
 		<a href="/index.html" target="_blank"
 			onClick="window.open('/server/help.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 			style="color:#FFFFFF"
 		>
 		${LANG_O5}
@@ -102,7 +102,7 @@ ${do:if-file-exists:html/index.html}
 <td>
 	<a href="/step2.html" target="_blank"
 		onClick="window.open('/step2.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>${LANG_TIPHELP}</a>
 </td>
 ${do:end-if}
@@ -118,7 +118,7 @@ ${do:end-if}
 <tr><td>
 		${LANG_G31}
 		<select name="todo"
-			onMouseOver="info('${html:LANG_G9}'); return true" onMouseOut="info('&nbsp;'); return true"		
+			title='${html:LANG_G9}' onMouseOver="info('${html:LANG_G9}'); return true" onMouseOut="info('&nbsp;'); return true"		
 		>
 		${listid:todo:LISTDEF_10}
 		</select>
@@ -131,12 +131,12 @@ ${do:end-if}
 		</td><td>
 		<input type="button" value="${LANG_G43}" 
 		       onClick="doOpenWindow()"
-			onMouseOver="info('${html:LANG_G24b}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_G24b}' onMouseOver="info('${html:LANG_G24b}'); return true" onMouseOut="info('&nbsp;'); return true"
 			   >
 		</td></tr></table>
 		<br>
 		<textarea name="urls" cols="50" rows="8"
-			onMouseOver="info('${html:LANG_G11}'); return true" onMouseOut="info('&nbsp;'); return true"		
+			title='${html:LANG_G11}' onMouseOver="info('${html:LANG_G11}'); return true" onMouseOut="info('&nbsp;'); return true"		
 		>
 ${do:output-mode:html}
 		${urls}
@@ -150,7 +150,7 @@ ${do:output-mode:}
 		${LANG_URLLIST}:
 		</td><td>
 		<input name="filelist" value="${filelist}" size="40"
-			onMouseOver="info('${html:LANG_G24c}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_G24c}' onMouseOver="info('${html:LANG_G24c}'); return true" onMouseOut="info('&nbsp;'); return true"
 		>
 		</td></tr></table>
 
@@ -161,7 +161,7 @@ ${do:output-mode:}
 		${LANG_G41}
 		</td><td>
 		<input type="button" value="${LANG_G40}" onClick="window.open('option1.html', 'option1', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_G24}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_G24}' onMouseOver="info('${html:LANG_G24}'); return true" onMouseOut="info('&nbsp;'); return true"
 		>
 		</td></tr></table>
 
@@ -170,11 +170,11 @@ ${do:output-mode:}
 	<tr><td align="right">
 		<table width="100%" border="0"><tr><td align="left">
 			<input type="submit" value=" << ${LANG_PREVIOUS} " onClick="form.redirect.value='step2.html'; form.submit()"
-			onMouseOver="info('${html:LANG_TIPPREV}'); return true" onMouseOut="info('&nbsp;'); return true"			
+			title='${html:LANG_TIPPREV}' onMouseOver="info('${html:LANG_TIPPREV}'); return true" onMouseOut="info('&nbsp;'); return true"			
 			>
 		</td><td align="right">
 			<input name="nextBtn" type="submit" value=" ${LANG_NEXT} >> "
-			onMouseOver="info('${html:LANG_TIPNEXT}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPNEXT}' onMouseOver="info('${html:LANG_TIPNEXT}'); return true" onMouseOut="info('&nbsp;'); return true"
 			>
 		</td></tr></table>
 

--- a/html/server/step4.html
+++ b/html/server/step4.html
@@ -43,7 +43,7 @@ function info(str) {
 	<td id="subTitle" align="right">
 		<a href="/server/file.html" target="_blank"
 			onClick="window.open('/server/file.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_O1}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_O1}' onMouseOver="info('${html:LANG_O1}'); return true" onMouseOut="info('&nbsp;'); return true"
 			style="color:#FFFFFF"
 		>
 		${LANG_O1}
@@ -55,7 +55,7 @@ ${do:if-file-exists:html/index.html}
 	<td id="subTitle" align="right">
 		<a href="/index.html" target="_blank"
 			onClick="window.open('/server/help.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 			style="color:#FFFFFF"
 		>
 		${LANG_O5}
@@ -84,7 +84,7 @@ ${do:if-file-exists:html/index.html}
 <td>
 	<a href="/step3.html" target="_blank"
 		onClick="window.open('/step3.html', 'help', 'toolbar=no, location=no, directories=no, status=yes, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'); return false"
-			onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPHELP}' onMouseOver="info('${html:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
 	>${LANG_TIPHELP}</a>
 </td>
 ${do:end-if}
@@ -298,11 +298,11 @@ ${do:output-mode:}
 </td></tr><tr><td>
 		<table width="100%" border="0"><tr><td align="left">
 			<input type="submit" value=" << ${LANG_PREVIOUS} " onClick="form.command.value=''; form.redirect.value='step3.html'; form.submit()"
-			onMouseOver="info('${html:LANG_TIPPREV}'); return true" onMouseOut="info('&nbsp;'); return true"			
+			title='${html:LANG_TIPPREV}' onMouseOver="info('${html:LANG_TIPPREV}'); return true" onMouseOut="info('&nbsp;'); return true"			
 			>
 		</td><td align="right">
 			<input name="nextBtn" type="submit" value=" ${LANG_J9} >> "
-			onMouseOver="info('${html:LANG_TIPNEXT}'); return true" onMouseOut="info('&nbsp;'); return true"
+			title='${html:LANG_TIPNEXT}' onMouseOver="info('${html:LANG_TIPNEXT}'); return true" onMouseOut="info('&nbsp;'); return true"
 			>
 		</td></tr></table>
 

--- a/tests/webhttrack-smoke.sh
+++ b/tests/webhttrack-smoke.sh
@@ -36,15 +36,19 @@ chmod +x "$stubdir/uname"
 
 # Stub browser: webhttrack tries its browser-name list in order and runs the
 # first it finds, so shadow the first entry, "x-www-browser". It fetches the
-# server URL and records PASS only for the working UI: the brand string AND the
-# step-2 form action, which a truncated/degraded template page would lack (the
-# bare title alone is not enough). htsserver only lives until webhttrack exits,
-# so the check has to happen here.
+# server URL and records PASS only for the working UI: the brand string, the
+# step-2 form action, and an option-page tooltip, which a truncated/degraded
+# template page would lack. htsserver only lives until webhttrack exits, so the
+# check has to happen here.
 # -a: the UI is served ISO-8859-1, so grep must not treat it as binary.
 cat >"$stubdir/x-www-browser" <<EOF
 #!/bin/bash
 echo "stub browser invoked with: \$1" >&2
-if body="\$(curl -fsSL --max-time 20 "\$1")" && printf '%s' "\$body" | grep -qai httrack && printf '%s' "\$body" | grep -qaF step2.html; then
+# Also fetch an option page and require a rendered title='' tooltip: proves the
+# option template expands and the \${html:} filter escapes into the attribute.
+opturl="\${1%/}/server/option2.html"
+if body="\$(curl -fsSL --max-time 20 "\$1")" && printf '%s' "\$body" | grep -qai httrack && printf '%s' "\$body" | grep -qaF step2.html &&
+    opt="\$(curl -fsSL --max-time 20 "\$opturl")" && printf '%s' "\$opt" | grep -qaF "title='"; then
     echo PASS >"$marker"
 else
     echo "FAIL: unexpected response from \$1" >"$marker"


### PR DESCRIPTION
The webhttrack option pages carried per-control help through `onMouseOver="info(...)"`, which only wrote the text into `window.status`. Browsers stopped letting scripts change the status bar years ago, so those hints have been landing nowhere and the GUI looks like it has no tooltips.

This adds a real `title='...'` attribute to every control that already had an `info()` hint, reusing the same `${html:LANG_*}` string, so there is no new localization work. The attribute is single-quoted on purpose: the `${html:}` filter escapes `'` to `&#39;` (and `<>&`), so apostrophe-heavy translations like French stay well-formed, and a literal `"` is harmless inside single quotes. The inert `window.status` calls stay put so the diff is nothing but added attributes: 291 tooltips across the option, step, and helper pages.

Verified by rendering `option2.html` through htsserver, where every hint comes out as a correct native tooltip, including the one built from two joined LANG fields. The webhttrack smoke test now also fetches an option page and requires a rendered `title='` tooltip, so a template or filter regression fails CI.