### PR TITLE
Three suite tests fail on an emulated buildd for being slow, not broken

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,11 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   check`, or `PATH="<bld>/src:$PATH"` for a manual run.
 - Give new `.test` scripts `set -e`: the older ones predate the rule, so several
   `local-crawl.sh` calls with no `set -e` report PASS on any non-last failure.
+- Each test runs under a 600s wall-clock guard that reports a wedge as 124. A test
+  whose own work outlasts it raises the budget with a `# TEST_TIMEOUT_AT_LEAST: N`
+  line, at column 0 within its first 40 lines, and paces itself with
+  `skip_if_out_of_budget` so a host too slow to finish skips instead. The value only
+  ever raises the budget: nothing can disarm the guard.
 - Run teardown with errexit off: `trap 'set +e; cleanup' EXIT`. Under `set -e` a
   failing cleanup command becomes the test's exit status (#773). Keep the other
   signals on their own `trap` line, or errexit stays off for the rest of the run.

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -38,29 +38,39 @@ EOF
 
 # Time the guard to its DUMP announcement, not to the driver's exit: the dump that
 # follows runs for minutes on an emulated host, and that is not what is under test.
-# Leaves the latency in $fired and the driver's status in $rc.
+rc=0
+fired=
+marked=
 run_wedged() { # run_wedged <budget> [VAR=VAL...]
     local budget=$1 start=$SECONDS pid
     shift
     : >"$tmp/progress"
     rc=0
     fired=
+    marked=
     env "$@" HTTRACK_PROGRESS_LOG="$tmp/progress" HTTRACK_TEST_TIMEOUT="$budget" \
         bash "$driver" "$tmp/90_wedged.test" >"$out" 2>&1 &
     pid=$!
     while kill -0 "$pid" 2>/dev/null; do
-        if grep -qx 'DUMP 90_wedged.test' "$tmp/progress" 2>/dev/null; then
+        # Read with the shell: a fork per poll would blur the latency being measured.
+        if read -r line <"$tmp/progress" 2>/dev/null && test "$line" = "DUMP 90_wedged.test"; then
             fired=$((SECONDS - start))
+            marked=1
             break
         fi
-        poll_wait 0.2 || sleep 1
+        poll_wait 0.1 || sleep 1
     done
     wait "$pid" || rc=$?
     # Missed between two polls: the whole run then bounds the latency from above.
     test -n "$fired" || fired=$((SECONDS - start))
 }
 
+# Retried once, because a dump short enough to fall between two polls is a race, not a
+# regression; announcing after the dump loses both attempts.
 run_wedged 5
+test -n "$marked" || run_wedged 5
+test -n "$marked" ||
+    fail "the announcement was never seen while the guard ran, so its latency is unknown"
 
 # Announced when the dump starts, which runs for minutes: a suite watchdog
 # reading that log would take the silence for a wedge and kill the step.
@@ -148,47 +158,74 @@ saw_budget 0 "a disabled guard"
 # emulated host; anything else asking would be disarming the guard.
 raiser() { # raiser <asked for>
     # shellcheck disable=SC2016 # the fixture has to read the variable, not us
-    printf '# TEST_TIMEOUT: %s\necho "budget=${HTTRACK_TEST_TIMEOUT-unset}"\n' \
+    printf '# TEST_TIMEOUT_AT_LEAST: %s\necho "budget=${HTTRACK_TEST_TIMEOUT-unset}"\n' \
         "$1" >"$tmp/97_raise.test"
 }
-for want in 900:900 5:600 garbage:600; do
+# 0900 must not read as octal, and a value past intmax must not reach `test`, which
+# errors on it rather than comparing and would leave the guard unarmed.
+for want in 900:900 5:600 garbage:600 0900:900 99999999999999999999:600 ' 900':600; do
     raiser "${want%%:*}"
     HTTRACK_TEST_TIMEOUT=600 bash "$driver" "$tmp/97_raise.test" >"$out" 2>&1
-    saw_budget "${want##*:}" "a test asking for ${want%%:*}"
+    saw_budget "${want##*:}" "a test asking for '${want%%:*}'"
 done
 raiser 900
 HTTRACK_TEST_TIMEOUT=0 bash "$driver" "$tmp/97_raise.test" >"$out" 2>&1
 saw_budget 0 "a raise under a disabled guard"
-# Read from the header, or a test's own data would be one: 151 writes this very line.
-{
-    for i in {1..45}; do echo "# pad $i"; done
-    cat "$tmp/97_raise.test"
-} >"$tmp/97_deep.test"
-HTTRACK_TEST_TIMEOUT=600 bash "$driver" "$tmp/97_deep.test" >"$out" 2>&1
-saw_budget 600 "a raise past the header"
+# Read from the header only, or a test's own data would be one: 151 writes this line.
+window() { # window <lines of padding> <budget wanted>
+    {
+        i=0
+        while test "$i" -lt "$1"; do
+            i=$((i + 1))
+            echo "# pad $i"
+        done
+        cat "$tmp/97_raise.test"
+    } >"$tmp/97_deep.test"
+    HTTRACK_TEST_TIMEOUT=600 bash "$driver" "$tmp/97_deep.test" >"$out" 2>&1
+    saw_budget "$2" "a raise on line $(($1 + 1))"
+}
+raiser 900
+window 39 900 # the last line the header reaches
+window 40 600
 
-# The guard has to enforce the raise, not just export it.
-printf '# TEST_TIMEOUT: 900\nsleep 4\necho "outlived the default"\n' >"$tmp/97_raise.test"
+# Enforced, not merely exported: the number the guard uses is the one it kills on.
+printf '# TEST_TIMEOUT_AT_LEAST: 900\nsleep 4\necho "outlived the default"\n' \
+    >"$tmp/97_raise.test"
 rc=0
 HTTRACK_TEST_TIMEOUT=2 bash "$driver" "$tmp/97_raise.test" >"$out" 2>&1 || rc=$?
 test "$rc" -eq 0 || fail "a 4s test that raised the budget to 900 reported $rc"
 grep -q 'outlived the default' "$out" || fail "the raised budget killed the test anyway"
