### PR TITLE
cleanup_push traps a SIGPIPE the runners never let it see

### DIFF
--- a/tests/256_testlib-cleanup.test
+++ b/tests/256_testlib-cleanup.test
@@ -84,9 +84,12 @@ want=$(printf '%s\n' "${trapped[@]}" | sort | tr '\n' ' ')
 got=$(sed -n "s/.*run_cleanups; exit 1' //p" "$testdir/testlib.sh" | tr ' ' '\n' | sort | tr '\n' ' ')
 assert_eq "$want" "$got" "cleanup_push's trap line names a signal no leg below sends"
 
-write_subject <<'EOF'
+# Redirected, never piped: a pipeline element is a subshell, and bash 3.2 resets its
+# traps at the fork, so "trap -p |" reads back empty on macOS.
+write_subject <<EOF
 cleanup_push true
-trap -p | awk '/run_cleanups/ && $NF != "EXIT" { sub(/^SIG/, "", $NF); print $NF }' | sort | tr '\n' ' '
+trap -p >"$tmpdir/traps"
+awk '/run_cleanups/ && \$NF != "EXIT" { sub(/^SIG/, "", \$NF); print \$NF }' "$tmpdir/traps" | sort | tr '\n' ' '
 EOF
 rc=$(subject)
 test "$rc" -eq 0 || fail "the subject exited $rc: $(cat "$tmpdir/out")"

--- a/tests/256_testlib-cleanup.test
+++ b/tests/256_testlib-cleanup.test
@@ -74,19 +74,10 @@ test "$rc" -eq 3 || fail "exit 3 was reported as $rc"
 test -s "$tmpdir/log" || fail "the teardown was skipped on a non-zero exit"
 ok "the script's own exit status survives the teardown"
 
-## a signal drains once, and through the library's own trap
+## the trap list is the one this test knows
 #
-# Status 1 is the trap's own exit. An untrapped fatal signal also reaches the EXIT
-# trap, so it would drain the stack too, but leaves 128+n -- asserting "non-zero"
-# would hold with no signal trap at all. Each signal is sent, since a trap
-# covering TERM alone passes a TERM-only check.
-# INT and QUIT never arrive on either Windows runner; TERM and HUP do.
+# Read back live, so a signal added to the library with no leg below goes red (#1136).
 trapped=(HUP INT QUIT TERM)
-sigs=("${trapped[@]}")
-! is_windows || sigs=(TERM HUP)
-
-# What the library traps is read back, not assumed: PIPE sat in that list untested
-# for as long as the list was only ever read by eye (#1136).
 write_subject <<'EOF'
 cleanup_push true
 trap -p | awk '$NF != "EXIT" { sub(/^SIG/, "", $NF); print $NF }' | sort | tr '\n' ' '
@@ -94,8 +85,18 @@ EOF
 rc=$(subject)
 test "$rc" -eq 0 || fail "the subject exited $rc: $(cat "$tmpdir/out")"
 assert_eq "$(printf '%s\n' "${trapped[@]}" | sort | tr '\n' ' ')" "$(cat "$tmpdir/out")" \
-    "cleanup_push traps a signal no leg below sends"
-ok "every signal cleanup_push traps has a leg here"
+    "cleanup_push's trap list is not the one this test knows"
+ok "cleanup_push traps no signal unknown to this test"
+
+## a signal drains once, and through the library's own trap
+#
+# Status 1 is the trap's own exit. An untrapped fatal signal also reaches the EXIT
+# trap, so it would drain the stack too, but leaves 128+n -- asserting "non-zero"
+# would hold with no signal trap at all. Each signal is sent, since a trap
+# covering TERM alone passes a TERM-only check.
+# INT and QUIT never arrive on either Windows runner; TERM and HUP do.
+sigs=("${trapped[@]}")
+! is_windows || sigs=(TERM HUP)
 
 # Every leg is reported rather than the first to break: they fail one platform at
 # a time, and the elapsed time tells a signal never delivered from one ignored.

--- a/tests/256_testlib-cleanup.test
+++ b/tests/256_testlib-cleanup.test
@@ -81,8 +81,22 @@ ok "the script's own exit status survives the teardown"
 # would hold with no signal trap at all. Each signal is sent, since a trap
 # covering TERM alone passes a TERM-only check.
 # INT and QUIT never arrive on either Windows runner; TERM and HUP do.
-sigs=(TERM INT HUP QUIT)
+trapped=(HUP INT QUIT TERM)
+sigs=("${trapped[@]}")
 ! is_windows || sigs=(TERM HUP)
+
+# What the library traps is read back, not assumed: PIPE sat in that list untested
+# for as long as the list was only ever read by eye (#1136).
+write_subject <<'EOF'
+cleanup_push true
+trap -p | awk '$NF != "EXIT" { sub(/^SIG/, "", $NF); print $NF }' | sort | tr '\n' ' '
+EOF
+rc=$(subject)
+test "$rc" -eq 0 || fail "the subject exited $rc: $(cat "$tmpdir/out")"
+assert_eq "$(printf '%s\n' "${trapped[@]}" | sort | tr '\n' ' ')" "$(cat "$tmpdir/out")" \
+    "cleanup_push traps a signal no leg below sends"
+ok "every signal cleanup_push traps has a leg here"
+
 # Every leg is reported rather than the first to break: they fail one platform at
 # a time, and the elapsed time tells a signal never delivered from one ignored.
 bad=

--- a/tests/256_testlib-cleanup.test
+++ b/tests/256_testlib-cleanup.test
@@ -76,24 +76,12 @@ ok "the script's own exit status survives the teardown"
 
 ## the trap list is the one this test knows
 #
