### PR TITLE
Do not mistake -%i and -@i for the -i continue flag

### DIFF
--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -307,10 +307,10 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
             } else {
               if (strncmp(tmp_argv[0], "--", 2)) { /* not a long option */
                 if (cmdl_shortopt_has(tmp_argv[0], 'q'))
-                  opt->quiet = 1; // do not ask any question (nohup, etc.)
+                  opt->quiet = HTS_TRUE; // never ask questions (nohup)
                 if (cmdl_shortopt_has(tmp_argv[0], 'i')) { // doit.log!
                   argv_url = -1;
-                  opt->quiet = 1;
+                  opt->quiet = HTS_TRUE;
                 }
               } else if (strcmp(tmp_argv[0] + 2, "quiet") == 0) {
                 opt->quiet = 1; // ne pas poser de questions! (nohup par exemple)
@@ -2808,12 +2808,30 @@ int check_path(String * s, char *defaultname) {
   return return_value;
 }
 
-/* Does the plain short-option cluster s (-i, -iC2, -qg) carry flag c?
-   -%i, -@i and -#i are options in their own right, not clusters of flags. */
+/* Does the short-option cluster s carry c from the main option set (-i, -iC2,
+   -%Mi)? Walked as the parser does below: %, &, @ and # each take the letter
+   after them into another set, so the i of -%i is not the main-set -i. */
 static hts_boolean cmdl_shortopt_has(const char *s, char c) {
-  if (s[0] != '-' || s[1] == '-' || s[1] == '%' || s[1] == '@' || s[1] == '#')
+  const char *com;
+
+  if (s[0] != '-' || s[1] == '-')
     return HTS_FALSE;
-  return strchr(s + 1, c) != NULL;
+  for (com = s + 1; *com != '\0'; com++) {
+    switch (*com) {
+    case '%':
+    case '&':
+    case '@':
+    case '#':
+      if (*(com + 1) != '\0')
+        com++; /* skip the other set's letter */
+      break;
+    default:
+      if (*com == c)
+        return HTS_TRUE;
+      break;
+    }
+  }
+  return HTS_FALSE;
 }
 
 // détermine si l'argument est une option

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -113,6 +113,7 @@ HTSEXT_API int hts_main(int argc, char **argv) {
 }
 
 static int hts_main_internal(int argc, char **argv, httrackp * opt);
+static hts_boolean cmdl_shortopt_has(const char *s, char c);
 
 // Main, récupère les paramètres et appelle le robot
 HTSEXT_API int hts_main2(int argc, char **argv, httrackp * opt) {
@@ -304,11 +305,11 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                      hts_get_version_info(opt));
               return 0;
             } else {
-              if (strncmp(tmp_argv[0], "--", 2)) {      /* pas */
-                if ((strchr(tmp_argv[0], 'q') != NULL))
-                  opt->quiet = 1;       // ne pas poser de questions! (nohup par exemple)
-                if ((strchr(tmp_argv[0], 'i') != NULL)) {       // doit.log!
-                  argv_url = -1;        /* forcer */
+              if (strncmp(tmp_argv[0], "--", 2)) { /* not a long option */
+                if (cmdl_shortopt_has(tmp_argv[0], 'q'))
+                  opt->quiet = 1; // do not ask any question (nohup, etc.)
+                if (cmdl_shortopt_has(tmp_argv[0], 'i')) { // doit.log!
+                  argv_url = -1;
                   opt->quiet = 1;
                 }
               } else if (strcmp(tmp_argv[0] + 2, "quiet") == 0) {
@@ -2805,6 +2806,14 @@ int check_path(String * s, char *defaultname) {
     StringCat(*s, "/");
 
   return return_value;
+}
+
+/* Does the plain short-option cluster s (-i, -iC2, -qg) carry flag c?
+   -%i, -@i and -#i are options in their own right, not clusters of flags. */
+static hts_boolean cmdl_shortopt_has(const char *s, char c) {
+  if (s[0] != '-' || s[1] == '-' || s[1] == '%' || s[1] == '@' || s[1] == '#')
+    return HTS_FALSE;
+  return strchr(s + 1, c) != NULL;
 }
 
 // détermine si l'argument est une option

--- a/tests/01_engine-cmdline.test
+++ b/tests/01_engine-cmdline.test
@@ -102,4 +102,38 @@ for bad in nan nan:5 5:nan inf 10:5 99999; do
     refused "#185: invalid --pause '$bad' not refused cleanly"
 done
 
+# An option is not -i (continue) merely because its name contains an 'i' (#615).
+# These used to wipe the URL given before them and exit on the usage screen.
+run "$tmp/ord-bti" --build-top-index
+accepted "$tmp/ord-bti" "#615: --build-top-index after the URL wiped the URL list"
+run "$tmp/ord-bti-s" "-%i"
+accepted "$tmp/ord-bti-s" "#615: -%i after the URL wiped the URL list"
+run "$tmp/ord-proto" --protocol 2
+accepted "$tmp/ord-proto" "#615: --protocol after the URL wiped the URL list"
+run "$tmp/ord-proto-s" "-@i2"
+accepted "$tmp/ord-proto-s" "#615: -@i2 after the URL wiped the URL list"
+
+# -%q trips the same defect on the neighbouring 'q' test, which only forces
+# quiet mode; the quiet flag itself is not observable here, so just check the
+# crawl still runs.
+run "$tmp/ord-iqs" "-%q"
+accepted "$tmp/ord-iqs" "#615: -%q after the URL broke the crawl"
+
+# The real -i still forces continue mode and drops the URL list, in every form:
+# a fix that merely stopped looking for 'i' would pass the checks above.
+run "$tmp/cont-s" -i
+refused "#615: -i after the URL no longer forces continue mode"
+run "$tmp/cont-c" -iC2
+refused "#615: -iC2 after the URL no longer forces continue mode"
+run "$tmp/cont-l" --continue
+refused "#615: --continue after the URL no longer forces continue mode"
+run "$tmp/cont-u" --update
+refused "#615: --update after the URL no longer forces continue mode"
+
+# Placed before the URL these always worked; they must keep working.
+run_only "$tmp/pre-bti" "-%i" "file://$tmp/index.html"
+accepted "$tmp/pre-bti" "#615: -%i before the URL broke the crawl"
+run_only "$tmp/pre-proto" "-@i2" "file://$tmp/index.html"
+accepted "$tmp/pre-proto" "#615: -@i2 before the URL broke the crawl"
+
 exit 0

--- a/tests/01_engine-cmdline.test
+++ b/tests/01_engine-cmdline.test
@@ -54,6 +54,13 @@ refused() {
         ! echo "FAIL: $1 (exit $RC)" || exit 1
 }
 
+# assert continue mode was entered: it drops the URL list, so with no cache to
+# resume the run ends on the usage screen rather than on any other error
+continued() {
+    { test "$RC" -ne 0 && grep -q 'usage:' "$1/.log"; } ||
+        ! echo "FAIL: $2 (exit $RC)" || exit 1
+}
+
 # a value past the old 126/256 caps but within the cap is accepted, on both the
 # short and long form of each option
 long=$(nchars 900)
@@ -113,22 +120,34 @@ accepted "$tmp/ord-proto" "#615: --protocol after the URL wiped the URL list"
 run "$tmp/ord-proto-s" "-@i2"
 accepted "$tmp/ord-proto-s" "#615: -@i2 after the URL wiped the URL list"
 
-# -%q trips the same defect on the neighbouring 'q' test, which only forces
-# quiet mode; the quiet flag itself is not observable here, so just check the
-# crawl still runs.
+# %, &, @ and # take the letter after them into another option set, wherever
+# they sit in the cluster, so the i of -q%i is not the main-set -i either.
+run "$tmp/ord-qpi" "-q%i"
+accepted "$tmp/ord-qpi" "#615: -q%i after the URL wiped the URL list"
+run "$tmp/ord-qai" "-q@i"
+accepted "$tmp/ord-qai" "#615: -q@i after the URL wiped the URL list"
+
+# -%q only forces quiet mode, which nothing here can see: a run whose stdout is
+# not a tty is quiet from the start (htscoremain.c:174). Just check it crawls.
 run "$tmp/ord-iqs" "-%q"
 accepted "$tmp/ord-iqs" "#615: -%q after the URL broke the crawl"
 
 # The real -i still forces continue mode and drops the URL list, in every form:
 # a fix that merely stopped looking for 'i' would pass the checks above.
 run "$tmp/cont-s" -i
-refused "#615: -i after the URL no longer forces continue mode"
+continued "$tmp/cont-s" "#615: -i after the URL no longer forces continue mode"
 run "$tmp/cont-c" -iC2
-refused "#615: -iC2 after the URL no longer forces continue mode"
+continued "$tmp/cont-c" "#615: -iC2 after the URL no longer forces continue mode"
 run "$tmp/cont-l" --continue
-refused "#615: --continue after the URL no longer forces continue mode"
+continued "$tmp/cont-l" "#615: --continue after the URL no longer forces continue mode"
 run "$tmp/cont-u" --update
-refused "#615: --update after the URL no longer forces continue mode"
+continued "$tmp/cont-u" "#615: --update after the URL no longer forces continue mode"
+
+# ...including where another set's letter precedes it in the cluster.
+run "$tmp/cont-pq" "-%qi"
+continued "$tmp/cont-pq" "#615: -%qi after the URL no longer forces continue mode"
+run "$tmp/cont-pm" "-%Mi"
+continued "$tmp/cont-pm" "#615: -%Mi after the URL no longer forces continue mode"
 
 # Placed before the URL these always worked; they must keep working.
 run_only "$tmp/pre-bti" "-%i" "file://$tmp/index.html"


### PR DESCRIPTION
`httrack <URL> --build-top-index` exits 255 on the usage screen instead of crawling. The pass in `htscoremain.c` that counts URLs also detects `-i` (continue), and it looked for a bare `i` with `strchr()` on anything `cmdl_opt()` calls an option. That test runs after `optalias_check()` has expanded the long aliases, so `--build-top-index` (`-%i`) and `--protocol N` (`-@iN`) matched the letter and wiped the URL list. The neighbouring `strchr(..., 'q')` has the same flaw, where `-%q` / `--include-query-string` quietly forces quiet mode.

The flag is now found by walking the cluster the way the parser does (`htscoremain.c:948`): `%`, `&`, `@` and `#` each take the letter after them into another option set, whatever their position, so the `i` of `-%i` is not the main-set `-i` while the one in `-%Mi` still is. `&` is on that list because the `-&` to `-%` rewrite only fires at position 0, leaving `-q&i` to reach the parser as-is. Testing the second character alone was not enough: it dropped continue mode for `-%qi` and `-%Mi` and left `-q%i` on the usage screen. No documented option or alias reaches those spellings, since they all put the prefix first, but the helper agrees with the parser now. `-i`, `-iC1`, `-iC2`, `--continue` and `--update` keep forcing continue and dropping the URL list exactly as they do today.

I went through the alias table rather than patching the two spellings I had: `-i`, `-iC1` and `-iC2` are the intended matches, `-%i` and `-@i` the broken ones. The rule only runs one way, `argv_url = -1` when the user asked to continue. The reverse has never held and still does not, because `cmdl_opt()`'s heuristic hands a filter like `-imagedir` to the same branch. Filters carrying a `.`, `/` or `*` were never in scope.

Tests go in the existing offline `01_engine-cmdline.test`. Six cases fail on master and pass here, and the continue guards look for the usage screen rather than any nonzero exit, so they show continue mode was actually entered. They discriminate in both directions: the second-character helper fails four of them, `-q%i` and `-q@i` for the bug plus `-%qi` and `-%Mi` for the regression, and mutating the helper to always return false fires the `-i` guard. The `-%q` case has no teeth and I left it labelled that way. A run whose stdout is not a tty is forced quiet before argv parsing (`htscoremain.c:174`), so the suite cannot see that flag at all. I checked that half under a pty instead, where master `-%q` prints usage and this branch opens the wizard, with `-q` and `-%g0` as controls.

Closes #615
