### PR TITLE
Single-file GUI strings are untranslated outside English and Francais

### DIFF
--- a/lang/Bulgarian.txt
+++ b/lang/Bulgarian.txt
@@ -964,3 +964,11 @@ WARC archive name:
 Име на WARC архива:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Незадължително базово име за WARC архива; оставете празно за автоматично именуване в изходната директория.
+Inline assets as data: URIs (self-contained pages)
+Вграждане на ресурсите като data: URI (самостоятелни страници)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+След завършване на огледалото всяка запазена страница се презаписва с вградени стилове, скриптове, изображения и шрифтове, така че страницата да може да се отвори и самостоятелно.
+Largest inlined asset (bytes):
+Най-голям вграден ресурс (байтове):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Ресурс над този размер запазва обикновена връзка; оставете празно за стойността по подразбиране от 10485760 байта.

--- a/lang/Castellano.txt
+++ b/lang/Castellano.txt
@@ -964,3 +964,11 @@ WARC archive name:
 Nombre del archivo WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Nombre base opcional para el archivo WARC; déjelo en blanco para nombrarlo automáticamente en el directorio de salida.
+Inline assets as data: URIs (self-contained pages)
+Incrustar los recursos como URI data: (páginas autónomas)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Una vez terminada la copia, reescribir cada página guardada con sus hojas de estilo, scripts, imágenes y fuentes incrustadas, de modo que una página también pueda abrirse por sí sola.
+Largest inlined asset (bytes):
+Tamaño máximo del recurso incrustado (bytes):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Un recurso mayor que este tamaño conserva un enlace normal; déjelo vacío para el valor predeterminado de 10485760 bytes.

--- a/lang/Cesky.txt
+++ b/lang/Cesky.txt
@@ -964,3 +964,11 @@ WARC archive name:
 Název archivu WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Volitelný základní název archivu WARC; ponechte prázdné pro automatické pojmenování ve výstupním adresáøi.
+Inline assets as data: URIs (self-contained pages)
+Vložit zdroje jako URI data: (samostatné stránky)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Po dokonèení zrcadlení pøepsat každou uloženou stránku s vloženými styly, skripty, obrázky a písmy, aby ji bylo možné otevøít i samostatnì.
+Largest inlined asset (bytes):
+Nejvìtší vložený zdroj (bajty):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Zdroj vìtší než tato velikost si ponechá bìžný odkaz; ponechte prázdné pro výchozí hodnotu 10485760 bajtù.

--- a/lang/Chinese-BIG5.txt
+++ b/lang/Chinese-BIG5.txt
@@ -964,3 +964,11 @@ WARC archive name:
 WARC 封存檔名稱：
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 WARC 封存檔的選用基本名稱；留空則於輸出目錄中自動命名。
+Inline assets as data: URIs (self-contained pages)
+將資源內嵌為 data: URI（獨立網頁）
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+鏡射完成後，重寫每個已儲存的網頁，將樣式表、指令碼、圖片與字型內嵌其中，讓網頁也能單獨開啟。
+Largest inlined asset (bytes):
+內嵌資源大小上限（位元組）：
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+超過此大小的資源會保留一般連結；留空則使用預設的 10485760 位元組。

--- a/lang/Chinese-Simplified.txt
+++ b/lang/Chinese-Simplified.txt
@@ -964,3 +964,11 @@ WARC archive name:
 WARC 归档名称：
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 WARC 归档的可选基本名称；留空则在输出目录中自动命名。
+Inline assets as data: URIs (self-contained pages)
+将资源内嵌为 data: URI（独立网页）
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+镜像完成后，重写每个已保存的网页，将样式表、脚本、图片和字体内嵌其中，使网页也能单独打开。
+Largest inlined asset (bytes):
+内嵌资源大小上限（字节）：
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+超过此大小的资源会保留普通链接；留空则使用默认的 10485760 字节。

--- a/lang/Croatian.txt
+++ b/lang/Croatian.txt
@@ -966,3 +966,11 @@ WARC archive name:
 Naziv WARC arhive:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Neobavezni osnovni naziv WARC arhive; ostavite prazno za automatsko imenovanje u izlaznom direktoriju.
