### PR TITLE
Ctrl-C does not shorten an in-flight HTTP connect

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -2771,6 +2771,38 @@ void back_clean(httrackp * opt, cache_back * cache, struct_back * sback) {
   }
 }
 
+/* Slot waiting for a connection to come up: nothing requested on it yet. */
+static hts_boolean back_is_preconnect(const int status) {
+  return status == STATUS_WAIT_DNS || status == STATUS_CONNECTING ||
+         status == STATUS_SSL_WAIT_HANDSHAKE;
+}
+
+/* A stopped mirror has nothing to finish on a connection never established, and
+   left alone such a slot holds the drain for the whole --timeout (#1073). Slots
+   already receiving stay: finishing those is what the first ^C promises. */
+static void back_stop_preconnect(httrackp *opt, struct_back *sback) {
+  lien_back *const back = sback->lnk;
+  int aborted = 0;
+  int i;
+
+  for (i = 0; i < sback->count; i++) {
+    if (!back_is_preconnect(back[i].status))
+      continue;
+    if (back[i].r.soc != INVALID_SOCKET)
+      deletehttp(&back[i].r);
+    back[i].r.soc = INVALID_SOCKET;
+    /* fatal, as back_add() reports it: a stop must not schedule a retry */
+    back[i].r.statuscode = STATUSCODE_INVALID;
+    strcpybuff(back[i].r.msg, "mirror stopped by user");
+    back_set_finished(sback, i);
+    aborted++;
+  }
+  if (aborted > 0)
+    hts_log_print(opt, LOG_WARNING,
+                  "Mirror stopped by user, %d pending connection(s) aborted",
+                  aborted);
+}
+
 // attente (gestion des buffers des sockets)
 void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                TStamp stat_timestart) {
@@ -2799,6 +2831,9 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
   // Cleanup the stack to save space!
   back_clean(opt, cache, sback);
 #endif
+
+  if (opt->state.stop)
+    back_stop_preconnect(opt, sback);
 
   /* Time/size limit exceeded past grace: abort in-flight transfers so no wait
      loop starves (#481, #77). FTP slots stay, their thread owns the socket. */

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -2777,9 +2777,8 @@ static hts_boolean back_is_preconnect(const int status) {
          status == STATUS_SSL_WAIT_HANDSHAKE;
 }
 
-/* A stopped mirror has nothing to finish on a connection never established, and
-   left alone such a slot holds the drain for the whole --timeout (#1073). Slots
-   already receiving stay: finishing those is what the first ^C promises. */
+/* Drop the slots still waiting to connect: nothing to finish there, and left
+   alone they hold the drain for --timeout (#1073). Receiving slots stay. */
 static void back_stop_preconnect(httrackp *opt, struct_back *sback) {
   lien_back *const back = sback->lnk;
   int aborted = 0;

--- a/src/htsdns_selftest.c
+++ b/src/htsdns_selftest.c
@@ -105,6 +105,10 @@ static mock_host mock_hosts[] = {
     /* a second one, so a cancelled resolve cannot cache an answer the next
        case then reads instead of asking for */
     {"slow2.test", 0, 1, {{AF_INET, {127, 0, 0, 10}}}, 0, MOCK_SLOW_MS},
+    /* two more for the cached entry point, checked with the mirror running and
+       then stopped: neither case may read the other's cached answer */
+    {"slow3.test", 0, 1, {{AF_INET, {127, 0, 0, 11}}}, 0, MOCK_SLOW_MS},
+    {"slow4.test", 0, 1, {{AF_INET, {127, 0, 0, 12}}}, 0, MOCK_SLOW_MS},
 };
 
 /* Serializes mock_host bookkeeping: a timed-out resolve is abandoned, so its
@@ -575,10 +579,31 @@ int dns_timeout_selftests(httrackp *opt) {
     CHECK(elapsed >= MOCK_SLOW_MS / 2);
   }
 
-  /* Three of the four resolves were abandoned mid-backend; wait for their
+  /* The cached entry point takes the mirror's own stop flag as its cancel, so
+     a ^C ends a resolve nothing else would bound (#1073). Unbounded here, to
+     tell the stop apart from a deadline. */
+  opt->timeout = 0;
+  {
+    /* control first: with the mirror running, the same call still waits */
+    start = mtime_local();
+    count = hts_dns_resolve_all(opt, "slow3.test", addrs, HTS_MAXADDRNUM, &err);
+    elapsed = mtime_local() - start;
+    CHECK(count == 1);
+    CHECK(elapsed >= MOCK_SLOW_MS / 2);
+
+    opt->state.stop = 1; /* the flag, not hts_request_stop's log line */
+    start = mtime_local();
+    count = hts_dns_resolve_all(opt, "slow4.test", addrs, HTS_MAXADDRNUM, &err);
+    elapsed = mtime_local() - start;
+    opt->state.stop = 0;
+    CHECK(count == 0);
+    CHECK(elapsed < MOCK_SLOW_MS / 2);
+  }
+
+  /* Four of the six resolves were abandoned mid-backend; wait for their
      workers to leave it before returning. The backend stays installed: an
      abandoned worker still reads it (to free its addrinfo). */
-  mock_wait_finished(4);
+  mock_wait_finished(6);
   return failures;
 }
 

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -5257,8 +5257,10 @@ static int hts_dns_resolve_nocache_list_bounded(
 int hts_dns_resolve_all(httrackp *opt, const char *iadr, SOCaddr *out, int max,
                         const char **error) {
   assertf(opt != NULL);
-  return hts_dns_resolve_all_bounded(opt, iadr, out, max, opt->timeout, NULL,
-                                     error);
+  /* the mirror's stop flag cancels: a resolve behind a black hole otherwise
+     holds a stopped crawl for the whole --timeout (#1073) */
+  return hts_dns_resolve_all_bounded(opt, iadr, out, max, opt->timeout,
+                                     &opt->state.stop, error);
 }
 
 int hts_dns_resolve_all_bounded(httrackp *opt, const char *iadr, SOCaddr *out,

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -279,7 +279,8 @@ LLint http_xfread1(htsblk * r, int bufl);
    resolver order), returning the count (0 = does not resolve, negative-cached).
    Resolves once per host; later calls read the DNS cache. Must hold no lock
    (brackets opt->state.lock itself, never across the resolve). A miss resolves
-   on a worker thread bounded by opt->timeout; a timeout reports 0, uncached. */
+   on a worker thread bounded by opt->timeout and cut short by a mirror stop;
+   either reports 0, uncached. */
 int hts_dns_resolve_all(httrackp *opt, const char *iadr, SOCaddr *out, int max,
                         const char **error);
 /* Like hts_dns_resolve_all(), with the wait bounded by timeout seconds (<= 0:

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -7722,6 +7722,122 @@ static int st_backswap(httrackp *opt, int argc, char **argv) {
   return back_selftest_slot_swap();
 }
 
+/* TEST-NET-1: routed nowhere, so a connect to it stays pending. */
+#define ST_BACKSTOP_DEADHOST "192.0.2.1"
+
+/* Open a connect that is still in flight, or INVALID_SOCKET where the network
+   answers for the blackhole instead of dropping. */
+static T_SOC st_backstop_pending(httrackp *opt, htsblk *r) {
+  T_SOC soc;
+
+  hts_init_htsblk(r);
+  soc = newhttp_addr(opt, ST_BACKSTOP_DEADHOST, r, 80, 0, 0, NULL);
+  if (soc == INVALID_SOCKET)
+    return INVALID_SOCKET;
+  r->soc = soc;
+  if (check_socket_connect(soc) != 0) {
+    strcpybuff(r->msg, "the network answers for this address");
+    deletehttp(r);
+    return INVALID_SOCKET;
+  }
+  return soc;
+}
+
+static void st_backstop_slot(lien_back *back, int status, const htsblk *r) {
+  back->r = *r;
+  back->r.location = back->location_buffer;
+  back->status = status;
+  back->timeout = -1; /* only the stop may end these slots */
+  back->rateout = -1;
+  /* poisoned, so the expected outcome cannot be the value the slot came with */
+  back->r.statuscode = STATUSCODE_TIMEOUT;
+  strcpybuff(back->r.msg, "untouched");
+  strcpybuff(back->url_adr, ST_BACKSTOP_DEADHOST);
+  strcpybuff(back->url_fil, "/stalled.html");
+}
+
+/* #1073: a user stop must drop the slots still waiting for a connection, and
+   only those. */
+static int st_backstop(httrackp *opt, int argc, char **argv) {
+  enum { SLOT_DNS = 0, SLOT_CONNECT, SLOT_SSL, SLOT_HEADERS, SLOT_XFER, SLOTS };
+
+  static const int status[SLOTS] = {STATUS_WAIT_DNS, STATUS_CONNECTING,
+                                    STATUS_SSL_WAIT_HANDSHAKE,
+                                    STATUS_WAIT_HEADERS, STATUS_TRANSFER};
+  htsblk r[SLOTS];
+  struct_back *sback;
+  cache_back cache;
+  lien_back *back;
+  int err = 0;
+  int i;
+
+  (void) argc;
+  (void) argv;
+
+  /* no quota may fire instead of the stop, and no slot may time out */
+  opt->maxtime = opt->maxsite = 0;
+  opt->timeout = 0;
+
+  /* The resolution wait owns no socket yet and the handshake wait no TLS
+     session: a stop must end them without reading either. */
+  for (i = 0; i < SLOTS; i++) {
+    if (i == SLOT_DNS) {
+      hts_init_htsblk(&r[i]);
+    } else if (st_backstop_pending(opt, &r[i]) == INVALID_SOCKET) {
+      printf("backstop: SKIP (no stalled connect to " ST_BACKSTOP_DEADHOST
+             ": %s)\n",
+             r[i].msg);
+      while (--i >= SLOT_CONNECT)
+        deletehttp(&r[i]);
+      return 77;
+    }
+  }
+
+  memset(&cache, 0, sizeof(cache));
+  cache.hashtable = coucal_new(0);
+  sback = back_new(opt, SLOTS);
+  back = sback->lnk;
+  for (i = 0; i < SLOTS; i++)
+    st_backstop_slot(&back[i], status[i], &r[i]);
+
+  hts_request_stop(opt, 0);
+  back_wait(sback, opt, &cache, 0);
+
+#define CHECK(cond)                                                            \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      printf("  FAIL line %d: %s\n", __LINE__, #cond);                         \
+      err = 1;                                                                 \
+    }                                                                          \
+  } while (0)
+
+  /* every pre-connect slot is gone, socket closed, and reported as fatal so
+     the link is not queued again */
+  for (i = SLOT_DNS; i <= SLOT_SSL; i++) {
+    CHECK(back[i].status == STATUS_READY);
+    CHECK(back[i].r.soc == INVALID_SOCKET);
+    CHECK(back[i].r.statuscode == STATUSCODE_INVALID);
+    CHECK(strcmp(back[i].r.msg, "mirror stopped by user") == 0);
+  }
+  /* control: an established transfer is what the first stop lets finish, so a
+     sweep that took these too would be the wrong fix */
+  for (i = SLOT_HEADERS; i <= SLOT_XFER; i++) {
+    CHECK(back[i].status == status[i]);
+    CHECK(back[i].r.soc != INVALID_SOCKET);
+    CHECK(back[i].r.statuscode == STATUSCODE_TIMEOUT);
+    CHECK(strcmp(back[i].r.msg, "untouched") == 0);
+  }
+#undef CHECK
+
+  for (i = 0; i < SLOTS; i++)
+    deletehttp(&back[i].r);
+  back_free(&sback);
+  coucal_delete(&cache.hashtable);
+
+  printf("backstop self-test: %s\n", err ? "FAIL" : "OK");
+  return err;
+}
+
 static int st_threadwait(httrackp *opt, int argc, char **argv) {
   int err = 0;
   int i, round;
@@ -8604,6 +8720,9 @@ static const struct selftest_entry {
      st_localtime},
     {"backswap", "", "which backlog slots may be swapped to the ready table",
      st_backswap},
+    {"backstop", "",
+     "a user stop drops the slots still waiting to connect (#1073)",
+     st_backstop},
     {"pause", "", "randomized inter-file pause target self-test", st_pause},
     {"relative", "<link> <curr-file>", "relative link between two paths",
      st_relative},

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -7743,7 +7743,21 @@ static T_SOC st_backstop_pending(httrackp *opt, htsblk *r) {
   return soc;
 }
 
-static void st_backstop_slot(lien_back *back, int status, const htsblk *r) {
+/* Is the descriptor still an open socket? Clearing r.soc proves nothing about
+   the connection: an abort that forgets deletehttp() leaks one fd per slot. */
+static hts_boolean st_backstop_soc_open(T_SOC soc) {
+  int type = 0;
+  socklen_t len = (socklen_t) sizeof(type);
+
+  return getsockopt(soc, SOL_SOCKET, SO_TYPE, (char *) &type, &len) == 0
+             ? HTS_TRUE
+             : HTS_FALSE;
+}
+
+static void st_backstop_slot(struct_back *sback, int p, int status,
+                             const htsblk *r) {
+  lien_back *const back = &sback->lnk[p];
+
   back->r = *r;
   back->r.location = back->location_buffer;
   back->status = status;
@@ -7754,21 +7768,61 @@ static void st_backstop_slot(lien_back *back, int status, const htsblk *r) {
   strcpybuff(back->r.msg, "untouched");
   strcpybuff(back->url_adr, ST_BACKSTOP_DEADHOST);
   strcpybuff(back->url_fil, "/stalled.html");
+  /* address list already probed, as it is for a live connect: re-probing it
+     would resolve, and the fd churn would spoil the closed-socket check */
+  sback->connect_fallback[p].addr_count = 1;
 }
 
-/* #1073: a user stop must drop the slots still waiting for a connection, and
-   only those. */
-static int st_backstop(httrackp *opt, int argc, char **argv) {
-  enum { SLOT_DNS = 0, SLOT_CONNECT, SLOT_SSL, SLOT_HEADERS, SLOT_XFER, SLOTS };
+/* Refill every slot: a fresh pending connect for each state that owns a socket,
+   plus the poison the assertions read back. False if the blackhole answered. */
+static hts_boolean st_backstop_arm(httrackp *opt, struct_back *sback,
+                                   const int *status, htsblk *r, int slots,
+                                   int dnsslot) {
+  int i;
 
-  static const int status[SLOTS] = {STATUS_WAIT_DNS, STATUS_CONNECTING,
-                                    STATUS_SSL_WAIT_HANDSHAKE,
-                                    STATUS_WAIT_HEADERS, STATUS_TRANSFER};
+  for (i = 0; i < slots; i++) {
+    deletehttp(&sback->lnk[i].r); /* whatever the previous round left */
+    if (i == dnsslot) {
+      hts_init_htsblk(&r[i]);
+    } else if (st_backstop_pending(opt, &r[i]) == INVALID_SOCKET) {
+      printf("backstop: SKIP (no stalled connect to " ST_BACKSTOP_DEADHOST
+             ": %s)\n",
+             r[i].msg);
+      return HTS_FALSE;
+    }
+    st_backstop_slot(sback, i, status[i], &r[i]);
+  }
+  return HTS_TRUE;
+}
+
+/* A user stop must drop only the slots still waiting to connect (#1073). */
+static int st_backstop(httrackp *opt, int argc, char **argv) {
+  /* pre-connect first, then the states a stop must leave running: two of the
+     receive automaton, and the FTP one whose socket another thread owns */
+  enum {
+    SLOT_DNS = 0,
+    SLOT_CONNECT,
+    SLOT_SSL,
+    SLOT_LAST_PRECONNECT = SLOT_SSL,
+    SLOT_HEADERS,
+    SLOT_XFER,
+    SLOT_CHUNK,
+    SLOT_FTP,
+    SLOTS
+  };
+
+  static const int status[SLOTS] = {
+      STATUS_WAIT_DNS,     STATUS_CONNECTING, STATUS_SSL_WAIT_HANDSHAKE,
+      STATUS_WAIT_HEADERS, STATUS_TRANSFER,   STATUS_CHUNK_WAIT,
+      STATUS_FTP_TRANSFER};
+  T_SOC swept[SLOTS];
   htsblk r[SLOTS];
-  struct_back *sback;
+  struct_back *sback = NULL;
   cache_back cache;
   lien_back *back;
   int err = 0;
+  int skipped = 0;
+  int round;
   int i;
 
   (void) argc;
@@ -7777,31 +7831,9 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
   /* no quota may fire instead of the stop, and no slot may time out */
   opt->maxtime = opt->maxsite = 0;
   opt->timeout = 0;
-
-  /* The resolution wait owns no socket yet and the handshake wait no TLS
-     session: a stop must end them without reading either. */
-  for (i = 0; i < SLOTS; i++) {
-    if (i == SLOT_DNS) {
-      hts_init_htsblk(&r[i]);
-    } else if (st_backstop_pending(opt, &r[i]) == INVALID_SOCKET) {
-      printf("backstop: SKIP (no stalled connect to " ST_BACKSTOP_DEADHOST
-             ": %s)\n",
-             r[i].msg);
-      while (--i >= SLOT_CONNECT)
-        deletehttp(&r[i]);
-      return 77;
-    }
-  }
+  opt->state.stop = 0;
 
   memset(&cache, 0, sizeof(cache));
-  cache.hashtable = coucal_new(0);
-  sback = back_new(opt, SLOTS);
-  back = sback->lnk;
-  for (i = 0; i < SLOTS; i++)
-    st_backstop_slot(&back[i], status[i], &r[i]);
-
-  hts_request_stop(opt, 0);
-  back_wait(sback, opt, &cache, 0);
 
 #define CHECK(cond)                                                            \
   do {                                                                         \
@@ -7811,28 +7843,75 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
     }                                                                          \
   } while (0)
 
-  /* every pre-connect slot is gone, socket closed, and reported as fatal so
-     the link is not queued again */
-  for (i = SLOT_DNS; i <= SLOT_SSL; i++) {
-    CHECK(back[i].status == STATUS_READY);
-    CHECK(back[i].r.soc == INVALID_SOCKET);
-    CHECK(back[i].r.statuscode == STATUSCODE_INVALID);
-    CHECK(strcmp(back[i].r.msg, "mirror stopped by user") == 0);
+  cache.hashtable = coucal_new(0);
+  sback = back_new(opt, SLOTS);
+  back = sback->lnk;
+  if (!st_backstop_arm(opt, sback, status, r, SLOTS, SLOT_DNS)) {
+    skipped = 1;
+    goto cleanup;
   }
-  /* control: an established transfer is what the first stop lets finish, so a
-     sweep that took these too would be the wrong fix */
-  for (i = SLOT_HEADERS; i <= SLOT_XFER; i++) {
+
+  /* Control: with the mirror running, back_wait ends nothing. A sweep that
+     fired unconditionally would strand every connect the crawl opens. Only the
+     states back_wait leaves alone are checked; it advances the resolution and
+     handshake waits by itself, the first to connect and the second to an error
+     for want of a TLS session this fixture cannot build. */
+  back_wait(sback, opt, &cache, 0);
+  CHECK(back[SLOT_CONNECT].status == STATUS_CONNECTING);
+  for (i = SLOT_HEADERS; i < SLOTS; i++)
     CHECK(back[i].status == status[i]);
-    CHECK(back[i].r.soc != INVALID_SOCKET);
+  for (i = SLOT_CONNECT; i < SLOTS; i++) {
+    if (i == SLOT_SSL)
+      continue;
     CHECK(back[i].r.statuscode == STATUSCODE_TIMEOUT);
     CHECK(strcmp(back[i].r.msg, "untouched") == 0);
   }
+
+  /* Twice, re-armed in between: the sweep runs on every wait, not once. A slot
+     that was connecting when the user hit ^C is the case under test, so the
+     flag goes up after the slots are in place. */
+  for (round = 0; round < 2 && !err; round++) {
+    opt->state.stop = 0;
+    if (!st_backstop_arm(opt, sback, status, r, SLOTS, SLOT_DNS)) {
+      skipped = 1;
+      goto cleanup;
+    }
+    for (i = 0; i < SLOTS; i++)
+      swept[i] = r[i].soc;
+    hts_request_stop(opt, 0);
+
+    back_wait(sback, opt, &cache, 0);
+
+    /* every pre-connect slot is gone, its socket closed rather than merely
+       forgotten, and reported as fatal so the link is not queued again */
+    for (i = SLOT_DNS; i <= SLOT_LAST_PRECONNECT; i++) {
+      CHECK(back[i].status == STATUS_READY);
+      CHECK(back[i].r.soc == INVALID_SOCKET);
+      CHECK(back[i].r.statuscode == STATUSCODE_INVALID);
+      CHECK(strcmp(back[i].r.msg, "mirror stopped by user") == 0);
+      if (swept[i] != INVALID_SOCKET)
+        CHECK(!st_backstop_soc_open(swept[i]));
+    }
+    /* control: a started transfer is what the stop lets finish, and the FTP
+       socket belongs to another thread; a wider sweep is the wrong fix */
+    for (i = SLOT_HEADERS; i < SLOTS; i++) {
+      CHECK(back[i].status == status[i]);
+      CHECK(back[i].r.soc == swept[i]);
+      CHECK(st_backstop_soc_open(back[i].r.soc));
+      CHECK(back[i].r.statuscode == STATUSCODE_TIMEOUT);
+      CHECK(strcmp(back[i].r.msg, "untouched") == 0);
+    }
+  }
 #undef CHECK
 
+cleanup:
+  opt->state.stop = 0;
   for (i = 0; i < SLOTS; i++)
     deletehttp(&back[i].r);
   back_free(&sback);
   coucal_delete(&cache.hashtable);
+  if (skipped)
+    return 77;
 
   printf("backstop self-test: %s\n", err ? "FAIL" : "OK");
   return err;

--- a/tests/246_engine-connect-stop.test
+++ b/tests/246_engine-connect-stop.test
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# A user stop must drop the slots still waiting to connect, instead of holding
+# the drain for the whole --timeout (#1073).
+
+set -euo pipefail
+
+command -v httrack >/dev/null || {
+    echo "could not find httrack" >&2
+    exit 1
+}
+
+out=$(httrack -#test=backstop) || {
+    status=$?
+    echo "$out"
+    # 77: the network answers for TEST-NET-1, so no connect stalls here.
+    exit "$status"
+}
+echo "$out"
+case "$out" in
+*"backstop self-test: OK") ;;
+*) exit 1 ;;
+esac


### PR DESCRIPTION
Pressing Ctrl-C only stopped new links from being queued. A slot already waiting on its connection sat there until `--timeout` expired, so ending a crawl against an unreachable host took minutes. #1071 gave the FTP connect loop a stop check; this does the same on the HTTP side, where the scheduler owns the wait. `back_wait()` now drops every slot whose connection is not up yet (name resolution, connect, TLS handshake) once the stop flag is set. Receiving slots stay, since those are the transfers the first Ctrl-C promises to finish.

Name resolution needed the same treatment. `hts_dns_resolve_all()` passed no cancel flag, so a Ctrl-C during a resolve behind a black hole still waited out `--timeout` per host. It now passes the mirror's stop flag, the parameter #1071 added.

`-#test=backstop` builds one slot per status against a blackholed address, runs a control pass with the mirror still going, and checks that only the pre-connect slots go away and that their sockets were really closed. `-#test=dnstimeout` gains a stopped resolve plus its running-mirror control. The sweep also fires during the `-E`/`-M` smooth-stop grace, so that window is now shorter for connects that never completed. Nothing received is lost.

On Linux the old behaviour looked correct by accident, which is worth knowing before you read the fix. `back_wait()` discards `select()`'s return value. `EINTR` leaves the descriptor sets with every requested bit still set, so the signal itself makes the pending connect look ready. The slot is then treated as connected and dies with a fabricated "Receive Error". A stop that arrives some other way, or a platform whose `select()` the console handler never interrupts, still waits out the full timeout.

Closes #1073