### PR TITLE
Change-report GUI strings are untranslated outside English and Francais

### DIFF
--- a/lang/Bulgarian.txt
+++ b/lang/Bulgarian.txt
@@ -964,3 +964,7 @@ WARC archive name:
 Име на WARC архива:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Незадължително базово име за WARC архива; оставете празно за автоматично именуване в изходната директория.
+Report what changed since the previous mirror
+Отчет за промените спрямо предишното огледало
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Записване и на hts-changes.json със списък на новите, променените, непроменените и изчезналите файлове спрямо предишното огледало.

--- a/lang/Castellano.txt
+++ b/lang/Castellano.txt
@@ -964,3 +964,7 @@ WARC archive name:
 Nombre del archivo WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Nombre base opcional para el archivo WARC; déjelo en blanco para nombrarlo automáticamente en el directorio de salida.
+Report what changed since the previous mirror
+Informar de los cambios desde la copia anterior
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Escribir también hts-changes.json con la lista de lo que esta captura deja como nuevo, modificado, sin cambios o desaparecido respecto a la copia anterior.

--- a/lang/Cesky.txt
+++ b/lang/Cesky.txt
@@ -964,3 +964,7 @@ WARC archive name:
 Název archivu WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Volitelný základní název archivu WARC; ponechte prázdné pro automatické pojmenování ve výstupním adresáøi.
+Report what changed since the previous mirror
+Hlásit, co se od pøedchozího zrcadlení zmìnilo
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Zapsat také hts-changes.json se seznamem toho, co je oproti pøedchozímu zrcadlení nové, zmìnìné, nezmìnìné nebo chybìjící.

--- a/lang/Chinese-BIG5.txt
+++ b/lang/Chinese-BIG5.txt
@@ -964,3 +964,7 @@ WARC archive name:
 WARC 封存檔名稱：
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 WARC 封存檔的選用基本名稱；留空則於輸出目錄中自動命名。
+Report what changed since the previous mirror
+回報自上次鏡射以來的變更
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+同時寫入 hts-changes.json，列出這次擷取相對於上次鏡射的新增、變更、未變更與消失的項目。

--- a/lang/Chinese-Simplified.txt
+++ b/lang/Chinese-Simplified.txt
@@ -964,3 +964,7 @@ WARC archive name:
 WARC 归档名称：
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 WARC 归档的可选基本名称；留空则在输出目录中自动命名。
+Report what changed since the previous mirror
+报告自上次镜像以来的变更
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+同时写入 hts-changes.json，列出本次抓取相对于上次镜像的新增、更改、未更改和消失的项目。

--- a/lang/Croatian.txt
+++ b/lang/Croatian.txt
@@ -966,3 +966,7 @@ WARC archive name:
 Naziv WARC arhive:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Neobavezni osnovni naziv WARC arhive; ostavite prazno za automatsko imenovanje u izlaznom direktoriju.
+Report what changed since the previous mirror
+Prijavi ¹to se promijenilo od prethodnog zrcaljenja
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Zapi¹i i hts-changes.json s popisom onoga ¹to je u odnosu na prethodno zrcaljenje novo, promijenjeno, nepromijenjeno ili nestalo.

--- a/lang/Dansk.txt
+++ b/lang/Dansk.txt
@@ -1012,3 +1012,7 @@ WARC archive name:
 Navn på WARC-arkiv:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Valgfrit basisnavn til WARC-arkivet; lad feltet stå tomt for automatisk navngivning i outputmappen.
+Report what changed since the previous mirror
+Rapportér hvad der er ændret siden den forrige spejling
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Skriv også hts-changes.json med en liste over, hvad denne gennemgang efterlader som nyt, ændret, uændret eller forsvundet i forhold til den forrige spejling.

--- a/lang/Deutsch.txt
+++ b/lang/Deutsch.txt
@@ -964,3 +964,7 @@ WARC archive name:
 Name des WARC-Archivs:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Optionaler Basisname für das WARC-Archiv; leer lassen, um es automatisch im Ausgabeverzeichnis zu benennen.
