### PR TITLE
The wizard can only answer about one exact host

### DIFF
--- a/src/htsdefines.h
+++ b/src/htsdefines.h
@@ -146,6 +146,13 @@ typedef const char *(*t_hts_htmlcheck_query3)(t_hts_callbackarg *carg,
                                               httrackp *opt,
                                               const char *question);
 
+/* query3 answers HTS_WIZARD_SCOPE_INCLUDE+k and HTS_WIZARD_SCOPE_EXCLUDE+k take
+   or drop the k-th host scope hts_wizard_host_scope() enumerates. The stride
+   outruns any hostname's label count, so it cannot collide with the plain
+   single-digit answers. */
+#define HTS_WIZARD_SCOPE_INCLUDE 1000
+#define HTS_WIZARD_SCOPE_EXCLUDE 2000
+
 /* Per-tick progress hook: 'back' is the transfer slot array of 'back_max'
    entries, back_index the active one; lien_tot/lien_ntot and stats report
    queue size and running totals, stat_time the elapsed time. */

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -4136,6 +4136,19 @@ hts_boolean hts_is_control_free(const char *str) {
   return hts_is_control_free_sized(str, strlen(str));
 }
 
+hts_boolean hts_host_is_ipv4(const char *host, size_t len) {
+  size_t i;
+  int dots = 0;
+
+  for (i = 0; i < len; i++) {
+    if (host[i] == '.')
+      dots++;
+    else if (host[i] < '0' || host[i] > '9')
+      return HTS_FALSE;
+  }
+  return dots > 0 ? HTS_TRUE : HTS_FALSE;
+}
+
 hts_boolean hts_proxy_is_socks(const char *name) {
   if (name == NULL)
     return HTS_FALSE;

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -255,6 +255,10 @@ hts_boolean hts_is_control_free_sized(const char *str, size_t len);
 /* Same over a NUL-terminated string. */
 hts_boolean hts_is_control_free(const char *str);
 
+/* TRUE if host[0..len) is an IPv4 literal: digits and dots, at least one dot.
+   Such a host has no domain structure to reverse or to widen into. */
+hts_boolean hts_host_is_ipv4(const char *host, size_t len);
+
 /* TRUE if this -P proxy name (which keeps its scheme) is a SOCKS5 proxy. */
 hts_boolean hts_proxy_is_socks(const char *name);
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4112,25 +4112,27 @@ static int st_hashkey_bounds(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-/* Prints the filter answer <n> emits for (adr, fil) [up]; with no arguments,
-   asserts every answer against its expected pattern (#1119). */
+/* Prints the filter answer <n> emits for (adr, fil) [up] in [slot]; with no
+   arguments, asserts every answer against its expected pattern (#1119). */
 static int st_wizardfilter(httrackp *opt, int argc, char **argv) {
   char pattern[HTS_URLMAXSIZE * 2];
   htsbuff f = htsbuff_array(pattern);
 
   (void) opt;
   if (argc >= 3) {
-    hts_wizard_answer_filter(&f, atoi(argv[0]), argv[1], argv[2],
-                             argc >= 4 && atoi(argv[3]) != 0 ? HTS_TRUE
-                                                             : HTS_FALSE);
+    hts_wizard_answer_filter(
+        &f, argc >= 5 ? atoi(argv[4]) : 0, atoi(argv[0]), argv[1], argv[2],
+        argc >= 4 && atoi(argv[3]) != 0 ? HTS_TRUE : HTS_FALSE);
     printf("%s\n", pattern);
     return 0;
   }
-#define EMITS(n, adr, fil, up, expect)                                         \
+#define EMITS_SLOT(slot, n, adr, fil, up, expect)                              \
   do {                                                                         \
-    hts_wizard_answer_filter(&f, (n), (adr), (fil), (up));                     \
+    hts_wizard_answer_filter(&f, (slot), (n), (adr), (fil), (up));             \
     assertf(strcmp(pattern, (expect)) == 0);                                   \
   } while (0)
+#define EMITS(n, adr, fil, up, expect)                                         \
+  EMITS_SLOT(0, (n), (adr), (fil), (up), (expect))
 
   /* the host-wide answers: 2 forbids, 5 (allowed to go up) and 6 authorize */
   EMITS(2, "foo.com", "/index.html", HTS_FALSE, "-foo.com/*");
@@ -4171,8 +4173,159 @@ static int st_wizardfilter(httrackp *opt, int argc, char **argv) {
   EMITS(3, "foo.com", "/x", HTS_FALSE, "");
   EMITS(4, "foo.com", "/x", HTS_FALSE, "");
   EMITS(50, "foo.com", "/x", HTS_FALSE, "");
+  /* only slot 0 is ever filled outside the host-scope answers */
+  EMITS_SLOT(1, 2, "foo.com", "/x", HTS_FALSE, "");
+  EMITS_SLOT(1, 6, "foo.com", "/x", HTS_FALSE, "");
+
+  /* the host-scope answers (#1117): both slots, the starred one missing the
+     apex is why the second exists */
+#define SCOPE_IN HTS_WIZARD_SCOPE_INCLUDE
+#define SCOPE_EX HTS_WIZARD_SCOPE_EXCLUDE
+  EMITS_SLOT(0, SCOPE_IN, "www.example.co.uk", "/x", HTS_FALSE,
+             "+*.www.example.co.uk/*");
+  EMITS_SLOT(1, SCOPE_IN, "www.example.co.uk", "/x", HTS_FALSE,
+             "+www.example.co.uk/*");
+  EMITS_SLOT(0, SCOPE_IN + 1, "www.example.co.uk", "/x", HTS_FALSE,
+             "+*.example.co.uk/*");
+  EMITS_SLOT(1, SCOPE_IN + 1, "www.example.co.uk", "/x", HTS_FALSE,
+             "+example.co.uk/*");
+  EMITS_SLOT(0, SCOPE_EX + 1, "www.example.co.uk", "/x", HTS_FALSE,
+             "-*.example.co.uk/*");
+  EMITS_SLOT(1, SCOPE_EX + 1, "www.example.co.uk", "/x", HTS_FALSE,
+             "-example.co.uk/*");
+  /* the port rides along, the credentials do not */
+  EMITS_SLOT(0, SCOPE_IN + 1, "www.foo.com:8080", "/x", HTS_FALSE,
+             "+*.foo.com:8080/*");
+  EMITS_SLOT(1, SCOPE_IN, "user:pass@www.foo.com", "/x", HTS_FALSE,
+             "+www.foo.com/*");
+  /* past the last scope, and slot 2, emit nothing */
+  EMITS_SLOT(0, SCOPE_IN + 2, "www.foo.com", "/x", HTS_FALSE, "");
+  EMITS_SLOT(2, SCOPE_IN, "www.foo.com", "/x", HTS_FALSE, "");
+
+  /* what the pair must and must not catch */
+  EMITS_SLOT(0, SCOPE_IN + 1, "www.example.co.uk", "/x", HTS_FALSE,
+             "+*.example.co.uk/*");
+  assertf(strjoker("a.b.example.co.uk/x", pattern + 1, NULL, NULL) != NULL);
+  assertf(strjoker("example.co.uk/x", pattern + 1, NULL, NULL) == NULL);
+  assertf(strjoker("notexample.co.uk/x", pattern + 1, NULL, NULL) == NULL);
+  assertf(strjoker("example.co.uk.evil.com/x", pattern + 1, NULL, NULL) ==
+          NULL);
+  EMITS_SLOT(1, SCOPE_IN + 1, "www.example.co.uk", "/x", HTS_FALSE,
+             "+example.co.uk/*");
+  assertf(strjoker("example.co.uk/x", pattern + 1, NULL, NULL) != NULL);
+  assertf(strjoker("notexample.co.uk/x", pattern + 1, NULL, NULL) == NULL);
+#undef SCOPE_IN
+#undef SCOPE_EX
+#undef EMITS_SLOT
 #undef EMITS
   printf("wizardfilter self-test OK\n");
+  return 0;
+}
+
+/* Prints the domain scopes offered for <question>; with no argument, asserts
+   the enumeration (#1117). */
+static int st_wizardscope(httrackp *opt, int argc, char **argv) {
+  char scope[HTS_URLMAXSIZE];
+  int k;
+
+  (void) opt;
+  if (argc >= 1) {
+    for (k = 0; hts_wizard_host_scope(argv[0], k, scope, sizeof(scope)); k++)
+      printf("%d %s\n", k, scope);
+    return 0;
+  }
+#define SCOPE(question, k, expect)                                             \
+  do {                                                                         \
+    assertf(hts_wizard_host_scope((question), (k), scope, sizeof(scope)));     \
+    assertf(strcmp(scope, (expect)) == 0);                                     \
+  } while (0)
+/* poisoned first: comparing against '\0' cannot see a clear that never ran */
+#define NOSCOPE_SIZED(question, k, size)                                       \
+  do {                                                                         \
+    memset(scope, 'X', sizeof(scope));                                         \
+    assertf(!hts_wizard_host_scope((question), (k), scope, (size)));           \
+    assertf(scope[0] == '\0');                                                 \
+  } while (0)
+#define NOSCOPE(question, k) NOSCOPE_SIZED((question), (k), sizeof(scope))
+
+  /* k widens by one label at a time, starting at the host itself */
+  SCOPE("download.example.co.uk/x", 0, "download.example.co.uk");
+  SCOPE("download.example.co.uk/x", 1, "example.co.uk");
+  SCOPE("download.example.co.uk/x", 2, "co.uk");
+  NOSCOPE("download.example.co.uk/x", 3); /* "uk" is a bare TLD */
+  SCOPE("example.com", 0, "example.com"); /* an adr with no fil works */
+  NOSCOPE("example.com", 1);
+  NOSCOPE("localhost/x", 0); /* nothing to widen into */
+  NOSCOPE("download.example.co.uk/x", -1);
+
+  /* protocol and credentials are stripped, the port kept */
+  SCOPE("ftp://user:pass@www.foo.com/x", 1, "foo.com");
+  SCOPE("www.foo.com:8080/x", 0, "www.foo.com:8080");
+  SCOPE("www.foo.com:8080/x", 1, "foo.com:8080");
+  NOSCOPE("www.foo.com:8080/x", 2);
+  /* a path that carries dots or a colon must not be read as host labels */
+  SCOPE("foo.com/a.b.c/d:e", 0, "foo.com");
+  NOSCOPE("foo.com/a.b.c/d:e", 1);
+
+  /* the shared predicate: a dotless run of digits is a hostname, not an IP */
+  assertf(hts_host_is_ipv4("1.2.3.4", 7));
+  assertf(!hts_host_is_ipv4("12345", 5));
+  assertf(!hts_host_is_ipv4("foo.com", 7));
+
+  /* an IP literal splits on dots without being a domain */
+  NOSCOPE("192.168.1.1/x", 0);
+  NOSCOPE("192.168.1.1:8080/x", 0);
+  NOSCOPE("[3ffe:b80:1234::1]/x", 0);
+  /* the dots inside this one reach the label walk unless brackets are refused
+   */
+  NOSCOPE("[::ffff:1.2.3.4]/x", 0);
+
+  /* the root label of a fully-qualified host is not a label */
+  SCOPE("www.foo.com./x", 0, "www.foo.com.");
+  SCOPE("www.foo.com./x", 1, "foo.com.");
+  NOSCOPE("www.foo.com./x", 2); /* "com." is still a bare TLD */
+  NOSCOPE(".", 0);
+
+  /* the destination must fit the scope and its terminator, and never truncate
+   */
+  {
+    const char *q = "www.example.com/x";
+    const size_t need = strlen("www.example.com");
+
+    memset(scope, 'X', sizeof(scope));
+    assertf(hts_wizard_host_scope(q, 0, scope, need + 1));
+    assertf(strcmp(scope, "www.example.com") == 0);
+    NOSCOPE_SIZED(q, 0, need);
+    NOSCOPE_SIZED(q, 0, 4);
+    NOSCOPE_SIZED(q, 0, 1);
+  }
+#undef SCOPE
+#undef NOSCOPE
+#undef NOSCOPE_SIZED
+  printf("wizardscope self-test OK\n");
+  return 0;
+}
+
+/* #1117: which host-scope range an answer falls in. */
+static int st_wizardscopeanswer(httrackp *opt, int argc, char **argv) {
+  (void) opt;
+  (void) argc;
+  (void) argv;
+#define ANSWER(n, expect) assertf(hts_wizard_scope_answer(n) == (expect))
+  /* the plain answers, and the boundary just below the first range */
+  ANSWER(-999, HTS_DEFAULT);
+  ANSWER(-1, HTS_DEFAULT);
+  ANSWER(0, HTS_DEFAULT);
+  ANSWER(7, HTS_DEFAULT);
+  ANSWER(50, HTS_DEFAULT);
+  ANSWER(HTS_WIZARD_SCOPE_INCLUDE - 1, HTS_DEFAULT);
+  /* include runs up to the exclude base, and exclude has no upper end */
+  ANSWER(HTS_WIZARD_SCOPE_INCLUDE, HTS_FALSE);
+  ANSWER(HTS_WIZARD_SCOPE_EXCLUDE - 1, HTS_FALSE);
+  ANSWER(HTS_WIZARD_SCOPE_EXCLUDE, HTS_TRUE);
+  ANSWER(INT_MAX, HTS_TRUE);
+#undef ANSWER
+  printf("wizardscopeanswer self-test OK\n");
   return 0;
 }
 
@@ -9687,8 +9840,12 @@ static const struct selftest_entry {
      st_hashkey_bounds},
     {"redirect-samefile", "", "same-file redirect detection self-test (#159)",
      st_redirect_samefile},
-    {"wizardfilter", "[<answer> <adr> <fil> [up]]",
+    {"wizardfilter", "[<answer> <adr> <fil> [up [slot]]]",
      "filter emitted by a wizard answer", st_wizardfilter},
+    {"wizardscope", "[<question>]",
+     "domain scopes the wizard can offer for a host", st_wizardscope},
+    {"wizardscopeanswer", "", "host-scope range of a wizard answer",
+     st_wizardscopeanswer},
     {"mime", "<filename>", "MIME type for a filename", st_mime},
     {"charset", "<charset> <hex:..|string>",
      "convert a string to UTF-8 from a charset", st_charset},

--- a/src/htswarc.c
+++ b/src/htswarc.c
@@ -557,19 +557,6 @@ static char *path_basename_dup(const char *path) {
   return strdupt(b);
 }
 
-/* A host made only of digits and dots is an IPv4 literal (never reversed). */
-static int surt_host_is_ip(const char *h, size_t n) {
-  size_t i;
-  int dots = 0;
-  for (i = 0; i < n; i++) {
-    if (h[i] == '.')
-      dots++;
-    else if (h[i] < '0' || h[i] > '9')
-      return 0;
-  }
-  return dots > 0;
-}
-
 /* SURT-canonicalize url into out (no newline): scheme and userinfo dropped,
    host lowercased with a leading www[digits] label stripped and the scheme
    default port removed, labels reversed and comma-joined then ')', path+query
@@ -637,7 +624,7 @@ static int surt_canon(const char *url, wbuf *out) {
   hostbuf[hlen] = '\0';
 
   if (!is_ipv6)
-    is_ip = surt_host_is_ip(hostbuf, hlen);
+    is_ip = hts_host_is_ipv4(hostbuf, hlen);
 
   if (!is_ipv6 && !is_ip && hlen >= 4 && hostbuf[0] == 'w' &&
       hostbuf[1] == 'w' && hostbuf[2] == 'w') {

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -181,7 +181,84 @@ static void wizard_cat_path(htsbuff *f, const char *sign, const char *adr,
   htsbuff_catn(f, fil, len);
 }
 
-void hts_wizard_answer_filter(htsbuff *f, int n, const char *adr,
+HTSEXT_API hts_boolean hts_wizard_host_scope(const char *question, int k,
+                                             char *dst, size_t dstsize) {
+  const char *host, *port, *slash, *end, *scope;
+  size_t len;
+
+  if (dst == NULL || dstsize == 0)
+    return HTS_FALSE;
+  dst[0] = '\0';
+  if (question == NULL || k < 0)
+    return HTS_FALSE;
+
+  host = jump_identification_const(question);
+  port = jump_toport_const(question);
+  slash = strchr(host, '/');
+  end = host + strlen(host);
+  scope = host;
+  if (slash != NULL && slash < end)
+    end = slash;
+  /* the port belongs to the filter, so keep it and only bound the label walk */
+  if (port != NULL && port < end)
+    slash = port;
+  else
+    slash = end;
+  /* a fully-qualified "foo.com." ends on the root label, which is not one */
+  if (slash > host && slash[-1] == '.')
+    slash--;
+  if (slash == host || *host == '[') /* no host, or an IPv6 literal */
+    return HTS_FALSE;
+  if (hts_host_is_ipv4(host, (size_t) (slash - host)))
+    return HTS_FALSE;
+
+  /* widen by dropping one leading label per step, and never offer a bare TLD */
+  for (; k > 0; k--) {
+    const char *dot = memchr(scope, '.', (size_t) (slash - scope));
+
+    if (dot == NULL)
+      return HTS_FALSE;
+    scope = dot + 1;
+  }
+  if (memchr(scope, '.', (size_t) (slash - scope)) == NULL)
+    return HTS_FALSE;
+
+  len = (size_t) (end - scope);
+  if (len >= dstsize)
+    return HTS_FALSE;
+  memcpy(dst, scope, len);
+  dst[len] = '\0';
+  return HTS_TRUE;
+}
+
+hts_tristate hts_wizard_scope_answer(int n) {
+  if (n >= HTS_WIZARD_SCOPE_EXCLUDE)
+    return HTS_TRUE;
+  if (n >= HTS_WIZARD_SCOPE_INCLUDE)
+    return HTS_FALSE;
+  return HTS_DEFAULT;
+}
+
+/* The subdomain form of the scope in slot 0, its apex in slot 1: the starred
+   one does not match the apex, so a whole-domain answer needs both. */
+static void wizard_cat_scope(htsbuff *f, const char *sign, const char *adr,
+                             int n, int slot) {
+  char scope[HTS_URLMAXSIZE];
+  const int k =
+      n - (hts_wizard_scope_answer(n) == HTS_TRUE ? HTS_WIZARD_SCOPE_EXCLUDE
+                                                  : HTS_WIZARD_SCOPE_INCLUDE);
+
+  if (slot >= HTS_WIZARD_MAX_FILTERS ||
+      !hts_wizard_host_scope(adr, k, scope, sizeof(scope)))
+    return;
+  htsbuff_cpy(f, sign);
+  if (slot == 0)
+    htsbuff_cat(f, "*.");
+  htsbuff_cat(f, scope);
+  htsbuff_cat(f, "/*");
+}
+
+void hts_wizard_answer_filter(htsbuff *f, int slot, int n, const char *adr,
                               const char *fil, hts_boolean seeker_up) {
   size_t dir = hts_lastcharoffset(fil);
 
@@ -189,6 +266,13 @@ void hts_wizard_answer_filter(htsbuff *f, int n, const char *adr,
     dir--;
 
   htsbuff_cpy(f, "");
+  if (hts_wizard_scope_answer(n) != HTS_DEFAULT) {
+    wizard_cat_scope(f, hts_wizard_scope_answer(n) == HTS_TRUE ? "-" : "+", adr,
+                     n, slot);
+    return;
+  }
+  if (slot != 0) /* every other answer emits a single filter */
+    return;
   switch (n) {
   case 0: /* this link only */
     wizard_cat_path(f, "-", adr, fil, (size_t) -1);
@@ -765,8 +849,9 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
           n = force_mirror;
       }
 
-      /* sanity check - reallocate filters HERE */
-      if ((*_FILTERS_PTR) + 1 >= opt->maxfilter) {
+      /* sanity check - reallocate filters HERE (a host-scope answer emits two)
+       */
+      if ((*_FILTERS_PTR) + 2 >= opt->maxfilter) {
         opt->maxfilter += HTS_FILTERSINC;
         if (filters_init(&_FILTERS, opt->maxfilter, HTS_FILTERSINC) == 0) {
           printf("PANIC! : Too many filters : >%d [%d]\n", (*_FILTERS_PTR),
@@ -827,17 +912,34 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
 
       case 50: // nothing to do
         break;
+
+      case -999: // the "!" answer, and anything the front end could not parse
+        break;
+
+      default:
+        /* a scope answer forbids like 2 or allows like 6 */
+        if (hts_wizard_scope_answer(n) == HTS_TRUE)
+          forbidden_url = 1;
+        else if (hts_wizard_scope_answer(n) == HTS_DEFAULT)
+          hts_log_print(opt, LOG_WARNING,
+                        "(wizard) unknown answer %d at %s%s, keeping the "
+                        "computed verdict",
+                        n, adr, fil);
+        break;
       } // switch
 
       /* the pattern half of the answer: a new answer needs both switches */
       {
         char BIGSTK pattern[HTS_FILTER_SLOT_SIZE];
         htsbuff f = htsbuff_array(pattern);
+        int slot;
 
-        hts_wizard_answer_filter(
-            &f, n, adr, fil,
-            (opt->seeker & HTS_SEEKER_UP) != 0 ? HTS_TRUE : HTS_FALSE);
-        if (f.len != 0) {
+        for (slot = 0; slot < HTS_WIZARD_MAX_FILTERS; slot++) {
+          hts_wizard_answer_filter(
+              &f, slot, n, adr, fil,
+              (opt->seeker & HTS_SEEKER_UP) != 0 ? HTS_TRUE : HTS_FALSE);
+          if (f.len == 0)
+            break;
           HT_INSERT_FILTERS0; // insert at slot 0
           strlcpybuff(_FILTERS[0], pattern, HTS_FILTER_SLOT_SIZE);
         }

--- a/src/htswizard.h
+++ b/src/htswizard.h
@@ -57,11 +57,20 @@ hts_boolean hts_robots_forbids(httrackp *opt, const char *adr, const char *fil,
                                hts_boolean filters_decided,
                                hts_boolean filters_refused);
 
-/* Builds into `f` the filter answer `n` adds for the link (adr,fil), and leaves
-   `f` empty when the answer adds none. `seeker_up` is the HTS_SEEKER_UP bit of
-   opt->seeker, read by answer 5. */
-void hts_wizard_answer_filter(htsbuff *f, int n, const char *adr,
+/* Most filters one wizard answer can add. Slots must stay contiguous: the
+   caller stops at the first empty one. */
+#define HTS_WIZARD_MAX_FILTERS 2
+
+/* Builds into `f` the `slot`-th filter answer `n` adds for the link (adr,fil),
+   and leaves `f` empty past the last one. Only the host-scope answers emit a
+   second, because their starred form misses the apex. `seeker_up` is the
+   HTS_SEEKER_UP bit of opt->seeker, read by answer 5. */
+void hts_wizard_answer_filter(htsbuff *f, int slot, int n, const char *adr,
                               const char *fil, hts_boolean seeker_up);
+
+/* Which host-scope range answer `n` falls in: HTS_TRUE excludes the scope,
+   HTS_FALSE includes it, HTS_DEFAULT for any answer outside both ranges. */
+hts_tristate hts_wizard_scope_answer(int n);
 
 /* A (tag, attribute) pair naming a reference kind. */
 #ifndef HTS_DEF_DEFSTRUCT_htspair_t

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -452,6 +452,23 @@ HTSEXT_API char *jump_identification(char *);
 
 HTSEXT_API const char *jump_identification_const(const char *);
 
+/** Write into dst the k-th domain scope the wizard can offer for the string
+    query3 was handed (an "adr" or an "adr[/fil]"). Scopes widen as k grows: for
+    download.example.co.uk/x, "download.example.co.uk", then "example.co.uk",
+    then "co.uk". A front end enumerates its menu by looping until this returns
+    HTS_FALSE, and answers HTS_WIZARD_SCOPE_INCLUDE+k or
+    HTS_WIZARD_SCOPE_EXCLUDE+k.
+
+    A bare TLD is never offered, and an IP literal has no scopes, so an empty
+    menu is normal. Protocol and credentials are stripped and the port is kept,
+    so a caller must not split the host itself.
+
+    dst is emptied on every failure, and HTS_URLMAXSIZE bytes always suffice. A
+    shorter dst also returns HTS_FALSE, which the loop cannot tell from the end
+    of the list. */
+HTSEXT_API hts_boolean hts_wizard_host_scope(const char *question, int k,
+                                             char *dst, size_t dstsize);
+
 /** Like jump_identification() and also strip a leading "www." host prefix,
     returning a pointer into the input to the normalized host. */
 HTSEXT_API char *jump_normalized(char *);

--- a/src/httrack.c
+++ b/src/httrack.c
@@ -712,6 +712,20 @@ static const char *__cdecl htsshow_query3(t_hts_callbackarg * carg,
          "5 Mirror this link (useful)\n"
          "6 Mirror all links located on the same domain as this link\n" "\n",
          question);
+  /* the domain scopes are host-dependent, so the engine enumerates them */
+  {
+    char scope[HTS_URLMAXSIZE];
+    int k;
+
+    for (k = 0; hts_wizard_host_scope(question, k, scope, sizeof(scope)); k++)
+      printf("%d Mirror %s and every host below it\n",
+             HTS_WIZARD_SCOPE_INCLUDE + k, scope);
+    for (k = 0; hts_wizard_host_scope(question, k, scope, sizeof(scope)); k++)
+      printf("%d Ignore %s and every host below it\n",
+             HTS_WIZARD_SCOPE_EXCLUDE + k, scope);
+    if (k != 0)
+      printf("\n");
+  }
   do {
     printf(">> ");
     io_flush;

--- a/tests/292_engine-wizard-scope.test
+++ b/tests/292_engine-wizard-scope.test
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+# #1117: the self-test asserts the scopes and the patterns; this feeds the pair
+# a scope answer emits back through the matcher that authorizes a link.
+
+# the front end enumerates by looping until the engine stops answering
+want="0 download.example.co.uk
+1 example.co.uk
+2 co.uk"
+assert_selftest "$want" wizardscope download.example.co.uk/x
+
+# widening stops before a bare TLD, and an IP literal offers nothing at all
+assert_selftest "0 example.com" wizardscope example.com/x
+assert_selftest "" wizardscope 192.168.1.1/x
+
+# answer 1000+1 is "example.co.uk and every host below it": two filters, since
+# the starred one misses the apex
+sub=$(httrack -O /dev/null -#test=wizardfilter 1001 www.example.co.uk /x)
+apex=$(httrack -O /dev/null -#test=wizardfilter 1001 www.example.co.uk /x 0 1)
+test "$sub" = "+*.example.co.uk/*" || fail "subdomain filter: got [$sub]"
+test "$apex" = "+example.co.uk/*" || fail "apex filter: got [$apex]"
+
+for host in www.example.co.uk a.b.example.co.uk; do
+    assert_selftest "$host/x does match ${sub#+}" filter "${sub#+}" "$host/x"
+done
+assert_selftest "example.co.uk/x does NOT match ${sub#+}" filter "${sub#+}" example.co.uk/x
+assert_selftest "example.co.uk/x does match ${apex#+}" filter "${apex#+}" example.co.uk/x
+
+# neither half may leak past the domain boundary
+for bad in notexample.co.uk/x example.co.uk.evil.com/x; do
+    assert_selftest "$bad does NOT match ${sub#+}" filter "${sub#+}" "$bad"
+    assert_selftest "$bad does NOT match ${apex#+}" filter "${apex#+}" "$bad"
+done
+
+# the exclude range emits the same pair negated
+assert_selftest "-*.example.co.uk/*" wizardfilter 2001 www.example.co.uk /x
+
+assert_selftest "wizardscope self-test OK" wizardscope
+assert_selftest "wizardfilter self-test OK" wizardfilter

--- a/tests/292_engine-wizard-scope.test
+++ b/tests/292_engine-wizard-scope.test
@@ -9,11 +9,16 @@ set -euo pipefail
 # #1117: the self-test asserts the scopes and the patterns; this feeds the pair
 # a scope answer emits back through the matcher that authorizes a link.
 
-# the front end enumerates by looping until the engine stops answering
+# The front end enumerates by looping until the engine stops answering. Strip
+# the CRs: MSYS hands the engine a text-mode stdout and $(...) eats only the
+# trailing newline, so an assertion spanning several lines keeps the interior
+# ones. Every other assert_selftest here compares a single line and cannot see
+# this.
 want="0 download.example.co.uk
 1 example.co.uk
 2 co.uk"
-assert_selftest "$want" wizardscope download.example.co.uk/x
+got=$(httrack -O /dev/null -#test=wizardscope download.example.co.uk/x | tr -d '\r')
+test "$got" = "$want" || fail "wizardscope enumeration: got [$got]"
 
 # widening stops before a bare TLD, and an IP literal offers nothing at all
 assert_selftest "0 example.com" wizardscope example.com/x


### PR DESCRIPTION
The interactive wizard could only answer about the exact host it asked about, so mirroring www.example.com stopped again at download.example.com, and *Skip All* stayed unusable while any unknown subdomain might still turn up. Reported against the GUI as xroche/httrack-windows#96.

The engine now enumerates the domain scopes for a host and takes two new answer ranges over them. `hts_wizard_host_scope()` does the splitting so a front end never has to: it derives the scopes from the same question string it was handed, which may carry a protocol, credentials and a port, and which a naive split breaks on at `com:8080`. Answers `HTS_WIZARD_SCOPE_INCLUDE+k` and `HTS_WIZARD_SCOPE_EXCLUDE+k` then take or drop the k-th scope. An index is only safe instead of a finished pattern because of that helper: the menu label and the applied filter come out of the same code and cannot drift.

Each answer emits two filters, since `+*.example.co.uk/*` misses the apex, which also meant widening the filter-array reservation before the answer switch. It made room for exactly one insert while `HT_INSERT_FILTERS0` asserts on overflow, so the second insert would have aborted on the boundary at `filptr == maxfilter - 2`. `hts_wizard_scope_answer()` carries the range decision for both the filter and the verdict halves, so the two cannot disagree, and the verdict switch now names -999 (the `!` answer, and anything the front end could not parse) rather than letting it reach the unknown-answer log.

No public suffix list is involved: every suffix down to a two-label domain is offered and the user picks the boundary. A bare TLD is never offered, an IP literal has no scopes, and a fully-qualified `www.foo.com.` stops at `foo.com.` instead of offering the root label as `com.`. The IPv4 test is `hts_host_is_ipv4()`, lifted out of htswarc.c where it was a static copy.

Only the CLI and WinHTTrack need the new menu entries. WebHTTrack answers `""` to every question and Android registers no `query3` at all, which is #1237.

Tested through `-#test=wizardscope`, `-#test=wizardscopeanswer`, `-#test=wizardfilter` and `tests/292`, which feeds both emitted filters back through the matcher. Twelve mutants each turn a test red, including the exact-fit `dstsize`, the bracket guard an IPv4-mapped IPv6 literal needs, and the root-label trim. `NOSCOPE` poisons the buffer before the call, since comparing a destination against `'\0'` cannot see a clear that never ran. A differential against the pre-diff engine over 2420 answer/host/path combinations shows no change to any existing answer, with a positive control confirming the harness can see one.

Not covered by a test: the widened reservation and the verdict switch itself. `hts_acceptlink_()` is static and reachable only through the interactive `query3` callback, so the verdict half would have to be extracted the way the filter half already was before any `-#test` could reach it.

Closes #1117