### PR TITLE
The engine self-test scripts each carry their own teardown, invocation and silent comparisons

### DIFF
--- a/tests/01_engine-cacheindex.test
+++ b/tests/01_engine-cacheindex.test
@@ -3,8 +3,11 @@
 
 set -euo pipefail
 
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
 # Cache-index (.ndx) parse must stay inside the buffer on a corrupt length
 # prefix (ASan aborts here on the pre-fix binary; the OK check gates the
 # non-sanitized build too).
 
-test "$(httrack -O /dev/null -#test=cacheindex)" == 'cacheindex: OK'
+assert_selftest 'cacheindex: OK' cacheindex

--- a/tests/01_engine-charset.test
+++ b/tests/01_engine-charset.test
@@ -3,14 +3,15 @@
 
 set -euo pipefail
 
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
 # charset -> UTF-8 conversion (hts_convertStringToUTF8).
 # -#test=charset <charset> <string> prints the string re-decoded from <charset> as UTF-8.
-conv() {
-    test "$(httrack -O /dev/null -#test=charset "$1" "$2")" == "$3" || exit 1
-}
+conv() { assert_selftest "$3" charset "$1" "$2"; }
 # crash probe: malformed input must exit cleanly, not abort.
 runs() {
-    httrack -O /dev/null -#test=charset "$1" "$2" >/dev/null 2>&1 || exit 1
+    httrack -O /dev/null -#test=charset "$1" "$2" >/dev/null 2>&1 || fail "charset '$1' '$2' exited non-zero"
 }
 
 # the source bytes below are UTF-8 (this file is UTF-8); "café" is 0x63 61 66 C3 A9.
@@ -31,7 +32,7 @@ conv 'us-ascii' 'hello' 'hello'
 # unknown charset: ASCII passes through unchanged, but non-ASCII input cannot be
 # decoded and yields empty output (an error is printed to stderr).
 conv 'no-such-charset-xyz' 'abc' 'abc'
-test "$(httrack -O /dev/null -#test=charset 'no-such-charset-xyz' 'café' 2>/dev/null)" == "" || exit 1
+assert_eq "" "$(httrack -O /dev/null -#test=charset 'no-such-charset-xyz' 'café' 2>/dev/null)"
 
 # malformed UTF-8 (lone continuation byte, truncated lead byte) must not crash
 runs 'utf-8' 'hex:80'
@@ -39,9 +40,7 @@ runs 'utf-8' 'hex:c3'
 
 # hts_getCharsetFromMeta: <meta> charset extraction, HTML5 and legacy forms.
 # -#test=metacharset <html> prints the charset, or "(none)".
-meta() {
-    test "$(httrack -O /dev/null -#test=metacharset "$1")" == "$2" || exit 1
-}
+meta() { assert_selftest "$2" metacharset "$1"; }
 
 # HTML5 form, quoting/spacing flavors
 meta '<meta charset="utf-8">' 'utf-8'
@@ -50,7 +49,7 @@ meta '<meta charset=utf-8>' 'utf-8'
 meta '<meta charset=utf-8 />' 'utf-8'
 meta '<meta charset=utf-8/>' 'utf-8'
 # charset labels are case-insensitive downstream; only require case-insensitive match
-test "$(httrack -O /dev/null -#test=metacharset '<META CHARSET=UTF-8>' | tr '[:upper:]' '[:lower:]')" == 'utf-8' || exit 1
+assert_eq 'utf-8' "$(httrack -O /dev/null -#test=metacharset '<META CHARSET=UTF-8>' | tr '[:upper:]' '[:lower:]')"
 meta '<html><head><meta   charset = "utf-8"  ></head>' 'utf-8'
 
 # legacy http-equiv form, attributes in any order
@@ -83,9 +82,7 @@ meta '<meta ' '(none)'
 meta '<meta' '(none)'
 
 # hts_isStringUTF8: valid-UTF-8 probe (guards the #180 link conversion).
-utf8() {
-    test "$(httrack -O /dev/null -#test=isutf8 "$1")" == "$2" || exit 1
-}
+utf8() { assert_selftest "$2" isutf8 "$1"; }
 utf8 'plain' '1'
 utf8 'café' '1'
 utf8 '统计' '1'

--- a/tests/01_engine-cmdline.test
+++ b/tests/01_engine-cmdline.test
@@ -9,10 +9,11 @@
 # overrunning a fixed scratch buffer.
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_cmdline.XXXXXX") || exit 1
-trap 'set +e; rm -rf "$tmp"' EXIT
-trap 'rm -rf "$tmp"' HUP INT QUIT PIPE TERM
+cleanup_push rm -rf "$tmp"
 
 echo '<html><body>hello</body></html>' >"$tmp/index.html"
 
