### PR TITLE
A verbatim English copy passes the lang integrity test

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,6 @@
 # bash die on $'\r' on every line of them.
 *.test text eol=lf
 *.sh text eol=lf
+
+# The count pin is parsed field by field; a CRLF checkout makes every line malformed.
+tests/*.counts text eol=lf

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -294,8 +294,8 @@ LC_ALL=C awk -v pin="$pin" '
         exit(bad > 0 ? 3 : 0)
     }
 ' "$tmp/counts" || rc=$?
-# A mismatch says so with 3, because awk's own error status is 1 on gawk and 2 on
-# mawk; reading either as a mismatch would hide a broken check.
+# A mismatch says so with 3, because awk's own error status varies by
+# implementation; reading any of them as a mismatch would hide a broken check.
 if [ "$rc" -ne 0 ] && [ "$rc" -ne 3 ]; then
     echo "the untranslated-count comparison itself failed"
     exit 1

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -72,8 +72,6 @@ c1=$(printf '\302[\200-\237]')
 # A single-byte charset maps all 256 byte values, so the iconv decode above
 # can never fail on it and cannot see a value left as raw UTF-8; a whole line
 # that itself decodes as valid multi-byte UTF-8 is that leak.
-# Scoped to single-byte charsets: BIG5, gb2312 and shift-jis are multi-byte, so
-# the premise fails and their genuine text matches this shape constantly.
 # Under 8 bytes a line can be valid UTF-8 by chance (Ukrainian.txt:686 is a
 # 2-byte word that is), so short mixed-encoding lines go undetected.
 # Raw bytes in an awk ERE, not grep -P: BSD grep has no -P. NUL is left out of
@@ -99,16 +97,22 @@ charset_declared_matches_bytes() {
         echo "${f##*/}: $n lines decode to C1 controls under $cs; the bytes are a Windows codepage"
         return 1
     fi
+    # BIG5, gb2312 and shift-jis reach here too: iconv passes a raw UTF-8 leak of
+    # accented Latin letters, whose bytes are valid singles in all three. Their own
+    # text hits the UTF-8 shape only in short runs, so ask for more non-ASCII bytes
+    # than any of it carries (4, in Chinese-Simplified.txt:316).
     case "$(printf '%s' "$cs" | LC_ALL=C tr '[:upper:]' '[:lower:]')" in
-    iso-8859-* | windows-125*)
-        ln=$(LC_ALL=C awk -v u="$utf8_full_line" -v h="$high_byte" \
-            'length($0) >= 8 && $0 ~ h && $0 ~ u { print NR; exit }' "$f")
-        if [ -n "$ln" ]; then
-            echo "${f##*/}:$ln: line fully decodes as UTF-8 despite declared $cs; mixed encoding"
-            return 1
-        fi
-        ;;
+    iso-8859-* | windows-125*) minhigh=1 ;;
+    *) minhigh=8 ;;
     esac
+    ln=$(LC_ALL=C awk -v u="$utf8_full_line" -v h="$high_byte" -v m="$minhigh" \
+        '{ s = $0; nhigh = gsub(h, "", s) }
+         length($0) >= 8 && nhigh >= m && $0 ~ u { print NR; exit }' "$f")
+    if [ -n "$ln" ]; then
+        echo "${f##*/}:$ln: line fully decodes as UTF-8 despite declared $cs; mixed encoding"
+        return 1
+    fi
+    return 0
 }
 
 if ! command -v iconv >/dev/null 2>&1; then
@@ -118,10 +122,14 @@ else
     # No CR: BSD sed writes a literal r, and the extractor strips CR anyway.
     LC_ALL=C sed '10s/.*/UTF-8/' "$langdir/Francais.txt" >"$tmp/undecodable.txt"
     LC_ALL=C sed '10s/.*/ISO-8859-2/' "$langdir/Croatian.txt" >"$tmp/c1.txt"
-    # A value line left as raw UTF-8 under a declared single-byte charset.
-    LC_ALL=C awk -v repl="$(printf 'Une fuite UTF-8 : caf\xc3\xa9, na\xc3\xafve, t\xc3\xa9l\xc3\xa9phone')" \
+    # A value line left as raw UTF-8, under a declared single-byte charset and
+    # then under a multi-byte one, which iconv on its own cannot reject.
+    leak=$(printf 'Une fuite UTF-8 : caf\xc3\xa9, na\xc3\xafve, t\xc3\xa9l\xc3\xa9phone, pr\xc3\xa9c\xc3\xa9d\xc3\xa9')
+    LC_ALL=C awk -v repl="$leak" \
         'NR == 20 { print repl; next } { print }' "$langdir/Francais.txt" >"$tmp/utf8mix.txt"
