### PR TITLE
structcheck() builds its rename target with an unbounded sprintf

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -2693,8 +2693,7 @@ HTSEXT_API int structcheck(const char *path) {
       if (!S_ISDIR(st.st_mode)) {
 #if HTS_REMOVE_ANNOYING_INDEX
         if (S_ISREG(st.st_mode)) {      /* Regular file in place ; move it and create directory */
-          /* bound the target here: the only thing keeping ".txt" inside tmpbuf
-             is the path-length guard dozens of lines above */
+          /* bounded here, not by the path-length guard far above */
           if (!sprintfbuff(tmpbuf, "%s.txt", file)) {
             errno = ENAMETOOLONG;
             return -1;
@@ -2806,8 +2805,7 @@ HTSEXT_API int structcheck_utf8(const char *path) {
       if (!S_ISDIR(st.st_mode)) {
 #if HTS_REMOVE_ANNOYING_INDEX
         if (S_ISREG(st.st_mode)) {      /* Regular file in place ; move it and create directory */
-          /* bound the target here: the only thing keeping ".txt" inside tmpbuf
-             is the path-length guard dozens of lines above */
+          /* bounded here, not by the path-length guard far above */
           if (!sprintfbuff(tmpbuf, "%s.txt", file)) {
             errno = ENAMETOOLONG;
             return -1;

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -2693,7 +2693,12 @@ HTSEXT_API int structcheck(const char *path) {
       if (!S_ISDIR(st.st_mode)) {
 #if HTS_REMOVE_ANNOYING_INDEX
         if (S_ISREG(st.st_mode)) {      /* Regular file in place ; move it and create directory */
-          sprintf(tmpbuf, "%s.txt", file);
+          /* bound the target here: the only thing keeping ".txt" inside tmpbuf
+             is the path-length guard dozens of lines above */
+          if (!sprintfbuff(tmpbuf, "%s.txt", file)) {
+            errno = ENAMETOOLONG;
+            return -1;
+          }
           if (rename(file, tmpbuf) != 0) {      /* Can't rename regular file */
             return -1;
           }
@@ -2801,7 +2806,12 @@ HTSEXT_API int structcheck_utf8(const char *path) {
       if (!S_ISDIR(st.st_mode)) {
 #if HTS_REMOVE_ANNOYING_INDEX
         if (S_ISREG(st.st_mode)) {      /* Regular file in place ; move it and create directory */
-          sprintf(tmpbuf, "%s.txt", file);
+          /* bound the target here: the only thing keeping ".txt" inside tmpbuf
+             is the path-length guard dozens of lines above */
+          if (!sprintfbuff(tmpbuf, "%s.txt", file)) {
+            errno = ENAMETOOLONG;
+            return -1;
+          }
           if (RENAME(file, tmpbuf) != 0) {      /* Can't rename regular file */
             return -1;
           }

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3264,6 +3264,95 @@ static int st_topindex(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* Build a path of exactly len characters under base, split into components a
+   filesystem accepts. Returns the length written. */
+static size_t st_structcheck_longpath(char *dst, size_t dstsize,
+                                      const char *base, size_t len) {
+  size_t n = strlen(base);
+
+  assertf(len < dstsize && n + 2 < len);
+  memmove(dst, base, n);
+  while (n < len) {
+    size_t seg = len - n - 1; /* what follows the separator */
+
+    if (seg > 200) /* stay under the usual 255-byte component limit */
+      seg = 200;
+    dst[n++] = '/';
+    memset(dst + n, 'x', seg);
+    n += seg;
+  }
+  dst[n] = '\0';
+  return n;
+}
+
+/* structcheck() renames a regular file out of a directory's way; that
+   ".txt" target must fit whatever path the guard admits (#745). */
+static int st_structcheck(httrackp *opt, int argc, char **argv) {
+  char BIGSTK path[HTS_URLMAXSIZE * 2];
+  char BIGSTK target[HTS_URLMAXSIZE * 2];
+  size_t n;
+  FILE *fp;
+
+  (void) opt;
+  if (argc < 1) {
+    fprintf(stderr, "usage: -#test=structcheck <writable directory>\n");
+    return 1;
+  }
+
+  /* over the guard: refused, and errno says why */
+  n = st_structcheck_longpath(path, sizeof(path), argv[0], HTS_URLMAXSIZE + 1);
+  errno = 0;
+  assertf(structcheck(path) == -1);
+  assertf(errno == EINVAL);
+  assertf(!fexist(path));
+
+  /* a regular file where a directory belongs is renamed to <name>.txt */
+  snprintf(path, sizeof(path), "%s/sc", argv[0]);
+  fp = fopen(path, "wb");
+  assertf(fp != NULL);
+  fclose(fp);
+  snprintf(path, sizeof(path), "%s/sc/sub/", argv[0]);
+  assertf(structcheck(path) == 0);
+  assertf(dir_exists(path));
+  snprintf(target, sizeof(target), "%s/sc.txt", argv[0]);
+  assertf(fexist(target));
+
+  /* same rename at the longest path the guard lets through: the target runs
+     four bytes past it and must still be written whole */
+  snprintf(path, sizeof(path), "%s/max", argv[0]);
+  assertf(structcheck(path) == 0);
+  n = st_structcheck_longpath(path, sizeof(path), path, HTS_URLMAXSIZE - 1);
+  assertf(structcheck(path) == 0); /* parents only: no trailing separator */
+  fp = fopen(path, "wb");
+  assertf(fp != NULL);
+  fclose(fp);
+  strcpybuff(target, path);
+  strcatbuff(target, ".txt");
+  path[n] = '/'; /* now exactly HTS_URLMAXSIZE, the guard's limit */
+  path[n + 1] = '\0';
+  assertf(structcheck(path) == 0);
+  assertf(dir_exists(path));
+  assertf(fexist(target));
+
+  /* the utf-8 twin carries the same rename */
+  snprintf(path, sizeof(path), "%s/u8", argv[0]);
+  assertf(structcheck_utf8(path) == 0);
+  n = st_structcheck_longpath(path, sizeof(path), path, HTS_URLMAXSIZE - 1);
+  assertf(structcheck_utf8(path) == 0);
+  fp = FOPEN(path, "wb");
+  assertf(fp != NULL);
+  fclose(fp);
+  strcpybuff(target, path);
+  strcatbuff(target, ".txt");
+  path[n] = '/';
+  path[n + 1] = '\0';
+  assertf(structcheck_utf8(path) == 0);
+  assertf(fexist_utf8(target));
+
+  printf("structcheck self-test OK\n");
+  return 0;
+}
+
 /* Each inplace_escape_*() must equal escape_*() on a copy. */
 static int st_inplace_escape(httrackp *opt, int argc, char **argv) {
   /* >255 bytes forces the helper's malloct path, not the stack buffer */
@@ -6330,6 +6419,9 @@ static const struct selftest_entry {
     {"useragent", "", "default User-Agent self-test", st_useragent},
     {"makeindex", "[dir]", "hts_finish_makeindex footer/refresh self-test",
      st_makeindex},
+    {"structcheck", "<dir>",
+     "structcheck path guard and the <name>.txt rename it performs",
+     st_structcheck},
     {"topindex", "[dir]",
      "hts_buildtopindex charset handling of a non-ASCII project dir",
      st_topindex},

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3264,19 +3264,18 @@ static int st_topindex(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-/* Build a path of exactly len characters under base, split into components a
-   filesystem accepts. Returns the length written. */
+/* Build a path of exactly len chars under base; returns that length. */
 static size_t st_structcheck_longpath(char *dst, size_t dstsize,
                                       const char *base, size_t len) {
   size_t n = strlen(base);
 
-  assertf(len < dstsize && n + 2 < len);
+  assertf(len < dstsize && n + 2 <= len);
   memmove(dst, base, n);
   while (n < len) {
-    size_t seg = len - n - 1; /* what follows the separator */
+    size_t seg = len - n - 1;
 
     if (seg > 200) /* stay under the usual 255-byte component limit */
-      seg = 200;
+      seg = len - n == 202 ? 199 : 200; /* never leave a bare separator */
     dst[n++] = '/';
     memset(dst + n, 'x', seg);
     n += seg;
@@ -3285,8 +3284,7 @@ static size_t st_structcheck_longpath(char *dst, size_t dstsize,
   return n;
 }
 
-/* structcheck() renames a regular file out of a directory's way; that
-   ".txt" target must fit whatever path the guard admits (#745). */
+/* The ".txt" rename target must fit any path the guard admits (#745). */
 static int st_structcheck(httrackp *opt, int argc, char **argv) {
   char BIGSTK path[HTS_URLMAXSIZE * 2];
   char BIGSTK target[HTS_URLMAXSIZE * 2];
@@ -3299,12 +3297,18 @@ static int st_structcheck(httrackp *opt, int argc, char **argv) {
     return 1;
   }
 
-  /* over the guard: refused, and errno says why */
-  n = st_structcheck_longpath(path, sizeof(path), argv[0], HTS_URLMAXSIZE + 1);
+  /* over the guard: refused before a single directory is created */
+  st_structcheck_longpath(path, sizeof(path), argv[0], HTS_URLMAXSIZE + 1);
   errno = 0;
   assertf(structcheck(path) == -1);
   assertf(errno == EINVAL);
-  assertf(!fexist(path));
+  {
+    char *const sep = strchr(path + strlen(argv[0]) + 1, '/');
+
+    assertf(sep != NULL);
+    sep[1] = '\0'; /* the outermost component it would have created */
+    assertf(!dir_exists(path));
+  }
 
   /* a regular file where a directory belongs is renamed to <name>.txt */
   snprintf(path, sizeof(path), "%s/sc", argv[0]);
@@ -3317,10 +3321,8 @@ static int st_structcheck(httrackp *opt, int argc, char **argv) {
   snprintf(target, sizeof(target), "%s/sc.txt", argv[0]);
   assertf(fexist(target));
 
-  /* same rename at the longest path the guard lets through: the target runs
-     four bytes past it and must still be written whole */
+  /* the same rename at the longest path the guard admits */
   snprintf(path, sizeof(path), "%s/max", argv[0]);
-  assertf(structcheck(path) == 0);
   n = st_structcheck_longpath(path, sizeof(path), path, HTS_URLMAXSIZE - 1);
   assertf(structcheck(path) == 0); /* parents only: no trailing separator */
   fp = fopen(path, "wb");
@@ -3336,9 +3338,8 @@ static int st_structcheck(httrackp *opt, int argc, char **argv) {
 
   /* the utf-8 twin carries the same rename */
   snprintf(path, sizeof(path), "%s/u8", argv[0]);
-  assertf(structcheck_utf8(path) == 0);
   n = st_structcheck_longpath(path, sizeof(path), path, HTS_URLMAXSIZE - 1);
-  assertf(structcheck_utf8(path) == 0);
+  assertf(structcheck_utf8(path) == 0); /* parents only */
   fp = FOPEN(path, "wb");
   assertf(fp != NULL);
   fclose(fp);
@@ -3347,6 +3348,7 @@ static int st_structcheck(httrackp *opt, int argc, char **argv) {
   path[n] = '/';
   path[n + 1] = '\0';
   assertf(structcheck_utf8(path) == 0);
+  assertf(dir_exists(path));
   assertf(fexist_utf8(target));
 
   printf("structcheck self-test OK\n");

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3284,11 +3284,11 @@ static size_t st_structcheck_longpath(char *dst, size_t dstsize,
   return n;
 }
 
-/* The ".txt" rename target must fit any path the guard admits (#745). */
+/* The path guard, and the <name>.txt rename structcheck() performs when a
+   regular file sits where a directory has to go (#745). */
 static int st_structcheck(httrackp *opt, int argc, char **argv) {
   char BIGSTK path[HTS_URLMAXSIZE * 2];
   char BIGSTK target[HTS_URLMAXSIZE * 2];
-  size_t n;
   FILE *fp;
 
   (void) opt;
@@ -3301,6 +3301,9 @@ static int st_structcheck(httrackp *opt, int argc, char **argv) {
   st_structcheck_longpath(path, sizeof(path), argv[0], HTS_URLMAXSIZE + 1);
   errno = 0;
   assertf(structcheck(path) == -1);
+  assertf(errno == EINVAL);
+  errno = 0;
+  assertf(structcheck_utf8(path) == -1);
   assertf(errno == EINVAL);
   {
     char *const sep = strchr(path + strlen(argv[0]) + 1, '/');
@@ -3321,34 +3324,15 @@ static int st_structcheck(httrackp *opt, int argc, char **argv) {
   snprintf(target, sizeof(target), "%s/sc.txt", argv[0]);
   assertf(fexist(target));
 
-  /* the same rename at the longest path the guard admits */
-  snprintf(path, sizeof(path), "%s/max", argv[0]);
-  n = st_structcheck_longpath(path, sizeof(path), path, HTS_URLMAXSIZE - 1);
-  assertf(structcheck(path) == 0); /* parents only: no trailing separator */
-  fp = fopen(path, "wb");
-  assertf(fp != NULL);
-  fclose(fp);
-  strcpybuff(target, path);
-  strcatbuff(target, ".txt");
-  path[n] = '/'; /* now exactly HTS_URLMAXSIZE, the guard's limit */
-  path[n + 1] = '\0';
-  assertf(structcheck(path) == 0);
-  assertf(dir_exists(path));
-  assertf(fexist(target));
-
-  /* the utf-8 twin carries the same rename */
+  /* the utf-8 entry point carries the same rename */
   snprintf(path, sizeof(path), "%s/u8", argv[0]);
-  n = st_structcheck_longpath(path, sizeof(path), path, HTS_URLMAXSIZE - 1);
-  assertf(structcheck_utf8(path) == 0); /* parents only */
   fp = FOPEN(path, "wb");
   assertf(fp != NULL);
   fclose(fp);
-  strcpybuff(target, path);
-  strcatbuff(target, ".txt");
-  path[n] = '/';
-  path[n + 1] = '\0';
+  snprintf(path, sizeof(path), "%s/u8/sub/", argv[0]);
   assertf(structcheck_utf8(path) == 0);
   assertf(dir_exists(path));
+  snprintf(target, sizeof(target), "%s/u8.txt", argv[0]);
   assertf(fexist_utf8(target));
 
   printf("structcheck self-test OK\n");

--- a/tests/01_engine-structcheck.test
+++ b/tests/01_engine-structcheck.test
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# structcheck(): the path-length guard, and the <name>.txt rename that used to
+# build its target with an unbounded sprintf (#745).
+
+set -euo pipefail
+
+dir=$(mktemp -d)
+trap 'rm -rf "$dir"' EXIT
+
+httrack -O /dev/null -#test=structcheck "$dir" |
+    grep -q "structcheck self-test OK"

--- a/tests/01_engine-structcheck.test
+++ b/tests/01_engine-structcheck.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# structcheck(): the path-length guard, and the <name>.txt rename that used to
-# build its target with an unbounded sprintf (#745).
+# structcheck(): the path-length guard, and the <name>.txt rename that once
+# built its target with an unbounded sprintf (#745).
 
 set -euo pipefail
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -81,6 +81,7 @@ TESTS = \
 	01_engine-status.test \
 	01_engine-stripquery.test \
 	01_engine-strsafe.test \
+	01_engine-structcheck.test \
 	01_engine-syscharset.test \
 	01_engine-topindex.test \
 	01_engine-urlhack.test \


### PR DESCRIPTION
`structcheck()` and `structcheck_utf8()` move a regular file aside when a directory has to go where it sits, and both build the `<name>.txt` rename target with a raw `sprintf` into a 2048-byte stack buffer. Nothing at the write says what keeps it in bounds. The answer is a `strlen(path) > HTS_URLMAXSIZE` check dozens of lines above, which reads as input validation rather than as the thing the buffer depends on. Both sites now go through `sprintfbuff()` and return -1 with ENAMETOOLONG when the target does not fit.

That failure branch is unreachable on today's tree: the guard caps the target at 1029 bytes of the 2048 available, so this is locality rather than a live bug fix. Patching the guard out and handing `structcheck()` a 2045-byte path makes ASan report a 2049-byte write into the 2048-byte buffer; the same build with `sprintfbuff()` returns -1 and reports nothing.

`-#test=structcheck` is therefore a characterization test, not a regression net for the overflow: it pins the guard and the rename for both the system-charset and the UTF-8 entry point. It deliberately does not try the rename at the guard's maximum length, since HTS_URLMAXSIZE plus ".txt" is longer than macOS will open.

Closes #745
