### PR TITLE
A wedged Windows suite takes the log that would name it

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -208,6 +208,15 @@ jobs:
           progress=suite-progress.log
           : >"$progress"
 
+          # Neither survives a job that dies with its runner (#795), so a watchdog
+          # reports through annotations, which do, and ends the step at 37 min if
+          # the deadline above never got its turn. Quiet below 12 min, since a
+          # healthy run takes 8-9; killing at 37 forfeits nothing, as the deadline
+          # gate already fails every suite still alive at 36.
+          ci_suite_heartbeat 720 360 "$progress" 2160 $$ &
+          heartbeat=$!
+          trap 'kill "$heartbeat" 2>/dev/null || true' EXIT
+
           pass=0 fail=0 skip=0 failed="" skipped="" deadline=0
           # Globbed, not enumerated: a new NNN_engine-*.test or NNN_local-*.test
           # is picked up automatically instead of silently getting zero coverage.

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -204,9 +204,11 @@ jobs:
           suite_deadline=1500
           started=$SECONDS
 
-          # Survives into the artifact even if the tail of the step log does not.
+          # Reaches the artifact whenever the step ends on its own terms, which the
+          # tail of its log may not. Absolute, since a .test may have chdir'd.
           progress=suite-progress.log
           : >"$progress"
+          export HTTRACK_PROGRESS_LOG="$PWD/$progress"
 
           # A dying runner takes both, and every annotation with them (measured, see
           # #795), so the watchdog's job is to end the step first: one that fails on

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -209,9 +209,10 @@ jobs:
           : >"$progress"
 
           # Neither survives a job that dies with its runner (#795), so a watchdog
-          # reports through annotations, which do. Quiet below 12 min because a
-          # healthy run takes 8-9; 900s without a progress line means $per_test
-          # never fired, and still leaves 4 min before the step timeout.
+          # reports through annotations, which do. Quiet past 12 min since a healthy
+          # run takes 8-9; a kill 900s after the last progress line clears the
+          # longest legitimate gap, one $per_test, and still lands inside the step's
+          # own timeout for anything the loop was able to start.
           ci_suite_heartbeat 720 360 "$progress" 900 $$ &
           heartbeat=$!
           trap 'kill "$heartbeat" 2>/dev/null || true' EXIT
@@ -253,6 +254,9 @@ jobs:
                 echo "FAIL $t (exit $rc)"
                 # These assert with `test "$(...)" == "..." || exit 1`, which
                 # says nothing at all on failure. Re-run traced, still bounded.
+                # Noted first, or a slow trace reads as a wedge to the watchdog,
+                # which would then kill the step in the middle of writing it.
+                echo "RERUN $t" >>"$progress"
                 run_with_timeout "$per_test" bash -x "$t" >>"$t.log" 2>&1 || true
                 tail -n 25 "$t.log" | sed 's/^/      /'
                 ;;

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -208,11 +208,11 @@ jobs:
           progress=suite-progress.log
           : >"$progress"
 
-          # Neither survives a job that dies with its runner (#795), so a watchdog
-          # reports through annotations, which do. Quiet past 12 min since a healthy
-          # run takes 8-9; a kill 900s after the last progress line clears the
-          # longest legitimate gap, one $per_test, and still lands inside the step's
-          # own timeout for anything the loop was able to start.
+          # A dying runner takes both, and every annotation with them (measured, see
+          # #795), so the watchdog's job is to end the step first: one that fails on
+          # its own terms keeps its log. Quiet past 12 min since a healthy run takes
+          # 8-9, and a kill 900s after the last progress line clears the longest
+          # legitimate gap, one $per_test.
           ci_suite_heartbeat 720 360 "$progress" 900 $$ &
           heartbeat=$!
           trap 'kill "$heartbeat" 2>/dev/null || true' EXIT

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -209,11 +209,10 @@ jobs:
           : >"$progress"
 
           # Neither survives a job that dies with its runner (#795), so a watchdog
-          # reports through annotations, which do, and ends the step at 37 min if
-          # the deadline above never got its turn. Quiet below 12 min, since a
-          # healthy run takes 8-9; killing at 37 forfeits nothing, as the deadline
-          # gate already fails every suite still alive at 36.
-          ci_suite_heartbeat 720 360 "$progress" 2160 $$ &
+          # reports through annotations, which do. Quiet below 12 min because a
+          # healthy run takes 8-9; 900s without a progress line means $per_test
+          # never fired, and still leaves 4 min before the step timeout.
+          ci_suite_heartbeat 720 360 "$progress" 900 $$ &
           heartbeat=$!
           trap 'kill "$heartbeat" 2>/dev/null || true' EXIT
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -212,10 +212,10 @@ jobs:
 
           # A dying runner takes both, and every annotation with them (measured, see
           # #795), so the watchdog's job is to end the step first: one that fails on
-          # its own terms keeps its log. Quiet past 12 min since a healthy run takes
-          # 8-9, and a kill 900s after the last progress line clears the longest
-          # legitimate gap, one $per_test.
-          ci_suite_heartbeat 720 360 "$progress" 900 $$ &
+          # its own terms keeps its log. Quiet past 16 min, clear of the 13 a healthy
+          # run measures here, and a kill 900s after the last progress line clears
+          # the longest legitimate gap, one $per_test.
+          ci_suite_heartbeat 960 360 "$progress" 900 $$ &
           heartbeat=$!
           trap 'kill "$heartbeat" 2>/dev/null || true' EXIT
 

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -39,8 +39,8 @@ HTTRACK_PROGRESS_LOG="$tmp/progress" HTTRACK_TEST_TIMEOUT=5 \
     bash "$driver" "$tmp/90_wedged.test" >"$out" 2>&1 || rc=$?
 elapsed=$((SECONDS - start))
 
-# Announced before the dump, which runs for minutes: a suite watchdog reading
-# that log would otherwise take the silence for a wedge and kill the step.
+# Announced when the dump starts, which runs for minutes: a suite watchdog
+# reading that log would take the silence for a wedge and kill the step.
 grep -qx 'DUMP 90_wedged.test' "$tmp/progress" ||
     fail "the dump was not announced: $(cat "$tmp/progress" 2>&1)"
 

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -35,8 +35,14 @@ EOF
 
 start=$SECONDS
 rc=0
-HTTRACK_TEST_TIMEOUT=5 bash "$driver" "$tmp/90_wedged.test" >"$out" 2>&1 || rc=$?
+HTTRACK_PROGRESS_LOG="$tmp/progress" HTTRACK_TEST_TIMEOUT=5 \
+    bash "$driver" "$tmp/90_wedged.test" >"$out" 2>&1 || rc=$?
 elapsed=$((SECONDS - start))
