### PR TITLE
Out-of-tree builds skip the online crawl tests with a misleading reason

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -550,7 +550,7 @@ AC_DEFINE(HAVE_STRNLEN, 1,[Check for strnlen])], AC_MSG_RESULT([not found]))
 ## Online unit tests
 AC_MSG_CHECKING(whether to enable online unit tests)
 AC_ARG_ENABLE([online-unit-tests],
-	[AS_HELP_STRING([--enable-online-unit-tests=@<:@yes/no/auto@:>@],[Enable online-unit-tests @<:@default=yes@:>@])],
+	[AS_HELP_STRING([--enable-online-unit-tests=@<:@yes/no/auto@:>@],[Enable online-unit-tests @<:@default=no@:>@])],
 	[
 	case "${enableval}" in
 	no|yes|auto)

--- a/tests/10_crawl-simple.test
+++ b/tests/10_crawl-simple.test
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
-bash check-network.sh || ! echo "skipping online unit tests" || exit 77
+testdir=$(cd "$(dirname "$0")" && pwd)
 
-bash crawl-test.sh --errors 0 --files 5 httrack http://ut.httrack.com/simple/basic.html
+bash "$testdir/check-network.sh" || ! echo "skipping online unit tests" || exit 77
+
+bash "$testdir/crawl-test.sh" --errors 0 --files 5 httrack http://ut.httrack.com/simple/basic.html

--- a/tests/11_crawl-cookies.test
+++ b/tests/11_crawl-cookies.test
@@ -3,9 +3,11 @@
 
 set -euo pipefail
 
-bash check-network.sh || ! echo "skipping online unit tests" || exit 77
+testdir=$(cd "$(dirname "$0")" && pwd)
 
-bash crawl-test.sh --errors 0 --files 3 \
+bash "$testdir/check-network.sh" || ! echo "skipping online unit tests" || exit 77
+
+bash "$testdir/crawl-test.sh" --errors 0 --files 3 \
     --found ut.httrack.com/cookies/third.html \
     --found ut.httrack.com/cookies/second.html \
     --found ut.httrack.com/cookies/entrance.html \

--- a/tests/11_crawl-idna.test
+++ b/tests/11_crawl-idna.test
@@ -3,10 +3,12 @@
 
 set -euo pipefail
 
-bash check-network.sh || ! echo "skipping online unit tests" || exit 77
+testdir=$(cd "$(dirname "$0")" && pwd)
+
+bash "$testdir/check-network.sh" || ! echo "skipping online unit tests" || exit 77
 
 # unicode tests
-bash crawl-test.sh \
+bash "$testdir/crawl-test.sh" \
     --errors 1 --files 5 \
     --found 'café.ut.httrack.com/unicode-links/café3860.html' \
     --found 'café.ut.httrack.com/unicode-links/café30f4.html' \
@@ -16,7 +18,7 @@ bash crawl-test.sh \
     '+*.ut.httrack.com/*' --robots=0
 
 # unicode tests (bogus links)
-bash crawl-test.sh \
+bash "$testdir/crawl-test.sh" \
     --errors 0 --files 1 \
     --found 'ut.httrack.com/unicode-links/idna_bogus.html' \
     httrack 'http://ut.httrack.com/unicode-links/idna_bogus.html' \

--- a/tests/11_crawl-international.test
+++ b/tests/11_crawl-international.test
@@ -3,10 +3,12 @@
 
 set -euo pipefail
 
-bash check-network.sh || ! echo "skipping online unit tests" || exit 77
+testdir=$(cd "$(dirname "$0")" && pwd)
+
+bash "$testdir/check-network.sh" || ! echo "skipping online unit tests" || exit 77
 
 # unicode tests
-bash crawl-test.sh \
+bash "$testdir/crawl-test.sh" \
     --errors 1 --files 10 \
     --found ut.httrack.com/unicode-links/caf%a91bce.html \
     --found ut.httrack.com/unicode-links/café30f4.html \
@@ -21,7 +23,7 @@ bash crawl-test.sh \
     --found ut.httrack.com/unicode-links/utf8.html \
     httrack http://ut.httrack.com/unicode-links/utf8.html
 
-bash crawl-test.sh \
+bash "$testdir/crawl-test.sh" \
     --errors 2 --files 9 \
     --found ut.httrack.com/unicode-links/café3860.html \
     --found ut.httrack.com/unicode-links/café9fa8.html \
@@ -36,7 +38,7 @@ bash crawl-test.sh \
     --found ut.httrack.com/unicode-links/default.html \
     httrack http://ut.httrack.com/unicode-links/default.html
 
-bash crawl-test.sh \
+bash "$testdir/crawl-test.sh" \
     --errors 2 --files 9 \
     --found ut.httrack.com/unicode-links/caf%a9ae52.html \
     --found ut.httrack.com/unicode-links/caf%a9bf59.html \
@@ -51,7 +53,7 @@ bash crawl-test.sh \
     --found ut.httrack.com/unicode-links/iso88591.html \
     httrack http://ut.httrack.com/unicode-links/iso88591.html
 
-bash crawl-test.sh \
+bash "$testdir/crawl-test.sh" \
     --errors 4 --files 9 \
     --found ut.httrack.com/unicode-links/caf%a8%a6c72a.html \
     --found ut.httrack.com/unicode-links/caf%a9bf59.html \

--- a/tests/11_crawl-longurl.test
+++ b/tests/11_crawl-longurl.test
@@ -3,10 +3,12 @@
 
 set -euo pipefail
 
-bash check-network.sh || ! echo "skipping online unit tests" || exit 77
+testdir=$(cd "$(dirname "$0")" && pwd)
+
+bash "$testdir/check-network.sh" || ! echo "skipping online unit tests" || exit 77
 
 # http://code.google.com/p/httrack/issues/detail?id=42&can=1
 # we expect 2 errors only because other links are too longs (to be modified if suitable)
-bash crawl-test.sh --errors 2 --files 1 \
+bash "$testdir/crawl-test.sh" --errors 2 --files 1 \
     --found ut.httrack.com/overflow/longquerywithaccents.html \
     httrack http://ut.httrack.com/overflow/longquerywithaccents.php

--- a/tests/11_crawl-parsing.test
+++ b/tests/11_crawl-parsing.test
@@ -3,10 +3,12 @@
 
 set -euo pipefail
 
-bash check-network.sh || ! echo "skipping online unit tests" || exit 77
+testdir=$(cd "$(dirname "$0")" && pwd)
+
+bash "$testdir/check-network.sh" || ! echo "skipping online unit tests" || exit 77
 
 # http://code.google.com/p/httrack/issues/detail?id=4&can=1
-bash crawl-test.sh --errors 0 --files 4 \
+bash "$testdir/crawl-test.sh" --errors 0 --files 4 \
     --found ut.httrack.com/parsing/back5e1f.gif \
     --found ut.httrack.com/parsing/events.html \
     --found ut.httrack.com/parsing/fade230f4.gif \
@@ -14,21 +16,21 @@ bash crawl-test.sh --errors 0 --files 4 \
     httrack http://ut.httrack.com/parsing/events.html
 
 # http://code.google.com/p/httrack/issues/detail?id=2&can=1
-bash crawl-test.sh --errors 0 --files 3 \
+bash "$testdir/crawl-test.sh" --errors 0 --files 3 \
     --found ut.httrack.com/parsing/background-image.css \
     --found ut.httrack.com/parsing/background-image.html \
     --found ut.httrack.com/parsing/fade.gif \
     httrack http://ut.httrack.com/parsing/background-image.html
 
 # javascript parsing
-bash crawl-test.sh --errors 0 --files 3 \
+bash "$testdir/crawl-test.sh" --errors 0 --files 3 \
     --found ut.httrack.com/parsing/back.gif \
     --found ut.httrack.com/parsing/fade.gif \
     --found ut.httrack.com/parsing/javascript.html \
     httrack http://ut.httrack.com/parsing/javascript.html
 
 # handling of + before query string
-bash crawl-test.sh --errors 0 --files 6 \
+bash "$testdir/crawl-test.sh" --errors 0 --files 6 \
     --found ut.httrack.com/parsing/escaping.html \
     --found "ut.httrack.com/parsing/foo bar30f4.html" \
     --found "ut.httrack.com/parsing/foo bar5e1f.html" \
@@ -39,7 +41,7 @@ bash crawl-test.sh --errors 0 --files 6 \
 
 # handling of # encoded in filename
 # see http://code.google.com/p/httrack/issues/detail?id=25
-bash crawl-test.sh --errors 2 --files 4 \
+bash "$testdir/crawl-test.sh" --errors 2 --files 4 \
     --found "ut.httrack.com/parsing/escaping2.html" \
     --found "ut.httrack.com/parsing/++foo++bar++plus++.html" \
     --found "ut.httrack.com/parsing/foo#bar#.html" \

--- a/tests/12_crawl_https.test
+++ b/tests/12_crawl_https.test
@@ -3,11 +3,13 @@
 
 set -euo pipefail
 
-bash check-network.sh || ! echo "skipping online unit tests" || exit 77
+testdir=$(cd "$(dirname "$0")" && pwd)
+
+bash "$testdir/check-network.sh" || ! echo "skipping online unit tests" || exit 77
 
 if test "${HTTPS_SUPPORT:-}" == "no"; then
     echo "no https support compiled, skipping"
     exit 77
 fi
 
-bash crawl-test.sh --errors 0 --files 5 httrack https://ut.httrack.com/simple/basic.html
+bash "$testdir/crawl-test.sh" --errors 0 --files 5 httrack https://ut.httrack.com/simple/basic.html

--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -49,6 +49,21 @@ chmod u+w "$run"/*.sh # distcheck's srcdir is read-only, and cp carries that ove
 cat >>"$run/testlib.sh" <<'EOF'
 reap_leftover_processes() { return 0; }
 EOF
+# Records who sourced this copy, so assert_staged can tell the staged driver from
+# the srcdir one. test-timeout.sh sources it too, hence the caller and not a bare
+# marker file.
+cat >>"$run/testlib.sh" <<EOF
+printf '%s\n' "\${BASH_SOURCE[1]##*/}" >>"$tmp/sourced-by"
+EOF
+: >"$tmp/sourced-by"
+
+# The suite under test has to be the staged copy: only it sources the testlib.sh
+# neutered above, and the srcdir one would reap sibling engines under "make check -j".
+assert_staged() {
+    grep -qx 'ci-windows-suite.sh' "$tmp/sourced-by" ||
+        fail "the srcdir driver ran, not the staged copy: $(sort -u "$tmp/sourced-by" | tr '\n' ' ')"
+    : >"$tmp/sourced-by"
+}
 
 bin=$tmp/bin
 mkdir -p "$bin"
