### PR TITLE
A foreign-host link that looks like a file is scanned as a page

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -1702,8 +1702,7 @@ int httpmirror(char *url1, httrackp * opt) {
             opt, LOG_INFO,
             "Note: not scanning %s%s, an HTML page on a host foreign "
             "to %s; mirror it by adding it as a starting URL",
-            /* normalized both sides: a page-supplied link can carry credentials
-             */
+            /* normalized: a page-supplied link can carry credentials */
             jump_identification_const(urladr()), urlfil(),
             jump_identification_const(heap(heap(ptr)->precedent)->adr));
         heap(ptr)->depth = 0;

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -1702,7 +1702,9 @@ int httpmirror(char *url1, httrackp * opt) {
             opt, LOG_INFO,
             "Note: not scanning %s%s, an HTML page on a host foreign "
             "to %s; mirror it by adding it as a starting URL",
-            urladr(), urlfil(),
+            /* normalized both sides: a page-supplied link can carry credentials
+             */
+            jump_identification_const(urladr()), urlfil(),
             jump_identification_const(heap(heap(ptr)->precedent)->adr));
         heap(ptr)->depth = 0;
       }

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -1693,6 +1693,20 @@ int httpmirror(char *url1, httrackp * opt) {
       // traitement (parsing)
       // ------------------------------------------------------
 
+      /* A URL taken for an asset on a foreign host, answering hypertext: keep
+         the file, but spend no depth on it. Its links are same-host now, so the
+         parent's budget would mirror that whole site (#121). */
+      if (!is_binary && heap(ptr)->depth > 0 &&
+          (is_hypertext_mime(opt, r.contenttype, urlfil()) ||
+           may_be_hypertext_mime(opt, r.contenttype, urlfil())) &&
+          hts_link_is_foreign_asset(opt, ptr)) {
+        hts_log_print(opt, LOG_INFO,
+                      "Note: not scanning %s%s: %s from a host foreign to %s",
+                      urladr(), urlfil(), r.contenttype,
+                      heap(heap(ptr)->precedent)->adr);
+        heap(ptr)->depth = 0;
+      }
+
       // traiter
       if (!is_binary && ((is_hypertext_mime(opt, r.contenttype, urlfil()))        /* Is HTML or Js, .. */
                          ||(may_be_hypertext_mime(opt, r.contenttype, urlfil()) && r.adr != NULL) /* Is real media, .. */

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -1698,10 +1698,12 @@ int httpmirror(char *url1, httrackp * opt) {
       if (!is_binary && heap(ptr)->depth > 0 &&
           is_html_mime_type(r.contenttype) &&
           hts_link_is_foreign_asset(opt, ptr)) {
-        hts_log_print(opt, LOG_INFO,
-                      "Note: not scanning %s%s, an HTML page on a host foreign "
-                      "to %s; mirror it by adding it as a starting URL",
-                      urladr(), urlfil(), heap(heap(ptr)->precedent)->adr);
+        hts_log_print(
+            opt, LOG_INFO,
+            "Note: not scanning %s%s, an HTML page on a host foreign "
+            "to %s; mirror it by adding it as a starting URL",
+            urladr(), urlfil(),
+            jump_identification_const(heap(heap(ptr)->precedent)->adr));
         heap(ptr)->depth = 0;
       }
 

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -1693,17 +1693,15 @@ int httpmirror(char *url1, httrackp * opt) {
       // traitement (parsing)
       // ------------------------------------------------------
 
-      /* A URL taken for an asset on a foreign host, answering hypertext: keep
-         the file, but spend no depth on it. Its links are same-host now, so the
-         parent's budget would mirror that whole site (#121). */
+      /* An asset URL on a foreign host that answers an HTML page gets no depth:
+         its links are same-host, and would mirror that whole site (#121). */
       if (!is_binary && heap(ptr)->depth > 0 &&
-          (is_hypertext_mime(opt, r.contenttype, urlfil()) ||
-           may_be_hypertext_mime(opt, r.contenttype, urlfil())) &&
+          is_html_mime_type(r.contenttype) &&
           hts_link_is_foreign_asset(opt, ptr)) {
         hts_log_print(opt, LOG_INFO,
-                      "Note: not scanning %s%s: %s from a host foreign to %s",
-                      urladr(), urlfil(), r.contenttype,
-                      heap(heap(ptr)->precedent)->adr);
+                      "Note: not scanning %s%s, an HTML page on a host foreign "
+                      "to %s; mirror it by adding it as a starting URL",
+                      urladr(), urlfil(), heap(heap(ptr)->precedent)->adr);
         heap(ptr)->depth = 0;
       }
 

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -930,50 +930,18 @@ int hts_acceptmime(httrackp * opt, int ptr,
 #undef _ROBOTS
 }
 
-/* Filter verdict for a link (1 accepted, -1 refused, 0 undecided), fed the two
-   URL forms the wizard tests. */
-static int hts_filters_verdict(httrackp *opt, const char *adr,
-                               const char *fil) {
-  char BIGSTK l[HTS_URLMAXSIZE * 2];
-  char BIGSTK lfull[HTS_URLMAXSIZE * 2];
-
-  strcpybuff(l, jump_identification_const(adr));
-  if (*fil != '/')
-    strcatbuff(l, "/");
-  strcatbuff(l, fil);
-  if (!link_has_authority(adr))
-    strcpybuff(lfull, "http://");
-  else
-    lfull[0] = '\0';
-  strcatbuff(lfull, adr);
-  if (*fil != '/')
-    strcatbuff(lfull, "/");
-  strcatbuff(lfull, fil);
-  return fa_strjoker_dual(/*url */ 0, *opt->filters.filters,
-                          *opt->filters.filptr, lfull, l, NULL, NULL, NULL);
-}
-
-/* Reserved TLD (RFC 2606): a filter matching this too is not host-specific. */
-#define HTS_FOREIGN_PROBE_HOST "unnamed.invalid"
-
 hts_boolean hts_link_is_foreign_asset(httrackp *opt, int ptr) {
   int parent;
 
   if (ptr <= 0)
     return HTS_FALSE;
   parent = heap(ptr)->precedent;
-  if (parent < 0 || parent >= opt->lien_tot)
+  /* Seeds hang off the synthetic primary link 0: the user asked for those. */
+  if (parent <= 0 || parent >= opt->lien_tot)
     return HTS_FALSE;
   if (ishtml(opt, heap(ptr)->fil) != 0) /* hypertext, or no telling */
     return HTS_FALSE;
-  if (strfield2(heap(ptr)->adr, heap(parent)->adr))
-    return HTS_FALSE;
-  /* A rule that stops matching once the host changes names that host, so the
-     user asked for this site by name: leave its depth alone. */
-  return (hts_filters_verdict(opt, heap(ptr)->adr, heap(ptr)->fil) == 1 &&
-          hts_filters_verdict(opt, HTS_FOREIGN_PROBE_HOST, heap(ptr)->fil) != 1)
-             ? HTS_FALSE
-             : HTS_TRUE;
+  return strfield2(heap(ptr)->adr, heap(parent)->adr) ? HTS_FALSE : HTS_TRUE;
 }
 
 // tester taille

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -941,7 +941,11 @@ hts_boolean hts_link_is_foreign_asset(httrackp *opt, int ptr) {
     return HTS_FALSE;
   if (ishtml(opt, heap(ptr)->fil) != 0) /* hypertext, or no telling */
     return HTS_FALSE;
-  return strfield2(heap(ptr)->adr, heap(parent)->adr) ? HTS_FALSE : HTS_TRUE;
+  /* adr carries the scheme and any user:pw@, so compare bare authorities. */
+  return strfield2(jump_identification_const(heap(ptr)->adr),
+                   jump_identification_const(heap(parent)->adr))
+             ? HTS_FALSE
+             : HTS_TRUE;
 }
 
 // tester taille

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -930,6 +930,52 @@ int hts_acceptmime(httrackp * opt, int ptr,
 #undef _ROBOTS
 }
 
+/* Filter verdict for a link (1 accepted, -1 refused, 0 undecided), fed the two
+   URL forms the wizard tests. */
+static int hts_filters_verdict(httrackp *opt, const char *adr,
+                               const char *fil) {
+  char BIGSTK l[HTS_URLMAXSIZE * 2];
+  char BIGSTK lfull[HTS_URLMAXSIZE * 2];
+
+  strcpybuff(l, jump_identification_const(adr));
+  if (*fil != '/')
+    strcatbuff(l, "/");
+  strcatbuff(l, fil);
+  if (!link_has_authority(adr))
+    strcpybuff(lfull, "http://");
+  else
+    lfull[0] = '\0';
+  strcatbuff(lfull, adr);
+  if (*fil != '/')
+    strcatbuff(lfull, "/");
+  strcatbuff(lfull, fil);
+  return fa_strjoker_dual(/*url */ 0, *opt->filters.filters,
+                          *opt->filters.filptr, lfull, l, NULL, NULL, NULL);
+}
+
+/* Reserved TLD (RFC 2606): a filter matching this too is not host-specific. */
+#define HTS_FOREIGN_PROBE_HOST "unnamed.invalid"
+
+hts_boolean hts_link_is_foreign_asset(httrackp *opt, int ptr) {
+  int parent;
+
+  if (ptr <= 0)
+    return HTS_FALSE;
+  parent = heap(ptr)->precedent;
+  if (parent < 0 || parent >= opt->lien_tot)
+    return HTS_FALSE;
+  if (ishtml(opt, heap(ptr)->fil) != 0) /* hypertext, or no telling */
+    return HTS_FALSE;
+  if (strfield2(heap(ptr)->adr, heap(parent)->adr))
+    return HTS_FALSE;
+  /* A rule that stops matching once the host changes names that host, so the
+     user asked for this site by name: leave its depth alone. */
+  return (hts_filters_verdict(opt, heap(ptr)->adr, heap(ptr)->fil) == 1 &&
+          hts_filters_verdict(opt, HTS_FOREIGN_PROBE_HOST, heap(ptr)->fil) != 1)
+             ? HTS_FALSE
+             : HTS_TRUE;
+}
+
 // tester taille
 int hts_testlinksize(httrackp * opt, const char *adr, const char *fil, LLint size) {
   int jok = 0;
@@ -954,7 +1000,7 @@ int hts_testlinksize(httrackp * opt, const char *adr, const char *fil, LLint siz
         lfull[0] = '\0';
       strcatbuff(lfull, adr);
       if (*fil != '/')
-        strcatbuff(l, "/");
+        strcatbuff(lfull, "/");
       strcatbuff(lfull, fil);
 
       // filters, 0=sait pas 1=ok -1=interdit

--- a/src/htswizard.h
+++ b/src/htswizard.h
@@ -70,8 +70,7 @@ typedef struct htspair_t {
 hts_boolean hts_cmp_tag_token(const char *tag, const char *cmp);
 
 /* HTS_TRUE when link `ptr` was taken for an asset on a host foreign to its
-   referer: its URL does not look like hypertext and no filter rule names that
-   host. Such a page may be stored but must not be scanned (#121). */
+   referer: its URL does not look like hypertext, and the hosts differ. */
 hts_boolean hts_link_is_foreign_asset(httrackp *opt, int ptr);
 
 int hts_acceptlink(httrackp * opt, int ptr,

--- a/src/htswizard.h
+++ b/src/htswizard.h
@@ -69,6 +69,11 @@ typedef struct htspair_t {
 /* HTS_TRUE if tag starts with the whole token cmp; NULL tag never matches. */
 hts_boolean hts_cmp_tag_token(const char *tag, const char *cmp);
 
+/* HTS_TRUE when link `ptr` was taken for an asset on a host foreign to its
+   referer: its URL does not look like hypertext and no filter rule names that
+   host. Such a page may be stored but must not be scanned (#121). */
+hts_boolean hts_link_is_foreign_asset(httrackp *opt, int ptr);
+
 int hts_acceptlink(httrackp * opt, int ptr,
                    const char *adr, const char *fil,
                    const char *tag, const char *attribute,

--- a/tests/252_local-nonhtml-foreign-depth.test
+++ b/tests/252_local-nonhtml-foreign-depth.test
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Issue #121: a link whose URL looks like an asset (".../distorted.jpg") on a
+# foreign host is taken for a file, then the server answers text/html. Its own
+# links are same-host, so scanning it with the referring page's depth budget
+# mirrors that whole site. On the unfixed engine the foreign host yields 3 files
+# under -n and 7 under +*.jpg, against the 1 page it is entitled to.
+set -eu
+
+: "${top_srcdir:=..}"
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_121.XXXXXX") || exit 1
+apid=
+bpid=
+cleanup() {
+    stop_server "$apid"
+    stop_server "$bpid"
+    rm -rf "$tmpdir"
+}
+trap 'set +e; cleanup' EXIT
+trap 'set +e; cleanup; exit 1' HUP INT QUIT PIPE TERM
+
+fail() {
+    echo "FAIL: $1"
+    exit 1
+}
+
+server=$(nativepath "${testdir}/local-server.py")
+mkdir -p "${tmpdir}/aroot" "${tmpdir}/broot"
+
+# The foreign host, answering text/html on every path under /foreign/.
+blog="${tmpdir}/b-server.log"
+: >"$blog"
+"$python" "$server" --root "$(nativepath "${tmpdir}/broot")" \
+    >"$blog" 2>&1 </dev/null &
+bpid=$!
+bport=$(discover_server_port "$blog" "$bpid") || exit 1
+
+# The crawled site: the foreign link, plus a chain of its own the crawl must
+# still walk to the end.
+cat >"${tmpdir}/aroot/index.html" <<EOF
+<html><body>
+<a href="http://127.0.0.1:${bport}/foreign/s/xxx/distorted.jpg">foreign</a>
+<a href="a1.html">local</a>
+</body></html>
+EOF
+printf '<html><body><a href="a2.html">deeper</a></body></html>\n' \
+    >"${tmpdir}/aroot/a1.html"
+printf '<html><body>leaf</body></html>\n' >"${tmpdir}/aroot/a2.html"
+
+alog="${tmpdir}/a-server.log"
+: >"$alog"
+"$python" "$server" --root "$(nativepath "${tmpdir}/aroot")" \
+    >"$alog" 2>&1 </dev/null &
+apid=$!
+aport=$(discover_server_port "$alog" "$apid") || exit 1
+
+which httrack >/dev/null || fail "could not find httrack"
+
+crawl() { # crawl <label> [httrack args...]
+    local label=$1
+    shift
+    httrack "http://127.0.0.1:${aport}/index.html" -O "${tmpdir}/out-${label}" \
+        --quiet --max-time=120 --timeout=30 --robots=0 "$@" \
+        >"${tmpdir}/crawl-${label}.log" 2>&1 || fail "crawl ${label} failed"
+}
+
+mirrored() { # mirrored <label> <port>
+    local dir="${tmpdir}/out-$1/127.0.0.1_$2"
+    test -d "$dir" || return 0
+    find "$dir" -type f | sed "s#^${dir}/##" | sort
+}
+
+check() { # check <label> <host port> <expected listing>
+    local got
+    got=$(mirrored "$1" "$2")
+    test "$got" = "$3" || fail "$1: mirror of 127.0.0.1:$2 holds
+${got}
+expected
+$3"
+}
+
+# One page, plus the .readme the store-without-scan path leaves beside it.
+kept="foreign/s/xxx/distorted.html
+foreign/s/xxx/distorted.html.readme"
+# What scanning that page reaches: the server's chain and its embedded image.
+scanned="foreign/s/xxx/c1.html
+foreign/s/xxx/c2.html
+foreign/s/xxx/c3.html
+foreign/s/xxx/c4.html
+foreign/s/xxx/c5.html
+foreign/s/xxx/distorted.html
+foreign/s/xxx/pic.html"
+# Negative control: same-host recursion is untouched and still reaches a2.
+local_pages="a1.html
+a2.html
+index.html"
+
+# Near links (-n), then the scan rule WinHTTrack ships by default.
+crawl near -n
+check near "$bport" "$kept"
+check near "$aport" "$local_pages"
+test -s "${tmpdir}/out-near/127.0.0.1_${bport}/foreign/s/xxx/distorted.html" ||
+    fail "the foreign page was not stored"
+
+crawl jpg '+*.jpg'
+check jpg "$bport" "$kept"
+check jpg "$aport" "$local_pages"
+
+crawl jpgnear -n '+*.jpg'
+check jpgnear "$bport" "$kept"
+
+# A rule naming the host asks for that site: it keeps its depth and is scanned.
+crawl hostrule "+127.0.0.1:${bport}/*"
+check hostrule "$bport" "$scanned"
+check hostrule "$aport" "$local_pages"
+
+# Without either, the foreign link is out of scope to begin with.
+crawl none
+check none "$bport" ""
+check none "$aport" "$local_pages"

--- a/tests/252_local-nonhtml-foreign-depth.test
+++ b/tests/252_local-nonhtml-foreign-depth.test
@@ -1,9 +1,7 @@
 #!/bin/bash
-# Issue #121: a link whose URL looks like an asset (".../distorted.jpg") on a
-# foreign host is taken for a file, then the server answers text/html. Its own
-# links are same-host, so scanning it with the referring page's depth budget
-# mirrors that whole site. On the unfixed engine the foreign host yields 3 files
-# under -n and 7 under +*.jpg, against the 1 page it is entitled to.
+# Issue #121: a URL that looks like an asset (".../distorted.jpg") on a foreign
+# host, answered with text/html, must be stored and not scanned. The unfixed
+# engine mirrored 3 files of that host under -n and 7 under +*.jpg, against 1.
 set -eu
 
 : "${top_srcdir:=..}"
@@ -40,17 +38,27 @@ blog="${tmpdir}/b-server.log"
 bpid=$!
 bport=$(discover_server_port "$blog" "$bpid") || exit 1
 
-# The crawled site: the foreign link, plus a chain of its own the crawl must
-# still walk to the end.
+# The crawled site: the foreign link, a chain of its own, and the same shape of
+# asset-looking HTML page served by A itself.
 cat >"${tmpdir}/aroot/index.html" <<EOF
 <html><body>
 <a href="http://127.0.0.1:${bport}/foreign/s/xxx/distorted.jpg">foreign</a>
+<a href="/foreign/local/thing.jpg">same host</a>
 <a href="a1.html">local</a>
 </body></html>
 EOF
 printf '<html><body><a href="a2.html">deeper</a></body></html>\n' \
     >"${tmpdir}/aroot/a1.html"
 printf '<html><body>leaf</body></html>\n' >"${tmpdir}/aroot/a2.html"
+# Reached on its own, so the other runs stay free of these fetches.
+cat >"${tmpdir}/aroot/assets.html" <<EOF
+<html><head>
+<link rel="stylesheet" href="http://127.0.0.1:${bport}/asset/style.css">
+<script src="http://127.0.0.1:${bport}/asset/script.js"></script>
+</head><body>
+<img src="http://127.0.0.1:${bport}/asset/vector.svg">
+</body></html>
+EOF
 
 alog="${tmpdir}/a-server.log"
 : >"$alog"
@@ -61,11 +69,11 @@ aport=$(discover_server_port "$alog" "$apid") || exit 1
 
 which httrack >/dev/null || fail "could not find httrack"
 
-crawl() { # crawl <label> [httrack args...]
-    local label=$1
-    shift
-    httrack "http://127.0.0.1:${aport}/index.html" -O "${tmpdir}/out-${label}" \
-        --quiet --max-time=120 --timeout=30 --robots=0 "$@" \
+crawl() { # crawl <label> <start path> [httrack args...]
+    local label=$1 start=$2
+    shift 2
+    httrack "http://127.0.0.1:${aport}${start}" -O "${tmpdir}/out-${label}" \
+        --quiet --max-time=120 --timeout=30 --robots=0 --debug-log "$@" \
         >"${tmpdir}/crawl-${label}.log" 2>&1 || fail "crawl ${label} failed"
 }
 
@@ -84,6 +92,18 @@ expected
 $3"
 }
 
+# The engine must say why it stopped, or a pass could come from any refusal.
+check_noted() { # check_noted <label>
+    grep -aq 'not scanning .*an HTML page on a host foreign' \
+        "${tmpdir}/out-$1/hts-log.txt" ||
+        fail "$1: the crawl log does not record the skipped scan"
+}
+
+stored() { # stored <label> <port> <path>
+    test -s "${tmpdir}/out-$1/127.0.0.1_$2/$3" ||
+        fail "$1: $3 is missing or empty"
+}
+
 # One page, plus the .readme the store-without-scan path leaves beside it.
 kept="foreign/s/xxx/distorted.html
 foreign/s/xxx/distorted.html.readme"
@@ -95,31 +115,62 @@ foreign/s/xxx/c4.html
 foreign/s/xxx/c5.html
 foreign/s/xxx/distorted.html
 foreign/s/xxx/pic.html"
-# Negative control: same-host recursion is untouched and still reaches a2.
-local_pages="a1.html
+# Guards the fix against over-firing: A's own chain, and A's own asset-looking
+# HTML page, which is same-host and must still be scanned in full.
+untouched="a1.html
 a2.html
+foreign/local/c1.html
+foreign/local/c2.html
+foreign/local/c3.html
+foreign/local/c4.html
+foreign/local/c5.html
+foreign/local/pic.html
+foreign/local/thing.html
 index.html"
 
-# Near links (-n), then the scan rule WinHTTrack ships by default.
-crawl near -n
+# Near links (-n), then the scan rule that matches by extension.
+crawl near /index.html -n
 check near "$bport" "$kept"
-check near "$aport" "$local_pages"
-test -s "${tmpdir}/out-near/127.0.0.1_${bport}/foreign/s/xxx/distorted.html" ||
-    fail "the foreign page was not stored"
+check near "$aport" "$untouched"
+check_noted near
+stored near "$bport" foreign/s/xxx/distorted.html
 
-crawl jpg '+*.jpg'
+crawl jpg /index.html '+*.jpg'
 check jpg "$bport" "$kept"
-check jpg "$aport" "$local_pages"
+check jpg "$aport" "$untouched"
+check_noted jpg
+stored jpg "$bport" foreign/s/xxx/distorted.html
 
-crawl jpgnear -n '+*.jpg'
+crawl jpgnear /index.html -n '+*.jpg'
 check jpgnear "$bport" "$kept"
+check_noted jpgnear
+stored jpgnear "$bport" foreign/s/xxx/distorted.html
 
-# A rule naming the host asks for that site: it keeps its depth and is scanned.
-crawl hostrule "+127.0.0.1:${bport}/*"
-check hostrule "$bport" "$scanned"
-check hostrule "$aport" "$local_pages"
+# Naming the host in a rule does not buy the page a scan: only a seed does.
+crawl hostrule /index.html "+127.0.0.1:${bport}/*"
+check hostrule "$bport" "$kept"
+check hostrule "$aport" "$untouched"
 
-# Without either, the foreign link is out of scope to begin with.
-crawl none
+# A seeded host is its own referer, so nothing is foreign to it.
+httrack "http://127.0.0.1:${aport}/index.html" \
+    "http://127.0.0.1:${bport}/foreign/s/xxx/distorted.jpg" \
+    -O "${tmpdir}/out-seed" --quiet --max-time=120 --timeout=30 --robots=0 \
+    >"${tmpdir}/crawl-seed.log" 2>&1 || fail "crawl seed failed"
+check seed "$bport" "$scanned"
+
+# A foreign asset honestly typed is still parsed for what it references: the
+# clamp is for an HTML page, not for every content type httrack scans.
+crawl assets /assets.html '+*.css' '+*.js' '+*.svg' '+*.png'
+for f in asset/style.css asset/script.js asset/vector.svg \
+    asset/bg.png asset/inner.png; do
+    stored assets "$bport" "$f"
+done
+for f in asset/style.css asset/script.js asset/vector.svg; do
+    test ! -e "${tmpdir}/out-assets/127.0.0.1_${bport}/${f}.readme" ||
+        fail "assets: ${f} was stored without a scan"
+done
+
+# Without a rule or -n, the foreign link is out of scope to begin with.
+crawl none /index.html
 check none "$bport" ""
-check none "$aport" "$local_pages"
+check none "$aport" "$untouched"

--- a/tests/252_local-nonhtml-foreign-depth.test
+++ b/tests/252_local-nonhtml-foreign-depth.test
@@ -38,12 +38,19 @@ blog="${tmpdir}/b-server.log"
 bpid=$!
 bport=$(discover_server_port "$blog" "$bpid") || exit 1
 
-# The crawled site: the foreign link, a chain of its own, and the same shape of
-# asset-looking HTML page served by A itself.
+alog="${tmpdir}/a-server.log"
+: >"$alog"
+"$python" "$server" --root "$(nativepath "${tmpdir}/aroot")" \
+    >"$alog" 2>&1 </dev/null &
+apid=$!
+aport=$(discover_server_port "$alog" "$apid") || exit 1
+
+# Written once A's port is known, since the same-host asset link has to be
+# absolute: a relative one would inherit whatever userinfo the crawl entered by.
 cat >"${tmpdir}/aroot/index.html" <<EOF
 <html><body>
 <a href="http://127.0.0.1:${bport}/foreign/s/xxx/distorted.jpg">foreign</a>
-<a href="/foreign/local/thing.jpg">same host</a>
+<a href="http://127.0.0.1:${aport}/foreign/local/thing.jpg">same host</a>
 <a href="a1.html">local</a>
 </body></html>
 EOF
@@ -59,13 +66,6 @@ cat >"${tmpdir}/aroot/assets.html" <<EOF
 <img src="http://127.0.0.1:${bport}/asset/vector.svg">
 </body></html>
 EOF
-
-alog="${tmpdir}/a-server.log"
-: >"$alog"
-"$python" "$server" --root "$(nativepath "${tmpdir}/aroot")" \
-    >"$alog" 2>&1 </dev/null &
-apid=$!
-aport=$(discover_server_port "$alog" "$apid") || exit 1
 
 which httrack >/dev/null || fail "could not find httrack"
 
@@ -150,6 +150,15 @@ stored jpgnear "$bport" foreign/s/xxx/distorted.html
 crawl hostrule /index.html "+127.0.0.1:${bport}/*"
 check hostrule "$bport" "$kept"
 check hostrule "$aport" "$untouched"
+
+# Entering through credentials puts them in the referer's address but not in
+# the page's own absolute links, which must still count as the same host.
+httrack "http://user:pw@127.0.0.1:${aport}/index.html" \
+    -O "${tmpdir}/out-userinfo" --quiet --max-time=120 --timeout=30 \
+    --robots=0 -n '+*.jpg' \
+    >"${tmpdir}/crawl-userinfo.log" 2>&1 || fail "crawl userinfo failed"
+check userinfo "$aport" "$untouched"
+check userinfo "$bport" "$kept"
 
 # A seeded host is its own referer, so nothing is foreign to it.
 httrack "http://127.0.0.1:${aport}/index.html" \

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -2441,11 +2441,10 @@ class Handler(SimpleHTTPRequestHandler):
             "text/html; charset=" + self.SINGLEFILE_MARK_CHARSET,
         )
 
-    # A host answering text/html on every path whatever the extension, like the
-    # dropbox preview page of #121; the chain is what scanning one would pull in.
     FOREIGN_CHAIN = 5
 
     def route_foreign(self):
+        # text/html on every path whatever the extension, and a chain to follow.
         name = urlsplit(self.path).path.rsplit("/", 1)[-1]
         step = re.fullmatch(r"c(\d+)\.html", name)
         n = int(step.group(1)) if step else 0
@@ -2455,6 +2454,28 @@ class Handler(SimpleHTTPRequestHandler):
             self.send_html(
                 '\t<a href="c%d.html">next</a>\n\t<img src="pic.png" />\n' % (n + 1)
             )
+
+    # Honestly typed assets, each referencing a file only a parse can find.
+    ASSETS = {
+        "/asset/style.css": (b"body { background: url(bg.png); }\n", "text/css"),
+        "/asset/script.js": (
+            b'var i = new Image(); i.src = "pic2.png";\n',
+            "application/x-javascript",
+        ),
+        "/asset/vector.svg": (
+            b'<svg xmlns="http://www.w3.org/2000/svg">'
+            b'<image href="inner.png" /></svg>\n',
+            "image/svg+xml",
+        ),
+    }
+
+    def route_asset(self):
+        path = urlsplit(self.path).path
+        if path in self.ASSETS:
+            body, ctype = self.ASSETS[path]
+            self.send_raw(body, ctype)
+        else:
+            self.send_raw(self.FAKE_PNG, "image/png")
 
     ROUTES = {
         "/sfmark.html": route_singlefile_mark,
@@ -2858,6 +2879,9 @@ class Handler(SimpleHTTPRequestHandler):
             return True
         if path.startswith("/foreign/"):
             self.route_foreign()
+            return True
+        if path.startswith("/asset/"):
+            self.route_asset()
             return True
         if path.startswith("/charset/"):
             self.route_charset()

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -2441,6 +2441,21 @@ class Handler(SimpleHTTPRequestHandler):
             "text/html; charset=" + self.SINGLEFILE_MARK_CHARSET,
         )
 
+    # A host answering text/html on every path whatever the extension, like the
+    # dropbox preview page of #121; the chain is what scanning one would pull in.
+    FOREIGN_CHAIN = 5
+
+    def route_foreign(self):
+        name = urlsplit(self.path).path.rsplit("/", 1)[-1]
+        step = re.fullmatch(r"c(\d+)\.html", name)
+        n = int(step.group(1)) if step else 0
+        if name == "pic.png" or n >= self.FOREIGN_CHAIN:
+            self.send_html("")
+        else:
+            self.send_html(
+                '\t<a href="c%d.html">next</a>\n\t<img src="pic.png" />\n' % (n + 1)
+            )
+
     ROUTES = {
         "/sfmark.html": route_singlefile_mark,
         "/cookies/entrance.php": route_entrance,
@@ -2840,6 +2855,9 @@ class Handler(SimpleHTTPRequestHandler):
         path = urlsplit(self.path).path
         if path.startswith("/big/"):
             self.route_big()
+            return True
+        if path.startswith("/foreign/"):
+            self.route_foreign()
             return True
         if path.startswith("/charset/"):
             self.route_charset()


### PR DESCRIPTION
A link to `https://www.dropbox.com/s/xxx/distorted.jpg` looks like a file, so the engine accepts it even though it points off-site. Dropbox answers with `text/html`, and the preview page is then parsed with the referring page's whole depth budget. Every link on it is same-host from there, so one link mirrors the entire foreign site: 372 files in the reproduction against the one page it was entitled to, and wikipedia `File:` pages do the same. The new test drives two loopback servers and pins the mirror of the foreign one, which held 3 files under `-n` and 7 under `+*.jpg` before the fix.

At the parse gate such a link's depth now counts as 0, so the page is still fetched and stored, through the store-without-scan path a depth limit already uses, but nothing on it is followed. The gate is `is_html_mime_type()` rather than the wider hypertext set, or a foreign stylesheet would stop being parsed and its images would go missing; the one cost is a typeless response, which that macro reads as HTML and which now picks up a stray `.readme`. Hosts are compared through `jump_identification_const()`, since `adr` carries the scheme and any `user:pw@` and a raw compare made a site foreign to itself. Nothing about filters enters into it: the only exemption is being a seed, which the user asked for by name. Also fixes `hts_testlinksize`, which built its filter URLs with the separator on the wrong buffer.

Closes #121
Closes #1095
