### PR TITLE
The suite watchdog cannot see the engine on an emulated buildd

### DIFF
--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -190,12 +190,19 @@ if ! is_windows && test -r /proc/self/stat; then
         stacks=$(request_engine_backtraces "$pgid")
         ! grep -q 'no engine process left' <<<"$stacks" ||
             fail "no-ps stack request found no engine to signal: $stacks"
-        # Gone, or a zombie: the fake is reparented, and a container's pid 1 does
-        # not always reap. kill -0 alone succeeds on a zombie and proves nothing.
-        case "$(procstate "$fake")" in
-        Z | gone) ;;
-        *) fail "the SIGABRT never reached pid $fake" ;;
-        esac
+        # Only Linux signals; elsewhere (Hurd's uname reports "GNU") the chain has
+        # to say it knows no mechanism instead of silently doing nothing.
+        if test "$(uname -s)" = Linux; then
+            # Gone, or a zombie: the fake is reparented, and a container's pid 1
+            # does not always reap. kill -0 succeeds on a zombie, proving nothing.
+            case "$(procstate "$fake")" in
+            Z | gone) ;;
+            *) fail "the SIGABRT never reached pid $fake" ;;
+            esac
+        else
+            grep -q 'no stack mechanism known' <<<"$stacks" ||
+                fail "no stack mechanism was reported on $(uname -s): $stacks"
+        fi
         # With neither source the dump must say so, not print an empty section.
         # shellcheck disable=SC2317 # reached through ps_snapshot
         proc_snapshot() { return 1; }
@@ -203,6 +210,33 @@ if ! is_windows && test -r /proc/self/stat; then
             fail "a host with no ps and no /proc produced no notice"
     )
     kill "$fake" "$outside" 2>/dev/null || true
+fi
+
+# --- an emulated buildd hides the engine behind its binfmt interpreter -------
+# Under qemu-user the engine is the interpreter's first argument, and a matcher
+# reading the command column alone finds nothing to name or signal. Synthetic
+# rows: no runner has qemu-user, and the column shift is the whole point.
+if ! is_windows; then
+    (
+        # shellcheck disable=SC2317 # reached through the two matchers below
+        ps_snapshot() {
+            cat <<'EOF'
+PID PPID PGID ELAPSED S COMMAND
+11 1 40 12 S /usr/libexec/qemu-binfmt/hppa-binfmt-P /bld/src/httrack -q http://h/
+12 1 40 12 S /usr/bin/qemu-hppa-static /usr/bin/python3 /t/local-server.py 8080
+13 1 40 12 S /bld/src/httrack -q http://h/
+14 1 40 12 S /usr/bin/strace /bld/src/httrack -q http://h/
+EOF
+        }
+        # Row 14 is the control: matching the argument unconditionally would take
+        # any wrapper for the engine and signal that instead.
+        engines=$(list_engine_pids 40)
+        test "$engines" = $'11\n13' ||
+            fail "emulated engine list is '$engines', want pids 11 and 13"
+        named=$(list_stray_processes 0 named | awk 'NR > 1 { print $1 }')
+        test "$named" = $'11\n12\n13' ||
+            fail "emulated stray list is '$named', want pids 11, 12 and 13"
+    )
 fi
 
 # --- a wedged crawl yields a symbolized engine stack ------------------------

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -186,12 +186,26 @@ if ! is_windows && test -r /proc/self/stat; then
         grep -qx "$fake" <<<"$engines" || fail "no-ps engine list lost pid $fake"
         ! grep -qx "$outside" <<<"$engines" ||
             fail "no-ps engine list reached outside the group (pid $outside)"
+        # A platform with no stack mechanism must say so and leave the engine
+        # alone. Shimmed, because no CI leg is one: the Hurd branch below runs
+        # only on the buildds that failed for want of it.
+        # shellcheck disable=SC2016 # the shim reads them, not us
+        printf '#!/bin/sh\ncase "$1" in -s) echo GNU;; *) exec %s "$@";; esac\n' \
+            "$(command -v uname)" >"$tmp/nops/uname"
+        chmod +x "$tmp/nops/uname"
+        grep -q "no stack mechanism known for GNU" <<<"$(request_engine_backtraces "$pgid")" ||
+            fail "a platform with no stack mechanism reported nothing"
+        case "$(procstate "$fake")" in
+        Z | gone) fail "the no-mechanism branch signalled pid $fake" ;;
+        esac
+        rm -f "$tmp/nops/uname"
+
         # The chain, not just its input: this is what reported nothing on Fedora.
         stacks=$(request_engine_backtraces "$pgid")
         ! grep -q 'no engine process left' <<<"$stacks" ||
             fail "no-ps stack request found no engine to signal: $stacks"
-        # Only Linux signals; elsewhere (Hurd's uname reports "GNU") the chain has
-        # to say it knows no mechanism instead of silently doing nothing.
+        # Only Linux signals; elsewhere (Hurd's uname reports "GNU") the chain
+        # owes the reader its no-mechanism report instead of silence.
         if test "$(uname -s)" = Linux; then
             # Gone, or a zombie: the fake is reparented, and a container's pid 1
             # does not always reap. kill -0 succeeds on a zombie, proving nothing.
@@ -213,9 +227,7 @@ if ! is_windows && test -r /proc/self/stat; then
 fi
 
 # --- an emulated buildd hides the engine behind its binfmt interpreter -------