+Inline assets as data: URIs (self-contained pages)
+Ugradi resurse kao data: URI-je (samostalne stranice)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Nakon dovr¹etka zrcaljenja ponovno zapi¹i svaku spremljenu stranicu s ugraðenim stilskim listovima, skriptama, slikama i fontovima, tako da se stranica mo¾e otvoriti i zasebno.
+Largest inlined asset (bytes):
+Najveæi ugraðeni resurs (bajtovi):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Resurs veæi od ove velièine zadr¾ava obiènu poveznicu; ostavite prazno za zadanih 10485760 bajtova.

--- a/lang/Dansk.txt
+++ b/lang/Dansk.txt
@@ -1012,3 +1012,11 @@ WARC archive name:
 Navn på WARC-arkiv:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Valgfrit basisnavn til WARC-arkivet; lad feltet stå tomt for automatisk navngivning i outputmappen.
+Inline assets as data: URIs (self-contained pages)
+Indlejr ressourcer som data:-URI'er (selvstændige sider)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Når spejlingen er færdig, omskrives hver gemt side med dens typografiark, scripts, billeder og skrifttyper indlejret, så en side også kan åbnes alene.
+Largest inlined asset (bytes):
+Største indlejrede ressource (byte):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+En ressource over denne størrelse beholder et almindeligt link; lad feltet stå tomt for standardværdien på 10485760 byte.

--- a/lang/Deutsch.txt
+++ b/lang/Deutsch.txt
@@ -964,3 +964,11 @@ WARC archive name:
 Name des WARC-Archivs:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Optionaler Basisname für das WARC-Archiv; leer lassen, um es automatisch im Ausgabeverzeichnis zu benennen.
+Inline assets as data: URIs (self-contained pages)
+Ressourcen als data:-URIs einbetten (eigenständige Seiten)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Nach Abschluss der Spiegelung jede gespeicherte Seite mit eingebetteten Stylesheets, Skripten, Bildern und Schriftarten neu schreiben, sodass eine Seite auch für sich allein geöffnet werden kann.
+Largest inlined asset (bytes):
+Größte eingebettete Ressource (Bytes):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Eine Ressource über dieser Größe behält einen gewöhnlichen Link; leer lassen für den Standardwert von 10485760 Bytes.

--- a/lang/Eesti.txt
+++ b/lang/Eesti.txt
@@ -964,3 +964,11 @@ WARC archive name:
 WARC-arhiivi nimi:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 WARC-arhiivi valikuline põhinimi; jäta tühjaks, et see väljundkataloogis automaatselt nimetada.
+Inline assets as data: URIs (self-contained pages)
+Manusta ressursid data: URI-dena (iseseisvad lehed)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Pärast peegelduse lõppu kirjuta iga salvestatud leht ümber, manustades selle laaditabelid, skriptid, pildid ja fondid, nii et lehte saab avada ka eraldi.
+Largest inlined asset (bytes):
+Suurim manustatud ressurss (baiti):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Sellest suurem ressurss säilitab tavalise lingi; jäta tühjaks vaikeväärtuse 10485760 baiti jaoks.

--- a/lang/Finnish.txt
+++ b/lang/Finnish.txt
@@ -966,3 +966,11 @@ WARC archive name:
 WARC-arkiston nimi:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Valinnainen WARC-arkiston perusnimi; j‰t‰ tyhj‰ksi, jotta se nimet‰‰n automaattisesti tulostehakemistoon.
+Inline assets as data: URIs (self-contained pages)
+Upota resurssit data:-URI-osoitteina (itsen‰iset sivut)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Kun peilaus on valmis, kirjoita jokainen tallennettu sivu uudelleen niin, ett‰ sen tyylitiedostot, komentosarjat, kuvat ja fontit upotetaan, jolloin sivun voi avata myˆs yksin‰‰n.
+Largest inlined asset (bytes):
+Suurin upotettu resurssi (tavua):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+T‰t‰ suurempi resurssi s‰ilytt‰‰ tavallisen linkin; j‰t‰ tyhj‰ksi, jolloin k‰ytet‰‰n oletusarvoa 10485760 tavua.

