### PR TITLE
Test 207 fails on a SIGPIPE from its own pipeline

### DIFF
--- a/tests/151_bash-shell-validate.test
+++ b/tests/151_bash-shell-validate.test
@@ -202,7 +202,9 @@ test "$rc" -eq 77 || fail "a slow but writing configure with 6s of budget report
 rc=$(probe 92 6 bash -c 'sleep 987 & wait')
 test "$rc" -eq 1 || fail "a silent configure with a child of its own reported $rc, want 1"
 sleep 1
-! ps_snapshot | grep -q '[s]leep 987' || fail "the killed run left its child running"
+# Not through a pipe: grep -q would leave ps_snapshot writing into a closed one,
+# and pipefail would then read the leaked child as an absent one.
+! grep -q '[s]leep 987' <<<"$(ps_snapshot)" || fail "the killed run left its child running"
 # The pacer must not fire before the case is judged: run() returns with the verdict
 # still unread, and a skip there would bury a configure that answered wrongly. Through
 # the real run(), since a stub cannot see a pacer left inside the one it replaced.

--- a/tests/207_install-headers-symbols.test
+++ b/tests/207_install-headers-symbols.test
@@ -102,8 +102,10 @@ awk 'NF >= 3 && $3 !~ /\./ { print $3 }' "$tmp/all.raw" | sort -u >"$tmp/plain"
 for suffix in lto_priv constprop isra part cold llvm; do
     awk -v s="$suffix" 'NF >= 3 && $3 ~ "\\." s "([.$]|$)" { print $3 }' "$tmp/all.raw" |
         sed -E 's/(\.[A-Za-z_][A-Za-z0-9_]*(\.[0-9]+)*)+$//' | sort -u >"$tmp/cloned"
+    # No early exit: awk quitting on the first match leaves comm writing into a
+    # closed pipe, and pipefail turns that SIGPIPE into the test's own failure.
     sym=$(comm -23 <(comm -23 "$tmp/cloned" "$tmp/plain") "$tmp/exported" |
-        awk '/^[A-Za-z_][A-Za-z0-9_]*$/ { print; exit }')
+        awk '/^[A-Za-z_][A-Za-z0-9_]*$/ && !seen { print; seen = 1 }')
     if [ -n "$sym" ]; then
         canaries+=("$sym")
     fi


### PR DESCRIPTION
The clone-suffix loop in test 207 pipes `comm` into an `awk` that exits on the first match. When `comm` still has output to write, it takes SIGPIPE, `pipefail` hands that status to the command substitution, and errexit ends the test with nothing to read but `comm: write error: Broken pipe`.

Only `lto_priv` is big enough to lose the race: at the syscall level `comm` emits it as two writes, 4096 and 213 bytes, while the other five suffix lists go out in one write the reader has not had a chance to close on yet. That is why the `-flto` leg alone sees it. It went red on an unrelated PR whose only change was a comment in another test, and green on the commit before.

awk now reads to the end and keeps the first match in a flag. Output is byte-identical for every input, checked against gawk, mawk and busybox awk, and the canary chosen for each of the six suffixes is unchanged.

The sweep for the same shape then turned up one more, fixed here too, and it fails the worse way. `151_bash-shell-validate.test` asserts that a killed configure left no child behind, by piping `ps_snapshot` into `grep -q`: the match that proves the leak is also what closes the pipe, so under `pipefail` the SIGPIPE becomes the pipeline status, the leading `!` inverts it, and a surviving child reads as an absent one. It is a vacuous pass on precisely the failure case. Both now use the here-string form that `105_suite-timeout.test` already uses for the same check.

AGENTS.md documents this for `grep -q` and `head`; awk with `exit` is the same family.