### PR TITLE
Test 295 expects a wizard verdict string that #1254 retired

### DIFF
--- a/tests/295_wizard-log.test
+++ b/tests/295_wizard-log.test
@@ -53,7 +53,7 @@ grep -q "$tag '2' (n=2) for $link: forbidden, filters: -other.invalid/[*]\$" "$l
 # misses the apex, so both slots must reach the log, in insertion order
 answers 1000
 crawl "$tmp/m1000" -W
-grep -q "$tag '1000' (n=1000) for $link: no verdict, filters: [+][*].other.invalid/[*] [+]other.invalid/[*]\$" "$log" ||
+grep -q "$tag '1000' (n=1000) for $link: allowed, filters: [+][*].other.invalid/[*] [+]other.invalid/[*]\$" "$log" ||
     fail "a two-filter answer is not logged whole in $log"
 
 # nobody was asked: the automatic resolution stays at the debug level. This run


### PR DESCRIPTION
#1254 changed what the wizard log line says: an answer that does not forbid now resolves to 0 at the end of `hts_wizard_apply_verdict()`, so an accepting answer logs `allowed` where test 295 still expects `no verdict`. Each of the two PRs was green on its own branch, which is why nothing caught it before both landed. Master has been red since #1249 went in second.

The engine is right and the assertion is stale, so this moves the expected string and nothing else. Full suite back to 317 pass, 12 skip, 0 fail.
