### PR TITLE
The SOCKS5 IPv6-literal origin reject is untested

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1510,6 +1510,18 @@ static int st_socks5(httrackp *opt, int argc, char **argv) {
     assertf(io.sent_len == 0);
   }
 
+  /* the request is always ATYP=domain, which cannot carry an IPv6 literal: a
+     bracketed origin is rejected rather than sent as a bogus domain name */
+  io.reply = script;
+  io.reply_len = len;
+  assertf(socks5_handshake_scripted(opt, "[::1]", proxy, &io) == 0);
+  assertf(io.sent_len == 0);
+  io.reply = script;
+  io.reply_len = len;
+  assertf(socks5_handshake_scripted(opt, "[2001:db8::1]:8443", proxy, &io) ==
+          0);
+  assertf(io.sent_len == 0);
+
   printf("socks5 self-test OK\n");
   return 0;
 }

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1511,16 +1511,20 @@ static int st_socks5(httrackp *opt, int argc, char **argv) {
   }
 
   /* the request is always ATYP=domain, which cannot carry an IPv6 literal: a
-     bracketed origin is rejected rather than sent as a bogus domain name */
+     bracketed origin is rejected rather than sent as a bogus domain name. The
+     msg check pins the reason: a stricter host validator would also reject
+     these, but for the wrong cause. */
   io.reply = script;
   io.reply_len = len;
   assertf(socks5_handshake_scripted(opt, "[::1]", proxy, &io) == 0);
   assertf(io.sent_len == 0);
+  assertf(strstr(io.msg, "IPv6") != NULL);
   io.reply = script;
   io.reply_len = len;
   assertf(socks5_handshake_scripted(opt, "[2001:db8::1]:8443", proxy, &io) ==
           0);
   assertf(io.sent_len == 0);
+  assertf(strstr(io.msg, "IPv6") != NULL);
 
   printf("socks5 self-test OK\n");
   return 0;


### PR DESCRIPTION
The SOCKS5 CONNECT request is always ATYP=domain, so `socks5_handshake_stream` rejects a bracketed IPv6-literal origin instead of sending the brackets as a domain name the proxy could never resolve. Nothing pinned that branch: stub the reject out and the whole suite still passes. This adds the bare and explicit-port bracketed forms to the `socks5` self-test, asserting the handshake fails with nothing written.

Test only, no behavior change.
