### PR TITLE
grep -q SIGPIPEs the producer feeding it, so an assertion that held reports failure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,12 +30,14 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   failing cleanup command becomes the test's exit status (#773). Keep the other
   signals on their own `trap` line, or errexit stays off for the rest of the run.
   The guard also resets `$?`, so save it first if teardown reads it.
-- Never assert with `cmd | grep -q MARKER && fail`. Under `pipefail` the
-  pipeline is non-zero both when `cmd` fails and when `grep -q` matches early
-  and SIGPIPEs it, so the `&&` never fires and a probe that proved nothing reads
-  as "marker absent". Capture the reply, assert the status line it must carry
-  (an empty, truncated or redirected one is marker-free too), then match with a
-  here-string.
+- Never pipe into `grep -q`: it exits on the first match, so whatever the
+  producer had left to write takes SIGPIPE, and under `pipefail` that becomes
+  the pipeline's status. `cmd | grep -q M && fail` then never fires and a probe
+  that proved nothing reads as "marker absent"; `cmd | grep -q M || fail` fails
+  a test whose marker was present. bash issues one `write()` per line, so any
+  match that is not on the last line is exposed. Capture the reply, assert the
+  status line it must carry (an empty, truncated or redirected one is
+  marker-free too), then match with a here-string: `grep -q M <<<"$reply"`.
 
 ## Hard invariants
 - **Generated autotools files are NOT in git.** `configure`, every

--- a/tests/01_engine-addlink.test
+++ b/tests/01_engine-addlink.test
@@ -4,4 +4,5 @@
 
 set -euo pipefail
 
