### PR TITLE
A pipefail SIGPIPE reds test 154 on the uutils leg

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,10 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   match that is not on the last line is exposed. Capture the reply, assert the
   status line it must carry (an empty, truncated or redirected one is
   marker-free too), then match with a here-string: `grep -q M <<<"$reply"`.
+  `head -c N` and `head -n N` end the same way, and there the reds are
+  platform-specific: GNU `tail | head -c 3` survives, the uutils coreutils leg
+  turns the same line into exit 141 with no output at all. Let the reader seek
+  instead: `od -An -c -j <skip> -N <len> file`.
 
 ## Hard invariants
 - **Generated autotools files are NOT in git.** `configure`, every

--- a/tests/154_local-proxytrack-arc-roundtrip.test
+++ b/tests/154_local-proxytrack-arc-roundtrip.test
@@ -58,11 +58,13 @@ test "$(convert "$dir/legacy.arc" "$dir/c.arc")" = 1 ||
 # a third would put the record out of its reach again.
 hdrlen=$(head -1 "$dir/a.arc" | wc -c)
 declared=$(head -1 "$dir/a.arc" | awk '{print $NF}')
-sep=$(tail -c +$((hdrlen + declared + 1)) "$dir/a.arc" | head -c 3 | od -An -c | tr -d ' ')
+# od seeks for itself: piping the archive into `head -c` leaves the writer with
+# a closed pipe, and under pipefail that SIGPIPE is the test's exit status.
+sep=$(od -An -c -j $((hdrlen + declared)) -N 3 "$dir/a.arc" | tr -d ' ')
 test "$sep" = '\n\nh' || fail "version block ends on '$sep', expected two newlines"
 # The block itself must not end on one either: counting the blank line and then
 # writing a second one round-trips, but leaves the length a byte too long.
-inner=$(tail -c +$((hdrlen + declared - 1)) "$dir/a.arc" | head -c 2 | od -An -c | tr -d ' ')
+inner=$(od -An -c -j $((hdrlen + declared - 2)) -N 2 "$dir/a.arc" | tr -d ' ')
 test "$inner" != '\n\n' || fail "declared length still counts the blank line"
 
 # An empty archive is not a corrupt one...


### PR DESCRIPTION
Test 154 reads three bytes out of the middle of an .arc with `tail -c +N file | head -c 3`. `head` exits as soon as it has its three bytes, `tail` keeps writing into the closed pipe and takes SIGPIPE, and the test's own `set -o pipefail` promotes that to the script's exit status. It dies at 141 having printed nothing, which reads as an unexplained failure rather than a harness bug.

GNU coreutils happens to let it through, so this only reds on the `build (Ubuntu devel, uutils coreutils)` leg, where it looks like the fault of whatever PR was running. `od -An -c -j <skip> -N <len>` seeks for itself and leaves no second process holding the other end. Same bytes at the same offsets: both assertions still fail when the offset moves by one in either direction. The AGENTS.md rule that already warns about `grep -q` now names `head` too.
