### PR TITLE
The --changes example names a version that keeps going stale

### DIFF
--- a/html/changes.html
+++ b/html/changes.html
@@ -155,6 +155,8 @@ rather than on <tt>url</tt> when a mirror is known to carry legacy-charset URLs.
 
 <h3 id="example">Example</h3>
 
+One captured run; <tt>generator</tt> and <tt>date</tt> will read differently in yours.
+
 <pre>
 {
   "schema": 1,


### PR DESCRIPTION
The --changes example in html/changes.html hardcoded a generator/date pair that will always drift from whatever a reader's own run produces. Both fields are stamped fresh every run (htschanges.c sets HTTRACK_VERSION and the current time), so dropping them would misrepresent the payload's shape. Instead the example now says it is one captured run, so a mismatched version or date reads as expected rather than as a bug.

I checked the rest of html/ for the same defect: html/cache.html has an old 3.31-ALPHA-4 sample, but that page documents the cache.zip format as it looked when introduced, with 2003/2004 dates throughout, so it already reads as historical rather than current. No other sibling found.

Closes #1007