### PR TITLE
The frozen-slot spool is written inside the mirror namespace

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -72,9 +72,11 @@ static hts_boolean back_tmpname(char *dest, size_t size, const char *save,
 
 hts_boolean back_spoolname(httrackp *opt, const char *save, char *dest,
                            size_t size) {
-  /* -p0 keeps no save name to derive from, so it counts instead */
+  /* -p0 keeps no save name to derive from, so it counts instead. No separator:
+     path_html_utf8 brings its own, and is "" with no -O, where an added one
+     would make this absolute and spool into the filesystem root. */
   if (opt->getmode == 0) {
-    if (!slprintfbuff(dest, size, "%s/" HTS_TMPDIR "/tmpfile%d.tmp",
+    if (!slprintfbuff(dest, size, "%s" HTS_TMPDIR "/tmpfile%d.tmp",
                       StringBuff(opt->path_html_utf8),
                       opt->state.tmpnameid++)) {
       dest[0] = '\0';
@@ -725,7 +727,7 @@ static int create_back_tmpfile(httrackp *opt, lien_back *const back,
     /* same directory as the named case, so back_tmpdir_drop() only removes one
        the engine made (#842) */
     /* truncation here would collide distinct tmpnameid's onto one name */
-    if (!sprintfbuff(back->tmpfile_buffer, "%s/" HTS_TMPDIR "/tmp%d.%s",
+    if (!sprintfbuff(back->tmpfile_buffer, "%s" HTS_TMPDIR "/tmp%d.%s",
                      StringBuff(opt->path_html_utf8), opt->state.tmpnameid++,
                      ext)) {
       hts_log_print(opt, LOG_WARNING, "temporary filename too long in %s",

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -62,7 +62,28 @@ Please visit our Website: http://www.httrack.com
 
 #define VT_CLREOL       "\33[K"
 
+/* Subdirectory holding a mirrored file's temporaries, beside it. url_savename()
+   maps '~' to '_', so no URL can ever be mirrored inside it (#774, #842). */
+#define HTS_TMPDIR "~hts-tmp"
+
 /* Slot operations */
+static hts_boolean back_tmpname(char *dest, size_t size, const char *save,
+                                const char *ext);
+
+hts_boolean back_spoolname(httrackp *opt, const char *save, char *dest,
+                           size_t size) {
+  /* -p0 keeps no save name to derive from, so it counts instead */
+  if (opt->getmode == 0) {
+    if (!slprintfbuff(dest, size, "%s/" HTS_TMPDIR "/tmpfile%d.tmp",
+                      StringBuff(opt->path_html_utf8),
+                      opt->state.tmpnameid++)) {
+      dest[0] = '\0';
+      return HTS_FALSE;
+    }
+    return HTS_TRUE;
+  }
+  return back_tmpname(dest, size, save, "tmp");
+}
 static int slot_can_be_cached_on_disk(const lien_back * back);
 static int slot_can_be_cleaned(const lien_back * back);
 static int slot_can_be_finalized(httrackp * opt, const lien_back * back);
@@ -217,6 +238,7 @@ void back_delete_all(httrackp * opt, cache_back * cache, struct_back * sback) {
 
         if (filename != NULL) {
           (void) UNLINK(filename);
+          back_tmpdir_drop(filename);
         }
 #else
         /* clear entry content (but not yet the entry) */
@@ -311,6 +333,7 @@ static int back_index_ready(httrackp * opt, struct_back * sback, const char *adr
                       adr, fil, sav);
       }
       (void) UNLINK(fileback);
+      back_tmpdir_drop(fileback);
 #else
       itemback = (lien_back *) ptr;
 #endif
@@ -483,22 +506,11 @@ int back_cleanup_background(httrackp * opt, cache_back * cache,
 #ifndef HTS_NO_BACK_ON_DISK
       /* temporarily serialize the entry on disk */
       {
-        /* +16: room for the ".tmp" the url_sav form appends to a full-length
-           save name, so one buffer holds both shapes */
-        char BIGSTK tmpname[HTS_URLMAXSIZE * 2 + 16];
+        /* +32: room for the directory and extension back_spoolname() inserts */
+        char BIGSTK tmpname[HTS_URLMAXSIZE * 2 + 32];
         char *filename;
-        hts_boolean named;
-
-        /* the -p0 name is not derived from url_sav, so it needs a buffer of
-           its own size rather than the save name's */
-        if (opt->getmode != 0) {
-          named =
-              slprintfbuff(tmpname, sizeof(tmpname), "%s.tmp", back[i].url_sav);
-        } else {
-          named = slprintfbuff(tmpname, sizeof(tmpname), "%stmpfile%d.tmp",
-                               StringBuff(opt->path_html_utf8),
-                               opt->state.tmpnameid++);
-        }
+        const hts_boolean named =
+            back_spoolname(opt, back[i].url_sav, tmpname, sizeof(tmpname));
         filename = named ? strdupt(tmpname) : NULL;
 
         if (filename != NULL) {
@@ -655,10 +667,6 @@ int back_nsoc_overall(const struct_back * sback) {
 
   return n;
 }
-
-/* Subdirectory holding a mirrored file's temporaries, beside it. url_savename()
-   maps '~' to '_', so no URL can ever be mirrored inside it (#774, #842). */
-#define HTS_TMPDIR "~hts-tmp"
 
 /* Build save's temporary as <dir>/<HTS_TMPDIR>/<name>.<ext>. Appending the
    extension to save instead put it in the mirror namespace, so a site serving

--- a/src/htsback.h
+++ b/src/htsback.h
@@ -155,6 +155,11 @@ hts_boolean back_finalize_backup(httrackp *opt, lien_back *const back,
 /* Remove the reserved directory a temporary sat in, once the last slot sharing
    it is done; a non-empty one just refuses. No-op outside that directory. */
 void back_tmpdir_drop(const char *tmp);
+/* Name the spool file of a frozen backlog slot, inside the reserved directory
+   no save name can spell. HTS_FALSE (dest emptied) if it would not fit.
+   Consumes an opt->state.tmpnameid under -p0. Note: utf-8. */
+hts_boolean back_spoolname(httrackp *opt, const char *save, char *dest,
+                           size_t size);
 /* -#test=backswap: slots eligible for the on-disk ready table. */
 int back_selftest_slot_swap(void);
 void back_info(struct_back * sback, int i, int j, FILE * fp);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6609,7 +6609,7 @@ static int st_spoolname(httrackp *opt, int argc, char **argv) {
     StringCopy(opt->path_html_utf8, base);
     opt->getmode = 0;
     opt->state.tmpnameid = 7;
-    snprintf(want, sizeof(want), "%s//~hts-tmp/tmpfile7.tmp", argv[0]);
+    snprintf(want, sizeof(want), "%s/~hts-tmp/tmpfile7.tmp", argv[0]);
     if (!back_spoolname(opt, "", got, sizeof(got))) {
       fprintf(stderr, "spoolname: naming failed under -p0\n");
       err++;
@@ -6621,6 +6621,20 @@ static int st_spoolname(httrackp *opt, int argc, char **argv) {
       fprintf(stderr, "spoolname: -p0 did not consume a tmpnameid\n");
       err++;
     }
+  }
+
+  /* with no -O, path_html_utf8 is empty and the spool must stay relative to
+     the working directory; a separator of our own would put it in / */
+  StringCopy(opt->path_html_utf8, "");
+  opt->getmode = 0;
+  opt->state.tmpnameid = 0;
+  if (!back_spoolname(opt, "", got, sizeof(got))) {
+    fprintf(stderr, "spoolname: naming failed with no output directory\n");
+    err++;
+  } else if (strcmp(got, "~hts-tmp/tmpfile0.tmp") != 0) {
+    fprintf(stderr, "spoolname: no -O gave %s, want ~hts-tmp/tmpfile0.tmp\n",
+            got);
+    err++;
   }
 
   /* too long must empty dest, not hand back a truncated name landing

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6567,6 +6567,74 @@ static int st_refetchbackup(httrackp *opt, int argc, char **argv) {
   return err;
 }
 
+// -#test=spoolname <dir>: a frozen backlog slot must spool inside ~hts-tmp, not
+// beside the mirrored file where a site serving <path>.tmp collides (#859).
+static int st_spoolname(httrackp *opt, int argc, char **argv) {
+  char BIGSTK got[HTS_URLMAXSIZE * 2 + 32];
+  char BIGSTK want[HTS_URLMAXSIZE * 2 + 32];
+  char BIGSTK save[HTS_URLMAXSIZE * 2];
+  int err = 0;
+
+  if (argc < 1) {
+    fprintf(stderr, "spoolname: needs a writable base dir\n");
+    return 1;
+  }
+
+  /* named: the spool lands in the save name's own ~hts-tmp, which no URL can
+     spell since url_savename() maps '~' to '_' */
+  snprintf(save, sizeof(save), "%s/sub/page.html", argv[0]);
+  snprintf(want, sizeof(want), "%s/sub/~hts-tmp/page.html.tmp", argv[0]);
+  opt->getmode = 1;
+  if (!back_spoolname(opt, save, got, sizeof(got))) {
+    fprintf(stderr, "spoolname: naming failed for %s\n", save);
+    err++;
+  } else if (strcmp(got, want) != 0) {
+    fprintf(stderr, "spoolname: got %s, want %s\n", got, want);
+    err++;
+  }
+
+  /* pin the pre-#859 name as forbidden too: a site serving sub/page.html.tmp
+     was mirrored straight onto it */
+  snprintf(want, sizeof(want), "%s.tmp", save);
+  if (strcmp(got, want) == 0) {
+    fprintf(stderr, "spoolname: still spooling into the mirror namespace\n");
+    err++;
+  }
+
+  /* -p0 keeps no save name, so the spool counts inside path_html's ~hts-tmp */
+  {
+    char BIGSTK base[HTS_URLMAXSIZE * 2];
+
+    snprintf(base, sizeof(base), "%s/", argv[0]);
+    StringCopy(opt->path_html_utf8, base);
+    opt->getmode = 0;
+    opt->state.tmpnameid = 7;
+    snprintf(want, sizeof(want), "%s//~hts-tmp/tmpfile7.tmp", argv[0]);
+    if (!back_spoolname(opt, "", got, sizeof(got))) {
+      fprintf(stderr, "spoolname: naming failed under -p0\n");
+      err++;
+    } else if (strcmp(got, want) != 0) {
+      fprintf(stderr, "spoolname: -p0 got %s, want %s\n", got, want);
+      err++;
+    }
+    if (opt->state.tmpnameid != 8) {
+      fprintf(stderr, "spoolname: -p0 did not consume a tmpnameid\n");
+      err++;
+    }
+  }
+
+  /* too long must empty dest, not hand back a truncated name landing
+     somewhere real */
+  opt->getmode = 1;
+  if (back_spoolname(opt, save, got, 8) || got[0] != '\0') {
+    fprintf(stderr, "spoolname: an overlong name was not rejected\n");
+    err++;
+  }
+
+  printf("spoolname: %s\n", err ? "FAIL" : "OK");
+  return err;
+}
+
 // -#test=direnum <dir>: enumerate a long+non-ASCII directory via the
 // opendir/readdir wrappers; children must round-trip as UTF-8 (#133,#630).
 static int st_direnum(httrackp *opt, int argc, char **argv) {
@@ -7733,6 +7801,8 @@ static const struct selftest_entry {
     {"refetchbackup", "<dir>",
      "the re-fetch backup always leaves a copy, and stays out of the mirror",
      st_refetchbackup},
+    {"spoolname", "<dir>",
+     "a frozen backlog slot spools outside the mirror namespace", st_spoolname},
     {"direnum", "<dir>",
      "enumerate a long+non-ASCII directory through opendir/readdir",
      st_direnum},

--- a/tests/148_engine-spoolname.test
+++ b/tests/148_engine-spoolname.test
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# A frozen backlog slot must spool outside the mirror namespace, or a site
+# serving <path>.tmp has its own copy truncated and then unlinked (#859).
+
+set -euo pipefail
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/spoolname.XXXXXX") || {
+    echo "no tmpdir" >&2
+    exit 1
+}
+trap 'set +e; rm -rf "${work}"' EXIT
+
+httrack -#test=spoolname "${work}"

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -218,3 +218,4 @@ TESTS += 143_engine-backtrace-empty.test
 TESTS += 144_engine-datadir.test
 TESTS += 145_webhttrack-datadir.test
 TESTS += 146_bash-shell.test
+TESTS += 148_engine-spoolname.test


### PR DESCRIPTION
When the backlog freezes a slot, `back_cleanup_background()` serialized it to `<save>.tmp`, beside the mirrored file. That is the collision #774 fixed for the re-fetch backup: a site serving `<path>.tmp` has its mirrored copy truncated by `filecreate()` and then unlinked when the slot is woken, and the run reports success. It needs no unusual options, since a `-Z` crawl of the bundled bigcrawl site with `-c4` already logs slots moving to background.

Both name shapes now go through `back_spoolname()`, which places them in the `~hts-tmp` directory `url_savename()` makes unspellable by mapping `~` to `_`, and the two sites that unlink a spool drop that directory after themselves. Naming was inline and untestable, which is why it survived #774; pulling it into a helper is what lets `-#test=spoolname` pin both shapes, including that an overlong name empties its destination rather than returning a truncated path that lands somewhere real.

One wrinkle worth flagging for review: `path_html_utf8` supplies its own trailing separator and is empty when `-O` is absent, so adding one turns the `-p0` spool into `/~hts-tmp/...` in the filesystem root. The first version of this branch did exactly that. `create_back_tmpfile()` has spelled it the same way since #842; its empty-path branch looks unreachable from the three call sites, so that side is a consistency fix carrying no test, unlike the spool.

Closes #859