-    for probe in undecodable c1 utf8mix; do
+    LC_ALL=C awk -v repl="$leak" \
+        'NR == 20 { print repl; next } { print }' "$langdir/Japanese.txt" >"$tmp/utf8mixmb.txt"
+    for probe in undecodable c1 utf8mix utf8mixmb; do
         if charset_declared_matches_bytes "$tmp/$probe.txt" >/dev/null; then
             echo "the charset check passed a deliberately mislabelled file ($probe)"
             exit 1
@@ -173,15 +181,107 @@ for scope in "Mirror %s and every host below it" "Ignore %s and every host below
 done
 
 # A msgid absent from a language file silently falls back to English (#862).
-LC_ALL=C sort -u <"$keys" >"$tmp/english.sorted"
+# Multisets, not sets: a msgid appearing twice keeps the set equal while the
+# engine reaches only one of its two values. English.txt repeats 27 msgids of its
+# own, so the legitimate duplicates cancel out on both sides.
+LC_ALL=C sort <"$keys" >"$tmp/english.sorted"
 for f in "$langdir"/*.txt; do
-    LC_ALL=C awk 'NR%2==1 { sub(/\r$/, ""); print }' "$f" | LC_ALL=C sort -u >"$tmp/have"
+    LC_ALL=C awk 'NR%2==1 { sub(/\r$/, ""); print }' "$f" | LC_ALL=C sort >"$tmp/have"
     untranslated=$(LC_ALL=C comm -23 "$tmp/english.sorted" "$tmp/have")
     if [ -n "$untranslated" ]; then
         printf '%s\n' "$untranslated" | awk -v n="${f##*/}" '{print n ": untranslated msgid: " $0}'
         fail=1
     fi
+    repeated=$(LC_ALL=C comm -13 "$tmp/english.sorted" "$tmp/have")
+    if [ -n "$repeated" ]; then
+        printf '%s\n' "$repeated" | awk -v n="${f##*/}" '{print n ": msgid occurs more often than in English.txt: " $0}'
+        fail=1
+    fi
 done
