### PR TITLE
The software-centre screenshot advertises a loopback address

### DIFF
--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -43,10 +43,12 @@
   </developer>
   <screenshots>
     <screenshot type="default">
-      <caption>Choosing the addresses and options for a new mirror</caption>
+      <caption>Choosing which files a mirror includes</caption>
       <!-- A guide asset, so every screenshot reshoot refreshes this too.
-           appstream-network.yml resolves the URL weekly if the name moves. -->
-      <image>https://www.httrack.com/html/img/guide-web-project-setup.png</image>
+           appstream-network.yml resolves the URL weekly if the name moves.
+           Not a wizard pane: the walk crawls a loopback server, so every pane
+           showing the address advertises 127.0.0.1 and an ephemeral port. -->
+      <image>https://www.httrack.com/html/img/guide-web-opt-scan-rules.png</image>
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1"/>


### PR DESCRIPTION
#1130 pointed the metainfo at the URL wizard pane without anyone looking at the image. That pane has exactly one piece of user content, the address box, and the screenshot walk crawls a throwaway loopback server, so the hero image in GNOME Software, KDE Discover and Flathub reads `http://127.0.0.1:43925/`. Poor advertising for a tool whose pitch is copying sites off the internet.

The scan-rules pane carries no address and shows something worth seeing, the wildcard include and exclude syntax. Caption follows the new content. Networked `appstreamcli validate` passes, so the asset is deployed.

This is the stopgap. The wizard panes are the natural hero, and they stay unusable until the walk can crawl a named host; the same loopback string is also in front of every reader of `guide.html`, which is the larger reason to fix it at the source rather than picking around the affected screens.
