### PR TITLE
Release 3.49.16

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.71])
 
-AC_INIT([httrack], [3.49.15], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
+AC_INIT([httrack], [3.49.16], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
 AC_COPYRIGHT([
 HTTrack Website Copier, Offline Browser for Windows and Unix
 Copyright (C) 1998-2015 Xavier Roche and other contributors
@@ -29,12 +29,13 @@ AC_CONFIG_SRCDIR(src/httrack.c)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
+# 3:8:0: revision-only bump, no ABI change this release.
 # 3:7:0: htsblk gained a tail field and lien_back embeds it by value, so
 # lien_back.is_update and everything after it shift +8 (httrackp's own tail growth
 # moves nothing). Soname stays .so.3: HTTrackQt is the only consumer of the installed
 # headers, so a libhttrack4 rename isn't worth it.
 # (3:0:0 was the htsblk mime-buffer widening, the ABI break that moved .so.2 -> .so.3.)
-VERSION_INFO="3:7:0"
+VERSION_INFO="3:8:0"
 AM_MAINTAINER_MODE
 AC_USE_SYSTEM_EXTENSIONS
 

--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ AC_CONFIG_SRCDIR(src/httrack.c)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
-# 3:8:0: revision-only bump, no ABI change this release.
+# 3:8:0: revision-only bump, no ABI change.
 # 3:7:0: htsblk gained a tail field and lien_back embeds it by value, so
 # lien_back.is_update and everything after it shift +8 (httrackp's own tail growth
 # moves nothing). Soname stays .so.3: HTTrackQt is the only consumer of the installed

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+httrack (3.49.16-1) unstable; urgency=medium
+
+  * New upstream release: two ProxyTrack buffer overflows fixed, chunked
+    trailer handling, relocatable installs, crash-report backtraces on armhf,
+    a hicolor icon theme and translation fixes; full list in history.txt.
+
+ -- Xavier Roche <xavier@debian.org>  Tue, 04 Aug 2026 18:32:40 +0200
+
 httrack (3.49.15-1) unstable; urgency=medium
 
   * New upstream release: single-file mirrors with inlined assets, sitemap

--- a/history.txt
+++ b/history.txt
@@ -5,24 +5,24 @@ HTTrack Website Copier release history:
 This file lists all changes and fixes that have been made for HTTrack
 
 3.49-16
-+ New: macOS ships a signed and notarized HTTrack.app with its own icon, bundling the OpenSSL it needs so a downloaded copy launches (#890, #900, #950, #954)
++ New: macOS ships a signed and notarized HTTrack.app with its own icon, bundling the OpenSSL it needs so a downloaded copy launches (#890, #900, #901, #950)
 + New: the desktop icons install into the hicolor theme, scalable SVG included, so Icon=httrack resolves in a launcher (#932, #933)
 + Fixed: an unauthenticated PROPFIND overflowed the ProxyTrack DAV item buffer (#836)
 + Fixed: the cached-headers block was built with an unbounded sprintf (#841)
 + Fixed: a chunked response carrying trailers was rejected as "Invalid chunk" (#855)
-+ Fixed: the cache aborted the crawl on URLs it had itself accepted (#935, #936)
++ Fixed: an over-long URL aborted the whole mirror inside the cache instead of reading as a miss (#935, #936)
 + Fixed: ProxyTrack could not re-read the .arc it writes, and crashed on a record whose body it could not read (#834, #929, #931)
 + Fixed: ProxyTrack logged a hashtable stats line and every PROPFIND body to stderr (#911, #918)
 + Fixed: the frozen-slot spool was written inside the mirror namespace, so it landed in the mirrored tree (#859)
 + Fixed: a stack overflow killed httrack with no diagnostic, crash reports named no frame of the executable, and on armhf they had no frames at all (#866, #889, #892)
 + Fixed: an install moved away from its configured prefix could not find its data directory, its shared library, or the html symlink (#885, #887, #894, #906)
-+ Fixed: tooltips in the web GUI broke on any translation containing an apostrophe (#864)
-+ Fixed: nine strings were untranslated in 26 of the 30 language files, and six of those files disagreed with their own declared charset (#863, #963)
++ Fixed: tooltips in the web GUI broke on a translation containing an apostrophe; the escaping now also covers quotes, backslashes, markup and DBCS lead bytes (#864)
++ Fixed: nine strings of the Windows GUI's option dialogs were untranslated in 26 of the 30 language files, and six language files disagreed with their own declared charset (#863, #963)
 + Fixed: the AppStream metainfo still advertised WebHTTrack 3.49.8 (#884)
 + Fixed: the installed development headers did not compile standalone (#943)
 + Fixed: configure discarded a user-supplied BASH_SHELL, resolved bash to /bin/sh on macOS, and hung on one pointing at a FIFO (#891, #895, #908, #922)
 + Changed: the masthead wordmark and the rings background are SVG, so they stay sharp on a hi-DPI screen (#910, #916)
-+ Changed: multiple internal hardening, test and build improvements
++ Changed: multiple internal hardening, build, test and CI improvements
 
 3.49-15
 + New: --single-file rewrites each saved page with its assets inlined as data: URIs (#713)

--- a/history.txt
+++ b/history.txt
@@ -4,6 +4,26 @@ HTTrack Website Copier release history:
 
 This file lists all changes and fixes that have been made for HTTrack
 
+3.49-16
++ New: macOS ships a signed and notarized HTTrack.app with its own icon, bundling the OpenSSL it needs so a downloaded copy launches (#890, #900, #950, #954)
++ New: the desktop icons install into the hicolor theme, scalable SVG included, so Icon=httrack resolves in a launcher (#932, #933)
++ Fixed: an unauthenticated PROPFIND overflowed the ProxyTrack DAV item buffer (#836)
++ Fixed: the cached-headers block was built with an unbounded sprintf (#841)
++ Fixed: a chunked response carrying trailers was rejected as "Invalid chunk" (#855)
++ Fixed: the cache aborted the crawl on URLs it had itself accepted (#935, #936)
++ Fixed: ProxyTrack could not re-read the .arc it writes, and crashed on a record whose body it could not read (#834, #929, #931)
++ Fixed: ProxyTrack logged a hashtable stats line and every PROPFIND body to stderr (#911, #918)
++ Fixed: the frozen-slot spool was written inside the mirror namespace, so it landed in the mirrored tree (#859)
++ Fixed: a stack overflow killed httrack with no diagnostic, crash reports named no frame of the executable, and on armhf they had no frames at all (#866, #889, #892)
++ Fixed: an install moved away from its configured prefix could not find its data directory, its shared library, or the html symlink (#885, #887, #894, #906)
++ Fixed: tooltips in the web GUI broke on any translation containing an apostrophe (#864)
++ Fixed: nine strings were untranslated in 26 of the 30 language files, and six of those files disagreed with their own declared charset (#863, #963)
++ Fixed: the AppStream metainfo still advertised WebHTTrack 3.49.8 (#884)
++ Fixed: the installed development headers did not compile standalone (#943)
++ Fixed: configure discarded a user-supplied BASH_SHELL, resolved bash to /bin/sh on macOS, and hung on one pointing at a FIFO (#891, #895, #908, #922)
++ Changed: the masthead wordmark and the rings background are SVG, so they stay sharp on a hi-DPI screen (#910, #916)
++ Changed: multiple internal hardening, test and build improvements
+
 3.49-15
 + New: --single-file rewrites each saved page with its assets inlined as data: URIs (#713)
 + New: --changes reports what a crawl added, updated or removed against the previous mirror (#714)

--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -51,6 +51,17 @@
   <content_rating type="oars-1.1"/>
   <!-- Newest first; tests/01_engine-version-macros.test enforces it. -->
   <releases>
+    <release version="3.49.16" date="2026-08-04">
+      <description>
+        <ul>
+          <li>The application has its own icon in the menu and the task switcher, at any screen size</li>
+          <li>Option tooltips work again in languages whose text contains an apostrophe</li>
+          <li>Nine interface strings that stayed in English are now translated in 26 languages</li>
+          <li>Mac users can download and launch HTTrack as an ordinary application</li>
+          <li>A page served in chunks with trailing headers is no longer rejected as invalid</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.49.15" date="2026-07-30">
       <description>
         <ul>

--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -54,11 +54,11 @@
     <release version="3.49.16" date="2026-08-04">
       <description>
         <ul>
-          <li>The application has its own icon in the menu and the task switcher, at any screen size</li>
-          <li>Option tooltips work again in languages whose text contains an apostrophe</li>
-          <li>Nine interface strings that stayed in English are now translated in 26 languages</li>
-          <li>Mac users can download and launch HTTrack as an ordinary application</li>
-          <li>A page served in chunks with trailing headers is no longer rejected as invalid</li>
+          <li>The application has its own icon in the desktop menu, at any screen size</li>
+          <li>Option tooltips no longer break in languages whose text contains quotes or other special characters</li>
+          <li>Croatian, Macedonian, Polish, Slovak, Slovenian and Swedish text no longer shows as mangled characters</li>
+          <li>Pages that failed with an "Invalid chunk" error now download correctly</li>
+          <li>A very long web address no longer aborts the whole mirror</li>
         </ul>
       </description>
     </release>

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -43,8 +43,8 @@ Please visit our Website: http://www.httrack.com
    configure.ac, decoupled from these). VERSION is the display form, VERSIONID
    the dotted numeric form, AFF_VERSION the short form shown in footers,
    LIB_VERSION the data/cache format generation. */
-#define HTTRACK_VERSION "3.49-15"
-#define HTTRACK_VERSIONID "3.49.15"
+#define HTTRACK_VERSION "3.49-16"
+#define HTTRACK_VERSIONID "3.49.16"
 #define HTTRACK_AFF_VERSION "3.x"
 #define HTTRACK_LIB_VERSION "2.0"
 

--- a/src/version.rc
+++ b/src/version.rc
@@ -17,8 +17,8 @@
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-  FILEVERSION 3, 49, 15, 0
-  PRODUCTVERSION 3, 49, 15, 0
+  FILEVERSION 3, 49, 16, 0
+  PRODUCTVERSION 3, 49, 16, 0
   FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
 #ifdef _DEBUG
   FILEFLAGS VS_FF_DEBUG
@@ -35,12 +35,12 @@ BEGIN
     BEGIN
       VALUE "CompanyName", "Xavier Roche"
       VALUE "FileDescription", VER_FILE_DESCRIPTION
-      VALUE "FileVersion", "3.49.15"
+      VALUE "FileVersion", "3.49.16"
       VALUE "InternalName", VER_ORIGINAL_FILENAME
       VALUE "LegalCopyright", "Copyright (C) 1998-2026 Xavier Roche and other contributors. GNU GPL v3 or later."
       VALUE "OriginalFilename", VER_ORIGINAL_FILENAME
       VALUE "ProductName", "HTTrack Website Copier"
-      VALUE "ProductVersion", "3.49-15"
+      VALUE "ProductVersion", "3.49-16"
     END
   END
   BLOCK "VarFileInfo"


### PR DESCRIPTION
Version bump to 3.49.16 with the release notes for the 56 changes since 3.49.15.

VERSION_INFO moves 3:7:0 to 3:8:0, a revision-only bump: no installed struct layout or exported signature changed this cycle, so the soname stays libhttrack.so.3 and the Debian package needs no rename. The version now lives in a fourth spot, the AppStream metainfo, which test 01_engine-version-macros.test checks against htsglobal.h.

Standards-Version 4.7.4 still matches the current debian-policy, so debian/control is untouched. Built out of tree with the full suite green (232 pass, 9 skip).