### PR TITLE
Ignore the fuzzer binaries an in-tree --enable-fuzzers build drops in fuzz/

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,14 @@
+# Anchored: a glob like /fuzz-* would also swallow the tracked fuzz-*.c sources.
+/fuzz-charset
+/fuzz-meta
+/fuzz-idna
+/fuzz-entities
+/fuzz-unescape
+/fuzz-filters
+/fuzz-url
+/fuzz-header
+/fuzz-cachendx
+/fuzz-htsparse
+/fuzz-singlefile
+/fuzz-sitemap
+/fuzz-arc


### PR DESCRIPTION
The 13 programs in fuzz/Makefile.am's noinst_PROGRAMS only build under --enable-fuzzers, so an in-tree fuzzer build leaves all 13 binaries untracked. fuzz/.gitignore lists each by anchored name instead of a fuzz-* glob, which would also hide the tracked fuzz-*.c sources.

Closes #970