### PR TITLE
An empty $HOME sends webhttrack's base path and httrack.ini to the root

### DIFF
--- a/src/htsserver.h
+++ b/src/htsserver.h
@@ -164,13 +164,12 @@ HTS_UNUSED static int linputsoc_t(T_SOC soc, char *s, int max, int timeout) {
   return -1;
 }
 
+/* Same contract as hts_gethome(), which is hidden and out of reach from here */
 static const char *gethomedir(void) {
   const char *home = getenv("HOME");
 
-  if (home)
-    return home;
-  else
-    return ".";
+  /* An empty $HOME would put the base path and httrack.ini at the root */
+  return strnotempty(home) ? home : ".";
 }
 static int linput_cpp(FILE * fp, char *s, int max) {
   int rlen = 0;

--- a/src/proxy/proxytrack.h
+++ b/src/proxy/proxytrack.h
@@ -107,13 +107,12 @@ HTS_UNUSED static void proxytrack_print_log(const char *severity, const char *fo
 	"<!-- _-._.--._._-._.--._._-._.--._._-._.--._._-._.--._. -->\r\n" \
 	"<!-- End Disable IE Friendly HTTP Error Messages -->\r\n"
 
+/* Same contract as hts_gethome(): proxytrack does not link libhttrack */
 HTS_UNUSED static const char *gethomedir(void) {
   const char *home = getenv("HOME");
 
-  if (home)
-    return home;
-  else
-    return ".";
+  /* An empty $HOME would resolve a relative path against the root */
+  return strnotempty(home) ? home : ".";
 }
 
 HTS_UNUSED static int linput(FILE * fp, char *s, int max) {

--- a/tests/63_webhttrack-home.test
+++ b/tests/63_webhttrack-home.test
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# htsserver's $HOME lookup, through the web UI it actually renders. An exported
+# but empty $HOME must not resolve the default base path against the root.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
+distdir=$(cd "${distdir}" && pwd)
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+command -v htsserver >/dev/null || fail "no htsserver in PATH"
+# Mirror local-crawl.sh's skip-with-77: the Debian buildd chroot has no python3.
+command -v python3 >/dev/null || {
+    echo "python3 not found; skipping" >&2
+    exit 77
+}
+
+srv=
+cleanup() {
+    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
+}
+trap cleanup EXIT HUP INT QUIT PIPE TERM
+
+log=$(mktemp)
+trap 'cleanup; rm -f "${log}"' EXIT
+
+# Ask htsserver for its rendered default base path, under the given $HOME
+# ("-" = leave $HOME unset).
+pathfor() {
+    local homeval=$1 port url got
+    port=$(python3 -c 'import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()')
+
+    : >"${log}"
+    (
+        # htsserver ignores SIGTERM/SIGTTOU handling from the harness shell
+        trap '' TERM TTOU
+        if test "${homeval}" = -; then unset HOME; else export HOME="${homeval}"; fi
+        exec htsserver "${distdir}/" --port "${port}" >"${log}" 2>&1
+    ) &
+    srv=$!
+
+    for _ in $(seq 1 40); do
+        url=$(sed -n 's/^URL=//p' "${log}" 2>/dev/null) && test -n "${url}" && break
+        kill -0 "${srv}" 2>/dev/null || break
+        sleep 0.25
+    done
+    test -n "${url:-}" || fail "htsserver did not come up: $(cat "${log}")"
+
+    # The UI is served ISO-8859-1, so keep python out of text mode.
+    got=$(python3 -c 'import re, sys, urllib.request
+body = urllib.request.urlopen(sys.argv[1] + "server/step2.html", timeout=20).read()
+m = re.search(br"name=\"path\" value=\"([^\"]*)\"", body)
+print(m.group(1).decode("latin-1") if m else "")' "${url}")
+
+    kill -9 "${srv}" 2>/dev/null || true
+    wait "${srv}" 2>/dev/null || true
+    srv=
+    test -n "${got}" || fail "no path field in the rendered step2.html"
+    echo "${got}"
+}
+
+check() {
+    local desc=$1 homeval=$2 want=$3 got
+    got=$(pathfor "${homeval}")
+    test "${got}" = "${want}" || fail "${desc}: want ${want}, got ${got}"
+    echo "ok: ${desc} -> ${got}"
+}
+
+# A real HOME must reach the page, or the two cases below are vacuous: they
+# also pass when gethomedir() ignores the environment and always answers ".".
+check 'a set HOME is used' /nonexistent/hts-home /nonexistent/hts-home/websites
+
+# Exported but empty is the regression: getenv() returns "", not NULL, so a
+# bare NULL check let the base path collapse onto /websites.
+check 'an empty HOME' '' ./websites
+check 'an unset HOME' - ./websites
+
+echo "PASS"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -143,6 +143,7 @@ TESTS = \
 	59_local-tls-stall.test \
 	60_crawl-log-salvage.test \
 	61_webhttrack-locale.test \
-	62_lang-integrity.test
+	62_lang-integrity.test \
+	63_webhttrack-home.test
 
 CLEANFILES = check-network_sh.cache


### PR DESCRIPTION
PR #619 fixed `hts_gethome()` for an exported-but-empty `$HOME`: `getenv` returns `""`, not NULL, so the old NULL-only check let `~/foo` expand into the absolute `/foo`. The same shape lives in two static clones the fix missed, and one of them is live.

With `HOME=` exported, htsserver renders `/websites` as webhttrack's default base path, reads `/.httrack.ini` on the first request of every session, and writes `/.httrack.ini` when a mirror starts. All three are confirmed under strace. The write matters most: as root it lands a file at the filesystem root, and as anyone else it fails EACCES.

The clones can't simply call `hts_gethome()`. It's hidden by `-fvisibility=hidden` (nm reports it as a local `t` in `libhttrack.so`), so htsserver can't reach it even though it links the library, and proxytrack doesn't link libhttrack at all. Exporting it would grow the public ABI for no other caller, so each copy keeps its own body. proxytrack's copy is dead today (zero callers, `HTS_UNUSED static`, absent from the binary) and fixed anyway, since one copy keeping the old shape is what caused this second round.

A static in `htsserver.h` is out of reach of the `-#test` registry, so test 63 drives htsserver for real and reads the base path back out of the rendered UI. It pins a real `$HOME` as well, or the empty case would also pass against a `gethomedir()` that ignored the environment and always answered `"."`, the exact mutant that survived #619's first test. On master the test fails with `want ./websites, got /websites`, while the `$HOME`-is-read case passes on both sides.
