### PR TITLE
local_crawl cannot feed the engine's stdin

### DIFF
--- a/tests/258_crawllib.test
+++ b/tests/258_crawllib.test
@@ -214,7 +214,9 @@ ok "--log takes the crawl output, one crawl at a time"
 cat >"${shim}/httrack" <<'SH'
 #!/bin/bash
 printf 'stdin=['
-cat 2>/dev/null || printf closed
+# uutils cat does not fail on a closed fd, so ask the shell; the subshell keeps
+# an exec redirection error from taking bash 3.2 down with it
+if (exec 3<&0) 2>/dev/null; then cat 2>/dev/null; else printf closed; fi
 printf ']\n'
 SH
 chmod +x "${shim}/httrack"

--- a/tests/258_crawllib.test
+++ b/tests/258_crawllib.test
@@ -206,6 +206,33 @@ local_crawl --log "${tmpdir}/crawl.log" -O /dev/null "$url"
 assert_eq "crawl-said-this" "$(cat "${tmpdir}/crawl.log")" "--log truncates per crawl"
 ok "--log takes the crawl output, one crawl at a time"
 
+## --stdin feeds the engine, which a redirect on the call cannot be trusted to do
+# Three outcomes on one line, so a closed descriptor is told apart from the empty
+# read /dev/null gives.
+# Written straight out, never through $(cat): with fd 0 closed a command
+# substitution takes the free slot 0 for its pipe and the read blocks forever.
+cat >"${shim}/httrack" <<'SH'
+#!/bin/bash
+printf 'stdin=['
+cat 2>/dev/null || printf closed
+printf ']\n'
+SH
+chmod +x "${shim}/httrack"
+
+printf answer >"${tmpdir}/answers"
+# Against a call redirected elsewhere: --stdin is on the engine, so it wins.
+local_crawl --stdin "${tmpdir}/answers" --log "${tmpdir}/crawl.log" \
+    -O /dev/null "$url" </dev/null
+assert_eq "stdin=[answer]" "$(cat "${tmpdir}/crawl.log")" "--stdin FILE"
+local_crawl --stdin closed --log "${tmpdir}/crawl.log" \
+    -O /dev/null "$url" <"${tmpdir}/answers"
+assert_eq "stdin=[closed]" "$(cat "${tmpdir}/crawl.log")" "--stdin closed"
+# Without the option the engine still has a descriptor, whatever the platform
+# gives a background job.
+local_crawl --log "${tmpdir}/crawl.log" -O /dev/null "$url" </dev/null
+assert_eq "stdin=[]" "$(cat "${tmpdir}/crawl.log")" "the default stdin"
+ok "--stdin hands the engine a file, or no descriptor at all"
+
 ## The watchdog reds a crawl that never ends, from a subject: it ends the test
 cat >"${shim}/httrack" <<'SH'
 #!/bin/bash

--- a/tests/294_local-wizard-eof.test
+++ b/tests/294_local-wizard-eof.test
@@ -5,8 +5,6 @@ set -eu
 # shellcheck source=tests/crawllib.sh
 . "$(dirname "$0")/crawllib.sh"
 
