### PR TITLE
The documentation footer fails AA contrast in light mode

### DIFF
--- a/html/doc.css
+++ b/html/doc.css
@@ -106,10 +106,11 @@ body {
 	.wrap.solo { display: block; }
 }
 
+/* Colour inherited: nothing lighter than --ink reaches 4.5:1 on the --field
+   this sits on, and at .8em it is small text. */
 footer {
 	max-width: 68rem;
 	margin: .5rem auto 0;
-	color: #eef;
 	font-size: .8em;
 }
 


### PR DESCRIPTION
The footer is `#eef` on the `--field` it sits on, which is 3.56:1. At `.8em` it is small text, so WCAG AA wants 4.5:1 and it misses on all 15 pages carrying a `<footer>`.

Dropping the declaration inherits `body`s `--ink` for 4.62:1. Nothing lighter clears the bar on that field (`#fff` is 4.09:1), and `--ink-soft` is 2.38:1 there, so light mode gets no de-emphasis and that is the constraint rather than a preference. Dark mode already passes at 7.76:1 and is untouched. Caught on httrack.com first, whose chrome carries the same rule; the pre-2026 pages set no footer colour at all and inherited black at 5.14:1.