### PR TITLE
Stalled TLS handshake ignores --timeout

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -2816,6 +2816,9 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                 if (SSL_set_fd(back[i].r.ssl_con, (int) back[i].r.soc) == 1) {
                   SSL_set_connect_state(back[i].r.ssl_con);
                   back[i].status = STATUS_SSL_WAIT_HANDSHAKE;   /* handshake wait */
+                  // the handshake gets its own timeout window, as connect does
+                  if (back[i].timeout > 0)
+                    back[i].timeout_refresh = time_local();
                 } else
                   back[i].r.statuscode = STATUSCODE_SSL_HANDSHAKE;
               } else
@@ -2875,6 +2878,11 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
       }
 #if HTS_USEOPENSSL
       else if (back[i].status == STATUS_SSL_WAIT_HANDSHAKE) {       // wait for SSL handshake
+        // a peer that never speaks TLS must be reaped by --timeout too (#607)
+        if (!gestion_timeout)
+          if (back[i].timeout > 0)
+            gestion_timeout = 1;
+
         /* SSL mode */
         if (back[i].r.ssl) {
           int conn_code;
@@ -4265,6 +4273,8 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                 strcpybuff(back[i].r.msg, "Connect Time Out");
               else if (back[i].status == STATUS_WAIT_DNS)
                 strcpybuff(back[i].r.msg, "DNS Time Out");
+              else if (back[i].status == STATUS_SSL_WAIT_HANDSHAKE)
+                strcpybuff(back[i].r.msg, "SSL/TLS Handshake Time Out");
               else
                 strcpybuff(back[i].r.msg, "Receive Time Out");
               back[i].status = STATUS_READY;    // terminé

--- a/tests/59_local-tls-stall.test
+++ b/tests/59_local-tls-stall.test
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# Issue #607: a peer that accepts the TCP connect but never speaks TLS leaves the
+# slot stuck in the handshake. The per-slot --timeout must reap it; before the
+# fix only --max-time did, so this crawl ran until the kill guard.
+
+set -euo pipefail
+
+: "${top_srcdir:=..}"
+
+# shellcheck source=tests/testlib.sh
+. "$top_srcdir/tests/testlib.sh"
+
+if test "${HTTPS_SUPPORT:-}" == "no"; then
+    echo "no https support compiled, skipping"
+    exit 77
+fi
+python=$(find_python) || {
+    echo "python3 missing, skipping"
+    exit 77
+}
+
+server=$(nativepath "$top_srcdir/tests/tls-stall-server.py")
+tmpdir=$(mktemp -d)
+serverpid=
+
+cleanup() {
+    stop_server "$serverpid"
+    rm -rf "$tmpdir"
+    return 0
+}
+trap cleanup EXIT
+
+"$python" "$server" >"$tmpdir/srv.out" 2>"$tmpdir/srv.err" &
+serverpid=$!
+port=
+for _ in $(seq 1 50); do
+    line=$(head -n1 "$tmpdir/srv.out" 2>/dev/null || true)
+    if test "${line%% *}" == "PORT"; then
+        port="${line#PORT }"
+        break
+    fi
+    kill -0 "$serverpid" 2>/dev/null || {
+        echo "server exited early: $(cat "$tmpdir/srv.err")"
+        exit 1
+    }
+    sleep 0.1
+done
+test -n "$port" || {
+    echo "could not discover server port"
+    exit 1
+}
+
+# no -E/--max-time on purpose: --timeout is the only thing that can end this.
+out="$tmpdir/crawl"
+start=$(date +%s)
+rc=0
+run_with_timeout 45 httrack "https://127.0.0.1:$port/" -O "$out" -c1 \
+    --robots=0 --timeout=3 --retries=0 --quiet -Z >"$tmpdir/log" 2>&1 || rc=$?
+wall=$(($(date +%s) - start))
+
+if test "$wall" -ge 30; then
+    echo "crawl took ${wall}s (rc=$rc): --timeout did not reap the stalled handshake" >&2
+    cat "$tmpdir/log" >&2
+    exit 1
+fi
+grep -q 'Handshake Time Out' "$out/hts-log.txt" || {
+    echo "crawl ended in ${wall}s but not on a handshake timeout" >&2
+    cat "$out/hts-log.txt" >&2
+    exit 1
+}
+echo "OK: stalled TLS handshake reaped by --timeout after ${wall}s"

--- a/tests/59_local-tls-stall.test
+++ b/tests/59_local-tls-stall.test
@@ -2,7 +2,7 @@
 #
 # Issue #607: a peer that accepts the TCP connect but never speaks TLS leaves the
 # slot stuck in the handshake. The per-slot --timeout must reap it; before the
-# fix only --max-time did, so this crawl ran until the kill guard.
+# fix only --max-time did, so these crawls ran until the kill guard.
 
 set -euo pipefail
 
@@ -31,42 +31,65 @@ cleanup() {
 }
 trap cleanup EXIT
 
-"$python" "$server" >"$tmpdir/srv.out" 2>"$tmpdir/srv.err" &
-serverpid=$!
-port=
-for _ in $(seq 1 50); do
-    line=$(head -n1 "$tmpdir/srv.out" 2>/dev/null || true)
-    if test "${line%% *}" == "PORT"; then
-        port="${line#PORT }"
-        break
-    fi
-    kill -0 "$serverpid" 2>/dev/null || {
-        echo "server exited early: $(cat "$tmpdir/srv.err")"
-        exit 1
-    }
-    sleep 0.1
-done
-test -n "$port" || {
+# start_stall_server <tag> <mode-args...>: sets $port from the announced one.
+start_stall_server() {
+    local tag="$1"
+    shift
+    "$python" "$server" "$@" >"$tmpdir/$tag.out" 2>"$tmpdir/$tag.err" &
+    serverpid=$!
+    port=
+    for _ in $(seq 1 50); do
+        line=$(head -n1 "$tmpdir/$tag.out" 2>/dev/null || true)
+        if test "${line%% *}" == "PORT"; then
+            port="${line#PORT }"
+            return 0
+        fi
+        kill -0 "$serverpid" 2>/dev/null || {
+            echo "server exited early: $(cat "$tmpdir/$tag.err")"
+            exit 1
+        }
+        sleep 0.1
+    done
     echo "could not discover server port"
     exit 1
 }
 
-# no -E/--max-time on purpose: --timeout is the only thing that can end this.
-out="$tmpdir/crawl"
-start=$(date +%s)
-rc=0
-run_with_timeout 45 httrack "https://127.0.0.1:$port/" -O "$out" -c1 \
-    --robots=0 --timeout=3 --retries=0 --quiet -Z >"$tmpdir/log" 2>&1 || rc=$?
-wall=$(($(date +%s) - start))
+# no -E/--max-time on purpose: --timeout is the only thing that can end these.
+# The kill guard stands in for the hang, so a wall time near it means no reap.
+crawl_wall() {
+    local out="$tmpdir/$1"
+    shift
+    local start
+    start=$(date +%s)
+    run_with_timeout 60 httrack -O "$out" -c1 --robots=0 --retries=0 --quiet -Z \
+        "$@" >>"$tmpdir/log" 2>&1 || true
+    echo $(($(date +%s) - start))
+}
 
-if test "$wall" -ge 30; then
-    echo "crawl took ${wall}s (rc=$rc): --timeout did not reap the stalled handshake" >&2
+# 1. handshake stalled from the first byte: reaped at --timeout, not before.
+start_stall_server direct direct
+wall=$(crawl_wall crawl1 "https://127.0.0.1:$port/" --timeout=5)
+if test "$wall" -ge 30 || test "$wall" -lt 3; then
+    echo "FAIL: stalled handshake reaped after ${wall}s, expected about 5s" >&2
     cat "$tmpdir/log" >&2
     exit 1
 fi
-grep -q 'Handshake Time Out' "$out/hts-log.txt" || {
-    echo "crawl ended in ${wall}s but not on a handshake timeout" >&2
-    cat "$out/hts-log.txt" >&2
+grep -q 'Handshake Time Out' "$tmpdir/crawl1/hts-log.txt" || {
+    echo "FAIL: crawl ended in ${wall}s but not on a handshake timeout" >&2
+    cat "$tmpdir/crawl1/hts-log.txt" >&2
     exit 1
 }
 echo "OK: stalled TLS handshake reaped by --timeout after ${wall}s"
+
+# 2. the handshake window is its own, not what the connect left over: a proxy
+# that takes 4s to answer CONNECT must still leave the full --timeout=5 for the
+# handshake (~9s total). Sharing the connect's clock would reap at ~5s.
+stop_server "$serverpid"
+start_stall_server proxy proxy 4
+wall=$(crawl_wall crawl2 "https://127.0.0.1:443/" -P "127.0.0.1:$port" --timeout=5)
+if test "$wall" -ge 20 || test "$wall" -lt 7; then
+    echo "FAIL: handshake after a slow connect reaped at ${wall}s, expected about 9s" >&2
+    cat "$tmpdir/log" >&2
+    exit 1
+fi
+echo "OK: handshake keeps its own timeout window after a slow connect (${wall}s)"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,7 +3,7 @@
 # silently drop it from the dist tarball and break "make distcheck".
 EXTRA_DIST = $(TESTS) crawl-test.sh run-all-tests.sh check-network.sh \
 	proxy-https-server.py socks5-server.py proxy-connect-server.py \
-	proxytestlib.py \
+	proxytestlib.py tls-stall-server.py \
 	local-crawl.sh local-server.py testlib.sh server.crt server.key \
 	server-root/simple/basic.html server-root/simple/link.html \
 	server-root/stripquery/index.html server-root/stripquery/a.html \
@@ -136,6 +136,7 @@ TESTS = \
 	55_local-chunked.test \
 	56_local-proxy-noleak.test \
 	57_local-proxy-connect.test \
-	58_watchdog.test
+	58_watchdog.test \
+	59_local-tls-stall.test
 
 CLEANFILES = check-network_sh.cache

--- a/tests/proxytestlib.py
+++ b/tests/proxytestlib.py
@@ -18,6 +18,15 @@ PROXY_LOG = "proxy.log"
 ORIGIN_LOG = "origin-headers.log"
 
 
+def bind_ephemeral():
+    """Listening socket on a free loopback port, and that port."""
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(16)
+    return srv, srv.getsockname()[1]
+
+
 def pipe(src, dst):
     """Relay bytes one way until EOF, then tear both ends down."""
     try:
@@ -113,11 +122,7 @@ def handle_client(conn, logdir, mode, default_port):
 
 
 def start_proxy(logdir, mode, default_port):
-    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    srv.bind(("127.0.0.1", 0))
-    srv.listen(16)
-    port = srv.getsockname()[1]
+    srv, port = bind_ephemeral()
 
     def accept_loop():
         while True:

--- a/tests/socks5-server.py
+++ b/tests/socks5-server.py
@@ -19,7 +19,7 @@ import threading
 # python3 -P (PYTHONSAFEPATH) drops the script's own directory from sys.path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from proxytestlib import pipe  # noqa: E402
+from proxytestlib import bind_ephemeral, pipe  # noqa: E402
 
 # The one name the proxy answers for; a .invalid TLD never resolves (RFC 6761),
 # so a locally-resolving client could not reach us -- success proves remote DNS.
@@ -180,11 +180,7 @@ def handle_socks(conn, logdir, mode):
 
 
 def start_socks(logdir, mode):
-    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    srv.bind(("127.0.0.1", 0))
-    srv.listen(16)
-    port = srv.getsockname()[1]
+    srv, port = bind_ephemeral()
 
     def serve():
         while True:

--- a/tests/tls-stall-server.py
+++ b/tests/tls-stall-server.py
@@ -1,18 +1,43 @@
 #!/usr/bin/env python3
-"""Accept TCP connections on an ephemeral port and never speak TLS (#607).
+"""Peers that accept a connection and never speak TLS (#607).
 
-Prints "PORT <n>" once listening. Connections are held open and silent, so a
-client's TLS handshake stalls until its own timeout reaps it.
+Modes: "direct" stalls the handshake straight away; "proxy <secs>" answers a
+CONNECT after <secs> before stalling, so the handshake starts on a clock the
+connect has already eaten into. Prints "PORT <n>" once listening.
+Usage: tls-stall-server.py [direct | proxy <secs>]
 """
-import socket
+import os
+import sys
+import threading
+import time
 
-srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-srv.bind(("127.0.0.1", 0))
-srv.listen(16)
-print("PORT %d" % srv.getsockname()[1], flush=True)
+# python3 -P (PYTHONSAFEPATH) drops the script's own directory from sys.path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-held = []
-while True:
-    conn, _ = srv.accept()
-    held.append(conn)  # keep it open: a closed socket would fail the handshake
+from proxytestlib import bind_ephemeral  # noqa: E402
+
+held = []  # keep every socket open: a close would fail the handshake outright
+
+
+def stall(conn, delay):
+    if delay is not None:
+        rfile = conn.makefile("rb")
+        while rfile.readline() not in (b"\r\n", b"\n", b""):
+            pass
+        time.sleep(delay)
+        conn.sendall(b"HTTP/1.0 200 Connection established\r\n\r\n")
+    held.append(conn)
+
+
+def main():
+    mode = sys.argv[1] if len(sys.argv) > 1 else "direct"
+    delay = float(sys.argv[2]) if mode == "proxy" else None
+    srv, port = bind_ephemeral()
+    sys.stdout.reconfigure(newline="\n")  # Windows would emit \r\n
+    print("PORT %d" % port, flush=True)
+    while True:
+        conn, _ = srv.accept()
+        threading.Thread(target=stall, args=(conn, delay), daemon=True).start()
+
+
+main()

--- a/tests/tls-stall-server.py
+++ b/tests/tls-stall-server.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Accept TCP connections on an ephemeral port and never speak TLS (#607).
+
+Prints "PORT <n>" once listening. Connections are held open and silent, so a
+client's TLS handshake stalls until its own timeout reaps it.
+"""
+import socket
+
+srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+srv.bind(("127.0.0.1", 0))
+srv.listen(16)
+print("PORT %d" % srv.getsockname()[1], flush=True)
+
+held = []
+while True:
+    conn, _ = srv.accept()
+    held.append(conn)  # keep it open: a closed socket would fail the handshake


### PR DESCRIPTION
In a single-connection crawl, a connection stuck in the TLS handshake was only ever reaped by `--max-time`. `back_wait` runs its per-slot timeout check only when the local `gestion_timeout` flag is armed, and the `STATUS_SSL_WAIT_HANDSHAKE` handler never armed it, so against a peer that completes the TCP connect and then says nothing, `SSL_connect` kept returning WANT_READ and `--timeout` was ignored. The flag is per-pass and armed by any slot, so a busier crawl would already reap such a slot, but on the connect's clock rather than the handshake's. This arms the flag there, and starts a fresh window when the slot enters the handshake so that a handshake reached through a slow connect still gets its full `--timeout` rather than whatever the connect left over. The generic reaper already handles any `status > 0` slot once armed; it now names this case instead of reporting "Receive Time Out".

Test 59 crawls a peer that accepts the connect and stays silent, first directly and then behind a proxy that takes 4s to answer CONNECT. Both cases are bounded above and below: the direct one must end at `--timeout` and not instantly, and the proxied one must take about 9s, since sharing the connect's clock reaps it at ~5s. Checked by mutation, since either half of the fix is invisible to the obvious test: dropping the refresh, collapsing the window to zero, and reverting the arm each fail a case that passes with the fix intact.

Closes #607