### PR TITLE
Wizard domain answers match beyond the domain

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3395,6 +3395,65 @@ static int st_urlhack(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* The filter each wizard answer emits, printed for an ad-hoc <n> <adr> <fil>
+   [up], asserted against the expected patterns otherwise (#1119). */
+static int st_wizardfilter(httrackp *opt, int argc, char **argv) {
+  char pattern[HTS_URLMAXSIZE * 2];
+  htsbuff f = htsbuff_array(pattern);
+
+  (void) opt;
+  if (argc >= 3) {
+    wizard_answer_filter(&f, atoi(argv[0]), argv[1], argv[2],
+                         argc >= 4 && atoi(argv[3]) != 0 ? HTS_TRUE
+                                                         : HTS_FALSE);
+    printf("%s\n", pattern);
+    return 0;
+  }
+#define EMITS(n, adr, fil, up, expect)                                         \
+  do {                                                                         \
+    wizard_answer_filter(&f, (n), (adr), (fil), (up));                         \
+    assertf(strcmp(pattern, (expect)) == 0);                                   \
+  } while (0)
+
+  /* the host-wide answers: 2 forbids, 5 (allowed to go up) and 6 authorize */
+  EMITS(2, "foo.com", "/index.html", HTS_FALSE, "-foo.com/*");
+  EMITS(5, "foo.com", "/dir/page.html", HTS_TRUE, "+foo.com/*");
+  EMITS(6, "foo.com", "/dir/page.html", HTS_FALSE, "+foo.com/*");
+  /* the port is part of the host, the credentials are not */
+  EMITS(6, "foo.com:8080", "/x", HTS_FALSE, "+foo.com:8080/*");
+  EMITS(6, "user:pass@foo.com", "/x", HTS_FALSE, "+foo.com/*");
+
+  /* the trailing slash is what keeps a longer host out */
+  assertf(strjoker("foo.com/index.html", pattern + 1, NULL, NULL) != NULL);
+  assertf(strjoker("foo.com/", pattern + 1, NULL, NULL) != NULL);
+  assertf(strjoker("foo.com.evil.org/x", pattern + 1, NULL, NULL) == NULL);
+  assertf(strjoker("foo.com:8080/x", pattern + 1, NULL, NULL) == NULL);
+
+  /* the link and directory answers, unchanged */
+  EMITS(0, "foo.com", "/dir/page.html", HTS_FALSE, "-foo.com/dir/page.html");
+  EMITS(0, "foo.com", "index.html", HTS_FALSE, "-foo.com/index.html");
+  EMITS(1, "foo.com", "/dir/page.html", HTS_FALSE, "-foo.com/dir/*");
+  EMITS(1, "foo.com", "/page.html", HTS_FALSE, "-foo.com/*");
+  EMITS(5, "foo.com", "/dir/page.html", HTS_FALSE, "+foo.com/dir/*");
+  EMITS(7, "foo.com", "/dir/page.html", HTS_FALSE, "+foo.com/dir/*[file]");
+  /* answer 1 collapses a doubled trailing slash, answers 5 and 7 keep it */
+  EMITS(1, "foo.com", "/dir//page.html", HTS_FALSE, "-foo.com/dir/*");
+  EMITS(5, "foo.com", "/dir//page.html", HTS_FALSE, "+foo.com/dir//*");
+  /* no directory to anchor on, so answers 1, 5 and 7 emit nothing */
+  EMITS(1, "foo.com", "page.html", HTS_FALSE, "");
+  EMITS(5, "foo.com", "page.html", HTS_FALSE, "");
+  EMITS(7, "foo.com", "page.html", HTS_FALSE, "");
+
+  /* the answers that add no filter at all */
+  EMITS(-1, "foo.com", "/x", HTS_FALSE, "");
+  EMITS(3, "foo.com", "/x", HTS_FALSE, "");
+  EMITS(4, "foo.com", "/x", HTS_FALSE, "");
+  EMITS(50, "foo.com", "/x", HTS_FALSE, "");
+#undef EMITS
+  printf("wizardfilter self-test OK\n");
+  return 0;
+}
+
 /* #159: hts_redirect_same_savefile decides whether a redirect is a same-file
  * alias. */
 static int st_redirect_samefile(httrackp *opt, int argc, char **argv) {
@@ -8868,6 +8927,8 @@ static const struct selftest_entry {
      st_urlhack},
     {"redirect-samefile", "", "same-file redirect detection self-test (#159)",
      st_redirect_samefile},
+    {"wizardfilter", "[<answer> <adr> <fil> [up]]",
+     "filter emitted by a wizard answer", st_wizardfilter},
     {"mime", "<filename>", "MIME type for a filename", st_mime},
     {"charset", "<charset> <hex:..|string>",
      "convert a string to UTF-8 from a charset", st_charset},

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3395,23 +3395,23 @@ static int st_urlhack(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-/* The filter each wizard answer emits, printed for an ad-hoc <n> <adr> <fil>
-   [up], asserted against the expected patterns otherwise (#1119). */
+/* Prints the filter answer <n> emits for (adr, fil) [up]; with no arguments,
+   asserts every answer against its expected pattern (#1119). */
 static int st_wizardfilter(httrackp *opt, int argc, char **argv) {
   char pattern[HTS_URLMAXSIZE * 2];
   htsbuff f = htsbuff_array(pattern);
 
   (void) opt;
   if (argc >= 3) {
-    wizard_answer_filter(&f, atoi(argv[0]), argv[1], argv[2],
-                         argc >= 4 && atoi(argv[3]) != 0 ? HTS_TRUE
-                                                         : HTS_FALSE);
+    hts_wizard_answer_filter(&f, atoi(argv[0]), argv[1], argv[2],
+                             argc >= 4 && atoi(argv[3]) != 0 ? HTS_TRUE
+                                                             : HTS_FALSE);
     printf("%s\n", pattern);
     return 0;
   }
 #define EMITS(n, adr, fil, up, expect)                                         \
   do {                                                                         \
-    wizard_answer_filter(&f, (n), (adr), (fil), (up));                         \
+    hts_wizard_answer_filter(&f, (n), (adr), (fil), (up));                     \
     assertf(strcmp(pattern, (expect)) == 0);                                   \
   } while (0)
 
@@ -3420,6 +3420,10 @@ static int st_wizardfilter(httrackp *opt, int argc, char **argv) {
   EMITS(5, "foo.com", "/dir/page.html", HTS_TRUE, "+foo.com/*");
   EMITS(6, "foo.com", "/dir/page.html", HTS_FALSE, "+foo.com/*");
   /* the port is part of the host, the credentials are not */
+  EMITS(2, "foo.com:8080", "/x", HTS_FALSE, "-foo.com:8080/*");
+  EMITS(2, "user:pass@foo.com", "/x", HTS_FALSE, "-foo.com/*");
+  EMITS(5, "foo.com:8080", "/x", HTS_TRUE, "+foo.com:8080/*");
+  EMITS(5, "user:pass@foo.com", "/x", HTS_TRUE, "+foo.com/*");
   EMITS(6, "foo.com:8080", "/x", HTS_FALSE, "+foo.com:8080/*");
   EMITS(6, "user:pass@foo.com", "/x", HTS_FALSE, "+foo.com/*");
 
@@ -3429,7 +3433,7 @@ static int st_wizardfilter(httrackp *opt, int argc, char **argv) {
   assertf(strjoker("foo.com.evil.org/x", pattern + 1, NULL, NULL) == NULL);
   assertf(strjoker("foo.com:8080/x", pattern + 1, NULL, NULL) == NULL);
 
-  /* the link and directory answers, unchanged */
+  /* the link and directory answers */
   EMITS(0, "foo.com", "/dir/page.html", HTS_FALSE, "-foo.com/dir/page.html");
   EMITS(0, "foo.com", "index.html", HTS_FALSE, "-foo.com/index.html");
   EMITS(1, "foo.com", "/dir/page.html", HTS_FALSE, "-foo.com/dir/*");
@@ -3439,6 +3443,7 @@ static int st_wizardfilter(httrackp *opt, int argc, char **argv) {
   /* answer 1 collapses a doubled trailing slash, answers 5 and 7 keep it */
   EMITS(1, "foo.com", "/dir//page.html", HTS_FALSE, "-foo.com/dir/*");
   EMITS(5, "foo.com", "/dir//page.html", HTS_FALSE, "+foo.com/dir//*");
+  EMITS(7, "foo.com", "/dir//page.html", HTS_FALSE, "+foo.com/dir//*[file]");
   /* no directory to anchor on, so answers 1, 5 and 7 emit nothing */
   EMITS(1, "foo.com", "page.html", HTS_FALSE, "");
   EMITS(5, "foo.com", "page.html", HTS_FALSE, "");

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -181,8 +181,8 @@ static void wizard_cat_path(htsbuff *f, const char *sign, const char *adr,
   htsbuff_catn(f, fil, len);
 }
 
-void wizard_answer_filter(htsbuff *f, int n, const char *adr, const char *fil,
-                          hts_boolean seeker_up) {
+void hts_wizard_answer_filter(htsbuff *f, int n, const char *adr,
+                              const char *fil, hts_boolean seeker_up) {
   size_t dir = hts_lastcharoffset(fil);
 
   while (fil[dir] != '/' && dir > 0)
@@ -825,14 +825,14 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
         break;
       } // switch
 
-      /* the answers that add a filter emit it here */
+      /* the pattern half of the answer: a new answer needs both switches */
       {
         char BIGSTK pattern[HTS_FILTER_SLOT_SIZE];
         htsbuff f = htsbuff_array(pattern);
 
-        wizard_answer_filter(&f, n, adr, fil,
-                             (opt->seeker & HTS_SEEKER_UP) != 0 ? HTS_TRUE
-                                                                : HTS_FALSE);
+        hts_wizard_answer_filter(
+            &f, n, adr, fil,
+            (opt->seeker & HTS_SEEKER_UP) != 0 ? HTS_TRUE : HTS_FALSE);
         if (f.len != 0) {
           HT_INSERT_FILTERS0; // insert at slot 0
           strlcpybuff(_FILTERS[0], pattern, HTS_FILTER_SLOT_SIZE);

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -166,6 +166,78 @@ hts_boolean hts_robots_forbids(httrackp *opt, const char *adr, const char *fil,
   return HTS_TRUE;
 }
 
+/* "<sign><host>", with any user:password@ stripped. */
+static void wizard_cat_host(htsbuff *f, const char *sign, const char *adr) {
+  htsbuff_cpy(f, sign);
+  htsbuff_cat(f, jump_identification_const(adr));
+}
+
+/* "<sign><host>/" then the first len characters of fil ((size_t) -1: all). */
+static void wizard_cat_path(htsbuff *f, const char *sign, const char *adr,
+                            const char *fil, size_t len) {
+  wizard_cat_host(f, sign, adr);
+  if (*fil != '/')
+    htsbuff_cat(f, "/");
+  htsbuff_catn(f, fil, len);
+}
+
+void wizard_answer_filter(htsbuff *f, int n, const char *adr, const char *fil,
+                          hts_boolean seeker_up) {
+  size_t dir = hts_lastcharoffset(fil);
+
+  while (fil[dir] != '/' && dir > 0)
+    dir--;
+
+  htsbuff_cpy(f, "");
+  switch (n) {
+  case 0: /* this link only */
+    wizard_cat_path(f, "-", adr, fil, (size_t) -1);
+    break;
+
+  case 1: /* this directory and below */
+    if (fil[dir] == '/') {
+      /* stops before the last slash, so a doubled one collapses */
+      wizard_cat_path(f, "-", adr, fil, dir);
+      if (f->buf[f->len - 1] != '/')
+        htsbuff_cat(f, "/");
+      htsbuff_cat(f, "*");
+    }
+    break;
+
+  case 2: /* the whole host */
+    wizard_cat_host(f, "-", adr);
+    htsbuff_cat(f, "/*");
+    break;
+
+  case 5: /* this directory and below, or the whole host */
+    if (!seeker_up) {
+      if (fil[dir] == '/') {
+        wizard_cat_path(f, "+", adr, fil, dir + 1);
+        htsbuff_cat(f, "*");
+      }
+    } else {
+      wizard_cat_host(f, "+", adr);
+      htsbuff_cat(f, "/*");
+    }
+    break;
+
+  case 6: /* the whole host */
+    wizard_cat_host(f, "+", adr);
+    htsbuff_cat(f, "/*");
+    break;
+
+  case 7: /* this directory, files only */
+    if (fil[dir] == '/') {
+      wizard_cat_path(f, "+", adr, fil, dir + 1);
+      htsbuff_cat(f, "*[file]");
+    }
+    break;
+
+  default: /* the other answers add no filter */
+    break;
+  }
+}
+
 static int hts_acceptlink_(httrackp * opt, int ptr,
                            const char *adr, const char *fil, const char *tag,
                            const char *attribute, int *set_prio_to,
@@ -710,55 +782,9 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
         opt->wizard = HTS_WIZARD_AUTO; // sauter tout le reste
         break;
       case 0: // forbid the same link: adr/fil
-        forbidden_url = 1;
-        HT_INSERT_FILTERS0; // insert at slot 0
-        {
-          htsbuff f = htsbuff_ptr(_FILTERS[0], HTS_FILTER_SLOT_SIZE);
-
-          htsbuff_cpy(&f, "-");
-          htsbuff_cat(&f, jump_identification_const(adr));
-          if (*fil != '/')
-            htsbuff_cat(&f, "/");
-          htsbuff_cat(&f, fil);
-        }
-        break;
-
       case 1: // forbid the whole directory and subdirs: adr/path/*
+      case 2: // the whole address: adr/*
         forbidden_url = 1;
-        {
-          size_t i = hts_lastcharoffset(fil);
-
-          while((fil[i] != '/') && (i > 0))
-            i--;
-          if (fil[i] == '/') {
-            htsbuff f;
-
-            HT_INSERT_FILTERS0; // insert at slot 0
-            f = htsbuff_ptr(_FILTERS[0], HTS_FILTER_SLOT_SIZE);
-            htsbuff_cpy(&f, "-");
-            htsbuff_cat(&f, jump_identification_const(adr));
-            if (*fil != '/')
-              htsbuff_cat(&f, "/");
-            htsbuff_catn(&f, fil, i);
-            if (f.len > 0 && f.buf[f.len - 1] != '/')
-              htsbuff_cat(&f, "/");
-            htsbuff_cat(&f, "*");
-          }
-        }
-
-        // ** ...
-        break;
-
-      case 2: // the whole address: adr*
-        forbidden_url = 1;
-        HT_INSERT_FILTERS0; // insert at slot 0
-        {
-          htsbuff f = htsbuff_ptr(_FILTERS[0], HTS_FILTER_SLOT_SIZE);
-
-          htsbuff_cpy(&f, "-");
-          htsbuff_cat(&f, jump_identification_const(adr));
-          htsbuff_cat(&f, "*");
-        }
         break;
 
       case 3:                  // ** A FAIRE
@@ -790,74 +816,28 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
 
         break;
 
-      case 5: // allow the whole directory and its children
-        if ((opt->seeker & HTS_SEEKER_UP) == 0) { // not allowed to go up
-          size_t i = hts_lastcharoffset(fil);
-
-          while((fil[i] != '/') && (i > 0))
-            i--;
-          if (fil[i] == '/') {
-            HT_INSERT_FILTERS0; // insert at slot 0
-            {
-              htsbuff f = htsbuff_ptr(_FILTERS[0], HTS_FILTER_SLOT_SIZE);
-
-              htsbuff_cpy(&f, "+");
-              htsbuff_cat(&f, jump_identification_const(adr));
-              if (*fil != '/')
-                htsbuff_cat(&f, "/");
-              htsbuff_catn(&f, fil, i + 1);
-              htsbuff_cat(&f, "*");
-            }
-          }
-        } else {              // then allow the domain
-          HT_INSERT_FILTERS0; // insert at slot 0
-          {
-            htsbuff f = htsbuff_ptr(_FILTERS[0], HTS_FILTER_SLOT_SIZE);
-
-            htsbuff_cpy(&f, "+");
-            htsbuff_cat(&f, jump_identification_const(adr));
-            htsbuff_cat(&f, "*");
-          }
-        }
-        break;
-
-      case 6:                  // same domain
-        HT_INSERT_FILTERS0;    // insert at slot 0
-        {
-          htsbuff f = htsbuff_ptr(_FILTERS[0], HTS_FILTER_SLOT_SIZE);
-
-          htsbuff_cpy(&f, "+");
-          htsbuff_cat(&f, jump_identification_const(adr));
-          htsbuff_cat(&f, "*");
-        }
-        break;
-        //
+      case 5: // allow the whole directory and its children, or the domain
+      case 6: // same domain
       case 7: // allow this directory
+        break;
+
+      case 50: // nothing to do
+        break;
+      } // switch
+
+      /* the answers that add a filter emit it here */
       {
-        size_t i = hts_lastcharoffset(fil);
+        char BIGSTK pattern[HTS_FILTER_SLOT_SIZE];
+        htsbuff f = htsbuff_array(pattern);
 
-        while ((fil[i] != '/') && (i > 0))
-          i--;
-        if (fil[i] == '/') {
+        wizard_answer_filter(&f, n, adr, fil,
+                             (opt->seeker & HTS_SEEKER_UP) != 0 ? HTS_TRUE
+                                                                : HTS_FALSE);
+        if (f.len != 0) {
           HT_INSERT_FILTERS0; // insert at slot 0
-          {
-            htsbuff f = htsbuff_ptr(_FILTERS[0], HTS_FILTER_SLOT_SIZE);
-
-            htsbuff_cpy(&f, "+");
-            htsbuff_cat(&f, jump_identification_const(adr));
-            if (*fil != '/')
-              htsbuff_cat(&f, "/");
-            htsbuff_catn(&f, fil, i + 1);
-            htsbuff_cat(&f, "*[file]");
-          }
+          strlcpybuff(_FILTERS[0], pattern, HTS_FILTER_SLOT_SIZE);
         }
       }
-
-      break;
-
-      case 50:                 // on fait rien
-        break;
-      }                         // switch 
 
     }                           // test du wizard sur l'url
   }                             // fin du test wizard..

--- a/src/htswizard.h
+++ b/src/htswizard.h
@@ -57,13 +57,11 @@ hts_boolean hts_robots_forbids(httrackp *opt, const char *adr, const char *fil,
                                hts_boolean filters_decided,
                                hts_boolean filters_refused);
 
-/* Build into `f` the filter the wizard's answer `n` adds for the link
-   (adr,fil), or leave it empty when that answer adds none. `seeker_up` is the
-   HTS_SEEKER_UP bit of opt->seeker, which answer 5 reads. A host-wide answer
-   puts a slash before the wildcard, anchoring it on the host so foo.com does
-   not also accept foo.com.evil.org (#1119). */
-void wizard_answer_filter(htsbuff *f, int n, const char *adr, const char *fil,
-                          hts_boolean seeker_up);
+/* Builds into `f` the filter answer `n` adds for the link (adr,fil), and leaves
+   `f` empty when the answer adds none. `seeker_up` is the HTS_SEEKER_UP bit of
+   opt->seeker, read by answer 5. */
+void hts_wizard_answer_filter(htsbuff *f, int n, const char *adr,
+                              const char *fil, hts_boolean seeker_up);
 
 /* A (tag, attribute) pair naming a reference kind. */
 #ifndef HTS_DEF_DEFSTRUCT_htspair_t

--- a/src/htswizard.h
+++ b/src/htswizard.h
@@ -38,6 +38,7 @@ Please visit our Website: http://www.httrack.com
 #ifdef HTS_INTERNAL_BYTECODE
 
 #include "htsglobal.h"
+#include "htssafe.h"
 
 /* Forward definitions */
 #ifndef HTS_DEF_FWSTRUCT_httrackp
@@ -55,6 +56,14 @@ typedef struct lien_url lien_url;
 hts_boolean hts_robots_forbids(httrackp *opt, const char *adr, const char *fil,
                                hts_boolean filters_decided,
                                hts_boolean filters_refused);
+
+/* Build into `f` the filter the wizard's answer `n` adds for the link
+   (adr,fil), or leave it empty when that answer adds none. `seeker_up` is the
+   HTS_SEEKER_UP bit of opt->seeker, which answer 5 reads. A host-wide answer
+   puts a slash before the wildcard, anchoring it on the host so foo.com does
+   not also accept foo.com.evil.org (#1119). */
+void wizard_answer_filter(htsbuff *f, int n, const char *adr, const char *fil,
+                          hts_boolean seeker_up);
 
 /* A (tag, attribute) pair naming a reference kind. */
 #ifndef HTS_DEF_DEFSTRUCT_htspair_t

--- a/tests/264_engine-wizard-filter.test
+++ b/tests/264_engine-wizard-filter.test
@@ -6,9 +6,8 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "$(dirname "$0")/testlib.sh"
 
-# #1119: the wizard answers that cover a whole host must anchor on it. The
-# emitted patterns are asserted in the self-test; here the host-wide one is fed
-# back to the matcher, which is what decides whether a link is authorized.
+# #1119: the self-test asserts the emitted patterns, this feeds the host-wide
+# one back through the matcher that decides whether a link is authorized.
 
 # 2 forbids the host, 5 (allowed to go up) and 6 authorize it
 assert_selftest "-foo.com/*" wizardfilter 2 foo.com /a/b.html

--- a/tests/264_engine-wizard-filter.test
+++ b/tests/264_engine-wizard-filter.test
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+# #1119: the wizard answers that cover a whole host must anchor on it. The
+# emitted patterns are asserted in the self-test; here the host-wide one is fed
+# back to the matcher, which is what decides whether a link is authorized.
+
+# 2 forbids the host, 5 (allowed to go up) and 6 authorize it
+assert_selftest "-foo.com/*" wizardfilter 2 foo.com /a/b.html
+assert_selftest "+foo.com/*" wizardfilter 5 foo.com /a/b.html 1
+assert_selftest "+foo.com/*" wizardfilter 6 foo.com /a/b.html
+
+pattern=$(httrack -O /dev/null -#test=wizardfilter 6 foo.com /a/b.html)
+pattern=${pattern#+}
+assert_selftest "foo.com/b.html does match $pattern" filter "$pattern" foo.com/b.html
+assert_selftest "foo.com/ does match $pattern" filter "$pattern" foo.com/
+assert_selftest "foo.com.evil.org/x does NOT match $pattern" filter "$pattern" foo.com.evil.org/x
+
+# answers 0, 1, 5 (no up), 7, the ones adding nothing, credentials and port
+assert_selftest "wizardfilter self-test OK" wizardfilter


### PR DESCRIPTION
Three of the wizard's answers built their host filter as `<host>*`, with nothing between the host and the wildcard, so `+foo.com*` also authorized `foo.com.evil.org`. Answering "mirror all links located on the same domain" on a page linking to such a host pulled it into the mirror. Answer 5's allow-the-domain branch had the same shape, and answer 2's exclude over-excluded for the same reason. All three now emit `<host>/*`, and nothing is lost at the bare-host end because both forms the wizard matches against insert a `/` after the host.

This is a visible behavior change: someone who answered "same domain" and relied on the loose match will now see fewer hosts accepted.

To make the emission testable without a crawl, it moved out of the answer switch into `wizard_answer_filter()`, which `-#test=wizardfilter` drives from tests/264. A differential against the old inline code over answers, hosts and paths came back with only the three intended changes; answer 1's collapse of a doubled slash is preserved and pinned by the test.

Closes #1119
