### PR TITLE
The Windows watchdog test calls a reaped ping a survivor

### DIFF
--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -135,9 +135,8 @@ done
 printf '#!/bin/sh\necho "TOKEN=${WATCHDOG_TOKEN:-}" >%s\nexit 0\n' "$tmp/childtoken" \
     >"$run/10_engine-pass.test"
 printf '#!/bin/sh\nexit 77\n' >"$run/11_engine-skip.test"
-# Intermittent, and chatty on the re-run: the trace appends to the failing run's
-# log, so only a stub that passes the second time and outruns the 25-line tail
-# can tell a report that kept the failure from one that kept the trace.
+# Intermittent and chatty on the re-run: only a stub that passes the second time
+# and outruns the 25-line tail can tell a kept failure from a kept trace.
 cat >"$run/12_engine-fail.test" <<EOF
 #!/bin/sh
 if test -e "$tmp/failedonce"; then
@@ -169,12 +168,17 @@ grep -q '^ran=12 pass=10 fail=1 skip=1$' <<<"$out" ||
 grep -q '::error::only 10 tests passed (1 skipped)' <<<"$out" ||
     fail "the pass floor did not report the count"
 grep -q 'FAIL 12_engine-fail.test (exit 3)' <<<"$out" || fail "the failing test was not named"
-# The report has to carry the run that failed. The trace is kept too, but it is
-# the one that passed here, so a report built from it alone says nothing.
-grep -q 'the first run said so' <<<"$out" ||
-    fail "the failing run's tail was lost to the traced re-run"
+# The report has to carry the run that failed, not just the trace that passed,
+# and carry it under its own label: reported after the separator it reads as
+# part of the trace. Captured, since a pipe would take grep -q's SIGPIPE.
 grep -q -- '--- traced re-run ---' <<<"$out" || fail "the traced re-run was not reported"
+first=$(sed -n '1,/--- traced re-run ---/p' <<<"$out")
+grep -q 'the first run said so' <<<"$first" ||
+    fail "the failing run's tail was lost to the traced re-run"
 grep -q 'trace line 39' <<<"$out" || fail "the traced re-run's own tail was dropped"
+# Both halves stay tails: an unbounded report would carry the trace's first line
+# as well as its last, and a CI failure would print the whole log.
+grep -q 'trace line 0$' <<<"$out" && fail "the report is not bounded to a tail"
 
 # This launches the watchdog the way the real driver does, not through a test
 # sourcing the helper, proving it starts and holds a token nothing else sees.

--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -135,7 +135,23 @@ done
 printf '#!/bin/sh\necho "TOKEN=${WATCHDOG_TOKEN:-}" >%s\nexit 0\n' "$tmp/childtoken" \
     >"$run/10_engine-pass.test"
 printf '#!/bin/sh\nexit 77\n' >"$run/11_engine-skip.test"
