### PR TITLE
Unbounded writes into the 80-byte htsblk failure message

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -125,6 +125,22 @@ void back_free(struct_back ** sback) {
    above a normal handshake. The last candidate still gets the full timeout. */
 #define HTS_CONNECT_FALLBACK_TIMEOUT 10
 
+void back_read_ftp_result(FILE *fp, htsblk *r) {
+  size_t j = 0;
+
+  if (fscanf(fp, "%d ", &r->statuscode) != 1)
+    r->statuscode = STATUSCODE_INVALID;
+  // an external helper writes this file: stop at capacity, not at EOF
+  while (j + 1 < sizeof(r->msg)) {
+    const int c = fgetc(fp);
+
+    if (c == EOF)
+      break;
+    r->msg[j++] = (char) c;
+  }
+  r->msg[j] = '\0';
+}
+
 int back_connect_fallback_due(int addr_index, int addr_count, int elapsed,
                               int timeout) {
   int deadline;
@@ -2960,7 +2976,7 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
               back[i].r.msg[0] = '\0';
               strncatbuff(back[i].r.msg, tmp, sizeof(back[i].r.msg) - 2);
               if (!strnotempty(back[i].r.msg)) {
-                sprintf(back[i].r.msg, "SSL/TLS error %d", err_code);
+                htsblk_failf(&back[i].r, "SSL/TLS error %d", err_code);
               }
               deletehttp(&back[i].r);
               back[i].r.soc = INVALID_SOCKET;
@@ -3033,16 +3049,7 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
             FOPEN(fconcat(OPT_GET_BUFF(opt), back[i].location_buffer, ".ok"),
                   "rb");
           if (fp) {
-            int j = 0;
-
-            fscanf(fp, "%d ", &(back[i].r.statuscode));
-            while(!feof(fp)) {
-              int c = fgetc(fp);
-
-              if (c != EOF)
-                back[i].r.msg[j++] = c;
-            }
-            back[i].r.msg[j++] = '\0';
+            back_read_ftp_result(fp, &back[i].r);
             fclose(fp);
             UNLINK(fconcat(OPT_GET_BUFF(opt), back[i].location_buffer, ".ok"));
             strcpybuff(fconcat
@@ -3343,10 +3350,11 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                   deleteaddr(&back[i].r);
                   if (back[i].r.size < back[i].r.totalsize)
                     back[i].r.statuscode = STATUSCODE_CONNERROR;        // recatch
-                  sprintf(back[i].r.msg,
-                          "Incorrect length (" LLintP " Bytes, " LLintP
-                          " expected)", (LLint) back[i].r.size,
-                          (LLint) back[i].r.totalsize);
+                  htsblk_failf(&back[i].r,
+                               "Incorrect length (" LLintP " Bytes, " LLintP
+                               " expected)",
+                               (LLint) back[i].r.size,
+                               (LLint) back[i].r.totalsize);
                 } else {
                   // Un warning suffira..
                   hts_log_print(opt, LOG_WARNING,

--- a/src/htsback.h
+++ b/src/htsback.h
@@ -74,6 +74,10 @@ void back_free(struct_back ** sback);
 // backing
 #define BACK_ADD_TEST "(dummy)"
 #define BACK_ADD_TEST2 "(dummy2)"
+/* Parse an external FTP helper's "<statuscode> <message>" result file into r,
+   clipping the message to r->msg. */
+void back_read_ftp_result(FILE *fp, htsblk *r);
+
 int back_index(httrackp * opt, struct_back * sback, const char *adr, const char *fil,
                const char *sav);
 int back_available(const struct_back * sback);

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -708,11 +708,11 @@ T_SOC http_xfopen(httrackp *opt, int mode, int treat, int waitconnect,
 #ifdef _WIN32
         int last_errno = WSAGetLastError();
 
-        sprintf(retour->msg, "Connect error: %s", strerror(last_errno));
+        htsblk_failf(retour, "Connect error: %s", strerror(last_errno));
 #else
         int last_errno = errno;
 
-        sprintf(retour->msg, "Connect error: %s", strerror(last_errno));
+        htsblk_failf(retour, "Connect error: %s", strerror(last_errno));
 #endif
       }
     }
@@ -2240,13 +2240,13 @@ T_SOC newhttp_addr(httrackp *opt, const char *_iadr, htsblk *retour, int port,
 #ifdef _WIN32
         int last_errno = WSAGetLastError();
 
-        sprintf(retour->msg, "Unable to create a socket: %s",
-                strerror(last_errno));
+        htsblk_failf(retour, "Unable to create a socket: %s",
+                     strerror(last_errno));
 #else
         int last_errno = errno;
 
-        sprintf(retour->msg, "Unable to create a socket: %s",
-                strerror(last_errno));
+        htsblk_failf(retour, "Unable to create a socket: %s",
+                     strerror(last_errno));
 #endif
       }
       return INVALID_SOCKET;    // erreur création socket impossible
@@ -2312,13 +2312,13 @@ T_SOC newhttp_addr(httrackp *opt, const char *_iadr, htsblk *retour, int port,
 #ifdef _WIN32
           const int last_errno = WSAGetLastError();
 
-          sprintf(retour->msg, "Unable to connect to the server: %s",
-                  strerror(last_errno));
+          htsblk_failf(retour, "Unable to connect to the server: %s",
+                       strerror(last_errno));
 #else
           const int last_errno = errno;
 
-          sprintf(retour->msg, "Unable to connect to the server: %s",
-                  strerror(last_errno));
+          htsblk_failf(retour, "Unable to connect to the server: %s",
+                       strerror(last_errno));
 #endif
         }
         /* Close the socket and notify the error!!! */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -43,6 +43,7 @@ Please visit our Website: http://www.httrack.com
 
 #include "htsglobal.h"
 #include "htscore.h"
+#include "htsback.h"
 #include "htsdefines.h"
 #include "htslib.h"
 #include "htsalias.h"
@@ -658,6 +659,35 @@ static int string_safety_selftests(void) {
     if (strcmp(r.msg, expect) != 0 || !NEIGHBOURS_INTACT())
       return 1;
 #undef NEIGHBOURS_INTACT
+  }
+
+  /* back_read_ftp_result: the helper's result file is external input, so an
+     over-long message must stop at msg[]'s capacity */
+  {
+    htsblk r;
+    FILE *fp = tmpfile();
+    size_t k;
+
+    if (fp == NULL)
+      return 1;
+    fprintf(fp, "226 ");
+    for (k = 0; k < 4 * sizeof(r.msg); k++)
+      fputc('q', fp);
+    rewind(fp);
+
+    memset(&r, 0, sizeof(r));
+    memset(r.msg, '#', sizeof(r.msg));
+    back_read_ftp_result(fp, &r);
+    fclose(fp);
+
+    if (r.statuscode != 226 || strlen(r.msg) != sizeof(r.msg) - 1)
+      return 1;
+    for (k = 0; k < sizeof(r.msg) - 1; k++) {
+      if (r.msg[k] != 'q')
+        return 1;
+    }
+    if (r.contenttype[0] != '\0') /* neighbour, as above */
+      return 1;
   }
 
   /* StringCatN/StringSetLength must eval SIZE once: (n_eval++, V) leaves

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -626,10 +626,12 @@ static int string_safety_selftests(void) {
     char big[4 * sizeof(r.msg)];
 
     /* contenttype abuts msg, so a one-past-the-end store lands in it rather
-       than in padding; checking it is this block's canary */
-#define NEIGHBOURS_INTACT() (r.contenttype[0] == '\0' && r.statuscode == 1234)
+       than in padding. Poison it: a stray NUL is invisible against zeroes,
+       and a stray NUL is exactly what an off-by-one terminator writes. */
+#define NEIGHBOURS_INTACT() (r.contenttype[0] == '#' && r.statuscode == 1234)
 
     memset(&r, 0, sizeof(r));
+    memset(r.contenttype, '#', sizeof(r.contenttype));
     r.statuscode = 1234;
 
     memset(r.msg, '#', sizeof(r.msg));
@@ -665,29 +667,55 @@ static int string_safety_selftests(void) {
      over-long message must stop at msg[]'s capacity */
   {
     htsblk r;
-    FILE *fp = tmpfile();
     size_t k;
 
-    if (fp == NULL)
-      return 1;
-    fprintf(fp, "226 ");
-    for (k = 0; k < 4 * sizeof(r.msg); k++)
-      fputc('q', fp);
-    rewind(fp);
+    /* poisoned so a short message cannot pass on leftovers, and so a stray
+       NUL past msg[] is visible in the neighbour */
+#define FTP_RESULT_CASE(BODY)                                                  \
+  do {                                                                         \
+    FILE *fp_ = tmpfile();                                                     \
+                                                                               \
+    if (fp_ == NULL)                                                           \
+      return 1;                                                                \
+    BODY;                                                                      \
+    rewind(fp_);                                                               \
+    memset(&r, 0, sizeof(r));                                                  \
+    memset(r.msg, '#', sizeof(r.msg));                                         \
+    memset(r.contenttype, '#', sizeof(r.contenttype));                         \
+    back_read_ftp_result(fp_, &r);                                             \
+    fclose(fp_);                                                               \
+    if (r.contenttype[0] != '#')                                               \
+      return 1;                                                                \
+  } while (0)
 
-    memset(&r, 0, sizeof(r));
-    memset(r.msg, '#', sizeof(r.msg));
-    back_read_ftp_result(fp, &r);
-    fclose(fp);
-
+    /* over capacity: clipped to 79 payload bytes plus the NUL */
+    FTP_RESULT_CASE({
+      fprintf(fp_, "226 ");
+      for (k = 0; k < 4 * sizeof(r.msg); k++)
+        fputc('q', fp_);
+    });
     if (r.statuscode != 226 || strlen(r.msg) != sizeof(r.msg) - 1)
       return 1;
     for (k = 0; k < sizeof(r.msg) - 1; k++) {
       if (r.msg[k] != 'q')
         return 1;
     }
-    if (r.contenttype[0] != '\0') /* neighbour, as above */
+
+    /* well under capacity: nothing padded, nothing eaten off the end */
+    FTP_RESULT_CASE(fprintf(fp_, "550 no such file"));
+    if (r.statuscode != 550 || strcmp(r.msg, "no such file") != 0)
       return 1;
+
+    /* a byte over 0x7f must not read as EOF and cut the message short */
+    FTP_RESULT_CASE(fprintf(fp_, "226 \xff ok"));
+    if (r.statuscode != 226 || strcmp(r.msg, "\xff ok") != 0)
+      return 1;
+
+    /* unparseable status: the message still loads, the code reports failure */
+    FTP_RESULT_CASE(fprintf(fp_, "not-a-number here"));
+    if (r.statuscode != STATUSCODE_INVALID)
+      return 1;
+#undef FTP_RESULT_CASE
   }
 
   /* StringCatN/StringSetLength must eval SIZE once: (n_eval++, V) leaves


### PR DESCRIPTION
Nine writers filled `htsblk.msg[80]` with no bound at all. Six of them `sprintf` the result of `strerror()` on the connect and socket error paths: the longest glibc string is 49 bytes in the C locale and 72 in `fr_FR`, against 46 bytes of room after the longest prefix ("Unable to connect to the server: "). Realistic `connect()` errnos are all short, so this was latent rather than live, but nothing enforced that.

The FTP helper's `.ok` result file was read a byte at a time until EOF straight into the same 80 bytes, so the file's size was the only limit. That one is **not reachable today**: its caller sits under `#else` of `#if USE_BEGINTHREAD`, which `htsglobal.h` defines to 1 unconditionally, and the compiled library contains none of that block's strings. It is bounded here anyway, as `back_read_ftp_result()`, which is compiled and small enough for a self-test to drive directly.

These sites were invisible to the `-Wformat-truncation` cluster that introduced `htsblk_failf` in #715: the diagnostic fires only on a *bounded* `snprintf` whose return value is discarded, so an unbounded `sprintf` never appears on the list. Worth remembering when a warning class is used to scope a cleanup.

Covered by `-#test=strsafe`. The first version of that test was weak, and a mutation pass killed six of eight candidates: it now poisons the neighbouring field rather than comparing against zero (a stray NUL is what an off-by-one terminator writes, and zeroes hide it), and adds short-message, high-byte, and unparseable-status cases. The same poisoning fixes the `htsblk_failf` canary inherited from #715.

One behaviour change beyond the bound: `back_read_ftp_result()` now checks `fscanf`'s return and sets `STATUSCODE_INVALID` when the status will not parse. The old code left `statuscode` untouched there, but `hts_init_htsblk()` has already set it to exactly that value on every path reaching this code, so no outcome moves.