### PR TITLE
Nine lang.def strings are untranslated in 26 of the 30 language files

### DIFF
--- a/lang/Bulgarian.txt
+++ b/lang/Bulgarian.txt
@@ -186,6 +186,8 @@ scanning
 сканира
 Waiting for scheduled time..
 Очаква зададеното време за начало...
+Transferring data..
+Прехвърляне на данни..
 Connecting to provider
 Свързване към доставчика
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 Създай стартова страница
 Create a word database of all html pages
 Създай база данни с думите от всички html страници
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Създай пълен пощенски архив RFC822 (MHT/EML) на огледалото
 Create error logging and report files
 Създай файлове за отчети и запис на грешките
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 Идентификация на браузъра
 Comment to be placed in each HTML file
 Да бъде поставен коментар във всеки HTML файл
+Languages accepted by the browser
+Езици, приемани от браузъра
+Additional HTTP headers to be sent in each requests
+Допълнителни HTTP заглавки, изпращани при всяка заявка
+HTTP referer to be sent for initial URLs
+HTTP referer, изпращан за началните адреси
 Back to starting page
 Назад към стартовата страница
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Създай индекс
 Make a word database
 Създай база данни с думи
+Build a mail archive
+Създай пощенски архив
 Log files
 Log файлове
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Идентичност
 HTML footer
 HTML край (footer)
+Languages
+Езици
+Additional HTTP Headers
+Допълнителни HTTP заглавки
+Default referer URL
+Подразбиращ се referer адрес
 N# connections
 Брой връзки
 Abandon host if error

--- a/lang/Castellano.txt
+++ b/lang/Castellano.txt
@@ -186,6 +186,8 @@ scanning
 recorriendo
 Waiting for scheduled time..
 Esperando a la hora especificada para comenzar
+Transferring data..
+Transfiriendo datos..
 Connecting to provider
 Conexión con el proveedor
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 Generar página de inicio
 Create a word database of all html pages
 Crear una base de datos de palabras de todas las páginas HTML
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Crear un archivo de correo RFC822 (MHT/EML) completo de la copia
 Create error logging and report files
 Generar ficheros de auditoría para los errores y mensajes
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 Identidad del navegador
 Comment to be placed in each HTML file
 Pie de página colocado en cada fichero HTML
+Languages accepted by the browser
+Idiomas aceptados por el navegador
+Additional HTTP headers to be sent in each requests
+Cabeceras HTTP adicionales a enviar en cada petición
+HTTP referer to be sent for initial URLs
+Referer HTTP a enviar para las URL iniciales
 Back to starting page
 Volver a la primera página
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Hacer un índice
 Make a word database
 Elaborar una base de datos de palabras
+Build a mail archive
+Crear un archivo de correo
 Log files
 Ficheros auditoría
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Identidad
 HTML footer
 Pie de página HTML
+Languages
+Idiomas
+Additional HTTP Headers
+Cabeceras HTTP adicionales
+Default referer URL
+URL de referer por defecto
 N# connections
 Nº de conexiones
 Abandon host if error

--- a/lang/Cesky.txt
+++ b/lang/Cesky.txt
@@ -186,6 +186,8 @@ scanning
 provìøování
 Waiting for scheduled time..
 Èekání na naplánovaný èas..
+Transferring data..
+Pøenos dat..
 Connecting to provider
 Pøipojování k poskytovateli
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 Vytvoøit úvodní stránku
 Create a word database of all html pages
 Vytvoøit seznam slov ze všech HTML stránek
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Vytvoøit úplný poštovní archiv RFC822 (MHT/EML) staženého webu
 Create error logging and report files
 Vytvoøit protokol s chybami a hlášeními
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 Totožnost prohlížeèe
 Comment to be placed in each HTML file
 Komentáø vložený do každého HTML souboru
+Languages accepted by the browser
+Jazyky pøijímané prohlížeèem
+Additional HTTP headers to be sent in each requests
+Další hlavièky HTTP odesílané v každém požadavku
+HTTP referer to be sent for initial URLs
+Hlavièka HTTP referer odesílaná pro poèáteèní adresy URL
 Back to starting page
 Zpìt na úvodní stránku
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Vytvoøit rejstøík
 Make a word database
 Vytvoøit seznam slov
+Build a mail archive
+Vytvoøit poštovní archiv
 Log files
 Protokoly
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Identifikace
 HTML footer
 Záhlaví HTML
+Languages
+Jazyky
+Additional HTTP Headers
+Další hlavièky HTTP
+Default referer URL
+Výchozí adresa referer
 N# connections
 Poèet spojení
 Abandon host if error

--- a/lang/Chinese-BIG5.txt
+++ b/lang/Chinese-BIG5.txt
@@ -186,6 +186,8 @@ scanning
 掃描
 Waiting for scheduled time..
 等待預定的時間..
+Transferring data..
+傳送資料..
 Connecting to provider
 正在連線網路
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 新增一個起始頁面
 Create a word database of all html pages
 為所有html頁建造一個文字數據庫
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+建立鏡像的完整 RFC822 郵件封存檔 (MHT/EML)
 Create error logging and report files
 新增錯誤記錄及報告檔案
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 瀏覽器身份
 Comment to be placed in each HTML file
 在每個HTML檔案裏增加的注釋
+Languages accepted by the browser
+瀏覽器接受的語言
+Additional HTTP headers to be sent in each requests
+每次要求時額外傳送的 HTTP 標頭
+HTTP referer to be sent for initial URLs
+起始網址所傳送的 HTTP referer
 Back to starting page
 回到起始頁面
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 新增一個 index.html 檔案
 Make a word database
 建造一個文字數據庫
