### PR TITLE
Installed headers break under some include orders

### DIFF
--- a/src/htsbasenet.h
+++ b/src/htsbasenet.h
@@ -39,6 +39,10 @@ Please visit our Website: http://www.httrack.com
 #ifndef HTS_DEFBASENETH
 #define HTS_DEFBASENETH
 
+/* HTS_INET6 and HTS_USEOPENSSL are tested below, and this guard gives only the
+   first include a chance to act on them. */
+#include "htsglobal.h"
+
 #ifdef _WIN32
 
 #if HTS_INET6 == 0

--- a/src/htsbasenet.h
+++ b/src/htsbasenet.h
@@ -39,8 +39,8 @@ Please visit our Website: http://www.httrack.com
 #ifndef HTS_DEFBASENETH
 #define HTS_DEFBASENETH
 
-/* HTS_INET6 and HTS_USEOPENSSL are tested below, and this guard gives only the
-   first include a chance to act on them. */
+/* Must precede the HTS_INET6 and HTS_USEOPENSSL tests below, which
+   HTS_DEFBASENETH lets only the first include reach. */
 #include "htsglobal.h"
 
 #ifdef _WIN32

--- a/src/htsstrings.h
+++ b/src/htsstrings.h
@@ -41,7 +41,7 @@ Please visit our Website: http://www.httrack.com
 #include <stdlib.h>
 #include <string.h>
 
-/* The attribute helpers, from their single definition: a partial copy here
+/* Take the attribute helpers from their single definition: a partial copy here
    would win their #ifndef guard and starve later headers of the rest. */
 #include "htsglobal.h"
 

--- a/src/htsstrings.h
+++ b/src/htsstrings.h
@@ -41,20 +41,9 @@ Please visit our Website: http://www.httrack.com
 #include <stdlib.h>
 #include <string.h>
 
-/* GCC extension */
-#ifndef HTS_UNUSED
-#ifdef __GNUC__
-#define HTS_UNUSED __attribute__((unused))
-
-#define HTS_STATIC static __attribute__((unused))
-
-#define HTS_PRINTF_FUN(fmt, arg) __attribute__((format(printf, fmt, arg)))
-#else
-#define HTS_UNUSED
-#define HTS_STATIC static
-#define HTS_PRINTF_FUN(fmt, arg)
-#endif
-#endif
+/* The attribute helpers, from their single definition: a partial copy here
+   would win their #ifndef guard and starve later headers of the rest. */
+#include "htsglobal.h"
 
 /** Forward definitions **/
 #ifndef HTS_DEF_FWSTRUCT_String

