### PR TITLE
Three hand-written copies of the same clipping contract

### DIFF
--- a/src/htscache.c
+++ b/src/htscache.c
@@ -142,13 +142,12 @@ struct cache_back_zip_entry {
   int compressionMethod;
 };
 
-/* Clip: strlcpybuff aborts on overflow, which would take the crawl down on a
-   corrupt cache carrying a field wider than ours. */
+/* A corrupt cache can carry a field wider than ours; clipping it keeps the
+   entry, where aborting would take the crawl down. */
 #define ZIP_READFIELD_STRING(line, value, refline, refvalue, refvalue_size)    \
   do {                                                                         \
     if (line[0] != '\0' && strfield2(line, refline)) {                         \
-      (refvalue)[0] = '\0';                                                    \
-      strlncatbuff(refvalue, value, refvalue_size, (refvalue_size) - 1);       \
+      (void) strclipbuff(refvalue, refvalue_size, value);                      \
       line[0] = '\0';                                                          \
     }                                                                          \
   } while (0)

--- a/src/htssafe.h
+++ b/src/htssafe.h
@@ -461,6 +461,25 @@ static HTS_INLINE HTS_UNUSED const char *htsbuff_str(const htsbuff *b) {
 }
 
 /**
+ * Copy src into dest (capacity size, NUL included), truncating to fit and
+ * always NUL-terminating. Unlike strlcpybuff() it never aborts, so it suits a
+ * value read back from a cache, a header or the wire, where refusing the whole
+ * record is worse than keeping a clipped one. Returns HTS_TRUE if it all fit;
+ * callers that clip on purpose ignore that, so it is not HTS_CHECK_RESULT.
+ */
+static HTS_INLINE HTS_UNUSED hts_boolean strclipbuff(char *dest, size_t size,
+                                                     const char *src) {
+  size_t len, copy;
+
+  assertf(dest != NULL && src != NULL && size != 0);
+  len = strlen(src);
+  copy = len < size ? len : size - 1;
+  memcpy(dest, src, copy);
+  dest[copy] = '\0';
+  return copy == len ? HTS_TRUE : HTS_FALSE;
+}
+
+/**
  * Callers that deliberately ignore truncation use this instead of
  * slprintfbuff(), so it is not HTS_CHECK_RESULT.
  */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -659,9 +659,13 @@ static int string_safety_selftests(void) {
         strcmp(s.dst, "0123456") != 0)
       return 1;
 
-    /* degenerate capacity 1: only the NUL fits */
+    /* degenerate capacity 1: only the NUL fits. Capacity 2 pins the boundary
+       between that and the sizes above: one character plus the NUL. */
     POISON_DST();
     if (strclipbuff(s.dst, 1, "x") || s.dst[0] != '\0')
+      return 1;
+    POISON_DST();
+    if (strclipbuff(s.dst, 2, "yz") || strcmp(s.dst, "y") != 0)
       return 1;
 
     /* the empty string fits any non-zero capacity */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -624,6 +624,62 @@ static int string_safety_selftests(void) {
       return 1;
   }
 
