### PR TITLE
Test assertions read a padded or truncated reply as a clean security verdict

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,10 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   check`, or `PATH="<bld>/src:$PATH"` for a manual run.
 - Give new `.test` scripts `set -e`: the older ones predate the rule, so several
   `local-crawl.sh` calls with no `set -e` report PASS on any non-last failure.
+- Never assert with `cmd | grep -q MARKER && fail`: under `pipefail` a failing
+  `cmd` makes the `&&` short-circuit, so a probe that never ran reads as "marker
+  absent" and the check passes without looking. Capture the reply first, fail if
+  it did not arrive, then match it.
 
 ## Hard invariants
 - **Generated autotools files are NOT in git.** `configure`, every

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,10 +26,12 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   check`, or `PATH="<bld>/src:$PATH"` for a manual run.
 - Give new `.test` scripts `set -e`: the older ones predate the rule, so several
   `local-crawl.sh` calls with no `set -e` report PASS on any non-last failure.
-- Never assert with `cmd | grep -q MARKER && fail`: under `pipefail` a failing
-  `cmd` makes the `&&` short-circuit, so a probe that never ran reads as "marker
-  absent" and the check passes without looking. Capture the reply first, fail if
-  it did not arrive, then match it.
+- Never assert with `cmd | grep -q MARKER && fail`. Under `pipefail` the
+  pipeline is non-zero both when `cmd` fails and when `grep -q` matches early
+  and SIGPIPEs it, so the `&&` never fires and a probe that proved nothing reads
+  as "marker absent". Capture the reply, assert the status line it must carry
+  (an empty, truncated or redirected one is marker-free too), then match with a
+  here-string.
 
 ## Hard invariants
 - **Generated autotools files are NOT in git.** `configure`, every