--- a/lang/Greek.txt
+++ b/lang/Greek.txt
@@ -966,3 +966,11 @@ WARC archive name:
 Όνομα αρχείου WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Προαιρετικό βασικό όνομα για το αρχείο WARC. Αφήστε το κενό για αυτόματη ονομασία στον κατάλογο εξόδου.
+Inline assets as data: URIs (self-contained pages)
+Ενσωμάτωση των πόρων ως URI data: (αυτόνομες σελίδες)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Μόλις ολοκληρωθεί το αντίγραφο, κάθε αποθηκευμένη σελίδα ξαναγράφεται με ενσωματωμένα τα φύλλα στυλ, τα σενάρια, τις εικόνες και τις γραμματοσειρές της, ώστε η σελίδα να μπορεί να ανοίξει και μόνη της.
+Largest inlined asset (bytes):
+Μέγιστος ενσωματωμένος πόρος (byte):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Πόρος μεγαλύτερος από αυτό το μέγεθος διατηρεί κανονικό σύνδεσμο. Αφήστε το κενό για την προεπιλογή των 10485760 byte.

--- a/lang/Italiano.txt
+++ b/lang/Italiano.txt
@@ -964,3 +964,11 @@ WARC archive name:
 Nome dell'archivio WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Nome di base facoltativo per l'archivio WARC; lascia vuoto per assegnarlo automaticamente nella directory di output.
+Inline assets as data: URIs (self-contained pages)
+Incorpora le risorse come URI data: (pagine autonome)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Al termine della copia, riscrive ogni pagina salvata incorporando fogli di stile, script, immagini e caratteri, in modo che una pagina possa essere aperta anche da sola.
+Largest inlined asset (bytes):
+Dimensione massima della risorsa incorporata (byte):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Una risorsa oltre questa dimensione mantiene un collegamento normale; lasciare vuoto per il valore predefinito di 10485760 byte.

--- a/lang/Japanese.txt
+++ b/lang/Japanese.txt
@@ -964,3 +964,11 @@ WARC archive name:
 WARC アーカイブ名:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 WARC アーカイブの任意のベース名。空欄にすると出力ディレクトリ内で自動的に名前が付けられます。
+Inline assets as data: URIs (self-contained pages)
+リソースを data: URI として埋め込む (単独で開けるページ)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+ミラーの完了後、保存された各ページを、スタイルシート、スクリプト、画像、フォントを埋め込んだ形で書き直します。ページ単体でも開けるようになります。
+Largest inlined asset (bytes):
+埋め込む最大サイズ (バイト):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+このサイズを超えるリソースは通常のリンクのままになります。空欄にすると既定値の 10485760 バイトになります。

--- a/lang/Macedonian.txt
+++ b/lang/Macedonian.txt
@@ -964,3 +964,11 @@ WARC archive name:
 Име на WARC архивата:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Изборно основно име за WARC архивата; оставете празно за автоматско именување во излезниот директориум.
+Inline assets as data: URIs (self-contained pages)
+Вгради ги ресурсите како data: URI (самостојни страници)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+По завршување на огледалото, секоја зачувана страница се препишува со вградени стилски листови, скрипти, слики и фонтови, за да може страницата да се отвори и самостојно.
+Largest inlined asset (bytes):
+Најголем вграден ресурс (бајти):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Ресурс поголем од оваа големина задржува обична врска; оставете празно за стандардните 10485760 бајти.

--- a/lang/Magyar.txt
+++ b/lang/Magyar.txt
@@ -964,3 +964,11 @@ WARC archive name:
 WARC archívum neve:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 A WARC archívum opcionális alapneve; hagyja üresen az automatikus elnevezéshez a kimeneti könyvtárban.
+Inline assets as data: URIs (self-contained pages)
+Erõforrások beágyazása data: URI-ként (önálló oldalak)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+A tükrözés befejezése után minden mentett oldal újraírása a stíluslapok, parancsfájlok, képek és betûtípusok beágyazásával, így az oldal önmagában is megnyitható.
+Largest inlined asset (bytes):
+Legnagyobb beágyazott erõforrás (bájt):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Az ennél nagyobb erõforrás közönséges hivatkozás marad; hagyja üresen a 10485760 bájtos alapértelmezéshez.