+Build a mail archive
+建立郵件封存檔
 Log files
 日誌檔案
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 身份
 HTML footer
 HTML頁腳
+Languages
+語言
+Additional HTTP Headers
+額外的 HTTP 標頭
+Default referer URL
+預設的 referer 網址
 N# connections
 連線數
 Abandon host if error

--- a/lang/Chinese-Simplified.txt
+++ b/lang/Chinese-Simplified.txt
@@ -186,6 +186,8 @@ scanning
 扫描
 Waiting for scheduled time..
 等待预定的时间..
+Transferring data..
+传送数据..
 Connecting to provider
 正在连接网络
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 创建一个起始页面
 Create a word database of all html pages
 根据网页使用语言创建词汇库文件
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+创建镜像的完整 RFC822 邮件归档 (MHT/EML)
 Create error logging and report files
 创建错误记录及汇报文件
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 浏览器身份
 Comment to be placed in each HTML file
 在每个HTML文件里添加的注释
+Languages accepted by the browser
+浏览器接受的语言
+Additional HTTP headers to be sent in each requests
+每次请求时额外发送的 HTTP 头
+HTTP referer to be sent for initial URLs
+起始网址所发送的 HTTP referer
 Back to starting page
 回到起始页面
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 创建一个 index.html 文件
 Make a word database
 创建词汇库
+Build a mail archive
+创建邮件归档
 Log files
 日志文件
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 身份
 HTML footer
 HTML页脚
+Languages
+语言
+Additional HTTP Headers
+额外的 HTTP 头
+Default referer URL
+默认的 referer 网址
 N# connections
 连接数
 Abandon host if error

--- a/lang/Croatian.txt
+++ b/lang/Croatian.txt
@@ -372,6 +372,8 @@ Create a Start Page
 Napraviti poèetnu stranicu
 Create a word database of all html pages
 Napraviti spisak rijeèi sa svih stranica HTML-a
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Izraditi potpunu po¹tansku arhivu RFC822 (MHT/EML) zrcala
 Create error logging and report files
 Napraviti datoteke zapisnika pogrešaka i izvješæa o tijeku postupka
 Generate DOS 8-3 filenames ONLY
@@ -420,6 +422,12 @@ Browser identity
 Preglednièko obilježje
 Comment to be placed in each HTML file
 Komentar koji æe biti smješten u svakoj datoteci HTML-a
+Languages accepted by the browser
+Jezici koje prihvaæa preglednik
+Additional HTTP headers to be sent in each requests
+Dodatna HTTP zaglavlja koja se ¹alju u svakom zahtjevu
+HTTP referer to be sent for initial URLs
+HTTP referer koji se ¹alje za poèetne URL-ove
 Back to starting page
 Natrag na poèetnu stranicu
 Save current preferences as default values
@@ -480,6 +488,8 @@ Make an index
 Napraviti kazalo
 Make a word database
 Napraviti spisak rijeèi
+Build a mail archive
+Izraditi po¹tansku arhivu
 Log files
 Zapisnièke datoteke
 DOS names (8+3)
@@ -508,6 +518,12 @@ Identity
 Obilježje
 HTML footer
 Podnožje HTML-a
+Languages
+Jezici
+Additional HTTP Headers
+Dodatna HTTP zaglavlja
+Default referer URL
+Zadani referer URL
 N# connections
 Broj veza
 Abandon host if error

--- a/lang/Deutsch.txt
+++ b/lang/Deutsch.txt
@@ -186,6 +186,8 @@ scanning
 scannen
 Waiting for scheduled time..
 Eingestellte Startzeit abwarten
+Transferring data..
+Daten werden übertragen..
 Connecting to provider
 Verbindung aufbauen
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 Startseite erstellen
 Create a word database of all html pages
 Liste mit allen Wörtern in den HTML-Seiten anlegen
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Vollständiges RFC822-Mailarchiv (MHT/EML) der Site-Kopie erstellen
 Create error logging and report files
 Fehlerprotokoll und Ablaufbericht erstellen
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 Browser-Kennung
 Comment to be placed in each HTML file
 Kommentar, einzufügen in jede HTML-Datei
+Languages accepted by the browser
+Vom Browser akzeptierte Sprachen
+Additional HTTP headers to be sent in each requests
+Zusätzliche HTTP-Header, die in jeder Anfrage gesendet werden
+HTTP referer to be sent for initial URLs
+HTTP-Referer, der für die Start-URLs gesendet wird
 Back to starting page
 Zurück zur Startseite
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Index erstellen
 Make a word database
 Wortliste anlegen
+Build a mail archive
+Mailarchiv erstellen
 Log files
 Protokolldateien
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Identität
 HTML footer
 HTML-Fußzeile
+Languages
+Sprachen
+Additional HTTP Headers
+Zusätzliche HTTP-Header
+Default referer URL
+Standard-Referer-URL
 N# connections
 Anzahl Verbindungen
 Abandon host if error

--- a/lang/Eesti.txt
+++ b/lang/Eesti.txt
@@ -186,6 +186,8 @@ scanning
 skaneerimine
 Waiting for scheduled time..
 Etteantud aja ootamine...
+Transferring data..
+Andmete edastamine..
 Connecting to provider
 Ühendusevõtmine
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 Tee alguslehekülg
 Create a word database of all html pages
 Loo kõigi HTML-lehekülgede sõnade andmebaas
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Koopia täieliku RFC822 kirjaarhiivi (MHT/EML) koostamine
 Create error logging and report files
 Tee vealogi ja raporti failid
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 Brauseri identiteet
 Comment to be placed in each HTML file
 Kommentaar, mis lisatakse igale HTML-failile
