### PR TITLE
The installed socket headers still need -D_POSIX_C_SOURCE under -std=c99

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,8 @@ AC_CONFIG_SRCDIR(src/httrack.c)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
+# 3:11:0: revision-only bump. #1001 moved SOCaddr_inetntoa_ out of htsnet.h, adding
+# an export where callers had an inline; nothing changed or went away.
 # 3:10:0: revision-only bump; only the version macro moved, the engine is untouched.
 # 3:9:0: revision-only bump. #991 and #1005 each added an export
 # (hts_set_thread_hooks, escape_control_url); nothing changed or went away.
@@ -38,7 +40,7 @@ AM_INIT_AUTOMAKE([subdir-objects])
 # moves nothing). Soname stays .so.3: HTTrackQt is the only consumer of the installed
 # headers, so a libhttrack4 rename isn't worth it.
 # (3:0:0 was the htsblk mime-buffer widening, the ABI break that moved .so.2 -> .so.3.)
-VERSION_INFO="3:10:0"
+VERSION_INFO="3:11:0"
 AM_MAINTAINER_MODE
 AC_USE_SYSTEM_EXTENSIONS
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -43,7 +43,8 @@ htsserver_LDADD = $(THREADS_LIBS) $(SOCKET_LIBS) libhttrack.la
 proxytrack_LDADD = $(THREADS_LIBS) $(SOCKET_LIBS)
 
 httrack_CFLAGS = $(AM_CFLAGS) $(CFLAGS_PIE)
-proxytrack_CFLAGS = $(AM_CFLAGS) $(CFLAGS_PIE) -DNO_MALLOCT -DZLIB_CONST -DHTS_INTHASH_USES_MD5
+# -DHTS_NO_LIBHTTRACK: proxytrack compiles htsnet.c in instead of linking the library.
+proxytrack_CFLAGS = $(AM_CFLAGS) $(CFLAGS_PIE) -DNO_MALLOCT -DZLIB_CONST -DHTS_INTHASH_USES_MD5 -DHTS_NO_LIBHTTRACK
 htsserver_CFLAGS = $(AM_CFLAGS) $(CFLAGS_PIE) -DZLIB_CONST -DHTS_INTHASH_USES_MD5
 
 # @RPATH_ORIGIN_LDFLAGS@ makes a copied tree find libhttrack next to it (#906),
@@ -59,7 +60,7 @@ htsserver_SOURCES = htsserver.c htsserver.h htsweb.c htsweb.h htsstats.h \
 	htsurlport.c htsurlport.h
 proxytrack_SOURCES = proxy/main.c \
 	proxy/proxytrack.c proxy/store.c \
-	htsurlport.c htsurlport.h \
+	htsurlport.c htsurlport.h htsnet.c \
 	coucal/coucal.c htsmd5.c md5.c \
 	minizip/ioapi.c minizip/mztools.c minizip/unzip.c minizip/zip.c
 
@@ -80,7 +81,7 @@ libhttrack_la_SOURCES =  htscore.c htsparse.c htsback.c htscache.c \
 	htsname.c htsrobots.c htstools.c htswizard.c \
 	htsalias.c htsthread.c htsindex.c htsbauth.c \
 	htscrashtest.c \
-	htsmd5.c htscodec.c htswarc.c htschanges.c htssinglefile.c htssitemap.c htsproxy.c htszlib.c htswrap.c htsconcat.c \
+	htsmd5.c htsnet.c htscodec.c htswarc.c htschanges.c htssinglefile.c htssitemap.c htsproxy.c htszlib.c htswrap.c htsconcat.c \
 	htsmodules.c htscharset.c punycode.c htsencoding.c htssniff.c \
 	md5.c \
 	minizip/ioapi.c minizip/mztools.c minizip/unzip.c minizip/zip.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -43,7 +43,7 @@ htsserver_LDADD = $(THREADS_LIBS) $(SOCKET_LIBS) libhttrack.la
 proxytrack_LDADD = $(THREADS_LIBS) $(SOCKET_LIBS)
 
 httrack_CFLAGS = $(AM_CFLAGS) $(CFLAGS_PIE)
