### PR TITLE
Installed headers do not compile under -std=c99

### DIFF
--- a/src/htsarrays.h
+++ b/src/htsarrays.h
@@ -47,7 +47,7 @@ Please visit our Website: http://www.httrack.com
 
 /* Abort (with the failed byte count) when a growth allocation fails. The
    array macros never return an out-of-memory error; they assert and abort. */
-static void hts_record_assert_memory_failed(const size_t size) {
+static HTS_UNUSED void hts_record_assert_memory_failed(const size_t size) {
   fprintf(stderr, "memory allocation failed (%lu bytes)", (long int) size);
   assertf(!"memory allocation failed");
 }

--- a/src/htssafe.h
+++ b/src/htssafe.h
@@ -110,7 +110,7 @@ static HTS_UNUSED void abortf_(const char *exp, const char *file, int line) {
 
 /* Note: char[] and const char[] are compatible */
 #define HTS_IS_CHAR_BUFFER(VAR)                                                \
-  (__builtin_types_compatible_p(typeof(VAR), char[]))
+  (__builtin_types_compatible_p(__typeof__(VAR), char[]))
 #else
 /* Note: a bit lame as char[8] won't be seen. */
 #define HTS_IS_CHAR_BUFFER(VAR) (sizeof(VAR) != sizeof(char *))
@@ -309,14 +309,25 @@ static char *strncatbuff_ptr_(char *dest, const char *src, size_t n) {
                "overflow while copying '" #B "' to '" #A "'", __FILE__,        \
                __LINE__)
 
-/** strnlen replacement (autotools). **/
-#if (!defined(_WIN32) && !defined(HAVE_STRNLEN))
-
-static HTS_UNUSED size_t strnlen(const char *s, size_t maxlen) {
+/* POSIX strnlen is hidden from a strict-ISO consumer (__STRICT_ANSI__) and
+   absent on a few targets, so the inline helpers below use this instead. */
+static HTS_INLINE HTS_UNUSED size_t htssafe_strnlen_(const char *s,
+                                                     size_t maxlen) {
+#if (defined(_WIN32) || (defined(HAVE_STRNLEN) && !defined(__STRICT_ANSI__)))
+  return strnlen(s, maxlen);
+#else
   size_t i;
   for (i = 0; i < maxlen && s[i] != '\0'; i++)
     ;
   return i;
+#endif
+}
+
+/** strnlen replacement (autotools), for the engine sources that call it. **/
+#if (!defined(_WIN32) && !defined(HAVE_STRNLEN))
+
+static HTS_UNUSED size_t strnlen(const char *s, size_t maxlen) {
+  return htssafe_strnlen_(s, maxlen);
 }
 #endif
 
@@ -329,7 +340,7 @@ static HTS_INLINE HTS_UNUSED size_t strlen_safe_(const char *source,
                                                  const char *file, int line) {
   size_t size;
   assertf_(source != NULL, file, line);
-  size = sizeof_source != (size_t) -1 ? strnlen(source, sizeof_source)
+  size = sizeof_source != (size_t) -1 ? htssafe_strnlen_(source, sizeof_source)
                                       : strlen(source);
   assertf_(size < sizeof_source, file, line);
   return size;
@@ -408,8 +419,8 @@ static HTS_INLINE HTS_UNUSED htsbuff htsbuff_ptr_(char *buf, size_t cap) {
 
 /* 0 for an array, a -1 array-size compile error for a pointer. */
 #define htsbuff_must_be_array_(A)                                              \
-  (sizeof(char[1 - 2 * !!__builtin_types_compatible_p(typeof(A),               \
-                                                      typeof(&(A)[0]))]) -     \
+  (sizeof(char[1 - 2 * !!__builtin_types_compatible_p(__typeof__(A),           \
+                                                      __typeof__(&(A)[0]))]) - \
    1)
 
 #define htsbuff_array(ARR)                                                     \
@@ -426,7 +437,7 @@ static HTS_INLINE HTS_UNUSED void htsbuff_catn(htsbuff *b, const char *s,
                                                size_t n) {
   /* the (size_t)-1 "no limit" sentinel would reach strnlen as a bound past
      PTRDIFF_MAX */
-  const size_t add = n != (size_t) -1 ? strnlen(s, n) : strlen(s);
+  const size_t add = n != (size_t) -1 ? htssafe_strnlen_(s, n) : strlen(s);
   /* Overflow-safe: keep the (potentially huge) 'add' alone on one side. The
      maintained invariant len < cap makes 'cap - len' >= 1 (no underflow), so
      'add < cap - len' cannot wrap the way 'len + add < cap' could. */

--- a/tests/206_install-headers-c99.test
+++ b/tests/206_install-headers-c99.test
@@ -148,6 +148,58 @@ for std in "${stds[@]}"; do
 done
 [ "$bad" -eq 0 ] || fail "htssafe.h macros do not compile in strict-ISO mode"
 
+# Strict-ISO mode is the only one that selects htssafe_strnlen_'s byte loop, and
+# -fsyntax-only never runs a byte of it: differential it against memchr.
+cat >"$tmp/strnlen.c" <<'EOF'
+#include <httrack/htssafe.h>
+#include <string.h>
+int main(void) {
+  static const char alpha[2] = {'\0', 'a'};
+  char buf[16];
+  size_t bits, len, n;
+  for (len = 0; len <= 8; len++) {
+    for (bits = 0; bits < ((size_t) 1 << len); bits++) {
+      size_t i;
+      /* poison, or an overshot bound lands on a NUL and reads as correct */
+      memset(buf, 'Z', sizeof(buf));
+      for (i = 0; i < len; i++)
+        buf[i] = alpha[(bits >> i) & 1];
+      for (n = 0; n <= len; n++) {
+        const void *p = memchr(buf, '\0', n);
+        const size_t want = p != NULL ? (size_t) ((const char *) p - buf) : n;
+        const size_t got = htssafe_strnlen_(buf, n);
+        if (got != want) {
+          fprintf(stderr, "htssafe_strnlen_(%u) = %u, want %u\n", (unsigned) n,
+                  (unsigned) got, (unsigned) want);
+          return 1;
+        }
+      }
+    }
+  }
+  return 0;
+}
+EOF
+# A noexec TMPDIR or a cross-compiler would red the run for the wrong reason.
+printf 'int main(void) { return 0; }\n' >"$tmp/tu.c"
+if ! ("${cc_argv[@]}" "${cpp_argv[@]}" -o "$tmp/tu" "$tmp/tu.c" 2>/dev/null && "$tmp/tu"); then
+    echo "cannot run a binary built in $tmp, skipping the htssafe_strnlen_ differential" >&2
+else
+    for std in "${stds[@]}"; do
+        # Vacuous if the gate handed us libc's strnlen. Match that branch, not
+        # the loop, or a mutated loop reads as a lost fallback instead.
+        pp=$("${cc_argv[@]}" "${cpp_argv[@]}" "-std=$std" -E "$tmp/strnlen.c") ||
+            fail "cannot preprocess the htssafe_strnlen_ probe under -std=$std"
+        if grep -q 'return strnlen' <<<"$pp"; then
+            fail "-std=$std left htssafe_strnlen_ on libc, the check below proves nothing"
+        fi
+        "${cc_argv[@]}" "${cpp_argv[@]}" "-std=$std" -o "$tmp/strnlen" "$tmp/strnlen.c" 2>"$tmp/cc.log" || {
+            head -5 "$tmp/cc.log" >&2
+            fail "the htssafe_strnlen_ probe does not build under -std=$std"
+        }
+        "$tmp/strnlen" || fail "htssafe_strnlen_ disagrees with memchr under -std=$std"
+    done
+fi
+
 # The loops above are only meaningful if this compiler rejects a missing include.
 printf '#include "no-such-header-972.h"\n' >"$tmp/tu.c"
 if "${cc_argv[@]}" "${cpp_argv[@]}" "-std=${stds[0]}" -fsyntax-only "$tmp/tu.c" 2>/dev/null; then

--- a/tests/206_install-headers-c99.test
+++ b/tests/206_install-headers-c99.test
@@ -91,15 +91,24 @@ headers=("$tmp/include/httrack"/*.h)
 [ "${#headers[@]}" -ge 10 ] || fail "only ${#headers[@]} headers installed, the list cannot be right"
 [ -f "$tmp/include/httrack/htssafe.h" ] || fail "htssafe.h was not installed"
 
+# No libc hands getnameinfo() to a strict-ISO unit, so a consumer of the two
+# socket headers must ask for POSIX. Prefer 2001: 2008 also un-hides strnlen,
+# which would stop those two covering that half of #972.
+posix_argv=(-D_POSIX_C_SOURCE=200112L)
+printf '#include <httrack/htsnet.h>\n' >"$tmp/tu.c"
+if ! "${cc_argv[@]}" "${cpp_argv[@]}" "${posix_argv[@]}" "-std=${stds[0]}" \
+    -fsyntax-only "$tmp/tu.c" 2>/dev/null; then
+    echo "note: htsnet.h needs POSIX.1-2008, strnlen goes uncovered there" >&2
+    posix_argv=(-D_POSIX_C_SOURCE=200809L)
+fi
+
 count=0
 bad=0
 for h in "${headers[@]}"; do
     b=$(basename "$h")
     argv=("${cpp_argv[@]}")
-    # No libc exposes getnameinfo() and friends to a strict-ISO unit, so a
-    # consumer of the two socket headers must ask for POSIX itself.
     case "$b" in
-    htsnet.h | htsopt.h) argv+=(-D_POSIX_C_SOURCE=200809L) ;;
+    htsnet.h | htsopt.h) argv+=("${posix_argv[@]}") ;;
     esac
     printf '#include <httrack/%s>\n' "$b" >"$tmp/tu.c"
     for std in "${stds[@]}"; do

--- a/tests/206_install-headers-c99.test
+++ b/tests/206_install-headers-c99.test
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# The installed headers must also compile in a strict-ISO translation unit
+# (-std=c99/c11), where __STRICT_ANSI__ drops the unprefixed GNU keywords and
+# hides the libc's POSIX declarations (#972). 205 varies only the bytecode mode,
+# so it sees neither.
+
+set -euo pipefail
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+# Unset means no automake run (the Windows job runs the scripts directly), so
+# there is no install rule to drive.
+if [ -z "${abs_top_builddir:-}" ]; then
+    echo "abs_top_builddir unset, no automake environment, skipping" >&2
+    exit 77
+fi
+[ -f "$abs_top_builddir/src/Makefile" ] || fail "$abs_top_builddir/src is not configured"
+
+# CC carries flags on some legs ("gcc -m32" on linux-i386, "ccache gcc"), so
+# split it before looking the program up.
+read -r -a cc_argv <<<"${CC:-cc}"
+command -v "${cc_argv[0]}" >/dev/null 2>&1 || {
+    echo "no C compiler (${cc_argv[0]}), skipping" >&2
+    exit 77
+}
+make=${MAKE:-make}
+command -v "$make" >/dev/null 2>&1 || {
+    echo "no make ($make), skipping" >&2
+    exit 77
+}
+
+tmp=$(mktemp -d) || exit 1
+trap 'set +e; rm -rf "$tmp"' EXIT
+
+# Seeding the array with -I keeps it non-empty, which bash 3.2 needs under set -u.
+cpp_argv=(-I"$tmp/include")
+if [ -n "${TEST_CPPFLAGS:-}" ]; then
+    read -r -a extra_argv <<<"$TEST_CPPFLAGS"
+    cpp_argv+=("${extra_argv[@]}")
+fi
+
+# gcc before 14 only warns on an implicit declaration, which would let the
+# hidden-strnlen half of #972 pass as clean.
+printf 'int main(void) { return 0; }\n' >"$tmp/tu.c"
+if "${cc_argv[@]}" "${cpp_argv[@]}" -Werror=implicit-function-declaration \
+    -fsyntax-only "$tmp/tu.c" 2>/dev/null; then
+    cpp_argv+=(-Werror=implicit-function-declaration)
+fi
+
+stds=()
+for std in c99 c11; do
+    printf 'int main(void) { return 0; }\n' >"$tmp/tu.c"
+    if ! "${cc_argv[@]}" "${cpp_argv[@]}" "-std=$std" -fsyntax-only "$tmp/tu.c" 2>/dev/null; then
+        echo "${cc_argv[*]} rejects -std=$std, skipping that mode" >&2
+        continue
+    fi
+    # Only meaningful if the flag is in force: bare typeof must not compile.
+    printf 'int f(int x) { typeof(x) y = x; return y; }\n' >"$tmp/tu.c"
+    if "${cc_argv[@]}" "${cpp_argv[@]}" "-std=$std" -fsyntax-only "$tmp/tu.c" 2>/dev/null; then
+        echo "-std=$std keeps the GNU keywords here, skipping that mode" >&2
+        continue
+    fi
+    stds+=("$std")
+done
+[ "${#stds[@]}" -gt 0 ] || {
+    echo "no strict-ISO mode available from ${cc_argv[*]}, skipping" >&2
+    exit 77
+}
+
+# Whether the strnlen half of #972 is observable on this libc.
+printf '#include <string.h>\nsize_t f(const char *s) { return strnlen(s, 8); }\n' >"$tmp/tu.c"
+if "${cc_argv[@]}" "${cpp_argv[@]}" "-std=${stds[0]}" -fsyntax-only "$tmp/tu.c" 2>/dev/null; then
+    echo "note: this libc declares strnlen in strict mode, only the keyword half is exercised" >&2
+fi
+
+# Override the install dir rather than use DESTDIR: same rule and file list, no
+# guessing at the prefix. Empty MAKEFLAGS, or the sub-make reaches for a
+# jobserver the test driver did not hand it.
+env MAKEFLAGS= MFLAGS= "$make" -C "$abs_top_builddir/src" install-DevIncludesDATA \
+    DevIncludesdir="$tmp/include/httrack" >"$tmp/install.log" 2>&1 ||
+    {
+        cat "$tmp/install.log" >&2
+        fail "install-DevIncludesDATA failed"
+    }
+
+headers=("$tmp/include/httrack"/*.h)
+[ "${#headers[@]}" -ge 10 ] || fail "only ${#headers[@]} headers installed, the list cannot be right"
+[ -f "$tmp/include/httrack/htssafe.h" ] || fail "htssafe.h was not installed"
+
+count=0
+bad=0
+for h in "${headers[@]}"; do
+    b=$(basename "$h")
+    argv=("${cpp_argv[@]}")
+    # No libc exposes getnameinfo() and friends to a strict-ISO unit, so a
+    # consumer of the two socket headers must ask for POSIX itself.
+    case "$b" in
+    htsnet.h | htsopt.h) argv+=(-D_POSIX_C_SOURCE=200809L) ;;
+    esac
+    printf '#include <httrack/%s>\n' "$b" >"$tmp/tu.c"
+    for std in "${stds[@]}"; do
+        for mode in -UHTS_INTERNAL_BYTECODE -DHTS_INTERNAL_BYTECODE; do
+            count=$((count + 1))
+            if ! "${cc_argv[@]}" "${argv[@]}" "-std=$std" "$mode" -fsyntax-only "$tmp/tu.c" 2>"$tmp/cc.log"; then
+                echo "$b does not compile under -std=$std ($mode):" >&2
+                head -5 "$tmp/cc.log" >&2
+                bad=1
+            fi
+        done
+    done
+done
+echo "compiled ${#headers[@]} headers x ${#stds[@]} std x 2 bytecode modes = $count units" >&2
+[ "$bad" -eq 0 ] || fail "installed headers do not compile in strict-ISO mode"
+
+# The loop above is only meaningful if this compiler rejects a missing include.
+printf '#include "no-such-header-972.h"\n' >"$tmp/tu.c"
+if "${cc_argv[@]}" "${cpp_argv[@]}" "-std=${stds[0]}" -fsyntax-only "$tmp/tu.c" 2>/dev/null; then
+    fail "${cc_argv[*]} accepted a missing include, the checks above proved nothing"
+fi
+
+exit 0

--- a/tests/206_install-headers-c99.test
+++ b/tests/206_install-headers-c99.test
@@ -125,7 +125,30 @@ done
 echo "compiled ${#headers[@]} headers x ${#stds[@]} std x 2 bytecode modes = $count units" >&2
 [ "$bad" -eq 0 ] || fail "installed headers do not compile in strict-ISO mode"
 
-# The loop above is only meaningful if this compiler rejects a missing include.
+# A macro body is only compiled where it expands, so the include-only loop above
+# never reaches the __typeof__ in htsbuff_must_be_array_ or HTS_IS_CHAR_BUFFER.
+cat >"$tmp/tu.c" <<'EOF'
+#include <httrack/htssafe.h>
+void f(void);
+void f(void) {
+  char a[8];
+  htsbuff b = htsbuff_array(a);
+  htsbuff_catn(&b, "x", 1);
+  strcpybuff(a, "y");
+}
+EOF
+for std in "${stds[@]}"; do
+    for mode in -UHTS_INTERNAL_BYTECODE -DHTS_INTERNAL_BYTECODE; do
+        if ! "${cc_argv[@]}" "${cpp_argv[@]}" "-std=$std" "$mode" -fsyntax-only "$tmp/tu.c" 2>"$tmp/cc.log"; then
+            echo "htssafe.h macros do not expand under -std=$std ($mode):" >&2
+            head -5 "$tmp/cc.log" >&2
+            bad=1
+        fi
+    done
+done
+[ "$bad" -eq 0 ] || fail "htssafe.h macros do not compile in strict-ISO mode"
+
+# The loops above are only meaningful if this compiler rejects a missing include.
 printf '#include "no-such-header-972.h"\n' >"$tmp/tu.c"
 if "${cc_argv[@]}" "${cpp_argv[@]}" "-std=${stds[0]}" -fsyntax-only "$tmp/tu.c" 2>/dev/null; then
     fail "${cc_argv[*]} accepted a missing include, the checks above proved nothing"

--- a/tests/206_install-headers-c99.test
+++ b/tests/206_install-headers-c99.test
@@ -1,9 +1,8 @@
 #!/bin/bash
 #
-# The installed headers must also compile in a strict-ISO translation unit
-# (-std=c99/c11), where __STRICT_ANSI__ drops the unprefixed GNU keywords and
-# hides the libc's POSIX declarations (#972). 205 varies only the bytecode mode,
-# so it sees neither.
+# The installed headers must also compile in a strict-ISO translation unit,
+# where __STRICT_ANSI__ drops the unprefixed GNU keywords and hides the libc's
+# POSIX declarations (#972). 205 varies only the bytecode mode, so it sees neither.
 
 set -euo pipefail
 
@@ -20,8 +19,7 @@ if [ -z "${abs_top_builddir:-}" ]; then
 fi
 [ -f "$abs_top_builddir/src/Makefile" ] || fail "$abs_top_builddir/src is not configured"
 
-# CC carries flags on some legs ("gcc -m32" on linux-i386, "ccache gcc"), so
-# split it before looking the program up.
+# CC carries flags on some legs ("gcc -m32", "ccache gcc"), so split it first.
 read -r -a cc_argv <<<"${CC:-cc}"
 command -v "${cc_argv[0]}" >/dev/null 2>&1 || {
     echo "no C compiler (${cc_argv[0]}), skipping" >&2
@@ -77,9 +75,8 @@ if "${cc_argv[@]}" "${cpp_argv[@]}" "-std=${stds[0]}" -fsyntax-only "$tmp/tu.c" 
     echo "note: this libc declares strnlen in strict mode, only the keyword half is exercised" >&2
 fi
 
-# Override the install dir rather than use DESTDIR: same rule and file list, no
-# guessing at the prefix. Empty MAKEFLAGS, or the sub-make reaches for a
-# jobserver the test driver did not hand it.
+# Override the install dir rather than DESTDIR: same rule and file list, no
+# prefix guessing. Empty MAKEFLAGS, or the sub-make hunts a jobserver it lacks.
 env MAKEFLAGS= MFLAGS= "$make" -C "$abs_top_builddir/src" install-DevIncludesDATA \
     DevIncludesdir="$tmp/include/httrack" >"$tmp/install.log" 2>&1 ||
     {
@@ -98,8 +95,7 @@ posix_argv=(-D_POSIX_C_SOURCE=200112L)
 printf '#include <httrack/htsnet.h>\n' >"$tmp/tu.c"
 if ! "${cc_argv[@]}" "${cpp_argv[@]}" "${posix_argv[@]}" "-std=${stds[0]}" \
     -fsyntax-only "$tmp/tu.c" 2>/dev/null; then
-    echo "note: htsnet.h needs POSIX.1-2008, strnlen goes uncovered there" >&2
-    posix_argv=(-D_POSIX_C_SOURCE=200809L)
+    fail "htsnet.h needs POSIX.1-2008, which un-hides strnlen and would leave that half of #972 uncovered"
 fi
 
 count=0

--- a/tests/206_install-headers-c99.test
+++ b/tests/206_install-headers-c99.test
@@ -2,7 +2,8 @@
 #
 # The installed headers must also compile in a strict-ISO translation unit,
 # where __STRICT_ANSI__ drops the unprefixed GNU keywords and hides the libc's
-# POSIX declarations (#972). 205 varies only the bytecode mode, so it sees neither.
+# POSIX declarations (#972), and as C++ (#1002). 205 varies only the bytecode
+# mode, so it sees neither.
 
 set -euo pipefail
 
@@ -40,6 +41,8 @@ if [ -n "${TEST_CPPFLAGS:-}" ]; then
     read -r -a extra_argv <<<"$TEST_CPPFLAGS"
     cpp_argv+=("${extra_argv[@]}")
 fi
+# Snapshot before the C-only flag below is appended; the C++ leg reuses this.
+base_cpp_argv=("${cpp_argv[@]}")
 
 # gcc before 14 only warns on an implicit declaration, which would let the
 # hidden-strnlen half of #972 pass as clean.
@@ -195,6 +198,47 @@ else
         "$tmp/strnlen" || fail "htssafe_strnlen_ disagrees with memchr under -std=$std"
     done
 fi
+
+# The installed headers must also compile as C++ (#1002). -fsyntax-only never
+# runs g++'s -Wunused-function pass, so this leg always does a real -c compile.
+cxx=""
+for cand in "${CXX:-}" g++ clang++ c++; do
+    [ -n "$cand" ] && command -v "$cand" >/dev/null 2>&1 && {
+        cxx="$cand"
+        break
+    }
+done
+if [ -z "$cxx" ]; then
+    echo "no C++ compiler found, skipping the C++ leg" >&2
+else
+    cxx_stds=()
+    for std in c++11 c++17; do
+        printf 'int main() { return 0; }\n' >"$tmp/tu.cpp"
+        "$cxx" "${base_cpp_argv[@]}" "-std=$std" -c "$tmp/tu.cpp" -o "$tmp/tu.o" 2>/dev/null &&
+            cxx_stds+=("$std")
+    done
+    [ "${#cxx_stds[@]}" -gt 0 ] || echo "$cxx accepts neither -std=c++11 nor -std=c++17, skipping the C++ leg" >&2
+    for h in "${headers[@]}"; do
+        b=$(basename "$h")
+        argv=("${base_cpp_argv[@]}" -Wall -Wextra -Werror)
+        case "$b" in
+        htsnet.h | htsopt.h) argv+=("${posix_argv[@]}") ;;
+        esac
+        printf '#include <httrack/%s>\nint main() { return 0; }\n' "$b" >"$tmp/tu.cpp"
+        for std in "${cxx_stds[@]}"; do
+            for mode in -UHTS_INTERNAL_BYTECODE -DHTS_INTERNAL_BYTECODE; do
+                if ! "$cxx" "${argv[@]}" "-std=$std" "$mode" -c "$tmp/tu.cpp" -o "$tmp/tu.o" 2>"$tmp/cc.log"; then
+                    echo "$b does not compile as C++ under -std=$std ($mode):" >&2
+                    head -5 "$tmp/cc.log" >&2
+                    bad=1
+                fi
+            done
+        done
+    done
+    [ "${#cxx_stds[@]}" -eq 0 ] ||
+        echo "compiled ${#headers[@]} headers x ${#cxx_stds[@]} C++ std x 2 bytecode modes with $cxx" >&2
+fi
+[ "$bad" -eq 0 ] || fail "installed headers do not compile as C++"
 
 # The loops above are only meaningful if this compiler rejects a missing include.
 printf '#include "no-such-header-972.h"\n' >"$tmp/tu.c"

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -241,3 +241,4 @@ TESTS += 205_install-headers.test
 TESTS += 185_webhttrack-js-escaping.test
 TESTS += 200_pixmaps-fallback.test
 TESTS += 210_appstream-metainfo.test
+TESTS += 206_install-headers-c99.test


### PR DESCRIPTION
Four of the installed headers fail to compile in a strict-ISO translation unit. `src/htssafe.h` spells `typeof` without the underscores in three `__GNUC__` branches, and that keyword is gone under `-std=c99` while `__GNUC__` is not; line 124 of the same file already used `__typeof__`. Fixing that exposes a second failure, since the inline bodies call POSIX `strnlen`, which glibc hides once `__STRICT_ANSI__` is set. `htsopt.h`, `htsnet.h` and `htsarrays.h` inherit both, each because it includes `htssafe.h`.

The `strnlen` half is fixed here rather than by asking consumers for `-D_POSIX_C_SOURCE`. A private `htssafe_strnlen_` calls the libc one wherever it is actually declared and uses a byte loop otherwise, so the default build compiles what it did before; a strict-ANSI C++ consumer now takes the byte loop, since g++ defines `__STRICT_ANSI__` under `-std=c++NN`. Defining a feature-test macro inside the header looks simpler but does not work: measured, it is a no-op once the consumer has included any other libc header, because glibc's `features.h` has already run by then. Keeping the name `strnlen` for our own static definition is worse, since a consumer that does set `_POSIX_C_SOURCE` then gets a static declaration after a non-static one.

`tests/206` compiles every installed header under `-std=c99` and `-std=c11` in both `HTS_INTERNAL_BYTECODE` states, 56 translation units on this box, and reverting either half of the header fix reds it. It skips rather than fails where the compiler has no strict mode, checks that `-std=` is really in force by requiring bare `typeof` to be rejected first, and runs the byte loop against `memchr` on a poisoned buffer so the fallback is not merely compiled. `htsnet.h` and `htsopt.h` get `-D_POSIX_C_SOURCE=200112L` in that loop, chosen over 200809L because 2008 would un-hide `strnlen` and stop those two covering that half: they wrap `getnameinfo()` and `NI_NUMERICHOST`, which no header can hand to a strict-ISO unit, since the macro's value is implementation-defined and glibc's own `<netdb.h>` is just as unusable in that mode. A consumer of those two has to ask for POSIX itself, exactly as it would to call `getnameinfo()` directly.

This also folds in #1002: `htsarrays.h`'s `hts_record_assert_memory_failed` needs the same `HTS_UNUSED` that `htssafe.h` already uses for this shape, since g++ and clang++ flag it unused once the header is compiled as C++ (`-std=c++11`/`c++17`, both `HTS_INTERNAL_BYTECODE` states). `tests/206` now compiles the installed headers as C++ too, with a real `-c` compile instead of `-fsyntax-only`, since g++ only runs `-Wunused-function` on the former.

Closes #972
Closes #1002
