### PR TITLE
Four architectures cannot build the altstack test shim, and nothing before the buildd sees it

### DIFF
--- a/.github/workflows/cross-arch.yml
+++ b/.github/workflows/cross-arch.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     # sid, not stable: the point is to predict what the sid buildds will say.
     container: debian:sid
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -49,8 +50,14 @@ jobs:
         run: |
           set -euo pipefail
           # deb-src, so zlib below comes from the archive and not a pinned URL.
-          sed -i 's/^Types: deb$/Types: deb deb-src/' \
-            /etc/apt/sources.list.d/debian.sources
+          # Its own stanza: editing the image's would break on a reworded one.
+          cat > /etc/apt/sources.list.d/deb-src.sources <<'EOF'
+          Types: deb-src
+          URIs: http://deb.debian.org/debian
+          Suites: sid
+          Components: main
+          Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+          EOF
           apt-get update
           apt-get install -y --no-install-recommends \
             build-essential autoconf automake libtool autoconf-archive \
@@ -84,7 +91,10 @@ jobs:
           eval "$(dpkg-buildflags --export=sh)"
           # A cross AC_TRY_RUN answers "cross", which would swap in the bundled
           # snprintf that no buildd ever builds. Every glibc passes these.
+          # --disable-https: no ports arch has a cross libssl, so the TLS paths
+          # are the one part of the tree this matrix does not compile.
           "$GITHUB_WORKSPACE/configure" --host="$TRIPLET" \
+            --build="$(dpkg-architecture -qDEB_BUILD_GNU_TYPE)" --disable-https \
             ac_cv_have_working_snprintf=yes ac_cv_have_working_vsnprintf=yes \
             CPPFLAGS="${CPPFLAGS:-} -I$ZPREFIX/include" \
             LDFLAGS="${LDFLAGS:-} -L$ZPREFIX/lib"
@@ -94,5 +104,9 @@ jobs:
 
       - name: Build the test artifacts
         # Nothing runs here, but the shims are where three of the four 3.49.17
-        # failures were: they only build under `check`.
-        run: make -C /tmp/bld -j"$(nproc)" check TESTS=
+        # failures were: they only build under `check`. Asserted, because an
+        # empty TESTS= would otherwise pass having built nothing.
+        run: |
+          set -euo pipefail
+          make -C /tmp/bld -j"$(nproc)" check TESTS=
+          test -f /tmp/bld/tests/.libs/libaltstackprobe.so

--- a/.github/workflows/cross-arch.yml
+++ b/.github/workflows/cross-arch.yml
@@ -79,8 +79,9 @@ jobs:
           CHOST="$TRIPLET" CC="$TRIPLET-gcc" CFLAGS="-O2 -fPIC" \
             ./configure --prefix="$ZPREFIX" --static
           # configure detects s390x's vector CRC, whose sources live in the
-          # contrib/ the .dfsg repack drops. Nothing here needs a fast CRC.
-          sed -i 's/-DHAVE_S390X_VX//g' Makefile
+          # contrib/ the .dfsg repack drops: drop the define and the object it
+          # would build. Nothing here needs a fast CRC.
+          sed -i -E 's/(-DHAVE_S390X_VX|crc32_vx\.l?o)//g' Makefile
           make -j"$(nproc)"
           make install
 

