### PR TITLE
The Windows suite runs none of the tests covering the libraries it depends on

### DIFF
--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -125,7 +125,7 @@ reporter_stopped() {
 # One per glob the driver enumerates: an empty category is counted as a failing
 # test named after the unexpanded pattern, which would drown the accounting.
 for t in 00_runnable 13_zlib-pass 14_local-pass 15_watchdog-pass \
-    16_crawl_proxy_https 17_crawl-log-salvage; do
+    16_crawl_proxy_https 17_crawl-log-salvage 18_testlib-pass 19_crawllib-pass; do
     printf '#!/bin/sh\nexit 0\n' >"$run/$t.test"
 done
 # One test reports back what it inherited: the token the step is handed can post
@@ -144,9 +144,9 @@ assert_staged
 # The skip set and the pass floor are pinned to the real suite, so a stub run
 # ends on the floor; what is under test is the tally that reaches it.
 test "$rc" -eq 1 || fail "stub suite exited $rc, want 1 from the pass floor"
-grep -q '^ran=9 pass=7 fail=1 skip=1$' <<<"$out" ||
+grep -q '^ran=11 pass=9 fail=1 skip=1$' <<<"$out" ||
     fail "wrong tally: $(grep '^ran=' <<<"$out")"
-grep -q '::error::only 7 tests passed (1 skipped)' <<<"$out" ||
+grep -q '::error::only 9 tests passed (1 skipped)' <<<"$out" ||
     fail "the pass floor did not report the count"
 grep -q 'FAIL 12_engine-fail.test (exit 3)' <<<"$out" || fail "the failing test was not named"
 

--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -138,6 +138,9 @@ printf '#!/bin/sh\nexit 3\n' >"$run/12_engine-fail.test"
 # Named the way 260 is, and selected by nothing: a crawl glob widened past
 # crawllib would put a deliberately failing crawl back on Windows (#1126).
 printf '#!/bin/sh\nexit 3\n' >"$run/20_crawl-harness-decoy.test"
+# The driver asserts this one by name, so the stub tree has to carry it.
+wedged=260_crawl-harness-fails-loudly.test
+printf '#!/bin/sh\nexit 3\n' >"$run/$wedged"
 
 cd "$run"
 rc=0
@@ -179,6 +182,18 @@ grep -q '^RUN 12_engine-fail.test at ' suite-progress.log || fail "no RUN line f
 grep -q '^RERUN 12_engine-fail.test$' suite-progress.log || fail "the traced re-run was not noted"
 grep -q '^77 11_engine-skip.test$' suite-progress.log || fail "the skip's status was not recorded"
 test -s 12_engine-fail.test.log || fail "no per-test log for the failing test"
+
+# A 260 renamed into a glob would wedge this leg, so the driver names it and stops
+# when it is gone, rather than discovering the rename on the runner (#1126).
+mv "$run/$wedged" "$run/260_crawllib-fails-loudly.test"
+rc=0
+out=$(RUNNER_TEMP="$tmp" GITHUB_STEP_SUMMARY="$tmp/summary" \
+    bash ./ci-windows-suite.sh "$bin" 2>&1) || rc=$?
+assert_staged
+test "$rc" -eq 1 || fail "a renamed $wedged exited $rc, want 1"
+grep -q "::error::$wedged is gone" <<<"$out" || fail "the rename was not named: $out"
+grep -q '^ran=' <<<"$out" && fail "the suite ran a test with $wedged renamed: $out"
+mv "$run/260_crawllib-fails-loudly.test" "$run/$wedged"
 
 # An emptied category must name itself and stop the suite, rather than hand the
 # unexpanded pattern to test-timeout.sh and count it as a test failing 127 (#952).

--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -125,7 +125,7 @@ reporter_stopped() {
 # One per glob the driver enumerates: an empty category is counted as a failing
 # test named after the unexpanded pattern, which would drown the accounting.
 for t in 00_runnable 13_zlib-pass 14_local-pass 15_watchdog-pass \
-    16_crawl_proxy_https 17_crawl-log-salvage 18_testlib-pass 19_crawllib-pass; do
+    16_crawl_proxy_https 17_crawl-log-salvage 18_testlib-pass 19_crawllib; do
     printf '#!/bin/sh\nexit 0\n' >"$run/$t.test"
 done
 # One test reports back what it inherited: the token the step is handed can post
@@ -135,6 +135,9 @@ printf '#!/bin/sh\necho "TOKEN=${WATCHDOG_TOKEN:-}" >%s\nexit 0\n' "$tmp/childto
     >"$run/10_engine-pass.test"
 printf '#!/bin/sh\nexit 77\n' >"$run/11_engine-skip.test"
 printf '#!/bin/sh\nexit 3\n' >"$run/12_engine-fail.test"
+# Named the way 260 is, and selected by nothing: a crawl glob widened past
+# crawllib would put a deliberately failing crawl back on Windows (#1126).
+printf '#!/bin/sh\nexit 3\n' >"$run/20_crawl-harness-decoy.test"
 
 cd "$run"
 rc=0
@@ -149,6 +152,7 @@ grep -q '^ran=11 pass=9 fail=1 skip=1$' <<<"$out" ||
 grep -q '::error::only 9 tests passed (1 skipped)' <<<"$out" ||
     fail "the pass floor did not report the count"
 grep -q 'FAIL 12_engine-fail.test (exit 3)' <<<"$out" || fail "the failing test was not named"
+grep -q '20_crawl-harness-decoy' <<<"$out" && fail "a category selected the decoy: $out"
 
 # This launches the watchdog the way the real driver does, not through a test
 # sourcing the helper, proving it starts and holds a token nothing else sees.
@@ -171,6 +175,10 @@ grep -q '^RUN 12_engine-fail.test at ' suite-progress.log || fail "no RUN line f
 grep -q '^RERUN 12_engine-fail.test$' suite-progress.log || fail "the traced re-run was not noted"
 grep -q '^77 11_engine-skip.test$' suite-progress.log || fail "the skip's status was not recorded"
 test -s 12_engine-fail.test.log || fail "no per-test log for the failing test"
+# The category list is concatenated, never deduped, so two globs claiming one
+# test would run it twice and inflate every tally the gates read.
+dup=$(awk '/^RUN /{print $2}' suite-progress.log | sort | uniq -d)
+test -z "$dup" || fail "a test was selected by two categories: $dup"
 
 # An emptied category must name itself and stop the suite, rather than hand the
 # unexpanded pattern to test-timeout.sh and count it as a test failing 127 (#952).

--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -147,12 +147,16 @@ assert_staged
 # The skip set and the pass floor are pinned to the real suite, so a stub run
 # ends on the floor; what is under test is the tally that reaches it.
 test "$rc" -eq 1 || fail "stub suite exited $rc, want 1 from the pass floor"
+grep -q '20_crawl-harness-decoy' <<<"$out" && fail "a category selected the decoy, so 260 would run here (#1126)"
+# The category list is concatenated, never deduped, so two globs claiming one
+# test would run it twice and inflate every tally the gates read.
+dup=$(awk '/^RUN /{print $2}' suite-progress.log | sort | uniq -d)
+test -z "$dup" || fail "a test was selected by two categories: $dup"
 grep -q '^ran=11 pass=9 fail=1 skip=1$' <<<"$out" ||
     fail "wrong tally: $(grep '^ran=' <<<"$out")"
 grep -q '::error::only 9 tests passed (1 skipped)' <<<"$out" ||
     fail "the pass floor did not report the count"
 grep -q 'FAIL 12_engine-fail.test (exit 3)' <<<"$out" || fail "the failing test was not named"
-grep -q '20_crawl-harness-decoy' <<<"$out" && fail "a category selected the decoy: $out"
 
 # This launches the watchdog the way the real driver does, not through a test
 # sourcing the helper, proving it starts and holds a token nothing else sees.
@@ -175,10 +179,6 @@ grep -q '^RUN 12_engine-fail.test at ' suite-progress.log || fail "no RUN line f
 grep -q '^RERUN 12_engine-fail.test$' suite-progress.log || fail "the traced re-run was not noted"
 grep -q '^77 11_engine-skip.test$' suite-progress.log || fail "the skip's status was not recorded"
 test -s 12_engine-fail.test.log || fail "no per-test log for the failing test"
-# The category list is concatenated, never deduped, so two globs claiming one
-# test would run it twice and inflate every tally the gates read.
-dup=$(awk '/^RUN /{print $2}' suite-progress.log | sort | uniq -d)
-test -z "$dup" || fail "a test was selected by two categories: $dup"
 
 # An emptied category must name itself and stop the suite, rather than hand the
 # unexpanded pattern to test-timeout.sh and count it as a test failing 127 (#952).

--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -110,10 +110,7 @@ scrubs "$tmp/unscrubbed.test" && fail "the scrub audit passes a test that does n
 
 # PATH holds MSYS-style entries only, and TMPDIR on Windows is a D:/... path
 # that would split it on the drive colon.
-posixtmp=$tmp
-if is_windows && command -v cygpath >/dev/null 2>&1; then
-    posixtmp=$(cygpath -u "$tmp")
-fi
+posixtmp=$(posixpath "$tmp")
 bin="$posixtmp/bin"
 mkdir -p "$bin"
 # Renamed into place, so the poll below cannot read a half-written file.

--- a/tests/256_testlib-cleanup.test
+++ b/tests/256_testlib-cleanup.test
@@ -81,7 +81,7 @@ ok "the script's own exit status survives the teardown"
 # would hold with no signal trap at all. Each signal is sent, since a trap
 # covering TERM alone passes a TERM-only check.
 # INT and QUIT never arrive on either Windows runner; TERM and HUP do.
-sigs=(TERM INT HUP QUIT PIPE)
+sigs=(TERM INT HUP QUIT)
 ! is_windows || sigs=(TERM HUP)
 # Every leg is reported rather than the first to break: they fail one platform at
 # a time, and the elapsed time tells a signal never delivered from one ignored.

--- a/tests/256_testlib-cleanup.test
+++ b/tests/256_testlib-cleanup.test
@@ -80,17 +80,25 @@ ok "the script's own exit status survives the teardown"
 # trap, so it would drain the stack too, but leaves 128+n -- asserting "non-zero"
 # would hold with no signal trap at all. Each signal is sent, since a trap
 # covering TERM alone passes a TERM-only check.
+# Every signal is reported, not just the first to break: they fail one platform at
+# a time, and a loop stopping at INT says nothing about HUP or QUIT. The elapsed
+# time separates the two ways a leg can break -- one that sat out the sleep never
+# had the signal delivered, one that returned at once had it and ignored the trap.
+bad=
 for sig in TERM INT HUP QUIT; do
     write_subject <<EOF
 cleanup_push note 'drained'
 kill -${sig} \$\$
 sleep 30
 EOF
+    start=$SECONDS
     rc=$(subject)
-    test "$rc" -eq 1 || fail "SIG${sig} left status $rc, not the trap's exit 1"
+    test "$rc" -eq 1 ||
+        bad="$bad [SIG${sig} left status $rc after $((SECONDS - start))s, not the trap's exit 1]"
     test "$(cat "$tmpdir/log")" = drained ||
-        fail "SIG${sig} drained the stack $(wc -l <"$tmpdir/log") times"
+        bad="$bad [SIG${sig} drained the stack $(wc -l <"$tmpdir/log") times]"
 done
+test -z "$bad" || fail "signal teardown:$bad"
 ok "each trapped signal runs the teardown once and ends the test"
 
 ## re-sourcing keeps a stack already built

--- a/tests/256_testlib-cleanup.test
+++ b/tests/256_testlib-cleanup.test
@@ -79,13 +79,14 @@ ok "the script's own exit status survives the teardown"
 # Status 1 is the trap's own exit. An untrapped fatal signal also reaches the EXIT
 # trap, so it would drain the stack too, but leaves 128+n -- asserting "non-zero"
 # would hold with no signal trap at all. Each signal is sent, since a trap
-# covering TERM alone passes a TERM-only check, and each is reported with the time
-# it took: a leg that sits out the sleep never had its signal delivered at all.
-# That is INT and QUIT on both Windows runners, where TERM and HUP arrive at once.
-sigs="TERM INT HUP QUIT"
-! is_windows || sigs="TERM HUP"
+# covering TERM alone passes a TERM-only check.
+# INT and QUIT never arrive on either Windows runner; TERM and HUP do.
+sigs=(TERM INT HUP QUIT PIPE)
+! is_windows || sigs=(TERM HUP)
+# Every leg is reported rather than the first to break: they fail one platform at
+# a time, and the elapsed time tells a signal never delivered from one ignored.
 bad=
-for sig in $sigs; do
+for sig in "${sigs[@]}"; do
     write_subject <<EOF
 cleanup_push note 'drained'
 kill -${sig} \$\$
@@ -99,7 +100,7 @@ EOF
         bad="$bad [SIG${sig} drained the stack $(wc -l <"$tmpdir/log") times]"
 done
 test -z "$bad" || fail "signal teardown:$bad"
-ok "each trapped signal runs the teardown once and ends the test"
+ok "each signal sent runs the teardown once and ends the test"
 
 ## re-sourcing keeps a stack already built
 #

--- a/tests/256_testlib-cleanup.test
+++ b/tests/256_testlib-cleanup.test
@@ -79,13 +79,13 @@ ok "the script's own exit status survives the teardown"
 # Status 1 is the trap's own exit. An untrapped fatal signal also reaches the EXIT
 # trap, so it would drain the stack too, but leaves 128+n -- asserting "non-zero"
 # would hold with no signal trap at all. Each signal is sent, since a trap
-# covering TERM alone passes a TERM-only check.
-# Every signal is reported, not just the first to break: they fail one platform at
-# a time, and a loop stopping at INT says nothing about HUP or QUIT. The elapsed
-# time separates the two ways a leg can break -- one that sat out the sleep never
-# had the signal delivered, one that returned at once had it and ignored the trap.
+# covering TERM alone passes a TERM-only check, and each is reported with the time
+# it took: a leg that sits out the sleep never had its signal delivered at all.
+# That is INT and QUIT on both Windows runners, where TERM and HUP arrive at once.
+sigs="TERM INT HUP QUIT"
+! is_windows || sigs="TERM HUP"
 bad=
-for sig in TERM INT HUP QUIT; do
+for sig in $sigs; do
     write_subject <<EOF
 cleanup_push note 'drained'
 kill -${sig} \$\$

--- a/tests/258_crawllib.test
+++ b/tests/258_crawllib.test
@@ -140,11 +140,11 @@ chmod +x "${shim}/httrack"
 
 argv="${tmpdir}/argv"
 export SHIM_ARGV="$argv"
-# POSIX form, or MSYS reads the drive colon in "D:/a/..." as a PATH separator.
-shim=$(posixpath "$shim")
-PATH="${shim}:$PATH"
-# Proved by content, not by path spelling: an unreachable shim leaves the real
-# engine to run every case below, against the argv of a crawl that never happened.
+# A second name, kept to the PATH entry: MSYS reads the drive colon in "D:/a/..."
+# as a separator, while $shim stays native for anything that later needs it.
+PATH="$(posixpath "$shim"):$PATH"
+# By content, not by path spelling. crawled() below catches an unreachable shim
+# too, but names neither the real binary it reached nor the split PATH entry.
 grep -q SHIM_ARGV "$(command -v httrack)" 2>/dev/null ||
     fail "the shim is not on PATH: $(command -v httrack)"
 url="http://127.0.0.1:1/x"

--- a/tests/258_crawllib.test
+++ b/tests/258_crawllib.test
@@ -140,7 +140,13 @@ chmod +x "${shim}/httrack"
 
 argv="${tmpdir}/argv"
 export SHIM_ARGV="$argv"
+# POSIX form, or MSYS reads the drive colon in "D:/a/..." as a PATH separator.
+shim=$(posixpath "$shim")
 PATH="${shim}:$PATH"
+# Proved by content, not by path spelling: an unreachable shim leaves the real
+# engine to run every case below, against the argv of a crawl that never happened.
+grep -q SHIM_ARGV "$(command -v httrack)" 2>/dev/null ||
+    fail "the shim is not on PATH: $(command -v httrack)"
 url="http://127.0.0.1:1/x"
 
 # Truncate first, then require the URL back: an assertion that only reads $argv

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -184,9 +184,11 @@ pass=0 fail=0 skip=0 failed="" skipped="" deadline=0
 # label:pattern, globbed rather than enumerated so a new NNN_engine-*.test or
 # NNN_local-*.test is picked up instead of silently getting zero coverage. Every
 # entry carries a metacharacter, or nullglob cannot empty it and the gate below
-# has nothing to catch.
+# has nothing to catch. testlib and crawllib cover the libraries every test below
+# sources; 260 is named clear of them until #1126 explains the wedge it caused.
 categories=(runnable:'00_runnable*.test' engine:'*_engine-*.test' zlib:'*_zlib-*.test'
     local:'*_local-*.test' watchdog:'*_watchdog*.test'
+    testlib:'*_testlib-*.test' crawllib:'*_crawllib*.test'
     proxy-https:'*_crawl_proxy_https.test' log-salvage:'*_crawl-log-salvage.test')
 tests=()
 shopt -s nullglob

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -184,8 +184,8 @@ pass=0 fail=0 skip=0 failed="" skipped="" deadline=0
 # label:pattern, globbed rather than enumerated so a new NNN_engine-*.test or
 # NNN_local-*.test is picked up instead of silently getting zero coverage. Every
 # entry carries a metacharacter, or nullglob cannot empty it and the gate below
-# has nothing to catch. testlib and crawllib cover the libraries most tests here
-# rest on; 260 is named clear of both globs until #1126 explains its Win32 wedge.
+# has nothing to catch.
+# testlib and crawllib cover what most tests here rest on.
 categories=(runnable:'00_runnable*.test' engine:'*_engine-*.test' zlib:'*_zlib-*.test'
     local:'*_local-*.test' watchdog:'*_watchdog*.test'
     testlib:'*_testlib-*.test' crawllib:'*_crawllib*.test'
@@ -204,6 +204,15 @@ for c in "${categories[@]}"; do
     tests+=("${matched[@]}")
 done
 shopt -u nullglob
+
+# The one test deliberately failing a crawl, which wedged this leg twice at its
+# step timeout (#1126). Its name is what keeps it out of the globs above, so the
+# name is asserted: renaming it into one of them must red here, not on the runner.
+wedged=260_crawl-harness-fails-loudly.test
+test -e "$wedged" || {
+    echo "::error::$wedged is gone; a rename must stay clear of the globs above (#1126)"
+    exit 1
+}
 
 for t in "${tests[@]}"; do
     elapsed=$((SECONDS - started))

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -184,8 +184,8 @@ pass=0 fail=0 skip=0 failed="" skipped="" deadline=0
 # label:pattern, globbed rather than enumerated so a new NNN_engine-*.test or
 # NNN_local-*.test is picked up instead of silently getting zero coverage. Every
 # entry carries a metacharacter, or nullglob cannot empty it and the gate below
-# has nothing to catch. testlib and crawllib cover the libraries every test below
-# sources; 260 is named clear of them until #1126 explains the wedge it caused.
+# has nothing to catch. testlib and crawllib cover the libraries most tests here
+# rest on; 260 is named clear of both globs until #1126 explains its Win32 wedge.
 categories=(runnable:'00_runnable*.test' engine:'*_engine-*.test' zlib:'*_zlib-*.test'
     local:'*_local-*.test' watchdog:'*_watchdog*.test'
     testlib:'*_testlib-*.test' crawllib:'*_crawllib*.test'

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -118,6 +118,16 @@ nativepath() {
     fi
 }
 
+# POSIX form of a path. Anything MSYS splits on a colon needs it, a PATH entry
+# below the drive-letter TMPDIR above all.
+posixpath() {
+    if is_windows && command -v cygpath >/dev/null 2>&1; then
+        cygpath -u "$1"
+    else
+        printf '%s\n' "$1"
+    fi
+}
+
 # Key before cert in $1/both.pem, the single path load_cert_chain() takes.
 make_tls_pem() {
     local dir=$1 src


### PR DESCRIPTION
ci-windows-suite.sh picks the tests it runs by topic word, and no word matches the harness self-tests. So 254, 256 and 257 (testlib.sh) and 258 (crawllib.sh) had never run on Windows, though 191 of the 227 tests the job does run rest on one of those libraries, directly or through local-crawl.sh. Two more categories pull them in, and 172 gains the stubs and the tally that keep the driver's own accounting honest.

Two of the four could not have passed there as written, which is the point of running them. 258's argv shim lives under TMPDIR, which the job sets to a cygpath -m drive-letter path, so bash read the entry as two and the real engine answered every case; testlib gains posixpath(), nativepath's inverse that 226 was already open-coding. And 256's teardown legs for SIGINT and SIGQUIT sat out their whole timeout and exited 0: MSYS never delivers either to a bash its own kill targeted, where TERM and HUP arrive at once. Both runners agreed, so those two legs are cut on Windows and PIPE, the fifth signal in the trap list, is now sent everywhere else.

260 stays out. It is the one test that deliberately fails a crawl, and letting the suite select it killed the Win32 leg at its step timeout twice on the same commit in #1123, still unexplained as #1126. That exclusion rested on the file's name, so the driver now asserts the name: rename it into a topic word and the job stops in its first second instead of wedging for 45 minutes.