### PR TITLE
WARC: WACZ packaging (--wacz)

### DIFF
--- a/html/httrack.man.html
+++ b/html/httrack.man.html
@@ -656,8 +656,8 @@ don&rsquo;t wait) (--cached-delayed-type-check)</p></td></tr>
 
 <p>write an ISO-28500 WARC/1.1 archive; --warc-file NAME
 sets the output name, --warc-max-size N rotates segments
-past N bytes, --warc-cdx also writes a sorted CDXJ index
-(--warc)</p> </td></tr>
+past N bytes, --warc-cdx also writes a sorted CDXJ index,
+--wacz packages it all as a WACZ file (--warc)</p></td></tr>
 <tr valign="top" align="left">
 <td width="9%"></td>
 <td width="4%">

--- a/man/httrack.1
+++ b/man/httrack.1
@@ -199,7 +199,7 @@ cached delayed type check, don't wait for remote type during updates, to speedup
 .IP \-%M
 generate a RFC MIME\-encapsulated full\-archive (.mht) (\-\-mime\-html)
 .IP \-%r
-write an ISO\-28500 WARC/1.1 archive; \-\-warc\-file NAME sets the output name, \-\-warc\-max\-size N rotates segments past N bytes, \-\-warc\-cdx also writes a sorted CDXJ index (\-\-warc)
+write an ISO\-28500 WARC/1.1 archive; \-\-warc\-file NAME sets the output name, \-\-warc\-max\-size N rotates segments past N bytes, \-\-warc\-cdx also writes a sorted CDXJ index, \-\-wacz packages it all as a WACZ file (\-\-warc)
 .IP \-%t
 keep the original file extension, don't rewrite it from the MIME type (%t0 rewrite)
 .IP \-LN

