### PR TITLE
An over-long FTP path or host name aborts the process instead of failing the link

### DIFF
--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -150,14 +150,21 @@ void ftp_split_userpass(const char *src, const char *end, char *user,
 }
 
 /* Build "<verb> <path>" (see htsftp.h). */
-void ftp_command(char *line, size_t line_size, const char *verb,
-                 const char *path) {
+hts_boolean ftp_command(char *line, size_t line_size, const char *verb,
+                        const char *path) {
+  int n;
+
   /* A leading '-' would reach a server that shells out to ls as a flag. */
   if (path[0] == '-' || strchr(path, ' ') != NULL ||
       strchr(path, '\"') != NULL || strchr(path, '\'') != NULL)
-    snprintf(line, line_size, "%s \"%s\"", verb, path);
+    n = snprintf(line, line_size, "%s \"%s\"", verb, path);
   else
-    snprintf(line, line_size, "%s %s", verb, path);
+    n = snprintf(line, line_size, "%s %s", verb, path);
+  if (n < 0 || (size_t) n >= line_size) {
+    line[0] = '\0'; // fail safe for a caller that ignores the result
+    return HTS_FALSE;
+  }
+  return HTS_TRUE;
 }
 
 /* MDTM reply "213 YYYYMMDDHHMMSS[.frac]" (RFC 3659, UTC) into tm_time. */
@@ -211,7 +218,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
   httrackp *opt = pStruct->pOpt;
   char user[256] = "anonymous";
   char pass[256] = "user@";
-  char line_retr[2048];
+  char line_retr[FTP_LINE_SIZE];
   int port = 21;
 
 #if FTP_PASV
@@ -262,13 +269,20 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
       if (strnotempty(a)) {
         const size_t len_a =
             strlen(unescape_http(ftp_path, sizeof(ftp_path), a));
+        hts_boolean fits;
 
         if (len_a > 0 &&
             ftp_path[len_a - 1] == '/') { /* obviously a directory listing */
           transfer_list = 1;
-          ftp_command(line_retr, sizeof(line_retr), "LIST -A", ftp_path);
+          fits = ftp_command(line_retr, sizeof(line_retr), "LIST -A", ftp_path);
         } else {
-          ftp_command(line_retr, sizeof(line_retr), "RETR", ftp_path);
+          fits = ftp_command(line_retr, sizeof(line_retr), "RETR", ftp_path);
+        }
+        /* Clipped, the command would fetch another file under this name. */
+        if (!fits) {
+          strcpybuff(back->r.msg, "FTP path too long");
+          back->r.statuscode = STATUSCODE_INVALID;
+          _HALT_FTP return 0;
         }
       } else {
         transfer_list = 1;
@@ -298,6 +312,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
     SOCaddr server;
     char *a;
     char _adr[256];
+    size_t adr_len;
     const char *error = "unknown error";
 
     _adr[0] = '\0';
@@ -315,9 +330,16 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
         back->r.statuscode = STATUSCODE_INVALID; // permanent, unlike a DNS miss
         _HALT_FTP return 0;
       }
-      strncatbuff(_adr, adr, (int) (a - adr));
+      adr_len = (size_t) (a - adr);
     } else
-      strcpybuff(_adr, adr);
+      adr_len = strlen(adr);
+    // no resolvable name is this long, and clipping would query another host
+    if (adr_len >= sizeof(_adr)) {
+      htsblk_failf(&back->r, "Host name too long");
+      back->r.statuscode = STATUSCODE_INVALID;
+      _HALT_FTP return 0;
+    }
+    strncatbuff(_adr, adr, (int) adr_len);
 
     // récupérer adresse résolue
     strcpybuff(back->info, "host name");