+
+# A value copied verbatim from its msgid, or left empty, satisfies every check
+# above while the string is still English on screen (#1260). A handful are
+# legitimate, so the per-catalog counts are pinned and have to match exactly.
+pin="$testdir/62_lang-untranslated.counts"
+[ -f "$pin" ] || {
+    echo "cannot find $pin"
+    exit 1
+}
+ncounted=0
+: >"$tmp/counts"
+for f in "$langdir"/*.txt; do
+    # English.txt is the msgid side of every pair, identical by construction.
+    [ "$f" != "$eng" ] || continue
+    ncounted=$((ncounted + 1))
+    LC_ALL=C awk -v name="${f##*/}" '
+        { sub(/\r$/, "") }
+        NR % 2 == 1 { key = $0; next }
+        $0 == "" { empty++ }
+        $0 != "" && $0 == key { same++ }
+        END { printf "%-25s %-9d %d\n", name, same + 0, empty + 0 }
+    ' "$f" >>"$tmp/counts"
+done
+if [ "$ncounted" -ne $((nfiles - 1)) ]; then
+    echo "untranslated counts cover $ncounted of the $((nfiles - 1)) catalogs"
+    exit 1
+fi
+LC_ALL=C sort -o "$tmp/counts" "$tmp/counts"
+
+rc=0
+LC_ALL=C awk -v pin="$pin" '
+    function report(name, got, want, kind,   what) {
+        what = "lower the pin here"
+        if (got > want)
+            what = "translate it rather than raise the pin"
+        printf "%s: %d %s, pinned at %d: %s\n", name, got, kind, want, what
+        bad++
+    }
+    BEGIN {
+        while ((getline line < pin) > 0) {
+            if (line ~ /^[ \t]*(#|$)/)
+                continue
+            if (split(line, a, /[ \t]+/) != 3) {
+                printf "%s: malformed pin line: %s\n", pin, line
+                bad++
+                continue
+            }
+            same[a[1]] = a[2]
+            empty[a[1]] = a[3]
+            pinned[a[1]] = 1
+        }
+    }
+    {
+        seen[$1] = 1
+        if (!($1 in pinned)) {
+            printf "%s: no pinned untranslated counts; add them\n", $1
+            bad++
+            next
+        }
+        if ($2 != same[$1])
+            report($1, $2, same[$1], "values identical to their English msgid")
+        if ($3 != empty[$1])
+            report($1, $3, empty[$1], "empty values")
+    }
+    END {
+        for (f in pinned)
+            if (!(f in seen)) {
+                printf "%s: pinned but no such catalog\n", f
+                bad++
+            }
+        exit(bad > 0)
+    }
+' "$tmp/counts" || rc=$?
+# awk exits 2 on its own errors and 1 on a mismatch; conflating them is vacuity.
+if [ "$rc" -gt 1 ]; then
+    echo "the untranslated-count comparison itself failed"
+    exit 1
+elif [ "$rc" -ne 0 ]; then
+    new=$PWD/62_lang-untranslated.counts.new
+    LC_ALL=C awk '/^[ \t]*#/ || /^[ \t]*$/' "$pin" >"$new"
+    cat "$tmp/counts" >>"$new"
+    echo "once the counts are right for the right reason: cp $new $pin"
+    fail=1
+fi
 
 # An unknown ${LANG_*} renders as nothing rather than erroring, so check that
 # every macro the templates interpolate, in any wrapper form, resolves.

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -99,9 +99,11 @@ charset_declared_matches_bytes() {
     fi
     # BIG5, gb2312 and shift-jis reach here too: iconv passes a raw UTF-8 leak of
     # accented Latin letters, whose bytes are valid singles in all three. Their own
-    # text hits the UTF-8 shape only in short runs, so ask for more non-ASCII bytes
-    # than any of it carries (4, in Chinese-Simplified.txt:316).
+    # text tops out at 4 non-ASCII bytes per UTF-8-shaped line, so gate on that
+    # count rather than on the charset family, and ask for more than 4.
     case "$(printf '%s' "$cs" | LC_ALL=C tr '[:upper:]' '[:lower:]')" in
+    # Nothing to tell apart once UTF-8 is what the file claims to be.
+    utf-8 | utf8) return 0 ;;
     iso-8859-* | windows-125*) minhigh=1 ;;
     *) minhigh=8 ;;
     esac
@@ -122,13 +124,15 @@ else
     # No CR: BSD sed writes a literal r, and the extractor strips CR anyway.
     LC_ALL=C sed '10s/.*/UTF-8/' "$langdir/Francais.txt" >"$tmp/undecodable.txt"
     LC_ALL=C sed '10s/.*/ISO-8859-2/' "$langdir/Croatian.txt" >"$tmp/c1.txt"
-    # A value line left as raw UTF-8, under a declared single-byte charset and
-    # then under a multi-byte one, which iconv on its own cannot reject.
-    leak=$(printf 'Une fuite UTF-8 : caf\xc3\xa9, na\xc3\xafve, t\xc3\xa9l\xc3\xa9phone, pr\xc3\xa9c\xc3\xa9d\xc3\xa9')
+    # A value line left as raw UTF-8, under a declared single-byte charset and then
+    # under gb2312, the multi-byte one whose own text comes closest to that shape.
+    # Its 8 non-ASCII bytes are what pin minhigh from above; the tree pins it from
+    # below, so widening either past the other is caught here.
+    leak=$(printf 'Une fuite UTF-8 : caf\xc3\xa9, na\xc3\xafve, t\xc3\xa9l\xc3\xa9phone')
     LC_ALL=C awk -v repl="$leak" \
         'NR == 20 { print repl; next } { print }' "$langdir/Francais.txt" >"$tmp/utf8mix.txt"
     LC_ALL=C awk -v repl="$leak" \
-        'NR == 20 { print repl; next } { print }' "$langdir/Japanese.txt" >"$tmp/utf8mixmb.txt"
+        'NR == 20 { print repl; next } { print }' "$langdir/Chinese-Simplified.txt" >"$tmp/utf8mixmb.txt"
     for probe in undecodable c1 utf8mix utf8mixmb; do
         if charset_declared_matches_bytes "$tmp/$probe.txt" >/dev/null; then
             echo "the charset check passed a deliberately mislabelled file ($probe)"
