### PR TITLE
A link the wizard authorized is mirrored under its .delayed placeholder name

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4389,7 +4389,7 @@ static int st_wizardverdict(httrackp *opt, int argc, char **argv) {
   APPLIES(HTS_WIZARD_SCOPE_EXCLUDE - 1, 0, 0, 0, PRIO_UNSET);
   APPLIES(HTS_WIZARD_SCOPE_EXCLUDE, 0, 1, 0, PRIO_UNSET);
   APPLIES(INT_MAX, 0, 1, 0, PRIO_UNSET);
-  /* an answer in no range overturns neither an accept nor a refusal */
+  /* an answer in no range never overturns an accept or a refusal */
   APPLIES(8, 0, 0, 0, PRIO_UNSET);
   APPLIES(8, 1, 1, 0, PRIO_UNSET);
   APPLIES(999, 0, 0, 0, PRIO_UNSET);
@@ -4397,18 +4397,21 @@ static int st_wizardverdict(httrackp *opt, int argc, char **argv) {
   APPLIES(-1000, 0, 0, 0, PRIO_UNSET);
   APPLIES(INT_MIN, 0, 0, 0, PRIO_UNSET);
   APPLIES(HTS_WIZARD_SCOPE_INCLUDE - 1, 0, 0, 0, PRIO_UNSET);
-  /* the state the question is asked in: an answer that did not refuse must
-     leave the link allowed, never undecided */
+  /* an answer that does not refuse leaves the link allowed, never undecided */
   APPLIES(4, -1, 0, 0, 1);
   APPLIES(5, -1, 0, 0, PRIO_UNSET);
   APPLIES(6, -1, 0, 0, PRIO_UNSET);
   APPLIES(7, -1, 0, 0, PRIO_UNSET);
   APPLIES(50, -1, 0, 0, PRIO_UNSET);
-  APPLIES(-999, -1, 0, 0, PRIO_UNSET);
-  APPLIES(8, -1, 0, 0, PRIO_UNSET);
+  APPLIES(8, -1, 0, 0, PRIO_UNSET); /* -999 is #1259's, not asserted here */
   APPLIES(HTS_WIZARD_SCOPE_INCLUDE, -1, 0, 0, PRIO_UNSET);
-  APPLIES(HTS_WIZARD_SCOPE_EXCLUDE, -1, 1, 0, PRIO_UNSET);
+  /* and one that does refuse must still refuse it */
+  APPLIES(-1, -1, 1, 1, PRIO_UNSET);
   APPLIES(0, -1, 1, 0, PRIO_UNSET);
+  APPLIES(1, -1, 1, 0, PRIO_UNSET);
+  APPLIES(2, -1, 1, 0, PRIO_UNSET);
+  APPLIES(3, -1, 1, 0, PRIO_UNSET);
+  APPLIES(HTS_WIZARD_SCOPE_EXCLUDE, -1, 1, 0, PRIO_UNSET);
 #undef APPLIES
 
   /* the warning is all an unknown answer does, so a known one must be silent */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4334,7 +4334,7 @@ static int st_wizardscopeanswer(httrackp *opt, int argc, char **argv) {
 #define PRIO_UNSET 42
 
 /* Prints what answer `n` does to the crawl; with no arguments, asserts every
-   answer, on both an allowed and an already refused link. */
+   answer, on an undecided, an allowed and an already refused link. */
 static int st_wizardverdict(httrackp *opt, int argc, char **argv) {
   const hts_wizard asked = opt->wizard;
   FILE *const projectlog = opt->log;
@@ -4342,7 +4342,7 @@ static int st_wizardverdict(httrackp *opt, int argc, char **argv) {
   FILE *log;
   int url, depth;
 
-  url = 0;
+  url = -1; /* the undecided verdict the wizard is asked about */
   depth = PRIO_UNSET;
   opt->wizard = HTS_WIZARD_ASK;
   if (argc >= 1) {
@@ -4374,7 +4374,7 @@ static int st_wizardverdict(httrackp *opt, int argc, char **argv) {
   APPLIES(1, 0, 1, 0, PRIO_UNSET);
   APPLIES(2, 0, 1, 0, PRIO_UNSET);
   APPLIES(3, 0, 1, 0, PRIO_UNSET);
-  /* 4 caps the recursion and decides the link neither way */
+  /* 4 caps the recursion, and takes the link like any accepting answer */
   APPLIES(4, 0, 0, 0, 1);
   APPLIES(4, 1, 1, 0, 1);
   /* an accepting answer never clears a refusal the crawl already computed */
@@ -4389,7 +4389,7 @@ static int st_wizardverdict(httrackp *opt, int argc, char **argv) {
   APPLIES(HTS_WIZARD_SCOPE_EXCLUDE - 1, 0, 0, 0, PRIO_UNSET);
   APPLIES(HTS_WIZARD_SCOPE_EXCLUDE, 0, 1, 0, PRIO_UNSET);
   APPLIES(INT_MAX, 0, 1, 0, PRIO_UNSET);
-  /* an answer in no range is not taken for an accept, nor for a refusal */
+  /* an answer in no range overturns neither an accept nor a refusal */
   APPLIES(8, 0, 0, 0, PRIO_UNSET);
   APPLIES(8, 1, 1, 0, PRIO_UNSET);
   APPLIES(999, 0, 0, 0, PRIO_UNSET);
@@ -4397,6 +4397,18 @@ static int st_wizardverdict(httrackp *opt, int argc, char **argv) {
   APPLIES(-1000, 0, 0, 0, PRIO_UNSET);
   APPLIES(INT_MIN, 0, 0, 0, PRIO_UNSET);
   APPLIES(HTS_WIZARD_SCOPE_INCLUDE - 1, 0, 0, 0, PRIO_UNSET);
+  /* the state the question is asked in: an answer that did not refuse must
+     leave the link allowed, never undecided */
+  APPLIES(4, -1, 0, 0, 1);
+  APPLIES(5, -1, 0, 0, PRIO_UNSET);
+  APPLIES(6, -1, 0, 0, PRIO_UNSET);
+  APPLIES(7, -1, 0, 0, PRIO_UNSET);
+  APPLIES(50, -1, 0, 0, PRIO_UNSET);
+  APPLIES(-999, -1, 0, 0, PRIO_UNSET);
+  APPLIES(8, -1, 0, 0, PRIO_UNSET);
+  APPLIES(HTS_WIZARD_SCOPE_INCLUDE, -1, 0, 0, PRIO_UNSET);
+  APPLIES(HTS_WIZARD_SCOPE_EXCLUDE, -1, 1, 0, PRIO_UNSET);
+  APPLIES(0, -1, 1, 0, PRIO_UNSET);
 #undef APPLIES
 
   /* the warning is all an unknown answer does, so a known one must be silent */

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -361,9 +361,8 @@ void hts_wizard_apply_verdict(httrackp *opt, int n, const char *adr,
     break;
   }
 
-  /* the question is asked only while the verdict is undecided, so an answer
-     that did not forbid has authorized: -1 records the link type-unresolved,
-     under its .delayed placeholder name */
+  /* the question is asked only while undecided; an answer that does not forbid
+     authorizes the link */
   if (*forbidden_url == -1)
     *forbidden_url = 0;
 }

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -360,6 +360,12 @@ void hts_wizard_apply_verdict(httrackp *opt, int n, const char *adr,
                     n, adr, fil);
     break;
   }
+
+  /* the question is asked only while the verdict is undecided, so an answer
+     that did not forbid has authorized: -1 records the link type-unresolved,
+     under its .delayed placeholder name */
+  if (*forbidden_url == -1)
+    *forbidden_url = 0;
 }
 
 static int hts_acceptlink_(httrackp * opt, int ptr,

--- a/src/htswizard.h
+++ b/src/htswizard.h
@@ -73,10 +73,10 @@ void hts_wizard_answer_filter(htsbuff *f, int slot, int n, const char *adr,
 hts_tristate hts_wizard_scope_answer(int n);
 
 /* Applies the verdict half of answer `n` for the link (adr,fil): refuses it,
-   stops the questions, or bans recursion from it. An answer never overturns a
-   verdict the crawl already computed, but always leaves one decided: an
-   undecided (-1) link the answer did not refuse comes out authorized. The
-   filter half is hts_wizard_answer_filter(), and a new answer needs both. */
+   stops the questions, or bans recursion from it. It never overturns a verdict
+   already computed, but resolves an undecided (-1) link: refused, or
+   authorized. The filter half is hts_wizard_answer_filter(), and a new answer
+   needs both. */
 void hts_wizard_apply_verdict(httrackp *opt, int n, const char *adr,
                               const char *fil, int *forbidden_url,
                               int *set_prio_to);

--- a/src/htswizard.h
+++ b/src/htswizard.h
@@ -73,10 +73,10 @@ void hts_wizard_answer_filter(htsbuff *f, int slot, int n, const char *adr,
 hts_tristate hts_wizard_scope_answer(int n);
 
 /* Applies the verdict half of answer `n` for the link (adr,fil): refuses it,
-   stops the questions, or bans recursion from it. Each effect is one-way, so an
-   answer deciding none of them leaves *forbidden_url, *set_prio_to and
-   opt->wizard alone; the filter half is hts_wizard_answer_filter(), and a new
-   answer needs both. */
+   stops the questions, or bans recursion from it. An answer never overturns a
+   verdict the crawl already computed, but always leaves one decided: an
+   undecided (-1) link the answer did not refuse comes out authorized. The
+   filter half is hts_wizard_answer_filter(), and a new answer needs both. */
 void hts_wizard_apply_verdict(httrackp *opt, int n, const char *adr,
                               const char *fil, int *forbidden_url,
                               int *set_prio_to);

--- a/tests/293_engine-wizard-verdict.test
+++ b/tests/293_engine-wizard-verdict.test
@@ -7,9 +7,10 @@ set -euo pipefail
 . "$(dirname "$0")/testlib.sh"
 
 # The verdict half of a wizard answer, driven without the interactive callback.
+# Both start from the undecided verdict the question is asked in.
 
 assert_selftest "forbidden=1 stop=1 prio=42" wizardverdict -1
 assert_selftest "forbidden=0 stop=0 prio=42" wizardverdict 6
 
-# every answer, both scope ranges, and a link the crawl had already refused
+# every answer, all three incoming verdicts, both scope ranges
 assert_selftest "wizardverdict self-test OK" wizardverdict

--- a/tests/296_local-wizard-delayed.test
+++ b/tests/296_local-wizard-delayed.test
@@ -10,12 +10,20 @@ set -euo pipefail
 
 httrack=$(httrack_path)
 
+# "mirror this link"
+WIZARD_MIRROR=5
+# spare answers: an empty one means "ignore this link", and EOF spins the
+# prompt (#1247)
+WIZARD_SPARES=40
+# the body the placeholder file never carried
+MARKER=beyond-the-scope
+
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_wizdelayed.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmpdir"
 
 # a second port is a second address to the wizard, hence a question
 mkdir -p "${tmpdir}/foreign"
-printf '<html><body>beyond</body></html>\n' >"${tmpdir}/foreign/a.html"
+printf '<html><body>%s</body></html>\n' "$MARKER" >"${tmpdir}/foreign/a.html"
 local_server_start --root "${tmpdir}/foreign" --log "${tmpdir}/foreign.log"
 foreign=$SRV_PORT
 
@@ -30,13 +38,11 @@ cat >"${tmpdir}/root/wizdelayed/index.html" <<EOF
 EOF
 local_server_start --root "${tmpdir}/root"
 
-# "mirror this link", with spares: an empty answer means "ignore this link" and
-# EOF spins the prompt (#1247)
 answers="${tmpdir}/answers"
-for _ in $(seq 40); do echo 5; done >"$answers"
+for _ in $(seq "$WIZARD_SPARES"); do echo "$WIZARD_MIRROR"; done >"$answers"
 
-# the redirection belongs to the engine, not to run_with_timeout: it backgrounds
-# the job, whose stdin is /dev/null wherever job control is off
+# redirect here, not in run_with_timeout's args: it backgrounds the job with
+# stdin closed (#1258)
 crawl() { "$httrack" "$@" <"$answers"; }
 
 rc=0
@@ -47,13 +53,23 @@ run_with_timeout "$(crawl_deadline)" crawl --max-time="$CRAWL_MAX_TIME" \
 test "$rc" -ne 124 || fail "the crawl never returned"
 test "$rc" -eq 0 || fail "the crawl exited $rc"
 
-log="${tmpdir}/mirror/hts-log.txt"
 grep -q 'beyond this mirror scope' "${tmpdir}/crawl.log" ||
     fail "the wizard never asked about the foreign link"
-test -f "${tmpdir}/mirror/127.0.0.1_${foreign}/a.html" ||
-    fail "the authorized link is missing from the mirror"
+
+# what the mirror holds, which is what the user sees
+page="${tmpdir}/mirror/127.0.0.1_${foreign}/a.html"
+test -f "$page" || fail "the authorized link is missing from the mirror"
+grep -q "$MARKER" "$page" || fail "the authorized link was saved without its body"
 left=$(find "${tmpdir}/mirror" -name '*.delayed' -print)
 test -z "$left" || fail "placeholder names left in the mirror: $left"
+# both references, including the second one the stored placeholder came back for
+index="${tmpdir}/mirror/127.0.0.1_${SRV_PORT}/wizdelayed/index.html"
+local_refs=$(grep -o "127\.0\.0\.1_${foreign}/a\.html" "$index" | wc -l)
+test "$local_refs" -eq 2 ||
+    fail "$local_refs of the 2 references were rewritten to the mirrored page"
+
+# secondary: the engine's own account of the same failure
+log="${tmpdir}/mirror/hts-log.txt"
 ! grep -q 'Duplicate entry in hts_wait_delayed' "$log" ||
     fail "the link was recorded before its type was resolved"
 ! grep -q 'probably looping, type unknown' "$log" ||

--- a/tests/296_local-wizard-delayed.test
+++ b/tests/296_local-wizard-delayed.test
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# An authorized wizard link was recorded before its type was resolved, so it
+# reached the mirror under its <base>.<id>.delayed placeholder name.
+
+set -euo pipefail
+
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
+
+httrack=$(httrack_path)
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_wizdelayed.XXXXXX") || exit 1
+cleanup_push rm -rf "$tmpdir"
+
+# a second port is a second address to the wizard, hence a question
+mkdir -p "${tmpdir}/foreign"
+printf '<html><body>beyond</body></html>\n' >"${tmpdir}/foreign/a.html"
+local_server_start --root "${tmpdir}/foreign" --log "${tmpdir}/foreign.log"
+foreign=$SRV_PORT
+
+# the SAME link twice: the first reference records the placeholder name, the
+# second one recalls it and can no longer resolve the type
+mkdir -p "${tmpdir}/root/wizdelayed"
+cat >"${tmpdir}/root/wizdelayed/index.html" <<EOF
+<html><body>
+<a href="http://127.0.0.1:${foreign}/a.html">a</a>
+<a href="http://127.0.0.1:${foreign}/a.html">b</a>
+</body></html>
+EOF
+local_server_start --root "${tmpdir}/root"
+
+# "mirror this link", with spares: an empty answer means "ignore this link" and
+# EOF spins the prompt (#1247)
+answers="${tmpdir}/answers"
+for _ in $(seq 40); do echo 5; done >"$answers"
+
+# the redirection belongs to the engine, not to run_with_timeout: it backgrounds
+# the job, whose stdin is /dev/null wherever job control is off
+crawl() { "$httrack" "$@" <"$answers"; }
+
+rc=0
+run_with_timeout "$(crawl_deadline)" crawl --max-time="$CRAWL_MAX_TIME" \
+    -O "${tmpdir}/mirror" -W --robots=0 --retries=0 \
+    "http://127.0.0.1:${SRV_PORT}/wizdelayed/index.html" \
+    >"${tmpdir}/crawl.log" 2>&1 || rc=$?
+test "$rc" -ne 124 || fail "the crawl never returned"
+test "$rc" -eq 0 || fail "the crawl exited $rc"
+
+log="${tmpdir}/mirror/hts-log.txt"
+grep -q 'beyond this mirror scope' "${tmpdir}/crawl.log" ||
+    fail "the wizard never asked about the foreign link"
+test -f "${tmpdir}/mirror/127.0.0.1_${foreign}/a.html" ||
+    fail "the authorized link is missing from the mirror"
+left=$(find "${tmpdir}/mirror" -name '*.delayed' -print)
+test -z "$left" || fail "placeholder names left in the mirror: $left"
+! grep -q 'Duplicate entry in hts_wait_delayed' "$log" ||
+    fail "the link was recorded before its type was resolved"
+! grep -q 'probably looping, type unknown' "$log" ||
+    fail "the authorized link was dropped as looping"


### PR DESCRIPTION
Answer the wizard with anything that takes the link (4, 5, 6, 7, 50, or a host-scope include) and the verdict came back undecided at -1 rather than 0. The parser records a link on `!= 1` but only resolves its delayed type on `== 0`, so an authorized link went into the hash still called `<base>.<hexid>.delayed`. Every later reference gets that stored name back, `hts_wait_delayed()` then finds the link's own record and gives up ("Duplicate entry in hts_wait_delayed() cancelled", then "link is probably looping, type unknown, aborting"), and the page lands in the mirror as a placeholder file no browser opens. Answering "mirror this domain and below" on httrack.com is enough.

The question is only asked while the verdict is undecided, so an answer that did not forbid has authorized. `hts_wizard_apply_verdict()` now resolves that once at the end instead of in six cases plus the scope-include branch, and it still never overturns a verdict the crawl had already computed. An unreadable reply (-999) used to arrive here undecided too; #1259 makes it refuse the link, so it reaches this normalization already set to 1 and the two changes compose in either merge order.

Two other effects move with it, both in the same direction. `htsAddLink()` (htscore.c:3786) gates on `if (!forbidden_url)`, so under -1 a link handed back by an external module parser was never saved: it logged "(module): file not caught" and shipped as an absolute external URL. It is now saved and rewritten local, and the function returns 1 where it returned 0. The `check_link` callback also sees this value, and html/plug.html documents -1 as "no decision has yet been taken by the engine", so a plugin keyed on -1 used to get a say on wizard-answered links and now defers. The user answering is a decision, so I read that as a correction rather than a regression, but it crosses the public plugin surface.

The two gates are unchanged. Outside `-W` the verdict reaching them is already 0 or 1, so aligning them would change no link I could build. `--addurl` is a second door onto the same state, filed as #1253. The "looks like binary" and octet-stream pair from the field log did not reproduce here and is untouched.

tests/296 crawls two references to one authorized foreign link and checks the mirror: the page is there with its body, both hrefs point at it, and no placeholder survives. tests/293's battery now drives every answer from the undecided verdict the question is actually asked in. The mutant that matters most, an unconditional `*forbidden_url = 0` erasing a refusal, is caught by 293 alone. 296 never crawls a link the crawl had already refused, so it cannot see that one.
