### PR TITLE
INTsys is gated on a macro that is never defined

### DIFF
--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -323,11 +323,9 @@ typedef int64_t TStamp;
 #define LLintP "%" PRId64
 
 /* Integer type for file offsets/sizes passed to the C library; INTsysP is its
-   printf conversion. FIXME: LFS_FLAG is a configure make variable, never a C
-   macro, so this test is dead and INTsys stays int on POSIX despite large-file
-   support (the real macro is HTS_LFS). Widening it there is an installed-header
-   type change, so it is left alone here. */
-#if defined(LFS_FLAG) || defined(_MSC_VER)
+   printf conversion. HTS_LFS is the large-file macro: LFS_FLAG is a configure
+   make variable carrying the -D flags, never itself defined. */
+#if defined(HTS_LFS) || defined(_MSC_VER)
 typedef LLint INTsys;
 
 #define INTsysP LLintP


### PR DESCRIPTION
`#ifdef LFS_FLAG` in `htsglobal.h` has always been false: `LFS_FLAG` is an `AC_SUBST` make variable carrying the `-D_FILE_OFFSET_BITS=64` flags, never a preprocessor macro. The real one is `HTS_LFS`, and `config.h` is already included 200 lines above the typedef, so the guard now tests it and `INTsys` is 64-bit where large-file support is on. The misleading FIXME goes with it.

Not quite the no-op it looks like, in two spots. `htsindex.c:330` casts `fread`'s return to `INTsys` and compares it against an `LLint` file size, so a temp index of 2 GB or more truncated to a mismatch and the index was silently not rebuilt (fails closed). And a tampered cache length wrapping mod 2^32, `4294967396` parsing to `100`, used to be accepted and desynchronized every later field; it now fails the `> 32768` guard. Neither arises from a legitimate writer, but the new behavior is the safer one. The FIXME's broader 2 GB claim does not hold up: the remaining sites are bounded string lengths and a `recv` length.

An installed header and the cache format are both in play, so this is verified rather than asserted: identical exported symbols and soname, byte-identical DWARF layouts for every installed struct (a canary `INTsys` field injected into `t_proxy` is caught, so the probe can fail), `.dat` round-trips byte-identical between master and branch builds, and no new `-Wformat=2` warnings while an injected #567-style `sscanf(INTsysP, &int)` does trip one. `INTsys` sits in no struct or exported signature, so there is no ABI break and no `VERSION_INFO` bump. One side effect worth knowing: `HTS_LFS` comes from `AC_CHECK_LIB(c, fopen64)`, which macOS lacks, so `INTsys` is now 64-bit on Linux and Windows and stays `int` on macOS. The wire format is width-independent decimal text, so nothing on disk changes.
