### PR TITLE
Expose WARC output in the webhttrack GUI

### DIFF
--- a/html/server/option9.html
+++ b/html/server/option9.html
@@ -103,6 +103,17 @@ ${do:end-if}
 > ${LANG_I61}
 <br><br>
 
+<input type="checkbox" name="warc" ${checked:warc}
+			title='${html:LANG_WARCTIP}' onMouseOver="info('${html:LANG_WARCTIP}'); return true" onMouseOut="info('&nbsp;'); return true"
+> ${LANG_WARC}
+<br><br>
+
+${LANG_WARCFILE}
+<input name="warcfile" value="${warcfile}" size="40"
+			title='${html:LANG_WARCFILETIP}' onMouseOver="info('${html:LANG_WARCFILETIP}'); return true" onMouseOut="info('&nbsp;'); return true"
+>
+<br><br>
+
 <input type="checkbox" name="norecatch" ${checked:norecatch}
 			title='${html:LANG_I5b}' onMouseOver="info('${html:LANG_I5b}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I34b}

--- a/html/server/step2.html
+++ b/html/server/step2.html
@@ -141,6 +141,8 @@ ${do:copy:KeepSlashes:keepslashes}
 ${do:copy:KeepQueryOrder:keepqueryorder}
 ${do:copy:StripQuery:stripquery}
 ${do:copy:StoreAllInCache:cache2}
+${do:copy:Warc:warc}
+${do:copy:WarcFile:warcfile}
 ${do:copy:LogType:logtype}
 ${do:copy:UseHTTPProxyForFTP:ftpprox}
 ${do:copy:ProxyType:proxytype}

--- a/html/server/step4.html
+++ b/html/server/step4.html
@@ -187,6 +187,8 @@ ${do:end-if}
 	${test:toler:--tolerant}
 	${test:http10:--http-10}
 	${test:cache2:--store-all-in-cache}
+	${test:warc:--warc}
+	${test:warcfile:--warc-file "}${html:warcfile}${test:warcfile:"}
 	${test:norecatch:--do-not-recatch}
 	${test:logf:--single-log}
 	${test:logtype:::--extra-log:--debug-log}
@@ -237,6 +239,8 @@ KeepSlashes=${ztest:keepslashes:0:1}
 KeepQueryOrder=${ztest:keepqueryorder:0:1}
 StripQuery=${stripquery}
 StoreAllInCache=${ztest:cache2:0:1}
+Warc=${ztest:warc:0:1}
+WarcFile=${warcfile}
 LogType=${logtype}
 UseHTTPProxyForFTP=${ztest:ftpprox:0:1}
 ProxyType=${proxytype}

--- a/lang.def
+++ b/lang.def
@@ -1034,3 +1034,11 @@ LANG_STRIPQUERY
 Strip query keys:
 LANG_STRIPQUERYTIP
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+LANG_WARC
+Write a WARC archive of the crawl
+LANG_WARCTIP
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+LANG_WARCFILE
+WARC archive name:
+LANG_WARCFILETIP
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.

--- a/lang/Bulgarian.txt
+++ b/lang/Bulgarian.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Премахване на ключове от заявката:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Ключове от заявката, разделени със запетая, които да се премахнат от името на записания файл (например sid,utm_source).
+Write a WARC archive of the crawl
+Записване на WARC архив на обхождането
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Записване на всеки изтеглен отговор и в WARC/1.1 архив по ISO-28500, до огледалото.
+WARC archive name:
+Име на WARC архива:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Незадължително базово име за WARC архива; оставете празно за автоматично именуване в изходната директория.

--- a/lang/Castellano.txt
+++ b/lang/Castellano.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Eliminar claves de query string:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Claves de query string, separadas por comas, que se eliminarán del nombre de los archivos guardados (p. ej. sid,utm_source).
+Write a WARC archive of the crawl
+Escribir un archivo WARC del rastreo
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Guardar también cada respuesta descargada en un archivo WARC/1.1 ISO-28500, junto a la réplica.
+WARC archive name:
+Nombre del archivo WARC:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Nombre base opcional para el archivo WARC; déjelo en blanco para nombrarlo automáticamente en el directorio de salida.

