### PR TITLE
size_t i = strlen(s) - 1: the (i > 0) guard cannot see the underflow

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6710,10 +6710,10 @@ static int st_changes_race(httrackp *opt, int argc, char **argv) {
   return err;
 }
 
-/* The x[strlen(x) - 1] class (#770) and its pointer spelling x + strlen(x) - 1
-   (#781). The string starts mid-arena so the byte it must not touch is a real
-   neighbour; poisoned with '#', not 0, or a stray NUL terminator would read as
-   untouched. */
+/* The x[strlen(x) - 1] class (#770), its pointer spelling x + strlen(x) - 1
+   (#781) and its size_t index spelling (#821). The string starts mid-arena so
+   the byte it must not touch is a real neighbour; poisoned with '#', not 0, or
+   a stray NUL terminator would read as untouched. */
 static int st_lastchar(httrackp *opt, int argc, char **argv) {
   enum { off = 8 };
 
@@ -6817,6 +6817,36 @@ static int st_lastchar(httrackp *opt, int argc, char **argv) {
   CHECK(hts_lastcharptr(s) == s);
   CHECK(*hts_lastcharptr(s) == '/');
   CHECK(arena[guard] == '#');
+
+  /* the size_t index spelling (#821): (i > 0) cannot reject SIZE_MAX, so only
+     a safe seed stops the sites' walk-back */
+  REPOISON("");
+  {
+    const size_t vacuous = strlen(s) - 1;
+    size_t i = hts_lastcharoffset(s);
+    int steps = 0;
+
+    CHECK(vacuous > 0);
+    CHECK(i == 0);
+    /* step-capped so a bad seed fails the count instead of running off */
+    while ((i > 0) && (steps < 8) && (s[i] != '/'))
+      i--, steps++;
+    CHECK(steps == 0);
+    CHECK(s[i] != '/');
+    CHECK(arena[guard] == '#');
+  }
+
+  /* and the same loop must still find the real byte on a non-empty string */
+  REPOISON("a/b");
+  {
+    size_t i = hts_lastcharoffset(s);
+    int steps = 0;
+
+    while ((i > 0) && (steps < 8) && (s[i] != '/'))
+      i--, steps++;
+    CHECK(i == 1);
+    CHECK(arena[guard] == '#');
+  }
 
   /* control: the canary must be able to fail, or the checks above prove
      nothing. Clobber it exactly as the unguarded idiom would. */
@@ -6975,7 +7005,7 @@ static const struct selftest_entry {
      "bounded string-op self-test", st_strsafe},
     {"copyopt", "", "copy_htsopt option-copy self-test", st_copyopt},
     {"lastchar", "",
-     "last-char helpers never index before the buffer (#770, #781)",
+     "last-char helpers never index before the buffer (#770, #781, #821)",
      st_lastchar},
     {"rtrim", "", "hts_rtrim never walks below the buffer", st_rtrim},
     {"changes", "", "--changes bucket accounting and JSON escaping (#714)",

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -374,8 +374,8 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
         forbidden_url = 1;
       break;                    // interdicton de sortir au dela de l'adresse
     case HTS_TRAVEL_SAME_DOMAIN: {
-      size_t i = strlen(adr) - 1;
-      size_t j = strlen(urladr()) - 1;
+      size_t i = hts_lastcharoffset(adr);
+      size_t j = hts_lastcharoffset(urladr());
 
       if ((i > 0) && (j > 0)) {
         while ((i > 0) && (adr[i] != '.'))
@@ -411,8 +411,8 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
         forbidden_url = 1;
     } break;
     case HTS_TRAVEL_SAME_TLD: {
-      size_t i = strlen(adr) - 1;
-      size_t j = strlen(urladr()) - 1;
+      size_t i = hts_lastcharoffset(adr);
+      size_t j = hts_lastcharoffset(urladr());
 
       while ((i > 0) && (adr[i] != '.'))
         i--;
@@ -728,7 +728,7 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
       case 1: // forbid the whole directory and subdirs: adr/path/*
         forbidden_url = 1;
         {
-          size_t i = strlen(fil) - 1;
+          size_t i = hts_lastcharoffset(fil);
 
           while((fil[i] != '/') && (i > 0))
             i--;
@@ -794,7 +794,7 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
 
       case 5: // allow the whole directory and its children
         if ((opt->seeker & HTS_SEEKER_UP) == 0) { // not allowed to go up
-          size_t i = strlen(fil) - 1;
+          size_t i = hts_lastcharoffset(fil);
 
           while((fil[i] != '/') && (i > 0))
             i--;
@@ -836,7 +836,7 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
         //
       case 7: // allow this directory
       {
-        size_t i = strlen(fil) - 1;
+        size_t i = hts_lastcharoffset(fil);
 
         while ((fil[i] != '/') && (i > 0))
           i--;

--- a/src/punycode.c
+++ b/src/punycode.c
@@ -425,10 +425,11 @@ int main(int argc, char **argv) {
       fail(io_error);
     if (feof(stdin))
       fail(invalid_input);
-    input_length = strlen(input) - 1;
-    if (input[input_length] != '\n')
+    /* a leading NUL byte leaves strlen() at 0, so trim before subtracting */
+    input_length = strlen(input);
+    if (input_length == 0 || input[input_length - 1] != '\n')
       fail(too_big);
-    input[input_length] = 0;
+    input[--input_length] = 0;
 
     for(p = input; *p != 0; ++p) {
       pp = strchr(print_ascii, *p);

--- a/tests/01_engine-lastchar.test
+++ b/tests/01_engine-lastchar.test
@@ -50,14 +50,18 @@ test -z "$hits" || {
     exit 1
 }
 
-# Same for the unsigned index spelling. Its (i > 0) guard is vacuous, since
-# SIZE_MAX passes it; the self-test's own control is the only survivor.
-hits=$(command grep -rnE '(size_t|unsigned +(int|long|short)) +[A-Za-z_][A-Za-z0-9_]* *= *(\([^)]*\) *)?strlen *\([^;]*\) *- *1' \
+# Same for the unsigned index spelling, whose (i > 0) guard is vacuous since
+# SIZE_MAX passes it. The second pattern catches a bare reassignment, which
+# carries no type to match; an (int) cast is the safe form, so it must be uncast.
+hits=$(command grep -rnE \
+    -e '(size_t|unsigned +(int|long|short)) +[A-Za-z_][A-Za-z0-9_]* *= *(\([^)]*\) *)?strlen *\([^;]*\) *- *1' \
+    -e '[A-Za-z_][A-Za-z0-9_]* *= *strlen *\([^;]*\) *- *1' \
     "$top_srcdir/src" --include='*.c' --include='*.h' --exclude-dir=coucal |
-    grep -v 'htsselftest\.c:.*size_t vacuous = strlen' || true)
+    grep -v 'htsselftest\.c:.*size_t vacuous = strlen' |
+    grep -v 'htswizard\.c:.*int i=strlen(adr)-1;' || true)
 
 test -z "$hits" || {
-    echo "size_t i = strlen(x) - 1 reintroduced; use hts_lastcharoffset:" >&2
+    echo "an unsigned index from strlen(x) - 1 reintroduced; use hts_lastcharoffset:" >&2
     echo "$hits" >&2
     exit 1
 }

--- a/tests/01_engine-lastchar.test
+++ b/tests/01_engine-lastchar.test
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# Runs the lastchar self-test (#770, #781), then keeps the idiom it replaced
-# from coming back: x[strlen(x) - 1] and x + strlen(x) - 1 both land one byte
-# before the buffer when x is empty, and the guard is never where they are.
+# Runs the lastchar self-test (#770, #781, #821), then keeps the idiom it
+# replaced from coming back: x[strlen(x) - 1], x + strlen(x) - 1 and an unsigned
+# index seeded from it all land before the buffer when x is empty.
 
 set -eu
 
@@ -46,6 +46,18 @@ hits=$(command grep -rnE '\+ *\(?(int|size_t)?\)? *strlen *\([^)]*\) *- *1' \
 
 test -z "$hits" || {
     echo "x + strlen(x) - 1 reintroduced; use hts_lastcharptr:" >&2
+    echo "$hits" >&2
+    exit 1
+}
+
+# Same for the unsigned index spelling. Its (i > 0) guard is vacuous, since
+# SIZE_MAX passes it; the self-test's own control is the only survivor.
+hits=$(command grep -rnE '(size_t|unsigned +(int|long|short)) +[A-Za-z_][A-Za-z0-9_]* *= *(\([^)]*\) *)?strlen *\([^;]*\) *- *1' \
+    "$top_srcdir/src" --include='*.c' --include='*.h' --exclude-dir=coucal |
+    grep -v 'htsselftest\.c:.*size_t vacuous = strlen' || true)
+
+test -z "$hits" || {
+    echo "size_t i = strlen(x) - 1 reintroduced; use hts_lastcharoffset:" >&2
     echo "$hits" >&2
     exit 1
 }


### PR DESCRIPTION
Seven sites in `htswizard.c` seed a `size_t` index with `strlen(x) - 1` and then guard the walk-back with `(i > 0)`. `SIZE_MAX` satisfies that, so the check the author meant as the emptiness test does nothing. They now seed from `hts_lastcharoffset()`, which #819 adds. On any non-empty string it is the same value, so the only behaviour that moves is the empty case that used to read below the buffer.

Nothing reaches them today. `ident_url_absolute()` returns -1 on an empty `adr` and substitutes `default-index.html` for an empty `fil`, and that is where the whole invariant lives, since no caller checks `fil` itself. A producer of an empty `fil` added later would turn three of the sites live at once.

`punycode.c` is the exception and the only out-of-bounds write in the set. RFC 3492's sample harness wants both `PUNYCODE_COSTELLO_RFC3492_INCLUDE_TEST` and `..._MAIN`, and nothing in the tree or the build defines either, so it never compiles. Define both and a stdin line whose first byte is NUL leaves `strlen()` at 0, which segfaults on the read at `input[input_length]` and would write there next. Checked under ASan against both versions.

Every site being latent, the barrier against the idiom coming back is the source guard rather than a crawl: the self-test picks up the `size_t` spelling and `01_engine-lastchar.test` grows a grep for it.

Based on #819 for the helper. A live crash turned up in the same sweep and went out separately as #829.

Closes #821
