### PR TITLE
proxytrack cannot re-read the .arc it writes

### DIFF
--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -1983,6 +1983,21 @@ static int skipArcNl(FILE * file) {
   return -1;
 }
 
+/* Stop on the newline opening the first record: archives whose version block
+   length swallowed the closing blank line leave only that one. */
+static int skipArcVersionNl(FILE *file) {
+  long int last = -1;
+  long int pos;
+
+  while ((pos = ftell(file)) >= 0 && fgetc(file) == 0x0a) {
+    last = pos;
+  }
+  if (last < 0) {
+    return -1;
+  }
+  return fseek(file, last, SEEK_SET);
+}
+
 static int skipArcData(FILE * file, const char *line) {
   int jump = getArcLength(line);
 
@@ -2095,9 +2110,9 @@ int PT_LoadCache__Arc(PT_Index index_, const char *filename) {
         }
         /* Timestamp */
         index->timestamp = getArcTimestamp(index->line);
-        /* Skip first entry */
-        if (skipArcData(index->file, index->line) != 0
-            || skipArcNl(index->file) != 0) {
+        /* Skip the version block, leaving the record loop its own separator */
+        if (skipArcData(index->file, index->line) != 0 ||
+            (skipArcVersionNl(index->file) != 0 && !feof(index->file))) {
           fprintf(stderr, "Unexpected bad data offset size first entry" LF);
           fclose(index->file);
           index->file = NULL;
@@ -2486,16 +2501,20 @@ static int PT_SaveCache__Arc(PT_Indexes indexes, const char *filename) {
        2<sp><reserved><sp><origin-code><nl>
        URL<sp>IP-address<sp>Archive-date<sp>Content-type<sp>Result-code<sp>Checksum<sp>Location<sp> Offset<sp>Filename<sp>Archive-length<nl>
        <nl> */
-    const char *prefix =
-      "2 0 HTTrack Website Copier" "\n"
-      "URL IP-address Archive-Date Content-Type Result-code Checksum Location Offset Filename Archive-length"
-      "\n" "\n";
+    const char *prefix = "2 0 HTTrack Website Copier"
+                         "\n"
+                         "URL IP-address Archive-Date Content-Type Result-code "
+                         "Checksum Location Offset Filename Archive-length"
+                         "\n";
     sprintf(st.filename, "httrack_%d.arc", (int) t);
     fprintf(fp,
             "filedesc://%s 0.0.0.0 %04d%02d%02d%02d%02d%02d text/plain 200 - - 0 %s %d"
             "\n" "%s", st.filename, tm.tm_year + 1900, tm.tm_mon + 1,
             tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec, st.filename,
             (int) strlen(prefix), prefix);
+    /* the blank line closing the version block is a separator, outside the
+       declared length: counting it left every entry unreadable on reload */
+    fputc('\n', fp);
     st.fp = fp;
     st.indexes = indexes;
     st.t = t;

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -1986,16 +1986,15 @@ static int skipArcNl(FILE * file) {
 /* Stop on the newline opening the first record: archives whose version block
    length swallowed the closing blank line leave only that one. */
 static int skipArcVersionNl(FILE *file) {
-  long int last = -1;
-  long int pos;
+  long int pos = ftell(file);
 
-  while ((pos = ftell(file)) >= 0 && fgetc(file) == 0x0a) {
-    last = pos;
-  }
-  if (last < 0) {
+  if (pos < 0 || fgetc(file) != 0x0a) {
     return -1;
   }
-  return fseek(file, last, SEEK_SET);
+  if (fgetc(file) == 0x0a) { /* the blank line, when outside the length */
+    pos++;
+  }
+  return fseek(file, pos, SEEK_SET);
 }
 
 static int skipArcData(FILE * file, const char *line) {
@@ -2112,7 +2111,7 @@ int PT_LoadCache__Arc(PT_Index index_, const char *filename) {
         index->timestamp = getArcTimestamp(index->line);
         /* Skip the version block, leaving the record loop its own separator */
         if (skipArcData(index->file, index->line) != 0 ||
-            (skipArcVersionNl(index->file) != 0 && !feof(index->file))) {
+            skipArcVersionNl(index->file) != 0) {
           fprintf(stderr, "Unexpected bad data offset size first entry" LF);
           fclose(index->file);
           index->file = NULL;
@@ -2513,7 +2512,7 @@ static int PT_SaveCache__Arc(PT_Indexes indexes, const char *filename) {
             tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec, st.filename,
             (int) strlen(prefix), prefix);
     /* the blank line closing the version block is a separator, outside the
-       declared length: counting it left every entry unreadable on reload */
+       declared length */
     fputc('\n', fp);
     st.fp = fp;
     st.indexes = indexes;

--- a/tests/154_local-proxytrack-arc-roundtrip.test
+++ b/tests/154_local-proxytrack-arc-roundtrip.test
@@ -60,6 +60,10 @@ hdrlen=$(head -1 "$dir/a.arc" | wc -c)
 declared=$(head -1 "$dir/a.arc" | awk '{print $NF}')
 sep=$(tail -c +$((hdrlen + declared + 1)) "$dir/a.arc" | head -c 3 | od -An -c | tr -d ' ')
 test "$sep" = '\n\nh' || fail "version block ends on '$sep', expected two newlines"
+# The block itself must not end on one either: counting the blank line and then
+# writing a second one round-trips, but leaves the length a byte too long.
+inner=$(tail -c +$((hdrlen + declared - 1)) "$dir/a.arc" | head -c 2 | od -An -c | tr -d ' ')
+test "$inner" != '\n\n' || fail "declared length still counts the blank line"
 
 # An empty archive is not a corrupt one...
 {

--- a/tests/154_local-proxytrack-arc-roundtrip.test
+++ b/tests/154_local-proxytrack-arc-roundtrip.test
@@ -1,0 +1,75 @@
+#!/bin/bash
+# proxytrack could not re-read the .arc it wrote: the version block's declared
+# length counted the blank line closing it, so the reader ate the first record's
+# separator and the archive loaded with no entries at all.
+
+set -euo pipefail
+export LC_ALL=C
+
+dir=$(mktemp -d)
+cleanup() { rm -rf "$dir"; }
+trap 'set +e; cleanup' EXIT
+trap 'set +e; cleanup; exit 1' HUP INT TERM
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+BODY=BODYMARKER
+printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nLast-Modified: Wed, 01 Jan 2025 00:00:00 GMT\r\nContent-Length: %d\r\n\r\n' "${#BODY}" >"$dir/hdr"
+printf '%s' "$BODY" >"$dir/body"
+alen=$(($(wc -c <"$dir/hdr") + ${#BODY}))
+
+# $1 output, $2 the filedesc length: 9 stops at the "2 0" line, 10 swallows the
+# blank line closing the version block the way the writer used to. Same bytes.
+build_arc() {
+    {
+        printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc %d\n' "$2"
+        printf '2 0 test\n'
+        printf '\n\n'
+        printf 'http://example.com/p.html 0.0.0.0 20250101000000 text/html 200 - - 0 t.arc %d\n' "$alen"
+        cat "$dir/hdr" "$dir/body"
+    } >"$1"
+}
+
+# Convert $1 into $2, echoing how many entries proxytrack reported reading.
+convert() {
+    proxytrack --convert "$2" "$1" 2>"$dir/log" >/dev/null ||
+        fail "proxytrack died converting $1"
+    sed -n 's/^processed: .*(\([0-9]*\) items added)$/\1/p' "$dir/log"
+}
+
+build_arc "$dir/spec.arc" 9
+test "$(convert "$dir/spec.arc" "$dir/a.arc")" = 1 ||
+    fail "the hand-built archive itself did not load"
+
+# The reported bug: a second hop over proxytrack's own output.
+test "$(convert "$dir/a.arc" "$dir/b.arc")" = 1 ||
+    fail "proxytrack read no entry back from the .arc it wrote"
+grep -aqF "$BODY" "$dir/b.arc" || fail "entry survived the round-trip without its body"
+
+# Archives written before the fix must still load.
+build_arc "$dir/legacy.arc" 10
+test "$(convert "$dir/legacy.arc" "$dir/c.arc")" = 1 ||
+    fail "an archive whose length counts the blank line no longer loads"
+
+# And the blank line must stay outside the declared length, or a proxytrack
+# predating the fix reads nothing from what we now write.
+hdrlen=$(head -1 "$dir/a.arc" | wc -c)
+declared=$(head -1 "$dir/a.arc" | awk '{print $NF}')
+sep=$(tail -c +$((hdrlen + declared + 1)) "$dir/a.arc" | head -c 2 | od -An -c | tr -d ' ')
+test "$sep" = '\n\n' || fail "version block ends on '$sep', expected two newlines"
+
+# An empty archive is not a corrupt one, in either form.
+for len in 9 10; do
+    {
+        printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc %d\n' "$len"
+        printf '2 0 test\n'
+        printf '\n'
+    } >"$dir/empty.arc"
+    convert "$dir/empty.arc" "$dir/d.arc" >/dev/null
+    ! grep -q 'Unexpected' "$dir/log" || fail "empty archive (length $len) reported as corrupt"
+done
+
+echo "OK: proxytrack re-reads the .arc it writes"

--- a/tests/154_local-proxytrack-arc-roundtrip.test
+++ b/tests/154_local-proxytrack-arc-roundtrip.test
@@ -1,7 +1,6 @@
 #!/bin/bash
-# proxytrack could not re-read the .arc it wrote: the version block's declared
-# length counted the blank line closing it, so the reader ate the first record's
-# separator and the archive loaded with no entries at all.
+# proxytrack must re-read the .arc it writes: the blank line closing the version
+# block is a separator, and counting it in the declared length cost every entry.
 
 set -euo pipefail
 export LC_ALL=C
@@ -55,21 +54,29 @@ test "$(convert "$dir/legacy.arc" "$dir/c.arc")" = 1 ||
     fail "an archive whose length counts the blank line no longer loads"
 
 # And the blank line must stay outside the declared length, or a proxytrack
-# predating the fix reads nothing from what we now write.
+# predating the fix reads nothing from what we now write. Two newlines exactly:
+# a third would put the record out of its reach again.
 hdrlen=$(head -1 "$dir/a.arc" | wc -c)
 declared=$(head -1 "$dir/a.arc" | awk '{print $NF}')
-sep=$(tail -c +$((hdrlen + declared + 1)) "$dir/a.arc" | head -c 2 | od -An -c | tr -d ' ')
-test "$sep" = '\n\n' || fail "version block ends on '$sep', expected two newlines"
+sep=$(tail -c +$((hdrlen + declared + 1)) "$dir/a.arc" | head -c 3 | od -An -c | tr -d ' ')
+test "$sep" = '\n\nh' || fail "version block ends on '$sep', expected two newlines"
 
-# An empty archive is not a corrupt one, in either form.
-for len in 9 10; do
-    {
-        printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc %d\n' "$len"
-        printf '2 0 test\n'
-        printf '\n'
-    } >"$dir/empty.arc"
-    convert "$dir/empty.arc" "$dir/d.arc" >/dev/null
-    ! grep -q 'Unexpected' "$dir/log" || fail "empty archive (length $len) reported as corrupt"
-done
+# An empty archive is not a corrupt one...
+{
+    printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc 9\n'
+    printf '2 0 test\n'
+    printf '\n'
+} >"$dir/empty.arc"
+convert "$dir/empty.arc" "$dir/d.arc" >/dev/null
+! grep -q 'Unexpected' "$dir/log" || fail "empty archive reported as corrupt"
+
+# ...but a length running past the end of the file still is.
+{
+    printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc 99999\n'
+    printf '2 0 test\n'
+    printf '\n\n'
+} >"$dir/truncated.arc"
+convert "$dir/truncated.arc" "$dir/e.arc" >/dev/null || true
+grep -q 'Unexpected' "$dir/log" || fail "a length past the end of the file loaded as an empty archive"
 
 echo "OK: proxytrack re-reads the .arc it writes"

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -225,3 +225,4 @@ TESTS += 151_bash-shell-validate.test
 TESTS += 150_engine-strsprintf.test
 TESTS += 152_engine-string-oom.test
 TESTS += 153_local-proxytrack-quiet.test
+TESTS += 154_local-proxytrack-arc-roundtrip.test


### PR DESCRIPTION
`proxytrack --convert` could not read back the `.arc` it had just written: the `filedesc` line's declared length counted the blank line that closes the version block, so the reader consumed the newline separating the first record and every entry was dropped.

The blank line now sits outside that length. The bytes on disk are unchanged (only the length field drops by one), so an older proxytrack reads the new files, and the reader accepts either form so archives already written the old way still load. A version block that does not end on a newline is still rejected, and the scan stops after two newlines so a padded archive cannot cost a read per byte.

Closes #834
