### PR TITLE
The crash report can hang: the symbolizer forks from the signal handler

### DIFF
--- a/src/htsbacktrace.c
+++ b/src/htsbacktrace.c
@@ -69,13 +69,18 @@ Please visit our Website: http://www.httrack.com
 #define USES_BACKTRACE
 #endif
 
+#ifdef _WIN32
+#define BT_REPORT_FD 2 /* MSVC ships no <unistd.h> */
+#else
+#define BT_REPORT_FD STDERR_FILENO
+#endif
+
 #ifdef USES_BACKTRACE
 #define BT_MAX_FRAMES 64  /* frames we try to name */
 #define BT_MAX_MODULES 8  /* distinct modules, one child each */
 #define BT_HEX_SIZE 19    /* "0x" + 16 nibbles + NUL */
 #define BT_PATH_SIZE 1024 /* module path; longer is skipped */
 #define BT_WAIT_TICKS 300 /* 10ms ticks, shared: cap a slow child */
-#define BT_REPORT_FD STDERR_FILENO
 
 static hts_boolean symbolize_crash = HTS_TRUE;
 
@@ -141,10 +146,11 @@ static hts_boolean copy_bounded(char *dest, size_t size, const char *src) {
   return src[i] == '\0' ? HTS_TRUE : HTS_FALSE;
 }
 
