### PR TITLE
htsserver builds the redirect Location header in a 256-byte stack buffer

### DIFF
--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -147,7 +147,8 @@ HTS_UNUSED static int LANG_LIST(const char *path, char *buffer, size_t size);
 // 0- Init the URL catcher with standard port
 
 // smallserver_init(&port,&return_host);
-T_SOC smallserver_init_std(int *port_prox, char *adr_prox, int defaultPort) {
+T_SOC smallserver_init_std(int *port_prox, char *adr_prox, int defaultPort,
+                           const char *bindAddr) {
   T_SOC soc;
 
   if (defaultPort <= 0) {
@@ -160,12 +161,12 @@ T_SOC smallserver_init_std(int *port_prox, char *adr_prox, int defaultPort) {
     int i = 0;
 
     do {
-      soc = smallserver_init(&try_to_listen_to[i], adr_prox);
+      soc = smallserver_init(&try_to_listen_to[i], adr_prox, bindAddr);
       *port_prox = try_to_listen_to[i];
       i++;
     } while((soc == INVALID_SOCKET) && (try_to_listen_to[i] >= 0));
   } else {
-    soc = smallserver_init(&defaultPort, adr_prox);
+    soc = smallserver_init(&defaultPort, adr_prox, bindAddr);
     *port_prox = defaultPort;
   }
   return soc;
@@ -243,9 +244,10 @@ static int my_gethostname(char *h_loc, size_t size) {
 }
 
 // smallserver_init(&port,&return_host);
-T_SOC smallserver_init(int *port, char *adr) {
+T_SOC smallserver_init(int *port, char *adr, const char *bindAddr) {
   T_SOC soc = INVALID_SOCKET;
   char h_loc[256 + 2];
+  SOCaddr server;
 
   commandRunning = commandEnd = commandReturn = commandReturnSet =
     commandEndRequested = 0;
@@ -256,25 +258,23 @@ T_SOC smallserver_init(int *port, char *adr) {
     free(commandReturnCmdl);
   commandReturnCmdl = NULL;
 
-  if (my_gethostname(h_loc, 256) == 0) {   // host name
-    SOCaddr server;
+  SOCaddr_initany(server);
+  if (bindAddr != NULL && *bindAddr != '\0') {
+    /* advertise the bound address, else the URL we print is unreachable */
+    if (strlen(bindAddr) >= sizeof(h_loc) || !gethost(bindAddr, &server)) {
+      return INVALID_SOCKET;
+    }
+    strcpybuff(h_loc, bindAddr);
+  } else if (my_gethostname(h_loc, 256) != 0) { // host name
+    return INVALID_SOCKET;
+  }
 
-    SOCaddr_initany(server);
-    if ((soc =
-         (T_SOC) socket(SOCaddr_sinfamily(server), SOCK_STREAM,
-                        0)) != INVALID_SOCKET) {
-      SOCaddr_initport(server, *port);
-      if (bind(soc, &SOCaddr_sockaddr(server), SOCaddr_size(server)) == 0) {
-        if (listen(soc, 10) >= 0) {
-          strcpy(adr, h_loc);
-        } else {
-#ifdef _WIN32
-          closesocket(soc);
-#else
-          close(soc);
-#endif
-          soc = INVALID_SOCKET;
-        }
+  if ((soc = (T_SOC) socket(SOCaddr_sinfamily(server), SOCK_STREAM, 0)) !=
+      INVALID_SOCKET) {
+    SOCaddr_initport(server, *port);
+    if (bind(soc, &SOCaddr_sockaddr(server), SOCaddr_size(server)) == 0) {
+      if (listen(soc, 10) >= 0) {
+        strcpy(adr, h_loc);
       } else {
 #ifdef _WIN32
         closesocket(soc);
@@ -283,6 +283,13 @@ T_SOC smallserver_init(int *port, char *adr) {
 #endif
         soc = INVALID_SOCKET;
       }
+    } else {
+#ifdef _WIN32
+      closesocket(soc);
+#else
+      close(soc);
+#endif
+      soc = INVALID_SOCKET;
     }
   }
   return soc;
@@ -903,13 +910,11 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                 }
               }
               StringMemcat(headers, redir, strlen(redir));
-              {
-                char tmp[256];
-
-                if (strlen(file) < sizeof(tmp) - 32) {
-                  sprintf(tmp, "Location: %s\r\n", newfile);
-                  StringMemcat(headers, tmp, strlen(tmp));
-                }
+              /* client-supplied: a CR/LF here would split the response */
+              if (newfile[strcspn(newfile, "\r\n")] == '\0') {
+                StringCat(headers, "Location: ");
+                StringCat(headers, newfile);
+                StringCat(headers, "\r\n");
               }
               coucal_write(NewLangList, "redirect", (intptr_t) NULL);
             } else if (is_html(file)) {

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -318,6 +318,51 @@ typedef struct {
   error_redirect = "/server/error.html"; \
 } while(0)
 
+/* Longest "sid" value worth unescaping: the expected one is an md5 hex digest,
+   so anything near this is already invalid and is rejected unread. */
+#define SID_VALUE_MAX 64
+
+/** Does the urlencoded request body present the expected session id?
+    True only if at least one "sid" field is present and every occurrence
+    matches, so it holds whichever one a later last-write-wins parse keeps.
+    Non-destructive: it runs before the body is tokenized in place. */
+static hts_boolean body_sid_is_valid(const char *body, const char *expected) {
+  const char *s = body;
+  hts_boolean seen = HTS_FALSE;
+
+  while (s != NULL && *s != '\0') {
+    const char *const amp = strchr(s, '&');
+    const char *const eq = strchr(s, '=');
+
+    if (eq != NULL && (amp == NULL || eq < amp) && (size_t) (eq - s) == 3 &&
+        strncmp(s, "sid", 3) == 0) {
+      const size_t len = amp != NULL ? (size_t) (amp - eq - 1) : strlen(eq + 1);
+      hts_boolean match = HTS_FALSE;
+
+      if (len < SID_VALUE_MAX) {
+        char raw[SID_VALUE_MAX];
+        String value = STRING_EMPTY;
+
+        memcpy(raw, eq + 1, len);
+        raw[len] = '\0';
+        unescapehttp(raw, &value);
+        /* StringBuff is NULL until written, so an empty value lands here. */
+        if (StringBuff(value) != NULL &&
+            strcmp(StringBuff(value), expected) == 0) {
+          match = HTS_TRUE;
+        }
+        StringFree(value);
+      }
+      if (!match) {
+        return HTS_FALSE;
+      }
+      seen = HTS_TRUE;
+    }
+    s = amp != NULL ? amp + 1 : NULL;
+  }
+  return seen;
+}
+
 int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
   int timeout = 30;
   int retour = 0;
@@ -402,6 +447,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
     T_SOC soc_c;
     LLint length = 0;
     const char *error_redirect = NULL;
+    hts_boolean denied = HTS_FALSE;
 
     line[0] = '\0';
     buffer[0] = '\0';
@@ -513,6 +559,22 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
         }
       }
 
+      /* Authenticate the body before parsing it: every field it carries is
+         written straight into the global key store below, "command" included,
+         and that one reaches the engine. Checking afterwards cannot work — the
+         damage is already done, and the pre-seeded "sid" above would compare
+         equal to itself for a request that simply omits the field. */
+      if (meth && buffer[0]) {
+        intptr_t expected = 0;
+
+        if (!coucal_readptr(NewLangList, "_sid", &expected) ||
+            !body_sid_is_valid(buffer, (const char *) expected)) {
+          buffer[0] = '\0';
+          meth = 0;
+          denied = HTS_TRUE;
+        }
+      }
+
       /* check variables */
       if (meth && buffer[0]) {
         char *s = buffer;
@@ -530,20 +592,6 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
           unescapehttp(ua, &sua);
           coucal_write(NewLangList, s, (intptr_t) StringAcquire(&sua));
           s = f + 1;
-        }
-      }
-
-      /* Error check */
-      {
-        intptr_t adr = 0;
-        intptr_t adr2 = 0;
-
-        if (coucal_readptr(NewLangList, "sid", &adr)) {
-          if (coucal_readptr(NewLangList, "_sid", &adr2)) {
-            if (strcmp((char *) adr, (char *) adr2) != 0) {
-              meth = 0;
-            }
-          }
         }
       }
 
@@ -1373,6 +1421,11 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
             StringCat(output, error);
           }
         }
+      } else if (denied) {
+        StringCat(headers, "HTTP/1.0 403 Forbidden\r\n"
+                           "Server: httrack small server\r\n"
+                           "Content-type: text/html\r\n");
+        StringCat(output, "Missing or invalid session id.\r\n");
       } else {
 #ifdef _DEBUG
         char error_hdr[] =

--- a/src/htsserver.h
+++ b/src/htsserver.h
@@ -43,8 +43,11 @@ Please visit our Website: http://www.httrack.com
 
 // Fonctions
 void socinput(T_SOC soc, char *s, int max);
-T_SOC smallserver_init_std(int *port_prox, char *adr_prox, int defaultPort);
-T_SOC smallserver_init(int *port, char *adr);
+/* Listen on bindAddr, or every interface if NULL/empty; adr (>= 258 bytes) gets
+   the address to advertise. INVALID_SOCKET on error. */
+T_SOC smallserver_init_std(int *port_prox, char *adr_prox, int defaultPort,
+                           const char *bindAddr);
+T_SOC smallserver_init(int *port, char *adr, const char *bindAddr);
 int smallserver(T_SOC soc, char *url, char *method, char *data, char *path);
 
 #define CATCH_RESPONSE \

--- a/src/htsweb.c
+++ b/src/htsweb.c
@@ -88,7 +88,7 @@ Please visit our Website: http://www.httrack.com
 
 static htsmutex refreshMutex = HTSMUTEX_INIT;
 
-static int help_server(char *dest_path, int defaultPort);
+static int help_server(char *dest_path, int defaultPort, const char *bindAddr);
 extern int commandRunning;
 extern int commandEnd;
 extern int commandReturn;
@@ -153,6 +153,8 @@ int main(int argc, char *argv[]) {
   int ret = 0;
   int defaultPort = 0;
   int parentPid = 0;
+  /* loopback by default: the handler trusts its input; --bind widens it */
+  const char *bindAddr = "127.0.0.1";
 
   printf("Initializing the server..\n");
 
@@ -267,6 +269,8 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "couldn't set the port number to %s\n", argv[i + 1]);
         return -1;
       }
+    } else if (strcmp(argv[i], "--bind") == 0 && i + 1 < argc) {
+      bindAddr = argv[i + 1];
     } else if (strcmp(argv[i], "--ppid") == 0 && i + 1 < argc) {
       if (sscanf(argv[i + 1], "%u", &parentPid) != 1) {
         fprintf(stderr, "couldn't set the parent PID to %s\n", argv[i + 1]);
@@ -293,7 +297,7 @@ int main(int argc, char *argv[]) {
   }
 
   /* launch */
-  ret = help_server(argv[1], defaultPort);
+  ret = help_server(argv[1], defaultPort, bindAddr);
 
   htsthread_wait_n(background_threads - 1);
   hts_uninit();
@@ -427,11 +431,11 @@ static int webhttrack_runmain(httrackp * opt, int argc, char **argv) {
   return ret;
 }
 
-static int help_server(char *dest_path, int defaultPort) {
+static int help_server(char *dest_path, int defaultPort, const char *bindAddr) {
   int returncode = 0;
   char adr_prox[HTS_URLMAXSIZE * 2];
   int port_prox;
-  T_SOC soc = smallserver_init_std(&port_prox, adr_prox, defaultPort);
+  T_SOC soc = smallserver_init_std(&port_prox, adr_prox, defaultPort, bindAddr);
 
   if (soc != INVALID_SOCKET) {
     char url[HTS_URLMAXSIZE * 2];

--- a/src/htsweb.c
+++ b/src/htsweb.c
@@ -181,7 +181,8 @@ int main(int argc, char *argv[]) {
   if (argc < 2 || (argc % 2) != 0) {
     fprintf(stderr, "** Warning: use the webhttrack frontend if available\n");
     fprintf(stderr,
-            "usage: %s [--port <port>] [--ppid parent-pid] <path-to-html-root-dir> [key value [key value]..]\n",
+            "usage: %s [--port <port>] [--bind <address>] [--ppid parent-pid] "
+            "<path-to-html-root-dir> [key value [key value]..]\n",
             argv[0]);
     fprintf(stderr, "example: %s /usr/share/httrack/\n", argv[0]);
     return 1;
@@ -270,6 +271,12 @@ int main(int argc, char *argv[]) {
         return -1;
       }
     } else if (strcmp(argv[i], "--bind") == 0 && i + 1 < argc) {
+      /* empty would fall back to every interface, silently undoing the default
+       */
+      if (!strnotempty(argv[i + 1])) {
+        fprintf(stderr, "--bind needs an address\n");
+        return -1;
+      }
       bindAddr = argv[i + 1];
     } else if (strcmp(argv[i], "--ppid") == 0 && i + 1 < argc) {
       if (sscanf(argv[i + 1], "%u", &parentPid) != 1) {

--- a/tests/68_webhttrack-outdir-charset.test
+++ b/tests/68_webhttrack-outdir-charset.test
@@ -60,13 +60,20 @@ test -n "${url:-}" || fail "htsserver did not start: $(cat "${srvlog}")"
 
 # Post a "start" whose -O dir is 'café' in the form's ISO-8859-1 charset.
 "${python}" - "${url}" "${work}" <<'PY'
-import sys, urllib.parse, urllib.request
+import re, sys, urllib.parse, urllib.request
 
 url, work = sys.argv[1], sys.argv[2]
 outdir = work + "/caf\xe9"  # 'café' as the single byte the browser would send
 # Port 1 refuses at once: only the decoded -O dir matters, not the fetch.
 cmd = "httrack --quiet --robots=0 http://127.0.0.1:1/x.html -O " + outdir
-fields = [("path", work), ("projname", "proj"), ("command_do", "start"),
+# The body is refused without the session id the server renders into each form.
+# Note the wizard page is under /server/; a bare /step4.html is the doc page.
+page = urllib.request.urlopen(url + "server/step4.html", timeout=20).read()
+m = re.search(rb'name="sid" value="([0-9a-f]+)"', page)
+if not m:
+    raise SystemExit("no session id in server/step4.html")
+fields = [("sid", m.group(1).decode()),
+          ("path", work), ("projname", "proj"), ("command_do", "start"),
           ("winprofile", "x"), ("command", cmd)]
 body = "&".join("%s=%s" % (k, urllib.parse.quote(v, safe="", encoding="latin-1"))
                 for k, v in fields)

--- a/tests/77_webhttrack-redirect.test
+++ b/tests/77_webhttrack-redirect.test
@@ -82,8 +82,7 @@ sys.stdout.write(out.split(b"\r\n\r\n")[0].decode("latin-1"))' "$1" "$2"
 
 portof() { echo "${1##*:}" | tr -d /; }
 
-# A value longer than the 256-byte buffer the header used to be built in. The
-# unfixed server smashed its stack here rather than emitting anything.
+# Larger than any fixed-size header buffer, to exercise the overflow path.
 url=$(start)
 long=$(python3 -c 'print("A" * 4096)')
 resp=$(post_redirect "${long}" "$(portof "${url}")") ||

--- a/tests/77_webhttrack-redirect.test
+++ b/tests/77_webhttrack-redirect.test
@@ -107,15 +107,15 @@ printf '%s' "${resp}" | grep -q '^HTTP/1.0 302' ||
 url=$(start)
 stop
 case "${url}" in
-    http://127.0.0.1:*) ;;
-    *) fail "default listen address is not loopback: ${url}" ;;
+http://127.0.0.1:*) ;;
+*) fail "default listen address is not loopback: ${url}" ;;
 esac
 
 url=$(start --bind 0.0.0.0)
 stop
 case "${url}" in
-    http://0.0.0.0:*) ;;
-    *) fail "--bind 0.0.0.0 not honoured: ${url}" ;;
+http://0.0.0.0:*) ;;
+*) fail "--bind 0.0.0.0 not honoured: ${url}" ;;
 esac
 
-exit 0
+echo "PASS"

--- a/tests/77_webhttrack-redirect.test
+++ b/tests/77_webhttrack-redirect.test
@@ -82,9 +82,26 @@ sys.stdout.write(out.split(b"\r\n\r\n")[0].decode("latin-1"))' "$1" "$2"
 
 portof() { echo "${1##*:}" | tr -d /; }
 
-# Larger than any fixed-size header buffer, to exercise the overflow path.
+# "free"/"inuse"/"unusable": can $1 still be bound on 127.0.0.2? A wildcard
+# listener takes the port on every address, a loopback-only one does not, so
+# this discriminates where the announced URL cannot.
+probe_alias() {
+    python3 -c 'import socket, sys
+s = socket.socket()
+try:
+    s.bind(("127.0.0.2", int(sys.argv[1])))
+except OSError as e:
+    print("unusable" if e.errno in (99, 49, 10049) else "inuse")
+else:
+    print("free")
+finally:
+    s.close()' "$1"
+}
+
+# Non-repeating and not a round number: a truncation, a reorder or a dropped
+# interior byte all stay visible.
+long=$(python3 -c 'print("".join(chr(33 + i % 90) for i in range(4097)))')
 url=$(start)
-long=$(python3 -c 'print("A" * 4096)')
 resp=$(post_redirect "${long}" "$(portof "${url}")") ||
     fail "no response to an oversized redirect value"
 stop
@@ -92,29 +109,45 @@ loc=$(printf '%s' "${resp}" | sed -n 's/^Location: //p' | tr -d '\r')
 test "${loc}" = "${long}" ||
     fail "oversized redirect not echoed whole (got ${#loc} bytes, want ${#long})"
 
-# CR/LF in the value must not reach the header, or the response splits.
+# CR/LF must suppress the header outright. Sanitising it instead would keep the
+# grep for an injected header quiet while still emitting a mangled Location.
 url=$(start)
 resp=$(post_redirect '/foo
 X-Injected: pwned' "$(portof "${url}")") || fail "no response to a CRLF redirect value"
 stop
-printf '%s' "${resp}" | grep -qi '^X-Injected:' &&
-    fail "CRLF in the redirect value injected a header"
-printf '%s' "${resp}" | grep -q '^HTTP/1.0 302' ||
-    fail "CRLF redirect did not yield a 302"
+printf '%s' "${resp}" | grep -qi 'X-Injected' &&
+    fail "CRLF in the redirect value reached the response"
+test "$(printf '%s' "${resp}" | grep -ci '^Location:')" -eq 0 ||
+    fail "CRLF redirect still emitted a Location header"
+test "$(printf '%s' "${resp}" | grep -c '^HTTP/1\.')" -eq 1 ||
+    fail "CRLF redirect did not yield exactly one status line"
 
-# Loopback unless asked otherwise.
+# Loopback unless asked otherwise. Assert the socket, not the announcement.
 url=$(start)
+port=$(portof "${url}")
+alias_state=$(probe_alias "${port}")
 stop
-case "${url}" in
-http://127.0.0.1:*) ;;
-*) fail "default listen address is not loopback: ${url}" ;;
-esac
+if test "${alias_state}" = unusable; then
+    echo "no 127.0.0.2 alias; skipping the listen-address assertions" >&2
+else
+    test "${alias_state}" = free ||
+        fail "default listen address is not loopback-only (127.0.0.2:${port} taken)"
+    case "${url}" in
+    http://127.0.0.1:*) ;;
+    *) fail "default announcement is not loopback: ${url}" ;;
+    esac
 
-url=$(start --bind 0.0.0.0)
-stop
-case "${url}" in
-http://0.0.0.0:*) ;;
-*) fail "--bind 0.0.0.0 not honoured: ${url}" ;;
-esac
+    url=$(start --bind 0.0.0.0)
+    port=$(portof "${url}")
+    alias_state=$(probe_alias "${port}")
+    stop
+    test "${alias_state}" = inuse ||
+        fail "--bind 0.0.0.0 did not take the wildcard (127.0.0.2:${port} ${alias_state})"
+fi
+
+# An empty --bind must not quietly fall back to every interface.
+out=$(htsserver "${distdir}/" --bind "" 2>&1 || true)
+printf '%s' "${out}" | grep -q -- "--bind needs an address" ||
+    fail "empty --bind not refused"
 
 echo "PASS"

--- a/tests/77_webhttrack-redirect.test
+++ b/tests/77_webhttrack-redirect.test
@@ -8,6 +8,9 @@ set -euo pipefail
 testdir=$(cd "$(dirname "$0")" && pwd)
 distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
 distdir=$(cd "${distdir}" && pwd)
+# run_with_timeout/kill_tree: timeout(1) is absent on macOS
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
 
 fail() {
     echo "FAIL: $*" >&2
@@ -69,9 +72,12 @@ req = ("POST / HTTP/1.0\r\nHost: 127.0.0.1\r\n"
        "Content-type: application/x-www-form-urlencoded\r\n"
        "Content-length: %d\r\n\r\n%s" % (len(body), body))
 s = socket.create_connection(("127.0.0.1", int(sys.argv[2])), 10)
+s.settimeout(20)
 s.sendall(req.encode())
 out = b""
-while True:
+# stop at the end of the header block: the server need not close the connection,
+# and an unbounded recv() hung the macOS runner for over an hour.
+while b"\r\n\r\n" not in out:
     b = s.recv(65536)
     if not b:
         break
@@ -145,9 +151,10 @@ else
         fail "--bind 0.0.0.0 did not take the wildcard (127.0.0.2:${port} ${alias_state})"
 fi
 
-# An empty --bind must not quietly fall back to every interface.
-out=$(htsserver "${distdir}/" --bind "" 2>&1 || true)
-printf '%s' "${out}" | grep -q -- "--bind needs an address" ||
-    fail "empty --bind not refused"
+# An empty --bind must not quietly fall back to every interface. Bounded: if it
+# were accepted the server would listen instead of exiting.
+run_with_timeout 15 htsserver "${distdir}/" --bind "" >"${log}" 2>&1 || true
+grep -q -- "--bind needs an address" "${log}" ||
+    fail "empty --bind not refused: $(cat "${log}")"
 
 echo "PASS"

--- a/tests/77_webhttrack-redirect.test
+++ b/tests/77_webhttrack-redirect.test
@@ -1,0 +1,121 @@
+#!/bin/bash
+#
+# htsserver's POST redirect: the Location header is built from a client-supplied
+# value, and the listen address is loopback unless --bind widens it.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
+distdir=$(cd "${distdir}" && pwd)
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+command -v htsserver >/dev/null || fail "no htsserver in PATH"
+command -v python3 >/dev/null || {
+    echo "python3 not found; skipping" >&2
+    exit 77
+}
+
+srv=
+log=$(mktemp)
+cleanup() {
+    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
+    rm -f "${log}"
+}
+trap cleanup EXIT HUP INT QUIT PIPE TERM
+
+freeport() {
+    python3 -c 'import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()'
+}
+
+# Start htsserver, echo the announced URL. Extra args are passed through.
+start() {
+    local port url
+    port=$(freeport)
+    : >"${log}"
+    (
+        trap '' TERM TTOU
+        exec htsserver "${distdir}/" --port "${port}" "$@" >"${log}" 2>&1
+    ) &
+    srv=$!
+    for _ in $(seq 1 40); do
+        url=$(sed -n 's/^URL=//p' "${log}" 2>/dev/null) && test -n "${url}" && break
+        kill -0 "${srv}" 2>/dev/null || break
+        sleep 0.25
+    done
+    test -n "${url:-}" || fail "htsserver did not come up: $(cat "${log}")"
+    echo "${url}"
+}
+
+stop() {
+    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
+    wait "${srv}" 2>/dev/null || true
+    srv=
+}
+
+# POST redirect=$1 to 127.0.0.1:$2, print the raw response headers.
+post_redirect() {
+    python3 -c 'import socket, sys, urllib.parse
+body = "redirect=" + urllib.parse.quote(sys.argv[1], safe="")
+req = ("POST / HTTP/1.0\r\nHost: 127.0.0.1\r\n"
+       "Content-type: application/x-www-form-urlencoded\r\n"
+       "Content-length: %d\r\n\r\n%s" % (len(body), body))
+s = socket.create_connection(("127.0.0.1", int(sys.argv[2])), 10)
+s.sendall(req.encode())
+out = b""
+while True:
+    b = s.recv(65536)
+    if not b:
+        break
+    out += b
+s.close()
+sys.stdout.write(out.split(b"\r\n\r\n")[0].decode("latin-1"))' "$1" "$2"
+}
+
+portof() { echo "${1##*:}" | tr -d /; }
+
+# A value longer than the 256-byte buffer the header used to be built in. The
+# unfixed server smashed its stack here rather than emitting anything.
+url=$(start)
+long=$(python3 -c 'print("A" * 4096)')
+resp=$(post_redirect "${long}" "$(portof "${url}")") ||
+    fail "no response to an oversized redirect value"
+stop
+loc=$(printf '%s' "${resp}" | sed -n 's/^Location: //p' | tr -d '\r')
+test "${loc}" = "${long}" ||
+    fail "oversized redirect not echoed whole (got ${#loc} bytes, want ${#long})"
+
+# CR/LF in the value must not reach the header, or the response splits.
+url=$(start)
+resp=$(post_redirect '/foo
+X-Injected: pwned' "$(portof "${url}")") || fail "no response to a CRLF redirect value"
+stop
+printf '%s' "${resp}" | grep -qi '^X-Injected:' &&
+    fail "CRLF in the redirect value injected a header"
+printf '%s' "${resp}" | grep -q '^HTTP/1.0 302' ||
+    fail "CRLF redirect did not yield a 302"
+
+# Loopback unless asked otherwise.
+url=$(start)
+stop
+case "${url}" in
+    http://127.0.0.1:*) ;;
+    *) fail "default listen address is not loopback: ${url}" ;;
+esac
+
+url=$(start --bind 0.0.0.0)
+stop
+case "${url}" in
+    http://0.0.0.0:*) ;;
+    *) fail "--bind 0.0.0.0 not honoured: ${url}" ;;
+esac
+
+exit 0

--- a/tests/77_webhttrack-redirect.test
+++ b/tests/77_webhttrack-redirect.test
@@ -23,10 +23,13 @@ command -v python3 >/dev/null || {
     exit 77
 }
 
-srv=
 log=$(mktemp)
+# start() runs inside a command substitution, so its $! never reaches this
+# shell. Take the pid from the server's own announcement instead: a missed kill
+# leaves an orphan holding the CI job open long after the suite has passed.
+srvpid() { sed -n 's/^PID=//p' "${log}" 2>/dev/null | head -1; }
 cleanup() {
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
+    stop
     rm -f "${log}"
 }
 trap cleanup EXIT HUP INT QUIT PIPE TERM
@@ -48,10 +51,8 @@ start() {
         trap '' TERM TTOU
         exec htsserver "${distdir}/" --port "${port}" "$@" >"${log}" 2>&1
     ) &
-    srv=$!
     for _ in $(seq 1 40); do
         url=$(sed -n 's/^URL=//p' "${log}" 2>/dev/null) && test -n "${url}" && break
-        kill -0 "${srv}" 2>/dev/null || break
         sleep 0.25
     done
     test -n "${url:-}" || fail "htsserver did not come up: $(cat "${log}")"
@@ -59,15 +60,34 @@ start() {
 }
 
 stop() {
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
-    wait "${srv}" 2>/dev/null || true
-    srv=
+    local pid
+    pid=$(srvpid)
+    test -z "${pid}" || kill -9 "${pid}" 2>/dev/null || true
 }
 
-# POST redirect=$1 to 127.0.0.1:$2, print the raw response headers.
+# The session id gates the request body, so a POST has to carry one. The server
+# renders it into every form, which is where a browser picks it up too.
+scrape_sid() {
+    python3 -c 'import socket, sys
+s = socket.create_connection(("127.0.0.1", int(sys.argv[1])), 10)
+s.settimeout(20)
+s.sendall(b"GET /server/index.html HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n")
+out = b""
+while True:
+    b = s.recv(65536)
+    if not b:
+        break
+    out += b
+s.close()
+sys.stdout.write(out.decode("latin-1"))' "$1" |
+        sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p' | head -1
+}
+
+# POST redirect=$1 to 127.0.0.1:$2 with session id $3, print the raw headers.
 post_redirect() {
     python3 -c 'import socket, sys, urllib.parse
-body = "redirect=" + urllib.parse.quote(sys.argv[1], safe="")
+body = ("sid=" + sys.argv[3] + "&redirect="
+        + urllib.parse.quote(sys.argv[1], safe=""))
 req = ("POST / HTTP/1.0\r\nHost: 127.0.0.1\r\n"
        "Content-type: application/x-www-form-urlencoded\r\n"
        "Content-length: %d\r\n\r\n%s" % (len(body), body))
@@ -83,7 +103,7 @@ while b"\r\n\r\n" not in out:
         break
     out += b
 s.close()
-sys.stdout.write(out.split(b"\r\n\r\n")[0].decode("latin-1"))' "$1" "$2"
+sys.stdout.write(out.split(b"\r\n\r\n")[0].decode("latin-1"))' "$1" "$2" "$3"
 }
 
 portof() { echo "${1##*:}" | tr -d /; }
@@ -108,7 +128,10 @@ finally:
 # interior byte all stay visible.
 long=$(python3 -c 'print("".join(chr(33 + i % 90) for i in range(4097)))')
 url=$(start)
-resp=$(post_redirect "${long}" "$(portof "${url}")") ||
+port=$(portof "${url}")
+sid=$(scrape_sid "${port}")
+test "${#sid}" -eq 32 || fail "did not scrape a 32-hex sid (got '${sid}')"
+resp=$(post_redirect "${long}" "${port}" "${sid}") ||
     fail "no response to an oversized redirect value"
 stop
 loc=$(printf '%s' "${resp}" | sed -n 's/^Location: //p' | tr -d '\r')
@@ -118,8 +141,10 @@ test "${loc}" = "${long}" ||
 # CR/LF must suppress the header outright. Sanitising it instead would keep the
 # grep for an injected header quiet while still emitting a mangled Location.
 url=$(start)
+port=$(portof "${url}")
+sid=$(scrape_sid "${port}")
 resp=$(post_redirect '/foo
-X-Injected: pwned' "$(portof "${url}")") || fail "no response to a CRLF redirect value"
+X-Injected: pwned' "${port}" "${sid}") || fail "no response to a CRLF redirect value"
 stop
 printf '%s' "${resp}" | grep -qi 'X-Injected' &&
     fail "CRLF in the redirect value reached the response"

--- a/tests/78_webhttrack-sid.test
+++ b/tests/78_webhttrack-sid.test
@@ -1,0 +1,142 @@
+#!/bin/bash
+#
+# htsserver's session id must gate the request body: every field in it is
+# written into the global key store, and "command" from there reaches the engine.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
+distdir=$(cd "${distdir}" && pwd)
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+command -v htsserver >/dev/null || fail "no htsserver in PATH"
+command -v python3 >/dev/null || {
+    echo "python3 not found; skipping" >&2
+    exit 77
+}
+
+srv=
+log=$(mktemp)
+cleanup() {
+    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
+    rm -f "${log}"
+}
+trap cleanup EXIT HUP INT QUIT PIPE TERM
+
+freeport() {
+    python3 -c 'import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()'
+}
+
+# Echo the announced URL. Runs in a command substitution, so it is a
+# subshell and cannot export the pid: the caller reads it back with srvpid.
+start() {
+    local port url
+    port=$(freeport)
+    : >"${log}"
+    (
+        trap '' TERM TTOU
+        exec htsserver "${distdir}/" --port "${port}" >"${log}" 2>&1
+    ) &
+    for _ in $(seq 1 40); do
+        url=$(sed -n 's/^URL=//p' "${log}" 2>/dev/null) && test -n "${url}" && break
+        sleep 0.25
+    done
+    test -n "${url:-}" || fail "htsserver did not come up: $(cat "${log}")"
+    echo "${url}"
+}
+
+# The server reports its own pid; the aliveness assertions below hang off it.
+srvpid() { sed -n 's/^PID=//p' "${log}" | head -1; }
+
+alive() { kill -0 "$1" 2>/dev/null; }
+
+portof() { echo "${1##*:}" | tr -d /; }
+
+# Raw request to 127.0.0.1:$1; $2 is the body ("" for a GET of the $3 page,
+# default index). Prints the reply.
+request() {
+    python3 -c 'import socket, sys
+port, body = int(sys.argv[1]), sys.argv[2]
+page = sys.argv[3] if len(sys.argv) > 3 else "index"
+if body:
+    req = ("POST / HTTP/1.0\r\nHost: 127.0.0.1\r\n"
+           "Content-type: application/x-www-form-urlencoded\r\n"
+           "Content-length: %d\r\n\r\n%s" % (len(body), body))
+else:
+    req = ("GET /server/%s.html HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n" % page)
+s = socket.create_connection(("127.0.0.1", port), 10)
+s.settimeout(30)
+s.sendall(req.encode())
+out = b""
+while True:
+    b = s.recv(65536)
+    if not b:
+        break
+    out += b
+s.close()
+sys.stdout.write(out.decode("latin-1"))' "$1" "$2" ${3+"$3"}
+}
+
+# The server hands the sid to any client in every form; scraping it is the
+# legitimate flow, and it is what makes the accept case below meaningful.
+scrape_sid() {
+    request "$1" "" | sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p' | head -1
+}
+
+url=$(start)
+port=$(portof "${url}")
+srv=$(srvpid)
+test -n "${srv}" || fail "htsserver did not report its pid"
+alive "${srv}" || fail "htsserver is not running"
+
+sid=$(scrape_sid "${port}")
+# Control: without a real sid every assertion below would pass vacuously.
+test "${#sid}" -eq 32 || fail "did not scrape a 32-hex sid from the page (got '${sid}')"
+
+# Accept: the legitimate flow still works. "redirect" is the cheapest field
+# with a reply that is visible in the headers.
+resp=$(request "${port}" "sid=${sid}&redirect=/accepted")
+printf '%s' "${resp}" | grep -q '^Location: /accepted' ||
+    fail "a body carrying the correct sid was refused"
+
+# Refuse: missing and wrong. A missing one is the regression under test — the
+# expected value used to be pre-seeded into the compared key, so omitting the
+# field compared equal to itself.
+for bad in "redirect=/nosid" "sid=&redirect=/empty" \
+    "sid=00000000000000000000000000000000&redirect=/wrong"; do
+    resp=$(request "${port}" "${bad}")
+    printf '%s' "${resp}" | grep -q '^Location:' &&
+        fail "body accepted without a valid sid: ${bad}"
+    # A refusal has to be a well-formed reply, not a headerless fragment: the
+    # release build used to emit only Content-length, which reads as a protocol
+    # error to any client and hides the reason.
+    printf '%s' "${resp}" | grep -q '^HTTP/1\.0 403 ' ||
+        fail "refusal was not a 403: ${bad}"
+done
+
+# Suppressing the reply is not the same as refusing the write: the body is
+# applied to one global key store that later requests render from, and the
+# command dispatcher reads it from there. Probe the store itself — step3
+# interpolates ${projname} into its title — rather than the refused reply.
+title() { request "$1" "" step3; }
+
+request "${port}" "projname=UNAUTHWRITE" >/dev/null 2>&1 || true
+title "${port}" | grep -q 'UNAUTHWRITE' &&
+    fail "a body without a valid sid was written to the key store"
+
+# Paired accept case: without it the assertion above passes even if the server
+# simply ignores every body, which would prove nothing.
+request "${port}" "sid=${sid}&projname=AUTHWRITE" >/dev/null 2>&1 || true
+title "${port}" | grep -q 'AUTHWRITE' ||
+    fail "a body carrying the correct sid was not written to the key store"
+
+echo "PASS"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -170,6 +170,7 @@ TESTS = \
 	74_local-warc-wacz.test \
 	74_local-warc-verbatim.test \
 	75_engine-longpath-posix.test \
-	76_cli-resize.test
+	76_cli-resize.test \
+	77_webhttrack-redirect.test
 
 CLEANFILES = check-network_sh.cache

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -171,6 +171,7 @@ TESTS = \
 	74_local-warc-verbatim.test \
 	75_engine-longpath-posix.test \
 	76_cli-resize.test \
-	77_webhttrack-redirect.test
+	77_webhttrack-redirect.test \
+	78_webhttrack-sid.test
 
 CLEANFILES = check-network_sh.cache


### PR DESCRIPTION
The POST redirect path checks strlen(file) but sprintf's newfile, which comes straight from the client's "redirect" POST field with no length cap. A 300-byte value overflows tmp[256], and ASan reports a stack-buffer-overflow write. The same value reached the Location header with no CR/LF check, so it could split the response and inject headers. Both go away by appending into the dynamic String the other headers already use, and dropping the header entirely when the value carries a CR or LF.

The listen socket was SOCaddr_initany, so the server answered the LAN and not just the local browser it exists to serve. webhttrack now binds 127.0.0.1, with `--bind <addr>` to widen it again or pick an interface. smallserver_init resolves the address through the existing gethost() helper the way proxytrack already does, and advertises the address it bound, so the printed URL stays reachable.

Test 77 drives the real server over a socket: a 4096-byte redirect value has to come back whole, a CRLF value must not inject a header, and the announced address has to match the default and `--bind`. All three fail on master, the first by crashing.

Left alone: the sid gate does not gate. `_sid` is copied into `sid` before the body is parsed, so omitting the field passes the comparison. Untangling that means separating the template expansion that shares the key, so it goes in its own PR.