+Report what changed since the previous mirror
+Melden, was sich seit der vorherigen Spiegelung geändert hat
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Zusätzlich hts-changes.json schreiben, das auflistet, was dieser Durchlauf gegenüber der vorherigen Spiegelung als neu, geändert, unverändert oder verschwunden hinterlässt.

--- a/lang/Eesti.txt
+++ b/lang/Eesti.txt
@@ -964,3 +964,7 @@ WARC archive name:
 WARC-arhiivi nimi:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 WARC-arhiivi valikuline põhinimi; jäta tühjaks, et see väljundkataloogis automaatselt nimetada.
+Report what changed since the previous mirror
+Teata, mis on eelmisest peegeldusest saadik muutunud
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Kirjuta ka hts-changes.json, mis loetleb, mis on võrreldes eelmise peegeldusega uus, muutunud, muutumatu või kadunud.

--- a/lang/Finnish.txt
+++ b/lang/Finnish.txt
@@ -966,3 +966,7 @@ WARC archive name:
 WARC-arkiston nimi:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Valinnainen WARC-arkiston perusnimi; jätä tyhjäksi, jotta se nimetään automaattisesti tulostehakemistoon.
+Report what changed since the previous mirror
+Raportoi, mikä on muuttunut edellisen peilauksen jälkeen
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Kirjoita myös hts-changes.json, joka luettelee, mikä on edelliseen peilaukseen verrattuna uutta, muuttunutta, muuttumatonta tai kadonnutta.

--- a/lang/Greek.txt
+++ b/lang/Greek.txt
@@ -966,3 +966,7 @@ WARC archive name:
 Όνομα αρχείου WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Προαιρετικό βασικό όνομα για το αρχείο WARC. Αφήστε το κενό για αυτόματη ονομασία στον κατάλογο εξόδου.
+Report what changed since the previous mirror
+Αναφορά των αλλαγών από το προηγούμενο αντίγραφο
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Εγγραφή και του hts-changes.json, που παραθέτει τι είναι νέο, τι άλλαξε, τι έμεινε ίδιο και τι χάθηκε σε σχέση με το προηγούμενο αντίγραφο.

--- a/lang/Italiano.txt
+++ b/lang/Italiano.txt
@@ -964,3 +964,7 @@ WARC archive name:
 Nome dell'archivio WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Nome di base facoltativo per l'archivio WARC; lascia vuoto per assegnarlo automaticamente nella directory di output.
+Report what changed since the previous mirror
+Segnala che cosa è cambiato dalla copia precedente
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Scrive anche hts-changes.json, che elenca ciò che questa scansione lascia come nuovo, modificato, invariato o scomparso rispetto alla copia precedente.

--- a/lang/Japanese.txt
+++ b/lang/Japanese.txt
@@ -964,3 +964,7 @@ WARC archive name:
 WARC アーカイブ名:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 WARC アーカイブの任意のベース名。空欄にすると出力ディレクトリ内で自動的に名前が付けられます。
+Report what changed since the previous mirror
+前回のミラーからの変更点を報告する
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+hts-changes.json も書き出し、前回のミラーと比べて新規、変更、変更なし、消滅となったものを一覧にします。

--- a/lang/Macedonian.txt
+++ b/lang/Macedonian.txt
@@ -964,3 +964,7 @@ WARC archive name:
 Име на WARC архивата:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Изборно основно име за WARC архивата; оставете празно за автоматско именување во излезниот директориум.
+Report what changed since the previous mirror
+Извести што е променето од претходното огледало
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Запиши и hts-changes.json со список на тоа што е ново, променето, непроменето или исчезнато во однос на претходното огледало.

--- a/lang/Magyar.txt
+++ b/lang/Magyar.txt
@@ -964,3 +964,7 @@ WARC archive name:
 WARC archívum neve:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 A WARC archívum opcionális alapneve; hagyja üresen az automatikus elnevezéshez a kimeneti könyvtárban.
+Report what changed since the previous mirror
+Jelentés arról, mi változott az elõzõ tükrözés óta
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+A hts-changes.json fájl írása is, amely felsorolja, mi új, mi változott, mi maradt változatlan és mi tûnt el az elõzõ tükrözéshez képest.

