### PR TITLE
Nothing pins the host-alias bytes WinHTTrack now depends on

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3935,6 +3935,10 @@ static int st_hostalias(httrackp *opt, int argc, char **argv) {
   assertf(!hts_host_alias_rule_ok("b.com=a.com\f"));
   assertf(!hts_host_alias_rule_ok("b.com=a\x7f.com"));
   assertf(!hts_host_alias_rule_ok("b\v.com=a.com"));
+  /* a high byte is a host in some local charset, not a control byte */
+  assertf(hts_host_alias_rule_ok("caf\xe9.example.com=h\xf4tel.example.com"));
+  /* an alias may lead with '-': why case 'C' carries no dash guard (#1179) */
+  assertf(hts_host_alias_rule_ok("-legacy.example.com=example.com"));
   assertf(!hts_host_alias_rule_ok("b.com=x://a.com"));
   assertf(!hts_host_alias_rule_ok("b.com=a.com://c.com"));
   assertf(hts_host_alias_rule_ok("b.com=ftp://a.com"));


### PR DESCRIPTION
`hts_host_alias_rule_ok` accepts bytes 0x80-0xFF inside a host, and lets an alias start with `-`. Both are deliberate: the high bytes are a host written in some local charset, and the leading dash is why the `--host-alias` argv case carries no dash guard (#1179). Neither was pinned by a test, so tightening the byte filter would stay green here while breaking WinHTTrack, which dropped its mirrored copy of the grammar for this exported validator in httrack-windows#109.

Two rows in the hostalias self-test, each killed by its own mutant: rejecting bytes >= 0x7f fails the first, rejecting a leading `-` fails the second.