### PR TITLE
The WebHTTrack wizard cannot reach --host-alias

### DIFF
--- a/html/guide.html
+++ b/html/guide.html
@@ -713,10 +713,10 @@ bottom are the ones that keep you welcome.</p>
 <div class="opt" data-for="web">
 	<div class="opt-head"><span class="opt-name">Host aliases</span><span class="cli">-%C, --host-alias</span></div>
 	<p>Names the other hostnames one site answers to, written
-	<code>www2.example.com,m.example.com=example.com</code>. They then count as the starting host:
-	their links travel under the same rules and each page is saved once instead of once per name.
-	Either side may carry a scheme, as in <code>legacy.example.com=https://example.com</code>. A path
-	is refused, this maps hosts and not addresses.</p>
+	<code>www2.example.com,m.example.com=example.com</code>. They fold onto that host: their links
+	travel under the same rules and each page is saved once instead of once per name. Either side may
+	carry a scheme, as in <code>legacy.example.com=https://example.com</code>. A trailing slash is
+	ignored, but a path is refused: this maps hosts, not addresses.</p>
 </div>
 </section>
 

--- a/html/guide.html
+++ b/html/guide.html
@@ -712,7 +712,7 @@ bottom are the ones that keep you welcome.</p>
 
 <div class="opt" data-for="web">
 	<div class="opt-head"><span class="opt-name">Host aliases</span><span class="cli">-%C, --host-alias</span></div>
-	<p>Names the other hostnames one site answers to, written
+	<p>Names the other hostnames one site answers to, one rule per line, written
 	<code>www2.example.com,m.example.com=example.com</code>. They fold onto that host: their links
 	travel under the same rules and each page is saved once instead of once per name. Either side may
 	carry a scheme, as in <code>legacy.example.com=https://example.com</code>. A trailing slash is

--- a/html/guide.html
+++ b/html/guide.html
@@ -709,6 +709,15 @@ bottom are the ones that keep you welcome.</p>
 	<code>sid,utm_source</code>. Keeps one page from being saved several times under tracking
 	parameters that change nothing.</p>
 </div>
+
+<div class="opt" data-for="web">
+	<div class="opt-head"><span class="opt-name">Host aliases</span><span class="cli">-%C, --host-alias</span></div>
+	<p>Names the other hostnames one site answers to, written
+	<code>www2.example.com,m.example.com=example.com</code>. They then count as the starting host:
+	their links travel under the same rules and each page is saved once instead of once per name.
+	Either side may carry a scheme, as in <code>legacy.example.com=https://example.com</code>. A path
+	is refused, this maps hosts and not addresses.</p>
+</div>
 </section>
 
 <section class="tab" id="opt-proxy">

--- a/html/guide.html
+++ b/html/guide.html
@@ -710,7 +710,7 @@ bottom are the ones that keep you welcome.</p>
 	parameters that change nothing.</p>
 </div>
 
-<div class="opt" data-for="web">
+<div class="opt" data-for="web droid">
 	<div class="opt-head"><span class="opt-name">Host aliases</span><span class="cli">-%C, --host-alias</span></div>
 	<p>Names the other hostnames one site answers to, one rule per line, written
 	<code>www2.example.com,m.example.com=example.com</code>. They fold onto that host: their links

--- a/html/guide.html
+++ b/html/guide.html
@@ -703,7 +703,7 @@ bottom are the ones that keep you welcome.</p>
 	mirror something that needs you logged in, by exporting the session from your browser.</p>
 </div>
 
-<div class="opt" data-for="win web">
+<div class="opt" data-for="win web droid">
 	<div class="opt-head"><span class="opt-name">Strip query keys</span><span class="cli">-%g, --strip-query</span></div>
 	<p>Comma-separated query keys to drop when naming saved files, such as
 	<code>sid,utm_source</code>. Keeps one page from being saved several times under tracking

--- a/html/server/option8.html
+++ b/html/server/option8.html
@@ -186,6 +186,12 @@ ${LANG_STRIPQUERY}
 >
 <br><br>
 
+${LANG_HOSTALIAS}
+<input name="hostalias" value="${attr:hostalias}" size="40"
+			title='${html:LANG_HOSTALIASTIP}' onMouseOver="info('${js:LANG_HOSTALIASTIP}'); return true" onMouseOut="info('&nbsp;'); return true"
+>
+<br><br>
+
 <input type="checkbox" name="toler" ${checked:toler}
 			title='${html:LANG_I1i}' onMouseOver="info('${js:LANG_I1i}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_I62}

--- a/html/server/option8.html
+++ b/html/server/option8.html
@@ -187,9 +187,10 @@ ${LANG_STRIPQUERY}
 <br><br>
 
 ${LANG_HOSTALIAS}
-<input name="hostalias" value="${attr:hostalias}" size="40"
+<br>
+<textarea name="hostalias" cols="60" rows="4"
 			title='${html:LANG_HOSTALIASTIP}' onMouseOver="info('${js:LANG_HOSTALIASTIP}'); return true" onMouseOut="info('&nbsp;'); return true"
->
+>${do:output-mode:html}${hostalias}${do:output-mode:}</textarea>
 <br><br>
 
 <input type="checkbox" name="toler" ${checked:toler}

