### PR TITLE
A long field in a cookies.txt aborts the mirror at startup

### DIFF
--- a/src/htsbauth.c
+++ b/src/htsbauth.c
@@ -203,9 +203,8 @@ char *cookie_nextfield(char *a) {
   return a;
 }
 
-/* Copy Netscape-jar field <param> of <line> into dst (capacity dst_size), or
-   refuse the line and say so. Clipping is not an option here: a shortened
-   domain or path silently changes the hosts and paths the cookie is sent to. */
+/* Copy Netscape-jar field <param> into dst, or refuse the line and say so: a
+   shortened domain or path would silently change where the cookie is sent. */
 static hts_boolean cookie_load_field(httrackp *opt, char *dst, size_t dst_size,
                                      char *buffer, const char *line, int param,
                                      const char *field_name, const char *file) {
@@ -304,17 +303,18 @@ int cookie_load(httrackp *opt, t_cookie *cookie, const char *fpath,
 
   // then cookies.txt
   {
-    // aliases catbuff, which nothing below rewrites
+    // file points into catbuff; nothing below writes catbuff again
     const char *const file = fconcat(catbuff, sizeof(catbuff), fpath, name);
     FILE *fp = FOPEN(file, "rb");
 
     if (fp) {
       char BIGSTK line[8192];
+      const size_t line_max = 8000;
 
       while((!feof(fp)) && (((int) strlen(cookie->data)) < cookie->max_len)) {
         rawlinput(fp, line, 8100);
         if (strnotempty(line)) {
-          if (strlen(line) < 8000) {
+          if (strlen(line) < line_max) {
             if (line[0] != '#') {
               char domain[256];             // cookie domain (.netscape.com)
               char path[256];               // path (/)
@@ -332,14 +332,21 @@ int cookie_load(httrackp *opt, t_cookie *cookie, const char *fpath,
                                     line, 5, "name", file) &&
                   cookie_load_field(opt, cook_value, sizeof(cook_value), buffer,
                                     line, 6, "value", file)) {
-                cookie_add(cookie, cook_name, cook_value, domain, path);
+                // the jar caps a field tighter still, and a full one refuses
+                if (cookie_add(cookie, cook_name, cook_value, domain, path) !=
+                    0) {
+                  hts_log_print(opt, LOG_WARNING,
+                                "cookie file %s: the jar did not store the "
+                                "cookie '%.64s'",
+                                file, cook_name);
+                }
               }
             }
           } else {
             hts_log_print(opt, LOG_WARNING,
                           "cookie file %s: ignoring an over-long line "
-                          "(%d bytes)",
-                          file, (int) strlen(line));
+                          "(%d bytes, maximum %d)",
+                          file, (int) strlen(line), (int) line_max - 1);
           }
         }
       }

--- a/src/htsbauth.c
+++ b/src/htsbauth.c
@@ -213,9 +213,9 @@ static hts_boolean cookie_load_field(httrackp *opt, char *dst, size_t dst_size,
 
   if (len >= dst_size) {
     hts_log_print(opt, LOG_WARNING,
-                  "cookie file %s: ignoring a line whose %s field is %d bytes "
-                  "(maximum %d)",
-                  file, field_name, (int) len, (int) dst_size - 1);
+                  "Cookies: ignoring a line whose %s field is %d bytes "
+                  "(maximum %d): %s",
+                  field_name, (int) len, (int) dst_size - 1, file);
     return HTS_FALSE;
   }
   strlcpybuff(dst, value, dst_size);
@@ -336,17 +336,16 @@ int cookie_load(httrackp *opt, t_cookie *cookie, const char *fpath,
                 if (cookie_add(cookie, cook_name, cook_value, domain, path) !=
                     0) {
                   hts_log_print(opt, LOG_WARNING,
-                                "cookie file %s: the jar did not store the "
-                                "cookie '%.64s'",
-                                file, cook_name);
+                                "Cookies: the jar did not store '%.64s': %s",
+                                cook_name, file);
                 }
               }
             }
           } else {
             hts_log_print(opt, LOG_WARNING,
-                          "cookie file %s: ignoring an over-long line "
-                          "(%d bytes, maximum %d)",
-                          file, (int) strlen(line), (int) line_max - 1);
+                          "Cookies: ignoring an over-long line "
+                          "(%d bytes, maximum %d): %s",
+                          (int) strlen(line), (int) line_max - 1, file);
           }
         }
       }

