### PR TITLE
Options ticked on by default cannot be un-ticked in the web GUI

### DIFF
--- a/html/server/option10.html
+++ b/html/server/option10.html
@@ -98,6 +98,9 @@ ${do:end-if}
 <input type="hidden" name="redirect" value="">
 <input type="hidden" name="closeme" value="">
 
+<!-- clear if not checked -->
+<input type="hidden" name="ftpprox" value="">
+
 ${LANG_PROXYTYPE}
 <select name="proxytype"
 			title='${html:LANG_PROXYTYPETIP}' onMouseOver="info('${html:LANG_PROXYTYPETIP}'); return true" onMouseOut="info('&nbsp;'); return true"

--- a/html/server/option2.html
+++ b/html/server/option2.html
@@ -98,6 +98,13 @@ ${do:end-if}
 <input type="hidden" name="redirect" value="">
 <input type="hidden" name="closeme" value="">
 
+<!-- clear if not checked -->
+<input type="hidden" name="errpage" value="">
+<input type="hidden" name="external" value="">
+<input type="hidden" name="hidepwd" value="">
+<input type="hidden" name="hidequery" value="">
+<input type="hidden" name="nopurge" value="">
+
 ${LANG_I33}
 <br>
 <select name="build"

--- a/html/server/option3.html
+++ b/html/server/option3.html
@@ -98,6 +98,9 @@ ${do:end-if}
 <input type="hidden" name="redirect" value="">
 <input type="hidden" name="closeme" value="">
 
+<!-- clear if not checked -->
+<input type="hidden" name="windebug" value="">
+
 ${LANG_I40c}
 <br>
 

--- a/html/server/option4.html
+++ b/html/server/option4.html
@@ -98,6 +98,11 @@ ${do:end-if}
 <input type="hidden" name="redirect" value="">
 <input type="hidden" name="closeme" value="">
 
+<!-- clear if not checked -->
+<input type="hidden" name="ka" value="">
+<input type="hidden" name="remt" value="">
+<input type="hidden" name="rems" value="">
+
 <table border="0" width="100%" cellspacing="0">
 
 <tr><td>

--- a/html/server/option8.html
+++ b/html/server/option8.html
@@ -98,6 +98,17 @@ ${do:end-if}
 <input type="hidden" name="redirect" value="">
 <input type="hidden" name="closeme" value="">
 
+<!-- clear if not checked -->
+<input type="hidden" name="cookies" value="">
+<input type="hidden" name="parsejava" value="">
+<input type="hidden" name="updhack" value="">
+<input type="hidden" name="urlhack" value="">
+<input type="hidden" name="keepwww" value="">
+<input type="hidden" name="keepslashes" value="">
+<input type="hidden" name="keepqueryorder" value="">
+<input type="hidden" name="toler" value="">
+<input type="hidden" name="http10" value="">
+
 <input type="checkbox" name="cookies" ${checked:cookies}
 			title='${html:LANG_I1b}' onMouseOver="info('${html:LANG_I1b}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I58}

--- a/html/server/option9.html
+++ b/html/server/option9.html
@@ -98,6 +98,13 @@ ${do:end-if}
 <input type="hidden" name="redirect" value="">
 <input type="hidden" name="closeme" value="">
 
+<!-- clear if not checked -->
+<input type="hidden" name="warc" value="">
+<input type="hidden" name="norecatch" value="">
+<input type="hidden" name="logf" value="">
+<input type="hidden" name="index" value="">
+<input type="hidden" name="index2" value="">
+
 <input type="checkbox" name="cache2" ${checked:cache2}
 			title='${html:LANG_I1e}' onMouseOver="info('${html:LANG_I1e}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I61}

--- a/html/server/step4.html
+++ b/html/server/step4.html
@@ -114,7 +114,7 @@ ${do:end-if}
 
 ${/* Real commands and ini file generated below */}
 
-<!-- engine commandline -->
+<!-- engine commandline; ztest so a cleared default-on option still emits its disabling flag -->
 ${do:output-mode:html}
 <textarea name="command" cols="50" rows="4" style="visibility:hidden">
 httrack \
