### PR TITLE
The hub lede reads like a changelog, and the rings are gone

### DIFF
--- a/html/doc.css
+++ b/html/doc.css
@@ -72,6 +72,18 @@ body {
 	background: var(--panel);
 	border-bottom: 6px solid #000;
 	padding: 1.5rem;
+	/* The rings the 2007 pages carried. The image has the light panel colour baked
+	   into it, so it is dropped rather than inverted in dark mode. */
+	background-image: url(images/bg_rings.gif);
+	background-repeat: no-repeat;
+	background-position: top right;
+}
+
+@media (prefers-color-scheme: dark) {
+	.wrap { background-image: none; }
+
+	/* The wordmark is black on transparent, and all but vanishes on the dark field. */
+	.masthead img { filter: invert(1); }
 }
 
 @media (min-width: 62rem) {

--- a/html/index.html
+++ b/html/index.html
@@ -23,10 +23,13 @@
 <h1>HTTrack documentation</h1>
 
 <p class="lede">HTTrack copies a website to your disk, rewriting its links so the local copy
-browses like the original. It can resume an interrupted download, update a mirror it made
-earlier, mirror over HTTPS and through a proxy, save the crawl as a WARC archive, and report
-what changed since last time. There is a Windows interface (WinHTTrack), one for Linux and
-Unix (WebHTTrack), an Android app, and a command-line program on every platform.</p>
+browses like the original. It speaks HTTPS, goes through a proxy when you need one, and follows
+how a current site puts its pages together, including responsive image sets and lazily loaded
+media. It can resume an interrupted download, and update an existing mirror without fetching
+again what has not changed.</p>
+
+<p>There is a Windows interface (WinHTTrack), one for Linux and Unix (WebHTTrack), an Android
+app, and a command-line program on every platform.</p>
 
 <ul class="hub">
 


### PR DESCRIPTION
The lede led with WARC output and the change report, which are niche features, because those happened to be the last things merged. What matters to someone arriving now is that HTTPS works, that proxies work, that a current page with responsive image sets and lazy loading captures properly, and that an update does not re-fetch the whole site.

The rings the 2007 pages carried behind their content panel come back, and now on every page rather than the handful that had them. The image has the light panel colour baked in, so dark mode drops it rather than showing a pale rectangle. It loads fine from a `file://` URL, which was the open question.

While in there: the wordmark is black on transparent and all but vanished against the dark field, which every page inherited along with the shared chrome. It is inverted in dark mode now.