### PR TITLE
An LTO build collapses the installed-header symbol test's candidate list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,30 @@ concurrency:
 
 jobs:
   build:
-    name: build (${{ matrix.arch }}, ${{ matrix.cc }})
+    name: build (${{ matrix.arch }}, ${{ matrix.cc }}${{ matrix.label }})
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
+        # cflags is spelled out everywhere: an exported empty CFLAGS reads as
+        # "set" to configure, which then drops its own -g -O2.
         include:
-          - { arch: x86-64, runner: ubuntu-24.04, cc: gcc }
-          - { arch: x86-64, runner: ubuntu-24.04, cc: clang }
-          - { arch: arm64, runner: ubuntu-24.04-arm, cc: gcc }
-          - { arch: arm64, runner: ubuntu-24.04-arm, cc: clang }
+          - { arch: x86-64, runner: ubuntu-24.04, cc: gcc, cflags: -g -O2 }
+          - { arch: x86-64, runner: ubuntu-24.04, cc: clang, cflags: -g -O2 }
+          - { arch: arm64, runner: ubuntu-24.04-arm, cc: gcc, cflags: -g -O2 }
+          - { arch: arm64, runner: ubuntu-24.04-arm, cc: clang, cflags: -g -O2 }
+          # Ubuntu ships httrack built this way and Debian does not, so nothing
+          # else here compiles the tree the way its largest distro does.
+          - {
+              arch: x86-64,
+              runner: ubuntu-24.04,
+              cc: gcc,
+              label: " -O3 -flto",
+              cflags: -g -O3 -flto=auto -ffat-lto-objects,
+            }
     env:
       CC: ${{ matrix.cc }}
