### PR TITLE
Strings added since 3.49 are still English in every catalog

### DIFF
--- a/lang.def
+++ b/lang.def
@@ -740,6 +740,10 @@ LANG_M8
 Mirror domain
 LANG_M9
 Ignore all
+LANG_M10
+Mirror %s and every host below it
+LANG_M11
+Ignore %s and every host below it
 LANG_N1
 Wizard query
 LANG_N2

--- a/lang/Bulgarian.txt
+++ b/lang/Bulgarian.txt
@@ -946,6 +946,36 @@ Server terminated
 Сървърът не отговаря
 A fatal error has occurred during this mirror
 Фатална грешка при създаването на този огледален сайт
+View Documentation
+Преглед на документацията
+Go To HTTrack Website
+Към уебсайта на HTTrack
+Go To HTTrack Forum
+Към форума на HTTrack
+View License
+Преглед на лиценза
+Beware: you local browser might be unable to browse files with embedded filenames
+Внимание: вашият локален браузър може да не успее да отвори файлове с вградени имена на файлове
+Recreated HTTrack internal cached resources
+Вътрешните кеширани ресурси на HTTrack бяха създадени наново
+Could not create internal cached resources
+Вътрешните кеширани ресурси не можаха да бъдат създадени
+Could not get the system external storage directory
+Системната външна памет не можа да бъде намерена
+Could not write to:
+Не може да се пише в:
+Read-only media (SDCARD)
+Носител само за четене (SDCARD)
+No storage media (SDCARD)
+Няма носител за съхранение (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Докато този проблем не бъде отстранен, HTTrack може да не успее да сваля уебсайтове
+HTTrack: mirror '%s' stopped!
+HTTrack: огледалното копие „%s“ беше спряно!
+Click on this notification to restart the interrupted mirror
+Натиснете това известие, за да продължите прекъснатото огледално копие
+HTTrack: could not save profile for '%s'!
+HTTrack: профилът за „%s“ не можа да бъде запазен!
 Proxy type:
 Тип на прокси:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ WARC segment size limit:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Започване на нов WARC сегмент, когато текущият надхвърли този брой байтове; оставете празно или 0 за един файл.
 Host aliases:
-Host aliases:
+Псевдоними на хоста:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Други имена на хостове, които обслужват същия сайт, обединени в едно, по едно правило на ред (напр. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Огледално копие на %s и всички хостове под него
+Ignore %s and every host below it
+Игнорирай %s и всички хостове под него

--- a/lang/Bulgarian.txt
+++ b/lang/Bulgarian.txt
@@ -1049,6 +1049,6 @@ Host aliases:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
 Други имена на хостове, които обслужват същия сайт, обединени в едно, по едно правило на ред (напр. www2.example.com,m.example.com=example.com).
 Mirror %s and every host below it
-Огледално копие на %s и всички хостове под него
+Направи огледално копие на %s и на всички хостове под него
 Ignore %s and every host below it
 Игнорирай %s и всички хостове под него

--- a/lang/Castellano.txt
+++ b/lang/Castellano.txt
@@ -946,6 +946,36 @@ Server terminated
 Servidor desconectado
 A fatal error has occurred during this mirror
 Ha ocurrido un error fatal durante esta copia
+View Documentation
+Ver la documentación
+Go To HTTrack Website
+Ir al sitio web de HTTrack
+Go To HTTrack Forum
+Ir al foro de HTTrack
+View License
+Ver la licencia
+Beware: you local browser might be unable to browse files with embedded filenames
+Atención: puede que su navegador local no pueda abrir archivos con nombres de archivo incrustados
+Recreated HTTrack internal cached resources
+Recursos internos en caché de HTTrack recreados
+Could not create internal cached resources
+No se han podido crear los recursos internos en caché
+Could not get the system external storage directory
+No se ha podido acceder al almacenamiento externo del sistema
+Could not write to:
+No se ha podido escribir en:
+Read-only media (SDCARD)
+Soporte de solo lectura (SDCARD)
+No storage media (SDCARD)
+No hay soporte de almacenamiento (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Puede que HTTrack no pueda descargar sitios web mientras no se corrija este problema
+HTTrack: mirror '%s' stopped!
+HTTrack: ¡el volcado «%s» se ha detenido!
+Click on this notification to restart the interrupted mirror
+Pulse esta notificación para reanudar el volcado interrumpido
+HTTrack: could not save profile for '%s'!
+HTTrack: ¡no se ha podido guardar el perfil de «%s»!
 Proxy type:
 Tipo de proxy:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ Tamaño máximo de segmento WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Empezar un nuevo segmento WARC cuando el actual supere este número de bytes; déjelo en blanco o 0 para un solo archivo.
 Host aliases:
-Host aliases:
+Alias de host:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Otros nombres de host que sirven este mismo sitio, unificados en uno solo, una regla por línea (p. ej. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Volcar %s y todos los hosts por debajo
+Ignore %s and every host below it
+Ignorar %s y todos los hosts por debajo

--- a/lang/Cesky.txt
+++ b/lang/Cesky.txt
@@ -1049,6 +1049,6 @@ Aliasy hostitele:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
 Další názvy hostitelù poskytující tentýž web, slouèené do jednoho, jedno pravidlo na øádek (napø. www2.example.com,m.example.com=example.com).
 Mirror %s and every host below it
-Zrcadlit %s a všechny hostitele pod ní
+Zrcadlit %s a všechny hostitele pod ním
 Ignore %s and every host below it
-Ignorovat %s a všechny hostitele pod ní
+Ignorovat %s a všechny hostitele pod ním

--- a/lang/Cesky.txt
+++ b/lang/Cesky.txt
@@ -946,6 +946,36 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+View Documentation
+Zobrazit dokumentaci
+Go To HTTrack Website
+Pøejít na web HTTrack
+Go To HTTrack Forum
+Pøejít na fórum HTTrack
+View License
+Zobrazit licenci
+Beware: you local browser might be unable to browse files with embedded filenames
+Pozor: váš místní prohlížeè nemusí umìt otevøít soubory s vloženými názvy souborù
+Recreated HTTrack internal cached resources
+Interní zdroje v mezipamìti HTTrack byly znovu vytvoøeny
+Could not create internal cached resources
+Interní zdroje v mezipamìti se nepodaøilo vytvoøit
+Could not get the system external storage directory
+Nepodaøilo se najít systémové externí úložištì
+Could not write to:
+Nelze zapisovat do:
+Read-only media (SDCARD)
+Médium jen pro ètení (SDCARD)
+No storage media (SDCARD)
+Žádné úložné médium (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Dokud nebude tento problém vyøešen, nemusí HTTrack stahovat weby
+HTTrack: mirror '%s' stopped!
+HTTrack: zrcadlení „%s“ bylo zastaveno!
+Click on this notification to restart the interrupted mirror
+Klepnutím na toto oznámení obnovíte pøerušené zrcadlení
+HTTrack: could not save profile for '%s'!
+HTTrack: profil pro „%s“ se nepodaøilo uložit!
 Proxy type:
 Typ proxy:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ Nejvìtší velikost segmentu WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Zaèít nový segment WARC, jakmile aktuální pøekroèí tento poèet bajtù; ponechte prázdné nebo 0 pro jeden soubor.
 Host aliases:
-Host aliases:
+Aliasy hostitele:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Další názvy hostitelù poskytující tentýž web, slouèené do jednoho, jedno pravidlo na øádek (napø. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Zrcadlit %s a všechny hostitele pod ní
+Ignore %s and every host below it
+Ignorovat %s a všechny hostitele pod ní

--- a/lang/Chinese-BIG5.txt
+++ b/lang/Chinese-BIG5.txt
@@ -946,6 +946,36 @@ Server terminated
 伺服器已終止
 A fatal error has occurred during this mirror
 這鏡像發生了不可回復的錯誤
+View Documentation
+檢視說明文件
+Go To HTTrack Website
+前往 HTTrack 網站
+Go To HTTrack Forum
+前往 HTTrack 論壇
+View License
+檢視授權條款
+Beware: you local browser might be unable to browse files with embedded filenames
+注意：本機瀏覽器可能無法開啟檔名內嵌的檔案
+Recreated HTTrack internal cached resources
+已重新建立 HTTrack 內部快取資源
+Could not create internal cached resources
+無法建立內部快取資源
+Could not get the system external storage directory
+無法取得系統外部儲存空間目錄
+Could not write to:
+無法寫入：
+Read-only media (SDCARD)
+唯讀媒體 (SDCARD)
+No storage media (SDCARD)
+沒有儲存媒體 (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+在此問題修正前，HTTrack 可能無法下載網站
+HTTrack: mirror '%s' stopped!
+HTTrack：鏡像「%s」已停止！
+Click on this notification to restart the interrupted mirror
+點選此通知以重新啟動中斷的鏡像
+HTTrack: could not save profile for '%s'!
+HTTrack：無法儲存「%s」的設定檔！
 Proxy type:
 proxy 類型:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ WARC 分段大小上限：
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 目前分段超過此位元組數時開始新的 WARC 分段；留空或填 0 則保持單一檔案。
 Host aliases:
-Host aliases:
+主機別名：
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+提供同一網站的其他主機名稱，合併為一個，每行一條規則（例如 www2.example.com,m.example.com=example.com）。
+Mirror %s and every host below it
+鏡像 %s 及其下所有主機
+Ignore %s and every host below it
+忽略 %s 及其下所有主機

--- a/lang/Chinese-BIG5.txt
+++ b/lang/Chinese-BIG5.txt
@@ -679,7 +679,7 @@ Mirror site
 Mirror domain
 鏡像網域名稱
 Ignore all
-全部乎略
+全部忽略
 Wizard query
 精靈提問
 NO

--- a/lang/Chinese-Simplified.txt
+++ b/lang/Chinese-Simplified.txt
@@ -946,6 +946,36 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+View Documentation
+查看文档
+Go To HTTrack Website
+前往 HTTrack 网站
+Go To HTTrack Forum
+前往 HTTrack 论坛
+View License
+查看许可协议
+Beware: you local browser might be unable to browse files with embedded filenames
+注意：本地浏览器可能无法打开文件名内嵌的文件
+Recreated HTTrack internal cached resources
+已重新创建 HTTrack 内部缓存资源
+Could not create internal cached resources
+无法创建内部缓存资源
+Could not get the system external storage directory
+无法获取系统外部存储目录
+Could not write to:
+无法写入：
+Read-only media (SDCARD)
+只读介质 (SDCARD)
+No storage media (SDCARD)
+没有存储介质 (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+在此问题修复前，HTTrack 可能无法下载网站
+HTTrack: mirror '%s' stopped!
+HTTrack：镜像“%s”已停止！
+Click on this notification to restart the interrupted mirror
+点击此通知以重新启动中断的镜像
+HTTrack: could not save profile for '%s'!
+HTTrack：无法保存“%s”的配置文件！
 Proxy type:
 代理类型:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ WARC 分段大小上限：
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 当前分段超过该字节数时开始新的 WARC 分段；留空或填 0 则保持单个文件。
 Host aliases:
-Host aliases:
+主机别名：
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+提供同一网站的其他主机名，合并为一个，每行一条规则（例如 www2.example.com,m.example.com=example.com）。
+Mirror %s and every host below it
+镜像 %s 及其下所有主机
+Ignore %s and every host below it
+忽略 %s 及其下所有主机

--- a/lang/Croatian.txt
+++ b/lang/Croatian.txt
@@ -946,6 +946,36 @@ Server terminated
 Poslužitelj je razriješen
 A fatal error has occurred during this mirror
 Tijekom ovog zrcaljenja je nastala fatalna pogreška
+View Documentation
+Prikaži dokumentaciju
+Go To HTTrack Website
+Otvori mrežno mjesto HTTrack
+Go To HTTrack Forum
+Otvori forum HTTrack
+View License
+Prikaži licencu
+Beware: you local browser might be unable to browse files with embedded filenames
+Pozor: vaš lokalni preglednik možda neæe moæi otvoriti datoteke s ugraðenim nazivima datoteka
+Recreated HTTrack internal cached resources
+Interni predmemorirani resursi HTTracka ponovno su stvoreni
+Could not create internal cached resources
+Interne predmemorirane resurse nije moguæe stvoriti
+Could not get the system external storage directory
+Nije moguæe pronaæi vanjski sustav pohrane
+Could not write to:
+Nije moguæe pisati u:
+Read-only media (SDCARD)
+Medij samo za èitanje (SDCARD)
+No storage media (SDCARD)
+Nema medija za pohranu (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Dok se taj problem ne riješi, HTTrack možda neæe moæi preuzimati mrežna mjesta
+HTTrack: mirror '%s' stopped!
+HTTrack: zrcaljenje „%s” je zaustavljeno!
+Click on this notification to restart the interrupted mirror
+Dodirnite tu obavijest za nastavak prekinutog zrcaljenja
+HTTrack: could not save profile for '%s'!
+HTTrack: profil za „%s” nije moguæe spremiti!
 Proxy type:
 Vrsta posrednika:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ Najveæa velièina WARC segmenta:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Zapoèni novi WARC segment kada trenutni prijeðe ovaj broj bajtova; ostavite prazno ili 0 za jednu datoteku.
 Host aliases:
-Host aliases:
+Nadimci poslužitelja:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Ostala imena poslužitelja koja poslužuju isto mrežno mjesto, sažeta u jedno, jedno pravilo po retku (npr. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Zrcali %s i sve poslužitelje ispod nje
+Ignore %s and every host below it
+Zanemari %s i sve poslužitelje ispod nje

--- a/lang/Croatian.txt
+++ b/lang/Croatian.txt
@@ -961,7 +961,7 @@ Interni predmemorirani resursi HTTracka ponovno su stvoreni
 Could not create internal cached resources
 Interne predmemorirane resurse nije moguæe stvoriti
 Could not get the system external storage directory
-Nije moguæe pronaæi vanjski sustav pohrane
+Nije moguæe pronaæi vanjsku pohranu sustava
 Could not write to:
 Nije moguæe pisati u:
 Read-only media (SDCARD)
@@ -1045,10 +1045,10 @@ Najveæa velièina WARC segmenta:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Zapoèni novi WARC segment kada trenutni prijeðe ovaj broj bajtova; ostavite prazno ili 0 za jednu datoteku.
 Host aliases:
-Nadimci poslužitelja:
+Aliasi poslužitelja:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
 Ostala imena poslužitelja koja poslužuju isto mrežno mjesto, sažeta u jedno, jedno pravilo po retku (npr. www2.example.com,m.example.com=example.com).
 Mirror %s and every host below it
-Zrcali %s i sve poslužitelje ispod nje
+Zrcali %s i sve poslužitelje ispod njega
 Ignore %s and every host below it
-Zanemari %s i sve poslužitelje ispod nje
+Zanemari %s i sve poslužitelje ispod njega

--- a/lang/Dansk.txt
+++ b/lang/Dansk.txt
@@ -1045,6 +1045,10 @@ Største størrelse på WARC-segment:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Begynd et nyt WARC-segment, når det aktuelle overstiger dette antal byte; lad feltet stå tomt eller skriv 0 for én fil.
 Host aliases:
-Host aliases:
+Værtsaliasser:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Andre værtsnavne der betjener det samme websted, samlet til ét, én regel pr. linje (f.eks. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Spejlkopiér %s og alle værter under den
+Ignore %s and every host below it
+Ignorer %s og alle værter under den

--- a/lang/Deutsch.txt
+++ b/lang/Deutsch.txt
@@ -946,6 +946,36 @@ Server terminated
 Der Server wurde beendet
 A fatal error has occurred during this mirror
 Fataler Fehler während der Webseiten-Kopie
+View Documentation
+Dokumentation anzeigen
+Go To HTTrack Website
+Zur HTTrack-Website
+Go To HTTrack Forum
+Zum HTTrack-Forum
+View License
+Lizenz anzeigen
+Beware: you local browser might be unable to browse files with embedded filenames
+Achtung: Ihr lokaler Browser kann Dateien mit eingebetteten Dateinamen möglicherweise nicht öffnen
+Recreated HTTrack internal cached resources
+Interne zwischengespeicherte Ressourcen von HTTrack neu angelegt
+Could not create internal cached resources
+Interne zwischengespeicherte Ressourcen konnten nicht angelegt werden
+Could not get the system external storage directory
+Der externe Systemspeicher konnte nicht ermittelt werden
+Could not write to:
+Schreiben nicht möglich nach:
+Read-only media (SDCARD)
+Schreibgeschützter Datenträger (SDCARD)
+No storage media (SDCARD)
+Kein Datenträger vorhanden (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Solange dieses Problem besteht, kann HTTrack möglicherweise keine Websites herunterladen
+HTTrack: mirror '%s' stopped!
+HTTrack: Kopie "%s" wurde angehalten!
+Click on this notification to restart the interrupted mirror
+Tippen Sie auf diese Benachrichtigung, um die unterbrochene Kopie fortzusetzen
+HTTrack: could not save profile for '%s'!
+HTTrack: Profil für "%s" konnte nicht gespeichert werden!
 Proxy type:
 Proxy-Typ:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ Maximale Größe eines WARC-Segments:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Ein neues WARC-Segment beginnen, sobald das aktuelle diese Anzahl Bytes überschreitet; leer lassen oder 0 für eine einzige Datei.
 Host aliases:
-Host aliases:
+Host-Aliase:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Weitere Hostnamen derselben Website, auf einen zusammengefasst, eine Regel pro Zeile (z. B. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+%s und alle darunter liegenden Hosts kopieren
+Ignore %s and every host below it
+%s und alle darunter liegenden Hosts ignorieren

--- a/lang/Deutsch.txt
+++ b/lang/Deutsch.txt
@@ -963,7 +963,7 @@ Interne zwischengespeicherte Ressourcen konnten nicht angelegt werden
 Could not get the system external storage directory
 Der externe Systemspeicher konnte nicht ermittelt werden
 Could not write to:
-Schreiben nicht möglich nach:
+Schreiben nicht möglich in:
 Read-only media (SDCARD)
 Schreibgeschützter Datenträger (SDCARD)
 No storage media (SDCARD)

--- a/lang/Eesti.txt
+++ b/lang/Eesti.txt
@@ -946,6 +946,36 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+View Documentation
+Vaata dokumentatsiooni
+Go To HTTrack Website
+Ava HTTracki veebisait
+Go To HTTrack Forum
+Ava HTTracki foorum
+View License
+Vaata litsentsi
+Beware: you local browser might be unable to browse files with embedded filenames
+Tähelepanu: kohalik brauser ei pruugi suuta avada faile, mille nimi on faili sisse põimitud
+Recreated HTTrack internal cached resources
+HTTracki sisemised puhverdatud ressursid loodi uuesti
+Could not create internal cached resources
+Sisemisi puhverdatud ressursse ei õnnestunud luua
+Could not get the system external storage directory
+Süsteemi välist salvestusruumi ei leitud
+Could not write to:
+Ei saa kirjutada asukohta:
+Read-only media (SDCARD)
+Kirjutuskaitstud andmekandja (SDCARD)
+No storage media (SDCARD)
+Andmekandjat pole (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Kuni see probleem püsib, ei pruugi HTTrack veebisaite alla laadida
+HTTrack: mirror '%s' stopped!
+HTTrack: koopia "%s" peatati!
+Click on this notification to restart the interrupted mirror
+Katkenud koopia jätkamiseks puuduta seda teadet
+HTTrack: could not save profile for '%s'!
+HTTrack: profiili "%s" ei õnnestunud salvestada!
 Proxy type:
 Proxy tüüp:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ WARC-segmendi suurim maht:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Alusta uut WARC-segmenti, kui praegune ületab selle baitide arvu; jäta tühjaks või 0, et hoida üks fail.
 Host aliases:
-Host aliases:
+Hosti aliased:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Muud sama saiti teenindavad hostinimed, koondatud üheks, üks reegel rea kohta (nt www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Kopeeri %s ja kõik selle all olevad hostid
+Ignore %s and every host below it
+Ignoreeri %s ja kõiki selle all olevaid hoste

--- a/lang/English.txt
+++ b/lang/English.txt
@@ -1048,3 +1048,7 @@ Host aliases:
 Host aliases:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Mirror %s and every host below it
+Ignore %s and every host below it
+Ignore %s and every host below it

--- a/lang/Finnish.txt
+++ b/lang/Finnish.txt
@@ -946,6 +946,36 @@ Server terminated
 Palvelin lopetettu
 A fatal error has occurred during this mirror
 Tällä peilillä tapahtui vakava virhe
+View Documentation
+Näytä ohjeet
+Go To HTTrack Website
+Siirry HTTrackin sivustolle
+Go To HTTrack Forum
+Siirry HTTrackin foorumille
+View License
+Näytä lisenssi
+Beware: you local browser might be unable to browse files with embedded filenames
+Huomio: paikallinen selaimesi ei ehkä pysty avaamaan tiedostoja, joiden nimi on upotettu
+Recreated HTTrack internal cached resources
+HTTrackin sisäiset välimuistiresurssit luotiin uudelleen
+Could not create internal cached resources
+Sisäisiä välimuistiresursseja ei voitu luoda
+Could not get the system external storage directory
+Järjestelmän ulkoista tallennushakemistoa ei löytynyt
+Could not write to:
+Ei voi kirjoittaa kohteeseen:
+Read-only media (SDCARD)
+Vain luku -media (SDCARD)
+No storage media (SDCARD)
+Ei tallennusmediaa (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+HTTrack ei ehkä pysty lataamaan sivustoja ennen kuin tämä ongelma on korjattu
+HTTrack: mirror '%s' stopped!
+HTTrack: peilaus "%s" pysäytettiin!
+Click on this notification to restart the interrupted mirror
+Jatka keskeytynyttä peilausta napauttamalla tätä ilmoitusta
+HTTrack: could not save profile for '%s'!
+HTTrack: profiilia "%s" ei voitu tallentaa!
 Proxy type:
 Välityspalvelimen tyyppi:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ WARC-osan enimmäiskoko:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Aloita uusi WARC-osa, kun nykyinen ylittää tämän tavumäärän; jätä tyhjäksi tai 0, jolloin tiedosto pysyy yhtenä.
 Host aliases:
-Host aliases:
+Palvelimen aliakset:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Muut samaa sivustoa palvelevat palvelinnimet yhdistettynä yhdeksi, yksi sääntö riviä kohden (esim. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Peilaa %s ja kaikki sen alla olevat palvelimet
+Ignore %s and every host below it
+Sivuuta %s ja kaikki sen alla olevat palvelimet

--- a/lang/Francais.txt
+++ b/lang/Francais.txt
@@ -1045,6 +1045,10 @@ Taille maximale d'un segment WARC :
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Commencer un nouveau segment WARC dès que le courant dépasse ce nombre d'octets ; laissez vide ou 0 pour un fichier unique.
 Host aliases:
-Host aliases:
+Alias d'hôtes :
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Autres noms d'hôtes servant ce même site, ramenés à un seul, une règle par ligne (ex. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Copier %s et tous les hôtes en dessous
+Ignore %s and every host below it
+Ignorer %s et tous les hôtes en dessous

--- a/lang/Greek.txt
+++ b/lang/Greek.txt
@@ -946,6 +946,36 @@ Server terminated
 Ακυρώθηκε από τον εξυπηρετητή
 A fatal error has occurred during this mirror
 Ένα καταστροφικό σφάλμα προκλήθηκε κατά την αντιγραφή αυτού του τόπου
+View Documentation
+Προβολή τεκμηρίωσης
+Go To HTTrack Website
+Μετάβαση στον ιστότοπο του HTTrack
+Go To HTTrack Forum
+Μετάβαση στο φόρουμ του HTTrack
+View License
+Προβολή άδειας χρήσης
+Beware: you local browser might be unable to browse files with embedded filenames
+Προσοχή: ο τοπικός σας browser ίσως δεν μπορεί να ανοίξει αρχεία με ενσωματωμένα ονόματα αρχείων
+Recreated HTTrack internal cached resources
+Οι εσωτερικοί προσωρινοί πόροι του HTTrack δημιουργήθηκαν ξανά
+Could not create internal cached resources
+Δεν ήταν δυνατή η δημιουργία των εσωτερικών προσωρινών πόρων
+Could not get the system external storage directory
+Δεν ήταν δυνατή η εύρεση του εξωτερικού χώρου αποθήκευσης του συστήματος
+Could not write to:
+Δεν ήταν δυνατή η εγγραφή στο:
+Read-only media (SDCARD)
+Μέσο μόνο για ανάγνωση (SDCARD)
+No storage media (SDCARD)
+Δεν υπάρχει μέσο αποθήκευσης (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Μέχρι να διορθωθεί αυτό το πρόβλημα, το HTTrack ίσως δεν μπορεί να κατεβάσει ιστότοπους
+HTTrack: mirror '%s' stopped!
+HTTrack: η αντιγραφή «%s» σταμάτησε!
+Click on this notification to restart the interrupted mirror
+Πατήστε αυτή την ειδοποίηση για να συνεχίσετε τη διακοπείσα αντιγραφή
+HTTrack: could not save profile for '%s'!
+HTTrack: δεν ήταν δυνατή η αποθήκευση του προφίλ «%s»!
 Proxy type:
 Τύπος proxy:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ WARC segment size limit:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Έναρξη νέου τμήματος WARC μόλις το τρέχον ξεπεράσει αυτόν τον αριθμό byte. Αφήστε κενό ή 0 για ένα ενιαίο αρχείο.
 Host aliases:
-Host aliases:
+Ψευδώνυμα host:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Άλλα ονόματα host που εξυπηρετούν την ίδια τοποθεσία, ενοποιημένα σε ένα, ένας κανόνας ανά γραμμή (π.χ. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Αντιγραφή του %s και κάθε host κάτω από αυτό
+Ignore %s and every host below it
+Αγνόηση του %s και κάθε host κάτω από αυτό

--- a/lang/Italiano.txt
+++ b/lang/Italiano.txt
@@ -946,6 +946,36 @@ Server terminated
 Server disconnesso
 A fatal error has occurred during this mirror
 Si è verificato un errore fatale durante la copia
+View Documentation
+Visualizza la documentazione
+Go To HTTrack Website
+Vai al sito di HTTrack
+Go To HTTrack Forum
+Vai al forum di HTTrack
+View License
+Visualizza la licenza
+Beware: you local browser might be unable to browse files with embedded filenames
+Attenzione: il browser locale potrebbe non riuscire ad aprire i file con nomi di file incorporati
+Recreated HTTrack internal cached resources
+Risorse interne nella cache di HTTrack ricreate
+Could not create internal cached resources
+Impossibile creare le risorse interne nella cache
+Could not get the system external storage directory
+Impossibile individuare la memoria esterna di sistema
+Could not write to:
+Impossibile scrivere in:
+Read-only media (SDCARD)
+Supporto di sola lettura (SDCARD)
+No storage media (SDCARD)
+Nessun supporto di memorizzazione (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Finché il problema non è risolto, HTTrack potrebbe non riuscire a scaricare siti web
+HTTrack: mirror '%s' stopped!
+HTTrack: mirror "%s" interrotto!
+Click on this notification to restart the interrupted mirror
+Tocca questa notifica per riprendere il mirror interrotto
+HTTrack: could not save profile for '%s'!
+HTTrack: impossibile salvare il profilo di "%s"!
 Proxy type:
 Tipo di proxy:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ Dimensione massima del segmento WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Inizia un nuovo segmento WARC quando quello corrente supera questo numero di byte; lascia vuoto o 0 per un solo file.
 Host aliases:
-Host aliases:
+Alias host:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Altri nomi host che servono questo stesso sito, ricondotti a uno solo, una regola per riga (es. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Mirror di %s e di tutti gli host sottostanti
+Ignore %s and every host below it
+Ignora %s e tutti gli host sottostanti

--- a/lang/Japanese.txt
+++ b/lang/Japanese.txt
@@ -946,6 +946,36 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+View Documentation
+ドキュメントの表示
+Go To HTTrack Website
+HTTrack のウェブサイトを開く
+Go To HTTrack Forum
+HTTrack のフォーラムを開く
+View License
+ライセンスの表示
+Beware: you local browser might be unable to browse files with embedded filenames
+注意: ローカルのブラウザではファイル名が埋め込まれたファイルを開けない場合があります
+Recreated HTTrack internal cached resources
+HTTrack の内部キャッシュを再作成しました
+Could not create internal cached resources
+内部キャッシュを作成できませんでした
+Could not get the system external storage directory
+システムの外部ストレージが見つかりませんでした
+Could not write to:
+次の場所に書き込めません:
+Read-only media (SDCARD)
+読み取り専用のメディア (SDCARD)
+No storage media (SDCARD)
+ストレージメディアがありません (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+この問題が解決するまで、HTTrack はサイトをダウンロードできない場合があります
+HTTrack: mirror '%s' stopped!
+HTTrack: ミラー「%s」を停止しました
+Click on this notification to restart the interrupted mirror
+中断したミラーを再開するには、この通知をタップしてください
+HTTrack: could not save profile for '%s'!
+HTTrack:「%s」のプロファイルを保存できませんでした
 Proxy type:
 プロキシの種類:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ WARC セグメントの最大サイズ:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 現在のセグメントがこのバイト数を超えたら新しい WARC セグメントを開始します。空欄または 0 で単一ファイルのままにします。
 Host aliases:
-Host aliases:
+ホストの別名:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+同じサイトを配信する他のホスト名を 1 つにまとめます。1 行につき 1 つの規則 (例: www2.example.com,m.example.com=example.com)。
+Mirror %s and every host below it
+%s とその配下のすべてのホストをコピー（ミラー）
+Ignore %s and every host below it
+%s とその配下のすべてのホストを無視

--- a/lang/Macedonian.txt
+++ b/lang/Macedonian.txt
@@ -946,6 +946,36 @@ Server terminated
 Серверот е прекинат
 A fatal error has occurred during this mirror
 Настана фатална грешка при овој mirror
+View Documentation
+Прикажи ја документацијата
+Go To HTTrack Website
+Оди на веб-страницата на HTTrack
+Go To HTTrack Forum
+Оди на форумот на HTTrack
+View License
+Прикажи ја лиценцата
+Beware: you local browser might be unable to browse files with embedded filenames
+Внимание: вашиот локален прелистувач можеби нема да може да отвори датотеки со вградени имиња на датотеки
+Recreated HTTrack internal cached resources
+Внатрешните кеширани ресурси на HTTrack се создадени повторно
+Could not create internal cached resources
+Внатрешните кеширани ресурси не можеа да се создадат
+Could not get the system external storage directory
+Системската надворешна меморија не можеше да се најде
+Could not write to:
+Не може да се запише во:
+Read-only media (SDCARD)
+Носач само за читање (SDCARD)
+No storage media (SDCARD)
+Нема носач за складирање (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Додека не се реши овој проблем, HTTrack можеби нема да може да презема веб-страници
+HTTrack: mirror '%s' stopped!
+HTTrack: копијата „%s“ е запрена!
+Click on this notification to restart the interrupted mirror
+Допрете го ова известување за да ја продолжите прекинатата копија
+HTTrack: could not save profile for '%s'!
+HTTrack: профилот за „%s“ не можеше да се зачува!
 Proxy type:
 Тип на прокси:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ WARC segment size limit:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Започни нов WARC сегмент кога тековниот ќе го надмине овој број бајти; оставете празно или 0 за една датотека.
 Host aliases:
-Host aliases:
+Алијаси на хостот:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Други имиња на хостови што ја служат истата страница, споени во едно, по едно правило во ред (пр. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Копирај го %s и сите хостови под него
+Ignore %s and every host below it
+Игнорирај го %s и сите хостови под него

--- a/lang/Macedonian.txt
+++ b/lang/Macedonian.txt
@@ -1047,7 +1047,7 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Host aliases:
 Алијаси на хостот:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Други имиња на хостови што ја служат истата страница, споени во едно, по едно правило во ред (пр. www2.example.com,m.example.com=example.com).
+Други имиња на хостови што го опслужуваат истиот сајт, споени во едно, по едно правило во ред (пр. www2.example.com,m.example.com=example.com).
 Mirror %s and every host below it
 Копирај го %s и сите хостови под него
 Ignore %s and every host below it

--- a/lang/Magyar.txt
+++ b/lang/Magyar.txt
@@ -946,6 +946,36 @@ Server terminated
 A kiszolgáló befejezte a kapcsolatot
 A fatal error has occurred during this mirror
 Végzetes hiba történt a tükrözés közben
+View Documentation
+Dokumentáció megtekintése
+Go To HTTrack Website
+Ugrás a HTTrack webhelyére
+Go To HTTrack Forum
+Ugrás a HTTrack fórumára
+View License
+Licenc megtekintése
+Beware: you local browser might be unable to browse files with embedded filenames
+Figyelem: a helyi böngészõ nem biztos, hogy meg tudja nyitni a beágyazott fájlneveket tartalmazó fájlokat
+Recreated HTTrack internal cached resources
+A HTTrack belsõ gyorsítótárazott erõforrásai újra létrejöttek
+Could not create internal cached resources
+A belsõ gyorsítótárazott erõforrásokat nem sikerült létrehozni
+Could not get the system external storage directory
+A rendszer külsõ tárhelye nem található
+Could not write to:
+Nem lehet írni ide:
+Read-only media (SDCARD)
+Csak olvasható adathordozó (SDCARD)
+No storage media (SDCARD)
+Nincs adathordozó (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Amíg ez a hiba fennáll, a HTTrack esetleg nem tud webhelyeket letölteni
+HTTrack: mirror '%s' stopped!
+HTTrack: a(z) "%s" tükrözés leállt!
+Click on this notification to restart the interrupted mirror
+A megszakadt tükrözés folytatásához koppintson erre az értesítésre
+HTTrack: could not save profile for '%s'!
+HTTrack: a(z) "%s" profilját nem sikerült menteni!
 Proxy type:
 Proxy típusa:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ WARC szegmens legnagyobb mérete:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Új WARC szegmens kezdése, amint az aktuális túllépi ezt a bájtszámot; hagyja üresen vagy adjon meg 0-t egyetlen fájlhoz.
 Host aliases:
-Host aliases:
+Kiszolgálói álnevek:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Ugyanazt a webhelyet kiszolgáló további kiszolgálónevek egybeolvasztva, soronként egy szabály (pl. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+%s és minden alatta lévõ kiszolgáló tükrözése
+Ignore %s and every host below it
+%s és minden alatta lévõ kiszolgáló kihagyása

--- a/lang/Nederlands.txt
+++ b/lang/Nederlands.txt
@@ -946,6 +946,36 @@ Server terminated
 Server beeindigd
 A fatal error has occurred during this mirror
 Een fatale fout is opgetreden tijdens deze spiegeling
+View Documentation
+Documentatie bekijken
+Go To HTTrack Website
+Ga naar de HTTrack-website
+Go To HTTrack Forum
+Ga naar het HTTrack-forum
+View License
+Licentie bekijken
+Beware: you local browser might be unable to browse files with embedded filenames
+Let op: uw lokale browser kan bestanden met ingesloten bestandsnamen mogelijk niet openen
+Recreated HTTrack internal cached resources
+Interne buffer van HTTrack opnieuw aangemaakt
+Could not create internal cached resources
+Kan de interne buffer niet aanmaken
+Could not get the system external storage directory
+Kan de externe opslag van het systeem niet vinden
+Could not write to:
+Kan niet schrijven naar:
+Read-only media (SDCARD)
+Alleen-lezen medium (SDCARD)
+No storage media (SDCARD)
+Geen opslagmedium (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Zolang dit probleem niet is opgelost, kan HTTrack mogelijk geen websites downloaden
+HTTrack: mirror '%s' stopped!
+HTTrack: spiegeling "%s" gestopt!
+Click on this notification to restart the interrupted mirror
+Tik op deze melding om de onderbroken spiegeling te hervatten
+HTTrack: could not save profile for '%s'!
+HTTrack: kan het profiel voor "%s" niet opslaan!
 Proxy type:
 Proxytype:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ Maximale grootte van een WARC-segment:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Een nieuw WARC-segment beginnen zodra het huidige dit aantal bytes overschrijdt; laat leeg of 0 voor één bestand.
 Host aliases:
-Host aliases:
+Host-aliassen:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Andere hostnamen die dezelfde site aanbieden, samengevoegd tot één, één regel per lijn (bijv. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+%s en alle onderliggende hosts spiegelen
+Ignore %s and every host below it
+%s en alle onderliggende hosts uitsluiten

--- a/lang/Nederlands.txt
+++ b/lang/Nederlands.txt
@@ -1047,7 +1047,7 @@ Een nieuw WARC-segment beginnen zodra het huidige dit aantal bytes overschrijdt;
 Host aliases:
 Host-aliassen:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Andere hostnamen die dezelfde site aanbieden, samengevoegd tot één, één regel per lijn (bijv. www2.example.com,m.example.com=example.com).
+Andere hostnamen die dezelfde site aanbieden, samengevoegd tot één; één vermelding per regel (bijv. www2.example.com,m.example.com=example.com).
 Mirror %s and every host below it
 %s en alle onderliggende hosts spiegelen
 Ignore %s and every host below it

--- a/lang/Norsk.txt
+++ b/lang/Norsk.txt
@@ -967,7 +967,7 @@ Klarte ikke å skrive til:
 Read-only media (SDCARD)
 Skrivebeskyttet medium (SDCARD)
 No storage media (SDCARD)
-Ingen lagringsmedium (SDCARD)
+Intet lagringsmedium (SDCARD)
 HTTrack may not be able to download websites until this problem is fixed
 Så lenge dette problemet varer, klarer HTTrack kanskje ikke å laste ned nettsteder
 HTTrack: mirror '%s' stopped!

--- a/lang/Norsk.txt
+++ b/lang/Norsk.txt
@@ -946,6 +946,36 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+View Documentation
+Vis dokumentasjonen
+Go To HTTrack Website
+Gå til HTTracks nettsted
+Go To HTTrack Forum
+Gå til HTTracks forum
+View License
+Vis lisensen
+Beware: you local browser might be unable to browse files with embedded filenames
+Merk: den lokale nettleseren din klarer kanskje ikke å åpne filer med innebygde filnavn
+Recreated HTTrack internal cached resources
+HTTracks interne bufrede ressurser er opprettet på nytt
+Could not create internal cached resources
+Klarte ikke å opprette de interne bufrede ressursene
+Could not get the system external storage directory
+Fant ikke systemets eksterne lagringsmappe
+Could not write to:
+Klarte ikke å skrive til:
+Read-only media (SDCARD)
+Skrivebeskyttet medium (SDCARD)
+No storage media (SDCARD)
+Ingen lagringsmedium (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Så lenge dette problemet varer, klarer HTTrack kanskje ikke å laste ned nettsteder
+HTTrack: mirror '%s' stopped!
+HTTrack: kopien "%s" ble stoppet!
+Click on this notification to restart the interrupted mirror
+Trykk på dette varselet for å fortsette den avbrutte kopien
+HTTrack: could not save profile for '%s'!
+HTTrack: klarte ikke å lagre profilen for "%s"!
 Proxy type:
 Proxytype:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ Største størrelse på WARC-segment:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Begynn et nytt WARC-segment når det gjeldende overstiger dette antallet byte; la feltet stå tomt eller 0 for én fil.
 Host aliases:
-Host aliases:
+Vertsaliaser:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Andre vertsnavn som betjener det samme nettstedet, slått sammen til ett, én regel per linje (f.eks. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Kopier %s og alle verter under den
+Ignore %s and every host below it
+Ignorer %s og alle verter under den

--- a/lang/Polski.txt
+++ b/lang/Polski.txt
@@ -946,6 +946,36 @@ Server terminated
 Serwer zakonczyl prace
 A fatal error has occurred during this mirror
 Podczas tworzenia lustra wydarzyl sie fatalny blad.
+View Documentation
+Poka¿ dokumentacjê
+Go To HTTrack Website
+PrzejdŸ do witryny HTTrack
+Go To HTTrack Forum
+PrzejdŸ do forum HTTrack
+View License
+Poka¿ licencjê
+Beware: you local browser might be unable to browse files with embedded filenames
+Uwaga: lokalna przegl¹darka mo¿e nie otworzyæ plików z osadzonymi nazwami plików
+Recreated HTTrack internal cached resources
+Wewnêtrzne zasoby podrêczne HTTrack zosta³y utworzone ponownie
+Could not create internal cached resources
+Nie mo¿na utworzyæ wewnêtrznych zasobów podrêcznych
+Could not get the system external storage directory
+Nie mo¿na odnaleŸæ zewnêtrznej pamiêci systemu
+Could not write to:
+Nie mo¿na zapisaæ do:
+Read-only media (SDCARD)
+Noœnik tylko do odczytu (SDCARD)
+No storage media (SDCARD)
+Brak noœnika pamiêci (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Dopóki ten problem nie zostanie rozwi¹zany, HTTrack mo¿e nie pobieraæ witryn
+HTTrack: mirror '%s' stopped!
+HTTrack: lustro „%s” zosta³o zatrzymane!
+Click on this notification to restart the interrupted mirror
+Dotknij tego powiadomienia, aby wznowiæ przerwane lustro
+HTTrack: could not save profile for '%s'!
+HTTrack: nie mo¿na zapisaæ profilu dla „%s”!
 Proxy type:
 Typ proxy:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ Maksymalny rozmiar segmentu WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Rozpocznij nowy segment WARC, gdy bie¿¹cy przekroczy tê liczbê bajtów; pozostaw puste lub 0, aby zachowaæ jeden plik.
 Host aliases:
-Host aliases:
+Aliasy hostów:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Inne nazwy hostów obs³uguj¹ce tê sam¹ witrynê, sprowadzone do jednej, jedna regu³a w wierszu (np. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Lustro %s i wszystkich hostów poni¿ej
+Ignore %s and every host below it
+Ignoruj %s i wszystkie hosty poni¿ej

--- a/lang/Polski.txt
+++ b/lang/Polski.txt
@@ -973,7 +973,7 @@ Dopóki ten problem nie zostanie rozwi¹zany, HTTrack mo¿e nie pobieraæ witryn
 HTTrack: mirror '%s' stopped!
 HTTrack: lustro „%s” zosta³o zatrzymane!
 Click on this notification to restart the interrupted mirror
-Dotknij tego powiadomienia, aby wznowiæ przerwane lustro
+Dotknij tego powiadomienia, aby wznowiæ przerwane tworzenie lustra
 HTTrack: could not save profile for '%s'!
 HTTrack: nie mo¿na zapisaæ profilu dla „%s”!
 Proxy type:
@@ -1049,6 +1049,6 @@ Aliasy hostów:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
 Inne nazwy hostów obs³uguj¹ce tê sam¹ witrynê, sprowadzone do jednej, jedna regu³a w wierszu (np. www2.example.com,m.example.com=example.com).
 Mirror %s and every host below it
-Lustro %s i wszystkich hostów poni¿ej
+Utwórz lustro %s i wszystkich hostów poni¿ej
 Ignore %s and every host below it
 Ignoruj %s i wszystkie hosty poni¿ej

--- a/lang/Portugues-Brasil.txt
+++ b/lang/Portugues-Brasil.txt
@@ -1045,6 +1045,10 @@ Tamanho máximo do segmento WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Iniciar um novo segmento WARC quando o atual passar deste número de bytes; deixe em branco ou 0 para um único arquivo.
 Host aliases:
-Host aliases:
+Apelidos de host:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Outros nomes de host que servem este mesmo site, unificados em um só, uma regra por linha (ex.: www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Copiar %s e todos os hosts abaixo dele
+Ignore %s and every host below it
+Ignorar %s e todos os hosts abaixo dele

--- a/lang/Portugues.txt
+++ b/lang/Portugues.txt
@@ -946,6 +946,36 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+View Documentation
+Ver a documentação
+Go To HTTrack Website
+Ir para o sítio do HTTrack
+Go To HTTrack Forum
+Ir para o fórum do HTTrack
+View License
+Ver a licença
+Beware: you local browser might be unable to browse files with embedded filenames
+Atenção: o seu navegador local pode não conseguir abrir ficheiros com nomes de ficheiro incorporados
+Recreated HTTrack internal cached resources
+Recursos internos em cache do HTTrack recriados
+Could not create internal cached resources
+Não foi possível criar os recursos internos em cache
+Could not get the system external storage directory
+Não foi possível encontrar o armazenamento externo do sistema
+Could not write to:
+Não foi possível escrever em:
+Read-only media (SDCARD)
+Suporte só de leitura (SDCARD)
+No storage media (SDCARD)
+Sem suporte de armazenamento (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Enquanto este problema não for resolvido, o HTTrack pode não conseguir transferir sítios
+HTTrack: mirror '%s' stopped!
+HTTrack: a cópia "%s" foi interrompida!
+Click on this notification to restart the interrupted mirror
+Toque nesta notificação para retomar a cópia interrompida
+HTTrack: could not save profile for '%s'!
+HTTrack: não foi possível guardar o perfil de "%s"!
 Proxy type:
 Tipo de proxy:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ Tamanho máximo do segmento WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Iniciar um novo segmento WARC quando o atual ultrapassar este número de bytes; deixe em branco ou 0 para um único ficheiro.
 Host aliases:
-Host aliases:
+Nomes alternativos do anfitrião:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Outros nomes de anfitrião que servem este mesmo sítio, reunidos num só, uma regra por linha (ex.: www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Copiar %s e todos os anfitriões abaixo
+Ignore %s and every host below it
+Ignorar %s e todos os anfitriões abaixo

--- a/lang/Romanian.txt
+++ b/lang/Romanian.txt
@@ -946,6 +946,36 @@ Server terminated
 Server terminat
 A fatal error has occurred during this mirror
 A survenit o eroare fatalã în timpul acestei clonãri.
+View Documentation
+Vezi documentaþia
+Go To HTTrack Website
+Mergi la site-ul HTTrack
+Go To HTTrack Forum
+Mergi la forumul HTTrack
+View License
+Vezi licenþa
+Beware: you local browser might be unable to browse files with embedded filenames
+Atenþie: navigatorul local ar putea sã nu poatã deschide fiºiere cu nume de fiºier încorporate
+Recreated HTTrack internal cached resources
+Resursele interne din cache ale HTTrack au fost recreate
+Could not create internal cached resources
+Resursele interne din cache nu au putut fi create
+Could not get the system external storage directory
+Directorul de stocare externã al sistemului nu a putut fi gãsit
+Could not write to:
+Nu se poate scrie în:
+Read-only media (SDCARD)
+Suport numai pentru citire (SDCARD)
+No storage media (SDCARD)
+Niciun suport de stocare (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Cât timp aceastã problemã persistã, HTTrack ar putea sã nu poatã descãrca site-uri
+HTTrack: mirror '%s' stopped!
+HTTrack: clona "%s" a fost opritã!
+Click on this notification to restart the interrupted mirror
+Atinge aceastã notificare pentru a relua clona întreruptã
+HTTrack: could not save profile for '%s'!
+HTTrack: profilul pentru "%s" nu a putut fi salvat!
 Proxy type:
 Tip proxy:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ Dimensiunea maxima a unui segment WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Incepe un nou segment WARC cand cel curent depaseste acest numar de octeti; lasati gol sau 0 pentru un singur fisier.
 Host aliases:
-Host aliases:
+Alias-uri gazdã:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Alte nume de gazdã care servesc acelaºi site, reunite într-unul singur, o regulã pe linie (ex. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Cloneazã %s ºi toate gazdele de sub el
+Ignore %s and every host below it
+Ignorã %s ºi toate gazdele de sub el

--- a/lang/Russian.txt
+++ b/lang/Russian.txt
@@ -946,6 +946,36 @@ Server terminated
 Server terminated
 A fatal error has occurred during this mirror
 Во время текущей закачки произошла фатальная ошибка
+View Documentation
+Показать документацию
+Go To HTTrack Website
+Перейти на сайт HTTrack
+Go To HTTrack Forum
+Перейти на форум HTTrack
+View License
+Показать лицензию
+Beware: you local browser might be unable to browse files with embedded filenames
+Внимание: локальный браузер может не открыть файлы со встроенными именами файлов
+Recreated HTTrack internal cached resources
+Внутренние кэшированные ресурсы HTTrack созданы заново
+Could not create internal cached resources
+Не удалось создать внутренние кэшированные ресурсы
+Could not get the system external storage directory
+Не удалось найти внешнее хранилище системы
+Could not write to:
+Не удалось записать в:
+Read-only media (SDCARD)
+Носитель только для чтения (SDCARD)
+No storage media (SDCARD)
+Нет носителя для хранения (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Пока эта проблема не устранена, HTTrack может не загружать сайты
+HTTrack: mirror '%s' stopped!
+HTTrack: зеркало «%s» остановлено!
+Click on this notification to restart the interrupted mirror
+Нажмите это уведомление, чтобы продолжить прерванное зеркало
+HTTrack: could not save profile for '%s'!
+HTTrack: не удалось сохранить профиль для «%s»!
 Proxy type:
 Тип прокси:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ WARC segment size limit:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Начинать новый сегмент WARC, когда текущий превысит указанное число байт; оставьте пустым или 0 для одного файла.
 Host aliases:
-Host aliases:
+Псевдонимы хоста:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Другие имена хостов, обслуживающие этот же сайт, сведённые к одному, по одному правилу в строке (напр. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Сделать зеркало %s и всех хостов ниже
+Ignore %s and every host below it
+Игнорировать %s и все хосты ниже

--- a/lang/Russian.txt
+++ b/lang/Russian.txt
@@ -973,7 +973,7 @@ HTTrack may not be able to download websites until this problem is fixed
 HTTrack: mirror '%s' stopped!
 HTTrack: зеркало «%s» остановлено!
 Click on this notification to restart the interrupted mirror
-Нажмите это уведомление, чтобы продолжить прерванное зеркало
+Нажмите на это уведомление, чтобы продолжить прерванное создание зеркала
 HTTrack: could not save profile for '%s'!
 HTTrack: не удалось сохранить профиль для «%s»!
 Proxy type:
@@ -1049,6 +1049,6 @@ Host aliases:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
 Другие имена хостов, обслуживающие этот же сайт, сведённые к одному, по одному правилу в строке (напр. www2.example.com,m.example.com=example.com).
 Mirror %s and every host below it
-Сделать зеркало %s и всех хостов ниже
+Сделать зеркало %s и всех хостов под ним
 Ignore %s and every host below it
-Игнорировать %s и все хосты ниже
+Игнорировать %s и все хосты под ним

--- a/lang/Slovak.txt
+++ b/lang/Slovak.txt
@@ -946,6 +946,36 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+View Documentation
+Zobrazi dokumentáciu
+Go To HTTrack Website
+Prejs na webovú stránku HTTrack
+Go To HTTrack Forum
+Prejs na fórum HTTrack
+View License
+Zobrazi licenciu
+Beware: you local browser might be unable to browse files with embedded filenames
+Pozor: váš miestny prehliadaè nemusí otvori súbory s vloenımi názvami súborov
+Recreated HTTrack internal cached resources
+Interné zdroje vo vyrovnávacej pamäti HTTrack boli znovu vytvorené
+Could not create internal cached resources
+Interné zdroje vo vyrovnávacej pamäti sa nepodarilo vytvori
+Could not get the system external storage directory
+Externé úloisko systému sa nepodarilo nájs
+Could not write to:
+Nedá sa zapisova do:
+Read-only media (SDCARD)
+Médium len na èítanie (SDCARD)
+No storage media (SDCARD)
+iadne úloné médium (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Kım sa tento problém nevyrieši, HTTrack nemusí sahova webové stránky
+HTTrack: mirror '%s' stopped!
+HTTrack: zrkadlenie „%s” bolo zastavené!
+Click on this notification to restart the interrupted mirror
+uknutím na toto oznámenie obnovíte prerušené zrkadlenie
+HTTrack: could not save profile for '%s'!
+HTTrack: profil pre „%s” sa nepodarilo uloi!
 Proxy type:
 Typ proxy:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ Najväèšia ve¾kos segmentu WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Zaèa novı segment WARC, keï aktuálny prekroèí tento poèet bajtov; ponechajte prázdne alebo 0 pre jeden súbor.
 Host aliases:
-Host aliases:
+Aliasy hostite¾a:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Ïalšie názvy hostite¾ov poskytujúce tú istú lokalitu, zlúèené do jedného, jedno pravidlo na riadok (napr. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Zrkadli %s a všetkıch hostite¾ov pod òou
+Ignore %s and every host below it
+Ignorova %s a všetkıch hostite¾ov pod òou

--- a/lang/Slovak.txt
+++ b/lang/Slovak.txt
@@ -971,11 +971,11 @@ No storage media (SDCARD)
 HTTrack may not be able to download websites until this problem is fixed
 Kım sa tento problém nevyrieši, HTTrack nemusí sahova webové stránky
 HTTrack: mirror '%s' stopped!
-HTTrack: zrkadlenie „%s” bolo zastavené!
+HTTrack: zrkadlenie „%s“ bolo zastavené!
 Click on this notification to restart the interrupted mirror
 uknutím na toto oznámenie obnovíte prerušené zrkadlenie
 HTTrack: could not save profile for '%s'!
-HTTrack: profil pre „%s” sa nepodarilo uloi!
+HTTrack: profil pre „%s“ sa nepodarilo uloi!
 Proxy type:
 Typ proxy:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1049,6 +1049,6 @@ Aliasy hostite¾a:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
 Ïalšie názvy hostite¾ov poskytujúce tú istú lokalitu, zlúèené do jedného, jedno pravidlo na riadok (napr. www2.example.com,m.example.com=example.com).
 Mirror %s and every host below it
-Zrkadli %s a všetkıch hostite¾ov pod òou
+Zrkadli %s a všetkıch hostite¾ov pod ním
 Ignore %s and every host below it
-Ignorova %s a všetkıch hostite¾ov pod òou
+Ignorova %s a všetkıch hostite¾ov pod ním

--- a/lang/Slovenian.txt
+++ b/lang/Slovenian.txt
@@ -955,7 +955,7 @@ Pojdi na forum HTTrack
 View License
 Prikaži licenco
 Beware: you local browser might be unable to browse files with embedded filenames
-Pozor: krajevni brskalnik morda ne bo mogel odpreti datotek z vdelanimi imeni datotek
+Pozor: lokalni brskalnik morda ne bo mogel odpreti datotek z vdelanimi imeni datotek
 Recreated HTTrack internal cached resources
 Notranji predpomnjeni viri HTTracka so bili znova ustvarjeni
 Could not create internal cached resources
@@ -971,11 +971,11 @@ Ni nosilca za shranjevanje (SDCARD)
 HTTrack may not be able to download websites until this problem is fixed
 Dokler ta težava ni odpravljena, HTTrack morda ne bo mogel prenašati spletnih mest
 HTTrack: mirror '%s' stopped!
-HTTrack: zrcaljenje „%s” je bilo ustavljeno!
+HTTrack: zrcaljenje „%s“ je bilo ustavljeno!
 Click on this notification to restart the interrupted mirror
 Tapnite to obvestilo za nadaljevanje prekinjenega zrcaljenja
 HTTrack: could not save profile for '%s'!
-HTTrack: profila za „%s” ni bilo mogoèe shraniti!
+HTTrack: profila za „%s“ ni bilo mogoèe shraniti!
 Proxy type:
 Vrsta proxyja:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1049,6 +1049,6 @@ Vzdevki gostitelja:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
 Druga imena gostiteljev, ki strežejo isto stran, združena v eno, eno pravilo na vrstico (npr. www2.example.com,m.example.com=example.com).
 Mirror %s and every host below it
-Zrcali %s in vse gostitelje pod njo
+Zrcali %s in vse gostitelje pod njim
 Ignore %s and every host below it
-Prezri %s in vse gostitelje pod njo
+Prezri %s in vse gostitelje pod njim

--- a/lang/Slovenian.txt
+++ b/lang/Slovenian.txt
@@ -946,6 +946,36 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+View Documentation
+Prikaži dokumentacijo
+Go To HTTrack Website
+Pojdi na spletno mesto HTTrack
+Go To HTTrack Forum
+Pojdi na forum HTTrack
+View License
+Prikaži licenco
+Beware: you local browser might be unable to browse files with embedded filenames
+Pozor: krajevni brskalnik morda ne bo mogel odpreti datotek z vdelanimi imeni datotek
+Recreated HTTrack internal cached resources
+Notranji predpomnjeni viri HTTracka so bili znova ustvarjeni
+Could not create internal cached resources
+Notranjih predpomnjenih virov ni bilo mogoèe ustvariti
+Could not get the system external storage directory
+Zunanje shrambe sistema ni bilo mogoèe najti
+Could not write to:
+Ni mogoèe pisati v:
+Read-only media (SDCARD)
+Nosilec samo za branje (SDCARD)
+No storage media (SDCARD)
+Ni nosilca za shranjevanje (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Dokler ta težava ni odpravljena, HTTrack morda ne bo mogel prenašati spletnih mest
+HTTrack: mirror '%s' stopped!
+HTTrack: zrcaljenje „%s” je bilo ustavljeno!
+Click on this notification to restart the interrupted mirror
+Tapnite to obvestilo za nadaljevanje prekinjenega zrcaljenja
+HTTrack: could not save profile for '%s'!
+HTTrack: profila za „%s” ni bilo mogoèe shraniti!
 Proxy type:
 Vrsta proxyja:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ Najvecja velikost segmenta WARC:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Zacni nov segment WARC, ko trenutni preseze to stevilo bajtov; pustite prazno ali 0 za eno datoteko.
 Host aliases:
-Host aliases:
+Vzdevki gostitelja:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Druga imena gostiteljev, ki strežejo isto stran, združena v eno, eno pravilo na vrstico (npr. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Zrcali %s in vse gostitelje pod njo
+Ignore %s and every host below it
+Prezri %s in vse gostitelje pod njo

--- a/lang/Svenska.txt
+++ b/lang/Svenska.txt
@@ -965,9 +965,9 @@ Det gick inte att hitta systemets externa lagring
 Could not write to:
 Det gick inte att skriva till:
 Read-only media (SDCARD)
-Skrivskyddat media (SDCARD)
+Skrivskyddat medium (SDCARD)
 No storage media (SDCARD)
-Inget lagringsmedia (SDCARD)
+Inget lagringsmedium (SDCARD)
 HTTrack may not be able to download websites until this problem is fixed
 Så länge problemet kvarstår kan HTTrack kanske inte hämta webbplatser
 HTTrack: mirror '%s' stopped!

--- a/lang/Svenska.txt
+++ b/lang/Svenska.txt
@@ -946,6 +946,36 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+View Documentation
+Visa dokumentationen
+Go To HTTrack Website
+Gå till HTTracks webbplats
+Go To HTTrack Forum
+Gå till HTTracks forum
+View License
+Visa licensen
+Beware: you local browser might be unable to browse files with embedded filenames
+Obs: din lokala webbläsare kan kanske inte öppna filer med inbäddade filnamn
+Recreated HTTrack internal cached resources
+HTTracks interna cachade resurser har skapats om
+Could not create internal cached resources
+Det gick inte att skapa de interna cachade resurserna
+Could not get the system external storage directory
+Det gick inte att hitta systemets externa lagring
+Could not write to:
+Det gick inte att skriva till:
+Read-only media (SDCARD)
+Skrivskyddat media (SDCARD)
+No storage media (SDCARD)
+Inget lagringsmedia (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Så länge problemet kvarstår kan HTTrack kanske inte hämta webbplatser
+HTTrack: mirror '%s' stopped!
+HTTrack: kopian "%s" stoppades!
+Click on this notification to restart the interrupted mirror
+Tryck på denna avisering för att återuppta den avbrutna kopian
+HTTrack: could not save profile for '%s'!
+HTTrack: det gick inte att spara profilen för "%s"!
 Proxy type:
 Proxytyp:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ Största storlek för WARC-segment:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Börja ett nytt WARC-segment när det aktuella passerar detta antal byte; lämna tomt eller 0 för en enda fil.
 Host aliases:
-Host aliases:
+Värdaliaser:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Andra värdnamn som betjänar samma webbplats, sammanslagna till ett, en regel per rad (t.ex. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Kopiera %s och alla värdar under den
+Ignore %s and every host below it
+Ignorera %s och alla värdar under den

--- a/lang/Turkish.txt
+++ b/lang/Turkish.txt
@@ -946,6 +946,36 @@ Server terminated
 Sunucu sonlandýrýldý
 A fatal error has occurred during this mirror
 Bu yansýlama iþlemi sýrasýnda ölümcül bir hata oluþtu
+View Documentation
+Belgeleri görüntüle
+Go To HTTrack Website
+HTTrack web sitesine git
+Go To HTTrack Forum
+HTTrack forumuna git
+View License
+Lisansý görüntüle
+Beware: you local browser might be unable to browse files with embedded filenames
+Dikkat: yerel tarayýcýnýz gömülü dosya adlarý içeren dosyalarý açamayabilir
+Recreated HTTrack internal cached resources
+HTTrack iç önbellek kaynaklarý yeniden oluþturuldu
+Could not create internal cached resources
+Ýç önbellek kaynaklarý oluþturulamadý
+Could not get the system external storage directory
+Sistemin dýþ depolama dizini bulunamadý
+Could not write to:
+Þuraya yazýlamadý:
+Read-only media (SDCARD)
+Salt okunur ortam (SDCARD)
+No storage media (SDCARD)
+Depolama ortamý yok (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Bu sorun giderilene kadar HTTrack web sitelerini indiremeyebilir
+HTTrack: mirror '%s' stopped!
+HTTrack: "%s" yansýsý durduruldu!
+Click on this notification to restart the interrupted mirror
+Yarým kalan yansýyý sürdürmek için bu bildirime dokunun
+HTTrack: could not save profile for '%s'!
+HTTrack: "%s" için profil kaydedilemedi!
 Proxy type:
 Proxy türü:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ WARC parça boyutu sýnýrý:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Geçerli parça bu bayt sayýsýný aþtýðýnda yeni bir WARC parçasý baþlat; tek dosya için boþ býrakýn veya 0 girin.
 Host aliases:
-Host aliases:
+Sunucu takma adlarý:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Ayný siteyi sunan diðer sunucu adlarý, tek bir ada indirgenir; her satýrda bir kural (örn. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+%s ve altýndaki tüm sunucularý yansýla
+Ignore %s and every host below it
+%s ve altýndaki tüm sunucularý yoksay

--- a/lang/Turkish.txt
+++ b/lang/Turkish.txt
@@ -1047,7 +1047,7 @@ Geçerli parça bu bayt sayýsýný aþtýðýnda yeni bir WARC parçasý baþlat; tek dosya
 Host aliases:
 Sunucu takma adlarý:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Ayný siteyi sunan diðer sunucu adlarý, tek bir ada indirgenir; her satýrda bir kural (örn. www2.example.com,m.example.com=example.com).
+Ayný siteyi sunan ve tek bir ada indirgenen diðer sunucu adlarý; her satýrda bir kural (örn. www2.example.com,m.example.com=example.com).
 Mirror %s and every host below it
 %s ve altýndaki tüm sunucularý yansýla
 Ignore %s and every host below it

--- a/lang/Ukrainian.txt
+++ b/lang/Ukrainian.txt
@@ -946,6 +946,36 @@ Server terminated
 
 A fatal error has occurred during this mirror
 
+View Documentation
+Показати документацію
+Go To HTTrack Website
+Перейти на сайт HTTrack
+Go To HTTrack Forum
+Перейти на форум HTTrack
+View License
+Показати ліцензію
+Beware: you local browser might be unable to browse files with embedded filenames
+Увага: локальний браузер може не відкрити файли з вбудованими іменами файлів
+Recreated HTTrack internal cached resources
+Внутрішні кешовані ресурси HTTrack створено заново
+Could not create internal cached resources
+Не вдалося створити внутрішні кешовані ресурси
+Could not get the system external storage directory
+Не вдалося знайти зовнішнє сховище системи
+Could not write to:
+Не вдалося записати в:
+Read-only media (SDCARD)
+Носій лише для читання (SDCARD)
+No storage media (SDCARD)
+Немає носія для зберігання (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Доки цю проблему не усунуто, HTTrack може не завантажувати сайти
+HTTrack: mirror '%s' stopped!
+HTTrack: дзеркало «%s» зупинено!
+Click on this notification to restart the interrupted mirror
+Натисніть це сповіщення, щоб продовжити перерване дзеркало
+HTTrack: could not save profile for '%s'!
+HTTrack: не вдалося зберегти профіль для «%s»!
 Proxy type:
 Тип проксі:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ WARC segment size limit:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Починати новий сегмент WARC, коли поточний перевищить цю кількість байтів; залиште порожнім або 0 для одного файлу.
 Host aliases:
-Host aliases:
+Псевдоніми хоста:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Інші імена хостів, що обслуговують цей самий сайт, зведені до одного, по одному правилу в рядку (напр. www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+Дзеркалювати %s і всі хости нижче
+Ignore %s and every host below it
+Ігнорувати %s і всі хости нижче

--- a/lang/Ukrainian.txt
+++ b/lang/Ukrainian.txt
@@ -973,7 +973,7 @@ HTTrack may not be able to download websites until this problem is fixed
 HTTrack: mirror '%s' stopped!
 HTTrack: дзеркало «%s» зупинено!
 Click on this notification to restart the interrupted mirror
-Натисніть це сповіщення, щоб продовжити перерване дзеркало
+Натисніть на це сповіщення, щоб продовжити перерване дзеркало
 HTTrack: could not save profile for '%s'!
 HTTrack: не вдалося зберегти профіль для «%s»!
 Proxy type:
@@ -1049,6 +1049,6 @@ Host aliases:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
 Інші імена хостів, що обслуговують цей самий сайт, зведені до одного, по одному правилу в рядку (напр. www2.example.com,m.example.com=example.com).
 Mirror %s and every host below it
-Дзеркалювати %s і всі хости нижче
+Дзеркалювати %s і всі хости під ним
 Ignore %s and every host below it
-Ігнорувати %s і всі хости нижче
+Ігнорувати %s і всі хости під ним

--- a/lang/Uzbek.txt
+++ b/lang/Uzbek.txt
@@ -946,6 +946,36 @@ Server terminated
 Server terminated
 A fatal error has occurred during this mirror
 Joriy ko’chirish vaqtida jiddiy xatolik yuz berdi
+View Documentation
+Hujjatlarni ko'rish
+Go To HTTrack Website
+HTTrack veb-saytiga o'tish
+Go To HTTrack Forum
+HTTrack forumiga o'tish
+View License
+Litsenziyani ko'rish
+Beware: you local browser might be unable to browse files with embedded filenames
+Diqqat: mahalliy brauzeringiz nomi ichiga joylangan fayllarni ocholmasligi mumkin
+Recreated HTTrack internal cached resources
+HTTrack ichki kesh resurslari qayta yaratildi
+Could not create internal cached resources
+Ichki kesh resurslarini yaratib bo'lmadi
+Could not get the system external storage directory
+Tizimning tashqi xotira jildini topib bo'lmadi
+Could not write to:
+Bunga yozib bo'lmadi:
+Read-only media (SDCARD)
+Faqat o'qish uchun tashuvchi (SDCARD)
+No storage media (SDCARD)
+Xotira tashuvchisi yo'q (SDCARD)
+HTTrack may not be able to download websites until this problem is fixed
+Bu muammo bartaraf etilmaguncha HTTrack veb-saytlarni yuklab ololmasligi mumkin
+HTTrack: mirror '%s' stopped!
+HTTrack: "%s" nusxasi to'xtatildi!
+Click on this notification to restart the interrupted mirror
+Uzilgan nusxani davom ettirish uchun bu bildirishnomani bosing
+HTTrack: could not save profile for '%s'!
+HTTrack: "%s" uchun profilni saqlab bo'lmadi!
 Proxy type:
 Proksi turi:
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.
@@ -1015,6 +1045,10 @@ WARC segmentining eng katta hajmi:
 Start a new WARC segment once the current one grows past this many bytes; leave blank or 0 to keep a single file.
 Joriy segment shu baytlar sonidan oshganda yangi WARC segmentini boshlash; bitta fayl uchun bo’sh qoldiring yoki 0 kiriting.
 Host aliases:
-Host aliases:
+Xost taxalluslari:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
+Shu saytga xizmat qiluvchi boshqa xost nomlari, bittaga birlashtiriladi, har satrda bitta qoida (masalan www2.example.com,m.example.com=example.com).
+Mirror %s and every host below it
+%s va uning ostidagi barcha xostlardan nusxa olish
+Ignore %s and every host below it
+%s va uning ostidagi barcha xostlarni e'tiborsiz qoldirish

--- a/lang/Uzbek.txt
+++ b/lang/Uzbek.txt
@@ -963,7 +963,7 @@ Ichki kesh resurslarini yaratib bo'lmadi
 Could not get the system external storage directory
 Tizimning tashqi xotira jildini topib bo'lmadi
 Could not write to:
-Bunga yozib bo'lmadi:
+Quyidagiga yozib bo'lmadi:
 Read-only media (SDCARD)
 Faqat o'qish uchun tashuvchi (SDCARD)
 No storage media (SDCARD)
@@ -1047,7 +1047,7 @@ Joriy segment shu baytlar sonidan oshganda yangi WARC segmentini boshlash; bitta
 Host aliases:
 Xost taxalluslari:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-Shu saytga xizmat qiluvchi boshqa xost nomlari, bittaga birlashtiriladi, har satrda bitta qoida (masalan www2.example.com,m.example.com=example.com).
+Shu saytga xizmat qiluvchi va bittaga birlashtiriladigan boshqa xost nomlari; har satrda bitta qoida (masalan www2.example.com,m.example.com=example.com).
 Mirror %s and every host below it
 %s va uning ostidagi barcha xostlardan nusxa olish
 Ignore %s and every host below it

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -162,44 +162,15 @@ LC_ALL=C awk -v keys="$keys" '
 ' "$def" || fail=1
 
 # A msgid absent from a language file silently falls back to English (#862).
-# What is left waived is the Android UI, whose strings never reached lang/*.txt.
 LC_ALL=C sort -u <"$keys" >"$tmp/english.sorted"
-LC_ALL=C sort -u >"$tmp/waived" <<'UNTRANSLATED'
-Beware: you local browser might be unable to browse files with embedded filenames
-Click on this notification to restart the interrupted mirror
-Could not create internal cached resources
-Could not get the system external storage directory
-Could not write to:
-Go To HTTrack Forum
-Go To HTTrack Website
-HTTrack may not be able to download websites until this problem is fixed
-HTTrack: could not save profile for '%s'!
-HTTrack: mirror '%s' stopped!
-No storage media (SDCARD)
-Read-only media (SDCARD)
-Recreated HTTrack internal cached resources
-View Documentation
-View License
-UNTRANSLATED
-
-: >"$tmp/complete"
 for f in "$langdir"/*.txt; do
     LC_ALL=C awk 'NR%2==1 { sub(/\r$/, ""); print }' "$f" | LC_ALL=C sort -u >"$tmp/have"
-    LC_ALL=C comm -23 "$tmp/english.sorted" "$tmp/have" >"$tmp/absent"
-    untranslated=$(LC_ALL=C comm -23 "$tmp/absent" "$tmp/waived")
+    untranslated=$(LC_ALL=C comm -23 "$tmp/english.sorted" "$tmp/have")
     if [ -n "$untranslated" ]; then
         printf '%s\n' "$untranslated" | awk -v n="${f##*/}" '{print n ": untranslated msgid: " $0}'
         fail=1
     fi
-    # A waiver nobody needs any more has to go, or the hole quietly reopens.
-    LC_ALL=C comm -12 "$tmp/absent" "$tmp/waived" >>"$tmp/complete"
 done
-LC_ALL=C sort -u -o "$tmp/complete" "$tmp/complete"
-stale=$(LC_ALL=C comm -23 "$tmp/waived" "$tmp/complete")
-if [ -n "$stale" ]; then
-    printf '%s\n' "$stale" | awk '{print "lang: translated everywhere now, drop the waiver: " $0}'
-    fail=1
-fi
 
 # An unknown ${LANG_*} renders as nothing rather than erroring, so check that
 # every macro the templates interpolate, in any wrapper form, resolves.

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -161,6 +161,17 @@ LC_ALL=C awk -v keys="$keys" '
     }
 ' "$def" || fail=1
 
+# The CLI prints the wizard's scope answers itself while the GUI reads them from
+# lang.def, so a reword on one side alone silently drifts the two apart (#1117).
+for scope in "Mirror %s and every host below it" "Ignore %s and every host below it"; do
+    for f in "$eng" "$def" "$top_srcdir/src/httrack.c"; do
+        if ! LC_ALL=C grep -qF "$scope" "$f"; then
+            echo "${f##*/}: missing the wizard scope answer \"$scope\""
+            fail=1
+        fi
+    done
+done
+
 # A msgid absent from a language file silently falls back to English (#862).
 LC_ALL=C sort -u <"$keys" >"$tmp/english.sorted"
 for f in "$langdir"/*.txt; do


### PR DESCRIPTION
`LANG_M10` and `LANG_M11` join `LANG_M1`..`LANG_M9` for the wizard's two domain-scope answers, which #1239 left hardcoded in the CLI menu with no key for WinHTTrack (xroche/httrack-windows#96). They are worded exactly like that menu, and test 62 now requires both to appear verbatim in `English.txt`, `lang.def` and `src/httrack.c`, so the front ends cannot drift the way #1117 warned about.

Two other sets were still English everywhere: the host-alias field and tooltip #1166 copied into every catalog, and the fifteen Android strings that had only ever reached Danish, French and Brazilian Portuguese, which `tests/62_lang-integrity.test` waived by name. Both are translated across the thirty catalogs now and the waiver is gone, so the next gap reds the test.

Each file keeps its own on-disk charset and line endings. Uzbek stays LF, Romanian still spells s-comma, t-comma and a-breve with the Latin-1 lookalikes it uses throughout, and the catalogs whose charset has no typographic quote pair take ASCII ones. Three mutants prove test 62 catches drift: a dropped msgid, a stray UTF-8 byte in a Latin-1 file, and `LANG_M10` pointed at a msgid missing from `English.txt`.

A review pass over the translations themselves fixed a feminine pronoun standing in for the masculine host in the Czech, Slovak, Croatian and Slovene scope answers, plus per-language defects in nine more catalogs. `Chinese-BIG5` also spelled `Ignore all` with the wrong character in the same wizard block; that is corrected here.