-httrack -O /dev/null -#test=addlink | grep -q "addlink self-test OK"
+out=$(httrack -O /dev/null -#test=addlink)
+grep -q "addlink self-test OK" <<<"$out"

--- a/tests/01_engine-backswap.test
+++ b/tests/01_engine-backswap.test
@@ -5,4 +5,5 @@ set -euo pipefail
 
 # A ready slot still owning a temporary must stay in memory: swapping it out
 # clears the entry, which unlinks the re-fetch backup (#771).
-httrack -O /dev/null -#test=backswap | grep -q "backswap self-test: OK"
+out=$(httrack -O /dev/null -#test=backswap)
+grep -q "backswap self-test: OK" <<<"$out"

--- a/tests/01_engine-cmdline-split.test
+++ b/tests/01_engine-cmdline-split.test
@@ -5,4 +5,5 @@ set -euo pipefail
 
 # webhttrack posts its command line as one string: the argv split must grow past
 # 1024 arguments and keep a quote inside a value out of the option parser.
-httrack -O /dev/null -#test=cmdline-split run | grep -q "cmdline-split self-test OK"
+out=$(httrack -O /dev/null -#test=cmdline-split run)
+grep -q "cmdline-split self-test OK" <<<"$out"

--- a/tests/01_engine-cookieimport.test
+++ b/tests/01_engine-cookieimport.test
@@ -9,4 +9,5 @@ set -euo pipefail
 dir=$(mktemp -d)
 trap 'set +e; rm -rf "$dir"' EXIT
 
-httrack -O /dev/null -#test=cookieimport "$dir" | grep -q "cookieimport:.*OK"
+out=$(httrack -O /dev/null -#test=cookieimport "$dir")
+grep -q "cookieimport:.*OK" <<<"$out"

--- a/tests/01_engine-direnum.test
+++ b/tests/01_engine-direnum.test
@@ -8,4 +8,5 @@ set -euo pipefail
 dir=$(mktemp -d)
 trap 'set +e; rm -rf "$dir"' EXIT
 
-httrack -O /dev/null -#test=direnum "$dir" | grep -q "direnum:.*OK"
+out=$(httrack -O /dev/null -#test=direnum "$dir")
+grep -q "direnum:.*OK" <<<"$out"

--- a/tests/01_engine-escape-room.test
+++ b/tests/01_engine-escape-room.test
@@ -4,4 +4,5 @@
 set -euo pipefail
 
 # HT_ADD_HTMLESCAPED* must reserve the escaper's worst case (6 for _full).
-httrack -O /dev/null -#test=escape-room run | grep -q "escape-room self-test OK"
+out=$(httrack -O /dev/null -#test=escape-room run)
+grep -q "escape-room self-test OK" <<<"$out"

--- a/tests/01_engine-footer-overflow.test
+++ b/tests/01_engine-footer-overflow.test
@@ -50,7 +50,7 @@ httrack "file://$deep/index.html" -O "$mir" -%F "$footer" -q -s0 -%v0 \
 
 # The crawled page must exist (proves the URL wasn't rejected for length, so the
 # footer path ran). Look under file/, not $mir, to skip the makeindex top index.
-find "$mir/file" -name index.html | grep -q . || {
+test -n "$(find "$mir/file" -name index.html)" || {
     echo "page not mirrored; the oversized-footer path was not exercised" >&2
     exit 1
 }

--- a/tests/01_engine-ftp-line.test
+++ b/tests/01_engine-ftp-line.test
@@ -4,4 +4,5 @@
 set -euo pipefail
 
 # get_ftp_line bounds a hostile CRLF-less FTP reply into its 1024-byte buffer.
-httrack -O /dev/null -#test=ftp-line run | grep -q "ftp-line self-test OK"
+out=$(httrack -O /dev/null -#test=ftp-line run)
+grep -q "ftp-line self-test OK" <<<"$out"

--- a/tests/01_engine-ftp-userpass.test
+++ b/tests/01_engine-ftp-userpass.test
@@ -4,4 +4,5 @@
 set -euo pipefail
 
 # ftp_split_userpass bounds an over-long user:pass@ from a hostile ftp:// URL.
-httrack -O /dev/null -#test=ftp-userpass run | grep -q "ftp-userpass self-test OK"
+out=$(httrack -O /dev/null -#test=ftp-userpass run)
+grep -q "ftp-userpass self-test OK" <<<"$out"

--- a/tests/01_engine-growsize.test
+++ b/tests/01_engine-growsize.test
@@ -19,7 +19,7 @@ printf -- '-*/zzmarker*\n' >"$tmp/rules.txt"
 # the rules file lands in the URL/filter string, echoed back by the banner
 run=$(httrack -O "$tmp/out" --quiet -n "-%S" "$tmp/rules.txt" \
     "file://$tmp/index.html" 2>&1) || true
-printf '%s\n' "$run" | grep -q 'zzmarker' || {
+grep -q 'zzmarker' <<<"$run" || {
     echo "FAIL: -%S rules file was not loaded"
     printf '%s\n' "$run"
     exit 1

--- a/tests/01_engine-hashtable.test
+++ b/tests/01_engine-hashtable.test
@@ -6,4 +6,4 @@ set -euo pipefail
 # httrack internal hashtable autotest on 100K keys. Assert the success line (on
 # stderr) so a misrouted registry entry can't pass on exit code alone.
 out=$(httrack -#test=hashtable 100000 2>&1)
-printf '%s\n' "$out" | grep -q "all hashtable tests were successful!" || exit 1
+grep -q "all hashtable tests were successful!" <<<"$out" || exit 1

--- a/tests/01_engine-inplace-escape.test
+++ b/tests/01_engine-inplace-escape.test
@@ -4,4 +4,5 @@
 set -euo pipefail
 
 # inplace_escape_*() must match escape_*() on a copy: guards the shared helper.
-httrack -O /dev/null -#test=inplace-escape run | grep -q "inplace-escape self-test OK"
+out=$(httrack -O /dev/null -#test=inplace-escape run)
+grep -q "inplace-escape self-test OK" <<<"$out"

--- a/tests/01_engine-logcallback.test
+++ b/tests/01_engine-logcallback.test
@@ -4,4 +4,5 @@
 
 set -euo pipefail
 
-httrack -O /dev/null -#test=logcallback | grep -q "logcallback self-test OK"
+out=$(httrack -O /dev/null -#test=logcallback)
+grep -q "logcallback self-test OK" <<<"$out"

--- a/tests/01_engine-longpath-io.test
+++ b/tests/01_engine-longpath-io.test
@@ -8,4 +8,5 @@ set -euo pipefail
 dir=$(mktemp -d)
 trap 'set +e; rm -rf "$dir"' EXIT
 
-httrack -O /dev/null -#test=longpath "$dir" | grep -q "longpath:.*OK"
+out=$(httrack -O /dev/null -#test=longpath "$dir")
+grep -q "longpath:.*OK" <<<"$out"

--- a/tests/01_engine-mirror-io.test
+++ b/tests/01_engine-mirror-io.test
@@ -9,4 +9,5 @@ set -euo pipefail
 dir=$(mktemp -d)
 trap 'set +e; rm -rf "$dir"' EXIT
 
-httrack -O /dev/null -#test=mirrorio "$dir" | grep -q "mirrorio:.*OK"
+out=$(httrack -O /dev/null -#test=mirrorio "$dir")
+grep -q "mirrorio:.*OK" <<<"$out"

--- a/tests/01_engine-redirect.test
+++ b/tests/01_engine-redirect.test
@@ -6,4 +6,5 @@ set -euo pipefail
 # #159: a redirect to a same-file alias (http<->https, user@host, ..) must be
 # followed through, not turned into a self-pointing "moved" stub. The decision
 # helper is exercised by the engine self-test.
-httrack -O /dev/null -#test=redirect-samefile run | grep -q "redirect-samefile self-test OK"
+out=$(httrack -O /dev/null -#test=redirect-samefile run)
+grep -q "redirect-samefile self-test OK" <<<"$out"

--- a/tests/01_engine-renameover.test
+++ b/tests/01_engine-renameover.test
@@ -16,8 +16,8 @@ MINGW* | MSYS_NT*) want=fallback ;; # native rename() refuses an existing target
 esac
 
 out=$(httrack -O /dev/null -#test=renameover "$dir")
-echo "$out" | grep -q "renameover: OK"
-echo "$out" | grep -q "renameover: regime $want"
+grep -q "renameover: OK" <<<"$out"
+grep -q "renameover: regime $want" <<<"$out"
 
 if [ "$(uname -s)" != "Linux" ]; then
     echo "renameover: LD_PRELOAD interposition is Linux-only here, skipping"
@@ -45,11 +45,11 @@ export ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}verify_asan_link_order=0"
 # The unlink fallback is dead code on POSIX, so borrow Windows' rename().
 out=$(LD_PRELOAD="$RENAMEFAIL_LIB" httrack -O /dev/null \
     -#test=renameover "$dir")
-echo "$out" | grep -q "renameover: OK"
-echo "$out" | grep -q "renameover: regime fallback"
+grep -q "renameover: OK" <<<"$out"
+grep -q "renameover: regime fallback" <<<"$out"
 
 # A source another process holds fails with EACCES, which dst had no part in.
 out=$(RENAMEFAIL_MODE=locked LD_PRELOAD="$RENAMEFAIL_LIB" httrack -O /dev/null \
     -#test=renameover "$dir")
-echo "$out" | grep -q "renameover: OK"
-echo "$out" | grep -q "renameover: regime refused"
+grep -q "renameover: OK" <<<"$out"
+grep -q "renameover: regime refused" <<<"$out"

--- a/tests/01_engine-robots.test
+++ b/tests/01_engine-robots.test
@@ -4,4 +4,5 @@
 set -euo pipefail
 
 # robots.txt RFC 9309 Allow/Disallow precedence (#452): longest match wins.
-httrack -O /dev/null -#test=robots run | grep -q "robots self-test OK"
+out=$(httrack -O /dev/null -#test=robots run)
+grep -q "robots self-test OK" <<<"$out"

--- a/tests/01_engine-selftest-dispatch.test
+++ b/tests/01_engine-selftest-dispatch.test
@@ -7,11 +7,11 @@ set -eu
 
 # Bare -#test lists known tests (printed to stderr).
 list=$(httrack -#test 2>&1)
-printf '%s\n' "$list" | grep -q "filter" || exit 1
-printf '%s\n' "$list" | grep -q "cache-writefail" || exit 1
+grep -q "filter" <<<"$list" || exit 1
+grep -q "cache-writefail" <<<"$list" || exit 1
 
 # Unknown name: non-zero exit + diagnostic, and no test result line.
 rc=0
 err=$(httrack -#test=bogus 2>&1) || rc=$?
 test "$rc" -ne 0 || exit 1
-printf '%s\n' "$err" | grep -q "Unknown self-test" || exit 1
+grep -q "Unknown self-test" <<<"$err" || exit 1

--- a/tests/01_engine-socks5.test
+++ b/tests/01_engine-socks5.test
@@ -6,4 +6,5 @@ set -euo pipefail
 # The SOCKS5 handshake framing and credential split, driven against scripted
 # server replies (frame draining, oversize rejects, RFC 1929 fields).
 
-httrack -O /dev/null '-#test=socks5' | grep -q "socks5 self-test OK"
+out=$(httrack -O /dev/null '-#test=socks5')
+grep -q "socks5 self-test OK" <<<"$out"

--- a/tests/01_engine-status.test
+++ b/tests/01_engine-status.test
@@ -4,4 +4,5 @@
 set -euo pipefail
 
 # HTTP status -> reason phrase, including the modern 429/451 (#453).
-httrack -O /dev/null -#test=status run | grep -q "status self-test OK"
+out=$(httrack -O /dev/null -#test=status run)
+grep -q "status self-test OK" <<<"$out"

--- a/tests/01_engine-stripquery.test
+++ b/tests/01_engine-stripquery.test
@@ -5,4 +5,5 @@ set -euo pipefail
 
 # --strip-query: pattern-scoped query-key stripping for dedup. All assertions
 # live in the engine self-test (hts_query_strip_keys + fil_normalized_filtered).
-httrack -O /dev/null -#test=stripquery | grep -q "strip-query self-test OK"
+out=$(httrack -O /dev/null -#test=stripquery)
+grep -q "strip-query self-test OK" <<<"$out"

--- a/tests/01_engine-unescape-bounds.test
+++ b/tests/01_engine-unescape-bounds.test
@@ -4,4 +4,5 @@
 set -euo pipefail
 
 # Entity/URL unescapers reserve one byte for the trailing NUL (no 1-byte OOB).
-httrack -O /dev/null -#test=unescape-bounds run | grep -q "unescape-bounds self-test OK"
+out=$(httrack -O /dev/null -#test=unescape-bounds run)
+grep -q "unescape-bounds self-test OK" <<<"$out"

--- a/tests/01_engine-urlhack.test
+++ b/tests/01_engine-urlhack.test
@@ -5,4 +5,5 @@ set -euo pipefail
 
 # -%u url-hack split (#271): www / // / query-order dedup toggle independently.
 # All assertions live in the engine self-test (hash compare flag resolution).
-httrack -O /dev/null -#test=urlhack run | grep -q "urlhack self-test OK"
+out=$(httrack -O /dev/null -#test=urlhack run)
+grep -q "urlhack self-test OK" <<<"$out"

--- a/tests/01_engine-useragent.test
+++ b/tests/01_engine-useragent.test
@@ -4,4 +4,5 @@
 set -euo pipefail
 
 # Default User-Agent (#449): honest HTTrack token, no Windows 98 relic.
-httrack -O /dev/null -#test=useragent run | grep -q "useragent self-test OK"
+out=$(httrack -O /dev/null -#test=useragent run)
+grep -q "useragent self-test OK" <<<"$out"

--- a/tests/01_engine-warc-surt.test
+++ b/tests/01_engine-warc-surt.test
@@ -5,4 +5,5 @@ set -euo pipefail
 
 # SURT canonicalization of the CDXJ sort key (--warc-cdx). Pure string work,
 # so it runs under the MSan-instrumented 01_engine glob.
-httrack -O /dev/null -#test=warc-surt | grep -q "warc-surt: OK"
+out=$(httrack -O /dev/null -#test=warc-surt)
+grep -q "warc-surt: OK" <<<"$out"

--- a/tests/01_zlib-cache-writefail.test
+++ b/tests/01_zlib-cache-writefail.test
@@ -1,8 +1,6 @@
 #!/bin/bash
 #
-# Keep this POSIX-portable: the harness runs it via $(BASH), which is a plain
-# POSIX /bin/sh on some platforms (e.g. macOS), so avoid bashisms and GNU-only
-# tool flags despite the #!/bin/bash above.
+# Stick to POSIX tool flags: macOS ships BSD grep/sed, not the GNU ones.
 
 # Cache write-failure policy (-#test=cache-writefail <dir>). #174/#219: disk
 # full or a failure streak aborts cleanly; an isolated failure or an oversized
@@ -17,13 +15,13 @@ out=$(httrack -#test=cache-writefail "$dir")
 
 # Match the exact success line (error logs also go to stdout); a renamed/removed
 # test prints the registry to stderr, which exits non-zero but never prints this.
-printf '%s\n' "$out" | grep -qx "cache-writefail: OK" || {
+grep -qx "cache-writefail: OK" <<<"$out" || {
     echo "expected 'cache-writefail: OK', got: $out" >&2
     exit 1
 }
 
 # A skipped entry must be warned about with its URL.
-printf '%s\n' "$out" | grep -q "entry not cached: example.com/" || {
+grep -q "entry not cached: example.com/" <<<"$out" || {
     echo "expected a URL-bearing skip warning" >&2
     exit 1
 }

--- a/tests/01_zlib-repair-shift.test
+++ b/tests/01_zlib-repair-shift.test
@@ -1,8 +1,6 @@
 #!/bin/bash
 #
-# Keep this POSIX-portable: the harness runs it via $(BASH), which is a plain
-# POSIX /bin/sh on some platforms (e.g. macOS), so avoid bashisms and GNU-only
-# tool flags despite the #!/bin/bash above.
+# Stick to POSIX tool flags: macOS ships BSD grep/sed, not the GNU ones.
 
 # unzRepair header read must not overflow a signed shift (-#test=zip-repair-shift
 # <dir>). A damaged local file header whose CRC high word has bit 15 set made
@@ -15,7 +13,7 @@ trap 'set +e; rm -rf "$dir"' EXIT
 
 out=$(httrack -#test=zip-repair-shift "$dir")
 
-printf '%s\n' "$out" | grep -qx "zip-repair-shift: OK (recovered 1 entry)" || {
+grep -qx "zip-repair-shift: OK (recovered 1 entry)" <<<"$out" || {
     echo "expected 'zip-repair-shift: OK (recovered 1 entry)', got: $out" >&2
     exit 1
 }

--- a/tests/01_zlib-warc-wacz.test
+++ b/tests/01_zlib-warc-wacz.test
@@ -10,7 +10,8 @@ set -euo pipefail
 
 httrack_bin=$(cd "$(dirname "$(command -v httrack)")" && pwd)/httrack
 
-if ! "$httrack_bin" -#test 2>&1 | grep -q '^  warc-wacz'; then
+registry=$("$httrack_bin" -#test 2>&1 || true)
+if ! grep -q '^  warc-wacz' <<<"$registry"; then
     echo "warc-wacz self-test unavailable (build without OpenSSL); skipping"
     exit 77
 fi

--- a/tests/102_local-ftp-refetch.test
+++ b/tests/102_local-ftp-refetch.test
@@ -152,13 +152,15 @@ ok "the kept copies survived the update purge"
 # --- the change report is the mirror's own account of the pass ----------------
 test -s "$report" || fail "pass 2 wrote no ${report}"
 test -z "$(listed gone)" || fail "the report calls something gone: $(listed gone)"
+unchanged=$(listed unchanged)
+changed=$(listed changed)
 for name in keep empty; do
-    listed unchanged | grep -qx "${host}/${name}.bin:$(size_of "${tmpdir}/snap/${name}.bin")" ||
+    grep -qx "${host}/${name}.bin:$(size_of "${tmpdir}/snap/${name}.bin")" <<<"$unchanged" ||
         fail "${name}.bin is not reported unchanged at its previous size"
-    if listed changed | grep -q "^${host}/${name}.bin:"; then
+    if grep -q "^${host}/${name}.bin:" <<<"$changed"; then
         fail "${name}.bin is reported changed as well"
     fi
 done
-listed changed | grep -qx "${host}/stay.bin:$(size_of "${out}/${host}/stay.bin")" ||
+grep -qx "${host}/stay.bin:$(size_of "${out}/${host}/stay.bin")" <<<"$changed" ||
     fail "stay.bin is not reported changed"
 ok "the change report calls the kept files unchanged and the refreshed one changed"

--- a/tests/61_webhttrack-locale.test
+++ b/tests/61_webhttrack-locale.test
@@ -23,7 +23,7 @@ funcs=$(sed -n '/^function lang_index/,/^}/p' "${script}")
 # would truncate the lift and silently stop testing everything below it.
 grep -q '^# Find the browser' "${script}" || fail "locale block terminator moved in ${script}"
 block=$(sed -n '/^# Locale/,/^# Find the browser/p' "${script}" | sed '$d')
-echo "${block}" | grep -q 'LANGN=.*lang_index' || fail "could not lift the whole locale block from ${script}"
+grep -q 'LANGN=.*lang_index' <<<"${block}" || fail "could not lift the whole locale block from ${script}"
 
 # Run the lifted block against whatever locale vars the caller exported.
 run_block() {

--- a/tests/66_engine-port80-strip.test
+++ b/tests/66_engine-port80-strip.test
@@ -9,4 +9,5 @@ set -euo pipefail
 # (#614) was stripped as if it were the default. The default is scheme-aware
 # (#638): an explicit :80 on https/ftp stays, :443/:21 strip under their own
 # scheme. All assertions live in the engine self-test.
-httrack -O /dev/null -#test=stripport | grep -q "stripport self-test OK"
+out=$(httrack -O /dev/null -#test=stripport)
+grep -q "stripport self-test OK" <<<"$out"

--- a/tests/72_watchdog-crawl.test
+++ b/tests/72_watchdog-crawl.test
@@ -21,7 +21,7 @@ test "$rc" -ne 77 || {
     echo "SKIP: local crawl prerequisites missing" >&2
     exit 77
 }
-if printf '%s\n' "$out" | grep -q "could not discover server port"; then
+if grep -q "could not discover server port" <<<"$out"; then
     echo "SKIP: server port announce raced" >&2
     exit 77
 fi
@@ -30,7 +30,7 @@ fi
 # together they pin the fast exit on the 3s watchdog, not httrack giving up.
 test "$rc" -ne 0 || fail "stalled crawl reported success"
 test "$elapsed" -lt 25 || fail "watchdog fired late (${elapsed}s)"
-printf '%s\n' "$out" | grep -q "watchdog fired" ||
+grep -q "watchdog fired" <<<"$out" ||
     fail "crawl failed but not via the watchdog: $out"
 
 echo "crawl watchdog OK (reaped in ${elapsed}s)"

--- a/tests/80_engine-crash-symbolize.test
+++ b/tests/80_engine-crash-symbolize.test
@@ -71,7 +71,8 @@ grep -qE 'st_strsafe|strcpy_safe_' "$oracle" || {
 # The payload. Dropping the raw frames first is what makes it specific: both
 # names are static, so .dynsym could never have carried them. Not anchored on
 # the "0xOFF:" line, the inline chain puts the name on either half.
-grep -v "$rawframe" "$out" | grep -qE 'st_strsafe|strcpy_safe_' || {
+symbolized=$(grep -v "$rawframe" "$out" || true)
+grep -qE 'st_strsafe|strcpy_safe_' <<<"$symbolized" || {
     echo "the handler did not name the hidden frames:" >&2
     cat "$out" >&2
     exit 1

--- a/tests/89_webhttrack-error-overflow.test
+++ b/tests/89_webhttrack-error-overflow.test
@@ -169,7 +169,8 @@ test "${written}" -lt "${#profile}" ||
     fail "the file-size limit did not stop the write (${written} bytes landed)"
 check_clipped "Unable to write ${#profile} bytes in the the init file " "${path}/p"
 
-get "${port}" /server/index.html | grep -q '200 OK' ||
+reply=$(get "${port}" /server/index.html || true)
+grep -q '200 OK' <<<"$reply" ||
     fail "the server stopped answering after the refused saves"
 
 echo "PASS"

--- a/tests/webhttrack-smoke.sh
+++ b/tests/webhttrack-smoke.sh
@@ -53,13 +53,13 @@ echo "stub browser invoked with: \$1" >&2
 opturl="\${1%/}/server/option2.html"
 warcurl="\${1%/}/server/option9.html"
 smurl="\${1%/}/server/option8.html"
-if body="\$(curl -fsSL --max-time 20 "\$1")" && printf '%s' "\$body" | grep -qai httrack && printf '%s' "\$body" | grep -qaF step2.html &&
-    opt="\$(curl -fsSL --max-time 20 "\$opturl")" && printf '%s' "\$opt" | grep -qaF "title='" &&
-    printf '%s' "\$opt" | grep -qaF 'name="singlefile"' && printf '%s' "\$opt" | grep -qaF 'name="singlefilemax"' &&
-    ! printf '%s' "\$opt" | grep -qaF '\${LANG_SINGLEFILE}' &&
-    warc="\$(curl -fsSL --max-time 20 "\$warcurl")" && printf '%s' "\$warc" | grep -qaF 'name="warcfile"' && printf '%s' "\$warc" | grep -qaF WARC &&
-    printf '%s' "\$warc" | grep -qaF 'name="changes"' && printf '%s' "\$warc" | grep -qaF hts-changes.json &&
-    sm="\$(curl -fsSL --max-time 20 "\$smurl")" && printf '%s' "\$sm" | grep -qaF 'name="sitemapurl"' && printf '%s' "\$sm" | grep -qaF 'name="sitemap"'; then
+if body="\$(curl -fsSL --max-time 20 "\$1")" && grep -qai httrack <<<"\$body" && grep -qaF step2.html <<<"\$body" &&
+    opt="\$(curl -fsSL --max-time 20 "\$opturl")" && grep -qaF "title='" <<<"\$opt" &&
+    grep -qaF 'name="singlefile"' <<<"\$opt" && grep -qaF 'name="singlefilemax"' <<<"\$opt" &&
+    ! grep -qaF '\${LANG_SINGLEFILE}' <<<"\$opt" &&
+    warc="\$(curl -fsSL --max-time 20 "\$warcurl")" && grep -qaF 'name="warcfile"' <<<"\$warc" && grep -qaF WARC <<<"\$warc" &&
+    grep -qaF 'name="changes"' <<<"\$warc" && grep -qaF hts-changes.json <<<"\$warc" &&
+    sm="\$(curl -fsSL --max-time 20 "\$smurl")" && grep -qaF 'name="sitemapurl"' <<<"\$sm" && grep -qaF 'name="sitemap"' <<<"\$sm"; then
     echo PASS >"$marker"
 else
     echo "FAIL: unexpected response from \$1" >"$marker"


### PR DESCRIPTION
`01_engine-growsize.test` went red on an unrelated PR's arm64 leg with `zzmarker` sitting in plain sight in the dump it printed. Under `pipefail`, `grep -q` exits on the first match and the `printf` still feeding it dies of SIGPIPE, so the pipeline reports failure for an assertion that held. bash issues one `write()` per line, which leaves the window open for any match that is not on the last line, so this is a live flake rather than a theoretical one. All 58 sites in `tests/` now match a captured variable with a here-string, and the AGENTS.md bullet covers both spellings: it only warned about `&& fail`, which fails green, not `|| fail`, which fails red.

Four of the converted shapes feed an `if` condition or an `&&` chain, where the SIGPIPE flips the branch instead of failing loudly. `01_zlib-warc-wacz.test` would skip a build that does have the WACZ self-test, and `102_local-ftp-refetch.test` would swallow a file wrongly reported as changed. The 22 `httrack -#test=X | grep -q "... OK"` drivers were the quiet category: they survive only because the matched line is the last thing httrack prints, so one added line of output turns a pass into 141.

The two zlib drivers carried a header asking for POSIX-only constructs because `$(BASH)` "is a plain POSIX /bin/sh on some platforms (e.g. macOS)". It is not: configure resolves `$(BASH)` to bash, `test-timeout.sh` execs it, and `01_zlib-warc-wacz.test` already uses `set -o pipefail`, which dash does not have, on the macOS leg. I kept the half of that comment that is true and converted them.

Every converted assertion the suite can drive locally was mutation-tested with an absent marker, and the `if` branches in both directions, to confirm none of them turned into an always-pass. The twelve inside the `webhttrack-smoke.sh` stub browser only run on the macOS smoke leg.

Closes #813