### PR TITLE
A target that is not a keyword shares one tab, and dark mode prints white on white

### DIFF
--- a/html/cache.html
+++ b/html/cache.html
@@ -77,8 +77,8 @@ The main advantages of this cache are:
 
 <ul>
 <li>One single file for a complete website cache archive</li>
-<li>Standard <a href="http://www.pkware.com/products/enterprise/white_papers/appnote.txt" target="_new">ZIP</a> format, that can be easily reused on most platforms and languages</li>
-<li>Compressed data with the efficient and opened <a href="http://www.gzip.org/zlib/" target="_new">zlib</a> format</li>
+<li>Standard <a href="http://www.pkware.com/products/enterprise/white_papers/appnote.txt" target="_blank">ZIP</a> format, that can be easily reused on most platforms and languages</li>
+<li>Compressed data with the efficient and opened <a href="http://www.gzip.org/zlib/" target="_blank">zlib</a> format</li>
 </ul>
 
 The cache is made of ZIP files entries ; with one ZIP file entry per fetched URL (successfully or not - errors are also stored).<br />

--- a/html/cache.html
+++ b/html/cache.html
@@ -86,7 +86,7 @@ For each entry:
 <ul>
 <li>The ZIP file name is the original URL [<small><a href="#orig">see notes below</a></small>]</li>
 <li>The ZIP file contents, <b>if available</b>, is the original (compressed, using the deflate algorythm) data</li>
-<li>The ZIP file extra field (in the local file header) contains a list of meta-fields, very similar to the <a href="http://www.ietf.org/rfc/rfc2616.txt?number=2616" target="new_">HTTP</a> headers fields. See also <a href="http://www.ietf.org/rfc/rfc2396.txt?number=2396" target="new_">RFC</a>.</li><br />
+<li>The ZIP file extra field (in the local file header) contains a list of meta-fields, very similar to the <a href="http://www.ietf.org/rfc/rfc2616.txt?number=2616" target="_blank">HTTP</a> headers fields. See also <a href="http://www.ietf.org/rfc/rfc2396.txt?number=2396" target="_blank">RFC</a>.</li><br />
 <li>The ZIP file timestamp follows the "Last-Modified-Since" field given for this URL, if any</li>
 </ul>
 

--- a/html/doc.css
+++ b/html/doc.css
@@ -366,8 +366,26 @@ dialog#zoom::backdrop { background: rgba(0, 0, 0, .8); }
 	z-index: 10;
 }
 
+/* Some browsers still match prefers-color-scheme: dark while printing, putting
+   #e6e6ee ink on white paper. Reset the palette, not each rule that reads it. */
 @media print {
+	:root {
+		--field: #77b;
+		--panel: #ccd;
+		--accent: #99c;
+		--ink: #111;
+		--ink-soft: #444;
+		--rule: #aab;
+		--link: #00c;
+		--link-hover: #c00;
+		--code-bg: #e8e8f2;
+		--chip: #dde;
+		--shadow: rgba(0, 0, 0, .25);
+	}
+
 	body { background: #fff; }
 	.toc, .filter { display: none; }
 	.wrap { display: block; border: 0; }
+	/* Not a token, same paper: the dark scheme inverts the wordmark to white. */
+	.masthead img { filter: none; }
 }

--- a/html/doc.css
+++ b/html/doc.css
@@ -366,8 +366,8 @@ dialog#zoom::backdrop { background: rgba(0, 0, 0, .8); }
 	z-index: 10;
 }
 