@@ -117,6 +132,7 @@ cd "$run"
 rc=0
 out=$(RUNNER_TEMP="$tmp" GITHUB_STEP_SUMMARY="$tmp/summary" WATCHDOG_TOKEN=s3cr3t \
     bash ./ci-windows-suite.sh "$bin" 2>&1) || rc=$?
+assert_staged
 # The skip set and the pass floor are pinned to the real suite, so a stub run
 # ends on the floor; what is under test is the tally that reaches it.
 test "$rc" -eq 1 || fail "stub suite exited $rc, want 1 from the pass floor"
@@ -154,6 +170,7 @@ rm -f "$run/13_zlib-pass.test"
 rc=0
 out=$(RUNNER_TEMP="$tmp" GITHUB_STEP_SUMMARY="$tmp/summary" \
     bash ./ci-windows-suite.sh "$bin" 2>&1) || rc=$?
+assert_staged
 test "$rc" -eq 1 || fail "an empty category exited $rc, want 1"
 grep -q '::error::test category zlib matched no tests' <<<"$out" ||
     fail "the empty category was not named: $out"
@@ -167,6 +184,7 @@ rm -f "$run/00_runnable.test"
 rc=0
 out=$(RUNNER_TEMP="$tmp" GITHUB_STEP_SUMMARY="$tmp/summary" \
     bash ./ci-windows-suite.sh "$bin" 2>&1) || rc=$?
