### PR TITLE
Two suite tests fail on the hppa, powerpc and ppc64 Debian buildds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,10 +138,8 @@ jobs:
         if: failure()
         run: cat tests/test-suite.log 2>/dev/null || true
 
-  # Several fixtures need a connect to TEST-NET-1 to stall. Runners drop it, the
-  # powerpc and ppc64 buildds refuse it a few ms later, and that gap failed
-  # 246_engine-connect-stop on both (#1108). tools/hostile-net.sh reproduces the
-  # refusing network; every dead-host test must skip under it, never fail.
+  # Reproduces the buildds that refuse TEST-NET-1 instead of dropping it, where
+  # every fixture needing a stalled connect must skip rather than fail (#1108).
   hostile-network:
     name: build (network refuses TEST-NET-1)
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,10 @@ jobs:
           set -euo pipefail
           jobs=$(( $(nproc) * 2 )); [ "$jobs" -le 16 ] || jobs=16
           tools/hostile-net.sh make check -j"$jobs"
+          # A refusal landing before connect() returns skips on the older probe
+          # instead, leaving the settle this leg exists to guard unrun.
+          cat tests/246_engine-connect-stop.log
+          grep -q 'within 500 ms' tests/246_engine-connect-stop.log
 
       - name: Print the test log on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,46 @@ jobs:
         if: failure()
         run: cat tests/test-suite.log 2>/dev/null || true
 
+  # Several fixtures need a connect to TEST-NET-1 to stall. Runners drop it, the
+  # powerpc and ppc64 buildds refuse it a few ms later, and that gap failed
+  # 246_engine-connect-stop on both (#1108). tools/hostile-net.sh reproduces the
+  # refusing network; every dead-host test must skip under it, never fail.
+  hostile-network:
+    name: build (network refuses TEST-NET-1)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential autoconf automake libtool autoconf-archive \
+            zlib1g-dev libssl-dev libbrotli-dev libzstd-dev iproute2
+
+      - name: Configure
+        run: |
+          set -euo pipefail
+          autoreconf -fi
+          ./configure
+
+      - name: Build
+        run: make -j"$(nproc)"
+
+      - name: Test on a network that refuses TEST-NET-1
+        timeout-minutes: 20
+        run: |
+          set -euo pipefail
+          jobs=$(( $(nproc) * 2 )); [ "$jobs" -le 16 ] || jobs=16
+          tools/hostile-net.sh make check -j"$jobs"
+
+      - name: Print the test log on failure
+        if: failure()
+        run: cat tests/test-suite.log 2>/dev/null || true
+
   # The Ubuntu buildds run a development release every runner above is well behind.
   # That gap is what shipped 3.49.18 broken on every Ubuntu architecture but
   # riscv64, when 25.10 made uutils the default coreutils (#1042).
