### PR TITLE
escape_remove_control() leaves the original tail glued to the result

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -4050,6 +4050,8 @@ HTSEXT_API void escape_remove_control(char *const s) {
       j++;
     }
   }
+  // compaction left the original tail sitting past j
+  s[j] = '\0';
 }
 
 #undef ADD_CHAR

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2329,11 +2329,14 @@ static int st_escape_control(httrackp *opt, int argc, char **argv) {
       {"", ""},
       /* only bytes below 32 go: DEL and high bytes are not control here */
       {"a\177\303\251", "a\177\303\251"},
+      /* both sides of the >= 32 cut, and a shrink of more than one byte */
+      {"a b", "a b"},
+      {"a\037b\036c", "abc"},
   };
 
   const size_t ncases = sizeof(cases) / sizeof(cases[0]);
   char buf[1024];
-  size_t k;
+  size_t k, m;
 
   (void) opt;
   if (argc > 0) {
@@ -2360,7 +2363,9 @@ static int st_escape_control(httrackp *opt, int argc, char **argv) {
     assertf(strlen(buf) == outlen);
     assertf(memcmp(buf, cases[k].out, outlen + 1) == 0);
     /* the terminator belongs inside the original string, never past its NUL */
-    assertf(buf[inlen + 1] == '#');
+    for (m = inlen + 1; m < sizeof(buf); m++) {
+      assertf(buf[m] == '#');
+    }
   }
   printf("escape-control self-test OK\n");
   return 0;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2310,6 +2310,62 @@ static int st_sniff(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* escape_remove_control() compacts in place, so it has to terminate at the new
+   end or the caller reads the compacted head plus the original tail (#974). */
+static int st_escape_control(httrackp *opt, int argc, char **argv) {
+  static const struct {
+    const char *in;
+    const char *out;
+  } cases[] = {
+      /* VT and FF are the ones that reach here: is_space() passes them */
+      {"/a\013bc", "/abc"},
+      {"\014abc", "abc"},
+      /* nothing moves, but the end does */
+      {"abc\013", "abc"},
+      {"abc\001def", "abcdef"},
+      {"\001\002\003", ""},
+      /* untouched inputs: the terminator must stay where it was */
+      {"abc", "abc"},
+      {"", ""},
+      /* only bytes below 32 go: DEL and high bytes are not control here */
+      {"a\177\303\251", "a\177\303\251"},
+  };
+
+  const size_t ncases = sizeof(cases) / sizeof(cases[0]);
+  char buf[1024];
+  size_t k;
+
+  (void) opt;
+  if (argc > 0) {
+    const size_t n = st_decode_body(argv[0], buf, sizeof(buf));
+
+    assertf(n < sizeof(buf));
+    escape_remove_control(buf);
+    printf("escape-control: len=%d out=hex:", (int) strlen(buf));
+    for (k = 0; buf[k] != '\0'; k++) {
+      printf("%02x", (unsigned char) buf[k]);
+    }
+    printf("\n");
+    return 0;
+  }
+
+  for (k = 0; k < ncases; k++) {
+    const size_t inlen = strlen(cases[k].in);
+    const size_t outlen = strlen(cases[k].out);
+
+    /* poison, so a stray write shows up as a byte a zeroed buffer would hide */
+    memset(buf, '#', sizeof(buf));
+    memcpy(buf, cases[k].in, inlen + 1);
+    escape_remove_control(buf);
+    assertf(strlen(buf) == outlen);
+    assertf(memcmp(buf, cases[k].out, outlen + 1) == 0);
+    /* the terminator belongs inside the original string, never past its NUL */
+    assertf(buf[inlen + 1] == '#');
+  }
+  printf("escape-control self-test OK\n");
+  return 0;
+}
+
 /* fsize()/fsize_utf8()/fpsize() must report a size past 4GB: 32-bit wraps both
    ways there (MSVC's off_t and struct _stat st_size are long, 32-bit even on
    x64), and a size under 4GB would survive an *unsigned* 32-bit truncation. */
@@ -7900,6 +7956,9 @@ static const struct selftest_entry {
      "local save-name for a URL", st_savename},
     {"sniff", "<content-type> <hex:..|text>", "MIME magic consistency",
      st_sniff},
+    {"escape-control", "[hex:..|string]",
+     "escape_remove_control() terminates at the compacted end",
+     st_escape_control},
     {"fsize", "<dir>", "file size past the 2GB signed-32-bit wrap", st_fsize},
     {"growsize", "", "buffer capacity for a 64-bit file size (no int wrap)",
      st_growsize},

--- a/tests/155_engine-escape-control.test
+++ b/tests/155_engine-escape-control.test
@@ -1,8 +1,7 @@
 #!/bin/bash
 #
-# escape_remove_control() used to compact in place without terminating, so a
-# dropped byte left the original tail glued to the result (#974). Hex both ways:
-# raw control bytes do not survive a Windows argv.
+# escape_remove_control() left a dropped byte's tail glued to the result (#974).
+# Vectors are hex: raw control bytes do not survive a Windows argv.
 
 set -euo pipefail
 
@@ -21,6 +20,8 @@ cases=(
     "616263:3:616263" # untouched: the terminator must stay put
     ":0:"
     "617fc3a9:4:617fc3a9" # DEL and high bytes are not stripped
+    "612062:3:612062"     # space is the first byte kept
+    "611f621e63:3:616263" # top of the control range, and two bytes dropped
 )
 
 for c in "${cases[@]}"; do
@@ -34,8 +35,7 @@ for c in "${cases[@]}"; do
         fail "hex:$in: expected len=$len out=hex:$out, got: $got"
 done
 
-# The in-binary table also checks what the printed result cannot show: that
-# nothing is written past the input's own NUL.
+# The in-binary table also checks the bytes past the NUL, which printing cannot show.
 got=$(httrack "-#test=escape-control") || fail "self-test exited non-zero"
 grep -q "escape-control self-test OK" <<<"$got" ||
     fail "unexpected self-test output: $got"

--- a/tests/155_engine-escape-control.test
+++ b/tests/155_engine-escape-control.test
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# escape_remove_control() used to compact in place without terminating, so a
+# dropped byte left the original tail glued to the result (#974). Hex both ways:
+# raw control bytes do not survive a Windows argv.
+
+set -euo pipefail
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+# input : expected length : expected output
+cases=(
+    "2f610b6263:4:2f616263" # VT mid-path, the shape the parser can reach
+    "0c616263:3:616263"     # FF first: every byte moves
+    "6162630b:3:616263"     # VT last: nothing moves, but the end does
+    "61626301646566:6:616263646566"
+    "010203:0:"       # all control
+    "616263:3:616263" # untouched: the terminator must stay put
+    ":0:"
+    "617fc3a9:4:617fc3a9" # DEL and high bytes are not stripped
+)
+
+for c in "${cases[@]}"; do
+    in=${c%%:*}
+    rest=${c#*:}
+    len=${rest%%:*}
+    out=${rest#*:}
+    got=$(httrack "-#test=escape-control" "hex:$in") ||
+        fail "hex:$in exited non-zero"
+    test "$got" = "escape-control: len=$len out=hex:$out" ||
+        fail "hex:$in: expected len=$len out=hex:$out, got: $got"
+done
+
+# The in-binary table also checks what the printed result cannot show: that
+# nothing is written past the input's own NUL.
+got=$(httrack "-#test=escape-control") || fail "self-test exited non-zero"
+grep -q "escape-control self-test OK" <<<"$got" ||
+    fail "unexpected self-test output: $got"

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -241,3 +241,4 @@ TESTS += 205_install-headers.test
 TESTS += 185_webhttrack-js-escaping.test
 TESTS += 200_pixmaps-fallback.test
 TESTS += 210_appstream-metainfo.test
+TESTS += 155_engine-escape-control.test


### PR DESCRIPTION
`escape_remove_control()` compacted the non-control bytes downward in place but never wrote the new terminator, so any input it actually shortened came back as the compacted head with the original tail still attached: `/a\013bc` came out `/abcc`. The function is `HTSEXT_API` and declared in the installed `httrack-library.h`, so the contract it broke is a public one.

The parser can get there. VT and FF are `is_space()` members, so the link scan lets them through, and the later strip only removes CR, LF and TAB. Against a local server, a page with `href="/a<VT>bc"` fetches `/abcc` (a 404) before the fix and `/abc` after it.

Covered by a new `-#test=escape-control` self-test and `tests/155_engine-escape-control.test`, pinning the exact bytes and length per vector plus a poisoned-buffer check that nothing is written past the NUL. No crawl test: the corruption is entirely inside the function, and freezing "a vertical tab in an href is stripped and followed" is #982's call, not this one.

Closes #974
