### PR TITLE
Run 230_local-ftp-userpass on Windows again

### DIFF
--- a/tests/230_local-ftp-userpass.test
+++ b/tests/230_local-ftp-userpass.test
@@ -11,12 +11,6 @@ testdir=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=tests/testlib.sh
 . "${testdir}/testlib.sh"
 
-# Starves the x64 CI runner until the whole suite step is lost; Win32 is fine (#1038).
-if is_windows; then
-    echo "windows: wedges the x64 runner (#1038), skipping"
-    exit 77
-fi
-
 python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
 command -v httrack >/dev/null || {
     echo "could not find httrack" >&2

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -273,7 +273,6 @@ echo "ran=$((pass + fail + skip)) pass=$pass fail=$fail skip=$skip" |
 # and needs the loader variable libtool picked, neither of which this job has;
 # link-control-bytes names its fixtures with the raw control bytes the requests
 # decode back to, which NTFS refuses;
-# ftp-userpass starves the x64 runner until the step is lost, Win32 passing (#1038);
 # memresume, repaircache and resume-recovery interrupt pass 1 with a signal
 # MSYS cannot deliver to a native exe;
 # ftp-deadhost-interrupt needs that same signal (its --timeout half runs, as 245).

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -286,7 +286,6 @@ expected_skips="01_engine-footer-overflow.test
 152_engine-string-oom.test
 153_local-proxytrack-quiet.test
 215_engine-datadir-ospath.test
-230_local-ftp-userpass.test
 243_local-ftp-deadhost-interrupt.test
 235_local-resume-recovery.test
 48_local-crange-memresume.test


### PR DESCRIPTION
The skip landed on a 3/3 wedge observed before #1039, #1055, #1071 and #1081 were in the tree. With all four merged, the test was re-run three times on current master with the gate and the `expected_skips` entry removed: six green legs, x64 and Win32, every run.

The runs were sequential on purpose. `windows-build`'s concurrency group is per-ref with `cancel-in-progress`, and overlapping Windows jobs are themselves a known way to lose a runner, so three parallel runs would have risked manufacturing the failure under test.

Detail and run IDs are on #1038.

Closes #1038