@@ -790,10 +830,7 @@ jobs:
         src/webhttrack.in
         tests/*.sh
         tests/*.test
-        tools/macos-app.sh
-        tools/macos-bundle.sh
-        tools/macos-release.sh
-        tools/mkdeb.sh
+        tools/*.sh
     steps:
       - uses: actions/checkout@v7
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,15 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   platform-specific: GNU `tail | head -c 3` survives, the uutils coreutils leg
   turns the same line into exit 141 with no output at all. Let the reader seek
   instead: `od -An -c -j <skip> -N <len> file`.
+- Never assert a fault by signal *number*: SIGBUS is 7 on x86, arm, powerpc and
+  s390x but 10 on hppa, alpha, mips and sparc. Map it with `kill -l "$n"` and
+  match the name. 183 failed on the hppa buildd for pinning `Caught signal 11`.
+- A fixture that needs a host to stay silent must settle (500ms), re-probe every
+  socket, and SKIP when one answered. The powerpc and ppc64 buildds refuse
+  TEST-NET-1 milliseconds after `connect()` where runners drop it, too late for
+  a probe taken the instant `connect()` returned (#1108). `tools/hostile-net.sh
+  make check` runs the suite on such a network; the `build (network refuses
+  TEST-NET-1)` CI leg is that same script.
 
 ## Hard invariants
 - **Generated autotools files are NOT in git.** `configure`, every

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,14 +47,11 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   turns the same line into exit 141 with no output at all. Let the reader seek
   instead: `od -An -c -j <skip> -N <len> file`.
 - Never assert a fault by signal *number*: SIGBUS is 7 on x86, arm, powerpc and
-  s390x but 10 on hppa, alpha, mips and sparc. Map it with `kill -l "$n"` and
-  match the name. 183 failed on the hppa buildd for pinning `Caught signal 11`.
+  s390x but 10 on hppa, alpha, mips and sparc. Map it with `kill -l "$n"`.
 - A fixture that needs a host to stay silent must settle (500ms), re-probe every
-  socket, and SKIP when one answered. The powerpc and ppc64 buildds refuse
-  TEST-NET-1 milliseconds after `connect()` where runners drop it, too late for
-  a probe taken the instant `connect()` returned (#1108). `tools/hostile-net.sh
-  make check` runs the suite on such a network; the `build (network refuses
-  TEST-NET-1)` CI leg is that same script.
+  socket, and SKIP when one answered: the powerpc and ppc64 buildds refuse
+  TEST-NET-1 milliseconds after `connect()` where runners drop it.
+  `tools/hostile-net.sh` runs a command on such a network.
 
 ## Hard invariants
 - **Generated autotools files are NOT in git.** `configure`, every

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -7896,9 +7896,8 @@ static hts_boolean st_backstop_arm(httrackp *opt, struct_back *sback,
     }
     st_backstop_slot(sback, i, status[i], &r[i]);
   }
-  /* Re-probe once settled: the check above runs on the heels of connect(), too
-     early to see a refusal, and back_wait() then rightly ends slots the caller
-     is about to assert it left alone (the powerpc buildds). */
+  /* The readback above is too early to see a refusal, and back_wait() then
+     ends slots the caller asserts are intact (the powerpc buildds). */
   Sleep(ST_BACKSTOP_SETTLE_MS);
   for (i = 0; i < slots; i++) {
     if (i != dnsslot && check_socket_connect(sback->lnk[i].r.soc) != 0) {

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -7874,6 +7874,9 @@ static void st_backstop_slot(struct_back *sback, int p, int status,
   sback->connect_fallback[p].addr_count = 1;
 }
 
+/* A network that rejects TEST-NET-1 instead of dropping it answers in ms. */
+#define ST_BACKSTOP_SETTLE_MS 500
+
 /* Refill every slot: a fresh pending connect for each state that owns a socket,
    plus the poison the assertions read back. False if the blackhole answered. */
 static hts_boolean st_backstop_arm(httrackp *opt, struct_back *sback,
@@ -7892,6 +7895,18 @@ static hts_boolean st_backstop_arm(httrackp *opt, struct_back *sback,
       return HTS_FALSE;
     }
     st_backstop_slot(sback, i, status[i], &r[i]);
+  }
+  /* Re-probe once settled: the check above runs on the heels of connect(), too
+     early to see a refusal, and back_wait() then rightly ends slots the caller
+     is about to assert it left alone (the powerpc buildds). */
+  Sleep(ST_BACKSTOP_SETTLE_MS);
+  for (i = 0; i < slots; i++) {
+    if (i != dnsslot && check_socket_connect(sback->lnk[i].r.soc) != 0) {
+      printf("backstop: SKIP (the network answered for " ST_BACKSTOP_DEADHOST
+             " within %d ms)\n",
+             ST_BACKSTOP_SETTLE_MS);
+      return HTS_FALSE;
+    }
   }
   return HTS_TRUE;
 }

--- a/tests/183_altstack-worker.test
+++ b/tests/183_altstack-worker.test
@@ -56,8 +56,8 @@ if [ "$traced" -eq 0 ]; then
     exit 0
 fi
 
-# Which fault a spent thread stack raises is the port's business (hppa does not
-# say SIGSEGV); SIGABRT would instead mean the engine ended itself.
+# Which fault a spent thread stack raises varies by port (hppa does not say
+# SIGSEGV); SIGABRT would instead mean the engine ended itself.
 caught=$(sed -n '/^Caught signal [0-9][0-9]*$/{s/.* //;p;q;}' <<<"$worker")
 case "$caught" in
 4 | 10 | 11) ;; # SIGILL, SIGBUS, SIGSEGV

--- a/tests/183_altstack-worker.test
+++ b/tests/183_altstack-worker.test
@@ -58,9 +58,10 @@ fi
 
 # Which fault a spent thread stack raises varies by port (hppa does not say
 # SIGSEGV); SIGABRT would instead mean the engine ended itself.
+# By name, not by number: SIGBUS is 7 on x86 and 10 on hppa.
 caught=$(sed -n '/^Caught signal [0-9][0-9]*$/{s/.* //;p;q;}' <<<"$worker")
-case "$caught" in
-4 | 10 | 11) ;; # SIGILL, SIGBUS, SIGSEGV
+case "$(kill -l "${caught:-x}" 2>/dev/null || true)" in
+SEGV | BUS | ILL) ;;
 *)
     printf '%s\n' "$worker" >&2
     fail "-#c=threadstack: caught signal '${caught:-none}', expected a fault"

