### PR TITLE
CI watchdog deadlines stretch under the starvation they exist to catch

### DIFF
--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -68,6 +68,22 @@ sleep 1
 ! grep -q "$tmp/90_wedged.test" <<<"$(ps -A -o args 2>/dev/null)" ||
     fail "the wedged test survived the guard"
 
+# --- the budget is wall clock, not a count of poll iterations ----------------
+# Starve the poll and a counted budget stretches with it: 10 polls of a 0.1s tick
+# become 40s, so the guard fires long after the step it was meant to beat (#795).
+(
+    starve_sleep "$tmp/starve" 4 || fail "could not install the slow sleep"
+    start=$SECONDS
+    rc=0
+    HTTRACK_TEST_TIMEOUT=1 bash "$driver" "$tmp/90_wedged.test" >"$out" 2>&1 || rc=$?
+    elapsed=$((SECONDS - start))
+    test "$rc" -eq 124 || fail "starved guard reported $rc, want 124"
+    # Generous: the diagnostics dump runs inside this window too. A counted
+    # budget needs 40s before it even starts dumping.
+    test "$elapsed" -lt 25 ||
+        fail "budget counted polls, not seconds: ${elapsed}s for a 1s budget"
+)
+
 # --- exit status and output of a healthy test pass straight through ----------
 # 77 is automake's SKIP and 99 its hard error, so both have to survive the wrapper.
 for want in 0 1 77 99; do

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -78,8 +78,7 @@ sleep 1
     HTTRACK_TEST_TIMEOUT=1 bash "$driver" "$tmp/90_wedged.test" >"$out" 2>&1 || rc=$?
     elapsed=$((SECONDS - start))
     test "$rc" -eq 124 || fail "starved guard reported $rc, want 124"
-    # Generous: the diagnostics dump runs inside this window too. A counted
-    # budget needs 40s before it even starts dumping.
+    # Generous: the diagnostics dump runs inside this window too.
     test "$elapsed" -lt 25 ||
         fail "budget counted polls, not seconds: ${elapsed}s for a 1s budget"
 )

--- a/tests/58_watchdog.test
+++ b/tests/58_watchdog.test
@@ -70,4 +70,22 @@ else
     test ! -e "$marker" || fail "watchdog left a grandchild running"
 fi
 
+# The deadline is wall clock, not a count of poll iterations. Under starvation an
+# iteration costs several times the second it asks for, so a counted deadline
+# stretches with it and the wedge outlives the CI step instead of being reported.
+(
+    starve_sleep "$tmp/starve" 4 || fail "could not install the slow sleep"
+    start=$SECONDS
+    rc=0
+    if is_windows; then
+        run_with_timeout 3 ping -n 60 127.0.0.1 || rc=$?
+    else
+        run_with_timeout 3 sleep 60 || rc=$?
+    fi
+    elapsed=$((SECONDS - start))
+    test "$rc" -eq 124 || fail "starved watchdog reported $rc, want 124"
+    test "$elapsed" -lt 9 ||
+        fail "deadline counted polls, not seconds: ${elapsed}s for a 3s budget"
+)
+
 echo "watchdog OK"

--- a/tests/58_watchdog.test
+++ b/tests/58_watchdog.test
@@ -70,11 +70,16 @@ else
     test ! -e "$marker" || fail "watchdog left a grandchild running"
 fi
 
-# The deadline is wall clock, not a count of poll iterations. Under starvation an
-# iteration costs several times the second it asks for, so a counted deadline
-# stretches with it and the wedge outlives the CI step instead of being reported.
+# Wall clock, not iteration count: under starvation a poll costs more than it asks,
+# so a counted deadline never fires before the CI step it was meant to beat.
 (
     starve_sleep "$tmp/starve" 4 || fail "could not install the slow sleep"
+    # Control: starvation must not make the watchdog kill work that is inside its
+    # budget. The command outlives several polls, so a guard that fires on the
+    # first one cannot pass this by exiting before it is ever looked at.
+    rc=0 && run_with_timeout 30 sleep 2 || rc=$?
+    test "$rc" -eq 0 || fail "starved watchdog killed a healthy command ($rc)"
+
     start=$SECONDS
     rc=0
     if is_windows; then
@@ -84,7 +89,10 @@ fi
     fi
     elapsed=$((SECONDS - start))
     test "$rc" -eq 124 || fail "starved watchdog reported $rc, want 124"
-    test "$elapsed" -lt 9 ||
+    # Never under budget, or a guard that kills everything on sight would pass.
+    test "$elapsed" -ge 3 || fail "the watchdog fired early (${elapsed}s of 3s)"
+    # One poll plus one reap, both stretched fourfold, is 8s; counting polls is 16s.
+    test "$elapsed" -lt 12 ||
         fail "deadline counted polls, not seconds: ${elapsed}s for a 3s budget"
 )
 