--- a/lang/Cesky.txt
+++ b/lang/Cesky.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Odebrat klíèe dotazu:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Klíèe dotazu oddìlené èárkami, které se vynechají z pojmenování ukládaných souborù (napø. sid,utm_source).
+Write a WARC archive of the crawl
+Zapsat archiv WARC z procházení
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Uložit také každou staženou odpovìï do archivu WARC/1.1 podle ISO-28500 vedle zrcadla.
+WARC archive name:
+Název archivu WARC:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Volitelný základní název archivu WARC; ponechte prázdné pro automatické pojmenování ve výstupním adresáøi.

--- a/lang/Chinese-BIG5.txt
+++ b/lang/Chinese-BIG5.txt
@@ -956,3 +956,11 @@ Strip query keys:
 移除查詢鍵:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 以逗號分隔的查詢鍵，將其從儲存檔案的命名中移除 (例如 sid,utm_source)。
+Write a WARC archive of the crawl
+寫入此次抓取的 WARC 封存檔
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+同時將每個已擷取的回應儲存為 ISO-28500 WARC/1.1 封存檔，置於鏡像網站旁。
+WARC archive name:
+WARC 封存檔名稱：
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+WARC 封存檔的選用基本名稱；留空則於輸出目錄中自動命名。

--- a/lang/Chinese-Simplified.txt
+++ b/lang/Chinese-Simplified.txt
@@ -956,3 +956,11 @@ Strip query keys:
 剥离查询键:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 用逗号分隔的查询键，将其从保存文件的命名中删除 (例如 sid,utm_source)。
+Write a WARC archive of the crawl
+写入本次抓取的 WARC 归档
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+同时将每个已获取的响应保存为 ISO-28500 WARC/1.1 归档，置于镜像站点旁边。
+WARC archive name:
+WARC 归档名称：
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+WARC 归档的可选基本名称；留空则在输出目录中自动命名。

--- a/lang/Croatian.txt
+++ b/lang/Croatian.txt
@@ -958,3 +958,11 @@ Strip query keys:
 Ukloniti kljuèeve upita:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Zarezom odvojeni kljuèevi upita koji se izostavljaju iz naziva spremljenih datoteka (npr. sid,utm_source).
+Write a WARC archive of the crawl
+Zapi¹i WARC arhivu obilaska
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Spremi i svaki preuzeti odgovor u ISO-28500 WARC/1.1 arhivu, uz zrcalo.
+WARC archive name:
+Naziv WARC arhive:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Neobavezni osnovni naziv WARC arhive; ostavite prazno za automatsko imenovanje u izlaznom direktoriju.

--- a/lang/Dansk.txt
+++ b/lang/Dansk.txt
@@ -1004,3 +1004,11 @@ Strip query keys:
 Fjern forespørgselsnøgler:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Kommaseparerede forespørgselsnøgler, der udelades i navngivningen af gemte filer (f.eks. sid,utm_source).
+Write a WARC archive of the crawl
+Skriv et WARC-arkiv af gennemsøgningen
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Gem også hvert hentet svar i et ISO-28500 WARC/1.1-arkiv ved siden af spejlet.
+WARC archive name:
+Navn på WARC-arkiv:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Valgfrit basisnavn til WARC-arkivet; lad feltet stå tomt for automatisk navngivning i outputmappen.

--- a/lang/Deutsch.txt
+++ b/lang/Deutsch.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Query-Schlüssel entfernen:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Kommagetrennte Query-Schlüssel, die bei der Benennung gespeicherter Dateien entfallen (z. B. sid,utm_source).
+Write a WARC archive of the crawl
+WARC-Archiv des Crawls schreiben
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Jede heruntergeladene Antwort zusätzlich in einem ISO-28500-WARC/1.1-Archiv neben dem Spiegel speichern.
+WARC archive name:
+Name des WARC-Archivs:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Optionaler Basisname für das WARC-Archiv; leer lassen, um es automatisch im Ausgabeverzeichnis zu benennen.

