### PR TITLE
The filter page describes a matcher that does not exist

### DIFF
--- a/html/cmdguide.html
+++ b/html/cmdguide.html
@@ -173,7 +173,7 @@ most scope problems once you understand them. A filter is a rule that accepts
   <li><b>Last match wins.</b> Rules are applied in order and the last one that
   matches a URL decides its fate. Order your rules from general to specific.</li>
   <li><b>Wildcards.</b> <tt>*</tt> matches any run of characters;
-  <tt>*[a-z]</tt>, <tt>*[0-9]</tt> and similar classes match sets. So
+  <tt>*[a-z]</tt>, <tt>*[0-9]</tt> and similar classes match a run of characters from a set, and the run may be empty. So
   <tt>+*.pdf</tt> means "any URL ending in .pdf".</li>
   <li><b>Whitelisting.</b> To keep one site and nothing else, deny everything then
   re-admit the host: <tt>"-*" "+example.com/*"</tt>. A lone <tt>+</tt> rule only
@@ -210,8 +210,8 @@ bracket forms match narrower sets. The full table, with size and mime rules, is 
   <tr><td><tt>*[file]</tt>, <tt>*[name]</tt></td><td>one path segment (any char but <tt>/</tt> and <tt>?</tt>)</td><td><tt>example.com/*[file]/</tt> &mdash; a directory-index page</td></tr>
   <tr><td><tt>*[path]</tt></td><td>a path, slashes allowed (any char but <tt>?</tt>)</td><td><tt>example.com/*[path].zip</tt></td></tr>
   <tr><td><tt>*[param]</tt></td><td>an optional query string</td><td><tt>page.html*[param]</tt> matches with or without <tt>?...</tt></td></tr>
-  <tr><td><tt>*[a,b,c]</tt></td><td>any one character in the set</td><td><tt>*[a,b,c].txt</tt></td></tr>
-  <tr><td><tt>*[a-z]</tt></td><td>any one character in the range</td><td><tt>img*[0-9].gif</tt></td></tr>
+  <tr><td><tt>*[a,b,c]</tt></td><td>a run of characters from the set</td><td><tt>*[a,b,c].txt</tt></td></tr>
+  <tr><td><tt>*[a-z]</tt></td><td>a run of characters from the range, lowercase only</td><td><tt>img*[0-9].gif</tt></td></tr>
   <tr><td><tt>*[\x]</tt></td><td>the literal character x (escapes <tt>* [ ] \</tt>)</td><td><tt>*[\*]</tt> matches a real <tt>*</tt></td></tr>
   <tr><td><tt>*[&lt;NN]</tt>, <tt>*[&gt;NN]</tt></td><td>file size in KB below / above NN</td><td><tt>-*.gif*[&lt;5]</tt> skips GIFs under 5&nbsp;KB</td></tr>
   <tr><td><tt>*[]</tt></td><td>end anchor: nothing may follow</td><td><tt>*.html*[]</tt> rejects <tt>i.html?p=1</tt></td></tr>

--- a/html/fcguide.html
+++ b/html/fcguide.html
@@ -1949,12 +1949,12 @@ are in reverse priority order.  Here's an example:
 
     <table BORDER="1" CELLPADDING="2">
     <tr><td>
-    <b>+*.gif -image*.gif</b>
+    <b>+*.gif -*image*.gif</b>
     </td><td>
     Will accept all gif files BUT image1.gif,imageblue.gif,imagery.gif and so on
     </tr>
     <tr><td>
-    <b>-image*.gif +*.gif</b>
+    <b>-*image*.gif +*.gif</b>
     </td><td>
     Will accept all gif files, because the second pattern is prioritary (because it is defined AFTER the first one)
     </tr>
@@ -1969,11 +1969,11 @@ are in reverse priority order.  Here's an example:
       </tr>
       <tr>
         <td><b>*[file] or *[name]</b></td>
-        <td>any filename or name, e.g. not /,? and ; characters</td>
+        <td>a run of any characters, stopping at / or ?</td>
       </tr>
       <tr>
         <td><b>*[path]</b></td>
-        <td>any path (and filename), e.g. not ? and ; characters</td>
+        <td>a run of any characters, stopping at ? (/ is allowed)</td>
       </tr>
       <tr>
         <td><b>*[a,z,e,r,t,y]</b></td>
@@ -1981,7 +1981,7 @@ are in reverse priority order.  Here's an example:
       </tr>
       <tr>
         <td><b>*[a-z]</b></td>
-        <td>any letters</td>
+        <td>any lowercase letters from a to z (a range, and case-sensitive)</td>
       </tr>
       <tr>
         <td><b>*[0-9,a,z,e,r,t,y]</b></td>
@@ -2016,7 +2016,7 @@ generated automatically using the interface)
       </tr>
       <tr>
         <td><b>+*.com/*</b></td>
-        <td>This will accept all links that contains .com in them</td>
+        <td>This will accept links where .com is followed by a /, so a .com host but also a path such as www.example.org/dir.com/page</td>
       </tr>
       <tr>
         <td><b>-*cgi-bin* </b></td>
@@ -2024,7 +2024,7 @@ generated automatically using the interface)
       </tr>
       <tr>
         <td><b>+*.com/*[path].zip </b></td>
-        <td>This will accept all zip files in .com addresses</td>
+        <td>This will accept zip files on addresses starting with www. and containing .com/</td>
       </tr>
       <tr>
         <td><b>-*example*/*.tar*</b></td>

