### PR TITLE
freeport reserves the ICP port over TCP, not the UDP it will be bound in

### DIFF
--- a/src/proxy/proxytrack.c
+++ b/src/proxy/proxytrack.c
@@ -300,8 +300,7 @@ static int socket_last_error(void) {
 #endif
 }
 
-/* Text for socket_last_error(): winsock codes are outside strerror()'s table,
-   so read them from the system message table instead. */
+/* Winsock codes are not in strerror(); read the system message table. */
 static const char *socket_error_string(int err, char *buf, size_t size) {
 #ifdef _WIN32
   DWORD len =
@@ -321,9 +320,12 @@ static const char *socket_error_string(int err, char *buf, size_t size) {
   return buf;
 }
 
-/* On failure *lasterr carries the error, read before the close() that would
-   overwrite it. */
-static T_SOC smallserver_init(const char *adr, int port, int family,
+/* gethost() resolves through getaddrinfo(), which never sets errno. */
+#define SMALLSERVER_ERR_RESOLVE (-1)
+
+/* socktype is SOCK_STREAM or SOCK_DGRAM. On INVALID_SOCKET *lasterr carries the
+   error, read before the close() that would overwrite it. */
+static T_SOC smallserver_init(const char *adr, int port, int socktype,
                               int *lasterr) {
   SOCaddr server;
   SOCaddr_initany(server);
@@ -331,12 +333,11 @@ static T_SOC smallserver_init(const char *adr, int port, int family,
   if (gethost(adr, &server)) {     // host name
     T_SOC soc = INVALID_SOCKET;
 
-    if ((soc =
-         (T_SOC) socket(SOCaddr_sinfamily(server), family,
-                        0)) != INVALID_SOCKET) {
+    if ((soc = (T_SOC) socket(SOCaddr_sinfamily(server), socktype, 0)) !=
+        INVALID_SOCKET) {
       SOCaddr_initport(server, port);
       if (bind(soc, &SOCaddr_sockaddr(server), SOCaddr_size(server)) == 0) {
-        if (family != SOCK_STREAM || listen(soc, 10) >= 0) {
+        if (socktype != SOCK_STREAM || listen(soc, 10) >= 0) {
           return soc;
         } else {
           *lasterr = socket_last_error();
@@ -360,7 +361,7 @@ static T_SOC smallserver_init(const char *adr, int port, int family,
       *lasterr = socket_last_error();
     }
   } else {
-    *lasterr = socket_last_error();
+    *lasterr = SMALLSERVER_ERR_RESOLVE;
   }
   return INVALID_SOCKET;
 }
@@ -407,11 +408,17 @@ int proxytrack_main(char *proxyAddr, int proxyPort, char *icpAddr, int icpPort,
     const int err = icpFailed ? udpErr : tcpErr;
     char errbuf[192];
 
-    fprintf(stderr,
-            "Unable to initialize a temporary server : cannot bind %s port %d "
-            "on %s: %s (%d)\n",
-            icpFailed ? "udp" : "tcp", icpFailed ? icpPort : proxyPort,
-            proxyAddr, socket_error_string(err, errbuf, sizeof(errbuf)), err);
+    if (err == SMALLSERVER_ERR_RESOLVE) {
+      fprintf(stderr,
+              "Unable to initialize a temporary server : cannot resolve %s\n",
+              proxyAddr);
+    } else {
+      fprintf(stderr,
+              "Unable to initialize a temporary server : cannot bind %s port %d"
+              " on %s: %s (%d)\n",
+              icpFailed ? "udp" : "tcp", icpFailed ? icpPort : proxyPort,
+              proxyAddr, socket_error_string(err, errbuf, sizeof(errbuf)), err);
+    }
     returncode = 1;
   }
   printf("EXITED\n");

--- a/src/proxy/proxytrack.c
+++ b/src/proxy/proxytrack.c
@@ -291,9 +291,43 @@ static String getip(SOCaddr * server) {
   return s;
 }
 
-static T_SOC smallserver_init(const char *adr, int port, int family) {
+/* Winsock reports through WSAGetLastError() and leaves errno untouched. */
+static int socket_last_error(void) {
+#ifdef _WIN32
+  return WSAGetLastError();
+#else
+  return errno;
+#endif
+}
+
+/* Text for socket_last_error(): winsock codes are outside strerror()'s table,
+   so read them from the system message table instead. */
+static const char *socket_error_string(int err, char *buf, size_t size) {
+#ifdef _WIN32
+  DWORD len =
+      FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                     NULL, (DWORD) err, 0, buf, (DWORD) size, NULL);
+
+  /* the table punctuates its strings with a trailing ".\r\n" */
+  while (len != 0 && (unsigned char) buf[len - 1] <= ' ') {
+    buf[--len] = '\0';
+  }
+  if (len == 0) {
+    strclipbuff(buf, size, "unknown error");
+  }
+#else
+  strclipbuff(buf, size, strerror(err));
+#endif
+  return buf;
+}
+
+/* On failure *lasterr carries the error, read before the close() that would
+   overwrite it. */
+static T_SOC smallserver_init(const char *adr, int port, int family,
+                              int *lasterr) {
   SOCaddr server;
   SOCaddr_initany(server);
+  *lasterr = 0;
   if (gethost(adr, &server)) {     // host name
     T_SOC soc = INVALID_SOCKET;
 
@@ -305,6 +339,7 @@ static T_SOC smallserver_init(const char *adr, int port, int family) {
         if (family != SOCK_STREAM || listen(soc, 10) >= 0) {
           return soc;
         } else {
+          *lasterr = socket_last_error();
 #ifdef _WIN32
           closesocket(soc);
 #else
@@ -313,6 +348,7 @@ static T_SOC smallserver_init(const char *adr, int port, int family) {
           soc = INVALID_SOCKET;
         }
       } else {
+        *lasterr = socket_last_error();
 #ifdef _WIN32
         closesocket(soc);
 #else
@@ -320,7 +356,11 @@ static T_SOC smallserver_init(const char *adr, int port, int family) {
 #endif
         soc = INVALID_SOCKET;
       }
+    } else {
+      *lasterr = socket_last_error();
     }
+  } else {
+    *lasterr = socket_last_error();
   }
   return INVALID_SOCKET;
 }
@@ -329,8 +369,9 @@ static int proxytrack_start(PT_Indexes indexes, T_SOC soc, T_SOC socICP);
 int proxytrack_main(char *proxyAddr, int proxyPort, char *icpAddr, int icpPort,
                     PT_Indexes index) {
   int returncode = 0;
-  T_SOC soc = smallserver_init(proxyAddr, proxyPort, SOCK_STREAM);
-  T_SOC socICP = smallserver_init(proxyAddr, icpPort, SOCK_DGRAM);
+  int tcpErr = 0, udpErr = 0;
+  T_SOC soc = smallserver_init(proxyAddr, proxyPort, SOCK_STREAM, &tcpErr);
+  T_SOC socICP = smallserver_init(proxyAddr, icpPort, SOCK_DGRAM, &udpErr);
 
   if (soc != INVALID_SOCKET && socICP != INVALID_SOCKET) {
 
@@ -362,10 +403,15 @@ int proxytrack_main(char *proxyAddr, int proxyPort, char *icpAddr, int icpPort,
       returncode = 0;
     }
   } else {
-    int last_errno = errno;
+    const hts_boolean icpFailed = (soc != INVALID_SOCKET);
+    const int err = icpFailed ? udpErr : tcpErr;
+    char errbuf[192];
 
-    fprintf(stderr, "Unable to initialize a temporary server : %s\n",
-            strerror(last_errno));
+    fprintf(stderr,
+            "Unable to initialize a temporary server : cannot bind %s port %d "
+            "on %s: %s (%d)\n",
+            icpFailed ? "udp" : "tcp", icpFailed ? icpPort : proxyPort,
+            proxyAddr, socket_error_string(err, errbuf, sizeof(errbuf)), err);
     returncode = 1;
   }
   printf("EXITED\n");

--- a/tests/223_webhttrack-session-id.test
+++ b/tests/223_webhttrack-session-id.test
@@ -31,7 +31,7 @@ for _ in $(seq 1 10); do
     mkdir -p "${work}/a" "${work}/b"
     # Both ports up front: a python fork apiece inside the window below is most
     # of it, and picking them together is what keeps the two apart.
-    read -r porta portb <<<"$(htsserver_freeport 2)"
+    read -r porta portb <<<"$(htsserver_freeport tcp tcp)"
     prev=$(date +%s)
     while test "$(date +%s)" = "${prev}"; do
         sleep 0.02

--- a/tests/276_testlib-freeport.test
+++ b/tests/276_testlib-freeport.test
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# freeport must reserve each port in the protocol its caller will bind: a
+# tcp-probed number can sit inside a Windows udp exclusion, and every retry
+# then loses the same way (#1178).
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+real_python=$(find_python) || skip "python3 missing"
+python=$real_python # freeport reads it from here
+
+tmpdir=$(mktemp -d)
+cleanup_push rm -rf "$tmpdir"
+typelog="$tmpdir/socktypes"
+
+bindable() { # bindable PROTO PORT
+    "$real_python" -c 'import socket, sys
+kinds = {"tcp": socket.SOCK_STREAM, "udp": socket.SOCK_DGRAM}
+s = socket.socket(socket.AF_INET, kinds[sys.argv[1]])
+s.bind(("127.0.0.1", int(sys.argv[2])))
+s.close()' "$1" "$2"
+}
+
+# Off Windows a tcp-probed number binds as udp just as well, so the port alone
+# cannot say which protocol reserved it: wrap the probe and record what it opened.
+spy_python() { # spy_python -c SCRIPT [PROTO...]
+    local script=$2
+    test "$1" = "-c" || fail "freeport no longer runs python with -c: $1"
+    shift 2
+    "$real_python" -c 'import socket, sys
+log, code = sys.argv[1], sys.argv[2]
+real = socket.socket
+
+
+def spy(family=socket.AF_INET, type=socket.SOCK_STREAM, *a, **kw):
+    with open(log, "a") as f:
+        f.write(socket.SocketKind(type).name + "\n")
+    return real(family, type, *a, **kw)
+
+
+socket.socket = spy
+sys.argv = sys.argv[2:]
+exec(code)' "$typelog" "$script" ${1+"$@"}
+}
+
+spied() { # spied [PROTO...]: echoes the ports, leaves the types in $typelog
+    : >"$typelog"
+    (
+        python=spy_python
+        freeport ${1+"$@"}
+    )
+}
+
+kinds() { sort -u "$typelog" | tr '\n' ','; }
+
+## a port nothing holds is bindable, one already bound is not
+port=$(freeport) || fail "default freeport failed"
+assert_match '^[0-9]+$' "$port" "default freeport"
+bindable tcp "$port" || fail "the default port $port does not bind as tcp"
+
+"$real_python" -c 'import socket, sys, time
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.bind(("127.0.0.1", 0))
+print("PORT %d" % s.getsockname()[1])
+sys.stdout.flush()
+time.sleep(60)' >"$tmpdir/holder.log" 2>&1 &
+holder=$!
+cleanup_push stop_server "$holder"
+held=$(discover_server_port "$tmpdir/holder.log" "$holder") || fail "no udp holder"
+# Control: a bindable that cannot fail proves nothing about the ports above.
+! bindable udp "$held" 2>/dev/null || fail "bindable udp accepted $held, already bound"
+
+## each protocol is probed in its own
+port=$(spied tcp) || fail "freeport tcp failed"
+bindable tcp "$port" || fail "the tcp port $port does not bind as tcp"
+assert_eq "SOCK_STREAM," "$(kinds)" "socket types freeport tcp opened"
+
+port=$(spied udp) || fail "freeport udp failed"
+bindable udp "$port" || fail "the udp port $port does not bind as udp"
+assert_eq "SOCK_DGRAM," "$(kinds)" "socket types freeport udp opened"
+
+## a mixed pair, the shape start_proxytrack asks for
+read -r tcpport udpport <<<"$(spied tcp udp)"
+assert_eq "SOCK_DGRAM,SOCK_STREAM," "$(kinds)" "socket types freeport tcp udp opened"
+test "$tcpport" != "$udpport" || fail "both ports came back as $tcpport"
+bindable tcp "$tcpport" || fail "the tcp port $tcpport does not bind as tcp"
+bindable udp "$udpport" || fail "the udp port $udpport does not bind as udp"
+
+## a typo must not read as a port
+rc=0
+out=$(freeport sctp 2>&1) || rc=$?
+test "$rc" -ne 0 || fail "freeport accepted an unknown protocol: $out"
+assert_match 'unknown protocol sctp' "$out" "freeport sctp"
+
+echo "OK: freeport reserves tcp and udp ports in their own protocol"

--- a/tests/276_testlib-freeport.test
+++ b/tests/276_testlib-freeport.test
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# freeport must reserve each port in the protocol its caller will bind: a
-# tcp-probed number can sit inside a Windows udp exclusion, and every retry
-# then loses the same way (#1178).
+# freeport must reserve each port in the protocol its caller will bind (#1178),
+# and proxytrack must name which of its two sockets lost, in words the harness's
+# own PT_BIND_LOST regex still reads.
 
 set -euo pipefail
 
@@ -12,9 +12,11 @@ set -euo pipefail
 real_python=$(find_python) || skip "python3 missing"
 python=$real_python # freeport reads it from here
 
-tmpdir=$(mktemp -d)
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_freeport.XXXXXX")
 cleanup_push rm -rf "$tmpdir"
 typelog="$tmpdir/socktypes"
+
+ok() { echo "OK: $*"; }
 
 bindable() { # bindable PROTO PORT
     "$real_python" -c 'import socket, sys
@@ -24,8 +26,24 @@ s.bind(("127.0.0.1", int(sys.argv[2])))
 s.close()' "$1" "$2"
 }
 
+# A port held for the rest of the test, so a bind of it must lose.
+hold_port() { # hold_port PROTO
+    local log="$tmpdir/hold-$1.log" pid
+    "$real_python" -c 'import socket, sys, time
+kinds = {"tcp": socket.SOCK_STREAM, "udp": socket.SOCK_DGRAM}
+s = socket.socket(socket.AF_INET, kinds[sys.argv[1]])
+s.bind(("127.0.0.1", 0))
+print("PORT %d" % s.getsockname()[1])
+sys.stdout.flush()
+time.sleep(120)' "$1" >"$log" 2>&1 &
+    pid=$!
+    cleanup_push stop_server "$pid"
+    discover_server_port "$log" "$pid" || fail "the $1 holder never announced a port"
+}
+
 # Off Windows a tcp-probed number binds as udp just as well, so the port alone
-# cannot say which protocol reserved it: wrap the probe and record what it opened.
+# cannot say which protocol reserved it. Log "KIND PORT" per bind instead, which
+# pins the number handed back to the socket it came from.
 spy_python() { # spy_python -c SCRIPT [PROTO...]
     local script=$2
     test "$1" = "-c" || fail "freeport no longer runs python with -c: $1"
@@ -35,18 +53,41 @@ log, code = sys.argv[1], sys.argv[2]
 real = socket.socket
 
 
-def spy(family=socket.AF_INET, type=socket.SOCK_STREAM, *a, **kw):
-    with open(log, "a") as f:
-        f.write(socket.SocketKind(type).name + "\n")
-    return real(family, type, *a, **kw)
+class Spy(real):
+    def bind(self, addr):
+        real.bind(self, addr)
+        with open(log, "a") as f:
+            f.write("%s %d\n" % (socket.SocketKind(self.type).name,
+                                 self.getsockname()[1]))
 
 
-socket.socket = spy
+socket.socket = Spy
 sys.argv = sys.argv[2:]
 exec(code)' "$typelog" "$script" ${1+"$@"}
 }
 
-spied() { # spied [PROTO...]: echoes the ports, leaves the types in $typelog
+# Every socket reports one port, so the redraw freeport does on a collision runs
+# out of tries: that branch is unreachable against a real kernel.
+collide_python() { # collide_python -c SCRIPT [PROTO...]
+    local script=$2
+    test "$1" = "-c" || fail "freeport no longer runs python with -c: $1"
+    shift 2
+    "$real_python" -c 'import socket, sys
+code = sys.argv[1]
+real = socket.socket
+
+
+class Collide(real):
+    def getsockname(self):
+        return ("127.0.0.1", 65000)
+
+
+socket.socket = Collide
+sys.argv = sys.argv[1:]
+exec(code)' "$script" ${1+"$@"}
+}
+
+spied() { # spied [PROTO...]: echoes the ports, leaves "KIND PORT" in $typelog
     : >"$typelog"
     (
         python=spy_python
@@ -54,45 +95,101 @@ spied() { # spied [PROTO...]: echoes the ports, leaves the types in $typelog
     )
 }
 
-kinds() { sort -u "$typelog" | tr '\n' ','; }
+drew() { # drew KIND PORT
+    grep -Fxq "$1 $2" "$typelog"
+}
 
 ## a port nothing holds is bindable, one already bound is not
 port=$(freeport) || fail "default freeport failed"
 assert_match '^[0-9]+$' "$port" "default freeport"
 bindable tcp "$port" || fail "the default port $port does not bind as tcp"
 
-"$real_python" -c 'import socket, sys, time
-s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-s.bind(("127.0.0.1", 0))
-print("PORT %d" % s.getsockname()[1])
-sys.stdout.flush()
-time.sleep(60)' >"$tmpdir/holder.log" 2>&1 &
-holder=$!
-cleanup_push stop_server "$holder"
-held=$(discover_server_port "$tmpdir/holder.log" "$holder") || fail "no udp holder"
+udpheld=$(hold_port udp)
+tcpheld=$(hold_port tcp)
 # Control: a bindable that cannot fail proves nothing about the ports above.
-! bindable udp "$held" 2>/dev/null || fail "bindable udp accepted $held, already bound"
+! bindable udp "$udpheld" 2>/dev/null || fail "bindable udp took $udpheld, held"
+! bindable tcp "$tcpheld" 2>/dev/null || fail "bindable tcp took $tcpheld, held"
+ok "an unheld port binds and a held one does not"
 
-## each protocol is probed in its own
+## the port handed back is the one drawn on a socket of that protocol
 port=$(spied tcp) || fail "freeport tcp failed"
 bindable tcp "$port" || fail "the tcp port $port does not bind as tcp"
-assert_eq "SOCK_STREAM," "$(kinds)" "socket types freeport tcp opened"
+drew SOCK_STREAM "$port" || fail "freeport tcp drew $port elsewhere: $(cat "$typelog")"
+! grep -q SOCK_DGRAM "$typelog" || fail "freeport tcp opened a udp socket"
 
 port=$(spied udp) || fail "freeport udp failed"
 bindable udp "$port" || fail "the udp port $port does not bind as udp"
-assert_eq "SOCK_DGRAM," "$(kinds)" "socket types freeport udp opened"
+drew SOCK_DGRAM "$port" || fail "freeport udp drew $port elsewhere: $(cat "$typelog")"
+! grep -q SOCK_STREAM "$typelog" || fail "freeport udp opened a tcp socket"
+ok "each protocol is probed in its own"
 
-## a mixed pair, the shape start_proxytrack asks for
+## a mixed pair, the shape start_proxytrack asks for, in that order
 read -r tcpport udpport <<<"$(spied tcp udp)"
-assert_eq "SOCK_DGRAM,SOCK_STREAM," "$(kinds)" "socket types freeport tcp udp opened"
-test "$tcpport" != "$udpport" || fail "both ports came back as $tcpport"
+drew SOCK_STREAM "$tcpport" || fail "the first port is not the tcp one: $(cat "$typelog")"
+drew SOCK_DGRAM "$udpport" || fail "the second port is not the udp one: $(cat "$typelog")"
 bindable tcp "$tcpport" || fail "the tcp port $tcpport does not bind as tcp"
 bindable udp "$udpport" || fail "the udp port $udpport does not bind as udp"
+ok "a tcp/udp pair comes back in the order start_proxytrack reads"
+
+## ports must differ, and a probe that cannot deliver that says so
+rc=0
+out=$(
+    python=collide_python
+    freeport tcp udp 2>&1
+) || rc=$?
+test "$rc" -ne 0 || fail "freeport handed back a duplicated pair: $out"
+assert_match 'no distinct' "$out" "freeport under a colliding probe"
 
 ## a typo must not read as a port
 rc=0
 out=$(freeport sctp 2>&1) || rc=$?
 test "$rc" -ne 0 || fail "freeport accepted an unknown protocol: $out"
 assert_match 'unknown protocol sctp' "$out" "freeport sctp"
+ok "a pair that cannot be made distinct, and a bad protocol, both fail loudly"
 
-echo "OK: freeport reserves tcp and udp ports in their own protocol"
+## proxytrack says which socket lost, and why
+command -v proxytrack >/dev/null || skip "no proxytrack in PATH"
+
+# The whole line, so a message left with the table's trailing CRLF fails the
+# anchors below.
+proxytrack_fails() { # proxytrack_fails HTTP_ADDR ICP_ADDR: echoes its error line
+    local log="$tmpdir/pt.log" rc=0
+    run_with_timeout 20 proxytrack "$1" "$2" >"$log" 2>&1 || rc=$?
+    test "$rc" -ne 124 || fail "proxytrack never exited on $1 $2: $(cat "$log")"
+    test "$rc" -ne 0 || fail "proxytrack started on $1 $2: $(cat "$log")"
+    grep '^Unable to initialize a temporary server' "$log" ||
+        fail "proxytrack failed without the harness's banner: $(cat "$log")"
+}
+
+# Both destinations, or the message could name one protocol for either failure.
+# The surviving socket's port is drawn late: a neighbour test stealing it would
+# report the wrong protocol.
+out=$(proxytrack_fails "127.0.0.1:$tcpheld" "127.0.0.1:$(freeport udp)")
+assert_match "$PT_BIND_LOST" "$out" "the harness reads proxytrack's http bind loss"
+assert_match "^.*cannot bind tcp port $tcpheld on 127\.0\.0\.1: .+ \([1-9][0-9]*\)\$" "$out"
+
+out=$(proxytrack_fails "127.0.0.1:$(freeport tcp)" "127.0.0.1:$udpheld")
+assert_match "$PT_BIND_LOST" "$out" "the harness reads proxytrack's icp bind loss"
+assert_match "^.*cannot bind udp port $udpheld on 127\.0\.0\.1: .+ \([1-9][0-9]*\)\$" "$out"
+
+# The cause is the whole point: winsock leaves errno at "No error" (#1178).
+case $out in
+*"No error"* | *": Success "* | *"unknown error"*) fail "no cause named: $out" ;;
+esac
+ok "proxytrack names the protocol, the port and the cause of a lost bind"
+
+## a name that does not resolve is not a bind failure
+badhost=no-such-host-1178.invalid
+if "$real_python" -c 'import socket, sys
+try:
+    socket.getaddrinfo(sys.argv[1], 80)
+except OSError:
+    sys.exit(0)
+sys.exit(1)' "$badhost"; then
+    out=$(proxytrack_fails "$badhost:1" "$badhost:2")
+    assert_match "$PT_BIND_LOST" "$out" "the harness reads proxytrack's resolver loss"
+    assert_match "cannot resolve $badhost" "$out"
+    ok "a resolver failure is reported as one, not as a bind error"
+else
+    echo "WARNING: $badhost resolves here, the resolver leg did not run" >&2
+fi

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -287,17 +287,36 @@ stop_server() {
     return 0
 }
 
-# $1 free loopback ports (default 1), space separated, bound together so two of
-# them always differ. Each is closed before its caller binds it: see start_proxytrack.
-freeport() {
+# Free loopback ports, one per protocol in $@ (tcp/udp, default a single tcp),
+# space separated and all distinct, each closed before its caller binds it: see
+# start_proxytrack. Probed in the protocol the caller binds, since free in tcp
+# says nothing about udp and Windows excludes port ranges per protocol (#1178).
+freeport() { # freeport [PROTO...]
+    local out
+    # Captured, not piped into tr, which would swallow a failed probe's status.
+    out=$("${python:?freeport needs the caller python}" -c 'import socket, sys
+kinds = {"tcp": socket.SOCK_STREAM, "udp": socket.SOCK_DGRAM}
+held, ports = [], []
+for proto in sys.argv[1:] or ["tcp"]:
+    if proto not in kinds:
+        sys.exit("freeport: unknown protocol " + proto)
+    for _ in range(10):
+        s = socket.socket(socket.AF_INET, kinds[proto])
+        s.bind(("127.0.0.1", 0))
+        held.append(s)
+        port = s.getsockname()[1]
+        # tcp and udp draw from separate spaces, so the same number can come
+        # back twice: hold that one too and draw again.
+        if port not in ports:
+            break
+    else:
+        sys.exit("freeport: no distinct " + proto + " port")
+    ports.append(port)
+print(" ".join(str(p) for p in ports))
+for s in held:
+    s.close()' "$@") || return 1
     # tr: Windows python's print leaves a CR that $() does not strip.
-    "${python:?freeport needs the caller python}" -c 'import socket, sys
-socks = [socket.socket() for _ in range(int(sys.argv[1]))]
-for s in socks:
-    s.bind(("127.0.0.1", 0))
-print(" ".join(str(s.getsockname()[1]) for s in socks))
-for s in socks:
-    s.close()' "${1:-1}" | tr -d '\r'
+    printf '%s\n' "$out" | tr -d '\r'
 }
 
 PT_LISTENING="HTTP Proxy installed on"
@@ -325,7 +344,7 @@ proxytrack_bound() { # proxytrack_bound LOG PID
 start_proxytrack() { # start_proxytrack LOGBASE LAUNCH
     local base=$1 launch=$2 try
     for try in 1 2 3; do
-        read -r proxyport icpport <<<"$(freeport 2)"
+        read -r proxyport icpport <<<"$(freeport tcp udp)"
         # One log per attempt: a killed one's pty drainer creates its .done
         # marker by path, and would answer for the attempt below.
         ptlog="$base.$try"


### PR DESCRIPTION
`79_local-proxytrack-webdav-mime` went red on a Win32 leg with "proxytrack bound none of 3 port pairs" while master passed the same test in the same hour. The harness reserves both proxytrack ports with `freeport`, which binds a plain `socket.socket()`, so TCP, but proxytrack opens its ICP socket with `SOCK_DGRAM`. A number free in TCP says nothing about the same number in UDP, and Windows keeps excluded port ranges per protocol, so a TCP-derived number can sit inside a UDP reservation and every retry then loses the same way. Hence a clean sweep rather than one unlucky attempt.

`freeport` now takes the protocol of each port it hands out (`freeport tcp udp`) and probes in that one. It also propagates the probe's exit status instead of letting the `tr` pipeline swallow it. Its three callers move with it.

Folded in: proxytrack printed "Unable to initialize a temporary server : No error", passing `strerror(errno)` for a socket error Winsock reports through `WSAGetLastError()`, and reading errno after both binds and a `close()` had run. It now captures the error at the call that failed and prints it with the protocol, the port and the system message. A host that does not resolve is reported as that, not as a bind failure carrying whatever errno held, since `getaddrinfo()` never sets it.

Test 276 checks that a reserved port binds in its own protocol. Off Windows a TCP-probed number binds as UDP just as well, so the port alone cannot see the bug; the test wraps the probe and records the port beside the socket type it came from, which a mutant mapping `udp` to `SOCK_STREAM` fails, as does one that opens a UDP socket and returns a TCP-drawn number. The Winsock message path is not exercised from Linux, only compiled by the Win32 leg.

Closes #1178