### PR TITLE
Nothing runs black or flake8, so .flake8 binds nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -921,15 +921,21 @@ jobs:
       - name: shfmt
         run: shfmt -d -i 4 $SHELL_SCRIPTS
 
-      # .flake8's 88 columns is black's width; ls-files so a .py in a new
-      # directory cannot escape the way a hand-kept glob list would.
-      - name: black and flake8
+      # Read the list rather than hand-keeping one: a .py added in a new
+      # directory then gets checked without anyone widening a glob.
+      - name: List the tracked Python files
         run: |
           set -euo pipefail
-          mapfile -t PYTHON_FILES < <(git ls-files '*.py')
-          echo "${#PYTHON_FILES[@]} tracked Python files"
-          black --check --diff "${PYTHON_FILES[@]}"
-          flake8 "${PYTHON_FILES[@]}"
+          mapfile -t py < <(git ls-files '*.py')
+          test "${#py[@]}" -gt 0  # flake8 given no paths exits 0, checking nothing
+          echo "${#py[@]} tracked Python files"
+          echo "PYTHON_FILES=${py[*]}" >> "$GITHUB_ENV"
+
+      - name: black
+        run: black --check --diff $PYTHON_FILES
+
+      - name: flake8
+        run: flake8 $PYTHON_FILES
 
       # A misnamed test falls outside the glob "make check" runs, so it goes
       # missing without failing anything.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -878,6 +878,7 @@ jobs:
           fi
 
   lint:
+    # The name is a required status check on master; renaming it blocks every PR.
     name: lint (shellcheck, shfmt)
     runs-on: ubuntu-24.04
     # Every tracked shell script; the globs expand at run time. Kept here so the
@@ -906,14 +907,29 @@ jobs:
           # version; use it rather than fetching a release binary from github.com.
           sudo apt-get install -y --no-install-recommends shellcheck shfmt appstream \
             appstream-util
+          # Pinned to the local dev versions: black's stable style moves across
+          # majors, so the runner image's build would reformat on its own schedule.
+          pip install --quiet black==25.1.0 flake8==7.1.1
           shfmt --version
           appstreamcli --version
+          black --version
+          flake8 --version
 
       - name: shellcheck
         run: shellcheck $SHELL_SCRIPTS
 
       - name: shfmt
         run: shfmt -d -i 4 $SHELL_SCRIPTS
+
+      # .flake8's 88 columns is black's width; ls-files so a .py in a new
+      # directory cannot escape the way a hand-kept glob list would.
+      - name: black and flake8
+        run: |
+          set -euo pipefail
+          mapfile -t PYTHON_FILES < <(git ls-files '*.py')
+          echo "${#PYTHON_FILES[@]} tracked Python files"
+          black --check --diff "${PYTHON_FILES[@]}"
+          flake8 "${PYTHON_FILES[@]}"
 
       # A misnamed test falls outside the glob "make check" runs, so it goes
       # missing without failing anything.

--- a/tools/doc-chrome.py
+++ b/tools/doc-chrome.py
@@ -98,7 +98,8 @@ DESCRIPTIONS = {
     "library.html": "Linking against the libhttrack library.",
     "plug.html": "Plugging your own C functions into the HTTrack engine.",
     "plug_330.html": "The HTTrack callback API as it was in release 3.30 and earlier.",
-    "scripting.html": "Driving the httrack command-line program from shell and" " batch scripts.",
+    "scripting.html": "Driving the httrack command-line program from shell and"
+    " batch scripts.",
 }
 
 # Pinned by SOURCE_DATE_EPOCH when set, as man/makeman.sh does, so a test can ask
@@ -256,7 +257,9 @@ def chrome(page, content):
     return content, "\n".join(head), "\n".join(top), "\n".join(bottom)
 
 
-LEGACY = re.compile(r"<!--=*\s*End prologue\s*=*-->(.*?)<!--=*\s*Start epilogue\s*=*-->", re.S)
+LEGACY = re.compile(
+    r"<!--=*\s*End prologue\s*=*-->(.*?)<!--=*\s*Start epilogue\s*=*-->", re.S
+)
 
 
 def convert(path):
@@ -331,7 +334,9 @@ def rewrite(path, text):
     open_, close = MARK["top"]
     body = text.split(close, 1)[1].split(MARK["bottom"][0], 1)[0]
     content, head, top, bottom = chrome(page, body)
-    text = text.replace(close + body + MARK["bottom"][0], close + content + MARK["bottom"][0], 1)
+    text = text.replace(
+        close + body + MARK["bottom"][0], close + content + MARK["bottom"][0], 1
+    )
     text = region(text, "head", head)
     text = region(text, "top", top)
     return region(text, "bottom", bottom)
@@ -340,11 +345,15 @@ def rewrite(path, text):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--check", action="store_true", help="report drift, change nothing")
-    ap.add_argument("--convert", nargs="*", metavar="FILE", help="migrate legacy pages first")
+    ap.add_argument(
+        "--convert", nargs="*", metavar="FILE", help="migrate legacy pages first"
+    )
     args = ap.parse_args()
 
     for name in args.convert or []:
