### PR TITLE
The --single-file crawl assertions run on Windows but are reported as a skip

### DIFF
--- a/tests/241_local-single-file-gui.test
+++ b/tests/241_local-single-file-gui.test
@@ -79,12 +79,12 @@ def textarea(name):
 
 
 # Whole tokens: "--single-file" is a substring of "--single-file-max-size=5000",
-# so a plain `in` would pass with the bare flag gone, and an unterminated value
-# match would take 50000 for 5000.
+# so a plain `in` passes with the bare flag gone, and a one-sided anchor takes
+# both 50000 and a template fusion like --near--single-file-max-size=5000.
 cmd = textarea("command")
 if "--single-file" not in cmd.split():
     sys.exit("FAIL: --single-file missing from the command line\n%s" % cmd)
-if not re.search(r"--single-file-max-size=5000(?!\d)", cmd):
+if "--single-file-max-size=5000" not in cmd.split():
     sys.exit("FAIL: --single-file-max-size=5000 missing from the command "
              "line\n%s" % cmd)
 ini = textarea("winprofile").replace("\r\n", "\n")

--- a/tests/241_local-single-file-gui.test
+++ b/tests/241_local-single-file-gui.test
@@ -1,6 +1,6 @@
 #!/bin/bash
-# The web GUI must emit the --single-file options (#713). Split from
-# 94_local-single-file.test so the engine half runs where htsserver is not built.
+# The web GUI must emit the --single-file options (#713), driven through a live
+# htsserver.
 set -e
 
 : "${top_srcdir:=..}"
@@ -71,16 +71,22 @@ page = urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
 
 
 def textarea(name):
-    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page, re.S)
+    # [ >] anchors the name: unanchored, "command" also matches "commandline".
+    m = re.search(r'<textarea name="%s"[ >].*?>(.*?)</textarea>' % name, page, re.S)
     if m is None:
         sys.exit("FAIL: no %s textarea in the rendered step4.html" % name)
     return m.group(1)
 
 
+# Whole tokens: "--single-file" is a substring of "--single-file-max-size=5000",
+# so a plain `in` would pass with the bare flag gone, and an unterminated value
+# match would take 50000 for 5000.
 cmd = textarea("command")
-for want in ("--single-file", "--single-file-max-size=5000"):
-    if want not in cmd:
-        sys.exit("FAIL: %s missing from the command line\n%s" % (want, cmd))
+if "--single-file" not in cmd.split():
+    sys.exit("FAIL: --single-file missing from the command line\n%s" % cmd)
+if not re.search(r"--single-file-max-size=5000(?!\d)", cmd):
+    sys.exit("FAIL: --single-file-max-size=5000 missing from the command "
+             "line\n%s" % cmd)
 ini = textarea("winprofile").replace("\r\n", "\n")
 for want in ("\nSingleFile=1\n", "\nSingleFileMaxSize=5000\n"):
     if want not in ini:

