### PR TITLE
WARC: file --warc under Log/index/cache in --help, not Build

### DIFF
--- a/html/httrack.man.html
+++ b/html/httrack.man.html
@@ -90,35 +90,34 @@ offline browser : copy websites to a local directory</p>
 ] [ <b>-NN, --structure[=N]</b> ] [ <b>-%N,
 --delayed-type-check</b> ] [ <b>-%D,
 --cached-delayed-type-check</b> ] [ <b>-%M, --mime-html</b>
-] [ <b>-%r, --warc</b> ] [ <b>-LN, --long-names[=N]</b> ] [
-<b>-KN, --keep-links[=N]</b> ] [ <b>-x,
---replace-external</b> ] [ <b>-%x, --disable-passwords</b> ]
-[ <b>-%q, --include-query-string</b> ] [ <b>-%g,
---strip-query</b> ] [ <b>-o, --generate-errors</b> ] [
-<b>-X, --purge-old[=N]</b> ] [ <b>-%p, --preserve</b> ] [
-<b>-%T, --utf8-conversion</b> ] [ <b>-bN, --cookies[=N]</b>
-] [ <b>-%K, --cookies-file</b> ] [ <b>-%Y, --why</b> ] [
-<b>-u, --check-type[=N]</b> ] [ <b>-j, --parse-java[=N]</b>
-] [ <b>-sN, --robots[=N]</b> ] [ <b>-%h, --http-10</b> ] [
-<b>-%k, --keep-alive</b> ] [ <b>-%z,
---disable-compression</b> ] [ <b>-%B, --tolerant</b> ] [
-<b>-%s, --updatehack</b> ] [ <b>-%u, --urlhack</b> ] [
+] [ <b>-LN, --long-names[=N]</b> ] [ <b>-KN,
+--keep-links[=N]</b> ] [ <b>-x, --replace-external</b> ] [
+<b>-%x, --disable-passwords</b> ] [ <b>-%q,
+--include-query-string</b> ] [ <b>-%g, --strip-query</b> ] [
+<b>-o, --generate-errors</b> ] [ <b>-X, --purge-old[=N]</b>
+] [ <b>-%p, --preserve</b> ] [ <b>-%T, --utf8-conversion</b>
+] [ <b>-bN, --cookies[=N]</b> ] [ <b>-%K, --cookies-file</b>
+] [ <b>-%Y, --why</b> ] [ <b>-u, --check-type[=N]</b> ] [
+<b>-j, --parse-java[=N]</b> ] [ <b>-sN, --robots[=N]</b> ] [
+<b>-%h, --http-10</b> ] [ <b>-%k, --keep-alive</b> ] [
+<b>-%z, --disable-compression</b> ] [ <b>-%B, --tolerant</b>
+] [ <b>-%s, --updatehack</b> ] [ <b>-%u, --urlhack</b> ] [
 <b>-%A, --assume</b> ] [ <b>-@iN, --protocol[=N]</b> ] [
 <b>-%w, --disable-module</b> ] [ <b>-F, --user-agent</b> ] [
 <b>-%R, --referer</b> ] [ <b>-%E, --from</b> ] [ <b>-%F,
 --footer</b> ] [ <b>-%l, --language</b> ] [ <b>-%a,
 --accept</b> ] [ <b>-%X, --headers</b> ] [ <b>-C,
 --cache[=N]</b> ] [ <b>-k, --store-all-in-cache</b> ] [
-<b>-%n, --do-not-recatch</b> ] [ <b>-%v, --display</b> ] [
-<b>-Q, --do-not-log</b> ] [ <b>-q, --quiet</b> ] [ <b>-z,
---extra-log</b> ] [ <b>-Z, --debug-log</b> ] [ <b>-v,
---verbose</b> ] [ <b>-f, --file-log</b> ] [ <b>-f2,
---single-log</b> ] [ <b>-I, --index</b> ] [ <b>-%i,
---build-top-index</b> ] [ <b>-%I, --search-index</b> ] [
-<b>-pN, --priority[=N]</b> ] [ <b>-S, --stay-on-same-dir</b>
-] [ <b>-D, --can-go-down</b> ] [ <b>-U, --can-go-up</b> ] [
-<b>-B, --can-go-up-and-down</b> ] [ <b>-a,
---stay-on-same-address</b> ] [ <b>-d,
+<b>-%r, --warc</b> ] [ <b>-%n, --do-not-recatch</b> ] [
+<b>-%v, --display</b> ] [ <b>-Q, --do-not-log</b> ] [ <b>-q,
+--quiet</b> ] [ <b>-z, --extra-log</b> ] [ <b>-Z,
+--debug-log</b> ] [ <b>-v, --verbose</b> ] [ <b>-f,
+--file-log</b> ] [ <b>-f2, --single-log</b> ] [ <b>-I,
+--index</b> ] [ <b>-%i, --build-top-index</b> ] [ <b>-%I,
+--search-index</b> ] [ <b>-pN, --priority[=N]</b> ] [ <b>-S,
+--stay-on-same-dir</b> ] [ <b>-D, --can-go-down</b> ] [
+<b>-U, --can-go-up</b> ] [ <b>-B, --can-go-up-and-down</b> ]
+[ <b>-a, --stay-on-same-address</b> ] [ <b>-d,
 --stay-on-same-domain</b> ] [ <b>-l, --stay-on-same-tld</b>
 ] [ <b>-e, --go-everywhere</b> ] [ <b>-%H,
 --debug-headers</b> ] [ <b>-%!,
@@ -649,20 +648,6 @@ don&rsquo;t wait) (--cached-delayed-type-check)</p></td></tr>
 <td width="4%">
 
 
