### PR TITLE
No UTF-8 to system-codepage conversion is exported to the Windows GUI

### DIFF
--- a/src/htscharset.c
+++ b/src/htscharset.c
@@ -390,6 +390,10 @@ HTSEXT_API char *hts_convertStringSystemToUTF8(const char *s, size_t size) {
   return hts_convertStringCPToUTF8(s, size, GetACP());
 }
 
+HTSEXT_API char *hts_convertStringUTF8ToSystem(const char *s, size_t size) {
+  return hts_convertStringCPFromUTF8(s, size, GetACP());
+}
+
 HTSEXT_API void hts_argv_utf8(int *pargc, char ***pargv) {
   int wargc = 0;
   LPWSTR *const wargv = CommandLineToArgvW(GetCommandLineW(), &wargc);

--- a/src/htscharset.h
+++ b/src/htscharset.h
@@ -185,6 +185,12 @@ extern LPWSTR hts_pathToUCS2(const char *path);
 HTSEXT_API char *hts_convertStringSystemToUTF8(const char *s, size_t size);
 
 /**
+ * Convert UTF-8 to the current system codepage. Caller frees; NULL upon error.
+ * This function is WIN32 specific.
+ **/
+HTSEXT_API char *hts_convertStringUTF8ToSystem(const char *s, size_t size);
+
+/**
  * Replace the CRT's ANSI argv by a UTF-8 one decoded from the real UTF-16
  * command line: every char* is UTF-8 on Windows (FOPEN, STAT, ... convert at
  * the syscall boundary). Keeps the CRT's argv on failure; the new array is

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -887,6 +887,54 @@ static int st_charset(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* hts_convertStringUTF8ToSystem: the UTF-8 -> ANSI leg an MBCS GUI needs at the
+   Win32 ANSI entry points. Oracle is the raw two-step Win32 dance it replaces,
+   so a mis-wired direction or a plain copy fails whatever the machine's ACP. */
+static int st_syscharset(httrackp *opt, int argc, char **argv) {
+#ifdef _WIN32
+  static const char *const utf8 = "caf\xC3\xA9 \xE2\x82\xAC"; /* "café €" */
+  const UINT cp = GetACP();
+  const int len = (int) strlen(utf8);
+  WCHAR wide[64];
+  char want[64];
+  char *sys, *back;
+  BOOL lossy = FALSE;
+  int wn, n;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+  wn = MultiByteToWideChar(CP_UTF8, 0, utf8, len, wide,
+                           (int) (sizeof(wide) / sizeof(wide[0])));
+  assertf(wn > 0);
+  /* lpUsedDefaultChar is rejected for CP_UTF8, and pointless there anyway */
+  n = WideCharToMultiByte(cp, 0, wide, wn, want, (int) sizeof(want) - 1, NULL,
+                          cp == CP_UTF8 ? NULL : &lossy);
+  assertf(n > 0);
+  want[n] = '\0';
+
+  sys = hts_convertStringUTF8ToSystem(utf8, (size_t) len);
+  assertf(sys != NULL);
+  assertf(strcmp(sys, want) == 0);
+  /* only round-trips when the ACP could hold é and € without substitution */
+  if (!lossy) {
+    back = hts_convertStringSystemToUTF8(sys, strlen(sys));
+    assertf(back != NULL);
+    assertf(strcmp(back, utf8) == 0);
+    freet(back);
+  }
+  freet(sys);
+  printf("syscharset: acp=%u %s: OK\n", (unsigned) cp,
+         lossy ? "one-way" : "round-trip");
+  return 0;
+#else
+  (void) opt;
+  (void) argc;
+  (void) argv;
+  return 77; /* WIN32-only entry point */
+#endif
+}
+
 static int st_metacharset(httrackp *opt, int argc, char **argv) {
   char *s;
 
@@ -4732,6 +4780,8 @@ static const struct selftest_entry {
     {"mime", "<filename>", "MIME type for a filename", st_mime},
     {"charset", "<charset> <hex:..|string>",
      "convert a string to UTF-8 from a charset", st_charset},
+    {"syscharset", "", "UTF-8 <-> system codepage conversion (WIN32 only)",
+     st_syscharset},
     {"metacharset", "<html>", "extract the <meta> charset from an HTML page",
      st_metacharset},
     {"isutf8", "<hex:..|string>", "is the string valid UTF-8 (1/0)", st_isutf8},

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -887,19 +887,17 @@ static int st_charset(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-/* hts_convertStringUTF8ToSystem: the UTF-8 -> ANSI leg an MBCS GUI needs at the
-   Win32 ANSI entry points. Oracle is the raw two-step Win32 dance it replaces,
-   so a mis-wired direction or a plain copy fails whatever the machine's ACP. */
+/* Oracle is the raw Win32 two-step this replaces, so a mis-wired direction or
+   a plain copy fails whatever the machine's ACP. */
 static int st_syscharset(httrackp *opt, int argc, char **argv) {
 #ifdef _WIN32
   static const char *const utf8 = "caf\xC3\xA9 \xE2\x82\xAC"; /* "café €" */
   const UINT cp = GetACP();
   const int len = (int) strlen(utf8);
-  WCHAR wide[64];
+  WCHAR wide[64], round[64];
   char want[64];
-  char *sys, *back;
-  BOOL lossy = FALSE;
-  int wn, n;
+  char *sys, *back, *part;
+  int wn, n, lossless;
 
   (void) opt;
   (void) argc;
@@ -907,17 +905,31 @@ static int st_syscharset(httrackp *opt, int argc, char **argv) {
   wn = MultiByteToWideChar(CP_UTF8, 0, utf8, len, wide,
                            (int) (sizeof(wide) / sizeof(wide[0])));
   assertf(wn > 0);
-  /* lpUsedDefaultChar is rejected for CP_UTF8, and pointless there anyway */
   n = WideCharToMultiByte(cp, 0, wide, wn, want, (int) sizeof(want) - 1, NULL,
-                          cp == CP_UTF8 ? NULL : &lossy);
+                          NULL);
   assertf(n > 0);
   want[n] = '\0';
+  /* the ACP holds the string only if its bytes decode back to the same UTF-16;
+     lpUsedDefaultChar would miss a best-fit mapping (é to a bare e) */
+  lossless =
+      MultiByteToWideChar(cp, 0, want, n, round,
+                          (int) (sizeof(round) / sizeof(round[0]))) == wn &&
+      memcmp(round, wide, (size_t) wn * sizeof(WCHAR)) == 0;
 
   sys = hts_convertStringUTF8ToSystem(utf8, (size_t) len);
   assertf(sys != NULL);
   assertf(strcmp(sys, want) == 0);
-  /* only round-trips when the ACP could hold é and € without substitution */
-  if (!lossy) {
+  assertf(strlen(sys) == (size_t) n); /* NUL-terminated, nothing past it */
+  /* the copy the ASCII fast path returns is a pass on a UTF-8 ACP only */
+  assertf(cp == CP_UTF8 || strcmp(sys, utf8) != 0);
+  /* size bounds the read: a caller-given length, not strlen() */
+  part = hts_convertStringUTF8ToSystem(utf8, 3);
+  assertf(part != NULL && strcmp(part, "caf") == 0);
+  freet(part);
+  part = hts_convertStringUTF8ToSystem(utf8, 0);
+  assertf(part != NULL && *part == '\0');
+  freet(part);
+  if (lossless) {
     back = hts_convertStringSystemToUTF8(sys, strlen(sys));
     assertf(back != NULL);
     assertf(strcmp(back, utf8) == 0);
@@ -925,7 +937,7 @@ static int st_syscharset(httrackp *opt, int argc, char **argv) {
   }
   freet(sys);
   printf("syscharset: acp=%u %s: OK\n", (unsigned) cp,
-         lossy ? "one-way" : "round-trip");
+         lossless ? "round-trip" : "one-way");
   return 0;
 #else
   (void) opt;

--- a/tests/01_engine-syscharset.test
+++ b/tests/01_engine-syscharset.test
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# UTF-8 <-> system codepage ('httrack -#test=syscharset'), the pair an MBCS GUI
+# uses at the Win32 ANSI entry points. WIN32 only, skipped elsewhere.
+
+set -euo pipefail
+
+rc=0
+out=$(httrack -O /dev/null -#test=syscharset) || rc=$?
+echo "$out"
+
+[ "$rc" = 77 ] && exit 77
+[ "$rc" = 0 ] || exit "$rc"
+
+case "$out" in
+"syscharset: acp="*": OK") ;;
+*)
+    echo "FAIL: unexpected report"
+    exit 1
+    ;;
+esac

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -77,6 +77,7 @@ TESTS = \
 	01_engine-status.test \
 	01_engine-stripquery.test \
 	01_engine-strsafe.test \
+	01_engine-syscharset.test \
 	01_engine-topindex.test \
 	01_engine-urlhack.test \
 	01_engine-unescape-bounds.test \


### PR DESCRIPTION
WinHTTrack is an MBCS build, so it still lands on the ANSI-only Win32 entry points (TTN_NEEDTEXTA and the like) while the engine hands it UTF-8. The other direction is already exported as `hts_convertStringSystemToUTF8`, so this adds the mirror, `hts_convertStringUTF8ToSystem`, a one-liner over the existing `hts_convertStringCPFromUTF8`. The GUI can then delegate instead of keeping its own MultiByteToWideChar/WideCharToMultiByte copy (`CopyTextUTF8ToCP` in newlang.cpp, added while fixing #114). `hts_convertStringFromUTF8` would also have done the job, but it is declared plain `extern` and never reaches the DLL export table; left alone here. Windows-only addition, so no POSIX ABI change and no soname move.

The new `-#test=syscharset` self-test round-trips against the raw Win32 two-step it replaces, and skips off Windows.