### PR TITLE
The suite watchdog dumps nothing on a host without ps

### DIFF
--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -140,32 +140,63 @@ test "$rc" -eq 0 || fail "a 60s step under a 600s budget reported $rc, want 0"
 grep -q 'the pacer let it through' "$out" || fail "the pacer skipped a test that fits"
 
 # --- the process lists survive a host with no ps ----------------------------
-# Fedora's build root ships no procps: every list came back empty, so the guard
-# fired but named nothing and salvaged no stack (#1021).
+# Fedora's build root ships no procps, and the guard then named nothing (#1021).
 if ! is_windows && test -r /proc/self/stat; then
     mkdir -p "$tmp/nops"
     printf '#!/bin/sh\nexit 127\n' >"$tmp/nops/ps"
     chmod +x "$tmp/nops/ps"
     # Both lists match on the basename alone, so any long-lived binary will do.
     ln -sf "$(command -v sleep)" "$tmp/httrack"
-    "$tmp/httrack" 60 &
-    fake=$!
-    pgid=$(awk '{ sub(/.*\) /, ""); print $3 }' "/proc/$fake/stat")
+    # Started from a subshell so ppid and pgid differ: swapping those two columns
+    # is invisible whenever the test shell happens to lead its own group.
+    (
+        "$tmp/httrack" 60 &
+        echo $! >"$tmp/fake.pid"
+    )
+    # Its own group, to prove the filter keeps an outsider out.
+    (
+        set -m
+        "$tmp/httrack" 60 &
+        echo $! >"$tmp/outside.pid"
+    )
+    fake=$(cat "$tmp/fake.pid")
+    outside=$(cat "$tmp/outside.pid")
+    trap 'set +e; kill "$fake" "$outside" 2>/dev/null; rm -rf "$tmp"' EXIT
+    # ppid and pgid of $1: the oracle the listing is checked against.
+    procfields() { awk '{ sub(/.*\) /, ""); print $2, $3 }' "/proc/$1/stat"; }
+    read -r fppid pgid _ <<<"$(procfields "$fake")"
+    read -r _ opgid _ <<<"$(procfields "$outside")"
+    test "$fppid" != "$pgid" || fail "the fake shares ppid and pgid ($pgid)"
+    test "$opgid" != "$pgid" || fail "the outsider landed in the group under test"
     (
         PATH="$tmp/nops:$PATH"
         ! ps -A >/dev/null 2>&1 || fail "the ps shim did not take"
         snap=$(list_stray_processes "$pgid" group)
-        grep -qE "^$fake " <<<"$snap" || fail "no-ps group list lost pid $fake: $snap"
-        grep -qx "$fake" <<<"$(list_engine_pids "$pgid")" ||
-            fail "no-ps engine list lost pid $fake"
+        # Line 1 is the header every consumer drops; a row there would be lost.
+        case "$(head -n1 <<<"$snap")" in
+        [0-9]*) fail "the no-ps listing has no header: $snap" ;;
+        esac
+        ! grep -qE "^$outside " <<<"$snap" ||
+            fail "no-ps group list reported pid $outside, in another group"
+        read -r _ rppid rpgid _ <<<"$(grep -E "^$fake " <<<"$snap")"
+        test "$rppid $rpgid" = "$fppid $pgid" ||
+            fail "no-ps row for $fake reads ppid/pgid '$rppid $rpgid', want '$fppid $pgid'"
+        engines=$(list_engine_pids "$pgid")
+        grep -qx "$fake" <<<"$engines" || fail "no-ps engine list lost pid $fake"
+        ! grep -qx "$outside" <<<"$engines" ||
+            fail "no-ps engine list reached outside the group (pid $outside)"
+        # The chain, not just its input: this is what reported nothing on Fedora.
+        stacks=$(request_engine_backtraces "$pgid")
+        ! grep -q 'no engine process left' <<<"$stacks" ||
+            fail "no-ps stack request found no engine to signal: $stacks"
+        ! kill -0 "$fake" 2>/dev/null || fail "the SIGABRT never reached pid $fake"
         # With neither source the dump must say so, not print an empty section.
         # shellcheck disable=SC2317 # reached through ps_snapshot
         proc_snapshot() { return 1; }
         grep -q 'no process list' <<<"$(list_stray_processes "$pgid" group)" ||
             fail "a host with no ps and no /proc produced no notice"
     )
