### PR TITLE
Windows: mirror files under non-ASCII or long directories silently break

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -699,7 +699,7 @@ int httpmirror(char *url1, httrackp * opt) {
     int primary_len = 8192;
 
     if (StringNotEmpty(opt->filelist)) {
-      primary_len += max(0, fsize(StringBuff(opt->filelist)) * 2);
+      primary_len += max(0, fsize_utf8(StringBuff(opt->filelist)) * 2);
     }
     primary_len += (int) strlen(url1) * 2;
 
@@ -856,19 +856,19 @@ int httpmirror(char *url1, httrackp * opt) {
       char *filelist_buff = NULL;
       size_t filelist_sz = 0;
       const char *filelist_err = NULL; /* failure reason, NULL on success */
-      const LLint fs = fsize(StringBuff(opt->filelist));
+      const LLint fs = fsize_utf8(StringBuff(opt->filelist));
 
       if (fs < 0) {
         /* fsize() hides the cause; redo stat() for a precise errno (#49) */
-        struct stat st;
-        filelist_err = stat(StringBuff(opt->filelist), &st) != 0
+        STRUCT_STAT st;
+        filelist_err = STAT(StringBuff(opt->filelist), &st) != 0
                            ? strerror(errno)
                            : "not a regular file";
       } else if ((filelist_sz = llint_to_size_t(fs)) == (size_t) -1) {
         filelist_err = "file too large";
         filelist_sz = 0;
       } else {
-        FILE *fp = fopen(StringBuff(opt->filelist), "rb");
+        FILE *fp = FOPEN(StringBuff(opt->filelist), "rb");
 
         if (fp == NULL) {
           filelist_err = strerror(errno);
@@ -976,10 +976,9 @@ int httpmirror(char *url1, httrackp * opt) {
   }
   // statistiques
   if (opt->makestat) {
-    makestat_fp =
-      fopen(fconcat
-            (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log), "hts-stats.txt"),
-            "wb");
+    makestat_fp = FOPEN(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                StringBuff(opt->path_log), "hts-stats.txt"),
+                        "wb");
     if (makestat_fp != NULL) {
       fprintf(makestat_fp, "HTTrack statistics report, every minutes" LF LF);
       fflush(makestat_fp);
@@ -987,10 +986,9 @@ int httpmirror(char *url1, httrackp * opt) {
   }
   // tracking -- débuggage
   if (opt->maketrack) {
-    maketrack_fp =
-      fopen(fconcat
-            (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log), "hts-track.txt"),
-            "wb");
+    maketrack_fp = FOPEN(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                 StringBuff(opt->path_log), "hts-track.txt"),
+                         "wb");
     if (maketrack_fp != NULL) {
       fprintf(maketrack_fp, "HTTrack tracking report, every minutes" LF LF);
       fflush(maketrack_fp);
@@ -1639,7 +1637,8 @@ int httpmirror(char *url1, httrackp * opt) {
 
           /* Remove file if being processed */
           if (is_loaded_from_file) {
-            (void) unlink(fconv(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), savename()));
+            (void) UNLINK(
+                fconv(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), savename()));
             is_loaded_from_file = 0;
           }
 
@@ -1952,8 +1951,8 @@ int httpmirror(char *url1, httrackp * opt) {
            } else */
 
         /* External modules */
-        if (opt->parsejava && (opt->parsejava & HTSPARSE_NO_CLASS) == 0
-            && fexist(savename())) {
+        if (opt->parsejava && (opt->parsejava & HTSPARSE_NO_CLASS) == 0 &&
+            fexist_utf8(savename())) {
           char BIGSTK buff_err_msg[1024];
           htsmoduleStruct BIGSTK str;
 
@@ -1994,7 +1993,7 @@ int httpmirror(char *url1, httrackp * opt) {
       }                         // text/html ou autre
 
       /* Post-processing */
-      if (fexist(savename())) {
+      if (fexist_utf8(savename())) {
         usercommand(opt, 0, NULL, savename(), urladr(), urlfil());
       }
 
@@ -2085,18 +2084,16 @@ int httpmirror(char *url1, httrackp * opt) {
       //
       opt->state._hts_in_html_parsing = 3;
       //
-      old_lst =
-        fopen(fconcat
-              (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-               "hts-cache/old.lst"), "rb");
+      old_lst = FOPEN(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                              StringBuff(opt->path_log), "hts-cache/old.lst"),
+                      "rb");
       if (old_lst) {
-        const size_t sz = llint_to_size_t(
-            fsize(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-                          StringBuff(opt->path_log), "hts-cache/new.lst")));
-        new_lst =
-          fopen(fconcat
-                (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                 "hts-cache/new.lst"), "rb");
+        const size_t sz = llint_to_size_t(fsize_utf8(
+            fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                    StringBuff(opt->path_log), "hts-cache/new.lst")));
+        new_lst = FOPEN(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                StringBuff(opt->path_log), "hts-cache/new.lst"),
+                        "rb");
         if (new_lst != NULL && sz != (size_t) -1) {
           /* +1 for the NUL below: new.lst is read raw, and the strstr()
              that follows needs a terminated C string. */
@@ -2116,9 +2113,9 @@ int httpmirror(char *url1, httrackp * opt) {
                   strcpybuff(file, StringBuff(opt->path_html));
                   strcatbuff(file, line + 1);
                   file[strlen(file) - 1] = '\0';
-                  if (fexist(file)) {   // toujours sur disque: virer
+                  if (fexist_utf8(file)) { // toujours sur disque: virer
                     hts_log_print(opt, LOG_INFO, "Purging %s", file);
-                    remove(file);
+                    UNLINK(file);
                     purge = 1;
                   }
                 }
@@ -2139,7 +2136,8 @@ int httpmirror(char *url1, httrackp * opt) {
 
                       strcpybuff(file, StringBuff(opt->path_html));
                       strcatbuff(file, line + 1);
-                      while((strnotempty(file)) && (rmdir(file) == 0)) {        // ok, éliminé (existait)
+                      while ((strnotempty(file)) &&
+                             (RMDIR(file) == 0)) { // ok, éliminé (existait)
                         purge = 1;
                         if (opt->log) {
                           hts_log_print(opt, LOG_INFO, "Purging directory %s/",
@@ -2962,8 +2960,8 @@ static void postprocess_file(httrackp *opt, const char *save, const char *adr,
     if (adr != NULL && strcmp(adr, "primary") == 0) {
       adr = NULL;
     }
-    if (save != NULL && opt != NULL && adr != NULL && adr[0]
-        && strnotempty(save) && fexist(save)) {
+    if (save != NULL && opt != NULL && adr != NULL && adr[0] &&
+        strnotempty(save) && fexist_utf8(save)) {
       const char *rsc_save = save;
       const char *rsc_fil = strrchr(fil, '/');
       int n;
@@ -2985,13 +2983,11 @@ static void postprocess_file(httrackp *opt, const char *save, const char *adr,
 
       if (!opt->state.mimehtml_created) {
         opt->state.mimefp =
-          fopen(fconcat
-                (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-                StringBuff(opt->path_html), "index.mht"),
-                "wb");
-        (void) unlink(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-          StringBuff(opt->path_html),
-                              "index.eml"));
+            FOPEN(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                          StringBuff(opt->path_html), "index.mht"),
+                  "wb");
+        (void) UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                              StringBuff(opt->path_html), "index.eml"));
 #ifndef _WIN32
         if (symlink("index.mht",
                     fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_html),

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -442,11 +442,10 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
           || (strnotempty(StringBuff(opt->path_html))))
         loops++;                // do not loop once again and do not include rc file (O option exists)
       else {
-        if ((!fexist
-             (fconcat
-              (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-              StringBuff(opt->path_log),
-               "hts-cache/doit.log"))) || (argv_url > 0)) {
+        if ((!fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                  StringBuff(opt->path_log),
+                                  "hts-cache/doit.log"))) ||
+            (argv_url > 0)) {
           if (!optinclude_file(
                   fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
                           StringBuff(opt->path_log), HTS_HTTRACKRC),
@@ -473,16 +472,12 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
   }                             // traiter -O
 
   /* load doit.log and insert in current command line */
-  if (fexist
-      (fconcat
-       (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-       StringBuff(opt->path_log), "hts-cache/doit.log"))
-      && (argv_url <= 0)) {
-    FILE *fp =
-      fopen(fconcat
-            (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-            StringBuff(opt->path_log),
-             "hts-cache/doit.log"), "rb");
+  if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                          StringBuff(opt->path_log), "hts-cache/doit.log")) &&
+      (argv_url <= 0)) {
+    FILE *fp = FOPEN(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_log), "hts-cache/doit.log"),
+                     "rb");
     if (fp) {
       int insert_after = 1;     /* insérer après nom au début */
 
@@ -531,23 +526,16 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
 
   /* Interrupted mirror detected */
   if (!opt->quiet) {
-    if (fexist
-        (fconcat
-         (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-         StringBuff(opt->path_log),
-          "hts-in_progress.lock"))) {
+    if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                            StringBuff(opt->path_log),
+                            "hts-in_progress.lock"))) {
       /* Old cache */
-      if ((fexist
-           (fconcat
-            (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-            StringBuff(opt->path_log),
-             "hts-cache/old.dat")))
-          &&
-          (fexist
-           (fconcat
-            (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-            StringBuff(opt->path_log),
-             "hts-cache/old.ndx")))) {
+      if ((fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                               StringBuff(opt->path_log),
+                               "hts-cache/old.dat"))) &&
+          (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                               StringBuff(opt->path_log),
+                               "hts-cache/old.ndx")))) {
         if (opt->log != NULL) {
           fprintf(opt->log, "Warning!\n");
           fprintf(opt->log,
@@ -576,111 +564,82 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
         if (argv[i][1] == '-') {        // --xxx
           if ((strfield2(argv[i] + 2, "clean")) || (strfield2(argv[i] + 2, "tide"))) {  // nettoyer
             argv[i][1] = '\0';
-            if (fexist
-                (fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log), "hts-log.txt")))
-              remove(fconcat
-                     (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                      "hts-log.txt"));
-            if (fexist
-                (fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log), "hts-err.txt")))
-              remove(fconcat
-                     (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                      "hts-err.txt"));
-            if (fexist
-                (fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_html), "index.html")))
-              remove(fconcat
-                     (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_html),
-                      "index.html"));
+            if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                    StringBuff(opt->path_log), "hts-log.txt")))
+              UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_log), "hts-log.txt"));
+            if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                    StringBuff(opt->path_log), "hts-err.txt")))
+              UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_log), "hts-err.txt"));
+            if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                    StringBuff(opt->path_html), "index.html")))
+              UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_html), "index.html"));
             /* */
