### PR TITLE
The tests driving the local server each rebuild its launch, and most crawl with no time cap

### DIFF
--- a/tests/112_local-single-file-fragment.test
+++ b/tests/112_local-single-file-fragment.test
@@ -3,16 +3,13 @@
 # fragment an SVG sprite selector needs to pick one icon out of the sheet.
 set -e
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-server=$(nativepath "${testdir}/local-server.py")
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_766.XXXXXX") || exit 1
-serverpid=
 cleanup() {
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
@@ -39,12 +36,7 @@ printf '<svg xmlns="http://www.w3.org/2000/svg"><g id="icon-foo"/></svg>\n' \
 } >"${doc}/big.svg"
 
 # --- server -----------------------------------------------------------------
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
-"$python" "$server" --root "$(nativepath "$doc")" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-base="http://127.0.0.1:${port}"
+local_server_start --root "$doc"
 
 which httrack >/dev/null || fail "could not find httrack"
 
@@ -53,11 +45,9 @@ which httrack >/dev/null || fail "could not find httrack"
 # for the rebase path.
 out="${tmpdir}/crawl"
 mkdir "$out"
-httrack -O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 \
-    --retries=0 --single-file --single-file-max-size 4096 \
-    "${base}/index.html" >"${tmpdir}/log" 2>&1
+local_crawl --log "${tmpdir}/log" -O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 --retries=0 --single-file --single-file-max-size 4096 "${BASEURL}/index.html"
 
-root="${out}/127.0.0.1_${port}"
+root="${out}/127.0.0.1_$SRV_PORT"
 page="${root}/index.html"
 test -f "$page" || fail "no mirrored page at $page"
 test -f "${root}/big.svg" || fail "the over-cap asset never reached the mirror"

--- a/tests/114_local-update-304-leak.test
+++ b/tests/114_local-update-304-leak.test
@@ -7,12 +7,8 @@
 
 set -eu
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-server=$(nativepath "${testdir}/local-server.py")
-root=$(nativepath "${testdir}/server-root")
-
-python=$(find_python) || skip "python3 not found"
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 
 probe=$(ASAN_OPTIONS=help=1 httrack -O /dev/null --version 2>&1 || true)
 case "$probe" in
