### PR TITLE
The macOS test server stalls 35s on a reverse DNS lookup nothing reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,75 +176,6 @@ jobs:
           sudo ifconfig lo0 alias 127.0.0.2 up
           sudo ifconfig lo0 alias 127.0.0.3 up
 
-      - name: PROBE where local-server.py's pre-PORT time goes
-        run: |
-          set +e
-          sw_vers; python3 -VV
-          cat > /tmp/probe870.py <<'PROBE_EOF'
-          # PROBE (#870): where does local-server.py's pre-PORT time go on macos-15?
-          import os
-          import socket
-          import sys
-          import time
-          from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
-
-
-          def timed(label, fn):
-              t = time.time()
-              try:
-                  r = fn()
-              except Exception as e:
-                  r = "EXC %s" % e
-              print("%-28s %6.2fs  %s" % (label, time.time() - t, r), flush=True)
-
-
-          tag = sys.argv[1] if len(sys.argv) > 1 else "solo"
-          print("=== %s pid=%d ===" % (tag, os.getpid()), flush=True)
-          timed("gethostname", socket.gethostname)
-          timed("gethostbyaddr(127.0.0.1)", lambda: socket.gethostbyaddr("127.0.0.1")[0])
-          timed("getfqdn(127.0.0.1)", lambda: socket.getfqdn("127.0.0.1"))
-          timed("getfqdn(<hostname>)", lambda: socket.getfqdn(socket.gethostname()))
-
-
-          def bind_stock():
-              s = ThreadingHTTPServer(("127.0.0.1", 0), SimpleHTTPRequestHandler)
-              p = s.server_port
-              s.server_close()
-              return p
-
-
-          class NoFqdnServer(ThreadingHTTPServer):
-              def server_bind(self):
-                  import socketserver
-
-                  socketserver.TCPServer.server_bind(self)
-                  self.server_name, self.server_port = self.server_address[:2]
-
-
-          def bind_nofqdn():
-              s = NoFqdnServer(("127.0.0.1", 0), SimpleHTTPRequestHandler)
-              p = s.server_port
-              s.server_close()
-              return p
-
-
-          timed("ThreadingHTTPServer bind", bind_stock)
-          timed("bind without getfqdn", bind_nofqdn)
-          PROBE_EOF
-          echo "===== solo ====="
-          python3 /tmp/probe870.py solo
-          echo "===== 6 concurrent ====="
-          for i in 1 2 3 4 5 6; do python3 /tmp/probe870.py "par$i" & done; wait
-          echo "===== real (patched) local-server.py, 6 concurrent, time to PORT ====="
-          for i in 1 2 3 4 5 6; do
-            ( t=$(python3 -c 'import time;print(time.time())')
-              python3 tests/local-server.py --root tests/server-root > "/tmp/srv$i.out" 2>&1 &
-              p=$!
-              for _ in $(seq 1 600); do grep -q '^PORT ' "/tmp/srv$i.out" && break; sleep 0.1; done
-              python3 -c "import sys,time;print('srv$i to PORT: %.2fs' % (time.time()-float(sys.argv[1])))" "$t"
-              kill $p 2>/dev/null ) &
-          done; wait
-
       - name: Test
         timeout-minutes: 20
         run: |
@@ -254,15 +185,6 @@ jobs:
       - name: Print the test log on failure
         if: failure()
         run: cat tests/test-suite.log 2>/dev/null || true
