### PR TITLE
No way to exercise the crash handlers without waiting for a real crash

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -66,6 +66,7 @@ libhttrack_la_SOURCES =  htscore.c htsparse.c htsback.c htscache.c \
 	htscmdline.c htshelp.c htslib.c htsurlport.c htscoremain.c \
 	htsname.c htsrobots.c htstools.c htswizard.c \
 	htsalias.c htsthread.c htsindex.c htsbauth.c \
+	htscrashtest.c \
 	htsmd5.c htscodec.c htswarc.c htschanges.c htssinglefile.c htssitemap.c htsproxy.c htszlib.c htswrap.c htsconcat.c \
 	htsmodules.c htscharset.c punycode.c htsencoding.c htssniff.c \
 	md5.c \
@@ -77,7 +78,7 @@ libhttrack_la_SOURCES =  htscore.c htsparse.c htsback.c htscache.c \
 	htshelp.h htsindex.h htslib.h htsurlport.h htsmd5.h \
 	htsmodules.h htsname.h htsnet.h htssniff.h \
 	htsopt.h htsrobots.h htsthread.h  \
-	htstools.h htswizard.h htswrap.h htscodec.h htswarc.h htschanges.h htssinglefile.h htssitemap.h htsproxy.h htszlib.h  \
+	htscrashtest.h htstools.h htswizard.h htswrap.h htscodec.h htswarc.h htschanges.h htssinglefile.h htssitemap.h htsproxy.h htszlib.h  \
 	htsstrings.h htsarrays.h httrack-library.h \
 	htscharset.h punycode.h htsencoding.h \
 	htsentities.h htsentities.sh htsbasiccharsets.sh htscodepages.h \

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -48,6 +48,7 @@ Please visit our Website: http://www.httrack.com
 #include "htszlib.h"
 #include "htscharset.h"
 #include "htsselftest.h"
+#include "htscrashtest.h"
 #include "htsmd5.h"
 
 #include <ctype.h>
@@ -92,19 +93,6 @@ extern int IPV6_resolver;
     } \
   } \
 } while(0)
-
-#ifdef HTS_CRASH_TEST
-static __attribute__ ((noinline)) void fourty_two(void) {
-  char *const ptr = (char*) (uintptr_t) 0x42;
-  (*ptr)++;
-}
-static __attribute__ ((noinline)) void do_really_crash(void) {
-  fourty_two();
-}
-static __attribute__ ((noinline)) void do_crash(void) {
-  do_really_crash();
-}
-#endif
 
 HTSEXT_API int hts_main(int argc, char **argv) {
   httrackp *opt = hts_create_opt();
@@ -688,6 +676,29 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
 
         htsmain_free();
         return code;
+      }
+    }
+  }
+
+  /* -#c[=KIND]: crash on purpose, to test crash handlers only (see
+     htscrashtest.h). Handled here so it needs no dummy URL either. */
+  {
+    int k;
+
+    for (k = 1; k < argc; k++) {
+      const char *const a = argv[k];
+
+      if (a[0] == '-' && a[1] == '#' && a[2] == 'c' &&
+          (a[3] == '\0' || a[3] == '=')) {
+        if (!hts_crash_test(a[3] == '=' ? a + 4 : NULL)) {
+          char s[256];
+
+          snprintf(s, sizeof(s), "Option #c expects one of: %s",
+                   hts_crash_test_kinds());
+          HTS_PANIC_PRINTF(s);
+        }
+        htsmain_free();
+        return -1;
       }
     }
   }
@@ -2267,12 +2278,6 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                 fprintf(stderr, "** AUTOCHECK OK\n");
                 return 0;
                 break;
-
-#ifdef HTS_CRASH_TEST
-              case 'c':  /* crash test */
-                do_crash();
-                break;
-#endif
 
               default:
                 printf("Internal option %c not recognized\n", *com);

