### PR TITLE
Fix duplicate and dead --help option letters, document -%z, -%t, -y

### DIFF
--- a/html/httrack.man.html
+++ b/html/httrack.man.html
@@ -100,28 +100,30 @@ offline browser : copy websites to a local directory</p>
 ] [ <b>-%Y, --why</b> ] [ <b>-u, --check-type[=N]</b> ] [
 <b>-j, --parse-java[=N]</b> ] [ <b>-sN, --robots[=N]</b> ] [
 <b>-%h, --http-10</b> ] [ <b>-%k, --keep-alive</b> ] [
-<b>-%B, --tolerant</b> ] [ <b>-%s, --updatehack</b> ] [
-<b>-%u, --urlhack</b> ] [ <b>-%A, --assume</b> ] [ <b>-@iN,
---protocol[=N]</b> ] [ <b>-%w, --disable-module</b> ] [
-<b>-F, --user-agent</b> ] [ <b>-%R, --referer</b> ] [
-<b>-%E, --from</b> ] [ <b>-%F, --footer</b> ] [ <b>-%l,
---language</b> ] [ <b>-%a, --accept</b> ] [ <b>-%X,
---headers</b> ] [ <b>-C, --cache[=N]</b> ] [ <b>-k,
---store-all-in-cache</b> ] [ <b>-%n, --do-not-recatch</b> ]
-[ <b>-%v, --display</b> ] [ <b>-Q, --do-not-log</b> ] [
-<b>-q, --quiet</b> ] [ <b>-z, --extra-log</b> ] [ <b>-Z,
---debug-log</b> ] [ <b>-v, --verbose</b> ] [ <b>-f,
---file-log</b> ] [ <b>-f2, --single-log</b> ] [ <b>-I,
---index</b> ] [ <b>-%i, --build-top-index</b> ] [ <b>-%I,
---search-index</b> ] [ <b>-pN, --priority[=N]</b> ] [ <b>-S,
---stay-on-same-dir</b> ] [ <b>-D, --can-go-down</b> ] [
-<b>-U, --can-go-up</b> ] [ <b>-B, --can-go-up-and-down</b> ]
-[ <b>-a, --stay-on-same-address</b> ] [ <b>-d,
+<b>-%z, --disable-compression</b> ] [ <b>-%B, --tolerant</b>
+] [ <b>-%s, --updatehack</b> ] [ <b>-%u, --urlhack</b> ] [
+<b>-%A, --assume</b> ] [ <b>-@iN, --protocol[=N]</b> ] [
+<b>-%w, --disable-module</b> ] [ <b>-F, --user-agent</b> ] [
+<b>-%R, --referer</b> ] [ <b>-%E, --from</b> ] [ <b>-%F,
+--footer</b> ] [ <b>-%l, --language</b> ] [ <b>-%a,
+--accept</b> ] [ <b>-%X, --headers</b> ] [ <b>-C,
+--cache[=N]</b> ] [ <b>-k, --store-all-in-cache</b> ] [
+<b>-%n, --do-not-recatch</b> ] [ <b>-%v, --display</b> ] [
+<b>-Q, --do-not-log</b> ] [ <b>-q, --quiet</b> ] [ <b>-z,
+--extra-log</b> ] [ <b>-Z, --debug-log</b> ] [ <b>-v,
+--verbose</b> ] [ <b>-f, --file-log</b> ] [ <b>-f2,
+--single-log</b> ] [ <b>-I, --index</b> ] [ <b>-%i,
+--build-top-index</b> ] [ <b>-%I, --search-index</b> ] [
+<b>-pN, --priority[=N]</b> ] [ <b>-S, --stay-on-same-dir</b>
+] [ <b>-D, --can-go-down</b> ] [ <b>-U, --can-go-up</b> ] [
+<b>-B, --can-go-up-and-down</b> ] [ <b>-a,
+--stay-on-same-address</b> ] [ <b>-d,
 --stay-on-same-domain</b> ] [ <b>-l, --stay-on-same-tld</b>
 ] [ <b>-e, --go-everywhere</b> ] [ <b>-%H,
 --debug-headers</b> ] [ <b>-%!,
 --disable-security-limits</b> ] [ <b>-V, --userdef-cmd</b> ]
-[ <b>-%W, --callback</b> ] [ <b>-K, --keep-links[=N]</b>
+[ <b>-%W, --callback</b> ] [ <b>-y,
+--background-on-suspend</b> ] [ <b>-K, --keep-links[=N]</b>
 ]</p>
 
 <h2>DESCRIPTION
@@ -646,6 +648,18 @@ don&rsquo;t wait) (--cached-delayed-type-check)</p></td></tr>
 <td width="4%">
 
 
+<p>-%t</p></td>
+<td width="5%"></td>
+<td width="82%">
+
+
+<p>keep the original file extension, don&rsquo;t rewrite it
+from the MIME type (%t0 rewrite)</p></td></tr>
+<tr valign="top" align="left">
+<td width="9%"></td>
+<td width="4%">
+
+
 <p>-LN</p></td>
 <td width="5%"></td>
 <td width="82%">
