### PR TITLE
The resume offer echoes the program path instead of the command line it would run

### DIFF
--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -182,7 +182,10 @@ static void cmdl_print_args(httrackp *opt, const cmdl_argv *cmd) {
     const size_t used = strlen(opt->state.HTbuff);
 
     if (used >= spare || strlen(cmd->argv[i]) >= spare - used) {
-      HT_PRINT(" ...");
+      /* clipped rather than HT_PRINT'd, so the mark fits whatever the caller
+         wrote before it */
+      strlncatbuff(opt->state.HTbuff, " ...", sizeof(opt->state.HTbuff),
+                   sizeof(opt->state.HTbuff) - 1 - used);
       return;
     }
     HT_PRINT(" ");

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -169,6 +169,27 @@ void hts_resolve_datadir(char *dst, size_t dstsize, const char *selfpath,
   snprintf(dst, dstsize, "%s", fallback);
 }
 
+/* Append CMD's arguments to the pending request, each behind a space, ending
+   in " ..." if they do not all fit. Clipped rather than bounded because
+   HT_PRINT aborts on overflow and a command line outgrows HTbuff easily. */
+static void cmdl_print_args(httrackp *opt, const cmdl_argv *cmd) {
+  /* what the caller still has to append: "?", the line break, the NUL */
+  static const size_t tail = sizeof("?" LF);
+  int i;
+
+  for (i = 1; i < cmd->argc; i++) {
+    const size_t spare = sizeof(opt->state.HTbuff) - tail - sizeof(" ...");
+    const size_t used = strlen(opt->state.HTbuff);
+
+    if (used >= spare || strlen(cmd->argv[i]) >= spare - used) {
+      HT_PRINT(" ...");
+      return;
+    }
+    HT_PRINT(" ");
+    HT_PRINT(cmd->argv[i]);
+  }
+}
+
 #define htsmain_free() do { \
   if (url != NULL) { \
     free(url); \
@@ -861,8 +882,8 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                        LF);
               HT_PRINT("OK to Update ");
             }
-            HT_PRINT("httrack ");
-            HT_PRINT(x_cmd.argv[0]);
+            HT_PRINT("httrack");
+            cmdl_print_args(opt, &x_cmd);
             HT_PRINT("?" LF);
             HT_REQUEST_END;
             if (!ask_continue(opt)) {

--- a/tests/284_cli-resume-prompt.test
+++ b/tests/284_cli-resume-prompt.test
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
 # Re-run in a mirror directory and the engine offers to resume, quoting the
-# command line it would run. It quoted its own path instead (#1204), and the
-# obvious fix aborts: HT_PRINT appends into a 2 KB buffer whose helper dies on
-# overflow, which a real command line outgrows.
+# command line it would run (#1204). The obvious way to print it aborts:
+# HT_PRINT appends into a 2 KB buffer whose helper dies on overflow, which a
+# real command line outgrows.
 
 set -eu
 
@@ -45,7 +45,6 @@ seed "$tmp/plain" --footer 'zzzmarker'
 out=$(ask "$tmp/plain")
 assert_match 'OK to (Continue|Update) httrack ' "$out" "no resume offer"
 assert_match 'zzzmarker' "$out" "the offer dropped the options"
-# The binary's own path is what it used to print in their place.
 ! grep -qF -- "$bin" <<<"$out" || {
     echo "FAIL: the offer still quotes the program path"
     exit 1

--- a/tests/284_cli-resume-prompt.test
+++ b/tests/284_cli-resume-prompt.test
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Re-run in a mirror directory and the engine offers to resume, quoting the
+# command line it would run. It quoted its own path instead (#1204), and the
+# obvious fix aborts: HT_PRINT appends into a 2 KB buffer whose helper dies on
+# overflow, which a real command line outgrows.
+
+set -eu
+
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+ttyrun=$(nativepath "$(dirname "$0")/ttyrun.py")
+
+skip_on_windows "no pty on Windows"
+python=$(find_python) || skip "python3 not found"
+
+bin=$(httrack_path)
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_resume.XXXXXX") || exit 1
+cleanup_push rm -rf "$tmp"
+
+echo '<html><body>hi</body></html>' >"$tmp/index.html"
+url="file://$tmp/index.html"
+
+# The prompt only appears when the replayed command line leaves quiet unset, so
+# the seeding crawl passes neither --quiet nor -%v0.
+seed() { # seed DIR ARG...
+    local dir=$1
+    shift
+    mkdir -p "$dir"
+    (cd "$dir" && "$bin" "$url" -n "$@" >/dev/null 2>&1) || true
+    assert_file "$dir/hts-cache/doit.log" "seeding crawl left no doit.log"
+}
+
+# The offer needs a terminal, and one ENTER answers it.
+ask() { # ask DIR
+    local cap="$tmp/cap.$$"
+    rm -f "$cap"
+    "$python" "$ttyrun" "$cap" --stdin tty --send enter -- \
+        sh -c "cd '$1' && exec '$bin'" >/dev/null 2>&1 || true
+    cat "$cap"
+}
+
+printf '[the offer quotes the command line, not the binary] ..\t'
+seed "$tmp/plain" --footer 'zzzmarker'
+out=$(ask "$tmp/plain")
+assert_match 'OK to (Continue|Update) httrack ' "$out" "no resume offer"
+assert_match 'zzzmarker' "$out" "the offer dropped the options"
+# The binary's own path is what it used to print in their place.
+! grep -qF -- "$bin" <<<"$out" || {
+    echo "FAIL: the offer still quotes the program path"
+    exit 1
+}
+echo OK
+
+# Teeth for the clip: doit.log replays up to 8000 bytes, so a command line built
+# from many filters outruns the 2 KB buffer several times over.
+printf '[a command line too long to fit is clipped, not fatal] ..\t'
+long=()
+for i in $(seq 1 40); do
+    long+=("+*/zzzfilter${i}_$(printf 'b%.0s' $(seq 1 60))*")
+done
+seed "$tmp/long" "${long[@]}"
+out=$(ask "$tmp/long")
+assert_match 'OK to (Continue|Update) httrack .*\.\.\.\?' "$out" \
+    "a command line past the buffer was not clipped"
+# htssafe names the file it aborts in; the offer must not be one of them.
+! grep -qE 'overflow while copying' <<<"$out" || {
+    echo "FAIL: the offer aborted on the bounds check instead of clipping"
+    exit 1
+}
+echo OK


### PR DESCRIPTION
The offer to resume or update a mirror ends with the command line it would run, but printed `argv[0]`, so it read "OK to Continue httrack /usr/bin/httrack?". It has never worked: the buffer it reads holds the rebuilt command line as NUL-separated tokens, so the append stopped at the first one. The code that filled it from doit.log was already commented out in the 3.20.2 import.

Printing the rest is not a plain loop over them. `HT_PRINT` appends through `strcatbuff` into a fixed 2 KB buffer and aborts on overflow, which a command line replayed from doit.log outgrows, so the tokens are clipped to what is left and closed with an ellipsis.

Test 284 drives the offer under a pty, since it appears only when the replayed command line leaves quiet unset, and checks both halves: the options are quoted back, and a command line built from 40 filters is clipped rather than fatal.

Closes #1204
