### PR TITLE
The credit tag in every mirrored page is dated 2014

### DIFF
--- a/src/hts-indextmpl.h
+++ b/src/hts-indextmpl.h
@@ -33,8 +33,7 @@ Please visit our Website: http://www.httrack.com
 #ifndef HTTRACK_DEFTMPL
 #define HTTRACK_DEFTMPL
 
-/* Generated data, not code: clang-format rewrites a whole literal table
-   the moment one line inside it is touched. */
+/* Generated data: clang-format rewrites the whole table if one line is touched. */
 /* clang-format off */
 
 /* Index for each project */

--- a/src/hts-indextmpl.h
+++ b/src/hts-indextmpl.h
@@ -33,7 +33,7 @@ Please visit our Website: http://www.httrack.com
 #ifndef HTTRACK_DEFTMPL
 #define HTTRACK_DEFTMPL
 
-/* Generated data: clang-format rewrites the whole table if one line is touched. */
+/* Generated data: clang-format rewrites the whole table on any edit. */
 /* clang-format off */
 
 /* Index for each project */

--- a/src/hts-indextmpl.h
+++ b/src/hts-indextmpl.h
@@ -33,6 +33,10 @@ Please visit our Website: http://www.httrack.com
 #ifndef HTTRACK_DEFTMPL
 #define HTTRACK_DEFTMPL
 
+/* Generated data, not code: clang-format rewrites a whole literal table
+   the moment one line inside it is touched. */
+/* clang-format off */
+
 /* Index for each project */
 /*
 regen:
@@ -168,7 +172,7 @@ regen:
   "	<BR>"LF\
   "	<BR>"LF\
   "  	<H6 ALIGN=\"RIGHT\">"LF\
-  "	<I>Mirror and index made by HTTrack Website Copier [XR&amp;CO'2014]</I>"LF\
+  "	<I>Mirror and index made by HTTrack Website Copier [XR&amp;CO]</I>"LF\
   "	</H6>"LF\
   "	%s"LF\
   "	<!-- Thanks for using HTTrack Website Copier! -->"LF\
@@ -186,7 +190,7 @@ regen:
   ""LF\
   "<table width=\"76%%\" border=\"0\" align=\"center\" valign=\"bottom\" cellspacing=\"0\" cellpadding=\"0\">"LF\
   "	<tr>"LF\
-  "	<td id=\"footer\"><small>&copy; 2014 Xavier Roche & other contributors - Web Design: Kauler Leto.</small></td>"LF\
+  "	<td id=\"footer\"><small>&copy; 1998 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>"LF\
   "	</tr>"LF\
   "</table>"LF\
   ""LF\
@@ -317,7 +321,7 @@ regen:
   "	</TABLE>"LF\
   "	<BR>"LF\
   "	<H6 ALIGN=\"RIGHT\">"LF\
-  "         <I>Mirror and index made by HTTrack Website Copier [XR&CO'2014]</I>"LF\
+  "         <I>Mirror and index made by HTTrack Website Copier [XR&CO]</I>"LF\
   "	</H6>"LF\
   "	%s"LF\
   "	<!-- Thanks for using HTTrack Website Copier! -->"LF\
@@ -335,7 +339,7 @@ regen:
   ""LF\
   "<table width=\"76%%\" border=\"0\" align=\"center\" valign=\"bottom\" cellspacing=\"0\" cellpadding=\"0\">"LF\
   "	<tr>"LF\
-  "	<td id=\"footer\"><small>&copy; 2014 Xavier Roche & other contributors - Web Design: Kauler Leto.</small></td>"LF\
+  "	<td id=\"footer\"><small>&copy; 1998 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>"LF\
   "	</tr>"LF\
   "</table>"LF\
   ""LF\
@@ -475,7 +479,7 @@ regen:
   ""LF\
   "<table width=\"76%%\" height=\"100%%\" border=\"0\" align=\"center\" valign=\"bottom\" cellspacing=\"0\" cellpadding=\"0\">"LF\
   "	<tr>"LF\
-  "	<td id=\"footer\"><small>&copy; 2014 Xavier Roche & other contributors - Web Design: Kauler Leto.</small></td>"LF\
+  "	<td id=\"footer\"><small>&copy; 1998 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>"LF\
   "	</tr>"LF\
   "</table>"LF\
   ""LF\
@@ -784,5 +788,7 @@ regen:
   "\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x21\xf9\x4\x1\x0\x0\xd8\x0\x2c\x0\x0\x0\x0\x8\x0\x8\x0\x0\x8"\
   "\x19\x0\xaf\x61\x13\x48\x10\xdb\xc0\x83\x4\xb\x16\x44\x88\x50\xe1\x41\x86\x9\x21\x1a\x74\x78\x2d\x20\x0\x3b\xff"
 #define HTS_DATA_FADE_GIF_LEN 828
+
+/* clang-format on */
 
 #endif

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -220,7 +220,7 @@ Please visit our Website: http://www.httrack.com
 #define HTS_MIMETYPE_SIZE 128
 
 /* Copyright (C) 1998 Xavier Roche and other contributors */
