### PR TITLE
The default footer still uses the legacy %s form

### DIFF
--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -221,9 +221,11 @@ Please visit our Website: http://www.httrack.com
 
 /* Copyright (C) 1998 Xavier Roche and other contributors */
 #define HTTRACK_AFF_AUTHORS "[XR&CO'2014]"
+/* Named fields (hts_footer_format); a "%s" anywhere would switch the template
+   back to the legacy positional model, a user's own additions included. */
 #define HTS_DEFAULT_FOOTER                                                     \
-  "<!-- Mirrored from %s%s by HTTrack Website Copier/" HTTRACK_AFF_VERSION     \
-  " " HTTRACK_AFF_AUTHORS ", %s -->"
+  "<!-- Mirrored from {url} by HTTrack Website Copier/" HTTRACK_AFF_VERSION    \
+  " " HTTRACK_AFF_AUTHORS ", {date} -->"
 /* Honest crawler User-Agent; no fake OS/browser to go stale. */
 #define HTS_DEFAULT_USER_AGENT                                                 \
   "Mozilla/5.0 (compatible; HTTrack/" HTTRACK_AFF_VERSION                      \

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -730,8 +730,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
     };
     initStrElt initStr[] = {
         {"user", HTS_DEFAULT_USER_AGENT},
-        {"footer", "<!-- Mirrored from %s%s by HTTrack Website Copier/3.x "
-                   "[XR&CO'2014], %s -->"},
+        {"footer", HTS_DEFAULT_FOOTER},
         {"url2",
          "+*.png +*.gif +*.jpg +*.jpeg +*.css +*.js -ad.doubleclick.net/*"},
         {NULL, NULL}};

--- a/tests/290_local-footer-default.test
+++ b/tests/290_local-footer-default.test
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# The default footer carries named fields, so a mirrored page must show the
+# crawled URL and date, not a literal "{url}" (what the legacy positional model
+# emits for a template it does not understand).
+
+set -euo pipefail
+
+: "${top_srcdir:=..}"
+
+bash "$top_srcdir/tests/local-crawl.sh" \
+    --files 5 --errors 0 \
+    --file-matches 'simple/basic.html' \
+    "<!-- Mirrored from http://127\.0\.0\.1:[0-9]+/simple/basic\.html by HTTrack Website Copier/[^ ]+ \[XR&CO'[0-9]{4}\], [A-Z][a-z]{2}, [0-9]{2} [A-Z][a-z]{2} [0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2} GMT -->" \
+    --file-not-matches 'simple/basic.html' '\{(url|date)\}' \
+    httrack 'BASEURL/simple/basic.html'

--- a/tests/291_webhttrack-footer-default.test
+++ b/tests/291_webhttrack-footer-default.test
@@ -1,8 +1,7 @@
 #!/bin/bash
 #
 # WebHTTrack prefills the engine's default footer, and a new project must get
-# the named fields: a "%s" anywhere would put the whole template, a user's own
-# additions included, back on the legacy positional model.
+# the named fields (see HTS_DEFAULT_FOOTER on why a stray "%s" is fatal).
 
 set -euo pipefail
 

--- a/tests/291_webhttrack-footer-default.test
+++ b/tests/291_webhttrack-footer-default.test
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# WebHTTrack prefills the engine's default footer, and a new project must get
+# the named fields: a "%s" anywhere would put the whole template, a user's own
+# additions included, back on the legacy positional model.
+
+set -euo pipefail
+
+# shellcheck source=tests/webhttracklib.sh
+. "$(dirname "$0")/webhttracklib.sh"
+
+htsserver_require
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_footer.XXXXXX") || fail "no tmpdir"
+cleanup() {
+    htsserver_cleanup
+    rm -rf "${work}"
+}
+cleanup_push cleanup
+
+printf '[a fresh profile prefills the named-field footer] ..\t'
+
+# An isolated HOME: a stored ~/.httrack.ini would answer with its own footer.
+mkdir -p "${work}/websites"
+htsserver_start --home "${work}"
+reply=$(htsserver_get /server/option6.html)
+grep -q '^HTTP/1.[01] 200' <<<"${reply}" || fail "option6.html: ${reply}"
+
+value=$(firstline "$(sed -n 's/.*name="footer" value="\([^"]*\)".*/\1/p' <<<"${reply}")")
+test -n "${value}" || fail "option6.html serves no footer field: ${reply}"
+case ${value} in
+*'%s'*) fail "the prefilled footer is still positional: ${value}" ;;
+esac
+grep -q '{url}.*{date}' <<<"${value}" || fail "prefilled footer: ${value}"
+
+htsserver_stop
+# A leaked server wedges the parallel harness behind a green log.
+htsserver_assert_reaped
+
+echo OK


### PR DESCRIPTION
`-%F` has taken named fields since #667, but the default template kept the old positional `%s` form, both in the engine and in WebHTTrack's own copy of the string. That form is contagious: one `%s` anywhere puts the whole template on the legacy path, so anyone who appended `{mime}` to the default got the braces back verbatim in every saved page.

The default is now `<!-- Mirrored from {url} by HTTrack Website Copier/3.x [XR&CO'2014], {date} -->`. Mirrored pages change in one visible way, the scheme: `Mirrored from example.com/p.html` reads `Mirrored from https://example.com/p.html`. WebHTTrack uses the engine macro instead of its duplicate, and projects that already saved a footer keep it.

Tests 290 and 291 check what a crawl writes into a page and what WebHTTrack prefills; both fail against the old default. WinHTTrack and the Android front end keep their own defaults and need the same change in their own repos.