### PR TITLE
htsserver: an unauthenticated GET of a directory spins the server forever

### DIFF
--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -118,13 +118,6 @@ static int is_js(const char *file) {
   return ((strstr(file, ".js") != NULL));
 }
 
-/* fopen() succeeds on a directory on POSIX; reading one never reaches EOF. */
-static hts_boolean is_directory(const char *file) {
-  STRUCT_STAT st;
-
-  return STAT(file, &st) == 0 && S_ISDIR(st.st_mode) ? HTS_TRUE : HTS_FALSE;
-}
-
 static void sig_brpipe(int code) {
   /* ignore */
 }
@@ -987,8 +980,9 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
 
           /* path itself may hold ".." (webhttrack passes "<bin>/../share"), so
              only the untrusted halves are checked: file here, website above. */
-          if (fsfile[0] && strstr(file, "..") == NULL &&
-              !is_directory(fsfile) && (fp = fopen(fsfile, "rb"))) {
+          /* Regular files only: serving a directory or a FIFO never ends. */
+          if (fsfile[0] && strstr(file, "..") == NULL && fexist(fsfile) &&
+              (fp = fopen(fsfile, "rb"))) {
             char ok[] =
               "HTTP/1.0 200 OK\r\n" "Connection: close\r\n"
               "Server: httrack-small-server\r\n" "Content-type: text/html\r\n"

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -118,6 +118,13 @@ static int is_js(const char *file) {
   return ((strstr(file, ".js") != NULL));
 }
 
+/* fopen() succeeds on a directory on POSIX; reading one never reaches EOF. */
+static hts_boolean is_directory(const char *file) {
+  STRUCT_STAT st;
+
+  return STAT(file, &st) == 0 && S_ISDIR(st.st_mode) ? HTS_TRUE : HTS_FALSE;
+}
+
 static void sig_brpipe(int code) {
   /* ignore */
 }
@@ -725,7 +732,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
           fp = fopen(StringBuff(fspath), "rb");
           if (fp) {
             /* Read file */
-            while(!feof(fp)) {
+            while (!feof(fp) && !ferror(fp)) {
               char *str = line;
               char *pos;
 
@@ -980,8 +987,8 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
 
           /* path itself may hold ".." (webhttrack passes "<bin>/../share"), so
              only the untrusted halves are checked: file here, website above. */
-          if (fsfile[0] && strstr(file, "..") == NULL
-              && (fp = fopen(fsfile, "rb"))) {
+          if (fsfile[0] && strstr(file, "..") == NULL &&
+              !is_directory(fsfile) && (fp = fopen(fsfile, "rb"))) {
             char ok[] =
               "HTTP/1.0 200 OK\r\n" "Connection: close\r\n"
               "Server: httrack-small-server\r\n" "Content-type: text/html\r\n"
@@ -1040,7 +1047,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
               int outputmode = 0;
 
               StringMemcat(headers, ok, sizeof(ok) - 1);
-              while(!feof(fp)) {
+              while (!feof(fp) && !ferror(fp)) {
                 char *str = line;
                 int prevlen = (int) StringLength(output);
                 int nocr = 0;
@@ -1474,14 +1481,15 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
               while(!feof(fp)) {
                 int n = (int) fread(line, 1, sizeof(line) - 2, fp);
 
-                if (n > 0) {
-                  StringMemcat(output, line, n);
+                if (n <= 0) {
+                  break; /* short read: EOF or error, never a retry */
                 }
+                StringMemcat(output, line, n);
               }
             }
             fclose(fp);
-          } else if (strcmp(file, "/ping") == 0
-                     || strncmp(file, "/ping?", 6) == 0) {
+          } else if (strcmp(file, "/ping") == 0 ||
+                     strncmp(file, "/ping?", 6) == 0) {
             char error_hdr[] =
               "HTTP/1.0 200 Pong\r\n" "Server: httrack small server\r\n"
               "Content-type: text/html\r\n";

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -980,9 +980,8 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
             }
           }
 
-          /* path itself may hold ".." (webhttrack passes "<bin>/../share"), so
-             only the untrusted halves are checked: file here, website above. */
-          /* Regular files only: serving a directory or a FIFO never ends. */
+          /* Regular files only: reading a directory or FIFO never ends, and
+             "path" may hold "..", so only the untrusted halves are checked. */
           if (fsfile[0] && strstr(file, "..") == NULL && fexist(fsfile) &&
               (fp = fopen(fsfile, "rb"))) {
             char ok[] =

--- a/tests/91_webhttrack-directory.test
+++ b/tests/91_webhttrack-directory.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# fopen() succeeds on a directory on POSIX and reading one never reaches EOF, so
-# a request naming one used to spin the single-threaded server forever.
+# fopen() succeeds on a directory on POSIX and reading one never reaches EOF; a
+# FIFO blocks in fopen() instead. Either used to wedge the single-threaded server.
 
 set -euo pipefail
 
@@ -67,9 +67,8 @@ alive() { kill -0 "$1" 2>/dev/null; }
 
 portof() { echo "${1##*:}" | tr -d /; }
 
-# Raw request to 127.0.0.1:$1: GET the path $2, or POST the body $3 to / when $2
-# is empty. The socket timeout is what makes an unfixed tree fail rather than
-# wedge CI, so it must stay.
+# GET the path $2 from 127.0.0.1:$1, or POST the body $3 to / when $2 is empty.
+# The socket timeout is what makes an unfixed tree fail rather than wedge CI.
 request() {
     python3 -c 'import socket, sys
 port, path, body = int(sys.argv[1]), sys.argv[2], sys.argv[3]
@@ -117,7 +116,7 @@ case "${reply}" in
 *) fail "a GUI directory did not answer 404: $(firstline "${reply}")" ;;
 esac
 
-# Every request body is gated by the session id (78_webhttrack-sid.test).
+# Every request body is gated by the session id.
 reply=$(get "${port}" /server/index.html "the GUI is not served")
 sid=$(firstline "$(echo "${reply}" |
     sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p')")
@@ -125,6 +124,13 @@ test "${#sid}" -eq 32 || fail "did not scrape a 32-hex sid (got '${sid}')"
 
 mkdir -p "${base}/proj/sub"
 echo "PROBEMARKER" >"${base}/proj/probe.txt"
+
+# mkfifo and ln -s may not work on a Windows checkout, so both stay optional.
+refuse=(/website/ /website/sub/)
+if mkfifo "${base}/proj/fifo.txt" 2>/dev/null; then
+    refuse+=(/website/fifo.txt)
+fi
+ln -s probe.txt "${base}/proj/link.txt" 2>/dev/null || true
 
 # step4's "save settings" flow registers the project without crawling, and that
 # is what arms the /website/ root.
@@ -134,29 +140,42 @@ post "${port}" "${body}" >/dev/null || fail "the save request did not answer"
 test -f "${base}/proj/hts-cache/winprofile.ini" ||
     fail "the project was not registered: $(cat "${log}")"
 
-# Positive control: without it every assertion below would pass on a server that
-# serves nothing at all under /website/.
+# Positive control: every assertion below would pass on a server serving nothing.
 served() {
-    case "$(get "$1" /website/probe.txt "$2")" in
+    case "$(get "$1" "$2" "$3")" in
     *PROBEMARKER*) ;;
-    *) fail "$2" ;;
+    *) fail "$3" ;;
     esac
 }
-served "${port}" "the registered project's mirror is not served"
+served "${port}" /website/probe.txt "the registered project's mirror is not served"
+if test -L "${base}/proj/link.txt"; then
+    # The guard stats rather than lstats, so a symlinked mirror file still serves.
+    served "${port}" /website/link.txt "a symlink to a mirror file is not served"
+fi
 
-# The mirror root and a directory below it. /website/ is where the GUI's own
-# "browse mirrored site" link points.
-for dir in /website/ /website/sub/; do
-    reply=$(get "${port}" "${dir}" "the server wedged on a mirror directory")
+# /website/ is where the GUI's own "browse mirrored site" link points.
+for path in "${refuse[@]}"; do
+    reply=$(get "${port}" "${path}" "the server wedged on ${path}")
     case "${reply}" in
     "HTTP/1.0 404 "*) ;;
-    *) fail "${dir} did not answer 404: $(firstline "${reply}")" ;;
+    *) fail "${path} did not answer 404: $(firstline "${reply}")" ;;
     esac
 done
 
-# A directory answered is worthless if it cost the server: the accept loop is
-# single-threaded, so one spin denies every later request, this shell's included.
+# The accept loop is single-threaded: one spin denies every later request.
 alive "${srv}" || fail "the server died: $(cat "${log}")"
-served "${port}" "the server stopped answering after a directory request"
+served "${port}" /website/probe.txt "the server stopped answering after a directory request"
+
+# This fopen() is reached before any guard, so its read loop must stop on ferror().
+mkdir -p "${base}/proj2/hts-cache/winprofile.ini"
+reply=$(post "${port}" "sid=${sid}&path=${base}&loadprojname=proj2") ||
+    fail "a directory winprofile.ini wedged the server"
+case "${reply}" in
+"HTTP/1.0 3"*) ;;
+*) fail "loading a project did not redirect: $(firstline "${reply}")" ;;
+esac
+
+alive "${srv}" || fail "the server died: $(cat "${log}")"
+served "${port}" /website/probe.txt "the server stopped answering after a project load"
 
 echo "PASS"

--- a/tests/91_webhttrack-directory.test
+++ b/tests/91_webhttrack-directory.test
@@ -1,0 +1,162 @@
+#!/bin/bash
+#
+# fopen() succeeds on a directory on POSIX and reading one never reaches EOF, so
+# a request naming one used to spin the single-threaded server forever.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
+distdir=$(cd "${distdir}" && pwd)
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+command -v htsserver >/dev/null || fail "no htsserver in PATH"
+command -v python3 >/dev/null || {
+    echo "python3 not found; skipping" >&2
+    exit 77
+}
+
+srv=
+log=$(mktemp)
+base=$(mktemp -d)
+cleanup() {
+    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
+    rm -f "${log}"
+    rm -rf "${base}"
+}
+trap cleanup EXIT HUP INT QUIT PIPE TERM
+
+# First line only. A "| head -1" would close the pipe early and, under pipefail,
+# SIGPIPE the producer into a spurious failure.
+firstline() { echo "${1%%$'\n'*}"; }
+
+freeport() {
+    python3 -c 'import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()'
+}
+
+# Echo the announced URL. Runs in a command substitution, so it is a
+# subshell and cannot export the pid: the caller reads it back with srvpid.
+start() {
+    local port url
+    port=$(freeport)
+    : >"${log}"
+    (
+        trap '' TERM TTOU
+        exec htsserver "${distdir}/" --port "${port}" >"${log}" 2>&1
+    ) &
+    for _ in $(seq 1 40); do
+        url=$(sed -n 's/^URL=//p' "${log}" 2>/dev/null) && test -n "${url}" && break
+        sleep 0.25
+    done
+    test -n "${url:-}" || fail "htsserver did not come up: $(cat "${log}")"
+    echo "${url}"
+}
+
+# The server reports its own pid; the aliveness assertion below hangs off it.
+srvpid() { firstline "$(sed -n 's/^PID=//p' "${log}")"; }
+
+alive() { kill -0 "$1" 2>/dev/null; }
+
+portof() { echo "${1##*:}" | tr -d /; }
+
+# Raw request to 127.0.0.1:$1: GET the path $2, or POST the body $3 to / when $2
+# is empty. The socket timeout is what makes an unfixed tree fail rather than
+# wedge CI, so it must stay.
+request() {
+    python3 -c 'import socket, sys
+port, path, body = int(sys.argv[1]), sys.argv[2], sys.argv[3]
+if path:
+    req = "GET %s HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n" % path
+else:
+    req = ("POST / HTTP/1.0\r\nHost: 127.0.0.1\r\n"
+           "Content-type: application/x-www-form-urlencoded\r\n"
+           "Content-length: %d\r\n\r\n%s" % (len(body), body))
+s = socket.create_connection(("127.0.0.1", port), 10)
+s.settimeout(15)
+s.sendall(req.encode())
+out = b""
+try:
+    while True:
+        b = s.recv(65536)
+        if not b:
+            break
+        out += b
+except socket.timeout:
+    sys.stderr.write("timed out after %d bytes\n" % len(out))
+    sys.exit(9)
+s.close()
+sys.stdout.write(out.decode("latin-1"))' "$1" "$2" "$3"
+}
+
+# GET $2, or fail with $3 when the reply never comes.
+get() {
+    local out
+    out=$(request "$1" "$2" "") || fail "$2 did not answer: $3"
+    echo "${out}"
+}
+
+post() { request "$1" "" "$2"; }
+
+url=$(start)
+port=$(portof "${url}")
+srv=$(srvpid)
+test -n "${srv}" || fail "htsserver did not report its pid"
+
+# Needs no session id and no project: html/server is a directory of the install.
+reply=$(get "${port}" /server/ "an unauthenticated request wedged the server")
+case "${reply}" in
+"HTTP/1.0 404 "*) ;;
+*) fail "a GUI directory did not answer 404: $(firstline "${reply}")" ;;
+esac
+
+# Every request body is gated by the session id (78_webhttrack-sid.test).
+reply=$(get "${port}" /server/index.html "the GUI is not served")
+sid=$(firstline "$(echo "${reply}" |
+    sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p')")
+test "${#sid}" -eq 32 || fail "did not scrape a 32-hex sid (got '${sid}')"
+
+mkdir -p "${base}/proj/sub"
+echo "PROBEMARKER" >"${base}/proj/probe.txt"
+
+# step4's "save settings" flow registers the project without crawling, and that
+# is what arms the /website/ root.
+body="sid=${sid}&command=httrack&command_do=save&winprofile=x"
+body="${body}&path=${base}&projname=proj"
+post "${port}" "${body}" >/dev/null || fail "the save request did not answer"
+test -f "${base}/proj/hts-cache/winprofile.ini" ||
+    fail "the project was not registered: $(cat "${log}")"
+
+# Positive control: without it every assertion below would pass on a server that
+# serves nothing at all under /website/.
+served() {
+    case "$(get "$1" /website/probe.txt "$2")" in
+    *PROBEMARKER*) ;;
+    *) fail "$2" ;;
+    esac
+}
+served "${port}" "the registered project's mirror is not served"
+
+# The mirror root and a directory below it. /website/ is where the GUI's own
+# "browse mirrored site" link points.
+for dir in /website/ /website/sub/; do
+    reply=$(get "${port}" "${dir}" "the server wedged on a mirror directory")
+    case "${reply}" in
+    "HTTP/1.0 404 "*) ;;
+    *) fail "${dir} did not answer 404: $(firstline "${reply}")" ;;
+    esac
+done
+
+# A directory answered is worthless if it cost the server: the accept loop is
+# single-threaded, so one spin denies every later request, this shell's included.
+alive "${srv}" || fail "the server died: $(cat "${log}")"
+served "${port}" "the server stopped answering after a directory request"
+
+echo "PASS"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -182,6 +182,7 @@ TESTS = \
 	82_webhttrack-browse-links.test \
 	83_webhttrack-argescape.test \
 	84_webhttrack-mirror-verbatim.test \
