### PR TITLE
Diagnostic messages built from remote replies discard snprintf's truncation signal

### DIFF
--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -251,7 +251,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
       // folding a nonsense port into 1..65535 fetches one the link never named;
       // an empty "host:" just means the default (#614)
       if (a[1] != '\0' && !hts_parse_url_port(a + 1, &port)) {
-        snprintf(back->r.msg, sizeof(back->r.msg), "Invalid port: %s", a + 1);
+        htsblk_failf(&back->r, "Invalid port: %s", a + 1);
         back->r.statuscode = STATUSCODE_INVALID; // permanent, unlike a DNS miss
         _HALT_FTP return 0;
       }
@@ -262,8 +262,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
     // récupérer adresse résolue
     strcpybuff(back->info, "host name");
     if (hts_dns_resolve2(opt, _adr, &server, &error) == NULL) {
-      snprintf(back->r.msg, sizeof(back->r.msg),
-               "Unable to get server's address: %s", error);
+      htsblk_failf(&back->r, "Unable to get server's address: %s", error);
       back->r.statuscode = STATUSCODE_NON_FATAL;
       _HALT_FTP return 0;
     }
@@ -332,18 +331,15 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
             }
 
           } else {
-            snprintf(back->r.msg, sizeof(back->r.msg), "Bad password: %s",
-                     linejmp(line));
+            htsblk_failf(&back->r, "Bad password: %s", linejmp(line));
             back->r.statuscode = STATUSCODE_INVALID;
           }
         } else {
-          snprintf(back->r.msg, sizeof(back->r.msg), "Bad user name: %s",
-                   linejmp(line));
+          htsblk_failf(&back->r, "Bad user name: %s", linejmp(line));
           back->r.statuscode = STATUSCODE_INVALID;
         }
       } else {
-        snprintf(back->r.msg, sizeof(back->r.msg), "Connection refused: %s",
-                 linejmp(line));
+        htsblk_failf(&back->r, "Connection refused: %s", linejmp(line));
         back->r.statuscode = STATUSCODE_INVALID;
       }
 
@@ -410,8 +406,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
             }
             // -- fin analyse de l'adresse IP et du port --
           } else {
-            snprintf(back->r.msg, sizeof(back->r.msg), "PASV incorrect: %s",
-                     linejmp(line));
+            htsblk_failf(&back->r, "PASV incorrect: %s", linejmp(line));
             back->r.statuscode = STATUSCODE_INVALID;
           }                     // sinon on est prêts
         } else {
@@ -442,13 +437,11 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
                 }
               }
             } else {
-              snprintf(back->r.msg, sizeof(back->r.msg), "EPSV incorrect: %s",
-                       linejmp(line));
+              htsblk_failf(&back->r, "EPSV incorrect: %s", linejmp(line));
               back->r.statuscode = STATUSCODE_INVALID;
             }
           } else {
-            snprintf(back->r.msg, sizeof(back->r.msg), "PASV/EPSV error: %s",
-                     linejmp(line));
+            htsblk_failf(&back->r, "PASV/EPSV error: %s", linejmp(line));
             back->r.statuscode = STATUSCODE_INVALID;
           }                     // sinon on est prêts
         }
@@ -554,8 +547,8 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
                   deletesoc(soc_dat);
                   soc_dat = INVALID_SOCKET;
                   //
-                  snprintf(back->r.msg, sizeof(back->r.msg),
-                           "RETR command error: %s", linejmp(line));
+                  htsblk_failf(&back->r, "RETR command error: %s",
+                               linejmp(line));
                   back->r.statuscode = STATUSCODE_INVALID;
                 }               // sinon on est prêts
               } else {
@@ -573,13 +566,12 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
               back->r.statuscode = STATUSCODE_INVALID;
             }                   // sinon on est prêts
           } else {
-            snprintf(back->r.msg, sizeof(back->r.msg),
-                     "Unable to resolve IP %s: %s", adr_ip, error);
+            htsblk_failf(&back->r, "Unable to resolve IP %s: %s", adr_ip,
+                         error);
             back->r.statuscode = STATUSCODE_INVALID;
           }                     // sinon on est prêts
         } else {
-          snprintf(back->r.msg, sizeof(back->r.msg), "PASV incorrect: %s",
-                   linejmp(line));
+          htsblk_failf(&back->r, "PASV incorrect: %s", linejmp(line));
           back->r.statuscode = STATUSCODE_INVALID;
         }                       // sinon on est prêts
 #else
