### PR TITLE
htsserver: the session id must gate the request body, not the reply

### DIFF
--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -318,6 +318,51 @@ typedef struct {
   error_redirect = "/server/error.html"; \
 } while(0)
 
+/* Longest "sid" value worth unescaping: the expected one is an md5 hex digest,
+   so anything near this is already invalid and is rejected unread. */
+#define SID_VALUE_MAX 64
+
+/** Does the urlencoded request body present the expected session id?
+    True only if at least one "sid" field is present and every occurrence
+    matches, so it holds whichever one a later last-write-wins parse keeps.
+    Non-destructive: it runs before the body is tokenized in place. */
+static hts_boolean body_sid_is_valid(const char *body, const char *expected) {
+  const char *s = body;
+  hts_boolean seen = HTS_FALSE;
+
+  while (s != NULL && *s != '\0') {
+    const char *const amp = strchr(s, '&');
+    const char *const eq = strchr(s, '=');
+
+    if (eq != NULL && (amp == NULL || eq < amp) && (size_t) (eq - s) == 3 &&
+        strncmp(s, "sid", 3) == 0) {
+      const size_t len = amp != NULL ? (size_t) (amp - eq - 1) : strlen(eq + 1);
+      hts_boolean match = HTS_FALSE;
+
+      if (len < SID_VALUE_MAX) {
+        char raw[SID_VALUE_MAX];
+        String value = STRING_EMPTY;
+
+        memcpy(raw, eq + 1, len);
+        raw[len] = '\0';
+        unescapehttp(raw, &value);
+        /* StringBuff is NULL until written, so an empty value lands here. */
+        if (StringBuff(value) != NULL &&
+            strcmp(StringBuff(value), expected) == 0) {
+          match = HTS_TRUE;
+        }
+        StringFree(value);
+      }
+      if (!match) {
+        return HTS_FALSE;
+      }
+      seen = HTS_TRUE;
+    }
+    s = amp != NULL ? amp + 1 : NULL;
+  }
+  return seen;
+}
+
 int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
   int timeout = 30;
   int retour = 0;
@@ -402,6 +447,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
     T_SOC soc_c;
     LLint length = 0;
     const char *error_redirect = NULL;
+    hts_boolean denied = HTS_FALSE;
 
     line[0] = '\0';
     buffer[0] = '\0';
@@ -513,6 +559,22 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
         }
       }
 
+      /* Authenticate the body before parsing it: every field it carries is
+         written straight into the global key store below, "command" included,
+         and that one reaches the engine. Checking afterwards cannot work — the
+         damage is already done, and the pre-seeded "sid" above would compare
+         equal to itself for a request that simply omits the field. */
+      if (meth && buffer[0]) {
+        intptr_t expected = 0;
+
+        if (!coucal_readptr(NewLangList, "_sid", &expected) ||
+            !body_sid_is_valid(buffer, (const char *) expected)) {
+          buffer[0] = '\0';
+          meth = 0;
+          denied = HTS_TRUE;
+        }
+      }
+
       /* check variables */
       if (meth && buffer[0]) {
         char *s = buffer;
@@ -530,20 +592,6 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
           unescapehttp(ua, &sua);
           coucal_write(NewLangList, s, (intptr_t) StringAcquire(&sua));
           s = f + 1;
-        }
-      }
-
-      /* Error check */
-      {
-        intptr_t adr = 0;
-        intptr_t adr2 = 0;
-
-        if (coucal_readptr(NewLangList, "sid", &adr)) {
-          if (coucal_readptr(NewLangList, "_sid", &adr2)) {
-            if (strcmp((char *) adr, (char *) adr2) != 0) {
-              meth = 0;
-            }
-          }
         }
       }
 
@@ -1373,6 +1421,11 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
             StringCat(output, error);
           }
         }
