### PR TITLE
SIGTERM never reaches teardown while an FTP worker is receiving

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -4119,6 +4119,12 @@ void hts_mirror_process_user_interaction(htsmoduleStruct * str,
         XH_uninit;
         return;
       }
+      /* Same omission as the wait for the current link: with every slot busy
+         the mirror parks here instead, and the exit never lands (#1096). */
+      if (*stre->exit_xh_) {
+        XH_uninit;
+        return;
+      }
       Sleep(100);               // pause
     }
     opt->state._hts_in_html_parsing = prev;

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -4226,6 +4226,12 @@ int hts_mirror_wait_for_next_file(htsmoduleStruct * str,
         XH_uninit;
         return 0;
       }
+      /* An exit asked of the engine must leave this wait too: only teardown
+         stops a live FTP worker, so waiting on its slot never ends (#1096). */
+      if (*stre->exit_xh_) {
+        XH_uninit;
+        return 0;
+      }
       // And fill the backing stack
       if (back[b].status > 0)
         back_fillmax(sback, opt, cache, ptr, numero_passe);

--- a/tests/255_local-ftp-sigterm.test
+++ b/tests/255_local-ftp-sigterm.test
@@ -42,8 +42,15 @@ out="${tmpdir}/crawl"
 cmds="${tmpdir}/cmds"
 modes="${tmpdir}/modes"
 mkdir -p "$root"
-awk 'BEGIN { s = sprintf("%0999d", 0); for (i = 0; i < 100; i++) print s }' \
-    >"${root}/f.bin"
+# 800 KB, of which the stall mode sends an eighth: past the 32768 bytes below
+# which the engine calls the session dead and rolls the mirror back, so the
+# teardown assertions below describe a real mirror.
+awk 'BEGIN { s = sprintf("%0999d", 0); for (i = 0; i < 800; i++) print s }' \
+    >"${root}/big.bin"
+# Small enough to trickle out in a couple of seconds.
+head -c 102400 "${root}/big.bin" >"${root}/f.bin"
+# Three of them against two slots, for the all-slots-busy leg.
+for f in a b c; do cp "${root}/f.bin" "${root}/${f}.bin"; done
 
 serverlog="${tmpdir}/server.out"
 "$python" "$server" --root "$(nativepath "$root")" \
@@ -52,70 +59,117 @@ serverlog="${tmpdir}/server.out"
 serverpid=$!
 port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 
-# Backgrounded, with no bound of any kind on the phase that must be ended by
-# the signal alone: a --timeout or --max-time would end it on its own and the
-# assertion below would hold on the unfixed engine too.
+# $1 is a space-separated list of files to fetch; $name is the first of them.
+name=
 start_crawl() {
+    local urls=() f
+    for f in $1; do urls+=("ftp://127.0.0.1:${port}/${f}"); done
+    name=${1%% *}
+    shift
     : >"$cmds"
     rm -rf "${out:?}"
     mkdir -p "$out"
-    httrack "ftp://127.0.0.1:${port}/f.bin" -O "$out" --quiet \
-        --disable-security-limits --robots=0 -c2 "$@" \
+    httrack "${urls[@]}" -O "$out" --quiet \
+        --disable-security-limits --robots=0 "$@" \
         >"${tmpdir}/log" 2>&1 &
     crawlpid=$!
 }
 
 # Observed rather than slept for: the partial file appearing is what says the
 # data connection is up and the engine is parked on the slot.
+partial=
 await_transfer() {
-    local deadline=$((SECONDS + 60)) partial=
+    local deadline=$((SECONDS + 60))
+    partial=
     until test -n "$partial"; do
         test "$SECONDS" -lt "$deadline" || fail "the crawl never started a transfer"
-        grep -aq '^RETR ' "$cmds" 2>/dev/null && partial=$(find "$out" -name f.bin)
+        grep -aq '^RETR ' "$cmds" 2>/dev/null && partial=$(find "$out" -name "$name")
         poll_wait 1
     done
 }
 
