### PR TITLE
A caught signal kills every in-flight transfer, and a stopped FTP transfer waits twice

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -2771,35 +2771,44 @@ void back_clean(httrackp * opt, cache_back * cache, struct_back * sback) {
   }
 }
 
-/* Slot waiting for a connection to come up: nothing requested on it yet. */
-static hts_boolean back_is_preconnect(const int status) {
-  return status == STATUS_WAIT_DNS || status == STATUS_CONNECTING ||
-         status == STATUS_SSL_WAIT_HANDSHAKE;
-}
-
-/* Drop the slots still waiting to connect: nothing to finish there, and left
-   alone they hold the drain for --timeout (#1073). Receiving slots stay. */
-static void back_stop_preconnect(httrackp *opt, struct_back *sback) {
+/* Tear down every live non-FTP slot with this outcome, returning the count: an
+   FTP slot is its worker thread's, which owns socket and slot. trunc archives a
+   partial body under that WARC-Truncated reason, WARC_TRUNC_NONE drops it. */
+static int back_abort_inflight(httrackp *opt, struct_back *sback,
+                               const int statuscode, const char *msg,
+                               const int trunc) {
   lien_back *const back = sback->lnk;
   int aborted = 0;
   int i;
 
   for (i = 0; i < sback->count; i++) {
-    if (!back_is_preconnect(back[i].status))
+    if (back[i].status <= 0 || back[i].status >= STATUS_FTP_TRANSFER)
       continue;
+    /* A cap-truncated body is deliberate, not broken: archive what arrived
+       with WARC-Truncated before the abort overwrites the slot's real 2xx
+       status. HTTrack still treats the slot as incomplete afterwards. */
+    if (trunc != WARC_TRUNC_NONE && StringNotEmpty(opt->warc_file) &&
+        back[i].r.statuscode > 0 && back[i].r.warc_resphdr != NULL &&
+        back[i].r.size > 0 &&
+        !(back[i].r.is_write && IS_DELAYED_EXT(back[i].url_sav))) {
+      if (back[i].r.is_write && back[i].r.out != NULL)
+        fflush(back[i].r.out);
+      back[i].r.warc_truncated = trunc;
+      warc_write_backtransaction(opt, &back[i]);
+    }
     if (back[i].r.soc != INVALID_SOCKET)
       deletehttp(&back[i].r);
     back[i].r.soc = INVALID_SOCKET;
-    /* fatal, as back_add() reports it: a stop must not schedule a retry */
-    back[i].r.statuscode = STATUSCODE_INVALID;
-    strcpybuff(back[i].r.msg, "mirror stopped by user");
+    /* drop a .delayed placeholder; real partials survive for resume */
+    if (back[i].r.is_write && IS_DELAYED_EXT(back[i].url_sav))
+      back_delayed_discard(opt, &back[i]);
+    back[i].r.statuscode = statuscode;
+    strcpybuff(back[i].r.msg, msg);
+    back[i].status = STATUS_READY;
     back_set_finished(sback, i);
     aborted++;
   }
-  if (aborted > 0)
-    hts_log_print(opt, LOG_WARNING,
-                  "Mirror stopped by user, %d pending connection(s) aborted",
-                  aborted);
+  return aborted;
 }
 
 // attente (gestion des buffers des sockets)
@@ -2831,50 +2840,30 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
   back_clean(opt, cache, sback);
 #endif
 
-  if (opt->state.stop)
-    back_stop_preconnect(opt, sback);
+  /* A stop finishes nothing, and a slot left in flight holds the drain for
+     --timeout (#1073, #1110). Fatal, so the link is not queued again. */
+  if (opt->state.stop) {
+    const int aborted =
+        back_abort_inflight(opt, sback, STATUSCODE_INVALID,
+                            "mirror stopped by user", WARC_TRUNC_NONE);
+
+    if (aborted > 0)
+      hts_log_print(opt, LOG_WARNING,
+                    "Mirror stopped by user, %d transfer(s) aborted", aborted);
+  }
 
   /* Time/size limit exceeded past grace: abort in-flight transfers so no wait
-     loop starves (#481, #77). FTP slots stay, their thread owns the socket. */
+     loop starves (#481, #77). */
   if (!back_checkmirror(opt)) {
     const hts_mirror_limit limit = back_mirror_limit(opt);
     const char *const reason =
         (limit == HTS_MIRROR_LIMIT_SIZE) ? "size limit" : "time limit";
-    const char *const slotmsg = (limit == HTS_MIRROR_LIMIT_SIZE)
-                                    ? "Mirror Size Limit"
-                                    : "Mirror Time Out";
-    int aborted = 0;
-    unsigned int i;
+    const int aborted = back_abort_inflight(
+        opt, sback, STATUSCODE_TIMEOUT,
+        (limit == HTS_MIRROR_LIMIT_SIZE) ? "Mirror Size Limit"
+                                         : "Mirror Time Out",
+        (limit == HTS_MIRROR_LIMIT_SIZE) ? WARC_TRUNC_LENGTH : WARC_TRUNC_TIME);
 
-    for (i = 0; i < (unsigned int) back_max; i++) {
-      if (back[i].status > 0 && back[i].status < STATUS_FTP_TRANSFER) {
-        /* A cap-truncated body is deliberate, not broken: archive what arrived
-           with WARC-Truncated before the abort overwrites the slot's real 2xx
-           status. HTTrack still treats the slot as incomplete afterwards. */
-        if (StringNotEmpty(opt->warc_file) && back[i].r.statuscode > 0 &&
-            back[i].r.warc_resphdr != NULL && back[i].r.size > 0 &&
-            !(back[i].r.is_write && IS_DELAYED_EXT(back[i].url_sav))) {
-          if (back[i].r.is_write && back[i].r.out != NULL)
-            fflush(back[i].r.out);
-          back[i].r.warc_truncated = (limit == HTS_MIRROR_LIMIT_SIZE)
-                                         ? WARC_TRUNC_LENGTH
-                                         : WARC_TRUNC_TIME;
-          warc_write_backtransaction(opt, &back[i]);
-        }
-        if (back[i].r.soc != INVALID_SOCKET) {
-          deletehttp(&back[i].r);
-        }
-        back[i].r.soc = INVALID_SOCKET;
-        /* drop a .delayed placeholder; real partials survive for resume */
-        if (back[i].r.is_write && IS_DELAYED_EXT(back[i].url_sav))
-          back_delayed_discard(opt, &back[i]);
-        back[i].r.statuscode = STATUSCODE_TIMEOUT;
-        strcpybuff(back[i].r.msg, slotmsg);
-        back[i].status = STATUS_READY;
-        back_set_finished(sback, i);
-        aborted++;
-      }
-    }
     if (aborted > 0)
       hts_log_print(opt, LOG_WARNING, "%s reached, %d transfer(s) aborted",
                     reason, aborted);
@@ -2999,7 +2988,13 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
 #if HTS_WIDE_DEBUG
       DEBUG_W("select\n");
 #endif
-      select((int) nfds, &fds, &fds_c, &fds_e, &tv);
+      /* An interrupted select() leaves the sets filled: read as-is, every
+         socket reads back as an exception and the loop kills it (#1110). */
+      if (select((int) nfds, &fds, &fds_c, &fds_e, &tv) <= 0) {
+        FD_ZERO(&fds);
+        FD_ZERO(&fds_c);
+        FD_ZERO(&fds_e);
+      }
 #if HTS_WIDE_DEBUG
       DEBUG_W("select done\n");
 #endif

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -96,6 +96,7 @@ typedef enum {
 } hts_mirror_limit;
 
 static hts_mirror_limit back_mirror_limit(httrackp *opt);
+static hts_boolean back_mirror_capped(const httrackp *opt);
 
 struct_back *back_new(httrackp *opt, int back_max) {
   int i;
@@ -2771,41 +2772,86 @@ void back_clean(httrackp * opt, cache_back * cache, struct_back * sback) {
   }
 }
 
-/* Tear down every live non-FTP slot with this outcome, returning the count: an
-   FTP slot is its worker thread's, which owns socket and slot. trunc archives a
-   partial body under that WARC-Truncated reason, WARC_TRUNC_NONE drops it. */
-static int back_abort_inflight(httrackp *opt, struct_back *sback,
-                               const int statuscode, const char *msg,
-                               const int trunc) {
-  lien_back *const back = sback->lnk;
+/* Slot waiting for a connection to come up: nothing requested on it yet. */
+static hts_boolean back_is_preconnect(const int status) {
+  return status == STATUS_WAIT_DNS || status == STATUS_CONNECTING ||
+         status == STATUS_SSL_WAIT_HANDSHAKE;
+}
+
+/* Slot carrying a transfer of ours. An FTP one is its worker thread's, which
+   owns socket and slot, so no sweep below may touch it. */
+static hts_boolean back_is_live(const int status) {
+  return status > 0 && status < STATUS_FTP_TRANSFER;
+}
+
+/* Tear down live slot p, reported as statuscode/msg. trunc is the
+   WARC-Truncated reason to archive its partial body under, WARC_TRUNC_NONE to
+   leave the body unarchived. */
+static void back_abort_slot(httrackp *opt, struct_back *sback, const int p,
+                            const int statuscode, const char *msg,
+                            const int trunc) {
+  lien_back *const back = &sback->lnk[p];
+
+  /* A cap-truncated body is deliberate, not broken: archive what arrived with
+     WARC-Truncated before the abort overwrites the slot's real 2xx status.
+     HTTrack still treats the slot as incomplete afterwards. */
+  if (trunc != WARC_TRUNC_NONE && StringNotEmpty(opt->warc_file) &&
+      back->r.statuscode > 0 && back->r.warc_resphdr != NULL &&
+      back->r.size > 0 &&
+      !(back->r.is_write && IS_DELAYED_EXT(back->url_sav))) {
+    if (back->r.is_write && back->r.out != NULL)
+      fflush(back->r.out);
+    back->r.warc_truncated = trunc;
+    warc_write_backtransaction(opt, back);
+  }
+  if (back->r.soc != INVALID_SOCKET)
+    deletehttp(&back->r);
+  back->r.soc = INVALID_SOCKET;
+  /* drop a .delayed placeholder; real partials survive for resume */
+  if (back->r.is_write && IS_DELAYED_EXT(back->url_sav))
+    back_delayed_discard(opt, back);
+  back->r.statuscode = statuscode;
+  strcpybuff(back->r.msg, msg);
+  back->status = STATUS_READY;
+  back_set_finished(sback, p);
+}
+
+/* Drop what a user stop must not leave running, and return the count. A cap
+   raises the stop flag itself, then grants the transfers already running a
+   grace that only back_abort_limit() may end (#77, #481). A slot still waiting
+   to connect has nothing to finish and would hold the drain (#1073). */
+static int back_abort_stopped(httrackp *opt, struct_back *sback) {
+  const hts_boolean grace = back_mirror_capped(opt);
   int aborted = 0;
   int i;
 
   for (i = 0; i < sback->count; i++) {
-    if (back[i].status <= 0 || back[i].status >= STATUS_FTP_TRANSFER)
+    const int status = sback->lnk[i].status;
+
+    if (!back_is_live(status) || (grace && !back_is_preconnect(status)))
       continue;
-    /* A cap-truncated body is deliberate, not broken: archive what arrived
-       with WARC-Truncated before the abort overwrites the slot's real 2xx
-       status. HTTrack still treats the slot as incomplete afterwards. */
-    if (trunc != WARC_TRUNC_NONE && StringNotEmpty(opt->warc_file) &&
-        back[i].r.statuscode > 0 && back[i].r.warc_resphdr != NULL &&
-        back[i].r.size > 0 &&
-        !(back[i].r.is_write && IS_DELAYED_EXT(back[i].url_sav))) {
-      if (back[i].r.is_write && back[i].r.out != NULL)
-        fflush(back[i].r.out);
-      back[i].r.warc_truncated = trunc;
-      warc_write_backtransaction(opt, &back[i]);
-    }
-    if (back[i].r.soc != INVALID_SOCKET)
-      deletehttp(&back[i].r);
-    back[i].r.soc = INVALID_SOCKET;
-    /* drop a .delayed placeholder; real partials survive for resume */
-    if (back[i].r.is_write && IS_DELAYED_EXT(back[i].url_sav))
-      back_delayed_discard(opt, &back[i]);
-    back[i].r.statuscode = statuscode;
-    strcpybuff(back[i].r.msg, msg);
-    back[i].status = STATUS_READY;
-    back_set_finished(sback, i);
+    /* fatal, as back_add() reports a stop: no retry may reschedule the link */
+    back_abort_slot(opt, sback, i, STATUSCODE_INVALID, "mirror stopped by user",
+                    WARC_TRUNC_NONE);
+    aborted++;
+  }
+  return aborted;
+}
+
+/* Abort every live slot once a cap has overrun its grace, and return the
+   count. Its partial body is archived: the truncation is the user's own cap. */
+static int back_abort_limit(httrackp *opt, struct_back *sback,
+                            const hts_mirror_limit limit) {
+  const hts_boolean size = limit == HTS_MIRROR_LIMIT_SIZE;
+  int aborted = 0;
+  int i;
+
+  for (i = 0; i < sback->count; i++) {
+    if (!back_is_live(sback->lnk[i].status))
+      continue;
+    back_abort_slot(opt, sback, i, STATUSCODE_TIMEOUT,
+                    size ? "Mirror Size Limit" : "Mirror Time Out",
+                    size ? WARC_TRUNC_LENGTH : WARC_TRUNC_TIME);
     aborted++;
   }
   return aborted;
@@ -2840,12 +2886,8 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
   back_clean(opt, cache, sback);
 #endif
 
-  /* A stop finishes nothing, and a slot left in flight holds the drain for
-     --timeout (#1073, #1110). Fatal, so the link is not queued again. */
   if (opt->state.stop) {
-    const int aborted =
-        back_abort_inflight(opt, sback, STATUSCODE_INVALID,
-                            "mirror stopped by user", WARC_TRUNC_NONE);
+    const int aborted = back_abort_stopped(opt, sback);
 
     if (aborted > 0)
       hts_log_print(opt, LOG_WARNING,
@@ -2858,11 +2900,7 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
     const hts_mirror_limit limit = back_mirror_limit(opt);
     const char *const reason =
         (limit == HTS_MIRROR_LIMIT_SIZE) ? "size limit" : "time limit";
-    const int aborted = back_abort_inflight(
-        opt, sback, STATUSCODE_TIMEOUT,
-        (limit == HTS_MIRROR_LIMIT_SIZE) ? "Mirror Size Limit"
-                                         : "Mirror Time Out",
-        (limit == HTS_MIRROR_LIMIT_SIZE) ? WARC_TRUNC_LENGTH : WARC_TRUNC_TIME);
+    const int aborted = back_abort_limit(opt, sback, limit);
 
     if (aborted > 0)
       hts_log_print(opt, LOG_WARNING, "%s reached, %d transfer(s) aborted",
@@ -2988,8 +3026,8 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
 #if HTS_WIDE_DEBUG
       DEBUG_W("select\n");
 #endif
-      /* An interrupted select() leaves the sets filled: read as-is, every
-         socket reads back as an exception and the loop kills it (#1110). */
+      /* Discard the sets select() did not write: on EINTR they still hold
+         every socket we filled in, which reads back as an error (#1110). */
       if (select((int) nfds, &fds, &fds_c, &fds_e, &tv) <= 0) {
         FD_ZERO(&fds);
         FD_ZERO(&fds_c);
@@ -4749,16 +4787,32 @@ static LLint back_maxsize_grace(const LLint maxsite) { return maxsite / 10; }
 /* Which cap has overrun its grace and must hard-stop the mirror (#77, #481).
    -M measures received volume (HTS_TOTAL_RECV), not saved 200-only stat_bytes
    which undercounts redirect/error-heavy crawls (#520). */
+static hts_boolean back_maxsize_reached(const httrackp *opt) {
+  return opt->maxsite > 0 && HTS_STAT.HTS_TOTAL_RECV >= opt->maxsite;
+}
+
+static hts_boolean back_maxtime_reached(const httrackp *opt) {
+  return opt->maxtime > 0 &&
+         (time_local() - HTS_STAT.stat_timestart) >= opt->maxtime;
+}
+
+/* A cap has been reached, so back_checkmirror() below is what raised the stop
+   flag: the stop the mirror is under is the engine's, not the user's. */
+static hts_boolean back_mirror_capped(const httrackp *opt) {
+  return back_maxsize_reached(opt) || back_maxtime_reached(opt);
+}
+
 static hts_mirror_limit back_mirror_limit(httrackp *opt) {
-  if (opt->maxsite > 0 && HTS_STAT.HTS_TOTAL_RECV >= opt->maxsite &&
-      HTS_STAT.HTS_TOTAL_RECV - opt->maxsite >=
-          back_maxsize_grace(opt->maxsite))
-    return HTS_MIRROR_LIMIT_SIZE;
-  if (opt->maxtime > 0) {
+  if (back_maxsize_reached(opt)) {
+    const LLint over = HTS_STAT.HTS_TOTAL_RECV - opt->maxsite;
+
+    if (over >= back_maxsize_grace(opt->maxsite))
+      return HTS_MIRROR_LIMIT_SIZE;
+  }
+  if (back_maxtime_reached(opt)) {
     const TStamp elapsed = time_local() - HTS_STAT.stat_timestart;
 
-    if (elapsed >= opt->maxtime &&
-        elapsed - opt->maxtime >= back_maxtime_grace(opt->maxtime))
+    if (elapsed - opt->maxtime >= back_maxtime_grace(opt->maxtime))
       return HTS_MIRROR_LIMIT_TIME;
   }
   return HTS_MIRROR_LIMIT_NONE;
@@ -4766,16 +4820,14 @@ static hts_mirror_limit back_mirror_limit(httrackp *opt) {
 
 int back_checkmirror(httrackp *opt) {
   /* request a smooth stop the first time each cap is reached */
-  if (opt->maxsite > 0 && HTS_STAT.HTS_TOTAL_RECV >= opt->maxsite &&
-      !opt->state.stop) {
+  if (back_maxsize_reached(opt) && !opt->state.stop) {
     hts_log_print(opt, LOG_ERROR,
                   "More than " LLintP
                   " bytes have been transferred.. giving up",
                   (LLint) opt->maxsite);
     hts_request_stop(opt, 0);
   }
-  if (opt->maxtime > 0 && !opt->state.stop &&
-      (time_local() - HTS_STAT.stat_timestart) >= opt->maxtime) {
+  if (back_maxtime_reached(opt) && !opt->state.stop) {
     hts_log_print(opt, LOG_ERROR, "More than %d seconds passed.. giving up",
                   opt->maxtime);
     hts_request_stop(opt, 0);

--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -992,10 +992,10 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
     _CHECK_HALT_FTP;
     strcpybuff(back->info, "quit");
     send_line(soc_ctl, "QUIT"); // bye bye
-    /* A stopped mirror gets no second --timeout window on a reply that is
-       courtesy, and whose text is discarded anyway (#1096). */
-    get_ftp_line(back, soc_ctl, NULL, 0,
-                 (opt != NULL && opt->state.stop) ? 0 : timeout, opt);
+    /* A stopped mirror skips the second --timeout window this courtesy reply
+       costs on a silent server; its text is discarded anyway (#1096). */
+    if (!opt->state.stop)
+      get_ftp_line(back, soc_ctl, NULL, 0, timeout, opt);
 #ifdef _WIN32
     closesocket(soc_ctl);
 #else

--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -992,7 +992,10 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
     _CHECK_HALT_FTP;
     strcpybuff(back->info, "quit");
     send_line(soc_ctl, "QUIT"); // bye bye
-    get_ftp_line(back, soc_ctl, NULL, 0, timeout, opt);
+    /* A stopped mirror gets no second --timeout window on a reply that is
+       courtesy, and whose text is discarded anyway (#1096). */
+    get_ftp_line(back, soc_ctl, NULL, 0,
+                 (opt != NULL && opt->state.stop) ? 0 : timeout, opt);
 #ifdef _WIN32
     closesocket(soc_ctl);
 #else

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -8014,9 +8014,45 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
     CHECK(back[SLOT_FTP].r.statuscode == STATUSCODE_TIMEOUT);
     CHECK(strcmp(back[SLOT_FTP].r.msg, "untouched") == 0);
   }
+
+  /* A cap raises the stop flag itself and leaves the transfers already running
+     a grace (#77, #481): the sweep takes the pre-connect slots only until the
+     grace overruns, and back_wait's own limit block ends the rest. */
+  if (!err) {
+    const LLint recv_was = HTS_STAT.HTS_TOTAL_RECV;
+
+    opt->state.stop = 0;
+    if (!st_backstop_arm(opt, sback, status, r, SLOTS, SLOT_DNS)) {
+      skipped = 1;
+      goto cleanup;
+    }
+    for (i = 0; i < SLOTS; i++)
+      swept[i] = r[i].soc;
+    /* cap reached, a tenth of it still to overrun before the hard stop */
+    HTS_STAT.HTS_TOTAL_RECV = 1000;
+    opt->maxsite = 1000;
+    hts_request_stop(opt, 0);
+
+    back_wait(sback, opt, &cache, 0);
+
+    for (i = SLOT_DNS; i < SLOT_HEADERS; i++) {
+      CHECK(back[i].status == STATUS_READY);
+      CHECK(back[i].r.statuscode == STATUSCODE_INVALID);
+    }
+    for (i = SLOT_HEADERS; i < SLOTS; i++) {
+      CHECK(back[i].status == status[i]);
+      CHECK(back[i].r.soc == swept[i]);
+      CHECK(st_backstop_soc_open(back[i].r.soc));
+      CHECK(back[i].r.statuscode == STATUSCODE_TIMEOUT);
+      CHECK(strcmp(back[i].r.msg, "untouched") == 0);
+    }
+    opt->maxsite = 0;
+    HTS_STAT.HTS_TOTAL_RECV = recv_was;
+  }
 #undef CHECK
 
 cleanup:
+  opt->maxsite = 0;
   opt->state.stop = 0;
   for (i = 0; i < SLOTS; i++)
     deletehttp(&back[i].r);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -7910,15 +7910,14 @@ static hts_boolean st_backstop_arm(httrackp *opt, struct_back *sback,
   return HTS_TRUE;
 }
 
-/* A user stop must drop only the slots still waiting to connect (#1073). */
+/* A user stop must drop every slot but the FTP one (#1073, #1110). */
 static int st_backstop(httrackp *opt, int argc, char **argv) {
-  /* pre-connect first, then the states a stop must leave running: two of the
-     receive automaton, and the FTP one whose socket another thread owns */
+  /* the states a stop sweeps, pre-connect then receive, and last the FTP one
+     whose socket another thread owns */
   enum {
     SLOT_DNS = 0,
     SLOT_CONNECT,
     SLOT_SSL,
-    SLOT_LAST_PRECONNECT = SLOT_SSL,
     SLOT_HEADERS,
     SLOT_XFER,
     SLOT_CHUNK,
@@ -7997,9 +7996,9 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
 
     back_wait(sback, opt, &cache, 0);
 
-    /* every pre-connect slot is gone, its socket closed rather than merely
+    /* every slot but the FTP one is gone, its socket closed rather than merely
        forgotten, and reported as fatal so the link is not queued again */
-    for (i = SLOT_DNS; i <= SLOT_LAST_PRECONNECT; i++) {
+    for (i = SLOT_DNS; i < SLOT_FTP; i++) {
       CHECK(back[i].status == STATUS_READY);
       CHECK(back[i].r.soc == INVALID_SOCKET);
       CHECK(back[i].r.statuscode == STATUSCODE_INVALID);
@@ -8007,15 +8006,13 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
       if (swept[i] != INVALID_SOCKET)
         CHECK(!st_backstop_soc_open(swept[i]));
     }
-    /* control: a started transfer is what the stop lets finish, and the FTP
-       socket belongs to another thread; a wider sweep is the wrong fix */
-    for (i = SLOT_HEADERS; i < SLOTS; i++) {
-      CHECK(back[i].status == status[i]);
-      CHECK(back[i].r.soc == swept[i]);
-      CHECK(st_backstop_soc_open(back[i].r.soc));
-      CHECK(back[i].r.statuscode == STATUSCODE_TIMEOUT);
-      CHECK(strcmp(back[i].r.msg, "untouched") == 0);
-    }
+    /* control: an FTP worker is still writing through this slot, so a sweep
+       reaching it frees a socket and a buffer under a live thread */
+    CHECK(back[SLOT_FTP].status == status[SLOT_FTP]);
+    CHECK(back[SLOT_FTP].r.soc == swept[SLOT_FTP]);
+    CHECK(st_backstop_soc_open(back[SLOT_FTP].r.soc));
+    CHECK(back[SLOT_FTP].r.statuscode == STATUSCODE_TIMEOUT);
+    CHECK(strcmp(back[SLOT_FTP].r.msg, "untouched") == 0);
   }
 #undef CHECK
 

--- a/tests/246_engine-connect-stop.test
+++ b/tests/246_engine-connect-stop.test
@@ -1,7 +1,8 @@
 #!/bin/bash
 #
-# A user stop must drop the slots still waiting to connect, instead of holding
-# the drain for the whole --timeout (#1073).
+# A user stop must drop every slot, waiting to connect (#1073) or receiving
+# (#1110), instead of holding the drain for the whole --timeout. All but the
+# FTP one, whose worker thread is still writing through it.
 
 set -euo pipefail
 

--- a/tests/262_local-signal-receive.test
+++ b/tests/262_local-signal-receive.test
@@ -1,0 +1,116 @@
+#!/bin/bash
+#
+# back_wait() discarded select()'s return, and EINTR leaves the fd sets exactly
+# as they were filled: every socket then read back as an exception and the slot
+# died as "Receive Error" (#1110). The prompt ^C users rely on came from that
+# same accident, so the stop check that replaces it is asserted here too.
+
+set -euo pipefail
+
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
+
+skip_on_windows "MSYS cannot signal a native httrack.exe"
+command -v httrack >/dev/null || fail "could not find httrack"
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_sigrecv.XXXXXX")
+crawlpid=
+cleanup() {
+    test -z "$crawlpid" || kill_tree "$crawlpid"
+    rm -rf "$tmpdir"
+}
+cleanup_push cleanup
+
+ok() { echo "OK: $*"; }
+
+# Verbose, so a request line in the server log says a body is in flight.
+local_server_start --env LOCAL_SERVER_VERBOSE=1
+
+out="${tmpdir}/crawl"
+log="${tmpdir}/log"
+start_crawl() {
+    local url=$1
+    shift
+    rm -rf "${out:?}"
+    mkdir -p "$out"
+    httrack "$url" -O "$out" --quiet --disable-security-limits --robots=0 \
+        --retries=0 "$@" >"$log" 2>&1 &
+    crawlpid=$!
+}
+
+# wait_bounded folds its timeout and the crawl's own status into one return, so
+# a crash reads as a hang. Tell them apart, or the message names the wrong bug.
+await_exit() {
+    local rc=0
+    wait_bounded "$crawlpid" "$1" || rc=$?
+    crawlpid=
+    test "$rc" -ne 124 || fail "$2 was still running ${1}s later"
+    test "$rc" -eq 0 || fail "$2 exited $rc instead of unwinding cleanly"
+}
+
+# $1 requests, as the server logs them, before the crawl is deemed in flight.
+await_requests() {
+    local deadline=$((SECONDS + 60))
+    until test "$(command grep -ac "$1" "$SRV_LOG" || true)" -ge "$2"; do
+        test "$SECONDS" -lt "$deadline" || fail "the crawl never fetched $1"
+        poll_wait 1
+    done
+}
+
+# --- a benign signal must cost nothing ---------------------------------------
+# SIGCHLD is caught (sig_ignore) and asks for nothing: the one shape of signal
+# that has no business ending a transfer. /dcancel/ trickles 4096 bytes over
+# 1.6s apiece, so the burst below spans bodies that are in flight throughout.
+start_crawl "${BASEURL}/dcancel/index.html" --timeout=30 --max-time=0 -c4
+await_requests 'GET /dcancel/p0.bin' 1
+for _ in $(seq 1 40); do
+    kill -CHLD "$crawlpid" 2>/dev/null || break
+    poll_wait 0.1
+done
+await_exit 120 "the signalled crawl"
+
+! command grep -q 'Receive Error' "${out}/hts-log.txt" ||
+    fail "a benign signal was reported as a socket error: $(cat "${out}/hts-log.txt")"
+# And what the retry queue makes of it afterwards is not the engine's choice to
+# make: the bodies have to arrive whole.
+mirror="${out}/127.0.0.1_${SRV_PORT}/dcancel"
+for i in 0 1 2 3 4 5 6 7; do
+    size=$(wc -c <"${mirror}/p${i}.bin" 2>/dev/null || echo 0)
+    test "$size" -eq 4096 ||
+        fail "p${i}.bin is ${size} bytes, not 4096: $(find "$out" -type f)"
+done
+ok "40 SIGCHLDs cost no transfer"
+
+# --- the same crawl, unsignalled ---------------------------------------------
+# Nothing above is evidence if the fixture cannot mirror on its own.
+start_crawl "${BASEURL}/dcancel/index.html" --timeout=30 --max-time=0 -c4
+await_exit 120 "the plain crawl"
+for i in 0 1 2 3 4 5 6 7; do
+    size=$(wc -c <"${mirror}/p${i}.bin" 2>/dev/null || echo 0)
+    test "$size" -eq 4096 ||
+        fail "unsignalled p${i}.bin is ${size} bytes, not 4096"
+done
+ok "an unsignalled crawl mirrors the same eight files"
+
+# --- ^C still ends a stalled transfer, and says why --------------------------
+# --timeout=0 --max-time=0: no bound of any kind is left, so only the stop
+# check can end this crawl, and it cannot be mistaken for a timeout firing.
+start_crawl "${BASEURL}/watchdog/stall" --timeout=0 --max-time=0
+await_requests 'GET /watchdog/stall' 1
+started=$SECONDS
+kill -INT "$crawlpid"
+await_exit 60 "the interrupted crawl"
+elapsed=$((SECONDS - started))
+test "$elapsed" -lt 15 || fail "^C took ${elapsed}s to end a stalled transfer"
+command grep -q 'Finishing pending transfers' "$log" ||
+    fail "the ^C never reached sig_leave: $(cat "$log")"
+command grep -q 'Thanks for using HTTrack' "$log" ||
+    fail "the stop skipped teardown: $(cat "$log")"
+htslog=$(cat "${out}/hts-log.txt")
+command grep -q 'stopped by user' <<<"$htslog" ||
+    fail "the abort was not reported as the user's stop: ${htslog}"
+# The fabricated error is the bug: a stop reported as a socket failure is what
+# sends the link to the retry queue and marks the mirror broken.
+! command grep -q 'Receive Error' <<<"$htslog" ||
+    fail "the stop was reported as a socket error: ${htslog}"
+ok "^C ended the stalled transfer in ${elapsed}s, reported as a stop"

--- a/tests/262_local-signal-receive.test
+++ b/tests/262_local-signal-receive.test
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# back_wait() discarded select()'s return, and EINTR leaves the fd sets exactly
-# as they were filled: every socket then read back as an exception and the slot
-# died as "Receive Error" (#1110). The prompt ^C users rely on came from that
-# same accident, so the stop check that replaces it is asserted here too.
+# back_wait() discarded select()'s return. EINTR leaves the fd sets as filled,
+# so every socket read back as an exception and the slot died as "Receive
+# Error" (#1110). A ^C ended a download quickly through that same accident, so
+# the stop check that replaces it is asserted here too.
 
 set -euo pipefail
 
@@ -48,28 +48,38 @@ await_exit() {
     test "$rc" -eq 0 || fail "$2 exited $rc instead of unwinding cleanly"
 }
 
-# $1 requests, as the server logs them, before the crawl is deemed in flight.
+# Wait until the server has logged $2 requests matching $1.
 await_requests() {
-    local deadline=$((SECONDS + 60))
-    until test "$(command grep -ac "$1" "$SRV_LOG" || true)" -ge "$2"; do
-        test "$SECONDS" -lt "$deadline" || fail "the crawl never fetched $1"
+    local pattern=$1 count=$2 deadline=$((SECONDS + 60))
+    until test "$(grep -ac "$pattern" "$SRV_LOG" || true)" -ge "$count"; do
+        test "$SECONDS" -lt "$deadline" || fail "the crawl never fetched $pattern"
         poll_wait 1
     done
 }
 
+# How many of the eight bodies the server has been asked for so far.
+bodies_requested() { grep -ac 'GET /dcancel/p' "$SRV_LOG" || true; }
+
 # --- a benign signal must cost nothing ---------------------------------------
 # SIGCHLD is caught (sig_ignore) and asks for nothing: the one shape of signal
-# that has no business ending a transfer. /dcancel/ trickles 4096 bytes over
-# 1.6s apiece, so the burst below spans bodies that are in flight throughout.
+# that must never end a transfer. /dcancel/ trickles 4096 bytes over 1.6s
+# apiece, so the burst below spans bodies that are in flight throughout.
 start_crawl "${BASEURL}/dcancel/index.html" --timeout=30 --max-time=0 -c4
 await_requests 'GET /dcancel/p0.bin' 1
+started=$(bodies_requested)
 for _ in $(seq 1 40); do
     kill -CHLD "$crawlpid" 2>/dev/null || break
     poll_wait 0.1
 done
 await_exit 120 "the signalled crawl"
 
-! command grep -q 'Receive Error' "${out}/hts-log.txt" ||
+# Bodies still to be asked for when the burst began: without this a loaded box
+# can signal a crawl that is already done, and the leg passes having proved
+# nothing.
+test "$started" -lt 8 ||
+    fail "all eight bodies were already fetched before the first signal"
+
+! grep -q 'Receive Error' "${out}/hts-log.txt" ||
     fail "a benign signal was reported as a socket error: $(cat "${out}/hts-log.txt")"
 # And what the retry queue makes of it afterwards is not the engine's choice to
 # make: the bodies have to arrive whole.
@@ -95,22 +105,25 @@ ok "an unsignalled crawl mirrors the same eight files"
 # --- ^C still ends a stalled transfer, and says why --------------------------
 # --timeout=0 --max-time=0: no bound of any kind is left, so only the stop
 # check can end this crawl, and it cannot be mistaken for a timeout firing.
+# A generous ceiling on the unwind, not a window: no engine constant bounds it.
+STOP_CEILING=15
 start_crawl "${BASEURL}/watchdog/stall" --timeout=0 --max-time=0
 await_requests 'GET /watchdog/stall' 1
 started=$SECONDS
 kill -INT "$crawlpid"
 await_exit 60 "the interrupted crawl"
 elapsed=$((SECONDS - started))
-test "$elapsed" -lt 15 || fail "^C took ${elapsed}s to end a stalled transfer"
-command grep -q 'Finishing pending transfers' "$log" ||
+test "$elapsed" -lt "$STOP_CEILING" ||
+    fail "^C took ${elapsed}s to end a stalled transfer"
+grep -q 'Finishing pending transfers' "$log" ||
     fail "the ^C never reached sig_leave: $(cat "$log")"
-command grep -q 'Thanks for using HTTrack' "$log" ||
+grep -q 'Thanks for using HTTrack' "$log" ||
     fail "the stop skipped teardown: $(cat "$log")"
 htslog=$(cat "${out}/hts-log.txt")
-command grep -q 'stopped by user' <<<"$htslog" ||
+grep -q 'stopped by user' <<<"$htslog" ||
     fail "the abort was not reported as the user's stop: ${htslog}"
 # The fabricated error is the bug: a stop reported as a socket failure is what
 # sends the link to the retry queue and marks the mirror broken.
-! command grep -q 'Receive Error' <<<"$htslog" ||
+! grep -q 'Receive Error' <<<"$htslog" ||
     fail "the stop was reported as a socket error: ${htslog}"
 ok "^C ended the stalled transfer in ${elapsed}s, reported as a stop"

--- a/tests/263_local-ftp-stop-window.test
+++ b/tests/263_local-ftp-stop-window.test
@@ -67,7 +67,7 @@ await_transfer() {
     partial=
     until test -n "$partial"; do
         test "$SECONDS" -lt "$deadline" || fail "the crawl never started a transfer"
-        command grep -aq '^RETR ' "$cmds" 2>/dev/null && partial=$(find "$out" -name 'big.bin')
+        grep -aq '^RETR ' "$cmds" 2>/dev/null && partial=$(find "$out" -name 'big.bin')
         poll_wait 1
     done
 }
@@ -86,14 +86,14 @@ await_exit() {
 assert_outcome() {
     local reply htslog
     reply=$(cat "${tmpdir}/log")
-    command grep -q 'Thanks for using HTTrack' <<<"$reply" ||
+    grep -q 'Thanks for using HTTrack' <<<"$reply" ||
         fail "$1 skipped teardown: ${reply}"
     test -s "$partial" ||
         fail "$1 dropped the received prefix: $(find "$out" -type f)"
     htslog=$(cat "${out}/hts-log.txt")
     # The worker's own wait is what has to expire, not some outer bound: only
     # that wait writes this line, with the timeout it was given.
-    command grep -q "Time out (${TIMEOUT})" <<<"$htslog" ||
+    grep -q "Time out (${TIMEOUT})" <<<"$htslog" ||
         fail "$1 did not end on the transfer's own timeout: ${htslog}"
 }
 
@@ -104,7 +104,7 @@ started=$SECONDS
 kill -INT "$crawlpid"
 await_exit 60 "the interrupted crawl"
 stopped=$((SECONDS - started))
-command grep -q 'Finishing pending transfers' "${tmpdir}/log" ||
+grep -q 'Finishing pending transfers' "${tmpdir}/log" ||
     fail "the ^C never reached sig_leave: $(cat "${tmpdir}/log")"
 assert_outcome "the interrupted crawl"
 # Upper bound: the second window is gone. Lower bound: the first one is not,
@@ -124,4 +124,8 @@ started=$SECONDS
 await_exit 90 "the plain stalled crawl"
 plain=$((SECONDS - started))
 assert_outcome "the plain stalled crawl"
-ok "an unsignalled stalled crawl reaches the same end in ${plain}s"
+# And it pays both windows, where the ^C paid one: the clip belongs to the
+# stop, it is not a blanket shortening of the QUIT reply.
+test "$plain" -ge $((TIMEOUT + TIMEOUT / 2)) ||
+    fail "the unsignalled crawl took ${plain}s, under two ${TIMEOUT}s windows"
+ok "an unsignalled stalled crawl pays both windows, ${plain}s"

--- a/tests/263_local-ftp-stop-window.test
+++ b/tests/263_local-ftp-stop-window.test
@@ -1,0 +1,127 @@
+#!/bin/bash
+#
+# A stopped FTP transfer against a silent server waited out --timeout twice:
+# once on the data socket, then again on the QUIT reply nobody was going to
+# send (#1096). One window is the bound; the transfer still gets to spend it,
+# which is what 255's single-^C leg pins.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+python=$(find_python) || skip "python3 not found"
+skip_on_windows "MSYS cannot signal a native httrack.exe"
+command -v httrack >/dev/null || fail "could not find httrack"
+
+# Long enough that a second window stands well clear of the measuring noise,
+# short enough to keep the test under half a minute.
+TIMEOUT=8
+
+server=$(nativepath "${testdir}/ftp-server.py")
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpstop.XXXXXX")
+serverpid=
+crawlpid=
+cleanup() {
+    test -z "$crawlpid" || kill_tree "$crawlpid"
+    stop_server "$serverpid"
+    rm -rf "$tmpdir"
+}
+cleanup_push cleanup
+
+ok() { echo "OK: $*"; }
+
+root="${tmpdir}/root"
+out="${tmpdir}/crawl"
+cmds="${tmpdir}/cmds"
+modes="${tmpdir}/modes"
+mkdir -p "$root"
+# 800 KB, of which stall mode sends an eighth: past the 32768 bytes below which
+# the engine calls the session dead and rolls the mirror back.
+awk 'BEGIN { s = sprintf("%0999d", 0); for (i = 0; i < 800; i++) print s }' \
+    >"${root}/big.bin"
+printf '* stall\n' >"$modes"
+
+serverlog="${tmpdir}/server.out"
+"$python" "$server" --root "$(nativepath "$root")" \
+    --mode-file "$(nativepath "$modes")" \
+    --log "$(nativepath "$cmds")" >"$serverlog" 2>&1 &
+serverpid=$!
+port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+
+start_crawl() {
+    : >"$cmds"
+    rm -rf "${out:?}"
+    mkdir -p "$out"
+    httrack "ftp://127.0.0.1:${port}/big.bin" -O "$out" --quiet \
+        --disable-security-limits --robots=0 --retries=0 \
+        --timeout="$TIMEOUT" --max-time=0 >"${tmpdir}/log" 2>&1 &
+    crawlpid=$!
+}
+
+# Observed rather than slept for: the partial file appearing is what says the
+# data connection is up and the worker is parked on its wait.
+partial=
+await_transfer() {
+    local deadline=$((SECONDS + 60))
+    partial=
+    until test -n "$partial"; do
+        test "$SECONDS" -lt "$deadline" || fail "the crawl never started a transfer"
+        command grep -aq '^RETR ' "$cmds" 2>/dev/null && partial=$(find "$out" -name 'big.bin')
+        poll_wait 1
+    done
+}
+
+await_exit() {
+    local rc=0
+    wait_bounded "$crawlpid" "$1" || rc=$?
+    crawlpid=
+    test "$rc" -ne 124 || fail "$2 was still running ${1}s later"
+    test "$rc" -eq 0 || fail "$2 exited $rc instead of unwinding cleanly"
+}
+
+# Leaving the wait is only half of it: a stop that abandoned the worker, dropped
+# the link or crashed the unwind is also fast. What the mirror ends up holding
+# is the other half, and it is the same either way the run was ended.
+assert_outcome() {
+    local reply htslog
+    reply=$(cat "${tmpdir}/log")
+    command grep -q 'Thanks for using HTTrack' <<<"$reply" ||
+        fail "$1 skipped teardown: ${reply}"
+    test -s "$partial" ||
+        fail "$1 dropped the received prefix: $(find "$out" -type f)"
+    htslog=$(cat "${out}/hts-log.txt")
+    # The worker's own wait is what has to expire, not some outer bound: only
+    # that wait writes this line, with the timeout it was given.
+    command grep -q "Time out (${TIMEOUT})" <<<"$htslog" ||
+        fail "$1 did not end on the transfer's own timeout: ${htslog}"
+}
+
+# --- ^C during a stalled transfer --------------------------------------------
+start_crawl
+await_transfer
+started=$SECONDS
+kill -INT "$crawlpid"
+await_exit 60 "the interrupted crawl"
+stopped=$((SECONDS - started))
+command grep -q 'Finishing pending transfers' "${tmpdir}/log" ||
+    fail "the ^C never reached sig_leave: $(cat "${tmpdir}/log")"
+assert_outcome "the interrupted crawl"
+# Upper bound: the second window is gone. Lower bound: the first one is not,
+# so a stop must not cut a transfer's wait short the way #1107 did.
+test "$stopped" -lt $((TIMEOUT + TIMEOUT / 2)) ||
+    fail "^C still cost ${stopped}s, close to two ${TIMEOUT}s windows"
+test "$stopped" -ge $((TIMEOUT / 2)) ||
+    fail "^C cut the transfer's own wait short after ${stopped}s"
+ok "^C ended the stalled transfer in ${stopped}s, one ${TIMEOUT}s window"
+
+# --- the same stall, unsignalled ---------------------------------------------
+# The control the measurement needs: without the ^C the crawl ends the same way
+# on its own, so the timing above is the stop's cost and nothing else.
+start_crawl
+await_transfer
+started=$SECONDS
+await_exit 90 "the plain stalled crawl"
+plain=$((SECONDS - started))
+assert_outcome "the plain stalled crawl"
+ok "an unsignalled stalled crawl reaches the same end in ${plain}s"

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -288,8 +288,8 @@ echo "ran=$((pass + fail + skip)) pass=$pass fail=$fail skip=$skip" |
 # decode back to, which NTFS refuses;
 # memresume, repaircache and resume-recovery interrupt pass 1 with a signal
 # MSYS cannot deliver to a native exe;
-# ftp-deadhost-interrupt and ftp-sigterm need that same signal (deadhost's
-# --timeout half runs, as 245);
+# ftp-deadhost-interrupt, ftp-sigterm, signal-receive and ftp-stop-window need
+# that same signal (deadhost's --timeout half runs, as 245);
 # close-once interposes close() through LD_PRELOAD, which MSYS has no equivalent for.
 expected_skips="01_engine-footer-overflow.test
 253_local-ftp-close-once.test
@@ -303,6 +303,8 @@ expected_skips="01_engine-footer-overflow.test
 215_engine-datadir-ospath.test
 243_local-ftp-deadhost-interrupt.test
 255_local-ftp-sigterm.test
+262_local-signal-receive.test
+263_local-ftp-stop-window.test
 235_local-resume-recovery.test
 48_local-crange-memresume.test
 71_local-crange-repaircache.test


### PR DESCRIPTION
`back_wait()` called `select()` and threw the return away. On EINTR Linux leaves the three fd sets exactly as the caller filled them, so every in-flight socket reads back as an exception and the slot dies with a fabricated "Receive Error": any caught signal costs a transfer, and on master a burst of SIGCHLD against a trickling body truncates the mirror. Reading the return is only half of it, because the prompt `^C` people rely on during an HTTP download exists only through that same accident. Nothing on the receive path ever read `opt->state.stop`, so a correct `select()` on its own would leave HTTP waiting out `--timeout` the way FTP does today. `back_wait()` now sweeps every live non-FTP slot when the stop flag is up, sharing the mirror-limit abort loop, and reports the user's stop instead of a socket failure. FTP slots are left alone: the worker thread owns both socket and slot, and finishing one under a live `fwrite()` is a use-after-free. So are the transfers running under a cap, because `back_checkmirror()` raises the same flag the first time `-M` or `--max-time` is reached: while that grace runs the sweep takes only the slots still waiting to connect, and the limit block that owns those transfers ends them with its own status and their WARC record.

On the FTP side a stopped transfer against a silent server waited out `--timeout` twice, once on the data socket and again on the QUIT reply nobody was going to send. Only the second window goes. The data wait keeps its own, since the first `^C` promises to finish pending transfers and clipping that wait truncates transfers still making progress (#1107). With `--timeout=0` a stop stays unbounded, which is what the user asked for, and a second `^C` already exits at once. No thread drain either: teardown is #1051, and a partial drain would hang the exit against that unbounded wait. Tests 262 and 263 cover both halves against a no-signal control arm, and the backstop self-test now pins the wider sweep with the FTP slot as its control.

Closes #1110
Closes #1096