### PR TITLE
Two suite tests fail on Debian's emulated hppa buildd

### DIFF
--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -132,18 +132,27 @@ saw_budget 0 "a disabled guard"
 # does not.
 cat >"$tmp/94_pacer.test" <<EOF
 . "${testdir}/testlib.sh"
-skip_if_out_of_budget 0 9999 # nothing left to run
-skip_if_out_of_budget 5 0    # steps that cost nothing
-skip_if_out_of_budget 5 40   # the next step alone wants 60s
+skip_if_out_of_budget 9 9 40  # nothing left to run
+skip_if_out_of_budget 5 10 0  # steps that cost nothing
+skip_if_out_of_budget 1 10 80 # step 1 is projected over itself alone: 120s
 echo "the pacer let it through"
 EOF
 rc=0
 HTTRACK_TEST_TIMEOUT=20 bash "$driver" "$tmp/94_pacer.test" >"$out" 2>&1 || rc=$?
-test "$rc" -eq 77 || fail "a 60s step under a 20s budget reported $rc, want 77"
+test "$rc" -eq 77 || fail "a 120s step under a 20s budget reported $rc, want 77"
 rc=0
 HTTRACK_TEST_TIMEOUT=600 bash "$driver" "$tmp/94_pacer.test" >"$out" 2>&1 || rc=$?
-test "$rc" -eq 0 || fail "a 60s step under a 600s budget reported $rc, want 0"
+test "$rc" -eq 0 || fail "a 120s step under a 600s budget reported $rc, want 0"
 grep -q 'the pacer let it through' "$out" || fail "the pacer skipped a test that fits"
+
+# Past step 1 every step left is reserved for, not just the next: 151 spent its
+# budget on twelve cheap cases and was killed with four expensive ones to go. The
+# step above is the control, same cost and budget, skipped only for being step 1.
+printf '. "%s"\nskip_if_out_of_budget 2 10 80\n' "${testdir}/testlib.sh" \
+    >"$tmp/96_project.test"
+rc=0
+HTTRACK_TEST_TIMEOUT=600 bash "$driver" "$tmp/96_project.test" >"$out" 2>&1 || rc=$?
+test "$rc" -eq 77 || fail "eight 80s steps under a 600s budget reported $rc, want 77"
 
 # --- the process lists survive a host with no ps ----------------------------
 # Fedora's build root ships no procps, and the guard then named nothing (#1021).
@@ -172,19 +181,30 @@ if ! is_windows && test -r /proc/self/stat; then
         "$tmp/httrack" -c "$hold" &
         echo $! >"$tmp/outside.pid"
     )
+    # A third, in the shape an emulated buildd hands the kernel: binfmt_misc with
+    # its P flag leaves the interpreter in argv[0] and the engine one place right.
+    # "exec -a" stands in for the qemu-user no runner here has.
+    mkdir "$tmp/emul"
+    printf '%s\n' "$hold" >"$tmp/emul/httrack"
+    (
+        exec -a /usr/libexec/qemu-binfmt/hppa-binfmt-P \
+            "$tmp/httrack" "$tmp/emul/httrack" &
+        echo $! >"$tmp/emul.pid"
+    )
     fake=$(cat "$tmp/fake.pid")
     outside=$(cat "$tmp/outside.pid")
+    emul=$(cat "$tmp/emul.pid")
     # Pushed, not trapped: a bare EXIT trap here would drop the stack that holds
     # $tmp and $shim, which is how $shim used to leak.
-    kill_probes() { kill "$fake" "$outside" 2>/dev/null || true; }
+    kill_probes() { kill "$fake" "$outside" "$emul" 2>/dev/null || true; }
     cleanup_push kill_probes
     # /proc holds the pid from the fork on, so a fake that never exec'd would fail
