### PR TITLE
105_suite-timeout can fail while the timeout guard it tests worked

### DIFF
--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -94,10 +94,10 @@ grep -q "own process tree" "$out" || fail "no process list in the diagnostics"
 # Announced BEFORE the dump, not merely at some point during it: the watchdog reading
 # that log takes the silence of a dump for a wedge. Only a slow dump tells the two
 # orderings apart, and the dump's own ps is what this makes slow.
-if ! is_windows; then
-    realps=$(command -v ps) || realps=
-    # Or the shim degenerates to a plain sleep and the dump below is not slowed.
-    test -n "$realps" || fail "no ps to build the slow shim from"
+realps=$(command -v ps) || realps= # the emulated buildds ship without one
+if is_windows || test -z "$realps"; then
+    echo "note: no slow ps to build here, the announcement ordering is not measured"
+else
     rm -f "$tmp/ps-used"
     printf '#!/bin/sh\n: >"%s"\nsleep 3\nexec %s "$@"\n' "$tmp/ps-used" "$realps" >"$shim/ps"
     chmod +x "$shim/ps"

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -36,8 +36,10 @@ echo "marker: the wedged test started"
 sleep 300
 EOF
 
-# Time the guard to its DUMP announcement, not to the driver's exit: the dump that
-# follows runs for minutes on an emulated host, and that is not what is under test.
+# $fired is the guard's own reading of when its deadline tripped, taken from the
+# progress log: a poll can miss a dump short enough to fall between two of them,
+# which is how #1242 reddened a run whose guard had done its job. The poll only
+# still answers whether the line was visible while the driver ran.
 rc=0
 fired=
 marked=
