### PR TITLE
The tagline bar still sits off the wordmark's baseline

### DIFF
--- a/html/doc.css
+++ b/html/doc.css
@@ -72,7 +72,6 @@ body {
 	/* A one-line label has no use for the body's prose leading. */
 	line-height: 1;
 	padding: .3rem .4rem;
-	margin-top: .4rem;
 }
 
 .wrap {


### PR DESCRIPTION
The black tagline bar in the documentation masthead sits about 5.3px below the wordmark instead of against it. #927 gave the image negative margins to put the bar back on the baseline, which is what its title claims, but left the `.4rem` that pushes the bar down, so the gap outlasted the fix aimed at it. Removing the declaration leaves the two siblings at the collapsed `-1.1px` #927 measured for the overshoot below the baseline, which is the spacing the 2007 tables had.

Verified by arithmetic and provenance rather than by rendering: there is no browser on this box. The symptom was reported on httrack.com, whose copy of this chrome carries the same declaration, and `git log -S` finds it entering in #878 and untouched since.