+
+# Announced before the dump, which runs for minutes: a suite watchdog reading
+# that log would otherwise take the silence for a wedge and kill the step.
+grep -qx 'DUMP 90_wedged.test' "$tmp/progress" ||
+    fail "the dump was not announced: $(cat "$tmp/progress" 2>&1)"
 
 test "$rc" -eq 124 || fail "wedged test reported $rc, want 124"
 # Never before the budget, or a slow-but-healthy test would be killed too.

--- a/tests/171_watchdog-heartbeat.test
+++ b/tests/171_watchdog-heartbeat.test
@@ -3,7 +3,8 @@
 # Unit-tests ci_suite_heartbeat (testlib.sh) on a virtual clock, at the values the
 # Windows workflow really passes: scaled-down timings collapse the sleep
 # granularity, the annotation cadence and the staticness window onto one number,
-# and a watchdog that confuses those kills healthy runs (#795).
+# and a watchdog that confuses those kills healthy runs (#795). The kill is timed
+# by the stub, never by the annotation, which the code under test writes itself.
 
 set -euo pipefail
 
@@ -19,63 +20,81 @@ fail() {
 }
 
 progress="$tmp/progress"
-kill_tree() { echo "KILL $1"; }
+kill_tree() { echo "KILL $1 at $(hb_now)"; }
+# Twelve lines, against a bound of eight.
 list_stray_processes() {
     printf '%s\n' "$*" >"$tmp/strayargs"
-    echo "(stub)"
+    for i in 1 2 3 4 5 6 7 8 9 10 11 12; do echo "(stub $i)"; done
 }
 
-# First on the real clock, so the virtual one below cannot be measuring itself:
-# hb_now must default to seconds, and a static log must actually be killed.
+# First on the real clock, so the virtual one cannot be measuring itself. The
+# bound is tight enough to catch hb_now returning some other unit.
 printf 'RUN 99_stuck.test at 0s\n' >"$progress"
 began=$SECONDS
 ci_suite_heartbeat 1 1 "$progress" 2 4242 >"$tmp/real" 2>&1
 spent=$((SECONDS - began))
-test "$spent" -ge 2 || fail "killed after ${spent}s of a 2s window: hb_now is not seconds"
-test "$spent" -le 30 || fail "took ${spent}s to notice a static log"
-grep -q '^KILL 4242$' "$tmp/real" || fail "a static log was not killed on the real clock"
+test "$spent" -ge 2 || fail "killed after ${spent}s of a 2s window: hb_now runs fast"
+test "$spent" -le 8 || fail "took ${spent}s to notice a 2s static window: hb_now is not seconds"
+grep -q '^KILL 4242 at ' "$tmp/real" || fail "a static log was not killed on the real clock"
 
-# Virtual clock. sleep advances it and reports progress up to 1200, so the suite
-# is still healthy well past the quiet window before it goes silent.
-vnow=0
-# Two % and a CR in every line, because the runner needs both encoded: left raw,
-# either one truncates the command it is carrying.
+# Virtual clock, started well away from zero so the quiet window is measured from
+# when the watchdog began rather than from whatever the clock happened to read.
+vnow=5000
 sleep() {
     vnow=$((vnow + $1))
-    test "$vnow" -gt 1200 || printf 'RUN %ss%%a%%b.test\r at %ss\n' "$vnow" "$vnow" >>"$progress"
+    if test "$vnow" -eq 5600; then
+        # The one exercise of the errexit guard: tail must not end the watchdog.
+        rm -f "$progress"
+    elif test "$vnow" -le 6230; then
+        # Two % and a CR in every line, because the runner needs both encoded:
+        # left raw, either one truncates the command it is carrying.
+        printf 'RUN %ss%%a%%b.test\r at %ss\n' "$vnow" "$vnow" >>"$progress"
+    fi
 }
 hb_now() { echo "$vnow"; }
 
 printf 'RUN 98_earlier.test at 0s\n' >"$progress"
 ci_suite_heartbeat 720 360 "$progress" 900 4242 >"$tmp/out" 2>&1
 
-# The suite reported healthily until 1200, past the quiet window, so nothing may
-# have killed it before then; the kill lands one staticness window later. tick is
-# clamped to 30, so it fires within 30s of that, not a whole 360 late.
-killed=$(sed -n 's/^::error title=suite watchdog::killing the step: \([0-9]*\)s.*/\1/p' "$tmp/out")
+# Timed by the stub, not by the annotation. Progress stops at 6230, so a kill is
+# due at 7130 and nowhere else: earlier means it fired on a suite still
+# reporting, later means the 30s tick clamp is gone or the check rides the 360s
+# annotation cadence.
+killed=$(sed -n 's/^KILL 4242 at \([0-9]*\)$/\1/p' "$tmp/out")
 test -n "$killed" || fail "a suite that stopped reporting was never killed"
-test "$killed" -ge 900 || fail "killed after only ${killed}s without progress, want 900"
-test "$killed" -le 930 || fail "killed ${killed}s after progress stopped: tick is not clamped to 30"
+test "$killed" -eq 7130 || fail "killed at ${killed}, want 7130 (progress stopped at 6230)"
 
-# Quiet window and cadence, from the annotations' own elapsed field.
+# The kill has to be announced before it happens, or it lands unexplained.
+sed -n '/^::error title=suite watchdog::/=;/^KILL 4242 at /=' "$tmp/out" |
+    { read -r announced && read -r fired && test "$announced" -lt "$fired"; } ||
+    fail "the kill was not announced ahead of itself"
+
+# Quiet window and cadence, from the annotations' own elapsed field: a lie there
+# is caught by the kill oracle above, so these only have to pin the schedule.
 said=()
 while IFS= read -r t; do
     said+=("$t")
 done < <(sed -n 's/^::notice title=suite still running::\([0-9]*\)s elapsed.*/\1/p' "$tmp/out")
 test "${#said[@]}" -ge 2 || fail "only ${#said[@]} annotations before the kill"
-test "${said[0]}" -eq 720 || fail "first annotation at ${said[0]}s, want 720"
+test "${said[0]}" -eq 720 || fail "first annotation at ${said[0]}s, want 720 after the watchdog began"
 prev=${said[0]}
 for t in "${said[@]:1}"; do
     test $((t - prev)) -eq 360 || fail "annotations ${prev}s and ${t}s apart, want 360"
     prev=$t
 done
 
