### PR TITLE
Release 3.49.13

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.71])
 
-AC_INIT([httrack], [3.49.12], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
+AC_INIT([httrack], [3.49.13], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
 AC_COPYRIGHT([
 HTTrack Website Copier, Offline Browser for Windows and Unix
 Copyright (C) 1998-2015 Xavier Roche and other contributors
@@ -29,11 +29,13 @@ AC_CONFIG_SRCDIR(src/httrack.c)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
-# 3:4:0: 3.49.12 tail-appends one field (why_url) to httrackp and otherwise only
-# deletes dead comments; no struct layout or exported signature broke vs 3.49.11,
-# so it stays soname .so.3; bump revision.
+# 3:5:0: 3.49.13 leaves every installed struct layout and the exported symbol set
+# untouched vs 3.49.12; the 2 GB (_stat64) and UTF-8 export widenings are _WIN32-only,
+# and INTsys widened on POSIX (#600) but sits in no installed struct. Stays soname
+# .so.3; bump revision. x32 alone changes layout (LLint was 4 bytes there, #524), and
+# is not a release architecture.
 # (3:0:0 was the htsblk mime-buffer widening, the ABI break that moved .so.2 -> .so.3.)
-VERSION_INFO="3:4:0"
+VERSION_INFO="3:5:0"
 AM_MAINTAINER_MODE
 AC_USE_SYSTEM_EXTENSIONS
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+httrack (3.49.13-1) unstable; urgency=medium
+
+  * New upstream release: SOCKS5 and CONNECT proxy support, brotli and zstd
+    content decoding, --update data-loss fixes, and hardening of several
+    network-facing parsers; full list in history.txt.
+  * Add libbrotli-dev and libzstd-dev to Build-Depends for the new content
+    codings.
+  * libhttrack3 and libhttrack-dev no longer ship libhtsjava.so.3*: the
+    obsolete Java-applet parser was removed upstream. It was a dlopen plugin
+    with no reverse dependencies, so this is a plain file drop on upgrade;
+    libhttrack.so.3 itself is unchanged and needs no rename.
+  * Drop the htsjava attribution from debian/copyright.
+
+ -- Xavier Roche <xavier@debian.org>  Fri, 17 Jul 2026 10:49:52 +0200
+
 httrack (3.49.12-1) unstable; urgency=medium
 
   * New upstream release: security and crawl-correctness fixes (remote stack

--- a/history.txt
+++ b/history.txt
@@ -4,6 +4,31 @@ HTTrack Website Copier release history:
 
 This file lists all changes and fixes that have been made for HTTrack
 
+3.49-13
++ New: SOCKS5 proxy support, with scheme-aware -P URLs (socks5://, socks5h://, connect://) and plain HTTP tunneled through a CONNECT-only proxy (#563, #564)
++ New: decode brotli and zstd content codings, advertised over TLS only as browsers do (#556)
++ New: webhttrack exposes the engine options added since 3.49-2, among them --cookies-file, --pause and --strip-query (#587)
++ Fixed: files of 2 GB or more were mishandled on Windows and on every 32-bit build (#569)
++ Fixed: --update destroyed a good local copy when the re-fetch returned an HTTP error, was aborted by -M/-E, failed to decode, or came in short (#176, #521, #557, #562)
++ Fixed: a self-redirect cookie wall was dropped instead of being re-fetched with the cookie (#15)
++ Fixed: a stalled TLS handshake ignored --timeout, and synchronous DNS resolution could wedge a crawl past --max-time (#607, #613)
++ Fixed: -M metered saved bytes rather than received volume, and overshot its cap under a slow server (#77, #520)
++ Fixed: several network-facing overflows and denial-of-service paths in the Content-Range, chunked-transfer, cookie, filter and ProxyTrack cache parsers
++ Fixed: a failed connect did not fall back to the next address on Windows (#579)
++ Fixed: -P took an out-of-range port as a garbage port, and scanned past an IPv6 literal's closing bracket (#598, #602)
++ Fixed: reject a port outside 1..65535 wherever one is parsed (a crawled URL, the htsserver and proxytrack listen arguments, an ftp:// URL), instead of letting a bare sscanf wrap a huge value into a plausible port and silently use it (#614, #626)
++ Fixed: a configured proxy still resolved and dialed the origin itself (#592)
++ Fixed: ~/ in the -O base path was never expanded (#270)
++ Fixed: a non-ASCII -O output path was double-encoded on Windows once argv became UTF-8 (#621)
++ Fixed: files under a non-ASCII project path were saved to a mangled directory on Windows (#217)
++ Fixed: --build-top-index (-%i) and --protocol (-@i) were taken for the -i continue flag, wiping the URL list and exiting on the usage screen (#615)
++ Fixed: webhttrack ignored LC_ALL/LC_MESSAGES and picked the wrong Chinese and Portuguese (#95)
++ Fixed: webhttrack wrote its base path and httrack.ini to the filesystem root when $HOME was empty (#625)
++ Fixed: crawls on a non-default port were slowed by a per-request pre-resolve (#181)
++ Changed: Windows builds moved to Visual Studio 2022 and OpenSSL 3.x, the VS2008 project files are retired, and the binaries carry a version resource
++ Changed: removed the obsolete Java-applet (.class) parser and the dead SWF module remnants
++ Changed: multiple internal hardening, test and CI improvements (Windows and macOS crawl suites, HTML-parser fuzzing, parallel make check)
+
 3.49-12
 + New: --why explains which filter rule accepts or rejects a given URL, then exits (#505)
 + Fixed: links carrying raw UTF-8 bytes were fetched double-encoded and 404'd (#516)

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -43,8 +43,8 @@ Please visit our Website: http://www.httrack.com
    configure.ac, decoupled from these). VERSION is the display form, VERSIONID
    the dotted numeric form, AFF_VERSION the short form shown in footers,
    LIB_VERSION the data/cache format generation. */
-#define HTTRACK_VERSION "3.49-12"
-#define HTTRACK_VERSIONID "3.49.12"
+#define HTTRACK_VERSION "3.49-13"
+#define HTTRACK_VERSIONID "3.49.13"
 #define HTTRACK_AFF_VERSION "3.x"
 #define HTTRACK_LIB_VERSION "2.0"
 

--- a/src/version.rc
+++ b/src/version.rc
@@ -17,8 +17,8 @@
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-  FILEVERSION 3, 49, 12, 0
-  PRODUCTVERSION 3, 49, 12, 0
+  FILEVERSION 3, 49, 13, 0
+  PRODUCTVERSION 3, 49, 13, 0
   FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
 #ifdef _DEBUG
   FILEFLAGS VS_FF_DEBUG
@@ -35,12 +35,12 @@ BEGIN
     BEGIN
       VALUE "CompanyName", "Xavier Roche"
       VALUE "FileDescription", VER_FILE_DESCRIPTION
-      VALUE "FileVersion", "3.49.12"
+      VALUE "FileVersion", "3.49.13"
       VALUE "InternalName", VER_ORIGINAL_FILENAME
       VALUE "LegalCopyright", "Copyright (C) 1998-2026 Xavier Roche and other contributors. GNU GPL v3 or later."
       VALUE "OriginalFilename", VER_ORIGINAL_FILENAME
       VALUE "ProductName", "HTTrack Website Copier"
-      VALUE "ProductVersion", "3.49-12"
+      VALUE "ProductVersion", "3.49-13"
     END
   END
   BLOCK "VarFileInfo"


### PR DESCRIPTION
Release 3.49.13. Rolls up everything merged since 3.49.12: SOCKS5 and CONNECT proxy support, brotli and zstd content decoding, a family of --update data-loss fixes, port range-checking across the crawled-URL, listen and ftp:// paths, 2 GB+ file handling and non-ASCII paths on Windows, and the Windows toolchain port to VS2022 with OpenSSL 3. Full list in history.txt.

VERSION_INFO moves 3:4:0 to 3:5:0, a revision bump only: the installed struct layouts and the exported symbol set are unchanged since 3.49.12, so the soname stays libhttrack.so.3 and the Debian runtime package is not renamed. Packaging adds libbrotli-dev and libzstd-dev to the build-deps and stops shipping libhtsjava.so.3* (the Java-applet parser was removed upstream).
