### PR TITLE
The wizard verdict switch is unreachable by any test

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4329,53 +4329,95 @@ static int st_wizardscopeanswer(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-/* Prints the verdict a wizard answer decides; with no arguments, asserts every
-   answer against it. */
-static int st_wizardverdict(httrackp *opt, int argc, char **argv) {
-  (void) opt;
-  if (argc >= 1) {
-    const hts_wizard_verdict v = hts_wizard_answer_verdict(atoi(argv[0]));
+/* Poison: comparing the recursion cap against 0 would not see a stray write of
+   the level the crawl uses. */
+#define PRIO_UNSET 42
 
-    printf("forbids=%d stop=%d link-only=%d unknown=%d\n", v.forbids,
-           v.stop_asking, v.link_only, v.unknown);
+/* Prints what a wizard answer applies; with no arguments, asserts it for every
+   answer, from both an allowed and an already refused link. */
+static int st_wizardverdict(httrackp *opt, int argc, char **argv) {
+  const hts_wizard asked = opt->wizard;
+  FILE *const projectlog = opt->log;
+  char line[HTS_URLMAXSIZE];
+  FILE *log;
+  int url, depth;
+
+  url = 0;
+  depth = PRIO_UNSET;
+  opt->wizard = HTS_WIZARD_ASK;
+  if (argc >= 1) {
+    hts_wizard_apply_verdict(opt, atoi(argv[0]), "foo.com", "/a/b.html", &url,
+                             &depth);
+    printf("forbidden=%d stop=%d prio=%d\n", url,
+           opt->wizard == HTS_WIZARD_AUTO, depth);
+    opt->wizard = asked;
     return 0;
   }
-#define VERDICT(n, f, s, l, u)                                                 \
+  opt->log = NULL; /* the battery walks the answers that warn */
+/* answer `n` over a link the crawl had left at `in` decides `forbidden`, and
+   raises the wizard mode or the recursion cap only where said. */
+#define APPLIES(n, in, forbidden, stop, prio)                                  \
   do {                                                                         \
-    const hts_wizard_verdict v = hts_wizard_answer_verdict(n);                 \
-    assertf(v.forbids == (f) && v.stop_asking == (s) && v.link_only == (l) &&  \
-            v.unknown == (u));                                                 \
+    url = (in);                                                                \
+    depth = PRIO_UNSET;                                                        \
+    opt->wizard = HTS_WIZARD_ASK;                                              \
+    hts_wizard_apply_verdict(opt, (n), "foo.com", "/a/b.html", &url, &depth);  \
+    assertf(url == (forbidden));                                               \
+    assertf(opt->wizard == ((stop) ? HTS_WIZARD_AUTO : HTS_WIZARD_ASK));       \
+    assertf(depth == (prio));                                                  \
   } while (0)
-  /* '*' is the only answer that also stops the questions */
-  VERDICT(-1, HTS_TRUE, HTS_TRUE, HTS_FALSE, HTS_FALSE);
+  /* '*' refuses and stops the questions */
+  APPLIES(-1, 0, 1, 1, PRIO_UNSET);
+  APPLIES(-1, 1, 1, 1, PRIO_UNSET);
   /* the refusing answers, 3 included although it emits no filter yet */
-  VERDICT(0, HTS_TRUE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
-  VERDICT(1, HTS_TRUE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
-  VERDICT(2, HTS_TRUE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
-  VERDICT(3, HTS_TRUE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
-  /* 4 takes the link without recursing from it */
-  VERDICT(4, HTS_FALSE, HTS_FALSE, HTS_TRUE, HTS_FALSE);
-  /* the accepting answers decide nothing, and neither does an unparsed one */
-  VERDICT(5, HTS_FALSE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
-  VERDICT(6, HTS_FALSE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
-  VERDICT(7, HTS_FALSE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
-  VERDICT(50, HTS_FALSE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
-  VERDICT(-999, HTS_FALSE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
+  APPLIES(0, 0, 1, 0, PRIO_UNSET);
+  APPLIES(1, 0, 1, 0, PRIO_UNSET);
+  APPLIES(2, 0, 1, 0, PRIO_UNSET);
+  APPLIES(3, 0, 1, 0, PRIO_UNSET);
+  /* 4 caps the recursion and decides the link neither way */
+  APPLIES(4, 0, 0, 0, 1);
+  APPLIES(4, 1, 1, 0, 1);
+  /* an accepting answer never clears a refusal the crawl already computed */
+  APPLIES(5, 1, 1, 0, PRIO_UNSET);
+  APPLIES(6, 1, 1, 0, PRIO_UNSET);
+  APPLIES(7, 1, 1, 0, PRIO_UNSET);
+  APPLIES(50, 1, 1, 0, PRIO_UNSET);
+  APPLIES(-999, 1, 1, 0, PRIO_UNSET);
+  APPLIES(6, 0, 0, 0, PRIO_UNSET);
   /* both ends of each scope range: include allows, exclude forbids */
-  VERDICT(HTS_WIZARD_SCOPE_INCLUDE, HTS_FALSE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
-  VERDICT(HTS_WIZARD_SCOPE_EXCLUDE - 1, HTS_FALSE, HTS_FALSE, HTS_FALSE,
-          HTS_FALSE);
-  VERDICT(HTS_WIZARD_SCOPE_EXCLUDE, HTS_TRUE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
-  VERDICT(INT_MAX, HTS_TRUE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
-  /* anything else is unknown rather than silently accepted */
-  VERDICT(8, HTS_FALSE, HTS_FALSE, HTS_FALSE, HTS_TRUE);
-  VERDICT(-2, HTS_FALSE, HTS_FALSE, HTS_FALSE, HTS_TRUE);
-  VERDICT(HTS_WIZARD_SCOPE_INCLUDE - 1, HTS_FALSE, HTS_FALSE, HTS_FALSE,
-          HTS_TRUE);
-#undef VERDICT
+  APPLIES(HTS_WIZARD_SCOPE_INCLUDE, 0, 0, 0, PRIO_UNSET);
+  APPLIES(HTS_WIZARD_SCOPE_EXCLUDE - 1, 0, 0, 0, PRIO_UNSET);
+  APPLIES(HTS_WIZARD_SCOPE_EXCLUDE, 0, 1, 0, PRIO_UNSET);
+  APPLIES(INT_MAX, 0, 1, 0, PRIO_UNSET);
+  /* an answer in no range is not taken for an accept, nor for a refusal */
+  APPLIES(8, 0, 0, 0, PRIO_UNSET);
+  APPLIES(8, 1, 1, 0, PRIO_UNSET);
+  APPLIES(999, 0, 0, 0, PRIO_UNSET);
+  APPLIES(-2, 0, 0, 0, PRIO_UNSET);
+  APPLIES(-1000, 0, 0, 0, PRIO_UNSET);
+  APPLIES(INT_MIN, 0, 0, 0, PRIO_UNSET);
+  APPLIES(HTS_WIZARD_SCOPE_INCLUDE - 1, 0, 0, 0, PRIO_UNSET);
+#undef APPLIES
+
+  /* the warning is all an unknown answer does, so a known one must be silent */
+  log = tmpfile();
+  assertf(log != NULL);
+  opt->log = log;
+  hts_wizard_apply_verdict(opt, 6, "foo.com", "/a/b.html", &url, &depth);
+  hts_wizard_apply_verdict(opt, 8, "foo.com", "/a/b.html", &url, &depth);
+  rewind(log);
+  assertf(fgets(line, (int) sizeof(line), log) != NULL);
+  assertf(strstr(line, "unknown answer 8") != NULL);
+  assertf(fgets(line, (int) sizeof(line), log) == NULL);
+  fclose(log);
+
+  opt->log = projectlog;
+  opt->wizard = asked;
   printf("wizardverdict self-test OK\n");
   return 0;
 }
+
+#undef PRIO_UNSET
 
 /* #159: hts_redirect_same_savefile decides whether a redirect is a same-file
  * alias. */
@@ -9894,7 +9936,7 @@ static const struct selftest_entry {
      "domain scopes the wizard can offer for a host", st_wizardscope},
     {"wizardscopeanswer", "", "host-scope range of a wizard answer",
      st_wizardscopeanswer},
-    {"wizardverdict", "[<answer>]", "verdict decided by a wizard answer",
+    {"wizardverdict", "[<answer>]", "what a wizard answer applies",
      st_wizardverdict},
     {"mime", "<filename>", "MIME type for a filename", st_mime},
     {"charset", "<charset> <hex:..|string>",

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4329,6 +4329,54 @@ static int st_wizardscopeanswer(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* Prints the verdict a wizard answer decides; with no arguments, asserts every
+   answer against it. */
+static int st_wizardverdict(httrackp *opt, int argc, char **argv) {
+  (void) opt;
+  if (argc >= 1) {
+    const hts_wizard_verdict v = hts_wizard_answer_verdict(atoi(argv[0]));
+
+    printf("forbids=%d stop=%d link-only=%d unknown=%d\n", v.forbids,
+           v.stop_asking, v.link_only, v.unknown);
+    return 0;
+  }
+#define VERDICT(n, f, s, l, u)                                                 \
+  do {                                                                         \
+    const hts_wizard_verdict v = hts_wizard_answer_verdict(n);                 \
+    assertf(v.forbids == (f) && v.stop_asking == (s) && v.link_only == (l) &&  \
+            v.unknown == (u));                                                 \
+  } while (0)
+  /* '*' is the only answer that also stops the questions */
+  VERDICT(-1, HTS_TRUE, HTS_TRUE, HTS_FALSE, HTS_FALSE);
+  /* the refusing answers, 3 included although it emits no filter yet */
+  VERDICT(0, HTS_TRUE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
+  VERDICT(1, HTS_TRUE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
+  VERDICT(2, HTS_TRUE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
+  VERDICT(3, HTS_TRUE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
+  /* 4 takes the link without recursing from it */
+  VERDICT(4, HTS_FALSE, HTS_FALSE, HTS_TRUE, HTS_FALSE);
+  /* the accepting answers decide nothing, and neither does an unparsed one */
+  VERDICT(5, HTS_FALSE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
+  VERDICT(6, HTS_FALSE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
+  VERDICT(7, HTS_FALSE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
+  VERDICT(50, HTS_FALSE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
+  VERDICT(-999, HTS_FALSE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
+  /* both ends of each scope range: include allows, exclude forbids */
+  VERDICT(HTS_WIZARD_SCOPE_INCLUDE, HTS_FALSE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
+  VERDICT(HTS_WIZARD_SCOPE_EXCLUDE - 1, HTS_FALSE, HTS_FALSE, HTS_FALSE,
+          HTS_FALSE);
+  VERDICT(HTS_WIZARD_SCOPE_EXCLUDE, HTS_TRUE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
+  VERDICT(INT_MAX, HTS_TRUE, HTS_FALSE, HTS_FALSE, HTS_FALSE);
+  /* anything else is unknown rather than silently accepted */
+  VERDICT(8, HTS_FALSE, HTS_FALSE, HTS_FALSE, HTS_TRUE);
+  VERDICT(-2, HTS_FALSE, HTS_FALSE, HTS_FALSE, HTS_TRUE);
+  VERDICT(HTS_WIZARD_SCOPE_INCLUDE - 1, HTS_FALSE, HTS_FALSE, HTS_FALSE,
+          HTS_TRUE);
+#undef VERDICT
+  printf("wizardverdict self-test OK\n");
+  return 0;
+}
+
 /* #159: hts_redirect_same_savefile decides whether a redirect is a same-file
  * alias. */
 static int st_redirect_samefile(httrackp *opt, int argc, char **argv) {
@@ -9846,6 +9894,8 @@ static const struct selftest_entry {
      "domain scopes the wizard can offer for a host", st_wizardscope},
     {"wizardscopeanswer", "", "host-scope range of a wizard answer",
      st_wizardscopeanswer},
+    {"wizardverdict", "[<answer>]", "verdict decided by a wizard answer",
+     st_wizardverdict},
     {"mime", "<filename>", "MIME type for a filename", st_mime},
     {"charset", "<charset> <hex:..|string>",
      "convert a string to UTF-8 from a charset", st_charset},

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4333,8 +4333,8 @@ static int st_wizardscopeanswer(httrackp *opt, int argc, char **argv) {
    the level the crawl uses. */
 #define PRIO_UNSET 42
 
-/* Prints what a wizard answer applies; with no arguments, asserts it for every
-   answer, from both an allowed and an already refused link. */
+/* Prints what answer `n` does to the crawl; with no arguments, asserts every
+   answer, on both an allowed and an already refused link. */
 static int st_wizardverdict(httrackp *opt, int argc, char **argv) {
   const hts_wizard asked = opt->wizard;
   FILE *const projectlog = opt->log;
@@ -4354,8 +4354,8 @@ static int st_wizardverdict(httrackp *opt, int argc, char **argv) {
     return 0;
   }
   opt->log = NULL; /* the battery walks the answers that warn */
-/* answer `n` over a link the crawl had left at `in` decides `forbidden`, and
-   raises the wizard mode or the recursion cap only where said. */
+/* answer `n` over a link the crawl had left at `in`: the verdict it must leave,
+   whether it stops the questions, and the recursion cap it must set. */
 #define APPLIES(n, in, forbidden, stop, prio)                                  \
   do {                                                                         \
     url = (in);                                                                \

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -322,6 +322,43 @@ void hts_wizard_answer_filter(htsbuff *f, int slot, int n, const char *adr,
   }
 }
 
+hts_wizard_verdict hts_wizard_answer_verdict(int n) {
+  hts_wizard_verdict v = {HTS_FALSE, HTS_FALSE, HTS_FALSE, HTS_FALSE};
+
+  switch (n) {
+  case -1: /* skip this link and every question after it */
+    v.forbids = v.stop_asking = HTS_TRUE;
+    break;
+
+  case 0: /* this link */
+  case 1: /* this directory and below */
+  case 2: /* the whole host */
+  case 3: /* the parent directory, which emits no filter yet */
+    v.forbids = HTS_TRUE;
+    break;
+
+  case 4: /* wizard filters both allow and forbid, so an isolated link taken
+             with no depth limit would mirror the world */
+    v.link_only = HTS_TRUE;
+    break;
+
+  case 5:    /* this directory and below, or the whole host */
+  case 6:    /* the whole host */
+  case 7:    /* this directory, files only */
+  case 50:   /* nothing to do */
+  case -999: /* the "!" answer, and anything the front end could not parse */
+    break;
+
+  default: /* a scope answer forbids like 2 or allows like 6 */
+    if (hts_wizard_scope_answer(n) == HTS_TRUE)
+      v.forbids = HTS_TRUE;
+    else if (hts_wizard_scope_answer(n) == HTS_DEFAULT)
+      v.unknown = HTS_TRUE;
+    break;
+  }
+  return v;
+}
+
 static int hts_acceptlink_(httrackp * opt, int ptr,
                            const char *adr, const char *fil, const char *tag,
                            const char *attribute, int *set_prio_to,
@@ -865,70 +902,25 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
         }
       }
       // here we have enough room for a new filter if necessary
-      switch (n) {
-      case -1:                 // sauter tout le reste
-        forbidden_url = 1;
-        opt->wizard = HTS_WIZARD_AUTO; // sauter tout le reste
-        break;
-      case 0: // forbid the same link: adr/fil
-      case 1: // forbid the whole directory and subdirs: adr/path/*
-      case 2: // the whole address: adr/*
-        forbidden_url = 1;
-        break;
 
-      case 3:                  // ** A FAIRE
-        forbidden_url = 1;
-        /*
-           {
-           int i=strlen(adr)-1;
-           while((adr[i]!='/') && (i>0)) i--;
-           if (i>0) {
+      /* the verdict half of the answer */
+      {
+        const hts_wizard_verdict v = hts_wizard_answer_verdict(n);
 
-           }
-
-           } */
-
-        break;
-        //
-      case 4:                  // same link
-        // PAS BESOIN!!
-        /*HT_INSERT_FILTERS0;    // insérer en 0                                
-           strcpybuff(_FILTERS[0],"+");
-           strcatbuff(_FILTERS[0],adr);
-           if (*fil!='/') strcatbuff(_FILTERS[0],"/");
-           strcatbuff(_FILTERS[0],fil); */
-
-        // étant donné le renversement wizard/primary filter (les primary autorisent up/down ET interdisent)
-        // il faut éviter d'un lien isolé effectue un miroir total..
-
-        *set_prio_to = 0 + 1;   // niveau de récursion=0 (pas de miroir)
-
-        break;
-
-      case 5: // allow the whole directory and its children, or the domain
-      case 6: // same domain
-      case 7: // allow this directory
-        break;
-
-      case 50: // nothing to do
-        break;
-
-      case -999: // the "!" answer, and anything the front end could not parse
-        break;
-
-      default:
-        /* a scope answer forbids like 2 or allows like 6 */
-        if (hts_wizard_scope_answer(n) == HTS_TRUE)
+        if (v.forbids)
           forbidden_url = 1;
-        else if (hts_wizard_scope_answer(n) == HTS_DEFAULT)
+        if (v.stop_asking)
+          opt->wizard = HTS_WIZARD_AUTO;
+        if (v.link_only)
+          *set_prio_to = 0 + 1; // recursion level 0
+        if (v.unknown)
           hts_log_print(opt, LOG_WARNING,
                         "(wizard) unknown answer %d at %s%s, keeping the "
                         "computed verdict",
                         n, adr, fil);
-        break;
-      } // switch
+      }
 
-      /* the pattern half of the answer: a new answer needs both switches */
+      /* the pattern half of the answer */
       {
         char BIGSTK pattern[HTS_FILTER_SLOT_SIZE];
         htsbuff f = htsbuff_array(pattern);

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -322,24 +322,25 @@ void hts_wizard_answer_filter(htsbuff *f, int slot, int n, const char *adr,
   }
 }
 
-hts_wizard_verdict hts_wizard_answer_verdict(int n) {
-  hts_wizard_verdict v = {HTS_FALSE, HTS_FALSE, HTS_FALSE, HTS_FALSE};
-
+void hts_wizard_apply_verdict(httrackp *opt, int n, const char *adr,
+                              const char *fil, int *forbidden_url,
+                              int *set_prio_to) {
   switch (n) {
   case -1: /* skip this link and every question after it */
-    v.forbids = v.stop_asking = HTS_TRUE;
+    *forbidden_url = 1;
+    opt->wizard = HTS_WIZARD_AUTO;
     break;
 
   case 0: /* this link */
   case 1: /* this directory and below */
   case 2: /* the whole host */
   case 3: /* the parent directory, which emits no filter yet */
-    v.forbids = HTS_TRUE;
+    *forbidden_url = 1;
     break;
 
   case 4: /* wizard filters both allow and forbid, so an isolated link taken
              with no depth limit would mirror the world */
-    v.link_only = HTS_TRUE;
+    *set_prio_to = 0 + 1; /* recursion level 0 */
     break;
 
   case 5:    /* this directory and below, or the whole host */
@@ -351,12 +352,14 @@ hts_wizard_verdict hts_wizard_answer_verdict(int n) {
 
   default: /* a scope answer forbids like 2 or allows like 6 */
     if (hts_wizard_scope_answer(n) == HTS_TRUE)
-      v.forbids = HTS_TRUE;
+      *forbidden_url = 1;
     else if (hts_wizard_scope_answer(n) == HTS_DEFAULT)
-      v.unknown = HTS_TRUE;
+      hts_log_print(opt, LOG_WARNING,
+                    "(wizard) unknown answer %d at %s%s, keeping the computed "
+                    "verdict",
+                    n, adr, fil);
     break;
   }
-  return v;
 }
 
 static int hts_acceptlink_(httrackp * opt, int ptr,
@@ -903,22 +906,7 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
       }
       // here we have enough room for a new filter if necessary
 
-      /* the verdict half of the answer */
-      {
-        const hts_wizard_verdict v = hts_wizard_answer_verdict(n);
-
-        if (v.forbids)
-          forbidden_url = 1;
-        if (v.stop_asking)
-          opt->wizard = HTS_WIZARD_AUTO;
-        if (v.link_only)
-          *set_prio_to = 0 + 1; // recursion level 0
-        if (v.unknown)
-          hts_log_print(opt, LOG_WARNING,
-                        "(wizard) unknown answer %d at %s%s, keeping the "
-                        "computed verdict",
-                        n, adr, fil);
-      }
+      hts_wizard_apply_verdict(opt, n, adr, fil, &forbidden_url, set_prio_to);
 
       /* the pattern half of the answer */
       {

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -339,7 +339,7 @@ void hts_wizard_apply_verdict(httrackp *opt, int n, const char *adr,
     break;
 
   case 4: /* wizard filters both allow and forbid, so an isolated link taken
-             with no depth limit would mirror the world */
+             with no depth limit would mirror the whole site */
     *set_prio_to = 0 + 1; /* recursion level 0 */
     break;
 

--- a/src/htswizard.h
+++ b/src/htswizard.h
@@ -72,11 +72,11 @@ void hts_wizard_answer_filter(htsbuff *f, int slot, int n, const char *adr,
    HTS_FALSE includes it, HTS_DEFAULT for any answer outside both ranges. */
 hts_tristate hts_wizard_scope_answer(int n);
 
-/* Applies the verdict half of answer `n` for the link (adr,fil): refuses the
-   link, stops the questions, or bans recursion from it. Each effect is one-way,
-   so an answer deciding none of them leaves *forbidden_url, *set_prio_to and
-   opt->wizard as they were. The filter half is hts_wizard_answer_filter(); a
-   new answer needs both. */
+/* Applies the verdict half of answer `n` for the link (adr,fil): refuses it,
+   stops the questions, or bans recursion from it. Each effect is one-way, so an
+   answer deciding none of them leaves *forbidden_url, *set_prio_to and
+   opt->wizard alone; the filter half is hts_wizard_answer_filter(), and a new
+   answer needs both. */
 void hts_wizard_apply_verdict(httrackp *opt, int n, const char *adr,
                               const char *fil, int *forbidden_url,
                               int *set_prio_to);

--- a/src/htswizard.h
+++ b/src/htswizard.h
@@ -72,6 +72,19 @@ void hts_wizard_answer_filter(htsbuff *f, int slot, int n, const char *adr,
    HTS_FALSE includes it, HTS_DEFAULT for any answer outside both ranges. */
 hts_tristate hts_wizard_scope_answer(int n);
 
+/* What an answer decides besides the filters it adds. Each field is one-way: no
+   answer clears a verdict the wizard already computed. */
+typedef struct hts_wizard_verdict {
+  hts_boolean forbids;     /**< refuse the link */
+  hts_boolean stop_asking; /**< and ask nothing more this run */
+  hts_boolean link_only;   /**< take the link, do not recurse from it */
+  hts_boolean unknown;     /**< answer outside every range the engine knows */
+} hts_wizard_verdict;
+
+/* The verdict half of answer `n`, the filter half being
+   hts_wizard_answer_filter(); a new answer needs both. */
+hts_wizard_verdict hts_wizard_answer_verdict(int n);
+
 /* A (tag, attribute) pair naming a reference kind. */
 #ifndef HTS_DEF_DEFSTRUCT_htspair_t
 #define HTS_DEF_DEFSTRUCT_htspair_t

--- a/src/htswizard.h
+++ b/src/htswizard.h
@@ -72,18 +72,14 @@ void hts_wizard_answer_filter(htsbuff *f, int slot, int n, const char *adr,
    HTS_FALSE includes it, HTS_DEFAULT for any answer outside both ranges. */
 hts_tristate hts_wizard_scope_answer(int n);
 
-/* What an answer decides besides the filters it adds. Each field is one-way: no
-   answer clears a verdict the wizard already computed. */
-typedef struct hts_wizard_verdict {
-  hts_boolean forbids;     /**< refuse the link */
-  hts_boolean stop_asking; /**< and ask nothing more this run */
-  hts_boolean link_only;   /**< take the link, do not recurse from it */
-  hts_boolean unknown;     /**< answer outside every range the engine knows */
-} hts_wizard_verdict;
-
-/* The verdict half of answer `n`, the filter half being
-   hts_wizard_answer_filter(); a new answer needs both. */
-hts_wizard_verdict hts_wizard_answer_verdict(int n);
+/* Applies the verdict half of answer `n` for the link (adr,fil): refuses the
+   link, stops the questions, or bans recursion from it. Each effect is one-way,
+   so an answer deciding none of them leaves *forbidden_url, *set_prio_to and
+   opt->wizard as they were. The filter half is hts_wizard_answer_filter(); a
+   new answer needs both. */
+void hts_wizard_apply_verdict(httrackp *opt, int n, const char *adr,
+                              const char *fil, int *forbidden_url,
+                              int *set_prio_to);
 
 /* A (tag, attribute) pair naming a reference kind. */
 #ifndef HTS_DEF_DEFSTRUCT_htspair_t

--- a/tests/293_engine-wizard-verdict.test
+++ b/tests/293_engine-wizard-verdict.test
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+# #1239 left the verdict half of an answer reachable only through the
+# interactive callback; it now answers on its own.
+
+assert_selftest "forbids=1 stop=1 link-only=0 unknown=0" wizardverdict -1
+assert_selftest "forbids=1 stop=0 link-only=0 unknown=0" wizardverdict 2
+assert_selftest "forbids=0 stop=0 link-only=1 unknown=0" wizardverdict 4
+assert_selftest "forbids=0 stop=0 link-only=0 unknown=0" wizardverdict 6
+# a scope answer forbids like 2 or allows like 6, one out of range is unknown
+assert_selftest "forbids=1 stop=0 link-only=0 unknown=0" wizardverdict 2000
+assert_selftest "forbids=0 stop=0 link-only=0 unknown=0" wizardverdict 1000
+assert_selftest "forbids=0 stop=0 link-only=0 unknown=1" wizardverdict 999
+
+# every answer, and both range boundaries
+assert_selftest "wizardverdict self-test OK" wizardverdict

--- a/tests/293_engine-wizard-verdict.test
+++ b/tests/293_engine-wizard-verdict.test
@@ -6,17 +6,10 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "$(dirname "$0")/testlib.sh"
 
-# #1239 left the verdict half of an answer reachable only through the
-# interactive callback; it now answers on its own.
+# The verdict half of a wizard answer, driven without the interactive callback.
 
-assert_selftest "forbids=1 stop=1 link-only=0 unknown=0" wizardverdict -1
-assert_selftest "forbids=1 stop=0 link-only=0 unknown=0" wizardverdict 2
-assert_selftest "forbids=0 stop=0 link-only=1 unknown=0" wizardverdict 4
-assert_selftest "forbids=0 stop=0 link-only=0 unknown=0" wizardverdict 6
-# a scope answer forbids like 2 or allows like 6, one out of range is unknown
-assert_selftest "forbids=1 stop=0 link-only=0 unknown=0" wizardverdict 2000
-assert_selftest "forbids=0 stop=0 link-only=0 unknown=0" wizardverdict 1000
-assert_selftest "forbids=0 stop=0 link-only=0 unknown=1" wizardverdict 999
+assert_selftest "forbidden=1 stop=1 prio=42" wizardverdict -1
+assert_selftest "forbidden=0 stop=0 prio=42" wizardverdict 6
 
-# every answer, and both range boundaries
+# every answer, both scope ranges, and a link the crawl had already refused
 assert_selftest "wizardverdict self-test OK" wizardverdict


### PR DESCRIPTION
The verdict half of a wizard answer moves into `hts_wizard_apply_verdict()`, leaving `hts_acceptlink_()` one call where a switch used to be. #1239 made the filter half a testable function and left this one unreachable: `hts_acceptlink_()` is static, and only the interactive `query3` callback gets there.

The self-test drives the new function against a real `httrackp`, so it asserts what an answer does to the crawl rather than what it means. An accepting answer must not clear a refusal the crawl already computed, answer 4 caps the recursion instead of deciding the link, `*` switches the wizard to automatic, and an answer in no known range only warns. Eight mutants each turn tests/293 red, including the three shapes the call site used to hide.

Behavior is unchanged for every int answer, both scope-range boundaries included. The dead commented-out blocks under answers 3 and 4 went with the move. The widened filter reservation is still untested: reaching it needs a crawl driving `query3`.