### PR TITLE
The frozen-slot spool name is written into a buffer sized from a different string

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -483,18 +483,25 @@ int back_cleanup_background(httrackp * opt, cache_back * cache,
 #ifndef HTS_NO_BACK_ON_DISK
       /* temporarily serialize the entry on disk */
       {
-        int fsz = (int) strlen(back[i].url_sav);
-        char *filename = malloc(fsz + 8 + 1);
+        char BIGSTK tmpname[HTS_URLMAXSIZE * 2];
+        char *filename;
+        hts_boolean named;
+
+        /* The path_html form is not derived from url_sav, so a buffer sized
+           from url_sav overran it whenever -p0 selected that branch. */
+        if (opt->getmode != 0) {
+          named =
+              slprintfbuff(tmpname, sizeof(tmpname), "%s.tmp", back[i].url_sav);
+        } else {
+          named = slprintfbuff(tmpname, sizeof(tmpname), "%stmpfile%d.tmp",
+                               StringBuff(opt->path_html_utf8),
+                               opt->state.tmpnameid++);
+        }
+        filename = named ? strdupt(tmpname) : NULL;
 
         if (filename != NULL) {
           FILE *fp;
 
-          if (opt->getmode != 0) {
-            sprintf(filename, "%s.tmp", back[i].url_sav);
-          } else {
-            sprintf(filename, "%stmpfile%d.tmp",
-                    StringBuff(opt->path_html_utf8), opt->state.tmpnameid++);
-          }
           /* Security check */
           if (fexist_utf8(filename)) {
             hts_log_print(opt, LOG_WARNING,
@@ -525,11 +532,12 @@ int back_cleanup_background(httrackp * opt, cache_back * cache,
                           "file does not exist");
           }
           if (filename != NULL)
-            free(filename);
+            freet(filename);
         } else {
           hts_log_print(opt, LOG_WARNING | LOG_ERRNO,
-                        "engine: warning: serialize error for %s%s: memory full",
-                        back[i].url_adr, back[i].url_fil);
+                        "engine: warning: serialize error for %s%s: %s",
+                        back[i].url_adr, back[i].url_fil,
+                        named ? "memory full" : "temporary filename too long");
         }
       }
 #else

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -483,12 +483,14 @@ int back_cleanup_background(httrackp * opt, cache_back * cache,
 #ifndef HTS_NO_BACK_ON_DISK
       /* temporarily serialize the entry on disk */
       {
-        char BIGSTK tmpname[HTS_URLMAXSIZE * 2];
+        /* +16: room for the ".tmp" the url_sav form appends to a full-length
+           save name, so one buffer holds both shapes */
+        char BIGSTK tmpname[HTS_URLMAXSIZE * 2 + 16];
         char *filename;
         hts_boolean named;
 
-        /* The path_html form is not derived from url_sav, so a buffer sized
-           from url_sav overran it whenever -p0 selected that branch. */
+        /* the -p0 name is not derived from url_sav, so it needs a buffer of
+           its own size rather than the save name's */
         if (opt->getmode != 0) {
           named =
               slprintfbuff(tmpname, sizeof(tmpname), "%s.tmp", back[i].url_sav);

--- a/tests/138_local-spool-name-overflow.test
+++ b/tests/138_local-spool-name-overflow.test
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# A frozen backlog slot spools to disk under a path_html-derived name when -p0
+# is in force, into a buffer sized from the save name instead. A one-character
+# save name (-N '%n') overruns it; only the sanitized build sees the write.
+
+set -e
+: "${top_srcdir:=..}"
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+server=$(nativepath "${testdir}/local-server.py")
+
+python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_spool.XXXXXX") || exit 1
+serverpid=
+cleanup() {
+    stop_server "$serverpid"
+    rm -rf "$tmpdir"
+}
+trap 'set +e; cleanup' EXIT
+trap cleanup HUP INT QUIT PIPE TERM
+
+serverlog="${tmpdir}/server.log"
+: >"$serverlog"
+"$python" "$server" --root "$(nativepath "${testdir}/server-root")" \
+    >"$serverlog" 2>&1 &
+serverpid=$!
+port=
+for _ in $(seq 1 50); do
+    line=$(head -n1 "$serverlog" 2>/dev/null)
+    if test "${line%% *}" == "PORT"; then
+        port="${line#PORT }"
+        break
+    fi
+    kill -0 "$serverpid" 2>/dev/null || {
+        echo "server exited early: $(cat "$serverlog")"
+        exit 1
+    }
+    sleep 0.1
+done
+test -n "$port" || {
+    echo "could not discover server port"
+    exit 1
+}
+
+which httrack >/dev/null || {
+    echo "could not find httrack"
+    exit 1
+}
+
+rc=0
+httrack -O "${tmpdir}/out" --quiet --disable-security-limits --robots=0 \
+    --timeout=30 --retries=0 -p0 -N '%n' -c4 \
+    "http://127.0.0.1:${port}/bakname/index.html" \
+    >"${tmpdir}/log" 2>&1 || rc=$?
+test "$rc" -eq 0 || {
+    echo "httrack exited $rc"
+    cat "${tmpdir}/log"
+    exit 1
+}

--- a/tests/138_local-spool-name-overflow.test
+++ b/tests/138_local-spool-name-overflow.test
@@ -1,8 +1,9 @@
 #!/bin/bash
 #
 # A frozen backlog slot spools to disk under a path_html-derived name when -p0
-# is in force, into a buffer sized from the save name instead. A one-character
-# save name (-N '%n') overruns it; only the sanitized build sees the write.
+# is in force, into a buffer sized from the save name instead; -N '%n' shortens
+# the save name enough to overrun it. -Z pins that a slot really was spooled,
+# so a build with neither fortify nor ASan still tests something.
 
 set -e
 : "${top_srcdir:=..}"
@@ -52,11 +53,28 @@ which httrack >/dev/null || {
 
 rc=0
 httrack -O "${tmpdir}/out" --quiet --disable-security-limits --robots=0 \
-    --timeout=30 --retries=0 -p0 -N '%n' -c4 \
+    --timeout=30 --retries=0 -Z -p0 -N '%n' -c4 \
     "http://127.0.0.1:${port}/bakname/index.html" \
     >"${tmpdir}/log" 2>&1 || rc=$?
 test "$rc" -eq 0 || {
     echo "httrack exited $rc"
     cat "${tmpdir}/log"
+    exit 1
+}
+
+enginelog="${tmpdir}/out/hts-log.txt"
+test -r "$enginelog" || {
+    echo "no engine log at $enginelog"
+    exit 1
+}
+moved=$(grep -c 'slots ready moved to background' "$enginelog" || true)
+test "$moved" -gt 0 || {
+    echo "no slot was ever spooled, so the name was never built"
+    exit 1
+}
+serr=$(grep -c 'serialize error' "$enginelog" || true)
+test "$serr" -eq 0 || {
+    echo "the spool refused to write:"
+    grep 'serialize error' "$enginelog"
     exit 1
 }

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -202,4 +202,5 @@ TESTS += 122_local-warc-revisit-headers.test
 TESTS += 119_local-proxytrack-ndx-fields2.test
 TESTS += 118_local-proxytrack-arcwrite.test
 TESTS += 137_local-charsetless-encoding.test
+TESTS += 138_local-spool-name-overflow.test
 TESTS += 133_engine-reentrant-time.test


### PR DESCRIPTION
`back_cleanup_background()` sizes the buffer for the file it spools a frozen backlog slot into from `url_sav`, then writes one of two names into it. Under `-p0` the name comes from `path_html` and the slot counter instead, so that one escapes the buffer it was sized for; the `url_sav` form fits by construction. A short save name is all it takes: `-N '%n'` over the test server's `bakname/a.bin` writes 43 bytes into 40.

This is not a sanitizer-only finding. An ASan build reports the heap-buffer-overflow, and a plain `-O2` build dies just as reliably in `__sprintf_chk`, since `-D_FORTIFY_SOURCE=3` sees the `malloc` in the same function.

The name is now composed in a bounded buffer and duplicated for the hashtable to own, which also gives the too-long case somewhere to go. Test 138 drives that crawl under `-Z` and requires the engine log to show a slot spooled with no serialize error, so the Windows leg, which has neither fortify nor ASan, still proves the branch ran.

Closes #857