### PR TITLE
Clear the last three compiler warnings

### DIFF
--- a/libtest/callbacks-example-filenameiisbug.c
+++ b/libtest/callbacks-example-filenameiisbug.c
@@ -71,8 +71,9 @@ static int mysavename(t_hts_callbackarg * carg, httrackp * opt,
       for(j = 0; iisBogus[i][j] == a[j] && iisBogus[i][j] != '\0'; j++) ;
       if (iisBogus[i][j] == '\0'
           && (a[j] == '\0' || a[j] == '/' || a[j] == '\\')) {
-        /* same length by construction, and the tail must survive */
-        memcpy(a, iisBogusReplace[i], strlen(iisBogusReplace[i]));
+        /* j bytes matched, so j fit: copying j cannot overrun whatever the
+           table holds, and the tail must survive untouched */
+        memcpy(a, iisBogusReplace[i], (size_t) j);
         break;
       }
     }

--- a/libtest/callbacks-example-filenameiisbug.c
+++ b/libtest/callbacks-example-filenameiisbug.c
@@ -71,7 +71,8 @@ static int mysavename(t_hts_callbackarg * carg, httrackp * opt,
       for(j = 0; iisBogus[i][j] == a[j] && iisBogus[i][j] != '\0'; j++) ;
       if (iisBogus[i][j] == '\0'
           && (a[j] == '\0' || a[j] == '/' || a[j] == '\\')) {
-        strncpy(a, iisBogusReplace[i], strlen(iisBogusReplace[i]));
+        /* same length by construction, and the tail must survive */
+        memcpy(a, iisBogusReplace[i], strlen(iisBogusReplace[i]));
         break;
       }
     }

--- a/src/htshelp.c
+++ b/src/htshelp.c
@@ -433,7 +433,8 @@ void help_catchurl(const char *dest_path) {
       }
       // former URL!
       {
-        char BIGSTK finalurl[HTS_URLMAXSIZE * 2];
+        /* url and dest are each HTS_URLMAXSIZE*2, plus the POSTTOK marker */
+        char BIGSTK finalurl[HTS_URLMAXSIZE * 4 + 32];
 
         inplace_escape_check_url(dest, sizeof(dest));
         snprintf(finalurl, sizeof(finalurl), "%s" POSTTOK "file:%s", url, dest);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1519,7 +1519,7 @@ static int st_hashtable(httrackp *opt, int argc, char **argv) {
       size_t i;
       for (i = bench[loop].offset; i < (size_t) count;
            i += bench[loop].modulus) {
-        int result;
+        int result = 0; /* no final else: an unknown type reports failure */
         FMT();
         if (bench[loop].type == DO_ADD || bench[loop].type == DO_DRY_ADD) {
           size_t k;


### PR DESCRIPTION
Three unrelated leftovers, one per warning, taking a clean build to zero.

`help_catchurl` sizes `finalurl` for a single URL but writes two into it, the captured URL plus the temp file path, with the POSTTOK marker between. `htsselftest`'s coucal bench declares `result` and assigns it in an if/else chain with no final else; every enum value that reaches the loop is handled, but nothing says so, and an unhandled one would read uninitialised. The IIS-bug example callback replaces a filename suffix in place with a replacement the array comments require to be the same length, deliberately not terminating the string, which is `memcpy` rather than `strncpy`.

Nothing here is reachable as a bug today. The value is the zero, which makes the next real warning visible.
