### PR TITLE
Tests 13 and 52 mint a cert the tree already ships

### DIFF
--- a/tests/13_crawl_proxy_https.test
+++ b/tests/13_crawl_proxy_https.test
@@ -16,8 +16,8 @@ if test "${HTTPS_SUPPORT:-}" == "no"; then
     exit 77
 fi
 python=$(find_python) || python=
-if test -z "$python" || ! command -v openssl >/dev/null 2>&1; then
-    echo "python3/openssl missing, skipping"
+if test -z "$python"; then
+    echo "python3 missing, skipping"
     exit 77
 fi
 

--- a/tests/254_testlib-tls-pem.test
+++ b/tests/254_testlib-tls-pem.test
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
-# The TLS fixture the crawl tests hand their python servers: the shipped cert
-# and key in one file, key first, the order load_cert_chain() documents.
+# make_tls_pem must hand back the shipped cert and key, not mint one.
 
 set -euo pipefail
 
@@ -21,19 +20,21 @@ ok() { echo "OK: $*"; }
 
 make_tls_pem "$tmpdir"
 
-# awk, not grep piped into head: the pipe would SIGPIPE the reader.
-keyline=$(awk '/BEGIN .*PRIVATE KEY/ { print NR; exit }' "$tmpdir/both.pem")
-certline=$(awk '/BEGIN CERTIFICATE/ { print NR; exit }' "$tmpdir/both.pem")
-test -n "$keyline" || fail "both.pem has no private key"
-test -n "$certline" || fail "both.pem has no certificate"
-test "$keyline" -lt "$certline" || fail "both.pem holds the certificate before the key"
-ok "make_tls_pem writes a key and then a certificate"
+# The shipped pair verbatim, key first, and not a fixture minted per run (#1099).
+cat "${testdir}/server.key" "${testdir}/server.crt" >"$tmpdir/want.pem"
+cmp -s "$tmpdir/both.pem" "$tmpdir/want.pem" ||
+    fail "both.pem is not tests/server.key followed by tests/server.crt"
+ok "make_tls_pem writes the shipped key and certificate"
 
-# The shipped pair verbatim, not a fixture minted per run (#1099).
-awk -v start="$certline" 'NR >= start' "$tmpdir/both.pem" >"$tmpdir/cert.pem"
-cmp -s "$tmpdir/cert.pem" "${testdir}/server.crt" ||
-    fail "both.pem does not carry tests/server.crt"
-awk -v end="$certline" 'NR < end' "$tmpdir/both.pem" >"$tmpdir/key.pem"
-cmp -s "$tmpdir/key.pem" "${testdir}/server.key" ||
-    fail "both.pem does not carry tests/server.key"
-ok "make_tls_pem hands back the shipped cert and key"
+# What the callers' servers actually do with it: a cert whose key does not match
+# passes the comparison above and still fails here.
+python=$(find_python) || python=
+if test -z "$python"; then
+    echo "python3 missing, skipping the load_cert_chain check"
+    exit 0
+fi
+"$python" -c 'import ssl, sys
+ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER).load_cert_chain(sys.argv[1])' \
+    "$(nativepath "$tmpdir/both.pem")" ||
+    fail "load_cert_chain rejected both.pem"
+ok "load_cert_chain accepts both.pem"

--- a/tests/254_testlib-tls-pem.test
+++ b/tests/254_testlib-tls-pem.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# A cert fixture that fails must say why: discarding openssl's output left tests
-# 13 and 52 exiting 1 with an empty log (#1094).
+# The TLS fixture the crawl tests hand their python servers: the shipped cert
+# and key in one file, key first, the order load_cert_chain() documents.
 
 set -euo pipefail
 
@@ -9,11 +9,6 @@ set -euo pipefail
 testdir=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=tests/testlib.sh
 . "${testdir}/testlib.sh"
-
-command -v openssl >/dev/null 2>&1 || {
-    echo "openssl not found; skipping" >&2
-    exit 77
-}
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_tlspem.XXXXXX")
 trap 'set +e; rm -rf "$tmpdir"' EXIT
@@ -24,53 +19,21 @@ fail() {
 }
 ok() { echo "OK: $*"; }
 
-# The working case first: a helper that never produces anything would otherwise
-# satisfy the failure case on its own.
-good="$tmpdir/good"
-mkdir -p "$good"
-make_tls_pem "$good"
+make_tls_pem "$tmpdir"
+
 # awk, not grep piped into head: the pipe would SIGPIPE the reader.
-keyline=$(awk '/BEGIN .*PRIVATE KEY/ { print NR; exit }' "$good/both.pem")
-certline=$(awk '/BEGIN CERTIFICATE/ { print NR; exit }' "$good/both.pem")
+keyline=$(awk '/BEGIN .*PRIVATE KEY/ { print NR; exit }' "$tmpdir/both.pem")
+certline=$(awk '/BEGIN CERTIFICATE/ { print NR; exit }' "$tmpdir/both.pem")
 test -n "$keyline" || fail "both.pem has no private key"
 test -n "$certline" || fail "both.pem has no certificate"