-    # some later assertion instead of this one.
+    # some later assertion instead of this one. Ten seconds: an emulated buildd
+    # spends whole seconds on an exec, and this returns as soon as it matches.
     running() {
-        local i=0 argv0
-        while test "$i" -lt 20; do
-            { read -r -d '' argv0 <"/proc/$1/cmdline"; } 2>/dev/null &&
-                test "${argv0##*/}" = httrack && return 0
+        local i=0
+        while test "$i" -lt 100; do
+            test "$(proc_program_name "$1")" = httrack && return 0
             sleep 0.1
             i=$((i + 1))
         done
@@ -192,6 +212,7 @@ if ! is_windows && test -r /proc/self/stat; then
     }
     running "$fake" || fail "the fake engine never started"
     running "$outside" || fail "the outsider never started"
+    running "$emul" || fail "an engine behind its binfmt interpreter never started"
     # ppid and pgid of $1: the oracle the listing is checked against.
     procfields() { awk '{ sub(/.*\) /, ""); print $2, $3 }' "/proc/$1/stat"; }
     procstate() { awk '{ sub(/.*\) /, ""); print $1 }' "/proc/$1/stat" 2>/dev/null || echo gone; }
@@ -214,6 +235,8 @@ if ! is_windows && test -r /proc/self/stat; then
             fail "no-ps row for $fake reads ppid/pgid '$rppid $rpgid', want '$fppid $pgid'"
         engines=$(list_engine_pids "$pgid")
         grep -qx "$fake" <<<"$engines" || fail "no-ps engine list lost pid $fake"
+        grep -qx "$emul" <<<"$engines" ||
+            fail "no-ps engine list lost emulated pid $emul"
         ! grep -qx "$outside" <<<"$engines" ||
             fail "no-ps engine list reached outside the group (pid $outside)"
         # A platform with no stack mechanism must say so and leave the engine
@@ -257,7 +280,8 @@ if ! is_windows && test -r /proc/self/stat; then
 fi
 
 # --- an emulated buildd hides the engine behind its binfmt interpreter -------
-# Synthetic rows: no runner here has qemu-user, and the column shift is the point.
+# The controls a real process cannot carry: a wrapper, and an emulator handed a
+# disk image rather than a program. No runner here has qemu-user, so synthesize.
 if ! is_windows; then
     (
         # shellcheck disable=SC2317 # reached through the two matchers below

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -132,27 +132,29 @@ saw_budget 0 "a disabled guard"
 # does not.
 cat >"$tmp/94_pacer.test" <<EOF
 . "${testdir}/testlib.sh"
-skip_if_out_of_budget 9 9 40  # nothing left to run
-skip_if_out_of_budget 5 10 0  # steps that cost nothing
-skip_if_out_of_budget 1 10 80 # step 1 is projected over itself alone: 120s
+skip_if_out_of_budget 0 9999 # nothing left to run
+skip_if_out_of_budget 5 0    # steps that cost nothing
+skip_if_out_of_budget 5 40   # the next step alone wants 60s
 echo "the pacer let it through"
 EOF
 rc=0
 HTTRACK_TEST_TIMEOUT=20 bash "$driver" "$tmp/94_pacer.test" >"$out" 2>&1 || rc=$?
-test "$rc" -eq 77 || fail "a 120s step under a 20s budget reported $rc, want 77"
+test "$rc" -eq 77 || fail "a 60s step under a 20s budget reported $rc, want 77"
 rc=0
 HTTRACK_TEST_TIMEOUT=600 bash "$driver" "$tmp/94_pacer.test" >"$out" 2>&1 || rc=$?
-test "$rc" -eq 0 || fail "a 120s step under a 600s budget reported $rc, want 0"
+test "$rc" -eq 0 || fail "a 60s step under a 600s budget reported $rc, want 0"
 grep -q 'the pacer let it through' "$out" || fail "the pacer skipped a test that fits"
 
-# Past step 1 every step left is reserved for, not just the next: 151 spent its
-# budget on twelve cheap cases and was killed with four expensive ones to go. The
-# step above is the control, same cost and budget, skipped only for being step 1.
-printf '. "%s"\nskip_if_out_of_budget 2 10 80\n' "${testdir}/testlib.sh" \
-    >"$tmp/96_project.test"
-rc=0
-HTTRACK_TEST_TIMEOUT=600 bash "$driver" "$tmp/96_project.test" >"$out" 2>&1 || rc=$?
-test "$rc" -eq 77 || fail "eight 80s steps under a 600s budget reported $rc, want 77"
+# The reserve is half a step over the last one, and only a budget between the two
+# sizes proves it: 100s alone would fit under 140, 150s does not.
+printf '. "%s"\nskip_if_out_of_budget 5 100\n' "${testdir}/testlib.sh" \
+    >"$tmp/96_margin.test"
+for want in 140:77 200:0; do
+    rc=0
+    HTTRACK_TEST_TIMEOUT=${want%%:*} bash "$driver" "$tmp/96_margin.test" >"$out" 2>&1 || rc=$?
+    test "$rc" -eq "${want##*:}" ||
+        fail "a 100s step under a ${want%%:*}s budget reported $rc, want ${want##*:}"
+done
 
 # --- the process lists survive a host with no ps ----------------------------
 # Fedora's build root ships no procps, and the guard then named nothing (#1021).
@@ -181,9 +183,9 @@ if ! is_windows && test -r /proc/self/stat; then
         "$tmp/httrack" -c "$hold" &
         echo $! >"$tmp/outside.pid"
     )