--- a/lang/Nederlands.txt
+++ b/lang/Nederlands.txt
@@ -964,3 +964,11 @@ WARC archive name:
 Naam van WARC-archief:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Optionele basisnaam voor het WARC-archief; laat leeg om het automatisch een naam te geven in de uitvoermap.
+Inline assets as data: URIs (self-contained pages)
+Bronnen insluiten als data:-URI's (op zichzelf staande pagina's)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Zodra de spiegeling klaar is, elke opgeslagen pagina herschrijven met ingesloten stijlbladen, scripts, afbeeldingen en lettertypen, zodat een pagina ook los geopend kan worden.
+Largest inlined asset (bytes):
+Grootste ingesloten bron (bytes):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Een bron boven deze grootte houdt een gewone koppeling; laat leeg voor de standaardwaarde van 10485760 bytes.

--- a/lang/Norsk.txt
+++ b/lang/Norsk.txt
@@ -964,3 +964,11 @@ WARC archive name:
 Navn på WARC-arkiv:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Valgfritt basisnavn for WARC-arkivet; la feltet stå tomt for automatisk navngivning i utdatamappen.
+Inline assets as data: URIs (self-contained pages)
+Bygg inn ressurser som data:-URI-er (selvstendige sider)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Når speilingen er ferdig, skrives hver lagrede side om med stilark, skript, bilder og skrifter innebygd, slik at en side også kan åpnes alene.
+Largest inlined asset (bytes):
+Største innebygde ressurs (byte):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+En ressurs over denne størrelsen beholder en vanlig lenke; la feltet stå tomt for standardverdien på 10485760 byte.

--- a/lang/Polski.txt
+++ b/lang/Polski.txt
@@ -964,3 +964,11 @@ WARC archive name:
 Nazwa archiwum WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Opcjonalna nazwa bazowa archiwum WARC; pozostaw puste, aby nazwaæ je automatycznie w katalogu wyj¶ciowym.
+Inline assets as data: URIs (self-contained pages)
+Osad¼ zasoby jako identyfikatory data: URI (samodzielne strony)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Po zakoñczeniu tworzenia kopii przepisz ka¿d± zapisan± stronê z osadzonymi arkuszami stylów, skryptami, obrazami i czcionkami, aby stronê mo¿na by³o otworzyæ równie¿ samodzielnie.
+Largest inlined asset (bytes):
+Najwiêkszy osadzony zasób (bajty):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Zasób wiêkszy ni¿ ten rozmiar zachowuje zwyk³y odno¶nik; pozostaw puste, aby u¿yæ domy¶lnych 10485760 bajtów.

--- a/lang/Portugues-Brasil.txt
+++ b/lang/Portugues-Brasil.txt
@@ -1012,3 +1012,11 @@ WARC archive name:
 Nome do arquivo WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Nome base opcional para o arquivo WARC; deixe em branco para nomeá-lo automaticamente no diretório de saída.
+Inline assets as data: URIs (self-contained pages)
+Incorporar os recursos como URIs data: (páginas autônomas)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Ao terminar o espelhamento, reescrever cada página salva com suas folhas de estilo, scripts, imagens e fontes incorporadas, para que a página também possa ser aberta sozinha.
+Largest inlined asset (bytes):
+Maior recurso incorporado (bytes):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Um recurso acima desse tamanho mantém um link comum; deixe em branco para o padrão de 10485760 bytes.

--- a/lang/Portugues.txt
+++ b/lang/Portugues.txt
@@ -964,3 +964,11 @@ WARC archive name:
 Nome do arquivo WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Nome base opcional para o arquivo WARC; deixe em branco para o nomear automaticamente no diretório de saída.