--- a/.github/workflows/cross-arch.yml
+++ b/.github/workflows/cross-arch.yml
@@ -1,0 +1,100 @@
+# Cross-compiles for the Debian architectures no GitHub runner exists for.
+# 3.49.17 failed on four of them at once and every failure was a compile or
+# assemble error that x86-64 and arm64 cannot produce, so the buildd was the
+# first thing to see the code.
+name: Cross-arch
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+# Least privilege: the workflow only needs to read the repo.
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same branch or PR.
+concurrency:
+  group: cross-arch-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cross:
+    name: cross (${{ matrix.arch }})
+    runs-on: ubuntu-24.04
+    # sid, not stable: the point is to predict what the sid buildds will say.
+    container: debian:sid
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # arch is the dpkg name that selects the hardening flags, triplet the
+          # toolchain prefix; the two differ often enough to spell both out.
+          # The first four are 3.49.17's failures.
+          - { arch: armhf, triplet: arm-linux-gnueabihf }
+          - { arch: powerpc, triplet: powerpc-linux-gnu }
+          - { arch: hppa, triplet: hppa-linux-gnu }
+          - { arch: loong64, triplet: loongarch64-linux-gnu }
+          - { arch: sh4, triplet: sh4-linux-gnu }
+          - { arch: m68k, triplet: m68k-linux-gnu }
+          - { arch: alpha, triplet: alpha-linux-gnu }
+          - { arch: sparc64, triplet: sparc64-linux-gnu }
+          - { arch: riscv64, triplet: riscv64-linux-gnu }
+          - { arch: s390x, triplet: s390x-linux-gnu }
+    env:
+      DEB_HOST_ARCH: ${{ matrix.arch }}
+      TRIPLET: ${{ matrix.triplet }}
+      ZPREFIX: /tmp/zlib-${{ matrix.arch }}
+    steps:
+      - name: Install the toolchain
+        run: |
+          set -euo pipefail
+          # deb-src, so zlib below comes from the archive and not a pinned URL.
+          sed -i 's/^Types: deb$/Types: deb deb-src/' \
+            /etc/apt/sources.list.d/debian.sources
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential autoconf automake libtool autoconf-archive \
+            dpkg-dev git ca-certificates "gcc-$TRIPLET"
+
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Cross-build zlib
+        run: |
+          set -euo pipefail
+          # The one mandatory dependency, and no ports architecture has a
+          # zlib1g-dev:<arch> to multiarch-install. -fPIC: libhttrack.so links it.
+          mkdir -p /tmp/zsrc && cd /tmp/zsrc
+          apt-get source zlib1g
+          cd zlib-*/
+          CHOST="$TRIPLET" CC="$TRIPLET-gcc" CFLAGS="-O2 -fPIC" \
+            ./configure --prefix="$ZPREFIX" --static
+          make -j"$(nproc)"
+          make install
+
+      - name: Configure
+        run: |
+          set -euo pipefail
+          autoreconf -fi
+          mkdir -p /tmp/bld && cd /tmp/bld
+          # The buildd's own flags, per architecture: -D_FILE_OFFSET_BITS=64 is
+          # what renamed an LD_PRELOAD shim's mmap() to mmap64 on 32-bit, and
+          # -fstack-clash-protection is not offered everywhere.
+          eval "$(dpkg-buildflags --export=sh)"
+          # A cross AC_TRY_RUN answers "cross", which would swap in the bundled
+          # snprintf that no buildd ever builds. Every glibc passes these.
+          "$GITHUB_WORKSPACE/configure" --host="$TRIPLET" \
+            ac_cv_have_working_snprintf=yes ac_cv_have_working_vsnprintf=yes \
+            CPPFLAGS="${CPPFLAGS:-} -I$ZPREFIX/include" \
+            LDFLAGS="${LDFLAGS:-} -L$ZPREFIX/lib"
+
+      - name: Build
+        run: make -C /tmp/bld -j"$(nproc)"
+
+      - name: Build the test artifacts
+        # Nothing runs here, but the shims are where three of the four 3.49.17
+        # failures were: they only build under `check`.
+        run: make -C /tmp/bld -j"$(nproc)" check TESTS=

--- a/.github/workflows/cross-arch.yml
+++ b/.github/workflows/cross-arch.yml
@@ -70,8 +70,12 @@ jobs:
           # Mandatory, and no ports arch has a zlib1g-dev:<arch> to
           # multiarch-install. -fPIC because libhttrack.so links it.
           mkdir -p /tmp/zsrc && cd /tmp/zsrc
