### PR TITLE
Nothing in CI builds our only consumer of the installed headers

### DIFF
--- a/.github/workflows/httraqt.yml
+++ b/.github/workflows/httraqt.yml
@@ -1,12 +1,16 @@
 # Build HTTraQt, the only consumer of our installed headers, against this branch.
 name: HTTraQt
 
+# Filtered, so it must never join the required set: a check that a path filter
+# skips stays "Expected" forever and blocks the merge.
 on:
   push:
     branches: [master]
-    paths: ['src/**', 'configure.ac', '.github/workflows/httraqt.yml']
+    paths: ['src/**', 'm4/**', 'configure.ac', '.github/workflows/httraqt.yml']
   pull_request:
-    paths: ['src/**', 'configure.ac', '.github/workflows/httraqt.yml']
+    paths: ['src/**', 'm4/**', 'configure.ac', '.github/workflows/httraqt.yml']
+  schedule:
+    - cron: '37 05 * * 1'  # upstream is pinned; this catches drift in Qt and the runner image
   workflow_dispatch:
 
 permissions:
@@ -38,7 +42,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             build-essential autoconf automake libtool autoconf-archive \
             zlib1g-dev libssl-dev libbrotli-dev libzstd-dev \
-            cmake qt6-base-dev qt6-multimedia-dev libgl-dev
+            cmake qt6-base-dev qt6-multimedia-dev
 
       - name: Build and install libhttrack
         run: |
@@ -54,9 +58,8 @@ jobs:
       - name: Assert no distribution libhttrack can shadow ours
         run: |
           set -euo pipefail
-          # FindHttrack.cmake hardcodes /usr/include/httrack first, so a stray
-          # libhttrack-dev would silently make this job test Debian's headers.
-          for stray in /usr/include/httrack /usr/lib/*/libhttrack.so; do
+          # FindHttrack.cmake hardcodes /usr/include/httrack first, so a stray libhttrack-dev would test Debian's headers.
+          for stray in /usr/include/httrack /usr/lib/libhttrack.so /usr/lib/*/libhttrack.so; do
             if [ -e "$stray" ]; then
               echo "::error::$stray exists; HTTraQt would build against it, not this branch"
               exit 1
@@ -81,8 +84,8 @@ jobs:
       - name: Configure HTTraQt
         run: |
           set -euo pipefail
-          # CMAKE_MINIMUM_REQUIRED is 2.8 upstream; CMake 4 rejects it outright.
-          # 2>&1 because a bare MESSAGE() is NOTICE mode, which CMake writes to stderr.
+          # CMAKE_MINIMUM_REQUIRED is 2.8 upstream, which CMake 4 rejects outright.
+          # The redirect is load-bearing: a bare MESSAGE() is NOTICE mode, which goes to stderr.
           cmake -S "$RUNNER_TEMP/httraqt" -B "$RUNNER_TEMP/httraqt-bld" \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             2>&1 | tee "$RUNNER_TEMP/cmake.log"

--- a/.github/workflows/httraqt.yml
+++ b/.github/workflows/httraqt.yml
@@ -21,8 +21,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Our mirror of the SourceForge tree, so no PR depends on a third-party host.
-  HTTRAQT_REPO: https://github.com/xroche/httraqt.git
+  # Unofficial mirror of the SourceForge tree, so no PR depends on a third-party host.
+  HTTRAQT_REPO: https://github.com/xroche/httraqt-ci-mirror.git
   HTTRAQT_REF: a1175565c61ab9afd7bda2dc96ed1182c2d44ec3  # 1.4.11 + cmake patch, upstream HEAD since 2023-01-06
   PREFIX: /usr/local
 

--- a/.github/workflows/httraqt.yml
+++ b/.github/workflows/httraqt.yml
@@ -21,8 +21,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # SourceForge is the only copy; a mirror we control would remove that dependency.
-  HTTRAQT_REPO: https://git.code.sf.net/p/httraqt/code
+  # Our mirror of the SourceForge tree, so no PR depends on a third-party host.
+  HTTRAQT_REPO: https://github.com/xroche/httraqt.git
   HTTRAQT_REF: a1175565c61ab9afd7bda2dc96ed1182c2d44ec3  # 1.4.11 + cmake patch, upstream HEAD since 2023-01-06
   PREFIX: /usr/local
 
@@ -70,16 +70,18 @@ jobs:
       - name: Fetch HTTraQt
         run: |
           set -euo pipefail
-          # SourceForge does not serve arbitrary SHAs to a shallow fetch, so clone whole.
+          # Fetching the SHA itself needs no pin check afterwards, and keeps the
+          # tree out of the workspace so our own build cannot pick it up.
+          rm -rf "$RUNNER_TEMP/httraqt"
+          git init -q "$RUNNER_TEMP/httraqt"
           ok=
           for attempt in 1 2 3; do
