### PR TITLE
Wedged offline crawl fetches hang the Windows CI step instead of failing fast

### DIFF
--- a/tests/72_watchdog-crawl.test
+++ b/tests/72_watchdog-crawl.test
@@ -1,10 +1,8 @@
 #!/bin/bash
 #
-# Control for the crawl watchdog (wait_bounded in local-crawl.sh): a fetch that
-# wedges past the engine's own limits must be reaped at the harness deadline and
-# reported in seconds, never left to hang the CI step to its 45-minute cap (the
-# Windows x64/Win32 "lost communication" hangs). Drives CRAWL_DEADLINE low
-# against an always-stall endpoint and asserts a fast, watchdog-attributed fail.
+# Control for the crawl watchdog (wait_bounded): a wedged fetch must be reaped at
+# the harness deadline in seconds, not hang the CI step to its 45-min cap. Drives
+# CRAWL_DEADLINE low against an always-stall endpoint; asserts a fast, attributed fail.
 
 : "${top_srcdir:=..}"
 
@@ -18,8 +16,8 @@ out=$(CRAWL_DEADLINE=3 bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
     httrack 'BASEURL/watchdog/stall' 2>&1) && rc=0 || rc=$?
 elapsed=$((SECONDS - start))
 
-# Skip, don't fail, on causes unrelated to the watchdog: no python3/server (77),
-# or the ephemeral-port announce racing on a slow Windows runner (flaky-13).
+# Skip (not fail) on causes unrelated to the watchdog: no python3/server, or a
+# port-announce race (flaky-13).
 test "$rc" -ne 77 || {
     echo "SKIP: local crawl prerequisites missing" >&2
     exit 77
@@ -29,9 +27,8 @@ if printf '%s\n' "$out" | grep -q "could not discover server port"; then
     exit 77
 fi
 
-# The watchdog message only prints on the 124 reap, and 20s is below the engine's
-# own --timeout=30, so both together pin the fast exit on the 3s harness watchdog
-# rather than httrack eventually giving up on the stalled read.
+# The message prints only on the 124 reap, and 20s < the engine's --timeout=30, so
+# together they pin the fast exit on the 3s watchdog, not httrack giving up.
 test "$rc" -ne 0 || fail "stalled crawl reported success"
 test "$elapsed" -lt 20 || fail "watchdog fired late (${elapsed}s)"
 printf '%s\n' "$out" | grep -q "watchdog fired" ||

--- a/tests/72_watchdog-crawl.test
+++ b/tests/72_watchdog-crawl.test
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Control for the crawl watchdog (wait_bounded in local-crawl.sh): a fetch that
+# wedges past the engine's own limits must be reaped at the harness deadline and
+# reported in seconds, never left to hang the CI step to its 45-minute cap (the
+# Windows x64/Win32 "lost communication" hangs). Drives CRAWL_DEADLINE low
+# against an always-stall endpoint and asserts a fast, watchdog-attributed fail.
+
+: "${top_srcdir:=..}"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+start=$SECONDS
+out=$(CRAWL_DEADLINE=3 bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
+    httrack 'BASEURL/watchdog/stall' 2>&1) && rc=0 || rc=$?
+elapsed=$((SECONDS - start))
+
+# Skip, don't fail, on causes unrelated to the watchdog: no python3/server (77),
+# or the ephemeral-port announce racing on a slow Windows runner (flaky-13).
+test "$rc" -ne 77 || {
+    echo "SKIP: local crawl prerequisites missing" >&2
+    exit 77
+}
+if printf '%s\n' "$out" | grep -q "could not discover server port"; then
+    echo "SKIP: server port announce raced" >&2
+    exit 77
+fi
+
+# The watchdog message only prints on the 124 reap, and 20s is below the engine's
+# own --timeout=30, so both together pin the fast exit on the 3s harness watchdog
+# rather than httrack eventually giving up on the stalled read.
+test "$rc" -ne 0 || fail "stalled crawl reported success"
+test "$elapsed" -lt 20 || fail "watchdog fired late (${elapsed}s)"
+printf '%s\n' "$out" | grep -q "watchdog fired" ||
+    fail "crawl failed but not via the watchdog: $out"
+
+echo "crawl watchdog OK (reaped in ${elapsed}s)"

--- a/tests/72_watchdog-crawl.test
+++ b/tests/72_watchdog-crawl.test
@@ -1,8 +1,7 @@
 #!/bin/bash
 #
-# Control for the crawl watchdog (wait_bounded): a wedged fetch must be reaped at
-# the harness deadline in seconds, not hang the CI step to its 45-min cap. Drives
-# CRAWL_DEADLINE low against an always-stall endpoint; asserts a fast, attributed fail.
+# Control for wait_bounded: a wedged fetch must be reaped at the harness deadline,
+# not hang the CI step to its 45-min cap.
 
 : "${top_srcdir:=..}"
 
@@ -27,10 +26,10 @@ if printf '%s\n' "$out" | grep -q "could not discover server port"; then
     exit 77
 fi
 
-# The message prints only on the 124 reap, and 20s < the engine's --timeout=30, so
+# The message prints only on the 124 reap, and 25s < the engine's --timeout=30, so
 # together they pin the fast exit on the 3s watchdog, not httrack giving up.
 test "$rc" -ne 0 || fail "stalled crawl reported success"
-test "$elapsed" -lt 20 || fail "watchdog fired late (${elapsed}s)"
+test "$elapsed" -lt 25 || fail "watchdog fired late (${elapsed}s)"
 printf '%s\n' "$out" | grep -q "watchdog fired" ||
     fail "crawl failed but not via the watchdog: $out"
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -152,6 +152,7 @@ TESTS = \
 	67_engine-delayed-truncate.test \
 	68_webhttrack-outdir-charset.test \
 	69_local-intl-logdir.test \
-	71_local-crange-repaircache.test
+	71_local-crange-repaircache.test \
+	72_watchdog-crawl.test
 
 CLEANFILES = check-network_sh.cache

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -243,13 +243,18 @@ fi
 # Localhost is fast; disable the rate/bandwidth safety limits but keep a
 # max-time backstop so a hang cannot wedge the suite.
 declare -a moreargs=(--quiet --max-time=120 --timeout=30 --disable-security-limits --robots=0)
+# Harness watchdog above --max-time: the engine limit fires first on a healthy
+# crawl, so this only catches a genuine wedge the engine missed (a Windows socket
+# stall). CRAWL_DEADLINE lets 72_watchdog-crawl drive it low to prove fail-fast.
+crawl_deadline=${CRAWL_DEADLINE:-180}
 log="${tmpdir}/log"
 info "running httrack ${hts[*]}"
 httrack -O "$odir" --user-agent="httrack $ver local ($(uname -mrs))" "${moreargs[@]}" "${hts[@]}" >"$log" 2>&1 &
 crawlpid=$!
-wait "$crawlpid"
+wait_bounded "$crawlpid" "$crawl_deadline"
 crawlres=$?
 crawlpid=
+test "$crawlres" -ne 124 || warning "crawl watchdog fired after ${crawl_deadline}s"
 # httrack exits 0 even on hard connect/DNS errors, so this is a backstop only;
 # the real guard is the audit below (--errors 0 plus the host-root existence check).
 test "$crawlres" -eq 0 || ! result "httrack exited $crawlres" || {
@@ -265,7 +270,7 @@ if test -n "$rerun"; then
     httrack -O "$odir" --user-agent="httrack $ver local ($(uname -mrs))" \
         "${moreargs[@]}" "${hts[@]}" >"${log}.2" 2>&1 &
     crawlpid=$!
-    wait "$crawlpid"
+    wait_bounded "$crawlpid" "$crawl_deadline"
     crawlres=$?
     crawlpid=
     test "$crawlres" -eq 0 || ! result "update pass exited $crawlres" || {
@@ -293,7 +298,7 @@ if test -n "$rerun_args"; then
     httrack -O "$odir" --user-agent="httrack $ver local ($(uname -mrs))" \
         "${moreargs[@]}" "${hts[@]}" "${extra[@]}" >"${log}.2" 2>&1 &
     crawlpid=$!
-    wait "$crawlpid"
+    wait_bounded "$crawlpid" "$crawl_deadline"
     crawlres=$?
     crawlpid=
     test "$crawlres" -eq 0 || ! result "second pass exited $crawlres" || {
@@ -315,7 +320,7 @@ if test -n "$rerun_dead"; then
     httrack -O "$odir" --user-agent="httrack $ver local ($(uname -mrs))" \
         "${moreargs[@]}" "${hts[@]}" >"${log}.dead" 2>&1 &
     crawlpid=$!
-    wait "$crawlpid" || true
+    wait_bounded "$crawlpid" "$crawl_deadline" || true
     crawlpid=
     result "OK (dead pass ran)"
     # The dead pass must have gone through the no-data rollback, not bailed out

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -243,9 +243,8 @@ fi
 # Localhost is fast; disable the rate/bandwidth safety limits but keep a
 # max-time backstop so a hang cannot wedge the suite.
 declare -a moreargs=(--quiet --max-time=120 --timeout=30 --disable-security-limits --robots=0)
-# Harness watchdog above --max-time: the engine limit fires first on a healthy
-# crawl, so this only catches a genuine wedge the engine missed (a Windows socket
-# stall). CRAWL_DEADLINE lets 72_watchdog-crawl drive it low to prove fail-fast.
+# Watchdog above --max-time so the engine limit fires first when healthy; only a
+# genuine wedge trips it. CRAWL_DEADLINE lets 72_watchdog-crawl drive it low.
 crawl_deadline=${CRAWL_DEADLINE:-180}
 log="${tmpdir}/log"
 info "running httrack ${hts[*]}"

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -979,6 +979,23 @@ class Handler(SimpleHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
+    # Always-stall endpoint for 72_watchdog-crawl: promise a body, deliver a
+    # prefix, then sleep past any deadline so the crawl wedges and the harness
+    # watchdog (not the engine) must reap it.
+    def route_watchdog_stall(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", "1000000")  # never delivered
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(b"STALL")
+            self.wfile.flush()
+            try:
+                while True:
+                    time.sleep(3600)
+            except OSError:
+                pass
+
     # C7: stall the first GET (partial + temp-ref), then answer the resume's
     # Range with a bogus 304; httrack must drop the partial and refetch.
     RESUME304_BODY = b"C7DATA--" + bytes((i * 7 + 3) % 256 for i in range(8192))
@@ -1563,6 +1580,7 @@ class Handler(SimpleHTTPRequestHandler):
         "/types/gen.php": route_types,
         "/intl/index.html": route_intl_index,
         "/intl/" + INTL_NAME: route_intl_page,
+        "/watchdog/stall": route_watchdog_stall,
         "/resume/index.html": route_resume_index,
         "/resume/blob.txt": route_resume,
         "/resume304/index.html": route_resume304_index,

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -979,9 +979,8 @@ class Handler(SimpleHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
-    # Always-stall endpoint for 72_watchdog-crawl: promise a body, deliver a
-    # prefix, then sleep past any deadline so the crawl wedges and the harness
-    # watchdog (not the engine) must reap it.
+    # Always-stall endpoint for 72_watchdog-crawl: promise a big body, send a few
+    # bytes, then sleep so the crawl wedges and the harness watchdog must reap it.
     def route_watchdog_stall(self):
         self.send_response(200)
         self.send_header("Content-Type", "application/octet-stream")

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -979,8 +979,8 @@ class Handler(SimpleHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
-    # Always-stall endpoint for 72_watchdog-crawl: promise a big body, send a few
-    # bytes, then sleep so the crawl wedges and the harness watchdog must reap it.
+    # Always-stall endpoint for 72_watchdog-crawl: never finishes, so the harness
+    # watchdog must reap it.
     def route_watchdog_stall(self):
         self.send_response(200)
         self.send_header("Content-Type", "application/octet-stream")

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -31,15 +31,15 @@ is_windows() {
     esac
 }
 
-# Stop a backgrounded server and reap it; MSYS cannot signal a native python.exe,
-# so only -9 lands. Every step is "|| true": callers run under set -e, and reaping
-# a server we just signalled makes wait return 143.
+# Stop a backgrounded server and reap it. MSYS cannot signal a native python.exe,
+# so on Windows we reap the whole native tree (kill_tree): a bare kill -9 leaves
+# the winpid's children behind, and a lingering server holds the CI step open.
+# Every step is "|| true": callers run under set -e, and reaping a server we just
+# signalled makes wait return 143.
 stop_server() {
     test -n "${1:-}" || return 0
     kill "$1" 2>/dev/null || true
-    if is_windows; then
-        kill -9 "$1" 2>/dev/null || true
-    fi
+    if is_windows; then kill_tree "$1"; fi
     wait "$1" 2>/dev/null || true
     return 0
 }
@@ -98,6 +98,27 @@ run_with_timeout() {
     local pid=$!
     test -n "$had_m" || is_windows || set +m
     local waited=0
+    while kill -0 "$pid" 2>/dev/null; do
+        if test "$waited" -ge "$secs"; then
+            kill_tree "$pid"
+            wait "$pid" 2>/dev/null || true
+            return 124
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    wait "$pid"
+}
+
+# Wait for an already-backgrounded crawl (pid $1) under a $2-second deadline,
+# returning its status or 124 if it overran and was reaped tree-and-all. The
+# crawl launchers background httrack themselves (they track the pid for their
+# EXIT trap), so they need a deadline attached to an existing pid rather than
+# run_with_timeout's own fork: a fetch that wedges past --max-time (a Windows
+# socket stall the engine can miss) would otherwise block wait(1) forever and
+# hang the CI step to its 45-minute cap, reading as "lost communication".
+wait_bounded() {
+    local pid=$1 secs=$2 waited=0
     while kill -0 "$pid" 2>/dev/null; do
         if test "$waited" -ge "$secs"; then
             kill_tree "$pid"

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -31,9 +31,9 @@ is_windows() {
     esac
 }
 
-# Stop a backgrounded server and reap it. On Windows MSYS can't signal a native
-# python.exe, so kill_tree ends the whole tree (a bare kill -9 leaves children).
-# "|| true" throughout: callers run under set -e and the reap makes wait return 143.
+# On Windows MSYS can't signal a native python.exe, so kill_tree ends the whole
+# tree (a bare kill -9 leaves children). "|| true" throughout: callers run under
+# set -e and the reap makes wait return 143.
 stop_server() {
     test -n "${1:-}" || return 0
     kill "$1" 2>/dev/null || true
@@ -108,9 +108,8 @@ run_with_timeout() {
     wait "$pid"
 }
 
-# Bound an already-backgrounded crawl (pid $1) at $2s, reaping it tree-and-all and
-# returning 124 on overrun: a wedge past --max-time would else block wait() forever
-# and hang the CI step. (The launchers keep the pid for their trap, hence not run_with_timeout.)
+# Bound an already-backgrounded crawl (pid $1) at $2s, reaping it and returning 124
+# on overrun: a wedge past --max-time would else block wait() forever and hang the CI step.
 wait_bounded() {
     local pid=$1 secs=$2 waited=0
     while kill -0 "$pid" 2>/dev/null; do

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -31,11 +31,9 @@ is_windows() {
     esac
 }
 
-# Stop a backgrounded server and reap it. MSYS cannot signal a native python.exe,
-# so on Windows we reap the whole native tree (kill_tree): a bare kill -9 leaves
-# the winpid's children behind, and a lingering server holds the CI step open.
-# Every step is "|| true": callers run under set -e, and reaping a server we just
-# signalled makes wait return 143.
+# Stop a backgrounded server and reap it. On Windows MSYS can't signal a native
+# python.exe, so kill_tree ends the whole tree (a bare kill -9 leaves children).
+# "|| true" throughout: callers run under set -e and the reap makes wait return 143.
 stop_server() {
     test -n "${1:-}" || return 0
     kill "$1" 2>/dev/null || true
@@ -110,13 +108,9 @@ run_with_timeout() {
     wait "$pid"
 }
 
-# Wait for an already-backgrounded crawl (pid $1) under a $2-second deadline,
-# returning its status or 124 if it overran and was reaped tree-and-all. The
-# crawl launchers background httrack themselves (they track the pid for their
-# EXIT trap), so they need a deadline attached to an existing pid rather than
-# run_with_timeout's own fork: a fetch that wedges past --max-time (a Windows
-# socket stall the engine can miss) would otherwise block wait(1) forever and
-# hang the CI step to its 45-minute cap, reading as "lost communication".
+# Bound an already-backgrounded crawl (pid $1) at $2s, reaping it tree-and-all and
+# returning 124 on overrun: a wedge past --max-time would else block wait() forever
+# and hang the CI step. (The launchers keep the pid for their trap, hence not run_with_timeout.)
 wait_bounded() {
     local pid=$1 secs=$2 waited=0
     while kill -0 "$pid" 2>/dev/null; do


### PR DESCRIPTION
The offline test suite waits on each httrack crawl with a bare `wait`, bounded only by the engine`s own `--max-time`. A fetch that wedges past that limit (a Windows socket stall the engine can miss) blocks the wait indefinitely, so the test step runs to its 45-minute cap and surfaces as the recurring x64/Win32 "the hosted runner lost communication with the server" hang, seen again on #658. The `kill_tree` reaper added in #595 was only ever exercised by `58_watchdog`; the real crawl path never used it.

`wait_bounded` attaches that reaper to the crawl the launcher already backgrounds, so an overrun is killed tree-and-all and reported in seconds rather than 45 minutes, and `stop_server` now reaps the server`s whole native tree instead of just its direct child. `72_watchdog-crawl` proves the fail-fast end to end against an always-stall endpoint, and skips rather than fails if the unrelated ephemeral-port announce races (a separate follow-up).