-            if (fexist
-                (fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/new.zip")))
-              remove(fconcat
-                     (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                      "hts-cache/new.zip"));
-            if (fexist
-                (fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/old.zip")))
-              remove(fconcat
-                     (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                      "hts-cache/old.zip"));
-            if (fexist
-                (fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/new.dat")))
-              remove(fconcat
-                     (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                      "hts-cache/new.dat"));
-            if (fexist
-                (fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/new.ndx")))
-              remove(fconcat
-                     (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                      "hts-cache/new.ndx"));
-            if (fexist
-                (fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/old.dat")))
-              remove(fconcat
-                     (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                      "hts-cache/old.dat"));
-            if (fexist
-                (fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/old.ndx")))
-              remove(fconcat
-                     (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                      "hts-cache/old.ndx"));
-            if (fexist
-                (fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/new.lst")))
-              remove(fconcat
-                     (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                      "hts-cache/new.lst"));
-            if (fexist
-                (fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/old.lst")))
-              remove(fconcat
-                     (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                      "hts-cache/old.lst"));
-            if (fexist
-                (fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/new.txt")))
-              remove(fconcat
-                     (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                      "hts-cache/new.txt"));
-            if (fexist
-                (fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/old.txt")))
-              remove(fconcat
-                     (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                      "hts-cache/old.txt"));
-            if (fexist
-                (fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-cache/doit.log")))
-              remove(fconcat
-                     (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                      "hts-cache/doit.log"));
-            if (fexist
-                (fconcat
-                 (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                  "hts-in_progress.lock")))
-              remove(fconcat
-                     (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                      "hts-in_progress.lock"));
-            rmdir(fconcat
-                  (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log), "hts-cache"));
+            if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                    StringBuff(opt->path_log),
+                                    "hts-cache/new.zip")))
+              UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_log), "hts-cache/new.zip"));
+            if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                    StringBuff(opt->path_log),
+                                    "hts-cache/old.zip")))
+              UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_log), "hts-cache/old.zip"));
+            if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                    StringBuff(opt->path_log),
+                                    "hts-cache/new.dat")))
+              UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_log), "hts-cache/new.dat"));
+            if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                    StringBuff(opt->path_log),
+                                    "hts-cache/new.ndx")))
+              UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_log), "hts-cache/new.ndx"));
+            if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                    StringBuff(opt->path_log),
+                                    "hts-cache/old.dat")))
+              UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_log), "hts-cache/old.dat"));
+            if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                    StringBuff(opt->path_log),
+                                    "hts-cache/old.ndx")))
+              UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_log), "hts-cache/old.ndx"));
+            if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                    StringBuff(opt->path_log),
+                                    "hts-cache/new.lst")))
+              UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_log), "hts-cache/new.lst"));
+            if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                    StringBuff(opt->path_log),
+                                    "hts-cache/old.lst")))
+              UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_log), "hts-cache/old.lst"));
+            if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                    StringBuff(opt->path_log),
+                                    "hts-cache/new.txt")))
+              UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_log), "hts-cache/new.txt"));
+            if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                    StringBuff(opt->path_log),
+                                    "hts-cache/old.txt")))
+              UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_log), "hts-cache/old.txt"));
+            if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                    StringBuff(opt->path_log),
+                                    "hts-cache/doit.log")))
+              UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_log), "hts-cache/doit.log"));
+            if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                    StringBuff(opt->path_log),
+                                    "hts-in_progress.lock")))
+              UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_log),
+                             "hts-in_progress.lock"));
+            RMDIR(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                          StringBuff(opt->path_log), "hts-cache"));
             //
           } else if (strfield2(argv[i] + 2, "catchurl")) {      // capture d'URL via proxy temporaire!
             argv_url = 1;       // forcer a passer les parametres
@@ -737,29 +696,27 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
 #endif
   if (argv_url == 0) {
     // Présence d'un cache, que faire?..
-    if ((fexist
-         (fconcat
-          (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), 
-          StringBuff(opt->path_log), "hts-cache/new.zip")))
-        ||
-        (fexist
-         (fconcat
-          (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), 
-          StringBuff(opt->path_log), "hts-cache/new.dat"))
-         &&
-         fexist(fconcat
-                (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-                StringBuff(opt->path_log),
-                 "hts-cache/new.ndx")))
-      ) {                       // il existe déja un cache précédent.. renommer
-      if (fexist(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-        StringBuff(opt->path_log), "hts-cache/doit.log"))) {        // un cache est présent
+    if ((fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_log),
+                             "hts-cache/new.zip"))) ||
+        (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_log), "hts-cache/new.dat")) &&
+         fexist_utf8(
+             fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                     StringBuff(opt->path_log),
+                     "hts-cache/new.ndx")))) { // il existe déja un cache
+                                               // précédent.. renommer
+      if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                              StringBuff(opt->path_log),
+                              "hts-cache/doit.log"))) { // un cache est présent
         if (x_argvblk != NULL) {
           int m;
 
           // établir mode - mode cache: 1 (cache valide) 2 (cache à vérifier)
-          if (fexist(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-            StringBuff(opt->path_log), "hts-in_progress.lock"))) {  // cache prioritaire
+          if (fexist_utf8(
+                  fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                          StringBuff(opt->path_log),
+                          "hts-in_progress.lock"))) { // cache prioritaire
             m = 1;
           } else {
             m = 2;
@@ -794,7 +751,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
           htsmain_free();
           return -1;
         }
-      } else {                  // log existe pas
+      } else { // log existe pas
         HTS_PANIC_PRINTF("A cache has been found, but no command line");
         printf
           ("Please launch httrack with proper parameters to reuse the cache\n");
@@ -802,7 +759,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
         return -1;
       }
 
