### PR TITLE
The AppStream metainfo still advertises WebHTTrack 3.49.8

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -128,7 +128,7 @@ This file lists all changes and fixes that have been made for HTTrack
 + Fixed: report why a -%L URL list could not be loaded (#49)
 + Changed: multiple internal hardening, build and CI improvements
 
-.49-9
+3.49-9
 + Fixed: file-type detection from the Content-Type header: trust a declared type over a binary URL extension, honor --assume under the delayed type check, and keep a known extension against a bogus or empty Content-Type (#267, #29, #56)
 + Fixed: an uninitialized-buffer read when the Content-Type is empty (#411)
 + Fixed: restored C++ source-compatibility of the installed headers so reverse dependencies (httraqt) build again (#413)

--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -49,7 +49,71 @@
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1"/>
+  <!-- Newest first; tests/01_engine-version-macros.test pins the top entry to the tree version. -->
   <releases>
-    <release version="3.49.8" date="2026-06-07"/>
+    <release version="3.49.15" date="2026-07-30">
+      <description>
+        <ul>
+          <li>Save a page and everything it needs as one self-contained file</li>
+          <li>Read a site's sitemap, so pages nothing links to are still found</li>
+          <li>See what a new pass added, updated or removed</li>
+          <li>Updating a mirror no longer destroys a good local copy when a download fails or is interrupted</li>
+        </ul>
+      </description>
+    </release>
+    <release version="3.49.14" date="2026-07-24">
+      <description>
+        <ul>
+          <li>Save a mirror as a web archive, indexed and packaged for replay</li>
+          <li>Choose what the page footer says</li>
+          <li>Windows handles very long paths and non-English project names correctly</li>
+        </ul>
+      </description>
+    </release>
+    <release version="3.49.13" date="2026-07-18">
+      <description>
+        <ul>
+          <li>Mirror through a SOCKS5 proxy</li>
+          <li>Files of 2 GB and over are handled correctly on Windows and on 32-bit systems</li>
+          <li>The web interface offers the options added since 3.49-2, among them a cookies file and a pause between downloads</li>
+        </ul>
+      </description>
+    </release>
+    <release version="3.49.12" date="2026-07-10">
+      <description>
+        <p>Links carrying accented characters are followed again, a page wrongly labelled as compressed is no longer lost, and a new option explains why a given address is kept or skipped.</p>
+      </description>
+    </release>
+    <release version="3.49.11" date="2026-07-05">
+      <description>
+        <ul>
+          <li>Audio and video sources are mirrored along with the page</li>
+          <li>Site rules written with wildcards are understood</li>
+          <li>A time limit now stops a slow download instead of waiting for it to end</li>
+        </ul>
+      </description>
+    </release>
+    <release version="3.49.10" date="2026-06-28">
+      <description>
+        <ul>
+          <li>Start from a cookies file, and space downloads out with a random pause</li>
+          <li>Ignore chosen query parameters when naming saved files</li>
+          <li>Resuming a partial download no longer duplicates bytes</li>
+        </ul>
+      </description>
+    </release>
+    <release version="3.49.9" date="2026-06-21">
+      <description>
+        <p>Saved files get the right type when the server and the address disagree about it.</p>
+      </description>
+    </release>
+    <release version="3.49.8" date="2026-06-20">
+      <description>
+        <ul>
+          <li>Secure downloads can go through a plain web proxy</li>
+          <li>Every size of a responsive image is fetched</li>
+        </ul>
+      </description>
+    </release>
   </releases>
 </component>

--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -49,7 +49,7 @@
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1"/>
-  <!-- Newest first; tests/01_engine-version-macros.test pins the top entry to the tree version. -->
+  <!-- Newest first; tests/01_engine-version-macros.test enforces it. -->
   <releases>
     <release version="3.49.15" date="2026-07-30">
       <description>
@@ -58,6 +58,7 @@
           <li>Read a site's sitemap, so pages nothing links to are still found</li>
           <li>See what a new pass added, updated or removed</li>
           <li>Updating a mirror no longer destroys a good local copy when a download fails or is interrupted</li>
+          <li>In the web interface, options ticked by default can be un-ticked again, the size limit applies to the whole site, and the finished mirror opens from its link</li>
         </ul>
       </description>
     </release>
@@ -66,7 +67,7 @@
         <ul>
           <li>Save a mirror as a web archive, indexed and packaged for replay</li>
           <li>Choose what the page footer says</li>
-          <li>Windows handles very long paths and non-English project names correctly</li>
+          <li>A mirror saved to a folder with accented characters in its name lands in the right place</li>
         </ul>
       </description>
     </release>
@@ -75,7 +76,7 @@
         <ul>
           <li>Mirror through a SOCKS5 proxy</li>
           <li>Files of 2 GB and over are handled correctly on Windows and on 32-bit systems</li>
-          <li>The web interface offers the options added since 3.49-2, among them a cookies file and a pause between downloads</li>
+          <li>The web interface offers options that used to be command-line only, among them a cookies file and a pause between downloads</li>
         </ul>
       </description>
     </release>
@@ -88,7 +89,7 @@
       <description>
         <ul>
           <li>Audio and video sources are mirrored along with the page</li>
-          <li>Site rules written with wildcards are understood</li>
+          <li>A site's robots.txt is followed more closely, including its Allow rules and wildcards</li>
           <li>A time limit now stops a slow download instead of waiting for it to end</li>
         </ul>
       </description>

--- a/tests/01_engine-version-macros.test
+++ b/tests/01_engine-version-macros.test
@@ -1,15 +1,18 @@
 #!/bin/bash
 #
-# version.rc repeats the version that htsglobal.h declares. Signing enforces that
-# every binary in a release reports the same one, so a drift fails the signing
-# request on release day rather than the build. Assert the two agree.
+# htsglobal.h declares the version; version.rc, configure.ac and the AppStream
+# metainfo repeat it. A release that misses one signs a mismatched binary or
+# leaves software centres advertising an old version, so fail on the drift here.
 
 set -euo pipefail
 
-src="${top_srcdir:-..}/src"
+top="${top_srcdir:-..}"
+src="$top/src"
 h="$src/htsglobal.h"
 rc="$src/version.rc"
-for f in "$h" "$rc"; do
+ac="$top/configure.ac"
+metainfo="$top/html/server/div/com.httrack.WebHTTrack.metainfo.xml"
+for f in "$h" "$rc" "$ac" "$metainfo"; do
     [ -f "$f" ] || {
         echo "cannot find $f"
         exit 1
@@ -31,23 +34,47 @@ rc_fileversion=$(sed -n 's/.*VALUE "FileVersion",[[:space:]]*"\([^"]*\)".*/\1/p'
 rc_productversion=$(sed -n 's/.*VALUE "ProductVersion",[[:space:]]*"\([^"]*\)".*/\1/p' "$rc")
 rc_productname=$(sed -n 's/.*VALUE "ProductName",[[:space:]]*"\([^"]*\)".*/\1/p' "$rc")
 
+# The same version again, in configure.ac and in the metainfo software centres read.
+ac_version=$(sed -n 's/^AC_INIT(\[[^]]*\],[[:space:]]*\[\([^]]*\)\].*/\1/p' "$ac")
+releases=$(sed -n 's/.*<release[^>]*version="\([^"]*\)".*/\1/p' "$metainfo")
+if [ -z "$ac_version" ]; then
+    echo "could not read the version from $ac"
+    exit 1
+fi
+if [ -z "$releases" ]; then
+    echo "could not read any release version from $metainfo"
+    exit 1
+fi
+
 # 3.49.12 -> 3,49,12,0
 expected_numeric="$(echo "$versionid" | tr '.' ','),0"
 
 fail=0
 check() { # what expected actual
     if [ "$2" != "$3" ]; then
-        echo "version.rc $1 is \"$3\", but htsglobal.h says it should be \"$2\""
+        echo "$1 is \"$3\", but htsglobal.h says it should be \"$2\""
         fail=1
     fi
 }
-check FILEVERSION "$expected_numeric" "$fileversion"
-check PRODUCTVERSION "$expected_numeric" "$productversion"
-check FileVersion "$versionid" "$rc_fileversion"
-check ProductVersion "$version" "$rc_productversion"
+check "version.rc FILEVERSION" "$expected_numeric" "$fileversion"
+check "version.rc PRODUCTVERSION" "$expected_numeric" "$productversion"
+check "version.rc FileVersion" "$versionid" "$rc_fileversion"
+check "version.rc ProductVersion" "$version" "$rc_productversion"
 
 # Signing pins the product name too.
-check ProductName "HTTrack Website Copier" "$rc_productname"
+check "version.rc ProductName" "HTTrack Website Copier" "$rc_productname"
+
+check "the configure.ac AC_INIT version" "$versionid" "$ac_version"
+check "the newest metainfo release" "$versionid" "$(echo "$releases" | head -n 1)"
+
+# The top entry is only the newest if the list is ordered, so hold it to that: an
+# entry appended at the bottom must fail rather than pass unnoticed.
+echo "$releases" | awk -F. '
+    !/^[0-9]+\.[0-9]+\.[0-9]+$/ { print "unparsable metainfo release version: " $0; exit 1 }
+    { n = $1 * 1000000 + $2 * 1000 + $3 }
+    NR > 1 && n >= prev { print "metainfo releases are not newest-first: " $0; exit 1 }
+    { prev = n }
+' || fail=1
 
 [ "$fail" -eq 0 ] || exit 1
 
@@ -61,4 +88,4 @@ case "$out" in
     ;;
 esac
 
-echo "version resource agrees with htsglobal.h: $version ($expected_numeric)"
+echo "version.rc, configure.ac and the metainfo agree with htsglobal.h: $version ($expected_numeric)"

--- a/tests/01_engine-version-macros.test
+++ b/tests/01_engine-version-macros.test
@@ -1,8 +1,7 @@
 #!/bin/bash
 #
-# htsglobal.h declares the version; version.rc, configure.ac and the AppStream
-# metainfo repeat it. A release that misses one signs a mismatched binary or
-# leaves software centres advertising an old version, so fail on the drift here.
+# htsglobal.h declares the version; version.rc, configure.ac and the metainfo
+# repeat it. Miss one and a release ships a mismatched binary or a stale store entry.
 
 set -euo pipefail
 
@@ -34,9 +33,12 @@ rc_fileversion=$(sed -n 's/.*VALUE "FileVersion",[[:space:]]*"\([^"]*\)".*/\1/p'
 rc_productversion=$(sed -n 's/.*VALUE "ProductVersion",[[:space:]]*"\([^"]*\)".*/\1/p' "$rc")
 rc_productname=$(sed -n 's/.*VALUE "ProductName",[[:space:]]*"\([^"]*\)".*/\1/p' "$rc")
 
-# The same version again, in configure.ac and in the metainfo software centres read.
+# And again in configure.ac and the AppStream metainfo.
 ac_version=$(sed -n 's/^AC_INIT(\[[^]]*\],[[:space:]]*\[\([^]]*\)\].*/\1/p' "$ac")
-releases=$(sed -n 's/.*<release[^>]*version="\([^"]*\)".*/\1/p' "$metainfo")
+# Comments dropped, one tag per line: a parked <release> or a version= on the
+# <releases> wrapper would otherwise pose as the newest entry.
+releases=$(sed 's/<!--.*-->//g' "$metainfo" | tr '<' '\n' |
+    sed -n 's/^release[[:space:]][^>]*version="\([^"]*\)".*/\1/p')
 if [ -z "$ac_version" ]; then
     echo "could not read the version from $ac"
     exit 1
@@ -67,11 +69,10 @@ check "version.rc ProductName" "HTTrack Website Copier" "$rc_productname"
 check "the configure.ac AC_INIT version" "$versionid" "$ac_version"
 check "the newest metainfo release" "$versionid" "$(echo "$releases" | head -n 1)"
 
-# The top entry is only the newest if the list is ordered, so hold it to that: an
-# entry appended at the bottom must fail rather than pass unnoticed.
-echo "$releases" | awk -F. '
+# The check above trusts head -1, so require the list to actually descend.
+echo "$releases" | awk -F'[.]' '
     !/^[0-9]+\.[0-9]+\.[0-9]+$/ { print "unparsable metainfo release version: " $0; exit 1 }
-    { n = $1 * 1000000 + $2 * 1000 + $3 }
+    { n = $1 * 1000000000 + $2 * 1000000 + $3 }
     NR > 1 && n >= prev { print "metainfo releases are not newest-first: " $0; exit 1 }
     { prev = n }
 ' || fail=1


### PR DESCRIPTION
`html/server/div/com.httrack.WebHTTrack.metainfo.xml` installs to `usr/share/metainfo`, so GNOME Software and KDE Discover read both the version and the "What's new" text out of it. Its `<releases>` block held one entry, 3.49.8, and nothing had moved it since, so the software centres were seven releases behind. It now lists 3.49.8 through 3.49.15, newest first, each with a short user-facing note taken from `history.txt`. Dates come from the git tags; that also corrects 3.49.8's, which carried 3.49.7's date. `appstreamcli validate` passes.

`tests/01_engine-version-macros.test` gains two assertions so the next release cannot miss this file, or `configure.ac`, the way this one did: `AC_INIT` and the top `<release>` must both match `HTTRACK_VERSIONID`. The top entry is only the newest if the list is ordered, so the test also requires the versions to descend, and it fails on a version it cannot parse rather than skipping the check.

Closes #884
