### PR TITLE
The footer field names are copied by hand in three places

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -855,22 +855,21 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                     // footer sits inside an HTML comment, so a value holding
                     // "-->" would otherwise close it and inject markup (#165).
                     // status/size are formatted integers and need no escaping.
-                    const hts_footer_field fields[] = {
-                        {"addr", safe_adr},
-                        {"path", safe_fil},
-                        {"url", safe_url},
-                        {"date", gmttime},
-                        {"lastmodified",
-                         html_inline_safe(r->lastmodified, safe_lastmod,
-                                          sizeof(safe_lastmod))},
-                        {"version", HTTRACK_VERSIONID},
-                        {"mime", html_inline_safe(r->contenttype, safe_ctype,
-                                                  sizeof(safe_ctype))},
-                        {"charset", html_inline_safe(r->charset, safe_charset,
-                                                     sizeof(safe_charset))},
-                        {"status", status_str},
-                        {"size", size_str},
-                    };
+                    const char *values[HTS_FOOTER_FIELD_COUNT];
+
+                    values[HTS_FOOTER_ADDR] = safe_adr;
+                    values[HTS_FOOTER_PATH] = safe_fil;
+                    values[HTS_FOOTER_URL] = safe_url;
+                    values[HTS_FOOTER_DATE] = gmttime;
+                    values[HTS_FOOTER_LASTMODIFIED] = html_inline_safe(
+                        r->lastmodified, safe_lastmod, sizeof(safe_lastmod));
+                    values[HTS_FOOTER_VERSION] = HTTRACK_VERSIONID;
+                    values[HTS_FOOTER_MIME] = html_inline_safe(
+                        r->contenttype, safe_ctype, sizeof(safe_ctype));
+                    values[HTS_FOOTER_CHARSET] = html_inline_safe(
+                        r->charset, safe_charset, sizeof(safe_charset));
+                    values[HTS_FOOTER_STATUS] = status_str;
+                    values[HTS_FOOTER_SIZE] = size_str;
 
                     tempo[0] = '\0';
                     strcatbuff(tempo, eol);
@@ -880,8 +879,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                     if (hts_footer_format(
                             tempo + strlen(tempo),
                             sizeof(tempo) - strlen(tempo) - strlen(eol),
-                            StringBuff(opt->footer), fields,
-                            sizeof(fields) / sizeof(fields[0])) >= 0) {
+                            StringBuff(opt->footer), values) >= 0) {
                       strcatbuff(tempo, eol);
                       HT_ADD(tempo);
                     }

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -855,7 +855,9 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                     // footer sits inside an HTML comment, so a value holding
                     // "-->" would otherwise close it and inject markup (#165).
                     // status/size are formatted integers and need no escaping.
