### PR TITLE
A URL longer than 1024 bytes in a -%L list is split into two links

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -831,33 +831,37 @@ int httpmirror(char *url1, httrackp * opt) {
         while(filelist_ptr < filelist_sz) {
           const int count =
               binput(filelist_buff + filelist_ptr, line, HTS_URLMAXSIZE);
-          const size_t next = filelist_ptr + (size_t) count;
-          /* Did binput stop on the line's own terminator, or clip mid-URL? The
-             buffer carries our NUL at filelist_sz, so next - 1 is in bounds. */
-          const hts_boolean whole =
-              next - 1 == filelist_sz || filelist_buff[next - 1] == '\n';
+          /* Where binput stopped, past any CR it dropped: a clipped line stops
+             on a URL byte. Our NUL at filelist_sz keeps the walk in bounds. */
+          size_t term = filelist_ptr + (size_t) count - 1;
+          hts_boolean whole;
 
+          while (term < filelist_sz && filelist_buff[term] == '\r') {
+            term++;
+          }
+          whole = term == filelist_sz || filelist_buff[term] == '\n';
           lineno++;
           if (!whole) {
-            /* Advancing by count would feed the tail back as a second URL, and
-               a clipped URL is a different URL, so refuse the line by name. */
-            if (filelist_buff[next - 1] == '\0') {
+            /* Resuming where binput stopped would feed the tail back as a
+               second URL, and a clipped URL is a different URL. */
+            if (filelist_buff[term] == '\0') {
               hts_log_print(opt, LOG_WARNING,
-                            "%s, line %d: URL contains a NUL byte, ignored",
+                            "\"%s\", line %d: URL contains a NUL byte, ignored",
                             StringBuff(opt->filelist), lineno);
             } else {
-              hts_log_print(opt, LOG_WARNING,
-                            "%s, line %d: URL longer than %d bytes, ignored",
-                            StringBuff(opt->filelist), lineno, HTS_URLMAXSIZE);
+              hts_log_print(
+                  opt, LOG_WARNING,
+                  "\"%s\", line %d: URL longer than %d bytes, ignored",
+                  StringBuff(opt->filelist), lineno, HTS_URLMAXSIZE);
             }
             while (filelist_ptr < filelist_sz &&
                    filelist_buff[filelist_ptr] != '\n') {
               filelist_ptr++;
             }
-            filelist_ptr++; /* step over the '\n' */
+            filelist_ptr++;
             continue;
           }
-          filelist_ptr = next;
+          filelist_ptr = term + 1;
           if (count && line[0]) {
             n++;
             if (strstr(line, ":/") == NULL) {

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -825,12 +825,39 @@ int httpmirror(char *url1, httrackp * opt) {
       if (filelist_buff != NULL) {
         size_t filelist_ptr = 0;
         int n = 0;
+        int lineno = 0;
         char BIGSTK line[HTS_URLMAXSIZE * 2];
 
         while(filelist_ptr < filelist_sz) {
-          int count =
-            binput(filelist_buff + filelist_ptr, line, HTS_URLMAXSIZE);
-          filelist_ptr += count;
+          const int count =
+              binput(filelist_buff + filelist_ptr, line, HTS_URLMAXSIZE);
+          const size_t next = filelist_ptr + (size_t) count;
+          /* Did binput stop on the line's own terminator, or clip mid-URL? The
+             buffer carries our NUL at filelist_sz, so next - 1 is in bounds. */
+          const hts_boolean whole =
+              next - 1 == filelist_sz || filelist_buff[next - 1] == '\n';
+
+          lineno++;
+          if (!whole) {
+            /* Advancing by count would feed the tail back as a second URL, and
+               a clipped URL is a different URL, so refuse the line by name. */
+            if (filelist_buff[next - 1] == '\0') {
+              hts_log_print(opt, LOG_WARNING,
+                            "%s, line %d: URL contains a NUL byte, ignored",
+                            StringBuff(opt->filelist), lineno);
+            } else {
+              hts_log_print(opt, LOG_WARNING,
+                            "%s, line %d: URL longer than %d bytes, ignored",
+                            StringBuff(opt->filelist), lineno, HTS_URLMAXSIZE);
+            }
+            while (filelist_ptr < filelist_sz &&
+                   filelist_buff[filelist_ptr] != '\n') {
+              filelist_ptr++;
+            }
+            filelist_ptr++; /* step over the '\n' */
+            continue;
+          }
+          filelist_ptr = next;
           if (count && line[0]) {
             n++;
             if (strstr(line, ":/") == NULL) {

--- a/tests/310_filelist-long-url.test
+++ b/tests/310_filelist-long-url.test
@@ -10,6 +10,8 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "$(dirname "$0")/testlib.sh"
 
+limit=1024 # HTS_URLMAXSIZE: the longest line -%L accepts
+
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_longurl.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmp"
 
@@ -18,57 +20,98 @@ echo '<html><body>two</body></html>' >"$tmp/two.html"
 echo '<html><body>three</body></html>' >"$tmp/three.html"
 
 base="file://$tmp/"
-out="$tmp/out"
-log="$out/hts-log.txt"
 
-# 1500 bytes, tail-marked: a split shows ENDMRK as a second link's host.
-padlen=$((1500 - ${#base} - 6))
-long="$base$(printf "%${padlen}s" '' | tr ' ' p)ENDMRK"
-# ~1000 bytes but just under the limit: dot segments collapse away, so the
-# URL is long while the file it names is a real one.
+# A URL of exactly $1 bytes on its own line, ending in the marker $2 so a
+# split is visible. $(...) strips the newline where a fixture wants none.
+padded_url() {
+    local want="$1" mark="$2"
+    printf '%s%s%s\n' "$base" \
+        "$(printf "%$((want - ${#base} - ${#mark}))s" '' | tr ' ' p)" "$mark"
+}
+
+# Dot segments collapse away, so the URL is long while the file it names is
+# real: this one has to survive the loop and be fetched.
 dots=$(((1000 - ${#base} - 10) / 2))
 near="$base$(printf "%${dots}s" '' | sed 's| |./|g')three.html"
 
-{
-    echo "${base}one.html"
-    echo "$long"
-    echo "${base}two.html"
-    echo "$near"
-} >"$tmp/urls.txt"
-
-assert_eq 1500 "${#long}" "long URL length"
-test "${#near}" -gt 900 -a "${#near}" -lt 1024 || fail "near URL is ${#near} bytes"
-
-mkdir -p "$out"
-httrack -O "$out" --quiet -n "-%L" "$tmp/urls.txt" >"$tmp/stdout" 2>&1 ||
-    fail "httrack failed: $(cat "$tmp/stdout")"
-
+log=""
+mirror=""
+run() { # run LIST -> sets $log and $mirror
+    local list="$1"
+    local out
+    out="$tmp/out.$(basename "$list" .txt)"
+    rm -rf "$out"
+    mkdir -p "$out"
+    httrack -O "$out" --quiet -n "-%L" "$list" >"$out/.stdout" 2>&1 ||
+        fail "httrack failed on $list: $(cat "$out/.stdout")"
+    log="$out/hts-log.txt"
+    mirror="$out"
+}
 loghas() {
-    grep -Eqi "$1" "$log" || {
+    grep -Eq "$1" "$log" || {
         cut -c1-200 "$log"
         fail "expected /$1/ in $log"
     }
 }
 lognot() {
-    if grep -Eqi "$1" "$log"; then
+    if grep -Eq "$1" "$log"; then
         cut -c1-200 "$log"
         fail "unexpected /$1/ in $log"
     fi
 }
 
-# The over-long line is refused by name, on stderr and in the log, naming the
-# list and the line: a fix that drops it silently passes the count check alone.
-loghas 'urls\.txt, line 2: URL longer than 1024 bytes, ignored'
-# ...and exactly the other three lines loaded: 4 would mean the tail still came
-# back as a link, 2 that the near-limit line was refused along with it.
-loghas '(^|[^0-9])3 links added from'
-# The tail of the split URL was fetched as a host of its own.
-lognot 'endmrk'
+# Blank line 4 keeps "physical line" and "binput call" from agreeing by
+# accident, so a line number counted the wrong way shows up on line 6.
+{
+    echo "${base}one.html"
+    padded_url 1500 ENDMRK
+    echo "${base}two.html"
+    echo ""
+    padded_url "$limit" EDGEMRK
+    padded_url "$((limit + 1))" OVERMRK
+    echo "$near"
+} >"$tmp/urls.txt"
 
+run "$tmp/urls.txt"
+# Named, so a fix that drops the line silently does not pass...
+loghas "\"[^\"]*urls\.txt\", line 2: URL longer than $limit bytes, ignored"
+loghas "\"[^\"]*urls\.txt\", line 6: URL longer than $limit bytes, ignored"
+# ...and refused, so neither does one that warns and splits anyway. 4 is every
+# line but those two: the blank one adds nothing, the $limit-byte one must.
+loghas '(^|[^0-9])4 links added from'
+# The tails of the split URLs, which the engine used to crawl as hosts.
+lognot 'ENDMRK|endmrk|OVERMRK|overmrk'
 # The near-limit line reached the crawler whole: a clipped URL names no file.
-loghas 'mirror complete.*[^0-9]3 links scanned'
-test -s "$out/file$tmp/three.html" || fail "near-limit URL was not fetched"
-test -s "$out/file$tmp/one.html" || fail "first URL was not fetched"
-test -s "$out/file$tmp/two.html" || fail "URL after the refused line was not fetched"
+test -n "$(find "$mirror" -type f -path '*/file/*' -name three.html -print -quit)" ||
+    fail "the near-limit URL was not fetched"
+
+# A Windows-authored list: binput drops the CR, so the byte it stopped on is
+# not the '\n'. A line of exactly $limit bytes still has to load.
+{
+    padded_url "$limit" CRLFMRK
+    echo "${base}two.html"
+} | sed 's|$|\r|' >"$tmp/crlf.txt"
+run "$tmp/crlf.txt"
+loghas '(^|[^0-9])2 links added from'
+lognot 'ignored'
+
+# No trailing newline: the last line ends on the buffer's own NUL, not a '\n'.
+printf '%s' "${base}one.html" >"$tmp/noeol.txt"
+run "$tmp/noeol.txt"
+loghas '(^|[^0-9])1 links added from'
+lognot 'ignored'
+
+printf '%s' "$(padded_url 1500 EOFMRK)" >"$tmp/noeol-long.txt"
+run "$tmp/noeol-long.txt"
+loghas "\"[^\"]*noeol-long\.txt\", line 1: URL longer than $limit bytes, ignored"
+loghas '(^|[^0-9])0 links added from'
+lognot 'EOFMRK|eofmrk'
+
+# A NUL splits a line the same way, which is what a list saved as UTF-16 is
+# made of. The good line after it still loads.
+printf 'file://%s/one\0.html\nfile://%s/two.html\n' "$tmp" "$tmp" >"$tmp/nul.txt"
+run "$tmp/nul.txt"
+loghas "\"[^\"]*nul\.txt\", line 1: URL contains a NUL byte, ignored"
+loghas '(^|[^0-9])1 links added from'
 
 exit 0

--- a/tests/310_filelist-long-url.test
+++ b/tests/310_filelist-long-url.test
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# -%L: a line the user wrote is read whole or refused by name, never split.
+# binput() clips at HTS_URLMAXSIZE and returns the clipped length, so the
+# loading loop used to resume mid-URL and add the tail as a second link.
+# Offline: file:// fixtures, no server.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_longurl.XXXXXX") || exit 1
+cleanup_push rm -rf "$tmp"
+
+echo '<html><body>one</body></html>' >"$tmp/one.html"
+echo '<html><body>two</body></html>' >"$tmp/two.html"
+echo '<html><body>three</body></html>' >"$tmp/three.html"
+
+base="file://$tmp/"
+out="$tmp/out"
+log="$out/hts-log.txt"
+
+# 1500 bytes, tail-marked: a split shows ENDMRK as a second link's host.
+padlen=$((1500 - ${#base} - 6))
+long="$base$(printf "%${padlen}s" '' | tr ' ' p)ENDMRK"
+# ~1000 bytes but just under the limit: dot segments collapse away, so the
+# URL is long while the file it names is a real one.
+dots=$(((1000 - ${#base} - 10) / 2))
+near="$base$(printf "%${dots}s" '' | sed 's| |./|g')three.html"
+
+{
+    echo "${base}one.html"
+    echo "$long"
+    echo "${base}two.html"
+    echo "$near"
+} >"$tmp/urls.txt"
+
+assert_eq 1500 "${#long}" "long URL length"
+test "${#near}" -gt 900 -a "${#near}" -lt 1024 || fail "near URL is ${#near} bytes"
+
+mkdir -p "$out"
+httrack -O "$out" --quiet -n "-%L" "$tmp/urls.txt" >"$tmp/stdout" 2>&1 ||
+    fail "httrack failed: $(cat "$tmp/stdout")"
+
+loghas() {
+    grep -Eqi "$1" "$log" || {
+        cut -c1-200 "$log"
+        fail "expected /$1/ in $log"
+    }
+}
+lognot() {
+    if grep -Eqi "$1" "$log"; then
+        cut -c1-200 "$log"
+        fail "unexpected /$1/ in $log"
+    fi
+}
+
+# The over-long line is refused by name, on stderr and in the log, naming the
+# list and the line: a fix that drops it silently passes the count check alone.
+loghas 'urls\.txt, line 2: URL longer than 1024 bytes, ignored'
+# ...and exactly the other three lines loaded: 4 would mean the tail still came
+# back as a link, 2 that the near-limit line was refused along with it.
+loghas '(^|[^0-9])3 links added from'
+# The tail of the split URL was fetched as a host of its own.
+lognot 'endmrk'
+
+# The near-limit line reached the crawler whole: a clipped URL names no file.
+loghas 'mirror complete.*[^0-9]3 links scanned'
+test -s "$out/file$tmp/three.html" || fail "near-limit URL was not fetched"
+test -s "$out/file$tmp/one.html" || fail "first URL was not fetched"
+test -s "$out/file$tmp/two.html" || fail "URL after the refused line was not fetched"
+
+exit 0


### PR DESCRIPTION
A URL longer than 1024 bytes in a `-%L` list file came back as two links. `binput()` clips at its destination size and still returns the source offset plus one, so the loading loop resumed mid-URL, lost the byte at the seam, and added the tail as a second link while the counter reported both. The tail lands where a hostname goes: a 1030-byte URL ending in `ENDMRK` makes the engine resolve, and on a name that exists fetch, a host called `ndmrk`.

The loop now looks at the byte `binput` stopped on. A `\n`, the buffer's own trailing NUL, or a `\r\n` pair, means the line was read whole; anything else means it did not fit, and the line is refused with the list name and the 1-based line number in the log while the rest of the list loads. Not clipped: a clipped URL is a different URL and fetching it is worse than not fetching it, the same call #1277 made. A stray NUL splits lines the same way and is refused too, which is what a list file saved as UTF-16 is made of.

The other `binput` callers read back data the engine wrote itself and are bounded by their own writer (htsbauth.c:347, htscache.c:1184, htscache.c:1481, htsrobots.c:104). Four do parse data off the wire and let a long line's tail become the next record: the ZIP cache header parse (htscache.c:588), the robots.txt parse (htsrobots.c:169) and the two HTTP response-header loops (htslib.c:2078, htsback.c:3946). None lets a server say anything it could not have sent as a separate line, so they lose fidelity without buying anyone reach, and I left them alone rather than widen this diff. ProxyTrack keeps its own static copy of `binput` in src/proxy/store.c, untouched.

`tests/310_filelist-long-url.test` drives the `-%L` path over file:// fixtures, no server. It asserts that each refusal is logged with the right line number, that the count is 4 and not 7, that no split tail ever appears, that a line of exactly 1024 bytes still loads while 1025 does not, and that a 1000-byte URL comes out the far end fetched. Separate fixtures cover CRLF endings, a list with no trailing newline, and an embedded NUL. Every one of those fails against a build of origin/master, which turns six written URLs into seven links, one of them a 1025-byte line quietly shortened to 1024 rather than split, because the byte the return value skips is the only one that overflowed.

Closes #1289