-httrack=$(command -v httrack) || ! echo "could not find httrack" >&2 || exit 1
-
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_1247.XXXXXX") || exit 1
 cleanup() {
     rm -rf "$tmpdir"
@@ -33,15 +31,14 @@ cat >"${tmpdir}/root/wizardeof/index.html" <<EOF
 EOF
 local_server_start --root "${tmpdir}/root"
 
-# crawl LABEL; the caller redirects the stdin the wizard will read from
+# crawl LABEL STDIN; STDIN is what the wizard reads from
 crawl() {
     local label=$1 rc=0 asked
 
-    run_with_timeout 60 "$httrack" -O "${tmpdir}/$label" -W --robots=0 \
-        --retries=0 "http://127.0.0.1:${SRV_PORT}/wizardeof/index.html" \
-        >"${tmpdir}/$label.log" 2>&1 || rc=$?
+    local_crawl --stdin "$2" --log "${tmpdir}/$label.log" -- \
+        -O "${tmpdir}/$label" -W --robots=0 --retries=0 \
+        "http://127.0.0.1:${SRV_PORT}/wizardeof/index.html" || rc=$?
 
-    test "$rc" -ne 124 || fail "$label: the wizard never returned"
     test "$rc" -eq 0 || fail "$label: the crawl exited $rc"
     # asked once and then stopped: refusing this one link would ask again
     asked=$(grep -c "beyond this mirror scope" "${tmpdir}/$label.log" || true)
@@ -52,6 +49,6 @@ crawl() {
         fail "$label: the refused link was mirrored"
 }
 
-crawl eof </dev/null
+crawl eof /dev/null
 # a closed descriptor sets only ferror, where EOF sets only feof
-crawl closed <&-
+crawl closed closed

--- a/tests/296_local-wizard-delayed.test
+++ b/tests/296_local-wizard-delayed.test
@@ -8,8 +8,6 @@ set -euo pipefail
 # shellcheck source=tests/crawllib.sh
 . "$(dirname "$0")/crawllib.sh"
 
-httrack=$(httrack_path)
-
 # "mirror this link"
 WIZARD_MIRROR=5
 # spare answers: an empty one means "ignore this link", and EOF spins the
@@ -41,16 +39,10 @@ local_server_start --root "${tmpdir}/root"
 answers="${tmpdir}/answers"
 for _ in $(seq "$WIZARD_SPARES"); do echo "$WIZARD_MIRROR"; done >"$answers"
 
-# redirect here, not in run_with_timeout's args: it backgrounds the job with
-# stdin closed (#1258)
-crawl() { "$httrack" "$@" <"$answers"; }
-
 rc=0
-run_with_timeout "$(crawl_deadline)" crawl --max-time="$CRAWL_MAX_TIME" \
+local_crawl --stdin "$answers" --log "${tmpdir}/crawl.log" -- \
     -O "${tmpdir}/mirror" -W --robots=0 --retries=0 \
-    "http://127.0.0.1:${SRV_PORT}/wizdelayed/index.html" \
-    >"${tmpdir}/crawl.log" 2>&1 || rc=$?
-test "$rc" -ne 124 || fail "the crawl never returned"
+    "http://127.0.0.1:${SRV_PORT}/wizdelayed/index.html" || rc=$?
 test "$rc" -eq 0 || fail "the crawl exited $rc"
 
 grep -q 'beyond this mirror scope' "${tmpdir}/crawl.log" ||

--- a/tests/crawllib.sh
+++ b/tests/crawllib.sh
@@ -104,15 +104,23 @@ local_server_start() {
 # backstops most of these tests lacked: a --max-time cap (skipped when the caller
 # sets its own) and a watchdog above it, so a wedge outliving the engine limit
 # reds the test instead of the 45-minute CI timeout.
-# One option, ahead of any httrack argument; -- ends it:
+# Options, ahead of any httrack argument; -- ends them:
 #   --log FILE     crawl output (default: discarded)
+#   --stdin FILE   what the engine reads on stdin, for a test answering an
+#                  interactive prompt; the word "closed" hands it no descriptor
+#                  at all. Redirecting the local_crawl call instead does not
+#                  reach the engine (#1258).
 local_crawl() {
-    local deadline log=/dev/null arg rc=0
+    local deadline log=/dev/null stdin=() arg rc=0
     deadline=$(crawl_deadline)
     while test $# -gt 0; do
         case $1 in
         --log)
             log=$2
+            shift 2
+            ;;
+        --stdin)
+            stdin=(--stdin "$2")
             shift 2
             ;;
         --)
@@ -129,7 +137,8 @@ local_crawl() {
     done
     args+=("$@")
 
-    run_with_timeout "$deadline" httrack "${args[@]}" >"$log" 2>&1 || rc=$?
+    run_with_timeout ${stdin[@]+"${stdin[@]}"} "$deadline" httrack "${args[@]}" \
+        >"$log" 2>&1 || rc=$?
     test "$rc" -ne 124 || fail "crawl watchdog fired after ${deadline}s"
     return "$rc"
 }

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -625,13 +625,28 @@ reap_bounded() {
 # macOS and its signals can't reap httrack.exe on Windows. We poll and kill_tree.
 # All three deadlines below compare strictly: $SECONDS is floored, so a reading of
 # the budget can be a fraction under it, and firing early kills healthy work.
+# One option, ahead of the deadline:
+#   --stdin FILE   read FILE, or nothing at all with the word "closed". A
+#                  redirect on the caller does not reach here: where job control
+#                  is off, bash gives a background job /dev/null (#1258). The
+#                  redirect stays on the job, so the target is still our direct
+#                  child and kill_tree keeps signalling it rather than a wrapper.
 run_with_timeout() {
+    local stdin=''
+    if test "${1:-}" = --stdin; then
+        stdin=$2
+        shift 2
+    fi
     local secs=$1
     shift
     local had_m=
     case "$-" in *m*) had_m=1 ;; esac
     is_windows || set -m # own process group, so kill_tree can signal the group
-    "$@" &
+    case $stdin in
+    '') "$@" & ;;
+    closed) "$@" <&- & ;;
+    *) "$@" <"$stdin" & ;;
+    esac
     local pid=$!
     test -n "$had_m" || is_windows || set +m
     # Read while the job is certainly alive: by kill time /proc/<pid>/winpid is gone.


### PR DESCRIPTION
`local_crawl` takes a `--stdin FILE` option, plus the word `closed` for a test that must hand the engine no descriptor at all. The redirect goes on the engine, not on the `local_crawl` call: `run_with_timeout` backgrounds the job, and where job control is off bash gives a background job `/dev/null` for stdin, so a redirect written on the call never arrives. Both wizard tests had rebuilt the helper's body around a wrapper carrying the redirect, which cost them its watchdog and `--max-time` backstop; they go back to the helper here.

`run_with_timeout` applies the redirect itself rather than through a wrapper function, so the engine is still its direct child and `kill_tree` signals the engine instead of a shell in between. 258 reads the three cases off a shim: a file, a closed descriptor, and the default. Dropping the forwarding reds 258 and 296; dropping the closed branch reds 258 and 294.

Closes #1258
