### PR TITLE
hts_rename_over() deletes its destination when the source is missing

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -6648,8 +6648,7 @@ int hts_rename_utf8(const char *oldpath, const char *newpath) {
   LPWSTR wnewpath = hts_pathToUCS2(newpath);
   if (woldpath != NULL && wnewpath != NULL) {
     const int result = _wrename(woldpath, wnewpath);
-    /* Callers decide from errno whether the target was in the way (#779), and
-       free() is not required to leave it alone. */
+    /* Save errno: callers key off it (#779) and free() may clobber it. */
     const int err = errno;
 
     free(woldpath);

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -6648,9 +6648,13 @@ int hts_rename_utf8(const char *oldpath, const char *newpath) {
   LPWSTR wnewpath = hts_pathToUCS2(newpath);
   if (woldpath != NULL && wnewpath != NULL) {
     const int result = _wrename(woldpath, wnewpath);
+    /* Callers decide from errno whether the target was in the way (#779), and
+       free() is not required to leave it alone. */
+    const int err = errno;
 
     free(woldpath);
     free(wnewpath);
+    errno = err;
     return result;
   } else {
     if (woldpath != NULL)

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5955,6 +5955,91 @@ static int st_mirrorio(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+static void ro_put(const char *path, const char *data) {
+  FILE *const fp = FOPEN(path, "wb");
+
+  assertf(fp != NULL);
+  assertf(fwrite(data, 1, strlen(data), fp) == strlen(data));
+  fclose(fp);
+}
+
+/* HTS_TRUE if path holds exactly data. */
+static hts_boolean ro_is(const char *path, const char *data) {
+  char buf[64];
+  FILE *const fp = FOPEN(path, "rb");
+  size_t n;
+
+  if (fp == NULL)
+    return HTS_FALSE;
+  n = fread(buf, 1, sizeof(buf), fp);
+  fclose(fp);
+  return n == strlen(data) && memcmp(buf, data, n) == 0 ? HTS_TRUE : HTS_FALSE;
+}
+
+// -#test=renameover <dir>: hts_rename_over() must replace an existing dst, and
+// must never delete a dst it did not replace (#779). POSIX rename() clobbers on
+// its own, so the unlink fallback is only reached under the LD_PRELOAD shim the
+// test also runs this under.
+static int st_renameover(httrackp *opt, int argc, char **argv) {
+  (void) opt;
+  if (argc < 1) {
+    fprintf(stderr, "renameover: needs a writable base dir\n");
+    return 1;
+  }
+  char src[HTS_URLMAXSIZE * 2], dst[HTS_URLMAXSIZE * 2];
+  int err = 0;
+
+  fconcat(src, sizeof(src), argv[0], "renameover-src.bin");
+  fconcat(dst, sizeof(dst), argv[0], "renameover-dst.bin");
+
+  /* Tell the harness whether the unlink fallback is reachable at all here: it
+     is dead unless rename() refuses an existing target, as Windows' does. */
+  (void) UNLINK(src);
+  (void) UNLINK(dst);
+  ro_put(src, "probe");
+  ro_put(dst, "probe");
+  if (RENAME(src, dst) != 0)
+    printf("renameover: fallback exercised, rename refuses an existing "
+           "target\n");
+
+  /* An existing dst must still be replaced: that is what the unlink is for. */
+  (void) UNLINK(src);
+  (void) UNLINK(dst);
+  ro_put(src, "new");
+  ro_put(dst, "old");
+  if (!hts_rename_over(src, dst)) {
+    fprintf(stderr, "renameover: replacing an existing dst failed: %s\n",
+            strerror(errno));
+    err++;
+  } else if (!ro_is(dst, "new") || fexist_utf8(src)) {
+    fprintf(stderr, "renameover: dst was not replaced by src\n");
+    err++;
+  }
+
+  /* A missing src must leave dst alone and report failure. */
+  (void) UNLINK(src);
+  ro_put(dst, "keep");
+  if (hts_rename_over(src, dst)) {
+    fprintf(stderr, "renameover: a missing src reported success\n");
+    err++;
+  }
+  if (!ro_is(dst, "keep")) {
+    fprintf(stderr, "renameover: a missing src destroyed dst\n");
+    err++;
+  }
+
+  /* Same, with dst absent too: nothing to lose, still a failure. */
+  (void) UNLINK(dst);
+  if (hts_rename_over(src, dst)) {
+    fprintf(stderr, "renameover: a missing src and dst reported success\n");
+    err++;
+  }
+
+  (void) UNLINK(dst);
+  printf("renameover: %s\n", err ? "FAIL" : "OK");
+  return err;
+}
+
 // -#test=direnum <dir>: enumerate a long+non-ASCII directory via the
 // opendir/readdir wrappers; children must round-trip as UTF-8 (#133,#630).
 static int st_direnum(httrackp *opt, int argc, char **argv) {
@@ -6603,6 +6688,10 @@ static const struct selftest_entry {
     {"mirrorio", "<dir>",
      "round-trip a long+non-ASCII path through the mirror I/O wrappers",
      st_mirrorio},
+    {"renameover", "<dir>",
+     "hts_rename_over(): replace dst, but never delete a dst it did not "
+     "replace",
+     st_renameover},
     {"direnum", "<dir>",
      "enumerate a long+non-ASCII directory through opendir/readdir",
      st_direnum},

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5976,10 +5976,9 @@ static hts_boolean ro_is(const char *path, const char *data) {
   return n == strlen(data) && memcmp(buf, data, n) == 0 ? HTS_TRUE : HTS_FALSE;
 }
 
-// -#test=renameover <dir>: hts_rename_over() must replace an existing dst, and
-// must never delete a dst it did not replace (#779). POSIX rename() clobbers on
-// its own, so the unlink fallback is only reached under the LD_PRELOAD shim the
-// test also runs this under.
+// -#test=renameover <dir>: hts_rename_over() must replace an existing dst and
+// never delete one it did not replace (#779). Which half is live depends on
+// what rename() does to an existing target, so probe that and name the regime.
 static int st_renameover(httrackp *opt, int argc, char **argv) {
   (void) opt;
   if (argc < 1) {
@@ -5992,28 +5991,42 @@ static int st_renameover(httrackp *opt, int argc, char **argv) {
   fconcat(src, sizeof(src), argv[0], "renameover-src.bin");
   fconcat(dst, sizeof(dst), argv[0], "renameover-dst.bin");
 
-  /* Tell the harness whether the unlink fallback is reachable at all here: it
-     is dead unless rename() refuses an existing target, as Windows' does. */
   (void) UNLINK(src);
   (void) UNLINK(dst);
   ro_put(src, "probe");
   ro_put(dst, "probe");
-  if (RENAME(src, dst) != 0)
-    printf("renameover: fallback exercised, rename refuses an existing "
-           "target\n");
 
-  /* An existing dst must still be replaced: that is what the unlink is for. */
+  const int probe = RENAME(src, dst) == 0 ? 0 : errno;
+  /* Only a target in the way is something the unlink can clear. */
+  const hts_boolean replaceable = probe == 0 || probe == EEXIST;
+
+  printf("renameover: regime %s\n",
+         probe == 0 ? "clobber" : (probe == EEXIST ? "fallback" : "refused"));
+
   (void) UNLINK(src);
   (void) UNLINK(dst);
   ro_put(src, "new");
   ro_put(dst, "old");
-  if (!hts_rename_over(src, dst)) {
-    fprintf(stderr, "renameover: replacing an existing dst failed: %s\n",
-            strerror(errno));
-    err++;
-  } else if (!ro_is(dst, "new") || fexist_utf8(src)) {
-    fprintf(stderr, "renameover: dst was not replaced by src\n");
-    err++;
+  if (replaceable) {
+    /* An existing dst must still be replaced: the unlink is for this. */
+    if (!hts_rename_over(src, dst)) {
+      fprintf(stderr, "renameover: replacing an existing dst failed: %s\n",
+              strerror(errno));
+      err++;
+    } else if (!ro_is(dst, "new") || fexist_utf8(src)) {
+      fprintf(stderr, "renameover: dst was not replaced by src\n");
+      err++;
+    }
+  } else {
+    /* A failure the unlink cannot fix must leave dst as it was. */
+    if (hts_rename_over(src, dst)) {
+      fprintf(stderr, "renameover: an unfixable failure reported success\n");
+      err++;
+    }
+    if (!ro_is(dst, "old")) {
+      fprintf(stderr, "renameover: an unfixable failure destroyed dst\n");
+      err++;
+    }
   }
 
   /* A missing src must leave dst alone and report failure. */

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -1451,13 +1451,13 @@ hts_boolean hts_rename_over(const char *src, const char *dst) {
   fconv(cdst, sizeof(cdst), dst);
   if (RENAME(csrc, cdst) == 0)
     return HTS_TRUE;
-  /* Unlink only for the failure the fallback exists for: a dst in the way,
-     which Windows' rename() reports as EACCES (POSIX replaces it silently). A
-     src that was never written must leave dst alone, whatever errno says --
-     the CRT does not promise ENOENT over EACCES when both hold. */
+  /* Only a dst standing in the way is something the unlink can clear, and the
+     CRT reports that as EEXIST (ERROR_ALREADY_EXISTS); it keeps EACCES for a
+     src another process holds, where removing dst would destroy a file the
+     retry then cannot replace. The src check covers a CRT that disagrees. */
   const int err = errno;
 
-  if ((err != EACCES && err != EEXIST) || !fexist_utf8(src))
+  if (err != EEXIST || !fexist_utf8(src))
     return HTS_FALSE;
   (void) UNLINK(cdst);
   return RENAME(csrc, cdst) == 0 ? HTS_TRUE : HTS_FALSE;

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -1452,9 +1452,9 @@ hts_boolean hts_rename_over(const char *src, const char *dst) {
   if (RENAME(csrc, cdst) == 0)
     return HTS_TRUE;
   /* Unlink only for the failure the fallback exists for: a dst in the way,
-     which Windows' rename() reports as EACCES (POSIX replaces it silently). A
-     src that was never written must leave dst alone, whatever errno says --
-     the CRT does not promise ENOENT over EACCES when both hold. */
+     which Windows' rename() reports as EACCES. The errno test alone is not
+     enough, the CRT does not promise ENOENT over EACCES when src is missing
+     too. */
   const int err = errno;
 
   if ((err != EACCES && err != EEXIST) || !fexist_utf8(src))

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -1451,7 +1451,14 @@ hts_boolean hts_rename_over(const char *src, const char *dst) {
   fconv(cdst, sizeof(cdst), dst);
   if (RENAME(csrc, cdst) == 0)
     return HTS_TRUE;
-  /* RENAME does not clobber an existing target on Windows. */
+  /* Unlink only for the failure the fallback exists for: a dst in the way,
+     which Windows' rename() reports as EACCES (POSIX replaces it silently). A
+     src that was never written must leave dst alone, whatever errno says --
+     the CRT does not promise ENOENT over EACCES when both hold. */
+  const int err = errno;
+
+  if ((err != EACCES && err != EEXIST) || !fexist_utf8(src))
+    return HTS_FALSE;
   (void) UNLINK(cdst);
   return RENAME(csrc, cdst) == 0 ? HTS_TRUE : HTS_FALSE;
 }

--- a/src/htstools.h
+++ b/src/htstools.h
@@ -138,8 +138,8 @@ HTSEXT_API hts_boolean hts_findisfile(find_handle find);
 HTSEXT_API hts_boolean hts_findissystem(find_handle find);
 
 /* Move src onto dst, replacing an existing dst; HTS_TRUE on success. Both
-   paths are fconv()'d. dst is never removed unless it is replaced, so a caller
-   whose src was never written keeps its dst. */
+   paths are fconv()'d. dst is only ever removed to make room for src, so a
+   failed call leaves it as it was. */
 hts_boolean hts_rename_over(const char *src, const char *dst);
 
 #endif

--- a/src/htstools.h
+++ b/src/htstools.h
@@ -138,8 +138,9 @@ HTSEXT_API hts_boolean hts_findisfile(find_handle find);
 HTSEXT_API hts_boolean hts_findissystem(find_handle find);
 
 /* Move src onto dst, replacing an existing dst; HTS_TRUE on success. Both
-   paths are fconv()'d. dst is never removed unless it is replaced, so a caller
-   whose src was never written keeps its dst. */
+   paths are fconv()'d. dst is removed only to make room for a src that exists,
+   so a caller whose src was never written keeps its dst; a retry that still
+   fails does not (#790). */
 hts_boolean hts_rename_over(const char *src, const char *dst);
 
 #endif

--- a/src/htstools.h
+++ b/src/htstools.h
@@ -138,7 +138,8 @@ HTSEXT_API hts_boolean hts_findisfile(find_handle find);
 HTSEXT_API hts_boolean hts_findissystem(find_handle find);
 
 /* Move src onto dst, replacing an existing dst; HTS_TRUE on success. Both
-   paths are fconv()'d. */
+   paths are fconv()'d. dst is never removed unless it is replaced, so a caller
+   whose src was never written keeps its dst. */
 hts_boolean hts_rename_over(const char *src, const char *dst);
 
 #endif

--- a/src/htswarc.c
+++ b/src/htswarc.c
@@ -1552,8 +1552,8 @@ static hts_boolean warc_commit(warc_writer *w) {
   if (!w->protect_prev)
     return HTS_TRUE; /* nothing was there to lose: written in place */
 
-  /* hts_rename_over unlinks its destination when the source is missing, so
-     every segment has to be on disk before the first rename. */
+  /* All or nothing: a swap stopping halfway would mix this run's segments with
+     the previous one's, so require every temp before renaming any. */
   swap = w->opened && !w->failed && w->unbacked_revisits == 0;
   for (s = 0; s < nseg && swap; s++) {
     snprintf(tmpbuf, sizeof(tmpbuf), "%s" WARC_TMP_SUFFIX,

--- a/tests/01_engine-renameover.test
+++ b/tests/01_engine-renameover.test
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# Drives -#test=renameover: hts_rename_over() must replace an existing dst, and
+# must leave dst alone when src is missing (#779). The second run interposes a
+# rename() with the Windows shape (refuses an existing target with EACCES),
+# which is the only way to reach the unlink fallback on POSIX.
+dir=$(mktemp -d)
+trap 'rm -rf "$dir"' EXIT
+
+httrack -O /dev/null -#test=renameover "$dir" | grep -q "renameover: OK"
+
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "renameover: LD_PRELOAD interposition is Linux-only here, skipping"
+    exit 0
+fi
+# Not a skip on Linux: a missing module would make the leg vacuous.
+if [ ! -r "${RENAMEFAIL_LIB:-}" ]; then
+    echo "renameover: ${RENAMEFAIL_LIB:-\$RENAMEFAIL_LIB} was not built" >&2
+    exit 1
+fi
+
+out=$(LD_PRELOAD="$RENAMEFAIL_LIB" httrack -O /dev/null \
+    -#test=renameover "$dir")
+echo "$out" | grep -q "renameover: OK"
+# A shim that never fired would make the leg vacuous.
+echo "$out" | grep -q "renameover: fallback exercised"

--- a/tests/01_engine-renameover.test
+++ b/tests/01_engine-renameover.test
@@ -4,26 +4,39 @@
 set -euo pipefail
 
 # Drives -#test=renameover: hts_rename_over() must replace an existing dst, and
-# must leave dst alone when src is missing (#779). The second run interposes a
-# rename() with the Windows shape (refuses an existing target with EACCES),
-# which is the only way to reach the unlink fallback on POSIX.
+# must leave dst alone when the rename failed for a reason removing dst cannot
+# fix (#779). The selftest prints the regime it detected; pin it per platform so
+# a leg cannot pass having tested the other half.
 dir=$(mktemp -d)
 trap 'rm -rf "$dir"' EXIT
 
-httrack -O /dev/null -#test=renameover "$dir" | grep -q "renameover: OK"
+case "$(uname -s)" in
+MINGW* | MSYS_NT*) want=fallback ;; # native rename() refuses an existing target
+*) want=clobber ;;
+esac
+
+out=$(httrack -O /dev/null -#test=renameover "$dir")
+echo "$out" | grep -q "renameover: OK"
+echo "$out" | grep -q "renameover: regime $want"
 
 if [ "$(uname -s)" != "Linux" ]; then
     echo "renameover: LD_PRELOAD interposition is Linux-only here, skipping"
     exit 0
 fi
-# Not a skip on Linux: a missing module would make the leg vacuous.
+# Not a skip on Linux: a missing module would make the interposed legs vacuous.
 if [ ! -r "${RENAMEFAIL_LIB:-}" ]; then
     echo "renameover: ${RENAMEFAIL_LIB:-\$RENAMEFAIL_LIB} was not built" >&2
     exit 1
 fi
 
+# The unlink fallback is dead code on POSIX, so borrow Windows' rename().
 out=$(LD_PRELOAD="$RENAMEFAIL_LIB" httrack -O /dev/null \
     -#test=renameover "$dir")
 echo "$out" | grep -q "renameover: OK"
-# A shim that never fired would make the leg vacuous.
-echo "$out" | grep -q "renameover: fallback exercised"
+echo "$out" | grep -q "renameover: regime fallback"
+
+# A source another process holds fails with EACCES, which dst had no part in.
+out=$(RENAMEFAIL_MODE=locked LD_PRELOAD="$RENAMEFAIL_LIB" httrack -O /dev/null \
+    -#test=renameover "$dir")
+echo "$out" | grep -q "renameover: OK"
+echo "$out" | grep -q "renameover: regime refused"

--- a/tests/01_engine-renameover.test
+++ b/tests/01_engine-renameover.test
@@ -23,11 +23,24 @@ if [ "$(uname -s)" != "Linux" ]; then
     echo "renameover: LD_PRELOAD interposition is Linux-only here, skipping"
     exit 0
 fi
-# Not a skip on Linux: a missing module would make the interposed legs vacuous.
+# A --disable-shared build has nothing to preload; anything else missing is a
+# build problem, not a skip, or the interposed legs would pass vacuously.
+if [ ! -r "${RENAMEFAIL_LA:-}" ]; then
+    echo "renameover: ${RENAMEFAIL_LA:-\$RENAMEFAIL_LA} was not built" >&2
+    exit 1
+fi
+if grep -q "^dlname=''" "$RENAMEFAIL_LA"; then
+    echo "renameover: static-only build, skipping the interposed legs"
+    exit 0
+fi
 if [ ! -r "${RENAMEFAIL_LIB:-}" ]; then
     echo "renameover: ${RENAMEFAIL_LIB:-\$RENAMEFAIL_LIB} was not built" >&2
     exit 1
 fi
+
+# An LD_PRELOAD library loads ahead of the executable's own libasan, which ASan
+# refuses by default. The shim allocates nothing, so the ordering is harmless.
+export ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}verify_asan_link_order=0"
 
 # The unlink fallback is dead code on POSIX, so borrow Windows' rename().
 out=$(LD_PRELOAD="$RENAMEFAIL_LIB" httrack -O /dev/null \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,7 @@
 # Committed binary fixture read by 01_zlib-cache-golden.test. List it
 # explicitly: automake does not expand wildcards in EXTRA_DIST, so a glob would
 # silently drop it from the dist tarball and break "make distcheck".
-EXTRA_DIST = $(TESTS) crawl-test.sh run-all-tests.sh check-network.sh \
+EXTRA_DIST = $(TESTS) renamefail.c crawl-test.sh run-all-tests.sh check-network.sh \
 	proxy-https-server.py socks5-server.py proxy-connect-server.py \
 	proxytestlib.py tls-stall-server.py warc-validate.py wacz-validate.py \
 	pty-resize.py \
@@ -21,6 +21,14 @@ TESTS_ENVIRONMENT += BROTLI_ENABLED=$(BROTLI_ENABLED)
 TESTS_ENVIRONMENT += ZSTD_ENABLED=$(ZSTD_ENABLED)
 TESTS_ENVIRONMENT += V6_SUPPORT=$(V6_SUPPORT)
 TESTS_ENVIRONMENT += top_srcdir=$(top_srcdir)
+TESTS_ENVIRONMENT += RENAMEFAIL_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/librenamefail.so
+
+# rename() interposer for 01_engine-renameover.test; -rpath is what makes
+# libtool build a shared module rather than a static-only convenience library.
+check_LTLIBRARIES = librenamefail.la
+librenamefail_la_SOURCES = renamefail.c
+librenamefail_la_LDFLAGS = -module -avoid-version -rpath $(abs_builddir)
+librenamefail_la_LIBADD = $(DL_LIBS)
 
 TEST_EXTENSIONS = .test
 # Run each .test through bash instead of execve()ing it. This lets "make check"
@@ -74,6 +82,7 @@ TESTS = \
 	01_engine-direnum.test \
 	01_engine-cookieimport.test \
 	01_engine-relative.test \
+	01_engine-renameover.test \
 	01_engine-robots.test \
 	01_engine-savename.test \
 	01_engine-selftest-dispatch.test \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -21,6 +21,7 @@ TESTS_ENVIRONMENT += BROTLI_ENABLED=$(BROTLI_ENABLED)
 TESTS_ENVIRONMENT += ZSTD_ENABLED=$(ZSTD_ENABLED)
 TESTS_ENVIRONMENT += V6_SUPPORT=$(V6_SUPPORT)
 TESTS_ENVIRONMENT += top_srcdir=$(top_srcdir)
+TESTS_ENVIRONMENT += RENAMEFAIL_LA=$(abs_builddir)/librenamefail.la
 TESTS_ENVIRONMENT += RENAMEFAIL_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/librenamefail.so
 
 # rename() interposer for 01_engine-renameover.test; -rpath is what makes

--- a/tests/renamefail.c
+++ b/tests/renamefail.c
@@ -1,0 +1,32 @@
+/* LD_PRELOAD shim giving POSIX rename() the Windows shape: it refuses an
+   existing target with EACCES, and reports that ahead of a missing source.
+   Without it hts_rename_over()'s unlink fallback is unreachable on POSIX. */
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <stddef.h>
+#include <sys/stat.h>
+
+/* The tree builds with -fvisibility=hidden, which would hide the interposer. */
+#define SHIM_EXPORT __attribute__((visibility("default")))
+
+SHIM_EXPORT int rename(const char *oldpath, const char *newpath);
+
+SHIM_EXPORT int rename(const char *oldpath, const char *newpath) {
+  static int (*real_rename)(const char *, const char *) = NULL;
+  struct stat st;
+
+  if (stat(newpath, &st) == 0) {
+    errno = EACCES;
+    return -1;
+  }
+  if (real_rename == NULL) {
+    *(void **) &real_rename = dlsym(RTLD_NEXT, "rename");
+    if (real_rename == NULL) {
+      errno = ENOSYS;
+      return -1;
+    }
+  }
+  return real_rename(oldpath, newpath);
+}

--- a/tests/renamefail.c
+++ b/tests/renamefail.c
@@ -1,11 +1,14 @@
-/* LD_PRELOAD shim giving POSIX rename() the Windows shape: it refuses an
-   existing target with EACCES, and reports that ahead of a missing source.
-   Without it hts_rename_over()'s unlink fallback is unreachable on POSIX. */
+/* Borrows Windows' rename() for 01_engine-renameover.test, since POSIX cannot
+   reach hts_rename_over()'s unlink fallback: an existing target is refused with
+   EEXIST, and RENAMEFAIL_MODE=locked reports EACCES instead, as the CRT does
+   for a source another process holds. */
 
 #define _GNU_SOURCE
 #include <dlfcn.h>
 #include <errno.h>
 #include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 
 /* The tree builds with -fvisibility=hidden, which would hide the interposer. */
@@ -15,10 +18,16 @@ SHIM_EXPORT int rename(const char *oldpath, const char *newpath);
 
 SHIM_EXPORT int rename(const char *oldpath, const char *newpath) {
   static int (*real_rename)(const char *, const char *) = NULL;
+  const char *const mode = getenv("RENAMEFAIL_MODE");
+  const int locked = mode != NULL && strcmp(mode, "locked") == 0;
   struct stat st;
 
-  if (stat(newpath, &st) == 0) {
+  if (locked) {
     errno = EACCES;
+    return -1;
+  }
+  if (stat(newpath, &st) == 0) {
+    errno = EEXIST;
     return -1;
   }
   if (real_rename == NULL) {


### PR DESCRIPTION
The unlink-then-rename fallback in `hts_rename_over()` is there because Windows' rename() refuses an existing target, but it fired on any failed rename, ENOENT on the source included. A caller moving a temp file it never managed to write lost the destination and got `HTS_FALSE` back, which reads as "nothing happened". #754 unified four hand-rolled copies into this helper, so every call site inherited it.

The unlink now runs only for EEXIST, and only with a source that exists. EEXIST is the value that matters: the CRT maps ERROR_ALREADY_EXISTS there and keeps EACCES for a source another process holds, so accepting EACCES as well would have deleted the destination for a failure it had no part in, and the retry would then fail with the destination already gone. The source check is belt and braces for a CRT that reports neither. `hts_rename_utf8()` preserves errno across its free() calls now, since the gate reads it.

The existing call sites all derive their source's existence from a create that had to succeed first, so the bug was latent rather than live, but three of those destinations are user data: a mirrored file, a finished .wacz, and a rewritten page nothing will re-fetch. What is left of the window after this is #790.

The selftest probes what rename() does to an existing target and asserts against the regime it finds, so it runs three ways on Linux: native, then under an LD_PRELOAD rename() with Windows' shape, then under one reporting a locked source. The harness pins the expected regime per platform, so no leg can pass having exercised the other half. Seven mutants of the gate were each confirmed to fail it.

Closes #779