### PR TITLE
Dependabot does not watch the coucal submodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  # src/coucal is a hard build dependency, and nothing else notices when it moves.
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,8 +178,14 @@ jobs:
 
       - name: Test
         timeout-minutes: 20
+        # Each test holds a python server plus a crawl, so the ceiling is memory,
+        # not cores: at ncpu*2 macos-15 SIGKILLs test servers and the -E/-M timing
+        # tests miss their budgets. Stay at ncpu. The echo is here because the
+        # image's core count is what decides this, and it is not otherwise logged.
         run: |
-          jobs=$(( $(sysctl -n hw.ncpu) * 2 )); [ "$jobs" -le 16 ] || jobs=16
+          ncpu=$(sysctl -n hw.ncpu)
+          echo "ncpu=$ncpu memsize=$(sysctl -n hw.memsize)"
+          jobs=$ncpu; [ "$jobs" -le 8 ] || jobs=8
           make check -j"$jobs"
 
       - name: Print the test log on failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,14 +178,8 @@ jobs:
 
       - name: Test
         timeout-minutes: 20
-        # Each test holds a python server plus a crawl, so the ceiling is memory,
-        # not cores: at ncpu*2 macos-15 SIGKILLs test servers and the -E/-M timing
-        # tests miss their budgets. Stay at ncpu. The echo is here because the
-        # image's core count is what decides this, and it is not otherwise logged.
         run: |
-          ncpu=$(sysctl -n hw.ncpu)
-          echo "ncpu=$ncpu memsize=$(sysctl -n hw.memsize)"
-          jobs=$ncpu; [ "$jobs" -le 8 ] || jobs=8
+          jobs=$(( $(sysctl -n hw.ncpu) * 2 )); [ "$jobs" -le 16 ] || jobs=16
           make check -j"$jobs"
 
       - name: Print the test log on failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
   # so point configure at it; everything else is in the SDK or default paths.
   macos:
     name: build (macOS arm64, clang)
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v7
         with:
@@ -191,7 +191,7 @@ jobs:
   # temp prefix, then check webhttrack brings up htsserver and serves the UI.
   webhttrack-macos:
     name: webhttrack smoke (macOS arm64)
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
   # so point configure at it; everything else is in the SDK or default paths.
   macos:
     name: build (macOS arm64, clang)
-    runs-on: macos-15
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v7
         with:
@@ -191,7 +191,7 @@ jobs:
   # temp prefix, then check webhttrack brings up htsserver and serves the UI.
   webhttrack-macos:
     name: webhttrack smoke (macOS arm64)
-    runs-on: macos-15
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
`src/coucal` is a hard build dependency and nothing notices when it moves; Dependabot already covers vcpkg and the action pins, so this closes the gap.

This PR originally also moved the macOS legs to macos-15, since GitHub lists macos-14 as deprecated. That is reverted and split out into #870: macos-15 fails six tests macos-14 passes, for reasons unrelated to the label, and the image has no announced removal date.