### PR TITLE
--without-zlib does not link, and cannot: make zlib a hard requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,32 @@ jobs:
       - name: Configure
         run: |
           set -euo pipefail
-          # Regenerate from configure.ac/Makefile.am to validate them; the
-          # committed generated files already let a plain checkout build.
+          # Regenerate: configure and the Makefile.in's are not tracked.
           autoreconf -fi
+          # Disabling zlib must fail here rather than at link with a pile of
+          # undefined minizip references (#735). Both spellings, so a rewrite
+          # cannot keep one and lose the other. Probed out-of-tree to leave
+          # nothing behind.
+          nozlib="$RUNNER_TEMP/nozlib"
+          for arg in --without-zlib --with-zlib=no; do
+            rm -rf "$nozlib" && mkdir -p "$nozlib"
+            if (cd "$nozlib" && "$GITHUB_WORKSPACE/configure" "$arg" >out.log 2>&1); then
+              echo "::error::configure $arg succeeded; it must be rejected"
+              exit 1
+            fi
+            # ... and for the stated reason, not an unrelated configure failure.
+            grep -q "zlib cannot be disabled" "$nozlib/out.log" \
+              || { cat "$nozlib/out.log"; exit 1; }
+          done
           ./configure
+          # Same dead end from the compile side. The bare compile is the
+          # control: without it a broken probe would pass vacuously.
+          hdr='#include "htsglobal.h"'
+          echo "$hdr" | $CC -I. -Isrc -fsyntax-only -xc -
+          if echo "$hdr" | $CC -DHTS_USEZLIB=0 -I. -Isrc -fsyntax-only -xc - 2>/dev/null; then
+            echo "::error::-DHTS_USEZLIB=0 compiled; htsglobal.h must reject it"
+            exit 1
+          fi
           # a missing decoder would silently drop the coding from Accept-Encoding
           grep -q "define HTS_USEBROTLI 1" config.h
           grep -q "define HTS_USEZSTD 1" config.h

--- a/configure.ac
+++ b/configure.ac
@@ -175,7 +175,7 @@ AX_CHECK_ALIGNED_ACCESS_REQUIRED
 # check for various headers
 AC_CHECK_HEADERS([execinfo.h sys/ioctl.h])
 
-### zlib
+### zlib (mandatory)
 CHECK_ZLIB()
 
 ### brotli and zstd content codings (optional)

--- a/m4/check_zlib.m4
+++ b/m4/check_zlib.m4
@@ -1,82 +1,33 @@
 dnl @synopsis CHECK_ZLIB()
 dnl
-dnl This macro searches for an installed zlib library. If nothing
-dnl was specified when calling configure, it searches first in /usr/local
-dnl and then in /usr. If the --with-zlib=DIR is specified, it will try
-dnl to find it in DIR/include/zlib.h and DIR/lib/libz.a. If --without-zlib
-dnl is specified, the library is not searched at all.
+dnl Look for zlib. It is a hard requirement, not an option: the cache and the
+dnl WARC output are zip/gzip containers, and the bundled minizip calls zlib
+dnl directly. --with-zlib=DIR points at a non-standard prefix.
 dnl
-dnl If either the header file (zlib.h) or the library (libz) is not
-dnl found, the configuration exits on error, asking for a valid
-dnl zlib installation directory or --without-zlib.
-dnl
-dnl The macro defines the symbol HAVE_LIBZ if the library is found. You should
-dnl use autoheader to include a definition for this symbol in a config.h
-dnl file. Sample usage in a C/C++ source is as follows:
-dnl
-dnl   #ifdef HAVE_LIBZ
-dnl   #include <zlib.h>
-dnl   #endif /* HAVE_LIBZ */
-dnl
-dnl @version $Id$
-dnl @author Loic Dachary <loic@senga.org>
-dnl
+dnl Adds -lz to LIBS and defines HAVE_LIBZ.
 
