### PR TITLE
A doit.log argument that begins with a quote is stripped twice

### DIFF
--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -588,6 +588,7 @@ const char *optalias_help(const char *token) {
    if it cannot. */
 static hts_boolean cmdl_reserve(cmdl_argv *cmd, int count) {
   char **slots;
+  hts_boolean *flags;
   int capacity;
 
   if (count <= cmd->capacity)
@@ -603,6 +604,12 @@ static hts_boolean cmdl_reserve(cmdl_argv *cmd, int count) {
   if (slots == NULL)
     return HTS_FALSE;
   cmd->argv = slots;
+  /* hts_boolean is no wider than a pointer, so this cannot wrap either */
+  flags = (hts_boolean *) realloct(cmd->unquoted,
+                                   sizeof(hts_boolean) * (size_t) capacity);
+  if (flags == NULL) /* argv stays grown; capacity does not, so it is retried */
+    return HTS_FALSE;
+  cmd->unquoted = flags;
   cmd->capacity = capacity;
   return HTS_TRUE;
 }
@@ -619,6 +626,7 @@ hts_boolean cmdl_init(cmdl_argv *cmd, int slots) {
 void cmdl_free(cmdl_argv *cmd) {
   hts_arena_free(&cmd->tokens);
   freet(cmd->argv);
+  freet(cmd->unquoted);
   memset(cmd, 0, sizeof(*cmd));
 }
 
@@ -633,10 +641,20 @@ hts_boolean cmdl_ins(cmdl_argv *cmd, const char *token, int pos) {
   copy = hts_arena_strdup(&cmd->tokens, token);
   if (copy == NULL)
     return HTS_FALSE;
-  for (i = cmd->argc; i > pos; i--)
+  for (i = cmd->argc; i > pos; i--) {
     cmd->argv[i] = cmd->argv[i - 1];
+    cmd->unquoted[i] = cmd->unquoted[i - 1];
+  }
   cmd->argv[pos] = copy;
+  cmd->unquoted[pos] = HTS_FALSE;
   cmd->argc++;
+  return HTS_TRUE;
+}
+
+hts_boolean cmdl_ins_unquoted(cmdl_argv *cmd, const char *token, int pos) {
+  if (!cmdl_ins(cmd, token, pos))
+    return HTS_FALSE;
+  cmd->unquoted[pos] = HTS_TRUE;
   return HTS_TRUE;
 }
 

--- a/src/htsalias.h
+++ b/src/htsalias.h
@@ -59,6 +59,9 @@ void expand_home(String * str);
    and every pointer a caller kept into one, valid. */
 typedef struct {
   char **argv; /* argc slots used out of capacity allocated */
+  /* per slot: the token arrived already unquoted, so the parser must not strip
+     a quote pair off it again (doit.log tokens, unquoted by next_token) */
+  hts_boolean *unquoted;
   int argc;
   int capacity;
   hts_arena tokens;
@@ -79,6 +82,10 @@ hts_boolean cmdl_add(cmdl_argv *cmd, const char *token);
    HTS_FALSE if it does not fit and neither the slots nor the arena can be
    grown. */
 hts_boolean cmdl_ins(cmdl_argv *cmd, const char *token, int pos);
+
+/* cmdl_ins for a token that has already been unquoted by its reader, marking
+   it so the parser leaves its quotes alone. */
+hts_boolean cmdl_ins_unquoted(cmdl_argv *cmd, const char *token, int pos);
 
 typedef enum {
   CMDL_FILE_MISSING, /* not found, or unreadable */

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -252,7 +252,7 @@ HTSEXT_API int hts_main2(int argc, char **argv, httrackp * opt) {
 
 static int hts_main_internal(int argc, char **argv, httrackp * opt) {
   /* command line rebuilt from argv, config files and doit.log */
-  cmdl_argv x_cmd = {NULL, 0, 0, {NULL, 0, 0}};
+  cmdl_argv x_cmd = {NULL, NULL, 0, 0, {NULL, 0, 0}};
 
   //
   int argv_url = -1;            // ==0 : utiliser cache et doit.log
@@ -623,7 +623,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
         /* Insert parameters BUT so that they can be in the same order */
         if (lastp) {
           if (strnotempty(lastp) || quoted) {
-            if (!cmdl_ins(&x_cmd, lastp, insert_after)) {
+            if (!cmdl_ins_unquoted(&x_cmd, lastp, insert_after)) {
               cmdl_free(&x_cmd);
               HTS_PANIC_PRINTF("Error, not enough memory");
               htsmain_free();
@@ -999,9 +999,12 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
     char *com;
     int na;
 
+    /* the flags below are indexed with argv, which still aliases x_cmd */
+    assertf(argv == x_cmd.argv && argc == x_cmd.argc);
+
     for(na = 1; na < argc; na++) {
 
-      if (argv[na][0] == '"') {
+      if (argv[na][0] == '"' && !x_cmd.unquoted[na]) {
         char BIGSTK tempo[HTS_CDLMAXSIZE + 256];
 
         strcpybuff(tempo, argv[na] + 1);

--- a/tests/01_engine-doitlog.test
+++ b/tests/01_engine-doitlog.test
@@ -179,18 +179,21 @@ grep -qF -- '"\"+*foo*"' "$out4/hts-cache/doit.log" || {
     head -1 "$out4/hts-cache/doit.log"
     exit 1
 }
-cp "$out4/hts-cache/doit.log" "$tmp/doit4.before"
+# line 1 only: line 2 carries the generation date, which moves whenever the two
+# runs straddle a second, as they do on a slower machine.
+head -1 "$out4/hts-cache/doit.log" >"$tmp/doit4.before"
 # no arguments at all: any would be recorded too, and the point here is that
-# the file is a fixed point of its own replay.
+# the command line is a fixed point of its own replay.
 rc=0
 (cd "$out4" && "$bin" >/dev/null 2>&1) || rc=$?
 test "$rc" -eq 0 || {
     echo "FAIL: leading-quote filter reprise exited $rc (token stripped twice?)"
     exit 1
 }
-cmp -s "$tmp/doit4.before" "$out4/hts-cache/doit.log" || {
-    echo "FAIL: the reprise rewrote doit.log differently"
-    diff "$tmp/doit4.before" "$out4/hts-cache/doit.log" | head -4
+head -1 "$out4/hts-cache/doit.log" >"$tmp/doit4.after"
+cmp -s "$tmp/doit4.before" "$tmp/doit4.after" || {
+    echo "FAIL: the reprise rewrote the command line differently"
+    diff "$tmp/doit4.before" "$tmp/doit4.after" | head -4
     exit 1
 }
 

--- a/tests/01_engine-doitlog.test
+++ b/tests/01_engine-doitlog.test
@@ -160,10 +160,8 @@ grep -qF -- '-%F "\"<!-- MARK -->" -r2' "$out3/hts-cache/doit.log" || {
 }
 
 # --- 5. a plain argument keeps its leading quote too (#1263) -----------------
-# A filter, not an option value, so it also meets the second strip pass. Three
-# leading quotes, because that pass and the -O one each eat one. The reader
-# unquotes through next_token, so stripping the token again aborts the reprise,
-# and the abort precedes the writer, so every later run repeats it.
+# A filter, not an option value, so it meets the second strip pass too. Three
+# leading quotes: that pass and the -O one each eat one.
 out4="$tmp/out4"
 site4="$tmp/site4"
 mkdir -p "$site4"

--- a/tests/01_engine-doitlog.test
+++ b/tests/01_engine-doitlog.test
@@ -159,4 +159,41 @@ grep -qF -- '-%F "\"<!-- MARK -->" -r2' "$out3/hts-cache/doit.log" || {
     exit 1
 }
 
+# --- 5. a plain argument keeps its leading quote too (#1263) -----------------
+# A filter, not an option value, so it also meets the second strip pass. Three
+# leading quotes, because that pass and the -O one each eat one. The reader
+# unquotes through next_token, so stripping the token again aborts the reprise,
+# and the abort precedes the writer, so every later run repeats it.
+out4="$tmp/out4"
+site4="$tmp/site4"
+mkdir -p "$site4"
+printf '<html><body><a href="foo.html">f</a></body></html>' >"$site4/index.html"
+echo '<html><body>foo</body></html>' >"$site4/foo.html"
+rc=0
+"$bin" "file://$site4/index.html" -O "$out4" --quiet -n -%v0 '"""+*foo*""' \
+    >/dev/null 2>&1 || rc=$?
+test "$rc" -eq 0 || {
+    echo "FAIL: initial mirror with a leading-quote filter exited $rc"
+    exit 1
+}
+grep -qF -- '"\"+*foo*"' "$out4/hts-cache/doit.log" || {
+    echo "FAIL: the filter was not recorded escaped"
+    head -1 "$out4/hts-cache/doit.log"
+    exit 1
+}
+cp "$out4/hts-cache/doit.log" "$tmp/doit4.before"
+# no arguments at all: any would be recorded too, and the point here is that
+# the file is a fixed point of its own replay.
+rc=0
+(cd "$out4" && "$bin" >/dev/null 2>&1) || rc=$?
+test "$rc" -eq 0 || {
+    echo "FAIL: leading-quote filter reprise exited $rc (token stripped twice?)"
+    exit 1
+}
+cmp -s "$tmp/doit4.before" "$out4/hts-cache/doit.log" || {
+    echo "FAIL: the reprise rewrote doit.log differently"
+    diff "$tmp/doit4.before" "$out4/hts-cache/doit.log" | head -4
+    exit 1
+}
+
 exit 0


### PR DESCRIPTION
Arguments reloaded from `hts-cache/doit.log` reach the parser already unquoted, because `next_token` does that as it splits them. The "Treat parameters" pass then strips a quote pair off any argument whose first character is a quote, and panics when there is no closing one. So a plain argument, a URL or a filter, whose value legitimately begins with a quote either lost it or aborted the reprise. The abort runs before the writer, so doit.log kept its contents and every later no-argument run failed the same way. The mirror could only be resumed by passing its URL again.

Command-line arguments meet that pass once and reloaded ones meet it a second time, so no encoding the writer picks is right for both readers. #1261 made the writer a faithful codec, which is what brought this into view: the token now survives intact and is then stripped again.

The token block carries the provenance instead. `cmdl_argv` grows a per-slot flag and `cmdl_ins_unquoted` sets it for tokens whose reader has already unquoted them, so the pass skips those. `htsalias.h` is not installed, so this is internal. Option values were never affected: the option switch consumes them with `na++`, so the pass never saw them, which is why they round-tripped while plain arguments did not.

Section 5 of `01_engine-doitlog.test` covers it. It asserts doit.log is a fixed point of its own replay rather than checking one token, so a reader and writer that agree on a wrong value still fail. The eleven-shape option-value differential is unchanged from #1261.

Closes #1263
