### PR TITLE
tests/fsize: skip when the filesystem caps file size below 5GB

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1889,8 +1889,7 @@ static int st_fsize(httrackp *opt, int argc, char **argv) {
     fprintf(stderr, "fsize: cannot extend '%s' to " LLintP ": %s\n", path,
             expected, strerror(err));
     UNLINK(path);
-    /* A filesystem that caps size below 5GB (e.g. GNU/Hurd ext2fs) can't host
-       the probe; skip (77), don't fail: the wrap is untestable there. */
+    /* EFBIG: file-size cap below 5GB (GNU/Hurd ext2fs); skip, don't fail. */
     return err == EFBIG ? 77 : 1;
   }
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1884,10 +1884,14 @@ static int st_fsize(httrackp *opt, int argc, char **argv) {
 #endif
   if (fseeko(fp, expected - 1, SEEK_SET) != 0 || fputc(0, fp) == EOF ||
       fclose(fp) != 0) {
+    const int err = errno;
+
     fprintf(stderr, "fsize: cannot extend '%s' to " LLintP ": %s\n", path,
-            expected, strerror(errno));
+            expected, strerror(err));
     UNLINK(path);
-    return 1;
+    /* A filesystem that caps size below 5GB (e.g. GNU/Hurd ext2fs) can't host
+       the probe; skip (77), don't fail: the wrap is untestable there. */
+    return err == EFBIG ? 77 : 1;
   }
 
   got = fsize(path);

--- a/tests/01_engine-fsize.test
+++ b/tests/01_engine-fsize.test
@@ -8,8 +8,14 @@ set -euo pipefail
 dir=$(mktemp -d)
 trap 'rm -rf "$dir"' EXIT
 
-out=$(httrack -#test=fsize "$dir")
+rc=0
+out=$(httrack -#test=fsize "$dir") || rc=$?
 echo "$out"
+
+# 77: the platform caps file size below 5GB (e.g. GNU/Hurd ext2fs, EFBIG) and
+# can't host the sparse probe. Nothing to exercise there; skip, don't fail.
+[ "$rc" = 77 ] && exit 77
+[ "$rc" = 0 ] || exit "$rc"
 
 want="fsize: width=8,8 size=5368709120,5368709120 psize=5368709120 absent=-1"
 test "$out" == "$want" || {

--- a/tests/01_engine-fsize.test
+++ b/tests/01_engine-fsize.test
@@ -12,8 +12,7 @@ rc=0
 out=$(httrack -#test=fsize "$dir") || rc=$?
 echo "$out"
 
-# 77: the platform caps file size below 5GB (e.g. GNU/Hurd ext2fs, EFBIG) and
-# can't host the sparse probe. Nothing to exercise there; skip, don't fail.
+# 77 = platform can't host the 5GB probe (EFBIG); skip, don't fail.
 [ "$rc" = 77 ] && exit 77
 [ "$rc" = 0 ] || exit "$rc"
 


### PR DESCRIPTION
On GNU/Hurd i386 the ext2fs translator cannot extend a file to 5GB and returns EFBIG, so the fsize self-test (which builds a 5GB sparse file to catch the 32-bit size wrap) fails the Debian build on that port: https://buildd.debian.org/status/fetch.php?pkg=httrack&arch=hurd-i386&ver=3.49.13-1&stamp=1784369465&raw=0

A platform that cannot host the probe has nothing to test, so it should skip rather than fail. The engine now returns 77 (automake skip) on EFBIG and the test wrapper maps it to a skip. Any other errno, or a wrong size report, still fails, so real regressions are not masked.