### PR TITLE
Test 157 fails wherever addr2line speaks a language other than English

### DIFF
--- a/tests/157_crash-argv0-path.test
+++ b/tests/157_crash-argv0-path.test
@@ -49,7 +49,9 @@ test -r "${bin}" || fail "no httrack in ${stage}${bindir}"
 cd "${work}"
 out=${work}/trace
 rc=0
+# LC_ALL=C: addr2line translates its " at " separator, which the frame match below pins.
 PATH="${stage}${bindir}:${PATH}" \
+    LC_ALL=C \
     LD_LIBRARY_PATH="${stage}${libdir%/}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" \
     run_with_timeout 60 httrack -#test=strsafe overflow \
     "this string is far too long for the buffer" >"${out}" 2>&1 || rc=$?


### PR DESCRIPTION
Test 157 matches a symbolized frame on addr2line's ` at ` separator, to keep a path component named `main` from satisfying it. binutils translates that separator, so under `LANG=fr_FR.UTF-8` the frame reads `sig_fatal à /src/httrack.c:913` and the test fails claiming the block names no frame, while the frames sit right there in the message. Running the crash under `LC_ALL=C` fixes it.

CI never sees this because the runners are English, but a French or German developer running `make check` on master hits it every time. Measured both ways: without the change the test fails under `fr_FR.UTF-8` and passes under `LC_ALL=C`; with it, both pass.

Closes #999
