### PR TITLE
CLI display does not repaint when the terminal is resized

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -169,7 +169,7 @@ AC_CHECK_TYPE(sa_family_t, [], [AC_DEFINE([sa_family_t], [uint16_t], [sa_family_
 AX_CHECK_ALIGNED_ACCESS_REQUIRED
 
 # check for various headers
-AC_CHECK_HEADERS([execinfo.h])
+AC_CHECK_HEADERS([execinfo.h sys/ioctl.h])
 
 ### zlib
 CHECK_ZLIB()

--- a/src/httrack.c
+++ b/src/httrack.c
@@ -68,6 +68,9 @@ static int linput(FILE * fp, char *s, int max);
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#ifdef HAVE_SYS_IOCTL_H
+#include <sys/ioctl.h>
+#endif
 #include <ctype.h>
 #if (defined(__linux) && defined(HAVE_EXECINFO_H))
 #include <execinfo.h>
@@ -185,6 +188,43 @@ static void vt_home(void) {
   printf("%s%s", VT_RESET, VT_GOTOXY("1", "0"));
 }
 
+/* Last known terminal geometry; the defaults are the classic VT100 size. */
+static int term_cols = 80;
+static int term_rows = 24;
+
+/* Refresh term_cols/term_rows, and tell whether they moved since last call. */
+static hts_boolean vt_size_refresh(void) {
+  int cols = 0;
+  int rows = 0;
+
+#ifdef _WIN32
+  CONSOLE_SCREEN_BUFFER_INFO info;
+  const HANDLE console = GetStdHandle(STD_OUTPUT_HANDLE);
+
+  if (console != INVALID_HANDLE_VALUE &&
+      GetConsoleScreenBufferInfo(console, &info)) {
+    cols = info.srWindow.Right - info.srWindow.Left + 1;
+    rows = info.srWindow.Bottom - info.srWindow.Top + 1;
+  }
+#elif defined(TIOCGWINSZ)
+  struct winsize ws;
+
+  if (ioctl(fileno(stdout), TIOCGWINSZ, &ws) == 0) {
+    cols = ws.ws_col;
+    rows = ws.ws_row;
+  }
+#endif
+  if (cols <= 0)
+    cols = 80;
+  if (rows <= 0)
+    rows = 24;
+  if (cols == term_cols && rows == term_rows)
+    return HTS_FALSE;
+  term_cols = cols;
+  term_rows = rows;
+  return HTS_TRUE;
+}
+
 //
 
 /*
@@ -195,7 +235,8 @@ static void vt_home(void) {
 #define STYLE_STATTEXT   VT_UNBOLD
 #define STYLE_STATRESET  VT_UNBOLD
 #define NStatsBuffer     14
-#define MAX_LEN_INPROGRESS 40
+/* Rows the stats block and "Current job" take above the in-progress list. */
+#define NStatsHeaderRows 7
 
 static int use_show;
 static httrackp *global_opt = NULL;
@@ -291,6 +332,7 @@ static int __cdecl htsshow_start(t_hts_callbackarg * carg, httrackp * opt) {
   use_show = 0;
   if (opt->verbosedisplay == HTS_VERBOSE_FULL) {
     use_show = 1;
+    (void) vt_size_refresh();
     vt_clear();
   }
   return 1;
@@ -396,6 +438,10 @@ static int __cdecl htsshow_loop(t_hts_callbackarg * carg, httrackp * opt, lien_b
 
     prev_mytime = mytime;
 
+    /* A resize leaves stale wrapped text on screen: repaint everything. */
+    if (vt_size_refresh())
+      vt_clear();
+
     st[0] = '\0';
     qsec2str(st, stat_time);
     vt_home();
@@ -435,6 +481,13 @@ static int __cdecl htsshow_loop(t_hts_callbackarg * carg, httrackp * opt, lien_b
       //
       t_StatsBuffer StatsBuffer[NStatsBuffer];
 
+      /* Keep the frame within the terminal, or it scrolls the stats away. */
+      const int nstats =
+          min(NStatsBuffer, max(0, term_rows - NStatsHeaderRows));
+      /* URL budget: half the width, i.e. the historical 40 at 80 columns. */
+      const int maxurl =
+          min((int) sizeof(StatsBuffer[0].name) - 1, max(16, term_cols / 2));
+
       {
         int i;
 
@@ -449,10 +502,11 @@ static int __cdecl htsshow_loop(t_hts_callbackarg * carg, httrackp * opt, lien_b
         }
       }
       for(k = 0; k < 2; k++) {  // 0: lien en cours 1: autres liens
-        for(j = 0; (j < 3) && (index < NStatsBuffer); j++) {    // passe de priorité
+        for (j = 0; (j < 3) && (index < nstats); j++) { // passe de priorité
           int _i;
 
-          for(_i = 0 + k; (_i < max(back_max * k, 1)) && (index < NStatsBuffer); _i++) {        // no lien
+          for (_i = 0 + k; (_i < max(back_max * k, 1)) && (index < nstats);
+               _i++) {                                  // no lien
             int i = (back_index + _i) % back_max;       // commencer par le "premier" (l'actuel)
 
             if (back[i].status >= 0) { // signifie "lien actif"
@@ -527,16 +581,14 @@ static int __cdecl htsshow_loop(t_hts_callbackarg * carg, httrackp * opt, lien_b
                   }
                 }
 
-                if ((l = (int) strlen(s)) < MAX_LEN_INPROGRESS)
+                if ((l = (int) strlen(s)) < maxurl)
                   strcpybuff(StatsBuffer[index].name, s);
                 else {
                   // couper
                   StatsBuffer[index].name[0] = '\0';
-                  strncatbuff(StatsBuffer[index].name, s,
-                              MAX_LEN_INPROGRESS / 2 - 2);
+                  strncatbuff(StatsBuffer[index].name, s, maxurl / 2 - 2);
                   strcatbuff(StatsBuffer[index].name, "...");
-                  strcatbuff(StatsBuffer[index].name,
-                             s + l - MAX_LEN_INPROGRESS / 2 + 2);
+                  strcatbuff(StatsBuffer[index].name, s + l - maxurl / 2 + 2);
                 }
 
                 if (back[i].r.totalsize >= 0) { // taille prédéfinie
@@ -597,7 +649,7 @@ static int __cdecl htsshow_loop(t_hts_callbackarg * carg, httrackp * opt, lien_b
       {
         int i;
 
-        for(i = 0; i < NStatsBuffer; i++) {
+        for (i = 0; i < nstats; i++) {
           if (strnotempty(StatsBuffer[i].state)) {
             printf(VT_CLREOL " %s - \t%s%s \t%s / \t%s", StatsBuffer[i].state,
                    StatsBuffer[i].name, StatsBuffer[i].file, int2bytes(&strc,

--- a/src/httrack.c
+++ b/src/httrack.c
@@ -192,7 +192,7 @@ static void vt_home(void) {
 static int term_cols = 80;
 static int term_rows = 24;
 
-/* Refresh term_cols/term_rows, and tell whether they moved since last call. */
+/* Returns HTS_TRUE if the terminal size changed since the last call. */
 static hts_boolean vt_size_refresh(void) {
   int cols = 0;
   int rows = 0;

--- a/tests/76_cli-resize.test
+++ b/tests/76_cli-resize.test
@@ -1,7 +1,7 @@
 #!/bin/bash
-# #97: the animated CLI display must repaint the whole screen when the terminal
-# is resized, otherwise stale wrapped text stays on screen.
-set -u
+# #97: a terminal resize must repaint the whole screen, and the frame must
+# follow the new geometry instead of the hardcoded 80x24 one.
+set -eu
 
 : "${top_srcdir:=..}"
 testdir=$(cd "$(dirname "$0")" && pwd)
@@ -52,16 +52,19 @@ which httrack >/dev/null || {
     exit 1
 }
 
-# The trickled pages keep the display animating long enough to resize under it.
+# Trickled pages under a long path: the display keeps animating while the pty is
+# resized under it, and the URL is truncated at 80 columns but not at 200.
+deep="127.0.0.1:${port}/trickle/deep/a-long-directory-segment/another-long-segment"
 out="${tmpdir}/crawl"
 mkdir "$out"
-"$python" "$driver" 2 8 "${tmpdir}/pty.raw" \
-    httrack "http://127.0.0.1:${port}/trickle/index.html" \
+rc=0
+# The in-progress rows show host:port, not the scheme.
+"$python" "$driver" "${tmpdir}/pty.raw" "${deep}/p" -- \
+    httrack "http://${deep}/index.html" \
     -O "$out" -%v --robots=0 --disable-security-limits \
-    --timeout=30 --retries=1 -c4 --max-time 6
-rc=$?
-test $rc -eq 0 || {
-    echo "pty capture head:"
-    head -c 400 "${tmpdir}/pty.raw" | cat -v
+    --timeout=30 --retries=1 -c4 --max-time 60 || rc=$?
+test "$rc" -eq 0 || {
+    echo "pty capture tail:"
+    tail -c 600 "${tmpdir}/pty.raw" | cat -v
     exit 1
 }

--- a/tests/76_cli-resize.test
+++ b/tests/76_cli-resize.test
@@ -1,0 +1,67 @@
+#!/bin/bash
+# #97: the animated CLI display must repaint the whole screen when the terminal
+# is resized, otherwise stale wrapped text stays on screen.
+set -u
+
+: "${top_srcdir:=..}"
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+server=$(nativepath "${testdir}/local-server.py")
+root=$(nativepath "${testdir}/server-root")
+driver=$(nativepath "${testdir}/pty-resize.py")
+
+if is_windows; then
+    echo "no pty on Windows; skipping" >&2
+    exit 77
+fi
+python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_resize.XXXXXX") || exit 1
+serverpid=
+cleanup() {
+    stop_server "$serverpid"
+    rm -rf "$tmpdir"
+}
+trap cleanup EXIT HUP INT QUIT PIPE TERM
+
+serverlog="${tmpdir}/server.log"
+: >"$serverlog"
+"$python" "$server" --root "$root" >"$serverlog" 2>&1 &
+serverpid=$!
+port=
+for _ in $(seq 1 50); do
+    line=$(head -n1 "$serverlog" 2>/dev/null)
+    if test "${line%% *}" == "PORT"; then
+        port="${line#PORT }"
+        break
+    fi
+    kill -0 "$serverpid" 2>/dev/null || {
+        echo "server exited early: $(cat "$serverlog")"
+        exit 1
+    }
+    sleep 0.1
+done
+test -n "$port" || {
+    echo "could not discover server port"
+    exit 1
+}
+
+which httrack >/dev/null || {
+    echo "could not find httrack"
+    exit 1
+}
+
+# The trickled pages keep the display animating long enough to resize under it.
+out="${tmpdir}/crawl"
+mkdir "$out"
+"$python" "$driver" 2 8 "${tmpdir}/pty.raw" \
+    httrack "http://127.0.0.1:${port}/trickle/index.html" \
+    -O "$out" -%v --robots=0 --disable-security-limits \
+    --timeout=30 --retries=1 -c4 --max-time 6
+rc=$?
+test $rc -eq 0 || {
+    echo "pty capture head:"
+    head -c 400 "${tmpdir}/pty.raw" | cat -v
+    exit 1
+}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,6 +4,7 @@
 EXTRA_DIST = $(TESTS) crawl-test.sh run-all-tests.sh check-network.sh \
 	proxy-https-server.py socks5-server.py proxy-connect-server.py \
 	proxytestlib.py tls-stall-server.py warc-validate.py wacz-validate.py \
+	pty-resize.py \
 	local-crawl.sh local-server.py testlib.sh server.crt server.key \
 	server-root/simple/basic.html server-root/simple/link.html \
 	server-root/stripquery/index.html server-root/stripquery/a.html \
@@ -167,6 +168,7 @@ TESTS = \
 	73_local-warc.test \
 	74_local-warc-wacz.test \
 	74_local-warc-verbatim.test \
-	75_engine-longpath-posix.test
+	75_engine-longpath-posix.test \
+	76_cli-resize.test
 
 CLEANFILES = check-network_sh.cache

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -457,6 +457,9 @@ def _big_sitemap(port):
     ).encode()
 
 
+DEEPDIR = "/trickle/deep/a-long-directory-segment/another-long-segment"
+
+
 class Handler(SimpleHTTPRequestHandler):
     # Quieter logging; the launcher captures httrack's own log anyway.
     def log_message(self, fmt, *args):
@@ -1461,6 +1464,11 @@ class Handler(SimpleHTTPRequestHandler):
     def route_trickle_index(self):
         self.send_bin_index()
 
+    # #97: a path long enough that the CLI in-progress column truncates it at 80
+    # columns but not at 200. Its own index: /trickle/ is asserted on elsewhere.
+    def route_deeptrickle_index(self):
+        self.send_html('\t<a href="p0.bin">p0</a>\n\t<a href="p1.bin">p1</a>\n')
+
     def route_trickle_page(self):
         self.send_response(200)
         self.send_header("Content-Type", "application/octet-stream")
@@ -1646,6 +1654,9 @@ class Handler(SimpleHTTPRequestHandler):
         "/trickle/p5.bin": route_trickle_page,
         "/trickle/p6.bin": route_trickle_page,
         "/trickle/p7.bin": route_trickle_page,
+        DEEPDIR + "/index.html": route_deeptrickle_index,
+        DEEPDIR + "/p0.bin": route_trickle_page,
+        DEEPDIR + "/p1.bin": route_trickle_page,
         "/dcancel/index.html": route_dcancel_index,
         "/dcancel/p0.bin": route_dcancel_page,
         "/dcancel/p1.bin": route_dcancel_page,

--- a/tests/pty-resize.py
+++ b/tests/pty-resize.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Run a command on a pty, resize the pty mid-run, check the display repaints.
+
+Usage: pty-resize.py <resize-after-s> <deadline-s> <capture-file> <cmd> [args...]
+"""
+import fcntl
+import os
+import pty
+import select
+import signal
+import struct
+import subprocess
+import sys
+import termios
+import time
+
+CLEAR = b"\033[2J"
+RUNNING = b"Bytes saved"
+
+
+def set_size(fd, rows, cols):
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+
+
+def main():
+    resize_after = float(sys.argv[1])
+    deadline = float(sys.argv[2])
+    capture = sys.argv[3]
+    argv = sys.argv[4:]
+
+    master, slave = pty.openpty()
+    set_size(master, 24, 80)
+    proc = subprocess.Popen(
+        argv, stdin=slave, stdout=slave, stderr=slave, start_new_session=True
+    )
+    os.close(slave)
+
+    buf = bytearray()
+    resized_at = None
+    start = time.monotonic()
+    while True:
+        now = time.monotonic() - start
+        if now > deadline:
+            break
+        if resized_at is None and now >= resize_after:
+            set_size(master, 40, 100)
+            resized_at = len(buf)
+        ready, _, _ = select.select([master], [], [], 0.2)
+        if ready:
+            try:
+                data = os.read(master, 65536)
+            except OSError:
+                break
+            if not data:
+                break
+            buf += data
+        elif proc.poll() is not None:
+            break
+
+    if proc.poll() is None:
+        os.killpg(proc.pid, signal.SIGKILL)
+    proc.wait()
+    os.close(master)
+
+    with open(capture, "wb") as fp:
+        fp.write(buf)
+
+    if resized_at is None:
+        print("FAIL: process ended before the resize")
+        return 1
+    before, after = bytes(buf[:resized_at]), bytes(buf[resized_at:])
+    # Control: without a live display the redraw check would pass vacuously.
+    if RUNNING not in before:
+        print("FAIL: no progress display before the resize (%d bytes)" % len(before))
+        return 1
+    if CLEAR not in after:
+        print("FAIL: no full redraw after the resize (%d bytes)" % len(after))
+        return 1
+    print("ok: redraw seen %d bytes after the resize" % after.index(CLEAR))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/pty-resize.py
+++ b/tests/pty-resize.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Run a command on a pty, resize the pty mid-run, check the display repaints.
+"""Drive httrack on a pty and check the animated display follows the terminal.
 
-Usage: pty-resize.py <resize-after-s> <deadline-s> <capture-file> <cmd> [args...]
+Usage: pty-resize.py <capture-file> <long-url-prefix> -- <cmd> [args...]
 """
 import fcntl
 import os
@@ -15,69 +15,115 @@ import termios
 import time
 
 CLEAR = b"\033[2J"
-RUNNING = b"Bytes saved"
+FRAME = b"\033[1;1f"  # every refresh homes here before painting the stats
+LIVE = b"Bytes saved"
 
 
-def set_size(fd, rows, cols):
-    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+class Term:
+    def __init__(self, argv, capture):
+        self.capture = capture
+        self.buf = bytearray()
+        self.master, slave = pty.openpty()
+        self.resize(24, 80)
+        self.proc = subprocess.Popen(
+            argv, stdin=slave, stdout=slave, stderr=slave, start_new_session=True
+        )
+        os.close(slave)
+
+    def resize(self, rows, cols):
+        fcntl.ioctl(
+            self.master, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0)
+        )
+
+    def _read(self, timeout):
+        ready, _, _ = select.select([self.master], [], [], timeout)
+        if not ready:
+            return b""
+        try:
+            return os.read(self.master, 65536)
+        except OSError:
+            return b""
+
+    def pump(self, seconds):
+        """Read for the given window; return only the bytes read during it."""
+        mark = len(self.buf)
+        end = time.monotonic() + seconds
+        while time.monotonic() < end:
+            self.buf += self._read(0.1)
+        return bytes(self.buf[mark:])
+
+    def wait_for(self, pattern, timeout):
+        mark = len(self.buf)
+        end = time.monotonic() + timeout
+        while time.monotonic() < end:
+            self.buf += self._read(0.1)
+            if pattern in bytes(self.buf[mark:]):
+                return True
+            if self.proc.poll() is not None:
+                break
+        return False
+
+    def alive(self):
+        return self.proc.poll() is None
+
+    def close(self):
+        if self.alive():
+            os.killpg(self.proc.pid, signal.SIGKILL)
+        self.proc.wait()
+        os.close(self.master)
+        with open(self.capture, "wb") as fp:
+            fp.write(self.buf)
+
+
+def frame_heights(chunk):
+    """Newline count of each complete frame in the chunk."""
+    return [f.count(b"\n") for f in chunk.split(FRAME)[1:-1]]
 
 
 def main():
-    resize_after = float(sys.argv[1])
-    deadline = float(sys.argv[2])
-    capture = sys.argv[3]
-    argv = sys.argv[4:]
+    capture, long_url = sys.argv[1], sys.argv[2].encode()
+    argv = sys.argv[sys.argv.index("--") + 1 :]
+    term = Term(argv, capture)
+    failures = []
 
-    master, slave = pty.openpty()
-    set_size(master, 24, 80)
-    proc = subprocess.Popen(
-        argv, stdin=slave, stdout=slave, stderr=slave, start_new_session=True
-    )
-    os.close(slave)
+    def check(cond, msg):
+        if not cond:
+            failures.append(msg)
+        return cond
 
-    buf = bytearray()
-    resized_at = None
-    start = time.monotonic()
-    while True:
-        now = time.monotonic() - start
-        if now > deadline:
-            break
-        if resized_at is None and now >= resize_after:
-            set_size(master, 40, 100)
-            resized_at = len(buf)
-        ready, _, _ = select.select([master], [], [], 0.2)
-        if ready:
-            try:
-                data = os.read(master, 65536)
-            except OSError:
-                break
-            if not data:
-                break
-            buf += data
-        elif proc.poll() is not None:
-            break
+    try:
+        if not check(term.wait_for(LIVE, 15), "the display never started"):
+            return 1
 
-    if proc.poll() is None:
-        os.killpg(proc.pid, signal.SIGKILL)
-    proc.wait()
-    os.close(master)
+        # Steady state: a repaint here would mask any resize-driven one below.
+        idle = term.pump(1.0)
+        check(CLEAR not in idle, "repaint without a resize")
+        check(long_url not in idle, "long URL not truncated at 80 columns")
 
-    with open(capture, "wb") as fp:
-        fp.write(buf)
+        term.resize(24, 120)
+        check(term.wait_for(CLEAR, 3), "no repaint after a width-only resize")
+        check(CLEAR not in term.pump(1.0), "repaint kept firing after the resize")
 
-    if resized_at is None:
-        print("FAIL: process ended before the resize")
-        return 1
-    before, after = bytes(buf[:resized_at]), bytes(buf[resized_at:])
-    # Control: without a live display the redraw check would pass vacuously.
-    if RUNNING not in before:
-        print("FAIL: no progress display before the resize (%d bytes)" % len(before))
-        return 1
-    if CLEAR not in after:
-        print("FAIL: no full redraw after the resize (%d bytes)" % len(after))
-        return 1
-    print("ok: redraw seen %d bytes after the resize" % after.index(CLEAR))
-    return 0
+        term.resize(10, 120)
+        check(term.wait_for(CLEAR, 3), "no repaint after a height-only resize")
+        heights = frame_heights(term.pump(1.0))
+        check(heights, "no frame after the height change")
+        check(
+            all(h <= 9 for h in heights),
+            "frame overflows a 10-row terminal: %s" % heights,
+        )
+
+        term.resize(24, 200)
+        check(term.wait_for(CLEAR, 3), "no repaint after growing the terminal")
+        check(long_url in term.pump(1.0), "long URL still truncated at 200 columns")
+
+        check(term.alive(), "httrack died mid-run (exit %s)" % term.proc.poll())
+    finally:
+        term.close()
+
+    for msg in failures:
+        print("FAIL: %s" % msg)
+    return 1 if failures else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The animated `-%v` display assumed a fixed 80x24 terminal: it cleared the screen once at startup, and afterwards cleared only to end of line on the rows it wrote. Resizing left stale wrapped text on screen, and on a terminal shorter than the 20-row frame the stats block scrolled away at every refresh.

It now polls the terminal size at each refresh (every 100ms) and repaints in full when it changed. The in-progress list is capped to the rows that fit, and the URL column follows the width, unchanged on an 80-column terminal. Polling instead of SIGWINCH keeps a single code path for POSIX and the Windows console, and the size only matters at the moments we redraw.

`76_cli-resize.test` runs httrack under a pty and resizes it in width and in height separately, asserting that each resize repaints, that nothing repaints in between, that the frame fits a 10-row terminal, and that a long URL stops being truncated once the terminal is wide enough. Mutating any of those four behaviors away fails the test.

Closes #97