### PR TITLE
Untrack the local CLAUDE.local.md symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ Makefile
 
 # Python bytecode (tests/local-server.py).
 __pycache__/
+
+# Per-checkout Claude Code rules (symlink into a local sandbox).
+/CLAUDE.local.md

--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -1,1 +1,0 @@
-/home/roche/git/httrack-works/CLAUDE.httrack.local.md


### PR DESCRIPTION
`CLAUDE.local.md` is a symlink into my home directory that got committed by accident in #556, so a fresh clone ends up with a dangling symlink and the repo publishes my local paths for no reason. Its own first line calls it "Local, untracked guidance for this checkout", so it was never meant to be in git.

Untrack it and ignore it, the way coucal and httrack-windows already do. `CLAUDE.md` and `AGENTS.md` stay tracked: those are the contributor instructions and are meant to be shared.