### PR TITLE
debian: record the 3.49.21-2 upload

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+httrack (3.49.21-2) unstable; urgency=medium
+
+  * Fix the FTBFS on hppa: three suite tests measured the build host rather
+    than the property they cover, and failed on the qemu-user buildd purely
+    for being slower there.  Patched from upstream, which now skips a step a
+    host is too slow to finish instead of failing the build
+    (skip-emulated-host-test-failures.patch).
+
+ -- Xavier Roche <xavier@debian.org>  Thu, 13 Aug 2026 07:26:38 +0200
+
 httrack (3.49.21-1) unstable; urgency=medium
 
   * New upstream release: a site answering to several hostnames can now be


### PR DESCRIPTION
The revision carried the hppa FTBFS fix (#1231) to the buildds as a quilt patch against the frozen orig, since a revision cannot ship a new upstream tarball. The patch stays out of git, where the fix is already in the source and it would no longer apply; only the changelog entry belongs here, so the file stays continuous for the next upload.

Uploaded and accepted on 2026-08-13: the release architectures are already building 3.49.21-2, and the ports buildds follow on their own schedule.