### PR TITLE
A -%F footer that exactly fills the page buffer aborts the crawl

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -874,11 +874,12 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
 
                     tempo[0] = '\0';
                     strcatbuff(tempo, eol);
-                    // hts_footer_format returns <0 on overflow, leaving tempo
-                    // unterminated; emitting it would abort in strcatbuff
-                    // below.
+                    // Overflow (<0) leaves tempo unterminated, and the closing
+                    // eol is reserved below because strcatbuff aborts rather
+                    // than clips: either one would kill the crawl.
                     if (hts_footer_format(tempo + strlen(tempo),
-                                          sizeof(tempo) - strlen(tempo),
+                                          sizeof(tempo) - strlen(tempo) -
+                                              strlen(eol),
                                           StringBuff(opt->footer), fields,
                                           sizeof(fields) / sizeof(fields[0])) >=
                         0) {

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -877,12 +877,11 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                     // Overflow (<0) leaves tempo unterminated, and the closing
                     // eol is reserved below because strcatbuff aborts rather
                     // than clips: either one would kill the crawl.
-                    if (hts_footer_format(tempo + strlen(tempo),
-                                          sizeof(tempo) - strlen(tempo) -
-                                              strlen(eol),
-                                          StringBuff(opt->footer), fields,
-                                          sizeof(fields) / sizeof(fields[0])) >=
-                        0) {
+                    if (hts_footer_format(
+                            tempo + strlen(tempo),
+                            sizeof(tempo) - strlen(tempo) - strlen(eol),
+                            StringBuff(opt->footer), fields,
+                            sizeof(fields) / sizeof(fields[0])) >= 0) {
                       strcatbuff(tempo, eol);
                       HT_ADD(tempo);
                     }

--- a/tests/01_engine-footer-boundary.test
+++ b/tests/01_engine-footer-boundary.test
@@ -22,13 +22,17 @@ mir="$dir/mir"
 page=
 body=
 
-make_page() { # make_page SEGLEN, leaving the page at $page
+make_page() { # make_page SEGLEN, leaving an LF page at $page
     local seg
     seg=$(printf 'a%.0s' $(seq 1 "$1"))
     mkdir -p "$dir/$seg"
     page="$dir/$seg/index.html"
-    printf '<html><body>hi</body></html>' >"$page"
+    write_page '<html><body>hi</body></html>'
 }
+
+# The emitter follows the page's own line ending, so the CR here is what picks
+# "\r\n" and moves the boundary two bytes.
+write_page() { printf '%s' "$1" >"$page"; }
 
 crawl() { # crawl FOOTER, leaving the mirrored page in $body
     rm -rf "$mir"
@@ -36,51 +40,63 @@ crawl() { # crawl FOOTER, leaving the mirrored page in $body
         fail "crawl died (exit $?) on a ${#1}-char footer"
     # Under file/, not $mir: the makeindex top index carries no -%F footer.
     local found
-    found=$(find "$mir/file" -name index.html)
+    found=$(find "$mir/file" -name index.html 2>/dev/null || true)
     test -n "$found" || fail "page not mirrored; the footer path never ran"
     body=$(cat "$found")
 }
 
-expansion() { # expansion FOOTER -> the length it expands to
-    crawl "$1"
+# Which line the footer lands on follows the page's own newlines, so find it by
+# its marker rather than by position.
+footer_line() { firstline "$(tr -d '\r' <<<"$body" | grep -F "$mark" || true)"; }
+
+path_expansion() { # the length {path} expands to
     local line
-    line=$(sed -n 2p <<<"$body")
-    printf '%s\n' "${#line}"
+    crawl "${mark}{path}"
+    line=$(footer_line)
+    test -n "$line" || fail "no footer emitted while measuring {path}"
+    printf '%s\n' "$((${#line} - ${#mark}))"
 }
 
 # -%F caps at 253 chars, so reaching a ~3 KB expansion takes repeats of the
 # longest field a file:// crawl offers. Size the directory to make {path}
 # exactly pathlen, rather than inherit whatever length mktemp handed out.
 make_page 8
-fixed=$(($(expansion '{path}') - 8))
+fixed=$(($(path_expansion) - 8))
 test "$fixed" -lt "$pathlen" ||
     skip "temp path is ${fixed} chars, leaving no room for a ${pathlen}-char one"
 make_page $((pathlen - fixed))
-got=$(expansion '{path}')
+got=$(path_expansion)
 test "$got" -eq "$pathlen" || fail "{path} is ${got} chars, wanted ${pathlen}"
 
-# Walk the total expansion across the point where the footer starts being
-# dropped: the abort sat on a single length, so a coarser sweep steps over it.
-# The window holds that point for a "\n" page and for a "\r\n" one.
 reps=$(((bufsize - 72) / pathlen))
-seen_footer=0
-seen_dropped=0
-for total in $(seq $((bufsize - 6)) "$bufsize"); do
-    pad=$((total - reps * pathlen))
-    test "$pad" -ge ${#mark} || fail "padding is down to ${pad} chars"
-    footer="${mark}$(printf 'A%.0s' $(seq 1 $((pad - ${#mark}))))"
-    footer="${footer}$(printf '{path}%.0s' $(seq 1 "$reps"))"
-    test ${#footer} -lt 254 || fail "footer template is ${#footer} chars"
-    crawl "$footer"
-    if grep -q "$mark" <<<"$body"; then
-        seen_footer=$((seen_footer + 1))
-    else
-        seen_dropped=$((seen_dropped + 1))
-    fi
-done
 
-# Both outcomes prove the window straddles the drop point, where the abort was.
-test "$seen_footer" -gt 0 ||
-    fail "no length in the sweep emitted a footer at all"
-test "$seen_dropped" -gt 0 ||
-    fail "no length in the sweep was dropped; the window missed the boundary"
+sweep() { # sweep LABEL: walk the expansion across the point where footers drop
+    local total pad footer line emitted=0 dropped=0
+    for total in $(seq $((bufsize - 6)) "$bufsize"); do
+        pad=$((total - reps * pathlen))
+        test "$pad" -gt ${#mark} || fail "padding is down to ${pad} chars"
+        footer="${mark}$(printf 'A%.0s' $(seq 1 $((pad - ${#mark}))))"
+        footer="${footer}$(printf '{path}%.0s' $(seq 1 "$reps"))"
+        test ${#footer} -lt 254 || fail "footer template is ${#footer} chars"
+        crawl "$footer"
+        if grep -q "$mark" <<<"$body"; then
+            line=$(footer_line)
+            # Whole or not at all: a clipped footer runs into the page below it.
+            test "${#line}" -eq "$total" ||
+                fail "$1: ${total}-char footer emitted as ${#line} chars"
+            emitted=$((emitted + 1))
+        else
+            dropped=$((dropped + 1))
+        fi
+    done
+    # Both outcomes prove the window straddles the drop point, where the abort
+    # was. All-emitted or all-dropped means the window missed it.
+    test "$emitted" -gt 0 || fail "$1: no length in the sweep emitted a footer"
+    test "$dropped" -gt 0 || fail "$1: no length in the sweep was dropped"
+}
+
+sweep LF
+# CRLF costs two bytes at each end, so the boundary sits two lengths lower: a
+# fix reserving one byte rather than strlen(eol) still aborts here.
+write_page $'<html>\r\n<body>hi</body></html>'
+sweep CRLF

--- a/tests/01_engine-footer-boundary.test
+++ b/tests/01_engine-footer-boundary.test
@@ -8,47 +8,66 @@ set -eu
 # shellcheck source=tests/testlib.sh
 . "$(dirname "$0")/testlib.sh"
 
-dir=$(mktemp -d)
-cleanup_push rm -rf "$dir"
-
-# The emitter's buffer, 1024 + 2 * HTS_URLMAXSIZE. Only the sweep window is
-# derived from it; a wrong value makes the crossing check below fail loudly.
+# The emitter's buffer, 1024 + 2 * HTS_URLMAXSIZE. The sweep window is derived
+# from it; a wrong value makes the crossing check below fail loudly.
 bufsize=3072
+# A {path} of this length divides the buffer with room left for the literal
+# padding that tunes the last few bytes, and keeps the mirror under MAX_PATH.
+pathlen=100
 mark=ZFOOTERZ
 
-seg=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-deep="$dir/$seg/$seg"
-mkdir -p "$deep"
-page="$deep/index.html"
-printf '<html><body>hi</body></html>' >"$page"
-
+dir=$(mktemp -d)
+cleanup_push rm -rf "$dir"
 mir="$dir/mir"
+page=
 body=
+
+make_page() { # make_page SEGLEN, leaving the page at $page
+    local seg
+    seg=$(printf 'a%.0s' $(seq 1 "$1"))
+    mkdir -p "$dir/$seg"
+    page="$dir/$seg/index.html"
+    printf '<html><body>hi</body></html>' >"$page"
+}
+
 crawl() { # crawl FOOTER, leaving the mirrored page in $body
     rm -rf "$mir"
     httrack "file://$page" -O "$mir" -%F "$1" -q -s0 -%v0 >/dev/null 2>&1 ||
         fail "crawl died (exit $?) on a ${#1}-char footer"
     # Under file/, not $mir: the makeindex top index carries no -%F footer.
+    local found
     found=$(find "$mir/file" -name index.html)
     test -n "$found" || fail "page not mirrored; the footer path never ran"
     body=$(cat "$found")
 }
 
-# {path} is the longest field a file:// crawl can hand the footer, and the
-# -%F argument caps at 253 chars, so the sweep needs few, long repeats.
-crawl '{path}'
-line=$(sed -n 2p <<<"$body")
-plen=${#line}
-test "$plen" -gt 100 || fail "{path} expands to only ${plen} chars"
+expansion() { # expansion FOOTER -> the length it expands to
+    crawl "$1"
+    local line
+    line=$(sed -n 2p <<<"$body")
+    printf '%s\n' "${#line}"
+}
 
-# Walk the total expansion from below the drop point to past it, one byte at a
-# time: the abort sat on a single length, so a coarser sweep steps over it.
-reps=$(((bufsize - 16) / plen))
+# -%F caps at 253 chars, so reaching a ~3 KB expansion takes repeats of the
+# longest field a file:// crawl offers. Size the directory to make {path}
+# exactly pathlen, rather than inherit whatever length mktemp handed out.
+make_page 8
+fixed=$(($(expansion '{path}') - 8))
+test "$fixed" -lt "$pathlen" ||
+    skip "temp path is ${fixed} chars, leaving no room for a ${pathlen}-char one"
+make_page $((pathlen - fixed))
+got=$(expansion '{path}')
+test "$got" -eq "$pathlen" || fail "{path} is ${got} chars, wanted ${pathlen}"
+
+# Walk the total expansion across the point where the footer starts being
+# dropped: the abort sat on a single length, so a coarser sweep steps over it.
+# The window holds that point for a "\n" page and for a "\r\n" one.
+reps=$(((bufsize - 72) / pathlen))
 seen_footer=0
 seen_dropped=0
-for total in $(seq $((bufsize - 16)) $((bufsize + 8))); do
-    pad=$((total - reps * plen))
-    test "$pad" -ge ${#mark} || fail "sweep needs ${pad} chars of padding"
+for total in $(seq $((bufsize - 6)) "$bufsize"); do
+    pad=$((total - reps * pathlen))
+    test "$pad" -ge ${#mark} || fail "padding is down to ${pad} chars"
     footer="${mark}$(printf 'A%.0s' $(seq 1 $((pad - ${#mark}))))"
     footer="${footer}$(printf '{path}%.0s' $(seq 1 "$reps"))"
     test ${#footer} -lt 254 || fail "footer template is ${#footer} chars"

--- a/tests/01_engine-footer-boundary.test
+++ b/tests/01_engine-footer-boundary.test
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# A -%F footer whose expansion exactly filled the on-page buffer aborted the
+# crawl (SIGABRT): the emitter appends its closing newline with strcatbuff,
+# which aborts rather than clips. #670 covered the overflow, not the exact fit.
+
+set -eu
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+dir=$(mktemp -d)
+cleanup_push rm -rf "$dir"
+
+# The emitter's buffer, 1024 + 2 * HTS_URLMAXSIZE. Only the sweep window is
+# derived from it; a wrong value makes the crossing check below fail loudly.
+bufsize=3072
+mark=ZFOOTERZ
+
+seg=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+deep="$dir/$seg/$seg"
+mkdir -p "$deep"
+page="$deep/index.html"
+printf '<html><body>hi</body></html>' >"$page"
+
+mir="$dir/mir"
+body=
+crawl() { # crawl FOOTER, leaving the mirrored page in $body
+    rm -rf "$mir"
+    httrack "file://$page" -O "$mir" -%F "$1" -q -s0 -%v0 >/dev/null 2>&1 ||
+        fail "crawl died (exit $?) on a ${#1}-char footer"
+    # Under file/, not $mir: the makeindex top index carries no -%F footer.
+    found=$(find "$mir/file" -name index.html)
+    test -n "$found" || fail "page not mirrored; the footer path never ran"
+    body=$(cat "$found")
+}
+
+# {path} is the longest field a file:// crawl can hand the footer, and the
+# -%F argument caps at 253 chars, so the sweep needs few, long repeats.
+crawl '{path}'
+line=$(sed -n 2p <<<"$body")
+plen=${#line}
+test "$plen" -gt 100 || fail "{path} expands to only ${plen} chars"
+
+# Walk the total expansion from below the drop point to past it, one byte at a
+# time: the abort sat on a single length, so a coarser sweep steps over it.
+reps=$(((bufsize - 16) / plen))
+seen_footer=0
+seen_dropped=0
+for total in $(seq $((bufsize - 16)) $((bufsize + 8))); do
+    pad=$((total - reps * plen))
+    test "$pad" -ge ${#mark} || fail "sweep needs ${pad} chars of padding"
+    footer="${mark}$(printf 'A%.0s' $(seq 1 $((pad - ${#mark}))))"
+    footer="${footer}$(printf '{path}%.0s' $(seq 1 "$reps"))"
+    test ${#footer} -lt 254 || fail "footer template is ${#footer} chars"
+    crawl "$footer"
+    if grep -q "$mark" <<<"$body"; then
+        seen_footer=$((seen_footer + 1))
+    else
+        seen_dropped=$((seen_dropped + 1))
+    fi
+done
+
+# Both outcomes prove the window straddles the drop point, where the abort was.
+test "$seen_footer" -gt 0 ||
+    fail "no length in the sweep emitted a footer at all"
+test "$seen_dropped" -gt 0 ||
+    fail "no length in the sweep was dropped; the window missed the boundary"

--- a/tests/01_engine-footer-boundary.test
+++ b/tests/01_engine-footer-boundary.test
@@ -13,7 +13,7 @@ set -eu
 bufsize=3072
 # A {path} of this length divides the buffer with room left for the literal
 # padding that tunes the last few bytes, and keeps the mirror under MAX_PATH.
-pathlen=100
+pathlen=120
 mark=ZFOOTERZ
 
 dir=$(mktemp -d)
@@ -34,10 +34,10 @@ make_page() { # make_page SEGLEN, leaving an LF page at $page
 # "\r\n" and moves the boundary two bytes.
 write_page() { printf '%s' "$1" >"$page"; }
 
-crawl() { # crawl FOOTER, leaving the mirrored page in $body
+crawl() { # crawl FOOTER [LABEL], leaving the mirrored page in $body
     rm -rf "$mir"
     httrack "file://$page" -O "$mir" -%F "$1" -q -s0 -%v0 >/dev/null 2>&1 ||
-        fail "crawl died (exit $?) on a ${#1}-char footer"
+        fail "crawl died (exit $?) on ${2:-a ${#1}-char footer}"
     # Under file/, not $mir: the makeindex top index carries no -%F footer.
     local found
     found=$(find "$mir/file" -name index.html 2>/dev/null || true)
@@ -62,8 +62,10 @@ path_expansion() { # the length {path} expands to
 # exactly pathlen, rather than inherit whatever length mktemp handed out.
 make_page 8
 fixed=$(($(path_expansion) - 8))
+# Loudly, not a skip: the Windows leg compares the skip set exactly, so a skip
+# reds it there anyway and quietly drops the coverage everywhere else.
 test "$fixed" -lt "$pathlen" ||
-    skip "temp path is ${fixed} chars, leaving no room for a ${pathlen}-char one"
+    fail "temp path is ${fixed} chars, leaving no room for a ${pathlen}-char one"
 make_page $((pathlen - fixed))
 got=$(path_expansion)
 test "$got" -eq "$pathlen" || fail "{path} is ${got} chars, wanted ${pathlen}"
@@ -78,7 +80,7 @@ sweep() { # sweep LABEL: walk the expansion across the point where footers drop
         footer="${mark}$(printf 'A%.0s' $(seq 1 $((pad - ${#mark}))))"
         footer="${footer}$(printf '{path}%.0s' $(seq 1 "$reps"))"
         test ${#footer} -lt 254 || fail "footer template is ${#footer} chars"
-        crawl "$footer"
+        crawl "$footer" "a $1 page at expansion ${total}"
         if grep -q "$mark" <<<"$body"; then
             line=$(footer_line)
             # Whole or not at all: a clipped footer runs into the page below it.


### PR DESCRIPTION
A footer whose expansion lands exactly on the on-page buffer size kills the crawl with SIGABRT. #670 handled the overflow by dropping the footer, but the success path still appends the closing newline with `strcatbuff`, which aborts instead of clipping, so the one length that fills the buffer exactly has nowhere to put that byte. Reserving it before formatting closes the window, and an expansion that no longer fits takes the drop path #670 already built.

It is reachable from the command line despite the 253-char cap on `-%F`: 36 repeats of `{path}` against an 85-char `file://` path expand to exactly the fatal length, which is how I hit it. It is not CLI-only either, since the Android options field feeds the same value unbounded. The test sweeps the expansion one byte at a time across the point where footers start being dropped and asserts it saw both outcomes, so a window that drifts off the boundary fails loudly rather than passing on nothing.

Found while working on #1240; independent of it.