### PR TITLE
StringRoomTotal doubles its capacity without saturating

### DIFF
--- a/src/htsstrings.h
+++ b/src/htsstrings.h
@@ -41,6 +41,8 @@ Please visit our Website: http://www.httrack.com
 #include <stdlib.h>
 #include <string.h>
 
+#include "htssafe.h"
+
 /* GCC extension */
 #ifndef HTS_UNUSED
 #ifdef __GNUC__
@@ -90,9 +92,9 @@ struct String {
 
 /** Allocator **/
 #ifndef STRING_REALLOC
-#define STRING_REALLOC(BUFF, SIZE) ((char *) realloc(BUFF, SIZE))
+#define STRING_REALLOC(BUFF, SIZE) ((char *) realloct(BUFF, SIZE))
 
-#define STRING_FREE(BUFF) free(BUFF)
+#define STRING_FREE(BUFF) freet(BUFF)
 #endif
 
 /** Initializer for an empty String (NULL buffer). Use to declare or reset. **/
@@ -156,7 +158,14 @@ HTS_STATIC void StringOom_(size_t size) {
   do {                                                                         \
     const size_t capacity_ = (size_t) (CAPACITY);                              \
     while ((BLK).capacity_ < capacity_) {                                      \
-      const size_t newcap_ = (BLK).capacity_ < 16 ? 16 : (BLK).capacity_ * 2;  \
+      const size_t maxcap_ = (size_t) -1;                                      \
+      const size_t mincap_ = 16;                                               \
+      const size_t cur_ = (BLK).capacity_;                                     \
+      /* Saturating: a plain cur_*2 wraps below cur_, which no further         \
+         doubling climbs back out of. */                                       \
+      const size_t newcap_ = cur_ < mincap_       ? mincap_                    \
+                             : cur_ > maxcap_ / 2 ? maxcap_                    \
+                                                  : cur_ * 2;                  \
       char *const buff_ = STRING_REALLOC((BLK).buffer_, newcap_);              \
                                                                                \
       if (buff_ == NULL) {                                                     \

--- a/src/htsstrings.h
+++ b/src/htsstrings.h
@@ -41,8 +41,6 @@ Please visit our Website: http://www.httrack.com
 #include <stdlib.h>
 #include <string.h>
 
-#include "htssafe.h"
-
 /* GCC extension */
 #ifndef HTS_UNUSED
 #ifdef __GNUC__
@@ -92,9 +90,9 @@ struct String {
 
 /** Allocator **/
 #ifndef STRING_REALLOC
-#define STRING_REALLOC(BUFF, SIZE) ((char *) realloct(BUFF, SIZE))
+#define STRING_REALLOC(BUFF, SIZE) ((char *) realloc(BUFF, SIZE))
 
-#define STRING_FREE(BUFF) freet(BUFF)
+#define STRING_FREE(BUFF) free(BUFF)
 #endif
 
 /** Initializer for an empty String (NULL buffer). Use to declare or reset. **/
@@ -161,10 +159,10 @@ HTS_STATIC void StringOom_(size_t size) {
       const size_t maxcap_ = (size_t) -1;                                      \
       const size_t mincap_ = 16;                                               \
       const size_t cur_ = (BLK).capacity_;                                     \
-      /* Saturating: a plain cur_*2 wraps below cur_, which no further         \
-         doubling climbs back out of. */                                       \
+      /* Past the halfway point cur_*2 wraps below cur_, which no further      \
+         doubling climbs back out of; ask for the requested total instead. */  \
       const size_t newcap_ = cur_ < mincap_       ? mincap_                    \
-                             : cur_ > maxcap_ / 2 ? maxcap_                    \
+                             : cur_ > maxcap_ / 2 ? capacity_                  \
                                                   : cur_ * 2;                  \
       char *const buff_ = STRING_REALLOC((BLK).buffer_, newcap_);              \
                                                                                \

--- a/tests/152_engine-string-oom.test
+++ b/tests/152_engine-string-oom.test
@@ -26,8 +26,8 @@ fi
 
 # Control first: with the stub allocating for real, growth must not reach the
 # failure path at all, and the capacity it announces must be writable to the
-# last byte. Then the three failure shapes, and the growers inside the header.
-for mode in grow hook keep sprintf buffn saturate; do
+# last byte. Then the failure shapes, and the growers inside the header.
+for mode in grow hook keep sprintf buffn saturate growloop; do
     out=$("$STRINGOOM_BIN" "$mode") || fail "$mode case exited non-zero: $out"
     test "$out" = "$mode: OK" || fail "expected '$mode: OK', got: $out"
 done

--- a/tests/152_engine-string-oom.test
+++ b/tests/152_engine-string-oom.test
@@ -27,7 +27,7 @@ fi
 # Control first: with the stub allocating for real, growth must not reach the
 # failure path at all, and the capacity it announces must be writable to the
 # last byte. Then the three failure shapes, and the growers inside the header.
-for mode in grow hook keep sprintf buffn; do
+for mode in grow hook keep sprintf buffn saturate; do
     out=$("$STRINGOOM_BIN" "$mode") || fail "$mode case exited non-zero: $out"
     test "$out" = "$mode: OK" || fail "expected '$mode: OK', got: $out"
 done

--- a/tests/250_timeout-poll-nofork.test
+++ b/tests/250_timeout-poll-nofork.test
@@ -41,16 +41,17 @@ cat >"$tmp/child.sh" <<'EOF'
 #!/bin/bash
 trap 'exit 0' TERM INT
 echo "$$" >"$PIDFILE"
-end=$((SECONDS + 5))
+end=$((SECONDS + ${CHILDLIFE:-5}))
 while test "$SECONDS" -lt "$end"; do :; done
 EOF
 
 # 60s, so a deadline firing in place of the guard shows up as a stall and a DUMP
 # line rather than as the same 124.
 run_timeout() {
-    local bin=$1 log=$2
+    local bin=$1 log=$2 life=${3:-5}
     env PATH="$bin:$PATH" \
         TICKFILE="$tmp/ticks" PIDFILE="$tmp/childpid" \
+        CHILDLIFE="$life" \
         HTTRACK_POLL_SLEEP=1 \
         HTTRACK_TEST_TIMEOUT=60 \
         HTTRACK_PROGRESS_LOG="$tmp/progress" \
@@ -61,7 +62,9 @@ run_timeout() {
 : >"$tmp/childpid"
 began=$SECONDS
 rc=0
-run_timeout "$tmp/dead" "$tmp/broken.log" || rc=$?
+# 20s of insurance, not 5: the kill is asserted with a 5s wait below, and a child
+# expiring on its own budget inside that window would read as a successful kill.
+run_timeout "$tmp/dead" "$tmp/broken.log" 20 || rc=$?
 spent=$((SECONDS - began))
 
 test "$rc" -eq 124 || fail "a tick that never waits exited $rc, not 124: $(cat "$tmp/broken.log")"
@@ -76,7 +79,10 @@ grep -q '^DUMP ' "$tmp/progress" && fail "the loop ran to its 60s deadline, not 
 test "$spent" -lt 30 || fail "took ${spent}s to give up on a tick that returns at once"
 childpid=$(cat "$tmp/childpid")
 test -n "$childpid" || fail "the child never started"
-kill -0 "$childpid" 2>/dev/null && fail "giving up left the wedged test running as $childpid"
+# Bounded, not instantaneous: the give-up branch skips reap_bounded on purpose, so
+# it returns with the kill barely delivered and the child not yet reaped (#1092).
+REAP_GRACE=5 reap_bounded "$childpid" ||
+    fail "giving up left the wedged test running as $childpid"
 
 # A tick that fails intermittently is a healthy box, and must never reach the
 # verdict: without the reset, any run long enough accumulates ten of them.

--- a/tests/stringoom.c
+++ b/tests/stringoom.c
@@ -37,10 +37,21 @@ static size_t oom_size = 0;
 static size_t last_request = 0;
 static jmp_buf oom_jump;
 
+/* Hands back a pointer no caller may dereference, so a growth loop can be run
+   to its end without allocating; alloc_budget caps a loop that never ends. */
+static int alloc_pretends = 0;
+static int alloc_budget = 0;
+static int alloc_calls = 0;
+static char pretend_buffer[1];
+
 static char *test_realloc(char *buff, size_t size) {
   last_request = size;
+  alloc_calls++;
   if (alloc_fails) {
     return NULL;
+  }
+  if (alloc_pretends) {
+    return alloc_calls > alloc_budget ? NULL : pretend_buffer;
   }
   return (char *) realloc(buff, size);
 }
@@ -206,9 +217,7 @@ static int buffn_case(void) {
   return 0;
 }
 
-/* Doubling past SIZE_MAX/2 must clamp, not wrap to a capacity below the one
-   already held, which no further doubling climbs back out of. Nothing reaches
-   that through the API, so the capacity is forced here. */
+/* Nothing reaches the halfway point through the API, so it is forced here. */
 static int saturate_case(void) {
   StringCapacity(room) = ((size_t) -1) / 2 + 1;
   alloc_fails = oom_jumps = 1;
@@ -226,8 +235,35 @@ static int saturate_case(void) {
     return 1;
   }
   alloc_fails = 0;
+  StringBuffRW(room) = NULL;
   StringFree(room);
   printf("saturate: OK\n");
+  return 0;
+}
+
+/* saturate_case dies on the first allocation, so it never sees a second step.
+   Here the allocator keeps saying yes: a clamp that fails to raise the
+   capacity spins, and the budget turns that spin into a failure. */
+static int growloop_case(void) {
+  enum { maxSteps = 8 * sizeof(size_t) + 4 };
+
+  alloc_pretends = oom_jumps = 1;
+  alloc_budget = maxSteps;
+  alloc_calls = 0;
+  if (setjmp(oom_jump) != 0) {
+    printf("growloop: FAIL (still growing after %d steps)\n", maxSteps);
+    return 1;
+  }
+  StringRoomTotal(room, (size_t) -1);
+  if (StringCapacity(room) != (size_t) -1) {
+    printf("growloop: FAIL (stopped at capacity %lu)\n",
+           (unsigned long) StringCapacity(room));
+    return 1;
+  }
+  alloc_pretends = 0;
+  StringBuffRW(room) = NULL; /* the stub's pointer never came from malloc */
+  StringFree(room);
+  printf("growloop: OK\n");
   return 0;
 }
 
@@ -254,10 +290,13 @@ int main(int argc, char **argv) {
     return buffn_case();
   } else if (strcmp(mode, "saturate") == 0) {
     return saturate_case();
+  } else if (strcmp(mode, "growloop") == 0) {
+    return growloop_case();
   } else if (strcmp(mode, "abort") == 0) {
     return abort_case();
   }
-  fprintf(stderr, "usage: %s grow|hook|keep|sprintf|buffn|saturate|abort\n",
+  fprintf(stderr,
+          "usage: %s grow|hook|keep|sprintf|buffn|saturate|growloop|abort\n",
           argv[0]);
   return 2;
 }

--- a/tests/stringoom.c
+++ b/tests/stringoom.c
@@ -206,6 +206,31 @@ static int buffn_case(void) {
   return 0;
 }
 
+/* Doubling past SIZE_MAX/2 must clamp, not wrap to a capacity below the one
+   already held, which no further doubling climbs back out of. Nothing reaches
+   that through the API, so the capacity is forced here. */
+static int saturate_case(void) {
+  StringCapacity(room) = ((size_t) -1) / 2 + 1;
+  alloc_fails = oom_jumps = 1;
+  if (setjmp(oom_jump) == 0) {
+    StringRoomTotal(room, (size_t) -1);
+    printf("saturate: FAIL (grew through a failing allocator)\n");
+    return 1;
+  }
+  if (!failure_reported("saturate")) {
+    return 1;
+  }
+  if (last_request != (size_t) -1) {
+    printf("saturate: FAIL (allocator asked for %lu bytes, want SIZE_MAX)\n",
+           (unsigned long) last_request);
+    return 1;
+  }
+  alloc_fails = 0;
+  StringFree(room);
+  printf("saturate: OK\n");
+  return 0;
+}
+
 /* Runs the shipped handler, which must print and abort. */
 static int abort_case(void) {
   alloc_fails = 1;
@@ -227,9 +252,12 @@ int main(int argc, char **argv) {
     return sprintf_case();
   } else if (strcmp(mode, "buffn") == 0) {
     return buffn_case();
+  } else if (strcmp(mode, "saturate") == 0) {
+    return saturate_case();
   } else if (strcmp(mode, "abort") == 0) {
     return abort_case();
   }
-  fprintf(stderr, "usage: %s grow|hook|keep|sprintf|buffn|abort\n", argv[0]);
+  fprintf(stderr, "usage: %s grow|hook|keep|sprintf|buffn|saturate|abort\n",
+          argv[0]);
   return 2;
 }


### PR DESCRIPTION
StringRoomTotal doubled its capacity with no cap, so once past SIZE_MAX/2 the product wrapped to a capacity below the one already held and no further doubling climbed back out. Nothing reaches that today, since the realloc sits inside the loop and an outsized request dies in STRING_OOM several doublings earlier, but the tree had one grower that saturates (TypedArrayEnsureRoom, fixed in #1056) and one that did not. Past the halfway point it now asks for the requested total rather than doubling.

Clamping to SIZE_MAX, the obvious mirror of TypedArrayEnsureRoom, hands GCC a constant `realloc(p, SIZE_MAX)` and lights `-Walloc-size-larger-than` at every String growth site: 24 new warnings in proxytrack alone. The requested total is a runtime value, so there is nothing to fold. #1062 also asked for the realloct/freet wrappers; I left those alone, since they are plain aliases for realloc/free, while `freet` is a statement macro that assigns to its argument, htsstrings.h is installed, and pulling in htssafe.h leaks config.h into a header documented as standalone.

Two stringoom modes cover it. `saturate` forces the capacity past the halfway point, which nothing reaches through the API, and pins the size the allocator is asked for; it dies on its first allocation and so never sees a second step. `growloop` runs the whole loop against an allocator that keeps saying yes, under a step budget, so a clamp that fails to raise the capacity fails instead of spinning. Both go red on the old doubling and on a clamp that hands back the current capacity.

One unrelated fix rides along. `tests/250_timeout-poll-nofork.test` checked that the wedged child was gone with a single `kill -0` that nothing had waited for, and that race reddened this PR's own `build (no python3, Debian buildd)` leg. It now waits for the pid, bounded well under the child's own self-limit so a child expiring on its budget cannot pass for a successful kill.

Closes #1062
Closes #1092
