### PR TITLE
A robots.txt whose rules run past 4 KB is dropped without a word

### DIFF
--- a/fuzz/fuzz-htsparse.c
+++ b/fuzz/fuzz-htsparse.c
@@ -82,8 +82,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   cache.cached_tests = coucal_new(0);
   coucal_value_is_malloc(cache.cached_tests, 1);
 
-  memset(&robots, 0, sizeof(robots));
-  strcpybuff(robots.adr, "!");
+  memset(&robots, 0, sizeof(robots)); /* list head: no host, no rules */
   opt->robotsptr = &robots;
 
   opt->maxfilter = maximum(opt->maxfilter, 128);

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -511,6 +511,11 @@ int httpmirror(char *url1, httrackp * opt) {
   //
   cookie.auth.next = NULL;
   cookie.auth.auth[0] = cookie.auth.prefix[0] = '\0';
+  /* Before the first XH_extuninit, whose checkrobots_free() frees these. */
+  robots.adr = NULL; // list head, holds no rules
+  robots.token = NULL;
+  robots.next = NULL;
+  opt->robotsptr = &robots;
   //
 
   // noter heure actuelle de départ en secondes
@@ -594,12 +599,6 @@ int httpmirror(char *url1, httrackp * opt) {
   coucal_value_is_malloc(cache_tests, 1);      /* malloc */
   cache.hashtable = (void *) cache_hashtable;   /* copy backcache hash */
   cache.cached_tests = (void *) cache_tests;    /* copy of cache_tests */
-
-  // robots.txt
-  robots.adr = NULL; // list head, holds no rules
-  robots.token = NULL;
-  robots.next = NULL;
-  opt->robotsptr = &robots;
 
   // effacer filters
   opt->maxfilter = maximum(opt->maxfilter, 128);

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -596,9 +596,9 @@ int httpmirror(char *url1, httrackp * opt) {
   cache.cached_tests = (void *) cache_tests;    /* copy of cache_tests */
 
   // robots.txt
-  strcpybuff(robots.adr, "!");  // dummy
-  robots.token[0] = '\0';
-  robots.next = NULL;           // suivant
+  robots.adr = NULL; // list head, holds no rules
+  robots.token = NULL;
+  robots.next = NULL;
   opt->robotsptr = &robots;
 
   // effacer filters
@@ -1768,7 +1768,7 @@ int httpmirror(char *url1, httrackp * opt) {
               hts_boolean keep_root = HTS_TRUE;
 #endif
 
-              robots_parse(&robots, urladr(), r.adr, r.size, infobuff,
+              robots_parse(opt, &robots, urladr(), r.adr, r.size, infobuff,
                            sizeof(infobuff), keep_root, sitemaps,
                            sizeof(sitemaps));
               if (strnotempty(infobuff)) {

--- a/src/htsrobots.c
+++ b/src/htsrobots.c
@@ -88,7 +88,7 @@ static hts_boolean robots_pattern_match(const char *pattern, const char *path) {
 }
 
 /* fil="": is a rule set already recorded for this host? */
-int checkrobots(robots_wizard * robots, const char *adr, const char *fil) {
+int checkrobots(const robots_wizard *robots, const char *adr, const char *fil) {
   while(robots) {
     if (robots->adr != NULL && strfield2(robots->adr, adr)) {
       if (fil[0]) {
@@ -153,9 +153,8 @@ void robots_parse(httrackp *opt, robots_wizard *robots, const char *adr,
   int ndropped = 0;
   char BIGSTK line[HTS_ROBOTS_LINE_SIZE];
   char dropped[128]; // first rule we could not honour, for the log
-  String blob;
+  String blob = STRING_EMPTY;
 
-  StringInit(blob);
   dropped[0] = '\0';
   if (info != NULL && infosize > 0)
     info[0] = '\0';
@@ -170,18 +169,22 @@ void robots_parse(httrackp *opt, robots_wizard *robots, const char *adr,
     hts_boolean cut;
 
     bptr += binput(body + bptr, line, sizeof(line) - 2);
-    // binput stops at the limit and resumes mid-line, so a cut value is silent
-    cut = (strlen(line) >= sizeof(line) - 2) ? HTS_TRUE : HTS_FALSE;
+    /* binput consumed body[bptr-1] and resumes mid-record when the buffer runs
+       out, so a record read whole is the one ending on its own newline. */
+    cut = (bptr - 1 < bodysize && body[bptr - 1] != '\n' &&
+           body[bptr - 1] != '\0')
+              ? HTS_TRUE
+              : HTS_FALSE;
     comm = strchr(line, '#'); // strip comment
-    if (comm != NULL)
+    if (comm != NULL) {
       *comm = '\0';
+      cut = HTS_FALSE; // the comment ended the value inside the buffer
+    }
     llen = (int) strlen(line); // strip trailing spaces
     while (llen > 0 && is_realspace(line[llen - 1])) {
       line[llen - 1] = '\0';
       llen--;
     }
-    if (llen < (int) sizeof(line) - 2)
-      cut = HTS_FALSE; // a comment or a space ended the value before the limit
     if (sitemaps != NULL && strfield(line, "sitemap:")) {
       // group-independent record (RFC 9309): collected whatever the group
       char *a = line + 8;
@@ -225,9 +228,8 @@ void robots_parse(httrackp *opt, robots_wizard *robots, const char *adr,
           if (is_disallow && !keep_root_disallow && strcmp(a, "/") == 0) {
             // dropped: site-wide disallow ignored by option
           } else {
-            /* A cut Allow is a shorter prefix, so it would permit more than
-               the site wrote; a cut Disallow can only forbid more, so it stays.
-               Neither is the rule as written. */
+            /* A cut Allow would permit more than the site wrote, so it goes;
+               a cut Disallow can only forbid more, so it stays. */
             const hts_boolean kept =
                 (cut && is_allow)
                     ? HTS_FALSE

--- a/src/htsrobots.c
+++ b/src/htsrobots.c
@@ -195,8 +195,7 @@ void robots_parse(httrackp *opt, robots_wizard *robots, const char *adr,
     hts_boolean cut;
 
     bptr += binput(body + bptr, line, sizeof(line) - 2);
-    /* binput stops at the limit and resumes mid-line, so what follows is the
-       tail of this record and not a record of its own. */
+    // binput stops at the limit and resumes mid-line, so a cut value is silent
     cut = (strlen(line) >= sizeof(line) - 2) ? HTS_TRUE : HTS_FALSE;
     comm = strchr(line, '#'); // strip comment
     if (comm != NULL)
@@ -253,9 +252,9 @@ void robots_parse(httrackp *opt, robots_wizard *robots, const char *adr,
           if (is_disallow && !keep_root_disallow && strcmp(a, "/") == 0) {
             // dropped: site-wide disallow ignored by option
           } else {
-            /* An Allow cut short by the line buffer is a shorter prefix, so it
-               would permit more than the site wrote; a Disallow prefix can only
-               forbid more, and is kept. Neither is the rule as written. */
+            /* A cut Allow is a shorter prefix, so it would permit more than
+               the site wrote; a cut Disallow can only forbid more, so it stays.
+               Neither is the rule as written. */
             const hts_boolean kept =
                 (cut && is_allow)
                     ? HTS_FALSE
@@ -292,7 +291,7 @@ void robots_parse(httrackp *opt, robots_wizard *robots, const char *adr,
 
 int checkrobots_set(robots_wizard *robots, const char *adr, const char *data) {
   while(robots) {
-    if (robots->adr != NULL && strfield2(robots->adr, adr)) { // entry exists
+    if (robots->adr != NULL && strfield2(robots->adr, adr)) {
       char *const token = strdupt(data);
 
       if (token == NULL)

--- a/src/htsrobots.c
+++ b/src/htsrobots.c
@@ -131,39 +131,16 @@ int checkrobots(robots_wizard * robots, const char *adr, const char *fil) {
   return 0;
 }
 
-/* Rule blob under construction: grown to what the site wrote, up to the cap. */
-typedef struct {
-  char *data;
-  size_t len;
-  size_t capa;
-} robots_blob;
-
-/* Append "<marker><pattern>\n"; HTS_FALSE when the cap or the heap says no. */
-static hts_boolean robots_blob_add(robots_blob *blob, char marker,
-                                   const char *pat) {
+/* Append "<marker><pattern>\n" to the rule blob; HTS_FALSE past the cap. */
+static hts_boolean robots_rule_add(String *blob, char marker, const char *pat) {
   const size_t patlen = strlen(pat);
-  const size_t need = patlen + 2; // marker + '\n'
 
-  // overflow-safe: len <= HTS_ROBOTS_MAX_TOKEN_SIZE
-  if (need > HTS_ROBOTS_MAX_TOKEN_SIZE - blob->len)
+  // overflow-safe: the blob never passes the cap
+  if (patlen + 2 > HTS_ROBOTS_MAX_TOKEN_SIZE - StringLength(*blob))
     return HTS_FALSE;
-  if (need + 1 > blob->capa - blob->len) {
-    size_t capa = blob->capa != 0 ? blob->capa : 512;
-    char *data;
-
-    while (need + 1 > capa - blob->len)
-      capa *= 2;
-    data = (char *) realloct(blob->data, capa);
-    if (data == NULL)
-      return HTS_FALSE;
-    blob->data = data;
-    blob->capa = capa;
-  }
-  blob->data[blob->len++] = marker;
-  memcpy(blob->data + blob->len, pat, patlen);
-  blob->len += patlen;
-  blob->data[blob->len++] = '\n';
-  blob->data[blob->len] = '\0';
+  StringMemcat(*blob, &marker, 1);
+  StringMemcat(*blob, pat, patlen);
+  StringMemcat(*blob, "\n", 1);
   return HTS_TRUE;
 }
 
@@ -176,11 +153,9 @@ void robots_parse(httrackp *opt, robots_wizard *robots, const char *adr,
   int ndropped = 0;
   char BIGSTK line[HTS_ROBOTS_LINE_SIZE];
   char dropped[128]; // first rule we could not honour, for the log
-  robots_blob blob;
+  String blob;
 
-  blob.data = NULL;
-  blob.len = 0;
-  blob.capa = 0;
+  StringInit(blob);
   dropped[0] = '\0';
   if (info != NULL && infosize > 0)
     info[0] = '\0';
@@ -229,9 +204,7 @@ void robots_parse(httrackp *opt, robots_wizard *robots, const char *adr,
           record = 1; // generic group applies to us
       } else if (strfield(a, "httrack") || strfield(a, "winhttrack") ||
                  strfield(a, "webhttrack")) {
-        blob.len = 0; // explicit group: restart capture
-        if (blob.data != NULL)
-          blob.data[0] = '\0';
+        StringClear(blob); // explicit group: restart capture
         ndropped = 0;
         dropped[0] = '\0';
         if (info != NULL && infosize > 0)
@@ -258,7 +231,7 @@ void robots_parse(httrackp *opt, robots_wizard *robots, const char *adr,
             const hts_boolean kept =
                 (cut && is_allow)
                     ? HTS_FALSE
-                    : robots_blob_add(&blob, is_allow ? 'A' : 'D', a);
+                    : robots_rule_add(&blob, is_allow ? 'A' : 'D', a);
 
             if (!kept || cut) {
               if (ndropped++ == 0) {
@@ -284,9 +257,9 @@ void robots_parse(httrackp *opt, robots_wizard *robots, const char *adr,
                   "starting with '%s' (rules kept up to %d bytes, lines to %d)",
                   adr, ndropped, dropped, (int) HTS_ROBOTS_MAX_TOKEN_SIZE,
                   (int) HTS_ROBOTS_LINE_SIZE);
-  if (blob.len != 0)
-    checkrobots_set(robots, adr, blob.data);
-  freet(blob.data);
+  if (StringNotEmpty(blob))
+    checkrobots_set(robots, adr, StringBuff(blob));
+  StringFree(blob);
 }
 
 int checkrobots_set(robots_wizard *robots, const char *adr, const char *data) {

--- a/src/htsrobots.c
+++ b/src/htsrobots.c
@@ -87,15 +87,15 @@ static hts_boolean robots_pattern_match(const char *pattern, const char *path) {
   return (p == pend) ? HTS_TRUE : HTS_FALSE;
 }
 
-// fil="" : vérifier si règle déja enregistrée
+/* fil="": is a rule set already recorded for this host? */
 int checkrobots(robots_wizard * robots, const char *adr, const char *fil) {
   while(robots) {
-    if (strfield2(robots->adr, adr)) {
+    if (robots->adr != NULL && strfield2(robots->adr, adr)) {
       if (fil[0]) {
         /* RFC 9309: longest pattern wins, Allow beats Disallow on ties. */
         int ptr = 0;
-        char line[HTS_ROBOTS_TOKEN_SIZE];
-        size_t toklen = strlen(robots->token);
+        char line[HTS_ROBOTS_LINE_SIZE + 2];
+        size_t toklen = robots->token != NULL ? strlen(robots->token) : 0;
         size_t best_len = 0;
         hts_boolean matched = HTS_FALSE;
         hts_boolean best_allow = HTS_FALSE;
@@ -131,30 +131,57 @@ int checkrobots(robots_wizard * robots, const char *adr, const char *fil) {
   return 0;
 }
 
-/* Append "<marker><pattern>\n" to the bounded rule blob if it fits. */
-static void robots_blob_add(char *blob, size_t blobsize, char marker,
-                            const char *pat) {
-  const size_t used = strlen(blob);
-  const size_t need = strlen(pat) + 2; // marker + '\n'
+/* Rule blob under construction: grown to what the site wrote, up to the cap. */
+typedef struct {
+  char *data;
+  size_t len;
+  size_t capa;
+} robots_blob;
 
-  if (need < blobsize - used) { // overflow-safe: used <= blobsize-1
-    blob[used] = marker;
-    blob[used + 1] = '\0';
-    strlcatbuff(blob, pat, blobsize);
-    strlcatbuff(blob, "\n", blobsize);
+/* Append "<marker><pattern>\n"; HTS_FALSE when the cap or the heap says no. */
+static hts_boolean robots_blob_add(robots_blob *blob, char marker,
+                                   const char *pat) {
+  const size_t patlen = strlen(pat);
+  const size_t need = patlen + 2; // marker + '\n'
+
+  // overflow-safe: len <= HTS_ROBOTS_MAX_TOKEN_SIZE
+  if (need > HTS_ROBOTS_MAX_TOKEN_SIZE - blob->len)
+    return HTS_FALSE;
+  if (need + 1 > blob->capa - blob->len) {
+    size_t capa = blob->capa != 0 ? blob->capa : 512;
+    char *data;
+
+    while (need + 1 > capa - blob->len)
+      capa *= 2;
+    data = (char *) realloct(blob->data, capa);
+    if (data == NULL)
+      return HTS_FALSE;
+    blob->data = data;
+    blob->capa = capa;
   }
+  blob->data[blob->len++] = marker;
+  memcpy(blob->data + blob->len, pat, patlen);
+  blob->len += patlen;
+  blob->data[blob->len++] = '\n';
+  blob->data[blob->len] = '\0';
+  return HTS_TRUE;
 }
 
-void robots_parse(robots_wizard *robots, const char *adr, const char *body,
-                  size_t bodysize, char *info, size_t infosize,
-                  hts_boolean keep_root_disallow, char *sitemaps,
-                  size_t sitemapsize) {
+void robots_parse(httrackp *opt, robots_wizard *robots, const char *adr,
+                  const char *body, size_t bodysize, char *info,
+                  size_t infosize, hts_boolean keep_root_disallow,
+                  char *sitemaps, size_t sitemapsize) {
   size_t bptr = 0;
   int record = 0;
-  char BIGSTK line[1024];
-  char BIGSTK blob[HTS_ROBOTS_TOKEN_SIZE];
+  int ndropped = 0;
+  char BIGSTK line[HTS_ROBOTS_LINE_SIZE];
+  char dropped[128]; // first rule we could not honour, for the log
+  robots_blob blob;
 
-  blob[0] = '\0';
+  blob.data = NULL;
+  blob.len = 0;
+  blob.capa = 0;
+  dropped[0] = '\0';
   if (info != NULL && infosize > 0)
     info[0] = '\0';
   if (sitemaps != NULL && sitemapsize > 0)
@@ -165,8 +192,12 @@ void robots_parse(robots_wizard *robots, const char *adr, const char *body,
   while (bptr < bodysize) {
     char *comm;
     int llen;
+    hts_boolean cut;
 
     bptr += binput(body + bptr, line, sizeof(line) - 2);
+    /* binput stops at the limit and resumes mid-line, so what follows is the
+       tail of this record and not a record of its own. */
+    cut = (strlen(line) >= sizeof(line) - 2) ? HTS_TRUE : HTS_FALSE;
     comm = strchr(line, '#'); // strip comment
     if (comm != NULL)
       *comm = '\0';
@@ -175,6 +206,8 @@ void robots_parse(robots_wizard *robots, const char *adr, const char *body,
       line[llen - 1] = '\0';
       llen--;
     }
+    if (llen < (int) sizeof(line) - 2)
+      cut = HTS_FALSE; // a comment or a space ended the value before the limit
     if (sitemaps != NULL && strfield(line, "sitemap:")) {
       // group-independent record (RFC 9309): collected whatever the group
       char *a = line + 8;
@@ -182,7 +215,7 @@ void robots_parse(robots_wizard *robots, const char *adr, const char *body,
       while (is_realspace(*a))
         a++;
       /* A line at the buffer limit was truncated: a half URL is not one. */
-      if (strnotempty(a) && strlen(line) < sizeof(line) - 3 &&
+      if (strnotempty(a) && !cut &&
           strlen(a) + 2 < sitemapsize - strlen(sitemaps)) {
         strlcatbuff(sitemaps, a, sitemapsize);
         strlcatbuff(sitemaps, "\n", sitemapsize);
@@ -197,7 +230,11 @@ void robots_parse(robots_wizard *robots, const char *adr, const char *body,
           record = 1; // generic group applies to us
       } else if (strfield(a, "httrack") || strfield(a, "winhttrack") ||
                  strfield(a, "webhttrack")) {
-        blob[0] = '\0'; // explicit group: restart capture
+        blob.len = 0; // explicit group: restart capture
+        if (blob.data != NULL)
+          blob.data[0] = '\0';
+        ndropped = 0;
+        dropped[0] = '\0';
         if (info != NULL && infosize > 0)
           info[0] = '\0';
         record = 2; // locked to the httrack group
@@ -216,8 +253,22 @@ void robots_parse(robots_wizard *robots, const char *adr, const char *body,
           if (is_disallow && !keep_root_disallow && strcmp(a, "/") == 0) {
             // dropped: site-wide disallow ignored by option
           } else {
-            robots_blob_add(blob, sizeof(blob), is_allow ? 'A' : 'D', a);
-            if (is_disallow && info != NULL &&
+            /* An Allow cut short by the line buffer is a shorter prefix, so it
+               would permit more than the site wrote; a Disallow prefix can only
+               forbid more, and is kept. Neither is the rule as written. */
+            const hts_boolean kept =
+                (cut && is_allow)
+                    ? HTS_FALSE
+                    : robots_blob_add(&blob, is_allow ? 'A' : 'D', a);
+
+            if (!kept || cut) {
+              if (ndropped++ == 0) {
+                dropped[0] = '\0'; // clip, never abort: this is remote data
+                strlncatbuff(dropped, a, sizeof(dropped), sizeof(dropped) - 1);
+              }
+            }
+            /* info reports what we honour, not what we read. */
+            if (kept && is_disallow && info != NULL &&
                 strlen(a) + 2 < infosize - strlen(info)) {
               if (strnotempty(info))
                 strlcatbuff(info, ", ", infosize);
@@ -228,36 +279,48 @@ void robots_parse(robots_wizard *robots, const char *adr, const char *body,
       }
     }
   }
-  if (strnotempty(blob))
-    checkrobots_set(robots, adr, blob);
+  if (ndropped != 0)
+    hts_log_print(opt, LOG_WARNING,
+                  "robots.txt for %s: %d rule(s) not honoured as written, "
+                  "starting with '%s' (rules kept up to %d bytes, lines to %d)",
+                  adr, ndropped, dropped, (int) HTS_ROBOTS_MAX_TOKEN_SIZE,
+                  (int) HTS_ROBOTS_LINE_SIZE);
+  if (blob.len != 0)
+    checkrobots_set(robots, adr, blob.data);
+  freet(blob.data);
 }
 
-int checkrobots_set(robots_wizard * robots, const char *adr, const char *data) {
-  if (((int) strlen(adr)) >= sizeof(robots->adr) - 2)
-    return 0;
-  if (((int) strlen(data)) >= sizeof(robots->token) - 2)
-    return 0;
+int checkrobots_set(robots_wizard *robots, const char *adr, const char *data) {
   while(robots) {
-    if (strfield2(robots->adr, adr)) {  // entrée existe
-      strcpybuff(robots->token, data);
+    if (robots->adr != NULL && strfield2(robots->adr, adr)) { // entry exists
+      char *const token = strdupt(data);
+
+      if (token == NULL)
+        return 0;
+      freet(robots->token);
+      robots->token = token;
 #if DEBUG_ROBOTS
       printf("robots.txt: set %s to %s\n", adr, data);
 #endif
       return -1;
     } else if (!robots->next) {
-      robots->next = (robots_wizard *) calloct(1, sizeof(robots_wizard));
-      if (robots->next) {
-        robots->next->next = NULL;
-        strcpybuff(robots->next->adr, adr);
-        strcpybuff(robots->next->token, data);
-#if DEBUG_ROBOTS
-        printf("robots.txt: new set %s to %s\n", adr, data);
-#endif
+      robots_wizard *node = (robots_wizard *) calloct(1, sizeof(robots_wizard));
+
+      if (node == NULL)
+        return 0;
+      node->adr = strdupt(adr);
+      node->token = strdupt(data);
+      if (node->adr == NULL || node->token == NULL) {
+        freet(node->adr);
+        freet(node->token);
+        freet(node);
+        return 0;
       }
+      robots->next = node;
 #if DEBUG_ROBOTS
-      else
-        printf("malloc error!!\n");
+      printf("robots.txt: new set %s to %s\n", adr, data);
 #endif
+      return -1;
     }
     robots = robots->next;
   }
@@ -269,6 +332,8 @@ void checkrobots_free(robots_wizard * robots) {
     freet(robots->next);
     robots->next = NULL;
   }
+  freet(robots->adr);
+  freet(robots->token);
 }
 
 // -- robots --

--- a/src/htsrobots.h
+++ b/src/htsrobots.h
@@ -40,12 +40,21 @@ Please visit our Website: http://www.httrack.com
 typedef struct robots_wizard robots_wizard;
 #endif
 
-/* Per-host blob: one rule per line, first byte 'A'/'D' then path pattern. */
-#define HTS_ROBOTS_TOKEN_SIZE 4096
+#ifndef HTS_DEF_FWSTRUCT_httrackp
+#define HTS_DEF_FWSTRUCT_httrackp
+typedef struct httrackp httrackp;
+#endif
+
+/* Rule blob ceiling. RFC 9309 §2.5 asks crawlers to honour at least the first
+   500 kiB of a robots.txt, and the blob only ever holds part of that file. */
+#define HTS_ROBOTS_MAX_TOKEN_SIZE (500 * 1024)
+
+/* Longest robots.txt line read; a stored rule is marker + pattern + LF. */
+#define HTS_ROBOTS_LINE_SIZE 1024
 
 struct robots_wizard {
-  char adr[128];
-  char token[HTS_ROBOTS_TOKEN_SIZE];
+  char *adr;   /* host; NULL on the list head, which holds no rules */
+  char *token; /* per-host blob, one rule per line: 'A'/'D' then the pattern */
   struct robots_wizard *next;
 };
 
@@ -53,15 +62,20 @@ struct robots_wizard {
 #ifdef HTS_INTERNAL_BYTECODE
 /* -1 if `fil` disallowed for `adr` (RFC 9309); empty: -1 if rules exist. */
 int checkrobots(robots_wizard * robots, const char *adr, const char *fil);
+/* Release every node's strings and the chain below `robots`, head excepted. */
 void checkrobots_free(robots_wizard * robots);
+/* Store `data` as the rule blob of `adr`, adding the host if new. -1 on
+   success, 0 if the allocation failed. */
 int checkrobots_set(robots_wizard * robots, const char *adr, const char *data);
 /* Parse robots.txt `body` for `adr`, storing the HTTrack group's rules; `info`
-   gets a disallow summary, `keep_root_disallow` FALSE drops "Disallow: /", and
-   `sitemaps` (optional) collects the Sitemap: URLs, one per line. */
-void robots_parse(robots_wizard *robots, const char *adr, const char *body,
-                  size_t bodysize, char *info, size_t infosize,
-                  hts_boolean keep_root_disallow, char *sitemaps,
-                  size_t sitemapsize);
+   gets a summary of the disallows actually kept, `keep_root_disallow` FALSE
+   drops "Disallow: /", and `sitemaps` (optional) collects the Sitemap: URLs,
+   one per line. Anything the parser has to leave out is logged through `opt`,
+   which may be NULL. */
+void robots_parse(httrackp *opt, robots_wizard *robots, const char *adr,
+                  const char *body, size_t bodysize, char *info,
+                  size_t infosize, hts_boolean keep_root_disallow,
+                  char *sitemaps, size_t sitemapsize);
 #endif
 
 #endif

--- a/src/htsrobots.h
+++ b/src/htsrobots.h
@@ -46,7 +46,7 @@ typedef struct httrackp httrackp;
 #endif
 
 /* Rule blob ceiling. RFC 9309 §2.5 asks crawlers to honour at least the first
-   500 kiB of a robots.txt, and the blob only ever holds part of that file. */
+   500 KiB of a robots.txt, and the blob only ever holds part of that file. */
 #define HTS_ROBOTS_MAX_TOKEN_SIZE (500 * 1024)
 
 /* Longest robots.txt line read; a stored rule is marker + pattern + LF. */
@@ -61,8 +61,9 @@ struct robots_wizard {
 /* Library internal definictions */
 #ifdef HTS_INTERNAL_BYTECODE
 /* -1 if `fil` disallowed for `adr` (RFC 9309); empty: -1 if rules exist. */
-int checkrobots(robots_wizard * robots, const char *adr, const char *fil);
-/* Release every node's strings and the chain below `robots`, head excepted. */
+int checkrobots(const robots_wizard *robots, const char *adr, const char *fil);
+/* Free every node's strings, plus every node below `robots` but not `robots`.
+ */
 void checkrobots_free(robots_wizard * robots);
 /* Store `data` as the rule blob of `adr`, adding the host if new. -1 on
    success, 0 if the allocation failed. */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5597,9 +5597,8 @@ static int st_robots(httrackp *opt, int argc, char **argv) {
   /* No rules: everything is allowed. */
   assertf(rb_decide(&robots, "User-agent: *\nDisallow:\n", "/x") == 0);
 
-  /* #1286: the rule store used to stop at 4 KB, losing the tail of the file,
-     and to throw the whole set away when it landed on 4094 bytes. Rules are
-     now kept to the RFC 9309 floor, and only what passes it is left out. */
+  /* #1286: rules are kept to the RFC 9309 floor, where the store used to stop
+     at 4 KB and to discard the whole set when it landed on 4094 bytes. */
   {
     char *txt = rb_bulk(8192); /* past the old cap, well under the new one */
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5509,8 +5509,24 @@ static int rb_decide(robots_wizard *r, const char *txt, const char *path) {
   char host[64];
 
   snprintf(host, sizeof(host), "h%d.example", n++);
-  robots_parse(r, host, txt, strlen(txt), NULL, 0, HTS_TRUE, NULL, 0);
+  robots_parse(NULL, r, host, txt, strlen(txt), NULL, 0, HTS_TRUE, NULL, 0);
   return checkrobots(r, host, path);
+}
+
+/* robots.txt whose stored rules come to about `blobsize` bytes, /secret/ last;
+   each "/padNNNNN/" costs 12 stored bytes (pattern plus marker and LF). */
+static char *rb_bulk(size_t blobsize) {
+  const size_t capa = blobsize * 2 + 4096;
+  char *const txt = (char *) malloct(capa);
+  size_t n, blob;
+  int i;
+
+  assertf(txt != NULL);
+  n = (size_t) snprintf(txt, capa, "User-agent: *\n");
+  for (i = 0, blob = 0; blob + 12 <= blobsize; i++, blob += 12)
+    n += (size_t) snprintf(txt + n, capa - n, "Disallow: /pad%05d/\n", i);
+  (void) snprintf(txt + n, capa - n, "Disallow: /secret/\n");
+  return txt;
 }
 
 static int st_robots(httrackp *opt, int argc, char **argv) {
@@ -5580,6 +5596,47 @@ static int st_robots(httrackp *opt, int argc, char **argv) {
 
   /* No rules: everything is allowed. */
   assertf(rb_decide(&robots, "User-agent: *\nDisallow:\n", "/x") == 0);
+
+  /* #1286: the rule store used to stop at 4 KB, losing the tail of the file,
+     and to throw the whole set away when it landed on 4094 bytes. Rules are
+     now kept to the RFC 9309 floor, and only what passes it is left out. */
+  {
+    char *txt = rb_bulk(8192); /* past the old cap, well under the new one */
+
+    assertf(rb_decide(&robots, txt, "/pad00000/x") == -1);
+    assertf(rb_decide(&robots, txt, "/secret/x") == -1);
+    freet(txt);
+
+    txt = rb_bulk(HTS_ROBOTS_MAX_TOKEN_SIZE - 1024); /* just under the cap */
+    assertf(rb_decide(&robots, txt, "/pad00000/x") == -1);
+    assertf(rb_decide(&robots, txt, "/secret/x") == -1);
+    freet(txt);
+
+    /* Past it the tail is lost, which robots_parse reports through the log. */
+    txt = rb_bulk(HTS_ROBOTS_MAX_TOKEN_SIZE + 4096);
+    assertf(rb_decide(&robots, txt, "/pad00000/x") == -1);
+    assertf(rb_decide(&robots, txt, "/secret/x") == 0);
+    freet(txt);
+  }
+
+  /* A rule longer than the line buffer is read as a prefix of itself. Kept for
+     a Disallow, which can then only forbid more; dropped for an Allow, which
+     would otherwise permit more than the site wrote and beat the Disallow. */
+  {
+    char BIGSTK txt[HTS_ROBOTS_LINE_SIZE * 3];
+    char BIGSTK path[HTS_ROBOTS_LINE_SIZE * 2];
+
+    memset(path, 'a', sizeof(path));
+    path[0] = '/';
+    path[HTS_ROBOTS_LINE_SIZE + 200] = '\0';
+
+    snprintf(txt, sizeof(txt), "User-agent: *\nDisallow: %s\n", path);
+    assertf(rb_decide(&robots, txt, path) == -1);
+
+    snprintf(txt, sizeof(txt), "User-agent: *\nDisallow: /a\nAllow: %s\n",
+             path);
+    assertf(rb_decide(&robots, txt, path) == -1);
+  }
 
   checkrobots_free(&robots);
   printf("robots self-test OK\n");
@@ -5832,7 +5889,7 @@ static int st_sitemap(httrackp *opt, int argc, char **argv) {
     robots_wizard rb;
 
     memset(&rb, 0, sizeof(rb));
-    robots_parse(&rb, "h.test", txt, strlen(txt), NULL, 0, HTS_TRUE, maps,
+    robots_parse(NULL, &rb, "h.test", txt, strlen(txt), NULL, 0, HTS_TRUE, maps,
                  sizeof(maps));
     assertf(strcmp(maps, "http://h.test/s1.xml\nhttps://h.test/s2.xml\n") == 0);
     assertf(checkrobots(&rb, "h.test", "/x") == -1);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5513,8 +5513,13 @@ static int rb_decide(robots_wizard *r, const char *txt, const char *path) {
   return checkrobots(r, host, path);
 }
 
-/* robots.txt whose stored rules come to about `blobsize` bytes, /secret/ last;
-   each "/padNNNNN/" costs 12 stored bytes (pattern plus marker and LF). */
+/* The rule store must reach the RFC 9309 §2.5 floor, whatever the macro says.
+ */
+enum { rb_rfc9309_floor = 1 / (HTS_ROBOTS_MAX_TOKEN_SIZE >= 500 * 1024) };
+
+/* robots.txt filling about `blobsize` stored bytes with "/padNNNNN/" rules
+   (12 each: pattern plus marker and LF), then the two rules a caller asserts
+   on: an Allow re-opening /pad00000/open/, and a final Disallow. */
 static char *rb_bulk(size_t blobsize) {
   const size_t capa = blobsize * 2 + 4096;
   char *const txt = (char *) malloct(capa);
@@ -5523,8 +5528,13 @@ static char *rb_bulk(size_t blobsize) {
 
   assertf(txt != NULL);
   n = (size_t) snprintf(txt, capa, "User-agent: *\n");
-  for (i = 0, blob = 0; blob + 12 <= blobsize; i++, blob += 12)
+  for (i = 0, blob = 0; blob + 12 <= blobsize; i++, blob += 12) {
+    assertf(i < 100000); // past that "/padNNNNNN/" costs 13, not 12
     n += (size_t) snprintf(txt + n, capa - n, "Disallow: /pad%05d/\n", i);
+    assertf(n < capa);
+  }
+  n += (size_t) snprintf(txt + n, capa - n, "Allow: /pad00000/open/\n");
+  assertf(n < capa);
   (void) snprintf(txt + n, capa - n, "Disallow: /secret/\n");
   return txt;
 }
@@ -5597,25 +5607,41 @@ static int st_robots(httrackp *opt, int argc, char **argv) {
   /* No rules: everything is allowed. */
   assertf(rb_decide(&robots, "User-agent: *\nDisallow:\n", "/x") == 0);
 
-  /* #1286: rules are kept to the RFC 9309 floor, where the store used to stop
-     at 4 KB and to discard the whole set when it landed on 4094 bytes. */
+  /* #1286: rules survive to the RFC 9309 floor. Past the old 4 KB store, just
+     under the floor, and past it, where only the tail is left out. */
   {
     char *txt = rb_bulk(8192); /* past the old cap, well under the new one */
 
     assertf(rb_decide(&robots, txt, "/pad00000/x") == -1);
+    assertf(rb_decide(&robots, txt, "/pad00000/open/x") == 0); /* Allow wins */
     assertf(rb_decide(&robots, txt, "/secret/x") == -1);
     freet(txt);
 
     txt = rb_bulk(HTS_ROBOTS_MAX_TOKEN_SIZE - 1024); /* just under the cap */
     assertf(rb_decide(&robots, txt, "/pad00000/x") == -1);
+    assertf(rb_decide(&robots, txt, "/pad00000/open/x") == 0);
     assertf(rb_decide(&robots, txt, "/secret/x") == -1);
     freet(txt);
 
     /* Past it the tail is lost, which robots_parse reports through the log. */
     txt = rb_bulk(HTS_ROBOTS_MAX_TOKEN_SIZE + 4096);
     assertf(rb_decide(&robots, txt, "/pad00000/x") == -1);
+    assertf(rb_decide(&robots, txt, "/pad00000/open/x") == -1);
     assertf(rb_decide(&robots, txt, "/secret/x") == 0);
     freet(txt);
+  }
+
+  /* A rule costs marker + pattern + LF, the accounting tests/309 computes. */
+  {
+    const char *const txt = "User-agent: *\nDisallow: /pad00000/\n";
+    robots_wizard rb;
+
+    memset(&rb, 0, sizeof(rb));
+    robots_parse(NULL, &rb, "h.test", txt, strlen(txt), NULL, 0, HTS_TRUE, NULL,
+                 0);
+    assertf(rb.next != NULL && rb.next->token != NULL);
+    assertf(strlen(rb.next->token) == strlen("/pad00000/") + 2);
+    checkrobots_free(&rb);
   }
 
   /* A rule longer than the line buffer is read as a prefix of itself. Kept for
@@ -5632,6 +5658,19 @@ static int st_robots(httrackp *opt, int argc, char **argv) {
     snprintf(txt, sizeof(txt), "User-agent: *\nDisallow: %s\n", path);
     assertf(rb_decide(&robots, txt, path) == -1);
 
+    snprintf(txt, sizeof(txt), "User-agent: *\nDisallow: /a\nAllow: %s\n",
+             path);
+    assertf(rb_decide(&robots, txt, path) == -1);
+
+    /* The longest line the buffer holds whole is not cut, so this Allow wins;
+       one byte more is cut, and the Disallow it would have beaten stands. */
+    path[HTS_ROBOTS_LINE_SIZE - 2 - strlen("Allow: ")] = '\0';
+    snprintf(txt, sizeof(txt), "User-agent: *\nDisallow: /a\nAllow: %s\n",
+             path);
+    assertf(rb_decide(&robots, txt, path) == 0);
+
+    path[HTS_ROBOTS_LINE_SIZE - 2 - strlen("Allow: ")] = 'a';
+    path[HTS_ROBOTS_LINE_SIZE - 1 - strlen("Allow: ")] = '\0';
     snprintf(txt, sizeof(txt), "User-agent: *\nDisallow: /a\nAllow: %s\n",
              path);
     assertf(rb_decide(&robots, txt, path) == -1);

--- a/tests/309_local-robots-rule-cap.test
+++ b/tests/309_local-robots-rule-cap.test
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Issue #1286: the rule store stopped at 4 KB, so a robots.txt longer than that
+# lost its tail, and one landing on 4094 bytes lost every rule it had. Nothing
+# said so, and the "will be forbidden" note listed the rules anyway.
+set -eu
+
+# shellcheck source=tests/crawllib.sh
+. "$(dirname "$0")/crawllib.sh"
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_1286.XXXXXX") || exit 1
+cleanup() {
+    rm -rf "$tmpdir"
+}
+cleanup_push cleanup
+
+doc="${tmpdir}/doc"
+mkdir -p "${doc}/secret" "${doc}/pad00000" "${doc}/ok"
+printf '<html><body><a href="secret/page.html">s</a>\n<a href="pad00000/page.html">p</a>\n<a href="ok/page.html">o</a></body></html>\n' \
+    >"${doc}/index.html"
+for d in secret pad00000 ok; do
+    printf '<html><body>body of %s</body></html>\n' "$d" >"${doc}/${d}/page.html"
+done
+
+warn='rule\(s\) not honoured as written'
+
+# robotsblobNNNN sizes the Disallow list so the stored rules come to exactly
+# NNNN bytes, /secret/ last. A short list is the control: the same rule, and
+# the same absence of a warning, at a size no cap was ever near.
+bash "$top_srcdir/tests/local-crawl.sh" --root "$(nativepath "$doc")" \
+    --errors 0 --found 'ok/page.html' --found 'pad00000/page.html' \
+    --not-found 'secret/page.html' --log-not-found "$warn" \
+    httrack 'BASEURL/index.html' -r3 -s2 -F 'robotsblob10-agent'
+
+# 4094 bytes: the size that used to throw the whole set away, so the first rule
+# is as good a witness as the last.
+bash "$top_srcdir/tests/local-crawl.sh" --root "$(nativepath "$doc")" \
+    --errors 0 --found 'ok/page.html' \
+    --not-found 'secret/page.html' --not-found 'pad00000/page.html' \
+    --log-not-found "$warn" \
+    httrack 'BASEURL/index.html' -r3 -s2 -F 'robotsblob4094-agent'
+
+# Past the RFC 9309 floor the tail really is dropped, and that is exactly what
+# has to reach the log, naming the first rule left out.
+bash "$top_srcdir/tests/local-crawl.sh" --root "$(nativepath "$doc")" \
+    --errors 0 --found 'ok/page.html' --found 'secret/page.html' \
+    --not-found 'pad00000/page.html' \
+    --log-found "$warn, starting with '/pad[0-9]+/'" \
+    httrack 'BASEURL/index.html' -r3 -s2 -F 'robotsblob516096-agent'

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -145,7 +145,11 @@ cleanup_push purge_tmpdir
 
 # Line 2 echoes the engine's command line, so a path named after a searched word
 # would answer for the crawl (#1220). The banner stays: audits match its URL.
-log_body() { awk 'NR == 2 && /^\(/ { next } { print }' "${logroot}/hts-log.txt"; }
+# A missing log would make every --log-not-found pass on an empty file.
+log_body() {
+    test -s "${logroot}/hts-log.txt" || die "no crawl log at ${logroot}/hts-log.txt"
+    awk 'NR == 2 && /^\(/ { next } { print }' "${logroot}/hts-log.txt"
+}
 
 # python3 is required; mirror check-network.sh's skip-with-77 convention. Found
 # here, not in local_server_start, so a host without it skips before any setup.

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -564,17 +564,10 @@ class Handler(SimpleHTTPRequestHandler):
     # ... and "robotsblobNNNN", which sizes the Disallow list so the engine's
     # stored rules come to exactly NNNN bytes, /secret/ last (#1286).
     BLOB_ROBOTS_RE = re.compile(r"robotsblob(\d+)")
-    _blob_robots = {}
 
-    @classmethod
-    def robots_blob_body(cls, blobsize):
-        """Disallow list stored as exactly blobsize bytes, /secret/ rule last.
-
-        The engine keeps one "<marker><pattern>\\n" line per rule, so a rule
-        costs len(pattern) + 2.
-        """
-        if blobsize in cls._blob_robots:
-            return cls._blob_robots[blobsize]
+    def robots_blob_body(self, blobsize):
+        # One "<marker><pattern>\n" line per stored rule, so a rule costs
+        # len(pattern) + 2. tests/01_engine-robots.test pins that accounting.
         rules = []
         used = 0
         room = blobsize - (len("/secret/") + 2)
@@ -589,11 +582,9 @@ class Handler(SimpleHTTPRequestHandler):
         if room - used:
             rules.append("/" + "z" * (room - used - 3))
         rules.append("/secret/")
-        body = (
+        return (
             "User-agent: *\n" + "".join("Disallow: %s\n" % r for r in rules)
         ).encode()
-        cls._blob_robots[blobsize] = body
-        return body
 
     def route_robots(self):
         # The Sitemap: record is group-independent; only --sitemap acts on it.

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -561,6 +561,39 @@ class Handler(SimpleHTTPRequestHandler):
     # ... and one whose probe fails, with a body past the 1070 bytes that
     # issue #769's over-read needed.
     ERROR_ROBOTS_UA = "errorrobots"
+    # ... and "robotsblobNNNN", which sizes the Disallow list so the engine's
+    # stored rules come to exactly NNNN bytes, /secret/ last (#1286).
+    BLOB_ROBOTS_RE = re.compile(r"robotsblob(\d+)")
+    _blob_robots = {}
+
+    @classmethod
+    def robots_blob_body(cls, blobsize):
+        """Disallow list stored as exactly blobsize bytes, /secret/ rule last.
+
+        The engine keeps one "<marker><pattern>\\n" line per rule, so a rule
+        costs len(pattern) + 2.
+        """
+        if blobsize in cls._blob_robots:
+            return cls._blob_robots[blobsize]
+        rules = []
+        used = 0
+        room = blobsize - (len("/secret/") + 2)
+        while used + 12 <= room:
+            rules.append("/pad%05d/" % len(rules))
+            used += 12
+        # A 1- or 2-byte filler cannot be written, and a 1-char one would be the
+        # site-wide "/". Give back a pad rule until the remainder is spendable.
+        while 0 < room - used < 5 and rules:
+            rules.pop()
+            used -= 12
+        if room - used:
+            rules.append("/" + "z" * (room - used - 3))
+        rules.append("/secret/")
+        body = (
+            "User-agent: *\n" + "".join("Disallow: %s\n" % r for r in rules)
+        ).encode()
+        cls._blob_robots[blobsize] = body
+        return body
 
     def route_robots(self):
         # The Sitemap: record is group-independent; only --sitemap acts on it.
@@ -573,6 +606,10 @@ class Handler(SimpleHTTPRequestHandler):
             self.end_headers()
             if self.command != "HEAD":
                 self.wfile.write(body)
+            return
+        blob = self.BLOB_ROBOTS_RE.search(ua)
+        if blob:
+            self.send_raw(self.robots_blob_body(int(blob.group(1))), "text/plain")
             return
         host = self.headers.get("Host")
         body = "User-agent: *\nDisallow:\n"


### PR DESCRIPTION
HTTrack collected a robots.txt's Allow/Disallow rules into a fixed 4096-byte store. Past that the tail of the file was dropped. When the rules came to exactly 4094 or 4095 bytes `checkrobots_set()` refused the blob whole, leaving the host with no rules at all. Neither drop reached the log at any level, and the "links beginning with these path will be forbidden" note comes from a separate 8 KB buffer, so on a 4094-byte run it listed all 342 patterns the engine had just discarded. Against a local server a `Disallow: /secret/` sitting past 4 KB was crawled anyway; at 4094 bytes so was the first rule in the file.

The store is a `String` now, grown to what the site wrote and capped at the 500 KiB RFC 9309 §2.5 asks crawlers to parse. Whatever still does not fit is logged with a count and the first rule left out. Growing to fit means the higher ceiling costs nothing on an ordinary robots.txt of a few hundred bytes. Matching goes through htsrobots.c's own prefix matcher rather than `strjoker()`, so #1270's `STRJOKER_MAXLEN` is not in play, and the only other reader of the blob, `checkrobots()`, had a per-rule buffer sized off the whole store; it is sized off the 1024-byte line buffer now.

Three neighbours of the same shape came along. The host key was a 128-byte array, and a host over 126 characters lost its whole ruleset with the same silence; it is heap now. A rule line longer than the read buffer used to be stored as a prefix of itself whichever kind it was, which for an Allow permits more than the site wrote and beats the Disallow it was meant to carve out of, so a cut Allow is dropped and a cut Disallow kept, both counted in the warning. And `checkrobots_free()` runs from an `XH_extuninit` twelve lines before the list head was initialised, so an early `coucal_new()` failure freed indeterminate stack words; the head is set up before that path now, which also retires a wild `freet(robots.next)` that predates this change.

The safe direction is to keep rules rather than drop them and never to drop one quietly, and the old 4094 behaviour got both wrong.

Test 309 runs three crawls against a robots.txt built to an exact stored size, short, 4094 bytes, and past the cap, and each asserts both halves: whether the rule is honoured, and whether the log says so. Either alone would pass a fix that warns and still drops. On the pre-fix tree the 4094 crawl fails on `secret/page.html` being present and the over-cap crawl on the missing warning. `-#test=robots` covers the parser at 8 KB, just under the cap and past it, the Allow-beats-Disallow precedence at those sizes, the exact line-buffer boundary in both directions, and the per-rule cost the crawl fixture computes. Mutants putting the cap back at 4096, keeping a truncated Allow, and restoring the old length-based truncation test all kill it.

Closes #1286