+Languages accepted by the browser
+Brauseri aktsepteeritavad keeled
+Additional HTTP headers to be sent in each requests
+Täiendavad HTTP-päised, mis saadetakse iga päringuga
+HTTP referer to be sent for initial URLs
+Algsete URL-ide jaoks saadetav HTTP referer
 Back to starting page
 Tagasi alguslehele
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Tee indeks
 Make a word database
 Tee sõnade andmebaas
+Build a mail archive
+Tee kirjaarhiiv
 Log files
 Logifailid
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Identiteet
 HTML footer
 HTML-i jalus
+Languages
+Keeled
+Additional HTTP Headers
+Täiendavad HTTP-päised
+Default referer URL
+Vaikimisi referer-URL
 N# connections
 Ühenduste arv
 Abandon host if error

--- a/lang/Finnish.txt
+++ b/lang/Finnish.txt
@@ -372,6 +372,8 @@ Create a Start Page
 Luo aloitussivu
 Create a word database of all html pages
 Luo sanatietokanta kaikista html-sivuista
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Luo peilistä täydellinen RFC822-postiarkisto (MHT/EML)
 Create error logging and report files
 Luo virheloki- ja raporttitiedostot
 Generate DOS 8-3 filenames ONLY
@@ -420,6 +422,12 @@ Browser identity
 Esittäydy selaimena
 Comment to be placed in each HTML file
 Jokaiseen HTML-tiedostoon pantava kommentti
+Languages accepted by the browser
+Selaimen hyväksymät kielet
+Additional HTTP headers to be sent in each requests
+Lisäotsakkeet, jotka lähetetään jokaisessa HTTP-pyynnössä
+HTTP referer to be sent for initial URLs
+Alkuperäisille URL-osoitteille lähetettävä HTTP-referer
 Back to starting page
 Palaa aloitussivulle
 Save current preferences as default values
@@ -480,6 +488,8 @@ Make an index
 Tee indeksi
 Make a word database
 Tee sanatietokanta
+Build a mail archive
+Tee postiarkisto
 Log files
 Lokitiedostot
 DOS names (8+3)
@@ -508,6 +518,12 @@ Identity
 Esittäydy
 HTML footer
 HTML-alatunniste
+Languages
+Kielet
+Additional HTTP Headers
+HTTP-lisäotsakkeet
+Default referer URL
+Oletusarvoinen referer-URL
 N# connections
 Yhteyksiä
 Abandon host if error

--- a/lang/Greek.txt
+++ b/lang/Greek.txt
@@ -372,6 +372,8 @@ Create a Start Page
 Δημιουργία αρχικής σελίδας
 Create a word database of all html pages
 Δημιουργία λίστας λέξεων από όλες τις σελίδες html
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Δημιουργία πλήρους αρχείου αλληλογραφίας RFC822 (MHT/EML) του αντιγράφου
 Create error logging and report files
 Δημιουργία αρχείου καταγραφής λαθών και αναφοράς
 Generate DOS 8-3 filenames ONLY
@@ -420,6 +422,12 @@ Browser identity
 Ταυτότητα που θα δηλώνει ο εξερευνητής
 Comment to be placed in each HTML file
 Σχόλια που θα τοποθετηθούν σε κάθε αρχείο HTML
+Languages accepted by the browser
+Γλώσσες που δέχεται ο εξερευνητής
+Additional HTTP headers to be sent in each requests
+Πρόσθετες κεφαλίδες HTTP που θα στέλνονται σε κάθε αίτηση
+HTTP referer to be sent for initial URLs
+HTTP referer που θα στέλνεται για τις αρχικές διευθύνσεις URL
 Back to starting page
 Πίσω στην αρχική σελίδα
 Save current preferences as default values
@@ -480,6 +488,8 @@ Make an index
 Δημιουργία ευρετηρίου
 Make a word database
 Δημιουργία βάσης-δεδομένων λέξεων
+Build a mail archive
+Δημιουργία αρχείου αλληλογραφίας
 Log files
 Αρχείο γεγονότων
 DOS names (8+3)
@@ -508,6 +518,12 @@ Identity
 Ταυτότητα
 HTML footer
 Σημείωση HTML
+Languages
+Γλώσσες
+Additional HTTP Headers
+Πρόσθετες κεφαλίδες HTTP
+Default referer URL
+Προεπιλεγμένη διεύθυνση referer
 N# connections
 Αριθμός συνδέσεων
 Abandon host if error

--- a/lang/Italiano.txt
+++ b/lang/Italiano.txt
@@ -186,6 +186,8 @@ scanning
 Scansione
 Waiting for scheduled time..
 Attesa dell'orario specificato per iniziare
+Transferring data..
+Trasferimento dati..
 Connecting to provider
 Connesione al provider in corso
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 Crea la pagina iniziale
 Create a word database of all html pages
 Crea un database delle parole di tutte le pagine HTML
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Crea un archivio di posta RFC822 (MHT/EML) completo del mirror
 Create error logging and report files
 Crea file di log per segnalare errori e informazioni
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 Identità del browser
 Comment to be placed in each HTML file
 Piè di pagina per ogni file HTML
+Languages accepted by the browser
+Lingue accettate dal browser
+Additional HTTP headers to be sent in each requests
+Intestazioni HTTP aggiuntive da inviare in ogni richiesta
+HTTP referer to be sent for initial URLs
+Referer HTTP da inviare per gli URL iniziali
 Back to starting page
 Torna alla pagina iniziale
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Crea un indice
 Make a word database
 Crea un database delle parole