-    # A third, in the shape an emulated buildd hands the kernel: binfmt_misc with
-    # its P flag leaves the interpreter in argv[0] and the engine one place right.
-    # "exec -a" stands in for the qemu-user no runner here has.
+    # A third, as binfmt_misc's P flag hands it over: the interpreter in argv[0]
+    # and the engine one place right. "exec -a" stands in for the qemu no runner
+    # here has.
     mkdir "$tmp/emul"
     printf '%s\n' "$hold" >"$tmp/emul/httrack"
     (
@@ -198,9 +200,8 @@ if ! is_windows && test -r /proc/self/stat; then
     # $tmp and $shim, which is how $shim used to leak.
     kill_probes() { kill "$fake" "$outside" "$emul" 2>/dev/null || true; }
     cleanup_push kill_probes
-    # /proc holds the pid from the fork on, so a fake that never exec'd would fail
-    # some later assertion instead of this one. Ten seconds: an emulated buildd
-    # spends whole seconds on an exec, and this returns as soon as it matches.
+    # /proc holds the pid from the fork on, so a never-exec'd fake fails later,
+    # not here. Ten seconds covers an emulated exec, and it returns on the match.
     running() {
         local i=0
         while test "$i" -lt 100; do
@@ -276,12 +277,12 @@ if ! is_windows && test -r /proc/self/stat; then
         grep -q 'no process list' <<<"$(list_stray_processes "$pgid" group)" ||
             fail "a host with no ps and no /proc produced no notice"
     )
-    kill "$fake" "$outside" 2>/dev/null || true
+    kill "$fake" "$outside" "$emul" 2>/dev/null || true
 fi
 
 # --- an emulated buildd hides the engine behind its binfmt interpreter -------
-# The controls a real process cannot carry: a wrapper, and an emulator handed a
-# disk image rather than a program. No runner here has qemu-user, so synthesize.
+# Two cases the process above cannot carry: a wrapper, and an emulator given a
+# disk image instead of a program. No runner has qemu-user, so synthesize them.
 if ! is_windows; then
     (
         # shellcheck disable=SC2317 # reached through the two matchers below
@@ -293,7 +294,7 @@ PID PPID PGID ELAPSED S COMMAND
 13 1 40 12 S /bld/src/httrack -q http://h/
 14 1 40 12 S /usr/bin/strace /bld/src/httrack -q http://h/
 15 1 40 12 S /usr/bin/qemu-img convert /srv/local-server.py out.raw
-16 1 40 12 S /usr/bin/qemu-nbd /mnt/httrack
+16 1 40 12 S /usr/bin/qemu-nbd-static /mnt/httrack
 17 1 40 12 S /opt/my-custom-binfmt /mnt/httrack
 EOF
         }

--- a/tests/151_bash-shell-validate.test
+++ b/tests/151_bash-shell-validate.test
@@ -81,7 +81,7 @@ run() { # run <label> <env argument>...
     wait "$pid" || status=$?
     log=$(cat "$rundir/log")
     echo "run $n ($label): exit $status"
-    skip_if_out_of_budget "$n" "$cases" "$((SECONDS - began))"
+    skip_if_out_of_budget "$((cases - n))" "$((SECONDS - began))"
 }
 
 reject() { # reject <label> <expected message> <env argument>...
@@ -127,6 +127,16 @@ accept() {
     fi
 }
 
+# The four that configure to completion run first. A reject stops at the
+# BASH_SHELL check and costs a fraction of one, and the pacer projects the step it
+# just timed: behind the cheap ones it read far too low and 151 met the harness
+# kill instead (#1146). Positive control first, as in 196.
+accept override "$tmp/mybash" '' "BASH_SHELL=$tmp/mybash"
+accept empty '' '' BASH_SHELL=
+# No override: an unusable bash is a warning, so a box that has none still builds.
+accept searched "$tmp/fakebin/bash" 'no usable bash found' -u BASH_SHELL "PATH=$tmp/fakebin:$PATH"
+accept searched-posix-env '' 'POSIXLY_CORRECT or SHELLOPTS' -u BASH_SHELL POSIXLY_CORRECT=1
+
 reject relative 'BASH_SHELL must be an absolute path' BASH_SHELL=relbash
 notreg='is not an executable regular file'
 reject missing "$notreg" "BASH_SHELL=$tmp/missing/bash"
@@ -161,11 +171,5 @@ if grep -q 'POSIXLY_CORRECT or SHELLOPTS' <<<"$log"; then
     exit 1
 fi
 
-accept override "$tmp/mybash" '' "BASH_SHELL=$tmp/mybash"
-accept empty '' '' BASH_SHELL=
-# No override: an unusable bash is a warning, so a box that has none still builds.
-accept searched "$tmp/fakebin/bash" 'no usable bash found' -u BASH_SHELL "PATH=$tmp/fakebin:$PATH"
-accept searched-posix-env '' 'POSIXLY_CORRECT or SHELLOPTS' -u BASH_SHELL POSIXLY_CORRECT=1
-
-assert_steps_ran "$n" "$cases"
+assert_steps_ran "$cases" "$n"
 echo "configure validated $n BASH_SHELL values"

--- a/tests/151_bash-shell-validate.test
+++ b/tests/151_bash-shell-validate.test
@@ -81,7 +81,7 @@ run() { # run <label> <env argument>...
     wait "$pid" || status=$?
     log=$(cat "$rundir/log")
     echo "run $n ($label): exit $status"
-    skip_if_out_of_budget "$((cases - n))" "$((SECONDS - began))"
+    skip_if_out_of_budget "$n" "$cases" "$((SECONDS - began))"
 }
 
 reject() { # reject <label> <expected message> <env argument>...
@@ -167,8 +167,5 @@ accept empty '' '' BASH_SHELL=
 accept searched "$tmp/fakebin/bash" 'no usable bash found' -u BASH_SHELL "PATH=$tmp/fakebin:$PATH"
 accept searched-posix-env '' 'POSIXLY_CORRECT or SHELLOPTS' -u BASH_SHELL POSIXLY_CORRECT=1
 
-test "$n" -eq "$cases" || {
-    echo "ran $n cases, not the $cases the budget is paced against" >&2
-    exit 1
-}
+assert_steps_ran "$n" "$cases"
 echo "configure validated $n BASH_SHELL values"

--- a/tests/196_install-rpath-gates.test
+++ b/tests/196_install-rpath-gates.test
@@ -64,7 +64,7 @@ expect() {
     test "${got}" = "${want}" ||
         fail "${desc}: libhttrack.pc rpath is '${got}', expected '${want}': ${line}"
     echo "ok: ${desc} -> ${want}"
-    skip_if_out_of_budget "${n}" "${cases}" "$((SECONDS - began))"
+    skip_if_out_of_budget "$((cases - n))" "$((SECONDS - began))"
 }
 
 # The positive control first, or every "no" below could come from a probe that
@@ -76,4 +76,4 @@ expect no "a 32-bit multilib libdir does not" --prefix=/usr --libdir=/usr/lib32
 expect no "--disable-origin-rpath is honoured" --prefix="${work}/inst" --disable-origin-rpath
 expect no "a static build does not" --prefix="${work}/inst" --disable-shared
 
-assert_steps_ran "${n}" "${cases}"
+assert_steps_ran "${cases}" "${n}"

--- a/tests/196_install-rpath-gates.test
+++ b/tests/196_install-rpath-gates.test
@@ -64,7 +64,7 @@ expect() {
     test "${got}" = "${want}" ||
         fail "${desc}: libhttrack.pc rpath is '${got}', expected '${want}': ${line}"
     echo "ok: ${desc} -> ${want}"
-    skip_if_out_of_budget "$((cases - n))" "$((SECONDS - began))"
+    skip_if_out_of_budget "${n}" "${cases}" "$((SECONDS - began))"
 }
 
 # The positive control first, or every "no" below could come from a probe that
@@ -76,4 +76,4 @@ expect no "a 32-bit multilib libdir does not" --prefix=/usr --libdir=/usr/lib32
 expect no "--disable-origin-rpath is honoured" --prefix="${work}/inst" --disable-origin-rpath
 expect no "a static build does not" --prefix="${work}/inst" --disable-shared
 
-test "${n}" -eq "${cases}" || fail "ran ${n} cases, not the ${cases} the budget is paced against"
+assert_steps_ran "${n}" "${cases}"

--- a/tests/proclib.sh
+++ b/tests/proclib.sh
@@ -13,12 +13,12 @@ ENGINE_EXE_RE="^(lt-)?(${ENGINE_EXES// /|})([.]exe)?\$"
 ENGINE_IMAGE_RE="^(${ENGINE_EXES// /|})[.]exe"
 FIXTURE_SERVER_RE='^(local-server|proxy-https-server|proxy-connect-server|socks5-server|tls-stall-server)[.]py$'
 
-# Under qemu-user the kernel reports the binfmt interpreter as the command and
+# Under qemu-user the kernel reports the binfmt interpreter as the command, and
 # the program's own argv[0] lands one place right (Debian's hppa buildd
-# emulates). qemu-img and friends take a disk image, not a program, and these
-# lists feed kill: shifting past them would read the image path as the process.
+# emulates). qemu-img and friends take a disk image, not a program; these lists
+# feed kill, so shifting past one would read the image path as the process.
 QEMU_INTERP_RE='^qemu-[[:alnum:]_]+(-static)?$|^[[:alnum:]_]+-binfmt(-[[:upper:]]+)?$'
-QEMU_IMAGE_TOOL_RE='^qemu-(img|nbd|io|ga|edid|keymap)$'
+QEMU_IMAGE_TOOL_RE='^qemu-(img|nbd|io|ga|edid|keymap)(-static)?$'
 
 # awk prologue for the matchers below, taking those two as -v qint and -v qimg.
 # shellcheck disable=SC2016 # awk fields, not shell expansions
@@ -30,19 +30,14 @@ function qemushift(  n) {
     return n ~ qint ? 1 : 0
 }'
 
-# The name of the program pid $1 is running, empty if it is gone. Same shift as
-# qemushift(), against /proc rather than a process listing.
+# The name of the program pid $1 is running, empty if it is gone. Fed to the
+# prologue above as a one-row listing, so the shift is decided in one place.
 proc_program_name() { # proc_program_name <pid>
-    local a n
-    local -a argv=()
-    { while IFS= read -r -d '' a; do argv+=("$a"); done <"/proc/$1/cmdline"; } 2>/dev/null
-    test "${#argv[@]}" -gt 0 || return 1
-    n=${argv[0]##*/}
-    if test "${#argv[@]}" -gt 1 && [[ $n =~ $QEMU_INTERP_RE ]] &&
-        ! [[ $n =~ $QEMU_IMAGE_TOOL_RE ]]; then
-        n=${argv[1]##*/}
-    fi
-    printf '%s\n' "$n"
+    local a args=
+    { while IFS= read -r -d '' a; do args="${args:+$args }$a"; done <"/proc/$1/cmdline"; } 2>/dev/null
+    test -n "$args" || return 1
+    awk -v qint="$QEMU_INTERP_RE" -v qimg="$QEMU_IMAGE_TOOL_RE" "$AWK_PROC_NAMES"'
+        { print basen($(6 + qemushift())) }' <<<"1 1 1 0 S $args"
 }
 
 # Every process as "PID PPID PGID ELAPSED S COMMAND", header first. A Fedora

--- a/tests/proclib.sh
+++ b/tests/proclib.sh
@@ -13,19 +13,37 @@ ENGINE_EXE_RE="^(lt-)?(${ENGINE_EXES// /|})([.]exe)?\$"
 ENGINE_IMAGE_RE="^(${ENGINE_EXES// /|})[.]exe"
 FIXTURE_SERVER_RE='^(local-server|proxy-https-server|proxy-connect-server|socks5-server|tls-stall-server)[.]py$'
 
-# awk prologue for the matchers below: under qemu-user the kernel reports the
-# binfmt interpreter as the command, so the name we match on lands one column
-# right (Debian's hppa buildd emulates).
+# Under qemu-user the kernel reports the binfmt interpreter as the command and
+# the program's own argv[0] lands one place right (Debian's hppa buildd
+# emulates). qemu-img and friends take a disk image, not a program, and these
+# lists feed kill: shifting past them would read the image path as the process.
+QEMU_INTERP_RE='^qemu-[[:alnum:]_]+(-static)?$|^[[:alnum:]_]+-binfmt(-[[:upper:]]+)?$'
+QEMU_IMAGE_TOOL_RE='^qemu-(img|nbd|io|ga|edid|keymap)$'
+
+# awk prologue for the matchers below, taking those two as -v qint and -v qimg.
 # shellcheck disable=SC2016 # awk fields, not shell expansions
 AWK_PROC_NAMES='
 function basen(s) { sub(/.*[\/\\]/, "", s); return s }
 function qemushift(  n) {
     n = basen($6)
-    # qemu-img and friends take an image, not a program, and this list is fed to
-    # kill: shifting past them would read a disk path as the process name.
-    if (n ~ /^qemu-(img|nbd|io|ga|edid|keymap)$/) return 0
-    return n ~ /^qemu-[[:alnum:]_]+(-static)?$|^[[:alnum:]_]+-binfmt(-[[:upper:]]+)?$/ ? 1 : 0
+    if (n ~ qimg) return 0
+    return n ~ qint ? 1 : 0
 }'
+
+# The name of the program pid $1 is running, empty if it is gone. Same shift as
+# qemushift(), against /proc rather than a process listing.
+proc_program_name() { # proc_program_name <pid>
+    local a n
+    local -a argv=()
+    { while IFS= read -r -d '' a; do argv+=("$a"); done <"/proc/$1/cmdline"; } 2>/dev/null
+    test "${#argv[@]}" -gt 0 || return 1
+    n=${argv[0]##*/}
+    if test "${#argv[@]}" -gt 1 && [[ $n =~ $QEMU_INTERP_RE ]] &&
+        ! [[ $n =~ $QEMU_IMAGE_TOOL_RE ]]; then
+        n=${argv[1]##*/}
+    fi
+    printf '%s\n' "$n"
+}
 
 # Every process as "PID PPID PGID ELAPSED S COMMAND", header first. A Fedora
 # build root has no procps, and an empty list reads as "nothing running" (#1021).
@@ -95,6 +113,7 @@ list_stray_processes() {
         # and its script, for the Python fixtures).
         ps_snapshot |
             awk -v pg="$pgid" -v mode="$mode" -v eng="$ENGINE_EXE_RE" -v srv="$FIXTURE_SERVER_RE" \
+                -v qint="$QEMU_INTERP_RE" -v qimg="$QEMU_IMAGE_TOOL_RE" \
                 "$AWK_PROC_NAMES"'
                 NR == 1 { print; next }
                 { ingroup = (pg > 0 && $3 == pg)
@@ -141,7 +160,8 @@ list_engine_pids() {
     local pgid=${1:-0}
     test "$pgid" -gt 0 2>/dev/null || return 0
     ps_snapshot |
-        awk -v pg="$pgid" -v eng="$ENGINE_EXE_RE" "$AWK_PROC_NAMES"'
+        awk -v pg="$pgid" -v eng="$ENGINE_EXE_RE" \
+            -v qint="$QEMU_INTERP_RE" -v qimg="$QEMU_IMAGE_TOOL_RE" "$AWK_PROC_NAMES"'
             NR > 1 && $3 == pg { if (basen($(6 + qemushift())) ~ eng) print $1 }'
 }
 

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -40,6 +40,12 @@ assert_match() { # assert_match RE TEXT [LABEL]
 
 assert_file() { test -f "$1" || fail "${2:+$2: }missing file: $1"; }
 
+# Every step skip_if_out_of_budget projects against ran. A skip is an exit, so a
+# loop that quietly ran fewer paces against a count that is a lie.
+assert_steps_ran() { # assert_steps_ran WANT GOT
+    assert_eq "$1" "$2" "steps the budget is paced against"
+}
+
 # Run engine self-test NAME: stdout must equal WANT, status must be 0 (which a
 # `test "$(...)" = ...` cannot see). expect_ok takes a command, for a real -O.
 assert_selftest() { # assert_selftest WANT NAME [ARGS...]
@@ -450,29 +456,21 @@ EOF
     test "$(command -v sleep)" = "$dir/sleep" || return 1
 }
 
-# Skip when the steps left of a run of $2, at 1.5x the $3 seconds the last one
-# took, no longer fit the budget meant to catch a wedge (hppa spends ~150s on one
-# configure run and would else FTBFS on the harness kill). Every step left, not
-# just the next: 151 pays for a full configure only in its last four cases, so a
-# reserve of one cheap reject let it walk into the kill with four to go. Step 1
-# is the exception, projected over itself alone -- 196 warms a shared
-# config.cache there, and over the rest that would skip a run that fits.
-skip_if_out_of_budget() { # skip_if_out_of_budget <steps done> <steps total> <seconds the last took>
-    local budget=${HTTRACK_TEST_TIMEOUT:-600} left=$(($2 - $1)) need
+# Skip when the next of $1 remaining steps, at 1.5x the $2 seconds the last one
+# took, no longer fits the budget meant to catch a wedge (hppa spends ~150s on one
+# configure run and would else FTBFS). One step ahead rather than all of them:
+# projecting a single sample over the whole tail skips a run that fits whenever
+# one step is slower than its neighbours. It asks an ordering of the callers
+# instead, expensive steps first, so no step left can outrun the reserve the one
+# before it set (#1146).
+skip_if_out_of_budget() { # skip_if_out_of_budget <steps left> <seconds the last took>
+    local budget=${HTTRACK_TEST_TIMEOUT:-600} need=$(($2 + $2 / 2))
 
     case "$budget" in '' | *[!0-9]*) budget=600 ;; esac
-    test "$left" -gt 0 && test "$budget" -gt 0 || return 0
-    need=$(($3 + $3 / 2))
-    test "$1" -le 1 || need=$((left * $3 + $3 / 2))
+    test "$1" -gt 0 && test "$budget" -gt 0 || return 0
     test "$((SECONDS + need))" -ge "$budget" || return 0
-    echo "$left steps left, the last took ${3}s and the budget is ${budget}s; skipping" >&2
+    echo "$1 steps left, the last took ${2}s and the budget is ${budget}s; skipping" >&2
     exit 77
-}
-
-# Every step the pacer projects against ran: a skip is an exit, so a loop that
-# quietly ran fewer would leave the budget paced against a count that is a lie.
-assert_steps_ran() { # assert_steps_ran <steps done> <steps total>
-    test "$1" -eq "$2" || fail "ran $1 steps, not the $2 the budget is paced against"
 }
 
 # Collect a killed job, giving up after REAP_GRACE seconds. kill_tree can fail to

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -450,19 +450,29 @@ EOF
     test "$(command -v sleep)" = "$dir/sleep" || return 1
 }
 
-# Skip when the next of $1 remaining steps, at 1.5x the $2 seconds the last one
-# took, no longer fits the budget meant to catch a wedge (hppa spends ~150s on one
-# configure run and would else FTBFS). One step ahead rather than all of them: 196
-# shares a config.cache, so its first step costs several times the rest and
-# projecting it over them would skip a run that fits.
-skip_if_out_of_budget() { # skip_if_out_of_budget <steps left> <seconds the last took>
-    local budget=${HTTRACK_TEST_TIMEOUT:-600} need=$(($2 + $2 / 2))
+# Skip when the steps left of a run of $2, at 1.5x the $3 seconds the last one
+# took, no longer fit the budget meant to catch a wedge (hppa spends ~150s on one
+# configure run and would else FTBFS on the harness kill). Every step left, not
+# just the next: 151 pays for a full configure only in its last four cases, so a
+# reserve of one cheap reject let it walk into the kill with four to go. Step 1
+# is the exception, projected over itself alone -- 196 warms a shared
+# config.cache there, and over the rest that would skip a run that fits.
+skip_if_out_of_budget() { # skip_if_out_of_budget <steps done> <steps total> <seconds the last took>
+    local budget=${HTTRACK_TEST_TIMEOUT:-600} left=$(($2 - $1)) need
 
     case "$budget" in '' | *[!0-9]*) budget=600 ;; esac
-    test "$1" -gt 0 && test "$budget" -gt 0 || return 0
+    test "$left" -gt 0 && test "$budget" -gt 0 || return 0
+    need=$(($3 + $3 / 2))
+    test "$1" -le 1 || need=$((left * $3 + $3 / 2))
     test "$((SECONDS + need))" -ge "$budget" || return 0
-    echo "$1 steps left, the last took ${2}s and the budget is ${budget}s; skipping" >&2
+    echo "$left steps left, the last took ${3}s and the budget is ${budget}s; skipping" >&2
     exit 77
+}
+
+# Every step the pacer projects against ran: a skip is an exit, so a loop that
+# quietly ran fewer would leave the budget paced against a count that is a lie.
+assert_steps_ran() { # assert_steps_ran <steps done> <steps total>
+    test "$1" -eq "$2" || fail "ran $1 steps, not the $2 the budget is paced against"
 }
 
 # Collect a killed job, giving up after REAP_GRACE seconds. kill_tree can fail to


### PR DESCRIPTION
Debian's hppa buildd is a qemu-user chroot, and two suite tests fail there in 3.49.20-1, taking the package build down with them.

105 read the first field of `/proc/<pid>/cmdline` as the program name. binfmt_misc gives that field to the interpreter, so the test's own probe never saw its fake engine start. proclib has handled that shift since #1026, so `proc_program_name` routes through the same awk prologue rather than deciding it a second time in bash.

151 was killed at the 600s budget with four cases to go. The pacer reserves one step ahead, which cannot see 151's shape: twelve cheap rejects that stop at the BASH_SHELL check, then four cases that run configure to completion. The fix is the ordering, not a cleverer estimate. Reserving every remaining step at the last one's cost was the obvious alternative and it is worse, because one slow step then projects over the whole tail and skips a run that fits: a 2x outlier in 196's case 2 skips a run that ends at 562s of 600. With the expensive cases first, no step left can outrun the reserve the one before it set.

No runner has qemu-user, but `exec -a` reproduces the buildd's cmdline exactly, so 105 starts a real process in that shape instead of trusting a synthetic listing. Under a shrunken budget the old order reproduces the buildd's exit 124 locally and the new one exits 77. Two things found on the way: `qemu-img-static` and friends escaped the image-tool exclusion and so could be shifted past into `kill -9`, and no fixture covered the reserve's half-step margin.

Closes #1146