### PR TITLE
A lost Windows runner leaves almost no telemetry behind

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -270,8 +270,10 @@ jobs:
           # Through the environment, never argv, which the process list exposes.
           WATCHDOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WATCHDOG_REPO: ${{ github.repository }}
-          # github.sha here is the PR's merge commit, so statuses posted against it stay out of the PR's checks UI.
-          WATCHDOG_SHA: ${{ github.sha }}
+          # The PR head, not github.sha: a merge commit is garbage-collected, and
+          # these statuses are the only trace a lost runner leaves (#1228). The
+          # cost is that they show up in the PR's checks list.
+          WATCHDOG_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           WATCHDOG_CONTEXT: windows-suite (${{ matrix.platform }}, ${{ matrix.configuration }})
           WATCHDOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -271,8 +271,7 @@ jobs:
           WATCHDOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WATCHDOG_REPO: ${{ github.repository }}
           # The PR head, not github.sha: a merge commit is garbage-collected, and
-          # these statuses are the only trace a lost runner leaves (#1228). The
-          # cost is that they show up in the PR's checks list.
+          # these statuses are the only trace a lost runner leaves (#1228).
           WATCHDOG_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           WATCHDOG_CONTEXT: windows-suite (${{ matrix.platform }}, ${{ matrix.configuration }})
           WATCHDOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/tests/171_watchdog-heartbeat.test
+++ b/tests/171_watchdog-heartbeat.test
@@ -188,8 +188,15 @@ rc=0
     kill_pid() { echo "DIRECT $1" >>"$rec"; }
     # shellcheck disable=SC2317
     kill_tree() {
-        echo "TREE $1" >>"$rec"
+        echo "TREE $*" >>"$rec"
         exit 9
+    }
+    # The suite's own pid has no /proc entry here, so the capture answers what a
+    # POSIX box answers: empty, and the kill goes on unguarded.
+    # shellcheck disable=SC2317
+    win_capture() {
+        echo "CAPTURE $1" >>"$rec"
+        WIN_PID=4242 WIN_IMAGE=bash.exe
     }
     hb_depth=$BASH_SUBSHELL
     ci_suite_heartbeat 960 360 "$progress" 900 4242 >"$tmp/hedge" 2>&1
@@ -197,11 +204,13 @@ rc=0
 test "$rc" -eq 9 || fail "the tree kill never fired: watchdog returned $rc"
 test "$(sed -n 1p "$rec")" = "DIRECT 777" ||
     fail "the reporter was not killed ahead of the suite: $(tr '\n' '/' <"$rec")"
-test "$(sed -n 2p "$rec")" = "DIRECT 4242" ||
+test "$(sed -n 2p "$rec")" = "CAPTURE 4242" ||
+    fail "the winpid was not read before the target was signalled: $(tr '\n' '/' <"$rec")"
+test "$(sed -n 3p "$rec")" = "DIRECT 4242" ||
     fail "the target was not signalled directly ahead of the tree walk: $(tr '\n' '/' <"$rec")"
-test "$(sed -n 3p "$rec")" = "TREE 4242" ||
-    fail "the tree was not killed after the direct signal: $(tr '\n' '/' <"$rec")"
-test "$(sed -n '$=' "$rec")" -eq 3 || fail "extra kills: $(tr '\n' '/' <"$rec")"
+test "$(sed -n 4p "$rec")" = "TREE 4242 4242 bash.exe" ||
+    fail "the tree kill did not carry what was captured: $(tr '\n' '/' <"$rec")"
+test "$(sed -n '$=' "$rec")" -eq 4 || fail "extra kills: $(tr '\n' '/' <"$rec")"
 
 test ! -e "$tmp/forked" || fail "the clock was read through a subshell, a fork a starved box cannot spare"
 

--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -622,6 +622,9 @@ for psrun in "${psruns[@]}"; do
     mutate failed-not-reported "s/'x={0}' -f \$Failed/'x={0}' -f 0/" 'failed-post count is not what the caller'
     # shellcheck disable=SC2016
     mutate tcp-total-not-delta 's/(\$Cur\[0\] - \$Prev\[0\])/($Cur[0])/' 'total was reported where the delta'
+    # shellcheck disable=SC2016
+    mutate lag-not-a-peak 's/if (\$lag -gt \$Peak) { return \$lag }/if ($false) { return $lag }/' \
+        'overshot by 200ms'
     # The production cadence: no leg below runs without a schedule of its own.
     # shellcheck disable=SC2016
     mutate default-cadence 's/\[int\]\$IntervalSeconds = 15/[int]$IntervalSeconds = 1500/' \
@@ -728,7 +731,8 @@ for psrun in "${psruns[@]}"; do
     # shellcheck disable=SC2016
     mutate_leg backoff-never-skips 's/if (\$skip -gt 0)/if ($false)/' backoff 'nothing backs off'
     # shellcheck disable=SC2016
-    mutate_leg failures-not-counted 's/if (\$ok) { \$failed = 0 } else { \$failed++ }/$failed = 0/' \
+    mutate_leg failures-not-counted \
+        's/if (\$ok) { \$failed = 0; \$lagMax = 0 } else { \$failed++ }/$failed = 0/' \
         backoff 'counted the failures before it'
     if test "$devfull" -eq 1; then
         mutate_leg log-write-fatal 's/try { \(Write-Host .*\) } catch { }/\1/' \

--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -214,8 +214,9 @@ def perms_of(wf, job):
 WANT_ENV = {
     "WATCHDOG_TOKEN": "${{ secrets.GITHUB_TOKEN }}",
     "WATCHDOG_REPO": "${{ github.repository }}",
-    # The merge commit, which no PR checks UI reads.
-    "WATCHDOG_SHA": "${{ github.sha }}",
+    # The PR head: statuses on the merge commit are GC'd, and they are the only
+    # trace a lost runner leaves (#1228).
+    "WATCHDOG_SHA": "${{ github.event.pull_request.head.sha || github.sha }}",
 }
 
 def audit(wf):
@@ -264,7 +265,7 @@ def mutate(wf, kind):
     elif kind == "token":
         suite_steps(wf)[0]["env"]["WATCHDOG_TOKEN"] = "${{ secrets.WATCHDOG_PAT }}"
     elif kind == "sha":
-        suite_steps(wf)[0]["env"]["WATCHDOG_SHA"] = "${{ github.event.pull_request.head.sha }}"
+        suite_steps(wf)[0]["env"]["WATCHDOG_SHA"] = "${{ github.sha }}"
     elif kind == "context":
         suite_steps(wf)[0]["env"]["WATCHDOG_CONTEXT"] = "windows-suite"
     elif kind == "url":
