### PR TITLE
Named footer fields for -%F

### DIFF
--- a/html/cmdguide.html
+++ b/html/cmdguide.html
@@ -323,9 +323,17 @@ options control what HTTrack says about itself.</p>
   <tr><td><tt>--user-agent (-F)</tt></td><td>The <tt>User-Agent</tt>. Set a browser string to get past crawler blocks; <tt>--user-agent ""</tt> sends none.</td></tr>
   <tr><td><tt>--referer (-%R), --from (-%E), --language (-%l), --accept (-%a)</tt></td><td>Referer, From, Accept-Language and Accept headers.</td></tr>
   <tr><td><tt>--headers (-%X)</tt></td><td>Add raw header lines to every request.</td></tr>
-  <tr><td><tt>--footer (-%F)</tt></td><td>A footer written into saved pages (on disk, not a network header).</td></tr>
+  <tr><td><tt>--footer (-%F)</tt></td><td>A footer written into saved pages (on disk, not a network header). See <b>Footer fields</b> below.</td></tr>
   <tr><td><tt>--cookies (-b), --cookies-file (-%K)</tt></td><td>Accept cookies, and preload a Netscape <tt>cookies.txt</tt>.</td></tr>
 </table>
+
+<p><b>Footer fields.</b> A footer with no <tt>%s</tt> may reference named fields:
+<tt>{addr}</tt>, <tt>{path}</tt>, <tt>{url}</tt>, <tt>{date}</tt> (mirror time),
+<tt>{lastmodified}</tt> (the page's Last-Modified), <tt>{version}</tt>,
+<tt>{mime}</tt>, <tt>{charset}</tt>, <tt>{status}</tt> and <tt>{size}</tt>; write
+<tt>{{</tt> or <tt>}}</tt> for a literal brace. A footer that contains <tt>%s</tt>
+keeps the older positional form (host, path, date in that order). Example:
+<tt>-%F "&lt;!-- Mirrored from {url} on {date} --&gt;"</tt>.</p>
 
 <p><b>Login.</b> For HTTP Basic auth, put the credentials in the URL:
 <tt>http://user:pass@host/</tt>. An <tt>@</tt> inside the username must be written

--- a/html/httrack.man.html
+++ b/html/httrack.man.html
@@ -1050,8 +1050,9 @@ headers (-F &quot;user-agent name&quot;) (--user-agent
 
 
 <p>footer string in Html code (-%F &quot;Mirrored from
-{addr}{path} on {date}&quot;; fields {addr} {path} {date}
-{version}, or legacy %s) (--footer &lt;param&gt;)</p></td></tr>
+{url} on {date}&quot;; fields {addr} {path} {url} {date}
+{lastmodified} {version} {mime} {charset} {status} {size},
+or legacy %s) (--footer &lt;param&gt;)</p></td></tr>
 <tr valign="top" align="left">
 <td width="9%"></td>
 <td width="4%">

--- a/html/httrack.man.html
+++ b/html/httrack.man.html
@@ -1049,9 +1049,9 @@ headers (-F &quot;user-agent name&quot;) (--user-agent
 <td width="82%">
 
 
-<p>footer string in Html code (-%F &quot;Mirrored [from
-host %s [file %s [at %s]]]&quot; (--footer
-&lt;param&gt;)</p> </td></tr>
+<p>footer string in Html code (-%F &quot;Mirrored from
+{addr}{path} on {date}&quot;; fields {addr} {path} {date}
+{version}, or legacy %s) (--footer &lt;param&gt;)</p></td></tr>
 <tr valign="top" align="left">
 <td width="9%"></td>
 <td width="4%">

--- a/man/httrack.1
+++ b/man/httrack.1
@@ -264,7 +264,7 @@ default referer field sent in HTTP headers (\-\-referer <param>)
 .IP \-%E
 from email address sent in HTTP headers (\-\-from <param>)
 .IP \-%F
-footer string in Html code (\-%F "Mirrored [from host %s [file %s [at %s]]]" (\-\-footer <param>)
+footer string in Html code (\-%F "Mirrored from {addr}{path} on {date}"; fields {addr} {path} {date} {version}, or legacy %s) (\-\-footer <param>)
 .IP \-%l
 preferred language (\-%l "fr, en, jp, *" (\-\-language <param>)
 .IP \-%a

--- a/man/httrack.1
+++ b/man/httrack.1
@@ -264,7 +264,7 @@ default referer field sent in HTTP headers (\-\-referer <param>)
 .IP \-%E
 from email address sent in HTTP headers (\-\-from <param>)
 .IP \-%F
-footer string in Html code (\-%F "Mirrored from {addr}{path} on {date}"; fields {addr} {path} {date} {version}, or legacy %s) (\-\-footer <param>)
+footer string in Html code (\-%F "Mirrored from {url} on {date}"; fields {addr} {path} {url} {date} {lastmodified} {version} {mime} {charset} {status} {size}, or legacy %s) (\-\-footer <param>)
 .IP \-%l
 preferred language (\-%l "fr, en, jp, *" (\-\-language <param>)
 .IP \-%a

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -1622,10 +1622,9 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                 if ((na + 1 >= argc) || (argv[na + 1][0] == '-')) {
                   HTS_PANIC_PRINTF
                     ("Option %F needs to be followed by a blank space, and a footer string");
-                  printf
-                    ("Example: -%%F \"<!-- Mirrored from %%s by HTTrack Website Copier/"
-                     HTTRACK_AFF_VERSION " " HTTRACK_AFF_AUTHORS
-                     ", %%s -->\"\n");
+                  printf("Example: -%%F \"<!-- Mirrored from {addr}{path} by "
+                         "HTTrack Website Copier/"
+                         "{version} " HTTRACK_AFF_AUTHORS ", {date} -->\"\n");
                   htsmain_free();
                   return -1;
                 } else {

--- a/src/htshelp.c
+++ b/src/htshelp.c
@@ -581,8 +581,10 @@ void help(const char *app, int more) {
     ("  F  user-agent field sent in HTTP headers (-F \"user-agent name\")");
   infomsg(" %R  default referer field sent in HTTP headers");
   infomsg(" %E  from email address sent in HTTP headers");
-  infomsg(" %F  footer string in Html code (-%F \"Mirrored from {addr}{path} "
-          "on {date}\"; fields {addr} {path} {date} {version}, or legacy %s)");
+  infomsg(
+      " %F  footer string in Html code (-%F \"Mirrored from {url} on "
+      "{date}\"; fields {addr} {path} {url} {date} {lastmodified} {version} "
+      "{mime} {charset} {status} {size}, or legacy %s)");
   infomsg(" %l  preferred language (-%l \"fr, en, jp, *\"");
   infomsg(" %a  accepted formats (-%a \"text/html,image/png;q=0.9,*/*;q=0.1\"");
   infomsg(" %X  additional HTTP header line (-%X \"X-Magic: 42\"");

--- a/src/htshelp.c
+++ b/src/htshelp.c
@@ -581,8 +581,8 @@ void help(const char *app, int more) {
     ("  F  user-agent field sent in HTTP headers (-F \"user-agent name\")");
   infomsg(" %R  default referer field sent in HTTP headers");
   infomsg(" %E  from email address sent in HTTP headers");
-  infomsg
-    (" %F  footer string in Html code (-%F \"Mirrored [from host %s [file %s [at %s]]]\"");
+  infomsg(" %F  footer string in Html code (-%F \"Mirrored from {addr}{path} "
+          "on {date}\"; fields {addr} {path} {date} {version}, or legacy %s)");
   infomsg(" %l  preferred language (-%l \"fr, en, jp, *\"");
   infomsg(" %a  accepted formats (-%a \"text/html,image/png;q=0.9,*/*;q=0.1\"");
   infomsg(" %X  additional HTTP header line (-%X \"X-Magic: 42\"");

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -792,19 +792,67 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                   char gmttime[256];
                   char BIGSTK safe_adr[HTS_URLMAXSIZE * 3 + 4];
                   char BIGSTK safe_fil[HTS_URLMAXSIZE * 3 + 4];
+                  char BIGSTK safe_url[HTS_URLMAXSIZE * 6 + 16];
+                  char safe_lastmod[sizeof(r->lastmodified) * 3 + 4];
+                  char safe_ctype[sizeof(r->contenttype) * 3 + 4];
+                  char safe_charset[sizeof(r->charset) * 3 + 4];
+                  char status_str[16];
+                  char size_str[32];
+                  // {url} scheme: jump_identification_const strips it for
+                  // http/https/ftp, so re-add it (bare host is http); for any
+                  // other scheme the host keeps its "scheme://" and we add
+                  // none.
+                  const char *const url_host =
+                      jump_identification_const(urladr());
+                  const char *const url_scheme =
+                      strstr(url_host, "://") != NULL  ? ""
+                      : strfield(urladr(), "https://") ? "https://"
+                      : strfield(urladr(), "ftp://")   ? "ftp://"
+                                                       : "http://";
 
-                  tempo[0] = '\0';
+                  // {addr}/{path} are the escaped host and remote path; {url}
+                  // prepends the scheme to them (credentials already stripped
+                  // by jump_identification_const, and the scheme is a safe
+                  // literal, so no re-escaping is needed).
+                  html_inline_safe(url_host, safe_adr, sizeof(safe_adr));
+                  html_inline_safe(urlfil(), safe_fil, sizeof(safe_fil));
+                  snprintf(safe_url, sizeof(safe_url), "%s%s%s", url_scheme,
+                           safe_adr, safe_fil);
+                  snprintf(status_str, sizeof(status_str), "%d", r->statuscode);
+                  snprintf(size_str, sizeof(size_str), LLintP, (LLint) r->size);
                   time_gmt_rfc822(gmttime);
-                  strcatbuff(tempo, eol);
-                  hts_footer_format(
-                      tempo + strlen(tempo), sizeof(tempo) - strlen(tempo),
-                      StringBuff(opt->footer),
-                      html_inline_safe(jump_identification_const(urladr()),
-                                       safe_adr, sizeof(safe_adr)),
-                      html_inline_safe(urlfil(), safe_fil, sizeof(safe_fil)),
-                      gmttime, HTTRACK_VERSIONID);
-                  strcatbuff(tempo, eol);
-                  HT_ADD(tempo);
+
+                  {
+                    // Every network-derived string is html_inline_safe()'d: the
+                    // footer sits inside an HTML comment, so a value holding
+                    // "-->" would otherwise close it and inject markup (#165).
+                    // status/size are formatted integers and need no escaping.
+                    const hts_footer_field fields[] = {
+                        {"addr", safe_adr},
+                        {"path", safe_fil},
+                        {"url", safe_url},
+                        {"date", gmttime},
+                        {"lastmodified",
+                         html_inline_safe(r->lastmodified, safe_lastmod,
+                                          sizeof(safe_lastmod))},
+                        {"version", HTTRACK_VERSIONID},
+                        {"mime", html_inline_safe(r->contenttype, safe_ctype,
+                                                  sizeof(safe_ctype))},
+                        {"charset", html_inline_safe(r->charset, safe_charset,
+                                                     sizeof(safe_charset))},
+                        {"status", status_str},
+                        {"size", size_str},
+                    };
+
+                    tempo[0] = '\0';
+                    strcatbuff(tempo, eol);
+                    hts_footer_format(tempo + strlen(tempo),
+                                      sizeof(tempo) - strlen(tempo),
+                                      StringBuff(opt->footer), fields,
+                                      sizeof(fields) / sizeof(fields[0]));
+                    strcatbuff(tempo, eol);
+                    HT_ADD(tempo);
+                  }
                 }
                 // Emit charset ?
                 if (emited_footer == 1 && strnotempty(r->charset)) {

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -796,11 +796,13 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                   tempo[0] = '\0';
                   time_gmt_rfc822(gmttime);
                   strcatbuff(tempo, eol);
-                  hts_template_format_str(tempo + strlen(tempo), sizeof(tempo) - strlen(tempo),
-                          StringBuff(opt->footer),
-                          html_inline_safe(jump_identification_const(urladr()), safe_adr, sizeof(safe_adr)),
-                          html_inline_safe(urlfil(), safe_fil, sizeof(safe_fil)), gmttime,
-                          HTTRACK_VERSIONID, /* EOF */ NULL);
+                  hts_footer_format(
+                      tempo + strlen(tempo), sizeof(tempo) - strlen(tempo),
+                      StringBuff(opt->footer),
+                      html_inline_safe(jump_identification_const(urladr()),
+                                       safe_adr, sizeof(safe_adr)),
+                      html_inline_safe(urlfil(), safe_fil, sizeof(safe_fil)),
+                      gmttime, HTTRACK_VERSIONID);
                   strcatbuff(tempo, eol);
                   HT_ADD(tempo);
                 }

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -971,6 +971,37 @@ static int st_entities(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+// -#test=footerfmt <template>: expand a -%F footer with fixed fields (drives
+// tests/01_engine-footerfmt.test). Also asserts the overflow/zero-size returns
+// the CLI cap keeps out of reach.
+static int st_footerfmt(httrackp *opt, int argc, char **argv) {
+  char out[1024];
+  char tiny[4];
+
+  (void) opt;
+  // Overflow (named and legacy) and a zero-size buffer must return <0, never
+  // truncate silently or write out of bounds.
+  assertf(hts_footer_format(tiny, sizeof(tiny), "{addr}", "host.example", "/p",
+                            "D", "V") < 0);
+  assertf(hts_footer_format(tiny, sizeof(tiny), "a %s b", "host.example", "/p",
+                            "D", "V") < 0);
+  assertf(hts_footer_format(out, 0, "", "", "", "", "") < 0);
+  // An empty template yields an empty, terminated string.
+  assertf(hts_footer_format(out, sizeof(out), "", "", "", "", "") == 1 &&
+          out[0] == '\0');
+  if (argc < 1) {
+    fprintf(stderr, "footerfmt: needs a template\n");
+    return 1;
+  }
+  if (hts_footer_format(out, sizeof(out), argv[0], "host.example",
+                        "/dir/page.html", "DATE", "VER") < 0) {
+    fprintf(stderr, "footerfmt: overflow\n");
+    return 1;
+  }
+  printf("%s\n", out);
+  return 0;
+}
+
 /* The unescapers must reserve one byte for the trailing NUL: a 'max'-byte
    dest holding 'max' output chars pre-fix wrote dest[max] (1-byte OOB, caught
    by ASan). Both unescapeEntities and unescapeUrl share the guard. */
@@ -3257,6 +3288,8 @@ static const struct selftest_entry {
     {"idna-decode", "<host>", "decode an IDNA/punycode hostname",
      st_idna_decode},
     {"entities", "<string> [encoding]", "unescape HTML entities", st_entities},
+    {"footerfmt", "<template>", "-%F footer positional/named expansion",
+     st_footerfmt},
     {"unescape-bounds", "", "unescapers reserve the NUL byte (no 1-byte OOB)",
      st_unescape_bounds},
     {"hashtable", "<count|file>", "coucal hashtable stress test", st_hashtable},

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -975,26 +975,36 @@ static int st_entities(httrackp *opt, int argc, char **argv) {
 // tests/01_engine-footerfmt.test). Also asserts the overflow/zero-size returns
 // the CLI cap keeps out of reach.
 static int st_footerfmt(httrackp *opt, int argc, char **argv) {
+  static const hts_footer_field fields[] = {
+      {"addr", "host.example"},
+      {"path", "/dir/page.html"},
+      {"url", "http://host.example/dir/page.html"},
+      {"date", "DATE"},
+      {"lastmodified", "LASTMOD"},
+      {"version", "VER"},
+      {"mime", "text/html"},
+      {"charset", "utf-8"},
+      {"status", "200"},
+      {"size", "1234"},
+  };
+  const size_t nfields = sizeof(fields) / sizeof(fields[0]);
   char out[1024];
   char tiny[4];
 
   (void) opt;
   // Overflow (named and legacy) and a zero-size buffer must return <0, never
   // truncate silently or write out of bounds.
-  assertf(hts_footer_format(tiny, sizeof(tiny), "{addr}", "host.example", "/p",
-                            "D", "V") < 0);
-  assertf(hts_footer_format(tiny, sizeof(tiny), "a %s b", "host.example", "/p",
-                            "D", "V") < 0);
-  assertf(hts_footer_format(out, 0, "", "", "", "", "") < 0);
+  assertf(hts_footer_format(tiny, sizeof(tiny), "{addr}", fields, nfields) < 0);
+  assertf(hts_footer_format(tiny, sizeof(tiny), "a %s b", fields, nfields) < 0);
+  assertf(hts_footer_format(out, 0, "", fields, nfields) < 0);
   // An empty template yields an empty, terminated string.
-  assertf(hts_footer_format(out, sizeof(out), "", "", "", "", "") == 1 &&
+  assertf(hts_footer_format(out, sizeof(out), "", fields, nfields) == 1 &&
           out[0] == '\0');
   if (argc < 1) {
     fprintf(stderr, "footerfmt: needs a template\n");
     return 1;
   }
-  if (hts_footer_format(out, sizeof(out), argv[0], "host.example",
-                        "/dir/page.html", "DATE", "VER") < 0) {
+  if (hts_footer_format(out, sizeof(out), argv[0], fields, nfields) < 0) {
     fprintf(stderr, "footerfmt: overflow\n");
     return 1;
   }

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -754,35 +754,48 @@ typedef struct hts_template_format_buf {
   size_t offset;
 } hts_template_format_buf;
 
+// Bounded append to a template buffer (or FILE); returns -1 on overflow/error.
+static int htsfmt_putc(hts_template_format_buf *buf, char c) {
+  if (buf->fp != NULL) {
+    assertf(buf->buffer == NULL);
+    if (fputc(c, buf->fp) < 0)
+      return -1;
+  } else {
+    assertf(buf->buffer != NULL);
+    if (buf->offset + 1 < buf->size)
+      buf->buffer[buf->offset++] = c;
+    else
+      return -1;
+  }
+  return 0;
+}
+
+static int htsfmt_puts(hts_template_format_buf *buf, const char *s) {
+  size_t i;
+  assertf(s != NULL);
+  for (i = 0; s[i] != '\0'; i++) {
+    if (htsfmt_putc(buf, s[i]) < 0)
+      return -1;
+  }
+  return 0;
+}
+
 // note: upstream arg list MUST be NULL-terminated for safety
 // returns a negative value upon error
-static int hts_template_formatv(hts_template_format_buf *buf, 
+static int hts_template_formatv(hts_template_format_buf *buf,
                                 const char *format, va_list args) {
 #undef FPUTC
 #undef FPUTS
-#define FPUTC(C) do { \
-  if (buf->fp != NULL) { \
-    assertf(buf->buffer == NULL); \
-    if (fputc(C, buf->fp) < 0) { \
-      return -1; \
-    } \
-  } else { \
-    assertf(buf->buffer != NULL); \
-    if (buf->offset + 1 < buf->size) { \
-      buf->buffer[buf->offset++] = (C); \
-    } else { \
-      return -1; \
-    } \
-  } \
-} while(0)
-#define FPUTS(S) do { \
-  size_t i; \
-  const char *const str_ = (S); \
-  assertf(str_ != NULL); \
-  for(i = 0 ; str_[i] != '\0' ; i++) { \
-    FPUTC(str_[i]); \
-  } \
-} while(0)
+#define FPUTC(C)                                                               \
+  do {                                                                         \
+    if (htsfmt_putc(buf, (C)) < 0)                                             \
+      return -1;                                                               \
+  } while (0)
+#define FPUTS(S)                                                               \
+  do {                                                                         \
+    if (htsfmt_puts(buf, (S)) < 0)                                             \
+      return -1;                                                               \
+  } while (0)
 
   if (buf != NULL && format != NULL) {
     const char *arg_expanded[32];
@@ -857,6 +870,65 @@ int hts_template_format_str(char *buffer, size_t size, const char *format, ...) 
   success = hts_template_formatv(&buf, format, args);
   va_end(args);
   return success;
+}
+
+int hts_footer_format(char *buffer, size_t size, const char *footer,
+                      const char *addr, const char *path, const char *date,
+                      const char *version) {
+  const struct {
+    const char *name;
+    const char *value;
+  } fields[] = {
+      {"addr", addr}, {"path", path}, {"date", date}, {"version", version}};
+
+  hts_template_format_buf buf = {NULL, buffer, size, 0};
+  size_t i;
+
+  if (footer == NULL || buffer == NULL || size == 0)
+    return -1;
+  // %s keeps the legacy positional model, byte-for-byte for existing -%F
+  // strings.
+  if (strstr(footer, "%s") != NULL)
+    return hts_template_format_str(buffer, size, footer, addr, path, date,
+                                   version, /* EOF */ NULL);
+  // "{{"/"}}" emit a literal brace; an unknown "{...}" is left verbatim so
+  // typos stay visible.
+  for (i = 0; footer[i] != '\0'; i++) {
+    const char c = footer[i];
+    if (c == '{' && footer[i + 1] == '{') {
+      if (htsfmt_putc(&buf, '{') < 0)
+        return -1;
+      i++;
+    } else if (c == '}' && footer[i + 1] == '}') {
+      if (htsfmt_putc(&buf, '}') < 0)
+        return -1;
+      i++;
+    } else if (c == '{') {
+      const char *const end = strchr(footer + i + 1, '}');
+      int matched = 0;
+      if (end != NULL) {
+        const size_t namelen = (size_t) (end - (footer + i + 1));
+        size_t j;
+        for (j = 0; j < sizeof(fields) / sizeof(fields[0]); j++) {
+          if (strlen(fields[j].name) == namelen &&
+              strncmp(fields[j].name, footer + i + 1, namelen) == 0) {
+            if (htsfmt_puts(&buf,
+                            fields[j].value != NULL ? fields[j].value : "") < 0)
+              return -1;
+            i += namelen + 1; // consume the name and its closing '}'
+            matched = 1;
+            break;
+          }
+        }
+      }
+      if (!matched && htsfmt_putc(&buf, '{') < 0)
+        return -1;
+    } else if (htsfmt_putc(&buf, c) < 0) {
+      return -1;
+    }
+  }
+  buffer[buf.offset] = '\0';
+  return 1;
 }
 
 /* Note: NOT utf-8 */

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -872,25 +872,34 @@ int hts_template_format_str(char *buffer, size_t size, const char *format, ...) 
   return success;
 }
 
-int hts_footer_format(char *buffer, size_t size, const char *footer,
-                      const char *addr, const char *path, const char *date,
-                      const char *version) {
-  const struct {
-    const char *name;
-    const char *value;
-  } fields[] = {
-      {"addr", addr}, {"path", path}, {"date", date}, {"version", version}};
+// Value of the named field, or "" if absent (never NULL, so callers can pass it
+// straight to a formatter).
+static const char *footer_field_value(const hts_footer_field *fields,
+                                      size_t nfields, const char *name) {
+  size_t j;
+  for (j = 0; j < nfields; j++) {
+    if (strcmp(fields[j].name, name) == 0)
+      return fields[j].value != NULL ? fields[j].value : "";
+  }
+  return "";
+}
 
+int hts_footer_format(char *buffer, size_t size, const char *footer,
+                      const hts_footer_field *fields, size_t nfields) {
   hts_template_format_buf buf = {NULL, buffer, size, 0};
   size_t i;
 
   if (footer == NULL || buffer == NULL || size == 0)
     return -1;
   // %s keeps the legacy positional model, byte-for-byte for existing -%F
-  // strings.
+  // strings: addr, path, date, version, looked up by name and
+  // order-independent.
   if (strstr(footer, "%s") != NULL)
-    return hts_template_format_str(buffer, size, footer, addr, path, date,
-                                   version, /* EOF */ NULL);
+    return hts_template_format_str(
+        buffer, size, footer, footer_field_value(fields, nfields, "addr"),
+        footer_field_value(fields, nfields, "path"),
+        footer_field_value(fields, nfields, "date"),
+        footer_field_value(fields, nfields, "version"), /* EOF */ NULL);
   // "{{"/"}}" emit a literal brace; an unknown "{...}" is left verbatim so
   // typos stay visible.
   for (i = 0; footer[i] != '\0'; i++) {
@@ -909,7 +918,7 @@ int hts_footer_format(char *buffer, size_t size, const char *footer,
       if (end != NULL) {
         const size_t namelen = (size_t) (end - (footer + i + 1));
         size_t j;
-        for (j = 0; j < sizeof(fields) / sizeof(fields[0]); j++) {
+        for (j = 0; j < nfields; j++) {
           if (strlen(fields[j].name) == namelen &&
               strncmp(fields[j].name, footer + i + 1, namelen) == 0) {
             if (htsfmt_puts(&buf,

--- a/src/htstools.h
+++ b/src/htstools.h
@@ -72,6 +72,12 @@ HTS_INLINE int rech_tageq_all(const char *adr, const char *s);
 
 int hts_template_format(FILE *const out, const char *format, ...);
 int hts_template_format_str(char *buffer, size_t size, const char *format, ...);
+// Expand a footer template: "%s" in it selects the legacy positional model
+// (addr, path, date, version); otherwise substitutes named {addr} {path} {date}
+// {version} fields ("{{"/"}}" for a literal brace). Returns <0 on overflow.
+int hts_footer_format(char *buffer, size_t size, const char *footer,
+                      const char *addr, const char *path, const char *date,
+                      const char *version);
 
 #define rech_tageq(adr,s) \
   ( \

--- a/src/htstools.h
+++ b/src/htstools.h
@@ -72,12 +72,20 @@ HTS_INLINE int rech_tageq_all(const char *adr, const char *s);
 
 int hts_template_format(FILE *const out, const char *format, ...);
 int hts_template_format_str(char *buffer, size_t size, const char *format, ...);
-// Expand a footer template: "%s" in it selects the legacy positional model
-// (addr, path, date, version); otherwise substitutes named {addr} {path} {date}
-// {version} fields ("{{"/"}}" for a literal brace). Returns <0 on overflow.
+
+// A footer named field and its already-context-escaped value.
+typedef struct hts_footer_field {
+  const char *name;
+  const char *value;
+} hts_footer_field;
+
+// Expand a footer template. A "%s" in it selects the legacy positional model,
+// consuming the "addr"/"path"/"date"/"version" fields in that order; otherwise
+// "{name}" is substituted from fields by name ("{{"/"}}" emit a literal brace,
+// an unknown "{...}" is left verbatim). Values must already be escaped for the
+// target context by the caller. Returns <0 on overflow.
 int hts_footer_format(char *buffer, size_t size, const char *footer,
-                      const char *addr, const char *path, const char *date,
-                      const char *version);
+                      const hts_footer_field *fields, size_t nfields);
 
 #define rech_tageq(adr,s) \
   ( \

--- a/tests/01_engine-footerfmt.test
+++ b/tests/01_engine-footerfmt.test
@@ -35,3 +35,8 @@ ftr '{bogus} {} {addr' '{bogus} {} {addr'
 ftr '100% {path}' '100% /dir/page.html'
 # %s anywhere forces legacy mode, so a mixed template leaves {addr} literal.
 ftr '{addr} %s' '{addr} host.example'
+
+# The added named fields (url, lastmodified, mime, charset, status, size).
+ftr '{url}' 'http://host.example/dir/page.html'
+ftr 'src {lastmodified}, got {date}' 'src LASTMOD, got DATE'
+ftr '{mime}; {charset}; {status}; {size}' 'text/html; utf-8; 200; 1234'

--- a/tests/01_engine-footerfmt.test
+++ b/tests/01_engine-footerfmt.test
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# -%F footer expansion (hts_footer_format via -#test=footerfmt). Fixed fields:
+# addr=host.example path=/dir/page.html date=DATE version=VER.
+ftr() {
+    out="$(httrack -O /dev/null -#test=footerfmt "$1")"
+    test "$out" == "$2" || {
+        echo "FAIL: '$1' -> '$out' (want '$2')"
+        exit 1
+    }
+}
+
+# Legacy positional model: a template with %s keeps the historic addr/path/date
+# order byte-for-byte (backward compatibility).
+ftr '<!-- Mirrored from %s%s by X, %s -->' \
+    '<!-- Mirrored from host.example/dir/page.html by X, DATE -->'
+# Legacy arg overflow past the four fields yields the historic "???" marker.
+ftr 'a %s b %s c %s d %s e %s' 'a host.example b /dir/page.html c DATE d VER e ???'
+# Legacy %% is a literal percent; an unknown %x passes through verbatim.
+ftr '100%% %d %s' '100% %d host.example'
+
+# Named model (no %s): fields substitute by name, in any order or subset.
+ftr '{addr}{path} {version} {date}' 'host.example/dir/page.html VER DATE'
+ftr 'built {date}' 'built DATE'
+# A literal char abutting a field's '}' survives (guards the index advance).
+ftr '{date}!{addr}' 'DATE!host.example'
+# {{ and }} escape to a literal brace.
+ftr 'a {{ b }} {addr}' 'a { b } host.example'
+# Unknown, empty, or unterminated braces are emitted verbatim (typos stay visible).
+ftr '{bogus} {} {addr' '{bogus} {} {addr'
+# A literal percent is untouched in named mode (no positional interpretation).
+ftr '100% {path}' '100% /dir/page.html'
+# %s anywhere forces legacy mode, so a mixed template leaves {addr} literal.
+ftr '{addr} %s' '{addr} host.example'

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -38,6 +38,7 @@ TESTS = \
 	01_engine-dnstimeout.test \
 	01_engine-doitlog.test \
 	01_engine-entities.test \
+	01_engine-footerfmt.test \
 	01_engine-filelist.test \
 	01_engine-filter.test \
 	01_engine-filterdual.test \


### PR DESCRIPTION
The `-%F` footer was a bare positional printf where each `%s` consumed the next of a fixed addr/path/date/version list. That is awkward to use: you can't reach the date without emitting the address and path first, you can't reorder, and a miscounted `%s` silently produces `???` or shifted values.

This adds a named alternative. A footer with no `%s` is expanded with `{addr}` `{path}` `{date}` `{version}` fields, with `{{` and `}}` for a literal brace and any unknown `{...}` left as-is so typos stay visible. A footer that contains `%s` keeps the exact legacy behavior, so the default footer and every existing `-%F` string are untouched.

Sanitization is unchanged: address and path still go through `html_inline_safe`, so the comment-injection guard from #165 still holds. A new `-#test=footerfmt` self-test covers both models, brace escaping, the mixed-mode boundary, and the overflow and zero-size return paths.