### PR TITLE
A long URL overflows the dedup key buffer in htshash.c

### DIFF
--- a/src/htscore.h
+++ b/src/htscore.h
@@ -242,8 +242,9 @@ struct hash_struct {
   const char *strip_query;
   /* host-alias rules (not owned); set from opt->host_alias at hash_init */
   const char *host_alias;
-  char normfil[HTS_URLMAXSIZE * 2];
-  char normfil2[HTS_URLMAXSIZE * 2];
+  /* key scratch: holds a host and a path, each up to HTS_URLMAXSIZE * 2 */
+  char normfil[HTS_URLMAXSIZE * 4];
+  char normfil2[HTS_URLMAXSIZE * 4];
   char catbuff[CATBUFF_SIZE];
 };
 

--- a/src/htscore.h
+++ b/src/htscore.h
@@ -242,9 +242,9 @@ struct hash_struct {
   const char *strip_query;
   /* host-alias rules (not owned); set from opt->host_alias at hash_init */
   const char *host_alias;
-  /* key scratch: holds a host and a path, each up to HTS_URLMAXSIZE * 2 */
+  /* scratch: the hash key is a host plus a path, the compare one a path */
   char normfil[HTS_URLMAXSIZE * 4];
-  char normfil2[HTS_URLMAXSIZE * 4];
+  char normfil2[HTS_URLMAXSIZE * 2];
   char catbuff[CATBUFF_SIZE];
 };
 

