### PR TITLE
AGENTS.md and CONTRIBUTING.md still describe merge commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,9 @@ Before pushing, and when reviewing others, don't skim for bugs:
 - **Co-Authored-By is mandatory for AI-assisted commits.** Carry a
   `Co-Authored-By:` trailer naming the assistant. Attribute there, never in a
   PR-body footer.
-- PRs land as a merge commit; every commit on the branch goes onto master, so
-  keep each commit message clean and meaningful.
+- PRs are squash-merged: one commit per PR lands on master, built from the PR
+  title and description, so those are what the history keeps. The branch's
+  intermediate commits are not preserved.
 
 ## PR descriptions
 - Plain concise prose; lead with what changed and why. No What/Why/How template.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ with an AI assistant? The operational checklist is [AGENTS.md](AGENTS.md).
 ## Pull requests
 
 - One change per PR. Small diffs merge fast.
-- PRs land as a merge commit, so the branch's commits go onto master as-is: keep
-  each commit message clean and explain *why*.
+- PRs are squash-merged: one commit per PR goes onto master, built from the PR
+  title and description, so those are the history. Explain *why* there.
 - Be terse in the PR title and description: name the problem, not the fix, don't
   restate the diff, and calibrate length to the change.
 - Add or update tests for engine changes (`tests/`), and keep CI green.


### PR DESCRIPTION
Both files say PRs land as a merge commit and tell you to keep every commit message clean because the branch goes onto master as-is. That was true through June, but master switched to squash at the end of it: July is 113 squashes against one merge commit. Under squash the branch's commits are dropped and the PR title and description become the commit, so the advice was aimed at the wrong text.

Says squash in both places, and points the *why* at the PR description where it now lands.