### PR TITLE
The footer copyright year is pinned to 2026 and will disagree with the site

### DIFF
--- a/tests/271_doc-chrome-year.test
+++ b/tests/271_doc-chrome-year.test
@@ -1,0 +1,84 @@
+#!/bin/bash
+#
+# --check tolerates a footer year older than the generator's, and nothing else
+# reaches that branch: the tree ships the year it was generated in, so the
+# comparison only diverges once a New Year has rolled the generator forward.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+srcdir="${abs_top_srcdir:?not run under make check}"
+chrome_src="${srcdir}/tools/doc-chrome.py"
+
+command -v python3 >/dev/null 2>&1 || skip "no python3"
+test -r "${chrome_src}" || skip "no ${chrome_src}"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/docyear.XXXXXX") || {
+    echo "no tmpdir" >&2
+    exit 1
+}
+cleanup_push rm -rf "${work}"
+
+# doc-chrome.py finds html/ relative to its own path, so it needs both trees.
+cp -a "${srcdir}/tools" "${srcdir}/html" "${work}/"
+chrome="${work}/tools/doc-chrome.py"
+page="${work}/html/index.html"
+
+later=2027
+epoch=$(python3 -c \
+    "import datetime;print(int(datetime.datetime(${later},7,1,tzinfo=datetime.timezone.utc).timestamp()))")
+
+shipped=$(grep -o '&copy; 1998-[0-9]\{4\}' "${page}" | head -1 | grep -o '[0-9]\{4\}$')
+test -n "${shipped}" || fail "no footer copyright year in ${page}"
+# Everything below compares the two, so an equal pair would pass vacuously.
+test "${shipped}" -ne "${later}" || fail "tree already ships ${later}"
+
+pristine="${work}/pristine"
+cp -a "${work}/html" "${pristine}"
+restore() { rm -rf "${work}/html" && cp -a "${pristine}" "${work}/html"; }
+
+# The assertion this test exists for: a lagging year is in sync.
+SOURCE_DATE_EPOCH="${epoch}" python3 "${chrome}" --check >/dev/null 2>&1 ||
+    fail "--check rejects a footer year of ${shipped} when the generator is at ${later}"
+
+# A drifted footer must still fail, or the line above passes for the wrong reason.
+python3 - "${page}" <<'EOF'
+import re, sys
+path = sys.argv[1]
+text = open(path, encoding="utf-8").read()
+out = re.sub(r'\n\t<a href="https://endsoftwarepatents[^\n]*\n', "\n", text)
+assert out != text, "chicklet anchor not found"
+open(path, "w", encoding="utf-8").write(out)
+EOF
+if SOURCE_DATE_EPOCH="${epoch}" python3 "${chrome}" --check >/dev/null 2>&1; then
+    fail "--check accepts a footer missing its chicklet"
+fi
+restore
+
+# The mask is [0-9], not \d, which also matches Arabic-Indic and fullwidth digits.
+python3 - "${page}" <<'EOF'
+import sys
+path = sys.argv[1]
+text = open(path, encoding="utf-8").read()
+out = text.replace("1998-2026", "1998-٢٠٢٦", 1)
+assert out != text, "no footer year to replace"
+open(path, "w", encoding="utf-8").write(out)
+EOF
+if SOURCE_DATE_EPOCH="${epoch}" python3 "${chrome}" --check >/dev/null 2>&1; then
+    fail "--check accepts non-ASCII digits in the footer year"
+fi
+restore
+
+# SOURCE_DATE_EPOCH has to reach the stamp, or every check above is vacuous.
+SOURCE_DATE_EPOCH="${epoch}" python3 "${chrome}" >/dev/null 2>&1 ||
+    fail "regeneration under SOURCE_DATE_EPOCH failed"
+grep -q "&copy; 1998-${later} " "${page}" ||
+    fail "SOURCE_DATE_EPOCH=${epoch} did not stamp ${later} into the footer"
+
+# The tolerance is symmetric: today's generator accepts the ${later} tree.
+python3 "${chrome}" --check >/dev/null 2>&1 ||
+    fail "--check rejects a footer year of ${later} when the generator is older"
+
+echo "doc chrome year: ${shipped} and ${later} interchange, drift still caught"

--- a/tools/doc-chrome.py
+++ b/tools/doc-chrome.py
@@ -101,11 +101,20 @@ DESCRIPTIONS = {
     "scripting.html": "Driving the httrack command-line program from shell and" " batch scripts.",
 }
 
