### PR TITLE
Correct stale facts in the HTML help pages

### DIFF
--- a/html/cache.html
+++ b/html/cache.html
@@ -173,7 +173,7 @@ There are also specific issues regarding this format:
 <ul>
 <li>The data in the central directory (such as CD extra field, and CD comments) are not used</li>
 <li>The ZIP archive is allowed to contains more than 2^16 files (65535) ; in such case the total number of entries in the 32-bit central directory is 65536 (0xffff), but the presence of the 64-bit central directory is not mandatory</li>
-<li>The ZIP archive is allowed to contains more than 2^32 bytes (4GiB) ; in such case the 64-bit central directory must be present <b>(not currently supported)</b></li>
+<li>The ZIP archive is allowed to contains more than 2^32 bytes (4GiB) ; in such case the 64-bit central directory is emitted automatically (a single stored entry of 4GiB or more is not supported)</li>
 </ul>
 
 <br />

--- a/html/faq.html
+++ b/html/faq.html
@@ -263,7 +263,7 @@ clear language!
 
 <li><a href="#QM8">Can HTTrack generates HP-UX or ISO9660 compatible files?</a><br></li>
 
-<li><a href="#QM9">If there any SOCKS support?</a><br></li>
+<li><a href="#QM9">Is there any SOCKS support?</a><br></li>
 
 <li><a href="#QM10">What's this hts-cache directory? Can I remove it?</a><br></li>
 
@@ -835,8 +835,8 @@ A: <em>Yes. Use user:password@your_proxy_name as your proxy name (example: <tt>s
 <br><br><a NAME="QM8">Q: <strong>Can HTTrack generates HP-UX or ISO9660 compatible files?</strong></a><br>
 A: <em>Yes. See the build options (-N, or see the WinHTTrack options)</em>
 
-<br><br><a NAME="QM9">Q: <strong>If there any SOCKS support?</strong></a><br>
-A: <em>Not yet!</em>
+<br><br><a NAME="QM9">Q: <strong>Is there any SOCKS support?</strong></a><br>
+A: <em>Yes. HTTrack supports SOCKS5 and HTTP CONNECT proxies: give the proxy with a scheme prefix, e.g. <tt>-P socks5://host:port</tt> or <tt>-P connect://host:port</tt> (prefix <tt>user:pass@</tt> before the host for authenticated proxies).</em>
 
 <br><br><a NAME="QM10">Q: <strong>What's this hts-cache directory? Can I remove it?</strong></a><br>
 A: <em>NO if you want to update the site, because this directory is used by HTTrack for this purpose. 

--- a/html/filters.html
+++ b/html/filters.html
@@ -189,7 +189,7 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
     <br>
     Filters are analyzed by HTTrack from the first filter to the last one. The complete URL
     name is compared to filters defined by the user or added automatically by HTTrack. <br><br>
-    A scan rule has an higher priority is it is declared later - hierarchy is important: <br>
+    A scan rule has a higher priority if it is declared later - hierarchy is important: <br>
 
     <br>
     <table BORDER="1" CELLPADDING="2">
@@ -307,7 +307,7 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
     <br>
     Filters are analyzed by HTTrack from the first filter to the last one. The sizes
     are compared against scan rules defined by the user.<br><br>
-    A scan rule has an higher priority is it is declared later - hierarchy is important.<br>
+    A scan rule has a higher priority if it is declared later - hierarchy is important.<br>
     
     Note: scan rules based on size can be mixed with regular URL patterns<br>
 
@@ -361,7 +361,7 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
     <br>
     Filters are analyzed by HTTrack from the first filter to the last one. The complete MIME
     type is compared against scan rules defined by the user.<br><br>
-    A scan rule has an higher priority is it is declared later - hierarchy is important<br>
+    A scan rule has a higher priority if it is declared later - hierarchy is important<br>
 
     Note: scan rules based on MIME types can <b>NOT</b> be mixed with regular URL patterns or size patterns within the same rule, but you can use both of them in distinct ones<br>
 
@@ -387,12 +387,12 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
       <tr>
         <td nowrap><tt>-mime:video/*</tt></td>
         <td>This will refuse all video links that were already scheduled for download
-        (i.e. all other 'application/' link download will be aborted)</td>
+        (i.e. the download will be aborted)</td>
       </tr>
       <tr>
         <td nowrap><tt>-mime:video/* -mime:audio/*</tt></td>
         <td>This will refuse all audio and video links that were already scheduled for download
-        (i.e. all other 'application/' link download will be aborted)</td>
+        (i.e. the download will be aborted)</td>
       </tr>
       <tr>
         <td nowrap><tt>-mime:*/* +mime:text/html +mime:image/*</tt></td>

--- a/html/plug.html
+++ b/html/plug.html
@@ -286,7 +286,7 @@ module exit point
 the function name and prototype MUST match this prototype
 */
 EXTERNAL_FUNCTION int hts_unplug(httrackp *opt) {
-  fprintf(stder, "Module unplugged");
+  fprintf(stderr, "Module unplugged");
 
   return 1;  /* success */
 }


### PR DESCRIPTION
Four factual bugs in the shipped html/ help pages, found while scoping a broader documentation refresh.

The FAQ still answered "Is there any SOCKS support? Not yet!", but SOCKS5 and HTTP CONNECT proxies have shipped (`-P socks5://host:port` / `-P connect://host:port`).

cache.html claimed a ZIP cache over 4GiB was "not currently supported". minizip emits the ZIP64 central directory automatically for archives over 4GiB or 65535 entries; the real remaining limit is a single stored entry of 4GiB or more.

Two `-mime:video/*` example rows in filters.html described "application/" instead of the video rule (a copy-paste slip), and a repeated "a scan rule has a higher priority is it is declared later" garbled "if".

plug.html's sample module had a compile-breaking `fprintf(stder, ...)`.

Docs-only, no engine change. First of a few small doc PRs; a larger grammar/chrome sweep and a new Android help page follow separately.