### PR TITLE
3.49.18 fails to build on Ubuntu: two tests assume GNU coreutils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,60 @@ jobs:
         if: failure()
         run: cat tests/test-suite.log 2>/dev/null || true
 
+  # The Ubuntu buildds run a development release that every runner above is well
+  # behind, and that gap shipped 3.49.18 broken on every Ubuntu architecture but
+  # riscv64: 25.10 made uutils the default coreutils, and a test that renamed
+  # `sleep` to `httrack` hit its argv[0] dispatch (#1042).
+  ubuntu-devel:
+    name: build (Ubuntu devel, uutils coreutils)
+    runs-on: ubuntu-24.04
+    container: ubuntu:devel
+    timeout-minutes: 40
+    steps:
+      # Before checkout: the container has no git, so submodules would be lost.
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            build-essential autoconf automake libtool autoconf-archive \
+            zlib1g-dev libssl-dev libbrotli-dev libzstd-dev \
+            git ca-certificates python3 procps
+
+      - name: Assert the coreutils are uutils
+        # Or the job silently degrades into a slower copy of the one above.
+        run: |
+          set -euo pipefail
+          sleep --version | head -n1
+          sleep --version | head -n1 | grep -qi uutils || {
+            echo "::error::this image ships GNU coreutils; the job no longer guards uutils" >&2
+            exit 1
+          }
+
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Configure
+        run: |
+          set -euo pipefail
+          autoreconf -fi
+          ./configure
+
+      - name: Build
+        run: make -j"$(nproc)"
+
+      - name: Test
+        timeout-minutes: 25
+        run: |
+          set -euo pipefail
+          jobs=$(( $(nproc) * 2 )); [ "$jobs" -le 16 ] || jobs=16
+          make check -j"$jobs"
+
+      - name: Print the test log on failure
+        if: failure()
+        run: cat tests/test-suite.log 2>/dev/null || true
+
   # Portability: build and test on macOS (Darwin/clang) on a native runner --
   # no VM. The tree has no __APPLE__ branches, so Darwin exercises the
   # generic-Unix path on a second libc and kernel. brew's openssl@3 is keg-only,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,10 +138,9 @@ jobs:
         if: failure()
         run: cat tests/test-suite.log 2>/dev/null || true
 
-  # The Ubuntu buildds run a development release that every runner above is well
-  # behind, and that gap shipped 3.49.18 broken on every Ubuntu architecture but
-  # riscv64: 25.10 made uutils the default coreutils, and a test that renamed
-  # `sleep` to `httrack` hit its argv[0] dispatch (#1042).
+  # The Ubuntu buildds run a development release every runner above is well behind.
+  # That gap is what shipped 3.49.18 broken on every Ubuntu architecture but
+  # riscv64, when 25.10 made uutils the default coreutils (#1042).
   ubuntu-devel:
     name: build (Ubuntu devel, uutils coreutils)
     runs-on: ubuntu-24.04
@@ -158,15 +157,17 @@ jobs:
             zlib1g-dev libssl-dev libbrotli-dev libzstd-dev \
             git ca-certificates python3 procps
 
-      - name: Assert the coreutils are uutils
-        # Or the job silently degrades into a slower copy of the one above.
+      - name: Assert the coreutils dispatch on argv[0]
+        # The property #1042 broke on, not the version banner, which uutils has
+        # already reworded once. Without it the job quietly becomes a slower copy
+        # of the one above.
         run: |
           set -euo pipefail
-          sleep --version | head -n1
-          sleep --version | head -n1 | grep -qi uutils || {
-            echo "::error::this image ships GNU coreutils; the job no longer guards uutils" >&2
+          ln -s "$(command -v sleep)" /tmp/not-a-coreutil
+          if /tmp/not-a-coreutil 0; then
+            echo "::error::coreutils here take any argv[0]; this image no longer guards uutils" >&2
             exit 1
-          }
+          fi
 
       - uses: actions/checkout@v7
         with:
@@ -177,6 +178,11 @@ jobs:
           set -euo pipefail
           autoreconf -fi
           ./configure
