### PR TITLE
The site menu is injected at a guessed `</header>`, not a marker

### DIFF
--- a/html/abuse.html
+++ b/html/abuse.html
@@ -13,12 +13,14 @@
 <body>
 
 <!-- doc-chrome:top -->
+<!-- doc-chrome:masthead -->
 <a class="skip" href="#main">Skip to content</a>
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
 	<div class="tagline">Free software offline browser</div>
 </header>
+<!-- /doc-chrome:masthead -->
 
 <div class="wrap">
 

--- a/html/cache.html
+++ b/html/cache.html
@@ -13,12 +13,14 @@
 <body>
 
 <!-- doc-chrome:top -->
+<!-- doc-chrome:masthead -->
 <a class="skip" href="#main">Skip to content</a>
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
 	<div class="tagline">Free software offline browser</div>
 </header>
+<!-- /doc-chrome:masthead -->
 
 <div class="wrap">
 

--- a/html/changes.html
+++ b/html/changes.html
@@ -13,12 +13,14 @@
 <body>
 
 <!-- doc-chrome:top -->
+<!-- doc-chrome:masthead -->
 <a class="skip" href="#main">Skip to content</a>
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
 	<div class="tagline">Free software offline browser</div>
 </header>
+<!-- /doc-chrome:masthead -->
 
 <div class="wrap">
 

--- a/html/cmdguide.html
+++ b/html/cmdguide.html
@@ -13,12 +13,14 @@
 <body>
 
 <!-- doc-chrome:top -->
+<!-- doc-chrome:masthead -->
 <a class="skip" href="#main">Skip to content</a>
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
 	<div class="tagline">Free software offline browser</div>
 </header>
+<!-- /doc-chrome:masthead -->
 
 <div class="wrap">
 

--- a/html/contact.html
+++ b/html/contact.html
@@ -23,12 +23,14 @@
 <body>
 
 <!-- doc-chrome:top -->
+<!-- doc-chrome:masthead -->
 <a class="skip" href="#main">Skip to content</a>
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
 	<div class="tagline">Free software offline browser</div>
 </header>
+<!-- /doc-chrome:masthead -->
 
 <div class="wrap">
 

--- a/html/dev.html
+++ b/html/dev.html
@@ -13,12 +13,14 @@
 <body>
 
 <!-- doc-chrome:top -->
+<!-- doc-chrome:masthead -->
 <a class="skip" href="#main">Skip to content</a>
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
 	<div class="tagline">Free software offline browser</div>
 </header>
+<!-- /doc-chrome:masthead -->
 
 <div class="wrap">
 

--- a/html/faq.html
+++ b/html/faq.html
@@ -13,12 +13,14 @@
 <body>
 
 <!-- doc-chrome:top -->
+<!-- doc-chrome:masthead -->
 <a class="skip" href="#main">Skip to content</a>
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
 	<div class="tagline">Free software offline browser</div>
 </header>
+<!-- /doc-chrome:masthead -->
 
 <div class="wrap">
 

--- a/html/fcguide.html
+++ b/html/fcguide.html
@@ -13,12 +13,14 @@
 <body>
 
 <!-- doc-chrome:top -->
+<!-- doc-chrome:masthead -->
 <a class="skip" href="#main">Skip to content</a>
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
 	<div class="tagline">Free software offline browser</div>
 </header>
+<!-- /doc-chrome:masthead -->
 
 <div class="wrap">
 

--- a/html/filters.html
+++ b/html/filters.html
@@ -13,12 +13,14 @@
 <body>
 
 <!-- doc-chrome:top -->
+<!-- doc-chrome:masthead -->
 <a class="skip" href="#main">Skip to content</a>
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
 	<div class="tagline">Free software offline browser</div>
 </header>
+<!-- /doc-chrome:masthead -->
 
 <div class="wrap">
 

--- a/html/library.html
+++ b/html/library.html
@@ -13,12 +13,14 @@
 <body>
 
 <!-- doc-chrome:top -->
+<!-- doc-chrome:masthead -->
 <a class="skip" href="#main">Skip to content</a>
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
 	<div class="tagline">Free software offline browser</div>
 </header>
+<!-- /doc-chrome:masthead -->
 
 <div class="wrap">
 

--- a/html/plug.html
+++ b/html/plug.html
@@ -13,12 +13,14 @@
 <body>
 
 <!-- doc-chrome:top -->
+<!-- doc-chrome:masthead -->
 <a class="skip" href="#main">Skip to content</a>
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
 	<div class="tagline">Free software offline browser</div>
 </header>
