### PR TITLE
htsrandom: OSX typedefs u_int in sys/random.h

### DIFF
--- a/src/htsrandom.c
+++ b/src/htsrandom.c
@@ -40,7 +40,7 @@ Please visit our Website: http://www.httrack.com
 #else
 #include <errno.h>
 #include <stdio.h>
-#ifdef HAVE_SYS_RANDOM_H
+#if defined(HAVE_SYS_RANDOM_H) && defined(HAVE_GETRANDOM)
 #include <sys/random.h>
 #endif
 #endif


### PR DESCRIPTION
On OSX, building httrack fails to build since it typedefs `u_int` when `sys/random.h` is included. However, htsrandom.c doesn't use functions provided by `sys/random.h` in OSX and macOS; `sys/random.h` provides `getrandom` on other UNIX-based systems, only.

As such, we should only include `sys/random.h` when both `HAVE_SYS_RANDOM_H` and `HAVE_GETRANDOM` are defined; you can have `sys/random.h` and not have `getrandom`.

This was a recently experienced issue in [MacPorts when upgrading `httrack` to 3.49.19](https://github.com/macports/macports-ports/pull/33981), where a quick and dirty patch was created. Tested on macOS 10.7.5 11G63 x86_64 Xcode 4.6.3 4H1503.