### PR TITLE
A wizard session leaves no record in hts-log.txt

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -3413,17 +3413,17 @@ int check_sockdata(T_SOC s) {
 
 // Attente de touche
 int ask_continue(httrackp * opt) {
-  const char *s;
+  const char *s = RUN_CALLBACK1(opt, query2, opt->state.HTbuff);
+  int go = 1;
 
-  s = RUN_CALLBACK1(opt, query2, opt->state.HTbuff);
-  if (s) {
-    if (strnotempty(s)) {
-      if ((strfield2(s, "N")) || (strfield2(s, "NO")) || (strfield2(s, "NON")))
-        return 0;
-    }
-    return 1;
-  }
-  return 1;
+  if (s != NULL && strnotempty(s) &&
+      ((strfield2(s, "N")) || (strfield2(s, "NO")) || (strfield2(s, "NON"))))
+    go = 0;
+  if (HAS_CALLBACK(opt, query2)) /* nobody was really asked otherwise */
+    hts_log_print(opt, LOG_NOTICE, "(wizard) answer '%s' to \"%.*s\": %s",
+                  s != NULL ? s : "", (int) strcspn(opt->state.HTbuff, "\r\n"),
+                  opt->state.HTbuff, go ? "continue" : "abort");
+  return go;
 }
 
 // nombre de digits dans un nombre

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -3421,7 +3421,7 @@ int ask_continue(httrackp * opt) {
   if (s != NULL && strnotempty(s) &&
       ((strfield2(s, "N")) || (strfield2(s, "NO")) || (strfield2(s, "NON"))))
     go = 0;
-  if (HAS_CALLBACK(opt, query2)) /* nobody was really asked otherwise */
+  if (HAS_CALLBACK(opt, query2)) /* nobody was asked otherwise */
     hts_log_print(opt, LOG_NOTICE, "(wizard) answer '%s' to \"%.*s\": %s",
                   s != NULL ? s : "", (int) strcspn(opt->state.HTbuff, "\r\n"),
                   opt->state.HTbuff, go ? "continue" : "abort");

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -2022,8 +2022,10 @@ int httpmirror(char *url1, httrackp * opt) {
   if ((HTS_STAT.stat_files <= 0)
       && (HTS_STAT.HTS_TOTAL_RECV < 32768)      /* should be fine */
     ) {
-    hts_log_print(opt, LOG_NOTICE,
-                  "No data seems to have been transferred during this session! : restoring previous one!");
+    /* not a notice: the session is rolled back and the WARC aborted */
+    hts_log_print(opt, LOG_WARNING,
+                  "No data seems to have been transferred during this session! "
+                  ": restoring previous one!");
     /* this run replaces nothing, so its archive must not be committed */
     warc_abort_opt(opt);
     opt->state.exit_xh = 2;     /* interrupted (no connection detected) */

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -6231,7 +6231,7 @@ HTSEXT_API void hts_log_vprint(httrackp * opt, int type, const char *format, va_
       s_type = "debug";
       break;
     case LOG_INFO:
-    case LOG_NOTICE: /* not a warning; fspc() tallies "info" as a message */
+    case LOG_NOTICE: /* not a warning: counted in the footer's messages */
       s_type = "info";
       break;
     case LOG_WARNING:

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -6231,9 +6231,9 @@ HTSEXT_API void hts_log_vprint(httrackp * opt, int type, const char *format, va_
       s_type = "debug";
       break;
     case LOG_INFO:
+    case LOG_NOTICE: /* not a warning; fspc() tallies "info" as a message */
       s_type = "info";
       break;
-    case LOG_NOTICE:
     case LOG_WARNING:
       s_type = "warning";
       break;

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -428,16 +428,15 @@ void *hts_get_callback(t_hts_htmlcheck_callbacks * callbacks,
 #define CBSTRUCT(OPT) ((t_hts_htmlcheck_callbacks*) ((OPT)->callbacks_fun))
 #define GET_USERCALLBACK(OPT, NAME) ( CBSTRUCT(OPT)-> NAME .fun )
 #define GET_USERARG(OPT, NAME) ( CBSTRUCT(OPT)-> NAME .carg )
-#define GET_USERDEF(OPT, NAME) ( \
-  (CBSTRUCT(OPT) != NULL && CBSTRUCT(OPT)-> NAME .fun != NULL) \
-	? ( GET_USERARG(OPT, NAME) ) \
-	: ( default_callbacks. NAME .carg ) \
-)
-#define GET_CALLBACK(OPT, NAME) ( \
-  (CBSTRUCT(OPT) != NULL && CBSTRUCT(OPT)-> NAME .fun != NULL) \
-	? ( GET_USERCALLBACK(OPT, NAME ) ) \
-  : ( default_callbacks. NAME .fun ) \
-)
+/* True when a front end chained its own NAME callback */
+#define HAS_CALLBACK(OPT, NAME)                                                \
+  (CBSTRUCT(OPT) != NULL && CBSTRUCT(OPT)->NAME.fun != NULL)
+#define GET_USERDEF(OPT, NAME)                                                 \
+  (HAS_CALLBACK(OPT, NAME) ? (GET_USERARG(OPT, NAME))                          \
+                           : (default_callbacks.NAME.carg))
+#define GET_CALLBACK(OPT, NAME)                                                \
+  (HAS_CALLBACK(OPT, NAME) ? (GET_USERCALLBACK(OPT, NAME))                     \
+                           : (default_callbacks.NAME.fun))
 
 /* Predefined macros */
 #define RUN_CALLBACK_NOARG(OPT, NAME) GET_CALLBACK(OPT, NAME)(GET_USERARG(OPT, NAME))

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -428,7 +428,7 @@ void *hts_get_callback(t_hts_htmlcheck_callbacks * callbacks,
 #define CBSTRUCT(OPT) ((t_hts_htmlcheck_callbacks*) ((OPT)->callbacks_fun))
 #define GET_USERCALLBACK(OPT, NAME) ( CBSTRUCT(OPT)-> NAME .fun )
 #define GET_USERARG(OPT, NAME) ( CBSTRUCT(OPT)-> NAME .carg )
-/* True when a front end chained its own NAME callback */
+/* True when a front end registered its own NAME callback */
 #define HAS_CALLBACK(OPT, NAME)                                                \
   (CBSTRUCT(OPT) != NULL && CBSTRUCT(OPT)->NAME.fun != NULL)
 #define GET_USERDEF(OPT, NAME)                                                 \
@@ -449,19 +449,6 @@ void *hts_get_callback(t_hts_htmlcheck_callbacks * callbacks,
 #define RUN_CALLBACK6(OPT, NAME, ARG1, ARG2, ARG3, ARG4, ARG5, ARG6) GET_CALLBACK(OPT, NAME)(GET_USERARG(OPT, NAME), OPT, ARG1, ARG2, ARG3, ARG4, ARG5, ARG6)
 #define RUN_CALLBACK7(OPT, NAME, ARG1, ARG2, ARG3, ARG4, ARG5, ARG6, ARG7) GET_CALLBACK(OPT, NAME)(GET_USERARG(OPT, NAME), OPT, ARG1, ARG2, ARG3, ARG4, ARG5, ARG6, ARG7)
 #define RUN_CALLBACK8(OPT, NAME, ARG1, ARG2, ARG3, ARG4, ARG5, ARG6, ARG7, ARG8) GET_CALLBACK(OPT, NAME)(GET_USERARG(OPT, NAME), OPT, ARG1, ARG2, ARG3, ARG4, ARG5, ARG6, ARG7, ARG8)
-
-/*
-#define GET_CALLBACK(OPT, NAME, ARG) ( \
-  ( \
-    ( ARG ) = GET_USERDEF(OPT, NAME), \
-    ( \
- 	    (CBSTRUCT(OPT) != NULL && CBSTRUCT(OPT)-> NAME .fun != NULL) \
-	    ? ( GET_USERCALLBACK(OPT, NAME ) ) \
-      : ( default_callbacks. NAME .fun ) \
-    ) \
-  ) \
-)
-*/
 
 /* UTF-8 aware FILE API */
 #ifndef HTS_DEF_FILEAPI

--- a/src/htssinglefile.c
+++ b/src/htssinglefile.c
@@ -517,11 +517,11 @@ static void sf_warn_oversize(sf_ctx *ctx, const char *path, LLint size,
   if (*ctx->warn_budget <= 0)
     return;
   if (--(*ctx->warn_budget) == 0) {
-    hts_log_print(ctx->opt, LOG_NOTICE,
+    hts_log_print(ctx->opt, LOG_WARNING,
                   "single-file: further over-cap assets not reported");
     return;
   }
-  hts_log_print(ctx->opt, LOG_NOTICE,
+  hts_log_print(ctx->opt, LOG_WARNING,
                 "single-file: %s left as a link (" LLintP
                 " bytes, over the " LLintP "-byte cap)",
                 path, size, cap);

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -796,7 +796,7 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
 
     /* en cas de question, ou lien primaire (enregistrer autorisations) */
     if (question || (ptr == 0)) {
-      const char *s;
+      const char *s = NULL; /* the front end's raw reply, NULL if unasked */
       int n = 0;
 
       // si primaire (plus bas) alors ...
@@ -931,7 +931,10 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
       /* the pattern half of the answer: a new answer needs both switches */
       {
         char BIGSTK pattern[HTS_FILTER_SLOT_SIZE];
+        /* the log echoes the inserted slots, so it cannot drift from them */
+        char BIGSTK list[HTS_WIZARD_MAX_FILTERS * (HTS_FILTER_SLOT_SIZE + 1)];
         htsbuff f = htsbuff_array(pattern);
+        htsbuff added = htsbuff_array(list);
         int slot;
 
         for (slot = 0; slot < HTS_WIZARD_MAX_FILTERS; slot++) {
@@ -942,6 +945,18 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
             break;
           HT_INSERT_FILTERS0; // insert at slot 0
           strlcpybuff(_FILTERS[0], pattern, HTS_FILTER_SLOT_SIZE);
+          if (added.len != 0)
+            htsbuff_cat(&added, " ");
+          htsbuff_cat(&added, _FILTERS[0]);
+        }
+        if (s != NULL) {
+          hts_log_print(
+              opt, LOG_NOTICE, "(wizard) answer '%s' (n=%d) for %s%s: %s%s%s",
+              s, n, adr, fil,
+              forbidden_url == 1   ? "forbidden"
+              : forbidden_url == 0 ? "allowed"
+                                   : "no verdict",
+              added.len != 0 ? ", filters: " : "", htsbuff_str(&added));
         }
       }
 

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -929,7 +929,8 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
             htsbuff_cat(&added, " ");
           htsbuff_cat(&added, _FILTERS[0]);
         }
-        if (s != NULL) {
+        /* the built-in query3 answers "" for nobody, so ask who replied */
+        if (s != NULL && HAS_CALLBACK(opt, query3)) {
           hts_log_print(
               opt, LOG_NOTICE, "(wizard) answer '%s' (n=%d) for %s%s: %s%s%s",
               s, n, adr, fil,

--- a/tests/295_wizard-log.test
+++ b/tests/295_wizard-log.test
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# A wizard session must be readable afterwards: one line per answer, carrying
+# the raw reply and the filters it inserted, reaches hts-log.txt at the default
+# verbosity, and a run where nobody was asked stays silent.
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+bin=$(httrack_path)
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_wizardlog.XXXXXX") || exit 1
+cleanup_push rm -rf "$tmp"
+
+site="$tmp/site"
+mkdir -p "$site"
+printf '<a href="a.html">a</a> <a href="http://other.invalid/x.html">e</a>' \
+    >"$site/index.html"
+echo hello >"$site/a.html"
+
+# the CLI re-prompts until the reply is not empty, so never run out of answers
+answers() { printf '%s\n' "$1" "$1" "$1" "$1" "$1" >"$tmp/answers"; }
+
+crawl() { # crawl MIRRORDIR [httrack args...], sets $log
+    local out=$1
+    shift
+    "$bin" "file://$site/index.html" -O "$out" --quiet "$@" \
+        <"$tmp/answers" >/dev/null 2>&1
+    log="$out/hts-log.txt"
+}
+
+# "ignore this link": the answer forbids it and inserts the single-link filter
+answers 0
+crawl "$tmp/m0" -W
+grep -q "(wizard) answer '0' (n=0) for other.invalid/x.html: forbidden, filters: -other.invalid/x.html$" "$log" ||
+    fail "the answer line is wrong in $log"
+
+# "ignore the whole host": same reply path, a different filter. The log echoes
+# what was inserted, so a hardcoded pattern would still read -.../x.html here.
+answers 2
+crawl "$tmp/m2" -W
+grep -q "(wizard) answer '2' (n=2) for other.invalid/x.html: forbidden, filters: -other.invalid/[*]$" "$log" ||
+    fail "the answer line does not echo the inserted filter in $log"
+
+# nobody was asked: the automatic resolution stays at the debug level
+answers 0
+crawl "$tmp/mauto"
+! grep -q "(wizard) answer" "$log" ||
+    fail "a non-interactive run logged a question in $log"

--- a/tests/295_wizard-log.test
+++ b/tests/295_wizard-log.test
@@ -13,9 +13,12 @@ bin=$(httrack_path)
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_wizardlog.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmp"
 
+link=other.invalid/x.html
+tag='(wizard) answer'
+
 site="$tmp/site"
 mkdir -p "$site"
-printf '<a href="a.html">a</a> <a href="http://other.invalid/x.html">e</a>' \
+printf '<a href="a.html">a</a> <a href="http://%s">e</a>' "$link" \
     >"$site/index.html"
 echo hello >"$site/a.html"
 
@@ -33,21 +36,30 @@ crawl() { # crawl MIRRORDIR [httrack args...], sets $log
 # "ignore this link": the answer forbids it and inserts the single-link filter
 answers 0
 crawl "$tmp/m0" -W
-grep -q "(wizard) answer '0' (n=0) for other.invalid/x.html: forbidden, filters: -other.invalid/x.html$" "$log" ||
+grep -q "$tag '0' (n=0) for $link: forbidden, filters: -$link\$" "$log" ||
     fail "the answer line is wrong in $log"
 # the prefix fspc() tallies by: a notice is a message, never a warning
-grep -q "Info:.*(wizard) answer '0'" "$log" ||
+grep -q "Info:.*$tag '0'" "$log" ||
     fail "the answer is not tallied as a message in $log"
 
 # "ignore the whole host": same reply path, a different filter. The log echoes
 # what was inserted, so a hardcoded pattern would still read -.../x.html here.
 answers 2
 crawl "$tmp/m2" -W
-grep -q "(wizard) answer '2' (n=2) for other.invalid/x.html: forbidden, filters: -other.invalid/[*]$" "$log" ||
+grep -q "$tag '2' (n=2) for $link: forbidden, filters: -other.invalid/[*]\$" "$log" ||
     fail "the answer line does not echo the inserted filter in $log"
 
-# nobody was asked: the automatic resolution stays at the debug level
+# a host-scope answer, which accepts and inserts two filters: the starred form
+# misses the apex, so both slots must reach the log, in insertion order
+answers 1000
+crawl "$tmp/m1000" -W
+grep -q "$tag '1000' (n=1000) for $link: no verdict, filters: [+][*].other.invalid/[*] [+]other.invalid/[*]\$" "$log" ||
+    fail "a two-filter answer is not logged whole in $log"
+
+# nobody was asked: the automatic resolution stays at the debug level. This run
+# is silent because no question is put, not because the callback is missing;
+# the CLI always registers query3, so no test here reaches that guard.
 answers 0
 crawl "$tmp/mauto"
-! grep -q "(wizard) answer" "$log" ||
-    fail "a non-interactive run logged a question in $log"
+! grep -q "$tag" "$log" ||
+    fail "a non-interactive run logged an answer in $log"

--- a/tests/295_wizard-log.test
+++ b/tests/295_wizard-log.test
@@ -35,6 +35,9 @@ answers 0
 crawl "$tmp/m0" -W
 grep -q "(wizard) answer '0' (n=0) for other.invalid/x.html: forbidden, filters: -other.invalid/x.html$" "$log" ||
     fail "the answer line is wrong in $log"
+# the prefix fspc() tallies by: a notice is a message, never a warning
+grep -q "Info:.*(wizard) answer '0'" "$log" ||
+    fail "the answer is not tallied as a message in $log"
 
 # "ignore the whole host": same reply path, a different filter. The log echoes
 # what was inserted, so a hardcoded pattern would still read -.../x.html here.


### PR DESCRIPTION
Two problems, same log. Driving the wizard by hand left no trace: hts-log.txt recorded the crawl going on around the questions, but not what was asked or what the user replied, so a session could not be reviewed afterwards. The levels themselves were mislabelled too. `hts_log_vprint` mapped LOG_NOTICE onto the "warning" prefix, so every notice read as a warning, while the footer's message count tracked LOG_INFO, which the default `opt->debug` filters out. That count was always zero.

The engine now writes one line per wizard answer at LOG_NOTICE: the link, the raw reply, the parsed answer number, the verdict, and the filters that answer inserted, read back from the slots they were written to. `ask_continue()` gets the same line for the yes/no prompts, and nothing is logged unless a front end registered a callback to answer with, so a non-interactive crawl gains no noise. LOG_NOTICE also gets its own arm in the level switch, mapping to "info", so notices print `Info:` and move from the warning column of `(N errors, N warnings, N messages)` to the message one. `html/faq.html` already documents the robots.txt notice as an `Info:` line. Two notice sites report a failure rather than progress, and this promotes them to LOG_WARNING so they render as before.

`tests/295_wizard-log.test` drives three answers through a `file://` crawl under `-W` and checks the line each one produces, the two-filter host-scope answer included.