-                    const char *values[HTS_FOOTER_FIELD_COUNT];
+                    // Zeroed first: a field added to the enum expands empty
+                    // here until this block fills it, never a stale pointer.
+                    const char *values[HTS_FOOTER_FIELD_COUNT] = {NULL};
 
                     values[HTS_FOOTER_ADDR] = safe_adr;
                     values[HTS_FOOTER_PATH] = safe_fil;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1279,40 +1279,49 @@ static int st_entities(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-// -#test=footerfmt <template>: expand a -%F footer with fixed fields (drives
-// tests/01_engine-footerfmt.test). Also asserts the overflow/zero-size returns
-// the CLI cap keeps out of reach.
+// -#test=footerfmt <template>: expand a -%F footer with fixed values (drives
+// tests/01_engine-footerfmt.test). Also asserts the published field names and
+// the overflow/zero-size returns the CLI cap keeps out of reach.
 static int st_footerfmt(httrackp *opt, int argc, char **argv) {
-  static const hts_footer_field fields[] = {
-      {"addr", "host.example"},
-      {"path", "/dir/page.html"},
-      {"url", "http://host.example/dir/page.html"},
-      {"date", "DATE"},
-      {"lastmodified", "LASTMOD"},
-      {"version", "VER"},
-      {"mime", "text/html"},
-      {"charset", "utf-8"},
-      {"status", "200"},
-      {"size", "1234"},
+  static const char *const values[HTS_FOOTER_FIELD_COUNT] = {
+      "host.example", "/dir/page.html", "http://host.example/dir/page.html",
+      "DATE",         "LASTMOD",        "VER",
+      "text/html",    "utf-8",          "200",
+      "1234",
   };
-  const size_t nfields = sizeof(fields) / sizeof(fields[0]);
+  // Spelled out, not read back from the engine: these ten are the published
+  // contract front ends validate their templates against.
+  static const char *const names[] = {
+      "addr",    "path", "url",     "date",   "lastmodified",
+      "version", "mime", "charset", "status", "size"};
+  size_t i;
   char out[1024];
   char tiny[4];
 
   (void) opt;
+  for (i = 0; i < sizeof(names) / sizeof(names[0]); i++) {
+    assertf(hts_footer_field_ok(names[i]));
+  }
+  assertf(!hts_footer_field_ok(NULL));
+  assertf(!hts_footer_field_ok(""));
+  assertf(!hts_footer_field_ok("nosuchfield"));
+  // A prefix or a longer name must not match, or "{addr}" and "{addrx}" would
+  // validate alike.
+  assertf(!hts_footer_field_ok("add"));
+  assertf(!hts_footer_field_ok("addrx"));
   // Overflow (named and legacy) and a zero-size buffer must return <0, never
   // truncate silently or write out of bounds.
-  assertf(hts_footer_format(tiny, sizeof(tiny), "{addr}", fields, nfields) < 0);
-  assertf(hts_footer_format(tiny, sizeof(tiny), "a %s b", fields, nfields) < 0);
-  assertf(hts_footer_format(out, 0, "", fields, nfields) < 0);
+  assertf(hts_footer_format(tiny, sizeof(tiny), "{addr}", values) < 0);
+  assertf(hts_footer_format(tiny, sizeof(tiny), "a %s b", values) < 0);
+  assertf(hts_footer_format(out, 0, "", values) < 0);
   // An empty template yields an empty, terminated string.
-  assertf(hts_footer_format(out, sizeof(out), "", fields, nfields) == 1 &&
+  assertf(hts_footer_format(out, sizeof(out), "", values) == 1 &&
           out[0] == '\0');
   if (argc < 1) {
     fprintf(stderr, "footerfmt: needs a template\n");
     return 1;
   }
-  if (hts_footer_format(out, sizeof(out), argv[0], fields, nfields) < 0) {
+  if (hts_footer_format(out, sizeof(out), argv[0], values) < 0) {
     fprintf(stderr, "footerfmt: overflow\n");
     return 1;
   }

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1283,24 +1283,32 @@ static int st_entities(httrackp *opt, int argc, char **argv) {
 // tests/01_engine-footerfmt.test). Also asserts the published field names and
 // the overflow/zero-size returns the CLI cap keeps out of reach.
 static int st_footerfmt(httrackp *opt, int argc, char **argv) {
-  static const char *const values[HTS_FOOTER_FIELD_COUNT] = {
-      "host.example", "/dir/page.html", "http://host.example/dir/page.html",
-      "DATE",         "LASTMOD",        "VER",
-      "text/html",    "utf-8",          "200",
-      "1234",
-  };
   // Spelled out, not read back from the engine: these ten are the published
   // contract front ends validate their templates against.
   static const char *const names[] = {
       "addr",    "path", "url",     "date",   "lastmodified",
       "version", "mime", "charset", "status", "size"};
+  // Filled by id, as htsparse.c does, so the .test's expected strings pin each
+  // name to its enum slot; a positional list would not see them drift apart.
+  const char *values[HTS_FOOTER_FIELD_COUNT] = {NULL};
   size_t i;
   char out[1024];
   char tiny[4];
 
   (void) opt;
+  values[HTS_FOOTER_ADDR] = "host.example";
+  values[HTS_FOOTER_PATH] = "/dir/page.html";
+  values[HTS_FOOTER_URL] = "http://host.example/dir/page.html";
+  values[HTS_FOOTER_DATE] = "DATE";
+  values[HTS_FOOTER_LASTMODIFIED] = "LASTMOD";
+  values[HTS_FOOTER_VERSION] = "VER";
+  values[HTS_FOOTER_MIME] = "text/html";
+  values[HTS_FOOTER_CHARSET] = "utf-8";
+  values[HTS_FOOTER_STATUS] = "200";
+  values[HTS_FOOTER_SIZE] = "1234";
+
   for (i = 0; i < sizeof(names) / sizeof(names[0]); i++) {
-    assertf(hts_footer_field_ok(names[i]));
+    assertf(hts_footer_field_ok(names[i]) == HTS_TRUE);
   }
   assertf(!hts_footer_field_ok(NULL));
   assertf(!hts_footer_field_ok(""));
@@ -1309,6 +1317,9 @@ static int st_footerfmt(httrackp *opt, int argc, char **argv) {
   // validate alike.
   assertf(!hts_footer_field_ok("add"));
   assertf(!hts_footer_field_ok("addrx"));
+  // Matching is exact: the expander is case-sensitive, so a validator that
+  // accepted "{ADDR}" would green-light a template the crawl emits verbatim.
+  assertf(!hts_footer_field_ok("Addr"));
   // Overflow (named and legacy) and a zero-size buffer must return <0, never
   // truncate silently or write out of bounds.
   assertf(hts_footer_format(tiny, sizeof(tiny), "{addr}", values) < 0);

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -890,11 +890,17 @@ int hts_template_format_str(char *buffer, size_t size, const char *format, ...) 
   return success;
 }
 
-// The engine owns the footer field names; front ends validate against
-// hts_footer_field_ok() rather than a copy. Indexed by hts_footer_field_id.
-static const char *const footer_field_names[HTS_FOOTER_FIELD_COUNT] = {
+// Indexed by hts_footer_field_id. Sized by the initializer, then pinned below:
+// a new id without a name here is a compile error, not a NULL slot.
+static const char *const footer_field_names[] = {
     "addr",    "path", "url",     "date",   "lastmodified",
     "version", "mime", "charset", "status", "size"};
+
+enum {
+  footer_field_names_complete =
+      1 / (int) (sizeof(footer_field_names) / sizeof(footer_field_names[0]) ==
+                 HTS_FOOTER_FIELD_COUNT)
+};
 
 HTSEXT_API hts_boolean hts_footer_field_ok(const char *name) {
   size_t i;

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -890,20 +890,33 @@ int hts_template_format_str(char *buffer, size_t size, const char *format, ...) 
   return success;
 }
 
-// Value of the named field, or "" if absent (never NULL, so callers can pass it
-// straight to a formatter).
-static const char *footer_field_value(const hts_footer_field *fields,
-                                      size_t nfields, const char *name) {
-  size_t j;
-  for (j = 0; j < nfields; j++) {
-    if (strcmp(fields[j].name, name) == 0)
-      return fields[j].value != NULL ? fields[j].value : "";
+// The engine owns the footer field names; front ends validate against
+// hts_footer_field_ok() rather than a copy. Indexed by hts_footer_field_id.
+static const char *const footer_field_names[HTS_FOOTER_FIELD_COUNT] = {
+    "addr",    "path", "url",     "date",   "lastmodified",
+    "version", "mime", "charset", "status", "size"};
+
+HTSEXT_API hts_boolean hts_footer_field_ok(const char *name) {
+  size_t i;
+
+  if (name == NULL)
+    return HTS_FALSE;
+  for (i = 0; i < HTS_FOOTER_FIELD_COUNT; i++) {
+    if (strcmp(footer_field_names[i], name) == 0)
+      return HTS_TRUE;
   }
-  return "";
+  return HTS_FALSE;
+}
+
+// Value of a field, or "" (never NULL, so callers can pass it straight to a
+// formatter).
+static const char *footer_field_value(const char *const *values,
+                                      hts_footer_field_id id) {
+  return values[id] != NULL ? values[id] : "";
 }
 
 int hts_footer_format(char *buffer, size_t size, const char *footer,
-                      const hts_footer_field *fields, size_t nfields) {
+                      const char *const values[HTS_FOOTER_FIELD_COUNT]) {
   hts_template_format_buf buf = {NULL, buffer, size, 0};
   size_t i;
 
@@ -914,10 +927,10 @@ int hts_footer_format(char *buffer, size_t size, const char *footer,
   // order-independent.
   if (strstr(footer, "%s") != NULL)
     return hts_template_format_str(
-        buffer, size, footer, footer_field_value(fields, nfields, "addr"),
-        footer_field_value(fields, nfields, "path"),
-        footer_field_value(fields, nfields, "date"),
-        footer_field_value(fields, nfields, "version"), /* EOF */ NULL);
+        buffer, size, footer, footer_field_value(values, HTS_FOOTER_ADDR),
+        footer_field_value(values, HTS_FOOTER_PATH),
+        footer_field_value(values, HTS_FOOTER_DATE),
+        footer_field_value(values, HTS_FOOTER_VERSION), /* EOF */ NULL);
   // "{{"/"}}" emit a literal brace; an unknown "{...}" is left verbatim so
   // typos stay visible.
   for (i = 0; footer[i] != '\0'; i++) {
@@ -936,11 +949,11 @@ int hts_footer_format(char *buffer, size_t size, const char *footer,
       if (end != NULL) {
         const size_t namelen = (size_t) (end - (footer + i + 1));
         size_t j;
-        for (j = 0; j < nfields; j++) {
-          if (strlen(fields[j].name) == namelen &&
-              strncmp(fields[j].name, footer + i + 1, namelen) == 0) {
-            if (htsfmt_puts(&buf,
-                            fields[j].value != NULL ? fields[j].value : "") < 0)
+        for (j = 0; j < HTS_FOOTER_FIELD_COUNT; j++) {
+          if (strlen(footer_field_names[j]) == namelen &&
+              strncmp(footer_field_names[j], footer + i + 1, namelen) == 0) {
+            if (htsfmt_puts(&buf, footer_field_value(
+                                      values, (hts_footer_field_id) j)) < 0)
               return -1;
             i += namelen + 1; // consume the name and its closing '}'
             matched = 1;

--- a/src/htstools.h
+++ b/src/htstools.h
@@ -78,19 +78,30 @@ HTS_INLINE int rech_tageq_all(const char *adr, const char *s);
 int hts_template_format(FILE *const out, const char *format, ...);
 int hts_template_format_str(char *buffer, size_t size, const char *format, ...);
 
-// A footer named field and its already-context-escaped value.
-typedef struct hts_footer_field {
-  const char *name;
-  const char *value;
-} hts_footer_field;
+// Index of a footer {field} in the engine's name table (htstools.c), and the
+// slot its value occupies in the values[] handed to hts_footer_format().
+typedef enum {
+  HTS_FOOTER_ADDR = 0,
+  HTS_FOOTER_PATH,
+  HTS_FOOTER_URL,
+  HTS_FOOTER_DATE,
+  HTS_FOOTER_LASTMODIFIED,
+  HTS_FOOTER_VERSION,
+  HTS_FOOTER_MIME,
+  HTS_FOOTER_CHARSET,
+  HTS_FOOTER_STATUS,
+  HTS_FOOTER_SIZE,
+  HTS_FOOTER_FIELD_COUNT
+} hts_footer_field_id;
 
 // Expand a footer template. A "%s" in it selects the legacy positional model,
-// consuming the "addr"/"path"/"date"/"version" fields in that order; otherwise
-// "{name}" is substituted from fields by name ("{{"/"}}" emit a literal brace,
-// an unknown "{...}" is left verbatim). Values must already be escaped for the
-// target context by the caller. Returns <0 on overflow.
+// consuming addr, path, date and version in that order; otherwise "{name}" is
+// substituted from values, indexed by hts_footer_field_id ("{{"/"}}" emit a
+// literal brace, an unknown "{...}" is left verbatim). A NULL slot expands
+// empty. Values must already be escaped for the target context by the caller.
+// Returns <0 on overflow.
 int hts_footer_format(char *buffer, size_t size, const char *footer,
-                      const hts_footer_field *fields, size_t nfields);
+                      const char *const values[HTS_FOOTER_FIELD_COUNT]);
 
 #define rech_tageq(adr,s) \
   ( \

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -361,6 +361,11 @@ HTSEXT_API int copy_htsopt(const httrackp *from, httrackp *to);
  */
 HTSEXT_API hts_boolean hts_host_alias_rule_ok(const char *rule);
 
+/** Whether @p name is a field the -%F footer expands as "{name}", so a front
+    end can validate a template against the engine's own list instead of a copy
+   that silently rots when a field is renamed. @return HTS_TRUE if known. */
+HTSEXT_API hts_boolean hts_footer_field_ok(const char *name);
+
 /** Return the engine's last error message, or NULL. The string is owned by
     @p opt; do not free it, and use it only while @p opt lives. */
 HTSEXT_API char *hts_errmsg(httrackp *opt);

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -362,8 +362,8 @@ HTSEXT_API int copy_htsopt(const httrackp *from, httrackp *to);
 HTSEXT_API hts_boolean hts_host_alias_rule_ok(const char *rule);
 
 /** Whether @p name is a field the -%F footer expands as "{name}", so a front
-    end can validate a template against the engine's own list instead of a copy
-   that silently rots when a field is renamed. @return HTS_TRUE if known. */
+    end can validate a template against the engine's own list. Matching is
+   exact, as the expander's is. @return HTS_TRUE if known. */
 HTSEXT_API hts_boolean hts_footer_field_ok(const char *name);
 
 /** Return the engine's last error message, or NULL. The string is owned by

--- a/tests/01_engine-footerfmt.test
+++ b/tests/01_engine-footerfmt.test
@@ -3,8 +3,8 @@
 
 set -euo pipefail
 
-# -%F footer expansion (hts_footer_format via -#test=footerfmt). Fixed fields:
-# addr=host.example path=/dir/page.html date=DATE version=VER.
+# -%F footer expansion (hts_footer_format via -#test=footerfmt). The expected
+# strings below also pin each field name to its engine enum slot.
 ftr() {
     out="$(httrack -O /dev/null -#test=footerfmt "$1")"
     test "$out" == "$2" || {
@@ -36,7 +36,7 @@ ftr '100% {path}' '100% /dir/page.html'
 # %s anywhere forces legacy mode, so a mixed template leaves {addr} literal.
 ftr '{addr} %s' '{addr} host.example'
 
-# The added named fields (url, lastmodified, mime, charset, status, size).
+# Distinct values per field, so a slot transposition shows as swapped text.
 ftr '{url}' 'http://host.example/dir/page.html'
 ftr 'src {lastmodified}, got {date}' 'src LASTMOD, got DATE'
 ftr '{mime}; {charset}; {status}; {size}' 'text/html; utf-8; 200; 1234'


### PR DESCRIPTION
The ten `-%F` footer field names were written out twice inside the formatter's own reach, in htsparse.c and in the htsselftest.c fixture, and a third time in WinHTTrack's preset validator with nothing to link against: `hts_footer_format` sits behind `HTS_INTERNAL_BYTECODE` and the field table was function-local. That third copy could catch a GUI typo and nothing else; an engine rename sailed straight past it.

The formatter's two callers now share one table in htstools.c and pass a positional `values[]` indexed by a new `hts_footer_field_id`, and front ends get `HTSEXT_API hts_boolean hts_footer_field_ok(const char *name)` to test a name against it. The export is additive and `hts_footer_format` is internal, so nothing about the ABI moves. The help text, man page and cmdguide.html still list the names by hand; that is #1256, not this PR.

Asked for by the httrack-windows session, which wires the GUI half once this lands.

Review caught the trap in the positional design and the second commit closes it: reordering the enum without touching the name table passed all 326 tests, because the named path resolves by name while the crawl assigns by enum symbol, so `{mime}` would have carried the charset. The fixture now fills `values[]` by id the way htsparse.c does, which makes the test's expected strings pin each name to its slot. A name missing from the table is a compile error instead of a NULL slot. Both mutants were confirmed to red, and a dropped name to fail the build.
