### PR TITLE
Cached headers longer than ProxyTrack's fields overflow into the location pointer

### DIFF
--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -866,12 +866,18 @@ static PT_Element PT_ReadCache__New(PT_Index index, const char *url, int flags) 
   sprintf(headers + headersSize, "%s: "LLintP"\r\n", field, (LLint)(value)); \
   (headersSize) += (int) strlen(headers + headersSize); \
 } while(0)
-#define ZIP_READFIELD_STRING(line, value, refline, refvalue) do { \
-  if (line[0] != '\0' && strfield2(line, refline)) { \
-    strcpy(refvalue, value); \
-    line[0] = '\0'; \
-	} \
-} while(0)
+/* refvalue_size is mandatory: value comes off the cache file bounded only by
+   the line buffer, which dwarfs most destinations. Clipped rather than
+   rejected, since an engine-written cache carries fields wider than ours
+   (contenttype is 128 there, 64 here). */
+#define ZIP_READFIELD_STRING(line, value, refline, refvalue, refvalue_size)    \
+  do {                                                                         \
+    if (line[0] != '\0' && strfield2(line, refline)) {                         \
+      (refvalue)[0] = '\0';                                                    \
+      strlncatbuff(refvalue, value, refvalue_size, (refvalue_size) - 1);       \
+      line[0] = '\0';                                                          \
+    }                                                                          \
+  } while (0)
 #define ZIP_READFIELD_INT(line, value, refline, refvalue) do { \
   if (line[0] != '\0' && strfield2(line, refline)) { \
     int intval = 0; \
@@ -1074,16 +1080,23 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
                 value++;
               ZIP_READFIELD_INT(line, value, "X-In-Cache", dataincache);
               ZIP_READFIELD_INT(line, value, "X-Statuscode", r->statuscode);
-              ZIP_READFIELD_STRING(line, value, "X-StatusMessage", r->msg);     // msg
+              ZIP_READFIELD_STRING(line, value, "X-StatusMessage", r->msg,
+                                   sizeof(r->msg));
               ZIP_READFIELD_INT(line, value, "X-Size", r->size);        // size
-              ZIP_READFIELD_STRING(line, value, "Content-Type", r->contenttype);        // contenttype
-              ZIP_READFIELD_STRING(line, value, "X-Charset", r->charset);       // contenttype
-              ZIP_READFIELD_STRING(line, value, "Last-Modified", r->lastmodified);      // last-modified
-              ZIP_READFIELD_STRING(line, value, "Etag", r->etag);       // Etag
-              ZIP_READFIELD_STRING(line, value, "Location", r->location);       // 'location' pour moved
+              ZIP_READFIELD_STRING(line, value, "Content-Type", r->contenttype,
+                                   sizeof(r->contenttype));
+              ZIP_READFIELD_STRING(line, value, "X-Charset", r->charset,
+                                   sizeof(r->charset));
+              ZIP_READFIELD_STRING(line, value, "Last-Modified",
+                                   r->lastmodified, sizeof(r->lastmodified));
+              ZIP_READFIELD_STRING(line, value, "Etag", r->etag,
+                                   sizeof(r->etag));
+              ZIP_READFIELD_STRING(line, value, "Location", r->location,
+                                   sizeof(location_default));
               ZIP_READFIELD_STRING(line, value, "Content-Disposition",
-                                   r->cdispo); // Content-disposition
-              ZIP_READFIELD_STRING(line, value, "X-Save", previous_save_);      // Original save filename
+                                   r->cdispo, sizeof(r->cdispo));
+              ZIP_READFIELD_STRING(line, value, "X-Save", previous_save_,
+                                   sizeof(previous_save_));
               if (line[0] != '\0') {
                 int len = r->headers ? ((int) strlen(r->headers)) : 0;
                 int nlen =

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -866,10 +866,9 @@ static PT_Element PT_ReadCache__New(PT_Index index, const char *url, int flags) 
   sprintf(headers + headersSize, "%s: "LLintP"\r\n", field, (LLint)(value)); \
   (headersSize) += (int) strlen(headers + headersSize); \
 } while(0)
