### PR TITLE
The ProxyTrack Windows skips outlived the reap that made them necessary

### DIFF
--- a/tests/120_local-proxytrack-webdav-default.test
+++ b/tests/120_local-proxytrack-webdav-default.test
@@ -18,9 +18,10 @@ command -v curl >/dev/null 2>&1 || {
     echo "curl missing, skipping"
     exit 77
 }
-# MSYS cannot reap a native listener, and the orphan wedges the suite (#595).
+# A leak on a fully buffered stdout shows only through the pty below, and Windows
+# builds neither Python's pty module nor os.fork.
 if is_windows; then
-    echo "windows: cannot reap a backgrounded proxytrack, skipping"
+    echo "windows: python has no pty, so a buffered leak would be invisible, skipping"
     exit 77
 fi
 

--- a/tests/147_local-proxytrack-webdav-overflow.test
+++ b/tests/147_local-proxytrack-webdav-overflow.test
@@ -18,11 +18,6 @@ command -v curl >/dev/null 2>&1 || {
     echo "curl missing, skipping"
     exit 77
 }
-# MSYS cannot reap a native listener, and the orphan wedges the suite (#595).
-if is_windows; then
-    echo "windows: cannot reap a backgrounded proxytrack, skipping"
-    exit 77
-fi
 
 dir=$(mktemp -d)
 ptpid=
@@ -49,8 +44,10 @@ alen=$(($(wc -c <"$dir/hdr") + $(wc -c <"$dir/body")))
     cat "$dir/hdr" "$dir/body"
 } >"$dir/in.arc"
 
+# $() strips a trailing LF, not the CR Windows python's print can put before it.
 freeport() {
-    "$python" -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()'
+    "$python" -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' |
+        tr -d '\r'
 }
 proxyport=$(freeport)
 icpport=$(freeport)
