### PR TITLE
lienrelatif() reads one byte before its stack buffer on an empty path

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -457,6 +457,12 @@ static void basic_selftests(void) {
     // link one level up -> a "../" prefix
     assertf(lienrelatif(s, sizeof(s), "a.html", "dir/index.html") == 0);
     assertf(strcmp(s, "../a.html") == 0);
+    // an empty current path: the trim used to walk off the front of it, which
+    // "?x" reaches too because the query pre-pass hands on the part before it
+    assertf(lienrelatif(s, sizeof(s), "dir/page.html", "") == 0);
+    assertf(strcmp(s, "dir/page.html") == 0);
+    assertf(lienrelatif(s, sizeof(s), "dir/page.html", "?x") == 0);
+    assertf(strcmp(s, "dir/page.html") == 0);
   }
 }
 

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -308,8 +308,10 @@ int lienrelatif(char *s, size_t ssize, const char *link, const char *curr_fil) {
   // copy only the current path
   curr = _curr;
   strlcpybuff(curr, curr_fil, sizeof(_curr));
-  if ((a = strchr(curr, '?')) == NULL)  // couper au ? (params)
-    a = curr + strlen(curr) - 1;        // pas de params: aller à la fin
+  if ((a = strchr(curr, '?')) == NULL) { // cut at the ? (query parameters)
+    // an empty path has no last character: curr-1 would read before the buffer
+    a = curr[0] != '\0' ? curr + strlen(curr) - 1 : curr;
+  }
   while((*a != '/') && (a > curr))
     a--;                        // chercher dernier / du chemin courant
   if (*a == '/')


### PR DESCRIPTION
`lienrelatif()` trims its current-path argument back to the last `/`, starting from `curr + strlen(curr) - 1`. When the path is empty that is `curr - 1`, and the loop dereferences it before the bounds test stops it.

The empty path is not hypothetical. The pre-pass that strips a query does `strncatbuff(newcurr_fil, curr_fil, a - curr_fil)`, so any `curr_fil` beginning with `?` hands the trim an empty string. `httrack -#test=relative "dir/page.html" "?x"` under ASan reports the underflow on current master.

The read is a single byte and the loop exits on its `a > curr` test whatever that byte holds, so the guard is behaviour-preserving rather than a behaviour change. Checked rather than assumed: 484 ordered pairs from a 22-value path corpus, run against builds that force the byte before the buffer to `0` and to `'/'`, produce output identical to the guarded build in both states.

Found while working on #712, which reaches the same path from a document with no save name.