-          apt-get source zlib1g
-          cd zlib-*/
+          # Unpatched: Debian's arch-specific patches expect its own rules to
+          # build them (s390x's vector CRC pulls a header they add), and we only
+          # need something to link -lz against.
+          apt-get source --download-only zlib1g
+          dpkg-source --skip-patches -x ./*.dsc src
+          cd src
           CHOST="$TRIPLET" CC="$TRIPLET-gcc" CFLAGS="-O2 -fPIC" \
             ./configure --prefix="$ZPREFIX" --static
           make -j"$(nproc)"

--- a/.github/workflows/cross-arch.yml
+++ b/.github/workflows/cross-arch.yml
@@ -50,14 +50,10 @@ jobs:
         run: |
           set -euo pipefail
           # deb-src, so zlib below comes from the archive and not a pinned URL.
-          # Its own stanza: editing the image's would break on a reworded one.
-          cat > /etc/apt/sources.list.d/deb-src.sources <<'EOF'
-          Types: deb-src
-          URIs: http://deb.debian.org/debian
-          Suites: sid
-          Components: main
-          Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
-          EOF
+          # In place: a second stanza has to repeat Signed-By, and apt rejects
+          # the same source carrying two spellings of the keyring.
+          sed -i 's/^Types: deb$/Types: deb deb-src/' \
+            /etc/apt/sources.list.d/debian.sources
           apt-get update
           apt-get install -y --no-install-recommends \
             build-essential autoconf automake libtool autoconf-archive \

--- a/.github/workflows/cross-arch.yml
+++ b/.github/workflows/cross-arch.yml
@@ -29,8 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # arch is the dpkg name that selects the hardening flags, triplet the
-          # toolchain prefix; the two differ often enough to spell both out.
+          # arch selects the hardening flags, triplet is the toolchain prefix.
           # The first four are 3.49.17's failures.
           - { arch: armhf, triplet: arm-linux-gnueabihf }
           - { arch: powerpc, triplet: powerpc-linux-gnu }
@@ -38,7 +37,6 @@ jobs:
           - { arch: loong64, triplet: loongarch64-linux-gnu }
           - { arch: sh4, triplet: sh4-linux-gnu }
           - { arch: m68k, triplet: m68k-linux-gnu }
-          - { arch: alpha, triplet: alpha-linux-gnu }
           - { arch: sparc64, triplet: sparc64-linux-gnu }
           - { arch: riscv64, triplet: riscv64-linux-gnu }
           - { arch: s390x, triplet: s390x-linux-gnu }
@@ -56,7 +54,8 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends \
             build-essential autoconf automake libtool autoconf-archive \
-            dpkg-dev git ca-certificates "gcc-$TRIPLET"
+            dpkg-dev git ca-certificates \
+            "gcc-$TRIPLET" "libc6-dev-$DEB_HOST_ARCH-cross"
 
       - uses: actions/checkout@v7
         with:
@@ -65,8 +64,8 @@ jobs:
       - name: Cross-build zlib
         run: |
           set -euo pipefail
-          # The one mandatory dependency, and no ports architecture has a
-          # zlib1g-dev:<arch> to multiarch-install. -fPIC: libhttrack.so links it.
+          # Mandatory, and no ports arch has a zlib1g-dev:<arch> to
+          # multiarch-install. -fPIC because libhttrack.so links it.
           mkdir -p /tmp/zsrc && cd /tmp/zsrc
           apt-get source zlib1g
           cd zlib-*/
@@ -80,9 +79,8 @@ jobs:
           set -euo pipefail
           autoreconf -fi
           mkdir -p /tmp/bld && cd /tmp/bld
-          # The buildd's own flags, per architecture: -D_FILE_OFFSET_BITS=64 is
-          # what renamed an LD_PRELOAD shim's mmap() to mmap64 on 32-bit, and
-          # -fstack-clash-protection is not offered everywhere.
+          # The buildd's own per-arch flags: -D_FILE_OFFSET_BITS=64 is the shim
+          # hazard, and -fstack-clash-protection is not offered everywhere.
           eval "$(dpkg-buildflags --export=sh)"
           # A cross AC_TRY_RUN answers "cross", which would swap in the bundled
           # snprintf that no buildd ever builds. Every glibc passes these.

--- a/.github/workflows/cross-arch.yml
+++ b/.github/workflows/cross-arch.yml
@@ -78,6 +78,9 @@ jobs:
           cd src
           CHOST="$TRIPLET" CC="$TRIPLET-gcc" CFLAGS="-O2 -fPIC" \
             ./configure --prefix="$ZPREFIX" --static
+          # configure detects s390x's vector CRC, whose sources live in the
+          # contrib/ the .dfsg repack drops. Nothing here needs a fast CRC.
+          sed -i 's/-DHAVE_S390X_VX//g' Makefile
           make -j"$(nproc)"
           make install
 

--- a/tests/183_altstack-worker.test
+++ b/tests/183_altstack-worker.test
@@ -63,10 +63,20 @@ grep -q "^Caught signal 11$" <<<"$worker" || fail "-#c=threadstack: no 'Caught s
 # worker's, which is what had no alternate stack.
 worker_frames=$(frame_count "$worker")
 plain_frames=$(frame_count "$plain")
-test "$worker_frames" -ge 100 ||
-    fail "-#c=threadstack: $worker_frames frames, expected a runaway recursion"
 test "$plain_frames" -lt 100 ||
     fail "-#c=segv: $plain_frames frames, the threshold no longer discriminates"
