### PR TITLE
The docs and the site disagree on what HTTrack is called

### DIFF
--- a/html/abuse.html
+++ b/html/abuse.html
@@ -17,7 +17,7 @@
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
-	<div class="tagline">Open Source offline browser</div>
+	<div class="tagline">Free software offline browser</div>
 </header>
 
 <div class="wrap">

--- a/html/cache.html
+++ b/html/cache.html
@@ -17,7 +17,7 @@
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
-	<div class="tagline">Open Source offline browser</div>
+	<div class="tagline">Free software offline browser</div>
 </header>
 
 <div class="wrap">

--- a/html/changes.html
+++ b/html/changes.html
@@ -17,7 +17,7 @@
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
-	<div class="tagline">Open Source offline browser</div>
+	<div class="tagline">Free software offline browser</div>
 </header>
 
 <div class="wrap">

--- a/html/cmdguide.html
+++ b/html/cmdguide.html
@@ -17,7 +17,7 @@
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
-	<div class="tagline">Open Source offline browser</div>
+	<div class="tagline">Free software offline browser</div>
 </header>
 
 <div class="wrap">

--- a/html/contact.html
+++ b/html/contact.html
@@ -27,7 +27,7 @@
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
-	<div class="tagline">Open Source offline browser</div>
+	<div class="tagline">Free software offline browser</div>
 </header>
 
 <div class="wrap">

--- a/html/dev.html
+++ b/html/dev.html
@@ -17,7 +17,7 @@
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
-	<div class="tagline">Open Source offline browser</div>
+	<div class="tagline">Free software offline browser</div>
 </header>
 
 <div class="wrap">

--- a/html/faq.html
+++ b/html/faq.html
@@ -17,7 +17,7 @@
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
-	<div class="tagline">Open Source offline browser</div>
+	<div class="tagline">Free software offline browser</div>
 </header>
 
 <div class="wrap">

--- a/html/fcguide.html
+++ b/html/fcguide.html
@@ -17,7 +17,7 @@
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
-	<div class="tagline">Open Source offline browser</div>
+	<div class="tagline">Free software offline browser</div>
 </header>
 
 <div class="wrap">

--- a/html/filters.html
+++ b/html/filters.html
@@ -17,7 +17,7 @@
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
-	<div class="tagline">Open Source offline browser</div>
+	<div class="tagline">Free software offline browser</div>
 </header>
 
 <div class="wrap">

--- a/html/guide.html
+++ b/html/guide.html
@@ -17,7 +17,7 @@
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
-	<div class="tagline">Open Source offline browser</div>
+	<div class="tagline">Free software offline browser</div>
 </header>
 
 <div class="wrap">

--- a/html/index.html
+++ b/html/index.html
@@ -14,7 +14,7 @@
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
-	<div class="tagline">Open Source offline browser</div>
+	<div class="tagline">Free software offline browser</div>
 </header>
 
 <div class="wrap solo">

--- a/html/library.html
+++ b/html/library.html
@@ -17,7 +17,7 @@
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
-	<div class="tagline">Open Source offline browser</div>
+	<div class="tagline">Free software offline browser</div>
 </header>
 
 <div class="wrap">

--- a/html/plug.html
+++ b/html/plug.html
@@ -17,7 +17,7 @@
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
-	<div class="tagline">Open Source offline browser</div>
+	<div class="tagline">Free software offline browser</div>
 </header>
 
 <div class="wrap">

--- a/html/plug_330.html
+++ b/html/plug_330.html
@@ -17,7 +17,7 @@
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
-	<div class="tagline">Open Source offline browser</div>
+	<div class="tagline">Free software offline browser</div>
 </header>
 
 <div class="wrap">

--- a/html/scripting.html
+++ b/html/scripting.html
@@ -17,7 +17,7 @@
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
-	<div class="tagline">Open Source offline browser</div>
+	<div class="tagline">Free software offline browser</div>
 </header>
 
 <div class="wrap">

--- a/tools/doc-chrome.py
+++ b/tools/doc-chrome.py
@@ -188,7 +188,7 @@ def chrome(page, content):
         '<header class="masthead">',
         '\t<img src="images/wordmark.svg" width="400" height="36"'
         ' alt="HTTrack Website Copier">',
-        '\t<div class="tagline">Open Source offline browser</div>',
+        '\t<div class="tagline">Free software offline browser</div>',
         "</header>",
         "",
         '<div class="wrap">',


### PR DESCRIPTION
The site says "Free software offline browser" and these pages said "Open Source offline browser". The French tagline has always been "Aspirateur de sites web libre", so one language already made the claim the other did not, which is what settled it rather than any argument about licence wording. Fifteen pages and `tools/doc-chrome.py`, which holds the canonical masthead, move together so the chrome-sync check stays green.

The 30 `lang/*.txt` catalogs deliberately keep "Open Source offline browser". They are the WinHTTrack and WebHTTrack GUI rather than a web surface, the English value is the join key that pairs each entry with its translation, and 17 of them carry a real translation that changing the key would orphan.

`src/hts-indextmpl.h` also keeps it, in the 2004 table markup HTTrack writes into a generated mirror. That is a third surface, neither the site nor the GUI, and rewording it would change what every new mirror says. Worth a decision of its own rather than riding along here.