### PR TITLE
url_savename never clamps the final path segment, only the whole path

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -269,15 +269,13 @@ jobs:
           # badmtime needs a filesystem that stores an mtime past gmtime's range;
           # single-file ends on a GUI half needing htsserver, which this job does not build;
           # update-304-leak needs a LeakSanitizer build, which MSVC has no equivalent of;
-          # crash-symbolize needs backtrace(), which Windows has no equivalent of;
-          # longpath-posix: TODO(#852), the last path segment isn't capped on Windows.
+          # crash-symbolize needs backtrace(), which Windows has no equivalent of.
           expected_skips="01_engine-footer-overflow.test
           100_local-purge-longpath.test
           114_local-update-304-leak.test
           120_local-proxytrack-webdav-default.test
           48_local-crange-memresume.test
           71_local-crange-repaircache.test
-          75_engine-longpath-posix.test
           79_local-proxytrack-webdav-mime.test
           80_engine-crash-symbolize.test
           88_local-proxytrack-badmtime.test

--- a/src/htsname.c
+++ b/src/htsname.c
@@ -1545,6 +1545,7 @@ int url_savename(lien_adrfilsave *const afs,
 #endif
 #define MIN_LAST_SEG_RESERVE 12
 #define MAX_LAST_SEG_RESERVE 24
+#define MAX_EXT_LEN 12 /* longest tail kept across a cut, sans the dot */
   if (hts_stringLengthUTF8(afs->save) +
       hts_stringLengthUTF8(StringBuff(opt->path_html_utf8)) >=
       HTS_MAX_PATH_LEN) {
@@ -1613,9 +1614,26 @@ int url_savename(lien_adrfilsave *const afs,
           markStart = (p > lastSeg && p < extDot && wsave[p - 1] == '.')
                           ? p - 1
                           : extDot;
+        } else {
+          // #852: reserve a plain extension too, or the cut costs the page
+          // the ".html" the mirror is browsed by.
+          size_t p = wsaveLen;
+
+          while (p > lastSeg && wsave[p - 1] != '.')
+            p--;
+          if (p > lastSeg + 1 && wsaveLen - p <= MAX_EXT_LEN) {
+            markStart = p - 1;
+          }
         }
-        // head, bounded so the marker still fits, then the marker itself
-        for (i = lastSeg; i < markStart && j + (wsaveLen - markStart) < maxLen;
+        // #852: clamp the name like any directory segment; it was bounded by
+        // the whole path alone, so one component could run to maxLen.
+        const size_t tailLen = wsaveLen - markStart;
+        const size_t headLen =
+            tailLen < MAX_SEG_LEN ? MAX_SEG_LEN - tailLen : 0;
+
+        // head, bounded so the reserved tail still fits, then the tail itself
+        for (i = lastSeg; i < markStart && i - lastSeg < headLen &&
+                          j < maxLen && tailLen < maxLen - j;
              i++)
           wsave[j++] = wsave[i];
         for (i = markStart; i < wsaveLen && j < maxLen; i++)
@@ -1668,6 +1686,7 @@ int url_savename(lien_adrfilsave *const afs,
 #undef MAX_UTF8_SEQ_CHARS
 #undef MIN_LAST_SEG_RESERVE
 #undef MAX_LAST_SEG_RESERVE
+#undef MAX_EXT_LEN
 #undef MAX_SEG_LEN
 #undef HTS_MAX_PATH_LEN
 #undef HTS_PATH_TAIL_RESERVE

--- a/tests/01_engine-savename.test
+++ b/tests/01_engine-savename.test
@@ -155,11 +155,12 @@ full '/%2e%2e/%2e%2e/etc/passwd' 'text/html' '/dev/null/www.example.com///etc/pa
 full '/x.php' 'application/pdf' '/dev/null/www.example.com///evil.exe' 'cdispo=../../evil.exe'
 name $'/evil\rname\t.php' 'text/html' 'evil name .html'
 
-# #133: oversized names are capped only on Windows (MAX_PATH, chopping the
-# extension); elsewhere the platform PATH_MAX leaves a 300-char name whole.
+# #133: oversized names are capped only on Windows, where the name takes the
+# same 48-char clamp as a directory segment and keeps its extension across the
+# cut (#852); elsewhere the platform PATH_MAX leaves a 300-char name whole.
 case "$(uname -s 2>/dev/null)" in
 MINGW* | MSYS* | CYGWIN*)
-    name "/$(printf 'a%.0s' {1..300}).php" 'text/html' "$(printf 'a%.0s' {1..210})"
+    name "/$(printf 'a%.0s' {1..300}).php" 'text/html' "$(printf 'a%.0s' {1..43}).html"
     ;;
 *)
     name "/$(printf 'a%.0s' {1..300}).php" 'text/html' "$(printf 'a%.0s' {1..300}).html"

--- a/tests/75_engine-longpath-posix.test
+++ b/tests/75_engine-longpath-posix.test
@@ -21,8 +21,13 @@ out="$("$httrack_bin" -O /dev/null -#test=savename "$deep/$seg.html" text/html |
 
 case "$(uname -s 2>/dev/null)" in
 MINGW* | MSYS* | CYGWIN*)
-    # TODO(#852): the last path segment isn't capped on Windows; skip until fixed.
-    exit 77
+    # Windows still caps at MAX_PATH: the distinctive tail is cut
+    case "$out" in
+    *"$seg"*)
+        echo "FAIL: Windows should have shortened the long name: '$out'"
+        exit 1
+        ;;
+    esac
     ;;
 *)
     # POSIX: the full name survives, no hashing