--- a/lang/Eesti.txt
+++ b/lang/Eesti.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Eemalda päringuvõtmed:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Komadega eraldatud päringuvõtmed, mis jäetakse salvestatud faili nimest välja (nt sid,utm_source).
+Write a WARC archive of the crawl
+Kirjuta läbimise WARC-arhiiv
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Salvesta iga alla laaditud vastus ka ISO-28500 WARC/1.1 arhiivi peegli kõrvale.
+WARC archive name:
+WARC-arhiivi nimi:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+WARC-arhiivi valikuline põhinimi; jäta tühjaks, et see väljundkataloogis automaatselt nimetada.

--- a/lang/English.txt
+++ b/lang/English.txt
@@ -1004,3 +1004,11 @@ Strip query keys:
 Strip query keys:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+Write a WARC archive of the crawl
+Write a WARC archive of the crawl
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+WARC archive name:
+WARC archive name:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.

--- a/lang/Finnish.txt
+++ b/lang/Finnish.txt
@@ -958,3 +958,11 @@ Strip query keys:
 Poista kyselyavaimet:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Pilkuin erotellut kyselyavaimet, jotka jätetään pois tallennettujen tiedostojen nimeämisestä (esim. sid,utm_source).
+Write a WARC archive of the crawl
+Kirjoita imuroinnin WARC-arkisto
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Tallenna myös jokainen noudettu vastaus ISO-28500 WARC/1.1 -arkistoon peilin viereen.
+WARC archive name:
+WARC-arkiston nimi:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Valinnainen WARC-arkiston perusnimi; jätä tyhjäksi, jotta se nimetään automaattisesti tulostehakemistoon.

--- a/lang/Francais.txt
+++ b/lang/Francais.txt
@@ -1004,3 +1004,11 @@ Strip query keys:
 Supprimer les clés de query string :
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Clés de query string à retirer du nommage des fichiers enregistrés, séparées par des virgules (par ex. sid,utm_source).
+Write a WARC archive of the crawl
+Écrire une archive WARC du crawl
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Enregistrer aussi chaque réponse téléchargée dans une archive WARC/1.1 (ISO-28500), à côté du miroir.
+WARC archive name:
+Nom de l'archive WARC :
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Nom de base optionnel pour l'archive WARC ; laissez vide pour le générer automatiquement dans le répertoire de sortie.

--- a/lang/Greek.txt
+++ b/lang/Greek.txt
@@ -958,3 +958,11 @@ Strip query keys:
 Αφαίρεση κλειδιών ερωτήματος:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Κλειδιά ερωτήματος χωρισμένα με κόμμα, που θα αφαιρεθούν από την ονομασία των αποθηκευμένων αρχείων (π.χ. sid,utm_source).
+Write a WARC archive of the crawl
+Εγγραφή αρχείου WARC της ανίχνευσης
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Αποθήκευση κάθε ληφθείσας απόκρισης και σε αρχείο WARC/1.1 ISO-28500, δίπλα στο είδωλο.
+WARC archive name:
+Όνομα αρχείου WARC:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Προαιρετικό βασικό όνομα για το αρχείο WARC. Αφήστε το κενό για αυτόματη ονομασία στον κατάλογο εξόδου.

--- a/lang/Italiano.txt
+++ b/lang/Italiano.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Rimuovi chiavi della query string:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Chiavi della query string, separate da virgole, da rimuovere dai nomi dei file salvati (ad es. sid,utm_source).
+Write a WARC archive of the crawl
+Scrivi un archivio WARC della scansione
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Salva anche ogni risposta scaricata in un archivio WARC/1.1 ISO-28500, accanto al mirror.
+WARC archive name:
+Nome dell'archivio WARC:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Nome di base facoltativo per l'archivio WARC; lascia vuoto per assegnarlo automaticamente nella directory di output.

