### PR TITLE
hts_finish_html_file is documented as skipping unchanged writes, and does not

### DIFF
--- a/src/htscore.h
+++ b/src/htscore.h
@@ -376,8 +376,8 @@ void hts_finish_makeindex(httrackp *opt, int *makeindex_done,
                           const char *template_footer, const char *adr,
                           const char *fil);
 
-// Flush ht_buff[0..ht_len] to save on disk (skip if MD5 unchanged); *fp
-// closed+NULLed on write. Precondition: ht_len>0.
+// Flush ht_buff[0..ht_len] to save on disk; *fp closed+NULLed on write.
+// Precondition: ht_len>0.
 void hts_finish_html_file(httrackp *opt, cache_back *cache, htsblk *r,
                           FILE **fp, const char *ht_buff, size_t ht_len,
                           const char *adr, const char *fil, const char *save);


### PR DESCRIPTION
`hts_finish_html_file()`'s header comment promises the write is skipped when the MD5 is unchanged. It is not: the function calls `file_notify()`, then `filecreate()`, then writes, every time.

The skip was real before #467, which lifted the code out of `htsparse.c`'s `HT_ADD_END` macro and carried the comment across without the hashing branch. #512 then dropped the `//[HTML-MD5]//` cache entry it compared against, so there is nothing left to reinstate it from. Behaviour is unchanged; only the comment moves.

Closes #727
