### PR TITLE
Use the platform path limit off Windows, not the Windows MAX_PATH (#133)

### DIFF
--- a/src/htsname.c
+++ b/src/htsname.c
@@ -1614,12 +1614,17 @@ int url_savename(lien_adrfilsave *const afs,
   {
     const size_t parentBytes = strlen(StringBuff(opt->path_html_utf8));
     const size_t cap = HTS_SAVE_BUFSIZE - HTS_PATH_TAIL_RESERVE;
-    size_t budget = parentBytes < cap ? cap - parentBytes : 0;
-    if (strlen(afs->save) > budget) {
-      while (budget > 0 && ((unsigned char) afs->save[budget] & 0xC0) == 0x80)
-        budget--; // back off a trailing continuation byte, never split a char
-      afs->save[budget] = '\0';
-      cleanEndingSpaceOrDot(afs->save);
+    // Shrink only the name. A parent that alone fills the buffer is left to the
+    // existing prepend abort, not collapsed to an empty name that would collide
+    // across URLs and overrun the unbounded collision-suffix sprintf.
+    if (parentBytes < cap) {
+      size_t budget = cap - parentBytes;
+      if (strlen(afs->save) > budget) {
+        while (budget > 0 && ((unsigned char) afs->save[budget] & 0xC0) == 0x80)
+          budget--; // back off a continuation byte, never split a char
+        afs->save[budget] = '\0';
+        cleanEndingSpaceOrDot(afs->save);
+      }
     }
   }
 #undef MAX_UTF8_SEQ_CHARS

--- a/src/htsname.c
+++ b/src/htsname.c
@@ -47,6 +47,7 @@ Please visit our Website: http://www.httrack.com
 #include "htszlib.h"
 #endif
 #include <ctype.h>
+#include <limits.h>
 
 #define ADD_STANDARD_PATH \
     {  /* ajout nom */\
@@ -1475,15 +1476,37 @@ int url_savename(lien_adrfilsave *const afs,
                   sizeof(afs->save) - (size_t) (lastDot - afs->save));
     }
   }
-  // enforce 260-character path limit before inserting destination path
-  // note: 12 characters at least for WIN32, and 12 for ".99.delayed"
-  // (MSDN) "When using an API to create a directory, the specified path 
-  // cannot be so long that you cannot append an 8.3 file name 
-  // (that is, the directory name cannot exceed MAX_PATH minus 12)."
-#define HTS_MAX_PATH_LEN ( 260 - 12 - 12 )
+  // Cap the save path: the final parent+name is copied into a fixed buffer that
+  // aborts() on overflow (htssafe.h), so clamp every ceiling to fit it.
+#define HTS_SAVE_BUFSIZE (HTS_URLMAXSIZE * 2) /* sizeof(afs->save) */
+#define HTS_PATH_TAIL_RESERVE 64 /* collision suffix + ".delayed" + NUL */
+#ifdef _WIN32
+  // MAX_PATH minus 8.3 headroom (MSDN) minus the ".delayed" marker; raising it
+  // needs the engine to "\\?\"-prefix its paths, which is separate work.
+#define HTS_MAX_PATH_LEN (260 - 12 - 12)
+#define MAX_SEG_LEN 48
+#else
+  // #133: use the platform's own PATH_MAX/NAME_MAX (Linux/Android 4096, macOS
+  // 1024) rather than the far smaller Windows MAX_PATH.
+#ifdef PATH_MAX
+#define HTS_PATH_MAX_ PATH_MAX
+#else
+#define HTS_PATH_MAX_ 1024
+#endif
+#ifdef NAME_MAX
+#define HTS_NAME_MAX_ NAME_MAX
+#else
+#define HTS_NAME_MAX_ 255
+#endif
+#define HTS_MAX_PATH_LEN                                                       \
+  ((HTS_PATH_MAX_ - HTS_PATH_TAIL_RESERVE) <                                   \
+           (HTS_SAVE_BUFSIZE - HTS_PATH_TAIL_RESERVE)                          \
+       ? (HTS_PATH_MAX_ - HTS_PATH_TAIL_RESERVE)                               \
+       : (HTS_SAVE_BUFSIZE - HTS_PATH_TAIL_RESERVE))
+#define MAX_SEG_LEN (HTS_NAME_MAX_ > 64 ? HTS_NAME_MAX_ - 16 : HTS_NAME_MAX_)
+#endif
 #define MIN_LAST_SEG_RESERVE 12
 #define MAX_LAST_SEG_RESERVE 24
-#define MAX_SEG_LEN 48
   if (hts_stringLengthUTF8(afs->save) +
       hts_stringLengthUTF8(StringBuff(opt->path_html_utf8)) >=
       HTS_MAX_PATH_LEN) {
@@ -1493,12 +1516,19 @@ int url_savename(lien_adrfilsave *const afs,
     if (wsave != NULL) {
       const size_t parentLen =
         hts_stringLengthUTF8(StringBuff(opt->path_html_utf8));
-      // parent path length is not insane (otherwise, ignore and pick 200 as 
+      // parent path length is not insane (otherwise, ignore and pick 200 as
       // suffix length)
-      const size_t maxLen =
+      size_t maxLen =
         parentLen <
         HTS_MAX_PATH_LEN - HTS_MAX_PATH_LEN / 4
         ? HTS_MAX_PATH_LEN - parentLen : HTS_MAX_PATH_LEN;
+      // the branch above can pick maxLen ignoring parentLen; keep the total
+      // inside the abort-on-overflow buffer even for an oversized parent.
+      if (parentLen + maxLen > HTS_SAVE_BUFSIZE - HTS_PATH_TAIL_RESERVE) {
+        maxLen = parentLen < HTS_SAVE_BUFSIZE - HTS_PATH_TAIL_RESERVE
+                     ? HTS_SAVE_BUFSIZE - HTS_PATH_TAIL_RESERVE - parentLen
+                     : MIN_LAST_SEG_RESERVE;
+      }
       size_t i, j, lastSeg, lastSegSize, dirSize;
       char *saveFinal;
 
@@ -1586,7 +1616,15 @@ int url_savename(lien_adrfilsave *const afs,
   }
 #undef MAX_UTF8_SEQ_CHARS
 #undef MIN_LAST_SEG_RESERVE
+#undef MAX_LAST_SEG_RESERVE
+#undef MAX_SEG_LEN
 #undef HTS_MAX_PATH_LEN
+#undef HTS_PATH_TAIL_RESERVE
+#undef HTS_SAVE_BUFSIZE
+#ifndef _WIN32
+#undef HTS_PATH_MAX_
+#undef HTS_NAME_MAX_
+#endif
 
   // chemin primaire éventuel A METTRE AVANT
   if (strnotempty(StringBuff(opt->path_html_utf8))) {

--- a/src/htsname.c
+++ b/src/htsname.c
@@ -1518,17 +1518,10 @@ int url_savename(lien_adrfilsave *const afs,
         hts_stringLengthUTF8(StringBuff(opt->path_html_utf8));
       // parent path length is not insane (otherwise, ignore and pick 200 as
       // suffix length)
-      size_t maxLen =
+      const size_t maxLen =
         parentLen <
         HTS_MAX_PATH_LEN - HTS_MAX_PATH_LEN / 4
         ? HTS_MAX_PATH_LEN - parentLen : HTS_MAX_PATH_LEN;
-      // the branch above can pick maxLen ignoring parentLen; keep the total
-      // inside the abort-on-overflow buffer even for an oversized parent.
-      if (parentLen + maxLen > HTS_SAVE_BUFSIZE - HTS_PATH_TAIL_RESERVE) {
-        maxLen = parentLen < HTS_SAVE_BUFSIZE - HTS_PATH_TAIL_RESERVE
-                     ? HTS_SAVE_BUFSIZE - HTS_PATH_TAIL_RESERVE - parentLen
-                     : MIN_LAST_SEG_RESERVE;
-      }
       size_t i, j, lastSeg, lastSegSize, dirSize;
       char *saveFinal;
 
@@ -1613,6 +1606,21 @@ int url_savename(lien_adrfilsave *const afs,
 
     // Re-check again ending space or dot after cut (see bug #5)
     cleanEndingSpaceOrDot(afs->save);
+  }
+  // The cut above counts UTF-8 codepoints, but parent+name lands in a fixed
+  // byte buffer that aborts() on overflow (htssafe.h). A multibyte name can
+  // pass the codepoint cap yet overflow in bytes, so hard-cut on a codepoint
+  // boundary to keep parent+name inside the buffer regardless (#133).
+  {
+    const size_t parentBytes = strlen(StringBuff(opt->path_html_utf8));
+    const size_t cap = HTS_SAVE_BUFSIZE - HTS_PATH_TAIL_RESERVE;
+    size_t budget = parentBytes < cap ? cap - parentBytes : 0;
+    if (strlen(afs->save) > budget) {
+      while (budget > 0 && ((unsigned char) afs->save[budget] & 0xC0) == 0x80)
+        budget--; // back off a trailing continuation byte, never split a char
+      afs->save[budget] = '\0';
+      cleanEndingSpaceOrDot(afs->save);
+    }
   }
 #undef MAX_UTF8_SEQ_CHARS
 #undef MIN_LAST_SEG_RESERVE

--- a/tests/01_engine-savename.test
+++ b/tests/01_engine-savename.test
@@ -149,10 +149,19 @@ full '/page.php?id=3&sid=42' 'text/html' '/dev/null/www.example.com/page475b.htm
     strip=sid 'prior=www.example.com|/page.php?id=4|/dev/null/www.example.com/PAGE-PRIOR.html'
 
 # Hostile fils stay rooted under the mirror: ../ (raw or %2e-encoded) drops out,
-# control characters become spaces, oversized names cap at 210 chars (the cap
-# can chop the extension off entirely).
+# control characters become spaces.
 full '/../../etc/passwd' 'text/html' '/dev/null/www.example.com///etc/passwd.html'
 full '/%2e%2e/%2e%2e/etc/passwd' 'text/html' '/dev/null/www.example.com///etc/passwd.html'
 full '/x.php' 'application/pdf' '/dev/null/www.example.com///evil.exe' 'cdispo=../../evil.exe'
 name $'/evil\rname\t.php' 'text/html' 'evil name .html'
-name "/$(printf 'a%.0s' {1..300}).php" 'text/html' "$(printf 'a%.0s' {1..210})"
+
+# #133: oversized names are capped only on Windows (MAX_PATH, chopping the
+# extension); elsewhere the platform PATH_MAX leaves a 300-char name whole.
+case "$(uname -s 2>/dev/null)" in
+MINGW* | MSYS* | CYGWIN*)
+    name "/$(printf 'a%.0s' {1..300}).php" 'text/html' "$(printf 'a%.0s' {1..210})"
+    ;;
+*)
+    name "/$(printf 'a%.0s' {1..300}).php" 'text/html' "$(printf 'a%.0s' {1..300}).html"
+    ;;
+esac

--- a/tests/67_engine-delayed-truncate.test
+++ b/tests/67_engine-delayed-truncate.test
@@ -3,30 +3,68 @@
 
 set -euo pipefail
 
-# #623: url_savename enforces the 236-char path ceiling by cutting the tail of
-# the last segment, where the mandatory ".delayed" placeholder marker lives. A
-# cut marker fails IS_DELAYED_EXT, so back_delayed_rename never renames the file
-# to its final name and the download is lost. The marker must survive the cut.
-
-# statuscode=302 status=-1 = a redirect answer still downloading: no type is
-# resolved, so the name gets a ".<id>.delayed" placeholder (see 01_engine-savename).
-CEIL=236
+# #623: url_savename shortens an over-ceiling path by cutting the tail of the
+# last segment, where the mandatory ".<id>.delayed" placeholder lives. A cut
+# marker fails IS_DELAYED_EXT, so back_delayed_rename never renames the file and
+# the download is lost. The marker must survive the cut.
+#
+# The ceiling is the Windows MAX_PATH on Windows but the (far larger) save
+# buffer elsewhere (#133). Each CLI arg is capped at HTS_CDLMAXSIZE (1024), so
+# on POSIX we lengthen the output dir as well to overrun the ceiling.
 
 httrack_bin=$(cd "$(dirname "$(command -v httrack)")" && pwd)/httrack
 scratch=$(mktemp -d)
 trap 'rm -rf "$scratch"' EXIT
 cd "$scratch"
 
+hexseg=$(printf 'a1b2c3d4e5f60718%.0s' {1..8}) # 128 hex chars
+
+# engine ceiling is the Windows MAX_PATH on Windows, the save buffer elsewhere
+case "$(uname -s 2>/dev/null)" in
+MINGW* | MSYS* | CYGWIN*)
+    ceil=236
+    outdir=/dev/null
+    deep="/d1$(printf 'a%.0s' {1..40})/d2$(printf 'b%.0s' {1..40})"
+    deep="$deep/d3$(printf 'c%.0s' {1..40})/d4$(printf 'd%.0s' {1..40})"
+    long="$deep/$(printf 'z%.0s' {1..90})"
+    hexpath="$deep/$hexseg"
+    ;;
+*)
+    # overrun the save-buffer ceiling with a long dir + long name
+    ceil=$((1024 * 2 - 64)) # HTS_URLMAXSIZE*2 - HTS_PATH_TAIL_RESERVE
+    outdir="$scratch/$(printf 'D%.0s' $(seq 1 $((1000 - ${#scratch}))))"
+    long="/d1/$(printf 'z%.0s' $(seq 1 985))"
+    hexpath="/d1/$(printf 'y%.0s' $(seq 1 850))/$hexseg"
+    ;;
+esac
+
 run() {
-    "$httrack_bin" -O /dev/null -#test=savename "$@" | sed -n 's/^savename: //p'
+    "$httrack_bin" -O "$outdir" -#test=savename "$@" | sed -n 's/^savename: //p'
 }
 
-# A deep path ending in a long segment that overruns the ceiling.
-deep="/d1$(printf 'a%.0s' {1..40})/d2$(printf 'b%.0s' {1..40})"
-deep="$deep/d3$(printf 'c%.0s' {1..40})/d4$(printf 'd%.0s' {1..40})"
-long="$deep/$(printf 'z%.0s' {1..90})"
+# untruncated "outdir/host/name" is longer than the ceiling, so truncation must
+# fire; out then sits at or under it. Together these keep the marker check below
+# non-vacuous.
+check_truncated() {
+    local out=$1 fil=$2
+    local untrunc=$((${#outdir} + 1 + 15 + ${#fil})) # host = www.example.com
+    test "$untrunc" -gt "$ceil" ||
+        {
+            echo "FAIL: input too short to truncate ($untrunc <= $ceil)"
+            exit 1
+        }
+    test "${#out}" -le "$ceil" ||
+        {
+            echo "FAIL: truncated name ${#out} > $ceil ceiling: '$out'"
+            exit 1
+        }
+}
 
-out="$(run "$long" text/html statuscode=302 status=-1)"
+# statuscode=302 status=-1 = a redirect still downloading: no type is resolved,
+# so the name gets a ".<id>.delayed" placeholder (see 01_engine-savename).
+long_delayed="$long.ext"
+out="$(run "$long_delayed" text/html statuscode=302 status=-1)"
+check_truncated "$out" "$long_delayed"
 case "$out" in
 *.delayed) ;;
 *)
@@ -34,16 +72,11 @@ case "$out" in
     exit 1
     ;;
 esac
-test "${#out}" -le "$CEIL" || {
-    echo "FAIL: truncated name ${#out} > $CEIL ceiling: '$out'"
-    exit 1
-}
 
 # #133-style hashed name: an all-hex last segment must keep the marker too (the
 # ".<id>." tag is not mistaken for part of the hash).
-hexseg=$(printf 'a1b2c3d4e5f60718%.0s' {1..8})
-hexpath="/d1$(printf 'x%.0s' {1..30})/d2$(printf 'y%.0s' {1..30})/$hexseg"
 out="$(run "$hexpath" text/html statuscode=302 status=-1)"
+check_truncated "$out" "$hexpath"
 case "$out" in
 *.delayed) ;;
 *)
@@ -51,17 +84,10 @@ case "$out" in
     exit 1
     ;;
 esac
-test "${#out}" -le "$CEIL" || {
-    echo "FAIL: hashed name ${#out} > $CEIL ceiling: '$out'"
-    exit 1
-}
 
 # A non-delayed name of the same shape still truncates, with no marker to keep.
-out="$(run "$long.html" text/html)"
-test "${#out}" -le "$CEIL" || {
-    echo "FAIL: non-delayed name ${#out} > $CEIL ceiling: '$out'"
-    exit 1
-}
+out="$(run "$long_delayed.html" text/html)"
+check_truncated "$out" "$long_delayed.html"
 case "$out" in
 *.delayed)
     echo "FAIL: non-delayed name grew a .delayed marker: '$out'"

--- a/tests/75_engine-longpath-posix.test
+++ b/tests/75_engine-longpath-posix.test
@@ -43,6 +43,21 @@ MINGW* | MSYS* | CYGWIN*)
             echo "FAIL: POSIX name not longer than the old ceiling: '$out'"
             exit 1
         }
