### PR TITLE
Nothing counts the MSYS fork failures, and the suite forks more than it needs

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -282,8 +282,8 @@ jobs:
             "$(cygpath -u "$GITHUB_WORKSPACE")/src/${{ matrix.platform }}/${{ matrix.configuration }}" \
             2>&1 | tee suite-console.log
 
-      # Its own step: the suite's may have been killed by its watchdog, which is
-      # exactly when the count is worth having.
+      # Its own step: the watchdog can kill the suite's step before it counts,
+      # which is exactly when the count is worth having.
       - name: Count the MSYS fork failures
         if: always()
         shell: bash

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -276,8 +276,21 @@ jobs:
           WATCHDOG_CONTEXT: windows-suite (${{ matrix.platform }}, ${{ matrix.configuration }})
           WATCHDOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          # Teed: the MSYS fork failures (#1273) land on this stderr, which no
+          # later step can read back.
           bash ./ci-windows-suite.sh \
-            "$(cygpath -u "$GITHUB_WORKSPACE")/src/${{ matrix.platform }}/${{ matrix.configuration }}"
+            "$(cygpath -u "$GITHUB_WORKSPACE")/src/${{ matrix.platform }}/${{ matrix.configuration }}" \
+            2>&1 | tee suite-console.log
+
+      # Its own step: the suite's may have been killed by its watchdog, which is
+      # exactly when the count is worth having.
+      - name: Count the MSYS fork failures
+        if: always()
+        shell: bash
+        working-directory: tests
+        run: |
+          . ./ci-windows-suite.sh
+          ci_report_fork_failures suite-console.log
 
       - name: Upload the test logs
         if: always()

--- a/tests/01_engine-cacheindex.test
+++ b/tests/01_engine-cacheindex.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Cache-index (.ndx) parse must stay inside the buffer on a corrupt length
 # prefix (ASan aborts here on the pre-fix binary; the OK check gates the

--- a/tests/01_engine-cacheindex.test
+++ b/tests/01_engine-cacheindex.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Cache-index (.ndx) parse must stay inside the buffer on a corrupt length
 # prefix (ASan aborts here on the pre-fix binary; the OK check gates the

--- a/tests/01_engine-changes.test
+++ b/tests/01_engine-changes.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_changes_st.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmpdir"

--- a/tests/01_engine-changes.test
+++ b/tests/01_engine-changes.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_changes_st.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmpdir"

--- a/tests/01_engine-charset.test
+++ b/tests/01_engine-charset.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # charset -> UTF-8 conversion (hts_convertStringToUTF8).
 # -#test=charset <charset> <string> prints the string re-decoded from <charset> as UTF-8.

--- a/tests/01_engine-charset.test
+++ b/tests/01_engine-charset.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # charset -> UTF-8 conversion (hts_convertStringToUTF8).
 # -#test=charset <charset> <string> prints the string re-decoded from <charset> as UTF-8.

--- a/tests/01_engine-cmdline.test
+++ b/tests/01_engine-cmdline.test
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_cmdline.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmp"

--- a/tests/01_engine-cmdline.test
+++ b/tests/01_engine-cmdline.test
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_cmdline.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmp"

--- a/tests/01_engine-cookieimport.test
+++ b/tests/01_engine-cookieimport.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Drives -#test=cookieimport: load a cookie jar (and, on Windows, copied IE
 # cookies *@*.txt) from a long, non-ASCII folder through the UTF-8/long-path

--- a/tests/01_engine-cookieimport.test
+++ b/tests/01_engine-cookieimport.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Drives -#test=cookieimport: load a cookie jar (and, on Windows, copied IE
 # cookies *@*.txt) from a long, non-ASCII folder through the UTF-8/long-path

--- a/tests/01_engine-direnum.test
+++ b/tests/01_engine-direnum.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Drives -#test=direnum: enumerate a long+non-ASCII directory through the
 # opendir/readdir wrappers, checking each child round-trips as UTF-8 (#133,#630).

--- a/tests/01_engine-direnum.test
+++ b/tests/01_engine-direnum.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Drives -#test=direnum: enumerate a long+non-ASCII directory through the
 # opendir/readdir wrappers, checking each child round-trips as UTF-8 (#133,#630).

--- a/tests/01_engine-doitlog.test
+++ b/tests/01_engine-doitlog.test
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Resolve httrack to an absolute path before we cd: PATH may hold a
 # build-relative entry that would not resolve from the temp directory.

--- a/tests/01_engine-doitlog.test
+++ b/tests/01_engine-doitlog.test
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Resolve httrack to an absolute path before we cd: PATH may hold a
 # build-relative entry that would not resolve from the temp directory.

--- a/tests/01_engine-entities.test
+++ b/tests/01_engine-entities.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # HTML entity unescaping (hts_unescapeEntitiesWithCharset).
 # -#test=entities <string> prints the string with entities decoded (UTF-8 output).

--- a/tests/01_engine-entities.test
+++ b/tests/01_engine-entities.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # HTML entity unescaping (hts_unescapeEntitiesWithCharset).
 # -#test=entities <string> prints the string with entities decoded (UTF-8 output).

--- a/tests/01_engine-expandhome.test
+++ b/tests/01_engine-expandhome.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # ~ expansion for the -O base path (expand_home). $HOME is pinned so the cases
 # cannot depend on the caller's, but MSYS rewrites it into a Windows path

--- a/tests/01_engine-expandhome.test
+++ b/tests/01_engine-expandhome.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # ~ expansion for the -O base path (expand_home). $HOME is pinned so the cases
 # cannot depend on the caller's, but MSYS rewrites it into a Windows path

--- a/tests/01_engine-filelist.test
+++ b/tests/01_engine-filelist.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_filelist.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmp"

--- a/tests/01_engine-filelist.test
+++ b/tests/01_engine-filelist.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_filelist.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmp"

--- a/tests/01_engine-filter.test
+++ b/tests/01_engine-filter.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # wildcard filter engine (strjoker), the core of +/- include/exclude rules.
 # -#test=filter <filter> <string> prints "<string> does match <filter>" or "... does NOT match ...".

--- a/tests/01_engine-filter.test
+++ b/tests/01_engine-filter.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # wildcard filter engine (strjoker), the core of +/- include/exclude rules.
 # -#test=filter <filter> <string> prints "<string> does match <filter>" or "... does NOT match ...".

--- a/tests/01_engine-filterdual.test
+++ b/tests/01_engine-filterdual.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # fa_strjoker_dual: merged verdict on the two URL forms the engine tests;
 # the match latest in the filter list wins, an unknown verdict defers.

--- a/tests/01_engine-filterdual.test
+++ b/tests/01_engine-filterdual.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # fa_strjoker_dual: merged verdict on the two URL forms the engine tests;
 # the match latest in the filter list wins, an unknown verdict defers.

--- a/tests/01_engine-footer-boundary.test
+++ b/tests/01_engine-footer-boundary.test
@@ -6,7 +6,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # The emitter's buffer, 1024 + 2 * HTS_URLMAXSIZE. The sweep window is derived
 # from it; a wrong value makes the crossing check below fail loudly.

--- a/tests/01_engine-footer-boundary.test
+++ b/tests/01_engine-footer-boundary.test
@@ -42,7 +42,7 @@ crawl() { # crawl FOOTER [LABEL], leaving the mirrored page in $body
     local found
     found=$(find "$mir/file" -name index.html 2>/dev/null || true)
     test -n "$found" || fail "page not mirrored; the footer path never ran"
-    body=$(cat "$found")
+    body=$(<"$found")
 }
 
 # Which line the footer lands on follows the page's own newlines, so find it by

--- a/tests/01_engine-footer-boundary.test
+++ b/tests/01_engine-footer-boundary.test
@@ -6,7 +6,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # The emitter's buffer, 1024 + 2 * HTS_URLMAXSIZE. The sweep window is derived
 # from it; a wrong value makes the crossing check below fail loudly.

--- a/tests/01_engine-footer-overflow.test
+++ b/tests/01_engine-footer-overflow.test
@@ -11,7 +11,7 @@ set -eu
 # The overflow needs a path longer than Windows MAX_PATH (260), so both the
 # source tree and the mirror output blow past it there; run on POSIX only. The
 # fix itself is platform-independent and covered on Linux/macOS.
-case "$(uname -s 2>/dev/null)" in
+case "$HTS_OS" in
 MINGW* | MSYS* | CYGWIN*) exit 77 ;;
 esac
 

--- a/tests/01_engine-footer-overflow.test
+++ b/tests/01_engine-footer-overflow.test
@@ -6,7 +6,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # The overflow needs a path longer than Windows MAX_PATH (260), so both the
 # source tree and the mirror output blow past it there; run on POSIX only. The

--- a/tests/01_engine-footer-overflow.test
+++ b/tests/01_engine-footer-overflow.test
@@ -6,7 +6,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # The overflow needs a path longer than Windows MAX_PATH (260), so both the
 # source tree and the mirror output blow past it there; run on POSIX only. The

--- a/tests/01_engine-fsize.test
+++ b/tests/01_engine-fsize.test
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/01_engine-fsize.test
+++ b/tests/01_engine-fsize.test
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/01_engine-ftp-userpass.test
+++ b/tests/01_engine-ftp-userpass.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpuser.XXXXXX") || exit 1
 cleanup_push rm -rf "${tmpdir}"

--- a/tests/01_engine-ftp-userpass.test
+++ b/tests/01_engine-ftp-userpass.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpuser.XXXXXX") || exit 1
 cleanup_push rm -rf "${tmpdir}"

--- a/tests/01_engine-gmtime.test
+++ b/tests/01_engine-gmtime.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # A non-UTC zone, so a helper that reached for localtime instead of gmtime gives
 # a different answer: CI runners are UTC, where the two agree.

--- a/tests/01_engine-gmtime.test
+++ b/tests/01_engine-gmtime.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # A non-UTC zone, so a helper that reached for localtime instead of gmtime gives
 # a different answer: CI runners are UTC, where the two agree.

