### PR TITLE
webhttrack wizard headings "Select URLs" and "Start" stay English in every locale

### DIFF
--- a/html/server/step3.html
+++ b/html/server/step3.html
@@ -95,7 +95,7 @@ ${do:end-if}
 
 <table border="0" width="100%">
 <tr><td width="90%">
-	<h2 align="center"><em>Select URLs</em></h2>
+	<h2 align="center"><em>${LANG_G44}</em></h2>
 </td>
 ${/* show help only if available */}
 ${do:if-file-exists:html/index.html}

--- a/html/server/step4.html
+++ b/html/server/step4.html
@@ -77,7 +77,7 @@ ${do:end-if}
 
 <table border="0" width="100%">
 <tr><td width="90%">
-	<h2 align="center"><em>Start</em></h2>
+	<h2 align="center"><em>${LANG_J9}</em></h2>
 </td>
 ${/* show help only if available */}
 ${do:if-file-exists:html/index.html}


### PR DESCRIPTION
The step3 and step4 section headings in the webhttrack server wizard were hardcoded English, bypassing the `${LANG_...}` substitution, so they showed English in all 30 locales.

They now reference existing, already-translated keys: `${LANG_J9}` ("Start", an exact match) and `${LANG_G44}` ("Web Addresses: (URL)"). Reusing keys avoids adding a string across the 32 legacy-encoded lang files. Note: `${LANG_G44}` also labels the URL textarea just below the step3 heading, so the two now read alike; the closer-worded `LANG_URLS` was rejected because it is empty in the Swedish locale and would render a blank heading. No changes to `lang.def` or `lang/*.txt`.