### PR TITLE
3.49.16-1 fails to build on four Debian architectures

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -34,9 +34,8 @@ configure-stamp:
 
 	dh_autoreconf
 	# note: dpkg-buildflags to be removed when compat=9
-	# No online tests: Policy 4.9 forbids network access during a build, and "auto"
-	# made it a lottery -- hurd-i386 FTBFS'd on a crawl whose DNS went away after
-	# the probe had said yes.
+	# Policy 4.9 forbids network access during a build, and "auto" made it a lottery:
+	# hurd-i386 FTBFS'd on a crawl whose DNS went away after the probe had said yes.
 	dh_auto_configure -- --disable-online-unit-tests $(shell dpkg-buildflags --export=configure)
 
 	touch configure-stamp

--- a/debian/rules
+++ b/debian/rules
@@ -34,7 +34,10 @@ configure-stamp:
 
 	dh_autoreconf
 	# note: dpkg-buildflags to be removed when compat=9
-	dh_auto_configure -- --enable-online-unit-tests=auto $(shell dpkg-buildflags --export=configure)
+	# No online tests: Policy 4.9 forbids network access during a build, and "auto"
+	# made it a lottery -- hurd-i386 FTBFS'd on a crawl whose DNS went away after
+	# the probe had said yes.
+	dh_auto_configure -- --disable-online-unit-tests $(shell dpkg-buildflags --export=configure)
 
 	touch configure-stamp
 

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -102,6 +102,43 @@ HTTRACK_TEST_TIMEOUT=0 bash "$driver" "$tmp/93_off.test" >"$out" 2>&1 || rc=$?
 test "$rc" -eq 3 || fail "disabled guard changed the exit status ($rc)"
 grep -q 'guard off' "$out" || fail "output lost with the guard disabled"
 
+# --- the test reads the same budget the guard enforces ----------------------
+# skip_if_out_of_budget paces against it, so a raw or absent value would pace
+# against a number the guard is not using.
+saw_budget() { # saw_budget <want> <label>
+    grep -qx "budget=$1" "$out" ||
+        fail "$2 reached the test as '$(cat "$out")', want budget=$1"
+}
+# shellcheck disable=SC2016 # the fixture has to read the variable, not us
+printf 'echo "budget=${HTTRACK_TEST_TIMEOUT-unset}"\n' >"$tmp/95_budget.test"
+(unset HTTRACK_TEST_TIMEOUT && bash "$driver" "$tmp/95_budget.test") >"$out" 2>&1
+saw_budget 600 "an unset budget"
+HTTRACK_TEST_TIMEOUT=garbage bash "$driver" "$tmp/95_budget.test" >"$out" 2>&1
+saw_budget 600 "a non-numeric budget"
+HTTRACK_TEST_TIMEOUT=45 bash "$driver" "$tmp/95_budget.test" >"$out" 2>&1
+saw_budget 45 "an explicit budget"
+# 0 execs the test directly, so the pacer has to see the guard is off too.
+HTTRACK_TEST_TIMEOUT=0 bash "$driver" "$tmp/95_budget.test" >"$out" 2>&1
+saw_budget 0 "a disabled guard"
+
+# --- a test too slow to finish skips instead of being killed ----------------
+# hppa spends ~150s on one configure run, and 124 takes the build down where 77
+# does not.
+cat >"$tmp/94_pacer.test" <<EOF
+. "${testdir}/testlib.sh"
+skip_if_out_of_budget 0 9999 # nothing left to run
+skip_if_out_of_budget 5 0    # steps that cost nothing
+skip_if_out_of_budget 5 40   # the next step alone wants 60s
+echo "the pacer let it through"
+EOF
+rc=0
+HTTRACK_TEST_TIMEOUT=20 bash "$driver" "$tmp/94_pacer.test" >"$out" 2>&1 || rc=$?
+test "$rc" -eq 77 || fail "a 60s step under a 20s budget reported $rc, want 77"
+rc=0
+HTTRACK_TEST_TIMEOUT=600 bash "$driver" "$tmp/94_pacer.test" >"$out" 2>&1 || rc=$?
+test "$rc" -eq 0 || fail "a 60s step under a 600s budget reported $rc, want 0"
+grep -q 'the pacer let it through' "$out" || fail "the pacer skipped a test that fits"
+
 # --- a wedged crawl yields a symbolized engine stack ------------------------
 # The whole point of the dump: name the frame the engine is stuck in. Windows has
 # neither half (MSYS signals do not reach a native httrack.exe, and that build has

