### PR TITLE
01_engine-xfread flakes on a SIGPIPE race under pipefail

### DIFF
--- a/tests/01_engine-xfread.test
+++ b/tests/01_engine-xfread.test
@@ -9,21 +9,23 @@ set -euo pipefail
 # drives both refusal paths and the accept path.
 
 out="$(httrack -O /dev/null -#test=xfread-limit)"
+# Match with here-strings, not `echo | grep -q`: under pipefail the early grep
+# exit SIGPIPEs echo and fails the pipeline even when the pattern matched.
 for case in bylen bygrow; do
-    echo "$out" | grep -q "${case}: refused=1 adr=null msg=In-memory content too large" || {
+    grep -q "${case}: refused=1 adr=null msg=In-memory content too large" <<<"$out" || {
         echo "FAIL ${case}: $out"
         exit 1
     }
 done
 
 # Exactly INT32_MAX must be refused too (the reallocs add 1).
-echo "$out" | grep -q 'boundary: msg=In-memory content too large' || {
+grep -q 'boundary: msg=In-memory content too large' <<<"$out" || {
     echo "FAIL boundary: $out"
     exit 1
 }
 
 # The guard must NOT fire for a legitimate small size.
-if echo "$out" | grep -q 'accept: msg=In-memory content too large'; then
+if grep -q 'accept: msg=In-memory content too large' <<<"$out"; then
     echo "FAIL accept (guard fired on a legit size): $out"
     exit 1
 fi


### PR DESCRIPTION
The test matched engine output with `echo "$out" | grep -q PATTERN`. Under `set -o pipefail`, `grep -q` exits the moment it matches, so `echo` takes a SIGPIPE writing the rest of its output and the pipeline reports failure even though the pattern was found. The `|| { echo FAIL; exit 1; }` guard then fired on a passing assertion, so the test failed intermittently depending on output size and scheduling. It showed up on the Debian buildd leg of #632, a PR that does not touch this code.

Switching the three matches to here-strings (`grep -q PATTERN <<<"$out"`) drops the pipe, so there is no early reader to SIGPIPE the writer. A deterministic control confirms the mechanism: the old form exits 141 when grep matches the first of many lines, the here-string form exits 0. The fixed test ran 200 times with no failures.

Pre-existing flake, independent of the batch fixes, so it gets its own PR.