### PR TITLE
A large .httrackrc aborts the engine on the rebuilt command line's token block

### DIFF
--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -558,15 +558,14 @@ struct cmdl_chunk {
   cmdl_chunk *next;
 };
 
-/* The token bytes an allocated chunk carries. */
-#define CMDL_CHUNK_DATA(chunk) ((char *) ((chunk) + 1))
+/* The token bytes CHUNK carries, which follow it. */
+static char *cmdl_chunk_data(cmdl_chunk *chunk) { return (char *) (chunk + 1); }
 
-/* Chunk floor, so a command line of ordinary length needs one allocation and a
-   long one a count proportional to its size. */
+/* Chunk floor, so an ordinary command line needs one allocation. */
 #define CMDL_CHUNK_MIN 32768
 
-/* Take a chunk with room for at least need bytes as the one tokens are cut
-   from, leaving cmd unchanged if it cannot be allocated. */
+/* Cut later tokens from a new chunk of at least need bytes; cmd is unchanged
+   on failure. */
 static hts_boolean cmdl_grow(cmdl_argv *cmd, size_t need) {
   size_t size = need > CMDL_CHUNK_MIN ? need : CMDL_CHUNK_MIN;
   cmdl_chunk *chunk;
@@ -578,14 +577,14 @@ static hts_boolean cmdl_grow(cmdl_argv *cmd, size_t need) {
     return HTS_FALSE;
   chunk->next = cmd->chunks;
   cmd->chunks = chunk;
-  cmd->blk_size = size;
-  cmd->blk_used = 0;
+  cmd->chunk_size = size;
+  cmd->chunk_used = 0;
   return HTS_TRUE;
 }
 
-hts_boolean cmdl_init(cmdl_argv *cmd, size_t blk_size, int slots) {
+hts_boolean cmdl_init(cmdl_argv *cmd, size_t chunk_size, int slots) {
   memset(cmd, 0, sizeof(*cmd));
-  if (!cmdl_grow(cmd, blk_size) || !cmdl_reserve(cmd, slots)) {
+  if (!cmdl_grow(cmd, chunk_size) || !cmdl_reserve(cmd, slots)) {
     cmdl_free(cmd);
     return HTS_FALSE;
   }
@@ -608,7 +607,8 @@ void cmdl_free(cmdl_argv *cmd) {
 /* Room left in the newest chunk; 0 makes the bounded copy abort rather than
    write past it. */
 static size_t cmdl_room(const cmdl_argv *cmd) {
-  return cmd->blk_used < cmd->blk_size ? cmd->blk_size - cmd->blk_used : 0;
+  return cmd->chunk_used < cmd->chunk_size ? cmd->chunk_size - cmd->chunk_used
+                                           : 0;
 }
 
 hts_boolean cmdl_ins(cmdl_argv *cmd, const char *token, int pos) {
@@ -623,9 +623,9 @@ hts_boolean cmdl_ins(cmdl_argv *cmd, const char *token, int pos) {
     return HTS_FALSE;
   for (i = cmd->argc; i > pos; i--)
     cmd->argv[i] = cmd->argv[i - 1];
-  cmd->argv[pos] = CMDL_CHUNK_DATA(cmd->chunks) + cmd->blk_used;
+  cmd->argv[pos] = cmdl_chunk_data(cmd->chunks) + cmd->chunk_used;
   strlcpybuff(cmd->argv[pos], token, cmdl_room(cmd));
-  cmd->blk_used += len;
+  cmd->chunk_used += len;
   cmd->argc++;
   return HTS_TRUE;
 }

--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -554,42 +554,78 @@ static hts_boolean cmdl_reserve(cmdl_argv *cmd, int count) {
   return HTS_TRUE;
 }
 
+struct cmdl_chunk {
+  cmdl_chunk *next;
+};
+
+/* The token bytes an allocated chunk carries. */
+#define CMDL_CHUNK_DATA(chunk) ((char *) ((chunk) + 1))
+
+/* Chunk floor, so a command line of ordinary length needs one allocation and a
+   long one a count proportional to its size. */
+#define CMDL_CHUNK_MIN 32768
+
+/* Take a chunk with room for at least need bytes as the one tokens are cut
+   from, leaving cmd unchanged if it cannot be allocated. */
+static hts_boolean cmdl_grow(cmdl_argv *cmd, size_t need) {
+  size_t size = need > CMDL_CHUNK_MIN ? need : CMDL_CHUNK_MIN;
+  cmdl_chunk *chunk;
+
+  if (size > (size_t) -1 - sizeof(cmdl_chunk))
+    return HTS_FALSE;
+  chunk = (cmdl_chunk *) malloct(sizeof(cmdl_chunk) + size);
+  if (chunk == NULL)
+    return HTS_FALSE;
+  chunk->next = cmd->chunks;
+  cmd->chunks = chunk;
+  cmd->blk_size = size;
+  cmd->blk_used = 0;
+  return HTS_TRUE;
+}
+
 hts_boolean cmdl_init(cmdl_argv *cmd, size_t blk_size, int slots) {
   memset(cmd, 0, sizeof(*cmd));
-  cmd->blk = blk_size != 0 ? (char *) malloct(blk_size) : NULL;
-  if (cmd->blk == NULL || !cmdl_reserve(cmd, slots)) {
+  if (!cmdl_grow(cmd, blk_size) || !cmdl_reserve(cmd, slots)) {
     cmdl_free(cmd);
     return HTS_FALSE;
   }
-  cmd->blk_size = blk_size;
-  cmd->blk[0] = '\0';
   return HTS_TRUE;
 }
 
 void cmdl_free(cmdl_argv *cmd) {
-  freet(cmd->blk);
+  cmdl_chunk *chunk = cmd->chunks;
+
+  while (chunk != NULL) {
+    cmdl_chunk *const next = chunk->next;
+
+    freet(chunk);
+    chunk = next;
+  }
   freet(cmd->argv);
   memset(cmd, 0, sizeof(*cmd));
 }
 
-/* Room left in the token block; 0 makes the bounded copy abort rather than
+/* Room left in the newest chunk; 0 makes the bounded copy abort rather than
    write past it. */
 static size_t cmdl_room(const cmdl_argv *cmd) {
   return cmd->blk_used < cmd->blk_size ? cmd->blk_size - cmd->blk_used : 0;
 }
 
 hts_boolean cmdl_ins(cmdl_argv *cmd, const char *token, int pos) {
+  const size_t len = strlen(token) + 1;
   int i;
 
   assertf(pos >= 0 && pos <= cmd->argc);
   /* argc <= capacity <= CMDL_MAX_SLOTS holds here, so argc + 1 can not wrap */
   if (!cmdl_reserve(cmd, cmd->argc + 1))
     return HTS_FALSE;
+  if (len > cmdl_room(cmd) && !cmdl_grow(cmd, len))
+    return HTS_FALSE;
   for (i = cmd->argc; i > pos; i--)
     cmd->argv[i] = cmd->argv[i - 1];
-  cmd->argv[pos] = cmd->blk + cmd->blk_used;
+  cmd->argv[pos] = CMDL_CHUNK_DATA(cmd->chunks) + cmd->blk_used;
   strlcpybuff(cmd->argv[pos], token, cmdl_room(cmd));
-  cmd->blk_used += strlen(cmd->argv[pos]) + 1;
+  cmd->blk_used += len;
   cmd->argc++;
   return HTS_TRUE;
 }

--- a/src/htsalias.h
+++ b/src/htsalias.h
@@ -53,32 +53,37 @@ const char *opthelp_value(int p);
 const char *hts_gethome(void);
 void expand_home(String * str);
 
+/* One token-block allocation, its bytes following the link. */
+typedef struct cmdl_chunk cmdl_chunk;
+
 /* Command line rebuilt from argv, config files and doit.log: argc slots
-   pointing into blk, where the tokens are packed back-to-back. The slots grow
-   on demand, since a config file and a doit.log each add a token count the
-   input decides; blk does not, so a token that no longer fits aborts in the
-   bounded copy instead of overrunning. */
+   pointing into the token chunks, where the tokens are packed back-to-back.
+   Both grow on demand, since a config file and a doit.log each add a token
+   count only the input knows. A chunk is never resized, so every argv[] slot,
+   and every pointer a caller kept into one, survives the growth. */
 typedef struct {
   char **argv; /* argc slots used out of capacity allocated */
   int argc;
   int capacity;
-  char *blk; /* token bytes, blk_used of blk_size in use */
-  size_t blk_size;
+  cmdl_chunk *chunks; /* newest first; tokens are cut from the newest */
+  size_t blk_size;    /* the newest chunk, blk_used of blk_size in use */
   size_t blk_used;
 } cmdl_argv;
 
-/* Allocate a token block of blk_size bytes and room for slots entries.
-   HTS_FALSE if either fails, leaving cmd empty. */
+/* Allocate a first token chunk of at least blk_size bytes and room for slots
+   entries. HTS_FALSE if either fails, leaving cmd empty. */
 hts_boolean cmdl_init(cmdl_argv *cmd, size_t blk_size, int slots);
 
 /* Release cmd; the tokens its argv pointed at die with it. */
 void cmdl_free(cmdl_argv *cmd);
 
-/* Append token as the last entry. HTS_FALSE if the slots can not be grown. */
+/* Append token as the last entry. HTS_FALSE if it does not fit and neither the
+   slots nor the chunks can be grown. */
 hts_boolean cmdl_add(cmdl_argv *cmd, const char *token);
 
 /* Insert token at 0 <= pos <= argc, shifting the entries above it up by one.
-   HTS_FALSE if the slots can not be grown. */
+   HTS_FALSE if it does not fit and neither the slots nor the chunks can be
+   grown. */
 hts_boolean cmdl_ins(cmdl_argv *cmd, const char *token, int pos);
 
 typedef enum {

--- a/src/htsalias.h
+++ b/src/htsalias.h
@@ -56,23 +56,21 @@ void expand_home(String * str);
 /* One token-block allocation, its bytes following the link. */
 typedef struct cmdl_chunk cmdl_chunk;
 
-/* Command line rebuilt from argv, config files and doit.log: argc slots
-   pointing into the token chunks, where the tokens are packed back-to-back.
-   Both grow on demand, since a config file and a doit.log each add a token
-   count only the input knows. A chunk is never resized, so every argv[] slot,
-   and every pointer a caller kept into one, survives the growth. */
+/* Command line rebuilt from argv, config files and doit.log, both parts growing
+   on demand. A chunk is never resized, so every argv[] slot, and every pointer
+   a caller kept into one, survives the growth. */
 typedef struct {
   char **argv; /* argc slots used out of capacity allocated */
   int argc;
   int capacity;
   cmdl_chunk *chunks; /* newest first; tokens are cut from the newest */
-  size_t blk_size;    /* the newest chunk, blk_used of blk_size in use */
-  size_t blk_used;
+  size_t chunk_size;  /* the newest chunk, chunk_used of chunk_size in use */
+  size_t chunk_used;
 } cmdl_argv;
 
-/* Allocate a first token chunk of at least blk_size bytes and room for slots
+/* Allocate a first token chunk of at least chunk_size bytes and room for slots
    entries. HTS_FALSE if either fails, leaving cmd empty. */
-hts_boolean cmdl_init(cmdl_argv *cmd, size_t blk_size, int slots);
+hts_boolean cmdl_init(cmdl_argv *cmd, size_t chunk_size, int slots);
 
 /* Release cmd; the tokens its argv pointed at die with it. */
 void cmdl_free(cmdl_argv *cmd);

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -314,16 +314,13 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
   /* create the token block for the transformed command line */
   {
     size_t current_size = 0;
-    const LLint size = fsize("config");
-    size_t blk_size;
     int na;
 
     for(na = 0; na < argc; na++)
       current_size += strlen(argv[na]) + 1;
-    /* a huge file named "config" must saturate, not wrap, the capacity */
-    blk_size = llint_grow_size_t(current_size, size > 0 ? size : 0, 32768);
-    /* argc slots to start with; alias expansion and doit.log grow the array */
-    if (blk_size == (size_t) -1 || !cmdl_init(&x_cmd, blk_size, argc)) {
+    /* the current argv and argc slots to start with; alias expansion, the
+       config files and doit.log grow both */
+    if (!cmdl_init(&x_cmd, current_size, argc)) {
       HTS_PANIC_PRINTF("Error, not enough memory");
       htsmain_free();
       return -1;
@@ -837,7 +834,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
       if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
                               StringBuff(opt->path_log),
                               "hts-cache/doit.log"))) { // un cache est présent
-        if (x_cmd.blk != NULL) {
+        if (x_cmd.chunks != NULL) {
           int m;
 
           // établir mode - mode cache: 1 (cache valide) 2 (cache à vérifier)
@@ -865,7 +862,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
               HT_PRINT("OK to Update ");
             }
             HT_PRINT("httrack ");
-            HT_PRINT(x_cmd.blk);
+            HT_PRINT(x_cmd.argv[0]);
             HT_PRINT("?" LF);
             HT_REQUEST_END;
             if (!ask_continue(opt)) {

--- a/tests/01_engine-rcfile.test
+++ b/tests/01_engine-rcfile.test
@@ -8,8 +8,7 @@
 #      user-agent expands to two tokens (-F <value>), so it exercises both
 #      cmdl_ins insertions.
 #   2. The block grows: an rc file whose expansions outrun the first chunk many
-#      times over is read to the end, and its last token still reaches doit.log
-#      (#1198). It used to abort in the bounded copy once the block filled.
+#      times over is read to the end, and its tokens still reach doit.log.
 
 # set -e with the intentional-nonzero httrack runs guarded explicitly (their
 # status is inspected by hand).
@@ -71,10 +70,8 @@ d2="$tmp/grow"
 mkdir -p "$d2"
 echo '<html><body>hi</body></html>' >"$d2/index.html"
 
-# Each line inserts two tokens of ~200 bytes; 2000 of them need some 400 KB,
-# which is a dozen times the 32 KB chunk floor. The first and last values are
-# distinct: doit.log then shows both that the tail of the file made it in, and
-# that a token written before the growth is still readable after it.
+# Two tokens of ~200 bytes per line, so 2000 lines need some 400 KB against a
+# 32 KB chunk floor. The first marker is read back after a dozen growths.
 val=$(printf 'a%.0s' $(seq 1 200))
 first='zzz_rcfile_marker_first_line_grown'
 last='zzz_rcfile_marker_last_line_grown'
@@ -89,14 +86,22 @@ last='zzz_rcfile_marker_last_line_grown'
 rc=0
 (cd "$d2" && "$bin" "file://$d2/index.html" --quiet -n >.log 2>&1) || rc=$?
 
-# A block that cannot grow aborts in the bounded copy (exit 134, a message
-# naming htsalias.c); an unbounded one used to overrun the heap here.
+# A block that cannot grow aborts in the bounded copy (exit 134).
 test "$rc" -eq 0 || {
     echo "FAIL: large rc-file crawl exited $rc, the token block did not grow"
     tail -3 "$d2/.log"
     exit 1
 }
 assert_file "$d2/hts-cache/doit.log" "no doit.log, so the rc file was not processed"
+# Clipping a token to the room left, instead of growing, would keep both
+# markers: only the tokens straddling a chunk boundary lose bytes. Line 1 alone
+# is the command line, so the prose below it cannot answer for a token.
+short=$(sed -n '1p' "$d2/hts-cache/doit.log" | tr ' ' '\n' |
+    awk -v n="${#val}" '/^a+$/ && length($0) != n {c++} END {print c + 0}')
+test "$short" -eq 0 || {
+    echo "FAIL: $short user-agent value(s) reached doit.log clipped"
+    exit 1
+}
 for marker in "$first" "$last"; do
     grep -q -- "-F $marker" "$d2/hts-cache/doit.log" || {
         echo "FAIL: $marker never reached the rebuilt command line"

--- a/tests/01_engine-rcfile.test
+++ b/tests/01_engine-rcfile.test
@@ -3,19 +3,16 @@
 
 # Config-file alias loading (no network). A .httrackrc in the working directory
 # is read by optinclude_file(), whose cmdl_ins() inserts each alias-expanded
-# token into the shared token block. That copy used to be an unbounded strcpy
-# on a bare char*; it is now bounded by the block capacity. Two properties are
-# checked:
-#   1. The bound does not truncate: a long user-agent alias reaches doit.log
-#      intact. user-agent expands to two tokens (-F <value>), so it exercises
-#      both cmdl_ins insertions.
-#   2. The bound holds under exhaustion: a pathological .httrackrc whose alias
-#      expansions overflow the block aborts cleanly through the htssafe bounds
-#      check (a message naming htsalias.c) instead of overrunning the heap. The
-#      unbounded version segfaulted here.
+# token into the token block. Two properties are checked:
+#   1. No truncation: a long user-agent alias reaches doit.log intact.
+#      user-agent expands to two tokens (-F <value>), so it exercises both
+#      cmdl_ins insertions.
+#   2. The block grows: an rc file whose expansions outrun the first chunk many
+#      times over is read to the end, and its last token still reaches doit.log
+#      (#1198). It used to abort in the bounded copy once the block filled.
 
-# set -e with the intentional-nonzero httrack runs guarded explicitly (the
-# crawls below are expected to fail/abort and their status is inspected by hand).
+# set -e with the intentional-nonzero httrack runs guarded explicitly (their
+# status is inspected by hand).
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "$(dirname "$0")/testlib.sh"
@@ -69,29 +66,42 @@ grep -q -- "-F $marker" "$d1/hts-cache/doit.log" || {
     exit 1
 }
 
-# --- 2. block exhaustion aborts through the bound, not the heap -------------
-d2="$tmp/exhaust"
+# --- 2. the block grows past its first chunk --------------------------------
+d2="$tmp/grow"
 mkdir -p "$d2"
 echo '<html><body>hi</body></html>' >"$d2/index.html"
 
-# Each line inserts ~two tokens of ~200 bytes; 400 lines overflow the block's
-# fixed slack (current_size + 32768) many times over, deterministically.
+# Each line inserts two tokens of ~200 bytes; 2000 of them need some 400 KB,
+# which is a dozen times the 32 KB chunk floor. The first and last values are
+# distinct: doit.log then shows both that the tail of the file made it in, and
+# that a token written before the growth is still readable after it.
 val=$(printf 'a%.0s' $(seq 1 200))
-for _ in $(seq 1 400); do
-    printf 'user-agent=%s\n' "$val"
-done | write_rc "$d2"
+first='zzz_rcfile_marker_first_line_grown'
+last='zzz_rcfile_marker_last_line_grown'
+{
+    printf 'user-agent=%s\n' "$first"
+    for _ in $(seq 1 2000); do
+        printf 'user-agent=%s\n' "$val"
+    done
+    printf 'user-agent=%s\n' "$last"
+} | write_rc "$d2"
 
-# The process aborts (httrack turns the fatal signal into exit 134 either way),
-# so the exit code does not distinguish the bounded abort from a heap overflow;
-# the stderr diagnostic does. The htssafe bounds check names the offending file.
-# Expected to fail, so the nonzero exit is swallowed; only the log is inspected.
-(cd "$d2" && "$bin" "file://$d2/index.html" --quiet -n >.log 2>&1) || true
+rc=0
+(cd "$d2" && "$bin" "file://$d2/index.html" --quiet -n >.log 2>&1) || rc=$?
 
-grep -Eq "overflow while copying.*htsalias\.c" "$d2/.log" || {
-    echo "FAIL: exhausted rc file did not abort through the htsalias.c bound"
-    echo "(an unbounded copy would overrun the heap here)"
+# A block that cannot grow aborts in the bounded copy (exit 134, a message
+# naming htsalias.c); an unbounded one used to overrun the heap here.
+test "$rc" -eq 0 || {
+    echo "FAIL: large rc-file crawl exited $rc, the token block did not grow"
     tail -3 "$d2/.log"
     exit 1
 }
+assert_file "$d2/hts-cache/doit.log" "no doit.log, so the rc file was not processed"
+for marker in "$first" "$last"; do
+    grep -q -- "-F $marker" "$d2/hts-cache/doit.log" || {
+        echo "FAIL: $marker never reached the rebuilt command line"
+        exit 1
+    }
+done
 
 exit 0


### PR DESCRIPTION
The token block holding the rebuilt command line was sized once, from the current argv plus `fsize("config")` plus 32 KB of slack, and never grew. The engine reads `.httrackrc`, `httrackrc` or `/etc/httrack.conf`, never a file called `config`, so nothing in that sum accounted for what the expansion would add. Past the slack `cmdl_ins` ran out of room and `strlcpybuff` aborted the process, on a config file the user wrote themselves.

The block is now a chain of chunks, so it grows the way the slot array has since #1196. A chunk is never resized, which is what makes the growth safe: every `argv[]` slot points into it and stays valid, as does `argv_firsturl` in htscoremain.c, where a realloc would have had to rebase them all. The `fsize("config")` term goes away, and the first chunk is sized from the current argv with a 32 KB floor.

Case 2 of `01_engine-rcfile.test` pinned the abort as the safe outcome; it now checks that an rc file needing a dozen chunks is read to the end with no token clipped. Green under ASan/UBSan, which reports a heap-use-after-free if the old chunk is freed on growth.

One line in the cache-resume prompt read the block directly and keeps its current output; #1204 tracks what it was meant to print.

Closes #1198
