### PR TITLE
Three compile-time rules, three spellings

### DIFF
--- a/src/htsarena.h
+++ b/src/htsarena.h
@@ -66,9 +66,7 @@ typedef struct {
 
 /** The padding below assumes a power of two, and a header that is already a
     multiple of it; neither can change without this failing to compile. **/
-typedef char hts_arena_align_is_pow2_[(HTS_ARENA_ALIGN & (HTS_ARENA_ALIGN - 1))
-                                          ? -1
-                                          : 1];
+HTS_STATIC_ASSERT(!(HTS_ARENA_ALIGN & (HTS_ARENA_ALIGN - 1)), arena_align_pow2);
 
 /** First aligned offset past the chunk header, where its bytes begin. **/
 #define HTS_ARENA_HDR                                                          \
@@ -97,8 +95,7 @@ static HTS_UNUSED hts_boolean hts_arena_grow_(hts_arena *arena, size_t need) {
   return HTS_TRUE;
 }
 
-typedef char
-    hts_arena_hdr_is_aligned_[(HTS_ARENA_HDR % HTS_ARENA_ALIGN) ? -1 : 1];
+HTS_STATIC_ASSERT(HTS_ARENA_HDR % HTS_ARENA_ALIGN == 0, arena_hdr_aligned);
 
 /** SIZE bytes from ARENA, starting on an ALIGN boundary (a power of two), or
     NULL when out of memory. Padding is charged where it is needed rather than

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -276,6 +276,11 @@ typedef int hts_tristate;
 /* Compile-time check, usable as an expression. */
 #define HTS_COMPILE_ASSERT(cond) ((void) sizeof(char[(cond) ? 1 : -1]))
 
+/* The same where a declaration goes, which is where a rule tying constants
+   together belongs. NAME is what the diagnostic points at. Takes a ';'. */
+#define HTS_STATIC_ASSERT(cond, name)                                          \
+  enum { hts_static_assert_##name = 1 / !!(cond) }
+
 /* 'inline' where the dialect supports it (C++), nothing in plain C. */
 #ifdef __cplusplus
 #define HTS_INLINE inline

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -3146,15 +3146,12 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                             char sf_mark[SINGLEFILE_MARK_MAX];
 
                             /* SINGLEFILE_MAX_SPAN is derived from these two
-                               buffers, so a resize must move it: divide by zero
-                               here rather than silently stop marking. */
-                            enum {
-                              sf_span_fits =
-                                  1 /
-                                  (sizeof(tempo) * HTS_HTMLESCAPE_FULL_MAXEXP +
-                                       sizeof(lien) * HTS_HTMLESCAPE_MAXEXP <=
-                                   SINGLEFILE_MAX_SPAN)
-                            };
+                               buffers, so a resize must move it. */
+                            HTS_STATIC_ASSERT(
+                                sizeof(tempo) * HTS_HTMLESCAPE_FULL_MAXEXP +
+                                        sizeof(lien) * HTS_HTMLESCAPE_MAXEXP <=
+                                    SINGLEFILE_MAX_SPAN,
+                                sf_span_fits);
 
                             HT_ADD(singlefile_mark(
                                 opt, sf_mark, sizeof(sf_mark), sf_class,


### PR DESCRIPTION
Three constants were pinned at compile time in three different ways: an enum dividing by zero in htsparse.c (#1080), and two negative-array typedefs added with the arena in #1212. `htsglobal.h` already carried `HTS_COMPILE_ASSERT` for the expression case, so this puts the declaration case next to it and moves all three onto it.

The enum form is the one that stays, per your call. It reads better at a declaration and it is what the tree already used.

Each rule was checked by breaking what it guards rather than by inspection: padding `hts_arena_align` to a size that is not a power of two stops the build on both arena rules, and shrinking `SINGLEFILE_MAX_SPAN` stops it on the parse one. A rule that cannot fail is worse than none.