@@ -175,8 +175,8 @@ ${/* -m<n> resets the html limit, so the bare form must precede the -m,<n> one *
 \
 	${unquoted:url2}
 \
-	${test:cookies:--cookies=0:}
-	${test:parsejava:--parse-java=0:}
+	${ztest:cookies:--cookies=0:}
+	${ztest:parsejava:--parse-java=0:}
 	${test:updhack:--updatehack}
 	${test:urlhack:--urlhack=0:--urlhack}
 	${test:keepwww:--keep-www-prefix}

--- a/tests/90_webhttrack-checkbox-clear.test
+++ b/tests/90_webhttrack-checkbox-clear.test
@@ -160,8 +160,8 @@ BOXES = [
 for field, key, when_set, when_clear in BOXES:
     for value, want, unwanted, stored in (("on", when_set, when_clear, "1"),
                                           ("", when_clear, when_set, "0")):
-        page = post([(field, value)])
-        cmd = textarea(page, "command").split()
+        rendered = post([(field, value)])
+        cmd = textarea(rendered, "command").split()
         label = "%s %s" % (field, "set" if value else "cleared")
         if want:
             check(want in cmd, "%s emits %s" % (label, want))
@@ -169,7 +169,7 @@ for field, key, when_set, when_clear in BOXES:
             check(unwanted not in cmd, "%s drops %s" % (label, unwanted))
         if key:
             # The Windows GUI reads the same option out of the profile.
-            check("%s=%s" % (key, stored) in textarea(page, "winprofile").splitlines(),
+            check("%s=%s" % (key, stored) in textarea(rendered, "winprofile").splitlines(),
                   "%s writes %s=%s" % (label, key, stored))
         check(checked(page_of[field], field) == bool(value),
               "%s draws %s box" % (label, "a ticked" if value else "an empty"))

--- a/tests/90_webhttrack-checkbox-clear.test
+++ b/tests/90_webhttrack-checkbox-clear.test
@@ -1,8 +1,7 @@
 #!/bin/bash
 #
-# An unchecked box posts nothing, so a stored "1" survives: each checkbox needs
-# a hidden companion posting an empty value, and a default-on option needs the
-# cleared value to emit the disabling flag.
+# An unchecked box posts nothing and the stored "1" survives: hence a hidden
+# companion per box, plus a disabling flag for the default-on ones.
 
 set -euo pipefail
 
@@ -72,6 +71,7 @@ def check(ok, what):
 
 # cache/cache2 are left to the separate rework of the dead "Cache" seed.
 skip = {"cache", "cache2"}
+page_of = {}
 boxes = 0
 for path in sorted(glob.glob(os.path.join(srcdir, "html", "server", "option*.html"))):
     page = open(path, "rb").read().decode("latin-1")
@@ -81,11 +81,14 @@ for path in sorted(glob.glob(os.path.join(srcdir, "html", "server", "option*.htm
         boxes += 1
         if m.group(1) in skip:
             continue
+        page_of[m.group(1)] = os.path.basename(path)
         at = cleared.get(m.group(1))
         check(at is not None and at < m.start(), "%s: %s is cleared before it is drawn"
               % (os.path.basename(path), m.group(1)))
 # Control: a regex that stopped matching would leave nothing to assert on.
 check(boxes >= 25, "the option pages were scanned (%d checkboxes)" % boxes)
+
+sid = None
 
 
 def get(path):
@@ -94,11 +97,14 @@ def get(path):
 
 
 def post(fields):
-    sid = re.search(r'name="sid" value="([0-9a-f]+)"', get("/server/index.html"))
+    global sid
     if sid is None:
-        sys.exit("no session id in server/index.html")
+        m = re.search(r'name="sid" value="([0-9a-f]+)"', get("/server/index.html"))
+        if m is None:
+            sys.exit("no session id in server/index.html")
+        sid = m.group(1)
     body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in
-                    [("sid", sid.group(1))] + fields)
+                    [("sid", sid)] + fields)
     req = urllib.request.Request(url + "/server/step4.html",
                                  data=body.encode("latin-1"), method="POST")
     return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
@@ -115,26 +121,69 @@ def checked(page, name):
     return re.search(r'name="%s"[ \t]*checked' % name, get("/server/" + page)) is not None
 
 
-# Positive control: while set, none of the three renders a disabling flag.
-cmd = textarea(post([("cookies", "on"), ("parsejava", "on"), ("updhack", "on")]), "command")
-check("--cookies=0" not in cmd, "a set cookies emits no --cookies=0")
-check("--parse-java=0" not in cmd, "a set parsejava emits no --parse-java=0")
-check("--updatehack" in cmd, "a set updhack emits --updatehack")
-check(checked("option8.html", "cookies"), "a set cookies draws a ticked box")
+# What each state puts on the command line (None: nothing) and its profile key.
+# Only a value-taking alias can carry a disabling flag: -I and -%I are "single"
+# (htsalias.c), so a --index=0 would read back as the bare enabling flag.
+BOXES = [
+    # field           profile key           set                          cleared
+    ("parseall", "ParseAll", "--near", None),
+    ("link", "Near", "--test", None),
+    ("testall", "Test", "--extended-parsing", None),
+    # htmlfirst emits --priority=7, which the scan-priority list also emits.
+    ("htmlfirst", "HTMLFirst", None, None),
+    ("errpage", "NoErrorPages", "--generate-errors=0", None),
+    ("external", "NoExternalPages", "--replace-external", None),
+    ("hidepwd", "NoPwdInPages", "--disable-passwords", None),
+    ("hidequery", "NoQueryStrings", "--include-query-string=0", None),
+    ("nopurge", "NoPurgeOldFiles", "--purge-old=0", None),
+    ("windebug", None, "--debug-headers", None),
+    ("ka", "KeepAlive", "--keep-alive", None),
+    ("remt", "RemoveTimeout", "--host-control=1", None),
+    ("rems", "RemoveRateout", "--host-control=2", None),
+    ("cookies", "Cookies", None, "--cookies=0"),
+    ("parsejava", "ParseJava", None, "--parse-java=0"),
+    ("updhack", "UpdateHack", "--updatehack", None),
+    ("urlhack", "URLHack", "--urlhack", None),
+    ("keepwww", "KeepWww", "--keep-www-prefix", None),
+    ("keepslashes", "KeepSlashes", "--keep-double-slashes", None),
+    ("keepqueryorder", "KeepQueryOrder", "--keep-query-order", None),
+    ("toler", "TolerantRequests", "--tolerant", None),
+    ("http10", "HTTP10", "--http-10", None),
+    ("warc", "Warc", "--warc", None),
+    ("norecatch", "NoRecatch", "--do-not-recatch", None),
+    ("logf", "Log", "--single-log", None),
+    ("index", "Index", None, None),
+    ("index2", "WordIndex", "--search-index", None),
+    ("ftpprox", "UseHTTPProxyForFTP", "--httpproxy-ftp", None),
+]
 
-page = post([("cookies", ""), ("parsejava", ""), ("updhack", "")])
-cmd = textarea(page, "command")
-check("--cookies=0" in cmd, "a cleared cookies emits --cookies=0")
-check("--parse-java=0" in cmd, "a cleared parsejava emits --parse-java=0")
-check("--updatehack" not in cmd, "a cleared updhack drops --updatehack")
-check(not checked("option8.html", "cookies"), "a cleared cookies draws an empty box")
-# The Windows GUI reads the same option out of the profile.
-check("\nCookies=0" in textarea(page, "winprofile"), "a cleared cookies writes Cookies=0")
+for field, key, when_set, when_clear in BOXES:
+    for value, want, unwanted, stored in (("on", when_set, when_clear, "1"),
+                                          ("", when_clear, when_set, "0")):
+        page = post([(field, value)])
+        cmd = textarea(page, "command").split()
+        label = "%s %s" % (field, "set" if value else "cleared")
+        if want:
+            check(want in cmd, "%s emits %s" % (label, want))
+        if unwanted:
+            check(unwanted not in cmd, "%s drops %s" % (label, unwanted))
+        if key:
+            # The Windows GUI reads the same option out of the profile.
+            check("%s=%s" % (key, stored) in textarea(page, "winprofile").splitlines(),
+                  "%s writes %s=%s" % (label, key, stored))
+        check(checked(page_of[field], field) == bool(value),
+              "%s draws %s box" % (label, "a ticked" if value else "an empty"))
+missing = sorted(set(page_of) - set(b[0] for b in BOXES))
+check(not missing, "every checkbox is exercised (missing %s)" % missing)
 
-# A default-off option is stuck the same way once it has been set.
-check("--tolerant" in textarea(post([("toler", "on")]), "command"), "a set toler emits --tolerant")
-check("--tolerant" not in textarea(post([("toler", "")]), "command"),
-      "a cleared toler drops --tolerant")
+# A browser posts the companion and the ticked box under one name, so the fix
+# rests on the body loop keeping the last value; both orders pin that down.
+cmd = textarea(post([("cookies", ""), ("cookies", "on")]), "command").split()
+check("--cookies=0" not in cmd, "cookies=&cookies=on keeps cookies set")
+check(checked("option8.html", "cookies"), "cookies=&cookies=on draws a ticked box")
+cmd = textarea(post([("cookies", "on"), ("cookies", "")]), "command").split()
+check("--cookies=0" in cmd, "cookies=on&cookies= clears cookies")
+check(not checked("option8.html", "cookies"), "cookies=on&cookies= draws an empty box")
 
 sys.exit(rc)
 PY

--- a/tests/90_webhttrack-checkbox-clear.test
+++ b/tests/90_webhttrack-checkbox-clear.test
@@ -1,0 +1,146 @@
+#!/bin/bash
+#
+# An unchecked box posts nothing, so a stored "1" survives: each checkbox needs
+# a hidden companion posting an empty value, and a default-on option needs the
+# cleared value to emit the disabling flag.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
+distdir=$(cd "${distdir}" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+command -v htsserver >/dev/null || fail "no htsserver in PATH"
+python=$(find_python) || {
+    echo "python3 not found; skipping" >&2
+    exit 77
+}
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_checkbox.XXXXXX") || fail "no tmpdir"
+srvlog=$(mktemp)
+srv=
+srvpid=
+cleanup() {
+    # htsserver keeps SIGTERM ignored across its exec, so only -9 reaps it.
+    test -z "${srvpid}" || kill -9 "${srvpid}" 2>/dev/null || true
+    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
+    wait "${srv}" 2>/dev/null || true # absorb bash's async "Killed" notice
+    rm -rf "${work}" "${srvlog}"
+}
+trap cleanup EXIT HUP INT QUIT PIPE TERM
+
+# An isolated HOME keeps a stray ~/.httrack.ini out of the served settings.
+sport=$("${python}" -c 'import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()')
+(
+    trap '' TERM TTOU
+    export HOME="${work}"
+    exec htsserver "${distdir}/" --port "${sport}" >"${srvlog}" 2>&1
+) &
+srv=$!
+for _ in $(seq 1 40); do
+    url=$(sed -n 's/^URL=//p' "${srvlog}") && test -n "${url}" && break
+    kill -0 "${srv}" 2>/dev/null || break
+    sleep 0.25
+done
+test -n "${url:-}" || fail "htsserver did not start: $(cat "${srvlog}")"
+srvpid=$(sed -n 's/^PID=//p' "${srvlog}") # absent on Windows
+
+"${python}" - "${url}" "${distdir}" <<'PY' || fail "checkbox clearing is broken (see above)"
+import glob, os, re, sys, urllib.parse, urllib.request
+
+url, srcdir = sys.argv[1].rstrip("/"), sys.argv[2]
+rc = 0
+
+
+def check(ok, what):
+    global rc
+    print(("ok: " if ok else "FAIL: ") + what)
+    if not ok:
+        rc = 1
+
+
+# cache/cache2 are left to the separate rework of the dead "Cache" seed.
+skip = {"cache", "cache2"}
+boxes = 0
+for path in sorted(glob.glob(os.path.join(srcdir, "html", "server", "option*.html"))):
+    page = open(path, "rb").read().decode("latin-1")
+    cleared = dict((m.group(1), m.start()) for m in
+                   re.finditer(r'<input type="hidden" name="([^"]+)" value="">', page))
+    for m in re.finditer(r'<input type="checkbox" name="([^"]+)"', page):
+        boxes += 1
+        if m.group(1) in skip:
+            continue
+        at = cleared.get(m.group(1))
+        check(at is not None and at < m.start(), "%s: %s is cleared before it is drawn"
+              % (os.path.basename(path), m.group(1)))
+# Control: a regex that stopped matching would leave nothing to assert on.
+check(boxes >= 25, "the option pages were scanned (%d checkboxes)" % boxes)
+
+
+def get(path):
+    # The UI is served ISO-8859-1, so decode, do not assume UTF-8.
+    return urllib.request.urlopen(url + path, timeout=20).read().decode("latin-1")
+
+
+def post(fields):
+    sid = re.search(r'name="sid" value="([0-9a-f]+)"', get("/server/index.html"))
+    if sid is None:
+        sys.exit("no session id in server/index.html")
+    body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in
+                    [("sid", sid.group(1))] + fields)
+    req = urllib.request.Request(url + "/server/step4.html",
+                                 data=body.encode("latin-1"), method="POST")
+    return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
+
+
+def textarea(page, name):
+    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page, re.S)
+    if m is None:
+        sys.exit("no %s textarea in the rendered step4.html" % name)
+    return m.group(1)
+
+
+def checked(page, name):
+    return re.search(r'name="%s"[ \t]*checked' % name, get("/server/" + page)) is not None
+
+
+# Positive control: while set, none of the three renders a disabling flag.
+cmd = textarea(post([("cookies", "on"), ("parsejava", "on"), ("updhack", "on")]), "command")
+check("--cookies=0" not in cmd, "a set cookies emits no --cookies=0")
+check("--parse-java=0" not in cmd, "a set parsejava emits no --parse-java=0")
+check("--updatehack" in cmd, "a set updhack emits --updatehack")
+check(checked("option8.html", "cookies"), "a set cookies draws a ticked box")
+
+page = post([("cookies", ""), ("parsejava", ""), ("updhack", "")])
+cmd = textarea(page, "command")
+check("--cookies=0" in cmd, "a cleared cookies emits --cookies=0")
+check("--parse-java=0" in cmd, "a cleared parsejava emits --parse-java=0")
+check("--updatehack" not in cmd, "a cleared updhack drops --updatehack")
+check(not checked("option8.html", "cookies"), "a cleared cookies draws an empty box")
+# The Windows GUI reads the same option out of the profile.
+check("\nCookies=0" in textarea(page, "winprofile"), "a cleared cookies writes Cookies=0")
+
+# A default-off option is stuck the same way once it has been set.
+check("--tolerant" in textarea(post([("toler", "on")]), "command"), "a set toler emits --tolerant")
+check("--tolerant" not in textarea(post([("toler", "")]), "command"),
+      "a cleared toler drops --tolerant")
+
+sys.exit(rc)
+PY
+
+# A leaked htsserver wedges the parallel harness behind a green log.
+cleanup
+! kill -0 "${srv}" 2>/dev/null || fail "htsserver ${srv} survived"
+
+echo "PASS"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -182,6 +182,7 @@ TESTS = \
 	82_webhttrack-browse-links.test \
 	83_webhttrack-argescape.test \
 	84_webhttrack-mirror-verbatim.test \
-	85_webhttrack-projpath.test
+	85_webhttrack-projpath.test \
+	90_webhttrack-checkbox-clear.test
 
 CLEANFILES = check-network_sh.cache


### PR DESCRIPTION
An unchecked HTML checkbox posts nothing, so htsserver never overwrites the value it already holds. Every box in the wizard is one-way: once the stored value is "1", whether htsserver seeded it at startup, a loaded profile set it, or the user ticked it earlier in the session, un-ticking and submitting leaves the option on and draws the box ticked again. Only four boxes, all in option1.html, carried the companion hidden field that guards against this.

The fix is wider than the eight options that start ticked. A posted value and a loaded profile land in the same persistent table, so any of the 30 checkboxes goes sticky once something sets it, and every bare box now gets a companion. That is enough for the twenty-odd options whose "off" state is just the absence of a flag. The ones the engine turns on by default also need an explicit disabling flag, and `${test:...}` renders nothing when the value is empty, so cookies and parsejava move to `${ztest:...}` and a cleared box emits `--cookies=0` or `--parse-java=0`, both verified against a local server to behave like `-b0` and `-j12`.

`index`, `urlhack` and `keep-alive` are deliberately left alone. Their long options are declared `"single"` in htsalias.c and optalias_check drops the `=value`, so `--index=0` resolves to `-I` and still builds the index; emitting it from a cleared box would turn the option back on rather than off. That is a pre-existing parser bug and needs its own fix. `cache` and `cache2` are being reworked separately, and `testall` is still open: it has a companion already, but `--extended-parsing` maps to `opt->parseall`, which defaults on, so clearing it changes nothing.

GUI behaviour changes for users: options that silently could not be turned off now can be.