--- a/src/htscrashtest.c
+++ b/src/htscrashtest.c
@@ -1,0 +1,146 @@
+/* ------------------------------------------------------------ */
+/*
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) 2026 Xavier Roche and other contributors
+
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Ethical use: we kindly ask that you NOT use this software to harvest email
+addresses or to collect any other private information about people. Doing so
+would dishonor our work and waste the many hours we have spent on it.
+
+Please visit our Website: http://www.httrack.com
+*/
+
+/* ------------------------------------------------------------ */
+/* On-demand crash, for crash-handler testing. See htscrashtest.h.
+   Several kinds, because a handler coping with one fault is not proven to
+   cope with the others. */
+/* ------------------------------------------------------------ */
+
+#define HTS_INTERNAL_BYTECODE
+
+#include "htscrashtest.h"
+
+#include "htssafe.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(_MSC_VER)
+#define CRASH_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
+#define CRASH_NOINLINE __attribute__((noinline))
+#else
+#define CRASH_NOINLINE
+#endif
+
+/* Read through volatiles so the optimizer cannot see the UB and delete it. */
+static volatile uintptr_t crash_address = 0x42;
+static volatile int crash_keep_recursing = 1;
+
+static CRASH_NOINLINE void fourty_two(void) {
+  volatile char *const ptr = (volatile char *) crash_address;
+
+  (*ptr)++;
+}
+
+/* Nested, so the backtrace under test has more than one frame to name. */
+static CRASH_NOINLINE void crash_segv(void) { fourty_two(); }
+
+/* The engine's own fatal path (htssafe assertions land here). */
+static CRASH_NOINLINE void crash_abort(void) {
+  abortLog("deliberate crash test");
+}
+
+static CRASH_NOINLINE void crash_trap(void) {
+#if defined(_MSC_VER)
+  __debugbreak();
+#elif defined(__GNUC__)
+  __builtin_trap();
+#else
+  abort();
+#endif
+}
+
+/* Reading the frame *after* the call keeps it live across it: returning
+   frame[0] + f(...) instead lets gcc accumulate and loop, never overflowing. */
+static CRASH_NOINLINE char blow_the_stack(size_t depth) {
+  volatile char frame[4096];
+  char deeper;
+
+  frame[0] = (char) depth;
+  if (!crash_keep_recursing) {
+    return frame[0];
+  }
+  deeper = blow_the_stack(depth + 1);
+  return (char) (frame[0] + deeper);
+}
+
+/* Faults with no stack left for the handler, unless it runs on an altstack. */
+static CRASH_NOINLINE void crash_stack(void) { (void) blow_the_stack(0); }
+
+static const struct {
+  const char *name;
+  void (*fn)(void);
+} crash_kinds[] = {
+    {"segv", crash_segv},
+    {"abort", crash_abort},
+    {"trap", crash_trap},
+    {"stack", crash_stack},
+};
+
+#define CRASH_KINDS_COUNT (sizeof(crash_kinds) / sizeof(crash_kinds[0]))
+
+const char *hts_crash_test_kinds(void) {
+  static char list[64];
+
+  if (list[0] == '\0') {
+    size_t i;
+
+    for (i = 0; i < CRASH_KINDS_COUNT; i++) {
+      if (i != 0) {
+        strcatbuff(list, ", ");
+      }
+      strcatbuff(list, crash_kinds[i].name);
+    }
+  }
+  return list;
+}
+
+hts_boolean hts_crash_test(const char *kind) {
+  size_t i;
+
+  if (kind == NULL || *kind == '\0') {
+    kind = crash_kinds[0].name;
+  }
+  for (i = 0; i < CRASH_KINDS_COUNT; i++) {
+    if (strcmp(kind, crash_kinds[i].name) == 0) {
+      fprintf(stderr,
+              "** Deliberate '%s' crash requested (-#c): crash handler test\n",
+              kind);
+      fflush(stderr);
+      crash_kinds[i].fn();
+      /* Reached only if a handler swallowed the fault and resumed. */
+      fprintf(stderr, "** Crash test '%s' did not crash the process\n", kind);
+      fflush(stderr);
+      return HTS_TRUE;
+    }
+  }
+  return HTS_FALSE;
+}