-grep -q 'in flight: RUN 1200s%25a%25b.test at 1200s' "$tmp/out" ||
+grep -q 'in flight: RUN 6230s%25a%25b.test at 6230s' "$tmp/out" ||
     fail "annotation does not name the escaped test in flight: $(head -3 "$tmp/out")"
 grep -q "$(printf '\r')" "$tmp/out" && fail "a CR reached the annotation, truncating it"
 grep -q '98_earlier' "$tmp/out" && fail "annotation names the first test, not the one in flight"
-grep -q '%0A(stub)' "$tmp/out" || fail "annotation dropped the process list, or its newline encoding"
 grep -qx '0 named' "$tmp/strayargs" || fail "process list not host-wide: $(cat "$tmp/strayargs")"
+
+# Joined with %0A and bounded to eight, and no separator left dangling: the
+# runner reads to end of line, so a trailing one is a visible empty tail.
+stubs=$(sed -n '/^::notice title=suite still running::/{p;q;}' "$tmp/out" |
+    grep -o '%0A(stub ' | grep -c '' || true)
+test "$stubs" -eq 8 || fail "annotation carried $stubs process lines, want 8"
+grep -q '%0A$' "$tmp/out" && fail "annotation ends on a dangling %0A separator"
 
 # A command is only read at the head of a line, so every annotation opens one.
 awk '/^::(notice|error) title=/ { if (prev != "") bad = 1 } { prev = $0 } END { exit bad }' "$tmp/out" ||

--- a/tests/171_watchdog-heartbeat.test
+++ b/tests/171_watchdog-heartbeat.test
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
 # Unit-tests ci_suite_heartbeat (testlib.sh) on a virtual clock, at the values the
-# Windows workflow really passes: scaled-down timings collapse the sleep
-# granularity, the annotation cadence and the staticness window onto one number,
-# and a watchdog that confuses those kills healthy runs (#795). The kill is timed
-# by the stub, never by the annotation, which the code under test writes itself.
+# Windows workflow really passes, in both its regimes: scaled-down timings
+# collapse the sleep granularity, the annotation cadence and the staticness
+# window onto one number, and a watchdog confusing those kills healthy runs
+# (#795). The kill is timed by the stub, never by the annotation the code writes.
 
 set -euo pipefail
 
@@ -120,5 +120,18 @@ grep -q '%0A$' "$tmp/out" && fail "annotation ends on a dangling %0A separator"
 # A command is only read at the head of a line, so every annotation opens one.
 awk '/^::(notice|error) title=/ { if (prev != "") bad = 1 } { prev = $0 } END { exit bad }' "$tmp/out" ||
     fail "an annotation followed a non-empty line, where the runner cannot see it"
+
+# The workflow's own quiet window is longer than its staticness one, and only
+# then does the gate ahead of the kill decide anything: a suite dead from the
+# start waits out the quiet window rather than the shorter staticness one. Above,
+# where quiet is the shorter of the two, that gate is unreachable.
+vnow=9000
+ticks=0
+printf 'RUN 97_dead.test at 0s\n' >"$progress"
+ci_suite_heartbeat 960 360 "$progress" 900 4242 >"$tmp/late" 2>&1
+killed=$(sed -n 's/^KILL 4242 at \([0-9]*\)$/\1/p' "$tmp/late")
+test -n "$killed" || fail "a suite static from the start was never killed"
+test "$killed" -ge 9960 || fail "killed at $killed, inside the 960s quiet window"
+test "$killed" -le 10080 || fail "killed at $killed, want 9960 within a tick"
 
 echo "heartbeat OK"

--- a/tests/171_watchdog-heartbeat.test
+++ b/tests/171_watchdog-heartbeat.test
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Unit-tests ci_suite_heartbeat (testlib.sh), the Windows job's last line of
+# reporting: when the runner dies the step log and the artifacts go with it, so a
+# wedged suite is only ever named by the annotations this emits (#795). Timings
+# are scaled down; the reap and the kill are stubbed, both being host-wide.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_hb.XXXXXX")
+trap 'set +e; rm -rf "$tmp"' EXIT
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+progress="$tmp/progress"
+export HTTRACK_WATCHDOG_GRACE=1
+
+# The reap stub models what the real one does to a wedged test: it kills the
+# engine, the test ends, and the caller records one more line of progress.
+unstick=0
+reap_leftover_processes() {
+    echo "REAP"
+    test "$unstick" -eq 0 || printf '0 99_stuck.test\n' >>"$progress"
+}
+kill_tree() { echo "KILL $1"; }
+list_stray_processes() { echo "(stub)"; }
+
+printf 'RUN 99_stuck.test at 0s\n' >"$progress"
+ci_suite_heartbeat 3 1 "$progress" 6 4242 >"$tmp/out" 2>&1 &
+hb=$!
+# Nothing may be said during the quiet window, or a healthy run annotates itself
+# every time.
+sleep 1
+test ! -s "$tmp/out" || fail "annotated inside the quiet window: $(cat "$tmp/out")"
+wait "$hb"
+out=$(cat "$tmp/out")
+
+# Every annotation names the test in flight, on a schedule landing exactly on the
+# hard deadline: one that overshot would report past the step's own timeout.
+got=$(sed -n 's/^::warning title=suite still running::\([0-9]*\)s elapsed.*/\1/p' "$tmp/out" | tr '\n' ' ')
+test "$got" = "3 4 5 6 " || fail "annotation schedule was [$got], want [3 4 5 6 ]"
+grep -q 'in flight: RUN 99_stuck.test' <<<"$out" || fail "annotation does not name the test in flight"
+grep -q '^KILL 4242$' <<<"$out" || fail "a suite stuck through the reap was not killed"
+
+# ... and one the reap frees keeps its step: it still has a result to report.
+unstick=1
+printf 'RUN 99_stuck.test at 0s\n' >"$progress"
+out=$(ci_suite_heartbeat 3 1 "$progress" 6 4242)
+grep -q '^REAP$' <<<"$out" || fail "positive control: never reached the reap"
+if grep -q '^KILL' <<<"$out"; then
+    fail "killed a suite that resumed after the reap"
+fi
+
+echo "heartbeat OK"

--- a/tests/171_watchdog-heartbeat.test
+++ b/tests/171_watchdog-heartbeat.test
@@ -1,10 +1,9 @@
 #!/bin/bash
 #
-# Unit-tests ci_suite_heartbeat (testlib.sh): when the Windows runner dies it
-# takes the step log and the artifacts, so these annotations are all that names
-# the wedged test (#795). Timings are scaled down and every assertion is against
-# the wall clock, since a watchdog with the right labels and the wrong delays
-# would kill healthy runs.
+# Unit-tests ci_suite_heartbeat (testlib.sh) on a virtual clock, at the values the
+# Windows workflow really passes: scaled-down timings collapse the sleep
+# granularity, the annotation cadence and the staticness window onto one number,
+# and a watchdog that confuses those kills healthy runs (#795).
 
 set -euo pipefail
 
