### PR TITLE
The macOS bundle declares a minimum OS that nothing checks

### DIFF
--- a/tools/Info.plist.in
+++ b/tools/Info.plist.in
@@ -22,9 +22,9 @@
 	<string>@PACKAGE_VERSION@</string>
 	<key>CFBundleVersion</key>
 	<string>@PACKAGE_VERSION@</string>
-	<!-- Rewritten by macos-app.sh from the load commands of the assembled payload. -->
+	<!-- macos-app.sh fails the build unless the payload's load commands agree. -->
 	<key>LSMinimumSystemVersion</key>
-	<string>11.0</string>
+	<string>15.0</string>
 	<!-- Not background-only: the UI opens in the user's default browser. -->
 	<key>LSBackgroundOnly</key>
 	<false/>

--- a/tools/Info.plist.in
+++ b/tools/Info.plist.in
@@ -22,6 +22,7 @@
 	<string>@PACKAGE_VERSION@</string>
 	<key>CFBundleVersion</key>
 	<string>@PACKAGE_VERSION@</string>
+	<!-- Rewritten by macos-app.sh from the load commands of the assembled payload. -->
 	<key>LSMinimumSystemVersion</key>
 	<string>11.0</string>
 	<!-- Not background-only: the UI opens in the user's default browser. -->

--- a/tools/Info.plist.in
+++ b/tools/Info.plist.in
@@ -22,7 +22,7 @@
 	<string>@PACKAGE_VERSION@</string>
 	<key>CFBundleVersion</key>
 	<string>@PACKAGE_VERSION@</string>
-	<!-- macos-app.sh fails the build unless the payload's load commands agree. -->
+	<!-- macos-app.sh checks this against the built payload. -->
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<!-- Not background-only: the UI opens in the user's default browser. -->

--- a/tools/macos-app.sh
+++ b/tools/macos-app.sh
@@ -196,15 +196,7 @@ cc -O2 -Wall -Wextra -Werror -Wl,-headerpad_max_install_names \
 
 copy_dylibs
 relink
-# Finder believes LSMinimumSystemVersion and dyld ignores it, so derive it from what
-# the payload can actually load: one bottled dylib built on a newer runner raises the
-# floor for the whole bundle.
-machos
-minos=$(macho_floor "$mach")
-test -n "$minos" || fail "no Mach-O in the bundle declares a minimum macOS"
-plist_set "$app/Contents/Info.plist" LSMinimumSystemVersion "$minos"
-
-# Last, so the seal covers every file the three rewrote. Signing the bundle is also
+# Last, so the seal covers every file the two rewrote. Signing the bundle is also
 # what signs the main executable, which codesign will not take on its own.
 codesign -f -s - "$app"
 
@@ -283,9 +275,14 @@ test "$plistver" = "$binver" ||
 bundlever=$(plist_value "$app/Contents/Info.plist" CFBundleVersion)
 test "$bundlever" = "$binver" ||
     fail "CFBundleVersion says $bundlever, httrack says $binver"
-# Catches a plist_set that matched no key, which is silent by design.
+# Finder refuses on LSMinimumSystemVersion and dyld refuses on the load commands, so a
+# bottled dylib built for a newer OS silently raises the real floor above the declared
+# one. Asserted rather than derived: the shipped minimum is a decision, not a side effect
+# of which runner image built it.
+minos=$(macho_floor "$mach") || fail "could not read a minimum macOS out of the payload"
+test -n "$minos" || fail "no Mach-O in the bundle declares a minimum macOS"
 plistmin=$(plist_value "$app/Contents/Info.plist" LSMinimumSystemVersion)
 test "$plistmin" = "$minos" ||
-    fail "LSMinimumSystemVersion says $plistmin, the payload needs $minos"
+    fail "Info.plist declares macOS $plistmin, the payload needs $minos"
 
 echo "built $appreal (version $plistver, macOS $minos and later)"

--- a/tools/macos-app.sh
+++ b/tools/macos-app.sh
@@ -196,7 +196,15 @@ cc -O2 -Wall -Wextra -Werror -Wl,-headerpad_max_install_names \
 
 copy_dylibs
 relink
-# Last, so the seal covers every file the two rewrote. Signing the bundle is also
+# Finder believes LSMinimumSystemVersion and dyld ignores it, so derive it from what
+# the payload can actually load: one bottled dylib built on a newer runner raises the
+# floor for the whole bundle.
+machos
+minos=$(macho_floor "$mach")
+test -n "$minos" || fail "no Mach-O in the bundle declares a minimum macOS"
+plist_set "$app/Contents/Info.plist" LSMinimumSystemVersion "$minos"
+
+# Last, so the seal covers every file the three rewrote. Signing the bundle is also
 # what signs the main executable, which codesign will not take on its own.
 codesign -f -s - "$app"
 
@@ -275,5 +283,9 @@ test "$plistver" = "$binver" ||
 bundlever=$(plist_value "$app/Contents/Info.plist" CFBundleVersion)
 test "$bundlever" = "$binver" ||
     fail "CFBundleVersion says $bundlever, httrack says $binver"
+# Catches a plist_set that matched no key, which is silent by design.
+plistmin=$(plist_value "$app/Contents/Info.plist" LSMinimumSystemVersion)
+test "$plistmin" = "$minos" ||
+    fail "LSMinimumSystemVersion says $plistmin, the payload needs $minos"
 
-echo "built $appreal (version $plistver)"
+echo "built $appreal (version $plistver, macOS $minos and later)"

