### PR TITLE
The suite watchdog may kill its own taskkill, and an empty category reads as a failing test

### DIFF
--- a/tests/171_watchdog-heartbeat.test
+++ b/tests/171_watchdog-heartbeat.test
@@ -21,6 +21,8 @@ fail() {
 
 progress="$tmp/progress"
 kill_tree() { echo "KILL $1 at $(hb_now)"; }
+# Stubbed too, or the legs below would send a real SIGKILL to pid 4242.
+kill_pid() { echo "DIRECT $1 at $(hb_now)"; }
 # Twelve lines, against a bound of eight.
 list_stray_processes() {
     printf '%s\n' "$*" >"$tmp/strayargs"
@@ -133,5 +135,29 @@ killed=$(sed -n 's/^KILL 4242 at \([0-9]*\)$/\1/p' "$tmp/late")
 test -n "$killed" || fail "a suite static from the start was never killed"
 test "$killed" -ge 9960 || fail "killed at $killed, inside the 960s quiet window"
 test "$killed" -le 10080 || fail "killed at $killed, want 9960 within a tick"
+
+# taskkill is a grandchild of its own target, so a leaves-first /T would reap the
+# watchdog before the root (#953): kill_tree here never returns, and the stubs
+# record the order, which the code under test cannot write to.
+rec="$tmp/killed"
+: >"$rec"
+vnow=9000
+ticks=0
+printf 'RUN 96_wedged.test at 0s\n' >"$progress"
+rc=0
+(
+    kill_pid() { echo "DIRECT $1" >>"$rec"; }
+    kill_tree() {
+        echo "TREE $1" >>"$rec"
+        exit 9
+    }
+    ci_suite_heartbeat 960 360 "$progress" 900 4242 >"$tmp/hedge" 2>&1
+) || rc=$?
+test "$rc" -eq 9 || fail "the tree kill never fired: watchdog returned $rc"
+test "$(sed -n 1p "$rec")" = "DIRECT 4242" ||
+    fail "the target was not signalled directly ahead of the tree walk: $(tr '\n' '/' <"$rec")"
+test "$(sed -n 2p "$rec")" = "TREE 4242" ||
+    fail "the tree was not killed after the direct signal: $(tr '\n' '/' <"$rec")"
+test "$(sed -n '$=' "$rec")" -eq 2 || fail "extra kills: $(tr '\n' '/' <"$rec")"
 
 echo "heartbeat OK"

--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -98,4 +98,16 @@ grep -q '::error::test category zlib matched no tests' <<<"$out" ||
 grep -q 'FAIL \*_zlib' <<<"$out" && fail "the glob was counted as a failing test: $out"
 grep -q '^ran=' <<<"$out" && fail "the suite ran a test with a category empty: $out"
 
+# The first category names a single test, and a name nullglob cannot empty would
+# never reach the gate at all.
+printf '#!/bin/sh\nexit 0\n' >"$run/13_zlib-pass.test"
+rm -f "$run/00_runnable.test"
+rc=0
+out=$(RUNNER_TEMP="$tmp" GITHUB_STEP_SUMMARY="$tmp/summary" \
+    bash ./ci-windows-suite.sh "$bin" 2>&1) || rc=$?
+test "$rc" -eq 1 || fail "an empty single-test category exited $rc, want 1"
+grep -q '::error::test category runnable matched no tests' <<<"$out" ||
+    fail "the empty single-test category was not named: $out"
+grep -q 'FAIL 00_runnable' <<<"$out" && fail "the unexpanded name was run as a test: $out"
+
 echo "ci-windows driver OK"

--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -77,11 +77,25 @@ grep -q '^ran=9 pass=7 fail=1 skip=1$' <<<"$out" ||
 grep -q '::error::only 7 tests passed (1 skipped)' <<<"$out" ||
     fail "the pass floor did not report the count"
 grep -q 'FAIL 12_engine-fail.test (exit 3)' <<<"$out" || fail "the failing test was not named"
+# Positive control for the gate below: with every category matched it stays silent.
+grep -q 'matched no tests' <<<"$out" && fail "a full suite reported an empty category"
 
 # The progress log is what the watchdog reads and what the artifact keeps.
 grep -q '^RUN 12_engine-fail.test at ' suite-progress.log || fail "no RUN line for the failing test"
 grep -q '^RERUN 12_engine-fail.test$' suite-progress.log || fail "the traced re-run was not noted"
 grep -q '^77 11_engine-skip.test$' suite-progress.log || fail "the skip's status was not recorded"
 test -s 12_engine-fail.test.log || fail "no per-test log for the failing test"
+
+# An emptied category must name itself and stop the suite, rather than hand the
+# unexpanded pattern to test-timeout.sh and count it as a test failing 127 (#952).
+rm -f "$run/13_zlib-pass.test"
+rc=0
+out=$(RUNNER_TEMP="$tmp" GITHUB_STEP_SUMMARY="$tmp/summary" \
+    bash ./ci-windows-suite.sh "$bin" 2>&1) || rc=$?
+test "$rc" -eq 1 || fail "an empty category exited $rc, want 1"
+grep -q '::error::test category zlib matched no tests' <<<"$out" ||
+    fail "the empty category was not named: $out"
+grep -q 'FAIL \*_zlib' <<<"$out" && fail "the glob was counted as a failing test: $out"
+grep -q '^ran=' <<<"$out" && fail "the suite ran a test with a category empty: $out"
 
 echo "ci-windows driver OK"

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -125,8 +125,10 @@ trap 'kill "$heartbeat" 2>/dev/null || true' EXIT
 
 pass=0 fail=0 skip=0 failed="" skipped="" deadline=0
 # label:pattern, globbed rather than enumerated so a new NNN_engine-*.test or
-# NNN_local-*.test is picked up instead of silently getting zero coverage.
-categories=(runnable:00_runnable.test engine:'*_engine-*.test' zlib:'*_zlib-*.test'
+# NNN_local-*.test is picked up instead of silently getting zero coverage. Every
+# entry carries a metacharacter, or nullglob cannot empty it and the gate below
+# has nothing to catch.
+categories=(runnable:'00_runnable*.test' engine:'*_engine-*.test' zlib:'*_zlib-*.test'
     local:'*_local-*.test' watchdog:'*_watchdog*.test'
     proxy-https:'*_crawl_proxy_https.test' log-salvage:'*_crawl-log-salvage.test')
 tests=()

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -48,6 +48,8 @@ ci_suite_heartbeat() {
         # outlive the step's own timeout before being caught.
         if test $((now - moved)) -ge "$stuck"; then
             ci_annotate error "suite watchdog" "killing the step: $((now - moved))s without progress, in flight: $last"
+            # Direct first: kill_tree may reap this watchdog before its own root (#953).
+            kill_pid "$main"
             kill_tree "$main"
             return 0
         fi
@@ -122,11 +124,27 @@ heartbeat=$!
 trap 'kill "$heartbeat" 2>/dev/null || true' EXIT
 
 pass=0 fail=0 skip=0 failed="" skipped="" deadline=0
-# Globbed, not enumerated: a new NNN_engine-*.test or NNN_local-*.test
-# is picked up automatically instead of silently getting zero coverage.
-for t in 00_runnable.test *_engine-*.test *_zlib-*.test \
-    *_local-*.test *_watchdog*.test *_crawl_proxy_https.test \
-    *_crawl-log-salvage.test; do
+# label:pattern, globbed rather than enumerated so a new NNN_engine-*.test or
+# NNN_local-*.test is picked up instead of silently getting zero coverage.
+categories=(runnable:00_runnable.test engine:'*_engine-*.test' zlib:'*_zlib-*.test'
+    local:'*_local-*.test' watchdog:'*_watchdog*.test'
+    proxy-https:'*_crawl_proxy_https.test' log-salvage:'*_crawl-log-salvage.test')
+tests=()
+shopt -s nullglob
+for c in "${categories[@]}"; do
+    # shellcheck disable=SC2206 # expanding the pattern is the point
+    matched=(${c#*:})
+    # Named, and before anything runs: left unexpanded the pattern reaches
+    # test-timeout.sh literally and is counted as a test failing 127 (#952).
+    test -n "${matched[0]:-}" || {
+        echo "::error::test category ${c%%:*} matched no tests (${c#*:})"
+        exit 1
+    }
+    tests+=("${matched[@]}")
+done
+shopt -u nullglob
+
+for t in "${tests[@]}"; do
     elapsed=$((SECONDS - started))
     if [ "$elapsed" -ge "$suite_deadline" ]; then
         echo "::error::suite deadline: ${elapsed}s elapsed, stopping before $t"

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -106,6 +106,28 @@ dump_crawl_logs() {
     done
 }
 
+# The Windows PID behind an MSYS pid, empty when unknown.
+win_pid() {
+    if test -r "/proc/$1/winpid"; then
+        cat "/proc/$1/winpid" 2>/dev/null || true
+    fi
+}
+
+# Signal one process, never its descendants: a caller inside the target's own
+# tree cannot rely on kill_tree, whose taskkill is then a grandchild of it (#953).
+kill_pid() {
+    local pid=$1
+    if is_windows; then
+        local winpid
+        winpid=$(win_pid "$pid")
+        if test -n "$winpid"; then
+            taskkill /F /PID "$winpid" >/dev/null 2>&1 || true
+        fi
+        return 0
+    fi
+    kill -9 "$pid" 2>/dev/null || true
+}
+
 # Kill a backgrounded job and its whole descendant tree. POSIX: the caller must
 # have put the job in its own process group (run_with_timeout does) so we signal
 # the group; a bare kill would orphan the grandchildren. Windows: the tree is
@@ -115,8 +137,8 @@ dump_crawl_logs() {
 kill_tree() {
     local pid=$1
     if is_windows; then
-        local winpid=
-        test -r "/proc/$pid/winpid" && winpid=$(cat "/proc/$pid/winpid" 2>/dev/null)
+        local winpid
+        winpid=$(win_pid "$pid")
         if test -n "$winpid"; then
             taskkill /F /T /PID "$winpid" >/dev/null 2>&1 || true
         else


### PR DESCRIPTION
The Windows suite driver hands an unmatched category glob straight to `test-timeout.sh`, which exits 127, so the tally counts a failing test named `*_zlib-*.test`. Categories now carry a label and expand under `nullglob`, and one that matches nothing stops the suite naming itself, before any test runs, instead of reading as a broken harness. Every entry is a real pattern, including the one that names a single test: without a metacharacter `nullglob` cannot empty it, and the gate would pass it straight through.

The watchdog kill is the part that matters. `ci_suite_heartbeat` runs in a subshell of the process it is told to kill, and `kill_tree` on Windows is `taskkill /F /T /PID`, so taskkill is a grandchild of its own target. If `/T` walks leaves-first, the watchdog and taskkill die before it reaches the target: the annotation is printed, nothing is killed, and the step runs on to the 45-minute cancel with no log, which is what #795 exists to prevent. The target is now signalled directly first and through the tree second, so the kill no longer depends on taskkill outliving its own ancestors. Direct first, because anything sequenced after the tree walk may never run. Detaching the heartbeat from the target's tree would remove the hazard instead of hedging it, but MSYS cannot: `setsid` changes the POSIX session, not the Win32 parent `taskkill /T` walks, and reparenting through `cmd /c start` would cost both the EXIT-trap cleanup and the in-process unit test.

None of this settles the ordering question, since no test exercises a real `taskkill /T`. 171 asserts only that a `kill_tree` which never returns no longer keeps the target from being signalled, from stubs that record which pids were signalled and in what order. The Windows arms of `kill_pid` and `kill_tree` have no local coverage either, `is_windows` being false wherever the suite runs: a mutant that makes `win_pid` always return empty survives, and pulling that helper out of `kill_tree` rests on a differential over its call sites rather than on a test. Eight mutants do go red against the new assertions: dropped direct kill, swapped order, wrong pid, gate removed, glob list reverted, single-test category back to a literal name, message naming the glob instead of the category, and gate firing on a full suite.

Closes #952
Closes #953
