### PR TITLE
The engine frees the transfer slots while an FTP thread is still writing to one

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -5,8 +5,7 @@ HTTrack Website Copier release history:
 This file lists all changes and fixes that have been made for HTTrack
 
 3.49-19
-+ Fixed: a crash when a mirror limit was reached while an FTP file was still downloading; the engine released the transfer slots without waiting for the FTP thread still writing to them (#1051)
-+ Fixed: --max-size and --max-time could not stop an FTP download that was already under way (#1051)
++ Fixed: when --max-size or --max-time was reached while an FTP file was still downloading, HTTrack could crash, or take up to five minutes to exit, instead of ending the transfer and stopping (#1051)
 
 3.49-18
 + Fixed: the 3.49.17 package build failed on four architectures: the test suite's mmap interposer did not compile on armhf, powerpc or hppa, and the alternate-stack test rejected loong64's shorter backtrace (#1023)

--- a/history.txt
+++ b/history.txt
@@ -4,6 +4,10 @@ HTTrack Website Copier release history:
 
 This file lists all changes and fixes that have been made for HTTrack
 
+3.49-19
++ Fixed: a crash when a mirror limit was reached while an FTP file was still downloading; the engine released the transfer slots without waiting for the FTP thread still writing to them (#1051)
++ Fixed: --max-size and --max-time could not stop an FTP download that was already under way (#1051)
+
 3.49-18
 + Fixed: the 3.49.17 package build failed on four architectures: the test suite's mmap interposer did not compile on armhf, powerpc or hppa, and the alternate-stack test rejected loong64's shorter backtrace (#1023)
 + Fixed: the test suite failed on a host with no ps command, such as a Fedora build root; its hang diagnostics now read /proc directly (#1021)

--- a/history.txt
+++ b/history.txt
@@ -4,9 +4,6 @@ HTTrack Website Copier release history:
 
 This file lists all changes and fixes that have been made for HTTrack
 
-3.49-19
-+ Fixed: when --max-size or --max-time was reached while an FTP file was still downloading, HTTrack could crash, or take up to five minutes to exit, instead of ending the transfer and stopping (#1051)
-
 3.49-18
 + Fixed: the 3.49.17 package build failed on four architectures: the test suite's mmap interposer did not compile on armhf, powerpc or hppa, and the alternate-stack test rejected loong64's shorter backtrace (#1023)
 + Fixed: the test suite failed on a host with no ps command, such as a Fedora build root; its hang diagnostics now read /proc directly (#1021)

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -226,7 +226,7 @@ void back_delete_all(httrackp * opt, cache_back * cache, struct_back * sback) {
     int i;
 
     /* An FTP worker writes through its slot until it returns, so nothing here
-       may wipe or free one under it (#1051). */
+       may wipe or free one under it. */
     ftp_stop_workers();
     // delete live slots
     for(i = 0; i < sback->count; i++) {

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -225,6 +225,9 @@ void back_delete_all(httrackp * opt, cache_back * cache, struct_back * sback) {
   if (sback != NULL) {
     int i;
 
+    /* An FTP worker writes through its slot until it returns, so nothing here
+       may wipe or free one under it (#1051). */
+    ftp_stop_workers();
     // delete live slots
     for(i = 0; i < sback->count; i++) {
       back_delete(opt, cache, sback, i);

--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -62,8 +62,8 @@ Please visit our Website: http://www.httrack.com
 
 /* Live FTP workers. Each writes through its backlog slot and reads opt for its
    whole run, so neither may be freed while the list is not empty (#1051).
-   Registered at spawn rather than at thread entry, so a launch immediately
-   followed by the wait still covers it (#747). */
+   Registration happens at spawn, not at thread entry: a worker that has not
+   been scheduled yet must already hold the list against a teardown. */
 static FTPDownloadStruct *ftp_workers = NULL;
 static htsmutex ftp_workers_mutex = HTSMUTEX_INIT;
 

--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -60,11 +60,54 @@ Please visit our Website: http://www.httrack.com
 
 #if USE_BEGINTHREAD
 
+/* Live FTP workers. Each writes through its backlog slot and reads opt for its
+   whole run, so neither may be freed while the list is not empty (#1051).
+   Registered at spawn rather than at thread entry, so a launch immediately
+   followed by the wait still covers it (#747). */
+static FTPDownloadStruct *ftp_workers = NULL;
+static htsmutex ftp_workers_mutex = HTSMUTEX_INIT;
+
+static void ftp_worker_register(FTPDownloadStruct *worker) {
+  hts_mutexlock(&ftp_workers_mutex);
+  worker->pNext = ftp_workers;
+  ftp_workers = worker;
+  hts_mutexrelease(&ftp_workers_mutex);
+}
+
+static void ftp_worker_unregister(FTPDownloadStruct *worker) {
+  FTPDownloadStruct **prev;
+
+  hts_mutexlock(&ftp_workers_mutex);
+  for (prev = &ftp_workers; *prev != NULL; prev = &(*prev)->pNext) {
+    if (*prev == worker) {
+      *prev = worker->pNext;
+      break;
+    }
+  }
+  hts_mutexrelease(&ftp_workers_mutex);
+}
+
+void ftp_stop_workers(void) {
+  int wait;
+
+  do {
+    FTPDownloadStruct *worker;
+
+    hts_mutexlock(&ftp_workers_mutex);
+    /* Idempotent, and re-raised each pass so a worker registered meanwhile is
+       not missed. A registered worker's slot is still live by construction:
+       back_delete_all() drains before back_free(). */
+    for (worker = ftp_workers; worker != NULL; worker = worker->pNext)
+      worker->pBack->stop_ftp = HTS_TRUE;
+    wait = ftp_workers != NULL;
+    hts_mutexrelease(&ftp_workers_mutex);
+    if (wait)
+      Sleep(100);
+  } while (wait);
+}
+
 void back_launch_ftp(void *pP) {
   FTPDownloadStruct *pStruct = (FTPDownloadStruct *) pP;
-
-  if (pStruct == NULL)
-    return;
 
   if (pStruct == NULL) {
 #if FTP_DEBUG
@@ -84,11 +127,15 @@ void back_launch_ftp(void *pP) {
   // prêt
   pStruct->pBack->status = STATUS_FTP_READY;
 
-  /* Delete structure */
-  free(pP);
-
   /* Uninitialize */
   hts_uninit();
+
+  /* The status store above was this worker's last read of the slot and of opt;
+     deregistering lets the engine free both. */
+  ftp_worker_unregister(pStruct);
+
+  /* Delete structure */
+  free(pP);
   return;
 }
 
@@ -98,7 +145,16 @@ void launch_ftp(FTPDownloadStruct * params) {
 #if FTP_DEBUG
   printf("[Launching main ftp thread]\n");
 #endif
-  hts_newthread(back_launch_ftp, (void *) params);
+  ftp_worker_register(params);
+  if (hts_newthread(back_launch_ftp, (void *) params) != 0) {
+    /* Nobody would ever reap a slot left in STATUS_FTP_TRANSFER, and
+       ftp_stop_workers() would never return. */
+    ftp_worker_unregister(params);
+    strcpybuff(params->pBack->r.msg, "Unable to launch FTP thread");
+    params->pBack->r.statuscode = STATUSCODE_INVALID;
+    params->pBack->status = STATUS_FTP_READY;
+    free(params);
+  }
 }
 
 #else
@@ -388,14 +444,14 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
       // envoi du login
 
       // --USER--
-      get_ftp_line(soc_ctl, line, sizeof(line), timeout);     // en tête
+      get_ftp_line(back, soc_ctl, line, sizeof(line), timeout); // en tête
       _CHECK_HALT_FTP;
 
       if (line[0] == '2') {     // ok, connecté
         strcpybuff(back->info, "login: user");
         snprintf(line, sizeof(line), "USER %s", user);
         send_line(soc_ctl, line);
-        get_ftp_line(soc_ctl, line, sizeof(line), timeout);
+        get_ftp_line(back, soc_ctl, line, sizeof(line), timeout);
         _CHECK_HALT_FTP;
         if ((line[0] == '3') || (line[0] == '2')) {
           // --PASS--
@@ -403,12 +459,12 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
             strcpybuff(back->info, "login: pass");
             snprintf(line, sizeof(line), "PASS %s", pass);
             send_line(soc_ctl, line);
-            get_ftp_line(soc_ctl, line, sizeof(line), timeout);
+            get_ftp_line(back, soc_ctl, line, sizeof(line), timeout);
             _CHECK_HALT_FTP;
           }
           if (line[0] == '2') { // ok
             send_line(soc_ctl, "TYPE I");
-            get_ftp_line(soc_ctl, line, sizeof(line), timeout);
+            get_ftp_line(back, soc_ctl, line, sizeof(line), timeout);
             _CHECK_HALT_FTP;
             if (line[0] == '2') {
               // ok
@@ -441,7 +497,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
           strcpybuff(back->info, "pasv");
           snprintf(line, sizeof(line), "PASV");
           send_line(soc_ctl, line);
-          get_ftp_line(soc_ctl, line, sizeof(line), timeout);
+          get_ftp_line(back, soc_ctl, line, sizeof(line), timeout);
         } else {                /* ipv6 */
           line[0] = '\0';
         }
@@ -503,7 +559,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
           strcpybuff(back->info, "pasv");
           snprintf(line, sizeof(line), "EPSV");
           send_line(soc_ctl, line);
-          get_ftp_line(soc_ctl, line, sizeof(line), timeout);
+          get_ftp_line(back, soc_ctl, line, sizeof(line), timeout);
           _CHECK_HALT_FTP;
           if (line[0] == '2') { /* got it */
             char *a;
@@ -546,7 +602,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
               // SIZE?
               strcpybuff(back->info, "size");
               send_line(soc_ctl, line);
-              get_ftp_line(soc_ctl, line, sizeof(line), timeout);
+              get_ftp_line(back, soc_ctl, line, sizeof(line), timeout);
               _CHECK_HALT_FTP;
               if (line[0] == '2') {     // SIZE compris, ALORS tester REST (sinon pas tester: cf probleme des txt.gz decompresses a la volee)
                 char *szstr = strchr(line, ' ');
@@ -566,7 +622,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
                 if (ftp_command_line(line, "MDTM", ftp_path)) {
                   strcpybuff(back->info, "mdtm");
                   send_line(soc_ctl, line);
-                  get_ftp_line(soc_ctl, line, sizeof(line), timeout);
+                  get_ftp_line(back, soc_ctl, line, sizeof(line), timeout);
                   _CHECK_HALT_FTP;
                   if (ftp_parse_mdtm(line, &remote_tm)) {
                     char date[256];
@@ -592,7 +648,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
                   snprintf(line, sizeof(line), "REST " LLintP,
                            (LLint) back->range_req_size);
                   send_line(soc_ctl, line);
-                  get_ftp_line(soc_ctl, line, sizeof(line), timeout);
+                  get_ftp_line(back, soc_ctl, line, sizeof(line), timeout);
                   _CHECK_HALT_FTP;
                   if ((line[0] == '3') || (line[0] == '2')) {   // ok
                     rest_understood = 1;
@@ -645,7 +701,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
                 line[0] = '\0';
                 strlncatbuff(line, line_retr, sizeof(line), sizeof(line) - 1);
                 send_line(soc_ctl, line);
-                get_ftp_line(soc_ctl, line, sizeof(line), timeout);
+                get_ftp_line(back, soc_ctl, line, sizeof(line), timeout);
                 _CHECK_HALT_FTP;
                 if (line[0] == '1') {
                   // OK
@@ -686,7 +742,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
         if ((soc_servdat = get_datasocket(line, sizeof(line))) != INVALID_SOCKET) {
           _CHECK_HALT_FTP;
           send_line(soc_ctl, line);     // envoi du RETR
-          get_ftp_line(soc_ctl, line, sizeof(line), timeout);
+          get_ftp_line(back, soc_ctl, line, sizeof(line), timeout);
           _CHECK_HALT_FTP;
           if (line[0] == '2') { // ok
             strcpybuff(back->info, "retr");
@@ -694,7 +750,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
             line[0] = '\0';
             strlncatbuff(line, line_retr, sizeof(line), sizeof(line) - 1);
             send_line(soc_ctl, line);
-            get_ftp_line(soc_ctl, line, sizeof(line), timeout);
+            get_ftp_line(back, soc_ctl, line, sizeof(line), timeout);
             _CHECK_HALT_FTP;
             if (line[0] == '1') {
               //T_SOC soc_dat;
@@ -749,14 +805,17 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
             while((len > 0) && (!stop_ftp(back))) {
               // attendre les données
               len = 1;          // pas d'erreur pour le moment
-              switch (wait_socket_receive(soc_dat, timeout)) {
+              switch (wait_socket_receive(back, soc_dat, timeout)) {
               case -1:
                 strcpybuff(back->r.msg, "FTP read error");
                 back->r.statuscode = STATUSCODE_INVALID;
                 len = 0;        // fin
                 break;
               case 0:
-                htsblk_failf(&back->r, "Time out (%d)", timeout);
+                /* stop_ftp() names the real reason when it is the stop that
+                   cut the wait short. */
+                if (!stop_ftp(back))
+                  htsblk_failf(&back->r, "Time out (%d)", timeout);
                 back->r.statuscode = STATUSCODE_INVALID;
                 len = 0;        // fin
                 break;
@@ -816,9 +875,9 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
 
           // 226 Transfer complete?
           if (back->r.statuscode != -1) {
-            if (wait_socket_receive(soc_ctl, timeout_onfly) > 0) {
+            if (wait_socket_receive(back, soc_ctl, timeout_onfly) > 0) {
               // récupérer 226 transfer complete
-              get_ftp_line(soc_ctl, line, sizeof(line), timeout);
+              get_ftp_line(back, soc_ctl, line, sizeof(line), timeout);
               if (line[0] == '2') {     // OK
                 strcpybuff(back->r.msg, "OK");
                 back->r.statuscode = HTTP_OK;
@@ -841,7 +900,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
     _CHECK_HALT_FTP;
     strcpybuff(back->info, "quit");
     send_line(soc_ctl, "QUIT"); // bye bye
-    get_ftp_line(soc_ctl, NULL, 0, timeout);
+    get_ftp_line(back, soc_ctl, NULL, 0, timeout);
 #ifdef _WIN32
     closesocket(soc_ctl);
 #else
@@ -998,7 +1057,8 @@ int send_line(T_SOC soc, const char *data) {
 #endif
 }
 
-int get_ftp_line(T_SOC soc, char *ptrline, size_t line_size, int timeout) {
+int get_ftp_line(lien_back *back, T_SOC soc, char *ptrline, size_t line_size,
+                 int timeout) {
   char BIGSTK data[1024];
   int i, ok, multiline;
 
@@ -1014,7 +1074,7 @@ int get_ftp_line(T_SOC soc, char *ptrline, size_t line_size, int timeout) {
     char b;
 
     // vérifier données
-    switch (wait_socket_receive(soc, timeout)) {
+    switch (wait_socket_receive(back, soc, timeout)) {
     case -1:                   // erreur de lecture
       if (ptrline)
         snprintf(ptrline, line_size, "500 *read error");
@@ -1126,7 +1186,7 @@ int check_socket_connect(T_SOC soc) {
 }
 
 // attendre des données
-int wait_socket_receive(T_SOC soc, int timeout) {
+int wait_socket_receive(lien_back *back, T_SOC soc, int timeout) {
   // attendre les données
   TStamp ltime = time_local();
   int r;
@@ -1135,8 +1195,10 @@ int wait_socket_receive(T_SOC soc, int timeout) {
   printf("\x0dWaiting for data ");
   fflush(stdout);
 #endif
-  while((!(r = check_socket(soc)))
-        && (((int) ((TStamp) (time_local() - ltime))) < timeout)) {
+  /* A stop raised by the engine ends the wait on the next 100ms tick instead of
+     after the full timeout, so teardown does not sit on a silent server. */
+  while ((!(r = check_socket(soc))) && (back == NULL || !back->stop_ftp) &&
+         (((int) ((TStamp) (time_local() - ltime))) < timeout)) {
     Sleep(100);
 #if FTP_DEBUG
     printf(".");

--- a/src/htsftp.h
+++ b/src/htsftp.h
@@ -55,6 +55,7 @@ typedef struct FTPDownloadStruct FTPDownloadStruct;
 struct FTPDownloadStruct {
   lien_back *pBack;
   httrackp *pOpt;
+  FTPDownloadStruct *pNext; /* live-worker list, owned by htsftp.c */
 };
 
 /* Library internal definictions */
@@ -65,6 +66,11 @@ struct FTPDownloadStruct {
 #if USE_BEGINTHREAD
 void launch_ftp(FTPDownloadStruct * params);
 void back_launch_ftp(void *pP);
+/* Cancel every live FTP worker and block until each has stopped reading its
+   backlog slot and opt. Must be called before either is freed (#1051); the
+   workers poll the flag inside their socket waits, so this costs a tick rather
+   than the rest of the transfer. */
+void ftp_stop_workers(void);
 #else
 void launch_ftp(FTPDownloadStruct * params, char *path, char *exec);
 int back_launch_ftp(FTPDownloadStruct * params);
@@ -72,7 +78,10 @@ int back_launch_ftp(FTPDownloadStruct * params);
 
 int run_launch_ftp(FTPDownloadStruct * params);
 int send_line(T_SOC soc, const char *data);
-int get_ftp_line(T_SOC soc, char *line, size_t line_size, int timeout);
+/* Read one control-channel reply into line[line_size]. back may be NULL; when
+   given, a stop raised on it ends the wait early. Returns 0 on error. */
+int get_ftp_line(lien_back *back, T_SOC soc, char *line, size_t line_size,
+                 int timeout);
 /* Split a "user[:pass]@" prefix (end = jump_identification result) into
    NUL-terminated user/pass buffers. Returns HTS_FALSE and empties both when a
    field does not fit, as a clipped one would name another account.
@@ -102,7 +111,9 @@ int stop_ftp(lien_back * back);
 char *linejmp(char *line);
 int check_socket(T_SOC soc);
 int check_socket_connect(T_SOC soc);
-int wait_socket_receive(T_SOC soc, int timeout);
+/* Wait up to timeout seconds for soc to become readable. back may be NULL;
+   when given, a stop raised on it cuts the wait short. */
+int wait_socket_receive(lien_back *back, T_SOC soc, int timeout);
 #endif
 
 #endif

--- a/src/htsftp.h
+++ b/src/htsftp.h
@@ -66,10 +66,8 @@ struct FTPDownloadStruct {
 #if USE_BEGINTHREAD
 void launch_ftp(FTPDownloadStruct * params);
 void back_launch_ftp(void *pP);
-/* Cancel every live FTP worker and block until each has stopped reading its
-   backlog slot and opt. Must be called before either is freed (#1051); the
-   workers poll the flag inside their socket waits, so this costs a tick rather
-   than the rest of the transfer. */
+/* Cancel every live FTP worker and block until each stops touching its backlog
+   slot and opt. Call before freeing either. */
 void ftp_stop_workers(void);
 #else
 void launch_ftp(FTPDownloadStruct * params, char *path, char *exec);

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -47,6 +47,7 @@ Please visit our Website: http://www.httrack.com
 #include "htsbauth.h"
 #include "htsthread.h"
 #include "htsback.h"
+#include "htsftp.h"
 #include "htswrap.h"
 #include "htsmd5.h"
 #include "htsmodules.h"
@@ -6126,6 +6127,9 @@ HTSEXT_API size_t hts_sizeof_opt(void) {
 
 HTSEXT_API void hts_free_opt(httrackp * opt) {
   if (opt != NULL) {
+    /* An FTP worker reads opt for its whole run, and not every caller drains
+       its threads the way httrack.c does before getting here (#1051). */
+    ftp_stop_workers();
 
     /* Alocated callbacks */
 

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -6128,7 +6128,7 @@ HTSEXT_API size_t hts_sizeof_opt(void) {
 HTSEXT_API void hts_free_opt(httrackp * opt) {
   if (opt != NULL) {
     /* An FTP worker reads opt for its whole run, and not every caller drains
-       its threads the way httrack.c does before getting here (#1051). */
+       its threads the way httrack.c does before getting here. */
     ftp_stop_workers();
 
     /* Alocated callbacks */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4494,7 +4494,7 @@ static int st_ftpline(httrackp *opt, int argc, char **argv) {
   assertf(send(sv[1], "\r\n", 2, 0) == 2); // end the line so we return
   deletesoc(sv[1]);
   line[0] = '\0';
-  get_ftp_line(sv[0], line, sizeof(line), 5);
+  get_ftp_line(NULL, sv[0], line, sizeof(line), 5);
   deletesoc(sv[0]);
   printf("ftp-line self-test OK (bounded %d-byte reply)\n",
          (int) sizeof(flood));

--- a/tests/236_local-ftp-teardown.test
+++ b/tests/236_local-ftp-teardown.test
@@ -33,6 +33,15 @@ fail() {
 ok() { echo "OK: $*"; }
 size_of() { wc -c <"$1" | tr -d '[:space:]'; }
 
+errlog="${tmpdir}/httrack.err"
+# A sanitized build reports the use-after-free and still exits 1, so the status
+# alone is blind to it. Leaks at exit are out of scope, hence no LeakSanitizer.
+assert_clean_run() {
+    cat "$errlog" >&2 # the redirect must not cost the harness log the crawl's stderr
+    ! grep -Eq 'AddressSanitizer:|MemorySanitizer:|runtime error:' "$errlog" ||
+        fail "$1: the crawl produced a sanitizer report (#1051)"
+}
+
 root="${tmpdir}/root"
 modes="${tmpdir}/modes"
 mkdir -p "$root"
@@ -61,8 +70,9 @@ out="${tmpdir}/trickle"
 rc=0
 start=$SECONDS
 run_with_timeout 120 httrack "ftp://127.0.0.1:${port}/f.bin" -O "$out" --quiet \
-    --disable-security-limits --robots=0 --timeout=200 -M"$CAP" -c1 || rc=$?
+    --disable-security-limits --robots=0 --timeout=200 -M"$CAP" -c1 2>"$errlog" || rc=$?
 elapsed=$((SECONDS - start))
+assert_clean_run "trickle"
 test "$rc" -ne 124 || fail "trickle crawl overran its 120s cap"
 # Faults reliably only while the backlog array stays mmap-sized: free() unmaps it.
 test "$rc" -lt 128 || fail "trickle crawl died on signal $((rc - 128)) (#1051)"
@@ -81,8 +91,9 @@ out="${tmpdir}/stall"
 rc=0
 start=$SECONDS
 run_with_timeout 120 httrack "ftp://127.0.0.1:${port}/f.bin" -O "$out" --quiet \
-    --disable-security-limits --robots=0 --timeout=200 -M"$CAP" -c1 || rc=$?
+    --disable-security-limits --robots=0 --timeout=200 -M"$CAP" -c1 2>"$errlog" || rc=$?
 elapsed=$((SECONDS - start))
+assert_clean_run "stall"
 test "$rc" -ne 124 || fail "stalled crawl overran its 120s cap, teardown is unbounded"
 test "$rc" -lt 128 || fail "stalled crawl died on signal $((rc - 128)) (#1051)"
 assert_capped "$out" "stall"

--- a/tests/236_local-ftp-teardown.test
+++ b/tests/236_local-ftp-teardown.test
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# An FTP transfer runs in a detached thread that writes through its backlog
+# slot, and the engine freed that array without waiting for it (#1051): a
+# --max-size cap reached while a slow server was still sending segfaulted in
+# run_launch_ftp. The stalled pass pins the drain as bounded rather than merely
+# patient -- a silent server must not hold teardown for the FTP read timeout.
+
+set -euo pipefail
+
+: "${top_srcdir:=..}"
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
+command -v httrack >/dev/null || {
+    echo "could not find httrack" >&2
+    exit 1
+}
+
+server=$(nativepath "${testdir}/ftp-server.py")
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")
+serverpid=
+cleanup() {
+    stop_server "$serverpid"
+    rm -rf "$tmpdir"
+}
+trap 'set +e; cleanup' EXIT
+trap cleanup HUP INT QUIT PIPE TERM
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+ok() { echo "OK: $*"; }
+size_of() { wc -c <"$1" | tr -d '[:space:]'; }
+
+root="${tmpdir}/root"
+modes="${tmpdir}/modes"
+mkdir -p "$root"
+# Big enough that neither mode can finish before the cap trips.
+"$python" -c 'import sys; sys.stdout.buffer.write(b"F" * 4194304)' >"${root}/f.bin"
+
+serverlog="${tmpdir}/server.out"
+"$python" "$server" --root "$(nativepath "$root")" \
+    --mode-file "$(nativepath "$modes")" >"$serverlog" 2>&1 &
+serverpid=$!
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+
+CAP=100000
+
+# The cap must trip with the transfer still in flight, or nothing here is tested.
+assert_capped() {
+    local out=$1 got
+    got=$(size_of "${out}/127.0.0.1_${port}/f.bin" 2>/dev/null || echo 0)
+    test "$got" -ge "$CAP" ||
+        fail "$2: only ${got} bytes arrived, the ${CAP}-byte cap never tripped"
+}
+
+# --- the crash: cap reached while the FTP thread is still writing to its slot
+echo "* trickle" >"$modes"
+out="${tmpdir}/trickle"
+rc=0
+run_with_timeout 120 httrack "ftp://127.0.0.1:${port}/f.bin" -O "$out" --quiet \
+    --disable-security-limits --robots=0 --timeout=200 -M"$CAP" -c1 || rc=$?
+test "$rc" -ne 124 || fail "trickle crawl overran its 120s cap"
+test "$rc" -lt 128 || fail "trickle crawl died on signal $((rc - 128)) (#1051)"
+assert_capped "$out" "trickle"
+ok "a --max-size cap on a trickling FTP transfer exits cleanly (rc=${rc})"
+
+# --- the bound: teardown cancels the thread instead of waiting out its read.
+# The FTP data read is a 300s wait, so anything near that means the stop flag
+# was only seen between operations.
+echo "* stall" >"$modes"
+out="${tmpdir}/stall"
+rc=0
+start=$SECONDS
+run_with_timeout 120 httrack "ftp://127.0.0.1:${port}/f.bin" -O "$out" --quiet \
+    --disable-security-limits --robots=0 --timeout=200 -M"$CAP" -c1 || rc=$?
+elapsed=$((SECONDS - start))
+test "$rc" -ne 124 || fail "stalled crawl overran its 120s cap, teardown is unbounded"
+test "$rc" -lt 128 || fail "stalled crawl died on signal $((rc - 128)) (#1051)"
+assert_capped "$out" "stall"
+test "$elapsed" -lt 60 ||
+    fail "stalled crawl took ${elapsed}s, teardown waited out the FTP read"
+ok "teardown of a stalled FTP transfer took ${elapsed}s"

--- a/tests/236_local-ftp-teardown.test
+++ b/tests/236_local-ftp-teardown.test
@@ -1,10 +1,7 @@
 #!/bin/bash
 #
-# An FTP transfer runs in a detached thread that writes through its backlog
-# slot, and the engine freed that array without waiting for it (#1051): a
-# --max-size cap reached while a slow server was still sending segfaulted in
-# run_launch_ftp. The stalled pass pins the drain as bounded rather than merely
-# patient -- a silent server must not hold teardown for the FTP read timeout.
+# Regression test for #1051: the engine freed FTP transfer slots a worker thread
+# was still writing to.
 
 set -euo pipefail
 
@@ -62,12 +59,19 @@ assert_capped() {
 echo "* trickle" >"$modes"
 out="${tmpdir}/trickle"
 rc=0
+start=$SECONDS
 run_with_timeout 120 httrack "ftp://127.0.0.1:${port}/f.bin" -O "$out" --quiet \
     --disable-security-limits --robots=0 --timeout=200 -M"$CAP" -c1 || rc=$?
+elapsed=$((SECONDS - start))
 test "$rc" -ne 124 || fail "trickle crawl overran its 120s cap"
+# Faults reliably only while the backlog array stays mmap-sized: free() unmaps it.
 test "$rc" -lt 128 || fail "trickle crawl died on signal $((rc - 128)) (#1051)"
 assert_capped "$out" "trickle"
-ok "a --max-size cap on a trickling FTP transfer exits cleanly (rc=${rc})"
+# A drain that waits the transfer out instead of cancelling it also exits 0, and
+# the trickle runs ~100s against ~3s for a cancel, so budget the clock as well.
+test "$elapsed" -lt 30 ||
+    fail "trickle crawl took ${elapsed}s, teardown waited for the transfer"
+ok "a --max-size cap on a trickling FTP transfer exits cleanly in ${elapsed}s"
 
 # --- the bound: teardown cancels the thread instead of waiting out its read.
 # The FTP data read is a 300s wait, so anything near that means the stop flag

--- a/tests/ftp-server.py
+++ b/tests/ftp-server.py
@@ -8,6 +8,8 @@ directory). Each line is "<path> <mode>...", path "*" matching everything:
 
   truncate  send a prefix of the body, then drop the data connection
   empty     open the data connection and send nothing
+  trickle   dribble the body out in small chunks, keeping it in flight for long
+  stall     send a prefix, then hold the data connection open sending nothing
   norest    answer REST with 500, so the client re-fetches from scratch
   nomdtm    answer MDTM with 500, like a server predating RFC 3659
 
@@ -20,6 +22,13 @@ import socket
 import sys
 import threading
 import time
+
+
+TRICKLE_CHUNK = 8192
+TRICKLE_PAUSE = 0.2
+# Enough to trip a --max-size cap before the silence starts.
+STALL_PREFIX = 200000
+STALL_SECONDS = 600
 
 
 def reply(conn, text):
@@ -91,6 +100,14 @@ class Session(threading.Thread):
                 pass
             elif "truncate" in modes:
                 data.sendall(body[: max(1, len(body) // 8)])
+            elif "trickle" in modes:
+                for off in range(0, len(body), TRICKLE_CHUNK):
+                    data.sendall(body[off : off + TRICKLE_CHUNK])
+                    time.sleep(TRICKLE_PAUSE)
+            elif "stall" in modes:
+                data.sendall(body[:STALL_PREFIX])
+                for _ in range(STALL_SECONDS):
+                    time.sleep(1)
             else:
                 data.sendall(body)
         except OSError:

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -259,6 +259,7 @@ TESTS += 216_engine-ftp-ctrlchars.test
 TESTS += 221_local-ftp-ctrlchars.test
 TESTS += 218_crash-nopie-frames.test
 TESTS += 222_pkgconfig-consumer.test
+TESTS += 236_local-ftp-teardown.test
 TESTS += 227_watchdog-poll.test
 TESTS += 228_icon-small-flat.test
 TESTS += 226_watchdog-native.test


### PR DESCRIPTION
An FTP transfer runs in a detached thread that writes through a slot in `sback->lnk`, and nothing ever waited for it. `back_delete_all` wipes the slot and `back_free` releases the array while the thread is still using both, so a mirror limit segfaults in `run_launch_ftp`: the engine stops the moment the cap trips, and does not wait for the FTP slot. On pristine master, `-M100000` against a server that trickles a file out crashes within seconds, 10 runs out of 10.

`opt` has the same exposure. `httrack.c` drains threads before `hts_free_opt`, but `hts_main` (exported, and reached from the CLI wizard) and `htsweb.c` do not.

`htsftp.c` now keeps a mutex-guarded list of live workers, registered before the thread is spawned and released only after the worker's last store to its slot. `ftp_stop_workers` cancels them and waits, and it runs at both lifetime boundaries: `back_delete_all` for the slot array, `hts_free_opt` for `opt`.

The wait also has to be bounded, not merely patient. `stop_ftp` was only read between operations, so a stalled server would have held teardown for the full FTP read timeout, and #1050 makes `--timeout=0` mean an unbounded wait, which would hang outright. `wait_socket_receive` and `get_ftp_line` therefore take the slot and leave their 100 ms poll loop as soon as the flag is raised. The two blocking `connect()` calls are still only kernel-bounded, which is pre-existing and unchanged.

Test 236 crawls a trickling server under a size cap, then a stalled one, and requires teardown well inside the read timeout. Both fail on master, the first on the segfault and the second at 300 seconds. 10 of 10 either way, on sanitized and plain builds alike.

Expect conflicts with #1050: it adds an `opt` parameter to the same `get_ftp_line` and `wait_socket_receive` call sites, and opens the same `3.49-19` block in history.txt.

Closes #1051