+printf '# TEST_TIMEOUT_AT_LEAST: 1\nsleep 3\necho "not shrunk"\n' >"$tmp/97_raise.test"
+rc=0
+HTTRACK_TEST_TIMEOUT=600 bash "$driver" "$tmp/97_raise.test" >"$out" 2>&1 || rc=$?
+test "$rc" -eq 0 || fail "a 3s test asking for a 1s budget reported $rc"
+grep -q 'not shrunk' "$out" || fail "the header shrank the budget and killed the test"
+
+# --- one budget parser, and what is left of it ------------------------------
+secs() { # secs <value in the environment> <seconds it must read as>
+    local got
+    got=$(HTTRACK_TEST_TIMEOUT=$1 bash -c '. "$1"; budget_secs' _ "${testdir}/testlib.sh" 2>&1)
+    test "$got" = "$2" || fail "budget_secs read '$1' as '$got', want $2"
+}
+secs 45 45
+secs 0900 900 # decimal, or $((...)) and test disagree on the same string
+secs garbage 600
+secs 99999999999999999999 600 # past intmax, where test errors instead of comparing
+secs 0 0
 
 # budget_left hands a child what is left of it, and keeps 0 meaning "no guard".
 # shellcheck disable=SC2016 # the fixture has to call the helper, not us
-printf '. "%s"\nsleep 2\necho "left=$(budget_left)"\n' "${testdir}/testlib.sh" \
+printf '. "%s"\nsleep 2\necho "left=$(budget_left) at=$SECONDS"\n' "${testdir}/testlib.sh" \
     >"$tmp/98_left.test"
-saw_left() { # saw_left <lowest> <highest> <label> <budget>
-    local got
-    HTTRACK_TEST_TIMEOUT=$4 bash "$driver" "$tmp/98_left.test" >"$out" 2>&1
-    got=$(sed -n 's/^left=//p' "$out")
-    case "$got" in '' | *[!0-9]*) fail "$3 left '$got', want $1..$2" ;; esac
-    if test "$got" -lt "$1" || test "$got" -gt "$2"; then
-        fail "$3 left '$got', want $1..$2"
-    fi
-}
-saw_left 50 58 "a 60s budget two seconds in" 60
-saw_left 0 0 "a disabled guard" 0
+# Exact, against the clock the child itself read: a tolerance would pass a wrong epoch.
+HTTRACK_TEST_TIMEOUT=60 bash "$driver" "$tmp/98_left.test" >"$out" 2>&1
+got=$(sed -n 's/^left=\([0-9][0-9]*\) .*/\1/p' "$out")
+at=$(sed -n 's/^left=[0-9][0-9]* at=\([0-9][0-9]*\)$/\1/p' "$out")
+case "$got$at" in '' | *[!0-9]*) fail "a 60s budget printed '$(cat "$out")'" ;; esac
+test "$got" -eq "$((60 - at))" ||
+    fail "a 60s budget left $got with $at gone, want $((60 - at))"
+HTTRACK_TEST_TIMEOUT=0 bash "$driver" "$tmp/98_left.test" >"$out" 2>&1
+grep -q '^left=0 ' "$out" || fail "a disabled guard left '$(cat "$out")', want 0"
 # Never 0 on an exhausted budget: a child would read that as the guard being off.
 HTTRACK_TEST_TIMEOUT=1 bash -c '. "$1"; sleep 2; echo "left=$(budget_left)"' \
     _ "${testdir}/testlib.sh" >"$out" 2>&1

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -41,6 +41,7 @@ EOF
 rc=0
 fired=
 marked=
