### PR TITLE
Slovak: the word for search is missing a letter

### DIFF
--- a/lang/Slovak.txt
+++ b/lang/Slovak.txt
@@ -163,7 +163,7 @@ Požiadavka
 connect
 Spojenie
 search
-H¾danie
+H¾adanie
 ready
 Pripravené
 error


### PR DESCRIPTION
lang/Slovak.txt spelled the word for "search" as `Hľdanie` instead of `Hľadanie`. Pre-existing, and untouched by #963: those bytes are identical to what master carried before the charset-declaration move. Fixed byte-wise, keeping the file's CRLF endings and cp1250 encoding intact.

Closes #994
