### PR TITLE
topindex: fix mojibake for non-ASCII project categories on Windows (#216)

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2672,7 +2672,6 @@ static int st_topindex(httrackp *opt, int argc, char **argv) {
   fclose(fp);
   buf[n] = '\0';
   assertf(strstr(buf, projUTF8) != NULL);
-  /* #216: the category from winprofile.ini is utf-8, not mojibake */
   assertf(strstr(buf, catUTF8) != NULL);
 
   /* raw unlink/rmdir: UNLINK is utf-8 on Windows, these paths aren't */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2625,14 +2625,17 @@ static int st_topindex(httrackp *opt, int argc, char **argv) {
   FILE *fp;
   size_t n;
 #ifdef _WIN32
-  /* the GUI hands hts_buildtopindex ANSI paths; mimic it. CP1252 'cafe' */
+  /* GUI writes ANSI paths and winprofile.ini; mimic it (CP1252) */
   static const char *const projName = "caf\xE9";
+  static const char *const catName = "th\xE9";
 #else
   /* POSIX system charset is already utf-8 */
   static const char *const projName = "caf\xC3\xA9";
+  static const char *const catName = "th\xC3\xA9";
 #endif
-  /* utf-8 form the index must carry whatever the input charset was */
+  /* utf-8 forms the index must carry whatever the input charset was */
   static const char *const projUTF8 = "caf\xC3\xA9";
+  static const char *const catUTF8 = "th\xC3\xA9";
 
   assertf(argc >= 1);
   /* a non-ASCII top dir (#217) holding a non-ASCII sub-project (#216) */
@@ -2644,6 +2647,15 @@ static int st_topindex(httrackp *opt, int argc, char **argv) {
   snprintf(path, sizeof(path), "%s/%s/index.html", topdir, projName);
   fp = fopen(path, "wb");
   assertf(fp != NULL);
+  fclose(fp);
+  /* a non-ASCII category exercises the winprofile.ini charset path (#216) */
+  snprintf(path, sizeof(path), "%s/%s/hts-cache/", topdir, projName);
+  assertf(structcheck(path) == 0);
+  snprintf(path, sizeof(path), "%s/%s/hts-cache/winprofile.ini", topdir,
+           projName);
+  fp = fopen(path, "wb");
+  assertf(fp != NULL);
+  fprintf(fp, "category=%s\n", catName);
   fclose(fp);
 
   assertf(hts_buildtopindex(opt, topdir, "") != 0);
@@ -2660,6 +2672,8 @@ static int st_topindex(httrackp *opt, int argc, char **argv) {
   fclose(fp);
   buf[n] = '\0';
   assertf(strstr(buf, projUTF8) != NULL);
+  /* #216: the category from winprofile.ini is utf-8, not mojibake */
+  assertf(strstr(buf, catUTF8) != NULL);
 
   /* raw unlink/rmdir: UNLINK is utf-8 on Windows, these paths aren't */
   unlink(path);
@@ -2667,6 +2681,11 @@ static int st_topindex(httrackp *opt, int argc, char **argv) {
   unlink(path);
   snprintf(path, sizeof(path), "%s/fade.gif", topdir);
   unlink(path);
+  snprintf(path, sizeof(path), "%s/%s/hts-cache/winprofile.ini", topdir,
+           projName);
+  unlink(path);
+  snprintf(path, sizeof(path), "%s/%s/hts-cache", topdir, projName);
+  rmdir(path);
   snprintf(path, sizeof(path), "%s/%s/index.html", topdir, projName);
   unlink(path);
   snprintf(path, sizeof(path), "%s/%s", topdir, projName);

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -1027,6 +1027,17 @@ HTSEXT_API int hts_buildtopindex(httrackp * opt, const char *path,
                     freet(category);
                     category = NULL;
                   }
+#ifdef _WIN32
+                  /* category is ANSI-codepage, doc is utf-8: convert (#216) */
+                  else {
+                    char *cat_utf8 = hts_convertStringSystemToUTF8(
+                        category, strlen(category));
+                    if (cat_utf8 != NULL) {
+                      freet(category);
+                      category = cat_utf8;
+                    }
+                  }
+#endif
                 }
               }
               if (category == NULL) {


### PR DESCRIPTION
Follow-up to #681, which fixed the non-ASCII project name in `hts_buildtopindex()` but left the sibling leak in the same function: the project category read from `hts-cache/winprofile.ini` comes back in the Windows ANSI codepage and is written straight into the `charset=utf-8` topindex template, so a non-ASCII category renders as mojibake in the category header. Convert it to UTF-8 the same way #681 handled the name.

The `topindex` self-test now also writes a `winprofile.ini` with a non-ASCII category (distinct from the project name) and asserts the generated `index.html` carries its UTF-8 form, so it reproduces the category leak on Windows CI.

This finishes the mojibake cleanup #216 reported.