-# -DHTS_NO_LIBHTTRACK: proxytrack compiles htsnet.c in instead of linking the library.
+# -DHTS_NO_LIBHTTRACK: see htsnet.h's HTSNET_API guard.
 proxytrack_CFLAGS = $(AM_CFLAGS) $(CFLAGS_PIE) -DNO_MALLOCT -DZLIB_CONST -DHTS_INTHASH_USES_MD5 -DHTS_NO_LIBHTTRACK
 htsserver_CFLAGS = $(AM_CFLAGS) $(CFLAGS_PIE) -DZLIB_CONST -DHTS_INTHASH_USES_MD5
 

--- a/src/htsnet.c
+++ b/src/htsnet.c
@@ -1,0 +1,52 @@
+/* ------------------------------------------------------------ */
+/*
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) 2026 Xavier Roche and other contributors
+
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Ethical use: we kindly ask that you NOT use this software to harvest email
+addresses or to collect any other private information about people. Doing so
+would dishonor our work and waste the many hours we have spent on it.
+
+Please visit our Website: http://www.httrack.com
+*/
+
+/* ------------------------------------------------------------ */
+/* File: Out-of-line htsnet.h helpers, kept here so the installed */
+/*       header needs nothing beyond strict ISO C                 */
+/* Author: Xavier Roche                                           */
+/* ------------------------------------------------------------ */
+
+#include "htsnet.h"
+
+HTSNET_API void SOCaddr_inetntoa_(char *namebuf, size_t namebuflen,
+                                  SOCaddr *const ss, const char *file,
+                                  const int line) {
+  assertf_(namebuf != NULL, file, line);
+  assertf_(ss != NULL, file, line);
+
+  if (getnameinfo(&ss->m_addr.sa, sizeof(ss->m_addr), namebuf, namebuflen, NULL,
+                  0, NI_NUMERICHOST) == 0) {
+    /* remove scope id(s) */
+    char *const pos = strchr(namebuf, '%');
+    if (pos != NULL) {
+      *pos = '\0';
+    }
+  } else {
+    namebuf[0] = '\0';
+  }
+}

--- a/src/htsnet.h
+++ b/src/htsnet.h
@@ -282,9 +282,8 @@ static HTS_UNUSED socklen_t SOCaddr_copyaddr_(SOCaddr *const server,
 #endif
 
 /** Write the numeric (dotted/colon) host of ss into namebuf (capacity
-    namebuflen), scope id stripped. On failure namebuf becomes "". Out of line
-    so this header stays free of getnameinfo(), which no libc declares to a
-    strict-ISO translation unit (#1001). */
+    namebuflen), scope id stripped. On failure namebuf becomes "". Out of line:
+    getnameinfo() isn't declared to a strict-ISO translation unit (#1001). */
 HTSNET_API void SOCaddr_inetntoa_(char *namebuf, size_t namebuflen,
                                   SOCaddr *const ss, const char *file,
                                   const int line);

--- a/src/htsnet.h
+++ b/src/htsnet.h
@@ -273,25 +273,21 @@ static HTS_UNUSED socklen_t SOCaddr_copyaddr_(SOCaddr *const server,
                       __LINE__);                                               \
   } while (0)
 