+
+# armhf and loong64 cannot unwind out of the frame that faulted on the guard
+# page, leaving the handler's own three frames and nothing to count; 180 skips
+# on the same absolute floor, which a worker that merely stopped recursing
+# (11 frames, like the control) stays well clear of. Only this half goes blind
+# there: the release trace below still judges the same fix.
+if [ "$worker_frames" -lt 6 ]; then
+    echo "-#c=threadstack: $worker_frames frames, too few for this unwinder to" \
+        "show the recursion" >&2
+elif [ "$worker_frames" -lt 100 ]; then
+    fail "-#c=threadstack: $worker_frames frames, expected a runaway recursion"
+fi
 
 # Everything above only proves the stack gets installed: the crashing worker
 # never returns, so the release hook never runs there. -#test=threadwait spawns

--- a/tests/183_altstack-worker.test
+++ b/tests/183_altstack-worker.test
@@ -66,12 +66,15 @@ plain_frames=$(frame_count "$plain")
 test "$plain_frames" -lt 100 ||
     fail "-#c=segv: $plain_frames frames, the threshold no longer discriminates"
 
-# armhf and loong64 cannot unwind out of the frame that faulted on the guard
-# page, leaving the handler's own three frames and nothing to count; 180 skips
-# on the same absolute floor, which a worker that merely stopped recursing
-# (11 frames, like the control) stays well clear of. Only this half goes blind
-# there: the release trace below still judges the same fix.
-if [ "$worker_frames" -lt 6 ]; then
+# Naming no frame at all is the unwinder failing outright, not a weak one, and
+# the floor below would take it for loong64. hts_print_backtrace() says which.
+if grep -q "No stack trace available" <<<"$worker"; then
+    fail "-#c=threadstack: the report carries no stack trace at all"
+fi
+
+# armhf and loong64 cannot unwind past the frame that faulted on the guard page
+# (180 skips on the same floor); the release trace below still judges the fix.
+if [ "$worker_frames" -ge 1 ] && [ "$worker_frames" -lt 6 ]; then
     echo "-#c=threadstack: $worker_frames frames, too few for this unwinder to" \
         "show the recursion" >&2
 elif [ "$worker_frames" -lt 100 ]; then

--- a/tests/altstackprobe.c
+++ b/tests/altstackprobe.c
@@ -192,10 +192,10 @@ static void *trace_mapped(void *sp) {
   return sp;
 }
 
