### PR TITLE
The documentation screenshots advertise 127.0.0.1 and a random port

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -52,6 +52,15 @@ jobs:
           pip install --quiet playwright
           playwright install --with-deps chromium
 
+      # The address is on screen in the wizard panes and names the mirror folder,
+      # so the crawl needs a presentable host rather than 127.0.0.1 and a random
+      # port. example.com is reserved for documentation (RFC 2606).
+      - name: Let the crawl address a named site on port 80
+        run: |
+          set -euo pipefail
+          echo "127.0.0.1 www.example.com" | sudo tee -a /etc/hosts
+          sudo sysctl -w net.ipv4.ip_unprivileged_port_start=80  # bind 80 unprivileged
+
       - name: Capture
         env:
           LANGN: ${{ inputs.lang || '1' }}
@@ -61,6 +70,7 @@ jobs:
           # --root is the dist root; the source tree already holds every piece
           # htsserver reads, so this needs no install.
           python3 tools/screenshot-walk.py --htsserver src/htsserver --root . \
+            --site-host www.example.com --site-port 80 \
             --lang "$LANGN" --scale "$SCALE" --out shots
 
       - name: Upload the screens

--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -68,10 +68,18 @@ class SiteHandler(BaseHTTPRequestHandler):
         pass
 
 
-def start_site():
-    httpd = ThreadingHTTPServer(("127.0.0.1", 0), SiteHandler)
+def start_site(host, port):
+    """Serve the site on loopback, addressed as `host` so the shots read like a site.
+
+    `host` only names the server; it has to resolve to 127.0.0.1 for the crawl to
+    reach it. Port 80 is left out of the URL, and needs the caller to have made it
+    bindable (see the screenshots workflow).
+    """
+    httpd = ThreadingHTTPServer(("127.0.0.1", port), SiteHandler)
     threading.Thread(target=httpd.serve_forever, daemon=True).start()
-    return httpd, "http://127.0.0.1:%d/" % httpd.socket.getsockname()[1]
+    bound = httpd.socket.getsockname()[1]
+    where = host if bound == 80 else "%s:%d" % (host, bound)
+    return httpd, "http://%s/" % where
 
 
 def free_port():
@@ -235,6 +243,17 @@ def main():
         "--lang", type=int, default=1, help="lang.indexes number (1 = English)"
     )
     ap.add_argument("--home", help="$HOME to run under; default is a throwaway one")
+    ap.add_argument(
+        "--site-host",
+        default="127.0.0.1",
+        help="name the crawled site answers to; must resolve to 127.0.0.1",
+    )
+    ap.add_argument(
+        "--site-port",
+        type=int,
+        default=0,
+        help="port to serve it on (default: any free one)",
+    )
     ap.add_argument("--width", type=int, default=1024)
     ap.add_argument("--height", type=int, default=768)
     ap.add_argument("--scale", type=float, default=2.0, help="device pixel ratio")
@@ -249,7 +268,7 @@ def main():
 
     from playwright.sync_api import sync_playwright
 
-    site, site_url = start_site()
+    site, site_url = start_site(args.site_host, args.site_port)
     # A pristine HOME by default: an existing mirror would finish from cache in
     # no time and turn the progress shot into a second copy of the finished
     # screen, and the project list would show whatever the host had lying

--- a/tools/screenshots.md
+++ b/tools/screenshots.md
@@ -22,6 +22,13 @@ python3 tools/screenshot-walk.py --htsserver src/htsserver --root . --out shots
 `--root` is the dist root — the directory holding `lang.def`, `lang.indexes`,
 `lang/` and `html/`. A source tree qualifies, so nothing has to be installed first.
 
+A local run addresses the crawl as `127.0.0.1` on a random port, and that string is
+on screen in the wizard panes and names the mirror folder. The workflow instead maps
+`www.example.com` in `/etc/hosts` and lowers `net.ipv4.ip_unprivileged_port_start`
+so the site can answer on 80, which is what `--site-host` and `--site-port` are for.
+Shots meant for publication want that treatment; anything else is a developer
+artifact on display.
+
 ## Adding a screen
 
 Nothing to edit for an option page: the tabs are enumerated from the tab bar and


### PR DESCRIPTION
The walk crawls a site it serves to itself on loopback, so the address it types into the wizard is `http://127.0.0.1:43925/`. That string is on screen in the URL pane and the add-URL popup, and it names the mirror folder on the finished screen, so it reaches every reader of `guide.html` and, until #1132, the image software centres show for WebHTTrack.

`--site-host` and `--site-port` let the walk address its own server by name. The workflow maps `www.example.com` to loopback and lowers `net.ipv4.ip_unprivileged_port_start` so the site can answer on 80 without running anything as root, which drops the port from the URL too. `example.com` is the domain reserved for documentation (RFC 2606). A local run with neither flag behaves as before.

Verified end to end rather than by reading the format string: a run with `--site-host localhost` reaches the server through the name and the URL pane comes out `http://localhost:33553/`. This PR does not regenerate the shots; the next reshoot picks the treatment up, and the wizard panes become usable as the software-centre image again.