+Build a mail archive
+Crea un archivio di posta
 Log files
 File di log
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Identità
 HTML footer
 Piè di pagina HTML
+Languages
+Lingue
+Additional HTTP Headers
+Intestazioni HTTP aggiuntive
+Default referer URL
+URL referer predefinito
 N# connections
 N° di connessioni
 Abandon host if error

--- a/lang/Japanese.txt
+++ b/lang/Japanese.txt
@@ -186,6 +186,8 @@ scanning
 スキャン中
 Waiting for scheduled time..
 設定された開始時間を待っています..
+Transferring data..
+データを転送しています..
 Connecting to provider
 プロバイダへ接続中
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 スタートページの作成
 Create a word database of all html pages
 全てのHTMLページに単語データベースを作成する
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+ミラーの完全な RFC822 メールアーカイブ (MHT/EML) を作成する
 Create error logging and report files
 エラーログとレポートファイルを作成する
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 ブラウザID
 Comment to be placed in each HTML file
 どのHTMLファイルにも挿入されるコメント
+Languages accepted by the browser
+ブラウザが受け入れる言語
+Additional HTTP headers to be sent in each requests
+各リクエストで送信する追加の HTTP ヘッダ
+HTTP referer to be sent for initial URLs
+最初の URL に送信する HTTP リファラ
 Back to starting page
 スタートページに戻る
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 インデックスの作成
 Make a word database
 単語データベースを作成する
+Build a mail archive
+メールアーカイブの作成
 Log files
 ログファイル
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 ID
 HTML footer
 HTMLフッタ
+Languages
+言語
+Additional HTTP Headers
+追加の HTTP ヘッダ
+Default referer URL
+既定のリファラ URL
 N# connections
 接続数
 Abandon host if error

--- a/lang/Macedonian.txt
+++ b/lang/Macedonian.txt
@@ -186,6 +186,8 @@ scanning
 скенира
 Waiting for scheduled time..
 √о чекам даденото време...
+Transferring data..
+ња’Ёёб Ё– яё‘–вёжЎ..
 Connecting to provider
 ѕоврзуваЬе со проваЉдерот
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
  реираЉте —тарт страница
 Create a word database of all html pages
  реираЉте word база на податоци на сите html страници
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Є„а–—ёвЎ ж’џёбЁ– яёив’ЁбЏ– –аеЎ“– RFC822 (MHT/EML) Ё– ЏёяЎш–в–
 Create error logging and report files
  реираЉте error logging и датотеки со извештаи
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 »дентификациЉа на пребарувачот
 Comment to be placed in each HTML file
  оментар коЉ треба да биде сместен во секоЉа HTML датотека
+Languages accepted by the browser
+®–„ЎжЎ яаЎд–в’ЁЎ ё‘ яа’џЎбвг“–зёв
+Additional HTTP headers to be sent in each requests
+іёяёџЁЎв’џЁЎ HTTP „–”џ–“ш– ивё б’ Ўбяа–ь––в “ё б’Џё’ —–а–ъ’
+HTTP referer to be sent for initial URLs
+HTTP referer ивё б’ Ўбяа–ь– „– яёз’вЁЎв’ URL –‘а’бЎ
 Back to starting page
 Ќазад до стартната страница
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Ќаправи индекс
 Make a word database
 Ќаправи word база на податоци
+Build a mail archive
+Є„а–—ёвЎ яёив’ЁбЏ– –аеЎ“–
 Log files
 Log датотеки
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 »дентификациЉа
 HTML footer
 HTML футер
+Languages
+®–„ЎжЎ
+Additional HTTP Headers
+іёяёџЁЎв’џЁЎ HTTP „–”џ–“ш–
+Default referer URL
+Ѕв–Ё‘–а‘Ё– referer URL –‘а’б–
 N# connections
 ЅроЉ на конекции
 Abandon host if error

--- a/lang/Magyar.txt
+++ b/lang/Magyar.txt
@@ -186,6 +186,8 @@ scanning
 vizsgálat
 Waiting for scheduled time..
 Várakozás az ütemezett idõpontra
+Transferring data..
+Adatok átvitele..
 Connecting to provider
 Csatlakozás a szolgáltatóhoz
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 Kezdõlap létrehozása
 Create a word database of all html pages
 Az összes HTML oldal szóadatbázisának létrehozása
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+A tükrözés teljes RFC822 levélarchívumának (MHT/EML) létrehozása
 Create error logging and report files
 Hibanapló- és jelentásfájl létrehozása
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 Böngészõ beazonosítása
 Comment to be placed in each HTML file
 Mindegyik HTML fájlban elhelyezendõ megjegyzés
+Languages accepted by the browser
+A böngészõ által elfogadott nyelvek
+Additional HTTP headers to be sent in each requests
+Minden kérésben elküldendõ további HTTP fejlécek
+HTTP referer to be sent for initial URLs
+A kiinduló URL-ekhez küldendõ HTTP referer
 Back to starting page
 Vissza a kezdõlaphoz
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Mutató készítése
 Make a word database
 Szóadatbázis létrehozása
+Build a mail archive
+Levélarchívum létrehozása
 Log files
 Naplófájlok
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Azonosítás
 HTML footer
 HTML lábjegyzet
+Languages
+Nyelvek
+Additional HTTP Headers
+További HTTP fejlécek
+Default referer URL
+Alapértelmezett referer URL
 N# connections
 Csatlakozások száma
 Abandon host if error

