### PR TITLE
SOCKS5 test server never checked the RFC 1929 version byte

### DIFF
--- a/tests/52_local-socks5.test
+++ b/tests/52_local-socks5.test
@@ -180,6 +180,12 @@ grep -q "^AUTH user secret\$" "$auth/socks.log" || {
     cat "$auth/socks.log" >&2
     exit 1
 }
+# the sub-negotiation carries RFC 1929's 0x01, not the 0x05 of the SOCKS5 greeting
+grep -q "^AUTHVER 1\$" "$auth/socks.log" || {
+    echo "FAIL: wrong RFC 1929 sub-negotiation version" >&2
+    cat "$auth/socks.log" >&2
+    exit 1
+}
 grep -qi "secret\|proxy-authorization" "$auth/origin-headers.log" && {
     echo "FAIL: socks credentials leaked into the origin request" >&2
     cat "$auth/origin-headers.log" >&2

--- a/tests/52_local-socks5.test
+++ b/tests/52_local-socks5.test
@@ -165,6 +165,13 @@ auth="$tmpdir/auth"
 start_server "$auth" ok
 run_crawl "$auth/out" "http://${host}:${http_port}/" \
     "socks5://user:secret@127.0.0.1:${socks_port}"
+# name a rejected version byte here: the crawl check below only knows the
+# handshake failed, not why
+grep -q "^AUTHVER-BAD" "$auth/socks.log" && {
+    echo "FAIL: sub-negotiation version was not RFC 1929's 0x01" >&2
+    cat "$auth/socks.log" >&2
+    exit 1
+}
 grep -rq "ORIGIN-PAGE-563" "$auth/out" || {
     echo "FAIL: origin not downloaded through the authenticated socks proxy" >&2
     cat "$auth/out.log" "$auth/socks.log" >&2
@@ -177,12 +184,6 @@ grep -q "^METHOD userpass\$" "$auth/socks.log" || {
 }
 grep -q "^AUTH user secret\$" "$auth/socks.log" || {
     echo "FAIL: wrong socks credentials sent" >&2
-    cat "$auth/socks.log" >&2
-    exit 1
-}
-# the sub-negotiation carries RFC 1929's 0x01, not the 0x05 of the SOCKS5 greeting
-grep -q "^AUTHVER 1\$" "$auth/socks.log" || {
-    echo "FAIL: wrong RFC 1929 sub-negotiation version" >&2
     cat "$auth/socks.log" >&2
     exit 1
 }

--- a/tests/socks5-server.py
+++ b/tests/socks5-server.py
@@ -111,7 +111,6 @@ def negotiate_auth(conn, logdir):
             log(logdir, "AUTHVER-BAD %d" % subver)
             conn.sendall(bytes([AUTH_VERSION, 0x01]))  # sub-negotiation failure
             return False
-        log(logdir, "AUTHVER %d" % subver)
         (ulen,) = recvn(conn, 1)
         uname = recvn(conn, ulen)
         (plen,) = recvn(conn, 1)

--- a/tests/socks5-server.py
+++ b/tests/socks5-server.py
@@ -24,6 +24,7 @@ from proxytestlib import bind_ephemeral, pipe  # noqa: E402
 # The one name the proxy answers for; a .invalid TLD never resolves (RFC 6761),
 # so a locally-resolving client could not reach us -- success proves remote DNS.
 REMOTE_HOST = b"socks-origin.invalid"
+AUTH_VERSION = 0x01  # RFC 1929 sub-negotiation version
 # index links the subpages so an -r3 crawl reuses one keep-alive socket
 LINKS = "".join('<a href="/p%d.html">%d</a>' % (i, i) for i in range(1, 6))
 ORIGIN_BODY = ("<html><body>ORIGIN-PAGE-563 " + LINKS + "</body></html>").encode()
@@ -104,6 +105,13 @@ def negotiate_auth(conn, logdir):
     if 0x02 in methods:  # prefer user/pass so the auth test exercises RFC 1929
         conn.sendall(b"\x05\x02")
         (subver,) = recvn(conn, 1)
+        # RFC 1929's version byte is 0x01, not SOCKS5's 0x05: a real proxy
+        # rejects a mismatch instead of tunnelling anyway
+        if subver != AUTH_VERSION:
+            log(logdir, "AUTHVER-BAD %d" % subver)
+            conn.sendall(bytes([AUTH_VERSION, 0x01]))  # sub-negotiation failure
+            return False
+        log(logdir, "AUTHVER %d" % subver)
         (ulen,) = recvn(conn, 1)
         uname = recvn(conn, ulen)
         (plen,) = recvn(conn, 1)


### PR DESCRIPTION
The SOCKS5 test server read the sub-negotiation version byte and dropped it. That byte must be 0x01, RFC 1929's own version, not the 0x05 of the SOCKS5 greeting. `htsproxy.c` gets it right and even comments the trap, but since the server never looked, a client that regressed to 0x05 would have kept `52_local-socks5.test` green forever while every real proxy rejected the handshake.

The server now rejects a mismatch the way a real proxy does, and the test names it, so a bad version byte reads as itself rather than as the vaguer "origin not downloaded".

This turned up while checking the proxy client against implementations we didn't write (microsocks, squid, tinyproxy, tor) over the live site. The client is correct on every leg, but this test could not have told us that. Verified by mutation: with `htsproxy.c` patched to send 0x05, master's test passes and the fixed one fails.