### PR TITLE
Release 3.49.15

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,10 +29,10 @@ AC_CONFIG_SRCDIR(src/httrack.c)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
-# 3:7:0: 3.49.15 appends to httrackp's tail (harmless) and to htsblk's, but lien_back
-# embeds htsblk by value, so lien_back.is_update and everything after it shift +8.
-# Soname deliberately stays .so.3, as in 3.49.14: HTTrackQt is the only consumer of the
-# installed headers and is tracked separately, so a libhttrack4 rename isn't worth it.
+# 3:7:0: htsblk gained a tail field and lien_back embeds it by value, so
+# lien_back.is_update and everything after it shift +8 (httrackp's own tail growth
+# moves nothing). Soname stays .so.3: HTTrackQt is the only consumer of the installed
+# headers, so a libhttrack4 rename isn't worth it.
 # (3:0:0 was the htsblk mime-buffer widening, the ABI break that moved .so.2 -> .so.3.)
 VERSION_INFO="3:7:0"
 AM_MAINTAINER_MODE

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.71])
 
-AC_INIT([httrack], [3.49.14], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
+AC_INIT([httrack], [3.49.15], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
 AC_COPYRIGHT([
 HTTrack Website Copier, Offline Browser for Windows and Unix
 Copyright (C) 1998-2015 Xavier Roche and other contributors
@@ -29,12 +29,12 @@ AC_CONFIG_SRCDIR(src/httrack.c)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
-# 3:6:0: 3.49.14 grows two installed structs from the inside (htsoptstate sits mid-
-# httrackp, htsblk mid-lien_back), so the fields after them shift: httrackp.cookies_file
-# +8, lien_back.http11 +48. Soname deliberately stays .so.3: the shifted fields are
-# 3.49-era additions no external consumer reaches, and a libhttrack3 rename isn't worth it.
+# 3:7:0: 3.49.15 appends to httrackp's tail (harmless) and to htsblk's, but lien_back
+# embeds htsblk by value, so lien_back.is_update and everything after it shift +8.
+# Soname deliberately stays .so.3, as in 3.49.14: HTTrackQt is the only consumer of the
+# installed headers and is tracked separately, so a libhttrack4 rename isn't worth it.
 # (3:0:0 was the htsblk mime-buffer widening, the ABI break that moved .so.2 -> .so.3.)
-VERSION_INFO="3:6:0"
+VERSION_INFO="3:7:0"
 AM_MAINTAINER_MODE
 AC_USE_SYSTEM_EXTENSIONS
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
 httrack (3.49.15-1) unstable; urgency=medium
 
   * New upstream release: single-file mirrors with inlined assets, sitemap
-    ingestion, a change report between crawls, and a long run of --update and
-    FTP data-loss fixes plus parser hardening; full list in history.txt.
+    ingestion, a change report between crawls, and numerous --update, FTP and
+    parser fixes; full list in history.txt.
   * httrack-doc grows by roughly 1 MB: the offline guide now ships screenshots
     of the WinHTTrack, WebHTTrack and Android interfaces.
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+httrack (3.49.15-1) unstable; urgency=medium
+
+  * New upstream release: single-file mirrors with inlined assets, sitemap
+    ingestion, a change report between crawls, and a long run of --update and
+    FTP data-loss fixes plus parser hardening; full list in history.txt.
+  * httrack-doc grows by roughly 1 MB: the offline guide now ships screenshots
+    of the WinHTTrack, WebHTTrack and Android interfaces.
+
+ -- Xavier Roche <xavier@debian.org>  Thu, 30 Jul 2026 10:40:08 +0200
+
 httrack (3.49.14-1) unstable; urgency=medium
 
   * New upstream release: WARC/WACZ archive output, Windows long-path support,

--- a/history.txt
+++ b/history.txt
@@ -16,16 +16,21 @@ This file lists all changes and fixes that have been made for HTTrack
 + Fixed: several backward scans from strlen(s) - 1 read before their buffer on an empty string (#730, #768, #770, #814, #821)
 + Fixed: a URL could be saved onto the engine's own temporary files, and the final path segment was never clamped (#774, #842, #852)
 + Fixed: a query-string character reference the page charset cannot represent was left unescaped, changing how the query parses (#854)
++ Fixed: a second --update pass overwrote the previous WARC and regenerated a page-less WACZ (#759)
 + Fixed: WARC output dropped URLs of 1005 bytes or more, archived nothing for a 304 revisit, and marked an engine-forced not-modified as one the server sent (#778, #785, #826, #838, #839)
 + Fixed: ProxyTrack overflowed its .arc header block, walked past the end of an .ndx buffer, trusted an unparsed offset, and crashed on a PROPFIND or on an entry with no usable Last-Modified (#793, #820, #825, #828)
-+ Fixed: webhttrack leaked the session id into crawled pages, overflowed its command line so a quoted value could inject flags, and let a posted project path repoint the served root (#706, #707, #710)
++ Fixed: webhttrack leaked the session id into crawled pages, overflowed its command line so a quoted value could inject flags, let a posted project path repoint the served root, and built its redirect Location in a 256-byte stack buffer (#700, #706, #707, #710)
 + Fixed: in the web GUI, options ticked on by default could not be un-ticked, "max site size" set a per-file cap instead of the HTML one, and the mirror link on the finished page could not be followed (#708, #709, #725)
 + Fixed: htsserver labelled every PNG as image/gif and offered JPEG as a download, and an unauthenticated GET of a directory spun the server forever (#724, #875)
++ Fixed: webhttrack hung at exit when no mirror had been launched (#753)
 + Fixed: oversized cache and header fields aborted the engine or overflowed a neighbouring field instead of being clipped (#701, #715, #717, #722, #732)
++ Fixed: a -%S rules file of 4 GB or more overran the heap (#702)
 + Fixed: the CLI display did not repaint when the terminal was resized (#97)
++ Fixed: a document with no declared charset double-encoded the title lifted for the local index (#848)
 + Fixed: a fragment on an inlined reference was dropped, losing an SVG sprite selector (#766)
 + Fixed: several time helpers handed out libc's shared gmtime/localtime static rather than a reentrant breakdown (#794, #806)
 + Changed: fatal-signal backtraces name engine frames instead of a bare module and offset (#705)
++ Changed: --without-zlib is rejected at configure time rather than failing at link (#735)
 + Changed: the offline documentation gains one GUI guide with screenshots, an Android option reference, and a restructured index
 + Changed: multiple internal hardening, test and CI improvements
 

--- a/history.txt
+++ b/history.txt
@@ -4,6 +4,31 @@ HTTrack Website Copier release history:
 
 This file lists all changes and fixes that have been made for HTTrack
 
+3.49-15
++ New: --single-file rewrites each saved page with its assets inlined as data: URIs (#713)
++ New: --changes reports what a crawl added, updated or removed against the previous mirror (#714)
++ New: --sitemap and --sitemap-url ingest sitemaps, so pages nothing links to are still found (#712)
++ New: webhttrack exposes --warc-cdx, --wacz and --warc-max-size (#862)
++ Fixed: --update and --purge-old destroyed a good local copy when the re-fetch got no response, was aborted mid-read, or when the backup meant to protect it failed (#746, #748, #758, #775)
++ Fixed: an FTP re-fetch truncated the mirrored file, resumed a complete mirror with REST and spliced the old body into the new one, and a successful transfer was blanked when its backlog slot was swapped out (#771, #797, #798, #823)
++ Fixed: a chunked response cut at a chunk boundary was stored and cached as complete (#840)
++ Fixed: cache repair deleted the old cache before a rename it never checked, and the unlink-then-rename fallback could lose the destination (#779, #786, #790, #824)
++ Fixed: several backward scans from strlen(s) - 1 read before their buffer on an empty string (#730, #768, #770, #814, #821)
++ Fixed: a URL could be saved onto the engine's own temporary files, and the final path segment was never clamped (#774, #842, #852)
++ Fixed: a query-string character reference the page charset cannot represent was left unescaped, changing how the query parses (#854)
++ Fixed: WARC output dropped URLs of 1005 bytes or more, archived nothing for a 304 revisit, and marked an engine-forced not-modified as one the server sent (#778, #785, #826, #838, #839)
++ Fixed: ProxyTrack overflowed its .arc header block, walked past the end of an .ndx buffer, trusted an unparsed offset, and crashed on a PROPFIND or on an entry with no usable Last-Modified (#793, #820, #825, #828)
++ Fixed: webhttrack leaked the session id into crawled pages, overflowed its command line so a quoted value could inject flags, and let a posted project path repoint the served root (#706, #707, #710)
++ Fixed: in the web GUI, options ticked on by default could not be un-ticked, "max site size" set a per-file cap instead of the HTML one, and the mirror link on the finished page could not be followed (#708, #709, #725)
++ Fixed: htsserver labelled every PNG as image/gif and offered JPEG as a download, and an unauthenticated GET of a directory spun the server forever (#724, #875)
++ Fixed: oversized cache and header fields aborted the engine or overflowed a neighbouring field instead of being clipped (#701, #715, #717, #722, #732)
++ Fixed: the CLI display did not repaint when the terminal was resized (#97)
++ Fixed: a fragment on an inlined reference was dropped, losing an SVG sprite selector (#766)
++ Fixed: several time helpers handed out libc's shared gmtime/localtime static rather than a reentrant breakdown (#794, #806)
++ Changed: fatal-signal backtraces name engine frames instead of a bare module and offset (#705)
++ Changed: the offline documentation gains one GUI guide with screenshots, an Android option reference, and a restructured index
++ Changed: multiple internal hardening, test and CI improvements
+
 3.49-14
 + New: WARC/1.1 archive output (--warc), with a sorted CDXJ index (--warc-cdx) and WACZ packaging (--wacz), also available from webhttrack (#668)
 + New: -%F takes named footer fields such as {url}, {lastmodified}, {mime}, {charset} and {status} instead of a fixed layout (#667)

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -43,8 +43,8 @@ Please visit our Website: http://www.httrack.com
    configure.ac, decoupled from these). VERSION is the display form, VERSIONID
    the dotted numeric form, AFF_VERSION the short form shown in footers,
    LIB_VERSION the data/cache format generation. */
-#define HTTRACK_VERSION "3.49-14"
-#define HTTRACK_VERSIONID "3.49.14"
+#define HTTRACK_VERSION "3.49-15"
+#define HTTRACK_VERSIONID "3.49.15"
 #define HTTRACK_AFF_VERSION "3.x"
 #define HTTRACK_LIB_VERSION "2.0"
 

--- a/src/version.rc
+++ b/src/version.rc
@@ -17,8 +17,8 @@
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-  FILEVERSION 3, 49, 14, 0
-  PRODUCTVERSION 3, 49, 14, 0
+  FILEVERSION 3, 49, 15, 0
+  PRODUCTVERSION 3, 49, 15, 0
   FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
 #ifdef _DEBUG
   FILEFLAGS VS_FF_DEBUG
@@ -35,12 +35,12 @@ BEGIN
     BEGIN
       VALUE "CompanyName", "Xavier Roche"
       VALUE "FileDescription", VER_FILE_DESCRIPTION
-      VALUE "FileVersion", "3.49.14"
+      VALUE "FileVersion", "3.49.15"
       VALUE "InternalName", VER_ORIGINAL_FILENAME
       VALUE "LegalCopyright", "Copyright (C) 1998-2026 Xavier Roche and other contributors. GNU GPL v3 or later."
       VALUE "OriginalFilename", VER_ORIGINAL_FILENAME
       VALUE "ProductName", "HTTrack Website Copier"
-      VALUE "ProductVersion", "3.49-14"
+      VALUE "ProductVersion", "3.49-15"
     END
   END
   BLOCK "VarFileInfo"


### PR DESCRIPTION
Version bump to 3.49.15 in the three spots that carry it (configure.ac, htsglobal.h, version.rc), plus the release notes and the Debian changelog entry.

VERSION_INFO goes 3:6:0 to 3:7:0, soname still .so.3. The installed htsblk gained a field at its tail and lien_back embeds it by value, so lien_back.is_update and everything after it shifts 8 bytes. An offsetof probe against both tags confirms httrackp's own fields did not move. Same call as 3.49.14: HTTrackQt is the only consumer of these headers, so no libhttrack4 rename.

109 commits since 3.49.14, none of them under debian/, so the changelog entry is a plain new-upstream one with a note that httrack-doc grows about 1 MB from the new GUI screenshots.