+      } else if (denied) {
+        StringCat(headers, "HTTP/1.0 403 Forbidden\r\n"
+                           "Server: httrack small server\r\n"
+                           "Content-type: text/html\r\n");
+        StringCat(output, "Missing or invalid session id.\r\n");
       } else {
 #ifdef _DEBUG
         char error_hdr[] =

--- a/tests/68_webhttrack-outdir-charset.test
+++ b/tests/68_webhttrack-outdir-charset.test
@@ -60,13 +60,20 @@ test -n "${url:-}" || fail "htsserver did not start: $(cat "${srvlog}")"
 
 # Post a "start" whose -O dir is 'café' in the form's ISO-8859-1 charset.
 "${python}" - "${url}" "${work}" <<'PY'
-import sys, urllib.parse, urllib.request
+import re, sys, urllib.parse, urllib.request
 
 url, work = sys.argv[1], sys.argv[2]
 outdir = work + "/caf\xe9"  # 'café' as the single byte the browser would send
 # Port 1 refuses at once: only the decoded -O dir matters, not the fetch.
 cmd = "httrack --quiet --robots=0 http://127.0.0.1:1/x.html -O " + outdir
-fields = [("path", work), ("projname", "proj"), ("command_do", "start"),
+# The body is refused without the session id the server renders into each form.
+# Note the wizard page is under /server/; a bare /step4.html is the doc page.
+page = urllib.request.urlopen(url + "server/step4.html", timeout=20).read()
+m = re.search(rb'name="sid" value="([0-9a-f]+)"', page)
+if not m:
+    raise SystemExit("no session id in server/step4.html")
+fields = [("sid", m.group(1).decode()),
+          ("path", work), ("projname", "proj"), ("command_do", "start"),
           ("winprofile", "x"), ("command", cmd)]
 body = "&".join("%s=%s" % (k, urllib.parse.quote(v, safe="", encoding="latin-1"))
                 for k, v in fields)

--- a/tests/77_webhttrack-redirect.test
+++ b/tests/77_webhttrack-redirect.test
@@ -61,10 +61,28 @@ stop() {
     srv=
 }
 
-# POST redirect=$1 to 127.0.0.1:$2, print the raw response headers.
+# The session id gates the request body, so a POST has to carry one. The server
+# renders it into every form, which is where a browser picks it up too.
+scrape_sid() {
+    python3 -c 'import socket, sys
+s = socket.create_connection(("127.0.0.1", int(sys.argv[1])), 10)
+s.sendall(b"GET /server/index.html HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n")
+out = b""
+while True:
+    b = s.recv(65536)
+    if not b:
+        break
+    out += b
+s.close()
+sys.stdout.write(out.decode("latin-1"))' "$1" |
+        sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p' | head -1
+}
+
+# POST redirect=$1 to 127.0.0.1:$2 with session id $3, print the raw headers.
 post_redirect() {
     python3 -c 'import socket, sys, urllib.parse
-body = "redirect=" + urllib.parse.quote(sys.argv[1], safe="")
+body = ("sid=" + sys.argv[3] + "&redirect="
+        + urllib.parse.quote(sys.argv[1], safe=""))
 req = ("POST / HTTP/1.0\r\nHost: 127.0.0.1\r\n"
        "Content-type: application/x-www-form-urlencoded\r\n"
        "Content-length: %d\r\n\r\n%s" % (len(body), body))
@@ -77,7 +95,7 @@ while True:
         break
     out += b
 s.close()
-sys.stdout.write(out.split(b"\r\n\r\n")[0].decode("latin-1"))' "$1" "$2"
+sys.stdout.write(out.split(b"\r\n\r\n")[0].decode("latin-1"))' "$1" "$2" "$3"
 }
 
 portof() { echo "${1##*:}" | tr -d /; }
@@ -102,7 +120,10 @@ finally:
 # interior byte all stay visible.
 long=$(python3 -c 'print("".join(chr(33 + i % 90) for i in range(4097)))')
 url=$(start)
-resp=$(post_redirect "${long}" "$(portof "${url}")") ||
+port=$(portof "${url}")
+sid=$(scrape_sid "${port}")
+test "${#sid}" -eq 32 || fail "did not scrape a 32-hex sid (got '${sid}')"
+resp=$(post_redirect "${long}" "${port}" "${sid}") ||
     fail "no response to an oversized redirect value"
 stop
 loc=$(printf '%s' "${resp}" | sed -n 's/^Location: //p' | tr -d '\r')
@@ -112,8 +133,10 @@ test "${loc}" = "${long}" ||
 # CR/LF must suppress the header outright. Sanitising it instead would keep the
 # grep for an injected header quiet while still emitting a mangled Location.
 url=$(start)
+port=$(portof "${url}")
+sid=$(scrape_sid "${port}")
 resp=$(post_redirect '/foo
-X-Injected: pwned' "$(portof "${url}")") || fail "no response to a CRLF redirect value"
+X-Injected: pwned' "${port}" "${sid}") || fail "no response to a CRLF redirect value"
 stop
 printf '%s' "${resp}" | grep -qi 'X-Injected' &&
     fail "CRLF in the redirect value reached the response"

--- a/tests/77_webhttrack-redirect.test
+++ b/tests/77_webhttrack-redirect.test
@@ -20,10 +20,13 @@ command -v python3 >/dev/null || {
     exit 77
 }
 
-srv=
 log=$(mktemp)
+# start() runs inside a command substitution, so its $! never reaches this
+# shell. Take the pid from the server's own announcement instead: a missed kill
+# leaves an orphan holding the CI job open long after the suite has passed.
+srvpid() { sed -n 's/^PID=//p' "${log}" 2>/dev/null | head -1; }
 cleanup() {
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
+    stop
     rm -f "${log}"
 }
 trap cleanup EXIT HUP INT QUIT PIPE TERM
@@ -45,10 +48,8 @@ start() {
         trap '' TERM TTOU
         exec htsserver "${distdir}/" --port "${port}" "$@" >"${log}" 2>&1
     ) &
-    srv=$!
     for _ in $(seq 1 40); do
         url=$(sed -n 's/^URL=//p' "${log}" 2>/dev/null) && test -n "${url}" && break
-        kill -0 "${srv}" 2>/dev/null || break
         sleep 0.25
     done
     test -n "${url:-}" || fail "htsserver did not come up: $(cat "${log}")"
@@ -56,9 +57,9 @@ start() {
 }
 
 stop() {
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
-    wait "${srv}" 2>/dev/null || true
-    srv=
+    local pid
+    pid=$(srvpid)
+    test -z "${pid}" || kill -9 "${pid}" 2>/dev/null || true
 }
 
 # The session id gates the request body, so a POST has to carry one. The server
@@ -66,6 +67,7 @@ stop() {
 scrape_sid() {
     python3 -c 'import socket, sys
 s = socket.create_connection(("127.0.0.1", int(sys.argv[1])), 10)
+s.settimeout(30)
 s.sendall(b"GET /server/index.html HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n")
 out = b""
 while True:
@@ -87,6 +89,7 @@ req = ("POST / HTTP/1.0\r\nHost: 127.0.0.1\r\n"
        "Content-type: application/x-www-form-urlencoded\r\n"
        "Content-length: %d\r\n\r\n%s" % (len(body), body))
 s = socket.create_connection(("127.0.0.1", int(sys.argv[2])), 10)
+s.settimeout(30)
 s.sendall(req.encode())
 out = b""
 while True:

--- a/tests/78_webhttrack-sid.test
+++ b/tests/78_webhttrack-sid.test
@@ -1,0 +1,141 @@
+#!/bin/bash
+#
+# htsserver's session id must gate the request body: every field in it is
+# written into the global key store, and "command" from there reaches the engine.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
+distdir=$(cd "${distdir}" && pwd)
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+command -v htsserver >/dev/null || fail "no htsserver in PATH"
+command -v python3 >/dev/null || {
+    echo "python3 not found; skipping" >&2
+    exit 77
+}
+
+srv=
+log=$(mktemp)
+cleanup() {
+    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
+    rm -f "${log}"
+}
+trap cleanup EXIT HUP INT QUIT PIPE TERM
+
+freeport() {
+    python3 -c 'import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()'
+}
+
+# Echo the announced URL. Runs in a command substitution, so it is a
+# subshell and cannot export the pid: the caller reads it back with srvpid.
+start() {
+    local port url
+    port=$(freeport)
+    : >"${log}"
+    (
+        trap '' TERM TTOU
+        exec htsserver "${distdir}/" --port "${port}" >"${log}" 2>&1
+    ) &
+    for _ in $(seq 1 40); do
+        url=$(sed -n 's/^URL=//p' "${log}" 2>/dev/null) && test -n "${url}" && break
+        sleep 0.25
+    done
+    test -n "${url:-}" || fail "htsserver did not come up: $(cat "${log}")"
+    echo "${url}"
+}
+
+# The server reports its own pid; the aliveness assertions below hang off it.
+srvpid() { sed -n 's/^PID=//p' "${log}" | head -1; }
+
+alive() { kill -0 "$1" 2>/dev/null; }
+
+portof() { echo "${1##*:}" | tr -d /; }
+
+# Raw request to 127.0.0.1:$1; $2 is the body ("" for a GET of the $3 page,
+# default index). Prints the reply.
+request() {
+    python3 -c 'import socket, sys
+port, body = int(sys.argv[1]), sys.argv[2]
+page = sys.argv[3] if len(sys.argv) > 3 else "index"
+if body:
+    req = ("POST / HTTP/1.0\r\nHost: 127.0.0.1\r\n"
+           "Content-type: application/x-www-form-urlencoded\r\n"
+           "Content-length: %d\r\n\r\n%s" % (len(body), body))
+else:
+    req = ("GET /server/%s.html HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n" % page)
+s = socket.create_connection(("127.0.0.1", port), 10)
+s.sendall(req.encode())
+out = b""
+while True:
+    b = s.recv(65536)
+    if not b:
+        break
+    out += b
+s.close()
+sys.stdout.write(out.decode("latin-1"))' "$1" "$2" ${3+"$3"}
+}
+
+# The server hands the sid to any client in every form; scraping it is the
+# legitimate flow, and it is what makes the accept case below meaningful.
+scrape_sid() {
+    request "$1" "" | sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p' | head -1
+}
+
+url=$(start)
+port=$(portof "${url}")
+srv=$(srvpid)
+test -n "${srv}" || fail "htsserver did not report its pid"
+alive "${srv}" || fail "htsserver is not running"
+
+sid=$(scrape_sid "${port}")
+# Control: without a real sid every assertion below would pass vacuously.
+test "${#sid}" -eq 32 || fail "did not scrape a 32-hex sid from the page (got '${sid}')"
+
+# Accept: the legitimate flow still works. "redirect" is the cheapest field
+# with a reply that is visible in the headers.
+resp=$(request "${port}" "sid=${sid}&redirect=/accepted")
+printf '%s' "${resp}" | grep -q '^Location: /accepted' ||
+    fail "a body carrying the correct sid was refused"
+
+# Refuse: missing and wrong. A missing one is the regression under test — the
+# expected value used to be pre-seeded into the compared key, so omitting the
+# field compared equal to itself.
+for bad in "redirect=/nosid" "sid=&redirect=/empty" \
+    "sid=00000000000000000000000000000000&redirect=/wrong"; do
+    resp=$(request "${port}" "${bad}")
+    printf '%s' "${resp}" | grep -q '^Location:' &&
+        fail "body accepted without a valid sid: ${bad}"
+    # A refusal has to be a well-formed reply, not a headerless fragment: the
+    # release build used to emit only Content-length, which reads as a protocol
+    # error to any client and hides the reason.
+    printf '%s' "${resp}" | grep -q '^HTTP/1\.0 403 ' ||
+        fail "refusal was not a 403: ${bad}"
+done
+
+# Suppressing the reply is not the same as refusing the write: the body is
+# applied to one global key store that later requests render from, and the
+# command dispatcher reads it from there. Probe the store itself — step3
+# interpolates ${projname} into its title — rather than the refused reply.
+title() { request "$1" "" step3; }
+
+request "${port}" "projname=UNAUTHWRITE" >/dev/null 2>&1 || true
+title "${port}" | grep -q 'UNAUTHWRITE' &&
+    fail "a body without a valid sid was written to the key store"
+
+# Paired accept case: without it the assertion above passes even if the server
+# simply ignores every body, which would prove nothing.
+request "${port}" "sid=${sid}&projname=AUTHWRITE" >/dev/null 2>&1 || true
+title "${port}" | grep -q 'AUTHWRITE' ||
+    fail "a body carrying the correct sid was not written to the key store"
+
+echo "PASS"

--- a/tests/78_webhttrack-sid.test
+++ b/tests/78_webhttrack-sid.test
@@ -74,6 +74,7 @@ if body:
 else:
     req = ("GET /server/%s.html HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n" % page)
 s = socket.create_connection(("127.0.0.1", port), 10)
+s.settimeout(30)
 s.sendall(req.encode())
 out = b""
 while True:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -171,6 +171,7 @@ TESTS = \
 	74_local-warc-verbatim.test \
 	75_engine-longpath-posix.test \
 	76_cli-resize.test \
-	77_webhttrack-redirect.test
+	77_webhttrack-redirect.test \
+	78_webhttrack-sid.test
 
 CLEANFILES = check-network_sh.cache


### PR DESCRIPTION
The `sid` gate ran after the body it was meant to gate. Every field of a POST goes into the one global key store that the templates and the command dispatcher both read, and `command` from there reaches the engine. The comparison happened afterwards, against a key already pre-seeded with the expected value so templates could render it, so a request that omitted the field compared equal to itself and passed. Only a wrong id was ever refused. Clearing the reply instead would not have helped, because the dispatcher sits outside the reply guard.

Authenticating first fixes it: scan the raw body for `sid`, require at least one occurrence and reject if any of them differs, and drop the body untouched when it does not match. That leaves the shared template key alone and closes the dispatcher too.

Refusals were malformed as well. The status line for that branch sat behind `_DEBUG`, so a release build sent nothing but a `Content-length` header, which any client reads as a protocol error rather than a refusal. That is why test 68 died on a `BadStatusLine` instead of reporting what happened. It returns 403 now.

Tests 68 and 77 both posted without an id, since that is what the server used to accept, so both now read the one it renders into the form. Test 78 covers accept, missing, empty and wrong, asserts the 403, and checks the key store through `${projname}` rather than the reply, because a reply-only assertion still passes while the write lands.

Stacked on #700, which fixes the loopback bind and the Location overflow and deliberately left this part alone. It targets `warnfix-p0` and should merge after it. Full suite green, 136 passed.
