### PR TITLE
Engine self-tests assert a substring, so the value underneath can change unseen

### DIFF
--- a/tests/01_engine-makeindex.test
+++ b/tests/01_engine-makeindex.test
@@ -10,5 +10,4 @@ set -euo pipefail
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
-httrack -O /dev/null -#test=makeindex "$dir" run |
-    grep -q "makeindex self-test OK"
+assert_selftest "makeindex self-test OK" makeindex "$dir" run

--- a/tests/01_engine-strsafe.test
+++ b/tests/01_engine-strsafe.test
@@ -2,15 +2,14 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # htssafe.h bounded string operations (driven by 'httrack -#test=strsafe').
 
 # Success path: every bounded op (strcpybuff/strcatbuff/strncatbuff/strlcpybuff)
 # must behave correctly. 'run' selects the success path (vs the overflow modes).
-rc=0
-out=$(httrack -#test=strsafe run) || rc=$?
-test "$rc" -eq 0 || exit 1
-test "$out" == "strsafe: OK" || exit 1
+assert_selftest "strsafe: OK" strsafe run
 
 # Overflow path: an over-capacity write into a sized buffer must be caught by
 # the bounded macro and abort the process, not be silently truncated/completed.

--- a/tests/01_engine-structcheck.test
+++ b/tests/01_engine-structcheck.test
@@ -10,5 +10,4 @@ set -euo pipefail
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
-httrack -O /dev/null -#test=structcheck "$dir" |
-    grep -q "structcheck self-test OK"
+assert_selftest "structcheck self-test OK" structcheck "$dir"

--- a/tests/01_engine-topindex.test
+++ b/tests/01_engine-topindex.test
@@ -10,5 +10,4 @@ set -euo pipefail
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
-httrack -O /dev/null -#test=topindex "$dir" run |
-    grep -q "topindex self-test OK"
+assert_selftest "topindex self-test OK" topindex "$dir" run

--- a/tests/01_zlib-acceptencoding.test
+++ b/tests/01_zlib-acceptencoding.test
@@ -9,5 +9,6 @@ set -euo pipefail
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
-httrack -O /dev/null -#test=acceptencoding "$dir" run |
-    grep -q "acceptencoding self-test OK"
+# The advertised codings are the contract, so pin the whole line.
+assert_selftest "acceptencoding self-test OK: gzip, deflate, identity;q=0.9" \
+    acceptencoding "$dir" run

--- a/tests/01_zlib-contentcodings.test
+++ b/tests/01_zlib-contentcodings.test
@@ -9,5 +9,4 @@ set -euo pipefail
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
-httrack -O /dev/null -#test=contentcodings "$dir" run |
-    grep -q "contentcodings self-test OK"
+assert_selftest "contentcodings self-test OK" contentcodings "$dir" run

--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -76,7 +76,11 @@ done
 # shellcheck disable=SC2016 # $env: is PowerShell's, not this shell's
 grep -q '\$env:WATCHDOG_TOKEN' "$wdscript" ||
     fail "the watchdog does not read its token from the environment"
-if sed -n '/^param(/,/^)/p' "$wdscript" | grep -qi 'token'; then
+# Captured, not piped: grep -qi exits on the first match, and the SIGPIPE it
+# sends sed becomes the pipeline's status under pipefail, so a token found
+# here would read as absent.
+params=$(sed -n '/^param(/,/^)/p' "$wdscript")
+if grep -qi 'token' <<<"$params"; then
     fail "the watchdog takes its token as a parameter, where the process list exposes it"
 fi
 grep -q "ApiBase = 'https://api.github.com'" "$wdscript" ||

--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -76,9 +76,8 @@ done
 # shellcheck disable=SC2016 # $env: is PowerShell's, not this shell's
 grep -q '\$env:WATCHDOG_TOKEN' "$wdscript" ||
     fail "the watchdog does not read its token from the environment"
-# Captured, not piped: grep -qi exits on the first match, and the SIGPIPE it
-# sends sed becomes the pipeline's status under pipefail, so a token found
-# here would read as absent.
+# Captured, not piped: grep -qi's early exit can SIGPIPE sed, and pipefail
+# would turn that into "no token found".
 params=$(sed -n '/^param(/,/^)/p' "$wdscript")
 if grep -qi 'token' <<<"$params"; then
     fail "the watchdog takes its token as a parameter, where the process list exposes it"

--- a/tests/237_engine-arrays.test
+++ b/tests/237_engine-arrays.test
@@ -2,15 +2,14 @@
 #
 
 set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 # htsarrays.h growth macros (driven by 'httrack -#test=arrays').
 
 # Success path: growth reaches the requested room and the payload survives
 # every reallocation.
-rc=0
-out=$(httrack -#test=arrays run) || rc=$?
-test "$rc" -eq 0 || exit 1
-test "$out" == "arrays: OK" || exit 1
+assert_selftest "arrays: OK" arrays run
 
 # A hang is the pre-fix symptom here, so bound the runs where the shell can
 # (macOS ships no timeout(1); there the suite watchdog is the backstop).

--- a/tests/255_local-ftp-sigterm.test
+++ b/tests/255_local-ftp-sigterm.test
@@ -6,9 +6,8 @@
 
 set -euo pipefail
 
-testdir=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=tests/testlib.sh
-. "${testdir}/testlib.sh"
+. "$(dirname "$0")/testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 skip_on_windows "MSYS cannot signal a native httrack.exe"


### PR DESCRIPTION
Five engine self-tests asserted their result with a substring grep, which cannot see the value changing underneath it. `01_zlib-acceptencoding` is the demonstration: change the engine's advertised Accept-Encoding from `identity;q=0.9` to `q=0.8` and the old test still passes, because `acceptencoding self-test OK` is still in there somewhere. `assert_selftest` pins the whole line and the exit status and prints want beside got, so the same mutant now reds it. That one now asserts the advertised codings, which nothing did before.

Two more (`strsafe`, `arrays`) already compared the whole line, but through a bare `test ... || exit 1` pair that reds without naming the value that differed; they get the same helper and a diagnostic. Both files also start sourcing `testlib.sh`, which they needed anyway.

The five greps were also pipes into `grep -q`, which AGENTS.md forbids because the producer takes SIGPIPE and `pipefail` turns that into the pipeline's status. Removing them is conformance, not a fix: I checked the remaining site in `226_watchdog-native` by putting a token in the watchdog's param block, and the piped form caught it exactly as the captured form does. At these output sizes the producer finishes writing before `grep` exits, so the trap cannot bite here.

Also drops `255_local-ftp-sigterm`'s own `$testdir`, a verbatim copy of the line `testlib.sh` already runs.