@@ -45,21 +46,21 @@ run_only() {
 # assert the value was accepted: clean exit and the fixture was mirrored
 accepted() {
     { test "$RC" -eq 0 && test -n "$(find "$1" -type f -path '*/index.html' -print -quit)"; } ||
-        ! echo "FAIL: $2 (exit $RC)" || exit 1
+        fail "$2 (exit $RC)"
 }
 
 # assert the value was refused cleanly: a normal error exit, never a crash
 # (a SIGABRT from an overflowed scratch buffer would surface as exit 134)
 refused() {
     { test "$RC" -ne 0 && test "$RC" -ne 134; } ||
-        ! echo "FAIL: $1 (exit $RC)" || exit 1
+        fail "$1 (exit $RC)"
 }
 
 # assert continue mode was entered: it drops the URL list, so with no cache to
 # resume the run ends on the usage screen rather than on any other error
 continued() {
     { test "$RC" -ne 0 && grep -q 'usage:' "$1/.log"; } ||
-        ! echo "FAIL: $2 (exit $RC)" || exit 1
+        fail "$2 (exit $RC)"
 }
 
 # a value past the old 126/256 caps but within the cap is accepted, on both the
@@ -165,11 +166,11 @@ accepted "$tmp/pre-proto" "#615: -@i2 before the URL broke the crawl"
 # stop tripping it if a trailing -K reset the count back to the default 4.
 warned() {
     grep -q 'simultaneous connections limited to' "$1/hts-log.txt" ||
-        ! echo "FAIL: $2" || exit 1
+        fail "$2"
 }
 not_warned() {
     ! grep -q 'simultaneous connections limited to' "$1/hts-log.txt" ||
-        ! echo "FAIL: $2" || exit 1
+        fail "$2"
 }
 run "$tmp/soc-c16" -c16
 warned "$tmp/soc-c16" "-c16 did not trip the socket-count warning (probe blind)"

--- a/tests/01_engine-cookieimport.test
+++ b/tests/01_engine-cookieimport.test
@@ -12,4 +12,4 @@ dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
 out=$(httrack -O /dev/null -#test=cookieimport "$dir")
-grep -q "cookieimport:.*OK" <<<"$out"
+assert_match "cookieimport:.*OK" "$out"

--- a/tests/01_engine-cookieimport.test
+++ b/tests/01_engine-cookieimport.test
@@ -2,12 +2,14 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # Drives -#test=cookieimport: load a cookie jar (and, on Windows, copied IE
 # cookies *@*.txt) from a long, non-ASCII folder through the UTF-8/long-path
 # file wrappers (#133,#630).
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 out=$(httrack -O /dev/null -#test=cookieimport "$dir")
 grep -q "cookieimport:.*OK" <<<"$out"

--- a/tests/01_engine-direnum.test
+++ b/tests/01_engine-direnum.test
@@ -11,4 +11,4 @@ dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
 out=$(httrack -O /dev/null -#test=direnum "$dir")
-grep -q "direnum:.*OK" <<<"$out"
+assert_match "direnum:.*OK" "$out"

--- a/tests/01_engine-direnum.test
+++ b/tests/01_engine-direnum.test
@@ -2,11 +2,13 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # Drives -#test=direnum: enumerate a long+non-ASCII directory through the
 # opendir/readdir wrappers, checking each child round-trips as UTF-8 (#133,#630).
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 out=$(httrack -O /dev/null -#test=direnum "$dir")
 grep -q "direnum:.*OK" <<<"$out"

--- a/tests/01_engine-doitlog.test
+++ b/tests/01_engine-doitlog.test
@@ -44,10 +44,7 @@ test "$rc" -eq 0 || {
     echo "FAIL: initial mirror exited $rc"
     exit 1
 }
-test -f "$out/hts-cache/doit.log" || {
-    echo "FAIL: doit.log not written by the initial mirror"
-    exit 1
-}
+assert_file "$out/hts-cache/doit.log" "the initial mirror wrote no doit.log"
 
 # --- 1. no-url reprise re-mirrors cleanly -----------------------------------
 # No url on the command line, so the engine loads doit.log and re-inserts the

--- a/tests/01_engine-doitlog.test
+++ b/tests/01_engine-doitlog.test
@@ -15,21 +15,15 @@
 #      file and re-running with no url picks up the new content.
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # Resolve httrack to an absolute path before we cd: PATH may hold a
 # build-relative entry that would not resolve from the temp directory.
-bin=$(command -v httrack) || {
-    echo "FAIL: httrack not found on PATH"
-    exit 1
-}
-case "$bin" in
-/*) ;;
-*) bin="$(cd "$(dirname "$bin")" && pwd)/$(basename "$bin")" ;;
-esac
+bin=$(httrack_path)
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_doitlog.XXXXXX") || exit 1
-trap 'set +e; rm -rf "$tmp"' EXIT
-trap 'rm -rf "$tmp"' HUP INT QUIT PIPE TERM
+cleanup_push rm -rf "$tmp"
 
 site="$tmp/site"
 out="$tmp/out"

--- a/tests/01_engine-entities.test
+++ b/tests/01_engine-entities.test
@@ -3,14 +3,15 @@
 
 set -euo pipefail
 
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
 # HTML entity unescaping (hts_unescapeEntitiesWithCharset).
 # -#test=entities <string> prints the string with entities decoded (UTF-8 output).
-ent() {
-    test "$(httrack -O /dev/null -#test=entities "$1")" == "$2" || exit 1
-}
+ent() { assert_selftest "$2" entities "$1"; }
 # crash probe: malformed input must exit cleanly, not abort.
 runs() {
-    httrack -O /dev/null -#test=entities "$1" >/dev/null 2>&1 || exit 1
+    httrack -O /dev/null -#test=entities "$1" >/dev/null 2>&1 || fail "entities '$1' exited non-zero"
 }
 
 # named entities

--- a/tests/01_engine-expandhome.test
+++ b/tests/01_engine-expandhome.test
@@ -6,6 +6,9 @@
 
 set -euo pipefail
 
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
 # ~ expansion for the -O base path (expand_home). $HOME is pinned so the cases
 # cannot depend on the caller's, but MSYS rewrites it into a Windows path
 # before the native httrack.exe reads it: ask the engine what it saw rather
@@ -13,17 +16,15 @@ set -euo pipefail
 ask() {
     HOME=HTSHOME httrack -O /dev/null -#test=expandhome "$1"
 }
-exp() {
-    test "$(ask "$1")" == "expanded=$2" || exit 1
-}
+exp() { assert_eq "expanded=$2" "$(ask "$1")" "expandhome '$1'"; }
 
 home=$(ask '~')
 home=${home#expanded=}
 
 # or every case below is vacuous: '~' means expansion never fired, '.' means it
 # fell back to the default without ever reading $HOME
-test "$home" != '~' || exit 1
-test "$home" != '.' || exit 1
+test "$home" != '~' || fail "expansion never fired"
+test "$home" != '.' || fail "expansion fell back to the default without reading HOME"
 
 exp '~' "$home"
 exp '~/foo' "$home/foo"
@@ -41,13 +42,13 @@ exp './~/x' './~/x'
 exp 'foo~bar' 'foo~bar'
 
 # an unset or empty $HOME must not turn ~/foo into the absolute /foo
-test "$(env -u HOME httrack -O /dev/null -#test=expandhome '~/foo')" == "expanded=./foo" || exit 1
-test "$(HOME='' httrack -O /dev/null -#test=expandhome '~/foo')" == "expanded=./foo" || exit 1
+assert_eq "expanded=./foo" "$(env -u HOME httrack -O /dev/null -#test=expandhome '~/foo')" 'unset HOME'
+assert_eq "expanded=./foo" "$(HOME='' httrack -O /dev/null -#test=expandhome '~/foo')" 'empty HOME'
 
 # A $HOME past the 2 * HTS_URLMAXSIZE buffer is left alone: strcatbuff aborts
 # rather than truncates. Only meaningful where the engine sees the value we set:
 # MSYS rewrites HOME into a path of its own choosing, long or not.
 if test "$home" = HTSHOME; then
     long=$(printf '%04096d' 0 | tr '0' 'A')
-    test "$(HOME="$long" httrack -O /dev/null -#test=expandhome '~/foo')" == "expanded=~/foo" || exit 1
+    assert_eq "expanded=~/foo" "$(HOME="$long" httrack -O /dev/null -#test=expandhome '~/foo')" 'over-long HOME'
 fi

--- a/tests/01_engine-filter.test
+++ b/tests/01_engine-filter.test
@@ -3,20 +3,17 @@
 
 set -euo pipefail
 
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
 # wildcard filter engine (strjoker), the core of +/- include/exclude rules.
 # -#test=filter <filter> <string> prints "<string> does match <filter>" or "... does NOT match ...".
 
-match() {
-    test "$(httrack -O /dev/null -#test=filter "$1" "$2")" == "$2 does match $1" || exit 1
-}
-nomatch() {
-    test "$(httrack -O /dev/null -#test=filter "$1" "$2")" == "$2 does NOT match $1" || exit 1
-}
+match() { assert_selftest "$2 does match $1" filter "$1" "$2"; }
+nomatch() { assert_selftest "$2 does NOT match $1" filter "$1" "$2"; }
 # single-arg call means an empty subject (unreachable as a CLI arg); '*(' used
 # to force max=1 and over-read past it.
-nomatch_empty() {
-    test "$(httrack -O /dev/null -#test=filter "$1")" == " does NOT match $1" || exit 1
-}
+nomatch_empty() { assert_selftest " does NOT match $1" filter "$1"; }
 
 # bare star matches everything
 match '*' 'anything/at/all'
@@ -108,9 +105,9 @@ nomatch '*.html*[]' 'page.html?x=1' # *[] forbids the trailing query
 # means the size is still unknown (scan time). A size exclusion must stay neutral
 # then, so the file is fetched and only cancelled once its size is known (#143).
 fsize() {
-    local want="$1"
+    local want=$1
     shift
-    test "$(httrack -O /dev/null -#test=filtersize "$@")" == "$want" || exit 1
+    assert_selftest "$want" filtersize "$@"
 }
 fsize 'verdict=allowed size_flag=0' -1 foo.jpg -* '+*.jpg' '-*.jpg*[<10]'   # scan time: keep
 fsize 'verdict=forbidden size_flag=1' 5 foo.jpg -* '+*.jpg' '-*.jpg*[<10]'  # <10KB: cancel
@@ -164,9 +161,9 @@ fsize 'verdict=unknown size_flag=1' 5 foo.jpg '-*.jpg*[>10]'
 # mime filters (-#test=filtermime = fa_strjoker type=1): only mime: rules
 # apply to a mime type, and mime: rules never apply to a URL
 fmime() {
-    local want="$1"
+    local want=$1
     shift
-    test "$(httrack -O /dev/null -#test=filtermime "$@")" == "verdict=$want" || exit 1
+    assert_selftest "verdict=$want" filtermime "$@"
 }
 fmime allowed 'image/png' '+mime:image/*'
 fmime unknown 'text/html' '+mime:image/*'
@@ -177,7 +174,7 @@ fsize 'verdict=unknown size_flag=0' -1 'image/png' '+mime:image/*' # and vice ve
 
 # memoized vs no-memo differential over seeded random patterns and subjects,
 # matching and non-matching (the self-test asserts both polarities occurred)
-test "$(httrack -O /dev/null -#test=filtermemo)" == "filtermemo: 20000 cases OK" || exit 1
+assert_selftest "filtermemo: 20000 cases OK" filtermemo
 
 # star-heavy non-match must stay polynomial (#501); 400 chars also exercises
 # the heap-allocated memo. timeout (where available) turns a hang into a FAIL.
@@ -186,7 +183,7 @@ with_timeout() {
 }
 pat=$(printf '*[a]%.0s' $(seq 1 12))b
 subj=$(printf 'a%.0s' $(seq 1 400))
-test "$(with_timeout httrack -O /dev/null -#test=filter "$pat" "$subj")" == "$subj does NOT match $pat" || exit 1
+assert_eq "$subj does NOT match $pat" "$(with_timeout httrack -O /dev/null -#test=filter "$pat" "$subj")"
 
 # a later star's class dead-end must re-extend the earlier star, not give up
 # (guards against a single-backtrack-point matcher rewrite)
@@ -194,12 +191,12 @@ match '*[aX]X*[a]Y' 'aXaXaY'
 nomatch '*[aX]X*[a]Y' 'aXbXaY'
 
 # hostile patterns must not stack-overflow or hang: length + depth + work caps
-test "$(with_timeout httrack -O /dev/null -#test=filterbounds)" == "filterbounds: OK" || exit 1
+assert_eq "filterbounds: OK" "$(with_timeout httrack -O /dev/null -#test=filterbounds)"
 
 # and the depth cap must hold on the 1MB stack a Windows thread gets (#574):
 # uncapped, the same pattern recursed ~900KB deep. Skipped where 512K is too
 # small to even start the binary.
 if (ulimit -s 512 && httrack --version >/dev/null 2>&1); then
     out=$(ulimit -s 512 && with_timeout httrack -O /dev/null -#test=filterbounds)
-    test "$out" == "filterbounds: OK" || exit 1
+    assert_eq "filterbounds: OK" "$out" "filterbounds on a 512K stack"
 fi

--- a/tests/01_engine-filterdual.test
+++ b/tests/01_engine-filterdual.test
@@ -3,13 +3,16 @@
 
 set -euo pipefail
 
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
 # fa_strjoker_dual: merged verdict on the two URL forms the engine tests;
 # the match latest in the filter list wins, an unknown verdict defers.
 
 fdual() {
-    local want="$1"
+    local want=$1
     shift
-    test "$(httrack -O /dev/null -#test=filterdual "$@")" == "$want" || exit 1
+    assert_selftest "$want" filterdual "$@"
 }
 
 fdual 'verdict=unknown rule=0' zzz yyy '+a*'     # neither form matches

--- a/tests/01_engine-footer-overflow.test
+++ b/tests/01_engine-footer-overflow.test
@@ -5,6 +5,8 @@
 # buffer unterminated and the next strcatbuff aborted (SIGABRT).
 
 set -eu
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # The overflow needs a path longer than Windows MAX_PATH (260), so both the
 # source tree and the mirror output blow past it there; run on POSIX only. The
@@ -14,7 +16,7 @@ MINGW* | MSYS* | CYGWIN*) exit 77 ;;
 esac
 
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 # A few-hundred-char file path (kept well under the URL length limit) makes the
 # {path} field long.

--- a/tests/01_engine-fsize.test
+++ b/tests/01_engine-fsize.test
@@ -4,9 +4,11 @@
 # signed *and* an unsigned truncation both show up; sparse, so it costs no disk.
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 rc=0
 out=$(httrack -#test=fsize "$dir") || rc=$?

--- a/tests/01_engine-growsize.test
+++ b/tests/01_engine-growsize.test
@@ -4,14 +4,15 @@
 # file past 4GB must size its buffer exactly or be refused, never wrap.
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 out=$(httrack -#test=growsize)
 echo "$out"
 test "$out" == "growsize self-test OK"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_growsize.XXXXXX")
-trap 'set +e; rm -rf "$tmp"' EXIT
-trap 'rm -rf "$tmp"' HUP INT QUIT PIPE TERM
+cleanup_push rm -rf "$tmp"
 
 echo '<html><body>hi</body></html>' >"$tmp/index.html"
 printf -- '-*/zzmarker*\n' >"$tmp/rules.txt"

--- a/tests/01_engine-header.test
+++ b/tests/01_engine-header.test
@@ -3,17 +3,16 @@
 
 set -euo pipefail
 
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
 # Response header-line parsing (treathead via -#test=header <raw-line> ...).
 # Isolates the wire layer from url_savename, which strips traversal on its own.
 
 hdr() {
-    local want="$1"
+    local want=$1
     shift
-    out="$(httrack -O /dev/null -#test=header "$@" | grep '^contenttype=')"
-    test "$out" == "$want" || {
-        echo "FAIL: $* -> '$out' (want '$want')"
-        exit 1
-    }
+    assert_eq "$want" "$(httrack -O /dev/null -#test=header "$@" | grep '^contenttype=')" "$*"
 }
 
 hdr 'contenttype=application/pdf cdispo=' 'Content-Type: application/pdf'
@@ -30,13 +29,11 @@ hdr 'contenttype= cdispo=evil.pdf' \
 
 # An over-long header value must not overflow the parse scratch (ASan aborts
 # here on the pre-fix binary).
-test "$(httrack -O /dev/null -#test=headerlong 'Content-Type:')" \
-    == 'contenttype_len=32 contentencoding_len=0'
-test "$(httrack -O /dev/null -#test=headerlong 'Content-Encoding:')" \
-    == 'contenttype_len=0 contentencoding_len=0'
+assert_selftest 'contenttype_len=32 contentencoding_len=0' headerlong 'Content-Type:'
+assert_selftest 'contenttype_len=0 contentencoding_len=0' headerlong 'Content-Encoding:'
 
 # An empty Content-Encoding yields no token: leave it empty, don't read the
 # uninitialized scratch (MSan aborts here on the pre-fix binary).
 enc() { httrack -O /dev/null -#test=header "$1" | grep '^contentencoding='; }
-test "$(enc 'Content-Encoding:')" == 'contentencoding='
-test "$(enc 'Content-Encoding: gzip')" == 'contentencoding=gzip'
+assert_eq 'contentencoding=' "$(enc 'Content-Encoding:')"
+assert_eq 'contentencoding=gzip' "$(enc 'Content-Encoding: gzip')"

--- a/tests/01_engine-header.test
+++ b/tests/01_engine-header.test
@@ -10,9 +10,11 @@ set -euo pipefail
 # Isolates the wire layer from url_savename, which strips traversal on its own.
 
 hdr() {
-    local want=$1
+    local want=$1 got
     shift
-    assert_eq "$want" "$(httrack -O /dev/null -#test=header "$@" | grep '^contenttype=')" "$*"
+    # Assigned, not passed inline: set -e sees a failing engine only in an assignment.
+    got=$(httrack -O /dev/null -#test=header "$@" | grep '^contenttype=')
+    assert_eq "$want" "$got" "$*"
 }
 
 hdr 'contenttype=application/pdf cdispo=' 'Content-Type: application/pdf'

--- a/tests/01_engine-identabs.test
+++ b/tests/01_engine-identabs.test
@@ -3,6 +3,9 @@
 
 set -euo pipefail
 
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
 # A 2047-byte hostless "?"-URL used to overflow fil[] by one byte and abort in
 # strncat_safe_; the guard now returns -1 while valid URLs still parse.
-test "$(httrack -O /dev/null -#test=identabs)" == "identabs self-test OK" || exit 1
+assert_selftest "identabs self-test OK" identabs

--- a/tests/01_engine-identurl.test
+++ b/tests/01_engine-identurl.test
@@ -3,13 +3,14 @@
 
 set -euo pipefail
 
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
 # ident_url_absolute splits a raw URL into (adr, fil), the first parser to touch
 # it. -#test=identurl <url> [pad] prints "adr=.. fil=.." or "error"; pad appends
 # N 'a's, reaching lengths a CLI arg can't.
 
-split() {
-    test "$(httrack -O /dev/null -#test=identurl "$1")" == "$2" || exit 1
-}
+split() { assert_selftest "$2" identurl "$1"; }
 
 split 'http://www.example.com/a/b/../c.html' 'adr=www.example.com fil=/a/c.html'
 split 'ftp://ftp.example.com/pub/file.txt' 'adr=ftp://ftp.example.com fil=/pub/file.txt'
@@ -20,8 +21,6 @@ split 'file://' 'adr=file:// fil=//'
 
 # a root-relative path is copied whole into fil[HTS_URLMAXSIZE*2], so a URL at
 # the buffer size is the tightest overflow; it must be rejected, not abort.
-split_pad() {
-    test "$(httrack -O /dev/null -#test=identurl "$1" "$2")" == "$3" || exit 1
-}
+split_pad() { assert_selftest "$3" identurl "$1" "$2"; }
 split_pad '/' 2047 'error' # 1 + 2047 = 2048 = HTS_URLMAXSIZE*2
 split_pad 'http://h/' 3000 'error'

--- a/tests/01_engine-idna.test
+++ b/tests/01_engine-idna.test
@@ -3,13 +3,18 @@
 
 set -euo pipefail
 
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
 # IDNA / punycode encode (-#test=idna-encode) and decode (-#test=idna-decode). This code has a CVE history,
 # so the edge cases below cover passthrough, round-trips, and malformed input.
 
-enc() { test "$(httrack -O /dev/null -#test=idna-encode "$1")" == "$2" || exit 1; }
-dec() { test "$(httrack -O /dev/null -#test=idna-decode "$1")" == "$2" || exit 1; }
+enc() { assert_selftest "$2" idna-encode "$1"; }
+dec() { assert_selftest "$2" idna-decode "$1"; }
 # a malformed encode input must be rejected (empty output), not encoded or leaked.
-enc_bad() { test -z "$(httrack -O /dev/null -#test=idna-encode "$1" 2>/dev/null)" || exit 1; }
+enc_bad() {
+    assert_eq "" "$(httrack -O /dev/null -#test=idna-encode "$1" 2>/dev/null)" "idna-encode '$1'"
+}
 
 # encode
 enc 'www.café.com' 'www.xn--caf-dma.com'

--- a/tests/01_engine-longpath-io.test
+++ b/tests/01_engine-longpath-io.test
@@ -2,11 +2,13 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # Drives -#test=longpath: a >MAX_PATH round trip exercising hts_pathToUCS2's
 # \\?\ prefixing on Windows (#133); a positive control on POSIX.
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 out=$(httrack -O /dev/null -#test=longpath "$dir")
 grep -q "longpath:.*OK" <<<"$out"

--- a/tests/01_engine-makeindex.test
+++ b/tests/01_engine-makeindex.test
@@ -2,11 +2,13 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # hts_finish_makeindex writes the footer and gates the refresh meta on a single
 # first link (guards the macro->function extraction).
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 httrack -O /dev/null -#test=makeindex "$dir" run |
     grep -q "makeindex self-test OK"

--- a/tests/01_engine-mime.test
+++ b/tests/01_engine-mime.test
@@ -3,14 +3,20 @@
 
 set -euo pipefail
 
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
 # MIME type guessing from extension (get_httptype / give_mimext).
 # -#test=mime <path> prints "<path> is '<mime>'" then "and its local type is '.<ext>'".
 
+# Only the type line is pinned, so firstline rather than a pipe into head, which
+# would SIGPIPE the engine and, under pipefail, red the test for the wrong reason.
 mime() {
-    test "$(httrack -O /dev/null -#test=mime "$1" | head -1)" == "$1 is '$2'" || exit 1
+    assert_eq "$1 is '$2'" "$(firstline "$(httrack -O /dev/null -#test=mime "$1")")"
 }
 unknown() {
-    test "$(httrack -O /dev/null -#test=mime "$1" | head -1)" == "$1 is of an unknown MIME type" || exit 1
+    assert_eq "$1 is of an unknown MIME type" \
+        "$(firstline "$(httrack -O /dev/null -#test=mime "$1")")"
 }
 
 mime '/a/b.html' 'text/html'

--- a/tests/01_engine-mime.test
+++ b/tests/01_engine-mime.test
@@ -9,8 +9,8 @@ set -euo pipefail
 # MIME type guessing from extension (get_httptype / give_mimext).
 # -#test=mime <path> prints "<path> is '<mime>'" then "and its local type is '.<ext>'".
 
-# Only the type line is pinned, so firstline rather than a pipe into head, which
-# would SIGPIPE the engine and, under pipefail, red the test for the wrong reason.
+# firstline, not a pipe into head: head would SIGPIPE the engine, and pipefail
+# then reds the test for the wrong reason.
 mime() {
     assert_eq "$1 is '$2'" "$(firstline "$(httrack -O /dev/null -#test=mime "$1")")"
 }

--- a/tests/01_engine-mirror-io.test
+++ b/tests/01_engine-mirror-io.test
@@ -2,12 +2,14 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # Drives -#test=mirrorio: rounds a file through a path that is both long
 # (>MAX_PATH) and non-ASCII, exercising the mirror I/O wrappers the engine's
 # raw file ops now route to on Windows (#133, #630). Positive control on POSIX.
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 out=$(httrack -O /dev/null -#test=mirrorio "$dir")
 grep -q "mirrorio:.*OK" <<<"$out"

--- a/tests/01_engine-parse.test
+++ b/tests/01_engine-parse.test
@@ -5,10 +5,11 @@
 # and checks which assets the parser captured and how it rewrote the links.
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_parse.XXXXXX") || exit 1
-trap 'set +e; rm -rf "$tmp"' EXIT
-trap 'rm -rf "$tmp"' HUP INT QUIT PIPE TERM
+cleanup_push rm -rf "$tmp"
 
 # a minimal valid 1x1 GIF, reused for every referenced asset
 gif() {
@@ -28,14 +29,14 @@ crawl() {
 # assert a file with the given basename was saved somewhere under <out>
 found() {
     test -n "$(find "$2" -type f -name "$1" -print -quit)" ||
-        ! echo "FAIL: expected '$1' to be downloaded under $2" || exit 1
+        fail "expected '$1' to be downloaded under $2"
 }
 
 # assert NO file with the given basename was saved (e.g. a descriptor token must
 # not be mistaken for a URL)
 notfound() {
     test -z "$(find "$2" -type f -name "$1" -print -quit)" ||
-        ! echo "FAIL: '$1' should not have been downloaded under $2" || exit 1
+        fail "'$1' should not have been downloaded under $2"
 }
 
 # the mirrored fixture page (under "file/"), not HTTrack's own landing index
@@ -76,31 +77,31 @@ notfound "800w" "$out"
 notfound "2x" "$out"
 
 saved=$(savedhtml "$out")
-test -n "$saved" || ! echo "FAIL: saved index.html not found" || exit 1
+test -n "$saved" || fail "saved index.html not found"
 
 # descriptors must survive the rewrite (no "b.gif 480w" mangled into a path)
 grep -Eq 'srcset="[^"]*480w[^"]*800w' "$saved" ||
-    ! echo "FAIL: srcset width descriptors lost/reordered in rewritten HTML" || exit 1
+    fail "srcset width descriptors lost/reordered in rewritten HTML"
 grep -Eq 'srcset="[^"]*1x[^"]*2x' "$saved" ||
-    ! echo "FAIL: srcset density descriptors lost/reordered in rewritten HTML" || exit 1
+    fail "srcset density descriptors lost/reordered in rewritten HTML"
 # the descriptor-less comma form keeps both candidates and the separator verbatim
 grep -Eq 'srcset="e\.gif, f\.gif"' "$saved" ||
-    ! echo "FAIL: comma-separated srcset without descriptors was altered" || exit 1
+    fail "comma-separated srcset without descriptors was altered"
 # an attribute following srcset in the same tag must be left intact
 grep -q 'alt="trailing attr after srcset"' "$saved" ||
-    ! echo "FAIL: srcset swallowed a following attribute" || exit 1
+    fail "srcset swallowed a following attribute"
 
 # a comma inside a URL (data: URI, CDN path) is part of the URL, not a split
 # point (WHATWG): the data: URI stays verbatim; the next candidate (dz) downloads
 grep -Fq 'data:image/gif;base64,R0lGODlhAQABAAAAACw= 1x' "$saved" ||
-    ! echo "FAIL: a comma inside a data: URI srcset candidate was mis-split" || exit 1
+    fail "a comma inside a data: URI srcset candidate was mis-split"
 
 # real rewrite, not passthrough: the absolute file:// candidate becomes local
 # (a flat fixture can't show this; the footer comment's file:// is not in srcset)
 grep -Eq 'srcset="j\.gif 2x"' "$saved" ||
-    ! echo "FAIL: absolute file:// srcset URL was not rewritten to a local link" || exit 1
+    fail "absolute file:// srcset URL was not rewritten to a local link"
 ! grep -Eq 'srcset="[^"]*file://' "$saved" ||
-    ! echo "FAIL: a file:// URL survived inside a rewritten srcset attribute" || exit 1
+    fail "a file:// URL survived inside a rewritten srcset attribute"
 
 # xlink:href (#298) and CSS background-image (#237): detected and rewritten to
 # local. background-image is covered in both an external <style> block and an
@@ -125,33 +126,33 @@ EOF
 out2="$tmp/attrs-out"
 crawl "$site2/index.html" "$out2"
 saved2=$(savedhtml "$out2")
-test -n "$saved2" || ! echo "FAIL: saved attrs page not found" || exit 1
+test -n "$saved2" || fail "saved attrs page not found"
 
 # detected attributes: the absolute URL is rewritten to a local link
 grep -Eq 'xlink:href="xl\.gif"' "$saved2" ||
-    ! echo "FAIL #298: xlink:href not detected/rewritten" || exit 1
+    fail "#298: xlink:href not detected/rewritten"
 
 # #237 external <style> block, each quoting form, quote style preserved
 grep -Eq 'url\(cex\.gif\)' "$saved2" ||
-    ! echo "FAIL #237: unquoted background-image in <style> not rewritten" || exit 1
+    fail "#237: unquoted background-image in <style> not rewritten"
 grep -Eq 'url\("cexd\.gif"\)' "$saved2" ||
-    ! echo "FAIL #237: double-quoted background-image in <style> not rewritten" || exit 1
+    fail "#237: double-quoted background-image in <style> not rewritten"
 grep -Eq "url\('cexs\.gif'\)" "$saved2" ||
-    ! echo "FAIL #237: single-quoted background-image in <style> not rewritten" || exit 1
+    fail "#237: single-quoted background-image in <style> not rewritten"
 
 # #237 inline style attribute, unquoted and single-quoted url()
 grep -Eq 'style="background-image:url\(ibg\.gif\)"' "$saved2" ||
-    ! echo "FAIL #237: inline unquoted background-image not rewritten" || exit 1
+    fail "#237: inline unquoted background-image not rewritten"
 grep -Eq "style=\"background-image:url\('ibgs\.gif'\)\"" "$saved2" ||
-    ! echo "FAIL #237: inline single-quoted background-image not rewritten" || exit 1
+    fail "#237: inline single-quoted background-image not rewritten"
 
 # no file:// URL survived inside any rewritten background-image
 ! grep -Eq 'background-image:[^;"]*file://' "$saved2" ||
-    ! echo "FAIL #237: a file:// URL survived inside a rewritten background-image" || exit 1
+    fail "#237: a file:// URL survived inside a rewritten background-image"
 
 # excluded attribute: title is on the no-detect list, so its value is left as-is
 grep -q 'title="file://' "$saved2" ||
-    ! echo "FAIL: a no-detect attribute (title) was wrongly rewritten" || exit 1
+    fail "a no-detect attribute (title) was wrongly rewritten"
 
 # xmlns / xmlns:prefix decls must not be crawled (#191). Local file:// targets so a
 # regression downloads them; each is the LAST attr (heuristic only scans a value before '>').
@@ -201,10 +202,10 @@ for f in nq dqu squ dqs sqs med cond sup lay spc; do found "$f.css" "$out4"; don
 # Over-capture guard: the trailing condition is not part of the URL, so it must
 # survive the rewrite verbatim. A regression that grabs it would mangle these.
 m4=$(find "$out4" -type f -path '*/file/*' -name main.css -print -quit)
-test -n "$m4" || ! echo "FAIL: saved main.css not found" || exit 1
+test -n "$m4" || fail "saved main.css not found"
 for cond in '@import "cond.css" screen;' 'supports(display: flex)' 'layer(base)'; do
     grep -Fq "$cond" "$m4" ||
-        ! echo "FAIL #94: '$cond' altered on rewrite (condition captured as URL?)" || exit 1
+        fail "#94: '$cond' altered on rewrite (condition captured as URL?)"
 done
 
 # Malformed input: an unterminated @import quote (truncated CSS) must not crash or
@@ -257,11 +258,11 @@ notfound "Post" "$out7"
 # rewritten to a local link. The rewrite only happens if the parser saw it, so
 # these two assertions fail if .open detection broke (not a trivial --near save).
 saved7=$(savedhtml "$out7")
-test -n "$saved7" || ! echo "FAIL: saved xhr page not found" || exit 1
+test -n "$saved7" || fail "saved xhr page not found"
 grep -Fq 'window.open("winopen.gif")' "$saved7" ||
-    ! echo "FAIL #218: window.open(url) no longer detected/rewritten" || exit 1
+    fail "#218: window.open(url) no longer detected/rewritten"
 ! grep -Fq 'window.open("file://' "$saved7" ||
-    ! echo "FAIL #218: window.open URL left absolute (not rewritten)" || exit 1
+    fail "#218: window.open URL left absolute (not rewritten)"
 
 # Parens in an unquoted url(...) (#163): the source %28/%29 decode to literal
 # '(' ')' in the saved name, but a literal ')' in the rewritten url() closes the
@@ -281,13 +282,13 @@ found "img (1).gif" "$out8"
 found "a(b)c(1).gif" "$out8"
 found "q (4).gif" "$out8"
 css8=$(find "$out8" -type f -path '*/file/*' -name style.css -print -quit)
-test -n "$css8" || ! echo "FAIL: saved style.css not found" || exit 1
+test -n "$css8" || fail "saved style.css not found"
 grep -Fq 'url(img%20%281%29.gif)' "$css8" ||
-    ! echo "FAIL #163: parens in unquoted url() not percent-encoded on rewrite" || exit 1
+    fail "#163: parens in unquoted url() not percent-encoded on rewrite"
 grep -Fq 'url(a%28b%29c%281%29.gif)' "$css8" ||
-    ! echo "FAIL #163: not every paren in a url() was percent-encoded" || exit 1
+    fail "#163: not every paren in a url() was percent-encoded"
 grep -Fq 'url("q%20%284%29.gif")' "$css8" ||
-    ! echo "FAIL #163: quoted url() altered or parens left literal on rewrite" || exit 1
+    fail "#163: quoted url() altered or parens left literal on rewrite"
 
 # The url() detector is not CSS-specific: <script> and inline style= get the
 # same encoding, but ordinary href/src (ending_p is the quote, not ')') keep
@@ -306,21 +307,21 @@ EOF
 out9="$tmp/urlparens-out"
 crawl "$site9/index.html" "$out9"
 saved9=$(savedhtml "$out9")
-test -n "$saved9" || ! echo "FAIL: saved urlparens page not found" || exit 1
+test -n "$saved9" || fail "saved urlparens page not found"
 # rewrite-only: the JS-string asset is not queued for download
 grep -Fq 'url(js%20%281%29.gif)' "$saved9" ||
-    ! echo "FAIL #163: parens in <script> url() not percent-encoded" || exit 1
+    fail "#163: parens in <script> url() not percent-encoded"
 found "inl (2).gif" "$out9"
 grep -Fq 'url(inl%20%282%29.gif)' "$saved9" ||
-    ! echo "FAIL #163: parens in inline style url() not percent-encoded" || exit 1
+    fail "#163: parens in inline style url() not percent-encoded"
 found "asrc (3).gif" "$out9"
 found "ahref (4).gif" "$out9"
 grep -Fq 'src="asrc%20(3).gif"' "$saved9" ||
-    ! echo "FAIL #163: parens in a plain src attribute were wrongly encoded" || exit 1
+    fail "#163: parens in a plain src attribute were wrongly encoded"
 grep -Fq 'href="ahref%20(4).gif"' "$saved9" ||
-    ! echo "FAIL #163: parens in a plain href attribute were wrongly encoded" || exit 1
+    fail "#163: parens in a plain href attribute were wrongly encoded"
 ! grep -Eq '(src|href)="[^"]*%28' "$saved9" ||
-    ! echo "FAIL #163: gate over-fired onto a non-url() attribute link" || exit 1
+    fail "#163: gate over-fired onto a non-url() attribute link"
 
 # HTML5 <source>/<track> follow as embedded near-links past the -r2 depth boundary (#451).
 # img.gif positive control; plain.gif (bare <a href>) negative control proves the gate is selective.
@@ -384,15 +385,15 @@ EOF
 out11="$tmp/dataattr-out"
 crawl "$site11/index.html" "$out11"
 saved11=$(savedhtml "$out11")
-test -n "$saved11" || ! echo "FAIL: saved dataattr page not found" || exit 1
+test -n "$saved11" || fail "saved dataattr page not found"
 grep -Fq 'data-pre="pre.gif"' "$saved11" ||
-    ! echo "FAIL #201: data-* URL before any script not detected/rewritten" || exit 1
+    fail "#201: data-* URL before any script not detected/rewritten"
 grep -Fq 'data-post="post.gif"' "$saved11" ||
-    ! echo "FAIL #201: data-* URL after a script not detected (state leak)" || exit 1
+    fail "#201: data-* URL after a script not detected (state leak)"
 grep -Fq 'data-mid="mid.gif"' "$saved11" ||
-    ! echo "FAIL #201: mid-tag data-* URL not detected" || exit 1
+    fail "#201: mid-tag data-* URL not detected"
 grep -Fq 'data-sp = "spdata.gif"' "$saved11" ||
-    ! echo "FAIL #201: spaced-= data-* URL not detected" || exit 1
+    fail "#201: spaced-= data-* URL not detected"
 found "handler.gif" "$out11"  # automaton reset at the handler-terminator exit
 found "handler2.gif" "$out11" # ... and at the '>' exit of an unterminated handler
 # a JS string not preceded by =/(/, is still ignored after the reset

--- a/tests/01_engine-proxyurl.test
+++ b/tests/01_engine-proxyurl.test
@@ -3,14 +3,15 @@
 
 set -euo pipefail
 
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
 # hts_parse_proxy splits a -P argument "[scheme://][user:pass@]host[:port]" into
 # the proxy host string and port. -#test=proxyurl <arg> prints
 # "name=.. port=.. host=.. kind=..", where host= is what the connect resolves and
 # kind= is the transport the scheme selects (http, socks or connect).
 
-p() {
-    test "$(httrack -O /dev/null -#test=proxyurl "$1")" == "$2" || exit 1
-}
+p() { assert_selftest "$2" proxyurl "$1"; }
 
 # bare host, with and without an explicit port
 p 'proxy.example.com:8080' 'name=proxy.example.com port=8080 host=proxy.example.com kind=http'

--- a/tests/01_engine-rcfile.test
+++ b/tests/01_engine-rcfile.test
@@ -61,10 +61,7 @@ test "$rc" -eq 0 || {
     echo "FAIL: rc-file crawl exited $rc"
     exit 1
 }
-test -f "$d1/hts-cache/doit.log" || {
-    echo "FAIL: doit.log not written (rc file not processed)"
-    exit 1
-}
+assert_file "$d1/hts-cache/doit.log" "no doit.log, so the rc file was not processed"
 # A truncated copy would cut the token; require the full -F value.
 grep -q -- "-F $marker" "$d1/hts-cache/doit.log" || {
     echo "FAIL: user-agent alias missing or truncated in doit.log"

--- a/tests/01_engine-rcfile.test
+++ b/tests/01_engine-rcfile.test
@@ -17,6 +17,8 @@
 # set -e with the intentional-nonzero httrack runs guarded explicitly (the
 # crawls below are expected to fail/abort and their status is inspected by hand).
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # Resolve httrack to an absolute path before we cd: PATH may hold a build-relative
 # entry that would not resolve from the temp directory.
@@ -30,8 +32,7 @@ case "$bin" in
 esac
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_rcfile.XXXXXX") || exit 1
-trap 'set +e; rm -rf "$tmp"' EXIT
-trap 'rm -rf "$tmp"' HUP INT QUIT PIPE TERM
+cleanup_push rm -rf "$tmp"
 
 # HTS_HTTRACKRC is ".httrackrc" on POSIX but "httrackrc" on Windows: write both,
 # each platform reads the one it knows.

--- a/tests/01_engine-reconcile.test
+++ b/tests/01_engine-reconcile.test
@@ -5,9 +5,11 @@
 # run, and restore the old one when an update transferred nothing.
 
 set -eu
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 out=$(httrack -#test=reconcile "$dir")
 

--- a/tests/01_engine-renameover.test
+++ b/tests/01_engine-renameover.test
@@ -2,13 +2,15 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # Drives -#test=renameover: hts_rename_over() must replace an existing dst, and
 # must leave dst alone when the rename failed for a reason moving dst aside
 # cannot fix (#779, #790). The selftest prints the regime and the restore
 # outcome it took; pin both per leg so none can pass having tested another.
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 case "$(uname -s)" in
 MINGW* | MSYS_NT*) want=fallback ;; # native rename() refuses an existing target

--- a/tests/01_engine-renameover.test
+++ b/tests/01_engine-renameover.test
@@ -18,9 +18,9 @@ MINGW* | MSYS_NT*) want=fallback ;; # native rename() refuses an existing target
 esac
 
 out=$(httrack -O /dev/null -#test=renameover "$dir")
-grep -q "renameover: OK" <<<"$out"
-grep -q "renameover: regime $want" <<<"$out"
-grep -q "renameover: restore back" <<<"$out"
+assert_match "renameover: OK" "$out"
+assert_match "renameover: regime $want" "$out"
+assert_match "renameover: restore back" "$out"
 
 if [ "$(uname -s)" != "Linux" ]; then
     echo "renameover: LD_PRELOAD interposition is Linux-only here, skipping"
@@ -48,26 +48,26 @@ export ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}verify_asan_link_order=0"
 # The aside fallback is dead code on POSIX, so borrow Windows' rename().
 out=$(LD_PRELOAD="$RENAMEFAIL_LIB" httrack -O /dev/null \
     -#test=renameover "$dir")
-grep -q "renameover: OK" <<<"$out"
-grep -q "renameover: regime fallback" <<<"$out"
-grep -q "renameover: restore back" <<<"$out"
+assert_match "renameover: OK" "$out"
+assert_match "renameover: regime fallback" "$out"
+assert_match "renameover: restore back" "$out"
 
 # #790: the move back out of the parked name fails once. Without the retry the
 # old copy stays parked and dst is left absent.
 out=$(RENAMEFAIL_ASIDE_FAILS=1 LD_PRELOAD="$RENAMEFAIL_LIB" httrack -O /dev/null \
     -#test=renameover "$dir")
-grep -q "renameover: OK" <<<"$out"
-grep -q "renameover: restore back" <<<"$out"
+assert_match "renameover: OK" "$out"
+assert_match "renameover: restore back" "$out"
 
 # It keeps failing: the old copy must survive under the parked name, never be
 # deleted, and the call must still report failure.
 out=$(RENAMEFAIL_ASIDE_FAILS=9 LD_PRELOAD="$RENAMEFAIL_LIB" httrack -O /dev/null \
     -#test=renameover "$dir")
-grep -q "renameover: OK" <<<"$out"
-grep -q "renameover: restore parked" <<<"$out"
+assert_match "renameover: OK" "$out"
+assert_match "renameover: restore parked" "$out"
 
 # A source another process holds fails with EACCES, which dst had no part in.
 out=$(RENAMEFAIL_MODE=locked LD_PRELOAD="$RENAMEFAIL_LIB" httrack -O /dev/null \
     -#test=renameover "$dir")
-grep -q "renameover: OK" <<<"$out"
-grep -q "renameover: regime refused" <<<"$out"
+assert_match "renameover: OK" "$out"
+assert_match "renameover: regime refused" "$out"

--- a/tests/01_engine-savename.test
+++ b/tests/01_engine-savename.test
@@ -2,17 +2,18 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # Local save-name resolution (url_savename via -#test=savename <fil> <content-type> [key=value ...]).
 # name() asserts on the basename, full() on the whole path; prior= registers an
 # already-crawled link whose sav is rooted under the -O path (/dev/null here).
 
-# resolve httrack before cd: make check puts a RELATIVE ../src on PATH
-httrack_bin=$(cd "$(dirname "$(command -v httrack)")" && pwd)/httrack
+httrack_bin=$(httrack_path)
 
 # scratch dir: body= and cached= write temp files (st-savename-body.tmp, hts-cache/)
 scratch=$(mktemp -d)
-trap 'set +e; rm -rf "$scratch"' EXIT
+cleanup_push rm -rf "$scratch"
 cd "$scratch"
 
 run() {

--- a/tests/01_engine-selftest-dispatch.test
+++ b/tests/01_engine-selftest-dispatch.test
@@ -5,13 +5,16 @@
 
 set -eu
 
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
 # Bare -#test lists known tests (printed to stderr).
 list=$(httrack -#test 2>&1)
-grep -q "filter" <<<"$list" || exit 1
-grep -q "cache-writefail" <<<"$list" || exit 1
+assert_match 'filter +<pattern> <string>' "$list" 'the registry listing'
+assert_match 'cache-writefail +<dir>' "$list" 'the registry listing'
 
 # Unknown name: non-zero exit + diagnostic, and no test result line.
 rc=0
 err=$(httrack -#test=bogus 2>&1) || rc=$?
-test "$rc" -ne 0 || exit 1
-grep -q "Unknown self-test" <<<"$err" || exit 1
+test "$rc" -ne 0 || fail "an unknown self-test name exited 0"
+assert_match 'Unknown self-test' "$err"

--- a/tests/01_engine-simplify.test
+++ b/tests/01_engine-simplify.test
@@ -3,10 +3,11 @@
 
 set -euo pipefail
 
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
 # path simplify engine (fil_simplifie): collapses ./ and ../ segments.
-simp() {
-    test "$(httrack -O /dev/null -#test=simplify "$1")" == "simplified=$2" || exit 1
-}
+simp() { assert_selftest "simplified=$2" simplify "$1"; }
 
 simp './foo/bar/' 'foo/bar/'
 simp './foo/bar' 'foo/bar'

--- a/tests/01_engine-structcheck.test
+++ b/tests/01_engine-structcheck.test
@@ -4,9 +4,11 @@
 # built its target with an unbounded sprintf (#745).
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 httrack -O /dev/null -#test=structcheck "$dir" |
     grep -q "structcheck self-test OK"

--- a/tests/01_engine-topindex.test
+++ b/tests/01_engine-topindex.test
@@ -2,11 +2,13 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # hts_buildtopindex takes a system-charset path but verif_backblue below it
 # expects utf-8, mangling a non-ASCII project dir on Windows (#216, #217).
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 httrack -O /dev/null -#test=topindex "$dir" run |
     grep -q "topindex self-test OK"

--- a/tests/01_zlib-acceptencoding.test
+++ b/tests/01_zlib-acceptencoding.test
@@ -2,10 +2,12 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # Accept-Encoding (#450): advertise gzip+deflate; decode gzip/zlib/raw-deflate.
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 httrack -O /dev/null -#test=acceptencoding "$dir" run |
     grep -q "acceptencoding self-test OK"

--- a/tests/01_zlib-cache-corrupt.test
+++ b/tests/01_zlib-cache-corrupt.test
@@ -5,9 +5,11 @@
 # deflate) must each be rejected per-entry, never crash, never taint the sibling.
 
 set -eu
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 # the smashed-header case logs expected "Corrupted cache entry" warnings on
 # stdout; the verdict is the last line

--- a/tests/01_zlib-cache-golden.test
+++ b/tests/01_zlib-cache-golden.test
@@ -19,10 +19,7 @@ set -eu
 : "${top_srcdir:=..}"
 fixture="$top_srcdir/tests/fixtures/cache-golden"
 
-test -e "$fixture/hts-cache/new.zip" || {
-    echo "missing committed cache fixture: $fixture/hts-cache/new.zip" >&2
-    exit 1
-}
+assert_file "$fixture/hts-cache/new.zip" "the committed cache fixture is missing"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/01_zlib-cache-golden.test
+++ b/tests/01_zlib-cache-golden.test
@@ -13,6 +13,8 @@
 # committed file.
 
 set -eu
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 : "${top_srcdir:=..}"
 fixture="$top_srcdir/tests/fixtures/cache-golden"
@@ -23,7 +25,7 @@ test -e "$fixture/hts-cache/new.zip" || {
 }
 
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 # Read against a private copy so the source tree is never touched (a read
 # session does not write, but copying keeps the test hermetic). Create the dir

--- a/tests/01_zlib-cache-legacy.test
+++ b/tests/01_zlib-cache-legacy.test
@@ -4,9 +4,11 @@
 # legacy pair and leave the files untouched (httrack -#test=cache-legacy <dir>).
 
 set -eu
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 # the refusal errors land on stdout (no log file); pin them and the verdict
 out=$(httrack -#test=cache-legacy "$dir" 2>/dev/null)

--- a/tests/01_zlib-cache-writefail.test
+++ b/tests/01_zlib-cache-writefail.test
@@ -7,9 +7,11 @@
 # entry is only dropped.
 
 set -eu
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 out=$(httrack -#test=cache-writefail "$dir")
 

--- a/tests/01_zlib-cache.test
+++ b/tests/01_zlib-cache.test
@@ -12,9 +12,11 @@
 # on the first mismatch.
 
 set -eu
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 # The working directory is a required argument; without it the test prints a
 # usage line to stderr and returns non-zero.

--- a/tests/01_zlib-cache.test
+++ b/tests/01_zlib-cache.test
@@ -31,10 +31,7 @@ test "$out" = "cache-selftest: OK" || {
 }
 
 # The self-test must have actually produced a ZIP cache on disk.
-test -e "$dir/hts-cache/new.zip" || {
-    echo "no ZIP cache was written by the self-test" >&2
-    exit 1
-}
+assert_file "$dir/hts-cache/new.zip" "the self-test wrote no ZIP cache"
 
 # Sanity-check the cache footprint: the few-thousand-entry pass is expected to
 # weigh ~1-2 MB. Fail if it balloons well past that (e.g. a per-entry overhead

--- a/tests/01_zlib-contentcodings.test
+++ b/tests/01_zlib-contentcodings.test
@@ -2,10 +2,12 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # brotli/zstd decode, unknown codings, and the decoded-size budget.
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 httrack -O /dev/null -#test=contentcodings "$dir" run |
     grep -q "contentcodings self-test OK"

--- a/tests/01_zlib-repair-shift.test
+++ b/tests/01_zlib-repair-shift.test
@@ -7,9 +7,11 @@
 # READ_32 shift an int past INT_MAX; UBSan aborts before the fix casts to uLong.
 
 set -eu
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 out=$(httrack -#test=zip-repair-shift "$dir")
 

--- a/tests/01_zlib-savename-cached.test
+++ b/tests/01_zlib-savename-cached.test
@@ -2,15 +2,16 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # Update-run naming from a real cache entry (-#test=savename cached=<ctype>|<save>).
 # Named 01_zlib-*: the cache writer needs zlib, which the MSan job can't run.
 
-# resolve httrack before cd: make check puts a RELATIVE ../src on PATH
-httrack_bin=$(cd "$(dirname "$(command -v httrack)")" && pwd)/httrack
+httrack_bin=$(httrack_path)
 
 scratch=$(mktemp -d)
-trap 'set +e; rm -rf "$scratch"' EXIT
+cleanup_push rm -rf "$scratch"
 cd "$scratch"
 
 name() {

--- a/tests/01_zlib-warc-cdx-errors.test
+++ b/tests/01_zlib-warc-cdx-errors.test
@@ -4,11 +4,13 @@
 # rewritten archive, must say so; a first run with nothing to index must not.
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
-httrack_bin=$(cd "$(dirname "$(command -v httrack)")" && pwd)/httrack
+httrack_bin=$(httrack_path)
 
 scratch=$(mktemp -d)
-trap 'set +e; rm -rf "$scratch"' EXIT
+cleanup_push rm -rf "$scratch"
 
 out=$("$httrack_bin" -O /dev/null -#test=warc-cdx-errors "$scratch/")
 echo "$out"

--- a/tests/01_zlib-warc-cdx.test
+++ b/tests/01_zlib-warc-cdx.test
@@ -2,14 +2,16 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # --warc-cdx CDXJ index over synthetic transactions: sorted, one line per
 # response/revisit/resource, each offset/length inflates to the right member.
 
-httrack_bin=$(cd "$(dirname "$(command -v httrack)")" && pwd)/httrack
+httrack_bin=$(httrack_path)
 
 scratch=$(mktemp -d)
-trap 'set +e; rm -rf "$scratch"' EXIT
+cleanup_push rm -rf "$scratch"
 
 out=$("$httrack_bin" -O /dev/null -#test=warc-cdx "$scratch/")
 echo "$out"

--- a/tests/01_zlib-warc-wacz.test
+++ b/tests/01_zlib-warc-wacz.test
@@ -2,13 +2,15 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # --wacz packaging over synthetic transactions: the WACZ unzips in-process to
 # the fixed layout, every entry is ZIP STORE, each datapackage sha256 recomputes
 # from the stored bytes, and the digest chains datapackage.json. WACZ needs the
 # OpenSSL SHA-256 digests, so the self-test is absent on non-OpenSSL builds.
 
-httrack_bin=$(cd "$(dirname "$(command -v httrack)")" && pwd)/httrack
+httrack_bin=$(httrack_path)
 
 registry=$("$httrack_bin" -#test 2>&1 || true)
 if ! grep -q '^  warc-wacz' <<<"$registry"; then
@@ -17,7 +19,7 @@ if ! grep -q '^  warc-wacz' <<<"$registry"; then
 fi
 
 scratch=$(mktemp -d)
-trap 'set +e; rm -rf "$scratch"' EXIT
+cleanup_push rm -rf "$scratch"
 
 out=$("$httrack_bin" -O /dev/null -#test=warc-wacz "$scratch/")
 echo "$out"

--- a/tests/01_zlib-warc.test
+++ b/tests/01_zlib-warc.test
@@ -2,15 +2,17 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # WARC/1.1 writer self-test: framing, Content-Length, gzip members, round-trip,
 # revisit dedup, plus v1.1 WARC-Truncated, ftp resource records, and
 # --warc-max-size rotation, over synthetic transactions.
 
-httrack_bin=$(cd "$(dirname "$(command -v httrack)")" && pwd)/httrack
+httrack_bin=$(httrack_path)
 
 scratch=$(mktemp -d)
-trap 'set +e; rm -rf "$scratch"' EXIT
+cleanup_push rm -rf "$scratch"
 
 for t in warc warc-trunc warc-ftp warc-rotate warc-verbatim; do
     out=$("$httrack_bin" -O /dev/null "-#test=$t" "$scratch/")

--- a/tests/02_manpage-regen.test
+++ b/tests/02_manpage-regen.test
@@ -5,8 +5,8 @@
 # followed by "make -C man regen-man".
 
 set -eu
-
-: "${top_srcdir:=..}"
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 gen="$top_srcdir/man/makeman.sh"
 committed="$top_srcdir/man/httrack.1"
@@ -24,7 +24,7 @@ command -v httrack >/dev/null 2>&1 || {
 tmp=$(mktemp) || exit 1
 committed_clean=$(mktemp) || exit 1
 generated_clean=$(mktemp) || exit 1
-trap 'set +e; rm -f "$tmp" "$committed_clean" "$generated_clean"' EXIT
+cleanup_push rm -f "$tmp" "$committed_clean" "$generated_clean"
 
 README="$top_srcdir/README" bash "$gen" httrack >"$tmp" 2>/dev/null || {
     echo "makeman.sh failed" >&2

--- a/tests/02_update-cache.test
+++ b/tests/02_update-cache.test
@@ -11,10 +11,12 @@
 #      (guards the update decision that reads the cached metadata).
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 site=$(mktemp -d)
 out=$(mktemp -d)
-trap 'set +e; rm -rf "$site" "$out"' EXIT
+cleanup_push rm -rf "$site" "$out"
 
 cat >"$site/index.html" <<EOF
 <a href="a.html">a</a> <a href="sub/b.html">b</a>

--- a/tests/100_local-purge-longpath.test
+++ b/tests/100_local-purge-longpath.test
@@ -20,12 +20,7 @@ python=$(find_python) || skip "python3 not found"
 
 # Resolve httrack now: the harness prepends a RELATIVE dir to PATH, so the cd
 # below would otherwise silently fall through to an installed copy.
-httrack_bin=$(command -v httrack)
-test -n "$httrack_bin" || {
-    echo "httrack not on PATH" >&2
-    exit 1
-}
-httrack_bin=$(cd "$(dirname "$httrack_bin")" && pwd)/$(basename "$httrack_bin")
+httrack_bin=$(httrack_path)
 
 work=$(mktemp -d)
 cleanup_push rm -rf "$work"

--- a/tests/104_engine-warc-longurl.test
+++ b/tests/104_engine-warc-longurl.test
@@ -4,10 +4,12 @@
 # used to lose it whole, with no error and an exit status of 0 (#785).
 
 set -e
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 : "${top_srcdir:=..}"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_longurl.XXXXXX")
-trap 'set +e; rm -rf "$tmp"' EXIT
+cleanup_push rm -rf "$tmp"
 
 httrack -O "$tmp/out" "-#test=warc-longurl" "$tmp"

--- a/tests/108_engine-refetch-backup.test
+++ b/tests/108_engine-refetch-backup.test
@@ -5,10 +5,11 @@
 # mirror namespace (#774, #775).
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
-trap 'set +e; rm -rf "$dir"; exit 1' HUP INT QUIT PIPE TERM
+cleanup_push rm -rf "$dir"
 
 rc=0
 out=$(httrack -O /dev/null -#test=refetchbackup "$dir" 2>&1) || rc=$?

--- a/tests/113_engine-threadattr-leak.test
+++ b/tests/113_engine-threadattr-leak.test
@@ -6,6 +6,8 @@
 # interposer counts the init/destroy imbalance instead.
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 if [ "$(uname -s)" != "Linux" ]; then
     echo "threadattr: LD_PRELOAD interposition is Linux-only here, skipping"
@@ -27,8 +29,7 @@ if [ ! -r "${THREADATTRFAIL_LIB:-}" ]; then
 fi
 
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
-trap 'rm -rf "$dir"' HUP INT QUIT PIPE TERM
+cleanup_push rm -rf "$dir"
 
 # An LD_PRELOAD library loads ahead of the executable's own libasan, which ASan
 # refuses by default. The shim allocates nothing, so the ordering is harmless.

--- a/tests/120_local-proxytrack-webdav-default.test
+++ b/tests/120_local-proxytrack-webdav-default.test
@@ -34,16 +34,10 @@ alen=$(($(wc -c <"$dir/hdr") + $(wc -c <"$dir/body")))
     cat "$dir/hdr" "$dir/body"
 } >"$dir/in.arc"
 
-freeport() {
-    "$python" -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()'
-}
-proxyport=$(freeport)
-icpport=$(freeport)
-
-: >"$dir/pt.log" # the drainer below creates it asynchronously
 # stdout to a file is fully buffered and SIGTERM never flushes it, so a leak on
 # stdout would be lost; a pty line-buffers it. The exec keeps $! on proxytrack.
-"$python" -c '
+launch_proxytrack() {
+    "$python" -c '
 import os, pty, sys
 master, slave = pty.openpty()
 if os.fork() == 0:
@@ -65,26 +59,9 @@ if slave > 2:
     os.close(slave)
 os.execvp(sys.argv[2], sys.argv[2:])
 ' "$dir/pt.log" proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc" &
-ptpid=$!
-waited=0
-until grep -qE "HTTP Proxy installed on|Unable to (initialize a temporary server|create the server)" "$dir/pt.log"; do
-    kill -0 "$ptpid" 2>/dev/null || {
-        echo "FAIL: proxytrack exited before listening"
-        cat "$dir/pt.log"
-        exit 1
-    }
-    test "$waited" -lt 50 || {
-        echo "FAIL: proxytrack never announced its listen port"
-        exit 1
-    }
-    sleep 0.1
-    waited=$((waited + 1))
-done
-grep -q "HTTP Proxy installed on" "$dir/pt.log" || {
-    echo "FAIL: proxytrack failed to bind"
-    cat "$dir/pt.log"
-    exit 1
+    ptpid=$!
 }
+start_proxytrack "$dir/pt.log" launch_proxytrack
 
 propfind() {
     local path=$1

--- a/tests/120_local-proxytrack-webdav-default.test
+++ b/tests/120_local-proxytrack-webdav-default.test
@@ -58,10 +58,10 @@ os.dup2(slave, 2)
 if slave > 2:
     os.close(slave)
 os.execvp(sys.argv[2], sys.argv[2:])
-' "$dir/pt.log" proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc" &
+' "$ptlog" proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc" &
     ptpid=$!
 }
-start_proxytrack "$dir/pt.log" launch_proxytrack
+start_proxytrack "$dir/pt" launch_proxytrack
 
 propfind() {
     local path=$1
@@ -72,7 +72,7 @@ propfind() {
 
 resp=$(propfind page.html) || {
     echo "FAIL: PROPFIND on an exact cache entry did not answer"
-    cat "$dir/pt.log"
+    cat "$ptlog"
     exit 1
 }
 grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
@@ -102,7 +102,7 @@ test "$responses" -eq 2 || {
 # The crash killed the process, so a second request is the liveness proof.
 resp=$(propfind "") || {
     echo "FAIL: proxytrack died serving the previous PROPFIND"
-    cat "$dir/pt.log"
+    cat "$ptlog"
     exit 1
 }
 grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
@@ -117,7 +117,7 @@ sentinel=PT911-DAV-BODY-CANARY
 pad=$(printf '%8192s' '')
 resp=$(propfind "" -H 'Expect:' --data-binary "$sentinel${pad// /x}") || {
     echo "FAIL: proxytrack died serving a PROPFIND carrying a body"
-    cat "$dir/pt.log"
+    cat "$ptlog"
     exit 1
 }
 grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
@@ -130,10 +130,10 @@ grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
 # PROPFIND is logged 403 without ever reaching the traces. It is logged after
 # them, so waiting on it also fences the drainer's copy.
 waited=0
-until test "$(grep -ci ' \* log: HTTP [^ ]* 207 [0-9]* propfind ' "$dir/pt.log" || true)" -ge 3; do
+until test "$(grep -ci ' \* log: HTTP [^ ]* 207 [0-9]* propfind ' "$ptlog" || true)" -ge 3; do
     test "$waited" -lt 50 || {
         echo "FAIL: fewer than three PROPFINDs were answered 207, so the checks below prove nothing"
-        cat "$dir/pt.log"
+        cat "$ptlog"
         exit 1
     }
     sleep 0.1
@@ -142,7 +142,7 @@ done
 
 # Neither what the client sent nor the generated body is echoed anywhere; the
 # two literals name the exact regression on top.
-log=$(<"$dir/pt.log")
+log=$(<"$ptlog")
 for marker in "$sentinel" 'Default Document for the Folder' 'DEBUG: DAV-DATA' '^RESPONSE:'; do
     if grep -q "$marker" <<<"$log"; then
         echo "FAIL: a PROPFIND echoed '$marker' into proxytrack's output"

--- a/tests/131_local-savename-reserved.test
+++ b/tests/131_local-savename-reserved.test
@@ -4,12 +4,13 @@
 # Asserted on the tail only, so the -O root's rendering stays out of it.
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
-# resolve httrack before cd: make check puts a RELATIVE ../src on PATH
-httrack_bin=$(cd "$(dirname "$(command -v httrack)")" && pwd)/httrack
+httrack_bin=$(httrack_path)
 
 scratch=$(mktemp -d)
-trap 'set +e; rm -rf "$scratch"' EXIT
+cleanup_push rm -rf "$scratch"
 cd "$scratch"
 
 tail_is() {

--- a/tests/144_engine-datadir.test
+++ b/tests/144_engine-datadir.test
@@ -4,11 +4,13 @@
 # back to the compiled-in defaults (#894).
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/datadir.XXXXXX") || {
     echo "no tmpdir" >&2
     exit 1
 }
-trap 'set +e; rm -rf "${work}"' EXIT
+cleanup_push rm -rf "${work}"
 
 httrack -#test=datadir "${work}"

--- a/tests/146_bash-shell.test
+++ b/tests/146_bash-shell.test
@@ -7,6 +7,8 @@
 # shellcheck disable=SC2016 # the probes are for the shell under test to expand
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 sh=${BASH_SHELL:-}
 test -n "$sh" || {
@@ -57,7 +59,7 @@ grep -q '^  *BASH_SHELL ' <<<"$help" || {
 }
 
 tmp=$(mktemp -d)
-trap 'set +e; rm -rf "$tmp"' EXIT
+cleanup_push rm -rf "$tmp"
 mkdir "$tmp/src" "$tmp/bld"
 ln -s "$sh" "$tmp/mybash"
 

--- a/tests/147_local-proxytrack-webdav-overflow.test
+++ b/tests/147_local-proxytrack-webdav-overflow.test
@@ -36,35 +36,11 @@ alen=$(($(wc -c <"$dir/hdr") + $(wc -c <"$dir/body")))
     cat "$dir/hdr" "$dir/body"
 } >"$dir/in.arc"
 
-# $() strips a trailing LF, not the CR Windows python's print can put before it.
-freeport() {
-    "$python" -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' |
-        tr -d '\r'
+launch_proxytrack() {
+    proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc" >"$dir/pt.log" 2>&1 &
+    ptpid=$!
 }
-proxyport=$(freeport)
-icpport=$(freeport)
-
-proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc" >"$dir/pt.log" 2>&1 &
-ptpid=$!
-waited=0
-until grep -qE "HTTP Proxy installed on|Unable to (initialize a temporary server|create the server)" "$dir/pt.log"; do
-    kill -0 "$ptpid" 2>/dev/null || {
-        echo "FAIL: proxytrack exited before listening"
-        cat "$dir/pt.log"
-        exit 1
-    }
-    test "$waited" -lt 50 || {
-        echo "FAIL: proxytrack never announced its listen port"
-        exit 1
-    }
-    sleep 0.1
-    waited=$((waited + 1))
-done
-grep -q "HTTP Proxy installed on" "$dir/pt.log" || {
-    echo "FAIL: proxytrack failed to bind"
-    cat "$dir/pt.log"
-    exit 1
-}
+start_proxytrack "$dir/pt.log" launch_proxytrack
 
 propfind() {
     curl -s -i --max-time 30 -X PROPFIND -H "Depth: 0" \

--- a/tests/147_local-proxytrack-webdav-overflow.test
+++ b/tests/147_local-proxytrack-webdav-overflow.test
@@ -37,10 +37,10 @@ alen=$(($(wc -c <"$dir/hdr") + $(wc -c <"$dir/body")))
 } >"$dir/in.arc"
 
 launch_proxytrack() {
-    proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc" >"$dir/pt.log" 2>&1 &
+    proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc" >"$ptlog" 2>&1 &
     ptpid=$!
 }
-start_proxytrack "$dir/pt.log" launch_proxytrack
+start_proxytrack "$dir/pt" launch_proxytrack
 
 propfind() {
     curl -s -i --max-time 30 -X PROPFIND -H "Depth: 0" \
@@ -52,7 +52,7 @@ propfind() {
 amps=$("$python" -c "print('&' * 900)" | tr -d '\r')
 resp=$(propfind "$amps") || {
     echo "FAIL: proxytrack died on an escapexml-amplified PROPFIND"
-    cat "$dir/pt.log"
+    cat "$ptlog"
     exit 1
 }
 grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
@@ -72,7 +72,7 @@ test "$got" -eq 1800 || {
 plain=$("$python" -c "print('a' * 900)" | tr -d '\r')
 resp=$(propfind "$plain") || {
     echo "FAIL: proxytrack died on a 900-byte plain PROPFIND path"
-    cat "$dir/pt.log"
+    cat "$ptlog"
     exit 1
 }
 grep -q "<href>/webdav/x/$plain</href>" <<<"$resp" || {
@@ -87,7 +87,7 @@ grep -q "<href>/webdav/x/$plain</href>" <<<"$resp" || {
 resp=$(curl -s -i --max-time 30 -X PROPFIND -H "Depth: 1" \
     "http://127.0.0.1:$proxyport/webdav/example.com/") || {
     echo "FAIL: proxytrack died on a Depth: 1 listing"
-    cat "$dir/pt.log"
+    cat "$ptlog"
     exit 1
 }
 grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
@@ -115,7 +115,7 @@ test "$responses" -eq 3 || {
 # The overflow killed the listener, so a later request is the liveness proof.
 resp=$(propfind "") || {
     echo "FAIL: proxytrack died before the follow-up listing"
-    cat "$dir/pt.log"
+    cat "$ptlog"
     exit 1
 }
 grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {

--- a/tests/148_engine-spoolname.test
+++ b/tests/148_engine-spoolname.test
@@ -4,11 +4,13 @@
 # serving <path>.tmp has its own copy truncated and then unlinked (#859).
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/spoolname.XXXXXX") || {
     echo "no tmpdir" >&2
     exit 1
 }
-trap 'set +e; rm -rf "${work}"' EXIT
+cleanup_push rm -rf "${work}"
 
 httrack -#test=spoolname "${work}"

--- a/tests/153_local-proxytrack-quiet.test
+++ b/tests/153_local-proxytrack-quiet.test
@@ -20,7 +20,7 @@ skip_on_windows "windows: python has no pty, so a buffered leak would be invisib
 dir=$(mktemp -d)
 quietpid=
 loudpid=
-ptpid= # start_proxytrack's, until the launch it started is named below
+ptpid= # start_proxytrack's, until the launch below takes it over
 cleanup() {
     stop_server "$ptpid"
     stop_server "$quietpid"
@@ -96,13 +96,13 @@ wait_drained() { # log
 launch_quiet() {
     (
         unset HTS_LOG
-        exec "$python" -c "$pty_exec" "$dir/quiet.log" \
+        exec "$python" -c "$pty_exec" "$ptlog" \
             proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc"
     ) &
     ptpid=$!
 }
-start_proxytrack "$dir/quiet.log" launch_quiet
-quietport=$proxyport quietpid=$ptpid ptpid=
+start_proxytrack "$dir/quiet" launch_quiet
+quietlog=$ptlog quietport=$proxyport quietpid=$ptpid ptpid=
 
 # Both on one connection: the access log is written before send(), and only
 # proxytrack's keep-alive loop orders anything written after it, since the
@@ -111,7 +111,7 @@ resp=$(curl -s -i --max-time 30 -X PROPFIND -H "Depth: 1" \
     "http://127.0.0.1:$quietport/webdav/example.com/" \
     "http://127.0.0.1:$quietport/webdav/example.com/page.html") || {
     echo "FAIL: the PROPFINDs did not answer"
-    cat "$dir/quiet.log"
+    cat "$quietlog"
     exit 1
 }
 served=$(grep -c '^HTTP/1\.[01] 207 ' <<<"$resp" || true)
@@ -132,10 +132,10 @@ test "$listed" -eq 4 || {
 # The enumeration is what builds the table, so the served 207s are what make
 # the check below mean anything.
 waited=0
-until test "$(request_log "$dir/quiet.log" | grep -ci ' \* log: HTTP [^ ]* 207 [0-9]* propfind ' || true)" -ge 2; do
+until test "$(request_log "$quietlog" | grep -ci ' \* log: HTTP [^ ]* 207 [0-9]* propfind ' || true)" -ge 2; do
     test "$waited" -lt 50 || {
         echo "FAIL: fewer than two PROPFINDs were answered 207, so the check below proves nothing"
-        cat "$dir/quiet.log"
+        cat "$quietlog"
         exit 1
     }
     sleep 0.1
@@ -148,12 +148,12 @@ done
 # sleep is short enough to be sound or long enough to be reliable.
 stop_server "$quietpid"
 quietpid=
-wait_drained "$dir/quiet.log"
+wait_drained "$quietlog"
 
 # The property is that serving adds nothing but the access log, so whitelist
 # what a line may be; naming strings that must be absent would pass any
 # reworded or differently shaped leak.
-extra=$(request_log "$dir/quiet.log" | grep -vE '^( \* log: (HTTP|ICP) .*)?$' || true)
+extra=$(request_log "$quietlog" | grep -vE '^( \* log: (HTTP|ICP) .*)?$' || true)
 test -z "$extra" || {
     echo "FAIL: serving a PROPFIND wrote this to proxytrack's console:"
     printf '%s\n' "$extra"
@@ -163,16 +163,16 @@ test -z "$extra" || {
 # HTS_LOG brings the summary back, so the silence above is a routed handler and
 # not a deleted message, and the grep that asserted it does match when fed one.
 launch_loud() {
-    HTS_LOG=1 "$python" -c "$pty_exec" "$dir/loud.log" \
+    HTS_LOG=1 "$python" -c "$pty_exec" "$ptlog" \
         proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc" &
     ptpid=$!
 }
-start_proxytrack "$dir/loud.log" launch_loud
-loudport=$proxyport loudpid=$ptpid ptpid=
+start_proxytrack "$dir/loud" launch_loud
+loudlog=$ptlog loudport=$proxyport loudpid=$ptpid ptpid=
 
 resp=$(propfind "$loudport" "") || {
     echo "FAIL: PROPFIND under HTS_LOG did not answer"
-    cat "$dir/loud.log"
+    cat "$loudlog"
     exit 1
 }
 grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
@@ -181,10 +181,10 @@ grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
     exit 1
 }
 waited=0
-until grep -qE 'hashtable .*summary:' "$dir/loud.log"; do
+until grep -qE 'hashtable .*summary:' "$loudlog"; do
     test "$waited" -lt 50 || {
         echo "FAIL: HTS_LOG=1 did not restore the hashtable summary"
-        cat "$dir/loud.log"
+        cat "$loudlog"
         exit 1
     }
     sleep 0.1
@@ -192,9 +192,9 @@ until grep -qE 'hashtable .*summary:' "$dir/loud.log"; do
 done
 # Pin the routed shape whole: a severity, then the message, and nothing in
 # between where the table address used to be.
-grep -qE '^ \* debug: hashtable "[^"]*" summary:' "$dir/loud.log" || {
+grep -qE '^ \* debug: hashtable "[^"]*" summary:' "$loudlog" || {
     echo "FAIL: the summary under HTS_LOG did not come through proxytrack's log"
-    cat "$dir/loud.log"
+    cat "$loudlog"
     exit 1
 }
 

--- a/tests/153_local-proxytrack-quiet.test
+++ b/tests/153_local-proxytrack-quiet.test
@@ -20,7 +20,9 @@ skip_on_windows "windows: python has no pty, so a buffered leak would be invisib
 dir=$(mktemp -d)
 quietpid=
 loudpid=
+ptpid= # start_proxytrack's, until the launch it started is named below
 cleanup() {
+    stop_server "$ptpid"
     stop_server "$quietpid"
     stop_server "$loudpid"
     rm -rf "$dir"
@@ -37,10 +39,6 @@ alen=$(($(wc -c <"$dir/hdr") + $(wc -c <"$dir/body")))
     printf 'http://example.com/page.html 0.0.0.0 20250101000000 text/html 200 - - 0 t.arc %d\n' "$alen"
     cat "$dir/hdr" "$dir/body"
 } >"$dir/in.arc"
-
-freeport() {
-    "$python" -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()'
-}
 
 # stdout to a file is fully buffered and SIGTERM never flushes it, so a leak on
 # stdout would be lost; a pty line-buffers it. The exec keeps $! on proxytrack.
@@ -68,28 +66,6 @@ if slave > 2:
 os.execvp(sys.argv[2], sys.argv[2:])
 '
 
-wait_listen() { # log pid
-    local waited=0
-    until grep -qE "HTTP Proxy installed on|Unable to (initialize a temporary server|create the server)" "$1"; do
-        kill -0 "$2" 2>/dev/null || {
-            echo "FAIL: proxytrack exited before listening"
-            cat "$1"
-            exit 1
-        }
-        test "$waited" -lt 50 || {
-            echo "FAIL: proxytrack never announced its listen port"
-            exit 1
-        }
-        sleep 0.1
-        waited=$((waited + 1))
-    done
-    grep -q "HTTP Proxy installed on" "$1" || {
-        echo "FAIL: proxytrack failed to bind"
-        cat "$1"
-        exit 1
-    }
-}
-
 propfind() { # port path
     curl -s -i --max-time 30 -X PROPFIND -H "Depth: 1" \
         "http://127.0.0.1:$1/webdav/example.com/$2"
@@ -115,17 +91,18 @@ wait_drained() { # log
     done
 }
 
-quietport=$(freeport)
-: >"$dir/quiet.log" # the drainer creates it asynchronously
 # Subshell, not env(1): uutils' env forks rather than execs, so stop_server would
 # kill the wrapper and leave proxytrack holding the pty open (#1042).
-(
-    unset HTS_LOG
-    exec "$python" -c "$pty_exec" "$dir/quiet.log" \
-        proxytrack "127.0.0.1:$quietport" "127.0.0.1:$(freeport)" "$dir/in.arc"
-) &
-quietpid=$!
-wait_listen "$dir/quiet.log" "$quietpid"
+launch_quiet() {
+    (
+        unset HTS_LOG
+        exec "$python" -c "$pty_exec" "$dir/quiet.log" \
+            proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc"
+    ) &
+    ptpid=$!
+}
+start_proxytrack "$dir/quiet.log" launch_quiet
+quietport=$proxyport quietpid=$ptpid ptpid=
 
 # Both on one connection: the access log is written before send(), and only
 # proxytrack's keep-alive loop orders anything written after it, since the
@@ -185,12 +162,13 @@ test -z "$extra" || {
 
 # HTS_LOG brings the summary back, so the silence above is a routed handler and
 # not a deleted message, and the grep that asserted it does match when fed one.
-loudport=$(freeport)
-: >"$dir/loud.log"
-HTS_LOG=1 "$python" -c "$pty_exec" "$dir/loud.log" \
-    proxytrack "127.0.0.1:$loudport" "127.0.0.1:$(freeport)" "$dir/in.arc" &
-loudpid=$!
-wait_listen "$dir/loud.log" "$loudpid"
+launch_loud() {
+    HTS_LOG=1 "$python" -c "$pty_exec" "$dir/loud.log" \
+        proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc" &
+    ptpid=$!
+}
+start_proxytrack "$dir/loud.log" launch_loud
+loudport=$proxyport loudpid=$ptpid ptpid=
 
 resp=$(propfind "$loudport" "") || {
     echo "FAIL: PROPFIND under HTS_LOG did not answer"

--- a/tests/160_zlib-cache-hdrbounds.test
+++ b/tests/160_zlib-cache-hdrbounds.test
@@ -5,9 +5,11 @@
 # fixed header buffer, and must not cost the entries written after it.
 
 set -eu
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 # stderr carries the expected "cached headers too large" warning alongside the
 # self-test's own diagnostics: keep it out of the verdict, but not the report.

--- a/tests/162_zlib-cache-urlbounds.test
+++ b/tests/162_zlib-cache-urlbounds.test
@@ -4,9 +4,11 @@
 # store and look up without aborting or aliasing a neighbouring key.
 
 set -eu
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 # stderr carries the expected "URL too long to be cached" warnings alongside the
 # self-test's own diagnostics: keep it out of the verdict, but not the report

--- a/tests/210_appstream-metainfo.test
+++ b/tests/210_appstream-metainfo.test
@@ -4,6 +4,8 @@
 # parse it just drops WebHTTrack, with no error anyone sees.
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 
@@ -41,7 +43,7 @@ work=$(mktemp -d "${TMPDIR:-/tmp}/appstream.XXXXXX") || {
     echo "no tmpdir" >&2
     exit 1
 }
-trap 'set +e; rm -rf "${work}"' EXIT
+cleanup_push rm -rf "${work}"
 
 for metainfo in "${metainfos[@]}"; do
     # Positive control: a validator that never fails would pass the check below.

--- a/tests/242_engine-warc-teardown.test
+++ b/tests/242_engine-warc-teardown.test
@@ -3,12 +3,13 @@
 # A late emit used to reopen the closed archive, orphaning a .tmp (#1060).
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
-httrack_bin=$(cd "$(dirname "$(command -v httrack)")" && pwd)/httrack
+httrack_bin=$(httrack_path)
 
 scratch=$(mktemp -d)
-trap 'set +e; rm -rf "$scratch"' EXIT
-trap 'rm -rf "$scratch"' HUP INT QUIT PIPE TERM
+cleanup_push rm -rf "$scratch"
 
 out=$("$httrack_bin" -O /dev/null -#test=warc-teardown "$scratch/")
 echo "$out"

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -1,8 +1,7 @@
 #!/bin/bash
 #
-# The assert_* vocabulary the engine self-test tier now rests on. An assertion
-# that fires exits, so each case is judged from another process: what matters is
-# that it fires exactly when it should and names the value it saw.
+# The assert_* helpers the engine self-test tier rests on, exercised from a
+# subject process, since a firing assertion would exit this script too.
 
 set -euo pipefail
 
@@ -16,7 +15,7 @@ ok() { echo "OK: $*"; }
 
 rc=0 out=
 run_subject() {
-    printf 'set -euo pipefail\n. %s/testlib.sh\n%s\n' "$testdir" "$1" >"$tmpdir/subject.sh"
+    printf 'set -euo pipefail\n. "%s/testlib.sh"\n%s\n' "$testdir" "$1" >"$tmpdir/subject.sh"
     rc=0
     out=$(bash "$tmpdir/subject.sh" 2>&1) || rc=$?
 }
@@ -26,8 +25,7 @@ holds() {
     test "$rc" -eq 0 || fail "[$1] should have held, exited $rc: $out"
 }
 
-# Fires, and its message carries $2 verbatim. A literal case, not assert_match:
-# the library cannot be its own oracle here.
+# Match $2 literally, not with assert_match, which is what this file tests.
 fires() {
     run_subject "$1"
     test "$rc" -eq 1 || fail "[$1] should have failed, exited $rc: $out"
@@ -41,50 +39,50 @@ fires() {
 holds 'assert_eq abc abc'
 holds 'assert_eq "a b" "a b"'
 fires 'assert_eq abc abd' 'expected [abc], got [abd]'
+# A got that merely starts with want must fire too, or a prefix compare passes.
+fires 'assert_eq abc abcd' 'expected [abc], got [abcd]'
+fires 'assert_eq abcd abc' 'expected [abcd], got [abc]'
 # Whitespace is part of the value, and the brackets are what makes it visible.
 fires 'assert_eq "a b" "a  b"' 'expected [a b], got [a  b]'
 fires 'assert_eq abc abd "reading the header"' 'reading the header: expected [abc]'
 ok "assert_eq fires on a difference and prints want beside got"
 
-## assert_match / assert_no_match are unanchored EREs
+## assert_match is an unanchored, case-sensitive ERE
 holds 'assert_match "^abc" abcde'
 holds 'assert_match "cd" abcde'
 fires 'assert_match "^bcd" abcde' 'no match for /^bcd/ in: abcde'
 # A metacharacter must act as one: both legs pass a substring matcher.
 holds 'assert_match "a.c" abc'
 fires 'assert_match "a.c" abbc' 'no match for /a.c/'
-holds 'assert_no_match "^bcd" abcde'
-fires 'assert_no_match "cd" abcde' 'unexpected match for /cd/ in: abcde'
-# The anchors are the whole text's ends, so "^name" over multi-line output misses.
-fires 'assert_match "^second" "first
-second"' 'no match for /^second/'
+# Case-folding would accept output the caller means to reject.
+fires 'assert_match "ABC" abc' 'no match for /ABC/'
 holds 'assert_match "^first" "first
 second"'
-ok "assert_match and assert_no_match agree on the same ERE"
+# The anchors are the whole text's ends, so "^second" over multi-line output misses.
+fires 'assert_match "^second" "first
+second"' 'no match for /^second/'
+# The label is the only context a caller gives; it must reach the message.
+fires 'assert_match "zz" abc "the registry listing"' 'the registry listing: no match for /zz/'
+ok "assert_match is an unanchored, case-sensitive ERE"
 
-## file assertions tell a file from a directory
+## assert_file wants a regular file, not merely something at that path
 mkdir "$tmpdir/adir"
 printf '12345' >"$tmpdir/afile"
 holds "assert_file $tmpdir/afile"
-holds "assert_dir $tmpdir/adir"
 fires "assert_file $tmpdir/adir" "missing file: $tmpdir/adir"
-fires "assert_dir $tmpdir/afile" "missing directory: $tmpdir/afile"
 fires "assert_file $tmpdir/nothing" "missing file: $tmpdir/nothing"
-ok "assert_file and assert_dir reject each other's argument"
-
-## assert_min_bytes, at the boundary
-holds "assert_min_bytes $tmpdir/afile 5"
-fires "assert_min_bytes $tmpdir/afile 6" 'expected at least 6 bytes, got 5'
-fires "assert_min_bytes $tmpdir/nothing 1" "missing file: $tmpdir/nothing"
-ok "assert_min_bytes accepts exactly the requested size and no less"
+fires "assert_file $tmpdir/adir 'the cache fixture'" "the cache fixture: missing file"
+ok "assert_file rejects a directory and a missing path alike"
 
 ## assert_selftest
 holds 'assert_selftest "identabs self-test OK" identabs'
 holds 'assert_selftest "www.xn--caf-dma.com" idna-encode "www.café.com"'
 fires 'assert_selftest nope identabs' 'expected [nope], got [identabs self-test OK]'
-fires 'assert_selftest "x" idna-encode "www.café.com"' '-#test=idna-encode www.café.com:'
-# An unknown self-test writes nothing and exits 1: the status is the only signal.
-fires 'assert_selftest "" no-such-selftest' 'exited 1'
+# The tail pins which branch fired: both carry the same "-#test=NAME args:" head.
+fires 'assert_selftest "x" idna-encode "www.café.com"' 'expected [x], got [www.xn--caf-dma.com]'
+# An unknown self-test writes nothing and exits 1, so the status is the only
+# signal; the exact status keeps a missing engine (127) from passing this leg.
+fires 'assert_selftest "" no-such-selftest' 'exited 1, output:'
 ok "assert_selftest pins the output and the exit status"
 
 ## httrack_path. The relative PATH entry is the whole case: make check prepends

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -1,0 +1,100 @@
+#!/bin/bash
+#
+# The assert_* vocabulary the engine self-test tier now rests on. An assertion
+# that fires exits, so each case is judged from another process: what matters is
+# that it fires exactly when it should and names the value it saw.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_asserts.XXXXXX")
+cleanup_push rm -rf "$tmpdir"
+
+ok() { echo "OK: $*"; }
+
+rc=0 out=
+run_subject() {
+    printf 'set -euo pipefail\n. %s/testlib.sh\n%s\n' "$testdir" "$1" >"$tmpdir/subject.sh"
+    rc=0
+    out=$(bash "$tmpdir/subject.sh" 2>&1) || rc=$?
+}
+
+holds() {
+    run_subject "$1"
+    test "$rc" -eq 0 || fail "[$1] should have held, exited $rc: $out"
+}
+
+# Fires, and its message carries $2 verbatim. A literal case, not assert_match:
+# the library cannot be its own oracle here.
+fires() {
+    run_subject "$1"
+    test "$rc" -eq 1 || fail "[$1] should have failed, exited $rc: $out"
+    case "$out" in
+    *"$2"*) ;;
+    *) fail "[$1] failed without reporting '$2': $out" ;;
+    esac
+}
+
+## assert_eq prints both sides
+holds 'assert_eq abc abc'
+holds 'assert_eq "a b" "a b"'
+fires 'assert_eq abc abd' 'expected [abc], got [abd]'
+# Whitespace is part of the value, and the brackets are what makes it visible.
+fires 'assert_eq "a b" "a  b"' 'expected [a b], got [a  b]'
+fires 'assert_eq abc abd "reading the header"' 'reading the header: expected [abc]'
+ok "assert_eq fires on a difference and prints want beside got"
+
+## assert_match / assert_no_match are unanchored EREs
+holds 'assert_match "^abc" abcde'
+holds 'assert_match "cd" abcde'
+fires 'assert_match "^bcd" abcde' 'no match for /^bcd/ in: abcde'
+# A metacharacter must act as one: both legs pass a substring matcher.
+holds 'assert_match "a.c" abc'
+fires 'assert_match "a.c" abbc' 'no match for /a.c/'
+holds 'assert_no_match "^bcd" abcde'
+fires 'assert_no_match "cd" abcde' 'unexpected match for /cd/ in: abcde'
+# The anchors are the whole text's ends, so "^name" over multi-line output misses.
+fires 'assert_match "^second" "first
+second"' 'no match for /^second/'
+holds 'assert_match "^first" "first
+second"'
+ok "assert_match and assert_no_match agree on the same ERE"
+
+## file assertions tell a file from a directory
+mkdir "$tmpdir/adir"
+printf '12345' >"$tmpdir/afile"
+holds "assert_file $tmpdir/afile"
+holds "assert_dir $tmpdir/adir"
+fires "assert_file $tmpdir/adir" "missing file: $tmpdir/adir"
+fires "assert_dir $tmpdir/afile" "missing directory: $tmpdir/afile"
+fires "assert_file $tmpdir/nothing" "missing file: $tmpdir/nothing"
+ok "assert_file and assert_dir reject each other's argument"
+
+## assert_min_bytes, at the boundary
+holds "assert_min_bytes $tmpdir/afile 5"
+fires "assert_min_bytes $tmpdir/afile 6" 'expected at least 6 bytes, got 5'
+fires "assert_min_bytes $tmpdir/nothing 1" "missing file: $tmpdir/nothing"
+ok "assert_min_bytes accepts exactly the requested size and no less"
+
+## assert_selftest
+holds 'assert_selftest "identabs self-test OK" identabs'
+holds 'assert_selftest "www.xn--caf-dma.com" idna-encode "www.café.com"'
+fires 'assert_selftest nope identabs' 'expected [nope], got [identabs self-test OK]'
+fires 'assert_selftest "x" idna-encode "www.café.com"' '-#test=idna-encode www.café.com:'
+# An unknown self-test writes nothing and exits 1: the status is the only signal.
+fires 'assert_selftest "" no-such-selftest' 'exited 1'
+ok "assert_selftest pins the output and the exit status"
+
+## httrack_path. The relative PATH entry is the whole case: make check prepends
+# ../src, so a helper echoing `command -v` back would pass everything but this.
+# shellcheck disable=SC2016 # a subject is shell source, expanded by the subject
+holds 'cd "$(dirname "$(command -v httrack)")"
+PATH=.:$PATH
+p=$(httrack_path)
+case "$p" in /*) ;; *) fail "not absolute: $p" ;; esac
+cd /
+"$p" --version >/dev/null'
+fires 'PATH= httrack_path' 'no httrack in PATH'
+ok "httrack_path returns an absolute path that still runs from elsewhere"

--- a/tests/40_local-why.test
+++ b/tests/40_local-why.test
@@ -2,11 +2,13 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # --why: report which +/- filter rule decides for a URL, without crawling.
 
 tmpdir="$(mktemp -d)"
-trap 'set +e; rm -rf "$tmpdir"' EXIT
+cleanup_push rm -rf "$tmpdir"
 
 why() {
     local want="$1" out

--- a/tests/53_local-proxytrack-arc-reason.test
+++ b/tests/53_local-proxytrack-arc-reason.test
@@ -3,9 +3,11 @@
 # round-trip; it used to be clipped to sizeof(char*) - 1 bytes.
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 printf 'HTTP/1.1 404 Not Found Here At All\r\nContent-Type: text/html\r\nLast-Modified: Wed, 01 Jan 2025 00:00:00 GMT\r\nContent-Length: 5\r\n\r\n' >"$dir/hdr"
 printf 'hello' >"$dir/body"

--- a/tests/53_local-proxytrack-cache-corrupt.test
+++ b/tests/53_local-proxytrack-cache-corrupt.test
@@ -3,9 +3,11 @@
 # sanitizer CI build turns any regression here into a hard stack/heap overflow.
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 # The first length-prefixed field declares far more than firstline[256] holds;
 # cache_brstr must clamp the copy to the destination, not the declared length.

--- a/tests/56_local-proxy-noleak.test
+++ b/tests/56_local-proxy-noleak.test
@@ -34,8 +34,7 @@ serverpid=$!
 port=$(discover_server_port "$tmpdir/srv.out" "$serverpid") || exit 1
 
 # a proxy port nothing listens on: grab a free one and let it close (refuses).
-deadproxy=$("$python" -c \
-    'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+deadproxy=$(freeport)
 
 # origin resolves to two addresses so a fallback would have a second to dial;
 # 127.0.0.1 (the decoy) is the one the old bypass reached.

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -7,9 +7,11 @@
 # for the engine (linput_cpp) but not for us. None do today.
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
-langdir="${top_srcdir:-..}/lang"
-def="${top_srcdir:-..}/lang.def"
+langdir="$top_srcdir/lang"
+def="$top_srcdir/lang.def"
 eng="$langdir/English.txt"
 for f in "$eng" "$def"; do
     [ -f "$f" ] || {
@@ -19,7 +21,7 @@ for f in "$eng" "$def"; do
 done
 
 tmp=$(mktemp -d)
-trap 'set +e; rm -rf "$tmp"' EXIT
+cleanup_push rm -rf "$tmp"
 keys="$tmp/english.keys"
 
 # Byte-wise: each file is in its own declared legacy charset, lang.def is CRLF.
@@ -201,7 +203,7 @@ fi
 
 # An unknown ${LANG_*} renders as nothing rather than erroring, so check that
 # every macro the templates interpolate, in any wrapper form, resolves.
-LC_ALL=C grep -oh '[$]{[^}]*LANG_[A-Za-z0-9_]*}' "${top_srcdir:-..}"/html/server/*.html |
+LC_ALL=C grep -oh '[$]{[^}]*LANG_[A-Za-z0-9_]*}' "$top_srcdir"/html/server/*.html |
     LC_ALL=C sed 's|.*\(LANG_[A-Za-z0-9_]*\)}|\1|' | LC_ALL=C sort -u >"$tmp/used"
 nused=$(wc -l <"$tmp/used")
 if [ "$nused" -lt 100 ]; then

--- a/tests/65_port-siblings.test
+++ b/tests/65_port-siblings.test
@@ -37,10 +37,10 @@ websrv() {
 web_refused() {
     websrv "$1"
     grep -q "couldn't set the port number" "$tmp/web.log" ||
-        ! echo "FAIL: #614: htsserver --port '$1' not refused" || exit 1
+        fail "#614: htsserver --port '$1' not refused"
     # it must not have reached the listen socket on some other port
     ! grep -q "^URL=" "$tmp/web.log" ||
-        ! echo "FAIL: #614: htsserver --port '$1' listened anyway" || exit 1
+        fail "#614: htsserver --port '$1' listened anyway"
 }
 
 web_accepted() {
@@ -64,9 +64,9 @@ web_accepted() {
     kill_tree "$pid"
     wait "$pid" 2>/dev/null || true
     ! grep -q "couldn't set the port number" "$tmp/web.log" ||
-        ! echo "FAIL: #614: htsserver --port '$port' wrongly refused" || exit 1
+        fail "#614: htsserver --port '$port' wrongly refused"
     grep -qE "^URL=http://.*:$port/|Unable to initialize a temporary server" "$tmp/web.log" ||
-        ! echo "FAIL: #614: htsserver --port '$port' never reached the listener" || exit 1
+        fail "#614: htsserver --port '$port' never reached the listener"
 }
 
 # this used to listen on 42099
@@ -89,11 +89,11 @@ web_exits() {
     : >"$tmp/exit.log"
     run_with_timeout 30 htsserver "$tmp" "$@" >"$tmp/exit.log" 2>&1 || rc=$?
     grep -q "^EXITED" "$tmp/exit.log" ||
-        ! echo "FAIL: #753: htsserver ${*:-(no options)} never finished serving" || exit 1
+        fail "#753: htsserver ${*:-(no options)} never finished serving"
     # exactly 1, not merely "not 124": a crash or an assertf abort also escapes
     # the wait, and would otherwise read as a pass
     test "$rc" -eq 1 ||
-        ! echo "FAIL: #753: htsserver ${*:-(no options)} exited $rc, want 1" || exit 1
+        fail "#753: htsserver ${*:-(no options)} exited $rc, want 1"
 }
 
 # no pinger: the excluded count went negative
@@ -108,13 +108,13 @@ web_exits --ppid $$
 proxy_refused() {
     run_with_timeout 3 proxytrack "127.0.0.1:$1" 127.0.0.1:3130 >"$tmp/pt.log" 2>&1 || true
     grep -q "^usage:" "$tmp/pt.log" ||
-        ! echo "FAIL: #614: proxytrack port '$1' not refused" || exit 1
+        fail "#614: proxytrack port '$1' not refused"
 }
 
 proxy_accepted() {
     run_with_timeout 3 proxytrack "127.0.0.1:$1" 127.0.0.1:3130 >"$tmp/pt.log" 2>&1 || true
     ! grep -q "^usage:" "$tmp/pt.log" ||
-        ! echo "FAIL: #614: proxytrack port '$1' wrongly refused" || exit 1
+        fail "#614: proxytrack port '$1' wrongly refused"
 }
 
 for p in "${malformed[@]}" 65616 4294967376 "$overflowing" 0 -1; do
@@ -139,11 +139,11 @@ ftp_port() {
 # 65616 truncated to 80 and really did connect there
 for p in 65616 99999; do
     test "$(ftp_port "$p")" -gt 0 ||
-        ! echo "FAIL: #614: ftp:// port $p not refused" || exit 1
+        fail "#614: ftp:// port $p not refused"
 done
 
 # a valid port still reaches the connect attempt
 test "$(ftp_port 65535)" -eq 0 ||
-    ! echo "FAIL: #614: ftp:// port 65535 wrongly refused" || exit 1
+    fail "#614: ftp:// port 65535 wrongly refused"
 
 exit 0

--- a/tests/67_engine-delayed-truncate.test
+++ b/tests/67_engine-delayed-truncate.test
@@ -2,6 +2,8 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # #623: url_savename shortens an over-ceiling path by cutting the tail of the
 # last segment, where the mandatory ".<id>.delayed" placeholder lives. A cut
@@ -12,9 +14,9 @@ set -euo pipefail
 # buffer elsewhere (#133). Each CLI arg is capped at HTS_CDLMAXSIZE (1024), so
 # on POSIX we lengthen the output dir as well to overrun the ceiling.
 
-httrack_bin=$(cd "$(dirname "$(command -v httrack)")" && pwd)/httrack
+httrack_bin=$(httrack_path)
 scratch=$(mktemp -d)
-trap 'set +e; rm -rf "$scratch"' EXIT
+cleanup_push rm -rf "$scratch"
 cd "$scratch"
 
 hexseg=$(printf 'a1b2c3d4e5f60718%.0s' {1..8}) # 128 hex chars

--- a/tests/75_engine-longpath-posix.test
+++ b/tests/75_engine-longpath-posix.test
@@ -2,14 +2,16 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # #133: the save-path ceiling used to be the Windows MAX_PATH (236 usable) on
 # every platform, needlessly hashing long names on Linux/macOS/Android. Off
 # Windows a name well under the platform PATH_MAX must now be kept whole.
 
-httrack_bin=$(cd "$(dirname "$(command -v httrack)")" && pwd)/httrack
+httrack_bin=$(httrack_path)
 scratch=$(mktemp -d)
-trap 'set +e; rm -rf "$scratch"' EXIT
+cleanup_push rm -rf "$scratch"
 cd "$scratch"
 
 # ~300 chars: over the old 236 ceiling, well under any POSIX PATH_MAX. The

--- a/tests/79_local-proxytrack-webdav-mime.test
+++ b/tests/79_local-proxytrack-webdav-mime.test
@@ -31,35 +31,11 @@ alen=$(($(wc -c <"$dir/hdr") + $(wc -c <"$dir/body")))
     cat "$dir/hdr" "$dir/body"
 } >"$dir/in.arc"
 
-# $() strips a trailing LF, not the CR Windows python's print can put before it.
-freeport() {
-    "$python" -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' |
-        tr -d '\r'
+launch_proxytrack() {
+    proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc" >"$dir/pt.log" 2>&1 &
+    ptpid=$!
 }
-proxyport=$(freeport)
-icpport=$(freeport)
-
-proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc" >"$dir/pt.log" 2>&1 &
-ptpid=$!
-waited=0
-until grep -qE "HTTP Proxy installed on|Unable to (initialize a temporary server|create the server)" "$dir/pt.log"; do
-    kill -0 "$ptpid" 2>/dev/null || {
-        echo "FAIL: proxytrack exited before listening"
-        cat "$dir/pt.log"
-        exit 1
-    }
-    test "$waited" -lt 50 || {
-        echo "FAIL: proxytrack never announced its listen port"
-        exit 1
-    }
-    sleep 0.1
-    waited=$((waited + 1))
-done
-grep -q "HTTP Proxy installed on" "$dir/pt.log" || {
-    echo "FAIL: proxytrack failed to bind"
-    cat "$dir/pt.log"
-    exit 1
-}
+start_proxytrack "$dir/pt.log" launch_proxytrack
 
 # --max-time: an unbounded read here would wedge the runner rather than fail
 curl -s --max-time 30 -X PROPFIND -H "Depth: 1" \

--- a/tests/79_local-proxytrack-webdav-mime.test
+++ b/tests/79_local-proxytrack-webdav-mime.test
@@ -32,10 +32,10 @@ alen=$(($(wc -c <"$dir/hdr") + $(wc -c <"$dir/body")))
 } >"$dir/in.arc"
 
 launch_proxytrack() {
-    proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc" >"$dir/pt.log" 2>&1 &
+    proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc" >"$ptlog" 2>&1 &
     ptpid=$!
 }
-start_proxytrack "$dir/pt.log" launch_proxytrack
+start_proxytrack "$dir/pt" launch_proxytrack
 
 # --max-time: an unbounded read here would wedge the runner rather than fail
 curl -s --max-time 30 -X PROPFIND -H "Depth: 1" \

--- a/tests/87_local-proxytrack-nodate.test
+++ b/tests/87_local-proxytrack-nodate.test
@@ -3,9 +3,11 @@
 # convert: the ARC writer used to dereference the parsed date unchecked.
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 dir=$(mktemp -d)
-trap 'set +e; rm -rf "$dir"' EXIT
+cleanup_push rm -rf "$dir"
 
 # $1 Last-Modified value (empty = omit the header), $2 expected archive date,
 # $3 label. The date is asserted exactly: a guard that fires unconditionally

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -32,31 +32,16 @@ assert_eq() { # assert_eq WANT GOT [LABEL]
     test "$1" = "$2" || fail "${3:+$3: }expected [$1], got [$2]"
 }
 
-# ERE, matched anywhere in TEXT: ^ and $ are TEXT's own ends, not a line's, so an
-# anchor over multi-line output never fires. The pattern must stay unquoted here,
-# or bash 3.2 takes it literally.
+# Unanchored ERE: ^ and $ are the whole subject's ends, not a line's.
+# Keep $1 unquoted here, or bash 3.2 matches it as a literal string.
 assert_match() { # assert_match RE TEXT [LABEL]
     [[ $2 =~ $1 ]] || fail "${3:+$3: }no match for /$1/ in: $2"
 }
 
-assert_no_match() { # assert_no_match RE TEXT [LABEL]
-    ! [[ $2 =~ $1 ]] || fail "${3:+$3: }unexpected match for /$1/ in: $2"
-}
-
 assert_file() { test -f "$1" || fail "${2:+$2: }missing file: $1"; }
-assert_dir() { test -d "$1" || fail "${2:+$2: }missing directory: $1"; }
 
-assert_min_bytes() { # assert_min_bytes PATH BYTES
-    local got
-    assert_file "$1"
-    got=$(wc -c <"$1")
-    # Arithmetic, since BSD wc pads its count with blanks.
-    test "$((got))" -ge "$2" || fail "$1: expected at least $2 bytes, got $((got))"
-}
-
-# Run engine self-test NAME and require its stdout to be exactly WANT. -O /dev/null
-# is fixed: a self-test writes no mirror, but the engine refuses to start without an
-# output path. A non-zero exit fails too, which a `test "$(...)" = ...` cannot see.
+# Run engine self-test NAME: stdout must equal WANT, status must be 0 (which a
+# `test "$(...)" = ...` cannot see). expect_ok takes a command, for a real -O.
 assert_selftest() { # assert_selftest WANT NAME [ARGS...]
     local want=$1 name=$2 got rc=0
     shift 2
@@ -65,13 +50,14 @@ assert_selftest() { # assert_selftest WANT NAME [ARGS...]
     test "$got" = "$want" || fail "-#test=$name $*: expected [$want], got [$got]"
 }
 
-# Absolute path to the httrack under test, for a test that cd's away: make check
-# prepends a RELATIVE ../src, which from anywhere else resolves to an installed
-# copy, or to nothing.
+# Absolute path to httrack, since make check's relative ../src breaks once a test
+# cd's away. assert_selftest runs the bare name, so a test that cd's calls this.
 httrack_path() {
-    local p
+    local p dir
     p=$(command -v httrack) || fail "no httrack in PATH"
-    printf '%s\n' "$(cd "$(dirname "$p")" && pwd)/$(basename "$p")"
+    # Assigned, so a failed cd is named here instead of yielding a bare /httrack.
+    dir=$(cd "$(dirname "$p")" && pwd) || fail "cannot reach $(dirname "$p")"
+    printf '%s\n' "$dir/$(basename "$p")"
 }
 
 # A literal, not $'..': Apple's bash 3.2 loses quote state on that inside a

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -26,6 +26,54 @@ skip() {
 # is merely not on Windows.
 skip_on_windows() { ! is_windows || skip "$*"; }
 
+# Assertions, each printing what it wanted beside what arrived: a bare
+# `|| exit 1` reds a test without naming the value that differed.
+assert_eq() { # assert_eq WANT GOT [LABEL]
+    test "$1" = "$2" || fail "${3:+$3: }expected [$1], got [$2]"
+}
+
+# ERE, matched anywhere in TEXT: ^ and $ are TEXT's own ends, not a line's, so an
+# anchor over multi-line output never fires. The pattern must stay unquoted here,
+# or bash 3.2 takes it literally.
+assert_match() { # assert_match RE TEXT [LABEL]
+    [[ $2 =~ $1 ]] || fail "${3:+$3: }no match for /$1/ in: $2"
+}
+
+assert_no_match() { # assert_no_match RE TEXT [LABEL]
+    ! [[ $2 =~ $1 ]] || fail "${3:+$3: }unexpected match for /$1/ in: $2"
+}
+
+assert_file() { test -f "$1" || fail "${2:+$2: }missing file: $1"; }
+assert_dir() { test -d "$1" || fail "${2:+$2: }missing directory: $1"; }
+
+assert_min_bytes() { # assert_min_bytes PATH BYTES
+    local got
+    assert_file "$1"
+    got=$(wc -c <"$1")
+    # Arithmetic, since BSD wc pads its count with blanks.
+    test "$((got))" -ge "$2" || fail "$1: expected at least $2 bytes, got $((got))"
+}
+
+# Run engine self-test NAME and require its stdout to be exactly WANT. -O /dev/null
+# is fixed: a self-test writes no mirror, but the engine refuses to start without an
+# output path. A non-zero exit fails too, which a `test "$(...)" = ...` cannot see.
+assert_selftest() { # assert_selftest WANT NAME [ARGS...]
+    local want=$1 name=$2 got rc=0
+    shift 2
+    got=$(httrack -O /dev/null "-#test=$name" "$@") || rc=$?
+    test "$rc" -eq 0 || fail "-#test=$name $*: exited $rc, output: $got"
+    test "$got" = "$want" || fail "-#test=$name $*: expected [$want], got [$got]"
+}
+
+# Absolute path to the httrack under test, for a test that cd's away: make check
+# prepends a RELATIVE ../src, which from anywhere else resolves to an installed
+# copy, or to nothing.
+httrack_path() {
+    local p
+    p=$(command -v httrack) || fail "no httrack in PATH"
+    printf '%s\n' "$(cd "$(dirname "$p")" && pwd)/$(basename "$p")"
+}
+
 # A literal, not $'..': Apple's bash 3.2 loses quote state on that inside a
 # parameter expansion and the whole file dies of "unexpected EOF".
 TESTLIB_NL='

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -254,6 +254,47 @@ stop_server() {
     return 0
 }
 
+# Ephemeral port from the caller's $python, released before it is returned: the
+# process that binds it can lose the race, so pair it with start_proxytrack.
+freeport() {
+    # tr: Windows python's print leaves a CR that $() does not strip.
+    "${python:?freeport needs the caller python}" -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' |
+        tr -d '\r'
+}
+
+# 0 once $1 (its log) carries the listen banner, 1 if the bind lost its port.
+proxytrack_bound() { # proxytrack_bound LOG PID
+    local log=$1 pid=$2 waited=0
+    until grep -qE "HTTP Proxy installed on|Unable to (initialize a temporary server|create the server)" "$log"; do
+        # An exit flushes the log, so re-read it rather than calling this dead.
+        kill -0 "$pid" 2>/dev/null || break
+        test "$waited" -lt 50 || fail "proxytrack never announced its listen port: $(cat "$log")"
+        sleep 0.1
+        waited=$((waited + 1))
+    done
+    grep -q "HTTP Proxy installed on" "$log"
+}
+
+# proxytrack binds the ports itself, well after freeport dropped them, so a
+# parallel suite can steal one in between: re-pick and relaunch. LAUNCH is a
+# function reading $proxyport/$icpport and leaving the pid in $ptpid.
+start_proxytrack() { # start_proxytrack LOG LAUNCH
+    local log=$1 launch=$2 try
+    for try in 1 2 3; do
+        proxyport=$(freeport)
+        icpport=$(freeport)
+        # New inode, so a killed attempt's pty drainer cannot land its banner
+        # (or its .done marker) in the run below and answer for it.
+        rm -f "$log" "$log.done"
+        : >"$log"
+        "$launch"
+        proxytrack_bound "$log" "$ptpid" && return 0
+        stop_server "$ptpid"
+        ptpid=
+    done
+    fail "proxytrack bound none of 3 port pairs: $(cat "$log")"
+}
+
 # Echo the port local-server.py announces on $1 (its log), $2 being its pid, or
 # return 2 if the server died and 1 on the deadline: only the deadline is a race a
 # caller may skip on. Matches anywhere, since a warning merged via 2>&1 can precede

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -254,45 +254,59 @@ stop_server() {
     return 0
 }
 
-# Ephemeral port from the caller's $python, released before it is returned: the
-# process that binds it can lose the race, so pair it with start_proxytrack.
+# $1 free loopback ports (default 1), space separated, bound together so two of
+# them always differ. Each is closed before its caller binds it: see start_proxytrack.
 freeport() {
     # tr: Windows python's print leaves a CR that $() does not strip.
-    "${python:?freeport needs the caller python}" -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' |
-        tr -d '\r'
+    "${python:?freeport needs the caller python}" -c 'import socket, sys
+socks = [socket.socket() for _ in range(int(sys.argv[1]))]
+for s in socks:
+    s.bind(("127.0.0.1", 0))
+print(" ".join(str(s.getsockname()[1]) for s in socks))
+for s in socks:
+    s.close()' "${1:-1}" | tr -d '\r'
 }
 
-# 0 once $1 (its log) carries the listen banner, 1 if the bind lost its port.
+PT_LISTENING="HTTP Proxy installed on"
+PT_BIND_LOST="Unable to (initialize a temporary server|create the server)"
+
+# Returns 0 once $1 (its log) carries the listen banner, 1 if the bind lost its
+# port; a proxytrack that announces neither ends the test here.
 proxytrack_bound() { # proxytrack_bound LOG PID
     local log=$1 pid=$2 waited=0
-    until grep -qE "HTTP Proxy installed on|Unable to (initialize a temporary server|create the server)" "$log"; do
+    until grep -qE "$PT_LISTENING|$PT_BIND_LOST" "$log"; do
         # An exit flushes the log, so re-read it rather than calling this dead.
         kill -0 "$pid" 2>/dev/null || break
         test "$waited" -lt 50 || fail "proxytrack never announced its listen port: $(cat "$log")"
         sleep 0.1
         waited=$((waited + 1))
     done
-    grep -q "HTTP Proxy installed on" "$log"
+    grep -q "$PT_LISTENING" "$log" && return 0
+    grep -qE "$PT_BIND_LOST" "$log" || fail "proxytrack exited before listening: $(cat "$log")"
+    return 1
 }
 
-# proxytrack binds the ports itself, well after freeport dropped them, so a
-# parallel suite can steal one in between: re-pick and relaunch. LAUNCH is a
-# function reading $proxyport/$icpport and leaving the pid in $ptpid.
-start_proxytrack() { # start_proxytrack LOG LAUNCH
-    local log=$1 launch=$2 try
+# proxytrack binds the ports itself and can find one stolen in between, so retry
+# rather than red the suite. LAUNCH reads $proxyport/$icpport, writes $ptlog and
+# leaves the pid in $ptpid; on return $ptlog is the surviving attempt's log.
+start_proxytrack() { # start_proxytrack LOGBASE LAUNCH
+    local base=$1 launch=$2 try
     for try in 1 2 3; do
-        proxyport=$(freeport)
-        icpport=$(freeport)
-        # New inode, so a killed attempt's pty drainer cannot land its banner
-        # (or its .done marker) in the run below and answer for it.
-        rm -f "$log" "$log.done"
-        : >"$log"
+        read -r proxyport icpport <<<"$(freeport 2)"
+        # One log per attempt: a killed one's pty drainer creates its .done
+        # marker by path, and would answer for the attempt below.
+        ptlog="$base.$try"
+        : >"$ptlog"
+        ptpid=
         "$launch"
-        proxytrack_bound "$log" "$ptpid" && return 0
+        test -n "$ptpid" || fail "$launch left no proxytrack pid in \$ptpid"
+        proxytrack_bound "$ptlog" "$ptpid" && return 0
         stop_server "$ptpid"
         ptpid=
+        # Loud, so an intermittent bind regression cannot hide behind the retry.
+        echo "proxytrack did not get port $proxyport, retrying" >&2
     done
-    fail "proxytrack bound none of 3 port pairs: $(cat "$log")"
+    fail "proxytrack bound none of 3 port pairs: $(cat "$ptlog")"
 }
 
 # Echo the port local-server.py announces on $1 (its log), $2 being its pid, or

--- a/tests/webhttracklib.sh
+++ b/tests/webhttracklib.sh
@@ -20,17 +20,10 @@ htsserver_require() {
     HTS_PYTHON=$(find_python) || skip "python3 not found"
 }
 
-# $1 free loopback ports (default 1), space separated. Bound together, so two
-# of them always differ; each is closed before htsserver rebinds it.
 # shellcheck disable=SC2120 # one port is the common case
 htsserver_freeport() {
-    "${HTS_PYTHON}" -c 'import socket, sys
-socks = [socket.socket() for _ in range(int(sys.argv[1]))]
-for s in socks:
-    s.bind(("127.0.0.1", 0))
-print(" ".join(str(s.getsockname()[1]) for s in socks))
-for s in socks:
-    s.close()' "${1:-1}"
+    local python=${HTS_PYTHON}
+    freeport "$@"
 }
 
 # First URL= and PID= of the announcement, or empty. Windows announces no pid.


### PR DESCRIPTION
The `01_engine-*` and `01_zlib-*` tests sourced nothing at all: each carried its own teardown trap, its own spelling of `httrack -O /dev/null -#test=NAME`, and comparisons ending in a bare `|| exit 1`, so a red test named a line number and never the value that differed. The assertion vocabulary #1113 deferred lands here, where the tier gives it callers.

`assert_selftest WANT NAME [ARGS...]` also checks the exit status, which `test "$(...)" = ...` threw away: an unknown or crashing self-test passed whenever its empty output happened to match. `httrack_path` replaces ten copies of the cd/dirname/pwd incantation, and 50 hand-written `trap ... EXIT` pairs become `cleanup_push`, most of them having had no signal half at all. Converting them turned up two live traps: `01_engine-mime.test` piped into `head -1`, the SIGPIPE-under-pipefail shape AGENTS.md warns about, and `01_engine-selftest-dispatch.test` checked the registry listing with a bare `grep -q filter`, which the `filtersize` row satisfies on its own.

A separate flake showed up while this sat in CI, on the Windows x64 leg. `freeport` picks a port by binding it and closing it again, so proxytrack's own bind a moment later can find it taken, which is how 79 went red. Picking and launching now live in `testlib.sh`, which retries three times, says so on stderr so a real bind regression cannot hide behind it, and gives each attempt its own log. That last part is not cosmetic: the pty drainer 153 relies on writes its completion marker by path, so a discarded attempt could otherwise answer for the surviving one and let the console-leak check read a half-copied log. Probed both ways, steal one port and all four tests still pass, steal every port and it gives up with the log instead of hanging.

Verified as #1113 was: identical per-test verdicts and log content before and after on the same tree, plus a 31-mutant matrix (each `assert_*` blinded in turn, one expected value flipped per converted file) with no survivors.