@@ -603,13 +595,11 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
                 back->r.statuscode = STATUSCODE_INVALID;
               }
             } else {
-              snprintf(back->r.msg, sizeof(back->r.msg),
-                       "RETR command error: %s", linejmp(line));
+              htsblk_failf(&back->r, "RETR command error: %s", linejmp(line));
               back->r.statuscode = STATUSCODE_INVALID;
             }
           } else {
-            snprintf(back->r.msg, sizeof(back->r.msg), "PORT command error: %s",
-                     linejmp(line));
+            htsblk_failf(&back->r, "PORT command error: %s", linejmp(line));
             back->r.statuscode = STATUSCODE_INVALID;
           }
 #ifdef _WIN32
@@ -652,8 +642,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
                 len = 0;        // fin
                 break;
               case 0:
-                snprintf(back->r.msg, sizeof(back->r.msg), "Time out (%d)",
-                         timeout);
+                htsblk_failf(&back->r, "Time out (%d)", timeout);
                 back->r.statuscode = STATUSCODE_INVALID;
                 len = 0;        // fin
                 break;
@@ -716,8 +705,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
                 strcpybuff(back->r.msg, "OK");
                 back->r.statuscode = HTTP_OK;
               } else {
-                snprintf(back->r.msg, sizeof(back->r.msg), "RETR incorrect: %s",
-                         linejmp(line));
+                htsblk_failf(&back->r, "RETR incorrect: %s", linejmp(line));
                 back->r.statuscode = STATUSCODE_INVALID;
               }
             } else {

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -2541,7 +2541,7 @@ void htsblk_failf(htsblk *r, const char *fmt, ...) {
   va_list args;
 
   va_start(args, fmt);
-  // discarding the fit flag is the point: clipping a diagnostic is intended
+  // deliberate clip: the reason is quoted from a remote reply
   (void) vslprintfbuff(r->msg, sizeof(r->msg), fmt, args);
   va_end(args);
 }

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -2537,6 +2537,15 @@ void fil_simplifie(char *f) {
   }
 }
 
