### PR TITLE
The guide explains a language dropdown that no longer exists

### DIFF
--- a/html/guide.html
+++ b/html/guide.html
@@ -127,8 +127,8 @@ data-for="droid">Tap <b>Next</b></span> to create a project, or open one you alr
 	<figcaption>The welcome screen.</figcaption>
 </figure>
 
-<p class="note" data-for="web">The language dropdown starts blank on purpose: its first entry
-means "leave the interface as it is". Pick a language only if you want to change it.</p>
+<p class="note" data-for="web">The dropdown shows the language the interface is already in.
+Picking another one reloads the page in it.</p>
 
 <p class="note" data-for="web">On macOS, <code>brew install httrack</code> installs WebHTTrack
 alongside the command line tool. Open <b>HTTrack.app</b> if you have it, or run


### PR DESCRIPTION
The guide's WebHTTrack note told readers the language menu opens blank because its first entry means "leave the interface as it is". #1086 dropped that placeholder: the menu now shows the language in force, and picking another reloads the page in it. The reshot screenshot in #1124 already showed the new behaviour, so the note contradicted the picture next to it.

Nothing else in the guide needed touching for either reshoot. The Windows layout change (panes follow the window) is entirely visual, and no prose describes pane positions.