@@ -555,6 +556,12 @@ backoff_leg() {
         echo "$calls calls and $lines log lines against an API rejecting every one: nothing backs off"
         return 1
     fi
+    # Every attempt here is refused, so each one after the first must say how many
+    # went missing: x= is what separates a stopped box from a network that healed.
+    grep -q ' x=[1-9]' "$posts" || {
+        echo "no posted status counted the failures before it: $(cat "$posts")"
+        return 1
+    }
 }
 
 fullstdout_leg() {
@@ -609,9 +616,15 @@ for psrun in "${psruns[@]}"; do
     # shellcheck disable=SC2016
     mutate tail-always-ok 's/\$r = @{ Ok = \$false;/$r = @{ Ok = $true;/' 'reads as one that was read'
     mutate counters-empty "s/return (\$f -join ' ')/return ''/" 'counters are not key=value'
+    # shellcheck disable=SC2016
+    mutate lag-not-measured "s/'l={0}' -f \$LagMs/'l={0}' -f 0/" 'loop lag is not what the caller measured'
+    # shellcheck disable=SC2016
+    mutate failed-not-reported "s/'x={0}' -f \$Failed/'x={0}' -f 0/" 'failed-post count is not what the caller'
+    # shellcheck disable=SC2016
+    mutate tcp-total-not-delta 's/(\$Cur\[0\] - \$Prev\[0\])/($Cur[0])/' 'total was reported where the delta'
     # The production cadence: no leg below runs without a schedule of its own.
     # shellcheck disable=SC2016
-    mutate default-cadence 's/\[int\]\$IntervalSeconds = 30/[int]$IntervalSeconds = 3000/' \
+    mutate default-cadence 's/\[int\]\$IntervalSeconds = 15/[int]$IntervalSeconds = 1500/' \
         'default status cadence'
     # shellcheck disable=SC2016
     mutate default-poll 's/\[int\]\$PollSeconds = 5/[int]$PollSeconds = 50/' 'default poll'
@@ -714,6 +727,9 @@ for psrun in "${psruns[@]}"; do
         throttle 'a landed post throttles the next'
     # shellcheck disable=SC2016
     mutate_leg backoff-never-skips 's/if (\$skip -gt 0)/if ($false)/' backoff 'nothing backs off'
+    # shellcheck disable=SC2016
+    mutate_leg failures-not-counted 's/if (\$ok) { \$failed = 0 } else { \$failed++ }/$failed = 0/' \
+        backoff 'counted the failures before it'
     if test "$devfull" -eq 1; then
         mutate_leg log-write-fatal 's/try { \(Write-Host .*\) } catch { }/\1/' \
             fullstdout 'took the loop with it'

--- a/tests/249_windows-reap-images.test
+++ b/tests/249_windows-reap-images.test
@@ -72,6 +72,42 @@ kill_tree 99
 test "$(cat "$tmp/killed")" = '/F /T /PID 4242' || fail "kill_tree with a winpid ran: $(cat "$tmp/killed")"
 win_pid() { :; }
 
+# The image the caller read while the target was alive. A winpid outlives its
+# process and Windows hands the number straight back out, so a kill that skips
+# this check reaps a stranger and, through /T, its children too (#1228).
+: >"$tmp/killed"
+kill_tree 99 4242 PROXYTRACK.EXE
+test "$(cat "$tmp/killed")" = '/F /T /PID 4242' ||
+    fail "a verified tree kill did not run: $(cat "$tmp/killed")"
+: >"$tmp/killed"
+out=$(kill_tree 99 4242 python.exe 2>&1)
+test ! -s "$tmp/killed" || fail "pid 4242 was killed as a python.exe: $(cat "$tmp/killed")"
+grep -q '::warning::pid 4242 is no longer python.exe' <<<"$out" ||
+    fail "the skipped kill was not reported: $out"
+# Gone from the table entirely, which is what a freed winpid usually looks like.
+: >"$tmp/killed"
+kill_tree 99 4343 proxytrack.exe >/dev/null 2>&1
+test ! -s "$tmp/killed" || fail "a pid tasklist does not list was killed: $(cat "$tmp/killed")"
+
+# The winpid stop_server hands over must be read before it signals: the one it
+# used to re-derive afterwards was that of a process already dead. Graded on the
+# order, since only a read taken while the target lived can name it.
+: >"$tmp/killed"
+: >"$tmp/order"
+kill() { echo "kill $*" >>"$tmp/order"; }
+win_capture() {
+    echo "capture $*" >>"$tmp/order"
+    WIN_PID=4242 WIN_IMAGE=proxytrack.exe
+}
+# The pid is fictional, and reap_bounded polls it through the kill stub above.
+reap_bounded() { :; }
+stop_server 99
+got=$(tr '\n' ' ' <"$tmp/order")
+test "$got" = 'capture 99 kill 99 ' || fail "stop_server did not capture before signalling: $got"
+test "$(cat "$tmp/killed")" = '/F /T /PID 4242' ||
+    fail "stop_server did not tree-kill what it captured: $(cat "$tmp/killed")"
+unset -f kill win_capture reap_bounded
+
 : >"$tmp/killed"
 out=$(reap_leftover_processes 99_probe.test)
 grep -q '99_probe.test left processes behind' <<<"$out" || fail "the leak was not attributed: $out"

--- a/tests/249_windows-reap-images.test
+++ b/tests/249_windows-reap-images.test
@@ -72,26 +72,29 @@ kill_tree 99
 test "$(cat "$tmp/killed")" = '/F /T /PID 4242' || fail "kill_tree with a winpid ran: $(cat "$tmp/killed")"
 win_pid() { :; }
 
-# The image the caller read while the target was alive. A winpid outlives its
-# process and Windows hands the number straight back out, so a kill that skips
-# this check reaps a stranger and, through /T, its children too (#1228).
+# The image read while the target was alive: a freed winpid can already be a
+# stranger's, and /T would take its children too (#1228).
 : >"$tmp/killed"
 kill_tree 99 4242 PROXYTRACK.EXE
 test "$(cat "$tmp/killed")" = '/F /T /PID 4242' ||
     fail "a verified tree kill did not run: $(cat "$tmp/killed")"
 : >"$tmp/killed"
-out=$(kill_tree 99 4242 python.exe 2>&1)
+out=$(kill_tree 99 4242 python.exe)
 test ! -s "$tmp/killed" || fail "pid 4242 was killed as a python.exe: $(cat "$tmp/killed")"
-grep -q '::warning::pid 4242 is no longer python.exe' <<<"$out" ||
+grep -q '::warning::pid 4242 no longer runs python.exe' <<<"$out" ||
     fail "the skipped kill was not reported: $out"
 # Gone from the table entirely, which is what a freed winpid usually looks like.
 : >"$tmp/killed"
-kill_tree 99 4343 proxytrack.exe >/dev/null 2>&1
+kill_tree 99 4343 proxytrack.exe >/dev/null
 test ! -s "$tmp/killed" || fail "a pid tasklist does not list was killed: $(cat "$tmp/killed")"
+# A stranger's pid leaves the caller with no target, so the serial runner's last
+# resort still applies: skipping it too would leave the engines running.
+: >"$tmp/killed"
+HTTRACK_EXCLUSIVE_HOST=1 kill_tree 99 4242 python.exe >/dev/null
+got=$(sort "$tmp/killed")
+test "$got" = "$want" || fail "an unverified pid skipped the last-resort sweep: $got"
 
-# The winpid stop_server hands over must be read before it signals: the one it
-# used to re-derive afterwards was that of a process already dead. Graded on the
-# order, since only a read taken while the target lived can name it.
+# Graded on the order, since only a winpid read while the target lived names it.
 : >"$tmp/killed"
 : >"$tmp/order"
 kill() { echo "kill $*" >>"$tmp/order"; }

--- a/tests/58_watchdog.test
+++ b/tests/58_watchdog.test
@@ -39,15 +39,8 @@ test "$((SECONDS - start))" -lt 15 || fail "watchdog fired late"
 rc=0
 if is_windows; then
     # Existence by exact Windows PID, not a global ping.exe count: the timing
-    # sub-test above leaves a still-dying ping that a count would race. Plain
-    # tasklist, no switches (the workflow's MSYS2_ARG_CONV_EXCL='*' mangles a
-    # //FI filter arg into a silent no-match); $2 is the PID, and $1 must be
-    # ping.exe too, since Windows hands a freed PID straight back out. Folded
-    # case, as the tasklist matchers in proclib.sh already are.
-    alive() {
-        tasklist 2>/dev/null |
-            awk -v p="$1" 'tolower($1) == "ping.exe" && $2 == p {f = 1} END {exit !f}'
-    }
+    # sub-test above leaves a still-dying ping that a count would race.
+    alive() { win_pid_runs "$1" ping.exe; }
     # alive() is a conjunction now, and one that never matches would call every
     # survivor reaped. Prove it fires on a live ping, reached the same way.
     ping -n 20 127.0.0.1 >/dev/null 2>&1 &
@@ -55,13 +48,12 @@ if is_windows; then
     cw=$(cat "/proc/$cpid/winpid" 2>/dev/null)
     test -n "$cw" || fail "could not read a live ping's Windows PID"
     alive "$cw" || fail "alive() cannot see a running ping.exe (pid $cw)"
-    # What kill_tree verifies before firing (#1228), on a live process: the image
-    # has to be readable from /proc, and has to be the name tasklist answers with,
-    # or the guard is disarmed on every kill and nothing says so.
+    # What kill_tree checks before firing (#1228), on a live process: /proc must
+    # name the image tasklist answers with, or the check passes nothing on.
     win_capture "$cpid"
     test "$WIN_PID" = "$cw" || fail "win_capture read winpid '$WIN_PID', /proc says $cw"
-    win_pid_is "$cw" "$WIN_IMAGE" || fail "tasklist does not call pid $cw a '$WIN_IMAGE'"
-    ! win_pid_is "$cw" no-such-image.exe || fail "win_pid_is accepts any image at all"
+    win_pid_runs "$cw" "$WIN_IMAGE" || fail "tasklist does not call pid $cw a '$WIN_IMAGE'"
+    ! win_pid_runs "$cw" no-such-image.exe || fail "win_pid_runs accepts any image at all"
     kill_tree "$cpid" "$cw"
     wait "$cpid" 2>/dev/null || true
     # The grandchild ping records its own Windows PID: non-empty proves it ran

--- a/tests/58_watchdog.test
+++ b/tests/58_watchdog.test
@@ -55,6 +55,13 @@ if is_windows; then
     cw=$(cat "/proc/$cpid/winpid" 2>/dev/null)
     test -n "$cw" || fail "could not read a live ping's Windows PID"
     alive "$cw" || fail "alive() cannot see a running ping.exe (pid $cw)"
+    # What kill_tree verifies before firing (#1228), on a live process: the image
+    # has to be readable from /proc, and has to be the name tasklist answers with,
+    # or the guard is disarmed on every kill and nothing says so.
+    win_capture "$cpid"
+    test "$WIN_PID" = "$cw" || fail "win_capture read winpid '$WIN_PID', /proc says $cw"
+    win_pid_is "$cw" "$WIN_IMAGE" || fail "tasklist does not call pid $cw a '$WIN_IMAGE'"
+    ! win_pid_is "$cw" no-such-image.exe || fail "win_pid_is accepts any image at all"
     kill_tree "$cpid" "$cw"
     wait "$cpid" 2>/dev/null || true
     # The grandchild ping records its own Windows PID: non-empty proves it ran

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -73,14 +73,18 @@ ci_start_native_watchdog() {
 # End the step, announcing $2 first: the kill runs no EXIT trap, so an unexplained
 # death is all the log would otherwise hold.
 ci_heartbeat_kill() {
-    local main=$1
+    local main=$1 winpid winimage
     ci_annotate error "suite watchdog" "$2"
     # Ahead of the kill, which runs no EXIT trap: an orphan would outlive the
     # step and overwrite its last status with a frozen tail.
     test -z "${watchdog:-}" || kill_pid "$watchdog"
+    # Read before the two kills below, which would leave the winpid naming
+    # whoever Windows hands the number to next (#1228).
+    win_capture "$main"
+    winpid=$WIN_PID winimage=$WIN_IMAGE
     # Direct first: kill_tree may reap this watchdog before its own root (#953).
     kill_pid "$main"
-    kill_tree "$main"
+    kill_tree "$main" "$winpid" "$winimage"
 }
 
 ci_suite_heartbeat() {

--- a/tests/ci-windows-watchdog.ps1
+++ b/tests/ci-windows-watchdog.ps1
@@ -3,7 +3,8 @@
 # channel that outlives a dead runner. Every status carries the same state.
 param(
     [string]$ProgressLog = '',
-    [int]$IntervalSeconds = 30,
+    # 15s, not 30: a lost runner dies inside a single status period (#1228).
+    [int]$IntervalSeconds = 15,
     [int]$PollSeconds = 5,
     # Cannot outlive the step, whatever the caller forgets to kill.
     [int]$MaxSeconds = 2700,
@@ -48,19 +49,32 @@ function Format-WatchdogStatus {
     $q = '?'
     if ($Static -ge 0) { $q = [string]$Static }
     $t = ($InFlight -replace '\s+', ' ').Trim()
-    if ($t.Length -gt 46) { $t = $t.Substring(0, 46) }
+    if ($t.Length -gt 30) { $t = $t.Substring(0, 30) }
     $s = 't={0}s q={1}s {2} | {3}' -f $Elapsed, $q, $t, $Counters
     if ($s.Length -gt 140) { $s = $s.Substring(0, 140) }
     return $s
 }
 
+# The TCP counters are cumulative since boot, so only the change over a status
+# period says what the suite did; $Prev is $null on the first sample.
+function Get-TcpDelta {
+    param($Prev, $Cur)
+    if ($null -eq $Prev) { return 'n=? f=?' }
+    return 'n={0} f={1}' -f ($Cur[0] - $Prev[0]), ($Cur[1] - $Prev[1])
+}
+
 # --- probes ------------------------------------------------------------------
+
+$script:LastTcp = $null
 
 # One try/catch per counter: a probe that fails costs its own field, not the loop.
 # In-process only. A CIM query is richer, but its connect to a wedged WMI service
-# is unbounded, and would hang the one reporter still standing.
+# is unbounded, and would hang the one reporter still standing. Ordered by what a
+# clipped line must keep, memory last: it stays an order of magnitude off the box.
 function Get-WatchdogCounters {
+    param([int]$LagMs = 0, [int]$Failed = 0)
     $f = New-Object System.Collections.ArrayList
+    $ps = @()
     try {
         $ps = @(Get-Process)
         [void]$f.Add('p={0}' -f $ps.Count)
@@ -68,8 +82,31 @@ function Get-WatchdogCounters {
     } catch { [void]$f.Add('p=? h=?') }
     try {
         $drive = New-Object System.IO.DriveInfo($env:SystemDrive + '\')
-        [void]$f.Add('d={0}' -f [int]($drive.AvailableFreeSpace / 1MB))
+        [void]$f.Add('d={0}' -f [int]($drive.AvailableFreeSpace / 1GB))
     } catch { [void]$f.Add('d=?') }
+    # The ramp detector: starvation is what makes a poll overshoot.
+    [void]$f.Add('l={0}' -f $LagMs)
+    # Box-stop against network-break: the status that lands after an outage says
+    # how many it swallowed, and a box that stopped never lands one.
+    [void]$f.Add('x={0}' -f $Failed)
+    try {
+        # One GetTcpStatisticsEx; GetActiveTcpConnections() would allocate per socket.
+        $t = [System.Net.NetworkInformation.IPGlobalProperties]::GetIPGlobalProperties().GetTcpIPv4Statistics()
+        $cur = @($t.ConnectionsInitiated, ($t.FailedConnectionAttempts + $t.ResetConnections))
+        [void]$f.Add((Get-TcpDelta $script:LastTcp $cur))
+        $script:LastTcp = $cur
+        [void]$f.Add('e={0}' -f $t.CurrentConnections)
+    } catch { [void]$f.Add('n=? f=? e=?') }
+    try {
+        if ($ps.Count -lt 1) { throw 'no process list' }
+        [void]$f.Add('m={0}' -f [int]((($ps | Measure-Object -Property WorkingSet64 -Sum).Sum) / 1MB))
+        [void]$f.Add('c={0}' -f [int]((($ps | Measure-Object -Property PagedMemorySize64 -Sum).Sum) / 1MB))
+        # Its own field: the agent is what stops reporting, and the box total hides it.
+        $agent = @($ps | Where-Object { $_.Name -eq 'Runner.Worker' })
+        $ws = 0
+        if ($agent.Count -gt 0) { $ws = [int]((($agent | Measure-Object -Property WorkingSet64 -Sum).Sum) / 1MB) }
+        [void]$f.Add('a={0}' -f $ws)
+    } catch { [void]$f.Add('m=? c=? a=?') }
     return ($f -join ' ')
 }
 
@@ -156,14 +193,15 @@ function Invoke-WatchdogSelfTest {
     Assert-That ($ko[0] -eq 8 -and $ko[1] -eq 8) 'a repeat rejection does not widen the gap'
 
     $long = '43_local-update-truncate-with-a-very-long-name-indeed.test'
-    $line = Format-WatchdogStatus 812 41 $long 'p=118 h=41230 d=13210'
+    # The widest real counter line, so a status that fits here fits on the runner.
+    $line = Format-WatchdogStatus 2700 2700 $long 'p=201 h=54598 d=85 l=120 x=0 n=412 f=0 e=180 m=3100 c=4200 a=210'
     Assert-That ($line.Length -le 140) ('status description is {0} characters' -f $line.Length)
-    Assert-That ($line -like 't=812s q=41s 43_local-update-truncate*') ('status leads with the wrong fields: {0}' -f $line)
-    Assert-That ($line -like '*d=13210') 'the counters did not survive a long test name'
+    Assert-That ($line -like 't=2700s q=2700s 43_local-update-truncate*') ('status leads with the wrong fields: {0}' -f $line)
+    Assert-That ($line -like '*a=210') 'the counters did not survive a long test name'
     # -match, not -like: '?' is a wildcard there, so q=0s would satisfy it too.
     Assert-That ((Format-WatchdogStatus 8 -1 'x' 'y') -match '^t=8s q=\?s x \| y$') 'an unknown staticness reads as a number'
     $clip = Format-WatchdogStatus 1 2 ('x' * 80) 'c'
-    Assert-That ($clip -match '^t=1s q=2s x{46} \| c$') ('the in-flight name was not clipped to 46: {0}' -f $clip)
+    Assert-That ($clip -match '^t=1s q=2s x{30} \| c$') ('the in-flight name was not clipped to 30: {0}' -f $clip)
     $wide = Format-WatchdogStatus 1 2 ('x' * 300) ('y' * 300)
     Assert-That ($wide.Length -le 140) ('an oversized status was not clipped: {0}' -f $wide.Length)
     # Cut from the tail: the head carries the fields a wedge is read for.
@@ -181,15 +219,20 @@ function Invoke-WatchdogSelfTest {
 
     # Space-separated key=value: the counters share the 140-char description with
     # the fields a wedge is read for, and '?' from a failed probe is a value.
-    $c = Get-WatchdogCounters
+    $c = Get-WatchdogCounters 120 3
     Assert-That ($c -match '^[a-z]+=\S+( [a-z]+=\S+)*$') ('the counters are not key=value pairs: {0}' -f $c)
-    foreach ($k in 'p', 'h', 'd') {
+    foreach ($k in 'p', 'h', 'd', 'l', 'x', 'n', 'f', 'e', 'm', 'c', 'a') {
         Assert-That ($c -match ('(^| ){0}=' -f $k)) ('the counters dropped {0}=: {1}' -f $k, $c)
     }
-    Assert-That ($c.Length -le 60) ('the counters take {0} of the 140 characters' -f $c.Length)
+    Assert-That ($c -match '(^| )l=120( |$)') ('the loop lag is not what the caller measured: {0}' -f $c)
+    Assert-That ($c -match '(^| )x=3( |$)') ('the failed-post count is not what the caller passed: {0}' -f $c)
+    Assert-That ((Get-TcpDelta $null @(70, 9)) -eq 'n=? f=?') 'a first sample with no predecessor reported a delta'
+    Assert-That ((Get-TcpDelta @(64, 7) @(70, 9)) -eq 'n=6 f=2') 'a total was reported where the delta was asked for'
+    # 140 less the 16 of t=/q= and the 33 a clipped test name and its separator take.
+    Assert-That ($c.Length -le 91) ('the counters take {0} of the 140 characters' -f $c.Length)
 
     # Nothing else reads these: every other leg passes its own schedule.
-    Assert-That ($IntervalSeconds -eq 30) ('the default status cadence is {0}s' -f $IntervalSeconds)
+    Assert-That ($IntervalSeconds -eq 15) ('the default status cadence is {0}s' -f $IntervalSeconds)
     Assert-That ($PollSeconds -eq 5) ('the default poll is {0}s' -f $PollSeconds)
 
     Assert-That (-not (Send-WatchdogStatus 'self-test')) 'the self-test can reach the API'
@@ -216,6 +259,9 @@ $movedAt = 0
 $postedAt = -$IntervalSeconds
 $backoff = 0
 $skip = 0
+$lagMax = 0
+$failed = 0
+$tickAt = $sw.Elapsed.TotalMilliseconds
 
 # Guarded like the rest; the launcher waits for this exact line.
 try { Write-Host 'watchdog ready' } catch { }
@@ -223,7 +269,11 @@ Write-WatchdogLog ('watching {0} every {1}s' -f $ProgressLog, $IntervalSeconds)
 
 while ($sw.Elapsed.TotalSeconds -lt $MaxSeconds) {
     # Measured, never accumulated: starvation is what makes a sleep overshoot.
-    $now = [int]$sw.Elapsed.TotalSeconds
+    $ms = $sw.Elapsed.TotalMilliseconds
+    $now = [int]($ms / 1000)
+    # Overshoot of the poll we asked for, kept at its worst until a status carries it.
+    $lag = [int]($ms - $tickAt - $PollSeconds * 1000)
+    if ($lag -gt $lagMax) { $lagMax = $lag }
     try {
         $tail = Get-ProgressTail -Path $ProgressLog
         if ($tail.Ok -and $tail.Signature -ne $lastSig) {
@@ -234,14 +284,17 @@ while ($sw.Elapsed.TotalSeconds -lt $MaxSeconds) {
             $postedAt = $now
             $static = -1
             if ($tail.Ok) { $static = $now - $movedAt }
-            $desc = Format-WatchdogStatus $now $static $tail.Line (Get-WatchdogCounters)
+            $desc = Format-WatchdogStatus $now $static $tail.Line (Get-WatchdogCounters $lagMax $failed)
+            $lagMax = 0
             # Logged whatever the backoff decides: it throttles the API, not the
             # artifact, which is all a run whose token cannot post will leave.
             Write-WatchdogLog $desc
             if ($skip -gt 0) {
                 $skip--
             } else {
-                $next = Get-NextThrottle (Send-WatchdogStatus $desc) $backoff
+                $ok = Send-WatchdogStatus $desc
+                if ($ok) { $failed = 0 } else { $failed++ }
+                $next = Get-NextThrottle $ok $backoff
                 $skip = $next[0]
                 $backoff = $next[1]
             }
@@ -249,6 +302,7 @@ while ($sw.Elapsed.TotalSeconds -lt $MaxSeconds) {
     } catch {
         Write-WatchdogLog ('tick failed: {0}' -f $_.Exception.Message)
     }
+    $tickAt = $sw.Elapsed.TotalMilliseconds
     Start-Sleep -Seconds $PollSeconds
 }
 

--- a/tests/ci-windows-watchdog.ps1
+++ b/tests/ci-windows-watchdog.ps1
@@ -55,6 +55,15 @@ function Format-WatchdogStatus {
     return $s
 }
 
+# The worse of the running peak and how much longer the last iteration took than
+# the poll it asked for. Peak, not last: a status covers several iterations.
+function Get-MaxLag {
+    param([int]$Peak, [double]$Elapsed, [double]$Since, [int]$Poll)
+    $lag = [int]($Elapsed - $Since - $Poll * 1000)
+    if ($lag -gt $Peak) { return $lag }
+    return $Peak
+}
+
 # The TCP counters are cumulative since boot, so only the change over a status
 # period says what the suite did; $Prev is $null on the first sample.
 function Get-TcpDelta {
@@ -69,8 +78,7 @@ $script:LastTcp = $null
 
 # One try/catch per counter: a probe that fails costs its own field, not the loop.
 # In-process only. A CIM query is richer, but its connect to a wedged WMI service
-# is unbounded, and would hang the one reporter still standing. Ordered by what a
-# clipped line must keep, memory last: it stays an order of magnitude off the box.
+# is unbounded, and would hang the one reporter still standing.
 function Get-WatchdogCounters {
     param([int]$LagMs = 0, [int]$Failed = 0)
     $f = New-Object System.Collections.ArrayList
@@ -226,6 +234,9 @@ function Invoke-WatchdogSelfTest {
     }
     Assert-That ($c -match '(^| )l=120( |$)') ('the loop lag is not what the caller measured: {0}' -f $c)
     Assert-That ($c -match '(^| )x=3( |$)') ('the failed-post count is not what the caller passed: {0}' -f $c)
+    Assert-That ((Get-MaxLag 0 6200 1000 5) -eq 200) 'a poll that overshot by 200ms was not measured'
+    Assert-That ((Get-MaxLag 500 6200 1000 5) -eq 500) 'a smaller lag replaced the peak'
+    Assert-That ((Get-MaxLag 0 5900 1000 5) -eq 0) 'a poll that returned early reported a lag'
     Assert-That ((Get-TcpDelta $null @(70, 9)) -eq 'n=? f=?') 'a first sample with no predecessor reported a delta'
     Assert-That ((Get-TcpDelta @(64, 7) @(70, 9)) -eq 'n=6 f=2') 'a total was reported where the delta was asked for'
     # 140 less the 16 of t=/q= and the 33 a clipped test name and its separator take.
@@ -271,9 +282,10 @@ while ($sw.Elapsed.TotalSeconds -lt $MaxSeconds) {
     # Measured, never accumulated: starvation is what makes a sleep overshoot.
     $ms = $sw.Elapsed.TotalMilliseconds
     $now = [int]($ms / 1000)
-    # Overshoot of the poll we asked for, kept at its worst until a status carries it.
-    $lag = [int]($ms - $tickAt - $PollSeconds * 1000)
-    if ($lag -gt $lagMax) { $lagMax = $lag }
+    # Measured at the top, so the lag covers the probes and the post as well as
+    # the sleep: starvation stretches all three.
+    $lagMax = Get-MaxLag $lagMax $ms $tickAt $PollSeconds
+    $tickAt = $ms
     try {
         $tail = Get-ProgressTail -Path $ProgressLog
         if ($tail.Ok -and $tail.Signature -ne $lastSig) {
@@ -285,7 +297,6 @@ while ($sw.Elapsed.TotalSeconds -lt $MaxSeconds) {
             $static = -1
             if ($tail.Ok) { $static = $now - $movedAt }
             $desc = Format-WatchdogStatus $now $static $tail.Line (Get-WatchdogCounters $lagMax $failed)
-            $lagMax = 0
             # Logged whatever the backoff decides: it throttles the API, not the
             # artifact, which is all a run whose token cannot post will leave.
             Write-WatchdogLog $desc
@@ -293,7 +304,9 @@ while ($sw.Elapsed.TotalSeconds -lt $MaxSeconds) {
                 $skip--
             } else {
                 $ok = Send-WatchdogStatus $desc
-                if ($ok) { $failed = 0 } else { $failed++ }
+                # Cleared together, and only by a status that landed: a peak reached
+                # while nothing was getting through is what the next one has to carry.
+                if ($ok) { $failed = 0; $lagMax = 0 } else { $failed++ }
                 $next = Get-NextThrottle $ok $backoff
                 $skip = $next[0]
                 $backoff = $next[1]
@@ -302,7 +315,6 @@ while ($sw.Elapsed.TotalSeconds -lt $MaxSeconds) {
     } catch {
         Write-WatchdogLog ('tick failed: {0}' -f $_.Exception.Message)
     }
-    $tickAt = $sw.Elapsed.TotalMilliseconds
     Start-Sleep -Seconds $PollSeconds
 }
 

--- a/tests/test-timeout.sh
+++ b/tests/test-timeout.sh
@@ -53,10 +53,9 @@ test -n "$windows" || set -m # own process group, so kill_tree can signal the gr
 "$BASH" "$@" &
 pid=$!
 test -n "$had_m" || test -n "$windows" || set +m
-# Read while the test is certainly alive: by kill time /proc/<pid>/winpid is gone,
-# and the number it named may belong to a stranger.
-win_capture "$pid"
-winpid=$WIN_PID winimage=$WIN_IMAGE
+# Read while the test is certainly alive: by kill time /proc/<pid>/winpid is gone.
+winpid=''
+test -z "$windows" || winpid=$(win_pid "$pid")
 
 # Poll, because bash cannot wait with a deadline and a watchdog subshell would
 # have to signal across process groups, which MSYS cannot do. The interval is the
@@ -83,7 +82,7 @@ while kill -0 "$pid" 2>/dev/null; do
         # watching, or the silence reads as a wedge and the step dies mid-stack.
         test -z "${HTTRACK_PROGRESS_LOG:-}" || echo "DUMP $name" >>"$HTTRACK_PROGRESS_LOG"
         dump_hang_diagnostics "$pid" "$name" "$budget"
-        kill_tree "$pid" "$winpid" "$winimage"
+        kill_tree "$pid" "$winpid"
         reap_bounded "$pid" || echo "hang: the tree outlived the kill; see the process list above"
         # After the kill, so a crawl log holds the backtrace its engine just wrote.
         dump_crawl_logs
@@ -99,7 +98,7 @@ while kill -0 "$pid" 2>/dev/null; do
     # commit status behind (#795).
     test -z "${HTTRACK_PROGRESS_LOG:-}" || echo "NOFORK $name" >>"$HTTRACK_PROGRESS_LOG"
     echo "hang: the poll tick ran $nowait times without waiting; this box cannot start a process"
-    kill_tree "$pid" "$winpid" "$winimage"
+    kill_tree "$pid" "$winpid"
     # No reap_bounded here: it polls on the same broken tick, which is the spin
     # this branch exists to end.
     # The EXIT trap deletes TMPDIR, so a crawl log left undumped is a destroyed one.

--- a/tests/test-timeout.sh
+++ b/tests/test-timeout.sh
@@ -53,9 +53,10 @@ test -n "$windows" || set -m # own process group, so kill_tree can signal the gr
 "$BASH" "$@" &
 pid=$!
 test -n "$had_m" || test -n "$windows" || set +m
-# Read while the test is certainly alive: by kill time /proc/<pid>/winpid is gone.
-winpid=''
-test -z "$windows" || winpid=$(win_pid "$pid")
+# Read while the test is certainly alive: by kill time /proc/<pid>/winpid is gone,
+# and the number it named may belong to a stranger.
+win_capture "$pid"
+winpid=$WIN_PID winimage=$WIN_IMAGE
 
 # Poll, because bash cannot wait with a deadline and a watchdog subshell would
 # have to signal across process groups, which MSYS cannot do. The interval is the
@@ -82,7 +83,7 @@ while kill -0 "$pid" 2>/dev/null; do
         # watching, or the silence reads as a wedge and the step dies mid-stack.
         test -z "${HTTRACK_PROGRESS_LOG:-}" || echo "DUMP $name" >>"$HTTRACK_PROGRESS_LOG"
         dump_hang_diagnostics "$pid" "$name" "$budget"
-        kill_tree "$pid" "$winpid"
+        kill_tree "$pid" "$winpid" "$winimage"
         reap_bounded "$pid" || echo "hang: the tree outlived the kill; see the process list above"
         # After the kill, so a crawl log holds the backtrace its engine just wrote.
         dump_crawl_logs
@@ -98,7 +99,7 @@ while kill -0 "$pid" 2>/dev/null; do
     # commit status behind (#795).
     test -z "${HTTRACK_PROGRESS_LOG:-}" || echo "NOFORK $name" >>"$HTTRACK_PROGRESS_LOG"
     echo "hang: the poll tick ran $nowait times without waiting; this box cannot start a process"
-    kill_tree "$pid" "$winpid"
+    kill_tree "$pid" "$winpid" "$winimage"
     # No reap_bounded here: it polls on the same broken tick, which is the spin
     # this branch exists to end.
     # The EXIT trap deletes TMPDIR, so a crawl log left undumped is a destroyed one.

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -286,8 +286,13 @@ poll_wait() {
 # trap, where a survivor would turn a passing test into a harness timeout.
 stop_server() {
     test -n "${1:-}" || return 0
+    local winpid winimage
+    # Before the signal, not after: this is the suite's most frequent kill, and
+    # the winpid it used to re-derive here was that of a process already dead.
+    win_capture "$1"
+    winpid=$WIN_PID winimage=$WIN_IMAGE
     kill "$1" 2>/dev/null || true
-    if is_windows; then kill_tree "$1"; fi
+    if is_windows; then kill_tree "$1" "$winpid" "$winimage"; fi
     reap_bounded "$1" || true
     return 0
 }
@@ -454,6 +459,30 @@ win_pid() {
     fi
 }
 
+# WIN_PID and WIN_IMAGE for MSYS pid $1, to be read while it is still alive: /proc
+# keeps the entry after the process is gone and Windows reissues the number at
+# once, so a later read can name a stranger (#1228). Assigned rather than echoed,
+# since this runs per fixture server and a command substitution is a fork (#795).
+win_capture() { # win_capture <pid>
+    WIN_PID='' WIN_IMAGE=''
+    is_windows || return 0
+    # Unguarded reads: a missing file leaves the empty value set above, and read
+    # reports EOF on an unterminated line having already assigned it.
+    { read -r WIN_PID <"/proc/$1/winpid"; } 2>/dev/null || true
+    { read -r WIN_IMAGE <"/proc/$1/winexename"; } 2>/dev/null || true
+    test -n "$WIN_IMAGE" || { read -r WIN_IMAGE <"/proc/$1/exename"; } 2>/dev/null || true
+    WIN_IMAGE=${WIN_IMAGE##*[\\/]}
+    return 0
+}
+
+# Whether Windows PID $1 is still running image $2. Case-folded and by both
+# columns at once, as 58_watchdog.test's liveness check is: either alone answers
+# for a recycled PID.
+win_pid_is() { # win_pid_is <winpid> <image>
+    tasklist 2>/dev/null |
+        awk -v p="$1" -v i="$2" 'tolower($1) == tolower(i) && $2 == p { f = 1 } END { exit !f }'
+}
+
 # Signal one process, never its descendants: a caller inside the target's own
 # tree cannot rely on kill_tree, whose taskkill is then a grandchild of it (#953).
 kill_pid() {
@@ -477,12 +506,18 @@ kill_pid() {
 # so args pass verbatim and a //T would reach taskkill unfolded and be rejected.
 # $2 is that Windows PID when the caller read it while the job was certainly
 # alive: /proc/<pid>/winpid is already gone for a job that has just died, and
-# without it the only route left is the host-wide sweep below.
+# without it the only route left is the host-wide sweep below. $3 is the image it
+# was running then, checked before firing so a PID Windows has already handed on
+# is skipped rather than tree-killed along with a stranger's children (#1228).
 kill_tree() {
-    local pid=$1 winpid=${2:-}
+    local pid=$1 winpid=${2:-} image=${3:-}
     if is_windows; then
         test -n "$winpid" || winpid=$(win_pid "$pid")
         if test -n "$winpid"; then
+            if test -n "$image" && ! win_pid_is "$winpid" "$image"; then
+                printf '::warning::pid %s is no longer %s, not killing it\n' "$winpid" "$image" >&2
+                return 0
+            fi
             taskkill /F /T /PID "$winpid" >/dev/null 2>&1 || true
         # Last resort, so it is opt-in: it kills every engine and every python on
         # the host, siblings of a parallel run included (HTTRACK_EXCLUSIVE_HOST).
@@ -579,12 +614,12 @@ run_with_timeout() {
     local pid=$!
     test -n "$had_m" || is_windows || set +m
     # Read while the job is certainly alive: by kill time /proc/<pid>/winpid is gone.
-    local winpid=''
-    ! is_windows || winpid=$(win_pid "$pid")
+    win_capture "$pid"
+    local winpid=$WIN_PID winimage=$WIN_IMAGE
     local start=$SECONDS
     while kill -0 "$pid" 2>/dev/null; do
         if test "$((SECONDS - start))" -gt "$secs"; then
-            kill_tree "$pid" "$winpid"
+            kill_tree "$pid" "$winpid" "$winimage"
             reap_bounded "$pid" || true
             return 124
         fi
@@ -597,9 +632,12 @@ run_with_timeout() {
 # on overrun: a wedge past --max-time would else block wait() forever and hang the CI step.
 wait_bounded() {
     local pid=$1 secs=$2 start=$SECONDS
+    # Same as run_with_timeout: the crawl is alive now, and may not be at kill time.
+    win_capture "$pid"
+    local winpid=$WIN_PID winimage=$WIN_IMAGE
     while kill -0 "$pid" 2>/dev/null; do
         if test "$((SECONDS - start))" -gt "$secs"; then
-            kill_tree "$pid"
+            kill_tree "$pid" "$winpid" "$winimage"
             reap_bounded "$pid" || true
             return 124
         fi

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -287,8 +287,7 @@ poll_wait() {
 stop_server() {
     test -n "${1:-}" || return 0
     local winpid winimage
-    # Before the signal, not after: this is the suite's most frequent kill, and
-    # the winpid it used to re-derive here was that of a process already dead.
+    # Before the signal: a winpid read after it can already name a stranger.
     win_capture "$1"
     winpid=$WIN_PID winimage=$WIN_IMAGE
     kill "$1" 2>/dev/null || true
@@ -459,10 +458,11 @@ win_pid() {
     fi
 }
 
-# WIN_PID and WIN_IMAGE for MSYS pid $1, to be read while it is still alive: /proc
-# keeps the entry after the process is gone and Windows reissues the number at
-# once, so a later read can name a stranger (#1228). Assigned rather than echoed,
-# since this runs per fixture server and a command substitution is a fork (#795).
+# WIN_PID and WIN_IMAGE for MSYS pid $1, read while it is alive: /proc keeps the
+# entry once the process is gone and Windows reissues the number at once, so a
+# later read can name a stranger (#1228). Not for a job just backgrounded: until
+# its exec lands, tens of milliseconds later, both still name the forking shell.
+# Assigned rather than echoed, a command substitution being a fork (#795).
 win_capture() { # win_capture <pid>
     WIN_PID='' WIN_IMAGE=''
     is_windows || return 0
@@ -470,15 +470,13 @@ win_capture() { # win_capture <pid>
     # reports EOF on an unterminated line having already assigned it.
     { read -r WIN_PID <"/proc/$1/winpid"; } 2>/dev/null || true
     { read -r WIN_IMAGE <"/proc/$1/winexename"; } 2>/dev/null || true
-    test -n "$WIN_IMAGE" || { read -r WIN_IMAGE <"/proc/$1/exename"; } 2>/dev/null || true
     WIN_IMAGE=${WIN_IMAGE##*[\\/]}
     return 0
 }
 
-# Whether Windows PID $1 is still running image $2. Case-folded and by both
-# columns at once, as 58_watchdog.test's liveness check is: either alone answers
-# for a recycled PID.
-win_pid_is() { # win_pid_is <winpid> <image>
+# Whether Windows PID $1 runs image $2. Both columns at once, since either alone
+# answers for a recycled PID, and case-folded as the proclib.sh matchers are.
+win_pid_runs() { # win_pid_runs <winpid> <image>
     tasklist 2>/dev/null |
         awk -v p="$1" -v i="$2" 'tolower($1) == tolower(i) && $2 == p { f = 1 } END { exit !f }'
 }
@@ -507,17 +505,17 @@ kill_pid() {
 # $2 is that Windows PID when the caller read it while the job was certainly
 # alive: /proc/<pid>/winpid is already gone for a job that has just died, and
 # without it the only route left is the host-wide sweep below. $3 is the image it
-# was running then, checked before firing so a PID Windows has already handed on
-# is skipped rather than tree-killed along with a stranger's children (#1228).
+# ran then: a number that no longer runs it was reissued while we were not
+# looking, and naming a stranger is as good as naming nobody (#1228).
 kill_tree() {
     local pid=$1 winpid=${2:-} image=${3:-}
     if is_windows; then
         test -n "$winpid" || winpid=$(win_pid "$pid")
+        if test -n "$winpid" && test -n "$image" && ! win_pid_runs "$winpid" "$image"; then
+            printf '::warning::pid %s no longer runs %s, not killing it\n' "$winpid" "$image"
+            winpid=
+        fi
         if test -n "$winpid"; then
-            if test -n "$image" && ! win_pid_is "$winpid" "$image"; then
-                printf '::warning::pid %s is no longer %s, not killing it\n' "$winpid" "$image" >&2
-                return 0
-            fi
             taskkill /F /T /PID "$winpid" >/dev/null 2>&1 || true
         # Last resort, so it is opt-in: it kills every engine and every python on
         # the host, siblings of a parallel run included (HTTRACK_EXCLUSIVE_HOST).
@@ -614,12 +612,12 @@ run_with_timeout() {
     local pid=$!
     test -n "$had_m" || is_windows || set +m
     # Read while the job is certainly alive: by kill time /proc/<pid>/winpid is gone.
-    win_capture "$pid"
-    local winpid=$WIN_PID winimage=$WIN_IMAGE
+    local winpid=''
+    ! is_windows || winpid=$(win_pid "$pid")
     local start=$SECONDS
     while kill -0 "$pid" 2>/dev/null; do
         if test "$((SECONDS - start))" -gt "$secs"; then
-            kill_tree "$pid" "$winpid" "$winimage"
+            kill_tree "$pid" "$winpid"
             reap_bounded "$pid" || true
             return 124
         fi
@@ -632,12 +630,9 @@ run_with_timeout() {
 # on overrun: a wedge past --max-time would else block wait() forever and hang the CI step.
 wait_bounded() {
     local pid=$1 secs=$2 start=$SECONDS
-    # Same as run_with_timeout: the crawl is alive now, and may not be at kill time.
-    win_capture "$pid"
-    local winpid=$WIN_PID winimage=$WIN_IMAGE
     while kill -0 "$pid" 2>/dev/null; do
         if test "$((SECONDS - start))" -gt "$secs"; then
-            kill_tree "$pid" "$winpid" "$winimage"
+            kill_tree "$pid"
             reap_bounded "$pid" || true
             return 124
         fi


### PR DESCRIPTION
The suite watchdog's commit statuses are the only evidence that survives a lost runner, and most of it was being thrown away: they went to the PR merge commit, whose SHA GitHub collects, leaving 3 of 146 recorded kills with any telemetry at all. They now go to the PR head, which costs us a line in the PR's checks list.

Each status carries more too. Loop lag and the number of posts that failed since one landed separate a box that stopped from a network that broke; `n=`/`f=`/`e=` come from one `GetTcpIPv4Statistics` call; `m=`/`c=`/`a=` are summed from the process array already enumerated for `p=` and `h=`. The cadence halves to 15s, and the in-flight test name is clipped to 30 characters to pay for the new fields. The widest real line measures 103 of the 140 characters GitHub keeps.

The rest closes two unsound spots in the Windows kill paths, neither of which explains the deaths. `stop_server` re-read `/proc/<pid>/winpid` after signalling its target, so the number it handed to `taskkill /F /T` could already belong to a stranger, and a hosted runner reissues a freed PID within a second rather than in theory. Nothing checked the image before firing either. Both the winpid and the image are now read while the target is alive and checked against `tasklist`, with a warning annotation when they disagree, which is also the meter for how often a tree kill would have left our own trees.

Refs #1228.
