### PR TITLE
A crash report names no frame of the httrack executable

### DIFF
--- a/src/htsbacktrace.c
+++ b/src/htsbacktrace.c
@@ -92,10 +92,11 @@ static int record_main_base(struct dl_phdr_info *info, size_t size,
 }
 
 static void find_main_object(void) {
-  const ssize_t len =
-      readlink("/proc/self/exe", main_path, sizeof(main_path) - 1);
+  const ssize_t len = readlink("/proc/self/exe", main_path, sizeof(main_path));
 
-  if (len > 0) {
+  /* A full buffer is a clipped path, which readlink() cannot report: its prefix
+     names another file, and the symbolizer would happily open that one. */
+  if (len > 0 && (size_t) len < sizeof(main_path)) {
     main_path[len] = '\0';
     if (dl_iterate_phdr(record_main_base, NULL) == 1)
       return;

--- a/src/htsbacktrace.c
+++ b/src/htsbacktrace.c
@@ -61,6 +61,7 @@ Please visit our Website: http://www.httrack.com
 #include <dlfcn.h>
 #include <errno.h>
 #include <execinfo.h>
+#include <link.h>
 #include <signal.h>
 #include <time.h>
 #include <sys/wait.h>
@@ -76,6 +77,31 @@ Please visit our Website: http://www.httrack.com
 #define BT_NO_SYMBOLIZER 127 /* child exit: execvp() found none */
 
 static hts_boolean symbolize_crash = HTS_TRUE;
+
+/* dladdr() names the main program after argv[0], which the symbolizer cannot
+   open when the binary came off PATH; /proc/self/exe always names the file. */
+static char main_path[BT_PATH_SIZE];
+static const void *main_base;
+
+static int record_main_base(struct dl_phdr_info *info, size_t size,
+                            void *data) {
+  (void) size;
+  (void) data;
+  main_base = (const void *) info->dlpi_addr;
+  return 1; /* dl_iterate_phdr starts at the main program */
+}
+
+static void find_main_object(void) {
+  const ssize_t len =
+      readlink("/proc/self/exe", main_path, sizeof(main_path) - 1);
+
+  if (len > 0) {
+    main_path[len] = '\0';
+    if (dl_iterate_phdr(record_main_base, NULL) == 1)
+      return;
+  }
+  main_path[0] = '\0'; /* unresolved: keep whatever dladdr() reported */
+}
 
 /* "0x"-prefixed hex: the handler must stay stdio-free. */
 static void print_hex(char *buffer, uintptr_t value) {
@@ -182,11 +208,14 @@ static void symbolize_backtrace(void *const *stack, int size, int fd) {
      once, so argc cannot exceed argv[]. */
   for (spawned = 0; spawned < BT_MAX_MODULES; spawned++) {
     int first, j, argc = 0;
+    const char *path;
 
     for (first = 0; first < size && grouped[first]; first++)
       ;
     if (first >= size)
       break;
+    path = main_path[0] != '\0' && base[first] == main_base ? main_path
+                                                            : name[first];
     argv[argc++] = prog;
     argv[argc++] = opts;
     argv[argc++] = dashe;
@@ -200,7 +229,7 @@ static void symbolize_backtrace(void *const *stack, int size, int fd) {
     argv[argc] = NULL;
     /* access(): skip pseudo-modules like linux-vdso, which have no file and
        would draw nothing but an addr2line complaint. */
-    if (copy_bounded(module, sizeof(module), name[first]) &&
+    if (copy_bounded(module, sizeof(module), path) &&
         access(module, R_OK) == 0) {
       const size_t len = strlen(module);
 
@@ -220,6 +249,7 @@ void hts_backtrace_init(void) {
 
   symbolize_crash =
       getenv("HTTRACK_NO_SYMBOLIZE") == NULL ? HTS_TRUE : HTS_FALSE;
+  find_main_object();
   /* Pay for the unwinder now: glibc's first backtrace() dlopen()s libgcc_s,
      which allocates and takes the loader lock the crashing thread may hold. */
   (void) backtrace(frame, 1);

--- a/tests/157_crash-argv0-path.test
+++ b/tests/157_crash-argv0-path.test
@@ -1,7 +1,6 @@
 #!/bin/bash
 # dladdr() names the main program after argv[0], so a binary found on PATH is
-# reported as a bare "httrack" the symbolizer cannot open (#889). The crash
-# report still has to name the executable's own frames.
+# reported as a bare "httrack" the symbolizer cannot open (#889).
 
 set -euo pipefail
 
@@ -65,16 +64,22 @@ fi
 grep -qE '^httrack\(\+0x[0-9a-f]+\)' "${out}" ||
     skip "the main program is not reported as a bare argv[0] here"
 
-header=$(grep -m1 -E '^/.*/httrack:$' "${out}" || true)
-test -n "${header}" || fail "the report has no symbolized block for the executable"
+headers=$(grep -E '^/.*/httrack:$' "${out}" || true)
+test -n "${headers}" || fail "the report has no symbolized block for the executable"
+# Every frame of a module is claimed in one pass, so a second block for the
+# executable means library frames were misattributed to it.
+test "$(wc -l <<<"${headers}")" -eq 1 || fail "several executable blocks: ${headers}"
+header=${headers}
 exe=${header%:}
 # Device+inode, so a symlinked TMPDIR does not read as a different binary.
 test "${exe}" -ef "${bin}" || fail "the report names ${exe}, not the running ${bin}"
 
 # Frames of httrack.c, which stays in the program whether or not the engine is
-# a shared library; the block ends at the next module header.
+# a shared library.
 block=$(awk -v h="${header}" '$0 == h { on = 1; next } /^\// { on = 0 } on' "${out}")
-grep -qE '\b(sig_fatal|main)\b' <<<"${block}" ||
+# " at " pins the symbol column: both addr2line -Cfipa and llvm-symbolizer -p
+# emit it, and a path component named "main" does not.
+grep -qE '(^|[^[:alnum:]_])(sig_fatal|main) at ' <<<"${block}" ||
     fail "the executable's block names no frame: ${block}"
 
 echo "the crash report named ${exe} and its own frames"

--- a/tests/157_crash-argv0-path.test
+++ b/tests/157_crash-argv0-path.test
@@ -1,0 +1,80 @@
+#!/bin/bash
+# dladdr() names the main program after argv[0], so a binary found on PATH is
+# reported as a bare "httrack" the symbolizer cannot open (#889). The crash
+# report still has to name the executable's own frames.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+builddir="${abs_top_builddir:?not run under make check}"
+bindir="${CONFIGURED_BINDIR:?not run under make check}"
+libdir="${CONFIGURED_LIBDIR:?not run under make check}"
+
+out=
+skip() {
+    echo "$*; skipping" >&2
+    exit 77
+}
+fail() {
+    echo "FAIL: $*" >&2
+    test -z "${out}" || sed 's/^/  | /' <"${out}" >&2
+    exit 1
+}
+
+if is_windows; then
+    skip "no backtrace() on Windows"
+fi
+if ! command -v addr2line >/dev/null && ! command -v llvm-symbolizer >/dev/null; then
+    skip "no symbolizer installed"
+fi
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/httrack_argv0.XXXXXX") || exit 1
+trap 'set +e; rm -rf "${work}"' EXIT
+trap 'rm -rf "${work}"' HUP INT QUIT PIPE TERM
+
+# The installed ELF, not the build tree's libtool wrapper: the wrapper re-execs
+# its binary by absolute path, which is the argv[0] this test must not have.
+stage=${work}/stage
+env -u MAKEFLAGS -u MAKELEVEL "${MAKE:-make}" -C "${builddir}/src" install-exec \
+    DESTDIR="${stage}" >"${work}/install.log" 2>&1 || {
+    cat "${work}/install.log" >&2
+    fail "make install-exec DESTDIR=${stage}"
+}
+bin=${stage}${bindir}/httrack
+test -r "${bin}" || fail "no httrack in ${stage}${bindir}"
+
+# No "httrack" here, so a report that kept argv[0] has nothing to open.
+cd "${work}"
+out=${work}/trace
+rc=0
+PATH="${stage}${bindir}:${PATH}" \
+    LD_LIBRARY_PATH="${stage}${libdir%/}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" \
+    run_with_timeout 60 httrack -#test=strsafe overflow \
+    "this string is far too long for the buffer" >"${out}" 2>&1 || rc=$?
+test "${rc}" -ne 124 || fail "the crash handler did not finish within the deadline"
+grep -q '^Caught signal ' "${out}" || fail "the installed binary printed no backtrace"
+if grep -q 'No stack trace available' "${out}"; then
+    skip "this build produced no backtrace"
+fi
+
+# Control: without a bare argv[0] in the raw trace there is nothing to repair,
+# and the assertions below would pass on a report that never needed the fix.
+grep -qE '^httrack\(\+0x[0-9a-f]+\)' "${out}" ||
+    skip "the main program is not reported as a bare argv[0] here"
+
+header=$(grep -m1 -E '^/.*/httrack:$' "${out}" || true)
+test -n "${header}" || fail "the report has no symbolized block for the executable"
+exe=${header%:}
+# Device+inode, so a symlinked TMPDIR does not read as a different binary.
+test "${exe}" -ef "${bin}" || fail "the report names ${exe}, not the running ${bin}"
+
+# Frames of httrack.c, which stays in the program whether or not the engine is
+# a shared library; the block ends at the next module header.
+block=$(awk -v h="${header}" '$0 == h { on = 1; next } /^\// { on = 0 } on' "${out}")
+grep -qE '\b(sig_fatal|main)\b' <<<"${block}" ||
+    fail "the executable's block names no frame: ${block}"
+
+echo "the crash report named ${exe} and its own frames"

--- a/tests/80_engine-crash-symbolize.test
+++ b/tests/80_engine-crash-symbolize.test
@@ -70,6 +70,8 @@ command -v addr2line >/dev/null || {
 oracle="${tmpdir}/oracle"
 sed -n 's/^\([^(]*\)(+\(0x[0-9a-f]*\)).*$/\1 \2/p' "$out" |
     while read -r mod off; do
+        # The main program is reported as argv[0], a bare name off PATH (#889).
+        test -f "$mod" || mod=$(command -v "$mod" 2>/dev/null) || continue
         test -f "$mod" || continue
         addr2line -Cfip -e "$mod" "$off" 2>/dev/null || true
     done >"$oracle"

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -241,3 +241,4 @@ TESTS += 205_install-headers.test
 TESTS += 185_webhttrack-js-escaping.test
 TESTS += 200_pixmaps-fallback.test
 TESTS += 210_appstream-metainfo.test
+TESTS += 157_crash-argv0-path.test


### PR DESCRIPTION
A crash report never named a single frame of the httrack executable itself. glibc's `dladdr()` reports the main program's path as `argv[0]`, so a binary found on PATH comes back as the bare string `httrack`, the symbolizer's `access()` check fails on it, and the whole module is dropped. Shared builds hid this: the engine lives in `libhttrack.so`, whose path the loader records in full, and the build tree's libtool wrapper re-execs its binary by absolute path. Configure with `--disable-shared` and the engine moves into the executable, taking the stack with it. That is the failing `105_suite-timeout` and the skip beside it in `80_engine-crash-symbolize`. An installed shared httrack run off PATH has the same hole, it just loses fewer frames. The issue guessed at link flags, which cannot work: `-rdynamic` on the static binary puts zero engine symbols in `.dynsym`, because `-fvisibility=hidden` and file-scope statics make them `STB_LOCAL`.

Reading `/proc/self/exe` once at init and matching frames by the main program's load base gives the symbolizer a path it can open: all 9 executable frames resolve in a static build and all 4 in an installed shared one, against none before. `157_crash-argv0-path` installs into a DESTDIR and runs the installed binary off PATH from a directory holding no httrack, which reproduces the bare `argv[0]` in a default shared build, so no static CI leg is needed. It asserts on `httrack.c` frames, so it survives #969 moving htsbacktrace.c into the library.

Closes #889