+# wait_bounded folds its timeout and the crawl's own status into one return, so
+# a crash reads as a hang. Tell them apart, or the message names the wrong bug.
+await_exit() {
+    local rc=0
+    wait_bounded "$crawlpid" "$1" || rc=$?
+    crawlpid=
+    test "$rc" -ne 124 || fail "$2 was still running ${1}s later"
+    test "$rc" -eq 0 || fail "$2 exited $rc instead of unwinding cleanly"
+}
+
 # --- SIGTERM lands on a transfer nothing else can end ------------------------
-# A prefix, then silence for 15 minutes.
+# A prefix, then silence for 15 minutes. No --timeout or --max-time either:
+# any bound would end this crawl on its own and the unfixed engine would pass.
 printf '* stall\n' >"$modes"
-start_crawl --timeout=0 --max-time=0
+start_crawl big.bin --timeout=0 --max-time=0 -c2
 await_transfer
 started=$SECONDS
 kill -TERM "$crawlpid"
-wait_bounded "$crawlpid" 60 ||
-    fail "the terminated crawl was still waiting on the FTP slot 60s later"
-elapsed=$((SECONDS - started))
-crawlpid=
-ok "SIGTERM ended the crawl in ${elapsed}s"
+await_exit 60 "the terminated crawl"
+ok "SIGTERM ended the crawl in $((SECONDS - started))s"
 
-# The exit has to walk out through teardown, which is what stops the worker;
-# a bounded exit that skipped it would be some other path, not this fix.
+# Leaving the wait is only half of it: the exit has to walk out through the
+# normal end of the mirror. Bailing to the error path, or skipping the link as
+# though it were done, also ends the wait and loses the mirror instead.
 reply=$(cat "${tmpdir}/log")
 grep -q 'Exit requested to engine' <<<"$reply" ||
     fail "SIGTERM did not reach the engine: ${reply}"
 grep -q 'Thanks for using HTTrack' <<<"$reply" ||
     fail "the exit skipped teardown: ${reply}"
-ok "the exit unwound through teardown"
+test -s "${out}/hts-cache/new.zip" ||
+    fail "the cache was not committed: $(find "$out" -type f)"
+test -s "$partial" ||
+    fail "the received prefix was dropped: $(find "$out" -type f)"
+log=$(cat "${out}/hts-log.txt")
+# Only the outer loop's own exit_xh branch writes this. Returning the caller's
+# error code leaves the wait just as well, and jumps straight to cleanup with a
+# cache holding nothing.
+grep -q 'Exit requested by shell or user' <<<"$log" ||
+    fail "the mirror did not end through the engine's exit path: ${log}"
+# And the abandoned link has to be reported as abandoned. Returning the
+# already-done code leaves the wait too, and drops it without a word.
+grep -q "at link ftp://127.0.0.1:${port}/big.bin" <<<"$log" ||
+    fail "the abandoned link went unreported: ${log}"
+ok "the exit unwound through teardown, keeping the mirror"
+
+# --- SIGTERM with every slot busy --------------------------------------------
+# Three stalled links against two sockets: the mirror then parks a frame higher,
+# in the wait for a free socket, which the leg above never enters.
+start_crawl "a.bin b.bin c.bin" --timeout=0 --max-time=0 -c2
+deadline=$((SECONDS + 60))
+until test "$(grep -ac '^RETR ' "$cmds" 2>/dev/null || true)" -ge 2; do
+    test "$SECONDS" -lt "$deadline" || fail "the crawl never filled both sockets"
+    poll_wait 1
+done
+started=$SECONDS
+kill -TERM "$crawlpid"
+await_exit 60 "the terminated saturated crawl"
+reply=$(cat "${tmpdir}/log")
+grep -q 'Thanks for using HTTrack' <<<"$reply" ||
+    fail "the saturated exit skipped teardown: ${reply}"
+ok "SIGTERM ended a crawl with no free socket in $((SECONDS - started))s"
 
 # --- a single ^C still finishes the pending transfer -------------------------
 # The engine's policy is to let a receiving slot run to the end; the poll above
 # must not have turned that into an abort.
 printf '* trickle\n' >"$modes"
