### PR TITLE
A non-PIE build's crash report still names no frame of the executable

### DIFF
--- a/src/htsbacktrace.c
+++ b/src/htsbacktrace.c
@@ -65,6 +65,7 @@ Please visit our Website: http://www.httrack.com
 #include <signal.h>
 #include <spawn.h>
 #include <time.h>
+#include <sys/stat.h>
 #include <sys/wait.h>
 #define USES_BACKTRACE
 #endif
@@ -93,8 +94,8 @@ static posix_spawn_file_actions_t *spawn_redirect = NULL;
    hts_self_path() (htscoremain.c) resolves the same path, out of reach here:
    it is library-side and hidden by -fvisibility=hidden (#997). */
 static char main_path[BT_PATH_SIZE];
-/* Where the main program is mapped, and the bias to take off an address to get
-   the one addr2line wants: 0 for an ET_EXEC, which is mapped where it links. */
+/* Main program's mapped range, and the bias to subtract for addr2line (0 on an
+   ET_EXEC). */
 static uintptr_t main_lo, main_hi, main_bias;
 
 static int record_main_range(struct dl_phdr_info *info, size_t size,
@@ -105,6 +106,7 @@ static int record_main_range(struct dl_phdr_info *info, size_t size,
   (void) data;
   main_bias = (uintptr_t) info->dlpi_addr;
   main_lo = (uintptr_t) -1; /* an empty range matches no frame */
+  main_hi = 0;
   for (i = 0; i < info->dlpi_phnum; i++) {
     const ElfW(Phdr) *const phdr = &info->dlpi_phdr[i];
     const uintptr_t start = main_bias + (uintptr_t) phdr->p_vaddr;
@@ -119,34 +121,43 @@ static int record_main_range(struct dl_phdr_info *info, size_t size,
   return 1; /* dl_iterate_phdr starts at the main program */
 }
 
-/* By range, not by load base: dladdr() reports the mapping start and
-   dl_iterate_phdr() the bias, which differ on an ET_EXEC (#995). */
+/* Address range, not load base: the two disagree on an ET_EXEC (#995). */
 static hts_boolean is_main_frame(const void *addr) {
   const uintptr_t value = (uintptr_t) addr;
 
   return value >= main_lo && value < main_hi ? HTS_TRUE : HTS_FALSE;
 }
 
-/* Trailing component of path, the whole of it when it holds no '/'. */
-static const char *base_name(const char *path) {
-  const char *const slash = strrchr(path, '/');
+/* Non-zero once a named link-map entry is the file *data stats to: the main
+   program's entry is the unnamed one, so a hit means a shared object. */
+static int names_a_shared_object(struct dl_phdr_info *info, size_t size,
+                                 void *data) {
+  const struct stat *const self = (const struct stat *) data;
+  struct stat st;
 
-  return slash != NULL ? slash + 1 : path;
+  (void) size;
+  if (info->dlpi_name == NULL || info->dlpi_name[0] == '\0')
+    return 0;
+  if (stat(info->dlpi_name, &st) != 0)
+    return 0; /* vDSO and the like have no file */
+  return st.st_dev == self->st_dev && st.st_ino == self->st_ino;
 }
 
 static void find_main_object(void) {
   const ssize_t len = readlink("/proc/self/exe", main_path, sizeof(main_path));
-  Dl_info info;
+  struct stat self;
 
   dl_iterate_phdr(record_main_range, NULL);
   /* A full buffer is a clipped path, which readlink() cannot report: its prefix
      names another file, and the symbolizer would happily open that one. */
   if (len > 0 && (size_t) len < sizeof(main_path)) {
     main_path[len] = '\0';
-    /* Started through the loader, /proc/self/exe is ld.so while dladdr() still
-       names the program: take dladdr()'s word for it (#996). */
-    if (dladdr((const void *) main_lo, &info) != 0 && info.dli_fname != NULL &&
-        strcmp(base_name(main_path), base_name(info.dli_fname)) == 0)
+    /* Started through the loader, /proc/self/exe is ld.so, which the link map
+       carries under its own name (#996). Identity, not dladdr()'s name: that is
+       argv[0] verbatim, so a symlinked or renamed program would lose its
+       module. */
+    if (stat(main_path, &self) == 0 &&
+        dl_iterate_phdr(names_a_shared_object, &self) == 0)
       return;
   }
   main_path[0] = '\0'; /* unresolved: keep whatever dladdr() reported */

--- a/src/htsbacktrace.c
+++ b/src/htsbacktrace.c
@@ -89,26 +89,64 @@ static posix_spawn_file_actions_t spawn_actions;
 static posix_spawn_file_actions_t *spawn_redirect = NULL;
 
 /* dladdr() names the main program after argv[0], which the symbolizer cannot
-   open when the binary came off PATH; /proc/self/exe always names the file. */
+   open when the binary came off PATH; /proc/self/exe always names the file.
+   hts_self_path() (htscoremain.c) resolves the same path, out of reach here:
+   it is library-side and hidden by -fvisibility=hidden (#997). */
 static char main_path[BT_PATH_SIZE];
-static const void *main_base;
+/* Where the main program is mapped, and the bias to take off an address to get
+   the one addr2line wants: 0 for an ET_EXEC, which is mapped where it links. */
+static uintptr_t main_lo, main_hi, main_bias;
 
-static int record_main_base(struct dl_phdr_info *info, size_t size,
-                            void *data) {
+static int record_main_range(struct dl_phdr_info *info, size_t size,
+                             void *data) {
+  size_t i;
+
   (void) size;
   (void) data;
-  main_base = (const void *) info->dlpi_addr;
+  main_bias = (uintptr_t) info->dlpi_addr;
+  main_lo = (uintptr_t) -1; /* an empty range matches no frame */
+  for (i = 0; i < info->dlpi_phnum; i++) {
+    const ElfW(Phdr) *const phdr = &info->dlpi_phdr[i];
+    const uintptr_t start = main_bias + (uintptr_t) phdr->p_vaddr;
+
+    if (phdr->p_type != PT_LOAD)
+      continue;
+    if (start < main_lo)
+      main_lo = start;
+    if (start + phdr->p_memsz > main_hi)
+      main_hi = start + phdr->p_memsz;
+  }
   return 1; /* dl_iterate_phdr starts at the main program */
+}
+
+/* By range, not by load base: dladdr() reports the mapping start and
+   dl_iterate_phdr() the bias, which differ on an ET_EXEC (#995). */
+static hts_boolean is_main_frame(const void *addr) {
+  const uintptr_t value = (uintptr_t) addr;
+
+  return value >= main_lo && value < main_hi ? HTS_TRUE : HTS_FALSE;
+}
+
+/* Trailing component of path, the whole of it when it holds no '/'. */
+static const char *base_name(const char *path) {
+  const char *const slash = strrchr(path, '/');
+
+  return slash != NULL ? slash + 1 : path;
 }
 
 static void find_main_object(void) {
   const ssize_t len = readlink("/proc/self/exe", main_path, sizeof(main_path));
+  Dl_info info;
 
+  dl_iterate_phdr(record_main_range, NULL);
   /* A full buffer is a clipped path, which readlink() cannot report: its prefix
      names another file, and the symbolizer would happily open that one. */
   if (len > 0 && (size_t) len < sizeof(main_path)) {
     main_path[len] = '\0';
-    if (dl_iterate_phdr(record_main_base, NULL) == 1)
+    /* Started through the loader, /proc/self/exe is ld.so while dladdr() still
+       names the program: take dladdr()'s word for it (#996). */
+    if (dladdr((const void *) main_lo, &info) != 0 && info.dli_fname != NULL &&
+        strcmp(base_name(main_path), base_name(info.dli_fname)) == 0)
       return;
   }
   main_path[0] = '\0'; /* unresolved: keep whatever dladdr() reported */
@@ -186,6 +224,7 @@ static void symbolize_backtrace(void *const *stack, int size) {
   const void *base[BT_MAX_FRAMES];
   const char *name[BT_MAX_FRAMES];
   hts_boolean grouped[BT_MAX_FRAMES];
+  hts_boolean is_main[BT_MAX_FRAMES];
   char module[BT_PATH_SIZE];
   char *argv[4 + BT_MAX_FRAMES + 1];
   int budget = BT_WAIT_TICKS;
@@ -205,8 +244,10 @@ static void symbolize_backtrace(void *const *stack, int size) {
       continue;
     base[i] = info.dli_fbase;
     name[i] = info.dli_fname;
-    print_hex(hex[i], (uintptr_t) ((const char *) stack[i] -
-                                   (const char *) info.dli_fbase));
+    is_main[i] = is_main_frame(stack[i]);
+    print_hex(hex[i],
+              (uintptr_t) stack[i] -
+                  (is_main[i] ? main_bias : (uintptr_t) info.dli_fbase));
     grouped[i] = HTS_FALSE;
   }
 
@@ -220,8 +261,7 @@ static void symbolize_backtrace(void *const *stack, int size) {
       ;
     if (first >= size)
       break;
-    path = main_path[0] != '\0' && base[first] == main_base ? main_path
-                                                            : name[first];
+    path = main_path[0] != '\0' && is_main[first] ? main_path : name[first];
     argv[argc++] = prog;
     argv[argc++] = opts;
     argv[argc++] = dashe;

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -87,6 +87,8 @@ static int datadir_has_templates(const char *dir) {
                         "templates/index-header.html"));
 }
 
+/* htsbacktrace.c copies the Linux branch: it is program-side and cannot reach
+   this hidden symbol, so a fix here belongs there too (#997). */
 const char *hts_self_path(char *dst, size_t dstsize) {
 #if defined(_WIN32)
   const DWORD n = GetModuleFileNameA(NULL, dst, (DWORD) dstsize);

--- a/tests/157_crash-argv0-path.test
+++ b/tests/157_crash-argv0-path.test
@@ -63,7 +63,8 @@ fi
 
 # Control: without a bare argv[0] in the raw trace there is nothing to repair,
 # and the assertions below would pass on a report that never needed the fix.
-grep -qE '^httrack\(\+0x[0-9a-f]+\)' "${out}" ||
+# glibc drops the "+0x" offset when the load bias is zero, as in a non-PIE build.
+grep -qE '^httrack\((\+0x[0-9a-f]+)?\)' "${out}" ||
     skip "the main program is not reported as a bare argv[0] here"
 
 headers=$(grep -E '^/.*/httrack:$' "${out}" || true)

--- a/tests/218_crash-nopie-frames.test
+++ b/tests/218_crash-nopie-frames.test
@@ -1,8 +1,7 @@
 #!/bin/bash
-# An ET_EXEC is mapped where it was linked, so dl_iterate_phdr() reports a zero
-# bias where dladdr() reports 0x400000. The crash report must still name the
-# executable and resolve its frames to source lines (#995), and must not take
-# /proc/self/exe for the program when that is the loader (#996).
+# A non-PIE crash report must name the executable and resolve its frames to
+# source lines (#995). /proc/self/exe must be rejected when it is the loader,
+# and kept when argv[0] merely differs from the file's name (#996).
 
 set -euo pipefail
 
@@ -78,11 +77,26 @@ if [ -n "${interp}" ] && [ -x "${interp}" ]; then
     rc=0
     LC_ALL=C run_with_timeout 60 "${interp}" "${work}/probe-pie" >"${out}" 2>&1 || rc=$?
     test "${rc}" -ne 124 || fail "the loader-launched probe did not finish in time"
-    grep -qE "^${work}/probe-pie:\$" "${out}" ||
+    grep -qxF "${work}/probe-pie:" "${out}" ||
         fail "launched through ${interp}, the report heads no block with the program"
     grep -qE 'probe_frame at .*nopieprobe\.c:[0-9]+' "${out}" ||
         fail "launched through ${interp}, the report resolves no source line"
 fi
+
+# Same probe under another name: dladdr() echoes argv[0], so anything matching
+# the two names drops the module here instead of keeping the real file.
+altdir=${work}/alt
+mkdir "${altdir}"
+ln -s "${work}/probe-pie" "${altdir}/probe-renamed"
+out=${work}/renamed.log
+rc=0
+LC_ALL=C PATH="${altdir}:${PATH}" \
+    run_with_timeout 60 probe-renamed >"${out}" 2>&1 || rc=$?
+test "${rc}" -ne 124 || fail "the symlinked probe did not finish in time"
+grep -qxF "${work}/probe-pie:" "${out}" ||
+    fail "launched as probe-renamed, the report heads no block with the program"
+grep -qE 'probe_frame at .*nopieprobe\.c:[0-9]+' "${out}" ||
+    fail "launched as probe-renamed, the report resolves no source line"
 
 if ! build "${work}/probe-nopie" -no-pie -fno-pie; then
     head -5 "${work}/cc.log" >&2

--- a/tests/218_crash-nopie-frames.test
+++ b/tests/218_crash-nopie-frames.test
@@ -1,0 +1,128 @@
+#!/bin/bash
+# An ET_EXEC is mapped where it was linked, so dl_iterate_phdr() reports a zero
+# bias where dladdr() reports 0x400000. The crash report must still name the
+# executable and resolve its frames to source lines (#995), and must not take
+# /proc/self/exe for the program when that is the loader (#996).
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+srcdir=${abs_top_srcdir:?not run under make check}
+builddir=${abs_top_builddir:?not run under make check}
+
+out=
+skip() {
+    echo "$*; skipping" >&2
+    exit 77
+}
+fail() {
+    echo "FAIL: $*" >&2
+    test -z "${out}" || sed 's/^/  | /' <"${out}" >&2
+    exit 1
+}
+
+test "$(uname -s)" = "Linux" || skip "the ELF load bias is a Linux matter"
+if ! command -v addr2line >/dev/null && ! command -v llvm-symbolizer >/dev/null; then
+    skip "no symbolizer installed"
+fi
+# CC carries flags on some legs ("gcc -m32", "ccache gcc"), so split it.
+read -r -a cc_argv <<<"${CC:-cc}"
+command -v "${cc_argv[0]}" >/dev/null || skip "no C compiler (${cc_argv[0]})"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/httrack_nopie.XXXXXX") || exit 1
+trap 'set +e; rm -rf "${work}"' EXIT
+trap 'rm -rf "${work}"' HUP INT QUIT PIPE TERM
+
+# The crash printer is linked into a probe of our own: every target the build
+# tree offers is a PIE, which is the case that already worked.
+cflags=(-g -O0 -I"${builddir}" -I"${builddir}/src" -I"${srcdir}/src")
+if [ -n "${TEST_CPPFLAGS:-}" ]; then
+    read -r -a extra_argv <<<"${TEST_CPPFLAGS}"
+    cflags+=("${extra_argv[@]}")
+fi
+sources=("${srcdir}/tests/nopieprobe.c" "${srcdir}/src/htsbacktrace.c")
+build() { # $1 output binary, rest extra flags
+    local bin=$1
+    shift
+    # shellcheck disable=SC2086 # DL_LIBS is a flag list; splitting is the point
+    "${cc_argv[@]}" "${cflags[@]}" "$@" -o "${bin}" "${sources[@]}" ${DL_LIBS:-} \
+        >"${work}/cc.log" 2>&1
+}
+
+# Control, run by absolute path so neither the load base nor argv[0] is in play:
+# it says whether this box symbolizes anything at all.
+build "${work}/probe-pie" || {
+    head -20 "${work}/cc.log" >&2
+    fail "the crash printer does not build standalone"
+}
+out=${work}/pie.log
+LC_ALL=C "${work}/probe-pie" >"${out}" 2>&1 || fail "the control probe exited non-zero"
+if grep -q 'No stack trace available' "${out}"; then
+    skip "this build produced no backtrace"
+fi
+grep -qE 'probe_frame at .*nopieprobe\.c:[0-9]+' "${out}" ||
+    skip "nothing is symbolized here, even from an absolute path"
+
+# Same probe under the loader: there /proc/self/exe is ld.so, and only dladdr()
+# still names the program.
+interp=
+if command -v readelf >/dev/null; then
+    interp=$(LC_ALL=C readelf -l "${work}/probe-pie" |
+        sed -n 's/.*Requesting program interpreter: \([^]]*\)].*/\1/p')
+fi
+if [ -n "${interp}" ] && [ -x "${interp}" ]; then
+    out=${work}/loader.log
+    rc=0
+    LC_ALL=C run_with_timeout 60 "${interp}" "${work}/probe-pie" >"${out}" 2>&1 || rc=$?
+    test "${rc}" -ne 124 || fail "the loader-launched probe did not finish in time"
+    grep -qE "^${work}/probe-pie:\$" "${out}" ||
+        fail "launched through ${interp}, the report heads no block with the program"
+    grep -qE 'probe_frame at .*nopieprobe\.c:[0-9]+' "${out}" ||
+        fail "launched through ${interp}, the report resolves no source line"
+fi
+
+if ! build "${work}/probe-nopie" -no-pie -fno-pie; then
+    head -5 "${work}/cc.log" >&2
+    skip "this toolchain takes no -no-pie"
+fi
+bindir=${work}/bin
+mkdir "${bindir}"
+mv "${work}/probe-nopie" "${bindir}/probe-nopie"
+if command -v readelf >/dev/null; then
+    LC_ALL=C readelf -h "${bindir}/probe-nopie" >"${work}/elf.txt"
+    grep -qE '^[[:space:]]*Type:[[:space:]]+EXEC' "${work}/elf.txt" ||
+        skip "the toolchain ignored -no-pie and linked a PIE anyway"
+fi
+
+# No probe-nopie here, so a report that kept argv[0] has nothing to open.
+cd "${work}"
+out=${work}/nopie.log
+rc=0
+# LC_ALL=C: addr2line translates its " at " separator, which the match below pins.
+LC_ALL=C PATH="${bindir}:${PATH}" \
+    run_with_timeout 60 probe-nopie >"${out}" 2>&1 || rc=$?
+test "${rc}" -ne 124 || fail "the probe did not finish within the deadline"
+if ! command -v readelf >/dev/null; then
+    # glibc drops the "+0x" offset when the load bias is zero.
+    grep -qE '^probe-nopie\(\) \[0x' "${out}" ||
+        skip "no zero-bias frame in the report; this is no ET_EXEC"
+fi
+
+headers=$(grep -E '^/.*/probe-nopie:$' "${out}" || true)
+test -n "${headers}" || fail "the report has no symbolized block for the executable"
+# Every frame of a module is claimed in one pass, so a second block for the
+# executable means library frames were misattributed to it.
+test "$(wc -l <<<"${headers}")" -eq 1 || fail "several executable blocks: ${headers}"
+exe=${headers%:}
+# Device+inode, so a symlinked TMPDIR does not read as a different binary.
+test "${exe}" -ef "${bindir}/probe-nopie" || fail "the report names ${exe}"
+block=$(awk -v h="${headers}" '$0 == h { on = 1; next } /^\// { on = 0 } on' "${out}")
+# " at " pins the symbol column: both addr2line -Cfipa and llvm-symbolizer -p
+# emit it. A wrong offset resolves to "?? ??:0" instead.
+grep -qE '(^|[^[:alnum:]_])probe_frame at .*nopieprobe\.c:[0-9]+' <<<"${block}" ||
+    fail "the executable's block resolves no source line: ${block}"
+
+echo "the non-PIE report named ${exe} and resolved its own frames"

--- a/tests/80_engine-crash-symbolize.test
+++ b/tests/80_engine-crash-symbolize.test
@@ -66,9 +66,11 @@ command -v addr2line >/dev/null || {
 }
 
 # Control: resolve the same frames ourselves, so a stripped build cannot turn
-# the assertion below into a vacuous pass.
+# the assertion below into a vacuous pass. Second form: glibc drops the "+0x"
+# when the load bias is zero, and the bracketed address is then the file one.
 oracle="${tmpdir}/oracle"
-sed -n 's/^\([^(]*\)(+\(0x[0-9a-f]*\)).*$/\1 \2/p' "$out" |
+sed -n -e 's/^\([^(]*\)(+\(0x[0-9a-f]*\)).*$/\1 \2/p' \
+    -e 's/^\([^(]*\)() \[\(0x[0-9a-f]*\)\].*$/\1 \2/p' "$out" |
     while read -r mod off; do
         # The main program is reported as argv[0], a bare name off PATH (#889).
         test -f "$mod" || mod=$(command -v "$mod" 2>/dev/null) || continue

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,7 +4,7 @@ include $(srcdir)/tests-list.mk
 # Committed binary fixture read by 01_zlib-cache-golden.test. List it
 # explicitly: automake does not expand wildcards in EXTRA_DIST, so a glob would
 # silently drop it from the dist tarball and break "make distcheck".
-EXTRA_DIST = $(TESTS) renamefail.c threadattrfail.c nobacktrace.c altstackprobe.c crawl-test.sh run-all-tests.sh check-network.sh \
+EXTRA_DIST = $(TESTS) renamefail.c threadattrfail.c nobacktrace.c altstackprobe.c nopieprobe.c crawl-test.sh run-all-tests.sh check-network.sh \
 	proxy-https-server.py socks5-server.py proxy-connect-server.py \
 	proxytestlib.py tls-stall-server.py warc-validate.py wacz-validate.py \
 	header-injection-server.py header-injection-check.py \
@@ -41,6 +41,8 @@ TESTS_ENVIRONMENT += MAKE="$(MAKE)"
 # openssl@3 is keg-only, so htsbasenet.h finds <openssl/ssl.h> only through it.
 TESTS_ENVIRONMENT += CC="$(CC)"
 TESTS_ENVIRONMENT += TEST_CPPFLAGS="$(CPPFLAGS)"
+# 218_crash-nopie-frames.test links the crash printer, which calls dladdr().
+TESTS_ENVIRONMENT += DL_LIBS="$(DL_LIBS)"
 # 207_install-headers-symbols.test links a consumer probe against it; absent on a
 # static-only build and named .dylib on macOS, where that ELF-only test skips.
 TESTS_ENVIRONMENT += HTTRACK_SHLIB=$(abs_top_builddir)/src/$(LT_CV_OBJDIR)/libhttrack.so

--- a/tests/nopieprobe.c
+++ b/tests/nopieprobe.c
@@ -1,0 +1,12 @@
+/* Crash-report driver for 218_crash-nopie-frames.test: links htsbacktrace.c
+   into a non-PIE program of its own, which the build tree cannot produce. */
+
+#include "htsbacktrace.h"
+
+static void probe_frame(void) { hts_print_backtrace(); }
+
+int main(void) {
+  hts_backtrace_init();
+  probe_frame();
+  return 0;
+}

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -250,3 +250,4 @@ TESTS += 215_engine-datadir-ospath.test
 TESTS += 157_crash-argv0-path.test
 TESTS += 159_local-header-injection.test
 TESTS += 158_local-link-control-bytes.test
+TESTS += 218_crash-nopie-frames.test


### PR DESCRIPTION
#984 matched crash frames against the main program by comparing `dladdr()`'s `dli_fbase` with `dl_iterate_phdr()`'s `dlpi_addr`. glibc fills those from the mapping start and the relocation bias, and the two agree only for a PIE: on an `ET_EXEC` the bias is 0 where the base is 0x400000, so the override never fires and the offsets handed to addr2line are 0x400000 too low. This matches the program by load range instead, and subtracts the bias rather than the base. Only a build without `-pie` is affected, since configure adds `-fpie`/`-pie` whenever the toolchain takes them.

The same function had two smaller problems. Launched through the loader explicitly (`/lib64/ld-linux-x86-64.so.2 ./httrack`), `/proc/self/exe` names ld.so, and every executable frame was symbolized against the loader; it is now rejected when it stats to a named entry of the link map, since the loader has one and the main program's entry is the unnamed one. That is an identity test rather than a name comparison because `dladdr()` hands back `argv[0]` verbatim, so anything keyed on that name loses the executable's whole module under `update-alternatives`, a Nix or snap wrapper, or any launcher that rewrites `argv[0]`. And `hts_self_path()` resolves the same path in htscoremain.c, out of reach from the program side, so each copy now points at the other. The new `218_crash-nopie-frames.test` links the crash printer into a probe of its own and covers the loader, renamed-symlink and non-PIE launches, skipping where the toolchain will not produce an `ET_EXEC`. Tests 157 and 80 skipped rather than covered any of this, because glibc prints `prog()` with no `+0x` offset when the bias is zero, and now recognize that form too.

Closes #995
Closes #996
Closes #997