### PR TITLE
The listen ports and the ftp:// port take a port sscanf never range-checked

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -46,9 +46,11 @@ htsserver_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS_PIE)
 
 lib_LTLIBRARIES = libhttrack.la
 
-htsserver_SOURCES = htsserver.c htsserver.h htsweb.c htsweb.h
+htsserver_SOURCES = htsserver.c htsserver.h htsweb.c htsweb.h \
+	htsurlport.c htsurlport.h
 proxytrack_SOURCES = proxy/main.c \
 	proxy/proxytrack.c proxy/store.c \
+	htsurlport.c htsurlport.h \
 	coucal/coucal.c htsmd5.c md5.c \
 	minizip/ioapi.c minizip/mztools.c minizip/unzip.c minizip/zip.c
 
@@ -58,7 +60,7 @@ whttrackrun_SCRIPTS = webhttrack
 libhttrack_la_SOURCES =  htscore.c htsparse.c htsback.c htscache.c \
 	htscache_selftest.c htsdns_selftest.c htsselftest.c \
 	htscatchurl.c htsfilters.c htsftp.c htshash.c coucal/coucal.c \
-	htshelp.c htslib.c htscoremain.c \
+	htshelp.c htslib.c htsurlport.c htscoremain.c \
 	htsname.c htsrobots.c htstools.c htswizard.c \
 	htsalias.c htsthread.c htsindex.c htsbauth.c \
 	htsmd5.c htscodec.c htsproxy.c htszlib.c htswrap.c htsconcat.c \
@@ -69,7 +71,7 @@ libhttrack_la_SOURCES =  htscore.c htsparse.c htsback.c htscache.c \
 	htsbasenet.h htsbauth.h htscache.h htscache_selftest.h htsdns_selftest.h htsselftest.h htscatchurl.h  \
 	htsconfig.h htscore.h htsparse.h htscoremain.h htsdefines.h  \
 	htsfilters.h htsftp.h htsglobal.h htshash.h coucal/coucal.h \
-	htshelp.h htsindex.h htslib.h htsmd5.h \
+	htshelp.h htsindex.h htslib.h htsurlport.h htsmd5.h \
 	htsmodules.h htsname.h htsnet.h htssniff.h \
 	htsopt.h htsrobots.h htsthread.h  \
 	htstools.h htswizard.h htswrap.h htscodec.h htsproxy.h htszlib.h  \

--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -248,7 +248,13 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
     // port
     a = strchr(adr, ':');       // port
     if (a) {
-      sscanf(a + 1, "%d", &port);
+      // folding a nonsense port into 1..65535 fetches one the link never named;
+      // an empty "host:" just means the default (#614)
+      if (a[1] != '\0' && !hts_parse_url_port(a + 1, &port)) {
+        snprintf(back->r.msg, sizeof(back->r.msg), "Invalid port: %s", a + 1);
+        back->r.statuscode = STATUSCODE_INVALID; // permanent, unlike a DNS miss
+        _HALT_FTP return 0;
+      }
       strncatbuff(_adr, adr, (int) (a - adr));
     } else
       strcpybuff(_adr, adr);

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -3751,19 +3751,6 @@ static int proxy_default_port(const char *arg) {
   return hts_proxy_is_socks(arg) ? 1080 : 8080;
 }
 
