### PR TITLE
A path-ceiling truncation drops the .delayed marker and loses the file

### DIFF
--- a/src/htsname.c
+++ b/src/htsname.c
@@ -1532,8 +1532,30 @@ int url_savename(lien_adrfilsave *const afs,
       // last segment
       wsave[j++] = '/';
 #define MAX_UTF8_SEQ_CHARS 4
-      for(i = lastSeg; wsave[i] != '\0' && j < maxLen; i++) {
-        wsave[j++] = wsave[i];
+      {
+        // #623: the ".delayed" placeholder marker sits at the tail; cutting
+        // through it drops IS_DELAYED_EXT, so the file is never renamed to its
+        // final name. Reserve the trailing ".<id>.delayed" across the cut.
+        size_t markStart = wsaveLen;
+        if (IS_DELAYED_EXT(afs->save)) {
+          const size_t extDot = wsaveLen - strlen("." DELAYED_EXT);
+          size_t p = extDot; /* walk back over a dot-separated ".<hexid>" tag */
+
+          while (p > lastSeg && ((wsave[p - 1] >= '0' && wsave[p - 1] <= '9') ||
+                                 (wsave[p - 1] >= 'a' && wsave[p - 1] <= 'f')))
+            p--;
+          // keep the tag only if truly ".<hexid>.delayed"; else the bare marker
+          // (a wholly-hex base, e.g. a hashed #133 name, must not be absorbed)
+          markStart = (p > lastSeg && p < extDot && wsave[p - 1] == '.')
+                          ? p - 1
+                          : extDot;
+        }
+        // head, bounded so the marker still fits, then the marker itself
+        for (i = lastSeg; i < markStart && j + (wsaveLen - markStart) < maxLen;
+             i++)
+          wsave[j++] = wsave[i];
+        for (i = markStart; i < wsaveLen && j < maxLen; i++)
+          wsave[j++] = wsave[i];
       }
       // terminating \0
       wsave[j++] = '\0';

--- a/tests/67_engine-delayed-truncate.test
+++ b/tests/67_engine-delayed-truncate.test
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# #623: url_savename enforces the 236-char path ceiling by cutting the tail of
+# the last segment, where the mandatory ".delayed" placeholder marker lives. A
+# cut marker fails IS_DELAYED_EXT, so back_delayed_rename never renames the file
+# to its final name and the download is lost. The marker must survive the cut.
+
+# statuscode=302 status=-1 = a redirect answer still downloading: no type is
+# resolved, so the name gets a ".<id>.delayed" placeholder (see 01_engine-savename).
+CEIL=236
+
+httrack_bin=$(cd "$(dirname "$(command -v httrack)")" && pwd)/httrack
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+cd "$scratch"
+
+run() {
+    "$httrack_bin" -O /dev/null -#test=savename "$@" | sed -n 's/^savename: //p'
+}
+
+# A deep path ending in a long segment that overruns the ceiling.
+deep="/d1$(printf 'a%.0s' {1..40})/d2$(printf 'b%.0s' {1..40})"
+deep="$deep/d3$(printf 'c%.0s' {1..40})/d4$(printf 'd%.0s' {1..40})"
+long="$deep/$(printf 'z%.0s' {1..90})"
+
+out="$(run "$long" text/html statuscode=302 status=-1)"
+case "$out" in
+*.delayed) ;;
+*)
+    echo "FAIL: delayed marker cut by truncation: '$out'"
+    exit 1
+    ;;
+esac
+test "${#out}" -le "$CEIL" || {
+    echo "FAIL: truncated name ${#out} > $CEIL ceiling: '$out'"
+    exit 1
+}
+
+# #133-style hashed name: an all-hex last segment must keep the marker too (the
+# ".<id>." tag is not mistaken for part of the hash).
+hexseg=$(printf 'a1b2c3d4e5f60718%.0s' {1..8})
+hexpath="/d1$(printf 'x%.0s' {1..30})/d2$(printf 'y%.0s' {1..30})/$hexseg"
+out="$(run "$hexpath" text/html statuscode=302 status=-1)"
+case "$out" in
+*.delayed) ;;
+*)
+    echo "FAIL: hashed-name marker cut by truncation: '$out'"
+    exit 1
+    ;;
+esac
+test "${#out}" -le "$CEIL" || {
+    echo "FAIL: hashed name ${#out} > $CEIL ceiling: '$out'"
+    exit 1
+}
+
+# A non-delayed name of the same shape still truncates, with no marker to keep.
+out="$(run "$long.html" text/html)"
+test "${#out}" -le "$CEIL" || {
+    echo "FAIL: non-delayed name ${#out} > $CEIL ceiling: '$out'"
+    exit 1
+}
+case "$out" in
+*.delayed)
+    echo "FAIL: non-delayed name grew a .delayed marker: '$out'"
+    exit 1
+    ;;
+esac
+
+echo "delayed-truncate OK"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -146,6 +146,7 @@ TESTS = \
 	62_lang-integrity.test \
 	63_webhttrack-home.test \
 	64_local-intl-outdir.test \
-	65_port-siblings.test
+	65_port-siblings.test \
+	67_engine-delayed-truncate.test
 
 CLEANFILES = check-network_sh.cache


### PR DESCRIPTION
HTTrack gives a file a temporary `.delayed` placeholder name while it can't resolve the file type yet, then renames the placeholder once the type is known. The problem is that url_savename appends that marker before it enforces the 236-char path ceiling, and the ceiling cuts the tail of the last path segment, which is exactly where the marker lives. Once the trailing `.delayed` is gone the name no longer matches `IS_DELAYED_EXT`, so back_delayed_rename bails out ("nothing bound to the placeholder name") and the downloaded file is never moved to its final name. It is reachable through #133-style deep paths whose final segment is a long hashed filename.

The fix reserves the trailing `.<id>.delayed` in the last-segment copy loop and trims the head of the segment instead, so the result still fits under the ceiling. The hex-id scan stops at its dot separator, so a wholly-hex hashed base is never mistaken for the collision tag and pulled into the marker.

Test 67 drives the naming path over a deep, over-long delayed URL and checks that the marker survives the cut. It fails on master and passes with the fix.

Closes #623
