### PR TITLE
A cold Python start makes 17 crawl tests miss the server port

### DIFF
--- a/tests/112_local-single-file-fragment.test
+++ b/tests/112_local-single-file-fragment.test
@@ -50,17 +50,7 @@ serverlog="${tmpdir}/server.log"
 : >"$serverlog"
 "$python" "$server" --root "$(nativepath "$doc")" >"$serverlog" 2>&1 &
 serverpid=$!
-port=
-for _ in $(seq 1 50); do
-    line=$(head -n1 "$serverlog" 2>/dev/null)
-    if test "${line%% *}" == "PORT"; then
-        port="${line#PORT }"
-        break
-    fi
-    kill -0 "$serverpid" 2>/dev/null || fail "server exited: $(cat "$serverlog")"
-    sleep 0.1
-done
-test -n "$port" || fail "could not discover server port"
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 base="http://127.0.0.1:${port}"
 
 which httrack >/dev/null || fail "could not find httrack"

--- a/tests/114_local-update-304-leak.test
+++ b/tests/114_local-update-304-leak.test
@@ -38,23 +38,7 @@ serverlog="${tmpdir}/server.log"
 : >"$serverlog"
 "$python" "$server" --root "$root" >"$serverlog" 2>&1 &
 serverpid=$!
-port=
-for _ in $(seq 1 50); do
-    line=$(head -n1 "$serverlog" 2>/dev/null)
-    if test "${line%% *}" == "PORT"; then
-        port="${line#PORT }"
-        break
-    fi
-    kill -0 "$serverpid" 2>/dev/null || {
-        echo "server exited early: $(cat "$serverlog")"
-        exit 1
-    }
-    sleep 0.1
-done
-test -n "$port" || {
-    echo "could not discover server port"
-    exit 1
-}
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 
 out="${tmpdir}/crawl"
 mkdir "$out"

--- a/tests/137_local-charsetless-encoding.test
+++ b/tests/137_local-charsetless-encoding.test
@@ -27,23 +27,7 @@ mkdir "${tmpdir}/docroot"
 "$python" "$server" --root "$(nativepath "${tmpdir}/docroot")" \
     >"$serverlog" 2>&1 &
 serverpid=$!
