### PR TITLE
An in-tree build leaves generated files untracked, tools/Info.plist among them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ Makefile.in
 /src/webhttrack
 Makefile
 .deps/
+.dirstamp
 .libs/
 *.o
 *.lo
@@ -35,6 +36,15 @@ Makefile
 *.so
 *.so.*
 *.a
+
+# Built into the checkout by an in-tree "make" / "make check".
+/src/httrack
+/src/htsserver
+/src/proxytrack
+/tools/Info.plist
+/tests/stringoom
+/tests/*.log
+/tests/*.trs
 
 # make dist output; dist/ holds httrack-gh-release staging artifacts.
 /httrack-*.tar.gz


### PR DESCRIPTION
`tools/Info.plist` is the one that matters: configure generates it from `Info.plist.in`, so a stray `git add -A` would commit a snapshot that shadows the generated file and pins `CFBundleShortVersionString` to whatever version built it, which is how #884 went wrong one directory over. This ignores it, plus the three `src/` binaries, the automake `.dirstamp` files and the `make check` logs, so `git status` stays readable in a source-tree build.

Closes #905