### PR TITLE
configure discards a user-supplied BASH_SHELL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,7 @@ LT_INIT
 
 # A real bash, for "make deb" and the test harness. Not searched into BASH: bash presets
 # that to its own path, and macOS /bin/sh is a bash, so the macro never searches (#895).
-# Nothing presets BASH_SHELL, so it is safe to let the user point it at their own.
+# BASH_SHELL isn't preset the way BASH is, so AC_ARG_VAR needs no guard.
 AC_ARG_VAR([BASH_SHELL], [path to a real (non-POSIX-mode) bash])
 AC_PATH_PROGS([BASH_SHELL], [bash], [/bin/bash])
 

--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,8 @@ LT_INIT
 
 # A real bash, for "make deb" and the test harness. Not searched into BASH: bash presets
 # that to its own path, and macOS /bin/sh is a bash, so the macro never searches (#895).
-AS_UNSET([BASH_SHELL])
+# Nothing presets BASH_SHELL, so it is safe to let the user point it at their own.
+AC_ARG_VAR([BASH_SHELL], [path to a real (non-POSIX-mode) bash])
 AC_PATH_PROGS([BASH_SHELL], [bash], [/bin/bash])
 
 # Export LD_LIBRARY_PATH name or equivalent.

--- a/tests/146_bash-shell.test
+++ b/tests/146_bash-shell.test
@@ -43,4 +43,32 @@ test "$out" = procsub || {
     exit 1
 }
 
+# Whatever configure picks, an absolute BASH_SHELL from the user must win over the search.
+configure="${abs_top_srcdir:-}/configure"
+test -r "$configure" || {
+    echo "no configure script at $configure; tests/Makefile.am must export abs_top_srcdir" >&2
+    exit 1
+}
+
+help=$(bash "$configure" --help)
+grep -q '^  *BASH_SHELL ' <<<"$help" || {
+    echo "configure --help does not advertise BASH_SHELL (AC_ARG_VAR missing)" >&2
+    exit 1
+}
+
+tmp=$(mktemp -d)
+trap 'set +e; rm -rf "$tmp"' EXIT
+ln -s "$sh" "$tmp/mybash"
+mkdir "$tmp/bld"
+(cd "$tmp/bld" && BASH_SHELL="$tmp/mybash" bash "$configure" >conf.log 2>&1) || {
+    echo "configure BASH_SHELL=$tmp/mybash failed:" >&2
+    tail -20 "$tmp/bld/conf.log" >&2
+    exit 1
+}
+got=$(sed -n 's/^BASH_SHELL = //p' "$tmp/bld/Makefile")
+test "$got" = "$tmp/mybash" || {
+    echo "configure discarded BASH_SHELL=$tmp/mybash, kept: $got" >&2
+    exit 1
+}
+
 echo "configured bash is $sh ($version)"

--- a/tests/146_bash-shell.test
+++ b/tests/146_bash-shell.test
@@ -61,8 +61,7 @@ trap 'set +e; rm -rf "$tmp"' EXIT
 mkdir "$tmp/src" "$tmp/bld"
 ln -s "$sh" "$tmp/mybash"
 
-# Symlink farm rather than the real srcdir: autoconf refuses an out-of-tree run when
-# srcdir holds a config.status, which is what an in-tree build leaves behind.
+# Symlink farm, not the real srcdir: an in-tree config.status makes autoconf refuse it.
 for f in "$abs_top_srcdir"/*; do
     case "${f##*/}" in
     config.status | config.log | config.h | stamp-h1 | Makefile) continue ;;