--- a/lang/Nederlands.txt
+++ b/lang/Nederlands.txt
@@ -186,6 +186,8 @@ scanning
 scanning
 Waiting for scheduled time..
 Wacht op voorgegeven uur om te starten
+Transferring data..
+Gegevens overdragen..
 Connecting to provider
 Maak verbinding met de provider
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 Startpagina aanmaken
 Create a word database of all html pages
 Kreëer een woorden-gegevensbank van alle HTML paginas
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Maak een volledig RFC822 mailarchief (MHT/EML) van de spiegeling
 Create error logging and report files
 Aanmaken van Protokolbestanden voor fouten en mededelingen.
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 Browser identiteit
 Comment to be placed in each HTML file
 Voetnoot in elk HTML bestand
+Languages accepted by the browser
+Talen die de browser accepteert
+Additional HTTP headers to be sent in each requests
+Extra HTTP-headers die bij elk verzoek worden verstuurd
+HTTP referer to be sent for initial URLs
+HTTP-referer die voor de begin-URL's wordt verstuurd
 Back to starting page
 Terug naar de startpagina
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Maak een index
 Make a word database
 Kreëer een woorden-gegevensbank
+Build a mail archive
+Maak een mailarchief
 Log files
 Protocolbestanden
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Identiteit
 HTML footer
 HTML voetnota
+Languages
+Talen
+Additional HTTP Headers
+Extra HTTP-headers
+Default referer URL
+Standaard referer-URL
 N# connections
 N# verbindingen
 Abandon host if error

--- a/lang/Norsk.txt
+++ b/lang/Norsk.txt
@@ -186,6 +186,8 @@ scanning
 søker
 Waiting for scheduled time..
 Venter på planlagt tidspunkt...
+Transferring data..
+Overfører data..
 Connecting to provider
 Kobler til leverandør
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 Opprett en startside
 Create a word database of all html pages
 Opprett en ord-database over alle HTML-sider
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Lag et komplett RFC822-postarkiv (MHT/EML) av kopien
 Create error logging and report files
 Opprett feillogging og rapporter
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 Nettleser-identitet
 Comment to be placed in each HTML file
 Sett inn kommentar i alle HTML-filer
+Languages accepted by the browser
+Språk nettleseren godtar
+Additional HTTP headers to be sent in each requests
+Ekstra HTTP-hoder som sendes med hver forespørsel
+HTTP referer to be sent for initial URLs
+HTTP-referer som sendes for de første URL-ene
 Back to starting page
 Tilbake til startside
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Opprett en forside
 Make a word database
 Opprett en ord-database
+Build a mail archive
+Lag et postarkiv
 Log files
 Loggfiler
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Identitet
 HTML footer
 HTML-fotnote
+Languages
+Språk
+Additional HTTP Headers
+Ekstra HTTP-hoder
+Default referer URL
+Standard referer-URL
 N# connections
 Antall forbindelser
 Abandon host if error

--- a/lang/Polski.txt
+++ b/lang/Polski.txt
@@ -186,6 +186,8 @@ scanning
 skanujê
 Waiting for scheduled time..
 Czekam na okreœlon¹ godzinê aby wystartowaæ
+Transferring data..
+Przesy³anie danych..
 Connecting to provider
 £¹cze siê z us³ugodawc¹
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 Utwórz stronê startow¹
 Create a word database of all html pages
 Utwórz bazê s³ów wystêpuj±cych we wszystkich stronach HTML
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Utwórz pe³ne archiwum pocztowe RFC822 (MHT/EML) lustra
 Create error logging and report files
 Utwórz pliki z raportem o b³êdach i informacjach
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 Identyfikacja przegl¹darki
 Comment to be placed in each HTML file
 Stopka do umieszczenia w ka¿dym pliku HTML
+Languages accepted by the browser
+Jêzyki akceptowane przez przegl±darkê
+Additional HTTP headers to be sent in each requests
+Dodatkowe nag³ówki HTTP wysy³ane w ka¿dym ¿±daniu
+HTTP referer to be sent for initial URLs
+Nag³ówek HTTP referer wysy³any dla pocz±tkowych adresów URL
 Back to starting page
 Z powortem do strony startowej
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Utwórz indeks
 Make a word database
 Utwórz bazê s³ów
+Build a mail archive
+Utwórz archiwum pocztowe
 Log files
 Raportuj pobrane pliki
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Identyfikacja
 HTML footer
 Stopka HTML
+Languages
+Jêzyki
+Additional HTTP Headers
+Dodatkowe nag³ówki HTTP
+Default referer URL
+Domy¶lny adres URL referera
 N# connections
 N# po³¹czeñ
 Abandon host if error

--- a/lang/Portugues.txt
+++ b/lang/Portugues.txt
@@ -186,6 +186,8 @@ scanning
 analisando
 Waiting for scheduled time..
 Aguardando hora programada para começar
+Transferring data..
+A transferir dados..
 Connecting to provider
 Ligação ao fornecedor de acesso
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 Criar uma página inicial
 Create a word database of all html pages
 Criar base de dados de palavras de todas as páginas html
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Criar um arquivo de correio RFC822 (MHT/EML) completo da cópia
 Create error logging and report files
 Criar ficheiros para as mensagens de erro e avisos
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 Identidade do browser
 Comment to be placed in each HTML file
 Nota de rodapé em cada ficheiro HTML
