### PR TITLE
WebHTTrack is advertised in software centres with a screenshot from 3.30

### DIFF
--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -44,7 +44,9 @@
   <screenshots>
     <screenshot type="default">
       <caption>Choosing the addresses and options for a new mirror</caption>
-      <image>https://www.httrack.com/html/images/screenshot_01b.jpg</image>
+      <!-- A guide asset, so every screenshot reshoot refreshes this too.
+           appstream-network.yml resolves the URL weekly if the name moves. -->
+      <image>https://www.httrack.com/html/img/guide-web-project-setup.png</image>
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1"/>


### PR DESCRIPTION
Points the WebHTTrack metainfo at a current screenshot. The old one, `screenshot_01b.jpg`, is a 300x238 JPEG of the UI in a Mozilla window on Windows 98 chrome, unchanged since 3.30.1, and it is what GNOME Software, KDE Discover and Flathub show.

The replacement is a guide asset rather than a new file, so every future reshoot refreshes the software-centre listing on its own. The cost is a filename `doc-images.py` generates; `appstream-network.yml` resolves the URL weekly if that ever moves.

Draft until the site deploy: the URL 404s today and resolves once httrack-com #57 goes out. The merge gate, which doubles as proof this is not cosmetic:

```
appstreamcli validate --explain html/server/div/com.httrack.WebHTTrack.metainfo.xml
```

It fails right now with `screenshot-image-not-found` and has to pass before this lands. The per-PR lint runs `--no-net` and is already green on this branch, which is exactly why it cannot be the gate.

Closes #1128