--- a/tests/183_altstack-worker.test
+++ b/tests/183_altstack-worker.test
@@ -56,7 +56,16 @@ if [ "$traced" -eq 0 ]; then
     exit 0
 fi
 
-grep -q "^Caught signal 11$" <<<"$worker" || fail "-#c=threadstack: no 'Caught signal 11' line"
+# Which fault a spent thread stack raises is the port's business (hppa does not
+# say SIGSEGV); SIGABRT would instead mean the engine ended itself.
+caught=$(sed -n '/^Caught signal [0-9][0-9]*$/{s/.* //;p;q;}' <<<"$worker")
+case "$caught" in
+4 | 10 | 11) ;; # SIGILL, SIGBUS, SIGSEGV
+*)
+    printf '%s\n' "$worker" >&2
+    fail "-#c=threadstack: caught signal '${caught:-none}', expected a fault"
+    ;;
+esac
 
 # The main thread is parked in htsthread_wait_n() once the worker announced
 # itself, and only the worker recurses. A trace that deep is therefore the

--- a/tools/hostile-net.sh
+++ b/tools/hostile-net.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Runs a command on a network that REFUSES TEST-NET-1 instead of dropping it,
+# which is what the powerpc and ppc64 Debian buildds do. The suite's dead-host
+# fixtures must skip there, never fail (#1108).
+#
+# Usage: tools/hostile-net.sh <command> [args...]        (re-execs under sudo)
+
+set -euo pipefail
+
+fail() {
+    echo "hostile-net: $*" >&2
+    exit 1
+}
+
+test $# -ge 1 || fail "usage: $0 <command> [args...]"
+
+if [ "$(id -u)" -ne 0 ]; then
+    exec sudo -E bash "$0" "$@"
+fi
+
+# Back to the invoking user for the payload: the suite must not run as root.
+run_as=${SUDO_USER:-}
+ns="hostilenet$$"
+peer="${ns}p"
+
+trap 'set +e; ip netns del "$ns" 2>/dev/null; ip netns del "$peer" 2>/dev/null' EXIT
+trap 'exit 1' HUP INT TERM
+
+ip netns add "$ns"
+ip netns add "$peer"
+ip link add veth-h netns "$ns" type veth peer name veth-p netns "$peer"
+ip -n "$ns" link set lo up
+ip -n "$ns" addr add 10.53.0.1/30 dev veth-h
+ip -n "$ns" link set veth-h up
+ip -n "$peer" link set lo up
+ip -n "$peer" addr add 10.53.0.2/30 dev veth-p
+ip -n "$peer" link set veth-p up
+# The peer owns TEST-NET-1 and listens on nothing, so every SYN draws a RST.
+ip -n "$peer" addr add 192.0.2.1/32 dev lo
+# A local veth answers before connect() has returned; 30ms is one real hop.
+ip netns exec "$ns" tc qdisc add dev veth-h root netem delay 30ms
+ip -n "$ns" route add 192.0.2.0/24 via 10.53.0.2
+
+# Non-vacuity: a namespace that drops, or one where the peer answers, makes
+# every fixture below skip for the wrong reason and proves nothing.
+probe=0
+ip netns exec "$ns" timeout 5 bash -c 'exec 3<>/dev/tcp/192.0.2.1/80' 2>/dev/null ||
+    probe=$?
+case "$probe" in
+0) fail "192.0.2.1 accepted a connection" ;;
+124) fail "192.0.2.1 is dropped, not refused; the run would prove nothing" ;;
+esac
+
+rc=0
+if [ -n "$run_as" ]; then
+    ip netns exec "$ns" sudo -E -u "$run_as" "$@" || rc=$?
+else
+    ip netns exec "$ns" "$@" || rc=$?
+fi
+exit "$rc"


### PR DESCRIPTION
Two tests added in the last two releases fail on the Debian buildds, holding 3.49.19 back on hppa, powerpc and ppc64.

`246_engine-connect-stop` arms its fixture from connects to TEST-NET-1 that have to be still in flight, and it checked that by polling the socket the instant `connect()` returned. A network that rejects 192.0.2.1 instead of dropping it answers a few milliseconds later, so the fixture armed anyway and `back_wait()` then correctly ended slots the control block asserts it left alone. The probe now settles for half a second before re-reading every socket, so such a host skips instead of failing.

`183_altstack-worker` pinned the worker's fault to signal 11, which hppa does not report for a thread that runs off its stack. The signal number was never the invariant: the test now accepts any fault the handler covers, and prints the crash report when it is none of them, so the next surprise is diagnosable.