-/** Write the numeric (dotted/colon) host of ss into namebuf (capacity
-    namebuflen), scope id stripped. On failure namebuf becomes "". */
-static HTS_UNUSED void SOCaddr_inetntoa_(char *namebuf, size_t namebuflen,
-                                         SOCaddr *const ss, const char *file,
-                                         const int line) {
-  assertf_(namebuf != NULL, file, line);
-  assertf_(ss != NULL, file, line);
+/* proxytrack compiles htsnet.c in rather than linking the library, and MSVC
+   rejects a dllimport definition. */
+#ifdef HTS_NO_LIBHTTRACK
+#define HTSNET_API
+#else
+#define HTSNET_API HTSEXT_API
+#endif
 
-  if (getnameinfo(&ss->m_addr.sa, sizeof(ss->m_addr), namebuf, namebuflen, NULL,
-                  0, NI_NUMERICHOST) == 0) {
-    /* remove scope id(s) */
-    char *const pos = strchr(namebuf, '%');
-    if (pos != NULL) {
-      *pos = '\0';
-    }
-  } else {
-    namebuf[0] = '\0';
-  }
-}
+/** Write the numeric (dotted/colon) host of ss into namebuf (capacity
+    namebuflen), scope id stripped. On failure namebuf becomes "". Out of line
+    so this header stays free of getnameinfo(), which no libc declares to a
+    strict-ISO translation unit (#1001). */
+HTSNET_API void SOCaddr_inetntoa_(char *namebuf, size_t namebuflen,
+                                  SOCaddr *const ss, const char *file,
+                                  const int line);
 
 /** Numeric host of ss into namebuf (capacity namebuflen); "" on failure. */
 #define SOCaddr_inetntoa(namebuf, namebuflen, ss)                              \

--- a/src/libhttrack.vcxproj
+++ b/src/libhttrack.vcxproj
@@ -126,6 +126,7 @@
     <ClCompile Include="htscmdline.c" />
     <ClCompile Include="htsurlport.c" />
     <ClCompile Include="htsmd5.c" />
+    <ClCompile Include="htsnet.c" />
     <ClCompile Include="htsmodules.c" />
     <ClCompile Include="htsname.c" />
     <ClCompile Include="htsparse.c" />

--- a/src/proxytrack.vcxproj
+++ b/src/proxytrack.vcxproj
@@ -57,7 +57,7 @@
     <ClCompile>
       <!-- Matches proxytrack_CFLAGS in Makefile.am. Standalone: it does not link
            libhttrack, it only borrows headers (hts_effective_mime is a macro). -->
-      <PreprocessorDefinitions>WIN32;_CONSOLE;_MBCS;NO_MALLOCT;ZLIB_CONST;HTS_INTHASH_USES_MD5;ZLIB_DLL;WINVER=0x0601;_WIN32_WINNT=0x0601;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_CONSOLE;_MBCS;NO_MALLOCT;HTS_NO_LIBHTTRACK;ZLIB_CONST;HTS_INTHASH_USES_MD5;ZLIB_DLL;WINVER=0x0601;_WIN32_WINNT=0x0601;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory);$(MSBuildThisFileDirectory)coucal;$(MSBuildThisFileDirectory)proxy;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level3</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -100,6 +100,7 @@
     <ClCompile Include="proxy\proxytrack.c" />
     <ClCompile Include="proxy\store.c" />
     <ClCompile Include="htsurlport.c" />
+    <ClCompile Include="htsnet.c" />
     <ClCompile Include="coucal\coucal.c" />
     <ClCompile Include="htsmd5.c" />
     <ClCompile Include="md5.c" />