+assert_staged
 test "$rc" -eq 1 || fail "an empty single-test category exited $rc, want 1"
 grep -q '::error::test category runnable matched no tests' <<<"$out" ||
     fail "the empty single-test category was not named: $out"

--- a/tests/232_online-gate-outoftree.test
+++ b/tests/232_online-gate-outoftree.test
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# The online crawl gates must resolve their helper scripts against the script's
+# own directory: an out-of-tree build tree holds no copy, so a bare relative
+# path fails to open and the tests skip claiming the network is unavailable
+# (#1016). Everything here runs from an unrelated directory with the flag off,
+# so it never touches the network.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+
+work=$(mktemp -d)
+cleanup() {
+    rm -rf "$work"
+}
+trap 'set +e; cleanup' EXIT
+trap 'set +e; cleanup; exit 1' HUP INT QUIT TERM
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+# Invocations of a helper .sh by a bare name, which reads like a lookup but is
+# resolved against the caller's cwd. An explicit "./" is left alone: it says cwd
+# outright, and ci-windows-suite.sh means it, running on a staged copy. Comments
+# are dropped, local-crawl.sh documents its own usage with a bare invocation.
+scan_bare_paths() {
+    command grep -HnE '(^|[[:space:];&|(])(bash|sh|source|\.)[[:space:]]+[A-Za-z0-9_][A-Za-z0-9_./-]*\.sh([[:space:]]|$)' "$@" |
+        command grep -vE '^[^:]*:[0-9]+:[[:space:]]*#' || true
+}
+
+## the seven gated tests must skip for the reason the flag gave, not because the
+## gate script could not be opened
+
+# Discovered rather than listed, so a new online test is covered too. Matches the
+# gate line itself, not the mentions of it in comments.
+gated=$(cd "$testdir" && command grep -lE '^[[:space:]]*[^#[:space:]].*check-network\.sh.*exit 77' -- *.test | sort)
+count=$(printf '%s\n' "$gated" | command grep -c . || true)
+# Floor: the seven of #1016. A silently empty list would pass every check below.
+test "$count" -ge 7 || fail "found only $count tests gating on check-network.sh, expected at least 7"
+
+for t in $gated; do
+    out=$(cd "$work" && ONLINE_UNIT_TESTS=no bash "$testdir/$t" 2>&1) && rc=0 || rc=$?
+    test "$rc" -eq 77 || fail "$t exited $rc from an out-of-tree cwd, expected 77 (skip)"
+    # Only check-network.sh emits this, and only once it has actually run. The
+    # "skipping online unit tests" banner prints on the broken path too, so
+    # matching that instead would assert nothing.
+    command grep -q 'online tests are disabled' <<<"$out" ||
+        fail "$t skipped without the gate's reason, got: $out"
+done
+
+## the flag still decides, from an out-of-tree cwd
+
+out=$(cd "$work" && ONLINE_UNIT_TESTS=no bash "$testdir/check-network.sh" 2>&1) && rc=0 || rc=$?
+test "$rc" -eq 1 || fail "check-network.sh exited $rc with the flag off, expected 1"
+command grep -q 'online tests are disabled' <<<"$out" || fail "check-network.sh gave no reason: $out"
+
+out=$(cd "$work" && ONLINE_UNIT_TESTS=yes bash "$testdir/check-network.sh" 2>&1) && rc=0 || rc=$?
+test "$rc" -eq 0 || fail "check-network.sh exited $rc with the flag on, expected 0: $out"
+
+## no helper is invoked by a cwd-relative path anywhere in tests/
+
+# Control: the scanner must flag a planted call and spare the commented one, or
+# the sweep below is a clean result from a filter that cannot see the failure.
+planted="$work/planted.sh"
+# Assembled from a variable so this file does not trip its own sweep.
+bare='bash crawl-test.sh --errors 0 httrack http://example.com/'
+printf '%s\n' '#!/bin/bash' "$bare" "# $bare" >"$planted"
+hits=$(scan_bare_paths "$planted")
+command grep -q 'planted.sh:2:' <<<"$hits" || fail "scanner missed a planted bare path, got: $hits"
+if command grep -q 'planted.sh:3:' <<<"$hits"; then
+    fail "scanner flagged a commented example: $hits"
+fi
+
+hits=$(cd "$testdir" && scan_bare_paths -- *.test *.sh)
+test -z "$hits" || fail "helper scripts invoked by a cwd-relative path:
+$hits"
+
+echo "OK: $count gated tests skip with the flag's reason from an out-of-tree cwd"

