### PR TITLE
getrandom() is called undeclared when configure finds the function but not its header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -700,6 +700,47 @@ jobs:
         if: failure()
         run: cat tests/test-suite.log 2>/dev/null || true
 
+  # The cell of #1139: a libc exporting getrandom() without shipping
+  # <sys/random.h>. Nothing else reaches it, and it is a hard build break when
+  # the call is not gated on the header. It also runs the /dev/urandom fallback.
+  no-getrandom:
+    name: build (getrandom header hidden)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
+          sudo apt-get install -y --no-install-recommends \
+            build-essential autoconf automake libtool autoconf-archive \
+            zlib1g-dev libssl-dev libbrotli-dev libzstd-dev
+
+      - name: Configure (sys/random.h hidden from configure)
+        run: |
+          set -euo pipefail
+          autoreconf -fi
+          ./configure ac_cv_header_sys_random_h=no
+          # A libc without getrandom() at all would pass this job vacuously.
+          grep -q "define HAVE_GETRANDOM 1" config.h
+          ! grep -q "define HAVE_SYS_RANDOM_H" config.h
+
+      - name: Build
+        run: make -j"$(nproc)"
+
+      - name: Test
+        timeout-minutes: 20
+        run: |
+          jobs=$(( $(nproc) * 2 )); [ "$jobs" -le 16 ] || jobs=16
+          make check -j"$jobs"
+
+      - name: Print the test log on failure
+        if: failure()
+        run: cat tests/test-suite.log 2>/dev/null || true
+
   # OpenSSL 4.0 removes the API 3.x deprecated. Building with that set hidden
   # keeps the engine ready for it: a deprecated call fails here rather than the
   # day a distro moves. Compile-only, since the headers are what is under test.

--- a/src/htsrandom.c
+++ b/src/htsrandom.c
@@ -40,7 +40,10 @@ Please visit our Website: http://www.httrack.com
 #else
 #include <errno.h>
 #include <stdio.h>
+/* getrandom() is declared only in <sys/random.h>, so one macro gates both the
+   include and the call: finding the symbol alone does not make it callable. */
 #if defined(HAVE_SYS_RANDOM_H) && defined(HAVE_GETRANDOM)
+#define HTS_USE_GETRANDOM
 #include <sys/random.h>
 #endif
 #endif
