### PR TITLE
Nothing validates the AppStream metainfo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,8 +715,9 @@ jobs:
           sudo apt-get update
           # noble ships shfmt 3.8.0 (universe), matching the pinned local dev
           # version; use it rather than fetching a release binary from github.com.
-          sudo apt-get install -y --no-install-recommends shellcheck shfmt
+          sudo apt-get install -y --no-install-recommends shellcheck shfmt appstream
           shfmt --version
+          appstreamcli --version
 
       - name: shellcheck
         run: shellcheck $SHELL_SCRIPTS
@@ -733,6 +734,14 @@ jobs:
             python3 -c "import sys,xml.dom.minidom; xml.dom.minidom.parse(sys.argv[1])" "$f"
             echo "ok $f"
           done
+
+      # A software centre quietly ignores a metainfo it cannot parse. Errors and
+      # warnings fail; --no-net so the gate is on the file, not httrack.com's uptime.
+      - name: AppStream metainfo validation
+        run: |
+          set -euo pipefail
+          appstreamcli validate --no-net --explain \
+            html/server/div/com.httrack.WebHTTrack.metainfo.xml
 
   # Check clang-format on CHANGED LINES ONLY. The engine predates clang-format
   # (it was shaped by an old Visual Studio formatter) and does not round-trip,

--- a/tests/210_appstream-metainfo.test
+++ b/tests/210_appstream-metainfo.test
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# The metainfo installs to usr/share/metainfo; a software centre that cannot
+# parse it just drops WebHTTrack, with no error anyone sees.
+
+set -euo pipefail
+
+srcdir="${abs_top_srcdir:?not run under make check}"
+metainfo="${srcdir}/html/server/div/com.httrack.WebHTTrack.metainfo.xml"
+
+command -v appstreamcli >/dev/null 2>&1 || {
+    echo "appstreamcli not installed; skipping" >&2
+    exit 77
+}
+test -f "${metainfo}" || {
+    echo "FAIL: ${metainfo} not found" >&2
+    exit 1
+}
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/appstream.XXXXXX") || {
+    echo "no tmpdir" >&2
+    exit 1
+}
+trap 'set +e; rm -rf "${work}"' EXIT
+
+# --no-net: validate the file, not the reachability of the screenshot host.
+validate() { appstreamcli validate --no-net --explain "$1"; }
+
+validate "${metainfo}" || {
+    echo "FAIL: metainfo does not validate" >&2
+    exit 1
+}
+
+# Positive control: an appstreamcli that never fails would pass the above.
+grep -v '<id>com.httrack.WebHTTrack</id>' "${metainfo}" >"${work}/noid.xml"
+if validate "${work}/noid.xml" >"${work}/noid.log" 2>&1; then
+    echo "FAIL: metainfo without <id> validated; the check proves nothing" >&2
+    exit 1
+fi
+grep -q component-id-missing "${work}/noid.log" ||
+    echo "note: id-less copy failed for another reason: $(tail -3 "${work}/noid.log")" >&2
+
+echo "appstream metainfo: valid"

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -233,3 +233,4 @@ TESTS += 162_zlib-cache-urlbounds.test
 TESTS += 164_local-proxytrack-arc-hostile.test
 TESTS += 171_watchdog-heartbeat.test
 TESTS += 172_ci-windows-driver.test
+TESTS += 210_appstream-metainfo.test


### PR DESCRIPTION
The metainfo installs to `usr/share/metainfo`, where GNOME Software and KDE Discover read it. #897 pinned its version against `htsglobal.h`, but a file broken in any other way still passes the suite: the software centre just drops WebHTTrack, silently. The lint job now runs `appstreamcli validate` beside the existing `.vcxproj` well-formedness pass, and `tests/210_appstream-metainfo.test` runs the same check under `make check` (skipping when appstreamcli is not installed) so you can catch it before pushing.

`--no-net` because the default fetches the screenshot URL, which would tie every PR to httrack.com being reachable. The gate is appstreamcli's default severity: errors and warnings fail, infos and pedantic hints do not. `--pedantic` would not work here regardless, since the single hint the file raises is `cid-contains-uppercase-letter` and the component ID has to match `WebHTTrack.desktop`.

The file validates clean today, so nothing in it needed changing. The test carries a positive control: it also validates a copy with `<id>` removed and fails if that one passes, so a validator that never fails cannot turn the check into a green tick that means nothing.

The `.49-9` header in history.txt turned out to be already fixed, by #897 itself. Every other block header in the file is well-formed.

Closes #903
