### PR TITLE
A control byte in a link makes the crawler fetch a URL the page never wrote

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -3960,9 +3960,14 @@ HTSEXT_API size_t escape_uri_utf(const char *const src,
   return x_escape_http(src, dest, size, 30);
 }
 
-HTSEXT_API size_t escape_check_url(const char *const src, 
-                                   char *const dest, const size_t size) {
+HTSEXT_API size_t escape_check_url(const char *const src, char *const dest,
+                                   const size_t size) {
   return x_escape_http(src, dest, size, 0);
+}
+
+HTSEXT_API size_t escape_control_url(const char *const src, char *const dest,
+                                     const size_t size) {
+  return x_escape_http(src, dest, size, 4);
 }
 
 // same as escape_check_url, but returns char*
@@ -4094,6 +4099,8 @@ HTSEXT_API size_t x_escape_http(const char *const s, char *const dest,
     else if (mode == 3)         // échapper que ce qui est nécessaire
       test = CHAR_SPECIAL(c)
              || CHAR_XXAVOID(c);
+    else if (mode == 4) // C0 controls only, leaving high bytes (UTF-8)
+      test = CHAR_LOW(c);
     else if (mode == 30)      // échapper que ce qui est nécessaire
       test = (c != '/' && CHAR_RESERVED(c))
         || CHAR_DELIM(c)

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -1943,10 +1943,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
             if (ok != -1) {     // continuer
               // découper le lien
               do {
-                if ((unsigned char) *eadr < 32) {   // caractère de contrôle (ou \0)
-                  if (!is_space(*eadr))
-                    ok = 0;
-                }
+                if (*eadr == '\0') // end of the parsed buffer
+                  ok = 0;
                 if (eadr - html > HTS_URLMAXSIZE)    // ** trop long, >HTS_URLMAXSIZE caractères (on prévoit HTS_URLMAXSIZE autres pour path)
                   ok = -1;      // ne pas traiter ce lien
 
@@ -1997,6 +1995,12 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                     }
                   }
                 }
+                /* A control byte still inside the URL here (CR/LF/TAB are
+                   stripped below) would be deleted from it, fetching a link
+                   the page never wrote (#982). */
+                if (ok == 1 && (unsigned char) *eadr < 32 &&
+                    !is_retorsep(*eadr))
+                  ok = -1;
                 eadr++;
               } while(ok == 1);
 
@@ -2109,10 +2113,11 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                   //  skip leading ones
                   while(is_realspace(*a))
                     a++;
-                  // strip cr, lf, tab inside URL
+                  // strip cr, lf, tab inside URL; the link scan lets only these
+                  // three control bytes through, and drops the link otherwise
                   llen = 0;
                   while(*a) {
-                    if (*a != '\n' && *a != '\r' && *a != '\t') {
+                    if (!is_retorsep(*a)) {
                       lien[llen++] = *a;
                     }
                     a++;
@@ -2152,7 +2157,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                   strcpybuff(lien, 
                     unescape_http_unharm(catbuff, sizeof(catbuff), lien, 1 | 2));     /* note: '%' is still escaped */
 
-                  // Force to encode non-printable chars (should never happend)
+                  // Drop the control bytes a %XX may have just decoded to; DEL
+                  // and the C1 range stay, being UTF-8 continuation bytes here
                   escape_remove_control(lien);
 
                   // charset conversion for the URI filename (not the query

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -1995,12 +1995,6 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                     }
                   }
                 }
-                /* A control byte still inside the URL here (CR/LF/TAB are
-                   stripped below) would be deleted from it, fetching a link
-                   the page never wrote (#982). */
-                if (ok == 1 && (unsigned char) *eadr < 32 &&
-                    !is_retorsep(*eadr))
-                  ok = -1;
                 eadr++;
               } while(ok == 1);
 
@@ -2113,8 +2107,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                   //  skip leading ones
                   while(is_realspace(*a))
                     a++;
