### PR TITLE
webhttrack: "max site size" sets a per-file cap and discards the HTML one

### DIFF
--- a/html/server/option2b.html
+++ b/html/server/option2b.html
@@ -103,7 +103,7 @@ ${LANG_Q3}
 <tr><td>
 	<table width="100%">
 	<tr><td align="left">
-	<input type="submit" value="${LANG_OK]" 
+	<input type="submit" value="${LANG_OK}"
 ${do:output-mode:html-urlescaped}
 		onClick="if (confirm(str_replace(str_replace('${LANG_DIAL7}', '%20', ' '), '%0a', ' '))) { form.closeme.value=1; form.submit(); } return false;"
 ${do:output-mode:}

--- a/html/server/step4.html
+++ b/html/server/step4.html
@@ -160,9 +160,10 @@ ${do:end-if}
 \
 	${test:depth:--depth=}${depth}
 	${test:depth2:--ext-depth=}${depth2}
-	${test:maxhtml:--max-files=,}${maxhtml}
+${/* -m<n> resets the html limit, so the bare form must precede the -m,<n> one */}
 	${test:othermax:--max-files=}${othermax}
-	${test:sizemax:--max-files=}${sizemax}
+	${test:maxhtml:--max-files=,}${maxhtml}
+	${test:sizemax:--max-size=}${sizemax}
 	${test:pausebytes:--max-pause=}${pausebytes}
 	${test:maxtime:--max-time=}${maxtime}
 	${test:maxrate:--max-rate=}${maxrate}
@@ -213,7 +214,7 @@ ParseAll=${ztest:parseall:0:1}
 HTMLFirst=${ztest:htmlfirst:0:1}
 Cache=${ztest:cache:0:1}
 NoRecatch=${ztest:norecatch:0:1}
-Dos=${dos
+Dos=${dos}
 Index=${ztest:index:0:1}
 WordIndex=${ztest:index2:0:1}
 Log=${ztest:logf:0:1:2}

--- a/tests/81_webhttrack-maxsize.test
+++ b/tests/81_webhttrack-maxsize.test
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# The web UI's three size fields must reach the engine as distinct limits: "Max
+# site size" (sizemax) is the overall -M cap, while the per-file HTML (maxhtml)
+# and non-HTML (othermax) caps share -m. step4.html emitted --max-files for all
+# three, so the site cap became a per-file one and overwrote othermax. Part 1
+# audits the command line and winprofile.ini the wizard renders; part 2 pins the
+# -m ordering it relies on, since a bare -m<n> clears the html limit.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
+distdir=$(cd "${distdir}" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+command -v htsserver >/dev/null || fail "no htsserver in PATH"
+python=$(find_python) || {
+    echo "python3 not found; skipping" >&2
+    exit 77
+}
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_maxsize.XXXXXX") || fail "no tmpdir"
+srvlog=$(mktemp)
+srv=
+cleanup() {
+    # htsserver keeps SIGTERM ignored across its exec, so only -9 reaps it.
+    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
+    wait "${srv}" 2>/dev/null || true # absorb bash's async "Killed" notice
+    srv=
+    rm -rf "${work}" "${srvlog}"
+}
+trap cleanup EXIT HUP INT QUIT PIPE TERM
+
+# webhttrack server on a pre-picked port; an isolated HOME keeps a stray
+# ~/.httrack.ini out of it.
+sport=$("${python}" -c 'import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()')
+(
+    trap '' TERM TTOU
+    export HOME="${work}"
+    exec htsserver "${distdir}/" --port "${sport}" >"${srvlog}" 2>&1
+) &
+srv=$!
+for _ in $(seq 1 40); do
+    url=$(sed -n 's/^URL=//p' "${srvlog}") && test -n "${url}" && break
+    kill -0 "${srv}" 2>/dev/null || break
+    sleep 0.25
+done
+test -n "${url:-}" || fail "htsserver did not start: $(cat "${srvlog}")"
+
+# Post the size fields, then audit what step4.html renders back. No command_do,
+# so nothing is launched.
+"${python}" - "${url}" <<'PY' || fail "wizard rendered the wrong options (see above)"
+import re, sys, urllib.parse, urllib.request
+
+url = sys.argv[1]
+html, other, site = "111111", "222222", "333333"
+fields = [("maxhtml", html), ("othermax", other), ("sizemax", site),
+          ("dos", "2")]
+body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in fields)
+req = urllib.request.Request(url + "server/step4.html",
+                             data=body.encode("latin-1"), method="POST")
+page = urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
+
+
+def textarea(name):
+    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page, re.S)
+    if m is None:
+        sys.exit("no %s textarea in the rendered step4.html" % name)
+    return m.group(1)
+
+
+def want(ok, msg, ctx):
+    if not ok:
+        sys.exit("%s\nrendered:%s" % (msg, ctx))
+
+
+cmd = textarea("command")
+want("--max-size=" + site in cmd, "site cap not emitted as --max-size", cmd)
+want("--max-files=" + site not in cmd, "site cap still an --max-files", cmd)
+# Positive controls: both per-file caps still ride -m, one option each.
+want("--max-files=" + other in cmd, "non-HTML cap not emitted as --max-files",
+     cmd)
+want("--max-files=," + html in cmd, "HTML cap not emitted as --max-files=,",
+     cmd)
+want(cmd.count("--max-files=") == 2, "unexpected --max-files count", cmd)
+want(cmd.index("--max-files=" + other) < cmd.index("--max-files=," + html),
+     "the bare --max-files must precede the --max-files=, form", cmd)
+
+# winprofile.ini: the Dos key used to be written from an unterminated ${dos.
+ini = textarea("winprofile")
+want("\nDos=2" in ini, "Dos not written from the dos field", ini)
+
+# A ${LANG_OK] typo rendered the key's own name into the button label.
+opts = urllib.request.urlopen(url + "server/option2b.html",
+                              timeout=20).read().decode("latin-1")
+want("LANG_OK" not in opts, "unexpanded LANG_OK in option2b.html", "")
+PY
+
+cleanup
+
+# The -m ordering the template depends on: a bare -m<n> resets the html limit,
+# so only the bare-then-comma order keeps both caps live. basic.html is 487
+# bytes, well past the 10-byte html cap that refuses it as "File too big".
+crawl() {
+    bash "${distdir}/tests/local-crawl.sh" "$@"
+}
+crawl --errors 1 --log-found 'File too big' \
+    httrack 'BASEURL/simple/basic.html' '--max-files=,10'
+crawl --errors 1 --log-found 'File too big' \
+    httrack 'BASEURL/simple/basic.html' '--max-files=500000' '--max-files=,10'
+crawl --errors 0 --found 'simple/basic.html' --log-not-found 'File too big' \
+    httrack 'BASEURL/simple/basic.html' '--max-files=,10' '--max-files=500000'
+
+echo "PASS"

