### PR TITLE
Nothing checks that the data directory comes from the OS path, not argv[0]

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3438,6 +3438,15 @@ static int st_datadir(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+// -#test=pathbin: report what startup resolved, which -#test=datadir cannot see
+// because it hands hts_resolve_datadir() the path instead (#904).
+static int st_pathbin(httrackp *opt, int argc, char **argv) {
+  (void) argc;
+  (void) argv;
+  printf("path_bin=%s\n", StringBuff(opt->path_bin));
+  return 0;
+}
+
 // hts_buildtopindex() writes a system-charset name into a charset=utf-8 doc: on
 // Windows the gifs land in a mangled twin dir (#217) and a listed name renders
 // as mojibake (#216). Both must come out utf-8. argv[0] is writable.
@@ -7945,6 +7954,8 @@ static const struct selftest_entry {
     {"datadir", "<dir>",
      "data directory resolution: compiled-in path, then the executable's tree",
      st_datadir},
+    {"pathbin", "", "print the data directory this run resolved at startup",
+     st_pathbin},
     {"inplace-escape", "", "inplace_escape_* vs escape_* equivalence self-test",
      st_inplace_escape},
     {"escape-room", "", "HT_ADD_HTMLESCAPED* reservation-factor self-test",

--- a/tests/215_engine-datadir-ospath.test
+++ b/tests/215_engine-datadir-ospath.test
@@ -50,6 +50,8 @@ plant "${work}/real" REAL
 plant "${work}/decoy" DECOY
 bin=${work}/real/bin/httrack
 cp "${src}" "${bin}"
+# A program at the decoy path too: an existence-checked argv[0] must still lose.
+cp "${src}" "${work}/decoy/bin/httrack"
 
 # libtool knows which variable this platform's loader reads.
 if [ -n "${SHLIBPATH_VAR:-}" ] && [ -n "${HTTRACK_LIBDIR:-}" ]; then
@@ -84,7 +86,9 @@ run_as "${work}/decoy/bin/httrack"
 mark=$(marker_of "${got}")
 [ "${mark}" = REAL ] || fail "argv[0] chose the data directory: ${got} (${mark:-no templates})"
 
-# What a PATH lookup leaves in argv[0]: no directory at all.
+# What a PATH lookup leaves in argv[0]: no directory at all, and a PATH whose
+# first hit is the decoy.
+PATH="${work}/decoy/bin:${PATH}"
 run_as httrack
 mark=$(marker_of "${got}")
 [ "${mark}" = REAL ] ||

--- a/tests/215_engine-datadir-ospath.test
+++ b/tests/215_engine-datadir-ospath.test
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# The data directory has to come from the OS-reported executable path, not from
+# argv[0], or a PATH-invoked binary has nothing but a bare name to derive from
+# (#904). -#test=datadir cannot see this: it hands the path in.
+
+set -euo pipefail
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+skip() {
+    echo "$*; skipping" >&2
+    exit 77
+}
+
+# Unset means this is not an automake run (the Windows job runs the scripts
+# directly), so there is no unwrapped binary to copy. Set but missing is a build
+# problem, not a skip.
+[ -n "${HTTRACK_BIN:-}" ] || skip "HTTRACK_BIN unset, no automake environment"
+[ -r "${HTTRACK_BIN}" ] || fail "${HTTRACK_BIN} was not built"
+datadir="${CONFIGURED_DATADIR:?not run under make check}"
+
+# The compiled-in directory short-circuits the whole resolution when it exists,
+# and then no argv[0] can change the answer.
+builtin="${datadir%/}/httrack"
+if [ -r "${builtin}/templates/index-header.html" ]; then
+    skip "the compiled-in data directory ${builtin} answers before the executable's tree"
+fi
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/ospath.XXXXXX") || {
+    echo "no tmpdir" >&2
+    exit 1
+}
+trap 'set +e; rm -rf "${work}"' EXIT
+
+# Two installed-looking trees, each with the templates file path_bin is read
+# for; only their contents tell them apart.
+plant() {
+    mkdir -p "$1/bin" "$1/share/httrack/templates"
+    printf '%s\n' "$2" >"$1/share/httrack/templates/index-header.html"
+}
+plant "${work}/real" REAL
+plant "${work}/decoy" DECOY
+bin=${work}/real/bin/httrack
+cp "${HTTRACK_BIN}" "${bin}"
+
+# libtool knows which variable this platform's loader reads.
+if [ -n "${SHLIBPATH_VAR:-}" ] && [ -n "${HTTRACK_LIBDIR:-}" ]; then
+    prev=$(printenv "${SHLIBPATH_VAR}" || true)
+    export "${SHLIBPATH_VAR}=${HTTRACK_LIBDIR}${prev:+:${prev}}"
+fi
+
+got=
+run_as() {
+    local out line
+    out=$(exec -a "$1" "${bin}" -#test=pathbin 2>&1) ||
+        fail "the copy did not run as argv[0]=$1: ${out}"
+    line=$(grep '^path_bin=' <<<"${out}") || fail "no path_bin line in: ${out}"
+    got=${line#path_bin=}
+}
+
+marker_of() {
+    local f="${1%/}/templates/index-header.html"
+    if [ -r "${f}" ]; then cat "${f}"; fi
+}
+
+# Control: a truthful argv[0] must land on the copy's own templates, or the
+# runs below compare nothing.
+run_as "${bin}"
+mark=$(marker_of "${got}")
+[ "${mark}" = REAL ] ||
+    fail "the copy did not read its own templates: ${got} (${mark:-no templates})"
+
+# An argv[0] naming a tree that has templates of its own: taking it would give
+# DECOY.
+run_as "${work}/decoy/bin/httrack"
+mark=$(marker_of "${got}")
+[ "${mark}" = REAL ] || fail "argv[0] chose the data directory: ${got} (${mark:-no templates})"
+
+# What a PATH lookup leaves in argv[0]: no directory at all.
+run_as httrack
+mark=$(marker_of "${got}")
+[ "${mark}" = REAL ] ||
+    fail "a bare argv[0] lost the data directory: ${got} (${mark:-no templates})"
+
+echo "data directory resolved from the executable path under a decoy and a bare argv[0]: ${got}"

--- a/tests/215_engine-datadir-ospath.test
+++ b/tests/215_engine-datadir-ospath.test
@@ -16,11 +16,16 @@ skip() {
 }
 
 # Unset means this is not an automake run (the Windows job runs the scripts
-# directly), so there is no unwrapped binary to copy. Set but missing is a build
-# problem, not a skip.
-[ -n "${HTTRACK_BIN:-}" ] || skip "HTTRACK_BIN unset, no automake environment"
-[ -r "${HTTRACK_BIN}" ] || fail "${HTTRACK_BIN} was not built"
+# directly), so there is no unwrapped binary to copy.
+[ -n "${abs_top_builddir:-}" ] || skip "abs_top_builddir unset, no automake environment"
 datadir="${CONFIGURED_DATADIR:?not run under make check}"
+
+# A shared build hides the program behind a wrapper script and puts the binary
+# in .libs; --disable-shared needs no wrapper and leaves it in src/.
+src=${HTTRACK_BIN:-}
+[ -r "${src}" ] || src=${abs_top_builddir}/src/httrack
+[ -r "${src}" ] || fail "no httrack binary under ${abs_top_builddir}/src"
+[ "$(head -c 2 "${src}")" != '#!' ] || fail "${src} is the libtool wrapper, not the binary"
 
 # The compiled-in directory short-circuits the whole resolution when it exists,
 # and then no argv[0] can change the answer.
@@ -44,7 +49,7 @@ plant() {
 plant "${work}/real" REAL
 plant "${work}/decoy" DECOY
 bin=${work}/real/bin/httrack
-cp "${HTTRACK_BIN}" "${bin}"
+cp "${src}" "${bin}"
 
 # libtool knows which variable this platform's loader reads.
 if [ -n "${SHLIBPATH_VAR:-}" ] && [ -n "${HTTRACK_LIBDIR:-}" ]; then

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -49,6 +49,12 @@ TESTS_ENVIRONMENT += NOBACKTRACE_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/libnobacktr
 TESTS_ENVIRONMENT += ALTSTACKPROBE_LA=$(abs_builddir)/libaltstackprobe.la
 TESTS_ENVIRONMENT += ALTSTACKPROBE_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/libaltstackprobe.so
 TESTS_ENVIRONMENT += STRINGOOM_BIN=$(abs_builddir)/stringoom$(EXEEXT)
+# 215_engine-datadir-ospath.test runs the engine from a copy, so it needs the
+# real binary rather than the libtool wrapper script, plus the loader variable
+# libtool picked for this platform.
+TESTS_ENVIRONMENT += HTTRACK_BIN=$(abs_top_builddir)/src/$(LT_CV_OBJDIR)/httrack$(EXEEXT)
+TESTS_ENVIRONMENT += HTTRACK_LIBDIR=$(abs_top_builddir)/src/$(LT_CV_OBJDIR)
+TESTS_ENVIRONMENT += SHLIBPATH_VAR=$(SHLIBPATH_VAR)
 
 # rename() interposer for 01_engine-renameover.test; -rpath is what makes
 # libtool build a shared module rather than a static-only convenience library.

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -213,7 +213,9 @@ echo "ran=$((pass + fail + skip)) pass=$pass fail=$fail skip=$skip" |
 # update-304-leak needs a LeakSanitizer build, which MSVC has no equivalent of;
 # crash-symbolize and backtrace-empty need backtrace(), which Windows has no
 # equivalent of;
-# string-oom drives a helper binary that only the automake build produces.
+# string-oom drives a helper binary that only the automake build produces;
+# datadir-ospath copies the unwrapped binary the automake build leaves in .libs,
+# and needs the loader variable libtool picked, neither of which this job has.
 expected_skips="01_engine-footer-overflow.test
 100_local-purge-longpath.test
 114_local-update-304-leak.test
@@ -222,6 +224,7 @@ expected_skips="01_engine-footer-overflow.test
 147_local-proxytrack-webdav-overflow.test
 152_engine-string-oom.test
 153_local-proxytrack-quiet.test
+215_engine-datadir-ospath.test
 48_local-crange-memresume.test
 71_local-crange-repaircache.test
 79_local-proxytrack-webdav-mime.test

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -241,3 +241,4 @@ TESTS += 205_install-headers.test
 TESTS += 185_webhttrack-js-escaping.test
 TESTS += 200_pixmaps-fallback.test
 TESTS += 210_appstream-metainfo.test
+TESTS += 215_engine-datadir-ospath.test


### PR DESCRIPTION
#899 moved the data directory resolution onto the OS-reported executable path, with argv[0] left as a fallback. `hts_resolve_datadir()` has a self-test, but that self-test is handed the path, so the startup lines picking which path to hand it were covered by nothing: reverting them to argv[0] alone left the whole suite green. Those lines are what make a PATH-invoked binary work, where argv[0] is a bare name with no directory in it.

The new test copies the engine into a fabricated `bin/` beside a marked `share/httrack/templates/`, then runs it under `exec -a` with a lying argv[0], once naming a decoy tree that has templates of its own and once a bare name. Both runs have to come back with the copy's templates. The assertion reads the marker inside the directory the run resolved instead of comparing path strings, so it does not care how macOS and Linux spell the executable path. `-#test=pathbin` is what prints it.

Either case kills the argv[0]-only mutant on its own. The test skips when the compiled-in data directory exists on the build machine, since that short-circuits the resolution before either path matters, and on Windows, where the job globs `_engine-` but has neither the unwrapped binary nor libtool's loader variable; the suite's expected-skip set lists it.

Closes #904
