### PR TITLE
An --enable-fuzzers build cannot link proxytrack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,6 +571,34 @@ jobs:
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         run: bash fuzz/run-fuzzers.sh fuzz check
 
+  # The job above links ASan, whose runtime also defines the sancov hooks the
+  # instrumentation emits, so it cannot see a program left without one (#1030).
+  # This is the bare --enable-fuzzers build; linking is what is under test.
+  fuzz-no-sanitizer:
+    name: build (fuzzers, no sanitizer runtime, clang)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential clang autoconf automake libtool autoconf-archive \
+            zlib1g-dev libssl-dev libbrotli-dev libzstd-dev
+
+      - name: Configure (fuzzers, static)
+        run: |
+          set -euo pipefail
+          autoreconf -fi
+          ./configure CC=clang --enable-fuzzers --disable-shared
+
+      - name: Build
+        run: make -j"$(nproc)"
+
   # Optional-dependency build: compile and test with HTTPS/OpenSSL disabled --
   # the configuration users on minimal systems build, and one libssl is not even
   # installed here so configure cannot silently re-enable it. The matrix above

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,9 +571,8 @@ jobs:
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         run: bash fuzz/run-fuzzers.sh fuzz check
 
-  # The job above links ASan, whose runtime also defines the sancov hooks the
-  # instrumentation emits, so it cannot see a program left without one (#1030).
-  # This is the bare --enable-fuzzers build; linking is what is under test.
+  # Catches #1030: the job above links ASan, whose runtime already defines the
+  # sancov hooks the instrumentation calls, hiding a program left without one.
   fuzz-no-sanitizer:
     name: build (fuzzers, no sanitizer runtime, clang)
     runs-on: ubuntu-24.04

--- a/configure.ac
+++ b/configure.ac
@@ -592,8 +592,7 @@ if test x"$fuzzers" = x"yes"; then
 	AX_CHECK_COMPILE_FLAG([-fsanitize=fuzzer-no-link],
 		[DEFAULT_CFLAGS="$DEFAULT_CFLAGS -fsanitize=fuzzer-no-link"],
 		[AC_MSG_ERROR([--enable-fuzzers requires libFuzzer support (clang)])])
-	# The ordinary programs are instrumented too, so they need the sancov runtime
-	# the harnesses get from -fsanitize=fuzzer.
+	# Ordinary programs are instrumented too, so they need that runtime at link.
 	AX_CHECK_LINK_FLAG([-fsanitize=fuzzer-no-link],
 		[DEFAULT_LDFLAGS="$DEFAULT_LDFLAGS -fsanitize=fuzzer-no-link"],
 		[AC_MSG_ERROR([--enable-fuzzers requires libFuzzer support (clang)])])

--- a/configure.ac
+++ b/configure.ac
@@ -592,6 +592,11 @@ if test x"$fuzzers" = x"yes"; then
 	AX_CHECK_COMPILE_FLAG([-fsanitize=fuzzer-no-link],
 		[DEFAULT_CFLAGS="$DEFAULT_CFLAGS -fsanitize=fuzzer-no-link"],
 		[AC_MSG_ERROR([--enable-fuzzers requires libFuzzer support (clang)])])
+	# The ordinary programs are instrumented too, so they need the sancov runtime
+	# the harnesses get from -fsanitize=fuzzer.
+	AX_CHECK_LINK_FLAG([-fsanitize=fuzzer-no-link],
+		[DEFAULT_LDFLAGS="$DEFAULT_LDFLAGS -fsanitize=fuzzer-no-link"],
+		[AC_MSG_ERROR([--enable-fuzzers requires libFuzzer support (clang)])])
 	# clang's static sanitizer runtimes clash with -Wl,--no-undefined on the .so.
 	if test x"$enable_shared" != x"no"; then
 		AC_MSG_ERROR([--enable-fuzzers requires --disable-shared])


### PR DESCRIPTION
`--enable-fuzzers` appends `-fsanitize=fuzzer-no-link` to `DEFAULT_CFLAGS`, so every object in the tree carries sancov instrumentation, but only `fuzz/Makefile.am` linked a runtime defining the hooks it emits. With clang, `bash configure --enable-fuzzers --disable-shared && make` then dies at `src/proxytrack`, the first program linked, on `__sancov_lowest_stack` and `__sanitizer_cov_trace_const_cmp4`. The same append on `DEFAULT_LDFLAGS` fixes it, and an ordinary build is unaffected because the branch only runs under `--enable-fuzzers`.

CI has had an `--enable-fuzzers` job all along, which is why nobody noticed: it configures with `LDFLAGS="-fsanitize=address,undefined"`, and ASan's runtime defines the same sancov hooks. That leg cannot see a program left without one. The new `fuzz-no-sanitizer` job builds the bare configuration from the issue and stops there, since the failure is at link time.

Checked with clang 19.1.7: the failure reproduces on master, where `make -k` gives 12337 undefined sancov references across `proxytrack`, `httrack` and `htsserver`, and none on the fix. The existing ASan fuzz configuration still builds and replays its corpora with the extra link flag in place.

GitHub cannot make the job a required check until it has reported once on master, so it needs adding to the ruleset after this lands. Until then it can only fail silently, which is how the over-long changelog line got past `deb package (lintian)` in 3.49.18.

Closes #1030