@@ -71,7 +74,14 @@ hts_boolean hts_random_bytes(void *buf, size_t len) {
   size_t got = 0;
   FILE *fp;
 
-#ifdef HAVE_GETRANDOM
+#ifdef HTS_USE_GETRANDOM
+  /* Without that prototype an implicit declaration returns int, so pin the
+     declared return type: a re-split guard divides by zero here instead. */
+  enum {
+    getrandom_is_prototyped =
+        1 / (sizeof(getrandom(p, len, 0)) == sizeof(ssize_t))
+  };
+
   while (got < len) {
     const ssize_t n = getrandom(p + got, len - got, 0);
 

--- a/src/htsrandom.c
+++ b/src/htsrandom.c
@@ -40,8 +40,8 @@ Please visit our Website: http://www.httrack.com
 #else
 #include <errno.h>
 #include <stdio.h>
-/* getrandom() is declared only in <sys/random.h>, so one macro gates both the
-   include and the call: finding the symbol alone does not make it callable. */
+/* One macro gates both the include and the call: <sys/random.h> is the only
+   declaration of getrandom(), so the symbol alone does not make it callable. */
 #if defined(HAVE_SYS_RANDOM_H) && defined(HAVE_GETRANDOM)
 #define HTS_USE_GETRANDOM
 #include <sys/random.h>
@@ -54,6 +54,8 @@ typedef BOOLEAN(WINAPI *hts_rtlgenrandom_t)(PVOID buffer, ULONG length);
 #endif
 
 hts_boolean hts_random_bytes(void *buf, size_t len) {
+  if (len == 0) /* nothing to ask any source for, on every platform alike */
+    return HTS_TRUE;
 #ifdef _WIN32
   hts_boolean ok = HTS_FALSE;
   HMODULE dll = LoadLibraryA("advapi32.dll");
@@ -75,8 +77,8 @@ hts_boolean hts_random_bytes(void *buf, size_t len) {
   FILE *fp;
 
 #ifdef HTS_USE_GETRANDOM
-  /* Without that prototype an implicit declaration returns int, so pin the
-     declared return type: a re-split guard divides by zero here instead. */
+  /* Breaks the build if the two guards ever split again: an implicit
+     declaration would return int, not ssize_t. */
   enum {
     getrandom_is_prototyped =
         1 / (sizeof(getrandom(p, len, 0)) == sizeof(ssize_t))

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1919,28 +1919,58 @@ static int st_pause(httrackp *opt, int argc, char **argv) {
 }
 
 static int st_random(httrackp *opt, int argc, char **argv) {
-  enum { want = 64, pad = 16 };
+  enum { want = 64, pad = 16, rounds = 8 };
 
-  unsigned char a[want + pad], b[want + pad];
-  int err = 0, all_zero = 1, i;
+  unsigned char buf[want + pad], first[want], touched[want], varies[want];
+  int err = 0, live = 0, r, i;
 
   (void) opt;
   (void) argc;
   (void) argv;
-  memset(a, 0xa5, sizeof(a)); /* non-zero canary, so a stray NUL shows */
-  memset(b, 0xa5, sizeof(b));
-  if (!hts_random_bytes(a, want) || !hts_random_bytes(b, want))
-    err = 1;
-  for (i = 0; i < pad; i++) {
-    if (a[want + i] != 0xa5 || b[want + i] != 0xa5)
-      err = 1; /* wrote past the requested length */
+  memset(touched, 0, sizeof(touched));
+  memset(varies, 0, sizeof(varies));
+  for (r = 0; r < rounds; r++) {
+    /* A fresh non-zero filler each round: a byte the fill skips keeps every one
+       of them, which a single canary value cannot tell from a written byte. */
+    const unsigned char filler = (unsigned char) (0xa5 + r);
+
+    memset(buf, filler, sizeof(buf));
+    if (!hts_random_bytes(buf, want))
+      err = 1;
+    for (i = 0; i < want; i++) {
+      if (buf[i] != filler)
+        touched[i] = 1;
+    }
+    for (i = 0; i < pad; i++) {
+      if (buf[want + i] != filler)
+        err = 1; /* wrote past the requested length */
+    }
+    if (r == 0) {
+      memcpy(first, buf, want);
+    } else {
+      for (i = 0; i < want; i++) {
+        if (buf[i] != first[i])
+          varies[i] = 1;
+      }
+    }
   }
-  for (i = 0; i < want; i++)
-    all_zero &= (a[i] == 0);
-  if (all_zero || memcmp(a, b, want) == 0)
+  for (i = 0; i < want; i++) {
+    if (!touched[i])
+      err = 1; /* a short fill left this byte alone in every round */
+    live += varies[i];
+  }
+  /* Over 8 draws a live source moves all 64 bytes; half is a floor no real one
+     misses, and a source stuck on one byte or a constant cannot reach it. */
+  if (live < want / 2)
     err = 1;
-  if (!hts_random_bytes(a, 0)) /* a zero-length ask is not a failure */
+  /* a zero-length ask succeeds and writes nothing */
+  memset(buf, 0x5a, sizeof(buf));
+  if (!hts_random_bytes(buf, 0))
     err = 1;
+  for (i = 0; i < (int) sizeof(buf); i++) {
+    if (buf[i] != 0x5a)
+      err = 1;
+  }
   printf("random: %s\n", err ? "FAIL" : "OK");
   return err;
 }
@@ -8946,7 +8976,7 @@ static const struct selftest_entry {
      "a user stop drops the slots still waiting to connect (#1073)",
      st_backstop},
     {"pause", "", "randomized inter-file pause target self-test", st_pause},
-    {"random", "", "hts_random_bytes() fills exactly what was asked for",
+    {"random", "", "hts_random_bytes() fills exactly the requested length",
      st_random},
     {"relative", "<link> <curr-file>", "relative link between two paths",
      st_relative},

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -62,6 +62,7 @@ Please visit our Website: http://www.httrack.com
 #include "htssniff.h"
 #include "htscodec.h"
 #include "htsproxy.h"
+#include "htsrandom.h"
 #include "htssitemap.h"
 #include "htswarc.h"
 #include "htschanges.h"
@@ -1914,6 +1915,33 @@ static int st_pause(httrackp *opt, int argc, char **argv) {
       err = 1;
   }
   printf("pause: %s\n", err ? "FAIL" : "OK");
+  return err;
+}
+
+static int st_random(httrackp *opt, int argc, char **argv) {
+  enum { want = 64, pad = 16 };
+
+  unsigned char a[want + pad], b[want + pad];
+  int err = 0, all_zero = 1, i;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+  memset(a, 0xa5, sizeof(a)); /* non-zero canary, so a stray NUL shows */
+  memset(b, 0xa5, sizeof(b));
+  if (!hts_random_bytes(a, want) || !hts_random_bytes(b, want))
+    err = 1;
+  for (i = 0; i < pad; i++) {
+    if (a[want + i] != 0xa5 || b[want + i] != 0xa5)
+      err = 1; /* wrote past the requested length */
+  }
+  for (i = 0; i < want; i++)
+    all_zero &= (a[i] == 0);
+  if (all_zero || memcmp(a, b, want) == 0)
+    err = 1;
+  if (!hts_random_bytes(a, 0)) /* a zero-length ask is not a failure */
+    err = 1;
+  printf("random: %s\n", err ? "FAIL" : "OK");
   return err;
 }
 
@@ -8918,6 +8946,8 @@ static const struct selftest_entry {
      "a user stop drops the slots still waiting to connect (#1073)",
      st_backstop},
     {"pause", "", "randomized inter-file pause target self-test", st_pause},
+    {"random", "", "hts_random_bytes() fills exactly what was asked for",
+     st_random},
     {"relative", "<link> <curr-file>", "relative link between two paths",
      st_relative},
     {"resolve", "<link> <adr> <fil>", "resolve a link against an origin",

--- a/tests/267_engine-random.test
+++ b/tests/267_engine-random.test
@@ -1,11 +1,14 @@
 #!/bin/bash
 #
-# hts_random_bytes() (#1139): the CSPRNG must fill exactly the requested length,
-# whichever source the build ended up with, getrandom() or /dev/urandom.
+# Checks that hts_random_bytes() (#1139) fills exactly the requested length,
+# whichever source the build ended up with: getrandom() or /dev/urandom.
 
 set -eu
 
-out=$(httrack -#test=random run)
+out=$(httrack -#test=random run) || {
+    echo "httrack -#test=random exited non-zero: $out" >&2
+    exit 1
+}
 
 test "$out" = "random: OK" || {
     echo "expected 'random: OK', got: $out" >&2

--- a/tests/267_engine-random.test
+++ b/tests/267_engine-random.test
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# hts_random_bytes() (#1139): the CSPRNG must fill exactly the requested length,
+# whichever source the build ended up with, getrandom() or /dev/urandom.
+
+set -eu
+
+out=$(httrack -#test=random run)
+
+test "$out" = "random: OK" || {
+    echo "expected 'random: OK', got: $out" >&2
+    exit 1
+}


### PR DESCRIPTION
configure probes `sys/random.h` and `getrandom()` separately, so a libc that exports the symbol without shipping the header reached the call site with no prototype in scope. gcc 14, clang 16 and C23 reject an implicit declaration, so that build fails instead of falling back to /dev/urandom. #1138 guarded the include on both macros and left the call on one; a single macro derived at the include now gates both.

Nothing reached that cell before. There is now a CI leg that configures with `ac_cv_header_sys_random_h=no`, checks the combination really came out that way, and builds: red on master, green here. With getrandom gone it is also the only leg that runs the /dev/urandom fallback. The `enum { x = 1/(cond) }` pin at the call site covers the rest, so if the two guards split again it is a build error even where the compiler would only warn.

`hts_random_bytes` now answers a zero-length ask before reaching any source. The getrandom path already did; the fallback opened /dev/urandom to read nothing, and Windows left it to RtlGenRandom's undocumented behavior.

The new selftest (`-#test=random`, test 267) covers `hts_random_bytes` itself, not the compile break. It draws eight times with a different filler byte each round, so a byte the fill skipped is distinguishable from one it wrote, and it checks that nothing past the ask is touched. Mutants that fill half the buffer, run one byte past the end, return a constant, or scribble on a zero-length ask all fail it. A counter stub passes, since what it asserts is extent and liveness, not entropy quality.

Closes #1139
