### PR TITLE
The guide tells Windows users to put one host-alias rule per line, in a single-line box

### DIFF
--- a/html/guide.html
+++ b/html/guide.html
@@ -720,6 +720,8 @@ bottom are the ones that keep you welcome.</p>
 	travel under the same rules and each page is saved once instead of once per name. Either side may
 	carry a scheme, as in <code>legacy.example.com=https://example.com</code>. A trailing slash is
 	ignored, but a path is refused: this maps hosts, not addresses.</p>
+	<p data-for="win">The box is a single line and holds one rule: the commas add aliases to it,
+	and another mapping needs its own <code>--host-alias</code> on the command line.</p>
 </div>
 </section>
 

--- a/html/guide.html
+++ b/html/guide.html
@@ -720,8 +720,9 @@ bottom are the ones that keep you welcome.</p>
 	travel under the same rules and each page is saved once instead of once per name. Either side may
 	carry a scheme, as in <code>legacy.example.com=https://example.com</code>. A trailing slash is
 	ignored, but a path is refused: this maps hosts, not addresses.</p>
-	<p data-for="win">The box is a single line and holds one rule: the commas add aliases to it,
-	and another mapping needs its own <code>--host-alias</code> on the command line.</p>
+	<p data-for="win">The box is a single line, so it holds one rule: the commas add aliases to
+	that rule, and a second mapping needs another <code>--host-alias</code> on the command
+	line.</p>
 </div>
 </section>
 


### PR DESCRIPTION
WinHTTrack draws Host aliases as a single-line edit box, while the guide entry, scoped `win web droid` since #1175, tells every reader the field takes one rule per line. `hts_host_alias_match` splits rules on `\n`, and the commas in `www2.example.com,m.example.com=example.com` add aliases inside one rule, so a second mapping is out of reach from the Windows GUI.

This documents the limit instead of fixing it. The better fix is a multi-line control in httrack-windows, which would make the caveat deletable rather than load-bearing. It sits beside the `data-for="web"` caveat #1176 put on Strip query keys and copies its shape. No test: prose only, and `tools/doc-chrome.py --check` plus 239's anchor check already cover what is mechanical on the page.

Closes #1188