--- a/src/htscrashtest.h
+++ b/src/htscrashtest.h
@@ -1,0 +1,56 @@
+/* ------------------------------------------------------------ */
+/*
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) 2026 Xavier Roche and other contributors
+
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Ethical use: we kindly ask that you NOT use this software to harvest email
+addresses or to collect any other private information about people. Doing so
+would dishonor our work and waste the many hours we have spent on it.
+
+Please visit our Website: http://www.httrack.com
+*/
+
+/* ------------------------------------------------------------ */
+/* On-demand crash, to test crash handlers only: httrack's own fatal-signal
+   handler, WinHTTrack's, and the Android app's mirror-recovery path. Reached
+   through the undocumented -#c option; never called by the engine itself. */
+/* ------------------------------------------------------------ */
+
+#ifndef HTSCRASHTEST_DEFH
+#define HTSCRASHTEST_DEFH
+
+#include "htsglobal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Crash the process on purpose, after announcing it on stderr so the log tells
+   a deliberate crash from a real one. 'kind' selects the fault and defaults to
+   "segv" when NULL or empty; hts_crash_test_kinds() lists the accepted names.
+   Returns HTS_FALSE, without crashing, only when 'kind' is unknown. */
+hts_boolean hts_crash_test(const char *kind);
+
+/* The names hts_crash_test() accepts, comma-separated, for diagnostics. */
+const char *hts_crash_test_kinds(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/libhttrack.vcxproj
+++ b/src/libhttrack.vcxproj
@@ -114,6 +114,7 @@
     <ClCompile Include="htsconcat.c" />
     <ClCompile Include="htscore.c" />
     <ClCompile Include="htscoremain.c" />
+    <ClCompile Include="htscrashtest.c" />
     <ClCompile Include="htsdns_selftest.c" />
     <ClCompile Include="htsencoding.c" />
     <ClCompile Include="htsfilters.c" />

--- a/tests/140_crash-handler.test
+++ b/tests/140_crash-handler.test
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# -#c crashes on purpose so the fatal-signal handler can be tested. Checks the
+# handler still catches, announces and backtraces each fault it claims to
+# handle. Not in the Windows glob: MSVC's abort() can raise a modal fault
+# dialog, which would wedge the runner rather than fail.
+
+set -eu
+
+ulimit -c 0 # a deliberate crash must not litter the box with cores
+
+# Dies from a caught fault, announcing it was deliberate and printing the
+# handler's own report. The handler ends in abort(), so the shell always sees
+# SIGABRT (134) whatever the original signal was.
+assert_crash() {
+    local kind="$1" signum="$2"
+    local out rc=0
+
+    out=$(httrack "-#c=$kind" 2>&1) || rc=$?
+    test "$rc" -eq 134 || exit 1
+    grep -q "Deliberate '$kind' crash requested" <<<"$out" || exit 1
+    grep -q "^Caught signal $signum$" <<<"$out" || exit 1
+    # Symbol names are unreliable under -fvisibility=hidden; match the frame
+    # address form only.
+    grep -q '\[0x[0-9a-f][0-9a-f]*\]' <<<"$out" || exit 1
+}
+
+assert_crash segv 11
+assert_crash abort 6
+
+# No kind means segv.
+rc=0
+out=$(httrack -#c 2>&1) || rc=$?
+test "$rc" -eq 134 || exit 1
+grep -q "Deliberate 'segv' crash requested" <<<"$out" || exit 1
+
+# An unknown kind is a usage error: the exit is the usual panic 255, not a
+# death, and the diagnostic names the kinds.
+rc=0
+err=$(httrack -#c=bogus 2>&1) || rc=$?
+test "$rc" -eq 255 || exit 1
+grep -q "expects one of:" <<<"$err" || exit 1
+grep -q "segv" <<<"$err" || exit 1
+if grep -q "Deliberate" <<<"$err"; then
+    exit 1
+fi
+
+# -#C (capital) is the cache lister and must not be swallowed by -#c.
+rc=0
+err=$(httrack -#C 2>&1) || rc=$?
+test "$rc" -eq 255 || exit 1
+if grep -q "Deliberate" <<<"$err"; then
+    exit 1
+fi

--- a/tests/140_crash-handler.test
+++ b/tests/140_crash-handler.test
@@ -20,9 +20,12 @@ assert_crash() {
     test "$rc" -eq 134 || exit 1
     grep -q "Deliberate '$kind' crash requested" <<<"$out" || exit 1
     grep -q "^Caught signal $signum$" <<<"$out" || exit 1
-    # Symbol names are unreliable under -fvisibility=hidden; match the frame
-    # address form only.
-    grep -q '\[0x[0-9a-f][0-9a-f]*\]' <<<"$out" || exit 1
+    # A frame, or the notice where the OS has no backtrace() (anything but
+    # Linux). Symbol names are unreliable under -fvisibility=hidden, and the
+    # frame format is libc-specific, so match an address only.
+    grep -qE '0x[0-9a-f]+|No stack trace available' <<<"$out" || exit 1
+    # The handler ran to its end rather than faulting midway.
+    grep -q "Please report the problem" <<<"$out" || exit 1
 }
 
 assert_crash segv 11

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -211,3 +211,4 @@ TESTS += 137_local-charsetless-encoding.test
 TESTS += 138_local-spool-name-overflow.test
 TESTS += 133_engine-reentrant-time.test
 TESTS += 139_local-query-charref.test
+TESTS += 140_crash-handler.test


### PR DESCRIPTION
Adds `-#c[=KIND]`, a hidden option that faults on purpose so the crash handlers can be tested: httrack's own fatal-signal handler, WinHTTrack's, and the Android app's mirror-recovery path. Four kinds (segv, abort, trap, stack), since a handler that copes with one fault is not proven to cope with another. Each prints a line to stderr saying the crash was asked for, so a log never reads as a real failure. The code sits in its own `src/htscrashtest.c`, with only the option parsing in `htscoremain.c` next to `-#test`, which also means a crash test needs no dummy URL.

The facility was already in the tree behind `#ifdef HTS_CRASH_TEST`, defined nowhere, so it had never been through a compiler. It is now always compiled in rather than hidden behind a configure flag, because the binary worth testing is the shipped one: the APK, the installer, the distro package. Reaching it takes local command-line access and it only kills the caller's own process. Test 140 checks each fault is caught, announced and backtraced, and that an unknown kind is a usage error instead of a crash; it kills all four mutants of the crash table. It stays out of the Windows CI glob because MSVC's `abort()` can raise a modal fault dialog, which would wedge the runner rather than fail it.

One thing the option found straight away: `-#c=stack` dies with a bare SIGSEGV and no handler output, because `sig_fatal` runs on the exhausted stack with no `sigaltstack`. Filed separately.
