### PR TITLE
Windows CI: cache vcpkg binary archives across runs

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -23,6 +23,11 @@ jobs:
       matrix:
         platform: [x64, Win32]
         configuration: [Release]
+    # Redirect vcpkg's default `files` binary cache into the workspace so
+    # actions/cache can persist it. vcpkg builds openssl/brotli/zlib/zstd from
+    # source otherwise, several minutes every run.
+    env:
+      VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}\vcpkg_cache
     steps:
       - uses: actions/checkout@v4
         with:
@@ -43,6 +48,24 @@ jobs:
       - name: Enable vcpkg MSBuild integration
         shell: pwsh
         run: vcpkg integrate install
+
+      # vcpkg errors if VCPKG_DEFAULT_BINARY_CACHE points at a missing dir, and
+      # actions/cache does not create it on a miss.
+      - name: Create the vcpkg binary cache directory
+        shell: pwsh
+        run: New-Item -ItemType Directory -Force -Path $env:VCPKG_DEFAULT_BINARY_CACHE | Out-Null
+
+      # x-gha is gone (vcpkg-tool #1662 dropped it after GitHub changed the cache
+      # API), so cache the binary archives directly. Keyed on the manifest, which
+      # carries the builtin-baseline, so a Dependabot bump busts it; restore-keys
+      # still seeds the unchanged ports' archives, so only the bumped one rebuilds.
+      - name: Cache vcpkg binary archives
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}\vcpkg_cache
+          key: vcpkg-${{ matrix.platform }}-${{ hashFiles('src/vcpkg.json') }}
+          restore-keys: |
+            vcpkg-${{ matrix.platform }}-
 
       # The runner image's vcpkg checkout is pinned to some commit; our manifest's
       # builtin-baseline is usually newer, so `git show <baseline>:versions/...`


### PR DESCRIPTION
The Windows job rebuilds openssl, brotli, zlib and zstd from source on every run, several minutes each time. This caches vcpkg's binary archives with actions/cache so unchanged dependencies restore instead of rebuilding.

The x-gha backend vcpkg once offered for exactly this was removed upstream (vcpkg-tool #1662) after GitHub reworked the Actions cache API, so the endorsed path now is actions/cache over vcpkg's binary-cache directory. That also keeps us inside the repo's GitHub-owned-actions-only policy, unlike run-vcpkg or a NuGet feed.

The cache key is the vcpkg manifest hash, which already carries the builtin-baseline, so a Dependabot baseline bump invalidates it cleanly. The restore-keys prefix still seeds the prior archives on a bump, so only the changed port rebuilds rather than the whole set.