-# Read twice: the names on the trap line, then what the shell installed. The second
-# is blind to a signal inherited ignored, which is how the runners hand PIPE down,
-# and the first is blind to a trap line that never runs (#1136).
+# The names on the trap line, not what a shell installed off it: which of them it
+# accepts is bash's business, and the legs below already prove the ones they send.
 trapped=(HUP INT QUIT TERM)
 want=$(printf '%s\n' "${trapped[@]}" | sort | tr '\n' ' ')
 got=$(sed -n "s/.*run_cleanups; exit 1' //p" "$testdir/testlib.sh" | tr ' ' '\n' | sort | tr '\n' ' ')
 assert_eq "$want" "$got" "cleanup_push's trap line names a signal no leg below sends"
-
-# Redirected, never piped: a pipeline element is a subshell, and bash 3.2 resets its
-# traps at the fork, so "trap -p |" reads back empty on macOS.
-write_subject <<EOF
-cleanup_push true
-trap -p >"$tmpdir/traps"
-awk '/run_cleanups/ && \$NF != "EXIT" { sub(/^SIG/, "", \$NF); print \$NF }' "$tmpdir/traps" | sort | tr '\n' ' '
-EOF
-rc=$(subject)
-test "$rc" -eq 0 || fail "the subject exited $rc: $(cat "$tmpdir/out")"
-assert_eq "$want" "$(cat "$tmpdir/out")" "cleanup_push did not install every trap it names"
 ok "cleanup_push traps no signal unknown to this test"
 
 ## a signal drains once, and through the library's own trap

--- a/tests/256_testlib-cleanup.test
+++ b/tests/256_testlib-cleanup.test
@@ -76,16 +76,21 @@ ok "the script's own exit status survives the teardown"
 
 ## the trap list is the one this test knows
 #
-# Read back live, so a signal added to the library with no leg below goes red (#1136).
+# Read twice: the names on the trap line, then what the shell installed. The second
+# is blind to a signal inherited ignored, which is how the runners hand PIPE down,
+# and the first is blind to a trap line that never runs (#1136).
 trapped=(HUP INT QUIT TERM)
+want=$(printf '%s\n' "${trapped[@]}" | sort | tr '\n' ' ')
+got=$(sed -n "s/.*run_cleanups; exit 1' //p" "$testdir/testlib.sh" | tr ' ' '\n' | sort | tr '\n' ' ')
+assert_eq "$want" "$got" "cleanup_push's trap line names a signal no leg below sends"
+
 write_subject <<'EOF'
 cleanup_push true
-trap -p | awk '$NF != "EXIT" { sub(/^SIG/, "", $NF); print $NF }' | sort | tr '\n' ' '
+trap -p | awk '/run_cleanups/ && $NF != "EXIT" { sub(/^SIG/, "", $NF); print $NF }' | sort | tr '\n' ' '
 EOF
 rc=$(subject)
 test "$rc" -eq 0 || fail "the subject exited $rc: $(cat "$tmpdir/out")"
-assert_eq "$(printf '%s\n' "${trapped[@]}" | sort | tr '\n' ' ')" "$(cat "$tmpdir/out")" \
-    "cleanup_push's trap list is not the one this test knows"
+assert_eq "$want" "$(cat "$tmpdir/out")" "cleanup_push did not install every trap it names"
 ok "cleanup_push traps no signal unknown to this test"
 
 ## a signal drains once, and through the library's own trap

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -81,8 +81,8 @@ cleanup_push() {
     CLEANUP_ARGV+=("$@")
     test "${#CLEANUP_FRAMES[@]}" -eq 1 || return 0
     trap 'set +e; run_cleanups' EXIT
-    # No PIPE: bash cannot trap what it inherited ignored, which is how the runners
-    # hand it down, and a real one drains through the EXIT trap anyway (#1136).
+    # No PIPE: bash cannot trap a signal it inherited as ignored, which is how the
+    # runners hand SIGPIPE down, and a real one drains via the EXIT trap (#1136).
     trap 'set +e; run_cleanups; exit 1' HUP INT QUIT TERM
 }
 

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -81,7 +81,9 @@ cleanup_push() {
     CLEANUP_ARGV+=("$@")
     test "${#CLEANUP_FRAMES[@]}" -eq 1 || return 0
     trap 'set +e; run_cleanups' EXIT
-    trap 'set +e; run_cleanups; exit 1' HUP INT QUIT PIPE TERM
+    # No PIPE: bash cannot trap what it inherited ignored, which is how the runners
+    # hand it down, and a real one drains through the EXIT trap anyway (#1136).
+    trap 'set +e; run_cleanups; exit 1' HUP INT QUIT TERM
 }
 
 # Drains the stack, so the EXIT trap after a signal is a no-op. Both slices carry


### PR DESCRIPTION
Settles #1136 as (b): PIPE leaves cleanup_push's trap list.

A non-interactive bash cannot trap a signal it inherited as ignored, and that is how the ubuntu runners hand SIGPIPE down, so `trap -p PIPE` reads back `trap -- '' SIGPIPE` and the entry was inert on the very hosts it was meant to cover. `perl -e '$SIG{PIPE}="IGNORE"; system("bash", ...)'` reproduces the CI red exactly: the subject sits out its full 30s sleep and exits 0. The container and macOS legs passed because their process ancestry resets the disposition. Even where it installed the entry bought nothing, since bash runs the EXIT trap for a fatal PIPE and the stack drains either way; only QUIT needs its own trap, because a non-interactive shell ignores it.

256 now reads the trap list back out of a live subject and checks it against the list it knows, so the next signal added without a leg goes red. Putting PIPE back makes that new case fail.

Closes #1136