### PR TITLE
A runner-image apt 403 reds a whole job, and the FTP active-mode branch never compiles

### DIFF
--- a/.github/workflows/appstream-network.yml
+++ b/.github/workflows/appstream-network.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install appstreamcli
         run: |
           set -euo pipefail
-          sudo apt-get update
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           sudo apt-get install -y --no-install-recommends appstream
           appstreamcli --version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install build dependencies
         run: |
           set -euo pipefail
-          sudo apt-get update
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           sudo apt-get install -y --no-install-recommends \
             build-essential clang autoconf automake libtool autoconf-archive \
             zlib1g-dev libssl-dev libbrotli-dev libzstd-dev \
@@ -80,6 +80,26 @@ jobs:
       - name: Build
         run: make -j"$(nproc)"
 
+      # FTP_PASV is 1 in every build, so #if !FTP_PASV never reaches a compiler
+      # and rots unnoticed (#1091). Rebuilt through make, to get the same flags
+      # the real object gets, then dropped so `make check` links a normal one.
+      - name: Compile the FTP active-mode branch
+        run: |
+          set -euo pipefail
+          objs="src/libhttrack_la-htsftp.lo src/libhttrack_la-htsftp.o src/.libs/libhttrack_la-htsftp.o"
+          rm -f $objs
+          log=$(make -C src libhttrack_la-htsftp.lo CPPFLAGS=-DFTP_PASV=0 2>&1) || { echo "$log"; exit 1; }
+          # Only the active branch calls accept(): without this the probe would
+          # pass just as well on a file that ignored -DFTP_PASV=0 entirely.
+          syms=$(nm --undefined-only src/.libs/libhttrack_la-htsftp.o)
+          grep -qw accept <<<"$syms" || { echo "::error::FTP_PASV=0 built no active-mode code"; exit 1; }
+          if grep -q 'warning:' <<<"$log"; then
+            echo "$log"
+            echo "::error::the FTP active-mode branch does not compile warning-free"
+            exit 1
+          fi
+          rm -f $objs
+
       # A backstop only: tests/test-timeout.sh bounds each test, and a healthy run
       # is a minute here, two on macOS. Without it a stall ran to the job's 6h default.
       - name: Test
@@ -108,7 +128,7 @@ jobs:
       - name: Install build dependencies
         run: |
           set -euo pipefail
-          sudo apt-get update
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           sudo apt-get install -y --no-install-recommends \
             build-essential autoconf automake libtool autoconf-archive \
             zlib1g-dev libssl-dev libbrotli-dev libzstd-dev
@@ -292,7 +312,7 @@ jobs:
       - name: Install build dependencies
         run: |
           set -euo pipefail
-          sudo apt-get update
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           sudo apt-get install -y --no-install-recommends \
             build-essential autoconf automake libtool autoconf-archive \
             zlib1g-dev libssl-dev libbrotli-dev libzstd-dev
@@ -401,7 +421,7 @@ jobs:
         run: |
           set -euo pipefail
           sudo dpkg --add-architecture i386
-          sudo apt-get update
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           sudo apt-get install -y --no-install-recommends \
             build-essential gcc-multilib autoconf automake libtool \
             autoconf-archive zlib1g-dev:i386 libssl-dev:i386 \
@@ -444,7 +464,7 @@ jobs:
       - name: Install build dependencies
         run: |
           set -euo pipefail
-          sudo apt-get update
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           sudo apt-get install -y --no-install-recommends \
             build-essential autoconf automake libtool autoconf-archive \
             zlib1g-dev libssl-dev libbrotli-dev libzstd-dev
@@ -499,7 +519,7 @@ jobs:
       - name: Install build dependencies
         run: |
           set -euo pipefail
-          sudo apt-get update
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           sudo apt-get install -y --no-install-recommends \
             build-essential clang autoconf automake libtool autoconf-archive \
             zlib1g-dev
@@ -548,7 +568,7 @@ jobs:
       - name: Install build dependencies
         run: |
           set -euo pipefail
-          sudo apt-get update
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           sudo apt-get install -y --no-install-recommends \
             build-essential clang autoconf automake libtool autoconf-archive \
             zlib1g-dev libssl-dev libbrotli-dev libzstd-dev
@@ -584,7 +604,7 @@ jobs:
       - name: Install build dependencies
         run: |
           set -euo pipefail
-          sudo apt-get update
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           sudo apt-get install -y --no-install-recommends \
             build-essential clang autoconf automake libtool autoconf-archive \
             zlib1g-dev libssl-dev libbrotli-dev libzstd-dev
@@ -614,7 +634,7 @@ jobs:
       - name: Install build dependencies (no libssl)
         run: |
           set -euo pipefail
-          sudo apt-get update
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           sudo apt-get install -y --no-install-recommends \
             build-essential autoconf automake libtool autoconf-archive zlib1g-dev
 
@@ -651,7 +671,7 @@ jobs:
       - name: Install build dependencies
         run: |
           set -euo pipefail
-          sudo apt-get update
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           sudo apt-get install -y --no-install-recommends \
             build-essential autoconf automake libtool autoconf-archive \
             zlib1g-dev libssl-dev libbrotli-dev libzstd-dev
@@ -730,7 +750,7 @@ jobs:
       - name: Install build dependencies
         run: |
           set -euo pipefail
