### PR TITLE
WebHTTrack's language menu never marks the language in force

### DIFF
--- a/html/server/index.html
+++ b/html/server/index.html
@@ -105,7 +105,6 @@ ${LANG_THANKYOU}!
 	<tr><td align="right">
 	${LANG_P15} 
 		<select name="lang" onChange="form.redirect.value='index.html'; form.submit()">
-		<option value=0></option>
 		${listid:lang:#iso}
 		</select>
 	</td></tr>

--- a/html/server/index.html
+++ b/html/server/index.html
@@ -106,7 +106,7 @@ ${LANG_THANKYOU}!
 	${LANG_P15} 
 		<select name="lang" onChange="form.redirect.value='index.html'; form.submit()">
 		<option value=0></option>
-		${list:#iso}
+		${listid:lang:#iso}
 		</select>
 	</td></tr>
 

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -1509,8 +1509,8 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
 
                           StringClear(tmpbuff);
                           if (format == 2) {
-                            /* the loop below only ever opens ids 2 and up, so
-                               the first option needs its own default check */
+                            /* Check the default here too: the loop only opens
+                             * ids 2 and up. */
                             StringCat(output, listDefault == 1
                                                   ? "<option value=1 selected>"
                                                   : "<option value=1>");

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -1509,7 +1509,11 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
 
                           StringClear(tmpbuff);
                           if (format == 2) {
-                            StringCat(output, "<option value=1>");
+                            /* the loop below only ever opens ids 2 and up, so
+                               the first option needs its own default check */
+                            StringCat(output, listDefault == 1
+                                                  ? "<option value=1 selected>"
+                                                  : "<option value=1>");
                           } else if (format == -2) {
                             StringCat(output, "<option value=\"");
                           }

--- a/tests/251_webhttrack-lang-selected.test
+++ b/tests/251_webhttrack-lang-selected.test
@@ -1,7 +1,8 @@
 #!/bin/bash
 #
-# The language menu must mark the language actually in force, index 1 included:
-# the first option is opened before the list loop that carries the default.
+# The language menu must mark the language the page is actually rendered in,
+# index 1 included: the first option is opened before the loop carrying the
+# default. Asserting the menu alone cannot tell that from echoing the request.
 
 set -euo pipefail
 
@@ -35,8 +36,7 @@ cleanup() {
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
 
-# The indexes and their labels come from lang.indexes, not from observed output.
-check() { # $1 = lang index, $2 = expected label
+serve() { # $1 = tag, $2.. = extra htsserver args; prints the URL
     local log port url
     log="${work}/srv$1.log"
     mkdir -p "${work}/h$1"
@@ -46,10 +46,12 @@ s = socket.socket()
 s.bind(("127.0.0.1", 0))
 print(s.getsockname()[1])
 s.close()')
+    local tag=$1
+    shift
     (
         trap '' TERM TTOU
-        export HOME="${work}/h$1"
-        exec htsserver "${distdir}/" --port "${port}" lang "$1" >"${log}" 2>&1
+        export HOME="${work}/h${tag}"
+        exec htsserver "${distdir}/" --port "${port}" "$@" >"${log}" 2>&1
     ) &
     pids="${pids} $!"
     url=
@@ -58,10 +60,19 @@ s.close()')
         sleep 0.25
     done
     test -n "${url}" || fail "htsserver did not start: $(cat "${log}")"
-    "${python}" - "${url}" "$1" "$2" <<'PY' || fail "wrong selection for language $2"
+    echo "${url}"
+}
+
+# Indexes and labels come from lang.indexes and lang.def, not from observed output.
+# The heading word is that language's own greeting, so it proves which language
+# the body was rendered in.
+check() { # $1 = lang index, $2 = expected label, $3 = word in the page heading
+    local url
+    url=$(serve "$1" lang "$1")
+    "${python}" - "${url}" "$1" "$2" "$3" <<'PY' || fail "wrong menu or body for language $2"
 import re, sys, urllib.request
 
-url, want_id, want_label = sys.argv[1], sys.argv[2], sys.argv[3]
+url, want_id, want_label, want_word = sys.argv[1:5]
 page = urllib.request.urlopen(url, timeout=20).read().decode("utf-8", "replace")
 block = re.search(r'<select name="lang".*?</select>', page, re.S)
 if not block:
@@ -76,12 +87,41 @@ if len(selected) != 1:
 got_id, got_label = selected[0]
 if got_id != want_id or got_label != want_label:
     sys.exit("selected %s/%r, wanted %s/%r" % (got_id, got_label, want_id, want_label))
+# The menu must follow the language in force, not merely echo the request.
+heading = re.search(r"<h2[^>]*><em>([^<]*)</em>", page)
+if not heading:
+    sys.exit("no welcome heading in the page")
+if want_word not in heading.group(1):
+    sys.exit("body heading %r does not carry %r" % (heading.group(1), want_word))
 PY
 }
 
 # 1 is the boundary the loop cannot reach; 2 and 4 prove it tracks the input.
-check 1 English
-check 2 Francais
-check 4 Deutsch
+check 1 English Welcome
+check 2 Francais Bienvenue
+check 4 Deutsch Willkommen
+
+# With no language set the menu falls back to its first entry, which must be the
+# one the page is rendered in. An empty placeholder option would show up blank.
+url=$(serve unset)
+"${python}" - "${url}" <<'PY' || fail "unset language does not fall back to English"
+import re, sys, urllib.request
+
+page = urllib.request.urlopen(sys.argv[1], timeout=20).read().decode("utf-8", "replace")
+block = re.search(r'<select name="lang".*?</select>', page, re.S)
+if not block:
+    sys.exit("no language <select> in the page")
+opts = re.findall(r"<option value=(\d+)( selected)?>([^<]*)</option>", block.group(0))
+if len(opts) < 20:
+    sys.exit("only %d options: the list did not expand" % len(opts))
+blank = [i for i, _, label in opts if not label.strip()]
+if blank:
+    sys.exit("placeholder option(s) %r would render the menu blank" % (blank,))
+if opts[0][0] != "1" or opts[0][2] != "English":
+    sys.exit("first option is %r, wanted 1/English" % (opts[0],))
+heading = re.search(r"<h2[^>]*><em>([^<]*)</em>", page)
+if not heading or "Welcome" not in heading.group(1):
+    sys.exit("body is not English: %r" % (heading and heading.group(1),))
+PY
 
 echo "PASS"

--- a/tests/251_webhttrack-lang-selected.test
+++ b/tests/251_webhttrack-lang-selected.test
@@ -36,8 +36,11 @@ cleanup() {
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
 
-serve() { # $1 = tag, $2.. = extra htsserver args; prints the URL
-    local log port url
+# Sets ${url}; it must not print it, or a caller's $(...) would collect ${pids} in a
+# subshell and leave every server running.
+url=
+serve() { # $1 = tag, $2.. = extra htsserver args
+    local log port
     log="${work}/srv$1.log"
     mkdir -p "${work}/h$1"
     # An isolated HOME keeps a stray ~/.httrack.ini out of the server's settings.
@@ -60,15 +63,13 @@ s.close()')
         sleep 0.25
     done
     test -n "${url}" || fail "htsserver did not start: $(cat "${log}")"
-    echo "${url}"
 }
 
 # Indexes and labels come from lang.indexes and lang.def, not from observed output.
 # The heading word is that language's own greeting, so it proves which language
 # the body was rendered in.
 check() { # $1 = lang index, $2 = expected label, $3 = word in the page heading
-    local url
-    url=$(serve "$1" lang "$1")
+    serve "$1" lang "$1"
     "${python}" - "${url}" "$1" "$2" "$3" <<'PY' || fail "wrong menu or body for language $2"
 import re, sys, urllib.request
 
@@ -103,7 +104,7 @@ check 4 Deutsch Willkommen
 
 # With no language set the menu falls back to its first entry, which must be the
 # one the page is rendered in. An empty placeholder option would show up blank.
-url=$(serve unset)
+serve unset
 "${python}" - "${url}" <<'PY' || fail "unset language does not fall back to English"
 import re, sys, urllib.request
 

--- a/tests/251_webhttrack-lang-selected.test
+++ b/tests/251_webhttrack-lang-selected.test
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# The language menu must mark the language actually in force, index 1 included:
+# the first option is opened before the list loop that carries the default.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
+distdir=$(cd "${distdir}" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+command -v htsserver >/dev/null || fail "no htsserver in PATH"
+python=$(find_python) || {
+    echo "python3 not found; skipping" >&2
+    exit 77
+}
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_lang.XXXXXX") || fail "no tmpdir"
+pids=
+cleanup() {
+    # htsserver keeps SIGTERM ignored across its exec, so only -9 reaps it.
+    for p in ${pids}; do
+        kill -9 "${p}" 2>/dev/null || true
+    done
+    wait 2>/dev/null || true # absorb bash's async "Killed" notice
+    rm -rf "${work}"
+}
+trap 'set +e; cleanup' EXIT
+trap cleanup HUP INT QUIT PIPE TERM
+
+# The indexes and their labels come from lang.indexes, not from observed output.
+check() { # $1 = lang index, $2 = expected label
+    local log port url
+    log="${work}/srv$1.log"
+    mkdir -p "${work}/h$1"
+    # An isolated HOME keeps a stray ~/.httrack.ini out of the server's settings.
+    port=$("${python}" -c 'import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()')
+    (
+        trap '' TERM TTOU
+        export HOME="${work}/h$1"
+        exec htsserver "${distdir}/" --port "${port}" lang "$1" >"${log}" 2>&1
+    ) &
+    pids="${pids} $!"
+    url=
+    for _ in $(seq 1 40); do
+        url=$(sed -n 's/^URL=//p' "${log}") && test -n "${url}" && break
+        sleep 0.25
+    done
+    test -n "${url}" || fail "htsserver did not start: $(cat "${log}")"
+    "${python}" - "${url}" "$1" "$2" <<'PY' || fail "wrong selection for language $2"
+import re, sys, urllib.request
+
+url, want_id, want_label = sys.argv[1], sys.argv[2], sys.argv[3]
+page = urllib.request.urlopen(url, timeout=20).read().decode("utf-8", "replace")
+block = re.search(r'<select name="lang".*?</select>', page, re.S)
+if not block:
+    sys.exit("no language <select> in the page")
+opts = re.findall(r"<option value=(\d+)( selected)?>([^<]*)</option>", block.group(0))
+# A menu that failed to expand would satisfy every check below vacuously.
+if len(opts) < 20:
+    sys.exit("only %d options: the list did not expand" % len(opts))
+selected = [(i, label) for i, sel, label in opts if sel]
+if len(selected) != 1:
+    sys.exit("expected exactly one selected option, got %r" % (selected,))
+got_id, got_label = selected[0]
+if got_id != want_id or got_label != want_label:
+    sys.exit("selected %s/%r, wanted %s/%r" % (got_id, got_label, want_id, want_label))
+PY
+}
+
+# 1 is the boundary the loop cannot reach; 2 and 4 prove it tracks the input.
+check 1 English
+check 2 Francais
+check 4 Deutsch
+
+echo "PASS"


### PR DESCRIPTION
The welcome page opened its language menu blank instead of showing the language in force. `index.html` used `${list:#iso}`, which carries no default, and it prepended its own empty `<option value=0>` that won whenever nothing was marked. The template now uses `${listid:lang:#iso}`, the form the other nine menus already use, and the placeholder is gone: the launcher hands htsserver the index as `lang`, so the menu follows it. Format 2 writes its first option before the loop that marks the default, so index 1 could never be marked either, and that opening now checks the default too. Nothing changes on screen for the other `listid:` menus, whose first option was already the one the browser displayed.

Test 251 drives htsserver at three indexes and at none, and asserts the marked option against the page's own greeting rather than against the request, so it cannot pass on a menu that merely echoes what it was given. Found on the 3.49.19 DMG on an Apple Silicon machine, where a French locale rendered the page in French with the selector still blank.

Closes #1084