@@ -26,54 +25,60 @@ list_stray_processes() {
     echo "(stub)"
 }
 
-# Two lines, and a '%' in the one that matters: the annotation must name the test
-# in flight, not the suite's first, and must escape what it quotes.
-printf 'RUN 98_earlier.test at 0s\nRUN 99_stuck%%mark.test at 10s\n' >"$progress"
+# First on the real clock, so the virtual one below cannot be measuring itself:
+# hb_now must default to seconds, and a static log must actually be killed.
+printf 'RUN 99_stuck.test at 0s\n' >"$progress"
+began=$SECONDS
+ci_suite_heartbeat 1 1 "$progress" 2 4242 >"$tmp/real" 2>&1
+spent=$((SECONDS - began))
+test "$spent" -ge 2 || fail "killed after ${spent}s of a 2s window: hb_now is not seconds"
+test "$spent" -le 30 || fail "took ${spent}s to notice a static log"
+grep -q '^KILL 4242$' "$tmp/real" || fail "a static log was not killed on the real clock"
 
-# Stamped as each line arrives. quiet=3 every=1 stuck=5, so nothing may be said
-# before 3s and the kill may not land before 5s of a static progress file.
-start=$SECONDS
-ci_suite_heartbeat 3 1 "$progress" 5 4242 |
-    while IFS= read -r line; do
-        test -z "$line" || printf '%s|%s\n' "$((SECONDS - start))" "$line"
-    done >"$tmp/out"
+# Virtual clock. sleep advances it and reports progress up to 1200, so the suite
+# is still healthy well past the quiet window before it goes silent.
+vnow=0
+# Two % and a CR in every line, because the runner needs both encoded: left raw,
+# either one truncates the command it is carrying.
+sleep() {
+    vnow=$((vnow + $1))
+    test "$vnow" -gt 1200 || printf 'RUN %ss%%a%%b.test\r at %ss\n' "$vnow" "$vnow" >>"$progress"
+}
+hb_now() { echo "$vnow"; }
 
-first=$(sed -n '1s/|.*//p' "$tmp/out")
-test -n "$first" || fail "the watchdog said nothing at all"
-test "$first" -ge 3 || fail "annotated at ${first}s, inside the 3s quiet window"
+printf 'RUN 98_earlier.test at 0s\n' >"$progress"
+ci_suite_heartbeat 720 360 "$progress" 900 4242 >"$tmp/out" 2>&1
 
-killed=$(sed -n 's/^\([0-9]*\)|KILL 4242$/\1/p' "$tmp/out")
-test -n "$killed" || fail "a suite static past the stuck window was not killed"
-test "$killed" -ge 5 || fail "killed at ${killed}s, before 5s without progress"
+# The suite reported healthily until 1200, past the quiet window, so nothing may
+# have killed it before then; the kill lands one staticness window later. tick is
+# clamped to 30, so it fires within 30s of that, not a whole 360 late.
+killed=$(sed -n 's/^::error title=suite watchdog::killing the step: \([0-9]*\)s.*/\1/p' "$tmp/out")
+test -n "$killed" || fail "a suite that stopped reporting was never killed"
+test "$killed" -ge 900 || fail "killed after only ${killed}s without progress, want 900"
+test "$killed" -le 930 || fail "killed ${killed}s after progress stopped: tick is not clamped to 30"
 
-# The kill has to be announced, or it lands as an unexplained dead step: exactly
-# the #795 silence this exists to end.
-sed -n "$(($(grep -c '' "$tmp/out") - 1))p" "$tmp/out" |
-    grep -q '::error title=suite watchdog::' || fail "the kill was not annotated"
+# Quiet window and cadence, from the annotations' own elapsed field.
+said=()
+while IFS= read -r t; do
+    said+=("$t")
+done < <(sed -n 's/^::notice title=suite still running::\([0-9]*\)s elapsed.*/\1/p' "$tmp/out")
+test "${#said[@]}" -ge 2 || fail "only ${#said[@]} annotations before the kill"
+test "${said[0]}" -eq 720 || fail "first annotation at ${said[0]}s, want 720"
+prev=${said[0]}
+for t in "${said[@]:1}"; do
+    test $((t - prev)) -eq 360 || fail "annotations ${prev}s and ${t}s apart, want 360"
+    prev=$t
+done
 
-grep -q 'in flight: RUN 99_stuck%25mark.test' "$tmp/out" ||
-    fail "annotation does not name the escaped test in flight: $(cat "$tmp/out")"
+grep -q 'in flight: RUN 1200s%25a%25b.test at 1200s' "$tmp/out" ||
+    fail "annotation does not name the escaped test in flight: $(head -3 "$tmp/out")"
+grep -q "$(printf '\r')" "$tmp/out" && fail "a CR reached the annotation, truncating it"
 grep -q '98_earlier' "$tmp/out" && fail "annotation names the first test, not the one in flight"
+grep -q '%0A(stub)' "$tmp/out" || fail "annotation dropped the process list, or its newline encoding"
 grep -qx '0 named' "$tmp/strayargs" || fail "process list not host-wide: $(cat "$tmp/strayargs")"
 
-# A suite that keeps reporting is never killed, however long it runs.
-printf 'RUN 99_slow.test at 0s\n' >"$progress"
-for i in 1 2 3 4 5 6 7 8 9; do
-    (
-        command sleep "$i"
-        printf '%s 99_slow.test\n' "$i" >>"$progress"
-    ) &
-done
-ci_suite_heartbeat 3 1 "$progress" 5 4242 >"$tmp/moving" 2>&1 &
-hb=$!
-command sleep 9
-kill "$hb" 2>/dev/null || true
-wait 2>/dev/null || true
-
-grep -q '::notice title=suite still running::' "$tmp/moving" ||
-    fail "positive control: the watchdog never reported on the moving suite"
-if grep -q '^KILL' "$tmp/moving"; then
-    fail "killed a suite that was still making progress"
-fi
+# A command is only read at the head of a line, so every annotation opens one.
+awk '/^::(notice|error) title=/ { if (prev != "") bad = 1 } { prev = $0 } END { exit bad }' "$tmp/out" ||
+    fail "an annotation followed a non-empty line, where the runner cannot see it"
 
 echo "heartbeat OK"