--- a/lang/Japanese.txt
+++ b/lang/Japanese.txt
@@ -956,3 +956,11 @@ Strip query keys:
 削除するクエリキー:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 保存ファイル名の生成から除外するクエリキーをカンマ区切りで指定します (例: sid,utm_source)。
+Write a WARC archive of the crawl
+クロールの WARC アーカイブを書き出す
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+取得した各レスポンスを ISO-28500 WARC/1.1 アーカイブとしてミラーの隣にも保存します。
+WARC archive name:
+WARC アーカイブ名:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+WARC アーカイブの任意のベース名。空欄にすると出力ディレクトリ内で自動的に名前が付けられます。

--- a/lang/Macedonian.txt
+++ b/lang/Macedonian.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Отстрани клучеви од барањето:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Клучеви од барањето, одделени со запирка, што се отстрануваат од името на зачуваната датотека (на пример sid,utm_source).
+Write a WARC archive of the crawl
+Запиши WARC архива на пребарувањето
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Зачувај го секој преземен одговор и во ISO-28500 WARC/1.1 архива, покрај огледалото.
+WARC archive name:
+Име на WARC архивата:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Изборно основно име за WARC архивата; оставете празно за автоматско именување во излезниот директориум.

--- a/lang/Magyar.txt
+++ b/lang/Magyar.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Lekérdezési kulcsok eltávolítása:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Vesszõvel elválasztott lekérdezési kulcsok, amelyeket el kell hagyni a mentett fájl elnevezésébõl (pl. sid,utm_source).
+Write a WARC archive of the crawl
+A bejárás WARC archívumának írása
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Minden letöltött válasz mentése ISO-28500 WARC/1.1 archívumba is, a tükör mellé.
+WARC archive name:
+WARC archívum neve:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+A WARC archívum opcionális alapneve; hagyja üresen az automatikus elnevezéshez a kimeneti könyvtárban.

--- a/lang/Nederlands.txt
+++ b/lang/Nederlands.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Query-sleutels verwijderen:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Door komma's gescheiden query-sleutels die bij het benoemen van opgeslagen bestanden worden weggelaten (bijv. sid,utm_source).
+Write a WARC archive of the crawl
+Schrijf een WARC-archief van de crawl
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Sla ook elke opgehaalde respons op in een ISO-28500 WARC/1.1-archief, naast de mirror.
+WARC archive name:
+Naam van WARC-archief:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Optionele basisnaam voor het WARC-archief; laat leeg om het automatisch een naam te geven in de uitvoermap.

--- a/lang/Norsk.txt
+++ b/lang/Norsk.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Fjern spørrenøkler:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Kommaseparerte spørrenøkler som utelates i navngivingen av lagrede filer (f.eks. sid,utm_source).
+Write a WARC archive of the crawl
+Skriv et WARC-arkiv av gjennomgangen
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Lagre også hvert nedlastet svar i et ISO-28500 WARC/1.1-arkiv ved siden av speilet.
+WARC archive name:
+Navn på WARC-arkiv:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Valgfritt basisnavn for WARC-arkivet; la feltet stå tomt for automatisk navngivning i utdatamappen.

--- a/lang/Polski.txt
+++ b/lang/Polski.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Usuñ klucze zapytania:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Rozdzielone przecinkami klucze zapytania pomijane przy nazywaniu zapisanych plików (np. sid,utm_source).
+Write a WARC archive of the crawl
+Zapisz archiwum WARC z indeksowania
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Zapisz te¿ ka¿d± pobran± odpowied¼ do archiwum WARC/1.1 ISO-28500, obok kopii lustrzanej.
+WARC archive name:
+Nazwa archiwum WARC:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Opcjonalna nazwa bazowa archiwum WARC; pozostaw puste, aby nazwaæ je automatycznie w katalogu wyj¶ciowym.

--- a/lang/Portugues-Brasil.txt
+++ b/lang/Portugues-Brasil.txt
@@ -1004,3 +1004,11 @@ Strip query keys:
 Remover chaves da query string:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Chaves da query string, separadas por vírgulas, a serem removidas da nomeação dos arquivos salvos (ex.: sid,utm_source).