--- a/tests/81_webhttrack-maxsize.test
+++ b/tests/81_webhttrack-maxsize.test
@@ -1,11 +1,7 @@
 #!/bin/bash
 #
-# The web UI's three size fields must reach the engine as distinct limits: "Max
-# site size" (sizemax) is the overall -M cap, while the per-file HTML (maxhtml)
-# and non-HTML (othermax) caps share -m. step4.html emitted --max-files for all
-# three, so the site cap became a per-file one and overwrote othermax. Part 1
-# audits the command line and winprofile.ini the wizard renders; part 2 pins the
-# -m ordering it relies on, since a bare -m<n> clears the html limit.
+# The wizard's size fields must render as distinct caps: sizemax is -M, othermax
+# then maxhtml share -m.
 
 set -euo pipefail
 
@@ -58,28 +54,28 @@ for _ in $(seq 1 40); do
 done
 test -n "${url:-}" || fail "htsserver did not start: $(cat "${srvlog}")"
 
-# Post the size fields, then audit what step4.html renders back. No command_do,
-# so nothing is launched.
+# Audit what step4.html renders back; without command_do nothing is launched.
 "${python}" - "${url}" <<'PY' || fail "wizard rendered the wrong options (see above)"
 import re, sys, urllib.parse, urllib.request
 
 url = sys.argv[1]
 html, other, site = "111111", "222222", "333333"
-# The body is refused without the session id the server renders into each form.
-form = urllib.request.urlopen(url + "server/index.html", timeout=20).read()
-m = re.search(rb'name="sid" value="([0-9a-f]+)"', form)
-if not m:
-    raise SystemExit("no session id in server/index.html")
-fields = [("sid", m.group(1).decode()),
-          ("maxhtml", html), ("othermax", other), ("sizemax", site),
-          ("dos", "2")]
-body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in fields)
-req = urllib.request.Request(url + "server/step4.html",
-                             data=body.encode("latin-1"), method="POST")
-page = urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
 
 
-def textarea(name):
+def post(fields):
+    # The body is refused without the session id the server puts in each form.
+    form = urllib.request.urlopen(url + "server/index.html", timeout=20).read()
+    m = re.search(rb'name="sid" value="([0-9a-f]+)"', form)
+    if not m:
+        raise SystemExit("no session id in server/index.html")
+    fields = [("sid", m.group(1).decode())] + fields
+    body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in fields)
+    req = urllib.request.Request(url + "server/step4.html",
+                                 data=body.encode("latin-1"), method="POST")
+    return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
+
+
+def textarea(page, name):
     m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page, re.S)
     if m is None:
         sys.exit("no %s textarea in the rendered step4.html" % name)
@@ -91,7 +87,9 @@ def want(ok, msg, ctx):
         sys.exit("%s\nrendered:%s" % (msg, ctx))
 
 