+          # A renamed dev package would disable a codec or TLS here, and the tests
+          # that cover them would SKIP rather than fail.
+          grep -q "define HTS_USEBROTLI 1" config.h
+          grep -q "define HTS_USEZSTD 1" config.h
+          grep -q "define HTS_USEOPENSSL 1" config.h
 
       - name: Build
         run: make -j"$(nproc)"

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -151,28 +151,32 @@ if ! is_windows && test -r /proc/self/stat; then
     mkdir -p "$tmp/nops"
     printf '#!/bin/sh\nexit 127\n' >"$tmp/nops/ps"
     chmod +x "$tmp/nops/ps"
-    # Matched on the basename alone, so any long-lived binary would do -- except a
-    # renamed coreutils: uutils dispatches on argv[0] and refuses it (#1042).
+    # A shell copy, not a renamed sleep: uutils refuses an argv[0] it does not own
+    # (#1042). Either works, since both lists match on the basename alone.
     cp "${BASH:-$(command -v sh)}" "$tmp/httrack" || fail "no shell to copy"
-    # The fakes block in open() and fork nothing, so the SIGABRT orphans no child.
+    "$tmp/httrack" -c : || fail "cannot exec out of $tmp (noexec?)"
+    # Read-write, so the open does not block and the timeout can bound it: the
+    # fakes then fork nothing for the SIGABRT to orphan, and a test killed
+    # outright leaks no process named httrack onto the runner.
     mkfifo "$tmp/hold"
+    hold="read -t 60 _ <>'$tmp/hold'"
     # Started from a subshell so ppid and pgid differ: swapping those two columns
     # is invisible whenever the test shell happens to lead its own group.
     (
-        "$tmp/httrack" -c "read _ <'$tmp/hold'" &
+        "$tmp/httrack" -c "$hold" &
         echo $! >"$tmp/fake.pid"
     )
     # Its own group, to prove the filter keeps an outsider out.
     (
         set -m
-        "$tmp/httrack" -c "read _ <'$tmp/hold'" &
+        "$tmp/httrack" -c "$hold" &
         echo $! >"$tmp/outside.pid"
     )
     fake=$(cat "$tmp/fake.pid")
     outside=$(cat "$tmp/outside.pid")
     trap 'set +e; kill "$fake" "$outside" 2>/dev/null; rm -rf "$tmp"' EXIT