-            rm -rf "$RUNNER_TEMP/httraqt"
-            if git clone "$HTTRAQT_REPO" "$RUNNER_TEMP/httraqt"; then ok=1; break; fi
-            echo "clone failed (attempt $attempt)"
-            sleep $((attempt * 15))
+            if git -C "$RUNNER_TEMP/httraqt" fetch -q --depth 1 "$HTTRAQT_REPO" "$HTTRAQT_REF"; then ok=1; break; fi
+            echo "fetch failed (attempt $attempt)"
+            [ "$attempt" -eq 3 ] || sleep $((attempt * 15))
           done
           [ -n "$ok" ] || { echo "::error::cannot reach $HTTRAQT_REPO"; exit 1; }
-          git -C "$RUNNER_TEMP/httraqt" checkout --detach "$HTTRAQT_REF"
+          git -C "$RUNNER_TEMP/httraqt" checkout -q --detach FETCH_HEAD
 
       - name: Configure HTTraQt
         run: |

--- a/.github/workflows/httraqt.yml
+++ b/.github/workflows/httraqt.yml
@@ -1,0 +1,101 @@
+# Build HTTraQt, the only consumer of our installed headers, against this branch.
+name: HTTraQt
+
+on:
+  push:
+    branches: [master]
+    paths: ['src/**', 'configure.ac', '.github/workflows/httraqt.yml']
+  pull_request:
+    paths: ['src/**', 'configure.ac', '.github/workflows/httraqt.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: httraqt-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # SourceForge is the only copy; a mirror we control would remove that dependency.
+  HTTRAQT_REPO: https://git.code.sf.net/p/httraqt/code
+  HTTRAQT_REF: a1175565c61ab9afd7bda2dc96ed1182c2d44ec3  # 1.4.11 + cmake patch, upstream HEAD since 2023-01-06
+  PREFIX: /usr/local
+
+jobs:
+  build:
+    name: build HTTraQt against this branch
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
+          sudo apt-get install -y --no-install-recommends \
+            build-essential autoconf automake libtool autoconf-archive \
+            zlib1g-dev libssl-dev libbrotli-dev libzstd-dev \
+            cmake qt6-base-dev qt6-multimedia-dev libgl-dev
+
+      - name: Build and install libhttrack
+        run: |
+          set -euo pipefail
+          autoreconf -fi
+          bld="$RUNNER_TEMP/bld"
+          mkdir -p "$bld"
+          (cd "$bld" && "$GITHUB_WORKSPACE/configure" --prefix="$PREFIX" --disable-static)
+          make -C "$bld" -j"$(nproc)"
+          sudo make -C "$bld" install
+          sudo ldconfig
+
+      - name: Assert no distribution libhttrack can shadow ours
+        run: |
+          set -euo pipefail
+          # FindHttrack.cmake hardcodes /usr/include/httrack first, so a stray
+          # libhttrack-dev would silently make this job test Debian's headers.
+          for stray in /usr/include/httrack /usr/lib/*/libhttrack.so; do
+            if [ -e "$stray" ]; then
+              echo "::error::$stray exists; HTTraQt would build against it, not this branch"
+              exit 1
+            fi
+          done
+          test -f "$PREFIX/include/httrack/htsglobal.h"
+
+      - name: Fetch HTTraQt
+        run: |
+          set -euo pipefail
+          # SourceForge does not serve arbitrary SHAs to a shallow fetch, so clone whole.
+          ok=
+          for attempt in 1 2 3; do
+            rm -rf "$RUNNER_TEMP/httraqt"
+            if git clone "$HTTRAQT_REPO" "$RUNNER_TEMP/httraqt"; then ok=1; break; fi
+            echo "clone failed (attempt $attempt)"
+            sleep $((attempt * 15))
+          done
+          [ -n "$ok" ] || { echo "::error::cannot reach $HTTRAQT_REPO"; exit 1; }
+          git -C "$RUNNER_TEMP/httraqt" checkout --detach "$HTTRAQT_REF"
+
+      - name: Configure HTTraQt
+        run: |
+          set -euo pipefail
+          # CMAKE_MINIMUM_REQUIRED is 2.8 upstream; CMake 4 rejects it outright.
+          # 2>&1 because a bare MESSAGE() is NOTICE mode, which CMake writes to stderr.
+          cmake -S "$RUNNER_TEMP/httraqt" -B "$RUNNER_TEMP/httraqt-bld" \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+            2>&1 | tee "$RUNNER_TEMP/cmake.log"
+          # A configure that resolved elsewhere would compile someone else's headers.
+          grep -q "httrack header directory found: $PREFIX/include/httrack/" "$RUNNER_TEMP/cmake.log"
+
+      - name: Build HTTraQt
+        run: cmake --build "$RUNNER_TEMP/httraqt-bld" -j"$(nproc)"
+
+      - name: Assert it linked against the libhttrack we just built
+        run: |
+          set -euo pipefail
+          # Not bin/: CMAKE_RUNTIME_OUTPUT_DIRECTORY is set after ADD_EXECUTABLE, too late.
+          bin="$RUNNER_TEMP/httraqt-bld/httraqt"
+          ldd "$bin" | grep -E "libhttrack\.so.* => $PREFIX/lib/" \
+            || { ldd "$bin"; exit 1; }

--- a/tests/206_install-headers-c99.test
+++ b/tests/206_install-headers-c99.test
@@ -207,22 +207,42 @@ else
             cxx_stds+=("$std")
     done
     [ "${#cxx_stds[@]}" -gt 0 ] || echo "$cxx accepts neither -std=c++11 nor -std=c++17, skipping the C++ leg" >&2
+    # Qt permits -fno-exceptions/-fno-rtti, so a consumer's TU may see the
+    # headers that way. Additive: the default mode keeps its own coverage.
+    noexc=()
+    exc_modes=1
+    printf 'int main() { return 0; }\n' >"$tmp/tu.cpp"
+    if "$cxx" "${base_cpp_argv[@]}" -fno-exceptions -fno-rtti -c "$tmp/tu.cpp" -o "$tmp/tu.o" 2>/dev/null; then
+        noexc=(-fno-exceptions -fno-rtti)
+        exc_modes=2
+    else
+        echo "$cxx rejects -fno-exceptions -fno-rtti, skipping that mode" >&2
+    fi
+    # Marks instead of failing, so one broken header does not cut the sweep short.
+    cxx_compile() {
+        local label=$1
+        shift
+        "$cxx" "$@" -c "$tmp/tu.cpp" -o "$tmp/tu.o" 2>"$tmp/cc.log" && return 0
+        echo "$label:" >&2
+        head -5 "$tmp/cc.log" >&2
+        bad=1
+    }
     for h in "${headers[@]}"; do
         b=$(basename "$h")
         argv=("${base_cpp_argv[@]}" -Wall -Wextra -Werror)
         printf '#include <httrack/%s>\nint main() { return 0; }\n' "$b" >"$tmp/tu.cpp"
         for std in "${cxx_stds[@]}"; do
             for mode in -UHTS_INTERNAL_BYTECODE -DHTS_INTERNAL_BYTECODE; do
-                if ! "$cxx" "${argv[@]}" "-std=$std" "$mode" -c "$tmp/tu.cpp" -o "$tmp/tu.o" 2>"$tmp/cc.log"; then
-                    echo "$b does not compile as C++ under -std=$std ($mode):" >&2
-                    head -5 "$tmp/cc.log" >&2
-                    bad=1
-                fi
+                cxx_compile "$b does not compile as C++ under -std=$std ($mode)" \
+                    "${argv[@]}" "-std=$std" "$mode"
+                [ "$exc_modes" -eq 1 ] ||
+                    cxx_compile "$b does not compile as C++ under -std=$std ($mode ${noexc[*]})" \
+                        "${argv[@]}" "-std=$std" "$mode" "${noexc[@]}"
             done
         done
     done
     [ "${#cxx_stds[@]}" -eq 0 ] ||
-        echo "compiled ${#headers[@]} headers x ${#cxx_stds[@]} C++ std x 2 bytecode modes with $cxx" >&2
+        echo "compiled ${#headers[@]} headers x ${#cxx_stds[@]} C++ std x 2 bytecode modes x $exc_modes exception modes with $cxx" >&2
 fi
 [ "$bad" -eq 0 ] || fail "installed headers do not compile as C++"
 


### PR DESCRIPTION
HTTraQt is the only consumer of `DevIncludes_DATA` anywhere, so it is the only thing that compiles our installed headers as a real application. An httraqt FTBFS has caught our breakage twice. The second time (#1150) we found out six days late and by accident, because Debian patched around it downstream and never forwarded it.

The delta over what we already test in-tree is narrow, and worth stating plainly. Test 206 already compiles every installed header under `c++11` and `c++17` in both bytecode modes at `-Wall -Wextra -Werror`, 269 sweeps all 182 ordered pairs, and 207 links every reachable symbol for real against the library. What none of them see is a changed *callback signature*: 207 says so in its own header, since the linker cannot see it either. `CHAIN_FUNCTION()` assigns the callback with no cast, so at a real consumer that becomes a compile error. The other uncovered piece is the consumer macro environment, Qt's headers and moc-generated TUs meeting ours, which 269 explicitly disclaims. This also widens 206: Qt permits `-fno-exceptions -fno-rtti`, and nothing compiled the headers that way.

Two checks stop the job passing vacuously. `FindHttrack.cmake` hardcodes `/usr/include/httrack` ahead of `/usr/local`, so a stray `libhttrack-dev` on the runner would quietly point the whole job at Debian's headers. The configure log also has to name the prefix we installed to.

The tree comes from `xroche/httraqt-ci-mirror`, a copy of the SourceForge repository with its full history, so no PR depends on a third-party host staying up. It is marked unofficial and has issues disabled: upstream is Kalinowski's, and bugs belong there. The job fetches the pinned SHA directly rather than cloning, so nothing has to check afterwards that it got the right commit.

The filter means this job must never join the required set, since a required check that a path filter skips stays "Expected" and blocks the merge. There is a comment on the trigger saying so.

