### PR TITLE
Pin vcpkg builtin-baseline so shipped OpenSSL is reproducible

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Bumps builtin-baseline in src/vcpkg.json so the pinned OpenSSL/zlib can't rot.
+  # windows-build.yml validates each bump; the pin makes what ships reproducible.
+  - package-ecosystem: vcpkg
+    directory: /src
+    schedule:
+      interval: weekly

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -44,6 +44,20 @@ jobs:
         shell: pwsh
         run: vcpkg integrate install
 
+      # The runner image's vcpkg checkout is pinned to some commit; our manifest's
+      # builtin-baseline is usually newer, so `git show <baseline>:versions/...`
+      # fails until that commit is local. Fetch exactly the pinned baseline (read
+      # from the manifest, so Dependabot bumps need no workflow edit).
+      - name: Fetch the pinned vcpkg baseline
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $root = if ($env:VCPKG_INSTALLATION_ROOT) { $env:VCPKG_INSTALLATION_ROOT } else { "C:\vcpkg" }
+          $baseline = (Get-Content src/vcpkg.json -Raw | ConvertFrom-Json).'builtin-baseline'
+          if (-not $baseline) { throw "no builtin-baseline in src/vcpkg.json" }
+          git -C $root fetch --no-tags origin $baseline
+          if ($LASTEXITCODE -ne 0) { throw "could not fetch vcpkg baseline $baseline" }
+
       # httrack and webhttrack carry a ProjectReference to libhttrack, so building
       # them builds it first; proxytrack is standalone.
       - name: Build

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -3,6 +3,7 @@
       "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "libhttrack",
   "version-string": "3.49",
+  "builtin-baseline": "4bca8fd8654e5ba76f92661db7bfe954768ad8ef",
   "dependencies": [
     "brotli",
     "openssl",


### PR DESCRIPTION
Without a `builtin-baseline`, `src/vcpkg.json` resolves its dependencies in vcpkg's Classic mode, which ignores versioning entirely: the OpenSSL and zlib DLLs deployed next to `libhttrack.dll` come from whatever ports tree the build runner happens to sit at, not from anything committed here. Two tags cut weeks apart with identical git SHAs can ship different OpenSSL, which is the wrong property for a code-signed installer.

Pinning the baseline to a current microsoft/vcpkg commit makes the resolved versions a property of the repo. It resolves OpenSSL to 3.6.3 and zlib to 1.3.2#1, exactly what the Windows build ships today, so it changes nothing about what ships and only makes it deterministic.

A pin on its own would eventually freeze into a CVE-bearing OpenSSL, so the second half is a Dependabot vcpkg entry that advances the baseline weekly through a gated PR. `windows-build.yml` builds every such PR, and the GUI's advisory gate is the release backstop, so the pin stays reproducible per tag without going stale.

Closes #642