### PR TITLE
A long filter or URL token overflows the mirror parser's stack buffer

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -449,15 +449,11 @@ static int look_like_xml(const char *s) {
     ;
 }
 
-/* Copies the next whitespace-delimited token of *ptr into dest (capacity size)
-   and leaves *ptr on the one after it. Returns the token's full length, so a
-   caller drops one that did not fit instead of acting on a clip: a clipped URL
-   or filter is a different one. */
-static size_t copy_token(char **ptr, char *dest, size_t size) {
-  char *a = *ptr;
+size_t copy_token(char **cursor, char *dest, size_t size) {
+  char *a = *cursor;
   size_t len = 0;
 
-  assertf(size != 0);
+  assertf(cursor != NULL && dest != NULL && size != 0);
   while (*a != 0 && !isspace((unsigned char) *a)) {
     if (len < size - 1)
       dest[len] = *a;
@@ -467,7 +463,7 @@ static size_t copy_token(char **ptr, char *dest, size_t size) {
   dest[len < size ? len : size - 1] = '\0';
   while (isspace((unsigned char) *a))
     a++;
-  *ptr = a;
+  *cursor = a;
   return len;
 }
 
@@ -681,7 +677,7 @@ int httpmirror(char *url1, httrackp * opt) {
         joker = 1;
 
       if (joker) { // joker ou filters
-        /* room for the longest rule the array takes, plus the implicit "*" */
+        /* the longest rule a slot holds, plus the "*" a bare pattern gets */
         char BIGSTK tempo[HTS_FILTER_MAXLEN + 2];
         size_t len;
         int type;
@@ -701,11 +697,14 @@ int httpmirror(char *url1, httrackp * opt) {
 
         // recopier prochaine chaine (+ ou -)
         len = copy_token(&a, tempo, sizeof(tempo));
-        if (len > HTS_FILTER_MAXLEN) {
+        /* the rule is the sign and the token, and filters_insert takes it
+           whole, so bound the token one byte short of the slot's own cap */
+        if (len > HTS_FILTER_MAXLEN - 1) {
           hts_log_print(opt, LOG_WARNING,
                         "Filter rule dropped: %d bytes is past the %d-byte "
-                        "limit, so it could never match",
-                        (int) len, (int) HTS_FILTER_MAXLEN);
+                        "limit, so it could never match: %c%s",
+                        (int) (len + 1), (int) HTS_FILTER_MAXLEN,
+                        type ? '+' : '-', tempo);
           continue;
         }
 
@@ -746,12 +745,14 @@ int httpmirror(char *url1, httrackp * opt) {
 
       } else { // adresse normale
         char BIGSTK url[HTS_URLMAXSIZE * 2];
+        size_t len;
 
         // prochaine adresse
-        if (copy_token(&a, url, sizeof(url)) >= sizeof(url)) {
+        len = copy_token(&a, url, sizeof(url));
+        if (len > sizeof(url) - 1) {
           hts_log_print(opt, LOG_WARNING,
-                        "URL dropped: longer than the %d-byte limit",
-                        (int) (sizeof(url) - 1));
+                        "URL dropped: %d bytes is past the %d-byte limit: %s",
+                        (int) len, (int) (sizeof(url) - 1), url);
           continue;
         }
 

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -677,7 +677,7 @@ int httpmirror(char *url1, httrackp * opt) {
         joker = 1;
 
       if (joker) { // joker ou filters
-        /* the longest rule a slot holds, plus the "*" a bare pattern gets */
+        /* the longest rule a slot holds, plus the "*" appended below */
         char BIGSTK tempo[HTS_FILTER_MAXLEN + 2];
         size_t len;
         int type;

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -449,6 +449,28 @@ static int look_like_xml(const char *s) {
     ;
 }
 
+/* Copies the next whitespace-delimited token of *ptr into dest (capacity size)
+   and leaves *ptr on the one after it. Returns the token's full length, so a
+   caller drops one that did not fit instead of acting on a clip: a clipped URL
+   or filter is a different one. */
+static size_t copy_token(char **ptr, char *dest, size_t size) {
+  char *a = *ptr;
+  size_t len = 0;
+
+  assertf(size != 0);
+  while (*a != 0 && !isspace((unsigned char) *a)) {
+    if (len < size - 1)
+      dest[len] = *a;
+    len++;
+    a++;
+  }
+  dest[len < size ? len : size - 1] = '\0';
+  while (isspace((unsigned char) *a))
+    a++;
+  *ptr = a;
+  return len;
+}
+
 // Début de httpmirror, robot
 // url1 peut être multiple
 int httpmirror(char *url1, httrackp * opt) {
@@ -649,8 +671,7 @@ int httpmirror(char *url1, httrackp * opt) {
     }
     htsbuff primarybuff = htsbuff_ptr(primary, primary_len);
 
-    while(*a) {
-      int i;
+    while (*a) {
       int joker = 0;
 
       // vérifier qu'il n'y a pas de * dans l'url
@@ -660,7 +681,9 @@ int httpmirror(char *url1, httrackp * opt) {
         joker = 1;
 
       if (joker) { // joker ou filters
-        char BIGSTK tempo[HTS_URLMAXSIZE * 2];
+        /* room for the longest rule the array takes, plus the implicit "*" */
+        char BIGSTK tempo[HTS_FILTER_MAXLEN + 2];
+        size_t len;
         int type;
         int plus = 0;
 
@@ -677,14 +700,13 @@ int httpmirror(char *url1, httrackp * opt) {
         }
 
         // recopier prochaine chaine (+ ou -)
-        i = 0;
-        while((*a != 0) && (!isspace((unsigned char) *a))) {
-          tempo[i++] = *a;
-          a++;
-        }
-        tempo[i++] = '\0';
-        while(isspace((unsigned char) *a)) {
-          a++;
+        len = copy_token(&a, tempo, sizeof(tempo));
+        if (len > HTS_FILTER_MAXLEN) {
+          hts_log_print(opt, LOG_WARNING,
+                        "Filter rule dropped: %d bytes is past the %d-byte "
+                        "limit, so it could never match",
+                        (int) len, (int) HTS_FILTER_MAXLEN);
+          continue;
         }
 
         // sauter les + sans rien après..
@@ -726,22 +748,19 @@ int httpmirror(char *url1, httrackp * opt) {
         char BIGSTK url[HTS_URLMAXSIZE * 2];
 
         // prochaine adresse
-        i = 0;
-        while((*a != 0) && (!isspace((unsigned char) *a))) {
-          url[i++] = *a;
-          a++;
+        if (copy_token(&a, url, sizeof(url)) >= sizeof(url)) {
+          hts_log_print(opt, LOG_WARNING,
+                        "URL dropped: longer than the %d-byte limit",
+                        (int) (sizeof(url) - 1));
+          continue;
         }
-        while(isspace((unsigned char) *a)) {
-          a++;
-        }
-        url[i++] = '\0';
 
         if (strstr(url, ":/") == NULL)
           htsbuff_cat(&primarybuff, "http://");
         htsbuff_cat(&primarybuff, url);
         htsbuff_cat(&primarybuff, "\n");
       }
-    }                           // while
+    } // while
 
     /* --why: print which filter rule decides for this URL, then stop */
     if (StringNotEmpty(opt->why_url)) {

--- a/src/htscore.h
+++ b/src/htscore.h
@@ -416,6 +416,12 @@ int fspc(httrackp * opt, FILE * fp, const char *type);
 
 char *next_token(char *p, int flag);
 
+/* Copies the whitespace-delimited token at *cursor into dest (size bytes, NUL
+   included) and leaves *cursor on the next one. Returns the token's full
+   length, past `size` when it did not fit: the caller drops such a token, since
+   a clipped URL or filter means something else. */
+size_t copy_token(char **cursor, char *dest, size_t size);
+
 /* Like fil_normalized(), but first drops query keys in STRIP (comma-separated,
    "*" = all); STRIP NULL/empty behaves exactly like fil_normalized(). */
 char *fil_normalized_filtered(const char *source, char *dest,

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5397,6 +5397,57 @@ static int st_filtercap(httrackp *opt, int argc, char **argv) {
 
 #undef POISON
 
+/* #1271: copy_token() bounds the mirror parser's token copies. Prints the two
+ * caps the parser applies, so a test does not hand-copy them. */
+static int st_copytoken(httrackp *opt, int argc, char **argv) {
+  /* GUARD is non-zero and never written, so an off-by-one terminator shows up
+     where a zeroed canary could not */
+#define GUARD 'G'
+#define CAP 8
+
+  struct {
+    char dest[CAP];
+    char guard[4];
+  } buf;
+
+  char input[64];
+  char *cursor;
+  size_t len, g;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+/* copy one token out of `text`, over a poisoned destination */
+#define TAKE(label, text)                                                      \
+  do {                                                                         \
+    memset(&buf, GUARD, sizeof(buf));                                          \
+    strcpybuff(input, (text));                                                 \
+    cursor = input;                                                            \
+    len = copy_token(&cursor, buf.dest, sizeof(buf.dest));                     \
+    for (g = 0; g < sizeof(buf.guard); g++)                                    \
+      assertf(buf.guard[g] == GUARD);                                          \
+    printf("%s: len=%d dest=[%s] rest=[%s]\n", (label), (int) len, buf.dest,   \
+           cursor);                                                            \
+  } while (0)
+
+  TAKE("empty", "");
+  TAKE("blank", "  ");
+  TAKE("one", "a b");
+  TAKE("fits", "abcdefg x");      /* CAP - 1, the longest that fits */
+  TAKE("one past", "abcdefgh x"); /* the last byte is lost, so it is dropped */
+  TAKE("far past", "abcdefghijkl x");
+  TAKE("mixed space", "a \t\r\n b");
+#undef TAKE
+
+  /* what the parser lets through, for the crawl test that drives it */
+  printf("filter cap=%d url cap=%d\n", (int) HTS_FILTER_MAXLEN - 1,
+         (int) (HTS_URLMAXSIZE * 2) - 1);
+  printf("copytoken self-test OK\n");
+  return 0;
+#undef CAP
+#undef GUARD
+}
+
 /* #159: hts_redirect_same_savefile decides whether a redirect is a same-file
  * alias. */
 static int st_redirect_samefile(httrackp *opt, int argc, char **argv) {
@@ -10992,6 +11043,8 @@ static const struct selftest_entry {
      st_filterbounds},
     {"filtercap", "", "an over-long filter rule is refused, not stored dead",
      st_filtercap},
+    {"copytoken", "", "bounded token copy behind the mirror parser (#1271)",
+     st_copytoken},
     {"simplify", "<path>", "collapse ./ and ../ in a path", st_simplify},
     {"expandhome", "<path>", "expand a leading ~/ into $HOME", st_expandhome},
     {"stripquery", "", "--strip-query pattern/key stripping self-test",

--- a/tests/313_scanrules-long-token.test
+++ b/tests/313_scanrules-long-token.test
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# #1271: -%S reads a rules file straight into the command-line string with no
+# per-token cap, so the parser's own copy loops are the only bound there is.
+# Offline: --why decides without crawling, so no server.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+maxlen=2048 # HTS_FILTER_MAXLEN, the longest rule a slot holds
+urlmax=2047 # HTS_URLMAXSIZE * 2 - 1, the longest URL token the loop copies
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_longtok.XXXXXX") || exit 1
+cleanup_push rm -rf "$tmp"
+
+pad() { printf "%$1s" '' | tr ' ' a; }
+
+out="$tmp/out"
+log="$out/hts-log.txt" # why() runs in a subshell, so nothing it sets survives
+
+why() { # why FILE -> the --why verdict, leaving its run behind in $log
+    rm -rf "$out"
+    mkdir -p "$out"
+    httrack -O "$out" -q "-%S" "$1" --why http://www.example.com/x.zip \
+        http://www.example.com/ 2>&1 |
+        grep -aoE 'rejected by rule #[0-9]+ \([^)]*\)|no filter rule'
+}
+
+logged() { grep -aq "$1" "$log"; }
+
+# -*.zip goes second, so the ordinal in the verdict says whether the long rule
+# took a slot: dropping it moves -*.zip from #2 to #1.
+rules() { # rules LEN -- a rule of LEN bytes, sign included
+    printf -- '-*%s\n-*.zip\n' "$(pad $(($1 - 2)))" >"$tmp/rules.txt"
+    why "$tmp/rules.txt"
+}
+
+assert_eq "rejected by rule #2 (-*.zip)" "$(rules $maxlen)" "rule at the cap"
+! logged "Filter rule dropped" || fail "the rule at the cap was dropped"
+assert_eq "rejected by rule #1 (-*.zip)" "$(rules $((maxlen + 1)))" "one past"
+# 3000 bytes at a 2050-byte buffer: the write ASan caught pre-fix.
+assert_eq "rejected by rule #1 (-*.zip)" "$(rules 3000)" "far past the cap"
+logged "Filter rule dropped" || fail "no drop warning in $log"
+
+# The URL branch copies into a buffer of its own, one byte narrower.
+urls() { # urls LEN -- a primary URL of LEN bytes
+    local u=http://www.example.com/
+
+    printf '%s%s\n-*.zip\n' "$u" "$(pad $(($1 - ${#u})))" >"$tmp/urls.txt"
+    why "$tmp/urls.txt"
+}
+
+assert_eq "rejected by rule #1 (-*.zip)" "$(urls $urlmax)" "URL at the cap"
+! logged "URL dropped" || fail "the URL at the cap was dropped"
+assert_eq "rejected by rule #1 (-*.zip)" "$(urls $((urlmax + 1)))" "URL one past"
+logged "URL dropped" || fail "no drop warning in $log"
+assert_eq "rejected by rule #1 (-*.zip)" "$(urls 3000)" "URL far past the cap"
+
+exit 0

--- a/tests/313_scanrules-long-token.test
+++ b/tests/313_scanrules-long-token.test
@@ -56,9 +56,9 @@ assert_eq 1 "$(counted 'Filter rule dropped')" "warnings for one dropped rule"
 assert_eq "$dropped" "$(why 3000)" "rule far past the cap"
 logged "dropped: 3001 bytes" || fail "wrong size in the warning"
 
-# A URL is dropped by its own branch, one byte short of the filter's cap. Only
-# a crawl shows it: the engine rejects a kept one downstream ("too long"), so
-# that warning is present exactly when the parse loop let it through.
+# A URL is dropped by its own branch, one byte short of the filter's cap. The
+# warning is the only sign of it: the engine caps a URL at HTS_URLMAXSIZE and
+# refuses one four times shorter, so no crawl ever sees the bound below.
 echo '<html><body>ok</body></html>' >"$tmp/ok.html"
 crawl() { # crawl URLLEN -> mirrors a primary URL of that length, plus a real one
     local url="file://$tmp/"
@@ -69,13 +69,11 @@ crawl() { # crawl URLLEN -> mirrors a primary URL of that length, plus a real on
 }
 
 crawl "$maxurl"
-logged "too long" || fail "the URL at the cap never reached the crawler"
 ! logged "URL dropped" || fail "the URL at the cap was dropped"
 crawl "$((maxurl + 1))"
 logged "URL dropped: $((maxurl + 1)) bytes is past the $maxurl-byte limit" ||
     fail "no drop warning in $log"
-! logged "too long" || fail "an over-long URL still reached the crawler"
 crawl 3000
-! logged "too long" || fail "a far over-long URL still reached the crawler"
+logged "URL dropped: 3000 bytes" || fail "wrong size in the warning"
 
 exit 0

--- a/tests/313_scanrules-long-token.test
+++ b/tests/313_scanrules-long-token.test
@@ -1,61 +1,77 @@
 #!/bin/bash
 #
-# #1271: -%S reads a rules file straight into the command-line string with no
-# per-token cap, so the parser's own copy loops are the only bound there is.
-# Offline: --why decides without crawling, so no server.
+# #1271: -%S loads a rules file into the command line with no per-token limit,
+# so the parse loop's own bound is the only one. Offline: file:// and --why.
 
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
 . "$(dirname "$0")/testlib.sh"
 
-maxlen=2048 # HTS_FILTER_MAXLEN, the longest rule a slot holds
-urlmax=2047 # HTS_URLMAXSIZE * 2 - 1, the longest URL token the loop copies
+# The caps the parser applies, straight from the engine rather than copied.
+caps=$(httrack -O /dev/null -#test=copytoken |
+    sed -n 's/^filter cap=\([0-9]*\) url cap=\([0-9]*\)$/\1 \2/p')
+read -r maxtoken maxurl <<<"$caps"
+test -n "${maxurl:-}" || fail "no caps in the copytoken self-test: $caps"
+maxrule=$((maxtoken + 1)) # the token plus its + or - sign
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_longtok.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmp"
 
-pad() { printf "%$1s" '' | tr ' ' a; }
-
 out="$tmp/out"
-log="$out/hts-log.txt" # why() runs in a subshell, so nothing it sets survives
+log="$out/hts-log.txt" # the run helpers are subshells, so nothing they set lives
 
-why() { # why FILE -> the --why verdict, leaving its run behind in $log
+pad() { printf "%$1s" '' | tr ' ' a; }
+logged() { grep -aq "$1" "$log"; }
+fresh() {
     rm -rf "$out"
     mkdir -p "$out"
-    httrack -O "$out" -q "-%S" "$1" --why http://www.example.com/x.zip \
+}
+
+# -*.zip goes second, so the ordinal in the verdict says whether the long rule
+# took a slot: dropping it moves -*.zip from #2 to #1.
+why() { # why TOKENLEN -> the --why verdict on a rule of that token length
+    fresh
+    printf -- '-%s\n-*.zip\n' "$(pad "$1")" >"$tmp/rules.txt"
+    httrack -O "$out" -q "-%S" "$tmp/rules.txt" --why http://www.example.com/x.zip \
         http://www.example.com/ 2>&1 |
         grep -aoE 'rejected by rule #[0-9]+ \([^)]*\)|no filter rule'
 }
 
-logged() { grep -aq "$1" "$log"; }
+kept="rejected by rule #2 (-*.zip)"
+dropped="rejected by rule #1 (-*.zip)"
 
-# -*.zip goes second, so the ordinal in the verdict says whether the long rule
-# took a slot: dropping it moves -*.zip from #2 to #1.
-rules() { # rules LEN -- a rule of LEN bytes, sign included
-    printf -- '-*%s\n-*.zip\n' "$(pad $(($1 - 2)))" >"$tmp/rules.txt"
-    why "$tmp/rules.txt"
-}
-
-assert_eq "rejected by rule #2 (-*.zip)" "$(rules $maxlen)" "rule at the cap"
+assert_eq "$kept" "$(why "$maxtoken")" "rule at the cap"
 ! logged "Filter rule dropped" || fail "the rule at the cap was dropped"
-assert_eq "rejected by rule #1 (-*.zip)" "$(rules $((maxlen + 1)))" "one past"
+assert_eq "$dropped" "$(why "$((maxtoken + 1))")" "rule one past the cap"
+# The count names the whole rule, as filters_insert's own refusal does, so the
+# two doors cannot report the same rule as two different sizes.
+logged "dropped: $((maxrule + 1)) bytes is past the $maxrule-byte limit" ||
+    fail "wrong size in the warning: $(grep -a dropped "$log")"
 # 3000 bytes at a 2050-byte buffer: the write ASan caught pre-fix.
-assert_eq "rejected by rule #1 (-*.zip)" "$(rules 3000)" "far past the cap"
-logged "Filter rule dropped" || fail "no drop warning in $log"
+assert_eq "$dropped" "$(why 3000)" "rule far past the cap"
+logged "dropped: 3001 bytes" || fail "wrong size in the warning"
 
-# The URL branch copies into a buffer of its own, one byte narrower.
-urls() { # urls LEN -- a primary URL of LEN bytes
-    local u=http://www.example.com/
+# A URL is dropped by its own branch, one byte short of the filter's cap. Only
+# a crawl shows it: the engine rejects a kept one downstream ("too long"), so
+# that warning is present exactly when the parse loop let it through.
+echo '<html><body>ok</body></html>' >"$tmp/ok.html"
+crawl() { # crawl URLLEN -> mirrors a primary URL of that length, plus a real one
+    local url="file://$tmp/"
 
-    printf '%s%s\n-*.zip\n' "$u" "$(pad $(($1 - ${#u})))" >"$tmp/urls.txt"
-    why "$tmp/urls.txt"
+    fresh
+    printf '%s%s\n' "$url" "$(pad $(($1 - ${#url})))" >"$tmp/urls.txt"
+    httrack -O "$out" -q "-%S" "$tmp/urls.txt" "file://$tmp/ok.html" >/dev/null 2>&1
 }
 
-assert_eq "rejected by rule #1 (-*.zip)" "$(urls $urlmax)" "URL at the cap"
+crawl "$maxurl"
+logged "too long" || fail "the URL at the cap never reached the crawler"
 ! logged "URL dropped" || fail "the URL at the cap was dropped"
-assert_eq "rejected by rule #1 (-*.zip)" "$(urls $((urlmax + 1)))" "URL one past"
-logged "URL dropped" || fail "no drop warning in $log"
-assert_eq "rejected by rule #1 (-*.zip)" "$(urls 3000)" "URL far past the cap"
+crawl "$((maxurl + 1))"
+logged "URL dropped: $((maxurl + 1)) bytes is past the $maxurl-byte limit" ||
+    fail "no drop warning in $log"
+! logged "too long" || fail "an over-long URL still reached the crawler"
+crawl 3000
+! logged "too long" || fail "a far over-long URL still reached the crawler"
 
 exit 0

--- a/tests/313_scanrules-long-token.test
+++ b/tests/313_scanrules-long-token.test
@@ -23,6 +23,7 @@ log="$out/hts-log.txt" # the run helpers are subshells, so nothing they set live
 
 pad() { printf "%$1s" '' | tr ' ' a; }
 logged() { grep -aq "$1" "$log"; }
+counted() { grep -ac "$1" "$log" || true; }
 fresh() {
     rm -rf "$out"
     mkdir -p "$out"
@@ -48,6 +49,9 @@ assert_eq "$dropped" "$(why "$((maxtoken + 1))")" "rule one past the cap"
 # two doors cannot report the same rule as two different sizes.
 logged "dropped: $((maxrule + 1)) bytes is past the $maxrule-byte limit" ||
     fail "wrong size in the warning: $(grep -a dropped "$log")"
+# Once, so a rule that is warned about and then offered to the array anyway,
+# which refuses it and warns again, does not read the same as one refused here.
+assert_eq 1 "$(counted 'Filter rule dropped')" "warnings for one dropped rule"
 # 3000 bytes at a 2050-byte buffer: the write ASan caught pre-fix.
 assert_eq "$dropped" "$(why 3000)" "rule far past the cap"
 logged "dropped: 3001 bytes" || fail "wrong size in the warning"

--- a/tests/314_engine-copy-token.test
+++ b/tests/314_engine-copy-token.test
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# #1271: copy_token() is the bound behind the mirror parser's token copies. It
+# reports the token's FULL length, so a caller can drop one that did not fit;
+# reporting the clipped length instead would read as a token that fit.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "$(dirname "$0")/testlib.sh"
+
+out=$(httrack -O /dev/null -#test=copytoken)
+
+has() { grep -q "^$1\$" <<<"$out" || fail "$1: $out"; }
+
+has 'empty: len=0 dest=\[\] rest=\[\]'
+has 'blank: len=0 dest=\[\] rest=\[\]'
+# the cursor lands on the next token, whatever the run of space between them
+has 'one: len=1 dest=\[a\] rest=\[b\]'
+has 'mixed space: len=1 dest=\[a\] rest=\[b\]'
+# 7 bytes is the last that fits an 8-byte destination
+has 'fits: len=7 dest=\[abcdefg\] rest=\[x\]'
+# past it the copy clips, and only the returned length still says so
+has 'one past: len=8 dest=\[abcdefg\] rest=\[x\]'
+has 'far past: len=12 dest=\[abcdefg\] rest=\[x\]'
+has 'copytoken self-test OK'


### PR DESCRIPTION
httpmirror() copied each whitespace-delimited token of the command line into a fixed stack buffer with no bound, so a long token walked off the end. `-%S` reads a rules file into that string with no per-token cap, so a pasted file or a front end reaches the bug. ASan fires on both the filter buffer and the URL one, one byte past the end.

Both loops now go through `copy_token()`, which returns the token's full length, so the caller can tell a token that fit from one that did not. An over-long token is dropped with a warning instead of clipped, because a clipped filter is a different filter. That is the trap #1266 hit. The gate bounds the token one byte short of the slot, since the stored rule is the sign plus the token. Measuring the token alone let a rule one byte over reach `filters_insert`, which refused it and named a size the user never wrote.

Test 314 drives `copy_token()` through a `-#test=copytoken` self-test. The bytes past the destination are poisoned to a non-zero value, so a stray terminator shows up without ASan. Test 313 covers the wiring. It reads the caps out of the engine instead of copying them, pins the size the warning reports, and drives the URL branch through a crawl, where a kept URL is visible downstream and a dropped one is not. Of eleven mutants, nine die. Both survivors are unobservable rather than untested: a filter gate loose by one byte, where `filters_insert` catches the same rule and prints the same sentence, and a URL warned about and then kept, which the engine refuses anyway at `HTS_URLMAXSIZE`, a quarter of where this branch clips.

Closes #1271