+Inline assets as data: URIs (self-contained pages)
+Incorporar os recursos como URI data: (páginas autónomas)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Depois de terminado o espelho, reescrever cada página guardada com as suas folhas de estilo, scripts, imagens e tipos de letra incorporados, para que a página também possa ser aberta sozinha.
+Largest inlined asset (bytes):
+Maior recurso incorporado (bytes):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Um recurso acima deste tamanho mantém uma ligação normal; deixe em branco para o valor predefinido de 10485760 bytes.

--- a/lang/Romanian.txt
+++ b/lang/Romanian.txt
@@ -964,3 +964,11 @@ WARC archive name:
 Numele arhivei WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Nume de baza optional pentru arhiva WARC; lasati gol pentru a-l denumi automat in directorul de iesire.
+Inline assets as data: URIs (self-contained pages)
+Încorporeaza resursele ca URI data: (pagini de sine statatoare)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Dupa terminarea copiei, fiecare pagina salvata este rescrisa cu foile de stil, scripturile, imaginile si fonturile încorporate, astfel încât pagina sa poata fi deschisa si singura.
+Largest inlined asset (bytes):
+Cea mai mare resursa încorporata (octeti):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+O resursa mai mare decât aceasta dimensiune pastreaza o legatura obisnuita; lasati gol pentru valoarea implicita de 10485760 de octeti.

--- a/lang/Russian.txt
+++ b/lang/Russian.txt
@@ -964,3 +964,11 @@ WARC archive name:
 »м€ WARC-архива:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Ќеоб€зательное базовое им€ WARC-архива; оставьте пустым дл€ автоматического именовани€ в выходном каталоге.
+Inline assets as data: URIs (self-contained pages)
+¬страивать ресурсы как data: URI (самосто€тельные страницы)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+ѕосле завершени€ зеркалировани€ кажда€ сохранЄнна€ страница перезаписываетс€ со встроенными таблицами стилей, сценари€ми, изображени€ми и шрифтами, чтобы страницу можно было открыть отдельно.
+Largest inlined asset (bytes):
+Ќаибольший встраиваемый ресурс (байты):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+–есурс больше этого размера сохран€ет обычную ссылку; оставьте пустым дл€ значени€ по умолчанию 10485760 байт.

--- a/lang/Slovak.txt
+++ b/lang/Slovak.txt
@@ -964,3 +964,11 @@ WARC archive name:
 Názov archívu WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Voliteµný základný názov archívu WARC; ponechajte prázdne pre automatické pomenovanie vo výstupnom adresári.
+Inline assets as data: URIs (self-contained pages)
+Vlo¾i» zdroje ako URI data: (samostatné stránky)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Po dokonèení zrkadlenia prepísa» ka¾dú ulo¾enú stránku s vlo¾enými ¹týlmi, skriptmi, obrázkami a písmami, aby sa stránka dala otvori» aj samostatne.
+Largest inlined asset (bytes):
+Najväè¹í vlo¾ený zdroj (bajty):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Zdroj väè¹í ne¾ táto veµkos» si ponechá be¾ný odkaz; ponechajte prázdne pre predvolených 10485760 bajtov.

--- a/lang/Slovenian.txt
+++ b/lang/Slovenian.txt
@@ -964,3 +964,11 @@ WARC archive name:
 Ime arhiva WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Neobvezno osnovno ime arhiva WARC; pustite prazno za samodejno poimenovanje v izhodni mapi.
+Inline assets as data: URIs (self-contained pages)
+Vgradi vire kot data: URI (samostojne strani)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Ko je zrcaljenje koncano, se vsaka shranjena stran prepise z vgrajenimi slogovnimi listi, skripti, slikami in pisavami, tako da jo je mogoce odpreti tudi samostojno.
+Largest inlined asset (bytes):
+Najvecji vgrajeni vir (bajti):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Vir, vecji od te velikosti, ohrani obicajno povezavo; pustite prazno za privzetih 10485760 bajtov.

--- a/lang/Svenska.txt
+++ b/lang/Svenska.txt
@@ -964,3 +964,11 @@ WARC archive name:
 WARC-arkivets namn:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Valfritt basnamn för WARC-arkivet; lämna tomt för att namnge det automatiskt i utdatakatalogen.
