### PR TITLE
Stop -K from silently resetting the -c socket count

### DIFF
--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -1055,6 +1055,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
               while(isdigit((unsigned char) *(com + 1)))
                 com++;
             }
+            break;
           case 'c':
             if (isdigit((unsigned char) *(com + 1))) {
               sscanf(com + 1, "%d", &opt->maxsoc);

--- a/tests/01_engine-cmdline.test
+++ b/tests/01_engine-cmdline.test
@@ -155,4 +155,22 @@ accepted "$tmp/pre-bti" "#615: -%i before the URL broke the crawl"
 run_only "$tmp/pre-proto" "-@i2" "file://$tmp/index.html"
 accepted "$tmp/pre-proto" "#615: -@i2 before the URL broke the crawl"
 
+# -K must not reset the -c socket count (its case fell through into 'c'). maxsoc
+# is only observable via the ">8, limited to 8" warning: -c16 trips it, and would
+# stop tripping it if a trailing -K reset the count back to the default 4.
+warned() {
+    grep -q 'simultaneous connections limited to' "$1/hts-log.txt" ||
+        ! echo "FAIL: $2" || exit 1
+}
+not_warned() {
+    ! grep -q 'simultaneous connections limited to' "$1/hts-log.txt" ||
+        ! echo "FAIL: $2" || exit 1
+}
+run "$tmp/soc-c16" -c16
+warned "$tmp/soc-c16" "-c16 did not trip the socket-count warning (probe blind)"
+run "$tmp/soc-c16k" -c16 -K
+warned "$tmp/soc-c16k" "-K reset the -c socket count (fell through into 'c')"
+run "$tmp/soc-c8k" -c8 -K
+not_warned "$tmp/soc-c8k" "-c8 -K spuriously warned"
+
 exit 0


### PR DESCRIPTION
The command-line parser's `case 'K':` fell through into `case 'c':` for lack of a `break`. A bare `-K` (the keep-links rewrite mode, no trailing digit) landed in the socket-count case and reset it to the default 4, so `-c8 -K` ran with four connections instead of eight. Only a trailing bare `-K` triggered it, which is why it stayed hidden.

The fix is the missing `break`. `maxsoc` is not printed anywhere reachable from the CLI, so the regression test keys off the one observable it has: a socket count above 8 trips the "limited to 8" security warning in `hts-log.txt`. `-c16` warns, and `-c16 -K` warns only if the 16 survives the `-K`. The test fails on the pre-fix build with the exact message and passes after; verified by rebuilding both ways.

No matching tracker issue found.