### PR TITLE
Ctrl-C does not shorten an in-flight FTP transfer

### DIFF
--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -270,6 +270,20 @@ static hts_boolean ftp_may_resume(httrackp *opt, const lien_back *back,
   return HTS_TRUE;
 }
 
+/* Idle time an in-flight transfer still gets after a stop: enough to ride out a
+   burst gap, far below the --timeout a silent server would else hold. Matches
+   the floor of the mirror deadline's own grace. */
+#define FTP_STOP_GRACE 5
+
+/* Clip a wait once a stop is pending: back_wait() can't abort this slot the way
+   it aborts an HTTP one, so an unclipped wait strands the crawl on ^C (#1096).
+   A function of the budget alone, so a caller may re-read it mid-wait. */
+static int ftp_stop_clip(const httrackp *opt, int timeout) {
+  if (opt != NULL && opt->state.stop && timeout > FTP_STOP_GRACE)
+    return FTP_STOP_GRACE;
+  return timeout;
+}
+
 /* Clip a wait to what is left of --max-time: back_wait() can't abort this slot
    the way it aborts an HTTP one. */
 static int ftp_wait_left(const httrackp *opt, int timeout) {
@@ -280,7 +294,7 @@ static int ftp_wait_left(const httrackp *opt, int timeout) {
     if (left < (TStamp) timeout)
       timeout = left > 0 ? (int) left : 0;
   }
-  return timeout;
+  return ftp_stop_clip(opt, timeout);
 }
 
 /* Connect honoring the stop flag, --timeout and --max-time: a blocking
@@ -1278,19 +1292,20 @@ int check_socket_connect(T_SOC soc) {
 // attendre des données
 int wait_socket_receive(lien_back *back, T_SOC soc, int timeout,
                         const httrackp *opt) {
-  TStamp ltime = time_local();
+  const TStamp ltime = time_local();
+  const int budget = ftp_wait_left(opt, timeout);
   int r;
-
-  timeout = ftp_wait_left(opt, timeout);
 
 #if FTP_DEBUG
   printf("\x0dWaiting for data ");
   fflush(stdout);
 #endif
   /* A stop raised by the engine ends the wait on the next 100ms tick instead of
-     after the full timeout, so teardown does not sit on a silent server. */
+     after the full timeout, so teardown does not sit on a silent server. Read
+     each pass, as a ^C lands long after the budget was fixed (#1096). */
   while ((!(r = check_socket(soc))) && (back == NULL || !back->stop_ftp) &&
-         (((int) ((TStamp) (time_local() - ltime))) < timeout)) {
+         (((int) ((TStamp) (time_local() - ltime))) <
+          ftp_stop_clip(opt, budget))) {
     Sleep(100);
 #if FTP_DEBUG
     printf(".");

--- a/tests/243_local-ftp-deadhost-interrupt.test
+++ b/tests/243_local-ftp-deadhost-interrupt.test
@@ -1,7 +1,8 @@
 #!/bin/bash
 #
-# A ^C must end a crawl parked in an FTP connect to a blackholed host, instead
-# of leaving it to the kernel's own two-minute connect timeout (#1059).
+# A ^C must end a crawl parked in an FTP wait the engine cannot reach: the
+# connect to a blackholed host (#1059), and the transfer from a server that
+# went silent mid-body (#1096).
 
 set -euo pipefail
 
@@ -20,8 +21,10 @@ command -v httrack >/dev/null || {
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpint.XXXXXX")
 crawlpid=
+serverpid=
 cleanup() {
     test -z "$crawlpid" || kill_tree "$crawlpid"
+    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 trap 'set +e; cleanup' EXIT
@@ -100,3 +103,57 @@ grep -aqE '"Unable to connect to the server" \([^)]*\) at link ftp://' "$log" ||
 test "$elapsed" -lt "$bound" ||
     fail "^C took ${elapsed}s to end a crawl stuck in connect()"
 ok "^C ends a crawl stuck in connect() (${elapsed}s)"
+
+# Same interrupt, but past the connect: the FTP worker owns the socket, so a
+# body that stops arriving parks the whole crawl on the worker's read (#1096).
+# Two waits get the grace in turn, the transfer's and the QUIT reply's.
+tbound=25
+root="${tmpdir}/root"
+out2="${tmpdir}/crawl2"
+cmds="${tmpdir}/cmds"
+mkdir -p "$root" "$out2"
+# Big enough that the served prefix leaves the transfer open and mid-body.
+awk 'BEGIN { s = sprintf("%0999d", 0); for (i = 0; i < 100; i++) print s }' \
+    >"${root}/f.bin"
+printf '* stall\n' >"${tmpdir}/modes"
+
+serverlog="${tmpdir}/server.out"
+"$python" "$(nativepath "${testdir}/ftp-server.py")" \
+    --root "$(nativepath "$root")" \
+    --mode-file "$(nativepath "${tmpdir}/modes")" \
+    --log "$(nativepath "$cmds")" >"$serverlog" 2>&1 &
+serverpid=$!
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+
+httrack "ftp://127.0.0.1:${port}/f.bin" -O "$out2" --quiet \
+    --disable-security-limits --debug-log --robots=0 --timeout=0 --max-time=0 \
+    -c1 >"${tmpdir}/log2" 2>&1 &
+crawlpid=$!
+
+# RETR, not the connect: the phase #1059 already covers reaches neither.
+deadline=$((SECONDS + 60))
+until test -s "$cmds" && grep -aq '^RETR ' "$cmds"; do
+    test "$SECONDS" -lt "$deadline" || fail "the crawl never reached RETR"
+    poll_wait 1
+done
+
+# Nothing bounds this run either, so an exit here is not the interrupt's doing.
+sleep 5
+kill -0 "$crawlpid" 2>/dev/null ||
+    fail "the crawl ended on its own, so ^C is not what stopped it"
+
+start=$SECONDS
+kill -INT "$crawlpid"
+wait_bounded "$crawlpid" 90 ||
+    fail "^C left the crawl running for $((SECONDS - start))s"
+elapsed=$((SECONDS - start))
+crawlpid=
+
+log2="${out2}/hts-log.txt"
+grep -aq 'Exit requested by shell or user' "$log2" ||
+    fail "the crawl never saw the interrupt: $(grep -a Error "$log2" || true)"
+! grep -aq 'Unable to connect to the server' "$log2" ||
+    fail "the interrupt landed on the connect, not on the transfer"
+test "$elapsed" -lt "$tbound" ||
+    fail "^C took ${elapsed}s to end a crawl stuck in a stalled transfer"
+ok "^C ends a crawl stuck mid-transfer (${elapsed}s)"


### PR DESCRIPTION
An FTP worker owns its own socket, so `back_wait()` cannot end its slot the way it ends an HTTP one. The worker's read wait honored `--timeout`, `--max-time` and the per-link cancel, but not the mirror stop a `^C` raises, so a server that went silent mid-body held the whole crawl for the full `--timeout`, and forever with `--timeout=0`. A second `^C` still killed the process, which is why this looked like a hang rather than a slow exit.

The wait is now clipped to a five-second grace once the stop flag is set, and the clip is read on every 100ms tick so a `^C` arriving after the wait began still lands. A transfer that is still moving keeps running, since the grace only starts once the socket goes quiet: a 1.6 MB trickle interrupted mid-body still completes. The `--max-time` budget stays fixed at entry on purpose. It counts from the mirror's start rather than the wait's, so recomputing it per pass halves the real deadline, which is what 234 caught.

243 gets a second leg for the transfer phase, next to the connect phase #1059 already covers. Revert the fix and that leg leaves the crawl running past its 90s guard while the connect leg still passes.

Closes #1096
