### PR TITLE
Release 3.49.18

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.71])
 
-AC_INIT([httrack], [3.49.17], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
+AC_INIT([httrack], [3.49.18], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
 AC_COPYRIGHT([
 HTTrack Website Copier, Offline Browser for Windows and Unix
 Copyright (C) 1998-2015 Xavier Roche and other contributors
@@ -29,6 +29,7 @@ AC_CONFIG_SRCDIR(src/httrack.c)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
+# 3:10:0: revision-only bump; only the version macro moved, the engine is untouched.
 # 3:9:0: revision-only bump. #991 and #1005 each added an export
 # (hts_set_thread_hooks, escape_control_url); nothing changed or went away.
 # 3:8:0: revision-only bump, no ABI change.
@@ -37,7 +38,7 @@ AM_INIT_AUTOMAKE([subdir-objects])
 # moves nothing). Soname stays .so.3: HTTrackQt is the only consumer of the installed
 # headers, so a libhttrack4 rename isn't worth it.
 # (3:0:0 was the htsblk mime-buffer widening, the ABI break that moved .so.2 -> .so.3.)
-VERSION_INFO="3:9:0"
+VERSION_INFO="3:10:0"
 AM_MAINTAINER_MODE
 AC_USE_SYSTEM_EXTENSIONS
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+httrack (3.49.18-1) unstable; urgency=medium
+
+  * New upstream release, fixing the 3.49.17-1 build failures on armhf, powerpc,
+    hppa and loong64: the test suite's mmap interposer did not compile on the
+    first three, and the alternate-stack test insisted on a longer backtrace than
+    loong64's unwinder produces. Nothing in the engine changed. Upstream now
+    cross-builds the test shims for the ports architectures on every push, so the
+    next such break surfaces before the buildds do.
+
+ -- Xavier Roche <xavier@debian.org>  Wed, 05 Aug 2026 23:00:24 +0200
+
 httrack (3.49.17-1) unstable; urgency=medium
 
   * New upstream release: security fixes in the FTP and HTTP request paths and

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,12 @@
 httrack (3.49.18-1) unstable; urgency=medium
 
-  * New upstream release, fixing the 3.49.17-1 build failures on armhf, powerpc,
-    hppa and loong64: the test suite's mmap interposer did not compile on the
-    first three, and the alternate-stack test insisted on a longer backtrace than
-    loong64's unwinder produces. Nothing in the engine changed. Upstream now
-    cross-builds the test shims for the ports architectures on every push, so the
-    next such break surfaces before the buildds do.
+  * New upstream release, fixing the 3.49.17-1 build failures on armhf,
+    powerpc, hppa and loong64: the test suite's mmap interposer did not
+    compile on the first three, and the alternate-stack test insisted on a
+    longer backtrace than loong64's unwinder produces. Nothing in the engine
+    changed. Upstream now cross-builds the test shims for the ports
+    architectures on every push, so the next such break surfaces before the
+    buildds do.
 
  -- Xavier Roche <xavier@debian.org>  Wed, 05 Aug 2026 23:00:24 +0200
 

--- a/history.txt
+++ b/history.txt
@@ -4,6 +4,10 @@ HTTrack Website Copier release history:
 
 This file lists all changes and fixes that have been made for HTTrack
 
+3.49-18
++ Fixed: the 3.49.17 package build failed on four architectures: the test suite's mmap interposer did not compile on armhf, powerpc or hppa, and the alternate-stack test rejected loong64's shorter backtrace (#1023)
++ Fixed: the test suite failed on a host with no ps command, such as a Fedora build root, its watchdog reporting an empty process list rather than an error (#1021)
+
 3.49-17
 + New: a pkg-config file, libhttrack.pc, ships with the development headers (#1018)
 + Fixed: a crawled page could read the WebHTTrack session id and drive the control panel; the id is now unguessable and cross-origin commands are refused (#877)

--- a/history.txt
+++ b/history.txt
@@ -6,7 +6,8 @@ This file lists all changes and fixes that have been made for HTTrack
 
 3.49-18
 + Fixed: the 3.49.17 package build failed on four architectures: the test suite's mmap interposer did not compile on armhf, powerpc or hppa, and the alternate-stack test rejected loong64's shorter backtrace (#1023)
-+ Fixed: the test suite failed on a host with no ps command, such as a Fedora build root, its watchdog reporting an empty process list rather than an error (#1021)
++ Fixed: the test suite failed on a host with no ps command, such as a Fedora build root; its hang diagnostics now read /proc directly (#1021)
++ Changed: multiple internal test and CI improvements, including a cross-compile matrix covering the Debian ports architectures
 
 3.49-17
 + New: a pkg-config file, libhttrack.pc, ships with the development headers (#1018)

--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -51,6 +51,13 @@
   <content_rating type="oars-1.1"/>
   <!-- Newest first; tests/01_engine-version-macros.test enforces it. -->
   <releases>
+    <release version="3.49.18" date="2026-08-05">
+      <description>
+        <ul>
+          <li>The program itself is unchanged: this release only fixes building HTTrack from source on some Linux distributions and processors</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.49.17" date="2026-08-05">
       <description>
         <ul>

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -43,8 +43,8 @@ Please visit our Website: http://www.httrack.com
    configure.ac, decoupled from these). VERSION is the display form, VERSIONID
    the dotted numeric form, AFF_VERSION the short form shown in footers,
    LIB_VERSION the data/cache format generation. */
-#define HTTRACK_VERSION "3.49-17"
-#define HTTRACK_VERSIONID "3.49.17"
+#define HTTRACK_VERSION "3.49-18"
+#define HTTRACK_VERSIONID "3.49.18"
 #define HTTRACK_AFF_VERSION "3.x"
 #define HTTRACK_LIB_VERSION "2.0"
 

--- a/src/version.rc
+++ b/src/version.rc
@@ -17,8 +17,8 @@
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-  FILEVERSION 3, 49, 17, 0
-  PRODUCTVERSION 3, 49, 17, 0
+  FILEVERSION 3, 49, 18, 0
+  PRODUCTVERSION 3, 49, 18, 0
   FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
 #ifdef _DEBUG
   FILEFLAGS VS_FF_DEBUG
@@ -35,12 +35,12 @@ BEGIN
     BEGIN
       VALUE "CompanyName", "Xavier Roche"
       VALUE "FileDescription", VER_FILE_DESCRIPTION
-      VALUE "FileVersion", "3.49.17"
+      VALUE "FileVersion", "3.49.18"
       VALUE "InternalName", VER_ORIGINAL_FILENAME
       VALUE "LegalCopyright", "Copyright (C) 1998-2026 Xavier Roche and other contributors. GNU GPL v3 or later."
       VALUE "OriginalFilename", VER_ORIGINAL_FILENAME
       VALUE "ProductName", "HTTrack Website Copier"
-      VALUE "ProductVersion", "3.49-17"
+      VALUE "ProductVersion", "3.49-18"
     END
   END
   BLOCK "VarFileInfo"


### PR DESCRIPTION
A source-only release so packagers can pick up the test-suite build fixes that landed after 3.49.17. Debian's buildds rejected 3.49.17-1 on armhf, powerpc, hppa and loong64, and a Fedora build root failed the suite for want of `ps`. Both are fixed on master (#1023, #1022), but a packager only sees them through a release.

Nothing in the engine changed: the only edit under `src/` is the version macro, so `VERSION_INFO` moves by revision alone (3:9:0 to 3:10:0) and the soname stays `libhttrack.so.3`. Verified out-of-tree: `libhttrack.so.3.0.10`, SONAME `libhttrack.so.3`, 257 tests and no failures.
