### PR TITLE
PT_GetTime hands out gmtime's shared static instead of a reentrant breakdown

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -2703,17 +2703,8 @@ void hts_now_iso8601(char out[32]) {
   time_t t = time(NULL);
   struct tm tmv;
 
-#if defined(_WIN32)
-  struct tm *g = gmtime(&t);
-
-  if (g != NULL)
-    tmv = *g;
-  else
+  if (!hts_gmtime(t, &tmv))
     memset(&tmv, 0, sizeof(tmv));
-#else
-  if (gmtime_r(&t, &tmv) == NULL)
-    memset(&tmv, 0, sizeof(tmv));
-#endif
   strftime(out, 32, "%Y-%m-%dT%H:%M:%SZ", &tmv);
 }
 

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -157,6 +157,19 @@ struct t_dnscache {
   char host_addr[HTS_MAXADDRNUM][HTS_MAXADDRLEN];
 };
 
+/* Break t down as UTC into the caller's buffer, HTS_FALSE if that failed.
+   gmtime()'s static is shared, and both the engine and ProxyTrack convert on
+   worker threads. */
+static HTS_INLINE HTS_UNUSED hts_boolean hts_gmtime(time_t t,
+                                                    struct tm *tmbuf) {
+#ifdef _WIN32
+  /* Microsoft's gmtime_s takes the destination first, unlike C11 Annex K. */
+  return gmtime_s(tmbuf, &t) == 0 ? HTS_TRUE : HTS_FALSE;
+#else
+  return gmtime_r(&t, tmbuf) != NULL ? HTS_TRUE : HTS_FALSE;
+#endif
+}
+
 /* Library internal definictions */
 #ifdef HTS_INTERNAL_BYTECODE
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6524,6 +6524,102 @@ static int st_threadwait(httrackp *opt, int argc, char **argv) {
   return err;
 }
 
+/* #794: hts_gmtime() must own its output. The table is an independent oracle;
+   the threaded phase is what corrupts if it ever goes back to gmtime()'s
+   shared static. */
+#define GMTIME_THREADS 8
+#define GMTIME_ROUNDS 50000
+
+static const struct {
+  time_t t;
+  int year, mon, mday, hour, min, sec, wday, yday;
+} gmtime_refs[] = {
+    {(time_t) 0, 70, 0, 1, 0, 0, 0, 4, 0},
+    {(time_t) 951782400, 100, 1, 29, 0, 0, 0, 2, 59}, /* a leap day */
+    {(time_t) 1000000000, 101, 8, 9, 1, 46, 40, 0, 251},
+    {(time_t) 2147483647, 138, 0, 19, 3, 14, 7, 2, 18}, /* 32-bit ceiling */
+};
+
+#define GMTIME_REFS ((int) (sizeof(gmtime_refs) / sizeof(gmtime_refs[0])))
+
+static hts_boolean gmtime_ref_matches(int i, const struct tm *tm) {
+  if (tm->tm_year != gmtime_refs[i].year || tm->tm_mon != gmtime_refs[i].mon ||
+      tm->tm_mday != gmtime_refs[i].mday ||
+      tm->tm_hour != gmtime_refs[i].hour || tm->tm_min != gmtime_refs[i].min ||
+      tm->tm_sec != gmtime_refs[i].sec || tm->tm_wday != gmtime_refs[i].wday ||
+      tm->tm_yday != gmtime_refs[i].yday)
+    return HTS_FALSE;
+  return HTS_TRUE;
+}
+
+static htsmutex gmtime_lock = HTSMUTEX_INIT;
+static int gmtime_bad = 0;
+
+static void gmtime_thread(void *arg) {
+  const int i = *(const int *) arg;
+  int bad = 0, round;
+
+  for (round = 0; round < GMTIME_ROUNDS; round++) {
+    struct tm tmv;
+
+    if (!hts_gmtime(gmtime_refs[i].t, &tmv) || !gmtime_ref_matches(i, &tmv))
+      bad++;
+  }
+  hts_mutexlock(&gmtime_lock);
+  gmtime_bad += bad;
+  hts_mutexrelease(&gmtime_lock);
+}
+
+static int st_gmtime(httrackp *opt, int argc, char **argv) {
+  static int idx[GMTIME_THREADS];
+  struct tm first, second;
+  int err = 0, i;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+
+  for (i = 0; i < GMTIME_REFS; i++) {
+    struct tm tmv;
+
+    if (!hts_gmtime(gmtime_refs[i].t, &tmv)) {
+      fprintf(stderr, "gmtime: conversion #%d failed\n", i);
+      err = 1;
+    } else if (!gmtime_ref_matches(i, &tmv)) {
+      fprintf(stderr,
+              "gmtime: #%d gave %04d-%02d-%02d %02d:%02d:%02d (wday %d, "
+              "yday %d)\n",
+              i, tmv.tm_year + 1900, tmv.tm_mon + 1, tmv.tm_mday, tmv.tm_hour,
+              tmv.tm_min, tmv.tm_sec, tmv.tm_wday, tmv.tm_yday);
+      err = 1;
+    }
+  }
+
+  /* the first result must survive the second call */
+  if (hts_gmtime(gmtime_refs[0].t, &first) &&
+      hts_gmtime(gmtime_refs[1].t, &second) && !gmtime_ref_matches(0, &first)) {
+    fprintf(stderr, "gmtime: a second conversion disturbed the first\n");
+    err = 1;
+  }
+
+  for (i = 0; i < GMTIME_THREADS; i++) {
+    idx[i] = i % GMTIME_REFS;
+    if (hts_newthread(gmtime_thread, &idx[i]) != 0) {
+      fprintf(stderr, "gmtime: cannot spawn\n");
+      return 1;
+    }
+  }
+  htsthread_wait();
+  if (gmtime_bad != 0) {
+    fprintf(stderr, "gmtime: %d/%d concurrent conversions were corrupt\n",
+            gmtime_bad, GMTIME_THREADS * GMTIME_ROUNDS);
+    err = 1;
+  }
+
+  printf("gmtime self-test: %s\n", err ? "FAIL" : "OK");
+  return err;
+}
+
 #define CHANGES_RACE_FILES 8
 #define CHANGES_RACE_ROUNDS 400
 
