### PR TITLE
The cached-headers block is built with an unbounded sprintf

### DIFF
--- a/src/htscache.c
+++ b/src/htscache.c
@@ -126,9 +126,10 @@ void cache_mayadd(httrackp * opt, cache_back * cache, htsblk * r,
    shorter value. `headers` must be an array, for sizeof. */
 #define ZIP_FIELD_STRING(headers, headersSize, dropped, field, value)          \
   do {                                                                         \
-    if ((value) != NULL && (value)[0] != '\0') {                               \
-      sprintf(headers + headersSize, "%s: %s\r\n", field, value);              \
-      (headersSize) += strlen(headers + headersSize);                          \
+    if ((value) != NULL && (value)[0] != '\0' &&                               \
+        !slcatprintfbuff(headers, sizeof(headers), &(headersSize),             \
+                         "%s: %s\r\n", field, value)) {                        \
+      (dropped)++;                                                             \
     }                                                                          \
   } while (0)
 #define ZIP_FIELD_INT(headers, headersSize, dropped, field, value)             \

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -119,11 +119,9 @@ void cache_mayadd(httrackp * opt, cache_back * cache, htsblk * r,
   // ---fin stockage en cache---
 }
 
-/* Append "<field>: <value>\r\n" to the header block, counting into `dropped`
-   the fields that did not fit. The values are remote-controlled (ETag,
-   Location, the URL itself) and together outgrow the block, so it is bounded;
-   the field is dropped whole because a clipped one reads back as a valid
-   shorter value. `headers` must be an array, for sizeof. */
+/* Remote-controlled values (ETag, Location, the URL) can together outgrow the
+   block, and a clipped field reads back as a valid shorter one, so one that
+   does not fit is dropped whole and counted. `headers` must be an array. */
 #define ZIP_FIELD_STRING(headers, headersSize, dropped, field, value)          \
   do {                                                                         \
     if ((value) != NULL && (value)[0] != '\0' &&                               \
@@ -221,7 +219,7 @@ void cache_add(httrackp * opt, cache_back * cache, const htsblk * r,
   char BIGSTK filename[HTS_URLMAXSIZE * 4];
   char catbuff[CATBUFF_SIZE];
   int dataincache = 0;          // put data in cache ?
-  char BIGSTK headers[8192];
+  char BIGSTK headers[CACHE_HEADERS_SIZE];
   size_t headersSize = 0;
   int headersDropped = 0;
 
@@ -324,8 +322,8 @@ void cache_add(httrackp * opt, cache_back * cache, const htsblk * r,
                    r->location); // 'location' pour moved
   ZIP_FIELD_STRING(headers, headersSize, headersDropped, "Content-Disposition",
                    r->cdispo); // Content-disposition
-  /* X-Save first of the three: it is the only one the reader consumes, so it
-     must not be what a full block drops */
+  /* X-Save first of the three: the only one a reader acts on, so a full block
+     must not drop it (X-Addr/X-Fil are pass-through metadata) */
   ZIP_FIELD_STRING(headers, headersSize, headersDropped, "X-Save",
                    url_save_suffix); // Original save filename
   ZIP_FIELD_STRING(headers, headersSize, headersDropped, "X-Addr",

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -126,10 +126,9 @@ void cache_mayadd(httrackp * opt, cache_back * cache, htsblk * r,
    shorter value. `headers` must be an array, for sizeof. */
 #define ZIP_FIELD_STRING(headers, headersSize, dropped, field, value)          \
   do {                                                                         \
-    if ((value) != NULL && (value)[0] != '\0' &&                               \
-        !slcatprintfbuff(headers, sizeof(headers), &(headersSize),             \
-                         "%s: %s\r\n", field, value)) {                        \
-      (dropped)++;                                                             \
+    if ((value) != NULL && (value)[0] != '\0') {                               \
+      sprintf(headers + headersSize, "%s: %s\r\n", field, value);              \
+      (headersSize) += strlen(headers + headersSize);                          \
     }                                                                          \
   } while (0)
 #define ZIP_FIELD_INT(headers, headersSize, dropped, field, value)             \

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -119,22 +119,34 @@ void cache_mayadd(httrackp * opt, cache_back * cache, htsblk * r,
   // ---fin stockage en cache---
 }
 
-#define ZIP_FIELD_STRING(headers, headersSize, field, value) do { \
-  if ( (value != NULL) && (value)[0] != '\0') { \
-    sprintf(headers + headersSize, "%s: %s\r\n", field, (value != NULL) ? (value) : ""); \
-    (headersSize) += (int) strlen(headers + headersSize); \
-  } \
-} while(0)
-#define ZIP_FIELD_INT(headers, headersSize, field, value) do { \
-  if ( (value != 0) ) { \
-    sprintf(headers + headersSize, "%s: "LLintP"\r\n", field, (LLint)(value)); \
-    (headersSize) += (int) strlen(headers + headersSize); \
-  } \
-} while(0)
-#define ZIP_FIELD_INT_FORCE(headers, headersSize, field, value) do { \
-  sprintf(headers + headersSize, "%s: "LLintP"\r\n", field, (LLint)(value)); \
-  (headersSize) += (int) strlen(headers + headersSize); \
-} while(0)
+/* Append "<field>: <value>\r\n" to the header block, counting into `dropped`
+   the fields that did not fit. The values are remote-controlled (ETag,
+   Location, the URL itself) and together outgrow the block, so it is bounded;
+   the field is dropped whole because a clipped one reads back as a valid
+   shorter value. `headers` must be an array, for sizeof. */
+#define ZIP_FIELD_STRING(headers, headersSize, dropped, field, value)          \
+  do {                                                                         \
+    if ((value) != NULL && (value)[0] != '\0' &&                               \
+        !slcatprintfbuff(headers, sizeof(headers), &(headersSize),             \
+                         "%s: %s\r\n", field, value)) {                        \
+      (dropped)++;                                                             \
+    }                                                                          \
+  } while (0)
+#define ZIP_FIELD_INT(headers, headersSize, dropped, field, value)             \
+  do {                                                                         \
+    if ((value) != 0 &&                                                        \
+        !slcatprintfbuff(headers, sizeof(headers), &(headersSize),             \
+                         "%s: " LLintP "\r\n", field, (LLint) (value))) {      \
+      (dropped)++;                                                             \
+    }                                                                          \
+  } while (0)
+#define ZIP_FIELD_INT_FORCE(headers, headersSize, dropped, field, value)       \
+  do {                                                                         \
+    if (!slcatprintfbuff(headers, sizeof(headers), &(headersSize),             \
+                         "%s: " LLintP "\r\n", field, (LLint) (value))) {      \
+      (dropped)++;                                                             \
+    }                                                                          \
+  } while (0)
 
 struct cache_back_zip_entry {
   unsigned long int hdrPos;
@@ -210,7 +222,8 @@ void cache_add(httrackp * opt, cache_back * cache, const htsblk * r,
   char catbuff[CATBUFF_SIZE];
   int dataincache = 0;          // put data in cache ?
   char BIGSTK headers[8192];
-  int headersSize = 0;
+  size_t headersSize = 0;
+  int headersDropped = 0;
 
   zip_fileinfo fi;
   const char *url_save_suffix = url_save;
@@ -275,10 +288,11 @@ void cache_add(httrackp * opt, cache_back * cache, const htsblk * r,
       message = "(See X-StatusMessage)";
     }
     /* 64 characters MAX for first line */
-    sprintf(headers + headersSize, "HTTP/1.%c %d %s\r\n", '1', r->statuscode,
-            message);
+    if (!slcatprintfbuff(headers, sizeof(headers), &headersSize,
+                         "HTTP/1.%c %d %s\r\n", '1', r->statuscode, message)) {
+      headersDropped++;
+    }
   }
-  headersSize += (int) strlen(headers + headersSize);
 
   if (path_prefix != NULL && path_prefix[0] != '\0' && url_save != NULL
       && url_save[0] != '\0') {
@@ -290,19 +304,39 @@ void cache_add(httrackp * opt, cache_back * cache, const htsblk * r,
   }
 
   /* Second line MUST ALWAYS be X-In-Cache */
-  ZIP_FIELD_INT_FORCE(headers, headersSize, "X-In-Cache", dataincache);
-  ZIP_FIELD_INT(headers, headersSize, "X-StatusCode", r->statuscode);
-  ZIP_FIELD_STRING(headers, headersSize, "X-StatusMessage", r->msg);
-  ZIP_FIELD_INT(headers, headersSize, "X-Size", r->size);       // size
-  ZIP_FIELD_STRING(headers, headersSize, "Content-Type", r->contenttype);       // contenttype
-  ZIP_FIELD_STRING(headers, headersSize, "X-Charset", r->charset);      // contenttype
-  ZIP_FIELD_STRING(headers, headersSize, "Last-Modified", r->lastmodified);     // last-modified
-  ZIP_FIELD_STRING(headers, headersSize, "Etag", r->etag);      // Etag
-  ZIP_FIELD_STRING(headers, headersSize, "Location", r->location);      // 'location' pour moved
-  ZIP_FIELD_STRING(headers, headersSize, "Content-Disposition", r->cdispo);     // Content-disposition
-  ZIP_FIELD_STRING(headers, headersSize, "X-Addr", url_adr);    // Original address
-  ZIP_FIELD_STRING(headers, headersSize, "X-Fil", url_fil);     // Original URI filename
-  ZIP_FIELD_STRING(headers, headersSize, "X-Save", url_save_suffix);    // Original save filename
+  ZIP_FIELD_INT_FORCE(headers, headersSize, headersDropped, "X-In-Cache",
+                      dataincache);
+  ZIP_FIELD_INT(headers, headersSize, headersDropped, "X-StatusCode",
+                r->statuscode);
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "X-StatusMessage",
+                   r->msg);
+  ZIP_FIELD_INT(headers, headersSize, headersDropped, "X-Size",
+                r->size); // size
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "Content-Type",
+                   r->contenttype); // contenttype
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "X-Charset",
+                   r->charset); // contenttype
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "Last-Modified",
+                   r->lastmodified); // last-modified
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "Etag",
+                   r->etag); // Etag
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "Location",
+                   r->location); // 'location' pour moved
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "Content-Disposition",
+                   r->cdispo); // Content-disposition
+  /* X-Save first of the three: it is the only one the reader consumes, so it
+     must not be what a full block drops */
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "X-Save",
+                   url_save_suffix); // Original save filename
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "X-Addr",
+                   url_adr); // Original address
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "X-Fil",
+                   url_fil); // Original URI filename
+  if (headersDropped != 0) {
+    hts_log_print(opt, LOG_WARNING,
+                  "cached headers too large, %d field(s) dropped: %s%s",
+                  headersDropped, url_adr, url_fil);
+  }
 
   /* Filename */
   if (!link_has_authority(url_adr)) {

--- a/src/htscache.h
+++ b/src/htscache.h
@@ -99,6 +99,10 @@ typedef enum {
    the involved files are absent. */
 void hts_cache_reconcile(httrackp *opt, hts_cache_reconcile_mode mode);
 
+/* Capacity of the per-entry header block cache_add builds; the self-test
+   asserts the writer stays inside it, so both must move together. */
+#define CACHE_HEADERS_SIZE 8192
+
 void cache_rstr(FILE *fp, char *s, size_t s_size);
 char *cache_rstr_addr(FILE * fp);
 int cache_brstr(char *adr, char *s, size_t s_size);

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -1642,9 +1642,9 @@ int cache_corruption_selftest(httrackp *opt, const char *dir) {
   return failures;
 }
 
-/* Header block of the ZIP's first entry (stored in its local extra field), or
-   -1. Located by position, not by name: unzLocateFile compares through a
-   256-byte buffer and cannot find the multi-KB entry name this test writes. */
+/* Header block of the ZIP's first entry, from its local extra field. By
+   position, not name: unzLocateFile compares through a 256-byte buffer and
+   cannot find the multi-KB entry name this test writes. */
 static int read_first_entry_extra(const char *path, char *extra,
                                   size_t extralen) {
   unzFile z = unzOpen(path);
@@ -1663,21 +1663,24 @@ static int read_first_entry_extra(const char *path, char *extra,
   return elen;
 }
 
-/* Fill s (capacity size) with `len` copies of c. */
 static void fill_str(char *s, size_t size, size_t len, char c) {
   assertf(len < size);
   memset(s, c, len);
   s[len] = '\0';
 }
 
-/* A value read back must be a prefix of what was written: the reader clips a
-   line to its parse buffer, but never splices or reorders bytes. */
-static int check_prefix(const char *what, const char *got, const char *want) {
-  if (got[0] == '\0' || strncmp(got, want, strlen(got)) != 0) {
+/* A value read back must be a prefix of what was written, and no shorter than
+   `least`: the reader clips a line to its parse buffer, but never splices,
+   reorders, or drops more than that. */
+static int check_prefix(const char *what, const char *got, const char *want,
+                        size_t least) {
+  const size_t len = strlen(got);
+
+  if (len < least || strncmp(got, want, len) != 0) {
     fprintf(stderr,
-            "cache-hdrbounds: %s reads back '%.32s...' (%d bytes), not a "
-            "prefix of the %d bytes written\n",
-            what, got, (int) strlen(got), (int) strlen(want));
+            "cache-hdrbounds: %s reads back '%.32s...' (%d bytes), expected a "
+            "prefix of the %d written, at least %d long\n",
+            what, got, (int) len, (int) strlen(want), (int) least);
     return 1;
   }
   return 0;
@@ -1689,14 +1692,12 @@ int cache_header_bounds_selftest(httrackp *opt, const char *dir) {
   /* every htsblk field at the cap its declaration allows */
   static char msg[80], ctype[HTS_MIMETYPE_SIZE], charset[HTS_MIMETYPE_SIZE];
   static char etag[256], cdispo[256], location[HTS_URLMAXSIZE * 2];
-  /* the overflow case: url_adr and url_fil are lien_back-sized, and with a
-     lien_back-sized save name the three of them alone reach 6 KB, past the
-     8 KB header block the writer builds them in */
+  /* url_adr/url_fil/save are all lien_back-sized, so the three alone reach
+     6 KB, past the header block the writer builds them in */
   static char big_adr[HTS_URLMAXSIZE * 2], big_fil[HTS_URLMAXSIZE * 2];
   static char big_save[HTS_URLMAXSIZE * 2];
-  /* the control: same maxed fields, but a URL the read path can look up (its
-     lookup buffer holds adr+fil in HTS_URLMAXSIZE*2), so nothing is dropped
-     and the round-trip must be exact */
+  /* the control: same maxed fields, but a URL short enough for the read path's
+     lookup buffer, so nothing is dropped and the round-trip must be exact */
   static char ok_fil[HTS_URLMAXSIZE];
   const char *const ok_adr = "example.com";
   const char *const ok_save = "example.com/big.html";
@@ -1741,12 +1742,11 @@ int cache_header_bounds_selftest(httrackp *opt, const char *dir) {
 
   /* The overflowing entry is never read back through cache_readex: adr+fil
      outgrows the read path's own lookup buffer. Read its header block straight
-     out of the ZIP instead and assert the writer kept it inside its buffer --
-     a platform whose runtime does not trap the overrun would otherwise store
-     the over-long block and still pass. */
+     out of the ZIP instead: a runtime that does not trap the overrun would
+     otherwise store the over-long block and still pass. */
   {
     char zippath[HTS_URLMAXSIZE];
-    static char extra[16384];
+    static char extra[CACHE_HEADERS_SIZE * 4];
     size_t elen;
 
     slprintfbuff_clip(zippath, sizeof(zippath), "%shts-cache/new.zip",
@@ -1754,15 +1754,43 @@ int cache_header_bounds_selftest(httrackp *opt, const char *dir) {
     if (read_first_entry_extra(zippath, extra, sizeof(extra)) < 0) {
       fprintf(stderr, "cache-hdrbounds: maxed entry missing from the ZIP\n");
       failures++;
-    } else if ((elen = strlen(extra)) >= 8192) {
+    } else if (strstr(extra, cdispo) == NULL) {
+      /* an early-out writer would leave the control entry first, and every
+         check below would then pass on the wrong block */
       fprintf(stderr,
-              "cache-hdrbounds: header block is %d bytes, past the writer's "
-              "8192-byte buffer\n",
-              (int) elen);
+              "cache-hdrbounds: first ZIP entry is not the maxed one\n");
       failures++;
-    } else if (elen < 2 || strcmp(extra + elen - 2, "\r\n") != 0) {
-      fprintf(stderr, "cache-hdrbounds: header block ends mid-line\n");
-      failures++;
+    } else {
+      elen = strlen(extra);
+      if (elen >= CACHE_HEADERS_SIZE) {
+        fprintf(stderr,
+                "cache-hdrbounds: header block is %d bytes, past the writer's "
+                "%d-byte buffer\n",
+                (int) elen, (int) CACHE_HEADERS_SIZE);
+        failures++;
+      }
+      if (elen < 2 || strcmp(extra + elen - 2, "\r\n") != 0) {
+        fprintf(stderr, "cache-hdrbounds: header block ends mid-line\n");
+        failures++;
+      }
+      /* X-Fil is written last, so its absence is how we know the block
+         filled. Still present means this entry no longer reaches the bound --
+         url_adr/url_fil cannot grow (cache_add's filename buffer caps them),
+         so the case would need rebuilding, not silently weakening. */
+      if (strstr(extra, "X-Fil: ") != NULL) {
+        fprintf(stderr,
+                "cache-hdrbounds: the maxed entry no longer fills the %d-byte "
+                "block (%d bytes); this case has stopped testing the bound\n",
+                (int) CACHE_HEADERS_SIZE, (int) elen);
+        failures++;
+      }
+      /* X-Save is the only one of the three a reader acts on, so a full block
+         must not be what drops it */
+      if (strstr(extra, "X-Save: ") == NULL) {
+        fprintf(stderr, "cache-hdrbounds: X-Save was dropped from a full "
+                        "block; it must be written before X-Addr/X-Fil\n");
+        failures++;
+      }
     }
   }
 
@@ -1787,8 +1815,9 @@ int cache_header_bounds_selftest(httrackp *opt, const char *dir) {
       fprintf(stderr, "cache-hdrbounds: a maxed field did not round-trip\n");
       failures++;
     }
-    /* clipped to the reader's line buffer, but still a prefix */
-    failures += check_prefix("location", locbuf, location);
+    /* the reader clips this to its line buffer (1014 of the 2047 bytes at the
+       current HTS_URLMAXSIZE); the floor only has to rule out a real loss */
+    failures += check_prefix("location", locbuf, location, 1000);
     if (r.adr == NULL || r.size != (LLint) strlen(body) ||
         memcmp(r.adr, body, strlen(body)) != 0) {
       fprintf(stderr, "cache-hdrbounds: body did not round-trip\n");

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -1641,3 +1641,165 @@ int cache_corruption_selftest(httrackp *opt, const char *dir) {
 
   return failures;
 }
+
+/* Header block of the ZIP's first entry (stored in its local extra field), or
+   -1. Located by position, not by name: unzLocateFile compares through a
+   256-byte buffer and cannot find the multi-KB entry name this test writes. */
+static int read_first_entry_extra(const char *path, char *extra,
+                                  size_t extralen) {
+  unzFile z = unzOpen(path);
+  int elen = -1;
+
+  if (z == NULL)
+    return -1;
+  if (unzGoToFirstFile(z) == UNZ_OK && unzOpenCurrentFile(z) == UNZ_OK) {
+    elen = unzGetLocalExtrafield(z, extra, (unsigned) (extralen - 1));
+    if (elen >= 0) {
+      extra[elen] = '\0';
+    }
+    unzCloseCurrentFile(z);
+  }
+  unzClose(z);
+  return elen;
+}
+
+/* Fill s (capacity size) with `len` copies of c. */
+static void fill_str(char *s, size_t size, size_t len, char c) {
+  assertf(len < size);
+  memset(s, c, len);
+  s[len] = '\0';
+}
+
+/* A value read back must be a prefix of what was written: the reader clips a
+   line to its parse buffer, but never splices or reorders bytes. */
+static int check_prefix(const char *what, const char *got, const char *want) {
+  if (got[0] == '\0' || strncmp(got, want, strlen(got)) != 0) {
+    fprintf(stderr,
+            "cache-hdrbounds: %s reads back '%.32s...' (%d bytes), not a "
+            "prefix of the %d bytes written\n",
+            what, got, (int) strlen(got), (int) strlen(want));
+    return 1;
+  }
+  return 0;
+}
+
+int cache_header_bounds_selftest(httrackp *opt, const char *dir) {
+  int failures = 0;
+  cache_back cache;
+  /* every htsblk field at the cap its declaration allows */
+  static char msg[80], ctype[HTS_MIMETYPE_SIZE], charset[HTS_MIMETYPE_SIZE];
+  static char etag[256], cdispo[256], location[HTS_URLMAXSIZE * 2];
+  /* the overflow case: url_adr and url_fil are lien_back-sized, and with a
+     lien_back-sized save name the three of them alone reach 6 KB, past the
+     8 KB header block the writer builds them in */
+  static char big_adr[HTS_URLMAXSIZE * 2], big_fil[HTS_URLMAXSIZE * 2];
+  static char big_save[HTS_URLMAXSIZE * 2];
+  /* the control: same maxed fields, but a URL the read path can look up (its
+     lookup buffer holds adr+fil in HTS_URLMAXSIZE*2), so nothing is dropped
+     and the round-trip must be exact */
+  static char ok_fil[HTS_URLMAXSIZE];
+  const char *const ok_adr = "example.com";
+  const char *const ok_save = "example.com/big.html";
+  const char *const body = "<html><body>maxed</body></html>";
+
+  fill_str(msg, sizeof(msg), sizeof(msg) - 1, 'M');
+  fill_str(ctype, sizeof(ctype), sizeof(ctype) - 1, 'C');
+  fill_str(charset, sizeof(charset), sizeof(charset) - 1, 'H');
+  fill_str(etag, sizeof(etag), sizeof(etag) - 1, 'E');
+  fill_str(cdispo, sizeof(cdispo), sizeof(cdispo) - 1, 'D');
+  fill_str(location, sizeof(location), sizeof(location) - 1, 'L');
+  /* 2040+2047: the largest pair cache_add's own "http://"+adr+fil filename
+     buffer (HTS_URLMAXSIZE*4) accepts, so the header block is what gives */
+  fill_str(big_adr, sizeof(big_adr), 2040, 'a');
+  big_fil[0] = '/';
+  fill_str(big_fil + 1, sizeof(big_fil) - 1, 2046, 'f');
+  fill_str(big_save, sizeof(big_save), sizeof(big_save) - 1, 'S');
+  ok_fil[0] = '/';
+  fill_str(ok_fil + 1, sizeof(ok_fil) - 1, sizeof(ok_fil) - 2, 'k');
+
+  {
+    char base[HTS_URLMAXSIZE];
+
+    strcpybuff(base, dir);
+    if (base[0] != '\0' && hts_lastchar(base) != '/') {
+      strcatbuff(base, "/");
+    }
+    StringCopy(opt->path_log, base);
+    StringCopy(opt->path_html, base);
+    StringCopy(opt->path_html_utf8, base);
+  }
+  opt->cache = HTS_CACHE_PRIORITY;
+
+  selftest_open_for_write(&cache, opt);
+  store_entry(opt, &cache, big_adr, big_fil, big_save, 200, msg, ctype, charset,
+              "Mon, 01 Jan 2024 00:00:00 GMT", etag, location, cdispo, body,
+              strlen(body));
+  store_entry(opt, &cache, ok_adr, ok_fil, ok_save, 200, msg, ctype, charset,
+              "Mon, 01 Jan 2024 00:00:00 GMT", etag, location, cdispo, body,
+              strlen(body));
+  selftest_close(&cache);
+
+  /* The overflowing entry is never read back through cache_readex: adr+fil
+     outgrows the read path's own lookup buffer. Read its header block straight
+     out of the ZIP instead and assert the writer kept it inside its buffer --
+     a platform whose runtime does not trap the overrun would otherwise store
+     the over-long block and still pass. */
+  {
+    char zippath[HTS_URLMAXSIZE];
+    static char extra[16384];
+    size_t elen;
+
+    slprintfbuff_clip(zippath, sizeof(zippath), "%shts-cache/new.zip",
+                      StringBuff(opt->path_log));
+    if (read_first_entry_extra(zippath, extra, sizeof(extra)) < 0) {
+      fprintf(stderr, "cache-hdrbounds: maxed entry missing from the ZIP\n");
+      failures++;
+    } else if ((elen = strlen(extra)) >= 8192) {
+      fprintf(stderr,
+              "cache-hdrbounds: header block is %d bytes, past the writer's "
+              "8192-byte buffer\n",
+              (int) elen);
+      failures++;
+    } else if (elen < 2 || strcmp(extra + elen - 2, "\r\n") != 0) {
+      fprintf(stderr, "cache-hdrbounds: header block ends mid-line\n");
+      failures++;
+    }
+  }
+
+  selftest_open_for_read(&cache, opt);
+  {
+    char *locbuf = malloct(HTS_URLMAXSIZE * 2);
+    htsblk r;
+
+    locbuf[0] = '\0';
+    r = cache_readex(opt, &cache, ok_adr, ok_fil, "", locbuf, NULL, 1);
+    if (r.statuscode != 200) {
+      fprintf(stderr,
+              "cache-hdrbounds: entry after the overflowing one reads "
+              "statuscode %d, expected 200\n",
+              r.statuscode);
+      failures++;
+    }
+    /* a header block that fits loses nothing */
+    if (strcmp(r.msg, msg) != 0 || strcmp(r.contenttype, ctype) != 0 ||
+        strcmp(r.charset, charset) != 0 || strcmp(r.etag, etag) != 0 ||
+        strcmp(r.cdispo, cdispo) != 0) {
+      fprintf(stderr, "cache-hdrbounds: a maxed field did not round-trip\n");
+      failures++;
+    }
+    /* clipped to the reader's line buffer, but still a prefix */
+    failures += check_prefix("location", locbuf, location);
+    if (r.adr == NULL || r.size != (LLint) strlen(body) ||
+        memcmp(r.adr, body, strlen(body)) != 0) {
+      fprintf(stderr, "cache-hdrbounds: body did not round-trip\n");
+      failures++;
+    }
+    if (r.adr != NULL) {
+      freet(r.adr);
+    }
+    freet(locbuf);
+  }
+  selftest_close(&cache);
+
+  return failures;
+}

--- a/src/htscache_selftest.h
+++ b/src/htscache_selftest.h
@@ -64,6 +64,13 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir);
    Returns the number of failed checks (0 = pass). */
 int cache_legacy_refused_selftest(httrackp *opt, const char *dir);
 
+/* A cache entry whose every field sits at its declared cap: the header block
+   the writer builds outgrows its fixed buffer, so this pins that the writer
+   bounds it, drops whole fields rather than halves, and still round-trips
+   everything written before the block filled. Returns the failed-check count.
+ */
+int cache_header_bounds_selftest(httrackp *opt, const char *dir);
+
 /* Inject read-side corruption (zip byte surgery: bad size, header, deflate)
    under <dir> and assert every case degrades to STATUSCODE_INVALID without
    tainting a sibling entry. */

--- a/src/htssafe.h
+++ b/src/htssafe.h
@@ -515,6 +515,31 @@ static HTS_INLINE HTS_UNUSED HTS_CHECK_RESULT HTS_PRINTF_FUN(3, 4) hts_boolean
 }
 
 /**
+ * Append formatted text at dest[*used] (dest capacity size, NUL included),
+ * advancing *used past it. All-or-nothing: when the whole output does not fit,
+ * dest is left exactly as it was and HTS_FALSE is returned. Suits a record
+ * parsed back field by field, where a half-written field reads as a valid
+ * shorter value.
+ */
+static HTS_INLINE HTS_UNUSED HTS_CHECK_RESULT HTS_PRINTF_FUN(4, 5) hts_boolean
+    slcatprintfbuff(char *dest, size_t size, size_t *used, const char *fmt,
+                    ...) {
+  va_list args;
+  hts_boolean fit;
+
+  assertf(dest != NULL && used != NULL && *used < size);
+  va_start(args, fmt);
+  fit = vslprintfbuff(dest + *used, size - *used, fmt, args);
+  va_end(args);
+  if (fit) {
+    *used += strlen(dest + *used);
+  } else {
+    dest[*used] = '\0';
+  }
+  return fit;
+}
+
+/**
  * slprintfbuff() for diagnostics quoting remote or client text, which are
  * meant to be clipped: nothing to act on, hence not HTS_CHECK_RESULT. A (void)
  * cast on slprintfbuff() is no substitute, GCC warns through it.

--- a/src/htssafe.h
+++ b/src/htssafe.h
@@ -516,10 +516,9 @@ static HTS_INLINE HTS_UNUSED HTS_CHECK_RESULT HTS_PRINTF_FUN(3, 4) hts_boolean
 
 /**
  * Append formatted text at dest[*used] (dest capacity size, NUL included),
- * advancing *used past it. All-or-nothing: when the whole output does not fit,
- * dest is left exactly as it was and HTS_FALSE is returned. Suits a record
- * parsed back field by field, where a half-written field reads as a valid
- * shorter value.
+ * advancing *used past it. All-or-nothing: on overflow dest is left as it was
+ * and HTS_FALSE returned, so a record parsed back field by field never carries
+ * a half-written one.
  */
 static HTS_INLINE HTS_UNUSED HTS_CHECK_RESULT HTS_PRINTF_FUN(4, 5) hts_boolean
     slcatprintfbuff(char *dest, size_t size, size_t *used, const char *fmt,

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2863,6 +2863,18 @@ static int st_cache_writefail(httrackp *opt, int argc, char **argv) {
   return err;
 }
 
+static int st_cache_hdrbounds(httrackp *opt, int argc, char **argv) {
+  int err;
+
+  if (argc < 1) {
+    fprintf(stderr, "cache-hdrbounds: needs a directory\n");
+    return 1;
+  }
+  err = cache_header_bounds_selftest(opt, argv[0]);
+  printf("cache-hdrbounds: %s\n", err ? "FAIL" : "OK");
+  return err;
+}
+
 static int st_cache_corrupt(httrackp *opt, int argc, char **argv) {
   int err;
 
@@ -7896,6 +7908,9 @@ static const struct selftest_entry {
      st_cache_legacy},
     {"cache-corrupt", "<dir>", "cache read-side corruption self-test",
      st_cache_corrupt},
+    {"cache-hdrbounds", "<dir>",
+     "cache header block must stay bounded at max-length fields",
+     st_cache_hdrbounds},
     {"zip-repair-shift", "<dir>",
      "cache zip-repair header read must not overflow a signed shift",
      st_zip_repair_shift},

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -854,11 +854,9 @@ static PT_Element PT_ReadCache__New(PT_Index index, const char *url, int flags) 
 /* New HTTrack cache (new.zip) format                           */
 /* ------------------------------------------------------------ */
 
-/* Append "<field>: <value>\r\n" to the header block, counting into `dropped`
-   the fields that did not fit. The values come back off a cache, so the block
-   is bounded rather than trusted to the element caps; the field is dropped
-   whole because a clipped one reads back as a valid shorter value.
-   `headers` must be an array, for sizeof. */
+/* Values read back off a cache, so the block is bounded rather than trusted to
+   the element caps; a field that does not fit is dropped whole and counted,
+   since a clipped one reads back as valid. `headers` must be an array. */
 #define ZIP_FIELD_STRING(headers, headersSize, dropped, field, value)          \
   do {                                                                         \
     if ((value) != NULL && (value)[0] != '\0' &&                               \

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -854,22 +854,34 @@ static PT_Element PT_ReadCache__New(PT_Index index, const char *url, int flags) 
 /* New HTTrack cache (new.zip) format                           */
 /* ------------------------------------------------------------ */
 
-#define ZIP_FIELD_STRING(headers, headersSize, field, value) do { \
-  if ( (value != NULL) && (value)[0] != '\0') { \
-    sprintf(headers + headersSize, "%s: %s\r\n", field, (value != NULL) ? (value) : ""); \
-    (headersSize) += (int) strlen(headers + headersSize); \
-  } \
-} while(0)
-#define ZIP_FIELD_INT(headers, headersSize, field, value) do { \
-  if ( (value != 0) ) { \
-    sprintf(headers + headersSize, "%s: "LLintP"\r\n", field, (LLint)(value)); \
-    (headersSize) += (int) strlen(headers + headersSize); \
-  } \
-} while(0)
-#define ZIP_FIELD_INT_FORCE(headers, headersSize, field, value) do { \
-  sprintf(headers + headersSize, "%s: "LLintP"\r\n", field, (LLint)(value)); \
-  (headersSize) += (int) strlen(headers + headersSize); \
-} while(0)
+/* Append "<field>: <value>\r\n" to the header block, counting into `dropped`
+   the fields that did not fit. The values come back off a cache, so the block
+   is bounded rather than trusted to the element caps; the field is dropped
+   whole because a clipped one reads back as a valid shorter value.
+   `headers` must be an array, for sizeof. */
+#define ZIP_FIELD_STRING(headers, headersSize, dropped, field, value)          \
+  do {                                                                         \
+    if ((value) != NULL && (value)[0] != '\0' &&                               \
+        !slcatprintfbuff(headers, sizeof(headers), &(headersSize),             \
+                         "%s: %s\r\n", field, value)) {                        \
+      (dropped)++;                                                             \
+    }                                                                          \
+  } while (0)
+#define ZIP_FIELD_INT(headers, headersSize, dropped, field, value)             \
+  do {                                                                         \
+    if ((value) != 0 &&                                                        \
+        !slcatprintfbuff(headers, sizeof(headers), &(headersSize),             \
+                         "%s: " LLintP "\r\n", field, (LLint) (value))) {      \
+      (dropped)++;                                                             \
+    }                                                                          \
+  } while (0)
+#define ZIP_FIELD_INT_FORCE(headers, headersSize, dropped, field, value)       \
+  do {                                                                         \
+    if (!slcatprintfbuff(headers, sizeof(headers), &(headersSize),             \
+                         "%s: " LLintP "\r\n", field, (LLint) (value))) {      \
+      (dropped)++;                                                             \
+    }                                                                          \
+  } while (0)
 /* refvalue_size is mandatory: the cache line is bounded only by the line
    buffer, not by the destination. */
 #define ZIP_READFIELD_STRING(line, value, refline, refvalue, refvalue_size)    \
@@ -1272,18 +1284,15 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
 static int PT_SaveCache__New_Fun(void *arg, const char *url, PT_Element element) {
   zipFile zFileOut = (zipFile) arg;
   char headers[8192];
-  int headersSize;
+  size_t headersSize = 0;
+  int headersDropped = 0;
   zip_fileinfo fi;
   int zErr;
   const char *url_adr = "";
   const char *url_fil = "";
 
-  headers[0] = '\0';
-  headersSize = 0;
-
   /* Fields */
   headers[0] = '\0';
-  headersSize = 0;
   /* */
   {
     const char *message;
@@ -1294,25 +1303,43 @@ static int PT_SaveCache__New_Fun(void *arg, const char *url, PT_Element element)
       message = "(See X-StatusMessage)";
     }
     /* 64 characters MAX for first line */
-    sprintf(headers + headersSize, "HTTP/1.%c %d %s\r\n", '1',
-            element->statuscode, message);
+    if (!slcatprintfbuff(headers, sizeof(headers), &headersSize,
+                         "HTTP/1.%c %d %s\r\n", '1', element->statuscode,
+                         message)) {
+      headersDropped++;
+    }
   }
-  headersSize += (int) strlen(headers + headersSize);
 
   /* Second line MUST ALWAYS be X-In-Cache */
-  ZIP_FIELD_INT_FORCE(headers, headersSize, "X-In-Cache", 1);
-  ZIP_FIELD_INT(headers, headersSize, "X-StatusCode", element->statuscode);
-  ZIP_FIELD_STRING(headers, headersSize, "X-StatusMessage", element->msg);
-  ZIP_FIELD_INT(headers, headersSize, "X-Size", element->size); // size
-  ZIP_FIELD_STRING(headers, headersSize, "Content-Type", element->contenttype); // contenttype
-  ZIP_FIELD_STRING(headers, headersSize, "X-Charset", element->charset);        // contenttype
-  ZIP_FIELD_STRING(headers, headersSize, "Last-Modified", element->lastmodified);       // last-modified
-  ZIP_FIELD_STRING(headers, headersSize, "Etag", element->etag);        // Etag
-  ZIP_FIELD_STRING(headers, headersSize, "Location", element->location);        // 'location' pour moved
-  ZIP_FIELD_STRING(headers, headersSize, "Content-Disposition", element->cdispo);       // Content-disposition
-  ZIP_FIELD_STRING(headers, headersSize, "X-Addr", url_adr);    // Original address
-  ZIP_FIELD_STRING(headers, headersSize, "X-Fil", url_fil);     // Original URI filename
-  ZIP_FIELD_STRING(headers, headersSize, "X-Save", ""); // Original save filename
+  ZIP_FIELD_INT_FORCE(headers, headersSize, headersDropped, "X-In-Cache", 1);
+  ZIP_FIELD_INT(headers, headersSize, headersDropped, "X-StatusCode",
+                element->statuscode);
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "X-StatusMessage",
+                   element->msg);
+  ZIP_FIELD_INT(headers, headersSize, headersDropped, "X-Size",
+                element->size); // size
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "Content-Type",
+                   element->contenttype); // contenttype
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "X-Charset",
+                   element->charset); // contenttype
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "Last-Modified",
+                   element->lastmodified); // last-modified
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "Etag",
+                   element->etag); // Etag
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "Location",
+                   element->location); // 'location' pour moved
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "Content-Disposition",
+                   element->cdispo); // Content-disposition
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "X-Addr",
+                   url_adr); // Original address
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "X-Fil",
+                   url_fil); // Original URI filename
+  ZIP_FIELD_STRING(headers, headersSize, headersDropped, "X-Save",
+                   ""); // Original save filename
+  if (headersDropped != 0) {
+    fprintf(stderr, "Headers of %s: %d field(s) dropped" LF, url,
+            headersDropped);
+  }
 
   /* Time */
   memset(&fi, 0, sizeof(fi));