-/* Run the symbolizer on argv, output on the report fd, within *budget ticks.
-   HTS_FALSE only if none could be run at all; otherwise silent, the raw trace
-   stands. Not fork(): it runs the pthread_atfork handlers, and glibc's malloc
-   registers one taking every arena lock a signal inside malloc holds (#968). */
+/* Run the symbolizer on argv within *budget ticks; HTS_FALSE only if none could
+   be run at all. Not fork(): it runs the pthread_atfork handlers, and glibc's
+   malloc registers one taking every arena lock a signal inside malloc holds
+   (#968). posix_spawn() clones with CLONE_VFORK instead, and counts as
+   async-signal-safe as of POSIX.1-2024. */
 static hts_boolean spawn_symbolizer(char **argv, int *budget) {
   static char llvm_prog[] = "llvm-symbolizer";
   static char llvm_opts[] = "-p";
@@ -172,7 +178,7 @@ static hts_boolean spawn_symbolizer(char **argv, int *budget) {
 /* Name the frames backtrace_symbols_fd() leaves as module+offset:
    -fvisibility=hidden keeps them out of .dynsym, but DWARF has them. dladdr()
    is not formally async-signal-safe; accepted, this path is already fatal. */
-static void symbolize_backtrace(void *const *stack, int size, int fd) {
+static void symbolize_backtrace(void *const *stack, int size) {
   static char prog[] = "addr2line";
   static char opts[] = "-Cfipa";
   static char dashe[] = "-e";
@@ -185,8 +191,7 @@ static void symbolize_backtrace(void *const *stack, int size, int fd) {
   int budget = BT_WAIT_TICKS;
   int i, spawned;
 
-  /* Raw frames go to any fd; only the child's redirect is pinned at init. */
-  if (spawn_redirect == NULL || fd != BT_REPORT_FD)
+  if (spawn_redirect == NULL) /* init could not prepare the child's redirect */
     return;
   if (size > BT_MAX_FRAMES)
     size = BT_MAX_FRAMES;
@@ -235,8 +240,8 @@ static void symbolize_backtrace(void *const *stack, int size, int fd) {
       const size_t len = strlen(module);
 
       /* addr2line -a prints offsets only: say which module they are in. */
-      (void) (write(fd, module, len) == (ssize_t) len);
-      (void) (write(fd, ":\n", 2) == 2);
+      (void) (write(BT_REPORT_FD, module, len) == (ssize_t) len);
+      (void) (write(BT_REPORT_FD, ":\n", 2) == 2);
       if (!spawn_symbolizer(argv, &budget))
         break; /* no symbolizer: stop at one header */
     }
@@ -299,31 +304,31 @@ static void print_no_trace(int fd, const char *msg, size_t len) {
   }
 }
 
-void hts_print_backtrace(int fd) {
+void hts_print_backtrace(void) {
 #ifdef USES_BACKTRACE
   void *stack[256];
   const int size = backtrace(stack, sizeof(stack) / sizeof(stack[0]));
 
   /* A fault inside the handler lands back here: symbolizing twice interleaves
-     two traces on fd and spends a second budget. */
+     two traces on the report fd and spends a second budget. */
   static volatile sig_atomic_t entered = 0;
 
   if (size != 0) {
-    backtrace_symbols_fd(stack, size, fd);
+    backtrace_symbols_fd(stack, size, BT_REPORT_FD);
     if (symbolize_crash && entered == 0) {
       entered = 1;
-      symbolize_backtrace(stack, size, fd);
+      symbolize_backtrace(stack, size);
       entered = 0;
     }
   } else {
     /* An empty trace means the build carries no unwind tables. */
     const char msg[] = "No stack trace available: unwinding failed\n";
 
-    print_no_trace(fd, msg, sizeof(msg) - 1);
+    print_no_trace(BT_REPORT_FD, msg, sizeof(msg) - 1);
   }
 #else
   const char msg[] = "No stack trace available on this OS :(\n";
 
-  print_no_trace(fd, msg, sizeof(msg) - 1);
+  print_no_trace(BT_REPORT_FD, msg, sizeof(msg) - 1);
 #endif
 }

--- a/src/htsbacktrace.c
+++ b/src/htsbacktrace.c
@@ -73,9 +73,14 @@ Please visit our Website: http://www.httrack.com
 #define BT_HEX_SIZE 19       /* "0x" + 16 nibbles + NUL */
 #define BT_PATH_SIZE 1024    /* module path; longer is skipped */
 #define BT_WAIT_TICKS 300    /* 10ms ticks, shared: cap a slow child */
-#define BT_NO_SYMBOLIZER 127 /* child exit: execvp() found none */
+#define BT_NO_SYMBOLIZER 127 /* child exit: execv() failed */
 
 static hts_boolean symbolize_crash = HTS_TRUE;
+
+/* Resolved before any crash: a PATH search allocates, and the child of a
+   vfork() must not. NULL opts means no symbolizer, skip the whole step. */
+static char symbolizer_path[BT_PATH_SIZE];
+static char *symbolizer_opts = NULL;
 
 /* "0x"-prefixed hex: the handler must stay stdio-free. */
 static void print_hex(char *buffer, uintptr_t value) {
@@ -109,23 +114,58 @@ static hts_boolean copy_bounded(char *dest, size_t size, const char *src) {
   return src[i] == '\0' ? HTS_TRUE : HTS_FALSE;
 }
 
-/* Run the symbolizer on argv, output on fd, within *budget ticks. HTS_FALSE
-   only if none could be run at all; otherwise silent, the raw trace stands. */
-static hts_boolean spawn_symbolizer(char **argv, int fd, int *budget) {
-  const pid_t pid = fork();
-  int status = 0;
+/* Store the first 'prog' found on PATH in symbolizer_path. Startup only: not
+   signal-safe, and pointless there since the answer cannot change. */
+static hts_boolean find_on_path(const char *prog) {
+  const size_t proglen = strlen(prog);
+  const char *dir = getenv("PATH");
 
+  while (dir != NULL && *dir != '\0') {
+    const char *const sep = strchr(dir, ':');
+    const size_t len = sep != NULL ? (size_t) (sep - dir) : strlen(dir);
+
+    /* An empty element means the current directory: never look there. */
+    if (len != 0 && len <= sizeof(symbolizer_path) - 2 &&
+        proglen < sizeof(symbolizer_path) - len - 1) {
+      memcpy(symbolizer_path, dir, len);
+      symbolizer_path[len] = '/';
+      memcpy(&symbolizer_path[len + 1], prog, proglen + 1);
+      if (access(symbolizer_path, X_OK) == 0)
+        return HTS_TRUE;
+    }
+    dir = sep != NULL ? sep + 1 : NULL;
+  }
+  symbolizer_path[0] = '\0';
+  return HTS_FALSE;
+}
+
+static void resolve_symbolizer(void) {
+  static char addr2line_opts[] = "-Cfipa";
+  static char llvm_opts[] = "-p";
+
+  if (find_on_path("addr2line"))
+    symbolizer_opts = addr2line_opts;
+  /* An LLVM-only install ships neither addr2line nor its option spelling. */
+  else if (find_on_path("llvm-symbolizer"))
+    symbolizer_opts = llvm_opts;
+}
+
+/* Run the symbolizer on argv, output on fd, within *budget ticks. HTS_FALSE
+   only if it could not be run at all; otherwise silent, the raw trace stands.
+   vfork(), not fork(): fork() runs the pthread_atfork prepare handlers, and
+   glibc's malloc registers one taking every arena lock, so a signal raised
+   inside malloc deadlocks the handler and loses the report (#968). */
+static hts_boolean spawn_symbolizer(char **argv, int fd, int *budget) {
+  int status = 0;
+  pid_t pid;
+
+  pid = vfork();
   if (pid == -1)
     return HTS_FALSE;
   if (pid == 0) {
-    static char llvm_prog[] = "llvm-symbolizer";
-    static char llvm_opts[] = "-p";
-
+    /* Syscalls only: the address space here is still the parent's. */
     dup2(fd, 1); /* both symbolizers write on stdout */
-    execvp(argv[0], argv);
-    argv[0] = llvm_prog; /* an LLVM-only install ships no addr2line */
-    argv[1] = llvm_opts;
-    execvp(argv[0], argv);
+    execv(symbolizer_path, argv);
     _exit(BT_NO_SYMBOLIZER);
   }
   for (; *budget > 0; (*budget)--) {
@@ -149,8 +189,6 @@ static hts_boolean spawn_symbolizer(char **argv, int fd, int *budget) {
    -fvisibility=hidden keeps them out of .dynsym, but DWARF has them. dladdr()
    is not formally async-signal-safe; accepted, this path is already fatal. */
 static void symbolize_backtrace(void *const *stack, int size, int fd) {
-  static char prog[] = "addr2line";
-  static char opts[] = "-Cfipa";
   static char dashe[] = "-e";
   char hex[BT_MAX_FRAMES][BT_HEX_SIZE];
   const void *base[BT_MAX_FRAMES];
@@ -161,6 +199,8 @@ static void symbolize_backtrace(void *const *stack, int size, int fd) {
   int budget = BT_WAIT_TICKS;
   int i, spawned;
 
+  if (symbolizer_opts == NULL) /* none on PATH at startup */
+    return;
   if (size > BT_MAX_FRAMES)
     size = BT_MAX_FRAMES;
 
@@ -187,8 +227,8 @@ static void symbolize_backtrace(void *const *stack, int size, int fd) {
       ;
     if (first >= size)
       break;
-    argv[argc++] = prog;
-    argv[argc++] = opts;
+    argv[argc++] = symbolizer_path;
+    argv[argc++] = symbolizer_opts;
     argv[argc++] = dashe;
     argv[argc++] = module;
     for (j = first; j < size; j++) {
@@ -220,6 +260,8 @@ void hts_backtrace_init(void) {
 
   symbolize_crash =
       getenv("HTTRACK_NO_SYMBOLIZE") == NULL ? HTS_TRUE : HTS_FALSE;
+  if (symbolize_crash)
+    resolve_symbolizer();
   /* Pay for the unwinder now: glibc's first backtrace() dlopen()s libgcc_s,
      which allocates and takes the loader lock the crashing thread may hold. */
   (void) backtrace(frame, 1);

--- a/src/htsbacktrace.c
+++ b/src/htsbacktrace.c
@@ -62,25 +62,25 @@ Please visit our Website: http://www.httrack.com
 #include <errno.h>
 #include <execinfo.h>
 #include <signal.h>
+#include <spawn.h>
 #include <time.h>
 #include <sys/wait.h>
 #define USES_BACKTRACE
 #endif
 
 #ifdef USES_BACKTRACE
-#define BT_MAX_FRAMES 64     /* frames we try to name */
-#define BT_MAX_MODULES 8     /* distinct modules, one child each */
-#define BT_HEX_SIZE 19       /* "0x" + 16 nibbles + NUL */
-#define BT_PATH_SIZE 1024    /* module path; longer is skipped */
-#define BT_WAIT_TICKS 300    /* 10ms ticks, shared: cap a slow child */
-#define BT_NO_SYMBOLIZER 127 /* child exit: execv() failed */
+#define BT_MAX_FRAMES 64  /* frames we try to name */
+#define BT_MAX_MODULES 8  /* distinct modules, one child each */
+#define BT_HEX_SIZE 19    /* "0x" + 16 nibbles + NUL */
+#define BT_PATH_SIZE 1024 /* module path; longer is skipped */
+#define BT_WAIT_TICKS 300 /* 10ms ticks, shared: cap a slow child */
+#define BT_REPORT_FD STDERR_FILENO
 
 static hts_boolean symbolize_crash = HTS_TRUE;
 
-/* Resolved before any crash: a PATH search allocates, and the child of a
-   vfork() must not. NULL opts means no symbolizer, skip the whole step. */
-static char symbolizer_path[BT_PATH_SIZE];
-static char *symbolizer_opts = NULL;
+/* Built at init: assembling file actions allocates; the crash path cannot. */
+static posix_spawn_file_actions_t spawn_actions;
+static posix_spawn_file_actions_t *spawn_redirect = NULL;
 
 /* "0x"-prefixed hex: the handler must stay stdio-free. */
 static void print_hex(char *buffer, uintptr_t value) {
@@ -114,69 +114,26 @@ static hts_boolean copy_bounded(char *dest, size_t size, const char *src) {
   return src[i] == '\0' ? HTS_TRUE : HTS_FALSE;
 }
 
-/* Store the first 'prog' found on PATH in symbolizer_path. Startup only: not
-   signal-safe, and pointless there since the answer cannot change. */
-static hts_boolean find_on_path(const char *prog) {
-  const size_t proglen = strlen(prog);
-  const char *dir = getenv("PATH");
-
-  while (dir != NULL && *dir != '\0') {
-    const char *const sep = strchr(dir, ':');
-    const size_t len = sep != NULL ? (size_t) (sep - dir) : strlen(dir);
-
-    /* An empty element means the current directory: never look there. */
-    if (len != 0 && len <= sizeof(symbolizer_path) - 2 &&
-        proglen < sizeof(symbolizer_path) - len - 1) {
-      memcpy(symbolizer_path, dir, len);
-      symbolizer_path[len] = '/';
-      memcpy(&symbolizer_path[len + 1], prog, proglen + 1);
-      if (access(symbolizer_path, X_OK) == 0)
-        return HTS_TRUE;
-    }
-    dir = sep != NULL ? sep + 1 : NULL;
-  }
-  symbolizer_path[0] = '\0';
-  return HTS_FALSE;
-}
-
-static void resolve_symbolizer(void) {
-  static char addr2line_opts[] = "-Cfipa";
+/* Run the symbolizer on argv, output on the report fd, within *budget ticks.
+   HTS_FALSE only if none could be run at all; otherwise silent, the raw trace
+   stands. Not fork(): it runs the pthread_atfork handlers, and glibc's malloc
+   registers one taking every arena lock a signal inside malloc holds (#968). */
+static hts_boolean spawn_symbolizer(char **argv, int *budget) {
+  static char llvm_prog[] = "llvm-symbolizer";
   static char llvm_opts[] = "-p";
-
-  if (find_on_path("addr2line"))
-    symbolizer_opts = addr2line_opts;
-  /* An LLVM-only install ships neither addr2line nor its option spelling. */
-  else if (find_on_path("llvm-symbolizer"))
-    symbolizer_opts = llvm_opts;
-}
-
-/* Run the symbolizer on argv, output on fd, within *budget ticks. HTS_FALSE
-   only if it could not be run at all; otherwise silent, the raw trace stands.
-   vfork(), not fork(): fork() runs the pthread_atfork prepare handlers, and
-   glibc's malloc registers one taking every arena lock, so a signal raised
-   inside malloc deadlocks the handler and loses the report (#968). */
-static hts_boolean spawn_symbolizer(char **argv, int fd, int *budget) {
-  int status = 0;
   pid_t pid;
 
-  pid = vfork();
-  if (pid == -1)
-    return HTS_FALSE;
-  if (pid == 0) {
-    /* Syscalls only: the address space here is still the parent's. */
-    dup2(fd, 1); /* both symbolizers write on stdout */
-    execv(symbolizer_path, argv);
-    _exit(BT_NO_SYMBOLIZER);
+  if (posix_spawnp(&pid, argv[0], spawn_redirect, NULL, argv, environ) != 0) {
+    argv[0] = llvm_prog; /* an LLVM-only install ships no addr2line */
+    argv[1] = llvm_opts;
+    if (posix_spawnp(&pid, argv[0], spawn_redirect, NULL, argv, environ) != 0)
+      return HTS_FALSE;
   }
   for (; *budget > 0; (*budget)--) {
     const struct timespec tick = {0, 10 * 1000 * 1000};
-    const pid_t reaped = waitpid(pid, &status, WNOHANG);
+    const pid_t reaped = waitpid(pid, NULL, WNOHANG);
 
-    if (reaped == pid)
-      return WIFEXITED(status) && WEXITSTATUS(status) == BT_NO_SYMBOLIZER
-                 ? HTS_FALSE
-                 : HTS_TRUE;
-    if (reaped == -1 && errno != EINTR)
+    if (reaped == pid || (reaped == -1 && errno != EINTR))
       return HTS_TRUE;
     nanosleep(&tick, NULL);
   }
@@ -189,6 +146,8 @@ static hts_boolean spawn_symbolizer(char **argv, int fd, int *budget) {
    -fvisibility=hidden keeps them out of .dynsym, but DWARF has them. dladdr()
    is not formally async-signal-safe; accepted, this path is already fatal. */
 static void symbolize_backtrace(void *const *stack, int size, int fd) {
+  static char prog[] = "addr2line";
+  static char opts[] = "-Cfipa";
   static char dashe[] = "-e";
   char hex[BT_MAX_FRAMES][BT_HEX_SIZE];
   const void *base[BT_MAX_FRAMES];
@@ -199,7 +158,8 @@ static void symbolize_backtrace(void *const *stack, int size, int fd) {
   int budget = BT_WAIT_TICKS;
   int i, spawned;
 
-  if (symbolizer_opts == NULL) /* none on PATH at startup */
+  /* Raw frames go to any fd; only the child's redirect is pinned at init. */
+  if (spawn_redirect == NULL || fd != BT_REPORT_FD)
     return;
   if (size > BT_MAX_FRAMES)
     size = BT_MAX_FRAMES;
@@ -227,8 +187,8 @@ static void symbolize_backtrace(void *const *stack, int size, int fd) {
       ;
     if (first >= size)
       break;
-    argv[argc++] = symbolizer_path;
-    argv[argc++] = symbolizer_opts;
+    argv[argc++] = prog;
+    argv[argc++] = opts;
     argv[argc++] = dashe;
     argv[argc++] = module;
     for (j = first; j < size; j++) {
@@ -247,7 +207,7 @@ static void symbolize_backtrace(void *const *stack, int size, int fd) {
       /* addr2line -a prints offsets only: say which module they are in. */
       (void) (write(fd, module, len) == (ssize_t) len);
       (void) (write(fd, ":\n", 2) == 2);
-      if (!spawn_symbolizer(argv, fd, &budget))
+      if (!spawn_symbolizer(argv, &budget))
         break; /* no symbolizer: stop at one header */
     }
   }
@@ -260,8 +220,10 @@ void hts_backtrace_init(void) {
 
   symbolize_crash =
       getenv("HTTRACK_NO_SYMBOLIZE") == NULL ? HTS_TRUE : HTS_FALSE;
-  if (symbolize_crash)
-    resolve_symbolizer();
+  if (symbolize_crash && posix_spawn_file_actions_init(&spawn_actions) == 0 &&
+      posix_spawn_file_actions_adddup2(&spawn_actions, BT_REPORT_FD,
+                                       STDOUT_FILENO) == 0)
+    spawn_redirect = &spawn_actions; /* both symbolizers write on stdout */
   /* Pay for the unwinder now: glibc's first backtrace() dlopen()s libgcc_s,
      which allocates and takes the loader lock the crashing thread may hold. */
   (void) backtrace(frame, 1);

--- a/src/htsbacktrace.h
+++ b/src/htsbacktrace.h
@@ -35,10 +35,9 @@ Please visit our Website: http://www.httrack.com
 
 #include "htsglobal.h"
 
-/* Sample HTTRACK_NO_SYMBOLIZE, locate the symbolizer and load the unwinder
-   before any crash: none of it is signal-safe, and skipping the call leaves the
-   report with raw frames only. Call once, from the process installing the fatal
-   handlers. */
+/* Sample HTTRACK_NO_SYMBOLIZE, prepare the symbolizer spawn and load the
+   unwinder: none of it is signal-safe. Call once, from the process installing
+   the fatal handlers. */
 void hts_backtrace_init(void);
 
 /* Ensure the calling thread has an alternate signal stack, so a handler
@@ -49,7 +48,8 @@ void hts_backtrace_init(void);
 hts_boolean hts_backtrace_altstack(void);
 
 /* Write the calling thread's stack to fd, callable from a fatal signal handler:
-   raw frames first, then whatever an external symbolizer can name. Allocates
+   raw frames first, then whatever an external symbolizer can name. Symbolizing
+   needs the stderr hts_backtrace_init() prepared its redirect for. Allocates
    nothing; prints a one-line notice where the OS has no backtrace(). */
 void hts_print_backtrace(int fd);
 

--- a/src/htsbacktrace.h
+++ b/src/htsbacktrace.h
@@ -47,10 +47,11 @@ void hts_backtrace_init(void);
    running on the faulting stack as it used to. */
 hts_boolean hts_backtrace_altstack(void);
 
-/* Write the calling thread's stack to fd, callable from a fatal signal handler:
-   raw frames first, then whatever an external symbolizer can name. Symbolizing
-   needs the stderr hts_backtrace_init() prepared its redirect for. Allocates
-   nothing; prints a one-line notice where the OS has no backtrace(). */
-void hts_print_backtrace(int fd);
+/* Write the calling thread's stack to stderr, callable from a fatal signal
+   handler: raw frames first, then whatever an external symbolizer can name.
+   Stderr and not a parameter: hts_backtrace_init() pre-builds the child's
+   redirect onto it. Allocates nothing; prints a one-line notice where the OS
+   has no backtrace(). */
+void hts_print_backtrace(void);
 
 #endif

--- a/src/htsbacktrace.h
+++ b/src/htsbacktrace.h
@@ -35,8 +35,10 @@ Please visit our Website: http://www.httrack.com
 
 #include "htsglobal.h"
 
-/* Sample HTTRACK_NO_SYMBOLIZE and load the unwinder before any crash: neither
-   is signal-safe. Call once, from the process installing the fatal handlers. */
+/* Sample HTTRACK_NO_SYMBOLIZE, locate the symbolizer and load the unwinder
+   before any crash: none of it is signal-safe, and skipping the call leaves the
+   report with raw frames only. Call once, from the process installing the fatal
+   handlers. */
 void hts_backtrace_init(void);
 
 /* Ensure the calling thread has an alternate signal stack, so a handler

--- a/src/htscrashtest.c
+++ b/src/htscrashtest.c
@@ -41,6 +41,10 @@ Please visit our Website: http://www.httrack.com
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef _WIN32
+#include <pthread.h>
+#define CRASH_HAS_ATFORK
+#endif
 
 #if defined(_MSC_VER)
 #define CRASH_NOINLINE __declspec(noinline)
@@ -95,14 +99,31 @@ static CRASH_NOINLINE char blow_the_stack(size_t depth) {
 /* Faults with no stack left for the handler, unless it runs on an altstack. */
 static CRASH_NOINLINE void crash_stack(void) { (void) blow_the_stack(0); }
 
+#ifdef CRASH_HAS_ATFORK
+static pthread_mutex_t crash_fork_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static void crash_fork_prepare(void) { pthread_mutex_lock(&crash_fork_lock); }
+
+static void crash_fork_parent(void) { pthread_mutex_unlock(&crash_fork_lock); }
+#endif
+
+/* Stands in for glibc's malloc, whose own pthread_atfork prepare handler takes
+   every arena lock: a fork() from the fatal handler then blocks forever and the
+   report is lost (#968). Plain segv where there is no pthread_atfork. */
+static CRASH_NOINLINE void crash_atfork(void) {
+#ifdef CRASH_HAS_ATFORK
+  pthread_atfork(crash_fork_prepare, crash_fork_parent, NULL);
+  pthread_mutex_lock(&crash_fork_lock);
+#endif
+  crash_segv();
+}
+
 static const struct {
   const char *name;
   void (*fn)(void);
 } crash_kinds[] = {
-    {"segv", crash_segv},
-    {"abort", crash_abort},
-    {"trap", crash_trap},
-    {"stack", crash_stack},
+    {"segv", crash_segv},   {"abort", crash_abort},   {"trap", crash_trap},
+    {"stack", crash_stack}, {"atfork", crash_atfork},
 };
 
 #define CRASH_KINDS_COUNT (sizeof(crash_kinds) / sizeof(crash_kinds[0]))

--- a/src/htscrashtest.c
+++ b/src/htscrashtest.c
@@ -107,9 +107,8 @@ static void crash_fork_prepare(void) { pthread_mutex_lock(&crash_fork_lock); }
 static void crash_fork_parent(void) { pthread_mutex_unlock(&crash_fork_lock); }
 #endif
 
-/* Stands in for glibc's malloc, whose own pthread_atfork prepare handler takes
-   every arena lock: a fork() from the fatal handler then blocks forever and the
-   report is lost (#968). Plain segv where there is no pthread_atfork. */
+/* Faults holding a lock a pthread_atfork prepare handler wants, as glibc's
+   malloc does with its arena locks. Plain segv where there is no atfork. */
 static CRASH_NOINLINE void crash_atfork(void) {
 #ifdef CRASH_HAS_ATFORK
   pthread_atfork(crash_fork_prepare, crash_fork_parent, NULL);

--- a/src/htscrashtest.c
+++ b/src/htscrashtest.c
@@ -107,8 +107,8 @@ static void crash_fork_prepare(void) { pthread_mutex_lock(&crash_fork_lock); }
 static void crash_fork_parent(void) { pthread_mutex_unlock(&crash_fork_lock); }
 #endif
 
-/* Faults holding a lock a pthread_atfork prepare handler wants, as glibc's
-   malloc does with its arena locks. Plain segv where there is no atfork. */
+/* Faults holding a lock a pthread_atfork prepare handler wants (#968). Plain
+   segv where there is no atfork. */
 static CRASH_NOINLINE void crash_atfork(void) {
 #ifdef CRASH_HAS_ATFORK
   pthread_atfork(crash_fork_prepare, crash_fork_parent, NULL);

--- a/src/httrack.c
+++ b/src/httrack.c
@@ -909,7 +909,7 @@ static void sig_fatal(int code) {
   size += print_num(&buffer[size], code);
   buffer[size++] = '\n';
   (void) (write(FD_ERR, buffer, size) == size);
-  hts_print_backtrace(FD_ERR);
+  hts_print_backtrace();
   (void) (write(FD_ERR, msgreport, sizeof(msgreport) - 1)
     == sizeof(msgreport) - 1);
   abort();

--- a/tests/182_crash-fork-safety.test
+++ b/tests/182_crash-fork-safety.test
@@ -1,0 +1,61 @@
+#!/bin/bash
+# The fatal handler spawns a symbolizer. Doing that with fork() first runs the
+# pthread_atfork prepare handlers, so a lock the crashing thread already holds
+# (glibc's malloc arena lock, when its own corruption detector aborts from
+# inside malloc) deadlocks the handler and loses the report (#968). -#c=atfork
+# reproduces that regime; a wedge is a failure here, not a slow test.
+
+set -euo pipefail
+
+ulimit -c 0 # a deliberate crash must not litter the box with cores
+
+fail() {
+    echo "$*" >&2
+    exit 1
+}
+
+# The spawn lives in USES_BACKTRACE (Linux + execinfo.h); elsewhere the handler
+# starts no child and there is nothing to deadlock.
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "the symbolizer spawn is Linux-only, skipping" >&2
+    exit 77
+fi
+command -v httrack >/dev/null || fail "could not find httrack"
+# SIGTERM does reach a wedged httrack, but its handler only sets a flag, so the
+# kill has to be uncatchable or the wedge outlives the timeout.
+command -v timeout >/dev/null || fail "no timeout(1): a hang would never end here"
+
+# 134 is SIGABRT, the handler's own last statement; 137 is the wedge.
+crash_report() {
+    local kind="$1" out rc=0
+
+    out=$(timeout -s KILL 60 httrack "-#c=$kind" 2>&1) || rc=$?
+    test "$rc" -ne 137 || fail "-#c=$kind wedged: the handler never came back"
+    test "$rc" -eq 134 || fail "-#c=$kind exited $rc, expected 134"
+    grep -q "Please report the problem" <<<"$out" ||
+        fail "-#c=$kind: report truncated, the handler died halfway"
+    printf '%s\n' "$out"
+}
+
+# Control: an ordinary fault walks the same spawn path with no lock held, so a
+# build that cannot report at all fails here rather than passing the real case.
+plain=$(crash_report segv)
+locked=$(crash_report atfork)
+
+# We write the module header right before spawning: no header, and the run
+# never reached the code under test.
+if command -v addr2line >/dev/null || command -v llvm-symbolizer >/dev/null; then
+    grep -qE '^/.+:$' <<<"$plain" || fail "-#c=segv: no symbolizer was spawned"
+    grep -qE '^/.+:$' <<<"$locked" ||
+        fail "-#c=atfork: no symbolizer was spawned, the deadlock went untested"
+else
+    echo "no addr2line and no llvm-symbolizer: spawn path not exercised" >&2
+fi
+
+# addr2line is searched first and its -a output is the one line format that
+# does not move with the locale. Proves the child actually ran, which a header
+# written before the spawn cannot.
+if command -v addr2line >/dev/null; then
+    grep -qE '^0x[0-9a-f]{16}: ' <<<"$locked" ||
+        fail "-#c=atfork: no symbolized frame, addr2line never ran"
+fi

--- a/tests/182_crash-fork-safety.test
+++ b/tests/182_crash-fork-safety.test
@@ -63,7 +63,8 @@ fi
 # addr2line runs first, and its -a address line is what proves the child ran.
 # Unanchored width: -a pads to the target pointer size, 8 nibbles on 32-bit.
 if command -v addr2line >/dev/null; then
-    grep -qE '^0x[0-9a-f]+: ' <<<"$locked" ||
+    # A name, not just the shape: an all-"??" regression still emits the offsets.
+    grep -qE '^0x[0-9a-f]+: [A-Za-z_]' <<<"$locked" ||
         fail "-#c=atfork: no symbolized frame, addr2line never ran"
     # The child's stdout is redirected onto the report fd, prebuilt at startup:
     # symbolized frames belong on stderr, never on the crawler's own stdout.

--- a/tests/182_crash-fork-safety.test
+++ b/tests/182_crash-fork-safety.test
@@ -1,9 +1,6 @@
 #!/bin/bash
-# The fatal handler spawns a symbolizer. Doing that with fork() first runs the
-# pthread_atfork prepare handlers, so a lock the crashing thread already holds
-# (glibc's malloc arena lock, when its own corruption detector aborts from
-# inside malloc) deadlocks the handler and loses the report (#968). -#c=atfork
-# reproduces that regime; a wedge is a failure here, not a slow test.
+# -#c=atfork faults holding a lock a pthread_atfork handler wants, the regime a
+# fork() from the fatal handler deadlocks in (#968). A wedge is a failure here.
 
 set -euo pipefail
 
@@ -14,8 +11,8 @@ fail() {
     exit 1
 }
 
-# The spawn lives in USES_BACKTRACE (Linux + execinfo.h); elsewhere the handler
-# starts no child and there is nothing to deadlock.
+# The spawn needs backtrace(), so Linux is necessary but not sufficient: the
+# runtime notice below is what actually rules a musl build out.
 if [ "$(uname -s)" != "Linux" ]; then
     echo "the symbolizer spawn is Linux-only, skipping" >&2
     exit 77
@@ -40,6 +37,10 @@ crash_report() {
 # Control: an ordinary fault walks the same spawn path with no lock held, so a
 # build that cannot report at all fails here rather than passing the real case.
 plain=$(crash_report segv)
+if grep -q 'No stack trace available on this OS' <<<"$plain"; then
+    echo "no backtrace() in this build; skipping" >&2
+    exit 77
+fi
 locked=$(crash_report atfork)
 
 # We write the module header right before spawning: no header, and the run

--- a/tests/182_crash-fork-safety.test
+++ b/tests/182_crash-fork-safety.test
@@ -1,6 +1,5 @@
 #!/bin/bash
-# -#c=atfork faults holding a lock a pthread_atfork handler wants, the regime a
-# fork() from the fatal handler deadlocks in (#968). A wedge is a failure here.
+# -#c=atfork reproduces the #968 regime; the timeout turns a wedge into a failure.
 
 set -euo pipefail
 
@@ -40,6 +39,16 @@ if grep -q 'No stack trace available on this OS' <<<"$plain"; then
     echo "no backtrace() in this build; skipping" >&2
     exit 77
 fi
+# 32-bit ARM may still build with no unwind tables, as test 80 allows for: an
+# empty trace has no module block to assert on.
+case "$(uname -m)" in
+arm | armv*)
+    if grep -q 'No stack trace available' <<<"$plain"; then
+        echo "no unwind tables in this ARM build; skipping" >&2
+        exit 77
+    fi
+    ;;
+esac
 locked=$(crash_report atfork)
 
 # The module header is written just before the spawn: no header, no code under test.
@@ -51,9 +60,8 @@ else
     echo "no addr2line and no llvm-symbolizer: spawn path not exercised" >&2
 fi
 
-# addr2line runs first and its -a output is the one line format the locale does
-# not move, so it is what proves the child ran. Unanchored width: -a pads to the
-# target pointer size, 8 nibbles on a 32-bit build.
+# addr2line runs first, and its -a address line is what proves the child ran.
+# Unanchored width: -a pads to the target pointer size, 8 nibbles on 32-bit.
 if command -v addr2line >/dev/null; then
     grep -qE '^0x[0-9a-f]+: ' <<<"$locked" ||
         fail "-#c=atfork: no symbolized frame, addr2line never ran"

--- a/tests/182_crash-fork-safety.test
+++ b/tests/182_crash-fork-safety.test
@@ -54,8 +54,9 @@ fi
 
 # addr2line is searched first and its -a output is the one line format that
 # does not move with the locale. Proves the child actually ran, which a header
-# written before the spawn cannot.
+# written before the spawn cannot. Unanchored width: -a pads to the target's
+# pointer size, 8 nibbles on a 32-bit build.
 if command -v addr2line >/dev/null; then
-    grep -qE '^0x[0-9a-f]{16}: ' <<<"$locked" ||
+    grep -qE '^0x[0-9a-f]+: ' <<<"$locked" ||
         fail "-#c=atfork: no symbolized frame, addr2line never ran"
 fi

--- a/tests/182_crash-fork-safety.test
+++ b/tests/182_crash-fork-safety.test
@@ -18,8 +18,7 @@ if [ "$(uname -s)" != "Linux" ]; then
     exit 77
 fi
 command -v httrack >/dev/null || fail "could not find httrack"
-# SIGTERM does reach a wedged httrack, but its handler only sets a flag, so the
-# kill has to be uncatchable or the wedge outlives the timeout.
+# A wedged httrack still catches SIGTERM and only sets a flag, hence -s KILL.
 command -v timeout >/dev/null || fail "no timeout(1): a hang would never end here"
 
 # 134 is SIGABRT, the handler's own last statement; 137 is the wedge.
@@ -43,8 +42,7 @@ if grep -q 'No stack trace available on this OS' <<<"$plain"; then
 fi
 locked=$(crash_report atfork)
 
-# We write the module header right before spawning: no header, and the run
-# never reached the code under test.
+# The module header is written just before the spawn: no header, no code under test.
 if command -v addr2line >/dev/null || command -v llvm-symbolizer >/dev/null; then
     grep -qE '^/.+:$' <<<"$plain" || fail "-#c=segv: no symbolizer was spawned"
     grep -qE '^/.+:$' <<<"$locked" ||
@@ -53,11 +51,15 @@ else
     echo "no addr2line and no llvm-symbolizer: spawn path not exercised" >&2
 fi
 
-# addr2line is searched first and its -a output is the one line format that
-# does not move with the locale. Proves the child actually ran, which a header
-# written before the spawn cannot. Unanchored width: -a pads to the target's
-# pointer size, 8 nibbles on a 32-bit build.
+# addr2line runs first and its -a output is the one line format the locale does
+# not move, so it is what proves the child ran. Unanchored width: -a pads to the
+# target pointer size, 8 nibbles on a 32-bit build.
 if command -v addr2line >/dev/null; then
     grep -qE '^0x[0-9a-f]+: ' <<<"$locked" ||
         fail "-#c=atfork: no symbolized frame, addr2line never ran"
+    # The child's stdout is redirected onto the report fd, prebuilt at startup:
+    # symbolized frames belong on stderr, never on the crawler's own stdout.
+    leaked=$(timeout -s KILL 60 httrack '-#c=segv' 2>/dev/null |
+        grep -cE '^0x[0-9a-f]+: ' || true)
+    test "$leaked" -eq 0 || fail "$leaked symbolized frames leaked to stdout"
 fi

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -241,3 +241,4 @@ TESTS += 205_install-headers.test
 TESTS += 185_webhttrack-js-escaping.test
 TESTS += 200_pixmaps-fallback.test
 TESTS += 210_appstream-metainfo.test
+TESTS += 182_crash-fork-safety.test


### PR DESCRIPTION
The fatal handler symbolizes the crash by spawning addr2line, and it did that with `fork()`. Under glibc `fork()` first runs the `pthread_atfork` prepare handlers, and malloc registers one that takes every arena lock. A signal raised inside malloc, most plausibly glibc's own heap-corruption detector calling `abort()`, then blocks there forever and the report is lost. `posix_spawnp()` reaches the same child through `clone(CLONE_VM|CLONE_VFORK)`, which runs no atfork handler at all.

It also searches PATH itself and reports an exec failure through its return value, so the child no longer needs a private exit code meaning "no symbolizer here". The one part that allocates, the file actions redirecting the child's stdout onto the report fd, is built once in `hts_backtrace_init()`; that fd is stderr, and the symbolizer step now says so rather than taking whatever it is handed. `-#c=atfork` faults while holding a lock an atfork handler wants, and test 182 drives it: a `fork()` build wedges there at exit 137, its report cut off mid-header.

Closes #968
