### PR TITLE
The WebHTTrack masthead never got the tagline-bar fix the doc pages did

### DIFF
--- a/html/server/style.css
+++ b/html/server/style.css
@@ -6,8 +6,15 @@ body, td {
 	font: 14px "Trebuchet MS", Verdana, Arial, Helvetica, sans-serif;
 	}
 
+/* Take back the whitespace the SVG carries around the letters, so the bar sits on
+   the wordmark's baseline as it does on the doc pages (html/doc.css). */
+#title {
+	display: block;
+	margin: -1.7px 0 -1.1px;
+	}
+
 #subTitle {
-	background: #000;  color: #fff;  padding: 4px;  font-weight: bold; 
+	background: #000;  color: #fff;  padding: 4px;  font-weight: bold;
 	}
 
 .tabCtrl {


### PR DESCRIPTION
The same wordmark-over-tagline masthead is rendered by two stylesheets that know nothing about each other: `html/doc.css` for the documentation pages and `html/server/style.css` for the WebHTTrack UI. #927 and #1111 cancelled the whitespace the SVG carries around the letters, and both landed in `doc.css` alone, so the web GUI kept the sliver of background between the wordmark's baseline and the black bar.

Same rule, ported to `#title`. Verified by geometry rather than by eye: `getBoundingClientRect` in one browser gave bar top minus image bottom of 0 on the server pages against -1.09 on a doc page, and -1.09 on both afterwards.

`exit.html` is the one server page with no wordmark, so it is unaffected. The WebHTTrack doc screenshots want a reshoot after this lands, since every one of them carries the masthead.
