### PR TITLE
FTP active mode waits for the data connection with no timeout and no stop check

### DIFF
--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -860,11 +860,9 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
             htsblk_failf(&back->r, "PORT command error: %s", linejmp(line));
             back->r.statuscode = STATUSCODE_INVALID;
           }
-#ifdef _WIN32
-          closesocket(soc_servdat);
-#else
-          close(soc_servdat);
-#endif
+          /* invalidate, or the _CHECK_HALT_FTP below re-closes a stale fd */
+          deletesoc(soc_servdat);
+          soc_servdat = INVALID_SOCKET;
         } else {
           strcpybuff(back->r.msg, "Unable to listen to a port");
           back->r.statuscode = STATUSCODE_INVALID;
@@ -961,11 +959,9 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
             strcpybuff(back->r.msg, "Unable to write file");
             back->r.statuscode = STATUSCODE_INVALID;
           }
-#ifdef _WIN32
-          closesocket(soc_dat);
-#else
-          close(soc_dat);
-#endif
+          /* invalidate, or the _CHECK_HALT_FTP below re-closes a stale fd */
+          deletesoc(soc_dat);
+          soc_dat = INVALID_SOCKET;
 
           // 226 Transfer complete?
           if (back->r.statuscode != -1) {

--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -314,6 +314,36 @@ static hts_boolean ftp_connect(lien_back *back, T_SOC soc, SOCaddr *server,
   return socket_set_nonblocking(soc, HTS_FALSE);
 }
 
+#if !FTP_PASV
+/* The active-mode counterpart: an unbounded accept() waits for a data
+   connection the server may never make (#1074). */
+static T_SOC ftp_accept(lien_back *back, T_SOC soc, int timeout,
+                        const httrackp *opt) {
+  const TStamp started = time_local();
+  T_SOC soc_dat;
+
+  timeout = ftp_wait_left(opt, timeout);
+  if (!socket_set_nonblocking(soc, HTS_TRUE))
+    return INVALID_SOCKET;
+  /* state.stop counts as in ftp_connect: nothing is established yet */
+  while (check_socket(soc) == 0) {
+    if (back->stop_ftp || (opt != NULL && opt->state.stop) ||
+        (int) (time_local() - started) >= timeout)
+      return INVALID_SOCKET;
+    Sleep(100);
+  }
+  soc_dat = accept(soc, NULL, NULL);
+  /* BSD hands the listener's non-blocking flag down to the accepted socket,
+     which the transfer below reads blocking. */
+  if (soc_dat != INVALID_SOCKET &&
+      !socket_set_nonblocking(soc_dat, HTS_FALSE)) {
+    deletesoc(soc_dat);
+    return INVALID_SOCKET;
+  }
+  return soc_dat;
+}
+#endif
+
 /* Resolve, likewise: the shared resolver bounds itself by opt->timeout alone
    and takes no stop flag. */
 static SOCaddr *ftp_dns_resolve(httrackp *opt, lien_back *back,
@@ -817,8 +847,8 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
             get_ftp_line(back, soc_ctl, line, sizeof(line), timeout, opt);
             _CHECK_HALT_FTP;
             if (line[0] == '1') {
-              //T_SOC soc_dat;
-              if ((soc_dat = accept(soc_servdat, NULL, NULL)) == INVALID_SOCKET) {
+              if ((soc_dat = ftp_accept(back, soc_servdat, timeout, opt)) ==
+                  INVALID_SOCKET) {
                 strcpybuff(back->r.msg, "Unable to accept connection");
                 back->r.statuscode = STATUSCODE_INVALID;
               }

--- a/tests/253_local-ftp-close-once.test
+++ b/tests/253_local-ftp-close-once.test
@@ -12,8 +12,8 @@ testdir=$(cd "$(dirname "$0")" && pwd)
 . "${testdir}/testlib.sh"
 
 if [ "$(uname -s)" != "Linux" ]; then
-    echo "close-once: LD_PRELOAD interposition is Linux-only here, skipping"
-    exit 0
+    echo "close-once: LD_PRELOAD interposition is Linux-only here, skipping" >&2
+    exit 77
 fi
 # A --disable-shared build has nothing to preload; anything else missing is a
 # build problem, not a skip, or the test would pass vacuously.

--- a/tests/253_local-ftp-close-once.test
+++ b/tests/253_local-ftp-close-once.test
@@ -1,0 +1,121 @@
+#!/bin/bash
+#
+# Cancelling a link mid-FTP-transfer used to reach _HALT_FTP with the data
+# socket already closed and its descriptor still in the variable, closing it a
+# second time. The interposer catches that second close as EBADF.
+
+set -euo pipefail
+
+: "${top_srcdir:=..}"
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "close-once: LD_PRELOAD interposition is Linux-only here, skipping"
+    exit 0
+fi
+# A --disable-shared build has nothing to preload; anything else missing is a
+# build problem, not a skip, or the test would pass vacuously.
+if [ ! -r "${CLOSETRACK_LA:-}" ]; then
+    echo "close-once: ${CLOSETRACK_LA:-\$CLOSETRACK_LA} was not built" >&2
+    exit 1
+fi
+if grep -q "^dlname=''" "$CLOSETRACK_LA"; then
+    echo "close-once: static-only build, skipping"
+    exit 0
+fi
+for lib in "${CLOSETRACK_LIB:-}" "${FTPCANCEL_LIB:-}"; do
+    test -r "$lib" || {
+        echo "close-once: ${lib:-an interposer} was not built" >&2
+        exit 1
+    }
+done
+
+python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
+command -v httrack >/dev/null || {
+    echo "could not find httrack" >&2
+    exit 1
+}
+
+server=$(nativepath "${testdir}/ftp-server.py")
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpclose.XXXXXX")
+serverpid=
+crawlpid=
+cleanup() {
+    test -z "$crawlpid" || kill_tree "$crawlpid"
+    stop_server "$serverpid"
+    rm -rf "$tmpdir"
+}
+trap 'set +e; cleanup' EXIT
+trap cleanup HUP INT QUIT PIPE TERM
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+ok() { echo "OK: $*"; }
+
+root="${tmpdir}/root"
+out="${tmpdir}/crawl"
+cmds="${tmpdir}/cmds"
+closes="${tmpdir}/closes"
+trigger="${tmpdir}/trigger"
+mkdir -p "$root" "$out"
+awk 'BEGIN { s = sprintf("%0999d", 0); for (i = 0; i < 100; i++) print s }' \
+    >"${root}/f.bin"
+# Sends a prefix and then goes quiet, so the transfer is still open when the
+# cancel lands.
+printf '* stall\n' >"${tmpdir}/modes"
+
+serverlog="${tmpdir}/server.out"
+"$python" "$server" --root "$(nativepath "$root")" \
+    --mode-file "$(nativepath "${tmpdir}/modes")" \
+    --log "$(nativepath "$cmds")" >"$serverlog" 2>&1 &
+serverpid=$!
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+
+# An LD_PRELOAD library loads ahead of the executable's own libasan, which ASan
+# refuses by default. The shims allocate nothing, so the ordering is harmless.
+export ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}verify_asan_link_order=0"
+
+# No bound of any kind, so only the cancel can end this transfer. -c2 leaves a
+# socket slot free: with none the main loop parks before the point where it
+# polls for cancelled links, and the request would never be seen.
+export CLOSETRACK_LOG="$closes" FTPCANCEL_TRIGGER="$trigger"
+export LD_PRELOAD="$CLOSETRACK_LIB $FTPCANCEL_LIB"
+httrack "ftp://127.0.0.1:${port}/f.bin" -O "$out" --quiet \
+    --disable-security-limits --robots=0 --timeout=0 --max-time=0 -c2 \
+    >"${tmpdir}/log" 2>&1 &
+crawlpid=$!
+unset LD_PRELOAD
+
+# Cancel once the body is in flight, observed rather than slept for: the engine
+# only flags a transfer it is still running, and the partial file appearing is
+# what says the data connection is up.
+deadline=$((SECONDS + 60))
+partial=
+until test -n "$partial"; do
+    test "$SECONDS" -lt "$deadline" || fail "the crawl never started a transfer"
+    grep -aq '^RETR ' "$cmds" 2>/dev/null && partial=$(find "$out" -name f.bin)
+    poll_wait 1
+done
+# The engine matches the cancel against the save path, byte for byte.
+printf '%s\n' "$partial" >"${trigger}.tmp"
+mv "${trigger}.tmp" "$trigger"
+
+wait_bounded "$crawlpid" 90 || fail "the cancelled crawl never ended"
+crawlpid=
+
+# Floors: without these a crawl that never reached the halt path passes
+# silently. stop_ftp() is what writes this message, so it stands for the
+# _HALT_FTP that follows.
+grep -aq 'Cancelled by User' "${out}/hts-log.txt" ||
+    fail "the cancel never reached the transfer: $(grep -a Error "${out}/hts-log.txt" || true)"
+test -s "$closes" || fail "the interposer logged no close() at all"
+ok "the cancel landed on an in-flight transfer ($(wc -l <"$closes") closes seen)"
+
+badf=$(grep -c ' EBADF$' "$closes" || true)
+test "$badf" -eq 0 ||
+    fail "$badf close() calls hit a stale descriptor: $(tr '\n' ' ' <"$closes")"
+ok "every descriptor was closed once"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,7 @@ TESTS = @TESTS_LIST@
 # Committed binary fixture read by 01_zlib-cache-golden.test. List it
 # explicitly: automake does not expand wildcards in EXTRA_DIST, so a glob would
 # silently drop it from the dist tarball and break "make distcheck".
-EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c altstackprobe.c nopieprobe.c crawl-test.sh run-all-tests.sh check-network.sh check-test-names.sh \
+EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c altstackprobe.c nopieprobe.c closetrack.c ftpcancel.c crawl-test.sh run-all-tests.sh check-network.sh check-test-names.sh \
 	proxy-https-server.py socks5-server.py proxy-connect-server.py \
 	proxytestlib.py tls-stall-server.py warc-validate.py wacz-validate.py \
 	header-injection-server.py header-injection-check.py \
@@ -68,6 +68,9 @@ TESTS_ENVIRONMENT += NOBACKTRACE_LA=$(abs_builddir)/libnobacktrace.la
 TESTS_ENVIRONMENT += NOBACKTRACE_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/libnobacktrace.so
 TESTS_ENVIRONMENT += ALTSTACKPROBE_LA=$(abs_builddir)/libaltstackprobe.la
 TESTS_ENVIRONMENT += ALTSTACKPROBE_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/libaltstackprobe.so
+TESTS_ENVIRONMENT += CLOSETRACK_LA=$(abs_builddir)/libclosetrack.la
+TESTS_ENVIRONMENT += CLOSETRACK_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/libclosetrack.so
+TESTS_ENVIRONMENT += FTPCANCEL_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/libftpcancel.so
 TESTS_ENVIRONMENT += STRINGOOM_BIN=$(abs_builddir)/stringoom$(EXEEXT)
 # 215_engine-datadir-ospath.test runs the engine from a copy, so it needs the
 # real binary rather than the libtool wrapper script, plus the loader variable
@@ -79,7 +82,7 @@ TESTS_ENVIRONMENT += SHLIBPATH_VAR=$(SHLIBPATH_VAR)
 # rename() interposer for 01_engine-renameover.test; -rpath is what makes
 # libtool build a shared module rather than a static-only convenience library.
 check_LTLIBRARIES = librenamefail.la libunlinkfail.la libthreadattrfail.la \
-	libnobacktrace.la libaltstackprobe.la
+	libnobacktrace.la libaltstackprobe.la libclosetrack.la libftpcancel.la
 librenamefail_la_SOURCES = renamefail.c
 librenamefail_la_LDFLAGS = -module -avoid-version -rpath $(abs_builddir)
 librenamefail_la_LIBADD = $(DL_LIBS)
@@ -102,6 +105,16 @@ libnobacktrace_la_LDFLAGS = -module -avoid-version -rpath $(abs_builddir)
 libaltstackprobe_la_SOURCES = altstackprobe.c
 libaltstackprobe_la_LDFLAGS = -module -avoid-version -rpath $(abs_builddir)
 libaltstackprobe_la_LIBADD = $(DL_LIBS)
+
+# close() observer for 253_local-ftp-close-once.test
+libclosetrack_la_SOURCES = closetrack.c
+libclosetrack_la_LDFLAGS = -module -avoid-version -rpath $(abs_builddir)
+libclosetrack_la_LIBADD = $(DL_LIBS)
+
+# per-link cancel driver for 253_local-ftp-close-once.test
+libftpcancel_la_SOURCES = ftpcancel.c
+libftpcancel_la_LDFLAGS = -module -avoid-version -rpath $(abs_builddir)
+libftpcancel_la_LIBADD = $(DL_LIBS) -lpthread
 
 # realloc stub for 152_engine-string-oom.test; links nothing, so it stays a
 # plain binary rather than a libtool wrapper script.

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -276,8 +276,10 @@ echo "ran=$((pass + fail + skip)) pass=$pass fail=$fail skip=$skip" |
 # ftp-userpass starves the x64 runner until the step is lost, Win32 passing (#1038);
 # memresume, repaircache and resume-recovery interrupt pass 1 with a signal
 # MSYS cannot deliver to a native exe;
-# ftp-deadhost-interrupt needs that same signal (its --timeout half runs, as 245).
+# ftp-deadhost-interrupt needs that same signal (its --timeout half runs, as 245);
+# close-once interposes close() through LD_PRELOAD, which MSYS has no equivalent for.
 expected_skips="01_engine-footer-overflow.test
+253_local-ftp-close-once.test
 100_local-purge-longpath.test
 158_local-link-control-bytes.test
 114_local-update-304-leak.test

--- a/tests/closetrack.c
+++ b/tests/closetrack.c
@@ -1,0 +1,82 @@
+/* close() observer for 253_local-ftp-close-once.test: one "fd rc status" line
+   per call in CLOSETRACK_LOG, so a double-close shows up as EBADF. Writes with
+   write(2) rather than stdio, which would close a descriptor and recurse. */
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* The tree builds with -fvisibility=hidden, which would hide the interposer. */
+#define SHIM_EXPORT __attribute__((visibility("default")))
+
+SHIM_EXPORT int close(int fd);
+
+static int closetrack_log = -1;
+static int closetrack_engine = 0;
+
+/* Opened from the constructor: the process is still single-threaded there, so
+   the descriptor needs no lock, and O_APPEND keeps concurrent writes whole. */
+static void __attribute__((constructor)) closetrack_open(void) {
+  const char *const path = getenv("CLOSETRACK_LOG");
+
+  if (path != NULL) {
+    closetrack_log =
+        open(path, O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, 0600);
+  }
+}
+
+/* The preload also lands on the libtool wrapper, a /bin/sh that closes -1 on
+   its own; the engine is the process holding libhttrack. Never caches a no, so
+   a close issued before the library is mapped cannot blind the rest. */
+static int closetrack_is_engine(void) {
+  if (!closetrack_engine && dlsym(RTLD_DEFAULT, "hts_init") != NULL) {
+    closetrack_engine = 1;
+  }
+  return closetrack_engine;
+}
+
+static const char *closetrack_status(int rc, int err) {
+  if (rc == 0) {
+    return "ok";
+  }
+  return err == EBADF ? "EBADF" : "other";
+}
+
+SHIM_EXPORT int close(int fd) {
+  static int (*real_close)(int) = NULL;
+  int rc, err;
+
+  if (real_close == NULL) {
+    *(void **) &real_close = dlsym(RTLD_NEXT, "close");
+    if (real_close == NULL) {
+      errno = ENOSYS;
+      return -1;
+    }
+  }
+  if (fd == closetrack_log) {
+    /* Refused rather than obeyed: losing the log would blind the test. */
+    rc = -1;
+    err = EBADF;
+  } else {
+    rc = real_close(fd);
+    err = errno;
+  }
+  if (closetrack_log != -1 && closetrack_is_engine()) {
+    char line[64];
+    const int len = snprintf(line, sizeof(line), "%d %d %s\n", fd, rc,
+                             closetrack_status(rc, err));
+
+    if (len > 0) {
+      const ssize_t written = write(closetrack_log, line, (size_t) len);
+
+      (void) written;
+    }
+  }
+  errno = err;
+  return rc;
+}

--- a/tests/ftpcancel.c
+++ b/tests/ftpcancel.c
@@ -1,0 +1,70 @@
+/* Fires the engine's per-link cancel, the one WebHTTrack's stop button pushes,
+   from outside the engine: 253_local-ftp-close-once.test writes the save path
+   to cancel into FTPCANCEL_TRIGGER once the FTP transfer is in flight. */
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* The tree builds with -fvisibility=hidden, which would hide the interposer. */
+#define SHIM_EXPORT __attribute__((visibility("default")))
+
+/* The engine's own httrackp, opaque here. */
+SHIM_EXPORT void *hts_create_opt(void);
+
+static void *ftpcancel_opt = NULL;
+
+/* Polls for the trigger rather than sleeping a fixed delay: the test decides
+   when the transfer is really in flight. Gives up so a missed trigger fails
+   the test rather than pinning a core. */
+static void *ftpcancel_thread(void *unused) {
+  int (*push)(void *, const char *) = NULL;
+  const char *const trigger = getenv("FTPCANCEL_TRIGGER");
+  int left = 600;
+
+  (void) unused;
+  *(void **) &push = dlsym(RTLD_DEFAULT, "hts_cancel_file_push");
+  if (trigger == NULL || push == NULL) {
+    return NULL;
+  }
+  while (left-- > 0) {
+    FILE *const fp = fopen(trigger, "rb");
+
+    if (fp != NULL) {
+      char url[2048];
+      const char *const got = fgets(url, (int) sizeof(url), fp);
+      char *const eol = got != NULL ? strchr(url, '\n') : NULL;
+
+      fclose(fp);
+      if (eol != NULL) {
+        *eol = '\0';
+        push(ftpcancel_opt, url);
+        return NULL;
+      }
+    }
+    usleep(100000);
+  }
+  return NULL;
+}
+
+SHIM_EXPORT void *hts_create_opt(void) {
+  static void *(*real_create)(void) = NULL;
+  pthread_t thread;
+
+  if (real_create == NULL) {
+    *(void **) &real_create = dlsym(RTLD_NEXT, "hts_create_opt");
+    if (real_create == NULL) {
+      return NULL;
+    }
+  }
+  ftpcancel_opt = real_create();
+  if (ftpcancel_opt != NULL &&
+      pthread_create(&thread, NULL, ftpcancel_thread, NULL) == 0) {
+    pthread_detach(thread);
+  }
+  return ftpcancel_opt;
+}


### PR DESCRIPTION
Active mode waited for the server's data connection in a blocking accept(), so it ignored --timeout, --max-time and the stop flag, the way the two connects did before #1071. It now polls on the same 100ms tick, re-reading the stop flags and what is left of --max-time each pass, and puts the accepted socket back into blocking mode because BSD hands it the listener's non-blocking flag.

The branch is compiled out today (FTP_PASV is 1), so there is no runtime path to test. I compiled htsftp.c with FTP_PASV forced to 0 instead: clean, no warnings, and the object's undefined accept symbol confirms the branch was really built. The default is untouched. No build in CI covers that branch, which #1091 tracks, so this check was a one-off by hand.

A review found a second bug in the same code, folded in here: the active-mode listener and the data socket were both closed with a raw close() that left the descriptor in the variable, so the _CHECK_HALT_FTP after the transfer loop closed them again through _HALT_FTP. The data socket one is on the live PASV path. Both now reset to INVALID_SOCKET the way the PASV path already does around its own deletesoc calls. 253_local-ftp-close-once.test cancels a link mid-transfer through the engine's own per-link cancel, the one WebHTTrack's stop button pushes, and an LD_PRELOAD close() interposer reds the test on any EBADF. Reverting the data socket to its raw close gives exactly one.

Closes #1074
Closes #1090
