### PR TITLE
A downloaded HTTrack.app cannot launch: Homebrew's OpenSSL never travels with it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,8 +270,10 @@ jobs:
           ssl="$(brew --prefix openssl@3)"
           brewp="$(brew --prefix)"
           ./bootstrap
+          # -headerpad_max_install_names: the bundle rewrites load commands to @rpath,
+          # which needs more header room than the linker leaves by default.
           ./configure CPPFLAGS="-I${ssl}/include -I${brewp}/include" \
-            LDFLAGS="-L${ssl}/lib -L${brewp}/lib" \
+            LDFLAGS="-L${ssl}/lib -L${brewp}/lib -Wl,-headerpad_max_install_names" \
             --prefix="$RUNNER_TEMP/inst" --disable-shared
           make -j"$(sysctl -n hw.ncpu)"
           make install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,10 +270,8 @@ jobs:
           ssl="$(brew --prefix openssl@3)"
           brewp="$(brew --prefix)"
           ./bootstrap
-          # -headerpad_max_install_names: the bundle rewrites load commands to @rpath,
-          # which needs more header room than the linker leaves by default.
           ./configure CPPFLAGS="-I${ssl}/include -I${brewp}/include" \
-            LDFLAGS="-L${ssl}/lib -L${brewp}/lib -Wl,-headerpad_max_install_names" \
+            LDFLAGS="-L${ssl}/lib -L${brewp}/lib" \
             --prefix="$RUNNER_TEMP/inst" --disable-shared
           make -j"$(sysctl -n hw.ncpu)"
           make install
@@ -299,15 +297,22 @@ jobs:
           app="$RUNNER_TEMP/moved/HTTrack.app"
           bash tests/webhttrack-smoke.sh "$app/Contents/Resources" "$app/Contents/MacOS/HTTrack"
 
-      # The load-command check cannot fail if the loader quietly falls back to Homebrew, so hide it (#901).
-      - name: Run it with Homebrew's OpenSSL out of reach
+      # The load-command check cannot fail while the loader can still reach Homebrew (#901).
+      - name: Run it with Homebrew's libraries out of reach
         run: |
           set -euo pipefail
-          ssl="$(brew --prefix)/opt/openssl@3"
-          test -e "$ssl"
-          sudo mv "$ssl" "$ssl.hidden"
-          trap 'sudo mv "$ssl.hidden" "$ssl"' EXIT
           app="$RUNNER_TEMP/moved/HTTrack.app"
+          # Without this the hiding below proves nothing: an empty Frameworks passes it.
+          ls "$app/Contents/Frameworks"/libssl.*.dylib >/dev/null
+          # The kegs, not just the opt symlinks: a source build records the Cellar path.
+          hidden=""
+          for keg in openssl@3 brotli zstd; do
+            for d in "$(brew --prefix)/opt/$keg" "$(brew --prefix)/Cellar/$keg"; do
+              if [ -e "$d" ]; then sudo mv "$d" "$d.hidden"; hidden="$hidden $d"; fi
+            done
+          done
+          trap 'for d in $hidden; do sudo mv "$d.hidden" "$d"; done' EXIT
+          test -n "$hidden"
           bash tests/webhttrack-smoke.sh "$app/Contents/Resources" "$app/Contents/MacOS/HTTrack"
 
       # No Developer ID here, so Gatekeeper cannot be exercised; an ad-hoc signature
@@ -316,6 +321,11 @@ jobs:
         run: |
           set -euo pipefail
           app="$RUNNER_TEMP/moved/HTTrack.app"
+          # Before --force, which would re-sign away the damage this is meant to catch.
+          for f in "$app/Contents/Resources/bin/"* "$app/Contents/Frameworks/"*.dylib; do
+            file "$f" | grep -q Mach-O || continue
+            codesign --verify --strict "$f"
+          done
           codesign -s - --force --deep "$app"
           codesign --verify --strict --verbose=2 "$app"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,17 @@ jobs:
           app="$RUNNER_TEMP/moved/HTTrack.app"
           bash tests/webhttrack-smoke.sh "$app/Contents/Resources" "$app/Contents/MacOS/HTTrack"
 
+      # The load-command check cannot fail if the loader quietly falls back to Homebrew, so hide it (#901).
+      - name: Run it with Homebrew's OpenSSL out of reach
+        run: |
+          set -euo pipefail
+          ssl="$(brew --prefix)/opt/openssl@3"
+          test -e "$ssl"
+          sudo mv "$ssl" "$ssl.hidden"
+          trap 'sudo mv "$ssl.hidden" "$ssl"' EXIT
+          app="$RUNNER_TEMP/moved/HTTrack.app"
+          bash tests/webhttrack-smoke.sh "$app/Contents/Resources" "$app/Contents/MacOS/HTTrack"
+
       # No Developer ID here, so Gatekeeper cannot be exercised; an ad-hoc signature
       # still proves the bundle is well formed enough to sign.
       - name: Check the bundle is signable