-start_crawl --timeout=30 --max-time=120
+start_crawl f.bin --timeout=30 --max-time=120 -c2
 await_transfer
 kill -INT "$crawlpid"
-wait_bounded "$crawlpid" 120 || fail "the interrupted crawl never ended"
-crawlpid=
+await_exit 120 "the interrupted crawl"
+# sig_leave's own line: without it the transfer completing says nothing, since
+# a signal that never arrived leaves a crawl that was going to finish anyway.
+grep -q 'Finishing pending transfers' "${tmpdir}/log" ||
+    fail "the ^C never reached sig_leave: $(cat "${tmpdir}/log")"
 cmp -s "${out}/127.0.0.1_${port}/f.bin" "${root}/f.bin" ||
     fail "^C cut the transfer short; mirror holds $(find "$out" -type f)"
 ok "a single ^C let the in-flight transfer complete"
 
 # --- an unsignalled crawl is unaffected --------------------------------------
 : >"$modes"
-start_crawl --timeout=30 --max-time=120
-wait_bounded "$crawlpid" 120 || fail "the plain crawl never ended"
-crawlpid=
+start_crawl f.bin --timeout=30 --max-time=120 -c2
+await_exit 120 "the plain crawl"
 cmp -s "${out}/127.0.0.1_${port}/f.bin" "${root}/f.bin" ||
     fail "the plain crawl did not mirror; it holds $(find "$out" -type f)"
 ok "an unsignalled crawl still mirrors normally"

--- a/tests/255_local-ftp-sigterm.test
+++ b/tests/255_local-ftp-sigterm.test
@@ -6,18 +6,13 @@
 
 set -euo pipefail
 
-: "${top_srcdir:=..}"
 testdir=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=tests/testlib.sh
 . "${testdir}/testlib.sh"
 