@@ -70,13 +69,20 @@ for f in "$abs_top_srcdir"/*; do
     ln -s "$f" "$tmp/src/"
 done
 
-# Read the trace, not the generated Makefile, and ignore the exit status: BASH_SHELL is
-# resolved long before the library checks, which need a build environment we cannot assume
-# (macOS CI hands its own configure the Homebrew paths for openssl).
-(cd "$tmp/bld" && BASH_SHELL="$tmp/mybash" bash "$tmp/src/configure" >conf.log 2>&1) || true
-got=$(sed -n 's/^checking for bash\.\.\. //p' "$tmp/bld/conf.log")
+# Prefer the Makefile: it proves the value that reaches $(BASH_SHELL), not just the macro's
+# decision. configure may die on a library check before writing one, so fall back to the
+# trace it printed earlier.
+(cd "$tmp/bld" && BASH_SHELL="$tmp/mybash" bash "$tmp/src/configure" --disable-https >conf.log 2>&1) || true
+if test -f "$tmp/bld/Makefile"; then
+    got=$(sed -n 's/^BASH_SHELL = //p' "$tmp/bld/Makefile")
+    from="Makefile"
+else
+    got=$(sed -n 's/^checking for bash\.\.\. //p' "$tmp/bld/conf.log")
+    got=${got#"(cached) "}
+    from="trace"
+fi
 test "$got" = "$tmp/mybash" || {
-    echo "configure discarded BASH_SHELL=$tmp/mybash, resolved: ${got:-<no result line>}" >&2
+    echo "configure discarded BASH_SHELL=$tmp/mybash, $from has: ${got:-<nothing>}" >&2
     tail -20 "$tmp/bld/conf.log" >&2
     exit 1
 }

--- a/tests/146_bash-shell.test
+++ b/tests/146_bash-shell.test
@@ -70,14 +70,14 @@ for f in "$abs_top_srcdir"/*; do
     ln -s "$f" "$tmp/src/"
 done
 
-(cd "$tmp/bld" && BASH_SHELL="$tmp/mybash" bash "$tmp/src/configure" >conf.log 2>&1) || {
-    echo "configure BASH_SHELL=$tmp/mybash failed:" >&2
-    tail -20 "$tmp/bld/conf.log" >&2
-    exit 1
-}
-got=$(sed -n 's/^BASH_SHELL = //p' "$tmp/bld/Makefile")
+# Read the trace, not the generated Makefile, and ignore the exit status: BASH_SHELL is
+# resolved long before the library checks, which need a build environment we cannot assume
+# (macOS CI hands its own configure the Homebrew paths for openssl).
+(cd "$tmp/bld" && BASH_SHELL="$tmp/mybash" bash "$tmp/src/configure" >conf.log 2>&1) || true
+got=$(sed -n 's/^checking for bash\.\.\. //p' "$tmp/bld/conf.log")
 test "$got" = "$tmp/mybash" || {
-    echo "configure discarded BASH_SHELL=$tmp/mybash, kept: $got" >&2
+    echo "configure discarded BASH_SHELL=$tmp/mybash, resolved: ${got:-<no result line>}" >&2
+    tail -20 "$tmp/bld/conf.log" >&2
     exit 1
 }
 

--- a/tests/146_bash-shell.test
+++ b/tests/146_bash-shell.test
@@ -58,9 +58,19 @@ grep -q '^  *BASH_SHELL ' <<<"$help" || {
 
 tmp=$(mktemp -d)
 trap 'set +e; rm -rf "$tmp"' EXIT
+mkdir "$tmp/src" "$tmp/bld"
 ln -s "$sh" "$tmp/mybash"
-mkdir "$tmp/bld"
-(cd "$tmp/bld" && BASH_SHELL="$tmp/mybash" bash "$configure" >conf.log 2>&1) || {
+
+# Symlink farm rather than the real srcdir: autoconf refuses an out-of-tree run when
+# srcdir holds a config.status, which is what an in-tree build leaves behind.
+for f in "$abs_top_srcdir"/*; do
+    case "${f##*/}" in
+    config.status | config.log | config.h | stamp-h1 | Makefile) continue ;;
+    esac
+    ln -s "$f" "$tmp/src/"
+done
+
+(cd "$tmp/bld" && BASH_SHELL="$tmp/mybash" bash "$tmp/src/configure" >conf.log 2>&1) || {
     echo "configure BASH_SHELL=$tmp/mybash failed:" >&2
     tail -20 "$tmp/bld/conf.log" >&2
     exit 1

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -27,6 +27,7 @@ TESTS_ENVIRONMENT += V6_SUPPORT=$(V6_SUPPORT)
 # Asserted by 146_bash-shell.test.
 TESTS_ENVIRONMENT += BASH_SHELL=$(BASH_SHELL)
 TESTS_ENVIRONMENT += top_srcdir=$(top_srcdir)
+TESTS_ENVIRONMENT += abs_top_srcdir=$(abs_top_srcdir)
 TESTS_ENVIRONMENT += abs_top_builddir=$(abs_top_builddir)
 TESTS_ENVIRONMENT += CONFIGURED_DATADIR=$(datadir)
 TESTS_ENVIRONMENT += RENAMEFAIL_LA=$(abs_builddir)/librenamefail.la


### PR DESCRIPTION
Follow-up to #898, which introduced `BASH_SHELL` and unset it first so a preset value could never defeat the search. That also threw away an explicit `./configure BASH_SHELL=/path`, so on a machine whose first bash on `PATH` is old or runs in POSIX mode there was no way to point the build elsewhere. `BASH` needed the guard because bash presets it; `BASH_SHELL` is our own name and nothing presets it, so `AC_ARG_VAR` is enough, and it documents the knob in `configure --help`.