-printf '#!/bin/sh\nexit 3\n' >"$run/12_engine-fail.test"
+# Intermittent, and chatty on the re-run: the trace appends to the failing run's
+# log, so only a stub that passes the second time and outruns the 25-line tail
+# can tell a report that kept the failure from one that kept the trace.
+cat >"$run/12_engine-fail.test" <<EOF
+#!/bin/sh
+if test -e "$tmp/failedonce"; then
+    i=0
+    while [ \$i -lt 40 ]; do
+        echo "trace line \$i"
+        i=\$((i + 1))
+    done
+    exit 0
+fi
+: >"$tmp/failedonce"
+echo "the first run said so"
+exit 3
+EOF
 cd "$run"
 rc=0
 out=$(RUNNER_TEMP="$tmp" GITHUB_STEP_SUMMARY="$tmp/summary" WATCHDOG_TOKEN=s3cr3t \
@@ -153,6 +169,12 @@ grep -q '^ran=12 pass=10 fail=1 skip=1$' <<<"$out" ||
 grep -q '::error::only 10 tests passed (1 skipped)' <<<"$out" ||
     fail "the pass floor did not report the count"
 grep -q 'FAIL 12_engine-fail.test (exit 3)' <<<"$out" || fail "the failing test was not named"
+# The report has to carry the run that failed. The trace is kept too, but it is
+# the one that passed here, so a report built from it alone says nothing.
+grep -q 'the first run said so' <<<"$out" ||
+    fail "the failing run's tail was lost to the traced re-run"
+grep -q -- '--- traced re-run ---' <<<"$out" || fail "the traced re-run was not reported"
+grep -q 'trace line 39' <<<"$out" || fail "the traced re-run's own tail was dropped"
 
 # This launches the watchdog the way the real driver does, not through a test
 # sourcing the helper, proving it starts and holds a token nothing else sees.

--- a/tests/58_watchdog.test
+++ b/tests/58_watchdog.test
@@ -41,13 +41,22 @@ if is_windows; then
     # Existence by exact Windows PID, not a global ping.exe count: the timing
     # sub-test above leaves a still-dying ping that a count would race. Plain
     # tasklist, no switches (the workflow's MSYS2_ARG_CONV_EXCL='*' mangles a
-    # //FI filter arg into a silent no-match); $1 is the image, $2 the PID.
-    # The image has to match too: Windows hands a freed PID straight back out,
-    # and under the parallel suite the next taker reads as our survivor.
+    # //FI filter arg into a silent no-match); $2 is the PID, and $1 must be
+    # ping.exe too, since Windows hands a freed PID straight back out. Folded
+    # case, as the tasklist matchers in proclib.sh already are.
     alive() {
         tasklist 2>/dev/null |
-            awk -v p="$1" '$1 == "ping.exe" && $2 == p {f = 1} END {exit !f}'
+            awk -v p="$1" 'tolower($1) == "ping.exe" && $2 == p {f = 1} END {exit !f}'
     }
+    # alive() is a conjunction now, and one that never matches would call every
+    # survivor reaped. Prove it fires on a live ping, reached the same way.
+    ping -n 20 127.0.0.1 >/dev/null 2>&1 &
+    cpid=$!
+    cw=$(cat "/proc/$cpid/winpid" 2>/dev/null)
+    test -n "$cw" || fail "could not read a live ping's Windows PID"
+    alive "$cw" || fail "alive() cannot see a running ping.exe (pid $cw)"
+    kill_tree "$cpid" "$cw"
+    wait "$cpid" 2>/dev/null || true
     # The grandchild ping records its own Windows PID: non-empty proves it ran
     # (positive control, so the reap check can't pass vacuously), then it must go.
     gw="$tmp/gcwinpid"
@@ -58,9 +67,8 @@ if is_windows; then
     test "$rc" -eq 124 || fail "grandchild hang reported $rc"
     w=$(cat "$gw" 2>/dev/null)
     test -n "$w" || fail "positive control: grandchild ping never started"
-    # taskkill returns before Windows has torn the process down, so poll instead
-    # of sleeping once. An orphan keeps pinging for ~29s, well past this window,
-    # so waiting cannot turn a real survivor into a pass.
+    # Poll, not one sleep: taskkill returns before the teardown finishes. An
+    # orphan pings for ~29s, past REAP_GRACE, so waiting cannot hide a survivor.
     start=$SECONDS
     while alive "$w" && test "$((SECONDS - start))" -lt "$REAP_GRACE"; do sleep 1; done
     ! alive "$w" || fail "native ping grandchild (pid $w) survived the watchdog"

--- a/tests/58_watchdog.test
+++ b/tests/58_watchdog.test
@@ -41,8 +41,13 @@ if is_windows; then
     # Existence by exact Windows PID, not a global ping.exe count: the timing
     # sub-test above leaves a still-dying ping that a count would race. Plain
     # tasklist, no switches (the workflow's MSYS2_ARG_CONV_EXCL='*' mangles a
-    # //FI filter arg into a silent no-match); $2 is the PID column.
-    alive() { tasklist 2>/dev/null | awk -v p="$1" '$2 == p {f = 1} END {exit !f}'; }
+    # //FI filter arg into a silent no-match); $1 is the image, $2 the PID.
+    # The image has to match too: Windows hands a freed PID straight back out,
+    # and under the parallel suite the next taker reads as our survivor.
+    alive() {
+        tasklist 2>/dev/null |
+            awk -v p="$1" '$1 == "ping.exe" && $2 == p {f = 1} END {exit !f}'
+    }
     # The grandchild ping records its own Windows PID: non-empty proves it ran
     # (positive control, so the reap check can't pass vacuously), then it must go.
     gw="$tmp/gcwinpid"
@@ -53,7 +58,11 @@ if is_windows; then
     test "$rc" -eq 124 || fail "grandchild hang reported $rc"
     w=$(cat "$gw" 2>/dev/null)
     test -n "$w" || fail "positive control: grandchild ping never started"
-    sleep 1
+    # taskkill returns before Windows has torn the process down, so poll instead
+    # of sleeping once. An orphan keeps pinging for ~29s, well past this window,
+    # so waiting cannot turn a real survivor into a pass.
+    start=$SECONDS
+    while alive "$w" && test "$((SECONDS - start))" -lt "$REAP_GRACE"; do sleep 1; done
     ! alive "$w" || fail "native ping grandchild (pid $w) survived the watchdog"
 else
     started="$tmp/started" marker="$tmp/alive"

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -268,6 +268,9 @@ run_one_test() (
         ;;
     *)
         echo "FAIL $t (exit $rc)"
+        # Kept before the trace below appends to the same log: on an
+        # intermittent failure the trace passes, and its tail reports a pass.
+        tail -n 25 "$t.log" | sed 's/^/      /' >"$results/$t.tail"
         # These assert with `test "$(...)" == "..." || exit 1`, which
         # says nothing at all on failure. Re-run traced, still bounded.
         # Charged to the suite deadline rather than given a budget of its
@@ -282,10 +285,12 @@ run_one_test() (
             # Handed the same TMPDIR: the trace runs outside test-timeout.sh,
             # which is what gave the first run one of its own.
             TMPDIR="$ttmp" run_with_timeout "$left" bash -x "$t" >>"$t.log" 2>&1 || true
+            echo "      --- traced re-run ---" >>"$results/$t.tail"
+            tail -n 25 "$t.log" | sed 's/^/      /' >>"$results/$t.tail"
         else
-            echo "no trace: past the ${suite_deadline}s suite deadline" >>"$t.log"
+            echo "no trace: past the ${suite_deadline}s suite deadline" |
+                tee -a "$t.log" | sed 's/^/      /' >>"$results/$t.tail"
         fi
-        tail -n 25 "$t.log" | sed 's/^/      /' >"$results/$t.tail"
         ;;
     esac
     echo "$rc $t" >>"$progress"

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -268,8 +268,8 @@ run_one_test() (
         ;;
     *)
         echo "FAIL $t (exit $rc)"
-        # Kept before the trace below appends to the same log: on an
-        # intermittent failure the trace passes, and its tail reports a pass.
+        # Captured before the trace appends below, or an intermittent failure
+        # reports the tail of the re-run that passed.
         tail -n 25 "$t.log" | sed 's/^/      /' >"$results/$t.tail"
         # These assert with `test "$(...)" == "..." || exit 1`, which
         # says nothing at all on failure. Re-run traced, still bounded.


### PR DESCRIPTION
`58_watchdog` has failed the Win32 leg on every master push since the suite went parallel, and it is the only red in the suite. The grandchild check reads `tasklist` one second after the watchdog fires and asks whether the ping's PID is still listed. Neither half of that holds up under sixteen concurrent tests: `taskkill` returns before Windows has finished tearing the process down, and a PID it has already freed goes straight back out to whoever asks next. The check now matches the image name as well as the PID, and polls for it to go instead of sleeping once. An orphaned ping runs for about 29 seconds, so the `REAP_GRACE` window cannot turn a real survivor into a pass. That image match is a new conjunction, so a live ping controls it first: a predicate that never matches would call every survivor reaped.

The report made this hard to see. On a non-timeout failure the driver re-runs the test traced, appending to the same log, then reports the last 25 lines; for an intermittent failure those lines belong to the run that passed, so the tail under the `FAIL` line ended in `watchdog OK`. The failing run's tail is now taken before the trace can append, and both are reported under a label. `172_ci-windows-driver` grows an intermittent stub whose re-run outruns the 25-line window, and pins the order and the bound as well as the content; each of those assertions was checked against a driver mutated to break it.