### PR TITLE
Refresh the documentation copyright year to 1998-2026

### DIFF
--- a/html/abuse.html
+++ b/html/abuse.html
@@ -579,7 +579,7 @@ And then, put the email address in your pages through:
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/addurl.html
+++ b/html/addurl.html
@@ -144,7 +144,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/cache.html
+++ b/html/cache.html
@@ -282,7 +282,7 @@ Libraries should generally handle this peculiar format, however.
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/cmddoc.html
+++ b/html/cmddoc.html
@@ -145,7 +145,7 @@ The command-line version
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/contact.html
+++ b/html/contact.html
@@ -243,7 +243,7 @@ roche at httrack dot com (Xavier ROCHE)<br>
 <br><hr><br>
 <br>
 	This program is covered by the GNU General Public License.<br>
-     	HTTrack/HTTrack Website Copier is Copyright (C) 1998-2007 Xavier Roche and other contributors
+     	HTTrack/HTTrack Website Copier is Copyright (C) 1998-2026 Xavier Roche and other contributors
 <br>
 
 <!-- ==================== Start epilogue ==================== -->
@@ -259,7 +259,7 @@ roche at httrack dot com (Xavier ROCHE)<br>
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/dev.html
+++ b/html/dev.html
@@ -147,7 +147,7 @@ This page describes the HTTrack cache format.
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/faq.html
+++ b/html/faq.html
@@ -931,7 +931,7 @@ A: <em>Feel free to <a href="contact.html">contact us</a>!
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/filters.html
+++ b/html/filters.html
@@ -466,7 +466,7 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/index.html
+++ b/html/index.html
@@ -142,7 +142,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/library.html
+++ b/html/library.html
@@ -125,7 +125,7 @@ You may also want to check the <tt>httrack.c</tt> and <tt>httrack.h<tt> files to
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/options.html
+++ b/html/options.html
@@ -352,7 +352,7 @@ Add debug informations on log files
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/overview.html
+++ b/html/overview.html
@@ -145,7 +145,7 @@ downloads. HTTrack is fully configurable, and has an integrated help system.
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/plug.html
+++ b/html/plug.html
@@ -331,7 +331,7 @@ httrack --wrapper mylibrary,myparameter-string http://www.example.com
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/plug_330.html
+++ b/html/plug_330.html
@@ -204,7 +204,7 @@ Below additional function names that can be defined inside the optional libhttra
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/scripting.html
+++ b/html/scripting.html
@@ -250,7 +250,7 @@ Script example:
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/server/about.html
+++ b/html/server/about.html
@@ -92,7 +92,7 @@ ${LANG_K3} : ${HTTRACK_WEB}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/addurl.html
+++ b/html/server/addurl.html
@@ -159,7 +159,7 @@ ${do:end-if}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/error.html
+++ b/html/server/error.html
@@ -72,7 +72,7 @@ ${error}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/file.html
+++ b/html/server/file.html
@@ -96,7 +96,7 @@ ${do:loadhash}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/finished.html
+++ b/html/server/finished.html
@@ -143,7 +143,7 @@ ${path}/${projname}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/help.html
+++ b/html/server/help.html
@@ -103,7 +103,7 @@ ${do:end-if}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/index.html
+++ b/html/server/index.html
@@ -133,7 +133,7 @@ ${LANG_THANKYOU}!
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/option1.html
+++ b/html/server/option1.html
@@ -158,7 +158,7 @@ ${do:end-if}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/option10.html
+++ b/html/server/option10.html
@@ -160,7 +160,7 @@ ${LANG_IOPT10}:
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/option11.html
+++ b/html/server/option11.html
@@ -250,7 +250,7 @@ ${LANG_W3}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/option2.html
+++ b/html/server/option2.html
@@ -176,7 +176,7 @@ ${listid:build:LISTDEF_3}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/option2b.html
+++ b/html/server/option2b.html
@@ -140,7 +140,7 @@ ${do:output-mode:}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/option3.html
+++ b/html/server/option3.html
@@ -191,7 +191,7 @@ ${listid:travel3:LISTDEF_11}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/option4.html
+++ b/html/server/option4.html
@@ -184,7 +184,7 @@ ${LANG_I46}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/option5.html
+++ b/html/server/option5.html
@@ -228,7 +228,7 @@ ${LANG_I64b}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/option6.html
+++ b/html/server/option6.html
@@ -156,7 +156,7 @@ ${LANG_I43b}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/option7.html
+++ b/html/server/option7.html
@@ -148,7 +148,7 @@ ${LANG_B13}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/option8.html
+++ b/html/server/option8.html
@@ -212,7 +212,7 @@ ${LANG_STRIPQUERY}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/option9.html
+++ b/html/server/option9.html
@@ -166,7 +166,7 @@ ${listid:logtype:LISTDEF_9}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/refresh.html
+++ b/html/server/refresh.html
@@ -204,7 +204,7 @@ ${LANG_H20} ${info.currentjob}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/step2.html
+++ b/html/server/step2.html
@@ -283,7 +283,7 @@ ${do:end-if:}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/step3.html
+++ b/html/server/step3.html
@@ -196,7 +196,7 @@ ${do:output-mode:}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/server/step4.html
+++ b/html/server/step4.html
@@ -324,7 +324,7 @@ ${do:output-mode:}
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
+	<td id="footer"><small><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></small></td>
 	</tr>
 </table>
 

--- a/html/shelldoc.html
+++ b/html/shelldoc.html
@@ -141,7 +141,7 @@ You may encounter minor differences (in the display, or in various options) betw
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/step.html
+++ b/html/step.html
@@ -128,7 +128,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/step1.html
+++ b/html/step1.html
@@ -143,7 +143,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/step2.html
+++ b/html/step2.html
@@ -157,7 +157,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/step3.html
+++ b/html/step3.html
@@ -151,7 +151,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/step4.html
+++ b/html/step4.html
@@ -128,7 +128,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/step5.html
+++ b/html/step5.html
@@ -127,7 +127,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/step9.html
+++ b/html/step9.html
@@ -144,7 +144,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/step9_opt1.html
+++ b/html/step9_opt1.html
@@ -145,7 +145,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/step9_opt10.html
+++ b/html/step9_opt10.html
@@ -150,7 +150,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/step9_opt11.html
+++ b/html/step9_opt11.html
@@ -182,7 +182,7 @@ In this case, HTTrack won't check the type, because it has learned that "foo" is
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/step9_opt2.html
+++ b/html/step9_opt2.html
@@ -181,7 +181,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/step9_opt3.html
+++ b/html/step9_opt3.html
@@ -145,7 +145,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/step9_opt4.html
+++ b/html/step9_opt4.html
@@ -176,7 +176,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/step9_opt5.html
+++ b/html/step9_opt5.html
@@ -165,7 +165,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/step9_opt6.html
+++ b/html/step9_opt6.html
@@ -162,7 +162,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/step9_opt7.html
+++ b/html/step9_opt7.html
@@ -151,7 +151,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/step9_opt8.html
+++ b/html/step9_opt8.html
@@ -141,7 +141,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/html/step9_opt9.html
+++ b/html/step9_opt9.html
@@ -156,7 +156,7 @@ h4 { margin: 0;  font-weight: bold;  font-size: 1.18em; }
 
 <table width="76%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2007 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998-2026 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 


### PR DESCRIPTION
The html/ help pages still carried a 2007 copyright in every footer, and contact.html an inline "Copyright (C) 1998-2007". This bumps them to 1998-2026. Footer text only, no content changes; fcguide.html (Fred Cohen, upstream) is left untouched.