+total=
 run_wedged() { # run_wedged <budget> [VAR=VAL...]
     local budget=$1 start=$SECONDS pid
     shift
@@ -61,8 +62,9 @@ run_wedged() { # run_wedged <budget> [VAR=VAL...]
         poll_wait 0.1 || sleep 1
     done
     wait "$pid" || rc=$?
+    total=$((SECONDS - start))
     # Missed between two polls: the whole run then bounds the latency from above.
-    test -n "$fired" || fired=$((SECONDS - start))
+    test -n "$fired" || fired=$total
 }
 
 # Retried once, because a dump short enough to fall between two polls is a race, not a
@@ -87,6 +89,20 @@ grep -q 'marker: the wedged test started' "$out" || fail "the test's own output 
 grep -q '^===== TIMEOUT: 90_wedged.test exceeded' "$out" ||
     fail "the diagnostics do not name the test"
 grep -q "own process tree" "$out" || fail "no process list in the diagnostics"
+
+# Announced BEFORE the dump, not merely at some point during it: the watchdog reading
+# that log takes the silence of a dump for a wedge. Only a slow dump tells the two
+# orderings apart, and the dump's own ps is what this makes slow.
+if ! is_windows; then
+    printf '#!/bin/sh\nsleep 3\nexec %s "$@"\n' "$(command -v ps)" >"$shim/ps"
+    chmod +x "$shim/ps"
+    run_wedged 5 "PATH=$shim:$PATH"
+    rm -f "$shim/ps" # before the starve shim shares this directory
+    test "$rc" -eq 124 || fail "the guard reported $rc under a slow dump, want 124"
+    test -n "$marked" || fail "no announcement under a slow dump"
+    test "$((total - fired))" -ge 2 ||
+        fail "announced with the dump (${fired}s of ${total}s), not before it"
+fi
 
 # The budget is read, not hard-coded: well under it, the same shape survives.
 printf 'sleep 3\necho "slow but healthy"\n' >"$tmp/92_slow.test"

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -36,11 +36,31 @@ echo "marker: the wedged test started"
 sleep 300
 EOF
 
-start=$SECONDS
-rc=0
-HTTRACK_PROGRESS_LOG="$tmp/progress" HTTRACK_TEST_TIMEOUT=5 \
-    bash "$driver" "$tmp/90_wedged.test" >"$out" 2>&1 || rc=$?
-elapsed=$((SECONDS - start))
+# Time the guard to its DUMP announcement, not to the driver's exit: the dump that
+# follows runs for minutes on an emulated host, and that is not what is under test.
+# Leaves the latency in $fired and the driver's status in $rc.
+run_wedged() { # run_wedged <budget> [VAR=VAL...]
+    local budget=$1 start=$SECONDS pid
+    shift
+    : >"$tmp/progress"
+    rc=0
+    fired=
+    env "$@" HTTRACK_PROGRESS_LOG="$tmp/progress" HTTRACK_TEST_TIMEOUT="$budget" \
+        bash "$driver" "$tmp/90_wedged.test" >"$out" 2>&1 &
+    pid=$!
+    while kill -0 "$pid" 2>/dev/null; do
+        if grep -qx 'DUMP 90_wedged.test' "$tmp/progress" 2>/dev/null; then
+            fired=$((SECONDS - start))
+            break
+        fi
+        poll_wait 0.2 || sleep 1
+    done
+    wait "$pid" || rc=$?
+    # Missed between two polls: the whole run then bounds the latency from above.
+    test -n "$fired" || fired=$((SECONDS - start))
+}
+
+run_wedged 5
 
 # Announced when the dump starts, which runs for minutes: a suite watchdog
 # reading that log would take the silence for a wedge and kill the step.
@@ -49,8 +69,8 @@ grep -qx 'DUMP 90_wedged.test' "$tmp/progress" ||
 
 test "$rc" -eq 124 || fail "wedged test reported $rc, want 124"
 # Never before the budget, or a slow-but-healthy test would be killed too.
-test "$elapsed" -ge 5 || fail "the guard fired early (${elapsed}s of a 5s budget)"
-test "$elapsed" -lt 30 || fail "the guard fired late (${elapsed}s)"
+test "$fired" -ge 5 || fail "the guard fired early (${fired}s of a 5s budget)"
+test "$fired" -lt 30 || fail "the guard fired late (${fired}s)"
 grep -q 'marker: the wedged test started' "$out" || fail "the test's own output was lost"
 # The header, not a bare name: the process list quotes the test's path too, so a
 # wrapper that named nothing would still match that.
@@ -78,15 +98,11 @@ sleep 1
 # the loop it stretches is the same one poll_wait's fd tick drives.
 (
     starve_sleep "$shim" 4 || fail "could not install the slow sleep"
-    start=$SECONDS
-    rc=0
-    HTTRACK_POLL_SLEEP=1 HTTRACK_TEST_TIMEOUT=1 \
-        bash "$driver" "$tmp/90_wedged.test" >"$out" 2>&1 || rc=$?
-    elapsed=$((SECONDS - start))
+    run_wedged 1 HTTRACK_POLL_SLEEP=1
     test "$rc" -eq 124 || fail "starved guard reported $rc, want 124"
-    # Generous: the diagnostics dump runs inside this window too.
-    test "$elapsed" -lt 25 ||
-        fail "budget counted polls, not seconds: ${elapsed}s for a 1s budget"
+    # 10 stretched polls would be 40s; a handful of them is the whole margin here.
+    test "$fired" -lt 25 ||
+        fail "budget counted polls, not seconds: ${fired}s for a 1s budget"
 )
 
 # --- exit status and output of a healthy test pass straight through ----------
@@ -126,6 +142,57 @@ saw_budget 45 "an explicit budget"
 # 0 execs the test directly, so the pacer has to see the guard is off too.
 HTTRACK_TEST_TIMEOUT=0 bash "$driver" "$tmp/95_budget.test" >"$out" 2>&1
 saw_budget 0 "a disabled guard"
+
+# --- a test may raise the budget, never lower it ----------------------------
+# 269's header sweep is n^2 compiles, real work that outlasts the wedge budget on an
+# emulated host; anything else asking would be disarming the guard.
+raiser() { # raiser <asked for>
+    # shellcheck disable=SC2016 # the fixture has to read the variable, not us
+    printf '# TEST_TIMEOUT: %s\necho "budget=${HTTRACK_TEST_TIMEOUT-unset}"\n' \
+        "$1" >"$tmp/97_raise.test"
+}
+for want in 900:900 5:600 garbage:600; do
+    raiser "${want%%:*}"
+    HTTRACK_TEST_TIMEOUT=600 bash "$driver" "$tmp/97_raise.test" >"$out" 2>&1
+    saw_budget "${want##*:}" "a test asking for ${want%%:*}"
+done
+raiser 900
+HTTRACK_TEST_TIMEOUT=0 bash "$driver" "$tmp/97_raise.test" >"$out" 2>&1
+saw_budget 0 "a raise under a disabled guard"
+# Read from the header, or a test's own data would be one: 151 writes this very line.
+{
+    for i in {1..45}; do echo "# pad $i"; done
+    cat "$tmp/97_raise.test"
+} >"$tmp/97_deep.test"
+HTTRACK_TEST_TIMEOUT=600 bash "$driver" "$tmp/97_deep.test" >"$out" 2>&1
+saw_budget 600 "a raise past the header"
+
+# The guard has to enforce the raise, not just export it.
+printf '# TEST_TIMEOUT: 900\nsleep 4\necho "outlived the default"\n' >"$tmp/97_raise.test"
+rc=0
+HTTRACK_TEST_TIMEOUT=2 bash "$driver" "$tmp/97_raise.test" >"$out" 2>&1 || rc=$?
+test "$rc" -eq 0 || fail "a 4s test that raised the budget to 900 reported $rc"
+grep -q 'outlived the default' "$out" || fail "the raised budget killed the test anyway"
+
+# budget_left hands a child what is left of it, and keeps 0 meaning "no guard".
+# shellcheck disable=SC2016 # the fixture has to call the helper, not us
+printf '. "%s"\nsleep 2\necho "left=$(budget_left)"\n' "${testdir}/testlib.sh" \
+    >"$tmp/98_left.test"
+saw_left() { # saw_left <lowest> <highest> <label> <budget>
+    local got
+    HTTRACK_TEST_TIMEOUT=$4 bash "$driver" "$tmp/98_left.test" >"$out" 2>&1
+    got=$(sed -n 's/^left=//p' "$out")
+    case "$got" in '' | *[!0-9]*) fail "$3 left '$got', want $1..$2" ;; esac
+    if test "$got" -lt "$1" || test "$got" -gt "$2"; then
+        fail "$3 left '$got', want $1..$2"
+    fi
+}
+saw_left 50 58 "a 60s budget two seconds in" 60
+saw_left 0 0 "a disabled guard" 0
+# Never 0 on an exhausted budget: a child would read that as the guard being off.
+HTTRACK_TEST_TIMEOUT=1 bash -c '. "$1"; sleep 2; echo "left=$(budget_left)"' \
+    _ "${testdir}/testlib.sh" >"$out" 2>&1
+grep -qx 'left=1' "$out" || fail "an exhausted budget left '$(cat "$out")', want 1"
 
 # --- a test too slow to finish skips instead of being killed ----------------
 # hppa spends ~150s on one configure run, and 124 takes the build down where 77

--- a/tests/151_bash-shell-validate.test
+++ b/tests/151_bash-shell-validate.test
@@ -51,6 +51,12 @@ chmod 755 "$tmp/fakebin/bash"
 mkfifo "$tmp/fifo"
 chmod 755 "$tmp/fifo"
 
+# Sampled rather than polled per second: the size read is a fork, and an emulated
+# host pays for it. SILENCE clears the slowest single configure probe there.
+SAMPLE=5
+SILENCE=${HTTRACK_CONFIGURE_SILENCE:-120}
+RESERVE=15 # what killing the run and skipping still needs of the budget
+
 n=0
 cases=16 # reject/accept calls below; pinned again once they have all run
 status=0