--- a/tests/test-timeout.sh
+++ b/tests/test-timeout.sh
@@ -60,11 +60,13 @@ else
     tick=0.1
 fi
 
-# Wall clock, not a tick count: under the starvation this exists to catch, an
-# iteration costs far more than $tick and a counted deadline never arrives.
+# Wall clock, not a tick count: under starvation an iteration costs far more than
+# $tick, so a counted deadline never arrives. Strictly greater, because $SECONDS
+# is floored: a reading of $budget can be a fraction under it, and firing early
+# kills a healthy test.
 start=$SECONDS
 while kill -0 "$pid" 2>/dev/null; do
-    if test "$((SECONDS - start))" -ge "$budget"; then
+    if test "$((SECONDS - start))" -gt "$budget"; then
         # The dump below can run for minutes. Say so where a suite watchdog is
         # watching, or the silence reads as a wedge and the step dies mid-stack.
         test -z "${HTTRACK_PROGRESS_LOG:-}" || echo "DUMP $name" >>"$HTTRACK_PROGRESS_LOG"

--- a/tests/test-timeout.sh
+++ b/tests/test-timeout.sh
@@ -55,14 +55,16 @@ test -n "$had_m" || test -n "$windows" || set +m
 # under MSYS fork costs tens of milliseconds, and a second is what the Windows
 # suite already paid before this wrapper existed.
 if test -n "$windows"; then
-    tick=1 per_sec=1
+    tick=1
 else
-    tick=0.1 per_sec=10
+    tick=0.1
 fi
 
-ticks=0
+# Wall clock, not a tick count: under the starvation this exists to catch, an
+# iteration costs far more than $tick and a counted deadline never arrives.
+start=$SECONDS
 while kill -0 "$pid" 2>/dev/null; do
-    if test "$((ticks / per_sec))" -ge "$budget"; then
+    if test "$((SECONDS - start))" -ge "$budget"; then
         # The dump below can run for minutes. Say so where a suite watchdog is
         # watching, or the silence reads as a wedge and the step dies mid-stack.
         test -z "${HTTRACK_PROGRESS_LOG:-}" || echo "DUMP $name" >>"$HTTRACK_PROGRESS_LOG"
@@ -74,6 +76,5 @@ while kill -0 "$pid" 2>/dev/null; do
         exit 124
     fi
     sleep "$tick"
-    ticks=$((ticks + 1))
 done
 wait "$pid"

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -310,17 +310,35 @@ dump_hang_diagnostics() {
     printf -- '===== end of diagnostics: %s =====\n' "$label"
 }
 