-
-      - name: PROBE dump every failing test's own log
-        if: failure()
-        run: |
-          set +e
-          for trs in tests/*.trs; do
-            grep -q '^:test-result: \(FAIL\|ERROR\)' "$trs" || continue
-            echo "########## ${trs%.trs}.log ##########"; cat "${trs%.trs}.log"
-          done
 
   # Runtime smoke of the WebHTTrack launcher on macOS: it carries a Darwin-only
   # browser path (open -W) and nothing else exercises htsserver. Install into a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
   # so point configure at it; everything else is in the SDK or default paths.
   macos:
     name: build (macOS arm64, clang)
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v7
         with:
@@ -176,6 +176,75 @@ jobs:
           sudo ifconfig lo0 alias 127.0.0.2 up
           sudo ifconfig lo0 alias 127.0.0.3 up
 
+      - name: PROBE where local-server.py's pre-PORT time goes
+        run: |
+          set +e
+          sw_vers; python3 -VV
+          cat > /tmp/probe870.py <<'PROBE_EOF'
+          # PROBE (#870): where does local-server.py's pre-PORT time go on macos-15?
+          import os
+          import socket
+          import sys
+          import time
+          from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
+
+
+          def timed(label, fn):
+              t = time.time()
+              try:
+                  r = fn()
+              except Exception as e:
+                  r = "EXC %s" % e
+              print("%-28s %6.2fs  %s" % (label, time.time() - t, r), flush=True)
+
+
+          tag = sys.argv[1] if len(sys.argv) > 1 else "solo"
+          print("=== %s pid=%d ===" % (tag, os.getpid()), flush=True)
+          timed("gethostname", socket.gethostname)
+          timed("gethostbyaddr(127.0.0.1)", lambda: socket.gethostbyaddr("127.0.0.1")[0])
+          timed("getfqdn(127.0.0.1)", lambda: socket.getfqdn("127.0.0.1"))
+          timed("getfqdn(<hostname>)", lambda: socket.getfqdn(socket.gethostname()))
+
+
+          def bind_stock():
+              s = ThreadingHTTPServer(("127.0.0.1", 0), SimpleHTTPRequestHandler)
+              p = s.server_port
+              s.server_close()
+              return p
+
+
+          class NoFqdnServer(ThreadingHTTPServer):
+              def server_bind(self):
+                  import socketserver
+
+                  socketserver.TCPServer.server_bind(self)
+                  self.server_name, self.server_port = self.server_address[:2]
+
+
+          def bind_nofqdn():
+              s = NoFqdnServer(("127.0.0.1", 0), SimpleHTTPRequestHandler)
+              p = s.server_port
+              s.server_close()
+              return p
+
+
+          timed("ThreadingHTTPServer bind", bind_stock)
+          timed("bind without getfqdn", bind_nofqdn)
+          PROBE_EOF
+          echo "===== solo ====="
+          python3 /tmp/probe870.py solo
+          echo "===== 6 concurrent ====="
+          for i in 1 2 3 4 5 6; do python3 /tmp/probe870.py "par$i" & done; wait
+          echo "===== real (patched) local-server.py, 6 concurrent, time to PORT ====="
+          for i in 1 2 3 4 5 6; do
+            ( t=$(python3 -c 'import time;print(time.time())')
+              python3 tests/local-server.py --root tests/server-root > "/tmp/srv$i.out" 2>&1 &
+              p=$!
+              for _ in $(seq 1 600); do grep -q '^PORT ' "/tmp/srv$i.out" && break; sleep 0.1; done
+              python3 -c "import sys,time;print('srv$i to PORT: %.2fs' % (time.time()-float(sys.argv[1])))" "$t"
+              kill $p 2>/dev/null ) &
+          done; wait
+
       - name: Test
         timeout-minutes: 20
         run: |
@@ -186,12 +255,21 @@ jobs:
         if: failure()
         run: cat tests/test-suite.log 2>/dev/null || true
 
+      - name: PROBE dump every failing test's own log
+        if: failure()
+        run: |
+          set +e
+          for trs in tests/*.trs; do
+            grep -q '^:test-result: \(FAIL\|ERROR\)' "$trs" || continue
+            echo "########## ${trs%.trs}.log ##########"; cat "${trs%.trs}.log"
+          done
+
   # Runtime smoke of the WebHTTrack launcher on macOS: it carries a Darwin-only
   # browser path (open -W) and nothing else exercises htsserver. Install into a
   # temp prefix, then check webhttrack brings up htsserver and serves the UI.
   webhttrack-macos:
     name: webhttrack smoke (macOS arm64)
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v7
         with:
@@ -251,7 +329,7 @@ jobs:
   # moved, which is the only thing a .app has to survive that a prefix install does not.
   macos-app:
     name: macOS app bundle (arm64)
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v7
         with:

--- a/tests/100_local-purge-longpath.test
+++ b/tests/100_local-purge-longpath.test
@@ -38,16 +38,7 @@ mkdir -p "$work/root" "$work/proj"
     >"$work/server.out" 2>"$work/server.err" &
 spid=$!
 
-port=
-for _ in $(seq 1 100); do
-    port=$(sed -n 's/^PORT \([0-9]*\)$/\1/p' "$work/server.out" 2>/dev/null || true)
-    test -n "$port" && break
-    sleep 0.1
-done
-test -n "$port" || {
-    echo "local-server.py did not announce a port" >&2
-    exit 1
-}
+port=$(discover_server_port "$work/server.out" "$spid") || exit 1
 
 # Save path is "127.0.0.1_<port>/" + the URL path; target 998 bytes total.
 prefix="127.0.0.1_${port}/"

--- a/tests/84_webhttrack-mirror-verbatim.test
+++ b/tests/84_webhttrack-mirror-verbatim.test
@@ -8,6 +8,8 @@ set -euo pipefail
 testdir=$(cd "$(dirname "$0")" && pwd)
 distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
 distdir=$(cd "${distdir}" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
 
 fail() {
     echo "FAIL: $*" >&2
@@ -148,12 +150,8 @@ grep -qi '^Content-type: text/html' "${hdr}" ||
 clog="${work}/content.log"
 python3 "${testdir}/local-server.py" --root "${work}" >"${clog}" 2>&1 &
 csrv=$!
-for _ in $(seq 1 40); do
-    cport=$(sed -n 's/^PORT //p' "${clog}") && test -n "${cport}" && break
-    kill -0 "${csrv}" 2>/dev/null || break
-    sleep 0.25
-done
-test -n "${cport:-}" || fail "content server did not come up: $(cat "${clog}")"
+cport=$(discover_server_port "${clog}" "${csrv}") ||
+    fail "content server did not come up"
 
 post "${port}" "sid=${sid}" "path=${work}" projname=crawl winprofile=x \
     command_do=start \

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -20,6 +20,7 @@ import hashlib
 import os
 import re
 import socket
+import socketserver
 import struct
 import sys
 import time
@@ -2664,6 +2665,14 @@ def main():
     # raise it from Python's default 5 so a busy -c8 crawl can't lose fetches.
     class BacklogHTTPServer(ThreadingHTTPServer):
         request_queue_size = 128
+
+        # HTTPServer.server_bind() reverse-resolves the bind address through
+        # getfqdn() only to fill server_name, which nothing here reads. On macOS
+        # that lookup stalls for ~30s under a parallel run, delaying the PORT
+        # line past every caller's discovery budget (#870).
+        def server_bind(self):
+            socketserver.TCPServer.server_bind(self)
+            self.server_name, self.server_port = self.server_address[:2]
 
     httpd = BacklogHTTPServer((args.bind, 0), factory)
 

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -2666,10 +2666,8 @@ def main():
     class BacklogHTTPServer(ThreadingHTTPServer):
         request_queue_size = 128
 
-        # HTTPServer.server_bind() reverse-resolves the bind address through
-        # getfqdn() only to fill server_name, which nothing here reads. On macOS
-        # that lookup stalls for ~30s under a parallel run, delaying the PORT
-        # line past every caller's discovery budget (#870).
+        # Skip the getfqdn() reverse lookup stock server_bind() does for the
+        # unread server_name: it stalls 35s on macOS (#870).
         def server_bind(self):
             socketserver.TCPServer.server_bind(self)
             self.server_name, self.server_port = self.server_address[:2]


### PR DESCRIPTION
`local-server.py` binds through `http.server`'s `HTTPServer`, whose `server_bind()` reverse-resolves the bind address with `getfqdn()` to fill `server_name`, a field nothing in the file ever reads. On the macos-15 runner `gethostbyaddr("127.0.0.1")` takes 35.03s, and six concurrent callers are all released at the same instant. A parallel `make check` pays that in its first wave, so the `PORT` line lands well past every caller's discovery budget. That is all of #870: the three tests asserting wall clock (`-E`, `-M`, the crawl watchdog) overshoot by ~35s, 84 and 100 give up waiting, and by the time 105's budget expires its wedged crawl has not started an engine to sample. Skipping the lookup brings the same six servers to 0.3s, and macos-15 then reports 213 tests with 200 passed and 13 skipped, matching the macos-14 baseline, so the three legs move over here. 84 and 100 also move onto `discover_server_port`, the two copies of the poll loop #869 did not reach.

Two of the issue's claims turn out to be wrong. `sample(1)` is not restricted on macOS 15: the probe's own output did carry a `Call graph:` section, and 105 failed for want of an engine to point it at. `-E` and `-M` do engage too, since 34's log shows the hard stop firing at `-E2` plus its 5s grace, with the whole overshoot sitting before the crawl.

Closes #870