### PR TITLE
A cache field wider than ours aborts the engine instead of clipping

### DIFF
--- a/src/htscache.c
+++ b/src/htscache.c
@@ -142,8 +142,8 @@ struct cache_back_zip_entry {
   int compressionMethod;
 };
 
-/* Clip: strlcpybuff aborts on overflow, and a cache written by another build
-   (or a corrupt one) can legitimately carry a field wider than ours. */
+/* Clip: strlcpybuff aborts on overflow, which would take the crawl down on a
+   corrupt cache carrying a field wider than ours. */
 #define ZIP_READFIELD_STRING(line, value, refline, refvalue, refvalue_size)    \
   do {                                                                         \
     if (line[0] != '\0' && strfield2(line, refline)) {                         \

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -142,10 +142,13 @@ struct cache_back_zip_entry {
   int compressionMethod;
 };
 
+/* Clip: strlcpybuff aborts on overflow, and a cache written by another build
+   (or a corrupt one) can legitimately carry a field wider than ours. */
 #define ZIP_READFIELD_STRING(line, value, refline, refvalue, refvalue_size)    \
   do {                                                                         \
     if (line[0] != '\0' && strfield2(line, refline)) {                         \
-      strlcpybuff(refvalue, value, refvalue_size);                             \
+      (refvalue)[0] = '\0';                                                    \
+      strlncatbuff(refvalue, value, refvalue_size, (refvalue_size) - 1);       \
       line[0] = '\0';                                                          \
     }                                                                          \
   } while (0)

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -1429,8 +1429,8 @@ static int corrupt_expect_disk_header(httrackp *opt, LLint wantsize,
 
 /* An over-long field from a foreign cache must clip, not abort: the entry
    still reads, clipped to capacity, and the canary survives. */
-static int corrupt_expect_victim_clipped(httrackp *opt, size_t wantlen,
-                                         const char *what) {
+static int corrupt_expect_victim_clipped(httrackp *opt, size_t wantmsg,
+                                         size_t wantlastmod, const char *what) {
   cache_back cache;
   htsblk v, c;
   char BIGSTK lv[HTS_URLMAXSIZE * 2];
@@ -1440,10 +1440,19 @@ static int corrupt_expect_victim_clipped(httrackp *opt, size_t wantlen,
   selftest_open_for_read(&cache, opt);
   lv[0] = lc[0] = '\0';
   v = cache_readex(opt, &cache, CORRUPT_ADR, "/victim.html", "", lv, NULL, 1);
-  if (v.statuscode != 200 || strlen(v.msg) != wantlen) {
-    fprintf(stderr, "%s: %s: status %d msg len %u, expected 200/%u\n",
-            selftest_tag, what, v.statuscode, (unsigned) strlen(v.msg),
-            (unsigned) wantlen);
+  if (v.statuscode != 200) {
+    fprintf(stderr, "%s: %s: status %d, expected 200\n", selftest_tag, what,
+            v.statuscode);
+    fail++;
+  }
+  if (wantmsg != (size_t) -1 && strlen(v.msg) != wantmsg) {
+    fprintf(stderr, "%s: %s: msg len %u, expected %u\n", selftest_tag, what,
+            (unsigned) strlen(v.msg), (unsigned) wantmsg);
+    fail++;
+  }
+  if (wantlastmod != (size_t) -1 && strlen(v.lastmodified) != wantlastmod) {
+    fprintf(stderr, "%s: %s: lastmodified len %u, expected %u\n", selftest_tag,
+            what, (unsigned) strlen(v.lastmodified), (unsigned) wantlastmod);
     fail++;
   }
   c = cache_readex(opt, &cache, CORRUPT_ADR, "/canary.html", "", lc, NULL, 1);
@@ -1496,17 +1505,30 @@ int cache_corruption_selftest(httrackp *opt, const char *dir) {
   failures += corrupt_expect_victim(opt, "Cache Read Error : Read Data",
                                     "garbled deflate stream");
 
-  /* A foreign cache may hold a field wider than ours: msg[80] here gets 89
-     bytes. Clipping keeps the entry; aborting would take the crawl down.
-     Overwrite the placeholder Etag line, same byte length, offsets intact. */
+  /* A corrupt cache can hold a field wider than ours. Clipping keeps the
+     entry; aborting would take the crawl down. Overwrite the placeholder Etag
+     line in place, same byte length, so the zip offsets stay intact. */
   corrupt_build_longetag(opt);
   corrupt_patch(opt, "Etag: " CORRUPT_LONG_ETAG, 106,
-                "X-StatusMessage: "
-                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "X-StatusMessage: " /* 17 + 89 = 106 */
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                1, 1);
+  failures +=
+      corrupt_expect_victim_clipped(opt, sizeof(((htsblk *) 0)->msg) - 1,
+                                    (size_t) -1, "over-long X-StatusMessage");
+
+  /* lastmodified[64] is narrower than msg[80]: one hardcoded clip length
+     cannot satisfy both. */
+  corrupt_build_longetag(opt);
+  corrupt_patch(opt, "Etag: " CORRUPT_LONG_ETAG, 106,
+                "Last-Modified: " /* 15 + 91 = 106 */
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
                 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 1, 1);
   failures += corrupt_expect_victim_clipped(
-      opt, sizeof(((htsblk *) 0)->msg) - 1, "over-long X-StatusMessage");
+      opt, (size_t) -1, sizeof(((htsblk *) 0)->lastmodified) - 1,
+      "over-long Last-Modified");
 
   /* An X-Size above INT_MAX is positive as int64 (slips a bare sign check) but
      truncates negative in the (int) cast the malloc uses: a wraparound alloc.

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -1195,6 +1195,12 @@ int cache_legacy_refused_selftest(httrackp *opt, const char *dir) {
 
 /* --- read-side corruption injection --------------------------------------- */
 
+/* 100 'A's: a placeholder header line long enough to be overwritten by a
+   forged, over-long X-StatusMessage of the same byte length. */
+#define CORRUPT_LONG_ETAG                                                      \
+  "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"                         \
+  "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
 /* canary read back intact after each corruption; victim gets the byte surgery
  */
 #define CORRUPT_ADR "corrupt.example.com"
@@ -1216,6 +1222,24 @@ static void corrupt_build(httrackp *opt) {
   store_entry(opt, &cache, CORRUPT_ADR, "/victim.html", "victim.html", 200,
               "OK", "text/html", "utf-8", "", "", "", "", corrupt_body_b,
               strlen(corrupt_body_b));
+  selftest_close(&cache);
+}
+
+/* Like corrupt_build, but the victim carries a 100-char Etag placeholder. */
+static void corrupt_build_longetag(httrackp *opt) {
+  cache_back cache;
+
+  memset(corrupt_body_a, 'a', sizeof(corrupt_body_a) - 1);
+  memset(corrupt_body_b, 'b', sizeof(corrupt_body_b) - 1);
+  remove(reconcile_st_path(opt, "hts-cache/new.zip"));
+  remove(reconcile_st_path(opt, "hts-cache/old.zip"));
+  selftest_open_for_write(&cache, opt);
+  store_entry(opt, &cache, CORRUPT_ADR, "/canary.html", "canary.html", 200,
+              "OK", "text/html", "utf-8", "", "", "", "", corrupt_body_a,
+              strlen(corrupt_body_a));
+  store_entry(opt, &cache, CORRUPT_ADR, "/victim.html", "victim.html", 200,
+              "OK", "text/html", "utf-8", "", CORRUPT_LONG_ETAG, "", "",
+              corrupt_body_b, strlen(corrupt_body_b));
   selftest_close(&cache);
 }
 
@@ -1403,6 +1427,39 @@ static int corrupt_expect_disk_header(httrackp *opt, LLint wantsize,
   return fail;
 }
 
+/* An over-long field from a foreign cache must clip, not abort: the entry
+   still reads, clipped to capacity, and the canary survives. */
+static int corrupt_expect_victim_clipped(httrackp *opt, size_t wantlen,
+                                         const char *what) {
+  cache_back cache;
+  htsblk v, c;
+  char BIGSTK lv[HTS_URLMAXSIZE * 2];
+  char BIGSTK lc[HTS_URLMAXSIZE * 2];
+  int fail = 0;
+
+  selftest_open_for_read(&cache, opt);
+  lv[0] = lc[0] = '\0';
+  v = cache_readex(opt, &cache, CORRUPT_ADR, "/victim.html", "", lv, NULL, 1);
+  if (v.statuscode != 200 || strlen(v.msg) != wantlen) {
+    fprintf(stderr, "%s: %s: status %d msg len %u, expected 200/%u\n",
+            selftest_tag, what, v.statuscode, (unsigned) strlen(v.msg),
+            (unsigned) wantlen);
+    fail++;
+  }
+  c = cache_readex(opt, &cache, CORRUPT_ADR, "/canary.html", "", lc, NULL, 1);
+  if (c.statuscode != 200) {
+    fprintf(stderr, "%s: %s: canary tainted (status %d)\n", selftest_tag, what,
+            c.statuscode);
+    fail++;
+  }
+  if (v.adr != NULL)
+    freet(v.adr);
+  if (c.adr != NULL)
+    freet(c.adr);
+  selftest_close(&cache);
+  return fail;
+}
+
 /* One zip corruption case: build, patch, then check victim+canary in-session.
  */
 static int corrupt_case_zip(httrackp *opt, const char *pat, const char *rep,
@@ -1438,6 +1495,18 @@ int cache_corruption_selftest(httrackp *opt, const char *dir) {
   corrupt_victim_body(opt);
   failures += corrupt_expect_victim(opt, "Cache Read Error : Read Data",
                                     "garbled deflate stream");
+
+  /* A foreign cache may hold a field wider than ours: msg[80] here gets 89
+     bytes. Clipping keeps the entry; aborting would take the crawl down.
+     Overwrite the placeholder Etag line, same byte length, offsets intact. */
+  corrupt_build_longetag(opt);
+  corrupt_patch(opt, "Etag: " CORRUPT_LONG_ETAG, 106,
+                "X-StatusMessage: "
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                1, 1);
+  failures += corrupt_expect_victim_clipped(
+      opt, sizeof(((htsblk *) 0)->msg) - 1, "over-long X-StatusMessage");
 
   /* An X-Size above INT_MAX is positive as int64 (slips a bare sign check) but
      truncates negative in the (int) cast the malloc uses: a wraparound alloc.


### PR DESCRIPTION
The read side of the engine's cache used `strlcpybuff`, and every `*_safe_` helper in `htssafe.h` aborts on overflow instead of truncating. The header line it copies from is bounded by `HTS_URLMAXSIZE`, while the destinations go down to `msg[80]`, so a cache carrying a wider field takes the whole crawl down rather than skipping the entry.

Only a corrupt cache reaches it. The writer emits each field from the same `htsblk` field the reader fills back, and no field has ever shrunk, so nothing httrack produces can overflow its own reader. That makes this a robustness fix, squarely inside what `01_zlib-cache-corrupt` already promises: corruption is "rejected per-entry, never crash". Same abort-versus-clip choice as #717, mirrored — there ProxyTrack's fields genuinely were narrower than the engine's.

Truncation is the safe direction everywhere it can now happen. A clipped `Last-Modified` or `Etag` yields a conditional request the server answers with a full 200, so `--update` re-fetches rather than wrongly skipping. The one case where truncation would be worse than aborting, a clipped `X-Save` feeding the rename in `back_finalize`, cannot occur: that destination is 2048 bytes and the source line is capped at 1024.

The self-test grows two cases, forged over the same-length placeholder line so the zip offsets survive. They target fields of different widths on purpose: with only `msg` covered, a hardcoded clip length passes.