--- a/tests/206_install-headers-c99.test
+++ b/tests/206_install-headers-c99.test
@@ -79,16 +79,7 @@ env MAKEFLAGS= MFLAGS= "$make" -C "$abs_top_builddir/src" install-DevIncludesDAT
 headers=("$tmp/include/httrack"/*.h)
 # Derived from DevIncludes_DATA so a new header needs no edit here. A header
 # dropped from that list moves both sides, hence the named checks below.
-declared=$(awk '/^DevIncludes_DATA[[:space:]]*=/ { inlist = 1 }
-    inlist {
-        last = ($0 !~ /\\$/)
-        sub(/^[^=]*=/, "")
-        gsub(/\\/, " ")
-        for (i = 1; i <= NF; i++)
-            if ($i ~ /\.h$/) n++
-        if (last) exit
-    }
-    END { print n + 0 }' "${abs_top_srcdir:?}/src/Makefile.am")
+declared=$(declared_header_count)
 [ "$declared" -ge 10 ] || fail "read only $declared headers out of DevIncludes_DATA, the parse is wrong"
 [ "${#headers[@]}" -eq "$declared" ] ||
     fail "${#headers[@]} headers installed, DevIncludes_DATA declares $declared"

--- a/tests/261_install-headers-order.test
+++ b/tests/261_install-headers-order.test
@@ -1,0 +1,99 @@
+#!/bin/bash
+#
+# A consumer picks its own include order, so every ordered pair of installed
+# headers must compile. Each one alone already does (205, 206), which is what
+# let two order-only breaks ship: a partial macro copy and a config-less guard.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+if [ -z "${abs_top_builddir:-}" ]; then
+    echo "abs_top_builddir unset, no automake environment, skipping" >&2
+    exit 77
+fi
+[ -f "$abs_top_builddir/src/Makefile" ] || fail "$abs_top_builddir/src is not configured"
+
+# CC carries flags on some legs ("gcc -m32", "ccache gcc"), so split it.
+read -r -a cc_argv <<<"${CC:-cc}"
+command -v "${cc_argv[0]}" >/dev/null 2>&1 || skip "no C compiler (${cc_argv[0]})"
+make=${MAKE:-make}
+command -v "$make" >/dev/null 2>&1 || skip "no make ($make)"
+
+tmp=$(mktemp -d) || exit 1
+cleanup_push rm -rf "$tmp"
+
+cpp_argv=(-I"$tmp/include")
+if [ -n "${TEST_CPPFLAGS:-}" ]; then
+    read -r -a extra_argv <<<"$TEST_CPPFLAGS"
+    cpp_argv+=("${extra_argv[@]}")
+fi
+
+# Positive control: a compiler that cannot find its own libc headers would
+# blame ours instead.
+printf '#include <stdio.h>\n' >"$tmp/tu.c"
+if ! "${cc_argv[@]}" "${cpp_argv[@]}" -fsyntax-only "$tmp/tu.c" 2>"$tmp/cc.log"; then
+    head -5 "$tmp/cc.log" >&2
+    echo "${cc_argv[*]} cannot compile a bare <stdio.h>, skipping" >&2
+    exit 77
+fi
+
+env MAKEFLAGS= MFLAGS= "$make" -C "$abs_top_builddir/src" install-DevIncludesDATA \
+    DevIncludesdir="$tmp/include/httrack" >"$tmp/install.log" 2>&1 ||
+    {
+        cat "$tmp/install.log" >&2
+        fail "install-DevIncludesDATA failed"
+    }
+
+headers=()
+for h in "$tmp/include/httrack"/*.h; do headers+=("$(basename "$h")"); done
+[ "${#headers[@]}" -ge 10 ] || fail "only ${#headers[@]} headers installed, the list cannot be right"
+
+cxx=""
+for cand in "${CXX:-}" g++ clang++ c++; do
+    [ -n "$cand" ] && command -v "$cand" >/dev/null 2>&1 && {
+        cxx="$cand"
+        break
+    }
+done
+[ -n "$cxx" ] || echo "no C++ compiler found, C leg only" >&2
+
+# Before trusting the sweep, prove it sees the shape it is here for: a
+# consumer that defined one attribute helper first used to starve htssafe.h of
+# HTS_CHECK_RESULT, because the guard is over the block, not the macro.
+printf '#define HTS_UNUSED\n#include <httrack/htssafe.h>\n' >"$tmp/poison.c"
+if "${cc_argv[@]}" "${cpp_argv[@]}" -fsyntax-only "$tmp/poison.c" 2>/dev/null; then
+    fail "a pre-defined HTS_UNUSED no longer breaks htssafe.h, this sweep proves nothing"
+fi
+
+bad=0
+for a in "${headers[@]}"; do
+    for b in "${headers[@]}"; do
+        [ "$a" = "$b" ] && continue
+        printf '#include <httrack/%s>\n#include <httrack/%s>\n' "$a" "$b" >"$tmp/tu.c"
+        if ! "${cc_argv[@]}" "${cpp_argv[@]}" -fsyntax-only "$tmp/tu.c" 2>"$tmp/cc.log"; then
+            echo "$a then $b does not compile as C:" >&2
+            head -5 "$tmp/cc.log" >&2
+            bad=1
+        fi
+        [ -n "$cxx" ] || continue
+        cp "$tmp/tu.c" "$tmp/tu.cpp"
+        if ! "$cxx" "${cpp_argv[@]}" -fsyntax-only "$tmp/tu.cpp" 2>"$tmp/cc.log"; then
+            echo "$a then $b does not compile as C++:" >&2
+            head -5 "$tmp/cc.log" >&2
+            bad=1
+        fi
+    done
+done
+[ "$bad" -eq 0 ] || fail "installed headers do not survive every include order"
+
+echo "swept ${#headers[@]} headers pairwise, both orders${cxx:+, C and C++}" >&2
+
+# The loop above is only meaningful if this compiler rejects a missing include.
+printf '#include "no-such-header-261.h"\n' >"$tmp/tu.c"
+if "${cc_argv[@]}" "${cpp_argv[@]}" -fsyntax-only "$tmp/tu.c" 2>/dev/null; then
+    fail "${cc_argv[*]} accepted a missing include, the checks above proved nothing"
+fi
+
+exit 0

--- a/tests/269_install-headers-order.test
+++ b/tests/269_install-headers-order.test
@@ -2,7 +2,9 @@
 #
 # A consumer picks its own include order, so every ordered pair of installed
 # headers must compile. 205 and 206 compile each one alone, where all of them
-# pass, so neither can see an order-only break.
+# pass, so neither can see an order-only break. Pairs are the practical bound:
+# a break needing three headers, or a macro the consumer defined first, is out
+# of reach here.
 
 set -euo pipefail
 
@@ -48,7 +50,14 @@ env MAKEFLAGS= MFLAGS= "$make" -C "$abs_top_builddir/src" install-DevIncludesDAT
 
 headers=()
 for h in "$tmp/include/httrack"/*.h; do headers+=("$(basename "$h")"); done
-[ "${#headers[@]}" -ge 10 ] || fail "only ${#headers[@]} headers installed, the list cannot be right"
+# A sweep over a set that quietly lost members passes for the wrong reason.
+declared=$(declared_header_count)
+[ "$declared" -ge 10 ] || fail "read only $declared headers out of DevIncludes_DATA, the parse is wrong"
+[ "${#headers[@]}" -eq "$declared" ] ||
+    fail "${#headers[@]} headers installed, DevIncludes_DATA declares $declared"
+for h in htssafe.h htsstrings.h htsbasenet.h htsopt.h; do
+    [ -f "$tmp/include/httrack/$h" ] || fail "$h was not installed"
+done
 
 cxx=""
 for cand in "${CXX:-}" g++ clang++ c++; do
@@ -59,35 +68,50 @@ for cand in "${CXX:-}" g++ clang++ c++; do
 done
 [ -n "$cxx" ] || echo "no C++ compiler found, C leg only" >&2
 
-# Prove the sweep can see a real break: the guard covers the whole attribute
-# block, so a pre-defined HTS_UNUSED must still make htssafe.h fail.
-printf '#define HTS_UNUSED\n#include <httrack/htssafe.h>\n' >"$tmp/poison.c"
-if "${cc_argv[@]}" "${cpp_argv[@]}" -fsyntax-only "$tmp/poison.c" 2>/dev/null; then
-    fail "a pre-defined HTS_UNUSED no longer breaks htssafe.h, this sweep proves nothing"
-fi
-
-bad=0
-for a in "${headers[@]}"; do
-    for b in "${headers[@]}"; do
-        [ "$a" = "$b" ] && continue
-        printf '#include <httrack/%s>\n#include <httrack/%s>\n' "$a" "$b" >"$tmp/tu.c"
-        if ! "${cc_argv[@]}" "${cpp_argv[@]}" -fsyntax-only "$tmp/tu.c" 2>"$tmp/cc.log"; then
-            echo "$a then $b does not compile as C:" >&2
+# Compile one ordered pair in every mode the sweep uses. Callers read $bad.
+sweep_pair() { # sweep_pair FIRST SECOND
+    local a=$1 b=$2 mode
+    printf '#include <httrack/%s>\n#include <httrack/%s>\n' "$a" "$b" >"$tmp/tu.c"
+    cp "$tmp/tu.c" "$tmp/tu.cpp"
+    for mode in -UHTS_INTERNAL_BYTECODE -DHTS_INTERNAL_BYTECODE; do
+        if ! "${cc_argv[@]}" "${cpp_argv[@]}" "$mode" -fsyntax-only "$tmp/tu.c" 2>"$tmp/cc.log"; then
+            echo "$a then $b does not compile as C ($mode):" >&2
             head -5 "$tmp/cc.log" >&2
             bad=1
         fi
         [ -n "$cxx" ] || continue
-        cp "$tmp/tu.c" "$tmp/tu.cpp"
-        if ! "$cxx" "${cpp_argv[@]}" -fsyntax-only "$tmp/tu.cpp" 2>"$tmp/cc.log"; then
-            echo "$a then $b does not compile as C++:" >&2
+        if ! "$cxx" "${cpp_argv[@]}" "$mode" -fsyntax-only "$tmp/tu.cpp" 2>"$tmp/cc.log"; then
+            echo "$a then $b does not compile as C++ ($mode):" >&2
             head -5 "$tmp/cc.log" >&2
             bad=1
         fi
     done
+}
+
+# Control: a pair that breaks in one order only, which the sweep must catch.
+# Synthetic, because asserting a real header still breaks would forbid ever
+# hardening it.
+mkdir -p "$tmp/include/httrack"
+printf '#define HTS_PROBE_269_TAKEN 1\n' >"$tmp/include/httrack/probe269-first.h"
+printf '#ifndef HTS_PROBE_269_TAKEN\ntypedef int probe269_t;\n#endif\nprobe269_t probe269_f(void);\n' \
+    >"$tmp/include/httrack/probe269-second.h"
+cleanup_push rm -f "$tmp/include/httrack/probe269-first.h" "$tmp/include/httrack/probe269-second.h"
+bad=0
+sweep_pair probe269-second.h probe269-first.h
+[ "$bad" -eq 0 ] || fail "the probe pair fails in its good order too, the control is broken"
+sweep_pair probe269-first.h probe269-second.h 2>/dev/null
+[ "$bad" -ne 0 ] || fail "the sweep missed a pair that only compiles in one order, so it proves nothing"
+rm -f "$tmp/include/httrack/probe269-first.h" "$tmp/include/httrack/probe269-second.h"
+
+bad=0
+for a in "${headers[@]}"; do
+    for b in "${headers[@]}"; do
+        [ "$a" = "$b" ] || sweep_pair "$a" "$b"
+    done
 done
 [ "$bad" -eq 0 ] || fail "installed headers do not survive every include order"
 
-echo "swept ${#headers[@]} headers pairwise, both orders${cxx:+, C and C++}" >&2
+echo "swept ${#headers[@]} headers pairwise x 2 bytecode modes${cxx:+, C and C++}" >&2
 
 # The loop above is only meaningful if this compiler rejects a missing include.
 printf '#include "no-such-header-269.h"\n' >"$tmp/tu.c"

--- a/tests/269_install-headers-order.test
+++ b/tests/269_install-headers-order.test
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
 # A consumer picks its own include order, so every ordered pair of installed
-# headers must compile. Each one alone already does (205, 206), which is what
-# let two order-only breaks ship: a partial macro copy and a config-less guard.
+# headers must compile. 205 and 206 compile each one alone, where all of them
+# pass, so neither can see an order-only break.
 
 set -euo pipefail
 
@@ -59,9 +59,8 @@ for cand in "${CXX:-}" g++ clang++ c++; do
 done
 [ -n "$cxx" ] || echo "no C++ compiler found, C leg only" >&2
 
-# Before trusting the sweep, prove it sees the shape it is here for: a
-# consumer that defined one attribute helper first used to starve htssafe.h of
-# HTS_CHECK_RESULT, because the guard is over the block, not the macro.
+# Prove the sweep can see a real break: the guard covers the whole attribute
+# block, so a pre-defined HTS_UNUSED must still make htssafe.h fail.
 printf '#define HTS_UNUSED\n#include <httrack/htssafe.h>\n' >"$tmp/poison.c"
 if "${cc_argv[@]}" "${cpp_argv[@]}" -fsyntax-only "$tmp/poison.c" 2>/dev/null; then
     fail "a pre-defined HTS_UNUSED no longer breaks htssafe.h, this sweep proves nothing"
@@ -91,7 +90,7 @@ done
 echo "swept ${#headers[@]} headers pairwise, both orders${cxx:+, C and C++}" >&2
 
 # The loop above is only meaningful if this compiler rejects a missing include.
-printf '#include "no-such-header-261.h"\n' >"$tmp/tu.c"
+printf '#include "no-such-header-269.h"\n' >"$tmp/tu.c"
 if "${cc_argv[@]}" "${cpp_argv[@]}" -fsyntax-only "$tmp/tu.c" 2>/dev/null; then
     fail "${cc_argv[*]} accepted a missing include, the checks above proved nothing"
 fi

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -184,6 +184,21 @@ stage_install_exec() {
     stage_install_target install-exec "$1" "$2"
 }
 
+# How many headers DevIncludes_DATA declares, so a caller can tell a shrunken
+# install from a complete one and refuse to sweep a set that lost members.
+declared_header_count() {
+    awk '/^DevIncludes_DATA[[:space:]]*=/ { inlist = 1 }
+        inlist {
+            last = ($0 !~ /\\$/)
+            sub(/^[^=]*=/, "")
+            gsub(/\\/, " ")
+            for (i = 1; i <= NF; i++)
+                if ($i ~ /\.h$/) n++
+            if (last) exit
+        }
+        END { print n + 0 }' "${abs_top_srcdir:?}/src/Makefile.am"
+}
+
 IS_WINDOWS=
 is_windows() {
     if test -z "$IS_WINDOWS"; then


### PR DESCRIPTION
A consumer picks its own include order, and five ordered pairs of our installed headers do not compile. Both causes are a guard placed over a block that a later, better-informed include should still have got to run: htsstrings.h kept a partial copy of htsglobal.h's attribute helpers behind the same `#ifndef HTS_UNUSED`, so including it first starved htssafe.h of `HTS_CHECK_RESULT`; htsbasenet.h tested `HTS_USEOPENSSL` before anything had defined it, and its own `HTS_DEFBASENETH` then locked the OpenSSL block out for good, leaving `SSL` undeclared in htsopt.h. Both now include htsglobal.h rather than guess at it.

The first one is not hypothetical. It shipped in 3.49.15 and broke httraqt, our only reverse dependency, as an RC-severity FTBFS ([Debian #1143660](https://bugs.debian.org/1143660)); Debian worked around it downstream by dropping the include and it never reached us, so it is still live in 3.49.20. The second has never been reported and turned up while sweeping for the first.

205 and 206 could not catch either, because they compile each installed header on its own, and on its own every header passes. 269 sweeps all 182 ordered pairs in C and C++ and in both `HTS_INTERNAL_BYTECODE` states, six installed headers gating declarations on that macro. Its control is a synthetic pair that compiles in one order only: it proves the sweep can see the shape it hunts, without asserting that any real header stays broken. Verified by reverting each fix in turn, each failing 269 alone and naming its own pair, and by making the sweep vacuous, which the control catches.

Closes #1150
Closes #1151