-# A regeneration stamps the current year; --check ignores the digits, so a page
-# shipped in an earlier year is in sync until something else rewrites it.
+# Pinned by SOURCE_DATE_EPOCH when set, as man/makeman.sh does, so a test can ask
+# for another year.
+_EPOCH = os.environ.get("SOURCE_DATE_EPOCH")
+YEAR = (
+    datetime.datetime.fromtimestamp(int(_EPOCH), datetime.timezone.utc).year
+    if _EPOCH
+    else datetime.date.today().year
+)
+
+# Stamped at regeneration time; --check masks the year, so a page shipped in an
+# earlier year still matches.
 FOOTER = [
     "<footer>",
-    f"\t<small>&copy; 1998-{datetime.date.today().year} Xavier Roche"
+    f"\t<small>&copy; 1998-{YEAR} Xavier Roche"
     " &amp; other contributors - Web Design: Leto Kauler.</small>",
     # Local copy: an absolute src breaks the image offline and makes a network request.
     '\t<a href="https://endsoftwarepatents.org/innovating-without-patents/"'
@@ -143,17 +152,18 @@ def region(text, part, body):
     return pattern.sub(open_ + "\n" + body.rstrip("\n") + "\n" + close, text, count=1)
 
 
-def undated(text):
+def mask_footer_year(text):
     """The page with the footer's copyright year masked, for comparison only.
 
-    Scoped to the footer region: contact.html carries a second 1998-YYYY in its
-    licence text, and that one has to stay byte-exact.
+    Scoped to the footer region so the mask cannot reach a 1998-YYYY elsewhere on
+    the page, such as contact.html's licence line.
     """
     open_, close = MARK["footer"]
     pattern = re.compile(re.escape(open_) + ".*?" + re.escape(close), re.S)
 
     def mask(match):
-        return re.sub(r"1998-\d{4}", "1998-YYYY", match.group(0))
+        # [0-9], not \d: \d also matches Arabic-Indic and fullwidth digits.
+        return re.sub(r"1998-[0-9]{4}", "1998-YYYY", match.group(0))
 
     return pattern.sub(mask, text, count=1)
 
@@ -373,7 +383,9 @@ def main():
             print(f"{page}: no {MARK['masthead'][0]} marker")
             stale += 1
         # A rewrite restamps the year; --check tolerates the one already shipped.
-        if after == before or (args.check and undated(after) == undated(before)):
+        if after == before:
+            continue
+        if args.check and mask_footer_year(after) == mask_footer_year(before):
             continue
         if args.check:
             print(f"{page}: chrome is out of sync with tools/doc-chrome.py")

--- a/tools/doc-chrome.py
+++ b/tools/doc-chrome.py
@@ -12,6 +12,7 @@ doc.css; --convert adds them to a page still using the 2007 table layout.
 """
 
 import argparse
+import datetime
 import os
 import re
 import sys
@@ -100,12 +101,12 @@ DESCRIPTIONS = {
     "scripting.html": "Driving the httrack command-line program from shell and" " batch scripts.",
 }
 
-# Year left static: --check diffs the regenerated chrome against the shipped
-# bytes, so a computed one would red CI every 1st of January.
+# A regeneration stamps the current year; --check ignores the digits, so a page
+# shipped in an earlier year is in sync until something else rewrites it.
 FOOTER = [
     "<footer>",
-    "\t<small>&copy; 1998-2026 Xavier Roche &amp; other contributors"
-    " - Web Design: Leto Kauler.</small>",
+    f"\t<small>&copy; 1998-{datetime.date.today().year} Xavier Roche"
+    " &amp; other contributors - Web Design: Leto Kauler.</small>",
     # Local copy: an absolute src breaks the image offline and makes a network request.
     '\t<a href="https://endsoftwarepatents.org/innovating-without-patents/"'
     ' target="_blank" rel="noopener"'
@@ -140,6 +141,21 @@ def region(text, part, body):
     if not pattern.search(text):
         raise SystemExit(f"missing {open_} marker")
     return pattern.sub(open_ + "\n" + body.rstrip("\n") + "\n" + close, text, count=1)
+
+
+def undated(text):
+    """The page with the footer's copyright year masked, for comparison only.
+
+    Scoped to the footer region: contact.html carries a second 1998-YYYY in its
+    licence text, and that one has to stay byte-exact.
+    """
+    open_, close = MARK["footer"]
+    pattern = re.compile(re.escape(open_) + ".*?" + re.escape(close), re.S)
+
+    def mask(match):
+        return re.sub(r"1998-\d{4}", "1998-YYYY", match.group(0))
+
+    return pattern.sub(mask, text, count=1)
 
 
 def slug(heading):
@@ -356,7 +372,8 @@ def main():
         if MARK["masthead"][0] not in (before if args.check else after):
             print(f"{page}: no {MARK['masthead'][0]} marker")
             stale += 1
-        if after == before:
+        # A rewrite restamps the year; --check tolerates the one already shipped.
+        if after == before or (args.check and undated(after) == undated(before)):
             continue
         if args.check:
             print(f"{page}: chrome is out of sync with tools/doc-chrome.py")


### PR DESCRIPTION
The footer year was hardcoded because `--check` diffs the regenerated chrome against the shipped bytes, so computing it would have turned every 1st of January into a red CI leg. The cost was that httrack.com prints `date('Y')` while the shipped pages print a literal, so from next New Year the same footer would say two different things and nothing would catch it.

Compute it, and relax the comparison to match: `--check` masks `1998-[0-9]{4}` before comparing, so a page shipped in an earlier year is still in sync, and the next regeneration restamps all 15. The rest of the footer stays byte-exact, the leading 1998 included. The mask covers the footer region rather than the whole page, so it cannot reach the second `1998-YYYY` in contact.html's licence text. It is `[0-9]` rather than `\d`, which in a Python `str` pattern would also accept Arabic-Indic and fullwidth digits.

The generator honours `SOURCE_DATE_EPOCH`, as man/makeman.sh already does. That pins the stamp, and pinning it is what makes the tolerance testable at all: the tree ships the year it was generated in, so on CI the two sides agree and the new branch is never reached. Left untested it would have run for the first time on a New Year, in production. tests/271 drives it with a 2027 stamp, asserting that a lagging year passes while a drifted footer and non-ASCII digits still fail, and each assertion is paired with the mutant that kills it.