-# load_cert_chain() in the callers' servers reads this order.
 test "$keyline" -lt "$certline" || fail "both.pem holds the certificate before the key"
 ok "make_tls_pem writes a key and then a certificate"
 
-# Shim in an openssl that refuses, and require its reason to reach stderr.
-marker="openssl-stub-declined-to-issue"
-stub="$tmpdir/bin"
-broken="$tmpdir/broken"
-mkdir -p "$stub" "$broken"
-# The stub still writes the files it was asked for, so nothing but the helper's
-# own exit can make the status below non-zero.
-cat >"$stub/openssl" <<EOF
-#!/bin/sh
-while [ \$# -gt 0 ]; do
-    case \$1 in
-    -keyout | -out)
-        : >"\$2"
-        shift
-        ;;
-    esac
-    shift
-done
-echo "${marker}" >&2
-exit 3
-EOF
-chmod +x "$stub/openssl"
-
-rc=0
-err=$(
-    PATH="$stub:$PATH"
-    make_tls_pem "$broken" 2>&1 1>/dev/null
-) || rc=$?
-
-# Also proves the shim was reached: the real openssl here would exit 0.
-test "$rc" -eq 1 || fail "make_tls_pem exited ${rc}, want 1, with an openssl that exits 3"
-case "$err" in
-*"$marker"*) ;;
-*) fail "openssl's reason never reached stderr, got: '${err}'" ;;
-esac
-ok "a failing openssl is reported on stderr"
+# The shipped pair verbatim, not a fixture minted per run (#1099).
+awk -v start="$certline" 'NR >= start' "$tmpdir/both.pem" >"$tmpdir/cert.pem"
+cmp -s "$tmpdir/cert.pem" "${testdir}/server.crt" ||
+    fail "both.pem does not carry tests/server.crt"
+awk -v end="$certline" 'NR < end' "$tmpdir/both.pem" >"$tmpdir/key.pem"
+cmp -s "$tmpdir/key.pem" "${testdir}/server.key" ||
+    fail "both.pem does not carry tests/server.key"
+ok "make_tls_pem hands back the shipped cert and key"

--- a/tests/52_local-socks5.test
+++ b/tests/52_local-socks5.test
@@ -16,8 +16,8 @@ if test "${HTTPS_SUPPORT:-}" == "no"; then
     exit 77
 fi
 python=$(find_python) || python=
-if test -z "$python" || ! command -v openssl >/dev/null 2>&1; then
-    echo "python3/openssl missing, skipping"
+if test -z "$python"; then
+    echo "python3 missing, skipping"
     exit 77
 fi
 

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -24,8 +24,7 @@ nativepath() {
     fi
 }
 
-# The shipped cert and key joined into $1/both.pem, the single path
-# load_cert_chain() takes, key first as it documents.
+# Key before cert in $1/both.pem, the single path load_cert_chain() takes.
 make_tls_pem() {
     local dir=$1 src
     src=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -24,16 +24,15 @@ nativepath() {
     fi
 }
 
-# Self-signed cert for a local TLS origin, written to $1/both.pem, key first.
-# openssl's failure output is reported; discarding it left an empty log (#1094).
+# The shipped cert and key joined into $1/both.pem, the single path
+# load_cert_chain() takes, key first as it documents.
 make_tls_pem() {
-    local dir=$1 out
-    out=$(openssl req -x509 -newkey rsa:2048 -keyout "$dir/key.pem" \
-        -out "$dir/cert.pem" -days 2 -nodes -subj "/CN=127.0.0.1" 2>&1) || {
-        echo "FAIL: openssl req could not create a self-signed cert: $out" >&2
+    local dir=$1 src
+    src=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+    cat "$src/server.key" "$src/server.crt" >"$dir/both.pem" || {
+        echo "FAIL: cannot read the test cert fixture under $src" >&2
         exit 1
     }
-    cat "$dir/key.pem" "$dir/cert.pem" >"$dir/both.pem"
 }
 
 # Longest surviving run of char $2 in file $1, or 0: the length a field was

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -29,7 +29,7 @@ make_tls_pem() {
     local dir=$1 src
     src=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
     cat "$src/server.key" "$src/server.crt" >"$dir/both.pem" || {
-        echo "FAIL: cannot read the test cert fixture under $src" >&2
+        echo "FAIL: could not write $dir/both.pem from the fixture in $src" >&2
         exit 1
     }
 }


### PR DESCRIPTION
Both tests minted a two-day self-signed cert with `openssl req` on every run, which is why each carried `command -v openssl` in its skip gate. `make_tls_pem` now joins the tracked `tests/server.crt` and `tests/server.key`, the pair `local-crawl.sh` already hands every `--tls` crawl and the better cert besides: `subjectAltName = IP:127.0.0.1, DNS:localhost` instead of a bare CN, valid to 2056. With the gate gone the two tests run wherever python3 does.

Test 254 follows the helper: it compares both.pem against the shipped pair, so a quiet return to minting reds it, and then loads the file the way the python servers do, so a key that stops matching the cert reds it too.

Closes #1099
