### PR TITLE
The per-option argument caps are literals the front ends have to copy

### DIFF
--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -1565,7 +1565,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                   return -1;
                 } else {
                   na++;
-                  if (strlen(argv[na]) >= 254) {
+                  if (strlen(argv[na]) >= HTS_FILELIST_MAXSIZE) {
                     HTS_PANIC_PRINTF("File list string too long");
                     htsmain_free();
                     return -1;
@@ -1582,7 +1582,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                   return -1;
                 } else {
                   na++;
-                  if (strlen(argv[na]) >= 254) {
+                  if (strlen(argv[na]) >= HTS_BINDHOST_MAXSIZE) {
                     HTS_PANIC_PRINTF("Hostname string too long");
                     htsmain_free();
                     return -1;
@@ -1683,7 +1683,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                   return -1;
                 } else {
                   na++;
-                  if (strlen(argv[na]) >= 62) {
+                  if (strlen(argv[na]) >= HTS_LANGISO_MAXSIZE) {
                     HTS_PANIC_PRINTF("Lang list string too long");
                     htsmain_free();
                     return -1;
@@ -1740,7 +1740,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                   return -1;
                 } else {
                   na++;
-                  if (strlen(argv[na]) >= 254) {
+                  if (strlen(argv[na]) >= HTS_FOOTER_MAXSIZE) {
                     HTS_PANIC_PRINTF("Footer string too long");
                     htsmain_free();
                     return -1;
@@ -1841,7 +1841,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                   return -1;
                 } else {
                   na++;
-                  if (strlen(argv[na]) >= 254) {
+                  if (strlen(argv[na]) >= HTS_REFERER_MAXSIZE) {
                     HTS_PANIC_PRINTF("Referer URL too long");
                     htsmain_free();
                     return -1;
@@ -1858,7 +1858,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                   return -1;
                 } else {
                   na++;
-                  if (strlen(argv[na]) >= 254) {
+                  if (strlen(argv[na]) >= HTS_FROMEMAIL_MAXSIZE) {
                     HTS_PANIC_PRINTF("From email too long");
                     htsmain_free();
                     return -1;

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -219,6 +219,16 @@ Please visit our Website: http://www.httrack.com
    the longest registered MIME type, the Office OOXML ones reaching 73 chars */
 #define HTS_MIMETYPE_SIZE 128
 
+/* Caps on single option arguments, in bytes, exclusive like the two above: an
+   argument this long or longer is rejected. The GUI front ends validate their
+   input fields against these, so each value is a cross-repo contract. */
+#define HTS_FOOTER_MAXSIZE 254    /* -%F */
+#define HTS_LANGISO_MAXSIZE 62    /* -%l */
+#define HTS_REFERER_MAXSIZE 254   /* -%R */
+#define HTS_FILELIST_MAXSIZE 254  /* -%L */
+#define HTS_BINDHOST_MAXSIZE 254  /* -%b */
+#define HTS_FROMEMAIL_MAXSIZE 254 /* -%E */
+
 /* Copyright (C) 1998 Xavier Roche and other contributors */
 #define HTTRACK_AFF_AUTHORS "[XR&CO'2014]"
 /* Named fields (hts_footer_format); a "%s" anywhere would switch the template

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -219,9 +219,9 @@ Please visit our Website: http://www.httrack.com
    the longest registered MIME type, the Office OOXML ones reaching 73 chars */
 #define HTS_MIMETYPE_SIZE 128
 
-/* Caps on single option arguments, in bytes, exclusive like the two above: an
-   argument this long or longer is rejected. The GUI front ends validate their
-   input fields against these, so each value is a cross-repo contract. */
+/* Caps on single option arguments, in bytes, exclusive like HTS_CDLMAXSIZE.
+   They bound the value, not a buffer: these option fields are dynamic Strings.
+   Named so the front ends can check against them instead of copying them. */
 #define HTS_FOOTER_MAXSIZE 254    /* -%F */
 #define HTS_LANGISO_MAXSIZE 62    /* -%l */
 #define HTS_REFERER_MAXSIZE 254   /* -%R */

--- a/tests/299_option-arg-caps.test
+++ b/tests/299_option-arg-caps.test
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# The per-option argument caps in htsglobal.h are a cross-repo contract: the
+# GUI front ends validate their input fields against the same numbers, and a
+# mirror only dies once the engine rejects a value the GUI accepted. Pin both
+# sides of each bound, and match each option's own message so a cap wired to
+# the wrong option shows up as the wrong rejection rather than as a pass.
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+bin=$(httrack_path)
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_argcaps.XXXXXX") || exit 1
+cleanup_push rm -rf "$tmp"
+
+echo '<html><body>x</body></html>' >"$tmp/page.html"
+
+# option limit message
+caps="-%F 254 Footer string too long
+-%l 62 Lang list string too long
+-%R 254 Referer URL too long
+-%L 254 File list string too long
+-%b 254 Hostname string too long
+-%E 254 From email too long"
+
+run() { # option value tag
+    "$bin" "file://$tmp/page.html" -O "$tmp/out$3" --quiet -n -%v0 "$1" "$2" 2>&1
+}
+
+n=0
+while read -r opt limit msg; do
+    n=$((n + 1))
+    val=$(printf "%*s" "$limit" "" | tr ' ' a)
+
+    rc=0
+    out=$(run "$opt" "${val%a}" "${n}a") || rc=$?
+    assert_eq 0 "$rc" "$opt rejected a value one byte under its cap"
+
+    rc=0
+    out=$(run "$opt" "$val" "${n}b") || rc=$?
+    test "$rc" -ne 0 || fail "$opt accepted a value of exactly $limit bytes"
+    grep -qF "$msg" <<<"$out" || fail "$opt rejected at its cap, but not with \"$msg\""
+done <<<"$caps"
+
+test "$n" -eq 6 || fail "expected 6 caps, checked $n"
+
+exit 0

--- a/tests/299_option-arg-caps.test
+++ b/tests/299_option-arg-caps.test
@@ -1,10 +1,8 @@
 #!/bin/bash
 #
-# The per-option argument caps in htsglobal.h are a cross-repo contract: the
-# GUI front ends validate their input fields against the same numbers, and a
-# mirror only dies once the engine rejects a value the GUI accepted. Pin both
-# sides of each bound, and match each option's own message so a cap wired to
-# the wrong option shows up as the wrong rejection rather than as a pass.
+# Pin each option's cap against the macro htsglobal.h declares for it, so the
+# header and the engine cannot drift apart. Limits are read from the header
+# rather than copied here, which is the duplication the macros exist to end.
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
@@ -12,36 +10,48 @@ set -euo pipefail
 
 bin=$(httrack_path)
 
+testdir=$(cd "$(dirname "$0")" && pwd)
+hdr="$(cd "${top_srcdir:-${testdir}/..}" && pwd)/src/htsglobal.h"
+assert_file "$hdr" "no htsglobal.h to read the caps from"
+
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_argcaps.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmp"
 
 echo '<html><body>x</body></html>' >"$tmp/page.html"
 
-# option limit message
-caps="-%F 254 Footer string too long
--%l 62 Lang list string too long
--%R 254 Referer URL too long
--%L 254 File list string too long
--%b 254 Hostname string too long
--%E 254 From email too long"
+# POSIX BRE only: BSD sed has no \+
+cap() {
+    sed -n "s/^#define $1[[:space:]][[:space:]]*\([0-9][0-9]*\).*/\1/p" "$hdr"
+}
 
 run() { # option value tag
     "$bin" "file://$tmp/page.html" -O "$tmp/out$3" --quiet -n -%v0 "$1" "$2" 2>&1
 }
 
+# option macro message
+caps="-%F HTS_FOOTER_MAXSIZE Footer string too long
+-%l HTS_LANGISO_MAXSIZE Lang list string too long
+-%R HTS_REFERER_MAXSIZE Referer URL too long
+-%L HTS_FILELIST_MAXSIZE File list string too long
+-%b HTS_BINDHOST_MAXSIZE Hostname string too long
+-%E HTS_FROMEMAIL_MAXSIZE From email too long"
+
 n=0
-while read -r opt limit msg; do
+while read -r opt macro msg; do
     n=$((n + 1))
+    limit=$(cap "$macro")
+    test "${limit:-0}" -gt 1 || fail "$macro: no usable cap read from htsglobal.h"
     val=$(printf "%*s" "$limit" "" | tr ' ' a)
 
     rc=0
-    out=$(run "$opt" "${val%a}" "${n}a") || rc=$?
-    assert_eq 0 "$rc" "$opt rejected a value one byte under its cap"
+    run "$opt" "${val%a}" "${n}a" >/dev/null || rc=$?
+    assert_eq 0 "$rc" "$opt rejected a value one byte under $macro ($limit)"
 
     rc=0
     out=$(run "$opt" "$val" "${n}b") || rc=$?
-    test "$rc" -ne 0 || fail "$opt accepted a value of exactly $limit bytes"
-    grep -qF "$msg" <<<"$out" || fail "$opt rejected at its cap, but not with \"$msg\""
+    test "$rc" -ne 0 || fail "$opt accepted a value of exactly $macro ($limit)"
+    # the message pins which check fired, so an unrelated panic cannot pass
+    grep -qF "$msg" <<<"$out" || fail "$opt was not rejected by \"$msg\""
 done <<<"$caps"
 
 test "$n" -eq 6 || fail "expected 6 caps, checked $n"


### PR DESCRIPTION
`htscoremain.c` held the caps for six option arguments as bare `254` and `62` literals at the option sites. The GUI front ends carry their own copies of three of them, and nothing links the two, so a changed cap shows up only when a user's mirror dies on a value the GUI accepted.

They move to `htsglobal.h`, which already reaches the front ends through `HTTrackInterface.h`, and keep the exclusive bound the existing checks use, so no boundary shifts by one. Naming all six rather than the three asked for avoids leaving a shared-looking `254` next to them for someone to cross-wire later.

No behavior change: every boundary was probed against master, one byte under and exactly at each cap, with identical results. `299_option-arg-caps.test` reads each limit out of the header rather than copying it, so it pins the engine against `htsglobal.h` instead of against a second copy of the numbers.