--- a/html/filters.html
+++ b/html/filters.html
@@ -218,10 +218,10 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
 
 
     <p align="JUSTIFY"><br>
-    Here are some example patterns: (that can be generated automatically using the
-    interface) A pattern becomes a scan rule only once you prefix it with <tt>+</tt> to
-    accept or <tt>-</tt> to refuse. On its own it is not a filter at all: HTTrack reads
-    it as one more URL to crawl.</p>
+    Here are some example patterns (they can also be generated automatically using the
+    interface). A pattern becomes a scan rule only once you prefix it with <tt>+</tt> to
+    accept or <tt>-</tt> to refuse. On its own it is not a filter: HTTrack reads it as one
+    more URL to crawl.</p>
     <table BORDER="1" CELLPADDING="2">
       <tr>
         <td nowrap><tt>www.thisweb.com* </tt></td>

--- a/html/filters.html
+++ b/html/filters.html
@@ -69,8 +69,9 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
     starts links, the default mode is to mirror these links - i.e. if one of your start page is
     www.example.com/test/index.html, all links starting with www.example.com/test/ will be
     accepted. But links directly in www.example.com/.. will not be accepted, however, because
-    they are in a higher structure. This prevent HTTrack from mirroring the whole site. (All
-    files in structure levels equal or lower than the primary links will be retrieved.)<br>
+    they are in a higher structure. This prevent HTTrack from mirroring the whole site. (Only
+    the start page's own directory and the directories below it are in scope: a sibling such as
+    www.example.com/other/ is refused too, since it is not below www.example.com/test/.)<br>
     </i>
     <br>
     <b>But</b> you may want to download files that are not directly in the subfolders, or on the 
@@ -106,7 +107,7 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
     including gif files inside this domain and outside (external images), but not take to large images, 
     or too small ones (thumbnails)<br>
     Excluding gif images smaller than 5KB and images larger than 100KB is therefore a good option;
-    +www.example.com +*.gif -*.gif*[<5] -*.gif*[>100] 
+    +www.example.com/* +*.gif -*.gif*[<5] -*.gif*[>100] 
     
     <br>
     
@@ -154,12 +155,12 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
     <br>
     <table BORDER="1" CELLPADDING="2">
     <tr><td nowrap>
-    <tt>+*.gif -image*.gif</tt>
+    <tt>+*.gif -*image*.gif</tt>
     </td><td>
     Will accept all gif files BUT image1.gif,imageblue.gif,imagery.gif and so on
     </tr>
     <tr><td nowrap>
-    <tt>-image*.gif +*.gif</tt>
+    <tt>-*image*.gif +*.gif</tt>
     </td><td>
     Will accept all gif files, because the second pattern is prioritary (because it is defined AFTER the first one)
     </tr>
@@ -172,7 +173,8 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
     We saw that patterns are composed of letters and wildcards (<b><tt>*</tt></b>), as in */image*.gif
 
     <p align="JUSTIFY"><br>