@@ -181,9 +185,9 @@ for scope in "Mirror %s and every host below it" "Ignore %s and every host below
 done
 
 # A msgid absent from a language file silently falls back to English (#862).
-# Multisets, not sets: a msgid appearing twice keeps the set equal while the
-# engine reaches only one of its two values. English.txt repeats 27 msgids of its
-# own, so the legitimate duplicates cancel out on both sides.
+# Multisets, not sets: a catalog repeating a msgid more often than English.txt
+# does keeps the set equal while one of the values it pairs goes unreachable.
+# English.txt repeats 27 msgids of its own, and those cancel out on both sides.
 LC_ALL=C sort <"$keys" >"$tmp/english.sorted"
 for f in "$langdir"/*.txt; do
     LC_ALL=C awk 'NR%2==1 { sub(/\r$/, ""); print }' "$f" | LC_ALL=C sort >"$tmp/have"
@@ -207,24 +211,22 @@ pin="$testdir/62_lang-untranslated.counts"
     echo "cannot find $pin"
     exit 1
 }
-ncounted=0
 : >"$tmp/counts"
 for f in "$langdir"/*.txt; do
     # English.txt is the msgid side of every pair, identical by construction.
     [ "$f" != "$eng" ] || continue
-    ncounted=$((ncounted + 1))
+    # Surrounding blanks are stripped before comparing: a value of one space, or a
+    # msgid copied with a trailing one, is as untranslated as the bare shapes.
     LC_ALL=C awk -v name="${f##*/}" '
+        function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
         { sub(/\r$/, "") }
-        NR % 2 == 1 { key = $0; next }
-        $0 == "" { empty++ }
-        $0 != "" && $0 == key { same++ }
+        NR % 2 == 1 { key = trim($0); next }
+        { value = trim($0) }
+        value == "" { empty++ }
+        value != "" && value == key { same++ }
         END { printf "%-25s %-9d %d\n", name, same + 0, empty + 0 }
     ' "$f" >>"$tmp/counts"
 done
-if [ "$ncounted" -ne $((nfiles - 1)) ]; then
-    echo "untranslated counts cover $ncounted of the $((nfiles - 1)) catalogs"
-    exit 1
-fi
 LC_ALL=C sort -o "$tmp/counts" "$tmp/counts"
 
 rc=0
