### PR TITLE
gcc warns on the (void) fgets in the log-callback self-test

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2659,8 +2659,11 @@ static int st_logcallback(httrackp *opt, int argc, char **argv) {
   strcpybuff(seen, st_log_callback_seen);
 
   rewind(fp);
-  line[0] = '\0';
-  (void) fgets(line, (int) sizeof(line), fp);
+  if (fgets(line, (int) sizeof(line), fp) == NULL) {
+    fprintf(stderr, "logcallback: log file is empty, nothing was written\n");
+    fclose(fp);
+    return 1;
+  }
   fclose(fp);
 
   /* The callback runs above the level filter and without a log file at all;


### PR DESCRIPTION
The `(void)` cast in front of `fgets` does not suppress glibc's `warn_unused_result`, so a gcc build of master warns on `src/htsselftest.c`. It came in with #801.

The self-test now checks the read instead. A NULL return means the log file it just wrote came back empty, which is exactly the thing the test is asserting did not happen, so it reports that and returns non-zero rather than comparing an empty buffer against the expected line. The success path is unchanged. This is the only cast-to-void of a `warn_unused_result` call in the tree.

Closes #812