--- a/lang/Nederlands.txt
+++ b/lang/Nederlands.txt
@@ -964,3 +964,7 @@ WARC archive name:
 Naam van WARC-archief:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Optionele basisnaam voor het WARC-archief; laat leeg om het automatisch een naam te geven in de uitvoermap.
+Report what changed since the previous mirror
+Rapporteren wat er sinds de vorige spiegeling is gewijzigd
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Ook hts-changes.json schrijven met een overzicht van wat deze doorloop nieuw, gewijzigd, ongewijzigd of verdwenen laat ten opzichte van de vorige spiegeling.

--- a/lang/Norsk.txt
+++ b/lang/Norsk.txt
@@ -964,3 +964,7 @@ WARC archive name:
 Navn på WARC-arkiv:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Valgfritt basisnavn for WARC-arkivet; la feltet stå tomt for automatisk navngivning i utdatamappen.
+Report what changed since the previous mirror
+Rapporter hva som er endret siden forrige speiling
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Skriv også hts-changes.json som lister opp hva denne gjennomgangen etterlater som nytt, endret, uendret eller forsvunnet sammenlignet med forrige speiling.

--- a/lang/Polski.txt
+++ b/lang/Polski.txt
@@ -964,3 +964,7 @@ WARC archive name:
 Nazwa archiwum WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Opcjonalna nazwa bazowa archiwum WARC; pozostaw puste, aby nazwaæ je automatycznie w katalogu wyj¶ciowym.
+Report what changed since the previous mirror
+Zg³o¶, co zmieni³o siê od poprzedniej kopii
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Zapisz równie¿ plik hts-changes.json z list± tego, co w porównaniu z poprzedni± kopi± jest nowe, zmienione, niezmienione lub usuniête.

--- a/lang/Portugues-Brasil.txt
+++ b/lang/Portugues-Brasil.txt
@@ -1012,3 +1012,7 @@ WARC archive name:
 Nome do arquivo WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Nome base opcional para o arquivo WARC; deixe em branco para nomeá-lo automaticamente no diretório de saída.
+Report what changed since the previous mirror
+Relatar o que mudou desde o espelhamento anterior
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Gravar também hts-changes.json listando o que esta captura deixa como novo, alterado, inalterado ou removido em relação ao espelhamento anterior.

--- a/lang/Portugues.txt
+++ b/lang/Portugues.txt
@@ -964,3 +964,7 @@ WARC archive name:
 Nome do arquivo WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Nome base opcional para o arquivo WARC; deixe em branco para o nomear automaticamente no diretório de saída.
+Report what changed since the previous mirror
+Comunicar o que mudou desde o espelho anterior
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Escrever também hts-changes.json, que lista o que esta recolha deixa como novo, alterado, inalterado ou desaparecido em relação ao espelho anterior.

--- a/lang/Romanian.txt
+++ b/lang/Romanian.txt
@@ -964,3 +964,7 @@ WARC archive name:
 Numele arhivei WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Nume de baza optional pentru arhiva WARC; lasati gol pentru a-l denumi automat in directorul de iesire.
+Report what changed since the previous mirror
+Raporteaza ce s-a schimbat fata de copia anterioara
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Scrie si hts-changes.json, care listeaza ce este nou, modificat, nemodificat sau disparut fata de copia anterioara.

--- a/lang/Russian.txt
+++ b/lang/Russian.txt
@@ -964,3 +964,7 @@ WARC archive name:
 Имя WARC-архива:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Необязательное базовое имя WARC-архива; оставьте пустым для автоматического именования в выходном каталоге.
+Report what changed since the previous mirror
+Сообщать, что изменилось с предыдущего зеркала
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Также записывать hts-changes.json со списком того, что по сравнению с предыдущим зеркалом стало новым, изменённым, неизменённым или исчезло.

--- a/lang/Slovak.txt
+++ b/lang/Slovak.txt
@@ -964,3 +964,7 @@ WARC archive name:
 Názov archívu WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Voliteµný základný názov archívu WARC; ponechajte prázdne pre automatické pomenovanie vo výstupnom adresári.
+Report what changed since the previous mirror
+Oznámi», èo sa od predchádzajúceho zrkadlenia zmenilo
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Zapísa» aj hts-changes.json so zoznamom toho, èo je oproti predchádzajúcemu zrkadleniu nové, zmenené, nezmenené alebo chýbajúce.

