### PR TITLE
The tagline bar carries prose leading it has no use for

### DIFF
--- a/html/doc.css
+++ b/html/doc.css
@@ -69,7 +69,9 @@ body {
 	background: #000;
 	color: #fff;
 	font-weight: bold;
-	padding: .25rem .4rem;
+	/* A one-line label has no use for the body's prose leading. */
+	line-height: 1;
+	padding: .3rem .4rem;
 	margin-top: .4rem;
 }
 


### PR DESCRIPTION
The bar under the wordmark inherits `line-height: 1.6` from `body`, so a one-line label gets prose leading: a 25.6px line box plus 8px of padding wrapped around glyphs that are 15px tall. Of the 15px between the wordmark's baseline and the tagline text, 10px sat inside the black block rather than above it, which is where the gap #927 did not account for was coming from.

`line-height: 1` with slightly larger padding brings the bar from 34px to 26px and the baseline-to-text distance to 11px, leaving 6px above the caps and 4.7px below the descenders. Verified on four masthead pages, in both colour schemes, at 360px wide and at 2x.