--- a/tests/151_bash-shell-validate.test
+++ b/tests/151_bash-shell-validate.test
@@ -6,6 +6,10 @@
 
 set -euo pipefail
 
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
 sh=${BASH_SHELL:-}
 test -n "$sh" || {
     echo "BASH_SHELL is empty; tests/Makefile.am must export the configured value" >&2
@@ -50,11 +54,12 @@ mkfifo "$tmp/fifo"
 chmod 755 "$tmp/fifo"
 
 n=0
+cases=16 # reject/accept calls below; pinned again once they have all run
 status=0
 log=
 rundir=
 run() { # run <label> <env argument>...
-    local label=$1
+    local label=$1 began=$SECONDS
     shift
     n=$((n + 1))
     rundir="$tmp/run$n"
@@ -78,6 +83,7 @@ run() { # run <label> <env argument>...
     wait "$pid" || status=$?
     log=$(cat "$rundir/log")
     echo "run $n ($label): exit $status"
+    skip_if_out_of_budget "$((cases - n))" "$((SECONDS - began))"
 }
 
 reject() { # reject <label> <expected message> <env argument>...
@@ -163,4 +169,8 @@ accept empty '' '' BASH_SHELL=
 accept searched "$tmp/fakebin/bash" 'no usable bash found' -u BASH_SHELL "PATH=$tmp/fakebin:$PATH"
 accept searched-posix-env '' 'POSIXLY_CORRECT or SHELLOPTS' -u BASH_SHELL POSIXLY_CORRECT=1
 
+test "$n" -eq "$cases" || {
+    echo "ran $n cases, not the $cases the budget is paced against" >&2
+    exit 1
+}
 echo "configure validated $n BASH_SHELL values"

--- a/tests/180_crash-stack-overflow.test
+++ b/tests/180_crash-stack-overflow.test
@@ -72,20 +72,19 @@ fi
 grep -q "^Caught signal 11$" <<<"$segv" || fail "-#c=segv: no 'Caught signal 11' line"
 grep -q "^Caught signal 11$" <<<"$stack" || fail "-#c=stack: no 'Caught signal 11' line"
 
-# Measured on x86-64: 256 frames and ~250 repeats for the recursion, 11 and 1
-# for the control.
+# Measured on x86-64: recursion 256 frames/~250 repeats, control 11/1.
 stack_deep=$(deepest_repeat "$stack")
 segv_deep=$(deepest_repeat "$segv")
 stack_frames=$(frame_count "$stack")
-segv_frames=$(frame_count "$segv")
 
-# armhf and loong64 cannot unwind out of the frame that faulted on the guard
-# page, and a report shallower than the control's holds no recursion to count.
-# Strictly shallower: a crash_stack that stopped recursing unwinds exactly as far
-# as the control, and that mutant is what the count below exists to kill.
-if [ "$stack_frames" -lt "$segv_frames" ]; then
-    echo "-#c=stack: $stack_frames frames against the control's $segv_frames;" \
-        "this unwinder cannot show the recursion:" >&2
+# armhf and loong64 cannot unwind out of the frame that faulted on the guard page,
+# leaving the handler's own three frames and nothing to count. An absolute floor,
+# not a compare against the control: the two call chains differ by a frame that
+# only -O2 tail-calls away, and a crash_stack that merely stopped recursing still
+# unwinds 11. Killing that mutant is what the count below is for.
+if [ "$stack_frames" -lt 6 ]; then
+    echo "-#c=stack: $stack_frames frames, too few for this unwinder to" \
+        "show the recursion:" >&2
     head -5 <<<"$stack" >&2
     exit 0
 fi

--- a/tests/180_crash-stack-overflow.test
+++ b/tests/180_crash-stack-overflow.test
@@ -54,6 +54,11 @@ deepest_repeat() {
     sort <<<"$addrs" | uniq -c | sort -rn | awk 'NR==1 { print $1 + 0 }'
 }
 
+# Raw frames in the report: backtrace_symbols_fd() closes every one with [0xADDR].
+frame_count() {
+    grep -c '\[0x' <<<"$1" || true
+}
+
 # Control: an ordinary SIGSEGV was already reported before the fix, so a build
 # or harness that can no longer see any crash fails here rather than passing the
 # real case vacuously.
@@ -67,10 +72,25 @@ fi
 grep -q "^Caught signal 11$" <<<"$segv" || fail "-#c=segv: no 'Caught signal 11' line"
 grep -q "^Caught signal 11$" <<<"$stack" || fail "-#c=stack: no 'Caught signal 11' line"
 
-# Measured on x86-64: ~250 repeats for the recursion, 1 for the control.
+# Measured on x86-64: 256 frames and ~250 repeats for the recursion, 11 and 1
+# for the control.
 stack_deep=$(deepest_repeat "$stack")
 segv_deep=$(deepest_repeat "$segv")
+stack_frames=$(frame_count "$stack")
+segv_frames=$(frame_count "$segv")
+
+# armhf and loong64 cannot unwind out of the frame that faulted on the guard
+# page, and a report shallower than the control's holds no recursion to count.
+# Strictly shallower: a crash_stack that stopped recursing unwinds exactly as far
+# as the control, and that mutant is what the count below exists to kill.
+if [ "$stack_frames" -lt "$segv_frames" ]; then
+    echo "-#c=stack: $stack_frames frames against the control's $segv_frames;" \
+        "this unwinder cannot show the recursion:" >&2
+    head -5 <<<"$stack" >&2
+    exit 0
+fi
 test "$stack_deep" -ge 20 ||
-    fail "-#c=stack: deepest frame repeats $stack_deep times, expected a recursion"
+    fail "-#c=stack: deepest frame repeats $stack_deep times over $stack_frames frames," \
+        "expected a recursion"
 test "$segv_deep" -lt 20 ||
     fail "-#c=segv: deepest frame repeats $segv_deep times, the threshold no longer discriminates"

--- a/tests/196_install-rpath-gates.test
+++ b/tests/196_install-rpath-gates.test
@@ -70,16 +70,15 @@ expect() {
 if [ "$(uname -s)" = Darwin ]; then
     cases=1
     expect no "Darwin opts out whatever the prefix" --prefix="${work}/inst"
-    exit 0
+else
+    # The positive control first, or every "no" below could come from a probe that
+    # simply never succeeds on this machine.
+    expect yes "a private prefix gets the rpath" --prefix="${work}/inst"
+    expect no "a system prefix does not" --prefix=/usr
+    expect no "a multiarch libdir does not" --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu
+    expect no "a 32-bit multilib libdir does not" --prefix=/usr --libdir=/usr/lib32
+    expect no "--disable-origin-rpath is honoured" --prefix="${work}/inst" --disable-origin-rpath
+    expect no "a static build does not" --prefix="${work}/inst" --disable-shared
 fi
-
-# The positive control first, or every "no" below could come from a probe that
-# simply never succeeds on this machine.
-expect yes "a private prefix gets the rpath" --prefix="${work}/inst"
-expect no "a system prefix does not" --prefix=/usr
-expect no "a multiarch libdir does not" --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu
-expect no "a 32-bit multilib libdir does not" --prefix=/usr --libdir=/usr/lib32
-expect no "--disable-origin-rpath is honoured" --prefix="${work}/inst" --disable-origin-rpath
-expect no "a static build does not" --prefix="${work}/inst" --disable-shared
 
 test "${n}" -eq "${cases}" || fail "ran ${n} cases, not the ${cases} the budget is paced against"

--- a/tests/196_install-rpath-gates.test
+++ b/tests/196_install-rpath-gates.test
@@ -4,6 +4,10 @@
 
 set -euo pipefail
 
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
 srcdir="${abs_top_srcdir:?not run under make check}"
 test -r "${srcdir}/configure" || {
     echo "no configure in ${srcdir}; skipping" >&2
@@ -35,11 +39,12 @@ test -r "${shadow}/configure" || fail "the shadow source tree has no configure"
 # not depend on the prefix.
 cache=${work}/config.cache
 n=0
+cases=6 # expect calls below, what the budget is paced against; 1 on Darwin
 
 expect() {
     local want=$1 desc=$2
     shift 2
-    local dir got
+    local dir got began=$SECONDS
     n=$((n + 1))
     dir=${work}/build${n}
     mkdir -p "${dir}"
@@ -57,11 +62,13 @@ expect() {
         fail "${desc}: ORIGIN_RPATH is '${got}', expected '${want}'"
     }
     echo "ok: ${desc} -> ${want}"
+    skip_if_out_of_budget "$((cases - n))" "$((SECONDS - began))"
 }
 
 # Darwin has no positive case: configure turns the rpath off there whatever the
 # prefix, so assert that one row rather than run "no" rows that cannot fail.
 if [ "$(uname -s)" = Darwin ]; then
+    cases=1
     expect no "Darwin opts out whatever the prefix" --prefix="${work}/inst"
     exit 0
 fi
@@ -74,3 +81,5 @@ expect no "a multiarch libdir does not" --prefix=/usr --libdir=/usr/lib/x86_64-l
 expect no "a 32-bit multilib libdir does not" --prefix=/usr --libdir=/usr/lib32
 expect no "--disable-origin-rpath is honoured" --prefix="${work}/inst" --disable-origin-rpath
 expect no "a static build does not" --prefix="${work}/inst" --disable-shared
+
+test "${n}" -eq "${cases}" || fail "ran ${n} cases, not the ${cases} the budget is paced against"

--- a/tests/crawl-test.sh
+++ b/tests/crawl-test.sh
@@ -194,7 +194,11 @@ tmpdir=
 crawlpid=
 nopurge=
 verbose=
-trap cleanup EXIT HUP INT QUIT ILL TRAP ABRT BUS FPE SEGV PIPE ALRM TERM STKFLT XCPU XFSZ
+# One at a time: STKFLT is Linux-only, and a single unknown name makes the whole
+# trap command complain on every run (GNU/Hurd, the BSDs).
+for sig in EXIT HUP INT QUIT ILL TRAP ABRT BUS FPE SEGV PIPE ALRM TERM STKFLT XCPU XFSZ; do
+    trap cleanup "$sig" 2>/dev/null || true
+done
 
 # working directory
 tmpdir="${tmptopdir}/httrack_ut.$$"

--- a/tests/crawl-test.sh
+++ b/tests/crawl-test.sh
@@ -194,8 +194,8 @@ tmpdir=
 crawlpid=
 nopurge=
 verbose=
-# One at a time: STKFLT is Linux-only, and a single unknown name makes the whole
-# trap command complain on every run (GNU/Hurd, the BSDs).
+# One at a time: an unknown name (STKFLT is Linux-only) makes the whole trap
+# command complain, on every run, on GNU/Hurd and the BSDs.
 for sig in EXIT HUP INT QUIT ILL TRAP ABRT BUS FPE SEGV PIPE ALRM TERM STKFLT XCPU XFSZ; do
     trap cleanup "$sig" 2>/dev/null || true
 done

--- a/tests/test-timeout.sh
+++ b/tests/test-timeout.sh
@@ -24,8 +24,8 @@ budget=${HTTRACK_TEST_TIMEOUT:-600}
 case "$budget" in
 '' | *[!0-9]*) budget=600 ;;
 esac
-# Exported, so a test that runs a long series of expensive steps can pace itself
-# against the same number instead of being killed halfway (skip_if_out_of_budget).
+# Exported so a test can pace itself against the same number (skip_if_out_of_budget)
+# instead of being killed halfway.
 export HTTRACK_TEST_TIMEOUT="$budget"
 test "$budget" -gt 0 || exec "$BASH" "$@"
 

--- a/tests/test-timeout.sh
+++ b/tests/test-timeout.sh
@@ -24,6 +24,9 @@ budget=${HTTRACK_TEST_TIMEOUT:-600}
 case "$budget" in
 '' | *[!0-9]*) budget=600 ;;
 esac
+# Exported, so a test that runs a long series of expensive steps can pace itself
+# against the same number instead of being killed halfway (skip_if_out_of_budget).
+export HTTRACK_TEST_TIMEOUT="$budget"
 test "$budget" -gt 0 || exec "$BASH" "$@"
 
 # The test script is the last argument; automake passes no others today.

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -350,6 +350,21 @@ EOF
     export PATH
 }
 
+# SKIP out when $1 more steps at the cost of the one that just ran ($2 seconds)
+# would overrun test-timeout.sh's budget: that budget is there to catch a wedge,
+# and a port slow enough to blow it on honest work (hppa spends ~150s on a single
+# configure run) would else FTBFS. Charge the step's own duration, not the elapsed
+# mean, or setup and a cold config.cache are billed to every remaining step.
+skip_if_out_of_budget() { # skip_if_out_of_budget <steps left> <seconds the last took>
+    local budget=${HTTRACK_TEST_TIMEOUT:-600} need=$((($1 + 1) * $2))
+
+    case "$budget" in '' | *[!0-9]*) budget=600 ;; esac
+    test "$1" -gt 0 && test "$budget" -gt 0 || return 0
+    test "$((SECONDS + need))" -ge "$budget" || return 0
+    echo "$1 steps left need ~${need}s and the budget is ${budget}s; skipping" >&2
+    exit 77
+}
+
 # Collect a killed job, giving up after REAP_GRACE seconds. kill_tree can fail to
 # reap a native Windows descendant -- the very case these watchdogs exist for --
 # and a bare `wait` then blocks the watchdog itself forever, so the timeout it was

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -350,18 +350,18 @@ EOF
     export PATH
 }
 