-    Special wild cards can be used for specific characters: (*[..])</p>
+    Special wild cards can be used for specific characters: (*[..]). Each of these matches a
+    run of characters, and the run may be empty; <tt>*(..)</tt> matches exactly one.</p>
     <table BORDER="1" CELLPADDING="2">
       <tr>
         <td nowrap><tt>*</tt></td>
@@ -180,11 +182,11 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
       </tr>
       <tr>
         <td nowrap><tt>*[file] or *[name]</tt></td>
-        <td>any filename or name, e.g. not /,? and ; characters</td>
+        <td>a run of any characters except / and ?</td>
       </tr>
       <tr>
         <td nowrap><tt>*[path]</tt></td>
-        <td>any path (and filename), e.g. not ? and ; characters</td>
+        <td>a run of any characters except ?, so / is allowed</td>
       </tr>
       <tr>
         <td nowrap><tt>*[a,z,e,r,t,y]</tt></td>
@@ -192,7 +194,7 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
       </tr>
       <tr>
         <td nowrap><tt>*[a-z]</tt></td>
-        <td>any letters</td>
+        <td>any lowercase letters from a to z (a range, and case-sensitive)</td>
       </tr>
       <tr>
         <td nowrap><tt>*[0-9,a,z,e,r,t,y]</tt></td>
@@ -225,11 +227,14 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
     <table BORDER="1" CELLPADDING="2">
       <tr>
         <td nowrap><tt>www.thisweb.com* </tt></td>
-        <td>This will refuse/accept this web site (all links located in it will be rejected)</td>
+        <td>This will refuse/accept this web site. The trailing <tt>*</tt> is not anchored, so it also
+        matches any other host beginning with the same text, such as www.thisweb.com.example.org;
+        use www.thisweb.com/* to pin it to the site itself</td>
       </tr>
       <tr>
         <td nowrap><tt>*.com/*</tt></td>
-        <td>This will refuse/accept all links that contains .com in them</td>
+        <td>This will refuse/accept all links where .com is followed by a /, so a .com host, but also a
+        path such as www.example.org/dir.com/page, and not a host carrying a port</td>
       </tr>
       <tr>
         <td nowrap><tt>*cgi-bin* </tt></td>
@@ -237,11 +242,13 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
       </tr>
       <tr>
         <td nowrap><tt>www.*[path].com/*[path].zip </tt></td>
-        <td>This will refuse/accept all zip files in .com addresses</td>
+        <td>This will refuse/accept all zip files on addresses starting with www. and containing .com/;
+        use *.com/*[path].zip for a .com host that does not start with www.</td>
       </tr>
       <tr>
         <td nowrap><tt>*example*/*.tar*</tt></td>