+Write a WARC archive of the crawl
+Gravar um arquivo WARC do rastreamento
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Salvar também cada resposta baixada em um arquivo WARC/1.1 ISO-28500, ao lado do espelho.
+WARC archive name:
+Nome do arquivo WARC:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Nome base opcional para o arquivo WARC; deixe em branco para nomeá-lo automaticamente no diretório de saída.

--- a/lang/Portugues.txt
+++ b/lang/Portugues.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Remover chaves da query string:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Chaves da query string, separadas por vírgulas, a remover da nomeação dos ficheiros guardados (por ex. sid,utm_source).
+Write a WARC archive of the crawl
+Escrever um arquivo WARC do rastreio
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Guardar também cada resposta transferida num arquivo WARC/1.1 ISO-28500, ao lado do espelho.
+WARC archive name:
+Nome do arquivo WARC:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Nome base opcional para o arquivo WARC; deixe em branco para o nomear automaticamente no diretório de saída.

--- a/lang/Romanian.txt
+++ b/lang/Romanian.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Elimina cheile din query string:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Chei din query string, separate prin virgula, de eliminat din denumirea fisierelor salvate (de ex. sid,utm_source).
+Write a WARC archive of the crawl
+Scrie o arhiva WARC a parcurgerii
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Salveaza si fiecare raspuns descarcat intr-o arhiva WARC/1.1 ISO-28500, langa oglinda.
+WARC archive name:
+Numele arhivei WARC:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Nume de baza optional pentru arhiva WARC; lasati gol pentru a-l denumi automat in directorul de iesire.

--- a/lang/Russian.txt
+++ b/lang/Russian.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Удалять ключи запроса:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Ключи запроса через запятую, удаляемые из имени сохраняемого файла (например, sid,utm_source).
+Write a WARC archive of the crawl
+Записать WARC-архив обхода
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Сохранять каждый загруженный ответ также в архив WARC/1.1 ISO-28500 рядом с зеркалом.
+WARC archive name:
+Имя WARC-архива:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Необязательное базовое имя WARC-архива; оставьте пустым для автоматического именования в выходном каталоге.

--- a/lang/Slovak.txt
+++ b/lang/Slovak.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Odstráni» kµúèe dotazu:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Kµúèe dotazu oddelené èiarkami, ktoré sa vynechajú z pomenovania ukladaných súborov (napr. sid,utm_source).
+Write a WARC archive of the crawl
+Zapísa» archív WARC z prehµadávania
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Ulo¾i» aj ka¾dú stiahnutú odpoveï do archívu WARC/1.1 ISO-28500 vedµa zrkadla.
+WARC archive name:
+Názov archívu WARC:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Voliteµný základný názov archívu WARC; ponechajte prázdne pre automatické pomenovanie vo výstupnom adresári.

--- a/lang/Slovenian.txt
+++ b/lang/Slovenian.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Odstrani kljuce poizvedbe:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Z vejicami loceni kljuci poizvedbe, ki se izpustijo pri poimenovanju shranjenih datotek (npr. sid,utm_source).
+Write a WARC archive of the crawl
+Zapisi arhiv WARC iz pregledovanja
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Shrani tudi vsak preneseni odgovor v arhiv WARC/1.1 ISO-28500 poleg zrcala.
+WARC archive name:
+Ime arhiva WARC:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Neobvezno osnovno ime arhiva WARC; pustite prazno za samodejno poimenovanje v izhodni mapi.

--- a/lang/Svenska.txt
+++ b/lang/Svenska.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Ta bort frågenycklar:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Kommaseparerade frågenycklar som utelämnas vid namngivningen av sparade filer (t.ex. sid,utm_source).
+Write a WARC archive of the crawl
+Skriv ett WARC-arkiv av genomsökningen
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Spara även varje hämtat svar i ett ISO-28500 WARC/1.1-arkiv, bredvid spegeln.
+WARC archive name:
+WARC-arkivets namn:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Valfritt basnamn för WARC-arkivet; lämna tomt för att namnge det automatiskt i utdatakatalogen.