-AC_DEFUN([CHECK_ZLIB],
-#
-# Handle user hints
-#
-[AC_MSG_CHECKING(if zlib is wanted)
-AC_ARG_WITH(zlib,
-[  --with-zlib=DIR root directory path of zlib installation [defaults to
-                    /usr/local or /usr if not found in /usr/local]
-  --without-zlib to disable zlib usage completely],
-[if test "$withval" != no ; then
-  AC_MSG_RESULT(yes)
-  ZLIB_HOME="$withval"
-else
-  AC_MSG_RESULT(no)
-fi], [
-AC_MSG_RESULT(yes)
-ZLIB_HOME=/usr/local
-if test ! -f "${ZLIB_HOME}/include/zlib.h"
-then
-        ZLIB_HOME=/usr
+AC_DEFUN([CHECK_ZLIB], [
+AC_ARG_WITH([zlib],
+	[AS_HELP_STRING([--with-zlib=DIR],[root directory of the zlib installation])],
+	[zlib_want=$withval], [zlib_want=yes])
+if test "$zlib_want" = "no"; then
+	AC_MSG_ERROR([zlib cannot be disabled: the cache and the WARC output are zip/gzip containers, and the bundled minizip calls zlib directly])
 fi
-])
-
-#
-# Locate zlib, if wanted
-#
-if test -n "${ZLIB_HOME}"
-then
-        ZLIB_OLD_LDFLAGS=$LDFLAGS
-        ZLIB_OLD_CPPFLAGS=$LDFLAGS
-        LDFLAGS="$LDFLAGS -L${ZLIB_HOME}/lib"
-        CPPFLAGS="$CPPFLAGS -I${ZLIB_HOME}/include"
-        AC_LANG_SAVE
-        AC_LANG_C
-        AC_CHECK_LIB(z, inflateEnd, [zlib_cv_libz=yes], [zlib_cv_libz=no])
-        AC_CHECK_HEADER(zlib.h, [zlib_cv_zlib_h=yes], [zlib_cv_zlib_h=no])
-        AC_LANG_RESTORE
-        if test "$zlib_cv_libz" = "yes" -a "$zlib_cv_zlib_h" = "yes"
-        then
-                #
-                # If both library and header were found, use them
-                #
-                AC_CHECK_LIB(z, inflateEnd)
-                AC_MSG_CHECKING(zlib in ${ZLIB_HOME})
-                AC_MSG_RESULT(ok)
-        else
-                #
-                # If either header or library was not found, revert and bomb
-                #
-                AC_MSG_CHECKING(zlib in ${ZLIB_HOME})
-                LDFLAGS="$ZLIB_OLD_LDFLAGS"
-                CPPFLAGS="$ZLIB_OLD_CPPFLAGS"
-                AC_MSG_RESULT(failed)
-                AC_MSG_ERROR(either specify a valid zlib installation with --with-zlib=DIR or disable zlib usage with --without-zlib)
-        fi
+if test "$zlib_want" != "yes"; then
+	# An explicit prefix is authoritative: if the header is not under it,
+	# error rather than silently pick a system copy.
+	if test ! -f "$zlib_want/include/zlib.h"; then
+		AC_MSG_ERROR([zlib requested at $zlib_want but $zlib_want/include/zlib.h is missing])
+	fi
+	CPPFLAGS="$CPPFLAGS -I$zlib_want/include"
+	LDFLAGS="$LDFLAGS -L$zlib_want/lib"
+elif test -f /usr/local/include/zlib.h; then
+	# Where the BSD ports tree lands zlib, and not always searched by default.
+	CPPFLAGS="$CPPFLAGS -I/usr/local/include"
+	LDFLAGS="$LDFLAGS -L/usr/local/lib"
 fi
-
+AC_CHECK_HEADER([zlib.h], [],
+	[AC_MSG_ERROR([zlib.h not found; install the zlib development files or pass --with-zlib=DIR])])
+AC_CHECK_LIB([z], [inflateEnd], [],
+	[AC_MSG_ERROR([libz not found; install the zlib development files or pass --with-zlib=DIR])])
 ])

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -48,11 +48,6 @@ Please visit our Website: http://www.httrack.com
 #include "htsftp.h"
 #include "htscodec.h"
 #include "htsproxy.h"
-#if HTS_USEZLIB
-#include "htszlib.h"
-#else
-#error HTS_USEZLIB not defined
-#endif
 
 #ifdef _WIN32
 #ifndef __cplusplus

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -138,10 +138,11 @@ Please visit our Website: http://www.httrack.com
 #define HTS_DOSNAME 0
 #endif
 
-// utiliser zlib?
+// zlib is mandatory: the cache is a zip and minizip calls it regardless
 #ifndef HTS_USEZLIB
-// autoload
 #define HTS_USEZLIB 1
+#elif !HTS_USEZLIB
+#error HTS_USEZLIB=0 is not a supported configuration
 #endif
 
 // brotli and zstd content codings; off unless the build opted in (configure,


### PR DESCRIPTION
`configure --without-zlib` has never produced a working build. It only dropped `-lz` from `LIBS` and never defined `HTS_USEZLIB 0`, so every `#if HTS_USEZLIB` guard in the tree stayed true and the link failed on minizip, `htszlib.c`, `htswarc.c` and `htsselftest.c` alike (two more than the issue lists). Nothing in CI covers that configuration, which is why it rotted.

Making it work would cost more than it returns: the cache and the WARC output are zip/gzip containers built on minizip, so a zlib-free binary would have no cache, no `--update` and no resume, and `htsback.c` already refused to compile with `HTS_USEZLIB=0`. So the option goes rather than the guards. `CHECK_ZLIB` now fails on `--without-zlib` and on a missing header or library, keeps `--with-zlib=DIR` for a non-standard prefix, and `htsback.c`'s `#error` moves to `htsglobal.h` where the knob is defined. One behaviour change worth flagging: `--with-zlib=DIR` now treats the prefix as authoritative and errors when the header is not under it rather than quietly falling back to the system copy, matching what `CHECK_BROTLI` and `CHECK_ZSTD` already do. CI asserts both spellings are rejected for the stated reason and that `-DHTS_USEZLIB=0` stops at compile, each with a control so a broken probe cannot pass vacuously.

Closes #735