-    kill "$fake" 2>/dev/null || true
-    wait "$fake" 2>/dev/null || true
+    kill "$fake" "$outside" 2>/dev/null || true
 fi
 
 # --- a wedged crawl yields a symbolized engine stack ------------------------

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -164,6 +164,7 @@ if ! is_windows && test -r /proc/self/stat; then
     trap 'set +e; kill "$fake" "$outside" 2>/dev/null; rm -rf "$tmp"' EXIT
     # ppid and pgid of $1: the oracle the listing is checked against.
     procfields() { awk '{ sub(/.*\) /, ""); print $2, $3 }' "/proc/$1/stat"; }
+    procstate() { awk '{ sub(/.*\) /, ""); print $1 }' "/proc/$1/stat" 2>/dev/null || echo gone; }
     read -r fppid pgid _ <<<"$(procfields "$fake")"
     read -r _ opgid _ <<<"$(procfields "$outside")"
     test "$fppid" != "$pgid" || fail "the fake shares ppid and pgid ($pgid)"
@@ -189,7 +190,12 @@ if ! is_windows && test -r /proc/self/stat; then
         stacks=$(request_engine_backtraces "$pgid")
         ! grep -q 'no engine process left' <<<"$stacks" ||
             fail "no-ps stack request found no engine to signal: $stacks"
-        ! kill -0 "$fake" 2>/dev/null || fail "the SIGABRT never reached pid $fake"
+        # Gone, or a zombie: the fake is reparented, and a container's pid 1 does
+        # not always reap. kill -0 alone succeeds on a zombie and proves nothing.
+        case "$(procstate "$fake")" in
+        Z | gone) ;;
+        *) fail "the SIGABRT never reached pid $fake" ;;
+        esac
         # With neither source the dump must say so, not print an empty section.
         # shellcheck disable=SC2317 # reached through ps_snapshot
         proc_snapshot() { return 1; }

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -65,7 +65,7 @@ grep -q 'slow but healthy' "$out" || fail "healthy test output lost"
 
 # The killed tree must really be gone, or the next test inherits its ports.
 sleep 1
-! grep -q "$tmp/90_wedged.test" <<<"$(ps -A -o args 2>/dev/null)" ||
+! grep -q "$tmp/90_wedged.test" <<<"$(ps_snapshot)" ||
     fail "the wedged test survived the guard"
 
 # --- the budget is wall clock, not a count of poll iterations ----------------
@@ -138,6 +138,35 @@ rc=0
 HTTRACK_TEST_TIMEOUT=600 bash "$driver" "$tmp/94_pacer.test" >"$out" 2>&1 || rc=$?
 test "$rc" -eq 0 || fail "a 60s step under a 600s budget reported $rc, want 0"
 grep -q 'the pacer let it through' "$out" || fail "the pacer skipped a test that fits"