--- a/tools/macos-app.sh
+++ b/tools/macos-app.sh
@@ -275,10 +275,8 @@ test "$plistver" = "$binver" ||
 bundlever=$(plist_value "$app/Contents/Info.plist" CFBundleVersion)
 test "$bundlever" = "$binver" ||
     fail "CFBundleVersion says $bundlever, httrack says $binver"
-# Finder refuses on LSMinimumSystemVersion and dyld refuses on the load commands, so a
-# bottled dylib built for a newer OS silently raises the real floor above the declared
-# one. Asserted rather than derived: the shipped minimum is a decision, not a side effect
-# of which runner image built it.
+# A bottled dylib's floor can exceed what the plist declares, and Finder only reads the
+# plist. The mismatch fails the build rather than being reconciled behind our backs.
 minos=$(macho_floor "$mach") || fail "could not read a minimum macOS out of the payload"
 test -n "$minos" || fail "no Mach-O in the bundle declares a minimum macOS"
 plistmin=$(plist_value "$app/Contents/Info.plist" LSMinimumSystemVersion)

--- a/tools/macos-bundle.sh
+++ b/tools/macos-bundle.sh
@@ -23,22 +23,13 @@ plist_value() {
         getline; gsub(/^[^>]*>|<[^<]*$/, ""); print; exit }' "$1"
 }
 
-# Rewrite the string value of key $2 in the plist $1 to $3. A missing key is silent,
-# so callers check the result rather than trust it.
-plist_set() {
-    _mb_tmp=$(mktemp)
-    awk -v k="$2" -v v="$3" '
-        { if (_p) { sub(/>[^<]*</, ">" v "<"); _p = 0 } print }
-        $0 ~ "<key>" k "</key>" { _p = 1 }' "$1" >"$_mb_tmp"
-    cat "$_mb_tmp" >"$1"
-    rm -f "$_mb_tmp"
-}
-
-# The oldest macOS every Mach-O listed in the file $1 can load on.
+# The oldest macOS every Mach-O listed in the file $1 can load on, empty if none says.
+# Nonzero when otool fails, which would otherwise drop that binary and lower the floor.
 macho_floor() {
     _mb_floor=
     while IFS= read -r _mb_bin; do
-        for _mb_v in $(otool -l "$_mb_bin" | awk '
+        _mb_cmds=$(otool -l "$_mb_bin") || return 1
+        for _mb_v in $(printf '%s\n' "$_mb_cmds" | awk '
             $1 == "cmd" { c = $2 }
             (c == "LC_BUILD_VERSION" && $1 == "minos") ||
             (c == "LC_VERSION_MIN_MACOSX" && $1 == "version") { print $2 }'); do

--- a/tools/macos-bundle.sh
+++ b/tools/macos-bundle.sh
@@ -23,6 +23,32 @@ plist_value() {
         getline; gsub(/^[^>]*>|<[^<]*$/, ""); print; exit }' "$1"
 }
 
+# Rewrite the string value of key $2 in the plist $1 to $3. A missing key is silent,
+# so callers check the result rather than trust it.
+plist_set() {
+    _mb_tmp=$(mktemp)
+    awk -v k="$2" -v v="$3" '
+        { if (_p) { sub(/>[^<]*</, ">" v "<"); _p = 0 } print }
+        $0 ~ "<key>" k "</key>" { _p = 1 }' "$1" >"$_mb_tmp"
+    cat "$_mb_tmp" >"$1"
+    rm -f "$_mb_tmp"
+}
+
+# The oldest macOS every Mach-O listed in the file $1 can load on.
+macho_floor() {
+    _mb_floor=
+    while IFS= read -r _mb_bin; do
+        for _mb_v in $(otool -l "$_mb_bin" | awk '
+            $1 == "cmd" { c = $2 }
+            (c == "LC_BUILD_VERSION" && $1 == "minos") ||
+            (c == "LC_VERSION_MIN_MACOSX" && $1 == "version") { print $2 }'); do
+            _mb_floor=$(printf '%s\n%s\n' "$_mb_floor" "$_mb_v" |
+                sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+        done
+    done <"$1"
+    printf '%s\n' "$_mb_floor"
+}
+
 # The bundle's main executable. codesign resolves it to the enclosing bundle, so it
 # is signed and verified with the bundle, never on its own.
 main_executable() {


### PR DESCRIPTION
The DMG says it runs on macOS 11 and it does not. `tools/Info.plist.in` declared `LSMinimumSystemVersion` 11.0, but no `MACOSX_DEPLOYMENT_TARGET` is set anywhere, so clang on the `macos-15` runner targeted the host: every one of the nine Mach-Os in the released image reports `minos 15.0`. Finder trusts the plist, launches on 11 through 14, and hands the user a dyld failure.

The plist now declares 15.0 and `macos-app.sh` fails the build when the assembled payload disagrees. Asserting rather than deriving is deliberate: the shipped minimum should be a decision recorded in the tree, not a side effect of which runner image happened to build the bundle. It takes the highest floor in the bundle, because five of the nine are Homebrew bottles whose own minimum was fixed when the bottle was built, so a deployment target on our code alone would leave `libcrypto` refusing to load anyway. Lowering the floor for real means building openssl, brotli and zstd from source, which is a separate question from telling the truth about where we are.

The `macos-app` leg runs this on every PR.

Follow-up for #901: the DMG on run 30855293254 carries the old plist and wants rebuilding before anyone links to it.