-        path = name if os.path.isabs(name) else os.path.join(HTML, os.path.basename(name))
+        path = (
+            name if os.path.isabs(name) else os.path.join(HTML, os.path.basename(name))
+        )
         text = convert(path)
         with open(path, "w", encoding="utf-8") as fp:
             fp.write(text)

--- a/tools/doc-images.py
+++ b/tools/doc-images.py
@@ -27,17 +27,41 @@ SCREENS = {
     "legacy-import": (None, None, "00_legacy_import_dialog"),
     "options-menu": (None, None, "04_options_menu"),
     # the eleven option tabs
-    "opt-scan-rules": ("05_options_scan_rules", "11_options_scan_rules", "05_options_scan_rules"),
+    "opt-scan-rules": (
+        "05_options_scan_rules",
+        "11_options_scan_rules",
+        "05_options_scan_rules",
+    ),
     "opt-limits": ("06_options_limits", "08_options_limits", "06_options_limits"),
-    "opt-flow-control": ("07_options_flow_control", "07_options_flow_control", "07_options_flow_control"),
+    "opt-flow-control": (
+        "07_options_flow_control",
+        "07_options_flow_control",
+        "07_options_flow_control",
+    ),
     "opt-links": ("08_options_links", "04_options_links", "08_options_links"),
     "opt-build": ("09_options_build", "05_options_build", "09_options_build"),
-    "opt-browser-id": ("12_options_browser_id", "10_options_browser_id", "10_options_browser_id"),
+    "opt-browser-id": (
+        "12_options_browser_id",
+        "10_options_browser_id",
+        "10_options_browser_id",
+    ),
     "opt-spider": ("10_options_spider", "12_options_spider", "11_options_spider"),
     "opt-proxy": ("04_options_proxy", "14_options_proxy", "12_options_proxy_address"),
-    "opt-log-index-cache": ("13_options_log_index_cache", "13_options_log_index_cache", "13_options_log_index_cache"),
-    "opt-mime-types": ("11_options_mime_types", "09_options_mime_types", "14_options_type_mime_associations"),
-    "opt-experts-only": ("14_options_experts_only", "06_options_experts_only", "15_options_experts_only"),
+    "opt-log-index-cache": (
+        "13_options_log_index_cache",
+        "13_options_log_index_cache",
+        "13_options_log_index_cache",
+    ),
+    "opt-mime-types": (
+        "11_options_mime_types",
+        "09_options_mime_types",
+        "14_options_type_mime_associations",
+    ),
+    "opt-experts-only": (
+        "14_options_experts_only",
+        "06_options_experts_only",
+        "15_options_experts_only",
+    ),
 }
 
 # (output dir, capture set, max width) — the Windows shots are already small
@@ -60,14 +84,18 @@ def convert(src, dst, max_width, fmt):
         # Median cut, not max coverage: the latter spreads the palette over the
         # colour cube whatever each entry costs in pixels, which greys out the
         # large flat backgrounds these shots are mostly made of.
-        im.convert("RGB").quantize(colors=256, dither=Image.Dither.NONE).save(dst, "PNG", optimize=True)
+        im.convert("RGB").quantize(colors=256, dither=Image.Dither.NONE).save(
+            dst, "PNG", optimize=True
+        )
     return im.size, os.path.getsize(dst)
 
 
 def main():
     fmt = sys.argv[1] if len(sys.argv) > 1 else "webp"
     works = os.path.expanduser("~/git/httrack-works")
-    out_root = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "html", "img")
+    out_root = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "..", "html", "img"
+    )
 
     total = 0
     for index, (platform, capture_set, max_width) in enumerate(PLATFORMS):
@@ -82,7 +110,10 @@ def main():
             dst = os.path.join(out_root, "guide-%s-%s.%s" % (platform, name, fmt))
             size, written = convert(src, dst, max_width, fmt)
             total += written
-            print("%-6s %-22s %4dx%-5d %6dK" % (platform, name, size[0], size[1], written // 1024))
+            print(
+                "%-6s %-22s %4dx%-5d %6dK"
+                % (platform, name, size[0], size[1], written // 1024)
+            )
     print("TOTAL %d K in %s" % (total // 1024, fmt))
 
 


### PR DESCRIPTION
`.flake8` caps lines at black's 88 columns, but nothing has ever enforced it: no workflow runs black, flake8 or any other Python linter. `tools/doc-images.py` and `tools/doc-chrome.py` drifted past it, 14 E501 between them with the longest line at 118, and they were the only two of the nineteen tracked files black would reformat.

The first commit is black's output on those two files, nothing by hand. The rest add `black` and `flake8` steps to the existing lint job, over `git ls-files '*.py'` instead of a hand-kept glob so a script added in a new directory still gets checked.

Both files feed the documentation surface, so I checked the reflow rather than assuming it. The two revisions of each script have byte-identical AST dumps and byte-identical bytecode, `doc-chrome.py --check` gives the same output before and after, and regenerating all 55 `html/img/guide-*.png` gives the same sha256 for every one. Each probe has a control that fires: a BICUBIC mutant moves 37 of the 55 hashes, and a mangled chrome region reds the check. Nothing under `html/img/` is committed.

Closes #1170