-/* refvalue_size is mandatory: value comes off the cache file bounded only by
-   the line buffer, which dwarfs most destinations. Clipped rather than
-   rejected, since an engine-written cache carries fields wider than ours
-   (contenttype is 128 there, 64 here). */
+/* refvalue_size is mandatory: the cache line is bounded only by the line
+   buffer, not by the destination. Clip rather than reject, since an
+   engine-written field can be wider than ours. */
 #define ZIP_READFIELD_STRING(line, value, refline, refvalue, refvalue_size)    \
   do {                                                                         \
     if (line[0] != '\0' && strfield2(line, refline)) {                         \
@@ -2147,12 +2146,15 @@ int PT_LoadCache__Arc(PT_Index index_, const char *filename) {
   return 0;
 }
 
-#define HTTP_READFIELD_STRING(line, value, refline, refvalue) do { \
-  if (line[0] != '\0' && strfield2(line, refline)) { \
-    strcpy(refvalue, value); \
-    line[0] = '\0'; \
-	} \
-} while(0)
+/* Same contract as ZIP_READFIELD_STRING, for the ARC reader's header lines. */
+#define HTTP_READFIELD_STRING(line, value, refline, refvalue, refvalue_size)   \
+  do {                                                                         \
+    if (line[0] != '\0' && strfield2(line, refline)) {                         \
+      (refvalue)[0] = '\0';                                                    \
+      strlncatbuff(refvalue, value, refvalue_size, (refvalue_size) - 1);       \
+      line[0] = '\0';                                                          \
+    }                                                                          \
+  } while (0)
 #define HTTP_READFIELD_INT(line, value, refline, refvalue) do { \
   if (line[0] != '\0' && strfield2(line, refline)) { \
     int intval = 0; \
@@ -2221,11 +2223,16 @@ static PT_Element PT_ReadCache__Arc_u(PT_Index index_, const char *url,
               *value = '\0';
               for(value++; *value == ' ' || *value == '\t'; value++) ;
               HTTP_READFIELD_INT(line, value, "Content-Length", r->size);       // size
-              HTTP_READFIELD_STRING(line, value, "Content-Type", r->contenttype);       // contenttype
-              HTTP_READFIELD_STRING(line, value, "Last-Modified", r->lastmodified);     // last-modified
-              HTTP_READFIELD_STRING(line, value, "Etag", r->etag);      // Etag
-              HTTP_READFIELD_STRING(line, value, "Location", r->location);      // 'location' pour moved
-              HTTP_READFIELD_STRING(line, value, "Content-Disposition", r->cdispo);     // Content-disposition
+              HTTP_READFIELD_STRING(line, value, "Content-Type", r->contenttype,
+                                    sizeof(r->contenttype));
+              HTTP_READFIELD_STRING(line, value, "Last-Modified",
+                                    r->lastmodified, sizeof(r->lastmodified));
+              HTTP_READFIELD_STRING(line, value, "Etag", r->etag,
+                                    sizeof(r->etag));
+              HTTP_READFIELD_STRING(line, value, "Location", r->location,
+                                    sizeof(location_default));
+              HTTP_READFIELD_STRING(line, value, "Content-Disposition",
+                                    r->cdispo, sizeof(r->cdispo));
               if (line[0] != '\0') {
                 int len = r->headers ? ((int) strlen(r->headers)) : 0;
                 int nlen =

--- a/tests/86_local-proxytrack-cache-longfields.test
+++ b/tests/86_local-proxytrack-cache-longfields.test
@@ -1,0 +1,61 @@
+#!/bin/bash
+# A cached header longer than proxytrack's field must be clipped, not copied
+# raw: contenttype[64] sits just before the location pointer, so an unbounded
+# copy smashed it and the next Location line wrote through the wreckage.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+python=$(find_python) || {
+    echo "python3 not found; skipping" >&2
+    exit 77
+}
+
+dir=$(mktemp -d)
+trap 'rm -rf "$dir"' EXIT
+
+# proxytrack reads its metadata from each entry's ZIP local extra field
+"$python" - "$dir/in.zip" <<'EOF'
+import sys, zipfile
+
+body = b"hello world"
+ct = "text/html" + "A" * 400
+meta = (
+    "X-In-Cache: 1\r\n"
+    "X-StatusCode: 200\r\n"
+    "X-StatusMessage: OK\r\n"
+    "X-Size: %d\r\n"
+    "Content-Type: %s\r\n"
+    "X-Charset: iso-8859-1\r\n"
+    # a parseable date is required: the ARC writer dereferences it unchecked
+    "Last-Modified: Wed, 01 Jan 2025 00:00:00 GMT\r\n"
+    "Location: http://example.com/%s\r\n"
+    "X-Save: out/page.html\r\n" % (len(body), ct, "B" * 400)
+).encode()
+
+zi = zipfile.ZipInfo("example.com/page.html")
+zi.compress_type = zipfile.ZIP_STORED
+zi.extra = meta
+with zipfile.ZipFile(sys.argv[1], "w") as z:
+    z.writestr(zi, body)
+EOF
+
+proxytrack --convert "$dir/out.arc" "$dir/in.zip" >/dev/null 2>&1 || {
+    echo "FAIL: proxytrack crashed on a cache with over-long header fields" >&2
+    exit 1
+}
+
+test -s "$dir/out.arc" || {
+    echo "FAIL: entry dropped instead of clipped" >&2
+    exit 1
+}
+
+# clipped to contenttype[64], so 63 characters survive: "text/html" plus 54 A's
+longest=$(grep -ao 'A\+' "$dir/out.arc" | awk '{ print length($0) }' | sort -rn | head -n1)
+test "$longest" = 54 || {
+    echo "FAIL: expected the content-type clipped to 63 chars (54 A's), got ${longest:-none}" >&2
+    exit 1
+}

--- a/tests/86_local-proxytrack-cache-longfields.test
+++ b/tests/86_local-proxytrack-cache-longfields.test
@@ -1,7 +1,6 @@
 #!/bin/bash
-# A cached header longer than proxytrack's field must be clipped, not copied
-# raw: contenttype[64] sits just before the location pointer, so an unbounded
-# copy smashed it and the next Location line wrote through the wreckage.
+# A cached header longer than proxytrack's field must be clipped to that field,
+# not overflow into the next one (contenttype[64] abuts the location pointer).
 
 set -euo pipefail
 
@@ -9,31 +8,77 @@ testdir=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=tests/testlib.sh
 . "${testdir}/testlib.sh"
 
-python=$(find_python) || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
-
 dir=$(mktemp -d)
 trap 'rm -rf "$dir"' EXIT
 
-# proxytrack reads its metadata from each entry's ZIP local extra field
+pad() { printf "%${1}s" '' | tr ' ' "$2"; }
+
+# Longest surviving run of char $2 in file $1, or 0.
+runlen() {
+    grep -ao "$2\\+" "$1" | awk '{ print length($0) }' | sort -rn | head -n1 || true
+}
+
+# --- ARC reader (HTTP_READFIELD_STRING), no python needed -------------------
+# Each header overshoots its own destination, so a per-field clip is the only
+# way to get every expected length right at once.
+{
+    printf 'HTTP/1.1 200 OK\r\n'
+    printf 'Content-Type: text/html%s\r\n' "$(pad 400 A)"
+    printf 'Etag: %s\r\n' "$(pad 400 E)"
+    printf 'Content-Disposition: %s\r\n' "$(pad 400 D)"
+    printf 'Last-Modified: Wed, 01 Jan 2025 00:00:00 GMT\r\n'
+    printf 'Content-Length: 5\r\n\r\n'
+} >"$dir/hdr"
+printf 'hello' >"$dir/body"
+alen=$(($(wc -c <"$dir/hdr") + $(wc -c <"$dir/body")))
+{
+    printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc 9\n'
+    printf '2 0 test\n'
+    printf '\n\n'
+    printf 'http://example.com/p.html 0.0.0.0 20250101000000 text/html 200 - - 0 t.arc %d\n' "$alen"
+    cat "$dir/hdr" "$dir/body"
+} >"$dir/in.arc"
+
+proxytrack --convert "$dir/out.arc" "$dir/in.arc" >/dev/null 2>&1 || {
+    echo "FAIL: proxytrack crashed reading an ARC with over-long headers" >&2
+    exit 1
+}
+test -s "$dir/out.arc" || {
+    echo "FAIL: ARC entry dropped instead of clipped" >&2
+    exit 1
+}
+# Only contenttype survives into the ARC output; the over-long Etag and
+# Content-Disposition above are still load-bearing, since bounding just one
+# field leaves the others smashing the element (the run above would crash).
+got=$(runlen "$dir/out.arc" A)
+test "${got:-0}" = 54 || {
+    echo "FAIL: ARC content-type clipped to ${got:-0}, expected 54" >&2
+    exit 1
+}
+
+# --- ZIP reader (ZIP_READFIELD_STRING) --------------------------------------
+python=$(find_python) || {
+    echo "python3 missing; ARC half only" >&2
+    exit 0
+}
+
 "$python" - "$dir/in.zip" <<'EOF'
 import sys, zipfile
 
 body = b"hello world"
-ct = "text/html" + "A" * 400
 meta = (
     "X-In-Cache: 1\r\n"
     "X-StatusCode: 200\r\n"
-    "X-StatusMessage: OK\r\n"
+    "X-StatusMessage: ok%s\r\n"
     "X-Size: %d\r\n"
-    "Content-Type: %s\r\n"
-    "X-Charset: iso-8859-1\r\n"
+    "Content-Type: text/html%s\r\n"
+    "X-Charset: %s\r\n"
+    "Etag: %s\r\n"
+    "Content-Disposition: %s\r\n"
     # a parseable date is required: the ARC writer dereferences it unchecked
     "Last-Modified: Wed, 01 Jan 2025 00:00:00 GMT\r\n"
-    "Location: http://example.com/%s\r\n"
-    "X-Save: out/page.html\r\n" % (len(body), ct, "B" * 400)
+    "X-Save: out/page.html\r\n"
+    % ("M" * 400, len(body), "A" * 400, "C" * 400, "E" * 400, "D" * 400)
 ).encode()
 
 zi = zipfile.ZipInfo("example.com/page.html")
@@ -43,19 +88,24 @@ with zipfile.ZipFile(sys.argv[1], "w") as z:
     z.writestr(zi, body)
 EOF
 
-proxytrack --convert "$dir/out.arc" "$dir/in.zip" >/dev/null 2>&1 || {
-    echo "FAIL: proxytrack crashed on a cache with over-long header fields" >&2
+proxytrack --convert "$dir/out2.arc" "$dir/in.zip" >/dev/null 2>&1 || {
+    echo "FAIL: proxytrack crashed reading a zip cache with over-long headers" >&2
     exit 1
 }
-
-test -s "$dir/out.arc" || {
-    echo "FAIL: entry dropped instead of clipped" >&2
+test -s "$dir/out2.arc" || {
+    echo "FAIL: zip entry dropped instead of clipped" >&2
     exit 1
 }
-
-# clipped to contenttype[64], so 63 characters survive: "text/html" plus 54 A's
-longest=$(grep -ao 'A\+' "$dir/out.arc" | awk '{ print length($0) }' | sort -rn | head -n1)
-test "$longest" = 54 || {
-    echo "FAIL: expected the content-type clipped to 63 chars (54 A's), got ${longest:-none}" >&2
-    exit 1
-}
+# three destinations, two capacities: msg[1024] keeps all 400 M's where a
+# one-size-fits-all clip would cut it to 63 like the others
+while read -r ch want; do
+    got=$(runlen "$dir/out2.arc" "$ch")
+    test "${got:-0}" = "$want" || {
+        echo "FAIL: zip field '$ch' clipped to ${got:-0}, expected $want" >&2
+        exit 1
+    }
+done <<'EOF'
+A 54
+C 63
+M 400
+EOF

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -182,6 +182,7 @@ TESTS = \
 	82_webhttrack-browse-links.test \
 	83_webhttrack-argescape.test \
 	84_webhttrack-mirror-verbatim.test \
-	85_webhttrack-projpath.test
+	85_webhttrack-projpath.test \
+	86_local-proxytrack-cache-longfields.test
 
 CLEANFILES = check-network_sh.cache


### PR DESCRIPTION
`proxy/store.c` carries two near-identical macros that copy a cache header into a fixed field, and neither took a destination size: `ZIP_READFIELD_STRING` for the `.zip` reader and `HTTP_READFIELD_STRING` for the ARC reader. Both did a raw `strcpy` from a line bounded only by its own buffer, ~1KB on the ZIP path and 2KB on the ARC one. The engine's namesake in `htscache.c` has taken a `refvalue_size` for years; these two never got it.

The destinations are small: `contenttype[64]`, `charset[64]`, `lastmodified[64]`, `etag[64]`. The engine stores `Content-Type` in 128 bytes, so an ordinary cache written by HTTrack itself already overflows the 64-byte field. `contenttype` sits just before the `location` pointer in the calloc'd `_PT_Element`, so a longer value walks over `charset` and then over `location`, and the next `Location:` line copies through the wrecked pointer. `proxytrack --convert` segfaults under ASan on either input shape.

Clipping is the right answer rather than rejecting, since our fields are narrower than the engine's and a valid cache must still load. Note that `strlcpybuff` would not do: the whole `*_safe_` family aborts on overflow, which trades the smash for a denial of service and refuses caches that are perfectly legal. This uses the clear-then-bounded-append idiom already present further down the same file.

Test 86 overshoots every destination in one input and asserts each surviving length against its own capacity, so a per-field clip and a one-size-fits-all clip are distinguishable; an earlier version asserted only `Content-Type` and could not tell them apart. The ARC half needs no python, so it runs on every CI leg.

Separately, and not touched here: `PT_SaveCache__Arc_Fun` dereferences `convert_time_rfc822()` at store.c:2402 with no NULL check, so any cached entry whose `Last-Modified` is missing or unparseable segfaults `proxytrack --convert`.