### PR TITLE
minizip re-apply snapshot for mztools.c drifted from the live file

### DIFF
--- a/src/minizip/mztools.c.diff
+++ b/src/minizip/mztools.c.diff
@@ -1,6 +1,6 @@
 --- mztools.c.orig	2024-01-27 14:07:18.636193212 +0100
 +++ mztools.c	2024-01-27 14:09:55.356620093 +0100
-@@ -10,6 +10,7 @@
+@@ -10,10 +10,11 @@
  #include <string.h>
  #include "zlib.h"
  #include "unzip.h"
@@ -8,6 +8,11 @@
  
  #define READ_8(adr)  ((unsigned char)*(adr))
  #define READ_16(adr) ( READ_8(adr) | (READ_8(adr+1) << 8) )
+-#define READ_32(adr) ( READ_16(adr) | (READ_16((adr)+2) << 16) )
++#define READ_32(adr) ((uLong) READ_16(adr) | ((uLong) READ_16((adr) + 2) << 16))
+ 
+ #define WRITE_8(buff, n) do { \
+   *((unsigned char*)(buff)) = (unsigned char) ((n) & 0xff); \
 @@ -141,8 +142,8 @@
          /* Central directory entry */
          {


### PR DESCRIPTION
src/minizip/ vendors a patched minizip: for each patched file there is a pristine X.orig plus an X.diff that gets replayed onto a fresh upstream when minizip is re-synced. That only works if X.diff tracks the live file.

PR #640 fixed a signed-shift UB in the live mztools.c (the READ_32 macro now casts each recovered 16-bit half to uLong before the shift) but never regenerated mztools.c.diff. The diff still carried the old READ_32, so the next minizip re-sync would have quietly dropped the fix.

Regenerated mztools.c.diff from the live file, keeping the existing date-label header convention so the change is content-only. It reproduces src/minizip/mztools.c byte-for-byte again. The other four snapshots (ioapi.c, ioapi.h, zip.c, zip.h) already match their live files and are left untouched.