### PR TITLE
Check snprintf truncation where the result must be complete

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -542,8 +542,14 @@ static int create_back_tmpfile(httrackp *opt, lien_back *const back,
   // do not use tempnam() but a regular filename
   back->tmpfile_buffer[0] = '\0';
   if (back->url_sav[0] != '\0') {
-    snprintf(back->tmpfile_buffer, sizeof(back->tmpfile_buffer), "%s.%s",
-             back->url_sav, ext);
+    /* same capacity as url_sav, so truncation drops the extension and aliases
+       the temp name onto the live file that back_finalize_backup() UNLINKs */
+    if (!sprintfbuff(back->tmpfile_buffer, "%s.%s", back->url_sav, ext)) {
+      hts_log_print(opt, LOG_WARNING, "temporary filename too long for %s",
+                    back->url_sav);
+      back->tmpfile_buffer[0] = '\0';
+      return -1;
+    }
     back->tmpfile = back->tmpfile_buffer;
     if (structcheck(back->tmpfile) != 0) {
       hts_log_print(opt, LOG_WARNING, "can not create directory to %s",
@@ -551,8 +557,15 @@ static int create_back_tmpfile(httrackp *opt, lien_back *const back,
       return -1;
     }
   } else {
-    snprintf(back->tmpfile_buffer, sizeof(back->tmpfile_buffer), "%s/tmp%d.%s",
-             StringBuff(opt->path_html_utf8), opt->state.tmpnameid++, ext);
+    /* truncation here would collide distinct tmpnameid's onto one name */
+    if (!sprintfbuff(back->tmpfile_buffer, "%s/tmp%d.%s",
+                     StringBuff(opt->path_html_utf8), opt->state.tmpnameid++,
+                     ext)) {
+      hts_log_print(opt, LOG_WARNING, "temporary filename too long in %s",
+                    StringBuff(opt->path_html_utf8));
+      back->tmpfile_buffer[0] = '\0';
+      return -1;
+    }
     back->tmpfile = back->tmpfile_buffer;
   }
   /* OK */

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -451,9 +451,16 @@ void hts_finish_makeindex(httrackp *opt, int *makeindex_done,
       if (makeindex_links == 1) {
         char BIGSTK link_escaped[HTS_URLMAXSIZE * 2];
         escape_uri_utf(makeindex_firstlink, link_escaped, sizeof(link_escaped));
-        snprintf(tempo, sizeof(tempo),
-                 "<meta HTTP-EQUIV=\"Refresh\" CONTENT=\"0; URL=%s\">" CRLF,
-                 link_escaped);
+        /* no redirect beats one pointing at a clipped URL */
+        if (!sprintfbuff(
+                tempo,
+                "<meta HTTP-EQUIV=\"Refresh\" CONTENT=\"0; URL=%s\">" CRLF,
+                link_escaped)) {
+          hts_log_print(opt, LOG_WARNING,
+                        "index redirect omitted: first link too long (%s)",
+                        makeindex_firstlink);
+          tempo[0] = '\0';
+        }
       } else
         tempo[0] = '\0';
       hts_template_format(*makeindex_fp, template_footer,

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -447,7 +447,9 @@ void hts_finish_makeindex(httrackp *opt, int *makeindex_done,
                           const char *fil) {
   if (!*makeindex_done) {
     if (*makeindex_fp) {
-      char BIGSTK tempo[1024];
+      /* sized off link_escaped below: at the old flat 1024 a long first link
+         produced a redirect to a clipped URL */
+      char BIGSTK tempo[HTS_URLMAXSIZE * 2 + 64];
       if (makeindex_links == 1) {
         char BIGSTK link_escaped[HTS_URLMAXSIZE * 2];
         escape_uri_utf(makeindex_firstlink, link_escaped, sizeof(link_escaped));

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -72,7 +72,8 @@ Please visit our Website: http://www.httrack.com
    HTS_UNUSED: suppress unused-symbol warnings. HTS_STATIC: an unused-safe
    static. HTS_PRINTF_FUN(fmt, arg): mark a printf-like function so the
    compiler type-checks the format string at argument index fmt against the
-   varargs starting at arg. */
+   varargs starting at arg. HTS_CHECK_RESULT: the return value carries the only
+   error signal, so dropping it is a bug; a (void) cast does not silence it. */
 #ifndef HTS_UNUSED
 #ifdef __GNUC__
 #define HTS_UNUSED __attribute__((unused))
@@ -80,10 +81,13 @@ Please visit our Website: http://www.httrack.com
 #define HTS_STATIC static __attribute__((unused))
 
 #define HTS_PRINTF_FUN(fmt, arg) __attribute__((format(printf, fmt, arg)))
+
+#define HTS_CHECK_RESULT __attribute__((warn_unused_result))
 #else
 #define HTS_UNUSED
 #define HTS_STATIC static
 #define HTS_PRINTF_FUN(fmt, arg)
+#define HTS_CHECK_RESULT
 #endif
 #endif
 

--- a/src/htshelp.c
+++ b/src/htshelp.c
@@ -308,7 +308,14 @@ void help_wizard(httrackp * opt) {
       printf("\n");
       if (strlen(stropt) == 1)
         stropt[0] = '\0';       // aucune
-      snprintf(cmd, sizeof(cmd), "%s %s %s %s", urls, stropt, stropt2, strwild);
+      /* the tail is the filter list, and cmd is split into the argv handed to
+         hts_main() below: a clipped line would silently widen the crawl */
+      if (!sprintfbuff(cmd, "%s %s %s %s", urls, stropt, stropt2, strwild)) {
+        printf("* command line too long (%d bytes max)\n",
+               (int) sizeof(cmd) - 1);
+        freet(buffers);
+        return;
+      }
       printf("---> Wizard command line: httrack %s\n\n", cmd);
       printf("Ready to launch the mirror? (Y/n) :");
       fflush(stdout);

--- a/src/htshelp.c
+++ b/src/htshelp.c
@@ -124,7 +124,9 @@ typedef struct help_wizard_buffers {
   char stropt[2048];        // options
   char stropt2[2048];       // options longues
   char strwild[2048];       // wildcards
-  char cmd[4096];
+  /* holds all four of the above plus separators: at 4096 a long answer set
+     clipped the filters off the command line */
+  char cmd[HTS_URLMAXSIZE * 2 + 3 * 2048 + 4];
   char str[256];
   char *argv[256];
 } help_wizard_buffers;

--- a/src/htssafe.h
+++ b/src/htssafe.h
@@ -33,6 +33,7 @@ Please visit our Website: http://www.httrack.com
 #ifndef HTSSAFE_DEFH
 #define HTSSAFE_DEFH
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -458,6 +459,38 @@ static HTS_INLINE HTS_UNUSED void htsbuff_cpy(htsbuff *b, const char *s) {
 static HTS_INLINE HTS_UNUSED const char *htsbuff_str(const htsbuff *b) {
   return b->buf;
 }
+
+/**
+ * Formatted print into dest (capacity size, NUL included), truncating to fit
+ * and always NUL-terminating. Returns HTS_TRUE if the whole output fit.
+ * The third contract beside the abort-on-overflow strcpybuff() family: abort
+ * is wrong where the source is a remote peer's banner. Discard the result with
+ * (void) only where a clipped one is the intended behavior.
+ */
+static HTS_INLINE HTS_UNUSED HTS_PRINTF_FUN(3, 4) hts_boolean
+    slprintfbuff(char *dest, size_t size, const char *fmt, ...) {
+  va_list args;
+  int ret;
+
+  assertf(dest != NULL && size != 0);
+  va_start(args, fmt);
+  ret = vsnprintf(dest, size, fmt, args);
+  va_end(args);
+  /* pre-C99 runtimes (msvcrt _vsnprintf) return -1 and do not terminate */
+  dest[size - 1] = '\0';
+  return ret >= 0 && (size_t) ret < size ? HTS_TRUE : HTS_FALSE;
+}
+
+/**
+ * slprintfbuff() over the in-scope array ARR (capacity = sizeof(ARR)).
+ * On GCC/Clang a pointer is a compile error; use slprintfbuff() for those.
+ */
+#if (defined(__GNUC__) && !defined(__cplusplus))
+#define sprintfbuff(ARR, ...)                                                  \
+  slprintfbuff((ARR), sizeof(ARR) + htsbuff_must_be_array_(ARR), __VA_ARGS__)
+#else
+#define sprintfbuff(ARR, ...) slprintfbuff((ARR), sizeof(ARR), __VA_ARGS__)
+#endif
 
 /* Thin aliases over the libc allocator/memcpy (historical "t" suffix); no
    added bounds checking. freet() also NULLs the freed pointer and tolerates

--- a/src/htssafe.h
+++ b/src/htssafe.h
@@ -462,12 +462,11 @@ static HTS_INLINE HTS_UNUSED const char *htsbuff_str(const htsbuff *b) {
 
 /**
  * Formatted print into dest (capacity size, NUL included), truncating to fit
- * and always NUL-terminating. Returns HTS_TRUE if the whole output fit.
- * The third contract beside the abort-on-overflow strcpybuff() family: abort
- * is wrong where the source is a remote peer's banner. Discard the result with
- * (void) only where a clipped one is the intended behavior.
+ * and always NUL-terminating. Returns HTS_TRUE if the whole output fit; the
+ * result is the only truncation signal, so it must be acted on. Unlike
+ * strcpybuff() it never aborts, so it suits text built from remote input.
  */
-static HTS_INLINE HTS_UNUSED HTS_PRINTF_FUN(3, 4) hts_boolean
+static HTS_INLINE HTS_UNUSED HTS_CHECK_RESULT HTS_PRINTF_FUN(3, 4) hts_boolean
     slprintfbuff(char *dest, size_t size, const char *fmt, ...) {
   va_list args;
   int ret;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -568,6 +568,44 @@ static int string_safety_selftests(void) {
       return 1;
   }
 
+  /* sprintfbuff: truncate-and-report. Must never abort (its callers format
+     remote banners) nor write past the array, which the canary catches. */
+  {
+    struct {
+      char dst[8];
+      char canary[8];
+    } s;
+
+    const char *const big = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+    memset(&s, '#', sizeof(s));
+    if (!sprintfbuff(s.dst, "%s-%d", "ab", 42) || strcmp(s.dst, "ab-42") != 0)
+      return 1;
+
+    /* exact fit: 7 characters plus the NUL */
+    if (!sprintfbuff(s.dst, "%s", "1234567") || strcmp(s.dst, "1234567") != 0)
+      return 1;
+
+    /* one over, then far over: truncated, terminated, reported */
+    if (sprintfbuff(s.dst, "%s", "12345678") || strcmp(s.dst, "1234567") != 0)
+      return 1;
+    if (sprintfbuff(s.dst, "%s", big) || strlen(s.dst) != sizeof(s.dst) - 1)
+      return 1;
+
+    if (memcmp(s.canary, "########", sizeof(s.canary)) != 0)
+      return 1;
+
+    /* explicit-capacity form, down to the degenerate size 1 */
+    {
+      char *const p = s.dst;
+
+      if (slprintfbuff(p, 1, "%s", "x") || p[0] != '\0')
+        return 1;
+      if (!slprintfbuff(p, sizeof(s.dst), "%s", "ok") || strcmp(p, "ok") != 0)
+        return 1;
+    }
+  }
+
   /* StringCatN/StringSetLength must eval SIZE once: (n_eval++, V) leaves
      n_eval == 2 on a double-eval macro. */
   {

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -578,32 +578,42 @@ static int string_safety_selftests(void) {
 
     const char *const big = "0123456789abcdefghijklmnopqrstuvwxyz";
 
+    /* repoison before every call, or an implementation that measures first and
+       writes nothing "passes" the truncating cases on the previous content */
+#define POISON_DST() memset(s.dst, '#', sizeof(s.dst))
+
     memset(&s, '#', sizeof(s));
     if (!sprintfbuff(s.dst, "%s-%d", "ab", 42) || strcmp(s.dst, "ab-42") != 0)
       return 1;
 
     /* exact fit: 7 characters plus the NUL */
+    POISON_DST();
     if (!sprintfbuff(s.dst, "%s", "1234567") || strcmp(s.dst, "1234567") != 0)
       return 1;
 
-    /* one over, then far over: truncated, terminated, reported */
+    /* one over, then far over: truncated to the prefix, terminated, reported */
+    POISON_DST();
     if (sprintfbuff(s.dst, "%s", "12345678") || strcmp(s.dst, "1234567") != 0)
       return 1;
-    if (sprintfbuff(s.dst, "%s", big) || strlen(s.dst) != sizeof(s.dst) - 1)
-      return 1;
-
-    if (memcmp(s.canary, "########", sizeof(s.canary)) != 0)
+    POISON_DST();
+    if (sprintfbuff(s.dst, "%s", big) || strcmp(s.dst, "0123456") != 0)
       return 1;
 
     /* explicit-capacity form, down to the degenerate size 1 */
     {
       char *const p = s.dst;
 
+      POISON_DST();
       if (slprintfbuff(p, 1, "%s", "x") || p[0] != '\0')
         return 1;
+      POISON_DST();
       if (!slprintfbuff(p, sizeof(s.dst), "%s", "ok") || strcmp(p, "ok") != 0)
         return 1;
     }
+#undef POISON_DST
+
+    if (memcmp(s.canary, "########", sizeof(s.canary)) != 0)
+      return 1;
   }
 
   /* StringCatN/StringSetLength must eval SIZE once: (n_eval++, V) leaves
@@ -2799,6 +2809,32 @@ static int st_makeindex(httrackp *opt, int argc, char **argv) {
   assertf(strstr(buf, "Mirror and index made by HTTrack") != NULL);
   assertf(strstr(buf, "Refresh") != NULL);
   assertf(strstr(buf, "example.com") != NULL);
+
+  /* a first link whose escaped form overruns the old flat 1024-byte tempo: the
+     redirect must carry the whole URL, not a clipped prefix */
+  {
+    char BIGSTK link[HTS_URLMAXSIZE * 2];
+    char *p = link;
+
+    strcpybuff(link, "http://example.com/");
+    p += strlen(link);
+    memset(p, 'a', 1200);
+    p += 1200;
+    strcpy(p, "/end.html");
+
+    done = 0;
+    fp = fopen(path, "wb");
+    assertf(fp != NULL);
+    hts_finish_makeindex(opt, &done, &fp, 1, link, "%s%s", "", "");
+    assertf(fp == NULL);
+    fp = fopen(path, "rb");
+    assertf(fp != NULL);
+    n = fread(buf, 1, sizeof(buf) - 1, fp);
+    fclose(fp);
+    buf[n] = '\0';
+    /* the closing quote proves the URL was not clipped mid-way */
+    assertf(strstr(buf, "/end.html\">") != NULL);
+  }
 
   /* no single link: footer only, no refresh meta */
   done = 0;

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -973,8 +973,7 @@ int PT_LoadCache__New(PT_Index index_, const char *filename) {
                     const char *scheme =
                         link_has_authority(filenameIndex) ? "" : "http://";
 
-                    /* dropped rather than truncated; keep looking at later
-                     * entries */
+                    /* dropped rather than truncated; try the next entry */
                     if (sprintfbuff(index->startUrl, "%s%s", scheme,
                                     filenameIndex))
                       firstSeen = 1;
@@ -1575,8 +1574,7 @@ static int PT_LoadCache__Old(PT_Index index_, const char *filename) {
                   const char *scheme =
                       link_has_authority(line) ? "" : "http://";
 
-                  /* dropped rather than truncated; keep looking at later
-                   * entries */
+                  /* dropped rather than truncated; try the next entry */
                   if (sprintfbuff(index->startUrl, "%s%s", scheme, line))
                     firstSeen = 1;
                   else

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -579,9 +579,10 @@ PT_Index PT_LoadCache(const char *filename) {
         if (chain != NULL) {
           const char *scheme = link_has_authority(chain->name) ? "" : "http://";
 
-          snprintf(index->slots.common.startUrl,
-                   sizeof(index->slots.common.startUrl), "%s%s", scheme,
-                   (const char *) chain->name);
+          /* dropped rather than truncated: empty already reads as "unset" */
+          if (!sprintfbuff(index->slots.common.startUrl, "%s%s", scheme,
+                           (const char *) chain->name))
+            index->slots.common.startUrl[0] = '\0';
         }
       }
     }
@@ -972,9 +973,13 @@ int PT_LoadCache__New(PT_Index index_, const char *filename) {
                     const char *scheme =
                         link_has_authority(filenameIndex) ? "" : "http://";
 
-                    firstSeen = 1;
-                    snprintf(index->startUrl, sizeof(index->startUrl), "%s%s",
-                             scheme, filenameIndex);
+                    /* dropped rather than truncated; keep looking at later
+                     * entries */
+                    if (sprintfbuff(index->startUrl, "%s%s", scheme,
+                                    filenameIndex))
+                      firstSeen = 1;
+                    else
+                      index->startUrl[0] = '\0';
                   }
                 }
               } else {
@@ -1570,9 +1575,12 @@ static int PT_LoadCache__Old(PT_Index index_, const char *filename) {
                   const char *scheme =
                       link_has_authority(line) ? "" : "http://";
 
-                  firstSeen = 1;
-                  snprintf(index->startUrl, sizeof(index->startUrl), "%s%s",
-                           scheme, line);
+                  /* dropped rather than truncated; keep looking at later
+                   * entries */
+                  if (sprintfbuff(index->startUrl, "%s%s", scheme, line))
+                    firstSeen = 1;
+                  else
+                    index->startUrl[0] = '\0';
                 }
               }
 


### PR DESCRIPTION
Adds `sprintfbuff()`/`slprintfbuff()` to `htssafe.h`: a formatted print that truncates to fit and returns whether it had to, marked `warn_unused_result` so the answer cannot be dropped. It fills the gap between the `strcpybuff` family, which aborts on overflow, and `String`, which grows without bound. Abort is the wrong contract wherever the text is built from a remote peer's reply.

Four `-Wformat-truncation=` sites used the result as if `snprintf` had never truncated. Two only needed a bigger destination, so they get one: `hts_finish_makeindex`'s `tempo` was a flat 1024 against a 2048-byte escaped URL and is now sized off it, and the wizard's `cmd[4096]` could not hold the answers it concatenates. The other two cannot grow. `create_back_tmpfile` formats `<url_sav>.bak` into a buffer the same size as `url_sav`, and that struct is installed, so a dropped extension would alias the backup onto the live file that `back_finalize_backup()` unlinks. ProxyTrack's `startUrl[1024]` is fed by cache content. Both take the error path they already had, and ProxyTrack moves to the next cache entry rather than publishing a clipped one.

On what the wrapper buys, since it is not what I first assumed: checking a raw `snprintf` return inline silences the warning just as well. The wrapper's value is that the capacity comes from `sizeof`, the check is the default rather than the exception, and `warn_unused_result` makes skipping it visible.

`-#test=strsafe` covers the primitive (exact fit, one over, 4 KB source, `size == 1`, trailing canary, destination repoisoned between cases), and `-#test=makeindex` gains a first link whose escaped form overruns the old buffer. Both were mutation-checked. The ProxyTrack change ships without a direct test: its only observable is the catalog page, which renders solely as a PROPFIND fallback I could not drive from curl. 25 gcc warnings down to 21; the rest of the cluster is diagnostic-only and follows separately.