-# SKIP out when $1 more steps at the cost of the one that just ran ($2 seconds)
-# would overrun test-timeout.sh's budget: that budget is there to catch a wedge,
-# and a port slow enough to blow it on honest work (hppa spends ~150s on a single
-# configure run) would else FTBFS. Charge the step's own duration, not the elapsed
-# mean, or setup and a cold config.cache are billed to every remaining step.
+# Skip when the next of $1 remaining steps, at 1.5x the $2 seconds the last one
+# took, no longer fits the budget meant to catch a wedge (hppa spends ~150s on one
+# configure run and would else FTBFS). One step ahead rather than all of them: 196
+# shares a config.cache, so its first step costs several times the rest and
+# projecting it over them would skip a run that fits.
 skip_if_out_of_budget() { # skip_if_out_of_budget <steps left> <seconds the last took>
-    local budget=${HTTRACK_TEST_TIMEOUT:-600} need=$((($1 + 1) * $2))
+    local budget=${HTTRACK_TEST_TIMEOUT:-600} need=$(($2 + $2 / 2))
 
     case "$budget" in '' | *[!0-9]*) budget=600 ;; esac
     test "$1" -gt 0 && test "$budget" -gt 0 || return 0
     test "$((SECONDS + need))" -ge "$budget" || return 0
