### PR TITLE
CI: let Dependabot track GitHub Actions versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
     directory: /src
     schedule:
       interval: weekly
+
+  # Keep the workflow action pins current (they only rot manually otherwise).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -24,7 +24,7 @@ jobs:
         platform: [x64, Win32]
         configuration: [Release]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive   # coucal lives in src/coucal
 


### PR DESCRIPTION
Dependabot only watched the vcpkg manifest, so the workflow action pins drifted by hand: windows-build.yml was still on actions/checkout@v4 while every other workflow had moved to v6. Add the github-actions ecosystem so the pins stay current on their own, and bump that one stray checkout to v6 now.