+Languages accepted by the browser
+Idiomas aceites pelo browser
+Additional HTTP headers to be sent in each requests
+Cabeçalhos HTTP adicionais a enviar em cada pedido
+HTTP referer to be sent for initial URLs
+Referer HTTP a enviar para os URL iniciais
 Back to starting page
 Voltar à página inicial
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Construir um índice
 Make a word database
 Criar base de dados de palavras
+Build a mail archive
+Criar um arquivo de correio
 Log files
 Relatórios
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Identificação
 HTML footer
 Rodapé HTML
+Languages
+Idiomas
+Additional HTTP Headers
+Cabeçalhos HTTP adicionais
+Default referer URL
+URL de referer predefinido
 N# connections
 Número de conexões
 Abandon host if error

--- a/lang/Romanian.txt
+++ b/lang/Romanian.txt
@@ -186,6 +186,8 @@ scanning
 scanare in progres
 Waiting for scheduled time..
 Aºtept timpul programat pentru a continua...
+Transferring data..
+Transfer de date..
 Connecting to provider
 Mã conectez la furnizor
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 Creazã o Paginã de Start
 Create a word database of all html pages
 Creeazã o bazã de date semanticã a tuturor paginilor html
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Construieste o arhiva de mail RFC822 (MHT/EML) completa a copiei
 Create error logging and report files
 Creeazã fiºiere jurnal pentru mesajele de eroare ºi fiºiere raport
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 Identitatea browser-ului
 Comment to be placed in each HTML file
 Comentariu ce va fi plasat în fiecare fiºier HTML
+Languages accepted by the browser
+Limbile acceptate de browser
+Additional HTTP headers to be sent in each requests
+Anteturi HTTP suplimentare de trimis la fiecare cerere
+HTTP referer to be sent for initial URLs
+Referer HTTP de trimis pentru URL-urile initiale
 Back to starting page
 Înapoi la pagina de start
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Construieºte un index
 Make a word database
 Construieºte o bazã de date semanticã
+Build a mail archive
+Construieste o arhiva de mail
 Log files
 Fiºiere jurnal
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Identitate
 HTML footer
 Subsol HTML
+Languages
+Limbi
+Additional HTTP Headers
+Anteturi HTTP suplimentare
+Default referer URL
+URL referer implicit
 N# connections
 Numãr de conexiuni
 Abandon host if error

--- a/lang/Romanian.txt
+++ b/lang/Romanian.txt
@@ -425,7 +425,7 @@ Comentariu ce va fi plasat în fiecare fiºier HTML
 Languages accepted by the browser
 Limbile acceptate de browser
 Additional HTTP headers to be sent in each requests
-Anteturi HTTP suplimentare de trimis la fiecare cerere
+Anteturi HTTP suplimentare de trimis în fiecare cerere
 HTTP referer to be sent for initial URLs
 Referer HTTP de trimis pentru URL-urile initiale
 Back to starting page

--- a/lang/Russian.txt
+++ b/lang/Russian.txt
@@ -186,6 +186,8 @@ scanning
 сканируем
 Waiting for scheduled time..
 Ожидаем заданное время начала..
+Transferring data..
+Передача данных..
 Connecting to provider
 Соединяемся с провайдером
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 Создать начальную страницу
 Create a word database of all html pages
 Создать базу данных слов, содержащихся в html-страницах
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Создать полный почтовый архив RFC822 (MHT/EML) зеркала
 Create error logging and report files
 Создать лог файлы с информацией о работе и ошибках
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 Идентификация броузера (строка User-Agent)
 Comment to be placed in each HTML file
 Комментарий, размещаемый в каждом HTML файле
+Languages accepted by the browser
+Языки, принимаемые броузером
+Additional HTTP headers to be sent in each requests
+Дополнительные HTTP заголовки, отправляемые в каждом запросе
+HTTP referer to be sent for initial URLs
+HTTP referer, отправляемый для начальных URL
 Back to starting page
 Назад на начальную страницу
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Создать индекс
 Make a word database
 Создать базу данных слов
+Build a mail archive
+Создать почтовый архив
 Log files
 Log файлы
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Идентификатор
 HTML footer
 Нижний HTML колонтитул
+Languages
+Языки
+Additional HTTP Headers
+Дополнительные HTTP заголовки
+Default referer URL
+Referer URL по умолчанию
 N# connections
 N# соединений
 Abandon host if error

--- a/lang/Slovak.txt
+++ b/lang/Slovak.txt
@@ -186,6 +186,8 @@ scanning
 Skenovanie
 Waiting for scheduled time..
 Èakanie na plánovanı èas...
+Transferring data..
+Prenos údajov..
 Connecting to provider
 Pripájanie providera
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 Vytvori úvodnú stránku
 Create a word database of all html pages
 Vytvori databázu všetkıch slov ako html stránky
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Vytvori» úplnı po¹tovı archív RFC822 (MHT/EML) zrkadla
 Create error logging and report files
 Vytvori protokoly chıb a hlásení
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 Identifikácia prehliadaèa
 Comment to be placed in each HTML file
 Komentár, ktorı má by umiestnenı do kadého HTML súboru
+Languages accepted by the browser
+Jazyky akceptované prehliadaèom
+Additional HTTP headers to be sent in each requests
+Ïal¹ie hlavièky HTTP odosielané v ka¾dej po¾iadavke
+HTTP referer to be sent for initial URLs
+Hlavièka HTTP referer odosielaná pre poèiatoèné adresy URL
 Back to starting page
 Spä na úvodnú stránku
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Vytvori index
 Make a word database
 Vytvori slovnú databázu