-    } else {                    // aucune URL définie et pas de cache
+    } else { // aucune URL définie et pas de cache
       if (opt->quiet) {
         help(argv[0], !opt->quiet);
         htsmain_free();
@@ -817,26 +774,21 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
     }
   } else {                      // plus de 2 paramètres
     // un fichier log existe?
-    if (fexist(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-                       StringBuff(opt->path_log),
-                       "hts-in_progress.lock"))) { // fichier lock?
+    if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                            StringBuff(opt->path_log),
+                            "hts-in_progress.lock"))) { // fichier lock?
 
       opt->cache = HTS_CACHE_PRIORITY; // cache prioritaire
       if (opt->quiet == 0) {
-        if ((fexist
-             (fconcat
-              (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-               "hts-cache/new.zip")))
-            ||
-            (fexist
-             (fconcat
-              (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-               "hts-cache/new.dat"))
-             &&
-             fexist(fconcat
-                    (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                     "hts-cache/new.ndx")))
-          ) {
+        if ((fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                 StringBuff(opt->path_log),
+                                 "hts-cache/new.zip"))) ||
+            (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                 StringBuff(opt->path_log),
+                                 "hts-cache/new.dat")) &&
+             fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                 StringBuff(opt->path_log),
+                                 "hts-cache/new.ndx")))) {
           HT_REQUEST_START;
           HT_PRINT("There is a lock-file in the directory ");
           HT_PRINT(StringBuff(opt->path_log));
@@ -850,24 +802,19 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
           }
         }
       }
