### PR TITLE
The -%F field names are hand-listed in the help text and the docs

### DIFF
--- a/src/htshelp.c
+++ b/src/htshelp.c
@@ -41,6 +41,7 @@ Please visit our Website: http://www.httrack.com
 #include "htscoremain.h"
 #include "htscatchurl.h"
 #include "htslib.h"
+#include "htstools.h"
 #include "htsalias.h"
 #include "htsmodules.h"
 #ifdef _WIN32
@@ -454,10 +455,29 @@ void help_catchurl(const char *dest_path) {
     printf("Unable to create a temporary proxy (no remaining port)\n");
 }
 
+// "{addr} {path} ..." for the -%F help line, from the engine's own table, so
+// the ten names have one owner (htstools.c) rather than a copy per surface.
+static void footer_field_list(char *dest, size_t size) {
+  size_t i, len = 0;
+
+  dest[0] = '\0';
+  for (i = 0; i < HTS_FOOTER_FIELD_COUNT; i++) {
+    const int n =
+        snprintf(dest + len, size - len, "%s{%s}", len != 0 ? " " : "",
+                 hts_footer_field_name((hts_footer_field_id) i));
+    if (n < 0 || (size_t) n >= size - len) {
+      dest[len] = '\0'; // drop a half-written name rather than show it
+      break;
+    }
+    len += (size_t) n;
+  }
+}
+
 // mini-aide  (h: help)
 //           y
 void help(const char *app, int more) {
   char info[2048];
+  char fields[256];
 
   infomsg("");
   if (more)
@@ -607,10 +627,12 @@ void help(const char *app, int more) {
     ("  F  user-agent field sent in HTTP headers (-F \"user-agent name\")");
   infomsg(" %R  default referer field sent in HTTP headers");
   infomsg(" %E  from email address sent in HTTP headers");
-  infomsg(
-      " %F  footer string in Html code (-%F \"Mirrored from {url} on "
-      "{date}\"; fields {addr} {path} {url} {date} {lastmodified} {version} "
-      "{mime} {charset} {status} {size}, or legacy %s)");
+  footer_field_list(fields, sizeof(fields));
+  snprintf(info, sizeof(info),
+           " %%F  footer string in Html code (-%%F \"Mirrored from {url} on "
+           "{date}\"; fields %s, or legacy %%s)",
+           fields);
+  infomsg(info);
   infomsg(" %l  preferred language (-%l \"fr, en, jp, *\"");
   infomsg(" %a  accepted formats (-%a \"text/html,image/png;q=0.9,*/*;q=0.1\"");
   infomsg(" %X  additional HTTP header line (-%X \"X-Magic: 42\"");

--- a/src/htshelp.c
+++ b/src/htshelp.c
@@ -455,22 +455,6 @@ void help_catchurl(const char *dest_path) {
     printf("Unable to create a temporary proxy (no remaining port)\n");
 }
 
-// "{addr} {path} ..." for the -%F help line, read from the engine's own table
-// so the ten names keep their single owner in htstools.c.
-static const char *footer_field_list(char *dest, size_t size) {
-  htsbuff fields = htsbuff_ptr(dest, size);
-  hts_footer_field_id id;
-
-  for (id = 0; id < HTS_FOOTER_FIELD_COUNT; id++) {
-    if (id != 0)
-      htsbuff_catc(&fields, ' ');
-    htsbuff_catc(&fields, '{');
-    htsbuff_cat(&fields, hts_footer_field_name(id));
-    htsbuff_catc(&fields, '}');
-  }
-  return htsbuff_str(&fields);
-}
-
 // mini-aide  (h: help)
 //           y
 void help(const char *app, int more) {
@@ -628,7 +612,7 @@ void help(const char *app, int more) {
   snprintf(info, sizeof(info),
            " %%F  footer string in Html code (-%%F \"Mirrored from {url} on "
            "{date}\"; fields %s, or legacy %%s)",
-           footer_field_list(fields, sizeof(fields)));
+           hts_footer_field_list(fields, sizeof(fields)));
   infomsg(info);
   infomsg(" %l  preferred language (-%l \"fr, en, jp, *\"");
   infomsg(" %a  accepted formats (-%a \"text/html,image/png;q=0.9,*/*;q=0.1\"");

--- a/src/htshelp.c
+++ b/src/htshelp.c
@@ -455,22 +455,20 @@ void help_catchurl(const char *dest_path) {
     printf("Unable to create a temporary proxy (no remaining port)\n");
 }
 
-// "{addr} {path} ..." for the -%F help line, from the engine's own table, so
-// the ten names have one owner (htstools.c) rather than a copy per surface.
-static void footer_field_list(char *dest, size_t size) {
-  size_t i, len = 0;
+// "{addr} {path} ..." for the -%F help line, read from the engine's own table
+// so the ten names keep their single owner in htstools.c.
+static const char *footer_field_list(char *dest, size_t size) {
+  htsbuff fields = htsbuff_ptr(dest, size);
+  hts_footer_field_id id;
 
-  dest[0] = '\0';
-  for (i = 0; i < HTS_FOOTER_FIELD_COUNT; i++) {
-    const int n =
-        snprintf(dest + len, size - len, "%s{%s}", len != 0 ? " " : "",
-                 hts_footer_field_name((hts_footer_field_id) i));
-    if (n < 0 || (size_t) n >= size - len) {
-      dest[len] = '\0'; // drop a half-written name rather than show it
-      break;
-    }
-    len += (size_t) n;
+  for (id = 0; id < HTS_FOOTER_FIELD_COUNT; id++) {
+    if (id != 0)
+      htsbuff_catc(&fields, ' ');
+    htsbuff_catc(&fields, '{');
+    htsbuff_cat(&fields, hts_footer_field_name(id));
+    htsbuff_catc(&fields, '}');
   }
+  return htsbuff_str(&fields);
 }
 
 // mini-aide  (h: help)
@@ -627,11 +625,10 @@ void help(const char *app, int more) {
     ("  F  user-agent field sent in HTTP headers (-F \"user-agent name\")");
   infomsg(" %R  default referer field sent in HTTP headers");
   infomsg(" %E  from email address sent in HTTP headers");
-  footer_field_list(fields, sizeof(fields));
   snprintf(info, sizeof(info),
            " %%F  footer string in Html code (-%%F \"Mirrored from {url} on "
            "{date}\"; fields %s, or legacy %%s)",
-           fields);
+           footer_field_list(fields, sizeof(fields)));
   infomsg(info);
   infomsg(" %l  preferred language (-%l \"fr, en, jp, *\"");
   infomsg(" %a  accepted formats (-%a \"text/html,image/png;q=0.9,*/*;q=0.1\"");

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -902,8 +902,8 @@ enum {
                  HTS_FOOTER_FIELD_COUNT)
 };
 
-const char *hts_footer_field_list(char *dest, size_t size) {
-  htsbuff fields = htsbuff_ptr(dest, size);
+const char *hts_footer_field_list(char *buffer, size_t size) {
+  htsbuff fields = htsbuff_ptr(buffer, size);
   size_t i;
 
   for (i = 0; i < HTS_FOOTER_FIELD_COUNT; i++) {

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -902,6 +902,10 @@ enum {
                  HTS_FOOTER_FIELD_COUNT)
 };
 
+const char *hts_footer_field_name(hts_footer_field_id id) {
+  return (size_t) id < HTS_FOOTER_FIELD_COUNT ? footer_field_names[id] : NULL;
+}
+
 HTSEXT_API hts_boolean hts_footer_field_ok(const char *name) {
   size_t i;
 

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -902,8 +902,18 @@ enum {
                  HTS_FOOTER_FIELD_COUNT)
 };
 
-const char *hts_footer_field_name(hts_footer_field_id id) {
-  return (size_t) id < HTS_FOOTER_FIELD_COUNT ? footer_field_names[id] : NULL;
+const char *hts_footer_field_list(char *dest, size_t size) {
+  htsbuff fields = htsbuff_ptr(dest, size);
+  size_t i;
+
+  for (i = 0; i < HTS_FOOTER_FIELD_COUNT; i++) {
+    if (i != 0)
+      htsbuff_catc(&fields, ' ');
+    htsbuff_catc(&fields, '{');
+    htsbuff_cat(&fields, footer_field_names[i]);
+    htsbuff_catc(&fields, '}');
+  }
+  return htsbuff_str(&fields);
 }
 
 HTSEXT_API hts_boolean hts_footer_field_ok(const char *name) {

--- a/src/htstools.h
+++ b/src/htstools.h
@@ -94,10 +94,10 @@ typedef enum {
   HTS_FOOTER_FIELD_COUNT
 } hts_footer_field_id;
 
-// Write the field names as "{addr} {path} ..." into dest (capacity size, NUL
-// included) and return it; aborts if they do not fit. Internal on purpose: the
-// exported surface is hts_footer_field_ok(), a predicate that cannot enumerate.
-const char *hts_footer_field_list(char *dest, size_t size);
+// Join the field names as "{addr} {path} ..." into buffer (size includes the
+// NUL, and it aborts if they do not fit) and return it. Internal on purpose:
+// hts_footer_field_ok() is the exported surface, and a predicate cannot list.
+const char *hts_footer_field_list(char *buffer, size_t size);
 
 // Expand a footer template. A "%s" in it selects the legacy positional model,
 // consuming addr, path, date and version in that order; otherwise "{name}" is

--- a/src/htstools.h
+++ b/src/htstools.h
@@ -94,9 +94,10 @@ typedef enum {
   HTS_FOOTER_FIELD_COUNT
 } hts_footer_field_id;
 
-// Name of a footer {field}, or NULL past the last id. Internal on purpose: the
+// Write the field names as "{addr} {path} ..." into dest (capacity size, NUL
+// included) and return it; aborts if they do not fit. Internal on purpose: the
 // exported surface is hts_footer_field_ok(), a predicate that cannot enumerate.
-const char *hts_footer_field_name(hts_footer_field_id id);
+const char *hts_footer_field_list(char *dest, size_t size);
 
 // Expand a footer template. A "%s" in it selects the legacy positional model,
 // consuming addr, path, date and version in that order; otherwise "{name}" is

--- a/src/htstools.h
+++ b/src/htstools.h
@@ -94,6 +94,10 @@ typedef enum {
   HTS_FOOTER_FIELD_COUNT
 } hts_footer_field_id;
 
+// Name of a footer {field}, or NULL past the last id. Internal on purpose: the
+// exported surface is hts_footer_field_ok(), a predicate that cannot enumerate.
+const char *hts_footer_field_name(hts_footer_field_id id);
+
 // Expand a footer template. A "%s" in it selects the legacy positional model,
 // consuming addr, path, date and version in that order; otherwise "{name}" is
 // substituted from values, indexed by hts_footer_field_id ("{{"/"}}" emit a

--- a/tests/305_doc-footer-fields.test
+++ b/tests/305_doc-footer-fields.test
@@ -28,9 +28,8 @@ segment=${segment%%, or legacy *}
 test "${segment}" != "${help_line}" ||
     fail "cannot find the field list in: ${help_line}"
 
-# Word-split on purpose, one field per line. Rejecting a token that is not a
-# {name} is what stops a name the doc grep cannot see from dropping out of both
-# lists and leaving two equally wrong sets comparing equal.
+# Word-split on purpose, one field per line. A token that is not a {name} fails
+# here, so a name the doc grep misses cannot vanish from both lists at once.
 # shellcheck disable=SC2086
 engine=$(printf '%s\n' ${segment})
 while read -r tok; do

--- a/tests/305_doc-footer-fields.test
+++ b/tests/305_doc-footer-fields.test
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# The -%F field names have one owner, footer_field_names[] in htstools.c, and
+# --help now prints them from it. man/httrack.1 is generated from --help and
+# 02_manpage-regen guards that; html/cmdguide.html is a hand-written copy, so
+# pin it to the binary's list in both directions.
+
+set -euo pipefail
+
+srcdir="${abs_top_srcdir:?not run under make check}"
+guide="${srcdir}/html/cmdguide.html"
+
+test -r "${guide}" || {
+    echo "FAIL: no ${guide}" >&2
+    exit 1
+}
+command -v httrack >/dev/null 2>&1 || {
+    echo "httrack not in PATH; skipping" >&2
+    exit 77
+}
+
+same_set() { # same_set <list A> <list B>: newline-separated, order-insensitive
+    diff <(sort <<<"$1") <(sort <<<"$2") >/dev/null
+}
+
+help_line=$(httrack --quiet --help 2>/dev/null | grep -m1 -- ' %F  footer string' || true)
+test -n "${help_line}" || {
+    echo "FAIL: --help prints no -%F line" >&2
+    exit 1
+}
+
+# " ...; fields {addr} {path} ..., or legacy %s)" -> one {name} per line.
+engine=$(sed -n 's/.*; fields \(.*\), or legacy .*/\1/p' <<<"${help_line}" |
+    tr ' ' '\n' | grep '^{[a-z]*}$' || true)
+doc=$(grep -o '<tt>{[a-z]*}</tt>' "${guide}" | sed 's,</*tt>,,g' | sort -u || true)
+
+# Controls: neither list may be silently empty, and the comparison must say no.
+grep -qx '{addr}' <<<"${engine}" || {
+    echo "FAIL: no field names parsed out of the -%F help line: ${help_line}" >&2
+    exit 1
+}
+grep -qx '{addr}' <<<"${doc}" || {
+    echo "FAIL: no <tt>{field}</tt> names parsed out of ${guide}" >&2
+    exit 1
+}
+if same_set "${engine}" "${engine}
+{nosuchfield}"; then
+    echo "FAIL: same_set() ignores an extra name; the check below proves nothing" >&2
+    exit 1
+fi
+
+same_set "${engine}" "${doc}" || {
+    echo "FAIL: html/cmdguide.html lists different -%F fields than the engine." >&2
+    echo "Left is --help, right is cmdguide.html:" >&2
+    diff <(sort <<<"${engine}") <(sort <<<"${doc}") >&2 || true
+    exit 1
+}
+
+echo "cmdguide.html lists the engine's $(wc -l <<<"${engine}") -%F fields"

--- a/tests/305_doc-footer-fields.test
+++ b/tests/305_doc-footer-fields.test
@@ -1,80 +1,63 @@
 #!/bin/bash
 #
 # Pin the -%F field lists in html/cmdguide.html and html/guide.html to the one
-# httrack --help prints. man/httrack.1 is generated from --help, and
-# 02_manpage-regen covers it. Slot order is pinned by 01_engine-footerfmt.
+# httrack --help prints. man/httrack.1 (02_manpage-regen) and the slot order
+# (01_engine-footerfmt) are covered elsewhere.
 
 set -euo pipefail
 
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
 srcdir="${abs_top_srcdir:?not run under make check}"
 
-command -v httrack >/dev/null 2>&1 || {
-    echo "httrack not in PATH; skipping" >&2
-    exit 77
-}
+command -v httrack >/dev/null 2>&1 || skip "httrack not in PATH"
 
 same_set() { # same_set <list A> <list B>: newline-separated, order-insensitive
     diff <(sort <<<"$1") <(sort <<<"$2") >/dev/null
 }
 
-# A crash after the line is printed must not read as a pass, so take the whole
-# output first and match it from a here-string.
-help=$(httrack --quiet --help 2>/dev/null) || {
-    echo "FAIL: httrack --help exited $?" >&2
-    exit 1
-}
-help_line=$(grep -m1 -- ' %F  footer string' <<<"${help}") || {
-    echo "FAIL: --help prints no -%F line" >&2
-    exit 1
-}
+# Capture it all first, so a crash after the -%F line still fails the test.
+help=$(httrack --quiet --help 2>/dev/null) || fail "httrack --help exited $?"
+help_line=$(grep -m1 -- ' %F  footer string' <<<"${help}") ||
+    fail "--help prints no -%F line"
 
 # " ...; fields {addr} {path} ..., or legacy %s)"
 segment=${help_line#*; fields }
 segment=${segment%%, or legacy *}
-test "${segment}" != "${help_line}" || {
-    echo "FAIL: cannot find the field list in: ${help_line}" >&2
-    exit 1
-}
+test "${segment}" != "${help_line}" ||
+    fail "cannot find the field list in: ${help_line}"
 
-# Deliberate word splitting: one field per line. Every token has to be a
-# {name}, or a name the doc regex cannot see would drop out of both lists and
-# the comparison below would hold on two equally wrong sets.
+# Word-split on purpose, one field per line. Rejecting a token that is not a
+# {name} is what stops a name the doc grep cannot see from dropping out of both
+# lists and leaving two equally wrong sets comparing equal.
 # shellcheck disable=SC2086
 engine=$(printf '%s\n' ${segment})
 while read -r tok; do
     case "${tok}" in
     "{"?*"}") ;;
-    *)
-        echo "FAIL: '${tok}' in the -%F field list is not a {name}" >&2
-        exit 1
-        ;;
+    *) fail "'${tok}' in the -%F field list is not a {name}" ;;
     esac
 done <<<"${engine}"
 
 # Control: the comparison must be able to say no.
 if same_set "${engine}" "${engine}
 {nosuchfield}"; then
-    echo "FAIL: same_set() ignores an extra name; the checks below prove nothing" >&2
-    exit 1
+    fail "same_set() ignores an extra name; the checks below prove nothing"
 fi
 
 check_page() { # check_page <html file> <tag wrapping each {name}>
     local page="$1" tag="$2" doc
-    test -r "${page}" || {
-        echo "FAIL: no ${page}" >&2
-        return 1
-    }
+    test -r "${page}" || fail "no ${page}"
     doc=$(grep -o "<${tag}>{[^{}<]*}</${tag}>" "${page}" |
         sed "s,</*${tag}>,,g" | sort -u || true)
-    grep -qx '{addr}' <<<"${doc}" || {
-        echo "FAIL: no <${tag}>{field}</${tag}> names parsed out of ${page}" >&2
-        return 1
-    }
+    grep -qx '{addr}' <<<"${doc}" ||
+        fail "no <${tag}>{field}</${tag}> names parsed out of ${page}"
     same_set "${engine}" "${doc}" || {
-        echo "FAIL: ${page} lists different -%F fields than the engine." >&2
+        echo "${page} lists different -%F fields than the engine." >&2
         echo "Left is --help, right is the page:" >&2
         diff <(sort <<<"${engine}") <(sort <<<"${doc}") >&2 || true
-        return 1
+        fail "${page} is out of date"
     }
 }
 

--- a/tests/305_doc-footer-fields.test
+++ b/tests/305_doc-footer-fields.test
@@ -1,19 +1,13 @@
 #!/bin/bash
 #
-# The -%F field names have one owner, footer_field_names[] in htstools.c, and
-# --help now prints them from it. man/httrack.1 is generated from --help and
-# 02_manpage-regen guards that; html/cmdguide.html is a hand-written copy, so
-# pin it to the binary's list in both directions.
+# Pin the -%F field lists in html/cmdguide.html and html/guide.html to the one
+# httrack --help prints. man/httrack.1 is generated from --help, and
+# 02_manpage-regen covers it. Slot order is pinned by 01_engine-footerfmt.
 
 set -euo pipefail
 
 srcdir="${abs_top_srcdir:?not run under make check}"
-guide="${srcdir}/html/cmdguide.html"
 
-test -r "${guide}" || {
-    echo "FAIL: no ${guide}" >&2
-    exit 1
-}
 command -v httrack >/dev/null 2>&1 || {
     echo "httrack not in PATH; skipping" >&2
     exit 77
@@ -23,37 +17,68 @@ same_set() { # same_set <list A> <list B>: newline-separated, order-insensitive
     diff <(sort <<<"$1") <(sort <<<"$2") >/dev/null
 }
 
-help_line=$(httrack --quiet --help 2>/dev/null | grep -m1 -- ' %F  footer string' || true)
-test -n "${help_line}" || {
+# A crash after the line is printed must not read as a pass, so take the whole
+# output first and match it from a here-string.
+help=$(httrack --quiet --help 2>/dev/null) || {
+    echo "FAIL: httrack --help exited $?" >&2
+    exit 1
+}
+help_line=$(grep -m1 -- ' %F  footer string' <<<"${help}") || {
     echo "FAIL: --help prints no -%F line" >&2
     exit 1
 }
 
-# " ...; fields {addr} {path} ..., or legacy %s)" -> one {name} per line.
-engine=$(sed -n 's/.*; fields \(.*\), or legacy .*/\1/p' <<<"${help_line}" |
-    tr ' ' '\n' | grep '^{[a-z]*}$' || true)
-doc=$(grep -o '<tt>{[a-z]*}</tt>' "${guide}" | sed 's,</*tt>,,g' | sort -u || true)
+# " ...; fields {addr} {path} ..., or legacy %s)"
+segment=${help_line#*; fields }
+segment=${segment%%, or legacy *}
+test "${segment}" != "${help_line}" || {
+    echo "FAIL: cannot find the field list in: ${help_line}" >&2
+    exit 1
+}
 
-# Controls: neither list may be silently empty, and the comparison must say no.
-grep -qx '{addr}' <<<"${engine}" || {
-    echo "FAIL: no field names parsed out of the -%F help line: ${help_line}" >&2
-    exit 1
-}
-grep -qx '{addr}' <<<"${doc}" || {
-    echo "FAIL: no <tt>{field}</tt> names parsed out of ${guide}" >&2
-    exit 1
-}
+# Deliberate word splitting: one field per line. Every token has to be a
+# {name}, or a name the doc regex cannot see would drop out of both lists and
+# the comparison below would hold on two equally wrong sets.
+# shellcheck disable=SC2086
+engine=$(printf '%s\n' ${segment})
+while read -r tok; do
+    case "${tok}" in
+    "{"?*"}") ;;
+    *)
+        echo "FAIL: '${tok}' in the -%F field list is not a {name}" >&2
+        exit 1
+        ;;
+    esac
+done <<<"${engine}"
+
+# Control: the comparison must be able to say no.
 if same_set "${engine}" "${engine}
 {nosuchfield}"; then
-    echo "FAIL: same_set() ignores an extra name; the check below proves nothing" >&2
+    echo "FAIL: same_set() ignores an extra name; the checks below prove nothing" >&2
     exit 1
 fi
 
-same_set "${engine}" "${doc}" || {
-    echo "FAIL: html/cmdguide.html lists different -%F fields than the engine." >&2
-    echo "Left is --help, right is cmdguide.html:" >&2
-    diff <(sort <<<"${engine}") <(sort <<<"${doc}") >&2 || true
-    exit 1
+check_page() { # check_page <html file> <tag wrapping each {name}>
+    local page="$1" tag="$2" doc
+    test -r "${page}" || {
+        echo "FAIL: no ${page}" >&2
+        return 1
+    }
+    doc=$(grep -o "<${tag}>{[^{}<]*}</${tag}>" "${page}" |
+        sed "s,</*${tag}>,,g" | sort -u || true)
+    grep -qx '{addr}' <<<"${doc}" || {
+        echo "FAIL: no <${tag}>{field}</${tag}> names parsed out of ${page}" >&2
+        return 1
+    }
+    same_set "${engine}" "${doc}" || {
+        echo "FAIL: ${page} lists different -%F fields than the engine." >&2
+        echo "Left is --help, right is the page:" >&2
+        diff <(sort <<<"${engine}") <(sort <<<"${doc}") >&2 || true
+        return 1
+    }
 }
 
-echo "cmdguide.html lists the engine's $(wc -l <<<"${engine}") -%F fields"
+check_page "${srcdir}/html/cmdguide.html" tt
+check_page "${srcdir}/html/guide.html" code
+
+echo "both doc pages list the engine's $(wc -l <<<"${engine}") -%F fields"


### PR DESCRIPTION
#1252 gave the ten footer `{field}` names one owner in `htstools.c`, but the `-%F` help line still spelled them out. That join now lives in `htstools.c` beside the table, built with `htsbuff` so an overgrown list aborts instead of losing its tail, and `htshelp.c` prints the string it gets back. The exported surface is still the `hts_footer_field_ok` predicate, which cannot list, and the help text comes out byte-identical.

`man/httrack.1` is generated from `--help` and guarded by `02_manpage-regen`, so it followed for free; the copies that are genuinely hand-written are `html/cmdguide.html` and `html/guide.html`. `305_doc-footer-fields.test` pins both to the binary's own list in both directions, and rejects any token in the help line that is not a well-formed `{name}`. Without that last check a name the doc regex cannot match would drop out of both lists and leave two wrong sets comparing equal.

Closes #1256
