### PR TITLE
Add a weekly networked AppStream metainfo check

### DIFF
--- a/.github/workflows/appstream-network.yml
+++ b/.github/workflows/appstream-network.yml
@@ -1,6 +1,5 @@
-# Weekly, networked re-check of the AppStream metainfo (#971). The per-PR lint
-# job runs --no-net so an httrack.com outage can't red an unrelated PR, but
-# that also means it never sees a broken screenshot URL; this job does.
+# The per-PR lint runs --no-net so an httrack.com outage can't red an unrelated
+# PR; that also blinds it to a broken screenshot URL, which this job catches.
 name: appstream metainfo (networked)
 
 on:
@@ -27,8 +26,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends appstream
           appstreamcli --version
 
-      # No --no-net: a warning (e.g. screenshot-image-not-found) exits non-zero
-      # and fails this job, same as an error would.
+      # appstreamcli exits 3 on a warning, so a dead screenshot fails the job.
       - name: AppStream metainfo validation (network)
         run: |
           set -euo pipefail

--- a/.github/workflows/appstream-network.yml
+++ b/.github/workflows/appstream-network.yml
@@ -1,0 +1,36 @@
+# Weekly, networked re-check of the AppStream metainfo (#971). The per-PR lint
+# job runs --no-net so an httrack.com outage can't red an unrelated PR, but
+# that also means it never sees a broken screenshot URL; this job does.
+name: appstream metainfo (networked)
+
+on:
+  schedule:
+    - cron: "12 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: appstreamcli validate (network)
+    # Scheduled workflows run per-fork independently; skip anywhere but upstream.
+    if: github.repository == 'xroche/httrack'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install appstreamcli
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends appstream
+          appstreamcli --version
+
+      # No --no-net: a warning (e.g. screenshot-image-not-found) exits non-zero
+      # and fails this job, same as an error would.
+      - name: AppStream metainfo validation (network)
+        run: |
+          set -euo pipefail
+          appstreamcli validate --explain \
+            html/server/div/com.httrack.WebHTTrack.metainfo.xml


### PR DESCRIPTION
The per-PR gate from #959 validates the AppStream metainfo with `--no-net`, on purpose, so an httrack.com outage never reds an unrelated PR. That also means nothing ever checks the one failure a software centre user would actually see: a dead screenshot URL. This adds `.github/workflows/appstream-network.yml`, the same `appstreamcli validate --explain` command without `--no-net`, on a weekly cron plus `workflow_dispatch`, restricted to `xroche/httrack` so it stays off forks. The existing `--no-net` gates in the lint job and tests/210 are untouched.

Checked it isn't vacuous: pointed a scratch copy of the metainfo at a URL that 404s and confirmed `appstreamcli validate` with network on reports `W: screenshot-image-not-found` and exits 3, while the same file under `--no-net` exits 0 clean; the real screenshot URL validates clean today. Exit 3 is a warning-level failure and the workflow has no `--strict` or `|| true` to swallow it, so it fails the job like any other nonzero exit.

Closes #971