@@ -53,9 +55,9 @@ run_wedged() { # run_wedged <budget> [VAR=VAL...]
         bash "$driver" "$tmp/90_wedged.test" >"$out" 2>&1 &
     pid=$!
     while kill -0 "$pid" 2>/dev/null; do
-        # Read with the shell: a fork per poll would blur the latency being measured.
-        if read -r line <"$tmp/progress" 2>/dev/null && test "$line" = "DUMP 90_wedged.test"; then
-            fired=$((SECONDS - start))
+        # Read with the shell: a fork per poll would slow the loop it drives.
+        if read -r line <"$tmp/progress" 2>/dev/null &&
+            test "${line#DUMP 90_wedged.test }" != "$line"; then
             marked=1
             break
         fi
@@ -63,22 +65,14 @@ run_wedged() { # run_wedged <budget> [VAR=VAL...]
     done
     wait "$pid" || rc=$?
     total=$((SECONDS - start))
-    if test -z "$fired"; then
-        # Missed between two polls: the whole run then bounds the latency from above.
-        fired=$total
-        echo "note: the announcement fell between two polls; ${total}s bounds its latency"
-    fi
+    fired=$(sed -n 's/^DUMP 90_wedged\.test \([0-9][0-9]*\)$/\1/p' "$tmp/progress")
+    # Announced when the dump starts, which runs for minutes: a suite watchdog
+    # reading that log would take the silence for a wedge and kill the step.
+    test -n "$fired" ||
+        fail "the dump went unannounced: $(cat "$tmp/progress" 2>&1)"
 }
 
-# Retried once for a measured latency; a dump short enough to fall between two
-# polls is a race, not a regression (#1242).
 run_wedged 5
-test -n "$marked" || run_wedged 5
-
-# Announced when the dump starts, which runs for minutes: a suite watchdog
-# reading that log would take the silence for a wedge and kill the step.
-grep -qx 'DUMP 90_wedged.test' "$tmp/progress" ||
-    fail "the dump was not announced: $(cat "$tmp/progress" 2>&1)"
 
 test "$rc" -eq 124 || fail "wedged test reported $rc, want 124"
 # Never before the budget, or a slow-but-healthy test would be killed too.

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -63,24 +63,27 @@ run_wedged() { # run_wedged <budget> [VAR=VAL...]
     done
     wait "$pid" || rc=$?
     total=$((SECONDS - start))
-    # Missed between two polls: the whole run then bounds the latency from above.
-    test -n "$fired" || fired=$total
+    if test -z "$fired"; then
+        # Missed between two polls: the whole run then bounds the latency from above.
+        fired=$total
+        echo "note: the announcement fell between two polls; ${total}s bounds its latency"
+    fi
 }
 
-# Retried once, because a dump short enough to fall between two polls is a race, not a
-# regression; announcing after the dump loses both attempts.
+# Retried once for a measured latency rather than a bounded one; a dump short enough
+# to fall between two polls is a race, and the log below is what settles it (#1242).
 run_wedged 5
 test -n "$marked" || run_wedged 5
-test -n "$marked" ||
-    fail "the announcement was never seen while the guard ran, so its latency is unknown"
 
 # Announced when the dump starts, which runs for minutes: a suite watchdog
-# reading that log would take the silence for a wedge and kill the step.
+# reading that log would take the silence for a wedge and kill the step. The file
+# outlives the run, so a poll that missed the line still finds it here.
 grep -qx 'DUMP 90_wedged.test' "$tmp/progress" ||
     fail "the dump was not announced: $(cat "$tmp/progress" 2>&1)"
 
 test "$rc" -eq 124 || fail "wedged test reported $rc, want 124"
-# Never before the budget, or a slow-but-healthy test would be killed too.
+# Never before the budget, or a slow-but-healthy test would be killed too. A missed
+# poll leaves $fired at the whole run, which bounds the same latency from above.
 test "$fired" -ge 5 || fail "the guard fired early (${fired}s of a 5s budget)"
 test "$fired" -lt 30 || fail "the guard fired late (${fired}s)"
 grep -q 'marker: the wedged test started' "$out" || fail "the test's own output was lost"

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -71,19 +71,23 @@ run_wedged() { # run_wedged <budget> [VAR=VAL...]
 }
 
 # Retried once for a measured latency rather than a bounded one; a dump short enough
-# to fall between two polls is a race, and the log below is what settles it (#1242).
+# to fall between two polls is a race, not a regression (#1242).
 run_wedged 5
 test -n "$marked" || run_wedged 5
 
-# Announced when the dump starts, which runs for minutes: a suite watchdog
-# reading that log would take the silence for a wedge and kill the step. The file
-# outlives the run, so a poll that missed the line still finds it here.
+# Announced when the dump starts, which runs for minutes: a suite watchdog reading
+# that log would take the silence for a wedge and kill the step. The file outlives
+# the run, so a poll that missed the line still finds it here.
 grep -qx 'DUMP 90_wedged.test' "$tmp/progress" ||
     fail "the dump was not announced: $(cat "$tmp/progress" 2>&1)"
+# Given seconds of dump to poll through, a marker the poll never saw was written
+# after that dump, not before it; only a shorter run can blame the race.
+test "$total" -lt 8 || test -n "$marked" ||
+    fail "announced after the ${total}s dump, not before it"
 
 test "$rc" -eq 124 || fail "wedged test reported $rc, want 124"
 # Never before the budget, or a slow-but-healthy test would be killed too. A missed
-# poll leaves $fired at the whole run, which bounds the same latency from above.
+# poll leaves $fired at the whole run, an upper bound on the same latency.
 test "$fired" -ge 5 || fail "the guard fired early (${fired}s of a 5s budget)"
 test "$fired" -lt 30 || fail "the guard fired late (${fired}s)"
 grep -q 'marker: the wedged test started' "$out" || fail "the test's own output was lost"
@@ -99,6 +103,10 @@ grep -q "own process tree" "$out" || fail "no process list in the diagnostics"
 if ! is_windows; then
     printf '#!/bin/sh\nsleep 3\nexec %s "$@"\n' "$(command -v ps)" >"$shim/ps"
     chmod +x "$shim/ps"
+    # Proved, not assumed, as starve_sleep does: a shim bash's PATH search skips
+    # leaves the real ps, and the fast dump that follows reads as a late announcement.
+    test "$(PATH="$shim:$PATH" command -v ps)" = "$shim/ps" ||
+        fail "the slow ps shim is unreachable"
     run_wedged 5 "PATH=$shim:$PATH"
     rm -f "$shim/ps" # before the starve shim shares this directory
     test "$rc" -eq 124 || fail "the guard reported $rc under a slow dump, want 124"

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -70,24 +70,18 @@ run_wedged() { # run_wedged <budget> [VAR=VAL...]
     fi
 }
 
-# Retried once for a measured latency rather than a bounded one; a dump short enough
-# to fall between two polls is a race, not a regression (#1242).
+# Retried once for a measured latency; a dump short enough to fall between two
+# polls is a race, not a regression (#1242).
 run_wedged 5
 test -n "$marked" || run_wedged 5
 
-# Announced when the dump starts, which runs for minutes: a suite watchdog reading
-# that log would take the silence for a wedge and kill the step. The file outlives
-# the run, so a poll that missed the line still finds it here.
+# Announced when the dump starts, which runs for minutes: a suite watchdog
+# reading that log would take the silence for a wedge and kill the step.
 grep -qx 'DUMP 90_wedged.test' "$tmp/progress" ||
     fail "the dump was not announced: $(cat "$tmp/progress" 2>&1)"
-# Given seconds of dump to poll through, a marker the poll never saw was written
-# after that dump, not before it; only a shorter run can blame the race.
-test "$total" -lt 8 || test -n "$marked" ||
-    fail "announced after the ${total}s dump, not before it"
 
 test "$rc" -eq 124 || fail "wedged test reported $rc, want 124"
-# Never before the budget, or a slow-but-healthy test would be killed too. A missed
-# poll leaves $fired at the whole run, an upper bound on the same latency.
+# Never before the budget, or a slow-but-healthy test would be killed too.
 test "$fired" -ge 5 || fail "the guard fired early (${fired}s of a 5s budget)"
 test "$fired" -lt 30 || fail "the guard fired late (${fired}s)"
 grep -q 'marker: the wedged test started' "$out" || fail "the test's own output was lost"
@@ -101,14 +95,17 @@ grep -q "own process tree" "$out" || fail "no process list in the diagnostics"
 # that log takes the silence of a dump for a wedge. Only a slow dump tells the two
 # orderings apart, and the dump's own ps is what this makes slow.
 if ! is_windows; then
-    printf '#!/bin/sh\nsleep 3\nexec %s "$@"\n' "$(command -v ps)" >"$shim/ps"
+    realps=$(command -v ps) || realps=
+    # Or the shim degenerates to a plain sleep and the dump below is not slowed.
+    test -n "$realps" || fail "no ps to build the slow shim from"
+    rm -f "$tmp/ps-used"
+    printf '#!/bin/sh\n: >"%s"\nsleep 3\nexec %s "$@"\n' "$tmp/ps-used" "$realps" >"$shim/ps"
     chmod +x "$shim/ps"
-    # Proved, not assumed, as starve_sleep does: a shim bash's PATH search skips
-    # leaves the real ps, and the fast dump that follows reads as a late announcement.
-    test "$(PATH="$shim:$PATH" command -v ps)" = "$shim/ps" ||
-        fail "the slow ps shim is unreachable"
     run_wedged 5 "PATH=$shim:$PATH"
     rm -f "$shim/ps" # before the starve shim shares this directory
+    # Proved, not assumed: a dump whose PATH search skipped the shim ran the real
+    # ps, and the fast dump that follows reads as a late announcement below.
+    test -e "$tmp/ps-used" || fail "the dump never ran the slow ps shim"
     test "$rc" -eq 124 || fail "the guard reported $rc under a slow dump, want 124"
     test -n "$marked" || fail "no announcement under a slow dump"
     test "$((total - fired))" -ge 2 ||

--- a/tests/test-timeout.sh
+++ b/tests/test-timeout.sh
@@ -100,7 +100,9 @@ while kill -0 "$pid" 2>/dev/null; do
     if test "$((SECONDS - start))" -gt "$budget"; then
         # The dump below can run for minutes. Say so where a suite watchdog is
         # watching, or the silence reads as a wedge and the step dies mid-stack.
-        test -z "${HTTRACK_PROGRESS_LOG:-}" || echo "DUMP $name" >>"$HTTRACK_PROGRESS_LOG"
+        # The elapsed time rides along because only the guard can measure it.
+        test -z "${HTTRACK_PROGRESS_LOG:-}" ||
+            echo "DUMP $name $((SECONDS - start))" >>"$HTTRACK_PROGRESS_LOG"
         dump_hang_diagnostics "$pid" "$name" "$budget"
         kill_tree "$pid" "$winpid"
         reap_bounded "$pid" || echo "hang: the tree outlived the kill; see the process list above"


### PR DESCRIPTION
105_suite-timeout timed the guard's DUMP announcement by polling the progress log every 100ms while the driver ran, and failed the test when a poll never caught the line. On a fast runner the announcement and the dump can both land inside one polling gap, so the test went red while the guard did exactly what it was asked to do. That is how it failed one Debian buildd leg of #1239 and then passed on a rerun of the same commit.

The guard now stamps its elapsed time onto the announcement and the test reads it back from the log, which outlives the run. That also closes a hole the poll had left: a guard tripping at a fifth of its budget and announcing after a four-second dump used to read back as on time, because what got timed was the poll rather than the deadline. The poll still answers whether the line was visible while the run was live, which is the slow-ps block's input.

Announcing before the dump rather than during it stays a measurement: the slow-ps block makes the dump's own `ps` sleep and requires a gap of more than two seconds. It needs a real `ps` to wrap, so Windows and the emulated buildds skip it and keep only the check that the announcement happened. Every assertion was checked against a mutated `tests/test-timeout.sh`; dropping the announcement, firing before the budget, announcing after the dump, and dumping without announcing each turn the test red.

Closes #1242