### PR TITLE
An out-of-range port in a crawled URL silently connects to a different port

### DIFF
--- a/src/htsdns_selftest.c
+++ b/src/htsdns_selftest.c
@@ -402,13 +402,11 @@ int dns_selftests(httrackp *opt) {
       deletesoc(s);
   }
 
-  /* A URL's ":port" (port == -1, so newhttp_addr parses it) outside 1..65535
-     must refuse the link, not fold into range and connect elsewhere (#614).
-     *addr_count is the discriminator: 0 only if the port was refused before the
-     resolve, still 2 for one merely truncated or defaulted to 80. */
+  /* A URL port outside 1..65535 must refuse the link, not fold into range and
+     connect elsewhere (#614). *addr_count discriminates: 0 only if refused
+     before the resolve, still 2 for one merely truncated or defaulted. */
   {
-    /* "dual.test:" is an empty port, which WHATWG and curl both accept as
-       meaning the default: it must keep resolving, not be refused as garbage */
+    /* an empty "dual.test:" means the default port (WHATWG, curl): keep it */
     static const char *const good[] = {"dual.test:1",    "dual.test:80",
                                        "dual.test:8080", "dual.test:65535",
                                        "dual.test:080",  "dual.test:"};

--- a/src/htsdns_selftest.c
+++ b/src/htsdns_selftest.c
@@ -407,15 +407,18 @@ int dns_selftests(httrackp *opt) {
      *addr_count is the discriminator: 0 only if the port was refused before the
      resolve, still 2 for one merely truncated or defaulted to 80. */
   {
-    static const char *const good[] = {"dual.test:1", "dual.test:80",
-                                       "dual.test:8080", "dual.test:65535"};
+    /* "dual.test:" is an empty port, which WHATWG and curl both accept as
+       meaning the default: it must keep resolving, not be refused as garbage */
+    static const char *const good[] = {"dual.test:1",    "dual.test:80",
+                                       "dual.test:8080", "dual.test:65535",
+                                       "dual.test:080",  "dual.test:"};
     /* 65616 and 4294967376 are load-bearing: both wrap to a plausible 80 */
     static const char *const bad[] = {
         "dual.test:0",          "dual.test:65536",      "dual.test:65616",
         "dual.test:99999",      "dual.test:2147483648", "dual.test:4294967296",
         "dual.test:4294967376", "dual.test:-1",         "dual.test:-23437",
-        "dual.test:80x",        "dual.test:",           "dual.test:+80",
-        "dual.test: 80",        "dual.test:0x50"};
+        "dual.test:80x",        "dual.test:+80",        "dual.test: 80",
+        "dual.test:0x50"};
     size_t k;
 
     for (k = 0; k < sizeof(good) / sizeof(good[0]); k++) {

--- a/src/htsdns_selftest.c
+++ b/src/htsdns_selftest.c
@@ -402,6 +402,49 @@ int dns_selftests(httrackp *opt) {
       deletesoc(s);
   }
 
+  /* A URL's ":port" (port == -1, so newhttp_addr parses it) outside 1..65535
+     must refuse the link, not fold into range and connect elsewhere (#614).
+     *addr_count is the discriminator: 0 only if the port was refused before the
+     resolve, still 2 for one merely truncated or defaulted to 80. */
+  {
+    static const char *const good[] = {"dual.test:1", "dual.test:80",
+                                       "dual.test:8080", "dual.test:65535"};
+    /* 65616 and 4294967376 are load-bearing: both wrap to a plausible 80 */
+    static const char *const bad[] = {
+        "dual.test:0",          "dual.test:65536",      "dual.test:65616",
+        "dual.test:99999",      "dual.test:2147483648", "dual.test:4294967296",
+        "dual.test:4294967376", "dual.test:-1",         "dual.test:-23437",
+        "dual.test:80x",        "dual.test:",           "dual.test:+80",
+        "dual.test: 80",        "dual.test:0x50"};
+    size_t k;
+
+    for (k = 0; k < sizeof(good) / sizeof(good[0]); k++) {
+      htsblk r;
+      int count = -1;
+      T_SOC s;
+
+      hts_init_htsblk(&r);
+      s = newhttp_addr(opt, good[k], &r, -1, 0, 0, &count);
+      CHECK(count == 2); /* accepted: reached the resolve */
+      if (s != INVALID_SOCKET)
+        deletesoc(s);
+    }
+
+    for (k = 0; k < sizeof(bad) / sizeof(bad[0]); k++) {
+      htsblk r;
+      int count = -1;
+      T_SOC s;
+
+      hts_init_htsblk(&r);
+      s = newhttp_addr(opt, bad[k], &r, -1, 0, 0, &count);
+      CHECK(s == INVALID_SOCKET);
+      CHECK(count == 0); /* refused before resolving, not a failed connect */
+      CHECK(strstr(r.msg, "Invalid port") != NULL);
+      if (s != INVALID_SOCKET)
+        deletesoc(s);
+    }
+  }
+
   /* Connect-fallback decision (consumer of the multi-address list): when a
      stuck connect should abandon the current address for the next one. */
   {

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -2167,9 +2167,8 @@ T_SOC newhttp_addr(httrackp *opt, const char *_iadr, htsblk *retour, int port,
 #endif
 
       if (a != NULL) {
-        // the link named a port: folding a nonsense one into 0..65535 would
-        // crawl a port neither the link nor a port filter named (#614). An
-        // empty "host:" is not nonsense, it means the default port.
+        // folding a nonsense port into 0..65535 crawls one neither the link nor
+        // a port filter named; an empty "host:" just means the default (#614)
         if (a[1] != '\0' && !hts_parse_url_port(a + 1, &port)) {
           if (retour != NULL) {
             snprintf(retour->msg, sizeof(retour->msg), "Invalid port: %s",

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -2168,8 +2168,9 @@ T_SOC newhttp_addr(httrackp *opt, const char *_iadr, htsblk *retour, int port,
 
       if (a != NULL) {
         // the link named a port: folding a nonsense one into 0..65535 would
-        // crawl a port neither the link nor a port filter named (#614)
-        if (!hts_parse_url_port(a + 1, &port)) {
+        // crawl a port neither the link nor a port filter named (#614). An
+        // empty "host:" is not nonsense, it means the default port.
+        if (a[1] != '\0' && !hts_parse_url_port(a + 1, &port)) {
           if (retour != NULL) {
             snprintf(retour->msg, sizeof(retour->msg), "Invalid port: %s",
                      a + 1);

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -2167,15 +2167,18 @@ T_SOC newhttp_addr(httrackp *opt, const char *_iadr, htsblk *retour, int port,
 #endif
 
       if (a != NULL) {
-        int i = -1;
-
-        iadr2[0] = '\0';
-        sscanf(a + 1, "%d", &i);
-        if (i != -1) {
-          port = (unsigned short int) i;
+        // the link named a port: folding a nonsense one into 0..65535 would
+        // crawl a port neither the link nor a port filter named (#614)
+        if (!hts_parse_url_port(a + 1, &port)) {
+          if (retour != NULL) {
+            snprintf(retour->msg, sizeof(retour->msg), "Invalid port: %s",
+                     a + 1);
+          }
+          return INVALID_SOCKET;
         }
 
-        // adresse véritable (sans :xx)
+        iadr2[0] = '\0';
+        // the address itself, without the ":port"
         strncatbuff(iadr2, iadr, (int) (a - iadr));
         resolve_host = iadr2;
       }
@@ -3748,18 +3751,27 @@ static int proxy_default_port(const char *arg) {
   return hts_proxy_is_socks(arg) ? 1080 : 8080;
 }
 
-// port "a" of -P argument "arg": digits fitting TCP's 1..65535, else the scheme
-// default. Not sscanf("%d"): past INT_MAX it wraps to a garbage port (#602)
-static int parse_proxy_port(const char *a, const char *arg) {
+hts_boolean hts_parse_url_port(const char *a, int *port) {
   char *end;
   long p;
 
   if (!isdigit((unsigned char) *a)) // strtol would eat a sign or leading space
-    return proxy_default_port(arg);
+    return HTS_FALSE;
   p = strtol(a, &end, 10);
   if (*end != '\0' || p < 1 || p > 65535) // ERANGE lands out of range too
+    return HTS_FALSE;
+  *port = (int) p;
+  return HTS_TRUE;
+}
+
+// port "a" of -P argument "arg": digits fitting TCP's 1..65535, else the scheme
+// default. Not sscanf("%d"): past INT_MAX it wraps to a garbage port (#602)
+static int parse_proxy_port(const char *a, const char *arg) {
+  int port;
+
+  if (!hts_parse_url_port(a, &port))
     return proxy_default_port(arg);
-  return (int) p;
+  return port;
 }
 
 void hts_parse_proxy(const char *arg, char *name, size_t name_size, int *port) {

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -288,6 +288,12 @@ const char *strrchr_limit(const char *s, char c, const char *limit);
 char *jump_protocol(char *source);
 const char *jump_protocol_const(const char *source);
 
+/* Parse a URL's port text "a" (after the ':', up to the end of the string):
+   TRUE and *port set for a bare decimal in 1..65535, else FALSE and *port left
+   alone. Not sscanf("%d"), which range-checks nothing and wraps past INT_MAX.
+ */
+hts_boolean hts_parse_url_port(const char *a, int *port);
+
 /* Split a -P proxy argument "[scheme://][user:pass@]host[:port]" into the proxy
    host string (scheme and any user:pass kept, for later stripping and auth),
    written NUL-terminated into name[name_size] (truncated to fit), and the port

--- a/src/htsproxy.c
+++ b/src/htsproxy.c
@@ -491,8 +491,9 @@ static int socks5_handshake_stream(httrackp *opt, socks5_stream *st,
     if ((unsigned char) host[i] < ' ')
       return socks5_fail(msg, msgsize, "SOCKS5: invalid origin host");
   }
-  // range-checking the sscanf("%d") result came too late: a value past INT_MAX
-  // wrapped into range first, then passed the check as a plausible port (#614)
+  // the old range check ran after sscanf("%d") had wrapped a huge value into a
+  // plausible port (#614). An empty "host:" stays refused here, unlike the
+  // direct path, as it was before #614.
   if (portsep != NULL && !hts_parse_url_port(portsep + 1, &port))
     return socks5_fail(msg, msgsize, "SOCKS5: invalid origin port");
   if (link_has_authorization(proxy_name)) {

--- a/src/htsproxy.c
+++ b/src/htsproxy.c
@@ -491,14 +491,10 @@ static int socks5_handshake_stream(httrackp *opt, socks5_stream *st,
     if ((unsigned char) host[i] < ' ')
       return socks5_fail(msg, msgsize, "SOCKS5: invalid origin host");
   }
-  if (portsep != NULL) {
-    int p = -1;
-
-    sscanf(portsep + 1, "%d", &p);
-    if (p <= 0 || p > 65535)
-      return socks5_fail(msg, msgsize, "SOCKS5: invalid origin port");
-    port = p;
-  }
+  // range-checking the sscanf("%d") result came too late: a value past INT_MAX
+  // wrapped into range first, then passed the check as a plausible port (#614)
+  if (portsep != NULL && !hts_parse_url_port(portsep + 1, &port))
+    return socks5_fail(msg, msgsize, "SOCKS5: invalid origin port");
   if (link_has_authorization(proxy_name)) {
     if (!socks5_credentials(opt, proxy_name, user, sizeof(user), &userlen, pass,
                             sizeof(pass), &passlen, msg, msgsize))

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1469,6 +1469,25 @@ static int st_socks5(httrackp *opt, int argc, char **argv) {
   assertf(socks5_handshake_scripted(opt, "origin.test:8443", proxy, &io) == 1);
   assertf(memcmp(io.sent + io.sent_len - 2, "\x20\xfb", 2) == 0);
 
+  /* a bad origin port is refused before any byte goes out (#614). 4294967376 is
+     the case the old range check could not see: it overflowed the sscanf("%d")
+     into a plausible 80 and passed. 65616 would not prove anything here, since
+     it fits an int and the old check already caught it. */
+  {
+    static const char *const bad[] = {"origin.test:4294967376",
+                                      "origin.test:80x", "origin.test:+80",
+                                      "origin.test: 80", "origin.test:8.0"};
+    size_t k;
+
+    for (k = 0; k < sizeof(bad) / sizeof(bad[0]); k++) {
+      len = socks5_reply(script, 0x01, v4, sizeof(v4));
+      io.reply = script;
+      io.reply_len = len;
+      assertf(socks5_handshake_scripted(opt, bad[k], proxy, &io) == 0);
+      assertf(io.sent_len == 0);
+    }
+  }
+
   /* credentials: split on the first colon of the escaped userinfo, so %3a stays
      inside the username and a colon in the password is not a delimiter */
   {


### PR DESCRIPTION
`newhttp_addr` parses the port of every crawled URL with `sscanf(a + 1, "%d", &i)`, validates it with `i != -1`, then casts to `unsigned short`, so an out-of-range port folds into 0..65535 and httrack connects there. Against a server on 127.0.0.1:40043, a link to `:105579` mirrored the site off 40043 and stored it under `127.0.0.1_105579`, so the URL identity and the connection target disagree. A value too big for an `int` is UB on top of that, and wraps on glibc. The severity is thin and worth saying so: it takes a port-specific exclusion filter plus an attacker-placed link. But once a filter names a port, the literal spelling is refused and a wrapped spelling of the same port is not, so the user's own rule ends up describing a port other than the one httrack opens. This is correctness rather than memory safety; the cast already bounded every path.

The port now goes through `hts_parse_url_port`, factored out of #610's `parse_proxy_port`, and a bad one refuses the link via the `msg` + `INVALID_SOCKET` path `newhttp_addr` already uses for an unresolvable host. Not a fallback to the scheme default, which is what the proxy parser does: `:65616` truncates to 80 today and would fall back to 80 tomorrow, i.e. the same wrong port with a passing test. A proxy port has a sensible default; a URL port does not, because the URL named one and named a nonsense one. curl and WHATWG both fail the URL instead. The one carve-out is an empty `http://host:/x`, which arrives here as `adr="host:"` and is legal, meaning the default port, so it keeps working; the second commit adds that guard after I caught myself refusing it. `socks5_handshake_stream` had the same shape, range-checking only after the `sscanf` had already wrapped a huge value into a plausible port, so it shares the parser now. That tightens it by more than the wrap, and the PR should say so: `sscanf` eats a sign and leading space and ignores trailing junk, so `+80`, ` 80`, `80x`, `8.0` and `8080 ` all used to reach port 80 through a SOCKS5 proxy and now error out. Nothing there turns into a different accepted port, so the worst case is a link refused that used to work. An empty port stays refused on that path, unlike the direct one, which is how it behaved before #614.

I did not touch three siblings. `src/htsftp.c:251` has the same parse with no check at all, but the wizard refuses an `ftp://` link from scanned HTML, so reaching it needs a CLI ftp seed: hygiene, not exposure. `src/htsweb.c:260` and `src/proxy/main.c:59` are operator-supplied listen ports and should error at startup instead.

The test rides in the existing `dns` self-test, which drives `newhttp_addr` through the mocked resolver. `*addr_count` separates the two outcomes: 0 only when the port was refused before the resolve, still 2 for one merely truncated or defaulted, so a fallback would fail it. Valid ports are the control, and the wrapped cases that land on a plausible 80 (65616, 4294967376) are the ones that matter. Fails on master, passes with the fix.

Closes #614