@@ -84,7 +81,7 @@ propfind() {
 
 # Amplification, not raw length, clears the old 1024-byte reserve: 900 '&'
 # become 4500 bytes, written twice, all under the 1024-byte request-line cap.
-amps=$("$python" -c "print('&' * 900)")
+amps=$("$python" -c "print('&' * 900)" | tr -d '\r')
 resp=$(propfind "$amps") || {
     echo "FAIL: proxytrack died on an escapexml-amplified PROPFIND"
     cat "$dir/pt.log"
@@ -104,7 +101,7 @@ test "$got" -eq 1800 || {
 }
 
 # Unescaped, so the bound is shown to be on the written length, not on '&'.
-plain=$("$python" -c "print('a' * 900)")
+plain=$("$python" -c "print('a' * 900)" | tr -d '\r')
 resp=$(propfind "$plain") || {
     echo "FAIL: proxytrack died on a 900-byte plain PROPFIND path"
     cat "$dir/pt.log"

--- a/tests/153_local-proxytrack-quiet.test
+++ b/tests/153_local-proxytrack-quiet.test
@@ -19,9 +19,11 @@ command -v curl >/dev/null 2>&1 || {
     echo "curl missing, skipping"
     exit 77
 }
-# MSYS cannot reap a native listener, and the orphan wedges the suite (#595).
+# A leak on a fully buffered stdout shows only through the pty below, and Windows
+# builds neither Python's pty module nor os.fork; proxytrack also skips the PID=
+# line, which request_log() cuts the banner off at.
 if is_windows; then
-    echo "windows: cannot reap a backgrounded proxytrack, skipping"
+    echo "windows: python has no pty, so a buffered leak would be invisible, skipping"
     exit 77
 fi
 

--- a/tests/249_windows-reap-images.test
+++ b/tests/249_windows-reap-images.test
@@ -1,9 +1,8 @@
 #!/bin/bash
 #
-# The Windows reap paths kill by image name, and their list used to be written out
-# by hand beside ENGINE_EXE_RE: it named only httrack.exe, so a proxytrack orphan
-# outlived the suite and starved the runner (#1067). Windows-only in production,
-# so nothing would exercise it before merge.
+# The Windows kill paths name images by hand and had drifted from ENGINE_EXE_RE,
+# so a leaked proxytrack.exe outlived the reap and starved the runner (#1067).
+# Shimmed, since nothing exercises those branches off a Windows runner.
 
 set -euo pipefail
 
@@ -19,9 +18,8 @@ fail() {
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_reapimg.XXXXXX")
 trap 'set +e; rm -rf "$tmp"' EXIT
 
-# Stand in for the runner. win_pid is shimmed rather than left to /proc so the
-# branch under test is pinned on every host -- and so a real MSYS run of this test
-# cannot resolve $$ and taskkill its own shell.
+# Stand in for the runner. win_pid is shimmed, not left to /proc, so each branch
+# is pinned on every host and an MSYS run cannot taskkill this shell.
 IS_WINDOWS=yes
 taskkill() { printf '%s\n' "$*" >>"$tmp/killed"; }
 tasklist() { printf 'proxytrack.exe   4242 Console\n'; }
@@ -72,12 +70,31 @@ done
 # cannot tell it from a leaked fixture server.
 if grep -qxF '/F /IM python.exe' "$tmp/killed"; then fail "the reap killed an unrelated python.exe"; fi
 
-# Control for the two greps above: with nothing engine-shaped listed it must warn
-# about nothing and kill nothing.
-tasklist() { printf 'System Idle Process              0 Services\n'; }
+# Near misses, not an idle host, are what a widened image matcher lets through.
+tasklist() {
+    printf 'System Idle Process              0 Services\n'
+    printf 'notepad-httrack-notes.exe      77 Console\n'
+    printf 'httrackless.exe                78 Console\n'
+    printf 'trackpad.exe                   79 Console\n'
+}
 : >"$tmp/killed"
 out=$(reap_leftover_processes 99_probe.test)
-test -z "$out" || fail "an idle host was reported as leaking: $out"
-test ! -s "$tmp/killed" || fail "an idle host was reaped: $(cat "$tmp/killed")"
+test -z "$out" || fail "an unrelated process was reported as a leak: $out"
+test ! -s "$tmp/killed" || fail "an unrelated process was reaped: $(cat "$tmp/killed")"
+
+# The same list drives the wedge report, which names python too so a leaked
+# fixture server is still visible to a reader.
+tasklist() { printf 'htsserver.exe   99 Console\npython.exe   98 Console\ntrackpad.exe   78 Console\n'; }
+out=$(list_stray_processes 0 named)
+grep -q 'htsserver.exe' <<<"$out" || fail "the stray listing dropped an engine: $out"
+grep -q 'python.exe' <<<"$out" || fail "the stray listing dropped python: $out"
+if grep -q 'trackpad' <<<"$out"; then fail "the stray listing caught an unrelated process: $out"; fi
+
+# The bug was a second engine list drifting from the first, so fail on any name
+# still written by hand inside a taskkill or a process-matching grep.
+stray=$(grep -nE '(taskkill|tasklist|grep -Ei)[^#]*(httrack|proxytrack|htsserver|webhttrack)' \
+    "$top_srcdir/tests/testlib.sh" | grep -vE 'ENGINE_EXES|ENGINE_IMAGE_RE' || true)
+test -z "$stray" || fail "engine names hand-written outside ENGINE_EXES:
+$stray"
 
 echo "OK: the Windows reap paths cover every engine image the matcher knows"

--- a/tests/249_windows-reap-images.test
+++ b/tests/249_windows-reap-images.test
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# The Windows reap paths kill by image name, and their list used to be written out
+# by hand beside ENGINE_EXE_RE: it named only httrack.exe, so a proxytrack orphan
+# outlived the suite and starved the runner (#1067). Windows-only in production,
+# so nothing would exercise it before merge.
+
+set -euo pipefail
+
+: "${top_srcdir:=..}"
+# shellcheck source=tests/testlib.sh
+. "$top_srcdir/tests/testlib.sh"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_reapimg.XXXXXX")
+trap 'set +e; rm -rf "$tmp"' EXIT
+
+# Stand in for the runner. win_pid is shimmed rather than left to /proc so the
+# branch under test is pinned on every host -- and so a real MSYS run of this test
+# cannot resolve $$ and taskkill its own shell.
+IS_WINDOWS=yes
+taskkill() { printf '%s\n' "$*" >>"$tmp/killed"; }
+tasklist() { printf 'proxytrack.exe   4242 Console\n'; }
+win_pid() { :; }
+
+# The matcher is the reference set, so a widened or unanchored one would make
+# every assertion below pass for free.
+for e in $ENGINE_EXES; do
+    [[ $e =~ $ENGINE_EXE_RE ]] || fail "ENGINE_EXE_RE does not match $e"
+    [[ $e.exe =~ $ENGINE_EXE_RE ]] || fail "ENGINE_EXE_RE does not match $e.exe"
+done
+for e in xhttrack httrackx httrack.dll python.exe ''; do
+    if [[ $e =~ $ENGINE_EXE_RE ]]; then fail "ENGINE_EXE_RE matches '$e'"; fi
+done
+
+: >"$tmp/killed"
+kill_tree 4242
+# Spelled out, not built from $ENGINE_EXES: dropping a name from that list has to
+# fail here, and an expectation derived from it would shrink along with the bug.
+want='/F /IM htsserver.exe
+/F /IM httrack.exe
+/F /IM proxytrack.exe
+/F /IM python.exe
+/F /IM webhttrack.exe'
+got=$(sort "$tmp/killed")
+test "$got" = "$want" || fail "kill_tree without a winpid ran: $got"
+# The defect itself: whatever the matcher reports as an engine, the kill names.
+for e in $ENGINE_EXES; do
+    grep -qxF "/F /IM $e.exe" "$tmp/killed" || fail "kill_tree leaves $e.exe running"
+done
+
+# With a winpid it is one tree kill and nothing by name, or a parallel sibling's
+# engine would go down with the target.
+win_pid() { echo 4242; }
+: >"$tmp/killed"
+kill_tree 99
+test "$(cat "$tmp/killed")" = '/F /T /PID 4242' || fail "kill_tree with a winpid ran: $(cat "$tmp/killed")"
+win_pid() { :; }
+
+: >"$tmp/killed"
+out=$(reap_leftover_processes 99_probe.test)
+grep -q '99_probe.test left processes behind' <<<"$out" || fail "the leak was not attributed: $out"
+grep -q 'proxytrack.exe' <<<"$out" || fail "the leftover proxytrack was not named: $out"
+for e in $ENGINE_EXES; do
+    grep -qxF "/F /IM $e.exe" "$tmp/killed" || fail "reap_leftover_processes leaves $e.exe running"
+done
+# Deliberately spared: the runner may run a python.exe of its own, and tasklist
+# cannot tell it from a leaked fixture server.
+if grep -qxF '/F /IM python.exe' "$tmp/killed"; then fail "the reap killed an unrelated python.exe"; fi
+
+# Control for the two greps above: with nothing engine-shaped listed it must warn
+# about nothing and kill nothing.
+tasklist() { printf 'System Idle Process              0 Services\n'; }
+: >"$tmp/killed"
+out=$(reap_leftover_processes 99_probe.test)
+test -z "$out" || fail "an idle host was reported as leaking: $out"
+test ! -s "$tmp/killed" || fail "an idle host was reaped: $(cat "$tmp/killed")"
+
+echo "OK: the Windows reap paths cover every engine image the matcher knows"

--- a/tests/79_local-proxytrack-webdav-mime.test
+++ b/tests/79_local-proxytrack-webdav-mime.test
@@ -17,12 +17,6 @@ command -v curl >/dev/null 2>&1 || {
     echo "curl missing, skipping"
     exit 77
 }
-# First test to run proxytrack as a live server, and MSYS cannot reap a native
-# listener: the orphan wedged the whole Windows suite for 48 minutes (#595).
-if is_windows; then
-    echo "windows: cannot reap a backgrounded proxytrack, skipping"
-    exit 77
-fi
 
 dir=$(mktemp -d)
 ptpid=
@@ -31,6 +25,7 @@ cleanup() {
     rm -rf "$dir"
 }
 trap 'set +e; cleanup' EXIT
+trap 'set +e; cleanup; exit 1' INT TERM HUP
 
 # Neither header is present, so file->contenttype and ->lastmodified stay "".
 printf 'HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\n' >"$dir/hdr"

--- a/tests/79_local-proxytrack-webdav-mime.test
+++ b/tests/79_local-proxytrack-webdav-mime.test
@@ -39,8 +39,10 @@ alen=$(($(wc -c <"$dir/hdr") + $(wc -c <"$dir/body")))
     cat "$dir/hdr" "$dir/body"
 } >"$dir/in.arc"
 
+# $() strips a trailing LF, not the CR Windows python's print can put before it.
 freeport() {
-    "$python" -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()'
+    "$python" -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' |
+        tr -d '\r'
 }
 proxyport=$(freeport)
 icpport=$(freeport)

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -256,8 +256,8 @@ echo "ran=$((pass + fail + skip)) pass=$pass fail=$fail skip=$skip" |
 # same line; compared as a sorted set below, so glob discovery order can't
 # cause a false mismatch either.
 # footer-overflow and purge-longpath skip on Windows (need a path past MAX_PATH);
-# webdav-default, webdav-overflow and proxytrack-quiet need a reapable background
-# listener, which MSYS cannot give them;
+# webdav-default and proxytrack-quiet read proxytrack's console through a pty,
+# which Windows Python does not build;
 # badmtime needs a filesystem that stores an mtime past gmtime's range;
 # single-file-gui drives htsserver, which this job does not build;
 # update-304-leak needs a LeakSanitizer build, which MSVC has no equivalent of;
@@ -278,7 +278,6 @@ expected_skips="01_engine-footer-overflow.test
 114_local-update-304-leak.test
 120_local-proxytrack-webdav-default.test
 143_engine-backtrace-empty.test
-147_local-proxytrack-webdav-overflow.test
 152_engine-string-oom.test
 153_local-proxytrack-quiet.test
 215_engine-datadir-ospath.test

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -256,8 +256,8 @@ echo "ran=$((pass + fail + skip)) pass=$pass fail=$fail skip=$skip" |
 # same line; compared as a sorted set below, so glob discovery order can't
 # cause a false mismatch either.
 # footer-overflow and purge-longpath skip on Windows (need a path past MAX_PATH);
-# webdav-default, webdav-mime, webdav-overflow and proxytrack-quiet need a
-# reapable background listener, which MSYS cannot give them;
+# webdav-default, webdav-overflow and proxytrack-quiet need a reapable background
+# listener, which MSYS cannot give them;
 # badmtime needs a filesystem that stores an mtime past gmtime's range;
 # single-file-gui drives htsserver, which this job does not build;
 # update-304-leak needs a LeakSanitizer build, which MSVC has no equivalent of;
@@ -287,7 +287,6 @@ expected_skips="01_engine-footer-overflow.test
 235_local-resume-recovery.test
 48_local-crange-memresume.test
 71_local-crange-repaircache.test
-79_local-proxytrack-webdav-mime.test
 80_engine-crash-symbolize.test
 88_local-proxytrack-badmtime.test
 241_local-single-file-gui.test"

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -199,6 +199,24 @@ dump_crawl_logs() {
     done
 }
 
+# Engine and fixture-server processes, matched on the executable basename only.
+# Matching the whole ps line instead would catch every unrelated command whose
+# arguments merely mention a path containing "httrack". One list feeds the matcher
+# and every Windows taskkill below: the two used to diverge, and a proxytrack
+# orphan survived the kill path that named only httrack.exe (#1067).
+ENGINE_EXES='httrack proxytrack htsserver webhttrack'
+ENGINE_EXE_RE="^(lt-)?(${ENGINE_EXES// /|})([.]exe)?\$"
+FIXTURE_SERVER_RE='^(local-server|proxy-https-server|proxy-connect-server|socks5-server|tls-stall-server)[.]py$'
+
+# taskkill every engine image on the host. Windows only, and by name, so the
+# caller must be sure no wanted process shares one.
+taskkill_engines() {
+    local e
+    for e in $ENGINE_EXES; do
+        taskkill /F /IM "$e.exe" >/dev/null 2>&1 || true
+    done
+}
+
 # The Windows PID behind an MSYS pid, empty when unknown.
 win_pid() {
     if test -r "/proc/$1/winpid"; then
@@ -236,7 +254,7 @@ kill_tree() {
             taskkill /F /T /PID "$winpid" >/dev/null 2>&1 || true
         else
             # The offline suite runs serially, so no wanted process races this.
-            taskkill /F /IM httrack.exe >/dev/null 2>&1 || true
+            taskkill_engines
             taskkill /F /IM python.exe >/dev/null 2>&1 || true
         fi
         return 0
@@ -246,12 +264,6 @@ kill_tree() {
     # with -- possibly the harness's own -- and taskkill above already reaped it.
     kill -9 -"$pid" 2>/dev/null || kill -9 "$pid" 2>/dev/null || true
 }
-
-# Engine and fixture-server processes, matched on the executable basename only.
-# Matching the whole ps line instead would catch every unrelated command whose
-# arguments merely mention a path containing "httrack".
-ENGINE_EXE_RE='^(lt-)?(httrack|proxytrack|htsserver|webhttrack)([.]exe)?$'
-FIXTURE_SERVER_RE='^(local-server|proxy-https-server|proxy-connect-server|socks5-server|tls-stall-server)[.]py$'
 
 # awk prologue for the matchers below: under qemu-user the kernel reports the
 # binfmt interpreter as the command, so the name we match on lands one column
@@ -329,7 +341,7 @@ list_stray_processes() {
         # slash switches: without MSYS_NO_PATHCONV a /fi would be rewritten to a
         # path. Plain output is Image Name + PID, which is all we need.
         test "$mode" != others || return 0
-        tasklist 2>/dev/null | grep -Ei 'httrack|proxytrack|htsserver|python' || true
+        tasklist 2>/dev/null | grep -Ei "${ENGINE_EXES// /|}|python" || true
     else
         # Fields 6 and 7 are the command and its first argument (the interpreter
         # and its script, for the Python fixtures).
@@ -357,7 +369,7 @@ list_stray_processes() {
 reap_leftover_processes() {
     local label=${1:-} left
     if is_windows; then
-        left=$(tasklist 2>/dev/null | grep -Ei 'httrack|proxytrack|htsserver' || true)
+        left=$(tasklist 2>/dev/null | grep -Ei "${ENGINE_EXES// /|}" || true)
     else
         left=$(list_stray_processes 0 named | awk 'NR > 1')
     fi
@@ -365,8 +377,7 @@ reap_leftover_processes() {
     printf '::warning::%s left processes behind\n' "$label"
     printf '%s\n' "$left"
     if is_windows; then
-        taskkill /F /IM httrack.exe >/dev/null 2>&1 || true
-        taskkill /F /IM proxytrack.exe >/dev/null 2>&1 || true
+        taskkill_engines
     else
         printf '%s\n' "$left" | awk '{ print $1 }' |
             while read -r p; do kill -9 "$p" 2>/dev/null || true; done

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -199,24 +199,6 @@ dump_crawl_logs() {
     done
 }
 
-# Engine and fixture-server processes, matched on the executable basename only.
-# Matching the whole ps line instead would catch every unrelated command whose
-# arguments merely mention a path containing "httrack". One list feeds the matcher
-# and every Windows taskkill below: the two used to diverge, and a proxytrack
-# orphan survived the kill path that named only httrack.exe (#1067).
-ENGINE_EXES='httrack proxytrack htsserver webhttrack'
-ENGINE_EXE_RE="^(lt-)?(${ENGINE_EXES// /|})([.]exe)?\$"
-FIXTURE_SERVER_RE='^(local-server|proxy-https-server|proxy-connect-server|socks5-server|tls-stall-server)[.]py$'
-
-# taskkill every engine image on the host. Windows only, and by name, so the
-# caller must be sure no wanted process shares one.
-taskkill_engines() {
-    local e
-    for e in $ENGINE_EXES; do
-        taskkill /F /IM "$e.exe" >/dev/null 2>&1 || true
-    done
-}
-
 # The Windows PID behind an MSYS pid, empty when unknown.
 win_pid() {
     if test -r "/proc/$1/winpid"; then
@@ -263,6 +245,26 @@ kill_tree() {
     # so -"$pid" here would target whatever real group $pid's number collides
     # with -- possibly the harness's own -- and taskkill above already reaped it.
     kill -9 -"$pid" 2>/dev/null || kill -9 "$pid" 2>/dev/null || true
+}
+
+# Engine and fixture-server processes, matched on the executable basename only.
+# Matching the whole ps line instead would catch every unrelated command whose
+# arguments merely mention a path containing "httrack". ENGINE_EXES feeds the
+# matcher and every Windows taskkill below, which used to drift apart (#1067).
+ENGINE_EXES='httrack proxytrack htsserver webhttrack'
+ENGINE_EXE_RE="^(lt-)?(${ENGINE_EXES// /|})([.]exe)?\$"
+# The same set against tasklist, whose first column is the image basename.
+# Anchored, or "notepad-httrack-notes.exe" reads as a leaked engine.
+ENGINE_IMAGE_RE="^(${ENGINE_EXES// /|})[.]exe"
+FIXTURE_SERVER_RE='^(local-server|proxy-https-server|proxy-connect-server|socks5-server|tls-stall-server)[.]py$'
+
+# taskkill every engine image on the host. Windows only, and by name, so the
+# caller must be sure no wanted process shares one.
+taskkill_engines() {
+    local e
+    for e in $ENGINE_EXES; do
+        taskkill /F /IM "$e.exe" >/dev/null 2>&1 || true
+    done
 }
 
 # awk prologue for the matchers below: under qemu-user the kernel reports the
@@ -341,7 +343,7 @@ list_stray_processes() {
         # slash switches: without MSYS_NO_PATHCONV a /fi would be rewritten to a
         # path. Plain output is Image Name + PID, which is all we need.
         test "$mode" != others || return 0
-        tasklist 2>/dev/null | grep -Ei "${ENGINE_EXES// /|}|python" || true
+        tasklist 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE|^python" || true
     else
         # Fields 6 and 7 are the command and its first argument (the interpreter
         # and its script, for the Python fixtures).
@@ -369,7 +371,7 @@ list_stray_processes() {
 reap_leftover_processes() {
     local label=${1:-} left
     if is_windows; then
-        left=$(tasklist 2>/dev/null | grep -Ei "${ENGINE_EXES// /|}" || true)
+        left=$(tasklist 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE" || true)
     else
         left=$(list_stray_processes 0 named | awk 'NR > 1')
     fi
@@ -465,7 +467,7 @@ dump_windows_stacks() {
         printf 'no stack: cdb.exe is not in the SDK Debuggers directories or on PATH\n'
         return 0
     fi
-    for p in $(tasklist 2>/dev/null | grep -Ei '^(httrack|proxytrack)[.]exe' | awk '{print $2}'); do
+    for p in $(tasklist 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE" | awk '{print $2}'); do
         found=1
         printf -- '--- cdb stack of pid %s ---\n' "$p"
         # Bounded, so a debugger that wedges cannot become the new hang. "qd"


### PR DESCRIPTION
Four ProxyTrack WebDAV tests still skip on Windows for a reap that #595 already landed, and that reap had a hole worth closing first. Three Windows kill and report paths each carried a hand-written list of engine images beside `ENGINE_EXE_RE` without matching it, so a leaked `proxytrack.exe` survived `kill_tree`'s fallback and a leaked `htsserver.exe` survived `reap_leftover_processes`. The greps over `tasklist` were unanchored too, so `notepad-httrack-notes.exe` read as a leaked engine. All of them now derive from one `ENGINE_EXES`, anchored through `ENGINE_IMAGE_RE`. `249_windows-reap-images.test` shims `taskkill` and `tasklist` to pin the three paths, and fails on any engine name still written by hand.

`79_local-proxytrack-webdav-mime` and `147_local-proxytrack-webdav-overflow` come off the skip list; 79 is already green on both Windows legs. `120_local-proxytrack-webdav-default` and `153_local-proxytrack-quiet` keep theirs, with an accurate reason: both read proxytrack's console through a pty so a leak on fully buffered stdout cannot be lost, and Windows has neither Python's `pty` module nor `os.fork`. 153 also parses the `PID=` banner line, which proxytrack prints only under `#ifndef _WIN32`.

Closes #1067