-python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
-! is_windows || ! echo "MSYS cannot signal a native httrack.exe; skipping" >&2 ||
-    exit 77
-command -v httrack >/dev/null || {
-    echo "could not find httrack" >&2
-    exit 1
-}
+python=$(find_python) || skip "python3 not found"
+skip_on_windows "MSYS cannot signal a native httrack.exe"
+command -v httrack >/dev/null || fail "could not find httrack"
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpterm.XXXXXX")
@@ -28,13 +23,8 @@ cleanup() {
     stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
-trap 'set +e; cleanup' EXIT
-trap cleanup HUP INT QUIT PIPE TERM
+cleanup_push cleanup
 
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
 ok() { echo "OK: $*"; }
 
 root="${tmpdir}/root"
@@ -151,8 +141,8 @@ grep -q 'Thanks for using HTTrack' <<<"$reply" ||
 ok "SIGTERM ended a crawl with no free socket in $((SECONDS - started))s"
 
 # --- a single ^C still finishes the pending transfer -------------------------
-# The engine's policy is to let a receiving slot run to the end; the poll above
-# must not have turned that into an abort.
+# sig_leave promises the pending transfers finish, so the poll above must not
+# have turned the first ^C into an abort.
 printf '* trickle\n' >"$modes"
 start_crawl f.bin --timeout=30 --max-time=120 -c2
 await_transfer

--- a/tests/255_local-ftp-sigterm.test
+++ b/tests/255_local-ftp-sigterm.test
@@ -1,0 +1,121 @@
+#!/bin/bash
+#
+# SIGTERM raises exit_xh, but the mirror's wait loop never polled it, so an
+# exit asked of the engine while an FTP worker was receiving waited forever:
+# only teardown stops that worker, and teardown was past the wait (#1096).
+
+set -euo pipefail
+
+: "${top_srcdir:=..}"
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+python=$(find_python) || ! echo "python3 not found; skipping" >&2 || exit 77
+! is_windows || ! echo "MSYS cannot signal a native httrack.exe; skipping" >&2 ||
+    exit 77
+command -v httrack >/dev/null || {
+    echo "could not find httrack" >&2
+    exit 1
+}
+
+server=$(nativepath "${testdir}/ftp-server.py")
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpterm.XXXXXX")
+serverpid=
+crawlpid=
+cleanup() {
+    test -z "$crawlpid" || kill_tree "$crawlpid"
+    stop_server "$serverpid"
+    rm -rf "$tmpdir"
+}
+trap 'set +e; cleanup' EXIT
+trap cleanup HUP INT QUIT PIPE TERM
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+ok() { echo "OK: $*"; }
+
+root="${tmpdir}/root"
+out="${tmpdir}/crawl"
+cmds="${tmpdir}/cmds"
+modes="${tmpdir}/modes"
+mkdir -p "$root"
+awk 'BEGIN { s = sprintf("%0999d", 0); for (i = 0; i < 100; i++) print s }' \
+    >"${root}/f.bin"
+
+serverlog="${tmpdir}/server.out"
+"$python" "$server" --root "$(nativepath "$root")" \
+    --mode-file "$(nativepath "$modes")" \
+    --log "$(nativepath "$cmds")" >"$serverlog" 2>&1 &
+serverpid=$!
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+
+# Backgrounded, with no bound of any kind on the phase that must be ended by
+# the signal alone: a --timeout or --max-time would end it on its own and the
+# assertion below would hold on the unfixed engine too.
+start_crawl() {
+    : >"$cmds"
+    rm -rf "${out:?}"
+    mkdir -p "$out"
+    httrack "ftp://127.0.0.1:${port}/f.bin" -O "$out" --quiet \
+        --disable-security-limits --robots=0 -c2 "$@" \
+        >"${tmpdir}/log" 2>&1 &
+    crawlpid=$!
+}
+
+# Observed rather than slept for: the partial file appearing is what says the
+# data connection is up and the engine is parked on the slot.
+await_transfer() {
+    local deadline=$((SECONDS + 60)) partial=
+    until test -n "$partial"; do
+        test "$SECONDS" -lt "$deadline" || fail "the crawl never started a transfer"
+        grep -aq '^RETR ' "$cmds" 2>/dev/null && partial=$(find "$out" -name f.bin)
+        poll_wait 1
+    done
+}
+
+# --- SIGTERM lands on a transfer nothing else can end ------------------------
+# A prefix, then silence for 15 minutes.
+printf '* stall\n' >"$modes"
+start_crawl --timeout=0 --max-time=0
+await_transfer
+started=$SECONDS
+kill -TERM "$crawlpid"
+wait_bounded "$crawlpid" 60 ||
+    fail "the terminated crawl was still waiting on the FTP slot 60s later"
+elapsed=$((SECONDS - started))
+crawlpid=
+ok "SIGTERM ended the crawl in ${elapsed}s"
+
+# The exit has to walk out through teardown, which is what stops the worker;
+# a bounded exit that skipped it would be some other path, not this fix.
+reply=$(cat "${tmpdir}/log")
+grep -q 'Exit requested to engine' <<<"$reply" ||
+    fail "SIGTERM did not reach the engine: ${reply}"
+grep -q 'Thanks for using HTTrack' <<<"$reply" ||
+    fail "the exit skipped teardown: ${reply}"
+ok "the exit unwound through teardown"
+
+# --- a single ^C still finishes the pending transfer -------------------------
+# The engine's policy is to let a receiving slot run to the end; the poll above
+# must not have turned that into an abort.
+printf '* trickle\n' >"$modes"
+start_crawl --timeout=30 --max-time=120
+await_transfer
+kill -INT "$crawlpid"
+wait_bounded "$crawlpid" 120 || fail "the interrupted crawl never ended"
+crawlpid=
+cmp -s "${out}/127.0.0.1_${port}/f.bin" "${root}/f.bin" ||
+    fail "^C cut the transfer short; mirror holds $(find "$out" -type f)"
+ok "a single ^C let the in-flight transfer complete"
+
+# --- an unsignalled crawl is unaffected --------------------------------------
+: >"$modes"
+start_crawl --timeout=30 --max-time=120
+wait_bounded "$crawlpid" 120 || fail "the plain crawl never ended"
+crawlpid=
+cmp -s "${out}/127.0.0.1_${port}/f.bin" "${root}/f.bin" ||
+    fail "the plain crawl did not mirror; it holds $(find "$out" -type f)"
+ok "an unsignalled crawl still mirrors normally"

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -275,7 +275,8 @@ echo "ran=$((pass + fail + skip)) pass=$pass fail=$fail skip=$skip" |
 # decode back to, which NTFS refuses;
 # memresume, repaircache and resume-recovery interrupt pass 1 with a signal
 # MSYS cannot deliver to a native exe;
-# ftp-deadhost-interrupt needs that same signal (its --timeout half runs, as 245);
+# ftp-deadhost-interrupt and ftp-sigterm need that same signal (deadhost's
+# --timeout half runs, as 245);
 # close-once interposes close() through LD_PRELOAD, which MSYS has no equivalent for.
 expected_skips="01_engine-footer-overflow.test
 253_local-ftp-close-once.test
@@ -288,6 +289,7 @@ expected_skips="01_engine-footer-overflow.test
 153_local-proxytrack-quiet.test
 215_engine-datadir-ospath.test
 243_local-ftp-deadhost-interrupt.test
+255_local-ftp-sigterm.test
 235_local-resume-recovery.test
 48_local-crange-memresume.test
 71_local-crange-repaircache.test


### PR DESCRIPTION
`sig_finish` raises `state.exit_xh` on SIGTERM, but the mirror's wait loop in `hts_mirror_wait_for_next_file` never polled it: it leaves only when the link is done, when `back_checkmirror` fails, or when `hts_loop_tick` says so. Nothing there ends a live FTP worker, and the call that does, `ftp_stop_workers()` from `back_delete_all` and `hts_free_opt`, sits past the loop in teardown. So "Exit requested to engine" printed and the crawl then waited forever on the receiving slot. Polling `exit_xh` there and returning the way the two neighbouring abort checks already do lets the outer loop's own `exit_xh` test end the crawl and reach teardown. The poll fires on any nonzero value, so a fatal `exit_xh = -1` raised while a slot is live no longer wedges either.

`hts_mirror_process_user_interaction` needed the same poll. The loop above is only reached while a socket is free, so with every slot busy the mirror parks one frame higher, in the wait for a free socket, whose guards were the identical pair. Both polls are load-bearing: with only the inner one, three stalled links against two sockets still hang; with only the outer one, the single-link case does.

`^C` is untouched. It sets `state.stop`, not `exit_xh`, and neither poll reads it, so a first `^C` still finishes pending transfers and a second still exits immediately. That half of #1096 is a separate bug on a separate path, `wait_socket_receive` in `htsftp.c` never reading `state.stop`, and it is not fixed here, so the issue stays open. Nothing in the code makes letting a receiving slot finish a deliberate policy, and a stalled HTTP body does not behave like the FTP one: measured on master, SIGINT ends a stalled HTTP transfer in 0.1s and a stalled FTP one only after `--timeout` expires. The HTTP promptness is itself accidental, #1110.

One consequence worth naming. The `exit_xh` route falls through the whole completion sequence, `--purge-old` included, so a SIGTERM during an `--update` run can purge files it never re-fetched. That is pre-existing on that route, but this fix reaches it where the engine used to hang, and a user who reached for SIGKILL kept their mirror. Filed as #1109.

`tests/255_local-ftp-sigterm.test` signals a crawl parked on a stalled FTP body with `--timeout=0 --max-time=0`, so only the fix can end it. It pins the exit path rather than just the exit: reverting the hunk hangs, and returning the caller's error code or the already-done code leaves the wait too but loses the cache or drops the link silently, which the log assertions catch. A saturated leg covers the outer poll, and controls check that a single `^C` still completes an in-flight transfer, that the `^C` actually reached `sig_leave`, and that an unsignalled crawl is unaffected. It skips on Windows, where MSYS cannot deliver the signal to a native exe.

Refs #1096