-    } else if (fexist(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-                              StringBuff(opt->path_html), "index.html"))) {
+    } else if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                   StringBuff(opt->path_html), "index.html"))) {
       opt->cache = HTS_CACHE_TEST_UPDATE;
       if (opt->quiet == 0) {
-        if ((fexist
-             (fconcat
-              (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-               "hts-cache/new.zip")))
-            ||
-            (fexist
-             (fconcat
-              (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-               "hts-cache/new.dat"))
-             &&
-             fexist(fconcat
-                    (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                     "hts-cache/new.ndx")))
-          ) {
+        if ((fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                 StringBuff(opt->path_log),
+                                 "hts-cache/new.zip"))) ||
+            (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                 StringBuff(opt->path_log),
+                                 "hts-cache/new.dat")) &&
+             fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                 StringBuff(opt->path_log),
+                                 "hts-cache/new.ndx")))) {
           HT_REQUEST_START;
           HT_PRINT
             ("There is an index.html and a hts-cache folder in the directory ");
@@ -1500,13 +1447,13 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                   LLint fz;
 
                   na++;
-                  fz = fsize(argv[na]);
+                  fz = fsize_utf8(argv[na]);
                   if (fz < 0) {
                     HTS_PANIC_PRINTF("File url list could not be opened");
                     htsmain_free();
                     return -1;
                   } else {
-                    FILE *fp = fopen(argv[na], "rb");
+                    FILE *fp = FOPEN(argv[na], "rb");
 
                     if (fp != NULL) {
                       int cl = (int) strlen(url);
@@ -2050,7 +1997,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                                      /*cache */ &cache, /*hash */ NULL, /*ptr */
                                      0, /*numero_passe */ 0, /*mime_type */
                                      NULL) != -1) {
-                                  if (fexist(afs.save)) {
+                                  if (fexist_utf8(afs.save)) {
                                     fprintf(stdout, "Content-location: %s\r\n",
                                             afs.save);
                                   }
@@ -2148,18 +2095,16 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                   uLong repaired = 0;
                   uLong repairedBytes = 0;
 
-                  if (fexist
-                      (fconcat
-                       (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                        "hts-cache/new.zip"))) {
+                  if (fexist_utf8(fconcat(
+                          OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                          StringBuff(opt->path_log), "hts-cache/new.zip"))) {
                     name =
                       fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
                               "hts-cache/new.zip");
-                  } else
-                    if (fexist
-                        (fconcat
-                         (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                          "hts-cache/old.zip"))) {
+                  } else if (fexist_utf8(fconcat(OPT_GET_BUFF(opt),
+                                                 OPT_GET_BUFF_SIZE(opt),
+                                                 StringBuff(opt->path_log),
+                                                 "hts-cache/old.zip"))) {
                     name =
                       fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
                               "hts-cache/old.zip");
@@ -2178,10 +2123,11 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                        fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
                                "hts-cache/repair.tmp"), &repaired,
                        &repairedBytes) == Z_OK) {
-                    unlink(name);
-                    rename(fconcat
-                           (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                            "hts-cache/repair.zip"), name);
+                    UNLINK(name);
+                    RENAME(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                   StringBuff(opt->path_log),
+                                   "hts-cache/repair.zip"),
+                           name);
                     fprintf(stderr,
                             "Cache: %d bytes successfully recovered in %d entries\n",
                             (int) repairedBytes, (int) repaired);