+Inline assets as data: URIs (self-contained pages)
+Bädda in resurser som data:-URI:er (fristående sidor)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+När speglingen är klar skrivs varje sparad sida om med sina formatmallar, skript, bilder och teckensnitt inbäddade, så att en sida också kan öppnas för sig.
+Largest inlined asset (bytes):
+Största inbäddade resurs (byte):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+En resurs över den här storleken behåller en vanlig länk; lämna tomt för standardvärdet 10485760 byte.

--- a/lang/Turkish.txt
+++ b/lang/Turkish.txt
@@ -964,3 +964,11 @@ WARC archive name:
 WARC arþivi adý:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 WARC arþivi için isteðe baðlý temel ad; çýktý dizininde otomatik adlandýrma için boþ býrakýn.
+Inline assets as data: URIs (self-contained pages)
+Kaynaklarý data: URI olarak göm (kendi kendine yeten sayfalar)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Yansýlama bittiðinde, kaydedilen her sayfa stil sayfalarý, betikleri, görselleri ve yazý tipleri gömülü olarak yeniden yazýlýr; böylece sayfa tek baþýna da açýlabilir.
+Largest inlined asset (bytes):
+En büyük gömülü kaynak (bayt):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Bu boyutun üzerindeki bir kaynak sýradan baðlantýsýný korur; 10485760 baytlýk varsayýlan için boþ býrakýn.

--- a/lang/Ukrainian.txt
+++ b/lang/Ukrainian.txt
@@ -964,3 +964,11 @@ WARC archive name:
 Ім'я WARC-архіву:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Необов'язкова базова назва WARC-архіву; залиште порожнім для автоматичного найменування у вихідному каталозі.
+Inline assets as data: URIs (self-contained pages)
+Вбудовувати ресурси як data: URI (самостійні сторінки)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Після завершення дзеркалювання кожна збережена сторінка перезаписується з вбудованими таблицями стилів, сценаріями, зображеннями та шрифтами, щоб сторінку можна було відкрити окремо.
+Largest inlined asset (bytes):
+Найбільший вбудований ресурс (байти):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Ресурс, більший за цей розмір, зберігає звичайне посилання; залиште порожнім для типового значення 10485760 байтів.

--- a/lang/Uzbek.txt
+++ b/lang/Uzbek.txt
@@ -964,3 +964,11 @@ WARC archive name:
 WARC arxivi nomi:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 WARC arxivi uchun ixtiyoriy asosiy nom; chiqish katalogida avtomatik nomlash uchun bo'sh qoldiring.
+Inline assets as data: URIs (self-contained pages)
+Resurslarni data: URI sifatida joylash (mustaqil sahifalar)
+Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
+Nusxalash tugagach, har bir saqlangan sahifa uslublar jadvallari, skriptlar, rasmlar va shriftlar joylangan holda qayta yoziladi, shunda sahifani alohida ham ochish mumkin.
+Largest inlined asset (bytes):
+Eng katta joylangan resurs (bayt):
+An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
+Bu o’lchamdan katta resurs oddiy havolani saqlab qoladi; standart 10485760 bayt uchun bo’sh qoldiring.


### PR DESCRIPTION
The single-file options landed in lang.def with English and Francais filled in, so the WebHTTrack form showed the English string in the other 28 locales. This fills those in.

Data only: four msgid/translation pairs appended per file, no deletions. Each file is written in its own declared charset rather than UTF-8, which is where the traps are. Svenska declares ISO-8859-2 but actually stores Latin-1, Chinese-BIG5 means Windows BIG5 (cp950), Uzbek is LF-terminated where the other 29 files are CRLF, and Romanian and Slovenian declare ISO-8859-1, which cannot carry their diacritics, so those fold to base letters the same way the existing content in those files already does.

Checked deterministically rather than by eye: every file still decodes in its own charset, the msgid/translation pairing stays even, the join keys are byte-identical ASCII, EOLs are uniform per file, and `tests/62_lang-integrity.test` passes. I also confirmed that test fails on a deliberately drifted msgid, so its pass means something. Translations are best effort; a native speaker is the real quality gate.

Stacked on `feat/single-file` because test 62 requires every msgid to exist in English.txt, and only that branch has these.