### PR TITLE
A redirect between 1 KB and 2 KB is refused by a gate half the size of its buffer

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -3931,6 +3931,7 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                   ) {
                   char rcvd[2048];
                   int ptr = 0;
+                  int adv = 0;
                   int noFreebuff = 0;
 
 #if BDEBUG==1
@@ -3943,10 +3944,16 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                     // ----------------------------------------
                     // traiter en-tête!
                     // status-line à récupérer
-                    ptr += binput(back[i].r.adr + ptr, rcvd, 2000);
+                    binput_header(back[i].r.adr + ptr,
+                                  back[i].r.adr + back[i].r.size, rcvd, 2000,
+                                  &adv);
+                    ptr += adv;
                     if (strnotempty(rcvd) == 0) {
                       /* Bogus CRLF, OR recycled connection and trailing chunk CRLF */
-                      ptr += binput(back[i].r.adr + ptr, rcvd, 2000);
+                      binput_header(back[i].r.adr + ptr,
+                                    back[i].r.adr + back[i].r.size, rcvd, 2000,
+                                    &adv);
+                      ptr += adv;
                     }
                     // traiter status-line
                     treatfirstline(&back[i].r, rcvd);
@@ -3968,7 +3975,19 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                     }
                     // header // ** !attention! HTTP/0.9 non supporté
                     do {
-                      ptr += binput(back[i].r.adr + ptr, rcvd, 2000);
+                      const hts_boolean cut = binput_header(
+                          back[i].r.adr + ptr, back[i].r.adr + back[i].r.size,
+                          rcvd, 2000, &adv);
+
+                      ptr += adv;
+                      if (cut) {
+                        /* not what the server sent: parsing it would follow a
+                           truncated Location, or read its tail as headers */
+                        hts_log_print(opt, LOG_WARNING,
+                                      "Over-long header dropped for %s%s",
+                                      back[i].url_adr, back[i].url_fil);
+                        continue;
+                      }
 #if HDEBUG
                       printf("(buffer)>%s\n", rcvd);
 #endif

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -96,7 +96,8 @@ void cache_mayadd(httrackp * opt, cache_back * cache, htsblk * r,
               if (coucal_read
                   (cache->cached_tests,
                    concat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), url_adr, url_fil), NULL) == 0) {
-                char BIGSTK tempo[HTS_URLMAXSIZE * 2];
+                /* a full-capacity location plus the status-code line */
+                char BIGSTK tempo[HTS_LOCATION_SIZE + 32];
 
                 sprintf(tempo, "%d", (int) r->statuscode);
                 if (r->location != NULL && r->location[0] != '\0') {
@@ -512,7 +513,7 @@ static htsblk cache_readex_new(httrackp * opt, cache_back * cache,
                                const char *adr, const char *fil,
                                const char *target_save, char *location,
                                char *return_save, int readonly) {
-  char BIGSTK location_default[HTS_URLMAXSIZE * 2];
+  char BIGSTK location_default[HTS_LOCATION_SIZE];
   char BIGSTK buff[CACHE_KEY_SIZE];
   char BIGSTK previous_save[HTS_URLMAXSIZE * 2];
   char BIGSTK previous_save_[HTS_URLMAXSIZE * 2];
@@ -576,7 +577,9 @@ static htsblk cache_readex_new(httrackp * opt, cache_back * cache,
              NULL, 0, NULL, 0, headerBuff, sizeof(headerBuff) - 2) == Z_OK ) */
         {
           int offset = 0;
-          char BIGSTK line[HTS_URLMAXSIZE + 2];
+          /* the longest stored line is "Location: " plus a full-capacity URL;
+             a shorter buffer truncates it into a valid-looking wrong target */
+          char BIGSTK line[HTS_LOCATION_SIZE + 32];
           int lineEof = 0;
 
           /*readSizeHeader = (int) strlen(headerBuff); */
@@ -606,9 +609,8 @@ static htsblk cache_readex_new(httrackp * opt, cache_back * cache,
               ZIP_READFIELD_STRING(line, value, "Last-Modified", r.lastmodified,
                                    sizeof(r.lastmodified));
               ZIP_READFIELD_STRING(line, value, "Etag", r.etag, sizeof(r.etag));
-              // r.location is a char* pointing into a HTS_URLMAXSIZE*2 buffer
               ZIP_READFIELD_STRING(line, value, "Location", r.location,
-                                   HTS_URLMAXSIZE * 2);
+                                   HTS_LOCATION_SIZE);
               ZIP_READFIELD_STRING(line, value, "Content-Disposition", r.cdispo,
                                    sizeof(r.cdispo));
               ZIP_READFIELD_STRING(line, value, "X-Save", previous_save_,

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -100,7 +100,7 @@ static void store_entry(httrackp *opt, cache_back *cache, const char *adr,
                         const char *etag, const char *location,
                         const char *cdispo, const char *body, size_t body_len) {
   htsblk r;
-  char locbuf[HTS_URLMAXSIZE * 2];
+  char locbuf[HTS_LOCATION_SIZE];
   char *bodycopy = NULL;
 
   hts_init_htsblk(&r);
@@ -136,7 +136,7 @@ static int check_entry(httrackp *opt, cache_back *cache, const char *adr,
                        const char *location, const char *cdispo,
                        const char *body, size_t body_len) {
   int fail = 0;
-  char *locbuf = malloct(HTS_URLMAXSIZE * 2);
+  char *locbuf = malloct(HTS_LOCATION_SIZE);
   htsblk r;
 
   locbuf[0] = '\0';
@@ -277,7 +277,7 @@ static int disk_fallback_selftest(httrackp *opt) {
 
   /* read it back: takes the X-In-Cache: 0 disk-fallback branch */
   selftest_open_for_read(&cache, opt);
-  locbuf = malloct(HTS_URLMAXSIZE * 2);
+  locbuf = malloct(HTS_LOCATION_SIZE);
   locbuf[0] = '\0';
   r = cache_readex(opt, &cache, adr, fil, "", locbuf, NULL, 1);
   if (r.statuscode != 200) {
@@ -697,14 +697,63 @@ int cache_write_failure_selftest(httrackp *opt, const char *dir) {
   return fail;
 }
 
+/* cache_mayadd()'s shortcut for a 3xx with no save name records "<code>\n<url>"
+   in cached_tests so the same URL is not re-tested. Its scratch must hold a
+   location at the full contract; too small and the mirror aborts on a long
+   redirect rather than storing it. */
+static int fast_header_selftest(httrackp *opt, const char *location) {
+  const char *const adr = "example.com";
+  const char *const fil = "/moved-fast";
+  cache_back cache;
+  htsblk r;
+  char *locbuf = malloct(HTS_LOCATION_SIZE);
+  char *want = malloct(HTS_LOCATION_SIZE + 32);
+  intptr_t stored = 0;
+  int fail = 0;
+
+  selftest_open_for_write(&cache, opt);
+  cache.cached_tests = coucal_new(0);
+  assertf(cache.cached_tests != NULL);
+  coucal_value_is_malloc(cache.cached_tests, 1);
+
+  hts_init_htsblk(&r);
+  r.statuscode = 301;
+  r.size = 0;
+  strcpybuff(r.msg, "Moved Permanently");
+  strcpybuff(r.contenttype, "text/html");
+  strlcpybuff(locbuf, location, HTS_LOCATION_SIZE);
+  r.location = locbuf;
+  r.is_write = 0;
+  cache_mayadd(opt, &cache, &r, adr, fil, NULL);
+
+  snprintf(want, HTS_LOCATION_SIZE + 32, "%d\n%s", (int) r.statuscode,
+           location);
+  if (!coucal_read(cache.cached_tests,
+                   concat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), adr, fil),
+                   &stored)) {
+    fprintf(stderr, "%s: fast-header: nothing recorded for %s%s\n",
+            selftest_tag, adr, fil);
+    fail++;
+  } else if (strcmp((const char *) stored, want) != 0) {
+    fprintf(stderr, "%s: fast-header: recorded %d bytes, expected %d\n",
+            selftest_tag, (int) strlen((const char *) stored),
+            (int) strlen(want));
+    fail++;
+  }
+
+  selftest_close(&cache);
+  freet(locbuf);
+  freet(want);
+  return fail;
+}
+
 int cache_selftests(httrackp *opt, const char *dir) {
   int failures = 0;
   cache_back cache;
   int i;
 
-  /* near-limit field values. The etag stresses htsblk.etag[256]; the location
-     stresses a redirect URL at the full HTS_LOCATION_SIZE contract, which the
-     header-line parse buffer has to be wide enough to read back whole. */
+  /* near-limit field values: the etag stresses htsblk.etag[256], the location
+     a redirect URL at the full HTS_LOCATION_SIZE contract */
   static char etag_long[251];
   static char location_long[HTS_LOCATION_SIZE];
 
@@ -866,6 +915,9 @@ int cache_selftests(httrackp *opt, const char *dir) {
 
   /* pass 6: the broken-transfer reference fallback */
   failures += broken_ref_selftest(opt);
+
+  /* pass 7: the save-less 3xx shortcut, whose scratch holds code + location */
+  failures += fast_header_selftest(opt, location_long);
 
   for (i = 0; i < large_count; i++) {
     freet(large_body[i]);
@@ -1689,7 +1741,7 @@ int cache_header_bounds_selftest(httrackp *opt, const char *dir) {
   cache_back cache;
   /* every htsblk field at the cap its declaration allows */
   static char msg[80], ctype[HTS_MIMETYPE_SIZE], charset[HTS_MIMETYPE_SIZE];
-  static char etag[256], cdispo[256], location[HTS_URLMAXSIZE * 2];
+  static char etag[256], cdispo[256], location[HTS_LOCATION_SIZE];
   /* url_adr/url_fil/save are all lien_back-sized, so the three alone reach
      6 KB, past the header block the writer builds them in */
   static char big_adr[HTS_URLMAXSIZE * 2], big_fil[HTS_URLMAXSIZE * 2];
@@ -1789,7 +1841,7 @@ int cache_header_bounds_selftest(httrackp *opt, const char *dir) {
 
   selftest_open_for_read(&cache, opt);
   {
-    char *locbuf = malloct(HTS_URLMAXSIZE * 2);
+    char *locbuf = malloct(HTS_LOCATION_SIZE);
     htsblk r;
 
     locbuf[0] = '\0';

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -703,12 +703,10 @@ int cache_selftests(httrackp *opt, const char *dir) {
   int i;
 
   /* near-limit field values. The etag stresses htsblk.etag[256]; the location
-     stresses a long redirect URL. Each cached header line is read back through
-     a HTS_URLMAXSIZE-sized parse buffer ("<field>: <value>\r\n"), so the
-     round-trippable value is shorter than HTS_URLMAXSIZE: 1000 stays safely
-     under that real limit. */
+     stresses a redirect URL at the full HTS_LOCATION_SIZE contract, which the
+     header-line parse buffer has to be wide enough to read back whole. */
   static char etag_long[251];
-  static char location_long[1001];
+  static char location_long[HTS_LOCATION_SIZE];
 
   /* a body with embedded NUL and high bytes, to prove binary safety */
   static const char binary_body[] = {

--- a/src/htscatchurl.c
+++ b/src/htscatchurl.c
@@ -193,7 +193,7 @@ HTSEXT_API hts_boolean catch_url(T_SOC soc, char *url, char *method,
           // adresse du lien
           if (ident_url_absolute(url, &af) >= 0) {
             // Traitement des en-têtes
-            char BIGSTK loc[HTS_URLMAXSIZE * 2];
+            char BIGSTK loc[HTS_LOCATION_SIZE];
             htsblk blkretour;
 
             hts_init_htsblk(&blkretour);

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -1047,7 +1047,7 @@ int httpmirror(char *url1, httrackp * opt) {
     int store_errpage = 0;      // c'est une erreur mais on enregistre le html
     int is_binary = 0;          // is a binary file
     int is_loaded_from_file = 0;        // has been loaded from a file (implies is_write=1)
-    char BIGSTK loc[HTS_URLMAXSIZE * 2];        // adresse de relocation
+    char BIGSTK loc[HTS_LOCATION_SIZE]; // redirect target
 
     // Ici on charge le fichier (html, gif..) en mémoire
     // Les HTMLs sont traités (si leur priorité est suffisante)

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -218,9 +218,8 @@ Please visit our Website: http://www.httrack.com
 /* MIME-type buffer contract (htsblk.contenttype/charset/contentencoding); holds
    the longest registered MIME type, the Office OOXML ones reaching 73 chars */
 #define HTS_MIMETYPE_SIZE 128
-/* Buffer contract for htsblk.location, a bare pointer every caller aims at an
-   array of this size. The Location header is gated against this, not against
-   HTS_URLMAXSIZE. */
+/* Capacity behind the htsblk.location pointer; the Location header is gated
+   against this, not against HTS_URLMAXSIZE */
 #define HTS_LOCATION_SIZE (HTS_URLMAXSIZE * 2)
 
 /* Caps on single option arguments, in bytes, exclusive like HTS_CDLMAXSIZE.

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -218,6 +218,10 @@ Please visit our Website: http://www.httrack.com
 /* MIME-type buffer contract (htsblk.contenttype/charset/contentencoding); holds
    the longest registered MIME type, the Office OOXML ones reaching 73 chars */
 #define HTS_MIMETYPE_SIZE 128
+/* Buffer contract for htsblk.location, a bare pointer every caller aims at an
+   array of this size. The Location header is gated against this, not against
+   HTS_URLMAXSIZE. */
+#define HTS_LOCATION_SIZE (HTS_URLMAXSIZE * 2)
 
 /* Caps on single option arguments, in bytes, exclusive like HTS_CDLMAXSIZE.
    They bound the value, not a buffer: these option fields are dynamic Strings.

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -800,9 +800,10 @@ T_SOC http_xfopen(httrackp *opt, int mode, int treat, int waitconnect,
         // Réception de la status line et de l'en-tête (norme RFC1945)
 
         // status-line à récupérer
-        finput(soc, rcvd, 1024);
+        finput_header(soc, rcvd, 1024);
+        // some buggy servers send a leading \n (RFC)
         if (strnotempty(rcvd) == 0)
-          finput(soc, rcvd, 1024);      // "certains serveurs buggés envoient un \n au début" (RFC)
+          finput_header(soc, rcvd, 1024);
 
         // traiter status-line
         treatfirstline(retour, rcvd);
@@ -815,12 +816,15 @@ T_SOC http_xfopen(httrackp *opt, int mode, int treat, int waitconnect,
 
         // header // ** !attention! HTTP/0.9 non supporté
         do {
-          finput(soc, rcvd, 1024);
+          const hts_boolean cut = finput_header(soc, rcvd, 1024);
+
 #if HDEBUG
           printf(">%s\n", rcvd);
 #endif
-          if (strnotempty(rcvd))
-            treathead(NULL, NULL, NULL, retour, rcvd);  // traiter
+          if (cut)
+            hts_log_print(NULL, LOG_WARNING, "Over-long header dropped");
+          else if (strnotempty(rcvd))
+            treathead(NULL, NULL, NULL, retour, rcvd);
 
         } while(strnotempty(rcvd));
 
@@ -2071,6 +2075,7 @@ htsblk http_test(httrackp * opt, const char *adr, const char *fil, char *loc) {
     if (e == 1) {
       if (adr != NULL) {
         int ptr = 0;
+        int adv = 0;
         char rcvd[1100];
 
         // note: en gros recopie du traitement de back_wait()
@@ -2079,9 +2084,15 @@ htsblk http_test(httrackp * opt, const char *adr, const char *fil, char *loc) {
         // ----------------------------------------
         // traiter en-tête!
         // status-line à récupérer
-        ptr += binput(retour.adr + ptr, rcvd, 1024);
-        if (strnotempty(rcvd) == 0)
-          ptr += binput(retour.adr + ptr, rcvd, 1024);  // "certains serveurs buggés envoient un \n au début" (RFC)
+        binput_header(retour.adr + ptr, retour.adr + retour.size, rcvd, 1024,
+                      &adv);
+        ptr += adv;
+        // some buggy servers send a leading \n (RFC)
+        if (strnotempty(rcvd) == 0) {
+          binput_header(retour.adr + ptr, retour.adr + retour.size, rcvd, 1024,
+                        &adv);
+          ptr += adv;
+        }
 
         // traiter status-line
         treatfirstline(&retour, rcvd);
@@ -2094,12 +2105,17 @@ htsblk http_test(httrackp * opt, const char *adr, const char *fil, char *loc) {
 
         // header // ** !attention! HTTP/0.9 non supporté
         do {
-          ptr += binput(retour.adr + ptr, rcvd, 1024);
+          const hts_boolean cut = binput_header(
+              retour.adr + ptr, retour.adr + retour.size, rcvd, 1024, &adv);
+
+          ptr += adv;
 #if HDEBUG
           printf("(buffer)>%s\n", rcvd);
 #endif
-          if (strnotempty(rcvd))
-            treathead(NULL, NULL, NULL, &retour, rcvd); // traiter
+          if (cut)
+            hts_log_print(NULL, LOG_WARNING, "Over-long header dropped");
+          else if (strnotempty(rcvd))
+            treathead(NULL, NULL, NULL, &retour, rcvd);
 
         } while(strnotempty(rcvd));
         // ----------------------------------------                    
@@ -3062,6 +3078,48 @@ int binput(const char *buff, char *s, int max) {
 
   // then return the supplemental jump offset
   return count + 1;
+}
+
+hts_boolean binput_header(const char *buff, const char *end, char *s, int max,
+                          int *offset) {
+  hts_boolean cut = HTS_FALSE;
+  const char *p;
+  int j = 0;
+
+  *offset = 0;
+  s[0] = '\0';
+  if (buff == NULL || buff >= end)
+    return HTS_FALSE;
+  for (p = buff; p < end && *p != '\0' && *p != '\n'; p++) {
+    if (*p == '\r')
+      continue;
+    if (j < max - 1)
+      s[j++] = *p;
+    else
+      cut = HTS_TRUE; /* keep walking: the tail must not become more headers */
+  }
+  s[j] = '\0';
+  *offset = (int) (p - buff) + 1; /* binput's convention: step over the \n */
+  return cut;
+}
+
+hts_boolean finput_header(T_SOC fd, char *s, int max) {
+  hts_boolean cut = HTS_FALSE;
+  int j = 0;
+  char c;
+
+  for (;;) {
+    if (read((int) fd, &c, 1) <= 0 || c == 10)
+      break;
+    if (c == 13)
+      continue;
+    if (j < max - 1)
+      s[j++] = c;
+    else
+      cut = HTS_TRUE; /* keep draining: the tail must not become more headers */
+  }
+  s[j] = '\0';
+  return cut;
 }
 
 // Lecture d'une ligne (peut être unicode à priori)

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -1546,12 +1546,16 @@ void treathead(t_cookie * cookie, const char *adr, const char *fil, htsblk * ret
     if (retour) {
       if (retour->location) {
         while(is_realspace(*(rcvd + p)))
-          p++;                  // sauter espaces
-        if ((int) strlen(rcvd + p) < HTS_URLMAXSIZE) // not too long?
-          /* location aliases location_buffer[HTS_URLMAXSIZE * 2] */
-          strlcpybuff(retour->location, rcvd + p, HTS_URLMAXSIZE * 2);
-        else                    // erreur.. ignorer
+          p++; // skip spaces
+        if (strlen(rcvd + p) < HTS_LOCATION_SIZE)
+          strlcpybuff(retour->location, rcvd + p, HTS_LOCATION_SIZE);
+        else {
+          /* no opt here, so this only reaches a registered log callback */
+          hts_log_print(NULL, LOG_WARNING,
+                        "Location header too long (%d bytes), redirect ignored",
+                        (int) strlen(rcvd + p));
           retour->location[0] = '\0';
+        }
       }
     }
   } else if (((p = strfield(rcvd, "Set-Cookie:")) != 0) &&

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -335,11 +335,10 @@ HTS_INLINE void time_rfc822_local(char *s, struct tm *A);
 HTS_INLINE int sendc(htsblk * r, const char *s);
 int finput(T_SOC fd, char *s, int max);
 int binput(const char *buff, char *s, int max);
-/* Read one response-header line, from a buffer up to "end" or from a socket.
-   Both consume the whole line even when it does not fit "s", and return
-   HTS_TRUE when it did not: a truncated line carries a value the server never
-   sent, so callers drop it rather than parse it. binput_header() reports
-   through *offset how many bytes to advance over. */
+/* Read one response-header line, from a buffer up to "end" or from a socket,
+   consuming it whole even when it does not fit "s". HTS_TRUE means it was cut:
+   the value is not what the server sent, so drop it rather than parse it.
+   binput_header() reports the advance through *offset. */
 hts_boolean binput_header(const char *buff, const char *end, char *s, int max,
                           int *offset);
 hts_boolean finput_header(T_SOC fd, char *s, int max);

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -335,6 +335,14 @@ HTS_INLINE void time_rfc822_local(char *s, struct tm *A);
 HTS_INLINE int sendc(htsblk * r, const char *s);
 int finput(T_SOC fd, char *s, int max);
 int binput(const char *buff, char *s, int max);
+/* Read one response-header line, from a buffer up to "end" or from a socket.
+   Both consume the whole line even when it does not fit "s", and return
+   HTS_TRUE when it did not: a truncated line carries a value the server never
+   sent, so callers drop it rather than parse it. binput_header() reports
+   through *offset how many bytes to advance over. */
+hts_boolean binput_header(const char *buff, const char *end, char *s, int max,
+                          int *offset);
+hts_boolean finput_header(T_SOC fd, char *s, int max);
 int linput(FILE * fp, char *s, int max);
 int linputsoc(T_SOC soc, char *s, int max);
 int linputsoc_t(T_SOC soc, char *s, int max, int timeout);

--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -673,7 +673,7 @@ struct htsblk {
   char contenttype[HTS_MIMETYPE_SIZE];     // content-type (e.g. "text/html")
   char charset[HTS_MIMETYPE_SIZE];         // charset (e.g. "iso-8859-1")
   char contentencoding[HTS_MIMETYPE_SIZE]; // content-encoding (e.g. "gzip")
-  char *location;    /**< resolved Location target, if any */
+  char *location;    /**< resolved Location target, HTS_LOCATION_SIZE bytes */
   LLint totalsize;   /**< total size to download (-1=unknown) */
   short int is_file; /**< 1 if a file descriptor rather than a socket */
   T_SOC soc;         /**< socket id */
@@ -751,8 +751,7 @@ struct lien_back {
   char url_sav[HTS_URLMAXSIZE * 2];     /**< local save name (with any path) */
   char referer_adr[HTS_URLMAXSIZE * 2]; /**< referer page host/address */
   char referer_fil[HTS_URLMAXSIZE * 2]; /**< referer page file */
-  char
-      location_buffer[HTS_URLMAXSIZE * 2]; /**< Location on a move (302, ...) */
+  char location_buffer[HTS_LOCATION_SIZE]; /**< Location on a move (302, ...) */
   char *tmpfile; /**< temporary save name (compressed) */
   char tmpfile_buffer[HTS_URLMAXSIZE * 2]; /**< storage for tmpfile */
   char send_too[1024];    /**< data to send together with the header */

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -4452,7 +4452,7 @@ int hts_mirror_wait_for_next_file(htsmoduleStruct * str,
       memcpy(r, &(back[b].r), sizeof(htsblk));
       r->location = stre->loc_; // ne PAS copier location!! adresse, pas de buffer
       if (back[b].r.location)
-        strlcpybuff(r->location, back[b].r.location, HTS_URLMAXSIZE * 2);
+        strlcpybuff(r->location, back[b].r.location, HTS_LOCATION_SIZE);
       back[b].r.adr = NULL;     // ne pas faire de desalloc ensuite
 
       // libérer emplacement backing

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2414,12 +2414,15 @@ static int st_header(httrackp *opt, int argc, char **argv) {
 }
 
 /* A header line that does not fit must be reported as cut and skipped whole,
-   so the line after it is the server's next header and not its own tail. */
+   so the line after it is the server's next header and not its own tail. The
+   block defaults to two headers and the blank line; \n and \r arrive escaped,
+   since the command line filters both out. */
 static int st_headerline(httrackp *opt, int argc, char **argv) {
-  static const char block[] = "X-First: 0123456789abcdefghij\r\n"
-                              "X-Second: ok\r\n"
-                              "\r\n";
-  char line[64];
+  static const char fixture[] = "X-First: 0123456789abcdefghij\r\n"
+                                "X-Second: ok\r\n"
+                                "\r\n";
+  char block[256], line[64];
+  size_t blocklen;
   int max, ptr = 0, i;
 
   (void) opt;
@@ -2432,13 +2435,35 @@ static int st_headerline(httrackp *opt, int argc, char **argv) {
     fprintf(stderr, "headerline: read size out of probe range\n");
     return 1;
   }
-  for (i = 0; i < 3; i++) {
+  if (argc < 2) {
+    memcpy(block, fixture, sizeof(fixture));
+    blocklen = sizeof(fixture) - 1;
+  } else {
+    const char *a = argv[1];
+
+    if (strlen(a) >= sizeof(block)) {
+      fprintf(stderr, "headerline: block too long\n");
+      return 1;
+    }
+    for (blocklen = 0; *a != '\0'; a++) {
+      if (*a == '\\' && a[1] == 'n')
+        block[blocklen++] = '\n', a++;
+      else if (*a == '\\' && a[1] == 'r')
+        block[blocklen++] = '\r', a++;
+      else
+        block[blocklen++] = *a;
+    }
+    block[blocklen] = '\0';
+  }
+  /* one read past the block's lines, to show the walk stops at its end */
+  for (i = 0; i < 4; i++) {
     int adv;
     const hts_boolean cut =
-        binput_header(block + ptr, block + sizeof(block) - 1, line, max, &adv);
+        binput_header(block + ptr, block + blocklen, line, max, &adv);
 
     ptr += adv;
-    printf("cut=%d line=%s\n", cut != HTS_FALSE, line);
+    printf("cut=%d over=%d line=%s\n", cut != HTS_FALSE,
+           ptr > (int) blocklen + 1, line);
   }
   return 0;
 }

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2413,6 +2413,36 @@ static int st_header(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* A header line that does not fit must be reported as cut and skipped whole,
+   so the line after it is the server's next header and not its own tail. */
+static int st_headerline(httrackp *opt, int argc, char **argv) {
+  static const char block[] = "X-First: 0123456789abcdefghij\r\n"
+                              "X-Second: ok\r\n"
+                              "\r\n";
+  char line[64];
+  int max, ptr = 0, i;
+
+  (void) opt;
+  if (argc < 1) {
+    fprintf(stderr, "headerline: needs a read size\n");
+    return 1;
+  }
+  max = atoi(argv[0]);
+  if (max < 2 || (size_t) max > sizeof(line)) {
+    fprintf(stderr, "headerline: read size out of probe range\n");
+    return 1;
+  }
+  for (i = 0; i < 3; i++) {
+    int adv;
+    const hts_boolean cut =
+        binput_header(block + ptr, block + sizeof(block) - 1, line, max, &adv);
+
+    ptr += adv;
+    printf("cut=%d line=%s\n", cut != HTS_FALSE, line);
+  }
+  return 0;
+}
+
 static int st_location_logged = 0;
 
 static void st_location_log(httrackp *opt, int type, const char *format,
@@ -10377,6 +10407,9 @@ static const struct selftest_entry {
      st_headerlong},
     {"location", "<url-length>", "Location gate matches the buffer it protects",
      st_location},
+    {"headerline", "<read-size>",
+     "a header line that does not fit is reported and skipped whole",
+     st_headerline},
     {"crange", "<raw-content-range-line> ...",
      "Content-Range parse integer safety", st_crange},
     {"xfread-limit", "", "in-memory receive buffer size bound",

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2413,9 +2413,20 @@ static int st_header(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-/* treathead's Location gate must be the capacity of the buffer htsblk.location
-   aims at, so a redirect that fits is kept and one that does not is refused
-   without touching the canary sitting right behind it. */
+static int st_location_logged = 0;
+
+static void st_location_log(httrackp *opt, int type, const char *format,
+                            va_list args) {
+  (void) opt;
+  (void) type;
+  (void) format;
+  (void) args;
+  st_location_logged++;
+}
+
+/* treathead's Location gate must match htsblk.location's buffer size: a
+   redirect that fits is kept whole, a longer one refused and reported, and
+   neither touches the canary behind the buffer. */
 static int st_location(httrackp *opt, int argc, char **argv) {
   struct {
     char loc[HTS_LOCATION_SIZE];
@@ -2424,20 +2435,24 @@ static int st_location(httrackp *opt, int argc, char **argv) {
 
   char BIGSTK line[HTS_LOCATION_SIZE + 1024];
   const char *const prefix = "http://www.example.com/";
+  const char *url, *want;
   htsblk r;
-  size_t n, urllen, i;
-  int smashed = 0;
+  size_t n, urllen, kept, i;
+  int asked, smashed = 0;
 
   (void) opt;
   if (argc < 1) {
     fprintf(stderr, "location: needs a Location URL length\n");
     return 1;
   }
-  urllen = (size_t) atoi(argv[0]);
-  if (urllen <= strlen(prefix) || urllen + 16 > sizeof(line)) {
+  /* subtract, never add: a negative argument must not wrap the range check */
+  asked = atoi(argv[0]);
+  if (asked <= (int) strlen(prefix) ||
+      (size_t) asked > sizeof(line) - sizeof("Location: ")) {
     fprintf(stderr, "location: length out of probe range\n");
     return 1;
   }
+  urllen = (size_t) asked;
 
   memset(probe.loc, 0, sizeof(probe.loc));
   memset(probe.canary, '#', sizeof(probe.canary));
@@ -2447,14 +2462,25 @@ static int st_location(httrackp *opt, int argc, char **argv) {
   n = (size_t) snprintf(line, sizeof(line), "Location: %s", prefix);
   memset(line + n, 'a', urllen - strlen(prefix));
   line[n + urllen - strlen(prefix)] = '\0';
+  url = line + n - strlen(prefix);
+
+  st_location_logged = 0;
+  hts_set_log_vprint_callback(st_location_log);
   treathead(NULL, "www.example.com", "/", &r, line);
+  hts_set_log_vprint_callback(NULL);
 
   for (i = 0; i < sizeof(probe.canary); i++) {
     if (probe.canary[i] != '#')
       smashed++;
   }
-  printf("asked=%d kept=%d canary_smashed=%d\n", (int) urllen,
-         (int) strlen(probe.loc), smashed);
+  /* bounded: an unterminated buffer reports capacity, never reads past it */
+  for (kept = 0; kept < sizeof(probe.loc) && probe.loc[kept] != '\0'; kept++)
+    ;
+  /* the wanted value comes from the contract, not from what treathead did */
+  want = urllen < HTS_LOCATION_SIZE ? url : "";
+  printf("asked=%d kept=%d value_ok=%d canary_smashed=%d logged=%d\n", asked,
+         (int) kept, strcmp(probe.loc, want) == 0, smashed,
+         st_location_logged != 0);
   return 0;
 }
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2413,6 +2413,51 @@ static int st_header(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* treathead's Location gate must be the capacity of the buffer htsblk.location
+   aims at, so a redirect that fits is kept and one that does not is refused
+   without touching the canary sitting right behind it. */
+static int st_location(httrackp *opt, int argc, char **argv) {
+  struct {
+    char loc[HTS_LOCATION_SIZE];
+    char canary[64];
+  } probe;
+
+  char BIGSTK line[HTS_LOCATION_SIZE + 1024];
+  const char *const prefix = "http://www.example.com/";
+  htsblk r;
+  size_t n, urllen, i;
+  int smashed = 0;
+
+  (void) opt;
+  if (argc < 1) {
+    fprintf(stderr, "location: needs a Location URL length\n");
+    return 1;
+  }
+  urllen = (size_t) atoi(argv[0]);
+  if (urllen <= strlen(prefix) || urllen + 16 > sizeof(line)) {
+    fprintf(stderr, "location: length out of probe range\n");
+    return 1;
+  }
+
+  memset(probe.loc, 0, sizeof(probe.loc));
+  memset(probe.canary, '#', sizeof(probe.canary));
+  memset(&r, 0, sizeof(r));
+  r.location = probe.loc;
+
+  n = (size_t) snprintf(line, sizeof(line), "Location: %s", prefix);
+  memset(line + n, 'a', urllen - strlen(prefix));
+  line[n + urllen - strlen(prefix)] = '\0';
+  treathead(NULL, "www.example.com", "/", &r, line);
+
+  for (i = 0; i < sizeof(probe.canary); i++) {
+    if (probe.canary[i] != '#')
+      smashed++;
+  }
+  printf("asked=%d kept=%d canary_smashed=%d\n", (int) urllen,
+         (int) strlen(probe.loc), smashed);
+  return 0;
+}
+
 /* An over-long header value must not overflow treathead's tempo[1100]. */
 static int st_headerlong(httrackp *opt, int argc, char **argv) {
   htsblk r;
@@ -10304,6 +10349,8 @@ static const struct selftest_entry {
     {"headerlong", "[header-name:]",
      "over-long header value must not overflow the parse scratch",
      st_headerlong},
+    {"location", "<url-length>", "Location gate matches the buffer it protects",
+     st_location},
     {"crange", "<raw-content-range-line> ...",
      "Content-Range parse integer safety", st_crange},
     {"xfread-limit", "", "in-memory receive buffer size bound",

--- a/tests/311_engine-location-gate.test
+++ b/tests/311_engine-location-gate.test
@@ -44,13 +44,11 @@ refused 3000
 # than the tail of the one before. "over" says the cursor walked past the
 # block's end, which must never happen.
 line() { # line READSIZE BLOCK WANT
-    local got
     if [ -n "$2" ]; then
-        got=$(httrack -O /dev/null -#test=headerline "$1" "$2")
+        assert_selftest_lines "$3" headerline "$1" "$2"
     else
-        got=$(httrack -O /dev/null -#test=headerline "$1")
+        assert_selftest_lines "$3" headerline "$1"
     fi
-    assert_eq "$3" "$got" "read size $1"
 }
 
 # Default block: "X-First: 0123456789abcdefghij" is 29 bytes, then

--- a/tests/311_engine-location-gate.test
+++ b/tests/311_engine-location-gate.test
@@ -1,33 +1,39 @@
 #!/bin/bash
 #
+
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
 . "$(dirname "$0")/testlib.sh"
 
-# The Location gate must be the capacity of the buffer htsblk.location aims at
-# (HTS_LOCATION_SIZE, 2048), not half of it. Each case reports the length asked
-# for, the length kept, and whether the 64-byte non-zero canary behind that
-# buffer survived: a fix that simply dropped the bound smashes it at 2048.
-# The cache side of the same contract rides 01_zlib-cache.test, whose fixture
-# stores a redirect whose Location is at full capacity.
-loc() { # loc URLLEN KEPT
-    assert_selftest "asked=$1 kept=$2 canary_smashed=0" location "$1"
+# The Location gate must equal htsblk.location's buffer (HTS_LOCATION_SIZE,
+# 2048). Each case reports the length asked, the length kept, whether the value
+# matches what the contract says to keep, and whether the 64-byte canary behind
+# the buffer survived. Cache side: 01_zlib-cache.test.
+kept() { # kept URLLEN KEPTLEN
+    assert_selftest \
+        "asked=$1 kept=$2 value_ok=1 canary_smashed=0 logged=0" location "$1"
+}
+
+# Refused lengths must say so rather than drop the redirect mutely.
+refused() { # refused URLLEN
+    assert_selftest \
+        "asked=$1 kept=0 value_ok=1 canary_smashed=0 logged=1" location "$1"
 }
 
 # Well inside the old gate, and the last length it allowed.
-loc 500 500
-loc 1023 1023
+kept 500 500
+kept 1023 1023
 
 # The old gate refused these; they fit the buffer with room to spare.
-loc 1024 1024
-loc 1500 1500
+kept 1024 1024
+kept 1500 1500
 
 # The last length that fits, terminator included.
-loc 2046 2046
-loc 2047 2047
+kept 2046 2046
+kept 2047 2047
 
 # Past the buffer: still refused, and refusing leaves the value empty rather
 # than a truncated URL, which would be a valid-looking wrong target.
-loc 2048 0
-loc 3000 0
+refused 2048
+refused 3000

--- a/tests/311_engine-location-gate.test
+++ b/tests/311_engine-location-gate.test
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+# The Location gate must be the capacity of the buffer htsblk.location aims at
+# (HTS_LOCATION_SIZE, 2048), not half of it. Each case reports the length asked
+# for, the length kept, and whether the 64-byte non-zero canary behind that
+# buffer survived: a fix that simply dropped the bound smashes it at 2048.
+# The cache side of the same contract rides 01_zlib-cache.test, whose fixture
+# stores a redirect whose Location is at full capacity.
+loc() { # loc URLLEN KEPT
+    assert_selftest "asked=$1 kept=$2 canary_smashed=0" location "$1"
+}
+
+# Well inside the old gate, and the last length it allowed.
+loc 500 500
+loc 1023 1023
+
+# The old gate refused these; they fit the buffer with room to spare.
+loc 1024 1024
+loc 1500 1500
+
+# The last length that fits, terminator included.
+loc 2046 2046
+loc 2047 2047
+
+# Past the buffer: still refused, and refusing leaves the value empty rather
+# than a truncated URL, which would be a valid-looking wrong target.
+loc 2048 0
+loc 3000 0

--- a/tests/311_engine-location-gate.test
+++ b/tests/311_engine-location-gate.test
@@ -38,19 +38,55 @@ kept 2047 2047
 refused 2048
 refused 3000
 
-# A wider gate only helps if the reader stops handing it cut values. Both
-# header lines below are read at a size that is one byte short, then one byte
-# long; the line after a cut one must be the server's next header, never the
-# tail of the one before.
-line() { # line READSIZE WANT1 WANT2
+# A wider gate only helps if the reader stops handing it cut values. Each case
+# reads four lines from a header block and compares every one: a cut line must
+# be reported, and the line after it must be the server's next header rather
+# than the tail of the one before. "over" says the cursor walked past the
+# block's end, which must never happen.
+line() { # line READSIZE BLOCK WANT
     local got
-    got=$(httrack -O /dev/null -#test=headerline "$1")
-    assert_eq "$2" "$(sed -n 1p <<<"$got")" "read size $1, first line"
-    assert_eq "$3" "$(sed -n 2p <<<"$got")" "read size $1, second line"
+    if [ -n "$2" ]; then
+        got=$(httrack -O /dev/null -#test=headerline "$1" "$2")
+    else
+        got=$(httrack -O /dev/null -#test=headerline "$1")
+    fi
+    assert_eq "$3" "$got" "read size $1"
 }
 
-# "X-First: 0123456789abcdefghij" is 29 bytes, "X-Second: ok" is 12.
-line 30 'cut=0 line=X-First: 0123456789abcdefghij' 'cut=0 line=X-Second: ok'
-line 29 'cut=1 line=X-First: 0123456789abcdefghi' 'cut=0 line=X-Second: ok'
-line 13 'cut=1 line=X-First: 012' 'cut=0 line=X-Second: ok'
-line 12 'cut=1 line=X-First: 01' 'cut=1 line=X-Second: o'
+# Default block: "X-First: 0123456789abcdefghij" is 29 bytes, then
+# "X-Second: ok" at 12, then the blank line that ends the header.
+line 30 '' 'cut=0 over=0 line=X-First: 0123456789abcdefghij
+cut=0 over=0 line=X-Second: ok
+cut=0 over=0 line=
+cut=0 over=0 line='
+
+# One byte short of the first line, then far short of it: the second line
+# survives whole either way.
+line 29 '' 'cut=1 over=0 line=X-First: 0123456789abcdefghi
+cut=0 over=0 line=X-Second: ok
+cut=0 over=0 line=
+cut=0 over=0 line='
+line 13 '' 'cut=1 over=0 line=X-First: 012
+cut=0 over=0 line=X-Second: ok
+cut=0 over=0 line=
+cut=0 over=0 line='
+line 12 '' 'cut=1 over=0 line=X-First: 01
+cut=1 over=0 line=X-Second: o
+cut=0 over=0 line=
+cut=0 over=0 line='
+
+# A last line with no terminator ends at the block, not past it.
+line 8 'A: 1\nB: 22222222' 'cut=0 over=0 line=A: 1
+cut=1 over=0 line=B: 2222
+cut=0 over=0 line=
+cut=0 over=0 line='
+
+# A leading blank line is a line, and CR never survives into the value.
+line 8 '\nA: 1\n' 'cut=0 over=0 line=
+cut=0 over=0 line=A: 1
+cut=0 over=0 line=
+cut=0 over=0 line='
+line 8 'A\r: 1\n' 'cut=0 over=0 line=A: 1
+cut=0 over=0 line=
+cut=0 over=0 line=
+cut=0 over=0 line='

--- a/tests/311_engine-location-gate.test
+++ b/tests/311_engine-location-gate.test
@@ -37,3 +37,20 @@ kept 2047 2047
 # than a truncated URL, which would be a valid-looking wrong target.
 refused 2048
 refused 3000
+
+# A wider gate only helps if the reader stops handing it cut values. Both
+# header lines below are read at a size that is one byte short, then one byte
+# long; the line after a cut one must be the server's next header, never the
+# tail of the one before.
+line() { # line READSIZE WANT1 WANT2
+    local got
+    got=$(httrack -O /dev/null -#test=headerline "$1")
+    assert_eq "$2" "$(sed -n 1p <<<"$got")" "read size $1, first line"
+    assert_eq "$3" "$(sed -n 2p <<<"$got")" "read size $1, second line"
+}
+
+# "X-First: 0123456789abcdefghij" is 29 bytes, "X-Second: ok" is 12.
+line 30 'cut=0 line=X-First: 0123456789abcdefghij' 'cut=0 line=X-Second: ok'
+line 29 'cut=1 line=X-First: 0123456789abcdefghi' 'cut=0 line=X-Second: ok'
+line 13 'cut=1 line=X-First: 012' 'cut=0 line=X-Second: ok'
+line 12 'cut=1 line=X-First: 01' 'cut=1 line=X-Second: o'

--- a/tests/312_local-location-toolong.test
+++ b/tests/312_local-location-toolong.test
@@ -1,0 +1,14 @@
+#!/bin/bash
+# A Location past the header-line read buffer reaches the engine already cut,
+# so the redirect must be dropped rather than followed to a target the server
+# never named (#1291). Only the page that links the redirect is mirrored: a
+# second file means the cut target was fetched.
+set -e
+
+: "${top_srcdir:=..}"
+
+bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
+    --files 1 \
+    --found 'longloc/index.html' \
+    --log-found 'Over-long header dropped' \
+    httrack 'BASEURL/longloc/index.html'

--- a/tests/312_local-location-toolong.test
+++ b/tests/312_local-location-toolong.test
@@ -10,5 +10,13 @@ set -e
 bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
     --files 1 \
     --found 'longloc/index.html' \
-    --log-found 'Over-long header dropped' \
+    --log-found 'Over-long header dropped for .*/longloc/go\.php' \
     httrack 'BASEURL/longloc/index.html'
+
+# Control: the same shape with a Location the reader takes whole is followed
+# to its target, so the refusal above is the header length and not the fixture.
+bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
+    --files 2 \
+    --found 'shortloc/index.html' \
+    --log-not-found 'Over-long header dropped' \
+    httrack 'BASEURL/shortloc/index.html'

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1965,6 +1965,21 @@ class Handler(SimpleHTTPRequestHandler):
     def route_longloc_target(self):
         self.send_raw(b"<html><body>long-location target</body></html>\n", "text/html")
 
+    # same shape with a Location the reader takes whole: the control proving
+    # the fixture only refuses because the header outran the read
+    def route_shortloc_index(self):
+        self.send_html('\t<a href="go.php">go</a>')
+
+    def route_shortloc_go(self):
+        base = "http://127.0.0.1:%d/shortloc/" % self.server.server_address[1]
+        self.send_response(302, "Found")
+        self.send_header("Location", base + "target.html?q=" + "a" * 40)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def route_shortloc_target(self):
+        self.send_raw(b"<html><body>short-location target</body></html>\n", "text/html")
+
     # --- /mini304/: tiny fully-cacheable site (an update gets only 304s) ---
     def route_mini304_index(self):
         self.big_send(
@@ -2755,6 +2770,9 @@ class Handler(SimpleHTTPRequestHandler):
         "/longloc/index.html": route_longloc_index,
         "/longloc/go.php": route_longloc_go,
         "/longloc/target.html": route_longloc_target,
+        "/shortloc/index.html": route_shortloc_index,
+        "/shortloc/go.php": route_shortloc_go,
+        "/shortloc/target.html": route_shortloc_target,
         "/bakname/index.html": route_bakname_index,
         "/bakname/a.bin": route_bakname_main,
         "/bakname/hts-tmp/a.bin.bak": route_bakname_sibling,

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1947,6 +1947,24 @@ class Handler(SimpleHTTPRequestHandler):
     def route_redir_target(self):
         self.send_raw(b"<html><body>redirect target</body></html>\n", "text/html")
 
+    # A Location past the header-line read buffer (#1291): the engine only ever
+    # sees a cut value, so it must drop the header rather than follow a target
+    # this server never named.
+    def route_longloc_index(self):
+        self.send_html('\t<a href="go.php">go</a>')
+
+    def route_longloc_go(self):
+        # absolute: a relative target is capped at HTS_URLMAXSIZE by
+        # ident_url_relatif long before the gate under test sees it
+        base = "http://127.0.0.1:%d/longloc/" % self.server.server_address[1]
+        self.send_response(302, "Found")
+        self.send_header("Location", base + "target.html?q=" + "a" * 2400)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def route_longloc_target(self):
+        self.send_raw(b"<html><body>long-location target</body></html>\n", "text/html")
+
     # --- /mini304/: tiny fully-cacheable site (an update gets only 304s) ---
     def route_mini304_index(self):
         self.big_send(
@@ -2734,6 +2752,9 @@ class Handler(SimpleHTTPRequestHandler):
         "/redir/index.html": route_redir_index,
         "/redir/go.php": route_redir_go,
         "/redir/target.html": route_redir_target,
+        "/longloc/index.html": route_longloc_index,
+        "/longloc/go.php": route_longloc_go,
+        "/longloc/target.html": route_longloc_target,
         "/bakname/index.html": route_bakname_index,
         "/bakname/a.bin": route_bakname_main,
         "/bakname/hts-tmp/a.bin.bak": route_bakname_sibling,

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -56,6 +56,19 @@ assert_selftest() { # assert_selftest WANT NAME [ARGS...]
     test "$got" = "$want" || fail "-#test=$name $*: expected [$want], got [$got]"
 }
 
+# assert_selftest for output spanning several lines: Windows stdout is text
+# mode, so every interior newline arrives as CRLF and a byte-exact compare
+# rejects it. Only the CR before a newline goes, or a test asserting the engine
+# drops an interior CR would pass whatever the engine did.
+assert_selftest_lines() { # assert_selftest_lines WANT NAME [ARGS...]
+    local want=$1 name=$2 got rc=0
+    shift 2
+    got=$(httrack -O /dev/null "-#test=$name" "$@") || rc=$?
+    test "$rc" -eq 0 || fail "-#test=$name $*: exited $rc, output: $got"
+    got=$(printf '%s\n' "$got" | sed $'s/\r$//')
+    test "$got" = "$want" || fail "-#test=$name $*: expected [$want], got [$got]"
+}
+
 # Absolute path to httrack, since make check's relative ../src breaks once a test
 # cd's away. assert_selftest runs the bare name, so a test that cd's calls this.
 httrack_path() {


### PR DESCRIPTION
`treathead()` gated the `Location:` header at `HTS_URLMAXSIZE` while copying it into a buffer twice that size. A redirect between 1024 and 2047 bytes fit the copy but was thrown away anyway, and silently: the engine saw a 3xx carrying no target and logged it as a loop. The gate, the copy and every buffer `htsblk.location` is aimed at now derive from one named constant, `HTS_LOCATION_SIZE`, instead of two literals that had already drifted apart once.

Widening it alone would have been wrong, and not for the reason a bounds map finds. `binput()` and `finput()` stop at the size they are given and leave the rest of the line to be read back as further headers, so a Location past about 1990 bytes reaches `treathead()` already cut. Master's undersized gate rejected those cut values by accident; with the gate at the buffer's real size they would pass, and the engine would follow a target the server never named. Against a server sending a 2500-byte Location, master refuses the redirect and the branch as first written followed a 1965-byte one. So `binput_header()` and `finput_header()` consume the whole line either way and report whether it fitted, and the three readers that feed `treathead()` drop a line that did not. The remaining `binput()` callers, in the cache, robots, FTP and auth parsers, keep the old behaviour; deciding what an over-long line should mean for all of them is #1294.

The rest of the downstream is clear. `url_savename()` clamps its result to `HTS_SAVE_BUFSIZE - HTS_PATH_TAIL_RESERVE`, so a long redirect target cannot feed the unbounded appender behind #1269; 73 ASan crawls over five URL shapes and every length from 1024 to 2047 peak at 1993 bytes of `save` against a 2048-byte buffer. Two cache-side bounds did have to move with the gate: `cache_mayadd()` records `"<code>\n<location>"` for a save-less 3xx in a scratch buffer that was exactly the location's own size, so a full-width value aborted the mirror, and the cached-header re-reader parsed each stored line through a `HTS_URLMAXSIZE` buffer, cutting a long `Location:` into a shorter URL that looks perfectly valid. That truncation is reachable on master today, in the 1014 to 1023 window the old gate still admitted.

`-#test=location` puts a 64-byte non-zero canary behind the destination, checks the kept bytes against what the contract says to keep rather than against a length, and reports whether the refusal reached the log; `-#test=headerline` pins that the line after a cut one is the server's next header and not its own tail. 311 drives both, 312 crawls a server whose redirect outruns the reader and asserts nothing behind it is fetched, against a control whose Location fits and is followed, and the cache fixture now carries a full-capacity Location with a new pass driving `cache_mayadd()`. Between them they kill an off-by-one `<=`, a bound removed outright, a clip in place of the refusal, a copy of the right length carrying the wrong bytes, a refusal that says nothing, a truncation never reported, and a caller that logs the cut header and parses it anyway.

Closes #1291