### PR TITLE
The Windows suite has no wall-clock bound, so a blown budget reaches the workflow timeout

### DIFF
--- a/tests/171_watchdog-heartbeat.test
+++ b/tests/171_watchdog-heartbeat.test
@@ -183,7 +183,10 @@ printf 'RUN 96_wedged.test at 0s\n' >"$progress"
 rc=0
 (
     watchdog=777
+    # Both are reached from the heartbeat's kill path, which shellcheck cannot see.
+    # shellcheck disable=SC2317
     kill_pid() { echo "DIRECT $1" >>"$rec"; }
+    # shellcheck disable=SC2317
     kill_tree() {
         echo "TREE $1" >>"$rec"
         exit 9

--- a/tests/171_watchdog-heartbeat.test
+++ b/tests/171_watchdog-heartbeat.test
@@ -156,6 +156,21 @@ test -n "$killed" || fail "a suite static from the start was never killed"
 test "$killed" -ge 9960 || fail "killed at $killed, inside the 960s quiet window"
 test "$killed" -le 10080 || fail "killed at $killed, want 9960 within a tick"
 
+# The wall-clock cap, on a suite that never stops reporting: back at 5000 the stub
+# writes a progress line every tick, so the staticness window is nowhere near and
+# only the cap can end this. Set under the quiet window, which it must not wait out.
+vnow=5000
+ticks=0
+printf 'RUN 95_slow.test at 0s\n' >"$progress"
+hb_depth=$BASH_SUBSHELL
+ci_suite_heartbeat 960 360 "$progress" 900 4242 480 >"$tmp/capped" 2>&1
+killed=$(sed -n 's/^KILL 4242 at \([0-9]*\)$/\1/p' "$tmp/capped")
+test -n "$killed" || fail "a suite still reporting outlived its wall-clock cap"
+test "$killed" -ge 5480 || fail "capped at $killed, inside the 480s cap"
+test "$killed" -le 5600 || fail "capped at $killed, want 5480 within a tick"
+grep -q '480s cap reached' "$tmp/capped" || fail "the cap kill was announced as something else"
+test "$(cat "$tmp/lastwrite")" -ge 5480 || fail "the log stopped moving: nothing here needed the cap"
+
 # taskkill is a grandchild of its own target, so a leaves-first /T would reap the
 # watchdog before the root (#953): kill_tree here never returns, and the stubs
 # record the order, which the code under test cannot write to. The reporter goes

--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -125,7 +125,8 @@ reporter_stopped() {
 # One per glob the driver enumerates: an empty category is counted as a failing
 # test named after the unexpanded pattern, which would drown the accounting.
 for t in 00_runnable 13_zlib-pass 14_local-pass 15_watchdog-pass \
-    16_crawl_proxy_https 17_crawl-log-salvage 18_testlib-pass 19_crawllib; do
+    16_crawl_proxy_https 17_crawl-log-salvage 18_testlib-pass 19_crawllib \
+    20_crawl-harness-pass; do
     printf '#!/bin/sh\nexit 0\n' >"$run/$t.test"
 done
 # One test reports back what it inherited: the token the step is handed can post
@@ -135,13 +136,6 @@ printf '#!/bin/sh\necho "TOKEN=${WATCHDOG_TOKEN:-}" >%s\nexit 0\n' "$tmp/childto
     >"$run/10_engine-pass.test"
 printf '#!/bin/sh\nexit 77\n' >"$run/11_engine-skip.test"
 printf '#!/bin/sh\nexit 3\n' >"$run/12_engine-fail.test"
-# Named the way 260 is, and selected by nothing: a crawl glob widened past
-# crawllib would put a deliberately failing crawl back on Windows (#1126).
-printf '#!/bin/sh\nexit 3\n' >"$run/20_crawl-harness-decoy.test"
-# The driver asserts this one by name, so the stub tree has to carry it.
-wedged=260_crawl-harness-fails-loudly.test
-printf '#!/bin/sh\nexit 3\n' >"$run/$wedged"
-
 cd "$run"
 rc=0
 out=$(RUNNER_TEMP="$tmp" GITHUB_STEP_SUMMARY="$tmp/summary" WATCHDOG_TOKEN=s3cr3t \
@@ -150,14 +144,13 @@ assert_staged
 # The skip set and the pass floor are pinned to the real suite, so a stub run
 # ends on the floor; what is under test is the tally that reaches it.
 test "$rc" -eq 1 || fail "stub suite exited $rc, want 1 from the pass floor"
-grep -q '20_crawl-harness-decoy' <<<"$out" && fail "a category selected the decoy, so 260 would run here (#1126)"
 # The category list is concatenated, never deduped, so two globs claiming one
 # test would run it twice and inflate every tally the gates read.
 dup=$(awk '/^RUN /{print $2}' suite-progress.log | sort | uniq -d)
 test -z "$dup" || fail "a test was selected by two categories: $dup"
-grep -q '^ran=11 pass=9 fail=1 skip=1$' <<<"$out" ||
+grep -q '^ran=12 pass=10 fail=1 skip=1$' <<<"$out" ||
     fail "wrong tally: $(grep '^ran=' <<<"$out")"
-grep -q '::error::only 9 tests passed (1 skipped)' <<<"$out" ||
+grep -q '::error::only 10 tests passed (1 skipped)' <<<"$out" ||
     fail "the pass floor did not report the count"
 grep -q 'FAIL 12_engine-fail.test (exit 3)' <<<"$out" || fail "the failing test was not named"
 
@@ -182,18 +175,6 @@ grep -q '^RUN 12_engine-fail.test at ' suite-progress.log || fail "no RUN line f
 grep -q '^RERUN 12_engine-fail.test$' suite-progress.log || fail "the traced re-run was not noted"
 grep -q '^77 11_engine-skip.test$' suite-progress.log || fail "the skip's status was not recorded"
 test -s 12_engine-fail.test.log || fail "no per-test log for the failing test"
-
-# A 260 renamed into a glob would wedge this leg, so the driver names it and stops
-# when it is gone, rather than discovering the rename on the runner (#1126).
-mv "$run/$wedged" "$run/260_crawllib-fails-loudly.test"
-rc=0
-out=$(RUNNER_TEMP="$tmp" GITHUB_STEP_SUMMARY="$tmp/summary" \
-    bash ./ci-windows-suite.sh "$bin" 2>&1) || rc=$?
-assert_staged
-test "$rc" -eq 1 || fail "a renamed $wedged exited $rc, want 1"
-grep -q "::error::$wedged is gone" <<<"$out" || fail "the rename was not named: $out"
-grep -q '^ran=' <<<"$out" && fail "the suite ran a test with $wedged renamed: $out"
-mv "$run/260_crawllib-fails-loudly.test" "$run/$wedged"
 
 # An emptied category must name itself and stop the suite, rather than hand the
 # unexpanded pattern to test-timeout.sh and count it as a test failing 127 (#952).

--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -307,11 +307,21 @@ PY
     # The heartbeat still owns the kill and must beat the step timeout.
     stuck=$(sed -n 's/^stuck=\([0-9]*\)$/\1/p' "$driver")
     deadline=$(sed -n 's/^suite_deadline=\([0-9]*\)$/\1/p' "$driver")
+    pertest=$(sed -n 's/^per_test=\([0-9]*\)$/\1/p' "$driver")
+    hard=$(sed -n 's/^hard_deadline=\([0-9]*\)$/\1/p' "$driver")
     test -n "$stuck" || fail "cannot read the heartbeat's static window"
     test -n "$deadline" || fail "cannot read the driver's suite deadline"
+    test -n "$pertest" || fail "cannot read the driver's per-test budget"
+    test -n "$hard" || fail "cannot read the heartbeat's wall-clock cap"
     # A test may start one second under the deadline and never report again.
     test $((deadline + stuck + 240)) -le "$cap" ||
         fail "a kill at ${deadline}+${stuck}s leaves under 240s before the ${cap}s step timeout"
+    # The cap is what bounds a suite that keeps reporting, so it decides the step:
+    # it has to sit above the longest legitimate tail and still clear the timeout.
+    test $((hard + 240)) -le "$cap" ||
+        fail "the ${hard}s cap leaves under 240s before the ${cap}s step timeout"
+    test "$hard" -ge $((deadline + pertest)) ||
+        fail "the ${hard}s cap fires inside the $((deadline + pertest))s a test started at the deadline may take"
 
     # The watchdog's own stop is its MaxSeconds, which must land inside the step.
     # shellcheck disable=SC2016 # $MaxSeconds is PowerShell's

--- a/tests/260_crawl-harness-fails-loudly.test
+++ b/tests/260_crawl-harness-fails-loudly.test
@@ -2,10 +2,6 @@
 #
 # The 62 tests behind local-crawl.sh read nothing but its exit status, so a
 # harness that swallowed a failed crawl would turn every one of them green.
-#
-# Named outside the Windows suite's topic globs, like the other harness
-# self-tests (254, 256-258): a failing crawl wedged that suite twice (#1126).
-# Naming that driver here, even in a comment, trips 226's credential audit.
 
 set -euo pipefail
 

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -24,9 +24,12 @@ ci_annotate() {
 # End a wedged suite before its runner dies: a step that fails on its own terms
 # keeps its log, a lost runner keeps nothing, annotations included (#795). Quiet
 # for $1s, then names the test in flight from $3 every $2s; kills $5 once $3 has
-# been static for $4s. Staticness, never elapsed time: a healthy test in flight and
-# a wedged one look identical by the clock, but every outcome writes a line, the
-# per-test timeout included, so $4 past that timeout means it never fired.
+# been static for $4s, or unconditionally $6s in (0: never). Staticness, never
+# elapsed time: a healthy test in flight and a wedged one look identical by the
+# clock, but every outcome writes a line, the per-test timeout included, so $4 past
+# that timeout means it never fired. The cap covers what staticness cannot: each of
+# those lines buys another $4s, so a tail of blown budgets walks the step onto the
+# workflow timeout, which keeps neither the log nor the artifacts (#1126).
 # Assigns into hb_time rather than printing: reading the clock forks nothing, which
 # matters when the box has none to spare. Overridable for the unit test virtual clock.
 hb_time=0
@@ -67,8 +70,21 @@ ci_start_native_watchdog() {
     return 1
 }
 
+# End the step, announcing $2 first: the kill runs no EXIT trap, so an unexplained
+# death is all the log would otherwise hold.
+ci_heartbeat_kill() {
+    local main=$1
+    ci_annotate error "suite watchdog" "$2"
+    # Ahead of the kill, which runs no EXIT trap: an orphan would outlive the
+    # step and overwrite its last status with a frozen tail.
+    test -z "${watchdog:-}" || kill_pid "$watchdog"
+    # Direct first: kill_tree may reap this watchdog before its own root (#953).
+    kill_pid "$main"
+    kill_tree "$main"
+}
+
 ci_suite_heartbeat() {
-    local quiet=$1 every=$2 progress=$3 stuck=$4 main=$5
+    local quiet=$1 every=$2 progress=$3 stuck=$4 main=$5 hard=${6:-0}
     local tick=$2 begin now line said moved last=''
     # Measured, never accumulated: the starvation this watchdog exists to catch is
     # exactly what makes a sleep overshoot, and drift only ever delays the kill.
@@ -85,17 +101,19 @@ ci_suite_heartbeat() {
         # end the watchdog in silence, which reads as protection and is not.
         line=$(tail -n 1 "$progress" 2>/dev/null || true)
         test "$line" = "$last" || { last=$line moved=$now; }
+        # Ahead of the quiet window, which only delays the staticness verdict: a
+        # cap that inherited that delay could not be set below it.
+        if test "$hard" -gt 0 && test $((now - begin)) -ge "$hard"; then
+            ci_heartbeat_kill "$main" \
+                "killing the step: ${hard}s cap reached, in flight: $last"
+            return 0
+        fi
         test $((now - begin)) -ge "$quiet" || continue
         # Every tick, not on the annotation cadence, which would let a late wedge
         # outlive the step's own timeout before being caught.
         if test $((now - moved)) -ge "$stuck"; then
-            ci_annotate error "suite watchdog" "killing the step: $((now - moved))s without progress, in flight: $last"
-            # Ahead of the kill, which runs no EXIT trap: an orphan would outlive the
-            # step and overwrite its last status with a frozen tail.
-            test -z "${watchdog:-}" || kill_pid "$watchdog"
-            # Direct first: kill_tree may reap this watchdog before its own root (#953).
-            kill_pid "$main"
-            kill_tree "$main"
+            ci_heartbeat_kill "$main" \
+                "killing the step: $((now - moved))s without progress, in flight: $last"
             return 0
         fi
         test $((now - said)) -ge "$every" || continue
@@ -174,9 +192,15 @@ stuck=900
 # 960s of quiet and 900s of static log, and every #795 death measured so far
 # lands inside the first 750s of the step.
 watchdog='' ci_watchdog_pid=''
+# Wall-clock backstop, because staticness alone bounds nothing: the deadline above
+# is read between tests, and past it one test may still spend $per_test and then a
+# traced rerun, each writing a progress line that re-arms $stuck. 2400s clears that
+# 1500+600 worst case with room for the hang dump, and leaves 300s of the step's
+# 45 minutes to fail on our own terms and upload (#1126).
+hard_deadline=2400
 ci_start_native_watchdog "$PWD/$progress" && watchdog=$ci_watchdog_pid
 test -n "$watchdog" || echo "no off-box watchdog: no usable PowerShell"
-ci_suite_heartbeat 960 360 "$progress" "$stuck" $$ &
+ci_suite_heartbeat 960 360 "$progress" "$stuck" $$ "$hard_deadline" &
 heartbeat=$!
 trap 'set +e; kill "$heartbeat" 2>/dev/null; test -z "$watchdog" || kill_pid "$watchdog"' EXIT
 
@@ -189,6 +213,7 @@ pass=0 fail=0 skip=0 failed="" skipped="" deadline=0
 categories=(runnable:'00_runnable*.test' engine:'*_engine-*.test' zlib:'*_zlib-*.test'
     local:'*_local-*.test' watchdog:'*_watchdog*.test'
     testlib:'*_testlib-*.test' crawllib:'*_crawllib*.test'
+    crawl-harness:'*_crawl-harness-*.test'
     proxy-https:'*_crawl_proxy_https.test' log-salvage:'*_crawl-log-salvage.test')
 tests=()
 shopt -s nullglob
@@ -204,15 +229,6 @@ for c in "${categories[@]}"; do
     tests+=("${matched[@]}")
 done
 shopt -u nullglob
-
-# The one test deliberately failing a crawl, which wedged this leg twice at its
-# step timeout (#1126). Its name is what keeps it out of the globs above, so the
-# name is asserted: renaming it into one of them must red here, not on the runner.
-wedged=260_crawl-harness-fails-loudly.test
-test -e "$wedged" || {
-    echo "::error::$wedged is gone; a rename must stay clear of the globs above (#1126)"
-    exit 1
-}
 
 for t in "${tests[@]}"; do
     elapsed=$((SECONDS - started))
@@ -252,10 +268,19 @@ for t in "${tests[@]}"; do
         echo "FAIL $t (exit $rc)"
         # These assert with `test "$(...)" == "..." || exit 1`, which
         # says nothing at all on failure. Re-run traced, still bounded.
-        # Noted first, or a slow trace reads as a wedge to the watchdog,
-        # which would then kill the step in the middle of writing it.
-        echo "RERUN $t" >>"$progress"
-        run_with_timeout "$per_test" bash -x "$t" >>"$t.log" 2>&1 || true
+        # Charged to the suite deadline rather than given a budget of its
+        # own: a failure just under that deadline would else spend
+        # $per_test twice and land on the workflow's own timeout (#1126).
+        left=$((suite_deadline - (SECONDS - started)))
+        test "$left" -le "$per_test" || left=$per_test
+        if [ "$left" -gt 0 ]; then
+            # Noted first, or a slow trace reads as a wedge to the watchdog,
+            # which would then kill the step in the middle of writing it.
+            echo "RERUN $t" >>"$progress"
+            run_with_timeout "$left" bash -x "$t" >>"$t.log" 2>&1 || true
+        else
+            echo "no trace: past the ${suite_deadline}s suite deadline"
+        fi
         tail -n 25 "$t.log" | sed 's/^/      /'
         ;;
     esac


### PR DESCRIPTION
The Windows suite has no wall-clock bound. Its heartbeat kills only a progress log that has gone static, and the suite deadline is read between tests, but every path that follows a blown budget writes a progress line of its own, and each of those re-arms the staticness window. A test starting a second under the deadline can spend the per-test budget, then a traced rerun on a budget of its own, and land on the workflow's 45-minute step timeout. A cancelled step keeps neither its log nor its artifacts, so nobody learns what it was doing.

The heartbeat now takes an absolute cap and kills at 2400s whatever the progress log is doing, and the traced rerun is charged to the suite deadline instead of getting a second budget. 226 asserts the arithmetic against the workflow's own timeout, 171 drives the cap on its virtual clock against a suite that never stops reporting, and both assertions were checked by mutation. I could not reproduce any of this locally, since it needs a Windows runner, so the fix rests on reading the two scripts rather than on a repro.

The artifacts of the runs the issue cites are still live, and they say something else. Both Win32 legs finished the suite on their own terms and kept their step log and artifacts. Run 31397002827 ran 1264s and failed on 79_local-proxytrack-webdav-mime, whose proxytrack bound none of three port pairs; run 31405831680 ran 1060s and failed on 226 tripping over the new name in the driver's comment. 260 ran on both Windows legs of the first run and passed, in 11s on Win32 and 13s on x64, so it goes back into the selection through a crawl-harness category. The one real overrun is the x64 leg of 31405831680, which ran past 44 minutes and was cancelled with nothing surviving. 260 was already renamed out of the globs in that tree, so it was not the cause, and nothing survives to say what was.

Closes #1126
