### PR TITLE
configure resolves bash to /bin/sh on macOS, and make deb runs a bash script with dash

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,8 +12,7 @@ EXTRA_DIST = INSTALL.Linux \
 # Build the signed Debian packages from a clean source export. Pass the signing
 # key and other options through DEB_FLAGS, e.g.:
 #   make deb DEB_FLAGS="--key BB71C7E6CB1AD8FAF53FE42A60C3AA7180598EFB"
-# See tools/mkdeb.sh --help for all options. Not $(SHELL): that is /bin/sh, which
-# on the Debian boxes you build packages on is dash, and mkdeb.sh is bash (#891).
+# See tools/mkdeb.sh --help for all options. Not $(SHELL): mkdeb.sh is bash, and dash chokes (#891).
 DEB_FLAGS =
 deb:
 	$(BASH_SHELL) $(top_srcdir)/tools/mkdeb.sh $(DEB_FLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,10 +12,11 @@ EXTRA_DIST = INSTALL.Linux \
 # Build the signed Debian packages from a clean source export. Pass the signing
 # key and other options through DEB_FLAGS, e.g.:
 #   make deb DEB_FLAGS="--key BB71C7E6CB1AD8FAF53FE42A60C3AA7180598EFB"
-# See tools/mkdeb.sh --help for all options.
+# See tools/mkdeb.sh --help for all options. Not $(SHELL): that is /bin/sh, which
+# on the Debian boxes you build packages on is dash, and mkdeb.sh is bash (#891).
 DEB_FLAGS =
 deb:
-	$(SHELL) $(top_srcdir)/tools/mkdeb.sh $(DEB_FLAGS)
+	$(BASH_SHELL) $(top_srcdir)/tools/mkdeb.sh $(DEB_FLAGS)
 .PHONY: deb
 
 # Assemble the macOS application bundle from an installed prefix, e.g.

--- a/configure.ac
+++ b/configure.ac
@@ -53,9 +53,8 @@ LT_INIT
 AC_PROG_LN_S
 LT_INIT
 
-# A real bash, for "make deb" and the test harness. Searched into BASH_SHELL and
-# not BASH because bash presets $BASH to its own path and macOS /bin/sh is itself
-# a bash, so AC_PATH_PROGS would honour that value instead of searching (#895).
+# A real bash, for "make deb" and the test harness. Not searched into BASH: bash presets
+# that to its own path, and macOS /bin/sh is a bash, so the macro never searches (#895).
 AS_UNSET([BASH_SHELL])
 AC_PATH_PROGS([BASH_SHELL], [bash], [/bin/bash])
 

--- a/configure.ac
+++ b/configure.ac
@@ -53,8 +53,11 @@ LT_INIT
 AC_PROG_LN_S
 LT_INIT
 
-# bash, used to run the test scripts (see tests/Makefile.am TEST_LOG_COMPILER)
-AC_PATH_PROGS([BASH], [bash], [/bin/bash])
+# A real bash, for "make deb" and the test harness. Searched into BASH_SHELL and
+# not BASH because bash presets $BASH to its own path and macOS /bin/sh is itself
+# a bash, so AC_PATH_PROGS would honour that value instead of searching (#895).
+AS_UNSET([BASH_SHELL])
+AC_PATH_PROGS([BASH_SHELL], [bash], [/bin/bash])
 
 # Export LD_LIBRARY_PATH name or equivalent.
 AC_SUBST(SHLIBPATH_VAR,$shlibpath_var)

--- a/tests/01_engine-copyopt.test
+++ b/tests/01_engine-copyopt.test
@@ -3,7 +3,6 @@
 # Regression guard for the unsigned-enum sentinel trap: copy_htsopt's
 # `if (from->X > -1)` guard is always false for unsigned hts_boolean fields, so
 # they silently stop being copied. Driven by the in-process 'httrack -#test=copyopt' test.
-# Keep POSIX-portable (harness runs it via $(BASH), a plain /bin/sh on macOS).
 
 set -eu
 

--- a/tests/01_engine-footer-overflow.test
+++ b/tests/01_engine-footer-overflow.test
@@ -1,9 +1,5 @@
 #!/bin/bash
 #
-# Keep this POSIX-portable: the harness runs it via $(BASH), which is a plain
-# POSIX /bin/sh on some platforms (e.g. macOS), so avoid bashisms despite the
-# #!/bin/bash above.
-
 # A -%F footer whose expansion overflows the on-page buffer must be dropped, not
 # crash the crawl. Before the fix the unchecked hts_footer_format return left the
 # buffer unterminated and the next strcatbuff aborted (SIGABRT).

--- a/tests/01_engine-pause.test
+++ b/tests/01_engine-pause.test
@@ -2,7 +2,7 @@
 #
 # --pause (#185): the inter-file pause target must stay in [min,max] and spread
 # across it (a per-call rand() would collapse it toward min). Driven by the
-# in-process 'httrack -#test=pause' test. POSIX-portable ($(BASH) is /bin/sh on macOS).
+# in-process 'httrack -#test=pause' test.
 
 set -eu
 

--- a/tests/01_zlib-cache-golden.test
+++ b/tests/01_zlib-cache-golden.test
@@ -1,9 +1,5 @@
 #!/bin/bash
 #
-# Keep this POSIX-portable: the harness runs it via $(BASH), which is a plain
-# POSIX /bin/sh on some platforms (e.g. macOS), so avoid bashisms and GNU-only
-# tool flags despite the #!/bin/bash above.
-
 # Golden cache-format regression test (driven by 'httrack -#test=cache-golden <dir>').
 #
 # 01_zlib-cache.test writes the cache with the same build it reads back (a

--- a/tests/01_zlib-cache.test
+++ b/tests/01_zlib-cache.test
@@ -1,9 +1,5 @@
 #!/bin/bash
 #
-# Keep this POSIX-portable: the harness runs it via $(BASH), which is a plain
-# POSIX /bin/sh on some platforms (e.g. macOS), so avoid bashisms and GNU-only
-# tool flags despite the #!/bin/bash above.
-
 # Cache create/read/update logic (driven by 'httrack -#test=cache <dir>').
 #
 # The in-process self-test stores several hand-crafted edge entries (normal

--- a/tests/02_manpage-regen.test
+++ b/tests/02_manpage-regen.test
@@ -3,12 +3,7 @@
 # The committed man/httrack.1 must match what man/makeman.sh produces from the
 # current "httrack --help" output. This catches a --help change that was not
 # followed by "make -C man regen-man".
-#
-# Keep this POSIX-portable: the harness runs it via $(BASH), which is a plain
-# POSIX /bin/sh on some platforms (e.g. macOS), so avoid bashisms (such as
-# process substitution) despite the #!/bin/bash above.
 
-# pipefail is a bashism; keep to POSIX set flags ($(BASH) may be /bin/sh here).
 set -eu
 
 : "${top_srcdir:=..}"

--- a/tests/146_bash-shell.test
+++ b/tests/146_bash-shell.test
@@ -1,10 +1,8 @@
 #!/bin/bash
 #
-# configure must hand the Makefiles a real bash (BASH_SHELL): "make deb" and the
-# test driver both run bash scripts through it. It used to search into BASH,
-# which bash presets to its own path, so on macOS -- where /bin/sh is a bash in
-# sh-mode -- configure reported /bin/sh and that shell rejects the process
-# substitution the bundle script uses (#895, #891).
+# configure must hand the Makefiles a real bash (BASH_SHELL): "make deb" and the test
+# driver both run bash scripts through it. Not searched into BASH, which bash presets to
+# its own path, so on macOS -- where /bin/sh is a bash -- it reported /bin/sh (#895, #891).
 #
 # shellcheck disable=SC2016 # the probes are for the shell under test to expand
 
@@ -35,7 +33,7 @@ case "$opts" in
     ;;
 esac
 
-# The construct that killed the macOS bundle job.
+# The test helpers use process substitution, which macOS's bash-3.2-as-sh rejects.
 out=$("$sh" -c 'cat <(echo procsub)' 2>&1) || {
     echo "BASH_SHELL=$sh cannot run a process substitution: $out" >&2
     exit 1

--- a/tests/146_bash-shell.test
+++ b/tests/146_bash-shell.test
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# configure must hand the Makefiles a real bash (BASH_SHELL): "make deb" and the
+# test driver both run bash scripts through it. It used to search into BASH,
+# which bash presets to its own path, so on macOS -- where /bin/sh is a bash in
+# sh-mode -- configure reported /bin/sh and that shell rejects the process
+# substitution the bundle script uses (#895, #891).
+#
+# shellcheck disable=SC2016 # the probes are for the shell under test to expand
+
+set -euo pipefail
+
+sh=${BASH_SHELL:-}
+test -n "$sh" || {
+    echo "BASH_SHELL is empty; tests/Makefile.am must export the configured value" >&2
+    exit 1
+}
+test -x "$sh" || {
+    echo "BASH_SHELL=$sh is not an executable file" >&2
+    exit 1
+}
+
+version=$("$sh" -c 'echo "${BASH_VERSION:-}"')
+test -n "$version" || {
+    echo "BASH_SHELL=$sh sets no BASH_VERSION, so it is not a bash" >&2
+    exit 1
+}
+
+# sh-mode bash sets BASH_VERSION too, so the version alone proves nothing.
+opts=$("$sh" -c 'echo ":${SHELLOPTS:-}:"')
+case "$opts" in
+*:posix:*)
+    echo "BASH_SHELL=$sh is a bash in POSIX sh-mode" >&2
+    exit 1
+    ;;
+esac
+
+# The construct that killed the macOS bundle job.
+out=$("$sh" -c 'cat <(echo procsub)' 2>&1) || {
+    echo "BASH_SHELL=$sh cannot run a process substitution: $out" >&2
+    exit 1
+}
+test "$out" = procsub || {
+    echo "expected 'procsub' from BASH_SHELL=$sh, got: $out" >&2
+    exit 1
+}
+
+echo "configured bash is $sh ($version)"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -24,6 +24,8 @@ TESTS_ENVIRONMENT += HTTPS_SUPPORT=$(HTTPS_SUPPORT)
 TESTS_ENVIRONMENT += BROTLI_ENABLED=$(BROTLI_ENABLED)
 TESTS_ENVIRONMENT += ZSTD_ENABLED=$(ZSTD_ENABLED)
 TESTS_ENVIRONMENT += V6_SUPPORT=$(V6_SUPPORT)
+# Asserted by 146_bash-shell.test.
+TESTS_ENVIRONMENT += BASH_SHELL=$(BASH_SHELL)
 TESTS_ENVIRONMENT += top_srcdir=$(top_srcdir)
 TESTS_ENVIRONMENT += RENAMEFAIL_LA=$(abs_builddir)/librenamefail.la
 TESTS_ENVIRONMENT += RENAMEFAIL_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/librenamefail.so
@@ -58,5 +60,5 @@ TEST_EXTENSIONS = .test
 # named, with diagnostics, rather than hang the job until CI cancels it -- a
 # cancelled step keeps neither its log nor its artifacts, so today a hang tells
 # us nothing at all. HTTRACK_TEST_TIMEOUT overrides the budget; 0 disables it.
-TEST_LOG_COMPILER = $(BASH) $(srcdir)/test-timeout.sh
+TEST_LOG_COMPILER = $(BASH_SHELL) $(srcdir)/test-timeout.sh
 CLEANFILES = check-network_sh.cache

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -215,3 +215,4 @@ TESTS += 140_crash-handler.test
 TESTS += 141_webhttrack-warc-options.test
 TESTS += 142_webhttrack-content-type.test
 TESTS += 143_engine-backtrace-empty.test
+TESTS += 146_bash-shell.test

--- a/tools/macos-app.sh
+++ b/tools/macos-app.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-# Assemble HTTrack.app from an installed prefix, then verify it. POSIX sh on purpose:
-# $(BASH) resolves to /bin/sh on macOS, where bash-in-sh-mode presets $BASH (#895). The payload lives in
-# Contents/Resources because webhttrack resolves htsserver and its data relative to its
-# own path, so the bundle needs no absolute paths of its own.
+# Assemble HTTrack.app from an installed prefix, then verify it. POSIX sh on purpose,
+# so shellcheck reads it as sh and a bashism creeping back in fails lint, not CI. The
+# payload lives in Contents/Resources because webhttrack resolves htsserver and its data
+# relative to its own path, so the bundle needs no absolute paths of its own.
 set -eu
 
 usage() {

--- a/tools/macos-app.sh
+++ b/tools/macos-app.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
-# Assemble HTTrack.app from an installed prefix, then verify it. POSIX sh on purpose,
-# so shellcheck reads it as sh and a bashism creeping back in fails lint, not CI. The
-# payload lives in Contents/Resources because webhttrack resolves htsserver and its data
-# relative to its own path, so the bundle needs no absolute paths of its own.
+# Assemble HTTrack.app from an installed prefix, then verify it. POSIX sh on purpose: a
+# bashism then fails shellcheck, not CI. Payload in Contents/Resources, where webhttrack
+# resolves htsserver and its data relative to its own path.
 set -eu
 
 usage() {


### PR DESCRIPTION
configure searched for bash into the BASH variable, which bash itself presets to whatever path it was invoked as. configure re-execs through /bin/sh, and on macOS /bin/sh is a bash, so AC_PATH_PROGS honoured the pre-set value and reported `checking for bash... /bin/sh`, a bash in sh-mode that rejects process substitution. The search now goes into `BASH_SHELL`, a name no shell presets, with an `AS_UNSET` in front so the environment cannot preset it either.

That makes the obvious fix for #891 safe. The `deb:` target ran `tools/mkdeb.sh` with `$(SHELL)`, which is `/bin/sh`, so `make deb` died on the first bashism on every Debian and Ubuntu box, which is to say on the machines you build the packages on. It now uses `$(BASH_SHELL)`. `tools/macos-app.sh` stays on `$(SHELL)`: it is POSIX sh on purpose, so shellcheck lints it as sh and a bashism creeping back in fails lint rather than CI.

`tests/146_bash-shell.test` asserts that the configured shell exists, sets `BASH_VERSION`, is not in POSIX sh-mode, and parses a process substitution. The version alone would not have caught macOS, since sh-mode bash sets it too, so the sh-mode and process-substitution checks are the ones doing the work. Forcing the variable by hand: dash fails, a bash symlinked as `sh` fails, the real bash passes.

Several test scripts carried a comment saying they avoid bashisms because the harness runs them under a plain `/bin/sh` on macOS. That is no longer true, so those comments are gone.

Closes #895
Closes #891