+      CFLAGS: ${{ matrix.cflags }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,7 @@ jobs:
           - { arch: x86-64, runner: ubuntu-24.04, cc: clang, cflags: -g -O2 }
           - { arch: arm64, runner: ubuntu-24.04-arm, cc: gcc, cflags: -g -O2 }
           - { arch: arm64, runner: ubuntu-24.04-arm, cc: clang, cflags: -g -O2 }
-          # Ubuntu ships httrack built this way and Debian does not, so nothing
-          # else here compiles the tree the way its largest distro does.
+          # Ubuntu builds httrack this way; no other leg here does.
           - {
               arch: x86-64,
               runner: ubuntu-24.04,

--- a/tests/207_install-headers-symbols.test
+++ b/tests/207_install-headers-symbols.test
@@ -34,7 +34,11 @@ cleanup_push rm -rf "$tmp"
 "$nm" --defined-only "$lib" >"$tmp/all.raw" 2>/dev/null ||
     skip "$nm cannot read the symbol table of $lib"
 awk 'NF >= 3 { print $3 }' "$tmp/exported.raw" | sort -u >"$tmp/exported"
-awk 'NF >= 3 { print $3 }' "$tmp/all.raw" | sort -u >"$tmp/all"
+# LTO and the IPA clones rename a local to "name.lto_priv.0", which stops
+# matching the header identifier and collapses the candidate list to nothing.
+awk 'NF >= 3 { print $3 }' "$tmp/all.raw" |
+    sed -E 's/(\.(lto_priv|constprop|isra|part|cold|llvm)(\.[0-9]+)*)+$//' |
+    sort -u >"$tmp/all"
 comm -23 "$tmp/all" "$tmp/exported" >"$tmp/hidden"
 n_exported=$(wc -l <"$tmp/exported")
 n_hidden=$(wc -l <"$tmp/hidden")

--- a/tests/207_install-headers-symbols.test
+++ b/tests/207_install-headers-symbols.test
@@ -34,11 +34,11 @@ cleanup_push rm -rf "$tmp"
 "$nm" --defined-only "$lib" >"$tmp/all.raw" 2>/dev/null ||
     skip "$nm cannot read the symbol table of $lib"
 awk 'NF >= 3 { print $3 }' "$tmp/exported.raw" | sort -u >"$tmp/exported"
-# LTO and the IPA clones rename a local to "name.lto_priv.0", which stops
-# matching the header identifier and collapses the candidate list to nothing.
-awk 'NF >= 3 { print $3 }' "$tmp/all.raw" |
-    sed -E 's/(\.(lto_priv|constprop|isra|part|cold|llvm)(\.[0-9]+)*)+$//' |
-    sort -u >"$tmp/all"
+# LTO and the optimizer's clones rename a local to "name.lto_priv.0", which
+# stops matching the header identifier and empties the candidate list.
+clone_alt='lto_priv|constprop|isra|part|cold|llvm'
+strip_clones="s/(\\.($clone_alt)(\\.[0-9]+)*)+\$//"
+awk 'NF >= 3 { print $3 }' "$tmp/all.raw" | sed -E "$strip_clones" | sort -u >"$tmp/all"
 comm -23 "$tmp/all" "$tmp/exported" >"$tmp/hidden"
 n_exported=$(wc -l <"$tmp/exported")
 n_hidden=$(wc -l <"$tmp/hidden")
@@ -93,7 +93,26 @@ env MAKEFLAGS= MFLAGS= "$make" -C "$abs_top_builddir/src" install-DevIncludesDAT
 # A synthetic leak the loop must report: every real candidate is a static defined
 # in the header, which links from the probe's own copy and so proves nothing.
 canary=zzz-canary.h
-printf 'extern void %s(void);\n' "$neg" >"$tmp/include/httrack/$canary"
+canaries=("$neg")
+
+# One name per clone suffix, taken from the raw table: a strip that drops a
+# suffix fails here instead of quietly shedding the candidates carrying it.
+# Listed again on purpose; sharing $clone_alt would let one edit disarm both.
+awk 'NF >= 3 && $3 !~ /\./ { print $3 }' "$tmp/all.raw" | sort -u >"$tmp/plain"
+for suffix in lto_priv constprop isra part cold llvm; do
+    awk -v s="$suffix" 'NF >= 3 && $3 ~ "\\." s "([.$]|$)" { print $3 }' "$tmp/all.raw" |
+        sed -E 's/(\.[A-Za-z_][A-Za-z0-9_]*(\.[0-9]+)*)+$//' | sort -u >"$tmp/cloned"
+    sym=$(comm -23 <(comm -23 "$tmp/cloned" "$tmp/plain") "$tmp/exported" |
+        awk '/^[A-Za-z_][A-Za-z0-9_]*$/ { print; exit }')
+    if [ -n "$sym" ]; then
+        canaries+=("$sym")
+    fi
+done
+mapfile -t canaries < <(printf '%s\n' "${canaries[@]}" | sort -u)
+
+for sym in "${canaries[@]}"; do
+    printf 'extern void %s(void);\n' "$sym"
+done >"$tmp/include/httrack/$canary"
 
 headers=("$tmp/include/httrack"/*.h)
 [ "${#headers[@]}" -ge 10 ] || fail "only ${#headers[@]} headers installed, the list cannot be right"
@@ -117,7 +136,7 @@ ours {
 EOF
 
 probed=0
-leaks=""
+leaks=()
 for h in "${headers[@]}"; do
     b=$(basename "$h")
     # config.h first, as a consumer must: it is what turns HTS_USEOPENSSL on, and
@@ -140,16 +159,26 @@ for h in "${headers[@]}"; do
             "$tmp/probe.c" 2>/dev/null || continue
         probed=$((probed + 1))
         "${cc_argv[@]}" -w -o "$tmp/probe" "$tmp/probe.o" "$lib" 2>/dev/null ||
-            leaks="$leaks $b:$sym"
+            leaks+=("$b:$sym")
     done < <(comm -12 "$tmp/hidden" "$tmp/ids")
 done
 
 echo "linked $probed reachable symbol(s) from ${#headers[@]} installed headers" \
     "($n_hidden hidden, $n_exported exported)"
 [ "$probed" -ge 5 ] || fail "only $probed symbols reached the link probe, the candidate list is broken"
-[ "${leaks#* "$canary":"$neg"}" != "$leaks" ] ||
-    fail "the synthetic $canary:$neg leak went unreported, the candidate list is broken"
-leaks=${leaks/ "$canary":"$neg"/}
-[ -z "$leaks" ] || fail "installed headers declare symbols $lib does not export:$leaks"
+for sym in "${canaries[@]}"; do
+    case " ${leaks[*]} " in
+    *" $canary:$sym "*) ;;
+    *) fail "the synthetic $canary:$sym leak went unreported, the candidate list is broken" ;;
+    esac
+done
+real=()
+for leak in "${leaks[@]}"; do
+    case $leak in
+    "$canary":*) ;;
+    *) real+=("$leak") ;;
+    esac
+done
+[ "${#real[@]}" -eq 0 ] || fail "installed headers declare symbols $lib does not export: ${real[*]}"
 
 exit 0


### PR DESCRIPTION
Ubuntu's 3.49.21-2 failed on four architectures (amd64, ppc64el, riscv64, s390x) with `207_install-headers-symbols.test` reporting "only 1 symbols reached the link probe, the candidate list is broken". Debian built the same source everywhere. Ubuntu compiles with `-flto=auto -ffat-lto-objects` by default and Debian does not.

The test picks its probe candidates by matching identifiers in the installed headers against the library's hidden symbol names. Under LTO, GCC renames a local to `abortf_.lto_priv.0`, the names stop matching, and the candidate list empties, so the `probed >= 5` floor fires. The floor was right; what fed it was broken. Stripping the clone suffixes before the comparison takes an `-O3 -flto` build from 1 candidate to 58, and an ordinary build from 32 to 65 by recovering its `.isra` and `.constprop` clones.

That floor turns out to be a weak detector on its own: a strip handling only `.lto_priv` still passed while losing 30 of 54 candidates. The canary header now declares one clone-only name per suffix and requires each to be reported, so dropping any single suffix fails the test.

Nothing in CI builds with LTO, which is how this reached the archive. The deb job runs inside debian:sid and gets Debian's flags; every other leg uses configure's defaults. The matrix gains an `-O3 -flto` leg.
