### PR TITLE
Windows: enumerate long or non-ASCII directories via FindFirstFileW

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -6431,21 +6431,31 @@ HTSEXT_API int hts_resetvar(void) {
 #ifdef _WIN32
 
 typedef struct dirent dirent;
+static LPWSTR hts_pathToUCS2(const char *path);
+
 DIR *opendir(const char *name) {
   WIN32_FILE_ATTRIBUTE_DATA st;
   DIR *dir;
   size_t len;
   int i;
+  LPWSTR wname;
 
   if (name == NULL || *name == '\0') {
     errno = ENOENT;
     return NULL;
   }
-  if (!GetFileAttributesEx(name, GetFileExInfoStandard, &st)
-      || (st.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+  // Existence/type check through the \\?\-aware wide path: a long or non-ASCII
+  // directory is otherwise MAX_PATH-capped or mis-decoded as CP_ACP
+  // (#133,#630).
+  wname = hts_pathToUCS2(name);
+  if (wname == NULL ||
+      !GetFileAttributesExW(wname, GetFileExInfoStandard, &st) ||
+      (st.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+    freet(wname);
     errno = ENOENT;
     return NULL;
   }
+  freet(wname);
   dir = calloc(sizeof(DIR), 1);
   if (dir == NULL) {
     errno = ENOMEM;
@@ -6465,19 +6475,30 @@ DIR *opendir(const char *name) {
 }
 
 struct dirent *readdir(DIR * dir) {
-  WIN32_FIND_DATAA find;
+  WIN32_FIND_DATAW find;
 
   if (dir->h == INVALID_HANDLE_VALUE) {
-    dir->h = FindFirstFileA(dir->name, &find);
+    // dir->name already carries the "\\*" wildcard, all-backslash; \\?\-prefix
+    // it so a long/non-ASCII directory enumerates instead of failing ENOENT.
+    LPWSTR wname = hts_pathToUCS2(dir->name);
+
+    dir->h =
+        wname != NULL ? FindFirstFileW(wname, &find) : INVALID_HANDLE_VALUE;
+    freet(wname);
   } else {
-    if (!FindNextFile(dir->h, &find)) {
+    if (!FindNextFileW(dir->h, &find)) {
       FindClose(dir->h);
       dir->h = INVALID_HANDLE_VALUE;
     }
   }
   if (dir->h != INVALID_HANDLE_VALUE) {
+    char *u = hts_convertUCS2StringToUTF8(find.cFileName, -1);
+
     dir->entry.d_name[0] = 0;
-    strncat(dir->entry.d_name, find.cFileName, HTS_DIRENT_SIZE - 1);
+    if (u != NULL) {
+      strncat(dir->entry.d_name, u, HTS_DIRENT_SIZE - 1);
+      freet(u);
+    }
     return &dir->entry;
   }
   errno = ENOENT;

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -6444,9 +6444,7 @@ DIR *opendir(const char *name) {
     errno = ENOENT;
     return NULL;
   }
-  // Existence/type check through the \\?\-aware wide path: a long or non-ASCII
-  // directory is otherwise MAX_PATH-capped or mis-decoded as CP_ACP
-  // (#133,#630).
+  // Wide \\?\ path: no MAX_PATH cap, no CP_ACP mis-decode (#133,#630).
   wname = hts_pathToUCS2(name);
   if (wname == NULL ||
       !GetFileAttributesExW(wname, GetFileExInfoStandard, &st) ||
@@ -6478,8 +6476,7 @@ struct dirent *readdir(DIR * dir) {
   WIN32_FIND_DATAW find;
 
   if (dir->h == INVALID_HANDLE_VALUE) {
-    // dir->name already carries the "\\*" wildcard, all-backslash; \\?\-prefix
-    // it so a long/non-ASCII directory enumerates instead of failing ENOENT.
+    // \\?\-prefix so a long/non-ASCII directory enumerates instead of ENOENT.
     LPWSTR wname = hts_pathToUCS2(dir->name);
 
     dir->h =

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -609,7 +609,9 @@ static HTS_UNUSED size_t llint_to_size_t(LLint o) {
 
 /* dirent() compatibility */
 #ifdef _WIN32
-#define HTS_DIRENT_SIZE 256
+/* Holds a UTF-8 d_name: MAX_PATH (260) UTF-16 units expand to <=3 bytes each.
+   Windows-only struct, ABI free to break. */
+#define HTS_DIRENT_SIZE 1024
 struct dirent {
   ino_t d_ino;                  /* ignored */
   off_t d_off;                  /* ignored */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4496,6 +4496,107 @@ static int st_mirrorio(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+// -#test=direnum <dir>: enumerate a long AND non-ASCII directory through the
+// opendir/readdir wrappers, asserting each non-ASCII child round-trips as UTF-8
+// (Windows FindFirstFileW + \\?\; positive control on POSIX libc) (#133, #630).
+static int st_direnum(httrackp *opt, int argc, char **argv) {
+  (void) opt;
+  if (argc < 1) {
+    fprintf(stderr, "direnum: needs a writable base dir\n");
+    return 1;
+  }
+  char path[HTS_URLMAXSIZE * 2];
+  size_t n = (size_t) snprintf(path, sizeof(path), "%s", argv[0]);
+
+  while (n > 0 && (path[n - 1] == '/' || path[n - 1] == '\\')) {
+    path[--n] = '\0';
+  }
+  const size_t base = n;
+  // Non-ASCII first segment + 40-char ASCII segments push the dir past
+  // MAX_PATH.
+  static const char nseg[] = "/\xC3\xA9\xE4\xB8\xAD-non-ascii-seg";
+  static const char seg[] = "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+  memcpybuff(path + n, nseg, sizeof(nseg));
+  n += sizeof(nseg) - 1;
+  if (MKDIR(path) != 0 && errno != EEXIST) {
+    fprintf(stderr, "direnum: mkdir failed (non-ascii): %s\n", strerror(errno));
+    return 1;
+  }
+  while (n + sizeof(seg) - 1 < 300) {
+    memcpybuff(path + n, seg, sizeof(seg));
+    n += sizeof(seg) - 1;
+    if (MKDIR(path) != 0 && errno != EEXIST) {
+      fprintf(stderr, "direnum: mkdir failed at %u chars: %s\n", (unsigned) n,
+              strerror(errno));
+      return 1;
+    }
+  }
+  const size_t dirlen = n;
+
+  assertf(dirlen > 260); /* the enumerated directory itself exceeds MAX_PATH */
+
+  // Two non-ASCII leaf files to read back by name.
+  static const char *const leaves[] = {"/\xC3\xA9-un.bin",
+                                       "/\xE4\xB8\xAD-deux.bin"};
+  for (size_t i = 0; i < 2; i++) {
+    memcpybuff(path + dirlen, leaves[i], strlen(leaves[i]) + 1);
+    FILE *fp = FOPEN(path, "wb");
+
+    if (fp == NULL) {
+      fprintf(stderr, "direnum: create failed: %s\n", strerror(errno));
+      return 1;
+    }
+    fclose(fp);
+  }
+  path[dirlen] = '\0';
+
+  int found = 0;
+  DIR *d = opendir(path);
+
+  if (d == NULL) {
+    fprintf(stderr, "direnum: opendir failed: %s\n", strerror(errno));
+    return 1;
+  }
+  struct dirent *e;
+
+  while ((e = readdir(d)) != NULL) {
+    for (size_t i = 0; i < 2; i++) {
+      if (strcmp(e->d_name, leaves[i] + 1) == 0) { /* +1: drop the '/' */
+        found |= 1 << i;
+      }
+    }
+  }
+  closedir(d);
+  if (found != 0x3) {
+    fprintf(stderr, "direnum: missing entries (found mask 0x%x)\n", found);
+    return 1;
+  }
+
+  // Teardown: leaves then the directory chain, via the long-path wrappers.
+  for (size_t i = 0; i < 2; i++) {
+    memcpybuff(path + dirlen, leaves[i], strlen(leaves[i]) + 1);
+    assertf(UNLINK(path) == 0);
+  }
+  path[dirlen] = '\0';
+  while (strlen(path) > base) {
+    char *const slash = strrchr(path, '/');
+
+    if (RMDIR(path) != 0) {
+      fprintf(stderr, "direnum: rmdir failed: %s\n", strerror(errno));
+      return 1;
+    }
+    if (slash == NULL || (size_t) (slash - path) < base) {
+      break;
+    }
+    *slash = '\0';
+  }
+
+  printf("direnum: enumerated 2 non-ASCII leaves under a %u-char dir: OK\n",
+         (unsigned) dirlen);
+  return 0;
+}
+
 /* ------------------------------------------------------------ */
 /* Registry: name -> handler, with a usage hint and a one-line description. */
 /* ------------------------------------------------------------ */
@@ -4634,6 +4735,9 @@ static const struct selftest_entry {
     {"mirrorio", "<dir>",
      "round-trip a long+non-ASCII path through the mirror I/O wrappers",
      st_mirrorio},
+    {"direnum", "<dir>",
+     "enumerate a long+non-ASCII directory through opendir/readdir",
+     st_direnum},
     {"warc-cdx", "<dir>", "--warc-cdx CDXJ index: sorted, offsets inflate",
      st_warc_cdx},
 #if HTS_USEOPENSSL

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4496,9 +4496,8 @@ static int st_mirrorio(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-// -#test=direnum <dir>: enumerate a long AND non-ASCII directory through the
-// opendir/readdir wrappers, asserting each non-ASCII child round-trips as UTF-8
-// (Windows FindFirstFileW + \\?\; positive control on POSIX libc) (#133, #630).
+// -#test=direnum <dir>: enumerate a long+non-ASCII directory via the
+// opendir/readdir wrappers; children must round-trip as UTF-8 (#133,#630).
 static int st_direnum(httrackp *opt, int argc, char **argv) {
   (void) opt;
   if (argc < 1) {

--- a/tests/01_engine-direnum.test
+++ b/tests/01_engine-direnum.test
@@ -3,9 +3,8 @@
 
 set -euo pipefail
 
-# Drives -#test=direnum: enumerates a directory that is both long (>MAX_PATH)
-# and non-ASCII through the opendir/readdir wrappers the Windows build supplies,
-# checking each non-ASCII child comes back as UTF-8 (#133, #630). POSIX control.
+# Drives -#test=direnum: enumerate a long+non-ASCII directory through the
+# opendir/readdir wrappers, checking each child round-trips as UTF-8 (#133,#630).
 dir=$(mktemp -d)
 trap 'rm -rf "$dir"' EXIT
 

--- a/tests/01_engine-direnum.test
+++ b/tests/01_engine-direnum.test
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# Drives -#test=direnum: enumerates a directory that is both long (>MAX_PATH)
+# and non-ASCII through the opendir/readdir wrappers the Windows build supplies,
+# checking each non-ASCII child comes back as UTF-8 (#133, #630). POSIX control.
+dir=$(mktemp -d)
+trap 'rm -rf "$dir"' EXIT
+
+httrack -O /dev/null -#test=direnum "$dir" | grep -q "direnum:.*OK"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -66,6 +66,7 @@ TESTS = \
 	01_engine-redirect.test \
 	01_engine-longpath-io.test \
 	01_engine-mirror-io.test \
+	01_engine-direnum.test \
 	01_engine-relative.test \
 	01_engine-robots.test \
 	01_engine-savename.test \


### PR DESCRIPTION
Windows opendir/readdir enumerated directories through the ANSI FindFirstFileA with a CP_ACP cFileName, so it capped listings at MAX_PATH and mis-decoded non-ASCII names. That is out of step with an engine that hands it UTF-8 paths and reads d_name back as UTF-8. The one live Windows caller is the end-of-crawl hts-cache/ref cleanup, which silently did nothing at a long or non-ASCII project root, leaking the temporary ref/ directory into the finished mirror.

opendir/readdir now go through hts_pathToUCS2 (the `\\?\` prefixing added in #684) and the wide FindFirstFileW APIs, converting cFileName back to UTF-8. Since d_name now carries UTF-8, HTS_DIRENT_SIZE grows from 256 to 1024 to fit MAX_PATH's worst-case expansion; the struct is `_WIN32`-only, so no POSIX ABI change. A `direnum` self-test enumerates a directory that is both over MAX_PATH and non-ASCII and checks each child round-trips.

Third of the #133 long-path series, after #684 (the `\\?\` layer) and #686 (the mirror-I/O wrapper sweep). The IE-cookie import in htsbauth.c is the remaining gap, left for a follow-up.
