### PR TITLE
An entry with no usable Last-Modified crashes proxytrack --convert

### DIFF
--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -2380,7 +2380,17 @@ static int PT_SaveCache__Arc_Fun(void *arg, const char *url, PT_Element element)
   PT_SaveCache__Arc_t *st = (PT_SaveCache__Arc_t *) arg;
   FILE *const fp = st->fp;
   struct tm *tm = convert_time_rfc822(&st->buff, element->lastmodified);
+  struct tm unknown_date;
   int size_headers;
+
+  /* a cached entry with no parseable Last-Modified must not take the writer
+     down; the epoch is the conventional "date unknown" */
+  if (tm == NULL) {
+    memset(&unknown_date, 0, sizeof(unknown_date));
+    unknown_date.tm_year = 70;
+    unknown_date.tm_mday = 1;
+    tm = &unknown_date;
+  }
 
   sprintf(st->headers,
           "HTTP/1.0 %d %s"

--- a/tests/87_local-proxytrack-nodate.test
+++ b/tests/87_local-proxytrack-nodate.test
@@ -7,10 +7,14 @@ set -euo pipefail
 dir=$(mktemp -d)
 trap 'rm -rf "$dir"' EXIT
 
-# entry 1 has no Last-Modified at all, entry 2 has one that cannot parse
+# $1 Last-Modified value (empty = omit the header), $2 expected archive date,
+# $3 label. The date is asserted exactly: a guard that fires unconditionally
+# would clobber the valid case, and one that skips the year/day would emit a
+# month and day of 00.
 run_case() {
     lastmod=$1
-    what=$2
+    wantdate=$2
+    what=$3
 
     {
         printf 'HTTP/1.1 200 OK\r\n'
@@ -32,11 +36,16 @@ run_case() {
         echo "FAIL: proxytrack crashed on $what" >&2
         exit 1
     }
-    grep -aq 'http://example.com/p.html' "$dir/out.arc" || {
-        echo "FAIL: entry dropped on $what" >&2
+    grep -aq "^http://example.com/p.html 0.0.0.0 ${wantdate} " "$dir/out.arc" || {
+        echo "FAIL: $what: expected archive date ${wantdate}, got:" >&2
+        grep -a '^http://example.com/' "$dir/out.arc" >&2 || echo "(entry dropped)" >&2
         exit 1
     }
 }
 
-run_case '' 'a missing Last-Modified'
-run_case 'not a date at all' 'an unparseable Last-Modified'
+# the epoch stands in for "date unknown"
+run_case '' 19700101000000 'a missing Last-Modified'
+run_case 'not a date at all' 19700101000000 'an unparseable Last-Modified'
+run_case '0' 19700101000000 'a bare 0 Last-Modified'
+# a parseable date must still come through untouched
+run_case 'Sun, 06 Nov 1994 08:49:37 GMT' 19941106084937 'a valid Last-Modified'

--- a/tests/87_local-proxytrack-nodate.test
+++ b/tests/87_local-proxytrack-nodate.test
@@ -1,0 +1,42 @@
+#!/bin/bash
+# A cached entry whose Last-Modified is missing or unparseable must still
+# convert: the ARC writer used to dereference the parsed date unchecked.
+
+set -euo pipefail
+
+dir=$(mktemp -d)
+trap 'rm -rf "$dir"' EXIT
+
+# entry 1 has no Last-Modified at all, entry 2 has one that cannot parse
+run_case() {
+    lastmod=$1
+    what=$2
+
+    {
+        printf 'HTTP/1.1 200 OK\r\n'
+        printf 'Content-Type: text/html\r\n'
+        test -z "$lastmod" || printf 'Last-Modified: %s\r\n' "$lastmod"
+        printf 'Content-Length: 5\r\n\r\n'
+    } >"$dir/hdr"
+    printf 'hello' >"$dir/body"
+    alen=$(($(wc -c <"$dir/hdr") + $(wc -c <"$dir/body")))
+    {
+        printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc 9\n'
+        printf '2 0 test\n'
+        printf '\n\n'
+        printf 'http://example.com/p.html 0.0.0.0 20250101000000 text/html 200 - - 0 t.arc %d\n' "$alen"
+        cat "$dir/hdr" "$dir/body"
+    } >"$dir/in.arc"
+
+    proxytrack --convert "$dir/out.arc" "$dir/in.arc" >/dev/null 2>&1 || {
+        echo "FAIL: proxytrack crashed on $what" >&2
+        exit 1
+    }
+    grep -aq 'http://example.com/p.html' "$dir/out.arc" || {
+        echo "FAIL: entry dropped on $what" >&2
+        exit 1
+    }
+}
+
+run_case '' 'a missing Last-Modified'
+run_case 'not a date at all' 'an unparseable Last-Modified'

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -183,6 +183,7 @@ TESTS = \
 	83_webhttrack-argescape.test \
 	84_webhttrack-mirror-verbatim.test \
 	85_webhttrack-projpath.test \
-	86_local-proxytrack-cache-longfields.test
+	86_local-proxytrack-cache-longfields.test \
+	87_local-proxytrack-nodate.test
 
 CLEANFILES = check-network_sh.cache


### PR DESCRIPTION
`PT_SaveCache__Arc_Fun` takes the `struct tm *` from `convert_time_rfc822()` and feeds it straight into the record line's date fields. That function returns NULL on anything it cannot parse, so a cached entry whose `Last-Modified` is missing or malformed segfaults `proxytrack --convert`. The sibling call site a thousand lines up already checks for NULL before using the result; this one never did.

Falls back to the epoch, which keeps the entry rather than dropping it and produces a well-formed timestamp. Found while building the cache-header test in #717.
