### PR TITLE
The installed html symlink is absolute, so an install tree cannot be moved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,36 @@ jobs:
       - name: Smoke-test webhttrack
         run: bash tests/webhttrack-smoke.sh "$RUNNER_TEMP/inst"
 
+  # Same smoke on the platform that ships webhttrack as a package: the install layout
+  # it asserts (a relative data symlink, #885) is what Debian consumes, and the macOS
+  # job alone left that untested on Linux.
+  webhttrack-linux:
+    name: webhttrack smoke (Linux x86-64)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            autoconf automake libtool autoconf-archive \
+            libssl-dev zlib1g-dev libbrotli-dev libzstd-dev
+
+      - name: Build and install into a temp prefix
+        run: |
+          set -euo pipefail
+          ./bootstrap
+          ./configure --prefix="$RUNNER_TEMP/inst"
+          make -j"$(nproc)"
+          make install
+
+      - name: Smoke-test webhttrack
+        run: bash tests/webhttrack-smoke.sh "$RUNNER_TEMP/inst"
+
   # Portability/hardening: 32-bit (i386) build on the x86-64 runner via multilib
   # -- no extra hardware. Exercises the 32-bit size_t/pointer ABI, where size
   # and bounds math can truncate or wrap in ways 64-bit never reveals (the axis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,8 +233,8 @@ jobs:
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            autoconf automake libtool autoconf-archive \
-            libssl-dev zlib1g-dev libbrotli-dev libzstd-dev
+            build-essential autoconf automake libtool autoconf-archive \
+            zlib1g-dev libssl-dev libbrotli-dev libzstd-dev
 
       - name: Build and install into a temp prefix
         run: |

--- a/html/Makefile.am
+++ b/html/Makefile.am
@@ -40,10 +40,3 @@ EXTRA_DIST = $(HelpHtml_DATA) $(HelpHtmlimg_DATA) $(HelpHtmlimages_DATA) \
 	$(HelpHtmldiv_DATA) $(WebHtml_DATA) $(WebHtmlimages_DATA) \
 	$(WebPixmap_DATA) $(WebIcon16x16_DATA) $(WebIcon32x32_DATA) $(WebIcon48x48_DATA) \
 	$(VFolderEntry_DATA) $(MetaInfo_DATA)
-
-install-data-hook:
-	if test ! -L $(DESTDIR)$(prefix)/share/httrack/html ; then \
-		( cd $(DESTDIR)$(prefix)/share/httrack \
-			&& $(LN_S) $(htmldir) html \
-		) \
-	fi

--- a/lang/Makefile.am
+++ b/lang/Makefile.am
@@ -8,4 +8,24 @@ langroot_DATA = ../lang.def ../lang.indexes
 
 EXTRA_DIST = $(lang_DATA) $(langroot_DATA)
 
