### PR TITLE
A query-string character reference the page charset cannot represent is left unescaped, changing the query's parse

### DIFF
--- a/src/htscharset.c
+++ b/src/htscharset.c
@@ -296,16 +296,41 @@ LPWSTR hts_convertUTF8StringToUCS2(const char *s, int size, int *pwsize) {
   return hts_convertStringToUCS2(s, size, CP_UTF8, pwsize);
 }
 
-char *hts_convertUCS2StringToCP(LPWSTR woutput, int wsize, UINT cp) {
+/* WideCharToMultiByte rejects lpUsedDefaultChar on the Unicode, ISO-2022, HZ,
+   GB18030 and ISCII codepages, where a substitution stays invisible. */
+static hts_boolean cp_reports_default_char(UINT cp) {
+  if (cp == 42 /* CP_SYMBOL */ || cp == CP_UTF7 || cp == CP_UTF8 ||
+      cp == 52936 || cp == 54936 || (cp >= 50220 && cp <= 50229) ||
+      (cp >= 57002 && cp <= 57011)) {
+    return HTS_FALSE;
+  }
+  return HTS_TRUE;
+}
+
+/* When plossy is non-NULL, *plossy reports that the codepage lacked a character
+   and a substitute was emitted for it. */
+static char *hts_convertUCS2StringToCPEx(LPWSTR woutput, int wsize, UINT cp,
+                                         hts_boolean *plossy) {
   const int usize =
-    WideCharToMultiByte(cp, 0, woutput, wsize, NULL, 0, NULL, FALSE);
+      WideCharToMultiByte(cp, 0, woutput, wsize, NULL, 0, NULL, NULL);
+
+  if (plossy != NULL) {
+    *plossy = HTS_FALSE;
+  }
   if (usize > 0) {
     char *const uoutput = malloc((usize + 1) * sizeof(char));
 
     if (uoutput != NULL) {
-      if (WideCharToMultiByte
-          (cp, 0, woutput, wsize, uoutput, usize, NULL, FALSE) == usize) {
+      BOOL usedDefault = FALSE;
+      LPBOOL const pUsedDefault =
+          plossy != NULL && cp_reports_default_char(cp) ? &usedDefault : NULL;
+
+      if (WideCharToMultiByte(cp, 0, woutput, wsize, uoutput, usize, NULL,
+                              pUsedDefault) == usize) {
         uoutput[usize] = '\0';
+        if (plossy != NULL && usedDefault) {
+          *plossy = HTS_TRUE;
+        }
         return uoutput;
       } else {
         free(uoutput);
@@ -313,6 +338,10 @@ char *hts_convertUCS2StringToCP(LPWSTR woutput, int wsize, UINT cp) {
     }
   }
   return NULL;
+}
+
+char *hts_convertUCS2StringToCP(LPWSTR woutput, int wsize, UINT cp) {
+  return hts_convertUCS2StringToCPEx(woutput, wsize, cp, NULL);
 }
 
 char *hts_convertUCS2StringToUTF8(LPWSTR woutput, int wsize) {
@@ -346,7 +375,11 @@ char *hts_convertStringCPToUTF8(const char *s, size_t size, UINT cp) {
   return NULL;
 }
 
-char *hts_convertStringCPFromUTF8(const char *s, size_t size, UINT cp) {
+static char *hts_convertStringCPFromUTF8Ex(const char *s, size_t size, UINT cp,
+                                           hts_boolean *plossy) {
+  if (plossy != NULL) {
+    *plossy = HTS_FALSE;
+  }
   /* Empty string ? */
   if (size == 0) {
     return hts_stringMemCopy(s, size);
@@ -362,7 +395,8 @@ char *hts_convertStringCPFromUTF8(const char *s, size_t size, UINT cp) {
     LPWSTR woutput = hts_convertStringToUCS2(s, (int) size, CP_UTF8, &wsize);
 
     if (woutput != NULL) {
-      char *const uoutput = hts_convertUCS2StringToCP(woutput, wsize, cp);
+      char *const uoutput =
+          hts_convertUCS2StringToCPEx(woutput, wsize, cp, plossy);
 
       free(woutput);
       return uoutput;
@@ -371,6 +405,10 @@ char *hts_convertStringCPFromUTF8(const char *s, size_t size, UINT cp) {
 
   /* Error, charset not found! */
   return NULL;
+}
+
+char *hts_convertStringCPFromUTF8(const char *s, size_t size, UINT cp) {
+  return hts_convertStringCPFromUTF8Ex(s, size, cp, NULL);
 }
 
 HTSEXT_API char *hts_convertStringToUTF8(const char *s, size_t size,
@@ -384,6 +422,19 @@ char *hts_convertStringFromUTF8(const char *s, size_t size, const char *charset)
   const UINT cp = hts_getCodepage(charset);
 
   return hts_convertStringCPFromUTF8(s, size, cp);
+}
+
+char *hts_convertStringFromUTF8Strict(const char *s, size_t size,
+                                      const char *charset) {
+  hts_boolean lossy = HTS_FALSE;
+  char *const out =
+      hts_convertStringCPFromUTF8Ex(s, size, hts_getCodepage(charset), &lossy);
+
+  if (lossy) {
+    free(out);
+    return NULL;
+  }
+  return out;
 }
 
 HTSEXT_API char *hts_convertStringSystemToUTF8(const char *s, size_t size) {
@@ -588,6 +639,13 @@ char *hts_convertStringFromUTF8(const char *s, size_t size, const char *charset)
   else {
     return hts_convertStringCharset(s, size, charset, "utf-8");
   }
+}
+
+char *hts_convertStringFromUTF8Strict(const char *s, size_t size,
+                                      const char *charset) {
+  /* No transliteration is requested of iconv, so an unrepresentable code point
+     already fails the conversion outright. */
+  return hts_convertStringFromUTF8(s, size, charset);
 }
 
 #endif

--- a/src/htscharset.h
+++ b/src/htscharset.h
@@ -62,6 +62,15 @@ extern char *hts_convertStringFromUTF8(const char *s, size_t size,
                                        const char *charset);
 
 /**
+ * Same, but refusing to lose a code point the charset can not represent:
+ * NULL is returned then, where hts_convertStringFromUTF8() may hand back a
+ * substituted string (Windows substitutes, iconv fails).
+ * Return NULL upon error.
+ **/
+extern char *hts_convertStringFromUTF8Strict(const char *s, size_t size,
+                                             const char *charset);
+
+/**
  * Convert an UTF-8 string to an IDNA (RFC 3492) string.
  **/
 extern char *hts_convertStringUTF8ToIDNA(const char *s, size_t size);

--- a/src/htsencoding.c
+++ b/src/htsencoding.c
@@ -62,19 +62,6 @@ static int get_hex_value(char c) {
     (HASH) *= HASH_PRIME;                                                      \
   } while (0)
 
-/* Did converting utf8 to charset preserve the code point? Windows substitutes
-   '?' for one the charset lacks rather than failing, so only converting back
-   tells a real conversion from a lossy one. */
-static hts_boolean charset_represents(const char *utf8, const char *converted,
-                                      const char *charset) {
-  char *back = hts_convertStringToUTF8(converted, strlen(converted), charset);
-  const hts_boolean same =
-      back != NULL && strcmp(back, utf8) == 0 ? HTS_TRUE : HTS_FALSE;
-
-  freet(back);
-  return same;
-}
-
 int hts_unescapeEntitiesWithCharset(const char *src, char *dest, const size_t max, const char *charset) {
   return hts_unescapeEntitiesWithCharsetSpecial(src, dest, max, charset, 0);
 }
@@ -140,12 +127,17 @@ int hts_unescapeEntitiesWithCharsetSpecial(const char *src, char *dest,
             char buffer[32];
             len = 0;
             if ( ( ulen = hts_writeUTF8(uc, buffer, sizeof(buffer)) ) != 0) {
+              const hts_boolean urlQuery =
+                  (flags & UNESCAPE_ENTITIES_URL_QUERY) != 0;
               char *s;
               buffer[ulen] = '\0';
-              s = hts_convertStringFromUTF8(buffer, strlen(buffer), charset);
-              if (s != NULL && (flags & UNESCAPE_ENTITIES_URL_QUERY) != 0 &&
-                  !charset_represents(buffer, s, charset)) {
-                freet(s);
+              /* Strict for a query only: a substituted '?' must not pass for
+                 the code point the document wrote. */
+              if (urlQuery) {
+                s = hts_convertStringFromUTF8Strict(buffer, strlen(buffer),
+                                                    charset);
+              } else {
+                s = hts_convertStringFromUTF8(buffer, strlen(buffer), charset);
               }
               if (s != NULL) {
                 const size_t sLen = strlen(s);
@@ -155,7 +147,7 @@ int hts_unescapeEntitiesWithCharsetSpecial(const char *src, char *dest,
                   len = sLen;
                 }
                 freet(s);
-              } else if ((flags & UNESCAPE_ENTITIES_URL_QUERY) != 0) {
+              } else if (urlQuery) {
                 /* URL Standard: an unrepresentable code point is written
                    %26%23<decimal>%3B rather than left as source text. */
                 char esc[32];

--- a/src/htsencoding.c
+++ b/src/htsencoding.c
@@ -62,7 +62,27 @@ static int get_hex_value(char c) {
     (HASH) *= HASH_PRIME;                                                      \
   } while (0)
 
+/* Did converting utf8 to charset preserve the code point? Windows substitutes
+   '?' for one the charset lacks rather than failing, so only converting back
+   tells a real conversion from a lossy one. */
+static hts_boolean charset_represents(const char *utf8, const char *converted,
+                                      const char *charset) {
+  char *back = hts_convertStringToUTF8(converted, strlen(converted), charset);
+  const hts_boolean same =
+      back != NULL && strcmp(back, utf8) == 0 ? HTS_TRUE : HTS_FALSE;
+
+  freet(back);
+  return same;
+}
+
 int hts_unescapeEntitiesWithCharset(const char *src, char *dest, const size_t max, const char *charset) {
+  return hts_unescapeEntitiesWithCharsetSpecial(src, dest, max, charset, 0);
+}
+
+int hts_unescapeEntitiesWithCharsetSpecial(const char *src, char *dest,
+                                           const size_t max,
+                                           const char *charset,
+                                           const int flags) {
   size_t i, j, ampStart, ampStartDest;
   int uc;
   int hex;
@@ -123,6 +143,10 @@ int hts_unescapeEntitiesWithCharset(const char *src, char *dest, const size_t ma
               char *s;
               buffer[ulen] = '\0';
               s = hts_convertStringFromUTF8(buffer, strlen(buffer), charset);
+              if (s != NULL && (flags & UNESCAPE_ENTITIES_URL_QUERY) != 0 &&
+                  !charset_represents(buffer, s, charset)) {
+                freet(s);
+              }
               if (s != NULL) {
                 const size_t sLen = strlen(s);
                 if (sLen < maxOut) {
@@ -130,7 +154,18 @@ int hts_unescapeEntitiesWithCharset(const char *src, char *dest, const size_t ma
                   memcpy(&dest[ampStartDest], s, sLen);
                   len = sLen;
                 }
-                free(s);
+                freet(s);
+              } else if ((flags & UNESCAPE_ENTITIES_URL_QUERY) != 0) {
+                /* URL Standard: an unrepresentable code point is written
+                   %26%23<decimal>%3B rather than left as source text. */
+                char esc[32];
+                const int escLen =
+                    snprintf(esc, sizeof(esc), "%%26%%23%d%%3B", uc);
+
+                if (escLen > 0 && (size_t) escLen < maxOut) {
+                  memcpy(&dest[ampStartDest], esc, (size_t) escLen);
+                  len = (size_t) escLen;
+                }
               }
             }
           }

--- a/src/htsencoding.h
+++ b/src/htsencoding.h
@@ -70,6 +70,29 @@ extern int hts_unescapeEntitiesWithCharset(const char *src,
                                            const char *charset);
 
 /**
+ * Flags for hts_unescapeEntitiesWithCharsetSpecial().
+ **/
+typedef enum unescapeEntitiesFlags {
+  /** The destination is a URL query string: emit a character reference the
+      charset can not represent as %26%23<decimal>%3B, as the URL Standard's
+      percent-encode-after-encoding step demands, instead of leaving literal
+      source text whose '&' and '#' would re-split the query. **/
+  UNESCAPE_ENTITIES_URL_QUERY = 1
+} unescapeEntitiesFlags;
+
+/**
+ * Unescape HTML entities into their charset equivalents, "flags" being a mask
+ * of UNESCAPE_ENTITIES_XXX constants.
+ * Note: source and destination MUST NOT be the same with a flag that may grow
+ * the string (UNESCAPE_ENTITIES_URL_QUERY).
+ * Returns 0 upon success, -1 upon overflow or error.
+ **/
+extern int hts_unescapeEntitiesWithCharsetSpecial(const char *src, char *dest,
+                                                  const size_t max,
+                                                  const char *charset,
+                                                  const int flags);
+
+/**
  * Unescape an URL-encoded string. The implicit charset is UTF-8.
  * In case of UTF-8 decoding error inside URL-encoded characters, 
  * the characters are left undecoded.

--- a/src/htsencoding.h
+++ b/src/htsencoding.h
@@ -70,14 +70,14 @@ extern int hts_unescapeEntitiesWithCharset(const char *src,
                                            const char *charset);
 
 /**
- * Flags for hts_unescapeEntitiesWithCharsetSpecial().
+ * Flags for hts_unescapeEntitiesWithCharsetSpecial(). Values stay distinct from
+ * unescapeFlags above: both reach their function as a plain int.
  **/
 typedef enum unescapeEntitiesFlags {
-  /** The destination is a URL query string: emit a character reference the
-      charset can not represent as %26%23<decimal>%3B, as the URL Standard's
-      percent-encode-after-encoding step demands, instead of leaving literal
-      source text whose '&' and '#' would re-split the query. **/
-  UNESCAPE_ENTITIES_URL_QUERY = 1
+  /** The destination is a URL query string: write a reference the charset can
+      not represent as %26%23<decimal>%3B (URL Standard), instead of source text
+      whose '&' and '#' would re-split the query. **/
+  UNESCAPE_ENTITIES_URL_QUERY = 2
 } unescapeEntitiesFlags;
 
 /**

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -2176,9 +2176,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                       "could not decode URI '%s' with charset '%s'", lien, charset);
                   }
 
-                  // decode query string entities with page charset; decoded
-                  // out-of-place because a reference the charset can not
-                  // represent is percent-escaped, and grows (#854)
+                  // decode query entities with the page charset, out-of-place
+                  // because the escape grows it (#854)
                   if (hasCharset) {
                     char BIGSTK decoded[sizeof(query)];
 

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -2154,13 +2154,21 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                       "could not decode URI '%s' with charset '%s'", lien, charset);
                   }
 
-                  // decode query string entities with page charset
+                  // decode query string entities with page charset; decoded
+                  // out-of-place because a reference the charset can not
+                  // represent is percent-escaped, and grows (#854)
                   if (hasCharset) {
-                    if (hts_unescapeEntitiesWithCharset(query, 
-                                                        query, strlen(query) + 1,
-                                                        charset) != 0) {
-                        hts_log_print(opt, LOG_WARNING,
-                          "could not decode query string '%s' with charset '%s'", query, charset);
+                    char BIGSTK decoded[sizeof(query)];
+
+                    if (hts_unescapeEntitiesWithCharsetSpecial(
+                            query, decoded, sizeof(decoded), charset,
+                            UNESCAPE_ENTITIES_URL_QUERY) == 0) {
+                      strcpybuff(query, decoded);
+                    } else {
+                      hts_log_print(opt, LOG_WARNING,
+                                    "could not decode query string '%s' with "
+                                    "charset '%s'",
+                                    query, charset);
                     }
                   }
 

--- a/tests/139_local-query-charref.test
+++ b/tests/139_local-query-charref.test
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Issue #854: a character reference the page charset can not represent must be
+# percent-escaped in a query string (%26%23<decimal>%3B), not left as source
+# text whose '&' and '#' split the query into extra parameters.
+set -eu
+
+: "${top_srcdir:=..}"
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+server=$(nativepath "${testdir}/local-server.py")
+root=$(nativepath "${testdir}/server-root")
+
+python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
+httrack=$(command -v httrack) || ! echo "could not find httrack" >&2 || exit 1
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_854.XXXXXX") || exit 1
+serverpid=
+cleanup() {
+    stop_server "$serverpid"
+    rm -rf "$tmpdir"
+}
+trap 'cleanup || true' EXIT HUP INT QUIT PIPE TERM
+
+serverlog="${tmpdir}/server.log"
+: >"$serverlog"
+reqlog="${tmpdir}/requests.txt"
+: >"$reqlog"
+CHARREF_LOG="$reqlog" "$python" "$server" --root "$root" >"$serverlog" 2>&1 &
+serverpid=$!
+port=
+for _ in $(seq 1 50); do
+    line=$(head -n1 "$serverlog" 2>/dev/null) || line=
+    if test "${line%% *}" == "PORT"; then
+        port="${line#PORT }"
+        break
+    fi
+    kill -0 "$serverpid" 2>/dev/null || {
+        echo "server exited early: $(cat "$serverlog")"
+        exit 1
+    }
+    sleep 0.1
+done
+test -n "$port" || {
+    echo "could not discover server port"
+    exit 1
+}
+
+"$httrack" -O "${tmpdir}/crawl" --quiet --disable-security-limits --robots=0 \
+    --timeout=30 --retries=0 "http://127.0.0.1:${port}/charref/index.html" \
+    >"${tmpdir}/crawl.log" 2>&1 || true
+
+# Assert the request-target the origin saw, per source page.
+check() {
+    local label="$1" page="$2" want="$3" wantcount="$4"
+    local got count
+    printf '[%s] ..\t' "$label"
+    got=$(grep -F "/charref/${page}?" "$reqlog" | sed "s|^/charref/${page}?||" | sort -u) || got=
+    if test "$got" != "$want"; then
+        echo "FAIL: expected query '${want}', got '${got}'"
+        exit 1
+    fi
+    # Parameter count the origin would parse out of that query.
+    count=$(printf '%s' "$got" | tr '&' '\n' | grep -c .) || count=0
+    if test "$count" -ne "$wantcount"; then
+        echo "FAIL: origin sees ${count} parameters, expected ${wantcount}"
+        exit 1
+    fi
+    echo "OK (${count} parameters)"
+}
+
+# iso-8859-1 fallback: € is unrepresentable (named and numeric alike), é is not.
+check "charset-less page" qnone.html \
+    'a=%26%238364%3B&b=%26%238364%3B&c=%e9&d=x' 4
+# Control: utf-8 represents both, so they go out as their encoded bytes.
+check "declared utf-8 page" qutf8.html \
+    'a=%e2%82%ac&b=%e2%82%ac&c=%c3%a9&d=x' 4

--- a/tests/139_local-query-charref.test
+++ b/tests/139_local-query-charref.test
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Issue #854: a character reference the page charset can not represent must be
 # percent-escaped in a query string (%26%23<decimal>%3B), not left as source
-# text whose '&' and '#' split the query into extra parameters.
+# text whose '&' and '#' split the query into extra parameters. A reference the
+# charset does represent must still go out as its encoded bytes.
 set -eu
 
 : "${top_srcdir:=..}"
@@ -50,28 +51,44 @@ test -n "$port" || {
     --timeout=30 --retries=0 "http://127.0.0.1:${port}/charref/index.html" \
     >"${tmpdir}/crawl.log" 2>&1 || true
 
-# Assert the request-target the origin saw, per source page.
+# check <label> <page> <want-parameter-count> <acceptable-query>...
+# The count is the origin's own parse of the wire bytes, independent of the
+# expected string. More than one query is acceptable where iconv and Windows
+# encode the same code point differently (ISO-2022-JP's shift back to ASCII).
 check() {
-    local label="$1" page="$2" want="$3" wantcount="$4"
-    local got count
+    local label="$1" page="$2" wantcount="$3" got count want ok=
+    shift 3
     printf '[%s] ..\t' "$label"
-    got=$(grep -F "/charref/${page}?" "$reqlog" | sed "s|^/charref/${page}?||" | sort -u) || got=
-    if test "$got" != "$want"; then
-        echo "FAIL: expected query '${want}', got '${got}'"
+    got=$(grep -F "/charref/${page}.html?" "$reqlog" | cut -f1 |
+        sed "s|^/charref/${page}.html?||" | sort -u) || got=
+    count=$(grep -F "/charref/${page}.html?" "$reqlog" | cut -f2 | sort -u) || count=
+    for want in "$@"; do
+        if test "$got" == "$want"; then
+            ok=1
+        fi
+    done
+    if test -z "$ok"; then
+        echo "FAIL: expected query '$1', got '${got}'"
         exit 1
     fi
-    # Parameter count the origin would parse out of that query.
-    count=$(printf '%s' "$got" | tr '&' '\n' | grep -c .) || count=0
-    if test "$count" -ne "$wantcount"; then
-        echo "FAIL: origin sees ${count} parameters, expected ${wantcount}"
+    if test "$count" != "$wantcount"; then
+        echo "FAIL: origin parsed '${count}' parameters, expected ${wantcount}"
         exit 1
     fi
     echo "OK (${count} parameters)"
 }
 
 # iso-8859-1 fallback: € is unrepresentable (named and numeric alike), é is not.
-check "charset-less page" qnone.html \
-    'a=%26%238364%3B&b=%26%238364%3B&c=%e9&d=x' 4
+check "charset-less page" qnone 4 \
+    'a=%26%238364%3B&b=%26%238364%3B&c=%e9&d=x'
 # Control: utf-8 represents both, so they go out as their encoded bytes.
-check "declared utf-8 page" qutf8.html \
-    'a=%e2%82%ac&b=%e2%82%ac&c=%c3%a9&d=x' 4
+check "declared utf-8 page" qutf8 4 \
+    'a=%e2%82%ac&b=%e2%82%ac&c=%c3%a9&d=x'
+# Multi-byte: あ and 〜 must survive as their encoded bytes, only € gets escaped.
+# 〜 (U+301C) is the one glibc's shift_jis table does not map back to itself, and
+# iso-2022-jp encodes both of them 7-bit clean.
+check "declared shift_jis page" qsjis 4 \
+    'a=%82%a0&c=%81`&b=%26%238364%3B&d=x'
+check "declared iso-2022-jp page" qjis 4 \
+    "a=%1b\$B\$%22&c=%1b\$B!A&b=%26%238364%3B&d=x" \
+    "a=%1b\$B\$%22%1b(B&c=%1b\$B!A%1b(B&b=%26%238364%3B&d=x"

--- a/tests/139_local-query-charref.test
+++ b/tests/139_local-query-charref.test
@@ -51,16 +51,20 @@ test -n "$port" || {
     --timeout=30 --retries=0 "http://127.0.0.1:${port}/charref/index.html" \
     >"${tmpdir}/crawl.log" 2>&1 || true
 
+query_of() {
+    grep -F "/charref/$1.html?" "$reqlog" | cut -f1 |
+        sed "s|^/charref/$1.html?||" | sort -u
+}
+
 # check <label> <page> <want-parameter-count> <acceptable-query>...
 # The count is the origin's own parse of the wire bytes, independent of the
 # expected string. More than one query is acceptable where iconv and Windows
-# encode the same code point differently (ISO-2022-JP's shift back to ASCII).
+# encode the same code point differently.
 check() {
     local label="$1" page="$2" wantcount="$3" got count want ok=
     shift 3
     printf '[%s] ..\t' "$label"
-    got=$(grep -F "/charref/${page}.html?" "$reqlog" | cut -f1 |
-        sed "s|^/charref/${page}.html?||" | sort -u) || got=
+    got=$(query_of "$page") || got=
     count=$(grep -F "/charref/${page}.html?" "$reqlog" | cut -f2 | sort -u) || count=
     for want in "$@"; do
         if test "$got" == "$want"; then
@@ -85,10 +89,37 @@ check "charset-less page" qnone 4 \
 check "declared utf-8 page" qutf8 4 \
     'a=%e2%82%ac&b=%e2%82%ac&c=%c3%a9&d=x'
 # Multi-byte: あ and 〜 must survive as their encoded bytes, only € gets escaped.
-# 〜 (U+301C) is the one glibc's shift_jis table does not map back to itself, and
-# iso-2022-jp encodes both of them 7-bit clean.
+# The two cp932 tables disagree about 〜 (U+301C): iconv encodes it, Windows maps
+# 0x8160 to U+FF5E instead and reports the substitution, so both are correct.
 check "declared shift_jis page" qsjis 4 \
-    'a=%82%a0&c=%81`&b=%26%238364%3B&d=x'
-check "declared iso-2022-jp page" qjis 4 \
-    "a=%1b\$B\$%22&c=%1b\$B!A&b=%26%238364%3B&d=x" \
-    "a=%1b\$B\$%22%1b(B&c=%1b\$B!A%1b(B&b=%26%238364%3B&d=x"
+    'a=%82%a0&c=%81`&b=%26%238364%3B&d=x' \
+    'a=%82%a0&c=%26%2312316%3B&b=%26%238364%3B&d=x'
+
+# iso-2022-jp encodes both references 7-bit clean, where a round-trip check saw
+# every one of them as unrepresentable. Asserted per field: iconv and Windows
+# differ on the trailing shift back to ASCII, so the bytes are not one string.
+printf '[declared iso-2022-jp page] ..\t'
+jis=$(query_of qjis) || jis=
+jiscount=$(grep -F "/charref/qjis.html?" "$reqlog" | cut -f2 | sort -u) || jiscount=
+for field in ${jis//&/ }; do
+    case "$field" in
+    a=%1b\$B* | c=%1b\$B*)
+        case "$field" in
+        *%26%23*)
+            echo "FAIL: '$field' escaped a reference iso-2022-jp represents"
+            exit 1
+            ;;
+        esac
+        ;;
+    b=%26%238364%3B | d=x) ;;
+    *)
+        echo "FAIL: unexpected field '$field' in '$jis'"
+        exit 1
+        ;;
+    esac
+done
+if test "$jiscount" != 4; then
+    echo "FAIL: origin parsed '${jiscount}' parameters, expected 4"
+    exit 1
+fi
+echo "OK (${jiscount} parameters)"

--- a/tests/139_local-query-charref.test
+++ b/tests/139_local-query-charref.test
@@ -111,7 +111,9 @@ for field in ${jis//&/ }; do
             ;;
         esac
         ;;
-    b=%26%238364%3B | d=x) ;;
+    # WideCharToMultiByte refuses lpUsedDefaultChar on a stateful codepage, so
+    # Windows substitutes € invisibly; harmless, '?' is no query delimiter.
+    b=%26%238364%3B | b=%3f | 'b=?' | d=x) ;;
     *)
         echo "FAIL: unexpected field '$field' in '$jis'"
         exit 1

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1196,6 +1196,42 @@ class Handler(SimpleHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
+    # Character references in a query string (#854). The charset-less page falls
+    # back to iso-8859-1, which represents é but not €; CHARREF_LOG collects the
+    # request-target the origin actually saw.
+    CHARREF_QUERY = "?a=&euro;&b=&#8364;&c=&eacute;&d=x"
+
+    def record_charref(self):
+        log = os.environ.get("CHARREF_LOG")
+        if log:
+            with open(log, "a") as fp:
+                fp.write(self.path + "\n")
+
+    def route_charref(self):
+        path = urlsplit(self.path).path
+        if path == "/charref/index.html":
+            self.send_raw(
+                b'<html><body><a href="none.html">n</a>'
+                b'<a href="utf8.html">u</a></body></html>',
+                "text/html",
+            )
+        elif path in ("/charref/none.html", "/charref/utf8.html"):
+            target = "qnone.html" if path.endswith("none.html") else "qutf8.html"
+            ctype = (
+                "text/html" if target == "qnone.html" else "text/html; charset=utf-8"
+            )
+            body = '<html><body><a href="%s%s">q</a></body></html>' % (
+                target,
+                self.CHARREF_QUERY,
+            )
+            self.send_raw(body.encode(), ctype)
+        elif path in ("/charref/qnone.html", "/charref/qutf8.html"):
+            self.send_raw(b"<html><body>q</body></html>", "text/html")
+        else:
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
     # resume / 416 loop (#206): the first GET stalls after a prefix so the crawl
     # can be interrupted (partial + temp-ref); every later request is 416.
     RESUME_PREFIX = b"PARTIAL-" + b"x" * 4096  # flushed before the stall
@@ -2362,6 +2398,9 @@ class Handler(SimpleHTTPRequestHandler):
         if path.startswith("/charset/"):
             self.route_charset()
             return True
+        if path.startswith("/charref/"):
+            self.route_charref()
+            return True
         # Match percent-encoded paths (accented #157 route) by their decoded form.
         handler = self.ROUTES.get(path) or self.ROUTES.get(unquote(path))
         if handler is None:
@@ -2377,6 +2416,9 @@ class Handler(SimpleHTTPRequestHandler):
         return False
 
     def do_GET(self):
+        # Before reject_fragment(), so an unescaped '#' still shows up recorded.
+        if self.path.startswith("/charref/"):
+            self.record_charref()
         if self.reject_fragment():
             return
         if not self.dispatch():

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1196,36 +1196,39 @@ class Handler(SimpleHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
-    # Character references in a query string (#854). The charset-less page falls
-    # back to iso-8859-1, which represents é but not €; CHARREF_LOG collects the
-    # request-target the origin actually saw.
+    # Character references in a query string (#854). CHARREF_LOG collects the
+    # request-target the origin saw, plus the parameter count it parses out of
+    # it. Per page: a reference the declared charset represents (é, あ) and one
+    # it does not (€).
     CHARREF_QUERY = "?a=&euro;&b=&#8364;&c=&eacute;&d=x"
+    CHARREF_MB_QUERY = "?a=&#12354;&c=&#12316;&b=&euro;&d=x"
+    CHARREF_PAGES = {
+        "none": ("text/html", CHARREF_QUERY),
+        "utf8": ("text/html; charset=utf-8", CHARREF_QUERY),
+        "sjis": ("text/html; charset=shift_jis", CHARREF_MB_QUERY),
+        "jis": ("text/html; charset=iso-2022-jp", CHARREF_MB_QUERY),
+    }
 
     def record_charref(self):
         log = os.environ.get("CHARREF_LOG")
         if log:
+            fields = [f for f in urlsplit(self.path).query.split("&") if f]
             with open(log, "a") as fp:
-                fp.write(self.path + "\n")
+                fp.write("%s\t%d\n" % (self.path, len(fields)))
 
     def route_charref(self):
-        path = urlsplit(self.path).path
-        if path == "/charref/index.html":
-            self.send_raw(
-                b'<html><body><a href="none.html">n</a>'
-                b'<a href="utf8.html">u</a></body></html>',
-                "text/html",
+        name = urlsplit(self.path).path[len("/charref/") :]
+        variant = name[: -len(".html")] if name.endswith(".html") else ""
+        if variant == "index":
+            body = "".join(
+                '<a href="%s.html">%s</a>' % (v, v) for v in self.CHARREF_PAGES
             )
-        elif path in ("/charref/none.html", "/charref/utf8.html"):
-            target = "qnone.html" if path.endswith("none.html") else "qutf8.html"
-            ctype = (
-                "text/html" if target == "qnone.html" else "text/html; charset=utf-8"
-            )
-            body = '<html><body><a href="%s%s">q</a></body></html>' % (
-                target,
-                self.CHARREF_QUERY,
-            )
-            self.send_raw(body.encode(), ctype)
-        elif path in ("/charref/qnone.html", "/charref/qutf8.html"):
+            self.send_raw(("<html><body>%s</body></html>" % body).encode(), "text/html")
+        elif variant in self.CHARREF_PAGES:
+            ctype, query = self.CHARREF_PAGES[variant]
+            body = '<a href="q%s.html%s">q</a>' % (variant, query)
+            self.send_raw(("<html><body>%s</body></html>" % body).encode(), ctype)
+        elif variant[1:] in self.CHARREF_PAGES:
             self.send_raw(b"<html><body>q</body></html>", "text/html")
         else:
             self.send_response(404)

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -202,3 +202,4 @@ TESTS += 122_local-warc-revisit-headers.test
 TESTS += 119_local-proxytrack-ndx-fields2.test
 TESTS += 118_local-proxytrack-arcwrite.test
 TESTS += 133_engine-reentrant-time.test
+TESTS += 139_local-query-charref.test


### PR DESCRIPTION
On a document with no declared charset the fallback is iso-8859-1, and a character reference it cannot represent (`&euro;`, `&#8364;`) was left in the query string as literal source text. The bare `&` and `#` then act as query delimiters, so `q.php?a=&euro;&b=&#8364;&c=&eacute;&d=x` goes out as `q.php?a=&euro;&b=&#8364;&c=%e9&d=x` and the origin parses six parameters where the document expressed four. The URL Standard's percent-encode-after-encoding step covers this case: an unrepresentable code point is written `%26%23`, the code point in decimal, `%3B`. That step lives in the URL parser rather than in form submission, so it binds an `<a href>` too.

The escape is a URL serialization rule, not a text-decoding one, so it is opt-in. A new `hts_unescapeEntitiesWithCharsetSpecial()` takes an `UNESCAPE_ENTITIES_URL_QUERY` flag that only the query-string call site in htsparse.c sets, and `hts_unescapeEntitiesWithCharset()` stays a flags-0 wrapper keeping its text contract and its in-place guarantee. The query is now decoded into a separate buffer, since `&euro;` grows from six bytes to thirteen and would clobber unread source in place. The path side is untouched: it is deliberately normalized to UTF-8 for the filesystem, while the query keeps the document's wire encoding.

Unrepresentability is decided by the encoder itself. iconv fails outright on a code point it cannot encode, so its NULL return is the answer; Windows substitutes `?` and reports success, so `hts_convertStringFromUTF8Strict()` passes `WideCharToMultiByte`'s `lpUsedDefaultChar` and turns a substitution into a NULL. Comparing a round trip instead would have been wrong on both counts: an ASCII result comes back undecoded, and glibc's CJK tables are not injective.

Test 139 crawls a charset-less page, a declared-utf-8 control, and declared shift_jis and iso-2022-jp pages, asserting the request-target the origin recorded along with the parameter count it parsed. The multi-byte pages pin the representable references (あ, 〜) to their encoded bytes, so an over-eager escape is caught too.

Closes #854