### PR TITLE
Make six lang/*.txt files agree with their own LANGUAGE_CHARSET

### DIFF
--- a/lang/Croatian.txt
+++ b/lang/Croatian.txt
@@ -7,7 +7,7 @@ hr
 LANGUAGE_AUTHOR
 Dominko Aždajiæ (domazd@mail.ru) \r\n
 LANGUAGE_CHARSET
-ISO-8859-2
+windows-1250
 LANGUAGE_WINDOWSID
 Croatian
 OK
@@ -373,7 +373,7 @@ Napraviti poèetnu stranicu
 Create a word database of all html pages
 Napraviti spisak rijeèi sa svih stranica HTML-a
 Build a complete RFC822 mail (MHT/EML) archive of the mirror
-Izraditi potpunu po¹tansku arhivu RFC822 (MHT/EML) zrcala
+Izraditi potpunu poštansku arhivu RFC822 (MHT/EML) zrcala
 Create error logging and report files
 Napraviti datoteke zapisnika pogrešaka i izvješæa o tijeku postupka
 Generate DOS 8-3 filenames ONLY
@@ -425,9 +425,9 @@ Komentar koji æe biti smješten u svakoj datoteci HTML-a
 Languages accepted by the browser
 Jezici koje prihvaæa preglednik
 Additional HTTP headers to be sent in each requests
-Dodatna HTTP zaglavlja koja se ¹alju u svakom zahtjevu
+Dodatna HTTP zaglavlja koja se šalju u svakom zahtjevu
 HTTP referer to be sent for initial URLs
-HTTP referer koji se ¹alje za poèetne URL-ove
+HTTP referer koji se šalje za poèetne URL-ove
 Back to starting page
 Natrag na poèetnu stranicu
 Save current preferences as default values
@@ -489,7 +489,7 @@ Napraviti kazalo
 Make a word database
 Napraviti spisak rijeèi
 Build a mail archive
-Izraditi po¹tansku arhivu
+Izraditi poštansku arhivu
 Log files
 Zapisnièke datoteke
 DOS names (8+3)
@@ -949,7 +949,7 @@ Tijekom ovog zrcaljenja je nastala fatalna pogreška
 Proxy type:
 Vrsta posrednika:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
-Protokol posrednika. HTTP: standardni posrednik. HTTP (CONNECT tunel): ¹alje svaki zahtjev kroz CONNECT tunel, za posrednike koji podr¾avaju samo CONNECT poput Torovog HTTPTunnelPorta. SOCKS5: zadani port 1080.
+Protokol posrednika. HTTP: standardni posrednik. HTTP (CONNECT tunel): šalje svaki zahtjev kroz CONNECT tunel, za posrednike koji podržavaju samo CONNECT poput Torovog HTTPTunnelPorta. SOCKS5: zadani port 1080.
 Load cookies from file:
 Uèitati kolaèiæe iz datoteke:
 Preload cookies from a Netscape cookies.txt file before crawling.
@@ -959,15 +959,15 @@ Stanka izmeðu datoteka:
 Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
 Nasumièna odgoda izmeðu preuzimanja datoteka, u sekundama. Za nasumièni raspon koristiti MIN:MAX (npr. 2:8).
 Keep the www. prefix (do not merge www.host with host)
-Zadr¾ati www. predmetak (ne spajati www.host s host)
+Zadržati www. predmetak (ne spajati www.host s host)
 Do not treat www.host and host as the same site.
 www.host i host ne smatrati istim web-mjestom.
 Keep double slashes in URLs
-Zadr¾ati dvostruke kose crte u URL-ovima
+Zadržati dvostruke kose crte u URL-ovima
 Do not collapse duplicate slashes in URLs.
-Ne sa¾imati ponovljene kose crte u URL-ovima.
+Ne sažimati ponovljene kose crte u URL-ovima.
 Keep the original query-string order
-Zadr¾ati izvorni redoslijed teksta za upite
+Zadržati izvorni redoslijed teksta za upite
 Do not reorder query-string parameters when deduplicating URLs.
 Ne mijenjati redoslijed parametara teksta za upite pri uklanjanju dvostrukih URL-ova.
 Strip query keys:
@@ -975,7 +975,7 @@ Ukloniti kljuèeve upita:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
 Zarezom odvojeni kljuèevi upita koji se izostavljaju iz naziva spremljenih datoteka (npr. sid,utm_source).
 Write a WARC archive of the crawl
-Zapi¹i WARC arhivu obilaska
+Zapiši WARC arhivu obilaska
 Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
 Spremi i svaki preuzeti odgovor u ISO-28500 WARC/1.1 arhivu, uz zrcalo.
 WARC archive name:
@@ -983,19 +983,19 @@ Naziv WARC arhive:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
 Neobavezni osnovni naziv WARC arhive; ostavite prazno za automatsko imenovanje u izlaznom direktoriju.
 Report what changed since the previous mirror
-Prijavi ¹to se promijenilo od prethodnog zrcaljenja
+Prijavi što se promijenilo od prethodnog zrcaljenja
 Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
-Zapi¹i i hts-changes.json s popisom onoga ¹to je u odnosu na prethodno zrcaljenje novo, promijenjeno, nepromijenjeno ili nestalo.
+Zapiši i hts-changes.json s popisom onoga što je u odnosu na prethodno zrcaljenje novo, promijenjeno, nepromijenjeno ili nestalo.
 Inline assets as data: URIs (self-contained pages)
 Ugradi resurse kao data: URI-je (samostalne stranice)
 Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
-Nakon dovr¹etka zrcaljenja ponovno zapi¹i svaku spremljenu stranicu s ugraðenim stilskim listovima, skriptama, slikama i fontovima, tako da se stranica mo¾e otvoriti i zasebno.
+Nakon dovršetka zrcaljenja ponovno zapiši svaku spremljenu stranicu s ugraðenim stilskim listovima, skriptama, slikama i fontovima, tako da se stranica može otvoriti i zasebno.
 Largest inlined asset (bytes):
 Najveæi ugraðeni resurs (bajtovi):
 An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
-Resurs veæi od ove velièine zadr¾ava obiènu poveznicu; ostavite prazno za zadanih 10485760 bajtova.
+Resurs veæi od ove velièine zadržava obiènu poveznicu; ostavite prazno za zadanih 10485760 bajtova.
 Seed the crawl from the site's sitemap
-Pokreni pretra¾ivanje iz karte web-mjesta
+Pokreni pretraživanje iz karte web-mjesta
 Read the site's sitemap (robots.txt Sitemap: lines, then /sitemap.xml) and add every URL it lists as a start URL.
 Proèitaj kartu web-mjesta (retke Sitemap: iz robots.txt, zatim /sitemap.xml) i dodaj svaki navedeni URL kao poèetnu adresu.
 Sitemap address:
@@ -1003,9 +1003,9 @@ Adresa karte web-mjesta:
 Address of a sitemap to read instead of probing the site; leave blank to probe robots.txt then /sitemap.xml.
 Adresa karte web-mjesta koju treba proèitati umjesto ispitivanja web-mjesta; ostavite prazno za ispitivanje robots.txt pa /sitemap.xml.
 Write a CDXJ index of the WARC archive
-Zapi¹i CDXJ indeks WARC arhive
+Zapiši CDXJ indeks WARC arhive
 Also write a sorted CDXJ index listing every record in the WARC archive, for replay tools.
-Zapi¹i i sortirani CDXJ indeks sa svim zapisima WARC arhive, za alate za reprodukciju.
+Zapiši i sortirani CDXJ indeks sa svim zapisima WARC arhive, za alate za reprodukciju.
 Package the crawl as a WACZ file
 Zapakiraj obilazak u WACZ datoteku
 Bundle the WARC archive, its CDXJ index and the mirrored pages into a single WACZ file; implies the WARC archive and the CDXJ index.

--- a/lang/Macedonian.txt
+++ b/lang/Macedonian.txt
@@ -7,7 +7,7 @@ mk
 LANGUAGE_AUTHOR
 јлександар —авиЭ (aleks@macedonia.eu.org) \r \n
 LANGUAGE_CHARSET
-ISO-8859-5
+windows-1251
 LANGUAGE_WINDOWSID
 FYRO Macedonian
 OK
@@ -187,7 +187,7 @@ scanning
 Waiting for scheduled time..
 √о чекам даденото време...
 Transferring data..
-ња’Ёёб Ё– яё‘–вёжЎ..
+ѕренос на податоци..
 Connecting to provider
 ѕоврзуваЬе со проваЉдерот
 [%d seconds] to go before start of operation
@@ -373,7 +373,7 @@ Create a Start Page
 Create a word database of all html pages
  реираЉте word база на податоци на сите html страници
 Build a complete RFC822 mail (MHT/EML) archive of the mirror
-Є„а–—ёвЎ ж’џёбЁ– яёив’ЁбЏ– –аеЎ“– RFC822 (MHT/EML) Ё– ЏёяЎш–в–
+»зработи целосна поштенска архива RFC822 (MHT/EML) на копиЉата
 Create error logging and report files
  реираЉте error logging и датотеки со извештаи
 Generate DOS 8-3 filenames ONLY
@@ -423,11 +423,11 @@ Browser identity
 Comment to be placed in each HTML file
  оментар коЉ треба да биде сместен во секоЉа HTML датотека
 Languages accepted by the browser
-®–„ЎжЎ яаЎд–в’ЁЎ ё‘ яа’џЎбвг“–зёв
+£азици прифатени од прелистувачот
 Additional HTTP headers to be sent in each requests
-іёяёџЁЎв’џЁЎ HTTP „–”џ–“ш– ивё б’ Ўбяа–ь––в “ё б’Џё’ —–а–ъ’
+ƒополнителни HTTP заглавЉа што се испраЭаат во секое бараЬе
 HTTP referer to be sent for initial URLs
-HTTP referer ивё б’ Ўбяа–ь– „– яёз’вЁЎв’ URL –‘а’бЎ
+HTTP referer што се испраЭа за почетните URL адреси
 Back to starting page
 Ќазад до стартната страница
 Save current preferences as default values
@@ -489,7 +489,7 @@ Make an index
 Make a word database
 Ќаправи word база на податоци
 Build a mail archive
-Є„а–—ёвЎ яёив’ЁбЏ– –аеЎ“–
+»зработи поштенска архива
 Log files
 Log датотеки
 DOS names (8+3)
@@ -519,11 +519,11 @@ Identity
 HTML footer
 HTML футер
 Languages
-®–„ЎжЎ
+£азици
 Additional HTTP Headers
-іёяёџЁЎв’џЁЎ HTTP „–”џ–“ш–
+ƒополнителни HTTP заглавЉа
 Default referer URL
-Ѕв–Ё‘–а‘Ё– referer URL –‘а’б–
+—тандардна referer URL адреса
 N# connections
 ЅроЉ на конекции
 Abandon host if error
@@ -947,70 +947,70 @@ Server terminated
 A fatal error has occurred during this mirror
 Ќастана фатална грешка при овоЉ mirror
 Proxy type:
-¬Ўя Ё– яаёЏбЎ:
+“ип на прокси:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
-њаёвёЏёџ Ё– яаёЏбЎ. HTTP: бв–Ё‘–а‘’Ё яаёЏбЎ. HTTP (вгЁ’џ CONNECT): ”ё Ўбяа–ь– б’Џё’ —–а–ъ’ яа’Џг вгЁ’џ CONNECT, „– яаёЏбЎ ивё яё‘‘а÷г“––в б–№ё CONNECT Џ–Џё HTTPTunnelPort Ё– Tor. SOCKS5: бв–Ё‘–а‘Ё– яёав– 1080.
+ѕротокол на прокси. HTTP: стандарден прокси. HTTP (тунел CONNECT): го испраЭа секое бараЬе преку тунел CONNECT, за прокси што поддржуваат само CONNECT како HTTPTunnelPort на Tor. SOCKS5: стандардна порта 1080.
 Load cookies from file:
-≤зЎв–ш Џёџ–зЎъ– ё‘ ‘–вёв’Џ–:
+¬читаЉ колачиЬа од датотека:
 Preload cookies from a Netscape cookies.txt file before crawling.
-Њ‘Ё–яа’‘ “зЎв–ш Џёџ–зЎъ– ё‘ ‘–вёв’Џ– Netscape cookies.txt яа’‘ яа’„’№–ъ’вё.
+ќднапред вчитаЉ колачиЬа од датотека Netscape cookies.txt пред преземаЬето.
 Pause between files:
-њ–г„– №’уг ‘–вёв’ЏЎ:
+ѕауза меГу датотеки:
 Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
-Ѕџгз–шЁё ‘ёжЁ’ъ’ №’уг яа’„’№–ъ–в– Ё– ‘–вёв’ЏЎ, “ё б’ЏгЁ‘Ў. ЇёаЎбвЎ MIN:MAX „– бџгз–’Ё ёяб’” (Ё– яаЎ№’а 2:8).
+—лучаЉно доцнеЬе меГу преземаЬата на датотеки, во секунди.  ористи MIN:MAX за случаен опсег (на пример 2:8).
 Keep the www. prefix (do not merge www.host with host)
-Ј–‘а÷Ў ”ё яа’дЎЏбёв www. (Ё’ бяёшг“–ш www.host бё host)
+«адржи го префиксот www. (не споЉуваЉ www.host со host)
 Do not treat www.host and host as the same site.
-љ’ ва’вЎа–ш ”Ў www.host Ў host Џ–Џё Ўбв б–шв.
+Ќе третираЉ ги www.host и host како ист саЉт.
 Keep double slashes in URLs
-Ј–‘а÷Ў ”Ў ‘“ёшЁЎв’ ЏёбЎ жавЎ “ё URL
+«адржи ги двоЉните коси црти во URL
 Do not collapse duplicate slashes in URLs.
-љ’ ёвбва–Ёг“–ш ”Ў яё“вёа’ЁЎв’ ЏёбЎ жавЎ “ё URL.
+Ќе отстрануваЉ ги повторените коси црти во URL.
 Keep the original query-string order
-Ј–‘а÷Ў ”ё Ў„“ёаЁЎёв а’‘ёбџ’‘ Ё– я–а–№’ваЎв’ “ё —–а–ъ’вё
+«адржи го изворниот редослед на параметрите во бараЬето
 Do not reorder query-string parameters when deduplicating URLs.
-љ’ №’Ёг“–ш ”ё а’‘ёбџ’‘ёв Ё– я–а–№’ваЎв’ Ё– —–а–ъ’вё яаЎ ёвбва–Ёг“–ъ’ ‘гяџЎЏ–вЎ URL.
+Ќе менуваЉ го редоследот на параметрите на бараЬето при отстрануваЬе дупликати URL.
 Strip query keys:
-Њвбва–ЁЎ Џџгз’“Ў ё‘ —–а–ъ’вё:
+ќтстрани клучеви од бараЬето:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
-Їџгз’“Ў ё‘ —–а–ъ’вё, ё‘‘’џ’ЁЎ бё „–яЎаЏ–, ивё б’ ёвбва–Ёг“––в ё‘ Ў№’вё Ё– „–зг“–Ё–в– ‘–вёв’Џ– (Ё– яаЎ№’а sid,utm_source).
+ лучеви од бараЬето, одделени со запирка, што се отстрануваат од името на зачуваната датотека (на пример sid,utm_source).
 Write a WARC archive of the crawl
-Ј–яЎиЎ WARC –аеЎ“– Ё– яа’—–аг“–ъ’вё
+«апиши WARC архива на пребаруваЬето
 Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
-Ј–зг“–ш ”ё б’Џёш яа’„’№’Ё ё‘”ё“ёа Ў “ё ISO-28500 WARC/1.1 –аеЎ“–, яёЏа–ш ё”џ’‘–џёвё.
+«ачуваЉ го секоЉ преземен одговор и во ISO-28500 WARC/1.1 архива, покраЉ огледалото.
 WARC archive name:
-Є№’ Ё– WARC –аеЎ“–в–:
+»ме на WARC архивата:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
-Є„—ёаЁё ёбЁё“Ёё Ў№’ „– WARC –аеЎ“–в–; ёбв–“’в’ яа–„Ёё „– –“вё№–вбЏё Ў№’Ёг“–ъ’ “ё Ў„џ’„ЁЎёв ‘Ўа’ЏвёаЎг№.
+»зборно основно име за WARC архивата; оставете празно за автоматско именуваЬе во излезниот директориум.
 Report what changed since the previous mirror
-Є„“’бвЎ ивё ’ яаё№’Ё’вё ё‘ яа’веё‘Ёёвё ё”џ’‘–џё
+»звести што е променето од претходното огледало
 Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
-Ј–яЎиЎ Ў hts-changes.json бё бяЎбёЏ Ё– вё– ивё ’ Ёё“ё, яаё№’Ё’вё, Ё’яаё№’Ё’вё ЎџЎ Ўбз’„Ё–вё “ё ё‘Ёёб Ё– яа’веё‘Ёёвё ё”џ’‘–џё.
+«апиши и hts-changes.json со список на тоа што е ново, променето, непроменето или исчезнато во однос на претходното огледало.
 Inline assets as data: URIs (self-contained pages)
-≤”а–‘Ў ”Ў а’бгабЎв’ Џ–Џё data: URI (б–№ёбвёшЁЎ бва–ЁЎжЎ)
+¬гради ги ресурсите како data: URI (самостоЉни страници)
 Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
-њё „–“аиг“–ъ’ Ё– ё”џ’‘–џёвё, б’Џёш– „–зг“–Ё– бва–ЁЎж– б’ яа’яЎиг“– бё “”а–‘’ЁЎ бвЎџбЏЎ џЎбвё“Ў, бЏаЎявЎ, бџЎЏЎ Ў дёЁвё“Ў, „– ‘– №ё÷’ бва–ЁЎж–в– ‘– б’ ёв“ёаЎ Ў б–№ёбвёшЁё.
+ѕо завршуваЬе на огледалото, секоЉа зачувана страница се препишува со вградени стилски листови, скрипти, слики и фонтови, за да може страницата да се отвори и самостоЉно.
 Largest inlined asset (bytes):
-љ–ш”ёџ’№ “”а–‘’Ё а’бгаб (—–швЎ):
+ЌаЉголем вграден ресурс (баЉти):
 An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
-ј’бгаб яё”ёџ’№ ё‘ ё“–– ”ёџ’№ЎЁ– „–‘а÷г“– ё—ЎзЁ– “абЏ–; ёбв–“’в’ яа–„Ёё „– бв–Ё‘–а‘ЁЎв’ 10485760 —–швЎ.
+–есурс поголем од оваа големина задржува обична врска; оставете празно за стандардните 10485760 баЉти.
 Seed the crawl from the site's sitemap
-Ј–яёзЁЎ ”ё яа’—–аг“–ъ’вё ё‘ Џ–ав–в– Ё– б–швёв
+«апочни го пребаруваЬето од картата на саЉтот
 Read the site's sitemap (robots.txt Sitemap: lines, then /sitemap.xml) and add every URL it lists as a start URL.
-њаёзЎв–ш ш– Џ–ав–в– Ё– б–швёв (а’‘ё“Ўв’ Sitemap: “ё robots.txt, яёвё– /sitemap.xml) Ў ‘ё‘–ш ш– б’Џёш– Ё–“’‘’Ё– URL –‘а’б– Џ–Џё яёз’вЁ–.
+ѕрочитаЉ Ља картата на саЉтот (редовите Sitemap: во robots.txt, потоа /sitemap.xml) и додаЉ Ља секоЉа наведена URL адреса како почетна.
 Sitemap address:
-∞‘а’б– Ё– Џ–ав–в– Ё– б–швёв:
+јдреса на картата на саЉтот:
 Address of a sitemap to read instead of probing the site; leave blank to probe robots.txt then /sitemap.xml.
-∞‘а’б– Ё– Џ–ав– Ё– б–швёв ивё ва’—– ‘– б’ яаёзЎв– Ё–№’бвё ЎбяЎвг“–ъ’ Ё– б–швёв; ёбв–“’в’ яа–„Ёё „– ‘– б’ ЎбяЎв– robots.txt, я– /sitemap.xml.
+јдреса на карта на саЉтот што треба да се прочита наместо испитуваЬе на саЉтот; оставете празно за да се испита robots.txt, па /sitemap.xml.
 Write a CDXJ index of the WARC archive
-Ј–яЎиЎ CDXJ ЎЁ‘’Џб Ё– WARC –аеЎ“–в–
+«апиши CDXJ индекс на WARC архивата
 Also write a sorted CDXJ index listing every record in the WARC archive, for replay tools.
-Ј–яЎиЎ Ў бёавЎа–Ё CDXJ ЎЁ‘’Џб бё бЎв’ „–яЎбЎ ё‘ WARC –аеЎ“–в–, „– –џ–вЏЎв’ „– а’яаё‘гЏжЎш–.
+«апиши и сортиран CDXJ индекс со сите записи од WARC архивата, за алатките за репродукциЉа.
 Package the crawl as a WACZ file
-Ѕя–Џг“–ш ”ё яа’—–аг“–ъ’вё Џ–Џё WACZ ‘–вёв’Џ–
+—пакуваЉ го пребаруваЬето како WACZ датотека
 Bundle the WARC archive, its CDXJ index and the mirrored pages into a single WACZ file; implies the WARC archive and the CDXJ index.
-Ѕё—’аЎ ”Ў WARC –аеЎ“–в–, Ё’ш„ЎЁЎёв CDXJ ЎЁ‘’Џб Ў ё”џ’‘–ЁЎв’ бва–ЁЎжЎ “ё ’‘Ё– WACZ ‘–вёв’Џ–; ”Ў “Џџгзг“– WARC –аеЎ“–в– Ў CDXJ ЎЁ‘’Џбёв.
+—обери ги WARC архивата, неЉзиниот CDXJ индекс и огледаните страници во една WACZ датотека; ги вклучува WARC архивата и CDXJ индексот.
 WARC segment size limit:
-љ–ш”ёџ’№– ”ёџ’№ЎЁ– Ё– WARC б’”№’Ёв:
+ЌаЉголема големина на WARC сегмент:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
-Ј–яёзЁЎ Ёё“ WARC б’”№’Ёв Џё”– в’Џё“ЁЎёв ь’ ”ё Ё–‘№ЎЁ’ ё“ёш —аёш —–швЎ; ёбв–“’в’ яа–„Ёё ЎџЎ 0 „– ’‘Ё– ‘–вёв’Џ–.
+«апочни нов WARC сегмент кога тековниот Эе го надмине овоЉ броЉ баЉти; оставете празно или 0 за една датотека.

--- a/lang/Polski.txt
+++ b/lang/Polski.txt
@@ -7,7 +7,7 @@ pl
 LANGUAGE_AUTHOR
 Lukasz Jokiel (Opole University of Technology, Lukasz.Jokiel at po.opole.pl) \r\n
 LANGUAGE_CHARSET
-ISO-8859-2
+windows-1250
 LANGUAGE_WINDOWSID
 Polish
 OK
@@ -207,7 +207,7 @@ Zakoñczono tworzenie lustra.\r\nKliknij OK aby wyjœæ z WinHTTrack.\r\nSprawdŸ lo
 * * MIRROR ABORTED! * *\r\nThe current temporary cache is required for any update operation and only contains data downloaded during the present aborted session.\r\nThe former cache might contain more complete information; if you do not want to lose that information, you have to restore it and delete the current cache.\r\n[Note: This can easily be done here by erasing the hts-cache/new.* files]\r\n\r\nDo you think the former cache might contain more complete information, and do you want to restore it?
 * * TWORZENIE LUSTRA PRZERWANE! * *\r\nObecnie wykorzystywany cache, wymagany dla jakichkolwiek operacji uaktualniaj¹cych zawiera jedynie dane z obecnej przerwanej sesji.\r\nPoprzedni cache mo¿e zawieraæ bardziej kompletne dane; jeœli nie chcesz ich straciæ, przywróæ je i usuñ obecny cache.\r\n[Uwaga: Mo¿esz to ³atwo zrobiæ tutaj poprzez skasowanie htscache/new.* pliki]\r\nCzy uwa¿asz, ¿e poprzedni cache mo¿e zawieraæ bardziej kompletne informacje i czy przywróciæ go ?
 * * MIRROR ERROR! * *\r\nHTTrack has detected that the current mirror is empty. If it was an update, the previous mirror has been restored.\r\nReason: the first page(s) either could not be found, or a connection problem occurred.\r\n=> Ensure that the website still exists, and/or check your proxy settings! <=
-* * B£¡D LUSTRA! * *\r\nHTtrack stwierdza ze obecne lustro jest puste. Je¶li by³o to uaktualnienie, to przywrócono poprzedni± wersjê lustra. Powód: Nie mo¿na by³o odczytaæ pierwszych stron lub wyst±pi³ b³±d po³±czenia.\r\n=> Upewnij siê czy strona ci±gle istnieje, lub te¿ sprawd¼ ustawienia proxy! <=
+* * B£¥D LUSTRA! * *\r\nHTtrack stwierdza ze obecne lustro jest puste. Jeœli by³o to uaktualnienie, to przywrócono poprzedni¹ wersjê lustra. Powód: Nie mo¿na by³o odczytaæ pierwszych stron lub wyst¹pi³ b³¹d po³¹czenia.\r\n=> Upewnij siê czy strona ci¹gle istnieje, lub te¿ sprawdŸ ustawienia proxy! <=
 \n\nTip: Click [View log file] to see warning or error messages
 Tip: Kliknij (Poka¿ logi) aby zobaczyæ informacje o b³êdach i ostrze¿eniach
 Error deleting a hts-cache/new.* file, please do it manually
@@ -371,7 +371,7 @@ Nie pobieraj plików ju¿ obecnych lokalnie, z zerow¹ wielkoœci¹ albo wymazancyh p
 Create a Start Page
 Utwórz stronê startow¹
 Create a word database of all html pages
-Utwórz bazê s³ów wystêpuj±cych we wszystkich stronach HTML
+Utwórz bazê s³ów wystêpuj¹cych we wszystkich stronach HTML
 Build a complete RFC822 mail (MHT/EML) archive of the mirror
 Utwórz pe³ne archiwum pocztowe RFC822 (MHT/EML) lustra
 Create error logging and report files
@@ -389,7 +389,7 @@ Wybierz katalog lustra w tym serwisie
 Select global parsing direction
 Wybierz globalny katalog lustra w tym serwisie
 Setup URL rewriting rules for internal links (downloaded ones) and external links (not downloaded ones)
-Ustaw metody przepisywania URL'i dla l±czy dostêpnych lokalnie (pobranych) oraz ³±czy dostêpnych przez Internet (niepobranych)
+Ustaw metody przepisywania URL'i dla l¹czy dostêpnych lokalnie (pobranych) oraz ³¹czy dostêpnych przez Internet (niepobranych)
 Max simultaneous connections
 Maksymalna liczba po³¹czeñ
 File timeout
@@ -417,17 +417,17 @@ Maksymalna prêdkoœæ transferu
 Maximum connections/seconds (avoid server overload)
 Maksymalna iloœæ po³¹czeñ na sekundê (zapobiwga przec¹¿eniu serwera)
 Maximum number of links that can be tested (not saved!)
-Maksymalna liczba ³±cz jakie mog± byæ przetestowane (zapisanych mo¿e byæ wiêcej!)
+Maksymalna liczba ³¹cz jakie mog¹ byæ przetestowane (zapisanych mo¿e byæ wiêcej!)
 Browser identity
 Identyfikacja przegl¹darki
 Comment to be placed in each HTML file
 Stopka do umieszczenia w ka¿dym pliku HTML
 Languages accepted by the browser
-Jêzyki akceptowane przez przegl±darkê
+Jêzyki akceptowane przez przegl¹darkê
 Additional HTTP headers to be sent in each requests
-Dodatkowe nag³ówki HTTP wysy³ane w ka¿dym ¿±daniu
+Dodatkowe nag³ówki HTTP wysy³ane w ka¿dym ¿¹daniu
 HTTP referer to be sent for initial URLs
-Nag³ówek HTTP referer wysy³any dla pocz±tkowych adresów URL
+Nag³ówek HTTP referer wysy³any dla pocz¹tkowych adresów URL
 Back to starting page
 Z powortem do strony startowej
 Save current preferences as default values
@@ -463,7 +463,7 @@ Spróbuj omin¹æ pewne b³êdy (bugs) serwera dziêki u¿yciu niestandardowych ¿¹dañ
 Use old HTTP/1.0 requests (limits engine power!)
 U¿yj trybu zgodnoœci z starszym standardem HTTP/1.0 (ogranicza moc silnika programu)
 Attempt to limit retransfers through several tricks (file size test..)
-Próba ograniczenia powtórnych transferów dziêki kilku trikom (test wielko¶ci pliku)
+Próba ograniczenia powtórnych transferów dziêki kilku trikom (test wielkoœci pliku)
 Attempt to limit the number of links by skipping similar URLs (www.foo.com==foo.com, http=https ..)
 Spróbuj ogranicznyc ilosc lacz poprzez  pomijanie podobnych URL'i (www.foo.com==foo.com, http=https ..)
 Write external links without login/password
@@ -509,7 +509,7 @@ Zwykle te opcje nie powinny byæ modyfikowane
 Activate Debugging Mode (winhttrack.log)
 Aktywacja trybu dla debuggera (winthhrack.log)
 Rewrite links: internal / external
-Przepisz ³±cza: na dostêpne lokalnie (pobierane i lokalne)/ na dostêpne przez Internet (zewnêtrzne i niepobierane)
+Przepisz ³¹cza: na dostêpne lokalnie (pobierane i lokalne)/ na dostêpne przez Internet (zewnêtrzne i niepobierane)
 Flow control
 Kontrola przep³ywu
 Limits
@@ -523,7 +523,7 @@ Jêzyki
 Additional HTTP Headers
 Dodatkowe nag³ówki HTTP
 Default referer URL
-Domy¶lny adres URL referera
+Domyœlny adres URL referera
 N# connections
 N# po³¹czeñ
 Abandon host if error
@@ -583,7 +583,7 @@ U¿yj ¿¹dañ HTTP/1.0 (BEZ HTTP/1.1)
 Max connections / seconds
 Maksymalna iloœæ po³¹czeñ na sekundê
 Maximum number of links
-Maksymalna liczba ³±cz
+Maksymalna liczba ³¹cz
 Pause after downloading..
 Pauza po pobraniu
 Hide passwords
@@ -759,7 +759,7 @@ Zapisz j&ako...
 &Delete...
 &Usuñ
 &Browse sites...
-&Przegl±daj strony sieciowe...
+&Przegl¹daj strony sieciowe...
 User-defined structure
 Struktura zdefiniowana przez u¿ytkownika
 %n\tName of file without file type (ex: image)\r\n%N\tName of file including file type (ex: image.gif)\r\n%t\tFile type only (ex: gif)\r\n%p\tPath [without ending /] (ex: /someimages)\r\n%h\tHost name (ex: www.someweb.com)\r\n%M\tMD5 URL (128 bits, 32 ascii bytes)\r\n%Q\tMD5 query string (128 bits, 32 ascii bytes)\r\n%q\tMD5 small query string (16 bits, 4 ascii bytes)\r\n\r\n%s?\tShort name (ex: %sN)
@@ -919,7 +919,7 @@ normalny\nrozszerzony\ntestowy
 Download web site(s)\nDownload web site(s) + questions\nGet individual files\nDownload all sites in pages (multiple mirror)\nTest links in pages (bookmark test)\n* Continue interrupted download\n* Update existing download
 Pobierz stronê(y) Web\nPobierz stronê(y) Web + pytania\npobierz oddzielne pliki\nPobierz strony Web w stronach (wiele luster)\nTestuj ³¹cza na stronach (test zak³adek)\n* Wznów tworzenie lustra\n* Uaktualnij lustro
 Relative URI / Absolute URL (default)\nAbsolute URL / Absolute URL\nAbsolute URI / Absolute URL\nOriginal URL / Original URL
-Relatywne URI / Absolutne URI (domy¶lnie)\nAbsolutne RRL / Absolutne URL\nAbsolutne URI / Absolutne URL\nOriginalne URL / Oryginalne URL
+Relatywne URI / Absolutne URI (domyœlnie)\nAbsolutne RRL / Absolutne URL\nAbsolutne URI / Absolutne URL\nOriginalne URL / Oryginalne URL
 Open Source offline browser
 Przegladarka Offline Open Source
 Website Copier/Offline Browser. Copy remote websites to your computer. Free.
@@ -949,7 +949,7 @@ Podczas tworzenia lustra wydarzyl sie fatalny blad.
 Proxy type:
 Typ proxy:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
-Protokó³ proxy. HTTP: standardowe proxy. HTTP (tunel CONNECT): wysy³a ka¿de ¿±danie przez tunel CONNECT, dla proxy obs³uguj±cych tylko CONNECT, jak HTTPTunnelPort w Torze. SOCKS5: port domy¶lny 1080.
+Protokó³ proxy. HTTP: standardowe proxy. HTTP (tunel CONNECT): wysy³a ka¿de ¿¹danie przez tunel CONNECT, dla proxy obs³uguj¹cych tylko CONNECT, jak HTTPTunnelPort w Torze. SOCKS5: port domyœlny 1080.
 Load cookies from file:
 Wczytaj ciasteczka z pliku:
 Preload cookies from a Netscape cookies.txt file before crawling.
@@ -957,19 +957,19 @@ Wczytaj ciasteczka z pliku Netscape cookies.txt przed rozpoczêciem pobierania.
 Pause between files:
 Pauza miêdzy plikami:
 Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
-Losowe opó¼nienie miêdzy pobieraniem plików, w sekundach. U¿yj MIN:MAX dla losowego zakresu (np. 2:8).
+Losowe opóŸnienie miêdzy pobieraniem plików, w sekundach. U¿yj MIN:MAX dla losowego zakresu (np. 2:8).
 Keep the www. prefix (do not merge www.host with host)
-Zachowaj przedrostek www. (nie ³±cz www.host z host)
+Zachowaj przedrostek www. (nie ³¹cz www.host z host)
 Do not treat www.host and host as the same site.
 Nie traktuj www.host i host jako tej samej witryny.
 Keep double slashes in URLs
-Zachowaj podwójne uko¶niki w adresach URL
+Zachowaj podwójne ukoœniki w adresach URL
 Do not collapse duplicate slashes in URLs.
-Nie scalaj powtórzonych uko¶ników w adresach URL.
+Nie scalaj powtórzonych ukoœników w adresach URL.
 Keep the original query-string order
-Zachowaj oryginaln± kolejno¶æ ci±gu zapytania
+Zachowaj oryginaln¹ kolejnoœæ ci¹gu zapytania
 Do not reorder query-string parameters when deduplicating URLs.
-Nie zmieniaj kolejno¶ci parametrów zapytania podczas usuwania duplikatów adresów URL.
+Nie zmieniaj kolejnoœci parametrów zapytania podczas usuwania duplikatów adresów URL.
 Strip query keys:
 Usuñ klucze zapytania:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
@@ -977,27 +977,27 @@ Rozdzielone przecinkami klucze zapytania pomijane przy nazywaniu zapisanych plik
 Write a WARC archive of the crawl
 Zapisz archiwum WARC z indeksowania
 Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
-Zapisz te¿ ka¿d± pobran± odpowied¼ do archiwum WARC/1.1 ISO-28500, obok kopii lustrzanej.
+Zapisz te¿ ka¿d¹ pobran¹ odpowiedŸ do archiwum WARC/1.1 ISO-28500, obok kopii lustrzanej.
 WARC archive name:
 Nazwa archiwum WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
-Opcjonalna nazwa bazowa archiwum WARC; pozostaw puste, aby nazwaæ je automatycznie w katalogu wyj¶ciowym.
+Opcjonalna nazwa bazowa archiwum WARC; pozostaw puste, aby nazwaæ je automatycznie w katalogu wyjœciowym.
 Report what changed since the previous mirror
-Zg³o¶, co zmieni³o siê od poprzedniej kopii
+Zg³oœ, co zmieni³o siê od poprzedniej kopii
 Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
-Zapisz równie¿ plik hts-changes.json z list± tego, co w porównaniu z poprzedni± kopi± jest nowe, zmienione, niezmienione lub usuniête.
+Zapisz równie¿ plik hts-changes.json z list¹ tego, co w porównaniu z poprzedni¹ kopi¹ jest nowe, zmienione, niezmienione lub usuniête.
 Inline assets as data: URIs (self-contained pages)
-Osad¼ zasoby jako identyfikatory data: URI (samodzielne strony)
+OsadŸ zasoby jako identyfikatory data: URI (samodzielne strony)
 Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
-Po zakoñczeniu tworzenia kopii przepisz ka¿d± zapisan± stronê z osadzonymi arkuszami stylów, skryptami, obrazami i czcionkami, aby stronê mo¿na by³o otworzyæ równie¿ samodzielnie.
+Po zakoñczeniu tworzenia kopii przepisz ka¿d¹ zapisan¹ stronê z osadzonymi arkuszami stylów, skryptami, obrazami i czcionkami, aby stronê mo¿na by³o otworzyæ równie¿ samodzielnie.
 Largest inlined asset (bytes):
 Najwiêkszy osadzony zasób (bajty):
 An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
-Zasób wiêkszy ni¿ ten rozmiar zachowuje zwyk³y odno¶nik; pozostaw puste, aby u¿yæ domy¶lnych 10485760 bajtów.
+Zasób wiêkszy ni¿ ten rozmiar zachowuje zwyk³y odnoœnik; pozostaw puste, aby u¿yæ domyœlnych 10485760 bajtów.
 Seed the crawl from the site's sitemap
 Rozpocznij pobieranie od mapy witryny
 Read the site's sitemap (robots.txt Sitemap: lines, then /sitemap.xml) and add every URL it lists as a start URL.
-Odczytaj mapê witryny (wiersze Sitemap: w pliku robots.txt, nastêpnie /sitemap.xml) i dodaj ka¿dy wymieniony adres URL jako adres pocz±tkowy.
+Odczytaj mapê witryny (wiersze Sitemap: w pliku robots.txt, nastêpnie /sitemap.xml) i dodaj ka¿dy wymieniony adres URL jako adres pocz¹tkowy.
 Sitemap address:
 Adres mapy witryny:
 Address of a sitemap to read instead of probing the site; leave blank to probe robots.txt then /sitemap.xml.
@@ -1009,8 +1009,8 @@ Zapisz te¿ posortowany indeks CDXJ ze wszystkimi rekordami archiwum WARC, dla na
 Package the crawl as a WACZ file
 Spakuj indeksowanie do pliku WACZ
 Bundle the WARC archive, its CDXJ index and the mirrored pages into a single WACZ file; implies the WARC archive and the CDXJ index.
-Po³±cz archiwum WARC, jego indeks CDXJ i strony kopii lustrzanej w jeden plik WACZ; wymusza archiwum WARC i indeks CDXJ.
+Po³¹cz archiwum WARC, jego indeks CDXJ i strony kopii lustrzanej w jeden plik WACZ; wymusza archiwum WARC i indeks CDXJ.
 WARC segment size limit:
 Maksymalny rozmiar segmentu WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
-Rozpocznij nowy segment WARC, gdy bie¿±cy przekroczy tê liczbê bajtów; pozostaw puste lub 0, aby zachowaæ jeden plik.
+Rozpocznij nowy segment WARC, gdy bie¿¹cy przekroczy tê liczbê bajtów; pozostaw puste lub 0, aby zachowaæ jeden plik.

--- a/lang/Slovak.txt
+++ b/lang/Slovak.txt
@@ -7,7 +7,7 @@ sk
 LANGUAGE_AUTHOR
 Dr. Martin Sereday (sereday at stonline.sk)\r\n
 LANGUAGE_CHARSET
-ISO-8859-2
+windows-1250
 LANGUAGE_WINDOWSID
 Slovak
 OK
@@ -181,7 +181,7 @@ Analıza HTML súboru (testovanie linkov)
 Pause - Toggle [Mirror]/[Pause download] to resume operation
 Pauza - Pokraèova [Stránka - Kópia]/[Zastavi kopírovanie]
 Finishing pending transfers - Select [Cancel] to stop now!
-Ukonèenie prebiehajúcich prenosov - Zvoµ [Zru¹i»]!
+Ukonèenie prebiehajúcich prenosov - Zvo¾ [Zruši]!
 scanning
 Skenovanie
 Waiting for scheduled time..
@@ -269,7 +269,7 @@ Kliknutím pokraèova
 Click to define options
 Kliknú a definova nastavenia
 Click to add a URL
-Klikuntím vlo¾ URL
+Klikuntím vlo URL
 Load URL(s) from text file
 Naèíta URL z textového súboru
 WinHTTrack preferences (*.opt)|*.opt||
@@ -373,7 +373,7 @@ Vytvori úvodnú stránku
 Create a word database of all html pages
 Vytvori databázu všetkıch slov ako html stránky
 Build a complete RFC822 mail (MHT/EML) archive of the mirror
-Vytvori» úplnı po¹tovı archív RFC822 (MHT/EML) zrkadla
+Vytvori úplnı poštovı archív RFC822 (MHT/EML) zrkadla
 Create error logging and report files
 Vytvori protokoly chıb a hlásení
 Generate DOS 8-3 filenames ONLY
@@ -389,7 +389,7 @@ Vybra poradie anaklızy
 Select global parsing direction
 Vybra globálnu analızu
 Setup URL rewriting rules for internal links (downloaded ones) and external links (not downloaded ones)
-Nastav URL prepísaním pravidiel pre vnútorné linky (u¾ skopírované) a vonkaj¹ie linky (e¹te neskopírované).
+Nastav URL prepísaním pravidiel pre vnútorné linky (u skopírované) a vonkajšie linky (ešte neskopírované).
 Max simultaneous connections
 Maximum súèasnıch spojení
 File timeout
@@ -425,7 +425,7 @@ Komentár, ktorı má by umiestnenı do kadého HTML súboru
 Languages accepted by the browser
 Jazyky akceptované prehliadaèom
 Additional HTTP headers to be sent in each requests
-Ïal¹ie hlavièky HTTP odosielané v ka¾dej po¾iadavke
+Ïalšie hlavièky HTTP odosielané v kadej poiadavke
 HTTP referer to be sent for initial URLs
 Hlavièka HTTP referer odosielaná pre poèiatoèné adresy URL
 Back to starting page
@@ -489,7 +489,7 @@ Vytvori index
 Make a word database
 Vytvori slovnú databázu
 Build a mail archive
-Vytvori» po¹tovı archív
+Vytvori poštovı archív
 Log files
 Log súbory
 DOS names (8+3)
@@ -509,7 +509,7 @@ Tieto pravidlá majú by upravované iba vınimoène
 Activate Debugging Mode (winhttrack.log)
 Aktivova mód vyh¾adávania chıb (winhttrack.log)
 Rewrite links: internal / external
-Prepí¹ linky: vnútorné / vonkaj¹ie
+Prepíš linky: vnútorné / vonkajšie
 Flow control
 Kontrola toku
 Limits
@@ -521,7 +521,7 @@ Päta HTML
 Languages
 Jazyky
 Additional HTTP Headers
-Ïal¹ie hlavièky HTTP
+Ïalšie hlavièky HTTP
 Default referer URL
 Predvolená adresa referer
 N# connections
@@ -539,9 +539,9 @@ Pre prenosy cez ftp poui proxy
 TimeOut(s)
 Interval(y) èakania
 Persistent connections (Keep-Alive)
-Trvalé spojenie (Udr¾a»-¾ivé)
+Trvalé spojenie (Udra-ivé)
 Reduce connection time and type lookup time using persistent connections
-Zní¾ dobu pripojenia a zadaj èas vyhµadávania pri trvalıch spojeniach
+Zní dobu pripojenia a zadaj èas vyh¾adávania pri trvalıch spojeniach
 Retries
 Opätovné pokusy
 Size limit
@@ -917,7 +917,7 @@ Ignorova pravidlá v robots.txt\nPrevza pravidlá -//- okrem filtrov\nPrevzia v
 normal\nextended\ndebug
 normálny\nrozšírenı\nladenie
 Download web site(s)\nDownload web site(s) + questions\nGet individual files\nDownload all sites in pages (multiple mirror)\nTest links in pages (bookmark test)\n* Continue interrupted download\n* Update existing download
-Skopíruj web stránku(y)\nSkopíruj web stránku(y) + otázky\nPreber jednotlivé súbory\nSkopíruj v¹etky umiestnenia na stánkach (viacnásobné zrkadlo)\nOtestuj linky na stránkach (testuj zálo¾ky)\n* Pokraèuj v preru¹enom kopírovaní\n* Aktualizuj existujúce kópie
+Skopíruj web stránku(y)\nSkopíruj web stránku(y) + otázky\nPreber jednotlivé súbory\nSkopíruj všetky umiestnenia na stánkach (viacnásobné zrkadlo)\nOtestuj linky na stránkach (testuj záloky)\n* Pokraèuj v prerušenom kopírovaní\n* Aktualizuj existujúce kópie
 Relative URI / Absolute URL (default)\nAbsolute URL / Absolute URL\nAbsolute URI / Absolute URL\nOriginal URL / Original URL
 Relatívna URI / Absolútna URL (prednastavené)\nABsolútna URL / Absolútna URL\nAbsolútna URL\nPôvodná URL / Pôvodná URL
 Open Source offline browser
@@ -949,68 +949,68 @@ A fatal error has occurred during this mirror
 Proxy type:
 Typ proxy:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
-Protokol proxy. HTTP: ¹tandardné proxy. HTTP (tunel CONNECT): odo¹le ka¾dú po¾iadavku cez tunel CONNECT, pre proxy podporujúce len CONNECT ako HTTPTunnelPort v Tore. SOCKS5: predvolenı port 1080.
+Protokol proxy. HTTP: štandardné proxy. HTTP (tunel CONNECT): odošle kadú poiadavku cez tunel CONNECT, pre proxy podporujúce len CONNECT ako HTTPTunnelPort v Tore. SOCKS5: predvolenı port 1080.
 Load cookies from file:
-Naèíta» cookies zo súboru:
+Naèíta cookies zo súboru:
 Preload cookies from a Netscape cookies.txt file before crawling.
-Naèíta» cookies zo súboru Netscape cookies.txt pred zaèatím s»ahovania.
+Naèíta cookies zo súboru Netscape cookies.txt pred zaèatím sahovania.
 Pause between files:
 Prestávka medzi súbormi:
 Random delay between file downloads, in seconds. Use MIN:MAX for a random range (e.g. 2:8).
-Náhodné oneskorenie medzi s»ahovaním súborov, v sekundách. Pre náhodnı rozsah pou¾ite MIN:MAX (napr. 2:8).
+Náhodné oneskorenie medzi sahovaním súborov, v sekundách. Pre náhodnı rozsah pouite MIN:MAX (napr. 2:8).
 Keep the www. prefix (do not merge www.host with host)
-Zachova» predponu www. (nezluèova» www.host s host)
+Zachova predponu www. (nezluèova www.host s host)
 Do not treat www.host and host as the same site.
-Nepova¾ova» www.host a host za tú istú lokalitu.
+Nepovaova www.host a host za tú istú lokalitu.
 Keep double slashes in URLs
-Zachova» dvojité lomky v URL
+Zachova dvojité lomky v URL
 Do not collapse duplicate slashes in URLs.
-Nezluèova» opakované lomky v URL.
+Nezluèova opakované lomky v URL.
 Keep the original query-string order
-Zachova» pôvodné poradie re»azca dotazu
+Zachova pôvodné poradie reazca dotazu
 Do not reorder query-string parameters when deduplicating URLs.
-Nemeni» poradie parametrov re»azca dotazu pri odstraòovaní duplicitnıch URL.
+Nemeni poradie parametrov reazca dotazu pri odstraòovaní duplicitnıch URL.
 Strip query keys:
-Odstráni» kµúèe dotazu:
+Odstráni k¾úèe dotazu:
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
-Kµúèe dotazu oddelené èiarkami, ktoré sa vynechajú z pomenovania ukladanıch súborov (napr. sid,utm_source).
+K¾úèe dotazu oddelené èiarkami, ktoré sa vynechajú z pomenovania ukladanıch súborov (napr. sid,utm_source).
 Write a WARC archive of the crawl
-Zapísa» archív WARC z prehµadávania
+Zapísa archív WARC z preh¾adávania
 Also save every fetched response into an ISO-28500 WARC/1.1 archive, next to the mirror.
-Ulo¾i» aj ka¾dú stiahnutú odpoveï do archívu WARC/1.1 ISO-28500 vedµa zrkadla.
+Uloi aj kadú stiahnutú odpoveï do archívu WARC/1.1 ISO-28500 ved¾a zrkadla.
 WARC archive name:
 Názov archívu WARC:
 Optional base name for the WARC archive; leave blank to auto-name it under the output directory.
-Voliteµnı základnı názov archívu WARC; ponechajte prázdne pre automatické pomenovanie vo vıstupnom adresári.
+Volite¾nı základnı názov archívu WARC; ponechajte prázdne pre automatické pomenovanie vo vıstupnom adresári.
 Report what changed since the previous mirror
-Oznámi», èo sa od predchádzajúceho zrkadlenia zmenilo
+Oznámi, èo sa od predchádzajúceho zrkadlenia zmenilo
 Also write hts-changes.json listing what this crawl left new, changed, unchanged and gone compared to the previous mirror.
-Zapísa» aj hts-changes.json so zoznamom toho, èo je oproti predchádzajúcemu zrkadleniu nové, zmenené, nezmenené alebo chıbajúce.
+Zapísa aj hts-changes.json so zoznamom toho, èo je oproti predchádzajúcemu zrkadleniu nové, zmenené, nezmenené alebo chıbajúce.
 Inline assets as data: URIs (self-contained pages)
-Vlo¾i» zdroje ako URI data: (samostatné stránky)
+Vloi zdroje ako URI data: (samostatné stránky)
 Once the mirror is finished, rewrite every saved page with its stylesheets, scripts, images and fonts embedded, so a page can also be opened on its own.
-Po dokonèení zrkadlenia prepísa» ka¾dú ulo¾enú stránku s vlo¾enımi ¹tılmi, skriptmi, obrázkami a písmami, aby sa stránka dala otvori» aj samostatne.
+Po dokonèení zrkadlenia prepísa kadú uloenú stránku s vloenımi štılmi, skriptmi, obrázkami a písmami, aby sa stránka dala otvori aj samostatne.
 Largest inlined asset (bytes):
-Najväè¹í vlo¾enı zdroj (bajty):
+Najväèší vloenı zdroj (bajty):
 An asset above this size keeps an ordinary link; leave blank for the 10485760-byte default.
-Zdroj väè¹í ne¾ táto veµkos» si ponechá be¾nı odkaz; ponechajte prázdne pre predvolenıch 10485760 bajtov.
+Zdroj väèší ne táto ve¾kos si ponechá benı odkaz; ponechajte prázdne pre predvolenıch 10485760 bajtov.
 Seed the crawl from the site's sitemap
-Zaèa» prehliadanie z mapy stránok
+Zaèa prehliadanie z mapy stránok
 Read the site's sitemap (robots.txt Sitemap: lines, then /sitemap.xml) and add every URL it lists as a start URL.
-Naèíta» mapu stránok (riadky Sitemap: v súbore robots.txt, potom /sitemap.xml) a prida» ka¾dú uvedenú adresu URL ako poèiatoènú.
+Naèíta mapu stránok (riadky Sitemap: v súbore robots.txt, potom /sitemap.xml) a prida kadú uvedenú adresu URL ako poèiatoènú.
 Sitemap address:
 Adresa mapy stránok:
 Address of a sitemap to read instead of probing the site; leave blank to probe robots.txt then /sitemap.xml.
-Adresa mapy stránok, ktorá sa má naèíta» namiesto zis»ovania na stránke; ponechajte prázdne na zistenie z robots.txt a potom /sitemap.xml.
+Adresa mapy stránok, ktorá sa má naèíta namiesto zisovania na stránke; ponechajte prázdne na zistenie z robots.txt a potom /sitemap.xml.
 Write a CDXJ index of the WARC archive
-Zapísa» index CDXJ archívu WARC
+Zapísa index CDXJ archívu WARC
 Also write a sorted CDXJ index listing every record in the WARC archive, for replay tools.
-Zapísa» aj zoradenı index CDXJ so v¹etkımi záznamami archívu WARC, pre nástroje na prehrávanie.
+Zapísa aj zoradenı index CDXJ so všetkımi záznamami archívu WARC, pre nástroje na prehrávanie.
 Package the crawl as a WACZ file
-Zabali» prehµadávanie do súboru WACZ
+Zabali preh¾adávanie do súboru WACZ
 Bundle the WARC archive, its CDXJ index and the mirrored pages into a single WACZ file; implies the WARC archive and the CDXJ index.
-Zlúèi» archív WARC, jeho index CDXJ a zrkadlené stránky do jedného súboru WACZ; vy¾aduje archív WARC a index CDXJ.
+Zlúèi archív WARC, jeho index CDXJ a zrkadlené stránky do jedného súboru WACZ; vyaduje archív WARC a index CDXJ.
 WARC segment size limit:
-Najväè¹ia veµkos» segmentu WARC:
+Najväèšia ve¾kos segmentu WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
-Zaèa» novı segment WARC, keï aktuálny prekroèí tento poèet bajtov; ponechajte prázdne alebo 0 pre jeden súbor.
+Zaèa novı segment WARC, keï aktuálny prekroèí tento poèet bajtov; ponechajte prázdne alebo 0 pre jeden súbor.

--- a/lang/Slovenian.txt
+++ b/lang/Slovenian.txt
@@ -7,7 +7,7 @@ sl
 LANGUAGE_AUTHOR
 Jadran Rudec,iur.\r\njrudec@email.si \r\n
 LANGUAGE_CHARSET
-ISO-8859-1
+windows-1250
 LANGUAGE_WINDOWSID
 Slovenian
 OK

--- a/lang/Svenska.txt
+++ b/lang/Svenska.txt
@@ -7,7 +7,7 @@ sv
 LANGUAGE_AUTHOR
 Staffan Ström (staffan at fam-strom.org) \r\n
 LANGUAGE_CHARSET
-ISO-8859-2
+ISO-8859-1
 LANGUAGE_WINDOWSID
 Swedish
 OK

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -81,7 +81,8 @@ charset_declared_matches_bytes() {
     # No legacy 8-bit charset puts text at U+0080..U+009F, so a C1 there means
     # the bytes are really the matching Windows codepage.
     n=$(LC_ALL=C grep -c "$c1" "$tmp/utf8" || true)
-    if [ "$n" -ne 0 ]; then
+    # An empty n means grep failed, not that it found nothing.
+    if [ "${n:-1}" -ne 0 ]; then
         echo "${f##*/}: $n lines decode to C1 controls under $cs; the bytes are a Windows codepage"
         return 1
     fi