-        <td>This will refuse/accept all tar (or tar.gz etc.) files in hosts containing example</td>
+        <td>This will refuse/accept all tar (or tar.gz etc.) files whose URL contains example before some
+        /, in the host or in any directory of the path</td>
       </tr>
       <tr>
         <td nowrap><tt>*/*somepage*</tt></td>
@@ -288,7 +295,7 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
       </tr>
       <tr>
         <td nowrap><tt>*[&lt;NN&gt;MM]</tt></td>
-        <td>the file size must be smaller than NN KB and greater than MM KB
+        <td>only the first bound is read, so this behaves as <tt>*[&lt;NN]</tt>: give each bound a rule of its own
         <br>(note: this may cause broken files during the download)</td>
       </tr>
     </table>
@@ -310,8 +317,8 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
         <td>the file will be forbidden if if its size is smaller than 10 KB <b>or</b> greater than 50 KB</td>
       </tr>
       <tr>
-        <td nowrap><tt>+*[&lt;80&gt;1]</tt></td>
-        <td>the file will be accepted if if its size is smaller than 80 KB <b>and</b> greater than 1 KB</td>
+        <td nowrap><tt>+*[&lt;80] -*[&lt;1]</tt></td>
+        <td>the file will be accepted if its size is smaller than 80 KB <b>and</b> greater than 1 KB</td>
       </tr>
     </table>
 
@@ -325,7 +332,7 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
     type is compared against scan rules defined by the user.<br><br>
     A scan rule has a higher priority if it is declared later - hierarchy is important<br>
 
-    Note: scan rules based on MIME types can <b>NOT</b> be mixed with regular URL patterns or size patterns within the same rule, but you can use both of them in distinct ones<br>
+    Note: scan rules based on MIME types can <b>NOT</b> be mixed with regular URL patterns or size patterns within the same rule, but you can use both of them in distinct ones. HTTrack does not refuse such a rule, it simply never matches<br>
 
     <p align="JUSTIFY"><br>
     Here are some examples of filters: (that can be generated automatically using the

--- a/html/filters.html
+++ b/html/filters.html
@@ -69,9 +69,8 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
     starts links, the default mode is to mirror these links - i.e. if one of your start page is
     www.example.com/test/index.html, all links starting with www.example.com/test/ will be
     accepted. But links directly in www.example.com/.. will not be accepted, however, because
-    they are in a higher structure. This prevent HTTrack from mirroring the whole site. (Only
-    the start page's own directory and the directories below it are in scope: a sibling such as
-    www.example.com/other/ is refused too, since it is not below www.example.com/test/.)<br>
+    they are in a higher structure. This prevent HTTrack from mirroring the whole site. (A sibling
+    such as www.example.com/other/ is refused too, being no lower than the start page.)<br>
     </i>
     <br>
     <b>But</b> you may want to download files that are not directly in the subfolders, or on the 
@@ -182,11 +181,11 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
       </tr>
       <tr>
         <td nowrap><tt>*[file] or *[name]</tt></td>
-        <td>a run of any characters except / and ?</td>
+        <td>a run of any characters, stopping at / or ?</td>
       </tr>
       <tr>
         <td nowrap><tt>*[path]</tt></td>
-        <td>a run of any characters except ?, so / is allowed</td>
+        <td>a run of any characters, stopping at ? (/ is allowed)</td>
       </tr>
       <tr>
         <td nowrap><tt>*[a,z,e,r,t,y]</tt></td>
@@ -227,14 +226,13 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
     <table BORDER="1" CELLPADDING="2">
       <tr>
         <td nowrap><tt>www.thisweb.com* </tt></td>
-        <td>This will refuse/accept this web site. The trailing <tt>*</tt> is not anchored, so it also
-        matches any other host beginning with the same text, such as www.thisweb.com.example.org;
-        use www.thisweb.com/* to pin it to the site itself</td>
+        <td>This will refuse/accept this web site, and any longer hostname too, such as
+        www.thisweb.com.example.org; use www.thisweb.com/* to pin it to the site itself</td>
       </tr>
       <tr>
         <td nowrap><tt>*.com/*</tt></td>
-        <td>This will refuse/accept all links where .com is followed by a /, so a .com host, but also a
-        path such as www.example.org/dir.com/page, and not a host carrying a port</td>
+        <td>This will refuse/accept links where .com is followed by a /, so a .com host but also a path
+        such as www.example.org/dir.com/page; a host given with a port is missed</td>
       </tr>
       <tr>
         <td nowrap><tt>*cgi-bin* </tt></td>
@@ -242,8 +240,8 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
       </tr>
       <tr>
         <td nowrap><tt>www.*[path].com/*[path].zip </tt></td>
-        <td>This will refuse/accept all zip files on addresses starting with www. and containing .com/;
-        use *.com/*[path].zip for a .com host that does not start with www.</td>
+        <td>This will refuse/accept all zip files on addresses starting with www. and containing .com/,
+        so not a .com host spelled without the www.</td>
       </tr>
       <tr>
         <td nowrap><tt>*example*/*.tar*</tt></td>
@@ -295,8 +293,7 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
       </tr>
       <tr>
         <td nowrap><tt>*[&lt;NN&gt;MM]</tt></td>
-        <td>only the first bound is read, so this behaves as <tt>*[&lt;NN]</tt>: give each bound a rule of its own
-        <br>(note: this may cause broken files during the download)</td>
+        <td>only the first bound is read, so this behaves as <tt>*[&lt;NN]</tt>: give each bound a rule of its own</td>
       </tr>
     </table>
 
