### PR TITLE
A long filter or URL token overflows its buffer in the option parser

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -441,22 +441,22 @@ void hts_finish_html_file(httrackp *opt, cache_back *cache, htsblk *r,
   }
 }
 
-hts_boolean hts_scan_token(char **ptr, char *dest, size_t maxlen) {
+hts_boolean hts_scan_token(char **ptr, char *dest, size_t destsize) {
   char *a = *ptr;
-  size_t len = 0; /* the token's real length, which may exceed maxlen */
+  size_t len = 0; /* the token's real length, which may exceed the room */
 
-  assertf(maxlen != 0);
+  assertf(destsize != 0);
   while (*a != '\0' && !isspace((unsigned char) *a)) {
-    if (len < maxlen)
+    if (len < destsize - 1)
       dest[len] = *a;
     len++;
     a++;
   }
-  dest[len < maxlen ? len : maxlen] = '\0';
+  dest[len < destsize ? len : destsize - 1] = '\0';
   while (isspace((unsigned char) *a))
     a++;
   *ptr = a;
-  return len <= maxlen ? HTS_TRUE : HTS_FALSE;
+  return len < destsize ? HTS_TRUE : HTS_FALSE;
 }
 
 /* does it look like XML ? (SVG et al.) */
@@ -648,14 +648,20 @@ int httpmirror(char *url1, httrackp * opt) {
   // copier adresse(s) dans liste des adresses
   {
     char *a = url1;
+    const size_t url_len = strlen(url1);
     const LLint list_sz = StringNotEmpty(opt->filelist)
                               ? fsize_utf8(StringBuff(opt->filelist))
                               : 0;
-    /* two bytes reserved per list byte; -1 makes an undoublable size refused */
+    /* a one-byte token is emitted as "http://a\n", so the reserve is five
+       bytes per input byte, not two; -1 refuses a size it would overflow */
     const LLint list_room =
-        list_sz > 0 ? (list_sz <= INT64_MAX / 2 ? list_sz * 2 : -1) : 0;
-    const size_t primary_len =
-        llint_grow_size_t(8192 + strlen(url1) * 2, list_room, 0);
+        list_sz > 0 ? (list_sz <= INT64_MAX / 5 ? list_sz * 5 : -1) : 0;
+    const size_t url_room = url_len <= (((size_t) -2) - 8192) / 5
+                                ? 8192 + url_len * 5
+                                : (size_t) -1;
+    const size_t primary_len = url_room != (size_t) -1
+                                   ? llint_grow_size_t(url_room, list_room, 0)
+                                   : (size_t) -1;
 
     // création de la première page, qui contient les liens de base à scanner
     // c'est plus propre et plus logique que d'entrer à la main les liens dans la pile
@@ -695,12 +701,17 @@ int httpmirror(char *url1, httrackp * opt) {
         }
 
         // recopier prochaine chaine (+ ou -)
-        /* the slot it lands in must also hold the sign, and the implicit form
-           below appends a '*' */
-        if (!hts_scan_token(&a, tempo, sizeof(tempo) - 3)) {
+        /* the slot it lands in must hold the sign too, and the implicit form
+           below gains a trailing '*' */
+        const size_t room = sizeof(tempo) - (plus == 0 && type == 1 ? 2 : 1);
+
+        if (!hts_scan_token(&a, tempo, room)) {
+          /* on the console too: the user who typed it may have no log open */
+          printf("Filter rule longer than %d bytes, ignored: %c%.64s...\n",
+                 (int) (room - 1), type ? '+' : '-', tempo);
           hts_log_print(opt, LOG_WARNING,
                         "Filter rule longer than %d bytes, ignored: %c%.64s...",
-                        (int) (sizeof(tempo) - 3), type ? '+' : '-', tempo);
+                        (int) (room - 1), type ? '+' : '-', tempo);
           continue;
         }
 
@@ -739,7 +750,9 @@ int httpmirror(char *url1, httrackp * opt) {
         char BIGSTK url[HTS_URLMAXSIZE * 2];
 
         // prochaine adresse
-        if (!hts_scan_token(&a, url, sizeof(url) - 1)) {
+        if (!hts_scan_token(&a, url, sizeof(url))) {
+          printf("URL longer than %d bytes, ignored: %.64s...\n",
+                 (int) (sizeof(url) - 1), url);
           hts_log_print(opt, LOG_WARNING,
                         "URL longer than %d bytes, ignored: %.64s...",
                         (int) (sizeof(url) - 1), url);

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -441,6 +441,24 @@ void hts_finish_html_file(httrackp *opt, cache_back *cache, htsblk *r,
   }
 }
 
+hts_boolean hts_scan_token(char **ptr, char *dest, size_t maxlen) {
+  char *a = *ptr;
+  size_t len = 0; /* the token's real length, which may exceed maxlen */
+
+  assertf(maxlen != 0);
+  while (*a != '\0' && !isspace((unsigned char) *a)) {
+    if (len < maxlen)
+      dest[len] = *a;
+    len++;
+    a++;
+  }
+  dest[len < maxlen ? len : maxlen] = '\0';
+  while (isspace((unsigned char) *a))
+    a++;
+  *ptr = a;
+  return len <= maxlen ? HTS_TRUE : HTS_FALSE;
+}
+
 /* does it look like XML ? (SVG et al.) */
 static int look_like_xml(const char *s) {
   return strncmp(s, "<?xml", 5) == 0
@@ -650,8 +668,7 @@ int httpmirror(char *url1, httrackp * opt) {
     }
     htsbuff primarybuff = htsbuff_ptr(primary, primary_len);
 
-    while(*a) {
-      int i;
+    while (*a) {
       int joker = 0;
 
       // vérifier qu'il n'y a pas de * dans l'url
@@ -678,14 +695,13 @@ int httpmirror(char *url1, httrackp * opt) {
         }
 
         // recopier prochaine chaine (+ ou -)
-        i = 0;
-        while((*a != 0) && (!isspace((unsigned char) *a))) {
-          tempo[i++] = *a;
-          a++;
-        }
-        tempo[i++] = '\0';
-        while(isspace((unsigned char) *a)) {
-          a++;
+        /* the slot it lands in must also hold the sign, and the implicit form
+           below appends a '*' */
+        if (!hts_scan_token(&a, tempo, sizeof(tempo) - 3)) {
+          hts_log_print(opt, LOG_WARNING,
+                        "Filter rule longer than %d bytes, ignored: %c%.64s...",
+                        (int) (sizeof(tempo) - 3), type ? '+' : '-', tempo);
+          continue;
         }
 
         // sauter les + sans rien après..
@@ -723,22 +739,19 @@ int httpmirror(char *url1, httrackp * opt) {
         char BIGSTK url[HTS_URLMAXSIZE * 2];
 
         // prochaine adresse
-        i = 0;
-        while((*a != 0) && (!isspace((unsigned char) *a))) {
-          url[i++] = *a;
-          a++;
+        if (!hts_scan_token(&a, url, sizeof(url) - 1)) {
+          hts_log_print(opt, LOG_WARNING,
+                        "URL longer than %d bytes, ignored: %.64s...",
+                        (int) (sizeof(url) - 1), url);
+          continue;
         }
-        while(isspace((unsigned char) *a)) {
-          a++;
-        }
-        url[i++] = '\0';
 
         if (strstr(url, ":/") == NULL)
           htsbuff_cat(&primarybuff, "http://");
         htsbuff_cat(&primarybuff, url);
         htsbuff_cat(&primarybuff, "\n");
       }
-    }                           // while
+    } // while
 
     /* --why: print which filter rule decides for this URL, then stop */
     if (StringNotEmpty(opt->why_url)) {

--- a/src/htscore.h
+++ b/src/htscore.h
@@ -327,6 +327,12 @@ void hts_record_init(httrackp *opt);
 
 void hts_record_free(httrackp *opt);
 
+/* Copy the whitespace-delimited token at *ptr into dest (maxlen characters plus
+   the NUL) and advance *ptr past it and the whitespace after it. HTS_FALSE when
+   the token was longer; dest holds what fit, which a filter caller must refuse
+   rather than use, a cut pattern authorizing something else. */
+hts_boolean hts_scan_token(char **ptr, char *dest, size_t maxlen);
+
 /* Run the mirror for the given start URL(s) under opt. Top-level engine entry.
  */
 int httpmirror(char *url1, httrackp * opt);

--- a/src/htscore.h
+++ b/src/htscore.h
@@ -327,12 +327,6 @@ void hts_record_init(httrackp *opt);
 
 void hts_record_free(httrackp *opt);
 
-/* Copy the whitespace-delimited token at *ptr into dest (maxlen characters plus
-   the NUL) and advance *ptr past it and the whitespace after it. HTS_FALSE when
-   the token was longer; dest holds what fit, which a filter caller must refuse
-   rather than use, a cut pattern authorizing something else. */
-hts_boolean hts_scan_token(char **ptr, char *dest, size_t maxlen);
-
 /* Run the mirror for the given start URL(s) under opt. Top-level engine entry.
  */
 int httpmirror(char *url1, httrackp * opt);
@@ -368,6 +362,12 @@ int filenote(filenote_strc * strct, const char *s, filecreate_params * params);
    sits under it. Also the change report's key, so the two must not drift. */
 void hts_savename_listed(const char *root, const char *s, char *dest,
                          size_t destsize);
+
+/* Copy the whitespace-delimited token at *ptr into dest (destsize bytes, NUL
+   included) and advance *ptr past it and the whitespace after it. HTS_FALSE
+   when the token was longer, dest then holding what fit. A caller reading a
+   filter must refuse it: a cut pattern authorizes something else. */
+hts_boolean hts_scan_token(char **ptr, char *dest, size_t destsize);
 
 void file_notify(httrackp * opt, const char *adr, const char *fil,
                  const char *save, int create, int modify, int wasupdated);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4132,6 +4132,76 @@ static int st_hashkey_bounds(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* Runs hts_scan_token() into a poisoned arena holding maxlen characters plus
+   the NUL, and reports whether anything past that moved. */
+static hts_boolean st_scantoken_run(char *src, size_t maxlen, char *arena,
+                                    size_t guard, hts_boolean *fit,
+                                    size_t *advance) {
+  char *p = src;
+  size_t i;
+
+  /* poisoned with '#', not 0, or the stray NUL of an off-by-one would read as
+     untouched */
+  memset(arena, '#', maxlen + 1 + guard);
+  *fit = hts_scan_token(&p, arena, maxlen);
+  *advance = (size_t) (p - src);
+  for (i = maxlen + 1; i < maxlen + 1 + guard; i++) {
+    if (arena[i] != '#')
+      return HTS_FALSE;
+  }
+  return HTS_TRUE;
+}
+
+/* The option string is copied token by token into fixed buffers, which a token
+   longer than one of them used to walk straight past (#1271). */
+static int st_scantoken(httrackp *opt, int argc, char **argv) {
+  /* the bound the engine's filter buffer imposes, and a small one the same
+     code must honour */
+  const size_t caps[] = {8, HTS_URLMAXSIZE * 2 - 3};
+  const size_t guard = 64;
+  size_t c;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+  for (c = 0; c < sizeof(caps) / sizeof(caps[0]); c++) {
+    const size_t maxlen = caps[c];
+    /* empty, short, and the four lengths that straddle the bound */
+    const size_t lens[] = {0,      1,          maxlen - 1,
+                           maxlen, maxlen + 1, maxlen + guard};
+    char *arena = malloct(maxlen + 1 + guard);
+    char *src = malloct(maxlen + guard + 8);
+    size_t k;
+
+    assertf(arena != NULL && src != NULL);
+    for (k = 0; k < sizeof(lens) / sizeof(lens[0]); k++) {
+      const size_t len = lens[k];
+      const size_t kept = len < maxlen ? len : maxlen;
+      hts_boolean fit;
+      size_t advance;
+
+      /* the token, the whitespace run after it, and the token to land on */
+      memset(src, 'a', len);
+      memcpy(src + len, " \tb", 4);
+      assertf(st_scantoken_run(src, maxlen, arena, guard, &fit, &advance));
+      assertf(fit == (len <= maxlen ? HTS_TRUE : HTS_FALSE));
+      assertf(strlen(arena) == kept && strspn(arena, "a") == kept);
+      assertf(advance == len + 2);
+
+      /* the same token ending the string: the cursor stops on its NUL */
+      src[len] = '\0';
+      assertf(st_scantoken_run(src, maxlen, arena, guard, &fit, &advance));
+      assertf(fit == (len <= maxlen ? HTS_TRUE : HTS_FALSE));
+      assertf(strlen(arena) == kept && strspn(arena, "a") == kept);
+      assertf(advance == len);
+    }
+    freet(arena);
+    freet(src);
+  }
+  printf("scantoken self-test OK\n");
+  return 0;
+}
+
 /* Prints the filter answer <n> emits for (adr, fil) [up] in [slot]; with no
    arguments, asserts every answer against its expected pattern (#1119). */
 static int st_wizardfilter(httrackp *opt, int argc, char **argv) {
@@ -10208,6 +10278,9 @@ static const struct selftest_entry {
      "merged two-form filter verdict (fa_strjoker_dual)", st_filterdual},
     {"filterbounds", "", "matcher length/work caps reject hostile patterns",
      st_filterbounds},
+    {"scantoken", "",
+     "option-string token copy is bounded and reports a refusal (#1271)",
+     st_scantoken},
     {"simplify", "<path>", "collapse ./ and ../ in a path", st_simplify},
     {"expandhome", "<path>", "expand a leading ~/ into $HOME", st_expandhome},
     {"stripquery", "", "--strip-query pattern/key stripping self-test",

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4132,9 +4132,9 @@ static int st_hashkey_bounds(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-/* Runs hts_scan_token() into a poisoned arena holding maxlen characters plus
-   the NUL, and reports whether anything past that moved. */
-static hts_boolean st_scantoken_run(char *src, size_t maxlen, char *arena,
+/* Runs hts_scan_token() into an arena of destsize bytes poisoned past its end,
+   and reports whether anything past that moved. */
+static hts_boolean st_scantoken_run(char *src, size_t destsize, char *arena,
                                     size_t guard, hts_boolean *fit,
                                     size_t *advance) {
   char *p = src;
@@ -4142,22 +4142,21 @@ static hts_boolean st_scantoken_run(char *src, size_t maxlen, char *arena,
 
   /* poisoned with '#', not 0, or the stray NUL of an off-by-one would read as
      untouched */
-  memset(arena, '#', maxlen + 1 + guard);
-  *fit = hts_scan_token(&p, arena, maxlen);
+  memset(arena, '#', destsize + guard);
+  *fit = hts_scan_token(&p, arena, destsize);
   *advance = (size_t) (p - src);
-  for (i = maxlen + 1; i < maxlen + 1 + guard; i++) {
+  for (i = destsize; i < destsize + guard; i++) {
     if (arena[i] != '#')
       return HTS_FALSE;
   }
   return HTS_TRUE;
 }
 
-/* The option string is copied token by token into fixed buffers, which a token
-   longer than one of them used to walk straight past (#1271). */
+/* A token longer than the buffer it is copied into must be refused, never
+   written past the end (#1271). */
 static int st_scantoken(httrackp *opt, int argc, char **argv) {
-  /* the bound the engine's filter buffer imposes, and a small one the same
-     code must honour */
-  const size_t caps[] = {8, HTS_URLMAXSIZE * 2 - 3};
+  /* the engine's own filter bound, and a small one the same code must honour */
+  const size_t caps[] = {8, HTS_URLMAXSIZE * 2 - 1};
   const size_t guard = 64;
   size_t c;
 
@@ -4165,34 +4164,36 @@ static int st_scantoken(httrackp *opt, int argc, char **argv) {
   (void) argc;
   (void) argv;
   for (c = 0; c < sizeof(caps) / sizeof(caps[0]); c++) {
-    const size_t maxlen = caps[c];
+    const size_t destsize = caps[c];
+    const size_t room = destsize - 1; /* characters, the NUL aside */
     /* empty, short, and the four lengths that straddle the bound */
-    const size_t lens[] = {0,      1,          maxlen - 1,
-                           maxlen, maxlen + 1, maxlen + guard};
-    char *arena = malloct(maxlen + 1 + guard);
-    char *src = malloct(maxlen + guard + 8);
+    const size_t lens[] = {0, 1, room - 1, room, room + 1, room + guard};
+    char *arena = malloct(destsize + guard);
+    char *src = malloct(room + guard + 8);
     size_t k;
 
     assertf(arena != NULL && src != NULL);
     for (k = 0; k < sizeof(lens) / sizeof(lens[0]); k++) {
       const size_t len = lens[k];
-      const size_t kept = len < maxlen ? len : maxlen;
+      const size_t kept = len < room ? len : room;
       hts_boolean fit;
-      size_t advance;
+      size_t advance, i;
 
-      /* the token, the whitespace run after it, and the token to land on */
-      memset(src, 'a', len);
+      /* the token, the whitespace run after it, and the token to land on. Its
+         bytes vary, or a copy landing on the wrong index would still match */
+      for (i = 0; i < len; i++)
+        src[i] = (char) ('a' + i % 26);
       memcpy(src + len, " \tb", 4);
-      assertf(st_scantoken_run(src, maxlen, arena, guard, &fit, &advance));
-      assertf(fit == (len <= maxlen ? HTS_TRUE : HTS_FALSE));
-      assertf(strlen(arena) == kept && strspn(arena, "a") == kept);
+      assertf(st_scantoken_run(src, destsize, arena, guard, &fit, &advance));
+      assertf(fit == (len <= room ? HTS_TRUE : HTS_FALSE));
+      assertf(strlen(arena) == kept && memcmp(arena, src, kept) == 0);
       assertf(advance == len + 2);
 
       /* the same token ending the string: the cursor stops on its NUL */
       src[len] = '\0';
-      assertf(st_scantoken_run(src, maxlen, arena, guard, &fit, &advance));
-      assertf(fit == (len <= maxlen ? HTS_TRUE : HTS_FALSE));
-      assertf(strlen(arena) == kept && strspn(arena, "a") == kept);
+      assertf(st_scantoken_run(src, destsize, arena, guard, &fit, &advance));
+      assertf(fit == (len <= room ? HTS_TRUE : HTS_FALSE));
+      assertf(strlen(arena) == kept && memcmp(arena, src, kept) == 0);
       assertf(advance == len);
     }
     freet(arena);

--- a/tests/302_filter-token-overflow.test
+++ b/tests/302_filter-token-overflow.test
@@ -2,8 +2,8 @@
 #
 
 set -euo pipefail
-# shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
 
 # A filter or a URL longer than the buffer it is copied into must be named and
 # dropped, never truncated into a rule that authorizes something else (#1271).
@@ -13,8 +13,8 @@ assert_selftest "scantoken self-test OK" scantoken
 tmpdir="$(mktemp -d)"
 cleanup_push rm -rf "$tmpdir"
 
-# HTS_URLMAXSIZE * 2, less the sign and the '*' an implicit rule gains
-maxfilter=2045
+# HTS_URLMAXSIZE * 2, less the sign the filter slot gains and the NUL
+maxfilter=2046
 maxurl=2047
 
 rep() { # rep CHAR COUNT
@@ -37,12 +37,14 @@ longrule() { # longrule LENGTH FILE
     printf -- '-%s\n+*.png\n' "$(rep a "$1")" >"$2"
 }
 
-# At the bound the rule is kept, so the one that decides is the second.
+# At the bound the rule is kept, so the one that decides is the second. This is
+# also the longest rule the pre-fix engine handled without dying.
 longrule "$maxfilter" "$tmpdir/fit.txt"
 assert_eq "http://www.example.com/a.png: accepted by rule #2 (+*.png)" \
     "$(why "$tmpdir/fit.txt")" "filter of $maxfilter bytes"
 
-# One byte over, and it is gone: the numbering shifts, and nothing aborts.
+# One byte over, and it is gone: the numbering shifts. The two overshoots die
+# differently before the fix, on the filter slot then on the stack canary.
 for over in 1 512; do
     longrule "$((maxfilter + over))" "$tmpdir/over.txt"
     assert_eq "http://www.example.com/a.png: accepted by rule #1 (+*.png)" \
@@ -51,6 +53,16 @@ for over in 1 512; do
         "$(cat "$tmpdir/p/hts-log.txt")" "refusal named in the log"
 done
 
+# Every seed costs "http://" and a newline on top of its own bytes, so the list
+# they are gathered into has to be budgeted per token: 5000 one-byte seeds used
+# to overrun it and abort on the append.
+{
+    for ((i = 0; i < 5000; i++)); do printf 'a\n'; done
+    echo '+*.png'
+} >"$tmpdir/many.txt"
+assert_eq "http://www.example.com/a.png: accepted by rule #1 (+*.png)" \
+    "$(why "$tmpdir/many.txt")" "5000 one-byte seeds"
+
 # The URL token beside it is copied by the same code and bounded on its own.
 printf 'http://www.example.com/%s\n+*.png\n' "$(rep a $((maxurl - 22)))" \
     >"$tmpdir/longurl.txt"
@@ -58,3 +70,27 @@ assert_eq "http://www.example.com/a.png: accepted by rule #1 (+*.png)" \
     "$(why "$tmpdir/longurl.txt")" "URL of $((maxurl + 1)) bytes"
 assert_match "URL longer than $maxurl bytes, ignored: http://www.example.com/aaa" \
     "$(cat "$tmpdir/p/hts-log.txt")" "refusal named in the log"
+
+# That line is written before the seed is dropped, so it cannot tell a refusal
+# from a truncation. Crawl for real and count what the refusal cost: a seed the
+# engine kept goes on to fail on a save path it cannot build, six warnings and
+# an error further on.
+find_python >/dev/null || skip "python3 not found"
+doc="$tmpdir/doc"
+mkdir -p "$doc"
+echo '<html><body>seed</body></html>' >"$doc/index.html"
+local_server_start --root "$doc"
+
+# Through -%S, since every argv entry is already capped at HTS_CDLMAXSIZE.
+long="$BASEURL/$(rep a $((maxurl + 1 - ${#BASEURL} - 1)))"
+assert_eq "$((maxurl + 1))" "${#long}" "seed one byte past the URL buffer"
+printf '%s\n' "$long" >"$tmpdir/seed.txt"
+local_crawl --log "$tmpdir/crawl.log" -O "$tmpdir/m" --quiet --robots=0 \
+    --retries=0 -%S "$tmpdir/seed.txt" "$BASEURL/index.html" ||
+    fail "crawl exited $?"
+assert_file "$tmpdir/m/127.0.0.1_$SRV_PORT/index.html" "the seed that fits"
+log="$(cat "$tmpdir/m/hts-log.txt")"
+assert_match "URL longer than $maxurl bytes, ignored: $BASEURL/aaa" "$log" \
+    "refusal named in the log"
+assert_eq 1 "$(grep -cE 'Warning:|Error:' <<<"$log")" \
+    "messages the refused seed cost"

--- a/tests/302_filter-token-overflow.test
+++ b/tests/302_filter-token-overflow.test
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+# A filter or a URL longer than the buffer it is copied into must be named and
+# dropped, never truncated into a rule that authorizes something else (#1271).
+
+assert_selftest "scantoken self-test OK" scantoken
+
+tmpdir="$(mktemp -d)"
+cleanup_push rm -rf "$tmpdir"
+
+# HTS_URLMAXSIZE * 2, less the sign and the '*' an implicit rule gains
+maxfilter=2045
+maxurl=2047
+
+rep() { # rep CHAR COUNT
+    local pad
+    pad=$(printf '%*s' "$2" '')
+    printf '%s' "${pad// /$1}"
+}
+
+# Runs --why over a rules file and returns the verdict line alone.
+why() { # why RULE-FILE
+    local out
+    out="$(httrack -O "$tmpdir/p" -q --why http://www.example.com/a.png \
+        -%S "$1" http://www.example.com/)" ||
+        fail "httrack exited $? on $(basename "$1")"
+    grep -E 'accepted|rejected|no filter|unable' <<<"$out"
+}
+
+# An over-long rule, then the one that decides.
+longrule() { # longrule LENGTH FILE
+    printf -- '-%s\n+*.png\n' "$(rep a "$1")" >"$2"
+}
+
+# At the bound the rule is kept, so the one that decides is the second.
+longrule "$maxfilter" "$tmpdir/fit.txt"
+assert_eq "http://www.example.com/a.png: accepted by rule #2 (+*.png)" \
+    "$(why "$tmpdir/fit.txt")" "filter of $maxfilter bytes"
+
+# One byte over, and it is gone: the numbering shifts, and nothing aborts.
+for over in 1 512; do
+    longrule "$((maxfilter + over))" "$tmpdir/over.txt"
+    assert_eq "http://www.example.com/a.png: accepted by rule #1 (+*.png)" \
+        "$(why "$tmpdir/over.txt")" "filter of $((maxfilter + over)) bytes"
+    assert_match "Filter rule longer than $maxfilter bytes, ignored: -aaa" \
+        "$(cat "$tmpdir/p/hts-log.txt")" "refusal named in the log"
+done
+
+# The URL token beside it is copied by the same code and bounded on its own.
+printf 'http://www.example.com/%s\n+*.png\n' "$(rep a $((maxurl - 22)))" \
+    >"$tmpdir/longurl.txt"
+assert_eq "http://www.example.com/a.png: accepted by rule #1 (+*.png)" \
+    "$(why "$tmpdir/longurl.txt")" "URL of $((maxurl + 1)) bytes"
+assert_match "URL longer than $maxurl bytes, ignored: http://www.example.com/aaa" \
+    "$(cat "$tmpdir/p/hts-log.txt")" "refusal named in the log"


### PR DESCRIPTION
httpmirror() splits its option string into whitespace-delimited tokens and copies each into a 2048-byte stack local with nothing bounding the index. There are two of these loops, byte for byte the same: one for a filter token, one for the URL beside it. A token longer than the buffer walks off the end of either, with bytes the caller picked. The string is not remote. It comes from the command line, a `-%S` scan-rules file, or a project's stored options, but a rules file is the sort of thing a user pastes or a front end writes, so reaching it takes nothing exotic. On master a 2047-byte rule dies on the filter slot, and a longer one on the stack canary.

Both loops now call `hts_scan_token()`, which fills its destination and then keeps counting, so it can tell the caller the token did not fit. The caller names it on the console and in the log, then drops it. Clipping was the alternative and is worse: a filter means its whole text, and a cut that lands on a wildcard turns a narrow rule into a broad one that is then stored as an allow rule. Dropping a deny rule is not free either, since what the user excluded gets crawled, but nothing under 2047 bytes is ever dropped and master crashed on the rest.

Review turned up a third overflow on the same path, fixed here too: the seed list reserves two bytes per input byte, while a one-byte seed comes out as `http://a\n`. Five thousand of them overran it and aborted on the append, on master as well.

Test 302 drives both branches through `--why`, which parses the rules and prints the verdict without crawling, and checks the boundary each way: at 2046 bytes the rule is kept and decides, one byte over it is gone and the numbering shifts. The URL branch also gets a real crawl, since its refusal is logged before the seed is dropped and so cannot tell a refusal from a truncation, while the number of messages the run costs can. The `scantoken` self-test sweeps lengths around two capacities into a `#`-poisoned arena, which catches a stray NUL past the end as well as a run of data. Both halves go red on master, and six mutants each go red on one of them.

Closes #1271