--- a/tests/241_local-single-file-gui.test
+++ b/tests/241_local-single-file-gui.test
@@ -1,0 +1,89 @@
+#!/bin/bash
+# The web GUI must emit the --single-file options (#713). Split from
+# 94_local-single-file.test so the engine half runs where htsserver is not built.
+set -e
+
+: "${top_srcdir:=..}"
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
+
+# The Windows job builds httrack.exe only and reaches this file through its
+# *_local-*.test glob, so report a skip there rather than a pass.
+if ! command -v htsserver >/dev/null; then
+    echo "SKIP (no htsserver in PATH)"
+    exit 77
+fi
+
+distdir=$(cd "${top_srcdir}" && pwd)
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_713gui.XXXXXX") || exit 1
+htssrv=
+cleanup() {
+    # htsserver keeps SIGTERM ignored across its exec, so only -9 reaps it.
+    test -z "$htssrv" || kill -9 "$htssrv" 2>/dev/null || true
+    wait "$htssrv" 2>/dev/null || true # absorb bash's async "Killed" notice
+    htssrv=
+    rm -rf "$tmpdir"
+}
+trap 'set +e; cleanup' EXIT
+trap cleanup HUP INT QUIT PIPE TERM
+
+printf '[webhttrack renders the options] ..\t'
+sport=$("$python" -c 'import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()')
+srvlog="${tmpdir}/htsserver.log"
+(
+    trap '' TERM TTOU
+    export HOME="${tmpdir}/home"
+    mkdir -p "$HOME"
+    exec htsserver "${distdir}/" --port "${sport}" >"${srvlog}" 2>&1
+) &
+htssrv=$!
+url=
+for _ in $(seq 1 40); do
+    url=$(sed -n 's/^URL=//p' "$srvlog" 2>/dev/null) && test -n "$url" && break
+    kill -0 "$htssrv" 2>/dev/null || break
+    sleep 0.25
+done
+test -n "${url:-}" || {
+    echo "FAIL: htsserver did not start: $(cat "$srvlog")"
+    exit 1
+}
+"$python" - "$url" <<'PY' || exit 1
+import re, sys, urllib.parse, urllib.request
+
+url = sys.argv[1]
+form = urllib.request.urlopen(url + "server/index.html", timeout=20).read()
+m = re.search(rb'name="sid" value="([0-9a-f]+)"', form)
+if not m:
+    sys.exit("FAIL: no session id in server/index.html")
+fields = [("sid", m.group(1).decode()), ("singlefile", "on"),
+          ("singlefilemax", "5000")]
+body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in fields)
+req = urllib.request.Request(url + "server/step4.html",
+                             data=body.encode("latin-1"), method="POST")
+page = urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
+
+
+def textarea(name):
+    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page, re.S)
+    if m is None:
+        sys.exit("FAIL: no %s textarea in the rendered step4.html" % name)
+    return m.group(1)
+
+
+cmd = textarea("command")
+for want in ("--single-file", "--single-file-max-size=5000"):
+    if want not in cmd:
+        sys.exit("FAIL: %s missing from the command line\n%s" % (want, cmd))
+ini = textarea("winprofile").replace("\r\n", "\n")
+for want in ("\nSingleFile=1\n", "\nSingleFileMaxSize=5000\n"):
+    if want not in ini:
+        sys.exit("FAIL: %r missing from winprofile.ini\n%s" % (want, ini))
+PY
+echo OK

--- a/tests/48_local-crange-memresume.test
+++ b/tests/48_local-crange-memresume.test
@@ -15,11 +15,10 @@ root=$(nativepath "${testdir}/server-root")
 
 python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
 
-# The resume needs a graceful pass-1 interrupt (a clean cache), which MSYS can't
-# deliver to a native exe, and the restart-whole path fails on a repaired cache
-# (#581); TODO: drop once that lands.
+# The resume needs a graceful pass-1 interrupt to leave a temp-ref, and MSYS
+# cannot deliver a signal to a native exe.
 if is_windows; then
-    echo "Windows: interrupted-resume restart fails on a repaired cache (#581), skipping"
+    echo "Windows: the pass-1 interrupt needs a signal MSYS cannot deliver, skipping"
     exit 77
 fi
 

