### PR TITLE
A filter rule that fits the slot is refused by one byte

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -700,9 +700,9 @@ int httpmirror(char *url1, httrackp * opt) {
         }
 
         // recopier prochaine chaine (+ ou -)
-        /* the slot it lands in must hold the sign too, and the implicit form
-           below gains a trailing '*' */
-        const size_t room = sizeof(tempo) - (plus == 0 && type == 1 ? 2 : 1);
+        /* the sign is prepended into `rule` below, not held here; only the
+           implicit form's trailing '*' has to be left room for */
+        const size_t room = sizeof(tempo) - (plus == 0 && type == 1 ? 1 : 0);
 
         if (!hts_scan_token(&a, tempo, room)) {
           /* on the console too: the user who typed it may have no log open */

--- a/tests/302_filter-token-overflow.test
+++ b/tests/302_filter-token-overflow.test
@@ -44,8 +44,8 @@ longrule "$maxfilter" "$tmpdir/fit.txt"
 assert_eq "http://www.example.com/a.png: accepted by rule #2 (+*.png)" \
     "$(why "$tmpdir/fit.txt")" "filter of $maxfilter bytes"
 
-# One byte over, and it is gone: the numbering shifts. The two overshoots die
-# differently before the fix, on the filter slot then on the stack canary.
+# One byte over, and it is gone: the numbering shifts. 512 over is there to
+# land past the buffer, not merely past the bound.
 for over in 1 512; do
     longrule "$((maxfilter + over))" "$tmpdir/over.txt"
     assert_eq "http://www.example.com/a.png: accepted by rule #1 (+*.png)" \

--- a/tests/302_filter-token-overflow.test
+++ b/tests/302_filter-token-overflow.test
@@ -13,8 +13,9 @@ assert_selftest "scantoken self-test OK" scantoken
 tmpdir="$(mktemp -d)"
 cleanup_push rm -rf "$tmpdir"
 
-# HTS_URLMAXSIZE * 2, less the sign the filter slot gains and the NUL
-maxfilter=2046
+# HTS_URLMAXSIZE * 2, less the NUL. The sign is prepended after the copy,
+# into a slot of its own, so it costs the token nothing.
+maxfilter=2047
 maxurl=2047
 
 rep() { # rep CHAR COUNT
@@ -37,8 +38,8 @@ longrule() { # longrule LENGTH FILE
     printf -- '-%s\n+*.png\n' "$(rep a "$1")" >"$2"
 }
 
-# At the bound the rule is kept, so the one that decides is the second. This is
-# also the longest rule the pre-fix engine handled without dying.
+# At the bound the rule is kept, so the one that decides is the second. The
+# pre-fix engine handled this length too, so refusing it would be a step back.
 longrule "$maxfilter" "$tmpdir/fit.txt"
 assert_eq "http://www.example.com/a.png: accepted by rule #2 (+*.png)" \
     "$(why "$tmpdir/fit.txt")" "filter of $maxfilter bytes"


### PR DESCRIPTION
The token gate in `httpmirror()` subtracts a byte from `tempo` for the sign, but the sign is prepended into `rule` after the copy, so `tempo` never holds it. A filter token of 2047 bytes is refused, where the buffer takes it and `filters_insert` still accepts the 2048-byte rule it makes. 352d2ba5 stored that rule and dropped at 2048, so #1280 narrowed the accepted set by one byte. The console and log message compounds it by naming 2046 as the limit, two below the real one.

Test 302 pinned 2046 as the bound and called it the longest the pre-fix engine handled without dying. It is not: that engine stores a 2047-byte token. The assertion was read off the new code instead of the contract, so it locked the regression in. Corrected here, and it goes red on master.

Found while reviewing the same bug from the other end, in #1296, which #1280 beat to it.