### PR TITLE
The guide hides the Host aliases row from WinHTTrack readers

### DIFF
--- a/html/guide.html
+++ b/html/guide.html
@@ -710,7 +710,7 @@ bottom are the ones that keep you welcome.</p>
 	parameters that change nothing.</p>
 </div>
 
-<div class="opt" data-for="web droid">
+<div class="opt" data-for="win web droid">
 	<div class="opt-head"><span class="opt-name">Host aliases</span><span class="cli">-%C, --host-alias</span></div>
 	<p>Names the other hostnames one site answers to, one rule per line, written
 	<code>www2.example.com,m.example.com=example.com</code>. They fold onto that host: their links


### PR DESCRIPTION
httrack-windows#101 merged as 2e65f8f and puts the field on WinHTTrack's Spider page, so the row can name all three front ends. It went in with #1166 as `web droid` because only WebHTTrack and the Android app had the field then.

The row reaches a WinHTTrack reader through whatever engine that build packages, so it arrives with the field rather than ahead of it.

Closes #1173