### PR TITLE
Two installed headers declare symbols the library does not export

### DIFF
--- a/src/htsbasenet.h
+++ b/src/htsbasenet.h
@@ -84,9 +84,12 @@ extern "C" {
 /* OpenSSL structure */
 #include <openssl/bio.h>
 
+/* Engine-only: not exported, so the installed header must not offer it. */
+#ifdef HTS_INTERNAL_BYTECODE
 /** Process-wide OpenSSL client context, created lazily on first TLS use;
     shared by all connections. NULL until initialized. */
 extern SSL_CTX *openssl_ctx;
+#endif
 
 #endif
 #endif

--- a/src/htsnet.h
+++ b/src/htsnet.h
@@ -319,6 +319,10 @@ typedef socklen_t SOClen;
 #define HTS_RESOLVER_CALL
 #endif
 
+/* File scope, or the tag below is a fresh type scoped to its own prototype
+   wherever <netdb.h> has not already declared it. */
+struct addrinfo;
+
 typedef struct hts_resolver_backend {
   int(HTS_RESOLVER_CALL *getaddrinfo)(const char *node, const char *service,
                                       const struct addrinfo *hints,

--- a/src/htsnet.h
+++ b/src/htsnet.h
@@ -305,6 +305,8 @@ static HTS_UNUSED void SOCaddr_inetntoa_(char *namebuf, size_t namebuflen,
 typedef socklen_t SOClen;
 
 #if HTS_INET6 != 0
+/* Engine-only: not exported, and the type is useless without the setter. */
+#ifdef HTS_INTERNAL_BYTECODE
 /** Resolver backend: getaddrinfo/freeaddrinfo as a swappable pair, so the
     self-test can script DNS answers (families, multiplicity, errors)
     in-process. The free function must match its getaddrinfo (a fake allocates
@@ -327,6 +329,7 @@ typedef struct hts_resolver_backend {
 /** Install a resolver backend for the process; NULL restores the libc default.
     Test-only seam, not thread-safe; callers must serialize against resolves. */
 void hts_dns_set_resolver_backend(const hts_resolver_backend *backend);
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/tests/207_install-headers-symbols.test
+++ b/tests/207_install-headers-symbols.test
@@ -1,9 +1,8 @@
 #!/bin/bash
 #
 # An installed header must not offer a name libhttrack.so keeps hidden: the
-# consumer compiles, then fails to link (#977). Asserted against the artifacts,
-# not the header text: the hidden set is the library's symbol table minus its
-# dynamic table, and every name a consumer can reach is linked for real.
+# consumer compiles, then fails to link (#977). Linked for real, not grepped.
+# Blind to a wrong signature, which the linker cannot see either.
 
 set -euo pipefail
 
@@ -61,10 +60,8 @@ probe_body() {
     printf 'int main(void) { const void *volatile p = (const void *) &%s; return p != 0; }\n' "$1"
 }
 
-# Declares $1 by hand, so the controls below lean on no header. A function type
-# is a lie the linker ignores, and unlike a data declaration it stays PIE-clean
-# whichever kind $1 turns out to be. Compiling apart keeps a malformed probe
-# from reading as a link failure.
+# A function declaration is a lie the linker ignores, and stays PIE-clean
+# whichever kind $1 is. Compiled apart, so a malformed probe is not a link error.
 links() {
     {
         printf 'extern void %s(void);\n' "$1"
@@ -77,9 +74,8 @@ links() {
     "${cc_argv[@]}" -w -o "$tmp/ctl" "$tmp/ctl.o" "$lib" 2>"$tmp/ctl.log"
 }
 
-# The probe must resolve an exported name and reject a hidden one, or every
-# verdict below is vacuous. Compiler-generated statics ("a.2") are not spellable
-# in C, so skip past them.
+# Without both controls every verdict below is vacuous. Compiler-generated
+# statics ("a.2") are not spellable in C, so skip past them.
 pos=$(grep -x hts_is_available "$tmp/exported" || head -1 "$tmp/exported")
 neg=$(awk '/^[A-Za-z_][A-Za-z0-9_]*$/ { print; exit }' "$tmp/hidden")
 links "$pos" || {
@@ -88,9 +84,8 @@ links "$pos" || {
 }
 ! links "$neg" || fail "the hidden $neg links anyway, so the probe cannot see the defect"
 
-# Override the install dir rather than use DESTDIR: same rule and file list, no
-# guessing at the prefix. Empty MAKEFLAGS, or the sub-make reaches for a
-# jobserver the test driver did not hand it.
+# Override the install dir rather than DESTDIR: same rule and file list, no
+# prefix guessing. Empty MAKEFLAGS, or the sub-make hunts a jobserver it lacks.
 env MAKEFLAGS= MFLAGS= "$make" -C "$abs_top_builddir/src" install-DevIncludesDATA \
     DevIncludesdir="$tmp/include/httrack" >"$tmp/install.log" 2>&1 ||
     {

--- a/tests/207_install-headers-symbols.test
+++ b/tests/207_install-headers-symbols.test
@@ -98,6 +98,11 @@ env MAKEFLAGS= MFLAGS= "$make" -C "$abs_top_builddir/src" install-DevIncludesDAT
         fail "install-DevIncludesDATA failed"
     }
 
+# A synthetic leak the loop must report: every real candidate is a static defined
+# in the header, which links from the probe's own copy and so proves nothing.
+canary=zzz-canary.h
+printf 'extern void %s(void);\n' "$neg" >"$tmp/include/httrack/$canary"
+
 headers=("$tmp/include/httrack"/*.h)
 [ "${#headers[@]}" -ge 10 ] || fail "only ${#headers[@]} headers installed, the list cannot be right"
 
@@ -150,6 +155,9 @@ done
 echo "linked $probed reachable symbol(s) from ${#headers[@]} installed headers" \
     "($n_hidden hidden, $n_exported exported)"
 [ "$probed" -ge 5 ] || fail "only $probed symbols reached the link probe, the candidate list is broken"
+[ "${leaks#* "$canary":"$neg"}" != "$leaks" ] ||
+    fail "the synthetic $canary:$neg leak went unreported, the candidate list is broken"
+leaks=${leaks/ "$canary":"$neg"/}
 [ -z "$leaks" ] || fail "installed headers declare symbols $lib does not export:$leaks"
 
 exit 0

--- a/tests/207_install-headers-symbols.test
+++ b/tests/207_install-headers-symbols.test
@@ -1,0 +1,155 @@
+#!/bin/bash
+#
+# An installed header must not offer a name libhttrack.so keeps hidden: the
+# consumer compiles, then fails to link (#977). Asserted against the artifacts,
+# not the header text: the hidden set is the library's symbol table minus its
+# dynamic table, and every name a consumer can reach is linked for real.
+
+set -euo pipefail
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+skip() {
+    echo "$1, skipping" >&2
+    exit 77
+}
+
+# Unset means no automake run (the Windows job runs the scripts directly), so
+# there is no install rule to drive.
+[ -n "${abs_top_builddir:-}" ] || skip "abs_top_builddir unset, no automake environment"
+[ -f "$abs_top_builddir/src/Makefile" ] || fail "$abs_top_builddir/src is not configured"
+
+lib=${HTTRACK_SHLIB:-}
+[ -f "${lib:-/nonexistent}" ] || skip "no shared libhttrack at '${lib:-unset}'"
+
+# CC carries flags on some legs ("gcc -m32", "ccache gcc"), so split it.
+read -r -a cc_argv <<<"${CC:-cc}"
+command -v "${cc_argv[0]}" >/dev/null 2>&1 || skip "no C compiler (${cc_argv[0]})"
+make=${MAKE:-make}
+command -v "$make" >/dev/null 2>&1 || skip "no make ($make)"
+nm=${NM:-nm}
+command -v "$nm" >/dev/null 2>&1 || skip "no nm ($nm)"
+
+tmp=$(mktemp -d) || exit 1
+trap 'set +e; rm -rf "$tmp"' EXIT
+
+# ELF only: BSD nm has no -D.
+"$nm" -D --defined-only "$lib" >"$tmp/exported.raw" 2>/dev/null ||
+    skip "$nm cannot read the dynamic table of $lib"
+"$nm" --defined-only "$lib" >"$tmp/all.raw" 2>/dev/null ||
+    skip "$nm cannot read the symbol table of $lib"
+awk 'NF >= 3 { print $3 }' "$tmp/exported.raw" | sort -u >"$tmp/exported"
+awk 'NF >= 3 { print $3 }' "$tmp/all.raw" | sort -u >"$tmp/all"
+comm -23 "$tmp/all" "$tmp/exported" >"$tmp/hidden"
+n_exported=$(wc -l <"$tmp/exported")
+n_hidden=$(wc -l <"$tmp/hidden")
+[ "$n_exported" -ge 50 ] || fail "$lib exports only $n_exported symbols, that cannot be right"
+[ "$n_hidden" -ge 100 ] || skip "only $n_hidden local symbols in $lib, it looks stripped"
+
+cpp_argv=(-I"$tmp/include")
+if [ -n "${TEST_CPPFLAGS:-}" ]; then
+    read -r -a extra_argv <<<"$TEST_CPPFLAGS"
+    cpp_argv+=("${extra_argv[@]}")
+fi
+
+# volatile, or the compiler folds "address of a known symbol is non-null" to 1
+# and drops the relocation the link is being asked about.
+probe_body() {
+    printf 'int main(void) { const void *volatile p = (const void *) &%s; return p != 0; }\n' "$1"
+}
+
+# Declares $1 by hand, so the controls below lean on no header. A function type
+# is a lie the linker ignores, and unlike a data declaration it stays PIE-clean
+# whichever kind $1 turns out to be. Compiling apart keeps a malformed probe
+# from reading as a link failure.
+links() {
+    {
+        printf 'extern void %s(void);\n' "$1"
+        probe_body "$1"
+    } >"$tmp/ctl.c"
+    "${cc_argv[@]}" -w -c -o "$tmp/ctl.o" "$tmp/ctl.c" 2>"$tmp/ctl.log" || {
+        head -5 "$tmp/ctl.log" >&2
+        fail "the control probe for $1 does not compile"
+    }
+    "${cc_argv[@]}" -w -o "$tmp/ctl" "$tmp/ctl.o" "$lib" 2>"$tmp/ctl.log"
+}
+
+# The probe must resolve an exported name and reject a hidden one, or every
+# verdict below is vacuous. Compiler-generated statics ("a.2") are not spellable
+# in C, so skip past them.
+pos=$(grep -x hts_is_available "$tmp/exported" || head -1 "$tmp/exported")
+neg=$(awk '/^[A-Za-z_][A-Za-z0-9_]*$/ { print; exit }' "$tmp/hidden")
+links "$pos" || {
+    head -5 "$tmp/ctl.log" >&2
+    skip "cannot link the exported $pos against $lib"
+}
+! links "$neg" || fail "the hidden $neg links anyway, so the probe cannot see the defect"
+
+# Override the install dir rather than use DESTDIR: same rule and file list, no
+# guessing at the prefix. Empty MAKEFLAGS, or the sub-make reaches for a
+# jobserver the test driver did not hand it.
+env MAKEFLAGS= MFLAGS= "$make" -C "$abs_top_builddir/src" install-DevIncludesDATA \
+    DevIncludesdir="$tmp/include/httrack" >"$tmp/install.log" 2>&1 ||
+    {
+        cat "$tmp/install.log" >&2
+        fail "install-DevIncludesDATA failed"
+    }
+
+headers=("$tmp/include/httrack"/*.h)
+[ "${#headers[@]}" -ge 10 ] || fail "only ${#headers[@]} headers installed, the list cannot be right"
+
+# Identifiers of the preprocessed unit, narrowed by cpp's line markers to the
+# installed headers, so <openssl/ssl.h> and friends stay out of the candidates.
+cat >"$tmp/ids.awk" <<'EOF'
+/^# [0-9]+ "/ {
+    s = $0
+    sub(/^# [0-9]+ "/, "", s)
+    sub(/".*$/, "", s)
+    ours = (index(s, PREFIX) == 1)
+    next
+}
+ours {
+    while (match($0, /[A-Za-z_][A-Za-z0-9_]*/)) {
+        print substr($0, RSTART, RLENGTH)
+        $0 = substr($0, RSTART + RLENGTH)
+    }
+}
+EOF
+
+probed=0
+leaks=""
+for h in "${headers[@]}"; do
+    b=$(basename "$h")
+    # config.h first, as a consumer must: it is what turns HTS_USEOPENSSL on, and
+    # without it htsbasenet.h preprocesses its OpenSSL half away.
+    printf '#include <httrack/config.h>\n#include <httrack/%s>\n' "$b" >"$tmp/tu.c"
+    "${cc_argv[@]}" "${cpp_argv[@]}" -UHTS_INTERNAL_BYTECODE -E -o "$tmp/tu.i" "$tmp/tu.c" \
+        2>"$tmp/cc.log" || {
+        head -5 "$tmp/cc.log" >&2
+        fail "$b does not preprocess the way a consumer includes it"
+    }
+    awk -v PREFIX="$tmp/include/httrack/" -f "$tmp/ids.awk" "$tmp/tu.i" | sort -u >"$tmp/ids"
+    while read -r sym; do
+        [ -n "$sym" ] || continue
+        {
+            printf '#include <httrack/config.h>\n#include <httrack/%s>\n' "$b"
+            probe_body "$sym"
+        } >"$tmp/probe.c"
+        # Undeclared means the header never put it on the consumer's surface.
+        "${cc_argv[@]}" "${cpp_argv[@]}" -UHTS_INTERNAL_BYTECODE -w -c -o "$tmp/probe.o" \
+            "$tmp/probe.c" 2>/dev/null || continue
+        probed=$((probed + 1))
+        "${cc_argv[@]}" -w -o "$tmp/probe" "$tmp/probe.o" "$lib" 2>/dev/null ||
+            leaks="$leaks $b:$sym"
+    done < <(comm -12 "$tmp/hidden" "$tmp/ids")
+done
+
+echo "linked $probed reachable symbol(s) from ${#headers[@]} installed headers" \
+    "($n_hidden hidden, $n_exported exported)"
+[ "$probed" -ge 5 ] || fail "only $probed symbols reached the link probe, the candidate list is broken"
+[ -z "$leaks" ] || fail "installed headers declare symbols $lib does not export:$leaks"
+
+exit 0

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -40,6 +40,9 @@ TESTS_ENVIRONMENT += MAKE="$(MAKE)"
 # openssl@3 is keg-only, so htsbasenet.h finds <openssl/ssl.h> only through it.
 TESTS_ENVIRONMENT += CC="$(CC)"
 TESTS_ENVIRONMENT += TEST_CPPFLAGS="$(CPPFLAGS)"
+# 207_install-headers-symbols.test links a consumer probe against it; missing on
+# a static-only build, where that test skips.
+TESTS_ENVIRONMENT += HTTRACK_SHLIB=$(abs_top_builddir)/src/$(LT_CV_OBJDIR)/libhttrack.so
 TESTS_ENVIRONMENT += RENAMEFAIL_LA=$(abs_builddir)/librenamefail.la
 TESTS_ENVIRONMENT += RENAMEFAIL_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/librenamefail.so
 TESTS_ENVIRONMENT += THREADATTRFAIL_LA=$(abs_builddir)/libthreadattrfail.la

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -40,8 +40,8 @@ TESTS_ENVIRONMENT += MAKE="$(MAKE)"
 # openssl@3 is keg-only, so htsbasenet.h finds <openssl/ssl.h> only through it.
 TESTS_ENVIRONMENT += CC="$(CC)"
 TESTS_ENVIRONMENT += TEST_CPPFLAGS="$(CPPFLAGS)"
-# 207_install-headers-symbols.test links a consumer probe against it; missing on
-# a static-only build, where that test skips.
+# 207_install-headers-symbols.test links a consumer probe against it; absent on a
+# static-only build and named .dylib on macOS, where that ELF-only test skips.
 TESTS_ENVIRONMENT += HTTRACK_SHLIB=$(abs_top_builddir)/src/$(LT_CV_OBJDIR)/libhttrack.so
 TESTS_ENVIRONMENT += RENAMEFAIL_LA=$(abs_builddir)/librenamefail.la
 TESTS_ENVIRONMENT += RENAMEFAIL_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/librenamefail.so

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -241,3 +241,4 @@ TESTS += 205_install-headers.test
 TESTS += 185_webhttrack-js-escaping.test
 TESTS += 200_pixmaps-fallback.test
 TESTS += 210_appstream-metainfo.test
+TESTS += 207_install-headers-symbols.test


### PR DESCRIPTION
`htsbasenet.h` declares `openssl_ctx` and `htsnet.h` declares `hts_dns_set_resolver_backend`, but `-fvisibility=hidden` keeps both out of `libhttrack.so`'s dynamic table. Both headers install into `$(includedir)/httrack`, so a consumer that includes one and uses the name compiles, then fails to link. Nothing breaks today only because nobody links against either. Both go behind `HTS_INTERNAL_BYTECODE`, the guard `htsmodules.h`, `htsbauth.h` and `htsdefines.h` already use and no consumer defines; every in-tree user already defines it ahead of its first include, and the exported set stays at 165 symbols.

The resolver seam is the arguable one, since an embedder might reasonably want to swap in c-ares or a caching resolver, and exporting it with `HTSEXT_API` is the alternative. It would freeze more than the function: `hts_resolver_backend` is caller-allocated and stored by pointer, so it could never grow a member compatibly; `HTS_RESOLVER_CALL` is `__stdcall` on Win32 and a macro cannot be versioned or deprecated; and the declaration itself calls the seam test-only and not thread-safe. That wants a designed entry point rather than a visibility flip, so this hides it for now. Test 207 asserts the property rather than the two names, linking a real probe for every hidden name an installed header exposes, with a canary declaration proving the harvest is not silently empty. Reverting either guard reds it with five findings.

`htsnet.h` also gains a file-scope `struct addrinfo;`, without which the tag in the resolver-backend prototypes is a fresh type scoped to its own declaration wherever `<netdb.h>` has not already declared it.

Closes #977
Closes #987