@@ -2399,10 +2345,9 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
   // Débuggage des en têtes
   if (_DEBUG_HEAD) {
-    ioinfo =
-      fopen(fconcat
-            (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log), "hts-ioinfo.txt"),
-            "wb");
+    ioinfo = FOPEN(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                           StringBuff(opt->path_log), "hts-ioinfo.txt"),
+                   "wb");
   }
 
   {
@@ -2477,9 +2422,9 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
       /* readme for information purpose */
       {
         FILE *fp =
-          fopen(fconcat
-                (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                 "hts-cache/readme.txt"), "wb");
+            FOPEN(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                          StringBuff(opt->path_log), "hts-cache/readme.txt"),
+                  "wb");
         if (fp) {
           fprintf(fp, "What's in this folder?" LF);
           fprintf(fp, "" LF);
@@ -2531,17 +2476,16 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
         int i;
 
 #ifdef _WIN32
-        mkdir(fconcat
-              (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log), "hts-cache"));
+        hts_mkdir_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                               StringBuff(opt->path_log), "hts-cache"));
 #else
         mkdir(fconcat
               (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log), "hts-cache"),
               HTS_PROTECT_FOLDER);
 #endif
-        fp =
-          fopen(fconcat
-                (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log),
-                 "hts-cache/doit.log"), "wb");
+        fp = FOPEN(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                           StringBuff(opt->path_log), "hts-cache/doit.log"),
+                   "wb");
         if (fp) {
           for(i = 0 + 1; i < argc; i++) {
             if (((strchr(argv[i], ' ') != NULL)
@@ -2586,7 +2530,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
         }
       }
       // petit message dans le lock
-      if ((fp = fopen(n_lock, "wb")) != NULL) {
+      if ((fp = FOPEN(n_lock, "wb")) != NULL) {
         int i;
 
         fprintf(fp, "Mirror in progress since %s .. please wait!" LF, t);
@@ -2746,16 +2690,15 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
           char *f = OPT_GET_BUFF(opt);
 
           sprintf(f, "%s/%s", CACHE_REFNAME, entry->d_name);
-          (void)
-            unlink(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log), f));
+          (void) UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                StringBuff(opt->path_log), f));
         }
       }
       if (dir != NULL) {
         (void) closedir(dir);
       }
-      (void)
-        rmdir(fconcat
-              (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), StringBuff(opt->path_log), CACHE_REFNAME));
+      (void) RMDIR(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                           StringBuff(opt->path_log), CACHE_REFNAME));
     }
 
     /* Info for wrappers */
