### PR TITLE
tests: test 82 fails on master after #707 and #709 landed together

### DIFF
--- a/tests/82_webhttrack-browse-links.test
+++ b/tests/82_webhttrack-browse-links.test
@@ -100,13 +100,14 @@ except urllib.error.HTTPError as e:
     check(e.code == 404, "/website/ is bound to a project (got %d)" % e.code)
 
 # Point the server at the mirror the way step4.html does; a body without the
-# session id is refused outright.
+# session id is refused outright. Only a profile save records the served root,
+# so post one; command_do=save runs no crawl.
 sid = re.search(r'name="sid" value="([0-9a-f]+)"', finished)
 if sid is None:
     print("FAIL: no sid in the rendered form")
     sys.exit(1)
 fields = [("sid", sid.group(1)), ("path", base), ("projname", "proj"),
-          ("projpath", proj + "/")]
+          ("command", "httrack"), ("command_do", "save"), ("winprofile", "x")]
 body = "&".join("%s=%s" % (k, urllib.parse.quote(v, safe="")) for k, v in fields)
 urllib.request.urlopen(urllib.request.Request(
     url + "/server/step4.html", data=body.encode("latin-1"), method="POST"),

--- a/tests/82_webhttrack-browse-links.test
+++ b/tests/82_webhttrack-browse-links.test
@@ -67,10 +67,10 @@ test -n "${url:-}" || fail "htsserver did not start: $(cat "${srvlog}")"
 srvpid=$(sed -n 's/^PID=//p' "${srvlog}") # absent on Windows
 
 # htsserver resolves the posted paths itself, so hand it native ones.
-"${python}" - "${url}" "$(nativepath "${work}/websites")" "$(nativepath "${proj}")" <<'PY' || fail "browse-link checks failed"
+"${python}" - "${url}" "$(nativepath "${work}/websites")" <<'PY' || fail "browse-link checks failed"
 import re, sys, urllib.error, urllib.parse, urllib.request
 
-url, base, proj = sys.argv[1].rstrip("/"), sys.argv[2], sys.argv[3]
+url, base = sys.argv[1].rstrip("/"), sys.argv[2]
 rc = 0
 
 


### PR DESCRIPTION
Test 82 armed `/website/` by posting a `projpath` field, which is the mechanism #707 removed: the served root is now recorded only when `structcheck()` succeeds during a profile save. Both PRs were green on their own branches and neither conflicted textually, so nothing caught it until master carried both, where the test 404s on the first mirror fetch. It now posts `command=httrack&command_do=save` to arm the root the way step4 does, which runs no crawl. The assertion #709 added is untouched and still fails when finished.html's `file://` link is put back.