@@ -240,7 +242,10 @@ LC_ALL=C awk -v pin="$pin" '
         while ((getline line < pin) > 0) {
             if (line ~ /^[ \t]*(#|$)/)
                 continue
-            if (split(line, a, /[ \t]+/) != 3) {
+            # A second row for the same catalog would otherwise just win, so the
+            # numbers a bad merge left behind have to be rejected, not applied.
+            if (split(line, a, /[ \t]+/) != 3 || a[2] !~ /^[0-9]+$/ ||
+                a[3] !~ /^[0-9]+$/ || a[1] in pinned) {
                 printf "%s: malformed pin line: %s\n", pin, line
                 bad++
                 continue
@@ -271,7 +276,7 @@ LC_ALL=C awk -v pin="$pin" '
         exit(bad > 0)
     }
 ' "$tmp/counts" || rc=$?
-# awk exits 2 on its own errors and 1 on a mismatch; conflating them is vacuity.
+# awk exits 2 on its own errors, 1 on a mismatch; treating them alike hides a broken check.
 if [ "$rc" -gt 1 ]; then
     echo "the untranslated-count comparison itself failed"
     exit 1

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -203,29 +203,46 @@ for f in "$langdir"/*.txt; do
     fi
 done
 
-# A value copied verbatim from its msgid, or left empty, satisfies every check
-# above while the string is still English on screen (#1260). A handful are
-# legitimate, so the per-catalog counts are pinned and have to match exactly.
+# A value copied verbatim from its msgid, or left empty, passes every check above
+# while the string is still English on screen (#1260). A handful are legitimate,
+# so the per-catalog counts are pinned and have to match exactly.
 pin="$testdir/62_lang-untranslated.counts"
 [ -f "$pin" ] || {
     echo "cannot find $pin"
     exit 1
 }
-: >"$tmp/counts"
-for f in "$langdir"/*.txt; do
-    # English.txt is the msgid side of every pair, identical by construction.
-    [ "$f" != "$eng" ] || continue
-    # Surrounding blanks are stripped before comparing: a value of one space, or a
-    # msgid copied with a trailing one, is as untranslated as the bare shapes.
-    LC_ALL=C awk -v name="${f##*/}" '
-        function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
+
+# Surrounding blanks are stripped before comparing: a value of one space, or a
+# msgid copied with a trailing one, is as untranslated as the bare shapes.
+count_untranslated() {
+    # Two anchored sub()s, not one alternation gsub: BSD awk restarts gsub after
+    # each match, where the leading-blank anchor can fire again mid-line.
+    LC_ALL=C awk -v name="$2" '
+        function trim(s) { sub(/^[ \t]+/, "", s); sub(/[ \t]+$/, "", s); return s }
         { sub(/\r$/, "") }
         NR % 2 == 1 { key = trim($0); next }
         { value = trim($0) }
         value == "" { empty++ }
         value != "" && value == key { same++ }
         END { printf "%-25s %-9d %d\n", name, same + 0, empty + 0 }
-    ' "$f" >>"$tmp/counts"
+    ' "$1"
+}
+
+# Catalogs pinned at zero would also match a counter that never leaves it, so
+# count a fixture carrying one of each shape before trusting the real ones.
+printf 'Cancel\nCancel\nClose\nClose \nOK\n \nSave\nEnregistrer\n' >"$tmp/probe.txt"
+got=$(count_untranslated "$tmp/probe.txt" probe.txt)
+want=$(printf '%-25s %-9d %d\n' probe.txt 2 1)
+if [ "$got" != "$want" ]; then
+    echo "the untranslated counter miscounts a known fixture: got [$got] want [$want]"
+    exit 1
+fi
+
+: >"$tmp/counts"
+for f in "$langdir"/*.txt; do
+    # English.txt is the msgid side of every pair, identical by construction.
+    [ "$f" != "$eng" ] || continue
+    count_untranslated "$f" "${f##*/}" >>"$tmp/counts"
 done
 LC_ALL=C sort -o "$tmp/counts" "$tmp/counts"
 
@@ -240,6 +257,7 @@ LC_ALL=C awk -v pin="$pin" '
     }
     BEGIN {
         while ((getline line < pin) > 0) {
+            sub(/\r$/, "", line)
             if (line ~ /^[ \t]*(#|$)/)
                 continue
             # A second row for the same catalog would otherwise just win, so the
@@ -273,11 +291,12 @@ LC_ALL=C awk -v pin="$pin" '
                 printf "%s: pinned but no such catalog\n", f
                 bad++
             }
-        exit(bad > 0)
+        exit(bad > 0 ? 3 : 0)
     }
 ' "$tmp/counts" || rc=$?
-# awk exits 2 on its own errors, 1 on a mismatch; treating them alike hides a broken check.
-if [ "$rc" -gt 1 ]; then
+# A mismatch says so with 3, because awk's own error status is 1 on gawk and 2 on
+# mawk; reading either as a mismatch would hide a broken check.
+if [ "$rc" -ne 0 ] && [ "$rc" -ne 3 ]; then
     echo "the untranslated-count comparison itself failed"
     exit 1
 elif [ "$rc" -ne 0 ]; then

--- a/tests/62_lang-untranslated.counts
+++ b/tests/62_lang-untranslated.counts
@@ -1,10 +1,7 @@
-# Untranslated values per lang/*.txt catalog: those copied verbatim from their
-# English msgid, then those left empty. Both pass 62_lang-integrity's join check
-# while the string stays English on screen (#1260), and a handful are legitimate
-# ("OK", "URLs"), so the test pins the counts and demands an exact match:
-# translate the new string rather than raise a number, and lower a number in the
-# change that translates one. English.txt is the msgid side of every pair, so it
-# is not listed.
+# Per-catalog counts: values identical to their English msgid, then empty ones.
+# 62_lang-integrity.test wants an exact match, so translate a string rather than
+# raise a count, and lower a count in the change that translates one.
+# English.txt is the msgid side of every pair, so it is not listed.
 #
 # catalog                 identical empty
 Bulgarian.txt             3         3

--- a/tests/62_lang-untranslated.counts
+++ b/tests/62_lang-untranslated.counts
@@ -1,7 +1,7 @@
 # Per-catalog counts: values identical to their English msgid, then empty ones.
+# English.txt is not listed: it is the msgid side of every pair.
 # 62_lang-integrity.test wants an exact match, so translate a string rather than
-# raise a count, and lower a count in the change that translates one.
-# English.txt is the msgid side of every pair, so it is not listed.
+# raise a count.
 #
 # catalog                 identical empty
 Bulgarian.txt             3         3

--- a/tests/62_lang-untranslated.counts
+++ b/tests/62_lang-untranslated.counts
@@ -1,0 +1,38 @@
+# Untranslated values per lang/*.txt catalog: those copied verbatim from their
+# English msgid, then those left empty. Both pass 62_lang-integrity's join check
+# while the string stays English on screen (#1260), and a handful are legitimate
+# ("OK", "URLs"), so the test pins the counts and demands an exact match:
+# translate the new string rather than raise a number, and lower a number in the
+# change that translates one. English.txt is the msgid side of every pair, so it
+# is not listed.
+#
+# catalog                 identical empty
+Bulgarian.txt             3         3
+Castellano.txt            7         0
+Cesky.txt                 3         23
+Chinese-BIG5.txt          1         4
+Chinese-Simplified.txt    0         23
+Croatian.txt              5         0
+Dansk.txt                 10        0
+Deutsch.txt               9         4
+Eesti.txt                 7         18
+Finnish.txt               2         0
+Francais.txt              5         0
+Greek.txt                 5         0
+Italiano.txt              13        1
+Japanese.txt              3         23
+Macedonian.txt            3         6
+Magyar.txt                4         4
+Nederlands.txt            17        4
+Norsk.txt                 5         21
+Polski.txt                6         0
+Portugues-Brasil.txt      4         0
+Portugues.txt             4         26
+Romanian.txt              4         5
+Russian.txt               5         0
+Slovak.txt                6         18
+Slovenian.txt             7         25
+Svenska.txt               9         23
+Turkish.txt               1         0
+Ukrainian.txt             0         21
+Uzbek.txt                 8         0

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,7 +23,8 @@ EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c a
 	server-root/hostalias/e.html \
 	server-root/fraglink/index.html server-root/fraglink/target.html \
 	fixtures/cache-golden/hts-cache/new.zip \
-	install-manifest.txt
+	install-manifest.txt \
+	62_lang-untranslated.counts
 
 TESTS_ENVIRONMENT =
 TESTS_ENVIRONMENT += PATH=$(top_builddir)/src$(PATH_SEPARATOR)$$PATH
@@ -138,4 +139,4 @@ TEST_EXTENSIONS = .test
 # cancelled step keeps neither its log nor its artifacts, so today a hang tells
 # us nothing at all. HTTRACK_TEST_TIMEOUT overrides the budget; 0 disables it.
 TEST_LOG_COMPILER = $(BASH_SHELL) $(srcdir)/test-timeout.sh
-CLEANFILES = check-network_sh.cache
+CLEANFILES = check-network_sh.cache 62_lang-untranslated.counts.new


### PR DESCRIPTION
62_lang-integrity.test checked that every English.txt msgid was present in each catalog, never that the value beside it had been translated. A verbatim copy of the msgid passes, and so does an empty value. #1166 shipped LANG_HOSTALIAS as an English copy to all thirty catalogs and the test stayed green until #1255 caught it by hand.

A blanket "value must differ from msgid" rule is not available, since a fair number legitimately are identical (OK, URLs, Proxy, proper nouns). So this pins the per-catalog counts of both shapes in `tests/62_lang-untranslated.counts` and requires an exact match: a translated string lowers the pin instead of leaving it stale the way the old waiver list rotted. Counts keep the data file small, at the cost of one blind spot: translating one string while copying another in the same catalog cancels out.

Two smaller holes in the same loop are fixed too. The msgid join was set-based, so a catalog repeating a msgid more often than English does went unseen; it compares multisets now. And the mixed-encoding probe skipped the three multi-byte charsets on a premise measurement does not support, so it now covers every charset except UTF-8 itself, with the gb2312 control pinning the new threshold from above where the tree pins it from below. 29 catalogs pinned, 156 values identical to their msgid and 252 empty, every check mutation-proved.

Closes #1260
