### PR TITLE
htsAddLink walks back from an empty codebase, one byte before the buffer

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -3821,11 +3821,12 @@ int htsAddLink(htsmoduleStruct * str, char *link) {
         strcpybuff(codebase, heap(ptr)->fil);
       else
         strcpybuff(codebase, heap(heap(ptr)->precedent)->fil);
-      a = codebase + strlen(codebase) - 1;
+      // empty codebase has no last char; codebase-1 would underflow
+      a = codebase[0] != '\0' ? codebase + strlen(codebase) - 1 : codebase;
       while((*a) && (*a != '/') && (a > codebase))
         a--;
       if (*a == '/')
-        *(a + 1) = '\0';        // couper
+        *(a + 1) = '\0';        // cut
     } else {                    // couper http:// éventuel
       if (strfield(codebase, "http://")) {
         char BIGSTK tempo[HTS_URLMAXSIZE * 2];

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -43,6 +43,7 @@ Please visit our Website: http://www.httrack.com
 
 #include "htsglobal.h"
 #include "htscore.h"
+#include "htsmodules.h"
 #include "htsback.h"
 #include "htsdefines.h"
 #include "htslib.h"
@@ -2620,6 +2621,62 @@ static int st_savename(httrackp *opt, int argc, char **argv) {
   if (body != NULL)
     (void) UNLINK(bodyfile);
   printf("savename: %s\n", afs.save);
+  return 0;
+}
+
+/* an empty fil started htsAddLink's codebase walk before the buffer (#730) */
+static int st_addlink(httrackp *opt, int argc, char **argv) {
+  htsmoduleStruct BIGSTK str;
+  cache_back cache;
+  struct_back *sback;
+  hash_struct hash;
+  char link[] = "sub/page.html";
+  int ptr = 0;
+  int i;
+
+  (void) argc;
+  (void) argv;
+
+  memset(&cache, 0, sizeof(cache));
+  cache.hashtable = (void *) coucal_new(0);
+  sback = back_new(opt, opt->maxsoc * 32 + 1024);
+  /* same wiring as hts_mirror (htscore.c) */
+  hash_init(opt, &hash, opt->urlhack);
+  hash.liens = (const lien_url *const *const *) &opt->liens;
+  opt->hash = &hash;
+  hts_record_init(opt);
+
+  memset(&str, 0, sizeof(str));
+  str.opt = opt;
+  str.sback = sback;
+  str.cache = &cache;
+  str.hashptr = &hash;
+  str.ptr_ = &ptr;
+  str.addLink = htsAddLink;
+
+  /* fil[0] is the underflow, fil[1] the control that the trim is unchanged */
+  for (i = 0; i < 2; i++) {
+    static const char *const fil[2] = {"", "/dir/page.html"};
+    static const char *const want[2] = {
+        "untouched", "http://www.example.com/dir/sub/page.html"};
+    char BIGSTK loc[HTS_URLMAXSIZE * 2];
+
+    strcpybuff(loc, "untouched");
+    str.localLink = loc;
+    str.localLinkSize = (int) sizeof(loc);
+    if (!hts_record_link(opt, "www.example.com", fil[i], "", "", "", ""))
+      return 1;
+    ptr = heap_top_index();
+    str.url_host = heap(ptr)->adr;
+    str.url_file = heap(ptr)->fil;
+    assertf(htsAddLink(&str, link) == 0); /* refused by the wizard either way */
+    if (strcmp(loc, want[i]) != 0) {
+      fprintf(stderr, "addlink[%d]: got '%s' want '%s'\n", i, loc, want[i]);
+      return 1;
+    }
+  }
+
+  printf("addlink self-test OK\n");
   return 0;
 }
 
@@ -6307,6 +6364,8 @@ static const struct selftest_entry {
     {"fsize", "<dir>", "file size past the 2GB signed-32-bit wrap", st_fsize},
     {"growsize", "", "buffer capacity for a 64-bit file size (no int wrap)",
      st_growsize},
+    {"addlink", "", "htsAddLink codebase walk over an empty current path",
+     st_addlink},
     {"cache", "<dir>", "cache read/write round-trip self-test", st_cache},
     {"cacheindex", "", "cache-index (.ndx) parse must stay in bounds",
      st_cacheindex},

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2628,7 +2628,6 @@ static int st_addlink(httrackp *opt, int argc, char **argv) {
   cache_back cache;
   struct_back *sback;
   hash_struct hash;
-  char link[] = "sub/page.html";
   int ptr = 0;
   int i;
 
@@ -2652,14 +2651,21 @@ static int st_addlink(httrackp *opt, int argc, char **argv) {
   str.ptr_ = &ptr;
   str.addLink = htsAddLink;
 
-  /* fil[0] is the underflow, fil[1] the control that the trim is unchanged */
-  for (i = 0; i < 2; i++) {
-    static const char *const fil[2] = {"", "/dir/page.html"};
-    static const char *const want[2] = {
-        "untouched", "http://www.example.com/dir/sub/page.html"};
+  /* [0] is the underflow; [1] and [2] are controls that the trim is unchanged.
+     A query-only link is the one that notices the trim at all: for the others
+     ident_url_relatif() re-derives the directory from the path it is given. */
+  for (i = 0; i < 3; i++) {
+    static const char *const fil[3] = {"", "/dir/page.html", "/dir/page.html"};
+    static const char *const lnk[3] = {"sub/page.html", "sub/page.html",
+                                       "?x=1"};
+    static const char *const want[3] = {
+        "untouched", "http://www.example.com/dir/sub/page.html",
+        "http://www.example.com/dir/?x=1"};
     char BIGSTK loc[HTS_URLMAXSIZE * 2];
+    char BIGSTK link[HTS_URLMAXSIZE];
 
     strcpybuff(loc, "untouched");
+    strcpybuff(link, lnk[i]);
     str.localLink = loc;
     str.localLinkSize = (int) sizeof(loc);
     if (!hts_record_link(opt, "www.example.com", fil[i], "", "", "", ""))

--- a/tests/01_engine-addlink.test
+++ b/tests/01_engine-addlink.test
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# an empty current path underflowed htsAddLink's codebase walk (#730).
+
+set -euo pipefail
+
+httrack -O /dev/null -#test=addlink | grep -q "addlink self-test OK"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -30,6 +30,7 @@ TEST_EXTENSIONS = .test
 TEST_LOG_COMPILER = $(BASH)
 TESTS = \
 	00_runnable.test \
+	01_engine-addlink.test \
 	01_engine-changes.test \
 	01_engine-charset.test \
 	01_engine-cmdline.test \


### PR DESCRIPTION
Same idiom as the `lienrelatif()` underflow fixed in #729. The trim that walks back to the last `/` starts at `codebase + strlen(codebase) - 1`, which is `codebase - 1` when the string is empty, and the loop dereferences it before `a > codebase` can stop it.

Unlike #729 there is no reachable empty value, and I checked rather than assumed: `codebase` is copied from a recorded link's `fil`, and no `hts_record_link()` call site can supply an empty one. Every `fil` is either a literal seed or an `ident_url_absolute()` / `ident_url_relatif()` success return, and `fil_simplifie()` restores `"/"` or `"./"` rather than leaving a path empty. A probe over 37 hostile URL shapes produced no empty result, with a seeded empty control to show the probe could see one.

The guard goes in anyway, and `-#test=addlink` drives the walk directly, so this is a regression net rather than a characterization test: in the `sanitize` job's ASan+UBSan build the test fails on the unfixed walk and passes with the guard. Two further cases pin the ordinary trim, which the guard leaves alone. One of them uses a query-only link, because that is the shape where the trim matters at all: for an ordinary relative link `ident_url_relatif()` re-derives the directory itself, and deleting the trim outright goes unnoticed.

Closes #730