--- a/tests/232_online-gate-outoftree.test
+++ b/tests/232_online-gate-outoftree.test
@@ -8,6 +8,10 @@
 
 set -euo pipefail
 
+# 226 asks this of every test naming the Windows suite driver, as the sweep's
+# allowlist below does.
+unset WATCHDOG_TOKEN WATCHDOG_REPO WATCHDOG_SHA WATCHDOG_URL
+
 testdir=$(cd "$(dirname "$0")" && pwd)
 
 work=$(mktemp -d)
@@ -22,17 +26,8 @@ fail() {
     exit 1
 }
 
-# Invocations of a helper .sh by a bare name, which reads like a lookup but is
-# resolved against the caller's cwd. An explicit "./" is left alone: it says cwd
-# outright, and the Windows CI driver means it, running on a staged copy.
-# Comments are dropped, local-crawl.sh documents its own usage with a bare call.
-scan_bare_paths() {
-    command grep -HnE '(^|[[:space:];&|(])(bash|sh|source|\.)[[:space:]]+[A-Za-z0-9_][A-Za-z0-9_./-]*\.sh([[:space:]]|$)' "$@" |
-        command grep -vE '^[^:]*:[0-9]+:[[:space:]]*#' || true
-}
-
-## the seven gated tests must skip for the reason the flag gave, not because the
-## gate script could not be opened
+## the gated tests must skip for the reason the flag gave, not because the gate
+## script could not be opened
 
 # Discovered rather than listed, so a new online test is covered too. Matches the
 # gate line itself, not the mentions of it in comments.