--- a/src/htshash.c
+++ b/src/htshash.c
@@ -128,7 +128,12 @@ static coucal_hashkeys key_adrfil_hashes_generic(void *arg,
 
   // copy address
   assertf(adr_norm != NULL);
-  strcpy(hash->normfil, adr_norm);
+  /* Clip, never abort: both halves come off the wire. The key only feeds the
+     hash — equality is decided by key_adrfil_equals_generic — so a clipped key
+     costs a collision, not a wrong dedup. */
+  hash->normfil[0] = '\0';
+  strlncatbuff(hash->normfil, adr_norm, sizeof(hash->normfil),
+               sizeof(hash->normfil) - 1);
 
   // copy link
   assertf(fil != NULL);
@@ -137,12 +142,16 @@ static coucal_hashkeys key_adrfil_hashes_generic(void *arg,
     char BIGSTK keybuf[HTS_URLMAXSIZE];
     const char *const keys = hts_query_strip_keys(hash->strip_query, adr_canon,
                                                   fil, keybuf, sizeof(keybuf));
+    const size_t used = strlen(hash->normfil);
+    const size_t avail = sizeof(hash->normfil) - used;
 
-    if (hash->norm_slash || hash->norm_query || keys != NULL) {
-      fil_normalized_filtered_ex(fil, &hash->normfil[strlen(hash->normfil)],
-                                 keys, hash->norm_slash, hash->norm_query);
+    /* normalizing never expands, so a path that fits fits normalized too */
+    if ((hash->norm_slash || hash->norm_query || keys != NULL) &&
+        strlen(fil) < avail) {
+      fil_normalized_filtered_ex(fil, &hash->normfil[used], keys,
+                                 hash->norm_slash, hash->norm_query);
     } else {
-      strcpy(&hash->normfil[strlen(hash->normfil)], fil);
+      strlncatbuff(hash->normfil, fil, sizeof(hash->normfil), avail - 1);
     }
   }
 
@@ -326,6 +335,33 @@ void hash_free(hash_struct *hash) {
     coucal_delete(&hash->adrfil);
     coucal_delete(&hash->former_adrfil);
   }
+}
+
+/* see htshash.h */
+hts_boolean hash_url_key(httrackp *opt, const char *adr, const char *fil,
+                         char *key, size_t keysize) {
+  hash_struct hash;
+  lien_url lien;
+  hts_boolean inbounds = HTS_TRUE;
+  size_t i;
+
+  memset(&lien, 0, sizeof(lien));
+  lien.adr = key_duphandler(NULL, adr);
+  lien.fil = key_duphandler(NULL, fil);
+  hash_init(opt, &hash, opt->urlhack);
+  /* poisoned, not zeroed: the stray NUL of an off-by-one must show too */
+  memset(hash.normfil2, 'Z', sizeof(hash.normfil2));
+  (void) key_adrfil_hashes(&hash, &lien);
+  for (i = 0; i < sizeof(hash.normfil2); i++) {
+    if (hash.normfil2[i] != 'Z') {
+      inbounds = HTS_FALSE;
+      break;
+    }
+  }
+  key[0] = '\0';
+  strlncatbuff(key, hash.normfil, keysize, keysize - 1);
+  hash_free(&hash);
+  return inbounds;
 }
 
 /* Test helper: do the two URLs dedupe to the same key under opt's urlhack

--- a/src/htshash.c
+++ b/src/htshash.c
@@ -108,14 +108,9 @@ static const char *key_host_alias(const hash_struct *hash, const char *adr,
   return canon != NULL ? canon : adr;
 }
 
-/* Pseudo-key (lien_url structure) hash function */
-static coucal_hashkeys key_adrfil_hashes_generic(void *arg,
-                                              coucal_key_const value, 
-                                              const int former) {
-  hash_struct *const hash = (hash_struct*) arg;
-  const lien_url*const lien = (const lien_url*) value;
-  const char *const adr = !former ? lien->adr : lien->former_adr;
-  const char *const fil = !former ? lien->fil : lien->former_fil;
+/* see htshash.h */
+const char *hash_url_key(hash_struct *hash, const char *adr, const char *fil,
+                         char *dst, size_t dstsize) {
   char BIGSTK aliasbuf[HTS_URLMAXSIZE * 2];
   const char *const adr_canon =
       adr != NULL ? key_host_alias(hash, adr, aliasbuf, sizeof(aliasbuf))
@@ -128,12 +123,9 @@ static coucal_hashkeys key_adrfil_hashes_generic(void *arg,
 
   // copy address
   assertf(adr_norm != NULL);
-  /* Clip, never abort: both halves come off the wire. The key only feeds the
-     hash — equality is decided by key_adrfil_equals_generic — so a clipped key
-     costs a collision, not a wrong dedup. */
-  hash->normfil[0] = '\0';
-  strlncatbuff(hash->normfil, adr_norm, sizeof(hash->normfil),
-               sizeof(hash->normfil) - 1);
+  /* clip, don't abort: a wire URL feeds this, and the key only feeds the hash,
+     so a clipped one costs a collision and never a wrong dedup */
+  (void) strclipbuff(dst, dstsize, adr_norm);
 
   // copy link
   assertf(fil != NULL);
@@ -142,21 +134,33 @@ static coucal_hashkeys key_adrfil_hashes_generic(void *arg,
     char BIGSTK keybuf[HTS_URLMAXSIZE];
     const char *const keys = hts_query_strip_keys(hash->strip_query, adr_canon,
                                                   fil, keybuf, sizeof(keybuf));
-    const size_t used = strlen(hash->normfil);
-    const size_t avail = sizeof(hash->normfil) - used;
+    const size_t used = strlen(dst);
+    char *const tail = &dst[used];
+    const size_t avail = dstsize - used;
 
-    /* normalizing never expands, so a path that fits fits normalized too */
+    /* normalizing never expands, and it takes a path of at most its own
+       HTS_URLMAXSIZE * 2, so bound on both */
     if ((hash->norm_slash || hash->norm_query || keys != NULL) &&
-        strlen(fil) < avail) {
-      fil_normalized_filtered_ex(fil, &hash->normfil[used], keys,
-                                 hash->norm_slash, hash->norm_query);
+        strlen(fil) < avail && strlen(fil) < HTS_URLMAXSIZE * 2) {
+      fil_normalized_filtered_ex(fil, tail, keys, hash->norm_slash,
+                                 hash->norm_query);
     } else {
-      strlncatbuff(hash->normfil, fil, sizeof(hash->normfil), avail - 1);
+      (void) strclipbuff(tail, avail, fil);
     }
   }
+  return dst;
+}
 
-  // hash
-  return coucal_hash_string(hash->normfil);
+/* Pseudo-key (lien_url structure) hash function */
+static coucal_hashkeys
+key_adrfil_hashes_generic(void *arg, coucal_key_const value, const int former) {
+  hash_struct *const hash = (hash_struct *) arg;
+  const lien_url *const lien = (const lien_url *) value;
+  const char *const adr = !former ? lien->adr : lien->former_adr;
+  const char *const fil = !former ? lien->fil : lien->former_fil;
+
+  return coucal_hash_string(
+      hash_url_key(hash, adr, fil, hash->normfil, sizeof(hash->normfil)));
 }
 
 /* Pseudo-key (lien_url structure) comparison function */
@@ -335,33 +339,6 @@ void hash_free(hash_struct *hash) {
     coucal_delete(&hash->adrfil);
     coucal_delete(&hash->former_adrfil);
   }
-}
-
-/* see htshash.h */
-hts_boolean hash_url_key(httrackp *opt, const char *adr, const char *fil,
-                         char *key, size_t keysize) {
-  hash_struct hash;
-  lien_url lien;
-  hts_boolean inbounds = HTS_TRUE;
-  size_t i;
-
-  memset(&lien, 0, sizeof(lien));
-  lien.adr = key_duphandler(NULL, adr);
-  lien.fil = key_duphandler(NULL, fil);
-  hash_init(opt, &hash, opt->urlhack);
-  /* poisoned, not zeroed: the stray NUL of an off-by-one must show too */
-  memset(hash.normfil2, 'Z', sizeof(hash.normfil2));
-  (void) key_adrfil_hashes(&hash, &lien);
-  for (i = 0; i < sizeof(hash.normfil2); i++) {
-    if (hash.normfil2[i] != 'Z') {
-      inbounds = HTS_FALSE;
-      break;
-    }
-  }
-  key[0] = '\0';
-  strlncatbuff(key, hash.normfil, keysize, keysize - 1);
-  hash_free(&hash);
-  return inbounds;
 }
 
 /* Test helper: do the two URLs dedupe to the same key under opt's urlhack

--- a/src/htshash.h
+++ b/src/htshash.h
@@ -57,6 +57,11 @@ void hash_free(hash_struct *hash);
    flags. */
 hts_boolean hash_url_equals(httrackp *opt, const char *adra, const char *fila,
                             const char *adrb, const char *filb);
+/* Test helper: build the dedup key of ADR/FIL under opt's urlhack flags into
+   KEY (KEYSIZE bytes, clipped). HTS_FALSE if building it wrote past the key
+   scratch buffer, into the poisoned field behind it. */
+hts_boolean hash_url_key(httrackp *opt, const char *adr, const char *fil,
+                         char *key, size_t keysize);
 int hash_read(const hash_struct * hash, const char *nom1, const char *nom2,
               hash_struct_type type);
 void hash_write(hash_struct * hash, size_t lpos);

--- a/src/htshash.h
+++ b/src/htshash.h
@@ -57,11 +57,11 @@ void hash_free(hash_struct *hash);
    flags. */
 hts_boolean hash_url_equals(httrackp *opt, const char *adra, const char *fila,
                             const char *adrb, const char *filb);
-/* Test helper: build the dedup key of ADR/FIL under opt's urlhack flags into
-   KEY (KEYSIZE bytes, clipped). HTS_FALSE if building it wrote past the key
-   scratch buffer, into the poisoned field behind it. */
-hts_boolean hash_url_key(httrackp *opt, const char *adr, const char *fil,
-                         char *key, size_t keysize);
+/* Build the dedup key of ADR/FIL, the canonical host then the path, into DST
+   (DSTSIZE bytes) and return it. Each half is clipped to fit, so DST is always
+   NUL-terminated; it only feeds the hash, never a comparison. */
+const char *hash_url_key(hash_struct *hash, const char *adr, const char *fil,
+                         char *dst, size_t dstsize);
 int hash_read(const hash_struct * hash, const char *nom1, const char *nom2,
               hash_struct_type type);
 void hash_write(hash_struct * hash, size_t lpos);

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -3641,15 +3641,19 @@ const char *hts_query_strip_keys(const char *rules, const char *adr,
   /* Match string = normalized host/path, query removed. jump_normalized_const
      collapses www+scheme/auth so read and write (double-normalized) agree;
      query excluded keeps the decision on host/path only. */
+  /* clip rather than abort: an overlong host+path is hostile input, and the
+     worst a clipped match string can do is pick another rule */
   url[0] = '\0';
-  strcatbuff(url, jump_normalized_const(adr));
+  strlncatbuff(url, jump_normalized_const(adr), sizeof(url), sizeof(url) - 1);
   if (fil[0] != '/')
-    strcatbuff(url, "/");
+    strlncatbuff(url, "/", sizeof(url), sizeof(url) - strlen(url) - 1);
   q = strchr(fil, '?');
-  if (q != NULL)
-    strncatbuff(url, fil, (int) (q - fil));
-  else
-    strcatbuff(url, fil);
+  {
+    const size_t avail = sizeof(url) - strlen(url) - 1;
+    const size_t fillen = q != NULL ? (size_t) (q - fil) : strlen(fil);
+
+    strlncatbuff(url, fil, sizeof(url), fillen < avail ? fillen : avail);
+  }
 
   /* Walk the '\n' entries; last match wins (like the +/- filter eval). Each is
      "pattern=keys"; no '=' is the bare form, pattern "*". */

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -3633,26 +3633,26 @@ const char *hts_query_strip_keys(const char *rules, const char *adr,
                                  const char *fil, char *dest, size_t destsize) {
   const char *p, *q;
   const char *result = NULL;
-  char BIGSTK url[HTS_URLMAXSIZE * 2];
+  /* holds a host and a path, each up to HTS_URLMAXSIZE * 2 */
+  char BIGSTK url[HTS_URLMAXSIZE * 4];
 
   if (rules == NULL || *rules == '\0' || destsize == 0)
     return NULL;
 
   /* Match string = normalized host/path, query removed. jump_normalized_const
      collapses www+scheme/auth so read and write (double-normalized) agree;
-     query excluded keeps the decision on host/path only. */
-  /* clip rather than abort: an overlong host+path is hostile input, and the
-     worst a clipped match string can do is pick another rule */
-  url[0] = '\0';
-  strlncatbuff(url, jump_normalized_const(adr), sizeof(url), sizeof(url) - 1);
+     query excluded keeps the decision on host/path only. Clipped rather than
+     aborting: a longer one is hostile input, and which rule it picks is a
+     filter decision, not a memory error. */
+  (void) strclipbuff(url, sizeof(url), jump_normalized_const(adr));
   if (fil[0] != '/')
-    strlncatbuff(url, "/", sizeof(url), sizeof(url) - strlen(url) - 1);
+    (void) strclipbuff(&url[strlen(url)], sizeof(url) - strlen(url), "/");
   q = strchr(fil, '?');
   {
-    const size_t avail = sizeof(url) - strlen(url) - 1;
+    const size_t room = sizeof(url) - strlen(url) - 1;
     const size_t fillen = q != NULL ? (size_t) (q - fil) : strlen(fil);
 
-    strlncatbuff(url, fil, sizeof(url), fillen < avail ? fillen : avail);
+    strlncatbuff(url, fil, sizeof(url), fillen < room ? fillen : room);
   }
 
   /* Walk the '\n' entries; last match wins (like the +/- filter eval). Each is

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3776,23 +3776,45 @@ static int st_hostalias(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-/* The dedup key is a host and a path built in one scratch buffer: two halves
-   at the engine's per-field maximum must fit whole, and anything longer must
-   clip rather than run into the field behind it (#1160). */
+/* Build the key for ADR/FIL into ARENA, whose KEYSIZE bytes are followed by
+   GUARD poisoned ones, and report whether those are still untouched. */
+static hts_boolean st_hashkey(httrackp *opt, const char *adr, const char *fil,
+                              char *arena, size_t keysize, size_t guard) {
+  hash_struct hash;
+  size_t i;
+
+  /* poisoned with '#', not 0, or the stray NUL of an off-by-one would read as
+     untouched */
+  memset(arena, '#', keysize + guard);
+  hash_init(opt, &hash, opt->urlhack);
+  hash_url_key(&hash, adr, fil, arena, keysize);
+  hash_free(&hash);
+  for (i = keysize; i < keysize + guard; i++) {
+    if (arena[i] != '#')
+      return HTS_FALSE;
+  }
+  return HTS_TRUE;
+}
+
+/* The dedup key is a host and a path built in one buffer: two halves at the
+   engine's per-field maximum must fit whole, and either half alone must clip
+   rather than run past the end (#1160). */
 static int st_hashkey_bounds(httrackp *opt, int argc, char **argv) {
   /* what lien_adrfil.adr / .fil hold, and what a whole key needs */
-  enum { field = HTS_URLMAXSIZE * 2, keysize = 2 * field };
+  enum { field = HTS_URLMAXSIZE * 2, keysize = 2 * field, guard = 64 };
 
-  char *adr = malloct(2 * field);
-  char *fil = malloct(2 * field);
-  char *cat = malloct(4 * field);
-  char *key = malloct(keysize);
-  int overlong;
+  char *adr = malloct(2 * keysize);
+  char *fil = malloct(2 * keysize);
+  char *cat = malloct(4 * keysize);
+  char *arena = malloct(keysize + guard);
+  int hack;
 
   (void) argc;
   (void) argv;
-  assertf(adr != NULL && fil != NULL && cat != NULL && key != NULL);
+  assertf(adr != NULL && fil != NULL && cat != NULL && arena != NULL);
   opt->no_www_dedup = opt->no_slash_dedup = opt->no_query_dedup = HTS_FALSE;
+  /* the crawler's own key buffer, or every maximal URL would collide */
+  assertf(sizeof(((hash_struct *) NULL)->normfil) >= (size_t) keysize);
 
   /* a host and a path one byte short of their own buffers: nothing here
      normalizes away, so the key is the plain concatenation */
@@ -3801,42 +3823,65 @@ static int st_hashkey_bounds(httrackp *opt, int argc, char **argv) {
   fil[0] = '/';
   memset(fil + 1, 'b', field - 2);
   fil[field - 1] = '\0';
-  snprintf(cat, 4 * field, "%s%s", adr, fil);
-  opt->urlhack = HTS_FALSE;
-  assertf(hash_url_key(opt, adr, fil, key, keysize));
-  assertf(strcmp(key, cat) == 0);
-  opt->urlhack = HTS_TRUE; /* the normalizing branch writes the same key */
-  assertf(hash_url_key(opt, adr, fil, key, keysize));
-  assertf(strcmp(key, cat) == 0);
-
-  /* past those maxima the key clips to a prefix, in both branches */
-  memset(adr, 'a', 2 * field - 1);
-  adr[2 * field - 1] = '\0';
-  fil[0] = '/';
-  memset(fil + 1, 'b', 2 * field - 2);
-  fil[2 * field - 1] = '\0';
-  snprintf(cat, 4 * field, "%s%s", adr, fil);
-  for (overlong = 0; overlong < 2; overlong++) {
-    opt->urlhack = overlong == 0 ? HTS_FALSE : HTS_TRUE;
-    assertf(hash_url_key(opt, adr, fil, key, keysize));
-    assertf(strlen(key) != 0 && strlen(key) < keysize);
-    assertf(strncmp(key, cat, strlen(key)) == 0);
+  snprintf(cat, 4 * keysize, "%s%s", adr, fil);
+  for (hack = 0; hack < 2; hack++) {
+    opt->urlhack = hack != 0 ? HTS_TRUE : HTS_FALSE;
+    assertf(st_hashkey(opt, adr, fil, arena, keysize, guard));
+    assertf(strcmp(arena, cat) == 0);
   }
 
-  /* the match string --strip-query builds from the same two halves used to
-     abort on the same input */
-  {
-    char keys[64];
-    const char *const k =
-        hts_query_strip_keys("*=sid", adr, fil, keys, sizeof(keys));
+  /* either half alone past the whole key: each copy is bounded on its own */
+  for (hack = 0; hack < 4; hack++) {
+    const hts_boolean longadr = (hack & 1) != 0 ? HTS_TRUE : HTS_FALSE;
 
+    memset(adr, 'a', longadr ? keysize + 32 : 8);
+    adr[longadr ? keysize + 32 : 8] = '\0';
+    fil[0] = '/';
+    memset(fil + 1, 'b', longadr ? 8 : keysize + 32);
+    fil[(longadr ? 8 : keysize + 32) + 1] = '\0';
+    snprintf(cat, 4 * keysize, "%s%s", adr, fil);
+    opt->urlhack = (hack & 2) != 0 ? HTS_TRUE : HTS_FALSE;
+    assertf(st_hashkey(opt, adr, fil, arena, keysize, guard));
+    /* clipped and terminated, and a prefix of the pair rather than garbage */
+    assertf(strlen(arena) == keysize - 1);
+    assertf(strncmp(arena, cat, strlen(arena)) == 0);
+  }
+
+  /* --strip-query builds its match string from the same two halves, and used
+     to abort on a maximal pair. Past STRJOKER_MAXLEN no rule can match, so a
+     clipped string would answer where the whole one must stay silent. */
+  {
+    const char *const rules = "*=other\n*bbz=sid";
+    char keys[64];
+    const char *k;
+
+    /* control: the rules do match a short URL */
+    k = hts_query_strip_keys(rules, "h.com", "/bbz", keys, sizeof(keys));
     assertf(k != NULL && strcmp(k, "sid") == 0);
+    memset(adr, 'a', field - 1);
+    adr[field - 1] = '\0';
+    fil[0] = '/';
+    memset(fil + 1, 'b', field - 3);
+    fil[field - 2] = 'z';
+    fil[field - 1] = '\0';
+    assertf(hts_query_strip_keys(rules, adr, fil, keys, sizeof(keys)) == NULL);
+    opt->urlhack = HTS_TRUE; /* and the key builder survives the same pair */
+    StringCopy(opt->strip_query, rules);
+    assertf(st_hashkey(opt, adr, fil, arena, keysize, guard));
+
+    /* a matching rule plus a query longer than the normalizer's own scratch:
+       the key builder must clip instead of handing it over */
+    snprintf(fil, 2 * keysize, "/bbz?");
+    memset(&fil[5], 'q', field + 64); /* past the normalizer, inside the key */
+    fil[5 + field + 64] = '\0';
+    assertf(st_hashkey(opt, "h.com", fil, arena, keysize, guard));
+    StringCopy(opt->strip_query, "");
   }
 
   freet(adr);
   freet(fil);
   freet(cat);
-  freet(key);
+  freet(arena);
   printf("hashkey-bounds self-test OK\n");
   return 0;
 }

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3776,6 +3776,71 @@ static int st_hostalias(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* The dedup key is a host and a path built in one scratch buffer: two halves
+   at the engine's per-field maximum must fit whole, and anything longer must
+   clip rather than run into the field behind it (#1160). */
+static int st_hashkey_bounds(httrackp *opt, int argc, char **argv) {
+  /* what lien_adrfil.adr / .fil hold, and what a whole key needs */
+  enum { field = HTS_URLMAXSIZE * 2, keysize = 2 * field };
+
+  char *adr = malloct(2 * field);
+  char *fil = malloct(2 * field);
+  char *cat = malloct(4 * field);
+  char *key = malloct(keysize);
+  int overlong;
+
+  (void) argc;
+  (void) argv;
+  assertf(adr != NULL && fil != NULL && cat != NULL && key != NULL);
+  opt->no_www_dedup = opt->no_slash_dedup = opt->no_query_dedup = HTS_FALSE;
+
+  /* a host and a path one byte short of their own buffers: nothing here
+     normalizes away, so the key is the plain concatenation */
+  memset(adr, 'a', field - 1);
+  adr[field - 1] = '\0';
+  fil[0] = '/';
+  memset(fil + 1, 'b', field - 2);
+  fil[field - 1] = '\0';
+  snprintf(cat, 4 * field, "%s%s", adr, fil);
+  opt->urlhack = HTS_FALSE;
+  assertf(hash_url_key(opt, adr, fil, key, keysize));
+  assertf(strcmp(key, cat) == 0);
+  opt->urlhack = HTS_TRUE; /* the normalizing branch writes the same key */
+  assertf(hash_url_key(opt, adr, fil, key, keysize));
+  assertf(strcmp(key, cat) == 0);
+
+  /* past those maxima the key clips to a prefix, in both branches */
+  memset(adr, 'a', 2 * field - 1);
+  adr[2 * field - 1] = '\0';
+  fil[0] = '/';
+  memset(fil + 1, 'b', 2 * field - 2);
+  fil[2 * field - 1] = '\0';
+  snprintf(cat, 4 * field, "%s%s", adr, fil);
+  for (overlong = 0; overlong < 2; overlong++) {
+    opt->urlhack = overlong == 0 ? HTS_FALSE : HTS_TRUE;
+    assertf(hash_url_key(opt, adr, fil, key, keysize));
+    assertf(strlen(key) != 0 && strlen(key) < keysize);
+    assertf(strncmp(key, cat, strlen(key)) == 0);
+  }
+
+  /* the match string --strip-query builds from the same two halves used to
+     abort on the same input */
+  {
+    char keys[64];
+    const char *const k =
+        hts_query_strip_keys("*=sid", adr, fil, keys, sizeof(keys));
+
+    assertf(k != NULL && strcmp(k, "sid") == 0);
+  }
+
+  freet(adr);
+  freet(fil);
+  freet(cat);
+  freet(key);
+  printf("hashkey-bounds self-test OK\n");
+  return 0;
+}
+
 /* Prints the filter answer <n> emits for (adr, fil) [up]; with no arguments,
    asserts every answer against its expected pattern (#1119). */
 static int st_wizardfilter(httrackp *opt, int argc, char **argv) {
@@ -9345,6 +9410,8 @@ static const struct selftest_entry {
     {"urlhack", "", "-%u url-hack sub-flag (www/slash/query) self-test",
      st_urlhack},
     {"hostalias", "", "--host-alias hostname folding self-test", st_hostalias},
+    {"hashkey-bounds", "", "dedup key holds a maximal host+path (#1160)",
+     st_hashkey_bounds},
     {"redirect-samefile", "", "same-file redirect detection self-test (#159)",
      st_redirect_samefile},
     {"wizardfilter", "[<answer> <adr> <fil> [up]]",

--- a/tests/01_engine-hashkey-bounds.test
+++ b/tests/01_engine-hashkey-bounds.test
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# A maximal host plus a maximal path must fit the dedup key, not the field
+# behind it (#1160).
+out=$(httrack -O /dev/null -#test=hashkey-bounds run)
+grep -q "hashkey-bounds self-test OK" <<<"$out"


### PR DESCRIPTION
The dedup key is the host followed by the path, copied into one 2048-byte scratch field by two unbounded strcpy(). Both halves come off the wire and either can be that long on its own, so a hostile URL wrote up to twice what the buffer holds, into the next field of the same struct, where neither ASan nor `_FORTIFY_SOURCE` can see it.

The scratch is now sized for what it holds, a host plus a path, and the copies clip instead of aborting: the key only feeds the hash, equality is decided by `key_adrfil_equals_generic`, so a clipped key costs a collision and never a wrong dedup. `hts_query_strip_keys()` builds its match string from the same two halves and aborted on that same input, because the `*_safe_` helpers abort on overflow; it clips now too.

The hashkey-bounds self-test poisons the neighbouring field and builds a key from a host and a path both at their maximum. Putting either strcpy back kills it, and so does leaving the buffer at its old size.

Closes #1160