@@ -2783,7 +2726,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
       }
     }
     // supprimer lock
-    remove(n_lock);
+    UNLINK(n_lock);
   }
 
   if (x_argvblk)

--- a/src/htshelp.c
+++ b/src/htshelp.c
@@ -412,9 +412,9 @@ void help_catchurl(const char *dest_path) {
       do {
         snprintf(dest, sizeof(dest), "%s%s%d", dest_path, "hts-post", i);
         i++;
-      } while(fexist(dest));
+      } while (fexist_utf8(dest));
       {
-        FILE *fp = fopen(dest, "wb");
+        FILE *fp = FOPEN(dest, "wb");
 
         if (fp) {
           fwrite(data, strlen(data), 1, fp);

--- a/src/htsindex.c
+++ b/src/htsindex.c
@@ -349,9 +349,13 @@ void index_finish(const char *indexpath, int mode) {
 
             // Write new file
             if (mode == 1)      // TEXT
-              fp = fopen(concat(catbuff, sizeof(catbuff), indexpath, "index.txt"), "wb");
+              fp = FOPEN(
+                  concat(catbuff, sizeof(catbuff), indexpath, "index.txt"),
+                  "wb");
             else                // HTML
-              fp = fopen(concat(catbuff, sizeof(catbuff), indexpath, "sindex.html"), "wb");
+              fp = FOPEN(
+                  concat(catbuff, sizeof(catbuff), indexpath, "sindex.html"),
+                  "wb");
             if (fp) {
               char current_word[KEYW_LEN + 32];
               char word[KEYW_LEN + 32];

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -6626,6 +6626,20 @@ int hts_rename_utf8(const char *oldpath, const char *newpath) {
   }
 }
 
+int hts_rmdir_utf8(const char *path) {
+  LPWSTR wpath = hts_pathToUCS2(path);
+
+  if (wpath != NULL) {
+    const int result = _wrmdir(wpath);
+
+    free(wpath);
+    return result;
+  } else {
+    // Fallback on conversion error.
+    return _rmdir(path);
+  }
+}
+
 int hts_mkdir_utf8(const char *path) {
   LPWSTR wpath = hts_pathToUCS2(path);
 

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -3656,7 +3656,7 @@ int hts_mirror_check_moved(htsmoduleStruct * str,
           !ref_existed;
       if (fexist_utf8(heap(ptr)->sav)) {
         had_partial = 1;
-        remove(heap(ptr)->sav);
+        UNLINK(heap(ptr)->sav);
       }
 
       // Re-get once, only if a partial existed and both Range triggers are
@@ -3862,18 +3862,13 @@ void hts_mirror_process_user_interaction(htsmoduleStruct * str,
     int do_pause = 0;
 
     // user pause lockfile : create hts-paused.lock --> HTTrack will be paused
-    if (fexist
-        (fconcat
-         (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-         StringBuff(opt->path_log), "hts-stop.lock"))) {
+    if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                            StringBuff(opt->path_log), "hts-stop.lock"))) {
       // remove lockfile
-      remove(fconcat
-             (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-             StringBuff(opt->path_log), "hts-stop.lock"));
-      if (!fexist
-          (fconcat
-           (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-           StringBuff(opt->path_log), "hts-stop.lock"))) {
+      UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                     StringBuff(opt->path_log), "hts-stop.lock"));
+      if (!fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                               StringBuff(opt->path_log), "hts-stop.lock"))) {
         do_pause = 1;
       }
     }
@@ -3902,11 +3897,9 @@ void hts_mirror_process_user_interaction(htsmoduleStruct * str,
         }
       }
       {
-        FILE *fp =
-          fopen(fconcat
-                (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-                StringBuff(opt->path_log),
-                 "hts-paused.lock"), "wb");
+        FILE *fp = FOPEN(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                 StringBuff(opt->path_log), "hts-paused.lock"),
+                         "wb");
         if (fp) {
           fspc(NULL, fp, "info");       // dater
           fprintf(fp,
@@ -4222,18 +4215,17 @@ int hts_mirror_wait_for_next_file(htsmoduleStruct * str,
             int a = 0;
 
             *stre->last_info_shell_ = tl;
-            if (fexist(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),  StringBuff(opt->path_log), "hts-autopsy"))) { // débuggage: teste si le robot est vivant
+            if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                    StringBuff(opt->path_log),
+                                    "hts-autopsy"))) { // débuggage: teste si le
+                                                       // robot est vivant
               // (oui je sais un robot vivant.. mais bon.. il a le droit de vivre lui aussi)
               // (libérons les robots esclaves de l'internet!)
-              remove(fconcat
-                     (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-                     StringBuff(opt->path_log),
-                      "hts-autopsy"));
-              fp =
-                fopen(fconcat
-                      (OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-                      StringBuff(opt->path_log),
-                       "hts-isalive"), "wb");
+              UNLINK(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                             StringBuff(opt->path_log), "hts-autopsy"));
+              fp = FOPEN(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                                 StringBuff(opt->path_log), "hts-isalive"),
+                         "wb");
               a = 1;
             }
             if ((*stre->info_shell_) || a) {

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4384,6 +4384,86 @@ static int st_longpath(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+// -#test=mirrorio <dir>: round-trip a file through a long AND non-ASCII path
+// via the mirror I/O wrappers — fexist_utf8/fsize_utf8, FOPEN/UNLINK, and the
+// new hts_rmdir_utf8 (RMDIR) teardown (#133, #630).
+static int st_mirrorio(httrackp *opt, int argc, char **argv) {
+  (void) opt;
+  if (argc < 1) {
+    fprintf(stderr, "mirrorio: needs a writable base dir\n");
+    return 1;
+  }
+  char path[HTS_URLMAXSIZE * 2];
+  size_t n = (size_t) snprintf(path, sizeof(path), "%s", argv[0]);
+
+  while (n > 0 && (path[n - 1] == '/' || path[n - 1] == '\\')) {
+    path[--n] = '\0';
+  }
+  const size_t base = n; /* the caller's base dir; teardown stops here */
+  // First segment carries non-ASCII UTF-8 (é 中) to drive the charset axis
+  // (#630); ASCII 40-char segments then push the total past MAX_PATH (#133).
+  static const char nseg[] = "/\xC3\xA9\xE4\xB8\xAD-non-ascii-seg";
+  static const char seg[] = "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+  memcpybuff(path + n, nseg, sizeof(nseg));
+  n += sizeof(nseg) - 1;
+  if (MKDIR(path) != 0 && errno != EEXIST) {
+    fprintf(stderr, "mirrorio: mkdir failed (non-ascii): %s\n",
+            strerror(errno));
+    return 1;
+  }
+  while (n + sizeof(seg) - 1 < 300) {
+    memcpybuff(path + n, seg, sizeof(seg));
+    n += sizeof(seg) - 1;
+    if (MKDIR(path) != 0 && errno != EEXIST) {
+      fprintf(stderr, "mirrorio: mkdir failed at %u chars: %s\n", (unsigned) n,
+              strerror(errno));
+      return 1;
+    }
+  }
+  const size_t leafdir = n;
+
+  memcpybuff(path + n, "/leaf.bin", sizeof("/leaf.bin"));
+  n += sizeof("/leaf.bin") - 1;
+  assertf(n > 260); /* must exceed the limit \\?\ lifts */
+
+  static const char payload[] = "mirrorio-ok";
+
+  assertf(!fexist_utf8(path)); /* absent before creation, through the guard */
+  FILE *fp = FOPEN(path, "wb");
+
+  if (fp == NULL) {
+    fprintf(stderr, "mirrorio: create failed (%u chars): %s\n", (unsigned) n,
+            strerror(errno));
+    return 1;
+  }
+  assertf(fwrite(payload, 1, sizeof(payload), fp) == sizeof(payload));
+  fclose(fp);
+  assertf(fexist_utf8(path));
+  assertf(fsize_utf8(path) == (LLint) sizeof(payload));
+  assertf(UNLINK(path) == 0);
+  assertf(!fexist_utf8(path));
+
+  // Tear the directory chain down through the UTF-8/long-path rmdir wrapper.
+  path[leafdir] = '\0';
+  while (strlen(path) > base) {
+    char *const slash = strrchr(path, '/');
+
+    if (RMDIR(path) != 0) {
+      fprintf(stderr, "mirrorio: rmdir failed: %s\n", strerror(errno));
+      return 1;
+    }
+    if (slash == NULL || (size_t) (slash - path) < base) {
+      break;
+    }
+    *slash = '\0';
+  }
+
+  printf("mirrorio: round-tripped a %u-char non-ASCII path: OK\n",
+         (unsigned) n);
+  return 0;
+}
+
 /* ------------------------------------------------------------ */
 /* Registry: name -> handler, with a usage hint and a one-line description. */
 /* ------------------------------------------------------------ */
@@ -4519,6 +4599,9 @@ static const struct selftest_entry {
      "round-trip a >MAX_PATH file through the _w* wrappers (\\\\?\\ on "
      "Windows)",
      st_longpath},
+    {"mirrorio", "<dir>",
+     "round-trip a long+non-ASCII path through the mirror I/O wrappers",
+     st_mirrorio},
     {"warc-cdx", "<dir>", "--warc-cdx CDXJ index: sorted, offsets inflate",
      st_warc_cdx},
 #if HTS_USEOPENSSL

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4385,8 +4385,8 @@ static int st_longpath(httrackp *opt, int argc, char **argv) {
 }
 
 // -#test=mirrorio <dir>: round-trip a file through a long AND non-ASCII path
-// via the mirror I/O wrappers — fexist_utf8/fsize_utf8, FOPEN/UNLINK, and the
-// new hts_rmdir_utf8 (RMDIR) teardown (#133, #630).
+// via the mirror I/O wrappers — fexist_utf8/fsize_utf8, FOPEN/RENAME/UNLINK,
+// and the new hts_rmdir_utf8 (RMDIR) teardown (#133, #630).
 static int st_mirrorio(httrackp *opt, int argc, char **argv) {
   (void) opt;
   if (argc < 1) {
@@ -4441,8 +4441,19 @@ static int st_mirrorio(httrackp *opt, int argc, char **argv) {
   fclose(fp);
   assertf(fexist_utf8(path));
   assertf(fsize_utf8(path) == (LLint) sizeof(payload));
-  assertf(UNLINK(path) == 0);
+
+  // Rename to a non-ASCII sibling to exercise RENAME on the long path.
+  char path2[HTS_URLMAXSIZE * 2];
+
+  memcpybuff(path2, path, leafdir);
+  memcpybuff(path2 + leafdir, "/\xC3\xA9-leaf.bin",
+             sizeof("/\xC3\xA9-leaf.bin"));
+  assertf(RENAME(path, path2) == 0);
   assertf(!fexist_utf8(path));
+  assertf(fexist_utf8(path2));
+  assertf(fsize_utf8(path2) == (LLint) sizeof(payload));
+  assertf(UNLINK(path2) == 0);
+  assertf(!fexist_utf8(path2));
 
   // Tear the directory chain down through the UTF-8/long-path rmdir wrapper.
   path[leafdir] = '\0';

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -758,6 +758,9 @@ HTSEXT_API int hts_rename_utf8(const char *oldpath, const char *newpath);
 
 HTSEXT_API int hts_mkdir_utf8(const char *pathname);
 
+#define RMDIR hts_rmdir_utf8
+HTSEXT_API int hts_rmdir_utf8(const char *pathname);
+
 #define UTIME(A, B) hts_utime_utf8(A, B)
 
 typedef struct _utimbuf STRUCT_UTIMBUF;
@@ -772,6 +775,7 @@ typedef struct stat STRUCT_STAT;
 #define UNLINK unlink
 #define RENAME rename
 #define MKDIR(F) mkdir(F, HTS_ACCESS_FOLDER)
+#define RMDIR rmdir
 
 typedef struct utimbuf STRUCT_UTIMBUF;
 

--- a/tests/01_engine-mirror-io.test
+++ b/tests/01_engine-mirror-io.test
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# Drives -#test=mirrorio: rounds a file through a path that is both long
+# (>MAX_PATH) and non-ASCII, exercising the mirror I/O wrappers the engine's
+# raw file ops now route to on Windows (#133, #630). Positive control on POSIX.
+dir=$(mktemp -d)
+trap 'rm -rf "$dir"' EXIT
+
+httrack -O /dev/null -#test=mirrorio "$dir" | grep -q "mirrorio:.*OK"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -65,6 +65,7 @@ TESTS = \
 	01_engine-fsize.test \
 	01_engine-redirect.test \
 	01_engine-longpath-io.test \
+	01_engine-mirror-io.test \
 	01_engine-relative.test \
 	01_engine-robots.test \
 	01_engine-savename.test \


### PR DESCRIPTION
On Windows the engine builds mirror-tree paths in UTF-8 (argv is transcoded at startup, and `fconcat` only rewrites separators), but dozens of raw `fopen`/`remove`/`rename`/`rmdir`/`mkdir`/`fexist`/`fsize` calls fed those paths straight to the narrow CRT. Under a non-ASCII or >MAX_PATH output directory that means mojibake and MAX_PATH truncation: a mirror file reads as absent so its purge or re-get is skipped, or its bytes land at a mangled path.

This routes those call sites (htscoremain, htscore, htsparse, htsindex, htshelp) to the existing UTF-8 wrappers (`FOPEN`/`UNLINK`/`RENAME`/`MKDIR`/`fexist_utf8`/`fsize_utf8`) and adds `hts_rmdir_utf8` for the three `rmdir` sites that had no wrapper. The arguments are already UTF-8, so wrapping fixes both the charset and the length axes with no double-conversion; raw calls on genuinely system-charset or ASCII paths (`$HOME`, `structcheck`'s ASCII twin, the cwd "config" file) are left alone.

Builds on #684 (the `\\?\` layer these wrappers reach). New self-test `-#test=mirrorio` rounds a file through a long and non-ASCII path across `FOPEN`/`RENAME`/`UNLINK` and the new rmdir wrapper; on POSIX it is a byte-transparent control. Advances #133 and the #630 residual.

(Supersedes #685, which GitHub auto-closed when its stacked base branch was deleted on #684's merge.)