+
+    # byte-safety: a multibyte name whose codepoint count is under the ceiling
+    # but whose bytes plus a long -O dir overflow the save buffer must be cut to
+    # fit, not abort the crawl (SIGABRT before the byte-cut guard).
+    bigdir="/x/$(printf 'D%.0s' $(seq 1 1015))"      # ~1020 bytes
+    cjk="/$(printf '\xe4\xb8\xad%.0s' $(seq 1 339))" # 1018 bytes, 339 codepoints
+    if ! mb="$("$httrack_bin" -O "$bigdir" -#test=savename "$cjk" text/html 2>/dev/null)"; then
+        echo "FAIL: aborted on a multibyte over-buffer name"
+        exit 1
+    fi
+    mb="${mb#savename: }"
+    if [ -z "$mb" ] || [ "${#mb}" -ge 2048 ]; then
+        echo "FAIL: multibyte name not bounded (len=${#mb})"
+        exit 1
+    fi
     ;;
 esac
 

--- a/tests/75_engine-longpath-posix.test
+++ b/tests/75_engine-longpath-posix.test
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# #133: the save-path ceiling used to be the Windows MAX_PATH (236 usable) on
+# every platform, needlessly hashing long names on Linux/macOS/Android. Off
+# Windows a name well under the platform PATH_MAX must now be kept whole.
+
+httrack_bin=$(cd "$(dirname "$(command -v httrack)")" && pwd)/httrack
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+cd "$scratch"
+
+# ~300 chars: over the old 236 ceiling, well under any POSIX PATH_MAX. The
+# distinctive 90-char last segment lets us tell "kept whole" from "hashed".
+seg="$(printf 'Z%.0s' {1..90})"
+deep="/a/$(printf 'b%.0s' {1..100})/c/$(printf 'd%.0s' {1..100})"
+out="$("$httrack_bin" -O /dev/null -#test=savename "$deep/$seg.html" text/html |
+    sed -n 's/^savename: //p')"
+
+case "$(uname -s 2>/dev/null)" in
+MINGW* | MSYS* | CYGWIN*)
+    # Windows still caps at MAX_PATH: the distinctive tail is cut
+    case "$out" in
+    *"$seg"*)
+        echo "FAIL: Windows should have shortened the long name: '$out'"
+        exit 1
+        ;;
+    esac
+    ;;
+*)
+    # POSIX: the full name survives, no hashing
+    case "$out" in
+    *"$seg"*) ;;
+    *)
+        echo "FAIL: long POSIX name was truncated: '$out'"
+        exit 1
+        ;;
+    esac
+    test "${#out}" -gt 236 ||
+        {
+            echo "FAIL: POSIX name not longer than the old ceiling: '$out'"
+            exit 1
+        }
+    ;;
+esac
+
+echo "longpath-posix OK"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -162,6 +162,7 @@ TESTS = \
 	72_watchdog-crawl.test \
 	73_local-warc.test \
 	74_local-warc-wacz.test \
