### PR TITLE
An abandoned WebHTTrack server never stops, holding the macOS app open

### DIFF
--- a/html/server/ping.js
+++ b/html/server/ping.js
@@ -1,11 +1,16 @@
 // Tell the server this window is alive, so an abandoned server stops instead of
-// outliving the session. The period is the one htsweb.c derives its timeout
-// from.
+// outliving the session. The period is the one htsweb.c sizes its timeout from.
 var PING_PERIOD = 5000;
+
+// Identifies this window for as long as it is open. The server counts windows,
+// so closing one of two must not read as the session ending.
+var PING_WINDOW =
+    String(Math.random()).replace(/[^0-9]/g, "") + String(new Date().getTime());
 
 function ping_url(extra) {
   // Unique, or a cached response would never reach the server again.
-  return "/ping?t=" + new Date().getTime() + (extra ? "&" + extra : "");
+  return "/ping?w=" + PING_WINDOW + "&t=" + new Date().getTime() +
+         (extra ? "&" + extra : "");
 }
 
 // An iframe is the fallback only: reassigning its src can push a history entry,
@@ -43,8 +48,8 @@ function ping_leaving() {
 
 // Old browsers reach none of this and stay on the legacy "wait for the launcher
 // to die" mode.
-if (document && document.createElement && document.body
-    && document.body.appendChild && document.getElementById) {
+if (document && document.createElement && document.body &&
+    document.body.appendChild && document.getElementById) {
   if (!window.fetch) {
     var iframe = document.createElement('iframe');
     if (iframe) {

--- a/html/server/ping.js
+++ b/html/server/ping.js
@@ -1,26 +1,63 @@
-// Function aimed to ping the webhttrack server regularly to keep it alive
-// If the browser window is closed, the server will eventually shutdown
-function ping_server() {
-	var iframe = document.getElementById('pingiframe');
-	if (iframe && iframe.src) {
-		iframe.src = iframe.src;
-		setTimeout(ping_server, 30000);
-	}
+// Tell the server this window is alive, so an abandoned server stops instead of
+// outliving the session. The period is the one htsweb.c derives its timeout
+// from.
+var PING_PERIOD = 5000;
+
+function ping_url(extra) {
+  // Unique, or a cached response would never reach the server again.
+  return "/ping?t=" + new Date().getTime() + (extra ? "&" + extra : "");
 }
 
-// Create an invisible iframe to hold the server ping result
-// Only modern browsers will support that, but old browsers are compatible
-// with the legacy "wait for browser PID" mode
+// An iframe is the fallback only: reassigning its src can push a history entry,
+// which would turn the Back button into a walk through past heartbeats.
+function ping_send(url) {
+  if (window.fetch) {
+    fetch(url, {cache : "no-store"});
+    return true;
+  }
+  var iframe = document.getElementById('pingiframe');
+  if (!iframe) {
+    return false;
+  }
+  iframe.src = url;
+  return true;
+}
+
+function ping_server() {
+  if (ping_send(ping_url())) {
+    setTimeout(ping_server, PING_PERIOD);
+  }
+}
+
+// Closing the window is the common case, and waiting out the timeout for it
+// would hold the server open long after the user considers it gone.
+function ping_leaving() {
+  var url = ping_url("e=bye");
+  if (navigator.sendBeacon) {
+    navigator.sendBeacon(url);
+  } else {
+    // A request the page's own teardown cannot cancel.
+    new Image().src = url;
+  }
+}
+
+// Old browsers reach none of this and stay on the legacy "wait for the launcher
+// to die" mode.
 if (document && document.createElement && document.body
     && document.body.appendChild && document.getElementById) {
-	var iframe = document.createElement('iframe');
-	if (iframe) {
-		iframe.id = 'pingiframe';
-		iframe.style.display = "none";
-		iframe.style.visibility = "hidden";
-		iframe.width = iframe.height = 0;
-		iframe.src = "/ping";
-		document.body.appendChild(iframe);
-		ping_server();
-	}
+  if (!window.fetch) {
+    var iframe = document.createElement('iframe');
+    if (iframe) {
+      iframe.id = 'pingiframe';
+      iframe.style.display = "none";
+      iframe.style.visibility = "hidden";
+      iframe.width = iframe.height = 0;
+      document.body.appendChild(iframe);
+    }
+  }
+  ping_server();
+  // pagehide, not unload: Safari's back/forward cache never fires unload.
+  if (window.addEventListener) {
+    window.addEventListener('pagehide', ping_leaving, false);
+  }
 }

--- a/html/server/ping.js
+++ b/html/server/ping.js
@@ -34,15 +34,32 @@ function ping_server() {
   }
 }
 
+// The session id this page carries, empty on the few pages that hold no form.
+function ping_sid() {
+  var f = document.getElementsByName('sid');
+  return f && f.length ? f[0].value : "";
+}
+
 // Closing the window is the common case, and waiting out the timeout for it
-// would hold the server open long after the user considers it gone.
+// would hold the server open long after the user considers it gone. The server
+// takes this only from a request holding the session id, so it goes as a POST;
+// a page without one falls back to the timeout.
 function ping_leaving() {
+  var sid = ping_sid();
+  if (!sid) {
+    return;
+  }
   var url = ping_url("e=bye");
+  var body = "sid=" + encodeURIComponent(sid);
+  var type = "application/x-www-form-urlencoded";
   if (navigator.sendBeacon) {
-    navigator.sendBeacon(url);
-  } else {
-    // A request the page's own teardown cannot cancel.
-    new Image().src = url;
+    navigator.sendBeacon(url, new Blob([ body ], {type : type}));
+  } else if (window.XMLHttpRequest) {
+    // Synchronous: the page is going away, and an async send dies with it.
+    var x = new XMLHttpRequest();
+    x.open("POST", url, false);
+    x.setRequestHeader("Content-Type", type);
+    x.send(body);
   }
 }
 

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -93,13 +93,13 @@ int commandReturnSet = 0;
 
 httrackp *global_opt = NULL;
 
-static void (*pingFun)(void *, smallserver_client_event) = NULL;
+static void (*pingFun)(void *, smallserver_client_event, const char *) = NULL;
 static void* pingFunArg = NULL;
 
 /* Report a client liveness event, if anybody is listening. */
-static void client_event(smallserver_client_event ev) {
+static void client_event(smallserver_client_event ev, const char *window) {
   if (pingFun != NULL) {
-    pingFun(pingFunArg, ev);
+    pingFun(pingFunArg, ev, window);
   }
 }
 
@@ -390,6 +390,39 @@ static void copy_header_value(char *dst, size_t size, const char *value) {
   }
   dst[0] = '\0';
   strlncatbuff(dst, value, size, size - 1);
+}
+
+/** Copy the value of query parameter "name" into dst, keeping only the
+    alphanumerics a window id is made of. True when a non-empty value fit.
+    Deliberately not the body walker below: this one fetches one value out of a
+    URL, where that one validates every occurrence of a field in a POST body. */
+static hts_boolean query_alnum_value(char *dst, size_t size, const char *query,
+                                     const char *name) {
+  const size_t namelen = strlen(name);
+  const char *s = query;
+
+  dst[0] = '\0';
+  while (*s != '\0') {
+    const char *const amp = strchr(s, '&');
+
+    if (strncmp(s, name, namelen) == 0 && s[namelen] == '=') {
+      const char *v = s + namelen + 1;
+      size_t n = 0;
+
+      while (*v != '\0' && *v != '&' && n + 1 < size &&
+             isalnum((unsigned char) *v)) {
+        dst[n++] = *v++;
+      }
+      dst[n] = '\0';
+      /* A truncated or otherwise unusable id is no id at all. */
+      return n > 0 && (*v == '\0' || *v == '&') ? HTS_TRUE : HTS_FALSE;
+    }
+    if (amp == NULL) {
+      break;
+    }
+    s = amp + 1;
+  }
+  return HTS_FALSE;
 }
 
 /** Does the urlencoded request body present the expected session id?
@@ -760,7 +793,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
     while((soc_c = (T_SOC) accept(soc, NULL, NULL)) == INVALID_SOCKET) ;
 
     /* Ping */
-    client_event(SMALLSERVER_CLIENT_REQUEST);
+    client_event(SMALLSERVER_CLIENT_REQUEST, NULL);
 
     /* Lock */
     webhttrack_lock();
@@ -1799,7 +1832,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
             fclose(fp);
           } else if (strcmp(file, "/ping") == 0) {
             /* A cached heartbeat would never reach us again, and silence is
-               what the watchdog reads as a dead client. */
+               what the watchdog reads as a dead window. */
             char error_hdr[] =
                 "HTTP/1.0 200 Pong\r\n"
                 "Server: httrack small server\r\n"
@@ -1807,10 +1840,18 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                 "Cache-Control: no-cache, must-revalidate, private\r\n"
                 "Pragma: no-cache\r\n";
 
+            char window[SMALLSERVER_WINDOW_ID_MAX + 1];
+
             StringCat(headers, error_hdr);
-            client_event(strstr(query, "e=bye") != NULL
-                             ? SMALLSERVER_CLIENT_LEAVING
-                             : SMALLSERVER_CLIENT_PING);
+            if (query_alnum_value(window, sizeof(window), query, "w")) {
+              char verb[SMALLSERVER_WINDOW_ID_MAX + 1];
+
+              client_event(query_alnum_value(verb, sizeof(verb), query, "e") &&
+                                   strcmp(verb, "bye") == 0
+                               ? SMALLSERVER_CLIENT_LEAVING
+                               : SMALLSERVER_CLIENT_PING,
+                           window);
+            }
           } else {
             char error_hdr[] =
               "HTTP/1.0 404 Not Found\r\n" "Server: httrack small server\r\n"
@@ -1936,7 +1977,8 @@ int htslang_uninit(void) {
   return 1;
 }
 
-void smallserver_setpinghandler(void (*fun)(void *, smallserver_client_event),
+void smallserver_setpinghandler(void (*fun)(void *, smallserver_client_event,
+                                            const char *),
                                 void *arg) {
   pingFun = fun;
   pingFunArg = arg;

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -93,8 +93,15 @@ int commandReturnSet = 0;
 
 httrackp *global_opt = NULL;
 
-static void (*pingFun)(void*) = NULL;
+static void (*pingFun)(void *, smallserver_client_event) = NULL;
 static void* pingFunArg = NULL;
+
+/* Report a client liveness event, if anybody is listening. */
+static void client_event(smallserver_client_event ev) {
+  if (pingFun != NULL) {
+    pingFun(pingFunArg, ev);
+  }
+}
 
 /* Extern */
 extern void webhttrack_main(char *cmd);
@@ -753,9 +760,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
     while((soc_c = (T_SOC) accept(soc, NULL, NULL)) == INVALID_SOCKET) ;
 
     /* Ping */
-    if (pingFun != NULL) {
-      pingFun(pingFunArg);
-    }
+    client_event(SMALLSERVER_CLIENT_REQUEST);
 
     /* Lock */
     webhttrack_lock();
@@ -1158,6 +1163,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
         if (url && *++url == '/' && (pos = strchr(url, ' ')) && !(*pos = '\0')) {
           char fsfile[1024];
           const char *file;
+          const char *query = "";
           FILE *fp;
           char *qpos;
 
@@ -1166,6 +1172,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
           if (error_redirect == NULL) {
             if ((qpos = strchr(url, '?'))) {
               *qpos = '\0';
+              query = qpos + 1;
             }
             if (strcmp(url, "/") == 0) {
               file = "/server/index.html";
@@ -1790,13 +1797,20 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
               }
             }
             fclose(fp);
-          } else if (strcmp(file, "/ping") == 0 ||
-                     strncmp(file, "/ping?", 6) == 0) {
+          } else if (strcmp(file, "/ping") == 0) {
+            /* A cached heartbeat would never reach us again, and silence is
+               what the watchdog reads as a dead client. */
             char error_hdr[] =
-              "HTTP/1.0 200 Pong\r\n" "Server: httrack small server\r\n"
-              "Content-type: text/html\r\n";
+                "HTTP/1.0 200 Pong\r\n"
+                "Server: httrack small server\r\n"
+                "Content-type: text/html\r\n"
+                "Cache-Control: no-cache, must-revalidate, private\r\n"
+                "Pragma: no-cache\r\n";
 
             StringCat(headers, error_hdr);
+            client_event(strstr(query, "e=bye") != NULL
+                             ? SMALLSERVER_CLIENT_LEAVING
+                             : SMALLSERVER_CLIENT_PING);
           } else {
             char error_hdr[] =
               "HTTP/1.0 404 Not Found\r\n" "Server: httrack small server\r\n"
@@ -1873,6 +1887,10 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
 #endif
   }
 
+  /* Only the UI asking to quit is a clean stop; losing the socket or the buffer
+     is what the caller reports as a failure. */
+  retour = willexit;
+
   StringFree(headers);
   StringFree(output);
   StringFree(tmpbuff);
@@ -1918,7 +1936,8 @@ int htslang_uninit(void) {
   return 1;
 }
 
-void smallserver_setpinghandler(void (*fun)(void*), void*arg) {
+void smallserver_setpinghandler(void (*fun)(void *, smallserver_client_event),
+                                void *arg) {
   pingFun = fun;
   pingFunArg = arg;
 }

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -392,10 +392,9 @@ static void copy_header_value(char *dst, size_t size, const char *value) {
   strlncatbuff(dst, value, size, size - 1);
 }
 
-/** Copy the value of query parameter "name" into dst, keeping only the
-    alphanumerics a window id is made of. True when a non-empty value fit.
-    Deliberately not the body walker below: this one fetches one value out of a
-    URL, where that one validates every occurrence of a field in a POST body. */
+/** Copy query parameter "name"'s alphanumeric value into dst; true when a
+    non-empty one fit, and dst is left empty otherwise. Query-string counterpart
+    to the POST-body checker below. */
 static hts_boolean query_alnum_value(char *dst, size_t size, const char *query,
                                      const char *name) {
   const size_t namelen = strlen(name);
@@ -414,8 +413,13 @@ static hts_boolean query_alnum_value(char *dst, size_t size, const char *query,
         dst[n++] = *v++;
       }
       dst[n] = '\0';
-      /* A truncated or otherwise unusable id is no id at all. */
-      return n > 0 && (*v == '\0' || *v == '&') ? HTS_TRUE : HTS_FALSE;
+      /* Truncated, or not alphanumeric to its end, is no value at all: it must
+         not reach a caller that trusted the return. */
+      if (n > 0 && (*v == '\0' || *v == '&')) {
+        return HTS_TRUE;
+      }
+      dst[0] = '\0';
+      return HTS_FALSE;
     }
     if (amp == NULL) {
       break;
@@ -763,6 +767,8 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
     LLint length = 0;
     const char *error_redirect = NULL;
     hts_boolean denied = HTS_FALSE;
+    /* The request proved it holds the session id. */
+    hts_boolean authed = HTS_FALSE;
     char origin[256];
     char host[256];
 
@@ -903,6 +909,8 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
           buffer[0] = '\0';
           meth = 0;
           denied = HTS_TRUE;
+        } else {
+          authed = HTS_TRUE;
         }
       }
 
@@ -1846,11 +1854,15 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
             if (query_alnum_value(window, sizeof(window), query, "w")) {
               char verb[SMALLSERVER_WINDOW_ID_MAX + 1];
 
-              client_event(query_alnum_value(verb, sizeof(verb), query, "e") &&
-                                   strcmp(verb, "bye") == 0
-                               ? SMALLSERVER_CLIENT_LEAVING
-                               : SMALLSERVER_CLIENT_PING,
-                           window);
+              /* Ending a session is a command, so it carries the session id
+                 like every other one. A heartbeat can only extend a life, and
+                 any local peer or visited page can send one of those. */
+              client_event(
+                  authed && query_alnum_value(verb, sizeof(verb), query, "e") &&
+                          strcmp(verb, "bye") == 0
+                      ? SMALLSERVER_CLIENT_LEAVING
+                      : SMALLSERVER_CLIENT_PING,
+                  window);
             }
           } else {
             char error_hdr[] =

--- a/src/htsserver.h
+++ b/src/htsserver.h
@@ -94,7 +94,16 @@ extern httrackp *global_opt;
 #define min(a,b) ((a)>(b)?(b):(a))
 #define max(a,b) ((a)>(b)?(a):(b))
 
-extern void smallserver_setpinghandler(void (*fun)(void*), void*arg);
+/* What the UI just told us about itself, reported to the ping handler. */
+typedef enum {
+  SMALLSERVER_CLIENT_REQUEST, /* any request: a page is attached */
+  SMALLSERVER_CLIENT_PING,    /* its heartbeat, so silence will mean gone */
+  SMALLSERVER_CLIENT_LEAVING  /* the page is closing */
+} smallserver_client_event;
+
+extern void smallserver_setpinghandler(void (*fun)(void *,
+                                                   smallserver_client_event),
+                                       void *arg);
 extern int smallserver_setkey(const char *key, const char *value);
 extern int smallserver_setkeyint(const char *key, LLint value);
 extern int smallserver_setkeyarr(const char *key, int id, const char *key2, const char *value);

--- a/src/htsserver.h
+++ b/src/htsserver.h
@@ -96,14 +96,18 @@ extern httrackp *global_opt;
 
 /* What the UI just told us about itself, reported to the ping handler. */
 typedef enum {
-  SMALLSERVER_CLIENT_REQUEST, /* any request: a page is attached */
-  SMALLSERVER_CLIENT_PING,    /* its heartbeat, so silence will mean gone */
-  SMALLSERVER_CLIENT_LEAVING  /* the page is closing */
+  SMALLSERVER_CLIENT_REQUEST, /* any request; claims no window */
+  SMALLSERVER_CLIENT_PING,    /* one window's heartbeat */
+  SMALLSERVER_CLIENT_LEAVING  /* that window is closing */
 } smallserver_client_event;
 
-extern void smallserver_setpinghandler(void (*fun)(void *,
-                                                   smallserver_client_event),
-                                       void *arg);
+/* Longest window id a page may claim; a longer one is ignored. */
+#define SMALLSERVER_WINDOW_ID_MAX 32
+
+/* fun() receives the id of the window the event came from, NULL when no window
+   claimed it. */
+extern void smallserver_setpinghandler(
+    void (*fun)(void *, smallserver_client_event, const char *), void *arg);
 extern int smallserver_setkey(const char *key, const char *value);
 extern int smallserver_setkeyint(const char *key, LLint value);
 extern int smallserver_setkeyarr(const char *key, int id, const char *key2, const char *value);

--- a/src/htsweb.c
+++ b/src/htsweb.c
@@ -105,49 +105,82 @@ static void htsweb_sig_brpipe(int code) {
 /* Threads that never return; no wait may count on them draining. */
 static int nonjoinable_threads = 0;
 
-/* Server/client ping handling */
+/* Server/client ping handling: the UI pings every PING_PERIOD seconds and says
+   goodbye when it closes, so an abandoned server can stop holding its payload
+   open (a mounted disk image, on macOS) instead of outliving the session. */
+#define PING_PERIOD 5
+/* Silence tolerated from a client whose heartbeat we have seen. */
+static int pingTimeout = 90;
+/* A goodbye only starts a countdown: another window may still be open, and its
+   next ping cancels the departure, so this must outlast PING_PERIOD. */
+#define LEAVE_GRACE max(1, min(12, pingTimeout / 4))
+
 static htsmutex pingMutex = HTSMUTEX_INIT;
-static unsigned int pingId = 0;
-static unsigned int getPingId(void) {
-  unsigned int id;
+static time_t lastSeen = 0; /* last request from the UI */
+static time_t leaveAt = 0;  /* when a pending goodbye expires, 0 if none */
+static int anyRequest = 0;  /* the UI reached us at least once */
+static int pingSeen = 0; /* ..and its heartbeat works, so silence means gone */
+
+static void pingHandler(void *arg, smallserver_client_event ev) {
+  (void) arg;
   hts_mutexlock(&pingMutex);
-  id = pingId;
-  hts_mutexrelease(&pingMutex);
-  return id;
-}
-static void ping(void) {
-  hts_mutexlock(&pingMutex);
-  pingId++;
+  lastSeen = time(NULL);
+  anyRequest = 1;
+  if (ev == SMALLSERVER_CLIENT_LEAVING) {
+    leaveAt = lastSeen + LEAVE_GRACE;
+  } else {
+    leaveAt = 0;
+    if (ev == SMALLSERVER_CLIENT_PING) {
+      pingSeen = 1;
+    }
+  }
   hts_mutexrelease(&pingMutex);
 }
 
-static void client_ping(void *pP) {
-#ifndef _WIN32
-  /* Timeout to 120s ; normally client pings every 30 second */
-  static int timeout = 120;
-  /* Wait for parent to die (legacy browser mode). */
-  const pid_t ppid = (pid_t) (uintptr_t) pP;
-  while (!kill(ppid, 0)) {
-    sleep(1);
-  }
-  /* Parent (webhttrack script) is dead: is client pinging ? */
-  for(;;) {
-    unsigned int id = getPingId();
-    sleep(timeout);
-    if (getPingId() == id) {
-      break;
-    }
-  }
-  /* Die! */
-  fprintf(stderr,
-          "Parent process %d died, and client did not ping for %ds: exiting!\n",
-          (int) ppid, timeout);
-  exit(EXIT_FAILURE);
+/* True unless the launcher we were started from is known to be gone. */
+static int parent_is_alive(pid_t ppid) {
+#ifdef _WIN32
+  (void) ppid;
+  return 1; /* no cheap probe; the heartbeat carries this */
+#else
+  /* kill(0) would signal our own process group, never a parent. */
+  return ppid <= 0 || kill(ppid, 0) == 0;
 #endif
 }
 
-static void pingHandler(void*arg) {
-  ping();
+static void client_ping(void *pP) {
+  const pid_t ppid = (pid_t) (uintptr_t) pP;
+  const char *why = NULL;
+
+  hts_mutexlock(&pingMutex);
+  lastSeen = time(NULL);
+  hts_mutexrelease(&pingMutex);
+
+  while (why == NULL) {
+    time_t now;
+
+    Sleep(1000);
+    /* A mirror in flight outranks every rule below: it may have hours of
+       crawling behind it, and the user can always come back to its page. */
+    if (commandRunning) {
+      continue;
+    }
+    hts_mutexlock(&pingMutex);
+    now = time(NULL);
+    if (leaveAt != 0 && now >= leaveAt) {
+      why = "the interface was closed";
+    } else if (now >= lastSeen + pingTimeout
+               /* Silence proves nothing about a client that never pings: it may
+                  simply be a user reading the page. Falling back to the
+                  launcher's death keeps such a browser working. */
+               && (pingSeen || !anyRequest || !parent_is_alive(ppid))) {
+      why = "the interface went silent";
+    }
+    hts_mutexrelease(&pingMutex);
+  }
+
+  fprintf(stderr, "Exiting: %s\n", why);
+  exit(EXIT_SUCCESS);
 }
 
 int main(int argc, char *argv[]) {
@@ -184,6 +217,7 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "** Warning: use the webhttrack frontend if available\n");
     fprintf(stderr,
             "usage: %s [--port <port>] [--bind <address>] [--ppid parent-pid] "
+            "[--ping-timeout <seconds>] "
             "<path-to-html-root-dir> [key value [key value]..]\n",
             argv[0]);
     fprintf(stderr, "example: %s /usr/share/httrack/\n", argv[0]);
@@ -288,6 +322,11 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "couldn't set the parent PID to %s\n", argv[i + 1]);
         return -1;
       }
+    } else if (strcmp(argv[i], "--ping-timeout") == 0 && i + 1 < argc) {
+      if (sscanf(argv[i + 1], "%d", &pingTimeout) != 1 || pingTimeout < 1) {
+        fprintf(stderr, "couldn't set the ping timeout to %s\n", argv[i + 1]);
+        return -1;
+      }
     } else if (i + 1 < argc) {
       smallserver_setkey(argv[i], argv[i + 1]);
     } else {
@@ -304,9 +343,7 @@ int main(int argc, char *argv[]) {
   /* pinger */
   if (parentPid > 0) {
     if (hts_newthread(client_ping, (void *) (uintptr_t) parentPid) == 0) {
-#ifndef _WIN32
       nonjoinable_threads++; /* client_ping() only ever leaves through exit() */
-#endif
     }
     smallserver_setpinghandler(pingHandler, NULL);
   }

--- a/src/htsweb.c
+++ b/src/htsweb.c
@@ -105,11 +105,10 @@ static void htsweb_sig_brpipe(int code) {
 /* Threads that never return; no wait may count on them draining. */
 static int nonjoinable_threads = 0;
 
-/* Session lifetime: each UI window pings every PING_PERIOD seconds under its
-   own id and drops that id when it closes, so an abandoned server stops instead
-   of outliving the session and holding its payload open (a mounted disk image,
-   on macOS). Windows are counted, not merely timed: closing one of two must not
-   end a session the other is still using. */
+/* Session lifetime: each window pings under its own id and drops it when it
+   closes, so an abandoned server stops instead of outliving the session and
+   holding its payload open (a mounted disk image, on macOS). Windows are
+   counted, not timed: closing one of several must not end the session. */
 #define PING_PERIOD 5
 /* Silence tolerated from one window. Generous: a hidden tab has its timers
    throttled to as little as one wake-up a minute. */
@@ -117,8 +116,8 @@ static int pingTimeout = 120;
 /* Once the last window leaves, only a page navigation can bring one back, and
    that takes a fraction of a second over the loopback. */
 #define LEAVE_GRACE max(2, min(5, pingTimeout / 4))
-/* Windows tracked at once. Past this the oldest is dropped, which costs that
-   one the prompt exit and nothing else. */
+/* Windows tracked at once. A full table refuses newcomers rather than evicting:
+   dropping a live window is what would let a flood of ids end the session. */
 #define MAX_WINDOWS 16
 
 static htsmutex pingMutex = HTSMUTEX_INIT;
@@ -128,16 +127,17 @@ static int ticks = 0;
 
 static struct {
   char id[SMALLSERVER_WINDOW_ID_MAX + 1];
-  int seen;
+  int last_seen;
 } windows[MAX_WINDOWS];
 
 static int windowCount = 0;
-static int emptySince = 0; /* tick the last window left at */
-static int anyWindow = 0;  /* some window has claimed an id */
-static int lastSeen = 0;   /* tick of the last request of any kind */
-static int anyRequest = 0; /* something has connected at least once */
+static int emptySince = 0;                /* tick the last window left at */
+static hts_boolean anyWindow = HTS_FALSE; /* a window has claimed an id */
+static int lastSeen = 0; /* tick of the last request of any kind */
+static hts_boolean anyRequest = HTS_FALSE; /* something has connected */
 
-/* Drop windows[i]. Caller holds pingMutex. */
+/* Drop windows[i], moving the last entry into its slot: a caller removing while
+   it iterates must walk backwards. Caller holds pingMutex. */
 static void window_forget(int i) {
   windows[i] = windows[--windowCount];
   if (windowCount == 0) {
@@ -152,9 +152,9 @@ static void pingHandler(void *arg, smallserver_client_event ev,
   (void) arg;
   hts_mutexlock(&pingMutex);
   lastSeen = ticks;
-  anyRequest = 1;
-  /* A bare request vouches for no window: any local peer can open a connection,
-     and none of them may cancel a real window's departure. */
+  anyRequest = HTS_TRUE;
+  /* A bare request names no window: any local peer can open a connection, but
+     none may cancel a real window's departure. */
   if (window != NULL) {
     while (i < windowCount && strcmp(windows[i].id, window) != 0) {
       i++;
@@ -164,27 +164,27 @@ static void pingHandler(void *arg, smallserver_client_event ev,
         window_forget(i);
       }
     } else if (i < windowCount) {
-      windows[i].seen = ticks;
-    } else {
-      if (windowCount == MAX_WINDOWS) {
-        window_forget(0);
-      }
-      strcpybuff(windows[windowCount].id, window);
-      windows[windowCount++].seen = ticks;
-      anyWindow = 1;
+      windows[i].last_seen = ticks;
+    } else if (windowCount < MAX_WINDOWS) {
+      windows[windowCount].id[0] = '\0';
+      strlncatbuff(windows[windowCount].id, window,
+                   sizeof(windows[windowCount].id),
+                   sizeof(windows[windowCount].id) - 1);
+      windows[windowCount++].last_seen = ticks;
+      anyWindow = HTS_TRUE;
     }
   }
   hts_mutexrelease(&pingMutex);
 }
 
 /* True unless the launcher we were started from is known to be gone. */
-static int parent_is_alive(pid_t ppid) {
+static hts_boolean parent_is_alive(pid_t ppid) {
 #ifdef _WIN32
   (void) ppid;
-  return 1; /* no cheap probe; the heartbeat carries this */
+  return HTS_TRUE; /* no cheap probe; the heartbeat carries this */
 #else
   /* kill(0) would signal our own process group, never a parent. */
-  return ppid <= 0 || kill(ppid, 0) == 0;
+  return ppid <= 0 || kill(ppid, 0) == 0 ? HTS_TRUE : HTS_FALSE;
 #endif
 }
 
@@ -206,7 +206,7 @@ static void client_ping(void *pP) {
     /* A window that stops pinging without a goodbye crashed with its browser.
      */
     for (i = windowCount; i-- > 0;) {
-      if (ticks - windows[i].seen >= pingTimeout) {
+      if (ticks - windows[i].last_seen >= pingTimeout) {
         window_forget(i);
       }
     }
@@ -214,10 +214,9 @@ static void client_ping(void *pP) {
       why = "the interface was closed";
     } else if (!anyWindow &&
                ticks - lastSeen >= pingTimeout
-               /* No window ever claimed an id, so this is a browser too old to
-                  ping, or one that never opened. Silence alone must not end a
-                  session a reader may still be looking at, so fall back to the
-                  launcher, which dies with that browser. */
+               /* No window ever pinged: a browser too old for it, or none
+                  opened. Fall back to the launcher dying with that browser,
+                  rather than to silence, which a reader also produces. */
                && (!anyRequest || !parent_is_alive(ppid))) {
       why = "the interface went silent";
     }
@@ -373,10 +372,16 @@ int main(int argc, char *argv[]) {
         return -1;
       }
     } else if (strcmp(argv[i], "--ping-timeout") == 0 && i + 1 < argc) {
-      if (sscanf(argv[i + 1], "%d", &pingTimeout) != 1 || pingTimeout < 1) {
+      /* Bounded, not just parsed: %d wrapping a huge value into a plausible one
+         is what #614 cost on --port, two cases above. */
+      char *end = NULL;
+      const long v = strtol(argv[i + 1], &end, 10);
+
+      if (end == argv[i + 1] || *end != '\0' || v < 1 || v > 86400) {
         fprintf(stderr, "couldn't set the ping timeout to %s\n", argv[i + 1]);
         return -1;
       }
+      pingTimeout = (int) v;
     } else if (i + 1 < argc) {
       smallserver_setkey(argv[i], argv[i + 1]);
     } else {

--- a/src/htsweb.c
+++ b/src/htsweb.c
@@ -105,35 +105,73 @@ static void htsweb_sig_brpipe(int code) {
 /* Threads that never return; no wait may count on them draining. */
 static int nonjoinable_threads = 0;
 
-/* Server/client ping handling: the UI pings every PING_PERIOD seconds and says
-   goodbye when it closes, so an abandoned server can stop holding its payload
-   open (a mounted disk image, on macOS) instead of outliving the session. */
+/* Session lifetime: each UI window pings every PING_PERIOD seconds under its
+   own id and drops that id when it closes, so an abandoned server stops instead
+   of outliving the session and holding its payload open (a mounted disk image,
+   on macOS). Windows are counted, not merely timed: closing one of two must not
+   end a session the other is still using. */
 #define PING_PERIOD 5
-/* Silence tolerated from a client whose heartbeat we have seen. Generous, and
-   deliberately so: a backgrounded tab has its timers throttled, and the prompt
-   exit is the goodbye's job, not this one's. */
+/* Silence tolerated from one window. Generous: a hidden tab has its timers
+   throttled to as little as one wake-up a minute. */
 static int pingTimeout = 120;
-/* A goodbye only starts a countdown: another window may still be open, and its
-   next ping cancels the departure, so this must outlast PING_PERIOD. */
-#define LEAVE_GRACE max(1, min(12, pingTimeout / 4))
+/* Once the last window leaves, only a page navigation can bring one back, and
+   that takes a fraction of a second over the loopback. */
+#define LEAVE_GRACE max(2, min(5, pingTimeout / 4))
+/* Windows tracked at once. Past this the oldest is dropped, which costs that
+   one the prompt exit and nothing else. */
+#define MAX_WINDOWS 16
 
 static htsmutex pingMutex = HTSMUTEX_INIT;
-static time_t lastSeen = 0; /* last request from the UI */
-static time_t leaveAt = 0;  /* when a pending goodbye expires, 0 if none */
-static int anyRequest = 0;  /* the UI reached us at least once */
-static int pingSeen = 0; /* ..and its heartbeat works, so silence means gone */
+/* Seconds the watchdog has been awake, not wall-clock: time(NULL) jumps across
+   a laptop suspend, and a suspended machine must not age a session. */
+static int ticks = 0;
 
-static void pingHandler(void *arg, smallserver_client_event ev) {
+static struct {
+  char id[SMALLSERVER_WINDOW_ID_MAX + 1];
+  int seen;
+} windows[MAX_WINDOWS];
+
+static int windowCount = 0;
+static int emptySince = 0; /* tick the last window left at */
+static int anyWindow = 0;  /* some window has claimed an id */
+static int lastSeen = 0;   /* tick of the last request of any kind */
+static int anyRequest = 0; /* something has connected at least once */
+
+/* Drop windows[i]. Caller holds pingMutex. */
+static void window_forget(int i) {
+  windows[i] = windows[--windowCount];
+  if (windowCount == 0) {
+    emptySince = ticks;
+  }
+}
+
+static void pingHandler(void *arg, smallserver_client_event ev,
+                        const char *window) {
+  int i = 0;
+
   (void) arg;
   hts_mutexlock(&pingMutex);
-  lastSeen = time(NULL);
+  lastSeen = ticks;
   anyRequest = 1;
-  if (ev == SMALLSERVER_CLIENT_LEAVING) {
-    leaveAt = lastSeen + LEAVE_GRACE;
-  } else {
-    leaveAt = 0;
-    if (ev == SMALLSERVER_CLIENT_PING) {
-      pingSeen = 1;
+  /* A bare request vouches for no window: any local peer can open a connection,
+     and none of them may cancel a real window's departure. */
+  if (window != NULL) {
+    while (i < windowCount && strcmp(windows[i].id, window) != 0) {
+      i++;
+    }
+    if (ev == SMALLSERVER_CLIENT_LEAVING) {
+      if (i < windowCount) {
+        window_forget(i);
+      }
+    } else if (i < windowCount) {
+      windows[i].seen = ticks;
+    } else {
+      if (windowCount == MAX_WINDOWS) {
+        window_forget(0);
+      }
+      strcpybuff(windows[windowCount].id, window);
+      windows[windowCount++].seen = ticks;
+      anyWindow = 1;
     }
   }
   hts_mutexrelease(&pingMutex);
@@ -154,12 +192,8 @@ static void client_ping(void *pP) {
   const pid_t ppid = (pid_t) (uintptr_t) pP;
   const char *why = NULL;
 
-  hts_mutexlock(&pingMutex);
-  lastSeen = time(NULL);
-  hts_mutexrelease(&pingMutex);
-
   while (why == NULL) {
-    time_t now;
+    int i;
 
     Sleep(1000);
     /* A mirror in flight outranks every rule below: it may have hours of
@@ -168,17 +202,31 @@ static void client_ping(void *pP) {
       continue;
     }
     hts_mutexlock(&pingMutex);
-    now = time(NULL);
-    if (leaveAt != 0 && now >= leaveAt) {
+    ticks++;
+    /* A window that stops pinging without a goodbye crashed with its browser.
+     */
+    for (i = windowCount; i-- > 0;) {
+      if (ticks - windows[i].seen >= pingTimeout) {
+        window_forget(i);
+      }
+    }
+    if (anyWindow && windowCount == 0 && ticks - emptySince >= LEAVE_GRACE) {
       why = "the interface was closed";
-    } else if (now >= lastSeen + pingTimeout
-               /* Silence proves nothing about a client that never pings: it may
-                  simply be a user reading the page. Falling back to the
-                  launcher's death keeps such a browser working. */
-               && (pingSeen || !anyRequest || !parent_is_alive(ppid))) {
+    } else if (!anyWindow &&
+               ticks - lastSeen >= pingTimeout
+               /* No window ever claimed an id, so this is a browser too old to
+                  ping, or one that never opened. Silence alone must not end a
+                  session a reader may still be looking at, so fall back to the
+                  launcher, which dies with that browser. */
+               && (!anyRequest || !parent_is_alive(ppid))) {
       why = "the interface went silent";
     }
     hts_mutexrelease(&pingMutex);
+    /* Re-read after the decision: a mirror may have started while it was made,
+       and exiting now would lose it. */
+    if (commandRunning) {
+      why = NULL;
+    }
   }
 
   fprintf(stderr, "Exiting: %s\n", why);
@@ -428,7 +476,13 @@ static void back_launch_cmd(void *pP) {
 void webhttrack_main(char *cmd) {
   commandRunning = 1;
   DEBUG(fprintf(stderr, "commandRunning=1\n"));
-  hts_newthread(back_launch_cmd, (void *) strdup(cmd));
+  if (hts_newthread(back_launch_cmd, (void *) strdup(cmd)) != 0) {
+    /* Nothing else clears the flag, and while it is set the watchdog holds the
+       server open for a mirror that never started. */
+    commandRunning = 0;
+    commandEnd = 1;
+    commandReturn = -1;
+  }
 }
 
 void webhttrack_lock(void) {

--- a/src/htsweb.c
+++ b/src/htsweb.c
@@ -178,18 +178,20 @@ static void pingHandler(void *arg, smallserver_client_event ev,
 }
 
 /* True unless the launcher we were started from is known to be gone. */
-static hts_boolean parent_is_alive(pid_t ppid) {
+static hts_boolean parent_is_alive(uintptr_t ppid) {
 #ifdef _WIN32
   (void) ppid;
   return HTS_TRUE; /* no cheap probe; the heartbeat carries this */
 #else
   /* kill(0) would signal our own process group, never a parent. */
-  return ppid <= 0 || kill(ppid, 0) == 0 ? HTS_TRUE : HTS_FALSE;
+  return ppid == 0 || kill((pid_t) ppid, 0) == 0 ? HTS_TRUE : HTS_FALSE;
 #endif
 }
 
 static void client_ping(void *pP) {
-  const pid_t ppid = (pid_t) (uintptr_t) pP;
+  /* uintptr_t, not pid_t: MSVC has no such type, and this signature is not
+     inside a POSIX guard. */
+  const uintptr_t ppid = (uintptr_t) pP;
   const char *why = NULL;
 
   while (why == NULL) {

--- a/src/htsweb.c
+++ b/src/htsweb.c
@@ -109,8 +109,10 @@ static int nonjoinable_threads = 0;
    goodbye when it closes, so an abandoned server can stop holding its payload
    open (a mounted disk image, on macOS) instead of outliving the session. */
 #define PING_PERIOD 5
-/* Silence tolerated from a client whose heartbeat we have seen. */
-static int pingTimeout = 90;
+/* Silence tolerated from a client whose heartbeat we have seen. Generous, and
+   deliberately so: a backgrounded tab has its timers throttled, and the prompt
+   exit is the goodbye's job, not this one's. */
+static int pingTimeout = 120;
 /* A goodbye only starts a countdown: another window may still be open, and its
    next ping cancels the departure, so this must outlast PING_PERIOD. */
 #define LEAVE_GRACE max(1, min(12, pingTimeout / 4))

--- a/src/webhttrack.in
+++ b/src/webhttrack.in
@@ -59,6 +59,19 @@ function launch_browser {
     log "Browser (or helper) exited"
 }
 
+# Wait until the session is over, which is whichever comes first: the server
+# stopping (the interface was closed, so this process has nothing left to
+# represent -- on macOS it is the app the Dock shows), or the browser exiting,
+# which is the only signal a browser too old to ping ever produces.
+function wait_for_session {
+    local browserpid=$1 srvpid=$2
+    while test -n "${srvpid}${browserpid}"; do
+        test -n "${srvpid}" && ! kill -0 "${srvpid}" 2>/dev/null && break
+        test -n "${browserpid}" && ! kill -0 "${browserpid}" 2>/dev/null && break
+        sleep 1
+    done
+}
+
 # First ensure that we can launch the server
 BINPATH=
 for i in "${SRCHPATH[@]}"; do
@@ -147,8 +160,14 @@ function cleanup {
 # Cleanup in case of emergency
 trap "cleanup now; exit" HUP INT QUIT PIPE TERM
 
-# Got SRVURL, launch browser
-launch_browser "${BROWSEREXE}" "${SRVURL}"
+# Got SRVURL, launch browser. Backgrounded so this process can outlive a browser
+# that returns at once and still stop with one that does not.
+launch_browser "${BROWSEREXE}" "${SRVURL}" &
+BROWSERPID=$!
+# Deliberately not SRVPID, which cleanup would then kill, taking a running mirror
+# with it.
+SESSIONPID=$(grep -E PID= "${TMPSRVFILE}" | cut -f2- -d=)
+wait_for_session "${BROWSERPID}" "${SESSIONPID}"
 
 # That's all, folks!
 trap "" HUP INT QUIT PIPE TERM

--- a/src/webhttrack.in
+++ b/src/webhttrack.in
@@ -59,14 +59,13 @@ function launch_browser {
     log "Browser (or helper) exited"
 }
 
-# Wait until the session is over, which is whichever comes first: the server
-# stopping (the interface was closed, so this process has nothing left to
-# represent -- on macOS it is the app the Dock shows), or the browser exiting,
-# which is the only signal a browser too old to ping ever produces.
+# Wait until the server stops (the interface closed, so this process has nothing
+# left to represent) or the browser exits, whichever comes first. An old browser
+# only ever signals by exiting.
 function wait_for_session {
-    local browserpid=$1 srvpid=$2
-    while test -n "${srvpid}${browserpid}"; do
-        test -n "${srvpid}" && ! kill -0 "${srvpid}" 2>/dev/null && break
+    local browserpid=$1 sessionpid=$2
+    while test -n "${sessionpid}${browserpid}"; do
+        test -n "${sessionpid}" && ! kill -0 "${sessionpid}" 2>/dev/null && break
         test -n "${browserpid}" && ! kill -0 "${browserpid}" 2>/dev/null && break
         sleep 1
     done

--- a/src/webhttrack.in
+++ b/src/webhttrack.in
@@ -160,8 +160,8 @@ function cleanup {
 # Cleanup in case of emergency
 trap "cleanup now; exit" HUP INT QUIT PIPE TERM
 
-# Got SRVURL, launch browser. Backgrounded so this process can outlive a browser
-# that returns at once and still stop with one that does not.
+# Got SRVURL, launch browser. Backgrounded so the wait below can watch the
+# server too, rather than only the browser.
 launch_browser "${BROWSEREXE}" "${SRVURL}" &
 BROWSERPID=$!
 # Deliberately not SRVPID, which cleanup would then kill, taking a running mirror

--- a/tests/289_webhttrack-lifetime.test
+++ b/tests/289_webhttrack-lifetime.test
@@ -109,10 +109,12 @@ while test "$((SECONDS - live_at))" -le $((timeout + 2)) ||
     test "$((SECONDS - quiet_at))" -le $((timeout + 2)); do
     poll_wait 0.5
 done
-! test -f "${pingfail}" || fail "the probe's own pings failed; nothing was proven"
+# Aliveness first: a server that dies also fails the pings aimed at it, and the
+# probe's own failure would then be the only thing reported.
 kill -0 "${live_pid}" 2>/dev/null || fail "a pinged server was killed anyway"
 kill -0 "${quiet_pid}" 2>/dev/null ||
     fail "a server whose client never pings was killed under a live launcher"
+! test -f "${pingfail}" || fail "the probe's own pings failed; nothing was proven"
 kill "${pinger}" 2>/dev/null || true
 pinger=
 

--- a/tests/289_webhttrack-lifetime.test
+++ b/tests/289_webhttrack-lifetime.test
@@ -101,7 +101,20 @@ sleep $((grace + 2))
 kill -0 "${bye_pid}" 2>/dev/null ||
     fail "an unauthenticated goodbye ended the session"
 
-# 4. The last window leaving takes the server with it, well inside the idle
+# 4. A flood of window ids must not push a real window out of the table: with
+# the last real one evicted, saying goodbye to the flood would end the session.
+# One more than the table holds, so the refusal itself is exercised.
+for i in $(seq 0 16); do
+    ping "${bye_port}" "f${i}"
+done
+for i in $(seq 0 16); do
+    bye "${bye_port}" "f${i}" "${sid}"
+done
+sleep $((grace + 2))
+kill -0 "${bye_pid}" 2>/dev/null ||
+    fail "a flood of window ids evicted the real window and ended the session"
+
+# 5. The last window leaving takes the server with it, well inside the idle
 # timeout that would otherwise apply.
 bye "${bye_port}" w2 "${sid}"
 bye_at=${SECONDS}
@@ -112,13 +125,13 @@ test "$((SECONDS - bye_at))" -le $((grace + 3)) ||
 
 # The four cases below share one wait, so they cost one timeout, not four.
 
-# 5. A window that stops pinging without a goodbye has crashed with its browser.
+# 6. A window that stops pinging without a goodbye has crashed with its browser.
 start_case
 lost_pid=${HTS_PID}
 ping "${HTS_PORT}" w1
 lost_at=${SECONDS}
 
-# 6. A window that keeps pinging keeps its server, past that same deadline.
+# 7. A window that keeps pinging keeps its server, past that same deadline.
 start_case
 live_pid=${HTS_PID}
 live_port=${HTS_PORT}
@@ -132,7 +145,7 @@ pingfail="${work}/pingfail"
 ) &
 pinger=$!
 
-# 7. A client that never pings at all is a browser too old for the heartbeat, or
+# 8. A client that never pings at all is a browser too old for the heartbeat, or
 # one with scripting off, and may be a user reading the page: only the
 # launcher's death may end that session, and nothing here kills this shell.
 start_case
@@ -140,7 +153,7 @@ quiet_pid=${HTS_PID}
 quiet_at=${SECONDS}
 get "${HTS_PORT}" /server/index.html >/dev/null
 
-# 8. ..and when that launcher does die, the same session ends: it is the only
+# 9. ..and when that launcher does die, the same session ends: it is the only
 # signal such a browser produces. A process of our own stands in for it.
 sleep 600 &
 sleeper=$!
@@ -180,7 +193,7 @@ kill -0 "${quiet_pid}" 2>/dev/null ||
 kill "${pinger}" 2>/dev/null || true
 pinger=
 
-# 9. Closing the window while a mirror runs must not take the mirror down: it
+# 10. Closing the window while a mirror runs must not take the mirror down: it
 # may have hours of crawling behind it. The veto has to lift when the crawl
 # ends, or the server it saved becomes immortal.
 start_case
@@ -213,7 +226,7 @@ test -d "${work}/crawl/hts-cache" || fail "no mirror ever started: $(cat "${clog
 died_within "${crawl_pid}" $((timeout * 3)) ||
     fail "the server never left once its mirror had finished"
 
-# 10. The wizard's own Quit button is the other way out, and the only one that
+# 11. The wizard's own Quit button is the other way out, and the only one that
 # leaves through smallserver(), which has to report the server it did create.
 start_case
 quit_pid=${HTS_PID}

--- a/tests/289_webhttrack-lifetime.test
+++ b/tests/289_webhttrack-lifetime.test
@@ -41,6 +41,16 @@ start_case() {
 
 get() { "${HTS_PYTHON}" "${testdir}/httpclient.py" --port "$1" --path "$2"; }
 ping() { get "$1" "/ping?w=$2&t=${RANDOM}${3:+&$3}" >/dev/null; }
+# The session id every UI page carries, which the server demands of a farewell.
+page_sid() {
+    firstline "$(get "$1" /server/index.html |
+        sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p')"
+}
+# A farewell as the page sends one: a POST holding that id.
+bye() {
+    "${HTS_PYTHON}" "${testdir}/httpclient.py" --port "$1" \
+        --path "/ping?w=$2&t=${RANDOM}&e=bye" --field "sid=$3" >/dev/null
+}
 
 # Wait up to $2 seconds for $1 to go away.
 died_within() {
@@ -59,12 +69,16 @@ printf '[an abandoned WebHTTrack server stops on its own] ..\t'
 js="${HTS_DISTDIR}/html/server/ping.js"
 grep -qF '"/ping?w=" + PING_WINDOW' "${js}" || fail "ping.js stopped naming its window"
 grep -qF 'ping_url("e=bye")' "${js}" || fail "ping.js stopped saying goodbye"
+grep -qF '"sid=" + encodeURIComponent(sid)' "${js}" ||
+    fail "ping.js stopped signing its goodbye, which the server then ignores"
 
 # 1. The heartbeat must never be answered from a cache: a reply the browser
 # reuses is one the server never sees, and silence is what kills it.
 start_case
 bye_pid=${HTS_PID}
 bye_port=${HTS_PORT}
+sid=$(page_sid "${bye_port}")
+test "${#sid}" -eq 32 || fail "no session id on the wizard's first page"
 reply=$(get "${bye_port}" '/ping?w=w1')
 grep -q '^HTTP/1\.0 200 ' <<<"${reply}" || fail "no pong: $(head -1 <<<"${reply}")"
 grep -qi '^Cache-Control:.*no-cache' <<<"${reply}" ||
@@ -74,14 +88,22 @@ grep -qi '^Cache-Control:.*no-cache' <<<"${reply}" ||
 # A hidden tab has its timers throttled to as little as one wake-up a minute, so
 # this cannot rest on the survivor answering inside the grace.
 ping "${bye_port}" w2
-ping "${bye_port}" w1 e=bye
+bye "${bye_port}" w1 "${sid}"
 sleep $((grace + 2))
 kill -0 "${bye_pid}" 2>/dev/null ||
     fail "closing one window ended a session another window still had open"
 
-# 3. The last window leaving takes the server with it, well inside the idle
-# timeout that would otherwise apply.
+# 3. An unsigned farewell is not one: /ping is a GET, so it clears neither the
+# session-id nor the Origin gate, and any local process or visited page can send
+# it. Only a heartbeat may go unproven, and a heartbeat only extends a life.
 ping "${bye_port}" w2 e=bye
+sleep $((grace + 2))
+kill -0 "${bye_pid}" 2>/dev/null ||
+    fail "an unauthenticated goodbye ended the session"
+
+# 4. The last window leaving takes the server with it, well inside the idle
+# timeout that would otherwise apply.
+bye "${bye_port}" w2 "${sid}"
 bye_at=${SECONDS}
 died_within "${bye_pid}" $((timeout - 1)) ||
     fail "the server outlived its last window by $((SECONDS - bye_at))s"
@@ -90,13 +112,13 @@ test "$((SECONDS - bye_at))" -le $((grace + 3)) ||
 
 # The four cases below share one wait, so they cost one timeout, not four.
 
-# 4. A window that stops pinging without a goodbye has crashed with its browser.
+# 5. A window that stops pinging without a goodbye has crashed with its browser.
 start_case
 lost_pid=${HTS_PID}
 ping "${HTS_PORT}" w1
 lost_at=${SECONDS}
 
-# 5. A window that keeps pinging keeps its server, past that same deadline.
+# 6. A window that keeps pinging keeps its server, past that same deadline.
 start_case
 live_pid=${HTS_PID}
 live_port=${HTS_PORT}
@@ -110,7 +132,7 @@ pingfail="${work}/pingfail"
 ) &
 pinger=$!
 
-# 6. A client that never pings at all is a browser too old for the heartbeat, or
+# 7. A client that never pings at all is a browser too old for the heartbeat, or
 # one with scripting off, and may be a user reading the page: only the
 # launcher's death may end that session, and nothing here kills this shell.
 start_case
@@ -118,7 +140,7 @@ quiet_pid=${HTS_PID}
 quiet_at=${SECONDS}
 get "${HTS_PORT}" /server/index.html >/dev/null
 
-# 7. ..and when that launcher does die, the same session ends: it is the only
+# 8. ..and when that launcher does die, the same session ends: it is the only
 # signal such a browser produces. A process of our own stands in for it.
 sleep 600 &
 sleeper=$!
@@ -143,9 +165,10 @@ died_within "${legacy_pid}" $((timeout * 3)) ||
     fail "a server outlived its launcher by $((SECONDS - legacy_at))s"
 
 # Both survivors started after the crashed one, so its death is too early to
-# judge them by: wait until each has outlived a timeout of its own.
-while test "$((SECONDS - live_at))" -le $((timeout + 2)) ||
-    test "$((SECONDS - quiet_at))" -le $((timeout + 2)); do
+# judge them by. Two timeouts, not one: a window whose refresh stopped working
+# would still be inside its first.
+while test "$((SECONDS - live_at))" -le $((timeout * 2)) ||
+    test "$((SECONDS - quiet_at))" -le $((timeout * 2)); do
     poll_wait 0.5
 done
 # Aliveness first: a server that dies also fails the pings aimed at it, and the
@@ -157,9 +180,9 @@ kill -0 "${quiet_pid}" 2>/dev/null ||
 kill "${pinger}" 2>/dev/null || true
 pinger=
 
-# 8. Closing the window while a mirror runs must not take the mirror down: it
-# may have hours of crawling behind it, and its page can be reopened. The veto
-# has to lift when the crawl ends, or the server it saved becomes immortal.
+# 9. Closing the window while a mirror runs must not take the mirror down: it
+# may have hours of crawling behind it. The veto has to lift when the crawl
+# ends, or the server it saved becomes immortal.
 start_case
 crawl_pid=${HTS_PID}
 crawl_port=${HTS_PORT}
@@ -168,8 +191,7 @@ clog="${work}/content.log"
 csrv=$!
 cport=$(discover_server_port "${clog}" "${csrv}") || fail "no content server"
 
-sid=$(firstline "$(get "${crawl_port}" /server/index.html |
-    sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p')")
+sid=$(page_sid "${crawl_port}")
 test "${#sid}" -eq 32 || fail "no session id to start a mirror with"
 # Its index links one page that sleeps 5s, so the crawl outlasts the grace and
 # still ends inside the test.
@@ -180,7 +202,7 @@ test "${#sid}" -eq 32 || fail "no session id to start a mirror with"
     >/dev/null
 
 ping "${crawl_port}" w1
-ping "${crawl_port}" w1 e=bye
+bye "${crawl_port}" w1 "${sid}"
 sleep $((grace + 2))
 kill -0 "${crawl_pid}" 2>/dev/null ||
     fail "the crawling server quit, taking its mirror with it"
@@ -191,13 +213,11 @@ test -d "${work}/crawl/hts-cache" || fail "no mirror ever started: $(cat "${clog
 died_within "${crawl_pid}" $((timeout * 3)) ||
     fail "the server never left once its mirror had finished"
 
-# 9. The wizard's own Quit button is the other way out, and the only one that
-# leaves through smallserver(). It used to report a server it could not create,
-# because that function returned its untouched initializer.
+# 10. The wizard's own Quit button is the other way out, and the only one that
+# leaves through smallserver(), which has to report the server it did create.
 start_case
 quit_pid=${HTS_PID}
-sid=$(firstline "$(get "${HTS_PORT}" /server/index.html |
-    sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p')")
+sid=$(page_sid "${HTS_PORT}")
 test "${#sid}" -eq 32 || fail "no session id to quit with"
 "${HTS_PYTHON}" "${testdir}/httpclient.py" --port "${HTS_PORT}" \
     --path /server/exit.html --field "sid=${sid}" --field command=quit >/dev/null

--- a/tests/289_webhttrack-lifetime.test
+++ b/tests/289_webhttrack-lifetime.test
@@ -1,0 +1,140 @@
+#!/bin/bash
+#
+# An abandoned htsserver has to stop on its own: it holds its payload open, and
+# on macOS that payload is a disk image the user then cannot eject.
+
+set -euo pipefail
+
+# shellcheck source=tests/webhttracklib.sh
+. "$(dirname "$0")/webhttracklib.sh"
+
+htsserver_require
+
+# Short enough to sit in the suite, long enough that a loaded parallel run
+# cannot starve a ping past it. The server derives the goodbye grace from it.
+timeout=10
+grace=2
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_life.XXXXXX") || fail "no tmpdir"
+pinger=
+csrv=
+cleanup() {
+    htsserver_cleanup
+    test -z "${pinger}" || kill "${pinger}" 2>/dev/null || true
+    test -z "${csrv}" || kill -9 "${csrv}" 2>/dev/null || true
+    wait "${pinger}" "${csrv}" 2>/dev/null || true
+    rm -rf "${work}"
+}
+cleanup_push cleanup
+
+export HOME="${work}"
+
+# Each case owns a server, so save its handle: the library keeps only the last.
+start_case() {
+    htsserver_start --home "${work}" -- --ppid $$ --ping-timeout "${timeout}"
+    test -n "${HTS_PID}" || skip "this platform announces no server pid"
+}
+
+get() { "${HTS_PYTHON}" "${testdir}/httpclient.py" --port "$1" --path "$2"; }
+
+# Wait up to $2 seconds for $1 to go away.
+died_within() {
+    local pid=$1 limit=$2 start=$SECONDS
+    while kill -0 "${pid}" 2>/dev/null; do
+        test "$((SECONDS - start))" -lt "${limit}" || return 1
+        poll_wait 0.2
+    done
+}
+
+printf '[an abandoned WebHTTrack server stops on its own] ..\t'
+
+# 1. The heartbeat must never be answered from a cache: a reply the browser
+# reuses is one the server never sees, and silence is what kills it.
+start_case
+bye_pid=${HTS_PID}
+reply=$(get "${HTS_PORT}" /ping)
+grep -q '^HTTP/1\.0 200 ' <<<"${reply}" || fail "no pong: $(head -1 <<<"${reply}")"
+grep -qi '^Cache-Control:.*no-cache' <<<"${reply}" ||
+    fail "the heartbeat is cacheable: ${reply}"
+
+# 2. A window that says goodbye takes the server with it, well inside the idle
+# timeout that would otherwise apply.
+get "${HTS_PORT}" '/ping?t=1&e=bye' >/dev/null
+bye_at=${SECONDS}
+died_within "${bye_pid}" $((timeout - 1)) ||
+    fail "the server outlived its goodbye by $((SECONDS - bye_at))s"
+test "$((SECONDS - bye_at))" -le $((grace + 3)) ||
+    fail "the goodbye took $((SECONDS - bye_at))s, past the ${grace}s grace"
+
+# The three cases below share one wait, so they cost one timeout, not three.
+
+# 3. A client whose heartbeat we have seen and then lost is gone for good: this
+# is the crash path, where no goodbye is ever sent.
+start_case
+lost_pid=${HTS_PID}
+get "${HTS_PORT}" /server/index.html >/dev/null
+get "${HTS_PORT}" /ping >/dev/null
+lost_at=${SECONDS}
+
+# 4. A client that keeps pinging keeps its server, past that same deadline.
+start_case
+live_pid=${HTS_PID}
+live_port=${HTS_PORT}
+pingfail="${work}/pingfail"
+(
+    while :; do
+        get "${live_port}" /ping >/dev/null 2>&1 || echo failed >>"${pingfail}"
+        poll_wait 0.5
+    done
+) &
+pinger=$!
+
+# 5. A client that never pings at all is a browser too old for the heartbeat, or
+# one with scripting off, and may be a user reading the page: only the
+# launcher's death may end that session, and nothing here kills the launcher.
+start_case
+quiet_pid=${HTS_PID}
+get "${HTS_PORT}" /server/index.html >/dev/null
+
+died_within "${lost_pid}" $((timeout * 3)) ||
+    fail "a server whose client stopped pinging survived $((SECONDS - lost_at))s"
+test "$((SECONDS - lost_at))" -ge $((timeout - 2)) ||
+    fail "the idle timeout fired after $((SECONDS - lost_at))s, under ${timeout}s"
+! test -f "${pingfail}" || fail "the probe's own pings failed; nothing was proven"
+kill -0 "${live_pid}" 2>/dev/null || fail "a pinged server was killed anyway"
+kill -0 "${quiet_pid}" 2>/dev/null ||
+    fail "a server whose client never pings was killed under a live launcher"
+kill "${pinger}" 2>/dev/null || true
+pinger=
+
+# 6. Closing the window while a mirror runs must not take the mirror down: it
+# may have hours of crawling behind it, and its page can be reopened. Without
+# that veto the goodbye below would end this server in ${grace}s.
+start_case
+crawl_pid=${HTS_PID}
+crawl_port=${HTS_PORT}
+clog="${work}/content.log"
+"${HTS_PYTHON}" "${testdir}/local-server.py" --root "${work}" >"${clog}" 2>&1 &
+csrv=$!
+cport=$(discover_server_port "${clog}" "${csrv}") || fail "no content server"
+
+sid=$(firstline "$(get "${crawl_port}" /server/index.html |
+    sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p')")
+test "${#sid}" -eq 32 || fail "no session id to start a mirror with"
+# Its .bin pages dribble for a minute, holding the crawl open past the timeout.
+"${HTS_PYTHON}" "${testdir}/httpclient.py" --port "${crawl_port}" \
+    --path /step4.html --field "sid=${sid}" --field "path=${work}" \
+    --field projname=crawl --field winprofile=x --field command_do=start \
+    --field "command=httrack --quiet --robots=0 http://127.0.0.1:${cport}/trickle/index.html -O ${work}/crawl" \
+    >/dev/null
+
+get "${crawl_port}" '/ping?t=1&e=bye' >/dev/null
+! died_within "${crawl_pid}" $((timeout * 2)) ||
+    fail "the crawling server quit, taking its mirror with it"
+# A crawl that never started would leave the veto unexercised, and the survival
+# above would prove nothing.
+test -d "${work}/crawl/hts-cache" || fail "no mirror ever started: $(cat "${clog}")"
+
+htsserver_stop
+htsserver_assert_reaped
+echo OK

--- a/tests/289_webhttrack-lifetime.test
+++ b/tests/289_webhttrack-lifetime.test
@@ -11,18 +11,20 @@ set -euo pipefail
 htsserver_require
 
 # Short enough to sit in the suite, long enough that a loaded parallel run
-# cannot starve a ping past it. The server derives the goodbye grace from it.
+# cannot starve a ping past it. The server derives the leave grace from it.
 timeout=10
 grace=2
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_life.XXXXXX") || fail "no tmpdir"
 pinger=
 csrv=
+sleeper=
 cleanup() {
     htsserver_cleanup
-    test -z "${pinger}" || kill "${pinger}" 2>/dev/null || true
-    test -z "${csrv}" || kill -9 "${csrv}" 2>/dev/null || true
-    wait "${pinger}" "${csrv}" 2>/dev/null || true
+    for p in "${pinger}" "${csrv}" "${sleeper}"; do
+        test -z "${p}" || kill -9 "${p}" 2>/dev/null || true
+    done
+    wait "${pinger}" "${csrv}" "${sleeper}" 2>/dev/null || true
     rm -rf "${work}"
 }
 cleanup_push cleanup
@@ -30,12 +32,15 @@ cleanup_push cleanup
 export HOME="${work}"
 
 # Each case owns a server, so save its handle: the library keeps only the last.
+# $1, when given, is the pid to name as the launcher instead of this shell.
 start_case() {
-    htsserver_start --home "${work}" -- --ppid $$ --ping-timeout "${timeout}"
+    htsserver_start --home "${work}" -- \
+        --ppid "${1:-$$}" --ping-timeout "${timeout}"
     test -n "${HTS_PID}" || skip "this platform announces no server pid"
 }
 
 get() { "${HTS_PYTHON}" "${testdir}/httpclient.py" --port "$1" --path "$2"; }
+ping() { get "$1" "/ping?w=$2&t=${RANDOM}${3:+&$3}" >/dev/null; }
 
 # Wait up to $2 seconds for $1 to go away.
 died_within() {
@@ -48,35 +53,50 @@ died_within() {
 
 printf '[an abandoned WebHTTrack server stops on its own] ..\t'
 
+# The page and the server agree on one wire format, and only the page half runs
+# in a browser: a client that stopped naming its window, or spelled the farewell
+# differently, would leave every case below testing the server against itself.
+js="${HTS_DISTDIR}/html/server/ping.js"
+grep -qF '"/ping?w=" + PING_WINDOW' "${js}" || fail "ping.js stopped naming its window"
+grep -qF 'ping_url("e=bye")' "${js}" || fail "ping.js stopped saying goodbye"
+
 # 1. The heartbeat must never be answered from a cache: a reply the browser
 # reuses is one the server never sees, and silence is what kills it.
 start_case
 bye_pid=${HTS_PID}
-reply=$(get "${HTS_PORT}" /ping)
+bye_port=${HTS_PORT}
+reply=$(get "${bye_port}" '/ping?w=w1')
 grep -q '^HTTP/1\.0 200 ' <<<"${reply}" || fail "no pong: $(head -1 <<<"${reply}")"
 grep -qi '^Cache-Control:.*no-cache' <<<"${reply}" ||
     fail "the heartbeat is cacheable: ${reply}"
 
-# 2. A window that says goodbye takes the server with it, well inside the idle
+# 2. Closing one of two windows must not end a session the other is still using.
+# A hidden tab has its timers throttled to as little as one wake-up a minute, so
+# this cannot rest on the survivor answering inside the grace.
+ping "${bye_port}" w2
+ping "${bye_port}" w1 e=bye
+sleep $((grace + 2))
+kill -0 "${bye_pid}" 2>/dev/null ||
+    fail "closing one window ended a session another window still had open"
+
+# 3. The last window leaving takes the server with it, well inside the idle
 # timeout that would otherwise apply.
-get "${HTS_PORT}" '/ping?t=1&e=bye' >/dev/null
+ping "${bye_port}" w2 e=bye
 bye_at=${SECONDS}
 died_within "${bye_pid}" $((timeout - 1)) ||
-    fail "the server outlived its goodbye by $((SECONDS - bye_at))s"
+    fail "the server outlived its last window by $((SECONDS - bye_at))s"
 test "$((SECONDS - bye_at))" -le $((grace + 3)) ||
-    fail "the goodbye took $((SECONDS - bye_at))s, past the ${grace}s grace"
+    fail "the last window took $((SECONDS - bye_at))s, past the ${grace}s grace"
 
-# The three cases below share one wait, so they cost one timeout, not three.
+# The four cases below share one wait, so they cost one timeout, not four.
 
-# 3. A client whose heartbeat we have seen and then lost is gone for good: this
-# is the crash path, where no goodbye is ever sent.
+# 4. A window that stops pinging without a goodbye has crashed with its browser.
 start_case
 lost_pid=${HTS_PID}
-get "${HTS_PORT}" /server/index.html >/dev/null
-get "${HTS_PORT}" /ping >/dev/null
+ping "${HTS_PORT}" w1
 lost_at=${SECONDS}
 
-# 4. A client that keeps pinging keeps its server, past that same deadline.
+# 5. A window that keeps pinging keeps its server, past that same deadline.
 start_case
 live_pid=${HTS_PID}
 live_port=${HTS_PORT}
@@ -84,27 +104,46 @@ live_at=${SECONDS}
 pingfail="${work}/pingfail"
 (
     while :; do
-        get "${live_port}" /ping >/dev/null 2>&1 || echo failed >>"${pingfail}"
+        ping "${live_port}" w1 || echo failed >>"${pingfail}"
         poll_wait 0.5
     done
 ) &
 pinger=$!
 
-# 5. A client that never pings at all is a browser too old for the heartbeat, or
+# 6. A client that never pings at all is a browser too old for the heartbeat, or
 # one with scripting off, and may be a user reading the page: only the
-# launcher's death may end that session, and nothing here kills the launcher.
+# launcher's death may end that session, and nothing here kills this shell.
 start_case
 quiet_pid=${HTS_PID}
 quiet_at=${SECONDS}
 get "${HTS_PORT}" /server/index.html >/dev/null
 
+# 7. ..and when that launcher does die, the same session ends: it is the only
+# signal such a browser produces. A process of our own stands in for it.
+sleep 600 &
+sleeper=$!
+start_case "${sleeper}"
+legacy_pid=${HTS_PID}
+get "${HTS_PORT}" /server/index.html >/dev/null
+legacy_at=${SECONDS}
+kill "${sleeper}" 2>/dev/null || true
+wait "${sleeper}" 2>/dev/null || true # absorb bash's async "Terminated" notice
+sleeper=
+
+# The crashed window must outlive its setup, or the floor asserted below could
+# be met by the time these four servers took to start.
+kill -0 "${lost_pid}" 2>/dev/null ||
+    fail "the idle timeout fired during setup, $((SECONDS - lost_at))s in"
+
 died_within "${lost_pid}" $((timeout * 3)) ||
-    fail "a server whose client stopped pinging survived $((SECONDS - lost_at))s"
+    fail "a server whose window stopped pinging survived $((SECONDS - lost_at))s"
 test "$((SECONDS - lost_at))" -ge $((timeout - 2)) ||
     fail "the idle timeout fired after $((SECONDS - lost_at))s, under ${timeout}s"
+died_within "${legacy_pid}" $((timeout * 3)) ||
+    fail "a server outlived its launcher by $((SECONDS - legacy_at))s"
 
-# Both survivors started after that one, so its death is too early to judge them
-# by: wait until each has outlived a timeout of its own.
+# Both survivors started after the crashed one, so its death is too early to
+# judge them by: wait until each has outlived a timeout of its own.
 while test "$((SECONDS - live_at))" -le $((timeout + 2)) ||
     test "$((SECONDS - quiet_at))" -le $((timeout + 2)); do
     poll_wait 0.5
@@ -118,9 +157,9 @@ kill -0 "${quiet_pid}" 2>/dev/null ||
 kill "${pinger}" 2>/dev/null || true
 pinger=
 
-# 6. Closing the window while a mirror runs must not take the mirror down: it
-# may have hours of crawling behind it, and its page can be reopened. Without
-# that veto the goodbye below would end this server in ${grace}s.
+# 8. Closing the window while a mirror runs must not take the mirror down: it
+# may have hours of crawling behind it, and its page can be reopened. The veto
+# has to lift when the crawl ends, or the server it saved becomes immortal.
 start_case
 crawl_pid=${HTS_PID}
 crawl_port=${HTS_PORT}
@@ -132,19 +171,39 @@ cport=$(discover_server_port "${clog}" "${csrv}") || fail "no content server"
 sid=$(firstline "$(get "${crawl_port}" /server/index.html |
     sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p')")
 test "${#sid}" -eq 32 || fail "no session id to start a mirror with"
-# Its .bin pages dribble for a minute, holding the crawl open past the timeout.
+# Its index links one page that sleeps 5s, so the crawl outlasts the grace and
+# still ends inside the test.
 "${HTS_PYTHON}" "${testdir}/httpclient.py" --port "${crawl_port}" \
     --path /step4.html --field "sid=${sid}" --field "path=${work}" \
     --field projname=crawl --field winprofile=x --field command_do=start \
-    --field "command=httrack --quiet --robots=0 http://127.0.0.1:${cport}/trickle/index.html -O ${work}/crawl" \
+    --field "command=httrack --quiet --robots=0 http://127.0.0.1:${cport}/abortpurge/index.html -O ${work}/crawl" \
     >/dev/null
 
-get "${crawl_port}" '/ping?t=1&e=bye' >/dev/null
-! died_within "${crawl_pid}" $((timeout * 2)) ||
+ping "${crawl_port}" w1
+ping "${crawl_port}" w1 e=bye
+sleep $((grace + 2))
+kill -0 "${crawl_pid}" 2>/dev/null ||
     fail "the crawling server quit, taking its mirror with it"
 # A crawl that never started would leave the veto unexercised, and the survival
 # above would prove nothing.
 test -d "${work}/crawl/hts-cache" || fail "no mirror ever started: $(cat "${clog}")"
+
+died_within "${crawl_pid}" $((timeout * 3)) ||
+    fail "the server never left once its mirror had finished"
+
+# 9. The wizard's own Quit button is the other way out, and the only one that
+# leaves through smallserver(). It used to report a server it could not create,
+# because that function returned its untouched initializer.
+start_case
+quit_pid=${HTS_PID}
+sid=$(firstline "$(get "${HTS_PORT}" /server/index.html |
+    sed -n 's/.*name="sid" value="\([0-9a-f]*\)".*/\1/p')")
+test "${#sid}" -eq 32 || fail "no session id to quit with"
+"${HTS_PYTHON}" "${testdir}/httpclient.py" --port "${HTS_PORT}" \
+    --path /server/exit.html --field "sid=${sid}" --field command=quit >/dev/null
+died_within "${quit_pid}" "${grace}" || fail "Quit did not stop the server"
+! grep -q 'Unable to create the server' "${HTS_LOG}" ||
+    fail "a clean quit reported a server it could not create: $(cat "${HTS_LOG}")"
 
 htsserver_stop
 htsserver_assert_reaped

--- a/tests/289_webhttrack-lifetime.test
+++ b/tests/289_webhttrack-lifetime.test
@@ -80,6 +80,7 @@ lost_at=${SECONDS}
 start_case
 live_pid=${HTS_PID}
 live_port=${HTS_PORT}
+live_at=${SECONDS}
 pingfail="${work}/pingfail"
 (
     while :; do
@@ -94,12 +95,20 @@ pinger=$!
 # launcher's death may end that session, and nothing here kills the launcher.
 start_case
 quiet_pid=${HTS_PID}
+quiet_at=${SECONDS}
 get "${HTS_PORT}" /server/index.html >/dev/null
 
 died_within "${lost_pid}" $((timeout * 3)) ||
     fail "a server whose client stopped pinging survived $((SECONDS - lost_at))s"
 test "$((SECONDS - lost_at))" -ge $((timeout - 2)) ||
     fail "the idle timeout fired after $((SECONDS - lost_at))s, under ${timeout}s"
+
+# Both survivors started after that one, so its death is too early to judge them
+# by: wait until each has outlived a timeout of its own.
+while test "$((SECONDS - live_at))" -le $((timeout + 2)) ||
+    test "$((SECONDS - quiet_at))" -le $((timeout + 2)); do
+    poll_wait 0.5
+done
 ! test -f "${pingfail}" || fail "the probe's own pings failed; nothing was proven"
 kill -0 "${live_pid}" 2>/dev/null || fail "a pinged server was killed anyway"
 kill -0 "${quiet_pid}" 2>/dev/null ||


### PR DESCRIPTION
The heartbeat only armed after the launcher died, and on macOS the launcher waits in `open -W` until the whole browser quits. Closing the interface therefore left htsserver running with the app bundle open, so the disk image could not be ejected without a force kill.

An idle session now ends when the user closes it, and a busy one when the work finishes. Each window pings under an id of its own and drops it when it closes, so the server exits once the last one is gone instead of after a two to four minute silence. Counting windows rather than timing them is what lets one of two close without ending the session: a hidden tab has its timers throttled to as little as one wake-up a minute, so it would lose that race. A running mirror vetoes every exit, so a long crawl survives a closed tab and its page can be reopened. The watchdog counts its own ticks instead of reading the wall clock, so a suspended laptop does not age a session out. A browser that never pings still ends only with the launcher, since it may be a reader with scripting off.

Ending a session is a command, so it now carries the session id like every other one. `/ping` is a GET and clears neither the sid nor the Origin gate, which was harmless while a heartbeat could only extend a life. Left alone it would have let any local process, or any page the user visits, close someone's WebHTTrack. A full window table also refuses newcomers rather than evicting, so a flood of ids cannot reach the same end by pushing the real window out.

Three smaller fixes ride along. `smallserver()` returned its untouched initializer, so every clean quit reported "Unable to create the server" and exited 1. A failed thread spawn left the mirror flag latched, which the new veto would have turned into a server that never exits. And `--ping-timeout`, the hidden knob the new test drives all of this with in seconds, parses the way `--port` does rather than with the bare `sscanf` that cost us #614.