--- a/tests/94_local-single-file.test
+++ b/tests/94_local-single-file.test
@@ -84,7 +84,8 @@ which httrack >/dev/null || {
 # The cap sits between pixel.svg and big.svg, so one inlines and one must not.
 out="${tmpdir}/crawl"
 mkdir "$out"
-common=(-O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 --retries=0)
+opts=(--quiet --disable-security-limits --robots=0 --timeout=30 --retries=0)
+common=(-O "$out" "${opts[@]}")
 httrack "${common[@]}" --single-file --single-file-max-size 4096 \
     "${base}/index.html" >"${tmpdir}/log1" 2>&1
 
@@ -264,8 +265,7 @@ printf '[-%%Z0 and a bad cap] ..\t'
 # it; a non-numeric cap is rejected and the built-in default used instead.
 off="${tmpdir}/off"
 mkdir "$off"
-httrack -O "$off" --quiet --disable-security-limits --robots=0 --timeout=30 \
-    --retries=0 -%Z0 "${base}/index.html" >"${tmpdir}/log3" 2>&1
+httrack -O "$off" "${opts[@]}" -%Z0 "${base}/index.html" >"${tmpdir}/log3" 2>&1
 offpage="${off}/127.0.0.1_${port}/index.html"
 if grep -q 'base64,' "$offpage"; then
     echo "FAIL: -%Z0 still inlined"
@@ -273,9 +273,8 @@ if grep -q 'base64,' "$offpage"; then
 fi
 bad="${tmpdir}/bad"
 mkdir "$bad"
-httrack -O "$bad" --quiet --disable-security-limits --robots=0 --timeout=30 \
-    --retries=0 --single-file-max-size notanumber "${base}/index.html" \
-    >"${tmpdir}/log4" 2>&1
+httrack -O "$bad" "${opts[@]}" --single-file-max-size notanumber \
+    "${base}/index.html" >"${tmpdir}/log4" 2>&1
 badpage="${bad}/127.0.0.1_${port}/index.html"
 # The default cap is 10 MB, so everything here inlines, big.svg included.
 grep -q 'data:image/svg+xml;base64,' "$badpage" || {
@@ -313,15 +312,16 @@ echo OK
 printf '[no file keeps a mark] ..\t'
 # Stripping matches the mark's shape, not this run's secret, so nothing in the
 # mirror may carry one -- pages included, and whatever an earlier run left.
-# grep's status dies in the pipeline, so an unsearchable tree would read as
-# clean: floor the file count first.
-searched=$(find "${out}/127.0.0.1_${port}" -type f 2>/dev/null | wc -l)
-test "$searched" -ge 5 || {
-    echo "FAIL: only $searched mirrored files to sweep; nothing was proven"
+# grep's own status, kept out of a pipeline that would launder it: 0 matched,
+# 1 clean, anything above that means the sweep never read the tree.
+st=0
+marked=$(grep -rlE '#![0-9a-f]{16}\.[-cj]\.[0-9]+' \
+    "${out}/127.0.0.1_${port}" 2>/dev/null) || st=$?
+test "$st" -le 1 || {
+    echo "FAIL: the mark sweep could not read the mirror (grep exit $st)"
     exit 1
 }
-marked=$(grep -rlE '#![0-9a-f]{16}\.[-cj]\.[0-9]+' \
-    "${out}/127.0.0.1_${port}" 2>/dev/null | tr '\n' ' ')
+marked=$(printf '%s' "$marked" | tr '\n' ' ')
 test -z "$marked" || {
     echo "FAIL: marks survived in $marked"
     exit 1
@@ -375,14 +375,13 @@ case "$both" in
 esac
 
 printf '[--changes and --single-file together] ..\t'
-# Both hook end-of-mirror. Expansion must run first, so the report sees the
-# inlined size rather than the marked intermediate.
+# Both hook end-of-mirror, and the report stats the file it names, so its size
+# for the page is the inlined one only if expansion ran first.
 chg="${tmpdir}/chg"
 mkdir "$chg"
 # Its own -O: "$common" points at the first mirror, which left $chgpage absent
 # and every check below vacuous.
-httrack -O "$chg" --quiet --disable-security-limits --robots=0 --timeout=30 \
-    --retries=0 --single-file --changes "${base}/index.html" \
+httrack -O "$chg" "${opts[@]}" --single-file --changes "${base}/index.html" \
     >"${tmpdir}/log6" 2>&1
 chgpage="${chg}/127.0.0.1_${port}/index.html"
 test -f "$chgpage" || {
@@ -391,6 +390,22 @@ test -f "$chgpage" || {
 }
 grep -q 'base64,' "$chgpage" || {
     echo "FAIL: --changes suppressed the inlining"
+    exit 1
+}
+reported=$("$python" - "${chg}/hts-changes.json" index.html <<'REPORT') || exit 1
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as fp:
+    report = json.load(fp)
+for bucket in ("new", "changed", "unchanged"):
+    for entry in report.get(bucket, []):
+        if entry["file"].replace("\\", "/").endswith("/" + sys.argv[2]):
+            print(entry.get("size", -1))
+            sys.exit(0)
+sys.exit("FAIL: index.html is in no bucket of the change report")
+REPORT
+onpage=$(wc -c <"$chgpage")
+test "$reported" -eq "$onpage" || {
+    echo "FAIL: the report sizes the page at $reported, on disk it is $onpage"
     exit 1
 }
 echo OK
@@ -404,9 +419,8 @@ else
     mkdir "$umaskdir"
     (
         umask 077
-        httrack -O "$umaskdir" --quiet --disable-security-limits --robots=0 \
-            --timeout=30 --retries=0 --single-file "${base}/index.html" \
-            >"${tmpdir}/log5" 2>&1
+        httrack -O "$umaskdir" "${opts[@]}" --single-file \
+            "${base}/index.html" >"${tmpdir}/log5" 2>&1
     )
     umaskroot="${umaskdir}/127.0.0.1_${port}"
     mode() { "$python" -c 'import os,sys

--- a/tests/94_local-single-file.test
+++ b/tests/94_local-single-file.test
@@ -301,10 +301,9 @@ grep -q 'data:image/svg+xml;base64,' "$page" || {
 echo OK
 
 printf '[a mark cannot ride in on a header] ..\t'
-# htsparse echoes the Content-Type charset into a <meta>; a forged mark there
-# bypasses anything that scans the body. Unforgeable means the channel does
-# not matter, so this asserts on the channel the body sweep could never see.
-grep -q 'charset=127' "$page" || true
+# htsparse echoes the Content-Type charset into a <meta>, a channel the body
+# sweep cannot see. A regression guard only: no fixture here serves a
+# mark-shaped charset, so it cannot fail today (#1069).
 if grep -q 'content="text/html;charset=data:' "$page"; then
     echo "FAIL: a charset-borne mark was expanded"
     exit 1
@@ -314,6 +313,13 @@ echo OK
 printf '[no file keeps a mark] ..\t'
 # Stripping matches the mark's shape, not this run's secret, so nothing in the
 # mirror may carry one -- pages included, and whatever an earlier run left.
+# grep's status dies in the pipeline, so an unsearchable tree would read as
+# clean: floor the file count first.
+searched=$(find "${out}/127.0.0.1_${port}" -type f 2>/dev/null | wc -l)
+test "$searched" -ge 5 || {
+    echo "FAIL: only $searched mirrored files to sweep; nothing was proven"
+    exit 1
+}
 marked=$(grep -rlE '#![0-9a-f]{16}\.[-cj]\.[0-9]+' \
     "${out}/127.0.0.1_${port}" 2>/dev/null | tr '\n' ' ')
 test -z "$marked" || {
@@ -373,10 +379,17 @@ printf '[--changes and --single-file together] ..\t'
 # inlined size rather than the marked intermediate.
 chg="${tmpdir}/chg"
 mkdir "$chg"
-httrack "${common[@]}" --single-file --changes "${base}/index.html" \
+# Its own -O: "$common" points at the first mirror, which left $chgpage absent
+# and every check below vacuous.
+httrack -O "$chg" --quiet --disable-security-limits --robots=0 --timeout=30 \
+    --retries=0 --single-file --changes "${base}/index.html" \
     >"${tmpdir}/log6" 2>&1
 chgpage="${chg}/127.0.0.1_${port}/index.html"
-test ! -f "$chgpage" || grep -q 'base64,' "$chgpage" || {
+test -f "$chgpage" || {
+    echo "FAIL: --changes produced no mirrored page"
+    exit 1
+}
+grep -q 'base64,' "$chgpage" || {
     echo "FAIL: --changes suppressed the inlining"
     exit 1
 }
@@ -420,7 +433,7 @@ case "$st" in
     ;;
 esac
 
-# --- the web GUI must emit the same options ---------------------------------
+# --- project reload restores the saved keys ---------------------------------
 distdir=$(cd "${top_srcdir}" && pwd)
 printf '[project reload maps the keys back] ..\t'
 grep -q 'do:copy:SingleFile:singlefile' "${distdir}/html/server/step2.html" || {

--- a/tests/94_local-single-file.test
+++ b/tests/94_local-single-file.test
@@ -13,13 +13,8 @@ python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_713.XXXXXX") || exit 1
 serverpid=
-htssrv=
 cleanup() {
     stop_server "$serverpid"
-    # htsserver keeps SIGTERM ignored across its exec, so only -9 reaps it.
-    test -z "$htssrv" || kill -9 "$htssrv" 2>/dev/null || true
-    wait "$htssrv" 2>/dev/null || true # absorb bash's async "Killed" notice
-    htssrv=
     rm -rf "$tmpdir"
 }
 trap 'set +e; cleanup' EXIT
@@ -436,68 +431,4 @@ grep -q 'do:copy:SingleFileMaxSize:singlefilemax' "${distdir}/html/server/step2.
     echo "FAIL: step2.html does not restore SingleFileMaxSize"
     exit 1
 }
-echo OK
-
-printf '[webhttrack renders the options] ..\t'
-# The Windows job builds httrack.exe only and reaches this file through its
-# *_local-*.test glob, so report a skip there rather than a pass.
-if ! command -v htsserver >/dev/null; then
-    echo "SKIP (no htsserver in PATH)"
-    exit 77
-fi
-sport=$("$python" -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()')
-srvlog="${tmpdir}/htsserver.log"
-(
-    trap '' TERM TTOU
-    export HOME="${tmpdir}/home"
-    mkdir -p "$HOME"
-    exec htsserver "${distdir}/" --port "${sport}" >"${srvlog}" 2>&1
-) &
-htssrv=$!
-url=
-for _ in $(seq 1 40); do
-    url=$(sed -n 's/^URL=//p' "$srvlog" 2>/dev/null) && test -n "$url" && break
-    kill -0 "$htssrv" 2>/dev/null || break
-    sleep 0.25
-done
-test -n "${url:-}" || {
-    echo "FAIL: htsserver did not start: $(cat "$srvlog")"
-    exit 1
-}
-"$python" - "$url" <<'PY' || exit 1
-import re, sys, urllib.parse, urllib.request
-
-url = sys.argv[1]
-form = urllib.request.urlopen(url + "server/index.html", timeout=20).read()
-m = re.search(rb'name="sid" value="([0-9a-f]+)"', form)
-if not m:
-    sys.exit("FAIL: no session id in server/index.html")
-fields = [("sid", m.group(1).decode()), ("singlefile", "on"),
-          ("singlefilemax", "5000")]
-body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in fields)
-req = urllib.request.Request(url + "server/step4.html",
-                             data=body.encode("latin-1"), method="POST")
-page = urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
-
-
-def textarea(name):
-    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page, re.S)
-    if m is None:
-        sys.exit("FAIL: no %s textarea in the rendered step4.html" % name)
-    return m.group(1)
-
-
-cmd = textarea("command")
-for want in ("--single-file", "--single-file-max-size=5000"):
-    if want not in cmd:
-        sys.exit("FAIL: %s missing from the command line\n%s" % (want, cmd))
-ini = textarea("winprofile").replace("\r\n", "\n")
-for want in ("\nSingleFile=1\n", "\nSingleFileMaxSize=5000\n"):
-    if want not in ini:
-        sys.exit("FAIL: %r missing from winprofile.ini\n%s" % (want, ini))
-PY
 echo OK

--- a/tests/94_local-single-file.test
+++ b/tests/94_local-single-file.test
@@ -392,7 +392,9 @@ grep -q 'base64,' "$chgpage" || {
     echo "FAIL: --changes suppressed the inlining"
     exit 1
 }
-reported=$("$python" - "${chg}/hts-changes.json" index.html <<'REPORT') || exit 1
+# Via a file, never a heredoc inside $(...): bash 3.2 (macOS) ends the
+# substitution at the ")" and runs the body as shell commands.
+cat >"${tmpdir}/report.py" <<'REPORT'
 import json, sys
 with open(sys.argv[1], encoding="utf-8") as fp:
     report = json.load(fp)
@@ -403,6 +405,7 @@ for bucket in ("new", "changed", "unchanged"):
             sys.exit(0)
 sys.exit("FAIL: index.html is in no bucket of the change report")
 REPORT
+reported=$("$python" "${tmpdir}/report.py" "${chg}/hts-changes.json" index.html) || exit 1
 onpage=$(wc -c <"$chgpage")
 test "$reported" -eq "$onpage" || {
     echo "FAIL: the report sizes the page at $reported, on disk it is $onpage"

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -256,7 +256,8 @@ echo "ran=$((pass + fail + skip)) pass=$pass fail=$fail skip=$skip" |
 # same line; compared as a sorted set below, so glob discovery order can't
 # cause a false mismatch either.
 # footer-overflow and purge-longpath skip on Windows (need a path past MAX_PATH);
-# webdav-default, webdav-mime, webdav-overflow and proxytrack-quiet need a reapable background listener, which MSYS cannot give them;
+# webdav-default, webdav-mime, webdav-overflow and proxytrack-quiet need a
+# reapable background listener, which MSYS cannot give them;
 # badmtime needs a filesystem that stores an mtime past gmtime's range;
 # single-file-gui drives htsserver, which this job does not build;
 # update-304-leak needs a LeakSanitizer build, which MSVC has no equivalent of;
@@ -268,7 +269,8 @@ echo "ran=$((pass + fail + skip)) pass=$pass fail=$fail skip=$skip" |
 # link-control-bytes names its fixtures with the raw control bytes the requests
 # decode back to, which NTFS refuses;
 # ftp-userpass starves the x64 runner until the step is lost, Win32 passing (#1038);
-# memresume, repaircache and resume-recovery interrupt pass 1 with a signal MSYS cannot deliver to a native exe.
+# memresume, repaircache and resume-recovery interrupt pass 1 with a signal
+# MSYS cannot deliver to a native exe.
 expected_skips="01_engine-footer-overflow.test
 100_local-purge-longpath.test
 158_local-link-control-bytes.test

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -256,10 +256,9 @@ echo "ran=$((pass + fail + skip)) pass=$pass fail=$fail skip=$skip" |
 # same line; compared as a sorted set below, so glob discovery order can't
 # cause a false mismatch either.
 # footer-overflow and purge-longpath skip on Windows (need a path past MAX_PATH);
-# memresume pending #581;
-# webdav-default, webdav-mime and webdav-overflow need a reapable background listener, which MSYS cannot give them;
+# webdav-default, webdav-mime, webdav-overflow and proxytrack-quiet need a reapable background listener, which MSYS cannot give them;
 # badmtime needs a filesystem that stores an mtime past gmtime's range;
-# single-file ends on a GUI half needing htsserver, which this job does not build;
+# single-file-gui drives htsserver, which this job does not build;
 # update-304-leak needs a LeakSanitizer build, which MSVC has no equivalent of;
 # crash-symbolize and backtrace-empty need backtrace(), which Windows has no
 # equivalent of;
@@ -269,7 +268,7 @@ echo "ran=$((pass + fail + skip)) pass=$pass fail=$fail skip=$skip" |
 # link-control-bytes names its fixtures with the raw control bytes the requests
 # decode back to, which NTFS refuses;
 # ftp-userpass starves the x64 runner until the step is lost, Win32 passing (#1038);
-# repaircache and resume-recovery interrupt pass 1 with a signal MSYS cannot deliver to a native exe.
+# memresume, repaircache and resume-recovery interrupt pass 1 with a signal MSYS cannot deliver to a native exe.
 expected_skips="01_engine-footer-overflow.test
 100_local-purge-longpath.test
 158_local-link-control-bytes.test
@@ -287,7 +286,7 @@ expected_skips="01_engine-footer-overflow.test
 79_local-proxytrack-webdav-mime.test
 80_engine-crash-symbolize.test
 88_local-proxytrack-badmtime.test
-94_local-single-file.test"
+241_local-single-file-gui.test"
 # First, or the deadline reads as an unexplained shortfall in the gates below.
 [ "$deadline" -eq 0 ] || {
     echo "::error::suite did not finish within ${suite_deadline}s"

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -275,3 +275,4 @@ TESTS += 232_online-gate-outoftree.test
 TESTS += 238_local-warc-nodata-rollback.test
 TESTS += 01_zlib-warc-cdx-errors.test
 TESTS += 239_doc-guide-anchors.test
+TESTS += 241_local-single-file-gui.test


### PR DESCRIPTION
`94_local-single-file.test` is listed in the Windows suite's `expected_skips` because it "ends on a GUI half needing htsserver". The engine half runs there anyway: the test only reaches its `exit 77` once every crawl assertion has passed, so under `set -e` a regression would already have failed the job. The skip set is recording the exit code of the last block, not the coverage.

That last block moves to `241_local-single-file-gui.test`, so the crawl assertions report a pass and only the htsserver half skips. The `step2.html` greps stay in 94, since they need no server. `--single-file` ships in 3.50 and had no visible Windows coverage before this.

Making 94 load-bearing on Windows meant fixing what it was letting through. The GUI check matched substrings, so `--single-file` passed on `--single-file-max-size=5000` with the bare flag gone, and the value match had no trailing delimiter, so a units regression emitting `50000` passed too; both are token matches now, and both mutants kill the test. Three fail-open checks in 94 went the same way: a grep whose status was discarded by construction, a mark sweep that read an unsearchable tree as clean, and a `--changes` crawl running under the first mirror's `-O`, which left its page absent and every assertion on it vacuous. The dead grep is gone and #1069 covers the fixture it was reaching for.

Two justifications in the same comment block had gone stale. 48 and 71 were pinned on #581, closed since #655 and #1057; what actually blocks them is that pass 1 has to be interrupted mid-download to leave a temp-ref, and MSYS cannot deliver a signal to a native exe. 71 already said so, 48 did not. `153_local-proxytrack-quiet.test` carried no justification at all.

The risk is that the skip set ratchets both ways, so 94 must now exit 0 on Windows. It will, for the reason above; nothing in it was conditional on the GUI block.