@@ -67,17 +73,35 @@ run() { # run <label> <env argument>...
     # at all. Polled, not a backgrounded "sleep" watchdog, which outlives the run it guards.
     (cd "$rundir" && env "$@" bash "$tmp/src/configure" --disable-https) \
         >"$rundir/log" 2>&1 &
-    local pid=$! waited=0
-    while test "$waited" -lt 300 && kill -0 "$pid" 2>/dev/null; do
+    local pid=$! waited=0 quiet=0 size=0 now left
+    # A hang is silence, not slowness: configure writes a line per probe, where hppa's
+    # emulated one spends longer on the whole run than a runner's whole budget (#1146).
+    while kill -0 "$pid" 2>/dev/null; do
         sleep 1
         waited=$((waited + 1))
+        test "$((waited % SAMPLE))" -eq 0 || continue
+        now=$(wc -c <"$rundir/log")
+        if test "$now" -gt "$size"; then
+            size=$now
+            quiet=0
+        else
+            quiet=$((quiet + SAMPLE))
+        fi
+        test "$quiet" -lt "$SILENCE" || {
+            kill -9 "$pid" 2>/dev/null
+            echo "configure wrote nothing for ${quiet}s of ${waited}s for $label" >&2
+            tail -5 "$rundir/log" >&2
+            exit 1
+        }
+        # Making progress but out of time: the harness would kill the whole test at the
+        # budget, and 124 takes the build down where a skip does not. 0 is the guard off.
+        left=$(budget_left)
+        test "$left" -eq 0 || test "$left" -gt "$RESERVE" || {
+            kill -9 "$pid" 2>/dev/null
+            echo "$label was still configuring ${waited}s in and the budget is out; skipping" >&2
+            exit 77
+        }
     done
-    if kill -0 "$pid" 2>/dev/null; then
-        kill -9 "$pid" 2>/dev/null
-        echo "configure did not return within ${waited}s for $label" >&2
-        tail -5 "$rundir/log" >&2
-        exit 1
-    fi
     wait "$pid" || status=$?
     log=$(cat "$rundir/log")
     echo "run $n ($label): exit $status"

--- a/tests/151_bash-shell-validate.test
+++ b/tests/151_bash-shell-validate.test
@@ -174,6 +174,7 @@ probe() { # probe <run number> <seconds of budget left> <command>...
     (
         # shellcheck disable=SC2030 # the isolation is the point: the real count is next door
         n=$want_n SAMPLE=1 SILENCE=2
+        # shellcheck disable=SC2030,SC2031 # likewise: the budget here is the probe's own
         export HTTRACK_TEST_TIMEOUT=$((SECONDS + left))
         configure_cmd=("$@")
         run probe
@@ -188,23 +189,28 @@ grep -q 'wrote nothing' "$tmp/probe.log" || fail "the hang was not named: $(cat 
 rc=$(probe 91 6 bash -c 'while :; do echo tick; sleep 1; done')
 test "$rc" -eq 77 || fail "a slow but writing configure with 6s of budget reported $rc, want 77"
 # The pacer must not fire before the case is judged: run() returns with the verdict
-# still unread, and a skip there would bury a configure that answered wrongly.
-verdict() { # verdict <accept|reject> <status the stub reports>
-    local rc=0 stub_status=$2
+# still unread, and a skip there would bury a configure that answered wrongly. Through
+# the real run(), since a stub cannot see a pacer left inside the one it replaced.
+verdict() { # verdict <accept|reject> <run number> <status the child exits with>
+    local rc=0
     (
-        # shellcheck disable=SC2030,SC2031,SC2317 # a stub, reached through accept/reject
-        run() { # stub: judged, and the budget spent
-            n=$((n + 1))
-            status=$stub_status
-            log=
-            took=99999
-        }
-        "$1" stub-verdict '' ''
+        # shellcheck disable=SC2030,SC2031 # the isolation is the point: the real run is next door
+        n=$2 SAMPLE=1
+        # Spent by the time the run ends, so a pacer anywhere after it would fire.
+        # shellcheck disable=SC2030,SC2031 # likewise: the budget here is the probe's own
+        export HTTRACK_TEST_TIMEOUT=$((SECONDS + 4))
+        configure_cmd=(bash -c "sleep 3; exit $3")
+        # Their arities differ, and an extra argument would reach run() as an env
+        # assignment: the child would then fail to exec and answer the wrong question.
+        case "$1" in
+        accept) accept probe-verdict '' '' ;;
+        *) reject probe-verdict '' ;;
+        esac
     ) >/dev/null 2>&1 || rc=$?
     test "$rc" -eq 1 || fail "$1 of a wrong answer with the budget spent reported $rc, want 1"
 }
-verdict accept 1 # configure rejected what it must accept
-verdict reject 0 # configure accepted what it must reject
+verdict accept 80 1 # configure rejected what it must accept
+verdict reject 81 0 # configure accepted what it must reject
 # The probes ran in subshells, so the real cases below start from a clean count.
 n=0
 status=0

--- a/tests/151_bash-shell-validate.test
+++ b/tests/151_bash-shell-validate.test
@@ -8,6 +8,8 @@ set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
 . "$(dirname "$0")/testlib.sh"
+# shellcheck source=tests/proclib.sh
+. "$(dirname "$0")/proclib.sh"
 
 sh=${BASH_SHELL:-}
 test -n "$sh" || {
@@ -75,9 +77,15 @@ run() { # run <label> <env argument>...
     status=0
     # Capped: configure executes the candidate, and a hang wedges "make check" with no output
     # at all. Polled, not a backgrounded "sleep" watchdog, which outlives the run it guards.
+    local had_m=
+    case "$-" in *m*) had_m=1 ;; esac
+    # Own process group, so the kills below reach what configure spawned: bash 3.2 keeps
+    # the subshell it runs in, and killing that alone leaves the child running (macOS).
+    set -m
     (cd "$rundir" && env "$@" "${configure_cmd[@]}") \
         >"$rundir/log" 2>&1 &
     local pid=$! waited=0 quiet=0 size=0 now left
+    test -n "$had_m" || set +m
     # A hang is silence, not slowness: configure writes a line per probe,
     # but hppa's emulated run can take longer overall than a runner's whole budget (#1146).
     while kill -0 "$pid" 2>/dev/null; do
@@ -92,7 +100,7 @@ run() { # run <label> <env argument>...
             quiet=$((quiet + SAMPLE))
         fi
         test "$quiet" -lt "$SILENCE" || {
-            kill -9 "$pid" 2>/dev/null
+            kill_tree "$pid"
             echo "configure wrote nothing for ${quiet}s of ${waited}s for $label" >&2
             tail -5 "$rundir/log" >&2
             exit 1
@@ -104,7 +112,7 @@ run() { # run <label> <env argument>...
         left=$(budget_left)
         if test "$quiet" -eq 0 && test "$left" -ne 0 &&
             test "$left" -le "$((RESERVE + SILENCE))"; then
-            kill -9 "$pid" 2>/dev/null
+            kill_tree "$pid"
             echo "$label was still configuring ${waited}s in and the budget is out; skipping" >&2
             exit 77
         fi
@@ -188,6 +196,13 @@ grep -q 'wrote nothing' "$tmp/probe.log" || fail "the hang was not named: $(cat 
 # Slow but talking is the emulated buildd, and a skip there beats the harness kill.
 rc=$(probe 91 6 bash -c 'while :; do echo tick; sleep 1; done')
 test "$rc" -eq 77 || fail "a slow but writing configure with 6s of budget reported $rc, want 77"
+# The kill has to reach what configure spawned. bash 3.2 keeps the subshell around the
+# child, so killing that alone leaves a live configure behind: it outlives "make check"
+# and holds the CI step open to its own timeout, with the suite reporting no failure.
+rc=$(probe 92 6 bash -c 'sleep 987 & wait')
+test "$rc" -eq 1 || fail "a silent configure with a child of its own reported $rc, want 1"
+sleep 1
+! ps_snapshot | grep -q '[s]leep 987' || fail "the killed run left its child running"
 # The pacer must not fire before the case is judged: run() returns with the verdict
 # still unread, and a skip there would bury a configure that answered wrongly. Through
 # the real run(), since a stub cannot see a pacer left inside the one it replaced.

--- a/tests/151_bash-shell-validate.test
+++ b/tests/151_bash-shell-validate.test
@@ -195,7 +195,8 @@ verdict() { # verdict <accept|reject> <run number> <status the child exits with>
     local rc=0
     (
         # shellcheck disable=SC2030,SC2031 # the isolation is the point: the real run is next door
-        n=$2 SAMPLE=1
+        # Cases still to come, or the pacer this is looking for would decline to fire.
+        n=$2 cases=$(($2 + 5)) SAMPLE=1
         # Spent by the time the run ends, so a pacer anywhere after it would fire.
         # shellcheck disable=SC2030,SC2031 # likewise: the budget here is the probe's own
         export HTTRACK_TEST_TIMEOUT=$((SECONDS + 4))
@@ -212,6 +213,7 @@ verdict() { # verdict <accept|reject> <run number> <status the child exits with>
 verdict accept 80 1 # configure rejected what it must accept
 verdict reject 81 0 # configure accepted what it must reject
 # The probes ran in subshells, so the real cases below start from a clean count.
+cases=16
 n=0
 status=0
 log=

--- a/tests/151_bash-shell-validate.test
+++ b/tests/151_bash-shell-validate.test
@@ -62,6 +62,10 @@ cases=16 # reject/accept calls below; pinned again once they have all run
 status=0
 log=
 rundir=
+took=0
+# What run() launches, so the checks below can hand it a child that hangs or one that
+# only crawls; nothing else may override it.
+configure_cmd=(bash "$tmp/src/configure" --disable-https)
 run() { # run <label> <env argument>...
     local label=$1 began=$SECONDS
     shift
@@ -71,11 +75,11 @@ run() { # run <label> <env argument>...
     status=0
     # Capped: configure executes the candidate, and a hang wedges "make check" with no output
     # at all. Polled, not a backgrounded "sleep" watchdog, which outlives the run it guards.
-    (cd "$rundir" && env "$@" bash "$tmp/src/configure" --disable-https) \
+    (cd "$rundir" && env "$@" "${configure_cmd[@]}") \
         >"$rundir/log" 2>&1 &
     local pid=$! waited=0 quiet=0 size=0 now left
-    # A hang is silence, not slowness: configure writes a line per probe, where hppa's
-    # emulated one spends longer on the whole run than a runner's whole budget (#1146).
+    # A hang is silence, not slowness: configure writes a line per probe,
+    # but hppa's emulated run can take longer overall than a runner's whole budget (#1146).
     while kill -0 "$pid" 2>/dev/null; do
         sleep 1
         waited=$((waited + 1))
@@ -93,19 +97,28 @@ run() { # run <label> <env argument>...
             tail -5 "$rundir/log" >&2
             exit 1
         }
-        # Making progress but out of time: the harness would kill the whole test at the
-        # budget, and 124 takes the build down where a skip does not. 0 is the guard off.
+        # Still writing but out of time: skip, where the harness would kill the whole test
+        # and take the build down with it. Only while writing, and only with a full silence
+        # window still affordable, or a hang would reach this before the check above fires
+        # and a wedge would report a skip. 0 is the guard off.
         left=$(budget_left)
-        test "$left" -eq 0 || test "$left" -gt "$RESERVE" || {
+        if test "$quiet" -eq 0 && test "$left" -ne 0 &&
+            test "$left" -le "$((RESERVE + SILENCE))"; then
             kill -9 "$pid" 2>/dev/null
             echo "$label was still configuring ${waited}s in and the budget is out; skipping" >&2
             exit 77
-        }
+        fi
     done
     wait "$pid" || status=$?
     log=$(cat "$rundir/log")
+    took=$((SECONDS - began))
     echo "run $n ($label): exit $status"
-    skip_if_out_of_budget "$((cases - n))" "$((SECONDS - began))"
+}
+
+# Pace here rather than in run(), which returns with the answer still unjudged: a
+# skip between the two would bury a configure that answered wrongly.
+paced() {
+    skip_if_out_of_budget "$((cases - n))" "$took"
 }
 
 reject() { # reject <label> <expected message> <env argument>...
@@ -121,6 +134,7 @@ reject() { # reject <label> <expected message> <env argument>...
         tail -5 <<<"$log" >&2
         exit 1
     }
+    paced
 }
 
 # accept <label> <expected $(BASH_SHELL), "" for any> <expected message, "" for none> <env argument>...
@@ -149,7 +163,53 @@ accept() {
             exit 1
         }
     fi
+    paced
 }
+
+# --- what run() does to a child that hangs, and to one that is merely slow -------
+# Driven through configure_cmd, since the real configure can do neither on demand.
+probe() { # probe <run number> <seconds of budget left> <command>...
+    local want_n=$1 left=$2 rc=0
+    shift 2
+    (
+        # shellcheck disable=SC2030 # the isolation is the point: the real count is next door
+        n=$want_n SAMPLE=1 SILENCE=2
+        export HTTRACK_TEST_TIMEOUT=$((SECONDS + left))
+        configure_cmd=("$@")
+        run probe
+    ) >"$tmp/probe.log" 2>&1 || rc=$?
+    echo "$rc"
+}
+# A wedge must fail even with the budget gone, or #922 comes back as a skip.
+rc=$(probe 90 6 sleep 999)
+test "$rc" -eq 1 || fail "a silent configure with 6s of budget reported $rc, want 1"
+grep -q 'wrote nothing' "$tmp/probe.log" || fail "the hang was not named: $(cat "$tmp/probe.log")"
+# Slow but talking is the emulated buildd, and a skip there beats the harness kill.
+rc=$(probe 91 6 bash -c 'while :; do echo tick; sleep 1; done')
+test "$rc" -eq 77 || fail "a slow but writing configure with 6s of budget reported $rc, want 77"
+# The pacer must not fire before the case is judged: run() returns with the verdict
+# still unread, and a skip there would bury a configure that answered wrongly.
+verdict() { # verdict <accept|reject> <status the stub reports>
+    local rc=0 stub_status=$2
+    (
+        # shellcheck disable=SC2030,SC2031,SC2317 # a stub, reached through accept/reject
+        run() { # stub: judged, and the budget spent
+            n=$((n + 1))
+            status=$stub_status
+            log=
+            took=99999
+        }
+        "$1" stub-verdict '' ''
+    ) >/dev/null 2>&1 || rc=$?
+    test "$rc" -eq 1 || fail "$1 of a wrong answer with the budget spent reported $rc, want 1"
+}
+verdict accept 1 # configure rejected what it must accept
+verdict reject 0 # configure accepted what it must reject
+# The probes ran in subshells, so the real cases below start from a clean count.
+n=0
+status=0
+log=
+took=0
 
 # The four that configure to completion run first. A reject stops at the
 # BASH_SHELL check and costs a fraction of one, and the pacer projects the step it

--- a/tests/269_install-headers-order.test
+++ b/tests/269_install-headers-order.test
@@ -9,7 +9,7 @@
 #
 # n^2 compiles is real work, not a wedge: emulated, it needs more than the suite's
 # default budget, and the sweep paces itself against whatever is left of this one.
-# TEST_TIMEOUT: 900
+# TEST_TIMEOUT_AT_LEAST: 900
 
 set -euo pipefail
 
@@ -74,8 +74,7 @@ done
 sweep_argv=(--headers-dir "$tmp/include/httrack" --cc "${CC:-cc}" --cxx "$cxx")
 [ "${#cpp_argv[@]}" -eq 0 ] || sweep_argv+=(-- "${cpp_argv[@]}")
 rc=0
-HTTRACK_TEST_TIMEOUT=$(budget_left) \
-    bash "$testdir/install-headers-sweep.sh" "${sweep_argv[@]}" || rc=$?
+bash "$testdir/install-headers-sweep.sh" --budget "$(budget_left)" "${sweep_argv[@]}" || rc=$?
 # 77 is the sweep giving up on a host too slow to finish it, not a broken header.
 [ "$rc" -ne 77 ] || exit 77
 [ "$rc" -eq 0 ] || fail "installed headers do not survive every include order"

--- a/tests/269_install-headers-order.test
+++ b/tests/269_install-headers-order.test
@@ -6,6 +6,10 @@
 # a break needing three headers, or a macro the consumer defined first, is out
 # of reach here. The sweep is shared with the MSVC job, which has no automake to
 # install with and so stages the same list out of DevIncludes_DATA (#1153).
+#
+# n^2 compiles is real work, not a wedge: emulated, it needs more than the suite's
+# default budget, and the sweep paces itself against whatever is left of this one.
+# TEST_TIMEOUT: 900
 
 set -euo pipefail
 
@@ -69,7 +73,11 @@ done
 
 sweep_argv=(--headers-dir "$tmp/include/httrack" --cc "${CC:-cc}" --cxx "$cxx")
 [ "${#cpp_argv[@]}" -eq 0 ] || sweep_argv+=(-- "${cpp_argv[@]}")
-bash "$testdir/install-headers-sweep.sh" "${sweep_argv[@]}" ||
-    fail "installed headers do not survive every include order"
+rc=0
+HTTRACK_TEST_TIMEOUT=$(budget_left) \
+    bash "$testdir/install-headers-sweep.sh" "${sweep_argv[@]}" || rc=$?
+# 77 is the sweep giving up on a host too slow to finish it, not a broken header.
+[ "$rc" -ne 77 ] || exit 77
+[ "$rc" -eq 0 ] || fail "installed headers do not survive every include order"
 
 exit 0

--- a/tests/install-headers-sweep.sh
+++ b/tests/install-headers-sweep.sh
@@ -237,13 +237,29 @@ fi
 
 began=$SECONDS
 bad=0
+# Sliced so the sweep can be given up on: one call per batch cannot be interrupted, and
+# an emulated compiler wants longer for it than the harness allows a test (#1146). Still
+# nowhere near a spawn per unit, which costs more than the compile on the Windows runner.
+slices=8
+slice=$(((${#units[@]} + slices - 1) / slices))
+left=$((${#langs[@]} * ${#modes[@]} * slices))
 for lang in "${langs[@]}"; do
     for mode in "${modes[@]}"; do
-        compile "$lang" "$mode" "${units[@]}" || {
-            head -40 "$sweep_log" >&2
-            echo "the headers do not compile as $lang standalone and pairwise ($mode)" >&2
-            bad=1
-        }
+        i=0
+        while [ "$i" -lt "${#units[@]}" ]; do
+            step=$SECONDS
+            compile "$lang" "$mode" "${units[@]:i:slice}" || {
+                head -40 "$sweep_log" >&2
+                echo "the headers do not compile as $lang standalone and pairwise ($mode)" >&2
+                bad=1
+            }
+            i=$((i + slice))
+            left=$((left - 1))
+            # Only under a caller that set the budget (269, not the MSVC job), and only
+            # while nothing has failed: a skip past a real break would bury it.
+            [ "$bad" -ne 0 ] || [ -z "${HTTRACK_TEST_TIMEOUT:-}" ] ||
+                skip_if_out_of_budget "$left" "$((SECONDS - step))"
+        done
     done
 done
 echo "swept $n headers standalone and pairwise x ${#modes[@]} bytecode modes x ${langs[*]}" \

--- a/tests/install-headers-sweep.sh
+++ b/tests/install-headers-sweep.sh
@@ -14,7 +14,8 @@ set -euo pipefail
 
 usage() {
     echo "usage: ${0##*/} {--srcdir DIR [--builddir DIR] | --headers-dir DIR}" \
-        "[--backend cl|cc] [--cc CMD] [--cxx CMD] [--self-test] [-- CPPFLAGS...]" >&2
+        "[--backend cl|cc] [--cc CMD] [--cxx CMD] [--budget SECONDS] [--self-test]" \
+        "[-- CPPFLAGS...]" >&2
     exit 1
 }
 
@@ -26,12 +27,17 @@ cc_cmd=""
 cxx_cmd=""
 cxx_set=0
 selftest=0
+budget=
 extra=()
 while [ $# -gt 0 ]; do
     case $1 in
     --self-test)
         selftest=1
         shift
+        ;;
+    --budget)
+        budget=${2-}
+        shift 2 || usage
         ;;
     --srcdir)
         srcdir=${2-}
@@ -237,31 +243,45 @@ fi
 
 began=$SECONDS
 bad=0
-# Sliced so the sweep can be given up on: one call per batch cannot be interrupted, and
-# an emulated compiler wants longer for it than the harness allows a test (#1146). Still
-# nowhere near a spawn per unit, which costs more than the compile on the Windows runner.
-slices=8
+# Sliced only for a caller that gave a budget: one call per batch cannot be given up on,
+# and an emulated compiler needs more time for it than the harness allows a test (#1146).
+# Unsliced elsewhere, so the Windows job keeps paying one compiler spawn per batch.
+if [ -n "$budget" ] && [ "$budget" -gt 0 ]; then
+    export HTTRACK_TEST_TIMEOUT=$budget
+    slices=8
+else
+    slices=1
+fi
 slice=$(((${#units[@]} + slices - 1) / slices))
-left=$((${#langs[@]} * ${#modes[@]} * slices))
+# From the slice size, not from $slices: they differ whenever the units do not divide
+# evenly, and a step count that outlives the loop leaves the pacer projecting forever.
+per=$(((${#units[@]} + slice - 1) / slice))
+left=$((${#langs[@]} * ${#modes[@]} * per))
+swept=0
 for lang in "${langs[@]}"; do
     for mode in "${modes[@]}"; do
         i=0
         while [ "$i" -lt "${#units[@]}" ]; do
             step=$SECONDS
-            compile "$lang" "$mode" "${units[@]:i:slice}" || {
+            chunk=("${units[@]:i:slice}")
+            swept=$((swept + ${#chunk[@]}))
+            compile "$lang" "$mode" "${chunk[@]}" || {
                 head -40 "$sweep_log" >&2
                 echo "the headers do not compile as $lang standalone and pairwise ($mode)" >&2
                 bad=1
             }
             i=$((i + slice))
             left=$((left - 1))
-            # Only under a caller that set the budget (269, not the MSVC job), and only
-            # while nothing has failed: a skip past a real break would bury it.
-            [ "$bad" -ne 0 ] || [ -z "${HTTRACK_TEST_TIMEOUT:-}" ] ||
+            # Only while nothing has failed: a skip past a real break would bury it.
+            [ "$bad" -ne 0 ] || [ -z "$budget" ] ||
                 skip_if_out_of_budget "$left" "$((SECONDS - step))"
         done
     done
 done
+# What reached the compiler, not what was generated: a slice loop that steps past a unit
+# would otherwise report the full set and pass.
+want=$((${#langs[@]} * ${#modes[@]} * ${#units[@]}))
+[ "$swept" -eq "$want" ] || fail "compiled $swept units of $want, the slicing lost some"
 echo "swept $n headers standalone and pairwise x ${#modes[@]} bytecode modes x ${langs[*]}" \
     "= $((${#modes[@]} * ${#langs[@]} * ${#units[@]})) units in $((SECONDS - began))s with $backend"
 [ "$bad" -eq 0 ] || exit 1

--- a/tests/test-timeout.sh
+++ b/tests/test-timeout.sh
@@ -26,14 +26,35 @@ budget=${HTTRACK_TEST_TIMEOUT:-600}
 case "$budget" in
 '' | *[!0-9]*) budget=600 ;;
 esac
+
+# The test script is the last argument; automake passes no others today.
+for path in "$@"; do :; done
+name=$(basename "$path")
+
+# A test whose work legitimately outlasts the wedge budget says so in its header
+# (269 sweeps n^2 compiles and paces itself inside it). Upwards only, so no test can
+# disarm the guard, and read with the shell to keep it off the per-test fork bill.
+if test "$budget" -gt 0 && test -r "$path"; then
+    read_lines=0
+    while test "$read_lines" -lt 40 && IFS= read -r line; do
+        read_lines=$((read_lines + 1))
+        case "$line" in
+        '# TEST_TIMEOUT: '*)
+            want=${line#'# TEST_TIMEOUT: '}
+            case "$want" in
+            '' | *[!0-9]*) ;;
+            *) test "$want" -le "$budget" || budget=$want ;;
+            esac
+            break
+            ;;
+        esac
+    done <"$path"
+fi
+
 # Exported so a test can pace itself against the same number (skip_if_out_of_budget)
 # instead of being killed halfway.
 export HTTRACK_TEST_TIMEOUT="$budget"
 test "$budget" -gt 0 || exec "$BASH" "$@"
-
-# The test script is the last argument; automake passes no others today.
-for name in "$@"; do :; done
-name=$(basename "$name")
 
 # Give the test its own TMPDIR, so the hang dump can salvage exactly this test's
 # crawl logs instead of racing (and deleting) a sibling's under "make check -j".

--- a/tests/test-timeout.sh
+++ b/tests/test-timeout.sh
@@ -22,28 +22,27 @@ testdir=$(cd "$(dirname "$0")" && pwd)
 # (CRAWL_DEADLINE, 180s a pass) -- budget below that and a slow-but-legitimate
 # run would be killed. The slowest healthy test measures 39s. A non-numeric or
 # absurd value falls back; 0 disables the guard, for use under a debugger.
-budget=${HTTRACK_TEST_TIMEOUT:-600}
-case "$budget" in
-'' | *[!0-9]*) budget=600 ;;
-esac
+budget=$(budget_secs)
 
 # The test script is the last argument; automake passes no others today.
 for path in "$@"; do :; done
 name=$(basename "$path")
 
 # A test whose work legitimately outlasts the wedge budget says so in its header
-# (269 sweeps n^2 compiles and paces itself inside it). Upwards only, so no test can
-# disarm the guard, and read with the shell to keep it off the per-test fork bill.
+# (269 sweeps n^2 compiles and paces itself inside it). The name carries the rule the
+# reader cannot see: it raises the budget, so no test can disarm the guard. Read with
+# the shell to keep it off the per-test fork bill, and bounded, since bash's `test`
+# errors rather than compares past intmax and would leave the guard unarmed.
 if test "$budget" -gt 0 && test -r "$path"; then
     read_lines=0
     while test "$read_lines" -lt 40 && IFS= read -r line; do
         read_lines=$((read_lines + 1))
         case "$line" in
-        '# TEST_TIMEOUT: '*)
-            want=${line#'# TEST_TIMEOUT: '}
+        '# TEST_TIMEOUT_AT_LEAST: '*)
+            want=${line#'# TEST_TIMEOUT_AT_LEAST: '}
             case "$want" in
-            '' | *[!0-9]*) ;;
-            *) test "$want" -le "$budget" || budget=$want ;;
+            '' | *[!0-9]* | ???????*) ;;
+            *) test "$((10#$want))" -le "$budget" || budget=$((10#$want)) ;;
             esac
             break
             ;;

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -549,6 +549,20 @@ skip_if_out_of_budget() { # skip_if_out_of_budget <steps left> <seconds the last
     exit 77
 }
 
+# Seconds left of the budget, for a child pacing itself against it (269 hands it to
+# the sweep). Never below 1 unless the guard is off, which 0 must keep meaning.
+budget_left() {
+    local budget=${HTTRACK_TEST_TIMEOUT:-600} left
+    case "$budget" in '' | *[!0-9]*) budget=600 ;; esac
+    test "$budget" -gt 0 || {
+        echo 0
+        return 0
+    }
+    left=$((budget - SECONDS))
+    test "$left" -ge 1 || left=1
+    echo "$left"
+}
+
 # Collect a killed job, giving up after REAP_GRACE seconds. kill_tree can fail to
 # reap a native Windows descendant -- the very case these watchdogs exist for --
 # and a bare `wait` then blocks the watchdog itself forever, so the timeout it was

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -539,10 +539,19 @@ EOF
 # one step is slower than its neighbours. It asks an ordering of the callers
 # instead, expensive steps first, so no step left can outrun the reserve the one
 # before it set (#1146).
-skip_if_out_of_budget() { # skip_if_out_of_budget <steps left> <seconds the last took>
-    local budget=${HTTRACK_TEST_TIMEOUT:-600} need=$(($2 + $2 / 2))
+# The budget test-timeout.sh enforces, in seconds, 0 being the guard off. The one
+# parser: a value bash arithmetic or test would choke on falls back to the default,
+# and a leading zero would otherwise read as octal in one place and decimal in the next.
+budget_secs() {
+    local budget=${HTTRACK_TEST_TIMEOUT:-600}
+    case "$budget" in '' | *[!0-9]* | ???????*) budget=600 ;; esac
+    echo "$((10#$budget))"
+}
 
-    case "$budget" in '' | *[!0-9]*) budget=600 ;; esac
+skip_if_out_of_budget() { # skip_if_out_of_budget <steps left> <seconds the last took>
+    local budget need=$(($2 + $2 / 2))
+
+    budget=$(budget_secs)
     test "$1" -gt 0 && test "$budget" -gt 0 || return 0
     test "$((SECONDS + need))" -ge "$budget" || return 0
     echo "$1 steps left, the last took ${2}s and the budget is ${budget}s; skipping" >&2
@@ -550,10 +559,10 @@ skip_if_out_of_budget() { # skip_if_out_of_budget <steps left> <seconds the last
 }
 
 # Seconds left of the budget, for a child pacing itself against it (269 hands it to
-# the sweep). Never below 1 unless the guard is off, which 0 must keep meaning.
+# the sweep). Never below 1 unless the guard is off, when it stays 0.
 budget_left() {
-    local budget=${HTTRACK_TEST_TIMEOUT:-600} left
-    case "$budget" in '' | *[!0-9]*) budget=600 ;; esac
+    local budget left
+    budget=$(budget_secs)
     test "$budget" -gt 0 || {
         echo 0
         return 0

--- a/tools/emulated-suite.sh
+++ b/tools/emulated-suite.sh
@@ -51,7 +51,7 @@ make -j"$(nproc)"
 rc=0
 make check -j"$(nproc)" || rc=$?
 # Always, not only where automake prints it: this leg exists to say what an emulated
-# host does, and a test that paced itself out reads as coverage without the reasons.
+# host does. A paced-out skip must not read as coverage with no reason given.
 cat tests/test-suite.log || true
 test "$rc" -eq 0 || exit "$rc"
 

--- a/tools/emulated-suite.sh
+++ b/tools/emulated-suite.sh
@@ -48,7 +48,12 @@ cd /bld
 bash "${GITHUB_WORKSPACE:-/src}/configure"
 make -j"$(nproc)"
 # The buildd's own invocation, so a failure here is the one it would report.
-make check -j"$(nproc)"
+rc=0
+make check -j"$(nproc)" || rc=$?
+# Always, not only where automake prints it: this leg exists to say what an emulated
+# host does, and a test that paced itself out reads as coverage without the reasons.
+cat tests/test-suite.log || true
+test "$rc" -eq 0 || exit "$rc"
 
 # make check exits 0 for an all-SKIP run, and this leg skips a lot by design, so
 # a container that quietly lost a dependency would report a green covering


### PR DESCRIPTION
Three tests went red on the hppa buildd for 3.49.21-1, none of them on what they cover: an emulated host is far slower than the runner these deadlines were tuned on. Each now measures the property instead of the host. 105 times the guard to its DUMP announcement, so the minutes-long dump that follows falls outside the bound. 151 watches configure's output for silence instead of capping its total, since a hang is silence and slowness is not, and gives up only while the run is still writing, keeping enough budget for the silence window to close. The header sweep runs in slices, so it can be paced and abandoned.

269 asks for a larger budget through a new `# TEST_TIMEOUT_AT_LEAST:` header, which the driver honours upwards only, bounded, and through a single budget parser. Without the raise, pacing alone would have flipped 269 from PASS to SKIP on the Emulated suite leg, the only place the sweep runs emulated at all. That leg is this buildd's CI counterpart and was green on the same commit, since it skips two of the three tests and passed the third just under the ceiling. It prints test-suite.log now, so a paced-out skip stops reading as coverage.

Every added assertion was mutation-tested against the bug it was written for, and the later commits are what that turned up: two probes that passed a mutant of their own bug, and a hung configure that could reach the budget skip before the silence window closed, reporting SKIP where a wedge must fail.

Closes #1230