@@ -873,6 +887,18 @@ for old servers or proxies) (--http-10)</p></td></tr>
 <p>use keep-alive if possible, greately reducing latency
 for small files and test requests (%k0 don&rsquo;t use)
 (--keep-alive)</p> </td></tr>
+<tr valign="top" align="left">
+<td width="9%"></td>
+<td width="4%">
+
+
+<p>-%z</p></td>
+<td width="5%"></td>
+<td width="82%">
+
+
+<p>do not request compressed content (%z0 request)
+(--disable-compression)</p> </td></tr>
 <tr valign="top" align="left">
 <td width="9%"></td>
 <td width="4%">
@@ -1383,25 +1409,13 @@ p7 get html files before, then treat other files</p>
 <td width="8%">
 
 
-<p style="margin-top: 1em">-#X</p></td>
+<p style="margin-top: 1em">-#test</p></td>
 <td width="1%"></td>
 <td width="82%">
 
 
-<p style="margin-top: 1em">*use optimized engine (limited
-memory boundary checks) (--fast-engine)</p></td></tr>
-<tr valign="top" align="left">
-<td width="9%"></td>
-<td width="8%">
-
-
-<p>-#test</p></td>
-<td width="1%"></td>
-<td width="82%">
-
-
-<p>list engine self-tests (run one with -#test=NAME
-[args])</p> </td></tr>
+<p style="margin-top: 1em">list engine self-tests (run one
+with -#test=NAME [args])</p></td></tr>
 <tr valign="top" align="left">
 <td width="9%"></td>
 <td width="8%">
@@ -1532,17 +1546,6 @@ memory boundary checks) (--fast-engine)</p></td></tr>
 <td width="8%">
 
 
-<p>-#R</p></td>
-<td width="1%"></td>
-<td width="82%">
-
-
-<p>old FTP routines (debug) (--repair-cache)</p></td></tr>
-<tr valign="top" align="left">
-<td width="9%"></td>
-<td width="8%">
-
-
 <p>-#T</p></td>
 <td width="1%"></td>
 <td width="82%">
@@ -1633,6 +1636,18 @@ each files ($0 is the filename: -V &quot;rm \$0&quot;)
 
 <p>use an external library function as a wrapper (-%W
 myfoo.so[,myparameters]) (--callback &lt;param&gt;)</p></td></tr>
+<tr valign="top" align="left">
+<td width="9%"></td>
+<td width="4%">
+
+
+<p>-y</p></td>
+<td width="5%"></td>
+<td width="82%">
+
+
+<p>go to background when suspended (y0 don&rsquo;t)
+(--background-on-suspend)</p> </td></tr>
 </table>
 
 <h3>Details: Option N

--- a/man/httrack.1
+++ b/man/httrack.1
@@ -58,6 +58,7 @@ httrack \- offline browser : copy websites to a local directory
 [ \fB\-sN, \-\-robots[=N]\fR ]
 [ \fB\-%h, \-\-http\-10\fR ]
 [ \fB\-%k, \-\-keep\-alive\fR ]
+[ \fB\-%z, \-\-disable\-compression\fR ]
 [ \fB\-%B, \-\-tolerant\fR ]
 [ \fB\-%s, \-\-updatehack\fR ]
 [ \fB\-%u, \-\-urlhack\fR ]
@@ -98,6 +99,7 @@ httrack \- offline browser : copy websites to a local directory
 [ \fB\-%!, \-\-disable\-security\-limits\fR ]
 [ \fB\-V, \-\-userdef\-cmd\fR ]
 [ \fB\-%W, \-\-callback\fR ]
+[ \fB\-y, \-\-background\-on\-suspend\fR ]
 [ \fB\-K, \-\-keep\-links[=N]\fR ]
 .SH DESCRIPTION
 .B httrack
@@ -195,6 +197,8 @@ delayed type check, don't make any link test but wait for files download to star
 cached delayed type check, don't wait for remote type during updates, to speedup them (%D0 wait, * %D1 don't wait) (\-\-cached\-delayed\-type\-check)
 .IP \-%M
 generate a RFC MIME\-encapsulated full\-archive (.mht) (\-\-mime\-html)
+.IP \-%t
+keep the original file extension, don't rewrite it from the MIME type (%t0 rewrite)
 .IP \-LN
 long names (L1 *long names / L0 8\-3 conversion / L2 ISO9660 compatible) (\-\-long\-names[=N])
 .IP \-KN