+void htsblk_failf(htsblk *r, const char *fmt, ...) {
+  va_list args;
+
+  va_start(args, fmt);
+  // discarding the fit flag is the point: clipping a diagnostic is intended
+  (void) vslprintfbuff(r->msg, sizeof(r->msg), fmt, args);
+  va_end(args);
+}
+
 // fermer liaison fichier ou socket
 void deletehttp(htsblk * r) {
 #if HTS_DEBUG_CLOSESOCK

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -199,6 +199,10 @@ T_SOC newhttp(httrackp * opt, const char *iadr, htsblk * retour, int port,
    etc.). */
 T_SOC newhttp_addr(httrackp *opt, const char *iadr, htsblk *retour, int port,
                    int waitconnect, int addr_index, int *addr_count);
+/* Set r->msg to the formatted failure reason, clipped to fit: the message is
+   diagnostic only. Leaves r->statuscode alone, the caller sets it. */
+void htsblk_failf(htsblk *r, const char *fmt, ...) HTS_PRINTF_FUN(2, 3);
+
 HTS_INLINE void deletehttp(htsblk * r);
 HTS_INLINE int deleteaddr(htsblk * r);
 HTS_INLINE void deletesoc(T_SOC soc);

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -199,8 +199,8 @@ T_SOC newhttp(httrackp * opt, const char *iadr, htsblk * retour, int port,
    etc.). */
 T_SOC newhttp_addr(httrackp *opt, const char *iadr, htsblk *retour, int port,
                    int waitconnect, int addr_index, int *addr_count);
-/* Set r->msg to the formatted failure reason, clipped to fit: the message is
-   diagnostic only. Leaves r->statuscode alone, the caller sets it. */
+/* Clips the formatted failure reason into r->msg, which also round-trips
+   through the cache as X-StatusMessage. Leaves r->statuscode to the caller. */
 void htsblk_failf(htsblk *r, const char *fmt, ...) HTS_PRINTF_FUN(2, 3);
 
 HTS_INLINE void deletehttp(htsblk * r);

--- a/src/htsproxy.c
+++ b/src/htsproxy.c
@@ -173,8 +173,8 @@ int http_proxy_tunnel(httrackp *opt, htsblk *retour, const char *adr,
   if (sscanf(line, "HTTP/%*d.%*d %d", &code) < 1)
     code = 0;
   if (code < 200 || code >= 300) {
-    snprintf(retour->msg, sizeof(retour->msg), "proxy CONNECT refused: %s",
-             strnotempty(line) ? line : "(no status)");
+    htsblk_failf(retour, "proxy CONNECT refused: %s",
+                 strnotempty(line) ? line : "(no status)");
     return 0;
   }
 

--- a/src/htssafe.h
+++ b/src/htssafe.h
@@ -461,12 +461,11 @@ static HTS_INLINE HTS_UNUSED const char *htsbuff_str(const htsbuff *b) {
 }
 
 /**
- * va_list form of slprintfbuff(). Callers that deliberately ignore truncation
- * use this one, so it is not HTS_CHECK_RESULT.
+ * Callers that deliberately ignore truncation use this instead of
+ * slprintfbuff(), so it is not HTS_CHECK_RESULT.
  */
-static HTS_INLINE HTS_UNUSED hts_boolean vslprintfbuff(char *dest, size_t size,
-                                                       const char *fmt,
-                                                       va_list args) {
+static HTS_INLINE HTS_UNUSED HTS_PRINTF_FUN(3, 0) hts_boolean
+    vslprintfbuff(char *dest, size_t size, const char *fmt, va_list args) {
   int ret;
 
   assertf(dest != NULL && size != 0);

--- a/src/htssafe.h
+++ b/src/htssafe.h
@@ -461,6 +461,22 @@ static HTS_INLINE HTS_UNUSED const char *htsbuff_str(const htsbuff *b) {
 }
 
 /**
+ * va_list form of slprintfbuff(). Callers that deliberately ignore truncation
+ * use this one, so it is not HTS_CHECK_RESULT.
+ */
+static HTS_INLINE HTS_UNUSED hts_boolean vslprintfbuff(char *dest, size_t size,
+                                                       const char *fmt,
+                                                       va_list args) {
+  int ret;
+
+  assertf(dest != NULL && size != 0);
+  ret = vsnprintf(dest, size, fmt, args);
+  /* pre-C99 runtimes (msvcrt _vsnprintf) return -1 and do not terminate */
+  dest[size - 1] = '\0';
+  return ret >= 0 && (size_t) ret < size ? HTS_TRUE : HTS_FALSE;
+}
+
+/**
  * Formatted print into dest (capacity size, NUL included), truncating to fit
  * and always NUL-terminating. Returns HTS_TRUE if the whole output fit; the
  * result is the only truncation signal, so it must be acted on. Unlike
@@ -469,15 +485,12 @@ static HTS_INLINE HTS_UNUSED const char *htsbuff_str(const htsbuff *b) {
 static HTS_INLINE HTS_UNUSED HTS_CHECK_RESULT HTS_PRINTF_FUN(3, 4) hts_boolean
     slprintfbuff(char *dest, size_t size, const char *fmt, ...) {
   va_list args;
-  int ret;
+  hts_boolean ret;
 
-  assertf(dest != NULL && size != 0);
   va_start(args, fmt);
-  ret = vsnprintf(dest, size, fmt, args);
+  ret = vslprintfbuff(dest, size, fmt, args);
   va_end(args);
-  /* pre-C99 runtimes (msvcrt _vsnprintf) return -1 and do not terminate */
-  dest[size - 1] = '\0';
-  return ret >= 0 && (size_t) ret < size ? HTS_TRUE : HTS_FALSE;
+  return ret;
 }
 
 /**

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -617,6 +617,35 @@ static int string_safety_selftests(void) {
       return 1;
   }
 
+  /* htsblk_failf: clips a reason quoted from a remote reply into msg[] and
+     leaves statuscode to the caller */
+  {
+    htsblk r;
+    char expect[sizeof(r.msg)];
+    char big[4 * sizeof(r.msg)];
+
+    memset(&r, 0, sizeof(r));
+    r.statuscode = 1234;
+
+    memset(r.msg, '#', sizeof(r.msg));
+    htsblk_failf(&r, "PASV incorrect: %s", "220 ok");
+    if (strcmp(r.msg, "PASV incorrect: 220 ok") != 0 || r.statuscode != 1234)
+      return 1;
+
+    /* clipped to capacity and terminated; the expected bytes differ from the
+       case above, so writing nothing cannot pass on the leftovers */
+    memset(big, 'z', sizeof(big) - 1);
+    big[sizeof(big) - 1] = '\0';
+    memset(expect, 'z', sizeof(expect) - 1);
+    expect[sizeof(expect) - 1] = '\0';
+    memcpy(expect, "Bad user name: ", sizeof("Bad user name: ") - 1);
+
+    memset(r.msg, '#', sizeof(r.msg));
+    htsblk_failf(&r, "Bad user name: %s", big);
+    if (strcmp(r.msg, expect) != 0 || r.statuscode != 1234)
+      return 1;
+  }
+
   /* StringCatN/StringSetLength must eval SIZE once: (n_eval++, V) leaves
      n_eval == 2 on a double-eval macro. */
   {
@@ -4998,10 +5027,10 @@ static int st_cookieimport(httrackp *opt, int argc, char **argv) {
   char fpath[HTS_URLMAXSIZE * 2];
   char file[HTS_URLMAXSIZE * 2];
 
-  snprintf(fpath, sizeof(fpath), "%s/", dir); /* IE glob wants a trailing sep */
+  assertf(sprintfbuff(fpath, "%s/", dir)); /* IE glob wants a trailing sep */
 
   /* cookies.txt: one Netscape record (host, _, path, _, _, name, value). */
-  snprintf(file, sizeof(file), "%scookies.txt", fpath);
+  assertf(sprintfbuff(file, "%scookies.txt", fpath));
   {
     FILE *fp = FOPEN(file, "wb");
 
@@ -5011,7 +5040,7 @@ static int st_cookieimport(httrackp *opt, int argc, char **argv) {
   }
 
   /* A copied IE cookie u@v.txt: name, value, url, then 6 unused fields. */
-  snprintf(file, sizeof(file), "%su@v.txt", fpath);
+  assertf(sprintfbuff(file, "%su@v.txt", fpath));
   {
     FILE *fp = FOPEN(file, "wb");
 
@@ -5033,7 +5062,7 @@ static int st_cookieimport(httrackp *opt, int argc, char **argv) {
 #endif
 
   (void) UNLINK(file); /* u@v.txt (already gone on Windows) */
-  snprintf(file, sizeof(file), "%scookies.txt", fpath);
+  assertf(sprintfbuff(file, "%scookies.txt", fpath));
   (void) UNLINK(file);
   dir[dirlen] = '\0';
   while (strlen(dir) > base) {

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -618,22 +618,35 @@ static int string_safety_selftests(void) {
   }
 
   /* htsblk_failf: clips a reason quoted from a remote reply into msg[] and
-     leaves statuscode to the caller */
+     touches nothing else in the block */
   {
     htsblk r;
     char expect[sizeof(r.msg)];
     char big[4 * sizeof(r.msg)];
+
+    /* contenttype abuts msg, so a one-past-the-end store lands in it rather
+       than in padding; checking it is this block's canary */
+#define NEIGHBOURS_INTACT() (r.contenttype[0] == '\0' && r.statuscode == 1234)
 
     memset(&r, 0, sizeof(r));
     r.statuscode = 1234;
 
     memset(r.msg, '#', sizeof(r.msg));
     htsblk_failf(&r, "PASV incorrect: %s", "220 ok");
-    if (strcmp(r.msg, "PASV incorrect: 220 ok") != 0 || r.statuscode != 1234)
+    if (strcmp(r.msg, "PASV incorrect: 220 ok") != 0 || !NEIGHBOURS_INTACT())
       return 1;
 
-    /* clipped to capacity and terminated; the expected bytes differ from the
-       case above, so writing nothing cannot pass on the leftovers */
+    /* exact fit: capacity - 1 characters plus the NUL */
+    memset(expect, 'y', sizeof(expect) - 1);
+    expect[sizeof(expect) - 1] = '\0';
+    memcpy(expect, "Bad password: ", sizeof("Bad password: ") - 1);
+    memset(r.msg, '#', sizeof(r.msg));
+    htsblk_failf(&r, "%s", expect);
+    if (strcmp(r.msg, expect) != 0 || !NEIGHBOURS_INTACT())
+      return 1;
+
+    /* far over: the expected bytes differ from the cases above, so writing
+       nothing cannot pass on the leftovers */
     memset(big, 'z', sizeof(big) - 1);
     big[sizeof(big) - 1] = '\0';
     memset(expect, 'z', sizeof(expect) - 1);
@@ -642,8 +655,9 @@ static int string_safety_selftests(void) {
 
     memset(r.msg, '#', sizeof(r.msg));
     htsblk_failf(&r, "Bad user name: %s", big);
-    if (strcmp(r.msg, expect) != 0 || r.statuscode != 1234)
+    if (strcmp(r.msg, expect) != 0 || !NEIGHBOURS_INTACT())
       return 1;
+#undef NEIGHBOURS_INTACT
   }
 
   /* StringCatN/StringSetLength must eval SIZE once: (n_eval++, V) leaves

--- a/src/htsweb.h
+++ b/src/htsweb.h
@@ -42,7 +42,7 @@ Please visit our Website: http://www.httrack.com
 typedef struct t_StatsBuffer {
   char name[1024];
   char file[1024];
-  char state[256];
+  char state[288];                      // a short label plus back->info[256]
   char url_sav[HTS_URLMAXSIZE * 2];     // pour cancel
   char url_adr[HTS_URLMAXSIZE * 2];
   char url_fil[HTS_URLMAXSIZE * 2];

--- a/src/httrack.h
+++ b/src/httrack.h
@@ -44,7 +44,7 @@ typedef struct t_StatsBuffer t_StatsBuffer;
 struct t_StatsBuffer {
   char name[1024];
   char file[1024];
-  char state[256];
+  char state[288]; // a short label plus back->info[256]
   char BIGSTK url_sav[HTS_URLMAXSIZE * 2];      // pour cancel
   char BIGSTK url_adr[HTS_URLMAXSIZE * 2];
   char BIGSTK url_fil[HTS_URLMAXSIZE * 2];

--- a/src/proxy/proxytrack.c
+++ b/src/proxy/proxytrack.c
@@ -688,7 +688,7 @@ static PT_Element proxytrack_process_DAV_Request(PT_Indexes indexes,
     PT_Element elt = PT_ElementNew();
 
     elt->statuscode = 405;
-    strcpy(elt->msg, "Method Not Allowed");
+    strcpybuff(elt->msg, "Method Not Allowed");
     return elt;
   }
 
@@ -822,7 +822,7 @@ static PT_Element proxytrack_process_DAV_Request(PT_Indexes indexes,
     elt->statuscode = 207;      /* Multi-Status */
     strcpy(elt->charset, "utf-8");
     strcpy(elt->contenttype, "text/xml");
-    strcpy(elt->msg, "Multi-Status");
+    strcpybuff(elt->msg, "Multi-Status");
     StringFree(response);
 
     fprintf(stderr, "RESPONSE:\n%s\n", elt->adr);
@@ -879,7 +879,7 @@ static PT_Element proxytrack_process_HTTP_List(PT_Indexes indexes,
     elt->statuscode = HTTP_OK;
     strcpy(elt->charset, "iso-8859-1");
     strcpy(elt->contenttype, "text/html");
-    strcpy(elt->msg, "OK");
+    strcpybuff(elt->msg, "OK");
     StringFree(html);
     return elt;
   }

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -407,7 +407,7 @@ PT_Element PT_Index_HTML_BuildRootInfo(PT_Indexes indexes) {
     elt->statuscode = HTTP_OK;
     strcpy(elt->charset, "iso-8859-1");
     strcpy(elt->contenttype, "text/html");
-    strcpy(elt->msg, "OK");
+    strcpybuff(elt->msg, "OK");
     StringFree(html);
     return elt;
   }
@@ -828,6 +828,18 @@ PT_Element PT_ElementNew(void) {
   return r;
 }
 
+/* ProxyTrack's htsblk_failf(): a clipped, diagnostic-only failure reason. */
+static void PT_Element_failf(PT_Element r, const char *fmt, ...)
+    HTS_PRINTF_FUN(2, 3);
+
+static void PT_Element_failf(PT_Element r, const char *fmt, ...) {
+  va_list args;
+
+  va_start(args, fmt);
+  (void) vslprintfbuff(r->msg, sizeof(r->msg), fmt, args);
+  va_end(args);
+}
+
 PT_Element PT_ReadCache(PT_Index index, const char *url, int flags) {
   if (index != NULL && SAFE_INDEX(index)) {
     return _IndexFuncts[index->type].PT_ReadCache(index, url, flags);
@@ -1139,8 +1151,9 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
                   snprintf(previous_save, sizeof(previous_save), "%s%s",
                            index->path, previous_save_ + index->fixedPath);
                 } else {
-                  snprintf(r->msg, sizeof(r->msg), "Bogus fixePath prefix for %s (prefixLen=%d)",
-                          previous_save_, (int) index->fixedPath);
+                  PT_Element_failf(
+                      r, "Bogus fixePath prefix for %s (prefixLen=%d)",
+                      previous_save_, (int) index->fixedPath);
                   r->statuscode = STATUSCODE_INVALID;
                 }
               } else {
@@ -1159,7 +1172,7 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
             // Peut-on stocker le fichier directement sur disque?
             if (ok) {
               if (r->msg[0] == '\0') {
-                strcpy(r->msg, "Cache Read Error : Unexpected error");
+                strcpybuff(r->msg, "Cache Read Error : Unexpected error");
               }
             } else {            // lire en mémoire
 
@@ -1177,24 +1190,27 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
                           int last_errno = errno;
 
                           r->statuscode = STATUSCODE_INVALID;
-                          sprintf(r->msg, "Read error in cache disk data: %s",
-                                  strerror(last_errno));
+                          PT_Element_failf(r,
+                                           "Read error in cache disk data: %s",
+                                           strerror(last_errno));
                         }
                         r->adr[r->size] = '\0';
                       } else {
                         r->statuscode = STATUSCODE_INVALID;
-                        strcpy(r->msg,
-                               "Read error (memory exhausted) from cache");
+                        strcpybuff(r->msg,
+                                   "Read error (memory exhausted) from cache");
                       }
                       fclose(fp);
                     } else {
                       r->statuscode = STATUSCODE_INVALID;
-                      snprintf(r->msg, sizeof(r->msg), "Read error (can't open '%s') from cache",
-                              file_convert(catbuff, sizeof(catbuff), previous_save));
+                      PT_Element_failf(
+                          r, "Read error (can't open '%s') from cache",
+                          file_convert(catbuff, sizeof(catbuff),
+                                       previous_save));
                     }
                   } else {
                     r->statuscode = STATUSCODE_INVALID;
-                    strcpy(r->msg, "Cached file name is invalid");
+                    strcpybuff(r->msg, "Cached file name is invalid");
                   }
                 }
               } else {
@@ -1206,12 +1222,12 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
                       free(r->adr);
                       r->adr = NULL;
                       r->statuscode = STATUSCODE_INVALID;
-                      strcpy(r->msg, "Cache Read Error : Read Data");
+                      strcpybuff(r->msg, "Cache Read Error : Read Data");
                     } else
                       *(r->adr + r->size) = '\0';
                   } else {      // erreur
                     r->statuscode = STATUSCODE_INVALID;
-                    strcpy(r->msg, "Cache Memory Error");
+                    strcpybuff(r->msg, "Cache Memory Error");
                   }
                 }
               }
@@ -1219,21 +1235,21 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
           }                     // si save==null, ne rien charger (juste en tête)
         } else {
           r->statuscode = STATUSCODE_INVALID;
-          strcpy(r->msg, "Cache Read Error : Read Header Data");
+          strcpybuff(r->msg, "Cache Read Error : Read Header Data");
         }
         unzCloseCurrentFile(index->zFile);
       } else {
         r->statuscode = STATUSCODE_INVALID;
-        strcpy(r->msg, "Cache Read Error : Open File");
+        strcpybuff(r->msg, "Cache Read Error : Open File");
       }
 
     } else {
       r->statuscode = STATUSCODE_INVALID;
-      strcpy(r->msg, "Cache Read Error : Bad Offset");
+      strcpybuff(r->msg, "Cache Read Error : Bad Offset");
     }
   } else {
     r->statuscode = STATUSCODE_INVALID;
-    strcpy(r->msg, "File Cache Entry Not Found");
+    strcpybuff(r->msg, "File Cache Entry Not Found");
   }
   if (r->location[0] != '\0') {
     r->location = strdup(r->location);
@@ -1799,8 +1815,9 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
                 snprintf(previous_save, sizeof(previous_save), "%s%s",
                          index->path, previous_save_ + index->fixedPath);
               } else {
-                snprintf(r->msg, sizeof(r->msg), "Bogus fixePath prefix for %s (prefixLen=%d)",
-                        previous_save_, (int) index->fixedPath);
+                PT_Element_failf(r,
+                                 "Bogus fixePath prefix for %s (prefixLen=%d)",
+                                 previous_save_, (int) index->fixedPath);
                 r->statuscode = STATUSCODE_INVALID;
               }
             } else {
@@ -1826,17 +1843,18 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
                 if (r->adr != NULL) {
                   if (r->size > 0 && fread(r->adr, 1, r->size, fp) != r->size) {
                     r->statuscode = STATUSCODE_INVALID;
-                    strcpy(r->msg, "Read error in cache disk data");
+                    strcpybuff(r->msg, "Read error in cache disk data");
                   }
                   r->adr[r->size] = '\0';
                 } else {
                   r->statuscode = STATUSCODE_INVALID;
-                  strcpy(r->msg, "Read error (memory exhausted) from cache");
+                  strcpybuff(r->msg,
+                             "Read error (memory exhausted) from cache");
                 }
                 fclose(fp);
               } else {
                 r->statuscode = STATUSCODE_INVALID;
-                strcpy(r->msg, "Previous cache file not found (2)");
+                strcpybuff(r->msg, "Previous cache file not found (2)");
               }
             }
           } else {
@@ -1848,30 +1866,30 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
                   free(r->adr);
                   r->adr = NULL;
                   r->statuscode = STATUSCODE_INVALID;
-                  strcpy(r->msg, "Cache Read Error : Read Data");
+                  strcpybuff(r->msg, "Cache Read Error : Read Data");
                 } else
                   r->adr[r->size] = '\0';
               } else {          // erreur
                 r->statuscode = STATUSCODE_INVALID;
-                strcpy(r->msg, "Cache Memory Error");
+                strcpybuff(r->msg, "Cache Memory Error");
               }
             }
           }
         } else {
           r->statuscode = STATUSCODE_INVALID;
-          strcpy(r->msg, "Cache Read Error : Bad Data");
+          strcpybuff(r->msg, "Cache Read Error : Bad Data");
         }
       } else {                  // erreur
         r->statuscode = STATUSCODE_INVALID;
-        strcpy(r->msg, "Cache Read Error : Read Header");
+        strcpybuff(r->msg, "Cache Read Error : Read Header");
       }
     } else {
       r->statuscode = STATUSCODE_INVALID;
-      strcpy(r->msg, "Cache Read Error : Seek Failed");
+      strcpybuff(r->msg, "Cache Read Error : Seek Failed");
     }
   } else {
     r->statuscode = STATUSCODE_INVALID;
-    strcpy(r->msg, "File Cache Entry Not Found");
+    strcpybuff(r->msg, "File Cache Entry Not Found");
   }
   if (r->location[0] != '\0') {
     r->location = strdup(r->location);
@@ -2252,7 +2270,7 @@ static PT_Element PT_ReadCache__Arc_u(PT_Index index_, const char *url,
                 fetchSize = dataLength - metaSize;
               } else if (fetchSize > dataLength - metaSize) {
                 r->statuscode = STATUSCODE_INVALID;
-                strcpy(r->msg, "Cache Read Error : Truncated Data");
+                strcpybuff(r->msg, "Cache Read Error : Truncated Data");
               }
               r->size = 0;
               if (r->statuscode != STATUSCODE_INVALID) {
@@ -2265,12 +2283,13 @@ static PT_Element PT_ReadCache__Arc_u(PT_Index index_, const char *url,
                     int last_errno = errno;
 
                     r->statuscode = STATUSCODE_INVALID;
-                    sprintf(r->msg, "Read error in cache disk data: %s",
-                            strerror(last_errno));
+                    PT_Element_failf(r, "Read error in cache disk data: %s",
+                                     strerror(last_errno));
                   }
                 } else {
                   r->statuscode = STATUSCODE_INVALID;
-                  strcpy(r->msg, "Read error (memory exhausted) from cache");
+                  strcpybuff(r->msg,
+                             "Read error (memory exhausted) from cache");
                 }
               }
             }