-          sudo apt-get update
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           sudo apt-get install -y --no-install-recommends \
             build-essential autoconf automake libtool autoconf-archive \
             zlib1g-dev libssl-dev libbrotli-dev libzstd-dev
@@ -800,7 +820,7 @@ jobs:
       - name: Install linters
         run: |
           set -euo pipefail
-          sudo apt-get update
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           # noble ships shfmt 3.8.0 (universe), matching the pinned local dev
           # version; use it rather than fetching a release binary from github.com.
           sudo apt-get install -y --no-install-recommends shellcheck shfmt appstream \
@@ -859,7 +879,7 @@ jobs:
             | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc >/dev/null
           echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" \
             | sudo tee /etc/apt/sources.list.d/llvm-19.list >/dev/null
-          sudo apt-get update
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           sudo apt-get install -y --no-install-recommends clang-format-19
           # The clang-format-19 package ships the git-clang-format driver;
           # expose it unsuffixed so "git clang-format" finds it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,23 +81,24 @@ jobs:
         run: make -j"$(nproc)"
 
       # FTP_PASV is 1 in every build, so #if !FTP_PASV never reaches a compiler
-      # and rots unnoticed (#1091). Rebuilt through make, to get the same flags
-      # the real object gets, then dropped so `make check` links a normal one.
+      # and rots unnoticed (#1091). Compiling is all this proves; nothing runs it.
       - name: Compile the FTP active-mode branch
         run: |
           set -euo pipefail
           objs="src/libhttrack_la-htsftp.lo src/libhttrack_la-htsftp.o src/.libs/libhttrack_la-htsftp.o"
-          rm -f $objs
-          log=$(make -C src libhttrack_la-htsftp.lo CPPFLAGS=-DFTP_PASV=0 2>&1) || { echo "$log"; exit 1; }
-          # Only the active branch calls accept(): without this the probe would
-          # pass just as well on a file that ignored -DFTP_PASV=0 entirely.
+          # accept() marks active-mode code: absent from the object Build made,
+          # present below. One-sided, it passes on a file that ignored the define.
           syms=$(nm --undefined-only src/.libs/libhttrack_la-htsftp.o)
-          grep -qw accept <<<"$syms" || { echo "::error::FTP_PASV=0 built no active-mode code"; exit 1; }
-          if grep -q 'warning:' <<<"$log"; then
-            echo "$log"
-            echo "::error::the FTP active-mode branch does not compile warning-free"
+          if grep -qw accept <<<"$syms"; then
+            echo "::error::accept() is reachable with FTP_PASV=1; the marker no longer discriminates"
             exit 1
           fi
+          rm -f $objs
+          # Through CC: overriding CPPFLAGS would drop configure's
+          # -D_FORTIFY_SOURCE and the object-size warnings that come with it.
+          make -C src libhttrack_la-htsftp.lo CC="$CC -DFTP_PASV=0 -Werror"
+          syms=$(nm --undefined-only src/.libs/libhttrack_la-htsftp.o)
+          grep -qw accept <<<"$syms" || { echo "::error::-DFTP_PASV=0 built no active-mode code"; exit 1; }
           rm -f $objs
 
       # A backstop only: tests/test-timeout.sh bounds each test, and a healthy run

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install build dependencies
         run: |
           set -euo pipefail
-          sudo apt-get update
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           sudo apt-get install -y --no-install-recommends \
             build-essential autoconf automake libtool autoconf-archive \
             zlib1g-dev libssl-dev

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install build dependencies
         run: |
           set -euo pipefail
-          sudo apt-get update
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           sudo apt-get install -y --no-install-recommends \
             build-essential autoconf automake libtool autoconf-archive \
             zlib1g-dev libssl-dev libbrotli-dev libzstd-dev

--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -56,8 +56,10 @@ Please visit our Website: http://www.httrack.com
 #endif
 #endif
 
-// ftp mode passif
+/* Passive FTP; overridable so CI can compile the active branch (#1091). */
+#ifndef FTP_PASV
 #define FTP_PASV 1
+#endif
 
 #define FTP_DEBUG 0
 


### PR DESCRIPTION
Two CI gaps, in one PR because both land in `.github/workflows` and would collide.

`apt-get update` runs in 19 jobs under `set -euo pipefail`, so a 403 from `packages.microsoft.com`, a source the runner image ships and we never install from, takes a job down before a single package arrives. It reads like a real failure too: on #1093 the leg that died was named `msan (MemorySanitizer, clang)`. The update is now advisory in the 16 jobs that run on a GitHub runner, and `apt-get install` still fails loudly if a package we do need is missing. The three container jobs keep the strict form, since every source in a `ubuntu:devel` or `debian:sid` image is one we put there.

`FTP_PASV` is 1 in every build, so the `#if !FTP_PASV` active-mode branch is dead at runtime and never reaches a compiler either, which left #1087 re-verifying it by hand. The `build` job now recompiles `htsftp.c` alone with `-DFTP_PASV=0` and fails on any warning, which is why the define grew an `#ifndef` guard. It goes through make, so the object gets the flags the real one gets, and is dropped afterwards so `make check` links a normal library. The control is an undefined `accept` in that object: only the active branch calls it, so a probe that quietly rebuilt passive mode fails instead of passing. Two mutants kill the probe, a stray warning inside the branch and a revert of the `#ifndef`.

Closes #1091
Closes #1097