--- a/tests/171_watchdog-heartbeat.test
+++ b/tests/171_watchdog-heartbeat.test
@@ -40,15 +40,24 @@ grep -q '^KILL 4242 at ' "$tmp/real" || fail "a static log was not killed on the
 # Virtual clock, started well away from zero so the quiet window is measured from
 # when the watchdog began rather than from whatever the clock happened to read.
 vnow=5000
+ticks=0
 sleep() {
-    vnow=$((vnow + $1))
-    if test "$vnow" -eq 5600; then
+    local step=$1
+    ticks=$((ticks + 1))
+    # Every fourth sleep overshoots fourfold. Starvation is what makes a sleep
+    # run long, and it is the whole difference between a clock that is measured
+    # and one accumulated from what was asked for: a perfect sleep here would
+    # make the code's central invariant unobservable.
+    test $((ticks % 4)) -ne 0 || step=$((step * 4))
+    vnow=$((vnow + step))
+    if test "$vnow" -ge 5600 && test "$vnow" -lt 5700; then
         # The one exercise of the errexit guard: tail must not end the watchdog.
         rm -f "$progress"
     elif test "$vnow" -le 6230; then
         # Two % and a CR in every line, because the runner needs both encoded:
         # left raw, either one truncates the command it is carrying.
         printf 'RUN %ss%%a%%b.test\r at %ss\n' "$vnow" "$vnow" >>"$progress"
+        echo "$vnow" >"$tmp/lastwrite"
     fi
 }
 hb_now() { echo "$vnow"; }
@@ -56,13 +65,17 @@ hb_now() { echo "$vnow"; }
 printf 'RUN 98_earlier.test at 0s\n' >"$progress"
 ci_suite_heartbeat 720 360 "$progress" 900 4242 >"$tmp/out" 2>&1
 
-# Timed by the stub, not by the annotation. Progress stops at 6230, so a kill is
-# due at 7130 and nowhere else: earlier means it fired on a suite still
-# reporting, later means the 30s tick clamp is gone or the check rides the 360s
-# annotation cadence.
+# Timed by the stub, not by the annotation. The kill is due one staticness window
+# after the last progress line and within a tick of it: earlier means it fired on
+# a suite still reporting, later means the 30s clamp is gone, or the check rides
+# the 360s annotation cadence, or the clock is being accumulated rather than read.
 killed=$(sed -n 's/^KILL 4242 at \([0-9]*\)$/\1/p' "$tmp/out")
+wrote=$(cat "$tmp/lastwrite")
 test -n "$killed" || fail "a suite that stopped reporting was never killed"
-test "$killed" -eq 7130 || fail "killed at ${killed}, want 7130 (progress stopped at 6230)"
+test "$killed" -ge $((wrote + 900)) ||
+    fail "killed at $killed, only $((killed - wrote))s after the last progress line at $wrote"
+test "$killed" -le $((wrote + 900 + 120)) ||
+    fail "killed at $killed, $((killed - wrote))s after the last progress line at $wrote"
 
 # The kill has to be announced before it happens, or it lands unexplained.
 sed -n '/^::error title=suite watchdog::/=;/^KILL 4242 at /=' "$tmp/out" |
@@ -76,14 +89,18 @@ while IFS= read -r t; do
     said+=("$t")
 done < <(sed -n 's/^::notice title=suite still running::\([0-9]*\)s elapsed.*/\1/p' "$tmp/out")
 test "${#said[@]}" -ge 2 || fail "only ${#said[@]} annotations before the kill"
-test "${said[0]}" -eq 720 || fail "first annotation at ${said[0]}s, want 720 after the watchdog began"
+if test "${said[0]}" -lt 720 || test "${said[0]}" -gt 840; then
+    fail "first annotation at ${said[0]}s, want 720 after the watchdog began, within a tick"
+fi
 prev=${said[0]}
 for t in "${said[@]:1}"; do
-    test $((t - prev)) -eq 360 || fail "annotations ${prev}s and ${t}s apart, want 360"
+    if test $((t - prev)) -lt 360 || test $((t - prev)) -gt 480; then
+        fail "annotations ${prev}s and ${t}s apart, want 360 within a tick"
+    fi
     prev=$t
 done
 
-grep -q 'in flight: RUN 6230s%25a%25b.test at 6230s' "$tmp/out" ||
+grep -q "in flight: RUN ${wrote}s%25a%25b.test at ${wrote}s" "$tmp/out" ||
     fail "annotation does not name the escaped test in flight: $(head -3 "$tmp/out")"
 grep -q "$(printf '\r')" "$tmp/out" && fail "a CR reached the annotation, truncating it"
 grep -q '98_earlier' "$tmp/out" && fail "annotation names the first test, not the one in flight"
@@ -91,9 +108,13 @@ grep -qx '0 named' "$tmp/strayargs" || fail "process list not host-wide: $(cat "
 
 # Joined with %0A and bounded to eight, and no separator left dangling: the
 # runner reads to end of line, so a trailing one is a visible empty tail.
-stubs=$(sed -n '/^::notice title=suite still running::/{p;q;}' "$tmp/out" |
-    grep -o '%0A(stub ' | grep -c '' || true)
-test "$stubs" -eq 8 || fail "annotation carried $stubs process lines, want 8"
+first=$(sed -n '/^::notice title=suite still running::/{p;q;}' "$tmp/out")
+for i in 1 8; do
+    grep -q "%0A(stub $i)" <<<"$first" || fail "annotation lost process line $i"
+done
+# By identity, not by count: any eight lines satisfy a tally, including the wrong
+# eight, which is what a bound applied at the far end would leave.
+grep -q '(stub 9)' <<<"$first" && fail "annotation carried more than the eight lines it bounds"
 grep -q '%0A$' "$tmp/out" && fail "annotation ends on a dangling %0A separator"
 
 # A command is only read at the head of a line, so every annotation opens one.

--- a/tests/171_watchdog-heartbeat.test
+++ b/tests/171_watchdog-heartbeat.test
@@ -1,9 +1,10 @@
 #!/bin/bash
 #
-# Unit-tests ci_suite_heartbeat (testlib.sh), the Windows job's last line of
-# reporting: when the runner dies the step log and the artifacts go with it, so a
-# wedged suite is only ever named by the annotations this emits (#795). Timings
-# are scaled down; the reap and the kill are stubbed, both being host-wide.
+# Unit-tests ci_suite_heartbeat (testlib.sh): when the Windows runner dies it
+# takes the step log and the artifacts, so these annotations are all that names
+# the wedged test (#795). Timings are scaled down and every assertion is against
+# the wall clock, since a watchdog with the right labels and the wrong delays
+# would kill healthy runs.
 
 set -euo pipefail
 
@@ -19,42 +20,60 @@ fail() {
 }
 
 progress="$tmp/progress"