+
+# --- the process lists survive a host with no ps ----------------------------
+# Fedora's build root ships no procps: every list came back empty, so the guard
+# fired but named nothing and salvaged no stack (#1021).
+if ! is_windows && test -r /proc/self/stat; then
+    mkdir -p "$tmp/nops"
+    printf '#!/bin/sh\nexit 127\n' >"$tmp/nops/ps"
+    chmod +x "$tmp/nops/ps"
+    # Both lists match on the basename alone, so any long-lived binary will do.
+    ln -sf "$(command -v sleep)" "$tmp/httrack"
+    "$tmp/httrack" 60 &
+    fake=$!
+    pgid=$(awk '{ sub(/.*\) /, ""); print $3 }' "/proc/$fake/stat")
+    (
+        PATH="$tmp/nops:$PATH"
+        ! ps -A >/dev/null 2>&1 || fail "the ps shim did not take"
+        snap=$(list_stray_processes "$pgid" group)
+        grep -qE "^$fake " <<<"$snap" || fail "no-ps group list lost pid $fake: $snap"
+        grep -qx "$fake" <<<"$(list_engine_pids "$pgid")" ||
+            fail "no-ps engine list lost pid $fake"
+        # With neither source the dump must say so, not print an empty section.
+        # shellcheck disable=SC2317 # reached through ps_snapshot
+        proc_snapshot() { return 1; }
+        grep -q 'no process list' <<<"$(list_stray_processes "$pgid" group)" ||
+            fail "a host with no ps and no /proc produced no notice"
+    )
+    kill "$fake" 2>/dev/null || true
+    wait "$fake" 2>/dev/null || true
+fi
 
 # --- a wedged crawl yields a symbolized engine stack ------------------------
 # The whole point of the dump: name the frame the engine is stuck in. Windows has

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -176,6 +176,47 @@ kill_tree() {
 ENGINE_EXE_RE='^(lt-)?(httrack|proxytrack|htsserver|webhttrack)([.]exe)?$'
 FIXTURE_SERVER_RE='^(local-server|proxy-https-server|proxy-connect-server|socks5-server|tls-stall-server)[.]py$'
 
+# Every process as "PID PPID PGID ELAPSED S COMMAND", header first. `ps` is not a
+# given: a Fedora build root has no procps, and its absence left the hang dump
+# printing an empty list rather than saying so (#1021).
+ps_snapshot() {
+    # POSIX keywords throughout, so the ps route holds on macOS too.
+    ps -A -o pid,ppid,pgid,etime,state,args 2>/dev/null && return 0
+    proc_snapshot && return 0
+    # Every consumer drops line 1, so the notice rides in the header's place.
+    printf 'no process list: this host has neither ps nor a readable /proc\n'
+    return 1
+}
+
+# The same six columns out of /proc, in bash alone; elapsed as plain seconds.
+proc_snapshot() {
+    local d stat rest arg args comm hz uptime
+    local -a f
+    local nl # spelled out of line: bash 3.2 fails to parse $'\n' inside ${v//p/r}
+    nl=$'\n'
+    test -r /proc/self/stat || return 1
+    hz=$(getconf CLK_TCK 2>/dev/null) || hz=
+    read -r uptime _ </proc/uptime 2>/dev/null || return 1
+    printf 'PID PPID PGID ELAPSED S COMMAND\n'
+    for d in /proc/[0-9]*; do
+        read -r stat <"$d/stat" 2>/dev/null || continue
+        # comm may hold spaces and parens; every field past it is numeric.
+        rest=${stat##*') '}
+        comm=${stat#*(}
+        comm=${comm%)*}
+        read -ra f <<<"$rest" || continue
+        test "${#f[@]}" -ge 20 || continue # short read: the process is going away
+        args=
+        # An argv holding a newline would split one process over two lines.
+        { while IFS= read -r -d '' arg; do
+            args="${args:+$args }${arg//"$nl"/ }"
+        done <"$d/cmdline"; } 2>/dev/null || true
+        printf '%s %s %s %s %s %s\n' "${d#/proc/}" "${f[1]}" "${f[2]}" \
+            "$(((${uptime%%.*} * ${hz:-100} - f[19]) / ${hz:-100}))" \
+            "${f[0]}" "${args:-[$comm]}"
+    done
+}
+
 # List processes a hung test may have left running, one per line. $1 is the test's
 # process group; $2 selects "group" (that group's members, whatever their name),
 # "others" (engine and fixture processes outside it, which under "make check -j"
@@ -190,10 +231,9 @@ list_stray_processes() {
         test "$mode" != others || return 0
         tasklist 2>/dev/null | grep -Ei 'httrack|proxytrack|htsserver|python' || true
     else
-        # `args` and `state` are POSIX ps keywords, so this holds on macOS too.
         # Fields 6 and 7 are the command and its first argument (the interpreter
         # and its script, for the Python fixtures).
-        ps -A -o pid,ppid,pgid,etime,state,args 2>/dev/null |
+        ps_snapshot |
             awk -v pg="$pgid" -v mode="$mode" -v eng="$ENGINE_EXE_RE" -v srv="$FIXTURE_SERVER_RE" '
                 NR == 1 { print; next }
                 { ingroup = (pg > 0 && $3 == pg)
@@ -239,9 +279,9 @@ reap_leftover_processes() {
 list_engine_pids() {
     local pgid=${1:-0}
     test "$pgid" -gt 0 2>/dev/null || return 0
-    ps -A -o pid,pgid,args 2>/dev/null |
+    ps_snapshot |
         awk -v pg="$pgid" -v eng="$ENGINE_EXE_RE" \
-            'NR > 1 && $2 == pg { c = $3; sub(/.*[\/\\]/, "", c); if (c ~ eng) print $1 }'
+            'NR > 1 && $3 == pg { c = $6; sub(/.*[\/\\]/, "", c); if (c ~ eng) print $1 }'
 }
 
 # Ask the wedged test's engine processes for a stack. What is obtainable differs

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -176,12 +176,17 @@ kill_tree() {
 ENGINE_EXE_RE='^(lt-)?(httrack|proxytrack|htsserver|webhttrack)([.]exe)?$'
 FIXTURE_SERVER_RE='^(local-server|proxy-https-server|proxy-connect-server|socks5-server|tls-stall-server)[.]py$'
 
-# Every process as "PID PPID PGID ELAPSED S COMMAND", header first. `ps` is not a
-# given: a Fedora build root has no procps, and its absence left the hang dump
-# printing an empty list rather than saying so (#1021).
+# Every process as "PID PPID PGID ELAPSED S COMMAND", header first. A Fedora
+# build root has no procps, and an empty list reads as "nothing running" (#1021).
 ps_snapshot() {
-    # POSIX keywords throughout, so the ps route holds on macOS too.
-    ps -A -o pid,ppid,pgid,etime,state,args 2>/dev/null && return 0
+    local snap
+    # POSIX keywords, so the ps route holds on macOS too; a ps that lists nothing
+    # (hidepid, a locked-down container) is no better than an absent one.
+    if snap=$(ps -A -o pid,ppid,pgid,etime,state,args 2>/dev/null |
+        awk 'NR > 1 { rows++ } { print } END { exit rows ? 0 : 1 }'); then
+        printf '%s\n' "$snap"
+        return 0
+    fi
     proc_snapshot && return 0
     # Every consumer drops line 1, so the notice rides in the header's place.
     printf 'no process list: this host has neither ps nor a readable /proc\n'
@@ -192,14 +197,17 @@ ps_snapshot() {
 proc_snapshot() {
     local d stat rest arg args comm hz uptime
     local -a f
-    local nl # spelled out of line: bash 3.2 fails to parse $'\n' inside ${v//p/r}
-    nl=$'\n'
+    local ws # spelled out of line: bash 3.2 fails to parse $'..' inside ${v//p/r}
+    ws=$' \t\n\v\f\r'
     test -r /proc/self/stat || return 1
     hz=$(getconf CLK_TCK 2>/dev/null) || hz=
+    # A zero or non-numeric tick would abort the shell in the division below.
+    case "$hz" in '' | 0 | *[!0-9]*) hz=100 ;; esac
     read -r uptime _ </proc/uptime 2>/dev/null || return 1
     printf 'PID PPID PGID ELAPSED S COMMAND\n'
     for d in /proc/[0-9]*; do
-        read -r stat <"$d/stat" 2>/dev/null || continue
+        # Braced: a failed open reports to the caller's stderr, not the redirect.
+        { read -r stat <"$d/stat"; } 2>/dev/null || continue
         # comm may hold spaces and parens; every field past it is numeric.
         rest=${stat##*') '}
         comm=${stat#*(}
@@ -207,12 +215,13 @@ proc_snapshot() {
         read -ra f <<<"$rest" || continue
         test "${#f[@]}" -ge 20 || continue # short read: the process is going away
         args=
-        # An argv holding a newline would split one process over two lines.
+        # Whitespace inside an argv would split the row or shift the columns the
+        # consumers match on, which ps avoids by mapping those bytes away.
         { while IFS= read -r -d '' arg; do
-            args="${args:+$args }${arg//"$nl"/ }"
+            args="${args:+$args }${arg//["$ws"]/ }"
         done <"$d/cmdline"; } 2>/dev/null || true
         printf '%s %s %s %s %s %s\n' "${d#/proc/}" "${f[1]}" "${f[2]}" \
-            "$(((${uptime%%.*} * ${hz:-100} - f[19]) / ${hz:-100}))" \
+            "$(((${uptime%%.*} * hz - f[19]) / hz))" \
             "${f[0]}" "${args:-[$comm]}"
     done
 }


### PR DESCRIPTION
Fedora's build root has no procps. Without `ps` every process list in the suite watchdog's hang dump came back empty, so 105_suite-timeout failed: the guard fired, but there was no engine process left to signal for a stack. The lists now read /proc when ps is missing, and a host with neither source says so instead of printing an empty section.

The new test leg hides `ps` behind a stub and checks both lists still find a live process, so CI keeps exercising the fallback even though its runners all have ps.

Closes #1021