### PR TITLE
The macOS Release asset name does not say it is arm64-only

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -153,9 +153,8 @@ jobs:
           set -euo pipefail
           dmg="$(echo "$RUNNER_TEMP"/HTTrack-*.dmg)"
           test -f "$dmg"
-          # The build is arm64-only and the Release name is the only one a user reads
-          # before downloading (#1083). Renamed here, not at build time: httrack-com's
-          # staging script matches the artifact's name exactly.
+          # Renamed here, not at build time, because httrack-com's staging script
+          # matches the artifact name exactly. The Release name is what a user reads (#1083).
           named="$RUNNER_TEMP/release/$(basename "${dmg%.dmg}")-macos-arm64.dmg"
           mkdir -p "$(dirname "$named")"
           cp "$dmg" "$named"

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -151,15 +151,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          dmg="$(echo "$RUNNER_TEMP"/HTTrack-*.dmg)"
-          test -f "$dmg"
-          # Renamed here, not at build time, because httrack-com's staging script
-          # matches the artifact name exactly. The Release name is what a user reads (#1083).
-          named="$RUNNER_TEMP/release/$(basename "${dmg%.dmg}")-macos-arm64.dmg"
-          mkdir -p "$(dirname "$named")"
-          cp "$dmg" "$named"
           if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" "$named" --clobber
+            gh release upload "$GITHUB_REF_NAME" "$RUNNER_TEMP"/HTTrack-*.dmg --clobber
           else
             echo "no release $GITHUB_REF_NAME yet -- the DMG is on this run's artifacts"
           fi

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -151,8 +151,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          dmg="$(echo "$RUNNER_TEMP"/HTTrack-*.dmg)"
+          test -f "$dmg"
+          # The build is arm64-only and the Release name is the only one a user reads
+          # before downloading (#1083). Renamed here, not at build time: httrack-com's
+          # staging script matches the artifact's name exactly.
+          named="$RUNNER_TEMP/release/$(basename "${dmg%.dmg}")-macos-arm64.dmg"
+          mkdir -p "$(dirname "$named")"
+          cp "$dmg" "$named"
           if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" "$RUNNER_TEMP"/HTTrack-*.dmg --clobber
+            gh release upload "$GITHUB_REF_NAME" "$named" --clobber
           else
             echo "no release $GITHUB_REF_NAME yet -- the DMG is on this run's artifacts"
           fi

--- a/tools/macos-release.sh
+++ b/tools/macos-release.sh
@@ -70,7 +70,7 @@ if [ "$skip_notarize" -eq 0 ]; then
     fi
     test -r "$notary_key" || fail "no App Store Connect key at $notary_key"
 fi
-for t in codesign xcrun hdiutil ditto file spctl; do
+for t in codesign xcrun hdiutil ditto file spctl lipo; do
     command -v "$t" >/dev/null 2>&1 ||
         fail "$t not found -- this needs the Xcode command line tools"
 done
@@ -142,7 +142,8 @@ test -n "$version" || fail "no CFBundleShortVersionString in $app/Contents/Info.
 # The filename is what a user reads before downloading, so name the arch (#1083).
 # An arch counts only if every Mach-O carries it: one thin dylib and the app is not universal.
 arch=$(while IFS= read -r _bin; do lipo -archs "$_bin" | tr ' ' '\n'; done <"$mach" |
-    sort | uniq -c | awk -v n="$(wc -l <"$mach")" '$1 == n { print $2 }' | sort | paste -sd- -)
+    grep -v '^$' | sort | uniq -c |
+    awk -v n="$(wc -l <"$mach")" '$1 == n { print $2 }' | sort | paste -sd- -)
 test -n "$arch" || fail "the bundle's Mach-O files share no architecture"
 case "$arch" in
 *-*) arch=universal ;;

--- a/tools/macos-release.sh
+++ b/tools/macos-release.sh
@@ -139,7 +139,16 @@ fi
 version=$(plist_value "$app/Contents/Info.plist" CFBundleShortVersionString)
 test -n "$version" || fail "no CFBundleShortVersionString in $app/Contents/Info.plist"
 
-dmg="$out/HTTrack-$version.dmg"
+# The filename is what a user reads before downloading, so name the arch (#1083).
+# An arch counts only if every Mach-O carries it: one thin dylib and the app is not universal.
+arch=$(while IFS= read -r _bin; do lipo -archs "$_bin" | tr ' ' '\n'; done <"$mach" |
+    sort | uniq -c | awk -v n="$(wc -l <"$mach")" '$1 == n { print $2 }' | sort | paste -sd- -)
+test -n "$arch" || fail "the bundle's Mach-O files share no architecture"
+case "$arch" in
+*-*) arch=universal ;;
+esac
+
+dmg="$out/HTTrack-$version-macos-$arch.dmg"
 stage=$(mktemp -d)
 trap 'rm -f "$mach" "$nlog"; rm -rf "$stage"' EXIT
 # ditto, not cp: it carries a bundle's metadata across intact.


### PR DESCRIPTION
The DMG is arm64-only, but its filename says nothing about that, so an Intel user downloads an app that cannot launch and gets no warning from the name. Everything around it already says arm64: the job title, the upload artifact, and the copy httrack.com serves.

The name is now built where the image is, so the artifact, the Release asset and the logs all carry it. The architecture comes from the bundle's own Mach-O list and counts only if every binary carries it, so a single thin dylib cannot get the image called universal, and a bundle whose binaries share nothing fails the release rather than shipping a lie.

Ordered with httrack-com, and this stays draft until their side lands: their `stage_macos_dmg.sh` asserts the basename is exactly `HTTrack-$VER.dmg`, and that assert guards the documented recovery for an expired artifact (`gh release download <tag> -p 'HTTrack-*.dmg'`). Renaming first would keep matching the glob and fail the assert, breaking that path months later. They accept both names first, then this merges.

Staying arm64-only rather than going universal is a deliberate call: all three bundled dylibs come from Homebrew, which has no universal bottles, so a universal image means building brotli, zstd and OpenSSL for both architectures or building twice and lipo-ing every Mach-O. If Intel ever earns that, a second `-x86_64` image fits this scheme unchanged.

Closes #1083
