### PR TITLE
A resurrected test registration stops make check with no test results

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,7 @@
 # bash die on $'\r' on every line of them.
 *.test text eol=lf
 *.sh text eol=lf
+
+# Scoped to this file so a union can never touch build logic. LF because a CRLF
+# checkout would make every line of it a stray to check-tests-list.sh.
+tests/tests-list.mk merge=union text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,3 @@
 # bash die on $'\r' on every line of them.
 *.test text eol=lf
 *.sh text eol=lf
-
-# Scoped to this file so a union can never touch build logic.
-tests/tests-list.mk merge=union

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -787,6 +787,11 @@ jobs:
       - name: shfmt
         run: shfmt -d -i 4 $SHELL_SCRIPTS
 
+      # A registration whose file is gone stops "make check" before it reports
+      # anything, so catch it here rather than as a missing line in a build log.
+      - name: tests-list.mk registrations
+        run: bash tests/check-tests-list.sh
+
       # MSBuild rejects a malformed .vcxproj with a bare MSB4025 and no build, so
       # catch it here in seconds rather than on a Windows runner minutes in.
       - name: XML well-formedness (MSBuild project files)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,9 +20,9 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   `-c16` bigcrawl the way Python's default backlog of 5 did.
   Or run `sh build.sh` to do bootstrap + configure + make in one shot.
 - A `tests/NN_*.test` runs only if listed in `tests/tests-list.mk`; an
-  unregistered file is silently skipped, and a registration whose file is gone
-  makes `make check` exit 2 with no `# TOTAL:` line. `tests/check-tests-list.sh`
-  (CI lint, and `231_tests-list-bijection.test`) enforces the pairing both ways.
+  unregistered file is silently skipped. A registration whose file is gone makes
+  `make check` exit 2 with no `# TOTAL:` line. `tests/check-tests-list.sh` (CI
+  lint and `231_tests-list-bijection.test`) enforces the pairing both ways.
 - `make check` prepends the build's `src/` to `PATH`, but a hand-run `.test` does
   not — an installed `/usr/bin/httrack` then shadows your build. Run via `make
   check`, or `PATH="<bld>/src:$PATH"` for a manual run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,9 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   `-c16` bigcrawl the way Python's default backlog of 5 did.
   Or run `sh build.sh` to do bootstrap + configure + make in one shot.
 - A `tests/NN_*.test` runs only if listed in `tests/tests-list.mk`; an
-  unregistered file is silently skipped.
+  unregistered file is silently skipped, and a registration whose file is gone
+  makes `make check` exit 2 with no `# TOTAL:` line. `tests/check-tests-list.sh`
+  (CI lint, and `231_tests-list-bijection.test`) enforces the pairing both ways.
 - `make check` prepends the build's `src/` to `PATH`, but a hand-run `.test` does
   not — an installed `/usr/bin/httrack` then shadows your build. Run via `make
   check`, or `PATH="<bld>/src:$PATH"` for a manual run.

--- a/tests/231_tests-list-bijection.test
+++ b/tests/231_tests-list-bijection.test
@@ -1,9 +1,40 @@
 #!/bin/bash
 #
-# Catches the unregistered half locally; a stale registration never gets this far
-# (make check dies first), so CI runs the same script out of band too.
+# Covers the unregistered-file case; a stale registration cannot reach this test,
+# because make check dies first.
 
 set -euo pipefail
 
 testdir=$(cd "$(dirname "$0")" && pwd)
-exec bash "${testdir}/check-tests-list.sh" "${testdir}"
+checker="${testdir}/check-tests-list.sh"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/tests_list.XXXXXX") || fail "no tmpdir"
+trap 'set +e; rm -rf "$work"' EXIT
+
+bash "$checker" "$testdir" || fail "the tree's own registrations do not check out"
+
+# Positive controls: every branch of the checker is silent on a clean tree, so
+# one that had stopped comparing would pass the assertion above just as well.
+control() {
+    local name=$1 want=$2 mutate=$3 dir="${work}/$1" out=""
+    mkdir -p "$dir"
+    : >"${dir}/00_kept.test"
+    printf 'TESTS =\nTESTS += 00_kept.test\n' >"${dir}/tests-list.mk"
+    (cd "$dir" && eval "$mutate")
+    if out=$(bash "$checker" "$dir" 2>&1); then
+        fail "$name: the checker accepted a broken list"
+    fi
+    grep -q "$want" <<<"$out" || fail "$name: wrong diagnostic: $out"
+}
+
+control absent 'registered but absent' 'echo "TESTS += 99_gone.test" >>tests-list.mk'
+control unregistered 'present but unregistered' ': >99_ghost.test'
+control duplicate 'registered twice' 'echo "TESTS += 00_kept.test" >>tests-list.mk'
+control malformed 'malformed' 'echo "TESTS += 00_kept.test 99_x.test" >>tests-list.mk'
+
+echo "OK: bijection holds, and the checker still sees each way it can break"

