### PR TITLE
Windows jobs queue repo-wide for a cap that outlived its reason

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -31,11 +31,10 @@ jobs:
       matrix:
         platform: [x64, Win32]
         configuration: [Release]
-    # Windows runs from other branches starve this one's runner (#1213), so cap
-    # them repo-wide at one per platform. queue: max: the default cancels a waiter.
-    concurrency:
-      group: windows-build-${{ matrix.platform }}
-      queue: max
+    # No repo-wide cap since #1213's 45-minute wedges: the suite runs parallel
+    # now and the step below is capped at 15, so queueing cost more than the
+    # overlap it prevented (a 9-minute job waited 51 behind other PRs).
+    timeout-minutes: 30
     # Redirect vcpkg's default `files` binary cache into the workspace so
     # actions/cache can persist it. vcpkg builds openssl/brotli/zlib/zstd from
     # source otherwise, several minutes every run.
@@ -265,7 +264,8 @@ jobs:
       - name: Run the engine test suite (offline tests)
         shell: bash
         working-directory: tests
-        timeout-minutes: 45
+        # 6 minutes is the measured run; the rest is headroom for a wedge to die in
+        timeout-minutes: 15
         env:
           # Through the environment, never argv, which the process list exposes.
           WATCHDOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -31,10 +31,10 @@ jobs:
       matrix:
         platform: [x64, Win32]
         configuration: [Release]
-    # No repo-wide cap since #1213's 45-minute wedges: the suite runs parallel
-    # now and the step below is capped at 15, so queueing cost more than the
-    # overlap it prevented (a 9-minute job waited 51 behind other PRs).
-    timeout-minutes: 30
+    # No repo-wide cap: #1213 added one against runner starvation, which #1228
+    # later measured out. The 35 minutes bound a slow job, not a lost runner:
+    # the service reaps that one, and no timeout-minutes shortens it.
+    timeout-minutes: 35
     # Redirect vcpkg's default `files` binary cache into the workspace so
     # actions/cache can persist it. vcpkg builds openssl/brotli/zlib/zstd from
     # source otherwise, several minutes every run.
@@ -264,7 +264,7 @@ jobs:
       - name: Run the engine test suite (offline tests)
         shell: bash
         working-directory: tests
-        # 6 minutes is the measured run; the rest is headroom for a wedge to die in
+        # 6 minutes is the measured run; the rest catches a hang while the runner still lives
         timeout-minutes: 15
         env:
           # Through the environment, never argv, which the process list exposes.

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -32,9 +32,8 @@ jobs:
         platform: [x64, Win32]
         configuration: [Release]
     # No repo-wide cap: #1213 added one against runner starvation, which #1228
-    # later measured out. The 35 minutes bound a slow job, not a lost runner:
-    # the service reaps that one, and no timeout-minutes shortens it.
-    timeout-minutes: 35
+    # later measured out. The step timeouts stay as they are, sized by 226
+    # against the suite watchdog, not against how long a job takes.
     # Redirect vcpkg's default `files` binary cache into the workspace so
     # actions/cache can persist it. vcpkg builds openssl/brotli/zlib/zstd from
     # source otherwise, several minutes every run.
@@ -264,8 +263,7 @@ jobs:
       - name: Run the engine test suite (offline tests)
         shell: bash
         working-directory: tests
-        # 6 minutes is the measured run; the rest catches a hang while the runner still lives
-        timeout-minutes: 15
+        timeout-minutes: 45
         env:
           # Through the environment, never argv, which the process list exposes.
           WATCHDOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Windows matrix job carries a `concurrency` group keyed on the platform alone, with no ref and no run id, so one slot per platform is shared by every run in the repository. Queue waits measured over the last two weeks reach 69 minutes for a job that runs in 9, and they grow with the number of open pull requests: three at once is most of an evening.

#1213 added that cap against runner starvation, reasoning from three incidents where overlapping Windows jobs died. #1228 later measured the inference and rejected it: across 146 kills in 3470 jobs, the killed ones saw a mean 4.9 concurrent siblings against 5.2 for the healthy ones, with the rate flat across concurrency buckets. The hazard tracks work done rather than elapsed time or overlap, and the same jobs run either way, so removing the cap does not change how many kills to expect, only when they land.

The timeouts are deliberately untouched. An earlier revision of this branch cut the suite step from 45 minutes to 15 and added a 35-minute job cap; 226 failed on ten legs and was right to. It reads the step's `timeout-minutes` out of this file and holds it against the suite watchdog: the cap has to clear `suite_deadline + stuck + 240` and `hard_deadline + 240`, both 2640s, and the watchdog's own `MaxSeconds` of 2700s. So 45 minutes is the tightest legal value rather than slack, and a shorter one would kill the suite before the watchdog could kill a hung test and dump what it found, which is the telemetry #1228 is waiting on. The job cap was wrong the same way, sitting under the step it contains.

Nothing is lost by leaving them: a job that loses its runner is reaped by the service 2700 seconds after its last lease renewal, independent of `timeout-minutes`, measured at 15 and 75. Every wedge in the history above died that way, with the suite step left `conclusion: null` and its 45-minute cap never firing. The timeouts were never what made queueing expensive.

If contention does appear, shard the group per platform for two slots rather than restoring a single one.

Two notes for whoever picks this up next. `queue: max`, removed with the block, is not a key I can find in GitHub's documented concurrency schema and there is no actionlint here to check it; jobs did visibly queue rather than cancel, so something honoured it. And 226 skips without PowerShell, so a local suite run cannot check the timeout contract at all.