-export HTTRACK_WATCHDOG_GRACE=1
-
-# The reap stub models what the real one does to a wedged test: it kills the
-# engine, the test ends, and the caller records one more line of progress.
-unstick=0
-reap_leftover_processes() {
-    echo "REAP"
-    test "$unstick" -eq 0 || printf '0 99_stuck.test\n' >>"$progress"
-}
 kill_tree() { echo "KILL $1"; }
-list_stray_processes() { echo "(stub)"; }
+list_stray_processes() {
+    printf '%s\n' "$*" >"$tmp/strayargs"
+    echo "(stub)"
+}
 
-printf 'RUN 99_stuck.test at 0s\n' >"$progress"
-ci_suite_heartbeat 3 1 "$progress" 6 4242 >"$tmp/out" 2>&1 &
+# Two lines, and a '%' in the one that matters: the annotation must name the test
+# in flight, not the suite's first, and must escape what it quotes.
+printf 'RUN 98_earlier.test at 0s\nRUN 99_stuck%%mark.test at 10s\n' >"$progress"
+
+# Stamped as each line arrives. quiet=3 every=1 stuck=5, so nothing may be said
+# before 3s and the kill may not land before 5s of a static progress file.
+start=$SECONDS
+ci_suite_heartbeat 3 1 "$progress" 5 4242 |
+    while IFS= read -r line; do
+        test -z "$line" || printf '%s|%s\n' "$((SECONDS - start))" "$line"
+    done >"$tmp/out"
+
+first=$(sed -n '1s/|.*//p' "$tmp/out")
+test -n "$first" || fail "the watchdog said nothing at all"
+test "$first" -ge 3 || fail "annotated at ${first}s, inside the 3s quiet window"
+
+killed=$(sed -n 's/^\([0-9]*\)|KILL 4242$/\1/p' "$tmp/out")
+test -n "$killed" || fail "a suite static past the stuck window was not killed"
+test "$killed" -ge 5 || fail "killed at ${killed}s, before 5s without progress"
+
+# The kill has to be announced, or it lands as an unexplained dead step: exactly
+# the #795 silence this exists to end.
+sed -n "$(($(grep -c '' "$tmp/out") - 1))p" "$tmp/out" |
+    grep -q '::error title=suite watchdog::' || fail "the kill was not annotated"
+
+grep -q 'in flight: RUN 99_stuck%25mark.test' "$tmp/out" ||
+    fail "annotation does not name the escaped test in flight: $(cat "$tmp/out")"
+grep -q '98_earlier' "$tmp/out" && fail "annotation names the first test, not the one in flight"
+grep -qx '0 named' "$tmp/strayargs" || fail "process list not host-wide: $(cat "$tmp/strayargs")"
+
+# A suite that keeps reporting is never killed, however long it runs.
+printf 'RUN 99_slow.test at 0s\n' >"$progress"
+for i in 1 2 3 4 5 6 7 8 9; do
+    (
+        command sleep "$i"
+        printf '%s 99_slow.test\n' "$i" >>"$progress"
+    ) &
+done
+ci_suite_heartbeat 3 1 "$progress" 5 4242 >"$tmp/moving" 2>&1 &
 hb=$!
-# Nothing may be said during the quiet window, or a healthy run annotates itself
-# every time.
-sleep 1
-test ! -s "$tmp/out" || fail "annotated inside the quiet window: $(cat "$tmp/out")"
-wait "$hb"
-out=$(cat "$tmp/out")
+command sleep 9
+kill "$hb" 2>/dev/null || true
+wait 2>/dev/null || true
 
-# Every annotation names the test in flight, on a schedule landing exactly on the
-# hard deadline: one that overshot would report past the step's own timeout.
-got=$(sed -n 's/^::warning title=suite still running::\([0-9]*\)s elapsed.*/\1/p' "$tmp/out" | tr '\n' ' ')
-test "$got" = "3 4 5 6 " || fail "annotation schedule was [$got], want [3 4 5 6 ]"
-grep -q 'in flight: RUN 99_stuck.test' <<<"$out" || fail "annotation does not name the test in flight"
-grep -q '^KILL 4242$' <<<"$out" || fail "a suite stuck through the reap was not killed"
-
-# ... and one the reap frees keeps its step: it still has a result to report.
-unstick=1
-printf 'RUN 99_stuck.test at 0s\n' >"$progress"
-out=$(ci_suite_heartbeat 3 1 "$progress" 6 4242)
-grep -q '^REAP$' <<<"$out" || fail "positive control: never reached the reap"
-if grep -q '^KILL' <<<"$out"; then
-    fail "killed a suite that resumed after the reap"
+grep -q '::notice title=suite still running::' "$tmp/moving" ||
+    fail "positive control: the watchdog never reported on the moving suite"
+if grep -q '^KILL' "$tmp/moving"; then
+    fail "killed a suite that was still making progress"
 fi
 
 echo "heartbeat OK"

--- a/tests/test-timeout.sh
+++ b/tests/test-timeout.sh
@@ -63,6 +63,9 @@ fi
 ticks=0
 while kill -0 "$pid" 2>/dev/null; do
     if test "$((ticks / per_sec))" -ge "$budget"; then
+        # The dump below can run for minutes. Say so where a suite watchdog is
+        # watching, or the silence reads as a wedge and the step dies mid-stack.
+        test -z "${HTTRACK_PROGRESS_LOG:-}" || echo "DUMP $name" >>"$HTTRACK_PROGRESS_LOG"
         dump_hang_diagnostics "$pid" "$name" "$budget"
         kill_tree "$pid"
         reap_bounded "$pid" || echo "hang: the tree outlived the kill; see the process list above"

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -194,46 +194,54 @@ reap_leftover_processes() {
     return 0
 }
 