+# Put a `sleep` costing $2 times what it asks first on PATH, in dir $1: the CPU
+# starvation that stretches a poll iteration, which is what a deadline counting
+# those iterations mistakes for elapsed time (#795). Callers subshell it, as it
+# edits PATH. Sub-second requests round up to one, so a 0.1s poll stretches too.
+starve_sleep() {
+    local dir=$1 factor=$2 real
+    real=$(command -v sleep) || return 1
+    mkdir -p "$dir" || return 1
+    cat >"$dir/sleep" <<EOF
+#!/bin/sh
+n=\${1%%.*}
+test "\$n" -gt 0 2>/dev/null || n=1
+exec "$real" "\$((n * $factor))"
+EOF
+    chmod +x "$dir/sleep" || return 1
+    PATH="$dir:$PATH"
+    export PATH
+}
+
 # Collect a killed job, giving up after REAP_GRACE seconds. kill_tree can fail to
 # reap a native Windows descendant -- the very case these watchdogs exist for --
 # and a bare `wait` then blocks the watchdog itself forever, so the timeout it was
 # about to report is never printed and the whole suite wedges silently.
 REAP_GRACE=${REAP_GRACE:-10}
 reap_bounded() {
-    local pid=$1 waited=0
+    local pid=$1 start=$SECONDS
     while kill -0 "$pid" 2>/dev/null; do
-        test "$waited" -lt "$REAP_GRACE" || return 1
+        test "$((SECONDS - start))" -lt "$REAP_GRACE" || return 1
         sleep 1
-        waited=$((waited + 1))
     done
     wait "$pid" 2>/dev/null || true
     return 0
@@ -338,15 +356,14 @@ run_with_timeout() {
     "$@" &
     local pid=$!
     test -n "$had_m" || is_windows || set +m
-    local waited=0
+    local start=$SECONDS
     while kill -0 "$pid" 2>/dev/null; do
-        if test "$waited" -ge "$secs"; then
+        if test "$((SECONDS - start))" -ge "$secs"; then
             kill_tree "$pid"
             reap_bounded "$pid" || true
             return 124
         fi
         sleep 1
-        waited=$((waited + 1))
     done
     wait "$pid"
 }
@@ -354,15 +371,14 @@ run_with_timeout() {
 # Bound an already-backgrounded crawl (pid $1) at $2s, reaping it and returning 124
 # on overrun: a wedge past --max-time would else block wait() forever and hang the CI step.
 wait_bounded() {
-    local pid=$1 secs=$2 waited=0
+    local pid=$1 secs=$2 start=$SECONDS
     while kill -0 "$pid" 2>/dev/null; do
-        if test "$waited" -ge "$secs"; then
+        if test "$((SECONDS - start))" -ge "$secs"; then
             kill_tree "$pid"
             reap_bounded "$pid" || true
             return 124
         fi
         sleep 1
-        waited=$((waited + 1))
     done
     wait "$pid"
 }

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -310,10 +310,9 @@ dump_hang_diagnostics() {
     printf -- '===== end of diagnostics: %s =====\n' "$label"
 }
 
-# Put a `sleep` costing $2 times what it asks first on PATH, in dir $1: the CPU
-# starvation that stretches a poll iteration, which is what a deadline counting
-# those iterations mistakes for elapsed time (#795). Callers subshell it, as it
-# edits PATH. Sub-second requests round up to one, so a 0.1s poll stretches too.
+# Install a `sleep` in dir $1 costing $2 times what it asks, simulating the CPU
+# starvation that stretches a poll iteration. Callers must subshell it (it edits
+# PATH); sub-second requests round up to 1s, so a 0.1s poll stretches too.
 starve_sleep() {
     local dir=$1 factor=$2 real
     real=$(command -v sleep) || return 1
@@ -337,7 +336,7 @@ REAP_GRACE=${REAP_GRACE:-10}
 reap_bounded() {
     local pid=$1 start=$SECONDS
     while kill -0 "$pid" 2>/dev/null; do
-        test "$((SECONDS - start))" -lt "$REAP_GRACE" || return 1
+        test "$((SECONDS - start))" -le "$REAP_GRACE" || return 1
         sleep 1
     done
     wait "$pid" 2>/dev/null || true
@@ -347,6 +346,8 @@ reap_bounded() {
 # Run "$@" under a wall-clock deadline of $1 seconds; return its exit status, or
 # 124 if it overran and was killed. timeout(1) is unusable here: it's absent on
 # macOS and its signals can't reap httrack.exe on Windows. We poll and kill_tree.
+# All three deadlines below compare strictly: $SECONDS is floored, so a reading of
+# the budget can be a fraction under it, and firing early kills healthy work.
 run_with_timeout() {
     local secs=$1
     shift
@@ -358,7 +359,7 @@ run_with_timeout() {
     test -n "$had_m" || is_windows || set +m
     local start=$SECONDS
     while kill -0 "$pid" 2>/dev/null; do
-        if test "$((SECONDS - start))" -ge "$secs"; then
+        if test "$((SECONDS - start))" -gt "$secs"; then
             kill_tree "$pid"
             reap_bounded "$pid" || true
             return 124
@@ -373,7 +374,7 @@ run_with_timeout() {
 wait_bounded() {
     local pid=$1 secs=$2 start=$SECONDS
     while kill -0 "$pid" 2>/dev/null; do
-        if test "$((SECONDS - start))" -ge "$secs"; then
+        if test "$((SECONDS - start))" -gt "$secs"; then
             kill_tree "$pid"
             reap_bounded "$pid" || true
             return 124


### PR DESCRIPTION
Every deadline in the test harness counts poll iterations and assumes each one costs the tick it asked for. Under the CPU and fork starvation those deadlines exist to catch, an iteration costs several times that, so the budget arrives late in wall-clock terms or not at all. The workflow's 45-minute step timeout cancels first, and a cancelled step keeps neither its log nor the artifacts the `if: always()` steps would upload, which is why the wedged Windows jobs in #795 name no test. `test-timeout.sh`, `run_with_timeout`, `wait_bounded` and `reap_bounded` now measure `$SECONDS`, compared strictly because `$SECONDS` is floored and a reading equal to the budget can be a fraction under it, and firing early kills healthy work.

Both new guards were checked against reverted and deliberately broken copies rather than trusted. With a shim stretching every `sleep` fourfold, the counting code takes 44s to honour a 1s budget and 16s a 3s one. An early version of the watchdog guard passed on a watchdog that killed everything on sight, so it now carries a control that outlives several polls. This doesn't cure #795 outright, since a runner that truly loses communication still takes the job with it, but it lets the watchdog fire first and name the test, which none of today's four wedges did.