--- a/tests/160_zlib-cache-hdrbounds.test
+++ b/tests/160_zlib-cache-hdrbounds.test
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Cache header-block bounds (httrack -#test=cache-hdrbounds <dir>): an entry
+# whose fields all sit at their declared caps must not overrun the writer's
+# fixed header buffer, and must not cost the entries written after it.
+
+set -eu
+
+dir=$(mktemp -d)
+trap 'set +e; rm -rf "$dir"' EXIT
+
+# the maxed entry logs an expected "cached headers too large" warning; the
+# verdict is the last line
+out=$(httrack -#test=cache-hdrbounds "$dir" 2>/dev/null | tail -n1)
+
+test "$out" = "cache-hdrbounds: OK" || {
+    echo "expected 'cache-hdrbounds: OK', got: $out" >&2
+    exit 1
+}

--- a/tests/160_zlib-cache-hdrbounds.test
+++ b/tests/160_zlib-cache-hdrbounds.test
@@ -9,10 +9,16 @@ set -eu
 dir=$(mktemp -d)
 trap 'set +e; rm -rf "$dir"' EXIT
 
-# the maxed entry logs an expected "cached headers too large" warning; the
-# verdict is the last line
-out=$(httrack -#test=cache-hdrbounds "$dir" 2>/dev/null | tail -n1)
+# the maxed entry logs an expected "cached headers too large" warning; keep the
+# whole run so a post-verdict abort is not read as a pass
+httrack -#test=cache-hdrbounds "$dir" >"$dir/out" 2>/dev/null ||
+    {
+        echo "httrack exited $? running the self-test:" >&2
+        cat "$dir/out" >&2
+        exit 1
+    }
 
+out=$(tail -n1 "$dir/out")
 test "$out" = "cache-hdrbounds: OK" || {
     echo "expected 'cache-hdrbounds: OK', got: $out" >&2
     exit 1

--- a/tests/161_local-proxytrack-zip-headers.test
+++ b/tests/161_local-proxytrack-zip-headers.test
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# ProxyTrack's new.zip writer (proxytrack --convert out.zip): the header block
+# it builds per entry rides uncompressed in the entry's local extra field, so
+# grep sees it in the raw file. Every field the element carries must be there,
+# and the result must load back.
+
+set -eu
+
+dir=$(mktemp -d)
+trap 'set +e; rm -rf "$dir"' EXIT
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+# just under the PT_Element caps (etag[64], cdispo[256]) and the reader's
+# per-line parse buffer, so every value must survive whole
+etag=$(printf '%0.sE' $(seq 1 60))
+cdispo="attachment; filename=$(printf '%0.sD' $(seq 1 200))"
+loc="http://example.com/$(printf '%0.sL' $(seq 1 900))"
+
+BODY='<html>hi</html>'
+printf 'HTTP/1.0 301 Moved\r\nContent-type: text/html\r\nEtag: "%s"\r\nLocation: %s\r\nContent-Disposition: %s\r\nLast-modified: Fri, 18 Jul 2003 08:59:11 GMT\r\nContent-length: %d\r\n\r\n' \
+    "$etag" "$loc" "$cdispo" ${#BODY} >"$dir/hdr"
+printf '%s' "$BODY" >"$dir/body"
+alen=$(($(wc -c <"$dir/hdr") + ${#BODY}))
+
+{
+    printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc 9\n'
+    printf '2 0 test\n'
+    printf '\n\n'
+    printf 'http://example.com/p.html 0.0.0.0 20250101000000 text/html 301 - - 0 t.arc %d\n' "$alen"
+    cat "$dir/hdr" "$dir/body"
+} >"$dir/in.arc"
+
+proxytrack --convert "$dir/out.zip" "$dir/in.arc" >/dev/null 2>&1 ||
+    fail "proxytrack died converting to new.zip"
+test -s "$dir/out.zip" || fail "no new.zip was written"
+
+# a writer that bounded the block by dropping fields would still produce a
+# loadable zip, so name the wide ones explicitly
+for field in "X-In-Cache: 1" "X-StatusCode: 301" "Etag: \"$etag\"" \
+    "Location: $loc" "Content-Disposition: $cdispo"; do
+    grep -qaF -- "$field" "$dir/out.zip" ||
+        fail "header block lost '$(echo "$field" | cut -c1-24)...'"
+done
+
+proxytrack --convert "$dir/back.arc" "$dir/out.zip" >"$dir/log" 2>&1 ||
+    fail "proxytrack died reading its own new.zip"
+grep -q '(1 items added)' "$dir/log" ||
+    fail "the new.zip did not load back: $(cat "$dir/log")"
+grep -qF "$BODY" "$dir/back.arc" || fail "body did not survive the round trip"

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -227,3 +227,4 @@ TESTS += 152_engine-string-oom.test
 TESTS += 153_local-proxytrack-quiet.test
 TESTS += 154_local-proxytrack-arc-roundtrip.test
 TESTS += 160_zlib-cache-hdrbounds.test
+TESTS += 161_local-proxytrack-zip-headers.test

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -225,3 +225,4 @@ TESTS += 151_bash-shell-validate.test
 TESTS += 150_engine-strsprintf.test
 TESTS += 152_engine-string-oom.test
 TESTS += 153_local-proxytrack-quiet.test
+TESTS += 160_zlib-cache-hdrbounds.test

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -225,5 +225,5 @@ TESTS += 151_bash-shell-validate.test
 TESTS += 150_engine-strsprintf.test
 TESTS += 152_engine-string-oom.test
 TESTS += 153_local-proxytrack-quiet.test
-TESTS += 160_zlib-cache-hdrbounds.test
 TESTS += 154_local-proxytrack-arc-roundtrip.test
+TESTS += 160_zlib-cache-hdrbounds.test


### PR DESCRIPTION
`ZIP_FIELD_STRING` and its integer siblings built the cached-headers block with an unbounded `sprintf` into a fixed `char headers[8192]`, in the engine's `cache_add` and in ProxyTrack's `new.zip` writer alike. Every value in that block is remote-controlled (ETag, Location, Content-Disposition, the status message, the URL), and in `cache_add` the caps those fields are declared with add up past 8192, so the writer could run off its own stack buffer. Issue #841 reported the ProxyTrack half, where the element caps keep the total near 3.9 KB; the engine copy is the one that overflows. A self-test entry at the declared caps makes the old writer emit a 9272-byte block.

The fields now go through `slcatprintfbuff()`, a bounded append that is all-or-nothing: a field that does not fit is dropped whole rather than clipped, because a half-written `X-Save:` line reads back as a valid shorter path. `X-Save` also moves ahead of `X-Addr`/`X-Fil`, so a full block does not drop the one field a reader acts on; nothing parses the other two by name, though ProxyTrack passes unknown fields through into its ARC/WARC records. Two new tests cover it: `-#test=cache-hdrbounds` for the engine writer, and an `.arc` to `.zip` round trip for ProxyTrack's, which had no runtime coverage at all since every `--convert` in the suite writes `.arc`.

Closes #841
