### PR TITLE
Retest: does 230_local-ftp-userpass still wedge the Windows x64 runner?

### DIFF
--- a/tests/230_local-ftp-userpass.test
+++ b/tests/230_local-ftp-userpass.test
@@ -11,12 +11,6 @@ testdir=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=tests/testlib.sh
 . "${testdir}/testlib.sh"
 
-# Starves the x64 CI runner until the whole suite step is lost; Win32 is fine (#1038).
-if is_windows; then
-    echo "windows: wedges the x64 runner (#1038), skipping"
-    exit 77
-fi
-
 python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
 command -v httrack >/dev/null || {
     echo "could not find httrack" >&2

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -282,7 +282,6 @@ expected_skips="01_engine-footer-overflow.test
 152_engine-string-oom.test
 153_local-proxytrack-quiet.test
 215_engine-datadir-ospath.test
-230_local-ftp-userpass.test
 243_local-ftp-deadhost-interrupt.test
 235_local-resume-recovery.test
 48_local-crange-memresume.test


### PR DESCRIPTION
Investigation branch for #1038, not for merge. The Windows skip landed in #1035, before the FTP fixes in #1039 and #1055, so the wedge was never retested against them. This removes the skip and its `expected_skips` entry so the x64 leg runs the test again.

A red x64 leg is the result being looked for, not a regression to fix.