--- a/lang/Turkish.txt
+++ b/lang/Turkish.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Sorgu anahtarlarýný çýkar:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Kaydedilen dosya adlandýrmasýndan çýkarýlacak, virgülle ayrýlmýþ sorgu anahtarlarý (örn. sid,utm_source).
+Write a WARC archive of the crawl
+Taramanýn WARC arþivini yaz
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Ýndirilen her yanýtý ayrýca aynanýn yanýna bir ISO-28500 WARC/1.1 arþivine kaydet.
+WARC archive name:
+WARC arþivi adý:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+WARC arþivi için isteðe baðlý temel ad; çýktý dizininde otomatik adlandýrma için boþ býrakýn.

--- a/lang/Ukrainian.txt
+++ b/lang/Ukrainian.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Вилучати ключі запиту:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Ключі запиту через кому, які вилучаються з імені збереженого файлу (наприклад, sid,utm_source).
+Write a WARC archive of the crawl
+Записати WARC-архів обходу
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Зберігати кожну завантажену відповідь також у архів WARC/1.1 ISO-28500 поряд із дзеркалом.
+WARC archive name:
+Ім'я WARC-архіву:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+Необов'язкова базова назва WARC-архіву; залиште порожнім для автоматичного найменування у вихідному каталозі.

--- a/lang/Uzbek.txt
+++ b/lang/Uzbek.txt
@@ -956,3 +956,11 @@ Strip query keys:
 Olib tashlanadigan so’rov kalitlari:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Saqlangan fayl nomidan olib tashlanadigan, vergul bilan ajratilgan so’rov kalitlari (masalan, sid,utm_source).
+Write a WARC archive of the crawl
+Qidiruvning WARC arxivini yozish
+Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
+Har bir yuklab olingan javobni ISO-28500 WARC/1.1 arxiviga ham, ko'zgu yonida saqlash.
+WARC archive name:
+WARC arxivi nomi:
+Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
+WARC arxivi uchun ixtiyoriy asosiy nom; chiqish katalogida avtomatik nomlash uchun bo'sh qoldiring.

--- a/tests/webhttrack-smoke.sh
+++ b/tests/webhttrack-smoke.sh
@@ -46,9 +46,12 @@ cat >"$stubdir/x-www-browser" <<EOF
 echo "stub browser invoked with: \$1" >&2
 # Also fetch an option page and require a rendered title='' tooltip: proves the
 # option template expands and the \${html:} filter escapes into the attribute.
+# option9 additionally proves the WARC control renders with its expanded label.
 opturl="\${1%/}/server/option2.html"
+warcurl="\${1%/}/server/option9.html"
 if body="\$(curl -fsSL --max-time 20 "\$1")" && printf '%s' "\$body" | grep -qai httrack && printf '%s' "\$body" | grep -qaF step2.html &&
-    opt="\$(curl -fsSL --max-time 20 "\$opturl")" && printf '%s' "\$opt" | grep -qaF "title='"; then
+    opt="\$(curl -fsSL --max-time 20 "\$opturl")" && printf '%s' "\$opt" | grep -qaF "title='" &&
+    warc="\$(curl -fsSL --max-time 20 "\$warcurl")" && printf '%s' "\$warc" | grep -qaF 'name="warcfile"' && printf '%s' "\$warc" | grep -qaF WARC; then
     echo PASS >"$marker"
 else
     echo "FAIL: unexpected response from \$1" >"$marker"


### PR DESCRIPTION
webhttrack builds an httrack command line from its option form, but never exposed the WARC output the engine gained in #671. This adds a WARC checkbox (`--warc`, auto-named) and an optional archive-name field (`--warc-file NAME`) to the "Log, Index, Cache" tab, wired like the cookies-file and query-stripping controls from #589: the field flows through the `${...}` template into the generated command and the saved winprofile.ini, and the reload path maps it back into the form. Four new LANG keys ship with English and French; other locales fall back to the English string until translated, as in #588. The smoke test now fetches option9.html and checks the WARC control renders.

Part of the WARC output work (#668).