-port=
-for _ in $(seq 1 50); do
-    line=$(head -n1 "$serverlog" 2>/dev/null)
-    if test "${line%% *}" == "PORT"; then
-        port="${line#PORT }"
-        break
-    fi
-    kill -0 "$serverpid" 2>/dev/null || {
-        echo "server exited early: $(cat "$serverlog")"
-        exit 1
-    }
-    sleep 0.1
-done
-test -n "$port" || {
-    echo "could not discover server port"
-    exit 1
-}
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 base="http://127.0.0.1:${port}"
 
 which httrack >/dev/null || {

--- a/tests/138_local-spool-name-overflow.test
+++ b/tests/138_local-spool-name-overflow.test
@@ -28,23 +28,7 @@ serverlog="${tmpdir}/server.log"
 "$python" "$server" --root "$(nativepath "${testdir}/server-root")" \
     >"$serverlog" 2>&1 &
 serverpid=$!
-port=
-for _ in $(seq 1 50); do
-    line=$(head -n1 "$serverlog" 2>/dev/null)
-    if test "${line%% *}" == "PORT"; then
-        port="${line#PORT }"
-        break
-    fi
-    kill -0 "$serverpid" 2>/dev/null || {
-        echo "server exited early: $(cat "$serverlog")"
-        exit 1
-    }
-    sleep 0.1
-done
-test -n "$port" || {
-    echo "could not discover server port"
-    exit 1
-}
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 
 which httrack >/dev/null || {
     echo "could not find httrack"

--- a/tests/139_local-query-charref.test
+++ b/tests/139_local-query-charref.test
@@ -29,23 +29,7 @@ reqlog="${tmpdir}/requests.txt"
 : >"$reqlog"
 CHARREF_LOG="$reqlog" "$python" "$server" --root "$root" >"$serverlog" 2>&1 &
 serverpid=$!
-port=
-for _ in $(seq 1 50); do
-    line=$(head -n1 "$serverlog" 2>/dev/null) || line=
-    if test "${line%% *}" == "PORT"; then
-        port="${line#PORT }"
-        break
-    fi
-    kill -0 "$serverpid" 2>/dev/null || {
-        echo "server exited early: $(cat "$serverlog")"
-        exit 1
-    }
-    sleep 0.1
-done
-test -n "$port" || {
-    echo "could not discover server port"
-    exit 1
-}
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 
 "$httrack" -O "${tmpdir}/crawl" --quiet --disable-security-limits --robots=0 \
     --timeout=30 --retries=0 "http://127.0.0.1:${port}/charref/index.html" \

--- a/tests/19_local-connect-fallback.test
+++ b/tests/19_local-connect-fallback.test
@@ -46,23 +46,7 @@ trap 'set +e; cleanup' EXIT
 # bind the live server to 127.0.0.1 only, so 127.0.0.2 refuses the connect
 "$python" "$server" --root "$root" --bind 127.0.0.1 >"$tmpdir/srv.out" 2>"$tmpdir/srv.err" &
 serverpid=$!
-port=
-for _ in $(seq 1 50); do
-    line=$(head -n1 "$tmpdir/srv.out" 2>/dev/null || true)
-    if test "${line%% *}" == "PORT"; then
-        port="${line#PORT }"
-        break
-    fi
-    kill -0 "$serverpid" 2>/dev/null || {
-        echo "server exited early: $(cat "$tmpdir/srv.err")"
-        exit 1
-    }
-    sleep 0.1
-done
-test -n "$port" || {
-    echo "could not discover server port"
-    exit 1
-}
+port=$(discover_server_port "$tmpdir/srv.out" "$serverpid") || exit 1
 
 out="$tmpdir/crawl"
 # macOS has only 127.0.0.1, so the dead 127.0.0.x connects block to the timeout

--- a/tests/20_local-resume-loop.test
+++ b/tests/20_local-resume-loop.test
@@ -29,23 +29,7 @@ serverlog="${tmpdir}/server.log"
 counter="${tmpdir}/blobcount"
 RESUME_COUNTER="$counter" "$python" "$server" --root "$root" >"$serverlog" 2>&1 &
 serverpid=$!
-port=
-for _ in $(seq 1 50); do
-    line=$(head -n1 "$serverlog" 2>/dev/null)
-    if test "${line%% *}" == "PORT"; then
-        port="${line#PORT }"
-        break
-    fi
-    kill -0 "$serverpid" 2>/dev/null || {
-        echo "server exited early: $(cat "$serverlog")"
-        exit 1
-    }
-    sleep 0.1
-done
-test -n "$port" || {
-    echo "could not discover server port"
-    exit 1
-}
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 base="http://127.0.0.1:${port}"
 
 which httrack >/dev/null || {

--- a/tests/24_local-resume-overlap.test
+++ b/tests/24_local-resume-overlap.test
@@ -36,23 +36,7 @@ OVERLAP_COUNTER="$counter" OVERLAP_RESUMED="$resumed" \
     "$python" "$server" --root "$root" \
     >"$serverlog" 2>&1 &
 serverpid=$!
-port=
-for _ in $(seq 1 50); do
-    line=$(head -n1 "$serverlog" 2>/dev/null)
-    if test "${line%% *}" == "PORT"; then
-        port="${line#PORT }"
-        break
-    fi
-    kill -0 "$serverpid" 2>/dev/null || {
-        echo "server exited early: $(cat "$serverlog")"
-        exit 1
-    }
-    sleep 0.1
-done
-test -n "$port" || {
-    echo "could not discover server port"
-    exit 1
-}
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 base="http://127.0.0.1:${port}"
 
 which httrack >/dev/null || {

--- a/tests/46_local-update-304-resume.test
+++ b/tests/46_local-update-304-resume.test
@@ -30,23 +30,7 @@ counter="${tmpdir}/reqcount"
 mark="${tmpdir}/got304"
 RESUME304_COUNTER="$counter" RESUME304_MARK="$mark" "$python" "$server" --root "$root" >"$serverlog" 2>&1 &
 serverpid=$!
-port=
-for _ in $(seq 1 50); do
-    line=$(head -n1 "$serverlog" 2>/dev/null)
-    if test "${line%% *}" == "PORT"; then
-        port="${line#PORT }"
-        break
-    fi
-    kill -0 "$serverpid" 2>/dev/null || {
-        echo "server exited early: $(cat "$serverlog")"
-        exit 1
-    }
-    sleep 0.1
-done
-test -n "$port" || {
-    echo "could not discover server port"
-    exit 1
-}
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 base="http://127.0.0.1:${port}"
 
 which httrack >/dev/null || {

--- a/tests/47_local-crange-overflow.test
+++ b/tests/47_local-crange-overflow.test
@@ -29,23 +29,7 @@ serverlog="${tmpdir}/server.log"
 : >"$serverlog"
 "$python" "$server" --root "$root" >"$serverlog" 2>&1 &
 serverpid=$!
-port=
-for _ in $(seq 1 50); do
-    line=$(head -n1 "$serverlog" 2>/dev/null)
-    if test "${line%% *}" == "PORT"; then
-        port="${line#PORT }"
-        break
-    fi
-    kill -0 "$serverpid" 2>/dev/null || {
-        echo "server exited early: $(cat "$serverlog")"
-        exit 1
-    }
-    sleep 0.1
-done
-test -n "$port" || {
-    echo "could not discover server port"
-    exit 1
-}
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 base="http://127.0.0.1:${port}"
 
 which httrack >/dev/null || {

--- a/tests/48_local-crange-memresume.test
+++ b/tests/48_local-crange-memresume.test
@@ -37,23 +37,7 @@ serverlog="${tmpdir}/server.log"
 : >"$serverlog"
 "$python" "$server" --root "$root" >"$serverlog" 2>&1 &
 serverpid=$!
-port=
-for _ in $(seq 1 50); do
-    line=$(head -n1 "$serverlog" 2>/dev/null)
-    if test "${line%% *}" == "PORT"; then
-        port="${line#PORT }"
-        break
-    fi
-    kill -0 "$serverpid" 2>/dev/null || {
-        echo "server exited early: $(cat "$serverlog")"
-        exit 1
-    }
-    sleep 0.1
-done
-test -n "$port" || {
-    echo "could not discover server port"
-    exit 1
-}
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 base="http://127.0.0.1:${port}"
 
 which httrack >/dev/null || {

--- a/tests/56_local-proxy-noleak.test
+++ b/tests/56_local-proxy-noleak.test
@@ -36,23 +36,7 @@ trap 'set +e; cleanup' EXIT
 LOCAL_SERVER_VERBOSE=1 "$python" "$server" --root "$root" --bind 127.0.0.1 \
     >"$tmpdir/srv.out" 2>"$tmpdir/srv.err" &
 serverpid=$!
-port=
-for _ in $(seq 1 50); do
-    line=$(head -n1 "$tmpdir/srv.out" 2>/dev/null || true)
-    if test "${line%% *}" == "PORT"; then
-        port="${line#PORT }"
-        break
-    fi
-    kill -0 "$serverpid" 2>/dev/null || {
-        echo "server exited early: $(cat "$tmpdir/srv.err")"
-        exit 1
-    }
-    sleep 0.1
-done
-test -n "$port" || {
-    echo "could not discover server port"
-    exit 1
-}
+port=$(discover_server_port "$tmpdir/srv.out" "$serverpid") || exit 1
 
 # a proxy port nothing listens on: grab a free one and let it close (refuses).
 deadproxy=$("$python" -c \

--- a/tests/59_local-tls-stall.test
+++ b/tests/59_local-tls-stall.test
@@ -36,21 +36,7 @@ start_stall_server() {
     shift
     "$python" "$server" "$@" >"$tmpdir/$tag.out" 2>"$tmpdir/$tag.err" &
     serverpid=$!
-    port=
-    for _ in $(seq 1 50); do
-        line=$(head -n1 "$tmpdir/$tag.out" 2>/dev/null || true)
-        if test "${line%% *}" == "PORT"; then
-            port="${line#PORT }"
-            return 0
-        fi
-        kill -0 "$serverpid" 2>/dev/null || {
-            echo "server exited early: $(cat "$tmpdir/$tag.err")"
-            exit 1
-        }
-        sleep 0.1
-    done
-    echo "could not discover server port"
-    exit 1
+    port=$(discover_server_port "$tmpdir/$tag.out" "$serverpid") || exit 1
 }
 
 # no -E/--max-time on purpose: --timeout is the only thing that can end these.

--- a/tests/71_local-crange-repaircache.test
+++ b/tests/71_local-crange-repaircache.test
@@ -39,23 +39,7 @@ serverlog="${tmpdir}/server.log"
 : >"$serverlog"
 "$python" "$server" --root "$root" >"$serverlog" 2>&1 &
 serverpid=$!
-port=
-for _ in $(seq 1 50); do
-    line=$(head -n1 "$serverlog" 2>/dev/null)
-    if test "${line%% *}" == "PORT"; then
-        port="${line#PORT }"
-        break
-    fi
-    kill -0 "$serverpid" 2>/dev/null || {
-        echo "server exited early: $(cat "$serverlog")"
-        exit 1
-    }
-    sleep 0.1
-done
-test -n "$port" || {
-    echo "could not discover server port"
-    exit 1
-}
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 base="http://127.0.0.1:${port}"
 
 which httrack >/dev/null || {

--- a/tests/76_cli-resize.test
+++ b/tests/76_cli-resize.test
@@ -30,23 +30,7 @@ serverlog="${tmpdir}/server.log"
 : >"$serverlog"
 "$python" "$server" --root "$root" >"$serverlog" 2>&1 &
 serverpid=$!
-port=
-for _ in $(seq 1 50); do
-    line=$(head -n1 "$serverlog" 2>/dev/null)
-    if test "${line%% *}" == "PORT"; then
-        port="${line#PORT }"
-        break
-    fi
-    kill -0 "$serverpid" 2>/dev/null || {
-        echo "server exited early: $(cat "$serverlog")"
-        exit 1
-    }
-    sleep 0.1
-done
-test -n "$port" || {
-    echo "could not discover server port"
-    exit 1
-}
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 
 which httrack >/dev/null || {
     echo "could not find httrack"

--- a/tests/93_local-changes.test
+++ b/tests/93_local-changes.test
@@ -26,23 +26,7 @@ serverlog="${tmpdir}/server.log"
 : >"$serverlog"
 "$python" "$server" --root "$root" >"$serverlog" 2>&1 &
 serverpid=$!
-port=
-for _ in $(seq 1 50); do
-    line=$(head -n1 "$serverlog" 2>/dev/null)
-    if test "${line%% *}" == "PORT"; then
-        port="${line#PORT }"
-        break
-    fi
-    kill -0 "$serverpid" 2>/dev/null || {
-        echo "server exited early: $(cat "$serverlog")"
-        exit 1
-    }
-    sleep 0.1
-done
-test -n "$port" || {
-    echo "could not discover server port"
-    exit 1
-}
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 base="http://127.0.0.1:${port}"
 
 which httrack >/dev/null || {

--- a/tests/94_local-single-file.test
+++ b/tests/94_local-single-file.test
@@ -66,23 +66,7 @@ serverlog="${tmpdir}/server.log"
 : >"$serverlog"
 "$python" "$server" --root "$(nativepath "$doc")" >"$serverlog" 2>&1 &
 serverpid=$!
-port=
-for _ in $(seq 1 50); do
-    line=$(head -n1 "$serverlog" 2>/dev/null)
-    if test "${line%% *}" == "PORT"; then
-        port="${line#PORT }"
-        break
-    fi
-    kill -0 "$serverpid" 2>/dev/null || {
-        echo "server exited early: $(cat "$serverlog")"
-        exit 1
-    }
-    sleep 0.1
-done
-test -n "$port" || {
-    echo "could not discover server port"
-    exit 1
-}
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 base="http://127.0.0.1:${port}"
 
 which httrack >/dev/null || {

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -66,6 +66,27 @@ stop_server() {
     return 0
 }
 
+# Echo the port local-server.py announces on $1 (its log), $2 being its pid.
+# Waits 30s: a cold Python start under a parallel `make check -jN` lags well
+# past a second, and 5s was tight enough that macos-15 missed it on 15 tests.
+# Matches anywhere, since a warning merged via 2>&1 can precede the line.
+discover_server_port() {
+    local log=$1 pid=$2 line _i
+    for _i in $(seq 1 300); do
+        if line=$(grep -m1 '^PORT ' "$log" 2>/dev/null); then
+            printf '%s\n' "${line#PORT }"
+            return 0
+        fi
+        kill -0 "$pid" 2>/dev/null || {
+            echo "server exited early: $(cat "$log" 2>/dev/null)" >&2
+            return 1
+        }
+        sleep 0.1
+    done
+    echo "could not discover server port: $(cat "$log" 2>/dev/null)" >&2
+    return 1
+}
+
 # Dump and clear the crawl logs a hard-killed test leaves in TMPDIR (its cleanup
 # trap never ran): hts-log.txt alone records "More than N seconds passed.. giving
 # up", so a wedge past --max-time is undiagnosable without it (#605).


### PR DESCRIPTION
`local-crawl.sh` waits 30s for `local-server.py`'s `PORT <n>` line and matches it anywhere in the log, because a cold Python start under a parallel `make check` lags past a second and a warning merged via `2>&1` can precede the line. The 17 tests that launch the server themselves carried an older copy of that loop: 5s, and only `head -n1`. Both limits are real, and neither is macOS-specific — macos-15 just has enough startup margin to cross them, failing 15 of the 17 where macos-14 passed on luck.

The proven idiom moves into `testlib.sh` beside `stop_server`. Callers also inherit the failure-path log dump `local-crawl.sh` already had, which is why the CI failure could only say "could not discover server port" with no way to distinguish a slow start from a dead server.

Verified by differential rather than by the suite going green, since these tests already pass on a fast machine: driving both idioms against a synthetic server, the old one misses on a preamble line and on a 7s start while the new one finds the port, and both agree on an immediate clean start — so the probe isn't rigged against the old code.