### PR TITLE
A log callback consumes the va_list the log file still needs

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -5790,7 +5790,8 @@ HTSEXT_API void hts_log_vprint(httrackp * opt, int type, const char *format, va_
   if (hts_log_print_callback != NULL) {
     va_list args_copy;
     va_copy(args_copy, args);
-    hts_log_print_callback(opt, type, format, args);
+    /* the copy, so the vfprintf() below still has an unread list */
+    hts_log_print_callback(opt, type, format, args_copy);
     va_end(args_copy);
   }
   if (opt != NULL && opt->log != NULL) {

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2622,6 +2622,58 @@ static int st_savename(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+static char st_log_callback_seen[256];
+
+static void st_log_callback(httrackp *opt, int type, const char *format,
+                            va_list args) {
+  (void) opt;
+  (void) type;
+  (void) vsnprintf(st_log_callback_seen, sizeof(st_log_callback_seen), format,
+                   args);
+}
+
+/* The callback must not consume the va_list the log file's vfprintf() needs. */
+static int st_logcallback(httrackp *opt, int argc, char **argv) {
+  static const char want[] = "42 sentinel";
+  char BIGSTK line[256];
+  FILE *fp;
+  int rc = 1;
+
+  (void) argc;
+  (void) argv;
+
+  fp = tmpfile();
+  if (fp == NULL) {
+    fprintf(stderr, "logcallback: tmpfile() failed\n");
+    return 1;
+  }
+  opt->log = fp;
+  opt->debug = LOG_NOTICE;
+  hts_set_log_vprint_callback(st_log_callback);
+  hts_log_print(opt, LOG_NOTICE, "%d %s", 42, "sentinel");
+  hts_set_log_vprint_callback(NULL);
+  opt->log = NULL;
+
+  rewind(fp);
+  line[0] = '\0';
+  (void) fgets(line, (int) sizeof(line), fp);
+  fclose(fp);
+
+  /* Same arguments both ways; the file line carries a level prefix. */
+  if (strcmp(st_log_callback_seen, want) != 0)
+    fprintf(stderr, "logcallback: callback got '%s' want '%s'\n",
+            st_log_callback_seen, want);
+  else if (strstr(line, want) == NULL)
+    fprintf(stderr, "logcallback: log file got '%s' want it to carry '%s'\n",
+            line, want);
+  else
+    rc = 0;
+
+  if (rc == 0)
+    printf("logcallback self-test OK\n");
+  return rc;
+}
+
 /* an empty fil started htsAddLink's codebase walk before the buffer (#730) */
 static int st_addlink(httrackp *opt, int argc, char **argv) {
   htsmoduleStruct BIGSTK str;
@@ -6824,6 +6876,8 @@ static const struct selftest_entry {
      st_growsize},
     {"addlink", "", "htsAddLink codebase walk over an empty current path",
      st_addlink},
+    {"logcallback", "", "log callback must not consume the log file's va_list",
+     st_logcallback},
     {"cache", "<dir>", "cache read/write round-trip self-test", st_cache},
     {"cacheindex", "", "cache-index (.ndx) parse must stay in bounds",
      st_cacheindex},

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2635,6 +2635,8 @@ static void st_log_callback(httrackp *opt, int type, const char *format,
 /* The callback must not consume the va_list the log file's vfprintf() needs. */
 static int st_logcallback(httrackp *opt, int argc, char **argv) {
   static const char want[] = "42 sentinel";
+  static const char want_filtered[] = "7 filtered";
+  char BIGSTK seen[sizeof(st_log_callback_seen)];
   char BIGSTK line[256];
   FILE *fp;
   int rc = 1;
@@ -2649,23 +2651,34 @@ static int st_logcallback(httrackp *opt, int argc, char **argv) {
   }
   opt->log = fp;
   opt->debug = LOG_NOTICE;
+  st_log_callback_seen[0] = '\0';
   hts_set_log_vprint_callback(st_log_callback);
   hts_log_print(opt, LOG_NOTICE, "%d %s", 42, "sentinel");
   hts_set_log_vprint_callback(NULL);
   opt->log = NULL;
+  strcpybuff(seen, st_log_callback_seen);
 
   rewind(fp);
   line[0] = '\0';
   (void) fgets(line, (int) sizeof(line), fp);
   fclose(fp);
 
+  /* The callback runs above the level filter and without a log file at all;
+     the front-ends that install one usually have no opt->log open. */
+  st_log_callback_seen[0] = '\0';
+  hts_set_log_vprint_callback(st_log_callback);
+  hts_log_print(opt, LOG_DEBUG, "%d %s", 7, "filtered");
+  hts_set_log_vprint_callback(NULL);
+
   /* Same arguments both ways; the file line carries a level prefix. */
-  if (strcmp(st_log_callback_seen, want) != 0)
-    fprintf(stderr, "logcallback: callback got '%s' want '%s'\n",
-            st_log_callback_seen, want);
+  if (strcmp(seen, want) != 0)
+    fprintf(stderr, "logcallback: callback got '%s' want '%s'\n", seen, want);
   else if (strstr(line, want) == NULL)
     fprintf(stderr, "logcallback: log file got '%s' want it to carry '%s'\n",
             line, want);
+  else if (strcmp(st_log_callback_seen, want_filtered) != 0)
+    fprintf(stderr, "logcallback: unfiltered callback got '%s' want '%s'\n",
+            st_log_callback_seen, want_filtered);
   else
     rc = 0;
 

--- a/tests/01_engine-logcallback.test
+++ b/tests/01_engine-logcallback.test
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# a log callback consumed the va_list the log file's vfprintf() still needed.
+# a log callback consumed the va_list the log file's vfprintf() still needed (#801).
 
 set -euo pipefail
 

--- a/tests/01_engine-logcallback.test
+++ b/tests/01_engine-logcallback.test
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# a log callback consumed the va_list the log file's vfprintf() still needed.
+
+set -euo pipefail
+
+httrack -O /dev/null -#test=logcallback | grep -q "logcallback self-test OK"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -71,6 +71,7 @@ TESTS = \
 	01_engine-escape-room.test \
 	01_engine-inplace-escape.test \
 	01_engine-lastchar.test \
+	01_engine-logcallback.test \
 	01_engine-makeindex.test \
 	01_engine-mime.test \
 	01_engine-parse.test \


### PR DESCRIPTION
hts_log_vprint() builds a va_copy and never uses it: the callback gets the caller's own va_list, then vfprintf() writes the log file from the list the callback just consumed. The second pass reads past the register save area, so %d comes out 0 and %s becomes a junk pointer that vfprintf() dereferences.

Nothing hits this unless an embedder installs a log callback, which is why the CLI never has. HTTrack Android installs one, and `--sitemap` added the first LOG_NOTICE lines there that carry arguments: ticking its checkbox segfaults the crawl thread on a device, while the same crawl is clean under the CLI built with ASan+UBSan. Found while device-testing the new option checkboxes in the Android app.

New `-#test=logcallback` sends one log line with a %d and a %s through both sinks and compares them. It fails on the unfixed code (the file gets `0 `) and passes with the copy.