-<p>-%r</p></td>
-<td width="5%"></td>
-<td width="82%">
-
-
-<p>write an ISO-28500 WARC/1.1 archive; --warc-file NAME
-sets the output name, --warc-max-size N rotates segments
-past N bytes, --warc-cdx also writes a sorted CDXJ index,
---wacz packages it all as a WACZ file (--warc)</p></td></tr>
-<tr valign="top" align="left">
-<td width="9%"></td>
-<td width="4%">
-
-
 <p>-%t</p></td>
 <td width="5%"></td>
 <td width="82%">
@@ -1139,6 +1124,20 @@ update before) (--cache[=N])</p></td></tr>
 
 <p>store all files in cache (not useful if files on disk)
 (--store-all-in-cache)</p> </td></tr>
+<tr valign="top" align="left">
+<td width="9%"></td>
+<td width="4%">
+
+
+<p>-%r</p></td>
+<td width="5%"></td>
+<td width="82%">
+
+
+<p>write an ISO-28500 WARC/1.1 archive; --warc-file NAME
+sets the output name, --warc-max-size N rotates segments
+past N bytes, --warc-cdx also writes a sorted CDXJ index,
+--wacz packages it all as a WACZ file (--warc)</p></td></tr>
 <tr valign="top" align="left">
 <td width="9%"></td>
 <td width="4%">

--- a/man/httrack.1
+++ b/man/httrack.1
@@ -40,7 +40,6 @@ httrack \- offline browser : copy websites to a local directory
 [ \fB\-%N, \-\-delayed\-type\-check\fR ]
 [ \fB\-%D, \-\-cached\-delayed\-type\-check\fR ]
 [ \fB\-%M, \-\-mime\-html\fR ]
-[ \fB\-%r, \-\-warc\fR ]
 [ \fB\-LN, \-\-long\-names[=N]\fR ]
 [ \fB\-KN, \-\-keep\-links[=N]\fR ]
 [ \fB\-x, \-\-replace\-external\fR ]
@@ -75,6 +74,7 @@ httrack \- offline browser : copy websites to a local directory
 [ \fB\-%X, \-\-headers\fR ]
 [ \fB\-C, \-\-cache[=N]\fR ]
 [ \fB\-k, \-\-store\-all\-in\-cache\fR ]
