### PR TITLE
The tagline no longer sits against the wordmark's baseline

### DIFF
--- a/html/doc.css
+++ b/html/doc.css
@@ -57,7 +57,15 @@ body {
 	padding: .6rem 0 0;
 }
 
-.masthead img { display: block; max-width: 100%; height: auto; }
+/* The wordmark's box is its ink box, so the k's ascender adds a band above the
+   caps and the round letters' overshoot one below the baseline. Trim both back
+   optically, or the tagline stops sitting against the baseline. */
+.masthead img {
+	display: block;
+	max-width: 100%;
+	height: auto;
+	margin: -1.7px 0 -1.1px;
+}
 
 .masthead .tagline {
 	background: #000;

--- a/html/doc.css
+++ b/html/doc.css
@@ -57,7 +57,7 @@ body {
 	padding: .6rem 0 0;
 }
 
-/* Trim the ink box's ascender and overshoot bands, so the tagline sits on the baseline. */
+/* Take back the whitespace the SVG carries around the letters, restoring the old bitmap's spacing. */
 .masthead img {
 	display: block;
 	max-width: 100%;

--- a/html/doc.css
+++ b/html/doc.css
@@ -57,9 +57,7 @@ body {
 	padding: .6rem 0 0;
 }
 
-/* The wordmark's box is its ink box, so the k's ascender adds a band above the
-   caps and the round letters' overshoot one below the baseline. Trim both back
-   optically, or the tagline stops sitting against the baseline. */
+/* Trim the ink box's ascender and overshoot bands, so the tagline sits on the baseline. */
 .masthead img {
 	display: block;
 	max-width: 100%;

--- a/tests/82_webhttrack-browse-links.test
+++ b/tests/82_webhttrack-browse-links.test
@@ -100,8 +100,7 @@ finished = get("/server/finished.html").decode("latin-1")
 check("HTTrack Website Copier" in finished, "finished.html rendered")
 check("file://" not in finished, "finished.html has no file: link")
 
-# Every image a GUI page names must be served. The masthead is referenced from 23
-# of them, so one renamed asset breaks the lot and nothing else here would notice.
+# Every image a GUI page names must be served; the masthead is on 23 of them.
 page = get("/server/step2.html").decode("latin-1")
 srcs = [s for s in re.findall(r'<img[^>]+src="([^"]+)"', page)
         if not s.startswith(("http:", "https:", "data:"))]


### PR DESCRIPTION
The old GIF was cropped from the cap tops to the baseline, so its box edges were the letters themselves and the tagline sat right against them. The SVG that replaced it in #916 carries the true ink box, which in Jost also holds the k's ascender above the caps and the round letters' overshoot below the baseline. Both show up as a band of field colour, the lower one as a visible gap above the tagline.

An `<img>`'s layout box is its image box, so neither band can be cropped out of the artwork without cutting ink. The masthead takes them back optically instead. Measured against the old rendering at 3x, the baseline-to-tagline distance is identical and the cap tops land within a third of a pixel.