--- a/tests/77_webhttrack-redirect.test
+++ b/tests/77_webhttrack-redirect.test
@@ -146,11 +146,13 @@ sid=$(scrape_sid "${port}")
 resp=$(post_redirect '/foo
 X-Injected: pwned' "${port}" "${sid}") || fail "no response to a CRLF redirect value"
 stop
-printf '%s' "${resp}" | grep -qi 'X-Injected' &&
+# Here-string, not a pipe: grep -q SIGPIPEs the producer on the first match, and
+# pipefail then turns the hit into a silent pass.
+grep -qi 'X-Injected' <<<"${resp}" &&
     fail "CRLF in the redirect value reached the response"
-test "$(printf '%s' "${resp}" | grep -ci '^Location:')" -eq 0 ||
+test "$(grep -ci '^Location:' <<<"${resp}")" -eq 0 ||
     fail "CRLF redirect still emitted a Location header"
-test "$(printf '%s' "${resp}" | grep -c '^HTTP/1\.')" -eq 1 ||
+test "$(grep -c '^HTTP/1\.' <<<"${resp}")" -eq 1 ||
     fail "CRLF redirect did not yield exactly one status line"
 
 # Loopback unless asked otherwise. Assert the socket, not the announcement.

--- a/tests/78_webhttrack-sid.test
+++ b/tests/78_webhttrack-sid.test
@@ -103,9 +103,10 @@ sid=$(scrape_sid "${port}")
 test "${#sid}" -eq 32 || fail "did not scrape a 32-hex sid from the page (got '${sid}')"
 
 # Accept: the legitimate flow still works. "redirect" is the cheapest field
-# with a reply that is visible in the headers.
+# with a reply that is visible in the headers. Matched from a here-string, not a
+# pipe: grep -q SIGPIPEs the producer, and pipefail then buries the verdict.
 resp=$(request "${port}" "sid=${sid}&redirect=/accepted")
-printf '%s' "${resp}" | grep -q '^Location: /accepted' ||
+grep -q '^Location: /accepted' <<<"${resp}" ||
     fail "a body carrying the correct sid was refused"
 
 # Refuse: missing and wrong. A missing one is the regression under test — the
@@ -114,12 +115,12 @@ printf '%s' "${resp}" | grep -q '^Location: /accepted' ||
 for bad in "redirect=/nosid" "sid=&redirect=/empty" \
     "sid=00000000000000000000000000000000&redirect=/wrong"; do
     resp=$(request "${port}" "${bad}")
-    printf '%s' "${resp}" | grep -q '^Location:' &&
+    grep -q '^Location:' <<<"${resp}" &&
         fail "body accepted without a valid sid: ${bad}"
     # A refusal has to be a well-formed reply, not a headerless fragment: the
     # release build used to emit only Content-length, which reads as a protocol
     # error to any client and hides the reason.
-    printf '%s' "${resp}" | grep -q '^HTTP/1\.0 403 ' ||
+    grep -q '^HTTP/1\.0 403 ' <<<"${resp}" ||
         fail "refusal was not a 403: ${bad}"
 done
 
@@ -127,19 +128,23 @@ done
 # applied to one global key store that later requests render from, and the
 # command dispatcher reads it from there. Probe the store itself — step3
 # interpolates ${projname} into its title — rather than the refused reply.
-title() { request "$1" "" step3; }
+store_page() {
+    # a dead probe or a non-page reply must not read as "the store was not written"
+    page=$(request "$1" "" step3) || fail "the key store probe failed"
+    grep -q '^HTTP/1\.0 200 ' <<<"${page}" ||
+        fail "the key store probe did not answer: '$(head -1 <<<"${page}")'"
+}
 
 request "${port}" "projname=UNAUTHWRITE" >/dev/null 2>&1 || true
-# Captured, not piped: a request that never ran would otherwise read as "the
-# store was not written", which is the verdict this is here to earn.
-page=$(title "${port}") || fail "the store probe failed"
+store_page "${port}"
 grep -q 'UNAUTHWRITE' <<<"${page}" &&
     fail "a body without a valid sid was written to the key store"
 
 # Paired accept case: without it the assertion above passes even if the server
 # simply ignores every body, which would prove nothing.
 request "${port}" "sid=${sid}&projname=AUTHWRITE" >/dev/null 2>&1 || true
-title "${port}" | grep -q 'AUTHWRITE' ||
+store_page "${port}"
+grep -q 'AUTHWRITE' <<<"${page}" ||
     fail "a body carrying the correct sid was not written to the key store"
 
 echo "PASS"

--- a/tests/78_webhttrack-sid.test
+++ b/tests/78_webhttrack-sid.test
@@ -130,7 +130,10 @@ done
 title() { request "$1" "" step3; }
 
 request "${port}" "projname=UNAUTHWRITE" >/dev/null 2>&1 || true
-title "${port}" | grep -q 'UNAUTHWRITE' &&
+# Captured, not piped: a request that never ran would otherwise read as "the
+# store was not written", which is the verdict this is here to earn.
+page=$(title "${port}") || fail "the store probe failed"
+grep -q 'UNAUTHWRITE' <<<"${page}" &&
     fail "a body without a valid sid was written to the key store"
 
 # Paired accept case: without it the assertion above passes even if the server

--- a/tests/85_webhttrack-projpath.test
+++ b/tests/85_webhttrack-projpath.test
@@ -90,13 +90,13 @@ sys.stdout.write(out.decode("latin-1"))' "$1" "$2" "$3"
 get() { request "$1" "$2" ""; }
 post() { request "$1" "" "$2"; }
 
-# GET $2 into ${reply}. Piping the request straight into "grep -q ... && fail"
-# reads a request that never ran as "marker absent", so the leak checks below
-# would pass on a dead probe; make one fail loudly instead.
+# GET $2 into ${reply}, requiring status $3. Captured, not piped: a dead request
+# reads as marker-absent, and so do a truncated body and a 302 to the file.
 reply=
 fetch() {
     reply=$(get "$1" "$2") || fail "the request for $2 failed"
-    test -n "${reply}" || fail "the request for $2 returned nothing"
+    grep -q "^HTTP/1\.0 $3 " <<<"${reply}" ||
+        fail "$2: wanted a $3 reply, got '$(head -1 <<<"${reply}")'"
 }
 
 url=$(start)
@@ -118,13 +118,13 @@ echo "LOGMARKER" >"${base}/proj/hts-log.txt"
 # with a component over NAME_MAX (mkdir refuses it whatever the uid). Must precede
 # any successful save: commandEnd then swaps the error page for the finished one.
 get "${port}" /server/style.css >/dev/null # leaves a path behind in fsfile
-post "${port}" "sid=${sid}&command=httrack&command_do=save&winprofile=x&path=${base}/$(printf '%0300d' 0)&projname=p" |
-    grep -q '^Location: /server/error.html' ||
+saved=$(post "${port}" "sid=${sid}&command=httrack&command_do=save&winprofile=x&path=${base}/$(printf '%0300d' 0)&projname=p")
+grep -q '^Location: /server/error.html' <<<"${saved}" ||
     fail "the refused save did not redirect to the error page"
 
 # No project yet, so no root to serve from.
 post "${port}" "sid=${sid}&projpath=${base}/" >/dev/null
-fetch "${port}" /website/secret.txt
+fetch "${port}" /website/secret.txt 404
 grep -q SECRETMARKER <<<"${reply}" &&
     fail "a posted projpath served a file outside any project"
 
@@ -136,28 +136,28 @@ body="${body}&path=${base}&projname=proj&projpath=${base}/proj/"
 post "${port}" "${body}" >/dev/null
 test -f "${base}/proj/hts-cache/winprofile.ini" ||
     fail "the project was not registered: $(cat "${log}")"
-fetch "${port}" /website/hts-log.txt
+fetch "${port}" /website/hts-log.txt 200
 grep -q LOGMARKER <<<"${reply}" ||
     fail "the registered project's mirror is not served"
 
 # Same request with the root repointed: the project is legitimate, projpath is
 # not what decides where the bytes come from.
 post "${port}" "sid=${sid}&projpath=${base}/" >/dev/null
-fetch "${port}" /website/secret.txt
+fetch "${port}" /website/secret.txt 404
 grep -q SECRETMARKER <<<"${reply}" &&
     fail "a posted projpath repointed the served root"
 post "${port}" "sid=${sid}&projpath=/etc/" >/dev/null
-fetch "${port}" /website/passwd
+fetch "${port}" /website/passwd 404
 grep -q '^root:' <<<"${reply}" &&
     fail "a posted projpath read an arbitrary system file"
 
 # A ".." anywhere in the recorded root would escape the mirror on every later
 # request, so the save must be refused and the previous root kept.
 post "${port}" "sid=${sid}&command=httrack&command_do=save&winprofile=x&path=${base}/proj&projname=.." >/dev/null
-fetch "${port}" /website/secret.txt
+fetch "${port}" /website/secret.txt 404
 grep -q SECRETMARKER <<<"${reply}" &&
     fail "a '..' in the saved project path escaped the mirror root"
-fetch "${port}" /website/hts-log.txt
+fetch "${port}" /website/hts-log.txt 200
 grep -q LOGMARKER <<<"${reply}" ||
     fail "rejecting the '..' root also lost the previous one"
 
@@ -177,8 +177,7 @@ test -f "${fspath}/hts-cache/winprofile.ini" ||
     fail "the long-path project was not registered: $(cat "${log}")"
 get "${port}" "/website/${longurl}" >/dev/null 2>&1 || true
 alive "${srv}" || fail "an over-long project path crashed the server: $(cat "${log}")"
-fetch "${port}" /server/index.html
-grep -q '200 OK' <<<"${reply}" ||
-    fail "the server stopped answering after the over-long project path"
+# Not just alive: still answering.
+fetch "${port}" /server/index.html 200
 
 echo "PASS"

--- a/tests/85_webhttrack-projpath.test
+++ b/tests/85_webhttrack-projpath.test
@@ -90,6 +90,15 @@ sys.stdout.write(out.decode("latin-1"))' "$1" "$2" "$3"
 get() { request "$1" "$2" ""; }
 post() { request "$1" "" "$2"; }
 
+# GET $2 into ${reply}. Piping the request straight into "grep -q ... && fail"
+# reads a request that never ran as "marker absent", so the leak checks below
+# would pass on a dead probe; make one fail loudly instead.
+reply=
+fetch() {
+    reply=$(get "$1" "$2") || fail "the request for $2 failed"
+    test -n "${reply}" || fail "the request for $2 returned nothing"
+}
+
 url=$(start)
 port=$(portof "${url}")
 srv=$(srvpid)
@@ -115,7 +124,8 @@ post "${port}" "sid=${sid}&command=httrack&command_do=save&winprofile=x&path=${b
 
 # No project yet, so no root to serve from.
 post "${port}" "sid=${sid}&projpath=${base}/" >/dev/null
-get "${port}" /website/secret.txt | grep -q SECRETMARKER &&
+fetch "${port}" /website/secret.txt
+grep -q SECRETMARKER <<<"${reply}" &&
     fail "a posted projpath served a file outside any project"
 
 # Positive control: step4's "save settings" flow registers the project without
@@ -126,24 +136,29 @@ body="${body}&path=${base}&projname=proj&projpath=${base}/proj/"
 post "${port}" "${body}" >/dev/null
 test -f "${base}/proj/hts-cache/winprofile.ini" ||
     fail "the project was not registered: $(cat "${log}")"
-get "${port}" /website/hts-log.txt | grep -q LOGMARKER ||
+fetch "${port}" /website/hts-log.txt
+grep -q LOGMARKER <<<"${reply}" ||
     fail "the registered project's mirror is not served"
 
 # Same request with the root repointed: the project is legitimate, projpath is
 # not what decides where the bytes come from.
 post "${port}" "sid=${sid}&projpath=${base}/" >/dev/null
-get "${port}" /website/secret.txt | grep -q SECRETMARKER &&
+fetch "${port}" /website/secret.txt
+grep -q SECRETMARKER <<<"${reply}" &&
     fail "a posted projpath repointed the served root"
 post "${port}" "sid=${sid}&projpath=/etc/" >/dev/null
-get "${port}" /website/passwd | grep -q '^root:' &&
+fetch "${port}" /website/passwd
+grep -q '^root:' <<<"${reply}" &&
     fail "a posted projpath read an arbitrary system file"
 
 # A ".." anywhere in the recorded root would escape the mirror on every later
 # request, so the save must be refused and the previous root kept.
 post "${port}" "sid=${sid}&command=httrack&command_do=save&winprofile=x&path=${base}/proj&projname=.." >/dev/null
-get "${port}" /website/secret.txt | grep -q SECRETMARKER &&
+fetch "${port}" /website/secret.txt
+grep -q SECRETMARKER <<<"${reply}" &&
     fail "a '..' in the saved project path escaped the mirror root"
-get "${port}" /website/hts-log.txt | grep -q LOGMARKER ||
+fetch "${port}" /website/hts-log.txt
+grep -q LOGMARKER <<<"${reply}" ||
     fail "rejecting the '..' root also lost the previous one"
 
 # The root is now the server's own, but it is still built from two posted
@@ -162,7 +177,8 @@ test -f "${fspath}/hts-cache/winprofile.ini" ||
     fail "the long-path project was not registered: $(cat "${log}")"
 get "${port}" "/website/${longurl}" >/dev/null 2>&1 || true
 alive "${srv}" || fail "an over-long project path crashed the server: $(cat "${log}")"
-get "${port}" /server/index.html | grep -q '200 OK' ||
+fetch "${port}" /server/index.html
+grep -q '200 OK' <<<"${reply}" ||
     fail "the server stopped answering after the over-long project path"
 
 echo "PASS"


### PR DESCRIPTION
@/tmp/claude-1000/-home-roche-git-httrack/69a76f53-3fa0-48b8-8d80-3bba01229b92/scratchpad/prbody.md