### PR TITLE
PT_GetTime's gmtime-failure fallback would print a day of 00

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -226,8 +226,9 @@ jobs:
           # Every gate here exits 77, so an all-skipped suite would report green having
           # tested nothing: pin the skips, and floor the passes in case the glob empties.
           # footer-overflow skips on Windows (needs a path past MAX_PATH); crange pending #581;
-          # webdav-mime needs a reapable background listener, which MSYS cannot give it.
-          expected_skips=" 01_engine-footer-overflow.test 48_local-crange-memresume.test 71_local-crange-repaircache.test 79_local-proxytrack-webdav-mime.test"
+          # webdav-mime needs a reapable background listener, which MSYS cannot give it;
+          # badmtime needs a filesystem that stores an mtime past gmtime's range.
+          expected_skips=" 01_engine-footer-overflow.test 48_local-crange-memresume.test 71_local-crange-repaircache.test 79_local-proxytrack-webdav-mime.test 88_local-proxytrack-badmtime.test"
           [ "$pass" -ge 90 ] || { echo "::error::only $pass tests passed ($skip skipped)"; exit 1; }
           [ "$skipped" = "$expected_skips" ] || { echo "::error::unexpected skips:$skipped"; exit 1; }
           [ "$fail" -eq 0 ] || { echo "::error::failing:$failed"; exit 1; }

--- a/src/proxy/proxytrack.h
+++ b/src/proxy/proxytrack.h
@@ -368,7 +368,11 @@ HTS_UNUSED static struct tm PT_GetTime(time_t t) {
   if (tm != NULL)
     return *tm;
   else {
+    /* an all-zero tm has tm_mday == 0, which the ARC date field prints as a
+       day of "00"; the epoch is the conventional "date unknown" */
     memset(&tmbuf, 0, sizeof(tmbuf));
+    tmbuf.tm_year = 70;
+    tmbuf.tm_mday = 1;
     return tmbuf;
   }
 }

--- a/tests/88_local-proxytrack-badmtime.test
+++ b/tests/88_local-proxytrack-badmtime.test
@@ -1,0 +1,65 @@
+#!/bin/bash
+# A cache file whose mtime is beyond what gmtime can represent must not put a
+# day of "00" in the ARC filedesc date: PT_GetTime fell back to an all-zero tm.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+python=$(find_python) || {
+    echo "python3 not found; skipping" >&2
+    exit 77
+}
+
+dir=$(mktemp -d)
+trap 'rm -rf "$dir"' EXIT
+
+"$python" - "$dir/in.zip" <<'EOF'
+import os, sys, zipfile
+
+body = b"hello world"
+meta = (
+    "X-In-Cache: 1\r\n"
+    "X-StatusCode: 200\r\n"
+    "X-StatusMessage: OK\r\n"
+    "X-Size: %d\r\n"
+    "Content-Type: text/html\r\n"
+    "Last-Modified: Wed, 01 Jan 2025 00:00:00 GMT\r\n"
+    "X-Save: out/page.html\r\n" % len(body)
+).encode()
+
+zi = zipfile.ZipInfo("example.com/page.html")
+zi.compress_type = zipfile.ZIP_STORED
+zi.extra = meta
+with zipfile.ZipFile(sys.argv[1], "w") as z:
+    z.writestr(zi, body)
+
+# past gmtime's range; the index timestamp is this file's mtime
+huge = 4611686018427387903
+try:
+    os.utime(sys.argv[1], (huge, huge))
+except OSError:
+    sys.exit(77)
+if int(os.stat(sys.argv[1]).st_mtime) < huge:
+    sys.exit(77)  # filesystem clamped it, nothing to test
+EOF
+rc=0 || rc=$?
+test "${rc:-0}" != 77 || {
+    echo "filesystem will not hold the mtime; skipping" >&2
+    exit 77
+}
+
+proxytrack --convert "$dir/out.arc" "$dir/in.zip" >/dev/null 2>&1 || {
+    echo "FAIL: proxytrack failed on a cache with an out-of-range mtime" >&2
+    exit 1
+}
+
+# field 3 of the filedesc line is YYYYMMDDhhmmss; the epoch stands in for
+# "unknown", and 14 digits with a real day is the point (00 is what broke)
+date=$(head -n1 "$dir/out.arc" | awk '{ print $3 }')
+test "$date" = 19700101000000 || {
+    echo "FAIL: filedesc date is '$date', expected 19700101000000" >&2
+    exit 1
+}

--- a/tests/88_local-proxytrack-badmtime.test
+++ b/tests/88_local-proxytrack-badmtime.test
@@ -16,7 +16,8 @@ python=$(find_python) || {
 dir=$(mktemp -d)
 trap 'rm -rf "$dir"' EXIT
 
-"$python" - "$dir/in.zip" <<'EOF'
+rc=0
+"$python" - "$dir/in.zip" <<'EOF' || rc=$?
 import os, sys, zipfile
 
 body = b"hello world"
@@ -45,9 +46,12 @@ except OSError:
 if int(os.stat(sys.argv[1]).st_mtime) < huge:
     sys.exit(77)  # filesystem clamped it, nothing to test
 EOF
-rc=0 || rc=$?
-test "${rc:-0}" != 77 || {
-    echo "filesystem will not hold the mtime; skipping" >&2
+test "$rc" -eq 0 || {
+    test "$rc" -eq 77 || {
+        echo "FAIL: could not build the cache (python exit $rc)" >&2
+        exit 1
+    }
+    echo "filesystem will not hold an out-of-range mtime; skipping" >&2
     exit 77
 }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -184,6 +184,7 @@ TESTS = \
 	84_webhttrack-mirror-verbatim.test \
 	85_webhttrack-projpath.test \
 	86_local-proxytrack-cache-longfields.test \
-	87_local-proxytrack-nodate.test
+	87_local-proxytrack-nodate.test \
+	88_local-proxytrack-badmtime.test
 
 CLEANFILES = check-network_sh.cache


### PR DESCRIPTION
`PT_GetTime` falls back to an all-zero `struct tm` when `gmtime` fails. That has `tm_mday == 0`, and the ARC filedesc line prints `tm_mday` without adjustment, so the date field comes out with a day of `00` — which `getArcTimestamp` then reads back on the next load. #731 made the same call the other way for an unparseable `Last-Modified`; this is the remaining site.

It is reachable. `file_timestamp()` returns `st_mtime` unfiltered apart from `0` and `-1`, and that becomes the index timestamp for the zip and old-cache loaders, so a cache file whose mtime is past what `gmtime` can represent takes the fallback. The ARC loader is the exception: it overwrites the timestamp with the filedesc line's own date, whose year is capped at four digits.

Test 88 builds a zip cache, sets an out-of-range mtime, and pins the emitted filedesc date. Without the fix it reads `19000100000000`. It skips rather than fails where the filesystem clamps the mtime.

The other caller, `set_filetime_time_t`, stamped the saved file with 1899-11-30 and now stamps the epoch; `file_timestamp` already discards `0`, so that value round-trips as "unset" instead of as a bogus date.