-	74_local-warc-verbatim.test
+	74_local-warc-verbatim.test \
+	75_engine-longpath-posix.test
 
 CLEANFILES = check-network_sh.cache


### PR DESCRIPTION
Off Windows, `url_savename` capped every saved path at the Windows MAX_PATH (236 usable chars), needlessly hashing long names on Linux/macOS/Android, which support paths an order of magnitude longer. This derives the ceiling from the running platform's own PATH_MAX/NAME_MAX instead. Windows keeps the MAX_PATH ceiling for now; lifting it there needs the engine to prefix its paths with `\\?\`, which is separate work.

Raising the ceiling exposed a latent unit mismatch: the truncation gate counted UTF-8 codepoints, but the buffer that holds the final path aborts on a byte overflow rather than truncating. A multibyte name (a long CJK path, say) can pass the codepoint cap yet run its byte length past the buffer. A byte-boundary cut before the output dir is prepended keeps the save name within the buffer on every platform. (An oversized output directory that alone overflows the buffer is a separate, pre-existing issue in the path-expansion code and is not touched here.)

Tests: `75_engine-longpath-posix` asserts a long name is kept whole off Windows and adds a multibyte over-buffer case (red before the byte-cut); `67_engine-delayed-truncate` and `01_engine-savename` are made platform-aware so their truncation cases still exercise the running platform's ceiling.

Partially addresses #133; the undocumented limit and the debug-only trace it also mentions are left for follow-up.