### PR TITLE
Two of the Android help screens have no anchor to deep-link at

### DIFF
--- a/html/guide.html
+++ b/html/guide.html
@@ -58,6 +58,9 @@
 
 <main id="main">
 
+<!-- Section ids are link API: the redirect stubs and the Android app's contextual help
+     hardcode them, and an app release outlives its engine pin. -->
+
 <h1>The HTTrack interface, step by step</h1>
 
 <p class="lede">HTTrack copies a website to your disk so you can read it offline. The same
@@ -88,7 +91,7 @@ itself down once those pings stop.</p>
 <p>Each option also lists its command-line equivalent, so anything you set here can later be
 scripted. The <a href="cmdguide.html">command-line guide</a> covers that side.</p>
 
-<div class="note" data-for="droid">
+<div class="note" data-for="droid" id="droid-first-launch">
 	<p><b>First launch.</b> Android asks for permission to store mirrors on your device. Without
 	it the app cannot save anything, so tap <b>Allow</b>.</p>
 	<figure>
@@ -287,7 +290,7 @@ usual causes.</p>
 <p data-for="win web">The files sit under the base path you chose, in a folder named after the
 project. Opening <code>index.html</code> there browses the mirror without HTTrack.</p>
 
-<p data-for="droid">Mirrors are written to
+<p data-for="droid" id="droid-storage-location">Mirrors are written to
 <code>/storage/emulated/0/HTTrack/Websites</code>, in a folder named after the project. That is
 shared storage, so a file manager or a USB cable can reach it, and opening
 <code>index.html</code> there browses the mirror without the app.</p>