-                  // strip cr, lf, tab inside URL; the link scan lets only these
-                  // three control bytes through, and drops the link otherwise
+                  // strip cr, lf, tab inside URL, as a browser does; every
+                  // other control byte percent-encodes below
                   llen = 0;
                   while(*a) {
                     if (!is_retorsep(*a)) {
@@ -2157,9 +2151,22 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                   strcpybuff(lien, 
                     unescape_http_unharm(catbuff, sizeof(catbuff), lien, 1 | 2));     /* note: '%' is still escaped */
 
-                  // Drop the control bytes a %XX may have just decoded to; DEL
-                  // and the C1 range stay, being UTF-8 continuation bytes here
-                  escape_remove_control(lien);
+                  // Percent-encode the control bytes as a browser does (#982);
+                  // a byte grows to three, and a link that no longer fits is
+                  // dropped rather than clipped to a URL nobody wrote.
+                  {
+                    char BIGSTK tempo[sizeof(lien)];
+
+                    if (escape_control_url(lien, tempo, sizeof(tempo)) <
+                        sizeof(tempo)) {
+                      strcpybuff(lien, tempo);
+                    } else {
+                      error = 1;
+                      hts_log_print(
+                          opt, LOG_DEBUG,
+                          "link rejected (control bytes do not fit) %s", lien);
+                    }
+                  }
 
                   // charset conversion for the URI filename (not the query
                   // string), unless the bytes already are valid UTF-8:

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -2152,8 +2152,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                     unescape_http_unharm(catbuff, sizeof(catbuff), lien, 1 | 2));     /* note: '%' is still escaped */
 
                   // Percent-encode the control bytes as a browser does (#982);
-                  // a byte grows to three, and a link that no longer fits is
-                  // dropped rather than clipped to a URL nobody wrote.
+                  // a byte grows to three, so a link that outgrows the buffer
+                  // is dropped rather than clipped to a URL nobody wrote.
                   {
                     char BIGSTK tempo[sizeof(lien)];
 

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -2099,13 +2099,14 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                   char *a = lien;
                   size_t llen;
 
-                  // strip ending spaces
+                  // strip both ends of every C0 control or space, as a browser
+                  // does; encoding one there would 404 a link that fetched fine
                   llen = (*a != '\0') ? strlen(a) : 0;
-                  while(llen > 0 && is_realspace(lien[llen - 1])) {
+                  while (llen > 0 && (unsigned char) lien[llen - 1] <= ' ') {
                     a[--llen] = '\0';
                   }
-                  //  skip leading ones
-                  while(is_realspace(*a))
+                  // '\0' is <= ' ' too, and an all-control link ends up empty
+                  while (*a != '\0' && (unsigned char) *a <= ' ')
                     a++;
                   // strip cr, lf, tab inside URL, as a browser does; every
                   // other control byte percent-encodes below
@@ -2217,10 +2218,22 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                       "could not URL-decode string '%s'", lien);
                   }
 
-                  // we need to encode query string non-ascii chars, 
+                  // we need to encode query string non-ascii chars,
                   // leaving the encoding as-is (unlike the file part)
                   // and copy back query
-                  append_escape_check_url(query, lien, sizeof(lien));
+                  {
+                    const size_t used = strlen(lien);
+
+                    // the append grows the query too, and clips silently on
+                    // overflow: drop, or we fetch a query nobody wrote (#982)
+                    if (append_escape_check_url(query, lien, sizeof(lien)) >=
+                        sizeof(lien) - used) {
+                      error = 1;
+                      hts_log_print(opt, LOG_DEBUG,
+                                    "link rejected (query does not fit) %s",
+                                    lien);
+                    }
+                  }
                 }
 
                 // convertir les éventuels \ en des / pour éviter des problèmes de reconnaissance!

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -521,6 +521,11 @@ HTSEXT_API size_t escape_uri_utf(const char *const src, char *const dest,
 HTSEXT_API size_t escape_check_url(const char *const src, char *const dest,
                                    const size_t size);
 
+/** Percent-escape the C0 control bytes of @p src (0x00-0x1f) and copy every
+    other byte verbatim, so bytes >= 0x7f keep the UTF-8 they carry. */
+HTSEXT_API size_t escape_control_url(const char *const src, char *const dest,
+                                     const size_t size);
+
 /** Append-variant of escape_spc_url(): escapes @p src after the existing
     NUL-terminated content of @p dest. Returns the bytes appended (excluding the
     NUL). */
@@ -572,7 +577,8 @@ HTSEXT_API size_t make_content_id(const char *const adr, const char *const fil,
 
 /** Low-level percent-escaper backing the escape_* family. @p mode selects the
     character class to escape: 0 check_url, 1 in_url, 2 spc_url, 3 uri,
-    30 uri_utf. @p max_size is the dest capacity including the NUL. */
+    4 control_url, 30 uri_utf. @p max_size is the dest capacity including the
+    NUL. */
 HTSEXT_API size_t x_escape_http(const char *const s, char *const dest,
                                 const size_t max_size, const int mode);
 

--- a/tests/158_local-link-control-bytes.test
+++ b/tests/158_local-link-control-bytes.test
@@ -17,11 +17,18 @@ testdir=$(cd "$(dirname "$0")" && pwd)
     exit 77
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_982.XXXXXX") || exit 1
+serverpid=
 cleanup() {
+    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
+
+fail() {
+    echo "FAIL: $1"
+    exit 1
+}
 
 doc="${tmpdir}/doc"
 mkdir -p "$doc"
@@ -31,12 +38,22 @@ ff=$(printf 'd\014ef.html')
 soh=$(printf 's\001oh.html')
 # CR, LF and TAB are stripped, not encoded, so this href must reach strip.html.
 strip=$(printf 's\011tr\015ip\012.html')
+# A control byte at either end is stripped like a space, so these two must reach
+# the plain names: encoding one there would 404 a link that fetches fine.
+trail=$(printf 'page.html\001')
+lead=$(printf '\037lead.html')
 # "abc.html" and "s" are what the old deletion and truncation would have hit.
-for f in clean.html abc.html def.html s d strip.html "$vt" "$ff" "$soh"; do
+for f in clean.html abc.html def.html s d strip.html page.html lead.html \
+    "$vt" "$ff" "$soh"; do
     printf 'body of %s\n' "$f" >"${doc}/${f}"
 done
-printf '<html><body>\n<a href="clean.html">c</a>\n<a href="%s">v</a>\n<a href="%s">f</a>\n<a href="%s">s</a>\n<a href="%s">t</a>\n<a href="big.html">b</a>\n</body></html>\n' \
-    "$vt" "$ff" "$soh" "$strip" >"${doc}/index.html"
+# Stripping both ends empties this one, which resolves to "./" and mirrors the
+# directory as index-2.html. The leading strip has to stop on the terminator the
+# trailing strip just wrote, or it reads on into the last link's leftovers and
+# fetches those.
+allctrl=$(printf '\013\013\013')
+printf '<html><body>\n<a href="clean.html">c</a>\n<a href="%s">v</a>\n<a href="%s">f</a>\n<a href="%s">s</a>\n<a href="%s">t</a>\n<a href="%s">e</a>\n<a href="%s">l</a>\n<a href="%s">a</a>\n<a href="big.html">b</a>\n</body></html>\n' \
+    "$vt" "$ff" "$soh" "$strip" "$trail" "$lead" "$allctrl" >"${doc}/index.html"
 
 # 700 control bytes encode to 2100, past the 2*HTS_URLMAXSIZE link buffer, so
 # the growth no longer fits and the link has to go rather than be clipped.
@@ -49,9 +66,12 @@ printf '<html><body>\n<a href="clean.html">c</a>\n<a href="%s">v</a>\n<a href="%
 # clean.html is the positive control: an ordinary link still crawls untouched,
 # and the three encoded fetches are what a browser would have requested.
 bash "$top_srcdir/tests/local-crawl.sh" --root "$(nativepath "$doc")" \
-    --errors 0 --files 7 \
+    --errors 0 --files 10 \
     --found 'clean.html' \
     --found 'strip.html' \
+    --found 'page.html' \
+    --found 'lead.html' \
+    --found 'index-2.html' \
     --found 'a%0bbc.html' \
     --found 'd%0cef.html' \
     --found 's%01oh.html' \
@@ -61,3 +81,39 @@ bash "$top_srcdir/tests/local-crawl.sh" --root "$(nativepath "$doc")" \
     --not-found 'd' \
     --log-found 'link rejected \(control bytes do not fit\)' \
     httrack 'BASEURL/index.html' --debug-log
+
+# The query is escaped separately and appended back, so its own growth has to
+# fit too. Absolute, because a clipped relative link dies on the URL-length gate
+# anyway while a clipped absolute one lands just under it and gets fetched. The
+# port is only known once the server is up, hence a second crawl of our own.
+python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
+qdoc="${tmpdir}/qdoc"
+mkdir -p "$qdoc"
+printf 'placeholder\n' >"${qdoc}/index.html"
+serverlog="${tmpdir}/server.log"
+: >"$serverlog"
+LOCAL_SERVER_VERBOSE=1 "$python" "$(nativepath "${testdir}/local-server.py")" \
+    --root "$(nativepath "$qdoc")" >"$serverlog" 2>&1 &
+serverpid=$!
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+
+# 300 control bytes of path escape to ~900, under the URL-length gate; 380 more
+# of query escape to ~1140, which together overrun the 2 KB link buffer.
+{
+    printf '<html><body><a href="http://127.0.0.1:%s/a' "$port"
+    awk 'BEGIN { while (i++ < 300) printf "%c", 11 }'
+    printf 'b.html?q='
+    awk 'BEGIN { while (i++ < 380) printf "%c", 11 }'
+    printf 'END">x</a></body></html>\n'
+} >"${qdoc}/index.html"
+
+out="${tmpdir}/qout"
+httrack "http://127.0.0.1:${port}/index.html" -O "$out" -q -r3 -%v0 ||
+    fail "the query crawl did not run"
+# A clipped link went out as a 2 KB request and 404ed, so assert the outcome
+# and not just the refusal: nothing oversized asked for, nothing errored.
+errors=$(grep -acE '^[0-9:]*[[:space:]]Error:' "${out}/hts-log.txt" || true)
+test "$errors" -eq 0 || fail "the oversized query was fetched ($errors errors)"
+longest=$(awk '{ if (length($0) > n) n = length($0) } END { print n + 0 }' \
+    "$serverlog")
+test "$longest" -lt 1024 || fail "a ${longest}-byte request line went out"

--- a/tests/158_local-link-control-bytes.test
+++ b/tests/158_local-link-control-bytes.test
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Issue #982: a VT or FF inside a quoted href used to survive the link scan and
+# then be deleted from the URL, so the crawler fetched a link the page never
+# wrote. Only the CR/LF/TAB the scan strips may stay; anything else below 32
+# must cost the link. Each hostile href has both a deletion target (vttail.html)
+# and a truncation target (vt) on the server, so a mirror holding either one
+# names which rewrite happened.
+set -eu
+
+: "${top_srcdir:=..}"
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_982.XXXXXX") || exit 1
+cleanup() {
+    rm -rf "$tmpdir"
+}
+trap 'set +e; cleanup' EXIT
+trap cleanup HUP INT QUIT PIPE TERM
+
+doc="${tmpdir}/doc"
+mkdir -p "$doc"
+for f in clean.html tabtail.html vttail.html fftail.html vt ff; do
+    printf '<html><body>%s</body></html>\n' "$f" >"${doc}/${f}"
+done
+printf '<html><body>\n<a href="clean.html">c</a>\n<a href="tab\011tail.html">t</a>\n<a href="vt\013tail.html">v</a>\n<a href="ff\014tail.html">f</a>\n</body></html>\n' \
+    >"${doc}/index.html"
+
+# clean.html and tabtail.html are the positive controls: the crawl still follows
+# an ordinary link, and TAB is still stripped rather than costing its link.
+bash "$top_srcdir/tests/local-crawl.sh" --root "$(nativepath "$doc")" \
+    --errors 0 --files 3 \
+    --found 'clean.html' \
+    --found 'tabtail.html' \
+    --not-found 'vttail.html' \
+    --not-found 'fftail.html' \
+    --not-found 'vt' \
+    --not-found 'ff' \
+    httrack 'BASEURL/index.html'

--- a/tests/158_local-link-control-bytes.test
+++ b/tests/158_local-link-control-bytes.test
@@ -29,12 +29,14 @@ mkdir -p "$doc"
 vt=$(printf 'a\013bc.html')
 ff=$(printf 'd\014ef.html')
 soh=$(printf 's\001oh.html')
+# CR, LF and TAB are stripped, not encoded, so this href must reach strip.html.
+strip=$(printf 's\011tr\015ip\012.html')
 # "abc.html" and "s" are what the old deletion and truncation would have hit.
-for f in clean.html abc.html def.html s d "$vt" "$ff" "$soh"; do
+for f in clean.html abc.html def.html s d strip.html "$vt" "$ff" "$soh"; do
     printf 'body of %s\n' "$f" >"${doc}/${f}"
 done
-printf '<html><body>\n<a href="clean.html">c</a>\n<a href="%s">v</a>\n<a href="%s">f</a>\n<a href="%s">s</a>\n<a href="big.html">b</a>\n</body></html>\n' \
-    "$vt" "$ff" "$soh" >"${doc}/index.html"
+printf '<html><body>\n<a href="clean.html">c</a>\n<a href="%s">v</a>\n<a href="%s">f</a>\n<a href="%s">s</a>\n<a href="%s">t</a>\n<a href="big.html">b</a>\n</body></html>\n' \
+    "$vt" "$ff" "$soh" "$strip" >"${doc}/index.html"
 
 # 700 control bytes encode to 2100, past the 2*HTS_URLMAXSIZE link buffer, so
 # the growth no longer fits and the link has to go rather than be clipped.
@@ -47,8 +49,9 @@ printf '<html><body>\n<a href="clean.html">c</a>\n<a href="%s">v</a>\n<a href="%
 # clean.html is the positive control: an ordinary link still crawls untouched,
 # and the three encoded fetches are what a browser would have requested.
 bash "$top_srcdir/tests/local-crawl.sh" --root "$(nativepath "$doc")" \
-    --errors 0 --files 6 \
+    --errors 0 --files 7 \
     --found 'clean.html' \
+    --found 'strip.html' \
     --found 'a%0bbc.html' \
     --found 'd%0cef.html' \
     --found 's%01oh.html' \

--- a/tests/158_local-link-control-bytes.test
+++ b/tests/158_local-link-control-bytes.test
@@ -1,16 +1,20 @@
 #!/bin/bash
-# Issue #982: a VT or FF inside a quoted href used to survive the link scan and
-# then be deleted from the URL, so the crawler fetched a link the page never
-# wrote. Only the CR/LF/TAB the scan strips may stay; anything else below 32
-# must cost the link. Each hostile href has both a deletion target (vttail.html)
-# and a truncation target (vt) on the server, so a mirror holding either one
-# names which rewrite happened.
+# Issue #982: a control byte inside a link used to end the URL where it stood,
+# or, for VT and FF, be deleted from it, so the crawler fetched a URL the page
+# never wrote. It must percent-encode instead, as a browser does. Each hostile
+# href also has its old truncation and deletion targets on the server, so a
+# mirror holding either one names which rewrite came back.
 set -eu
 
 : "${top_srcdir:=..}"
 testdir=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=tests/testlib.sh
 . "${testdir}/testlib.sh"
+
+# The fixtures carry the raw bytes the requests decode back to, which NTFS
+# refuses.
+! is_windows || ! echo "control bytes are illegal in a Windows filename" >&2 ||
+    exit 77
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_982.XXXXXX") || exit 1
 cleanup() {
@@ -21,20 +25,36 @@ trap cleanup HUP INT QUIT PIPE TERM
 
 doc="${tmpdir}/doc"
 mkdir -p "$doc"
-for f in clean.html tabtail.html vttail.html fftail.html vt ff; do
-    printf '<html><body>%s</body></html>\n' "$f" >"${doc}/${f}"
+# What the links must reach, named with the raw byte the server decodes back to.
+vt=$(printf 'a\013bc.html')
+ff=$(printf 'd\014ef.html')
+soh=$(printf 's\001oh.html')
+# "abc.html" and "s" are what the old deletion and truncation would have hit.
+for f in clean.html abc.html def.html s d "$vt" "$ff" "$soh"; do
+    printf 'body of %s\n' "$f" >"${doc}/${f}"
 done
-printf '<html><body>\n<a href="clean.html">c</a>\n<a href="tab\011tail.html">t</a>\n<a href="vt\013tail.html">v</a>\n<a href="ff\014tail.html">f</a>\n</body></html>\n' \
-    >"${doc}/index.html"
+printf '<html><body>\n<a href="clean.html">c</a>\n<a href="%s">v</a>\n<a href="%s">f</a>\n<a href="%s">s</a>\n<a href="big.html">b</a>\n</body></html>\n' \
+    "$vt" "$ff" "$soh" >"${doc}/index.html"
 
-# clean.html and tabtail.html are the positive controls: the crawl still follows
-# an ordinary link, and TAB is still stripped rather than costing its link.
+# 700 control bytes encode to 2100, past the 2*HTS_URLMAXSIZE link buffer, so
+# the growth no longer fits and the link has to go rather than be clipped.
+{
+    printf '<html><body><a href="big/'
+    awk 'BEGIN { while (i++ < 700) printf "%c", 11 }'
+    printf 'end.html">x</a></body></html>\n'
+} >"${doc}/big.html"
+
+# clean.html is the positive control: an ordinary link still crawls untouched,
+# and the three encoded fetches are what a browser would have requested.
 bash "$top_srcdir/tests/local-crawl.sh" --root "$(nativepath "$doc")" \
-    --errors 0 --files 3 \
+    --errors 0 --files 6 \
     --found 'clean.html' \
-    --found 'tabtail.html' \
-    --not-found 'vttail.html' \
-    --not-found 'fftail.html' \
-    --not-found 'vt' \
-    --not-found 'ff' \
-    httrack 'BASEURL/index.html'
+    --found 'a%0bbc.html' \
+    --found 'd%0cef.html' \
+    --found 's%01oh.html' \
+    --not-found 'abc.html' \
+    --not-found 'def.html' \
+    --not-found 's' \
+    --not-found 'd' \
+    --log-found 'link rejected \(control bytes do not fit\)' \
+    httrack 'BASEURL/index.html' --debug-log

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -215,9 +215,12 @@ echo "ran=$((pass + fail + skip)) pass=$pass fail=$fail skip=$skip" |
 # equivalent of;
 # string-oom drives a helper binary that only the automake build produces;
 # datadir-ospath copies the unwrapped binary the automake build leaves in .libs,
-# and needs the loader variable libtool picked, neither of which this job has.
+# and needs the loader variable libtool picked, neither of which this job has;
+# link-control-bytes names its fixtures with the raw control bytes the requests
+# decode back to, which NTFS refuses.
 expected_skips="01_engine-footer-overflow.test
 100_local-purge-longpath.test
+158_local-link-control-bytes.test
 114_local-update-304-leak.test
 120_local-proxytrack-webdav-default.test
 143_engine-backtrace-empty.test

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -243,3 +243,4 @@ TESTS += 200_pixmaps-fallback.test
 TESTS += 210_appstream-metainfo.test
 TESTS += 215_engine-datadir-ospath.test
 TESTS += 157_crash-argv0-path.test
+TESTS += 158_local-link-control-bytes.test


### PR DESCRIPTION
A control byte inside a link ended the URL where it stood, so `href="/s<SOH>oh.html"` fetched `/s`. VT and FF came out worse: `is_space()` counts them, so the scan carried them into the URL, and neither is among the CR, LF and TAB stripped further down, so `escape_remove_control()` deleted them and `href="/a<VT>bc"` resolved to `/abc`. Either way the crawler requested a URL the page never wrote.

An interior control byte now percent-encodes as a browser does, giving `/a%0bbc` and `/s%01oh.html`. CR, LF and TAB are still stripped, and both ends of the link now lose any C0 control or space before anything else runs, which is what the WHATWG URL parser does: a byte sitting at the end is noise, and encoding it would 404 a link that fetches fine.

A byte grows to three when encoded, so the encoding runs on the extracted link where the destination capacity is visible. Leaving the raw byte for the request path to escape instead was worse in practice: a link carrying 900 control bytes clipped silently at the 2 KB link buffer and fetched the truncated result. The query is escaped and appended separately, and its helper clips just as quietly, so both halves are checked and a link that no longer fits is dropped rather than clipped.

The escaper is a new mode on `x_escape_http()` with the matching `escape_control_url()` wrapper, one added exported symbol. No existing mode fits, since they all escape bytes >= 0x7f too, which would double-encode the UTF-8 this code takes care to preserve.

Test 158 asserts the encoded fetches land and the stripped ends still reach their plain names, keeps a clean link as the positive control, and puts the old truncation and deletion targets on the server so a mirror holding either one names the regression. It reds against master, against swapped hex nibbles, against either growth bound removed, and against a leading strip that runs past the terminator into the previous link's bytes. It skips on Windows, where a fixture cannot carry a raw control byte in its name.

Closes #982
