### PR TITLE
The heartbeat's sleep can inherit the caller's stdout, and no test sees it

### DIFF
--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -233,4 +233,39 @@ wedge_leg >"$tmp/wedge.log" 2>&1 || {
     exit 1
 }
 
+# A sleep still holding the step's stdout keeps its reader waiting for EOF past the
+# trap that killed the heartbeat (#949); 171 shims sleep, forks nothing, is blind to it.
+fd_tick=15
+fd_kill=$tmp/fd-killed
+
+# Seconds between the producer's own kill and the reader seeing EOF.
+eof_latency() {
+    "$1" 2>>"$tmp/fd.err" | cat >"$tmp/fd.out"
+    echo $(($(date +%s) - $(cat "$fd_kill")))
+}
+
+# What the driver's EXIT trap does: signal the heartbeat shell mid-tick and let go.
+fd_leg() (
+    printf 'RUN 99_fd.test at 0s\n' >"$tmp/fd-progress.log"
+    sleep 30 >/dev/null 2>&1 & # a pid for the wedge branch, which cannot fire here
+    victim=$!
+    ci_suite_heartbeat 100000 "$fd_tick" "$tmp/fd-progress.log" 100000 "$victim" &
+    hb=$!
+    sleep 2 # well inside the first tick
+    date +%s >"$fd_kill"
+    kill "$hb" "$victim" 2>/dev/null || :
+)
+
+# Positive control: the same reader, against a child that does keep the pipe.
+fd_holder() (
+    sleep 6 &
+    date +%s >"$fd_kill"
+)
+
+lat=$(eof_latency fd_holder)
+test "$lat" -ge 3 || fail "EOF ${lat}s after a child kept the pipe: the reader cannot see one"
+lat=$(eof_latency fd_leg)
+test "$lat" -le 4 ||
+    fail "EOF ${lat}s after the heartbeat died: its sleep inherited the caller's stdout"
+
 echo "ci-windows driver OK"

--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -247,11 +247,15 @@ eof_latency() {
 # What the driver's EXIT trap does: signal the heartbeat shell mid-tick and let go.
 fd_leg() (
     printf 'RUN 99_fd.test at 0s\n' >"$tmp/fd-progress.log"
+    rm -f "$tmp/fd-dead"
     sleep 30 >/dev/null 2>&1 & # a pid for the wedge branch, which cannot fire here
     victim=$!
     ci_suite_heartbeat 100000 "$fd_tick" "$tmp/fd-progress.log" 100000 "$victim" &
     hb=$!
     sleep 2 # well inside the first tick
+    # A heartbeat that ended early forks no sleep and gives a prompt EOF too, so the
+    # verdict below would be vacuous. Marked, not failed: this is a subshell.
+    kill -0 "$hb" 2>/dev/null || : >"$tmp/fd-dead"
     date +%s >"$fd_kill"
     kill "$hb" "$victim" 2>/dev/null || :
 )
@@ -265,6 +269,8 @@ fd_holder() (
 lat=$(eof_latency fd_holder)
 test "$lat" -ge 3 || fail "EOF ${lat}s after a child kept the pipe: the reader cannot see one"
 lat=$(eof_latency fd_leg)
+test ! -e "$tmp/fd-dead" ||
+    fail "the heartbeat was already dead at the kill, so a prompt EOF proves nothing"
 test "$lat" -le 4 ||
     fail "EOF ${lat}s after the heartbeat died: its sleep inherited the caller's stdout"
 


### PR DESCRIPTION
The `>/dev/null 2>&1` on `ci_suite_heartbeat`'s `sleep` is load-bearing, not noise suppression. The suite's EXIT trap kills the heartbeat shell and not the sleep it forked, so an orphan still holding the step's stdout keeps its reader waiting for EOF, which delays or loses the step the watchdog was there to protect.

171 is blind to it: its `sleep` is a shell function on a virtual clock, so nothing is forked and no descriptor is inherited, and the test stays green with the redirection deleted. The new leg goes in 172, which already drives the driver on real sleeps. Start the heartbeat on a 15s tick with its stdout in a pipe, let it enter the first sleep, kill it the way the trap does, then time how long the reader waits for EOF: 0s today, 13s with the redirection removed. Two things keep a prompt EOF from passing for the wrong reason: a control leg runs first and forks a child that does keep the pipe, and the leg samples the heartbeat pid before it signals, since one that died before forking its sleep would look identical.

Costs 172 about 8 seconds.

Closes #949
