### PR TITLE
~/ in the -O base path has never been expanded

### DIFF
--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -572,20 +572,21 @@ int optinclude_file(const char *name, int *argc, char **argv, char *x_argvblk,
 const char *hts_gethome(void) {
   const char *home = getenv("HOME");
 
-  /* An empty $HOME would expand ~/foo into the absolute /foo */
+  /* An empty $HOME is no better than an unset one: it would expand ~/foo into
+     the absolute /foo. */
   return strnotempty(home) ? home : ".";
 }
 
 /* Convert ~/foo into /home/smith/foo (~user/ left alone: no getpwnam here) */
 void expand_home(String * str) {
-  if (StringNotEmpty(*str) && StringSub(*str, 0) == '~' &&
-      (StringLength(*str) == 1 || StringSub(*str, 1) == '/')) {
+  if (StringNotEmpty(*str) && StringSub(*str, 0) == '~'
+      && (StringLength(*str) == 1 || StringSub(*str, 1) == '/')) {
     char BIGSTK tempo[HTS_URLMAXSIZE * 2];
     const char *const home = hts_gethome();
     const size_t homelen = strlen(home);
     const size_t taillen = StringLength(*str) - 1;
 
-    /* Leave untouched rather than abort() in strcatbuff on a huge $HOME */
+    /* Leave untouched rather than let strcatbuff abort() on an oversized $HOME */
     if (taillen < sizeof(tempo) && homelen < sizeof(tempo) - taillen) {
       strcpybuff(tempo, home);
       strcatbuff(tempo, StringBuff(*str) + 1);

--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -567,24 +567,29 @@ int optinclude_file(const char *name, int *argc, char **argv, char *x_argvblk,
   return 0;
 }
 
-/* Get home directory, '.' if failed */
+/* Get home directory, '.' if unset or empty */
 /* example: /home/smith */
 const char *hts_gethome(void) {
   const char *home = getenv("HOME");
 
-  if (home)
-    return home;
-  else
-    return ".";
+  /* An empty $HOME would expand ~/foo into the absolute /foo */
+  return strnotempty(home) ? home : ".";
 }
 
-/* Convert ~/foo into /home/smith/foo */
+/* Convert ~/foo into /home/smith/foo (~user/ left alone: no getpwnam here) */
 void expand_home(String * str) {
-  if (StringSub(*str, 1) == '~') {
+  if (StringNotEmpty(*str) && StringSub(*str, 0) == '~' &&
+      (StringLength(*str) == 1 || StringSub(*str, 1) == '/')) {
     char BIGSTK tempo[HTS_URLMAXSIZE * 2];
+    const char *const home = hts_gethome();
+    const size_t homelen = strlen(home);
+    const size_t taillen = StringLength(*str) - 1;
 
-    strcpybuff(tempo, hts_gethome());
-    strcatbuff(tempo, StringBuff(*str) + 1);
-    StringCopy(*str, tempo);
+    /* Leave untouched rather than abort() in strcatbuff on a huge $HOME */
+    if (taillen < sizeof(tempo) && homelen < sizeof(tempo) - taillen) {
+      strcpybuff(tempo, home);
+      strcatbuff(tempo, StringBuff(*str) + 1);
+      StringCopy(*str, tempo);
+    }
   }
 }

--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -572,21 +572,20 @@ int optinclude_file(const char *name, int *argc, char **argv, char *x_argvblk,
 const char *hts_gethome(void) {
   const char *home = getenv("HOME");
 
-  /* An empty $HOME is no better than an unset one: it would expand ~/foo into
-     the absolute /foo. */
+  /* An empty $HOME would expand ~/foo into the absolute /foo */
   return strnotempty(home) ? home : ".";
 }
 
 /* Convert ~/foo into /home/smith/foo (~user/ left alone: no getpwnam here) */
 void expand_home(String * str) {
-  if (StringNotEmpty(*str) && StringSub(*str, 0) == '~'
-      && (StringLength(*str) == 1 || StringSub(*str, 1) == '/')) {
+  if (StringNotEmpty(*str) && StringSub(*str, 0) == '~' &&
+      (StringLength(*str) == 1 || StringSub(*str, 1) == '/')) {
     char BIGSTK tempo[HTS_URLMAXSIZE * 2];
     const char *const home = hts_gethome();
     const size_t homelen = strlen(home);
     const size_t taillen = StringLength(*str) - 1;
 
-    /* Leave untouched rather than let strcatbuff abort() on an oversized $HOME */
+    /* Leave untouched rather than abort() in strcatbuff on a huge $HOME */
     if (taillen < sizeof(tempo) && homelen < sizeof(tempo) - taillen) {
       strcpybuff(tempo, home);
       strcatbuff(tempo, StringBuff(*str) + 1);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -45,6 +45,7 @@ Please visit our Website: http://www.httrack.com
 #include "htscore.h"
 #include "htsdefines.h"
 #include "htslib.h"
+#include "htsalias.h"
 #include "htsparse.h"
 #include "htscache.h"
 #include "htscache_selftest.h"
@@ -822,6 +823,21 @@ static int st_simplify(httrackp *opt, int argc, char **argv) {
   }
   fil_simplifie(argv[0]);
   printf("simplified=%s\n", argv[0]);
+  return 0;
+}
+
+static int st_expandhome(httrackp *opt, int argc, char **argv) {
+  String path = STRING_EMPTY;
+
+  (void) opt;
+  if (argc < 1) {
+    fprintf(stderr, "expandhome: needs a path\n");
+    return 1;
+  }
+  StringCopy(path, argv[0]);
+  expand_home(&path);
+  printf("expanded=%s\n", StringBuff(path));
+  StringFree(path);
   return 0;
 }
 
@@ -3079,6 +3095,7 @@ static const struct selftest_entry {
     {"filterbounds", "", "matcher length/work caps reject hostile patterns",
      st_filterbounds},
     {"simplify", "<path>", "collapse ./ and ../ in a path", st_simplify},
+    {"expandhome", "<path>", "expand a leading ~/ into $HOME", st_expandhome},
     {"stripquery", "", "--strip-query pattern/key stripping self-test",
      st_stripquery},
     {"urlhack", "", "-%u url-hack sub-flag (www/slash/query) self-test",

--- a/tests/01_engine-expandhome.test
+++ b/tests/01_engine-expandhome.test
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+
+# SC2088: the literal, unexpanded '~' is the input under test.
+# shellcheck disable=SC2088
+
+set -euo pipefail
+
+# ~ expansion for the -O base path (expand_home). $HOME is pinned: the engine
+# reads it, so an inherited one would make these cases pass by accident.
+exp() {
+    test "$(HOME=/home/smith httrack -O /dev/null -#test=expandhome "$1")" == "expanded=$2" || exit 1
+}
+
+exp '~/foo' '/home/smith/foo'
+exp '~/foo/bar/#' '/home/smith/foo/bar/#'
+exp '~' '/home/smith'
+exp '~/' '/home/smith/'
+
+# ~user/ needs getpwnam: left alone rather than mangled into $HOME + "user/"
+exp '~smith/foo' '~smith/foo'
+exp '~root' '~root'
+exp '~/../x' '/home/smith/../x'
+
+# only a leading '~' expands; anything else is a literal path component
+exp 'a~/x' 'a~/x'
+exp './~/x' './~/x'
+exp '/tmp/~/x' '/tmp/~/x'
+exp 'foo~bar' 'foo~bar'
+exp '/plain/path' '/plain/path'
+
+# an unset or empty $HOME must not turn ~/foo into the absolute /foo
+test "$(env -u HOME httrack -O /dev/null -#test=expandhome '~/foo')" == "expanded=./foo" || exit 1
+test "$(HOME='' httrack -O /dev/null -#test=expandhome '~/foo')" == "expanded=./foo" || exit 1

--- a/tests/01_engine-expandhome.test
+++ b/tests/01_engine-expandhome.test
@@ -6,21 +6,22 @@
 
 set -euo pipefail
 
-# ~ expansion for the -O base path (expand_home). $HOME is pinned: the engine
-# reads it, so an inherited one would make these cases pass by accident.
+# ~ expansion for the -O base path (expand_home). $HOME is pinned so a case
+# cannot pass by accident, and has no leading '/': MSYS rewrites a POSIX
+# absolute one into C:\... when spawning the native httrack.exe on Windows.
 exp() {
-    test "$(HOME=/home/smith httrack -O /dev/null -#test=expandhome "$1")" == "expanded=$2" || exit 1
+    test "$(HOME=HTSHOME httrack -O /dev/null -#test=expandhome "$1")" == "expanded=$2" || exit 1
 }
 
-exp '~/foo' '/home/smith/foo'
-exp '~/foo/bar/#' '/home/smith/foo/bar/#'
-exp '~' '/home/smith'
-exp '~/' '/home/smith/'
+exp '~/foo' 'HTSHOME/foo'
+exp '~/foo/bar/#' 'HTSHOME/foo/bar/#'
+exp '~' 'HTSHOME'
+exp '~/' 'HTSHOME/'
 
 # ~user/ needs getpwnam: left alone rather than mangled into $HOME + "user/"
 exp '~smith/foo' '~smith/foo'
 exp '~root' '~root'
-exp '~/../x' '/home/smith/../x'
+exp '~/../x' 'HTSHOME/../x'
 
 # only a leading '~' expands; anything else is a literal path component
 exp 'a~/x' 'a~/x'

--- a/tests/01_engine-expandhome.test
+++ b/tests/01_engine-expandhome.test
@@ -6,29 +6,36 @@
 
 set -euo pipefail
 
-# ~ expansion for the -O base path (expand_home). $HOME is pinned so a case
-# cannot pass by accident, and has no leading '/': MSYS rewrites a POSIX
-# absolute one into C:\... when spawning the native httrack.exe on Windows.
+# ~ expansion for the -O base path (expand_home). $HOME is pinned so the cases
+# cannot depend on the caller's, but MSYS rewrites it into a Windows path
+# before the native httrack.exe reads it: ask the engine what it saw rather
+# than hardcoding the value.
+ask() {
+    HOME=HTSHOME httrack -O /dev/null -#test=expandhome "$1"
+}
 exp() {
-    test "$(HOME=HTSHOME httrack -O /dev/null -#test=expandhome "$1")" == "expanded=$2" || exit 1
+    test "$(ask "$1")" == "expanded=$2" || exit 1
 }
 
-exp '~/foo' 'HTSHOME/foo'
-exp '~/foo/bar/#' 'HTSHOME/foo/bar/#'
-exp '~' 'HTSHOME'
-exp '~/' 'HTSHOME/'
+home=$(ask '~')
+home=${home#expanded=}
+
+# '~' must expand to something else, or every case below is vacuous
+test "$home" != '~' || exit 1
+
+exp '~/foo' "$home/foo"
+exp '~/foo/bar/#' "$home/foo/bar/#"
+exp '~/' "$home/"
+exp '~/../x' "$home/../x"
 
 # ~user/ needs getpwnam: left alone rather than mangled into $HOME + "user/"
 exp '~smith/foo' '~smith/foo'
 exp '~root' '~root'
-exp '~/../x' 'HTSHOME/../x'
 
 # only a leading '~' expands; anything else is a literal path component
 exp 'a~/x' 'a~/x'
 exp './~/x' './~/x'
-exp '/tmp/~/x' '/tmp/~/x'
 exp 'foo~bar' 'foo~bar'
-exp '/plain/path' '/plain/path'
 
 # an unset or empty $HOME must not turn ~/foo into the absolute /foo
 test "$(env -u HOME httrack -O /dev/null -#test=expandhome '~/foo')" == "expanded=./foo" || exit 1

--- a/tests/01_engine-expandhome.test
+++ b/tests/01_engine-expandhome.test
@@ -44,6 +44,7 @@ exp 'foo~bar' 'foo~bar'
 test "$(env -u HOME httrack -O /dev/null -#test=expandhome '~/foo')" == "expanded=./foo" || exit 1
 test "$(HOME='' httrack -O /dev/null -#test=expandhome '~/foo')" == "expanded=./foo" || exit 1
 
-# a $HOME too long for the buffer is left alone: strcatbuff aborts, never truncates
-long=$(printf 'A%.0s' $(seq 1 70000))
+# a $HOME past the 2 * HTS_URLMAXSIZE buffer is left alone: strcatbuff aborts
+# rather than truncates. Stay well under Windows' 32767 environment limit.
+long=$(printf '%04096d' 0 | tr '0' 'A')
 test "$(HOME="$long" httrack -O /dev/null -#test=expandhome '~/foo')" == "expanded=~/foo" || exit 1

--- a/tests/01_engine-expandhome.test
+++ b/tests/01_engine-expandhome.test
@@ -44,7 +44,10 @@ exp 'foo~bar' 'foo~bar'
 test "$(env -u HOME httrack -O /dev/null -#test=expandhome '~/foo')" == "expanded=./foo" || exit 1
 test "$(HOME='' httrack -O /dev/null -#test=expandhome '~/foo')" == "expanded=./foo" || exit 1
 
-# a $HOME past the 2 * HTS_URLMAXSIZE buffer is left alone: strcatbuff aborts
-# rather than truncates. Stay well under Windows' 32767 environment limit.
-long=$(printf '%04096d' 0 | tr '0' 'A')
-test "$(HOME="$long" httrack -O /dev/null -#test=expandhome '~/foo')" == "expanded=~/foo" || exit 1
+# A $HOME past the 2 * HTS_URLMAXSIZE buffer is left alone: strcatbuff aborts
+# rather than truncates. Only meaningful where the engine sees the value we set:
+# MSYS rewrites HOME into a path of its own choosing, long or not.
+if test "$home" = HTSHOME; then
+    long=$(printf '%04096d' 0 | tr '0' 'A')
+    test "$(HOME="$long" httrack -O /dev/null -#test=expandhome '~/foo')" == "expanded=~/foo" || exit 1
+fi

--- a/tests/01_engine-expandhome.test
+++ b/tests/01_engine-expandhome.test
@@ -20,9 +20,12 @@ exp() {
 home=$(ask '~')
 home=${home#expanded=}
 
-# '~' must expand to something else, or every case below is vacuous
+# or every case below is vacuous: '~' means expansion never fired, '.' means it
+# fell back to the default without ever reading $HOME
 test "$home" != '~' || exit 1
+test "$home" != '.' || exit 1
 
+exp '~' "$home"
 exp '~/foo' "$home/foo"
 exp '~/foo/bar/#' "$home/foo/bar/#"
 exp '~/' "$home/"
@@ -40,3 +43,7 @@ exp 'foo~bar' 'foo~bar'
 # an unset or empty $HOME must not turn ~/foo into the absolute /foo
 test "$(env -u HOME httrack -O /dev/null -#test=expandhome '~/foo')" == "expanded=./foo" || exit 1
 test "$(HOME='' httrack -O /dev/null -#test=expandhome '~/foo')" == "expanded=./foo" || exit 1
+
+# a $HOME too long for the buffer is left alone: strcatbuff aborts, never truncates
+long=$(printf 'A%.0s' $(seq 1 70000))
+test "$(HOME="$long" httrack -O /dev/null -#test=expandhome '~/foo')" == "expanded=~/foo" || exit 1

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -59,6 +59,7 @@ TESTS = \
 	01_engine-pause.test \
 	01_engine-rcfile.test \
 	01_engine-reconcile.test \
+	01_engine-expandhome.test \
 	01_engine-fsize.test \
 	01_engine-redirect.test \
 	01_engine-relative.test \


### PR DESCRIPTION
Closes #270

`expand_home()` turns a leading `~/` into `$HOME` for the `-O` base path. It has never run. 660b569 (3.41.2, 2012) refactored it from `char*` to `String` and turned the correct `str[0] == '~'` into `StringSub(*str, 1) == '~'`, while the body below it still skips exactly one leading character. `"~/foo"[1]` is `/`, never `~`, so the guard cannot match. That makes this a dead-code regression rather than a missing feature: the maintainer already decided the behavior in 2012, and the pre-refactor code is the spec.

This changes what an existing path means, after 13 years: `-O '~/foo'` has been creating a literal directory named `~` and now writes to `$HOME/foo`. The behavior is not new, though. `man/httrack.1` documents `path ~/websites/#` under ENVIRONMENT/HOME, and the `path` alias routes `-O` straight into `expand_home`, so anyone relying on the literal `~` was relying on a documented bug.

The dead branch was not inert. Any path whose *second* character is `~` did match, lost its first character and gained `$HOME`: `-O 'a~/corrupt'` produced `/home/smith~/corrupt`.

Indexing from 0 is not enough on its own, because the body prepends `$HOME` and skips only the `~`. That would mangle `~user/foo` into `/home/smithuser/foo`. Resolving `~user` needs `getpwnam`, which this does not do, so the fix gates on a following `/` and leaves `~user/` alone. The same audit turned up two smaller cases. An empty `$HOME` would have expanded `~/foo` to the absolute `/foo`, since `getenv` returns non-NULL and the old "unset" check missed it. An oversized `$HOME` would abort() inside `strcatbuff`, which bounds-checks but does not truncate. Both now leave the path alone or fall back to `.`.

Tested by a new `-#test=expandhome` self-test driven by `tests/01_engine-expandhome.test`, with `HOME` pinned so the cases cannot pass by accident. It fails on master. The `~user/` and `a~/` negatives are what give it teeth: the naive index-0-no-gate variant still passes `~/foo` and `a~/x`, but dies on `~smith/foo` -> `/home/smithsmith/foo`.
