### PR TITLE
http_xfread1's reserve-only read mode has no caller

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -1948,13 +1948,6 @@ LLint http_xfread1(htsblk * r, int bufl) {
 
     }                           // stockage disque ou mémoire
 
-  } else if (bufl == HTS_XFREAD_RESERVE) {
-    if (r->adr == NULL) {
-      r->adr = (char *) malloct(HTS_LINE_BLOCK_SIZE);
-      r->size = 0;
-      return 0;
-    }
-    return -1;
   } else { // line modes: byte by byte, CR dropped
     int count = 256;
     int tot_nl = 0;

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -253,10 +253,9 @@ void treatfirstline(htsblk * retour, const char *rcvd);
    section. Overrunning it fails the transfer. */
 #define HTS_LINE_BLOCK_SIZE 8192
 /* http_xfread1() read modes: a positive bufl reads at most that many raw bytes,
-   these three read CR-stripped lines into the HTS_LINE_BLOCK_SIZE buffer. */
+   these two read CR-stripped lines into the HTS_LINE_BLOCK_SIZE buffer. */
 #define HTS_XFREAD_LINE_BLOCK 0 /* lines up to a blank one (header/trailer) */
 #define HTS_XFREAD_LINE (-1)    /* one line, stopping at the first LF */
-#define HTS_XFREAD_RESERVE (-2) /* allocate only; no caller (#923) */
 LLint http_xfread1(htsblk * r, int bufl);
 /* Cached resolver: fill out[0..count-1] with up to max addresses for iadr (in
    resolver order), returning the count (0 = does not resolve, negative-cached).

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -253,7 +253,7 @@ void treatfirstline(htsblk * retour, const char *rcvd);
    section. Overrunning it fails the transfer. */
 #define HTS_LINE_BLOCK_SIZE 8192
 /* http_xfread1() read modes: a positive bufl reads at most that many raw bytes,
-   these two read CR-stripped lines into the HTS_LINE_BLOCK_SIZE buffer. */
+   anything else reads CR-stripped lines into the HTS_LINE_BLOCK_SIZE buffer. */
 #define HTS_XFREAD_LINE_BLOCK 0 /* lines up to a blank one (header/trailer) */
 #define HTS_XFREAD_LINE (-1)    /* one line, stopping at the first LF */
 LLint http_xfread1(htsblk * r, int bufl);


### PR DESCRIPTION
The `bufl == -2` branch of `http_xfread1()` allocates the line buffer and returns without reading. Nothing has ever called it: no call site in the tree passes -2, and scanning all 2649 revisions in this repository for `xfread1(` call sites turns up 24 distinct lines, none of them -2. The branch arrived with the 3.20.2 import commented "force reserve", so it was probably meant for a preallocate-then-fill pattern that never landed. Naming it `HTS_XFREAD_RESERVE` in #919 made it read as a supported mode.

No external caller is possible either: `htslib.h` is not installed and the symbol is hidden, so this is not an API change.

Equivalence checked against the object code. `htsback.o` and `htsselftest.o` disassemble identically; in `htslib.o` every function except `http_xfread1` differs only in the `__LINE__` values `htssafe.h` bakes in, shifted by the seven deleted lines. No new test: nothing changes for any input a caller can produce, and `01_engine-xfread` plus the chunked tests still pass.

Closes #923
