### PR TITLE
--single-file writes marks it cannot read back

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -3145,6 +3145,17 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                           if (sf_class != 0) {
                             char sf_mark[SINGLEFILE_MARK_MAX];
 
+                            /* SINGLEFILE_MAX_SPAN is derived from these two
+                               buffers, so a resize must move it: divide by zero
+                               here rather than silently stop marking. */
+                            enum {
+                              sf_span_fits =
+                                  1 /
+                                  (sizeof(tempo) * HTS_HTMLESCAPE_FULL_MAXEXP +
+                                       sizeof(lien) * HTS_HTMLESCAPE_MAXEXP <=
+                                   SINGLEFILE_MAX_SPAN)
+                            };
+
                             HT_ADD(singlefile_mark(
                                 opt, sf_mark, sizeof(sf_mark), sf_class,
                                 TypedArraySize(output_buffer) - sf_start));

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6841,6 +6841,86 @@ static int st_singlefile(httrackp *opt, int argc, char **argv) {
   }
   (void) outlen;
 
+  /* Whatever singlefile_mark writes the pass has to read back: a mark it
+     cannot parse stays in the page as text. emit_max restates htsparse's worst
+     case for one reference, and the spans straddle it. */
+  {
+    const size_t emit_max =
+        HTS_URLMAXSIZE * 2 *
+        (HTS_HTMLESCAPE_FULL_MAXEXP + HTS_HTMLESCAPE_MAXEXP);
+    const size_t spans[] = {4097, emit_max, emit_max + 1, emit_max * 4};
+    char mark[SINGLEFILE_MARK_MAX];
+    size_t k;
+
+    sf_check(singlefile_mark(opt, mark, sizeof(mark), SINGLEFILE_CLASS_ANY,
+                             emit_max)[0] != '\0',
+             "a span htsparse can emit was refused a mark");
+    for (k = 0; k < sizeof(spans) / sizeof(spans[0]); k++) {
+      String marked = STRING_EMPTY, got = STRING_EMPTY;
+      char *pad = (char *) malloct(spans[k]);
+
+      assertf(pad != NULL);
+      memset(pad, 'a', spans[k]);
+      StringClear(marked);
+      StringCat(marked, "<img src=\"");
+      StringMemcat(marked, pad, spans[k]);
+      StringCat(marked, singlefile_mark(opt, mark, sizeof(mark),
+                                        SINGLEFILE_CLASS_ANY, spans[k]));
+      StringCat(marked, "\">\n");
+      StringClear(got);
+      (void) singlefile_rewrite_html(opt, root, page, StringBuff(marked),
+                                     StringLength(marked),
+                                     SINGLEFILE_MAX_PAGE_SIZE, &got);
+      sf_check(strstr(StringBuff(got), singlefile_intro(opt)) == NULL,
+               "a mark the emitter wrote stayed in the page as text");
+      sf_check(hts_memstr(StringBuff(got), StringLength(got), pad, spans[k]) !=
+                   NULL,
+               "the reference the mark measured was lost");
+      /* One byte over the cap, hand-built: the padding is there to back into,
+         so a missing cap eats it instead of leaving the mark alone. */
+      if (spans[k] == emit_max + 1) {
+        char tail[32];
+
+        snprintf(tail, sizeof(tail), ".%c.%d", SINGLEFILE_CLASS_ANY,
+                 (int) spans[k]);
+        StringClear(marked);
+        StringCat(marked, "<img src=\"");
+        StringMemcat(marked, pad, spans[k]);
+        StringCat(marked, singlefile_intro(opt));
+        StringCat(marked, tail);
+        StringCat(marked, "\">\n");
+        StringClear(got);
+        (void) singlefile_rewrite_html(opt, root, page, StringBuff(marked),
+                                       StringLength(marked),
+                                       SINGLEFILE_MAX_PAGE_SIZE, &got);
+        sf_check(strstr(StringBuff(got), singlefile_intro(opt)) != NULL,
+                 "an over-cap length was read as a mark");
+      }
+      freet(pad);
+      StringFree(marked);
+      StringFree(got);
+    }
+  }
+
+  /* singlefile_may_mark finds the intro with hts_memstr, which reports no
+     match for an empty needle: the intro is a fixed-width string. */
+  {
+    String probe = STRING_EMPTY;
+
+    sf_check(strlen(singlefile_intro(opt)) == SINGLEFILE_INTRO_LEN,
+             "the intro is not the fixed-width string may_mark assumes");
+    sf_check(singlefile_may_mark(opt, "", 0), "an empty body was refused");
+    StringClear(probe);
+    StringMemcat(probe, "x\0", 2); /* bodies carry NULs; strstr would stop */
+    StringCat(probe, singlefile_intro(opt));
+    sf_check(!singlefile_may_mark(opt, StringBuff(probe), StringLength(probe)),
+             "an intro ending the body, past a NUL, was missed");
+    sf_check(
+        singlefile_may_mark(opt, StringBuff(probe), StringLength(probe) - 1),
+        "a truncated intro was read as one");
+    StringFree(probe);
+  }
+
   /* The per-page budget against a self-importing stylesheet. The large-budget
      run is the control: it proves the fan-out is real, so the small one was
      cut short by the budget and not by the fixture. */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6841,9 +6841,10 @@ static int st_singlefile(httrackp *opt, int argc, char **argv) {
   }
   (void) outlen;
 
-  /* Whatever singlefile_mark writes the pass has to read back: a mark it
-     cannot parse stays in the page as text. emit_max restates htsparse's worst
-     case for one reference, and the spans straddle it. */
+  /* A mark the pass cannot parse stays in the page as text, so whatever
+     singlefile_mark writes it has to read back. emit_max restates htsparse's
+     worst case for one reference independently of SINGLEFILE_MAX_SPAN, and the
+     spans straddle it. */
   {
     const size_t emit_max =
         HTS_URLMAXSIZE * 2 *
@@ -6858,14 +6859,16 @@ static int st_singlefile(httrackp *opt, int argc, char **argv) {
     for (k = 0; k < sizeof(spans) / sizeof(spans[0]); k++) {
       String marked = STRING_EMPTY, got = STRING_EMPTY;
       char *pad = (char *) malloct(spans[k]);
+      size_t marklen;
 
       assertf(pad != NULL);
       memset(pad, 'a', spans[k]);
       StringClear(marked);
       StringCat(marked, "<img src=\"");
       StringMemcat(marked, pad, spans[k]);
-      StringCat(marked, singlefile_mark(opt, mark, sizeof(mark),
-                                        SINGLEFILE_CLASS_ANY, spans[k]));
+      marklen = strlen(singlefile_mark(opt, mark, sizeof(mark),
+                                       SINGLEFILE_CLASS_ANY, spans[k]));
+      StringCat(marked, mark);
       StringCat(marked, "\">\n");
       StringClear(got);
       (void) singlefile_rewrite_html(opt, root, page, StringBuff(marked),
@@ -6876,11 +6879,15 @@ static int st_singlefile(httrackp *opt, int argc, char **argv) {
       sf_check(hts_memstr(StringBuff(got), StringLength(got), pad, spans[k]) !=
                    NULL,
                "the reference the mark measured was lost");
-      /* One byte over the cap, hand-built: the padding is there to back into,
-         so a missing cap eats it instead of leaving the mark alone. */
+      /* Nothing resolves here, so the mark is the only thing that may go: a
+         length check catches what a presence check cannot. */
+      sf_check(StringLength(got) == StringLength(marked) - marklen,
+               "the pass removed something other than the mark");
       if (spans[k] == emit_max + 1) {
         char tail[32];
 
+        /* Hand-built at cap+1, which singlefile_mark now refuses: without the
+           cap sf_parse_mark reads it and eats the padding behind it. */
         snprintf(tail, sizeof(tail), ".%c.%d", SINGLEFILE_CLASS_ANY,
                  (int) spans[k]);
         StringClear(marked);
@@ -6895,6 +6902,20 @@ static int st_singlefile(httrackp *opt, int argc, char **argv) {
                                        SINGLEFILE_MAX_PAGE_SIZE, &got);
         sf_check(strstr(StringBuff(got), singlefile_intro(opt)) != NULL,
                  "an over-cap length was read as a mark");
+        /* 2^64 + 10: unsaturated, the digits wrap to 10 and the mark eats ten
+           bytes of padding instead of being refused. */
+        StringClear(marked);
+        StringCat(marked, "<img src=\"");
+        StringMemcat(marked, pad, spans[k]);
+        StringCat(marked, singlefile_intro(opt));
+        StringCat(marked, ".-.18446744073709551626");
+        StringCat(marked, "\">\n");
+        StringClear(got);
+        (void) singlefile_rewrite_html(opt, root, page, StringBuff(marked),
+                                       StringLength(marked),
+                                       SINGLEFILE_MAX_PAGE_SIZE, &got);
+        sf_check(StringLength(got) == StringLength(marked),
+                 "a wrapping digit run was read as a mark");
       }
       freet(pad);
       StringFree(marked);
@@ -6902,8 +6923,8 @@ static int st_singlefile(httrackp *opt, int argc, char **argv) {
     }
   }
 
-  /* singlefile_may_mark finds the intro with hts_memstr, which reports no
-     match for an empty needle: the intro is a fixed-width string. */
+  /* singlefile_may_mark searches with hts_memstr, which finds nothing for an
+     empty needle; the intro is fixed-width, so that case cannot arise. */
   {
     String probe = STRING_EMPTY;
 

--- a/src/htssinglefile.c
+++ b/src/htssinglefile.c
@@ -64,6 +64,12 @@ Please visit our Website: http://www.httrack.com
 #define SF_MAX_REF 4096
 #define SF_MAX_COMPONENTS 128
 
+/* Longest span htsparse can measure: HTS_URLMAXSIZE*2 of savename through
+   escape_for_html_print_full, plus as much query through
+   escape_for_html_print. */
+#define SF_MAX_SPAN                                                            \
+  (HTS_URLMAXSIZE * 2 * (HTS_HTMLESCAPE_FULL_MAXEXP + HTS_HTMLESCAPE_MAXEXP))
+
 /* Over-cap assets reported per pass; beyond that the log would carry one line
    per referencing page. */
 #define SF_MAX_WARN 32
@@ -125,18 +131,14 @@ const char *singlefile_intro(httrackp *opt) {
 
 hts_boolean singlefile_may_mark(httrackp *opt, const char *body, size_t len) {
   const char *const intro = singlefile_intro(opt);
-  size_t introlen, i;
 
   if (intro == NULL)
     return HTS_FALSE;
-  introlen = strlen(intro);
-  for (i = 0; i + introlen <= len; i++) {
-    if (memcmp(body + i, intro, introlen) == 0) {
-      hts_log_print(opt, LOG_ERROR,
-                    "single-file: document already carries this run's mark, "
-                    "leaving it alone");
-      return HTS_FALSE;
-    }
+  if (hts_memstr(body, len, intro, strlen(intro)) != NULL) {
+    hts_log_print(opt, LOG_ERROR,
+                  "single-file: document already carries this run's mark, "
+                  "leaving it alone");
+    return HTS_FALSE;
   }
   return HTS_TRUE;
 }
@@ -146,7 +148,9 @@ const char *singlefile_mark(httrackp *opt, char *buf, size_t bufsize, char cls,
   const char *const intro = singlefile_intro(opt);
 
   buf[0] = '\0';
-  if (intro != NULL)
+  /* Nothing sf_parse_mark would refuse: an unread mark stays in the page as
+     text and takes its reference with it. */
+  if (intro != NULL && reflen <= SF_MAX_SPAN)
     snprintf(buf, bufsize, "%s.%c.%d", intro, cls, (int) reflen);
   return buf;
 }
@@ -660,10 +664,11 @@ static void sf_warn_unresolved(sf_ctx *ctx, const char *ref, size_t reflen) {
   if (*ctx->warn_budget <= 0)
     return;
   (*ctx->warn_budget)--;
+  /* Clipped: a span runs far past anything that could name a file. */
   hts_log_print(ctx->opt, LOG_WARNING,
                 "single-file: marked reference \"%.*s\" resolves to no "
                 "mirrored file, left as a link",
-                (int) reflen, ref);
+                (int) (reflen > 256 ? 256 : reflen), ref);
 }
 
 /* Parse the mark at [p,end): "<intro>.<class>.<len>". Returns its length, or 0
@@ -701,12 +706,12 @@ static size_t sf_parse_mark(const char *intro, size_t introlen, const char *p,
   if (++i >= avail || p[i++] != '.')
     return 0;
   while (i < avail && p[i] >= '0' && p[i] <= '9') {
-    if (n >= SF_MAX_REF) /* a length this big cannot name a mirrored file */
+    if (n > SF_MAX_SPAN) /* saturated: no digit run can overflow n */
       return 0;
     n = n * 10 + (size_t) (p[i++] - '0');
     digits++;
   }
-  if (digits == 0)
+  if (digits == 0 || n > SF_MAX_SPAN)
     return 0;
   *reflen = n;
   return i;

--- a/src/htssinglefile.c
+++ b/src/htssinglefile.c
@@ -64,12 +64,6 @@ Please visit our Website: http://www.httrack.com
 #define SF_MAX_REF 4096
 #define SF_MAX_COMPONENTS 128
 
-/* Longest span htsparse can measure: HTS_URLMAXSIZE*2 of savename through
-   escape_for_html_print_full, plus as much query through
-   escape_for_html_print. */
-#define SF_MAX_SPAN                                                            \
-  (HTS_URLMAXSIZE * 2 * (HTS_HTMLESCAPE_FULL_MAXEXP + HTS_HTMLESCAPE_MAXEXP))
-
 /* Over-cap assets reported per pass; beyond that the log would carry one line
    per referencing page. */
 #define SF_MAX_WARN 32
@@ -150,7 +144,7 @@ const char *singlefile_mark(httrackp *opt, char *buf, size_t bufsize, char cls,
   buf[0] = '\0';
   /* Nothing sf_parse_mark would refuse: an unread mark stays in the page as
      text and takes its reference with it. */
-  if (intro != NULL && reflen <= SF_MAX_SPAN)
+  if (intro != NULL && reflen <= SINGLEFILE_MAX_SPAN)
     snprintf(buf, bufsize, "%s.%c.%d", intro, cls, (int) reflen);
   return buf;
 }
@@ -706,12 +700,12 @@ static size_t sf_parse_mark(const char *intro, size_t introlen, const char *p,
   if (++i >= avail || p[i++] != '.')
     return 0;
   while (i < avail && p[i] >= '0' && p[i] <= '9') {
-    if (n > SF_MAX_SPAN) /* saturated: no digit run can overflow n */
+    if (n > SINGLEFILE_MAX_SPAN) /* saturated: no digit run can overflow n */
       return 0;
     n = n * 10 + (size_t) (p[i++] - '0');
     digits++;
   }
-  if (digits == 0 || n > SF_MAX_SPAN)
+  if (digits == 0 || n > SINGLEFILE_MAX_SPAN)
     return 0;
   *reflen = n;
   return i;

--- a/src/htssinglefile.h
+++ b/src/htssinglefile.h
@@ -38,6 +38,7 @@ Please visit our Website: http://www.httrack.com
 #ifndef HTS_SINGLEFILE_DEFH
 #define HTS_SINGLEFILE_DEFH
 
+#include "htscore.h" /* HTS_HTMLESCAPE_*_MAXEXP */
 #include "htsopt.h"
 #include "htsstrings.h"
 
@@ -80,6 +81,13 @@ extern "C" {
 
 /* Enough for the intro, the secret, both separators and a 20-digit length. */
 #define SINGLEFILE_MARK_MAX 64
+
+/* Longest <len> a mark may carry, which is what htsparse can append for one
+   reference: HTS_URLMAXSIZE*2 of savename through escape_for_html_print_full,
+   plus as much query through escape_for_html_print. The emit site asserts the
+   derivation against its own buffers. */
+#define SINGLEFILE_MAX_SPAN                                                    \
+  (HTS_URLMAXSIZE * 2 * (HTS_HTMLESCAPE_FULL_MAXEXP + HTS_HTMLESCAPE_MAXEXP))
 
 /* Release this run's secret. */
 void singlefile_free(httrackp *opt);

--- a/src/htssinglefile.h
+++ b/src/htssinglefile.h
@@ -94,7 +94,8 @@ const char *singlefile_intro(httrackp *opt);
    not something fetched content can spell. */
 hts_boolean singlefile_may_mark(httrackp *opt, const char *body, size_t len);
 
-/* Write the mark for a reference of reflen bytes into buf; returns buf. */
+/* Write the mark for a reference of reflen bytes into buf; returns buf, left
+   empty for a reflen the pass could not read back. */
 const char *singlefile_mark(httrackp *opt, char *buf, size_t bufsize, char cls,
                             size_t reflen);
 

--- a/tests/94_local-single-file.test
+++ b/tests/94_local-single-file.test
@@ -462,6 +462,19 @@ case "$st" in
     ;;
 esac
 
+printf '[the unresolved-reference warning is clipped] ..\t'
+# The self-test drives a 90 KB reference through it, so an unclipped build puts
+# all of it in the log. The first check is the floor: no warning proves nothing.
+grep -q 'resolves to no mirrored file' <<<"$st" || {
+    echo "FAIL: the self-test logged no unresolved reference"
+    exit 1
+}
+awk 'length($0) > 1024 { exit 1 }' <<<"$st" || {
+    echo "FAIL: a log line ran past the clip"
+    exit 1
+}
+echo OK
+
 # --- project reload restores the saved keys ---------------------------------
 distdir=$(cd "${top_srcdir}" && pwd)
 printf '[project reload maps the keys back] ..\t'

--- a/tests/94_local-single-file.test
+++ b/tests/94_local-single-file.test
@@ -41,6 +41,7 @@ cat >"${doc}/index.html" <<'EOF'
 <a href=pixel.svg>unquoted</a>
 <iframe src=pixel.svg></iframe>
 <link href="style_norel.css">
+<a href="/sfmark.html">charset</a>
 </body></html>
 EOF
 cat >"${doc}/other.html" <<'EOF'
@@ -301,12 +302,23 @@ echo OK
 
 printf '[a mark cannot ride in on a header] ..\t'
 # htsparse echoes the Content-Type charset into a <meta>, a channel the body
-# sweep cannot see. A regression guard only: no fixture here serves a
-# mark-shaped charset, so it cannot fail today (#1069).
-if grep -q 'content="text/html;charset=data:' "$page"; then
+# sweep cannot see, so /sfmark.html serves a mark there. It names pixel.svg, so
+# an expansion would leave a data: URI.
+markpage="${out}/127.0.0.1_${port}/sfmark.html"
+test -f "$markpage" || {
+    echo "FAIL: the charset-mark page was not mirrored"
+    exit 1
+}
+if grep -q 'charset=data:' "$markpage"; then
     echo "FAIL: a charset-borne mark was expanded"
     exit 1
 fi
+# The mark is deleted and its reference kept: without this the check above
+# passes on a page that never carried a charset.
+grep -q 'content="text/html;charset=pixel.svg" />' "$markpage" || {
+    echo "FAIL: the charset never reached the page, so nothing was proven"
+    exit 1
+}
 echo OK
 
 printf '[no file keeps a mark] ..\t'

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -2431,7 +2431,20 @@ class Handler(SimpleHTTPRequestHandler):
             "application/octet-stream",
         )
 
+    # A --single-file mark in the response charset, which htsparse echoes into a
+    # <meta>: the one channel no body-side sweep can see (#1069). Wrong secret,
+    # so it must be deleted and not expanded; "pixel.svg" is a real mirrored
+    # asset, so an expansion would show.
+    SINGLEFILE_MARK_CHARSET = "pixel.svg#!0011223344556677.-.9"
+
+    def route_singlefile_mark(self):
+        self.send_raw(
+            b"<html><head></head><body><p>charset</p></body></html>",
+            "text/html; charset=" + self.SINGLEFILE_MARK_CHARSET,
+        )
+
     ROUTES = {
+        "/sfmark.html": route_singlefile_mark,
         "/cookies/entrance.php": route_entrance,
         "/cookies/second.php": route_second,
         "/cookies/third.php": route_third,

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -2431,10 +2431,8 @@ class Handler(SimpleHTTPRequestHandler):
             "application/octet-stream",
         )
 
-    # A --single-file mark in the response charset, which htsparse echoes into a
-    # <meta>: the one channel no body-side sweep can see (#1069). Wrong secret,
-    # so it must be deleted and not expanded; "pixel.svg" is a real mirrored
-    # asset, so an expansion would show.
+    # A --single-file mark in the charset, the one channel a body sweep cannot
+    # see (#1069). It names pixel.svg, a real asset, so an expansion would show.
     SINGLEFILE_MARK_CHARSET = "pixel.svg#!0011223344556677.-.9"
 
     def route_singlefile_mark(self):


### PR DESCRIPTION
`sf_parse_mark` refused a `<len>` above `SF_MAX_REF` (4096), but htsparse measures the escaped bytes it just appended: up to `HTS_URLMAXSIZE*2` of savename through `escape_for_html_print_full`, plus as much query string through `escape_for_html_print`, which is 22528. A mark past the cap parses as nothing, so it survives into the delivered page as literal text and drags its reference along with it. Nothing reaches that today because savenames arrive percent-escaped, and the old digit-loop guard was sloppy enough to hide the mismatch anyway (it actually tripped at 40959, not 4096). The cap is now `SINGLEFILE_MAX_SPAN`, derived from the emitter and exact, and `singlefile_mark` declines to write a span `sf_parse_mark` would not read back. The emit site checks the derivation against its own `tempo` and `lien` at compile time, so resizing either buffer breaks the build instead of quietly switching inlining off. `SF_MAX_REF` keeps its value for `sf_resolve`'s buffers, a different quantity: the span covers the query string, the resolver's bound covers only the name before it.

`singlefile_may_mark` calls `hts_memstr` instead of hand-rolling the same bounded, NUL-safe search, and the unresolved-reference warning is clipped, since a span can run to 22 KB and the log is not the place to reproduce it.

The charset case in `94_local-single-file.test` asserted nothing, as #1069 describes: no route served a mark-shaped charset, so grepping for an expanded one passed on a build that would have expanded it. `local-server.py` now answers `/sfmark.html` with a mark in its `Content-Type` charset, and the test checks both that the mark was deleted rather than expanded and that the charset reached the page at all. A truncated-secret mutant turns that meta into a `data:` URI and a mutant dropping the charset meta kills the floor. The `--changes` case the issue also names was already fixed by #1066.

Deliberately unchanged: `<object data=>` and `<embed src=>` now inline as JavaScript, because the deny-list classifies by MIME rather than by the old per-attribute table. I would keep it. One of those elements pointing at a script rendered nothing before and renders nothing now, and a per-tag restriction would have to be maintained by hand against `hts_detect[]`, which is the coupling the deny-list removed.

Closes #1054
Closes #1069