@@ -91,8 +92,9 @@ if ! command -v iconv >/dev/null 2>&1; then
     echo "iconv not found; charset check skipped" >&2
 else
     # Positive controls, one per branch: a file cannot pass while mislabelled.
-    LC_ALL=C sed '10s/.*/UTF-8\r/' "$langdir/Francais.txt" >"$tmp/undecodable.txt"
-    LC_ALL=C sed '10s/.*/ISO-8859-2\r/' "$langdir/Croatian.txt" >"$tmp/c1.txt"
+    # No CR: BSD sed writes a literal r, and the extractor strips CR anyway.
+    LC_ALL=C sed '10s/.*/UTF-8/' "$langdir/Francais.txt" >"$tmp/undecodable.txt"
+    LC_ALL=C sed '10s/.*/ISO-8859-2/' "$langdir/Croatian.txt" >"$tmp/c1.txt"
     for probe in undecodable c1; do
         if charset_declared_matches_bytes "$tmp/$probe.txt" >/dev/null; then
             echo "the charset check passed a deliberately mislabelled file ($probe)"

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -63,6 +63,54 @@ if [ "$nfiles" -lt 25 ]; then
     exit 1
 fi
 
+# html/server/*.html copies LANGUAGE_CHARSET straight into its <meta>, and
+# htsserver.c decodes the POST body with it, so bytes that are not what it says
+# render and convert wrong (#963).
+c1=$(printf '\302[\200-\237]')
+charset_declared_matches_bytes() {
+    f=$1
+    cs=$(LC_ALL=C awk '{ sub(/\r$/, "") } $0 == "LANGUAGE_CHARSET" { p = 1; next } p { print; exit }' "$f")
+    if [ -z "$cs" ]; then
+        echo "${f##*/}: no LANGUAGE_CHARSET declared"
+        return 1
+    fi
+    if ! LC_ALL=C iconv -f "$cs" -t UTF-8 "$f" >"$tmp/utf8" 2>"$tmp/err"; then
+        echo "${f##*/}: bytes do not decode as the declared $cs: $(cat "$tmp/err")"
+        return 1
+    fi
+    # No legacy 8-bit charset puts text at U+0080..U+009F, so a C1 there means
+    # the bytes are really the matching Windows codepage.
+    n=$(LC_ALL=C grep -c "$c1" "$tmp/utf8" || true)
+    if [ "$n" -ne 0 ]; then
+        echo "${f##*/}: $n lines decode to C1 controls under $cs; the bytes are a Windows codepage"
+        return 1
+    fi
+}
+
+if ! command -v iconv >/dev/null 2>&1; then
+    echo "iconv not found; charset check skipped" >&2
+else
+    # Positive controls, one per branch: a file cannot pass while mislabelled.
+    LC_ALL=C sed '10s/.*/UTF-8\r/' "$langdir/Francais.txt" >"$tmp/undecodable.txt"
+    LC_ALL=C sed '10s/.*/ISO-8859-2\r/' "$langdir/Croatian.txt" >"$tmp/c1.txt"
+    for probe in undecodable c1; do
+        if charset_declared_matches_bytes "$tmp/$probe.txt" >/dev/null; then
+            echo "the charset check passed a deliberately mislabelled file ($probe)"
+            exit 1
+        fi
+    done
+
+    nchecked=0
+    for f in "$langdir"/*.txt; do
+        nchecked=$((nchecked + 1))
+        charset_declared_matches_bytes "$f" || fail=1
+    done
+    if [ "$nchecked" -ne "$nfiles" ]; then
+        echo "charset check saw $nchecked of $nfiles language files"
+        exit 1
+    fi
+fi
+
 # lang.def maps each LANG_* macro to the English string the GUI compiles in,
 # which is the lookup key into every lang/*.txt: no msgid, no translations.
 LC_ALL=C awk -v keys="$keys" '


### PR DESCRIPTION
Croatian, Slovak, Polski and Slovenian are stored in CP1250 and Macedonian in CP1251, but each declared an ISO-8859 charset. `html/server/*.html` copies `LANGUAGE_CHARSET` straight into its `<meta>` and `htsserver.c` decodes the POST body with it, so all five render wrong in webhttrack today. Svenska is the mirror image, ISO-8859-2 declared over Latin-1 bytes that agree on everything it uses except å.

Each declaration moves to the codepage the bytes are actually in, and the lines added since #588, which had followed the declaration instead of the surrounding bytes, are transcoded to match. The reverse was not available: Latin-1 cannot spell Slovenian at all, and ISO-8859-2 would lose the typographic quotes and ellipsis Polski uses. `windows-1250` and `windows-1251` are already in the engine's codepage table and already declared by Cesky, Russian, Bulgarian, Ukrainian and Uzbek. Every rewritten line was diffed against the original decoded under its own verdict, so no translation changed meaning. Three Slovak lines whose only high byte is 0xBE were settled by hand as ľ rather than ž, confirmed by the same lexemes spelled with 0xB5 elsewhere in the file.

`62_lang-integrity.test` now decodes each file through its own declared charset and rejects a byte the charset cannot map, or a decode landing in the C1 range, which is the tell of a Windows codepage wearing an ISO-8859 label. It flags exactly the five on master. It cannot see Svenska's class, where both charsets define every byte present, so that half of the fix stays unguarded.

Closes #963