-/* Some browsers still match prefers-color-scheme: dark while printing, putting
-   #e6e6ee ink on white paper. Reset the palette, not each rule that reads it. */
+/* Some browsers still apply prefers-color-scheme: dark when printing, so the ink
+   comes out #e6e6ee on white paper. Reset the palette, not each rule reading it. */
 @media print {
 	:root {
 		--field: #77b;

--- a/html/faq.html
+++ b/html/faq.html
@@ -320,7 +320,7 @@ However, be sure to always download HTTrack from a <b>trusted source</b> (prefer
 
 <br><br><a NAME="QG0c">Q: <strong>This software is 'free', but I bought it from an authorized reseller . What's going on?</strong></a><br>
 A: <em>
-HTTrack is free (free as in 'freedom') as it is covered by the <a href="http://www.gnu.org/licenses/gpl.txt" target="_new">GNU General Public License (GPL)</a>. 
+HTTrack is free (free as in 'freedom') as it is covered by the <a href="http://www.gnu.org/licenses/gpl.txt" target="_blank">GNU General Public License (GPL)</a>. 
 You can freely download it, without paying any fees, copy it to your friends, and modify it if you respect the license.
 There are NO official/authorized resellers, because HTTrack is <b>NOT</b> a commercial product.
 But you can be charged for duplication fees, or any other services (example: software CDroms or shareware collections, or fees for maintenance), 

--- a/html/server/file.html
+++ b/html/server/file.html
@@ -61,7 +61,7 @@ function info(str) {
 ${do:output-mode:html-urlescaped}
   href="file://${path}/"
 ${do:output-mode:}
-  target="_new">
+  target="_blank">
 ${LANG_D8}
 </a>
 </td></tr>

--- a/html/server/finished.html
+++ b/html/server/finished.html
@@ -99,12 +99,12 @@ ${do:end-if}
 
 ${LANG_G8} : 
 ${/* an http: page cannot navigate to file:, so the mirror is reached through the server */}
-<a href="/website/index.html" target="_new">
+<a href="/website/index.html" target="_blank">
 ${html:path}/${html:projname}
 </a></li>
 <ul>
-<li><a href="/website/index.html" target="_new">${LANG_D8}</a></li>
-<li><a href="/website/hts-log.txt" target="_new">${LANG_D4}</a></li>
+<li><a href="/website/index.html" target="_blank">${LANG_D8}</a></li>
+<li><a href="/website/hts-log.txt" target="_blank">${LANG_D4}</a></li>
 </ul>
 
 <form method="POST" action="exit.html" name="form">

--- a/html/server/help.html
+++ b/html/server/help.html
@@ -57,7 +57,7 @@ function info(str) {
 
 <table class="tableWidth" border="0" width="100%" cellspacing="0">
 <tr><td class="tabCtrl" align="left">
-<a style="background:black;color: white" href="about.html" target="_new"
+<a style="background:black;color: white" href="about.html" target="_blank"
 			title='${html:LANG_G21}' onMouseOver="info('${js:LANG_G21}'); return true" onMouseOut="info('&nbsp;'); return true"
 			>
 ${LANG_O16}...
@@ -66,7 +66,7 @@ ${LANG_O16}...
 
 <tr><td class="tabCtrl" align="left">
 <a style="background:black;color: white" 
-   href="http://www.httrack.com/update.php3?Product=HTTrack&Version=${attr:HTTRACK_VERSIONID}&VersionStr=${attr:HTTRACK_VERSION}&Platform=${attr:HTS_PLATFORM}&LanguageId=${attr:lang}" target="_new"
+   href="http://www.httrack.com/update.php3?Product=HTTrack&Version=${attr:HTTRACK_VERSIONID}&VersionStr=${attr:HTTRACK_VERSION}&Platform=${attr:HTS_PLATFORM}&LanguageId=${attr:lang}" target="_blank"
 			title='${html:LANG_O17}' onMouseOver="info('${js:LANG_O17}'); return true" onMouseOut="info('&nbsp;'); return true"
    >
 ${LANG_O17}...
@@ -77,7 +77,7 @@ ${/* show help only if available */}
 ${do:if-file-exists:html/index.html}
 <tr><td class="tabCtrl" align="left">
 <a style="background:black;color: white" 
-   href="/index.html" target="_new"
+   href="/index.html" target="_blank"
 			title='${html:LANG_TIPHELP}' onMouseOver="info('${js:LANG_TIPHELP}'); return true" onMouseOut="info('&nbsp;'); return true"
    >
 ${LANG_P16}

--- a/tests/277_html-target-and-print.test
+++ b/tests/277_html-target-and-print.test
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# Two html/ defects that render invisibly: target="_new" is a named context, not
+# a keyword, so every such link reuses one tab; and a print block that resets
+# only body leaves the dark palette live on paper.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+srcdir="${abs_top_srcdir:?not run under make check}"
+htmldir="${srcdir}/html"
+test -d "${htmldir}" || fail "no ${htmldir}"
+
+# ---- target="_new" ----
+
+pages=()
+while IFS= read -r f; do
+    pages+=("$f")
+done < <(find "${htmldir}" -type f \
+    \( -name '*.html' -o -name '*.css' -o -name '*.js' -o -name '*.xml' \) | LC_ALL=C sort)
+
+# A silently empty candidate list would pass the scan below proving nothing.
+test "${#pages[@]}" -ge 60 || fail "only ${#pages[@]} markup files under html/"
+listing=$(printf '%s\n' "${pages[@]}")
+for want in faq.html cache.html server/file.html server/finished.html server/help.html; do
+    grep -qxF "${htmldir}/${want}" <<<"${listing}" ||
+        fail "candidate list misses html/${want}: the scan cannot see the pages it is for"
+done
+
+offenders=$(grep -l 'target="_new"' "${pages[@]}" || true)
+test -z "${offenders}" || fail "target=\"_new\" is a named context, use _blank: ${offenders}"
+
+# ---- print palette ----
+
+css="${htmldir}/doc.css"
+test -r "${css}" || fail "no ${css}"
+
+# Emits "scope name value" for every custom property in a :root block.
+tokens=$(awk '
+/^@media print \{$/                          { media = "print"; next }
+/^@media \(prefers-color-scheme: dark\) \{$/ { media = "dark";  next }
+/^@media/                                    { media = "other"; next }
+/^\}$/                                       { media = ""; inroot = 0; next }
+/^\t?\}$/                                    { inroot = 0; next }
+/^\t?:root \{$/                              { inroot = 1; next }
+inroot && match($0, /--[a-z-]+:/) {
+    name = substr($0, RSTART, RLENGTH - 1)
+    value = substr($0, RSTART + RLENGTH)
+    sub(/^[ \t]+/, "", value)
+    sub(/;.*$/, "", value)
+    scope = (media == "" ? "light" : media)
+    print scope, name, value
+}' "${css}")
+
+value_of() { awk -v s="$1" -v n="$2" '$1 == s && $2 == n { $1 = ""; $2 = ""; sub(/^ +/, ""); print }' <<<"${tokens}"; }
+
+dark_names=$(awk '$1 == "dark" { print $2 }' <<<"${tokens}")
+test "$(grep -c . <<<"${dark_names}")" -ge 5 ||
+    fail "found no dark palette to compare against: awk parse of ${css} is broken"
+
+for name in ${dark_names}; do
+    light=$(value_of light "${name}")
+    printed=$(value_of print "${name}")
+    test -n "${light}" || fail "${name} has no light value"
+    test -n "${printed}" || fail "@media print leaves the dark ${name} live on paper"
+    test "${printed}" = "${light}" ||
+        fail "@media print sets ${name} to '${printed}', not the light '${light}'"
+done
+
+echo "html hygiene: ${#pages[@]} markup files free of _new, print restores $(grep -c . <<<"${dark_names}") palette tokens"

--- a/tests/277_html-target-and-print.test
+++ b/tests/277_html-target-and-print.test
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# Two html/ defects that render invisibly: target="_new" is a named context, not
-# a keyword, so every such link reuses one tab; and a print block that resets
-# only body leaves the dark palette live on paper.
+# Two html/ defects that render invisibly: a misspelt target keyword is a named
+# context, so every such link reuses one tab; and a print block that resets only
+# body leaves the dark palette live on paper.
 
 set -euo pipefail
 
@@ -13,13 +13,14 @@ srcdir="${abs_top_srcdir:?not run under make check}"
 htmldir="${srcdir}/html"
 test -d "${htmldir}" || fail "no ${htmldir}"
 
-# ---- target="_new" ----
+# ---- link targets ----
 
 pages=()
 while IFS= read -r f; do
     pages+=("$f")
 done < <(find "${htmldir}" -type f \
-    \( -name '*.html' -o -name '*.css' -o -name '*.js' -o -name '*.xml' \) | LC_ALL=C sort)
+    \( -name '*.html' -o -name '*.css' -o -name '*.js' -o -name '*.xml' -o -name '*.svg' \) |
+    LC_ALL=C sort)
 
 # A silently empty candidate list would pass the scan below proving nothing.
 test "${#pages[@]}" -ge 60 || fail "only ${#pages[@]} markup files under html/"
@@ -29,8 +30,22 @@ for want in faq.html cache.html server/file.html server/finished.html server/hel
         fail "candidate list misses html/${want}: the scan cannot see the pages it is for"
 done
 
-offenders=$(grep -l 'target="_new"' "${pages[@]}" || true)
-test -z "${offenders}" || fail "target=\"_new\" is a named context, use _blank: ${offenders}"
+# Leading space so data-target and friends do not match. Unquoted values are not
+# covered; nothing in the tree writes one.
+attr() { grep -ohE "[[:space:]][Tt][Aa][Rr][Gg][Ee][Tt][[:space:]]*=[[:space:]]*$1" "${pages[@]}" || true; }
+values=$(
+    attr '"[^"]*"'
+    attr "'[^']*'"
+)
+values=$(tr -d "\"' \\t" <<<"${values}" | sed 's/^[Tt][Aa][Rr][Gg][Ee][Tt]=//' | grep . || true)
+
+seen=$(grep -c . <<<"${values}" || true)
+test "${seen}" -ge 50 || fail "only ${seen} target attributes found under html/"
+
+# Anything but the four keywords is a named context: _new and new_ both were.
+# Nothing here wants a named one, so the keywords are the whole allowlist.
+bad=$(grep -vxE '_blank|_self|_parent|_top' <<<"${values}" | LC_ALL=C sort -u || true)
+test -z "${bad}" || fail "not a target keyword: $(tr '\n' ' ' <<<"${bad}")"
 
 # ---- print palette ----
 
@@ -45,21 +60,31 @@ tokens=$(awk '
 /^\}$/                                       { media = ""; inroot = 0; next }
 /^\t?\}$/                                    { inroot = 0; next }
 /^\t?:root \{$/                              { inroot = 1; next }
-inroot && match($0, /--[a-z-]+:/) {
-    name = substr($0, RSTART, RLENGTH - 1)
-    value = substr($0, RSTART + RLENGTH)
-    sub(/^[ \t]+/, "", value)
-    sub(/;.*$/, "", value)
-    scope = (media == "" ? "light" : media)
-    print scope, name, value
+inroot {
+    rest = $0
+    while (match(rest, /--[A-Za-z0-9_-]+[[:space:]]*:/)) {
+        name = substr(rest, RSTART, RLENGTH)
+        sub(/[[:space:]]*:$/, "", name)
+        rest = substr(rest, RSTART + RLENGTH)
+        value = rest
+        sub(/^[[:space:]]+/, "", value)
+        sub(/;.*$/, "", value)
+        sub(/[[:space:]]+$/, "", value)
+        print (media == "" ? "light" : media), name, value
+    }
 }' "${css}")
 
 value_of() { awk -v s="$1" -v n="$2" '$1 == s && $2 == n { $1 = ""; $2 = ""; sub(/^ +/, ""); print }' <<<"${tokens}"; }
+count_in() { awk -v s="$1" '$1 == s' <<<"${tokens}" | grep -c . || true; }
+
+# Independent count, so a token the awk above never saw cannot pass unrestored.
+declared=$(sed -n '/^@media (prefers-color-scheme: dark) {$/,/^}$/p' "${css}" |
+    grep -oE -- '--[A-Za-z0-9_-]+[[:space:]]*:' | grep -c . || true)
+test "${declared}" -ge 5 || fail "found no dark palette in ${css} to compare against"
+test "$(count_in dark)" -eq "${declared}" ||
+    fail "awk read $(count_in dark) of ${declared} dark tokens in ${css}: the parse is broken"
 
 dark_names=$(awk '$1 == "dark" { print $2 }' <<<"${tokens}")
-test "$(grep -c . <<<"${dark_names}")" -ge 5 ||
-    fail "found no dark palette to compare against: awk parse of ${css} is broken"
-
 for name in ${dark_names}; do
     light=$(value_of light "${name}")
     printed=$(value_of print "${name}")
@@ -69,4 +94,4 @@ for name in ${dark_names}; do
         fail "@media print sets ${name} to '${printed}', not the light '${light}'"
 done
 
-echo "html hygiene: ${#pages[@]} markup files free of _new, print restores $(grep -c . <<<"${dark_names}") palette tokens"
+echo "html hygiene: ${seen} link targets are keywords, print restores ${declared} palette tokens"


### PR DESCRIPTION
Twelve hand-written links under `html/` name a target that is not a keyword: ten spell it `target="_new"`, and two on the cache page transpose it to `target="new_"`. Browsers fall back on the named-browsing-context rule and give each misspelling one shared tab, so the GPL link in the FAQ, the format links on the cache page and the seven on the WebHTTrack pages take turns in the same window. They all mean `_blank`, which the other 47 links on those same pages already use. #1157 fixed the generated footer; these are older, and `tools/doc-chrome.py` never looks at them.

`doc.css`'s `@media print` block set `body { background: #fff }` and left the palette custom properties wherever the media query had put them. Browsers disagree on whether `prefers-color-scheme: dark` keeps matching while printing, and the ones that say yes put `--ink` at `#e6e6ee` on white paper, about 2.2:1, with `--ink-soft` and the `.wrap` panel no better. The block now redefines the tokens rather than recolouring rules one at a time, so the panel and anything added later that reads a token come along. The masthead's `filter: invert(1)` gets its own reset next to them: not a token, and it would otherwise print the black wordmark white.

Nothing here moves a pixel on screen, so the doc screenshots still match. Test 277 checks that every `target=` value under `html/` is one of the four keywords and that every token the dark block defines is back at its light value in the print block. Both halves die on a reintroduced misspelling and on a deleted or dark-valued token reset, including the two cases an audit caught silently passing: two tokens packed onto one line, and a token whose name the parser's charset missed. The scan asserts its own file count, its target count and the five pages that were wrong, since an empty candidate list would otherwise pass while proving nothing.

Closes #1164
Closes #1158
