### PR TITLE
A crawl on a terminal with stdin at end of file toggles its display mode in a loop

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -3411,6 +3411,7 @@ int read_stdin(char *s, int max) {
 
 #ifdef _WIN32
 int check_stdin(void) {
+  /* The console queue, not stdin: no end of file to mistake for a keystroke. */
   return (_kbhit());
 }
 #else
@@ -3426,11 +3427,18 @@ int check_flot(T_SOC s) {
   return FD_ISSET(s, &fds);
 }
 int check_stdin(void) {
+  int c;
+
   fflush(stdout);
-  fflush(stdin);
-  if (check_flot(0))
-    return 1;
-  return 0;
+  if (!check_flot(0))
+    return 0;
+  /* Readable is not data: an stdin at EOF stays readable forever and reads as a
+     keypress (#1072). clearerr: a terminal can get input again after a ^D. */
+  clearerr(stdin);
+  if ((c = fgetc(stdin)) == EOF)
+    return 0;
+  ungetc(c, stdin);
+  return 1;
 }
 #endif
 #endif

--- a/tests/244_local-tty-output.test
+++ b/tests/244_local-tty-output.test
@@ -30,31 +30,8 @@ serverpid=$!
 port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 url="http://127.0.0.1:${port}/simple/basic.html"
 
-# Stdin is the pty too, and never written to: an stdin at EOF reads as a keypress
-# and flips the display mode in a loop. ONLCR off stops the pty manufacturing the
-# CRs the spinner check counts.
-cat >"${tmpdir}/ttyrun.py" <<'EOF'
-import os, subprocess, sys, termios
-
-out, argv = sys.argv[1], sys.argv[2:]
-master, slave = os.openpty()
-attrs = termios.tcgetattr(slave)
-attrs[1] &= ~termios.ONLCR
-termios.tcsetattr(slave, termios.TCSANOW, attrs)
-p = subprocess.Popen(argv, stdin=slave, stdout=slave, stderr=slave)
-os.close(slave)
-with open(out, "wb") as f:
-    while True:
-        try:
-            data = os.read(master, 4096)
-        except OSError:  # the slave closed: EIO on Linux, empty read on BSD
-            break
-        if not data:
-            break
-        f.write(data)
-os.close(master)
-sys.exit(p.wait())
-EOF
+# Stdin is the pty too, and never written to, so it never reads as a keypress.
+ttyrun=$(nativepath "${testdir}/ttyrun.py")
 
 # crawl <label> <httrack args...>, stdout to a pipe; CRLF from the Windows CRT
 # is normalized away so only a CR the display wrote is left. --quiet would gate
@@ -71,7 +48,7 @@ crawl() {
 crawl_tty() {
     local label=$1
     shift
-    run_with_timeout 120 "$python" "${tmpdir}/ttyrun.py" "${tmpdir}/out_${label}" \
+    run_with_timeout 120 "$python" "$ttyrun" "${tmpdir}/out_${label}" -- \
         httrack -O "${tmpdir}/m_${label}" --robots=0 --timeout=30 --retries=1 \
         -c1 "$@" "$url" >/dev/null 2>&1 || true
 }

--- a/tests/247_cli-stdin-eof.test
+++ b/tests/247_cli-stdin-eof.test
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# #1072: on a terminal with stdin at end of file, select() keeps saying readable,
+# the crawl loop takes that for an ENTER and toggles the display on every pass.
+# -%v0 then paints the full panel it was told not to.
+
+set -eu
+
+: "${top_srcdir:=..}"
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+server=$(nativepath "${testdir}/local-server.py")
+root=$(nativepath "${testdir}/server-root")
+ttyrun=$(nativepath "${testdir}/ttyrun.py")
+
+if is_windows; then
+    echo "no pty on Windows; skipping" >&2
+    exit 77
+fi
+python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_stdineof.XXXXXX") || exit 1
+serverpid=
+cleanup() {
+    stop_server "$serverpid"
+    rm -rf "$tmpdir"
+}
+trap 'set +e; cleanup' EXIT
+trap cleanup HUP INT QUIT PIPE TERM
+
+serverlog="${tmpdir}/server.log"
+: >"$serverlog"
+"$python" "$server" --root "$root" >"$serverlog" 2>&1 &
+serverpid=$!
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+
+which httrack >/dev/null || {
+    echo "could not find httrack"
+    exit 1
+}
+
+# Trickled pages: the crawl has to outlive several passes of the loop that polls
+# stdin, or a display that toggles has no time to show it.
+url="http://127.0.0.1:${port}/trickle/index.html"
+
+# crawl <label> <ttyrun opts...>
+crawl() {
+    local label=$1
+    shift
+    run_with_timeout 120 "$python" "$ttyrun" "${tmpdir}/out_${label}" "$@" -- \
+        httrack "$url" -O "${tmpdir}/m_${label}" --robots=0 -%v0 \
+        --timeout=30 --retries=1 -c2 --max-time 8 >/dev/null 2>&1 || true
+}
+
+# count <label> <ERE>
+count() {
+    LC_ALL=C grep -ac "$2" "${tmpdir}/out_$1" || true
+}
+
+# expect <description> <actual> <op> <bound> <label>
+expect() {
+    printf '[%s] ..\t' "$1"
+    if test "$2" -"$3" "$4"; then
+        echo "OK"
+    else
+        echo "FAIL: got $2"
+        LC_ALL=C head -c 400 "${tmpdir}/out_$5" | cat -v >&2
+        exit 1
+    fi
+}
+
+esc=$'\033'
+cr=$'\r'
+
+crawl eof --stdin eof
+expect "the crawl ran" "$(count eof '^Mirror launched')" ge 1 eof
+expect "an stdin at EOF leaves -%v0 alone" "$(count eof "$esc")" eq 0 eof
+# Teeth: without this, a display that painted nothing at all would pass.
+expect "the spinner still turned" "$(count eof "$cr")" ge 1 eof
+
+# Control: a real ENTER must still toggle, or a check_stdin() that always reports
+# "nothing to read" would satisfy the case above.
+crawl enter --stdin tty --enter
+expect "ENTER ran the crawl too" "$(count enter '^Mirror launched')" ge 1 enter
+expect "ENTER still switches to the panel" "$(count enter "$esc")" ge 20 enter

--- a/tests/247_cli-stdin-eof.test
+++ b/tests/247_cli-stdin-eof.test
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# #1072: on a terminal with stdin at end of file, select() keeps saying readable,
-# the crawl loop takes that for an ENTER and toggles the display on every pass.
-# -%v0 then paints the full panel it was told not to.
+# select() reports stdin readable even at end of file (#1072). The crawl loop
+# reads that as an ENTER and toggles the display every pass, so -%v0 paints
+# the full panel it was told to suppress.
 
 set -eu
 
@@ -79,8 +79,14 @@ expect "an stdin at EOF leaves -%v0 alone" "$(count eof "$esc")" eq 0 eof
 # Teeth: without this, a display that painted nothing at all would pass.
 expect "the spinner still turned" "$(count eof "$cr")" ge 1 eof
 
+# The ticket's own case: a terminal, not a redirection. A fix that just gave up
+# off a tty would pass the leg above and leave this one broken.
+crawl eot --stdin tty --send eot
+expect "^D ran the crawl too" "$(count eot '^Mirror launched')" ge 1 eot
+expect "a terminal at EOF leaves -%v0 alone" "$(count eot "$esc")" eq 0 eot
+
 # Control: a real ENTER must still toggle, or a check_stdin() that always reports
-# "nothing to read" would satisfy the case above.
-crawl enter --stdin tty --enter
+# "nothing to read" would satisfy both cases above.
+crawl enter --stdin tty --send enter
 expect "ENTER ran the crawl too" "$(count enter '^Mirror launched')" ge 1 enter
 expect "ENTER still switches to the panel" "$(count enter "$esc")" ge 20 enter

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -10,7 +10,7 @@ EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c a
 	proxy-https-server.py socks5-server.py proxy-connect-server.py \
 	proxytestlib.py tls-stall-server.py warc-validate.py wacz-validate.py \
 	header-injection-server.py header-injection-check.py \
-	pty-resize.py test-timeout.sh png-colors.py \
+	pty-resize.py ttyrun.py test-timeout.sh png-colors.py \
 	local-crawl.sh local-server.py ftp-server.py testlib.sh \
 	ci-windows-suite.sh ci-windows-watchdog.ps1 \
 	server.crt server.key \

--- a/tests/ttyrun.py
+++ b/tests/ttyrun.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Run a command with a pty for stdout/stderr and capture what it paints.
 
-Usage: ttyrun.py <capture-file> [--stdin tty|eof] [--enter] -- <cmd> [args...]
+Usage: ttyrun.py <capture-file> [--stdin tty|eof] [--send enter|eot] -- <cmd> [args...]
 
---stdin tty (default) hands the child the pty, which never goes readable;
---stdin eof gives it /dev/null. --enter types one ENTER once the child paints.
+--stdin tty (default) hands the child the pty, --stdin eof gives it /dev/null.
+--send types one ENTER, or one ^D to put the terminal at end of file, as soon
+as the child paints.
 """
 import os
 import subprocess
@@ -15,7 +16,8 @@ capture = sys.argv[1]
 opts = sys.argv[2 : sys.argv.index("--")]
 argv = sys.argv[sys.argv.index("--") + 1 :]
 stdin_mode = opts[opts.index("--stdin") + 1] if "--stdin" in opts else "tty"
-send_enter = "--enter" in opts
+keys = {"enter": b"\n", "eot": b"\004"}
+send = keys[opts[opts.index("--send") + 1]] if "--send" in opts else None
 
 master, slave = os.openpty()
 attrs = termios.tcgetattr(slave)
@@ -38,8 +40,8 @@ with open(capture, "wb") as f:
         if not data:
             break
         f.write(data)
-        if send_enter:
-            os.write(master, b"\n")
-            send_enter = False
+        if send:
+            os.write(master, send)
+            send = None
 os.close(master)
 sys.exit(p.wait())

--- a/tests/ttyrun.py
+++ b/tests/ttyrun.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Run a command with a pty for stdout/stderr and capture what it paints.
+
+Usage: ttyrun.py <capture-file> [--stdin tty|eof] [--enter] -- <cmd> [args...]
+
+--stdin tty (default) hands the child the pty, which never goes readable;
+--stdin eof gives it /dev/null. --enter types one ENTER once the child paints.
+"""
+import os
+import subprocess
+import sys
+import termios
+
+capture = sys.argv[1]
+opts = sys.argv[2 : sys.argv.index("--")]
+argv = sys.argv[sys.argv.index("--") + 1 :]
+stdin_mode = opts[opts.index("--stdin") + 1] if "--stdin" in opts else "tty"
+send_enter = "--enter" in opts
+
+master, slave = os.openpty()
+attrs = termios.tcgetattr(slave)
+attrs[1] &= ~termios.ONLCR  # or the pty manufactures the CRs a spinner check counts
+termios.tcsetattr(slave, termios.TCSANOW, attrs)
+devnull = os.open(os.devnull, os.O_RDONLY) if stdin_mode == "eof" else None
+p = subprocess.Popen(
+    argv, stdin=slave if devnull is None else devnull, stdout=slave, stderr=slave
+)
+os.close(slave)
+if devnull is not None:
+    os.close(devnull)
+
+with open(capture, "wb") as f:
+    while True:
+        try:
+            data = os.read(master, 4096)
+        except OSError:  # the slave closed: EIO on Linux, empty read on BSD
+            break
+        if not data:
+            break
+        f.write(data)
+        if send_enter:
+            os.write(master, b"\n")
+            send_enter = False
+os.close(master)
+sys.exit(p.wait())


### PR DESCRIPTION
A select() that reports stdin readable does not report that there is data: at end of file it stays readable forever. `check_stdin()` sold that to the crawl loop as a keypress. The ENTER handler then flipped `opt->verbosedisplay` on every pass, so `httrack -%v0 ... < /dev/null` on a terminal alternated between the spinner and the full panel for the whole run.

It now peeks a byte with fgetc/ungetc before saying yes, which also stops `read_stdin()` filling its buffer with (char)EOF. The `fflush(stdin)` had to go with it: undefined on an input stream, and it would have discarded the byte pushed back. `clearerr()` comes first, so a terminal that gets input again after a ^D is still heard. The Windows branch needs nothing: `_kbhit()` reads the console queue, not stdin, so it has no end of file to report. It gets a comment saying so.

Test 247 runs httrack on a pty and checks that `-%v0` paints no escape sequence while the spinner still turns, once with stdin on /dev/null and once with a ^D typed into the terminal. On master each capture holds over a thousand lines of panel escapes. The ^D leg is the one that matters: a fix that just gave up off a tty passes the /dev/null leg. A third crawl types ENTER instead, guarding against a `check_stdin()` that simply never reports input. Test 244's inlined pty driver moved to `tests/ttyrun.py`, which both tests now use.

Closes #1072