+Build a mail archive
+Vytvori» po¹tovı archív
 Log files
 Log súbory
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Identita
 HTML footer
 Päta HTML
+Languages
+Jazyky
+Additional HTTP Headers
+Ïal¹ie hlavièky HTTP
+Default referer URL
+Predvolená adresa referer
 N# connections
 Poèet spojení
 Abandon host if error

--- a/lang/Slovenian.txt
+++ b/lang/Slovenian.txt
@@ -186,6 +186,8 @@ scanning
 iskanje
 Waiting for scheduled time..
 Èakanje na èas razporejanja..
+Transferring data..
+Prenos podatkov..
 Connecting to provider
 Povezava z oskrbovalcem
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 Naredi Zaèetno stran
 Create a word database of all html pages
 Naredi besedilno bazo podatkov vseh html strani
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Ustvari popoln postni arhiv RFC822 (MHT/EML) zrcaljene strani
 Create error logging and report files
 Naredi zgodovino napak (log) in datoteke s poroèili
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 Istovetnost brskalnika
 Comment to be placed in each HTML file
 Opombe bodo vstavljene v HTML dattekah
+Languages accepted by the browser
+Jeziki, ki jih sprejema brskalnik
+Additional HTTP headers to be sent in each requests
+Dodatne glave HTTP, poslane v vsaki zahtevi
+HTTP referer to be sent for initial URLs
+Glava HTTP referer, poslana za zacetne naslove URL
 Back to starting page
 Pojdi na zaèetno stran
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Naredi indeks
 Make a word database
 Naredi podatkovno bazo besed
+Build a mail archive
+Ustvari postni arhiv
 Log files
 Log datoteke
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Istovetnost
 HTML footer
 Glava HTML dokumenta
+Languages
+Jeziki
+Additional HTTP Headers
+Dodatne glave HTTP
+Default referer URL
+Privzeti naslov referer
 N# connections
 Število prikljuèitev
 Abandon host if error

--- a/lang/Svenska.txt
+++ b/lang/Svenska.txt
@@ -186,6 +186,8 @@ scanning
 sökning
 Waiting for scheduled time..
 Vänta på planlagd tidpunkt...
+Transferring data..
+Överför data..
 Connecting to provider
 Ansluter till Internet
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 Skapa en startsida
 Create a word database of all html pages
 Skapa en textbaserad databas över alla HTML-sidor
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Skapa ett komplett RFC822-postarkiv (MHT/EML) av kopian
 Create error logging and report files
 Skapa felloggning och rapport-filer
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 Webbläsare identitet
 Comment to be placed in each HTML file
 Kommentarer för infogas i varje HTML fil
+Languages accepted by the browser
+Språk som webbläsaren accepterar
+Additional HTTP headers to be sent in each requests
+Extra HTTP-huvuden som skickas i varje begäran
+HTTP referer to be sent for initial URLs
+HTTP-referer som skickas för de första URL:erna
 Back to starting page
 Tillbaka till startsidan
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Gör ett index
 Make a word database
 Gör en textbaserad databas
+Build a mail archive
+Skapa ett postarkiv
 Log files
 Log filer
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Identitet
 HTML footer
 HTML fot
+Languages
+Språk
+Additional HTTP Headers
+Extra HTTP-huvuden
+Default referer URL
+Förvald referer-URL
 N# connections
 Antal förbindelser
 Abandon host if error

--- a/lang/Turkish.txt
+++ b/lang/Turkish.txt
@@ -186,6 +186,8 @@ scanning
 
 Waiting for scheduled time..
 Planlanan zaman bekleniyor..
+Transferring data..
+Veri aktarýlýyor..
 Connecting to provider
 Servis saðlayýcýya baðlanýyor
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 Baþlangýç Sayfasý Yarat
 Create a word database of all html pages
 Tüm html sayfalarýndan bir kelime veritabaný yarat
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Yansýnýn tam bir RFC822 posta arþivini (MHT/EML) oluþtur
 Create error logging and report files
 Hata kaydý ve rapor dosyalarý yarat
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 Browser Kimliði
 Comment to be placed in each HTML file
 Her HTML sayfasýnýn içerisine yerleþtirilecek açýklama
+Languages accepted by the browser
+Tarayýcýnýn kabul ettiði diller
+Additional HTTP headers to be sent in each requests
+Her istekte gönderilecek ek HTTP baþlýklarý
+HTTP referer to be sent for initial URLs
+Ýlk adresler için gönderilecek HTTP referer
 Back to starting page
 Baþlangýç sayfasýna dön
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Bir index yarat
 Make a word database
 Sözcük veritabaný hazýrla
+Build a mail archive
+Posta arþivi oluþtur
 Log files
 Kayýt dosyalarý
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Kimlik
 HTML footer
 HTML sayfa altlýðý
+Languages
+Diller
+Additional HTTP Headers
+Ek HTTP baþlýklarý
+Default referer URL
+Varsayýlan referer adresi
 N# connections
 N# baðlantý
 Abandon host if error

--- a/lang/Ukrainian.txt
+++ b/lang/Ukrainian.txt
@@ -186,6 +186,8 @@ scanning
 скануємо
 Waiting for scheduled time..
 Очікуємо заданий час початку
+Transferring data..
+Передача даних..
 Connecting to provider
 З'єднуємося з провайдером
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 Створити початкову сторінку
 Create a word database of all html pages
 Стоврити базу даних слів зі всіх html сторінок
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Створити повний поштовий архів RFC822 (MHT/EML) дзеркала
 Create error logging and report files
 Створити лог файли з інформацією про роботу і помилки
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 Ідентифікація броузера (рядок User-Agent)
 Comment to be placed in each HTML file
 Коментар, розташовуваний у кожному HTML файлі