--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -121,6 +121,8 @@ const char *hts_optalias[][4] = {
   {"warc-cdx", "-%rc", "single",
    "write a sorted CDXJ index next to the WARC archive"},
   {"warc-cdxj", "-%rc", "single", ""},
+  {"wacz", "-%rz", "single",
+   "package the WARC archive, CDXJ index and pages as a WACZ file"},
   {"why", "-%Y", "param1",
    "explain which filter rule accepts or rejects a URL, then exit"},
   {"pause", "-%G", "param1",

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -3634,6 +3634,7 @@ HTSEXT_API int copy_htsopt(const httrackp * from, httrackp * to) {
     StringCopyS(to->warc_file, from->warc_file);
   to->warc_max_size = from->warc_max_size;
   to->warc_cdx = from->warc_cdx;
+  to->warc_wacz = from->warc_wacz;
 
   if (from->pause_max_ms > 0) {
     to->pause_min_ms = from->pause_min_ms;

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -1828,6 +1828,12 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                 } else if (*(com + 1) == 'c') { // --warc-cdx: sorted CDXJ index
                   com++;
                   opt->warc_cdx = 1;
+                } else if (*(com + 1) == 'z') { // --wacz: WACZ package
+                  com++;
+                  opt->warc_wacz = 1;
+                  opt->warc_cdx = 1; // WACZ embeds the CDXJ index
+                  if (!StringNotEmpty(opt->warc_file))
+                    StringCopy(opt->warc_file, WARC_AUTONAME);
                 } else { // --warc: auto-named archive under the output dir
                   StringCopy(opt->warc_file, WARC_AUTONAME);
                 }

--- a/src/htshelp.c
+++ b/src/htshelp.c
@@ -526,7 +526,8 @@ void help(const char *app, int more) {
   infomsg(" %M  generate a RFC MIME-encapsulated full-archive (.mht)");
   infomsg(" %r  write an ISO-28500 WARC/1.1 archive; --warc-file NAME sets the "
           "output name, --warc-max-size N rotates segments past N bytes, "
-          "--warc-cdx also writes a sorted CDXJ index");
+          "--warc-cdx also writes a sorted CDXJ index, --wacz packages it all "
+          "as a WACZ file");
   infomsg(" %t  keep the original file extension, don't rewrite it from the "
           "MIME type (%t0 rewrite)");
   infomsg

--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -545,6 +545,8 @@ struct httrackp {
                             bytes (<=0: single file). Tail: ABI */
   hts_boolean warc_cdx; /**< --warc-cdx: write a sorted CDXJ index next to the
                              archive. Tail: ABI */
+  hts_boolean warc_wacz; /**< --wacz: package archive+index+pages as a WACZ zip
+                              (implies --warc + --warc-cdx). Tail: ABI */
 };
 
 /* Running statistics for a mirror. */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3954,7 +3954,7 @@ typedef struct {
    fixed layout, STORE-mode entries, recomputing sha256 digests, the digest
    chain, and the pages.jsonl header. */
 static int st_warc_wacz(httrackp *opt, int argc, char **argv) {
-  char wpath[HTS_URLMAXSIZE], waczpath[HTS_URLMAXSIZE];
+  char wpath[HTS_URLMAXSIZE], waczpath[HTS_URLMAXSIZE], cdxpath[HTS_URLMAXSIZE];
   warc_writer *w;
   hts_boolean saved_cdx, saved_wacz;
   wacz_entry ent[16];
@@ -3962,6 +3962,7 @@ static int st_warc_wacz(httrackp *opt, int argc, char **argv) {
   unzFile uf;
   const wacz_entry *dp = NULL, *dig = NULL, *pages = NULL;
   int have_archive = 0, have_index = 0, all_store = 1;
+  LLint good_size;
 
   if (argc < 1) {
     fprintf(stderr, "warc-wacz: needs a writable directory\n");
@@ -3969,6 +3970,7 @@ static int st_warc_wacz(httrackp *opt, int argc, char **argv) {
   }
   fconcat(wpath, sizeof(wpath), argv[0], "warc-wacz.warc.gz");
   fconcat(waczpath, sizeof(waczpath), argv[0], "warc-wacz.wacz");
+  fconcat(cdxpath, sizeof(cdxpath), argv[0], "warc-wacz.cdx");
   saved_cdx = opt->warc_cdx;
   saved_wacz = opt->warc_wacz;
   opt->warc_cdx = 1;
@@ -3986,8 +3988,6 @@ static int st_warc_wacz(httrackp *opt, int argc, char **argv) {
       "Content-Type: application/octet-stream\r\n\r\n",
       "\x00\x01\x02\x03\x04", 5, NULL, 200, 0, 0);
   warc_close(w);
-  opt->warc_cdx = saved_cdx;
-  opt->warc_wacz = saved_wacz;
 
   /* Unzip every member in-process. */
   uf = unzOpen(waczpath);
@@ -4042,11 +4042,22 @@ static int st_warc_wacz(httrackp *opt, int argc, char **argv) {
       dig == NULL || !all_store)
     err = 1;
 
-  /* pages.jsonl first line is the json-pages-1.0 header. */
-  if (pages != NULL &&
-      (pages->len < 20 ||
-       memcmp(pages->data, "{\"format\": \"json-pages-1.0\"", 27) != 0))
-    err = 1;
+  /* pages.jsonl: header line, then >= 1 body row carrying url + ts. */
+  if (pages != NULL) {
+    if (pages->len < 27 ||
+        memcmp(pages->data, "{\"format\": \"json-pages-1.0\"", 27) != 0)
+      err = 1;
+    else {
+      const char *nl = memchr(pages->data, '\n', pages->len);
+      const char *body = nl ? nl + 1 : NULL;
+      size_t blen =
+          body ? pages->len - (size_t) (body - (char *) pages->data) : 0;
+      if (body == NULL || blen == 0 ||
+          warc_memstr(body, "\"url\": ", blen, 7) == NULL ||
+          warc_memstr(body, "\"ts\": ", blen, 6) == NULL)
+        err = 1;
+    }
+  }
 
   /* Every datapackage resource hash recomputes from the stored member bytes. */
   if (dp != NULL) {
@@ -4057,6 +4068,9 @@ static int st_warc_wacz(httrackp *opt, int argc, char **argv) {
       const char *p;
       memcpy(json, dp->data, dp->len);
       json[dp->len] = '\0';
+      if (strstr(json, "\"profile\": \"data-package\"") == NULL ||
+          strstr(json, "\"wacz_version\": \"") == NULL)
+        err = 1;
       p = json;
       while ((p = strstr(p, "\"path\": \"")) != NULL) {
         char path[256], want[80], got[65];
@@ -4097,6 +4111,8 @@ static int st_warc_wacz(httrackp *opt, int argc, char **argv) {
     } else {
       memcpy(djson, dig->data, dig->len);
       djson[dig->len] = '\0';
+      if (strstr(djson, "\"path\": \"datapackage.json\"") == NULL)
+        err = 1;
       h = strstr(djson, "\"hash\": \"sha256:");
       if (h == NULL || sscanf(h + 16, "%79[0-9a-f]", want) != 1 ||
           strcmp(want, dphex) != 0)
@@ -4107,6 +4123,21 @@ static int st_warc_wacz(httrackp *opt, int argc, char **argv) {
 
   for (i = 0; i < nent; i++)
     freet(ent[i].data);
+
+  /* #522-class: a failed re-package must leave the existing .wacz untouched.
+     Drop the .cdx and re-run empty so packaging fails on the missing index. */
+  good_size = fsize(waczpath);
+  if (good_size <= 0)
+    err = 1;
+  (void) UNLINK(cdxpath);
+  w = warc_open(opt, wpath);
+  assertf(w != NULL);
+  warc_close(w);
+  if (fsize(waczpath) != good_size) /* destroyed or rewritten = data loss */
+    err = 1;
+
+  opt->warc_cdx = saved_cdx;
+  opt->warc_wacz = saved_wacz;
   printf("warc-wacz: %d members (store=%d): %s\n", nent, all_store,
          err ? "FAIL" : "OK");
   return err;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -64,6 +64,9 @@ Please visit our Website: http://www.httrack.com
 #if HTS_USEZSTD
 #include <zstd.h>
 #endif
+#if HTS_USEOPENSSL
+#include <openssl/evp.h>
+#endif
 #include "coucal/coucal.h"
 
 #include <ctype.h>
@@ -3915,6 +3918,201 @@ static int st_warc_cdx(httrackp *opt, int argc, char **argv) {
   return err;
 }
 
+#if HTS_USEOPENSSL
+/* Lowercase-hex SHA-256 of n bytes into out[65]; 1 on success. */
+static int wacz_test_sha256(const void *p, size_t n, char out[65]) {
+  EVP_MD_CTX *c = EVP_MD_CTX_new();
+  unsigned char md[EVP_MAX_MD_SIZE];
+  unsigned int mdlen = 0, i;
+  static const char hx[] = "0123456789abcdef";
+  int ok;
+  if (c == NULL)
+    return 0;
+  ok = EVP_DigestInit_ex(c, EVP_sha256(), NULL) == 1 &&
+       (n == 0 || EVP_DigestUpdate(c, p, n) == 1) &&
+       EVP_DigestFinal_ex(c, md, &mdlen) == 1 && mdlen == 32;
+  EVP_MD_CTX_free(c);
+  if (!ok)
+    return 0;
+  for (i = 0; i < 32; i++) {
+    out[i * 2] = hx[md[i] >> 4];
+    out[i * 2 + 1] = hx[md[i] & 0x0F];
+  }
+  out[64] = '\0';
+  return 1;
+}
+
+/* One unzipped WACZ member: name, raw bytes, and the ZIP compression method. */
+typedef struct {
+  char name[256];
+  unsigned char *data;
+  size_t len;
+  int method;
+} wacz_entry;
+
+/* Package a 2-record WARC as a WACZ, then unzip it in-process and assert the
+   fixed layout, STORE-mode entries, recomputing sha256 digests, the digest
+   chain, and the pages.jsonl header. */
+static int st_warc_wacz(httrackp *opt, int argc, char **argv) {
+  char wpath[HTS_URLMAXSIZE], waczpath[HTS_URLMAXSIZE];
+  warc_writer *w;
+  hts_boolean saved_cdx, saved_wacz;
+  wacz_entry ent[16];
+  int nent = 0, err = 0, i;
+  unzFile uf;
+  const wacz_entry *dp = NULL, *dig = NULL, *pages = NULL;
+  int have_archive = 0, have_index = 0, all_store = 1;
+
+  if (argc < 1) {
+    fprintf(stderr, "warc-wacz: needs a writable directory\n");
+    return 1;
+  }
+  fconcat(wpath, sizeof(wpath), argv[0], "warc-wacz.warc.gz");
+  fconcat(waczpath, sizeof(waczpath), argv[0], "warc-wacz.wacz");
+  saved_cdx = opt->warc_cdx;
+  saved_wacz = opt->warc_wacz;
+  opt->warc_cdx = 1;
+  opt->warc_wacz = 1;
+  w = warc_open(opt, wpath);
+  assertf(w != NULL);
+  warc_write_transaction(w, "http://www.example.com/", "127.0.0.1",
+                         "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+                         "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n",
+                         "<html>home</html>\n", 18, NULL, 200, 0, 0);
+  warc_write_transaction(
+      w, "http://www.example.com/data.bin", "127.0.0.1",
+      "GET /data.bin HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Type: application/octet-stream\r\n\r\n",
+      "\x00\x01\x02\x03\x04", 5, NULL, 200, 0, 0);
+  warc_close(w);
+  opt->warc_cdx = saved_cdx;
+  opt->warc_wacz = saved_wacz;
+
+  /* Unzip every member in-process. */
+  uf = unzOpen(waczpath);
+  assertf(uf != NULL);
+  if (unzGoToFirstFile(uf) == UNZ_OK) {
+    do {
+      unz_file_info info;
+      wacz_entry *e;
+      if (nent >= (int) (sizeof(ent) / sizeof(ent[0]))) {
+        err = 1;
+        break;
+      }
+      e = &ent[nent];
+      if (unzGetCurrentFileInfo(uf, &info, e->name, sizeof(e->name), NULL, 0,
+                                NULL, 0) != UNZ_OK) {
+        err = 1;
+        break;
+      }
+      e->method = (int) info.compression_method;
+      e->len = (size_t) info.uncompressed_size;
+      e->data = malloct(e->len ? e->len : 1);
+      if (e->data == NULL || unzOpenCurrentFile(uf) != UNZ_OK) {
+        err = 1;
+        break;
+      }
+      if (e->len > 0 &&
+          unzReadCurrentFile(uf, e->data, (unsigned) e->len) != (int) e->len)
+        err = 1;
+      unzCloseCurrentFile(uf);
+      nent++;
+    } while (unzGoToNextFile(uf) == UNZ_OK);
+  }
+  unzClose(uf);
+
+  /* Classify members and assert STORE mode (WACZ spec requirement). */
+  for (i = 0; i < nent; i++) {
+    const wacz_entry *e = &ent[i];
+    if (e->method != 0)
+      all_store = 0;
+    if (strncmp(e->name, "archive/", 8) == 0)
+      have_archive = 1;
+    else if (strcmp(e->name, "indexes/index.cdx") == 0)
+      have_index = 1;
+    else if (strcmp(e->name, "pages/pages.jsonl") == 0)
+      pages = e;
+    else if (strcmp(e->name, "datapackage.json") == 0)
+      dp = e;
+    else if (strcmp(e->name, "datapackage-digest.json") == 0)
+      dig = e;
+  }
+  if (!have_archive || !have_index || pages == NULL || dp == NULL ||
+      dig == NULL || !all_store)
+    err = 1;
+
+  /* pages.jsonl first line is the json-pages-1.0 header. */
+  if (pages != NULL &&
+      (pages->len < 20 ||
+       memcmp(pages->data, "{\"format\": \"json-pages-1.0\"", 27) != 0))
+    err = 1;
+
+  /* Every datapackage resource hash recomputes from the stored member bytes. */
+  if (dp != NULL) {
+    char *json = malloct(dp->len + 1);
+    if (json == NULL) {
+      err = 1;
+    } else {
+      const char *p;
+      memcpy(json, dp->data, dp->len);
+      json[dp->len] = '\0';
+      p = json;
+      while ((p = strstr(p, "\"path\": \"")) != NULL) {
+        char path[256], want[80], got[65];
+        const char *pe, *h;
+        size_t plen;
+        p += 9;
+        pe = strchr(p, '"');
+        if (pe == NULL || (plen = (size_t) (pe - p)) >= sizeof(path)) {
+          err = 1;
+          break;
+        }
+        memcpy(path, p, plen);
+        path[plen] = '\0';
+        h = strstr(pe, "\"hash\": \"sha256:");
+        if (h == NULL || sscanf(h + 16, "%79[0-9a-f]", want) != 1) {
+          err = 1;
+          break;
+        }
+        for (i = 0; i < nent; i++)
+          if (strcmp(ent[i].name, path) == 0)
+            break;
+        if (i == nent || !wacz_test_sha256(ent[i].data, ent[i].len, got) ||
+            strcmp(got, want) != 0)
+          err = 1;
+        p = pe;
+      }
+      freet(json);
+    }
+  }
+
+  /* datapackage-digest.json chains sha256(datapackage.json). */
+  if (dp != NULL && dig != NULL) {
+    char dphex[65], *djson = malloct(dig->len + 1);
+    const char *h;
+    char want[80];
+    if (djson == NULL || !wacz_test_sha256(dp->data, dp->len, dphex)) {
+      err = 1;
+    } else {
+      memcpy(djson, dig->data, dig->len);
+      djson[dig->len] = '\0';
+      h = strstr(djson, "\"hash\": \"sha256:");
+      if (h == NULL || sscanf(h + 16, "%79[0-9a-f]", want) != 1 ||
+          strcmp(want, dphex) != 0)
+        err = 1;
+    }
+    freet(djson);
+  }
+
+  for (i = 0; i < nent; i++)
+    freet(ent[i].data);
+  printf("warc-wacz: %d members (store=%d): %s\n", nent, all_store,
+         err ? "FAIL" : "OK");
+  return err;
+}
+#endif
+
 /* ------------------------------------------------------------ */
 /* Registry: name -> handler, with a usage hint and a one-line description. */
 /* ------------------------------------------------------------ */
@@ -4046,6 +4244,10 @@ static const struct selftest_entry {
      st_warc_surt},
     {"warc-cdx", "<dir>", "--warc-cdx CDXJ index: sorted, offsets inflate",
      st_warc_cdx},
+#if HTS_USEOPENSSL
+    {"warc-wacz", "<dir>", "--wacz package: layout, STORE mode, sha256 digests",
+     st_warc_wacz},
+#endif
 };
 
 static void list_selftests(void) {

--- a/src/htswarc.c
+++ b/src/htswarc.c
@@ -59,6 +59,7 @@ Please visit our Website: http://www.httrack.com
 
 struct warc_writer {
   FILE *f;
+  httrackp *opt;   /* kept for close-time logging (warc_wacz_package) */
   int gz;          /* 1: one gzip member per record; 0: raw */
   uint64_t offset; /* running byte offset (member starts, for a future index) */
   uint64_t counter; /* monotonic record counter */
@@ -979,10 +980,21 @@ static zipFile wacz_zip_open(const char *path) {
   return zipOpen2_64(path, 0 /*create*/, NULL, &ff);
 }
 
+/* Move src onto dst (UTF-8/Windows-safe); RENAME won't clobber on Windows, so
+   fall back to unlink+rename. Returns 0 on success. */
+static int wacz_rename_over(const char *src, const char *dst) {
+  char cs[CATBUFF_SIZE], cd[CATBUFF_SIZE];
+  if (RENAME(fconv(cs, sizeof(cs), src), fconv(cd, sizeof(cd), dst)) == 0)
+    return 0;
+  (void) UNLINK(fconv(cd, sizeof(cd), dst));
+  return RENAME(fconv(cs, sizeof(cs), src), fconv(cd, sizeof(cd), dst));
+}
+
 /* Package the segment(s) + .cdx + a generated pages.jsonl into <base>.wacz at
    crawl end (the archive file(s) and .cdx are already closed on disk). */
 static void warc_wacz_package(warc_writer *w) {
   char waczpath[HTS_URLMAXSIZE * 2];
+  char tmppath[HTS_URLMAXSIZE * 2];
   char segpath[HTS_URLMAXSIZE * 2];
   char catbuff[CATBUFF_SIZE];
   zipFile zf;
@@ -997,9 +1009,14 @@ static void warc_wacz_package(warc_writer *w) {
   if (w->base_path == NULL || w->cdx_path == NULL)
     return;
   snprintf(waczpath, sizeof(waczpath), "%s.wacz", w->base_path);
-  zf = wacz_zip_open(fconv(catbuff, sizeof(catbuff), waczpath));
-  if (zf == NULL)
+  snprintf(tmppath, sizeof(tmppath), "%s.wacz.tmp", w->base_path);
+  /* Build into a temp; only full success replaces <base>.wacz, so a zero-record
+     re-run can't destroy a good archive (#522). */
+  zf = wacz_zip_open(fconv(catbuff, sizeof(catbuff), tmppath));
+  if (zf == NULL) {
+    hts_log_print(w->opt, LOG_WARNING, "WACZ: could not create %s", tmppath);
     return;
+  }
   memset(&resources, 0, sizeof(resources));
 
   /* archive/<name>.warc.gz for every segment (single file, or 0..seg). */
@@ -1086,8 +1103,16 @@ static void warc_wacz_package(warc_writer *w) {
   wbuf_free(&resources);
 
   zipClose(zf, NULL);
-  if (err)
-    (void) UNLINK(fconv(catbuff, sizeof(catbuff), waczpath));
+  if (err) {
+    (void) UNLINK(fconv(catbuff, sizeof(catbuff), tmppath));
+    hts_log_print(w->opt, LOG_WARNING,
+                  "WACZ: packaging failed, kept existing %s untouched",
+                  waczpath);
+  } else if (wacz_rename_over(tmppath, waczpath) != 0) {
+    (void) UNLINK(fconv(catbuff, sizeof(catbuff), tmppath));
+    hts_log_print(w->opt, LOG_WARNING | LOG_ERRNO,
+                  "WACZ: could not finalize %s", waczpath);
+  }
 }
 #endif
 
@@ -1357,6 +1382,7 @@ warc_writer *warc_open(httrackp *opt, const char *path) {
   w = calloct(1, sizeof(*w));
   if (w == NULL)
     return NULL;
+  w->opt = opt;
   plen = strlen(path);
   w->gz = (plen >= 3 && strcasecmp(path + plen - 3, ".gz") == 0);
   w->rng = (uint64_t) time(NULL) ^ ((uint64_t) (uintptr_t) w << 16) ^

--- a/src/htswarc.c
+++ b/src/htswarc.c
@@ -79,6 +79,17 @@ struct warc_writer {
   char **cdx_lines; /* NUL-terminated CDXJ lines (no newline), owned */
   size_t cdx_count; /* lines in use */
   size_t cdx_cap;   /* lines allocated */
+  /* --wacz: at crawl end, package the segment(s) + .cdx + a generated
+     pages.jsonl into <base>.wacz (WACZ 1.1.1). SHA-256 needs OpenSSL. */
+  int wacz_on;          /* --wacz enabled (and OpenSSL present) */
+  char *base_path;      /* resolved archive path minus .warc[.gz] suffix */
+  const char *base_ext; /* ".warc.gz" or ".warc" (static) */
+  char *arc_path;    /* full single-file archive path (NULL under rotation) */
+  char **page_lines; /* one JSON page line per 200 text/html response, owned */
+  size_t page_count;
+  size_t page_cap;
+  char *main_url;  /* first captured page URL (datapackage mainPageUrl) */
+  char *main_date; /* its WARC-Date (mainPageDate) */
 };
 
 const char *warc_truncated_reason(int code) {
@@ -354,6 +365,71 @@ static int payload_digest_b32(const char *body, size_t body_len,
   return 0;
 #endif
 }
+
+/* ---- SHA-256 hex (WACZ digests; OpenSSL-only) ---- */
+
+#if HTS_USEOPENSSL
+static void md32_to_hex(const unsigned char md[32], char out[65]) {
+  static const char hx[] = "0123456789abcdef";
+  int i;
+  for (i = 0; i < 32; i++) {
+    out[i * 2] = hx[md[i] >> 4];
+    out[i * 2 + 1] = hx[md[i] & 0x0F];
+  }
+  out[64] = '\0';
+}
+
+/* Lowercase-hex SHA-256 of n bytes at p into out[65]. Returns 1 on success. */
+static int sha256_hex_mem(const void *p, size_t n, char out[65]) {
+  EVP_MD_CTX *c = EVP_MD_CTX_new();
+  unsigned char md[EVP_MAX_MD_SIZE];
+  unsigned int mdlen = 0;
+  int ok;
+  if (c == NULL)
+    return 0;
+  ok = EVP_DigestInit_ex(c, EVP_sha256(), NULL) == 1 &&
+       (n == 0 || EVP_DigestUpdate(c, p, n) == 1) &&
+       EVP_DigestFinal_ex(c, md, &mdlen) == 1 && mdlen == 32;
+  EVP_MD_CTX_free(c);
+  if (ok)
+    md32_to_hex(md, out);
+  return ok;
+}
+
+/* Lowercase-hex SHA-256 of the on-disk file at path into out[65]. */
+static int sha256_hex_file(const char *path, char out[65]) {
+  EVP_MD_CTX *c;
+  FILE *fp;
+  char catbuff[CATBUFF_SIZE];
+  unsigned char md[EVP_MAX_MD_SIZE];
+  unsigned int mdlen = 0;
+  int ok;
+  fp = FOPEN(fconv(catbuff, sizeof(catbuff), path), "rb");
+  if (fp == NULL)
+    return 0;
+  c = EVP_MD_CTX_new();
+  if (c == NULL) {
+    fclose(fp);
+    return 0;
+  }
+  ok = EVP_DigestInit_ex(c, EVP_sha256(), NULL) == 1;
+  while (ok) {
+    unsigned char b[32768];
+    size_t nl = fread(b, 1, sizeof(b), fp);
+    if (nl > 0 && EVP_DigestUpdate(c, b, nl) != 1)
+      ok = 0;
+    if (nl < sizeof(b))
+      break;
+  }
+  ok = ok && !ferror(fp) && EVP_DigestFinal_ex(c, md, &mdlen) == 1 &&
+       mdlen == 32;
+  EVP_MD_CTX_free(c);
+  fclose(fp);
+  if (ok)
+    md32_to_hex(md, out);
+  return ok;
+}
+#endif
 
 /* ---- misc record helpers ---- */
 
@@ -769,6 +845,252 @@ static void warc_cdx_flush(warc_writer *w) {
   fclose(f);
 }
 
+/* ---- WACZ pages + packaging (--wacz) ---- */
+
+/* Record one pages.jsonl line for a top-level 200 text/html capture. First
+   page also seeds datapackage mainPageUrl/mainPageDate. Best-effort. */
+static void warc_page_add(warc_writer *w, const char *url, const char *date) {
+  wbuf line;
+  memset(&line, 0, sizeof(line));
+  if (wbuf_printf(&line, "{\"id\": \"p%llu\", \"url\": ",
+                  (unsigned long long) w->page_count) != 0 ||
+      cdx_json_str(&line, url) != 0 || wbuf_puts(&line, ", \"ts\": ") != 0 ||
+      cdx_json_str(&line, date) != 0 || wbuf_puts(&line, "}") != 0 ||
+      wbuf_add(&line, "", 1) != 0) {
+    wbuf_free(&line);
+    return;
+  }
+  if (w->page_count == w->page_cap) {
+    size_t ncap = w->page_cap ? w->page_cap * 2 : 32;
+    char **n;
+    if (ncap > (size_t) -1 / sizeof(char *)) {
+      wbuf_free(&line);
+      return;
+    }
+    n = realloct(w->page_lines, ncap * sizeof(char *));
+    if (n == NULL) {
+      wbuf_free(&line);
+      return;
+    }
+    w->page_lines = n;
+    w->page_cap = ncap;
+  }
+  w->page_lines[w->page_count++] = line.data;
+  if (w->main_url == NULL) {
+    w->main_url = strdupt(url);
+    w->main_date = strdupt(date);
+  }
+}
+
+#if HTS_USEOPENSSL
+/* WACZ requires every ZIP entry stored, not deflated (spec 1.1.1). */
+static int wacz_open_store(zipFile zf, const char *name) {
+  zip_fileinfo zi;
+  memset(&zi, 0, sizeof(zi));
+  return zipOpenNewFileInZip(zf, name, &zi, NULL, 0, NULL, 0, NULL, 0 /*store*/,
+                             0 /*level*/);
+}
+
+static int wacz_write_bytes(zipFile zf, const void *p, size_t n) {
+  while (n > 0) {
+    unsigned chunk = (n > 0x40000000u) ? 0x40000000u : (unsigned) n;
+    if (zipWriteInFileInZip(zf, p, chunk) != ZIP_OK)
+      return -1;
+    p = (const char *) p + chunk;
+    n -= chunk;
+  }
+  return 0;
+}
+
+/* Append one datapackage resource object; comma-prefixed unless first. */
+static int wacz_resource_add(wbuf *res, int first, const char *name,
+                             const char *path, const char *hex,
+                             uint64_t bytes) {
+  if (!first && wbuf_puts(res, ", ") != 0)
+    return -1;
+  if (wbuf_puts(res, "{\"name\": ") != 0 || cdx_json_str(res, name) != 0 ||
+      wbuf_puts(res, ", \"path\": ") != 0 || cdx_json_str(res, path) != 0 ||
+      wbuf_printf(res, ", \"hash\": \"sha256:%s\", \"bytes\": %llu}", hex,
+                  (unsigned long long) bytes) != 0)
+    return -1;
+  return 0;
+}
+
+/* Store an on-disk file as zipname, hash it, and list it in res. */
+static int wacz_add_disk(zipFile zf, const char *zipname, const char *diskpath,
+                         const char *resname, wbuf *res, int first) {
+  char hex[65];
+  char catbuff[CATBUFF_SIZE];
+  FILE *fp;
+  uint64_t bytes = 0;
+  int rc = -1;
+  if (!sha256_hex_file(diskpath, hex))
+    return -1;
+  if (wacz_open_store(zf, zipname) != ZIP_OK)
+    return -1;
+  fp = FOPEN(fconv(catbuff, sizeof(catbuff), diskpath), "rb");
+  if (fp != NULL) {
+    rc = 0;
+    for (;;) {
+      char b[32768];
+      size_t nl = fread(b, 1, sizeof(b), fp);
+      if (nl > 0 && wacz_write_bytes(zf, b, nl) != 0) {
+        rc = -1;
+        break;
+      }
+      bytes += nl;
+      if (nl < sizeof(b)) {
+        if (ferror(fp))
+          rc = -1;
+        break;
+      }
+    }
+    fclose(fp);
+  }
+  if (zipCloseFileInZip(zf) != ZIP_OK)
+    rc = -1;
+  if (rc == 0)
+    rc = wacz_resource_add(res, first, resname, zipname, hex, bytes);
+  return rc;
+}
+
+/* Store in-memory bytes as zipname; when res != NULL, hash and list them. */
+static int wacz_add_mem(zipFile zf, const char *zipname, const void *data,
+                        size_t n, const char *resname, wbuf *res, int first) {
+  char hex[65];
+  if (res != NULL && !sha256_hex_mem(data, n, hex))
+    return -1;
+  if (wacz_open_store(zf, zipname) != ZIP_OK)
+    return -1;
+  if (wacz_write_bytes(zf, data, n) != 0) {
+    zipCloseFileInZip(zf);
+    return -1;
+  }
+  if (zipCloseFileInZip(zf) != ZIP_OK)
+    return -1;
+  if (res != NULL)
+    return wacz_resource_add(res, first, resname, zipname, hex, n);
+  return 0;
+}
+
+static zipFile wacz_zip_open(const char *path) {
+  zlib_filefunc64_def ff;
+  fill_fopen64_filefunc(&ff);
+  return zipOpen2_64(path, 0 /*create*/, NULL, &ff);
+}
+
+/* Package the segment(s) + .cdx + a generated pages.jsonl into <base>.wacz at
+   crawl end (the archive file(s) and .cdx are already closed on disk). */
+static void warc_wacz_package(warc_writer *w) {
+  char waczpath[HTS_URLMAXSIZE * 2];
+  char segpath[HTS_URLMAXSIZE * 2];
+  char catbuff[CATBUFF_SIZE];
+  zipFile zf;
+  wbuf pages, resources, dp, digest;
+  char *seg_name;
+  char dp_hex[65];
+  char created[32];
+  unsigned s, nseg;
+  int err = 0, first = 1;
+  size_t i;
+
+  if (w->base_path == NULL || w->cdx_path == NULL)
+    return;
+  snprintf(waczpath, sizeof(waczpath), "%s.wacz", w->base_path);
+  zf = wacz_zip_open(fconv(catbuff, sizeof(catbuff), waczpath));
+  if (zf == NULL)
+    return;
+  memset(&resources, 0, sizeof(resources));
+
+  /* archive/<name>.warc.gz for every segment (single file, or 0..seg). */
+  nseg = (w->max_size > 0) ? w->seg + 1 : 1;
+  for (s = 0; s < nseg && !err; s++) {
+    char zipname[HTS_URLMAXSIZE];
+    if (w->max_size > 0)
+      snprintf(segpath, sizeof(segpath), "%s-%05u%s", w->base_path, s,
+               w->base_ext);
+    else
+      strlcpybuff(segpath, w->arc_path != NULL ? w->arc_path : w->base_path,
+                  sizeof(segpath));
+    seg_name = path_basename_dup(segpath);
+    if (seg_name == NULL) {
+      err = 1;
+      break;
+    }
+    snprintf(zipname, sizeof(zipname), "archive/%s", seg_name);
+    if (wacz_add_disk(zf, zipname, segpath, seg_name, &resources, first) != 0)
+      err = 1;
+    freet(seg_name);
+    first = 0;
+  }
+
+  /* indexes/index.cdx */
+  if (!err && wacz_add_disk(zf, "indexes/index.cdx", w->cdx_path, "index.cdx",
+                            &resources, first) != 0)
+    err = 1;
+  first = 0;
+
+  /* pages/pages.jsonl: header line + one line per captured page. */
+  memset(&pages, 0, sizeof(pages));
+  if (!err &&
+      wbuf_puts(&pages, "{\"format\": \"json-pages-1.0\", \"id\": \"pages\", "
+                        "\"title\": \"All Pages\"}\n") != 0)
+    err = 1;
+  for (i = 0; i < w->page_count && !err; i++)
+    if (wbuf_puts(&pages, w->page_lines[i]) != 0 ||
+        wbuf_add(&pages, "\n", 1) != 0)
+      err = 1;
+  if (!err && wacz_add_mem(zf, "pages/pages.jsonl", pages.data, pages.len,
+                           "pages.jsonl", &resources, first) != 0)
+    err = 1;
+  wbuf_free(&pages);
+
+  /* datapackage.json listing every stored file with its sha256 + size. */
+  warc_now_iso8601(created);
+  memset(&dp, 0, sizeof(dp));
+  if (!err &&
+      (wbuf_printf(&dp,
+                   "{\"profile\": \"data-package\", \"wacz_version\": "
+                   "\"1.1.1\", \"software\": \"HTTrack/%s\", \"created\": ",
+                   HTTRACK_VERSION) != 0 ||
+       cdx_json_str(&dp, created) != 0))
+    err = 1;
+  if (!err && w->main_url != NULL &&
+      (wbuf_puts(&dp, ", \"mainPageUrl\": ") != 0 ||
+       cdx_json_str(&dp, w->main_url) != 0 ||
+       wbuf_puts(&dp, ", \"mainPageDate\": ") != 0 ||
+       cdx_json_str(&dp, w->main_date != NULL ? w->main_date : created) != 0))
+    err = 1;
+  if (!err && (wbuf_puts(&dp, ", \"resources\": [") != 0 ||
+               wbuf_add(&dp, resources.data, resources.len) != 0 ||
+               wbuf_puts(&dp, "]}") != 0))
+    err = 1;
+  if (!err &&
+      wacz_add_mem(zf, "datapackage.json", dp.data, dp.len, NULL, NULL, 0) != 0)
+    err = 1;
+
+  /* datapackage-digest.json chains the integrity of datapackage.json. */
+  memset(&digest, 0, sizeof(digest));
+  if (!err && sha256_hex_mem(dp.data, dp.len, dp_hex)) {
+    if (wbuf_printf(&digest,
+                    "{\"path\": \"datapackage.json\", \"hash\": \"sha256:%s\"}",
+                    dp_hex) != 0 ||
+        wacz_add_mem(zf, "datapackage-digest.json", digest.data, digest.len,
+                     NULL, NULL, 0) != 0)
+      err = 1;
+  } else {
+    err = 1;
+  }
+  wbuf_free(&digest);
+  wbuf_free(&dp);
+  wbuf_free(&resources);
+
+  zipClose(zf, NULL);
+  if (err)
+    (void) UNLINK(fconv(catbuff, sizeof(catbuff), waczpath));
+}
+#endif
+
 /* Close the current segment and open the next; writes its warcinfo. */
 static int warc_rotate(warc_writer *w);
 
@@ -908,6 +1230,12 @@ static int warc_emit(warc_writer *w, const char *type, const char *content_type,
          strcmp(type, "resource") == 0))
       warc_cdx_add(w, target_uri, date, cdx_status, cdx_mime, payload_digest,
                    rec_offset, w->offset - rec_offset);
+    /* WACZ pages: top-level 200 text/html captures. */
+    if (w->wacz_on && target_uri != NULL && target_uri[0] != '\0' &&
+        strcmp(type, "response") == 0 && cdx_status != NULL &&
+        strcmp(cdx_status, "200") == 0 && cdx_mime != NULL &&
+        strncasecmp(cdx_mime, "text/html", 9) == 0)
+      warc_page_add(w, target_uri, date);
   }
   if (out_id != NULL)
     strlcpybuff(out_id, id, 64);
@@ -1067,18 +1395,37 @@ warc_writer *warc_open(httrackp *opt, const char *path) {
   if (opt->warc_cdx) {
     size_t l = strlen(path);
     size_t baselen = l;
-    if (l >= 8 && strcasecmp(path + l - 8, ".warc.gz") == 0)
+    if (l >= 8 && strcasecmp(path + l - 8, ".warc.gz") == 0) {
       baselen = l - 8;
-    else if (l >= 5 && strcasecmp(path + l - 5, ".warc") == 0)
+      w->base_ext = ".warc.gz";
+    } else if (l >= 5 && strcasecmp(path + l - 5, ".warc") == 0) {
       baselen = l - 5;
+      w->base_ext = ".warc";
+    } else {
+      w->base_ext = w->gz ? ".warc.gz" : ".warc";
+    }
     w->cdx_on = 1;
     w->cdx_path = malloct(baselen + 5); /* ".cdx" + NUL */
-    if (w->cdx_path == NULL) {
+    w->base_path = malloct(baselen + 1);
+    if (w->cdx_path == NULL || w->base_path == NULL) {
       warc_close(w);
       return NULL;
     }
     memcpy(w->cdx_path, path, baselen);
     memcpy(w->cdx_path + baselen, ".cdx", 5);
+    memcpy(w->base_path, path, baselen);
+    w->base_path[baselen] = '\0';
+  }
+
+  /* --wacz packages archive+cdx+pages at close; SHA-256 needs OpenSSL. */
+  if (opt->warc_wacz) {
+#if HTS_USEOPENSSL
+    w->wacz_on = 1;
+#else
+    hts_log_print(opt, LOG_WARNING,
+                  "WACZ requires an OpenSSL-enabled build for SHA-256 digests; "
+                  "--wacz disabled (WARC and CDXJ still written)");
+#endif
   }
 
   /* Rotation on: the first segment is <base>-00000<ext> (wget-style); split the
@@ -1116,6 +1463,8 @@ warc_writer *warc_open(httrackp *opt, const char *path) {
   }
   if (w->cdx_on)
     w->cur_seg = path_basename_dup(path);
+  if (w->wacz_on && w->max_size == 0)
+    w->arc_path = strdupt(path); /* single-file: package this exact path */
 
   if (warc_write_warcinfo_record(w) != 0) {
     warc_close(w);
@@ -1131,12 +1480,24 @@ void warc_close(warc_writer *w) {
   warc_cdx_flush(w); /* sort + write <base>.cdx before tearing down */
   if (w->f != NULL)
     fclose(w->f);
+  w->f = NULL;
+#if HTS_USEOPENSSL
+  if (w->wacz_on) /* package once the segment(s) + .cdx are closed on disk */
+    warc_wacz_package(w);
+#endif
   if (w->seen != NULL)
     coucal_delete(&w->seen);
   for (i = 0; i < w->cdx_count; i++)
     freet(w->cdx_lines[i]);
   freet(w->cdx_lines);
   freet(w->cdx_path);
+  for (i = 0; i < w->page_count; i++)
+    freet(w->page_lines[i]);
+  freet(w->page_lines);
+  freet(w->base_path);
+  freet(w->arc_path);
+  freet(w->main_url);
+  freet(w->main_date);
   freet(w->cur_seg);
   freet(w->seg_base);
   freet(w->info_fields);

--- a/tests/01_zlib-warc-wacz.test
+++ b/tests/01_zlib-warc-wacz.test
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# --wacz packaging over synthetic transactions: the WACZ unzips in-process to
+# the fixed layout, every entry is ZIP STORE, each datapackage sha256 recomputes
+# from the stored bytes, and the digest chains datapackage.json. WACZ needs the
+# OpenSSL SHA-256 digests, so the self-test is absent on non-OpenSSL builds.
+
+httrack_bin=$(cd "$(dirname "$(command -v httrack)")" && pwd)/httrack
+
+if ! "$httrack_bin" -#test 2>&1 | grep -q '^  warc-wacz'; then
+    echo "warc-wacz self-test unavailable (build without OpenSSL); skipping"
+    exit 77
+fi
+
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+
+out=$("$httrack_bin" -O /dev/null -#test=warc-wacz "$scratch/")
+echo "$out"
+case "$out" in
+*": OK") ;;
+*) exit 1 ;;
+esac

--- a/tests/74_local-warc-wacz.test
+++ b/tests/74_local-warc-wacz.test
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# A --wacz crawl packages the WARC archive, its CDXJ index and a generated
+# pages.jsonl into a single WACZ file at crawl end. The stdlib validator is the
+# real gate: STORE-mode entries, the fixed layout, recomputed sha256 digests and
+# the datapackage-digest chain (plus py-wacz/pywb when importable). The crawl
+# skips cleanly on a build without OpenSSL (no conformant SHA-256 -> no package).
+
+set -eu
+
+: "${top_srcdir:=..}"
+
+bash "$top_srcdir/tests/local-crawl.sh" --errors 0 --wacz-validate \
+    --found 'mini304/index.html' --found 'mini304/page.html' \
+    httrack 'BASEURL/mini304/index.html' --warc-file warc-out --wacz

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,7 +3,7 @@
 # silently drop it from the dist tarball and break "make distcheck".
 EXTRA_DIST = $(TESTS) crawl-test.sh run-all-tests.sh check-network.sh \
 	proxy-https-server.py socks5-server.py proxy-connect-server.py \
-	proxytestlib.py tls-stall-server.py warc-validate.py \
+	proxytestlib.py tls-stall-server.py warc-validate.py wacz-validate.py \
 	local-crawl.sh local-server.py testlib.sh server.crt server.key \
 	server-root/simple/basic.html server-root/simple/link.html \
 	server-root/stripquery/index.html server-root/stripquery/a.html \
@@ -83,6 +83,7 @@ TESTS = \
 	01_zlib-acceptencoding.test \
 	01_zlib-warc.test \
 	01_zlib-warc-cdx.test \
+	01_zlib-warc-wacz.test \
 	01_zlib-contentcodings.test \
 	01_zlib-cache.test \
 	01_zlib-cache-corrupt.test \
@@ -159,6 +160,7 @@ TESTS = \
 	69_local-intl-logdir.test \
 	71_local-crange-repaircache.test \
 	72_watchdog-crawl.test \
-	73_local-warc.test
+	73_local-warc.test \
+	74_local-warc-wacz.test
 
 CLEANFILES = check-network_sh.cache

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -48,6 +48,7 @@ key="${testdir}/server.key"
 tls=
 verbose=
 warc_validate=
+wacz_validate=
 html_subdir=
 outdir_intl=
 rerun=
@@ -117,6 +118,8 @@ while test "$pos" -lt "$nargs"; do
     --rerun-dead) rerun_dead=1 ;; # re-run with the server stopped (cache rollback)
     # validate the produced .warc.gz (see the validation block near the end)
     --warc-validate) warc_validate=1 ;;
+    # validate the produced .wacz package (stdlib, plus py-wacz/pywb if present)
+    --wacz-validate) wacz_validate=1 ;;
     --no-purge)
         nopurge=1
         audit+=("--no-purge")
@@ -396,6 +399,23 @@ if test -n "$warc_validate"; then
         info "warcio check (optional)"
         if warcio check -v "$warc" >&2; then result "OK"; else die "warcio check failed"; fi
     fi
+fi
+
+# --- optional WACZ validation (--wacz) --------------------------------------
+if test -n "$wacz_validate"; then
+    wacz=$(find "$mirrorroot" -maxdepth 2 -name '*.wacz' 2>/dev/null | sort | tail -n1)
+    if test -z "$wacz"; then
+        # No package: only acceptable when the build lacks OpenSSL (SHA-256).
+        if grep -aqi "WACZ requires an OpenSSL" "${logroot}/hts-log.txt"; then
+            info "no .wacz produced (build without OpenSSL); skipping"
+            exit 77
+        fi
+        die "no .wacz file produced under $mirrorroot"
+    fi
+    validator=$(nativepath "${testdir}/wacz-validate.py")
+    info "validating WACZ package"
+    "$python" "$validator" "$(nativepath "$wacz")" >&2 || die "WACZ validation failed"
+    result "OK"
 fi
 
 # No crawl, even a cancelled one, may leave engine temporaries: .delayed (#107,

--- a/tests/wacz-validate.py
+++ b/tests/wacz-validate.py
@@ -39,11 +39,19 @@ def main():
         if not ok:
             fail("missing %s (entries: %s)" % (req, names))
 
-    hdr = z.read("pages/pages.jsonl").split(b"\n")[0]
-    if json.loads(hdr).get("format") != "json-pages-1.0":
-        fail("pages.jsonl header is not json-pages-1.0: %r" % hdr)
+    lines = [ln for ln in z.read("pages/pages.jsonl").split(b"\n") if ln.strip()]
+    if not lines or json.loads(lines[0]).get("format") != "json-pages-1.0":
+        fail("pages.jsonl header is not json-pages-1.0: %r" % lines[:1])
+    body = [json.loads(ln) for ln in lines[1:]]
+    if not body:
+        fail("pages.jsonl has no page rows after the header")
+    for row in body:
+        if "url" not in row or "ts" not in row:
+            fail("pages.jsonl row missing url/ts: %r" % row)
 
     dp = json.loads(z.read("datapackage.json"))
+    if dp.get("profile") != "data-package":
+        fail("profile != data-package: %r" % dp.get("profile"))
     if dp.get("wacz_version") != "1.1.1":
         fail("wacz_version != 1.1.1: %r" % dp.get("wacz_version"))
     resources = dp.get("resources", [])

--- a/tests/wacz-validate.py
+++ b/tests/wacz-validate.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Validate a WACZ package with the stdlib only (no py-wacz needed): every entry
+# is ZIP STORE, the fixed layout is present, each datapackage resource hash and
+# size recomputes, the digest chains datapackage.json, and pages.jsonl carries
+# the json-pages-1.0 header. If py-wacz (`wacz validate`) is importable it runs
+# too; both gates must pass. Exit 0 = valid, nonzero = invalid.
+import sys
+import json
+import zipfile
+import hashlib
+
+
+def fail(msg):
+    print("wacz-validate: FAIL: %s" % msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    if len(sys.argv) < 2:
+        fail("usage: wacz-validate.py FILE.wacz")
+    path = sys.argv[1]
+    z = zipfile.ZipFile(path)
+    names = z.namelist()
+
+    for info in z.infolist():
+        if info.compress_type != zipfile.ZIP_STORED:
+            fail("%s is not STORE mode (%d)" % (info.filename, info.compress_type))
+
+    need_arc = any(
+        n.startswith("archive/") and n.endswith((".warc.gz", ".warc")) for n in names
+    )
+    for req, ok in (
+        ("archive/*.warc.gz", need_arc),
+        ("indexes/index.cdx", "indexes/index.cdx" in names),
+        ("pages/pages.jsonl", "pages/pages.jsonl" in names),
+        ("datapackage.json", "datapackage.json" in names),
+        ("datapackage-digest.json", "datapackage-digest.json" in names),
+    ):
+        if not ok:
+            fail("missing %s (entries: %s)" % (req, names))
+
+    hdr = z.read("pages/pages.jsonl").split(b"\n")[0]
+    if json.loads(hdr).get("format") != "json-pages-1.0":
+        fail("pages.jsonl header is not json-pages-1.0: %r" % hdr)
+
+    dp = json.loads(z.read("datapackage.json"))
+    if dp.get("wacz_version") != "1.1.1":
+        fail("wacz_version != 1.1.1: %r" % dp.get("wacz_version"))
+    resources = dp.get("resources", [])
+    if not resources:
+        fail("datapackage has no resources")
+    for r in resources:
+        data = z.read(r["path"])
+        h = "sha256:" + hashlib.sha256(data).hexdigest()
+        if h != r["hash"]:
+            fail("%s hash %s != %s" % (r["path"], h, r["hash"]))
+        if len(data) != r["bytes"]:
+            fail("%s bytes %d != %d" % (r["path"], len(data), r["bytes"]))
+
+    dig = json.loads(z.read("datapackage-digest.json"))
+    want = "sha256:" + hashlib.sha256(z.read("datapackage.json")).hexdigest()
+    if dig.get("path") != "datapackage.json" or dig.get("hash") != want:
+        fail("digest chain broken: %r" % dig)
+
+    print(
+        "wacz-validate: OK (%d entries, %d resources, stdlib)"
+        % (len(names), len(resources))
+    )
+
+    # Optional stricter gate when py-wacz is present.
+    try:
+        import wacz  # noqa: F401
+    except Exception:
+        return
+    try:
+        from wacz.main import main as wacz_main  # type: ignore
+    except Exception:
+        return
+    print("wacz-validate: running py-wacz validate")
+    rc = wacz_main(["validate", "-f", path])
+    if rc not in (0, None):
+        fail("py-wacz validate returned %r" % rc)
+    print("wacz-validate: py-wacz OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds `--wacz`, which packages the crawl into a single WACZ file (`<archive>.wacz`, WACZ 1.1.1) alongside the WARC. The package holds the WARC segment(s) under `archive/`, the sorted CDXJ under `indexes/index.cdx`, a `pages/pages.jsonl` listing the top-level HTML pages, and a `datapackage.json` / `datapackage-digest.json` SHA-256 chain. Every ZIP entry is stored (no re-compression), as the spec requires, so the already-gzipped WARC is not re-deflated. `--wacz` implies `--warc` and `--warc-cdx`.

Packaging runs at crawl end and reuses the in-tree minizip, so there's no new dependency. SHA-256 comes from OpenSSL; a build without OpenSSL can't produce conformant digests, so `--wacz` refuses at open with a clear message and still writes the plain WARC and CDXJ.

Validated on single-file and 11-segment rotation crawls: the package unzips, every entry is STORE mode, all resource hashes and the datapackage digest recompute, and the inner `archive/*.warc.gz` re-inflates to valid WARC/1.1. Replay-tool validation (py-wacz / ReplayWeb.page) was not run here because those tools aren't available in this environment; the SURT index keys follow the pywb/surt convention and are unit-tested, but a drag-drop replay check is worth doing before relying on replay.

Builds on #674 (CDXJ index) and completes the WARC v2 tooling for #668.
