### PR TITLE
Every Windows push starts a run that outlives the ones before it

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -15,6 +15,11 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on the same branch or PR.
+concurrency:
+  group: windows-build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   libhttrack:
     runs-on: windows-2022


### PR DESCRIPTION
windows-build.yml gets the same concurrency group ci.yml and codeql.yml already use, so a new push cancels the runs it supersedes instead of leaving three Win32 legs to fight over the runners, as happened on 2026-08-03. That reduces exposure to the #795 hang and contention on the shared vcpkg binary cache; it does not fix the hang, which hits roughly 5% of jobs whether or not another run is in flight.

Closes #942