@@ -232,6 +236,8 @@ follow robots.txt and meta robots tags (0=never,1=sometimes,* 2=always, 3=always
 force HTTP/1.0 requests (reduce update features, only for old servers or proxies) (\-\-http\-10)
 .IP \-%k
 use keep\-alive if possible, greately reducing latency for small files and test requests (%k0 don't use) (\-\-keep\-alive)
+.IP \-%z
+do not request compressed content (%z0 request) (\-\-disable\-compression)
 .IP \-%B
 tolerant requests (accept bogus responses on some servers, but not standard!) (\-\-tolerant)
 .IP \-%s
@@ -326,8 +332,6 @@ go everywhere on the web (\-\-go\-everywhere)
 .IP \-%H
 debug HTTP headers in logfile (\-\-debug\-headers)
 .SS Guru options: (do NOT use if possible)
-.IP \-#X
-*use optimized engine (limited memory boundary checks) (\-\-fast\-engine)
 .IP \-#test
 list engine self\-tests (run one with \-#test=NAME [args])
 .IP \-#C
@@ -352,8 +356,6 @@ maximum number of links (\-#L1000000) (\-\-advanced\-maxlinks[=N])
 display ugly progress information (\-\-advanced\-progressinfo)
 .IP \-#P
 catch URL (\-\-catch\-url)
-.IP \-#R
-old FTP routines (debug) (\-\-repair\-cache)
 .IP \-#T
 generate transfer ops. log every minutes (\-\-debug\-xfrstats)
 .IP \-#u
@@ -372,6 +374,8 @@ USE IT WITH EXTREME CARE
 execute system command after each files ($0 is the filename: \-V "rm \\$0") (\-\-userdef\-cmd <param>)
 .IP \-%W
 use an external library function as a wrapper (\-%W myfoo.so[,myparameters]) (\-\-callback <param>)
+.IP \-y
+go to background when suspended (y0 don't) (\-\-background\-on\-suspend)
 .SS Details: Option N
 .IP \-N0
 Site\-structure (default)

--- a/src/htshelp.c
+++ b/src/htshelp.c
@@ -524,6 +524,8 @@ void help(const char *app, int more) {
   infomsg
     (" %D  cached delayed type check, don't wait for remote type during updates, to speedup them (%D0 wait, * %D1 don't wait)");
   infomsg(" %M  generate a RFC MIME-encapsulated full-archive (.mht)");
+  infomsg(" %t  keep the original file extension, don't rewrite it from the "
+          "MIME type (%t0 rewrite)");
   infomsg
     ("  LN long names (L1 *long names / L0 8-3 conversion / L2 ISO9660 compatible)");
   infomsg
@@ -554,6 +556,7 @@ void help(const char *app, int more) {
     (" %h  force HTTP/1.0 requests (reduce update features, only for old servers or proxies)");
   infomsg
     (" %k  use keep-alive if possible, greately reducing latency for small files and test requests (%k0 don't use)");
+  infomsg(" %z  do not request compressed content (%z0 request)");
   infomsg
     (" %B  tolerant requests (accept bogus responses on some servers, but not standard!)");
   infomsg
@@ -620,7 +623,6 @@ void help(const char *app, int more) {
   infomsg(" %H  debug HTTP headers in logfile");
   infomsg("");
   infomsg("Guru options: (do NOT use if possible)");
-  infomsg(" #X *use optimized engine (limited memory boundary checks)");
   infomsg(" #test  list engine self-tests (run one with -#test=NAME [args])");
   infomsg(" #C  cache list (-#C '*.com/spider*.gif'");
   infomsg(" #R  cache repair (damaged cache)");
@@ -633,7 +635,6 @@ void help(const char *app, int more) {
   infomsg(" #L  maximum number of links (-#L1000000)");
   infomsg(" #p  display ugly progress information");
   infomsg(" #P  catch URL");
-  infomsg(" #R  old FTP routines (debug)");
   infomsg(" #T  generate transfer ops. log every minutes");
   infomsg(" #u  wait time");
   infomsg(" #Z  generate transfer rate statistics every minutes");
@@ -650,6 +651,7 @@ void help(const char *app, int more) {
     ("  V execute system command after each files ($0 is the filename: -V \"rm \\$0\")");
   infomsg(" %W use an external library function as a wrapper (-%W "
           "myfoo.so[,myparameters])");
+  infomsg("  y  go to background when suspended (y0 don't)");
   infomsg("");
   infomsg("Details: Option N");
   infomsg("  N0 Site-structure (default)");


### PR DESCRIPTION
`--help` advertised `#R` twice ("cache repair" and "old FTP routines"). The FTP handler has been commented out in the parser for years, so only cache repair is real. `#X` was shown as the default optimized engine, but its parser case just prints "option has no effect". This drops the bogus `#R` line and the dead `#X` line; the `--repair-cache` alias annotation moves onto the surviving cache-repair line.

It also documents three real but previously undocumented options: `-%z`/`--disable-compression`, `-%t` (keep the original file extension instead of rewriting it from the MIME type), and `-y`/`--background-on-suspend`.

`man/httrack.1` and `html/httrack.man.html` are regenerated from the updated help text.