@@ -6790,6 +6886,8 @@ static const struct selftest_entry {
      st_changes_race},
     {"threadwait", "", "htsthread_wait() joins threads spawned just before it",
      st_threadwait},
+    {"gmtime", "",
+     "hts_gmtime() fills the caller's buffer, not a static (#794)", st_gmtime},
     {"backswap", "", "which backlog slots may be swapped to the ready table",
      st_backswap},
     {"pause", "", "randomized inter-file pause target self-test", st_pause},

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6664,10 +6664,10 @@ static int st_gmtime(httrackp *opt, int argc, char **argv) {
      Out of range for a 64-bit time_t: NULL from gmtime_r, EINVAL from
      _gmtime64_s. */
   if (sizeof(time_t) >= 8) {
-    const time_t far = (time_t) INT64_MAX;
+    const time_t beyond = (time_t) INT64_MAX;
     struct tm tmv;
 
-    if (hts_gmtime(far, &tmv)) {
+    if (hts_gmtime(beyond, &tmv)) {
       fprintf(stderr,
               "gmtime: an out-of-range time_t was reported converted\n");
       err = 1;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6637,7 +6637,6 @@ static void gmtime_thread(void *arg) {
 
 static int st_gmtime(httrackp *opt, int argc, char **argv) {
   static int idx[GMTIME_THREADS];
-  struct tm first, second;
   int err = 0, i;
 
   (void) opt;
@@ -6660,11 +6659,19 @@ static int st_gmtime(httrackp *opt, int argc, char **argv) {
     }
   }
 
-  /* the first result must survive the second call */
-  if (hts_gmtime(gmtime_refs[0].t, &first) &&
-      hts_gmtime(gmtime_refs[1].t, &second) && !gmtime_ref_matches(0, &first)) {
-    fprintf(stderr, "gmtime: a second conversion disturbed the first\n");
-    err = 1;
+  /* the return is the only failure signal the callers have, so a helper that
+     always claims success leaves them formatting an uninitialised struct tm.
+     Out of range for a 64-bit time_t: NULL from gmtime_r, EINVAL from
+     _gmtime64_s. */
+  if (sizeof(time_t) >= 8) {
+    const time_t far = (time_t) INT64_MAX;
+    struct tm tmv;
+
+    if (hts_gmtime(far, &tmv)) {
+      fprintf(stderr,
+              "gmtime: an out-of-range time_t was reported converted\n");
+      err = 1;
+    }
   }
 
   for (i = 0; i < GMTIME_THREADS; i++) {

--- a/src/htswarc.c
+++ b/src/htswarc.c
@@ -1392,16 +1392,8 @@ warc_writer *warc_open(httrackp *opt, const char *path) {
     char ts[32];
     time_t t = time(NULL);
     struct tm tmv;
-#if defined(_WIN32)
-    struct tm *g = gmtime(&t);
-    if (g != NULL)
-      tmv = *g;
-    else
+    if (!hts_gmtime(t, &tmv))
       memset(&tmv, 0, sizeof(tmv));
-#else
-    if (gmtime_r(&t, &tmv) == NULL)
-      memset(&tmv, 0, sizeof(tmv));
-#endif
     strftime(ts, sizeof(ts), "%Y%m%d%H%M%S", &tmv);
     snprintf(catbuff, sizeof(catbuff), "httrack-%s.warc.gz", ts);
     path =

--- a/src/proxy/proxytrack.c
+++ b/src/proxy/proxytrack.c
@@ -520,12 +520,13 @@ static void proxytrack_add_DAV_Item(String * item, String * buff,
                                     const char *filename, size_t size,
                                     time_t timestamp, const char *mime,
                                     int isDir, int isRoot, int isDefault) {
-  struct tm *timetm;
+  struct tm timetmbuf;
+  struct tm *timetm = &timetmbuf;
 
   if (timestamp == (time_t) 0 || timestamp == (time_t) - 1) {
     timestamp = time(NULL);
   }
-  if ((timetm = gmtime(&timestamp)) != NULL) {
+  if (hts_gmtime(timestamp, timetm)) {
     char tms[256 + 1];
     const char *name;
 

--- a/src/proxy/proxytrack.h
+++ b/src/proxy/proxytrack.h
@@ -360,21 +360,14 @@ HTS_UNUSED static struct tm *convert_time_rfc822(struct tm *result, const char *
 HTS_UNUSED static struct tm PT_GetTime(time_t t) {
   struct tm tmbuf;
 
-#ifdef _WIN32
-  struct tm *tm = gmtime(&t);
-#else
-  struct tm *tm = gmtime_r(&t, &tmbuf);
-#endif
-  if (tm != NULL)
-    return *tm;
-  else {
+  if (!hts_gmtime(t, &tmbuf)) {
     /* an all-zero tm has tm_mday == 0, which the ARC date field prints as a
        day of "00"; the epoch is the conventional "date unknown" */
     memset(&tmbuf, 0, sizeof(tmbuf));
     tmbuf.tm_year = 70;
     tmbuf.tm_mday = 1;
-    return tmbuf;
   }
+  return tmbuf;
 }
 HTS_UNUSED static int set_filetime(const char *file, struct tm *tm_time) {
   struct utimbuf tim;

--- a/tests/01_engine-changes.test
+++ b/tests/01_engine-changes.test
@@ -3,26 +3,13 @@
 
 set -euo pipefail
 
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_changes_st.XXXXXX") || exit 1
 trap 'set +e; rm -rf "$tmpdir"' EXIT
 trap 'rm -rf "$tmpdir"' HUP INT QUIT PIPE TERM
-
-# No pipe into grep: SIGPIPE would mask a failing exit status.
-expect_ok() {
-    local label="$1" out
-    shift
-    out=$("$@" 2>&1) || {
-        echo "FAIL: ${label} exited non-zero: ${out}"
-        exit 1
-    }
-    case "$out" in
-    *"${label}: OK"*) ;;
-    *)
-        echo "FAIL: ${out}"
-        exit 1
-        ;;
-    esac
-}
 
 # --changes bucket accounting and JSON escaping (#714).
 expect_ok "changes self-test" httrack -O "${tmpdir}/o1" -#test=changes run

--- a/tests/01_engine-gmtime.test
+++ b/tests/01_engine-gmtime.test
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_gmtime_st.XXXXXX") || exit 1
+trap 'set +e; rm -rf "$tmpdir"' EXIT
+trap 'rm -rf "$tmpdir"' HUP INT QUIT PIPE TERM
+
+# No pipe into grep: SIGPIPE would mask a failing exit status.
+expect_ok() {
+    local label="$1" out
+    shift
+    out=$("$@" 2>&1) || {
+        echo "FAIL: ${label} exited non-zero: ${out}"
+        exit 1
+    }
+    case "$out" in
+    *"${label}: OK"*) ;;
+    *)
+        echo "FAIL: ${out}"
+        exit 1
+        ;;
+    esac
+}
+
+# Concurrent conversions do not tread on each other the way gmtime()'s shared
+# static does (#794).
+expect_ok "gmtime self-test" httrack -O "${tmpdir}/o1" -#test=gmtime

--- a/tests/01_engine-gmtime.test
+++ b/tests/01_engine-gmtime.test
@@ -3,26 +3,18 @@
 
 set -euo pipefail
 
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+# A non-UTC zone, so a helper that reached for localtime instead of gmtime gives
+# a different answer: CI runners are UTC, where the two agree.
+TZ=XXX5
+export TZ
+
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_gmtime_st.XXXXXX") || exit 1
 trap 'set +e; rm -rf "$tmpdir"' EXIT
 trap 'rm -rf "$tmpdir"' HUP INT QUIT PIPE TERM
-
-# No pipe into grep: SIGPIPE would mask a failing exit status.
-expect_ok() {
-    local label="$1" out
-    shift
-    out=$("$@" 2>&1) || {
-        echo "FAIL: ${label} exited non-zero: ${out}"
-        exit 1
-    }
-    case "$out" in
-    *"${label}: OK"*) ;;
-    *)
-        echo "FAIL: ${out}"
-        exit 1
-        ;;
-    esac
-}
 
 # Concurrent conversions do not tread on each other the way gmtime()'s shared
 # static does (#794).

--- a/tests/01_engine-threadwait.test
+++ b/tests/01_engine-threadwait.test
@@ -3,26 +3,13 @@
 
 set -euo pipefail
 
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_threadwait_st.XXXXXX") || exit 1
 trap 'set +e; rm -rf "$tmpdir"' EXIT
 trap 'rm -rf "$tmpdir"' HUP INT QUIT PIPE TERM
-
-# No pipe into grep: SIGPIPE would mask a failing exit status.
-expect_ok() {
-    local label="$1" out
-    shift
-    out=$("$@" 2>&1) || {
-        echo "FAIL: ${label} exited non-zero: ${out}"
-        exit 1
-    }
-    case "$out" in
-    *"${label}: OK"*) ;;
-    *)
-        echo "FAIL: ${out}"
-        exit 1
-        ;;
-    esac
-}
 
 # A thread is outstanding from the moment hts_newthread() returns, so a wait
 # that follows the spawn joins it, and wait_n(n) still leaves n behind (#747).

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -64,6 +64,7 @@ TESTS = \
 	01_engine-filterdual.test \
 	01_engine-ftp-line.test \
 	01_engine-ftp-userpass.test \
+	01_engine-gmtime.test \
 	01_engine-backswap.test \
 	01_engine-cacheindex.test \
 	01_engine-hashtable.test \

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -24,6 +24,24 @@ nativepath() {
     fi
 }
 
+# Run an engine self-test and require its "<label>: OK" line. No pipe into grep:
+# SIGPIPE would mask a failing exit status.
+expect_ok() {
+    local label="$1" out
+    shift
+    out=$("$@" 2>&1) || {
+        echo "FAIL: ${label} exited non-zero: ${out}"
+        exit 1
+    }
+    case "$out" in
+    *"${label}: OK"*) ;;
+    *)
+        echo "FAIL: ${out}"
+        exit 1
+        ;;
+    esac
+}
+
 is_windows() {
     case "$(uname -s)" in
     MINGW* | MSYS* | CYGWIN*) return 0 ;;


### PR DESCRIPTION
On Windows, PT_GetTime took gmtime()'s pointer and dereferenced it a statement later, so the breakdown it handed out could have been rewritten by another thread's conversion in between. The POSIX branch was already reentrant through gmtime_r, and the same `#ifdef` pair had been copy-pasted into `hts_now_iso8601()` and the WARC auto-name, so all three now go through one `hts_gmtime()` helper instead of the Windows arm getting a local patch. ProxyTrack's WebDAV listing gets it too; that one reads the static's fields well past the `strftime()`, a much wider window than PT_GetTime's.

Windows uses Microsoft's `gmtime_s` (destination first, `errno_t` return), not the C11 Annex K function that shares the name and swaps the arguments.

Two bare `gmtime()` calls stay as they are. `time_gmt_rfc822()` and `get_filetime_rfc822()` hold the static across a `strftime()` on both platforms, but their `localtime()` failure fallback needs a decision of its own, since falling back to local time and then labelling the result GMT is wrong whichever thread wins. Both are tracked in #806 with the `localtime()` readers.

The new `gmtime` engine self-test also runs on the MSVC legs, which is where the argument order needs proving. A reference table pins the breakdown for four timestamps, a forced out-of-range conversion pins the failure return that all three callers key their fallback off, and eight threads hammering the helper catch any return to the shared static. Mutants: copying out of `gmtime()`'s static corrupts 16k of 400k concurrent conversions, discarding `gmtime_r`'s NULL trips the failure row, and `localtime_r` trips the reference table. The test exports a non-UTC `TZ`, without which that last mutant passes on a UTC CI runner.

Closes #794