### PR TITLE
ProxyTrack still copies through raw strcpy in fourteen places

### DIFF
--- a/src/proxy/proxytrack.c
+++ b/src/proxy/proxytrack.c
@@ -820,8 +820,8 @@ static PT_Element proxytrack_process_DAV_Request(PT_Indexes indexes,
     elt->size = StringLength(response);
     elt->adr = StringAcquire(&response);
     elt->statuscode = 207;      /* Multi-Status */
-    strcpy(elt->charset, "utf-8");
-    strcpy(elt->contenttype, "text/xml");
+    strcpybuff(elt->charset, "utf-8");
+    strcpybuff(elt->contenttype, "text/xml");
     strcpybuff(elt->msg, "Multi-Status");
     StringFree(response);
 
@@ -877,8 +877,8 @@ static PT_Element proxytrack_process_HTTP_List(PT_Indexes indexes,
     elt->size = StringLength(html);
     elt->adr = StringAcquire(&html);
     elt->statuscode = HTTP_OK;
-    strcpy(elt->charset, "iso-8859-1");
-    strcpy(elt->contenttype, "text/html");
+    strcpybuff(elt->charset, "iso-8859-1");
+    strcpybuff(elt->contenttype, "text/html");
     strcpybuff(elt->msg, "OK");
     StringFree(html);
     return elt;

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -405,8 +405,8 @@ PT_Element PT_Index_HTML_BuildRootInfo(PT_Indexes indexes) {
     elt->size = StringLength(html);
     elt->adr = StringAcquire(&html);
     elt->statuscode = HTTP_OK;
-    strcpy(elt->charset, "iso-8859-1");
-    strcpy(elt->contenttype, "text/html");
+    strcpybuff(elt->charset, "iso-8859-1");
+    strcpybuff(elt->contenttype, "text/html");
     strcpybuff(elt->msg, "OK");
     StringFree(html);
     return elt;
@@ -1042,7 +1042,7 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
   previous_save[0] = previous_save_[0] = '\0';
   memset(r, 0, sizeof(_PT_Element));
   r->location = location_default;
-  strcpy(r->location, "");
+  r->location[0] = '\0';
   if (strncmp(url, "http://", 7) == 0)
     url += 7;
   hash_pos_return = coucal_read(index->hash, url, &hash_pos);
@@ -1127,7 +1127,7 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
             int pathLen = (int) strlen(index->path);
 
             if (pathLen > 0 && strncmp(previous_save_, index->path, pathLen) == 0) {    // old (<3.40) buggy format
-              strcpy(previous_save, previous_save_);
+              strcpybuff(previous_save, previous_save_);
             }
             // relative ? (hack)
             else if (index->safeCache || (previous_save_[0] != '/'      // /home/foo/bar.gif
@@ -1554,7 +1554,7 @@ static int PT_LoadCache__Old(PT_Index index_, const char *filename) {
             cache->version = (int) (firstline[8] - '0');        // cache 1.x
             if (cache->version <= 5) {
               a += cache_brstr(a, firstline, sizeof(firstline));
-              strcpy(cache->lastmodified, firstline);
+              strcpybuff(cache->lastmodified, firstline);
             } else {
               fclose(cache->dat);
               cache->dat = NULL;
@@ -1571,7 +1571,7 @@ static int PT_LoadCache__Old(PT_Index index_, const char *filename) {
         } else {                // Vieille version du cache
           /* */
           cache->version = 0;   // cache 1.0
-          strcpy(cache->lastmodified, firstline);
+          strcpybuff(cache->lastmodified, firstline);
         }
 
         /* Create hash table for the cache (MUCH FASTER!) */
@@ -1684,7 +1684,7 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
   previous_save[0] = previous_save_[0] = '\0';
   memset(r, 0, sizeof(_PT_Element));
   r->location = location_default;
-  strcpy(r->location, "");
+  r->location[0] = '\0';
   if (strncmp(url, "http://", 7) == 0)
     url += 7;
   hash_pos_return = coucal_read(cache->hash, url, &hash_pos);
@@ -1791,7 +1791,7 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
           int pathLen = (int) strlen(index->path);
 
           if (pathLen > 0 && strncmp(previous_save_, index->path, pathLen) == 0) {      // old (<3.40) buggy format
-            strcpy(previous_save, previous_save_);
+            strcpybuff(previous_save, previous_save_);
           }
           // relative ? (hack)
           else if (index->safeCache || (previous_save_[0] != '/'        // /home/foo/bar.gif
@@ -2208,7 +2208,7 @@ static PT_Element PT_ReadCache__Arc_u(PT_Index index_, const char *url,
   location_default[0] = '\0';
   memset(r, 0, sizeof(_PT_Element));
   r->location = location_default;
-  strcpy(r->location, "");
+  r->location[0] = '\0';
   if (strncmp(url, "http://", 7) == 0)
     url += 7;
   hash_pos_return = coucal_read(index->hash, url, &hash_pos);
@@ -2427,7 +2427,7 @@ static int PT_SaveCache__Arc_Fun(void *arg, const char *url, PT_Element element)
   if (element->adr != NULL) {
     domd5mem(element->adr, element->size, st->md5, 1);
   } else {
-    strcpy(st->md5, "-");
+    strcpybuff(st->md5, "-");
   }
   fprintf(fp,
           /* nl */


### PR DESCRIPTION
Fourteen raw `strcpy` calls left in `proxy/store.c` and `proxy/proxytrack.c`, all safe today but none of them saying so: string literals into sized struct fields, and two copies between same-sized arrays.

Three of them write `""` through `r->location`, which is a `char *`, not an array. Those become a direct `[0] = '\0'` rather than `strcpybuff`, because the macro would have silently taken its pointer path and lost the bound it exists to provide.

One `strcpy` in the same file is deliberately left for a follow-up: `previous_save_` in the cache-1.0 reader takes the decoded request URL, which wants the clipping helper from #741 rather than an aborting wrapper. It is not reachable with an over-long URL today, since `coucal_read` requires the URL to already be a key in the cache, so its length is whatever wrote the cache.
