### PR TITLE
An aborted --update run purges against the files it never reached

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -545,6 +545,7 @@ int httpmirror(char *url1, httrackp * opt) {
   int retcode = 1; // return code for the single exit; a bailout sets -1
   hts_boolean rollback = HTS_FALSE;  // set to roll back the cache at cleanup
   hts_boolean completed = HTS_FALSE; // set once the crawl loop reaches its end
+  hts_boolean aborted = HTS_FALSE; // set when it stops with links left instead
 
   //
   int numero_passe = 0;         // deux passes pour html puis images
@@ -2069,8 +2070,12 @@ int httpmirror(char *url1, httrackp * opt) {
         }
       }
     }
+    /* links left here means new.lst is only a partial view of the mirror */
+    const hts_boolean links_left = ptr < opt->lien_tot;
+
     // a-t-on dépassé le quota?
     if (!back_checkmirror(opt)) {
+      aborted = links_left;
       ptr = opt->lien_tot;
     } else if (opt->state.exit_xh) {    // sortir
       if (opt->state.exit_xh == 1) {
@@ -2078,6 +2083,7 @@ int httpmirror(char *url1, httrackp * opt) {
       } else {
         hts_log_print(opt, LOG_ERROR, "Exit requested by engine");
       }
+      aborted = links_left;
       ptr = opt->lien_tot;
     }
   } while(ptr < opt->lien_tot);