--- a/src/htsbauth.c
+++ b/src/htsbauth.c
@@ -203,8 +203,29 @@ char *cookie_nextfield(char *a) {
   return a;
 }
 
+/* Copy Netscape-jar field <param> of <line> into dst (capacity dst_size), or
+   refuse the line and say so. Clipping is not an option here: a shortened
+   domain or path silently changes the hosts and paths the cookie is sent to. */
+static hts_boolean cookie_load_field(httrackp *opt, char *dst, size_t dst_size,
+                                     char *buffer, const char *line, int param,
+                                     const char *field_name, const char *file) {
+  const char *const value = cookie_get(buffer, line, param);
+  const size_t len = strlen(value);
+
+  if (len >= dst_size) {
+    hts_log_print(opt, LOG_WARNING,
+                  "cookie file %s: ignoring a line whose %s field is %d bytes "
+                  "(maximum %d)",
+                  file, field_name, (int) len, (int) dst_size - 1);
+    return HTS_FALSE;
+  }
+  strlcpybuff(dst, value, dst_size);
+  return HTS_TRUE;
+}
+
 // Read cookies.txt (+ copied IE cookies *@*.txt on Windows); !=0 on error.
-int cookie_load(t_cookie * cookie, const char *fpath, const char *name) {
+int cookie_load(httrackp *opt, t_cookie *cookie, const char *fpath,
+                const char *name) {
   char catbuff[CATBUFF_SIZE];
   char buffer[8192];
 
@@ -281,9 +302,11 @@ int cookie_load(t_cookie * cookie, const char *fpath, const char *name) {
   }
 #endif
 
-  // Ensuite, cookies.txt
+  // then cookies.txt
   {
-    FILE *fp = FOPEN(fconcat(catbuff, sizeof(catbuff), fpath, name), "rb");
+    // aliases catbuff, which nothing below rewrites
+    const char *const file = fconcat(catbuff, sizeof(catbuff), fpath, name);
+    FILE *fp = FOPEN(file, "rb");
 
     if (fp) {
       char BIGSTK line[8192];
@@ -293,20 +316,30 @@ int cookie_load(t_cookie * cookie, const char *fpath, const char *name) {
         if (strnotempty(line)) {
           if (strlen(line) < 8000) {
             if (line[0] != '#') {
-              char domain[256]; // domaine cookie (.netscape.com)
-              char path[256];   // chemin (/)
-              char cook_name[1024];     // nom cookie (MYCOOK)
-              char BIGSTK cook_value[8192];     // valeur (ID=toto,S=1234)
+              char domain[256];             // cookie domain (.netscape.com)
+              char path[256];               // path (/)
+              char cook_name[1024];         // cookie name (MYCOOK)
+              char BIGSTK cook_value[8192]; // value (ID=toto,S=1234)
 
-              strcpybuff(domain, cookie_get(buffer, line, 0));  // host
-              strcpybuff(path, cookie_get(buffer, line, 2));    // path
-              strcpybuff(cook_name, cookie_get(buffer, line, 5));       // name
-              strcpybuff(cook_value, cookie_get(buffer, line, 6));      // value
 #if DEBUG_COOK
               printf("%s\n", line);
 #endif
-              cookie_add(cookie, cook_name, cook_value, domain, path);
+              if (cookie_load_field(opt, domain, sizeof(domain), buffer, line,
+                                    0, "domain", file) &&
+                  cookie_load_field(opt, path, sizeof(path), buffer, line, 2,
+                                    "path", file) &&
+                  cookie_load_field(opt, cook_name, sizeof(cook_name), buffer,
+                                    line, 5, "name", file) &&
+                  cookie_load_field(opt, cook_value, sizeof(cook_value), buffer,
+                                    line, 6, "value", file)) {
+                cookie_add(cookie, cook_name, cook_value, domain, path);
+              }
             }
+          } else {
+            hts_log_print(opt, LOG_WARNING,
+                          "cookie file %s: ignoring an over-long line "
+                          "(%d bytes)",
+                          file, (int) strlen(line));
           }
         }
       }

--- a/src/htsbauth.h
+++ b/src/htsbauth.h
@@ -81,8 +81,8 @@ int cookie_del(t_cookie *cookie, const char *cook_name, const char *domain,
 
 /** Load the Netscape jar <path>/<name> into cookie (plus the copied IE jars in
     <path> on Windows). A line whose field does not fit is refused, not clipped,
-    and reported through opt (which may be NULL: only the log callback runs).
-    Returns 0 if the jar was opened, -1 otherwise. */
+    and reported through opt, which may be NULL. Returns 0 if the jar was
+    opened, -1 otherwise. */
 int cookie_load(httrackp *opt, t_cookie *cookie, const char *path,
                 const char *name);
 

--- a/src/htsbauth.h
+++ b/src/htsbauth.h
@@ -67,6 +67,11 @@ struct t_cookie {
 /* Library internal definictions */
 #ifdef HTS_INTERNAL_BYTECODE
 
+#ifndef HTS_DEF_FWSTRUCT_httrackp
+#define HTS_DEF_FWSTRUCT_httrackp
+typedef struct httrackp httrackp;
+#endif
+
 /* cookies */
 int cookie_add(t_cookie *cookie, const char *cook_name, const char *cook_value,
                const char *domain, const char *path);
@@ -74,7 +79,12 @@ int cookie_add(t_cookie *cookie, const char *cook_name, const char *cook_value,
 int cookie_del(t_cookie *cookie, const char *cook_name, const char *domain,
                const char *path);
 
-int cookie_load(t_cookie *cookie, const char *path, const char *name);
+/** Load the Netscape jar <path>/<name> into cookie (plus the copied IE jars in
+    <path> on Windows). A line whose field does not fit is refused, not clipped,
+    and reported through opt (which may be NULL: only the log callback runs).
+    Returns 0 if the jar was opened, -1 otherwise. */
+int cookie_load(httrackp *opt, t_cookie *cookie, const char *path,
+                const char *name);
 
 int cookie_save(t_cookie *cookie, const char *name);
 

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -535,11 +535,11 @@ int httpmirror(char *url1, httrackp * opt) {
     cookie.max_len = 30000;     // max len
     strcpybuff(cookie.data, "");
     // Load the mirror's cookies.txt, then the one in the current directory
-    cookie_load(opt->cookie, StringBuff(opt->path_log), "cookies.txt");
-    cookie_load(opt->cookie, "", "cookies.txt");
+    cookie_load(opt, opt->cookie, StringBuff(opt->path_log), "cookies.txt");
+    cookie_load(opt, opt->cookie, "", "cookies.txt");
     // A user-supplied cookie file is merged last so it wins on conflicts
     if (strnotempty(StringBuff(opt->cookies_file)))
-      cookie_load(opt->cookie, "", StringBuff(opt->cookies_file));
+      cookie_load(opt, opt->cookie, "", StringBuff(opt->cookies_file));
   } else
     opt->cookie = NULL;
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -8985,7 +8985,7 @@ static int st_cookieimport(httrackp *opt, int argc, char **argv) {
 
   ck.max_len = (int) sizeof(ck.data);
   ck.data[0] = '\0';
-  assertf(cookie_load(&ck, fpath, "cookies.txt") == 0);
+  assertf(cookie_load(NULL, &ck, fpath, "cookies.txt") == 0);
   assertf(strstr(ck.data, "JARCOOK") != NULL); /* jar read on a long path */
 #ifdef _WIN32
   /* the IE scan merged the cookie and unlinked the consumed file */

--- a/tests/307_cookies-file-longfield.test
+++ b/tests/307_cookies-file-longfield.test
@@ -92,7 +92,7 @@ refusals=(
     "name field is 1024 bytes (maximum 1023)"
 )
 for want in "${refusals[@]}"; do
-    grep -qF "cookie file $jar: ignoring a line whose $want" <<<"$log" ||
+    grep -qF "Cookies: ignoring a line whose $want: $jar" <<<"$log" ||
         fail "no refusal for the $want in $out/hts-log.txt"
 done
 n=$(grep -c 'ignoring a line whose' <<<"$log" || true)
@@ -101,9 +101,9 @@ assert_eq "${#refusals[@]}" "$n" "refused jar lines"
 # a 7900-byte value fits its destination, so it is the jar's cap that drops it
 ! grep -q 'value field is' <<<"$log" ||
     fail "a value the widest destination holds was refused: $out/hts-log.txt"
-for want in "the jar did not store the cookie 'JARCAP" \
-    "the jar did not store the cookie 'BIGVAL7900'" \
+for want in "the jar did not store 'JARCAP" \
+    "the jar did not store 'BIGVAL7900'" \
     "ignoring an over-long line (8049 bytes, maximum 7999)"; do
-    grep -qF "cookie file $jar: $want" <<<"$log" ||
+    grep -qF "Cookies: $want" <<<"$log" ||
         fail "no report of [$want] in $out/hts-log.txt"
 done

--- a/tests/307_cookies-file-longfield.test
+++ b/tests/307_cookies-file-longfield.test
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# A cookies.txt field longer than the buffer it is copied into costs that line
+# alone: the mirror does not abort, nothing of the line is stored, the refusal
+# names the file and the field, and the rest of the jar still loads (#1277).
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+bin=$(httrack_path)
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_cookiejar.XXXXXX") || exit 1
+cleanup_push rm -rf "$tmp"
+
+site="$tmp/site"
+mkdir -p "$site"
+echo '<html>hello</html>' >"$site/index.html"
+
+# 2000 bytes overruns domain[256], path[256] and cook_name[1024] alike, so one
+# jar exercises all three capacities the loader copies into.
+big=$(printf '%*s' 2000 '' | tr ' ' A)
+# cook_value[8192] cannot be overrun through the 8000-byte line gate, so its
+# bound is probed from the other side: a value far wider than the other three
+# destinations must still load, unclipped.
+val=$(printf '%*s' 500 '' | tr ' ' v)
+
+# The Netscape record, in the very spelling cookie_save() writes back.
+rec() { # rec DOMAIN PATH NAME VALUE
+    printf '%s\tTRUE\t%s\tFALSE\t1999999999\t%s\t%s\n' "$1" "$2" "$3" "$4"
+}
+
+jar="$tmp/jar.txt"
+{
+    rec www.example.com / GOODFIRST v1
+    rec "$big.example.com" / LONGDOM v
+    rec www.example.com "/$big" LONGPATH v
+    rec www.example.com / "LONGNAME$big" v
+    rec www.example.com / BIGVAL "$val"
+    rec www.example.com / GOODLAST v2
+} >"$jar"
+
+out="$tmp/mirror"
+rc=0
+"$bin" "file://$site/index.html" -O "$out" --cookies-file "$jar" --quiet \
+    >/dev/null 2>&1 || rc=$?
+# 134 was the abort the unchecked strcpybuff took on the first over-long field
+assert_eq 0 "$rc" "crawl exit status"
+
+# the jar is written back when the mirror ends, so it says what was loaded
+jar_out="$out/cookies.txt"
+assert_file "$jar_out" "reloaded jar"
+loaded=$(cat "$jar_out")
+
+# whole-line matches, so a fix that clipped a field instead of refusing the line
+# is red here rather than passing on the cookie name alone
+grep -qxF "$(rec www.example.com / GOODFIRST v1)" <<<"$loaded" ||
+    fail "the first jar line did not load: $jar_out"
+grep -qxF "$(rec www.example.com / GOODLAST v2)" <<<"$loaded" ||
+    fail "a refused line stopped the rest of the jar loading: $jar_out"
+grep -qxF "$(rec www.example.com / BIGVAL "$val")" <<<"$loaded" ||
+    fail "a value the widest destination holds was refused or clipped: $jar_out"
+
+for gone in LONGDOM LONGPATH LONGNAME; do
+    ! grep -q "$gone" <<<"$loaded" ||
+        fail "$gone was stored from an over-long line: $jar_out"
+done
+
+log=$(cat "$out/hts-log.txt")
+for field in domain path name; do
+    grep -qF "cookie file $jar: ignoring a line whose $field field is" \
+        <<<"$log" ||
+        fail "the refused $field field is not reported in $out/hts-log.txt"
+done
+n=$(grep -c 'ignoring a line whose' <<<"$log" || true)
+assert_eq 3 "$n" "refused jar lines"

--- a/tests/307_cookies-file-longfield.test
+++ b/tests/307_cookies-file-longfield.test
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# A cookies.txt field longer than the buffer it is copied into costs that line
-# alone: the mirror does not abort, nothing of the line is stored, the refusal
-# names the file and the field, and the rest of the jar still loads (#1277).
+# A jar field longer than its buffer must not abort the mirror. The line is
+# refused, with the file and the field named in the log, and the rest of the
+# jar still loads (#1277).
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
@@ -17,26 +17,36 @@ site="$tmp/site"
 mkdir -p "$site"
 echo '<html>hello</html>' >"$site/index.html"
 
-# 2000 bytes overruns domain[256], path[256] and cook_name[1024] alike, so one
-# jar exercises all three capacities the loader copies into.
-big=$(printf '%*s' 2000 '' | tr ' ' A)
-# cook_value[8192] cannot be overrun through the 8000-byte line gate, so its
-# bound is probed from the other side: a value far wider than the other three
-# destinations must still load, unclipped.
-val=$(printf '%*s' 500 '' | tr ' ' v)
+pad() { printf '%*s' "$1" '' | tr ' ' "${2:-A}"; }
 
-# The Netscape record, in the very spelling cookie_save() writes back.
+# Netscape record, in the spelling cookie_save() writes back.
 rec() { # rec DOMAIN PATH NAME VALUE
     printf '%s\tTRUE\t%s\tFALSE\t1999999999\t%s\t%s\n' "$1" "$2" "$3" "$4"
 }
 
+# Each destination is hit at the first byte that must not fit and at the byte
+# below it, so a > for a >= in the bound reds this. The three capacities differ
+# (domain[256], path[256], cook_name[1024]), and the message pins each one.
 jar="$tmp/jar.txt"
 {
     rec www.example.com / GOODFIRST v1
-    rec "$big.example.com" / LONGDOM v
-    rec www.example.com "/$big" LONGPATH v
-    rec www.example.com / "LONGNAME$big" v
-    rec www.example.com / BIGVAL "$val"
+    rec "$(pad 2000)" / DOM2000 v
+    rec "$(pad 256)" / DOM256 v
+    rec "$(pad 255)" / DOM255 v
+    rec www.example.com "/$(pad 1999)" PATH2000 v
+    rec www.example.com "/$(pad 255)" PATH256 v
+    rec www.example.com "/$(pad 254)" PATH255 v
+    rec www.example.com / "NAME2000$(pad 1992)" v
+    rec www.example.com / "NAME1024$(pad 1016)" v
+    # fits cook_name[1024] but not cookie_add()'s own 256-byte cap, so the line
+    # is gone for a second reason, which has to be reported too
+    rec www.example.com / "JARCAP$(pad 294)" v
+    # cook_value[8192] is out of reach behind the line gate, so it is pinned
+    # from below: neither of these may be refused for its value
+    rec www.example.com / BIGVAL "$(pad 500 v)"
+    rec www.example.com / BIGVAL7900 "$(pad 7900 v)"
+    # 8049 bytes: over the line gate, under what rawlinput() reads in one go
+    rec www.example.com / LONGLINE "$(pad 8000 L)"
     rec www.example.com / GOODLAST v2
 } >"$jar"
 
@@ -44,33 +54,56 @@ out="$tmp/mirror"
 rc=0
 "$bin" "file://$site/index.html" -O "$out" --cookies-file "$jar" --quiet \
     >/dev/null 2>&1 || rc=$?
-# 134 was the abort the unchecked strcpybuff took on the first over-long field
+# 134 is the SIGABRT the unchecked strcpybuff produced here before the fix
 assert_eq 0 "$rc" "crawl exit status"
 
-# the jar is written back when the mirror ends, so it says what was loaded
+# the jar is written back when the mirror ends, so it says what was loaded.
+# cookie_save() ends its lines with LF, which is CRLF on Windows.
 jar_out="$out/cookies.txt"
 assert_file "$jar_out" "reloaded jar"
-loaded=$(cat "$jar_out")
+loaded=$(tr -d '\r' <"$jar_out")
+log=$(tr -d '\r' <"$out/hts-log.txt")
 
-# whole-line matches, so a fix that clipped a field instead of refusing the line
-# is red here rather than passing on the cookie name alone
-grep -qxF "$(rec www.example.com / GOODFIRST v1)" <<<"$loaded" ||
-    fail "the first jar line did not load: $jar_out"
-grep -qxF "$(rec www.example.com / GOODLAST v2)" <<<"$loaded" ||
-    fail "a refused line stopped the rest of the jar loading: $jar_out"
-grep -qxF "$(rec www.example.com / BIGVAL "$val")" <<<"$loaded" ||
-    fail "a value the widest destination holds was refused or clipped: $jar_out"
-
-for gone in LONGDOM LONGPATH LONGNAME; do
-    ! grep -q "$gone" <<<"$loaded" ||
-        fail "$gone was stored from an over-long line: $jar_out"
+# match whole lines: a clipping fix would still store the cookie name, and
+# only the rest of the line says the field was cut
+for want in "$(rec www.example.com / GOODFIRST v1)" \
+    "$(rec "$(pad 255)" / DOM255 v)" \
+    "$(rec www.example.com "/$(pad 254)" PATH255 v)" \
+    "$(rec www.example.com / BIGVAL "$(pad 500 v)")" \
+    "$(rec www.example.com / GOODLAST v2)"; do
+    grep -qxF "$want" <<<"$loaded" ||
+        fail "a line that fits did not load whole: ${want:0:40}... in $jar_out"
 done
 
-log=$(cat "$out/hts-log.txt")
-for field in domain path name; do
-    grep -qF "cookie file $jar: ignoring a line whose $field field is" \
-        <<<"$log" ||
-        fail "the refused $field field is not reported in $out/hts-log.txt"
+for gone in DOM2000 DOM256 PATH2000 PATH256 NAME2000 NAME1024 JARCAP \
+    BIGVAL7900 LONGLINE; do
+    ! grep -q "$gone" <<<"$loaded" ||
+        fail "$gone was stored from a line that had to be refused: $jar_out"
+done
+
+# the byte count and the maximum are asserted too: they are what says which
+# destination the field was measured against
+refusals=(
+    "domain field is 2000 bytes (maximum 255)"
+    "domain field is 256 bytes (maximum 255)"
+    "path field is 2000 bytes (maximum 255)"
+    "path field is 256 bytes (maximum 255)"
+    "name field is 2000 bytes (maximum 1023)"
+    "name field is 1024 bytes (maximum 1023)"
+)
+for want in "${refusals[@]}"; do
+    grep -qF "cookie file $jar: ignoring a line whose $want" <<<"$log" ||
+        fail "no refusal for the $want in $out/hts-log.txt"
 done
 n=$(grep -c 'ignoring a line whose' <<<"$log" || true)
-assert_eq 3 "$n" "refused jar lines"
+assert_eq "${#refusals[@]}" "$n" "refused jar lines"
+
+# a 7900-byte value fits its destination, so it is the jar's cap that drops it
+! grep -q 'value field is' <<<"$log" ||
+    fail "a value the widest destination holds was refused: $out/hts-log.txt"
+for want in "the jar did not store the cookie 'JARCAP" \
+    "the jar did not store the cookie 'BIGVAL7900'" \
+    "ignoring an over-long line (8049 bytes, maximum 7999)"; do
+    grep -qF "cookie file $jar: $want" <<<"$log" ||
+        fail "no report of [$want] in $out/hts-log.txt"
+done


### PR DESCRIPTION
A cookies.txt written by another tool, or edited by hand, could kill a mirror before it started. `cookie_load()` copied the jar's domain, path, name and value into fixed arrays behind one 8000-byte gate on the whole line, so a 2000-byte domain reached `strcpybuff`'s abort and the process died with SIGABRT. Since `--cookies-file` exists to consume someone else's jar, that is about the worst thing it could do.

Each field is now measured against the destination it goes to, and one that does not fit costs its own line, with the field and the file named in the log; the rest of the jar still loads. Clipping is wrong here even though the data comes off a file, because a shortened domain or path silently changes which hosts the cookie is sent to. A field that clears its buffer can still be dropped by `cookie_add()`, whose caps are tighter, and those lines were going missing with nothing in the log at all, so they are reported now too.

`cookie_load()` gains an `opt` argument to log through. It is internal, so no ABI surface moves, and the Windows IE-jar merge beside it reads through `linput()` into buffers that already fit, so it never reached the abort.

The test hits each destination at the first byte that must not fit and at the byte below it, and asserts the byte counts and maxima the log reports, so an off-by-one in the bound or a capacity applied to the wrong field is red. Against a build of origin/master the domain, path and name fields each abort on their own.

Closes #1277