### PR TITLE
Skip an oversized -%F footer instead of aborting the crawl

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -202,7 +202,8 @@ jobs:
 
           # Every gate here exits 77, so an all-skipped suite would report green having
           # tested nothing: pin the skips, and floor the passes in case the glob empties.
-          expected_skips=" 48_local-crange-memresume.test 71_local-crange-repaircache.test"  # pending #581
+          # footer-overflow skips on Windows (needs a path past MAX_PATH); crange pending #581.
+          expected_skips=" 01_engine-footer-overflow.test 48_local-crange-memresume.test 71_local-crange-repaircache.test"
           [ "$pass" -ge 90 ] || { echo "::error::only $pass tests passed ($skip skipped)"; exit 1; }
           [ "$skipped" = "$expected_skips" ] || { echo "::error::unexpected skips:$skipped"; exit 1; }
           [ "$fail" -eq 0 ] || { echo "::error::failing:$failed"; exit 1; }

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -846,12 +846,17 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
 
                     tempo[0] = '\0';
                     strcatbuff(tempo, eol);
-                    hts_footer_format(tempo + strlen(tempo),
-                                      sizeof(tempo) - strlen(tempo),
-                                      StringBuff(opt->footer), fields,
-                                      sizeof(fields) / sizeof(fields[0]));
-                    strcatbuff(tempo, eol);
-                    HT_ADD(tempo);
+                    // hts_footer_format returns <0 on overflow, leaving tempo
+                    // unterminated; emitting it would abort in strcatbuff
+                    // below.
+                    if (hts_footer_format(tempo + strlen(tempo),
+                                          sizeof(tempo) - strlen(tempo),
+                                          StringBuff(opt->footer), fields,
+                                          sizeof(fields) / sizeof(fields[0])) >=
+                        0) {
+                      strcatbuff(tempo, eol);
+                      HT_ADD(tempo);
+                    }
                   }
                 }
                 // Emit charset ?

--- a/tests/01_engine-footer-overflow.test
+++ b/tests/01_engine-footer-overflow.test
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Keep this POSIX-portable: the harness runs it via $(BASH), which is a plain
+# POSIX /bin/sh on some platforms (e.g. macOS), so avoid bashisms despite the
+# #!/bin/bash above.
+
+# A -%F footer whose expansion overflows the on-page buffer must be dropped, not
+# crash the crawl. Before the fix the unchecked hts_footer_format return left the
+# buffer unterminated and the next strcatbuff aborted (SIGABRT).
+
+set -eu
+
+dir=$(mktemp -d)
+trap 'rm -rf "$dir"' EXIT
+
+# A few-hundred-char file path (kept well under the URL length limit) makes the
+# {path} field long.
+seg=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+deep="$dir"
+i=0
+while [ "$i" -lt 6 ]; do
+    deep="$deep/$seg"
+    i=$((i + 1))
+done
+mkdir -p "$deep"
+printf '<html><body>hi</body></html>' >"$deep/index.html"
+
+# 40 {path} references (~240 chars, under the 254-char -%F cap); expanded against
+# a few-hundred-char path this far exceeds the per-page footer buffer.
+footer=""
+i=0
+while [ "$i" -lt 40 ]; do
+    footer="$footer{path}"
+    i=$((i + 1))
+done
+
+mir="$dir/mir"
+httrack "file://$deep/index.html" -O "$mir" -%F "$footer" -q -s0 -%v0 \
+    >/dev/null 2>&1 || {
+    echo "crawl failed/aborted (exit $?) on an oversized footer" >&2
+    exit 1
+}
+
+# The crawled page must exist (proves the URL wasn't rejected for length, so the
+# footer path ran). Look under file/, not $mir, to skip the makeindex top index.
+find "$mir/file" -name index.html | grep -q . || {
+    echo "page not mirrored; the oversized-footer path was not exercised" >&2
+    exit 1
+}

--- a/tests/01_engine-footer-overflow.test
+++ b/tests/01_engine-footer-overflow.test
@@ -10,6 +10,13 @@
 
 set -eu
 
+# The overflow needs a path longer than Windows MAX_PATH (260), so both the
+# source tree and the mirror output blow past it there; run on POSIX only. The
+# fix itself is platform-independent and covered on Linux/macOS.
+case "$(uname -s 2>/dev/null)" in
+MINGW* | MSYS* | CYGWIN*) exit 77 ;;
+esac
+
 dir=$(mktemp -d)
 trap 'rm -rf "$dir"' EXIT
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -39,6 +39,7 @@ TESTS = \
 	01_engine-doitlog.test \
 	01_engine-entities.test \
 	01_engine-footerfmt.test \
+	01_engine-footer-overflow.test \
 	01_engine-filelist.test \
 	01_engine-filter.test \
 	01_engine-filterdual.test \


### PR DESCRIPTION
An oversized `-%F` footer aborted the crawl instead of being dropped. The footer is expanded into a fixed ~3 KB on-page buffer; on overflow `hts_footer_format` returns a negative error and leaves the buffer unterminated, but the call site ignored that return and ran `strcatbuff` on the buffer anyway. `strcatbuff`'s bounded scan finds no terminator within the buffer and calls `abort()`, so the crawl dies with SIGABRT. This guards the emit on the return value: an overflowing footer is dropped rather than crashing the crawl. The pre-existing default `%s%s ... %s` footer had the same exposure.

The regression test drives a `file://` crawl of a deep directory path with a footer that repeats `{path}`, and asserts the crawl completes and the page is mirrored; it SIGABRTs on the pre-fix binary.

Closes #669