@@ -60,22 +55,118 @@ command grep -q 'online tests are disabled' <<<"$out" || fail "check-network.sh 
 out=$(cd "$work" && ONLINE_UNIT_TESTS=yes bash "$testdir/check-network.sh" 2>&1) && rc=0 || rc=$?
 test "$rc" -eq 0 || fail "check-network.sh exited $rc with the flag on, expected 0: $out"
 
-## no helper is invoked by a cwd-relative path anywhere in tests/
+## no helper anywhere in tests/ is invoked through the caller's cwd
+#
+# The gate above cannot see this class: with the flag off check-network.sh exits
+# before a test's own crawl-test.sh line is ever reached, so the sweep is the
+# only thing standing between #1016 and a rerun of it.
 
-# Control: the scanner must flag a planted call and spare the commented one, or
-# the sweep below is a clean result from a filter that cannot see the failure.
-planted="$work/planted.sh"
-# Assembled from a variable so this file does not trip its own sweep.
-bare='bash crawl-test.sh --errors 0 httrack http://example.com/'
-printf '%s\n' '#!/bin/bash' "$bare" "# $bare" >"$planted"
-hits=$(scan_bare_paths "$planted")
-command grep -q 'planted.sh:2:' <<<"$hits" || fail "scanner missed a planted bare path, got: $hits"
-if command grep -q 'planted.sh:3:' <<<"$hits"; then
-    fail "scanner flagged a commented example: $hits"
-fi
+# An invocation is safe when its operand resolves the same from any cwd: an
+# absolute path, or one built from a variable holding a directory. Quotes and a
+# leading "./" change nothing about what the shell opens, so neither is exempt.
+invoke='(^|[[:space:];&|(`])(bash|sh|source|\.)[[:space:]]+'
+quote='["'"'"']?'
+literal_re="$invoke$quote"'(\./)?[A-Za-z0-9_][A-Za-z0-9_./-]*\.sh'
+var_re="$invoke$quote"'\$\{?[A-Za-z_][A-Za-z0-9_]*\}?'"$quote"'([[:space:]]|$)'
+# Anchored at a command position, or the word inside these failure messages
+# would match and this file would pin itself.
+eval_re='(^|[;&|(`])[[:space:]]*eval[[:space:]]'
 
