### PR TITLE
An out-of-range -P proxy port parses to a garbage port instead of being rejected

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -3748,7 +3748,7 @@ static int proxy_default_port(const char *arg) {
   return hts_proxy_is_socks(arg) ? 1080 : 8080;
 }
 
-// port "a" of -P argument "arg": *DIGIT in 1..65535 (RFC3986), else the scheme
+// port "a" of -P argument "arg": digits fitting TCP's 1..65535, else the scheme
 // default. Not sscanf("%d"): past INT_MAX it wraps to a garbage port (#602)
 static int parse_proxy_port(const char *a, const char *arg) {
   char *end;

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -65,6 +65,7 @@ Please visit our Website: http://www.httrack.com
 #endif /* _WIN32 */
 #include <stdarg.h>
 
+#include <ctype.h>
 #include <string.h>
 #include <time.h>
 #include <stdarg.h>
@@ -3747,6 +3748,20 @@ static int proxy_default_port(const char *arg) {
   return hts_proxy_is_socks(arg) ? 1080 : 8080;
 }
 
+// port "a" of -P argument "arg": *DIGIT in 1..65535 (RFC3986), else the scheme
+// default. Not sscanf("%d"): past INT_MAX it wraps to a garbage port (#602)
+static int parse_proxy_port(const char *a, const char *arg) {
+  char *end;
+  long p;
+
+  if (!isdigit((unsigned char) *a)) // strtol would eat a sign or leading space
+    return proxy_default_port(arg);
+  p = strtol(a, &end, 10);
+  if (*end != '\0' || p < 1 || p > 65535) // ERANGE lands out of range too
+    return proxy_default_port(arg);
+  return (int) p;
+}
+
 void hts_parse_proxy(const char *arg, char *name, size_t name_size, int *port) {
   const char *authority = strstr(arg, "://");
   const char *a;
@@ -3762,10 +3777,7 @@ void hts_parse_proxy(const char *arg, char *name, size_t name_size, int *port) {
   while (a > authority && a[-1] != ':' && a[-1] != '@' && a[-1] != ']')
     a--;
   if (a > authority && a[-1] == ':') {
-    int p = -1;
-
-    sscanf(a, "%d", &p);
-    *port = (p > 0) ? p : proxy_default_port(arg);
+    *port = parse_proxy_port(a, arg);
     namelen = (size_t) (a - 1 - arg);
   } else {
     *port = proxy_default_port(arg);

--- a/tests/01_engine-proxyurl.test
+++ b/tests/01_engine-proxyurl.test
@@ -71,3 +71,23 @@ p 'http://a]b:c@host' 'name=http://a]b:c@host port=8080 host=host kind=http'
 
 # a lone ':' must not underflow the backward scan
 p ':' 'name= port=8080 host= kind=http'
+
+# a port is *DIGIT in 1..65535, else the scheme default: sscanf("%d") used to
+# wrap past INT_MAX and hand back a garbage port (#602)
+p 'http://host:65535' 'name=http://host port=65535 host=host kind=http'
+p 'http://host:1' 'name=http://host port=1 host=host kind=http'
+p 'http://host:65536' 'name=http://host port=8080 host=host kind=http'
+p 'http://host:2147483648' 'name=http://host port=8080 host=host kind=http'
+p 'http://host:4294967296' 'name=http://host port=8080 host=host kind=http'
+p 'http://host:99999999999999' 'name=http://host port=8080 host=host kind=http'
+# discriminating: this one wrapped to a plausible 80, so range-checking the
+# sscanf result instead of rejecting the overflow still passes everything above
+p 'http://host:4294967376' 'name=http://host port=8080 host=host kind=http'
+p 'http://host:999999999999999999999999999999' 'name=http://host port=8080 host=host kind=http'
+p 'http://host:0' 'name=http://host port=8080 host=host kind=http'
+p 'http://host:-1' 'name=http://host port=8080 host=host kind=http'
+p 'http://host:80x' 'name=http://host port=8080 host=host kind=http'
+p 'http://host: 80' 'name=http://host port=8080 host=host kind=http'
+p 'http://host:' 'name=http://host port=8080 host=host kind=http'
+# the fallback is the scheme's own default, not a hardcoded 8080
+p 'socks5://host:99999999999999' 'name=socks5://host port=1080 host=host kind=socks'


### PR DESCRIPTION
`hts_parse_proxy` read the proxy port with `sscanf(a, "%d", &p)`. A value that doesn't fit an `int` is undefined behavior there (C11 7.21.6.2p10), and glibc wraps instead of failing, so `-P 'http://host:99999999999999'` connected to port 276447231 while `-P 'http://host:4294967296'` happened to fail and fall back to the default. 65536 was taken at face value. The port now goes through strtol with a 1..65535 range check, so anything out of range or malformed falls back to `proxy_default_port`, exactly as an unparsable port already did. RFC 3986 allows any digit string; the 1..65535 bound is TCP's 16-bit port field.

Two smaller behavior changes come with it, both reachable only from a malformed `-P`. A port with trailing garbage is now rejected, so `-P 'host:80x'` defaults instead of silently connecting to 80. A leading `+` or space is rejected too. A leading `-` already was.

The self-test covers the range fence and the overflow values from the issue, plus `4294967376`. That one wraps to a plausible port 80, so it catches a fix that range-checks the sscanf result instead of rejecting the overflow. Six of the fourteen cases discriminate against a buggy build: the fence on both sides, trailing garbage, leading space, the socks5 default, and `4294967376`. The rest already pass on master and pin the behavior.

Closes #602