@@ -53,6 +58,21 @@ MINGW* | MSYS* | CYGWIN*)
         echo "FAIL: multibyte name not bounded (len=${#mb})"
         exit 1
     fi
+    ;;
+esac
+
+# #852: with the directories eating the budget, the final segment was bounded
+# by the whole path alone, so the cut took its extension with it. Vacuous on
+# Linux, whose ceiling is out of the save buffer's reach; it bites on Windows
+# and macOS.
+dirs="/$(printf 'p%.0s' {1..200})/$(printf 'q%.0s' {1..200})/$(printf 'r%.0s' {1..200})"
+cut="$("$httrack_bin" -O "/$(printf 'o%.0s' {1..100})" -#test=savename \
+    "$dirs/$(printf 'Y%.0s' {1..300}).html" text/html | sed -n 's/^savename: //p')"
+case "$cut" in
+*.html) ;;
+*)
+    echo "FAIL: the cut dropped the extension: '$cut'"
+    exit 1
     ;;
 esac
 


### PR DESCRIPTION
url_savename cuts every directory segment to MAX_SEG_LEN when a save path goes over the ceiling, but copies the final segment under the whole-path budget alone. So one component could run to about 226 characters on Windows while its parent directories were held to 48, and once the directories had eaten the budget the cut landed mid-name and took the extension with it, leaving a page saved with no `.html`. This clamps the name like any other segment and reserves a plain extension across the cut, the way #623 already reserves the `.delayed` marker.

I kept the Windows MAX_PATH ceiling rather than lifting it now that #133's `\\?\` prefixing exists: that prefix does not lift NTFS's 255-byte per-component limit, and it does not make the mirror openable by Explorer, browsers or archivers that never opt in. It is the safety net for the user's `-O` directory, not a licence to emit longer save names.

One correction to the issue: the shortened path itself does stay inside the ceiling (221 chars in the reported case). What escapes is the per-segment clamp.

`75_engine-longpath-posix`'s Windows branch has asserted that clamp all along and simply never ran before #847 broadened the CI glob, so this also drops the `expected_skips` entry #847 added, and the Windows legs are the real proof. The case I added (extension kept across the cut) fails today on Windows and macOS and is vacuous on Linux, whose PATH_MAX ceiling is out of the save buffer's reach. I checked it locally by forcing the Windows and macOS ceilings on a Linux build: before, the name kept all 95 chars on Windows and lost its extension on both; after, 48 chars with `.html` intact, and Linux output byte-identical.

`01_engine-savename`'s Windows arm also had to move, for the same reason #75's Windows branch was skipped: it pinned the pre-fix output, 210 characters of name and no extension at all, under a comment that described the chopped extension as the expected behaviour. For `/aaa...(300).php` served as text/html the name is now 43 a's plus `.html`, 48 characters, the same clamp every directory segment above it already gets.

Closes #852