@@ -314,11 +311,12 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
       </tr>
       <tr>
         <td nowrap><tt>-*[&lt;10] -*[&gt;50]</tt></td>
-        <td>the file will be forbidden if if its size is smaller than 10 KB <b>or</b> greater than 50 KB</td>
+        <td>the file will be forbidden if its size is smaller than 10 KB <b>or</b> greater than 50 KB</td>
       </tr>
       <tr>
-        <td nowrap><tt>+*[&lt;80] -*[&lt;1]</tt></td>
-        <td>the file will be accepted if its size is smaller than 80 KB <b>and</b> greater than 1 KB</td>
+        <td nowrap><tt>+*[&lt;80]</tt></td>
+        <td>the file will be accepted if its size is smaller than 80 KB; a larger one is left to the
+        other rules, since an accepting rule refuses nothing</td>
       </tr>
     </table>
 

--- a/html/filters.html
+++ b/html/filters.html
@@ -218,8 +218,10 @@ See also: The <a href="faq.html#VF1">FAQ</a><br>
 
 
     <p align="JUSTIFY"><br>
-    Here are some examples of filters: (that can be generated automatically using the
-    interface)</p>
+    Here are some example patterns: (that can be generated automatically using the
+    interface) A pattern becomes a scan rule only once you prefix it with <tt>+</tt> to
+    accept or <tt>-</tt> to refuse. On its own it is not a filter at all: HTTrack reads
+    it as one more URL to crawl.</p>
     <table BORDER="1" CELLPADDING="2">
       <tr>
         <td nowrap><tt>www.thisweb.com* </tt></td>

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -687,19 +687,17 @@ int httpmirror(char *url1, httrackp * opt) {
         int type;
         int plus = 0;
 
-        // noter joker (dans b)
-        if (*a == '+') {        // champ +
+        if (*a == '+') { // the accept field
           type = 1;
           plus = 1;
           a++;
-        } else if (*a == '-') { // champ forbidden[]
+        } else if (*a == '-') { // the forbidden[] field
           type = 0;
           a++;
-        } else {                // champ + avec joker sans doute
+        } else { // dead: joker is set only for '+' or '-' (#1297)
           type = 1;
         }
 
-        // recopier prochaine chaine (+ ou -)
         /* the sign is prepended into `rule` below, not held here; only the
            implicit form's trailing '*' has to be left room for */
         const size_t room = sizeof(tempo) - (plus == 0 && type == 1 ? 1 : 0);
@@ -714,11 +712,12 @@ int httpmirror(char *url1, httrackp * opt) {
           continue;
         }
 
-        // sauter les + sans rien après..
+        // skip a sign with nothing after it
         if (strnotempty(tempo)) {
-          if ((plus == 0) && (type == 1)) {     // implicite: *www.edf.fr par exemple
+          /* only the dead arm above reaches this, so nothing appends the '*' */
+          if ((plus == 0) && (type == 1)) {
             if (hts_lastchar(tempo) != '*') {
-              strcatbuff(tempo, "*");   // ajouter un *
+              strcatbuff(tempo, "*");
             }
           }
           {

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -676,13 +676,14 @@ int httpmirror(char *url1, httrackp * opt) {
     while (*a) {
       int joker = 0;
 
-      // vérifier qu'il n'y a pas de * dans l'url
+      // only a leading + or - makes a token a filter rule; anything else is a
+      // URL
       if (*a == '+')
         joker = 1;
       else if (*a == '-')
         joker = 1;
 
-      if (joker) { // joker ou filters
+      if (joker) { // a filter rule
         char BIGSTK tempo[HTS_URLMAXSIZE * 2];
         int type;
         int plus = 0;
@@ -694,12 +695,12 @@ int httpmirror(char *url1, httrackp * opt) {
         } else if (*a == '-') { // the forbidden[] field
           type = 0;
           a++;
-        } else { // dead: joker is set only for '+' or '-' (#1297)
+        } else { // dead: joker is set only for '+' or '-'
           type = 1;
         }
 
-        /* the sign is prepended into `rule` below, not held here; only the
-           implicit form's trailing '*' has to be left room for */
+        /* the sign is prepended into `rule` below, not held here; the spare
+           byte is the dead branch's trailing '*' */
         const size_t room = sizeof(tempo) - (plus == 0 && type == 1 ? 1 : 0);
 
         if (!hts_scan_token(&a, tempo, room)) {
@@ -714,7 +715,6 @@ int httpmirror(char *url1, httrackp * opt) {
 
         // skip a sign with nothing after it
         if (strnotempty(tempo)) {
-          /* only the dead arm above reaches this, so nothing appends the '*' */
           if ((plus == 0) && (type == 1)) {
             if (hts_lastchar(tempo) != '*') {
               strcatbuff(tempo, "*");
@@ -748,7 +748,7 @@ int httpmirror(char *url1, httrackp * opt) {
 
         }
 
-      } else { // adresse normale
+      } else { // a plain URL
         char BIGSTK url[HTS_URLMAXSIZE * 2];
 
         // prochaine adresse


### PR DESCRIPTION
`filters.html` lists `www.thisweb.com*`, `*cgi-bin*` and six more under "Here are some examples of filters", none of them carrying a `+` or a `-`. They are patterns, not rules, and the page never says so. Copy one into a scan-rules file and HTTrack does not read it as a filter at all: it takes it for another URL and crawls it. Against 3.49-21, `*cgi-bin*` in a `-%S` file gives "no filter rule matches" and turns up in the log banner as a URL.

The engine's own comments claimed the opposite, that a bare `*www.edf.fr` is an implicit accept rule. Nothing reaches that code: `joker` is set only for `+` or `-`, and both assign `plus` or `type`, so the third arm never runs. The comments now say the arm is dead instead of describing a form that has never worked. The dead code stays, since whether the implicit form should exist is a separate question.

Auditing the rest of the page for the same problem turned up ten more claims that do not match the engine. Each was checked with `-#test=filter`, `-#test=filtersize` or `-#test=filtermime`, and every replacement was run before being written down.

`*[file]`, `*[name]` and `*[path]` all say they exclude `;`. None of them does, so `www.x.com/a;jsessionid=1` matches `www.x.com/*[file]`. `*[a-z]` is called "any letters" when it is a lowercase range that refuses `A`. The priority example used `-image*.gif`, which is anchored at the start of the whole URL and so never fires on a real one: `www.x.com/image1.gif does NOT match image*.gif`. The size table offered `*[<NN>MM]` as two bounds, but only the first is read, so `+*[<80>1]` accepts a 0 KB file; that half-implemented syntax is #1303, and the page now points at the two-rule form instead. The opening paragraph promised every structure level "equal or lower", while a sibling directory is equal and refused.

Four of the eight example patterns described something wider or narrower than they match. `*.com/*` is not "contains .com": the `.com` must be followed by a `/`, so it misses `www.example.com:8080/x` and catches `www.example.org/dir.com/page`. `*example*/*.tar*` is not about hosts, any path segment will do. `www.*[path].com/*[path].zip` silently requires the `www.`. Worst is `www.thisweb.com*`, a bare prefix that also takes `www.thisweb.com.example.org`, which as a `+` rule hands the crawl to whoever registers that name; the engine's own self-test already asserts the wizard never emits such a pattern.

Three things were missing rather than wrong, and each changes what a rule built from them does: a `*[..]` class matches a run and may match nothing, `*(..)` takes exactly one character, and a mime rule carrying a URL or size clause is stored and then never matches.

A review pass over those corrections caught three of them being wrong in turn, now fixed. "A run of any characters except `/` and `?`" reads as if a URL with a query cannot match: the run stops at `?`, the pattern does not. `+*[<80] -*[<1]` was offered as a size window, but an accepting rule refuses nothing, so above 80 KB the pair decides nothing; the row now shows `+*[<80]` and says so. And the zip row recommended `*.com/*[path].zip`, which walks into the trap the row two above it warns about.

`fcguide.html` and `cmdguide.html` carry the same tables, so correcting `filters.html` alone left seven statements contradicting it. They are corrected here too. `cmdguide.html` was also wrong on its own terms, calling a class "any one character in the set" when `ab.txt` and `.txt` both match `*[a,b,c].txt`.

Closes #1297