-    # /proc holds the pid from the fork on, so a fake that never exec'd surfaces
-    # only as an empty field far below -- which is how #1042 read.
+    # /proc holds the pid from the fork on, so a fake that never exec'd would fail
+    # some later assertion instead of this one.
     running() {
         local i=0 argv0
         while test "$i" -lt 20; do

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -151,23 +151,40 @@ if ! is_windows && test -r /proc/self/stat; then
     mkdir -p "$tmp/nops"
     printf '#!/bin/sh\nexit 127\n' >"$tmp/nops/ps"
     chmod +x "$tmp/nops/ps"
-    # Both lists match on the basename alone, so any long-lived binary will do.
-    ln -sf "$(command -v sleep)" "$tmp/httrack"
+    # Matched on the basename alone, so any long-lived binary would do -- except a
+    # renamed coreutils: uutils dispatches on argv[0] and refuses it (#1042).
+    cp "${BASH:-$(command -v sh)}" "$tmp/httrack" || fail "no shell to copy"
+    # The fakes block in open() and fork nothing, so the SIGABRT orphans no child.
+    mkfifo "$tmp/hold"
     # Started from a subshell so ppid and pgid differ: swapping those two columns
     # is invisible whenever the test shell happens to lead its own group.
     (
-        "$tmp/httrack" 60 &
+        "$tmp/httrack" -c "read _ <'$tmp/hold'" &
         echo $! >"$tmp/fake.pid"
     )
     # Its own group, to prove the filter keeps an outsider out.
     (
         set -m
-        "$tmp/httrack" 60 &
+        "$tmp/httrack" -c "read _ <'$tmp/hold'" &
         echo $! >"$tmp/outside.pid"
     )
     fake=$(cat "$tmp/fake.pid")
     outside=$(cat "$tmp/outside.pid")
     trap 'set +e; kill "$fake" "$outside" 2>/dev/null; rm -rf "$tmp"' EXIT
+    # /proc holds the pid from the fork on, so a fake that never exec'd surfaces
+    # only as an empty field far below -- which is how #1042 read.
+    running() {
+        local i=0 argv0
+        while test "$i" -lt 20; do
+            { read -r -d '' argv0 <"/proc/$1/cmdline"; } 2>/dev/null &&
+                test "${argv0##*/}" = httrack && return 0
+            sleep 0.1
+            i=$((i + 1))
+        done
+        return 1
+    }
+    running "$fake" || fail "the fake engine never started"
+    running "$outside" || fail "the outsider never started"
     # ppid and pgid of $1: the oracle the listing is checked against.
     procfields() { awk '{ sub(/.*\) /, ""); print $2, $3 }' "/proc/$1/stat"; }
     procstate() { awk '{ sub(/.*\) /, ""); print $1 }' "/proc/$1/stat" 2>/dev/null || echo gone; }

--- a/tests/153_local-proxytrack-quiet.test
+++ b/tests/153_local-proxytrack-quiet.test
@@ -126,9 +126,8 @@ wait_drained() { # log
 
 quietport=$(freeport)
 : >"$dir/quiet.log" # the drainer creates it asynchronously
-# Unset in a subshell rather than through env(1): uutils' forks instead of
-# exec'ing, so stop_server would kill it and leave proxytrack holding the pty
-# open, and the drainer below would wait for an EOF that never comes (#1042).
+# Subshell, not env(1): uutils' env forks rather than execs, so stop_server would
+# kill the wrapper and leave proxytrack holding the pty open (#1042).
 (
     unset HTS_LOG
     exec "$python" -c "$pty_exec" "$dir/quiet.log" \

--- a/tests/153_local-proxytrack-quiet.test
+++ b/tests/153_local-proxytrack-quiet.test
@@ -126,8 +126,14 @@ wait_drained() { # log
 
 quietport=$(freeport)
 : >"$dir/quiet.log" # the drainer creates it asynchronously
-env -u HTS_LOG "$python" -c "$pty_exec" "$dir/quiet.log" \
-    proxytrack "127.0.0.1:$quietport" "127.0.0.1:$(freeport)" "$dir/in.arc" &
+# Unset in a subshell rather than through env(1): uutils' forks instead of
+# exec'ing, so stop_server would kill it and leave proxytrack holding the pty
+# open, and the drainer below would wait for an EOF that never comes (#1042).
+(
+    unset HTS_LOG
+    exec "$python" -c "$pty_exec" "$dir/quiet.log" \
+        proxytrack "127.0.0.1:$quietport" "127.0.0.1:$(freeport)" "$dir/in.arc"
+) &
 quietpid=$!
 wait_listen "$dir/quiet.log" "$quietpid"
 


### PR DESCRIPTION
3.49.18-1 failed to build on every Ubuntu architecture but riscv64, and both causes are the same collision: Ubuntu made uutils the default coreutils in 25.10. Its multi-call binary refuses an argv[0] it does not own, which killed 105's fake engine (a `sleep` symlinked as `httrack`), and its `env` forks rather than execs, so 153's `stop_server` killed the wrapper and left proxytrack holding a pty the drainer was waiting to see close. Debian sid is still on GNU coreutils and builds fine. 105 also checks that its fake actually started, since one that never ran showed up only as an empty pgid in an assertion about something else.

Nothing in CI ran anything newer than 24.04, so the buildd saw this first. The new job builds and runs the suite in an `ubuntu:devel` container: 245 pass, 18 skip, 0 fail under uutils 0.8.0. It renames `sleep` and requires the refusal, so it cannot quietly become a slower copy of an existing job. Worth leaving out of the required checks, though, since `ubuntu:devel` will redden on Ubuntu's own churn.

Closes #1042