### PR TITLE
Poll longer for the test server's port so a cold Windows CI start can't flake

### DIFF
--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -183,16 +183,12 @@ debug "starting $python $server ${serverargs[*]}"
 "$python" "$(nativepath "$server")" "${serverargs[@]}" >"$serverlog" 2>&1 &
 serverpid=$!
 
-# Wait for the "PORT <n>" line (server prints it once bound).
+# Wait for the "PORT <n>" line (server prints it once bound). A cold Python
+# start under a parallel `make check -jN` can lag past a second on a loaded Windows runner.
 port=
-for _ in $(seq 1 50); do
-    if test -s "$serverlog"; then
-        line=$(head -n1 "$serverlog")
-        if test "${line%% *}" == "PORT"; then
-            port="${line#PORT }"
-            break
-        fi
-    fi
+for _ in $(seq 1 300); do
+    # Match anywhere: a startup warning merged via 2>&1 could precede the PORT line.
+    line=$(grep -m1 '^PORT ' "$serverlog" 2>/dev/null) && port="${line#PORT }" && break
     kill -0 "$serverpid" 2>/dev/null || die "server exited early: $(cat "$serverlog")"
     sleep 0.1
 done


### PR DESCRIPTION
The offline crawl harness discovers the test server's ephemeral port from the `PORT <n>` line it prints once bound, but it only waited 5 seconds and matched the first line. Under `make check -jN`, up to 16 Python servers cold-start at once, and on a loaded Windows runner a cold MSYS Python start can lag past that, so discovery timed out with an empty log and failed `13_local-cookies` for no real reason. This widens the deadline to 30 seconds and matches the `PORT` line anywhere in the log, so a stray startup warning merged onto the same stream can't wedge discovery either. A healthy server still breaks out the moment the line appears.