### PR TITLE
A deeper -O path on a later run overruns the save name the cache rebuilds

### DIFF
--- a/src/htscache.c
+++ b/src/htscache.c
@@ -630,8 +630,8 @@ static htsblk cache_readex_new(httrackp * opt, cache_back * cache,
                     : "";
             size_t used = 0;
 
-            /* a clipped name is a different file: refuse the entry rather than
-               hand the file layer a name that is not the one we stored */
+            /* refuse the entry: a clipped name would point at a file we never
+               stored */
             if (!slcatprintfbuff(previous_save, sizeof(previous_save), &used,
                                  "%s%s", prefix, previous_save_)) {
               hts_log_print(opt, LOG_WARNING,

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -616,15 +616,30 @@ static htsblk cache_readex_new(httrackp * opt, cache_back * cache,
             }
           } while (offset < readSizeHeader && !lineEof);
 
-          /* Previous entry */
+          /* Previous entry. cache_add() stores X-Save relative (it strips
+             path_html_utf8), so the read re-prepends the current one, which
+             may have grown since the entry was written. */
           if (previous_save_[0] != '\0') {
-            int pathLen = (int) strlen(StringBuff(opt->path_html_utf8));
+            const char *const path_html = StringBuff(opt->path_html_utf8);
+            const size_t pathLen = strlen(path_html);
+            /* an X-Save that already carries the path is taken as-is */
+            const char *const prefix =
+                (pathLen != 0 &&
+                 strncmp(previous_save_, path_html, pathLen) != 0)
+                    ? path_html
+                    : "";
+            size_t used = 0;
 
-            if (pathLen != 0 && strncmp(previous_save_, StringBuff(opt->path_html_utf8), pathLen) != 0) {       // old (<3.40) buggy format
-              sprintf(previous_save, "%s%s", StringBuff(opt->path_html_utf8),
-                      previous_save_);
-            } else {
-              strcpy(previous_save, previous_save_);
+            /* a clipped name is a different file: refuse the entry rather than
+               hand the file layer a name that is not the one we stored */
+            if (!slcatprintfbuff(previous_save, sizeof(previous_save), &used,
+                                 "%s%s", prefix, previous_save_)) {
+              hts_log_print(opt, LOG_WARNING,
+                            "cached filename too long once rebuilt under '%s', "
+                            "not using the cache entry: %s%s",
+                            path_html, adr, fil);
+              r.statuscode = STATUSCODE_INVALID;
+              strcpybuff(r.msg, "Cache Read Error : Filename Too Long");
             }
           }
           if (return_save != NULL) {

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -1983,37 +1983,36 @@ int cache_url_bounds_selftest(httrackp *opt, const char *dir) {
   return failures;
 }
 
-/* Capacity cache_readex_new() rebuilds the save name in, so the longest name
-   that fits is one byte less. */
+/* Buffer the reader rebuilds the save name into, so the longest name that fits
+   is one byte less. */
 #define SAVEBOUNDS_CAP (HTS_URLMAXSIZE * 2)
-/* X-Save length used here, kept under HTS_URLMAXSIZE: binput() clips the header
-   line to that, and a clipped one would test the clipping, not the rebuild. */
+/* X-Save length used here. binput() clips the whole header line at
+   HTS_URLMAXSIZE, and "X-Save: " plus CRLF eat into it. */
 #define SAVEBOUNDS_REL_LEN 1000
 #define SAVEBOUNDS_GUARD 16
 #define SAVEBOUNDS_GUARD_BYTE '\x5a'
 
 /* A path of exactly len bytes, slash-bounded like an -O directory. */
 static void savebounds_path(char *s, size_t size, size_t len) {
-  assertf(len >= 2 && len < size);
-  memset(s, 'd', len);
-  s[0] = '/';
-  s[len - 1] = '/';
-  s[len] = '\0';
+  assertf(len >= 2);
+  fill_str(s, size, len, 'd');
+  s[0] = s[len - 1] = '/';
 }
 
-/* Read the entry back with path_html_utf8 set to `path`. want is the save name
-   the reader must rebuild, or NULL when the rebuild cannot fit and the entry
-   must be refused. */
-static int savebounds_read(httrackp *opt, const char *path, const char *adr,
-                           const char *fil, const char *want) {
+/* Read the entry back with path_html_utf8 set to `path`, and check what the
+   reader rebuilt. want/body are the save name and body it must return, or NULL
+   for an entry whose rebuilt name cannot fit and must be refused. */
+static int savebounds_expect(httrackp *opt, const char *path, const char *adr,
+                             const char *fil, const char *want,
+                             const char *body) {
   int failures = 0;
   cache_back cache;
   htsblk r;
   char *got = malloct(SAVEBOUNDS_CAP + SAVEBOUNDS_GUARD);
   size_t k;
 
-  /* non-zero guard: a stray NUL written one past the end is invisible against
-     a zeroed one */
+  /* guard past the capacity the reader is handed, poisoned non-zero so a stray
+     NUL shows up too */
   memset(got, SAVEBOUNDS_GUARD_BYTE, SAVEBOUNDS_CAP + SAVEBOUNDS_GUARD);
   got[0] = '\0';
 
@@ -2035,6 +2034,12 @@ static int savebounds_read(httrackp *opt, const char *path, const char *adr,
               " expected %d bytes '%.48s...'\n",
               selftest_tag, (int) strlen(path), (int) strlen(got), got,
               (int) strlen(want), want);
+      failures++;
+    }
+    if (r.adr == NULL || (size_t) r.size != strlen(body) ||
+        memcmp(r.adr, body, strlen(body)) != 0) {
+      fprintf(stderr, "%s: html path of %d bytes: body mismatch\n",
+              selftest_tag, (int) strlen(path));
       failures++;
     }
   } else {
@@ -2076,20 +2081,56 @@ static int savebounds_read(httrackp *opt, const char *path, const char *adr,
   return failures;
 }
 
+/* The rebuilt name cannot fit under `path`: the entry must come back refused,
+   with neither a save name nor a body. */
+static int savebounds_expect_refused(httrackp *opt, const char *path,
+                                     const char *adr, const char *fil) {
+  return savebounds_expect(opt, path, adr, fil, NULL, NULL);
+}
+
+/* Store one entry, with path_prefix as a mirror passes it: non-NULL strips the
+   html path off X-Save, NULL leaves the name absolute (the pre-3.40 shape). */
+static void savebounds_store(httrackp *opt, cache_back *cache, const char *adr,
+                             const char *fil, const char *save,
+                             const char *path_prefix, const char *body) {
+  htsblk w;
+  char locw[4];
+  char *bodycopy = strdupt(body);
+
+  hts_init_htsblk(&w);
+  w.statuscode = 200;
+  w.size = (LLint) strlen(body);
+  strcpybuff(w.msg, "OK");
+  strcpybuff(w.contenttype, "text/html");
+  strcpybuff(w.charset, "utf-8");
+  locw[0] = '\0';
+  w.location = locw;
+  w.is_write = 0;
+  w.adr = bodycopy;
+  cache_add(opt, cache, &w, adr, fil, save, 1, path_prefix);
+  freet(bodycopy);
+}
+
 int cache_savename_bounds_selftest(httrackp *opt, const char *dir) {
   int failures = 0;
   cache_back cache;
+  static const char rel_head[] = "example.com/";
+  static const char rel_tail[] = ".html";
   const char *const adr = "example.com";
   const char *const fil = "/deep.html";
+  /* second entry, stored with an absolute X-Save: exercises the branch that
+     copies the stored name verbatim instead of prepending */
+  const char *const flat_fil = "/flat.html";
   static const char body[] = "<html><body>deep</body></html>";
+  static const char flat_body[] = "<html><body>flat</body></html>";
   static char rel[SAVEBOUNDS_REL_LEN + 1];
-  /* the deeper html paths a later run may carry: one where the rebuilt name
-     ends exactly on the last byte that fits, one a single byte past it, and
-     the issue's own 1500 */
+  /* the rebuilt name ends on the last byte that fits, then one byte past it */
   static char path_fit[SAVEBOUNDS_CAP], path_over[SAVEBOUNDS_CAP];
+  /* the html path the issue reported against */
   static char path_huge[SAVEBOUNDS_CAP];
   char BIGSTK writepath[HTS_URLMAXSIZE * 2];
   char BIGSTK save[HTS_URLMAXSIZE * 2];
+  char BIGSTK flat_save[HTS_URLMAXSIZE * 2];
   /* concat() refuses a result that only just fits, and the longest expected
      name here is exactly SAVEBOUNDS_CAP - 1 bytes */
   char BIGSTK expected[SAVEBOUNDS_CAP + 8];
@@ -2100,48 +2141,35 @@ int cache_savename_bounds_selftest(httrackp *opt, const char *dir) {
 
   memset(rel, 'p', SAVEBOUNDS_REL_LEN);
   rel[SAVEBOUNDS_REL_LEN] = '\0';
-  memcpy(rel, "example.com/", 12);
-  memcpy(rel + SAVEBOUNDS_REL_LEN - 5, ".html", 5);
+  memcpy(rel, rel_head, sizeof(rel_head) - 1);
+  memcpy(rel + SAVEBOUNDS_REL_LEN - (sizeof(rel_tail) - 1), rel_tail,
+         sizeof(rel_tail) - 1);
   savebounds_path(path_fit, sizeof(path_fit),
                   SAVEBOUNDS_CAP - 1 - SAVEBOUNDS_REL_LEN);
   savebounds_path(path_over, sizeof(path_over),
                   SAVEBOUNDS_CAP - SAVEBOUNDS_REL_LEN);
   savebounds_path(path_huge, sizeof(path_huge), 1500);
   concat(save, sizeof(save), writepath, rel);
+  concat(flat_save, sizeof(flat_save), writepath, "example.com/flat.html");
 
-  /* store it the way a mirror does: path_prefix set, so X-Save goes to the ZIP
-     relative to the html path of this run */
   selftest_open_for_write(&cache, opt);
-  {
-    htsblk w;
-    char locw[4];
-    char *bodycopy = strdupt(body);
-
-    hts_init_htsblk(&w);
-    w.statuscode = 200;
-    w.size = (LLint) strlen(body);
-    strcpybuff(w.msg, "OK");
-    strcpybuff(w.contenttype, "text/html");
-    strcpybuff(w.charset, "utf-8");
-    locw[0] = '\0';
-    w.location = locw;
-    w.is_write = 0;
-    w.adr = bodycopy;
-    cache_add(opt, &cache, &w, adr, fil, save, 1, writepath);
-    freet(bodycopy);
-  }
+  savebounds_store(opt, &cache, adr, fil, save, writepath, body);
+  savebounds_store(opt, &cache, adr, flat_fil, flat_save, NULL, flat_body);
   selftest_close(&cache);
 
   /* same html path as the write: the stripped prefix goes back on unchanged */
-  failures += savebounds_read(opt, writepath, adr, fil, save);
+  failures += savebounds_expect(opt, writepath, adr, fil, save, body);
+  /* an absolute stored name is used as-is, not prefixed a second time */
+  failures +=
+      savebounds_expect(opt, writepath, adr, flat_fil, flat_save, flat_body);
 
   /* deeper path, rebuilt name still fits to the last byte */
   concat(expected, sizeof(expected), path_fit, rel);
-  failures += savebounds_read(opt, path_fit, adr, fil, expected);
+  failures += savebounds_expect(opt, path_fit, adr, fil, expected, body);
 
   /* one byte past: refuse and re-fetch rather than name another file */
-  failures += savebounds_read(opt, path_over, adr, fil, NULL);
-  failures += savebounds_read(opt, path_huge, adr, fil, NULL);
+  failures += savebounds_expect_refused(opt, path_over, adr, fil);
+  failures += savebounds_expect_refused(opt, path_huge, adr, fil);
 
   return failures;
 }

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -1982,3 +1982,166 @@ int cache_url_bounds_selftest(httrackp *opt, const char *dir) {
 
   return failures;
 }
+
+/* Capacity cache_readex_new() rebuilds the save name in, so the longest name
+   that fits is one byte less. */
+#define SAVEBOUNDS_CAP (HTS_URLMAXSIZE * 2)
+/* X-Save length used here, kept under HTS_URLMAXSIZE: binput() clips the header
+   line to that, and a clipped one would test the clipping, not the rebuild. */
+#define SAVEBOUNDS_REL_LEN 1000
+#define SAVEBOUNDS_GUARD 16
+#define SAVEBOUNDS_GUARD_BYTE '\x5a'
+
+/* A path of exactly len bytes, slash-bounded like an -O directory. */
+static void savebounds_path(char *s, size_t size, size_t len) {
+  assertf(len >= 2 && len < size);
+  memset(s, 'd', len);
+  s[0] = '/';
+  s[len - 1] = '/';
+  s[len] = '\0';
+}
+
+/* Read the entry back with path_html_utf8 set to `path`. want is the save name
+   the reader must rebuild, or NULL when the rebuild cannot fit and the entry
+   must be refused. */
+static int savebounds_read(httrackp *opt, const char *path, const char *adr,
+                           const char *fil, const char *want) {
+  int failures = 0;
+  cache_back cache;
+  htsblk r;
+  char *got = malloct(SAVEBOUNDS_CAP + SAVEBOUNDS_GUARD);
+  size_t k;
+
+  /* non-zero guard: a stray NUL written one past the end is invisible against
+     a zeroed one */
+  memset(got, SAVEBOUNDS_GUARD_BYTE, SAVEBOUNDS_CAP + SAVEBOUNDS_GUARD);
+  got[0] = '\0';
+
+  StringCopy(opt->path_html_utf8, path);
+  selftest_open_for_read(&cache, opt);
+  r = cache_readex(opt, &cache, adr, fil, "", NULL, got, 1);
+  selftest_close(&cache);
+
+  if (want != NULL) {
+    if (r.statuscode != 200) {
+      fprintf(stderr,
+              "%s: html path of %d bytes: statuscode %d, expected 200 (%s)\n",
+              selftest_tag, (int) strlen(path), r.statuscode, r.msg);
+      failures++;
+    }
+    if (strcmp(got, want) != 0) {
+      fprintf(stderr,
+              "%s: html path of %d bytes: save name is %d bytes '%.48s...',"
+              " expected %d bytes '%.48s...'\n",
+              selftest_tag, (int) strlen(path), (int) strlen(got), got,
+              (int) strlen(want), want);
+      failures++;
+    }
+  } else {
+    if (r.statuscode != STATUSCODE_INVALID) {
+      fprintf(stderr,
+              "%s: html path of %d bytes: statuscode %d, expected the entry to"
+              " be refused\n",
+              selftest_tag, (int) strlen(path), r.statuscode);
+      failures++;
+    }
+    /* the point of the refusal: a clipped name would name another file */
+    if (got[0] != '\0') {
+      fprintf(stderr,
+              "%s: html path of %d bytes: refused entry still returns a %d-byte"
+              " save name '%.48s...'\n",
+              selftest_tag, (int) strlen(path), (int) strlen(got), got);
+      failures++;
+    }
+    if (r.adr != NULL) {
+      fprintf(stderr,
+              "%s: html path of %d bytes: refused entry returns a body\n",
+              selftest_tag, (int) strlen(path));
+      failures++;
+    }
+  }
+  for (k = SAVEBOUNDS_CAP; k < SAVEBOUNDS_CAP + SAVEBOUNDS_GUARD; k++) {
+    if (got[k] != SAVEBOUNDS_GUARD_BYTE) {
+      fprintf(stderr, "%s: html path of %d bytes: guard byte %d overwritten\n",
+              selftest_tag, (int) strlen(path), (int) (k - SAVEBOUNDS_CAP));
+      failures++;
+      break;
+    }
+  }
+
+  if (r.adr != NULL) {
+    freet(r.adr);
+  }
+  freet(got);
+  return failures;
+}
+
+int cache_savename_bounds_selftest(httrackp *opt, const char *dir) {
+  int failures = 0;
+  cache_back cache;
+  const char *const adr = "example.com";
+  const char *const fil = "/deep.html";
+  static const char body[] = "<html><body>deep</body></html>";
+  static char rel[SAVEBOUNDS_REL_LEN + 1];
+  /* the deeper html paths a later run may carry: one where the rebuilt name
+     ends exactly on the last byte that fits, one a single byte past it, and
+     the issue's own 1500 */
+  static char path_fit[SAVEBOUNDS_CAP], path_over[SAVEBOUNDS_CAP];
+  static char path_huge[SAVEBOUNDS_CAP];
+  char BIGSTK writepath[HTS_URLMAXSIZE * 2];
+  char BIGSTK save[HTS_URLMAXSIZE * 2];
+  /* concat() refuses a result that only just fits, and the longest expected
+     name here is exactly SAVEBOUNDS_CAP - 1 bytes */
+  char BIGSTK expected[SAVEBOUNDS_CAP + 8];
+
+  selftest_tag = "cache-savebounds";
+  selftest_setup_dir(opt, dir);
+  strcpybuff(writepath, StringBuff(opt->path_html_utf8));
+
+  memset(rel, 'p', SAVEBOUNDS_REL_LEN);
+  rel[SAVEBOUNDS_REL_LEN] = '\0';
+  memcpy(rel, "example.com/", 12);
+  memcpy(rel + SAVEBOUNDS_REL_LEN - 5, ".html", 5);
+  savebounds_path(path_fit, sizeof(path_fit),
+                  SAVEBOUNDS_CAP - 1 - SAVEBOUNDS_REL_LEN);
+  savebounds_path(path_over, sizeof(path_over),
+                  SAVEBOUNDS_CAP - SAVEBOUNDS_REL_LEN);
+  savebounds_path(path_huge, sizeof(path_huge), 1500);
+  concat(save, sizeof(save), writepath, rel);
+
+  /* store it the way a mirror does: path_prefix set, so X-Save goes to the ZIP
+     relative to the html path of this run */
+  selftest_open_for_write(&cache, opt);
+  {
+    htsblk w;
+    char locw[4];
+    char *bodycopy = strdupt(body);
+
+    hts_init_htsblk(&w);
+    w.statuscode = 200;
+    w.size = (LLint) strlen(body);
+    strcpybuff(w.msg, "OK");
+    strcpybuff(w.contenttype, "text/html");
+    strcpybuff(w.charset, "utf-8");
+    locw[0] = '\0';
+    w.location = locw;
+    w.is_write = 0;
+    w.adr = bodycopy;
+    cache_add(opt, &cache, &w, adr, fil, save, 1, writepath);
+    freet(bodycopy);
+  }
+  selftest_close(&cache);
+
+  /* same html path as the write: the stripped prefix goes back on unchanged */
+  failures += savebounds_read(opt, writepath, adr, fil, save);
+
+  /* deeper path, rebuilt name still fits to the last byte */
+  concat(expected, sizeof(expected), path_fit, rel);
+  failures += savebounds_read(opt, path_fit, adr, fil, expected);
+
+  /* one byte past: refuse and re-fetch rather than name another file */
+  failures += savebounds_read(opt, path_over, adr, fil, NULL);
+  failures += savebounds_read(opt, path_huge, adr, fil, NULL);
+
+  return failures;
+}

--- a/src/htscache_selftest.h
+++ b/src/htscache_selftest.h
@@ -75,9 +75,9 @@ int cache_header_bounds_selftest(httrackp *opt, const char *dir);
    abort nor alias two keys. Returns the failed-check count. */
 int cache_url_bounds_selftest(httrackp *opt, const char *dir);
 
-/* X-Save is stored relative to path_html_utf8, so a later run with a deeper one
-   rebuilds a longer name: it must fit or the entry be refused, never clipped
-   into a name pointing at another file (#1278). Failed-check count. */
+/* X-Save is stored relative to path_html_utf8; a name rebuilt under a deeper
+   path must fit or the entry be refused, never clipped into a name pointing at
+   another file (#1278). Returns the failed-check count. */
 int cache_savename_bounds_selftest(httrackp *opt, const char *dir);
 
 /* Inject read-side corruption (zip byte surgery: bad size, header, deflate)

--- a/src/htscache_selftest.h
+++ b/src/htscache_selftest.h
@@ -75,6 +75,11 @@ int cache_header_bounds_selftest(httrackp *opt, const char *dir);
    abort nor alias two keys. Returns the failed-check count. */
 int cache_url_bounds_selftest(httrackp *opt, const char *dir);
 
+/* X-Save is stored relative to path_html_utf8, so a later run with a deeper one
+   rebuilds a longer name: it must fit or the entry be refused, never clipped
+   into a name pointing at another file (#1278). Failed-check count. */
+int cache_savename_bounds_selftest(httrackp *opt, const char *dir);
+
 /* Inject read-side corruption (zip byte surgery: bad size, header, deflate)
    under <dir> and assert every case degrades to STATUSCODE_INVALID without
    tainting a sibling entry. */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3187,6 +3187,18 @@ static int st_cache_urlbounds(httrackp *opt, int argc, char **argv) {
   return err;
 }
 
+static int st_cache_savebounds(httrackp *opt, int argc, char **argv) {
+  int err;
+
+  if (argc < 1) {
+    fprintf(stderr, "cache-savebounds: needs a directory\n");
+    return 1;
+  }
+  err = cache_savename_bounds_selftest(opt, argv[0]);
+  printf("cache-savebounds: %s\n", err ? "FAIL" : "OK");
+  return err;
+}
+
 static int st_cache_corrupt(httrackp *opt, int argc, char **argv) {
   int err;
 
@@ -10341,6 +10353,9 @@ static const struct selftest_entry {
     {"cache-urlbounds", "<dir>",
      "cache store and lookup at max-length URLs must not abort or alias",
      st_cache_urlbounds},
+    {"cache-savebounds", "<dir>",
+     "cached save name rebuilt under a deeper html path must fit or be refused",
+     st_cache_savebounds},
     {"zip-repair-shift", "<dir>",
      "cache zip-repair header read must not overflow a signed shift",
      st_zip_repair_shift},

--- a/tests/308_zlib-cache-savebounds.test
+++ b/tests/308_zlib-cache-savebounds.test
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Cache save-name bounds (httrack -#test=cache-savebounds <dir>): a deeper html
+# path on a later run must not overrun the name the reader rebuilds (#1278).
+
+set -eu
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+dir=$(mktemp -d)
+cleanup_push rm -rf "$dir"
+
+# stderr carries the expected "filename too long" warnings alongside the
+# self-test's own diagnostics: keep it out of the verdict, but not the report
+httrack -#test=cache-savebounds "$dir" >"$dir/out" 2>"$dir/err" ||
+    {
+        echo "httrack exited $? running the self-test:" >&2
+        cat "$dir/out" "$dir/err" >&2
+        exit 1
+    }
+
+out=$(tail -n1 "$dir/out")
+test "$out" = "cache-savebounds: OK" || {
+    echo "expected 'cache-savebounds: OK', got: $out" >&2
+    cat "$dir/err" >&2
+    exit 1
+}


### PR DESCRIPTION
The cache read path rebuilt a stored save name with an unbounded sprintf into a 2048-byte buffer. `cache_add()` stores `X-Save` relative to `path_html_utf8`, and the read prepends the current one back. The two cancel out within a run, and stop cancelling once the html path grows while the cache stays put. `-O "<html>,<log>"` does that, and so does moving a project into a deeper directory. The comment calling this a legacy pre-3.40 format path was wrong; it is fixed here.

The rebuild goes through `slcatprintfbuff()` into `sizeof()` now, and a name that no longer fits refuses the entry (a warning plus `STATUSCODE_INVALID`) instead of clipping. A clipped save name is a different filename handed to the file layer, so re-fetching the URL is the honest outcome. `check_path()`'s own `~/` and `#` expansions turned out to be bounded already, so nothing else needed touching.

The new `-#test=cache-savebounds` self-test, driven by `tests/308_zlib-cache-savebounds.test`, stores two entries under a short html path and reads them back under the original path and three deeper ones: the last that fits, one byte past it, and the issue's 1500. It asserts the exact rebuilt name and body, checks a non-zero guard past the caller's buffer, and requires the refused reads to return no name and no body. I ran it against four mutants: a silent clip, an always-prepend, a never-prepend, and pre-fix `origin/master`, where it aborts in `_FORTIFY_SOURCE` at htscache.c:624, the line the issue reports.

Closes #1278
