### PR TITLE
Release 3.49.19

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.71])
 
-AC_INIT([httrack], [3.49.18], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
+AC_INIT([httrack], [3.49.19], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
 AC_COPYRIGHT([
 HTTrack Website Copier, Offline Browser for Windows and Unix
 Copyright (C) 1998-2015 Xavier Roche and other contributors
@@ -29,6 +29,8 @@ AC_CONFIG_SRCDIR(src/httrack.c)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
+# 3:12:0: revision-only bump. httrackp gained a tail field (singlefile_state) and
+# htsopt.h added volatile qualifiers; no layout moved, nothing went away.
 # 3:11:0: revision-only bump. #1001 moved SOCaddr_inetntoa_ out of htsnet.h, adding
 # an export where callers had an inline; nothing changed or went away.
 # 3:10:0: revision-only bump; only the version macro moved, the engine is untouched.
@@ -40,7 +42,7 @@ AM_INIT_AUTOMAKE([subdir-objects])
 # moves nothing). Soname stays .so.3: HTTrackQt is the only consumer of the installed
 # headers, so a libhttrack4 rename isn't worth it.
 # (3:0:0 was the htsblk mime-buffer widening, the ABI break that moved .so.2 -> .so.3.)
-VERSION_INFO="3:11:0"
+VERSION_INFO="3:12:0"
 AM_MAINTAINER_MODE
 AC_USE_SYSTEM_EXTENSIONS
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,13 +1,10 @@
 httrack (3.49.19-1) unstable; urgency=medium
 
-  * New upstream release: FTP fixes across the board, from an over-long user
-    name in a URL logging in as a different account to a crash when a mirror
-    hit its limit while an FTP transfer was in flight, plus stack-overflow
-    and interruption fixes and an --update data-loss fix; full list in
-    history.txt.
-  * Fixes two build failures reported by other distributions: two tests
-    assumed GNU coreutils, and the AppStream metainfo declared an icon name
-    that is not a stock one, which appstream-util rejects.
+  * New upstream release: mostly FTP fixes, plus stack-overflow, mirror
+    interruption and --update data-loss fixes; full list in history.txt. Two
+    of them matter to the build: the test suite no longer assumes GNU
+    coreutils, and the AppStream metainfo no longer declares a non-stock icon
+    name that appstream-util rejects.
 
  -- Xavier Roche <xavier@debian.org>  Sat, 08 Aug 2026 21:29:56 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+httrack (3.49.19-1) unstable; urgency=medium
+
+  * New upstream release: FTP fixes across the board, from an over-long user
+    name in a URL logging in as a different account to a crash when a mirror
+    hit its limit while an FTP transfer was in flight, plus stack-overflow
+    and interruption fixes and an --update data-loss fix; full list in
+    history.txt.
+  * Fixes two build failures reported by other distributions: two tests
+    assumed GNU coreutils, and the AppStream metainfo declared an icon name
+    that is not a stock one, which appstream-util rejects.
+
+ -- Xavier Roche <xavier@debian.org>  Sat, 08 Aug 2026 21:29:56 +0200
+
 httrack (3.49.18-1) unstable; urgency=medium
 
   * New upstream release, fixing the 3.49.17-1 build failures on armhf,

--- a/history.txt
+++ b/history.txt
@@ -4,6 +4,26 @@ HTTrack Website Copier release history:
 
 This file lists all changes and fixes that have been made for HTTrack
 
+3.49-19
++ Fixed: an over-long user name in an ftp:// URL was truncated at the credential boundary, so the login went to a different account (#1032)
++ Fixed: an over-long FTP path or host name aborted the process instead of failing that one link (#1019)
++ Fixed: an FTP crawl ignored --timeout and --max-time, so a server that went quiet held a slot for five minutes, and a dead host took two minutes to give up with no way to shorten it (#1039, #1059)
++ Fixed: the engine released the transfer slots while an FTP thread was still writing to one, crashing a mirror that hit its size or time limit (#1051)
++ Fixed: Ctrl-C did not shorten a connection or a name lookup already in flight, so ending a crawl against an unreachable host took minutes (#1073)
++ Fixed: a crawl that gave up mid-loop, on the link limit or an abort, lost its WARC archive and its change report, and a WARC written past teardown was stranded in a .tmp file (#1061, #1060)
++ Fixed: a resume the server answered with an unusable Content-Range deleted the partial file and never fetched it again; the restart no longer spends the retry budget, and is latched to one per link (#581, #1052)
++ Fixed: a long argument to -n or -O smashed the stack through an unbounded panic message, and the growable arrays could wrap their capacity to zero (#1040)
++ Fixed: --single-file could write a reference mark longer than it reads back, leaving it in the delivered page as visible text (#1054, #1069)
++ Fixed: on a terminal with no input left, a crawl toggled between the spinner and the full panel on every pass (#1072)
++ Fixed: -%v1 ended each line with a carriage return, so the lines overwrote each other and a redirected log was unreadable; -%v2 now paints its panel only on a terminal
++ Fixed: the installed socket headers did not compile under -std=c99 without _POSIX_C_SOURCE (#1001)
++ Fixed: the 16 px application icon rendered every stem as grey (#938)
++ Fixed: the desktop files installed outside the data directory, and the AppStream metainfo declared an icon name that is not a stock one
++ Fixed: the build failed on distributions whose coreutils are not GNU's, and an --enable-fuzzers build could not link proxytrack (#1042, #1030)
++ Changed: --single-file drops its own HTML and CSS scanner and reuses the crawler's parser, so it follows the same references the mirror does (#749)
++ Changed: updated Turkish translation (#306)
++ Changed: multiple internal hardening, build, test and CI improvements
+
 3.49-18
 + Fixed: the 3.49.17 package build failed on four architectures: the test suite's mmap interposer did not compile on armhf, powerpc or hppa, and the alternate-stack test rejected loong64's shorter backtrace (#1023)
 + Fixed: the test suite failed on a host with no ps command, such as a Fedora build root; its hang diagnostics now read /proc directly (#1021)

--- a/history.txt
+++ b/history.txt
@@ -7,10 +7,12 @@ This file lists all changes and fixes that have been made for HTTrack
 3.49-19
 + Fixed: an over-long user name in an ftp:// URL was truncated at the credential boundary, so the login went to a different account (#1032)
 + Fixed: an over-long FTP path or host name aborted the process instead of failing that one link (#1019)
-+ Fixed: an FTP crawl ignored --timeout and --max-time, so a server that went quiet held a slot for five minutes, and a dead host took two minutes to give up with no way to shorten it (#1039, #1059)
++ Fixed: an FTP crawl ignored --timeout and --max-time, so a server that went quiet held a slot for five minutes (#1039)
++ Fixed: an FTP crawl of a dead host took two minutes to give up, and no signal could shorten it (#1059)
 + Fixed: the engine released the transfer slots while an FTP thread was still writing to one, crashing a mirror that hit its size or time limit (#1051)
 + Fixed: Ctrl-C did not shorten a connection or a name lookup already in flight, so ending a crawl against an unreachable host took minutes (#1073)
 + Fixed: a crawl that gave up mid-loop, on the link limit or an abort, lost its WARC archive and its change report, and a WARC written past teardown was stranded in a .tmp file (#1061, #1060)
++ Fixed: a crawl that rolled back for want of data still replaced the previous WARC archive, stranding its temporary and never writing its index; a stale or unwritable index is now reported rather than left silently in place (#1053)
 + Fixed: a resume the server answered with an unusable Content-Range deleted the partial file and never fetched it again; the restart no longer spends the retry budget, and is latched to one per link (#581, #1052)
 + Fixed: a long argument to -n or -O smashed the stack through an unbounded panic message, and the growable arrays could wrap their capacity to zero (#1040)
 + Fixed: --single-file could write a reference mark longer than it reads back, leaving it in the delivered page as visible text (#1054, #1069)
@@ -19,9 +21,9 @@ This file lists all changes and fixes that have been made for HTTrack
 + Fixed: the installed socket headers did not compile under -std=c99 without _POSIX_C_SOURCE (#1001)
 + Fixed: the 16 px application icon rendered every stem as grey (#938)
 + Fixed: the desktop files installed outside the data directory, and the AppStream metainfo declared an icon name that is not a stock one
-+ Fixed: the build failed on distributions whose coreutils are not GNU's, and an --enable-fuzzers build could not link proxytrack (#1042, #1030)
++ Fixed: the build failed on distributions whose coreutils are not GNU's (#1042)
 + Changed: --single-file drops its own HTML and CSS scanner and reuses the crawler's parser, so it follows the same references the mirror does (#749)
-+ Changed: updated Turkish translation (#306)
++ Changed: updated Turkish translation, and repaired two mangled Polish strings (#306)
 + Changed: multiple internal hardening, build, test and CI improvements
 
 3.49-18

--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -54,10 +54,11 @@
       <description>
         <ul>
           <li>Stopping a mirror now takes effect at once, instead of waiting for connections that were still being opened</li>
-          <li>A mirror that stops early keeps its WARC archive and its list of changes</li>
+          <li>A mirror that stops early keeps its web archive and its list of changes</li>
           <li>A partly downloaded file the server refuses to resume is fetched again rather than lost</li>
-          <li>An FTP site that stops responding no longer holds a download slot for five minutes</li>
-          <li>A crash could be triggered by a very long web address, a long FTP path or a stopped mirror</li>
+          <li>An FTP site that stops responding no longer blocks a download for five minutes</li>
+          <li>A very long web address or FTP path no longer crashes the mirror</li>
+          <li>Stopping a mirror while an FTP file is downloading no longer crashes</li>
           <li>An FTP address carrying an over-long user name could sign in as a different account</li>
           <li>Updated Turkish translation</li>
         </ul>

--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -50,6 +50,19 @@
   <content_rating type="oars-1.1"/>
   <!-- Newest first; tests/01_engine-version-macros.test enforces it. -->
   <releases>
+    <release version="3.49.19" date="2026-08-08">
+      <description>
+        <ul>
+          <li>Stopping a mirror now takes effect at once, instead of waiting for connections that were still being opened</li>
+          <li>A mirror that stops early keeps its WARC archive and its list of changes</li>
+          <li>A partly downloaded file the server refuses to resume is fetched again rather than lost</li>
+          <li>An FTP site that stops responding no longer holds a download slot for five minutes</li>
+          <li>A crash could be triggered by a very long web address, a long FTP path or a stopped mirror</li>
+          <li>An FTP address carrying an over-long user name could sign in as a different account</li>
+          <li>Updated Turkish translation</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.49.18" date="2026-08-05">
       <description>
         <ul>

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -43,8 +43,8 @@ Please visit our Website: http://www.httrack.com
    configure.ac, decoupled from these). VERSION is the display form, VERSIONID
    the dotted numeric form, AFF_VERSION the short form shown in footers,
    LIB_VERSION the data/cache format generation. */
-#define HTTRACK_VERSION "3.49-18"
-#define HTTRACK_VERSIONID "3.49.18"
+#define HTTRACK_VERSION "3.49-19"
+#define HTTRACK_VERSIONID "3.49.19"
 #define HTTRACK_AFF_VERSION "3.x"
 #define HTTRACK_LIB_VERSION "2.0"
 

--- a/src/version.rc
+++ b/src/version.rc
@@ -17,8 +17,8 @@
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-  FILEVERSION 3, 49, 18, 0
-  PRODUCTVERSION 3, 49, 18, 0
+  FILEVERSION 3, 49, 19, 0
+  PRODUCTVERSION 3, 49, 19, 0
   FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
 #ifdef _DEBUG
   FILEFLAGS VS_FF_DEBUG
@@ -35,12 +35,12 @@ BEGIN
     BEGIN
       VALUE "CompanyName", "Xavier Roche"
       VALUE "FileDescription", VER_FILE_DESCRIPTION
-      VALUE "FileVersion", "3.49.18"
+      VALUE "FileVersion", "3.49.19"
       VALUE "InternalName", VER_ORIGINAL_FILENAME
       VALUE "LegalCopyright", "Copyright (C) 1998-2026 Xavier Roche and other contributors. GNU GPL v3 or later."
       VALUE "OriginalFilename", VER_ORIGINAL_FILENAME
       VALUE "ProductName", "HTTrack Website Copier"
-      VALUE "ProductVersion", "3.49-18"
+      VALUE "ProductVersion", "3.49-19"
     END
   END
   BLOCK "VarFileInfo"


### PR DESCRIPTION
Version bump for 3.49.19. Most of what landed since 3.49.18 is FTP: an over-long user name in an `ftp://` URL logged in as a different account, a crawl ignored `--timeout` and `--max-time` and pinned a slot for five minutes, a dead host took two minutes to give up with no way to shorten it, and the engine freed the transfer slots while an FTP thread was still writing to one. Elsewhere, an unbounded panic message could smash the stack, a crawl that gave up mid-loop lost its WARC archive and its change report, and a resume the server refused could still lose the partial file.

`VERSION_INFO` goes 3:11:0 to 3:12:0, revision only: `httrackp` gained a tail field and `htsopt.h` added two `volatile` qualifiers, so no layout moved and nothing went away. Soname stays `libhttrack.so.3`, exports 167 to 168. Nothing under `debian/` landed since 3.49.18, so that changelog entry is the upstream overview plus the two build failures other distributions reported. `Standards-Version` 4.7.4 still matches debian-policy.