--- a/tests/239_doc-guide-anchors.test
+++ b/tests/239_doc-guide-anchors.test
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# guide.html's section ids are link API: the redirect stubs left by the page
+# merge and the Android app's per-screen help both hardcode them, and an app
+# release outlives its engine pin.
+
+set -euo pipefail
+
+srcdir="${abs_top_srcdir:?not run under make check}"
+html="${srcdir}/html"
+guide="${html}/guide.html"
+
+test -r "${guide}" || {
+    echo "FAIL: no ${guide}" >&2
+    exit 1
+}
+
+ids=$(grep -o 'id="[^"]*"' "${guide}" | sed 's/^id="//; s/"$//' | sort)
+dups=$(uniq -d <<<"${ids}")
+test -z "${dups}" || {
+    echo "FAIL: duplicate id in guide.html: ${dups}" >&2
+    exit 1
+}
+
+has_id() { grep -qx "$1" <<<"${ids}"; }
+
+# Control: the matcher must be able to say no.
+if has_id no-such-section; then
+    echo "FAIL: has_id matches anything; the checks below prove nothing" >&2
+    exit 1
+fi
+
+# Cross-page "guide.html#..." plus guide.html's own "#..." links, minus the
+# "#<platform>/" routing prefix guide.js strips before scrolling.
+targets=$(
+    {
+        cat "${html}"/*.html | grep -o 'guide\.html#[^"'"'"' >]*' | sed 's/.*#//'
+        grep -o 'href="#[^"]*"' "${guide}" | sed 's/^href="#//; s/"$//'
+    } | sed 's/^\(win\|web\|droid\)\///' | grep -v '^$' | sort -u
+)
+
+# Non-vacuity: the stubs and the in-page links must both have been seen.
+for seen in opt-links opt-scan-rules; do
+    grep -qx "${seen}" <<<"${targets}" || {
+        echo "FAIL: collected no reference to ${seen}; the scan found nothing" >&2
+        exit 1
+    }
+done
+
+fail=0
+for target in ${targets}; do
+    has_id "${target}" || {
+        echo "FAIL: something links to guide.html#${target}, which no id matches" >&2
+        fail=1
+    }
+done
+
+# Hardcoded by httrack-android for its contextual help; renaming one silently
+# drops installed builds at the top of the page.
+for anchor in droid-first-launch step-start step-project step-address options \
+    step-run step-done droid-storage-location; do
+    has_id "${anchor}" || {
+        echo "FAIL: guide.html lost the Android help anchor ${anchor}" >&2
+        fail=1
+    }
+done
+
+test "${fail}" -eq 0 || exit 1
+
+echo "guide anchors: $(wc -l <<<"${targets}") link targets resolved, Android set intact"

--- a/tests/239_doc-guide-anchors.test
+++ b/tests/239_doc-guide-anchors.test
@@ -1,70 +1,56 @@
 #!/bin/bash
 #
-# guide.html's section ids are link API: the redirect stubs left by the page
-# merge and the Android app's per-screen help both hardcode them, and an app
-# release outlives its engine pin.
+# httrack-android deep-links these ids as "guide.html#droid/<id>", and an
+# installed release outlives its engine pin. tools/doc-links.py resolves the
+# links the doc set itself carries; nothing else pins this set.
 
 set -euo pipefail
 
 srcdir="${abs_top_srcdir:?not run under make check}"
-html="${srcdir}/html"
-guide="${html}/guide.html"
+guide="${srcdir}/html/guide.html"
 
 test -r "${guide}" || {
     echo "FAIL: no ${guide}" >&2
     exit 1
 }
 
-ids=$(grep -o 'id="[^"]*"' "${guide}" | sed 's/^id="//; s/"$//' | sort)
-dups=$(uniq -d <<<"${ids}")
-test -z "${dups}" || {
-    echo "FAIL: duplicate id in guide.html: ${dups}" >&2
-    exit 1
+# The table of contents repeats every heading, so only <main> holds real anchors.
+main=$(awk '/<main[ >]/ { inmain = 1 } inmain { print } /<\/main>/ { inmain = 0 }' "${guide}")
+
+check() { # check <anchor>: present once, and reachable on Android
+    local hits tag platforms
+    hits=$(grep -o "id=\"$1\"" <<<"${main}" | wc -l || true)
+    test "${hits}" -eq 1 || {
+        echo "FAIL: ${hits} elements inside <main> carry id=\"$1\", want 1" >&2
+        return 1
+    }
+    tag=$(grep -m1 "id=\"$1\"" <<<"${main}")
+    platforms=$(grep -o 'data-for="[^"]*"' <<<"${tag}" | sed 's/^data-for="//; s/"$//' || true)
+    # guide.css hides one platform's elements from the others, so an anchor on a
+    # win-only element scrolls nowhere.
+    if test -n "${platforms}"; then
+        case " ${platforms} " in
+        *" droid "*) ;;
+        *)
+            echo "FAIL: id=\"$1\" sits on a data-for=\"${platforms}\" element, hidden from droid" >&2
+            return 1
+            ;;
+        esac
+    fi
 }
 
-has_id() { grep -qx "$1" <<<"${ids}"; }
-
-# Control: the matcher must be able to say no.
-if has_id no-such-section; then
-    echo "FAIL: has_id matches anything; the checks below prove nothing" >&2
+# Control: the check must be able to say no.
+if check no-such-section 2>/dev/null; then
+    echo "FAIL: check() passes an absent id; the assertions below prove nothing" >&2
     exit 1
 fi
 
-# Cross-page "guide.html#..." plus guide.html's own "#..." links, minus the
-# "#<platform>/" routing prefix guide.js strips before scrolling.
-targets=$(
-    {
-        cat "${html}"/*.html | grep -o 'guide\.html#[^"'"'"' >]*' | sed 's/.*#//'
-        grep -o 'href="#[^"]*"' "${guide}" | sed 's/^href="#//; s/"$//'
-    } | sed -e 's|^win/||' -e 's|^web/||' -e 's|^droid/||' | grep -v '^$' | sort -u
-)
-
-# Non-vacuity: the stubs and the in-page links must both have been seen.
-for seen in opt-links opt-scan-rules; do
-    grep -qx "${seen}" <<<"${targets}" || {
-        echo "FAIL: collected no reference to ${seen}; the scan found nothing" >&2
-        exit 1
-    }
-done
-
+# One target per Android screen; the pane-to-anchor map lives in httrack-android.
 fail=0
-for target in ${targets}; do
-    has_id "${target}" || {
-        echo "FAIL: something links to guide.html#${target}, which no id matches" >&2
-        fail=1
-    }
-done
-
-# Hardcoded by httrack-android for its contextual help; renaming one silently
-# drops installed builds at the top of the page.
 for anchor in droid-first-launch step-start step-project step-address options \
     step-run step-done droid-storage-location; do
-    has_id "${anchor}" || {
-        echo "FAIL: guide.html lost the Android help anchor ${anchor}" >&2
-        fail=1
-    }
+    check "${anchor}" || fail=1
 done
-
 test "${fail}" -eq 0 || exit 1
 
-echo "guide anchors: $(wc -l <<<"${targets}") link targets resolved, Android set intact"
+echo "guide anchors: the eight Android help targets are present and droid-visible"

--- a/tests/239_doc-guide-anchors.test
+++ b/tests/239_doc-guide-anchors.test
@@ -36,7 +36,7 @@ targets=$(
     {
         cat "${html}"/*.html | grep -o 'guide\.html#[^"'"'"' >]*' | sed 's/.*#//'
         grep -o 'href="#[^"]*"' "${guide}" | sed 's/^href="#//; s/"$//'
-    } | sed 's/^\(win\|web\|droid\)\///' | grep -v '^$' | sort -u
+    } | sed -e 's|^win/||' -e 's|^web/||' -e 's|^droid/||' | grep -v '^$' | sort -u
 )
 
 # Non-vacuity: the stubs and the in-page links must both have been seen.

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -274,3 +274,4 @@ TESTS += 234_local-ftp-maxtime.test
 TESTS += 232_online-gate-outoftree.test
 TESTS += 238_local-warc-nodata-rollback.test
 TESTS += 01_zlib-warc-cdx-errors.test
+TESTS += 239_doc-guide-anchors.test


### PR DESCRIPTION
The Android app is getting per-screen contextual help (httrack-android#113), and it needs somewhere to link. Six of the eight screens already have a target, since the wizard steps and the option panel kept their ids when the eighteen GUI pages were folded into `guide.html`. The first-launch permission note and the paragraph saying where mirrors land did not, so this adds an id to each.

Those two, and the six that already existed, are link API now: the app hardcodes them and an installed release outlives whatever engine SHA it was built against, so a rename quietly drops users at the top of the page rather than at their screen. `tools/doc-links.py` already resolves the links the doc set carries, so the new test only pins what it cannot know, that each of the eight is present once and sits on an element the droid platform can see.
