### PR TITLE
Top-index gifs land in a mangled directory for non-ASCII Windows projects

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2486,7 +2486,7 @@ static int st_topindex(httrackp *opt, int argc, char **argv) {
   snprintf(path, sizeof(path), "%s/backblue.gif", projdir);
   assertf(fexist(path));
 
-  /* raw unlink/rmdir: the UNLINK macro is utf-8 on Windows, these paths aren't */
+  /* raw unlink/rmdir: UNLINK is utf-8 on Windows, these paths aren't */
   unlink(path);
   snprintf(path, sizeof(path), "%s/fade.gif", projdir);
   unlink(path);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2458,6 +2458,45 @@ static int st_makeindex(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+// hts_buildtopindex takes a system-charset path but verif_backblue() below it
+// expects utf-8, so on Windows a non-ASCII project dir gets the gifs written to
+// a mangled twin (issues #216/#217). argv[0] is a writable dir.
+static int st_topindex(httrackp *opt, int argc, char **argv) {
+  char projdir[HTS_URLMAXSIZE];
+  char path[HTS_URLMAXSIZE + 16]; /* projdir plus a basename */
+#ifdef _WIN32
+  /* the GUI hands hts_buildtopindex an ANSI path; mimic it. CP1252 'cafe' */
+  static const char *const projName = "caf\xE9";
+#else
+  /* POSIX system charset is UTF-8 */
+  static const char *const projName = "caf\xC3\xA9";
+#endif
+
+  assertf(argc >= 1);
+  snprintf(projdir, sizeof(projdir), "%s/%s", argv[0], projName);
+
+  /* structcheck(), not the utf-8 MKDIR family: same charset as buildtopindex */
+  snprintf(path, sizeof(path), "%s/", projdir);
+  assertf(structcheck(path) == 0);
+
+  /* returns 0 here: the dir holds no sub-project, only the gifs matter */
+  (void) hts_buildtopindex(opt, projdir, "");
+
+  /* the gifs must land in the project dir itself, not in a mangled sibling */
+  snprintf(path, sizeof(path), "%s/backblue.gif", projdir);
+  assertf(fexist(path));
+
+  /* raw unlink/rmdir: the UNLINK macro is utf-8 on Windows, these paths aren't */
+  unlink(path);
+  snprintf(path, sizeof(path), "%s/fade.gif", projdir);
+  unlink(path);
+  snprintf(path, sizeof(path), "%s/index.html", projdir);
+  unlink(path);
+  rmdir(projdir);
+  printf("topindex self-test OK\n");
+  return 0;
+}
+
 /* Each inplace_escape_*() must equal escape_*() on a copy. */
 static int st_inplace_escape(httrackp *opt, int argc, char **argv) {
   /* >255 bytes forces the helper's malloct path, not the stack buffer */
@@ -3165,6 +3204,9 @@ static const struct selftest_entry {
     {"useragent", "", "default User-Agent self-test", st_useragent},
     {"makeindex", "[dir]", "hts_finish_makeindex footer/refresh self-test",
      st_makeindex},
+    {"topindex", "[dir]",
+     "hts_buildtopindex charset handling of a non-ASCII project dir",
+     st_topindex},
     {"inplace-escape", "", "inplace_escape_* vs escape_* equivalence self-test",
      st_inplace_escape},
     {"escape-room", "", "HT_ADD_HTMLESCAPED* reservation-factor self-test",

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -896,7 +896,20 @@ HTSEXT_API int hts_buildtopindex(httrackp * opt, const char *path,
     if (fpo) {
       find_handle h;
 
-      verif_backblue(opt, concat(catbuff, sizeof(catbuff), rpath, "/")); // générer gif
+      // générer gif. verif_backblue() is utf-8, but our path is the system
+      // charset, so on Windows convert it or the gifs land in a mangled twin
+      // dir (#217). Elsewhere the system charset is already utf-8.
+#ifdef _WIN32
+      {
+        const char *const base = concat(catbuff, sizeof(catbuff), rpath, "/");
+        char *const base_utf8 =
+            hts_convertStringSystemToUTF8(base, strlen(base));
+        verif_backblue(opt, base_utf8 != NULL ? base_utf8 : base);
+        free(base_utf8);
+      }
+#else
+      verif_backblue(opt, concat(catbuff, sizeof(catbuff), rpath, "/"));
+#endif
       // Header
       hts_template_format(fpo, toptemplate_header,
               "<!-- Mirror and index made by HTTrack Website Copier/"

--- a/tests/01_engine-topindex.test
+++ b/tests/01_engine-topindex.test
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# hts_buildtopindex takes a system-charset path but verif_backblue below it
+# expects utf-8, mangling a non-ASCII project dir on Windows (#216, #217).
+dir=$(mktemp -d)
+trap 'rm -rf "$dir"' EXIT
+
+httrack -O /dev/null -#test=topindex "$dir" run |
+    grep -q "topindex self-test OK"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -71,6 +71,7 @@ TESTS = \
 	01_engine-status.test \
 	01_engine-stripquery.test \
 	01_engine-strsafe.test \
+	01_engine-topindex.test \
 	01_engine-urlhack.test \
 	01_engine-unescape-bounds.test \
 	01_engine-useragent.test \


### PR DESCRIPTION
Adds a `topindex` self-test for a non-ASCII project directory and fixes the bug it exposed (#217).

`hts_buildtopindex()` works in the system charset, but `verif_backblue()`, which writes `backblue.gif` and `fade.gif`, expects UTF-8, and every other caller already hands it the UTF-8 path. Only this one passed a system-charset path, so on Windows the high bytes were invalid UTF-8, the gif open failed, and the fallback wrote them into a mangled twin directory instead of the project. The fix converts at the call site, guarded by `_WIN32` because the converter is Windows-only and the system charset is UTF-8 everywhere else.

The self-test is named to match the `01_engine-*.test` glob the Windows job uses to pick the offline suite, so it runs where the bug is reachable; it already passed on every UTF-8-charset platform. Before the fix it failed on both Windows legs at the `backblue.gif` assertion, which is what confirmed #217. Sibling #216, the mojibake project name written into the generated index, is a separate leak in the same function and is not touched here.

Closes #217
Refs #216