@@ -24,22 +20,16 @@ case "$probe" in
 esac
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_304leak.XXXXXX") || exit 1
-serverpid=
 cleanup() {
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
-"$python" "$server" --root "$root" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+local_server_start
 
 out="${tmpdir}/crawl"
 mkdir "$out"
-url="http://127.0.0.1:${port}/mini304/index.html"
+url="http://127.0.0.1:${SRV_PORT}/mini304/index.html"
 
 # Last value wins in the sanitizer flag parser, so this overrides the job's
 # settings; the report file, not the exit status, is the verdict.
@@ -52,8 +42,7 @@ run_pass() {
     rm -f "${tmpdir}/asan".*
     printf '[%s] ..\t' "$label"
     ASAN_OPTIONS="${asan_base}:log_path=${tmpdir}/asan" \
-        httrack -O "$out" --quiet --disable-security-limits --robots=0 \
-        --timeout=30 --retries=1 -c1 "$@" "$url" >"${tmpdir}/log_${label}" 2>&1 || true
+        local_crawl --log "${tmpdir}/log_${label}" -O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 --retries=1 -c1 "$@" "$url" || true
     report=$(cat "${tmpdir}/asan".* 2>/dev/null || true)
     test -z "$report" || {
         echo "FAIL: sanitizer report on the ${label} pass"

--- a/tests/137_local-charsetless-encoding.test
+++ b/tests/137_local-charsetless-encoding.test
@@ -4,28 +4,19 @@
 # the engine lifts out of it that already is UTF-8 must be left alone.
 
 set -e
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-server=$(nativepath "${testdir}/local-server.py")
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_833.XXXXXX") || exit 1
-serverpid=
 cleanup() {
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
 mkdir "${tmpdir}/docroot"
-"$python" "$server" --root "$(nativepath "${tmpdir}/docroot")" \
-    >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-base="http://127.0.0.1:${port}"
+local_server_start --root "${tmpdir}/docroot"
 
 which httrack >/dev/null || {
     echo "could not find httrack"
@@ -35,13 +26,11 @@ which httrack >/dev/null || {
 # One crawl per variant: the generated top index carries the seed page's title.
 for variant in u8 l1 declared gb2312 l1decl; do
     mkdir "${tmpdir}/${variant}"
-    httrack -O "${tmpdir}/${variant}" --quiet --disable-security-limits \
-        --robots=0 --timeout=30 --retries=0 \
-        "${base}/titleenc/${variant}.html" >"${tmpdir}/log-${variant}" 2>&1
+    local_crawl --log "${tmpdir}/log-${variant}" -O "${tmpdir}/${variant}" --quiet --disable-security-limits --robots=0 --timeout=30 --retries=0 "${BASEURL}/titleenc/${variant}.html"
 done
 
 # Byte-level assertions in python: portable, and the shell cannot mangle them.
-"$python" - "$tmpdir" "$port" <<'PY'
+"$python" - "$tmpdir" "$SRV_PORT" <<'PY'
 import os
 import sys
 

--- a/tests/138_local-spool-name-overflow.test
+++ b/tests/138_local-spool-name-overflow.test
@@ -6,26 +6,16 @@
 # so a build with neither fortify nor ASan still tests something.
 
 set -e
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-server=$(nativepath "${testdir}/local-server.py")
-
-python=$(find_python) || skip "python3 not found"
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_spool.XXXXXX") || exit 1
-serverpid=
 cleanup() {
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
-"$python" "$server" --root "$(nativepath "${testdir}/server-root")" \
-    >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+local_server_start
 
 which httrack >/dev/null || {
     echo "could not find httrack"
@@ -33,10 +23,7 @@ which httrack >/dev/null || {
 }
 
 rc=0
-httrack -O "${tmpdir}/out" --quiet --disable-security-limits --robots=0 \
-    --timeout=30 --retries=0 -Z -p0 -N '%n' -c4 \
-    "http://127.0.0.1:${port}/bakname/index.html" \
-    >"${tmpdir}/log" 2>&1 || rc=$?
+local_crawl --log "${tmpdir}/log" -O "${tmpdir}/out" --quiet --disable-security-limits --robots=0 --timeout=30 --retries=0 -Z -p0 -N '%n' -c4 "http://127.0.0.1:${SRV_PORT}/bakname/index.html" || rc=$?
 test "$rc" -eq 0 || {
     echo "httrack exited $rc"
     cat "${tmpdir}/log"

--- a/tests/139_local-query-charref.test
+++ b/tests/139_local-query-charref.test
@@ -5,32 +5,24 @@
 # charset does represent must still go out as its encoded bytes.
 set -eu
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-server=$(nativepath "${testdir}/local-server.py")
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 root=$(nativepath "${testdir}/server-root")
 
-python=$(find_python) || skip "python3 not found"
 httrack=$(command -v httrack) || ! echo "could not find httrack" >&2 || exit 1
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_854.XXXXXX") || exit 1
-serverpid=
 cleanup() {
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
 reqlog="${tmpdir}/requests.txt"
 : >"$reqlog"
-CHARREF_LOG="$reqlog" "$python" "$server" --root "$root" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+local_server_start --env CHARREF_LOG="$reqlog" --root "$root"
 
 "$httrack" -O "${tmpdir}/crawl" --quiet --disable-security-limits --robots=0 \
-    --timeout=30 --retries=0 "http://127.0.0.1:${port}/charref/index.html" \
+    --timeout=30 --retries=0 "http://127.0.0.1:${SRV_PORT}/charref/index.html" \
     >"${tmpdir}/crawl.log" 2>&1 || true
 
 query_of() {

--- a/tests/158_local-link-control-bytes.test
+++ b/tests/158_local-link-control-bytes.test
@@ -6,8 +6,8 @@
 # mirror holding either one names which rewrite came back.
 set -eu
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 
 # The fixtures carry the raw bytes the requests decode back to, which NTFS
 # refuses.
@@ -15,9 +15,7 @@ set -eu
     exit 77
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_982.XXXXXX") || exit 1
-serverpid=
 cleanup() {
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
@@ -78,21 +76,15 @@ bash "$top_srcdir/tests/local-crawl.sh" --root "$(nativepath "$doc")" \
 # fit too. Absolute, because a clipped relative link dies on the URL-length gate
 # anyway while a clipped absolute one lands just under it and gets fetched. The
 # port is only known once the server is up, hence a second crawl of our own.
-python=$(find_python) || skip "python3 not found"
 qdoc="${tmpdir}/qdoc"
 mkdir -p "$qdoc"
 printf 'placeholder\n' >"${qdoc}/index.html"
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
-LOCAL_SERVER_VERBOSE=1 "$python" "$(nativepath "${testdir}/local-server.py")" \
-    --root "$(nativepath "$qdoc")" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+local_server_start --env LOCAL_SERVER_VERBOSE=1 --root "$qdoc"
 
 # 300 control bytes of path escape to ~900, under the URL-length gate; 380 more
 # of query escape to ~1140, which together overrun the 2 KB link buffer.
 {
-    printf '<html><body><a href="http://127.0.0.1:%s/a' "$port"
+    printf '<html><body><a href="http://127.0.0.1:%s/a' "$SRV_PORT"
     awk 'BEGIN { while (i++ < 300) printf "%c", 11 }'
     printf 'b.html?q='
     awk 'BEGIN { while (i++ < 380) printf "%c", 11 }'
@@ -100,12 +92,12 @@ port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 } >"${qdoc}/index.html"
 
 out="${tmpdir}/qout"
-httrack "http://127.0.0.1:${port}/index.html" -O "$out" -q -r3 -%v0 ||
+httrack "http://127.0.0.1:${SRV_PORT}/index.html" -O "$out" -q -r3 -%v0 ||
     fail "the query crawl did not run"
 # A clipped link went out as a 2 KB request and 404ed, so assert the outcome
 # and not just the refusal: nothing oversized asked for, nothing errored.
 errors=$(grep -acE '^[0-9:]*[[:space:]]Error:' "${out}/hts-log.txt" || true)
 test "$errors" -eq 0 || fail "the oversized query was fetched ($errors errors)"
 longest=$(awk '{ if (length($0) > n) n = length($0) } END { print n + 0 }' \
-    "$serverlog")
+    "$SRV_LOG")
 test "$longest" -lt 1024 || fail "a ${longest}-byte request line went out"

--- a/tests/19_local-connect-fallback.test
+++ b/tests/19_local-connect-fallback.test
@@ -10,14 +10,13 @@
 
 set -euo pipefail
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 
 if test "${V6_SUPPORT:-}" == "no"; then
     echo "no IPv6 support (resolver list/override is IPv6-only), skipping"
     exit 77
 fi
-python=$(find_python) || skip "python3 missing"
 # The fixture needs a second loopback IP (dead 127.0.0.2 + live 127.0.0.1) for
 # the fallback to have a target; GNU/Hurd has only 127.0.0.1, so skip there.
 case "$(uname -s)" in
@@ -27,29 +26,22 @@ GNU | GNU/*)
     ;;
 esac
 
-server=$(nativepath "$top_srcdir/tests/local-server.py")
-root=$(nativepath "$top_srcdir/tests/server-root")
 tmpdir=$(mktemp -d)
-serverpid=
 
 cleanup() {
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
 # bind the live server to 127.0.0.1 only, so 127.0.0.2 refuses the connect
-"$python" "$server" --root "$root" --bind 127.0.0.1 >"$tmpdir/srv.out" 2>"$tmpdir/srv.err" &
-serverpid=$!
-port=$(discover_server_port "$tmpdir/srv.out" "$serverpid") || exit 1
+local_server_start --log "$tmpdir/srv.out" --bind 127.0.0.1
 
 out="$tmpdir/crawl"
 # macOS has only 127.0.0.1, so the dead 127.0.0.x connects block to the timeout
 # instead of refusing instantly (as on Linux); a small --timeout + --retries=0
 # bound the stall without changing what the fallback exercises.
 HTTRACK_DEBUG_RESOLVE="deadhost:127.0.0.2,127.0.0.1" \
-    httrack "http://deadhost:$port/simple/basic.html" -O "$out" \
-    -c1 --robots=0 --timeout=5 --retries=0 --quiet -Z >"$tmpdir/log" 2>&1
+    local_crawl --log "$tmpdir/log" "http://deadhost:${SRV_PORT}/simple/basic.html" -O "$out" -c1 --robots=0 --timeout=5 --retries=0 --quiet -Z
 
 log="$out/hts-log.txt"
 
@@ -67,7 +59,7 @@ test "$errs" == "0" || {
     grep -iE "Error:" "$log"
     exit 1
 }
-test -f "$out/deadhost_$port/simple/basic.html" || {
+test -f "$out/deadhost_${SRV_PORT}/simple/basic.html" || {
     echo "FAIL: basic.html not downloaded via fallback"
     find "$out" -type f
     exit 1
@@ -77,8 +69,7 @@ test -f "$out/deadhost_$port/simple/basic.html" || {
 # timeout would catch a hang/loop)
 out2="$tmpdir/crawl2"
 HTTRACK_DEBUG_RESOLVE="alldead:127.0.0.2,127.0.0.3" \
-    httrack "http://alldead:$port/simple/basic.html" -O "$out2" \
-    -c1 --robots=0 --timeout=5 --retries=0 --quiet -Z >"$tmpdir/log2" 2>&1
+    local_crawl --log "$tmpdir/log2" "http://alldead:${SRV_PORT}/simple/basic.html" -O "$out2" -c1 --robots=0 --timeout=5 --retries=0 --quiet -Z
 log2="$out2/hts-log.txt"
 
 grep -q "trying next address" "$log2" || {
@@ -91,7 +82,7 @@ grep -iqE "^[0-9:]*[[:space:]]Error:" "$log2" || {
     cat "$log2"
     exit 1
 }
-test ! -f "$out2/alldead_$port/simple/basic.html" || {
+test ! -f "$out2/alldead_${SRV_PORT}/simple/basic.html" || {
     echo "FAIL: file downloaded despite every address failing"
     exit 1
 }

--- a/tests/20_local-resume-loop.test
+++ b/tests/20_local-resume-loop.test
@@ -3,32 +3,22 @@
 # 416. Pass 1 leaves a partial + temp-ref; pass 2 must terminate and not loop.
 set -u
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-server=$(nativepath "${testdir}/local-server.py")
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 root=$(nativepath "${testdir}/server-root")
 
-python=$(find_python) || skip "python3 not found"
-
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_206.XXXXXX") || exit 1
-serverpid=
 crawlpid=
 cleanup() {
     test -n "$crawlpid" && kill -9 "$crawlpid" 2>/dev/null
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
 # --- start the server, discover its ephemeral port --------------------------
 # RESUME_COUNTER gets a byte per /resume/blob.txt request (pass-2 delta bounds re-gets).
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
 counter="${tmpdir}/blobcount"
-RESUME_COUNTER="$counter" "$python" "$server" --root "$root" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-base="http://127.0.0.1:${port}"
+local_server_start --env RESUME_COUNTER="$counter" --root "$root"
 
 which httrack >/dev/null || {
     echo "could not find httrack"
@@ -41,7 +31,7 @@ refdir="${out}/hts-cache/ref"
 
 # --- pass 1: crawl, interrupt once the blob download is underway -------------
 printf '[pass 1: interrupt mid-download] ..\t'
-httrack "${common[@]}" "${base}/resume/index.html" >"${tmpdir}/log1" 2>&1 &
+httrack "${common[@]}" "${BASEURL}/resume/index.html" >"${tmpdir}/log1" 2>&1 &
 crawlpid=$!
 # Wait until blob.txt is requested, then SIGTERM so httrack's exit handler
 # finalizes the cache and serializes the temp-ref.
@@ -65,7 +55,7 @@ before=$(wc -c <"$counter" 2>/dev/null || echo 0)
 # Kill pass 2 after a deadline (portable stand-in for `timeout`, absent on macOS).
 printf '[pass 2: resume must terminate] ..\t'
 HANG_RC=137 # 128 + SIGKILL
-httrack "${common[@]}" --continue "${base}/resume/index.html" >"${tmpdir}/log2" 2>&1 &
+httrack "${common[@]}" --continue "${BASEURL}/resume/index.html" >"${tmpdir}/log2" 2>&1 &
 crawlpid=$!
 (sleep 30 && kill -9 "$crawlpid" 2>/dev/null) &
 guard=$!

--- a/tests/20_local-resume-loop.test
+++ b/tests/20_local-resume-loop.test
@@ -15,7 +15,6 @@ cleanup() {
 }
 cleanup_push cleanup
 
-# --- start the server, discover its ephemeral port --------------------------
 # RESUME_COUNTER gets a byte per /resume/blob.txt request (pass-2 delta bounds re-gets).
 counter="${tmpdir}/blobcount"
 local_server_start --env RESUME_COUNTER="$counter" --root "$root"

--- a/tests/235_local-resume-recovery.test
+++ b/tests/235_local-resume-recovery.test
@@ -23,8 +23,6 @@ cleanup() {
 }
 cleanup_push cleanup
 
-# stdin off the terminal: run_with_timeout toggles job control, and a background
-# job that touches the tty is stopped with SIGTTIN.
 local_server_start
 
 which httrack >/dev/null || {
@@ -92,7 +90,9 @@ test "$(blob_size "$out")" -eq "$have" || {
     exit 1
 }
 rc=0
-local_crawl --log "${out}.log2" -O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 -c1 --retries=0 --continue "${BASEURL}/resume206/index.html" || rc=$?
+run_with_timeout 120 httrack -O "$out" --quiet --disable-security-limits \
+    --robots=0 --timeout=30 -c1 --retries=0 --continue \
+    "${BASEURL}/resume206/index.html" >"${out}.log2" 2>&1 || rc=$?
 test "$rc" -ne 124 || {
     echo "FAIL: the crawl never terminated"
     exit 1
@@ -123,7 +123,9 @@ out="${tmpdir}/loop"
 mkdir "$out"
 interrupt_pass1 "$out" resume206loop --retries=0
 rc=0
-local_crawl --log "${out}.log2" -O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 -c1 --retries=0 --continue "${BASEURL}/resume206loop/index.html" || rc=$?
+run_with_timeout 120 httrack -O "$out" --quiet --disable-security-limits \
+    --robots=0 --timeout=30 -c1 --retries=0 --continue \
+    "${BASEURL}/resume206loop/index.html" >"${out}.log2" 2>&1 || rc=$?
 test "$rc" -ne 124 || {
     echo "FAIL: the crawl never terminated; the restart is unbounded"
     exit 1
@@ -148,7 +150,9 @@ printf '[alias redirect cannot reset the latch] ..\t'
 out="${tmpdir}/alias"
 mkdir "$out"
 rc=0
-local_crawl --log "${out}.log1" -O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 -c1 --retries=1 "${BASEURL}/alias206/index.html" || rc=$?
+run_with_timeout 120 httrack -O "$out" --quiet --disable-security-limits \
+    --robots=0 --timeout=30 -c1 --retries=1 \
+    "${BASEURL}/alias206/index.html" >"${out}.log1" 2>&1 || rc=$?
 test "$rc" -ne 124 || {
     echo "FAIL: the crawl never terminated; the alias hop reset the latch"
     exit 1
@@ -205,7 +209,9 @@ attempts="${tmpdir}/attempts.txt"
 export ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}verify_asan_link_order=0"
 export UNLINKFAIL_MATCH=blob.bin UNLINKFAIL_LOG="$attempts" LD_PRELOAD="$UNLINKFAIL_LIB"
 rc=0
-local_crawl --log "${out}.log2" -O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 -c1 --retries=1 --continue "${BASEURL}/crange206mem/index.html" || rc=$?
+run_with_timeout 120 httrack -O "$out" --quiet --disable-security-limits \
+    --robots=0 --timeout=30 -c1 --retries=1 --continue \
+    "${BASEURL}/crange206mem/index.html" >"${out}.log2" 2>&1 || rc=$?
 unset LD_PRELOAD
 test "$rc" -ne 124 || {
     echo "FAIL: the crawl never terminated"

--- a/tests/235_local-resume-recovery.test
+++ b/tests/235_local-resume-recovery.test
@@ -4,10 +4,9 @@
 set -e
 set -u
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 server=$(nativepath "${testdir}/local-server.py")
-root=$(nativepath "${testdir}/server-root")
 
 python=$(find_python) || skip "python3 not found"
 
@@ -16,24 +15,17 @@ python=$(find_python) || skip "python3 not found"
 skip_on_windows "Windows: the pass-1 interrupt needs a signal MSYS cannot deliver"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_resume.XXXXXX") || exit 1
-serverpid=
 crawlpid=
 cleanup() {
     set +e
     test -n "$crawlpid" && kill -9 "$crawlpid" 2>/dev/null
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
 # stdin off the terminal: run_with_timeout toggles job control, and a background
 # job that touches the tty is stopped with SIGTTIN.
-"$python" "$server" --root "$root" >"$serverlog" 2>&1 </dev/null &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-base="http://127.0.0.1:${port}"
+local_server_start
 
 which httrack >/dev/null || {
     echo "could not find httrack"
@@ -59,7 +51,7 @@ interrupt_pass1() { # interrupt_pass1 <out> <route> <extra httrack args...>
     shift 2
     local refdir="${out}/hts-cache/ref"
     httrack -O "$out" --quiet --disable-security-limits --robots=0 \
-        --timeout=30 -c1 "$@" "${base}/${route}/index.html" \
+        --timeout=30 -c1 "$@" "${BASEURL}/${route}/index.html" \
         >"${out}.log1" 2>&1 &
     crawlpid=$!
     local _
@@ -100,9 +92,7 @@ test "$(blob_size "$out")" -eq "$have" || {
     exit 1
 }
 rc=0
-run_with_timeout 120 httrack -O "$out" --quiet --disable-security-limits \
-    --robots=0 --timeout=30 -c1 --retries=0 --continue \
-    "${base}/resume206/index.html" >"${out}.log2" 2>&1 || rc=$?
+local_crawl --log "${out}.log2" -O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 -c1 --retries=0 --continue "${BASEURL}/resume206/index.html" || rc=$?
 test "$rc" -ne 124 || {
     echo "FAIL: the crawl never terminated"
     exit 1
@@ -133,9 +123,7 @@ out="${tmpdir}/loop"
 mkdir "$out"
 interrupt_pass1 "$out" resume206loop --retries=0
 rc=0
-run_with_timeout 120 httrack -O "$out" --quiet --disable-security-limits \
-    --robots=0 --timeout=30 -c1 --retries=0 --continue \
-    "${base}/resume206loop/index.html" >"${out}.log2" 2>&1 || rc=$?
+local_crawl --log "${out}.log2" -O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 -c1 --retries=0 --continue "${BASEURL}/resume206loop/index.html" || rc=$?
 test "$rc" -ne 124 || {
     echo "FAIL: the crawl never terminated; the restart is unbounded"
     exit 1
@@ -160,9 +148,7 @@ printf '[alias redirect cannot reset the latch] ..\t'
 out="${tmpdir}/alias"
 mkdir "$out"
 rc=0
-run_with_timeout 120 httrack -O "$out" --quiet --disable-security-limits \
-    --robots=0 --timeout=30 -c1 --retries=1 \
-    "${base}/alias206/index.html" >"${out}.log1" 2>&1 || rc=$?
+local_crawl --log "${out}.log1" -O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 -c1 --retries=1 "${BASEURL}/alias206/index.html" || rc=$?
 test "$rc" -ne 124 || {
     echo "FAIL: the crawl never terminated; the alias hop reset the latch"
     exit 1
@@ -219,9 +205,7 @@ attempts="${tmpdir}/attempts.txt"
 export ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}verify_asan_link_order=0"
 export UNLINKFAIL_MATCH=blob.bin UNLINKFAIL_LOG="$attempts" LD_PRELOAD="$UNLINKFAIL_LIB"
 rc=0
-run_with_timeout 120 httrack -O "$out" --quiet --disable-security-limits \
-    --robots=0 --timeout=30 -c1 --retries=1 --continue \
-    "${base}/crange206mem/index.html" >"${out}.log2" 2>&1 || rc=$?
+local_crawl --log "${out}.log2" -O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 -c1 --retries=1 --continue "${BASEURL}/crange206mem/index.html" || rc=$?
 unset LD_PRELOAD
 test "$rc" -ne 124 || {
     echo "FAIL: the crawl never terminated"

--- a/tests/240_local-abort-teardown.test
+++ b/tests/240_local-abort-teardown.test
@@ -70,7 +70,7 @@ cp "${out}/warc-out.warc.gz" "${tmpdir}/warc2.gz"
 cp "${out}/warc-out.cdx" "${tmpdir}/cdx2"
 
 # --- pass 3: server gone, so the no-data rollback restores the last session --
-stop_server "$SRV_PID"
+local_server_stop "$SRV_PID"
 local_crawl --log "${tmpdir}/log3" "${common[@]}" -O "$out" --retries=1 --update "${BASEURL}/changes/index.html"
 expect "the dead pass rolled the session back" \
     grep -aq "restoring previous one" "${out}/hts-log.txt"

--- a/tests/240_local-abort-teardown.test
+++ b/tests/240_local-abort-teardown.test
@@ -4,27 +4,16 @@
 # never ran the index pass, so any report it wrote would be false (#1061).
 set -euo pipefail
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-server=$(nativepath "${testdir}/local-server.py")
-root=$(nativepath "${testdir}/server-root")
-
-python=$(find_python) || skip "python3 not found"
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_abort.XXXXXX") || exit 1
-serverpid=
 cleanup() {
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
-"$python" "$server" --root "$root" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-base="http://127.0.0.1:${port}"
+local_server_start
 
 which httrack >/dev/null || {
     echo "could not find httrack"
@@ -51,8 +40,7 @@ no_tmp() { test -z "$(find "$out" -maxdepth 1 -name '*.tmp' -print -quit)"; }
 unpoisoned() { ! grep -qa "$poison" "$1"; }
 
 # --- pass 1: a complete crawl, to have something an abort could destroy ------
-httrack "${common[@]}" -O "$out" "${base}/changes/index.html" \
-    >"${tmpdir}/log1" 2>&1
+local_crawl --log "${tmpdir}/log1" "${common[@]}" -O "$out" "${BASEURL}/changes/index.html"
 test -s "$report" || {
     echo "FAIL: pass 1 wrote no ${report}"
     exit 1
@@ -68,8 +56,7 @@ done
 
 # --- pass 2: -#L trips the link limit deep in the crawl loop -----------------
 # -C0 so the pass re-downloads: a revisit-only pass declines to swap on its own.
-httrack "${common[@]}" -O "$out" -C0 -\#L4 "${base}/changes/index.html" \
-    >"${tmpdir}/log2" 2>&1
+local_crawl --log "${tmpdir}/log2" "${common[@]}" -O "$out" -C0 -\#L4 "${BASEURL}/changes/index.html"
 expect "the link limit aborted the crawl" \
     grep -aq "Too many URLs" "${out}/hts-log.txt"
 expect "the abort still committed the archive" \
@@ -83,10 +70,8 @@ cp "${out}/warc-out.warc.gz" "${tmpdir}/warc2.gz"
 cp "${out}/warc-out.cdx" "${tmpdir}/cdx2"
 
 # --- pass 3: server gone, so the no-data rollback restores the last session --
-stop_server "$serverpid"
-serverpid=
-httrack "${common[@]}" -O "$out" --retries=1 --update "${base}/changes/index.html" \
-    >"${tmpdir}/log3" 2>&1
+stop_server "$SRV_PID"
+local_crawl --log "${tmpdir}/log3" "${common[@]}" -O "$out" --retries=1 --update "${BASEURL}/changes/index.html"
 expect "the dead pass rolled the session back" \
     grep -aq "restoring previous one" "${out}/hts-log.txt"
 expect "the rollback kept the previous change report" \

--- a/tests/244_local-tty-output.test
+++ b/tests/244_local-tty-output.test
@@ -5,27 +5,19 @@
 
 set -eu
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-server=$(nativepath "${testdir}/local-server.py")
-root=$(nativepath "${testdir}/server-root")
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ttyout.XXXXXX") || exit 1
-serverpid=
 cleanup() {
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
-"$python" "$server" --root "$root" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-url="http://127.0.0.1:${port}/simple/basic.html"
+local_server_start
+url="http://127.0.0.1:${SRV_PORT}/simple/basic.html"
 
 # Stdin is the pty too, and never written to, so it never reads as a keypress.
 ttyrun=$(nativepath "${testdir}/ttyrun.py")

--- a/tests/247_cli-stdin-eof.test
+++ b/tests/247_cli-stdin-eof.test
@@ -6,28 +6,20 @@
 
 set -eu
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-server=$(nativepath "${testdir}/local-server.py")
-root=$(nativepath "${testdir}/server-root")
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 ttyrun=$(nativepath "${testdir}/ttyrun.py")
 
 skip_on_windows "no pty on Windows"
 python=$(find_python) || skip "python3 not found"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_stdineof.XXXXXX") || exit 1
-serverpid=
 cleanup() {
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
-"$python" "$server" --root "$root" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+local_server_start
 
 which httrack >/dev/null || {
     echo "could not find httrack"
@@ -36,7 +28,7 @@ which httrack >/dev/null || {
 
 # Trickled pages: the crawl has to outlive several passes of the loop that polls
 # stdin, or a display that toggles has no time to show it.
-url="http://127.0.0.1:${port}/trickle/index.html"
+url="http://127.0.0.1:${SRV_PORT}/trickle/index.html"
 
 # crawl <label> <ttyrun opts...>
 crawl() {

--- a/tests/24_local-resume-overlap.test
+++ b/tests/24_local-resume-overlap.test
@@ -7,34 +7,22 @@
 # backs up 8 bytes. The result must equal the same bytes fetched whole (full.bin).
 set -eu
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-server=$(nativepath "${testdir}/local-server.py")
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 root=$(nativepath "${testdir}/server-root")
 
-python=$(find_python) || skip "python3 not found"
-
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_198.XXXXXX") || exit 1
-serverpid=
 crawlpid=
 cleanup() {
     if test -n "$crawlpid"; then kill -9 "$crawlpid" 2>/dev/null || true; fi
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
 # OVERLAP_COUNTER gets a byte per flaky.bin request so pass 1 knows when to interrupt.
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
 counter="${tmpdir}/hits"
 resumed="${tmpdir}/resumed" # gets a byte when the server serves a resume 206
-OVERLAP_COUNTER="$counter" OVERLAP_RESUMED="$resumed" \
-    "$python" "$server" --root "$root" \
-    >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-base="http://127.0.0.1:${port}"
+local_server_start --env OVERLAP_COUNTER="$counter" --env OVERLAP_RESUMED="$resumed" --root "$root"
 
 which httrack >/dev/null || {
     echo "could not find httrack"
@@ -46,7 +34,7 @@ refdir="${out}/hts-cache/ref"
 
 # pass 1: interrupt once flaky.bin's prefix is streaming (partial + temp-ref).
 printf '[pass 1: interrupt flaky.bin] ..\t'
-httrack "${common[@]}" "${base}/overlap/index.html" >"${tmpdir}/log1" 2>&1 &
+httrack "${common[@]}" "${BASEURL}/overlap/index.html" >"${tmpdir}/log1" 2>&1 &
 crawlpid=$!
 for _ in $(seq 1 300); do
     test -s "$counter" && break
@@ -65,7 +53,7 @@ echo "OK (temp-ref present)"
 
 # pass 2: --continue -> resume Range -> 206 that starts 8 bytes early.
 printf '[pass 2: resume flaky.bin] ..\t'
-httrack "${common[@]}" --continue "${base}/overlap/index.html" >"${tmpdir}/log2" 2>&1 || true
+local_crawl --log "${tmpdir}/log2" "${common[@]}" --continue "${BASEURL}/overlap/index.html" || true
 echo "OK"
 
 # Guard against a silent full re-download: the byte-compare below only tests the

--- a/tests/252_local-nonhtml-foreign-depth.test
+++ b/tests/252_local-nonhtml-foreign-depth.test
@@ -4,38 +4,27 @@
 # engine mirrored 3 files of that host under -n and 7 under +*.jpg, against 1.
 set -eu
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-
-python=$(find_python) || skip "python3 not found"
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_121.XXXXXX") || exit 1
-apid=
-bpid=
 cleanup() {
-    stop_server "$apid"
-    stop_server "$bpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
-server=$(nativepath "${testdir}/local-server.py")
 mkdir -p "${tmpdir}/aroot" "${tmpdir}/broot"
 
 # The foreign host, answering text/html on every path under /foreign/.
 blog="${tmpdir}/b-server.log"
 : >"$blog"
-"$python" "$server" --root "$(nativepath "${tmpdir}/broot")" \
-    >"$blog" 2>&1 </dev/null &
-bpid=$!
-bport=$(discover_server_port "$blog" "$bpid") || exit 1
+local_server_start --root "${tmpdir}/broot" --log "$blog"
+bport=$SRV_PORT
 
 alog="${tmpdir}/a-server.log"
 : >"$alog"
-"$python" "$server" --root "$(nativepath "${tmpdir}/aroot")" \
-    >"$alog" 2>&1 </dev/null &
-apid=$!
-aport=$(discover_server_port "$alog" "$apid") || exit 1
+local_server_start --root "${tmpdir}/aroot" --log "$alog"
+aport=$SRV_PORT
 
 # Written once A's port is known, since the same-host asset link has to be
 # absolute: a relative one would inherit whatever userinfo the crawl entered by.
@@ -64,9 +53,7 @@ which httrack >/dev/null || fail "could not find httrack"
 crawl() { # crawl <label> <start path> [httrack args...]
     local label=$1 start=$2
     shift 2
-    httrack "http://127.0.0.1:${aport}${start}" -O "${tmpdir}/out-${label}" \
-        --quiet --max-time=120 --timeout=30 --robots=0 --debug-log "$@" \
-        >"${tmpdir}/crawl-${label}.log" 2>&1 || fail "crawl ${label} failed"
+    local_crawl --log "${tmpdir}/crawl-${label}.log" "http://127.0.0.1:${aport}${start}" -O "${tmpdir}/out-${label}" --quiet --max-time=120 --timeout=30 --robots=0 --debug-log "$@" || fail "crawl ${label} failed"
 }
 
 mirrored() { # mirrored <label> <port>
@@ -145,18 +132,12 @@ check hostrule "$aport" "$untouched"
 
 # Entering through credentials puts them in the referer's address but not in
 # the page's own absolute links, which must still count as the same host.
-httrack "http://user:pw@127.0.0.1:${aport}/index.html" \
-    -O "${tmpdir}/out-userinfo" --quiet --max-time=120 --timeout=30 \
-    --robots=0 -n '+*.jpg' \
-    >"${tmpdir}/crawl-userinfo.log" 2>&1 || fail "crawl userinfo failed"
+local_crawl --log "${tmpdir}/crawl-userinfo.log" "http://user:pw@127.0.0.1:${aport}/index.html" -O "${tmpdir}/out-userinfo" --quiet --max-time=120 --timeout=30 --robots=0 -n '+*.jpg' || fail "crawl userinfo failed"
 check userinfo "$aport" "$untouched"
 check userinfo "$bport" "$kept"
 
 # A seeded host is its own referer, so nothing is foreign to it.
-httrack "http://127.0.0.1:${aport}/index.html" \
-    "http://127.0.0.1:${bport}/foreign/s/xxx/distorted.jpg" \
-    -O "${tmpdir}/out-seed" --quiet --max-time=120 --timeout=30 --robots=0 \
-    >"${tmpdir}/crawl-seed.log" 2>&1 || fail "crawl seed failed"
+local_crawl --log "${tmpdir}/crawl-seed.log" "http://127.0.0.1:${aport}/index.html" "http://127.0.0.1:${bport}/foreign/s/xxx/distorted.jpg" -O "${tmpdir}/out-seed" --quiet --max-time=120 --timeout=30 --robots=0 || fail "crawl seed failed"
 check seed "$bport" "$scanned"
 
 # A foreign asset honestly typed is still parsed for what it references: the

--- a/tests/258_crawllib.test
+++ b/tests/258_crawllib.test
@@ -1,0 +1,162 @@
+#!/bin/bash
+#
+# crawllib's launch and crawl helpers, exercised from a subject process: a
+# firing assertion, and the reaping the library registers, both end that
+# process rather than this one.
+
+# The subject snippets below are deliberately unexpanded: they run in the
+# subject, against its own tmpdir and the variables the library sets there.
+# shellcheck disable=SC2016
+
+set -euo pipefail
+
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
+
+find_python >/dev/null || skip "python3 not found"
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_crawllib.XXXXXX")
+cleanup_push rm -rf "$tmpdir"
+
+ok() { echo "OK: $*"; }
+
+rc=0 out=
+run_subject() {
+    printf 'set -euo pipefail\n. "%s/crawllib.sh"\ntmpdir=%s\n%s\n' \
+        "$testdir" "$1" "$2" >"${1}/subject.sh"
+    rc=0
+    out=$(bash "${1}/subject.sh" 2>&1) || rc=$?
+}
+
+# Each subject gets its own tmpdir: the library defaults its log to $tmpdir and
+# registers cleanups there.
+subject=0
+holds() {
+    subject=$((subject + 1))
+    mkdir -p "${tmpdir}/s${subject}"
+    run_subject "${tmpdir}/s${subject}" "$1"
+    test "$rc" -eq 0 || fail "[$1] should have held, exited $rc: $out"
+}
+
+fires() {
+    subject=$((subject + 1))
+    mkdir -p "${tmpdir}/s${subject}"
+    run_subject "${tmpdir}/s${subject}" "$1"
+    test "$rc" -eq 1 || fail "[$1] should have failed, exited $rc: $out"
+    case "$out" in
+    *"$2"*) ;;
+    *) fail "[$1] failed without reporting '$2': $out" ;;
+    esac
+}
+
+## local_server_start announces a live server
+holds 'local_server_start
+test -n "$SRV_PORT" && test -n "$SRV_PID" && test -n "$SRV_LOG"
+test "$BASEURL" = "http://127.0.0.1:${SRV_PORT}"
+kill -0 "$SRV_PID"'
+ok "local_server_start sets BASEURL, SRV_PORT, SRV_PID and SRV_LOG"
+
+# A server that cannot bind must end the test, not leave SRV_PORT empty and let
+# every later assertion run against a dead port.
+fires 'local_server_start --bind 300.300.300.300' 'local-server did not come up'
+ok "a server that fails to bind fails the test"
+
+## --root picks what is served, and the default is the shared fixture
+holds 'mkdir -p "${tmpdir}/doc"
+printf "picked-this-root\n" >"${tmpdir}/doc/probe.html"
+local_server_start --root "${tmpdir}/doc"
+body=$("$(find_python)" - "$SRV_PORT" <<PY
+import sys, urllib.request
+print(urllib.request.urlopen("http://127.0.0.1:%s/probe.html" % sys.argv[1]).read().decode())
+PY
+)
+assert_match "picked-this-root" "$body" "served from --root"'
+ok "--root is what gets served"
+
+## --env reaches the server process
+holds 'local_server_start --env LOCAL_SERVER_VERBOSE=1
+"$(find_python)" - "$SRV_PORT" <<PY
+import sys, urllib.request
+urllib.request.urlopen("http://127.0.0.1:%s/simple/basic.html" % sys.argv[1]).read()
+PY
+grep -q "GET /simple/basic.html" "$SRV_LOG"'
+ok "--env is exported to the server"
+
+## Two servers coexist on their own ports, and both are reaped
+holds 'local_server_start --log "${tmpdir}/a.log"
+a=$SRV_PORT apid=$SRV_PID
+assert_eq "${tmpdir}/a.log" "$SRV_LOG" "--log is where the announcement went"
+local_server_start --log "${tmpdir}/b.log"
+test "$a" != "$SRV_PORT" || fail "both servers took port $a"
+# Two servers, two logs: one shared default would leave the second port
+# discoverable in the first log and hide a --log that never took effect.
+grep -q "PORT ${a}$" "${tmpdir}/a.log" || fail "a.log holds no announcement"
+grep -q "PORT ${SRV_PORT}$" "${tmpdir}/b.log" || fail "b.log holds no announcement"
+! grep -q "PORT ${SRV_PORT}$" "${tmpdir}/a.log" || fail "both servers logged to a.log"
+printf "%s %s\n" "$apid" "$SRV_PID" >"${tmpdir}/pids"'
+read -r apid bpid <"${tmpdir}/s${subject}/pids"
+# The subject has exited, so its cleanups have run.
+! kill -0 "$apid" 2>/dev/null || fail "server $apid survived its test"
+! kill -0 "$bpid" 2>/dev/null || fail "server $bpid survived its test"
+ok "two servers get distinct ports and both are reaped on exit"
+
+## local_crawl's argument contract, read off a shim rather than a real crawl
+shim="${tmpdir}/bin"
+mkdir -p "$shim"
+cat >"${shim}/httrack" <<'SH'
+#!/bin/bash
+printf '%s\n' "$@" >"${SHIM_ARGV:?}"
+exit "${SHIM_RC:-0}"
+SH
+chmod +x "${shim}/httrack"
+
+argv="${tmpdir}/argv"
+export SHIM_ARGV="$argv"
+PATH="${shim}:$PATH"
+
+local_crawl -O /dev/null "http://127.0.0.1:1/x"
+grep -qx -- '--max-time=120' "$argv" || fail "local_crawl dropped its default --max-time"
+grep -qx -- '-O' "$argv" || fail "local_crawl dropped the caller's arguments"
+ok "local_crawl adds a --max-time backstop"
+
+# A caller's own cap wins: with two of them the engine takes one of the pair,
+# and the backstop exists to be the weaker.
+local_crawl --max-time=7 -O /dev/null "http://127.0.0.1:1/x"
+! grep -qx -- '--max-time=120' "$argv" || fail "local_crawl added a cap over the caller's"
+grep -qx -- '--max-time=7' "$argv" || fail "local_crawl dropped the caller's cap"
+local_crawl --max-time 7 -O /dev/null "http://127.0.0.1:1/x"
+! grep -qx -- '--max-time=120' "$argv" || fail "the spaced form did not suppress the default"
+ok "a caller's own --max-time suppresses the default, in either spelling"
+
+## The exit status is httrack's own
+export SHIM_RC=3
+rc=0
+local_crawl -O /dev/null "http://127.0.0.1:1/x" || rc=$?
+assert_eq 3 "$rc" "local_crawl returns httrack's status"
+unset SHIM_RC
+ok "local_crawl returns the crawl's exit status"
+
+## --log captures the crawl's output, and the default discards it
+cat >"${shim}/httrack" <<'SH'
+#!/bin/bash
+echo "crawl-said-this"
+SH
+chmod +x "${shim}/httrack"
+local_crawl --log "${tmpdir}/crawl.log" -O /dev/null "http://127.0.0.1:1/x"
+assert_match "crawl-said-this" "$(cat "${tmpdir}/crawl.log")" "--log captured stdout"
+ok "--log captures the crawl output"
+
+## The watchdog reds a crawl that never ends, from a subject: it ends the test
+cat >"${shim}/httrack" <<'SH'
+#!/bin/bash
+sleep 30
+SH
+chmod +x "${shim}/httrack"
+export PATH
+start=$SECONDS
+fires 'local_crawl --deadline 2 -O /dev/null "http://127.0.0.1:1/x"' \
+    'crawl watchdog fired after 2s'
+test "$((SECONDS - start))" -lt 20 || fail "the watchdog outran its own deadline"
+ok "the watchdog reds a wedged crawl instead of hanging the suite"
+
+echo "PASS"

--- a/tests/258_crawllib.test
+++ b/tests/258_crawllib.test
@@ -1,8 +1,7 @@
 #!/bin/bash
 #
 # crawllib's launch and crawl helpers, exercised from a subject process: a
-# firing assertion, and the reaping the library registers, both end that
-# process rather than this one.
+# firing assertion, and the library's own reaping, each end that process.
 
 # The subject snippets below are deliberately unexpanded: they run in the
 # subject, against its own tmpdir and the variables the library sets there.
@@ -100,6 +99,16 @@ read -r apid bpid <"${tmpdir}/s${subject}/pids"
 ! kill -0 "$bpid" 2>/dev/null || fail "server $bpid survived its test"
 ok "two servers get distinct ports and both are reaped on exit"
 
+## A test that stops its own server still exits clean, and reaps nothing twice
+holds 'local_server_start
+pid=$SRV_PID
+stop_server "$SRV_PID"
+! kill -0 "$pid" 2>/dev/null || fail "the mid-run stop left the server alive"
+printf "%s\n" "$pid" >"${tmpdir}/pid"'
+read -r pid <"${tmpdir}/s${subject}/pid"
+! kill -0 "$pid" 2>/dev/null || fail "server $pid survived"
+ok "a server stopped mid-test leaves the teardown a no-op"
+
 ## local_crawl's argument contract, read off a shim rather than a real crawl
 shim="${tmpdir}/bin"
 mkdir -p "$shim"
@@ -113,38 +122,64 @@ chmod +x "${shim}/httrack"
 argv="${tmpdir}/argv"
 export SHIM_ARGV="$argv"
 PATH="${shim}:$PATH"
+url="http://127.0.0.1:1/x"
 
-local_crawl -O /dev/null "http://127.0.0.1:1/x"
-grep -qx -- '--max-time=120' "$argv" || fail "local_crawl dropped its default --max-time"
-grep -qx -- '-O' "$argv" || fail "local_crawl dropped the caller's arguments"
-ok "local_crawl adds a --max-time backstop"
+# Truncate first, then require the URL back: an assertion that only reads $argv
+# would otherwise pass on the previous call's arguments when the crawl never ran.
+crawled() { # crawled ARGS...
+    local rc=0
+    : >"$argv"
+    # Not the last command, so its status is captured rather than the grep's.
+    local_crawl "$@" || rc=$?
+    grep -qxF -- "$url" "$argv" || fail "httrack never ran, or lost its URL"
+    return "$rc"
+}
+has() { grep -qxF -- "$1" "$argv" || fail "${2:-missing argument $1}"; }
+hasnt() { ! grep -qxF -- "$1" "$argv" || fail "${2:-unwanted argument $1}"; }
+
+crawled -O /dev/null "$url"
+has '--max-time=120' "local_crawl dropped its default --max-time"
+# Values, not just flags: an argv rebuilt from options alone would pass on flags.
+assert_eq "--max-time=120
+-O
+/dev/null
+$url" "$(cat "$argv")" "the caller's arguments reach httrack, in order, after the cap"
+ok "local_crawl adds a --max-time backstop ahead of the caller's arguments"
 
 # A caller's own cap wins: with two of them the engine takes one of the pair,
 # and the backstop exists to be the weaker.
-local_crawl --max-time=7 -O /dev/null "http://127.0.0.1:1/x"
-! grep -qx -- '--max-time=120' "$argv" || fail "local_crawl added a cap over the caller's"
-grep -qx -- '--max-time=7' "$argv" || fail "local_crawl dropped the caller's cap"
-local_crawl --max-time 7 -O /dev/null "http://127.0.0.1:1/x"
-! grep -qx -- '--max-time=120' "$argv" || fail "the spaced form did not suppress the default"
+crawled --max-time=7 -O /dev/null "$url"
+hasnt '--max-time=120' "local_crawl added a cap over the caller's"
+has '--max-time=7' "local_crawl dropped the caller's cap"
+crawled --max-time 7 -O /dev/null "$url"
+hasnt '--max-time=120' "the spaced form did not suppress the default"
+has '--max-time' "the spaced form lost the caller's cap"
+has '7' "the spaced form lost the cap's value"
+# Back to the default, so a library that only ever adds it once is caught.
+crawled -O /dev/null "$url"
+has '--max-time=120' "the default cap was added only on the first crawl"
 ok "a caller's own --max-time suppresses the default, in either spelling"
 
 ## The exit status is httrack's own
 export SHIM_RC=3
 rc=0
-local_crawl -O /dev/null "http://127.0.0.1:1/x" || rc=$?
+crawled -O /dev/null "$url" || rc=$?
 assert_eq 3 "$rc" "local_crawl returns httrack's status"
 unset SHIM_RC
 ok "local_crawl returns the crawl's exit status"
 
-## --log captures the crawl's output, and the default discards it
+## --log takes the crawl's output, and the default discards it
 cat >"${shim}/httrack" <<'SH'
 #!/bin/bash
 echo "crawl-said-this"
 SH
 chmod +x "${shim}/httrack"
-local_crawl --log "${tmpdir}/crawl.log" -O /dev/null "http://127.0.0.1:1/x"
-assert_match "crawl-said-this" "$(cat "${tmpdir}/crawl.log")" "--log captured stdout"
-ok "--log captures the crawl output"
+local_crawl --log "${tmpdir}/crawl.log" -O /dev/null "$url"
+assert_eq "crawl-said-this" "$(cat "${tmpdir}/crawl.log")" "--log took stdout"
+# Truncated, not appended: every call site it replaced used a plain > redirect.
+local_crawl --log "${tmpdir}/crawl.log" -O /dev/null "$url"
+assert_eq "crawl-said-this" "$(cat "${tmpdir}/crawl.log")" "--log truncates per crawl"
+ok "--log takes the crawl output, one crawl at a time"
 
 ## The watchdog reds a crawl that never ends, from a subject: it ends the test
 cat >"${shim}/httrack" <<'SH'
@@ -152,11 +187,16 @@ cat >"${shim}/httrack" <<'SH'
 sleep 30
 SH
 chmod +x "${shim}/httrack"
-export PATH
+export PATH CRAWL_DEADLINE=2
 start=$SECONDS
-fires 'local_crawl --deadline 2 -O /dev/null "http://127.0.0.1:1/x"' \
+fires 'local_crawl -O /dev/null "http://127.0.0.1:1/x"' \
     'crawl watchdog fired after 2s'
-test "$((SECONDS - start))" -lt 20 || fail "the watchdog outran its own deadline"
-ok "the watchdog reds a wedged crawl instead of hanging the suite"
+elapsed=$((SECONDS - start))
+# Bounded both ways: firing early would red a healthy crawl, and a watchdog that
+# ignored CRAWL_DEADLINE would sit out the shim's whole sleep.
+test "$elapsed" -ge 1 || fail "the watchdog fired before its deadline"
+test "$elapsed" -lt 15 || fail "the watchdog outran its deadline: ${elapsed}s"
+unset CRAWL_DEADLINE
+ok "CRAWL_DEADLINE drives the watchdog, which reds a wedged crawl"
 
 echo "PASS"

--- a/tests/258_crawllib.test
+++ b/tests/258_crawllib.test
@@ -99,15 +99,20 @@ read -r apid bpid <"${tmpdir}/s${subject}/pids"
 ! kill -0 "$bpid" 2>/dev/null || fail "server $bpid survived its test"
 ok "two servers get distinct ports and both are reaped on exit"
 
-## A test that stops its own server still exits clean, and reaps nothing twice
-holds 'local_server_start
-pid=$SRV_PID
-stop_server "$SRV_PID"
-! kill -0 "$pid" 2>/dev/null || fail "the mid-run stop left the server alive"
-printf "%s\n" "$pid" >"${tmpdir}/pid"'
-read -r pid <"${tmpdir}/s${subject}/pid"
-! kill -0 "$pid" 2>/dev/null || fail "server $pid survived"
-ok "a server stopped mid-test leaves the teardown a no-op"
+## local_server_stop reaps now and disarms the teardown
+holds 'local_server_start --log "${tmpdir}/a.log"
+first=$SRV_PID
+local_server_start --log "${tmpdir}/b.log"
+local_server_stop "$first"
+! kill -0 "$first" 2>/dev/null || fail "the mid-run stop left the server alive"
+# The emptied slot is what stops teardown signalling a recycled pid number.
+test -z "${SRV_PIDS[0]}" || fail "the stopped server was left armed: ${SRV_PIDS[0]}"
+test "${SRV_PIDS[1]}" = "$SRV_PID" || fail "the running server lost its teardown"
+printf "%s %s\n" "$first" "$SRV_PID" >"${tmpdir}/pids"'
+read -r first second <"${tmpdir}/s${subject}/pids"
+! kill -0 "$first" 2>/dev/null || fail "server $first survived"
+! kill -0 "$second" 2>/dev/null || fail "server $second survived its test"
+ok "local_server_stop reaps its server and disarms only that teardown"
 
 ## local_crawl's argument contract, read off a shim rather than a real crawl
 shim="${tmpdir}/bin"

--- a/tests/46_local-update-304-resume.test
+++ b/tests/46_local-update-304-resume.test
@@ -5,31 +5,21 @@
 # 304, and must recover the whole file.
 set -u
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-server=$(nativepath "${testdir}/local-server.py")
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 root=$(nativepath "${testdir}/server-root")
 
-python=$(find_python) || skip "python3 not found"
-
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_c7.XXXXXX") || exit 1
-serverpid=
 crawlpid=
 cleanup() {
     test -n "$crawlpid" && kill -9 "$crawlpid" 2>/dev/null
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
 counter="${tmpdir}/reqcount"
 mark="${tmpdir}/got304"
-RESUME304_COUNTER="$counter" RESUME304_MARK="$mark" "$python" "$server" --root "$root" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-base="http://127.0.0.1:${port}"
+local_server_start --env RESUME304_COUNTER="$counter" --env RESUME304_MARK="$mark" --root "$root"
 
 which httrack >/dev/null || {
     echo "could not find httrack"
@@ -42,7 +32,7 @@ refdir="${out}/hts-cache/ref"
 
 # --- pass 1: crawl, interrupt once the blob download is underway -------------
 printf '[pass 1: interrupt mid-download] ..\t'
-httrack "${common[@]}" "${base}/resume304/index.html" >"${tmpdir}/log1" 2>&1 &
+httrack "${common[@]}" "${BASEURL}/resume304/index.html" >"${tmpdir}/log1" 2>&1 &
 crawlpid=$!
 for _ in $(seq 1 300); do
     test -s "$counter" && break
@@ -62,7 +52,7 @@ before=$(wc -c <"$counter" 2>/dev/null || echo 0)
 
 # --- pass 2: --continue -> resume Range -> bogus 304 -> drop + refetch --------
 printf '[pass 2: resume gets 304, must refetch] ..\t'
-httrack "${common[@]}" --continue "${base}/resume304/index.html" >"${tmpdir}/log2" 2>&1
+local_crawl --log "${tmpdir}/log2" "${common[@]}" --continue "${BASEURL}/resume304/index.html"
 echo "OK (terminated)"
 
 blob=$(find "$out" -name blob.bin 2>/dev/null | head -1)

--- a/tests/47_local-crange-overflow.test
+++ b/tests/47_local-crange-overflow.test
@@ -6,29 +6,18 @@
 # are UBSan-only: a normal build wraps to the same reject+restart.
 set -u
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-server=$(nativepath "${testdir}/local-server.py")
-root=$(nativepath "${testdir}/server-root")
-
-python=$(find_python) || skip "python3 not found"
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_crange.XXXXXX") || exit 1
-serverpid=
 crawlpid=
 cleanup() {
     test -n "$crawlpid" && kill -9 "$crawlpid" 2>/dev/null
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
-"$python" "$server" --root "$root" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-base="http://127.0.0.1:${port}"
+local_server_start
 
 which httrack >/dev/null || {
     echo "could not find httrack"
@@ -41,7 +30,7 @@ refdir="${out}/hts-cache/ref"
 
 # --- pass 1: crawl, interrupt once the blob download is underway -------------
 printf '[pass 1: interrupt mid-download] ..\t'
-httrack "${common[@]}" "${base}/crange206/index.html" >"${tmpdir}/log1" 2>&1 &
+httrack "${common[@]}" "${BASEURL}/crange206/index.html" >"${tmpdir}/log1" 2>&1 &
 crawlpid=$!
 for _ in $(seq 1 300); do
     test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" && break
@@ -60,7 +49,7 @@ echo "OK (temp-ref present)"
 
 # --- pass 2: --continue -> resume -> hostile INT64_MAX Content-Range ----------
 printf '[pass 2: hostile 206, no overflow, refetch] ..\t'
-httrack "${common[@]}" --continue "${base}/crange206/index.html" >"${tmpdir}/log2" 2>&1
+local_crawl --log "${tmpdir}/log2" "${common[@]}" --continue "${BASEURL}/crange206/index.html"
 echo "OK (terminated)"
 
 blob=$(find "$out" -name blob.bin 2>/dev/null | head -1)

--- a/tests/48_local-crange-memresume.test
+++ b/tests/48_local-crange-memresume.test
@@ -6,33 +6,22 @@
 # file. Teeth are UBSan-only: a normal build wraps to the same reject+restart.
 set -u
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-server=$(nativepath "${testdir}/local-server.py")
-root=$(nativepath "${testdir}/server-root")
-
-python=$(find_python) || skip "python3 not found"
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 
 # The resume needs a graceful pass-1 interrupt to leave a temp-ref, and MSYS
 # cannot deliver a signal to a native exe.
 skip_on_windows "Windows: the pass-1 interrupt needs a signal MSYS cannot deliver"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_crangemem.XXXXXX") || exit 1
-serverpid=
 crawlpid=
 cleanup() {
     test -n "$crawlpid" && kill -9 "$crawlpid" 2>/dev/null
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
-"$python" "$server" --root "$root" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-base="http://127.0.0.1:${port}"
+local_server_start
 
 which httrack >/dev/null || {
     echo "could not find httrack"
@@ -45,7 +34,7 @@ refdir="${out}/hts-cache/ref"
 
 # --- pass 1: crawl, interrupt once the blob download is underway -------------
 printf '[pass 1: interrupt mid-download] ..\t'
-httrack "${common[@]}" "${base}/crange206mem/index.html" >"${tmpdir}/log1" 2>&1 &
+httrack "${common[@]}" "${BASEURL}/crange206mem/index.html" >"${tmpdir}/log1" 2>&1 &
 crawlpid=$!
 for _ in $(seq 1 300); do
     test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" && break
@@ -65,7 +54,7 @@ echo "OK (temp-ref present)"
 # --- pass 2: --continue -> resume -> hostile INT64_MAX Content-Range ----------
 printf '[pass 2: hostile 206, no overflow, refetch] ..\t'
 rc=0
-httrack "${common[@]}" --continue "${base}/crange206mem/index.html" >"${tmpdir}/log2" 2>&1 || rc=$?
+local_crawl --log "${tmpdir}/log2" "${common[@]}" --continue "${BASEURL}/crange206mem/index.html" || rc=$?
 # a crash here would otherwise read as a clean "terminated"
 test "$rc" -eq 0 || {
     echo "FAIL: httrack exited $rc"

--- a/tests/56_local-proxy-noleak.test
+++ b/tests/56_local-proxy-noleak.test
@@ -7,31 +7,26 @@
 
 set -euo pipefail
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 
 if test "${V6_SUPPORT:-}" == "no"; then
     echo "no IPv6 support (resolver override compiled out), skipping"
     exit 77
 fi
-python=$(find_python) || skip "python3 missing"
 
-server=$(nativepath "$top_srcdir/tests/local-server.py")
+python=$(find_python) || skip "python3 missing" # freeport reads it from here
+
 root=$(nativepath "$top_srcdir/tests/server-root")
 tmpdir=$(mktemp -d)
-serverpid=
 
 cleanup() {
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
 # decoy origin: it must stay silent. LOCAL_SERVER_VERBOSE logs any request it gets.
-LOCAL_SERVER_VERBOSE=1 "$python" "$server" --root "$root" --bind 127.0.0.1 \
-    >"$tmpdir/srv.out" 2>"$tmpdir/srv.err" &
-serverpid=$!
-port=$(discover_server_port "$tmpdir/srv.out" "$serverpid") || exit 1
+local_server_start --env LOCAL_SERVER_VERBOSE=1 --root "$root" --bind 127.0.0.1
 
 # a proxy port nothing listens on: grab a free one and let it close (refuses).
 deadproxy=$(freeport)
@@ -40,16 +35,14 @@ deadproxy=$(freeport)
 # 127.0.0.1 (the decoy) is the one the old bypass reached.
 out="$tmpdir/crawl"
 HTTRACK_DEBUG_RESOLVE="decoyhost:127.0.0.2,127.0.0.1" \
-    httrack "http://decoyhost:$port/simple/basic.html" -O "$out" \
-    -P "127.0.0.1:$deadproxy" -c1 --robots=0 --timeout=5 --retries=0 --quiet -Z \
-    >"$tmpdir/log" 2>&1
+    local_crawl --log "$tmpdir/log" "http://decoyhost:${SRV_PORT}/simple/basic.html" -O "$out" -P "127.0.0.1:$deadproxy" -c1 --robots=0 --timeout=5 --retries=0 --quiet -Z
 
 log="$out/hts-log.txt"
 
 # the origin must have seen no connection (no leak/bypass)
-if grep -qE '"(GET|POST|HEAD|CONNECT) ' "$tmpdir/srv.err"; then
+if grep -qE '"(GET|POST|HEAD|CONNECT) ' "$SRV_LOG"; then
     echo "FAIL: origin was contacted directly, bypassing the proxy"
-    cat "$tmpdir/srv.err"
+    cat "$SRV_LOG"
     exit 1
 fi
 

--- a/tests/71_local-crange-repaircache.test
+++ b/tests/71_local-crange-repaircache.test
@@ -7,10 +7,8 @@
 # the refetch carries no Range either way. Test 235 is the one with teeth there.
 set -u
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-server=$(nativepath "${testdir}/local-server.py")
-root=$(nativepath "${testdir}/server-root")
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 
@@ -19,21 +17,14 @@ python=$(find_python) || skip "python3 not found"
 skip_on_windows "Windows: the pass-1 interrupt needs a signal MSYS cannot deliver"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_crangerep.XXXXXX") || exit 1
-serverpid=
 crawlpid=
 cleanup() {
     test -n "$crawlpid" && kill -9 "$crawlpid" 2>/dev/null
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
-"$python" "$server" --root "$root" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-base="http://127.0.0.1:${port}"
+local_server_start
 
 which httrack >/dev/null || {
     echo "could not find httrack"
@@ -47,7 +38,7 @@ newzip="${out}/hts-cache/new.zip"
 
 # --- pass 1: crawl, interrupt once the blob download is underway -------------
 printf '[pass 1: interrupt mid-download] ..\t'
-httrack "${common[@]}" "${base}/crange206mem/index.html" >"${tmpdir}/log1" 2>&1 &
+httrack "${common[@]}" "${BASEURL}/crange206mem/index.html" >"${tmpdir}/log1" 2>&1 &
 crawlpid=$!
 for _ in $(seq 1 300); do
     test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" && break
@@ -80,7 +71,7 @@ echo "OK"
 # --- pass 2: --continue -> repair -> resume -> hostile 206 -> refetch whole ---
 printf '[pass 2: repair, reject range, refetch] ..\t'
 rc=0
-httrack "${common[@]}" --continue "${base}/crange206mem/index.html" >"${tmpdir}/log2" 2>&1 || rc=$?
+local_crawl --log "${tmpdir}/log2" "${common[@]}" --continue "${BASEURL}/crange206mem/index.html" || rc=$?
 test "$rc" -eq 0 || {
     echo "FAIL: httrack exited $rc"
     cat "${tmpdir}/log2" >&2

--- a/tests/76_cli-resize.test
+++ b/tests/76_cli-resize.test
@@ -3,28 +3,20 @@
 # follow the new geometry instead of the hardcoded 80x24 one.
 set -eu
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-server=$(nativepath "${testdir}/local-server.py")
-root=$(nativepath "${testdir}/server-root")
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 driver=$(nativepath "${testdir}/pty-resize.py")
 
 skip_on_windows "no pty on Windows"
 python=$(find_python) || skip "python3 not found"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_resize.XXXXXX") || exit 1
-serverpid=
 cleanup() {
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
-"$python" "$server" --root "$root" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+local_server_start
 
 which httrack >/dev/null || {
     echo "could not find httrack"
@@ -33,7 +25,7 @@ which httrack >/dev/null || {
 
 # Trickled pages under a long path: the display keeps animating while the pty is
 # resized under it, and the URL is truncated at 80 columns but not at 200.
-deep="127.0.0.1:${port}/trickle/deep/a-long-directory-segment/another-long-segment"
+deep="127.0.0.1:${SRV_PORT}/trickle/deep/a-long-directory-segment/another-long-segment"
 out="${tmpdir}/crawl"
 mkdir "$out"
 rc=0

--- a/tests/93_local-changes.test
+++ b/tests/93_local-changes.test
@@ -4,27 +4,18 @@
 # would call the whole site changed.
 set -euo pipefail
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-server=$(nativepath "${testdir}/local-server.py")
-root=$(nativepath "${testdir}/server-root")
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_changes.XXXXXX") || exit 1
-serverpid=
 cleanup() {
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
 
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
-"$python" "$server" --root "$root" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-base="http://127.0.0.1:${port}"
+local_server_start
 
 which httrack >/dev/null || {
     echo "could not find httrack"
@@ -79,8 +70,7 @@ lines() { printf '%s\n' "$@" | sort; }
 digest() { cksum <"$1" | tr -d '[:space:]'; }
 
 # --- pass 1: nothing to compare against --------------------------------------
-httrack "${common[@]}" -O "$out" --purge-old=0 "${base}/changes/index.html" \
-    >"${tmpdir}/log1" 2>&1
+local_crawl --log "${tmpdir}/log1" "${common[@]}" -O "$out" --purge-old=0 "${BASEURL}/changes/index.html"
 test -s "$report" || {
     echo "FAIL: pass 1 wrote no ${report}"
     exit 1
@@ -98,15 +88,14 @@ grep -aq "first crawl" "${out}/hts-log.txt" || {
     exit 1
 }
 
-host="127.0.0.1_${port}"
+host="127.0.0.1_$SRV_PORT"
 resetdigest=$(digest "${out}/${host}/changes/reset.bin")
 # A leftover from some earlier failed attempt, at a name pass 2 fetches for the
 # first time: on disk, but never part of the previous mirror, so it is new.
 printf 'leftover junk' >"${out}/${host}/changes/fresh.html"
 
 # --- pass 2: two bodies move, pages appear and disappear ---------------------
-httrack "${common[@]}" -O "$out" --purge-old=0 --update \
-    "${base}/changes/index.html" >"${tmpdir}/log2" 2>&1
+local_crawl --log "${tmpdir}/log2" "${common[@]}" -O "$out" --purge-old=0 --update "${BASEURL}/changes/index.html"
 expect "pass 2 is not a first crawl" "false" "$(field first_crawl)"
 
 # The redirect behind sized.html now points at a much longer target name.
@@ -174,8 +163,7 @@ expect "a failed transfer keeps its bytes" "$resetdigest" \
     "$(digest "${out}/${host}/changes/reset.bin")"
 
 # --- pass 3: the same run with purging on ------------------------------------
-httrack "${common[@]}" -O "$out" --update "${base}/changes/index.html" \
-    >"${tmpdir}/log3" 2>&1
+local_crawl --log "${tmpdir}/log3" "${common[@]}" -O "$out" --update "${BASEURL}/changes/index.html"
 expect "the report says files were purged" "true" "$(field purged)"
 expect "gone is the page that only pass 2 linked" \
     "${host}/changes/transient.html" "$(listed gone | sort)"
@@ -191,8 +179,7 @@ nocache="${tmpdir}/nocache"
 mkdir "$nocache"
 ncreport="${nocache}/hts-changes.json"
 for pass in 1 2; do
-    httrack "${common[@]}" -O "$nocache" -C0 "${base}/changes2/index.html" \
-        >"${tmpdir}/lognc${pass}" 2>&1
+    local_crawl --log "${tmpdir}/lognc${pass}" "${common[@]}" -O "$nocache" -C0 "${BASEURL}/changes2/index.html"
 done
 expect "with no cache first_crawl is undetermined, not guessed" "null" \
     "$(field first_crawl "$ncreport")" "$ncreport"

--- a/tests/94_local-single-file.test
+++ b/tests/94_local-single-file.test
@@ -3,16 +3,13 @@
 # end over a real crawl, decoding the payloads against what the server served.
 set -e
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-server=$(nativepath "${testdir}/local-server.py")
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_713.XXXXXX") || exit 1
-serverpid=
 cleanup() {
-    stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
@@ -66,12 +63,7 @@ printf '<svg xmlns="http://www.w3.org/2000/svg"><circle r="1"/></svg>\n' \
 } >"${doc}/big.svg"
 
 # --- server -----------------------------------------------------------------
-serverlog="${tmpdir}/server.log"
-: >"$serverlog"
-"$python" "$server" --root "$(nativepath "$doc")" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-base="http://127.0.0.1:${port}"
+local_server_start --root "$doc"
 
 which httrack >/dev/null || {
     echo "could not find httrack"
@@ -84,10 +76,9 @@ out="${tmpdir}/crawl"
 mkdir "$out"
 opts=(--quiet --disable-security-limits --robots=0 --timeout=30 --retries=0)
 common=(-O "$out" "${opts[@]}")
-httrack "${common[@]}" --single-file --single-file-max-size 4096 \
-    "${base}/index.html" >"${tmpdir}/log1" 2>&1
+local_crawl --log "${tmpdir}/log1" "${common[@]}" --single-file --single-file-max-size 4096 "${BASEURL}/index.html"
 
-page="${out}/127.0.0.1_${port}/index.html"
+page="${out}/127.0.0.1_${SRV_PORT}/index.html"
 test -f "$page" || {
     echo "FAIL: no mirrored page at $page"
     exit 1
@@ -139,7 +130,7 @@ if grep -q 'data-src="lazy.svg"' "$page"; then
     echo "FAIL: data-src kept its link"
     exit 1
 fi
-test -f "${out}/127.0.0.1_${port}/lazy.svg" || {
+test -f "${out}/127.0.0.1_${SRV_PORT}/lazy.svg" || {
     echo "FAIL: the lazy image was never downloaded, so nothing was proven"
     exit 1
 }
@@ -170,7 +161,7 @@ grep -q 'href="other.html"' "$page" || {
     echo "FAIL: the link to another page was not left relative"
     exit 1
 }
-test -f "${out}/127.0.0.1_${port}/other.html" || {
+test -f "${out}/127.0.0.1_${SRV_PORT}/other.html" || {
     echo "FAIL: the linked page is missing from the mirror"
     exit 1
 }
@@ -204,7 +195,7 @@ grep -q '<link href="style_norel.css">' "$page" || {
     echo "FAIL: a <link> with no rel was inlined"
     exit 1
 }
-test -f "${out}/127.0.0.1_${port}/style_norel.css" || {
+test -f "${out}/127.0.0.1_${SRV_PORT}/style_norel.css" || {
     echo "FAIL: style_norel.css is missing, so the probe proves nothing"
     exit 1
 }
@@ -215,7 +206,7 @@ grep -q 'src="big.svg"' "$page" || {
     echo "FAIL: the over-cap asset did not keep its link"
     exit 1
 }
-test -f "${out}/127.0.0.1_${port}/big.svg" || {
+test -f "${out}/127.0.0.1_${SRV_PORT}/big.svg" || {
     echo "FAIL: the over-cap asset is missing from the mirror"
     exit 1
 }
@@ -230,7 +221,7 @@ if grep -q 'href="style.css"' "$page"; then
     echo "FAIL: the stylesheet link survived"
     exit 1
 fi
-test -f "${out}/127.0.0.1_${port}/style.css" || {
+test -f "${out}/127.0.0.1_${SRV_PORT}/style.css" || {
     echo "FAIL: the mirror lost the standalone stylesheet"
     exit 1
 }
@@ -240,8 +231,7 @@ echo OK
 printf '[idempotent under --update] ..\t'
 # HTTrack stamps the time into its own footer comment, so compare without it.
 grep -v 'Mirrored from' "$page" >"${tmpdir}/page1.html"
-httrack "${common[@]}" --single-file --single-file-max-size 4096 --update \
-    "${base}/index.html" >"${tmpdir}/log2" 2>&1
+local_crawl --log "${tmpdir}/log2" "${common[@]}" --single-file --single-file-max-size 4096 --update "${BASEURL}/index.html"
 grep -v 'Mirrored from' "$page" >"${tmpdir}/page2.html"
 cmp -s "${tmpdir}/page1.html" "${tmpdir}/page2.html" || {
     echo "FAIL: the second run changed the page"
@@ -263,17 +253,16 @@ printf '[-%%Z0 and a bad cap] ..\t'
 # it; a non-numeric cap is rejected and the built-in default used instead.
 off="${tmpdir}/off"
 mkdir "$off"
-httrack -O "$off" "${opts[@]}" -%Z0 "${base}/index.html" >"${tmpdir}/log3" 2>&1
-offpage="${off}/127.0.0.1_${port}/index.html"
+local_crawl --log "${tmpdir}/log3" -O "$off" "${opts[@]}" -%Z0 "${BASEURL}/index.html"
+offpage="${off}/127.0.0.1_${SRV_PORT}/index.html"
 if grep -q 'base64,' "$offpage"; then
     echo "FAIL: -%Z0 still inlined"
     exit 1
 fi
 bad="${tmpdir}/bad"
 mkdir "$bad"
-httrack -O "$bad" "${opts[@]}" --single-file-max-size notanumber \
-    "${base}/index.html" >"${tmpdir}/log4" 2>&1
-badpage="${bad}/127.0.0.1_${port}/index.html"
+local_crawl --log "${tmpdir}/log4" -O "$bad" "${opts[@]}" --single-file-max-size notanumber "${BASEURL}/index.html"
+badpage="${bad}/127.0.0.1_${SRV_PORT}/index.html"
 # The default cap is 10 MB, so everything here inlines, big.svg included.
 grep -q 'data:image/svg+xml;base64,' "$badpage" || {
     echo "FAIL: a rejected cap did not fall back to the default"
@@ -301,7 +290,7 @@ printf '[a mark cannot ride in on a header] ..\t'
 # htsparse echoes the Content-Type charset into a <meta>, a channel the body
 # sweep cannot see, so /sfmark.html serves a mark there. It names pixel.svg, so
 # an expansion would leave a data: URI.
-markpage="${out}/127.0.0.1_${port}/sfmark.html"
+markpage="${out}/127.0.0.1_${SRV_PORT}/sfmark.html"
 test -f "$markpage" || {
     echo "FAIL: the charset-mark page was not mirrored"
     exit 1
@@ -325,7 +314,7 @@ printf '[no file keeps a mark] ..\t'
 # 1 clean, anything above that means the sweep never read the tree.
 st=0
 marked=$(grep -rlE '#![0-9a-f]{16}\.[-cj]\.[0-9]+' \
-    "${out}/127.0.0.1_${port}" 2>/dev/null) || st=$?
+    "${out}/127.0.0.1_$SRV_PORT" 2>/dev/null) || st=$?
 test "$st" -le 1 || {
     echo "FAIL: the mark sweep could not read the mirror (grep exit $st)"
     exit 1
@@ -374,7 +363,7 @@ echo OK
 
 printf '[-%%M refuses to pair with --single-file] ..\t'
 both=$(httrack -O "${tmpdir}/both" --quiet --robots=0 --retries=0 -%M \
-    --single-file "${base}/index.html" 2>&1 || true)
+    --single-file "${BASEURL}/index.html" 2>&1 || true)
 case "$both" in
 *"pick one"*) echo OK ;;
 *)
@@ -390,9 +379,8 @@ chg="${tmpdir}/chg"
 mkdir "$chg"
 # Its own -O: "$common" points at the first mirror, which left $chgpage absent
 # and every check below vacuous.
-httrack -O "$chg" "${opts[@]}" --single-file --changes "${base}/index.html" \
-    >"${tmpdir}/log6" 2>&1
-chgpage="${chg}/127.0.0.1_${port}/index.html"
+local_crawl --log "${tmpdir}/log6" -O "$chg" "${opts[@]}" --single-file --changes "${BASEURL}/index.html"
+chgpage="${chg}/127.0.0.1_${SRV_PORT}/index.html"
 test -f "$chgpage" || {
     echo "FAIL: --changes produced no mirrored page"
     exit 1
@@ -431,10 +419,9 @@ else
     mkdir "$umaskdir"
     (
         umask 077
-        httrack -O "$umaskdir" "${opts[@]}" --single-file \
-            "${base}/index.html" >"${tmpdir}/log5" 2>&1
+        local_crawl --log "${tmpdir}/log5" -O "$umaskdir" "${opts[@]}" --single-file "${BASEURL}/index.html"
     )
-    umaskroot="${umaskdir}/127.0.0.1_${port}"
+    umaskroot="${umaskdir}/127.0.0.1_$SRV_PORT"
     mode() { "$python" -c 'import os,sys
 print("%04o" % (os.stat(sys.argv[1]).st_mode & 0o777))' "$1"; }
     pagemode=$(mode "${umaskroot}/index.html")

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,7 +12,7 @@ EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c a
 	header-injection-server.py header-injection-check.py \
 	pty-resize.py ttyrun.py test-timeout.sh png-colors.py \
 	local-crawl.sh local-server.py ftp-server.py testlib.sh proclib.sh \
-	webhttracklib.sh httpclient.py \
+	webhttracklib.sh httpclient.py crawllib.sh \
 	ci-windows-suite.sh ci-windows-watchdog.ps1 \
 	server.crt server.key \
 	server-root/simple/basic.html server-root/simple/link.html \

--- a/tests/crawllib.sh
+++ b/tests/crawllib.sh
@@ -6,10 +6,19 @@
 # shellcheck source=tests/testlib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
 
+# Reap the server unless it is already gone. A test that stops its own server
+# mid-run leaves the registered cleanup holding a dead pid, and stop_server's
+# Windows path answers an unresolvable pid by killing every python.exe.
+local_server_reap() {
+    kill -0 "$1" 2>/dev/null || return 0
+    stop_server "$1"
+}
+
 # Start local-server.py in the background on an ephemeral port and wait for its
 # "PORT n" line. Sets SRV_PORT, SRV_PID, SRV_LOG and BASEURL, and registers the
-# reaping cleanup. Callable more than once; a caller wanting two servers saves
-# each set before starting the next. Options, ahead of any server argument:
+# reaping cleanup. A second call overwrites all four and truncates the default
+# log, so a caller wanting two servers saves each set and gives each its own
+# --log. Options, ahead of any server argument; -- ends them:
 #   --root DIR    tree to serve (default: the shared server-root fixture)
 #   --log FILE    where the announcement lands (default: $tmpdir/server.log)
 #   --env V=VAL   an environment variable for the server, repeatable
@@ -38,17 +47,19 @@ local_server_start() {
         esac
     done
 
-    test -n "${CRAWLLIB_PYTHON:-}" ||
-        CRAWLLIB_PYTHON=$(find_python) || skip "python3 not found"
+    test -n "${SRV_PYTHON:-}" ||
+        SRV_PYTHON=$(find_python) || skip "python3 not found"
     test -n "$log" || log="${tmpdir:?no tmpdir and no --log}/server.log"
     SRV_LOG=$log
     : >"$SRV_LOG"
 
-    env ${envs[@]+"${envs[@]}"} "$CRAWLLIB_PYTHON" \
+    # Stdin off the terminal: run_with_timeout toggles job control, and a
+    # background job that touches the tty is stopped with SIGTTIN.
+    env ${envs[@]+"${envs[@]}"} "$SRV_PYTHON" \
         "$(nativepath "${testdir}/local-server.py")" \
         --root "$(nativepath "$root")" "$@" >"$SRV_LOG" 2>&1 </dev/null &
     SRV_PID=$!
-    cleanup_push stop_server "$SRV_PID"
+    cleanup_push local_server_reap "$SRV_PID"
 
     SRV_PORT=$(discover_server_port "$SRV_LOG" "$SRV_PID") ||
         fail "local-server did not come up: $(cat "$SRV_LOG")"
@@ -60,16 +71,13 @@ local_server_start() {
 # backstops local-crawl.sh has and most of these tests lacked: a --max-time cap
 # (skipped when the caller sets its own) and a watchdog above it, so a wedge
 # outliving the engine limit reds the test instead of the 45-minute CI timeout.
-#   --deadline N   watchdog seconds (default: CRAWL_DEADLINE, else 180)
-#   --log FILE     crawl output, appended (default: discarded)
+# CRAWL_DEADLINE drives the watchdog, as it does for local-crawl.sh.
+# One option, ahead of any httrack argument; -- ends it:
+#   --log FILE     crawl output (default: discarded)
 local_crawl() {
     local deadline="${CRAWL_DEADLINE:-180}" log=/dev/null arg rc=0
     while test $# -gt 0; do
         case $1 in
-        --deadline)
-            deadline=$2
-            shift 2
-            ;;
         --log)
             log=$2
             shift 2
@@ -88,7 +96,7 @@ local_crawl() {
     done
     args+=("$@")
 
-    run_with_timeout "$deadline" httrack "${args[@]}" >>"$log" 2>&1 || rc=$?
+    run_with_timeout "$deadline" httrack "${args[@]}" >"$log" 2>&1 || rc=$?
     test "$rc" -ne 124 || fail "crawl watchdog fired after ${deadline}s"
     return "$rc"
 }

--- a/tests/crawllib.sh
+++ b/tests/crawllib.sh
@@ -6,19 +6,36 @@
 # shellcheck source=tests/testlib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
 
-# Reap the server unless it is already gone. A test that stops its own server
-# mid-run leaves the registered cleanup holding a dead pid, and stop_server's
-# Windows path answers an unresolvable pid by killing every python.exe.
+# Live servers, in start order; a stopped one leaves an empty slot. cleanup_push
+# expands its arguments at push time, so a teardown holding the pid itself could
+# not be disarmed, and 240 stops its server mid-test on purpose.
+SRV_PIDS=()
+
+# Teardown for the server in slot $1. Signalling a pid the system has since
+# recycled would kill an unrelated process and then stall reap_bounded for its
+# whole grace period, so a slot is read, not a pid.
 local_server_reap() {
-    kill -0 "$1" 2>/dev/null || return 0
+    local pid=${SRV_PIDS[$1]:-}
+    test -n "$pid" || return 0
+    SRV_PIDS[$1]=
+    stop_server "$pid"
+}
+
+# Stop server $1 now and disarm its teardown, for a test whose next step needs
+# the server gone.
+local_server_stop() {
+    local i
+    for ((i = 0; i < ${#SRV_PIDS[@]}; i++)); do
+        test "${SRV_PIDS[$i]:-}" != "$1" || SRV_PIDS[i]=
+    done
     stop_server "$1"
 }
 
 # Start local-server.py in the background on an ephemeral port and wait for its
 # "PORT n" line. Sets SRV_PORT, SRV_PID, SRV_LOG and BASEURL, and registers the
-# reaping cleanup. A second call overwrites all four and truncates the default
-# log, so a caller wanting two servers saves each set and gives each its own
-# --log. Options, ahead of any server argument; -- ends them:
+# reaping cleanup, and appends to SRV_PIDS. A second call overwrites all four
+# and truncates the default
+# log, so a caller wanting two servers saves each set and gives each its own --log. Options, ahead of any server argument; -- ends them:
 #   --root DIR    tree to serve (default: the shared server-root fixture)
 #   --log FILE    where the announcement lands (default: $tmpdir/server.log)
 #   --env V=VAL   an environment variable for the server, repeatable
@@ -59,7 +76,8 @@ local_server_start() {
         "$(nativepath "${testdir}/local-server.py")" \
         --root "$(nativepath "$root")" "$@" >"$SRV_LOG" 2>&1 </dev/null &
     SRV_PID=$!
-    cleanup_push local_server_reap "$SRV_PID"
+    SRV_PIDS+=("$SRV_PID")
+    cleanup_push local_server_reap "$((${#SRV_PIDS[@]} - 1))"
 
     SRV_PORT=$(discover_server_port "$SRV_LOG" "$SRV_PID") ||
         fail "local-server did not come up: $(cat "$SRV_LOG")"

--- a/tests/crawllib.sh
+++ b/tests/crawllib.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+# local-server.py launch and crawl helpers, for the tests that drive the server
+# themselves instead of going through local-crawl.sh. Sourced, not run.
+
+# shellcheck source=tests/testlib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/testlib.sh"
+
+# Start local-server.py in the background on an ephemeral port and wait for its
+# "PORT n" line. Sets SRV_PORT, SRV_PID, SRV_LOG and BASEURL, and registers the
+# reaping cleanup. Callable more than once; a caller wanting two servers saves
+# each set before starting the next. Options, ahead of any server argument:
+#   --root DIR    tree to serve (default: the shared server-root fixture)
+#   --log FILE    where the announcement lands (default: $tmpdir/server.log)
+#   --env V=VAL   an environment variable for the server, repeatable
+# shellcheck disable=SC2120 # most callers want the fixture and no options
+local_server_start() {
+    local root="${testdir}/server-root" log='' envs=()
+    while test $# -gt 0; do
+        case $1 in
+        --root)
+            root=$2
+            shift 2
+            ;;
+        --log)
+            log=$2
+            shift 2
+            ;;
+        --env)
+            envs+=("$2")
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *) break ;;
+        esac
+    done
+
+    test -n "${CRAWLLIB_PYTHON:-}" ||
+        CRAWLLIB_PYTHON=$(find_python) || skip "python3 not found"
+    test -n "$log" || log="${tmpdir:?no tmpdir and no --log}/server.log"
+    SRV_LOG=$log
+    : >"$SRV_LOG"
+
+    env ${envs[@]+"${envs[@]}"} "$CRAWLLIB_PYTHON" \
+        "$(nativepath "${testdir}/local-server.py")" \
+        --root "$(nativepath "$root")" "$@" >"$SRV_LOG" 2>&1 </dev/null &
+    SRV_PID=$!
+    cleanup_push stop_server "$SRV_PID"
+
+    SRV_PORT=$(discover_server_port "$SRV_LOG" "$SRV_PID") ||
+        fail "local-server did not come up: $(cat "$SRV_LOG")"
+    # shellcheck disable=SC2034 # set here for the caller, not used here
+    BASEURL="http://127.0.0.1:${SRV_PORT}"
+}
+
+# Run httrack against the local server, returning its exit status. Carries the
+# backstops local-crawl.sh has and most of these tests lacked: a --max-time cap
+# (skipped when the caller sets its own) and a watchdog above it, so a wedge
+# outliving the engine limit reds the test instead of the 45-minute CI timeout.
+#   --deadline N   watchdog seconds (default: CRAWL_DEADLINE, else 180)
+#   --log FILE     crawl output, appended (default: discarded)
+local_crawl() {
+    local deadline="${CRAWL_DEADLINE:-180}" log=/dev/null arg rc=0
+    while test $# -gt 0; do
+        case $1 in
+        --deadline)
+            deadline=$2
+            shift 2
+            ;;
+        --log)
+            log=$2
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *) break ;;
+        esac
+    done
+
+    local args=(--max-time=120)
+    for arg in "$@"; do
+        case $arg in --max-time | --max-time=*) args=() ;; esac
+    done
+    args+=("$@")
+
+    run_with_timeout "$deadline" httrack "${args[@]}" >>"$log" 2>&1 || rc=$?
+    test "$rc" -ne 124 || fail "crawl watchdog fired after ${deadline}s"
+    return "$rc"
+}


### PR DESCRIPTION
Twenty-two tests drive `tests/local-server.py` themselves rather than through `local-crawl.sh`, and each one rebuilds the same launch: resolve the script, find a python, background it, poll stdout for the ephemeral port, register the reaping, build the base URL. Only three of their crawls carry `--max-time` and none carries a watchdog, so a wedge in this cluster runs until CI cancels the job at 45 minutes, which takes the log with it.

`tests/crawllib.sh` gives them `local_server_start`, which sets `$BASEURL`/`$SRV_PORT`/`$SRV_LOG` and registers its own cleanup, and `local_crawl`, which runs httrack under the existing `run_with_timeout` and adds a `--max-time` cap only when the caller passed none. `258_crawllib.test` covers both from a subject process, since a firing assertion and the library's own reaping each end that process; a 15-mutant matrix on the library reds it 15 times. Before and after `make check` verdicts are identical apart from the new test.

Two files the scripted conversion got wrong, both caught by that diff: 240 stops the server mid-test on purpose, and 56 reads a caller-scope `$python` that `freeport` picks up by dynamic scoping without ever spelling it. `--tls` is left out because `local-crawl.sh` is its only would-be caller and this PR does not convert it, so the option would ship with no caller.
