### PR TITLE
A --host-alias rule may carry bytes no host can, and no front end can call the validator

### DIFF
--- a/src/htscore.h
+++ b/src/htscore.h
@@ -431,8 +431,6 @@ const char *hts_host_alias_fold(httrackp *opt, lien_adrfil *af);
 hts_boolean hts_host_same_alias(const char *rules, const char *adra,
                                 const char *adrb, hts_boolean collapse_www);
 
-/* hts_host_alias_rule_ok() is exported; see httrack-library.h */
-
 /* First canonical host in RULES whose chain never ends ("a=b" plus "b=a"),
    copied into DEST, or NULL if every chain settles. Those hosts are left
    unaliased, so the engine reports them rather than picking a hop. */

--- a/src/htscore.h
+++ b/src/htscore.h
@@ -431,9 +431,7 @@ const char *hts_host_alias_fold(httrackp *opt, lien_adrfil *af);
 hts_boolean hts_host_same_alias(const char *rules, const char *adra,
                                 const char *adrb, hts_boolean collapse_www);
 
-/* HTS_TRUE if RULE is a well-formed "[scheme://]alias[,...]=[scheme://]host"
-   line: one literal host after the '=', and no path on either side. */
-hts_boolean hts_host_alias_rule_ok(const char *rule);
+/* hts_host_alias_rule_ok() is exported; see httrack-library.h */
 
 /* First canonical host in RULES whose chain never ends ("a=b" plus "b=a"),
    copied into DEST, or NULL if every chain settles. Those hosts are left

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -3966,9 +3966,9 @@ static hts_boolean hts_host_alias_token_ok(const char *token, size_t len,
   buff[len] = '\0';
   while (len > 0 && buff[len - 1] == '/')
     buff[--len] = '\0'; /* the matcher strips the whole run */
-  /* the scheme may itself be a glob on the alias side, so cut on "://" */
-  host = strstr(buff, "://") != NULL ? strstr(buff, "://") + 3
-                                     : jump_protocol_const(buff);
+  /* an alias may glob its scheme; an unknown canonical one lands in the host */
+  host = glob && strstr(buff, "://") != NULL ? strstr(buff, "://") + 3
+                                             : jump_protocol_const(buff);
   /* a scheme with no host behind it, and the engine's own pseudo-host, name
      nothing the fold could write into an address */
   if (*host == '\0' || strcmp(host, "primary") == 0)
@@ -3976,8 +3976,14 @@ static hts_boolean hts_host_alias_token_ok(const char *token, size_t len,
   /* --host-alias maps hosts: a path belongs to no part of an address */
   if (strchr(host, '/') != NULL)
     return HTS_FALSE;
-  return strpbrk(host, glob ? "=# \t" : "=,*?();\\#@ \t") == NULL ? HTS_TRUE
-                                                                  : HTS_FALSE;
+  /* a control byte names no host, and '\n' would split the store's rule list */
+  for (; *host != '\0'; host++) {
+    if ((unsigned char) *host < ' ' || *host == '\x7f')
+      return HTS_FALSE;
+    if (strchr(glob ? "=# " : "=,*?();\\#@ ", *host) != NULL)
+      return HTS_FALSE;
+  }
+  return HTS_TRUE;
 }
 
 /* see httrack-library.h */
