### PR TITLE
The wizard can only hold one --strip-query rule

### DIFF
--- a/html/guide.html
+++ b/html/guide.html
@@ -707,7 +707,11 @@ bottom are the ones that keep you welcome.</p>
 	<div class="opt-head"><span class="opt-name">Strip query keys</span><span class="cli">-%g, --strip-query</span></div>
 	<p>Comma-separated query keys to drop when naming saved files, such as
 	<code>sid,utm_source</code>. Keeps one page from being saved several times under tracking
-	parameters that change nothing.</p>
+	parameters that change nothing. A rule may be scoped to the addresses it applies to, written
+	<code>shop.example.com/*=sid</code>.</p>
+	<p data-for="web">The box takes one rule per line. Only the last rule matching an address is
+	applied, so keys sharing a scope belong together on one line rather than on lines of their
+	own.</p>
 </div>
 
 <div class="opt" data-for="web droid">

--- a/html/guide.html
+++ b/html/guide.html
@@ -707,11 +707,10 @@ bottom are the ones that keep you welcome.</p>
 	<div class="opt-head"><span class="opt-name">Strip query keys</span><span class="cli">-%g, --strip-query</span></div>
 	<p>Comma-separated query keys to drop when naming saved files, such as
 	<code>sid,utm_source</code>. Keeps one page from being saved several times under tracking
-	parameters that change nothing. A rule may be scoped to the addresses it applies to, written
+	parameters that change nothing. You can scope a rule to the addresses it covers, for example
 	<code>shop.example.com/*=sid</code>.</p>
-	<p data-for="web">The box takes one rule per line. Only the last rule matching an address is
-	applied, so keys sharing a scope belong together on one line rather than on lines of their
-	own.</p>
+	<p data-for="web">The box takes one rule per line. Only the last matching rule applies, so keep
+	the keys for one scope together on a line rather than on lines of their own.</p>
 </div>
 
 <div class="opt" data-for="web droid">

--- a/html/server/option8.html
+++ b/html/server/option8.html
@@ -181,9 +181,10 @@ ${LANG_SITEMAPURL}
 <br><br>
 
 ${LANG_STRIPQUERY}
-<input name="stripquery" value="${attr:stripquery}" size="40"
+<br>
+<textarea name="stripquery" cols="60" rows="4"
 			title='${html:LANG_STRIPQUERYTIP}' onMouseOver="info('${js:LANG_STRIPQUERYTIP}'); return true" onMouseOut="info('&nbsp;'); return true"
->
+>${do:output-mode:html}${stripquery}${do:output-mode:}</textarea>
 <br><br>
 
 ${LANG_HOSTALIAS}

--- a/html/server/step4.html
+++ b/html/server/step4.html
@@ -185,7 +185,7 @@ ${/* -m<n> resets the html limit, so the bare form must precede the -m,<n> one *
 	${test:keepqueryorder:--keep-query-order}
 	${test:cookiesfile:--cookies-file "}${arg:cookiesfile}${test:cookiesfile:"}
 	${test:pausefiles:--pause "}${arg:pausefiles}${test:pausefiles:"}
-	${test:stripquery:--strip-query "}${arg:stripquery}${test:stripquery:"}
+	${arglist:stripquery:--strip-query}
 	${arglist:hostalias:--host-alias}
 	${test:toler:--tolerant}
 	${test:http10:--http-10}

--- a/tests/26_local-strip-query.test
+++ b/tests/26_local-strip-query.test
@@ -21,3 +21,17 @@ bash "$top_srcdir/tests/local-crawl.sh" --errors 0 --files 3 \
 # savename branch, which must normalize the dedup key the same way the hash does
 bash "$top_srcdir/tests/local-crawl.sh" --errors 0 --files 2 \
     httrack 'BASEURL/stripquery/index.html' -%u0 --strip-query 'utm_source'
+
+# several flags accumulate, as the wizard's rules box now emits them. The scoped
+# rule matches no host here, so either order must leave utm_source stripping.
+bash "$top_srcdir/tests/local-crawl.sh" --errors 0 --files 2 \
+    httrack 'BASEURL/stripquery/index.html' \
+    --strip-query 'other.invalid/*=nothing' --strip-query 'utm_source'
+bash "$top_srcdir/tests/local-crawl.sh" --errors 0 --files 2 \
+    httrack 'BASEURL/stripquery/index.html' \
+    --strip-query 'utm_source' --strip-query 'other.invalid/*=nothing'
+
+# control: the scoped rule alone strips nothing, so the pair above owes its
+# result to the utm_source rule surviving accumulation
+bash "$top_srcdir/tests/local-crawl.sh" --errors 0 --files 3 \
+    httrack 'BASEURL/stripquery/index.html' --strip-query 'other.invalid/*=nothing'

--- a/tests/26_local-strip-query.test
+++ b/tests/26_local-strip-query.test
@@ -31,7 +31,12 @@ bash "$top_srcdir/tests/local-crawl.sh" --errors 0 --files 2 \
     httrack 'BASEURL/stripquery/index.html' \
     --strip-query '*/stripquery/*=utm_source' --strip-query 'other.invalid/*=utm_source'
 
-# control: same keys behind a host that never matches strip nothing, so the pair
-# above owes its result to the pattern and not to the keys being listed at all
+# control: same keys behind a host that never matches, so nothing is stripped
 bash "$top_srcdir/tests/local-crawl.sh" --errors 0 --files 3 \
     httrack 'BASEURL/stripquery/index.html' --strip-query 'other.invalid/*=utm_source'
+
+# the last matching rule replaces the earlier one rather than adding to it: a
+# union, or a first-match-wins, would strip utm_source here and save 2 files
+bash "$top_srcdir/tests/local-crawl.sh" --errors 0 --files 3 \
+    httrack 'BASEURL/stripquery/index.html' \
+    --strip-query '*=utm_source' --strip-query '*/stripquery/*=nokey'

--- a/tests/26_local-strip-query.test
+++ b/tests/26_local-strip-query.test
@@ -22,16 +22,16 @@ bash "$top_srcdir/tests/local-crawl.sh" --errors 0 --files 3 \
 bash "$top_srcdir/tests/local-crawl.sh" --errors 0 --files 2 \
     httrack 'BASEURL/stripquery/index.html' -%u0 --strip-query 'utm_source'
 
-# several flags accumulate, as the wizard's rules box now emits them. The scoped
-# rule matches no host here, so either order must leave utm_source stripping.
+# several flags accumulate, as the wizard's rules box now emits them: one rule
+# of each pair matches, so either order needs both to survive
 bash "$top_srcdir/tests/local-crawl.sh" --errors 0 --files 2 \
     httrack 'BASEURL/stripquery/index.html' \
-    --strip-query 'other.invalid/*=nothing' --strip-query 'utm_source'
+    --strip-query 'other.invalid/*=utm_source' --strip-query '*/stripquery/*=utm_source'
 bash "$top_srcdir/tests/local-crawl.sh" --errors 0 --files 2 \
     httrack 'BASEURL/stripquery/index.html' \
-    --strip-query 'utm_source' --strip-query 'other.invalid/*=nothing'
+    --strip-query '*/stripquery/*=utm_source' --strip-query 'other.invalid/*=utm_source'
 
-# control: the scoped rule alone strips nothing, so the pair above owes its
-# result to the utm_source rule surviving accumulation
+# control: same keys behind a host that never matches strip nothing, so the pair
+# above owes its result to the pattern and not to the keys being listed at all
 bash "$top_srcdir/tests/local-crawl.sh" --errors 0 --files 3 \
-    httrack 'BASEURL/stripquery/index.html' --strip-query 'other.invalid/*=nothing'
+    httrack 'BASEURL/stripquery/index.html' --strip-query 'other.invalid/*=utm_source'

--- a/tests/273_webhttrack-strip-query.test
+++ b/tests/273_webhttrack-strip-query.test
@@ -92,6 +92,14 @@ back = textarea(urllib.request.urlopen(url + "/server/option8.html?sid=" + sid,
 if [l.strip() for l in back.split("\n") if l.strip()] != RULES:
     sys.exit("option8.html renders %r back, wanted the two rules" % back)
 
+# A '<' comes back as an entity: raw, it would close the box early and put the
+# rest of the page inside a rule.
+post([("stripquery", "a<b=sid")])
+page = urllib.request.urlopen(url + "/server/option8.html?sid=" + sid,
+                              timeout=20).read().decode("latin-1")
+if "a&lt;b=sid" not in page:
+    sys.exit("option8.html does not escape a rule holding '<'")
+
 
 def emitted_rules(value):
     flag = '--strip-query "'

--- a/tests/273_webhttrack-strip-query.test
+++ b/tests/273_webhttrack-strip-query.test
@@ -13,7 +13,7 @@ distdir=$(cd "${distdir}" && pwd)
 
 htsserver_require
 
-printf '[project reload maps the key back] ..\t'
+printf '[the project key stays bound to the field] ..\t'
 grep -q "do:copy:StripQuery:stripquery" "${distdir}/html/server/step2.html" ||
     fail "step2.html does not restore StripQuery"
 echo OK
@@ -44,8 +44,8 @@ if not m:
     sys.exit("no session id in server/index.html")
 sid = m.group(1).decode()
 
-# A single-line input renders the name too, so match the tag: only a textarea
-# can hold a second rule.
+# The tag, because a single-line input renders the name too; the label text,
+# because an unknown ${LANG_*} renders empty.
 page = urllib.request.urlopen(url + "/server/option8.html?sid=" + sid,
                               timeout=20).read().decode("latin-1")
 for want in ('<textarea name="stripquery"', "Strip query keys:"):
@@ -75,24 +75,25 @@ for rule in RULES:
     if '--strip-query "%s"' % rule not in lines:
         sys.exit('--strip-query "%s" missing from the command line\n%s'
                  % (rule, cmd))
-# One ini line holds both rules, their separator percent-encoded.
-ini = [l for l in textarea(page, "winprofile").split("\n")
+# Exactly one ini line, holding both rules with the CRLF between them
+# percent-encoded: a separator dropped here merges them into one bad rule.
+want = "StripQuery=" + "%0d%0a".join(RULES)
+ini = [l.strip() for l in textarea(page, "winprofile").split("\n")
        if l.startswith("StripQuery=")]
-if not ini or not all(rule in ini[0] for rule in RULES):
-    sys.exit("winprofile.ini does not carry both rules\n%s" % ini)
+if ini != [want]:
+    sys.exit("winprofile.ini reads %s, wanted [%r]" % (ini, want))
 
-# Reopening the page must show both rules back, one per line: a name the state
-# never writes renders an empty box and the project loses them on every reload.
+# Reopening the page must show the rules back on their own lines: a name the
+# session state never writes renders an empty box, and rules run together come
+# back as one.
 back = textarea(urllib.request.urlopen(url + "/server/option8.html?sid=" + sid,
                                        timeout=20).read().decode("latin-1"),
                 "stripquery")
-for rule in RULES:
-    if rule not in back:
-        sys.exit("option8.html does not render %r back\n%s" % (rule, back))
+if [l.strip() for l in back.split("\n") if l.strip()] != RULES:
+    sys.exit("option8.html renders %r back, wanted the two rules" % back)
 
 
 def emitted_rules(value):
-    """The rules the template emits for a box holding VALUE."""
     flag = '--strip-query "'
     return [line.strip()[len(flag):-1]
             for line in textarea(post([("stripquery", value)]),
@@ -100,12 +101,13 @@ def emitted_rules(value):
             if flag in line]
 
 
-# Whitespace beside the ',' that separates two keys or the '=' that scopes them
-# stays inside its rule; a blank line and an empty box emit no flag at all,
-# which the engine would refuse.
+# Whitespace beside the ',' between two keys or the '=' scoping them stays in
+# the rule; elsewhere it separates two. An empty box must emit no flag at all.
 for value, want in [(" ".join(RULES), RULES),
                     ("\r\n" + "\r\n\r\n".join(RULES) + "\r\n", RULES),
                     ("ex.com/* = sid, utm", ["ex.com/*=sid,utm"]),
+                    ("a ,b", ["a,b"]),
+                    ("sid,utm ref", ["sid,utm", "ref"]),
                     ("sid\r\nutm", ["sid", "utm"]),
                     (" \r\n\t ", []),
                     ("", [])]:

--- a/tests/273_webhttrack-strip-query.test
+++ b/tests/273_webhttrack-strip-query.test
@@ -1,0 +1,137 @@
+#!/bin/bash
+#
+# The Strip query keys field holds several rules: the template must emit one
+# --strip-query per rule, and the engine must take the flag name it emits.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
+distdir=$(cd "${distdir}" && pwd)
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
+
+htsserver_require
+
+printf '[project reload maps the key back] ..\t'
+grep -q "do:copy:StripQuery:stripquery" "${distdir}/html/server/step2.html" ||
+    fail "step2.html does not restore StripQuery"
+echo OK
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_stripquery.XXXXXX") || fail "no tmpdir"
+cleanup() {
+    htsserver_cleanup
+    rm -rf "${work}"
+}
+cleanup_push cleanup
+
+printf '[webhttrack emits one --strip-query per rule] ..\t'
+htsserver_start --home "${work}"
+
+"${HTS_PYTHON}" - "${HTS_URL}" "${work}/emitted" <<'PY' || fail "the Strip query keys field is not wired (see above)"
+import re, shlex, sys, urllib.parse, urllib.request
+
+url, emitted = sys.argv[1].rstrip("/"), sys.argv[2]
+# Scoped rules, because the engine applies the last one matching an address: a
+# browser posts the textarea lines CRLF-separated.
+RULES = ["shop.example.com/*=sid,utm_source",
+         "www.example.org/*=ref"]
+RULE = "\r\n".join(RULES)
+
+form = urllib.request.urlopen(url + "/server/index.html", timeout=20).read()
+m = re.search(rb'name="sid" value="([0-9a-f]+)"', form)
+if not m:
+    sys.exit("no session id in server/index.html")
+sid = m.group(1).decode()
+
+# A single-line input renders the name too, so match the tag: only a textarea
+# can hold a second rule.
+page = urllib.request.urlopen(url + "/server/option8.html?sid=" + sid,
+                              timeout=20).read().decode("latin-1")
+for want in ('<textarea name="stripquery"', "Strip query keys:"):
+    if want not in page:
+        sys.exit("option8.html does not render %r" % want)
+
+
+def post(fields):
+    body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in
+                    [("sid", sid)] + fields)
+    req = urllib.request.Request(url + "/server/step4.html",
+                                 data=body.encode("latin-1"), method="POST")
+    return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
+
+
+def textarea(page, name):
+    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page, re.S)
+    if m is None:
+        sys.exit("no %s textarea in the rendered step4.html" % name)
+    return m.group(1)
+
+
+page = post([("stripquery", RULE)])
+cmd = textarea(page, "command")
+lines = [l.strip() for l in cmd.split("\n")]
+for rule in RULES:
+    if '--strip-query "%s"' % rule not in lines:
+        sys.exit('--strip-query "%s" missing from the command line\n%s'
+                 % (rule, cmd))
+# One ini line holds both rules, their separator percent-encoded.
+ini = [l for l in textarea(page, "winprofile").split("\n")
+       if l.startswith("StripQuery=")]
+if not ini or not all(rule in ini[0] for rule in RULES):
+    sys.exit("winprofile.ini does not carry both rules\n%s" % ini)
+
+# Reopening the page must show both rules back, one per line: a name the state
+# never writes renders an empty box and the project loses them on every reload.
+back = textarea(urllib.request.urlopen(url + "/server/option8.html?sid=" + sid,
+                                       timeout=20).read().decode("latin-1"),
+                "stripquery")
+for rule in RULES:
+    if rule not in back:
+        sys.exit("option8.html does not render %r back\n%s" % (rule, back))
+
+
+def emitted_rules(value):
+    """The rules the template emits for a box holding VALUE."""
+    flag = '--strip-query "'
+    return [line.strip()[len(flag):-1]
+            for line in textarea(post([("stripquery", value)]),
+                                 "command").split("\n")
+            if flag in line]
+
+
+# Whitespace beside the ',' that separates two keys or the '=' that scopes them
+# stays inside its rule; a blank line and an empty box emit no flag at all,
+# which the engine would refuse.
+for value, want in [(" ".join(RULES), RULES),
+                    ("\r\n" + "\r\n\r\n".join(RULES) + "\r\n", RULES),
+                    ("ex.com/* = sid, utm", ["ex.com/*=sid,utm"]),
+                    ("sid\r\nutm", ["sid", "utm"]),
+                    (" \r\n\t ", []),
+                    ("", [])]:
+    got = emitted_rules(value)
+    if got != want:
+        sys.exit("%r emitted %r, wanted %r" % (value, got, want))
+
+# Hand the engine below both flags the template actually emitted, not literals.
+emit = [lines[lines.index('--strip-query "%s"' % rule)] for rule in RULES]
+open(emitted, "w").write("\n".join(w for e in emit for w in shlex.split(e))
+                         + "\n")
+PY
+echo OK
+
+printf '[the engine knows the flag] ..\t'
+# macOS runs the suite under bash 3.2, which has no mapfile
+argv=()
+while IFS= read -r arg; do
+    argv+=("${arg}")
+done <"${work}/emitted"
+# Rejected flags exit 255 like a URL-less run, so match the diagnostic.
+out=$(httrack "${argv[@]}" 2>&1) || true
+if grep -q "Unknown option" <<<"${out}"; then
+    fail "the engine rejects ${argv[0]}: ${out}"
+fi
+# Control: the same probe on a flag that does not exist.
+out=$(httrack "${argv[0]}es" "${argv[1]}" 2>&1) || true
+grep -q "Unknown option" <<<"${out}" || fail "the unknown-option probe proves nothing"
+echo OK


### PR DESCRIPTION
The engine accumulates `--strip-query` into a newline-separated list, one rule per flag, but the wizard bound the option to a single-line input and emitted one flag, so a project built there held one rule. Two hosts needing different keys stripped meant the command line or a hand-edited project file. The field is a textarea now, and the `arglist:` directive #1166 added emits one flag per rule, so nothing changes in the template engine.

One legacy value changes meaning. Whitespace separates two rules unless it sits beside a `,` or an `=`, so an old box mixing both separators, `sid,utm ref`, now yields two bare rules. Last match wins, so only `ref` survives and `sid` stops being stripped. Nothing the tooltip tells you to type has that shape, and the trailing token was never a key the engine could match, but a project saved with it strips one key fewer from now on. Splitting on newlines alone would have spared it, at the cost of two adjacent boxes on the same page splitting differently.

The catalog strings stay as they are: `LANG_STRIPQUERY` and its tip are translated in all 30 languages, and rewording an English value orphans every translation joined to it. The guide row carries the multi-rule form instead, along with the scoped syntax `shop.example.com/*=sid`, which was never written down anywhere, and a web-only note that only the last rule matching an address applies. That warning matters more here than it did for host aliases: put `sid` and `utm_source` on lines of their own and only `utm_source` is stripped, which is exactly what a box invites you to do.

Test 273 posts two scoped rules, compares the whole command line, project-file line and reopened box against what the rules must produce, and feeds the flag the template emitted to the engine with a negative control on a flag name the engine does not know. Test 26 gains two legs for something nothing covered: two `--strip-query` flags on one command line. It passed a single rule and the self-test starts from the already-accumulated string, so the accumulation in htscoremain.c was only reachable by hand. The pair runs in both orders, one rule of each matching the fixture, with a control carrying the same keys behind a host that never matches.

Closes #1168