### PR TITLE
The Windows build rebuilds OpenSSL from source on every run

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -67,16 +67,31 @@ jobs:
         run: New-Item -ItemType Directory -Force -Path $env:VCPKG_DEFAULT_BINARY_CACHE | Out-Null
 
       # x-gha is gone (vcpkg-tool #1662 dropped it after GitHub changed the cache
-      # API), so cache the binary archives directly. Keyed on the manifest, which
-      # carries the builtin-baseline, so a Dependabot bump busts it; restore-keys
-      # still seeds the unchanged ports' archives, so only the bumped one rebuilds.
-      - name: Cache vcpkg binary archives
-        uses: actions/cache@v6
+      # API), so cache the binary archives directly. The run id keeps the primary key
+      # unique so it never scores an exact hit, which is what makes this self-healing:
+      # an archive is named for vcpkg's ABI hash, and anything that hash folds in
+      # (compiler, vcpkg-tool, its cmake) can orphan every archive at once, but on an
+      # exact hit actions/cache skips the save and the dead entry pins itself. A key
+      # naming those inputs is a list that can always be one short; restoring by
+      # prefix takes the newest entry whatever moved.
+      - name: Restore the vcpkg binary archives
+        uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}\vcpkg_cache
-          key: vcpkg-${{ matrix.platform }}-${{ hashFiles('src/vcpkg.json') }}
+          key: vcpkg-${{ matrix.platform }}-${{ hashFiles('src/vcpkg.json') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
+            vcpkg-${{ matrix.platform }}-${{ hashFiles('src/vcpkg.json') }}-
             vcpkg-${{ matrix.platform }}-
+
+      # Counted before the build, or vcpkg's own writes during it make a cold cache
+      # read as a warm one.
+      - name: Count the restored vcpkg archives
+        shell: pwsh
+        run: |
+          $n = @(Get-ChildItem -Recurse -File -Filter *.zip `
+            $env:VCPKG_DEFAULT_BINARY_CACHE -EA SilentlyContinue).Count
+          Write-Host "restored $n archive(s)"
+          "VCPKG_ARCHIVES_BEFORE=$n" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       # The runner image's vcpkg checkout is pinned to some commit; our manifest's
       # builtin-baseline is usually newer, so `git show <baseline>:versions/...`
@@ -106,6 +121,38 @@ jobs:
               /flp:LogFile=msbuild-$proj.log`;Verbosity=normal
             if ($LASTEXITCODE -ne 0) { throw "$proj failed" }
           }
+
+      # A stale cache and a warm one look alike by wall clock: both restore, both
+      # rebuild. Only archives-restored-but-none-matched is diagnostic.
+      - name: Check whether vcpkg could use the restored archives
+        id: vcpkg
+        if: ${{ !cancelled() }}
+        shell: pwsh
+        run: |
+          $before = [int]$env:VCPKG_ARCHIVES_BEFORE
+          $after = @(Get-ChildItem -Recurse -File -Filter *.zip `
+            $env:VCPKG_DEFAULT_BINARY_CACHE -EA SilentlyContinue).Count
+          "grew=$($after -gt $before)".ToLower() | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          # Absent whenever the build never reached MSBuild, which this step outlives.
+          if (-not (Test-Path msbuild-libhttrack.log)) { Write-Host "no build log"; exit 0 }
+          $m = Select-String -Path msbuild-libhttrack.log -Pattern 'Restored (\d+) package' |
+            Select-Object -First 1
+          if (-not $m) { Write-Host "no vcpkg restore line in the build log"; exit 0 }
+          $restored = [int]$m.Matches[0].Groups[1].Value
+          Write-Host "vcpkg restored $restored of $before archive(s); $after now cached"
+          if ($restored -eq 0 -and $before -gt 0) {
+            Write-Host "::warning::stale vcpkg cache: $before archives, none matching this toolchain; every port rebuilt from source"
+          }
+
+      # Only on growth, so a warm run adds no entry and the eviction budget stays for
+      # the runs that did build something: a cold cache, a manifest bump, or a
+      # toolchain whose ABI hash moved for a reason the key cannot name.
+      - name: Save the vcpkg binary archives
+        if: ${{ !cancelled() && steps.vcpkg.outputs.grew == 'true' }}
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}\vcpkg_cache
+          key: vcpkg-${{ matrix.platform }}-${{ hashFiles('src/vcpkg.json') }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       # WinHTTrack links src\$(Platform)\$(Configuration)\libhttrack.lib, so the
       # import lib and the DLL both have to land there under that exact name.

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -88,10 +88,11 @@ jobs:
       - name: Count the restored vcpkg archives
         shell: pwsh
         run: |
-          $n = @(Get-ChildItem -Recurse -File -Filter *.zip `
-            $env:VCPKG_DEFAULT_BINARY_CACHE -EA SilentlyContinue).Count
-          Write-Host "restored $n archive(s)"
-          "VCPKG_ARCHIVES_BEFORE=$n" | Out-File -FilePath $env:GITHUB_ENV -Append
+          $a = @(Get-ChildItem -Recurse -File -Filter *.zip `
+            $env:VCPKG_DEFAULT_BINARY_CACHE -EA SilentlyContinue)
+          Write-Host "restored $($a.Count) archive(s)"
+          $a.FullName | Out-File -FilePath vcpkg-restored.txt
+          "VCPKG_ARCHIVES_BEFORE=$($a.Count)" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       # The runner image's vcpkg checkout is pinned to some commit; our manifest's
       # builtin-baseline is usually newer, so `git show <baseline>:versions/...`
@@ -130,25 +131,38 @@ jobs:
         shell: pwsh
         run: |
           $before = [int]$env:VCPKG_ARCHIVES_BEFORE
+          $stale = $false
+          # The log is absent whenever the build never reached MSBuild, which this
+          # step outlives.
+          if (Test-Path msbuild-libhttrack.log) {
+            $m = Select-String -Path msbuild-libhttrack.log -Pattern 'Restored (\d+) package' |
+              Select-Object -First 1
+            if ($m) {
+              $restored = [int]$m.Matches[0].Groups[1].Value
+              Write-Host "vcpkg restored $restored of $before archive(s)"
+              $stale = ($restored -eq 0 -and $before -gt 0)
+            } else { Write-Host "no vcpkg restore line in the build log" }
+          } else { Write-Host "no build log" }
+          if ($stale) {
+            Write-Host "::warning::stale vcpkg cache: $before archives, none matching this toolchain; every port rebuilt from source"
+            # Provably dead, vcpkg matched none of them, so drop them rather than
+            # carry every past toolchain generation in the saved entry forever.
+            Get-Content vcpkg-restored.txt -EA SilentlyContinue | Where-Object { $_ } |
+              Remove-Item -Force -EA SilentlyContinue
+          }
           $after = @(Get-ChildItem -Recurse -File -Filter *.zip `
             $env:VCPKG_DEFAULT_BINARY_CACHE -EA SilentlyContinue).Count
-          "grew=$($after -gt $before)".ToLower() | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          # Absent whenever the build never reached MSBuild, which this step outlives.
-          if (-not (Test-Path msbuild-libhttrack.log)) { Write-Host "no build log"; exit 0 }
-          $m = Select-String -Path msbuild-libhttrack.log -Pattern 'Restored (\d+) package' |
-            Select-Object -First 1
-          if (-not $m) { Write-Host "no vcpkg restore line in the build log"; exit 0 }
-          $restored = [int]$m.Matches[0].Groups[1].Value
-          Write-Host "vcpkg restored $restored of $before archive(s); $after now cached"
-          if ($restored -eq 0 -and $before -gt 0) {
-            Write-Host "::warning::stale vcpkg cache: $before archives, none matching this toolchain; every port rebuilt from source"
-          }
+          Write-Host "$after archive(s) to cache"
+          # Pruning can leave the count unmoved while replacing every archive, so the
+          # stale case saves on its own account rather than on growth.
+          "save=$($stale -or ($after -gt $before))".ToLower() |
+            Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
-      # Only on growth, so a warm run adds no entry and the eviction budget stays for
-      # the runs that did build something: a cold cache, a manifest bump, or a
-      # toolchain whose ABI hash moved for a reason the key cannot name.
+      # Only when the archive set actually changed, so a warm run adds no entry and
+      # the eviction budget stays for the runs that did build something: a cold
+      # cache, a manifest bump, or a toolchain whose ABI hash moved.
       - name: Save the vcpkg binary archives
-        if: ${{ !cancelled() && steps.vcpkg.outputs.grew == 'true' }}
+        if: ${{ !cancelled() && steps.vcpkg.outputs.save == 'true' }}
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}\vcpkg_cache

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -67,13 +67,10 @@ jobs:
         run: New-Item -ItemType Directory -Force -Path $env:VCPKG_DEFAULT_BINARY_CACHE | Out-Null
 
       # x-gha is gone (vcpkg-tool #1662 dropped it after GitHub changed the cache
-      # API), so cache the binary archives directly. The run id keeps the primary key
-      # unique so it never scores an exact hit, which is what makes this self-healing:
-      # an archive is named for vcpkg's ABI hash, and anything that hash folds in
-      # (compiler, vcpkg-tool, its cmake) can orphan every archive at once, but on an
-      # exact hit actions/cache skips the save and the dead entry pins itself. A key
-      # naming those inputs is a list that can always be one short; restoring by
-      # prefix takes the newest entry whatever moved.
+      # API), so cache the binary archives directly. An exact key hit skips the save,
+      # so a cache orphaned by a toolchain bump pins itself, and naming every input
+      # vcpkg's ABI hash folds in is a list that can come up short: key on the run
+      # id instead, and restore by prefix.
       - name: Restore the vcpkg binary archives
         uses: actions/cache/restore@v6
         with:
@@ -84,7 +81,7 @@ jobs:
             vcpkg-${{ matrix.platform }}-
 
       # Counted before the build, or vcpkg's own writes during it make a cold cache
-      # read as a warm one.
+      # look warm.
       - name: Count the restored vcpkg archives
         shell: pwsh
         run: |
@@ -123,8 +120,8 @@ jobs:
             if ($LASTEXITCODE -ne 0) { throw "$proj failed" }
           }
 
