### PR TITLE
The htsserver tests copy five helpers per file, and the copies have drifted

### DIFF
--- a/tests/141_webhttrack-warc-options.test
+++ b/tests/141_webhttrack-warc-options.test
@@ -7,19 +7,10 @@ set -euo pipefail
 testdir=$(cd "$(dirname "$0")" && pwd)
 distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
 distdir=$(cd "${distdir}" && pwd)
-# shellcheck source=tests/testlib.sh
-. "${testdir}/testlib.sh"
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
-
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-python=$(find_python) || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
+htsserver_require
 
 printf '[project reload maps the keys back] ..\t'
 for key in Warc:warc WarcFile:warcfile WarcMaxSize:warcmaxsize WarcCdx:warccdx Wacz:wacz; do
@@ -29,41 +20,17 @@ done
 echo OK
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_warc.XXXXXX") || fail "no tmpdir"
-srvlog=$(mktemp)
-srv=
-srvpid=
 cleanup() {
-    # htsserver keeps SIGTERM ignored across its exec, so only -9 reaps it.
-    test -z "${srvpid}" || kill -9 "${srvpid}" 2>/dev/null || true
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
-    wait "${srv}" 2>/dev/null || true # absorb bash's async "Killed" notice
-    rm -rf "${work}" "${srvlog}"
+    htsserver_cleanup
+    rm -rf "${work}"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
 
 printf '[webhttrack emits the WARC options] ..\t'
-# An isolated HOME keeps a stray ~/.httrack.ini out of the served settings.
-sport=$("${python}" -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()')
-(
-    trap '' TERM TTOU
-    export HOME="${work}"
-    exec htsserver "${distdir}/" --port "${sport}" >"${srvlog}" 2>&1
-) &
-srv=$!
-for _ in $(seq 1 40); do
-    url=$(sed -n 's/^URL=//p' "${srvlog}") && test -n "${url}" && break
-    kill -0 "${srv}" 2>/dev/null || break
-    sleep 0.25
-done
-test -n "${url:-}" || fail "htsserver did not start: $(cat "${srvlog}")"
-srvpid=$(sed -n 's/^PID=//p' "${srvlog}") # absent on Windows
+htsserver_start --home "${work}"
 
-"${python}" - "${url}" <<'PY' || fail "the WARC controls are not wired (see above)"
+"${HTS_PYTHON}" - "${HTS_URL}" <<'PY' || fail "the WARC controls are not wired (see above)"
 import re, sys, urllib.parse, urllib.request
 
 url = sys.argv[1].rstrip("/")

--- a/tests/142_webhttrack-content-type.test
+++ b/tests/142_webhttrack-content-type.test
@@ -8,19 +8,10 @@ set -euo pipefail
 testdir=$(cd "$(dirname "$0")" && pwd)
 distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
 distdir=$(cd "${distdir}" && pwd)
-# shellcheck source=tests/testlib.sh
-. "${testdir}/testlib.sh"
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
-
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-python=$(find_python) || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
+htsserver_require
 
 # The GUI assets asserted below have to exist, or every check goes vacuous.
 for asset in server/ping.js server/style.css images/screenshot_01.jpg \
@@ -30,15 +21,9 @@ for asset in server/ping.js server/style.css images/screenshot_01.jpg \
 done
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_ctype.XXXXXX") || fail "no tmpdir"
-srvlog=$(mktemp)
-srv=
-srvpid=
 cleanup() {
-    # htsserver keeps SIGTERM ignored across its exec, so only -9 reaps it.
-    test -z "${srvpid}" || kill -9 "${srvpid}" 2>/dev/null || true
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
-    wait "${srv}" 2>/dev/null || true # absorb bash's async "Killed" notice
-    rm -rf "${work}" "${srvlog}"
+    htsserver_cleanup
+    rm -rf "${work}"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
@@ -69,28 +54,10 @@ printf 'blob\n' >"${proj}/photos.css/plain"
 printf '<html>MIRROR-RAW ${_sid} ${LANG_WHATEVER}</html>\n' >"${proj}/page.html"
 printf '<html>MIRROR-HTM</html>\n' >"${proj}/Legacy.HtM"
 
-# An isolated HOME keeps a stray ~/.httrack.ini out of the server's settings.
-sport=$("${python}" -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()')
-(
-    trap '' TERM TTOU
-    export HOME="${work}"
-    exec htsserver "${distdir}/" --port "${sport}" >"${srvlog}" 2>&1
-) &
-srv=$!
-for _ in $(seq 1 40); do
-    url=$(sed -n 's/^URL=//p' "${srvlog}") && test -n "${url}" && break
-    kill -0 "${srv}" 2>/dev/null || break
-    sleep 0.25
-done
-test -n "${url:-}" || fail "htsserver did not start: $(cat "${srvlog}")"
-srvpid=$(sed -n 's/^PID=//p' "${srvlog}") # absent on Windows
+htsserver_start --home "${work}"
 
 # htsserver resolves the posted paths itself, so hand it native ones.
-"${python}" - "${url}" "$(nativepath "${work}/websites")" <<'PY' || fail "content-type checks failed"
+"${HTS_PYTHON}" - "${HTS_URL}" "$(nativepath "${work}/websites")" <<'PY' || fail "content-type checks failed"
 import re, socket, sys, urllib.parse, urllib.request
 
 url, base = sys.argv[1].rstrip("/"), sys.argv[2]
@@ -198,8 +165,7 @@ check_type("/website/Legacy.HtM", "text/html")
 sys.exit(rc)
 PY
 
-# A leaked htsserver wedges the parallel harness behind a green log.
-cleanup
-! kill -0 "${srv}" 2>/dev/null || fail "htsserver ${srv} survived"
+htsserver_cleanup
+htsserver_assert_reaped
 
 echo "PASS"

--- a/tests/185_webhttrack-js-escaping.test
+++ b/tests/185_webhttrack-js-escaping.test
@@ -6,24 +6,14 @@
 set -euo pipefail
 
 testdir=$(cd "$(dirname "$0")" && pwd)
-distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
-distdir=$(cd "${distdir}" && pwd)
-# shellcheck source=tests/testlib.sh
-. "${testdir}/testlib.sh"
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
-
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-python=$(find_python) || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
+htsserver_require
+distdir=${HTS_DISTDIR}
 
 printf '[each template escapes for the position it interpolates into] ..\t'
-"${python}" - "${distdir}" <<'PY' || fail "the templates mix the escaping modes (see above)"
+"${HTS_PYTHON}" - "${distdir}" <<'PY' || fail "the templates mix the escaping modes (see above)"
 import glob, os, re, sys
 
 # A handler value is JS, everything else is HTML text: the two never swap.
@@ -200,15 +190,9 @@ PY
 echo OK
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_jsesc.XXXXXX") || fail "no tmpdir"
-srvlog=$(mktemp)
-srv=
-srvpid=
 cleanup() {
-    # htsserver keeps SIGTERM ignored across its exec, so only -9 reaps it.
-    test -z "${srvpid}" || kill -9 "${srvpid}" 2>/dev/null || true
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
-    wait "${srv}" 2>/dev/null || true # absorb bash's async "Killed" notice
-    rm -rf "${work}" "${srvlog}"
+    htsserver_cleanup
+    rm -rf "${work}"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
@@ -235,27 +219,9 @@ printf '%s\r\n' \
     >"${root}/lang/Francais.txt"
 
 printf '[a French tooltip survives the two decoders] ..\t'
-sport=$("${python}" -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()')
-(
-    trap '' TERM TTOU
-    # An isolated HOME keeps a stray ~/.httrack.ini out of the served settings.
-    export HOME="${work}"
-    exec htsserver "${root}/" --port "${sport}" >"${srvlog}" 2>&1
-) &
-srv=$!
-for _ in $(seq 1 40); do
-    url=$(sed -n 's/^URL=//p' "${srvlog}") && test -n "${url}" && break
-    kill -0 "${srv}" 2>/dev/null || break
-    sleep 0.25
-done
-test -n "${url:-}" || fail "htsserver did not start: $(cat "${srvlog}")"
-srvpid=$(sed -n 's/^PID=//p' "${srvlog}") # absent on Windows
+htsserver_start --root "${root}" --home "${work}"
 
-"${python}" - "${url}" <<'PY' || fail "tooltips are not JS-escaped (see above)"
+"${HTS_PYTHON}" - "${HTS_URL}" <<'PY' || fail "tooltips are not JS-escaped (see above)"
 import re, sys, urllib.request
 
 url = sys.argv[1].rstrip("/")

--- a/tests/186_webhttrack-url-escaping.test
+++ b/tests/186_webhttrack-url-escaping.test
@@ -6,64 +6,32 @@
 set -euo pipefail
 
 testdir=$(cd "$(dirname "$0")" && pwd)
-distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
-distdir=$(cd "${distdir}" && pwd)
-# shellcheck source=tests/testlib.sh
-. "${testdir}/testlib.sh"
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
+htsserver_require
 
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-python=$(find_python) || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
-
-log=$(mktemp)
 work=$(mktemp -d)
 csrv=
-# start() runs in a command substitution, so its $! never reaches this shell.
-srvpid() { sed -n 's/^PID=//p' "${log}" 2>/dev/null | head -1; }
 cleanup() {
-    local pid
-    pid=$(srvpid)
-    test -z "${pid}" || kill -9 "${pid}" 2>/dev/null || true
+    htsserver_cleanup
     test -z "${csrv}" || kill -9 "${csrv}" 2>/dev/null || true
     wait "${csrv}" 2>/dev/null || true # absorb bash's async "Killed" notice
-    rm -rf "${log}" "${work}"
+    rm -rf "${work}"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
 
-# An isolated HOME keeps a developer's ~/.httrack.ini out of the served settings.
-export HOME="${work}"
-
-port=$("${python}" -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()')
-(
-    trap '' TERM TTOU
-    exec htsserver "${distdir}/" --port "${port}" >"${log}" 2>&1
-) &
-for _ in $(seq 1 40); do
-    url=$(sed -n 's/^URL=//p' "${log}" 2>/dev/null) && test -n "${url}" && break
-    sleep 0.25
-done
-test -n "${url:-}" || fail "htsserver did not come up: $(cat "${log}")"
+htsserver_start --home "${work}"
 
 clog="${work}/content.log"
-"${python}" "${testdir}/local-server.py" --root "${work}" >"${clog}" 2>&1 &
+"${HTS_PYTHON}" "${testdir}/local-server.py" --root "${work}" >"${clog}" 2>&1 &
 csrv=$!
 cport=$(discover_server_port "${clog}" "${csrv}") ||
     fail "content server did not come up"
 
 printf '[a hostile link path is escaped in the progress panel] ..\t'
-"${python}" - "${port}" "${cport}" "${work}" <<'PY' || fail "the panel leaks the crawled URL (see above)"
+"${HTS_PYTHON}" - "${HTS_PORT}" "${cport}" "${work}" <<'PY' || fail "the panel leaks the crawled URL (see above)"
 import re, sys, time, urllib.parse, urllib.request
 
 port, cport, work = sys.argv[1:4]

--- a/tests/217_webhttrack-attr-escaping.test
+++ b/tests/217_webhttrack-attr-escaping.test
@@ -6,32 +6,16 @@
 set -euo pipefail
 
 testdir=$(cd "$(dirname "$0")" && pwd)
-distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
-distdir=$(cd "${distdir}" && pwd)
-# shellcheck source=tests/testlib.sh
-. "${testdir}/testlib.sh"
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
-
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-python=$(find_python) || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
+htsserver_require
+distdir=${HTS_DISTDIR}
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_attresc.XXXXXX") || fail "no tmpdir"
-srvlog=$(mktemp)
-srv=
-srvpid=
 cleanup() {
-    # htsserver keeps SIGTERM ignored across its exec, so only -9 reaps it.
-    test -z "${srvpid}" || kill -9 "${srvpid}" 2>/dev/null || true
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
-    wait "${srv}" 2>/dev/null || true # absorb bash's async "Killed" notice
-    rm -rf "${work}" "${srvlog}"
+    htsserver_cleanup
+    rm -rf "${work}"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
@@ -67,27 +51,10 @@ printf 'Category=c%%22d\r\n' >"${projects}/p\"q/hts-cache/winprofile.ini"
 printf 'path=C:\\ab\r\nlang=\r\n' >"${work}/.httrack.ini"
 
 printf '[a hostile settings value is entity-escaped in its attribute] ..\t'
-sport=$("${python}" -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()')
-(
-    trap '' TERM TTOU
-    # An isolated HOME, so the ~/.httrack.ini above is the only one served.
-    export HOME="${work}"
-    exec htsserver "${root}/" --port "${sport}" >"${srvlog}" 2>&1
-) &
-srv=$!
-for _ in $(seq 1 40); do
-    url=$(sed -n 's/^URL=//p' "${srvlog}") && test -n "${url}" && break
-    kill -0 "${srv}" 2>/dev/null || break
-    sleep 0.25
-done
-test -n "${url:-}" || fail "htsserver did not start: $(cat "${srvlog}")"
-srvpid=$(sed -n 's/^PID=//p' "${srvlog}") # absent on Windows
+# An isolated HOME, so the ~/.httrack.ini above is the only one served.
+htsserver_start --root "${root}" --home "${work}"
 
-"${python}" - "${url}" "${projects}" <<'PY' || fail "an attribute takes the value raw (see above)"
+"${HTS_PYTHON}" - "${HTS_URL}" "${projects}" <<'PY' || fail "an attribute takes the value raw (see above)"
 import html, re, sys, urllib.parse, urllib.request
 
 url = sys.argv[1].rstrip("/")

--- a/tests/220_webhttrack-mirror-isolation.test
+++ b/tests/220_webhttrack-mirror-isolation.test
@@ -6,21 +6,11 @@
 set -euo pipefail
 
 testdir=$(cd "$(dirname "$0")" && pwd)
-distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
-distdir=$(cd "${distdir}" && pwd)
-# shellcheck source=tests/testlib.sh
-. "${testdir}/testlib.sh"
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
-
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-python=$(find_python) || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
+htsserver_require
+distdir=${HTS_DISTDIR}
 
 # The panel assets the negative side reads have to exist, or it goes vacuous.
 for asset in server/index.html server/ping.js; do
@@ -28,15 +18,9 @@ for asset in server/index.html server/ping.js; do
 done
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_sandbox.XXXXXX") || fail "no tmpdir"
-srvlog=$(mktemp)
-srv=
-srvpid=
 cleanup() {
-    # htsserver keeps SIGTERM ignored across its exec, so only -9 reaps it.
-    test -z "${srvpid}" || kill -9 "${srvpid}" 2>/dev/null || true
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
-    wait "${srv}" 2>/dev/null || true # absorb bash's async "Killed" notice
-    rm -rf "${work}" "${srvlog}"
+    htsserver_cleanup
+    rm -rf "${work}"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
@@ -53,28 +37,10 @@ printf '<svg xmlns="http://www.w3.org/2000/svg">MIRROR-SVG-OK</svg>\n' >"${proj}
 # Untyped: sniffing can still hand it to the HTML parser.
 printf 'MIRROR-BLOB-OK\n' >"${proj}/data.bin"
 
-# An isolated HOME keeps a stray ~/.httrack.ini out of the server's settings.
-sport=$("${python}" -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()')
-(
-    trap '' TERM TTOU
-    export HOME="${work}"
-    exec htsserver "${distdir}/" --port "${sport}" >"${srvlog}" 2>&1
-) &
-srv=$!
-for _ in $(seq 1 40); do
-    url=$(sed -n 's/^URL=//p' "${srvlog}") && test -n "${url}" && break
-    kill -0 "${srv}" 2>/dev/null || break
-    sleep 0.25
-done
-test -n "${url:-}" || fail "htsserver did not start: $(cat "${srvlog}")"
-srvpid=$(sed -n 's/^PID=//p' "${srvlog}") # absent on Windows
+htsserver_start --home "${work}"
 
 # htsserver resolves the posted paths itself, so hand it native ones.
-"${python}" - "${url}" "$(nativepath "${work}/websites")" <<'PY' || fail "mirror isolation checks failed"
+"${HTS_PYTHON}" - "${HTS_URL}" "$(nativepath "${work}/websites")" <<'PY' || fail "mirror isolation checks failed"
 import re, socket, sys, urllib.parse, urllib.request
 
 url, base = sys.argv[1].rstrip("/"), sys.argv[2]
@@ -203,8 +169,7 @@ check(b"\n" not in head.replace(b"\r\n", b""), "no bare LF in the header block")
 sys.exit(rc)
 PY
 
-# A leaked htsserver wedges the parallel harness behind a green log.
-cleanup
-! kill -0 "${srv}" 2>/dev/null || fail "htsserver ${srv} survived"
+htsserver_cleanup
+htsserver_assert_reaped
 
 echo "PASS"

--- a/tests/223_webhttrack-session-id.test
+++ b/tests/223_webhttrack-session-id.test
@@ -6,65 +6,22 @@
 set -euo pipefail
 
 testdir=$(cd "$(dirname "$0")" && pwd)
-distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
-distdir=$(cd "${distdir}" && pwd)
-# shellcheck source=tests/testlib.sh
-. "${testdir}/testlib.sh"
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
-
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-python=$(find_python) || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
+htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_sid.XXXXXX") || fail "no tmpdir"
-pids=
 cleanup() {
-    # htsserver keeps SIGTERM ignored across its exec, so only -9 reaps it.
-    for p in ${pids}; do
-        kill -9 "${p}" 2>/dev/null || true
-    done
-    wait 2>/dev/null || true # absorb bash's async "Killed" notice
+    htsserver_cleanup
     rm -rf "${work}"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
 
-# Both bound at once, or the two picks could land on the same free port.
-read -r porta portb <<<"$("${python}" -c 'import socket
-s = [socket.socket() for _ in range(2)]
-for x in s:
-    x.bind(("127.0.0.1", 0))
-print(*[x.getsockname()[1] for x in s])
-for x in s:
-    x.close()')"
-
-# An isolated HOME keeps a stray ~/.httrack.ini out of the server's settings.
-launch() { # $1 = tag, $2 = port
+launch() { # $1 = tag; leaves the URL in ${HTS_URL}
     mkdir -p "${work}/$1"
-    (
-        trap '' TERM TTOU
-        export HOME="${work}/$1"
-        exec htsserver "${distdir}/" --port "$2" >"${work}/$1.log" 2>&1
-    ) &
-    pids="${pids} $!"
-}
-
-started() { # $1 = tag; prints the URL once the server is up
-    for _ in $(seq 1 100); do
-        url=$(sed -n 's/^URL=//p' "${work}/$1.log" 2>/dev/null) &&
-            test -n "${url}" && {
-            echo "${url}"
-            return 0
-        }
-        sleep 0.05
-    done
-    return 1
+    htsserver_start --home "${work}/$1" --log "${work}/$1.log"
 }
 
 # Both servers have to read the same second off the clock, or the id they used
@@ -73,17 +30,16 @@ started() { # $1 = tag; prints the URL once the server is up
 urla=
 urlb=
 for _ in $(seq 1 10); do
-    pids=
     rm -f "${work}"/*.log
     prev=$(date +%s)
     while test "$(date +%s)" = "${prev}"; do
         sleep 0.02
     done
     t0=$(date +%s)
-    launch a "${porta}"
-    launch b "${portb}"
-    urla=$(started a) || fail "htsserver a did not start: $(cat "${work}/a.log")"
-    urlb=$(started b) || fail "htsserver b did not start: $(cat "${work}/b.log")"
+    launch a
+    urla=${HTS_URL}
+    launch b
+    urlb=${HTS_URL}
     t1=$(date +%s)
     test "${t0}" != "${t1}" || break
     cleanup
@@ -94,7 +50,7 @@ test -n "${urla}" || {
     exit 77
 }
 
-"${python}" - "${urla}" "${urlb}" <<'PY' || fail "session id checks failed"
+"${HTS_PYTHON}" - "${urla}" "${urlb}" <<'PY' || fail "session id checks failed"
 import re, sys, urllib.request
 
 ids = []

--- a/tests/223_webhttrack-session-id.test
+++ b/tests/223_webhttrack-session-id.test
@@ -19,9 +19,8 @@ cleanup() {
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
 
-launch() { # $1 = tag; leaves the URL in ${HTS_URL}
-    mkdir -p "${work}/$1"
-    htsserver_start --home "${work}/$1" --log "${work}/$1.log"
+launch() { # $1 = tag, $2 = port; leaves the URL in ${HTS_URL}
+    htsserver_start --port "$2" --home "${work}/$1" --log "${work}/$1.log"
 }
 
 # Both servers have to read the same second off the clock, or the id they used
@@ -31,14 +30,18 @@ urla=
 urlb=
 for _ in $(seq 1 10); do
     rm -f "${work}"/*.log
+    mkdir -p "${work}/a" "${work}/b"
+    # Both ports up front: a python fork apiece inside the window below is most
+    # of it, and picking them together is what keeps the two apart.
+    read -r porta portb <<<"$(htsserver_freeport 2)"
     prev=$(date +%s)
     while test "$(date +%s)" = "${prev}"; do
         sleep 0.02
     done
     t0=$(date +%s)
-    launch a
+    launch a "${porta}"
     urla=${HTS_URL}
-    launch b
+    launch b "${portb}"
     urlb=${HTS_URL}
     t1=$(date +%s)
     test "${t0}" != "${t1}" || break

--- a/tests/241_local-single-file-gui.test
+++ b/tests/241_local-single-file-gui.test
@@ -3,12 +3,9 @@
 # htsserver.
 set -e
 
-: "${top_srcdir:=..}"
 testdir=$(cd "$(dirname "$0")" && pwd)
-# shellcheck source=tests/testlib.sh
-. "${testdir}/testlib.sh"
-
-python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
 # The Windows job builds httrack.exe only and reaches this file through its
 # *_local-*.test glob, so report a skip there rather than a pass.
@@ -17,44 +14,20 @@ if ! command -v htsserver >/dev/null; then
     exit 77
 fi
 
-distdir=$(cd "${top_srcdir}" && pwd)
+htsserver_require
+
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_713gui.XXXXXX") || exit 1
-htssrv=
 cleanup() {
-    # htsserver keeps SIGTERM ignored across its exec, so only -9 reaps it.
-    test -z "$htssrv" || kill -9 "$htssrv" 2>/dev/null || true
-    wait "$htssrv" 2>/dev/null || true # absorb bash's async "Killed" notice
-    htssrv=
+    htsserver_cleanup
     rm -rf "$tmpdir"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
 
 printf '[webhttrack renders the options] ..\t'
-sport=$("$python" -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()')
-srvlog="${tmpdir}/htsserver.log"
-(
-    trap '' TERM TTOU
-    export HOME="${tmpdir}/home"
-    mkdir -p "$HOME"
-    exec htsserver "${distdir}/" --port "${sport}" >"${srvlog}" 2>&1
-) &
-htssrv=$!
-url=
-for _ in $(seq 1 40); do
-    url=$(sed -n 's/^URL=//p' "$srvlog" 2>/dev/null) && test -n "$url" && break
-    kill -0 "$htssrv" 2>/dev/null || break
-    sleep 0.25
-done
-test -n "${url:-}" || {
-    echo "FAIL: htsserver did not start: $(cat "$srvlog")"
-    exit 1
-}
-"$python" - "$url" <<'PY' || exit 1
+mkdir -p "${tmpdir}/home"
+htsserver_start --home "${tmpdir}/home" --log "${tmpdir}/htsserver.log"
+"${HTS_PYTHON}" - "${HTS_URL}" <<'PY' || exit 1
 import re, sys, urllib.parse, urllib.request
 
 url = sys.argv[1]

--- a/tests/251_webhttrack-lang-selected.test
+++ b/tests/251_webhttrack-lang-selected.test
@@ -7,62 +7,26 @@
 set -euo pipefail
 
 testdir=$(cd "$(dirname "$0")" && pwd)
-distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
-distdir=$(cd "${distdir}" && pwd)
-# shellcheck source=tests/testlib.sh
-. "${testdir}/testlib.sh"
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
-
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-python=$(find_python) || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
+htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_lang.XXXXXX") || fail "no tmpdir"
-pids=
 cleanup() {
-    # htsserver keeps SIGTERM ignored across its exec, so only -9 reaps it.
-    for p in ${pids}; do
-        kill -9 "${p}" 2>/dev/null || true
-    done
-    wait 2>/dev/null || true # absorb bash's async "Killed" notice
+    htsserver_cleanup
     rm -rf "${work}"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
 
-# Sets ${url}; it must not print it, or a caller's $(...) would collect ${pids} in a
-# subshell and leave every server running.
-url=
+# Leaves the URL in ${HTS_URL}; never call it from a $(...), or the pids it
+# records would stay in the subshell and every server would keep running.
 serve() { # $1 = tag, $2.. = extra htsserver args
-    local log port
-    log="${work}/srv$1.log"
-    mkdir -p "${work}/h$1"
-    # An isolated HOME keeps a stray ~/.httrack.ini out of the server's settings.
-    port=$("${python}" -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()')
     local tag=$1
     shift
-    (
-        trap '' TERM TTOU
-        export HOME="${work}/h${tag}"
-        exec htsserver "${distdir}/" --port "${port}" "$@" >"${log}" 2>&1
-    ) &
-    pids="${pids} $!"
-    url=
-    for _ in $(seq 1 40); do
-        url=$(sed -n 's/^URL=//p' "${log}") && test -n "${url}" && break
-        sleep 0.25
-    done
-    test -n "${url}" || fail "htsserver did not start: $(cat "${log}")"
+    mkdir -p "${work}/h${tag}"
+    htsserver_start --home "${work}/h${tag}" --log "${work}/srv${tag}.log" "$@"
 }
 
 # Indexes and labels come from lang.indexes and lang.def, not from observed output.
@@ -70,7 +34,7 @@ s.close()')
 # the body was rendered in.
 check() { # $1 = lang index, $2 = expected label, $3 = word in the page heading
     serve "$1" lang "$1"
-    "${python}" - "${url}" "$1" "$2" "$3" <<'PY' || fail "wrong menu or body for language $2"
+    "${HTS_PYTHON}" - "${HTS_URL}" "$1" "$2" "$3" <<'PY' || fail "wrong menu or body for language $2"
 import re, sys, urllib.request
 
 url, want_id, want_label, want_word = sys.argv[1:5]
@@ -105,7 +69,7 @@ check 4 Deutsch Willkommen
 # With no language set the menu falls back to its first entry, which must be the
 # one the page is rendered in. An empty placeholder option would show up blank.
 serve unset
-"${python}" - "${url}" <<'PY' || fail "unset language does not fall back to English"
+"${HTS_PYTHON}" - "${HTS_URL}" <<'PY' || fail "unset language does not fall back to English"
 import re, sys, urllib.request
 
 page = urllib.request.urlopen(sys.argv[1], timeout=20).read().decode("utf-8", "replace")

--- a/tests/63_webhttrack-home.test
+++ b/tests/63_webhttrack-home.test
@@ -6,75 +6,44 @@
 set -euo pipefail
 
 testdir=$(cd "$(dirname "$0")" && pwd)
-distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
-distdir=$(cd "${distdir}" && pwd)
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
+htsserver_require
 
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-# Mirror local-crawl.sh's skip-with-77: the Debian buildd chroot has no python3.
-command -v python3 >/dev/null || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
+trap 'set +e; htsserver_cleanup' EXIT
+trap htsserver_cleanup HUP INT QUIT PIPE TERM
 
-srv=
-cleanup() {
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
-}
-trap 'set +e; cleanup' EXIT
-trap cleanup HUP INT QUIT PIPE TERM
+savedhome=${HOME:-}
 
-log=$(mktemp)
-trap 'set +e; cleanup; rm -f "${log}"' EXIT
-
-# Ask htsserver for its rendered default base path, under the given $HOME
-# ("-" = leave $HOME unset).
+# Render htsserver's default base path into ${pathfor_result}, under the given
+# $HOME ("-" = leave $HOME unset). Assigns rather than echoes: a command
+# substitution would hide the server from the cleanup trap.
 pathfor() {
-    local homeval=$1 port url got
-    port=$(python3 -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()')
+    local homeval=$1
+    if test -n "${homeval}" && test "${homeval}" != -; then
+        htsserver_start --home "${homeval}"
+    else
+        # --home names a directory, so the empty and unset cases ride this
+        # shell's own environment across the fork.
+        if test "${homeval}" = -; then unset HOME; else export HOME=""; fi
+        htsserver_start
+        export HOME="${savedhome}"
+    fi
 
-    : >"${log}"
-    (
-        # htsserver ignores SIGTERM/SIGTTOU handling from the harness shell
-        trap '' TERM TTOU
-        if test "${homeval}" = -; then unset HOME; else export HOME="${homeval}"; fi
-        exec htsserver "${distdir}/" --port "${port}" >"${log}" 2>&1
-    ) &
-    srv=$!
+    pathfor_result=$(firstline "$(htsserver_client --path /server/step2.html \
+        --timeout 20 | sed -n 's/.*name="path" value="\([^"]*\)".*/\1/p')")
 
-    for _ in $(seq 1 40); do
-        url=$(sed -n 's/^URL=//p' "${log}" 2>/dev/null) && test -n "${url}" && break
-        kill -0 "${srv}" 2>/dev/null || break
-        sleep 0.25
-    done
-    test -n "${url:-}" || fail "htsserver did not come up: $(cat "${log}")"
-
-    # The UI is served ISO-8859-1, so keep python out of text mode.
-    got=$(python3 -c 'import re, sys, urllib.request
-body = urllib.request.urlopen(sys.argv[1] + "server/step2.html", timeout=20).read()
-m = re.search(br"name=\"path\" value=\"([^\"]*)\"", body)
-print(m.group(1).decode("latin-1") if m else "")' "${url}")
-
-    kill -9 "${srv}" 2>/dev/null || true
-    wait "${srv}" 2>/dev/null || true
-    srv=
-    test -n "${got}" || fail "no path field in the rendered step2.html"
-    echo "${got}"
+    htsserver_stop
+    test -n "${pathfor_result}" || fail "no path field in the rendered step2.html"
 }
 
 check() {
-    local desc=$1 homeval=$2 want=$3 got
-    got=$(pathfor "${homeval}")
-    test "${got}" = "${want}" || fail "${desc}: want ${want}, got ${got}"
-    echo "ok: ${desc} -> ${got}"
+    local desc=$1 homeval=$2 want=$3
+    pathfor "${homeval}"
+    test "${pathfor_result}" = "${want}" ||
+        fail "${desc}: want ${want}, got ${pathfor_result}"
+    echo "ok: ${desc} -> ${pathfor_result}"
 }
 
 # A real HOME must reach the page, or the two cases below are vacuous: they

--- a/tests/68_webhttrack-outdir-charset.test
+++ b/tests/68_webhttrack-outdir-charset.test
@@ -11,56 +11,23 @@
 set -euo pipefail
 
 testdir=$(cd "$(dirname "$0")" && pwd)
-distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
-distdir=$(cd "${distdir}" && pwd)
-# shellcheck source=tests/testlib.sh
-. "${testdir}/testlib.sh"
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
-
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-python=$(find_python) || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
+htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_charset.XXXXXX") || fail "no tmpdir"
-srvlog=$(mktemp)
-srv=
 cleanup() {
-    # htsserver keeps SIGTERM ignored across its exec, so only -9 reaps it.
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
-    wait "${srv}" 2>/dev/null || true # absorb bash's async "Killed" notice
-    rm -rf "${work}" "${srvlog}"
+    htsserver_cleanup
+    rm -rf "${work}"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
 
-# webhttrack server on a pre-picked port; an isolated HOME keeps a stray
-# ~/.httrack.ini out of it.
-sport=$("${python}" -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()')
-(
-    trap '' TERM TTOU
-    export HOME="${work}"
-    exec htsserver "${distdir}/" --port "${sport}" >"${srvlog}" 2>&1
-) &
-srv=$!
-for _ in $(seq 1 40); do
-    url=$(sed -n 's/^URL=//p' "${srvlog}") && test -n "${url}" && break
-    kill -0 "${srv}" 2>/dev/null || break
-    sleep 0.25
-done
-test -n "${url:-}" || fail "htsserver did not start: $(cat "${srvlog}")"
+htsserver_start --home "${work}"
 
 # Post a "start" whose -O dir is 'café' in the form's ISO-8859-1 charset.
-"${python}" - "${url}" "${work}" <<'PY'
+"${HTS_PYTHON}" - "${HTS_URL}" "${work}" <<'PY'
 import re, sys, urllib.parse, urllib.request
 
 url, work = sys.argv[1], sys.argv[2]
@@ -89,7 +56,7 @@ utf8dir="${work}/café"
 latin1dir="${work}/caf"$'\xe9'
 for _ in $(seq 1 80); do
     test -e "${utf8dir}" && break
-    kill -0 "${srv}" 2>/dev/null || break
+    kill -0 "${HTS_BGPID}" 2>/dev/null || break
     sleep 0.25
 done
 test -e "${utf8dir}" || fail "-O dir never landed as UTF-8 café/: $(find "${work}" -maxdepth 2 2>/dev/null)"

--- a/tests/77_webhttrack-redirect.test
+++ b/tests/77_webhttrack-redirect.test
@@ -6,114 +6,30 @@
 set -euo pipefail
 
 testdir=$(cd "$(dirname "$0")" && pwd)
-distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
-distdir=$(cd "${distdir}" && pwd)
-# run_with_timeout/kill_tree: timeout(1) is absent on macOS
-# shellcheck source=tests/testlib.sh
-. "${testdir}/testlib.sh"
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
+htsserver_require
 
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-command -v python3 >/dev/null || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
-
-log=$(mktemp)
-# start() runs inside a command substitution, so its $! never reaches this
-# shell. Take the pid from the server's own announcement instead: a missed kill
-# leaves an orphan holding the CI job open long after the suite has passed.
-srvpid() { sed -n 's/^PID=//p' "${log}" 2>/dev/null | head -1; }
+bindlog=$(mktemp)
 cleanup() {
-    stop
-    rm -f "${log}"
+    htsserver_cleanup
+    rm -f "${bindlog}"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
 
-freeport() {
-    python3 -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()'
-}
-
-# Start htsserver, echo the announced URL. Extra args are passed through.
-start() {
-    local port url
-    port=$(freeport)
-    : >"${log}"
-    (
-        trap '' TERM TTOU
-        exec htsserver "${distdir}/" --port "${port}" "$@" >"${log}" 2>&1
-    ) &
-    for _ in $(seq 1 40); do
-        url=$(sed -n 's/^URL=//p' "${log}" 2>/dev/null) && test -n "${url}" && break
-        sleep 0.25
-    done
-    test -n "${url:-}" || fail "htsserver did not come up: $(cat "${log}")"
-    echo "${url}"
-}
-
-stop() {
-    local pid
-    pid=$(srvpid)
-    test -z "${pid}" || kill -9 "${pid}" 2>/dev/null || true
-}
-
-# The session id gates the request body, so a POST has to carry one. The server
-# renders it into every form, which is where a browser picks it up too.
-scrape_sid() {
-    python3 -c 'import socket, sys
-s = socket.create_connection(("127.0.0.1", int(sys.argv[1])), 10)
-s.settimeout(20)
-s.sendall(b"GET /server/index.html HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n")
-out = b""
-while True:
-    b = s.recv(65536)
-    if not b:
-        break
-    out += b
-s.close()
-sys.stdout.write(out.decode("latin-1"))' "$1" |
-        sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p' | head -1
-}
-
-# POST redirect=$1 to 127.0.0.1:$2 with session id $3, print the raw headers.
+# POST redirect=$1 with session id $2, printing the raw headers. Stopping at the
+# header block matters: an unbounded recv() hung the macOS runner for over an hour.
 post_redirect() {
-    python3 -c 'import socket, sys, urllib.parse
-body = ("sid=" + sys.argv[3] + "&redirect="
-        + urllib.parse.quote(sys.argv[1], safe=""))
-req = ("POST / HTTP/1.0\r\nHost: 127.0.0.1\r\n"
-       "Content-type: application/x-www-form-urlencoded\r\n"
-       "Content-length: %d\r\n\r\n%s" % (len(body), body))
-s = socket.create_connection(("127.0.0.1", int(sys.argv[2])), 10)
-s.settimeout(20)
-s.sendall(req.encode())
-out = b""
-# stop at the end of the header block: the server need not close the connection,
-# and an unbounded recv() hung the macOS runner for over an hour.
-while b"\r\n\r\n" not in out:
-    b = s.recv(65536)
-    if not b:
-        break
-    out += b
-s.close()
-sys.stdout.write(out.split(b"\r\n\r\n")[0].decode("latin-1"))' "$1" "$2" "$3"
+    htsserver_client --headers-only --field "sid=$2" --field "redirect=$1"
 }
-
-portof() { echo "${1##*:}" | tr -d /; }
 
 # "free"/"inuse"/"unusable": can $1 still be bound on 127.0.0.2? A wildcard
 # listener takes the port on every address, a loopback-only one does not, so
 # this discriminates where the announced URL cannot.
 probe_alias() {
-    python3 -c 'import socket, sys
+    "${HTS_PYTHON}" -c 'import socket, sys
 s = socket.socket()
 try:
     s.bind(("127.0.0.2", int(sys.argv[1])))
@@ -127,26 +43,24 @@ finally:
 
 # Non-repeating and not a round number: a truncation, a reorder or a dropped
 # interior byte all stay visible.
-long=$(python3 -c 'print("".join(chr(33 + i % 90) for i in range(4097)))')
-url=$(start)
-port=$(portof "${url}")
-sid=$(scrape_sid "${port}")
+long=$("${HTS_PYTHON}" -c 'print("".join(chr(33 + i % 90) for i in range(4097)))')
+htsserver_start
+sid=$(htsserver_sid)
 test "${#sid}" -eq 32 || fail "did not scrape a 32-hex sid (got '${sid}')"
-resp=$(post_redirect "${long}" "${port}" "${sid}") ||
+resp=$(post_redirect "${long}" "${sid}") ||
     fail "no response to an oversized redirect value"
-stop
+htsserver_stop
 loc=$(printf '%s' "${resp}" | sed -n 's/^Location: //p' | tr -d '\r')
 test "${loc}" = "${long}" ||
     fail "oversized redirect not echoed whole (got ${#loc} bytes, want ${#long})"
 
 # CR/LF must suppress the header outright. Sanitising it instead would keep the
 # grep for an injected header quiet while still emitting a mangled Location.
-url=$(start)
-port=$(portof "${url}")
-sid=$(scrape_sid "${port}")
+htsserver_start
+sid=$(htsserver_sid)
 resp=$(post_redirect '/foo
-X-Injected: pwned' "${port}" "${sid}") || fail "no response to a CRLF redirect value"
-stop
+X-Injected: pwned' "${sid}") || fail "no response to a CRLF redirect value"
+htsserver_stop
 # Here-string, not a pipe: grep -q SIGPIPEs the producer on the first match, and
 # pipefail then turns the hit into a silent pass.
 grep -qi 'X-Injected' <<<"${resp}" &&
@@ -157,32 +71,30 @@ test "$(grep -c '^HTTP/1\.' <<<"${resp}")" -eq 1 ||
     fail "CRLF redirect did not yield exactly one status line"
 
 # Loopback unless asked otherwise. Assert the socket, not the announcement.
-url=$(start)
-port=$(portof "${url}")
-alias_state=$(probe_alias "${port}")
-stop
+htsserver_start
+alias_state=$(probe_alias "${HTS_PORT}")
+htsserver_stop
 if test "${alias_state}" = unusable; then
     echo "no 127.0.0.2 alias; skipping the listen-address assertions" >&2
 else
     test "${alias_state}" = free ||
-        fail "default listen address is not loopback-only (127.0.0.2:${port} taken)"
-    case "${url}" in
+        fail "default listen address is not loopback-only (127.0.0.2:${HTS_PORT} taken)"
+    case "${HTS_URL}" in
     http://127.0.0.1:*) ;;
-    *) fail "default announcement is not loopback: ${url}" ;;
+    *) fail "default announcement is not loopback: ${HTS_URL}" ;;
     esac
 
-    url=$(start --bind 0.0.0.0)
-    port=$(portof "${url}")
-    alias_state=$(probe_alias "${port}")
-    stop
+    htsserver_start --bind 0.0.0.0
+    alias_state=$(probe_alias "${HTS_PORT}")
+    htsserver_stop
     test "${alias_state}" = inuse ||
-        fail "--bind 0.0.0.0 did not take the wildcard (127.0.0.2:${port} ${alias_state})"
+        fail "--bind 0.0.0.0 did not take the wildcard (127.0.0.2:${HTS_PORT} ${alias_state})"
 fi
 
 # An empty --bind must not quietly fall back to every interface. Bounded: if it
 # were accepted the server would listen instead of exiting.
-run_with_timeout 15 htsserver "${distdir}/" --bind "" >"${log}" 2>&1 || true
-grep -q -- "--bind needs an address" "${log}" ||
-    fail "empty --bind not refused: $(cat "${log}")"
+run_with_timeout 15 htsserver "${HTS_DISTDIR}/" --bind "" >"${bindlog}" 2>&1 || true
+grep -q -- "--bind needs an address" "${bindlog}" ||
+    fail "empty --bind not refused: $(cat "${bindlog}")"
 
 echo "PASS"

--- a/tests/78_webhttrack-sid.test
+++ b/tests/78_webhttrack-sid.test
@@ -6,107 +6,26 @@
 set -euo pipefail
 
 testdir=$(cd "$(dirname "$0")" && pwd)
-distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
-distdir=$(cd "${distdir}" && pwd)
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
+htsserver_require
 
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-command -v python3 >/dev/null || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
+trap 'set +e; htsserver_cleanup' EXIT
+trap htsserver_cleanup HUP INT QUIT PIPE TERM
 
-srv=
-log=$(mktemp)
-cleanup() {
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
-    rm -f "${log}"
-}
-trap 'set +e; cleanup' EXIT
-trap cleanup HUP INT QUIT PIPE TERM
+htsserver_start
+test -n "${HTS_PID}" || fail "htsserver did not report its pid"
+htsserver_alive || fail "htsserver is not running"
 
-freeport() {
-    python3 -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()'
-}
-
-# Echo the announced URL. Runs in a command substitution, so it is a
-# subshell and cannot export the pid: the caller reads it back with srvpid.
-start() {
-    local port url
-    port=$(freeport)
-    : >"${log}"
-    (
-        trap '' TERM TTOU
-        exec htsserver "${distdir}/" --port "${port}" >"${log}" 2>&1
-    ) &
-    for _ in $(seq 1 40); do
-        url=$(sed -n 's/^URL=//p' "${log}" 2>/dev/null) && test -n "${url}" && break
-        sleep 0.25
-    done
-    test -n "${url:-}" || fail "htsserver did not come up: $(cat "${log}")"
-    echo "${url}"
-}
-
-# The server reports its own pid; the aliveness assertions below hang off it.
-srvpid() { sed -n 's/^PID=//p' "${log}" | head -1; }
-
-alive() { kill -0 "$1" 2>/dev/null; }
-
-portof() { echo "${1##*:}" | tr -d /; }
-
-# Raw request to 127.0.0.1:$1; $2 is the body ("" for a GET of the $3 page,
-# default index). Prints the reply.
-request() {
-    python3 -c 'import socket, sys
-port, body = int(sys.argv[1]), sys.argv[2]
-page = sys.argv[3] if len(sys.argv) > 3 else "index"
-if body:
-    req = ("POST / HTTP/1.0\r\nHost: 127.0.0.1\r\n"
-           "Content-type: application/x-www-form-urlencoded\r\n"
-           "Content-length: %d\r\n\r\n%s" % (len(body), body))
-else:
-    req = ("GET /server/%s.html HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n" % page)
-s = socket.create_connection(("127.0.0.1", port), 10)
-s.settimeout(30)
-s.sendall(req.encode())
-out = b""
-while True:
-    b = s.recv(65536)
-    if not b:
-        break
-    out += b
-s.close()
-sys.stdout.write(out.decode("latin-1"))' "$1" "$2" ${3+"$3"}
-}
-
-# The server hands the sid to any client in every form; scraping it is the
-# legitimate flow, and it is what makes the accept case below meaningful.
-scrape_sid() {
-    request "$1" "" | sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p' | head -1
-}
-
-url=$(start)
-port=$(portof "${url}")
-srv=$(srvpid)
-test -n "${srv}" || fail "htsserver did not report its pid"
-alive "${srv}" || fail "htsserver is not running"
-
-sid=$(scrape_sid "${port}")
+sid=$(htsserver_sid)
 # Control: without a real sid every assertion below would pass vacuously.
 test "${#sid}" -eq 32 || fail "did not scrape a 32-hex sid from the page (got '${sid}')"
 
 # Accept: the legitimate flow still works. "redirect" is the cheapest field
 # with a reply that is visible in the headers. Matched from a here-string, not a
 # pipe: grep -q SIGPIPEs the producer, and pipefail then buries the verdict.
-resp=$(request "${port}" "sid=${sid}&redirect=/accepted")
+resp=$(htsserver_post "sid=${sid}&redirect=/accepted")
 grep -q '^Location: /accepted' <<<"${resp}" ||
     fail "a body carrying the correct sid was refused"
 
@@ -115,7 +34,7 @@ grep -q '^Location: /accepted' <<<"${resp}" ||
 # field compared equal to itself.
 for bad in "redirect=/nosid" "sid=&redirect=/empty" \
     "sid=00000000000000000000000000000000&redirect=/wrong"; do
-    resp=$(request "${port}" "${bad}")
+    resp=$(htsserver_post "${bad}")
     grep -q '^Location:' <<<"${resp}" &&
         fail "body accepted without a valid sid: ${bad}"
     # A refusal has to be a well-formed reply, not a headerless fragment: the
@@ -131,20 +50,20 @@ done
 # interpolates ${projname} into its title — rather than the refused reply.
 store_page() {
     # a dead probe or a non-page reply must not read as "the store was not written"
-    page=$(request "$1" "" step3) || fail "the key store probe failed"
+    page=$(htsserver_get /server/step3.html) || fail "the key store probe failed"
     grep -q '^HTTP/1\.0 200 ' <<<"${page}" ||
         fail "the key store probe did not answer: '$(head -1 <<<"${page}")'"
 }
 
-request "${port}" "projname=UNAUTHWRITE" >/dev/null 2>&1 || true
-store_page "${port}"
+htsserver_post "projname=UNAUTHWRITE" >/dev/null 2>&1 || true
+store_page
 grep -q 'UNAUTHWRITE' <<<"${page}" &&
     fail "a body without a valid sid was written to the key store"
 
 # Paired accept case: without it the assertion above passes even if the server
 # simply ignores every body, which would prove nothing.
-request "${port}" "sid=${sid}&projname=AUTHWRITE" >/dev/null 2>&1 || true
-store_page "${port}"
+htsserver_post "sid=${sid}&projname=AUTHWRITE" >/dev/null 2>&1 || true
+store_page
 grep -q 'AUTHWRITE' <<<"${page}" ||
     fail "a body carrying the correct sid was not written to the key store"
 

--- a/tests/81_webhttrack-maxsize.test
+++ b/tests/81_webhttrack-maxsize.test
@@ -6,57 +6,23 @@
 set -euo pipefail
 
 testdir=$(cd "$(dirname "$0")" && pwd)
-distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
-distdir=$(cd "${distdir}" && pwd)
-# shellcheck source=tests/testlib.sh
-. "${testdir}/testlib.sh"
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
-
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-python=$(find_python) || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
+htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_maxsize.XXXXXX") || fail "no tmpdir"
-srvlog=$(mktemp)
-srv=
 cleanup() {
-    # htsserver keeps SIGTERM ignored across its exec, so only -9 reaps it.
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
-    wait "${srv}" 2>/dev/null || true # absorb bash's async "Killed" notice
-    srv=
-    rm -rf "${work}" "${srvlog}"
+    htsserver_cleanup
+    rm -rf "${work}"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
 
-# webhttrack server on a pre-picked port; an isolated HOME keeps a stray
-# ~/.httrack.ini out of it.
-sport=$("${python}" -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()')
-(
-    trap '' TERM TTOU
-    export HOME="${work}"
-    exec htsserver "${distdir}/" --port "${sport}" >"${srvlog}" 2>&1
-) &
-srv=$!
-for _ in $(seq 1 40); do
-    url=$(sed -n 's/^URL=//p' "${srvlog}") && test -n "${url}" && break
-    kill -0 "${srv}" 2>/dev/null || break
-    sleep 0.25
-done
-test -n "${url:-}" || fail "htsserver did not start: $(cat "${srvlog}")"
+htsserver_start --home "${work}"
 
 # Audit what step4.html renders back; without command_do nothing is launched.
-"${python}" - "${url}" <<'PY' || fail "wizard rendered the wrong options (see above)"
+"${HTS_PYTHON}" - "${HTS_URL}" <<'PY' || fail "wizard rendered the wrong options (see above)"
 import re, sys, urllib.parse, urllib.request
 
 url = sys.argv[1]
@@ -131,7 +97,7 @@ cleanup
 # A bare -m<n> resets the html limit, so only the bare-then-comma order keeps
 # both caps live. basic.html is 487 bytes, well past the 10-byte html cap.
 crawl() {
-    bash "${distdir}/tests/local-crawl.sh" "$@"
+    bash "${HTS_DISTDIR}/tests/local-crawl.sh" "$@"
 }
 crawl --errors 1 --log-found 'File too big' \
     httrack 'BASEURL/simple/basic.html' '--max-files=,10'

--- a/tests/82_webhttrack-browse-links.test
+++ b/tests/82_webhttrack-browse-links.test
@@ -8,19 +8,10 @@ set -euo pipefail
 testdir=$(cd "$(dirname "$0")" && pwd)
 distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
 distdir=$(cd "${distdir}" && pwd)
-# shellcheck source=tests/testlib.sh
-. "${testdir}/testlib.sh"
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
-
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-python=$(find_python) || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
+htsserver_require
 
 # Control: on a path that does not resolve, grep "passes" without reading anything.
 test -f "${distdir}/html/server/finished.html" || fail "no GUI pages under ${distdir}"
@@ -28,15 +19,9 @@ bad=$(grep -l 'file://' "${distdir}"/html/server/finished.html || true)
 test -z "${bad}" || fail "file: link left in: ${bad}"
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_browse.XXXXXX") || fail "no tmpdir"
-srvlog=$(mktemp)
-srv=
-srvpid=
 cleanup() {
-    # htsserver keeps SIGTERM ignored across its exec, so only -9 reaps it.
-    test -z "${srvpid}" || kill -9 "${srvpid}" 2>/dev/null || true
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
-    wait "${srv}" 2>/dev/null || true # absorb bash's async "Killed" notice
-    rm -rf "${work}" "${srvlog}"
+    htsserver_cleanup
+    rm -rf "${work}"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
@@ -47,28 +32,10 @@ mkdir -p "${proj}"
 printf 'MIRROR-PROBE-OK\n' >"${proj}/probe.txt"
 printf '<html><body>MIRROR-INDEX-OK</body></html>\n' >"${proj}/index.html"
 
-# An isolated HOME keeps a stray ~/.httrack.ini out of the server's settings.
-sport=$("${python}" -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()')
-(
-    trap '' TERM TTOU
-    export HOME="${work}"
-    exec htsserver "${distdir}/" --port "${sport}" >"${srvlog}" 2>&1
-) &
-srv=$!
-for _ in $(seq 1 40); do
-    url=$(sed -n 's/^URL=//p' "${srvlog}") && test -n "${url}" && break
-    kill -0 "${srv}" 2>/dev/null || break
-    sleep 0.25
-done
-test -n "${url:-}" || fail "htsserver did not start: $(cat "${srvlog}")"
-srvpid=$(sed -n 's/^PID=//p' "${srvlog}") # absent on Windows
+htsserver_start --home "${work}"
 
 # htsserver resolves the posted paths itself, so hand it native ones.
-"${python}" - "${url}" "$(nativepath "${work}/websites")" <<'PY' || fail "browse-link checks failed"
+"${HTS_PYTHON}" - "${HTS_URL}" "$(nativepath "${work}/websites")" <<'PY' || fail "browse-link checks failed"
 import re, sys, urllib.error, urllib.parse, urllib.request
 
 url, base = sys.argv[1].rstrip("/"), sys.argv[2]
@@ -147,8 +114,7 @@ check("file://" not in body, "finished.html has no file: link")
 sys.exit(rc)
 PY
 
-# A leaked htsserver wedges the parallel harness behind a green log.
-cleanup
-! kill -0 "${srv}" 2>/dev/null || fail "htsserver ${srv} survived"
+htsserver_cleanup
+htsserver_assert_reaped
 
 echo "PASS"

--- a/tests/83_webhttrack-argescape.test
+++ b/tests/83_webhttrack-argescape.test
@@ -7,109 +7,31 @@
 set -euo pipefail
 
 testdir=$(cd "$(dirname "$0")" && pwd)
-distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
-distdir=$(cd "${distdir}" && pwd)
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
+htsserver_require
 
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-command -v python3 >/dev/null || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
-
-srv=
-log=$(mktemp)
 cleanup() {
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
-    rm -f "${log}"
+    htsserver_cleanup
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
 
-freeport() {
-    python3 -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()'
-}
+htsserver_start
+test -n "${HTS_PID}" || fail "htsserver did not report its pid"
 
-# Echo the announced URL. Runs in a command substitution, so it is a
-# subshell and cannot export the pid: the caller reads it back with srvpid.
-start() {
-    local port url
-    port=$(freeport)
-    : >"${log}"
-    (
-        trap '' TERM TTOU
-        exec htsserver "${distdir}/" --port "${port}" >"${log}" 2>&1
-    ) &
-    for _ in $(seq 1 40); do
-        url=$(sed -n 's/^URL=//p' "${log}" 2>/dev/null) && test -n "${url}" && break
-        sleep 0.25
-    done
-    test -n "${url:-}" || fail "htsserver did not come up: $(cat "${log}")"
-    echo "${url}"
-}
-
-srvpid() { sed -n 's/^PID=//p' "${log}" | head -1; }
-
-portof() { echo "${1##*:}" | tr -d /; }
-
-# Raw request to 127.0.0.1:$1; $2 is the body ("" for a GET of the $3 page,
-# default index). Prints the reply.
-request() {
-    python3 -c 'import socket, sys
-port, body = int(sys.argv[1]), sys.argv[2]
-page = sys.argv[3] if len(sys.argv) > 3 else "index"
-if body:
-    req = ("POST / HTTP/1.0\r\nHost: 127.0.0.1\r\n"
-           "Content-type: application/x-www-form-urlencoded\r\n"
-           "Content-length: %d\r\n\r\n%s" % (len(body), body))
-else:
-    req = ("GET /server/%s.html HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n" % page)
-s = socket.create_connection(("127.0.0.1", port), 10)
-s.settimeout(30)
-s.sendall(req.encode())
-out = b""
-while True:
-    b = s.recv(65536)
-    if not b:
-        break
-    out += b
-s.close()
-sys.stdout.write(out.decode("latin-1"))' "$1" "$2" ${3+"$3"}
-}
-
-scrape_sid() {
-    request "$1" "" | sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p' | head -1
-}
-
-# urlencode the key=value pairs given as arguments
-formencode() {
-    python3 -c 'import sys, urllib.parse
-print(urllib.parse.urlencode([tuple(a.split("=", 1)) for a in sys.argv[1:]]))' "$@"
-}
-
-url=$(start)
-port=$(portof "${url}")
-srv=$(srvpid)
-test -n "${srv}" || fail "htsserver did not report its pid"
-
-sid=$(scrape_sid "${port}")
+sid=$(htsserver_sid)
 test "${#sid}" -eq 32 || fail "did not scrape a 32-hex sid from the page (got '${sid}')"
 
 # Fill the wizard fields with what would break each position, then read back the
 # generated command line; the project name stays plain as a control.
-body=$(formencode "sid=${sid}" 'user=Moz" -V "touch /tmp/pwn' 'footer=a\b"c' \
-    "path=/tmp/p" "projname=plain proj" 'urls=http://x/a"b' 'url2=+*.png"</textarea>' \
-    'sitemapurl=http://x/s.xml"b')
-request "${port}" "${body}" >/dev/null
-cmdline=$(request "${port}" "" step4 |
+htsserver_client --field "sid=${sid}" \
+    --field 'user=Moz" -V "touch /tmp/pwn' --field 'footer=a\b"c' \
+    --field 'path=/tmp/p' --field 'projname=plain proj' \
+    --field 'urls=http://x/a"b' --field 'url2=+*.png"</textarea>' \
+    --field 'sitemapurl=http://x/s.xml"b' >/dev/null
+cmdline=$(htsserver_get /server/step4.html |
     sed -n '/<textarea name="command"/,/<\/textarea>/p')
 
 # Control: without the fields in the page every assertion below is vacuous.

--- a/tests/84_webhttrack-mirror-verbatim.test
+++ b/tests/84_webhttrack-mirror-verbatim.test
@@ -6,100 +6,21 @@
 set -euo pipefail
 
 testdir=$(cd "$(dirname "$0")" && pwd)
-distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
-distdir=$(cd "${distdir}" && pwd)
-# shellcheck source=tests/testlib.sh
-. "${testdir}/testlib.sh"
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
+htsserver_require
 
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-command -v python3 >/dev/null || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
-
-log=$(mktemp)
 work=$(mktemp -d)
 csrv=
-# start() runs in a command substitution, so its $! never reaches this shell. A
-# missed kill leaves an orphan holding the CI job open long after a green suite.
-srvpid() { sed -n 's/^PID=//p' "${log}" 2>/dev/null | head -1; }
 cleanup() {
-    local pid
-    pid=$(srvpid)
-    test -z "${pid}" || kill -9 "${pid}" 2>/dev/null || true
+    htsserver_cleanup
     test -z "${csrv}" || kill -9 "${csrv}" 2>/dev/null || true
     wait "${csrv}" 2>/dev/null || true # absorb bash's async "Killed" notice
-    rm -rf "${log}" "${work}"
+    rm -rf "${work}"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
-
-freeport() {
-    python3 -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()'
-}
-
-# Echo the announced URL.
-start() {
-    local port url
-    port=$(freeport)
-    : >"${log}"
-    (
-        trap '' TERM TTOU
-        exec htsserver "${distdir}/" --port "${port}" >"${log}" 2>&1
-    ) &
-    for _ in $(seq 1 40); do
-        url=$(sed -n 's/^URL=//p' "${log}" 2>/dev/null) && test -n "${url}" && break
-        sleep 0.25
-    done
-    test -n "${url:-}" || fail "htsserver did not come up: $(cat "${log}")"
-    echo "${url}"
-}
-
-portof() { echo "${1##*:}" | tr -d /; }
-
-# GET $2 from 127.0.0.1:$1, headers into $3 and the body, byte for byte, into $4.
-fetch() {
-    python3 -c 'import socket, sys
-s = socket.create_connection(("127.0.0.1", int(sys.argv[1])), 10)
-s.settimeout(20)
-s.sendall(("GET %s HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n" % sys.argv[2]).encode())
-out = b""
-while True:
-    b = s.recv(65536)
-    if not b:
-        break
-    out += b
-s.close()
-head, _, body = out.partition(b"\r\n\r\n")
-open(sys.argv[3], "wb").write(head)
-open(sys.argv[4], "wb").write(body)' "$1" "$2" "$3" "$4"
-}
-
-# POST the remaining args as urlencoded key=value fields to 127.0.0.1:$1.
-post() {
-    local port=$1
-    shift
-    python3 -c 'import socket, sys, urllib.parse
-body = "&".join("%s=%s" % (k, urllib.parse.quote(v, safe=""))
-                for k, v in (a.split("=", 1) for a in sys.argv[2:])).encode()
-s = socket.create_connection(("127.0.0.1", int(sys.argv[1])), 10)
-s.settimeout(30)
-s.sendall(b"POST /step4.html HTTP/1.0\r\nHost: 127.0.0.1\r\n"
-          b"Content-type: application/x-www-form-urlencoded\r\n"
-          b"Content-length: %d\r\n\r\n" % len(body) + body)
-while s.recv(65536):
-    pass
-s.close()' "${port}" "$@" >/dev/null
-}
 
 # LF-only, and a line ending in a backslash: the expander rewrites both, so a
 # mangled reply fails the byte comparison even where no directive is present.
@@ -111,27 +32,27 @@ body="${work}/body"
 # point it somewhere empty so a developer's own file cannot shadow the fields.
 export HOME="${work}"
 
-url=$(start)
-port=$(portof "${url}")
+htsserver_start
 
 # Positive control: the GUI's own templates must still expand. This is also
 # where the real token comes from, so its absence below can be asserted.
-fetch "${port}" /server/index.html "${hdr}" "${body}"
-sid=$(sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p' "${body}" | head -1)
+htsserver_client --path /server/index.html --head-file "${hdr}" --body-file "${body}"
+sid=$(firstline "$(sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p' "${body}")")
 test "${#sid}" -eq 32 || fail "GUI page did not expand \${sid} (got '${sid}')"
 
 # /website/ serves only the root the server itself recorded, so save a profile
 # (no command_do=start, so nothing crawls) to create it, then plant the file.
-post "${port}" "sid=${sid}" command=httrack command_do=save winprofile=x \
-    "path=${work}" projname=proj
+htsserver_client --path /step4.html --field "sid=${sid}" --field command=httrack \
+    --field command_do=save --field winprofile=x \
+    --field "path=${work}" --field projname=proj >/dev/null
 test -f "${work}/proj/hts-cache/winprofile.ini" ||
-    fail "profile save did not create the project: $(cat "${log}")"
+    fail "profile save did not create the project: $(cat "${HTS_LOG}")"
 mkdir -p "$(dirname "${mirror}")"
 # shellcheck disable=SC2016 # the directives are the payload, not shell expansions
 printf 'Hostile mirrored page.\nsid=${_sid} copy=${sid}\ntrailing backslash: \\\n' \
     >"${mirror}"
 
-fetch "${port}" /website/hostile.html "${hdr}" "${body}"
+htsserver_client --path /website/hostile.html --head-file "${hdr}" --body-file "${body}"
 grep -q '^HTTP/1\.0 200 ' "${hdr}" || fail "mirrored page not served: $(head -1 "${hdr}")"
 grep -qF "${sid}" "${body}" &&
     fail "the session id was expanded into mirrored content"
@@ -148,16 +69,17 @@ grep -qi '^Content-type: text/html' "${hdr}" ||
 # the GUI's own refresh page, so a /website/ URL stops naming mirrored content.
 # /trickle/ dribbles for a minute, which holds the crawl open for the probe.
 clog="${work}/content.log"
-python3 "${testdir}/local-server.py" --root "${work}" >"${clog}" 2>&1 &
+"${HTS_PYTHON}" "${testdir}/local-server.py" --root "${work}" >"${clog}" 2>&1 &
 csrv=$!
 cport=$(discover_server_port "${clog}" "${csrv}") ||
     fail "content server did not come up"
 
-post "${port}" "sid=${sid}" "path=${work}" projname=crawl winprofile=x \
-    command_do=start \
-    "command=httrack --quiet --robots=0 http://127.0.0.1:${cport}/trickle/ -O ${work}/crawl"
+htsserver_client --path /step4.html --field "sid=${sid}" --field "path=${work}" \
+    --field projname=crawl --field winprofile=x --field command_do=start \
+    --field "command=httrack --quiet --robots=0 http://127.0.0.1:${cport}/trickle/ -O ${work}/crawl" \
+    >/dev/null
 
-fetch "${port}" /website/hostile.html "${hdr}" "${body}"
+htsserver_client --path /website/hostile.html --head-file "${hdr}" --body-file "${body}"
 grep -q '^HTTP/1\.0 200 ' "${hdr}" ||
     fail "running crawl: /website/ was not overridden to the GUI page: $(head -1 "${hdr}")"
 grep -qF "'crawl' - HTTrack Website Copier" "${body}" ||

--- a/tests/85_webhttrack-projpath.test
+++ b/tests/85_webhttrack-projpath.test
@@ -6,108 +6,34 @@
 set -euo pipefail
 
 testdir=$(cd "$(dirname "$0")" && pwd)
-distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
-distdir=$(cd "${distdir}" && pwd)
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
+htsserver_require
 
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-command -v python3 >/dev/null || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
-
-srv=
-log=$(mktemp)
 base=$(mktemp -d)
 cleanup() {
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
-    rm -f "${log}"
+    htsserver_cleanup
     rm -rf "${base}"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
 
-freeport() {
-    python3 -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()'
-}
-
-# Echo the announced URL. Runs in a command substitution, so it is a
-# subshell and cannot export the pid: the caller reads it back with srvpid.
-start() {
-    local port url
-    port=$(freeport)
-    : >"${log}"
-    (
-        trap '' TERM TTOU
-        exec htsserver "${distdir}/" --port "${port}" >"${log}" 2>&1
-    ) &
-    for _ in $(seq 1 40); do
-        url=$(sed -n 's/^URL=//p' "${log}" 2>/dev/null) && test -n "${url}" && break
-        sleep 0.25
-    done
-    test -n "${url:-}" || fail "htsserver did not come up: $(cat "${log}")"
-    echo "${url}"
-}
-
-# The server reports its own pid; the aliveness assertion below hangs off it.
-srvpid() { sed -n 's/^PID=//p' "${log}" | head -1; }
-
-alive() { kill -0 "$1" 2>/dev/null; }
-
-portof() { echo "${1##*:}" | tr -d /; }
-
-# Raw request to 127.0.0.1:$1: GET the path $2, or POST the body $3 to / when
-# $2 is empty. Prints the reply.
-request() {
-    python3 -c 'import socket, sys
-port, path, body = int(sys.argv[1]), sys.argv[2], sys.argv[3]
-if path:
-    req = "GET %s HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n" % path
-else:
-    req = ("POST / HTTP/1.0\r\nHost: 127.0.0.1\r\n"
-           "Content-type: application/x-www-form-urlencoded\r\n"
-           "Content-length: %d\r\n\r\n%s" % (len(body), body))
-s = socket.create_connection(("127.0.0.1", port), 10)
-s.settimeout(30)
-s.sendall(req.encode())
-out = b""
-while True:
-    b = s.recv(65536)
-    if not b:
-        break
-    out += b
-s.close()
-sys.stdout.write(out.decode("latin-1"))' "$1" "$2" "$3"
-}
-
-get() { request "$1" "$2" ""; }
-post() { request "$1" "" "$2"; }
-
-# GET $2 into ${reply}, requiring status $3. Captured, not piped: a dead request
+# GET $1 into ${reply}, requiring status $2. Captured, not piped: a dead request
 # reads as marker-absent, and so do a truncated body and a 302 to the file.
 reply=
 fetch() {
-    reply=$(get "$1" "$2") || fail "the request for $2 failed"
-    grep -q "^HTTP/1\.0 $3 " <<<"${reply}" ||
-        fail "$2: wanted a $3 reply, got '$(head -1 <<<"${reply}")'"
+    reply=$(htsserver_get "$1") || fail "the request for $1 failed"
+    grep -q "^HTTP/1\.0 $2 " <<<"${reply}" ||
+        fail "$1: wanted a $2 reply, got '$(head -1 <<<"${reply}")'"
 }
 
-url=$(start)
-port=$(portof "${url}")
-srv=$(srvpid)
-test -n "${srv}" || fail "htsserver did not report its pid"
+htsserver_start
+# The aliveness assertion below hangs off the pid the server reports.
+test -n "${HTS_PID}" || fail "htsserver did not report its pid"
 
 # Every request body is gated by the session id (78_webhttrack-sid.test).
-sid=$(get "${port}" /server/index.html |
-    sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p' | head -1)
+sid=$(htsserver_sid)
 test "${#sid}" -eq 32 || fail "did not scrape a 32-hex sid (got '${sid}')"
 
 # A file the mirror must never expose, next to the project that may.
@@ -118,14 +44,14 @@ echo "LOGMARKER" >"${base}/proj/hts-log.txt"
 # error_redirect is the branch that skipped the fsfile clearing, so fail the save
 # with a component over NAME_MAX (mkdir refuses it whatever the uid). Must precede
 # any successful save: commandEnd then swaps the error page for the finished one.
-get "${port}" /server/style.css >/dev/null # leaves a path behind in fsfile
-saved=$(post "${port}" "sid=${sid}&command=httrack&command_do=save&winprofile=x&path=${base}/$(printf '%0300d' 0)&projname=p")
+htsserver_get /server/style.css >/dev/null # leaves a path behind in fsfile
+saved=$(htsserver_post "sid=${sid}&command=httrack&command_do=save&winprofile=x&path=${base}/$(printf '%0300d' 0)&projname=p")
 grep -q '^Location: /server/error.html' <<<"${saved}" ||
     fail "the refused save did not redirect to the error page"
 
 # No project yet, so no root to serve from.
-post "${port}" "sid=${sid}&projpath=${base}/" >/dev/null
-fetch "${port}" /website/secret.txt 404
+htsserver_post "sid=${sid}&projpath=${base}/" >/dev/null
+fetch /website/secret.txt 404
 grep -q SECRETMARKER <<<"${reply}" &&
     fail "a posted projpath served a file outside any project"
 
@@ -134,31 +60,31 @@ grep -q SECRETMARKER <<<"${reply}" &&
 # around it would pass on a server that never serves /website/ at all.
 body="sid=${sid}&command=httrack&command_do=save&winprofile=x"
 body="${body}&path=${base}&projname=proj&projpath=${base}/proj/"
-post "${port}" "${body}" >/dev/null
+htsserver_post "${body}" >/dev/null
 test -f "${base}/proj/hts-cache/winprofile.ini" ||
-    fail "the project was not registered: $(cat "${log}")"
-fetch "${port}" /website/hts-log.txt 200
+    fail "the project was not registered: $(cat "${HTS_LOG}")"
+fetch /website/hts-log.txt 200
 grep -q LOGMARKER <<<"${reply}" ||
     fail "the registered project's mirror is not served"
 
 # Same request with the root repointed: the project is legitimate, projpath is
 # not what decides where the bytes come from.
-post "${port}" "sid=${sid}&projpath=${base}/" >/dev/null
-fetch "${port}" /website/secret.txt 404
+htsserver_post "sid=${sid}&projpath=${base}/" >/dev/null
+fetch /website/secret.txt 404
 grep -q SECRETMARKER <<<"${reply}" &&
     fail "a posted projpath repointed the served root"
-post "${port}" "sid=${sid}&projpath=/etc/" >/dev/null
-fetch "${port}" /website/passwd 404
+htsserver_post "sid=${sid}&projpath=/etc/" >/dev/null
+fetch /website/passwd 404
 grep -q '^root:' <<<"${reply}" &&
     fail "a posted projpath read an arbitrary system file"
 
 # A ".." anywhere in the recorded root would escape the mirror on every later
 # request, so the save must be refused and the previous root kept.
-post "${port}" "sid=${sid}&command=httrack&command_do=save&winprofile=x&path=${base}/proj&projname=.." >/dev/null
-fetch "${port}" /website/secret.txt 404
+htsserver_post "sid=${sid}&command=httrack&command_do=save&winprofile=x&path=${base}/proj&projname=.." >/dev/null
+fetch /website/secret.txt 404
 grep -q SECRETMARKER <<<"${reply}" &&
     fail "a '..' in the saved project path escaped the mirror root"
-fetch "${port}" /website/hts-log.txt 200
+fetch /website/hts-log.txt 200
 grep -q LOGMARKER <<<"${reply}" ||
     fail "rejecting the '..' root also lost the previous one"
 
@@ -173,12 +99,12 @@ test "$((${#fspath} + 11))" -le 1024 ||
 longurl=$(printf '%0800d' 0)
 test "$((${#fspath} + 1 + ${#longurl}))" -gt 1024 ||
     fail "the composed path (${#fspath} + ${#longurl}) would not overflow"
-post "${port}" "sid=${sid}&command=httrack&command_do=save&winprofile=x&path=${longpath}&projname=proj" >/dev/null
+htsserver_post "sid=${sid}&command=httrack&command_do=save&winprofile=x&path=${longpath}&projname=proj" >/dev/null
 test -f "${fspath}/hts-cache/winprofile.ini" ||
-    fail "the long-path project was not registered: $(cat "${log}")"
-get "${port}" "/website/${longurl}" >/dev/null 2>&1 || true
-alive "${srv}" || fail "an over-long project path crashed the server: $(cat "${log}")"
+    fail "the long-path project was not registered: $(cat "${HTS_LOG}")"
+htsserver_get "/website/${longurl}" >/dev/null 2>&1 || true
+htsserver_alive || fail "an over-long project path crashed the server: $(cat "${HTS_LOG}")"
 # Not just alive: still answering.
-fetch "${port}" /server/index.html 200
+fetch /server/index.html 200
 
 echo "PASS"

--- a/tests/89_webhttrack-error-overflow.test
+++ b/tests/89_webhttrack-error-overflow.test
@@ -6,97 +6,23 @@
 set -euo pipefail
 
 testdir=$(cd "$(dirname "$0")" && pwd)
-distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
-distdir=$(cd "${distdir}" && pwd)
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
-
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-command -v python3 >/dev/null || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
+htsserver_require
 
 # ERROR_MESSAGE_MAX - 1 in htsserver.c.
 msgmax=1023
 
-srv=
-log=$(mktemp)
 # Physical path: macOS resolves TMPDIR through /var -> private/var, and the
 # paths built below sit within a few bytes of its 1024-byte PATH_MAX.
 base=$(cd "$(mktemp -d)" && pwd -P)
 cleanup() {
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
-    rm -f "${log}"
+    htsserver_cleanup
     rm -rf "${base}"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
-
-freeport() {
-    python3 -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()'
-}
-
-# Echo the announced URL. Runs in a command substitution, so it is a
-# subshell and cannot export the pid: the caller reads it back with srvpid.
-start() {
-    local port url
-    port=$(freeport)
-    : >"${log}"
-    (
-        trap '' TERM TTOU XFSZ
-        # Caps regular-file writes, which is how the failing-write branch below
-        # is reached without /dev/full; the announce rides a pipe, exempt.
-        ulimit -f 8
-        exec htsserver "${distdir}/" --port "${port}" 2>&1
-    ) | cat >"${log}" &
-    for _ in $(seq 1 40); do
-        url=$(sed -n 's/^URL=//p' "${log}" 2>/dev/null) && test -n "${url}" && break
-        sleep 0.25
-    done
-    test -n "${url:-}" || fail "htsserver did not come up: $(cat "${log}")"
-    echo "${url}"
-}
-
-srvpid() { sed -n 's/^PID=//p' "${log}" | head -1; }
-
-alive() { kill -0 "$1" 2>/dev/null; }
-
-portof() { echo "${1##*:}" | tr -d /; }
-
-# Raw request to 127.0.0.1:$1: GET the path $2, or POST the body $3 to / when
-# $2 is empty. Prints the reply.
-request() {
-    python3 -c 'import socket, sys
-port, path, body = int(sys.argv[1]), sys.argv[2], sys.argv[3]
-if path:
-    req = "GET %s HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n" % path
-else:
-    req = ("POST / HTTP/1.0\r\nHost: 127.0.0.1\r\n"
-           "Content-type: application/x-www-form-urlencoded\r\n"
-           "Content-length: %d\r\n\r\n%s" % (len(body), body))
-s = socket.create_connection(("127.0.0.1", port), 10)
-s.settimeout(30)
-s.sendall(req.encode())
-out = b""
-while True:
-    b = s.recv(65536)
-    if not b:
-        break
-    out += b
-s.close()
-sys.stdout.write(out.decode("latin-1"))' "$1" "$2" "$3"
-}
-
-get() { request "$1" "$2" ""; }
-post() { request "$1" "" "$2"; }
 
 # Echo a path under the root $1 exactly $2 bytes long, in NAME_MAX-sized parts.
 padpath() {
@@ -115,7 +41,7 @@ check_clipped() {
     local prefix=$1 full=$((${#1} + ${#2})) page line shown
     test "${full}" -gt "${msgmax}" ||
         fail "a ${full}-byte message fits in ${msgmax}: it cannot show a clip"
-    page=$(get "${port}" /server/error.html | tr -d '\r')
+    page=$(htsserver_get /server/error.html | tr -d '\r')
     line=$(printf '%s\n' "${page}" | grep "^${prefix}") || {
         shown=$(printf '%s\n' "${page}" | grep '^Unable to ' | cut -c1-80 || true)
         fail "the error page reports '${shown:-nothing}', want: ${prefix}"
@@ -124,25 +50,23 @@ check_clipped() {
         fail "the message rendered ${#line} bytes, want ${full} clipped to ${msgmax}"
 }
 
-url=$(start)
-port=$(portof "${url}")
-srv=$(srvpid)
-test -n "${srv}" || fail "htsserver did not report its pid"
+# The write cap is how the failing-write branch below is reached without /dev/full.
+htsserver_start --write-limit 8
+test -n "${HTS_PID}" || fail "htsserver did not report its pid"
 
 # Every request body is gated by the session id (78_webhttrack-sid.test).
-sid=$(get "${port}" /server/index.html |
-    sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p' | head -1)
+sid=$(htsserver_sid)
 test "${#sid}" -eq 32 || fail "did not scrape a 32-hex sid (got '${sid}')"
 
 save() {
-    post "${port}" "sid=${sid}&command=httrack&command_do=save&winprofile=$2&path=$1&projname=$3"
+    htsserver_post "sid=${sid}&command=httrack&command_do=save&winprofile=$2&path=$1&projname=$3"
 }
 
 # A project path too long to be created at all.
 path=$(padpath "${base}/nodir" 1098)
 save "${path}" x p >/dev/null
-alive "${srv}" ||
-    fail "an over-long project path crashed the server: $(cat "${log}")"
+htsserver_alive ||
+    fail "an over-long project path crashed the server: $(cat "${HTS_LOG}")"
 check_clipped "Unable to create the directory structure in " "${path}/p"
 
 # A creatable project path whose hts-cache is not a directory, so the init file
@@ -151,7 +75,7 @@ path=$(padpath "${base}/isdir" 993)
 mkdir -p "${path}/p"
 ln -s /dev/null "${path}/p/hts-cache"
 save "${path}" x p >/dev/null
-alive "${srv}" || fail "an unwritable init file crashed the server: $(cat "${log}")"
+htsserver_alive || fail "an unwritable init file crashed the server: $(cat "${HTS_LOG}")"
 check_clipped "Unable to create the init file " "${path}/p"
 
 # The init file opens, then the write fails: the profile is past both stdio's
@@ -163,13 +87,13 @@ profile=${profile}${profile}${profile}${profile}
 profile=${profile}${profile}${profile}${profile}
 test "${#profile}" -eq 16384 || fail "built a ${#profile}-byte profile, want 16384"
 save "${path}" "${profile}" p >/dev/null
-alive "${srv}" || fail "a short init file write crashed the server: $(cat "${log}")"
+htsserver_alive || fail "a short init file write crashed the server: $(cat "${HTS_LOG}")"
 written=$(wc -c <"${path}/p/hts-cache/winprofile.ini" | tr -d ' ')
 test "${written}" -lt "${#profile}" ||
     fail "the file-size limit did not stop the write (${written} bytes landed)"
 check_clipped "Unable to write ${#profile} bytes in the the init file " "${path}/p"
 
-reply=$(get "${port}" /server/index.html || true)
+reply=$(htsserver_get /server/index.html || true)
 grep -q '200 OK' <<<"$reply" ||
     fail "the server stopped answering after the refused saves"
 

--- a/tests/90_webhttrack-checkbox-clear.test
+++ b/tests/90_webhttrack-checkbox-clear.test
@@ -8,55 +8,22 @@ set -euo pipefail
 testdir=$(cd "$(dirname "$0")" && pwd)
 distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
 distdir=$(cd "${distdir}" && pwd)
-# shellcheck source=tests/testlib.sh
-. "${testdir}/testlib.sh"
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
-
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-python=$(find_python) || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
+htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_checkbox.XXXXXX") || fail "no tmpdir"
-srvlog=$(mktemp)
-srv=
-srvpid=
 cleanup() {
-    # htsserver keeps SIGTERM ignored across its exec, so only -9 reaps it.
-    test -z "${srvpid}" || kill -9 "${srvpid}" 2>/dev/null || true
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
-    wait "${srv}" 2>/dev/null || true # absorb bash's async "Killed" notice
-    rm -rf "${work}" "${srvlog}"
+    htsserver_cleanup
+    rm -rf "${work}"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
 
-# An isolated HOME keeps a stray ~/.httrack.ini out of the served settings.
-sport=$("${python}" -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()')
-(
-    trap '' TERM TTOU
-    export HOME="${work}"
-    exec htsserver "${distdir}/" --port "${sport}" >"${srvlog}" 2>&1
-) &
-srv=$!
-for _ in $(seq 1 40); do
-    url=$(sed -n 's/^URL=//p' "${srvlog}") && test -n "${url}" && break
-    kill -0 "${srv}" 2>/dev/null || break
-    sleep 0.25
-done
-test -n "${url:-}" || fail "htsserver did not start: $(cat "${srvlog}")"
-srvpid=$(sed -n 's/^PID=//p' "${srvlog}") # absent on Windows
+htsserver_start --home "${work}"
 
-"${python}" - "${url}" "${distdir}" <<'PY' || fail "checkbox clearing is broken (see above)"
+"${HTS_PYTHON}" - "${HTS_URL}" "${distdir}" <<'PY' || fail "checkbox clearing is broken (see above)"
 import glob, os, re, sys, urllib.parse, urllib.request
 
 url, srcdir = sys.argv[1].rstrip("/"), sys.argv[2]
@@ -194,8 +161,7 @@ check(not checked("option8.html", "cookies"), "cookies=on&cookies= draws an empt
 sys.exit(rc)
 PY
 
-# A leaked htsserver wedges the parallel harness behind a green log.
-cleanup
-! kill -0 "${srv}" 2>/dev/null || fail "htsserver ${srv} survived"
+htsserver_cleanup
+htsserver_assert_reaped
 
 echo "PASS"

--- a/tests/91_webhttrack-directory.test
+++ b/tests/91_webhttrack-directory.test
@@ -6,119 +6,38 @@
 set -euo pipefail
 
 testdir=$(cd "$(dirname "$0")" && pwd)
-distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
-distdir=$(cd "${distdir}" && pwd)
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
+htsserver_require
 
-command -v htsserver >/dev/null || fail "no htsserver in PATH"
-command -v python3 >/dev/null || {
-    echo "python3 not found; skipping" >&2
-    exit 77
-}
-
-srv=
-log=$(mktemp)
 base=$(mktemp -d)
 cleanup() {
-    test -z "${srv}" || kill -9 "${srv}" 2>/dev/null || true
-    rm -f "${log}"
+    htsserver_cleanup
     rm -rf "${base}"
 }
 trap 'set +e; cleanup' EXIT
 trap cleanup HUP INT QUIT PIPE TERM
 
-# First line only. A "| head -1" would close the pipe early and, under pipefail,
-# SIGPIPE the producer into a spurious failure.
-firstline() { echo "${1%%$'\n'*}"; }
-
-freeport() {
-    python3 -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()'
-}
-
-# Echo the announced URL. Runs in a command substitution, so it is a
-# subshell and cannot export the pid: the caller reads it back with srvpid.
-start() {
-    local port url
-    port=$(freeport)
-    : >"${log}"
-    (
-        trap '' TERM TTOU
-        exec htsserver "${distdir}/" --port "${port}" >"${log}" 2>&1
-    ) &
-    for _ in $(seq 1 40); do
-        url=$(sed -n 's/^URL=//p' "${log}" 2>/dev/null) && test -n "${url}" && break
-        sleep 0.25
-    done
-    test -n "${url:-}" || fail "htsserver did not come up: $(cat "${log}")"
-    echo "${url}"
-}
-
-# The server reports its own pid; the aliveness assertion below hangs off it.
-srvpid() { firstline "$(sed -n 's/^PID=//p' "${log}")"; }
-
-alive() { kill -0 "$1" 2>/dev/null; }
-
-portof() { echo "${1##*:}" | tr -d /; }
-
-# GET the path $2 from 127.0.0.1:$1, or POST the body $3 to / when $2 is empty.
-# The socket timeout is what makes an unfixed tree fail rather than wedge CI.
-request() {
-    python3 -c 'import socket, sys
-port, path, body = int(sys.argv[1]), sys.argv[2], sys.argv[3]
-if path:
-    req = "GET %s HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n" % path
-else:
-    req = ("POST / HTTP/1.0\r\nHost: 127.0.0.1\r\n"
-           "Content-type: application/x-www-form-urlencoded\r\n"
-           "Content-length: %d\r\n\r\n%s" % (len(body), body))
-s = socket.create_connection(("127.0.0.1", port), 10)
-s.settimeout(15)
-s.sendall(req.encode())
-out = b""
-try:
-    while True:
-        b = s.recv(65536)
-        if not b:
-            break
-        out += b
-except socket.timeout:
-    sys.stderr.write("timed out after %d bytes\n" % len(out))
-    sys.exit(9)
-s.close()
-sys.stdout.write(out.decode("latin-1"))' "$1" "$2" "$3"
-}
-
-# GET $2, or fail with $3 when the reply never comes.
+# GET $1, or fail with $2 when the reply never comes.
 get() {
     local out
-    out=$(request "$1" "$2" "") || fail "$2 did not answer: $3"
+    out=$(htsserver_get "$1") || fail "$1 did not answer: $2"
     echo "${out}"
 }
 
-post() { request "$1" "" "$2"; }
-
-url=$(start)
-port=$(portof "${url}")
-srv=$(srvpid)
-test -n "${srv}" || fail "htsserver did not report its pid"
+htsserver_start
+test -n "${HTS_PID}" || fail "htsserver did not report its pid"
 
 # Needs no session id and no project: html/server is a directory of the install.
-reply=$(get "${port}" /server/ "an unauthenticated request wedged the server")
+reply=$(get /server/ "an unauthenticated request wedged the server")
 case "${reply}" in
 "HTTP/1.0 404 "*) ;;
 *) fail "a GUI directory did not answer 404: $(firstline "${reply}")" ;;
 esac
 
 # Every request body is gated by the session id.
-reply=$(get "${port}" /server/index.html "the GUI is not served")
+reply=$(get /server/index.html "the GUI is not served")
 sid=$(firstline "$(echo "${reply}" |
     sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p')")
 test "${#sid}" -eq 32 || fail "did not scrape a 32-hex sid (got '${sid}')"
@@ -137,26 +56,26 @@ ln -s probe.txt "${base}/proj/link.txt" 2>/dev/null || true
 # is what arms the /website/ root.
 body="sid=${sid}&command=httrack&command_do=save&winprofile=x"
 body="${body}&path=${base}&projname=proj"
-post "${port}" "${body}" >/dev/null || fail "the save request did not answer"
+htsserver_post "${body}" >/dev/null || fail "the save request did not answer"
 test -f "${base}/proj/hts-cache/winprofile.ini" ||
-    fail "the project was not registered: $(cat "${log}")"
+    fail "the project was not registered: $(cat "${HTS_LOG}")"
 
 # Positive control: every assertion below would pass on a server serving nothing.
 served() {
-    case "$(get "$1" "$2" "$3")" in
+    case "$(get "$1" "$2")" in
     *PROBEMARKER*) ;;
-    *) fail "$3" ;;
+    *) fail "$2" ;;
     esac
 }
-served "${port}" /website/probe.txt "the registered project's mirror is not served"
+served /website/probe.txt "the registered project's mirror is not served"
 if test -L "${base}/proj/link.txt"; then
     # The guard stats rather than lstats, so a symlinked mirror file still serves.
-    served "${port}" /website/link.txt "a symlink to a mirror file is not served"
+    served /website/link.txt "a symlink to a mirror file is not served"
 fi
 
 # /website/ is where the GUI's own "browse mirrored site" link points.
 for path in "${refuse[@]}"; do
-    reply=$(get "${port}" "${path}" "the server wedged on ${path}")
+    reply=$(get "${path}" "the server wedged on ${path}")
     case "${reply}" in
     "HTTP/1.0 404 "*) ;;
     *) fail "${path} did not answer 404: $(firstline "${reply}")" ;;
@@ -164,19 +83,19 @@ for path in "${refuse[@]}"; do
 done
 
 # The accept loop is single-threaded: one spin denies every later request.
-alive "${srv}" || fail "the server died: $(cat "${log}")"
-served "${port}" /website/probe.txt "the server stopped answering after a directory request"
+htsserver_alive || fail "the server died: $(cat "${HTS_LOG}")"
+served /website/probe.txt "the server stopped answering after a directory request"
 
 # This fopen() is reached before any guard, so its read loop must stop on ferror().
 mkdir -p "${base}/proj2/hts-cache/winprofile.ini"
-reply=$(post "${port}" "sid=${sid}&path=${base}&loadprojname=proj2") ||
+reply=$(htsserver_post "sid=${sid}&path=${base}&loadprojname=proj2") ||
     fail "a directory winprofile.ini wedged the server"
 case "${reply}" in
 "HTTP/1.0 3"*) ;;
 *) fail "loading a project did not redirect: $(firstline "${reply}")" ;;
 esac
 
-alive "${srv}" || fail "the server died: $(cat "${log}")"
-served "${port}" /website/probe.txt "the server stopped answering after a project load"
+htsserver_alive || fail "the server died: $(cat "${HTS_LOG}")"
+served /website/probe.txt "the server stopped answering after a project load"
 
 echo "PASS"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,6 +12,7 @@ EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c a
 	header-injection-server.py header-injection-check.py \
 	pty-resize.py ttyrun.py test-timeout.sh png-colors.py \
 	local-crawl.sh local-server.py ftp-server.py testlib.sh \
+	webhttracklib.sh httpclient.py \
 	ci-windows-suite.sh ci-windows-watchdog.ps1 \
 	server.crt server.key \
 	server-root/simple/basic.html server-root/simple/link.html \

--- a/tests/httpclient.py
+++ b/tests/httpclient.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 """Raw HTTP/1.0 client for the htsserver tests.
 
-Speaks the socket directly rather than through urllib: the tests assert on the
-status line and on header bytes urllib parses away, and they need a reply even
-when the server answers with a headerless fragment.
+Speaks the socket directly: the tests assert on status-line and header bytes
+urllib parses away, and need a reply even from a headerless fragment.
 """
 import argparse
 import socket

--- a/tests/httpclient.py
+++ b/tests/httpclient.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Raw HTTP/1.0 client for the htsserver tests.
+
+Speaks the socket directly rather than through urllib: the tests assert on the
+status line and on header bytes urllib parses away, and they need a reply even
+when the server answers with a headerless fragment.
+"""
+import argparse
+import socket
+import sys
+import urllib.parse
+
+
+def build_request(args):
+    if args.field or args.post is not None:
+        if args.field:
+            # urlencode, not quote(): a browser sends "+" for a space, and the
+            # server decodes that on its own branch.
+            body = urllib.parse.urlencode([tuple(f.split("=", 1)) for f in args.field])
+        else:
+            body = args.post
+        return (
+            "POST %s HTTP/1.0\r\nHost: 127.0.0.1\r\n"
+            "Content-type: application/x-www-form-urlencoded\r\n"
+            "Content-length: %d\r\n\r\n%s" % (args.path or "/", len(body), body)
+        )
+    return "GET %s HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n" % (
+        args.path or "/server/index.html"
+    )
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--port", type=int, required=True)
+    p.add_argument("--path")
+    p.add_argument("--post", help="raw urlencoded body; POSTs it")
+    p.add_argument(
+        "--field",
+        action="append",
+        metavar="K=V",
+        help="POST field, form-encoded here; repeatable",
+    )
+    p.add_argument("--timeout", type=float, default=30)
+    p.add_argument(
+        "--headers-only",
+        action="store_true",
+        help="stop at the end of the header block; the server need not close",
+    )
+    p.add_argument("--head-file", help="write the header block here, not to stdout")
+    p.add_argument("--body-file", help="write the body here, not to stdout")
+    args = p.parse_args()
+
+    s = socket.create_connection(("127.0.0.1", args.port), 10)
+    s.settimeout(args.timeout)
+    s.sendall(build_request(args).encode())
+    out = b""
+    try:
+        while True:
+            if args.headers_only and b"\r\n\r\n" in out:
+                break
+            chunk = s.recv(65536)
+            if not chunk:
+                break
+            out += chunk
+    except socket.timeout:
+        # Exit rather than hang: a wedged server is the failure under test.
+        sys.stderr.write("timed out after %d bytes\n" % len(out))
+        sys.exit(9)
+    s.close()
+
+    if args.headers_only:
+        out = out.split(b"\r\n\r\n")[0]
+    if args.head_file or args.body_file:
+        head, _, body = out.partition(b"\r\n\r\n")
+        if args.head_file:
+            open(args.head_file, "wb").write(head)
+        if args.body_file:
+            open(args.body_file, "wb").write(body)
+        return
+    # The GUI is served ISO-8859-1, and a mirrored file can hold any byte.
+    sys.stdout.write(out.decode("latin-1"))
+
+
+main()

--- a/tests/webhttracklib.sh
+++ b/tests/webhttracklib.sh
@@ -17,29 +17,54 @@ fail() {
     exit 1
 }
 
+# 77 is automake's "skipped", not a failure.
 skip() {
     echo "$*; skipping" >&2
     exit 77
 }
 
-# First line of $1. A "| head -1" would close the pipe early and, under
-# pipefail, SIGPIPE the producer into a spurious failure.
-firstline() { printf '%s\n' "${1%%$'\n'*}"; }
+# Literals, not $'..': Apple's bash 3.2 loses quote state on that inside a
+# parameter expansion, and 21 tests source this file.
+HTS_NL='
+'
+HTS_CR=$(printf '\r')
 
-# What every test here needs. The Debian buildd chroot has no python3, so that
-# one skips rather than reds.
+# First line of $1. A "| head -1" would close the pipe early and, under pipefail,
+# SIGPIPE the producer into a spurious failure.
+firstline() { printf '%s\n' "${1%%"$HTS_NL"*}"; }
+
+# htsserver, plus a python3 the Debian buildd chroot may not have: that one skips.
 htsserver_require() {
     command -v htsserver >/dev/null || fail "no htsserver in PATH"
     HTS_PYTHON=$(find_python) || skip "python3 not found"
 }
 
-# A free loopback port; the socket is closed before htsserver rebinds it.
+# $1 free loopback ports (default 1), space separated. Bound together, so two
+# of them always differ; each is closed before htsserver rebinds it.
+# shellcheck disable=SC2120 # one port is the common case
 htsserver_freeport() {
-    "${HTS_PYTHON}" -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()'
+    "${HTS_PYTHON}" -c 'import socket, sys
+socks = [socket.socket() for _ in range(int(sys.argv[1]))]
+for s in socks:
+    s.bind(("127.0.0.1", 0))
+print(" ".join(str(s.getsockname()[1]) for s in socks))
+for s in socks:
+    s.close()' "${1:-1}"
+}
+
+# First URL= and PID= of the announcement, or empty. Windows announces no pid.
+htsserver_announced() {
+    local line
+    HTS_URL=
+    HTS_PID=
+    test -r "${HTS_LOG}" || return 0
+    while read -r line; do
+        line=${line%"$HTS_CR"}
+        case ${line} in
+        URL=*) test -n "${HTS_URL}" || HTS_URL=${line#URL=} ;;
+        PID=*) test -n "${HTS_PID}" || HTS_PID=${line#PID=} ;;
+        esac
+    done <"${HTS_LOG}"
 }
 
 # The server process; reads htsserver_start's locals and its background stdout.
@@ -58,10 +83,12 @@ htsserver_exec() {
 #   --root DIR       tree to serve (default: the dist root)
 #   --home DIR       $HOME for the server, so no ~/.httrack.ini leaks in
 #   --log FILE       where the announcement lands (default: a temp file)
-#   --write-limit N  ulimit -f N; the announcement then rides a pipe, exempt
+#   --port N         a port already picked, to keep the fork out of a
+#                    window the caller is timing
+#   --write-limit N  ulimit -f N; the log rides a pipe, which the cap spares
 # shellcheck disable=SC2120 # most callers need no htsserver argument
 htsserver_start() {
-    local root=${HTS_DISTDIR} home='' log='' wlimit=''
+    local root=${HTS_DISTDIR} home='' log='' wlimit='' port=''
     while test $# -gt 0; do
         case $1 in
         --root)
@@ -80,6 +107,10 @@ htsserver_start() {
             wlimit=$2
             shift 2
             ;;
+        --port)
+            port=$2
+            shift 2
+            ;;
         --)
             shift
             break
@@ -88,7 +119,9 @@ htsserver_start() {
         esac
     done
 
-    HTS_PORT=$(htsserver_freeport) || fail "no free loopback port"
+    HTS_PORT=${port}
+    test -n "${HTS_PORT}" ||
+        HTS_PORT=$(htsserver_freeport) || fail "no free loopback port"
     if test -z "${log}"; then
         log=$(mktemp)
         HTS_TMP_LOGS+=("${log}")
@@ -96,23 +129,27 @@ htsserver_start() {
     HTS_LOG=${log}
     : >"${HTS_LOG}"
     if test -n "${wlimit}"; then
-        htsserver_exec "$@" | cat >"${HTS_LOG}" &
+        # Process substitution, not a pipeline: $! must be the server. In a
+        # pipeline it is the reader, so a start that never announces leaves the
+        # server unkilled and parks the reaping wait on the whole job.
+        htsserver_exec "$@" > >(cat >"${HTS_LOG}") &
     else
         htsserver_exec "$@" >"${HTS_LOG}" &
     fi
     HTS_BGPID=$!
     HTS_BG_PIDS+=("${HTS_BGPID}")
 
-    HTS_URL=
-    for _ in $(seq 1 40); do
-        HTS_URL=$(sed -n 's/^URL=//p' "${HTS_LOG}" 2>/dev/null | tr -d '\r') &&
-            test -n "${HTS_URL}" && break
+    # A sed and a sleep per tick is a process per tick (#795), and the deadline
+    # self-extends rather than expiring on a loaded parallel run.
+    local start=$SECONDS
+    while :; do
+        htsserver_announced
+        test -z "${HTS_URL}" || break
         kill -0 "${HTS_BGPID}" 2>/dev/null || break
-        sleep 0.25
+        test "$((SECONDS - start))" -lt 60 || break
+        poll_wait 0.1
     done
     test -n "${HTS_URL}" || fail "htsserver did not come up: $(cat "${HTS_LOG}")"
-    HTS_URL=$(firstline "${HTS_URL}")
-    HTS_PID=$(firstline "$(sed -n 's/^PID=//p' "${HTS_LOG}" | tr -d '\r')")
     test -z "${HTS_PID}" || HTS_SRV_PIDS+=("${HTS_PID}")
 }
 
@@ -120,7 +157,8 @@ htsserver_start() {
 # htsserver_assert_reaped. Safe from a cleanup trap, and safe to call twice.
 htsserver_stop() {
     local pid
-    HTS_REAPED_PIDS=(${HTS_BG_PIDS[@]+"${HTS_BG_PIDS[@]}"})
+    HTS_REAPED_PIDS=(${HTS_BG_PIDS[@]+"${HTS_BG_PIDS[@]}"}
+        ${HTS_SRV_PIDS[@]+"${HTS_SRV_PIDS[@]}"})
     # Grouped: bash announces a killed job at any command boundary, so the
     # notice escapes a redirect on the wait alone once there are two servers.
     {
@@ -129,7 +167,7 @@ htsserver_stop() {
             kill -9 "${pid}" 2>/dev/null || true
         done
         for pid in ${HTS_BG_PIDS[@]+"${HTS_BG_PIDS[@]}"}; do
-            wait "${pid}" || true
+            reap_bounded "${pid}" || true
         done
     } 2>/dev/null
     HTS_SRV_PIDS=()
@@ -147,6 +185,7 @@ htsserver_cleanup() {
 # A leaked htsserver wedges the parallel harness behind a green log.
 htsserver_assert_reaped() {
     local pid
+    test "${#HTS_REAPED_PIDS[@]}" -gt 0 || fail "nothing was reaped to assert on"
     for pid in ${HTS_REAPED_PIDS[@]+"${HTS_REAPED_PIDS[@]}"}; do
         ! kill -0 "${pid}" 2>/dev/null || fail "htsserver ${pid} survived"
     done

--- a/tests/webhttracklib.sh
+++ b/tests/webhttracklib.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+#
+# htsserver launch, request and reaping helpers. Sourced, not run.
+
+HTS_TESTDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${HTS_TESTDIR}/testlib.sh"
+
+HTS_DISTDIR=$(cd "${top_srcdir:-${HTS_TESTDIR}/..}" && pwd)
+HTS_BG_PIDS=()
+HTS_SRV_PIDS=()
+HTS_REAPED_PIDS=()
+HTS_TMP_LOGS=()
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+skip() {
+    echo "$*; skipping" >&2
+    exit 77
+}
+
+# First line of $1. A "| head -1" would close the pipe early and, under
+# pipefail, SIGPIPE the producer into a spurious failure.
+firstline() { printf '%s\n' "${1%%$'\n'*}"; }
+
+# What every test here needs. The Debian buildd chroot has no python3, so that
+# one skips rather than reds.
+htsserver_require() {
+    command -v htsserver >/dev/null || fail "no htsserver in PATH"
+    HTS_PYTHON=$(find_python) || skip "python3 not found"
+}
+
+# A free loopback port; the socket is closed before htsserver rebinds it.
+htsserver_freeport() {
+    "${HTS_PYTHON}" -c 'import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()'
+}
+
+# The server process; reads htsserver_start's locals and its background stdout.
+htsserver_exec() {
+    # htsserver keeps SIGTERM ignored across its exec, so only -9 reaps it.
+    trap '' TERM TTOU XFSZ
+    test -z "${wlimit}" || ulimit -f "${wlimit}"
+    test -z "${home}" || export HOME="${home}"
+    exec htsserver "${root%/}/" --port "${HTS_PORT}" "$@" 2>&1
+}
+
+# Start htsserver in the background on a free port and wait for its
+# announcement. Sets HTS_URL, HTS_PORT, HTS_LOG, HTS_BGPID and HTS_PID (the
+# server's own pid, which Windows does not announce). Options, ahead of any
+# htsserver argument:
+#   --root DIR       tree to serve (default: the dist root)
+#   --home DIR       $HOME for the server, so no ~/.httrack.ini leaks in
+#   --log FILE       where the announcement lands (default: a temp file)
+#   --write-limit N  ulimit -f N; the announcement then rides a pipe, exempt
+# shellcheck disable=SC2120 # most callers need no htsserver argument
+htsserver_start() {
+    local root=${HTS_DISTDIR} home='' log='' wlimit=''
+    while test $# -gt 0; do
+        case $1 in
+        --root)
+            root=$2
+            shift 2
+            ;;
+        --home)
+            home=$2
+            shift 2
+            ;;
+        --log)
+            log=$2
+            shift 2
+            ;;
+        --write-limit)
+            wlimit=$2
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *) break ;;
+        esac
+    done
+
+    HTS_PORT=$(htsserver_freeport) || fail "no free loopback port"
+    if test -z "${log}"; then
+        log=$(mktemp)
+        HTS_TMP_LOGS+=("${log}")
+    fi
+    HTS_LOG=${log}
+    : >"${HTS_LOG}"
+    if test -n "${wlimit}"; then
+        htsserver_exec "$@" | cat >"${HTS_LOG}" &
+    else
+        htsserver_exec "$@" >"${HTS_LOG}" &
+    fi
+    HTS_BGPID=$!
+    HTS_BG_PIDS+=("${HTS_BGPID}")
+
+    HTS_URL=
+    for _ in $(seq 1 40); do
+        HTS_URL=$(sed -n 's/^URL=//p' "${HTS_LOG}" 2>/dev/null | tr -d '\r') &&
+            test -n "${HTS_URL}" && break
+        kill -0 "${HTS_BGPID}" 2>/dev/null || break
+        sleep 0.25
+    done
+    test -n "${HTS_URL}" || fail "htsserver did not come up: $(cat "${HTS_LOG}")"
+    HTS_URL=$(firstline "${HTS_URL}")
+    HTS_PID=$(firstline "$(sed -n 's/^PID=//p' "${HTS_LOG}" | tr -d '\r')")
+    test -z "${HTS_PID}" || HTS_SRV_PIDS+=("${HTS_PID}")
+}
+
+# Reap every server started so far and remember them for
+# htsserver_assert_reaped. Safe from a cleanup trap, and safe to call twice.
+htsserver_stop() {
+    local pid
+    HTS_REAPED_PIDS=(${HTS_BG_PIDS[@]+"${HTS_BG_PIDS[@]}"})
+    # Grouped: bash announces a killed job at any command boundary, so the
+    # notice escapes a redirect on the wait alone once there are two servers.
+    {
+        for pid in ${HTS_SRV_PIDS[@]+"${HTS_SRV_PIDS[@]}"} \
+            ${HTS_BG_PIDS[@]+"${HTS_BG_PIDS[@]}"}; do
+            kill -9 "${pid}" 2>/dev/null || true
+        done
+        for pid in ${HTS_BG_PIDS[@]+"${HTS_BG_PIDS[@]}"}; do
+            wait "${pid}" || true
+        done
+    } 2>/dev/null
+    HTS_SRV_PIDS=()
+    HTS_BG_PIDS=()
+}
+
+# Teardown: reap, then drop the logs the library allocated. Keep it out of
+# htsserver_stop, which a test may call mid-run before reading the log back.
+htsserver_cleanup() {
+    htsserver_stop
+    rm -f ${HTS_TMP_LOGS[@]+"${HTS_TMP_LOGS[@]}"}
+    HTS_TMP_LOGS=()
+}
+
+# A leaked htsserver wedges the parallel harness behind a green log.
+htsserver_assert_reaped() {
+    local pid
+    for pid in ${HTS_REAPED_PIDS[@]+"${HTS_REAPED_PIDS[@]}"}; do
+        ! kill -0 "${pid}" 2>/dev/null || fail "htsserver ${pid} survived"
+    done
+}
+
+htsserver_alive() { test -n "${HTS_PID:-}" && kill -0 "${HTS_PID}" 2>/dev/null; }
+
+# Raw HTTP against $HTS_PORT; tests/httpclient.py documents the options.
+htsserver_client() {
+    "${HTS_PYTHON}" "${HTS_TESTDIR}/httpclient.py" --port "${HTS_PORT}" "$@"
+}
+
+# The reply to a GET of $1, status line and headers included.
+htsserver_get() { htsserver_client --path "$1"; }
+
+# The reply to a POST of the urlencoded body $1, to / unless $2 names a page.
+htsserver_post() { htsserver_client --path "${2:-/}" --post "$1"; }
+
+# The session id the server renders into every form, as a browser picks it up.
+# Callers assert its length: an empty one makes every later check vacuous.
+htsserver_sid() {
+    firstline "$(htsserver_get /server/index.html |
+        sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p')"
+}


### PR DESCRIPTION
Each of the ~20 tests driving htsserver carried its own `freeport`, `start`, `srvpid`, `portof` and `request`, plus an inline python socket client: eleven copies of `freeport` in three variants, eight of `srvpid` in six. Two of the divergences were live bugs. Five copies read the announced pid with `sed ... | head -1`, which SIGPIPEs the producer so that under `pipefail` a spurious 141 becomes the test's verdict; `91_webhttrack-directory.test` wrote a `firstline()` to dodge that and nobody copied it. And the socket timeout had drifted to 15s in one copy and 30s in four, with only the 15s copy catching `socket.timeout` and reporting, so the other four wedge where that one fails cleanly.

`tests/webhttracklib.sh` and `tests/httpclient.py` now own picking the port, the background launch under an ignored SIGTERM, the wait for the `URL=` announcement, the pid the server reports (Windows announces none) and the reaping of both. `portof` is gone entirely, since the library picks the port and nothing has to parse it back out of the URL. The canonical choices are `find_python` over a bare `python3` (seven copies hardcoded it and skipped on Windows, where they can run), `firstline` over `| head -1`, and a 30s timeout with the `socket.timeout` catch.

Behaviour is unchanged: the full suite returns the same 286 verdicts, and all 21 converted tests write logs identical to their pre-conversion runs apart from a timestamp and the random session ids. To check the assertions survived translation rather than merely still running, I put three bugs back into `src/htsserver.c` (dropping the body sid gate, letting a mirrored page take the `${...}` expander branch, removing the `fexist` regular-file guard); each is killed by the test that guards it, with a clean control passing.

Second of the four test-boilerplate PRs. It leaves `fail` and `skip` in `webhttracklib.sh` for now; the preamble PR moves them down into `testlib.sh` where the other 85 tests can drop their copies too.
