### PR TITLE
doit.log writes a leading quote raw and swallows the options after it

### DIFF
--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -2734,9 +2734,10 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                    "wb");
         if (fp) {
           for(i = 0 + 1; i < argc; i++) {
-            if (((strchr(argv[i], ' ') != NULL)
-                 || (strchr(argv[i], '"') != NULL)
-                 || (strchr(argv[i], '\\') != NULL)) && (argv[i][0] != '"')) {
+            /* argv[] is already unquoted here, so a leading quote is data */
+            if ((strchr(argv[i], ' ') != NULL) ||
+                (strchr(argv[i], '"') != NULL) ||
+                (strchr(argv[i], '\\') != NULL)) {
               size_t j;
 
               fprintf(fp, "\"");

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -2750,9 +2750,9 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                   fprintf(fp, "%c", argv[i][j]);
               }
               fprintf(fp, "\"");
-            } else if (strnotempty(argv[i]) == 0) {     // ""
+            } else if (strnotempty(argv[i]) == 0) { // ""
               fprintf(fp, "\"\"");
-            } else {            // non critique
+            } else { // nothing to escape
               fprintf(fp, "%s", argv[i]);
             }
             if (i < argc - 1)

--- a/tests/01_engine-doitlog.test
+++ b/tests/01_engine-doitlog.test
@@ -114,4 +114,52 @@ grep -q ' -%F "" -r2' "$out2/hts-cache/doit.log" || {
     exit 1
 }
 
+# --- 4. a value whose first character is a quote survives the round-trip -----
+# The command line needs two leading quotes: the -O pass strips one pair in
+# place, leaving the footer "<!-- MARK -->, which the writer must escape. Left
+# raw it reopens a quote, so the reader swallows the rest of the line into the
+# footer and -r2 is lost for good. Asserted on the mirrored page, not just on
+# doit.log, so a writer/reader pair that agrees on a wrong value still fails.
+out3="$tmp/out3"
+site3="$tmp/site3"
+footer='"<!-- MARK -->'
+# the footer is injected into the html body, so this fixture needs real tags
+mkdir -p "$site3"
+printf '<html><body><a href="a.html">a</a></body></html>' >"$site3/index.html"
+echo '<html><body>aaa</body></html>' >"$site3/a.html"
+rc=0
+"$bin" "file://$site3/index.html" -O "$out3" --quiet -n -%v0 \
+    -%F "\"$footer\"" -r2 >/dev/null 2>&1 || rc=$?
+test "$rc" -eq 0 || {
+    echo "FAIL: initial mirror with a leading-quote footer exited $rc"
+    exit 1
+}
+page=$(find "$out3" -path '*/site3/index.html' -print -quit)
+test -n "$page" || {
+    echo "FAIL: mirrored page missing after the leading-quote mirror"
+    exit 1
+}
+grep -qF "$footer" "$page" || {
+    echo "FAIL: run 1 did not inject the footer verbatim"
+    exit 1
+}
+rc=0
+"$bin" -O "$out3" --quiet >/dev/null 2>&1 || rc=$?
+test "$rc" -eq 0 || {
+    echo "FAIL: leading-quote reprise exited $rc"
+    exit 1
+}
+grep -qF "$footer" "$page" || {
+    echo "FAIL: the footer changed across the reprise (leading quote written raw?)"
+    grep -o '<!--[^>]*MARK[^>]*-->' "$page" | head -1
+    exit 1
+}
+# -r2 sits after the footer. A plain ' -r2' match would also hit it *inside* a
+# swallowed footer, so pin the escaped token and its neighbour instead.
+grep -qF -- '-%F "\"<!-- MARK -->" -r2' "$out3/hts-cache/doit.log" || {
+    echo "FAIL: footer and -r2 are not two tokens in the regenerated doit.log"
+    head -1 "$out3/hts-cache/doit.log"
+    exit 1
+}
+
 exit 0

--- a/tests/01_engine-doitlog.test
+++ b/tests/01_engine-doitlog.test
@@ -115,11 +115,8 @@ grep -q ' -%F "" -r2' "$out2/hts-cache/doit.log" || {
 }
 
 # --- 4. a value whose first character is a quote survives the round-trip -----
-# The command line needs two leading quotes: the -O pass strips one pair in
-# place, leaving the footer "<!-- MARK -->, which the writer must escape. Left
-# raw it reopens a quote, so the reader swallows the rest of the line into the
-# footer and -r2 is lost for good. Asserted on the mirrored page, not just on
-# doit.log, so a writer/reader pair that agrees on a wrong value still fails.
+# Two leading quotes, because the -O pass strips one pair: the footer keeps a
+# leading quote, which reopens on reprise and swallows -r2 unless escaped.
 out3="$tmp/out3"
 site3="$tmp/site3"
 footer='"<!-- MARK -->'


### PR DESCRIPTION
httrack wrote an argument into `hts-cache/doit.log` unquoted and unescaped whenever its first character was already a quote. Against the raw command line that guard makes sense. But by the time the writer runs, the `-O` pass has stripped one layer of surrounding quotes in place, so a leading quote is data, not syntax. Written raw it opens a quote that never closes, and the next run pulls everything after it into that one argument.

A footer of `"<!-- x -->` loses every option recorded after `-%F`. The reprise then rewrites doit.log from the corrupted parse, so the loss carries into every later update, and the mirrored page footer differs between the first run and the second. Reaching it takes two leading quotes on the command line, since the `-O` pass eats one pair, which is the shape the GUI front ends produce when they wrap an argument in literal quotes (xroche/httrack-windows#122).

One class is not fixed and changes failure mode, so it is worth stating plainly. A plain argument (not an option value) whose value starts with a quote and does not end with one now aborts the reprise with `Missing quote`, where master silently dropped the quote instead. The abort precedes the writer, so the no-argument update stays dead until the mirror is re-run with its URL. Option values are unaffected: they bypass the second strip pass. It takes three leading quotes typed by hand to reach, since the single-pair shape a front end emits already panics on the first run, on master too. #1263 has the asymmetry behind it.

Section 4 of `01_engine-doitlog.test` checks the footer on the mirrored page rather than the doit.log text alone, so a writer and reader that agree on a wrong value still fail it. A differential over 11 argv shapes moves only the leading-quote cases.