+Languages accepted by the browser
+Мови, що приймаються броузером
+Additional HTTP headers to be sent in each requests
+Додаткові HTTP заголовки, що надсилаються у кожному запиті
+HTTP referer to be sent for initial URLs
+HTTP referer, що надсилається для початкових URL
 Back to starting page
 Назад на початкову сторінку
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Створити індекс
 Make a word database
 Створити базу даних слів
+Build a mail archive
+Створити поштовий архів
 Log files
 Log файли
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Ідентифікатор
 HTML footer
 Нижній HTML колонтитул
+Languages
+Мови
+Additional HTTP Headers
+Додаткові HTTP заголовки
+Default referer URL
+Referer URL за замовчуванням
 N# connections
 N# з'єднань
 Abandon host if error

--- a/lang/Uzbek.txt
+++ b/lang/Uzbek.txt
@@ -186,6 +186,8 @@ scanning
 tekshirilmoqda
 Waiting for scheduled time..
 Tayinlangan vaqt boshlanishu kutilmoqda..
+Transferring data..
+MaТlumotlar uzatilmoqda..
 Connecting to provider
 Provayder bilan bogТlanilmoqda
 [%d seconds] to go before start of operation
@@ -370,6 +372,8 @@ Create a Start Page
 BoshlangТich sahifani yaratmoq
 Create a word database of all html pages
 —оздать базу данных слов, содержащихс€ в html-страницах
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Nusxaning toТliq RFC822 pochta arxivini (MHT/EML) yaratmoq
 Create error logging and report files
 —оздать лог файлы с информацией о работе и ошибках
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +422,12 @@ Browser identity
 »дентификаци€ броузера (строка User-Agent)
 Comment to be placed in each HTML file
  омментарий, размещаемый в каждом HTML файле
+Languages accepted by the browser
+Brauzer qabul qiladigan tillar
+Additional HTTP headers to be sent in each requests
+Har bir soТrovda yuboriladigan qoТshimcha HTTP sarlavhalari
+HTTP referer to be sent for initial URLs
+BoshlangТich URL uchun yuboriladigan HTTP referer
 Back to starting page
 BoshlangТich sahifaga oТtish
 Save current preferences as default values
@@ -478,6 +488,8 @@ Make an index
 Indeks yaratmoq
 Make a word database
 SoТz bazasini yaratmoq
+Build a mail archive
+Pochta arxivini yaratmoq
 Log files
 Log fayllar
 DOS names (8+3)
@@ -506,6 +518,12 @@ Identity
 Identifikator
 HTML footer
 Quyi HTML kolontitul
+Languages
+Tillar
+Additional HTTP Headers
+QoТshimcha HTTP sarlavhalari
+Default referer URL
+Standart referer URL
 N# connections
 N# bogТlanish
 Abandon host if error

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -86,31 +86,22 @@ LC_ALL=C awk -v keys="$keys" '
 ' "$def" || fail=1
 
 # A msgid absent from a language file silently falls back to English (#862).
-# The waivers predate the check, are tracked in #863, and may only shrink.
+# What is left waived is the Android UI, whose strings never reached lang/*.txt.
 LC_ALL=C sort -u <"$keys" >"$tmp/english.sorted"
 LC_ALL=C sort -u >"$tmp/waived" <<'UNTRANSLATED'
-Additional HTTP Headers
-Additional HTTP headers to be sent in each requests
 Beware: you local browser might be unable to browse files with embedded filenames
-Build a complete RFC822 mail (MHT/EML) archive of the mirror
-Build a mail archive
 Click on this notification to restart the interrupted mirror
 Could not create internal cached resources
 Could not get the system external storage directory
 Could not write to:
-Default referer URL
 Go To HTTrack Forum
 Go To HTTrack Website
-HTTP referer to be sent for initial URLs
 HTTrack may not be able to download websites until this problem is fixed
 HTTrack: could not save profile for '%s'!
 HTTrack: mirror '%s' stopped!
-Languages
-Languages accepted by the browser
 No storage media (SDCARD)
 Read-only media (SDCARD)
 Recreated HTTrack internal cached resources
-Transferring data..
 View Documentation
 View License
 UNTRANSLATED


### PR DESCRIPTION
Nine `lang.def` keys (`LANG_F15b`, `LANG_I6c`, `LANG_I23c`/`d`/`e`, `LANG_I35c`, `LANG_I43c`/`d`/`e`) were translated only in English, Francais, Dansk and Portugues-Brasil, so the Windows GUI's option dialogs fell back to English everywhere else. This fills them in for the other 26 files, each encoded in that file's declared `LANGUAGE_CHARSET` and inserted where English.txt orders it. No existing byte moves; the diff is additions only. Two files ignore their own header: Svenska.txt says ISO-8859-2 but holds Latin-1, and Chinese-BIG5.txt needs cp950 rather than strict big5. Romanian.txt and Slovenian.txt declare ISO-8859-1, which cannot spell either language, so both stay unaccented ASCII the way #862 left them.

Test 62 waived these nine msgids by name and fails once a waiver is no longer needed, so the change also drops them from that list; the shortened list reports 231 untranslated msgids against master. Worth a separate look: Croatian, Slovak, Polski and Slovenian already carry CP1250 bytes under an ISO-8859-2 or ISO-8859-1 declaration, and Macedonian carries CP1251 under ISO-8859-5. The new strings follow the declaration, as #862 did.

Closes #863
