### PR TITLE
mkdeb.sh reaches debsign before it discovers the key is wrong

### DIFF
--- a/tools/mkdeb.sh
+++ b/tools/mkdeb.sh
@@ -130,6 +130,10 @@ main() {
     if [[ $unsigned -eq 0 ]]; then
         need gpg
         [[ -n $key ]] || die "no signing key (pass --key or set DEBSIGN_KEYID, or use --unsigned)"
+        # Here rather than at debsign, which runs once the tarball is built: a key id gpg
+        # cannot resolve to a secret key would otherwise cost the whole build first.
+        gpg --list-secret-keys -- "$key" >/dev/null 2>&1 ||
+            die "gpg has no secret key for '$key' (an 0x-prefixed full fingerprint is unambiguous)"
     fi
 
     local repo


### PR DESCRIPTION
The signing key is only resolved when debsign runs, and on a release that is after the upstream tarball has been built, so a key id gpg cannot resolve costs the whole build before saying so. It is now checked at startup, with the `0x`-prefixed fingerprint form named in the error: the short id is what one reaches for first, and it is the form that can be ambiguous or absent.

Came out of the 3.49.21-2 upload, where the key had to be given as a full fingerprint.