### PR TITLE
A build path containing "assert" or "panic" fails the crawl tests

### DIFF
--- a/tests/260_crawl-harness-fails-loudly.test
+++ b/tests/260_crawl-harness-fails-loudly.test
@@ -49,4 +49,21 @@ test "$rc" -ne 0 || fail "a wrong file count reported success: $out"
 assert_match "expected '999'" "$out" "the audit names the value it wanted"
 ok "a failing audit fails the run"
 
+# The log audits read what the mirror wrote, not the banner above it: that line
+# carries the engine's whole command line, so every path the run was given is in
+# it (#1220). TMPDIR puts a searched word in one of them.
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_logbody.XXXXXX") || exit 1
+cleanup_push rm -rf "$tmp"
+mkdir -p "$tmp/assert-and-panic"
+rc=0
+out=$(TMPDIR="$tmp/assert-and-panic" bash "$crawl" --errors 0 \
+    --log-not-found 'assert|[Pp]anic' httrack "$url" 2>&1) || rc=$?
+test "$rc" -eq 0 || fail "the audit matched the path the crawl ran from: $out"
+ok "a log audit ignores the command line the banner echoes"
+
+# Teeth: it still reads the body, or the line above would pass on anything.
+run --errors 0 --log-not-found 'Information, Warnings and Errors' httrack "$url"
+test "$rc" -ne 0 || fail "a log audit matched nothing in the body: $out"
+ok "a log audit still sees what the mirror wrote"
+
 echo "PASS"

--- a/tests/260_crawl-harness-fails-loudly.test
+++ b/tests/260_crawl-harness-fails-loudly.test
@@ -49,9 +49,8 @@ test "$rc" -ne 0 || fail "a wrong file count reported success: $out"
 assert_match "expected '999'" "$out" "the audit names the value it wanted"
 ok "a failing audit fails the run"
 
-# The log audits read what the mirror wrote, not the banner above it: that line
-# carries the engine's whole command line, so every path the run was given is in
-# it (#1220). TMPDIR puts a searched word in one of them.
+# A directory named after a searched word must not answer for the crawl (#1220):
+# TMPDIR plants one on the command line the log echoes.
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_logbody.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmp"
 mkdir -p "$tmp/assert-and-panic"
@@ -65,5 +64,12 @@ ok "a log audit ignores the command line the banner echoes"
 run --errors 0 --log-not-found 'Information, Warnings and Errors' httrack "$url"
 test "$rc" -ne 0 || fail "a log audit matched nothing in the body: $out"
 ok "a log audit still sees what the mirror wrote"
+
+# And the banner, which only the echo below it is skipped: dropping both is the
+# mistake this fix was written twice to avoid. 14_local-https covers it only
+# where TLS is built.
+run --errors 0 --log-found 'launched on' httrack "$url"
+test "$rc" -eq 0 || fail "a log audit stopped seeing the banner: $out"
+ok "a log audit still sees the launch banner"
 
 echo "PASS"

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -143,6 +143,13 @@ function assert_equals {
 nopurge=
 cleanup_push purge_tmpdir
 
+# What the mirror itself wrote. Line 2 echoes the engine's whole command line,
+# absolute paths included, so a build or output directory named after a searched
+# word would otherwise answer for the crawl (#1220). The banner above it stays:
+# it names the URL, which audits do match. Left in place if it ever stops
+# looking like that echo, since hiding a real match is the worse failure.
+log_body() { awk 'NR == 2 && /^\(/ { next } { print }' "${logroot}/hts-log.txt"; }
+
 # python3 is required; mirror check-network.sh's skip-with-77 convention. Found
 # here, not in local_server_start, so a host without it skips before any setup.
 python=$(find_python) || ! echo "python3 not found; skipping local crawl tests" >&2 || exit 77
@@ -151,6 +158,7 @@ SRV_PYTHON=$python
 tmptopdir=${TMPDIR:-/tmp}
 test -d "$tmptopdir" || mkdir -p "$tmptopdir" || die "no temporary directory; set TMPDIR"
 tmpdir=$(mktemp -d "${tmptopdir}/httrack_local.XXXXXX") || die "could not create tmpdir"
+logbody="${tmpdir}/hts-log-body.txt"
 
 # --- parse leading control flags --------------------------------------------
 declare -a audit=()
@@ -660,7 +668,8 @@ while test "$i" -lt "${#audit[@]}"; do
     --log-found)
         i=$((i + 1))
         info "checking log matches ${audit[$i]}"
-        if grep -aqE "${audit[$i]}" "${logroot}/hts-log.txt"; then result "OK"; else
+        log_body >"$logbody"
+        if grep -aqE "${audit[$i]}" "$logbody"; then result "OK"; else
             result "not in log"
             exit 1
         fi
@@ -668,7 +677,8 @@ while test "$i" -lt "${#audit[@]}"; do
     --log-not-found)
         i=$((i + 1))
         info "checking log lacks ${audit[$i]}"
-        if grep -aqE "${audit[$i]}" "${logroot}/hts-log.txt"; then
+        log_body >"$logbody"
+        if grep -aqE "${audit[$i]}" "$logbody"; then
             result "present in log"
             exit 1
         else result "OK"; fi

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -143,11 +143,8 @@ function assert_equals {
 nopurge=
 cleanup_push purge_tmpdir
 
-# What the mirror itself wrote. Line 2 echoes the engine's whole command line,
-# absolute paths included, so a build or output directory named after a searched
-# word would otherwise answer for the crawl (#1220). The banner above it stays:
-# it names the URL, which audits do match. Left in place if it ever stops
-# looking like that echo, since hiding a real match is the worse failure.
+# Line 2 echoes the engine's command line, so a path named after a searched word
+# would answer for the crawl (#1220). The banner stays: audits match its URL.
 log_body() { awk 'NR == 2 && /^\(/ { next } { print }' "${logroot}/hts-log.txt"; }
 
 # python3 is required; mirror check-network.sh's skip-with-77 convention. Found


### PR DESCRIPTION
`hts-log.txt` line 2 echoes the engine's whole command line, absolute paths included, and `--log-found` / `--log-not-found` grepped the file whole. So every path the run was given was part of the text being searched. `36_local-bigcrawl` looks for `not cached|[Pp]anic|assert`, which made it fail for anyone whose build directory contains one of those words, with no hint as to why.

Only that line is skipped, not the banner above it: the banner names the URL, and `14_local-https` matches it. The first cut dropped both and broke that test, so 260 now pins the banner as well as the body.

Closes #1220