-      # A stale cache and a warm one look alike by wall clock: both restore, both
-      # rebuild. Only archives-restored-but-none-matched is diagnostic.
+      # A stale cache and a warm one both restore and rebuild; only archives
+      # restored and unmatched prove staleness.
       - name: Check whether vcpkg could use the restored archives
         id: vcpkg
         if: ${{ !cancelled() }}
@@ -132,8 +129,7 @@ jobs:
         run: |
           $before = [int]$env:VCPKG_ARCHIVES_BEFORE
           $stale = $false
-          # The log is absent whenever the build never reached MSBuild, which this
-          # step outlives.
+          # The log is missing when the build never reached MSBuild.
           if (Test-Path msbuild-libhttrack.log) {
             $m = Select-String -Path msbuild-libhttrack.log -Pattern 'Restored (\d+) package' |
               Select-Object -First 1
@@ -145,10 +141,11 @@ jobs:
           } else { Write-Host "no build log" }
           if ($stale) {
             Write-Host "::warning::stale vcpkg cache: $before archives, none matching this toolchain; every port rebuilt from source"
-            # Provably dead, vcpkg matched none of them, so drop them rather than
-            # carry every past toolchain generation in the saved entry forever.
+            # Provably dead: drop them rather than carry every past toolchain
+            # generation in the saved entry forever. -LiteralPath because a piped
+            # string binds -Path, which globs on a name carrying [ ].
             Get-Content vcpkg-restored.txt -EA SilentlyContinue | Where-Object { $_ } |
-              Remove-Item -Force -EA SilentlyContinue
+              ForEach-Object { Remove-Item -LiteralPath $_ -Force -EA SilentlyContinue }
           }
           $after = @(Get-ChildItem -Recurse -File -Filter *.zip `
             $env:VCPKG_DEFAULT_BINARY_CACHE -EA SilentlyContinue).Count
@@ -158,9 +155,8 @@ jobs:
           "save=$($stale -or ($after -gt $before))".ToLower() |
             Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
-      # Only when the archive set actually changed, so a warm run adds no entry and
-      # the eviction budget stays for the runs that did build something: a cold
-      # cache, a manifest bump, or a toolchain whose ABI hash moved.
+      # Only when the archive set changed, so a warm run adds no entry and the
+      # eviction budget stays for the runs that rebuilt something.
       - name: Save the vcpkg binary archives
         if: ${{ !cancelled() && steps.vcpkg.outputs.save == 'true' }}
         uses: actions/cache/save@v6


### PR DESCRIPTION
The vcpkg binary cache has not served a package since 2026-08-04: both legs log `Restored 0 package(s)` and rebuild openssl from source, 7.7 min on x64 and 5.1 min on Win32. The key named only the manifest, so nothing busted it when a runner image orphaned every archive, and actions/cache skips the save on an exact hit. That is why it stayed broken for eight days rather than one run.

Naming every input vcpkg's ABI hash folds in would only make a list that can still come up short, so the restore keys on the run id and prefix-matches instead, the save runs when the archive set changed, and a cache vcpkg matched nothing in is dropped rather than carried forward. Two runs are needed to show it: the first supersedes the dead entry, the second should restore warm and bring the build step to roughly 2 min.

Closes #1208