--- a/tests/231_tests-list-bijection.test
+++ b/tests/231_tests-list-bijection.test
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Catches the unregistered half locally; a stale registration never gets this far
+# (make check dies first), so CI runs the same script out of band too.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+exec bash "${testdir}/check-tests-list.sh" "${testdir}"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,10 +1,10 @@
-# One entry per line so parallel branches union-merge instead of colliding (#844).
+# One entry per line so an append conflicts on that line alone (#844).
 include $(srcdir)/tests-list.mk
 
 # Committed binary fixture read by 01_zlib-cache-golden.test. List it
 # explicitly: automake does not expand wildcards in EXTRA_DIST, so a glob would
 # silently drop it from the dist tarball and break "make distcheck".
-EXTRA_DIST = $(TESTS) renamefail.c threadattrfail.c nobacktrace.c altstackprobe.c nopieprobe.c crawl-test.sh run-all-tests.sh check-network.sh \
+EXTRA_DIST = $(TESTS) renamefail.c threadattrfail.c nobacktrace.c altstackprobe.c nopieprobe.c crawl-test.sh run-all-tests.sh check-network.sh check-tests-list.sh \
 	proxy-https-server.py socks5-server.py proxy-connect-server.py \
 	proxytestlib.py tls-stall-server.py warc-validate.py wacz-validate.py \
 	header-injection-server.py header-injection-check.py \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,4 @@
-# One entry per line so an append conflicts on that line alone (#844).
+# One entry per line so parallel branches union-merge instead of colliding (#844).
 include $(srcdir)/tests-list.mk
 
 # Committed binary fixture read by 01_zlib-cache-golden.test. List it

--- a/tests/check-tests-list.sh
+++ b/tests/check-tests-list.sh
@@ -29,7 +29,11 @@ strays=$(grep -nv -e '^$' -e '^#' -e '^TESTS =$' -e '^TESTS += [^ ]*\.test$' "$l
 $strays"
 
 sed -n 's/^TESTS += //p' "$list" | sort >"$tmp/all"
-for f in "$testdir"/*.test; do printf '%s\n' "${f##*/}"; done | sort >"$tmp/present"
+# A directory or a dangling symlink named NN_x.test is not a test file, and
+# make check would choke on it; count it as absent.
+for f in "$testdir"/*.test; do
+    if [ -f "$f" ]; then printf '%s\n' "${f##*/}"; fi
+done | sort >"$tmp/present"
 
 # Dedupe before comparing, or a repeated entry also reads as an absent file.
 dup=$(uniq -d "$tmp/all")

--- a/tests/check-tests-list.sh
+++ b/tests/check-tests-list.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# tests-list.mk and tests/*.test must stay a bijection: a registration whose file
+# is gone makes "make check" exit 2 before any test runs, with no "# TOTAL:" line
+# at all, and an unregistered file is silently never run (#1037).
+
+set -euo pipefail
+
+testdir=$(cd "${1:-$(dirname "$0")}" && pwd)
+list="${testdir}/tests-list.mk"
+[ -r "$list" ] || {
+    echo "not readable: $list" >&2
+    exit 2
+}
+
+status=0
+bad() {
+    echo "$*" >&2
+    status=1
+}
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/tests-list.XXXXXX")
+trap 'set +e; rm -rf "$tmp"' EXIT
+
+# The extraction below takes one file per "TESTS +=" line, so a continuation or a
+# second name on a line would slip past the comparison unseen.
+strays=$(grep -nv -e '^$' -e '^#' -e '^TESTS =$' -e '^TESTS += [^ ]*\.test$' "$list" || true)
+[ -z "$strays" ] || bad "malformed tests-list.mk lines, want one 'TESTS += NN_name.test' each:
+$strays"
+
+sed -n 's/^TESTS += //p' "$list" | sort >"$tmp/all"
+for f in "$testdir"/*.test; do printf '%s\n' "${f##*/}"; done | sort >"$tmp/present"
+
+# Dedupe before comparing, or a repeated entry also reads as an absent file.
+dup=$(uniq -d "$tmp/all")
+[ -z "$dup" ] || bad "registered twice: $dup"
+uniq "$tmp/all" >"$tmp/registered"
+
+missing=$(comm -23 "$tmp/registered" "$tmp/present")
+[ -z "$missing" ] || bad "registered but absent, so make check dies with no results: $missing"
+
+extra=$(comm -13 "$tmp/registered" "$tmp/present")
+[ -z "$extra" ] || bad "present but unregistered, so never run: $extra"
+
+if [ "$status" -eq 0 ]; then
+    echo "tests-list.mk: $(wc -l <"$tmp/registered") registrations, each matching a file"
+fi
+exit "$status"

