### PR TITLE
Release notes understate the #841 cache-header overflow

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,10 @@
 httrack (3.49.16-1) unstable; urgency=medium
 
-  * New upstream release: two ProxyTrack buffer overflows fixed, chunked
-    trailer handling, relocatable installs, crash-report backtraces on armhf,
-    a hicolor icon theme and translation fixes; full list in history.txt.
+  * New upstream release: a stack overflow in the cache header writer, which a
+    server's response headers could trigger in httrack and libhttrack3 as well
+    as in proxytrack, and a ProxyTrack DAV buffer overflow; chunked trailer
+    handling, relocatable installs, crash-report backtraces on armhf, a hicolor
+    icon theme and translation fixes; full list in history.txt.
 
  -- Xavier Roche <xavier@debian.org>  Tue, 04 Aug 2026 18:32:40 +0200
 

--- a/history.txt
+++ b/history.txt
@@ -8,7 +8,7 @@ This file lists all changes and fixes that have been made for HTTrack
 + New: macOS ships a signed and notarized HTTrack.app with its own icon, bundling the OpenSSL it needs so a downloaded copy launches (#890, #900, #901, #950)
 + New: the desktop icons install into the hicolor theme, scalable SVG included, so Icon=httrack resolves in a launcher (#932, #933)
 + Fixed: an unauthenticated PROPFIND overflowed the ProxyTrack DAV item buffer (#836)
-+ Fixed: the cached-headers block was built with an unbounded sprintf (#841)
++ Fixed: response headers from the server overflowed the stack buffer holding the cache header block, in both httrack and ProxyTrack (#841)
 + Fixed: a chunked response carrying trailers was rejected as "Invalid chunk" (#855)
 + Fixed: an over-long URL aborted the whole mirror inside the cache instead of reading as a miss (#935, #936)
 + Fixed: ProxyTrack could not re-read the .arc it writes, and crashed on a record whose body it could not read (#834, #929, #931)


### PR DESCRIPTION
The 3.49.16 notes call the #841 fix an unbounded sprintf in "the cached-headers block", and the Debian entry counts it as one of "two ProxyTrack buffer overflows". Both undersell it: PR #934 bounded that block in the engine's own `cache_add` as well as in ProxyTrack's writer, the values come off the wire (ETag, Location, Content-Disposition, the URL), and in `cache_add` the declared field caps sum past the 8192-byte stack buffer. Read as written, either file says only `proxytrack` was exposed, so a Debian triager would skip an overrun that any ordinary mirror of a hostile server can reach.

Notes only, no code change. The 3.49.16-1 entry has not been uploaded, so it is corrected in place rather than superseded.