### PR TITLE
Release 3.49.21

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.71])
 
-AC_INIT([httrack], [3.49.20], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
+AC_INIT([httrack], [3.49.21], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
 AC_COPYRIGHT([
 HTTrack Website Copier, Offline Browser for Windows and Unix
 Copyright (C) 1998-2015 Xavier Roche and other contributors
@@ -29,6 +29,8 @@ AC_CONFIG_SRCDIR(src/httrack.c)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
+# 3:14:0: revision-only bump. httrackp gained a tail field (host_alias) and #1202
+# added an export (hts_host_alias_rule_ok); no layout moved, nothing went away.
 # 3:13:0: revision-only bump. htsstrings.h's StringRoomTotal grew saturation in
 # its macro body; no installed struct moved and no export came or went.
 # 3:12:0: revision-only bump. httrackp gained a tail field (singlefile_state) and
@@ -44,7 +46,7 @@ AM_INIT_AUTOMAKE([subdir-objects])
 # moves nothing). Soname stays .so.3: HTTrackQt is the only consumer of the installed
 # headers, so a libhttrack4 rename isn't worth it.
 # (3:0:0 was the htsblk mime-buffer widening, the ABI break that moved .so.2 -> .so.3.)
-VERSION_INFO="3:13:0"
+VERSION_INFO="3:14:0"
 AM_MAINTAINER_MODE
 AC_USE_SYSTEM_EXTENSIONS
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,9 @@
 httrack (3.49.21-1) unstable; urgency=medium
 
-  * New upstream release: a new --host-alias option folds the several hostnames
-    of one site onto a single canonical host, plus fixes to mirror
-    interruption, to the --update purge and to several buffer overflows, and a
-    WebHTTrack wizard that reads its saved projects back correctly; full list
-    in history.txt.
+  * New upstream release: a site answering to several hostnames can now be
+    mirrored once rather than once per name, plus fixes to mirror
+    interruption, to an update pass that purged files it had never reached,
+    and to several buffer overflows; full list in history.txt.
 
  -- Xavier Roche <xavier@debian.org>  Wed, 12 Aug 2026 15:05:15 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+httrack (3.49.21-1) unstable; urgency=medium
+
+  * New upstream release: a new --host-alias option folds the several hostnames
+    of one site onto a single canonical host, plus fixes to mirror
+    interruption, to the --update purge and to several buffer overflows, and a
+    WebHTTrack wizard that reads its saved projects back correctly; full list
+    in history.txt.
+
+ -- Xavier Roche <xavier@debian.org>  Wed, 12 Aug 2026 15:05:15 +0200
+
 httrack (3.49.20-1) unstable; urgency=medium
 
   * New upstream release: an off-site link that looked like a file could pull

--- a/history.txt
+++ b/history.txt
@@ -4,6 +4,24 @@ HTTrack Website Copier release history:
 
 This file lists all changes and fixes that have been made for HTTrack
 
+3.49-21
++ New: --host-alias (-%C) folds the several hostnames of one site onto a single canonical host, so a site answering as both example.com and mirror.example.com is fetched once instead of once per name (#16)
++ New: the WebHTTrack wizard and the WinHTTrack guide both reach the host-alias rules, and a malformed rule is refused where it can still be corrected (#1161, #1172, #1192)
++ Fixed: any signal caught during a mirror killed every transfer in flight, so a burst of them silently truncated the mirror; a stop now ends an HTTP transfer as the user's stop rather than a fabricated receive error (#1110)
++ Fixed: stopping an FTP transfer against a silent server waited out --timeout twice, once on the data socket and again on a QUIT reply nobody was going to send (#1096)
++ Fixed: a crawl that ended early ran --update's purge against the files it had never reached, deleting good ones (#1109)
++ Fixed: a long URL overflowed the duplicate-detection key buffer (#1160)
++ Fixed: a long command line, a large doit.log or a large .httrackrc aborted the engine while it rebuilt its arguments (#1189, #1198)
++ Fixed: a scan rule beginning with a dash ended the whole run (#1179)
++ Fixed: --index=0 and --noindex enabled the index rather than disabling it, and --purge-old=1 killed the run; an option that takes no value now refuses one instead of silently dropping it (#1195, #1200)
++ Fixed: reloading a WebHTTrack project lost every zero and every cleared field, so a rate limit of 0 came back as 100 KB/s and a cleared user-agent refilled itself (#1177, #1171, #1186)
++ Fixed: the wizard kept only the last of several --strip-query rules, and its domain answers matched beyond the domain they named (#1168, #1119)
++ Fixed: the offer to resume an interrupted mirror printed the program path instead of the command line it would rerun (#1204)
++ Fixed: the build failed where getrandom() has no declaration, and the installed headers did not compile under some include orders (#1139, #1150, #1151)
++ Changed: the documentation and the WebHTTrack pages compute their copyright year instead of carrying a fixed one (#1165)
++ Changed: refreshed the guide screenshots for all three interfaces, and repaired the documentation's dark mode and its search-target tabs (#1164, #1158)
++ Changed: multiple internal hardening, build, test and CI improvements
+
 3.49-20
 + Fixed: a link to another host whose name looked like a file was scanned as a page, so one link could mirror the whole foreign site on the referring page's depth budget (#121)
 + Fixed: a size-bounded filter built both of its filter URLs wrong when the path had no leading slash (#1095)

--- a/history.txt
+++ b/history.txt
@@ -5,8 +5,8 @@ HTTrack Website Copier release history:
 This file lists all changes and fixes that have been made for HTTrack
 
 3.49-21
-+ New: --host-alias (-%C) folds the several hostnames of one site onto a single canonical host, so a site answering as both example.com and mirror.example.com is fetched once instead of once per name (#16)
-+ New: the WebHTTrack wizard and the WinHTTrack guide both reach the host-alias rules, and a malformed rule is refused where it can still be corrected (#1161, #1172, #1192)
++ New: --host-alias (-%C) folds the several hostnames of one site onto a single canonical host, so a site that answers under more than one hostname is fetched once instead of once per name (#16)
++ New: the WebHTTrack wizard can set the host-alias rules and the guide documents them for every front end; a malformed rule is refused where it can still be corrected, through a newly exported hts_host_alias_rule_ok() (#1161, #1172, #1192)
 + Fixed: any signal caught during a mirror killed every transfer in flight, so a burst of them silently truncated the mirror; a stop now ends an HTTP transfer as the user's stop rather than a fabricated receive error (#1110)
 + Fixed: stopping an FTP transfer against a silent server waited out --timeout twice, once on the data socket and again on a QUIT reply nobody was going to send (#1096)
 + Fixed: a crawl that ended early ran --update's purge against the files it had never reached, deleting good ones (#1109)
@@ -18,7 +18,7 @@ This file lists all changes and fixes that have been made for HTTrack
 + Fixed: the wizard kept only the last of several --strip-query rules, and its domain answers matched beyond the domain they named (#1168, #1119)
 + Fixed: the offer to resume an interrupted mirror printed the program path instead of the command line it would rerun (#1204)
 + Fixed: the build failed where getrandom() has no declaration, and the installed headers did not compile under some include orders (#1139, #1150, #1151)
-+ Changed: the documentation and the WebHTTrack pages compute their copyright year instead of carrying a fixed one (#1165)
++ Changed: the documentation and the WebHTTrack pages compute their copyright year instead of carrying a fixed one (#1163, #1165)
 + Changed: refreshed the guide screenshots for all three interfaces, and repaired the documentation's dark mode and its search-target tabs (#1164, #1158)
 + Changed: multiple internal hardening, build, test and CI improvements
 

--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -60,7 +60,7 @@
           <li>Stopping a mirror ends the transfers under way instead of reporting them as network errors</li>
           <li>A mirror that ends early no longer deletes files the update pass never reached</li>
           <li>Reloading a project keeps the boxes you cleared and the values you set to zero</li>
-          <li>Clearing "create a top index" now turns the index off</li>
+          <li>Clearing the option to build an index page now turns it off</li>
           <li>A very long address, or a very large settings file, no longer stops the mirror</li>
           <li>Refreshed screenshots throughout the documentation</li>
         </ul>

--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -53,6 +53,19 @@
   <content_rating type="oars-1.1"/>
   <!-- Newest first; tests/01_engine-version-macros.test enforces it. -->
   <releases>
+    <release version="3.49.21" date="2026-08-12">
+      <description>
+        <ul>
+          <li>A site that answers to several names is mirrored once, instead of once per name</li>
+          <li>Stopping a mirror ends the transfers under way instead of reporting them as network errors</li>
+          <li>A mirror that ends early no longer deletes files the update pass never reached</li>
+          <li>Reloading a project keeps the boxes you cleared and the values you set to zero</li>
+          <li>Clearing "create a top index" now turns the index off</li>
+          <li>A very long address, or a very large settings file, no longer stops the mirror</li>
+          <li>Refreshed screenshots throughout the documentation</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.49.20" date="2026-08-10">
       <description>
         <ul>

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -43,8 +43,8 @@ Please visit our Website: http://www.httrack.com
    configure.ac, decoupled from these). VERSION is the display form, VERSIONID
    the dotted numeric form, AFF_VERSION the short form shown in footers,
    LIB_VERSION the data/cache format generation. */
-#define HTTRACK_VERSION "3.49-20"
-#define HTTRACK_VERSIONID "3.49.20"
+#define HTTRACK_VERSION "3.49-21"
+#define HTTRACK_VERSIONID "3.49.21"
 #define HTTRACK_AFF_VERSION "3.x"
 #define HTTRACK_LIB_VERSION "2.0"
 

--- a/src/version.rc
+++ b/src/version.rc
@@ -17,8 +17,8 @@
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-  FILEVERSION 3, 49, 20, 0
-  PRODUCTVERSION 3, 49, 20, 0
+  FILEVERSION 3, 49, 21, 0
+  PRODUCTVERSION 3, 49, 21, 0
   FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
 #ifdef _DEBUG
   FILEFLAGS VS_FF_DEBUG
@@ -35,12 +35,12 @@ BEGIN
     BEGIN
       VALUE "CompanyName", "Xavier Roche"
       VALUE "FileDescription", VER_FILE_DESCRIPTION
-      VALUE "FileVersion", "3.49.20"
+      VALUE "FileVersion", "3.49.21"
       VALUE "InternalName", VER_ORIGINAL_FILENAME
       VALUE "LegalCopyright", "Copyright (C) 1998-2026 Xavier Roche and other contributors. GNU GPL v3 or later."
       VALUE "OriginalFilename", VER_ORIGINAL_FILENAME
       VALUE "ProductName", "HTTrack Website Copier"
-      VALUE "ProductVersion", "3.49-20"
+      VALUE "ProductVersion", "3.49-21"
     END
   END
   BLOCK "VarFileInfo"


### PR DESCRIPTION
Version bump to 3.49.21.

The headline is `--host-alias` (#16): it folds the several hostnames of one site onto one canonical host, so a site answering to more than one name is fetched once instead of once per name. The rest is fixes. A caught signal no longer kills every transfer in flight, a crawl that ends early no longer runs `--update`'s purge against files it never reached, long URLs and long command lines no longer overflow their buffers, and the WebHTTrack wizard reads its saved projects back correctly.

`VERSION_INFO` goes to 3:14:0, a revision-only bump: `httrackp` gained a tail field (`host_alias`) and #1202 added an export, so nothing moved and nothing went away. `Standards-Version` is already 4.7.4, matching unstable, and nothing under `debian/` changed this cycle, so the changelog carries only the upstream overview line.