--- a/tests/01_engine-growsize.test
+++ b/tests/01_engine-growsize.test
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 out=$(httrack -#test=growsize)
 echo "$out"

--- a/tests/01_engine-growsize.test
+++ b/tests/01_engine-growsize.test
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 out=$(httrack -#test=growsize)
 echo "$out"

--- a/tests/01_engine-header.test
+++ b/tests/01_engine-header.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Response header-line parsing (treathead via -#test=header <raw-line> ...).
 # Isolates the wire layer from url_savename, which strips traversal on its own.

--- a/tests/01_engine-header.test
+++ b/tests/01_engine-header.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Response header-line parsing (treathead via -#test=header <raw-line> ...).
 # Isolates the wire layer from url_savename, which strips traversal on its own.

--- a/tests/01_engine-identabs.test
+++ b/tests/01_engine-identabs.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # A 2047-byte hostless "?"-URL used to overflow fil[] by one byte and abort in
 # strncat_safe_; the guard now returns -1 while valid URLs still parse.

--- a/tests/01_engine-identabs.test
+++ b/tests/01_engine-identabs.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # A 2047-byte hostless "?"-URL used to overflow fil[] by one byte and abort in
 # strncat_safe_; the guard now returns -1 while valid URLs still parse.

--- a/tests/01_engine-identurl.test
+++ b/tests/01_engine-identurl.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # ident_url_absolute splits a raw URL into (adr, fil), the first parser to touch
 # it. -#test=identurl <url> [pad] prints "adr=.. fil=.." or "error"; pad appends

--- a/tests/01_engine-identurl.test
+++ b/tests/01_engine-identurl.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # ident_url_absolute splits a raw URL into (adr, fil), the first parser to touch
 # it. -#test=identurl <url> [pad] prints "adr=.. fil=.." or "error"; pad appends

--- a/tests/01_engine-idna.test
+++ b/tests/01_engine-idna.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # IDNA / punycode encode (-#test=idna-encode) and decode (-#test=idna-decode). This code has a CVE history,
 # so the edge cases below cover passthrough, round-trips, and malformed input.

--- a/tests/01_engine-idna.test
+++ b/tests/01_engine-idna.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # IDNA / punycode encode (-#test=idna-encode) and decode (-#test=idna-decode). This code has a CVE history,
 # so the edge cases below cover passthrough, round-trips, and malformed input.

--- a/tests/01_engine-longpath-io.test
+++ b/tests/01_engine-longpath-io.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Drives -#test=longpath: a >MAX_PATH round trip exercising hts_pathToUCS2's
 # \\?\ prefixing on Windows (#133); a positive control on POSIX.

--- a/tests/01_engine-longpath-io.test
+++ b/tests/01_engine-longpath-io.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Drives -#test=longpath: a >MAX_PATH round trip exercising hts_pathToUCS2's
 # \\?\ prefixing on Windows (#133); a positive control on POSIX.

--- a/tests/01_engine-makeindex.test
+++ b/tests/01_engine-makeindex.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # hts_finish_makeindex writes the footer and gates the refresh meta on a single
 # first link (guards the macro->function extraction).

--- a/tests/01_engine-makeindex.test
+++ b/tests/01_engine-makeindex.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # hts_finish_makeindex writes the footer and gates the refresh meta on a single
 # first link (guards the macro->function extraction).

--- a/tests/01_engine-mime.test
+++ b/tests/01_engine-mime.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # MIME type guessing from extension (get_httptype / give_mimext).
 # -#test=mime <path> prints "<path> is '<mime>'" then "and its local type is '.<ext>'".

--- a/tests/01_engine-mime.test
+++ b/tests/01_engine-mime.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # MIME type guessing from extension (get_httptype / give_mimext).
 # -#test=mime <path> prints "<path> is '<mime>'" then "and its local type is '.<ext>'".

--- a/tests/01_engine-mirror-io.test
+++ b/tests/01_engine-mirror-io.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Drives -#test=mirrorio: rounds a file through a path that is both long
 # (>MAX_PATH) and non-ASCII, exercising the mirror I/O wrappers the engine's

--- a/tests/01_engine-mirror-io.test
+++ b/tests/01_engine-mirror-io.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Drives -#test=mirrorio: rounds a file through a path that is both long
 # (>MAX_PATH) and non-ASCII, exercising the mirror I/O wrappers the engine's

--- a/tests/01_engine-parse.test
+++ b/tests/01_engine-parse.test
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_parse.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmp"

--- a/tests/01_engine-parse.test
+++ b/tests/01_engine-parse.test
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_parse.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmp"

--- a/tests/01_engine-proxyurl.test
+++ b/tests/01_engine-proxyurl.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # hts_parse_proxy splits a -P argument "[scheme://][user:pass@]host[:port]" into
 # the proxy host string and port. -#test=proxyurl <arg> prints

--- a/tests/01_engine-proxyurl.test
+++ b/tests/01_engine-proxyurl.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # hts_parse_proxy splits a -P argument "[scheme://][user:pass@]host[:port]" into
 # the proxy host string and port. -#test=proxyurl <arg> prints

--- a/tests/01_engine-rcfile.test
+++ b/tests/01_engine-rcfile.test
@@ -14,7 +14,7 @@
 # status is inspected by hand).
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Resolve httrack to an absolute path before we cd: PATH may hold a build-relative
 # entry that would not resolve from the temp directory.

--- a/tests/01_engine-rcfile.test
+++ b/tests/01_engine-rcfile.test
@@ -14,7 +14,7 @@
 # status is inspected by hand).
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Resolve httrack to an absolute path before we cd: PATH may hold a build-relative
 # entry that would not resolve from the temp directory.

--- a/tests/01_engine-reconcile.test
+++ b/tests/01_engine-reconcile.test
@@ -6,7 +6,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/01_engine-reconcile.test
+++ b/tests/01_engine-reconcile.test
@@ -6,7 +6,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/01_engine-renameover.test
+++ b/tests/01_engine-renameover.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Drives -#test=renameover: hts_rename_over() must replace an existing dst, and
 # must leave dst alone when the rename failed for a reason moving dst aside

--- a/tests/01_engine-renameover.test
+++ b/tests/01_engine-renameover.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Drives -#test=renameover: hts_rename_over() must replace an existing dst, and
 # must leave dst alone when the rename failed for a reason moving dst aside

--- a/tests/01_engine-renameover.test
+++ b/tests/01_engine-renameover.test
@@ -12,7 +12,7 @@ set -euo pipefail
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
-case "$(uname -s)" in
+case "$HTS_OS" in
 MINGW* | MSYS_NT*) want=fallback ;; # native rename() refuses an existing target
 *) want=clobber ;;
 esac
@@ -22,7 +22,7 @@ assert_match "renameover: OK" "$out"
 assert_match "renameover: regime $want" "$out"
 assert_match "renameover: restore back" "$out"
 
-if [ "$(uname -s)" != "Linux" ]; then
+if [ "$HTS_OS" != "Linux" ]; then
     echo "renameover: LD_PRELOAD interposition is Linux-only here, skipping"
     exit 0
 fi

--- a/tests/01_engine-savename.test
+++ b/tests/01_engine-savename.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Local save-name resolution (url_savename via -#test=savename <fil> <content-type> [key=value ...]).
 # name() asserts on the basename, full() on the whole path; prior= registers an

--- a/tests/01_engine-savename.test
+++ b/tests/01_engine-savename.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Local save-name resolution (url_savename via -#test=savename <fil> <content-type> [key=value ...]).
 # name() asserts on the basename, full() on the whole path; prior= registers an

--- a/tests/01_engine-savename.test
+++ b/tests/01_engine-savename.test
@@ -159,7 +159,7 @@ name $'/evil\rname\t.php' 'text/html' 'evil name .html'
 # #133: oversized names are capped only on Windows, where the name takes the
 # same 48-char clamp as a directory segment and keeps its extension across the
 # cut (#852); elsewhere the platform PATH_MAX leaves a 300-char name whole.
-case "$(uname -s 2>/dev/null)" in
+case "$HTS_OS" in
 MINGW* | MSYS* | CYGWIN*)
     name "/$(printf 'a%.0s' {1..300}).php" 'text/html' "$(printf 'a%.0s' {1..43}).html"
     ;;

--- a/tests/01_engine-selftest-dispatch.test
+++ b/tests/01_engine-selftest-dispatch.test
@@ -6,7 +6,7 @@
 set -eu
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Bare -#test lists known tests (printed to stderr).
 list=$(httrack -#test 2>&1)

--- a/tests/01_engine-selftest-dispatch.test
+++ b/tests/01_engine-selftest-dispatch.test
@@ -6,7 +6,7 @@
 set -eu
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Bare -#test lists known tests (printed to stderr).
 list=$(httrack -#test 2>&1)

--- a/tests/01_engine-simplify.test
+++ b/tests/01_engine-simplify.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # path simplify engine (fil_simplifie): collapses ./ and ../ segments.
 simp() { assert_selftest "simplified=$2" simplify "$1"; }

--- a/tests/01_engine-simplify.test
+++ b/tests/01_engine-simplify.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # path simplify engine (fil_simplifie): collapses ./ and ../ segments.
 simp() { assert_selftest "simplified=$2" simplify "$1"; }

--- a/tests/01_engine-strsafe.test
+++ b/tests/01_engine-strsafe.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # htssafe.h bounded string operations (driven by 'httrack -#test=strsafe').
 

--- a/tests/01_engine-strsafe.test
+++ b/tests/01_engine-strsafe.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # htssafe.h bounded string operations (driven by 'httrack -#test=strsafe').
 

--- a/tests/01_engine-structcheck.test
+++ b/tests/01_engine-structcheck.test
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/01_engine-structcheck.test
+++ b/tests/01_engine-structcheck.test
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/01_engine-threadwait.test
+++ b/tests/01_engine-threadwait.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_threadwait_st.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmpdir"

--- a/tests/01_engine-threadwait.test
+++ b/tests/01_engine-threadwait.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_threadwait_st.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmpdir"

--- a/tests/01_engine-topindex.test
+++ b/tests/01_engine-topindex.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # hts_buildtopindex takes a system-charset path but verif_backblue below it
 # expects utf-8, mangling a non-ASCII project dir on Windows (#216, #217).

--- a/tests/01_engine-topindex.test
+++ b/tests/01_engine-topindex.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # hts_buildtopindex takes a system-charset path but verif_backblue below it
 # expects utf-8, mangling a non-ASCII project dir on Windows (#216, #217).

--- a/tests/01_zlib-acceptencoding.test
+++ b/tests/01_zlib-acceptencoding.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Accept-Encoding (#450): advertise gzip+deflate; decode gzip/zlib/raw-deflate.
 dir=$(mktemp -d)

--- a/tests/01_zlib-acceptencoding.test
+++ b/tests/01_zlib-acceptencoding.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Accept-Encoding (#450): advertise gzip+deflate; decode gzip/zlib/raw-deflate.
 dir=$(mktemp -d)

--- a/tests/01_zlib-cache-corrupt.test
+++ b/tests/01_zlib-cache-corrupt.test
@@ -6,7 +6,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/01_zlib-cache-corrupt.test
+++ b/tests/01_zlib-cache-corrupt.test
@@ -6,7 +6,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/01_zlib-cache-golden.test
+++ b/tests/01_zlib-cache-golden.test
@@ -14,7 +14,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 : "${top_srcdir:=..}"
 fixture="$top_srcdir/tests/fixtures/cache-golden"

--- a/tests/01_zlib-cache-golden.test
+++ b/tests/01_zlib-cache-golden.test
@@ -14,7 +14,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 : "${top_srcdir:=..}"
 fixture="$top_srcdir/tests/fixtures/cache-golden"

--- a/tests/01_zlib-cache-legacy.test
+++ b/tests/01_zlib-cache-legacy.test
@@ -5,7 +5,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/01_zlib-cache-legacy.test
+++ b/tests/01_zlib-cache-legacy.test
@@ -5,7 +5,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/01_zlib-cache-writefail.test
+++ b/tests/01_zlib-cache-writefail.test
@@ -8,7 +8,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/01_zlib-cache-writefail.test
+++ b/tests/01_zlib-cache-writefail.test
@@ -8,7 +8,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/01_zlib-cache.test
+++ b/tests/01_zlib-cache.test
@@ -13,7 +13,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/01_zlib-cache.test
+++ b/tests/01_zlib-cache.test
@@ -13,7 +13,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/01_zlib-contentcodings.test
+++ b/tests/01_zlib-contentcodings.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # brotli/zstd decode, unknown codings, and the decoded-size budget.
 dir=$(mktemp -d)

--- a/tests/01_zlib-contentcodings.test
+++ b/tests/01_zlib-contentcodings.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # brotli/zstd decode, unknown codings, and the decoded-size budget.
 dir=$(mktemp -d)

--- a/tests/01_zlib-repair-shift.test
+++ b/tests/01_zlib-repair-shift.test
@@ -8,7 +8,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/01_zlib-repair-shift.test
+++ b/tests/01_zlib-repair-shift.test
@@ -8,7 +8,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/01_zlib-savename-cached.test
+++ b/tests/01_zlib-savename-cached.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Update-run naming from a real cache entry (-#test=savename cached=<ctype>|<save>).
 # Named 01_zlib-*: the cache writer needs zlib, which the MSan job can't run.

--- a/tests/01_zlib-savename-cached.test
+++ b/tests/01_zlib-savename-cached.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Update-run naming from a real cache entry (-#test=savename cached=<ctype>|<save>).
 # Named 01_zlib-*: the cache writer needs zlib, which the MSan job can't run.

--- a/tests/01_zlib-warc-cdx-errors.test
+++ b/tests/01_zlib-warc-cdx-errors.test
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 httrack_bin=$(httrack_path)
 

--- a/tests/01_zlib-warc-cdx-errors.test
+++ b/tests/01_zlib-warc-cdx-errors.test
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 httrack_bin=$(httrack_path)
 

--- a/tests/01_zlib-warc-cdx.test
+++ b/tests/01_zlib-warc-cdx.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # --warc-cdx CDXJ index over synthetic transactions: sorted, one line per
 # response/revisit/resource, each offset/length inflates to the right member.

--- a/tests/01_zlib-warc-cdx.test
+++ b/tests/01_zlib-warc-cdx.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # --warc-cdx CDXJ index over synthetic transactions: sorted, one line per
 # response/revisit/resource, each offset/length inflates to the right member.

--- a/tests/01_zlib-warc-wacz.test
+++ b/tests/01_zlib-warc-wacz.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # --wacz packaging over synthetic transactions: the WACZ unzips in-process to
 # the fixed layout, every entry is ZIP STORE, each datapackage sha256 recomputes

--- a/tests/01_zlib-warc-wacz.test
+++ b/tests/01_zlib-warc-wacz.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # --wacz packaging over synthetic transactions: the WACZ unzips in-process to
 # the fixed layout, every entry is ZIP STORE, each datapackage sha256 recomputes

--- a/tests/01_zlib-warc.test
+++ b/tests/01_zlib-warc.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # WARC/1.1 writer self-test: framing, Content-Length, gzip members, round-trip,
 # revisit dedup, plus v1.1 WARC-Truncated, ftp resource records, and

--- a/tests/01_zlib-warc.test
+++ b/tests/01_zlib-warc.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # WARC/1.1 writer self-test: framing, Content-Length, gzip members, round-trip,
 # revisit dedup, plus v1.1 WARC-Truncated, ftp resource records, and

--- a/tests/02_manpage-regen.test
+++ b/tests/02_manpage-regen.test
@@ -6,7 +6,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 gen="$top_srcdir/man/makeman.sh"
 committed="$top_srcdir/man/httrack.1"

--- a/tests/02_manpage-regen.test
+++ b/tests/02_manpage-regen.test
@@ -6,7 +6,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 gen="$top_srcdir/man/makeman.sh"
 committed="$top_srcdir/man/httrack.1"

--- a/tests/02_update-cache.test
+++ b/tests/02_update-cache.test
@@ -12,7 +12,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 site=$(mktemp -d)
 out=$(mktemp -d)

--- a/tests/02_update-cache.test
+++ b/tests/02_update-cache.test
@@ -12,7 +12,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 site=$(mktemp -d)
 out=$(mktemp -d)

--- a/tests/100_local-purge-longpath.test
+++ b/tests/100_local-purge-longpath.test
@@ -13,7 +13,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # python3 is required; mirror check-network.sh's skip-with-77 convention.
 python=$(find_python) || skip "python3 not found"

--- a/tests/100_local-purge-longpath.test
+++ b/tests/100_local-purge-longpath.test
@@ -48,7 +48,7 @@ test "$pathmax" -ge $((need + ${#work} + 128)) || skip "PATH_MAX $pathmax too sm
 
 # Same on Win32, where MAX_PATH clamps the save path; getconf answers for the
 # MSYS emulation, not the Win32 API httrack calls, so it cannot see this.
-case "$(uname -s)" in
+case "$HTS_OS" in
 MINGW* | MSYS* | CYGWIN*)
     echo "Win32 MAX_PATH cannot hold a $need-byte save path; skipping" >&2
     exit 77

--- a/tests/100_local-purge-longpath.test
+++ b/tests/100_local-purge-longpath.test
@@ -13,7 +13,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # python3 is required; mirror check-network.sh's skip-with-77 convention.
 python=$(find_python) || skip "python3 not found"

--- a/tests/102_local-ftp-refetch.test
+++ b/tests/102_local-ftp-refetch.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/102_local-ftp-refetch.test
+++ b/tests/102_local-ftp-refetch.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/103_teardown-status.test
+++ b/tests/103_teardown-status.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 tmp=$(mktemp -d)
 cleanup_push rm -rf "$tmp"

--- a/tests/103_teardown-status.test
+++ b/tests/103_teardown-status.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 tmp=$(mktemp -d)
 cleanup_push rm -rf "$tmp"

--- a/tests/104_engine-warc-longurl.test
+++ b/tests/104_engine-warc-longurl.test
@@ -5,7 +5,7 @@
 
 set -e
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 : "${top_srcdir:=..}"
 

--- a/tests/104_engine-warc-longurl.test
+++ b/tests/104_engine-warc-longurl.test
@@ -5,7 +5,7 @@
 
 set -e
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 : "${top_srcdir:=..}"
 

--- a/tests/106_engine-repair-rename.test
+++ b/tests/106_engine-repair-rename.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 tmpdir=$(mktemp -d) # honors the Windows-shaped TMPDIR the MSYS suite exports
 cleanup() { rm -rf "$tmpdir"; }

--- a/tests/106_engine-repair-rename.test
+++ b/tests/106_engine-repair-rename.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 tmpdir=$(mktemp -d) # honors the Windows-shaped TMPDIR the MSYS suite exports
 cleanup() { rm -rf "$tmpdir"; }

--- a/tests/106_engine-repair-rename.test
+++ b/tests/106_engine-repair-rename.test
@@ -66,7 +66,7 @@ test "$(wc -c <"${proj}/hts-cache/new.zip")" -eq 28 || {
 }
 echo "OK"
 
-if [ "$(uname -s)" != "Linux" ]; then
+if [ "$HTS_OS" != "Linux" ]; then
     echo "repair-rename: LD_PRELOAD interposition is Linux-only here, skipping"
     exit 0
 fi

--- a/tests/108_engine-refetch-backup.test
+++ b/tests/108_engine-refetch-backup.test
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/108_engine-refetch-backup.test
+++ b/tests/108_engine-refetch-backup.test
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/110_local-ftp-parallel.test
+++ b/tests/110_local-ftp-parallel.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/110_local-ftp-parallel.test
+++ b/tests/110_local-ftp-parallel.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/111_local-ftp-update-rest.test
+++ b/tests/111_local-ftp-update-rest.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/111_local-ftp-update-rest.test
+++ b/tests/111_local-ftp-update-rest.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/112_local-single-file-fragment.test
+++ b/tests/112_local-single-file-fragment.test
@@ -4,7 +4,7 @@
 set -e
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 

--- a/tests/112_local-single-file-fragment.test
+++ b/tests/112_local-single-file-fragment.test
@@ -4,7 +4,7 @@
 set -e
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 

--- a/tests/112_local-single-file-fragment.test
+++ b/tests/112_local-single-file-fragment.test
@@ -73,7 +73,7 @@ if m is None:
 open(sys.argv[2], "wb").write(base64.b64decode(m.group(1)))
 PY
 grep -Eq "url\\(data:image/svg\\+xml;base64,${b64}#icon-css\\)" "${tmpdir}/got.css" ||
-    fail "url() lost its fragment: $(cat "${tmpdir}/got.css")"
+    fail "url() lost its fragment: $(<"${tmpdir}/got.css")"
 # Over the cap, so it stays a link, rebased onto the page's directory: it still
 # names the sprite sheet, so it still needs the selector.
 grep -q 'url(big.svg#icon-big)' "${tmpdir}/got.css" ||

--- a/tests/113_engine-threadattr-leak.test
+++ b/tests/113_engine-threadattr-leak.test
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 if [ "$HTS_OS" != "Linux" ]; then
     echo "threadattr: LD_PRELOAD interposition is Linux-only here, skipping"

--- a/tests/113_engine-threadattr-leak.test
+++ b/tests/113_engine-threadattr-leak.test
@@ -9,7 +9,7 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "$(dirname "$0")/testlib.sh"
 
-if [ "$(uname -s)" != "Linux" ]; then
+if [ "$HTS_OS" != "Linux" ]; then
     echo "threadattr: LD_PRELOAD interposition is Linux-only here, skipping"
     exit 0
 fi

--- a/tests/113_engine-threadattr-leak.test
+++ b/tests/113_engine-threadattr-leak.test
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 if [ "$HTS_OS" != "Linux" ]; then
     echo "threadattr: LD_PRELOAD interposition is Linux-only here, skipping"

--- a/tests/114_local-update-304-leak.test
+++ b/tests/114_local-update-304-leak.test
@@ -8,7 +8,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 probe=$(ASAN_OPTIONS=help=1 httrack -O /dev/null --version 2>&1 || true)
 case "$probe" in

--- a/tests/114_local-update-304-leak.test
+++ b/tests/114_local-update-304-leak.test
@@ -8,7 +8,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 probe=$(ASAN_OPTIONS=help=1 httrack -O /dev/null --version 2>&1 || true)
 case "$probe" in

--- a/tests/116_engine-rtrim.test
+++ b/tests/116_engine-rtrim.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Resolve httrack before any cd: PATH may carry a build-relative entry.
 bin=$(command -v httrack) || {

--- a/tests/116_engine-rtrim.test
+++ b/tests/116_engine-rtrim.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Resolve httrack before any cd: PATH may carry a build-relative entry.
 bin=$(command -v httrack) || {

--- a/tests/117_local-proxytrack-ndx-cursor.test
+++ b/tests/117_local-proxytrack-ndx-cursor.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup() { rm -rf "$dir"; }

--- a/tests/117_local-proxytrack-ndx-cursor.test
+++ b/tests/117_local-proxytrack-ndx-cursor.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup() { rm -rf "$dir"; }

--- a/tests/118_local-proxytrack-arcwrite.test
+++ b/tests/118_local-proxytrack-arcwrite.test
@@ -7,7 +7,7 @@ set -euo pipefail
 export LC_ALL=C
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup() { rm -rf "$dir"; }

--- a/tests/118_local-proxytrack-arcwrite.test
+++ b/tests/118_local-proxytrack-arcwrite.test
@@ -7,7 +7,7 @@ set -euo pipefail
 export LC_ALL=C
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup() { rm -rf "$dir"; }

--- a/tests/119_local-proxytrack-ndx-fields2.test
+++ b/tests/119_local-proxytrack-ndx-fields2.test
@@ -8,7 +8,7 @@ set -euo pipefail
 export LC_ALL=C
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup() { rm -rf "$dir"; }

--- a/tests/119_local-proxytrack-ndx-fields2.test
+++ b/tests/119_local-proxytrack-ndx-fields2.test
@@ -8,7 +8,7 @@ set -euo pipefail
 export LC_ALL=C
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup() { rm -rf "$dir"; }

--- a/tests/120_local-proxytrack-webdav-default.test
+++ b/tests/120_local-proxytrack-webdav-default.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 missing"
 command -v curl >/dev/null 2>&1 || skip "curl missing"

--- a/tests/120_local-proxytrack-webdav-default.test
+++ b/tests/120_local-proxytrack-webdav-default.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 missing"
 command -v curl >/dev/null 2>&1 || skip "curl missing"

--- a/tests/121_local-ftp-nocache-splice.test
+++ b/tests/121_local-ftp-nocache-splice.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/121_local-ftp-nocache-splice.test
+++ b/tests/121_local-ftp-nocache-splice.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/131_local-savename-reserved.test
+++ b/tests/131_local-savename-reserved.test
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 httrack_bin=$(httrack_path)
 

--- a/tests/131_local-savename-reserved.test
+++ b/tests/131_local-savename-reserved.test
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 httrack_bin=$(httrack_path)
 

--- a/tests/133_engine-reentrant-time.test
+++ b/tests/133_engine-reentrant-time.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # A non-UTC zone, so a helper that reached for gmtime instead of localtime (or
 # vice-versa) gives a different answer: CI runners are UTC, where they agree.

--- a/tests/133_engine-reentrant-time.test
+++ b/tests/133_engine-reentrant-time.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # A non-UTC zone, so a helper that reached for gmtime instead of localtime (or
 # vice-versa) gives a different answer: CI runners are UTC, where they agree.

--- a/tests/137_local-charsetless-encoding.test
+++ b/tests/137_local-charsetless-encoding.test
@@ -5,7 +5,7 @@
 
 set -e
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 

--- a/tests/137_local-charsetless-encoding.test
+++ b/tests/137_local-charsetless-encoding.test
@@ -5,7 +5,7 @@
 
 set -e
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 

--- a/tests/138_local-spool-name-overflow.test
+++ b/tests/138_local-spool-name-overflow.test
@@ -7,7 +7,7 @@
 
 set -e
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_spool.XXXXXX") || exit 1
 cleanup() {

--- a/tests/138_local-spool-name-overflow.test
+++ b/tests/138_local-spool-name-overflow.test
@@ -7,7 +7,7 @@
 
 set -e
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_spool.XXXXXX") || exit 1
 cleanup() {

--- a/tests/139_local-query-charref.test
+++ b/tests/139_local-query-charref.test
@@ -6,7 +6,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 root=$(nativepath "${testdir}/server-root")
 
 httrack=$(command -v httrack) || ! echo "could not find httrack" >&2 || exit 1

--- a/tests/139_local-query-charref.test
+++ b/tests/139_local-query-charref.test
@@ -6,7 +6,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 root=$(nativepath "${testdir}/server-root")
 
 httrack=$(command -v httrack) || ! echo "could not find httrack" >&2 || exit 1

--- a/tests/13_crawl_proxy_https.test
+++ b/tests/13_crawl_proxy_https.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 if test "${HTTPS_SUPPORT:-}" == "no"; then
     echo "no https support compiled, skipping"

--- a/tests/13_crawl_proxy_https.test
+++ b/tests/13_crawl_proxy_https.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 if test "${HTTPS_SUPPORT:-}" == "no"; then
     echo "no https support compiled, skipping"

--- a/tests/144_engine-datadir.test
+++ b/tests/144_engine-datadir.test
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/datadir.XXXXXX") || {
     echo "no tmpdir" >&2

--- a/tests/144_engine-datadir.test
+++ b/tests/144_engine-datadir.test
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/datadir.XXXXXX") || {
     echo "no tmpdir" >&2

--- a/tests/145_webhttrack-datadir.test
+++ b/tests/145_webhttrack-datadir.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 script="${abs_top_builddir:?not run under make check}/src/webhttrack"
 datadir="${CONFIGURED_DATADIR:?not run under make check}"

--- a/tests/145_webhttrack-datadir.test
+++ b/tests/145_webhttrack-datadir.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 script="${abs_top_builddir:?not run under make check}/src/webhttrack"
 datadir="${CONFIGURED_DATADIR:?not run under make check}"

--- a/tests/146_bash-shell.test
+++ b/tests/146_bash-shell.test
@@ -8,7 +8,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 sh=${BASH_SHELL:-}
 test -n "$sh" || {

--- a/tests/146_bash-shell.test
+++ b/tests/146_bash-shell.test
@@ -8,7 +8,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 sh=${BASH_SHELL:-}
 test -n "$sh" || {

--- a/tests/147_local-proxytrack-webdav-overflow.test
+++ b/tests/147_local-proxytrack-webdav-overflow.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 missing"
 command -v curl >/dev/null 2>&1 || skip "curl missing"

--- a/tests/147_local-proxytrack-webdav-overflow.test
+++ b/tests/147_local-proxytrack-webdav-overflow.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 missing"
 command -v curl >/dev/null 2>&1 || skip "curl missing"

--- a/tests/148_engine-spoolname.test
+++ b/tests/148_engine-spoolname.test
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/spoolname.XXXXXX") || {
     echo "no tmpdir" >&2

--- a/tests/148_engine-spoolname.test
+++ b/tests/148_engine-spoolname.test
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/spoolname.XXXXXX") || {
     echo "no tmpdir" >&2

--- a/tests/150_engine-strsprintf.test
+++ b/tests/150_engine-strsprintf.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Resolve httrack before any cd: PATH may carry a build-relative entry.
 bin=$(command -v httrack) || {

--- a/tests/150_engine-strsprintf.test
+++ b/tests/150_engine-strsprintf.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Resolve httrack before any cd: PATH may carry a build-relative entry.
 bin=$(command -v httrack) || {

--- a/tests/151_bash-shell-validate.test
+++ b/tests/151_bash-shell-validate.test
@@ -7,9 +7,9 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 # shellcheck source=tests/proclib.sh
-. "$(dirname "$0")/proclib.sh"
+. "${0%"${0##*/}"}proclib.sh"
 
 sh=${BASH_SHELL:-}
 test -n "$sh" || {

--- a/tests/151_bash-shell-validate.test
+++ b/tests/151_bash-shell-validate.test
@@ -118,7 +118,7 @@ run() { # run <label> <env argument>...
         fi
     done
     wait "$pid" || status=$?
-    log=$(cat "$rundir/log")
+    log=$(<"$rundir/log")
     took=$((SECONDS - began))
     echo "run $n ($label): exit $status"
 }
@@ -192,7 +192,7 @@ probe() { # probe <run number> <seconds of budget left> <command>...
 # A wedge must fail even with the budget gone, or #922 comes back as a skip.
 rc=$(probe 90 6 sleep 999)
 test "$rc" -eq 1 || fail "a silent configure with 6s of budget reported $rc, want 1"
-grep -q 'wrote nothing' "$tmp/probe.log" || fail "the hang was not named: $(cat "$tmp/probe.log")"
+grep -q 'wrote nothing' "$tmp/probe.log" || fail "the hang was not named: $(<"$tmp/probe.log")"
 # Slow but talking is the emulated buildd, and a skip there beats the harness kill.
 rc=$(probe 91 6 bash -c 'while :; do echo tick; sleep 1; done')
 test "$rc" -eq 77 || fail "a slow but writing configure with 6s of budget reported $rc, want 77"

--- a/tests/151_bash-shell-validate.test
+++ b/tests/151_bash-shell-validate.test
@@ -7,9 +7,9 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 # shellcheck source=tests/proclib.sh
-. "${0%"${0##*/}"}proclib.sh"
+. "${0%"${0##*/}"}./proclib.sh"
 
 sh=${BASH_SHELL:-}
 test -n "$sh" || {

--- a/tests/152_engine-string-oom.test
+++ b/tests/152_engine-string-oom.test
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 ulimit -c 0 # a deliberate abort must not litter the box with cores
 

--- a/tests/152_engine-string-oom.test
+++ b/tests/152_engine-string-oom.test
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 ulimit -c 0 # a deliberate abort must not litter the box with cores
 

--- a/tests/153_local-proxytrack-quiet.test
+++ b/tests/153_local-proxytrack-quiet.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 missing"
 command -v curl >/dev/null 2>&1 || skip "curl missing"

--- a/tests/153_local-proxytrack-quiet.test
+++ b/tests/153_local-proxytrack-quiet.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 missing"
 command -v curl >/dev/null 2>&1 || skip "curl missing"

--- a/tests/154_local-proxytrack-arc-roundtrip.test
+++ b/tests/154_local-proxytrack-arc-roundtrip.test
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 export LC_ALL=C
 

--- a/tests/154_local-proxytrack-arc-roundtrip.test
+++ b/tests/154_local-proxytrack-arc-roundtrip.test
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 export LC_ALL=C
 

--- a/tests/155_engine-escape-control.test
+++ b/tests/155_engine-escape-control.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # input : expected length : expected output
 cases=(

--- a/tests/155_engine-escape-control.test
+++ b/tests/155_engine-escape-control.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # input : expected length : expected output
 cases=(

--- a/tests/157_crash-argv0-path.test
+++ b/tests/157_crash-argv0-path.test
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 : "${abs_top_builddir:?not run under make check}"
 bindir="${CONFIGURED_BINDIR:?not run under make check}"

--- a/tests/157_crash-argv0-path.test
+++ b/tests/157_crash-argv0-path.test
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 : "${abs_top_builddir:?not run under make check}"
 bindir="${CONFIGURED_BINDIR:?not run under make check}"

--- a/tests/158_local-link-control-bytes.test
+++ b/tests/158_local-link-control-bytes.test
@@ -7,7 +7,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 # The fixtures carry the raw bytes the requests decode back to, which NTFS
 # refuses.

--- a/tests/158_local-link-control-bytes.test
+++ b/tests/158_local-link-control-bytes.test
@@ -7,7 +7,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 # The fixtures carry the raw bytes the requests decode back to, which NTFS
 # refuses.

--- a/tests/159_local-header-injection.test
+++ b/tests/159_local-header-injection.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 missing"
 

--- a/tests/159_local-header-injection.test
+++ b/tests/159_local-header-injection.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 missing"
 

--- a/tests/160_zlib-cache-hdrbounds.test
+++ b/tests/160_zlib-cache-hdrbounds.test
@@ -6,7 +6,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/160_zlib-cache-hdrbounds.test
+++ b/tests/160_zlib-cache-hdrbounds.test
@@ -6,7 +6,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/161_local-proxytrack-zip-headers.test
+++ b/tests/161_local-proxytrack-zip-headers.test
@@ -8,7 +8,7 @@
 set -eu
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/161_local-proxytrack-zip-headers.test
+++ b/tests/161_local-proxytrack-zip-headers.test
@@ -48,5 +48,5 @@ done
 proxytrack --convert "$dir/back.arc" "$dir/out.zip" >"$dir/log" 2>&1 ||
     fail "proxytrack died reading its own new.zip"
 grep -q '(1 items added)' "$dir/log" ||
-    fail "the new.zip did not load back: $(cat "$dir/log")"
+    fail "the new.zip did not load back: $(<"$dir/log")"
 grep -qF "$BODY" "$dir/back.arc" || fail "body did not survive the round trip"

--- a/tests/161_local-proxytrack-zip-headers.test
+++ b/tests/161_local-proxytrack-zip-headers.test
@@ -8,7 +8,7 @@
 set -eu
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/162_zlib-cache-urlbounds.test
+++ b/tests/162_zlib-cache-urlbounds.test
@@ -5,7 +5,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/162_zlib-cache-urlbounds.test
+++ b/tests/162_zlib-cache-urlbounds.test
@@ -5,7 +5,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/163_icon-theme.test
+++ b/tests/163_icon-theme.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 builddir="${abs_top_builddir:?not run under make check}"

--- a/tests/163_icon-theme.test
+++ b/tests/163_icon-theme.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 builddir="${abs_top_builddir:?not run under make check}"

--- a/tests/164_local-proxytrack-arc-hostile.test
+++ b/tests/164_local-proxytrack-arc-hostile.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 export LC_ALL=C
 

--- a/tests/164_local-proxytrack-arc-hostile.test
+++ b/tests/164_local-proxytrack-arc-hostile.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 export LC_ALL=C
 

--- a/tests/171_watchdog-heartbeat.test
+++ b/tests/171_watchdog-heartbeat.test
@@ -91,7 +91,7 @@ ci_suite_heartbeat 720 360 "$progress" 900 4242 >"$tmp/out" 2>&1
 # a suite still reporting, later means the 30s clamp is gone, or the check rides
 # the 360s annotation cadence, or the clock is being accumulated rather than read.
 killed=$(sed -n 's/^KILL 4242 at \([0-9]*\)$/\1/p' "$tmp/out")
-wrote=$(cat "$tmp/lastwrite")
+wrote=$(<"$tmp/lastwrite")
 test -n "$killed" || fail "a suite that stopped reporting was never killed"
 test "$killed" -ge $((wrote + 900)) ||
     fail "killed at $killed, only $((killed - wrote))s after the last progress line at $wrote"
@@ -125,7 +125,7 @@ grep -q "in flight: RUN ${wrote}s%25a%25b.test at ${wrote}s" "$tmp/out" ||
     fail "annotation does not name the escaped test in flight: $(head -3 "$tmp/out")"
 grep -q "$(printf '\r')" "$tmp/out" && fail "a CR reached the annotation, truncating it"
 grep -q '98_earlier' "$tmp/out" && fail "annotation names the first test, not the one in flight"
-grep -qx '0 named' "$tmp/strayargs" || fail "process list not host-wide: $(cat "$tmp/strayargs")"
+grep -qx '0 named' "$tmp/strayargs" || fail "process list not host-wide: $(<"$tmp/strayargs")"
 
 # Joined with %0A and bounded to eight, and no separator left dangling: the
 # runner reads to end of line, so a trailing one is a visible empty tail.
@@ -169,7 +169,7 @@ test -n "$killed" || fail "a suite still reporting outlived its wall-clock cap"
 test "$killed" -ge 5480 || fail "capped at $killed, inside the 480s cap"
 test "$killed" -le 5600 || fail "capped at $killed, want 5480 within a tick"
 grep -q '480s cap reached' "$tmp/capped" || fail "the cap kill was announced as something else"
-test "$(cat "$tmp/lastwrite")" -ge 5480 || fail "the log stopped moving: nothing here needed the cap"
+test "$(<"$tmp/lastwrite")" -ge 5480 || fail "the log stopped moving: nothing here needed the cap"
 
 # taskkill is a grandchild of its own target, so a leaves-first /T would reap the
 # watchdog before the root (#953): kill_tree here never returns, and the stubs

--- a/tests/171_watchdog-heartbeat.test
+++ b/tests/171_watchdog-heartbeat.test
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Before the driver is sourced: with these set, anything it starts posts a commit
 # status on whatever the surrounding shell was last looking at.

--- a/tests/171_watchdog-heartbeat.test
+++ b/tests/171_watchdog-heartbeat.test
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Before the driver is sourced: with these set, anything it starts posts a commit
 # status on whatever the surrounding shell was last looking at.

--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Before the driver is sourced: with these set, anything it starts posts a commit
 # status on whatever the surrounding shell was last looking at.

--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -182,15 +182,15 @@ grep -q 'trace line 0$' <<<"$out" && fail "the report is not bounded to a tail"
 
 # This launches the watchdog the way the real driver does, not through a test
 # sourcing the helper, proving it starts and holds a token nothing else sees.
-grep -q '^watchdog ready$' watchdog.log || fail "no watchdog was launched: $(cat watchdog.log)"
+grep -q '^watchdog ready$' watchdog.log || fail "no watchdog was launched: $(<watchdog.log)"
 test -r "$tmp/childtoken" || fail "the test that reads its environment did not run"
 grep -qx 'TOKEN=' "$tmp/childtoken" ||
-    fail "a test inherited the status token: $(cat "$tmp/childtoken")"
+    fail "a test inherited the status token: $(<"$tmp/childtoken")"
 grep -qx 'TOKEN=s3cr3t' "$wdargv" ||
-    fail "the watchdog was launched without its token: $(cat "$wdargv")"
+    fail "the watchdog was launched without its token: $(<"$wdargv")"
 test -s "$tmp/cygpathtoken" || fail "the cygpath stub never ran"
 grep -q 'TOKEN=s3cr3t' "$tmp/cygpathtoken" &&
-    fail "the driver forked a child before scrubbing its token: $(cat "$tmp/cygpathtoken")"
+    fail "the driver forked a child before scrubbing its token: $(<"$tmp/cygpathtoken")"
 # An orphan runs out its own deadline, re-posting a frozen tail past the step (#795).
 reporter_stopped || fail "the driver exited leaving its reporter running"
 # Positive control for the gate below: with every category matched it stays silent.
@@ -248,7 +248,7 @@ wedge_leg() (
     ci_suite_heartbeat 0 1 "$prog" 0 "$victim" >"$tmp/wedge.out" 2>&1 &
     wait "$!"
     grep -q '::error title=suite watchdog::' "$tmp/wedge.out" ||
-        fail "the wedge branch was never reached: $(cat "$tmp/wedge.out")"
+        fail "the wedge branch was never reached: $(<"$tmp/wedge.out")"
     reporter_stopped || fail "the wedge kill orphaned the reporter"
 )
 # Held back: bash announces every job it reaps from a signal, which reads as a
@@ -266,7 +266,7 @@ fd_kill=$tmp/fd-killed
 # Seconds between the producer's own kill and the reader seeing EOF.
 eof_latency() {
     "$1" 2>>"$tmp/fd.err" | cat >"$tmp/fd.out"
-    echo $(($(date +%s) - $(cat "$fd_kill")))
+    echo $(($(date +%s) - $(<"$fd_kill")))
 }
 
 # What the driver's EXIT trap does: signal the heartbeat shell mid-tick and let go.

--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Before the driver is sourced: with these set, anything it starts posts a commit
 # status on whatever the surrounding shell was last looking at.

--- a/tests/180_crash-stack-overflow.test
+++ b/tests/180_crash-stack-overflow.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 ulimit -c 0 # a deliberate crash must not litter the box with cores
 

--- a/tests/180_crash-stack-overflow.test
+++ b/tests/180_crash-stack-overflow.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 ulimit -c 0 # a deliberate crash must not litter the box with cores
 

--- a/tests/180_crash-stack-overflow.test
+++ b/tests/180_crash-stack-overflow.test
@@ -11,7 +11,7 @@ set -euo pipefail
 
 ulimit -c 0 # a deliberate crash must not litter the box with cores
 
-case "$(uname -s)" in
+case "$HTS_OS" in
 Linux) traced=1 ;;
 MINGW* | MSYS* | CYGWIN*)
     echo "no sigaltstack on Windows, skipping" >&2

--- a/tests/181_altstack-honoured.test
+++ b/tests/181_altstack-honoured.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 ulimit -c 0 # a deliberate crash must not litter the box with cores
 

--- a/tests/181_altstack-honoured.test
+++ b/tests/181_altstack-honoured.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 ulimit -c 0 # a deliberate crash must not litter the box with cores
 

--- a/tests/181_altstack-honoured.test
+++ b/tests/181_altstack-honoured.test
@@ -11,7 +11,7 @@ set -euo pipefail
 
 ulimit -c 0 # a deliberate crash must not litter the box with cores
 
-if [ "$(uname -s)" != "Linux" ]; then
+if [ "$HTS_OS" != "Linux" ]; then
     echo "LD_PRELOAD interposition is Linux-only here, skipping" >&2
     exit 77
 fi

--- a/tests/182_crash-fork-safety.test
+++ b/tests/182_crash-fork-safety.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 ulimit -c 0 # a deliberate crash must not litter the box with cores
 

--- a/tests/182_crash-fork-safety.test
+++ b/tests/182_crash-fork-safety.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 ulimit -c 0 # a deliberate crash must not litter the box with cores
 

--- a/tests/182_crash-fork-safety.test
+++ b/tests/182_crash-fork-safety.test
@@ -10,7 +10,7 @@ ulimit -c 0 # a deliberate crash must not litter the box with cores
 
 # The spawn needs backtrace(), so Linux is necessary but not sufficient: the
 # runtime notice below is what actually rules a musl build out.
-if [ "$(uname -s)" != "Linux" ]; then
+if [ "$HTS_OS" != "Linux" ]; then
     echo "the symbolizer spawn is Linux-only, skipping" >&2
     exit 77
 fi

--- a/tests/183_altstack-worker.test
+++ b/tests/183_altstack-worker.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 ulimit -c 0 # a deliberate crash must not litter the box with cores
 

--- a/tests/183_altstack-worker.test
+++ b/tests/183_altstack-worker.test
@@ -10,7 +10,7 @@ set -euo pipefail
 
 ulimit -c 0 # a deliberate crash must not litter the box with cores
 
-case "$(uname -s)" in
+case "$HTS_OS" in
 Linux) traced=1 ;;
 MINGW* | MSYS* | CYGWIN*)
     echo "no sigaltstack on Windows, skipping" >&2

--- a/tests/183_altstack-worker.test
+++ b/tests/183_altstack-worker.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 ulimit -c 0 # a deliberate crash must not litter the box with cores
 

--- a/tests/185_webhttrack-js-escaping.test
+++ b/tests/185_webhttrack-js-escaping.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 distdir=${HTS_DISTDIR}

--- a/tests/185_webhttrack-js-escaping.test
+++ b/tests/185_webhttrack-js-escaping.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 distdir=${HTS_DISTDIR}

--- a/tests/186_webhttrack-url-escaping.test
+++ b/tests/186_webhttrack-url-escaping.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/186_webhttrack-url-escaping.test
+++ b/tests/186_webhttrack-url-escaping.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/195_install-relocate.test
+++ b/tests/195_install-relocate.test
@@ -28,7 +28,7 @@ test -r "${bin}" || fail "no httrack in ${stage}${bindir}"
 
 # Chosen by platform, not by whatever is installed: an ELF reader handed a
 # Mach-O prints no rpath instead of failing, which reads as "no rpath at all".
-case "$(uname -s)" in
+case "$HTS_OS" in
 Darwin) candidates="otool" ;;
 *) candidates="readelf objdump" ;;
 esac

--- a/tests/195_install-relocate.test
+++ b/tests/195_install-relocate.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 : "${abs_top_builddir:?not run under make check}"
 bindir="${CONFIGURED_BINDIR:?not run under make check}"

--- a/tests/195_install-relocate.test
+++ b/tests/195_install-relocate.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 : "${abs_top_builddir:?not run under make check}"
 bindir="${CONFIGURED_BINDIR:?not run under make check}"

--- a/tests/196_install-rpath-gates.test
+++ b/tests/196_install-rpath-gates.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 test -r "${srcdir}/configure" || skip "no configure in ${srcdir}"

--- a/tests/196_install-rpath-gates.test
+++ b/tests/196_install-rpath-gates.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 test -r "${srcdir}/configure" || skip "no configure in ${srcdir}"

--- a/tests/19_local-connect-fallback.test
+++ b/tests/19_local-connect-fallback.test
@@ -11,7 +11,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 if test "${V6_SUPPORT:-}" == "no"; then
     echo "no IPv6 support (resolver list/override is IPv6-only), skipping"

--- a/tests/19_local-connect-fallback.test
+++ b/tests/19_local-connect-fallback.test
@@ -11,7 +11,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 if test "${V6_SUPPORT:-}" == "no"; then
     echo "no IPv6 support (resolver list/override is IPv6-only), skipping"

--- a/tests/19_local-connect-fallback.test
+++ b/tests/19_local-connect-fallback.test
@@ -19,7 +19,7 @@ if test "${V6_SUPPORT:-}" == "no"; then
 fi
 # The fixture needs a second loopback IP (dead 127.0.0.2 + live 127.0.0.1) for
 # the fallback to have a target; GNU/Hurd has only 127.0.0.1, so skip there.
-case "$(uname -s)" in
+case "$HTS_OS" in
 GNU | GNU/*)
     echo "GNU/Hurd: single loopback IP, connect-fallback fixture unbuildable, skipping"
     exit 77

--- a/tests/200_pixmaps-fallback.test
+++ b/tests/200_pixmaps-fallback.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 builddir="${abs_top_builddir:?not run under make check}"

--- a/tests/200_pixmaps-fallback.test
+++ b/tests/200_pixmaps-fallback.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 builddir="${abs_top_builddir:?not run under make check}"

--- a/tests/205_install-headers.test
+++ b/tests/205_install-headers.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Unset means no automake run (the Windows job runs the scripts directly), so
 # there is no install rule to drive.

--- a/tests/205_install-headers.test
+++ b/tests/205_install-headers.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Unset means no automake run (the Windows job runs the scripts directly), so
 # there is no install rule to drive.

--- a/tests/206_install-headers-c99.test
+++ b/tests/206_install-headers-c99.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Unset means no automake run (the Windows job runs the scripts directly), so
 # there is no install rule to drive.

--- a/tests/206_install-headers-c99.test
+++ b/tests/206_install-headers-c99.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Unset means no automake run (the Windows job runs the scripts directly), so
 # there is no install rule to drive.

--- a/tests/207_install-headers-symbols.test
+++ b/tests/207_install-headers-symbols.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Unset means no automake run (the Windows job runs the scripts directly), so
 # there is no install rule to drive.

--- a/tests/207_install-headers-symbols.test
+++ b/tests/207_install-headers-symbols.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Unset means no automake run (the Windows job runs the scripts directly), so
 # there is no install rule to drive.

--- a/tests/20_local-resume-loop.test
+++ b/tests/20_local-resume-loop.test
@@ -4,7 +4,7 @@
 set -u
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 root=$(nativepath "${testdir}/server-root")
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_206.XXXXXX") || exit 1

--- a/tests/20_local-resume-loop.test
+++ b/tests/20_local-resume-loop.test
@@ -4,7 +4,7 @@
 set -u
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 root=$(nativepath "${testdir}/server-root")
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_206.XXXXXX") || exit 1

--- a/tests/210_appstream-metainfo.test
+++ b/tests/210_appstream-metainfo.test
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 

--- a/tests/210_appstream-metainfo.test
+++ b/tests/210_appstream-metainfo.test
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 

--- a/tests/215_engine-datadir-ospath.test
+++ b/tests/215_engine-datadir-ospath.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Unset means this is not an automake run (the Windows job runs the scripts
 # directly), so there is no unwrapped binary to copy.

--- a/tests/215_engine-datadir-ospath.test
+++ b/tests/215_engine-datadir-ospath.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Unset means this is not an automake run (the Windows job runs the scripts
 # directly), so there is no unwrapped binary to copy.

--- a/tests/217_webhttrack-attr-escaping.test
+++ b/tests/217_webhttrack-attr-escaping.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 distdir=${HTS_DISTDIR}

--- a/tests/217_webhttrack-attr-escaping.test
+++ b/tests/217_webhttrack-attr-escaping.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 distdir=${HTS_DISTDIR}

--- a/tests/218_crash-nopie-frames.test
+++ b/tests/218_crash-nopie-frames.test
@@ -19,7 +19,7 @@ fail() {
     exit 1
 }
 
-test "$(uname -s)" = "Linux" || skip "the ELF load bias is a Linux matter"
+test "$HTS_OS" = "Linux" || skip "the ELF load bias is a Linux matter"
 if ! command -v addr2line >/dev/null && ! command -v llvm-symbolizer >/dev/null; then
     skip "no symbolizer installed"
 fi

--- a/tests/218_crash-nopie-frames.test
+++ b/tests/218_crash-nopie-frames.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 srcdir=${abs_top_srcdir:?not run under make check}
 builddir=${abs_top_builddir:?not run under make check}

--- a/tests/218_crash-nopie-frames.test
+++ b/tests/218_crash-nopie-frames.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 srcdir=${abs_top_srcdir:?not run under make check}
 builddir=${abs_top_builddir:?not run under make check}

--- a/tests/219_install-rpath-darwin.test
+++ b/tests/219_install-rpath-darwin.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Unset means no automake run (the Windows job runs the scripts directly), so
 # there is no install rule to drive.

--- a/tests/219_install-rpath-darwin.test
+++ b/tests/219_install-rpath-darwin.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Unset means no automake run (the Windows job runs the scripts directly), so
 # there is no install rule to drive.

--- a/tests/219_install-rpath-darwin.test
+++ b/tests/219_install-rpath-darwin.test
@@ -15,7 +15,7 @@ bindir="${CONFIGURED_BINDIR:?not run under make check}"
 libdir="${CONFIGURED_LIBDIR:?not run under make check}"
 libdir=${libdir%/}
 
-test "$(uname -s)" = Darwin || skip "no Mach-O install commands to read here"
+test "$HTS_OS" = Darwin || skip "no Mach-O install commands to read here"
 command -v otool >/dev/null 2>&1 || skip "no otool"
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/rpathid.XXXXXX") || {

--- a/tests/220_webhttrack-mirror-isolation.test
+++ b/tests/220_webhttrack-mirror-isolation.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 distdir=${HTS_DISTDIR}

--- a/tests/220_webhttrack-mirror-isolation.test
+++ b/tests/220_webhttrack-mirror-isolation.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 distdir=${HTS_DISTDIR}

--- a/tests/221_local-ftp-ctrlchars.test
+++ b/tests/221_local-ftp-ctrlchars.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/221_local-ftp-ctrlchars.test
+++ b/tests/221_local-ftp-ctrlchars.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/221_local-ftp-ctrlchars.test
+++ b/tests/221_local-ftp-ctrlchars.test
@@ -55,7 +55,7 @@ grep -aq 'Invalid control character in FTP URL' "${out}/hts-log.txt" ||
     fail "no refusal in the log: $(grep -a 'Error' "${out}/hts-log.txt" || true)"
 ok "the injected URL is refused in $((SECONDS - start))s"
 
-sent=$(cat "$cmds")
+sent=$(<"$cmds")
 test -z "$sent" || fail "the engine still talked to the server: ${sent}"
 ok "nothing reached the control channel"
 

--- a/tests/222_pkgconfig-consumer.test
+++ b/tests/222_pkgconfig-consumer.test
@@ -41,7 +41,7 @@ shared=$(find "${staged_libdir}" -maxdepth 1 \( -name 'libhttrack.so*' -o -name 
 
 # Without the @rpath id there is nothing an rpath can answer: the dylib keeps an
 # absolute install name, and only the real libdir resolves.
-[ "$(uname -s)" != Darwin ] || [ "${ORIGIN_RPATH:-no}" = yes ] ||
+[ "$HTS_OS" != Darwin ] || [ "${ORIGIN_RPATH:-no}" = yes ] ||
     skip "configure did not enable a binary-relative rpath in this build"
 
 export PKG_CONFIG_PATH=${staged_libdir}/pkgconfig

--- a/tests/222_pkgconfig-consumer.test
+++ b/tests/222_pkgconfig-consumer.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Unset means no automake run (the Windows job runs the scripts directly).
 [ -n "${abs_top_builddir:-}" ] || skip "abs_top_builddir unset, no automake environment"

--- a/tests/222_pkgconfig-consumer.test
+++ b/tests/222_pkgconfig-consumer.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Unset means no automake run (the Windows job runs the scripts directly).
 [ -n "${abs_top_builddir:-}" ] || skip "abs_top_builddir unset, no automake environment"

--- a/tests/223_webhttrack-session-id.test
+++ b/tests/223_webhttrack-session-id.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/223_webhttrack-session-id.test
+++ b/tests/223_webhttrack-session-id.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/224_engine-ftp-cmdlen.test
+++ b/tests/224_engine-ftp-cmdlen.test
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpcmdlen.XXXXXX") || exit 1
 cleanup_push rm -rf "${tmpdir}"

--- a/tests/224_engine-ftp-cmdlen.test
+++ b/tests/224_engine-ftp-cmdlen.test
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpcmdlen.XXXXXX") || exit 1
 cleanup_push rm -rf "${tmpdir}"

--- a/tests/225_install-manifest.test
+++ b/tests/225_install-manifest.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 : "${abs_top_builddir:?not run under make check}"
 manifest="${abs_top_srcdir:?not run under make check}/tests/install-manifest.txt"

--- a/tests/225_install-manifest.test
+++ b/tests/225_install-manifest.test
@@ -13,7 +13,7 @@ set -euo pipefail
 manifest="${abs_top_srcdir:?not run under make check}/tests/install-manifest.txt"
 
 # macOS names the library .dylib, and Windows has no distro packaging to protect.
-test "$(uname -s)" = Linux || skip "install layout is pinned on Linux only"
+test "$HTS_OS" = Linux || skip "install layout is pinned on Linux only"
 test -r "${manifest}" || fail "no ${manifest}"
 
 # The docs are dropped below, so a docdir holding datadir would drop the pinned

--- a/tests/225_install-manifest.test
+++ b/tests/225_install-manifest.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 : "${abs_top_builddir:?not run under make check}"
 manifest="${abs_top_srcdir:?not run under make check}/tests/install-manifest.txt"

--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -12,7 +12,7 @@ unset WATCHDOG_TOKEN WATCHDOG_REPO WATCHDOG_SHA WATCHDOG_URL
 export WATCHDOG_CONTEXT='226_watchdog-native (never posted)'
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 top=${abs_top_srcdir:-$(cd "$testdir/.." && pwd)}
 wdscript="$testdir/ci-windows-watchdog.ps1"
@@ -182,6 +182,7 @@ else
     # Parsed, not grepped: every key below has to be read from the block that
     # owns it, and an ordinary reformatting of the workflow must not move it.
     cat >"$tmp/wf.py" <<'PY'
+import re
 import sys
 
 import yaml
@@ -192,9 +193,21 @@ def steps_of(wf):
 def checkouts(wf):
     return [s for s in steps_of(wf) if str(s.get("uses", "")).startswith("actions/checkout")]
 
-# Runs it, not merely names it: another step sources the driver for a helper.
+# Runs it under any spelling, but not the step that only sources it for a helper:
+# a matcher pinned to one invocation would pass a second job that drives a suite.
+SUITE_RUN = re.compile(r"(?<![.\w])bash\s+\S*ci-windows-suite\.sh")
+
 def runs_suite(s):
-    return "bash ./ci-windows-suite.sh" in str(s.get("run", ""))
+    return bool(SUITE_RUN.search(str(s.get("run", ""))))
+
+# One control per spelling, or the audit below is worth only what it can see.
+for _run, _want in [("bash ./ci-windows-suite.sh $dir", True),
+                    ('bash "$GITHUB_WORKSPACE/tests/ci-windows-suite.sh" $dir', True),
+                    ("bash ci-windows-suite.sh $dir", True),
+                    (". ./ci-windows-suite.sh\nci_report_fork_failures x.log", False),
+                    ("source ./ci-windows-suite.sh", False)]:
+    if runs_suite({"run": _run}) is not _want:
+        sys.exit("the suite-step matcher is wrong for: %r" % _run)
 
 def suite_steps(wf):
     return [s for s in steps_of(wf) if runs_suite(s)]

--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -12,7 +12,7 @@ unset WATCHDOG_TOKEN WATCHDOG_REPO WATCHDOG_SHA WATCHDOG_URL
 export WATCHDOG_CONTEXT='226_watchdog-native (never posted)'
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 top=${abs_top_srcdir:-$(cd "$testdir/.." && pwd)}
 wdscript="$testdir/ci-windows-watchdog.ps1"
@@ -192,14 +192,18 @@ def steps_of(wf):
 def checkouts(wf):
     return [s for s in steps_of(wf) if str(s.get("uses", "")).startswith("actions/checkout")]
 
+# Runs it, not merely names it: another step sources the driver for a helper.
+def runs_suite(s):
+    return "bash ./ci-windows-suite.sh" in str(s.get("run", ""))
+
 def suite_steps(wf):
-    return [s for s in steps_of(wf) if "ci-windows-suite.sh" in str(s.get("run", ""))]
+    return [s for s in steps_of(wf) if runs_suite(s)]
 
 def suite_jobs(wf):
     return [
         j
         for j in (wf.get("jobs") or {}).values()
-        if any("ci-windows-suite.sh" in str(s.get("run", "")) for s in (j.get("steps") or []))
+        if any(runs_suite(s) for s in (j.get("steps") or []))
     ]
 
 # A job-level block replaces the workflow's outright, so one naming only contents
@@ -411,7 +415,7 @@ sink_start() {
     # Where the teardown can find it: sink_start runs in a subshell of its own.
     echo "$sinkpid" >"$sinkpidfile"
     port=$(discover_server_port "$sinklog" "$sinkpid") ||
-        fail "the status sink never bound a port: $(cat "$sinklog")"
+        fail "the status sink never bound a port: $(<"$sinklog")"
 }
 sink_stop() {
     stop_server "$sinkpid"
@@ -444,7 +448,7 @@ cadence_leg() {
     run_posting 60 -File "$1" -ProgressLog "$(nativepath "$tmp/progress.log")" \
         -IntervalSeconds 100 -PollSeconds 1 -MaxSeconds 4 >"$legout" 2>&1 || {
         sink_stop
-        echo "the loop exited nonzero: $(cat "$legout")"
+        echo "the loop exited nonzero: $(<"$legout")"
         return 1
     }
     sink_stop
@@ -454,7 +458,7 @@ cadence_leg() {
         return 1
     }
     grep -q '36_local-bigcrawl.test' "$posts" || {
-        echo "the posted status does not name the test in flight: $(cat "$posts")"
+        echo "the posted status does not name the test in flight: $(<"$posts")"
         return 1
     }
     case $(posted_pairs) in
@@ -489,7 +493,7 @@ staticness_leg() {
     done
     wait "$legpid" || {
         sink_stop
-        echo "the loop exited nonzero: $(cat "$legout")"
+        echo "the loop exited nonzero: $(<"$legout")"
         return 1
     }
     sink_stop
@@ -517,7 +521,7 @@ throttle_leg() {
     run_posting 60 -File "$1" -ProgressLog "$(nativepath "$tmp/progress.log")" \
         -IntervalSeconds 1 -PollSeconds 1 -MaxSeconds 8 >"$legout" 2>&1 || {
         sink_stop
-        echo "the loop exited nonzero: $(cat "$legout")"
+        echo "the loop exited nonzero: $(<"$legout")"
         return 1
     }
     sink_stop
@@ -540,7 +544,7 @@ backoff_leg() {
     run_posting 60 -File "$1" -ProgressLog "$(nativepath "$tmp/progress.log")" \
         -IntervalSeconds 1 -PollSeconds 1 -MaxSeconds 8 >"$legout" 2>&1 || {
         sink_stop
-        echo "the loop exited nonzero: $(cat "$legout")"
+        echo "the loop exited nonzero: $(<"$legout")"
         return 1
     }
     sink_stop
@@ -559,7 +563,7 @@ backoff_leg() {
     # Every attempt here is refused, so each one after the first must say how many
     # went missing: x= is what separates a stopped box from a network that healed.
     grep -q ' x=[1-9]' "$posts" || {
-        echo "no posted status counted the failures before it: $(cat "$posts")"
+        echo "no posted status counted the failures before it: $(<"$posts")"
         return 1
     }
 }

--- a/tests/227_watchdog-poll.test
+++ b/tests/227_watchdog-poll.test
@@ -7,7 +7,7 @@
 set -eu
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_poll.XXXXXX") || exit 1
 # A colon-free root for the PATH shim below: MSYS hands out a drive-letter TMPDIR

--- a/tests/227_watchdog-poll.test
+++ b/tests/227_watchdog-poll.test
@@ -7,7 +7,7 @@
 set -eu
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_poll.XXXXXX") || exit 1
 # A colon-free root for the PATH shim below: MSYS hands out a drive-letter TMPDIR

--- a/tests/228_icon-small-flat.test
+++ b/tests/228_icon-small-flat.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 div="${srcdir}/html/server/div"

--- a/tests/228_icon-small-flat.test
+++ b/tests/228_icon-small-flat.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 div="${srcdir}/html/server/div"

--- a/tests/230_local-ftp-userpass.test
+++ b/tests/230_local-ftp-userpass.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/230_local-ftp-userpass.test
+++ b/tests/230_local-ftp-userpass.test
@@ -50,7 +50,7 @@ crawl() {
 
 # --- a plain login goes out unchanged ----------------------------------------
 crawl "bob:secret" || fail "the plain-login crawl never finished"
-sent=$(cat "$cmds")
+sent=$(<"$cmds")
 grep -qxF "USER bob" <<<"$sent" || fail "no USER bob on the wire: ${sent}"
 grep -qxF "PASS secret" <<<"$sent" || fail "no PASS secret on the wire: ${sent}"
 cmp -s "${out}/127.0.0.1_${port}/f.txt" "${root}/f.txt" ||
@@ -62,7 +62,7 @@ ok "bob:secret reaches the server verbatim, and mirrors"
 user=$(rep a 255)
 pass=$(rep b 255)
 crawl "${user}:${pass}" || fail "the 255-byte login crawl never finished"
-sent=$(cat "$cmds")
+sent=$(<"$cmds")
 grep -qxF "USER ${user}" <<<"$sent" ||
     fail "the wire user is not the 255 bytes the URL named: $(grep -a '^USER' <<<"$sent")"
 grep -qxF "PASS ${pass}" <<<"$sent" ||
@@ -74,8 +74,8 @@ ok "a 255-byte user and password reach the server unclipped"
 for u in "$(rep a 256):pw" "$(rep a 256)"; do
     crawl "$u" || fail "the over-long crawl never finished"
     grep -aq "FTP user name or password too long" "${out}/hts-log.txt" ||
-        fail "over-long userinfo was not refused: $(cat "${out}/hts-log.txt")"
-    sent=$(cat "$cmds")
+        fail "over-long userinfo was not refused: $(<"${out}/hts-log.txt")"
+    sent=$(<"$cmds")
     test -z "$sent" || fail "the engine logged in under a clipped name: ${sent}"
 done
 ok "an over-long name is refused before anything reaches the control channel"

--- a/tests/230_local-ftp-userpass.test
+++ b/tests/230_local-ftp-userpass.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/231_test-names.test
+++ b/tests/231_test-names.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 checker="${testdir}/check-test-names.sh"
 

--- a/tests/231_test-names.test
+++ b/tests/231_test-names.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 checker="${testdir}/check-test-names.sh"
 

--- a/tests/232_online-gate-outoftree.test
+++ b/tests/232_online-gate-outoftree.test
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # 226 asks this of every test naming the Windows suite driver, as the sweep's
 # allowlist below does.

--- a/tests/232_online-gate-outoftree.test
+++ b/tests/232_online-gate-outoftree.test
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # 226 asks this of every test naming the Windows suite driver, as the sweep's
 # allowlist below does.

--- a/tests/233_local-ftp-ctrl-timeout.test
+++ b/tests/233_local-ftp-ctrl-timeout.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/233_local-ftp-ctrl-timeout.test
+++ b/tests/233_local-ftp-ctrl-timeout.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/233_local-ftp-ctrl-timeout.test
+++ b/tests/233_local-ftp-ctrl-timeout.test
@@ -98,7 +98,7 @@ ok "a 20s timeout waits ${long}s: the wait tracks the value, not a constant"
 start=$SECONDS
 crawl stall 5 60 "ftp://127.0.0.1:${liveport}/stall.bin"
 stalled=$((SECONDS - start))
-sent=$(cat "$cmds")
+sent=$(<"$cmds")
 grep -q '^RETR ' <<<"$sent" || fail "the body transfer never started: ${sent}"
 logged stall 'Time out (5)'
 test "$stalled" -lt 40 ||

--- a/tests/234_local-ftp-maxtime.test
+++ b/tests/234_local-ftp-maxtime.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/234_local-ftp-maxtime.test
+++ b/tests/234_local-ftp-maxtime.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/234_local-ftp-maxtime.test
+++ b/tests/234_local-ftp-maxtime.test
@@ -49,7 +49,7 @@ elapsed=$((SECONDS - start))
 
 log="${out}/hts-log.txt"
 # Confirms the transfer had started; otherwise the wait under test never runs.
-sent=$(cat "$cmds")
+sent=$(<"$cmds")
 grep -q '^RETR ' <<<"$sent" ||
     fail "the transfer never started, so nothing was in flight: ${sent}"
 ok "the crawl was inside the body transfer when the cap hit"

--- a/tests/235_local-resume-recovery.test
+++ b/tests/235_local-resume-recovery.test
@@ -5,7 +5,7 @@ set -e
 set -u
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 server=$(nativepath "${testdir}/local-server.py")
 
 python=$(find_python) || skip "python3 not found"

--- a/tests/235_local-resume-recovery.test
+++ b/tests/235_local-resume-recovery.test
@@ -179,7 +179,7 @@ echo "OK (1 free restart, budget intact)"
 # Windows refuses to unlink a file it still holds open, so the partial outlives
 # the restart. LD_PRELOAD is the only way to reach that from POSIX, and the
 # interposer needs /proc to tell an open handle from a closed one.
-if [ "$(uname -s)" != "Linux" ] || [ ! -d /proc/self/fd ]; then
+if [ "$HTS_OS" != "Linux" ] || [ ! -d /proc/self/fd ]; then
     echo "resume-recovery: unlink interposition needs Linux + /proc, skipping the last leg"
     exit 0
 fi

--- a/tests/235_local-resume-recovery.test
+++ b/tests/235_local-resume-recovery.test
@@ -5,7 +5,7 @@ set -e
 set -u
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 server=$(nativepath "${testdir}/local-server.py")
 
 python=$(find_python) || skip "python3 not found"

--- a/tests/236_local-ftp-teardown.test
+++ b/tests/236_local-ftp-teardown.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/236_local-ftp-teardown.test
+++ b/tests/236_local-ftp-teardown.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/237_engine-arrays.test
+++ b/tests/237_engine-arrays.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # htsarrays.h growth macros (driven by 'httrack -#test=arrays').
 

--- a/tests/237_engine-arrays.test
+++ b/tests/237_engine-arrays.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # htsarrays.h growth macros (driven by 'httrack -#test=arrays').
 

--- a/tests/240_local-abort-teardown.test
+++ b/tests/240_local-abort-teardown.test
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_abort.XXXXXX") || exit 1
 cleanup() {

--- a/tests/240_local-abort-teardown.test
+++ b/tests/240_local-abort-teardown.test
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_abort.XXXXXX") || exit 1
 cleanup() {

--- a/tests/241_local-single-file-gui.test
+++ b/tests/241_local-single-file-gui.test
@@ -4,7 +4,7 @@
 set -e
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 # The Windows job builds httrack.exe only and reaches this file through its
 # *_local-*.test glob, so report a skip there rather than a pass.

--- a/tests/241_local-single-file-gui.test
+++ b/tests/241_local-single-file-gui.test
@@ -4,7 +4,7 @@
 set -e
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 # The Windows job builds httrack.exe only and reaches this file through its
 # *_local-*.test glob, so report a skip there rather than a pass.

--- a/tests/242_engine-warc-teardown.test
+++ b/tests/242_engine-warc-teardown.test
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 httrack_bin=$(httrack_path)
 

--- a/tests/242_engine-warc-teardown.test
+++ b/tests/242_engine-warc-teardown.test
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 httrack_bin=$(httrack_path)
 

--- a/tests/243_local-ftp-deadhost-interrupt.test
+++ b/tests/243_local-ftp-deadhost-interrupt.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/243_local-ftp-deadhost-interrupt.test
+++ b/tests/243_local-ftp-deadhost-interrupt.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/244_local-tty-output.test
+++ b/tests/244_local-tty-output.test
@@ -6,7 +6,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 

--- a/tests/244_local-tty-output.test
+++ b/tests/244_local-tty-output.test
@@ -6,7 +6,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 

--- a/tests/245_local-ftp-deadhost-timeout.test
+++ b/tests/245_local-ftp-deadhost-timeout.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/245_local-ftp-deadhost-timeout.test
+++ b/tests/245_local-ftp-deadhost-timeout.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 command -v httrack >/dev/null || {

--- a/tests/247_cli-stdin-eof.test
+++ b/tests/247_cli-stdin-eof.test
@@ -7,7 +7,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 ttyrun=$(nativepath "${testdir}/ttyrun.py")
 
 skip_on_windows "no pty on Windows"

--- a/tests/247_cli-stdin-eof.test
+++ b/tests/247_cli-stdin-eof.test
@@ -7,7 +7,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 ttyrun=$(nativepath "${testdir}/ttyrun.py")
 
 skip_on_windows "no pty on Windows"

--- a/tests/249_windows-reap-images.test
+++ b/tests/249_windows-reap-images.test
@@ -7,9 +7,9 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 # shellcheck source=tests/proclib.sh
-. "${0%"${0##*/}"}proclib.sh"
+. "${0%"${0##*/}"}./proclib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_reapimg.XXXXXX")
 cleanup_push rm -rf "$tmp"

--- a/tests/249_windows-reap-images.test
+++ b/tests/249_windows-reap-images.test
@@ -7,9 +7,9 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 # shellcheck source=tests/proclib.sh
-. "$(dirname "$0")/proclib.sh"
+. "${0%"${0##*/}"}proclib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_reapimg.XXXXXX")
 cleanup_push rm -rf "$tmp"

--- a/tests/249_windows-reap-images.test
+++ b/tests/249_windows-reap-images.test
@@ -35,7 +35,7 @@ done
 # engine and the python fixture server behind it.
 : >"$tmp/killed"
 kill_tree 4242
-test ! -s "$tmp/killed" || fail "kill_tree swept the host unasked: $(cat "$tmp/killed")"
+test ! -s "$tmp/killed" || fail "kill_tree swept the host unasked: $(<"$tmp/killed")"
 
 # The opt-in a runner with one test in flight sets.
 : >"$tmp/killed"
@@ -61,7 +61,7 @@ done
 win_pid() { echo 9999; }
 : >"$tmp/killed"
 HTTRACK_EXCLUSIVE_HOST=1 kill_tree 99 4242
-got=$(cat "$tmp/killed")
+got=$(<"$tmp/killed")
 test "$got" = '/F /T /PID 4242' || fail "kill_tree with a pre-resolved winpid ran: $got"
 
 # With a winpid it is one tree kill and nothing by name, or a parallel sibling's
@@ -69,24 +69,24 @@ test "$got" = '/F /T /PID 4242' || fail "kill_tree with a pre-resolved winpid ra
 win_pid() { echo 4242; }
 : >"$tmp/killed"
 kill_tree 99
-test "$(cat "$tmp/killed")" = '/F /T /PID 4242' || fail "kill_tree with a winpid ran: $(cat "$tmp/killed")"
+test "$(<"$tmp/killed")" = '/F /T /PID 4242' || fail "kill_tree with a winpid ran: $(<"$tmp/killed")"
 win_pid() { :; }
 
 # The image read while the target was alive: a freed winpid can already be a
 # stranger's, and /T would take its children too (#1228).
 : >"$tmp/killed"
 kill_tree 99 4242 PROXYTRACK.EXE
-test "$(cat "$tmp/killed")" = '/F /T /PID 4242' ||
-    fail "a verified tree kill did not run: $(cat "$tmp/killed")"
+test "$(<"$tmp/killed")" = '/F /T /PID 4242' ||
+    fail "a verified tree kill did not run: $(<"$tmp/killed")"
 : >"$tmp/killed"
 out=$(kill_tree 99 4242 python.exe)
-test ! -s "$tmp/killed" || fail "pid 4242 was killed as a python.exe: $(cat "$tmp/killed")"
+test ! -s "$tmp/killed" || fail "pid 4242 was killed as a python.exe: $(<"$tmp/killed")"
 grep -q '::warning::pid 4242 no longer runs python.exe' <<<"$out" ||
     fail "the skipped kill was not reported: $out"
 # Gone from the table entirely, which is what a freed winpid usually looks like.
 : >"$tmp/killed"
 kill_tree 99 4343 proxytrack.exe >/dev/null
-test ! -s "$tmp/killed" || fail "a pid tasklist does not list was killed: $(cat "$tmp/killed")"
+test ! -s "$tmp/killed" || fail "a pid tasklist does not list was killed: $(<"$tmp/killed")"
 # A stranger's pid leaves the caller with no target, so the serial runner's last
 # resort still applies: skipping it too would leave the engines running.
 : >"$tmp/killed"
@@ -107,8 +107,8 @@ reap_bounded() { :; }
 stop_server 99
 got=$(tr '\n' ' ' <"$tmp/order")
 test "$got" = 'capture 99 kill 99 ' || fail "stop_server did not capture before signalling: $got"
-test "$(cat "$tmp/killed")" = '/F /T /PID 4242' ||
-    fail "stop_server did not tree-kill what it captured: $(cat "$tmp/killed")"
+test "$(<"$tmp/killed")" = '/F /T /PID 4242' ||
+    fail "stop_server did not tree-kill what it captured: $(<"$tmp/killed")"
 unset -f kill win_capture reap_bounded
 
 : >"$tmp/killed"
@@ -132,7 +132,7 @@ tasklist() {
 : >"$tmp/killed"
 out=$(reap_leftover_processes 99_probe.test)
 test -z "$out" || fail "an unrelated process was reported as a leak: $out"
-test ! -s "$tmp/killed" || fail "an unrelated process was reaped: $(cat "$tmp/killed")"
+test ! -s "$tmp/killed" || fail "an unrelated process was reaped: $(<"$tmp/killed")"
 
 # The same list drives the wedge report, which names python too so a leaked
 # fixture server is still visible to a reader.

--- a/tests/24_local-resume-overlap.test
+++ b/tests/24_local-resume-overlap.test
@@ -8,7 +8,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 root=$(nativepath "${testdir}/server-root")
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_198.XXXXXX") || exit 1

--- a/tests/24_local-resume-overlap.test
+++ b/tests/24_local-resume-overlap.test
@@ -8,7 +8,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 root=$(nativepath "${testdir}/server-root")
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_198.XXXXXX") || exit 1

--- a/tests/250_timeout-poll-nofork.test
+++ b/tests/250_timeout-poll-nofork.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_nofork.XXXXXX")
 cleanup_push rm -rf "$tmp"

--- a/tests/250_timeout-poll-nofork.test
+++ b/tests/250_timeout-poll-nofork.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_nofork.XXXXXX")
 cleanup_push rm -rf "$tmp"

--- a/tests/250_timeout-poll-nofork.test
+++ b/tests/250_timeout-poll-nofork.test
@@ -67,17 +67,17 @@ rc=0
 run_timeout "$tmp/dead" "$tmp/broken.log" 20 || rc=$?
 spent=$((SECONDS - began))
 
-test "$rc" -eq 124 || fail "a tick that never waits exited $rc, not 124: $(cat "$tmp/broken.log")"
+test "$rc" -eq 124 || fail "a tick that never waits exited $rc, not 124: $(<"$tmp/broken.log")"
 # With the count, or a guard tripping on the first tick reads the same.
 grep -q 'poll tick ran 10 times' "$tmp/broken.log" ||
-    fail "no verdict naming the tenth tick: $(cat "$tmp/broken.log")"
+    fail "no verdict naming the tenth tick: $(<"$tmp/broken.log")"
 grep -q '^NOFORK child.sh$' "$tmp/progress" ||
-    fail "the off-box watchdog got no marker: $(cat "$tmp/progress")"
+    fail "the off-box watchdog got no marker: $(<"$tmp/progress")"
 # The deadline path writes DUMP and spends the whole 60s, so either says the guard
 # is gone and the budget is what ended the loop.
 grep -q '^DUMP ' "$tmp/progress" && fail "the loop ran to its 60s deadline, not the guard"
 test "$spent" -lt 30 || fail "took ${spent}s to give up on a tick that returns at once"
-childpid=$(cat "$tmp/childpid")
+childpid=$(<"$tmp/childpid")
 test -n "$childpid" || fail "the child never started"
 # Bounded, not instantaneous: the give-up branch skips reap_bounded on purpose, so
 # it returns with the kill barely delivered and the child not yet reaped (#1092).
@@ -88,13 +88,13 @@ REAP_GRACE=5 reap_bounded "$childpid" ||
 # verdict: without the reset, any run long enough accumulates ten of them.
 : >"$tmp/progress"
 : >"$tmp/ticks"
-run_timeout "$tmp/flaky" "$tmp/flaky.log" || fail "an intermittent tick failed the run: $(cat "$tmp/flaky.log")"
+run_timeout "$tmp/flaky" "$tmp/flaky.log" || fail "an intermittent tick failed the run: $(<"$tmp/flaky.log")"
 grep -q 'NOFORK' "$tmp/progress" && fail "ticks that fail every other call were read as a wedge"
 
 # Control: a working sleep must reach neither branch, or the assertions above would
 # hold for any run at all.
 : >"$tmp/progress"
-run_timeout "" "$tmp/ok.log" || fail "a healthy run failed: $(cat "$tmp/ok.log")"
+run_timeout "" "$tmp/ok.log" || fail "a healthy run failed: $(<"$tmp/ok.log")"
 grep -q 'NOFORK' "$tmp/progress" && fail "a healthy poll tick was read as a broken one"
 
 echo "test-timeout poll guard OK"

--- a/tests/251_webhttrack-lang-selected.test
+++ b/tests/251_webhttrack-lang-selected.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/251_webhttrack-lang-selected.test
+++ b/tests/251_webhttrack-lang-selected.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/252_local-nonhtml-foreign-depth.test
+++ b/tests/252_local-nonhtml-foreign-depth.test
@@ -5,7 +5,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_121.XXXXXX") || exit 1
 cleanup() {

--- a/tests/252_local-nonhtml-foreign-depth.test
+++ b/tests/252_local-nonhtml-foreign-depth.test
@@ -5,7 +5,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_121.XXXXXX") || exit 1
 cleanup() {

--- a/tests/253_local-ftp-close-once.test
+++ b/tests/253_local-ftp-close-once.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 if [ "$HTS_OS" != "Linux" ]; then
     echo "close-once: LD_PRELOAD interposition is Linux-only here, skipping" >&2

--- a/tests/253_local-ftp-close-once.test
+++ b/tests/253_local-ftp-close-once.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 if [ "$HTS_OS" != "Linux" ]; then
     echo "close-once: LD_PRELOAD interposition is Linux-only here, skipping" >&2

--- a/tests/253_local-ftp-close-once.test
+++ b/tests/253_local-ftp-close-once.test
@@ -9,7 +9,7 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "$(dirname "$0")/testlib.sh"
 
-if [ "$(uname -s)" != "Linux" ]; then
+if [ "$HTS_OS" != "Linux" ]; then
     echo "close-once: LD_PRELOAD interposition is Linux-only here, skipping" >&2
     exit 77
 fi

--- a/tests/254_testlib-tls-pem.test
+++ b/tests/254_testlib-tls-pem.test
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_tlspem.XXXXXX")
 cleanup_push rm -rf "$tmpdir"

--- a/tests/254_testlib-tls-pem.test
+++ b/tests/254_testlib-tls-pem.test
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_tlspem.XXXXXX")
 cleanup_push rm -rf "$tmpdir"

--- a/tests/255_local-ftp-sigterm.test
+++ b/tests/255_local-ftp-sigterm.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 skip_on_windows "MSYS cannot signal a native httrack.exe"

--- a/tests/255_local-ftp-sigterm.test
+++ b/tests/255_local-ftp-sigterm.test
@@ -101,7 +101,7 @@ ok "SIGTERM ended the crawl in $((SECONDS - started))s"
 # Leaving the wait is only half of it: the exit has to walk out through the
 # normal end of the mirror. Bailing to the error path, or skipping the link as
 # though it were done, also ends the wait and loses the mirror instead.
-reply=$(cat "${tmpdir}/log")
+reply=$(<"${tmpdir}/log")
 grep -q 'Exit requested to engine' <<<"$reply" ||
     fail "SIGTERM did not reach the engine: ${reply}"
 grep -q 'Thanks for using HTTrack' <<<"$reply" ||
@@ -110,7 +110,7 @@ test -s "${out}/hts-cache/new.zip" ||
     fail "the cache was not committed: $(find "$out" -type f)"
 test -s "$partial" ||
     fail "the received prefix was dropped: $(find "$out" -type f)"
-log=$(cat "${out}/hts-log.txt")
+log=$(<"${out}/hts-log.txt")
 # Only the outer loop's own exit_xh branch writes this. Returning the caller's
 # error code leaves the wait just as well, and jumps straight to cleanup with a
 # cache holding nothing.
@@ -134,7 +134,7 @@ done
 started=$SECONDS
 kill -TERM "$crawlpid"
 await_exit 60 "the terminated saturated crawl"
-reply=$(cat "${tmpdir}/log")
+reply=$(<"${tmpdir}/log")
 grep -q 'Thanks for using HTTrack' <<<"$reply" ||
     fail "the saturated exit skipped teardown: ${reply}"
 ok "SIGTERM ended a crawl with no free socket in $((SECONDS - started))s"
@@ -150,7 +150,7 @@ await_exit 120 "the interrupted crawl"
 # sig_leave's own line: without it the transfer completing says nothing, since
 # a signal that never arrived leaves a crawl that was going to finish anyway.
 grep -q 'Finishing pending transfers' "${tmpdir}/log" ||
-    fail "the ^C never reached sig_leave: $(cat "${tmpdir}/log")"
+    fail "the ^C never reached sig_leave: $(<"${tmpdir}/log")"
 cmp -s "${out}/127.0.0.1_${port}/f.bin" "${root}/f.bin" ||
     fail "^C cut the transfer short; mirror holds $(find "$out" -type f)"
 ok "a single ^C let the in-flight transfer complete"

--- a/tests/255_local-ftp-sigterm.test
+++ b/tests/255_local-ftp-sigterm.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 skip_on_windows "MSYS cannot signal a native httrack.exe"

--- a/tests/256_testlib-cleanup.test
+++ b/tests/256_testlib-cleanup.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_cleanup.XXXXXX")
 # Hand-written, not cleanup_push: this test must not lose its own teardown to

--- a/tests/256_testlib-cleanup.test
+++ b/tests/256_testlib-cleanup.test
@@ -43,10 +43,10 @@ cleanup_push
 cleanup_push note "pushed  second 'quoted'"
 EOF
 rc=$(subject)
-test "$rc" -eq 0 || fail "the subject exited $rc: $(cat "$tmpdir/out")"
+test "$rc" -eq 0 || fail "the subject exited $rc: $(<"$tmpdir/out")"
 want="pushed  second 'quoted'
 pushed first"
-test "$(cat "$tmpdir/log")" = "$want" || fail "wrong teardown order: $(cat "$tmpdir/log")"
+test "$(<"$tmpdir/log")" = "$want" || fail "wrong teardown order: $(<"$tmpdir/log")"
 ok "cleanups run last-pushed-first with their arguments intact"
 
 ## a failing teardown does not become the test's verdict (#773)
@@ -61,7 +61,7 @@ rc=$(subject)
 test "$rc" -eq 0 || fail "a failing cleanup left status $rc"
 want="above the failure
 below the failure"
-test "$(cat "$tmpdir/log")" = "$want" || fail "the drain stopped at the failure: $(cat "$tmpdir/log")"
+test "$(<"$tmpdir/log")" = "$want" || fail "the drain stopped at the failure: $(<"$tmpdir/log")"
 ok "a failing cleanup neither aborts the drain nor reds the test"
 
 # And the real status still reaches automake.
@@ -107,7 +107,7 @@ EOF
     rc=$(subject)
     test "$rc" -eq 1 ||
         bad="$bad [SIG${sig} left status $rc after $((SECONDS - start))s, not the trap's exit 1]"
-    test "$(cat "$tmpdir/log")" = drained ||
+    test "$(<"$tmpdir/log")" = drained ||
         bad="$bad [SIG${sig} drained the stack $(wc -l <"$tmpdir/log") times]"
 done
 test -z "$bad" || fail "signal teardown:$bad"
@@ -122,9 +122,9 @@ cleanup_push note 'registered before the second source'
 . ${testdir}/testlib.sh
 EOF
 rc=$(subject)
-test "$rc" -eq 0 || fail "the subject exited $rc: $(cat "$tmpdir/out")"
-test "$(cat "$tmpdir/log")" = 'registered before the second source' ||
-    fail "re-sourcing dropped the stack: $(cat "$tmpdir/log")"
+test "$rc" -eq 0 || fail "the subject exited $rc: $(<"$tmpdir/out")"
+test "$(<"$tmpdir/log")" = 'registered before the second source' ||
+    fail "re-sourcing dropped the stack: $(<"$tmpdir/log")"
 ok "re-sourcing the library keeps a stack already built"
 
 ## nothing pushed, no trap
@@ -137,6 +137,6 @@ cleanup_push note 'pushed'
 test -n "$(trap -p EXIT)" || note 'cleanup_push installed no EXIT trap'
 EOF
 rc=$(subject)
-test "$rc" -eq 0 || fail "the subject exited $rc: $(cat "$tmpdir/out")"
-test "$(cat "$tmpdir/log")" = pushed || fail "unexpected EXIT trap state: $(cat "$tmpdir/log")"
+test "$rc" -eq 0 || fail "the subject exited $rc: $(<"$tmpdir/out")"
+test "$(<"$tmpdir/log")" = pushed || fail "unexpected EXIT trap state: $(<"$tmpdir/log")"
 ok "the traps arrive with the first cleanup_push, not with the source line"

--- a/tests/256_testlib-cleanup.test
+++ b/tests/256_testlib-cleanup.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_cleanup.XXXXXX")
 # Hand-written, not cleanup_push: this test must not lose its own teardown to

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_asserts.XXXXXX")
 cleanup_push rm -rf "$tmpdir"

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -1,12 +1,13 @@
 #!/bin/bash
 #
-# The assert_* helpers the engine self-test tier rests on, exercised from a
-# subject process, since a firing assertion would exit this script too.
+# The assert_* helpers the engine self-test tier rests on, plus the HTS_OS cache
+# the skip gates read, exercised from a subject process: a firing assertion would
+# exit this script too.
 
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_asserts.XXXXXX")
 cleanup_push rm -rf "$tmpdir"
@@ -96,3 +97,18 @@ cd /
 "$p" --version >/dev/null'
 fires 'PATH= httrack_path' 'no httrack in PATH'
 ok "httrack_path returns an absolute path that still runs from elsewhere"
+
+## HTS_OS. Exported, so a child reads the value instead of forking for it, which
+# makes that value what every platform skip gate now decides on.
+# shellcheck disable=SC2016 # a subject is shell source, expanded by the subject
+holds 'test "$HTS_OS" = "$(uname -s)"'
+# shellcheck disable=SC2016
+holds 'test "$(bash -c "printf %s \"\$HTS_OS\"")" = "$(uname -s)"'
+# shellcheck disable=SC2016
+printf 'set -euo pipefail\n. "%s/testlib.sh"\nprintf %%s "$HTS_OS"\n' "$testdir" >"$tmpdir/os.sh"
+for pre in "-u HTS_OS" "HTS_OS="; do
+    # shellcheck disable=SC2086 # the split is what makes it env's argument
+    got=$(env $pre bash "$tmpdir/os.sh")
+    test "$got" = "$(uname -s)" || fail "HTS_OS under [env $pre] resolved to [$got]"
+done
+ok "HTS_OS resolves to uname -s, unset or inherited empty"

--- a/tests/258_crawllib.test
+++ b/tests/258_crawllib.test
@@ -10,7 +10,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 find_python >/dev/null || skip "python3 not found"
 

--- a/tests/258_crawllib.test
+++ b/tests/258_crawllib.test
@@ -10,7 +10,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 find_python >/dev/null || skip "python3 not found"
 

--- a/tests/258_crawllib.test
+++ b/tests/258_crawllib.test
@@ -168,7 +168,7 @@ has '--max-time=120' "local_crawl dropped its default --max-time"
 assert_eq "--max-time=120
 -O
 /dev/null
-$url" "$(cat "$argv")" "the caller's arguments reach httrack, in order, after the cap"
+$url" "$(<"$argv")" "the caller's arguments reach httrack, in order, after the cap"
 ok "local_crawl adds a --max-time backstop ahead of the caller's arguments"
 
 # A caller's own cap wins: with two of them the engine takes one of the pair,
@@ -200,10 +200,10 @@ echo "crawl-said-this"
 SH
 chmod +x "${shim}/httrack"
 local_crawl --log "${tmpdir}/crawl.log" -O /dev/null "$url"
-assert_eq "crawl-said-this" "$(cat "${tmpdir}/crawl.log")" "--log took stdout"
+assert_eq "crawl-said-this" "$(<"${tmpdir}/crawl.log")" "--log took stdout"
 # Truncated, not appended: every call site it replaced used a plain > redirect.
 local_crawl --log "${tmpdir}/crawl.log" -O /dev/null "$url"
-assert_eq "crawl-said-this" "$(cat "${tmpdir}/crawl.log")" "--log truncates per crawl"
+assert_eq "crawl-said-this" "$(<"${tmpdir}/crawl.log")" "--log truncates per crawl"
 ok "--log takes the crawl output, one crawl at a time"
 
 ## --stdin feeds the engine, which a redirect on the call cannot be trusted to do
@@ -225,14 +225,14 @@ printf answer >"${tmpdir}/answers"
 # Against a call redirected elsewhere: --stdin is on the engine, so it wins.
 local_crawl --stdin "${tmpdir}/answers" --log "${tmpdir}/crawl.log" \
     -O /dev/null "$url" </dev/null
-assert_eq "stdin=[answer]" "$(cat "${tmpdir}/crawl.log")" "--stdin FILE"
+assert_eq "stdin=[answer]" "$(<"${tmpdir}/crawl.log")" "--stdin FILE"
 local_crawl --stdin closed --log "${tmpdir}/crawl.log" \
     -O /dev/null "$url" <"${tmpdir}/answers"
-assert_eq "stdin=[closed]" "$(cat "${tmpdir}/crawl.log")" "--stdin closed"
+assert_eq "stdin=[closed]" "$(<"${tmpdir}/crawl.log")" "--stdin closed"
 # Without the option the engine still has a descriptor, whatever the platform
 # gives a background job.
 local_crawl --log "${tmpdir}/crawl.log" -O /dev/null "$url" </dev/null
-assert_eq "stdin=[]" "$(cat "${tmpdir}/crawl.log")" "the default stdin"
+assert_eq "stdin=[]" "$(<"${tmpdir}/crawl.log")" "the default stdin"
 ok "--stdin hands the engine a file, or no descriptor at all"
 
 ## The watchdog reds a crawl that never ends, from a subject: it ends the test

--- a/tests/259_doc-css-assets.test
+++ b/tests/259_doc-css-assets.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 builddir="${abs_top_builddir:?not run under make check}"

--- a/tests/259_doc-css-assets.test
+++ b/tests/259_doc-css-assets.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 builddir="${abs_top_builddir:?not run under make check}"

--- a/tests/260_crawl-harness-fails-loudly.test
+++ b/tests/260_crawl-harness-fails-loudly.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 find_python >/dev/null || skip "python3 not found"
 command -v httrack >/dev/null || skip "no httrack in PATH"

--- a/tests/260_crawl-harness-fails-loudly.test
+++ b/tests/260_crawl-harness-fails-loudly.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 find_python >/dev/null || skip "python3 not found"
 command -v httrack >/dev/null || skip "no httrack in PATH"

--- a/tests/261_local-abort-purge.test
+++ b/tests/261_local-abort-purge.test
@@ -85,7 +85,7 @@ urls_of "${names[@]}"
 run_with_timeout 300 httrack "${urls[@]}" -O "$out" "${common[@]}" \
     --timeout=20 --max-time=120 >"${tmpdir}/log2" 2>&1
 grep -aq 'mirror complete in' "${out}/hts-log.txt" ||
-    fail "pass 2 did not run to completion: $(cat "${out}/hts-log.txt")"
+    fail "pass 2 did not run to completion: $(<"${out}/hts-log.txt")"
 test ! -f "${out}/${host}/f.bin" ||
     fail "a completed crawl no longer purges the file it dropped"
 ok "a completed crawl still purges"
@@ -117,7 +117,7 @@ wait_bounded "$crawlpid" 120 || rc=$?
 crawlpid=
 test "$rc" -ne 124 || fail "the terminated crawl was still running 120s later"
 
-log=$(cat "${out}/hts-log.txt")
+log=$(<"${out}/hts-log.txt")
 # The exit has to land in the outer loop's own branch, the one that falls
 # through to the purge. A bailout jumps past it and proves nothing.
 grep -q 'Exit requested by shell or user' <<<"$log" ||

--- a/tests/261_local-abort-purge.test
+++ b/tests/261_local-abort-purge.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 skip_on_windows "MSYS cannot signal a native httrack.exe"

--- a/tests/261_local-abort-purge.test
+++ b/tests/261_local-abort-purge.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 skip_on_windows "MSYS cannot signal a native httrack.exe"

--- a/tests/262_local-signal-receive.test
+++ b/tests/262_local-signal-receive.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 skip_on_windows "MSYS cannot signal a native httrack.exe"
 command -v httrack >/dev/null || fail "could not find httrack"

--- a/tests/262_local-signal-receive.test
+++ b/tests/262_local-signal-receive.test
@@ -80,7 +80,7 @@ test "$started" -lt 8 ||
     fail "all eight bodies were already fetched before the first signal"
 
 ! grep -q 'Receive Error' "${out}/hts-log.txt" ||
-    fail "a benign signal was reported as a socket error: $(cat "${out}/hts-log.txt")"
+    fail "a benign signal was reported as a socket error: $(<"${out}/hts-log.txt")"
 # And what the retry queue makes of it afterwards is not the engine's choice to
 # make: the bodies have to arrive whole.
 mirror="${out}/127.0.0.1_${SRV_PORT}/dcancel"
@@ -116,10 +116,10 @@ elapsed=$((SECONDS - started))
 test "$elapsed" -lt "$STOP_CEILING" ||
     fail "^C took ${elapsed}s to end a stalled transfer"
 grep -q 'Finishing pending transfers' "$log" ||
-    fail "the ^C never reached sig_leave: $(cat "$log")"
+    fail "the ^C never reached sig_leave: $(<"$log")"
 grep -q 'Thanks for using HTTrack' "$log" ||
-    fail "the stop skipped teardown: $(cat "$log")"
-htslog=$(cat "${out}/hts-log.txt")
+    fail "the stop skipped teardown: $(<"$log")"
+htslog=$(<"${out}/hts-log.txt")
 grep -q 'stopped by user' <<<"$htslog" ||
     fail "the abort was not reported as the user's stop: ${htslog}"
 # The fabricated error is the bug: a stop reported as a socket failure is what

--- a/tests/262_local-signal-receive.test
+++ b/tests/262_local-signal-receive.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 skip_on_windows "MSYS cannot signal a native httrack.exe"
 command -v httrack >/dev/null || fail "could not find httrack"

--- a/tests/263_local-ftp-stop-window.test
+++ b/tests/263_local-ftp-stop-window.test
@@ -85,12 +85,12 @@ await_exit() {
 # is the other half, and it is the same either way the run was ended.
 assert_outcome() {
     local reply htslog
-    reply=$(cat "${tmpdir}/log")
+    reply=$(<"${tmpdir}/log")
     grep -q 'Thanks for using HTTrack' <<<"$reply" ||
         fail "$1 skipped teardown: ${reply}"
     test -s "$partial" ||
         fail "$1 dropped the received prefix: $(find "$out" -type f)"
-    htslog=$(cat "${out}/hts-log.txt")
+    htslog=$(<"${out}/hts-log.txt")
     # The worker's own wait is what has to expire, not some outer bound: only
     # that wait writes this line, with the timeout it was given.
     grep -q "Time out (${TIMEOUT})" <<<"$htslog" ||
@@ -105,7 +105,7 @@ kill -INT "$crawlpid"
 await_exit 60 "the interrupted crawl"
 stopped=$((SECONDS - started))
 grep -q 'Finishing pending transfers' "${tmpdir}/log" ||
-    fail "the ^C never reached sig_leave: $(cat "${tmpdir}/log")"
+    fail "the ^C never reached sig_leave: $(<"${tmpdir}/log")"
 assert_outcome "the interrupted crawl"
 # Upper bound: the second window is gone. Lower bound: the first one is not,
 # so a stop must not cut a transfer's wait short the way #1107 did.

--- a/tests/263_local-ftp-stop-window.test
+++ b/tests/263_local-ftp-stop-window.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 skip_on_windows "MSYS cannot signal a native httrack.exe"

--- a/tests/263_local-ftp-stop-window.test
+++ b/tests/263_local-ftp-stop-window.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 skip_on_windows "MSYS cannot signal a native httrack.exe"

--- a/tests/264_engine-wizard-filter.test
+++ b/tests/264_engine-wizard-filter.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # #1119: the self-test asserts the emitted patterns, this feeds the host-wide
 # one back through the matcher that decides whether a link is authorized.

--- a/tests/264_engine-wizard-filter.test
+++ b/tests/264_engine-wizard-filter.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # #1119: the self-test asserts the emitted patterns, this feeds the host-wide
 # one back through the matcher that decides whether a link is authorized.

--- a/tests/268_local-abort-purge-capped.test
+++ b/tests/268_local-abort-purge-capped.test
@@ -44,7 +44,7 @@ local_crawl --log "${tmpdir}/log2" "${common[@]}" -O "$out" --timeout=0 \
     --max-time=2 "${BASEURL}/abortpurge/index.html" || rc=$?
 test "$rc" -ne 124 || fail "the capped crawl overran its deadline"
 
-log=$(cat "${out}/hts-log.txt")
+log=$(<"${out}/hts-log.txt")
 grep -q 'giving up' <<<"$log" || fail "the time cap never fired: ${log}"
 # Fewer links than pass 1 saw is what says some were dropped; without it this
 # passes on a mirror that simply finished.

--- a/tests/268_local-abort-purge-capped.test
+++ b/tests/268_local-abort-purge-capped.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 command -v httrack >/dev/null || fail "could not find httrack"
 

--- a/tests/268_local-abort-purge-capped.test
+++ b/tests/268_local-abort-purge-capped.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 command -v httrack >/dev/null || fail "could not find httrack"
 

--- a/tests/269_install-headers-order.test
+++ b/tests/269_install-headers-order.test
@@ -14,7 +14,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 if [ -z "${abs_top_builddir:-}" ]; then
     echo "abs_top_builddir unset, no automake environment, skipping" >&2

--- a/tests/269_install-headers-order.test
+++ b/tests/269_install-headers-order.test
@@ -14,7 +14,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 if [ -z "${abs_top_builddir:-}" ]; then
     echo "abs_top_builddir unset, no automake environment, skipping" >&2

--- a/tests/271_doc-chrome-year.test
+++ b/tests/271_doc-chrome-year.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 chrome_src="${srcdir}/tools/doc-chrome.py"

--- a/tests/271_doc-chrome-year.test
+++ b/tests/271_doc-chrome-year.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 chrome_src="${srcdir}/tools/doc-chrome.py"

--- a/tests/275_local-dash-rule.test
+++ b/tests/275_local-dash-rule.test
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_dashrule.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmp"

--- a/tests/275_local-dash-rule.test
+++ b/tests/275_local-dash-rule.test
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_dashrule.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmp"

--- a/tests/276_testlib-freeport.test
+++ b/tests/276_testlib-freeport.test
@@ -101,19 +101,19 @@ ok "an unheld port binds and a held one does not"
 ## the port handed back is the one drawn on a socket of that protocol
 port=$(spied tcp) || fail "freeport tcp failed"
 bindable tcp "$port" || fail "the tcp port $port does not bind as tcp"
-drew SOCK_STREAM "$port" || fail "freeport tcp drew $port elsewhere: $(cat "$typelog")"
+drew SOCK_STREAM "$port" || fail "freeport tcp drew $port elsewhere: $(<"$typelog")"
 ! grep -q SOCK_DGRAM "$typelog" || fail "freeport tcp opened a udp socket"
 
 port=$(spied udp) || fail "freeport udp failed"
 bindable udp "$port" || fail "the udp port $port does not bind as udp"
-drew SOCK_DGRAM "$port" || fail "freeport udp drew $port elsewhere: $(cat "$typelog")"
+drew SOCK_DGRAM "$port" || fail "freeport udp drew $port elsewhere: $(<"$typelog")"
 ! grep -q SOCK_STREAM "$typelog" || fail "freeport udp opened a tcp socket"
 ok "each protocol is probed in its own"
 
 ## a mixed pair, the shape start_proxytrack asks for, in that order
 read -r tcpport udpport <<<"$(spied tcp udp)"
-drew SOCK_STREAM "$tcpport" || fail "the first port is not the tcp one: $(cat "$typelog")"
-drew SOCK_DGRAM "$udpport" || fail "the second port is not the udp one: $(cat "$typelog")"
+drew SOCK_STREAM "$tcpport" || fail "the first port is not the tcp one: $(<"$typelog")"
+drew SOCK_DGRAM "$udpport" || fail "the second port is not the udp one: $(<"$typelog")"
 bindable tcp "$tcpport" || fail "the tcp port $tcpport does not bind as tcp"
 bindable udp "$udpport" || fail "the udp port $udpport does not bind as udp"
 ok "a tcp/udp pair comes back in the order start_proxytrack reads"
@@ -142,10 +142,10 @@ command -v proxytrack >/dev/null || skip "no proxytrack in PATH"
 proxytrack_fails() { # proxytrack_fails HTTP_ADDR ICP_ADDR: echoes its error line
     local log="$tmpdir/pt.log" rc=0
     run_with_timeout 20 proxytrack "$1" "$2" >"$log" 2>&1 || rc=$?
-    test "$rc" -ne 124 || fail "proxytrack never exited on $1 $2: $(cat "$log")"
-    test "$rc" -ne 0 || fail "proxytrack started on $1 $2: $(cat "$log")"
+    test "$rc" -ne 124 || fail "proxytrack never exited on $1 $2: $(<"$log")"
+    test "$rc" -ne 0 || fail "proxytrack started on $1 $2: $(<"$log")"
     grep '^Unable to initialize a temporary server' "$log" ||
-        fail "proxytrack failed without the harness's banner: $(cat "$log")"
+        fail "proxytrack failed without the harness's banner: $(<"$log")"
 }
 
 # Both destinations get one, or the message could name one protocol for either

--- a/tests/276_testlib-freeport.test
+++ b/tests/276_testlib-freeport.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 real_python=$(find_python) || skip "python3 missing"
 python=$real_python # freeport reads it from here

--- a/tests/276_testlib-freeport.test
+++ b/tests/276_testlib-freeport.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 real_python=$(find_python) || skip "python3 missing"
 python=$real_python # freeport reads it from here

--- a/tests/277_html-target-and-print.test
+++ b/tests/277_html-target-and-print.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 htmldir="${srcdir}/html"

--- a/tests/277_html-target-and-print.test
+++ b/tests/277_html-target-and-print.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 htmldir="${srcdir}/html"

--- a/tests/278_install-headers-msvc.test
+++ b/tests/278_install-headers-msvc.test
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 top=${abs_top_srcdir:-$(cd "$testdir/.." && pwd)}
 sweep="$testdir/install-headers-sweep.sh"

--- a/tests/278_install-headers-msvc.test
+++ b/tests/278_install-headers-msvc.test
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 top=${abs_top_srcdir:-$(cd "$testdir/.." && pwd)}
 sweep="$testdir/install-headers-sweep.sh"

--- a/tests/279_doc-guide-image-sizes.test
+++ b/tests/279_doc-guide-image-sizes.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 checker="${testdir}/guide-image-check.py"

--- a/tests/279_doc-guide-image-sizes.test
+++ b/tests/279_doc-guide-image-sizes.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 checker="${testdir}/guide-image-check.py"

--- a/tests/281_argv-overflow.test
+++ b/tests/281_argv-overflow.test
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 bin=$(httrack_path)
 

--- a/tests/281_argv-overflow.test
+++ b/tests/281_argv-overflow.test
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 bin=$(httrack_path)
 

--- a/tests/282_option-flag-values.test
+++ b/tests/282_option-flag-values.test
@@ -54,7 +54,7 @@ refused() { # refused WANTED-MESSAGE ARG...
     crawl "$@"
     { test "${RC}" -ne 0 && test "${RC}" -ne 134; } || fail "$* not refused (exit ${RC})"
     grep -q "${want}" "${tmp}/out/.log" ||
-        fail "$* refused without saying why: $(cat "${tmp}/out/.log")"
+        fail "$* refused without saying why: $(<"${tmp}/out/.log")"
 }
 
 refused 'does not take the value' --index=2

--- a/tests/283_engine-cmdline-leak.test
+++ b/tests/283_engine-cmdline-leak.test
@@ -8,7 +8,7 @@
 set -eu
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 probe=$(ASAN_OPTIONS=help=1 httrack -O /dev/null --version 2>&1 || true)
 case "$probe" in

--- a/tests/283_engine-cmdline-leak.test
+++ b/tests/283_engine-cmdline-leak.test
@@ -8,7 +8,7 @@
 set -eu
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 probe=$(ASAN_OPTIONS=help=1 httrack -O /dev/null --version 2>&1 || true)
 case "$probe" in

--- a/tests/284_cli-resume-prompt.test
+++ b/tests/284_cli-resume-prompt.test
@@ -8,8 +8,8 @@
 set -eu
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
-ttyrun=$(nativepath "$(dirname "$0")/ttyrun.py")
+. "${0%"${0##*/}"}testlib.sh"
+ttyrun=$(nativepath "${0%"${0##*/}"}ttyrun.py")
 
 skip_on_windows "no pty on Windows"
 python=$(find_python) || skip "python3 not found"

--- a/tests/284_cli-resume-prompt.test
+++ b/tests/284_cli-resume-prompt.test
@@ -8,8 +8,8 @@
 set -eu
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
-ttyrun=$(nativepath "${0%"${0##*/}"}ttyrun.py")
+. "${0%"${0##*/}"}./testlib.sh"
+ttyrun=$(nativepath "${0%"${0##*/}"}./ttyrun.py")
 
 skip_on_windows "no pty on Windows"
 python=$(find_python) || skip "python3 not found"

--- a/tests/285_engine-arena.test
+++ b/tests/285_engine-arena.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # htsarena.h, the pool the link records and the rebuilt command line hold raw
 # pointers into (driven by 'httrack -#test=arena'). It keeps every address it

--- a/tests/285_engine-arena.test
+++ b/tests/285_engine-arena.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # htsarena.h, the pool the link records and the rebuilt command line hold raw
 # pointers into (driven by 'httrack -#test=arena'). It keeps every address it

--- a/tests/286_ci-windows-pool.test
+++ b/tests/286_ci-windows-pool.test
@@ -78,7 +78,7 @@ run_suite() { # run_suite <dir> <jobs>
     ) >"$tmp/out" 2>&1 || rc=$?
     spent=$((SECONDS - began))
     test "$rc" -eq 1 ||
-        fail "the stub suite exited $rc, want 1 from the pass floor: $(cat "$tmp/out")"
+        fail "the stub suite exited $rc, want 1 from the pass floor: $(<"$tmp/out")"
 }
 
 assert_tally() {

--- a/tests/286_ci-windows-pool.test
+++ b/tests/286_ci-windows-pool.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # Before the driver is sourced: with these set, anything it starts posts a commit
 # status on whatever the surrounding shell was last looking at.

--- a/tests/286_ci-windows-pool.test
+++ b/tests/286_ci-windows-pool.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Before the driver is sourced: with these set, anything it starts posts a commit
 # status on whatever the surrounding shell was last looking at.

--- a/tests/287_webhttrack-footer-year.test
+++ b/tests/287_webhttrack-footer-year.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 distdir=${HTS_DISTDIR}

--- a/tests/287_webhttrack-footer-year.test
+++ b/tests/287_webhttrack-footer-year.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 distdir=${HTS_DISTDIR}

--- a/tests/288_testlib-holdport.test
+++ b/tests/288_testlib-holdport.test
@@ -9,9 +9,9 @@ set -euo pipefail
 
 # crawllib, for the listening server the dial probe is controlled against.
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 real_python=$(find_python) || skip "python3 missing"
 python=$real_python # hold_port reads it from here

--- a/tests/288_testlib-holdport.test
+++ b/tests/288_testlib-holdport.test
@@ -100,6 +100,6 @@ cleanup_push cat "$tmpdir/retry.err"
 htsserver_start --log "$tmpdir/hts.log" 2>"$tmpdir/retry.err"
 test ! -f "$tmpdir/steal" || fail "htsserver_start never drew the stolen port"
 test "$HTS_PORT" != "$taken" || fail "htsserver_start served the taken port"
-assert_match "did not get port $taken, retrying" "$(cat "$tmpdir/retry.err")" "the retry notice"
+assert_match "did not get port $taken, retrying" "$(<"$tmpdir/retry.err")" "the retry notice"
 htsserver_cleanup
 ok "a stolen draw is redrawn, loudly, and the server comes up on port $HTS_PORT"

--- a/tests/288_testlib-holdport.test
+++ b/tests/288_testlib-holdport.test
@@ -9,9 +9,9 @@ set -euo pipefail
 
 # crawllib, for the listening server the dial probe is controlled against.
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 real_python=$(find_python) || skip "python3 missing"
 python=$real_python # hold_port reads it from here

--- a/tests/289_webhttrack-lifetime.test
+++ b/tests/289_webhttrack-lifetime.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/289_webhttrack-lifetime.test
+++ b/tests/289_webhttrack-lifetime.test
@@ -221,7 +221,7 @@ kill -0 "${crawl_pid}" 2>/dev/null ||
     fail "the crawling server quit, taking its mirror with it"
 # A crawl that never started would leave the veto unexercised, and the survival
 # above would prove nothing.
-test -d "${work}/crawl/hts-cache" || fail "no mirror ever started: $(cat "${clog}")"
+test -d "${work}/crawl/hts-cache" || fail "no mirror ever started: $(<"${clog}")"
 
 died_within "${crawl_pid}" $((timeout * 3)) ||
     fail "the server never left once its mirror had finished"
@@ -236,7 +236,7 @@ test "${#sid}" -eq 32 || fail "no session id to quit with"
     --path /server/exit.html --field "sid=${sid}" --field command=quit >/dev/null
 died_within "${quit_pid}" "${grace}" || fail "Quit did not stop the server"
 ! grep -q 'Unable to create the server' "${HTS_LOG}" ||
-    fail "a clean quit reported a server it could not create: $(cat "${HTS_LOG}")"
+    fail "a clean quit reported a server it could not create: $(<"${HTS_LOG}")"
 
 htsserver_stop
 htsserver_assert_reaped

--- a/tests/289_webhttrack-lifetime.test
+++ b/tests/289_webhttrack-lifetime.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/28_local-pause.test
+++ b/tests/28_local-pause.test
@@ -8,7 +8,7 @@
 set -e
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # python3 runs the local server (mirror local-crawl.sh); skip when absent, else
 # run() swallows its exit-77 and the serverless 0s/0s crawl looks like a fail.

--- a/tests/28_local-pause.test
+++ b/tests/28_local-pause.test
@@ -8,7 +8,7 @@
 set -e
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # python3 runs the local server (mirror local-crawl.sh); skip when absent, else
 # run() swallows its exit-77 and the serverless 0s/0s crawl looks like a fail.

--- a/tests/291_webhttrack-footer-default.test
+++ b/tests/291_webhttrack-footer-default.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/291_webhttrack-footer-default.test
+++ b/tests/291_webhttrack-footer-default.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/292_engine-wizard-scope.test
+++ b/tests/292_engine-wizard-scope.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # #1117: the self-test asserts the scopes and the patterns; this feeds the pair
 # a scope answer emits back through the matcher that authorizes a link.

--- a/tests/292_engine-wizard-scope.test
+++ b/tests/292_engine-wizard-scope.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # #1117: the self-test asserts the scopes and the patterns; this feeds the pair
 # a scope answer emits back through the matcher that authorizes a link.

--- a/tests/293_engine-wizard-verdict.test
+++ b/tests/293_engine-wizard-verdict.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # The verdict half of a wizard answer, driven without the interactive callback.
 # Both start from the undecided verdict the question is asked in.

--- a/tests/293_engine-wizard-verdict.test
+++ b/tests/293_engine-wizard-verdict.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # The verdict half of a wizard answer, driven without the interactive callback.
 # Both start from the undecided verdict the question is asked in.

--- a/tests/294_local-wizard-eof.test
+++ b/tests/294_local-wizard-eof.test
@@ -3,7 +3,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_1247.XXXXXX") || exit 1
 cleanup() {

--- a/tests/294_local-wizard-eof.test
+++ b/tests/294_local-wizard-eof.test
@@ -3,7 +3,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_1247.XXXXXX") || exit 1
 cleanup() {

--- a/tests/295_wizard-log.test
+++ b/tests/295_wizard-log.test
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 bin=$(httrack_path)
 

--- a/tests/295_wizard-log.test
+++ b/tests/295_wizard-log.test
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 bin=$(httrack_path)
 

--- a/tests/296_local-wizard-delayed.test
+++ b/tests/296_local-wizard-delayed.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 # "mirror this link"
 WIZARD_MIRROR=5

--- a/tests/296_local-wizard-delayed.test
+++ b/tests/296_local-wizard-delayed.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 # "mirror this link"
 WIZARD_MIRROR=5

--- a/tests/297_engine-wizard-precedence.test
+++ b/tests/297_engine-wizard-precedence.test
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # answering "ignore this link" and then "mirror the whole host" takes it back
 list=$(httrack -O /dev/null -#test=wizardinsert h /dir/one.html 0 6)

--- a/tests/297_engine-wizard-precedence.test
+++ b/tests/297_engine-wizard-precedence.test
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # answering "ignore this link" and then "mirror the whole host" takes it back
 list=$(httrack -O /dev/null -#test=wizardinsert h /dir/one.html 0 6)

--- a/tests/298_engine-wizard-fallback.test
+++ b/tests/298_engine-wizard-fallback.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # #1251: an answer the engine cannot honour as asked must still record a rule
 # and say so, or it decides one link and the next one asks all over again.

--- a/tests/298_engine-wizard-fallback.test
+++ b/tests/298_engine-wizard-fallback.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # #1251: an answer the engine cannot honour as asked must still record a rule
 # and say so, or it decides one link and the next one asks all over again.

--- a/tests/299_option-arg-caps.test
+++ b/tests/299_option-arg-caps.test
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 bin=$(httrack_path)
 

--- a/tests/299_option-arg-caps.test
+++ b/tests/299_option-arg-caps.test
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 bin=$(httrack_path)
 

--- a/tests/300_engine-wizard-filter-size.test
+++ b/tests/300_engine-wizard-filter-size.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # #1264/#1266: the pattern is cut from the link the question is about, so a long
 # enough one used to outgrow the filter slot. It must neither abort the run nor

--- a/tests/300_engine-wizard-filter-size.test
+++ b/tests/300_engine-wizard-filter-size.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # #1264/#1266: the pattern is cut from the link the question is about, so a long
 # enough one used to outgrow the filter slot. It must neither abort the run nor

--- a/tests/301_engine-savename-bounds.test
+++ b/tests/301_engine-savename-bounds.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # url_savename_addstr() appends a crawled link to afs->save; with no size cap it
 # wrote past the buffer (#1269).

--- a/tests/301_engine-savename-bounds.test
+++ b/tests/301_engine-savename-bounds.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # url_savename_addstr() appends a crawled link to afs->save; with no size cap it
 # wrote past the buffer (#1269).

--- a/tests/302_filter-token-overflow.test
+++ b/tests/302_filter-token-overflow.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 # A filter or a URL longer than the buffer it is copied into must be named and
 # dropped, never truncated into a rule that authorizes something else (#1271).

--- a/tests/302_filter-token-overflow.test
+++ b/tests/302_filter-token-overflow.test
@@ -51,7 +51,7 @@ for over in 1 512; do
     assert_eq "http://www.example.com/a.png: accepted by rule #1 (+*.png)" \
         "$(why "$tmpdir/over.txt")" "filter of $((maxfilter + over)) bytes"
     assert_match "Filter rule longer than $maxfilter bytes, ignored: -aaa" \
-        "$(cat "$tmpdir/p/hts-log.txt")" "refusal named in the log"
+        "$(<"$tmpdir/p/hts-log.txt")" "refusal named in the log"
 done
 
 # Every seed costs "http://" and a newline on top of its own bytes, so the list
@@ -70,7 +70,7 @@ printf 'http://www.example.com/%s\n+*.png\n' "$(rep a $((maxurl - 22)))" \
 assert_eq "http://www.example.com/a.png: accepted by rule #1 (+*.png)" \
     "$(why "$tmpdir/longurl.txt")" "URL of $((maxurl + 1)) bytes"
 assert_match "URL longer than $maxurl bytes, ignored: http://www.example.com/aaa" \
-    "$(cat "$tmpdir/p/hts-log.txt")" "refusal named in the log"
+    "$(<"$tmpdir/p/hts-log.txt")" "refusal named in the log"
 
 # That line is written before the seed is dropped, so it cannot tell a refusal
 # from a truncation. Crawl for real and count what the refusal cost: a seed the
@@ -90,7 +90,7 @@ local_crawl --log "$tmpdir/crawl.log" -O "$tmpdir/m" --quiet --robots=0 \
     --retries=0 -%S "$tmpdir/seed.txt" "$BASEURL/index.html" ||
     fail "crawl exited $?"
 assert_file "$tmpdir/m/127.0.0.1_$SRV_PORT/index.html" "the seed that fits"
-log="$(cat "$tmpdir/m/hts-log.txt")"
+log="$(<"$tmpdir/m/hts-log.txt")"
 assert_match "URL longer than $maxurl bytes, ignored: $BASEURL/aaa" "$log" \
     "refusal named in the log"
 assert_eq 1 "$(grep -cE 'Warning:|Error:' <<<"$log")" \

--- a/tests/302_filter-token-overflow.test
+++ b/tests/302_filter-token-overflow.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 # A filter or a URL longer than the buffer it is copied into must be named and
 # dropped, never truncated into a rule that authorizes something else (#1271).

--- a/tests/303_engine-filter-cap.test
+++ b/tests/303_engine-filter-cap.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 out=$(httrack -O /dev/null -#test=filtercap)
 

--- a/tests/303_engine-filter-cap.test
+++ b/tests/303_engine-filter-cap.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 out=$(httrack -O /dev/null -#test=filtercap)
 

--- a/tests/305_doc-footer-fields.test
+++ b/tests/305_doc-footer-fields.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 

--- a/tests/305_doc-footer-fields.test
+++ b/tests/305_doc-footer-fields.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 srcdir="${abs_top_srcdir:?not run under make check}"
 

--- a/tests/306_assume-mime-bounds.test
+++ b/tests/306_assume-mime-bounds.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 for capacity in 128 256 1024; do
     assert_selftest "assumemime ok" assumemime "$capacity"

--- a/tests/306_assume-mime-bounds.test
+++ b/tests/306_assume-mime-bounds.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 for capacity in 128 256 1024; do
     assert_selftest "assumemime ok" assumemime "$capacity"

--- a/tests/307_cookies-file-longfield.test
+++ b/tests/307_cookies-file-longfield.test
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 bin=$(httrack_path)
 

--- a/tests/307_cookies-file-longfield.test
+++ b/tests/307_cookies-file-longfield.test
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 bin=$(httrack_path)
 

--- a/tests/308_zlib-cache-savebounds.test
+++ b/tests/308_zlib-cache-savebounds.test
@@ -5,7 +5,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/308_zlib-cache-savebounds.test
+++ b/tests/308_zlib-cache-savebounds.test
@@ -5,7 +5,7 @@
 
 set -eu
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/309_local-robots-rule-cap.test
+++ b/tests/309_local-robots-rule-cap.test
@@ -5,7 +5,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_1286.XXXXXX") || exit 1
 cleanup() {

--- a/tests/309_local-robots-rule-cap.test
+++ b/tests/309_local-robots-rule-cap.test
@@ -5,7 +5,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_1286.XXXXXX") || exit 1
 cleanup() {

--- a/tests/310_filelist-long-url.test
+++ b/tests/310_filelist-long-url.test
@@ -43,7 +43,7 @@ run() { # run LIST -> sets $log and $mirror
     rm -rf "$out"
     mkdir -p "$out"
     httrack -O "$out" --quiet -n "-%L" "$list" >"$out/.stdout" 2>&1 ||
-        fail "httrack failed on $list: $(cat "$out/.stdout")"
+        fail "httrack failed on $list: $(<"$out/.stdout")"
     log="$out/hts-log.txt"
     mirror="$out"
 }

--- a/tests/310_filelist-long-url.test
+++ b/tests/310_filelist-long-url.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 limit=1024 # HTS_URLMAXSIZE: the longest line -%L accepts
 

--- a/tests/310_filelist-long-url.test
+++ b/tests/310_filelist-long-url.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 limit=1024 # HTS_URLMAXSIZE: the longest line -%L accepts
 

--- a/tests/311_engine-location-gate.test
+++ b/tests/311_engine-location-gate.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # The Location gate must equal htsblk.location's buffer (HTS_LOCATION_SIZE,
 # 2048). Each case reports the length asked, the length kept, whether the value

--- a/tests/311_engine-location-gate.test
+++ b/tests/311_engine-location-gate.test
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # The Location gate must equal htsblk.location's buffer (HTS_LOCATION_SIZE,
 # 2048). Each case reports the length asked, the length kept, whether the value

--- a/tests/313_ci-fork-failures.test
+++ b/tests/313_ci-fork-failures.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # Before the driver is sourced: with these set, anything it starts posts a commit
 # status on whatever the surrounding shell was last looking at.
@@ -22,9 +22,8 @@ GITHUB_STEP_SUMMARY=$tmp/summary
 export GITHUB_STEP_SUMMARY
 : >"$GITHUB_STEP_SUMMARY"
 
-# The lines as the runtime and bash write them, from the run in #1273. A retry
-# and a give-up differ only by the "retry:" the retry carries, so a counter that
-# matched the message alone would report every retry as a command that never ran.
+# Real lines from the #1273 run, not invented. A retry and a give-up differ only
+# by the "retry:", so matching the message alone would count every retry as one.
 cat >"$tmp/console.log" <<'EOF'
 PASS 244_local-tty-output.test
 1 [main] bash 1728 dofork: child -1 - forked process 3984 died unexpectedly, retry 0, exit code 0xC0000142, errno 11
@@ -35,15 +34,46 @@ PASS 244_local-tty-output.test
 ran=257 pass=234 fail=0 skip=23
 EOF
 
-rc=0
-out=$(ci_report_fork_failures "$tmp/console.log") || rc=$?
-test "$rc" -eq 0 || fail "counting a struggling leg exited $rc"
-grep -q '::warning title=MSYS fork failures::' <<<"$out" ||
-    fail "fork failures raised no annotation: $out"
-grep -q '2 child(ren) died at DLL init, 2 retry wait(s), 1 fork(s) given up' <<<"$out" ||
-    fail "wrong counts: $out"
-grep -q 'MSYS forks: 2 died, 2 retried, 1 given up' "$GITHUB_STEP_SUMMARY" ||
-    fail "the step summary lost the count: $(<"$GITHUB_STEP_SUMMARY")"
+# Every leg asserts the annotation as well as the summary: a counter that tallies
+# right and annotates nothing leaves the step as silent as the one this replaces.
+assert_counts() { # assert_counts LOG WANT-DIED WANT-RETRIED WANT-GAVEUP LABEL
+    local log=$1 want="$2 child(ren) died at DLL init, $3 retry wait(s), $4 fork(s) given up"
+    local label=$5 out rc=0
+    : >"$GITHUB_STEP_SUMMARY"
+    out=$(ci_report_fork_failures "$log") || rc=$?
+    test "$rc" -eq 0 || fail "$label: exited $rc"
+    grep -q '::warning title=MSYS fork failures::' <<<"$out" ||
+        fail "$label: no annotation: $out"
+    grep -q "$want" <<<"$out" || fail "$label: wanted [$want], got: $out"
+    grep -q "MSYS forks: $2 died, $3 retried, $4 given up" "$GITHUB_STEP_SUMMARY" ||
+        fail "$label: step summary says $(<"$GITHUB_STEP_SUMMARY")"
+}
+
+assert_counts "$tmp/console.log" 2 2 1 "the #1273 leg"
+
+# A retry storm that never gave up is the shape the issue reports, so a gate that
+# only fires on a give-up would call this leg healthy.
+cat >"$tmp/retries.log" <<'EOF'
+1 [main] bash 1728 dofork: child -1 - forked process 3984 died unexpectedly, retry 0, exit code 0xC0000142, errno 11
+./ci-windows-suite.sh: fork: retry: Resource temporarily unavailable
+EOF
+assert_counts "$tmp/retries.log" 1 1 0 "retries with no give-up"
+
+# bash retries on EAGAIN alone, so any other strerror arrives as a give-up with no
+# retry before it; the cygwin spellings carry no "do" and no errno at all.
+cat >"$tmp/variants.log" <<'EOF'
+./x.test: fork: Cannot allocate memory
+2 [main] sh 900 fork: child -1 - forked process 12 died unexpectedly, retry 0, exit code 0xC0000142, errno 11
+3 [main] sh 900 child_info_fork::abort: address space needed by cygz.dll is already occupied
+EOF
+assert_counts "$tmp/variants.log" 2 0 1 "the non-EAGAIN and cygwin spellings"
+
+# Two messages on one physical line: the console is stdout and stderr merged, and
+# a bare line count would report one. The decoy pins the marker, not "errno 11",
+# which the engine's own diagnostics also carry.
+printf 'PASS 1.test\r1 [main] bash 1 dofork: child -1 - forked process 2 died unexpectedly, errno 11\r2 [main] bash 1 dofork: child -1 - forked process 3 died unexpectedly, errno 11\nrmdir failed, errno 11\n' \
+    >"$tmp/crjoined.log"
+assert_counts "$tmp/crjoined.log" 2 0 0 "two messages joined by a CR"
 
 # A healthy leg still says so: a silent step and a broken counter read alike.
 : >"$GITHUB_STEP_SUMMARY"
@@ -54,7 +84,7 @@ grep -q 'no MSYS fork failure' <<<"$out" || fail "a clean leg said: $out"
 grep -q 'MSYS forks: 0 died, 0 retried, 0 given up' "$GITHUB_STEP_SUMMARY" ||
     fail "a clean leg wrote no count: $(<"$GITHUB_STEP_SUMMARY")"
 
-# The suite step can die before writing one, and the counter runs if:always().
+# The suite step can die before writing a log; the counter step still runs.
 out=$(ci_report_fork_failures "$tmp/absent.log") || fail "a missing log failed the step"
 grep -q 'not counted' <<<"$out" || fail "a missing log said: $out"
 

--- a/tests/313_ci-fork-failures.test
+++ b/tests/313_ci-fork-failures.test
@@ -36,7 +36,7 @@ EOF
 
 # Every leg asserts the annotation as well as the summary: a counter that tallies
 # right and annotates nothing leaves the step as silent as the one this replaces.
-assert_counts() { # assert_counts LOG WANT-DIED WANT-RETRIED WANT-GAVEUP LABEL
+assert_counts() { # assert_counts LOG WANT-DIED WANT-RETRIED WANT-GAVEUP LABEL SAMPLE-RE
     local log=$1 want="$2 child(ren) died at DLL init, $3 retry wait(s), $4 fork(s) given up"
     local label=$5 out rc=0
     : >"$GITHUB_STEP_SUMMARY"
@@ -45,11 +45,14 @@ assert_counts() { # assert_counts LOG WANT-DIED WANT-RETRIED WANT-GAVEUP LABEL
     grep -q '::warning title=MSYS fork failures::' <<<"$out" ||
         fail "$label: no annotation: $out"
     grep -q "$want" <<<"$out" || fail "$label: wanted [$want], got: $out"
+    # The counts alone name no test and no time: an annotation without an example
+    # line sends the reader back to a log the runner may no longer have.
+    grep -q "$6" <<<"$out" || fail "$label: no sample line matching [$6]: $out"
     grep -q "MSYS forks: $2 died, $3 retried, $4 given up" "$GITHUB_STEP_SUMMARY" ||
         fail "$label: step summary says $(<"$GITHUB_STEP_SUMMARY")"
 }
 
-assert_counts "$tmp/console.log" 2 2 1 "the #1273 leg"
+assert_counts "$tmp/console.log" 2 2 1 "the #1273 leg" "forked process 3984"
 
 # A retry storm that never gave up is the shape the issue reports, so a gate that
 # only fires on a give-up would call this leg healthy.
@@ -57,7 +60,12 @@ cat >"$tmp/retries.log" <<'EOF'
 1 [main] bash 1728 dofork: child -1 - forked process 3984 died unexpectedly, retry 0, exit code 0xC0000142, errno 11
 ./ci-windows-suite.sh: fork: retry: Resource temporarily unavailable
 EOF
-assert_counts "$tmp/retries.log" 1 1 0 "retries with no give-up"
+assert_counts "$tmp/retries.log" 1 1 0 "retries with no give-up" "forked process 3984"
+
+# Only retries, so a gate reading the other two counters calls this leg healthy.
+printf './x.test: fork: retry: Resource temporarily unavailable\n%s\n' \
+    './x.test: fork: retry: Resource temporarily unavailable' >"$tmp/retryonly.log"
+assert_counts "$tmp/retryonly.log" 0 2 0 "retries alone" "fork: retry:"
 
 # bash retries on EAGAIN alone, so any other strerror arrives as a give-up with no
 # retry before it; the cygwin spellings carry no "do" and no errno at all.
@@ -65,15 +73,17 @@ cat >"$tmp/variants.log" <<'EOF'
 ./x.test: fork: Cannot allocate memory
 2 [main] sh 900 fork: child -1 - forked process 12 died unexpectedly, retry 0, exit code 0xC0000142, errno 11
 3 [main] sh 900 child_info_fork::abort: address space needed by cygz.dll is already occupied
+4 [main] sh 900 sync_with_child: child 901 died before initialization with status code 0x1
+5 [main] sh 900 fork: can not reserve memory for parent stack
 EOF
-assert_counts "$tmp/variants.log" 2 0 1 "the non-EAGAIN and cygwin spellings"
+assert_counts "$tmp/variants.log" 4 0 1 "the non-EAGAIN and cygwin spellings" "Cannot allocate memory"
 
 # Two messages on one physical line: the console is stdout and stderr merged, and
-# a bare line count would report one. The decoy pins the marker, not "errno 11",
-# which the engine's own diagnostics also carry.
-printf 'PASS 1.test\r1 [main] bash 1 dofork: child -1 - forked process 2 died unexpectedly, errno 11\r2 [main] bash 1 dofork: child -1 - forked process 3 died unexpectedly, errno 11\nrmdir failed, errno 11\n' \
+# a bare line count would report one. The two decoys pin the whole marker: the
+# engine's own diagnostics carry "errno 11" and "child -1" too.
+printf 'PASS 1.test\r1 [main] bash 1 dofork: child -1 - forked process 2 died unexpectedly, errno 11\r2 [main] bash 1 dofork: child -1 - forked process 3 died unexpectedly, errno 11\nrmdir failed, errno 11\nengine: child -1 has no slot left\n' \
     >"$tmp/crjoined.log"
-assert_counts "$tmp/crjoined.log" 2 0 0 "two messages joined by a CR"
+assert_counts "$tmp/crjoined.log" 2 0 0 "two messages joined by a CR" "forked process 2"
 
 # A healthy leg still says so: a silent step and a broken counter read alike.
 : >"$GITHUB_STEP_SUMMARY"

--- a/tests/313_ci-fork-failures.test
+++ b/tests/313_ci-fork-failures.test
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# ci-windows-suite.sh's MSYS fork-failure counter (#1273). It only ever runs on
+# the Windows leg, where a miscount is invisible: the lines it counts exist
+# nowhere but that console log.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}testlib.sh"
+
+# Before the driver is sourced: with these set, anything it starts posts a commit
+# status on whatever the surrounding shell was last looking at.
+unset WATCHDOG_TOKEN WATCHDOG_REPO WATCHDOG_SHA WATCHDOG_URL
+# shellcheck source=tests/ci-windows-suite.sh
+. "$testdir/ci-windows-suite.sh"
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_forkcount.XXXXXX")
+cleanup_push rm -rf "$tmp"
+
+GITHUB_STEP_SUMMARY=$tmp/summary
+export GITHUB_STEP_SUMMARY
+: >"$GITHUB_STEP_SUMMARY"
+
+# The lines as the runtime and bash write them, from the run in #1273. A retry
+# and a give-up differ only by the "retry:" the retry carries, so a counter that
+# matched the message alone would report every retry as a command that never ran.
+cat >"$tmp/console.log" <<'EOF'
+PASS 244_local-tty-output.test
+1 [main] bash 1728 dofork: child -1 - forked process 3984 died unexpectedly, retry 0, exit code 0xC0000142, errno 11
+./ci-windows-suite.sh: fork: retry: Resource temporarily unavailable
+1000626 [main] bash 1728 dofork: child -1 - forked process 6308 died unexpectedly, retry 0, exit code 0xC0000142, errno 11
+./ci-windows-suite.sh: fork: retry: Resource temporarily unavailable
+./ci-windows-suite.sh: fork: Resource temporarily unavailable
+ran=257 pass=234 fail=0 skip=23
+EOF
+
+rc=0
+out=$(ci_report_fork_failures "$tmp/console.log") || rc=$?
+test "$rc" -eq 0 || fail "counting a struggling leg exited $rc"
+grep -q '::warning title=MSYS fork failures::' <<<"$out" ||
+    fail "fork failures raised no annotation: $out"
+grep -q '2 child(ren) died at DLL init, 2 retry wait(s), 1 fork(s) given up' <<<"$out" ||
+    fail "wrong counts: $out"
+grep -q 'MSYS forks: 2 died, 2 retried, 1 given up' "$GITHUB_STEP_SUMMARY" ||
+    fail "the step summary lost the count: $(<"$GITHUB_STEP_SUMMARY")"
+
+# A healthy leg still says so: a silent step and a broken counter read alike.
+: >"$GITHUB_STEP_SUMMARY"
+grep -v 'fork' "$tmp/console.log" >"$tmp/clean.log"
+out=$(ci_report_fork_failures "$tmp/clean.log") || fail "counting a clean leg failed"
+grep -q 'no MSYS fork failure' <<<"$out" || fail "a clean leg said: $out"
+! grep -q '::warning' <<<"$out" || fail "a clean leg raised an annotation: $out"
+grep -q 'MSYS forks: 0 died, 0 retried, 0 given up' "$GITHUB_STEP_SUMMARY" ||
+    fail "a clean leg wrote no count: $(<"$GITHUB_STEP_SUMMARY")"
+
+# The suite step can die before writing one, and the counter runs if:always().
+out=$(ci_report_fork_failures "$tmp/absent.log") || fail "a missing log failed the step"
+grep -q 'not counted' <<<"$out" || fail "a missing log said: $out"
+
+echo "MSYS fork-failure counting OK"

--- a/tests/40_local-why.test
+++ b/tests/40_local-why.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # --why: report which +/- filter rule decides for a URL, without crawling.
 

--- a/tests/40_local-why.test
+++ b/tests/40_local-why.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # --why: report which +/- filter rule decides for a URL, without crawling.
 

--- a/tests/46_local-update-304-resume.test
+++ b/tests/46_local-update-304-resume.test
@@ -6,7 +6,7 @@
 set -u
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 root=$(nativepath "${testdir}/server-root")
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_c7.XXXXXX") || exit 1

--- a/tests/46_local-update-304-resume.test
+++ b/tests/46_local-update-304-resume.test
@@ -6,7 +6,7 @@
 set -u
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 root=$(nativepath "${testdir}/server-root")
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_c7.XXXXXX") || exit 1

--- a/tests/47_local-crange-overflow.test
+++ b/tests/47_local-crange-overflow.test
@@ -7,7 +7,7 @@
 set -u
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_crange.XXXXXX") || exit 1
 crawlpid=

--- a/tests/47_local-crange-overflow.test
+++ b/tests/47_local-crange-overflow.test
@@ -7,7 +7,7 @@
 set -u
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_crange.XXXXXX") || exit 1
 crawlpid=

--- a/tests/48_local-crange-memresume.test
+++ b/tests/48_local-crange-memresume.test
@@ -7,7 +7,7 @@
 set -u
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 # The resume needs a graceful pass-1 interrupt to leave a temp-ref, and MSYS
 # cannot deliver a signal to a native exe.

--- a/tests/48_local-crange-memresume.test
+++ b/tests/48_local-crange-memresume.test
@@ -7,7 +7,7 @@
 set -u
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 # The resume needs a graceful pass-1 interrupt to leave a temp-ref, and MSYS
 # cannot deliver a signal to a native exe.

--- a/tests/52_local-socks5.test
+++ b/tests/52_local-socks5.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 if test "${HTTPS_SUPPORT:-}" == "no"; then
     echo "no https support compiled, skipping"

--- a/tests/52_local-socks5.test
+++ b/tests/52_local-socks5.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 if test "${HTTPS_SUPPORT:-}" == "no"; then
     echo "no https support compiled, skipping"

--- a/tests/53_local-proxytrack-arc-reason.test
+++ b/tests/53_local-proxytrack-arc-reason.test
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/53_local-proxytrack-arc-reason.test
+++ b/tests/53_local-proxytrack-arc-reason.test
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/53_local-proxytrack-cache-corrupt.test
+++ b/tests/53_local-proxytrack-cache-corrupt.test
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/53_local-proxytrack-cache-corrupt.test
+++ b/tests/53_local-proxytrack-cache-corrupt.test
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/56_local-proxy-noleak.test
+++ b/tests/56_local-proxy-noleak.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 if test "${V6_SUPPORT:-}" == "no"; then
     echo "no IPv6 support (resolver override compiled out), skipping"

--- a/tests/56_local-proxy-noleak.test
+++ b/tests/56_local-proxy-noleak.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 if test "${V6_SUPPORT:-}" == "no"; then
     echo "no IPv6 support (resolver override compiled out), skipping"

--- a/tests/56_local-proxy-noleak.test
+++ b/tests/56_local-proxy-noleak.test
@@ -33,7 +33,7 @@ local_server_start --env LOCAL_SERVER_VERBOSE=1 --root "$root" --bind 127.0.0.1
 # Not on macOS, which drops the SYN on a held port where Linux resets it, so the
 # crawl would time out instead of failing to connect and stop testing the bypass.
 # That leaves the #1218 race here on macOS alone, as it was everywhere before.
-if test "$(uname -s)" = Darwin; then
+if test "$HTS_OS" = Darwin; then
     deadproxy=$(freeport)
 else
     hold_port

--- a/tests/57_local-proxy-connect.test
+++ b/tests/57_local-proxy-connect.test
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || python=
 if test -z "$python"; then

--- a/tests/57_local-proxy-connect.test
+++ b/tests/57_local-proxy-connect.test
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || python=
 if test -z "$python"; then

--- a/tests/58_watchdog.test
+++ b/tests/58_watchdog.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_wd.XXXXXX")
 # A colon-free root for the PATH shim below: MSYS hands out a drive-letter TMPDIR

--- a/tests/58_watchdog.test
+++ b/tests/58_watchdog.test
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_wd.XXXXXX")
 # A colon-free root for the PATH shim below: MSYS hands out a drive-letter TMPDIR

--- a/tests/59_local-tls-stall.test
+++ b/tests/59_local-tls-stall.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 if test "${HTTPS_SUPPORT:-}" == "no"; then
     echo "no https support compiled, skipping"

--- a/tests/59_local-tls-stall.test
+++ b/tests/59_local-tls-stall.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 if test "${HTTPS_SUPPORT:-}" == "no"; then
     echo "no https support compiled, skipping"

--- a/tests/60_crawl-log-salvage.test
+++ b/tests/60_crawl-log-salvage.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/httrack_salv.XXXXXX")
 export TMPDIR

--- a/tests/60_crawl-log-salvage.test
+++ b/tests/60_crawl-log-salvage.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/httrack_salv.XXXXXX")
 export TMPDIR

--- a/tests/61_webhttrack-locale.test
+++ b/tests/61_webhttrack-locale.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 distdir=$(cd "${testdir}/.." && pwd)
 # The .in, not the generated script: only SRCHDISTPATH differs, and this stays in srcdir.

--- a/tests/61_webhttrack-locale.test
+++ b/tests/61_webhttrack-locale.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 distdir=$(cd "${testdir}/.." && pwd)
 # The .in, not the generated script: only SRCHDISTPATH differs, and this stays in srcdir.

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -8,7 +8,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 langdir="$top_srcdir/lang"
 def="$top_srcdir/lang.def"

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -86,7 +86,7 @@ charset_declared_matches_bytes() {
         return 1
     fi
     if ! LC_ALL=C iconv -f "$cs" -t UTF-8 "$f" >"$tmp/utf8" 2>"$tmp/err"; then
-        echo "${f##*/}: bytes do not decode as the declared $cs: $(cat "$tmp/err")"
+        echo "${f##*/}: bytes do not decode as the declared $cs: $(<"$tmp/err")"
         return 1
     fi
     # No legacy 8-bit charset puts text at U+0080..U+009F, so a C1 there means

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -8,7 +8,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 langdir="$top_srcdir/lang"
 def="$top_srcdir/lang.def"

--- a/tests/63_webhttrack-home.test
+++ b/tests/63_webhttrack-home.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/63_webhttrack-home.test
+++ b/tests/63_webhttrack-home.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/65_port-siblings.test
+++ b/tests/65_port-siblings.test
@@ -10,7 +10,7 @@ set -euo pipefail
 
 # run_with_timeout: timeout(1) is absent on macOS, and the listen servers block.
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_portsib.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmp"

--- a/tests/65_port-siblings.test
+++ b/tests/65_port-siblings.test
@@ -10,7 +10,7 @@ set -euo pipefail
 
 # run_with_timeout: timeout(1) is absent on macOS, and the listen servers block.
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_portsib.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmp"

--- a/tests/67_engine-delayed-truncate.test
+++ b/tests/67_engine-delayed-truncate.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # #623: url_savename shortens an over-ceiling path by cutting the tail of the
 # last segment, where the mandatory ".<id>.delayed" placeholder lives. A cut

--- a/tests/67_engine-delayed-truncate.test
+++ b/tests/67_engine-delayed-truncate.test
@@ -22,7 +22,7 @@ cd "$scratch"
 hexseg=$(printf 'a1b2c3d4e5f60718%.0s' {1..8}) # 128 hex chars
 
 # engine ceiling is the Windows MAX_PATH on Windows, the save buffer elsewhere
-case "$(uname -s 2>/dev/null)" in
+case "$HTS_OS" in
 MINGW* | MSYS* | CYGWIN*)
     ceil=236
     outdir=/dev/null

--- a/tests/67_engine-delayed-truncate.test
+++ b/tests/67_engine-delayed-truncate.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # #623: url_savename shortens an over-ceiling path by cutting the tail of the
 # last segment, where the mandatory ".<id>.delayed" placeholder lives. A cut

--- a/tests/68_webhttrack-outdir-charset.test
+++ b/tests/68_webhttrack-outdir-charset.test
@@ -11,7 +11,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/68_webhttrack-outdir-charset.test
+++ b/tests/68_webhttrack-outdir-charset.test
@@ -11,7 +11,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/71_local-crange-repaircache.test
+++ b/tests/71_local-crange-repaircache.test
@@ -8,7 +8,7 @@
 set -u
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 

--- a/tests/71_local-crange-repaircache.test
+++ b/tests/71_local-crange-repaircache.test
@@ -8,7 +8,7 @@
 set -u
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 

--- a/tests/75_engine-longpath-posix.test
+++ b/tests/75_engine-longpath-posix.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 # #133: the save-path ceiling used to be the Windows MAX_PATH (236 usable) on
 # every platform, needlessly hashing long names on Linux/macOS/Android. Off

--- a/tests/75_engine-longpath-posix.test
+++ b/tests/75_engine-longpath-posix.test
@@ -21,7 +21,7 @@ deep="/a/$(printf 'b%.0s' {1..100})/c/$(printf 'd%.0s' {1..100})"
 out="$("$httrack_bin" -O /dev/null -#test=savename "$deep/$seg.html" text/html |
     sed -n 's/^savename: //p')"
 
-case "$(uname -s 2>/dev/null)" in
+case "$HTS_OS" in
 MINGW* | MSYS* | CYGWIN*)
     # Windows still caps at MAX_PATH: the distinctive tail is cut
     case "$out" in

--- a/tests/75_engine-longpath-posix.test
+++ b/tests/75_engine-longpath-posix.test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 # #133: the save-path ceiling used to be the Windows MAX_PATH (236 usable) on
 # every platform, needlessly hashing long names on Linux/macOS/Android. Off

--- a/tests/76_cli-resize.test
+++ b/tests/76_cli-resize.test
@@ -4,7 +4,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 driver=$(nativepath "${testdir}/pty-resize.py")
 
 skip_on_windows "no pty on Windows"

--- a/tests/76_cli-resize.test
+++ b/tests/76_cli-resize.test
@@ -4,7 +4,7 @@
 set -eu
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 driver=$(nativepath "${testdir}/pty-resize.py")
 
 skip_on_windows "no pty on Windows"

--- a/tests/77_webhttrack-redirect.test
+++ b/tests/77_webhttrack-redirect.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/77_webhttrack-redirect.test
+++ b/tests/77_webhttrack-redirect.test
@@ -93,6 +93,6 @@ fi
 # were accepted the server would listen instead of exiting.
 run_with_timeout 15 htsserver "${HTS_DISTDIR}/" --bind "" >"${bindlog}" 2>&1 || true
 grep -q -- "--bind needs an address" "${bindlog}" ||
-    fail "empty --bind not refused: $(cat "${bindlog}")"
+    fail "empty --bind not refused: $(<"${bindlog}")"
 
 echo "PASS"

--- a/tests/77_webhttrack-redirect.test
+++ b/tests/77_webhttrack-redirect.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/78_webhttrack-sid.test
+++ b/tests/78_webhttrack-sid.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/78_webhttrack-sid.test
+++ b/tests/78_webhttrack-sid.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/79_local-proxytrack-webdav-mime.test
+++ b/tests/79_local-proxytrack-webdav-mime.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 missing"
 command -v curl >/dev/null 2>&1 || skip "curl missing"

--- a/tests/79_local-proxytrack-webdav-mime.test
+++ b/tests/79_local-proxytrack-webdav-mime.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 missing"
 command -v curl >/dev/null 2>&1 || skip "curl missing"

--- a/tests/80_engine-crash-symbolize.test
+++ b/tests/80_engine-crash-symbolize.test
@@ -4,7 +4,7 @@
 set -eu
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 skip_on_windows "no backtrace() on Windows"
 command -v httrack >/dev/null || {

--- a/tests/80_engine-crash-symbolize.test
+++ b/tests/80_engine-crash-symbolize.test
@@ -4,7 +4,7 @@
 set -eu
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 skip_on_windows "no backtrace() on Windows"
 command -v httrack >/dev/null || {

--- a/tests/81_webhttrack-maxsize.test
+++ b/tests/81_webhttrack-maxsize.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/81_webhttrack-maxsize.test
+++ b/tests/81_webhttrack-maxsize.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/83_webhttrack-argescape.test
+++ b/tests/83_webhttrack-argescape.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/83_webhttrack-argescape.test
+++ b/tests/83_webhttrack-argescape.test
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/84_webhttrack-mirror-verbatim.test
+++ b/tests/84_webhttrack-mirror-verbatim.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/84_webhttrack-mirror-verbatim.test
+++ b/tests/84_webhttrack-mirror-verbatim.test
@@ -44,7 +44,7 @@ htsserver_client --path /step4.html --field "sid=${sid}" --field command=httrack
     --field command_do=save --field winprofile=x \
     --field "path=${work}" --field projname=proj >/dev/null
 test -f "${work}/proj/hts-cache/winprofile.ini" ||
-    fail "profile save did not create the project: $(cat "${HTS_LOG}")"
+    fail "profile save did not create the project: $(<"${HTS_LOG}")"
 mkdir -p "$(dirname "${mirror}")"
 # shellcheck disable=SC2016 # the directives are the payload, not shell expansions
 printf 'Hostile mirrored page.\nsid=${_sid} copy=${sid}\ntrailing backslash: \\\n' \
@@ -61,7 +61,7 @@ grep -qF '${sid}' "${body}" || fail "\${sid} did not survive verbatim"
 cmp -s "${mirror}" "${body}" || fail "mirrored file not served byte for byte"
 # The mirror stays browsable: verbatim must not mean served as a download.
 grep -qi '^Content-type: text/html' "${hdr}" ||
-    fail "mirrored page lost its text/html type: $(cat "${hdr}")"
+    fail "mirrored page lost its text/html type: $(<"${hdr}")"
 
 # The other direction: while a crawl runs, every .html request is overridden to
 # the GUI's own refresh page, so a /website/ URL stops naming mirrored content.

--- a/tests/84_webhttrack-mirror-verbatim.test
+++ b/tests/84_webhttrack-mirror-verbatim.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/85_webhttrack-projpath.test
+++ b/tests/85_webhttrack-projpath.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/85_webhttrack-projpath.test
+++ b/tests/85_webhttrack-projpath.test
@@ -60,7 +60,7 @@ body="sid=${sid}&command=httrack&command_do=save&winprofile=x"
 body="${body}&path=${base}&projname=proj&projpath=${base}/proj/"
 htsserver_post "${body}" >/dev/null
 test -f "${base}/proj/hts-cache/winprofile.ini" ||
-    fail "the project was not registered: $(cat "${HTS_LOG}")"
+    fail "the project was not registered: $(<"${HTS_LOG}")"
 fetch /website/hts-log.txt 200
 grep -q LOGMARKER <<<"${reply}" ||
     fail "the registered project's mirror is not served"
@@ -99,9 +99,9 @@ test "$((${#fspath} + 1 + ${#longurl}))" -gt 1024 ||
     fail "the composed path (${#fspath} + ${#longurl}) would not overflow"
 htsserver_post "sid=${sid}&command=httrack&command_do=save&winprofile=x&path=${longpath}&projname=proj" >/dev/null
 test -f "${fspath}/hts-cache/winprofile.ini" ||
-    fail "the long-path project was not registered: $(cat "${HTS_LOG}")"
+    fail "the long-path project was not registered: $(<"${HTS_LOG}")"
 htsserver_get "/website/${longurl}" >/dev/null 2>&1 || true
-htsserver_alive || fail "an over-long project path crashed the server: $(cat "${HTS_LOG}")"
+htsserver_alive || fail "an over-long project path crashed the server: $(<"${HTS_LOG}")"
 # Not just alive: still answering.
 fetch /server/index.html 200
 

--- a/tests/85_webhttrack-projpath.test
+++ b/tests/85_webhttrack-projpath.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/86_local-proxytrack-cache-longfields.test
+++ b/tests/86_local-proxytrack-cache-longfields.test
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/86_local-proxytrack-cache-longfields.test
+++ b/tests/86_local-proxytrack-cache-longfields.test
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/87_local-proxytrack-nodate.test
+++ b/tests/87_local-proxytrack-nodate.test
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/87_local-proxytrack-nodate.test
+++ b/tests/87_local-proxytrack-nodate.test
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"

--- a/tests/88_local-proxytrack-badmtime.test
+++ b/tests/88_local-proxytrack-badmtime.test
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 

--- a/tests/88_local-proxytrack-badmtime.test
+++ b/tests/88_local-proxytrack-badmtime.test
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 

--- a/tests/89_webhttrack-error-overflow.test
+++ b/tests/89_webhttrack-error-overflow.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/89_webhttrack-error-overflow.test
+++ b/tests/89_webhttrack-error-overflow.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/89_webhttrack-error-overflow.test
+++ b/tests/89_webhttrack-error-overflow.test
@@ -64,7 +64,7 @@ save() {
 path=$(padpath "${base}/nodir" 1098)
 save "${path}" x p >/dev/null
 htsserver_alive ||
-    fail "an over-long project path crashed the server: $(cat "${HTS_LOG}")"
+    fail "an over-long project path crashed the server: $(<"${HTS_LOG}")"
 check_clipped "Unable to create the directory structure in " "${path}/p"
 
 # A creatable project path whose hts-cache is not a directory, so the init file
@@ -73,7 +73,7 @@ path=$(padpath "${base}/isdir" 993)
 mkdir -p "${path}/p"
 ln -s /dev/null "${path}/p/hts-cache"
 save "${path}" x p >/dev/null
-htsserver_alive || fail "an unwritable init file crashed the server: $(cat "${HTS_LOG}")"
+htsserver_alive || fail "an unwritable init file crashed the server: $(<"${HTS_LOG}")"
 check_clipped "Unable to create the init file " "${path}/p"
 
 # The init file opens, then the write fails: the profile is past both stdio's
@@ -85,7 +85,7 @@ profile=${profile}${profile}${profile}${profile}
 profile=${profile}${profile}${profile}${profile}
 test "${#profile}" -eq 16384 || fail "built a ${#profile}-byte profile, want 16384"
 save "${path}" "${profile}" p >/dev/null
-htsserver_alive || fail "a short init file write crashed the server: $(cat "${HTS_LOG}")"
+htsserver_alive || fail "a short init file write crashed the server: $(<"${HTS_LOG}")"
 written=$(wc -c <"${path}/p/hts-cache/winprofile.ini" | tr -d ' ')
 test "${written}" -lt "${#profile}" ||
     fail "the file-size limit did not stop the write (${written} bytes landed)"

--- a/tests/91_webhttrack-directory.test
+++ b/tests/91_webhttrack-directory.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "$(dirname "$0")/webhttracklib.sh"
+. "${0%"${0##*/}"}webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/91_webhttrack-directory.test
+++ b/tests/91_webhttrack-directory.test
@@ -56,7 +56,7 @@ body="sid=${sid}&command=httrack&command_do=save&winprofile=x"
 body="${body}&path=${base}&projname=proj"
 htsserver_post "${body}" >/dev/null || fail "the save request did not answer"
 test -f "${base}/proj/hts-cache/winprofile.ini" ||
-    fail "the project was not registered: $(cat "${HTS_LOG}")"
+    fail "the project was not registered: $(<"${HTS_LOG}")"
 
 # Positive control: every assertion below would pass on a server serving nothing.
 served() {
@@ -81,7 +81,7 @@ for path in "${refuse[@]}"; do
 done
 
 # The accept loop is single-threaded: one spin denies every later request.
-htsserver_alive || fail "the server died: $(cat "${HTS_LOG}")"
+htsserver_alive || fail "the server died: $(<"${HTS_LOG}")"
 served /website/probe.txt "the server stopped answering after a directory request"
 
 # This fopen() is reached before any guard, so its read loop must stop on ferror().
@@ -93,7 +93,7 @@ case "${reply}" in
 *) fail "loading a project did not redirect: $(firstline "${reply}")" ;;
 esac
 
-htsserver_alive || fail "the server died: $(cat "${HTS_LOG}")"
+htsserver_alive || fail "the server died: $(<"${HTS_LOG}")"
 served /website/probe.txt "the server stopped answering after a project load"
 
 echo "PASS"

--- a/tests/91_webhttrack-directory.test
+++ b/tests/91_webhttrack-directory.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/webhttracklib.sh
-. "${0%"${0##*/}"}webhttracklib.sh"
+. "${0%"${0##*/}"}./webhttracklib.sh"
 
 htsserver_require
 

--- a/tests/92_local-proxytrack-ndx-fields.test
+++ b/tests/92_local-proxytrack-ndx-fields.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}testlib.sh"
+. "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 

--- a/tests/92_local-proxytrack-ndx-fields.test
+++ b/tests/92_local-proxytrack-ndx-fields.test
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "${0%"${0##*/}"}testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
 

--- a/tests/93_local-changes.test
+++ b/tests/93_local-changes.test
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 

--- a/tests/93_local-changes.test
+++ b/tests/93_local-changes.test
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 

--- a/tests/94_local-single-file.test
+++ b/tests/94_local-single-file.test
@@ -4,7 +4,7 @@
 set -e
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 

--- a/tests/94_local-single-file.test
+++ b/tests/94_local-single-file.test
@@ -4,7 +4,7 @@
 set -e
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 
 python=$(find_python) || skip "python3 not found"
 

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -29,12 +29,15 @@ ci_report_fork_failures() {
         echo "no console log at $log: MSYS fork failures not counted"
         return 0
     }
-    # The runtime's own line, one per child that died at DLL init (0xC0000142).
-    died=$(grep -c 'dofork: child' "$log" || true)
-    retried=$(grep -c 'fork: retry:' "$log" || true)
-    # bash's message once the retries are spent: the only one meaning a command
-    # never ran, which reds whatever test was in flight.
-    gaveup=$(grep -c 'fork: Resource temporarily unavailable' "$log" || true)
+    # Split on CR first: the console carries stdout and stderr merged, so two
+    # messages can share a physical line and a line count would see one. bash
+    # retries on EAGAIN alone, so a give-up can carry any strerror, and the awk
+    # `next` is what keeps a retry from being counted as one.
+    read -r died retried gaveup <<<"$(tr '\r' '\n' <"$log" | awk '
+        /fork: child -1|child_info_fork::abort/ { died++ }
+        /fork: retry:/ { retried++; next }
+        /: fork: / { gaveup++ }
+        END { print died + 0, retried + 0, gaveup + 0 }')"
     test -z "${GITHUB_STEP_SUMMARY:-}" ||
         printf 'MSYS forks: %s died, %s retried, %s given up\n' \
             "$died" "$retried" "$gaveup" >>"$GITHUB_STEP_SUMMARY"
@@ -45,8 +48,9 @@ ci_report_fork_failures() {
     ci_annotate warning "MSYS fork failures" "$(
         printf '%s child(ren) died at DLL init, %s retry wait(s), %s fork(s) given up\n' \
             "$died" "$retried" "$gaveup"
-        grep -m 3 -e 'dofork: child' -e 'fork: retry:' \
-            -e 'fork: Resource temporarily unavailable' "$log" || true
+        # -a: one NUL in the log would otherwise cost every sample line.
+        tr '\r' '\n' <"$log" | grep -am 3 -e 'fork: child -1' \
+            -e 'child_info_fork::abort' -e ': fork: ' || true
     )"
 }
 

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -21,6 +21,35 @@ ci_annotate() {
     printf '\n::%s title=%s::%s\n' "$level" "$title" "$msg"
 }
 
+# Count the MSYS fork-emulation failures in the console log $1. Nothing counted
+# them, so a leg that struggled read exactly like one that never did (#1273).
+ci_report_fork_failures() {
+    local log=$1 died retried gaveup
+    test -r "$log" || {
+        echo "no console log at $log: MSYS fork failures not counted"
+        return 0
+    }
+    # The runtime's own line, one per child that died at DLL init (0xC0000142).
+    died=$(grep -c 'dofork: child' "$log" || true)
+    retried=$(grep -c 'fork: retry:' "$log" || true)
+    # bash's message once the retries are spent: the only one meaning a command
+    # never ran, which reds whatever test was in flight.
+    gaveup=$(grep -c 'fork: Resource temporarily unavailable' "$log" || true)
+    test -z "${GITHUB_STEP_SUMMARY:-}" ||
+        printf 'MSYS forks: %s died, %s retried, %s given up\n' \
+            "$died" "$retried" "$gaveup" >>"$GITHUB_STEP_SUMMARY"
+    if test $((died + retried + gaveup)) -eq 0; then
+        echo "no MSYS fork failure in $log"
+        return 0
+    fi
+    ci_annotate warning "MSYS fork failures" "$(
+        printf '%s child(ren) died at DLL init, %s retry wait(s), %s fork(s) given up\n' \
+            "$died" "$retried" "$gaveup"
+        grep -m 3 -e 'dofork: child' -e 'fork: retry:' \
+            -e 'fork: Resource temporarily unavailable' "$log" || true
+    )"
+}
+
 # End a wedged suite before its runner dies: a step that fails on its own terms
 # keeps its log, a lost runner keeps nothing, annotations included (#795). Quiet
 # for $1s, then names the test in flight from $3 every $2s; kills $5 once $3 has

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -31,10 +31,11 @@ ci_report_fork_failures() {
     }
     # Split on CR first: the console carries stdout and stderr merged, so two
     # messages can share a physical line and a line count would see one. bash
-    # retries on EAGAIN alone, so a give-up can carry any strerror, and the awk
-    # `next` is what keeps a retry from being counted as one.
+    # retries on EAGAIN alone, so a give-up can carry any strerror; each `next`
+    # keeps one message out of a second class.
     read -r died retried gaveup <<<"$(tr '\r' '\n' <"$log" | awk '
-        /fork: child -1|child_info_fork::abort/ { died++ }
+        /fork: child -1|child_info_fork::abort|sync_with_child:/ { died++; next }
+        /reserve memory for parent stack/ { died++; next }
         /fork: retry:/ { retried++; next }
         /: fork: / { gaveup++ }
         END { print died + 0, retried + 0, gaveup + 0 }')"
@@ -49,8 +50,8 @@ ci_report_fork_failures() {
         printf '%s child(ren) died at DLL init, %s retry wait(s), %s fork(s) given up\n' \
             "$died" "$retried" "$gaveup"
         # -a: one NUL in the log would otherwise cost every sample line.
-        tr '\r' '\n' <"$log" | grep -am 3 -e 'fork: child -1' \
-            -e 'child_info_fork::abort' -e ': fork: ' || true
+        tr '\r' '\n' <"$log" | grep -am 3 -e 'fork: child -1' -e 'sync_with_child:' \
+            -e 'child_info_fork::abort' -e 'reserve memory' -e ': fork: ' || true
     )"
 }
 

--- a/tests/crawllib.sh
+++ b/tests/crawllib.sh
@@ -95,7 +95,7 @@ local_server_start() {
     cleanup_push local_server_reap "$((${#SRV_PIDS[@]} - 1))"
 
     SRV_PORT=$(discover_server_port "$SRV_LOG" "$SRV_PID") ||
-        fail "local-server did not come up: $(cat "$SRV_LOG")"
+        fail "local-server did not come up: $(<"$SRV_LOG")"
     # shellcheck disable=SC2034 # set here for the caller, not used here
     BASEURL="${scheme}://127.0.0.1:${SRV_PORT}"
 }

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -53,7 +53,7 @@
 set -u
 
 # shellcheck source=tests/crawllib.sh
-. "$(dirname "$0")/crawllib.sh"
+. "${0%"${0##*/}"}crawllib.sh"
 root="${LOCAL_SERVER_ROOT:-${testdir}/server-root}"
 
 tlsargs=()

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -53,7 +53,7 @@
 set -u
 
 # shellcheck source=tests/crawllib.sh
-. "${0%"${0##*/}"}crawllib.sh"
+. "${0%"${0##*/}"}./crawllib.sh"
 root="${LOCAL_SERVER_ROOT:-${testdir}/server-root}"
 
 tlsargs=()

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -11,6 +11,11 @@ testdir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # own value, so the default only serves a hand-run and the Windows suite.
 : "${top_srcdir:=..}"
 
+# uname -s once per process tree, since every skip gate and every crawl asks for
+# it and each one is a fork the MSYS runtime emulates (#1273).
+: "${HTS_OS:=$(uname -s 2>/dev/null || echo unknown)}"
+export HTS_OS
+
 fail() {
     echo "FAIL: $*" >&2
     exit 1
@@ -219,13 +224,13 @@ declared_header_count() {
     declared_headers | awk 'END { print NR + 0 }'
 }
 
-IS_WINDOWS=
 is_windows() {
-    if test -z "$IS_WINDOWS"; then
-        case "$(uname -s)" in
+    if test -z "${IS_WINDOWS:-}"; then
+        case "$HTS_OS" in
         MINGW* | MSYS* | CYGWIN*) IS_WINDOWS=yes ;;
         *) IS_WINDOWS=no ;;
         esac
+        export IS_WINDOWS
     fi
     test "$IS_WINDOWS" = yes
 }

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -11,8 +11,8 @@ testdir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # own value, so the default only serves a hand-run and the Windows suite.
 : "${top_srcdir:=..}"
 
-# uname -s once per process tree, since every skip gate and every crawl asks for
-# it and each one is a fork the MSYS runtime emulates (#1273).
+# Cache uname -s once: every skip gate and every crawl asks for it, and each
+# call is a fork the MSYS runtime emulates (#1273).
 : "${HTS_OS:=$(uname -s 2>/dev/null || echo unknown)}"
 export HTS_OS
 

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -374,7 +374,7 @@ time.sleep(900)  # bounded, so a SIGKILLed test cannot pin the port for the run
     cleanup_push rm -f "$log"
     cleanup_push stop_server "$HELD_PID"
     HELD_PORT=$(discover_server_port "$log" "$HELD_PID") ||
-        fail "the $proto port holder did not come up: $(cat "$log")"
+        fail "the $proto port holder did not come up: $(<"$log")"
 }
 
 PT_LISTENING="HTTP Proxy installed on"
@@ -388,12 +388,12 @@ proxytrack_bound() { # proxytrack_bound LOG PID
     until grep -qE "$PT_LISTENING|$BIND_LOST" "$log"; do
         # An exit flushes the log, so re-read it rather than calling this dead.
         kill -0 "$pid" 2>/dev/null || break
-        test "$waited" -lt 50 || fail "proxytrack never announced its listen port: $(cat "$log")"
+        test "$waited" -lt 50 || fail "proxytrack never announced its listen port: $(<"$log")"
         sleep 0.1
         waited=$((waited + 1))
     done
     grep -q "$PT_LISTENING" "$log" && return 0
-    grep -qE "$BIND_LOST" "$log" || fail "proxytrack exited before listening: $(cat "$log")"
+    grep -qE "$BIND_LOST" "$log" || fail "proxytrack exited before listening: $(<"$log")"
     return 1
 }
 
@@ -417,7 +417,7 @@ start_proxytrack() { # start_proxytrack LOGBASE LAUNCH
         # Loud, so an intermittent bind regression cannot hide behind the retry.
         echo "proxytrack did not get port $proxyport, retrying" >&2
     done
-    fail "proxytrack bound none of 3 port pairs: $(cat "$ptlog")"
+    fail "proxytrack bound none of 3 port pairs: $(<"$ptlog")"
 }
 
 # Echo the port local-server.py announces on $1 (its log), $2 being its pid, or

--- a/tests/webhttracklib.sh
+++ b/tests/webhttracklib.sh
@@ -133,14 +133,14 @@ htsserver_start() {
         test -z "${HTS_URL}" || break
         # Only a lost bind is worth redrawing; anything else is a regression.
         grep -qE "${BIND_LOST}" "${HTS_LOG}" ||
-            fail "htsserver did not come up: $(cat "${HTS_LOG}")"
+            fail "htsserver did not come up: $(<"${HTS_LOG}")"
         test -z "${port}" ||
-            fail "htsserver could not bind port ${port}: $(cat "${HTS_LOG}")"
+            fail "htsserver could not bind port ${port}: $(<"${HTS_LOG}")"
         stop_server "${HTS_BGPID}"
         # Loud, so an intermittent bind regression cannot hide behind the retry.
         echo "htsserver did not get port ${HTS_PORT}, retrying" >&2
     done
-    test -n "${HTS_URL}" || fail "htsserver bound none of 3 ports: $(cat "${HTS_LOG}")"
+    test -n "${HTS_URL}" || fail "htsserver bound none of 3 ports: $(<"${HTS_LOG}")"
     test -z "${HTS_PID}" || HTS_SRV_PIDS+=("${HTS_PID}")
 }
 


### PR DESCRIPTION
The runtime's `dofork` lines and bash's own retries land on the suite step's stderr and nowhere else, so a leg that struggled reads exactly like one that never did, and a fork that finally gives up inside a test reds it as if the test were at fault. The console is teed and counted now, in a step of its own so the count still arrives when the watchdog killed the suite's step. The last 34 Windows jobs carry none of these lines, so the counter starts from a measured zero.

The rest is a fork diet, because there is no lighter runtime to move to: MSYS emulates fork by copying the address space into a suspended `CreateProcess`, bash takes that path for every subshell and every `$(...)`, and neither Cygwin's `posix_spawn` fast path nor any `MSYS=` flag avoids it. The only lever left is asking for fewer processes. `uname -s` now resolves once into an exported `HTS_OS`, the test's own directory is stripped by parameter expansion instead of a subshell plus `dirname`, and `$(cat f)` is read back by the shell. Over the 255 tests the Windows leg runs, those three drop from 1864 calls to 1083, each call a fork and an exec. That is not a fix for #1228, where the forkiest tests have never lost a runner, but process-creation rate is the one dimension that investigation never got to measure.

226's suite-step audit now matches a step that runs the driver rather than one that merely names it, since the new counting step sources it for the helper.

Closes #1273
