### PR TITLE
Two branches adding a test always collide on the TESTS list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,8 @@
 # bash die on $'\r' on every line of them.
 *.test text eol=lf
 *.sh text eol=lf
+
+# Every new test appends to the TESTS list, so two branches in flight always
+# collide on its last line. A union merge keeps both entries; automake does not
+# care about order.
+tests/Makefile.am merge=union


### PR DESCRIPTION
Every new test appends to the same last line of `tests/Makefile.am`, so any two branches in flight conflict there and each one has to be hand-resolved before it can land. Git has a built-in union merge driver for exactly this: it keeps both sides' lines, and automake does not care about the order.

Scoped to that one file. The residual risk is that union applies to the whole file, so two branches editing the same non-list line (`TESTS_ENVIRONMENT`, `EXTRA_DIST`) would silently get both versions rather than a conflict. Moving the list into its own included fragment would remove that, but it would conflict with every open PR once, so it is better done when the queue is empty.