--- a/html/server/step2.html
+++ b/html/server/step2.html
@@ -140,6 +140,7 @@ ${do:copy:KeepWww:keepwww}
 ${do:copy:KeepSlashes:keepslashes}
 ${do:copy:KeepQueryOrder:keepqueryorder}
 ${do:copy:StripQuery:stripquery}
+${do:copy:HostAlias:hostalias}
 ${do:copy:StoreAllInCache:cache2}
 ${do:copy:Sitemap:sitemap}
 ${do:copy:SitemapUrl:sitemapurl}

--- a/html/server/step4.html
+++ b/html/server/step4.html
@@ -186,7 +186,7 @@ ${/* -m<n> resets the html limit, so the bare form must precede the -m,<n> one *
 	${test:cookiesfile:--cookies-file "}${arg:cookiesfile}${test:cookiesfile:"}
 	${test:pausefiles:--pause "}${arg:pausefiles}${test:pausefiles:"}
 	${test:stripquery:--strip-query "}${arg:stripquery}${test:stripquery:"}
-	${test:hostalias:--host-alias "}${arg:hostalias}${test:hostalias:"}
+	${arglist:hostalias:--host-alias}
 	${test:toler:--tolerant}
 	${test:http10:--http-10}
 	${test:cache2:--store-all-in-cache}

--- a/html/server/step4.html
+++ b/html/server/step4.html
@@ -186,6 +186,7 @@ ${/* -m<n> resets the html limit, so the bare form must precede the -m,<n> one *
 	${test:cookiesfile:--cookies-file "}${arg:cookiesfile}${test:cookiesfile:"}
 	${test:pausefiles:--pause "}${arg:pausefiles}${test:pausefiles:"}
 	${test:stripquery:--strip-query "}${arg:stripquery}${test:stripquery:"}
+	${test:hostalias:--host-alias "}${arg:hostalias}${test:hostalias:"}
 	${test:toler:--tolerant}
 	${test:http10:--http-10}
 	${test:cache2:--store-all-in-cache}
@@ -248,6 +249,7 @@ KeepWww=${ztest:keepwww:0:1}
 KeepSlashes=${ztest:keepslashes:0:1}
 KeepQueryOrder=${ztest:keepqueryorder:0:1}
 StripQuery=${stripquery}
+HostAlias=${hostalias}
 StoreAllInCache=${ztest:cache2:0:1}
 Sitemap=${ztest:sitemap:0:1}
 SitemapUrl=${sitemapurl}

--- a/lang.def
+++ b/lang.def
@@ -1034,6 +1034,10 @@ LANG_STRIPQUERY
 Strip query keys:
 LANG_STRIPQUERYTIP
 Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_source).
+LANG_HOSTALIAS
+Host aliases:
+LANG_HOSTALIASTIP
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
 LANG_WARC
 Write a WARC archive of the crawl
 LANG_WARCTIP

--- a/lang.def
+++ b/lang.def
@@ -1037,7 +1037,7 @@ Comma-separated query keys to drop from the saved-file naming (e.g. sid,utm_sour
 LANG_HOSTALIAS
 Host aliases:
 LANG_HOSTALIASTIP
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
 LANG_WARC
 Write a WARC archive of the crawl
 LANG_WARCTIP

--- a/lang/Bulgarian.txt
+++ b/lang/Bulgarian.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 Най-голям размер на WARC сегмент:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Започване на нов WARC сегмент, когато текущият надхвърли този брой байтове; оставете празно или 0 за един файл.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Bulgarian.txt
+++ b/lang/Bulgarian.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Започване на нов WARC сегмент, когато текущият надхвърли този брой байтове; оставете празно или 0 за един файл.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Castellano.txt
+++ b/lang/Castellano.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 Tamaño máximo de segmento WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Empezar un nuevo segmento WARC cuando el actual supere este número de bytes; déjelo en blanco o 0 para un solo archivo.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Castellano.txt
+++ b/lang/Castellano.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Empezar un nuevo segmento WARC cuando el actual supere este número de bytes; déjelo en blanco o 0 para un solo archivo.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Cesky.txt
+++ b/lang/Cesky.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Zaèít nový segment WARC, jakmile aktuální pøekroèí tento poèet bajtù; ponechte prázdné nebo 0 pro jeden soubor.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Cesky.txt
+++ b/lang/Cesky.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 Nejvìtší velikost segmentu WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Zaèít nový segment WARC, jakmile aktuální pøekroèí tento poèet bajtù; ponechte prázdné nebo 0 pro jeden soubor.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Chinese-BIG5.txt
+++ b/lang/Chinese-BIG5.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 WARC 分段大小上限：
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 目前分段超過此位元組數時開始新的 WARC 分段；留空或填 0 則保持單一檔案。
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Chinese-BIG5.txt
+++ b/lang/Chinese-BIG5.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 目前分段超過此位元組數時開始新的 WARC 分段；留空或填 0 則保持單一檔案。
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Chinese-Simplified.txt
+++ b/lang/Chinese-Simplified.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 WARC 分段大小上限：
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 当前分段超过该字节数时开始新的 WARC 分段；留空或填 0 则保持单个文件。
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Chinese-Simplified.txt
+++ b/lang/Chinese-Simplified.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 当前分段超过该字节数时开始新的 WARC 分段；留空或填 0 则保持单个文件。
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Croatian.txt
+++ b/lang/Croatian.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 Najveæa velièina WARC segmenta:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Zapoèni novi WARC segment kada trenutni prijeðe ovaj broj bajtova; ostavite prazno ili 0 za jednu datoteku.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Croatian.txt
+++ b/lang/Croatian.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Zapoèni novi WARC segment kada trenutni prijeðe ovaj broj bajtova; ostavite prazno ili 0 za jednu datoteku.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Dansk.txt
+++ b/lang/Dansk.txt
@@ -1046,5 +1046,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Begynd et nyt WARC-segment, når det aktuelle overstiger dette antal byte; lad feltet stå tomt eller skriv 0 for én fil.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Dansk.txt
+++ b/lang/Dansk.txt
@@ -1044,3 +1044,7 @@ WARC segment size limit:
 Største størrelse på WARC-segment:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Begynd et nyt WARC-segment, når det aktuelle overstiger dette antal byte; lad feltet stå tomt eller skriv 0 for én fil.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Deutsch.txt
+++ b/lang/Deutsch.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 Maximale Größe eines WARC-Segments:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Ein neues WARC-Segment beginnen, sobald das aktuelle diese Anzahl Bytes überschreitet; leer lassen oder 0 für eine einzige Datei.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Deutsch.txt
+++ b/lang/Deutsch.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Ein neues WARC-Segment beginnen, sobald das aktuelle diese Anzahl Bytes überschreitet; leer lassen oder 0 für eine einzige Datei.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Eesti.txt
+++ b/lang/Eesti.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 WARC-segmendi suurim maht:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Alusta uut WARC-segmenti, kui praegune ületab selle baitide arvu; jäta tühjaks või 0, et hoida üks fail.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Eesti.txt
+++ b/lang/Eesti.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Alusta uut WARC-segmenti, kui praegune ületab selle baitide arvu; jäta tühjaks või 0, et hoida üks fail.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/English.txt
+++ b/lang/English.txt
@@ -1046,5 +1046,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/English.txt
+++ b/lang/English.txt
@@ -1044,3 +1044,7 @@ WARC segment size limit:
 WARC segment size limit:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Finnish.txt
+++ b/lang/Finnish.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Aloita uusi WARC-osa, kun nykyinen ylitt‰‰ t‰m‰n tavum‰‰r‰n; j‰t‰ tyhj‰ksi tai 0, jolloin tiedosto pysyy yhten‰.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Finnish.txt
+++ b/lang/Finnish.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 WARC-osan enimm‰iskoko:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Aloita uusi WARC-osa, kun nykyinen ylitt‰‰ t‰m‰n tavum‰‰r‰n; j‰t‰ tyhj‰ksi tai 0, jolloin tiedosto pysyy yhten‰.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Francais.txt
+++ b/lang/Francais.txt
@@ -1044,3 +1044,7 @@ WARC segment size limit:
 Taille maximale d'un segment WARC :
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Commencer un nouveau segment WARC dès que le courant dépasse ce nombre d'octets ; laissez vide ou 0 pour un fichier unique.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Francais.txt
+++ b/lang/Francais.txt
@@ -1046,5 +1046,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Commencer un nouveau segment WARC dès que le courant dépasse ce nombre d'octets ; laissez vide ou 0 pour un fichier unique.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Greek.txt
+++ b/lang/Greek.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Έναρξη νέου τμήματος WARC μόλις το τρέχον ξεπεράσει αυτόν τον αριθμό byte. Αφήστε κενό ή 0 για ένα ενιαίο αρχείο.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Greek.txt
+++ b/lang/Greek.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 Μέγιστο μέγεθος τμήματος WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Έναρξη νέου τμήματος WARC μόλις το τρέχον ξεπεράσει αυτόν τον αριθμό byte. Αφήστε κενό ή 0 για ένα ενιαίο αρχείο.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Italiano.txt
+++ b/lang/Italiano.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Inizia un nuovo segmento WARC quando quello corrente supera questo numero di byte; lascia vuoto o 0 per un solo file.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Italiano.txt
+++ b/lang/Italiano.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 Dimensione massima del segmento WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Inizia un nuovo segmento WARC quando quello corrente supera questo numero di byte; lascia vuoto o 0 per un solo file.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Japanese.txt
+++ b/lang/Japanese.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 WARC セグメントの最大サイズ:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 現在のセグメントがこのバイト数を超えたら新しい WARC セグメントを開始します。空欄または 0 で単一ファイルのままにします。
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Japanese.txt
+++ b/lang/Japanese.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 現在のセグメントがこのバイト数を超えたら新しい WARC セグメントを開始します。空欄または 0 で単一ファイルのままにします。
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Macedonian.txt
+++ b/lang/Macedonian.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 Најголема големина на WARC сегмент:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Започни нов WARC сегмент кога тековниот ќе го надмине овој број бајти; оставете празно или 0 за една датотека.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Macedonian.txt
+++ b/lang/Macedonian.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Започни нов WARC сегмент кога тековниот ќе го надмине овој број бајти; оставете празно или 0 за една датотека.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Magyar.txt
+++ b/lang/Magyar.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Új WARC szegmens kezdése, amint az aktuális túllépi ezt a bájtszámot; hagyja üresen vagy adjon meg 0-t egyetlen fájlhoz.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Magyar.txt
+++ b/lang/Magyar.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 WARC szegmens legnagyobb mérete:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Új WARC szegmens kezdése, amint az aktuális túllépi ezt a bájtszámot; hagyja üresen vagy adjon meg 0-t egyetlen fájlhoz.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Nederlands.txt
+++ b/lang/Nederlands.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Een nieuw WARC-segment beginnen zodra het huidige dit aantal bytes overschrijdt; laat leeg of 0 voor één bestand.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Nederlands.txt
+++ b/lang/Nederlands.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 Maximale grootte van een WARC-segment:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Een nieuw WARC-segment beginnen zodra het huidige dit aantal bytes overschrijdt; laat leeg of 0 voor één bestand.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Norsk.txt
+++ b/lang/Norsk.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 Største størrelse på WARC-segment:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Begynn et nytt WARC-segment når det gjeldende overstiger dette antallet byte; la feltet stå tomt eller 0 for én fil.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Norsk.txt
+++ b/lang/Norsk.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Begynn et nytt WARC-segment når det gjeldende overstiger dette antallet byte; la feltet stå tomt eller 0 for én fil.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Polski.txt
+++ b/lang/Polski.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Rozpocznij nowy segment WARC, gdy bie¿¹cy przekroczy tê liczbê bajtów; pozostaw puste lub 0, aby zachowaæ jeden plik.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Polski.txt
+++ b/lang/Polski.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 Maksymalny rozmiar segmentu WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Rozpocznij nowy segment WARC, gdy bie¿¹cy przekroczy tê liczbê bajtów; pozostaw puste lub 0, aby zachowaæ jeden plik.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Portugues-Brasil.txt
+++ b/lang/Portugues-Brasil.txt
@@ -1046,5 +1046,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Iniciar um novo segmento WARC quando o atual passar deste número de bytes; deixe em branco ou 0 para um único arquivo.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Portugues-Brasil.txt
+++ b/lang/Portugues-Brasil.txt
@@ -1044,3 +1044,7 @@ WARC segment size limit:
 Tamanho máximo do segmento WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Iniciar um novo segmento WARC quando o atual passar deste número de bytes; deixe em branco ou 0 para um único arquivo.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Portugues.txt
+++ b/lang/Portugues.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Iniciar um novo segmento WARC quando o atual ultrapassar este número de bytes; deixe em branco ou 0 para um único ficheiro.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Portugues.txt
+++ b/lang/Portugues.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 Tamanho máximo do segmento WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Iniciar um novo segmento WARC quando o atual ultrapassar este número de bytes; deixe em branco ou 0 para um único ficheiro.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Romanian.txt
+++ b/lang/Romanian.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Incepe un nou segment WARC cand cel curent depaseste acest numar de octeti; lasati gol sau 0 pentru un singur fisier.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Romanian.txt
+++ b/lang/Romanian.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 Dimensiunea maxima a unui segment WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Incepe un nou segment WARC cand cel curent depaseste acest numar de octeti; lasati gol sau 0 pentru un singur fisier.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Russian.txt
+++ b/lang/Russian.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Начинать новый сегмент WARC, когда текущий превысит указанное число байт; оставьте пустым или 0 для одного файла.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Russian.txt
+++ b/lang/Russian.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 Максимальный размер сегмента WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Начинать новый сегмент WARC, когда текущий превысит указанное число байт; оставьте пустым или 0 для одного файла.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Slovak.txt
+++ b/lang/Slovak.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 Najväèšia ve¾kos segmentu WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Zaèa novı segment WARC, keï aktuálny prekroèí tento poèet bajtov; ponechajte prázdne alebo 0 pre jeden súbor.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Slovak.txt
+++ b/lang/Slovak.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Zaèa novı segment WARC, keï aktuálny prekroèí tento poèet bajtov; ponechajte prázdne alebo 0 pre jeden súbor.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Slovenian.txt
+++ b/lang/Slovenian.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Zacni nov segment WARC, ko trenutni preseze to stevilo bajtov; pustite prazno ali 0 za eno datoteko.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Slovenian.txt
+++ b/lang/Slovenian.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 Najvecja velikost segmenta WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Zacni nov segment WARC, ko trenutni preseze to stevilo bajtov; pustite prazno ali 0 za eno datoteko.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Svenska.txt
+++ b/lang/Svenska.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 Största storlek för WARC-segment:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Börja ett nytt WARC-segment när det aktuella passerar detta antal byte; lämna tomt eller 0 för en enda fil.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Svenska.txt
+++ b/lang/Svenska.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Börja ett nytt WARC-segment när det aktuella passerar detta antal byte; lämna tomt eller 0 för en enda fil.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Turkish.txt
+++ b/lang/Turkish.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Geçerli parça bu bayt sayýsýný aþtýðýnda yeni bir WARC parçasý baþlat; tek dosya için boþ býrakýn veya 0 girin.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Turkish.txt
+++ b/lang/Turkish.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 WARC parça boyutu sýnýrý:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Geçerli parça bu bayt sayýsýný aþtýðýnda yeni bir WARC parçasý baþlat; tek dosya için boþ býrakýn veya 0 girin.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Ukrainian.txt
+++ b/lang/Ukrainian.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Починати новий сегмент WARC, коли поточний перевищить цю кількість байтів; залиште порожнім або 0 для одного файлу.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Ukrainian.txt
+++ b/lang/Ukrainian.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 Найбільший розмір сегмента WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Починати новий сегмент WARC, коли поточний перевищить цю кількість байтів; залиште порожнім або 0 для одного файлу.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Uzbek.txt
+++ b/lang/Uzbek.txt
@@ -1016,5 +1016,5 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Joriy segment shu baytlar sonidan oshganda yangi WARC segmentini boshlash; bitta fayl uchun bo’sh qoldiring yoki 0 kiriting.
 Host aliases:
 Host aliases:
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).

--- a/lang/Uzbek.txt
+++ b/lang/Uzbek.txt
@@ -1014,3 +1014,7 @@ WARC segment size limit:
 WARC segmentining eng katta hajmi:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Joriy segment shu baytlar sonidan oshganda yangi WARC segmentini boshlash; bitta fayl uchun bo’sh qoldiring yoki 0 kiriting.
+Host aliases:
+Host aliases:
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).
+Other hostnames serving this same site, folded onto one (e.g. www2.example.com,m.example.com=example.com).

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -514,19 +514,59 @@ static void cat_js_escaped(String *dst, const char *value) {
   }
 }
 
-/* Append the value of a double-quoted command-line argument: escaped for HTML,
-   which the browser undoes when it posts the command line back, and for the
-   argv splitter, which does not. */
-static void cat_cmdline_arg(String *output, const char *value) {
-  const char *a;
+/* Append LEN bytes of the value of a double-quoted command-line argument:
+   escaped for HTML, which the browser undoes when it posts the command line
+   back, and for the argv splitter, which does not. */
+static void cat_cmdline_argn(String *output, const char *value, size_t len) {
+  size_t i;
 
-  for (a = value; *a != '\0'; a++) {
-    if (*a == '\\' || *a == '\"') {
+  for (i = 0; i < len; i++) {
+    if (value[i] == '\\' || value[i] == '\"') {
       StringCat(*output, "\\");
     }
-    if (!cat_html_escaped(output, *a)) {
-      StringMemcat(*output, a, 1);
+    if (!cat_html_escaped(output, value[i])) {
+      StringMemcat(*output, &value[i], 1);
     }
+  }
+}
+
+/* see cat_cmdline_argn() */
+static void cat_cmdline_arg(String *output, const char *value) {
+  cat_cmdline_argn(output, value, strlen(value));
+}
+
+/* Append FLAG "<rule>" once per rule in VALUE, the way the engine takes the
+   options it accumulates: one flag per rule. Any whitespace separates two
+   rules, as it separates two URLs in the wizard's URL box, except beside a ','
+   or '=' where it belongs to the rule the parser trims it out of. */
+static void cat_cmdline_arglist(String *output, const char *value,
+                                const char *flag) {
+  static const char *const ws = " \t\r\n";
+  const char *p = value + strspn(value, ws);
+  hts_boolean first = HTS_TRUE;
+
+  while (*p != '\0') {
+    hts_boolean more = HTS_TRUE;
+
+    if (!first) {
+      StringCat(*output, "\n\t");
+    }
+    StringCat(*output, flag);
+    StringCat(*output, " \"");
+    first = HTS_FALSE;
+    while (more) {
+      const size_t len = strcspn(p, ws);
+      const char *const next = p + len + strspn(p + len, ws);
+
+      cat_cmdline_argn(output, p, len);
+      more = *next != '\0' &&
+                     (*next == ',' || *next == '=' ||
+                      (len != 0 && (p[len - 1] == ',' || p[len - 1] == '=')))
+                 ? HTS_TRUE
+                 : HTS_FALSE;
+      p = next;
+    }
+    StringCat(*output, "\"");
   }
 }
 
@@ -1325,6 +1365,26 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                           } else {
                             coucal_write(NewLangList, pos2, (intptr_t) NULL);
                           }
+                        }
+                      }
+                    }
+                    /* arglist:<field>:<flag>
+                       one "<flag> "rule"" per non-empty line of the field */
+                    else if ((p = strfield(name, "arglist:"))) {
+                      char *pos2;
+
+                      langstr = "";
+                      literal = HTS_TRUE;
+                      name += p;
+                      pos2 = strchr(name, ':');
+                      if (pos2 != NULL && outputmode != -1) {
+                        intptr_t adr = 0;
+
+                        *pos2 = '\0';
+                        if (coucal_readptr(NewLangList, name, &adr) &&
+                            adr != 0) {
+                          cat_cmdline_arglist(&output, (const char *) adr,
+                                              pos2 + 1);
                         }
                       }
                     }

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -541,7 +541,9 @@ static void cat_cmdline_arg(String *output, const char *value) {
    or '=' where it belongs to the rule the parser trims it out of. */
 static void cat_cmdline_arglist(String *output, const char *value,
                                 const char *flag) {
-  static const char *const ws = " \t\r\n";
+  /* isspace()'s C-locale set, so a rules box splits the same here and in the
+     Android app, whose Java \s covers \v and \f too. */
+  static const char *const ws = " \t\r\n\v\f";
   const char *p = value + strspn(value, ws);
   hts_boolean first = HTS_TRUE;
 

--- a/tests/272_webhttrack-host-alias.test
+++ b/tests/272_webhttrack-host-alias.test
@@ -1,0 +1,96 @@
+#!/bin/bash
+#
+# The Host aliases field must reach the command line, winprofile.ini and the
+# engine: a template-only check cannot see a flag name the engine rejects.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
+distdir=$(cd "${distdir}" && pwd)
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
+
+htsserver_require
+
+printf '[project reload maps the key back] ..\t'
+grep -q "do:copy:HostAlias:hostalias" "${distdir}/html/server/step2.html" ||
+    fail "step2.html does not restore HostAlias"
+echo OK
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_hostalias.XXXXXX") || fail "no tmpdir"
+cleanup() {
+    htsserver_cleanup
+    rm -rf "${work}"
+}
+cleanup_push cleanup
+
+printf '[webhttrack emits --host-alias] ..\t'
+htsserver_start --home "${work}"
+
+"${HTS_PYTHON}" - "${HTS_URL}" "${work}/emitted" <<'PY' || fail "the Host aliases field is not wired (see above)"
+import re, shlex, sys, urllib.parse, urllib.request
+
+url, emitted = sys.argv[1].rstrip("/"), sys.argv[2]
+RULE = "www2.example.com,m.example.com=example.com"
+
+form = urllib.request.urlopen(url + "/server/index.html", timeout=20).read()
+m = re.search(rb'name="sid" value="([0-9a-f]+)"', form)
+if not m:
+    sys.exit("no session id in server/index.html")
+sid = m.group(1).decode()
+
+# An unknown ${LANG_*} renders empty, so assert the label text, not its absence.
+page = urllib.request.urlopen(url + "/server/option8.html?sid=" + sid,
+                              timeout=20).read().decode("latin-1")
+for want in ('name="hostalias"', "Host aliases:"):
+    if want not in page:
+        sys.exit("option8.html does not render %r" % want)
+
+
+def post(fields):
+    body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in
+                    [("sid", sid)] + fields)
+    req = urllib.request.Request(url + "/server/step4.html",
+                                 data=body.encode("latin-1"), method="POST")
+    return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
+
+
+def textarea(page, name):
+    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page, re.S)
+    if m is None:
+        sys.exit("no %s textarea in the rendered step4.html" % name)
+    return m.group(1)
+
+
+page = post([("hostalias", RULE)])
+cmd = textarea(page, "command")
+# Whole lines: the rule carries the separators the argv splitter reads.
+want = '--host-alias "%s"' % RULE
+lines = [l.strip() for l in cmd.split("\n")]
+if want not in lines:
+    sys.exit("%s missing from the command line\n%s" % (want, cmd))
+ini = textarea(page, "winprofile").replace("\r\n", "\n")
+if "\nHostAlias=%s\n" % RULE not in ini:
+    sys.exit("HostAlias missing from winprofile.ini\n%s" % ini)
+
+# An empty field must drop the flag, not emit a valueless --host-alias.
+if "--host-alias" in textarea(post([("hostalias", "")]), "command"):
+    sys.exit("an empty Host aliases field still emits --host-alias")
+
+# Hand the engine below what the template actually emitted, not a literal.
+open(emitted, "w").write("\n".join(shlex.split(lines[lines.index(want)])) + "\n")
+PY
+echo OK
+
+printf '[the engine knows the flag] ..\t'
+mapfile -t argv <"${work}/emitted"
+# Rejected flags exit 255 like a URL-less run, so match the diagnostic.
+out=$(httrack "${argv[@]}" 2>&1) || true
+if grep -q "Unknown option" <<<"${out}"; then
+    fail "the engine rejects ${argv[0]}: ${out}"
+fi
+# Control: the same probe on a flag that does not exist.
+out=$(httrack "${argv[0]}es" "${argv[1]}" 2>&1) || true
+grep -q "Unknown option" <<<"${out}" || fail "the unknown-option probe proves nothing"
+echo OK

--- a/tests/272_webhttrack-host-alias.test
+++ b/tests/272_webhttrack-host-alias.test
@@ -109,11 +109,13 @@ for value, want in [(" ".join(RULES), RULES),
                     ("\r\n" + "\r\n\r\n".join(RULES) + "\r\n", RULES),
                     ("a=b  c=d", ["a=b", "c=d"]),
                     ("a=b\tc=d", ["a=b", "c=d"]),
+                    ("a=b\vc=d", ["a=b", "c=d"]),
+                    ("a=b\fc=d", ["a=b", "c=d"]),
                     ("a=b \r\n\t c=d", ["a=b", "c=d"]),
                     ("  \r\n a=b \r\n  ", ["a=b"]),
                     ("a.com  ,  b.com  =  c.com", ["a.com,b.com=c.com"]),
                     ("a.com,\r\nb.com=c.com", ["a.com,b.com=c.com"]),
-                    (" \r\n\t ", []),
+                    (" \r\n\t\v\f ", []),
                     ("", [])]:
     got = emitted_rules(value)
     if got != want:

--- a/tests/272_webhttrack-host-alias.test
+++ b/tests/272_webhttrack-host-alias.test
@@ -92,26 +92,32 @@ for rule in RULES:
     if rule not in back:
         sys.exit("option8.html does not render %r back\n%s" % (rule, back))
 
-# A blank line, and the trailing one a user leaves behind, emit nothing: the
-# engine refuses an empty rule.
-blanks = textarea(post([("hostalias",
-                         "\r\n" + "\r\n\r\n".join(RULES) + "\r\n")]),
-                  "command")
-if blanks.count("--host-alias") != len(RULES) or '--host-alias ""' in blanks:
-    sys.exit("blank lines reach the command line\n%s" % blanks)
+def emitted_rules(value):
+    """The rules the template emits for a box holding VALUE."""
+    flag = '--host-alias "'
+    return [line.strip()[len(flag):-1]
+            for line in textarea(post([("hostalias", value)]),
+                                 "command").split("\n")
+            if flag in line]
 
-# Rules separate on any whitespace, like the URLs box. A space beside a ',' or
-# an '=' is inside its rule, which is why the parser trims it.
-spaced = textarea(post([("hostalias", " ".join(RULES))]), "command")
-if spaced.count("--host-alias") != len(RULES):
-    sys.exit("a space does not separate two rules\n%s" % spaced)
-joined = textarea(post([("hostalias", "a.com , b.com = c.com")]), "command")
-if joined.count("--host-alias") != 1 or '"a.com,b.com=c.com"' not in joined:
-    sys.exit("a spaced-out single rule was split\n%s" % joined)
 
-# An empty field must drop the flag, not emit a valueless --host-alias.
-if "--host-alias" in textarea(post([("hostalias", "")]), "command"):
-    sys.exit("an empty Host aliases field still emits --host-alias")
+# Any whitespace separates two rules, whatever the mix and the run length, and
+# a run beside a ',' or an '=' stays inside its rule, which is why the parser
+# trims it. The empty cases matter most: the engine refuses an empty rule, so
+# neither a blank line nor an empty box may emit --host-alias "".
+for value, want in [(" ".join(RULES), RULES),
+                    ("\r\n" + "\r\n\r\n".join(RULES) + "\r\n", RULES),
+                    ("a=b  c=d", ["a=b", "c=d"]),
+                    ("a=b\tc=d", ["a=b", "c=d"]),
+                    ("a=b \r\n\t c=d", ["a=b", "c=d"]),
+                    ("  \r\n a=b \r\n  ", ["a=b"]),
+                    ("a.com  ,  b.com  =  c.com", ["a.com,b.com=c.com"]),
+                    ("a.com,\r\nb.com=c.com", ["a.com,b.com=c.com"]),
+                    (" \r\n\t ", []),
+                    ("", [])]:
+    got = emitted_rules(value)
+    if got != want:
+        sys.exit("%r emitted %r, wanted %r" % (value, got, want))
 
 # Hand the engine below what the template actually emitted, not a literal.
 emit = lines[lines.index('--host-alias "%s"' % RULES[0])]

--- a/tests/272_webhttrack-host-alias.test
+++ b/tests/272_webhttrack-host-alias.test
@@ -74,6 +74,13 @@ ini = textarea(page, "winprofile").replace("\r\n", "\n")
 if "\nHostAlias=%s\n" % RULE not in ini:
     sys.exit("HostAlias missing from winprofile.ini\n%s" % ini)
 
+# Reopening the page must show the rule back: a name the state never writes
+# renders an empty field, and the project loses the rule on every reload.
+back = urllib.request.urlopen(url + "/server/option8.html?sid=" + sid,
+                              timeout=20).read().decode("latin-1")
+if 'value="%s"' % RULE not in back:
+    sys.exit("option8.html does not render the stored rule back")
+
 # An empty field must drop the flag, not emit a valueless --host-alias.
 if "--host-alias" in textarea(post([("hostalias", "")]), "command"):
     sys.exit("an empty Host aliases field still emits --host-alias")
@@ -84,7 +91,11 @@ PY
 echo OK
 
 printf '[the engine knows the flag] ..\t'
-mapfile -t argv <"${work}/emitted"
+# macOS runs the suite under bash 3.2, which has no mapfile
+argv=()
+while IFS= read -r arg; do
+    argv+=("${arg}")
+done <"${work}/emitted"
 # Rejected flags exit 255 like a URL-less run, so match the diagnostic.
 out=$(httrack "${argv[@]}" 2>&1) || true
 if grep -q "Unknown option" <<<"${out}"; then

--- a/tests/272_webhttrack-host-alias.test
+++ b/tests/272_webhttrack-host-alias.test
@@ -32,7 +32,11 @@ htsserver_start --home "${work}"
 import re, shlex, sys, urllib.parse, urllib.request
 
 url, emitted = sys.argv[1].rstrip("/"), sys.argv[2]
-RULE = "www2.example.com,m.example.com=example.com"
+# two rules, because one flag carries one rule: a browser posts the textarea
+# lines CRLF-separated
+RULES = ["www2.example.com,m.example.com=example.com",
+         "legacy.example.org=https://example.org"]
+RULE = "\r\n".join(RULES)
 
 form = urllib.request.urlopen(url + "/server/index.html", timeout=20).read()
 m = re.search(rb'name="sid" value="([0-9a-f]+)"', form)
@@ -65,28 +69,53 @@ def textarea(page, name):
 
 page = post([("hostalias", RULE)])
 cmd = textarea(page, "command")
-# Whole lines: the rule carries the separators the argv splitter reads.
-want = '--host-alias "%s"' % RULE
+# Whole lines: each rule carries the separators the argv splitter reads, and
+# one flag per rule is what the engine accumulates.
 lines = [l.strip() for l in cmd.split("\n")]
-if want not in lines:
-    sys.exit("%s missing from the command line\n%s" % (want, cmd))
-ini = textarea(page, "winprofile").replace("\r\n", "\n")
-if "\nHostAlias=%s\n" % RULE not in ini:
-    sys.exit("HostAlias missing from winprofile.ini\n%s" % ini)
+for rule in RULES:
+    if '--host-alias "%s"' % rule not in lines:
+        sys.exit('--host-alias "%s" missing from the command line\n%s'
+                 % (rule, cmd))
+# One ini line holds both rules, their separator percent-encoded: that is what
+# unescapeini() turns back into a line break when the project is reopened.
+ini = [l for l in textarea(page, "winprofile").split("\n")
+       if l.startswith("HostAlias=")]
+if not ini or not all(rule in ini[0] for rule in RULES):
+    sys.exit("winprofile.ini does not carry both rules\n%s" % ini)
 
-# Reopening the page must show the rule back: a name the state never writes
-# renders an empty field, and the project loses the rule on every reload.
-back = urllib.request.urlopen(url + "/server/option8.html?sid=" + sid,
-                              timeout=20).read().decode("latin-1")
-if 'value="%s"' % RULE not in back:
-    sys.exit("option8.html does not render the stored rule back")
+# Reopening the page must show both rules back, one per line: a name the state
+# never writes renders an empty box and the project loses them on every reload.
+back = textarea(urllib.request.urlopen(url + "/server/option8.html?sid=" + sid,
+                                       timeout=20).read().decode("latin-1"),
+                "hostalias")
+for rule in RULES:
+    if rule not in back:
+        sys.exit("option8.html does not render %r back\n%s" % (rule, back))
+
+# A blank line, and the trailing one a user leaves behind, emit nothing: the
+# engine refuses an empty rule.
+blanks = textarea(post([("hostalias",
+                         "\r\n" + "\r\n\r\n".join(RULES) + "\r\n")]),
+                  "command")
+if blanks.count("--host-alias") != len(RULES) or '--host-alias ""' in blanks:
+    sys.exit("blank lines reach the command line\n%s" % blanks)
+
+# Rules separate on any whitespace, like the URLs box. A space beside a ',' or
+# an '=' is inside its rule, which is why the parser trims it.
+spaced = textarea(post([("hostalias", " ".join(RULES))]), "command")
+if spaced.count("--host-alias") != len(RULES):
+    sys.exit("a space does not separate two rules\n%s" % spaced)
+joined = textarea(post([("hostalias", "a.com , b.com = c.com")]), "command")
+if joined.count("--host-alias") != 1 or '"a.com,b.com=c.com"' not in joined:
+    sys.exit("a spaced-out single rule was split\n%s" % joined)
 
 # An empty field must drop the flag, not emit a valueless --host-alias.
 if "--host-alias" in textarea(post([("hostalias", "")]), "command"):
     sys.exit("an empty Host aliases field still emits --host-alias")
 
 # Hand the engine below what the template actually emitted, not a literal.
-open(emitted, "w").write("\n".join(shlex.split(lines[lines.index(want)])) + "\n")
+emit = lines[lines.index('--host-alias "%s"' % RULES[0])]
+open(emitted, "w").write("\n".join(shlex.split(emit)) + "\n")
 PY
 echo OK
 


### PR DESCRIPTION
`--host-alias` was command line only. It now has a field on the wizard's Spider page, next to the other URL-canonicalization options it belongs with, a `HostAlias` key in the project file, and a row in the guide.

The engine takes one rule per flag, so a single-line field would have capped a project at one canonical host. The field is a textarea and a new `arglist:` template directive emits one `--host-alias` per rule. Rules separate on any whitespace, the way the URL box separates two URLs, except beside a `,` or an `=` where the space belongs to the rule the parser trims it out of, so `a.com , b.com = c.com` stays one rule. `--strip-query` has the same one-rule-per-flag shape and the same field, and is filed as #1168.

The test drives the running server: it posts two rules, checks both reach the command line and the project file, reopens the page to see them come back, and feeds the flag the template actually emitted to the engine, with a negative control on a flag name the engine does not know. The two new catalog strings land in English in all 30 languages, which `lang/README.md` allows; a translation pass would be its own change.

The splitter takes isspace()'s C-locale set, so the box splits the same way as the Host aliases field httrack-android#116 adds, where Java's `\s` also covers `\v` and `\f`. That comparison turned up a second thing: the guide's "Strip query keys" row was `data-for="win web"`, but the Android app has shown that field for a while, so the in-app guide hid it. The row is fixed here, and the host-alias row is `web droid` now that httrack-android#116 has merged.

Closes #1161

