### PR TITLE
A debug fprintf dumps every PROPFIND body to stderr

### DIFF
--- a/src/proxy/proxytrack.c
+++ b/src/proxy/proxytrack.c
@@ -827,8 +827,6 @@ static PT_Element proxytrack_process_DAV_Request(PT_Indexes indexes,
     strcpybuff(elt->msg, "Multi-Status");
     StringFree(response);
 
-    fprintf(stderr, "RESPONSE:\n%s\n", elt->adr);
-
     return elt;
   }
   return NULL;
@@ -1048,7 +1046,6 @@ static void proxytrack_process_HTTP(PT_Indexes indexes, T_SOC soc_c) {
           msgCode = 403;
           msgError = "DAV Depth Limit Forbidden";
         } else {
-          fprintf(stderr, "DEBUG: DAV-DATA=<%s>\n", StringBuff(davRequest));
           listRequest = 2;      /* propfind */
         }
       } else if (strcasecmp(command, "mkcol") == 0

--- a/tests/120_local-proxytrack-webdav-default.test
+++ b/tests/120_local-proxytrack-webdav-default.test
@@ -118,4 +118,21 @@ grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
     exit 1
 }
 
+# Leftover debug traces dumped the client's PROPFIND body and the generated
+# response straight to stderr, unauthenticated (#911). The per-request log line
+# proves the requests reached the handler, so the absence below means something.
+log=$(cat "$dir/pt.log")
+if ! grep -qi ' \* log: HTTP .* propfind ' <<<"$log"; then
+    echo "FAIL: proxytrack never logged the PROPFIND, so the checks below prove nothing"
+    printf '%s\n' "$log"
+    exit 1
+fi
+for marker in 'DEBUG: DAV-DATA' '^RESPONSE:'; do
+    if grep -q "$marker" <<<"$log"; then
+        echo "FAIL: a PROPFIND wrote '$marker' to proxytrack's stderr"
+        printf '%s\n' "$log"
+        exit 1
+    fi
+done
+
 echo "OK: PROPFIND on an exact cache entry lists its default document and survives"

