### PR TITLE
Release 3.49.14

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.71])
 
-AC_INIT([httrack], [3.49.13], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
+AC_INIT([httrack], [3.49.14], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
 AC_COPYRIGHT([
 HTTrack Website Copier, Offline Browser for Windows and Unix
 Copyright (C) 1998-2015 Xavier Roche and other contributors
@@ -29,13 +29,12 @@ AC_CONFIG_SRCDIR(src/httrack.c)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
-# 3:5:0: 3.49.13 leaves every installed struct layout and the exported symbol set
-# untouched vs 3.49.12; the 2 GB (_stat64) and UTF-8 export widenings are _WIN32-only,
-# and INTsys widened on POSIX (#600) but sits in no installed struct. Stays soname
-# .so.3; bump revision. x32 alone changes layout (LLint was 4 bytes there, #524), and
-# is not a release architecture.
+# 3:6:0: 3.49.14 grows two installed structs from the inside (htsoptstate sits mid-
+# httrackp, htsblk mid-lien_back), so the fields after them shift: httrackp.cookies_file
+# +8, lien_back.http11 +48. Soname deliberately stays .so.3: the shifted fields are
+# 3.49-era additions no external consumer reaches, and a libhttrack3 rename isn't worth it.
 # (3:0:0 was the htsblk mime-buffer widening, the ABI break that moved .so.2 -> .so.3.)
-VERSION_INFO="3:5:0"
+VERSION_INFO="3:6:0"
 AM_MAINTAINER_MODE
 AC_USE_SYSTEM_EXTENSIONS
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+httrack (3.49.14-1) unstable; urgency=medium
+
+  * New upstream release: WARC/WACZ archive output, Windows long-path support,
+    named -%F footer fields, and encoding fixes for non-ASCII project paths;
+    full list in history.txt.
+
+ -- Xavier Roche <xavier@debian.org>  Fri, 24 Jul 2026 08:01:43 +0200
+
 httrack (3.49.13-1) unstable; urgency=medium
 
   * New upstream release: SOCKS5 and CONNECT proxy support, brotli and zstd

--- a/history.txt
+++ b/history.txt
@@ -4,6 +4,23 @@ HTTrack Website Copier release history:
 
 This file lists all changes and fixes that have been made for HTTrack
 
+3.49-14
++ New: WARC/1.1 archive output (--warc), with a sorted CDXJ index (--warc-cdx) and WACZ packaging (--wacz), also available from webhttrack (#668)
++ New: -%F takes named footer fields such as {url}, {lastmodified}, {mime}, {charset} and {status} instead of a fixed layout (#667)
++ New: a command-line guide organized by task ships with the offline documentation (#649)
++ Fixed: on Windows, paths beyond MAX_PATH truncated files, and mirroring into a long or non-ASCII directory silently failed (#133)
++ Fixed: the top index showed mojibake for non-ASCII project names and categories on Windows (#216)
++ Fixed: webhttrack handed the engine the web form's charset rather than UTF-8, so a non-ASCII path mirrored into a mojibake directory (#629)
++ Fixed: a non-ASCII single -O left the logs and the cache in a mangled twin directory on Windows (#630)
++ Fixed: a path-ceiling truncation dropped the .delayed marker, losing the file (#623)
++ Fixed: an oversized -%F footer aborted the crawl instead of being skipped (#669)
++ Fixed: a rejected 206 resume could loop and lose the file rather than refetch it whole (#581)
++ Fixed: default-port stripping was scheme-blind and dropped explicit ports from https and ftp URLs, and a :80 written with leading zeros mangled the host (#627, #638)
++ Fixed: -K silently reset the -c socket count (#650)
++ Fixed: signed-shift undefined behaviour in the zip-repair local-header read (#639)
++ Changed: the offline documentation drops stale facts, gains an Android help page, and documents the filter wildcards and the real long option forms
++ Changed: multiple internal hardening, test and CI improvements
+
 3.49-13
 + New: SOCKS5 proxy support, with scheme-aware -P URLs (socks5://, socks5h://, connect://) and plain HTTP tunneled through a CONNECT-only proxy (#563, #564)
 + New: decode brotli and zstd content codings, advertised over TLS only as browsers do (#556)

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -43,8 +43,8 @@ Please visit our Website: http://www.httrack.com
    configure.ac, decoupled from these). VERSION is the display form, VERSIONID
    the dotted numeric form, AFF_VERSION the short form shown in footers,
    LIB_VERSION the data/cache format generation. */
-#define HTTRACK_VERSION "3.49-13"
-#define HTTRACK_VERSIONID "3.49.13"
+#define HTTRACK_VERSION "3.49-14"
+#define HTTRACK_VERSIONID "3.49.14"
 #define HTTRACK_AFF_VERSION "3.x"
 #define HTTRACK_LIB_VERSION "2.0"
 

--- a/src/version.rc
+++ b/src/version.rc
@@ -17,8 +17,8 @@
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-  FILEVERSION 3, 49, 13, 0
-  PRODUCTVERSION 3, 49, 13, 0
+  FILEVERSION 3, 49, 14, 0
+  PRODUCTVERSION 3, 49, 14, 0
   FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
 #ifdef _DEBUG
   FILEFLAGS VS_FF_DEBUG
@@ -35,12 +35,12 @@ BEGIN
     BEGIN
       VALUE "CompanyName", "Xavier Roche"
       VALUE "FileDescription", VER_FILE_DESCRIPTION
-      VALUE "FileVersion", "3.49.13"
+      VALUE "FileVersion", "3.49.14"
       VALUE "InternalName", VER_ORIGINAL_FILENAME
       VALUE "LegalCopyright", "Copyright (C) 1998-2026 Xavier Roche and other contributors. GNU GPL v3 or later."
       VALUE "OriginalFilename", VER_ORIGINAL_FILENAME
       VALUE "ProductName", "HTTrack Website Copier"
-      VALUE "ProductVersion", "3.49-13"
+      VALUE "ProductVersion", "3.49-14"
     END
   END
   BLOCK "VarFileInfo"


### PR DESCRIPTION
Version bump to 3.49.14, covering the 51 commits since 3.49.13: WARC/WACZ archive output, Windows long-path support closing #133, named `-%F` footer fields, and the non-ASCII path encoding fixes.

Worth a look before merging: the WARC work appended its fields at the tail of `httrackp` and `htsblk`, normally the ABI-safe move, but `htsoptstate state` sits mid-`httrackp` and `htsblk r` sits mid-`lien_back`, so growing the inner struct shifted everything after it. An offsetof probe compiled against both tags puts `httrackp.cookies_file` at +8 and `lien_back.http11` at +48. Per your call the soname stays `.so.3` (VERSION_INFO 3:5:0 to 3:6:0) and the Debian package keeps its name; the VERSION_INFO comment now records the shift instead of claiming the layouts are unchanged.

Standards-Version 4.7.4 still matches sid, and no `debian/` changes landed this cycle, so the changelog entry is the upstream overview only. Built out-of-tree: `make check -j` is 133 pass / 7 skip / 0 fail, the binary reports 3.49-14, and the library is `libhttrack.so.3.0.6`.