-	85_webhttrack-projpath.test
+	85_webhttrack-projpath.test \
+	91_webhttrack-directory.test
 
 CLEANFILES = check-network_sh.cache


### PR DESCRIPTION
`GET /server/` wedges a freshly started htsserver: no session id, no project, nothing set up. `fopen()` on a directory succeeds on POSIX and every read from it then fails with EISDIR without ever setting the EOF flag, so the `while (!feof(fp))` loop that serves a static file in `smallserver()` never terminates. The session id gates the request body, not GET, and connections come off a single-threaded accept loop, so one request from localhost pins the process at 100% CPU and it never answers anything again. `/website/` does the same once a project is registered, and that is where the GUI's "browse mirrored site" link goes.

The serving `fopen()` now runs only for a regular file, gated on `fexist()`, the stat + `S_ISREG` predicate this file already applies to the `file-exists:` template op. Refusing directories alone would leave FIFOs on the same path, where `fopen()` blocks for want of a writer and kills the accept loop just as dead, so a whitelist closes the class instead of one instance. Ending the read loop rather than refusing the open is not an alternative: every directory would then come back as a well-formed `200 OK` with an empty body, which is worse than a 404 for a mirror browser. One behavior change falls out of it. `/dev/null` under a mirror root now 404s instead of serving zero bytes, and that seems right: a mirror holds what HTTrack wrote there, and that is never a device node.

The settings loader `fopen()`s the posted `path` + `projname` ahead of every guard, so its read loop stops on `ferror()` too. The GUI template loop and the `fread` serving loop got the same treatment, but both sit behind the whitelisted open and I have no probe that reaches them: they are defense in depth with no coverage of their own.

`tests/91_webhttrack-directory.test` asks for `/server/`, `/website/`, a subdirectory and a FIFO, then POSTs a project load whose `hts-cache/winprofile.ini` is a directory, with a positive control that a real mirror file still serves and an aliveness check after each. Restoring the directory-only refusal fails it on the FIFO alone; restoring `while (!feof(fp))` on the settings loader fails it on the project load. The red CodeQL check is pre-existing alert #195, `cpp/path-injection` on this same `fopen`, open on master since 2026-07-07 and renumbered by the added lines.