--- a/tests/120_local-proxytrack-webdav-default.test
+++ b/tests/120_local-proxytrack-webdav-default.test
@@ -50,7 +50,31 @@ freeport() {
 proxyport=$(freeport)
 icpport=$(freeport)
 
-proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc" >"$dir/pt.log" 2>&1 &
+: >"$dir/pt.log" # the drainer below creates it asynchronously
+# stdout to a file is fully buffered and SIGTERM never flushes it, so a leak on
+# stdout would be lost; a pty line-buffers it. The exec keeps $! on proxytrack.
+"$python" -c '
+import os, pty, sys
+master, slave = pty.openpty()
+if os.fork() == 0:
+    os.close(slave)
+    with open(sys.argv[1], "wb", 0) as log:
+        while True:
+            try:
+                data = os.read(master, 65536)
+            except OSError:
+                break
+            if not data:
+                break
+            log.write(data)
+    os._exit(0)
+os.close(master)
+os.dup2(slave, 1)
+os.dup2(slave, 2)
+if slave > 2:
+    os.close(slave)
+os.execvp(sys.argv[2], sys.argv[2:])
+' "$dir/pt.log" proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc" &
 ptpid=$!
 waited=0
 until grep -qE "HTTP Proxy installed on|Unable to (initialize a temporary server|create the server)" "$dir/pt.log"; do
@@ -73,8 +97,10 @@ grep -q "HTTP Proxy installed on" "$dir/pt.log" || {
 }
 
 propfind() {
-    curl -s -i --max-time 30 -X PROPFIND -H "Depth: 1" \
-        "http://127.0.0.1:$proxyport/webdav/example.com/$1"
+    local path=$1
+    shift
+    curl -s -i --max-time 30 -X PROPFIND -H "Depth: 1" "$@" \
+        "http://127.0.0.1:$proxyport/webdav/example.com/$path"
 }
 
 resp=$(propfind page.html) || {
@@ -118,18 +144,41 @@ grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
     exit 1
 }
 
-# Leftover debug traces dumped the client's PROPFIND body and the generated
-# response straight to stderr, unauthenticated (#911). The per-request log line
-# proves the requests reached the handler, so the absence below means something.
-log=$(cat "$dir/pt.log")
-if ! grep -qi ' \* log: HTTP .* propfind ' <<<"$log"; then
-    echo "FAIL: proxytrack never logged the PROPFIND, so the checks below prove nothing"
-    printf '%s\n' "$log"
+# Leftover traces echoed the client's body and the generated response (#911).
+# The padding spills the canary past any stdio buffer, newline or not.
+sentinel=PT911-DAV-BODY-CANARY
+pad=$(printf '%8192s' '')
+resp=$(propfind "" -H 'Expect:' --data-binary "$sentinel${pad// /x}") || {
+    echo "FAIL: proxytrack died serving a PROPFIND carrying a body"
+    cat "$dir/pt.log"
     exit 1
-fi
-for marker in 'DEBUG: DAV-DATA' '^RESPONSE:'; do
+}
+grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
+    echo "FAIL: expected 207 Multi-Status on the canary listing"
+    printf '%s\n' "$resp"
+    exit 1
+}
+
+# The 207 is what makes the absence below mean something: a depth-rejected
+# PROPFIND is logged 403 without ever reaching the traces. It is logged after
+# them, so waiting on it also fences the drainer's copy.
+waited=0
+until test "$(grep -ci ' \* log: HTTP [^ ]* 207 [0-9]* propfind ' "$dir/pt.log" || true)" -ge 3; do
+    test "$waited" -lt 50 || {
+        echo "FAIL: fewer than three PROPFINDs were answered 207, so the checks below prove nothing"
+        cat "$dir/pt.log"
+        exit 1
+    }
+    sleep 0.1
+    waited=$((waited + 1))
+done
+
+# Neither what the client sent nor the generated body is echoed anywhere; the
+# two literals name the exact regression on top.
+log=$(<"$dir/pt.log")
+for marker in "$sentinel" 'Default Document for the Folder' 'DEBUG: DAV-DATA' '^RESPONSE:'; do
     if grep -q "$marker" <<<"$log"; then
-        echo "FAIL: a PROPFIND wrote '$marker' to proxytrack's stderr"
+        echo "FAIL: a PROPFIND echoed '$marker' into proxytrack's output"
         printf '%s\n' "$log"
         exit 1
     fi


### PR DESCRIPTION
Two leftover `fprintf(stderr, ...)` calls in proxytrack's WebDAV path shipped by accident. One printed the client-supplied PROPFIND request body, the other the whole generated multistatus response. Both ran on every PROPFIND with no authentication in front of them, so any client could write bytes of its own choosing into the operator's stderr, which for a daemonized proxytrack is wherever the service redirects it.

I deleted both rather than route them through `proxytrack_print_log(DEBUG, ...)`. proxytrack never parses the request body, it reads it off the socket and frees it, and the response is reconstructible from the index, so neither trace tells an operator anything he cannot get elsewhere. `DEBUG` is also a no-op severity unless `_DEBUG` is defined, so escaping the body properly would buy a line that is dead in every shipped build. The issue names only the first call; the second is the same bug two functions away. The per-request access log stays as it is: `proxytrack_print_log` writes to stderr too and its line carries the client's method and URL, but that one is a log the operator asked for.

The check went into `tests/120_local-proxytrack-webdav-default.test`, which already drives PROPFIND against a live proxytrack. Pinning the two deleted strings is weak on its own, so the test sends a PROPFIND with a canary in its body and requires that neither the canary nor a distinctive string from the generated response turns up in proxytrack's output. The literals stay on top, as names for the specific regression. proxytrack now runs on a pty rather than writing to a file, because a file makes its stdout fully buffered and SIGTERM never flushes it, which hid a re-added trace that used stdout. The guard that makes the absence mean anything requires a PROPFIND answered 207, since a depth-rejected one is logged 403 without ever reaching the deleted code. Five variants of the traces were re-added one at a time and all five fail the test; four of them passed it before this hardening.

Closes #911