-# Under qemu-user the engine is the interpreter's first argument, and a matcher
-# reading the command column alone finds nothing to name or signal. Synthetic
-# rows: no runner has qemu-user, and the column shift is the whole point.
+# Synthetic rows: no runner here has qemu-user, and the column shift is the point.
 if ! is_windows; then
     (
         # shellcheck disable=SC2317 # reached through the two matchers below
@@ -226,10 +238,13 @@ PID PPID PGID ELAPSED S COMMAND
 12 1 40 12 S /usr/bin/qemu-hppa-static /usr/bin/python3 /t/local-server.py 8080
 13 1 40 12 S /bld/src/httrack -q http://h/
 14 1 40 12 S /usr/bin/strace /bld/src/httrack -q http://h/
+15 1 40 12 S /usr/bin/qemu-img convert /srv/local-server.py out.raw
+16 1 40 12 S /usr/bin/qemu-nbd /mnt/httrack
+17 1 40 12 S /opt/my-custom-binfmt /mnt/httrack
 EOF
         }
-        # Row 14 is the control: matching the argument unconditionally would take
-        # any wrapper for the engine and signal that instead.
+        # Rows 14 to 17 are the controls: shifting past anything but an emulator
+        # would take a wrapper, or a disk image, for the engine and kill it.
         engines=$(list_engine_pids 40)
         test "$engines" = $'11\n13' ||
             fail "emulated engine list is '$engines', want pids 11 and 13"

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -184,7 +184,10 @@ AWK_PROC_NAMES='
 function basen(s) { sub(/.*[\/\\]/, "", s); return s }
 function qemushift(  n) {
     n = basen($6)
-    return n ~ /^qemu-[[:alnum:]_]+(-static)?$|-binfmt(-[[:upper:]]+)?$/ ? 1 : 0
+    # qemu-img and friends take an image, not a program, and this list is fed to
+    # kill: shifting past them would read a disk path as the process name.
+    if (n ~ /^qemu-(img|nbd|io|ga|edid|keymap)$/) return 0
+    return n ~ /^qemu-[[:alnum:]_]+(-static)?$|^[[:alnum:]_]+-binfmt(-[[:upper:]]+)?$/ ? 1 : 0
 }'
 
 # Every process as "PID PPID PGID ELAPSED S COMMAND", header first. A Fedora

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -176,6 +176,17 @@ kill_tree() {
 ENGINE_EXE_RE='^(lt-)?(httrack|proxytrack|htsserver|webhttrack)([.]exe)?$'
 FIXTURE_SERVER_RE='^(local-server|proxy-https-server|proxy-connect-server|socks5-server|tls-stall-server)[.]py$'
 
+# awk prologue for the matchers below: under qemu-user the kernel reports the
+# binfmt interpreter as the command, so the name we match on lands one column
+# right (Debian's hppa buildd emulates).
+# shellcheck disable=SC2016 # awk fields, not shell expansions
+AWK_PROC_NAMES='
+function basen(s) { sub(/.*[\/\\]/, "", s); return s }
+function qemushift(  n) {
+    n = basen($6)
+    return n ~ /^qemu-[[:alnum:]_]+(-static)?$|-binfmt(-[[:upper:]]+)?$/ ? 1 : 0
+}'
+
 # Every process as "PID PPID PGID ELAPSED S COMMAND", header first. A Fedora
 # build root has no procps, and an empty list reads as "nothing running" (#1021).
 ps_snapshot() {
@@ -243,11 +254,13 @@ list_stray_processes() {
         # Fields 6 and 7 are the command and its first argument (the interpreter
         # and its script, for the Python fixtures).
         ps_snapshot |
-            awk -v pg="$pgid" -v mode="$mode" -v eng="$ENGINE_EXE_RE" -v srv="$FIXTURE_SERVER_RE" '
+            awk -v pg="$pgid" -v mode="$mode" -v eng="$ENGINE_EXE_RE" -v srv="$FIXTURE_SERVER_RE" \
+                "$AWK_PROC_NAMES"'
                 NR == 1 { print; next }
                 { ingroup = (pg > 0 && $3 == pg)
-                  c = $6; sub(/.*[\/\\]/, "", c)
-                  s = $7; sub(/.*[\/\\]/, "", s)
+                  q = qemushift()
+                  c = basen($(6 + q))
+                  s = basen($(7 + q))
                   named = (c ~ eng || s ~ srv)
                   if (mode == "group" ? ingroup : \
                       mode == "named" ? named : (named && !ingroup)) print }' || true
@@ -289,8 +302,8 @@ list_engine_pids() {
     local pgid=${1:-0}
     test "$pgid" -gt 0 2>/dev/null || return 0
     ps_snapshot |
-        awk -v pg="$pgid" -v eng="$ENGINE_EXE_RE" \
-            'NR > 1 && $3 == pg { c = $6; sub(/.*[\/\\]/, "", c); if (c ~ eng) print $1 }'
+        awk -v pg="$pgid" -v eng="$ENGINE_EXE_RE" "$AWK_PROC_NAMES"'
+            NR > 1 && $3 == pg { if (basen($(6 + qemushift())) ~ eng) print $1 }'
 }
 
 # Ask the wedged test's engine processes for a stack. What is obtainable differs


### PR DESCRIPTION
3.49.18-1 failed to build on hppa, hurd-amd64 and hurd-i386: the suite watchdog cannot see the engine on an emulated buildd, and 105_suite-timeout asserted a SIGABRT on platforms that never send one.

Under qemu-user the process the kernel reports is the binfmt interpreter and the engine is only its first argument, so the name matchers now skip an interpreter before reading the command, gated on the interpreter's own name. Shifting past anything else would take a wrapper (strace) or an image tool (qemu-img, whose argument is a disk, not a program) for the engine and feed it to kill, which is what the control rows pin. `request_engine_backtraces` only signals on Linux, so the test asserts the death there and, through a `uname` shim, the "no stack mechanism known" report on the platforms that get none. No CI leg is one of those.

Both buildd failures reproduce here, message for message, against the synthetic process rows and the shim.

Closes #1025