### PR TITLE
The chrome check cannot see the masthead on two of the fifteen pages

### DIFF
--- a/html/guide.html
+++ b/html/guide.html
@@ -13,12 +13,14 @@
 </head>
 <body>
 
+<!-- doc-chrome:masthead -->
 <a class="skip" href="#main">Skip to content</a>
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
 	<div class="tagline">Free software offline browser</div>
 </header>
+<!-- /doc-chrome:masthead -->
 
 <div class="wrap">
 

--- a/html/index.html
+++ b/html/index.html
@@ -10,12 +10,14 @@
 </head>
 <body>
 
+<!-- doc-chrome:masthead -->
 <a class="skip" href="#main">Skip to content</a>
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
 	<div class="tagline">Free software offline browser</div>
 </header>
+<!-- /doc-chrome:masthead -->
 
 <div class="wrap solo">
 <main id="main">

--- a/tools/doc-chrome.py
+++ b/tools/doc-chrome.py
@@ -102,9 +102,21 @@ DESCRIPTIONS = {
 
 FOOTER = "&copy; 1998-2026 Xavier Roche &amp; other contributors" " - Web Design: Leto Kauler."
 
+# Identical on every page, sidebar or not, so it is its own region: pages that
+# build their own navigation still get their masthead checked (#1115).
+MASTHEAD = [
+    '<a class="skip" href="#main">Skip to content</a>',
+    "",
+    '<header class="masthead">',
+    '\t<img src="images/wordmark.svg" width="400" height="36"'
+    ' alt="HTTrack Website Copier">',
+    '\t<div class="tagline">Free software offline browser</div>',
+    "</header>",
+]
+
 MARK = {
     part: (f"<!-- doc-chrome:{part} -->", f"<!-- /doc-chrome:{part} -->")
-    for part in ("head", "top", "bottom")
+    for part in ("head", "masthead", "top", "bottom")
 }
 
 
@@ -183,13 +195,7 @@ def chrome(page, content):
     nav.append("</nav>")
 
     top = [
-        '<a class="skip" href="#main">Skip to content</a>',
-        "",
-        '<header class="masthead">',
-        '\t<img src="images/wordmark.svg" width="400" height="36"'
-        ' alt="HTTrack Website Copier">',
-        '\t<div class="tagline">Free software offline browser</div>',
-        "</header>",
+        *MASTHEAD,
         "",
         '<div class="wrap">',
         "",
@@ -274,6 +280,10 @@ def convert(path):
 
 def rewrite(path, text):
     page = os.path.basename(path)
+    # A page owning its sidebar takes the masthead alone, and nothing else here
+    # applies to it: no head, no wrap, no generated navigation.
+    if MARK["top"][0] not in text:
+        return region(text, "masthead", "\n".join(MASTHEAD))
     open_, close = MARK["top"]
     body = text.split(close, 1)[1].split(MARK["bottom"][0], 1)[0]
     content, head, top, bottom = chrome(page, body)
@@ -302,7 +312,7 @@ def main():
         path = os.path.join(HTML, page)
         with open(path, encoding="utf-8") as fp:
             before = fp.read()
-        if MARK["top"][0] not in before:
+        if MARK["top"][0] not in before and MARK["masthead"][0] not in before:
             continue
         owned += 1
         after = rewrite(path, before)


### PR DESCRIPTION
`guide.html` and `index.html` build their own sidebar, so they carried no doc-chrome markers at all and the masthead above it was free to drift. Changing the tagline in `guide.html` left `--check` reporting `0 out of sync`, while the same edit in `faq.html` was caught. #1114 kept all fifteen in step by editing each page directly, which is exactly the manual step the checker is supposed to make unnecessary.

The masthead is byte-identical everywhere, so it becomes a region a page can take on its own, without the generated navigation. The two pages get that marker and nothing else: no head, no wrap, no sidebar, so neither page structure moves.

Verified by canary rather than by reading. A changed tagline in `MASTHEAD` now reaches 15 pages where it reached 13, and mutating the tagline or the wordmark `src` in `guide.html` or `index.html` now fails `--check`, as it already did for `faq.html`.

Closes #1115