--- a/tests/206_install-headers-c99.test
+++ b/tests/206_install-headers-c99.test
@@ -88,8 +88,24 @@ env MAKEFLAGS= MFLAGS= "$make" -C "$abs_top_builddir/src" install-DevIncludesDAT
     }
 
 headers=("$tmp/include/httrack"/*.h)
-[ "${#headers[@]}" -ge 10 ] || fail "only ${#headers[@]} headers installed, the list cannot be right"
-[ -f "$tmp/include/httrack/htssafe.h" ] || fail "htssafe.h was not installed"
+# Derived from DevIncludes_DATA so a new header needs no edit here. A header
+# dropped from that list moves both sides, hence the named checks below.
+declared=$(awk '/^DevIncludes_DATA[[:space:]]*=/ { inlist = 1 }
+    inlist {
+        last = ($0 !~ /\\$/)
+        sub(/^[^=]*=/, "")
+        gsub(/\\/, " ")
+        for (i = 1; i <= NF; i++)
+            if ($i ~ /\.h$/) n++
+        if (last) exit
+    }
+    END { print n + 0 }' "${abs_top_srcdir:?}/src/Makefile.am")
+[ "$declared" -ge 10 ] || fail "read only $declared headers out of DevIncludes_DATA, the parse is wrong"
+[ "${#headers[@]}" -eq "$declared" ] ||
+    fail "${#headers[@]} headers installed, DevIncludes_DATA declares $declared"
+for h in htssafe.h htsnet.h htsopt.h; do
+    [ -f "$tmp/include/httrack/$h" ] || fail "$h was not installed"
+done
 
 # No -D_POSIX_C_SOURCE anywhere below: every installed header, htsnet.h and
 # htsopt.h included, must compile against the strict-ISO libc alone (#1001).
@@ -110,6 +126,7 @@ for h in "${headers[@]}"; do
     done
 done
 echo "compiled ${#headers[@]} headers x ${#stds[@]} std x 2 bytecode modes = $count units" >&2
+[ "$count" -eq $((${#headers[@]} * ${#stds[@]} * 2)) ] || fail "the compile loop skipped units"
 [ "$bad" -eq 0 ] || fail "installed headers do not compile in strict-ISO mode"
 
 # A macro body is only compiled where it expands, so the include-only loop above
@@ -166,19 +183,23 @@ int main(void) {
   return 0;
 }
 EOF
+# Vacuous if the gate handed us libc's strnlen. Match that branch, not the
+# loop, or a mutated loop reads as a lost fallback instead. Needs no runnable
+# binary, so it stays outside the gate below.
+for std in "${stds[@]}"; do
+    pp=$("${cc_argv[@]}" "${cpp_argv[@]}" "-std=$std" -E "$tmp/strnlen.c") ||
+        fail "cannot preprocess the htssafe_strnlen_ probe under -std=$std"
+    if grep -q 'return strnlen' <<<"$pp"; then
+        fail "-std=$std left htssafe_strnlen_ on libc, the differential proves nothing"
+    fi
+done
+
 # A noexec TMPDIR or a cross-compiler would red the run for the wrong reason.
 printf 'int main(void) { return 0; }\n' >"$tmp/tu.c"
 if ! ("${cc_argv[@]}" "${cpp_argv[@]}" -o "$tmp/tu" "$tmp/tu.c" 2>/dev/null && "$tmp/tu"); then
     echo "cannot run a binary built in $tmp, skipping the htssafe_strnlen_ differential" >&2
 else
     for std in "${stds[@]}"; do
-        # Vacuous if the gate handed us libc's strnlen. Match that branch, not
-        # the loop, or a mutated loop reads as a lost fallback instead.
-        pp=$("${cc_argv[@]}" "${cpp_argv[@]}" "-std=$std" -E "$tmp/strnlen.c") ||
-            fail "cannot preprocess the htssafe_strnlen_ probe under -std=$std"
-        if grep -q 'return strnlen' <<<"$pp"; then
-            fail "-std=$std left htssafe_strnlen_ on libc, the check below proves nothing"
-        fi
         "${cc_argv[@]}" "${cpp_argv[@]}" "-std=$std" -o "$tmp/strnlen" "$tmp/strnlen.c" 2>"$tmp/cc.log" || {
             head -5 "$tmp/cc.log" >&2
             fail "the htssafe_strnlen_ probe does not build under -std=$std"

--- a/tests/206_install-headers-c99.test
+++ b/tests/206_install-headers-c99.test
@@ -91,29 +91,17 @@ headers=("$tmp/include/httrack"/*.h)
 [ "${#headers[@]}" -ge 10 ] || fail "only ${#headers[@]} headers installed, the list cannot be right"
 [ -f "$tmp/include/httrack/htssafe.h" ] || fail "htssafe.h was not installed"
 
-# No libc hands getnameinfo() to a strict-ISO unit, so a consumer of the two
-# socket headers must ask for POSIX. Prefer 2001: 2008 also un-hides strnlen,
-# which would stop those two covering that half of #972.
-posix_argv=(-D_POSIX_C_SOURCE=200112L)
-printf '#include <httrack/htsnet.h>\n' >"$tmp/tu.c"
-if ! "${cc_argv[@]}" "${cpp_argv[@]}" "${posix_argv[@]}" "-std=${stds[0]}" \
-    -fsyntax-only "$tmp/tu.c" 2>/dev/null; then
-    fail "htsnet.h needs POSIX.1-2008, which un-hides strnlen and would leave that half of #972 uncovered"
-fi
-
+# No -D_POSIX_C_SOURCE anywhere below: every installed header, htsnet.h and
+# htsopt.h included, must compile against the strict-ISO libc alone (#1001).
 count=0
 bad=0
 for h in "${headers[@]}"; do
     b=$(basename "$h")
-    argv=("${cpp_argv[@]}")
-    case "$b" in
-    htsnet.h | htsopt.h) argv+=("${posix_argv[@]}") ;;
-    esac
     printf '#include <httrack/%s>\n' "$b" >"$tmp/tu.c"
     for std in "${stds[@]}"; do
         for mode in -UHTS_INTERNAL_BYTECODE -DHTS_INTERNAL_BYTECODE; do
             count=$((count + 1))
-            if ! "${cc_argv[@]}" "${argv[@]}" "-std=$std" "$mode" -fsyntax-only "$tmp/tu.c" 2>"$tmp/cc.log"; then
+            if ! "${cc_argv[@]}" "${cpp_argv[@]}" "-std=$std" "$mode" -fsyntax-only "$tmp/tu.c" 2>"$tmp/cc.log"; then
                 echo "$b does not compile under -std=$std ($mode):" >&2
                 head -5 "$tmp/cc.log" >&2
                 bad=1
@@ -221,9 +209,6 @@ else
     for h in "${headers[@]}"; do
         b=$(basename "$h")
         argv=("${base_cpp_argv[@]}" -Wall -Wextra -Werror)
-        case "$b" in
-        htsnet.h | htsopt.h) argv+=("${posix_argv[@]}") ;;
-        esac
         printf '#include <httrack/%s>\nint main() { return 0; }\n' "$b" >"$tmp/tu.cpp"
         for std in "${cxx_stds[@]}"; do
             for mode in -UHTS_INTERNAL_BYTECODE -DHTS_INTERNAL_BYTECODE; do


### PR DESCRIPTION
`htsnet.h` and `htsopt.h` were the last installed headers a strict-ISO consumer had to prefix with `-D_POSIX_C_SOURCE`, and `tests/206` carried an exception for exactly those two. All of it came from one inline body: `SOCaddr_inetntoa_` calls `getnameinfo()` and `NI_NUMERICHOST`, and no libc declares either to a `__STRICT_ANSI__` translation unit. The body moves to a new `src/htsnet.c`, the exception in 206 goes away, and all fourteen installed headers now compile under `-std=c99` and `-std=c11` against the strict-mode libc. Putting the inline back makes 206 fail on both headers in both std modes, so the coverage is real and not a vacuous pass.

What the diff cannot show is the ABI side. This turns a `static inline` into an exported symbol, which is an addition rather than a break, so `VERSION_INFO` moves to `3:11:0` as a revision-only bump and the soname and the Debian package stay put; `configure.ac` records the same reasoning for `3:9:0`. `proxytrack` does not link libhttrack, so it compiles `htsnet.c` in directly under `-DHTS_NO_LIBHTTRACK`, which leaves the export marker bare there because MSVC rejects a dllimport definition.

Closes #1001