-#define HTTRACK_AFF_AUTHORS "[XR&CO'2014]"
+#define HTTRACK_AFF_AUTHORS "[XR&CO]"
 /* Named fields (hts_footer_format); a "%s" anywhere would switch the template
    back to the legacy positional model, a user's own additions included. */
 #define HTS_DEFAULT_FOOTER                                                     \

--- a/templates/index-footer.html
+++ b/templates/index-footer.html
@@ -3,7 +3,7 @@
 	<BR>
 	<BR>
   	<H6 ALIGN="RIGHT">
-	<I>Mirror and index made by HTTrack Website Copier [XR&amp;CO'2008]</I>
+	<I>Mirror and index made by HTTrack Website Copier [XR&amp;CO]</I>
 	</H6>
 	%s
 	<!-- Thanks for using HTTrack Website Copier! -->
@@ -22,7 +22,7 @@
 
 <table width="76%%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2008 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/templates/topindex-footer.html
+++ b/templates/topindex-footer.html
@@ -1,7 +1,7 @@
 	</TABLE>
 	<BR>
 	<H6 ALIGN="RIGHT">
-         <I>Mirror and index made by HTTrack Website Copier [XR&CO'2008]</I>
+         <I>Mirror and index made by HTTrack Website Copier [XR&CO]</I>
 	</H6>
 	%s
 	<!-- Thanks for using HTTrack Website Copier! -->
@@ -19,7 +19,7 @@
 
 <table width="76%%" border="0" align="center" valign="bottom" cellspacing="0" cellpadding="0">
 	<tr>
-	<td id="footer"><small>&copy; 2008 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
+	<td id="footer"><small>&copy; 1998 Xavier Roche & other contributors - Web Design: Leto Kauler.</small></td>
 	</tr>
 </table>
 

--- a/tests/290_local-footer-default.test
+++ b/tests/290_local-footer-default.test
@@ -11,6 +11,6 @@ set -euo pipefail
 bash "$top_srcdir/tests/local-crawl.sh" \
     --files 5 --errors 0 \
     --file-matches 'simple/basic.html' \
-    "<!-- Mirrored from http://127\.0\.0\.1:[0-9]+/simple/basic\.html by HTTrack Website Copier/[^ ]+ \[XR&CO'[0-9]{4}\], [A-Z][a-z]{2}, [0-9]{2} [A-Z][a-z]{2} [0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2} GMT -->" \
+    "<!-- Mirrored from http://127\.0\.0\.1:[0-9]+/simple/basic\.html by HTTrack Website Copier/[^ ]+ \[XR&CO\], [A-Z][a-z]{2}, [0-9]{2} [A-Z][a-z]{2} [0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2} GMT -->" \
     --file-not-matches 'simple/basic.html' '\{(url|date)\}' \
     httrack 'BASEURL/simple/basic.html'


### PR DESCRIPTION
`HTTRACK_AFF_AUTHORS` reads `[XR&CO'2014]` and rides into every mirrored page's footer, every generated index and the version banner, so a 2026 crawl gets stamped with a year nobody has touched in twelve. Dropping the year beats bumping it: the next value goes stale the same way, and the footer already dates itself through `{date}`.

The index templates kept their own copies, and those had drifted apart while nobody was comparing them. Compiled-in said `'2014`, the shipped `templates/` said `'2008`, and the web designer's name was reversed between the two. Both now credit 1998, the start year the source headers already carry, with the name matching the served WebHTTrack pages.

`hts-indextmpl.h` is generated data (the recipe sits in its own header comment), and clang-format rewrites a whole literal table as soon as one line inside it is touched, so it now carries `clang-format off`.

Two things this turned up that are not fixed here, both in the same drifted pair, filed as #1244. The compiled-in `HTS_INDEX_FOOTER` lost the `%s` slot for the index redirect, so a run that cannot find its data directory silently produces an index with no `<meta refresh>`; I confirmed it by crawling with and without `templates/` installed, and `01_engine-makeindex.test` cannot see it because it drives its own `"%s%s"` template rather than the real one. The shipped headers also carry a duplicate stale `<meta generator>`/`<TITLE>`/`</HEAD>`/`<BODY>` block after `</head>`, and the compiled-in top index has a `width="100%%%"` typo.