--- a/lang/Slovenian.txt
+++ b/lang/Slovenian.txt
@@ -964,3 +964,7 @@ WARC archive name:
 Ime arhiva WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Neobvezno osnovno ime arhiva WARC; pustite prazno za samodejno poimenovanje v izhodni mapi.
+Report what changed since the previous mirror
+Porocaj, kaj se je spremenilo od prejsnjega zrcaljenja
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Zapisi tudi hts-changes.json s seznamom tega, kar je v primerjavi s prejsnjim zrcaljenjem novo, spremenjeno, nespremenjeno ali izginilo.

--- a/lang/Svenska.txt
+++ b/lang/Svenska.txt
@@ -964,3 +964,7 @@ WARC archive name:
 WARC-arkivets namn:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Valfritt basnamn för WARC-arkivet; lämna tomt för att namnge det automatiskt i utdatakatalogen.
+Report what changed since the previous mirror
+Rapportera vad som ändrats sedan föregående spegling
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Skriv även hts-changes.json som listar vad den här genomgången lämnar som nytt, ändrat, oförändrat eller försvunnet jämfört med föregående spegling.

--- a/lang/Turkish.txt
+++ b/lang/Turkish.txt
@@ -964,3 +964,7 @@ WARC archive name:
 WARC arþivi adý:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 WARC arþivi için isteðe baðlý temel ad; çýktý dizininde otomatik adlandýrma için boþ býrakýn.
+Report what changed since the previous mirror
+Önceki yansýmadan bu yana deðiþenleri bildir
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Ayrýca hts-changes.json yazarak bu taramanýn önceki yansýmaya göre neyi yeni, deðiþmiþ, deðiþmemiþ veya kaybolmuþ býraktýðýný listele.

--- a/lang/Ukrainian.txt
+++ b/lang/Ukrainian.txt
@@ -964,3 +964,7 @@ WARC archive name:
 Ім'я WARC-архіву:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Необов'язкова базова назва WARC-архіву; залиште порожнім для автоматичного найменування у вихідному каталозі.
+Report what changed since the previous mirror
+Повідомляти, що змінилося з попереднього дзеркала
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+Також записувати hts-changes.json зі списком того, що порівняно з попереднім дзеркалом є новим, зміненим, незміненим або зниклим.

--- a/lang/Uzbek.txt
+++ b/lang/Uzbek.txt
@@ -964,3 +964,7 @@ WARC archive name:
 WARC arxivi nomi:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 WARC arxivi uchun ixtiyoriy asosiy nom; chiqish katalogida avtomatik nomlash uchun bo'sh qoldiring.
+Report what changed since the previous mirror
+Oldingi nusxadan beri nima o’zgarganini xabar qilish
+Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
+hts-changes.json ham yoziladi: unda ushbu yig’ish oldingi nusxaga nisbatan nimani yangi, o’zgargan, o’zgarmagan yoki yo’qolgan holda qoldirgani ro’yxati bo’ladi.


### PR DESCRIPTION
The change-report options landed in lang.def with English and Francais filled in, so the WebHTTrack form showed the English string in the other 28 locales. This fills those in.

Data only: two msgid/translation pairs appended per file, no deletions. Each file is written in its own declared charset rather than UTF-8, which is where the traps are. Svenska declares ISO-8859-2 but actually stores Latin-1, Chinese-BIG5 means Windows BIG5 (cp950), Uzbek is LF-terminated where the other 29 files are CRLF, and Romanian and Slovenian declare ISO-8859-1, which cannot carry their diacritics, so those fold to base letters the same way the existing content in those files already does.

Checked deterministically rather than by eye: every file still decodes in its own charset, the msgid/translation pairing stays even, the join keys are byte-identical ASCII, EOLs are uniform per file, and `tests/62_lang-integrity.test` passes. I also confirmed that test fails on a deliberately drifted msgid, so its pass means something. Translations are best effort; a native speaker is the real quality gate.

Stacked on `feat/change-report` because test 62 requires every msgid to exist in English.txt, and only that branch has these.