--- a/configure.ac
+++ b/configure.ac
@@ -197,6 +197,11 @@ AC_SUBST([LDFLAGS_PIE])
 # Ties a crash trace from a stripped build back to its separate debug symbols.
 AX_CHECK_LINK_FLAG([-Wl,--build-id], [DEFAULT_LDFLAGS="$DEFAULT_LDFLAGS -Wl,--build-id"])
 
+# tools/macos-app.sh rewrites load commands to @rpath, which needs header room ld64 does
+# not leave by default; the probe fails on GNU ld, so this self-gates on Darwin.
+AX_CHECK_LINK_FLAG([-Wl,-headerpad_max_install_names],
+	[DEFAULT_LDFLAGS="$DEFAULT_LDFLAGS -Wl,-headerpad_max_install_names"])
+
 ### Check for -fvisibility=hidden support
 gl_VISIBILITY
 AM_CFLAGS="$AM_CFLAGS $CFLAG_VISIBILITY"

--- a/tools/macos-app.sh
+++ b/tools/macos-app.sh
@@ -9,6 +9,11 @@ usage() {
     exit 2
 }
 
+fail() {
+    echo "bundle check: $*" >&2
+    exit 1
+}
+
 prefix=""
 plist=""
 icon=""
@@ -52,7 +57,9 @@ test -r "$icon" || {
 
 prefix=$(cd "$prefix" && pwd -P)
 list=$(mktemp)
-trap 'rm -f "$list"' EXIT
+mach=$(mktemp)
+deplist=$(mktemp)
+trap 'rm -f "$list" "$mach" "$deplist"' EXIT
 app="$out/HTTrack.app"
 rm -rf "$app"
 mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
@@ -76,10 +83,95 @@ exec "$(dirname "$0")/../Resources/bin/webhttrack" "$@"
 EOF
 chmod +x "$app/Contents/MacOS/HTTrack"
 
-fail() {
-    echo "bundle check: $*" >&2
-    exit 1
+fw="$app/Contents/Frameworks"
+
+# Everything outside macOS itself must travel with the bundle; OpenSSL comes from Homebrew here.
+sysdep() {
+    case "$1" in
+    /usr/lib/* | /System/Library/*) return 0 ;;
+    esac
+    return 1
 }
+
+# Mach-O files only, prefiltered so `file` is not run over the whole html payload.
+machos() {
+    find "$app/Contents" -type f \
+        \( -perm -u+x -o -name '*.dylib' -o -name '*.so' \) >"$list"
+    : >"$mach"
+    while IFS= read -r f; do
+        file "$f" | grep -q Mach-O && printf '%s\n' "$f" >>"$mach"
+    done <"$list"
+}
+
+# A dylib's first entry is its own LC_ID_DYLIB, skipped like any satisfied dependency.
+deps() {
+    otool -L "$1" | tail -n +2 | awk '{print $1}'
+}
+
+# One ../ per component below Contents, so the rpath is depth-correct wherever the loader sits.
+uprefix() {
+    printf '%s' "${1#"$app/Contents"}" |
+        awk -F/ '{for (i = 1; i <= NF; i++) if ($i != "") printf "../"}'
+}
+
+# Each pass rescans, so a dylib pulled in by the last pass gets its own deps on the next.
+copy_dylibs() {
+    mkdir -p "$fw"
+    while :; do
+        machos
+        : >"$deplist"
+        while IFS= read -r bin; do
+            deps "$bin" >>"$deplist"
+        done <"$mach"
+        sort -u "$deplist" -o "$deplist"
+        : >"$list"
+        while IFS= read -r dep; do
+            case "$dep" in @*) continue ;; esac
+            sysdep "$dep" && continue
+            test -r "$fw/$(basename "$dep")" && continue
+            printf '%s\n' "$dep" >>"$list"
+        done <"$deplist"
+        test -s "$list" || break
+        while IFS= read -r dep; do
+            test -r "$dep" || fail "$dep is loaded by the bundle but is not readable here"
+            cp "$dep" "$fw/"
+            chmod u+w "$fw/$(basename "$dep")"
+        done <"$list"
+    done
+    rmdir "$fw" 2>/dev/null || true
+}
+
+relink() {
+    test -d "$fw" || return 0
+    machos
+    while IFS= read -r bin; do
+        case "$bin" in
+        "$fw"/*) install_name_tool -id "@rpath/$(basename "$bin")" "$bin" ;;
+        esac
+        deps "$bin" >"$deplist"
+        while IFS= read -r dep; do
+            case "$dep" in @*) continue ;; esac
+            sysdep "$dep" && continue
+            install_name_tool -change "$dep" "@rpath/$(basename "$dep")" "$bin"
+        done <"$deplist"
+        rp="@loader_path/$(uprefix "${bin%/*}")Frameworks"
+        otool -l "$bin" | awk '/LC_RPATH/ {r = 1} r && $1 == "path" {print $2; r = 0}' >"$deplist"
+        grep -qxF "$rp" "$deplist" || install_name_tool -add_rpath "$rp" "$bin"
+        # install_name_tool invalidates the signature, and arm64 kills an unsigned Mach-O.
+        codesign -f -s - "$bin"
+    done <"$mach"
+}
+
+if [ "$(uname -s)" = Darwin ]; then
+    for t in otool install_name_tool codesign file; do
+        command -v "$t" >/dev/null 2>&1 ||
+            fail "$t not found -- install the Xcode command line tools"
+    done
+fi
+if command -v otool >/dev/null 2>&1; then
+    copy_dylibs
+    relink
+fi
 
 appreal=$(cd "$app" && pwd -P)
 
@@ -96,17 +188,32 @@ test "$nlink" -gt 0 || fail "scanned no symlinks at all, the check proved nothin
 test -d "$app/Contents/Resources/share/httrack/html/server" ||
     fail "Contents/Resources/share/httrack/html/server missing"
 
-# Only our own library must be absent: system and Homebrew dylibs resolve from the
-# user's own install.
+# A downloaded bundle resolves against macOS and itself; neither the staging prefix nor Homebrew is on the user's machine (#901).
 if command -v otool >/dev/null 2>&1; then
-    find "$app/Contents" -type f -perm -u+x >"$list"
+    nmach=0
+    machos
     while IFS= read -r bin; do
-        file "$bin" | grep -q Mach-O || continue
-        if otool -L "$bin" | tail -n +2 | grep -q "$prefix"; then
+        nmach=$((nmach + 1))
+        deps "$bin" >"$deplist"
+        while IFS= read -r dep; do
+            case "$dep" in
+            @rpath/*)
+                test -r "$fw/${dep#@rpath/}" ||
+                    fail "$bin loads $dep, absent from Contents/Frameworks"
+                continue
+                ;;
+            esac
+            sysdep "$dep" && continue
             otool -L "$bin" >&2
-            fail "$bin still links against the staging prefix (build with --disable-shared)"
-        fi
-    done <"$list"
+            case "$dep" in
+            "$prefix"/*)
+                fail "$bin links against the staging prefix (build with --disable-shared)"
+                ;;
+            esac
+            fail "$bin loads $dep from outside the bundle"
+        done <"$deplist"
+    done <"$mach"
+    test "$nmach" -gt 0 || fail "scanned no Mach-O files at all, the check proved nothing"
 fi
 
 # otool sees load commands only, so scan the text payload separately. The binaries

--- a/tools/macos-app.sh
+++ b/tools/macos-app.sh
@@ -114,6 +114,12 @@ uprefix() {
         awk -F/ '{for (i = 1; i <= NF; i++) if ($i != "") printf "../"}'
 }
 
+# Rewriting needs header slack that only -headerpad_max_install_names leaves behind.
+rewrite() {
+    install_name_tool "$@" ||
+        fail "install_name_tool failed; link with LDFLAGS=-Wl,-headerpad_max_install_names"
+}
+
 # Each pass rescans, so a dylib pulled in by the last pass gets its own deps on the next.
 copy_dylibs() {
     mkdir -p "$fw"
@@ -146,17 +152,17 @@ relink() {
     machos
     while IFS= read -r bin; do
         case "$bin" in
-        "$fw"/*) install_name_tool -id "@rpath/$(basename "$bin")" "$bin" ;;
+        "$fw"/*) rewrite -id "@rpath/$(basename "$bin")" "$bin" ;;
         esac
         deps "$bin" >"$deplist"
         while IFS= read -r dep; do
             case "$dep" in @*) continue ;; esac
             sysdep "$dep" && continue
-            install_name_tool -change "$dep" "@rpath/$(basename "$dep")" "$bin"
+            rewrite -change "$dep" "@rpath/$(basename "$dep")" "$bin"
         done <"$deplist"
         rp="@loader_path/$(uprefix "${bin%/*}")Frameworks"
         otool -l "$bin" | awk '/LC_RPATH/ {r = 1} r && $1 == "path" {print $2; r = 0}' >"$deplist"
-        grep -qxF "$rp" "$deplist" || install_name_tool -add_rpath "$rp" "$bin"
+        grep -qxF "$rp" "$deplist" || rewrite -add_rpath "$rp" "$bin"
         # install_name_tool invalidates the signature, and arm64 kills an unsigned Mach-O.
         codesign -f -s - "$bin"
     done <"$mach"

--- a/tools/macos-app.sh
+++ b/tools/macos-app.sh
@@ -123,6 +123,11 @@ rewrite() {
         fail "install_name_tool failed; link with LDFLAGS=-Wl,-headerpad_max_install_names"
 }
 
+# Resolves the directory, which is what Homebrew's opt -> Cellar symlink is.
+resolved() {
+    (cd "$(dirname "$1")" && printf '%s/%s\n' "$(pwd -P)" "$(basename "$1")")
+}
+
 # Each pass rescans, so a dylib pulled in by the last pass gets its own deps on the next.
 copy_dylibs() {
     mkdir -p "$fw"
@@ -138,11 +143,14 @@ copy_dylibs() {
         while IFS= read -r dep; do
             case "$dep" in @*) continue ;; esac
             sysdep "$dep" && continue
+            test -r "$dep" || fail "$dep is loaded by the bundle but is not readable here"
             base=$(basename "$dep")
             known=$(awk -v b="$base" '$1 == b {print $2}' "$fwmap")
             if [ -n "$known" ]; then
-                # Frameworks is flat, so two libraries under one name would clobber.
-                test "$known" = "$dep" || fail "$dep and $known are both named $base"
+                # Frameworks is flat, so two distinct libraries under one name would
+                # clobber; one library reached by two paths is fine.
+                test "$(resolved "$known")" = "$(resolved "$dep")" ||
+                    fail "$dep and $known are both named $base"
                 continue
             fi
             printf '%s\t%s\n' "$base" "$dep" >>"$fwmap"
@@ -150,7 +158,6 @@ copy_dylibs() {
         done <"$deplist"
         test -s "$list" || break
         while IFS= read -r dep; do
-            test -r "$dep" || fail "$dep is loaded by the bundle but is not readable here"
             cp "$dep" "$fw/"
             chmod u+w "$fw/$(basename "$dep")"
         done <"$list"

--- a/tools/macos-app.sh
+++ b/tools/macos-app.sh
@@ -59,7 +59,9 @@ prefix=$(cd "$prefix" && pwd -P)
 list=$(mktemp)
 mach=$(mktemp)
 deplist=$(mktemp)
-trap 'rm -f "$list" "$mach" "$deplist"' EXIT
+otmp=$(mktemp)
+fwmap=$(mktemp)
+trap 'rm -f "$list" "$mach" "$deplist" "$otmp" "$fwmap"' EXIT
 app="$out/HTTrack.app"
 rm -rf "$app"
 mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
@@ -93,19 +95,20 @@ sysdep() {
     return 1
 }
 
-# Mach-O files only, prefiltered so `file` is not run over the whole html payload.
+# Every file, not a prefilter: this list drives the copy, the relink and the audit alike.
 machos() {
-    find "$app/Contents" -type f \
-        \( -perm -u+x -o -name '*.dylib' -o -name '*.so' \) >"$list"
+    find "$app/Contents" -type f >"$list"
     : >"$mach"
     while IFS= read -r f; do
-        file "$f" | grep -q Mach-O && printf '%s\n' "$f" >>"$mach"
+        if file "$f" | grep -q Mach-O; then printf '%s\n' "$f" >>"$mach"; fi
     done <"$list"
 }
 
+# Only the indented lines are dependencies; a universal binary heads each slice.
 # A dylib's first entry is its own LC_ID_DYLIB, skipped like any satisfied dependency.
 deps() {
-    otool -L "$1" | tail -n +2 | awk '{print $1}'
+    otool -L "$1" >"$otmp" || fail "otool -L failed on $1"
+    awk '/^[[:space:]]/ {print $1}' "$otmp"
 }
 
 # One ../ per component below Contents, so the rpath is depth-correct wherever the loader sits.
@@ -123,6 +126,7 @@ rewrite() {
 # Each pass rescans, so a dylib pulled in by the last pass gets its own deps on the next.
 copy_dylibs() {
     mkdir -p "$fw"
+    : >"$fwmap"
     while :; do
         machos
         : >"$deplist"
@@ -134,7 +138,14 @@ copy_dylibs() {
         while IFS= read -r dep; do
             case "$dep" in @*) continue ;; esac
             sysdep "$dep" && continue
-            test -r "$fw/$(basename "$dep")" && continue
+            base=$(basename "$dep")
+            known=$(awk -v b="$base" '$1 == b {print $2}' "$fwmap")
+            if [ -n "$known" ]; then
+                # Frameworks is flat, so two libraries under one name would clobber.
+                test "$known" = "$dep" || fail "$dep and $known are both named $base"
+                continue
+            fi
+            printf '%s\t%s\n' "$base" "$dep" >>"$fwmap"
             printf '%s\n' "$dep" >>"$list"
         done <"$deplist"
         test -s "$list" || break
@@ -168,16 +179,13 @@ relink() {
     done <"$mach"
 }
 
-if [ "$(uname -s)" = Darwin ]; then
-    for t in otool install_name_tool codesign file; do
-        command -v "$t" >/dev/null 2>&1 ||
-            fail "$t not found -- install the Xcode command line tools"
-    done
-fi
-if command -v otool >/dev/null 2>&1; then
-    copy_dylibs
-    relink
-fi
+# Unconditional: shipping an unchecked bundle is worse than refusing to build one.
+for t in otool install_name_tool codesign file; do
+    command -v "$t" >/dev/null 2>&1 ||
+        fail "$t not found -- macOS bundling needs the Xcode command line tools"
+done
+copy_dylibs
+relink
 
 appreal=$(cd "$app" && pwd -P)
 
@@ -195,32 +203,30 @@ test -d "$app/Contents/Resources/share/httrack/html/server" ||
     fail "Contents/Resources/share/httrack/html/server missing"
 
 # A downloaded bundle resolves against macOS and itself; neither the staging prefix nor Homebrew is on the user's machine (#901).
-if command -v otool >/dev/null 2>&1; then
-    nmach=0
-    machos
-    while IFS= read -r bin; do
-        nmach=$((nmach + 1))
-        deps "$bin" >"$deplist"
-        while IFS= read -r dep; do
-            case "$dep" in
-            @rpath/*)
-                test -r "$fw/${dep#@rpath/}" ||
-                    fail "$bin loads $dep, absent from Contents/Frameworks"
-                continue
-                ;;
-            esac
-            sysdep "$dep" && continue
-            otool -L "$bin" >&2
-            case "$dep" in
-            "$prefix"/*)
-                fail "$bin links against the staging prefix (build with --disable-shared)"
-                ;;
-            esac
-            fail "$bin loads $dep from outside the bundle"
-        done <"$deplist"
-    done <"$mach"
-    test "$nmach" -gt 0 || fail "scanned no Mach-O files at all, the check proved nothing"
-fi
+nmach=0
+machos
+while IFS= read -r bin; do
+    nmach=$((nmach + 1))
+    deps "$bin" >"$deplist"
+    while IFS= read -r dep; do
+        case "$dep" in
+        @rpath/*)
+            test -r "$fw/${dep#@rpath/}" ||
+                fail "$bin loads $dep, absent from Contents/Frameworks"
+            continue
+            ;;
+        esac
+        sysdep "$dep" && continue
+        otool -L "$bin" >&2
+        case "$dep" in
+        "$prefix"/*)
+            fail "$bin links against the staging prefix (build with --disable-shared)"
+            ;;
+        esac
+        fail "$bin loads $dep from outside the bundle"
+    done <"$deplist"
+done <"$mach"
+test "$nmach" -gt 0 || fail "scanned no Mach-O files at all, the check proved nothing"
 
 # otool sees load commands only, so scan the text payload separately. The binaries
 # themselves still carry $(datadir) compiled in (#894), so they are not in scope here.


### PR DESCRIPTION
HTTrack.app carried Homebrew's OpenSSL as an external dependency, so a bundle that works on the machine that built it fails once downloaded: `configure.ac` links `-lcrypto -lssl`, and the bundle check only rejected the staging prefix, letting `/opt/homebrew` load commands through. `tools/macos-app.sh` now bundles the non-system dylib closure into `Contents/Frameworks` and relinks everything to resolve from the app itself.

The static check cannot fail on a machine that has Homebrew, since the loader finds the dylib whatever the load command says, so CI hides the kegs and reruns the smoke against the relocated bundle. That probe needs a positive control of its own: an empty `Frameworks` would otherwise sail through it.

This unblocks the signed DMG without delivering it. #901 stays open for the Developer ID certificate and notarization.