### PR TITLE
Windows: load IE cookies from long or non-ASCII folders (FindFirstFileW)

### DIFF
--- a/src/htsbauth.c
+++ b/src/htsbauth.c
@@ -203,8 +203,7 @@ char *cookie_nextfield(char *a) {
   return a;
 }
 
-// Read cookies.txt, plus (Windows only) any copied IE cookies *@*.txt.
-// Returns !=0 on error.
+// Read cookies.txt (+ copied IE cookies *@*.txt on Windows); !=0 on error.
 int cookie_load(t_cookie * cookie, const char *fpath, const char *name) {
   char catbuff[CATBUFF_SIZE];
   char buffer[8192];
@@ -228,8 +227,7 @@ int cookie_load(t_cookie * cookie, const char *fpath, const char *name) {
         if (!(find.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
           if (!(find.dwFileAttributes & FILE_ATTRIBUTE_SYSTEM)) {
             // cFileName is UTF-16: convert to UTF-8 so the mirror path and
-            // hts_fopen_utf8/_unlink stay UTF-8 end to end (no CP_ACP
-            // mojibake).
+            // file wrappers stay UTF-8 (no CP_ACP mojibake).
             char *u = hts_convertUCS2StringToUTF8(find.cFileName, -1);
             FILE *fp =
                 u != NULL

--- a/src/htsbauth.c
+++ b/src/htsbauth.c
@@ -39,6 +39,9 @@ Please visit our Website: http://www.httrack.com
 #include "htsglobal.h"
 #include "htslib.h"
 #include "htscore.h"
+#ifdef _WIN32
+#include "htscharset.h" /* hts_pathToUCS2, hts_convertUCS2StringToUTF8 */
+#endif
 
 /* END specific definitions */
 
@@ -200,28 +203,38 @@ char *cookie_nextfield(char *a) {
   return a;
 }
 
-// lire cookies.txt
-// lire également (Windows seulement) les *@*.txt (cookies IE copiés)
-// !=0 : erreur
+// Read cookies.txt, plus (Windows only) any copied IE cookies *@*.txt.
+// Returns !=0 on error.
 int cookie_load(t_cookie * cookie, const char *fpath, const char *name) {
   char catbuff[CATBUFF_SIZE];
   char buffer[8192];
 
-  // Fusionner d'abord les éventuels cookies IE
+  // Merge any IE cookies first
 #ifdef _WIN32
   {
-    WIN32_FIND_DATAA find;
+    WIN32_FIND_DATAW find;
     HANDLE h;
-    char pth[MAX_PATH + 32];
+    char pth[HTS_URLMAXSIZE];
+    LPWSTR wpth;
 
     strcpybuff(pth, fpath);
     strcatbuff(pth, "*@*.txt");
-    h = FindFirstFileA((char *) pth, &find);
+    // Wide glob so a long or non-ASCII IE-cookie folder is scanned (#133).
+    wpth = hts_pathToUCS2(pth);
+    h = wpth != NULL ? FindFirstFileW(wpth, &find) : INVALID_HANDLE_VALUE;
+    freet(wpth);
     if (h != INVALID_HANDLE_VALUE) {
       do {
         if (!(find.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
           if (!(find.dwFileAttributes & FILE_ATTRIBUTE_SYSTEM)) {
-            FILE *fp = fopen(fconcat(catbuff, sizeof(catbuff), fpath, find.cFileName), "rb");
+            // cFileName is UTF-16: convert to UTF-8 so the mirror path and
+            // hts_fopen_utf8/_unlink stay UTF-8 end to end (no CP_ACP
+            // mojibake).
+            char *u = hts_convertUCS2StringToUTF8(find.cFileName, -1);
+            FILE *fp =
+                u != NULL
+                    ? FOPEN(fconcat(catbuff, sizeof(catbuff), fpath, u), "rb")
+                    : NULL;
 
             if (fp) {
               char cook_name[256];
@@ -229,11 +242,9 @@ int cookie_load(t_cookie * cookie, const char *fpath, const char *name) {
               char domainpathpath[512];
               char dummy[512];
 
-              //
-              lien_adrfil af;   // chemin (/)
+              lien_adrfil af; // host + path (/)
               int cookie_merged = 0;
 
-              //
               // Read all cookies
               while(!feof(fp)) {
                 cook_name[0] = cook_value[0] = domainpathpath[0]
@@ -262,10 +273,11 @@ int cookie_load(t_cookie * cookie, const char *fpath, const char *name) {
               }
               fclose(fp);
               if (cookie_merged)
-                remove(fconcat(catbuff, sizeof(catbuff), fpath, find.cFileName));
+                UNLINK(fconcat(catbuff, sizeof(catbuff), fpath, u));
             }                   // if fp
+            freet(u);
           }
-      } while(FindNextFileA(h, &find));
+      } while (FindNextFileW(h, &find));
       FindClose(h);
     }
   }
@@ -273,7 +285,7 @@ int cookie_load(t_cookie * cookie, const char *fpath, const char *name) {
 
   // Ensuite, cookies.txt
   {
-    FILE *fp = fopen(fconcat(catbuff, sizeof(catbuff), fpath, name), "rb");
+    FILE *fp = FOPEN(fconcat(catbuff, sizeof(catbuff), fpath, name), "rb");
 
     if (fp) {
       char BIGSTK line[8192];
@@ -315,7 +327,7 @@ int cookie_save(t_cookie * cookie, const char *name) {
   if (strnotempty(cookie->data)) {
     char BIGSTK line[8192];
 #ifdef _WIN32
-    FILE *fp = fopen(fconv(catbuff, sizeof(catbuff), name), "wb");
+    FILE *fp = FOPEN(fconv(catbuff, sizeof(catbuff), name), "wb");
 #else
     const int fd = open(fconv(catbuff, sizeof(catbuff), name),
                         O_WRONLY | O_CREAT | O_TRUNC, HTS_PROTECT_FILE);

--- a/src/htscharset.h
+++ b/src/htscharset.h
@@ -173,7 +173,7 @@ extern char *hts_convertUCS2StringToUTF8(LPWSTR woutput, int wsize);
 
 /**
  * UTF-8 path to UCS-2 for the wide file/FindFirst APIs, \\?\-prefixed above
- * MAX_PATH (#133). Defined in htslib.c; internal (not exported). Caller frees.
+ * MAX_PATH (#133). Internal, not exported; caller frees.
  * This function is WIN32 specific.
  **/
 extern LPWSTR hts_pathToUCS2(const char *path);

--- a/src/htscharset.h
+++ b/src/htscharset.h
@@ -172,6 +172,13 @@ extern LPWSTR hts_convertUTF8StringToUCS2(const char *s, int size, int *pwsize);
 extern char *hts_convertUCS2StringToUTF8(LPWSTR woutput, int wsize);
 
 /**
+ * UTF-8 path to UCS-2 for the wide file/FindFirst APIs, \\?\-prefixed above
+ * MAX_PATH (#133). Defined in htslib.c; internal (not exported). Caller frees.
+ * This function is WIN32 specific.
+ **/
+extern LPWSTR hts_pathToUCS2(const char *path);
+
+/**
  * Convert current system codepage to UTF-8.
  * This function is WIN32 specific.
  **/

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -6431,7 +6431,6 @@ HTSEXT_API int hts_resetvar(void) {
 #ifdef _WIN32
 
 typedef struct dirent dirent;
-static LPWSTR hts_pathToUCS2(const char *path);
 
 DIR *opendir(const char *name) {
   WIN32_FILE_ATTRIBUTE_DATA st;
@@ -6533,7 +6532,7 @@ static void copyWchar(LPWSTR dest, const char *src) {
    Any prefixing failure falls back to the plain converted path. */
 #define HTS_WIN_LONGPATH_MIN 240 /* stay clear of MAX_PATH (260) */
 
-static LPWSTR hts_pathToUCS2(const char *path) {
+LPWSTR hts_pathToUCS2(const char *path) {
   LPWSTR wpath = hts_convertUTF8StringToUCS2(path, (int) strlen(path), NULL);
 
   if (wpath == NULL) {

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4596,11 +4596,9 @@ static int st_direnum(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-/* cookie_load reads its jar, and on Windows also imports copied IE cookies
-   (*@*.txt), through the UTF-8/long-path file wrappers. Drive it against a
-   long, non-ASCII cookie folder end to end (#133). POSIX compiles out the
-   IE-scan block, so there the merge only proves the cookies.txt read; the wide
-   FindFirstFileW glob and the IE import are exercised on the Windows legs. */
+/* -#test=cookieimport <dir>: load a jar (and, on Windows, copied IE cookies
+   *@*.txt) from a long, non-ASCII folder via the UTF-8/long-path wrappers
+   (#133). POSIX compiles the IE block out; there it is a positive control. */
 static int st_cookieimport(httrackp *opt, int argc, char **argv) {
   (void) opt;
   if (argc < 1) {

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4596,6 +4596,110 @@ static int st_direnum(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* cookie_load reads its jar, and on Windows also imports copied IE cookies
+   (*@*.txt), through the UTF-8/long-path file wrappers. Drive it against a
+   long, non-ASCII cookie folder end to end (#133). POSIX compiles out the
+   IE-scan block, so there the merge only proves the cookies.txt read; the wide
+   FindFirstFileW glob and the IE import are exercised on the Windows legs. */
+static int st_cookieimport(httrackp *opt, int argc, char **argv) {
+  (void) opt;
+  if (argc < 1) {
+    fprintf(stderr, "cookieimport: needs a writable base dir\n");
+    return 1;
+  }
+  char dir[HTS_URLMAXSIZE * 2];
+  size_t n = (size_t) snprintf(dir, sizeof(dir), "%s", argv[0]);
+
+  while (n > 0 && (dir[n - 1] == '/' || dir[n - 1] == '\\')) {
+    dir[--n] = '\0';
+  }
+  const size_t base = n;
+  static const char nseg[] = "/\xC3\xA9\xE4\xB8\xAD-cookie-seg";
+  static const char seg[] = "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+  memcpybuff(dir + n, nseg, sizeof(nseg));
+  n += sizeof(nseg) - 1;
+  if (MKDIR(dir) != 0 && errno != EEXIST) {
+    fprintf(stderr, "cookieimport: mkdir failed: %s\n", strerror(errno));
+    return 1;
+  }
+  while (n + sizeof(seg) - 1 < 300) {
+    memcpybuff(dir + n, seg, sizeof(seg));
+    n += sizeof(seg) - 1;
+    if (MKDIR(dir) != 0 && errno != EEXIST) {
+      fprintf(stderr, "cookieimport: mkdir failed at %u: %s\n", (unsigned) n,
+              strerror(errno));
+      return 1;
+    }
+  }
+  const size_t dirlen = n;
+
+  assertf(dirlen > 260); /* the cookie folder itself exceeds MAX_PATH */
+
+  char fpath[HTS_URLMAXSIZE * 2];
+  char file[HTS_URLMAXSIZE * 2];
+
+  snprintf(fpath, sizeof(fpath), "%s/", dir); /* IE glob wants a trailing sep */
+
+  /* cookies.txt: one Netscape record (host, _, path, _, _, name, value). */
+  snprintf(file, sizeof(file), "%scookies.txt", fpath);
+  {
+    FILE *fp = FOPEN(file, "wb");
+
+    assertf(fp != NULL);
+    fprintf(fp, "www.example.com\tFALSE\t/\tFALSE\t0\tJARCOOK\tjarval\n");
+    fclose(fp);
+  }
+
+  /* A copied IE cookie u@v.txt: name, value, url, then 6 unused fields. */
+  snprintf(file, sizeof(file), "%su@v.txt", fpath);
+  {
+    FILE *fp = FOPEN(file, "wb");
+
+    assertf(fp != NULL);
+    fprintf(fp, "IECOOK\nieval\nwww.example.com/\n0\n0\n0\n0\n0\n*\n");
+    fclose(fp);
+  }
+
+  static t_cookie ck;
+
+  ck.max_len = (int) sizeof(ck.data);
+  ck.data[0] = '\0';
+  assertf(cookie_load(&ck, fpath, "cookies.txt") == 0);
+  assertf(strstr(ck.data, "JARCOOK") != NULL); /* jar read on a long path */
+#ifdef _WIN32
+  /* the IE scan merged the cookie and unlinked the consumed file */
+  assertf(strstr(ck.data, "IECOOK") != NULL);
+  assertf(FOPEN(file, "rb") == NULL);
+#endif
+
+  (void) UNLINK(file); /* u@v.txt (already gone on Windows) */
+  snprintf(file, sizeof(file), "%scookies.txt", fpath);
+  (void) UNLINK(file);
+  dir[dirlen] = '\0';
+  while (strlen(dir) > base) {
+    char *const slash = strrchr(dir, '/');
+
+    if (RMDIR(dir) != 0) {
+      fprintf(stderr, "cookieimport: rmdir failed: %s\n", strerror(errno));
+      return 1;
+    }
+    if (slash == NULL || (size_t) (slash - dir) < base) {
+      break;
+    }
+    *slash = '\0';
+  }
+
+  printf("cookieimport: merged jar%s under a %u-char non-ASCII dir: OK\n",
+#ifdef _WIN32
+         " + IE cookie",
+#else
+         "",
+#endif
+         (unsigned) dirlen);
+  return 0;
+}
+
 /* ------------------------------------------------------------ */
 /* Registry: name -> handler, with a usage hint and a one-line description. */
 /* ------------------------------------------------------------ */
@@ -4737,6 +4841,9 @@ static const struct selftest_entry {
     {"direnum", "<dir>",
      "enumerate a long+non-ASCII directory through opendir/readdir",
      st_direnum},
+    {"cookieimport", "<dir>",
+     "load a jar (and Windows IE cookies) from a long+non-ASCII folder",
+     st_cookieimport},
     {"warc-cdx", "<dir>", "--warc-cdx CDXJ index: sorted, offsets inflate",
      st_warc_cdx},
 #if HTS_USEOPENSSL

--- a/tests/01_engine-cookieimport.test
+++ b/tests/01_engine-cookieimport.test
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# Drives -#test=cookieimport: load a cookie jar (and, on Windows, copied IE
+# cookies *@*.txt) from a long, non-ASCII folder through the UTF-8/long-path
+# file wrappers (#133,#630).
+dir=$(mktemp -d)
+trap 'rm -rf "$dir"' EXIT
+
+httrack -O /dev/null -#test=cookieimport "$dir" | grep -q "cookieimport:.*OK"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -67,6 +67,7 @@ TESTS = \
 	01_engine-longpath-io.test \
 	01_engine-mirror-io.test \
 	01_engine-direnum.test \
+	01_engine-cookieimport.test \
 	01_engine-relative.test \
 	01_engine-robots.test \
 	01_engine-savename.test \


### PR DESCRIPTION
On Windows, cookie_load imported IE cookies and read cookies.txt through the narrow ANSI file API (FindFirstFileA, fopen, remove). A cookie folder whose path was non-ASCII or longer than MAX_PATH was therefore skipped without a word, and a matched IE cookie filename came back into the mirror path as CP_ACP bytes. This runs the `*@*.txt` glob through `hts_pathToUCS2` + `FindFirstFileW`, converts `cFileName` to UTF-8 before rebuilding the path, and moves the reads and removes onto the `FOPEN`/`UNLINK` wrappers.

The find-side A-to-W swap and the sink swaps have to land together: swap only the sink and a CP_ACP name reaches `hts_fopen_utf8`'s UTF-8 decode and mojibakes the path that used to be accidentally consistent. `hts_pathToUCS2` loses its `static` (internal, still hidden and unexported) so the glob picks up the same `\\?\` long-path handling as the other file wrappers.

This is the last piece of the #133 long-path series. POSIX acts as a positive control since the IE block compiles out; the wide glob and the IE import run on the Windows CI legs, driven by a new `-#test=cookieimport` self-test.

Closes #133.