+  /* strclipbuff: truncate-and-report, never abort. Same canary shape; the
+     destination is poisoned before every call so a case cannot pass on the
+     previous one's bytes. */
+  {
+    struct {
+      char dst[8];
+      char canary[8];
+    } s;
+
+    memset(&s, '#', sizeof(s));
+#define POISON_DST() memset(s.dst, '#', sizeof(s.dst))
+
+    /* well under capacity: no padding, nothing eaten off the end */
+    POISON_DST();
+    if (!strclipbuff(s.dst, sizeof(s.dst), "abc") || strcmp(s.dst, "abc") != 0)
+      return 1;
+
+    /* exact fit: capacity - 1 characters plus the NUL */
+    POISON_DST();
+    if (!strclipbuff(s.dst, sizeof(s.dst), "1234567") ||
+        strcmp(s.dst, "1234567") != 0)
+      return 1;
+
+    /* one over, then far over: clipped, terminated, reported. The expected
+       bytes differ from the case above, so a write-nothing implementation
+       cannot pass on the leftovers. */
+    POISON_DST();
+    if (strclipbuff(s.dst, sizeof(s.dst), "abcdefgh") ||
+        strcmp(s.dst, "abcdefg") != 0)
+      return 1;
+    POISON_DST();
+    if (strclipbuff(s.dst, sizeof(s.dst), "0123456789abcdef") ||
+        strcmp(s.dst, "0123456") != 0)
+      return 1;
+
+    /* degenerate capacity 1: only the NUL fits */
+    POISON_DST();
+    if (strclipbuff(s.dst, 1, "x") || s.dst[0] != '\0')
+      return 1;
+
+    /* the empty string fits any non-zero capacity */
+    POISON_DST();
+    if (!strclipbuff(s.dst, sizeof(s.dst), "") || s.dst[0] != '\0')
+      return 1;
+
+    /* a byte over 0x7f must not end the copy early */
+    POISON_DST();
+    if (!strclipbuff(s.dst, sizeof(s.dst), "\xff\xfe") ||
+        strcmp(s.dst, "\xff\xfe") != 0)
+      return 1;
+#undef POISON_DST
+
+    if (memcmp(s.canary, "########", sizeof(s.canary)) != 0)
+      return 1;
+  }
+
   /* htsblk_failf: clips a reason quoted from a remote reply into msg[] and
      touches nothing else in the block */
   {

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -879,13 +879,11 @@ static PT_Element PT_ReadCache__New(PT_Index index, const char *url, int flags) 
   (headersSize) += (int) strlen(headers + headersSize); \
 } while(0)
 /* refvalue_size is mandatory: the cache line is bounded only by the line
-   buffer, not by the destination. Clip rather than reject, since an
-   engine-written field can be wider than ours. */
+   buffer, not by the destination. */
 #define ZIP_READFIELD_STRING(line, value, refline, refvalue, refvalue_size)    \
   do {                                                                         \
     if (line[0] != '\0' && strfield2(line, refline)) {                         \
-      (refvalue)[0] = '\0';                                                    \
-      strlncatbuff(refvalue, value, refvalue_size, (refvalue_size) - 1);       \
+      (void) strclipbuff(refvalue, refvalue_size, value);                      \
       line[0] = '\0';                                                          \
     }                                                                          \
   } while (0)
@@ -2168,8 +2166,7 @@ int PT_LoadCache__Arc(PT_Index index_, const char *filename) {
 #define HTTP_READFIELD_STRING(line, value, refline, refvalue, refvalue_size)   \
   do {                                                                         \
     if (line[0] != '\0' && strfield2(line, refline)) {                         \
-      (refvalue)[0] = '\0';                                                    \
-      strlncatbuff(refvalue, value, refvalue_size, (refvalue_size) - 1);       \
+      (void) strclipbuff(refvalue, refvalue_size, value);                      \
       line[0] = '\0';                                                          \
     }                                                                          \
   } while (0)


### PR DESCRIPTION
Three places spelled out the same clip-don't-abort copy by hand: the engine's cache reader in `htscache.c`, and both the ZIP and ARC readers in `proxy/store.c`. They live in binaries that share no code, so the duplication could not be caught by the linker, only by noticing it.

`strclipbuff()` in `htssafe.h` states the contract once. It also evaluates its arguments once, which the macro form did not: `refvalue` and `refvalue_size` were each expanded twice, and `(refvalue_size) - 1` would have wrapped to `SIZE_MAX` if any call site had ever passed zero. No call site does, so that part is hardening rather than a fix.

Covered by `-#test=strsafe`, mutation-tested against six candidate bugs: an off-by-one clip, a missing terminator, writing nothing when truncating, always reporting a fit, a sign-extended `0xff` ending the copy early, and dropping the last byte. All six fail the test; the restored build passes.