@@ -2278,21 +2297,21 @@ static PT_Element PT_ReadCache__Arc_u(PT_Index index_, const char *url,
 
         } else {
           r->statuscode = STATUSCODE_INVALID;
-          strcpy(r->msg, "Cache Read Error : Read Header Error");
+          strcpybuff(r->msg, "Cache Read Error : Read Header Error");
         }
 
       } else {
         r->statuscode = STATUSCODE_INVALID;
-        strcpy(r->msg, "Cache Read Error : Read Header Error");
+        strcpybuff(r->msg, "Cache Read Error : Read Header Error");
       }
     } else {
       r->statuscode = STATUSCODE_INVALID;
-      strcpy(r->msg, "Cache Read Error : Seek Error");
+      strcpybuff(r->msg, "Cache Read Error : Seek Error");
     }
 
   } else {
     r->statuscode = STATUSCODE_INVALID;
-    strcpy(r->msg, "File Cache Entry Not Found");
+    strcpybuff(r->msg, "File Cache Entry Not Found");
   }
   if (r->location[0] != '\0') {
     r->location = strdup(r->location);


### PR DESCRIPTION
The last 18 `-Wformat-truncation=` warnings all had the same shape: build a diagnostic string from a remote server's reply, then drop what `snprintf` returned. `htsblk_failf()` (engine, `htsblk.msg[80]`) and `PT_Element_failf()` (ProxyTrack, `msg[1024]`) clip to fit and absorb that discard once, inside the helper, instead of at every call site.

Clipping is the right answer here rather than a bigger buffer: `msg[80]` lives in the installed `htsopt.h`, so growing it breaks the ABI, and a truncated FTP banner costs nothing. Where the destination is not ABI-fixed the buffer grows instead. `StatsBuffer.state` is private to `httrack.h`/`htsweb.h`, so it goes to 288 and `back->info[256]` now fits alongside its label.

Two unbounded `sprintf(r->msg, ...strerror(...))` calls in ProxyTrack's cache reader get bounded along the way, and the raw `strcpy` neighbours on the same field become `strcpybuff`.

New cases go in the existing `-#test=strsafe`, mutation-tested against wrong-capacity, write-nothing and statuscode-clobbering implementations. Clean build: 21 warnings down to 3. `make check -j`: 143 pass, 8 skip, 0 fail.
