### PR TITLE
A wizard answer is outranked by every filter that came before it

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -608,10 +608,7 @@ int httpmirror(char *url1, httrackp * opt) {
     XH_extuninit;
     return 0;
   }
-  opt->filters.filters = &filters;
-  //
-  opt->filters.filptr = &filptr;
-  opt->wizard_filters = 0; // an opt reused for a second crawl starts empty
+  filters_bind(opt, &filters, &filptr);
 
   // hash table
   opt->hash = &hash;
@@ -2423,6 +2420,12 @@ void host_ban(httrackp * opt, int ptr,
                     i);
     }
   }
+}
+
+void filters_bind(httrackp *opt, char ***ptrfilters, int *filptr) {
+  opt->filters.filters = ptrfilters;
+  opt->filters.filptr = filptr;
+  opt->wizard_filters = 0;
 }
 
 int filters_init(char ***ptrfilters, int maxfilter, int filterinc) {

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -611,6 +611,7 @@ int httpmirror(char *url1, httrackp * opt) {
   opt->filters.filters = &filters;
   //
   opt->filters.filptr = &filptr;
+  opt->wizard_filters = 0; // an opt reused for a second crawl starts empty
 
   // hash table
   opt->hash = &hash;

--- a/src/htscore.h
+++ b/src/htscore.h
@@ -387,6 +387,10 @@ void hts_finish_html_file(httrackp *opt, cache_back *cache, htsblk *r,
 
 int filters_init(char ***ptrfilters, int maxfilter, int filterinc);
 
+/* Binds this crawl's filter array to `opt`, and empties the wizard block with
+   it: opt->wizard_filters indexes into that array and outlives no crawl. */
+void filters_bind(httrackp *opt, char ***ptrfilters, int *filptr);
+
 int fspc(httrackp * opt, FILE * fp, const char *type);
 
 char *next_token(char *p, int flag);

--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -572,8 +572,8 @@ struct httrackp {
                           rules folding the hostnames of one site onto a single
                           canonical host. Tail: ABI */
   /* Live state, not an option: copy_htsopt must leave it alone. */
-  int wizard_filters; /**< filters the wizard has inserted, held at the low
-                           indices of the array. Tail: ABI */
+  int wizard_filters; /**< count of filters the wizard has inserted, held at the
+                           low indices of the array. Tail: ABI */
 };
 
 /* Running statistics for a mirror. */

--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -571,6 +571,9 @@ struct httrackp {
   String host_alias; /**< --host-alias: '\n'-separated "alias[,alias...]=host"
                           rules folding the hostnames of one site onto a single
                           canonical host. Tail: ABI */
+  /* Live state, not an option: copy_htsopt must leave it alone. */
+  int wizard_filters; /**< filters the wizard has inserted, held at the low
+                           indices of the array. Tail: ABI */
 };
 
 /* Running statistics for a mirror. */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4419,8 +4419,8 @@ static int st_wizardverdict(httrackp *opt, int argc, char **argv) {
 
 #undef PRIO_UNSET
 
-/* Refills the array the wizard inserts into with `cmd`, the filters the crawl
-   started with (NULL-terminated). */
+/* Resets the wizard's filter array to the command-line filters `cmd`
+   (NULL-terminated). */
 static void wz_seed(httrackp *opt, char **filters, int *filptr,
                     const char *const *cmd) {
   int i;
@@ -4431,21 +4431,26 @@ static void wz_seed(httrackp *opt, char **filters, int *filptr,
     strlcpybuff(filters[(*filptr)++], cmd[i], HTS_FILTER_SLOT_SIZE);
 }
 
-/* Asserts the array holds exactly `want`, in order. */
+/* Asserts the array holds exactly `want`, in order, naming the slot that
+   differs: every scenario below aborts through here. */
 static void wz_holds(char **filters, int filptr, const char *const *want) {
   int i;
 
   for (i = 0; want[i] != NULL; i++) {
+    if (i >= filptr || strcmp(filters[i], want[i]) != 0)
+      fprintf(stderr, "filter %d: got [%s], want [%s]\n", i,
+              i < filptr ? filters[i] : "<past the end>", want[i]);
     assertf(i < filptr);
     assertf(strcmp(filters[i], want[i]) == 0);
   }
+  if (filptr != i)
+    fprintf(stderr, "filter %d: got [%s], want nothing\n", i,
+            i < filptr ? filters[i] : "<past the end>");
   assertf(filptr == i);
 }
 
-/* Where hts_wizard_insert_filters() puts a wizard answer. With <adr> <fil>
-   [answer...] [@ filter...], applies the answers over the command-line filters
-   listed after the "@" ("--" would be eaten by the option parser) and prints
-   the resulting array; with no argument, asserts the precedence rules. */
+/* Drives hts_wizard_insert_filters(): prints the array the given answers build
+   over the command-line filters, or asserts the precedence rules. */
 static int st_wizardinsert(httrackp *opt, int argc, char **argv) {
   const htsfilters saved = opt->filters;
   const int savedwizard = opt->wizard_filters;
@@ -4458,6 +4463,10 @@ static int st_wizardinsert(httrackp *opt, int argc, char **argv) {
   opt->filters.filters = &filters;
   opt->filters.filptr = &filptr;
   opt->wizard_filters = 0;
+/* Answers, from httrack.c's question: 0 this link, 1 this directory, 2 the
+   host, 3 the parent, 4 this page only, 5 the directory and below, 6 the host,
+   7 the directory's files, 50 nothing. seeker_up is pinned off, so answer 5
+   takes its directory branch; 264 covers the host one. */
 #define INSERT(n, adr, fil)                                                    \
   hts_wizard_insert_filters(opt, (n), (adr), (fil), HTS_FALSE)
 #define HOLDS(...)                                                             \
@@ -4483,7 +4492,8 @@ static int st_wizardinsert(httrackp *opt, int argc, char **argv) {
         break;
       }
     }
-    for (i = sep + 1; i < argc; i++)
+    for (i = sep + 1;
+         i < argc && filptr + HTS_WIZARD_MAX_FILTERS < opt->maxfilter; i++)
       strlcpybuff(filters[filptr++], argv[i], HTS_FILTER_SLOT_SIZE);
     for (i = 2; i < sep; i++)
       INSERT(atoi(argv[i]), argv[0], argv[1]);
@@ -4492,6 +4502,24 @@ static int st_wizardinsert(httrackp *opt, int argc, char **argv) {
     printf("\n");
     goto done;
   }
+
+  /* the block size indexes one crawl's array, so binding an array empties it */
+  {
+    char **other = NULL;
+    int otherptr = 7;
+
+    opt->wizard_filters = 3;
+    filters_bind(opt, &other, &otherptr);
+    assertf(opt->wizard_filters == 0);
+    assertf(opt->filters.filters == &other && opt->filters.filptr == &otherptr);
+    filters_bind(opt, &filters, &filptr);
+  }
+
+  /* and a counter that outlived its array still cannot index past the end */
+  SEED("-*.zip");
+  opt->wizard_filters = 99;
+  INSERT(6, "h", "/dir/two.html");
+  assertf(opt->wizard_filters <= filptr);
 
   /* the correction case: "ignore this link", then "mirror the whole host" */
   RESET();
@@ -4533,7 +4561,7 @@ static int st_wizardinsert(httrackp *opt, int argc, char **argv) {
   HOLDS("+*.example.co.uk/*", "+example.co.uk/*", "-*.zip");
   assertf(opt->wizard_filters == 2);
 
-  /* an answer that emits nothing leaves the block, and the array, alone */
+  /* an answer that emits nothing leaves the block and the array unchanged */
   SEED("-*.zip");
   INSERT(4, "h", "/dir/one.html");
   INSERT(50, "h", "/dir/one.html");

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4419,6 +4419,150 @@ static int st_wizardverdict(httrackp *opt, int argc, char **argv) {
 
 #undef PRIO_UNSET
 
+/* Refills the array the wizard inserts into with `cmd`, the filters the crawl
+   started with (NULL-terminated). */
+static void wz_seed(httrackp *opt, char **filters, int *filptr,
+                    const char *const *cmd) {
+  int i;
+
+  *filptr = 0;
+  opt->wizard_filters = 0;
+  for (i = 0; cmd != NULL && cmd[i] != NULL; i++)
+    strlcpybuff(filters[(*filptr)++], cmd[i], HTS_FILTER_SLOT_SIZE);
+}
+
+/* Asserts the array holds exactly `want`, in order. */
+static void wz_holds(char **filters, int filptr, const char *const *want) {
+  int i;
+
+  for (i = 0; want[i] != NULL; i++) {
+    assertf(i < filptr);
+    assertf(strcmp(filters[i], want[i]) == 0);
+  }
+  assertf(filptr == i);
+}
+
+/* Where hts_wizard_insert_filters() puts a wizard answer. With <adr> <fil>
+   [answer...] [@ filter...], applies the answers over the command-line filters
+   listed after the "@" ("--" would be eaten by the option parser) and prints
+   the resulting array; with no argument, asserts the precedence rules. */
+static int st_wizardinsert(httrackp *opt, int argc, char **argv) {
+  const htsfilters saved = opt->filters;
+  const int savedwizard = opt->wizard_filters;
+  const int savedmax = opt->maxfilter;
+  char **filters = NULL;
+  int filptr = 0;
+  int i;
+
+  assertf(filters_init(&filters, opt->maxfilter, 0) != 0);
+  opt->filters.filters = &filters;
+  opt->filters.filptr = &filptr;
+  opt->wizard_filters = 0;
+#define INSERT(n, adr, fil)                                                    \
+  hts_wizard_insert_filters(opt, (n), (adr), (fil), HTS_FALSE)
+#define HOLDS(...)                                                             \
+  do {                                                                         \
+    const char *const want[] = {__VA_ARGS__, NULL};                            \
+    wz_holds(filters, filptr, want);                                           \
+  } while (0)
+#define SEED(...)                                                              \
+  do {                                                                         \
+    const char *const cmd[] = {__VA_ARGS__, NULL};                             \
+    wz_seed(opt, filters, &filptr, cmd);                                       \
+  } while (0)
+#define RESET() wz_seed(opt, filters, &filptr, NULL)
+/* what the array as it stands decides for `url` */
+#define VERDICT(url) fa_strjoker(0, filters, filptr, (url), NULL, NULL, NULL)
+
+  if (argc >= 2) {
+    int sep = argc;
+
+    for (i = 2; i < argc; i++) {
+      if (strcmp(argv[i], "@") == 0) {
+        sep = i;
+        break;
+      }
+    }
+    for (i = sep + 1; i < argc; i++)
+      strlcpybuff(filters[filptr++], argv[i], HTS_FILTER_SLOT_SIZE);
+    for (i = 2; i < sep; i++)
+      INSERT(atoi(argv[i]), argv[0], argv[1]);
+    for (i = 0; i < filptr; i++)
+      printf("%s%s", i != 0 ? " " : "", filters[i]);
+    printf("\n");
+    goto done;
+  }
+
+  /* the correction case: "ignore this link", then "mirror the whole host" */
+  RESET();
+  INSERT(0, "h", "/dir/one.html");
+  HOLDS("-h/dir/one.html");
+  assertf(opt->wizard_filters == 1);
+  assertf(VERDICT("h/dir/one.html") == -1);
+  INSERT(6, "h", "/dir/two.html");
+  HOLDS("-h/dir/one.html", "+h/*");
+  assertf(opt->wizard_filters == 2);
+  assertf(VERDICT("h/dir/one.html") == 1);
+
+  /* reversing the answers reverses the outcome, or the block is not ordered */
+  RESET();
+  INSERT(6, "h", "/dir/two.html");
+  INSERT(0, "h", "/dir/one.html");
+  HOLDS("+h/*", "-h/dir/one.html");
+  assertf(VERDICT("h/dir/one.html") == -1);
+  assertf(VERDICT("h/dir/two.html") == 1);
+
+  /* no answer reaches above the command line */
+  SEED("-h/*.zip", "+h/keep/*");
+  INSERT(6, "h", "/dir/two.html");
+  HOLDS("+h/*", "-h/*.zip", "+h/keep/*");
+  assertf(opt->wizard_filters == 1);
+  assertf(VERDICT("h/a.zip") == -1);
+  assertf(VERDICT("h/dir/two.html") == 1);
+
+  /* the primary link records its scope first, so a later answer overrides it */
+  RESET();
+  INSERT(7, "h", "/dir/index.html");
+  INSERT(0, "h", "/dir/one.html");
+  HOLDS("+h/dir/*[file]", "-h/dir/one.html");
+  assertf(VERDICT("h/dir/one.html") == -1);
+
+  /* both halves of a host-scope answer land in the block, in emission order */
+  SEED("-*.zip");
+  INSERT(HTS_WIZARD_SCOPE_INCLUDE + 1, "www.example.co.uk", "/x.html");
+  HOLDS("+*.example.co.uk/*", "+example.co.uk/*", "-*.zip");
+  assertf(opt->wizard_filters == 2);
+
+  /* an answer that emits nothing leaves the block, and the array, alone */
+  SEED("-*.zip");
+  INSERT(4, "h", "/dir/one.html");
+  INSERT(50, "h", "/dir/one.html");
+  INSERT(3, "h", "/dir/one.html");
+  HOLDS("-*.zip");
+  assertf(opt->wizard_filters == 0);
+
+  /* answers 1, 5 and 7 emit nothing when the file part has no directory */
+  RESET();
+  INSERT(1, "h", "one.html");
+  INSERT(5, "h", "one.html");
+  INSERT(7, "h", "one.html");
+  assertf(filptr == 0 && opt->wizard_filters == 0);
+
+  printf("wizardinsert self-test OK\n");
+done:
+#undef INSERT
+#undef HOLDS
+#undef SEED
+#undef RESET
+#undef VERDICT
+  freet(filters[0]);
+  freet(filters);
+  opt->filters = saved;
+  opt->wizard_filters = savedwizard;
+  opt->maxfilter = savedmax;
+  return 0;
+}
+
 /* #159: hts_redirect_same_savefile decides whether a redirect is a same-file
  * alias. */
 static int st_redirect_samefile(httrackp *opt, int argc, char **argv) {
@@ -9938,6 +10082,8 @@ static const struct selftest_entry {
      st_wizardscopeanswer},
     {"wizardverdict", "[<answer>]", "what a wizard answer applies",
      st_wizardverdict},
+    {"wizardinsert", "[<adr> <fil> [answer...] [@ filter...]]",
+     "where a wizard answer lands in the filter array", st_wizardinsert},
     {"mime", "<filename>", "MIME type for a filename", st_mime},
     {"charset", "<charset> <hex:..|string>",
      "convert a string to UTF-8 from a charset", st_charset},

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -42,25 +42,6 @@ Please visit our Website: http://www.httrack.com
 #include <ctype.h>
 /* END specific definitions */
 
-// libérer filters[0] pour insérer un élément dans filters[0]
-/* Per-slot capacity of the filters array, matching the slot stride allocated by
-   filters_init() in htscore.c (HTS_URLMAXSIZE * 2). */
-#define HTS_FILTER_SLOT_SIZE (HTS_URLMAXSIZE * 2)
-
-#define HT_INSERT_FILTERS0                                                     \
-  do {                                                                         \
-    int i;                                                                     \
-    if (*opt->filters.filptr > 0) {                                            \
-      for (i = (*opt->filters.filptr) - 1; i >= 0; i--) {                      \
-        strlcpybuff((*opt->filters.filters)[i + 1],                            \
-                    (*opt->filters.filters)[i], HTS_FILTER_SLOT_SIZE);         \
-      }                                                                        \
-    }                                                                          \
-    (*opt->filters.filters)[0][0] = '\0';                                      \
-    (*opt->filters.filptr)++;                                                  \
-    assertf((*opt->filters.filptr) < opt->maxfilter);                          \
-  } while (0)
-
 /* "embedded" */
 htspair_t hts_detect_embed[] = {
   {"img", "src"},
@@ -319,6 +300,50 @@ void hts_wizard_answer_filter(htsbuff *f, int slot, int n, const char *adr,
 
   default: /* the other answers add no filter */
     break;
+  }
+}
+
+/* Inserts `pattern` at index `pos`, shifting the filters from there up a slot.
+   The caller has already ensured the array has room. */
+static void filters_insert_at(httrackp *opt, int pos, const char *pattern) {
+  char **const filters = *opt->filters.filters;
+  int i;
+
+  assertf(pos >= 0 && pos <= *opt->filters.filptr);
+  for (i = *opt->filters.filptr; i > pos; i--)
+    strlcpybuff(filters[i], filters[i - 1], HTS_FILTER_SLOT_SIZE);
+  strlcpybuff(filters[pos], pattern, HTS_FILTER_SLOT_SIZE);
+  (*opt->filters.filptr)++;
+  assertf((*opt->filters.filptr) < opt->maxfilter);
+}
+
+void hts_wizard_insert_filters(httrackp *opt, int n, const char *adr,
+                               const char *fil, hts_boolean seeker_up) {
+  char BIGSTK pattern[HTS_FILTER_SLOT_SIZE];
+  htsbuff f = htsbuff_array(pattern);
+  int slot;
+
+  /* grow first: a host-scope answer emits two filters */
+  if ((*opt->filters.filptr) + 2 >= opt->maxfilter) {
+    opt->maxfilter += HTS_FILTERSINC;
+    if (filters_init(opt->filters.filters, opt->maxfilter, HTS_FILTERSINC) ==
+        0) {
+      printf("PANIC! : Too many filters : >%d [%d]\n", *opt->filters.filptr,
+             __LINE__);
+      fflush(stdout);
+      hts_log_print(opt, LOG_PANIC, "Too many filters, giving up..(>%d)",
+                    *opt->filters.filptr);
+      hts_log_print(
+          opt, LOG_INFO,
+          "To avoid that: use #F option for more filters (example: -#F5000)");
+      assertf("too many filters - giving up" == NULL); // wild..
+    }
+  }
+  for (slot = 0; slot < HTS_WIZARD_MAX_FILTERS; slot++) {
+    hts_wizard_answer_filter(&f, slot, n, adr, fil, seeker_up);
+    if (f.len == 0)
+      break;
+    filters_insert_at(opt, opt->wizard_filters++, pattern);
   }
 }
 
@@ -889,41 +914,10 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
           n = force_mirror;
       }
 
-      /* sanity check - reallocate filters HERE (a host-scope answer emits two)
-       */
-      if ((*_FILTERS_PTR) + 2 >= opt->maxfilter) {
-        opt->maxfilter += HTS_FILTERSINC;
-        if (filters_init(&_FILTERS, opt->maxfilter, HTS_FILTERSINC) == 0) {
-          printf("PANIC! : Too many filters : >%d [%d]\n", (*_FILTERS_PTR),
-                 __LINE__);
-          fflush(stdout);
-          hts_log_print(opt, LOG_PANIC, "Too many filters, giving up..(>%d)",
-                        (*_FILTERS_PTR));
-          hts_log_print(opt, LOG_INFO,
-                        "To avoid that: use #F option for more filters (example: -#F5000)");
-          assertf("too many filters - giving up" == NULL);      // wild..
-        }
-      }
-      // here we have enough room for a new filter if necessary
-
       hts_wizard_apply_verdict(opt, n, adr, fil, &forbidden_url, set_prio_to);
-
-      /* the pattern half of the answer */
-      {
-        char BIGSTK pattern[HTS_FILTER_SLOT_SIZE];
-        htsbuff f = htsbuff_array(pattern);
-        int slot;
-
-        for (slot = 0; slot < HTS_WIZARD_MAX_FILTERS; slot++) {
-          hts_wizard_answer_filter(
-              &f, slot, n, adr, fil,
-              (opt->seeker & HTS_SEEKER_UP) != 0 ? HTS_TRUE : HTS_FALSE);
-          if (f.len == 0)
-            break;
-          HT_INSERT_FILTERS0; // insert at slot 0
-          strlcpybuff(_FILTERS[0], pattern, HTS_FILTER_SLOT_SIZE);
-        }
-      }
+      hts_wizard_insert_filters(opt, n, adr, fil,
+                                (opt->seeker & HTS_SEEKER_UP) != 0 ? HTS_TRUE
+                                                                   : HTS_FALSE);
 
     }                           // test du wizard sur l'url
   }                             // fin du test wizard..
@@ -1068,5 +1062,3 @@ int hts_testlinksize(httrackp * opt, const char *adr, const char *fil, LLint siz
   }
   return jok;
 }
-
-#undef HT_INSERT_FILTERS0

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -936,7 +936,7 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
           htsbuff added = htsbuff_array(list);
           int slot;
 
-          /* read the slots back, so the log cannot drift from what was applied */
+          /* read the slots back, so the log cannot drift from them */
           for (slot = opt->wizard_filters - inserted;
                slot < opt->wizard_filters; slot++) {
             if (added.len != 0)

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -339,6 +339,10 @@ void hts_wizard_insert_filters(httrackp *opt, int n, const char *adr,
       assertf("too many filters - giving up" == NULL); // wild..
     }
   }
+  /* a counter outliving its array (an opt reused for a second crawl) would
+     index past the end */
+  if (opt->wizard_filters > *opt->filters.filptr)
+    opt->wizard_filters = *opt->filters.filptr;
   for (slot = 0; slot < HTS_WIZARD_MAX_FILTERS; slot++) {
     hts_wizard_answer_filter(&f, slot, n, adr, fil, seeker_up);
     if (f.len == 0)

--- a/src/htswizard.h
+++ b/src/htswizard.h
@@ -57,6 +57,10 @@ hts_boolean hts_robots_forbids(httrackp *opt, const char *adr, const char *fil,
                                hts_boolean filters_decided,
                                hts_boolean filters_refused);
 
+/* Per-slot capacity of the filters array, matching the slot stride allocated by
+   filters_init() in htscore.c (HTS_URLMAXSIZE * 2). */
+#define HTS_FILTER_SLOT_SIZE (HTS_URLMAXSIZE * 2)
+
 /* Most filters one wizard answer can add. Slots must stay contiguous: the
    caller stops at the first empty one. */
 #define HTS_WIZARD_MAX_FILTERS 2
@@ -67,6 +71,14 @@ hts_boolean hts_robots_forbids(httrackp *opt, const char *adr, const char *fil,
    HTS_SEEKER_UP bit of opt->seeker, read by answer 5. */
 void hts_wizard_answer_filter(htsbuff *f, int slot, int n, const char *adr,
                               const char *fil, hts_boolean seeker_up);
+
+/* Records the filters answer `n` leaves behind for the link (adr,fil), on top
+   of the wizard's own block at the low indices of opt->filters. Last match
+   wins, so a later answer outranks an earlier one, while the command-line
+   filters sitting above the block outrank every answer. Grows the array as
+   needed; the verdict half is hts_wizard_apply_verdict(). */
+void hts_wizard_insert_filters(httrackp *opt, int n, const char *adr,
+                               const char *fil, hts_boolean seeker_up);
 
 /* Which host-scope range answer `n` falls in: HTS_TRUE excludes the scope,
    HTS_FALSE includes it, HTS_DEFAULT for any answer outside both ranges. */

--- a/src/htswizard.h
+++ b/src/htswizard.h
@@ -75,8 +75,8 @@ void hts_wizard_answer_filter(htsbuff *f, int slot, int n, const char *adr,
 /* Records the filters answer `n` leaves behind for the link (adr,fil), on top
    of the wizard's own block at the low indices of opt->filters. Last match
    wins, so a later answer outranks an earlier one, while the command-line
-   filters sitting above the block outrank every answer. Grows the array as
-   needed; the verdict half is hts_wizard_apply_verdict(). */
+   filters sitting above the block outrank every answer. The verdict half is
+   hts_wizard_apply_verdict(). */
 void hts_wizard_insert_filters(httrackp *opt, int n, const char *adr,
                                const char *fil, hts_boolean seeker_up);
 

--- a/tests/297_engine-wizard-precedence.test
+++ b/tests/297_engine-wizard-precedence.test
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+# #1250: the array the wizard hands the matcher, fed back to the matcher. Last
+# match wins, so the block order below is the precedence.
+
+# answering "ignore this link" and then "mirror the whole host" takes it back
+list=$(httrack -O /dev/null -#test=wizardinsert h /dir/one.html 0 6)
+test "$list" = "-h/dir/one.html +h/*" || fail "answer order: got [$list]"
+# shellcheck disable=SC2086 # the array is one filter per word, by construction
+assert_selftest "verdict=allowed rule=1" filterdual http://h/dir/one.html h/dir/one.html $list
+
+# the reverse order still refuses, so the block is ordered rather than sorted
+list=$(httrack -O /dev/null -#test=wizardinsert h /dir/one.html 6 0)
+test "$list" = "+h/* -h/dir/one.html" || fail "reverse order: got [$list]"
+# shellcheck disable=SC2086
+assert_selftest "verdict=forbidden rule=1" filterdual http://h/dir/one.html h/dir/one.html $list
+
+# a standing command-line rule is not revoked by "mirror the whole host"
+list=$(httrack -O /dev/null -#test=wizardinsert h /dir/one.html 6 @ "-h/*.zip")
+test "$list" = "+h/* -h/*.zip" || fail "command line: got [$list]"
+# shellcheck disable=SC2086
+assert_selftest "verdict=forbidden rule=1" filterdual http://h/a.zip h/a.zip $list
+
+assert_selftest "wizardinsert self-test OK" wizardinsert

--- a/tests/297_engine-wizard-precedence.test
+++ b/tests/297_engine-wizard-precedence.test
@@ -6,8 +6,7 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "$(dirname "$0")/testlib.sh"
 
-# #1250: the array the wizard hands the matcher, fed back to the matcher. Last
-# match wins, so the block order below is the precedence.
+# #1250: last match wins, so the order below is each answer's precedence.
 
 # answering "ignore this link" and then "mirror the whole host" takes it back
 list=$(httrack -O /dev/null -#test=wizardinsert h /dir/one.html 0 6)


### PR DESCRIPTION
`fa_strjoker` lets the last matching filter win, but every wizard answer was inserted at index 0, at the bottom of the precedence order: the command line outranked it, and so did every earlier answer. Answer "ignore this link" and then "mirror the whole host" for the same host and the first link stays excluded, with no way to take it back.

The answers now form a block at the low indices of the filter array, each new one appended at the end of that block. A later answer beats an earlier one, which is how a user corrects a misclick, and the command-line filters stay above the block, so a standing `-*.zip` survives a "mirror this domain" answer given mid-crawl. `opt->wizard_filters` carries the block size, appended at the tail of `httrackp`, so no ABI break.

The primary link's own scope filter, recorded before any question is asked, is now the weakest entry of the block instead of the strongest, and a later answer can override it. Nothing relied on the old order: a link that filter matches is authorized before the question is reached, so the two never compete. The old "renversement wizard/primary filter" note is about answer 4 capping recursion depth, not about filter indices.

The insertion path is one function now, `hts_wizard_insert_filters()`, so test 297 asserts the ordering without a crawl. It goes red on the pre-fix tree, and on an append-at-the-end variant that would let an answer outrank the command line.

#1249 rewrites the same insert loop, so whichever of the two merges second has to make its log echo read the slot the filter was inserted at rather than `_FILTERS[0]`, or its claim that the log cannot drift from the applied filter stops holding.

Closes #1250