-    echo "$1 steps left need ~${need}s and the budget is ${budget}s; skipping" >&2
+    echo "$1 steps left, the last took ${2}s and the budget is ${budget}s; skipping" >&2
     exit 77
 }
 


### PR DESCRIPTION
Three unrelated causes behind the four architectures that failed to build 3.49.16-1.

`180_crash-stack-overflow` counts how often the report repeats one address, which is what separates a runaway recursion from an ordinary fault. armhf and loong64 cannot unwind out of the frame that faulted on the guard page, so the report stops at the handler's own three frames and there is nothing left to count. That check now runs only when the report carries more than those. It is an absolute floor rather than a comparison against the ordinary-fault control, because the two call chains differ by a frame that only `-O2` tail-calls away: at `-O0` the control is the deeper of the two, and a `crash_stack` that stopped recursing would have slipped past. Checked at both optimisation levels, and against a `backtrace()` interposer modelling the shallow unwinder.

hppa spends around 150s on a single configure run, so `151_bash-shell-validate` (16 of them) and `196_install-rpath-gates` (6) overran the 600s per-test budget and were killed at 124. That budget exists to catch a wedge, and neither was wedged. Both now look one step ahead, at the cost of the step they just finished, and skip out when the next one will not fit; `test-timeout.sh` exports the budget for them to read. One step rather than all of them: 196 shares a config.cache, so its first run costs several times the rest and projecting it across them would skip a run that fits. What they cover is configure logic, the same on every architecture and exercised on the fast ones.

hurd-i386 is one of the few buildds with a network, so the online probe said yes and the crawls then failed on DNS. Policy 4.9 forbids network access during a build, so `debian/rules` stops asking for it. Also installs `crawl-test.sh`'s traps one signal at a time: `SIGSTKFLT` is Linux-only, and bash rejected that one name on every Hurd run.

`105_suite-timeout.test` covers both new gates: deleting the export, or the skip, fails it.

Closes #1015