+[ \fB\-%r, \-\-warc\fR ]
 [ \fB\-%n, \-\-do\-not\-recatch\fR ]
 [ \fB\-%v, \-\-display\fR ]
 [ \fB\-Q, \-\-do\-not\-log\fR ]
@@ -198,8 +198,6 @@ delayed type check, don't make any link test but wait for files download to star
 cached delayed type check, don't wait for remote type during updates, to speedup them (%D0 wait, * %D1 don't wait) (\-\-cached\-delayed\-type\-check)
 .IP \-%M
 generate a RFC MIME\-encapsulated full\-archive (.mht) (\-\-mime\-html)
-.IP \-%r
-write an ISO\-28500 WARC/1.1 archive; \-\-warc\-file NAME sets the output name, \-\-warc\-max\-size N rotates segments past N bytes, \-\-warc\-cdx also writes a sorted CDXJ index, \-\-wacz packages it all as a WACZ file (\-\-warc)
 .IP \-%t
 keep the original file extension, don't rewrite it from the MIME type (%t0 rewrite)
 .IP \-LN
@@ -279,6 +277,8 @@ additional HTTP header line (\-%X "X\-Magic: 42" (\-\-headers <param>)
 create/use a cache for updates and retries (C0 no cache,C1 cache is prioritary,* C2 test update before) (\-\-cache[=N])
 .IP \-k
 store all files in cache (not useful if files on disk) (\-\-store\-all\-in\-cache)
+.IP \-%r
+write an ISO\-28500 WARC/1.1 archive; \-\-warc\-file NAME sets the output name, \-\-warc\-max\-size N rotates segments past N bytes, \-\-warc\-cdx also writes a sorted CDXJ index, \-\-wacz packages it all as a WACZ file (\-\-warc)
 .IP \-%n
 do not re\-download locally erased files (\-\-do\-not\-recatch)
 .IP \-%v

--- a/src/htshelp.c
+++ b/src/htshelp.c
@@ -524,10 +524,6 @@ void help(const char *app, int more) {
   infomsg
     (" %D  cached delayed type check, don't wait for remote type during updates, to speedup them (%D0 wait, * %D1 don't wait)");
   infomsg(" %M  generate a RFC MIME-encapsulated full-archive (.mht)");
-  infomsg(" %r  write an ISO-28500 WARC/1.1 archive; --warc-file NAME sets the "
-          "output name, --warc-max-size N rotates segments past N bytes, "
-          "--warc-cdx also writes a sorted CDXJ index, --wacz packages it all "
-          "as a WACZ file");
   infomsg(" %t  keep the original file extension, don't rewrite it from the "
           "MIME type (%t0 rewrite)");
   infomsg
@@ -597,6 +593,10 @@ void help(const char *app, int more) {
   infomsg
     ("  C  create/use a cache for updates and retries (C0 no cache,C1 cache is prioritary,* C2 test update before)");
   infomsg("  k  store all files in cache (not useful if files on disk)");
+  infomsg(" %r  write an ISO-28500 WARC/1.1 archive; --warc-file NAME sets the "
+          "output name, --warc-max-size N rotates segments past N bytes, "
+          "--warc-cdx also writes a sorted CDXJ index, --wacz packages it all "
+          "as a WACZ file");
   infomsg(" %n  do not re-download locally erased files");
   infomsg
     (" %v  display on screen filenames downloaded (in realtime) - * %v1 short version - %v2 full animation");


### PR DESCRIPTION
Files `--warc` under the **Log, index, cache** help section instead of **Build options**. WARC is a transaction-level archive of what was fetched, a sibling of the hts-cache, not a browsable-mirror build format like MHTML (`%M`), so it reads more naturally next to the cache options than next to mirror-structure ones.

Help text only, no behavior change. The webhttrack GUI already places the WARC toggle on the Log/Index/Cache tab (option9), so this just aligns the CLI `--help` and man page with that. Man page regenerated.
