### PR TITLE
The in-progress display struct is defined twice with nothing keeping the copies in step

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,7 +48,7 @@ htsserver_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS_PIE)
 
 lib_LTLIBRARIES = libhttrack.la
 
-htsserver_SOURCES = htsserver.c htsserver.h htsweb.c htsweb.h \
+htsserver_SOURCES = htsserver.c htsserver.h htsweb.c htsweb.h htsstats.h \
 	htscmdline.c htscmdline.h \
 	htsurlport.c htsurlport.h
 proxytrack_SOURCES = proxy/main.c \
@@ -87,7 +87,7 @@ libhttrack_la_LIBADD = $(THREADS_LIBS) $(ZLIB_LIBS) $(BROTLI_LIBS) $(ZSTD_LIBS) 
 libhttrack_la_CFLAGS = $(AM_CFLAGS) -DLIBHTTRACK_EXPORTS -DZLIB_CONST
 libhttrack_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(VERSION_INFO)
 
-EXTRA_DIST = httrack.h webhttrack \
+EXTRA_DIST = httrack.h htsstats.h webhttrack \
 		version.rc \
 		libhttrack.rc \
 		httrack.rc \

--- a/src/htsstats.h
+++ b/src/htsstats.h
@@ -26,45 +26,38 @@ Please visit our Website: http://www.httrack.com
 */
 
 /* ------------------------------------------------------------ */
-/* File: htsshow.c console progress info                        */
+/* File: in-progress display rows, shared by httrack and htsserver .h */
 /* Author: Xavier Roche                                         */
 /* ------------------------------------------------------------ */
 
-#ifndef HTSTOOLS_DEFH
-#define HTSTOOLS_DEFH
+#ifndef HTS_STATS_DEFH
+#define HTS_STATS_DEFH
 
 #include "htsglobal.h"
-#include "htscore.h"
-#include "htssafe.h"
-#include "htsstats.h"
 
-#ifndef HTS_DEF_FWSTRUCT_t_InpInfo
-#define HTS_DEF_FWSTRUCT_t_InpInfo
-typedef struct t_InpInfo t_InpInfo;
+/* One row of the "in progress" display, shared so the CLI (httrack) and the
+   web GUI (htsserver) cannot drift apart: each fills its own array. */
+
+#define NStatsBuffer 14
+
+#ifndef HTS_DEF_FWSTRUCT_t_StatsBuffer
+#define HTS_DEF_FWSTRUCT_t_StatsBuffer
+typedef struct t_StatsBuffer t_StatsBuffer;
 #endif
-struct t_InpInfo {
-  int ask_refresh;
-  int refresh;
-  LLint stat_bytes;
-  int stat_time;
-  int lien_n;
-  int lien_tot;
-  int stat_nsocket;
-  int rate;
-  int irate;
-  int ft;
-  LLint stat_written;
-  int stat_updated;
-  int stat_errors;
-  int stat_warnings;
-  int stat_infos;
-  TStamp stat_timestart;
-  int stat_back;
+struct t_StatsBuffer {
+  char name[1024];
+  char file[1024];
+  char state[288];                         // a short label plus back->info[256]
+  char BIGSTK url_sav[HTS_URLMAXSIZE * 2]; // pour cancel
+  char BIGSTK url_adr[HTS_URLMAXSIZE * 2];
+  char BIGSTK url_fil[HTS_URLMAXSIZE * 2];
+  LLint size;
+  LLint sizetot;
+  int offset;
+  //
+  int back;
+  //
+  int actived; // pour disabled
 };
 
-int main(int argc, char **argv);
 #endif
-
-extern HTSEXT_API hts_stat_struct HTS_STAT;
-extern int _DEBUG_HEAD;
-extern FILE *ioinfo;

--- a/src/htsweb.h
+++ b/src/htsweb.h
@@ -35,25 +35,9 @@ Please visit our Website: http://www.httrack.com
 
 #include "htsglobal.h"
 #include "htscore.h"
+#include "htsstats.h"
 
-#define NStatsBuffer     14
 #define MAX_LEN_INPROGRESS 40
-
-typedef struct t_StatsBuffer {
-  char name[1024];
-  char file[1024];
-  char state[288];                      // a short label plus back->info[256]
-  char url_sav[HTS_URLMAXSIZE * 2];     // pour cancel
-  char url_adr[HTS_URLMAXSIZE * 2];
-  char url_fil[HTS_URLMAXSIZE * 2];
-  LLint size;
-  LLint sizetot;
-  int offset;
-  //
-  int back;
-  //
-  int actived;                  // pour disabled
-} t_StatsBuffer;
 
 typedef struct t_InpInfo {
   int ask_refresh;

--- a/src/httrack.c
+++ b/src/httrack.c
@@ -230,8 +230,7 @@ static hts_boolean vt_size_refresh(void) {
 */
 #define STYLE_STATVALUES VT_BOLD
 #define STYLE_STATTEXT   VT_UNBOLD
-#define STYLE_STATRESET  VT_UNBOLD
-#define NStatsBuffer     14
+#define STYLE_STATRESET VT_UNBOLD
 /* Rows the stats block and "Current job" take above the in-progress list. */
 #define NStatsHeaderRows 7
 


### PR DESCRIPTION
`t_StatsBuffer` was defined twice, byte for byte, in `httrack.h` and `htsweb.h`, with `NStatsBuffer` duplicated between `httrack.c` and `htsweb.h`. `httrack` and `htsserver` are separate binaries that each keep their own array, so the duplication is not a link error waiting to happen; it is a silent divergence risk, and #715 had to widen `state` in both copies by hand to keep them in step.

Both now include a new `src/htsstats.h`. Sizes and offsets are unchanged: compiled through either header the struct is 8512 bytes with `state` at 2048, `url_sav` at 2336 and `actived` at 8504.