--- a/tests/check-tests-list.sh
+++ b/tests/check-tests-list.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
-# tests-list.mk and tests/*.test must stay a bijection: a registration whose file
-# is gone makes "make check" exit 2 before any test runs, with no "# TOTAL:" line
-# at all, and an unregistered file is silently never run (#1037).
+# tests-list.mk and tests/*.test must stay a bijection (#1037): a stale
+# registration kills make check silently, an unregistered file just never runs.
 
 set -euo pipefail
+export LC_ALL=C
 
 testdir=$(cd "${1:-$(dirname "$0")}" && pwd)
 list="${testdir}/tests-list.mk"
@@ -22,8 +22,8 @@ bad() {
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/tests-list.XXXXXX")
 trap 'set +e; rm -rf "$tmp"' EXIT
 
-# The extraction below takes one file per "TESTS +=" line, so a continuation or a
-# second name on a line would slip past the comparison unseen.
+# The sed below assumes one file per "TESTS +=" line; a continuation or a second
+# name on a line would slip past unseen.
 strays=$(grep -nv -e '^$' -e '^#' -e '^TESTS =$' -e '^TESTS += [^ ]*\.test$' "$list" || true)
 [ -z "$strays" ] || bad "malformed tests-list.mk lines, want one 'TESTS += NN_name.test' each:
 $strays"

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -1,5 +1,6 @@
-# One entry per line, never a backslash continuation: two branches appending a
-# test then conflict on that line alone, and check-tests-list.sh reads it (#844).
+# One entry per line, never a backslash continuation: unioning a continued list
+# drops an entry silently (#844). A deletion merged alongside another branch's
+# append is restored by the union -- remove a test in a commit of its own.
 TESTS =
 TESTS += 00_runnable.test
 TESTS += 01_engine-addlink.test

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -1,6 +1,5 @@
-# One entry per line, never a backslash continuation: unioning a continued list
-# drops an entry silently (#844). A deletion merged alongside another branch's
-# append is restored by the union -- remove a test in a commit of its own.
+# One entry per line, never a backslash continuation: two branches appending a
+# test then conflict on that line alone, and check-tests-list.sh reads it (#844).
 TESTS =
 TESTS += 00_runnable.test
 TESTS += 01_engine-addlink.test
@@ -265,3 +264,4 @@ TESTS += 226_watchdog-native.test
 TESTS += 224_engine-ftp-cmdlen.test
 TESTS += 230_local-ftp-userpass.test
 TESTS += 225_install-manifest.test
+TESTS += 231_tests-list-bijection.test


### PR DESCRIPTION
`tests/tests-list.mk` carries `merge=union`, so two branches that each append a test still merge cleanly. Union never removes a line, so a merge or rebase past a deleted or renamed test restores its registration too. Automake then hits the missing file and exits 2, with no FAIL lines and no `# TOTAL:` summary, so the tell is a line that is not there.

`tests/check-tests-list.sh` checks the pairing both ways, and catches duplicate and malformed entries. The lint job runs it, since a stale registration kills `make check` before any test can report. `231_tests-list-bijection.test` covers the other direction, where an unregistered file is never run at all; it also feeds the checker four broken fixtures, because every branch of the script is silent on a healthy tree and one that had stopped comparing would pass just as well.

The attribute stays rather than going, which is what #1037 suggests first. Since it landed, 75 tests were added and one removed: the union is right on 75 merges out of 76, and hand-resolving those invites the whole-file resolution that drops a sibling's registration, the loss #844 was about. Dropping it would not have helped the conflicted-PR half of the issue anyway, since GitHub never ran the driver; that half stays true while the list is shared, and the glob alternative was tried and reverted in e5c0918d.

Closes #1037
