### PR TITLE
Three open-coded chunked pools with the same stable-pointer contract

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -94,7 +94,7 @@ libhttrack_la_SOURCES =  htscore.c htsparse.c htsback.c htscache.c \
 	htsmodules.h htsname.h htsnet.h htssniff.h \
 	htsopt.h htsrobots.h htsthread.h  \
 	htscrashtest.h htstools.h htsrandom.h htswizard.h htswrap.h htscodec.h htswarc.h htschanges.h htssinglefile.h htssitemap.h htsproxy.h htszlib.h  \
-	htsstrings.h htsarrays.h httrack-library.h \
+	htsstrings.h htsarrays.h htsarena.h httrack-library.h \
 	htscharset.h punycode.h htsencoding.h \
 	htsentities.h htsentities.sh htsbasiccharsets.sh htscodepages.h \
 	md5.h coucal/murmurhash3.h \

--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -554,37 +554,9 @@ static hts_boolean cmdl_reserve(cmdl_argv *cmd, int count) {
   return HTS_TRUE;
 }
 
-struct cmdl_chunk {
-  cmdl_chunk *next;
-};
-
-/* The token bytes CHUNK carries, which follow it. */
-static char *cmdl_chunk_data(cmdl_chunk *chunk) { return (char *) (chunk + 1); }
-
-/* Chunk floor, so an ordinary command line needs one allocation. */
-#define CMDL_CHUNK_MIN 32768
-
-/* Cut later tokens from a new chunk of at least need bytes; cmd is unchanged
-   on failure. */
-static hts_boolean cmdl_grow(cmdl_argv *cmd, size_t need) {
-  size_t size = need > CMDL_CHUNK_MIN ? need : CMDL_CHUNK_MIN;
-  cmdl_chunk *chunk;
-
-  if (size > (size_t) -1 - sizeof(cmdl_chunk))
-    return HTS_FALSE;
-  chunk = (cmdl_chunk *) malloct(sizeof(cmdl_chunk) + size);
-  if (chunk == NULL)
-    return HTS_FALSE;
-  chunk->next = cmd->chunks;
-  cmd->chunks = chunk;
-  cmd->chunk_size = size;
-  cmd->chunk_used = 0;
-  return HTS_TRUE;
-}
-
-hts_boolean cmdl_init(cmdl_argv *cmd, size_t chunk_size, int slots) {
+hts_boolean cmdl_init(cmdl_argv *cmd, int slots) {
   memset(cmd, 0, sizeof(*cmd));
-  if (!cmdl_grow(cmd, chunk_size) || !cmdl_reserve(cmd, slots)) {
+  if (!cmdl_reserve(cmd, slots)) {
     cmdl_free(cmd);
     return HTS_FALSE;
   }
@@ -592,40 +564,25 @@ hts_boolean cmdl_init(cmdl_argv *cmd, size_t chunk_size, int slots) {
 }
 
 void cmdl_free(cmdl_argv *cmd) {
-  cmdl_chunk *chunk = cmd->chunks;
-
-  while (chunk != NULL) {
-    cmdl_chunk *const next = chunk->next;
-
-    freet(chunk);
-    chunk = next;
-  }
+  hts_arena_free(&cmd->tokens);
   freet(cmd->argv);
   memset(cmd, 0, sizeof(*cmd));
 }
 
-/* Room left in the newest chunk; 0 makes the bounded copy abort rather than
-   write past it. */
-static size_t cmdl_room(const cmdl_argv *cmd) {
-  return cmd->chunk_used < cmd->chunk_size ? cmd->chunk_size - cmd->chunk_used
-                                           : 0;
-}
-
 hts_boolean cmdl_ins(cmdl_argv *cmd, const char *token, int pos) {
-  const size_t len = strlen(token) + 1;
+  char *copy;
   int i;
 
   assertf(pos >= 0 && pos <= cmd->argc);
   /* argc <= capacity <= CMDL_MAX_SLOTS holds here, so argc + 1 can not wrap */
   if (!cmdl_reserve(cmd, cmd->argc + 1))
     return HTS_FALSE;
-  if (len > cmdl_room(cmd) && !cmdl_grow(cmd, len))
+  copy = hts_arena_strdup(&cmd->tokens, token);
+  if (copy == NULL)
     return HTS_FALSE;
   for (i = cmd->argc; i > pos; i--)
     cmd->argv[i] = cmd->argv[i - 1];
-  cmd->argv[pos] = cmdl_chunk_data(cmd->chunks) + cmd->chunk_used;
-  strlcpybuff(cmd->argv[pos], token, cmdl_room(cmd));
-  cmd->chunk_used += len;
+  cmd->argv[pos] = copy;
   cmd->argc++;
   return HTS_TRUE;
 }

--- a/src/htsalias.h
+++ b/src/htsalias.h
@@ -35,6 +35,7 @@ Please visit our Website: http://www.httrack.com
 #define HTSALIAS_DEFH
 
 #include "htsglobal.h"
+#include "htsarena.h"
 
 /* Library internal definictions */
 #ifdef HTS_INTERNAL_BYTECODE
@@ -53,34 +54,29 @@ const char *opthelp_value(int p);
 const char *hts_gethome(void);
 void expand_home(String * str);
 
-/* One token-block allocation, its bytes following the link. */
-typedef struct cmdl_chunk cmdl_chunk;
-
-/* Command line rebuilt from argv, config files and doit.log, both parts growing
-   on demand. A chunk is never resized, so every argv[] slot, and every pointer
-   a caller kept into one, survives the growth. */
+/* Command line rebuilt from argv, config files and doit.log: slots into an
+   arena holding the tokens, both growing on demand. The arena is what keeps
+   every argv[] slot, and every pointer a caller kept into one, valid. */
 typedef struct {
   char **argv; /* argc slots used out of capacity allocated */
   int argc;
   int capacity;
-  cmdl_chunk *chunks; /* newest first; tokens are cut from the newest */
-  size_t chunk_size;  /* the newest chunk, chunk_used of chunk_size in use */
-  size_t chunk_used;
+  hts_arena tokens;
 } cmdl_argv;
 
-/* Allocate a first token chunk of at least chunk_size bytes and room for slots
-   entries. HTS_FALSE if either fails, leaving cmd empty. */
-hts_boolean cmdl_init(cmdl_argv *cmd, size_t chunk_size, int slots);
+/* Prepare an empty command line with room for slots entries. HTS_FALSE if the
+   slots cannot be allocated. */
+hts_boolean cmdl_init(cmdl_argv *cmd, int slots);
 
 /* Release cmd; the tokens its argv pointed at die with it. */
 void cmdl_free(cmdl_argv *cmd);
 
 /* Append token as the last entry. HTS_FALSE if it does not fit and neither the
-   slots nor the chunks can be grown. */
+   slots nor the arena can be grown. */
 hts_boolean cmdl_add(cmdl_argv *cmd, const char *token);
 
 /* Insert token at 0 <= pos <= argc, shifting the entries above it up by one.
-   HTS_FALSE if it does not fit and neither the slots nor the chunks can be
+   HTS_FALSE if it does not fit and neither the slots nor the arena can be
    grown. */
 hts_boolean cmdl_ins(cmdl_argv *cmd, const char *token, int pos);
 

--- a/src/htsalias.h
+++ b/src/htsalias.h
@@ -54,9 +54,9 @@ const char *opthelp_value(int p);
 const char *hts_gethome(void);
 void expand_home(String * str);
 
-/* Command line rebuilt from argv, config files and doit.log: slots into an
-   arena holding the tokens, both growing on demand. The arena is what keeps
-   every argv[] slot, and every pointer a caller kept into one, valid. */
+/* Command line rebuilt from argv, config files and doit.log. The slots and the
+   token arena each grow on demand; the arena is what keeps every argv[] slot,
+   and every pointer a caller kept into one, valid. */
 typedef struct {
   char **argv; /* argc slots used out of capacity allocated */
   int argc;

--- a/src/htsarena.h
+++ b/src/htsarena.h
@@ -64,6 +64,12 @@ typedef struct {
 #define HTS_ARENA_MIN 32768
 #define HTS_ARENA_MAX (16 * 1024 * 1024)
 
+/** The padding below assumes a power of two, and a header that is already a
+    multiple of it; neither can change without this failing to compile. **/
+typedef char hts_arena_align_is_pow2_[(HTS_ARENA_ALIGN & (HTS_ARENA_ALIGN - 1))
+                                          ? -1
+                                          : 1];
+
 /** First aligned offset past the chunk header, where its bytes begin. **/
 #define HTS_ARENA_HDR                                                          \
   ((sizeof(hts_arena_chunk) + HTS_ARENA_ALIGN - 1) &                           \
@@ -90,6 +96,9 @@ static HTS_UNUSED hts_boolean hts_arena_grow_(hts_arena *arena, size_t need) {
   arena->used = 0;
   return HTS_TRUE;
 }
+
+typedef char
+    hts_arena_hdr_is_aligned_[(HTS_ARENA_HDR % HTS_ARENA_ALIGN) ? -1 : 1];
 
 /** SIZE bytes from ARENA, starting on an ALIGN boundary (a power of two), or
     NULL when out of memory. Padding is charged where it is needed rather than

--- a/src/htsarena.h
+++ b/src/htsarena.h
@@ -22,8 +22,7 @@ Please visit our Website: http://www.httrack.com
 */
 
 /* ------------------------------------------------------------ */
-/* File: htsarena.h subroutines:                                */
-/*       bump allocator whose allocations never move            */
+/* File: htsarena.h bump allocator whose allocations never move  */
 /* Author: Xavier Roche                                         */
 /* ------------------------------------------------------------ */
 
@@ -35,13 +34,12 @@ Please visit our Website: http://www.httrack.com
 
 #include <string.h>
 
-/* A bump allocator over chunks that are never resized, so what it hands out
-   keeps its address. That is what the realloc-based String and TypedArray
-   cannot promise, and what the link records and the rebuilt command line need,
-   both holding raw pointers into their own storage. Nothing is released until
-   the whole arena is. */
+/** @file htsarena.h
+ *  Bump allocator over chunks that are never resized, so what it hands out
+ *  keeps its address, which the realloc-based String and TypedArray cannot
+ *  promise. Nothing is released until the whole arena is. **/
 
-/* Alignment fit for anything an arena is asked to hold. */
+/** Alignment fit for anything an arena is asked to hold. **/
 typedef union {
   void *p;
   long l;
@@ -62,24 +60,16 @@ typedef struct {
 
 #define HTS_ARENA_ALIGN sizeof(hts_arena_align)
 
-/* Smallest chunk, then doubling up to the largest, so an arena holding a lot
-   keeps few chunks and one holding little wastes none. */
+/** Smallest chunk, then doubling up to the largest. **/
 #define HTS_ARENA_MIN 32768
 #define HTS_ARENA_MAX (16 * 1024 * 1024)
 
-/* First aligned offset past the chunk header, where its bytes begin. */
+/** First aligned offset past the chunk header, where its bytes begin. **/
 #define HTS_ARENA_HDR                                                          \
   ((sizeof(hts_arena_chunk) + HTS_ARENA_ALIGN - 1) &                           \
    ~(size_t) (HTS_ARENA_ALIGN - 1))
 
-/* SIZE rounded up to the arena's alignment, or 0 if that would wrap. */
-static HTS_INLINE HTS_UNUSED size_t hts_arena_round_(size_t size) {
-  return size <= (size_t) -1 - (HTS_ARENA_ALIGN - 1)
-             ? (size + HTS_ARENA_ALIGN - 1) & ~(size_t) (HTS_ARENA_ALIGN - 1)
-             : 0;
-}
-
-/* Take a chunk with room for NEED bytes; ARENA is unchanged on failure. */
+/** Take a chunk with room for NEED bytes; ARENA is unchanged on failure. **/
 static HTS_UNUSED hts_boolean hts_arena_grow_(hts_arena *arena, size_t need) {
   size_t size = arena->size < HTS_ARENA_MAX / 2 ? arena->size * 2
                                                 : (size_t) HTS_ARENA_MAX;
@@ -101,33 +91,49 @@ static HTS_UNUSED hts_boolean hts_arena_grow_(hts_arena *arena, size_t need) {
   return HTS_TRUE;
 }
 
-/* SIZE bytes from ARENA, aligned for any type, or NULL when out of memory.
-   The address stays valid until hts_arena_free(). */
-static HTS_UNUSED void *hts_arena_alloc(hts_arena *arena, size_t size) {
-  const size_t need = hts_arena_round_(size);
+/** SIZE bytes from ARENA, starting on an ALIGN boundary (a power of two), or
+    NULL when out of memory. Padding is charged where it is needed rather than
+    to every size, so a run of strings stays packed. **/
+static HTS_UNUSED void *hts_arena_take_(hts_arena *arena, size_t size,
+                                        size_t align) {
+  if (arena->chunks != NULL) {
+    /* used never passes size, so the room below can not go negative */
+    const size_t room = arena->size - arena->used;
+    const size_t pad = (align - (arena->used & (align - 1))) & (align - 1);
 
-  if (need == 0 && size != 0) /* the rounding wrapped */
-    return NULL;
-  /* need alone on one side: used never passes size, so the difference holds */
-  if (arena->chunks == NULL || need > arena->size - arena->used) {
-    if (!hts_arena_grow_(arena, need))
-      return NULL;
+    /* pad, then size, each alone on one side: neither test can wrap */
+    if (pad <= room && size <= room - pad) {
+      char *const at =
+          (char *) arena->chunks + HTS_ARENA_HDR + arena->used + pad;
+
+      arena->used += pad + size;
+      return at;
+    }
   }
-  arena->used += need;
-  return (char *) arena->chunks + HTS_ARENA_HDR + arena->used - need;
+  /* a fresh chunk begins aligned, so it needs no padding */
+  if (!hts_arena_grow_(arena, size))
+    return NULL;
+  arena->used = size;
+  return (char *) arena->chunks + HTS_ARENA_HDR;
 }
 
-/* A copy of S in ARENA, or NULL when out of memory. */
+/** SIZE bytes from ARENA, aligned for any type, or NULL when out of memory.
+    The address stays valid until hts_arena_free(). **/
+static HTS_UNUSED void *hts_arena_alloc(hts_arena *arena, size_t size) {
+  return hts_arena_take_(arena, size, HTS_ARENA_ALIGN);
+}
+
+/** A copy of S in ARENA, or NULL when out of memory. **/
 static HTS_UNUSED char *hts_arena_strdup(hts_arena *arena, const char *s) {
   const size_t len = strlen(s) + 1;
-  char *const copy = (char *) hts_arena_alloc(arena, len);
+  char *const copy = (char *) hts_arena_take_(arena, len, 1);
 
   if (copy != NULL)
     memcpy(copy, s, len);
   return copy;
 }
 
-/* Release every chunk, and with them everything the arena handed out. */
+/** Release every chunk, and with them everything the arena handed out. **/
 static HTS_UNUSED void hts_arena_free(hts_arena *arena) {
   hts_arena_chunk *chunk = arena->chunks;
 

--- a/src/htsarena.h
+++ b/src/htsarena.h
@@ -1,0 +1,143 @@
+/* ------------------------------------------------------------ */
+/*
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) 1998 Xavier Roche and other contributors
+
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Please visit our Website: http://www.httrack.com
+*/
+
+/* ------------------------------------------------------------ */
+/* File: htsarena.h subroutines:                                */
+/*       bump allocator whose allocations never move            */
+/* Author: Xavier Roche                                         */
+/* ------------------------------------------------------------ */
+
+#ifndef HTSARENA_DEFH
+#define HTSARENA_DEFH
+
+#include "htsglobal.h"
+#include "htssafe.h"
+
+#include <string.h>
+
+/* A bump allocator over chunks that are never resized, so what it hands out
+   keeps its address. That is what the realloc-based String and TypedArray
+   cannot promise, and what the link records and the rebuilt command line need,
+   both holding raw pointers into their own storage. Nothing is released until
+   the whole arena is. */
+
+/* Alignment fit for anything an arena is asked to hold. */
+typedef union {
+  void *p;
+  long l;
+  double d;
+} hts_arena_align;
+
+typedef struct hts_arena_chunk hts_arena_chunk;
+
+struct hts_arena_chunk {
+  hts_arena_chunk *next;
+};
+
+typedef struct {
+  hts_arena_chunk *chunks; /* newest first; allocations are cut from it */
+  size_t size;             /* the newest chunk, used of size bytes taken */
+  size_t used;
+} hts_arena;
+
+#define HTS_ARENA_ALIGN sizeof(hts_arena_align)
+
+/* Smallest chunk, then doubling up to the largest, so an arena holding a lot
+   keeps few chunks and one holding little wastes none. */
+#define HTS_ARENA_MIN 32768
+#define HTS_ARENA_MAX (16 * 1024 * 1024)
+
+/* First aligned offset past the chunk header, where its bytes begin. */
+#define HTS_ARENA_HDR                                                          \
+  ((sizeof(hts_arena_chunk) + HTS_ARENA_ALIGN - 1) &                           \
+   ~(size_t) (HTS_ARENA_ALIGN - 1))
+
+/* SIZE rounded up to the arena's alignment, or 0 if that would wrap. */
+static HTS_INLINE HTS_UNUSED size_t hts_arena_round_(size_t size) {
+  return size <= (size_t) -1 - (HTS_ARENA_ALIGN - 1)
+             ? (size + HTS_ARENA_ALIGN - 1) & ~(size_t) (HTS_ARENA_ALIGN - 1)
+             : 0;
+}
+
+/* Take a chunk with room for NEED bytes; ARENA is unchanged on failure. */
+static HTS_UNUSED hts_boolean hts_arena_grow_(hts_arena *arena, size_t need) {
+  size_t size = arena->size < HTS_ARENA_MAX / 2 ? arena->size * 2
+                                                : (size_t) HTS_ARENA_MAX;
+  hts_arena_chunk *chunk;
+
+  if (size < HTS_ARENA_MIN)
+    size = HTS_ARENA_MIN;
+  if (size < need)
+    size = need;
+  if (size > (size_t) -1 - HTS_ARENA_HDR)
+    return HTS_FALSE;
+  chunk = (hts_arena_chunk *) malloct(HTS_ARENA_HDR + size);
+  if (chunk == NULL)
+    return HTS_FALSE;
+  chunk->next = arena->chunks;
+  arena->chunks = chunk;
+  arena->size = size;
+  arena->used = 0;
+  return HTS_TRUE;
+}
+
+/* SIZE bytes from ARENA, aligned for any type, or NULL when out of memory.
+   The address stays valid until hts_arena_free(). */
+static HTS_UNUSED void *hts_arena_alloc(hts_arena *arena, size_t size) {
+  const size_t need = hts_arena_round_(size);
+
+  if (need == 0 && size != 0) /* the rounding wrapped */
+    return NULL;
+  /* need alone on one side: used never passes size, so the difference holds */
+  if (arena->chunks == NULL || need > arena->size - arena->used) {
+    if (!hts_arena_grow_(arena, need))
+      return NULL;
+  }
+  arena->used += need;
+  return (char *) arena->chunks + HTS_ARENA_HDR + arena->used - need;
+}
+
+/* A copy of S in ARENA, or NULL when out of memory. */
+static HTS_UNUSED char *hts_arena_strdup(hts_arena *arena, const char *s) {
+  const size_t len = strlen(s) + 1;
+  char *const copy = (char *) hts_arena_alloc(arena, len);
+
+  if (copy != NULL)
+    memcpy(copy, s, len);
+  return copy;
+}
+
+/* Release every chunk, and with them everything the arena handed out. */
+static HTS_UNUSED void hts_arena_free(hts_arena *arena) {
+  hts_arena_chunk *chunk = arena->chunks;
+
+  while (chunk != NULL) {
+    hts_arena_chunk *const next = chunk->next;
+
+    freet(chunk);
+    chunk = next;
+  }
+  memset(arena, 0, sizeof(*arena));
+}
+
+#endif

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -68,6 +68,7 @@ Please visit our Website: http://www.httrack.com
 
 /* Dynamic typed arrays */
 #include "htsarrays.h"
+#include "htsarena.h"
 
 /* END specific definitions */
 
@@ -200,58 +201,22 @@ struct lien_buffers {
   /* Main array of pointers. 
      This is the real "lien_url **liens" pointer base. */
   TypedArray(lien_url*) ptr;
-  /* String pool, chunked. */
-  char *string_buffer;
-  size_t string_buffer_size;
-  size_t string_buffer_capa;
-  TypedArray(char*) string_buffers;
-  /* Structure list, chunked. */
-  lien_url *lien_buffer;
-  size_t lien_buffer_size;
-  size_t lien_buffer_capa;
-  TypedArray(lien_url*) lien_buffers;
+  /* Strings and structures both live where their addresses cannot move: the
+     entries below point into them. */
+  hts_arena strings;
+  hts_arena liens;
 };
 
 // duplicate a string, or return NULL upon error (out-of-memory)
-static char* hts_record_link_strdup_(httrackp *opt, const char *s) {
-  static const size_t block_capa = 32768;
+static char *hts_record_link_strdup_(httrackp *opt, const char *s) {
   lien_buffers *const liensbuf = opt->liensbuf;
-  const size_t len = strlen(s) + 1;  /* including terminating \0 */
   char *s_dup;
 
   assertf(liensbuf != NULL);
-  assertf(len < block_capa);
-
-  // not enough capacity ? then create a new chunk
-  if (len + liensbuf->string_buffer_size > liensbuf->string_buffer_capa) {
-    // backup current block pointer for later free
-    if (liensbuf->string_buffer != NULL) {
-      TypedArrayAdd(liensbuf->string_buffers, liensbuf->string_buffer);
-      liensbuf->string_buffer = NULL;
-      liensbuf->string_buffer_size = 0;
-    }
-
-    // Double capacity for each new chained block
-    liensbuf->string_buffer_capa = 
-      liensbuf->string_buffer_capa < block_capa 
-      ? block_capa : liensbuf->string_buffer_capa * 2;
-
-    liensbuf->string_buffer = malloct(liensbuf->string_buffer_capa);
-    if (liensbuf->string_buffer == NULL) {
-      hts_record_assert_memory_failed(liensbuf->string_buffer_capa);
-    }
-    liensbuf->string_buffer_size = 0;
-
-    hts_log_print(opt, LOG_DEBUG,
-      "reallocated %d new bytes of strings room",
-      (int) liensbuf->string_buffer_capa);
+  s_dup = hts_arena_strdup(&liensbuf->strings, s);
+  if (s_dup == NULL) {
+    hts_record_assert_memory_failed(strlen(s) + 1);
   }
-
-  assertf(len + liensbuf->string_buffer_size <= liensbuf->string_buffer_capa);
-  s_dup = &liensbuf->string_buffer[liensbuf->string_buffer_size];
-  memcpy(s_dup, s, len);
-  liensbuf->string_buffer_size += len;
-  
   return s_dup;
 }
 
@@ -272,7 +237,6 @@ size_t hts_record_link_latest(httrackp *opt) {
 // or (size_t) -1 upon error (out-of-memory)
 // the returned index is the osset within opt->liens[]
 static size_t hts_record_link_alloc(httrackp *opt) {
-  static const size_t block_capa = 256;
   lien_buffers *const liensbuf = opt->liensbuf;
   lien_url *link;
 
@@ -284,35 +248,11 @@ static size_t hts_record_link_alloc(httrackp *opt) {
     return (size_t) -1;
   }
 
-  // Create a new chunk of lien_url[]
-  // There are references to item pointers, so we can not just realloc()
-  if (liensbuf->lien_buffer_size == liensbuf->lien_buffer_capa) {
-    size_t capa_bytes;
-
-    if (liensbuf->lien_buffer != NULL) {
-      TypedArrayAdd(liensbuf->lien_buffers, liensbuf->lien_buffer);
-      liensbuf->lien_buffer_size = 0;
-    }
-
-    // Double capacity for each new chained block
-    liensbuf->lien_buffer_capa = 
-      liensbuf->lien_buffer_capa < block_capa 
-      ? block_capa : liensbuf->lien_buffer_capa * 2;
-
-    capa_bytes = liensbuf->lien_buffer_capa*sizeof(*liensbuf->lien_buffer);
-    liensbuf->lien_buffer = (lien_url*) malloct(capa_bytes);
-    if (liensbuf->lien_buffer == NULL) {
-      hts_record_assert_memory_failed(capa_bytes);
-    }
-    liensbuf->lien_buffer_size = 0;
-
-    hts_log_print(opt, LOG_DEBUG, "reallocated %d new link placeholders",
-      (int) liensbuf->lien_buffer_capa);
+  // The entries are pointed at from elsewhere, so they must keep their address
+  link = (lien_url *) hts_arena_alloc(&liensbuf->liens, sizeof(*link));
+  if (link == NULL) {
+    hts_record_assert_memory_failed(sizeof(*link));
   }
-
-  // Take next lien_url item
-  assertf(liensbuf->lien_buffer_size < liensbuf->lien_buffer_capa);
-  link = &liensbuf->lien_buffer[liensbuf->lien_buffer_size++];
   memset(link, 0, sizeof(*link));
 
   // Add new lien_url pointer to the array of links
@@ -347,33 +287,10 @@ void hts_record_free(httrackp *opt) {
   lien_buffers *const liensbuf = opt->liensbuf;
 
   if (liensbuf != NULL) {
-    size_t i;
-
     TypedArrayFree(liensbuf->ptr);
 
-    if (liensbuf->string_buffer != NULL) {
-      freet(liensbuf->string_buffer);
-      liensbuf->string_buffer = NULL;
-      liensbuf->string_buffer_size = 0;
-      liensbuf->string_buffer_capa = 0;
-    }
-
-    for(i = 0 ; i < TypedArraySize(liensbuf->string_buffers) ; i++) {
-      freet(TypedArrayNth(liensbuf->string_buffers, i));
-      TypedArrayNth(liensbuf->string_buffers, i) = NULL;
-    }
-    TypedArrayFree(liensbuf->string_buffers);
-
-    if (liensbuf->lien_buffer != NULL) {
-      freet(liensbuf->lien_buffer);
-      liensbuf->lien_buffer = NULL;
-    }
-
-    for(i = 0 ; i < TypedArraySize(liensbuf->lien_buffers) ; i++) {
-      freet(TypedArrayNth(liensbuf->lien_buffers, i));
-      TypedArrayNth(liensbuf->lien_buffers, i) = NULL;
-    }
-    TypedArrayFree(liensbuf->lien_buffers);
+    hts_arena_free(&liensbuf->strings);
+    hts_arena_free(&liensbuf->liens);
 
     freet(opt->liensbuf);
     opt->liensbuf = NULL;

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -224,7 +224,7 @@ HTSEXT_API int hts_main2(int argc, char **argv, httrackp * opt) {
 
 static int hts_main_internal(int argc, char **argv, httrackp * opt) {
   /* command line rebuilt from argv, config files and doit.log */
-  cmdl_argv x_cmd = {NULL, 0, 0, NULL, 0, 0};
+  cmdl_argv x_cmd = {NULL, 0, 0, {NULL, 0, 0}};
 
   //
   int argv_url = -1;            // ==0 : utiliser cache et doit.log
@@ -312,19 +312,10 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
   }
 
   /* create the token block for the transformed command line */
-  {
-    size_t current_size = 0;
-    int na;
-
-    for(na = 0; na < argc; na++)
-      current_size += strlen(argv[na]) + 1;
-    /* the current argv and argc slots to start with; alias expansion, the
-       config files and doit.log grow both */
-    if (!cmdl_init(&x_cmd, current_size, argc)) {
-      HTS_PANIC_PRINTF("Error, not enough memory");
-      htsmain_free();
-      return -1;
-    }
+  if (!cmdl_init(&x_cmd, argc)) {
+    HTS_PANIC_PRINTF("Error, not enough memory");
+    htsmain_free();
+    return -1;
   }
 
   /* Create new argc/argv, replace alias, count URLs, treat -h, -q, -i */
@@ -834,7 +825,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
       if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
                               StringBuff(opt->path_log),
                               "hts-cache/doit.log"))) { // un cache est présent
-        if (x_cmd.chunks != NULL) {
+        if (x_cmd.tokens.chunks != NULL) {
           int m;
 
           // établir mode - mode cache: 1 (cache valide) 2 (cache à vérifier)

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1737,6 +1737,56 @@ static int array_growth_selftests(void) {
   return err;
 }
 
+/* The arena's promise is that what it hands out never moves, so this keeps
+   every pointer it returns and re-reads them all at the end. */
+static int st_arena(httrackp *opt, int argc, char **argv) {
+  enum { count = 4096 };
+
+  hts_arena arena = {NULL, 0, 0};
+  char **kept = (char **) calloct(count, sizeof(*kept));
+  char BIGSTK big[HTS_ARENA_MIN * 2];
+  char token[256];
+  int i;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+  assertf(kept != NULL);
+
+  /* Enough tokens to span many chunks, each holding its own index. */
+  for (i = 0; i < count; i++) {
+    snprintf(token, sizeof(token), "%d-%*s", i, 200, "x");
+    kept[i] = hts_arena_strdup(&arena, token);
+    assertf(kept[i] != NULL);
+  }
+  /* One allocation larger than a whole chunk takes one of its own. */
+  memset(big, 'b', sizeof(big) - 1);
+  big[sizeof(big) - 1] = '\0';
+  assertf(hts_arena_strdup(&arena, big) != NULL);
+  /* An aligned allocation is aligned whatever the byte-sized ones did to it. */
+  for (i = 0; i < 8; i++) {
+    void *const p = hts_arena_alloc(&arena, sizeof(hts_arena_align));
+
+    assertf(p != NULL);
+    assertf(((size_t) (char *) p) % HTS_ARENA_ALIGN == 0);
+    assertf(hts_arena_strdup(&arena, "x") != NULL);
+  }
+  /* Nothing moved: every token still reads back as itself. */
+  for (i = 0; i < count; i++) {
+    snprintf(token, sizeof(token), "%d-%*s", i, 200, "x");
+    assertf(strcmp(kept[i], token) == 0);
+  }
+  /* A size that would wrap when rounded up is refused, not truncated. */
+  assertf(hts_arena_alloc(&arena, (size_t) -1) == NULL);
+
+  freet(kept);
+  hts_arena_free(&arena);
+  assertf(arena.chunks == NULL && arena.size == 0 && arena.used == 0);
+  hts_arena_free(&arena); /* releasing an empty arena is a no-op */
+  printf("arena self-test OK\n");
+  return 0;
+}
+
 static int st_arrays(httrackp *opt, int argc, char **argv) {
   /* volatile keeps the sizes below opaque, so these stay runtime checks rather
      than compile-time allocation warnings. */
@@ -9500,6 +9550,7 @@ static const struct selftest_entry {
      "bounded string-op self-test", st_strsafe},
     {"strsprintf", "", "StringSprintf grows to fit at every capacity boundary",
      st_strsprintf},
+    {"arena", "", "htsarena.h hands out addresses that never move", st_arena},
     {"arrays", "[overflow-capa|overflow-loop]",
      "htsarrays.h growth reaches the requested room, overflow aborts",
      st_arrays},

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1776,8 +1776,19 @@ static int st_arena(httrackp *opt, int argc, char **argv) {
     snprintf(token, sizeof(token), "%d-%*s", i, 200, "x");
     assertf(strcmp(kept[i], token) == 0);
   }
-  /* A size that would wrap when rounded up is refused, not truncated. */
+  /* A size no allocation could hold is refused, not truncated. */
   assertf(hts_arena_alloc(&arena, (size_t) -1) == NULL);
+  /* Strings are packed: alignment is charged where it is needed, not to every
+     allocation, which would cost several bytes on each link a mirror records.
+   */
+  {
+    hts_arena packed = {NULL, 0, 0};
+    const char *const a = hts_arena_strdup(&packed, "abc");
+    const char *const b = hts_arena_strdup(&packed, "de");
+
+    assertf(a != NULL && b == a + sizeof("abc"));
+    hts_arena_free(&packed);
+  }
 
   freet(kept);
   hts_arena_free(&arena);

--- a/tests/285_engine-arena.test
+++ b/tests/285_engine-arena.test
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+# htsarena.h, the pool the link records and the rebuilt command line hold raw
+# pointers into (driven by 'httrack -#test=arena'). It keeps every address it
+# is handed across thousands of allocations and re-reads them all, so a pool
+# that grew by moving its bytes fails here rather than in a crawl.
+assert_selftest "arena self-test OK" arena
+
+exit 0


### PR DESCRIPTION
htscore.c grew two chunked pools, one for link strings and one for `lien_url` records, and #1205 added a third for the rebuilt command line. All three exist for the reason one of their own comments states: "There are references to item pointers, so we can not just realloc()". All three picked 32768. The growable primitives the tree already has are no substitute, since `String` and `TypedArray` move their contents and coucal's pool rebases its keys on purpose.

`htsarena.h` is that pool written once: chunks that are never resized, doubling to a ceiling, with the alignment and the overflow guards in one place instead of three. Two limits disappear with the hand-rolled version, both in the string pool: the 32 KB cap on a single link string, and the assert that aborted on a longer one.

The risk here is the link path rather than the arithmetic, since every recorded link allocates from both pools. Test 285 pins the property the callers actually depend on, holding 4096 addresses across many chunk changes and re-reading them all, and the suite is green under ASan/UBSan.

Closes #1207