@@ -2119,8 +2125,15 @@ int httpmirror(char *url1, httrackp * opt) {
     fclose(cache.lst);
     cache.lst = opt->state.strc.lst = NULL;
     /* old.lst minus new.lst is the set of files the previous mirror had and
-       this one does not. --changes reports it; only --purge-old acts on it. */
-    if (opt->delete_old || opt->changes) {
+       this one does not. --changes reports it; only --purge-old acts on it.
+       An aborted run never reached every link, so that difference is mostly
+       what it did not get to: purging against it deletes a live mirror. */
+    if (aborted) {
+      if (opt->delete_old || opt->changes) {
+        hts_log_print(opt, LOG_WARNING,
+                      "Mirror aborted: keeping all previously mirrored files");
+      }
+    } else if (opt->delete_old || opt->changes) {
       FILE *old_lst, *new_lst;
 
       hts_changes_indexed(opt);
@@ -2263,11 +2276,12 @@ int httpmirror(char *url1, httrackp * opt) {
     }
     finalInfo[0] = '\0';
     sprintf(finalInfo + strlen(finalInfo),
-            "HTTrack Website Copier/" HTTRACK_VERSION
-            " mirror complete in %s : " "%d links scanned, %d files written ("
-            LLintP " bytes overall)%s " "[" LLintP " bytes received at " LLintP
-            " bytes/sec]", htstime, (int) opt->lien_tot - 1,
-            (int) HTS_STAT.stat_files, (LLint) HTS_STAT.stat_bytes, infoupdated,
+            "HTTrack Website Copier/" HTTRACK_VERSION " mirror %s %s : "
+            "%d links scanned, %d files written (" LLintP " bytes overall)%s "
+            "[" LLintP " bytes received at " LLintP " bytes/sec]",
+            aborted ? "aborted after" : "complete in", htstime,
+            (int) opt->lien_tot - 1, (int) HTS_STAT.stat_files,
+            (LLint) HTS_STAT.stat_bytes, infoupdated,
             (LLint) HTS_STAT.HTS_TOTAL_RECV, (LLint) n);
 
     if (HTS_STAT.total_packed > 0 && HTS_STAT.total_unpacked > 0) {
@@ -2307,7 +2321,7 @@ int httpmirror(char *url1, httrackp * opt) {
 
   // ending
   usercommand(opt, 0, NULL, NULL, NULL, NULL);
-  completed = HTS_TRUE;
+  completed = !aborted;
 
 cleanup:
   /* single exit: every bailout jumps here, so the closes below always run */

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -2125,8 +2125,7 @@ int httpmirror(char *url1, httrackp * opt) {
     cache.lst = opt->state.strc.lst = NULL;
     /* old.lst minus new.lst is the set of files the previous mirror had and
        this one does not. --changes reports it; only --purge-old acts on it.
-       An aborted run never reached every link, so that difference is mostly
-       what it did not get to: purging against it deletes a live mirror. */
+       For a stopped mirror it is mostly what the run never got to. */
     if (aborted) {
       if (opt->delete_old || opt->changes) {
         hts_log_print(opt, LOG_WARNING,

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -2070,12 +2070,8 @@ int httpmirror(char *url1, httrackp * opt) {
         }
       }
     }
-    /* links left here means new.lst is only a partial view of the mirror */
-    const hts_boolean links_left = ptr < opt->lien_tot;
-
     // a-t-on dépassé le quota?
     if (!back_checkmirror(opt)) {
-      aborted = links_left;
       ptr = opt->lien_tot;
     } else if (opt->state.exit_xh) {    // sortir
       if (opt->state.exit_xh == 1) {
@@ -2083,10 +2079,13 @@ int httpmirror(char *url1, httrackp * opt) {
       } else {
         hts_log_print(opt, LOG_ERROR, "Exit requested by engine");
       }
-      aborted = links_left;
       ptr = opt->lien_tot;
     }
   } while(ptr < opt->lien_tot);
+
+  /* A stop request cuts the mirror short whether or not the loop ran out of
+     links: with one pending, the parser stops queueing the links it finds. */
+  aborted = opt->state.stop != 0 || opt->state.exit_xh != 0;
   //
   //
   //

--- a/tests/261_local-abort-purge.test
+++ b/tests/261_local-abort-purge.test
@@ -1,13 +1,14 @@
 #!/bin/bash
 #
-# An aborted run purged against the truncated new.lst of what it had reached,
-# deleting everything it never got to (#1109). Pass 2 is a complete crawl that
-# still purges, so a fix that only silences the purge fails here.
+# A SIGTERM'd --update purged against the truncated new.lst of what it had
+# reached, deleting everything it never got to (#1109). Pass 2 is a complete
+# crawl that still purges, so a fix that only silences the purge fails here.
+# 268 covers the same loss without a signal.
 
 set -euo pipefail
 
-# shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 skip_on_windows "MSYS cannot signal a native httrack.exe"
@@ -142,39 +143,3 @@ ok "the files the aborted run never reached kept their previous copies"
 grep -q 'mirror aborted after' <<<"$log" ||
     fail "the aborted run still reports a complete mirror: ${log}"
 ok "the summary reports the abort"
-
-# --- pass 4: a --max-time stop, over links the crawl never even queued -------
-# The cap fires while slow.html is in flight, and the parser then drops the
-# leaf links it carries: the loop runs out of links without reaching them, so
-# an abort is not always visible in the cursor. Deleting the cache is what
-# makes the drop happen, and is something users do to reclaim space.
-out2="${tmpdir}/crawl2"
-mkdir -p "$out2"
-local_server_start --log "${tmpdir}/http.log"
-host2="127.0.0.1_${SRV_PORT}"
-leaves=(x0 x1 x2 x3 x4 x5)
-run_with_timeout 300 httrack "${BASEURL}/abortpurge/index.html" -O "$out2" \
-    "${common[@]}" --timeout=20 --max-time=120 >"${tmpdir}/log4" 2>&1
-for name in "${leaves[@]}"; do
-    test -s "${out2}/${host2}/abortpurge/${name}.html" ||
-        fail "pass 4 did not mirror ${name}.html"
-done
-ok "pass 4 mirrored the six leaves"
-
-rm -f "${out2}/hts-cache/new.zip"
-rc=0
-run_with_timeout 300 httrack "${BASEURL}/abortpurge/index.html" -O "$out2" \
-    "${common[@]}" --timeout=0 --max-time=2 >"${tmpdir}/log5" 2>&1 || rc=$?
-test "$rc" -ne 124 || fail "the capped crawl overran its deadline"
-capped=$(cat "${out2}/hts-log.txt")
-grep -q 'giving up' <<<"$capped" || fail "the time cap never fired: ${capped}"
-# Fewer links than pass 4 saw is what says the parser dropped some; without it
-# this leg passes on a mirror that simply finished.
-scanned=$(sed -n 's/.* : \([0-9][0-9]*\) links scanned.*/\1/p' <<<"$capped" | tail -1)
-test "${scanned:-99}" -lt 8 ||
-    fail "the stop dropped no link, so nothing was left unreached (${scanned} scanned)"
-for name in "${leaves[@]}"; do
-    test -s "${out2}/${host2}/abortpurge/${name}.html" ||
-        fail "${name}.html was purged by a run that stopped before queueing it"
-done
-ok "a capped run keeps the files its parser never queued"

--- a/tests/261_local-abort-purge.test
+++ b/tests/261_local-abort-purge.test
@@ -36,9 +36,8 @@ mkdir -p "$root" "$out"
 names=(a b c d e)
 write_bodies() {
     local gen=$1 name
-    # a.bin is fetched first and alone exceeds the 32768 bytes below which the
-    # engine calls the session dead and rolls it back: that path skips the purge
-    # on its own and would pass the abort leg whatever the loop did.
+    # a.bin alone exceeds the 32768 bytes below which the engine calls the
+    # session dead and rolls back, a path that skips the purge on its own.
     "$python" -c 'import sys
 sys.stdout.buffer.write((sys.argv[1] + "-a-").encode() * 24000)' "$gen" \
         >"${root}/a.bin"
@@ -79,9 +78,8 @@ done
 ok "pass 1 mirrored six files"
 
 # --- pass 2: a complete re-crawl of five of the six --------------------------
-# The purge is what deletes f.bin. Without this leg, gating the purge on nothing
-# at all would pass the abort leg below. Not --update: that pass restores the
-# previous seed list from the cache, and f.bin with it.
+# Deleting f.bin is the control the abort legs below need. Not --update: that
+# restores the previous seed list from the cache, and f.bin with it.
 urls_of "${names[@]}"
 run_with_timeout 300 httrack "${urls[@]}" -O "$out" "${common[@]}" \
     --timeout=20 --max-time=120 >"${tmpdir}/log2" 2>&1

--- a/tests/261_local-abort-purge.test
+++ b/tests/261_local-abort-purge.test
@@ -1,0 +1,147 @@
+#!/bin/bash
+#
+# An aborted --update run purged against the truncated new.lst it had reached,
+# so everything it never got to was deleted (#1109). The complete pass before
+# it does purge a dropped file, so a fix that only silences the purge, or that
+# moves it elsewhere in the same fall-through, fails here.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+python=$(find_python) || skip "python3 not found"
+skip_on_windows "MSYS cannot signal a native httrack.exe"
+command -v httrack >/dev/null || fail "could not find httrack"
+
+server=$(nativepath "${testdir}/ftp-server.py")
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_abortpurge.XXXXXX")
+serverpid=
+crawlpid=
+cleanup() {
+    test -z "$crawlpid" || kill_tree "$crawlpid"
+    stop_server "$serverpid"
+    rm -rf "$tmpdir"
+}
+cleanup_push cleanup
+
+ok() { echo "OK: $*"; }
+
+root="${tmpdir}/root"
+out="${tmpdir}/crawl"
+modes="${tmpdir}/modes"
+cmds="${tmpdir}/cmds"
+lst="${out}/hts-cache"
+mkdir -p "$root" "$out"
+
+names=(a b c d e)
+write_bodies() {
+    local gen=$1 name
+    # a.bin is fetched first and alone exceeds the 32768 bytes below which the
+    # engine calls the session dead and rolls it back: that path skips the purge
+    # on its own and would pass the abort leg whatever the loop did.
+    "$python" -c 'import sys
+sys.stdout.buffer.write((sys.argv[1] + "-a-").encode() * 24000)' "$gen" \
+        >"${root}/a.bin"
+    for name in "${names[@]:1}" f; do
+        "$python" -c 'import sys
+sys.stdout.buffer.write((sys.argv[1] + "-" + sys.argv[2] + "-").encode() * 400)' \
+            "$gen" "$name" >"${root}/${name}.bin"
+    done
+}
+write_bodies V1
+: >"$modes"
+
+serverlog="${tmpdir}/server.out"
+"$python" "$server" --root "$(nativepath "$root")" \
+    --mode-file "$(nativepath "$modes")" \
+    --log "$(nativepath "$cmds")" >"$serverlog" 2>&1 &
+serverpid=$!
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+host="127.0.0.1_${port}"
+
+urls=()
+urls_of() {
+    local name
+    urls=()
+    for name in "$@"; do urls+=("ftp://127.0.0.1:${port}/${name}.bin"); done
+}
+# -c1: a parallel FTP crawl loses whole transfers to an older backlog bug (#797),
+# and one socket also pins the order in which the links are reached.
+common=(--quiet --disable-security-limits --robots=0 --retries=1 -c1)
+
+# --- pass 1: the full mirror an abort could destroy --------------------------
+urls_of "${names[@]}" f
+run_with_timeout 300 httrack "${urls[@]}" -O "$out" "${common[@]}" \
+    --timeout=20 --max-time=120 >"${tmpdir}/log1" 2>&1
+for name in "${names[@]}" f; do
+    test -s "${out}/${host}/${name}.bin" || fail "pass 1 did not mirror ${name}.bin"
+done
+ok "pass 1 mirrored six files"
+
+# --- pass 2: a complete re-crawl of five of the six --------------------------
+# The purge is what deletes f.bin. Without this leg, gating the purge on nothing
+# at all would pass the abort leg below. Not --update: that pass restores the
+# previous seed list from the cache, and f.bin with it.
+urls_of "${names[@]}"
+run_with_timeout 300 httrack "${urls[@]}" -O "$out" "${common[@]}" \
+    --timeout=20 --max-time=120 >"${tmpdir}/log2" 2>&1
+grep -aq 'mirror complete in' "${out}/hts-log.txt" ||
+    fail "pass 2 did not run to completion: $(cat "${out}/hts-log.txt")"
+test ! -f "${out}/${host}/f.bin" ||
+    fail "a completed crawl no longer purges the file it dropped"
+ok "a completed crawl still purges"
+
+mkdir "${tmpdir}/snap"
+cp "${out}/${host}"/*.bin "${tmpdir}/snap/"
+
+# --- pass 3: the same update, aborted while b.bin stalls ---------------------
+# No --timeout or --max-time: any bound would end this crawl by itself, through
+# the quota branch rather than the exit one.
+write_bodies V3
+printf '/b.bin stall\n' >"$modes"
+: >"$cmds"
+urls_of "${names[@]}"
+httrack "${urls[@]}" -O "$out" "${common[@]}" --update --timeout=0 --max-time=0 \
+    >"${tmpdir}/log3" 2>&1 &
+crawlpid=$!
+
+# Observed, not slept for: the stalled RETR is what says a.bin is done and the
+# crawl is parked with c, d and e still unreached.
+deadline=$((SECONDS + 120))
+until grep -aq 'RETR .*b\.bin' "$cmds" 2>/dev/null; do
+    test "$SECONDS" -lt "$deadline" || fail "the crawl never reached b.bin"
+    poll_wait 1
+done
+kill -TERM "$crawlpid"
+rc=0
+wait_bounded "$crawlpid" 120 || rc=$?
+crawlpid=
+test "$rc" -ne 124 || fail "the terminated crawl was still running 120s later"
+
+log=$(cat "${out}/hts-log.txt")
+# The exit has to land in the outer loop's own branch, the one that falls
+# through to the purge. A bailout jumps past it and proves nothing.
+grep -q 'Exit requested by shell or user' <<<"$log" ||
+    fail "the crawl did not end through the engine's exit path: ${log}"
+! grep -q 'restoring previous one' <<<"$log" ||
+    fail "the abort rolled the session back, which skips the purge anyway: ${log}"
+# And the run must really have left links behind, or there is nothing to purge.
+for name in c d e; do
+    ! grep -aq "${name}\.bin" "${lst}/new.lst" ||
+        fail "${name}.bin was reached after all; the abort came too late"
+done
+grep -aq "V3-a-" "${out}/${host}/a.bin" ||
+    fail "the aborted run never transferred a.bin, so it wrote no file at all"
+ok "the abort left c.bin, d.bin and e.bin unreached"
+
+for name in c d e; do
+    cmp -s "${out}/${host}/${name}.bin" "${tmpdir}/snap/${name}.bin" ||
+        fail "${name}.bin no longer holds the previous mirror's bytes: $(find \
+            "${out}/${host}" -type f)"
+done
+ok "the files the aborted run never reached kept their previous copies"
+
+grep -q 'mirror aborted after' <<<"$log" ||
+    fail "the aborted run still reports a complete mirror: ${log}"
+ok "the summary reports the abort"

--- a/tests/261_local-abort-purge.test
+++ b/tests/261_local-abort-purge.test
@@ -1,14 +1,13 @@
 #!/bin/bash
 #
-# An aborted --update run purged against the truncated new.lst it had reached,
-# so everything it never got to was deleted (#1109). The complete pass before
-# it does purge a dropped file, so a fix that only silences the purge, or that
-# moves it elsewhere in the same fall-through, fails here.
+# An aborted run purged against the truncated new.lst of what it had reached,
+# deleting everything it never got to (#1109). Pass 2 is a complete crawl that
+# still purges, so a fix that only silences the purge fails here.
 
 set -euo pipefail
 
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 skip_on_windows "MSYS cannot signal a native httrack.exe"
@@ -145,3 +144,39 @@ ok "the files the aborted run never reached kept their previous copies"
 grep -q 'mirror aborted after' <<<"$log" ||
     fail "the aborted run still reports a complete mirror: ${log}"
 ok "the summary reports the abort"
+
+# --- pass 4: a --max-time stop, over links the crawl never even queued -------
+# The cap fires while slow.html is in flight, and the parser then drops the
+# leaf links it carries: the loop runs out of links without reaching them, so
+# an abort is not always visible in the cursor. Deleting the cache is what
+# makes the drop happen, and is something users do to reclaim space.
+out2="${tmpdir}/crawl2"
+mkdir -p "$out2"
+local_server_start --log "${tmpdir}/http.log"
+host2="127.0.0.1_${SRV_PORT}"
+leaves=(x0 x1 x2 x3 x4 x5)
+run_with_timeout 300 httrack "${BASEURL}/abortpurge/index.html" -O "$out2" \
+    "${common[@]}" --timeout=20 --max-time=120 >"${tmpdir}/log4" 2>&1
+for name in "${leaves[@]}"; do
+    test -s "${out2}/${host2}/abortpurge/${name}.html" ||
+        fail "pass 4 did not mirror ${name}.html"
+done
+ok "pass 4 mirrored the six leaves"
+
+rm -f "${out2}/hts-cache/new.zip"
+rc=0
+run_with_timeout 300 httrack "${BASEURL}/abortpurge/index.html" -O "$out2" \
+    "${common[@]}" --timeout=0 --max-time=2 >"${tmpdir}/log5" 2>&1 || rc=$?
+test "$rc" -ne 124 || fail "the capped crawl overran its deadline"
+capped=$(cat "${out2}/hts-log.txt")
+grep -q 'giving up' <<<"$capped" || fail "the time cap never fired: ${capped}"
+# Fewer links than pass 4 saw is what says the parser dropped some; without it
+# this leg passes on a mirror that simply finished.
+scanned=$(sed -n 's/.* : \([0-9][0-9]*\) links scanned.*/\1/p' <<<"$capped" | tail -1)
+test "${scanned:-99}" -lt 8 ||
+    fail "the stop dropped no link, so nothing was left unreached (${scanned} scanned)"
+for name in "${leaves[@]}"; do
+    test -s "${out2}/${host2}/abortpurge/${name}.html" ||
+        fail "${name}.html was purged by a run that stopped before queueing it"
+done
+ok "a capped run keeps the files its parser never queued"

--- a/tests/268_local-abort-purge-capped.test
+++ b/tests/268_local-abort-purge-capped.test
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# A run stopped by --max-time purged the files it never reached (#1109). The
+# cap fires while slow.html is in flight, and the parser then drops the leaf
+# links that page carries, so the crawl loop runs out of links without ever
+# queueing them: an abort the cursor cannot see. 261 covers the signalled half.
+
+set -euo pipefail
+
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
+
+command -v httrack >/dev/null || fail "could not find httrack"
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_capped.XXXXXX")
+cleanup() { rm -rf "$tmpdir"; }
+cleanup_push cleanup
+
+ok() { echo "OK: $*"; }
+
+out="${tmpdir}/crawl"
+mkdir -p "$out"
+leaves=(x0 x1 x2 x3 x4 x5)
+common=(--quiet --disable-security-limits --robots=0 --retries=1 -c1)
+
+local_server_start --log "${tmpdir}/server.log"
+host="127.0.0.1_${SRV_PORT}"
+
+# --- pass 1: the full mirror the capped run could destroy --------------------
+local_crawl --log "${tmpdir}/log1" "${common[@]}" -O "$out" --timeout=20 \
+    "${BASEURL}/abortpurge/index.html"
+for name in "${leaves[@]}"; do
+    test -s "${out}/${host}/abortpurge/${name}.html" ||
+        fail "pass 1 did not mirror ${name}.html"
+done
+ok "pass 1 mirrored the six leaves"
+
+# --- pass 2: the same crawl, cut short by the cap ----------------------------
+# Deleting the cache is what makes the parser drop the links rather than follow
+# them from the previous session, and is something users do to reclaim space.
+rm -f "${out}/hts-cache/new.zip"
+rc=0
+local_crawl --log "${tmpdir}/log2" "${common[@]}" -O "$out" --timeout=0 \
+    --max-time=2 "${BASEURL}/abortpurge/index.html" || rc=$?
+test "$rc" -ne 124 || fail "the capped crawl overran its deadline"
+
+log=$(cat "${out}/hts-log.txt")
+grep -q 'giving up' <<<"$log" || fail "the time cap never fired: ${log}"
+# Fewer links than pass 1 saw is what says some were dropped; without it this
+# passes on a mirror that simply finished.
+scanned=$(sed -n 's/.* : \([0-9][0-9]*\) links scanned.*/\1/p' <<<"$log" | tail -1)
+test "${scanned:-99}" -lt 8 ||
+    fail "the stop dropped no link, so nothing was left unreached (${scanned} scanned)"
+ok "the cap left the leaf links unqueued"
+
+for name in "${leaves[@]}"; do
+    test -s "${out}/${host}/abortpurge/${name}.html" ||
+        fail "${name}.html was purged by a run that stopped before queueing it"
+done
+ok "the capped run kept the files it never reached"
+
+grep -q 'mirror aborted after' <<<"$log" ||
+    fail "the capped run still reports a complete mirror: ${log}"
+ok "the summary reports the abort"

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -288,8 +288,8 @@ echo "ran=$((pass + fail + skip)) pass=$pass fail=$fail skip=$skip" |
 # decode back to, which NTFS refuses;
 # memresume, repaircache and resume-recovery interrupt pass 1 with a signal
 # MSYS cannot deliver to a native exe;
-# ftp-deadhost-interrupt and ftp-sigterm need that same signal (deadhost's
-# --timeout half runs, as 245);
+# ftp-deadhost-interrupt, ftp-sigterm and abort-purge need that same signal
+# (deadhost's --timeout half runs as 245, abort-purge's --max-time half as 268);
 # close-once interposes close() through LD_PRELOAD, which MSYS has no equivalent for.
 expected_skips="01_engine-footer-overflow.test
 253_local-ftp-close-once.test
@@ -303,6 +303,7 @@ expected_skips="01_engine-footer-overflow.test
 215_engine-datadir-ospath.test
 243_local-ftp-deadhost-interrupt.test
 255_local-ftp-sigterm.test
+261_local-abort-purge.test
 235_local-resume-recovery.test
 48_local-crange-memresume.test
 71_local-crange-repaircache.test

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -2153,6 +2153,22 @@ class Handler(SimpleHTTPRequestHandler):
     def route_trickle_index(self):
         self.send_bin_index()
 
+    # #1109: slow.html outlasts any small -E budget and is the only source of
+    # the leaf links, which a stopped parser then drops.
+    ABORTPURGE_SECONDS = 5
+
+    def route_abortpurge_index(self):
+        self.send_html('\t<a href="slow.html">slow</a>\n')
+
+    def route_abortpurge_slow(self):
+        time.sleep(self.ABORTPURGE_SECONDS)
+        self.send_html(
+            "".join('\t<a href="x%d.html">x%d</a>\n' % (i, i) for i in range(6))
+        )
+
+    def route_abortpurge_leaf(self):
+        self.send_html("\t<p>leaf</p>\n")
+
     # #97: a path long enough that the CLI in-progress column truncates it at 80
     # columns but not at 200. Its own index: /trickle/ is asserted on elsewhere.
     def route_deeptrickle_index(self):
@@ -2616,6 +2632,14 @@ class Handler(SimpleHTTPRequestHandler):
         "/cdispo/fetch.php": route_cdispo,
         "/cdispo/evil.php": route_cdispo,
         "/delayed/index.html": route_delayed_index,
+        "/abortpurge/index.html": route_abortpurge_index,
+        "/abortpurge/slow.html": route_abortpurge_slow,
+        "/abortpurge/x0.html": route_abortpurge_leaf,
+        "/abortpurge/x1.html": route_abortpurge_leaf,
+        "/abortpurge/x2.html": route_abortpurge_leaf,
+        "/abortpurge/x3.html": route_abortpurge_leaf,
+        "/abortpurge/x4.html": route_abortpurge_leaf,
+        "/abortpurge/x5.html": route_abortpurge_leaf,
         "/trickle/index.html": route_trickle_index,
         "/xssjob/": route_xssjob_index,
         "/xssjob/index.html": route_xssjob_index,


### PR DESCRIPTION
An interrupted run still ran the end-of-mirror purge, comparing old.lst against the truncated new.lst of what it had managed to fetch. Everything it had not reached was deleted, and `--purge-old` is on by default, so no flag has to be set for this.

The gate now reads `opt->state.stop` and `state.exit_xh` once the crawl loop ends, and skips the purge and the `--changes` report when either is set. Reading the cursor is not enough: a stop that lands while a page is in flight makes the parser drop the links that page carries, so a run can reach the end of its list having never queued half the mirror. Every stop route sets `state.stop` (signals, the GUI, and the `--max-time` and `--max-size` caps through `hts_request_stop`), and nothing sets it on a mirror that ran to the end. The report is suppressed for the reason #1061 gives: a run that never walked the list cannot say what is gone.

The rest of the completion sequence stays. `hts_finish_makeindex` and `index_finish` close files the run was writing, `singlefile_process_mirror` only rewrites pages that arrived whole, and `warc_close_opt` commits records for transfers that really happened, where `warc_abort_opt` would throw them away. The summary line is the other change: it says "mirror aborted after" instead of claiming a complete mirror.

Test 261 covers both halves, a SIGTERM during a stalled FTP `--update` and a `--max-time` cap firing while the page carrying the only links to six leaves is still in flight. The complete crawl in between still purges a file it dropped, so a fix that merely silences the purge fails there.

Closes #1109