@@ -3985,9 +3991,6 @@ HTSEXT_API hts_boolean hts_host_alias_rule_ok(const char *rule) {
   const char *const eq = rule != NULL ? strchr(rule, '=') : NULL;
   const char *pat;
 
-  /* the store separates rules with '\n', so a rule carrying one is not one */
-  if (rule != NULL && strchr(rule, '\n') != NULL)
-    return HTS_FALSE;
   if (eq == NULL || eq == rule || eq[1] == '\0')
     return HTS_FALSE;
   if (!hts_host_alias_token_ok(eq + 1, strlen(eq + 1), HTS_FALSE))

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -3980,11 +3980,14 @@ static hts_boolean hts_host_alias_token_ok(const char *token, size_t len,
                                                                   : HTS_FALSE;
 }
 
-/* see htscore.h */
-hts_boolean hts_host_alias_rule_ok(const char *rule) {
+/* see httrack-library.h */
+HTSEXT_API hts_boolean hts_host_alias_rule_ok(const char *rule) {
   const char *const eq = rule != NULL ? strchr(rule, '=') : NULL;
   const char *pat;
 
+  /* the store separates rules with '\n', so a rule carrying one is not one */
+  if (rule != NULL && strchr(rule, '\n') != NULL)
+    return HTS_FALSE;
   if (eq == NULL || eq == rule || eq[1] == '\0')
     return HTS_FALSE;
   if (!hts_host_alias_token_ok(eq + 1, strlen(eq + 1), HTS_FALSE))

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3717,6 +3717,13 @@ static int st_hostalias(httrackp *opt, int argc, char **argv) {
   assertf(!hts_host_alias_rule_ok("https://www.foo.com/a=ftp://ftp.foo.com"));
   assertf(!hts_host_alias_rule_ok("a.com,b.com/deep=c.com"));
   assertf(!hts_host_alias_rule_ok("b.com=http://a.com/x"));
+  /* the store joins rules with '\n', so one rule may not carry one: the matcher
+     would take the fragment past it for a second, '='-less rule and drop it */
+  assertf(!hts_host_alias_rule_ok("b.com=a.com\nc.com"));
+  assertf(!hts_host_alias_rule_ok("b.com\nc.com=a.com"));
+  assertf(!hts_host_alias_rule_ok("b.com=a.com\nc.com=d.com"));
+  assertf(!hts_host_alias_rule_ok("b.com=a.com\n"));
+  assertf(!hts_host_alias_rule_ok("\nb.com=a.com"));
 
   /* the same-address test the wizard uses to decide scope */
   assertf(hts_host_same_alias(rules, "b.com", "a.com", HTS_TRUE));

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3717,13 +3717,20 @@ static int st_hostalias(httrackp *opt, int argc, char **argv) {
   assertf(!hts_host_alias_rule_ok("https://www.foo.com/a=ftp://ftp.foo.com"));
   assertf(!hts_host_alias_rule_ok("a.com,b.com/deep=c.com"));
   assertf(!hts_host_alias_rule_ok("b.com=http://a.com/x"));
-  /* the store joins rules with '\n', so one rule may not carry one: the matcher
-     would take the fragment past it for a second, '='-less rule and drop it */
+  /* a control byte, or a scheme the fold cannot parse, lands in the host */
   assertf(!hts_host_alias_rule_ok("b.com=a.com\nc.com"));
   assertf(!hts_host_alias_rule_ok("b.com\nc.com=a.com"));
-  assertf(!hts_host_alias_rule_ok("b.com=a.com\nc.com=d.com"));
   assertf(!hts_host_alias_rule_ok("b.com=a.com\n"));
   assertf(!hts_host_alias_rule_ok("\nb.com=a.com"));
+  assertf(!hts_host_alias_rule_ok("b.com=a.com\r"));
+  assertf(!hts_host_alias_rule_ok("b.com=a.com\v"));
+  assertf(!hts_host_alias_rule_ok("b.com=a.com\f"));
+  assertf(!hts_host_alias_rule_ok("b.com=a\x7f.com"));
+  assertf(!hts_host_alias_rule_ok("b\v.com=a.com"));
+  assertf(!hts_host_alias_rule_ok("b.com=x://a.com"));
+  assertf(!hts_host_alias_rule_ok("b.com=a.com://c.com"));
+  assertf(hts_host_alias_rule_ok("b.com=ftp://a.com"));
+  assertf(hts_host_alias_rule_ok("*://b.com=a.com"));
 
   /* the same-address test the wizard uses to decide scope */
   assertf(hts_host_same_alias(rules, "b.com", "a.com", HTS_TRUE));

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -354,6 +354,13 @@ HTSEXT_API hts_boolean hts_resetaddurl(httrackp *opt);
    to is left untouched. The user-agent string is deep-copied. @return 0. */
 HTSEXT_API int copy_htsopt(const httrackp *from, httrackp *to);
 
+/** Whether @p rule is one well-formed "[scheme://]alias[,...]=[scheme://]host",
+    so a front end can refuse it while the user can still edit it. Only the
+   alias side may glob; neither side may carry a path or a control byte, and the
+    canonical scheme must be one the engine speaks. @return HTS_TRUE if valid.
+ */
+HTSEXT_API hts_boolean hts_host_alias_rule_ok(const char *rule);
+
 /** Return the engine's last error message, or NULL. The string is owned by
     @p opt; do not free it, and use it only while @p opt lives. */
 HTSEXT_API char *hts_errmsg(httrackp *opt);
@@ -384,14 +391,6 @@ HTSEXT_API void hts_cancel_parsing(httrackp *opt);
 /** Nonzero once the mirror has fully ended. Read under the engine state lock,
    so safe to poll from another thread. Wait for this before hts_free_opt(). */
 HTSEXT_API hts_boolean hts_has_stopped(httrackp *opt);
-
-/** Whether @p rule is one well-formed --host-alias rule,
-    "[scheme://]alias[,alias...]=[scheme://]host": filter metacharacters are
-    legal on the alias side only, no path on either side, and no '\\n', which
-    the engine uses to join the rules it accepted. For a front end offering the
-    option, to reject a rule while the user can still fix it.
-    @return HTS_TRUE if the engine would accept it. */
-HTSEXT_API hts_boolean hts_host_alias_rule_ok(const char *rule);
 
 /* Tools */
 /** Ensure the directory chain leading to @p path exists, creating missing

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -385,6 +385,14 @@ HTSEXT_API void hts_cancel_parsing(httrackp *opt);
    so safe to poll from another thread. Wait for this before hts_free_opt(). */
 HTSEXT_API hts_boolean hts_has_stopped(httrackp *opt);
 
+/** Whether @p rule is one well-formed --host-alias rule,
+    "[scheme://]alias[,alias...]=[scheme://]host": filter metacharacters are
+    legal on the alias side only, no path on either side, and no '\\n', which
+    the engine uses to join the rules it accepted. For a front end offering the
+    option, to reject a rule while the user can still fix it.
+    @return HTS_TRUE if the engine would accept it. */
+HTSEXT_API hts_boolean hts_host_alias_rule_ok(const char *rule);
+
 /* Tools */
 /** Ensure the directory chain leading to @p path exists, creating missing
     directories. @p path ends either with '/' (a directory) or a filename (its

--- a/tests/275_local-dash-rule.test
+++ b/tests/275_local-dash-rule.test
@@ -79,6 +79,17 @@ refused 'Rejected: -nope' "malformed --host-alias"
 ! grep -q '%C' <<<"$out" || fail "the host-alias error still names -%C: $out"
 echo OK
 
+# Both would land in the host verbatim. '\v' and not '\n': the argv filter
+# rewrites only CR, LF and TAB.
+printf '[a rule the fold could not use is refused] ..\t'
+parse --host-alias 'b.com=x://a.com'
+refused 'Rejected: b.com=x://a.com' "unknown canonical scheme"
+parse --host-alias "$(printf 'b.com=a.com\v')"
+refused 'Rejected: b.com=a.com' "control byte in the canonical"
+parse --host-alias 'b.com=ftp://a.com'
+accepted "--host-alias b.com=ftp://a.com"
+echo OK
+
 # Every other option keeps the guess it has always made: relaxing it wholesale
 # would turn `-O -q url` into a silent mirror into a directory named -q.
 printf '[an option genuinely missing its parameter still errors] ..\t'


### PR DESCRIPTION
`hts_host_alias_rule_ok()` moves to `httrack-library.h` behind `HTSEXT_API` (#1172), so WinHTTrack (httrack-windows#101) can stop mirroring the grammar in its own field and drifting from it. That makes the function's reject set a supported contract, so the holes in it are fixed in the same change.

A rule may no longer carry a control byte, and the canonical side must name a scheme the engine speaks. The engine joins the rules it accepts with `'\n'`, so a rule holding one is not one rule (#1192), and `\v` and `\f` reach the host outright, since htscoremain.c:292 rewrites only CR, LF and TAB in argv. The scheme was worse: the validator cut on a literal `"://"` where every consumer cuts with `jump_protocol_const`, so `--host-alias "b.com=x://a.com"` validated, and folded `http://b.com` to a host of `x://a.com` that then goes to DNS and into the on-disk path.

Only the `'\n'` case needed the export to be reachable at all; the other two are reachable from the command line today. Test 275 covers them there and fails against a master build. Additive export, no struct or signature touched, so no soname move.

Closes #1192
Closes #1172