@@ -356,7 +378,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
     _CHECK_HALT_FTP;
 
     {
-      char BIGSTK line[1024];
+      char BIGSTK line[FTP_LINE_SIZE];
 
       // envoi du login
 
@@ -514,9 +536,9 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
 #endif
           // SIZE
           if (back->r.statuscode != -1) {
-            if (!transfer_list) {
-              ftp_command(line, sizeof(line), "SIZE", ftp_path);
-
+            // a clipped probe would size and date a different file
+            if (!transfer_list &&
+                ftp_command(line, sizeof(line), "SIZE", ftp_path)) {
               // SIZE?
               strcpybuff(back->info, "size");
               send_line(soc_ctl, line);
@@ -537,22 +559,24 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
                 }
 
                 // MDTM?
-                ftp_command(line, sizeof(line), "MDTM", ftp_path);
-                strcpybuff(back->info, "mdtm");
-                send_line(soc_ctl, line);
-                get_ftp_line(soc_ctl, line, sizeof(line), timeout);
-                _CHECK_HALT_FTP;
-                if (ftp_parse_mdtm(line, &remote_tm)) {
-                  char date[256];
+                if (ftp_command(line, sizeof(line), "MDTM", ftp_path)) {
+                  strcpybuff(back->info, "mdtm");
+                  send_line(soc_ctl, line);
+                  get_ftp_line(soc_ctl, line, sizeof(line), timeout);
+                  _CHECK_HALT_FTP;
+                  if (ftp_parse_mdtm(line, &remote_tm)) {
+                    char date[256];
 
-                  time_rfc822(date, &remote_tm);
-                  /* Stamp the mirror as the HTTP path does, so a later pass
-                     compares server-clock times instead of crossing clocks. */
-                  back->r.lastmodified[0] = '\0';
-                  strlncatbuff(back->r.lastmodified, date,
-                               sizeof(back->r.lastmodified),
-                               sizeof(back->r.lastmodified) - 1);
-                  remote_mtime = timegm(&remote_tm);
+                    time_rfc822(date, &remote_tm);
+                    /* Stamp the mirror as the HTTP path does, so a later pass
+                       compares server-clock times instead of crossing clocks.
+                     */
+                    back->r.lastmodified[0] = '\0';
+                    strlncatbuff(back->r.lastmodified, date,
+                                 sizeof(back->r.lastmodified),
+                                 sizeof(back->r.lastmodified) - 1);
+                    remote_mtime = timegm(&remote_tm);
+                  }
                 }
 
                 /* Only over a copy back_add() judged partial: on --update every
@@ -570,7 +594,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
                     rest_understood = 1;
                   } // else never mind
                 }
-              }                 // sinon tant pis 
+              }                 // sinon tant pis
             }
           }
 #if FTP_PASV
@@ -613,7 +637,9 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
               SOCaddr_initport(server, port_pasv);
               if (connect(soc_dat, &SOCaddr_sockaddr(server), SOCaddr_size(server)) == 0) {
                 strcpybuff(back->info, "retr");
-                strcpybuff(line, line_retr);
+                // clip, never abort: this line is built from a crawled URL
+                line[0] = '\0';
+                strlncatbuff(line, line_retr, sizeof(line), sizeof(line) - 1);
                 send_line(soc_ctl, line);
                 get_ftp_line(soc_ctl, line, sizeof(line), timeout);
                 _CHECK_HALT_FTP;
@@ -660,7 +686,9 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
           _CHECK_HALT_FTP;
           if (line[0] == '2') { // ok
             strcpybuff(back->info, "retr");
-            strcpybuff(line, line_retr);
+            // clip, never abort: this line is built from a crawled URL
+            line[0] = '\0';
+            strlncatbuff(line, line_retr, sizeof(line), sizeof(line) - 1);
             send_line(soc_ctl, line);
             get_ftp_line(soc_ctl, line, sizeof(line), timeout);
             _CHECK_HALT_FTP;
@@ -922,7 +950,8 @@ FILE *dd = NULL;
 // routines de réception/émission
 // 0 = ERROR
 int send_line(T_SOC soc, const char *data) {
-  char BIGSTK line[1024];
+  char BIGSTK line[FTP_LINE_SIZE + 2]; // room for the CRLF of a maximal command
+  int n;
 
   // backstop: the driver fails earlier, but no injected byte reaches the wire
   if (!hts_is_control_free(data))
@@ -942,7 +971,10 @@ int send_line(T_SOC soc, const char *data) {
   printf("---> %s", data);
   fflush(stdout);
 #endif
-  snprintf(line, sizeof(line), "%s\x0d\x0a", data);
+  // an unterminated command would blend into whatever the server reads next
+  n = snprintf(line, sizeof(line), "%s\x0d\x0a", data);
+  if (n < 0 || n >= (int) sizeof(line))
+    return 0;
   if (check_socket_connect(soc) != 1) {
 #if FTP_DEBUG
     printf("!SOC WRITE ERROR\n");

--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -274,11 +274,10 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
         if (len_a > 0 &&
             ftp_path[len_a - 1] == '/') { /* obviously a directory listing */
           transfer_list = 1;
-          fits = ftp_command(line_retr, sizeof(line_retr), "LIST -A", ftp_path);
+          fits = ftp_command_line(line_retr, "LIST -A", ftp_path);
         } else {
-          fits = ftp_command(line_retr, sizeof(line_retr), "RETR", ftp_path);
+          fits = ftp_command_line(line_retr, "RETR", ftp_path);
         }
-        /* Clipped, the command would fetch another file under this name. */
         if (!fits) {
           strcpybuff(back->r.msg, "FTP path too long");
           back->r.statuscode = STATUSCODE_INVALID;
@@ -379,6 +378,9 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
 
     {
       char BIGSTK line[FTP_LINE_SIZE];
+
+      /* line_retr is copied here verbatim; a narrower line[] would clip it. */
+      HTS_COMPILE_ASSERT(sizeof(line) == sizeof(line_retr));
 
       // envoi du login
 
@@ -537,8 +539,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
           // SIZE
           if (back->r.statuscode != -1) {
             // a clipped probe would size and date a different file
-            if (!transfer_list &&
-                ftp_command(line, sizeof(line), "SIZE", ftp_path)) {
+            if (!transfer_list && ftp_command_line(line, "SIZE", ftp_path)) {
               // SIZE?
               strcpybuff(back->info, "size");
               send_line(soc_ctl, line);
@@ -559,7 +560,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
                 }
 
                 // MDTM?
-                if (ftp_command(line, sizeof(line), "MDTM", ftp_path)) {
+                if (ftp_command_line(line, "MDTM", ftp_path)) {
                   strcpybuff(back->info, "mdtm");
                   send_line(soc_ctl, line);
                   get_ftp_line(soc_ctl, line, sizeof(line), timeout);
@@ -594,7 +595,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
                     rest_understood = 1;
                   } // else never mind
                 }
-              }                 // sinon tant pis
+              } // sinon tant pis
             }
           }
 #if FTP_PASV

--- a/src/htsftp.h
+++ b/src/htsftp.h
@@ -84,6 +84,11 @@ void ftp_split_userpass(const char *src, const char *end, char *user,
    command does not fit, as a clipped one would name a different file. */
 hts_boolean ftp_command(char *line, size_t line_size, const char *verb,
                         const char *path);
+/* ftp_command() into a control line of the one capacity every FTP buffer has;
+   anything narrower fails the build rather than refusing a path that fits. */
+#define ftp_command_line(line, verb, path)                                     \
+  (HTS_COMPILE_ASSERT(sizeof(line) == FTP_LINE_SIZE),                          \
+   ftp_command((line), sizeof(line), (verb), (path)))
 T_SOC get_datasocket(char *to_send, size_t to_send_size);
 int stop_ftp(lien_back * back);
 char *linejmp(char *line);

--- a/src/htsftp.h
+++ b/src/htsftp.h
@@ -59,6 +59,9 @@ struct FTPDownloadStruct {
 
 /* Library internal definictions */
 #ifdef HTS_INTERNAL_BYTECODE
+/* Capacity of every FTP control-line buffer; send_line() adds the CRLF. */
+#define FTP_LINE_SIZE 1024
+
 #if USE_BEGINTHREAD
 void launch_ftp(FTPDownloadStruct * params);
 void back_launch_ftp(void *pP);
@@ -75,11 +78,12 @@ int get_ftp_line(T_SOC soc, char *line, size_t line_size, int timeout);
    Both sizes must be nonzero. */
 void ftp_split_userpass(const char *src, const char *end, char *user,
                         size_t user_size, char *pass, size_t pass_size);
-/* Build "<verb> <path>" into line[line_size], truncating to fit. The path is
-   quoted whenever a bare one would give the server a second token; it must
-   already have been screened for control bytes. */
-void ftp_command(char *line, size_t line_size, const char *verb,
-                 const char *path);
+/* Build "<verb> <path>" into line[line_size]. The path is quoted whenever a
+   bare one would give the server a second token; it must already have been
+   screened for control bytes. Returns HTS_FALSE and empties line when the
+   command does not fit, as a clipped one would name a different file. */
+hts_boolean ftp_command(char *line, size_t line_size, const char *verb,
+                        const char *path);
 T_SOC get_datasocket(char *to_send, size_t to_send_size);
 int stop_ftp(lien_back * back);
 char *linejmp(char *line);

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -273,6 +273,9 @@ typedef int hts_tristate;
 /* True when A is a non-NULL, non-empty string. */
 #define strnotempty(A) (((A) != NULL && (A)[0] != '\0'))
 
+/* Compile-time check, usable as an expression. */
+#define HTS_COMPILE_ASSERT(cond) ((void) sizeof(char[(cond) ? 1 : -1]))
+
 /* 'inline' where the dialect supports it (C++), nothing in plain C. */
 #ifdef __cplusplus
 #define HTS_INLINE inline

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4540,12 +4540,12 @@ static int st_ftpuser(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-/* A command that does not fit its control line must be reported, not clipped:
-   clipped, it would name a different file (#1019). Both quoting forms at two
-   capacities, since the quoted one is two bytes wider. */
+/* Both quoting forms at two capacities: the quoted form is two bytes wider
+   (#1019). */
 static int st_ftpcmdlen(httrackp *opt, int argc, char **argv) {
   static const size_t caps[] = {32, FTP_LINE_SIZE};
-  char BIGSTK buf[FTP_LINE_SIZE + 2];
+  char BIGSTK buf[FTP_LINE_SIZE + 32];
+  char BIGSTK poison[FTP_LINE_SIZE + 32];
   char BIGSTK path[FTP_LINE_SIZE + 2];
   char BIGSTK wire[FTP_LINE_SIZE * 2];
   size_t c, got = 0;
@@ -4554,6 +4554,7 @@ static int st_ftpcmdlen(httrackp *opt, int argc, char **argv) {
   (void) opt;
   (void) argc;
   (void) argv;
+  memset(poison, '#', sizeof(poison));
   for (c = 0; c < sizeof(caps) / sizeof(caps[0]); c++) {
     const size_t cap = caps[c];
     int quoted;
@@ -4567,8 +4568,8 @@ static int st_ftpcmdlen(httrackp *opt, int argc, char **argv) {
         memset(path, 'p', len);
         path[len] = '\0';
         if (quoted)
-          path[0] = ' ';               /* any of these forces the quoted form */
-        memset(buf, '#', sizeof(buf)); /* poison: a zero canary hides a NUL */
+          path[0] = ' '; /* any of these forces the quoted form */
+        memcpy(buf, poison, sizeof(buf)); /* a zero canary would hide a NUL */
         if (len > fit) {
           assertf(ftp_command(buf, cap, "RETR", path) == HTS_FALSE);
           assertf(buf[0] == '\0'); /* fail-safe for an ignored result */
@@ -4578,13 +4579,14 @@ static int st_ftpcmdlen(httrackp *opt, int argc, char **argv) {
           assertf(strncmp(buf, "RETR ", 5) == 0);
           assertf(buf[verb + len - 1] == (quoted ? '\"' : 'p'));
         }
-        assertf(buf[cap] == '#'); /* nothing written past the bound */
+        /* the whole tail: one canary byte misses a write just past it */
+        assertf(memcmp(buf + cap, poison, sizeof(buf) - cap) == 0);
       }
     }
   }
 
-  /* send_line() carries the CRLF a maximal command needs, and drops rather
-     than truncates one that is longer. */
+  /* send_line() adds the CRLF and drops, rather than truncates, an over-length
+     line. */
   memset(path, 'q', FTP_LINE_SIZE);
   path[FTP_LINE_SIZE] = '\0';
   assertf(st_socketpair(sv) == 0);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4540,6 +4540,73 @@ static int st_ftpuser(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* A command that does not fit its control line must be reported, not clipped:
+   clipped, it would name a different file (#1019). Both quoting forms at two
+   capacities, since the quoted one is two bytes wider. */
+static int st_ftpcmdlen(httrackp *opt, int argc, char **argv) {
+  static const size_t caps[] = {32, FTP_LINE_SIZE};
+  char BIGSTK buf[FTP_LINE_SIZE + 2];
+  char BIGSTK path[FTP_LINE_SIZE + 2];
+  char BIGSTK wire[FTP_LINE_SIZE * 2];
+  size_t c, got = 0;
+  T_SOC sv[2];
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+  for (c = 0; c < sizeof(caps) / sizeof(caps[0]); c++) {
+    const size_t cap = caps[c];
+    int quoted;
+
+    for (quoted = 0; quoted <= 1; quoted++) {
+      const size_t verb = 5 + 2 * (size_t) quoted; /* "RETR " plus quotes */
+      const size_t fit = cap - 1 - verb; /* longest path still fitting */
+      size_t len;
+
+      for (len = fit - 1; len <= fit + 1; len++) {
+        memset(path, 'p', len);
+        path[len] = '\0';
+        if (quoted)
+          path[0] = ' ';               /* any of these forces the quoted form */
+        memset(buf, '#', sizeof(buf)); /* poison: a zero canary hides a NUL */
+        if (len > fit) {
+          assertf(ftp_command(buf, cap, "RETR", path) == HTS_FALSE);
+          assertf(buf[0] == '\0'); /* fail-safe for an ignored result */
+        } else {
+          assertf(ftp_command(buf, cap, "RETR", path) == HTS_TRUE);
+          assertf(strlen(buf) == verb + len);
+          assertf(strncmp(buf, "RETR ", 5) == 0);
+          assertf(buf[verb + len - 1] == (quoted ? '\"' : 'p'));
+        }
+        assertf(buf[cap] == '#'); /* nothing written past the bound */
+      }
+    }
+  }
+
+  /* send_line() carries the CRLF a maximal command needs, and drops rather
+     than truncates one that is longer. */
+  memset(path, 'q', FTP_LINE_SIZE);
+  path[FTP_LINE_SIZE] = '\0';
+  assertf(st_socketpair(sv) == 0);
+  assertf(send_line(sv[0], path) == 0); /* one byte too long: never sent */
+  path[FTP_LINE_SIZE - 1] = '\0';
+  assertf(send_line(sv[0], path) != 0);
+  deletesoc(sv[0]);
+  for (;;) {
+    const int n = (int) recv(sv[1], wire + got, (int) (sizeof(wire) - got), 0);
+
+    if (n <= 0)
+      break;
+    got += (size_t) n;
+  }
+  deletesoc(sv[1]);
+  assertf(got == FTP_LINE_SIZE + 1); /* the maximal command alone */
+  assertf(memcmp(wire, path, FTP_LINE_SIZE - 1) == 0);
+  assertf(memcmp(wire + FTP_LINE_SIZE - 1, "\r\n", 2) == 0);
+  printf("ftp-cmdlen self-test OK (%d bytes sent)\n", (int) got);
+  return 0;
+}
+
 /* send_line() must drop a command line carrying a control byte (#1010). */
 static int st_ftpctrl(httrackp *opt, int argc, char **argv) {
   /* Verb and URL path as run_launch_ftp() hands them over, then the line the
@@ -8120,6 +8187,8 @@ static const struct selftest_entry {
     {"ftp-userpass", "", "ftp_split_userpass bounds URL userinfo", st_ftpuser},
     {"ftp-ctrlchars", "", "send_line rejects a control byte in an FTP command",
      st_ftpctrl},
+    {"ftp-cmdlen", "",
+     "an FTP command too long for its control line is refused", st_ftpcmdlen},
     {"warc", "<dir>", "WARC/1.1 writer: framing, digests, revisit dedup",
      st_warc},
     {"warc-trunc", "<dir>", "WARC-Truncated on a cap-truncated body",

--- a/tests/224_engine-ftp-cmdlen.test
+++ b/tests/224_engine-ftp-cmdlen.test
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# An FTP command too long for the control line it is sent from must be refused,
+# not clipped into a request for another file, and must never abort (#1019).
+
+set -euo pipefail
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpcmdlen.XXXXXX") || exit 1
+trap 'set +e; rm -rf "${tmpdir}"' EXIT
+trap 'exit 1' HUP INT QUIT TERM
+
+out=$(httrack -O "${tmpdir}/st" "-#test=ftp-cmdlen" run 2>&1) ||
+    fail "self-test exited non-zero: ${out}"
+grep -q "ftp-cmdlen self-test OK" <<<"${out}" || fail "unexpected output: ${out}"
+
+# The reachable half: a 300-byte host aborted in the copy into _adr[256].
+host=$(awk 'BEGIN { while (i++ < 300) printf "a" }')
+out=$(httrack "ftp://${host}/f.txt" -O "${tmpdir}/host" -q 2>&1) ||
+    fail "a long FTP host name crashed the engine: ${out}"
+grep -q "Host name too long" "${tmpdir}/host/hts-log.txt" ||
+    fail "the link was not rejected: $(cat "${tmpdir}/host/hts-log.txt")"

--- a/tests/224_engine-ftp-cmdlen.test
+++ b/tests/224_engine-ftp-cmdlen.test
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
-# An FTP command too long for the control line it is sent from must be refused,
-# not clipped into a request for another file, and must never abort (#1019).
+# A too-long FTP command must be refused, never truncated or aborted (#1019).
 
 set -euo pipefail
 
@@ -18,9 +17,26 @@ out=$(httrack -O "${tmpdir}/st" "-#test=ftp-cmdlen" run 2>&1) ||
     fail "self-test exited non-zero: ${out}"
 grep -q "ftp-cmdlen self-test OK" <<<"${out}" || fail "unexpected output: ${out}"
 
-# The reachable half: a 300-byte host aborted in the copy into _adr[256].
-host=$(awk 'BEGIN { while (i++ < 300) printf "a" }')
-out=$(httrack "ftp://${host}/f.txt" -O "${tmpdir}/host" -q 2>&1) ||
-    fail "a long FTP host name crashed the engine: ${out}"
-grep -q "Host name too long" "${tmpdir}/host/hts-log.txt" ||
-    fail "the link was not rejected: $(cat "${tmpdir}/host/hts-log.txt")"
+# The reachable half: the copy into _adr[256] aborted on a long host.
+rep() { awk -v n="$1" 'BEGIN { while (i++ < n) printf "a" }'; }
+
+probe_host() {
+    rm -rf "${tmpdir}/host"
+    httrack "ftp://$1/f.txt" -O "${tmpdir}/host" -q >/dev/null 2>&1 ||
+        fail "a ${#1}-byte FTP host name crashed the engine"
+    cat "${tmpdir}/host/hts-log.txt"
+}
+
+for n in 256 257 300; do
+    log=$(probe_host "$(rep "${n}")")
+    grep -q "Host name too long" <<<"${log}" ||
+        fail "a ${n}-byte host was not rejected: ${log}"
+done
+
+# 255 still fits _adr[256]; 127.0.0.1:1 is the outsider a widened gate swallows.
+log=$(probe_host "$(rep 255)")
+grep -q "Unable to get server's address" <<<"${log}" ||
+    fail "a 255-byte host did not reach the resolver: ${log}"
+log=$(probe_host "127.0.0.1:1")
+grep -q "Unable to connect to the server" <<<"${log}" ||
+    fail "a normal host did not reach the connect: ${log}"

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -259,3 +259,4 @@ TESTS += 216_engine-ftp-ctrlchars.test
 TESTS += 221_local-ftp-ctrlchars.test
 TESTS += 218_crash-nopie-frames.test
 TESTS += 222_pkgconfig-consumer.test
+TESTS += 224_engine-ftp-cmdlen.test


### PR DESCRIPTION
An FTP path or host name that survives the upstream clamps reaches an aborting `strcpybuff` and kills the process instead of failing the link. The path case (#1019) needs 1024 bytes exactly and nobody could reproduce it. The host case is trivial: `httrack ftp://<300 chars>/f` aborts on master, because the URL host is copied into a 256-byte buffer with no check at all.

Rather than re-derive the worst case, every FTP control line now shares one `FTP_LINE_SIZE`, and `ftp_command()` reports a command that did not fit. A clipped `RETR` would name a real but different file and save its body under the intended name, so an over-long path fails the transfer rather than being truncated. The two `line_retr` copies are bounded clips regardless. Two neighbours came along: `send_line()` dropped the CRLF off a maximal command, letting it run into whatever the server read next, and the SIZE/MDTM probes reused the same builder, so a clipped one would have sized and dated another file. MDTM now feeds the resume decision, so that one matters.

The new `-#test=ftp-cmdlen` covers the fit threshold at two capacities and both quoting forms, plus the bytes `send_line()` puts on the wire. `tests/224_engine-ftp-cmdlen.test` also crawls the long host, which aborts on master.

Closes #1019
