### PR TITLE
Put the URL pane back as the software-centre screenshot

### DIFF
--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -43,12 +43,11 @@
   </developer>
   <screenshots>
     <screenshot type="default">
-      <caption>Choosing which files a mirror includes</caption>
+      <caption>Choosing the addresses and options for a new mirror</caption>
       <!-- A guide asset, so every screenshot reshoot refreshes this too.
-           appstream-network.yml resolves the URL weekly if the name moves.
-           Not a wizard pane: the walk crawls a loopback server, so every pane
-           showing the address advertises 127.0.0.1 and an ephemeral port. -->
-      <image>https://www.httrack.com/html/img/guide-web-opt-scan-rules.png</image>
+           appstream-network.yml resolves the URL weekly if the name moves; it
+           cannot see a stale deploy, since the name survives a reshoot. -->
+      <image>https://www.httrack.com/html/img/guide-web-project-setup.png</image>
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1"/>


### PR DESCRIPTION
#1132 pointed the metainfo at the scan-rules pane as a stopgap, because the walk crawled a loopback server and so every wizard pane advertised `http://127.0.0.1:43925/`. #1133 fixed the walk, #1135 reshot the set, and the site now serves the reshot bytes, so the URL pane is usable again and is the more legible image for someone browsing a software centre.

Gated on the bytes, not the URL: `guide-web-project-setup.png` hashes `97dcb5ddd05469ad` both on the wire and in the tree. That check matters here because the filename never changed through any of this, so a resolving URL and a green `appstreamcli` would both have been satisfied by the stale deploy.
