### PR TITLE
A WARC abort can orphan a .tmp when teardown reopens the writer

### DIFF
--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -527,6 +527,7 @@ struct httrackp {
   // store library handles
   htslibhandles libHandles; /**< loaded external module handles */
   //
+  /* Live state, not options: copy_htsopt must leave it alone. */
   htsoptstate state; /**< embedded live engine state */
   String strip_query; /**< query keys to drop when deduping URLs (-strip-query);
                            appended at the tail to keep field offsets stable */

--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -256,7 +256,7 @@ struct htsoptstate {
   unsigned int debug_state;
   unsigned int tmpnameid; /**< counter for temporary file names */
   int is_ended;           /**< mirror has finished */
-  void *warc;             /**< open WARC writer (warc_writer*), or NULL */
+  void *warc;             /**< WARC writer, or NULL/an htswarc.c sentinel */
 };
 
 /* Library handles */

--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -256,7 +256,8 @@ struct htsoptstate {
   unsigned int debug_state;
   unsigned int tmpnameid; /**< counter for temporary file names */
   int is_ended;           /**< mirror has finished */
-  void *warc;             /**< WARC writer, or NULL/an htswarc.c sentinel */
+  void *warc; /**< WARC writer (warc_writer*), or NULL, or the WARC_DISABLED
+                   sentinel (htswarc.c) */
 };
 
 /* Library handles */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5899,8 +5899,9 @@ static int st_warc_cdx_errors(httrackp *opt, int argc, char **argv) {
   return err;
 }
 
-/* One finished transaction through the engine hook, as back_finalize does. */
-static void st_warc_emit(httrackp *opt) {
+/* One finished transaction through the engine hook. No stashed headers, so the
+   hook synthesizes the status line the real caller supplies. */
+static void st_warc_emit(httrackp *opt, const char *body) {
   lien_back *back = calloct(1, sizeof(lien_back));
 
   assertf(back != NULL);
@@ -5909,20 +5910,67 @@ static void st_warc_emit(httrackp *opt) {
   back->r.statuscode = 200;
   strcpybuff(back->r.msg, "OK");
   strcpybuff(back->r.contenttype, "text/html");
-  back->r.adr = strdupt("body\n");
-  back->r.size = 5;
+  back->r.adr = strdupt(body);
+  back->r.size = (LLint) strlen(body);
   warc_write_backtransaction(opt, back);
   freet(back->r.adr);
   freet(back);
 }
 
-/* Two runs against one archive; the second ends per `abort_run`, then takes the
-   late emit teardown makes once the writer is gone. */
+/* memmem(): a NUL byte anywhere in the archive would cut strstr() short. */
+static hts_boolean st_blob_has(const unsigned char *blob, size_t len,
+                               const char *s) {
+  const size_t n = strlen(s);
+  size_t i;
+
+  for (i = 0; n <= len && i <= len - n; i++) {
+    if (memcmp(blob + i, s, n) == 0)
+      return HTS_TRUE;
+  }
+  return HTS_FALSE;
+}
+
+/* The archive on disk must hold `want`'s run, and no trace of the others. */
+static int st_warc_holds(const char *name, const char *path, const char *want,
+                         const char *absent1, const char *absent2) {
+  const char *const absent[2] = {absent1, absent2};
+  size_t len = 0, i;
+  unsigned char *blob = warc_slurp(path, &len);
+  int err = 0;
+
+  if (blob == NULL) {
+    fprintf(stderr, "warc-teardown: %s: cannot read %s\n", name, path);
+    return 1;
+  }
+  if (len < 8 || memcmp(blob, "WARC/1.1", 8) != 0) {
+    fprintf(stderr, "warc-teardown: %s: %s does not open on a WARC record\n",
+            name, path);
+    err++;
+  }
+  if (!st_blob_has(blob, len, want)) {
+    fprintf(stderr, "warc-teardown: %s: %s lost the run holding \"%s\"\n", name,
+            path, want);
+    err++;
+  }
+  for (i = 0; i < 2; i++) {
+    if (st_blob_has(blob, len, absent[i])) {
+      fprintf(stderr, "warc-teardown: %s: %s took \"%s\"\n", name, path,
+              absent[i]);
+      err++;
+    }
+  }
+  freet(blob);
+  return err;
+}
+
+/* One archive, three writes: two runs, then the emit teardown makes. */
 static int st_warc_teardown_case(httrackp *opt, const char *name,
                                  const char *path, hts_boolean abort_run) {
+  static const char run1[] = "teardown-run-1-body";
+  static const char run2[] = "teardown-run-2-body-longer";
+  static const char late[] = "teardown-late-body";
   char tmp[HTS_URLMAXSIZE * 2 + 8];
   char catbuff[CATBUFF_SIZE];
-  LLint after, late;
   int err = 0;
 
   snprintf(tmp, sizeof(tmp), "%s.tmp", path);
@@ -5930,9 +5978,10 @@ static int st_warc_teardown_case(httrackp *opt, const char *name,
   (void) UNLINK(fconv(catbuff, sizeof(catbuff), tmp));
   StringCopy(opt->warc_file, path);
 
-  /* nothing to protect yet, so the first run is written in place */
+  /* stands in for the per-mirror memset in hts_create_opt(): this test reuses
+     the dispatcher's opt where the engine always has a fresh one */
   opt->state.warc = NULL;
-  st_warc_emit(opt);
+  st_warc_emit(opt, run1);
   warc_close_opt(opt);
   if (fsize_utf8(path) <= 0) {
     fprintf(stderr, "warc-teardown: %s: the hook opened no archive\n", name);
@@ -5941,7 +5990,7 @@ static int st_warc_teardown_case(httrackp *opt, const char *name,
 
   /* a previous archive is now there, so this run goes through the temporary */
   opt->state.warc = NULL;
-  st_warc_emit(opt);
+  st_warc_emit(opt, run2);
   if (!fexist_utf8(tmp)) {
     fprintf(stderr, "warc-teardown: %s: no temporary beside %s\n", name, path);
     return 1;
@@ -5950,21 +5999,15 @@ static int st_warc_teardown_case(httrackp *opt, const char *name,
     warc_abort_opt(opt);
   else
     warc_close_opt(opt);
-  after = fsize_utf8(path);
 
-  st_warc_emit(opt);
-  late = fsize_utf8(path);
+  st_warc_emit(opt, late); /* what back_finalize emits during teardown */
   if (fexist_utf8(tmp)) {
     fprintf(stderr, "warc-teardown: %s: orphan temporary %s\n", name, tmp);
     err++;
   }
-  if (late != after) {
-    fprintf(stderr,
-            "warc-teardown: %s: archive is " LLintP " bytes after teardown, "
-            "was " LLintP "\n",
-            name, (LLint) late, (LLint) after);
-    err++;
-  }
+  /* abort keeps run 1, close commits run 2, and neither takes the late emit */
+  err += abort_run ? st_warc_holds(name, path, run1, run2, late)
+                   : st_warc_holds(name, path, run2, run1, late);
   return err;
 }
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4801,7 +4801,8 @@ static int st_ftpctrl(httrackp *opt, int argc, char **argv) {
 
 /* Slurp a whole file into a malloc'd buffer; sets *len. NULL on error. */
 static unsigned char *warc_slurp(const char *path, size_t *len) {
-  FILE *f = FOPEN(path, "rb");
+  char catbuff[CATBUFF_SIZE];
+  FILE *f = FOPEN(fconv(catbuff, sizeof(catbuff), path), "rb");
   unsigned char *buf;
   long sz;
   if (f == NULL)
@@ -5942,6 +5943,7 @@ static int st_warc_holds(const char *name, const char *path, const char *want,
     fprintf(stderr, "warc-teardown: %s: cannot read %s\n", name, path);
     return 1;
   }
+  /* shape, not validity: the first record's version line, nothing more */
   if (len < 8 || memcmp(blob, "WARC/1.1", 8) != 0) {
     fprintf(stderr, "warc-teardown: %s: %s does not open on a WARC record\n",
             name, path);
@@ -6005,7 +6007,8 @@ static int st_warc_teardown_case(httrackp *opt, const char *name,
     fprintf(stderr, "warc-teardown: %s: orphan temporary %s\n", name, tmp);
     err++;
   }
-  /* abort keeps run 1, close commits run 2, and neither takes the late emit */
+  /* abort keeps run 1, close commits run 2; the late body guards against an
+     append, no reopen can reach the archive without losing that run first */
   err += abort_run ? st_warc_holds(name, path, run1, run2, late)
                    : st_warc_holds(name, path, run2, run1, late);
   return err;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5899,6 +5899,100 @@ static int st_warc_cdx_errors(httrackp *opt, int argc, char **argv) {
   return err;
 }
 
+/* One finished transaction through the engine hook, as back_finalize does. */
+static void st_warc_emit(httrackp *opt) {
+  lien_back *back = calloct(1, sizeof(lien_back));
+
+  assertf(back != NULL);
+  strcpybuff(back->url_adr, "example.com");
+  strcpybuff(back->url_fil, "/teardown.html");
+  back->r.statuscode = 200;
+  strcpybuff(back->r.msg, "OK");
+  strcpybuff(back->r.contenttype, "text/html");
+  back->r.adr = strdupt("body\n");
+  back->r.size = 5;
+  warc_write_backtransaction(opt, back);
+  freet(back->r.adr);
+  freet(back);
+}
+
+/* Two runs against one archive; the second ends per `abort_run`, then takes the
+   late emit teardown makes once the writer is gone. */
+static int st_warc_teardown_case(httrackp *opt, const char *name,
+                                 const char *path, hts_boolean abort_run) {
+  char tmp[HTS_URLMAXSIZE * 2 + 8];
+  char catbuff[CATBUFF_SIZE];
+  LLint after, late;
+  int err = 0;
+
+  snprintf(tmp, sizeof(tmp), "%s.tmp", path);
+  (void) UNLINK(fconv(catbuff, sizeof(catbuff), path));
+  (void) UNLINK(fconv(catbuff, sizeof(catbuff), tmp));
+  StringCopy(opt->warc_file, path);
+
+  /* nothing to protect yet, so the first run is written in place */
+  opt->state.warc = NULL;
+  st_warc_emit(opt);
+  warc_close_opt(opt);
+  if (fsize_utf8(path) <= 0) {
+    fprintf(stderr, "warc-teardown: %s: the hook opened no archive\n", name);
+    return 1;
+  }
+
+  /* a previous archive is now there, so this run goes through the temporary */
+  opt->state.warc = NULL;
+  st_warc_emit(opt);
+  if (!fexist_utf8(tmp)) {
+    fprintf(stderr, "warc-teardown: %s: no temporary beside %s\n", name, path);
+    return 1;
+  }
+  if (abort_run)
+    warc_abort_opt(opt);
+  else
+    warc_close_opt(opt);
+  after = fsize_utf8(path);
+
+  st_warc_emit(opt);
+  late = fsize_utf8(path);
+  if (fexist_utf8(tmp)) {
+    fprintf(stderr, "warc-teardown: %s: orphan temporary %s\n", name, tmp);
+    err++;
+  }
+  if (late != after) {
+    fprintf(stderr,
+            "warc-teardown: %s: archive is " LLintP " bytes after teardown, "
+            "was " LLintP "\n",
+            name, (LLint) late, (LLint) after);
+    err++;
+  }
+  return err;
+}
+
+// -#test=warc-teardown <dir>: teardown finalizes the slots left in flight, so
+// back_finalize emits after warc_close_opt/warc_abort_opt has run (#1060).
+static int st_warc_teardown(httrackp *opt, int argc, char **argv) {
+  char path[HTS_URLMAXSIZE], saved_file[HTS_URLMAXSIZE];
+  void *saved_state;
+  int err = 0;
+
+  if (argc < 1) {
+    fprintf(stderr, "warc-teardown: needs a writable directory\n");
+    return 1;
+  }
+  saved_state = opt->state.warc;
+  strlcpybuff(saved_file, StringBuff(opt->warc_file), sizeof(saved_file));
+
+  fconcat(path, sizeof(path), argv[0], "teardown-close.warc");
+  err += st_warc_teardown_case(opt, "close", path, HTS_FALSE);
+  fconcat(path, sizeof(path), argv[0], "teardown-abort.warc");
+  err += st_warc_teardown_case(opt, "abort", path, HTS_TRUE);
+
+  StringCopy(opt->warc_file, saved_file);
+  opt->state.warc = saved_state;
+  printf("warc-teardown: %s\n", err ? "FAIL" : "OK");
+  return err;
+}
+
 #if HTS_USEOPENSSL
 /* Lowercase-hex SHA-256 of n bytes into out[65]; 1 on success. */
 static int wacz_test_sha256(const void *p, size_t n, char out[65]) {
@@ -8604,6 +8698,9 @@ static const struct selftest_entry {
     {"warc-cdx-errors", "<dir>",
      "--warc-cdx diagnostics when the index cannot be written or is empty",
      st_warc_cdx_errors},
+    {"warc-teardown", "<dir>",
+     "a closed or abandoned archive is not reopened by a late transaction",
+     st_warc_teardown},
 #if HTS_USEOPENSSL
     {"warc-wacz", "<dir>", "--wacz package: layout, STORE mode, sha256 digests",
      st_warc_wacz},

--- a/src/htswarc.c
+++ b/src/htswarc.c
@@ -55,7 +55,8 @@ Please visit our Website: http://www.httrack.com
 #include <openssl/rand.h>
 #endif
 
-/* opt->state.warc value meaning "open failed once, do not retry". */
+/* opt->state.warc value meaning "no writer, and do not open one": the open
+   failed, or the session is done with the archive. */
 #define WARC_DISABLED ((void *) ~(uintptr_t) 0)
 
 /* Suffix of the in-progress archive when a previous one must survive it. */
@@ -1691,7 +1692,9 @@ void warc_close_opt(httrackp *opt) {
   if (opt->state.warc != NULL && opt->state.warc != WARC_DISABLED) {
     warc_close((warc_writer *) opt->state.warc);
   }
-  opt->state.warc = NULL;
+  /* final: teardown still finalizes slots, and a reopen there would orphan a
+     .tmp nobody closes (#1060) */
+  opt->state.warc = WARC_DISABLED;
 }
 
 void warc_abort_opt(httrackp *opt) {
@@ -1701,7 +1704,7 @@ void warc_abort_opt(httrackp *opt) {
     w->failed = HTS_TRUE;
     warc_close(w);
   }
-  opt->state.warc = NULL;
+  opt->state.warc = WARC_DISABLED;
 }
 
 /* ---- one transaction ---- */

--- a/src/htswarc.h
+++ b/src/htswarc.h
@@ -84,7 +84,8 @@ void warc_adopt_rawspool(htsblk *r, const char *tmpfile_path);
    once) if the archive cannot be created. */
 void warc_write_backtransaction(httrackp *opt, lien_back *back);
 
-/* Close and free the writer held in opt->state.warc, if any. */
+/* Close and free the writer held in opt->state.warc, if any. Both this and
+   warc_abort_opt() are final: a later transaction reopens nothing. */
 void warc_close_opt(httrackp *opt);
 
 /* Same, but discards this run's archive: keeps the previous one and drops

--- a/src/htswarc.h
+++ b/src/htswarc.h
@@ -80,8 +80,9 @@ void warc_move_request(htsblk *src, htsblk *dst);
 void warc_adopt_rawspool(htsblk *r, const char *tmpfile_path);
 
 /* Emit the request + response (or revisit) records for one finished
-   transaction. Lazily opens the writer into opt->state.warc; a no-op (logged
-   once) if the archive cannot be created. */
+   transaction. Lazily opens the writer into opt->state.warc; a no-op if the
+   archive cannot be created (logged once), and a silent one once the session
+   has closed or abandoned it. */
 void warc_write_backtransaction(httrackp *opt, lien_back *back);
 
 /* Close and free the writer held in opt->state.warc, if any. Both this and

--- a/tests/242_engine-warc-teardown.test
+++ b/tests/242_engine-warc-teardown.test
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Teardown finalizes the slots left in flight, and that late emit used to reopen
+# the archive the session had just closed or abandoned, orphaning a .tmp (#1060).
+
+set -euo pipefail
+
+httrack_bin=$(cd "$(dirname "$(command -v httrack)")" && pwd)/httrack
+
+scratch=$(mktemp -d)
+trap 'set +e; rm -rf "$scratch"' EXIT
+
+out=$("$httrack_bin" -O /dev/null -#test=warc-teardown "$scratch/")
+echo "$out"
+case "$out" in
+*": OK") ;;
+*) exit 1 ;;
+esac
+
+# Same check from outside, so a temporary under any other name fails too.
+leftover=$(find "$scratch" -name '*.tmp' -print)
+if [ -n "$leftover" ]; then
+    echo "orphan temporaries: $leftover"
+    exit 1
+fi

--- a/tests/242_engine-warc-teardown.test
+++ b/tests/242_engine-warc-teardown.test
@@ -8,6 +8,7 @@ httrack_bin=$(cd "$(dirname "$(command -v httrack)")" && pwd)/httrack
 
 scratch=$(mktemp -d)
 trap 'set +e; rm -rf "$scratch"' EXIT
+trap 'rm -rf "$scratch"' HUP INT QUIT PIPE TERM
 
 out=$("$httrack_bin" -O /dev/null -#test=warc-teardown "$scratch/")
 echo "$out"

--- a/tests/242_engine-warc-teardown.test
+++ b/tests/242_engine-warc-teardown.test
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
-# Teardown finalizes the slots left in flight, and that late emit used to reopen
-# the archive the session had just closed or abandoned, orphaning a .tmp (#1060).
+# A late emit used to reopen the closed archive, orphaning a .tmp (#1060).
 
 set -euo pipefail
 

--- a/tests/tests-list.mk
+++ b/tests/tests-list.mk
@@ -275,3 +275,4 @@ TESTS += 232_online-gate-outoftree.test
 TESTS += 238_local-warc-nodata-rollback.test
 TESTS += 01_zlib-warc-cdx-errors.test
 TESTS += 239_doc-guide-anchors.test
+TESTS += 242_engine-warc-teardown.test


### PR DESCRIPTION
`warc_close_opt` and `warc_abort_opt` both left `opt->state.warc` NULL, which the emit hook reads as "never opened". Teardown runs after them: `XH_uninit` finalizes the slots still in flight, `back_finalize` calls `warc_write_backtransaction`, and that lazily reopens the archive. Nobody closes the new writer, and since the archive it would replace is already on disk it writes through a temporary, so the run ends on an orphan `warc-out.warc.gz.tmp`.

Both now leave the `WARC_DISABLED` sentinel htswarc.c already carries for a failed open, which the hook reads as "no writer, and none to open". A flag of its own would have meant moving `opt->state` in an installed header for nothing, and nothing outside htswarc.c reads the field. Close has to change along with abort: the window is on the normal tail, and #1064 has since routed the three loop bailouts through the same `warc_close_opt`, so five exits now reach teardown with the writer closed where two did. Its description says #1060's window is unchanged, which held for the rollback it kept but not for the bailouts it moved. One content difference comes with the fix. A run whose only archivable transactions are the teardown ones now drops them, where the old code opened a writer it never closed and left the orphan, or an unfinalized archive with no index beside it.

Test 242 drives close and abort through a new `-#test=warc-teardown`, and reads the archive back to pin which run survived. Two mutants, one per function, kill their case, and reverting both is master. Two more cover the content assertions: a close that stops committing its run, and an abort that publishes it anyway.

Closes #1060