### PR TITLE
A filter rule longer than the matcher's cap is stored and never matches

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -696,11 +696,15 @@ int httpmirror(char *url1, httrackp * opt) {
             }
           }
           {
-            htsbuff fb = htsbuff_ptr(filters[filptr], HTS_URLMAXSIZE * 2);
+            /* wider than a slot, so an over-long rule reaches the length check
+               rather than aborting here */
+            char BIGSTK rule[HTS_FILTER_SLOT_SIZE + 2];
+            htsbuff fb = htsbuff_array(rule);
+
             htsbuff_cpy(&fb, type ? "+" : "-");
             htsbuff_cat(&fb, tempo);
+            filters_insert(opt, filptr, rule); /* bumps filptr when stored */
           }
-          filptr++;
 
           /* sanity check */
           if (filptr + 1 >= opt->maxfilter) {
@@ -2346,11 +2350,13 @@ void host_ban(httrackp * opt, int ptr,
   // interdire host
   assertf((*_FILTERS_PTR) < opt->maxfilter);
   if (*_FILTERS_PTR < opt->maxfilter) {
-    htsbuff fb = htsbuff_ptr(_FILTERS[*_FILTERS_PTR], HTS_URLMAXSIZE * 2);
+    char BIGSTK rule[HTS_FILTER_SLOT_SIZE + 4];
+    htsbuff fb = htsbuff_array(rule);
+
     htsbuff_cpy(&fb, "-");
     htsbuff_cat(&fb, host);
     htsbuff_cat(&fb, "/*"); // forbid host/*
-    (*_FILTERS_PTR)++;
+    filters_insert(opt, *_FILTERS_PTR, rule);
   }
   // oups
   if (strlen(host) <= 1) {      // euhh?? longueur <= 1
@@ -2428,6 +2434,27 @@ void filters_bind(httrackp *opt, char ***ptrfilters, int *filptr) {
   opt->filters.filters = ptrfilters;
   opt->filters.filptr = filptr;
   opt->wizard_filters = 0;
+}
+
+hts_boolean filters_insert(httrackp *opt, int pos, const char *pattern) {
+  char **const filters = *opt->filters.filters;
+  const size_t len = strlen(pattern);
+  int i;
+
+  assertf(pos >= 0 && pos <= *opt->filters.filptr);
+  if (len > HTS_FILTER_MAXLEN) {
+    hts_log_print(opt, LOG_WARNING,
+                  "Filter rule dropped: %d bytes, past the %d the matcher "
+                  "reads, so it could never match: %s",
+                  (int) len, (int) HTS_FILTER_MAXLEN, pattern);
+    return HTS_FALSE;
+  }
+  for (i = *opt->filters.filptr; i > pos; i--)
+    strlcpybuff(filters[i], filters[i - 1], HTS_FILTER_SLOT_SIZE);
+  strlcpybuff(filters[pos], pattern, HTS_FILTER_SLOT_SIZE);
+  (*opt->filters.filptr)++;
+  assertf((*opt->filters.filptr) < opt->maxfilter);
+  return HTS_TRUE;
 }
 
 int filters_init(char ***ptrfilters, int maxfilter, int filterinc) {

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -2436,6 +2436,13 @@ void filters_bind(httrackp *opt, char ***ptrfilters, int *filptr) {
   opt->wizard_filters = 0;
 }
 
+/* A rule the array takes is one strjoker() reads and one a slot holds, whatever
+   the two caps become; a hardcoded limit would silently stop being either. */
+enum {
+  hts_filter_maxlen_matches = 1 / (HTS_FILTER_MAXLEN <= STRJOKER_MAXLEN),
+  hts_filter_maxlen_fits = 1 / (HTS_FILTER_MAXLEN < HTS_FILTER_SLOT_SIZE)
+};
+
 hts_boolean filters_insert(httrackp *opt, int pos, const char *pattern) {
   char **const filters = *opt->filters.filters;
   const size_t len = strlen(pattern);
@@ -2444,8 +2451,8 @@ hts_boolean filters_insert(httrackp *opt, int pos, const char *pattern) {
   assertf(pos >= 0 && pos <= *opt->filters.filptr);
   if (len > HTS_FILTER_MAXLEN) {
     hts_log_print(opt, LOG_WARNING,
-                  "Filter rule dropped: %d bytes, past the %d the matcher "
-                  "reads, so it could never match: %s",
+                  "Filter rule dropped: %d bytes is past the %d-byte limit, so "
+                  "it could never match: %s",
                   (int) len, (int) HTS_FILTER_MAXLEN, pattern);
     return HTS_FALSE;
   }
@@ -2469,16 +2476,13 @@ int filters_init(char ***ptrfilters, int maxfilter, int filterinc) {
   }
   if (filters) {
     if (filters[0] == NULL) {
-      filters[0] =
-        (char *) malloct(sizeof(char) * (filter_max + 2) *
-                         (HTS_URLMAXSIZE * 2));
+      filters[0] = (char *) malloct(sizeof(char) * (filter_max + 2) *
+                                    HTS_FILTER_SLOT_SIZE);
       memset(filters[0], 0,
-             sizeof(char) * (filter_max + 2) * (HTS_URLMAXSIZE * 2));
+             sizeof(char) * (filter_max + 2) * HTS_FILTER_SLOT_SIZE);
     } else {
-      filters[0] =
-        (char *) realloct(filters[0],
-                          sizeof(char) * (filter_max +
-                                          2) * (HTS_URLMAXSIZE * 2));
+      filters[0] = (char *) realloct(
+          filters[0], sizeof(char) * (filter_max + 2) * HTS_FILTER_SLOT_SIZE);
     }
     if (filters[0] == NULL) {
       freet(filters);
@@ -2494,7 +2498,7 @@ int filters_init(char ***ptrfilters, int maxfilter, int filterinc) {
     else
       from = filter_max - filterinc;
     for(i = 0; i <= filter_max; i++) {  // PLUS UN (sécurité)
-      filters[i] = filters[0] + i * (HTS_URLMAXSIZE * 2);
+      filters[i] = filters[0] + i * HTS_FILTER_SLOT_SIZE;
     }
     for(i = from; i <= filter_max; i++) {       // PLUS UN (sécurité)
       filters[i][0] = '\0';     // clear

--- a/src/htscore.h
+++ b/src/htscore.h
@@ -391,6 +391,17 @@ int filters_init(char ***ptrfilters, int maxfilter, int filterinc);
    it: opt->wizard_filters indexes into that array and outlives no crawl. */
 void filters_bind(httrackp *opt, char ***ptrfilters, int *filptr);
 
+/* Longest rule a slot holds and the matcher still looks at. */
+#define HTS_FILTER_MAXLEN                                                      \
+  (HTS_FILTER_SLOT_SIZE - 1 < STRJOKER_MAXLEN ? HTS_FILTER_SLOT_SIZE - 1       \
+                                              : STRJOKER_MAXLEN)
+
+/* Stores `pattern` at `pos` in this crawl's filter array, shifting the rules
+   from there up a slot; the caller has ensured there is room. The single door
+   into the array: a rule past HTS_FILTER_MAXLEN is refused with a warning and
+   HTS_FALSE, never stored as one that could not fire (#1270). */
+hts_boolean filters_insert(httrackp *opt, int pos, const char *pattern);
+
 int fspc(httrackp * opt, FILE * fp, const char *type);
 
 char *next_token(char *p, int flag);

--- a/src/htscore.h
+++ b/src/htscore.h
@@ -385,6 +385,10 @@ void hts_finish_html_file(httrackp *opt, cache_back *cache, htsblk *r,
                           FILE **fp, const char *ht_buff, size_t ht_len,
                           const char *adr, const char *fil, const char *save);
 
+/* Per-slot capacity of the filters array; filters_init() strides the slots by
+   it. */
+#define HTS_FILTER_SLOT_SIZE (HTS_URLMAXSIZE * 2)
+
 int filters_init(char ***ptrfilters, int maxfilter, int filterinc);
 
 /* Binds this crawl's filter array to `opt`, and empties the wizard block with
@@ -396,10 +400,9 @@ void filters_bind(httrackp *opt, char ***ptrfilters, int *filptr);
   (HTS_FILTER_SLOT_SIZE - 1 < STRJOKER_MAXLEN ? HTS_FILTER_SLOT_SIZE - 1       \
                                               : STRJOKER_MAXLEN)
 
-/* Stores `pattern` at `pos` in this crawl's filter array, shifting the rules
-   from there up a slot; the caller has ensured there is room. The single door
-   into the array: a rule past HTS_FILTER_MAXLEN is refused with a warning and
-   HTS_FALSE, never stored as one that could not fire (#1270). */
+/* Stores `pattern` at `pos`, shifting the rules from there up a slot; the
+   caller has ensured there is room. The one door into the array: a rule past
+   HTS_FILTER_MAXLEN warns and returns HTS_FALSE, never stored dead (#1270). */
 hts_boolean filters_insert(httrackp *opt, int pos, const char *pattern);
 
 int fspc(httrackp * opt, FILE * fp, const char *type);

--- a/src/htsfilters.c
+++ b/src/htsfilters.c
@@ -121,11 +121,9 @@ int fa_strjoker_dual(int type, char **filters, int nfil, const char *nom1,
   return use1 ? jok1 : jok2;
 }
 
-/* Real filters/URLs fit HTS_URLMAXSIZE*2; past it a hostile pattern recurses
-   O(len) deep or runs O(n^2*stars). Cap length, recursion depth and steps
-   (work): the length cap alone still allows ~2000 frames, ~900KB of stack,
-   which overflows the 1MB a Windows thread gets (#574). */
-#define STRJOKER_MAXLEN (HTS_URLMAXSIZE * 2)
+/* The length cap is STRJOKER_MAXLEN (htsfilters.h); it alone still allows ~2000
+   frames, ~900KB of stack, which overflows the 1MB a Windows thread gets
+   (#574), so depth and work (steps) are capped too. */
 #define STRJOKER_MAXDEPTH 256u
 #define STRJOKER_MAXSTEPS 2000000u
 

--- a/src/htsfilters.c
+++ b/src/htsfilters.c
@@ -121,9 +121,8 @@ int fa_strjoker_dual(int type, char **filters, int nfil, const char *nom1,
   return use1 ? jok1 : jok2;
 }
 
-/* The length cap is STRJOKER_MAXLEN (htsfilters.h); it alone still allows ~2000
-   frames, ~900KB of stack, which overflows the 1MB a Windows thread gets
-   (#574), so depth and work (steps) are capped too. */
+/* STRJOKER_MAXLEN alone still allows ~2000 frames, ~900KB of stack, which
+   overflows the 1MB a Windows thread gets (#574). */
 #define STRJOKER_MAXDEPTH 256u
 #define STRJOKER_MAXSTEPS 2000000u
 

--- a/src/htsfilters.h
+++ b/src/htsfilters.h
@@ -39,10 +39,9 @@ Please visit our Website: http://www.httrack.com
 
 #include "htsbase.h"
 
-/* Longest pattern or subject strjoker() looks at; past it a hostile pattern
-   recurses O(len) deep or runs O(n^2*stars). Real filters and URLs fit, and a
-   longer pattern can never match, so whatever builds one has to refuse it
-   rather than store a rule that silently never fires (#1270). */
+/* Longest pattern or subject strjoker() reads; past it a hostile pattern
+   recurses O(len) deep or runs O(n^2*stars). Real filters and URLs fit, so a
+   longer rule could only be stored dead (#1270). */
 #define STRJOKER_MAXLEN (HTS_URLMAXSIZE * 2)
 
 int fa_strjoker(int type, char **filters, int nfil, const char *nom, LLint * size,

--- a/src/htsfilters.h
+++ b/src/htsfilters.h
@@ -39,6 +39,12 @@ Please visit our Website: http://www.httrack.com
 
 #include "htsbase.h"
 
+/* Longest pattern or subject strjoker() looks at; past it a hostile pattern
+   recurses O(len) deep or runs O(n^2*stars). Real filters and URLs fit, and a
+   longer pattern can never match, so whatever builds one has to refuse it
+   rather than store a rule that silently never fires (#1270). */
+#define STRJOKER_MAXLEN (HTS_URLMAXSIZE * 2)
+
 int fa_strjoker(int type, char **filters, int nfil, const char *nom, LLint * size,
                 int *size_flag, int *depth);
 /* fa_strjoker() on both URL forms the engine builds (nom1 full, nom2 without

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4642,7 +4642,7 @@ static int st_wizardinsert(httrackp *opt, int argc, char **argv) {
 
   /* the correction case: "ignore this link", then "mirror the whole host" */
   RESET();
-  INSERT(0, "h", "/dir/one.html");
+  assertf(INSERT(0, "h", "/dir/one.html") == 1);
   HOLDS("-h/dir/one.html");
   assertf(opt->wizard_filters == 1);
   assertf(VERDICT("h/dir/one.html") == -1);
@@ -4674,17 +4674,19 @@ static int st_wizardinsert(httrackp *opt, int argc, char **argv) {
   HOLDS("+h/dir/*[file]", "-h/dir/one.html");
   assertf(VERDICT("h/dir/one.html") == -1);
 
-  /* both halves of a host-scope answer land in the block, in emission order */
+  /* both halves of a host-scope answer land in the block, in emission order.
+     The count returned is what the caller slices the block by, so assert it. */
   SEED("-*.zip");
-  INSERT(HTS_WIZARD_SCOPE_INCLUDE + 1, "www.example.co.uk", "/x.html");
+  assertf(INSERT(HTS_WIZARD_SCOPE_INCLUDE + 1, "www.example.co.uk",
+                 "/x.html") == 2);
   HOLDS("+*.example.co.uk/*", "+example.co.uk/*", "-*.zip");
   assertf(opt->wizard_filters == 2);
 
   /* an answer that emits nothing leaves the block and the array unchanged */
   SEED("-*.zip");
-  INSERT(4, "h", "/dir/one.html");
-  INSERT(50, "h", "/dir/one.html");
-  INSERT(3, "h", "/dir/one.html");
+  assertf(INSERT(4, "h", "/dir/one.html") == 0);
+  assertf(INSERT(50, "h", "/dir/one.html") == 0);
+  assertf(INSERT(3, "h", "/dir/one.html") == 0);
   HOLDS("-*.zip");
   assertf(opt->wizard_filters == 0);
 
@@ -4710,11 +4712,7 @@ done:
   return 0;
 }
 
-/* Non-zero, so a stray write into the slot above shows up (a '\0' there would
-   not). */
-#define POISON "-poison/*"
-
-/* #1270: filters_insert() refuses a rule the matcher would never look at, and
+/* #1270: filters_insert() refuses a rule the matcher would never read, and
    says so, instead of storing one that can never fire. */
 static int st_filtercap(httrackp *opt, int argc, char **argv) {
   const htsfilters saved = opt->filters;
@@ -4725,7 +4723,7 @@ static int st_filtercap(httrackp *opt, int argc, char **argv) {
   char BIGSTK overcap[HTS_FILTER_MAXLEN + 2]; /* the same, one byte too long */
   char BIGSTK toolong[STRJOKER_MAXLEN + 3];   /* and one the matcher skips */
   char BIGSTK subject[HTS_FILTER_MAXLEN];     /* a URL all three would match */
-  char line[HTS_URLMAXSIZE];
+  char BIGSTK line[STRJOKER_MAXLEN + 256]; /* room for a warning quoting one */
   char **filters = NULL;
   int filptr = 0;
   int taken, verdict, warned;
@@ -4750,8 +4748,6 @@ static int st_filtercap(httrackp *opt, int argc, char **argv) {
   assertf(strlen(overcap) == HTS_FILTER_MAXLEN + 1);
   assertf(strlen(toolong) > STRJOKER_MAXLEN);
   assertf(strlen(subject) <= STRJOKER_MAXLEN); /* else none could match */
-  /* why the array has a cap at all: past this one the matcher does not look at
-     the pattern, so the rule could only sit there dead */
   assertf(strjoker(subject, toolong + 1, NULL, NULL) == NULL);
 
   assertf(filters_init(&filters, opt->maxfilter, 0) != 0);
@@ -4759,11 +4755,13 @@ static int st_filtercap(httrackp *opt, int argc, char **argv) {
   opt->filters.filptr = &filptr;
   opt->wizard_filters = 0;
   opt->debug = LOG_NOTICE;
-/* offer `pattern` to the array: whether it was taken, what the array then
-   decides for `subject`, and whether the refusal was told */
+/* non-zero, so a stray write into the slot above the last rule shows up */
+#define POISON "-poison/*"
+/* offer `pattern` to the array, and report what it did with it */
 #define TRY(label, pattern)                                                    \
   do {                                                                         \
     FILE *const log = tmpfile();                                               \
+    char want[64];                                                             \
     assertf(log != NULL);                                                      \
     opt->log = log;                                                            \
     taken = filters_insert(opt, filptr, (pattern));                            \
@@ -4771,15 +4769,16 @@ static int st_filtercap(httrackp *opt, int argc, char **argv) {
     rewind(log);                                                               \
     if (fgets(line, (int) sizeof(line), log) == NULL)                          \
       line[0] = '\0';                                                          \
-    warned = strstr(line, "could never match") != NULL;                        \
+    /* the reason, this rule's own length, and the rule itself */              \
+    snprintf(want, sizeof(want), "%d bytes", (int) strlen(pattern));           \
+    warned = strstr(line, "could never match") != NULL &&                      \
+             strstr(line, want) != NULL && strstr(line, (pattern)) != NULL;    \
     assertf(line[0] == '\0' || warned); /* nothing else may be logged */       \
     fclose(log);                                                               \
     printf("%s: stored=%d rules=%d verdict=%d warned=%d\n", (label),           \
            taken != 0, filptr, verdict, warned);                               \
   } while (0)
-/* refused, and the array left as it was: neither the count, nor the verdict
-   (last match wins, so a stored rule would forbid what the first one allows),
-   nor the slot above. A warning alone would still leave a dead rule behind. */
+/* a refusal leaves the count, the verdict and the slot above it untouched */
 #define REFUSED()                                                              \
   do {                                                                         \
     assertf(!taken && filptr == 1 && verdict == 1 && warned);                  \
@@ -4787,12 +4786,14 @@ static int st_filtercap(httrackp *opt, int argc, char **argv) {
     assertf(strcmp(filters[1], POISON) == 0);                                  \
   } while (0)
 
-  /* a rule at the cap is stored, silently, and still matches: refusing one
-     byte early would be a regression nobody would notice */
+  /* a rule at the cap is stored, silently, and still matches; refusing one byte
+     early would be silent too */
   TRY("at the cap", atcap);
   assertf(taken && filptr == 1 && verdict == 1 && !warned);
   assertf(strcmp(filters[0], atcap) == 0);
 
+  /* last match wins, so a stored overcap rule would forbid what the first
+     allows: the verdict below is what proves it is really absent */
   strlcpybuff(filters[1], POISON, HTS_FILTER_SLOT_SIZE);
   TRY("one past the cap", overcap);
   REFUSED();
@@ -4801,6 +4802,7 @@ static int st_filtercap(httrackp *opt, int argc, char **argv) {
 
 #undef REFUSED
 #undef TRY
+#undef POISON
   opt->log = projectlog;
   opt->debug = saveddebug;
   freet(filters[0]);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4710,6 +4710,109 @@ done:
   return 0;
 }
 
+/* Non-zero, so a stray write into the slot above shows up (a '\0' there would
+   not). */
+#define POISON "-poison/*"
+
+/* #1270: filters_insert() refuses a rule the matcher would never look at, and
+   says so, instead of storing one that can never fire. */
+static int st_filtercap(httrackp *opt, int argc, char **argv) {
+  const htsfilters saved = opt->filters;
+  const int savedwizard = opt->wizard_filters;
+  const int saveddebug = opt->debug;
+  FILE *const projectlog = opt->log;
+  char BIGSTK atcap[HTS_FILTER_MAXLEN + 1];   /* "+a..a*", the longest rule */
+  char BIGSTK overcap[HTS_FILTER_MAXLEN + 2]; /* the same, one byte too long */
+  char BIGSTK toolong[STRJOKER_MAXLEN + 3];   /* and one the matcher skips */
+  char BIGSTK subject[HTS_FILTER_MAXLEN];     /* a URL all three would match */
+  char line[HTS_URLMAXSIZE];
+  char **filters = NULL;
+  int filptr = 0;
+  int taken, verdict, warned;
+
+  (void) argc;
+  (void) argv;
+  memset(atcap, 'a', sizeof(atcap) - 1);
+  atcap[0] = '+';
+  atcap[sizeof(atcap) - 2] = '*';
+  atcap[sizeof(atcap) - 1] = '\0';
+  memset(overcap, 'a', sizeof(overcap) - 1);
+  overcap[0] = '-';
+  overcap[sizeof(overcap) - 2] = '*';
+  overcap[sizeof(overcap) - 1] = '\0';
+  memset(toolong, 'a', sizeof(toolong) - 1);
+  toolong[0] = '-';
+  toolong[sizeof(toolong) - 2] = '*';
+  toolong[sizeof(toolong) - 1] = '\0';
+  memset(subject, 'a', sizeof(subject) - 1);
+  subject[sizeof(subject) - 1] = '\0';
+  assertf(strlen(atcap) == HTS_FILTER_MAXLEN);
+  assertf(strlen(overcap) == HTS_FILTER_MAXLEN + 1);
+  assertf(strlen(toolong) > STRJOKER_MAXLEN);
+  assertf(strlen(subject) <= STRJOKER_MAXLEN); /* else none could match */
+  /* why the array has a cap at all: past this one the matcher does not look at
+     the pattern, so the rule could only sit there dead */
+  assertf(strjoker(subject, toolong + 1, NULL, NULL) == NULL);
+
+  assertf(filters_init(&filters, opt->maxfilter, 0) != 0);
+  opt->filters.filters = &filters;
+  opt->filters.filptr = &filptr;
+  opt->wizard_filters = 0;
+  opt->debug = LOG_NOTICE;
+/* offer `pattern` to the array: whether it was taken, what the array then
+   decides for `subject`, and whether the refusal was told */
+#define TRY(label, pattern)                                                    \
+  do {                                                                         \
+    FILE *const log = tmpfile();                                               \
+    assertf(log != NULL);                                                      \
+    opt->log = log;                                                            \
+    taken = filters_insert(opt, filptr, (pattern));                            \
+    verdict = fa_strjoker(0, filters, filptr, subject, NULL, NULL, NULL);      \
+    rewind(log);                                                               \
+    if (fgets(line, (int) sizeof(line), log) == NULL)                          \
+      line[0] = '\0';                                                          \
+    warned = strstr(line, "could never match") != NULL;                        \
+    assertf(line[0] == '\0' || warned); /* nothing else may be logged */       \
+    fclose(log);                                                               \
+    printf("%s: stored=%d rules=%d verdict=%d warned=%d\n", (label),           \
+           taken != 0, filptr, verdict, warned);                               \
+  } while (0)
+/* refused, and the array left as it was: neither the count, nor the verdict
+   (last match wins, so a stored rule would forbid what the first one allows),
+   nor the slot above. A warning alone would still leave a dead rule behind. */
+#define REFUSED()                                                              \
+  do {                                                                         \
+    assertf(!taken && filptr == 1 && verdict == 1 && warned);                  \
+    assertf(strcmp(filters[0], atcap) == 0);                                   \
+    assertf(strcmp(filters[1], POISON) == 0);                                  \
+  } while (0)
+
+  /* a rule at the cap is stored, silently, and still matches: refusing one
+     byte early would be a regression nobody would notice */
+  TRY("at the cap", atcap);
+  assertf(taken && filptr == 1 && verdict == 1 && !warned);
+  assertf(strcmp(filters[0], atcap) == 0);
+
+  strlcpybuff(filters[1], POISON, HTS_FILTER_SLOT_SIZE);
+  TRY("one past the cap", overcap);
+  REFUSED();
+  TRY("past the matcher", toolong);
+  REFUSED();
+
+#undef REFUSED
+#undef TRY
+  opt->log = projectlog;
+  opt->debug = saveddebug;
+  freet(filters[0]);
+  freet(filters);
+  opt->filters = saved;
+  opt->wizard_filters = savedwizard;
+  printf("filtercap self-test OK\n");
+  return 0;
+}
+
+#undef POISON
+
 /* #159: hts_redirect_same_savefile decides whether a redirect is a same-file
  * alias. */
 static int st_redirect_samefile(httrackp *opt, int argc, char **argv) {
@@ -10208,6 +10311,8 @@ static const struct selftest_entry {
      "merged two-form filter verdict (fa_strjoker_dual)", st_filterdual},
     {"filterbounds", "", "matcher length/work caps reject hostile patterns",
      st_filterbounds},
+    {"filtercap", "", "an over-long filter rule is refused, not stored dead",
+     st_filtercap},
     {"simplify", "<path>", "collapse ./ and ../ in a path", st_simplify},
     {"expandhome", "<path>", "expand a leading ~/ into $HOME", st_expandhome},
     {"stripquery", "", "--strip-query pattern/key stripping self-test",

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -331,25 +331,11 @@ void hts_wizard_answer_filter(htsbuff *f, int slot, int n, const char *adr,
   }
 }
 
-/* Inserts `pattern` at index `pos`, shifting the filters from there up a slot.
-   The caller has already ensured the array has room. */
-static void filters_insert_at(httrackp *opt, int pos, const char *pattern) {
-  char **const filters = *opt->filters.filters;
-  int i;
-
-  assertf(pos >= 0 && pos <= *opt->filters.filptr);
-  for (i = *opt->filters.filptr; i > pos; i--)
-    strlcpybuff(filters[i], filters[i - 1], HTS_FILTER_SLOT_SIZE);
-  strlcpybuff(filters[pos], pattern, HTS_FILTER_SLOT_SIZE);
-  (*opt->filters.filptr)++;
-  assertf((*opt->filters.filptr) < opt->maxfilter);
-}
-
 int hts_wizard_insert_filters(httrackp *opt, int n, const char *adr,
                               const char *fil, hts_boolean seeker_up) {
   char BIGSTK pattern[HTS_FILTER_SLOT_SIZE];
   htsbuff f = htsbuff_array(pattern);
-  int slot;
+  int slot, inserted = 0;
 
   /* grow first: a host-scope answer emits two filters */
   if ((*opt->filters.filptr) + 2 >= opt->maxfilter) {
@@ -375,9 +361,14 @@ int hts_wizard_insert_filters(httrackp *opt, int n, const char *adr,
     hts_wizard_answer_filter(&f, slot, n, adr, fil, seeker_up);
     if (f.len == 0)
       break;
-    filters_insert_at(opt, opt->wizard_filters++, pattern);
+    /* a refused rule must not advance the block, or the caller reads back the
+       neighbour's filter as this answer's */
+    if (filters_insert(opt, opt->wizard_filters, pattern)) {
+      opt->wizard_filters++;
+      inserted++;
+    }
   }
-  return slot;
+  return inserted;
 }
 
 void hts_wizard_apply_verdict(httrackp *opt, int n, const char *adr,

--- a/src/htswizard.h
+++ b/src/htswizard.h
@@ -82,7 +82,8 @@ void hts_wizard_prompt_url(char *dst, size_t dstsize, const char *adr,
    of the wizard's block at the low indices of opt->filters: last match wins, so
    a later answer outranks an earlier one and the command-line filters above the
    block outrank every answer. Returns the number inserted, which sit at the
-   tail of the block, ending at opt->wizard_filters. */
+   tail of the block, ending at opt->wizard_filters; a rule too long for the
+   matcher is dropped, so that can fall short of what the answer emits. */
 int hts_wizard_insert_filters(httrackp *opt, int n, const char *adr,
                               const char *fil, hts_boolean seeker_up);
 

--- a/src/htswizard.h
+++ b/src/htswizard.h
@@ -57,10 +57,6 @@ hts_boolean hts_robots_forbids(httrackp *opt, const char *adr, const char *fil,
                                hts_boolean filters_decided,
                                hts_boolean filters_refused);
 
-/* Per-slot capacity of the filters array, matching the slot stride allocated by
-   filters_init() in htscore.c (HTS_URLMAXSIZE * 2). */
-#define HTS_FILTER_SLOT_SIZE (HTS_URLMAXSIZE * 2)
-
 /* Most filters one wizard answer can add. Slots must stay contiguous: the
    caller stops at the first empty one. */
 #define HTS_WIZARD_MAX_FILTERS 2

--- a/tests/303_engine-filter-cap.test
+++ b/tests/303_engine-filter-cap.test
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# #1270: a rule longer than the matcher looks at can never fire, so the filter
+# array must refuse it and say so rather than store it dead.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+out=$(httrack -O /dev/null -#test=filtercap)
+
+# a rule at the cap is still taken, silently, and still decides the URL
+grep -q '^at the cap: stored=1 rules=1 verdict=1 warned=0$' <<<"$out" || fail "at the cap: $out"
+# one byte more, and one past what the matcher reads: refused (the array did
+# not grow and its verdict did not move) and warned about
+grep -q '^one past the cap: stored=0 rules=1 verdict=1 warned=1$' <<<"$out" || fail "one past: $out"
+grep -q '^past the matcher: stored=0 rules=1 verdict=1 warned=1$' <<<"$out" || fail "past matcher: $out"
+grep -q '^filtercap self-test OK$' <<<"$out" || fail "self-test did not finish: $out"


### PR DESCRIPTION
`strjoker()` ignores any pattern longer than `STRJOKER_MAXLEN`, and nothing told the code that builds a filter about that cap. An over-long rule was accepted, stored, and then skipped on every match, with no warning, and `-#test=filter` reporting NOMATCH as if it had never been written.

Writes into the filter array now go through one `filters_insert()`, which drops an over-cap rule with a warning giving its length and the limit. Three places wrote into the array before this (the filter loop in `httpmirror()`, `host_ban()`, and the wizard's own helper) and they are now one. The wizard declines the rule and carries on, so the link still gets its verdict and nothing aborts. Raising `STRJOKER_MAXLEN` instead would touch every filter match and deepen the recursion the comment at htsfilters.c:124 already worries about on a 1 MB Windows thread stack, and no fallback rule is worth emitting since at these lengths even the single-link rule is over the cap.

Caveat worth knowing: today the slot stride and the matcher cap are the same constant, command-line arguments cap at 1023 bytes, and `host_ban()` builds from a hostname, so nothing can currently produce an over-cap rule. Nothing enforced that, it just happened to hold, and #1266 breaks it when it sizes the wizard slot for the worst case. The second commit collapses the stride duplication (`filters_init()` hardcoded `HTS_URLMAXSIZE * 2` while htswizard.h mirrored it by comment) and pins both caps at compile time, so a widened slot cannot outrun the guard.

tests/303_engine-filter-cap.test drives a new `-#test=filtercap`. A rule at the cap is still stored, silently, and still decides the URL; one byte more, and one past what the matcher reads, are both refused, warned about with their own length, and leave the array's count, verdict and poisoned neighbour slot untouched. Mutants for no guard, warn-and-store, silent refusal, off-by-one, a raised cap, a warning that omits the length, and a miscounted wizard block all go red. The warning reaches `hts-log.txt`, not the console, like every other engine warning.

Test number 303 is unclaimed by the other open PRs. #1266 and #1280 both edit the two lines this replaces in `httpmirror()` and `host_ban()`; a trial merge with #1280 auto-merges the code and conflicts only on the self-test registry row, and #1266 will conflict for real. Left to the merge rather than rebasing.

Closes #1270