+# webhttrack and htsserver reach the served UI through $(langrootdir)/html, so the
+# link is relative: an absolute $(htmldir) dangles under DESTDIR or relocation (#885).
+install-data-hook:
+	@rel='$(htmldir)'; \
+	case '$(htmldir)' in \
+		'$(datadir)'/*) rel="../$${rel#$(datadir)/}" ;; \
+	esac; \
+	link='$(DESTDIR)$(langrootdir)/html'; \
+	if test -L "$$link"; then rm -f "$$link" || exit 1; fi; \
+	if test -e "$$link"; then \
+		echo "$$link exists and is not a symlink, leaving it alone" >&2; \
+	else \
+		echo " $(LN_S) $$rel $$link"; \
+		$(LN_S) "$$rel" "$$link"; \
+	fi
+
+uninstall-hook:
+	@link='$(DESTDIR)$(langrootdir)/html'; \
+	if test -L "$$link"; then rm -f "$$link"; fi
+
 #dist-hook:

--- a/tests/webhttrack-smoke.sh
+++ b/tests/webhttrack-smoke.sh
@@ -10,10 +10,11 @@ test -x "$wht" || {
     exit 1
 }
 
+browserstub="$prefix/bin/x-www-browser"
 work="$(mktemp -d)"
 # webhttrack backgrounds htsserver, which outlives it; reap any stray one (scoped
 # to this prefix) so a lingering server can never hold the CI step open.
-trap 'set +e; pkill -f "$prefix/bin/htsserver" 2>/dev/null || true; rm -rf "$work"' EXIT
+trap 'set +e; pkill -f "$prefix/bin/htsserver" 2>/dev/null || true; rm -rf "$work" "$browserstub"' EXIT
 export HOME="$work/home"
 mkdir -p "$HOME/websites"
 marker="$work/marker"
@@ -90,14 +91,15 @@ exec /usr/bin/uname "$@"
 EOF
 chmod +x "$stubdir/uname"
 
-# Stub browser: webhttrack tries its browser-name list in order and runs the
-# first it finds, so shadow the first entry, "x-www-browser". It fetches the
-# server URL and records PASS only for the working UI: the brand string, the
-# step-2 form action, and an option-page tooltip, which a truncated/degraded
-# template page would lack. htsserver only lives until webhttrack exits, so the
-# check has to happen here.
+# Stub browser, named after the first entry of webhttrack's browser list. It goes in
+# $prefix/bin because webhttrack searches its own SRCHPATH before $PATH, so a real
+# /usr/bin/x-www-browser (Edge, on the GitHub Linux runners) would beat a PATH shadow.
+# It fetches the server URL and records PASS only for the working UI: the brand
+# string, the step-2 form action, and an option-page tooltip, which a
+# truncated/degraded template page would lack. htsserver only lives until webhttrack
+# exits, so the check has to happen here.
 # -a: the UI is served ISO-8859-1, so grep must not treat it as binary.
-cat >"$stubdir/x-www-browser" <<EOF
+cat >"$browserstub" <<EOF
 #!/bin/bash
 echo "stub browser invoked with: \$1" >&2
 # Also fetch an option page and require a rendered title='' tooltip: proves the
@@ -121,7 +123,7 @@ else
     echo "FAIL: unexpected response from \$1" >"$marker"
 fi
 EOF
-chmod +x "$stubdir/x-www-browser"
+chmod +x "$browserstub"
 export PATH="$stubdir:$prefix/bin:$PATH"
 
 echo "launching webhttrack"

--- a/tests/webhttrack-smoke.sh
+++ b/tests/webhttrack-smoke.sh
@@ -18,6 +18,62 @@ export HOME="$work/home"
 mkdir -p "$HOME/websites"
 marker="$work/marker"
 
+# No installed symlink may be absolute, or the tree only works at the prefix it was
+# built for (#885). BSD find has no -lname, so read each link back by hand.
+abs=""
+nlink=0
+while IFS= read -r l; do
+    nlink=$((nlink + 1))
+    case "$(readlink "$l")" in
+    /*) abs="$abs $l" ;;
+    esac
+done < <(find "$prefix" -type l)
+test -z "$abs" || {
+    echo "absolute symlink(s) in install tree:$abs" >&2
+    exit 1
+}
+# find's status is lost through the pipe, so an empty scan would pass vacuously.
+test "$nlink" -gt 0 || {
+    echo "scanned no symlinks at all under $prefix" >&2
+    exit 1
+}
+
+# Locate the data dir the way webhttrack does, by the file it keys on, rather than
+# assuming $prefix/share: --datadir moves it, and the link has to follow the data.
+langdef=$(find "$prefix" -name lang.def -type f | head -1)
+test -n "$langdef" || {
+    echo "no lang.def under $prefix" >&2
+    exit 1
+}
+htmllink="$(dirname "$langdef")/html"
+test -L "$htmllink" || {
+    echo "no data symlink beside $langdef" >&2
+    exit 1
+}
+
+# Relocation: resolve the link inside a copy at another path and require it to stay
+# inside that copy. An absolute link resolves back to $prefix and fails here.
+reloc="$work/reloc"
+cp -R "$prefix" "$reloc"
+relocreal=$(cd "$reloc" && pwd -P)
+htmlreal=$(cd "$reloc${htmllink#"$prefix"}" 2>/dev/null && pwd -P) || {
+    echo "relocated tree: the data link does not resolve" >&2
+    exit 1
+}
+case "$htmlreal" in
+"$relocreal"/*) ;;
+*)
+    echo "relocated tree: link escapes to $htmlreal" >&2
+    exit 1
+    ;;
+esac
+# Resolving is not enough: it must land on the served UI, not just any directory.
+test -d "$htmlreal/server" || {
+    echo "relocated tree: $htmlreal has no server/" >&2
+    exit 1
+}
+echo "install tree is relocatable"
+
 stubdir="$work/bin"
 mkdir -p "$stubdir"
 


### PR DESCRIPTION
The install-data-hook wrote `share/httrack/html` as a symlink to an absolute `$(htmldir)`, so an installed tree only worked at the prefix it was configured for: the link dangled under DESTDIR staging (which is why the webhttrack smoke has to install into a real prefix rather than stage) and in any relocated copy, where webhttrack then fails its `test -d "${DISTPATH}/html"` check and exits. It is now relative whenever htmldir sits under datadir. The hook also moves to `lang/Makefile.am`, which declares and populates the directory it writes into, so it no longer leans on SUBDIRS ordering to find a directory another subdirectory owns.

Inert for the .deb: `debian/rules` deletes this link and builds its own inverted layout, and Debian's datadir is `/usr/share`, so the path its un-`-f`'d `rm` targets is unchanged. Two adjacent defects went with it. A pre-existing symlink was left alone, so an upgrade kept a stale absolute link. And nothing removed the link on uninstall, which `distuninstallcheck` never noticed because it only counts `-type f`.

The smoke test now asserts that no installed symlink is absolute, and that the link resolved inside a copy of the tree at another path stays inside that copy and reaches the served UI. It runs on Linux now as well, having only ever run on macOS. Writing that Linux job with a non-default `--datadir` is what surfaced #887: webhttrack's own data search ignores `--datadir`, so the hook following datadir instead of assuming `$prefix/share` is consistency rather than an observable fix until that one lands.

Closes #885