+<!-- /doc-chrome:masthead -->
 
 <div class="wrap">
 

--- a/html/plug_330.html
+++ b/html/plug_330.html
@@ -13,12 +13,14 @@
 <body>
 
 <!-- doc-chrome:top -->
+<!-- doc-chrome:masthead -->
 <a class="skip" href="#main">Skip to content</a>
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
 	<div class="tagline">Free software offline browser</div>
 </header>
+<!-- /doc-chrome:masthead -->
 
 <div class="wrap">
 

--- a/html/scripting.html
+++ b/html/scripting.html
@@ -13,12 +13,14 @@
 <body>
 
 <!-- doc-chrome:top -->
+<!-- doc-chrome:masthead -->
 <a class="skip" href="#main">Skip to content</a>
 
 <header class="masthead">
 	<img src="images/wordmark.svg" width="400" height="36" alt="HTTrack Website Copier">
 	<div class="tagline">Free software offline browser</div>
 </header>
+<!-- /doc-chrome:masthead -->
 
 <div class="wrap">
 

--- a/tools/doc-chrome.py
+++ b/tools/doc-chrome.py
@@ -3,8 +3,8 @@
 
 The documentation is read from disk as often as over http, so it cannot use server
 includes: the navigation is real markup in every page, written here and verified by
-CI. Pages opt in by carrying the doc-chrome markers; --convert adds them to a page
-still using the 2007 table layout.
+CI. Pages opt in by carrying the doc-chrome markers, mandatory once a page loads
+doc.css; --convert adds them to a page still using the 2007 table layout.
 
     tools/doc-chrome.py                 rewrite the chrome regions in place
     tools/doc-chrome.py --check         fail if any page is out of sync
@@ -194,7 +194,7 @@ def chrome(page, content):
         nav.append("\t</ul>")
     nav.append("</nav>")
 
-    # Marked even inside top: httrack.com injects its site menu right after it.
+    # Marked inside top too, so every page exposes httrack.com's injection point.
     top = [
         MARK["masthead"][0],
         *MASTHEAD,
@@ -323,7 +323,7 @@ def main():
             continue
         owned += 1
         after = rewrite(path, before)
-        # Assert the bytes that ship, not the regenerated form, which always has it.
+        # Check the bytes that ship, not the regenerated form, which always has it.
         if MARK["masthead"][0] not in (before if args.check else after):
             print(f"{page}: no {MARK['masthead'][0]} marker")
             stale += 1

--- a/tools/doc-chrome.py
+++ b/tools/doc-chrome.py
@@ -194,8 +194,11 @@ def chrome(page, content):
         nav.append("\t</ul>")
     nav.append("</nav>")
 
+    # Marked even inside top: httrack.com injects its site menu right after it.
     top = [
+        MARK["masthead"][0],
         *MASTHEAD,
+        MARK["masthead"][1],
         "",
         '<div class="wrap">',
         "",
@@ -313,9 +316,17 @@ def main():
         with open(path, encoding="utf-8") as fp:
             before = fp.read()
         if MARK["top"][0] not in before and MARK["masthead"][0] not in before:
+            # A doc.css page without markers would drop out of the check, not fail it.
+            if 'href="doc.css"' in before:
+                print(f"{page}: loads doc.css but carries no doc-chrome marker")
+                stale += 1
             continue
         owned += 1
         after = rewrite(path, before)
+        # Assert the bytes that ship, not the regenerated form, which always has it.
+        if MARK["masthead"][0] not in (before if args.check else after):
+            print(f"{page}: no {MARK['masthead'][0]} marker")
+            stale += 1
         if after == before:
             continue
         if args.check:


### PR DESCRIPTION
httrack.com serves the `html/` pages through a wrapper that injects the site menu under the masthead, and it locates that spot by finding the first `</header>`. Only `index.html` and `guide.html` carry a literal `<!-- doc-chrome:masthead -->`. The other 13 get their masthead emitted inside the generated `top` region, so its content is governed while the marker itself never reaches the shipped bytes.

`doc-chrome.py` now emits the markers as part of `top`, so all 15 pages expose the same injection point and `--check` keeps them there. Shipped bytes change by exactly those two comment lines per page and nothing else, which matters because the site copies these files verbatim. Two checks make the guarantee direct rather than resting on "it sits in a generated region": a page carrying the chrome whose file has lost the marker fails `--check`, and a page loading `doc.css` with no markers at all is now an error instead of dropping out of the check unnoticed.