-hits=$(cd "$testdir" && scan_bare_paths -- *.test *.sh)
-test -z "$hits" || fail "helper scripts invoked by a cwd-relative path:
+# The only two call sites that mean the cwd: each cd's into a directory it has
+# just filled with copies, and the copy is the target. Named rather than matched
+# by shape, because a shape exemption cannot tell them from #1016 in disguise.
+allowed='172_ci-windows-driver.test ci-windows-suite.sh
+ci-windows-suite.sh test-timeout.sh'
+
+# Matching lines of the given files as file:line:text, comments dropped:
+# local-crawl.sh documents its own usage with a bare call.
+code_lines() {
+    local re=$1
+    shift
+    command grep -HnE "$re" -- "$@" | command grep -vE '^[^:]*:[0-9]+:[[:space:]]*#' || true
+}
+
+# Prints every invocation resolved against the caller's cwd, and every one whose
+# operand it cannot resolve. Silence means the files are clean.
+sweep() {
+    local hit file text script var val
+
+    while IFS= read -r hit; do
+        test -n "$hit" || continue
+        file=${hit%%:*}
+        text=${hit#*:}
+        text=${text#*:}
+        script=$(command grep -oE '[A-Za-z0-9_][A-Za-z0-9_./-]*\.sh' <<<"$text" | head -1)
+        command grep -qxF "${file##*/} $script" <<<"$allowed" || echo "cwd-relative: $hit"
+    done < <(code_lines "$literal_re" "$@")
+
+    # A variable operand is only as good as what it holds, so resolve it: an
+    # assignment that is not itself anchored, or that cannot be found in the
+    # file at all, is reported rather than assumed innocent.
+    while IFS= read -r hit; do
+        test -n "$hit" || continue
+        file=${hit%%:*}
+        text=${hit#*:}
+        text=${text#*:}
+        var=$(command grep -oE "$var_re" <<<"$text" | head -1 |
+            sed -E 's/.*\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?.*/\1/')
+        val=$(command grep -hE "^[[:space:]]*$var=" "$file" | head -1)
+        val=${val#*=}
+        val=${val#[\"\']}
+        case $val in
+        /* | \$*) ;;
+        *) echo "unresolved \$$var: $hit" ;;
+        esac
+    done < <(code_lines "$var_re" "$@")
+}
+
+# eval hides its operand from any static reading, so the set of them is pinned
+# instead: a new one fails here and gets a human's eye rather than passing unseen.
+scan_eval() {
+    code_lines "$eval_re" "$@" |
+        sed -E 's#^\./##; s/^([^:]*):[0-9]+:[[:space:]]*(.*[[:space:]])?eval[[:space:]]+/\1 /'
+}
+
+# Controls. Each evasion is a printf format here, so the forms under test reach
+# the fixtures without appearing in this file as invocations the sweep would see.
+name=crawl-test.sh
+driver=ci-windows-suite.sh
+ev=$work/evasions
+mkdir -p "$ev"
+printf '#!/bin/bash\nbash %s --errors 0\n' "$name" >"$ev/bare.sh"
+printf '#!/bin/bash\nbash ./%s --errors 0\n' "$name" >"$ev/dotslash.sh"
+printf '#!/bin/bash\nbash "%s" --errors 0\n' "$name" >"$ev/quoted.sh"
+# shellcheck disable=SC2016 # the fixture's text, not this shell's
+printf '#!/bin/bash\nS=%s\nbash $S --errors 0\n' "$name" >"$ev/indirect.sh"
+# shellcheck disable=SC2016 # the fixture's text, not this shell's
+printf '#!/bin/bash\nbash ./%s "$bin"\n' "$driver" >"$ev/impostor.sh"
+# shellcheck disable=SC2016 # the fixture's text, not this shell's
+printf '#!/bin/bash\nG="$testdir/%s"\nbash $G --errors 0\n' "$name" >"$ev/anchored.sh"
+printf '#!/bin/bash\n# bash %s --errors 0\n' "$name" >"$ev/commented.sh"
+
+for f in bare dotslash quoted indirect impostor; do
+    test -n "$(sweep "$ev/$f.sh")" || fail "the sweep let $f through: $(tail -n +2 "$ev/$f.sh")"
+done
+# The other half of the control: a rule that flags everything proves nothing.
+for f in anchored commented; do
+    out=$(sweep "$ev/$f.sh")
+    test -z "$out" || fail "the sweep flagged $f.sh, which is correct code: $out"
+done
+printf '#!/bin/bash\neval "bash %s"\n' "$name" >"$ev/eval.sh"
+test -n "$(scan_eval "$ev/eval.sh")" || fail "the eval scan missed a planted eval"
+
+hits=$(cd "$testdir" && sweep ./*.test ./*.sh)
+test -z "$hits" || fail "helper scripts reachable only from the right cwd:
 $hits"
 
-echo "OK: $count gated tests skip with the flag's reason from an out-of-tree cwd"
+# Pinned by operand, since none of these builds a command naming a helper today.
+# shellcheck disable=SC2016 # the pinned operands, quoted as they appear
+reviewed='145_webhttrack-datadir.test "${line}"
+231_tests-list-bijection.test "$mutate")
+61_webhttrack-locale.test "${block}"
+61_webhttrack-locale.test "${funcs}"'
+got=$(cd "$testdir" && scan_eval ./*.test ./*.sh | sort)
+test "$got" = "$(sort <<<"$reviewed")" || fail "the set of eval sites changed; each hides its operand from the sweep and needs reading:
+$got"
+
+echo "OK: $count gated tests skip with the flag's reason, and tests/ is free of cwd-relative helper calls"

--- a/tests/232_online-gate-outoftree.test
+++ b/tests/232_online-gate-outoftree.test
@@ -24,8 +24,8 @@ fail() {
 
 # Invocations of a helper .sh by a bare name, which reads like a lookup but is
 # resolved against the caller's cwd. An explicit "./" is left alone: it says cwd
-# outright, and ci-windows-suite.sh means it, running on a staged copy. Comments
-# are dropped, local-crawl.sh documents its own usage with a bare invocation.
+# outright, and the Windows CI driver means it, running on a staged copy.
+# Comments are dropped, local-crawl.sh documents its own usage with a bare call.
 scan_bare_paths() {
     command grep -HnE '(^|[[:space:];&|(])(bash|sh|source|\.)[[:space:]]+[A-Za-z0-9_][A-Za-z0-9_./-]*\.sh([[:space:]]|$)' "$@" |
         command grep -vE '^[^:]*:[0-9]+:[[:space:]]*#' || true

--- a/tests/check-network.sh
+++ b/tests/check-network.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 
+testdir=$(cd "$(dirname "$0")" && pwd)
+
 # ensure the httrack unit tests are available so that ut will not break
 # the build in case of network outage
 
@@ -32,7 +34,7 @@ else
         fi
 
     # fetch single file
-    elif bash crawl-test.sh --errors 0 --files 1 httrack --timeout=3 --max-time=3 "$url" 2>/dev/null >/dev/null; then
+    elif bash "$testdir/crawl-test.sh" --errors 0 --files 1 httrack --timeout=3 --max-time=3 "$url" 2>/dev/null >/dev/null; then
         echo "ok" >$cache
         exit 0
     else

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -266,3 +266,4 @@ TESTS += 224_engine-ftp-cmdlen.test
 TESTS += 230_local-ftp-userpass.test
 TESTS += 225_install-manifest.test
 TESTS += 231_tests-list-bijection.test
+TESTS += 232_online-gate-outoftree.test


### PR DESCRIPTION
The seven online crawl tests gate on `bash check-network.sh`, a bare name the shell resolves against the caller's cwd rather than the script's own directory. `make check` runs from the build tree's `tests/`, and an out-of-tree build keeps no copy there, so the gate never opened at all: the `||` branch reported "skipping online unit tests" and the tests skipped whatever `--enable-online-unit-tests` had asked for. In-tree builds (CI, `dpkg-buildpackage`) do find the script, which is why this went unnoticed. Resolving against `$(dirname "$0")`, the idiom `local-crawl.sh` already uses, covers the whole set of bare paths: the gate in all seven tests, their fifteen `crawl-test.sh` calls, and the auto-probe call inside `check-network.sh` itself.

An out-of-tree build can now reach the network, though only when asked: the option defaults to `no`, and its help string wrongly advertised `yes`, fixed here. Test 232 runs each gated test from an unrelated cwd with the flag off and checks that the skip carries the gate's own reason. Matching the "skipping online unit tests" banner would prove nothing, since it prints on the broken path too. Nothing in the test touches the network.

Below the gate, the sweep in test 232 is the only thing that can see the problem, since with the flag off `check-network.sh` exits before a test reaches its own `crawl-test.sh` line. So it does not exempt an invocation by shape. Quoting a bare name, or writing it as `./crawl-test.sh`, does not change what the shell opens, and the two call sites that really do mean the cwd are named instead: `172_ci-windows-driver.test` running `ci-windows-suite.sh`, and `ci-windows-suite.sh` running `test-timeout.sh`, each of which `cd`s into a directory it has just filled with copies. A variable operand is resolved back to its assignment. `eval` hides its operand from any static reading, so those sites are pinned as a set and a new one has to be read rather than passing unseen. Each form is planted as a fixture and confirmed caught, with anchored and commented fixtures for the other direction.

Separately, `172_ci-windows-driver.test` never asserted that it ran its own staged copy of the suite. Pointing it at the srcdir copy passed, which drops the `reap_leftover_processes` neuter it appends to the staged `testlib.sh` and leaves the test reaping sibling engines under `make check -j`. The staged `testlib.sh` now records which script sourced it, and the test requires that to be the driver.

Closes #1016