-hts_boolean hts_parse_url_port(const char *a, int *port) {
-  char *end;
-  long p;
-
-  if (!isdigit((unsigned char) *a)) // strtol would eat a sign or leading space
-    return HTS_FALSE;
-  p = strtol(a, &end, 10);
-  if (*end != '\0' || p < 1 || p > 65535) // ERANGE lands out of range too
-    return HTS_FALSE;
-  *port = (int) p;
-  return HTS_TRUE;
-}
-
 // port "a" of -P argument "arg": digits fitting TCP's 1..65535, else the scheme
 // default. Not sscanf("%d"): past INT_MAX it wraps to a garbage port (#602)
 static int parse_proxy_port(const char *a, const char *arg) {

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -61,6 +61,7 @@ typedef struct lien_adrfilsave lien_adrfilsave;
 
 /* définitions globales */
 #include "htsglobal.h"
+#include "htsurlport.h"
 
 /* basic net definitions */
 #include "htsbase.h"
@@ -287,12 +288,6 @@ int may_unknown2(httrackp * opt, const char *mime, const char *filename);
 const char *strrchr_limit(const char *s, char c, const char *limit);
 char *jump_protocol(char *source);
 const char *jump_protocol_const(const char *source);
-
-/* Parse a URL's port text "a" (after the ':', up to the end of the string):
-   TRUE and *port set for a bare decimal in 1..65535, else FALSE and *port left
-   alone. Not sscanf("%d"), which range-checks nothing and wraps past INT_MAX.
- */
-hts_boolean hts_parse_url_port(const char *a, int *port);
 
 /* Split a -P proxy argument "[scheme://][user:pass@]host[:port]" into the proxy
    host string (scheme and any user:pass kept, for later stripping and auth),

--- a/src/htsurlport.c
+++ b/src/htsurlport.c
@@ -1,0 +1,50 @@
+/* ------------------------------------------------------------ */
+/*
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) 1998 Xavier Roche and other contributors
+
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Ethical use: we kindly ask that you NOT use this software to harvest email
+addresses or to collect any other private information about people. Doing so
+would dishonor our work and waste the many hours we have spent on it.
+
+Please visit our Website: http://www.httrack.com
+*/
+
+/* ------------------------------------------------------------ */
+/* File: TCP port parser, shared by the engine, htsserver and    */
+/*       proxytrack                                              */
+/* Author: Xavier Roche                                          */
+/* ------------------------------------------------------------ */
+
+#include "htsurlport.h"
+
+#include <ctype.h>
+#include <stdlib.h>
+
+hts_boolean hts_parse_url_port(const char *a, int *port) {
+  char *end;
+  long p;
+
+  if (!isdigit((unsigned char) *a)) // strtol would eat a sign or leading space
+    return HTS_FALSE;
+  p = strtol(a, &end, 10);
+  if (*end != '\0' || p < 1 || p > 65535) // ERANGE lands out of range too
+    return HTS_FALSE;
+  *port = (int) p;
+  return HTS_TRUE;
+}

--- a/src/htsurlport.h
+++ b/src/htsurlport.h
@@ -1,0 +1,45 @@
+/* ------------------------------------------------------------ */
+/*
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) 1998 Xavier Roche and other contributors
+
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Ethical use: we kindly ask that you NOT use this software to harvest email
+addresses or to collect any other private information about people. Doing so
+would dishonor our work and waste the many hours we have spent on it.
+
+Please visit our Website: http://www.httrack.com
+*/
+
+/* ------------------------------------------------------------ */
+/* File: TCP port parser, shared by the engine, htsserver and    */
+/*       proxytrack                                              */
+/* Author: Xavier Roche                                          */
+/* ------------------------------------------------------------ */
+
+#ifndef HTSURLPORT_DEFH
+#define HTSURLPORT_DEFH
+
+#include "htsglobal.h"
+
+/* Parse the port text "a" (after the ':', up to the end of the string): TRUE
+   and *port set for a bare decimal in 1..65535, else FALSE and *port left
+   alone. Not sscanf("%d"), which range-checks nothing and wraps past INT_MAX.
+   Its own file so proxytrack, which does not link the library, can share it. */
+hts_boolean hts_parse_url_port(const char *a, int *port);
+
+#endif

--- a/src/htsweb.c
+++ b/src/htsweb.c
@@ -63,6 +63,7 @@ Please visit our Website: http://www.httrack.com
 #include "md5.c"
 
 #include "htsserver.h"
+#include "htsurlport.h"
 #include "htsweb.h"
 
 #if USE_BEGINTHREAD==0
@@ -257,8 +258,10 @@ int main(int argc, char *argv[]) {
   /* set commandline keys */
   for(i = 2; i < argc; i += 2) {
     if (strcmp(argv[i], "--port") == 0 && i + 1 < argc) {
-      if (sscanf(argv[i + 1], "%d", &defaultPort) != 1 || defaultPort < 0
-          || defaultPort >= 65535) {
+      // the range check ran after sscanf("%d") had wrapped a huge value into a
+      // plausible port, and listened there (#614). 0 (was the auto-pick) and
+      // 65535 (was refused, off by one) now both mean what they say.
+      if (!hts_parse_url_port(argv[i + 1], &defaultPort)) {
         fprintf(stderr, "couldn't set the port number to %s\n", argv[i + 1]);
         return -1;
       }

--- a/src/libhttrack.vcxproj
+++ b/src/libhttrack.vcxproj
@@ -121,6 +121,7 @@
     <ClCompile Include="htshelp.c" />
     <ClCompile Include="htsindex.c" />
     <ClCompile Include="htslib.c" />
+    <ClCompile Include="htsurlport.c" />
     <ClCompile Include="htsmd5.c" />
     <ClCompile Include="htsmodules.c" />
     <ClCompile Include="htsname.c" />

--- a/src/proxy/main.c
+++ b/src/proxy/main.c
@@ -47,7 +47,9 @@ static void sig_brpipe(int code) {
 }
 #endif
 
-static int scanHostPort(const char *str, char *host, int *port) {
+// split a "host:port" listen argument; FALSE sends the caller to the usage
+// screen. The port was unchecked, so a huge one wrapped into range (#614).
+static hts_boolean scanHostPort(const char *str, char *host, int *port) {
   char *pos = strrchr(str, ':');
 
   if (pos != NULL) {
@@ -56,12 +58,10 @@ static int scanHostPort(const char *str, char *host, int *port) {
     if (n < 256) {
       host[0] = '\0';
       strncat(host, str, n);
-      if (sscanf(pos + 1, "%d", port) == 1) {
-        return 1;
-      }
+      return hts_parse_url_port(pos + 1, port);
     }
   }
-  return 0;
+  return HTS_FALSE;
 }
 
 int main(int argc, char *argv[]) {

--- a/src/proxytrack.vcxproj
+++ b/src/proxytrack.vcxproj
@@ -99,6 +99,7 @@
     <ClCompile Include="proxy\main.c" />
     <ClCompile Include="proxy\proxytrack.c" />
     <ClCompile Include="proxy\store.c" />
+    <ClCompile Include="htsurlport.c" />
     <ClCompile Include="coucal\coucal.c" />
     <ClCompile Include="htsmd5.c" />
     <ClCompile Include="md5.c" />

--- a/src/webhttrack.vcxproj
+++ b/src/webhttrack.vcxproj
@@ -97,6 +97,7 @@
   <ItemGroup>
     <ClCompile Include="htsserver.c" />
     <ClCompile Include="htsweb.c" />
+    <ClCompile Include="htsurlport.c" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/64_port-siblings.test
+++ b/tests/64_port-siblings.test
@@ -1,0 +1,107 @@
+#!/bin/bash
+#
+
+# Port parsing outside the crawled-URL path (#614): the htsserver --port listen
+# port, proxytrack's host:port listen arguments, and an ftp:// URL port. All
+# three took the port from sscanf("%d"), which range-checks nothing and wraps
+# past INT_MAX, so a value naming no real port silently became a plausible one.
+
+set -euo pipefail
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_portsib.XXXXXX") || exit 1
+trap 'rm -rf "$tmp"' EXIT HUP INT QUIT PIPE TERM
+
+# A port the old code accepted only by wrapping: 4295009395 = 2^32 + 42099 and
+# 4294967376 = 2^32 + 80 both fold to a plausible listen port. They are the
+# load-bearing cases, since a value that merely exceeds 65535 while still
+# fitting an int (65616) was already caught by the htsserver range check.
+overflowing="4295009395"
+
+# Values sscanf("%d") took as a port that no operator meant: a trailing
+# character, a sign, leading whitespace, a decimal point. Each silently listened
+# on the prefix it managed to scan.
+malformed=("80x" "+80" " 80" "8.0" "")
+
+# --- htsserver --port ------------------------------------------------------
+# Its argv[1] is the html root; the option pairs follow.
+
+# run htsserver with the given --port value, leaving its output in $tmp/web.log.
+# It blocks serving once a port is accepted, so cap it; we assert on the output,
+# not the exit status.
+websrv() {
+    timeout 5 htsserver "$tmp" --port "$1" >"$tmp/web.log" 2>&1 || true
+}
+
+web_refused() {
+    websrv "$1"
+    grep -q "couldn't set the port number" "$tmp/web.log" ||
+        ! echo "FAIL: #614: htsserver --port '$1' not refused" || exit 1
+    # it must not have reached the listen socket on some other port
+    ! grep -q "^URL=" "$tmp/web.log" ||
+        ! echo "FAIL: #614: htsserver --port '$1' listened anyway" || exit 1
+}
+
+web_accepted() {
+    websrv "$1"
+    ! grep -q "couldn't set the port number" "$tmp/web.log" ||
+        ! echo "FAIL: #614: htsserver --port '$1' wrongly refused" || exit 1
+    # the value must reach the listener: either it bound, or the bind failed --
+    # both prove the parser passed it through, whether or not the port is free
+    grep -qE "^URL=http://.*:$1/|Unable to initialize a temporary server" "$tmp/web.log" ||
+        ! echo "FAIL: #614: htsserver --port '$1' never reached the listener" || exit 1
+}
+
+# this used to listen on 42099
+web_refused "$overflowing"
+for p in "${malformed[@]}" 0 65536 99999 -1; do
+    web_refused "$p"
+done
+
+# 65535 is a valid port the old "< 65535" bound refused
+web_accepted 65535
+
+# --- proxytrack <proxy-addr:port> <ICP-addr:port> --------------------------
+# A bad argument falls through to the usage screen; it had no range check at
+# all, so 65616 quietly listened on port 80.
+
+proxy_refused() {
+    timeout 5 proxytrack "127.0.0.1:$1" 127.0.0.1:3130 >"$tmp/pt.log" 2>&1 || true
+    grep -q "^usage:" "$tmp/pt.log" ||
+        ! echo "FAIL: #614: proxytrack port '$1' not refused" || exit 1
+}
+
+proxy_accepted() {
+    timeout 5 proxytrack "127.0.0.1:$1" 127.0.0.1:3130 >"$tmp/pt.log" 2>&1 || true
+    ! grep -q "^usage:" "$tmp/pt.log" ||
+        ! echo "FAIL: #614: proxytrack port '$1' wrongly refused" || exit 1
+}
+
+for p in "${malformed[@]}" 65616 4294967376 "$overflowing" 0 -1; do
+    proxy_refused "$p"
+done
+proxy_accepted 45678
+
+# --- ftp:// URL port -------------------------------------------------------
+# A URL port, so it follows the crawled-URL policy: refuse the link rather than
+# fold it into range. An ftp:// link in scanned HTML is not followed, so the
+# seed has to come from the command line.
+
+ftp_port() {
+    local out="$tmp/ftp"
+
+    rm -rf "$out"
+    timeout 30 httrack "ftp://127.0.0.1:$1/x" -O "$out" --quiet -n >/dev/null 2>&1 || true
+    grep -c "Invalid port: $1" "$out/hts-log.txt" 2>/dev/null || true
+}
+
+# 65616 truncated to 80 and really did connect there
+for p in 65616 99999; do
+    test "$(ftp_port "$p")" -gt 0 ||
+        ! echo "FAIL: #614: ftp:// port $p not refused" || exit 1
+done
+
+# a valid port still reaches the connect attempt
+test "$(ftp_port 65535)" -eq 0 ||
+    ! echo "FAIL: #614: ftp:// port 65535 wrongly refused" || exit 1
+
+exit 0

--- a/tests/65_port-siblings.test
+++ b/tests/65_port-siblings.test
@@ -8,6 +8,11 @@
 
 set -euo pipefail
 
+testdir=$(cd "$(dirname "$0")" && pwd)
+# run_with_timeout: timeout(1) is absent on macOS, and the listen servers block.
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_portsib.XXXXXX") || exit 1
 trap 'rm -rf "$tmp"' EXIT HUP INT QUIT PIPE TERM
 
@@ -23,13 +28,11 @@ overflowing="4295009395"
 malformed=("80x" "+80" " 80" "8.0" "")
 
 # --- htsserver --port ------------------------------------------------------
-# Its argv[1] is the html root; the option pairs follow.
+# Its argv[1] is the html root; the option pairs follow. It blocks serving once
+# a port is accepted, so bound it; we assert on the output, not the exit status.
 
-# run htsserver with the given --port value, leaving its output in $tmp/web.log.
-# It blocks serving once a port is accepted, so cap it; we assert on the output,
-# not the exit status.
 websrv() {
-    timeout 5 htsserver "$tmp" --port "$1" >"$tmp/web.log" 2>&1 || true
+    run_with_timeout 3 htsserver "$tmp" --port "$1" >"$tmp/web.log" 2>&1 || true
 }
 
 web_refused() {
@@ -42,13 +45,29 @@ web_refused() {
 }
 
 web_accepted() {
-    websrv "$1"
+    local port=$1
+    : >"$tmp/web.log"
+    # A bound server blocks, so stop it once it announces, not on a fixed
+    # deadline: the announce trails a local-hostname resolve that stalls on macOS,
+    # where a 3s kill landed mid-resolve, before the URL= line ever printed.
+    local had_m=
+    case "$-" in *m*) had_m=1 ;; esac
+    is_windows || set -m
+    htsserver "$tmp" --port "$port" >"$tmp/web.log" 2>&1 &
+    local pid=$!
+    test -n "$had_m" || is_windows || set +m
+    local waited=0
+    until grep -qE "^URL=http://.*:$port/|couldn't set the port number|Unable to initialize a temporary server" "$tmp/web.log"; do
+        test "$waited" -lt 20 || break
+        sleep 1
+        waited=$((waited + 1))
+    done
+    kill_tree "$pid"
+    wait "$pid" 2>/dev/null || true
     ! grep -q "couldn't set the port number" "$tmp/web.log" ||
-        ! echo "FAIL: #614: htsserver --port '$1' wrongly refused" || exit 1
-    # the value must reach the listener: either it bound, or the bind failed --
-    # both prove the parser passed it through, whether or not the port is free
-    grep -qE "^URL=http://.*:$1/|Unable to initialize a temporary server" "$tmp/web.log" ||
-        ! echo "FAIL: #614: htsserver --port '$1' never reached the listener" || exit 1
+        ! echo "FAIL: #614: htsserver --port '$port' wrongly refused" || exit 1
+    grep -qE "^URL=http://.*:$port/|Unable to initialize a temporary server" "$tmp/web.log" ||
+        ! echo "FAIL: #614: htsserver --port '$port' never reached the listener" || exit 1
 }
 
 # this used to listen on 42099
@@ -62,16 +81,16 @@ web_accepted 65535
 
 # --- proxytrack <proxy-addr:port> <ICP-addr:port> --------------------------
 # A bad argument falls through to the usage screen; it had no range check at
-# all, so 65616 quietly listened on port 80.
+# all, so 65616 quietly listened on port 80. A valid one binds and blocks.
 
 proxy_refused() {
-    timeout 5 proxytrack "127.0.0.1:$1" 127.0.0.1:3130 >"$tmp/pt.log" 2>&1 || true
+    run_with_timeout 3 proxytrack "127.0.0.1:$1" 127.0.0.1:3130 >"$tmp/pt.log" 2>&1 || true
     grep -q "^usage:" "$tmp/pt.log" ||
         ! echo "FAIL: #614: proxytrack port '$1' not refused" || exit 1
 }
 
 proxy_accepted() {
-    timeout 5 proxytrack "127.0.0.1:$1" 127.0.0.1:3130 >"$tmp/pt.log" 2>&1 || true
+    run_with_timeout 3 proxytrack "127.0.0.1:$1" 127.0.0.1:3130 >"$tmp/pt.log" 2>&1 || true
     ! grep -q "^usage:" "$tmp/pt.log" ||
         ! echo "FAIL: #614: proxytrack port '$1' wrongly refused" || exit 1
 }
@@ -90,7 +109,8 @@ ftp_port() {
     local out="$tmp/ftp"
 
     rm -rf "$out"
-    timeout 30 httrack "ftp://127.0.0.1:$1/x" -O "$out" --quiet -n >/dev/null 2>&1 || true
+    run_with_timeout 30 httrack "ftp://127.0.0.1:$1/x" -O "$out" --quiet -n \
+        >/dev/null 2>&1 || true
     grep -c "Invalid port: $1" "$out/hts-log.txt" 2>/dev/null || true
 }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -145,6 +145,7 @@ TESTS = \
 	61_webhttrack-locale.test \
 	62_lang-integrity.test \
 	63_webhttrack-home.test \
-	64_local-intl-outdir.test
+	64_local-intl-outdir.test \
+	65_port-siblings.test
 
 CLEANFILES = check-network_sh.cache


### PR DESCRIPTION
The three port parses #610 and #620 left alone: htsserver's `--port`, proxytrack's `host:port` listen arguments, and the `ftp://` URL port. All three read the port with `sscanf("%d")`, which range-checks nothing and is undefined past INT_MAX. `htsserver --port 4295009395` listened on 42099, and proxytrack, which had no range check at all, listened on port 80 for `:65616`. The severity is low and worth saying so: these are operator arguments rather than a link off a scanned page, and a wrong listen port shows up immediately. The ftp one needs a CLI ftp seed, since the wizard refuses an `ftp://` link from scanned HTML.

The policy is not uniform, on purpose. A listen port is the operator's own argument, so htsweb and proxytrack refuse a bad value at startup through the error path each already had: htsweb's `fprintf` + `return -1`, proxytrack's usage screen. Falling back to a default the way #610 does would be a non-fix here, since `:65616` truncates to 80 today and would default to 80 tomorrow, the same wrong port with a passing test. The `ftp://` port is a URL port, so it follows #620 and refuses the link.

`hts_parse_url_port` moves to its own file because neither caller could reach it in htslib.c: htsserver links libhttrack but cannot see a hidden symbol, and proxytrack does not link the library at all. I confirmed the link genuinely fails rather than assuming it from the Makefile. Nothing new is exported, so the ABI is unchanged. Two `--port` changes are deliberate: 0, which quietly asked for the auto-pick, and 65535, which an off-by-one `>= 65535` refused, now both mean what they say.

Test 64 drives the real binaries and fails on the base for each of the three sites independently, checked one leg at a time rather than trusting the first assertion to stop the run. The values that carry it are the ones folding to a plausible port: 4295009395 for `--port`, since 65616 fits an int and the old range check already caught it, plus 65616 and 4294967376 for proxytrack.

Stacks on #620, which owns `hts_parse_url_port`, so only the last commit is mine.

Refs #614