### PR TITLE
The cache aborts the crawl on URLs it accepts

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -2071,11 +2071,13 @@ int back_add(struct_back *sback, httrackp *opt, cache_back *cache,
       int hash_pos_return = 0;
 
       if (cache->hashtable) {
-        char BIGSTK buff[HTS_URLMAXSIZE * 4];
+        char BIGSTK buff[CACHE_KEY_SIZE];
+        size_t used = 0;
 
-        strcpybuff(buff, adr);
-        strcatbuff(buff, fil);
-        hash_pos_return = coucal_read(cache->hashtable, buff, &hash_pos);
+        /* a key too long to be in the table is a miss, not a fatal error */
+        if (slcatprintfbuff(buff, sizeof(buff), &used, "%s%s", adr, fil)) {
+          hash_pos_return = coucal_read(cache->hashtable, buff, &hash_pos);
+        }
 
         // negative values when data is not in cache
         if (hash_pos_return < 0) {

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -212,25 +212,6 @@ static void cache_zip_write_failed(httrackp *opt, cache_back *cache,
   }
 }
 
-/* Append the cache key adr+fil to dst (already holding an optional scheme
-   prefix). All-or-nothing: a key that does not fit leaves dst untouched and
-   returns HTS_FALSE, because a clipped one is another URL's valid key. */
-static hts_boolean cache_key_cat(char *dst, size_t dstSize, const char *adr,
-                                 const char *fil) {
-  const size_t used = strlen(dst);
-  const size_t adrLen = strlen(adr);
-  const size_t filLen = strlen(fil);
-
-  /* untrusted alone on the left, the rest provably non-negative */
-  if (used >= dstSize || adrLen >= dstSize - used ||
-      filLen >= dstSize - used - adrLen) {
-    return HTS_FALSE;
-  }
-  memcpy(dst + used, adr, adrLen);
-  memcpy(dst + used + adrLen, fil, filLen + 1);
-  return HTS_TRUE;
-}
-
 /* Ajout d'un fichier en cache */
 void cache_add(httrackp * opt, cache_back * cache, const htsblk * r,
                const char *url_adr, const char *url_fil, const char *url_save,
@@ -356,17 +337,19 @@ void cache_add(httrackp * opt, cache_back * cache, const htsblk * r,
   }
 
   /* Filename */
-  if (!link_has_authority(url_adr)) {
-    strcpybuff(filename, "http://");
-  } else {
-    strcpybuff(filename, "");
-  }
-  /* the URL comes off the wire: drop the entry rather than abort the mirror */
-  if (!cache_key_cat(filename, sizeof(filename), url_adr, url_fil)) {
-    hts_log_print(opt, LOG_WARNING,
-                  "URL too long to be cached, entry not cached: %s%s", url_adr,
-                  url_fil);
-    return;
+  {
+    size_t used = 0;
+
+    /* the URL comes off the wire: drop the entry rather than abort the mirror,
+       and stop where the index load does so nothing written is unreadable */
+    if (!slcatprintfbuff(filename, sizeof(filename) - 2, &used, "%s%s%s",
+                         link_has_authority(url_adr) ? "" : "http://", url_adr,
+                         url_fil)) {
+      hts_log_print(opt, LOG_WARNING,
+                    "URL too long to be cached, entry not cached: %s%s",
+                    url_adr, url_fil);
+      return;
+    }
   }
 
   /* Time */
@@ -549,12 +532,15 @@ static htsblk cache_readex_new(httrackp * opt, cache_back * cache,
     r.location = location_default;
   }
   r.location[0] = '\0';
-  /* a key too long to be in the table is a miss, not a fatal error */
-  buff[0] = '\0';
-  if (!cache_key_cat(buff, sizeof(buff), adr, fil)) {
-    hash_pos_return = 0;
-  } else {
-    hash_pos_return = coucal_read(cache->hashtable, buff, &hash_pos);
+  {
+    size_t used = 0;
+
+    /* a key too long to be in the table is a miss, not a fatal error */
+    if (!slcatprintfbuff(buff, sizeof(buff), &used, "%s%s", adr, fil)) {
+      hash_pos_return = 0;
+    } else {
+      hash_pos_return = coucal_read(cache->hashtable, buff, &hash_pos);
+    }
   }
   /* avoid errors on data entries */
   if (adr[0] == '/' && adr[1] == '/' && adr[2] == '[') {

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -212,11 +212,30 @@ static void cache_zip_write_failed(httrackp *opt, cache_back *cache,
   }
 }
 
+/* Append the cache key adr+fil to dst (already holding an optional scheme
+   prefix). All-or-nothing: a key that does not fit leaves dst untouched and
+   returns HTS_FALSE, because a clipped one is another URL's valid key. */
+static hts_boolean cache_key_cat(char *dst, size_t dstSize, const char *adr,
+                                 const char *fil) {
+  const size_t used = strlen(dst);
+  const size_t adrLen = strlen(adr);
+  const size_t filLen = strlen(fil);
+
+  /* untrusted alone on the left, the rest provably non-negative */
+  if (used >= dstSize || adrLen >= dstSize - used ||
+      filLen >= dstSize - used - adrLen) {
+    return HTS_FALSE;
+  }
+  memcpy(dst + used, adr, adrLen);
+  memcpy(dst + used + adrLen, fil, filLen + 1);
+  return HTS_TRUE;
+}
+
 /* Ajout d'un fichier en cache */
 void cache_add(httrackp * opt, cache_back * cache, const htsblk * r,
                const char *url_adr, const char *url_fil, const char *url_save,
                int all_in_cache, const char *path_prefix) {
-  char BIGSTK filename[HTS_URLMAXSIZE * 4];
+  char BIGSTK filename[CACHE_ENTRYNAME_SIZE];
   char catbuff[CATBUFF_SIZE];
   int dataincache = 0;          // put data in cache ?
   char BIGSTK headers[CACHE_HEADERS_SIZE];
@@ -342,8 +361,13 @@ void cache_add(httrackp * opt, cache_back * cache, const htsblk * r,
   } else {
     strcpybuff(filename, "");
   }
-  strcatbuff(filename, url_adr);
-  strcatbuff(filename, url_fil);
+  /* the URL comes off the wire: drop the entry rather than abort the mirror */
+  if (!cache_key_cat(filename, sizeof(filename), url_adr, url_fil)) {
+    hts_log_print(opt, LOG_WARNING,
+                  "URL too long to be cached, entry not cached: %s%s", url_adr,
+                  url_fil);
+    return;
+  }
 
   /* Time */
   memset(&fi, 0, sizeof(fi));
@@ -506,7 +530,7 @@ static htsblk cache_readex_new(httrackp * opt, cache_back * cache,
                                const char *target_save, char *location,
                                char *return_save, int readonly) {
   char BIGSTK location_default[HTS_URLMAXSIZE * 2];
-  char BIGSTK buff[HTS_URLMAXSIZE * 2];
+  char BIGSTK buff[CACHE_KEY_SIZE];
   char BIGSTK previous_save[HTS_URLMAXSIZE * 2];
   char BIGSTK previous_save_[HTS_URLMAXSIZE * 2];
   char catbuff[CATBUFF_SIZE];
@@ -525,9 +549,13 @@ static htsblk cache_readex_new(httrackp * opt, cache_back * cache,
     r.location = location_default;
   }
   r.location[0] = '\0';
-  strcpybuff(buff, adr);
-  strcatbuff(buff, fil);
-  hash_pos_return = coucal_read(cache->hashtable, buff, &hash_pos);
+  /* a key too long to be in the table is a miss, not a fatal error */
+  buff[0] = '\0';
+  if (!cache_key_cat(buff, sizeof(buff), adr, fil)) {
+    hash_pos_return = 0;
+  } else {
+    hash_pos_return = coucal_read(cache->hashtable, buff, &hash_pos);
+  }
   /* avoid errors on data entries */
   if (adr[0] == '/' && adr[1] == '/' && adr[2] == '[') {
     hash_pos_return = 0;
@@ -1126,7 +1154,8 @@ void cache_init(cache_back * cache, httrackp * opt) {
         /* Ready directory entries */
         if ((zErr = unzGoToFirstFile((unzFile) cache->zipInput)) == Z_OK) {
           char comment[128];
-          char BIGSTK filename[HTS_URLMAXSIZE * 4];
+          char BIGSTK filename[CACHE_ENTRYNAME_SIZE];
+          unz_file_info zfi;
           int entries = 0;
 
           memset(comment, 0, sizeof(comment));  // for truncated reads
@@ -1135,13 +1164,17 @@ void cache_init(cache_back * cache, httrackp * opt) {
 
             filename[0] = '\0';
             comment[0] = '\0';
+            memset(&zfi, 0, sizeof(zfi));
             if (unzOpenCurrentFile((unzFile) cache->zipInput) == Z_OK) {
               if ((readSizeHeader =
-                   unzGetLocalExtrafield((unzFile) cache->zipInput, comment,
-                                         sizeof(comment) - 2)) > 0
-                  && unzGetCurrentFileInfo((unzFile) cache->zipInput, NULL,
-                                           filename, sizeof(filename) - 2, NULL,
-                                           0, NULL, 0) == Z_OK) {
+                       unzGetLocalExtrafield((unzFile) cache->zipInput, comment,
+                                             sizeof(comment) - 2)) > 0 &&
+                  unzGetCurrentFileInfo((unzFile) cache->zipInput, &zfi,
+                                        filename, sizeof(filename) - 2, NULL, 0,
+                                        NULL, 0) == Z_OK
+                  /* minizip leaves a name this long unterminated, and a clipped
+                     one would index as another URL's key */
+                  && zfi.size_filename < sizeof(filename) - 2) {
                 long int pos =
                   (long int) unzGetOffset((unzFile) cache->zipInput);
                 assertf(readSizeHeader < sizeof(comment));

--- a/src/htscache.h
+++ b/src/htscache.h
@@ -103,6 +103,12 @@ void hts_cache_reconcile(httrackp *opt, hts_cache_reconcile_mode mode);
    asserts the writer stays inside it, so both must move together. */
 #define CACHE_HEADERS_SIZE 8192
 
+/* Cache key: url_adr followed by url_fil, each lien_back-sized. Write, index
+   load and lookup must each hold one whole -- a clipped key aliases another. */
+#define CACHE_KEY_SIZE (HTS_URLMAXSIZE * 4)
+/* The ZIP entry name is the key behind a "http://" the index load strips. */
+#define CACHE_ENTRYNAME_SIZE (CACHE_KEY_SIZE + 8)
+
 void cache_rstr(FILE *fp, char *s, size_t s_size);
 char *cache_rstr_addr(FILE * fp);
 int cache_brstr(char *adr, char *s, size_t s_size);

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -1738,9 +1738,8 @@ int cache_header_bounds_selftest(httrackp *opt, const char *dir) {
               strlen(body));
   selftest_close(&cache);
 
-  /* Read the header block straight out of the ZIP rather than through
-     cache_readex: a runtime that does not trap the overrun would otherwise
-     store the over-long block and still pass. */
+  /* Read the header straight from the ZIP, not through cache_readex: a runtime
+     that does not trap the overrun would store the block and still pass. */
   {
     char zippath[HTS_URLMAXSIZE];
     static char extra[CACHE_HEADERS_SIZE * 4];
@@ -1770,10 +1769,9 @@ int cache_header_bounds_selftest(httrackp *opt, const char *dir) {
         fprintf(stderr, "cache-hdrbounds: header block ends mid-line\n");
         failures++;
       }
-      /* X-Fil is written last, so its absence is how we know the block
-         filled. Still present means this entry no longer reaches the bound --
-         url_adr/url_fil are already at their lien_back caps, so the case would
-         need rebuilding, not silently weakening. */
+      /* X-Fil is written last, so its absence proves the block filled; the URL
+         is already at its lien_back cap, so a surviving X-Fil means the case
+         needs rebuilding, not silently weakening. */
       if (strstr(extra, "X-Fil: ") != NULL) {
         fprintf(stderr,
                 "cache-hdrbounds: the maxed entry no longer fills the %d-byte "
@@ -1830,12 +1828,32 @@ int cache_header_bounds_selftest(httrackp *opt, const char *dir) {
   return failures;
 }
 
-/* Hand-write a cache ZIP whose first entry name is longer than the writer can
-   emit, followed by a sane one; minizip hands such a name back unterminated. */
+/* A URL the cache cannot hold must read as a miss, never abort. */
+static int expect_miss(httrackp *opt, cache_back *cache, const char *adr,
+                       const char *fil) {
+  htsblk r = cache_readex(opt, cache, adr, fil, "", NULL, NULL, 1);
+  int failures = 0;
+
+  if (r.statuscode != STATUSCODE_INVALID) {
+    fprintf(stderr,
+            "%s: an unstorable URL reads statuscode %d, expected a "
+            "miss\n",
+            selftest_tag, r.statuscode);
+    failures++;
+  }
+  if (r.adr != NULL) {
+    freet(r.adr);
+  }
+  return failures;
+}
+
+/* A cache ZIP whose first entry name is longer than the writer can emit,
+   followed by a sane one; minizip hands such a name back unterminated. */
 static int urlbounds_write_foreign_zip(const char *zippath, size_t namelen) {
   static const char hdr[] = "HTTP/1.1 200 OK\r\nX-In-Cache: 1\r\n"
                             "X-StatusCode: 200\r\nX-Size: 4\r\n"
-                            "Content-Type: text/html\r\n";
+                            "X-StatusMessage: OK\r\n"
+                            "Content-Type: text/html\r\nX-Charset: utf-8\r\n";
   static char longname[CACHE_ENTRYNAME_SIZE * 2];
   const char *const body = "okay";
   zip_fileinfo fi;
@@ -1861,29 +1879,6 @@ static int urlbounds_write_foreign_zip(const char *zippath, size_t namelen) {
   return err;
 }
 
-/* Read back through cache_readex; returns the failed-check count. */
-static int urlbounds_expect_body(httrackp *opt, cache_back *cache,
-                                 const char *what, const char *adr,
-                                 const char *fil, const char *body) {
-  int failures = 0;
-  htsblk r = cache_readex(opt, cache, adr, fil, "", NULL, NULL, 1);
-
-  if (r.statuscode != 200) {
-    fprintf(stderr, "cache-urlbounds: %s reads statuscode %d, expected 200\n",
-            what, r.statuscode);
-    failures++;
-  } else if (r.adr == NULL || r.size != (LLint) strlen(body) ||
-             memcmp(r.adr, body, strlen(body)) != 0) {
-    /* a key clipped anywhere on the path resolves to a neighbour's entry */
-    fprintf(stderr, "cache-urlbounds: %s read back the wrong body\n", what);
-    failures++;
-  }
-  if (r.adr != NULL) {
-    freet(r.adr);
-  }
-  return failures;
-}
-
 int cache_url_bounds_selftest(httrackp *opt, const char *dir) {
   int failures = 0;
   cache_back cache;
@@ -1891,14 +1886,20 @@ int cache_url_bounds_selftest(httrackp *opt, const char *dir) {
      byte: a key clipped anywhere on the path aliases the two together */
   static char big_adr[HTS_URLMAXSIZE * 2], big_fil[HTS_URLMAXSIZE * 2];
   static char twin_fil[HTS_URLMAXSIZE * 2];
-  /* past every buffer on the path: no lien_back holds this, but the cache API
-     takes plain pointers, and dropping the entry beats aborting the mirror */
+  /* past every buffer on the path: no lien_back holds these, but the cache API
+     takes plain pointers, and dropping the entry beats aborting the mirror.
+     One overshoots url_fil, the other url_adr, so a bound on one destination
+     only is not enough to pass */
   static char huge_fil[CACHE_ENTRYNAME_SIZE * 2];
+  static char huge_adr[CACHE_ENTRYNAME_SIZE * 2];
+  /* the key a writer that clipped huge_fil would have stored it under */
+  static char decoy_fil[HTS_URLMAXSIZE * 2];
   const char *const short_adr = "example.com";
   const char *const short_fil = "/after.html";
   const char *const big_body = "<html><body>maxed</body></html>";
   const char *const twin_body = "<html><body>twin</body></html>";
   const char *const short_body = "<html><body>after</body></html>";
+  const char *const decoy_body = "<html><body>decoy</body></html>";
   const char *const lm = "Mon, 01 Jan 2024 00:00:00 GMT";
 
   fill_str(big_adr, sizeof(big_adr), sizeof(big_adr) - 1, 'a');
@@ -1908,7 +1909,11 @@ int cache_url_bounds_selftest(httrackp *opt, const char *dir) {
   twin_fil[sizeof(twin_fil) - 2] = 'g';
   huge_fil[0] = '/';
   fill_str(huge_fil + 1, sizeof(huge_fil) - 1, sizeof(huge_fil) - 2, 'h');
+  fill_str(huge_adr, sizeof(huge_adr), sizeof(huge_adr) - 1, 'A');
+  decoy_fil[0] = '/';
+  fill_str(decoy_fil + 1, sizeof(decoy_fil) - 1, sizeof(decoy_fil) - 2, 'h');
 
+  selftest_tag = "cache-urlbounds";
   selftest_setup_dir(opt, dir);
 
   selftest_open_for_write(&cache, opt);
@@ -1917,8 +1922,15 @@ int cache_url_bounds_selftest(httrackp *opt, const char *dir) {
   store_entry(opt, &cache, big_adr, twin_fil, "example.com/twin.html", 200,
               "OK", "text/html", "utf-8", lm, "", "", "", twin_body,
               strlen(twin_body));
+  /* stored first, so a writer that clipped rather than dropped would overwrite
+     it under its own key */
+  store_entry(opt, &cache, big_adr, decoy_fil, "example.com/decoy.html", 200,
+              "OK", "text/html", "utf-8", lm, "", "", "", decoy_body,
+              strlen(decoy_body));
   store_entry(opt, &cache, big_adr, huge_fil, "example.com/huge.html", 200,
               "OK", "text/html", "utf-8", lm, "", "", "", "dropped", 7);
+  store_entry(opt, &cache, huge_adr, "/short.html", "example.com/wide.html",
+              200, "OK", "text/html", "utf-8", lm, "", "", "", "dropped", 7);
   /* written after the dropped one: the drop must cost nothing but itself */
   store_entry(opt, &cache, short_adr, short_fil, "example.com/after.html", 200,
               "OK", "text/html", "utf-8", lm, "", "", "", short_body,
@@ -1926,28 +1938,21 @@ int cache_url_bounds_selftest(httrackp *opt, const char *dir) {
   selftest_close(&cache);
 
   selftest_open_for_read(&cache, opt);
-  failures += urlbounds_expect_body(opt, &cache, "the maxed entry", big_adr,
-                                    big_fil, big_body);
-  failures += urlbounds_expect_body(opt, &cache, "its last-byte twin", big_adr,
-                                    twin_fil, twin_body);
-  failures += urlbounds_expect_body(opt, &cache,
-                                    "the entry after the dropped "
-                                    "one",
-                                    short_adr, short_fil, short_body);
-  {
-    htsblk r = cache_readex(opt, &cache, big_adr, huge_fil, "", NULL, NULL, 1);
-
-    if (r.statuscode != STATUSCODE_INVALID) {
-      fprintf(stderr,
-              "cache-urlbounds: an unstorable URL reads statuscode %d, "
-              "expected a miss\n",
-              r.statuscode);
-      failures++;
-    }
-    if (r.adr != NULL) {
-      freet(r.adr);
-    }
-  }
+  /* the twin differs from the maxed entry only in its last byte: a key clipped
+     anywhere on the path serves one for the other */
+  failures += check_entry(opt, &cache, big_adr, big_fil, 200, "OK", "text/html",
+                          "utf-8", lm, "", "", "", big_body, strlen(big_body));
+  failures +=
+      check_entry(opt, &cache, big_adr, twin_fil, 200, "OK", "text/html",
+                  "utf-8", lm, "", "", "", twin_body, strlen(twin_body));
+  failures +=
+      check_entry(opt, &cache, short_adr, short_fil, 200, "OK", "text/html",
+                  "utf-8", lm, "", "", "", short_body, strlen(short_body));
+  failures +=
+      check_entry(opt, &cache, big_adr, decoy_fil, 200, "OK", "text/html",
+                  "utf-8", lm, "", "", "", decoy_body, strlen(decoy_body));
+  failures += expect_miss(opt, &cache, big_adr, huge_fil);
+  failures += expect_miss(opt, &cache, huge_adr, "/short.html");
   selftest_close(&cache);
 
   /* An entry name past every buffer on the path must be skipped, not indexed
@@ -1967,25 +1972,10 @@ int cache_url_bounds_selftest(httrackp *opt, const char *dir) {
       fill_str(foreign_fil, sizeof(foreign_fil), CACHE_ENTRYNAME_SIZE - 2 - 7,
                'z');
       selftest_open_for_read(&cache, opt);
-      failures += urlbounds_expect_body(opt, &cache,
-                                        "the sane entry beside a "
-                                        "foreign one",
-                                        "example.com", "/sane.html", "okay");
-      {
-        htsblk r =
-            cache_readex(opt, &cache, "", foreign_fil, "", NULL, NULL, 1);
-
-        if (r.statuscode != STATUSCODE_INVALID) {
-          fprintf(stderr,
-                  "cache-urlbounds: an entry name the loader cannot hold was "
-                  "indexed anyway (statuscode %d)\n",
-                  r.statuscode);
-          failures++;
-        }
-        if (r.adr != NULL) {
-          freet(r.adr);
-        }
-      }
+      failures +=
+          check_entry(opt, &cache, "example.com", "/sane.html", 200, "OK",
+                      "text/html", "utf-8", "", "", "", "", "okay", 4);
+      failures += expect_miss(opt, &cache, "", foreign_fil);
       selftest_close(&cache);
     }
   }

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -921,7 +921,7 @@ static const golden_entry golden_entries[] = {
 
 #define GOLDEN_COUNT (sizeof(golden_entries) / sizeof(golden_entries[0]))
 
-static void golden_setup(httrackp *opt, const char *dir) {
+static void selftest_setup_dir(httrackp *opt, const char *dir) {
   char base[HTS_URLMAXSIZE];
 
   strcpybuff(base, dir);
@@ -940,7 +940,7 @@ int cache_golden_selftest(httrackp *opt, const char *dir, int regen) {
   cache_back cache;
 
   selftest_tag = "cache-golden";
-  golden_setup(opt, dir);
+  selftest_setup_dir(opt, dir);
 
   /* regen rewrites the fixture from the table; the test never passes it, so the
      read pass verifies bytes a previous build froze */
@@ -1025,7 +1025,7 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   /* around the interrupted-run thresholds (new < 32768, old > 65536) */
   static const LLint TINY = 1024, MID = 40000, SOLID = 131072;
 
-  golden_setup(opt, dir);
+  selftest_setup_dir(opt, dir);
 #ifdef _WIN32
   mkdir(reconcile_st_path(opt, "hts-cache"));
 #else
@@ -1174,7 +1174,7 @@ int cache_legacy_refused_selftest(httrackp *opt, const char *dir) {
   int variant;
 
   selftest_tag = "cache-legacy";
-  golden_setup(opt, dir);
+  selftest_setup_dir(opt, dir);
 #ifdef _WIN32
   mkdir(reconcile_st_path(opt, "hts-cache"));
 #else
@@ -1552,7 +1552,7 @@ int cache_corruption_selftest(httrackp *opt, const char *dir) {
   int failures = 0;
 
   selftest_tag = "cache-corrupt";
-  golden_setup(opt, dir);
+  selftest_setup_dir(opt, dir);
 
   failures +=
       corrupt_case_zip(opt, "X-Size: 44", "X-Size: 99", 1, 1,
@@ -1696,8 +1696,8 @@ int cache_header_bounds_selftest(httrackp *opt, const char *dir) {
      6 KB, past the header block the writer builds them in */
   static char big_adr[HTS_URLMAXSIZE * 2], big_fil[HTS_URLMAXSIZE * 2];
   static char big_save[HTS_URLMAXSIZE * 2];
-  /* the control: same maxed fields, but a URL short enough for the read path's
-     lookup buffer, so nothing is dropped and the round-trip must be exact */
+  /* the control: same maxed fields, but a URL short enough to leave the header
+     block room, so nothing is dropped and the round-trip must be exact */
   static char ok_fil[HTS_URLMAXSIZE];
   const char *const ok_adr = "example.com";
   const char *const ok_save = "example.com/big.html";
@@ -1709,9 +1709,7 @@ int cache_header_bounds_selftest(httrackp *opt, const char *dir) {
   fill_str(etag, sizeof(etag), sizeof(etag) - 1, 'E');
   fill_str(cdispo, sizeof(cdispo), sizeof(cdispo) - 1, 'D');
   fill_str(location, sizeof(location), sizeof(location) - 1, 'L');
-  /* 2040+2047: the largest pair cache_add's own "http://"+adr+fil filename
-     buffer (HTS_URLMAXSIZE*4) accepts, so the header block is what gives */
-  fill_str(big_adr, sizeof(big_adr), 2040, 'a');
+  fill_str(big_adr, sizeof(big_adr), sizeof(big_adr) - 1, 'a');
   big_fil[0] = '/';
   fill_str(big_fil + 1, sizeof(big_fil) - 1, 2046, 'f');
   fill_str(big_save, sizeof(big_save), sizeof(big_save) - 1, 'S');
@@ -1740,10 +1738,9 @@ int cache_header_bounds_selftest(httrackp *opt, const char *dir) {
               strlen(body));
   selftest_close(&cache);
 
-  /* The overflowing entry is never read back through cache_readex: adr+fil
-     outgrows the read path's own lookup buffer. Read its header block straight
-     out of the ZIP instead: a runtime that does not trap the overrun would
-     otherwise store the over-long block and still pass. */
+  /* Read the header block straight out of the ZIP rather than through
+     cache_readex: a runtime that does not trap the overrun would otherwise
+     store the over-long block and still pass. */
   {
     char zippath[HTS_URLMAXSIZE];
     static char extra[CACHE_HEADERS_SIZE * 4];
@@ -1775,8 +1772,8 @@ int cache_header_bounds_selftest(httrackp *opt, const char *dir) {
       }
       /* X-Fil is written last, so its absence is how we know the block
          filled. Still present means this entry no longer reaches the bound --
-         url_adr/url_fil cannot grow (cache_add's filename buffer caps them),
-         so the case would need rebuilding, not silently weakening. */
+         url_adr/url_fil are already at their lien_back caps, so the case would
+         need rebuilding, not silently weakening. */
       if (strstr(extra, "X-Fil: ") != NULL) {
         fprintf(stderr,
                 "cache-hdrbounds: the maxed entry no longer fills the %d-byte "
@@ -1829,6 +1826,169 @@ int cache_header_bounds_selftest(httrackp *opt, const char *dir) {
     freet(locbuf);
   }
   selftest_close(&cache);
+
+  return failures;
+}
+
+/* Hand-write a cache ZIP whose first entry name is longer than the writer can
+   emit, followed by a sane one; minizip hands such a name back unterminated. */
+static int urlbounds_write_foreign_zip(const char *zippath, size_t namelen) {
+  static const char hdr[] = "HTTP/1.1 200 OK\r\nX-In-Cache: 1\r\n"
+                            "X-StatusCode: 200\r\nX-Size: 4\r\n"
+                            "Content-Type: text/html\r\n";
+  static char longname[CACHE_ENTRYNAME_SIZE * 2];
+  const char *const body = "okay";
+  zip_fileinfo fi;
+  zipFile z = zipOpen(zippath, APPEND_STATUS_CREATE);
+  int err = 0;
+  int i;
+
+  if (z == NULL) {
+    return -1;
+  }
+  memset(&fi, 0, sizeof(fi));
+  fill_str(longname, sizeof(longname), namelen, 'z');
+  memcpy(longname, "http://", 7);
+  for (i = 0; i < 2; i++) {
+    const char *const name = i == 0 ? longname : "http://example.com/sane.html";
+
+    err |= zipOpenNewFileInZip(z, name, &fi, hdr, (uInt) strlen(hdr), NULL, 0,
+                               NULL, Z_DEFLATED, Z_DEFAULT_COMPRESSION);
+    err |= zipWriteInFileInZip(z, body, (int) strlen(body));
+    err |= zipCloseFileInZip(z);
+  }
+  err |= zipClose(z, NULL);
+  return err;
+}
+
+/* Read back through cache_readex; returns the failed-check count. */
+static int urlbounds_expect_body(httrackp *opt, cache_back *cache,
+                                 const char *what, const char *adr,
+                                 const char *fil, const char *body) {
+  int failures = 0;
+  htsblk r = cache_readex(opt, cache, adr, fil, "", NULL, NULL, 1);
+
+  if (r.statuscode != 200) {
+    fprintf(stderr, "cache-urlbounds: %s reads statuscode %d, expected 200\n",
+            what, r.statuscode);
+    failures++;
+  } else if (r.adr == NULL || r.size != (LLint) strlen(body) ||
+             memcmp(r.adr, body, strlen(body)) != 0) {
+    /* a key clipped anywhere on the path resolves to a neighbour's entry */
+    fprintf(stderr, "cache-urlbounds: %s read back the wrong body\n", what);
+    failures++;
+  }
+  if (r.adr != NULL) {
+    freet(r.adr);
+  }
+  return failures;
+}
+
+int cache_url_bounds_selftest(httrackp *opt, const char *dir) {
+  int failures = 0;
+  cache_back cache;
+  /* the largest pair lien_back can hold, and a twin differing only in its last
+     byte: a key clipped anywhere on the path aliases the two together */
+  static char big_adr[HTS_URLMAXSIZE * 2], big_fil[HTS_URLMAXSIZE * 2];
+  static char twin_fil[HTS_URLMAXSIZE * 2];
+  /* past every buffer on the path: no lien_back holds this, but the cache API
+     takes plain pointers, and dropping the entry beats aborting the mirror */
+  static char huge_fil[CACHE_ENTRYNAME_SIZE * 2];
+  const char *const short_adr = "example.com";
+  const char *const short_fil = "/after.html";
+  const char *const big_body = "<html><body>maxed</body></html>";
+  const char *const twin_body = "<html><body>twin</body></html>";
+  const char *const short_body = "<html><body>after</body></html>";
+  const char *const lm = "Mon, 01 Jan 2024 00:00:00 GMT";
+
+  fill_str(big_adr, sizeof(big_adr), sizeof(big_adr) - 1, 'a');
+  big_fil[0] = '/';
+  fill_str(big_fil + 1, sizeof(big_fil) - 1, sizeof(big_fil) - 2, 'f');
+  memcpy(twin_fil, big_fil, sizeof(twin_fil));
+  twin_fil[sizeof(twin_fil) - 2] = 'g';
+  huge_fil[0] = '/';
+  fill_str(huge_fil + 1, sizeof(huge_fil) - 1, sizeof(huge_fil) - 2, 'h');
+
+  selftest_setup_dir(opt, dir);
+
+  selftest_open_for_write(&cache, opt);
+  store_entry(opt, &cache, big_adr, big_fil, "example.com/big.html", 200, "OK",
+              "text/html", "utf-8", lm, "", "", "", big_body, strlen(big_body));
+  store_entry(opt, &cache, big_adr, twin_fil, "example.com/twin.html", 200,
+              "OK", "text/html", "utf-8", lm, "", "", "", twin_body,
+              strlen(twin_body));
+  store_entry(opt, &cache, big_adr, huge_fil, "example.com/huge.html", 200,
+              "OK", "text/html", "utf-8", lm, "", "", "", "dropped", 7);
+  /* written after the dropped one: the drop must cost nothing but itself */
+  store_entry(opt, &cache, short_adr, short_fil, "example.com/after.html", 200,
+              "OK", "text/html", "utf-8", lm, "", "", "", short_body,
+              strlen(short_body));
+  selftest_close(&cache);
+
+  selftest_open_for_read(&cache, opt);
+  failures += urlbounds_expect_body(opt, &cache, "the maxed entry", big_adr,
+                                    big_fil, big_body);
+  failures += urlbounds_expect_body(opt, &cache, "its last-byte twin", big_adr,
+                                    twin_fil, twin_body);
+  failures += urlbounds_expect_body(opt, &cache,
+                                    "the entry after the dropped "
+                                    "one",
+                                    short_adr, short_fil, short_body);
+  {
+    htsblk r = cache_readex(opt, &cache, big_adr, huge_fil, "", NULL, NULL, 1);
+
+    if (r.statuscode != STATUSCODE_INVALID) {
+      fprintf(stderr,
+              "cache-urlbounds: an unstorable URL reads statuscode %d, "
+              "expected a miss\n",
+              r.statuscode);
+      failures++;
+    }
+    if (r.adr != NULL) {
+      freet(r.adr);
+    }
+  }
+  selftest_close(&cache);
+
+  /* An entry name past every buffer on the path must be skipped, not indexed
+     from an unterminated read -- which only the sanitizer legs see. */
+  {
+    char zippath[HTS_URLMAXSIZE];
+    /* no pair of lien_back fields reaches this key, so look it up as one */
+    static char foreign_fil[CACHE_KEY_SIZE];
+
+    slprintfbuff_clip(zippath, sizeof(zippath), "%shts-cache/new.zip",
+                      StringBuff(opt->path_log));
+    if (urlbounds_write_foreign_zip(zippath, CACHE_ENTRYNAME_SIZE - 2) != 0) {
+      fprintf(stderr, "cache-urlbounds: could not write the foreign cache\n");
+      failures++;
+    } else {
+      /* the name the loader saw, minus the "http://" the index load strips */
+      fill_str(foreign_fil, sizeof(foreign_fil), CACHE_ENTRYNAME_SIZE - 2 - 7,
+               'z');
+      selftest_open_for_read(&cache, opt);
+      failures += urlbounds_expect_body(opt, &cache,
+                                        "the sane entry beside a "
+                                        "foreign one",
+                                        "example.com", "/sane.html", "okay");
+      {
+        htsblk r =
+            cache_readex(opt, &cache, "", foreign_fil, "", NULL, NULL, 1);
+
+        if (r.statuscode != STATUSCODE_INVALID) {
+          fprintf(stderr,
+                  "cache-urlbounds: an entry name the loader cannot hold was "
+                  "indexed anyway (statuscode %d)\n",
+                  r.statuscode);
+          failures++;
+        }
+        if (r.adr != NULL) {
+          freet(r.adr);
+        }
+      }
+      selftest_close(&cache);
+    }
+  }
 
   return failures;
 }

--- a/src/htscache_selftest.h
+++ b/src/htscache_selftest.h
@@ -71,9 +71,8 @@ int cache_legacy_refused_selftest(httrackp *opt, const char *dir);
  */
 int cache_header_bounds_selftest(httrackp *opt, const char *dir);
 
-/* URLs at (and past) the length the cache API accepts: storing and looking one
-   up must neither abort nor alias two keys together. Returns the failed-check
-   count. */
+/* URLs at (and past) the cache API's length cap: store and lookup must neither
+   abort nor alias two keys. Returns the failed-check count. */
 int cache_url_bounds_selftest(httrackp *opt, const char *dir);
 
 /* Inject read-side corruption (zip byte surgery: bad size, header, deflate)

--- a/src/htscache_selftest.h
+++ b/src/htscache_selftest.h
@@ -71,6 +71,11 @@ int cache_legacy_refused_selftest(httrackp *opt, const char *dir);
  */
 int cache_header_bounds_selftest(httrackp *opt, const char *dir);
 
+/* URLs at (and past) the length the cache API accepts: storing and looking one
+   up must neither abort nor alias two keys together. Returns the failed-check
+   count. */
+int cache_url_bounds_selftest(httrackp *opt, const char *dir);
+
 /* Inject read-side corruption (zip byte surgery: bad size, header, deflate)
    under <dir> and assert every case degrades to STATUSCODE_INVALID without
    tainting a sibling entry. */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2875,6 +2875,18 @@ static int st_cache_hdrbounds(httrackp *opt, int argc, char **argv) {
   return err;
 }
 
+static int st_cache_urlbounds(httrackp *opt, int argc, char **argv) {
+  int err;
+
+  if (argc < 1) {
+    fprintf(stderr, "cache-urlbounds: needs a directory\n");
+    return 1;
+  }
+  err = cache_url_bounds_selftest(opt, argv[0]);
+  printf("cache-urlbounds: %s\n", err ? "FAIL" : "OK");
+  return err;
+}
+
 static int st_cache_corrupt(httrackp *opt, int argc, char **argv) {
   int err;
 
@@ -7911,6 +7923,9 @@ static const struct selftest_entry {
     {"cache-hdrbounds", "<dir>",
      "cache header block must stay bounded at max-length fields",
      st_cache_hdrbounds},
+    {"cache-urlbounds", "<dir>",
+     "cache store and lookup at max-length URLs must not abort or alias",
+     st_cache_urlbounds},
     {"zip-repair-shift", "<dir>",
      "cache zip-repair header read must not overflow a signed shift",
      st_zip_repair_shift},

--- a/tests/162_zlib-cache-urlbounds.test
+++ b/tests/162_zlib-cache-urlbounds.test
@@ -1,25 +1,25 @@
 #!/bin/bash
 #
-# Cache URL bounds (httrack -#test=cache-urlbounds <dir>): a URL at the length
-# lien_back can hold must store and look up without aborting, two keys differing
-# only past a clip point must not alias, and a longer one must drop its entry
-# rather than take the mirror down.
+# Cache URL bounds (httrack -#test=cache-urlbounds <dir>): a max-length URL must
+# store and look up without aborting or aliasing a neighbouring key.
 
 set -eu
 
 dir=$(mktemp -d)
 trap 'set +e; rm -rf "$dir"' EXIT
 
-# the unstorable entry logs an expected "URL too long to be cached" warning
-httrack -#test=cache-urlbounds "$dir" >"$dir/out" 2>/dev/null ||
+# stderr carries the expected "URL too long to be cached" warnings alongside the
+# self-test's own diagnostics: keep it out of the verdict, but not the report
+httrack -#test=cache-urlbounds "$dir" >"$dir/out" 2>"$dir/err" ||
     {
         echo "httrack exited $? running the self-test:" >&2
-        cat "$dir/out" >&2
+        cat "$dir/out" "$dir/err" >&2
         exit 1
     }
 
 out=$(tail -n1 "$dir/out")
 test "$out" = "cache-urlbounds: OK" || {
     echo "expected 'cache-urlbounds: OK', got: $out" >&2
+    cat "$dir/err" >&2
     exit 1
 }

--- a/tests/162_zlib-cache-urlbounds.test
+++ b/tests/162_zlib-cache-urlbounds.test
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Cache URL bounds (httrack -#test=cache-urlbounds <dir>): a URL at the length
+# lien_back can hold must store and look up without aborting, two keys differing
+# only past a clip point must not alias, and a longer one must drop its entry
+# rather than take the mirror down.
+
+set -eu
+
+dir=$(mktemp -d)
+trap 'set +e; rm -rf "$dir"' EXIT
+
+# the unstorable entry logs an expected "URL too long to be cached" warning
+httrack -#test=cache-urlbounds "$dir" >"$dir/out" 2>/dev/null ||
+    {
+        echo "httrack exited $? running the self-test:" >&2
+        cat "$dir/out" >&2
+        exit 1
+    }
+
+out=$(tail -n1 "$dir/out")
+test "$out" = "cache-urlbounds: OK" || {
+    echo "expected 'cache-urlbounds: OK', got: $out" >&2
+    exit 1
+}

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -229,3 +229,4 @@ TESTS += 160_icon-theme.test
 TESTS += 154_local-proxytrack-arc-roundtrip.test
 TESTS += 160_zlib-cache-hdrbounds.test
 TESTS += 161_local-proxytrack-zip-headers.test
+TESTS += 162_zlib-cache-urlbounds.test


### PR DESCRIPTION
Four places built or consumed the cache key, each assuming a different maximum URL length. A URL long enough to fill a `lien_back` field is legal and reachable off the wire, so one of them aborted the crawl where it should have missed the cache, and the index load read entry names into a buffer minizip can fill without a terminator.

All four now size off one bound, and the key is built all-or-nothing with the existing `slcatprintfbuff`: too long to store drops the entry with a warning, too long to look up is a miss. Clipping is never right here, because a clipped key is a valid key for some other URL, and that is a cache hit on the wrong content. The new `cache-urlbounds` self-test (`tests/162`) stores at the cap and pins that neither a twin differing only in its last byte nor a decoy sitting on a clip point can be served in its place.

Closes #935
Closes #936