### PR TITLE
Make the test servers' proxytestlib import survive python3 -P

### DIFF
--- a/tests/proxy-connect-server.py
+++ b/tests/proxy-connect-server.py
@@ -16,9 +16,13 @@ Proxy modes (argv[2], default "ok"):
 Usage: proxy-connect-server.py <logdir> [mode]
 Prints "ORIGIN <port>", "PROXY <port>", then "ready" (one per line) on stdout.
 """
+import os
 import sys
 
-import proxytestlib
+# python3 -P (PYTHONSAFEPATH) drops the script's own directory from sys.path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import proxytestlib  # noqa: E402
 
 ORIGIN_BODY = b"<html><body>ORIGIN-PAGE-564</body></html>"
 

--- a/tests/proxy-https-server.py
+++ b/tests/proxy-https-server.py
@@ -15,9 +15,13 @@ Proxy modes (argv[3], default "ok"):
 Usage: proxy-https-server.py <cert.pem> <logdir> [mode]
 Prints "ORIGIN <port>", "PROXY <port>", then "ready" (one per line) on stdout.
 """
+import os
 import sys
 
-import proxytestlib
+# python3 -P (PYTHONSAFEPATH) drops the script's own directory from sys.path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import proxytestlib  # noqa: E402
 
 ORIGIN_BODY = b"<html><body>ORIGIN-PAGE-85</body></html>"
 

--- a/tests/socks5-server.py
+++ b/tests/socks5-server.py
@@ -16,7 +16,10 @@ import struct
 import sys
 import threading
 
-from proxytestlib import pipe
+# python3 -P (PYTHONSAFEPATH) drops the script's own directory from sys.path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from proxytestlib import pipe  # noqa: E402
 
 # The one name the proxy answers for; a .invalid TLD never resolves (RFC 6761),
 # so a locally-resolving client could not reach us -- success proves remote DNS.


### PR DESCRIPTION
The three test servers import `proxytestlib` from their own directory, which works because Python puts the running script's directory on `sys.path`. `PYTHONSAFEPATH` (`python3 -P`) drops it and the import fails. Nothing in the harness or CI sets it, and the failure is loud rather than a silent skip, so this is belt-and-braces for anyone running a server by hand under `-P`.

Each server now inserts its own directory before the import. Verified by reproducing the `ModuleNotFoundError` on master first, then confirming all three announce `ready` under `-P` afterwards. No file in `tests/` shadows a stdlib module, so the extra `sys.path` entry is inert in the normal case. Full suite unchanged at 102 pass / 7 skip.