-/* Reached only if dlsym() failed, and then it is the process's only mmap(), so
-   it has to be the right call: 32-bit arches have no SYS_mmap, and i386's wants
-   a pointer to an argument block, so prefer SYS_mmap2 wherever it exists. Its
-   offset is in 4096-byte units whatever the page size. */
+/* The fallback when dlsym() failed, so it has to be the right call: 32-bit
+   arches have no SYS_mmap and i386's wants a pointer to an argument block, so
+   prefer SYS_mmap2, whose offset is in 4096-byte units whatever the page size.
+ */
 static void *raw_mmap(void *addr, size_t len, int prot, int flags, int fd,
                       off_t off) {
 #ifdef SYS_mmap2

--- a/tests/altstackprobe.c
+++ b/tests/altstackprobe.c
@@ -192,10 +192,9 @@ static void *trace_mapped(void *sp) {
   return sp;
 }
 
-/* The fallback when dlsym() failed, so it has to be the right call: 32-bit
-   arches have no SYS_mmap and i386's wants a pointer to an argument block, so
-   prefer SYS_mmap2, whose offset is in 4096-byte units whatever the page size.
- */
+/* The fallback when dlsym() failed, so it has to be right: 32-bit arches have
+   no SYS_mmap and i386's wants an argument block, so prefer SYS_mmap2, whose
+   offset is in 4096-byte units whatever the page size. */
 static void *raw_mmap(void *addr, size_t len, int prot, int flags, int fd,
                       off_t off) {
 #ifdef SYS_mmap2

--- a/tests/altstackprobe.c
+++ b/tests/altstackprobe.c
@@ -14,10 +14,8 @@
 
 #define _GNU_SOURCE
 
-/* An interposer has to define the symbol names the process really calls, so the
-   largefile redirect must not rename them: on a 32-bit glibc it gives mmap()
-   below the asm name mmap64, colliding with the mmap64() beside it. _TIME_BITS
-   rides on _FILE_OFFSET_BITS and cannot outlive it. */
+/* The largefile redirect renames this file's mmap() to mmap64, colliding with
+   its own mmap64(). _TIME_BITS rides on _FILE_OFFSET_BITS, so it goes too. */
 #undef _FILE_OFFSET_BITS
 #undef _TIME_BITS
 

--- a/tests/altstackprobe.c
+++ b/tests/altstackprobe.c
@@ -14,6 +14,13 @@
 
 #define _GNU_SOURCE
 
+/* An interposer has to define the symbol names the process really calls, so the
+   largefile redirect must not rename them: on a 32-bit glibc it gives mmap()
+   below the asm name mmap64, colliding with the mmap64() beside it. _TIME_BITS
+   rides on _FILE_OFFSET_BITS and cannot outlive it. */
+#undef _FILE_OFFSET_BITS
+#undef _TIME_BITS
+
 #include <dlfcn.h>
 #include <fcntl.h>
 #include <signal.h>
@@ -187,6 +194,20 @@ static void *trace_mapped(void *sp) {
   return sp;
 }
 
+/* Reached only if dlsym() failed, and then it is the process's only mmap(), so
+   it has to be the right call: 32-bit arches have no SYS_mmap, and i386's wants
+   a pointer to an argument block, so prefer SYS_mmap2 wherever it exists. Its
+   offset is in 4096-byte units whatever the page size. */
+static void *raw_mmap(void *addr, size_t len, int prot, int flags, int fd,
+                      off_t off) {
+#ifdef SYS_mmap2
+  return (void *) syscall(SYS_mmap2, addr, len, prot, flags, fd,
+                          (unsigned long) (off / 4096));
+#else
+  return (void *) syscall(SYS_mmap, addr, len, prot, flags, fd, off);
+#endif
+}
+
 SHIM_EXPORT void *mmap(void *addr, size_t len, int prot, int flags, int fd,
                        off_t off);
 
@@ -194,10 +215,9 @@ SHIM_EXPORT void *mmap(void *addr, size_t len, int prot, int flags, int fd,
    between, so the thread's last mapping is the whole of the check. */
 SHIM_EXPORT void *mmap(void *addr, size_t len, int prot, int flags, int fd,
                        off_t off) {
-  return trace_mapped(
-      real_mmap != NULL
-          ? real_mmap(addr, len, prot, flags, fd, off)
-          : (void *) syscall(SYS_mmap, addr, len, prot, flags, fd, off));
+  return trace_mapped(real_mmap != NULL
+                          ? real_mmap(addr, len, prot, flags, fd, off)
+                          : raw_mmap(addr, len, prot, flags, fd, off));
 }
 
 /* glibc only, and the name that matters: _FILE_OFFSET_BITS=64 redirects the


### PR DESCRIPTION
3.49.17 failed on armhf, powerpc, hppa and loong64. Three of those were the same file failing to compile, and none of the four can happen on x86-64 or arm64, so the buildd was the first thing to see the code.

`tests/altstackprobe.c` is an LD_PRELOAD interposer, so it has to define the symbol names the process really calls. Debian builds the 32-bit time64 architectures with `-D_FILE_OFFSET_BITS=64`, under which glibc redirects a declared `mmap` to the symbol `mmap64`, the name the shim's own `mmap64` already takes. That is the assembler's "symbol `mmap64' is already defined" on hppa and powerpc. armhf never got that far: the raw-syscall fallback names `SYS_mmap`, which no 32-bit architecture has. i386 escaped both only because Debian left it out of the time64 transition, so it is not the control it looks like. The file now undefines the largefile macros, which also keeps `off_t` narrow enough for the `SYS_mmap2` page-offset conversion the fallback prefers wherever that call exists, i386 included.

Forcing those flags reproduces the collision on x86-64, so there is a red/green pair for it without a cross toolchain.

loong64 was a different bug: 183 asserted that a runaway recursion unwinds at least 100 frames, and loong64 cannot unwind out of the frame that faulted on the guard page, so it counted 5. 180 already documents that limitation and skips below a floor of 6; 183 was missing the same accommodation. Only the frame-counting half goes blind there, and the release trace after it still judges the fix. A report naming no frame at all stays a failure, since that is the unwinder giving up rather than a weak one.

The new Cross-arch workflow cross-compiles for nine architectures no runner exists for, under `debian:sid` with each architecture's own `dpkg-buildflags`, which is what puts `-D_FILE_OFFSET_BITS=64` on the command line in the first place. It builds the test shims too, since that is where three of the four failures were, and asserts the shim exists so an empty `TESTS=` cannot pass having built nothing. Two gaps worth naming: alpha has no cross libc in Debian, and no ports architecture has a cross libssl, so the TLS paths are the one part of the tree the matrix does not compile.