-# Emit a GitHub annotation in one write, so a background writer cannot interleave
-# into the foreground's output and split the command across two log lines.
+# Emit one GitHub annotation at level $1. The runner keeps only the first 10 of
+# each level per step and silently drops the rest, so the level is a budget: pick
+# one the step does not spend elsewhere. One printf led by a newline, since a
+# command is read only at the head of a line and the foreground shares this
+# stdout. sed/awk, not ${v//p/r}: bash 3.2 (macOS) cannot parse $'..' inside one.
 ci_annotate() {
-    local title=$1 msg=$2
-    msg=${msg//'%'/%25}
-    msg=${msg//$'\r'/}
-    msg=${msg//$'\n'/%0A}
-    printf '::warning title=%s::%s\n' "$title" "$msg"
+    local level=$1 title=$2 msg
+    msg=$(printf '%s' "$3" | tr -d '\r' | sed 's/%/%25/g' |
+        awk 'NR > 1 { printf "%%0A" } { printf "%s", $0 }')
+    printf '\n::%s title=%s::%s\n' "$level" "$title" "$msg"
 }
 
-# Report, and finally break, a suite running long. The Windows job dies with its
-# runner (#795), taking the step log and the if:always() artifacts with it, so the
-# wedging test has never been named; annotations stream as the log is written and
-# survive. Silent for $1s, then names the test in flight from $3 every $2; at $4
-# it kills the engine, and $5 if that frees nothing. Pick $4 past any run that
-# could still pass, since it forfeits whatever the suite had left to do.
+# Report, and finally break, a wedged suite, through annotations: the Windows job
+# dies with its runner (#795), which takes the step log and the artifacts with it.
+# Quiet for $1s, then names the test in flight from $3 every $2s; kills $5 once $3
+# has been static for $4s. Staticness, never elapsed time: a healthy test in flight
+# and a wedged one look identical by the clock, but every outcome writes a line,
+# the per-test timeout included, so $4 past that timeout means it never fired.
 ci_suite_heartbeat() {
-    local quiet=$1 every=$2 progress=$3 hard=$4 main=$5 waited=$1
-    sleep "$quiet"
+    local quiet=$1 every=$2 progress=$3 stuck=$4 main=$5
+    local tick=$2 waited=0 static=0 said=0 last='' now=''
+    test "$tick" -le 30 || tick=30
     while :; do
-        ci_annotate "suite still running" "$(
-            printf '%ss elapsed, in flight: %s\n' "$waited" "$(tail -n 1 "$progress" 2>/dev/null)"
-            # Bounded: past the pipe's atomic size the write can interleave, and
-            # half a workflow command is not one.
+        sleep "$tick" >/dev/null 2>&1 # holds no stdout: the caller's trap orphans it
+        waited=$((waited + tick))
+        now=$(tail -n 1 "$progress" 2>/dev/null)
+        if test "$now" != "$last"; then
+            last=$now static=0
+        else
+            static=$((static + tick))
+        fi
+        test "$waited" -ge "$quiet" || continue
+        # Checked every tick, not on the annotation cadence, which would let a
+        # late wedge run past the step's own timeout before being caught.
+        if test "$static" -ge "$stuck"; then
+            ci_annotate error "suite watchdog" "killing the step: ${static}s without progress, in flight: $now"
+            kill_tree "$main"
+            return 0
+        fi
+        test $((waited - said)) -ge "$every" || continue
+        said=$waited
+        # notice, not warning: reap_leftover_processes spends the warning budget
+        # one leaking test at a time, and a leak is what precedes the wedge.
+        ci_annotate notice "suite still running" "$(
+            printf '%ss elapsed, %ss without progress, in flight: %s\n' "$waited" "$static" "$now"
             list_stray_processes 0 named | head -n 8
         )"
-        test "$waited" -lt "$hard" || break
-        sleep "$every"
-        waited=$((waited + every))
     done
-    local before after
-    before=$(tail -n 1 "$progress" 2>/dev/null)
-    reap_leftover_processes "watchdog at ${waited}s"
-    # A suite the reap frees reports far more than a killed step, so only kill one
-    # that stayed stuck. The grace is overridable so the unit test need not wait it out.
-    sleep "${HTTRACK_WATCHDOG_GRACE:-60}"
-    after=$(tail -n 1 "$progress" 2>/dev/null)
-    test "$before" = "$after" || return 0
-    ci_annotate "suite watchdog" "killing the step, last progress: $after"
-    kill_tree "$main"
 }
 
 # Pids of engine processes in process group $1. Scoped to the group because the

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -194,6 +194,48 @@ reap_leftover_processes() {
     return 0
 }
 
+# Emit a GitHub annotation in one write, so a background writer cannot interleave
+# into the foreground's output and split the command across two log lines.
+ci_annotate() {
+    local title=$1 msg=$2
+    msg=${msg//'%'/%25}
+    msg=${msg//$'\r'/}
+    msg=${msg//$'\n'/%0A}
+    printf '::warning title=%s::%s\n' "$title" "$msg"
+}
+
+# Report, and finally break, a suite running long. The Windows job dies with its
+# runner (#795), taking the step log and the if:always() artifacts with it, so the
+# wedging test has never been named; annotations stream as the log is written and
+# survive. Silent for $1s, then names the test in flight from $3 every $2; at $4
+# it kills the engine, and $5 if that frees nothing. Pick $4 past any run that
+# could still pass, since it forfeits whatever the suite had left to do.
+ci_suite_heartbeat() {
+    local quiet=$1 every=$2 progress=$3 hard=$4 main=$5 waited=$1
+    sleep "$quiet"
+    while :; do
+        ci_annotate "suite still running" "$(
+            printf '%ss elapsed, in flight: %s\n' "$waited" "$(tail -n 1 "$progress" 2>/dev/null)"
+            # Bounded: past the pipe's atomic size the write can interleave, and
+            # half a workflow command is not one.
+            list_stray_processes 0 named | head -n 8
+        )"
+        test "$waited" -lt "$hard" || break
+        sleep "$every"
+        waited=$((waited + every))
+    done
+    local before after
+    before=$(tail -n 1 "$progress" 2>/dev/null)
+    reap_leftover_processes "watchdog at ${waited}s"
+    # A suite the reap frees reports far more than a killed step, so only kill one
+    # that stayed stuck. The grace is overridable so the unit test need not wait it out.
+    sleep "${HTTRACK_WATCHDOG_GRACE:-60}"
+    after=$(tail -n 1 "$progress" 2>/dev/null)
+    test "$before" = "$after" || return 0
+    ci_annotate "suite watchdog" "killing the step, last progress: $after"
+    kill_tree "$main"
+}
+
 # Pids of engine processes in process group $1. Scoped to the group because the
 # caller signals them, and under "make check -j" a global match would abort a
 # healthy sibling test's engine. Matches the executable basename only, so a

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -205,10 +205,12 @@ ci_annotate() {
     printf '\n::%s title=%s::%s\n' "$level" "$title" "$msg"
 }
 
-# Quiet for $1s, then names the test in flight from $3 every $2s; kills $5 once $3
-# has been static for $4s. Staticness, never elapsed time: a healthy test in flight
-# and a wedged one look identical by the clock, but every outcome writes a line,
-# the per-test timeout included, so $4 past that timeout means it never fired (#795).
+# End a wedged suite before its runner dies: a step that fails on its own terms
+# keeps its log, a lost runner keeps nothing, annotations included (#795). Quiet
+# for $1s, then names the test in flight from $3 every $2s; kills $5 once $3 has
+# been static for $4s. Staticness, never elapsed time: a healthy test in flight and
+# a wedged one look identical by the clock, but every outcome writes a line, the
+# per-test timeout included, so $4 past that timeout means it never fired.
 # Seconds since this shell started. Overridable, so the unit test can drive the
 # schedule the workflow really passes off a virtual clock instead of waiting it out.
 hb_now() { echo "$SECONDS"; }

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -195,50 +195,52 @@ reap_leftover_processes() {
 }
 
 # Emit one GitHub annotation at level $1. The runner keeps only the first 10 of
-# each level per step and silently drops the rest, so the level is a budget: pick
-# one the step does not spend elsewhere. One printf led by a newline, since a
-# command is read only at the head of a line and the foreground shares this
-# stdout. sed/awk, not ${v//p/r}: bash 3.2 (macOS) cannot parse $'..' inside one.
+# each level per step and drops the rest silently, so the level is a budget: pick
+# one the step does not spend elsewhere. Led by a newline, since a command is only
+# read at a line head. sed/awk, not ${v//p/r}: bash 3.2 cannot parse $'..' inside one.
 ci_annotate() {
     local level=$1 title=$2 msg
     msg=$(printf '%s' "$3" | tr -d '\r' | sed 's/%/%25/g' |
-        awk 'NR > 1 { printf "%%0A" } { printf "%s", $0 }')
+        awk 'NR > 1 { printf "%%0A" } { printf "%s", $0 }' || true)
     printf '\n::%s title=%s::%s\n' "$level" "$title" "$msg"
 }
 
-# Report, and finally break, a wedged suite, through annotations: the Windows job
-# dies with its runner (#795), which takes the step log and the artifacts with it.
 # Quiet for $1s, then names the test in flight from $3 every $2s; kills $5 once $3
 # has been static for $4s. Staticness, never elapsed time: a healthy test in flight
 # and a wedged one look identical by the clock, but every outcome writes a line,
-# the per-test timeout included, so $4 past that timeout means it never fired.
+# the per-test timeout included, so $4 past that timeout means it never fired (#795).
+# Seconds since this shell started. Overridable, so the unit test can drive the
+# schedule the workflow really passes off a virtual clock instead of waiting it out.
+hb_now() { echo "$SECONDS"; }
+
 ci_suite_heartbeat() {
     local quiet=$1 every=$2 progress=$3 stuck=$4 main=$5
-    local tick=$2 waited=0 static=0 said=0 last='' now=''
+    local tick=$2 begin now line said moved last=''
+    # Measured, never accumulated: the starvation this watchdog exists to catch is
+    # exactly what makes a sleep overshoot, and drift only ever delays the kill.
     test "$tick" -le 30 || tick=30
+    begin=$(hb_now) said=$begin moved=$begin
     while :; do
         sleep "$tick" >/dev/null 2>&1 # holds no stdout: the caller's trap orphans it
-        waited=$((waited + tick))
-        now=$(tail -n 1 "$progress" 2>/dev/null)
-        if test "$now" != "$last"; then
-            last=$now static=0
-        else
-            static=$((static + tick))
-        fi
-        test "$waited" -ge "$quiet" || continue
-        # Checked every tick, not on the annotation cadence, which would let a
-        # late wedge run past the step's own timeout before being caught.
-        if test "$static" -ge "$stuck"; then
-            ci_annotate error "suite watchdog" "killing the step: ${static}s without progress, in flight: $now"
+        now=$(hb_now)
+        # Guarded: under the caller's errexit a bare substitution assignment would
+        # end the watchdog in silence, which reads as protection and is not.
+        line=$(tail -n 1 "$progress" 2>/dev/null || true)
+        test "$line" = "$last" || { last=$line moved=$now; }
+        test $((now - begin)) -ge "$quiet" || continue
+        # Every tick, not on the annotation cadence, which would let a late wedge
+        # outlive the step's own timeout before being caught.
+        if test $((now - moved)) -ge "$stuck"; then
+            ci_annotate error "suite watchdog" "killing the step: $((now - moved))s without progress, in flight: $last"
             kill_tree "$main"
             return 0
         fi
-        test $((waited - said)) -ge "$every" || continue
-        said=$waited
-        # notice, not warning: reap_leftover_processes spends the warning budget
-        # one leaking test at a time, and a leak is what precedes the wedge.
+        test $((now - said)) -ge "$every" || continue
+        said=$now
+        # notice, not warning: reap_leftover_processes spends the warning budget.
         ci_annotate notice "suite still running" "$(
-            printf '%ss elapsed, %ss without progress, in flight: %s\n' "$waited" "$static" "$now"
+            printf '%ss elapsed, %ss without progress, in flight: %s\n' \
+                "$((now - begin))" "$((now - moved))" "$last"
             list_stray_processes 0 named | head -n 8
         )"
     done

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -231,3 +231,4 @@ TESTS += 160_zlib-cache-hdrbounds.test
 TESTS += 161_local-proxytrack-zip-headers.test
 TESTS += 162_zlib-cache-urlbounds.test
 TESTS += 164_local-proxytrack-arc-hostile.test
+TESTS += 171_watchdog-heartbeat.test


### PR DESCRIPTION
The Windows job wedges every few dozen runs: the test step never completes, the runner is lost, and the log blob and the `if: always()` artifact uploads go with it. So the wedging test has never been named.

A watchdog now runs beside the suite and ends the step before the runner dies, because a step that fails on its own terms keeps its log and still runs the uploads. It never triggers on elapsed time, since a healthy test and a wedged one look identical by the clock. It watches the progress log instead, where every outcome writes a line, the per-test timeout included: 900 seconds without one means that timeout did not fire, which is the wedge. On the way it names the test in flight as annotations, at 12 minutes and every 6 after, which is live progress rather than evidence.

That distinction is measured, not assumed. A throwaway workflow (branch `canary-795`, now deleted) emitted notices and then died four ways: a step cancelled by its own timeout keeps its log and every annotation, on Linux and on Windows, from a background subshell as well as the foreground; a runner killed mid-step keeps neither, dropping notices that had been on the wire for twenty seconds. An earlier draft of this PR claimed the opposite.

Refs #795 rather than closing it: this ends the silence, it does not fix the leak behind it. `171_watchdog-heartbeat.test` drives the values the workflow really passes off a virtual clock, since scaled-down timings collapse the sleep granularity, the annotation cadence and the staticness window onto one number; fourteen mutants of those properties fail it, on bash 3.2 as well as 5.2.