-cmd = textarea("command")
+page = post([("maxhtml", html), ("othermax", other), ("sizemax", site),
+             ("dos", "2")])
+cmd = textarea(page, "command")
 want("--max-size=" + site in cmd, "site cap not emitted as --max-size", cmd)
 want("--max-files=" + site not in cmd, "site cap still an --max-files", cmd)
 # Positive controls: both per-file caps still ride -m, one option each.
@@ -103,21 +101,34 @@ want(cmd.count("--max-files=") == 2, "unexpected --max-files count", cmd)
 want(cmd.index("--max-files=" + other) < cmd.index("--max-files=," + html),
      "the bare --max-files must precede the --max-files=, form", cmd)
 
-# winprofile.ini: the Dos key used to be written from an unterminated ${dos.
-ini = textarea("winprofile")
+# winprofile.ini feeds the same three caps to the Windows GUI, one key each.
+ini = textarea(page, "winprofile").replace("\r\n", "\n")  # the ini is CRLF
 want("\nDos=2" in ini, "Dos not written from the dos field", ini)
+want("\nMaxHtml=" + html + "\n" in ini, "MaxHtml not written from maxhtml", ini)
+want("\nMaxOther=" + other + "\n" in ini, "MaxOther not written from othermax",
+     ini)
+want("\nMaxAll=" + site + "\n" in ini, "MaxAll not written from sizemax", ini)
 
-# A ${LANG_OK] typo rendered the key's own name into the button label.
+# A bare --max-files= (an unguarded empty field) parses as -m with no digits,
+# silently clearing the html cap.
+page = post([("maxhtml", ""), ("othermax", ""), ("sizemax", ""), ("dos", "2")])
+cmd = textarea(page, "command")
+want("--max-rate=" in cmd, "empty size fields rendered no command line", cmd)
+want("--max-files" not in cmd and "--max-size" not in cmd,
+     "empty size fields still rendered a size option", cmd)
+
+# A mistyped ${LANG_OK] key renders the OK button's label empty.
 opts = urllib.request.urlopen(url + "server/option2b.html",
                               timeout=20).read().decode("latin-1")
 want("LANG_OK" not in opts, "unexpanded LANG_OK in option2b.html", "")
+want('<input type="submit" value="OK"' in opts, "no OK label in option2b.html",
+     "")
 PY
 
 cleanup
 
-# The -m ordering the template depends on: a bare -m<n> resets the html limit,
-# so only the bare-then-comma order keeps both caps live. basic.html is 487
-# bytes, well past the 10-byte html cap that refuses it as "File too big".
+# A bare -m<n> resets the html limit, so only the bare-then-comma order keeps
+# both caps live. basic.html is 487 bytes, well past the 10-byte html cap.
 crawl() {
     bash "${distdir}/tests/local-crawl.sh" "$@"
 }

--- a/tests/81_webhttrack-maxsize.test
+++ b/tests/81_webhttrack-maxsize.test
@@ -65,7 +65,13 @@ import re, sys, urllib.parse, urllib.request
 
 url = sys.argv[1]
 html, other, site = "111111", "222222", "333333"
-fields = [("maxhtml", html), ("othermax", other), ("sizemax", site),
+# The body is refused without the session id the server renders into each form.
+form = urllib.request.urlopen(url + "server/index.html", timeout=20).read()
+m = re.search(rb'name="sid" value="([0-9a-f]+)"', form)
+if not m:
+    raise SystemExit("no session id in server/index.html")
+fields = [("sid", m.group(1).decode()),
+          ("maxhtml", html), ("othermax", other), ("sizemax", site),
           ("dos", "2")]
 body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in fields)
 req = urllib.request.Request(url + "server/step4.html",

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -172,6 +172,7 @@ TESTS = \
 	74_local-warc-wacz.test \
 	74_local-warc-verbatim.test \
 	75_engine-longpath-posix.test \
-	76_cli-resize.test
+	76_cli-resize.test \
+	81_webhttrack-maxsize.test
 
 CLEANFILES = check-network_sh.cache


### PR DESCRIPTION
"Max site size" in the web wizard rendered `--max-files`, which is `-m`, a per-file cap, so the overall limit the user typed was never applied. It also collided with the non-HTML field, which legitimately uses `-m`: `htscoremain.c` reads a bare `-m<n>` with no comma as "clear the HTML cap", so the stray option threw the HTML limit away too. The site field now renders `--max-size`, and the bare `-m` form is rendered before the comma form so the reset lands first.

Two one-character template typos ride along. `Dos=${dos` was missing its closing brace, so the DOS-names setting went into the profile as the literal text `dos` and reset on every project reload, and `value="${LANG_OK]"` closed with a bracket, leaving the button labelled `LANG_OK]`. A malformed `${...}` renders as nothing or as itself instead of failing, which is how all three went unnoticed. Test 81 checks what the wizard renders back with the size fields filled and with them empty, then runs three crawl legs that pin the `-m` ordering. Every assertion was watched fail against its own reverted change.