### PR TITLE
The format check diffs against master's moving tip instead of the branch's merge base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,7 +627,12 @@ jobs:
           set -euo pipefail
           git fetch --no-tags origin \
             "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
-          base="origin/${{ github.base_ref }}"
+          # Merge base, not the branch tip: master moves during a run, and a
+          # tip-relative diff blames its new C on this PR.
+          if ! base="$(git merge-base "origin/${{ github.base_ref }}" HEAD)"; then
+            echo "::error::no merge base with origin/${{ github.base_ref }}; cannot scope the check."
+            exit 1
+          fi
           set +e
           diff="$(git clang-format --binary clang-format-19 --style=file \
                     --diff --extensions c,h "$base")"
@@ -669,6 +674,8 @@ jobs:
           git fetch --no-tags origin \
             "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
           base="origin/${{ github.base_ref }}"
+          # Three dots: merge-base scoped, so commits landing on master mid-run
+          # are not counted as this PR's.
           changed="$(git diff --name-only "$base"...HEAD)"
           has() { printf '%s\n' "$changed" | grep -qx "$1"; }
           if has man/httrack.1 && ! has html/httrack.man.html; then


### PR DESCRIPTION
The changed-lines clang-format job took its base from `origin/master`, which is master's tip when the job runs, not the point the branch left master. Once master gains a C commit while a PR sits open, the diff also contains the reverse of that commit, and the job fails on code the PR never touched. #796 hit this twice in a row with a branch carrying no C at all.

Using `git merge-base` puts the comparison back on the branch's own changes. The checkout already uses `fetch-depth: 0` and the step refetches the base branch, so the merge base is there; if it ever is not, the step now stops with an error rather than quietly comparing the whole tree.

I checked it on a branch seven commits behind master with one format-clean C addition: today's step prints 171 lines of someone else's diff and exits 1, the patched step exits 0, and a deliberately misformatted line is still caught. The man-page-sync job next door already diffs with three dots, which is merge-base scoped, so it only got a comment saying so.

Closes #800
