### PR TITLE
Release 3.49.22

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.71])
 
-AC_INIT([httrack], [3.49.21], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
+AC_INIT([httrack], [3.49.22], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
 AC_COPYRIGHT([
 HTTrack Website Copier, Offline Browser for Windows and Unix
 Copyright (C) 1998-2015 Xavier Roche and other contributors
@@ -29,6 +29,9 @@ AC_CONFIG_SRCDIR(src/httrack.c)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
+# 3:15:0: revision-only bump. httrackp gained a tail field (wizard_filters) and two
+# exports arrived (hts_footer_field_ok, hts_wizard_host_scope); HTS_LOCATION_SIZE only
+# names lien_back.location_buffer's existing size, it does not change it.
 # 3:14:0: revision-only bump. httrackp gained a tail field (host_alias) and #1202
 # added an export (hts_host_alias_rule_ok); no layout moved, nothing went away.
 # 3:13:0: revision-only bump. htsstrings.h's StringRoomTotal grew saturation in
@@ -46,7 +49,7 @@ AM_INIT_AUTOMAKE([subdir-objects])
 # moves nothing). Soname stays .so.3: HTTrackQt is the only consumer of the installed
 # headers, so a libhttrack4 rename isn't worth it.
 # (3:0:0 was the htsblk mime-buffer widening, the ABI break that moved .so.2 -> .so.3.)
-VERSION_INFO="3:14:0"
+VERSION_INFO="3:15:0"
 AM_MAINTAINER_MODE
 AC_USE_SYSTEM_EXTENSIONS
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -12,6 +12,10 @@ httrack (3.49.22-1) unstable; urgency=medium
     package also ships htsserver, which serves the same interface to a
     browser elsewhere.
   * Drop skip-emulated-host-test-failures.patch, applied upstream.
+  * Fix the FTBFS on an LTO build, which broke 3.49.21-2 on four Ubuntu
+    architectures: the installed-header symbol test matched header
+    identifiers against symbol names that GCC had renamed, and emptied its
+    own candidate list.  It now strips the clone suffixes first.
 
  -- Xavier Roche <xavier@debian.org>  Sun, 16 Aug 2026 11:29:20 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+httrack (3.49.22-1) unstable; urgency=medium
+
+  * New upstream release: the interactive wizard can be answered for a whole
+    domain and its answer now holds for the rest of the mirror, the mirrored
+    page footer takes named fields, and a series of buffer overflows on long
+    values read off the network or the command line are fixed; full list in
+    history.txt.
+  * Move webhttrack's browser dependency to Recommends: the autoremoval
+    gatherer reads only the first alternative of a disjunction and never
+    looks at Recommends, so chromium's RC bugs put the whole httrack source
+    on its removal clock.  Apt installs Recommends by default, and the
+    package also ships htsserver, which serves the same interface to a
+    browser elsewhere.
+  * Drop skip-emulated-host-test-failures.patch, applied upstream.
+
+ -- Xavier Roche <xavier@debian.org>  Sun, 16 Aug 2026 11:29:20 +0200
+
 httrack (3.49.21-2) unstable; urgency=medium
 
   * Fix the FTBFS on hppa: three suite tests measured the build host rather

--- a/history.txt
+++ b/history.txt
@@ -19,7 +19,7 @@ This file lists all changes and fixes that have been made for HTTrack
 + Fixed: a URL longer than 1024 bytes in a -%L list was split into two links (#1289)
 + Fixed: doit.log wrote a leading quote raw and swallowed the options after it, and stripped a quoted argument twice on the way back in (#1263)
 + Fixed: the credit tag in every mirrored page was dated 2014 (#1243)
-+ Fixed: the index templates and their compiled-in copies had drifted apart, so the built-in fallback wrote a different page (#1244, #1301)
++ Fixed: the index templates and their compiled-in copies had drifted apart, so the built-in fallback wrote a different page (#1244)
 + Fixed: an abandoned WebHTTrack server never stopped, holding the macOS application open (#1236)
 + Fixed: the filter documentation described a matcher the engine does not implement (#1302)
 + Changed: every language catalog carries the strings added since 3.49, and a value left in English no longer passes the integrity test (#1255, #1260)

--- a/history.txt
+++ b/history.txt
@@ -4,6 +4,27 @@ HTTrack Website Copier release history:
 
 This file lists all changes and fixes that have been made for HTTrack
 
+3.49-22
++ New: an interactive wizard question can be answered for a whole domain rather than for the one exact host it asked about; a front end enumerates the scopes on offer through the newly exported hts_wizard_host_scope() (#1117)
++ New: the -%F footer template takes named fields ("{url}", "{date}") in place of positional "%s", so a custom footer keeps working as the list grows; hts_footer_field_ok() exports the engine's own field list, which the help text and the guide are now generated from (#1240, #1256)
++ New: the per-option argument caps are macros in htsglobal.h (HTS_FOOTER_MAXSIZE and friends), so a front end can check a value against the engine's limit instead of copying it (#1262)
++ Fixed: a wizard answer decided a single link and vanished; it now becomes a filter that outranks the rules preceding it, applies for the rest of the mirror, and is written to hts-log.txt (#1249, #1250, #1251)
++ Fixed: a link the wizard authorized was mirrored under its ".delayed" placeholder name (#1254)
++ Fixed: the interactive wizard spun forever once stdin reached EOF (#1247)
++ Fixed: the wizard silently truncated the filter it built for a long host (#1264)
++ Fixed: several buffer overflows on long values read off the wire or the command line: --assume (#1276), a cookies.txt field (#1284), a filter or URL token in the option parser (#1271), the save name the cache rebuilds under a deeper -O (#1278), a crawled link just past the naming cap (#1269), and a -%F footer that exactly filled the page buffer (#1241)
++ Fixed: a filter rule longer than the matcher's cap was stored and never matched anything, while a rule that exactly fitted was refused by one byte (#1270, #1299)
++ Fixed: a redirect between 1 KB and 2 KB was refused by a gate half the size of the buffer holding it (#1291)
++ Fixed: a robots.txt whose rules ran past 4 KB was dropped without a word (#1286)
++ Fixed: a URL longer than 1024 bytes in a -%L list was split into two links (#1289)
++ Fixed: doit.log wrote a leading quote raw and swallowed the options after it, and stripped a quoted argument twice on the way back in (#1263)
++ Fixed: the credit tag in every mirrored page was dated 2014 (#1243)
++ Fixed: the index templates and their compiled-in copies had drifted apart, so the built-in fallback wrote a different page (#1244, #1301)
++ Fixed: an abandoned WebHTTrack server never stopped, holding the macOS application open (#1236)
++ Fixed: the filter documentation described a matcher the engine does not implement (#1302)
++ Changed: every language catalog carries the strings added since 3.49, and a value left in English no longer passes the integrity test (#1255, #1260)
++ Changed: multiple internal hardening, test and build improvements
+
 3.49-21
 + New: --host-alias (-%C) folds the several hostnames of one site onto a single canonical host, so a site that answers under more than one hostname is fetched once instead of once per name (#16)
 + New: the WebHTTrack wizard can set the host-alias rules and the guide documents them for every front end; a malformed rule is refused where it can still be corrected, through a newly exported hts_host_alias_rule_ok() (#1161, #1172, #1192)

--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -53,6 +53,18 @@
   <content_rating type="oars-1.1"/>
   <!-- Newest first; tests/01_engine-version-macros.test enforces it. -->
   <releases>
+    <release version="3.49.22" date="2026-08-16">
+      <description>
+        <ul>
+          <li>When the mirror asks whether to follow a link, you can now answer for a whole domain instead of that one address</li>
+          <li>Your answer is applied to the rest of the mirror and written to the log, instead of deciding a single link</li>
+          <li>The footer added to mirrored pages takes named fields, so a custom one keeps working when the list grows</li>
+          <li>A long address, a long filter, a large cookies file or a large robots.txt no longer stops the mirror</li>
+          <li>A redirection to a long address is followed instead of being refused</li>
+          <li>Every language now has the text added since 3.49, and WebHTTrack quits when its window is closed</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.49.21" date="2026-08-12">
       <description>
         <ul>

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -43,8 +43,8 @@ Please visit our Website: http://www.httrack.com
    configure.ac, decoupled from these). VERSION is the display form, VERSIONID
    the dotted numeric form, AFF_VERSION the short form shown in footers,
    LIB_VERSION the data/cache format generation. */
-#define HTTRACK_VERSION "3.49-21"
-#define HTTRACK_VERSIONID "3.49.21"
+#define HTTRACK_VERSION "3.49-22"
+#define HTTRACK_VERSIONID "3.49.22"
 #define HTTRACK_AFF_VERSION "3.x"
 #define HTTRACK_LIB_VERSION "2.0"
 

--- a/src/version.rc
+++ b/src/version.rc
@@ -17,8 +17,8 @@
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-  FILEVERSION 3, 49, 21, 0
-  PRODUCTVERSION 3, 49, 21, 0
+  FILEVERSION 3, 49, 22, 0
+  PRODUCTVERSION 3, 49, 22, 0
   FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
 #ifdef _DEBUG
   FILEFLAGS VS_FF_DEBUG
@@ -35,12 +35,12 @@ BEGIN
     BEGIN
       VALUE "CompanyName", "Xavier Roche"
       VALUE "FileDescription", VER_FILE_DESCRIPTION
-      VALUE "FileVersion", "3.49.21"
+      VALUE "FileVersion", "3.49.22"
       VALUE "InternalName", VER_ORIGINAL_FILENAME
       VALUE "LegalCopyright", "Copyright (C) 1998-2026 Xavier Roche and other contributors. GNU GPL v3 or later."
       VALUE "OriginalFilename", VER_ORIGINAL_FILENAME
       VALUE "ProductName", "HTTrack Website Copier"
-      VALUE "ProductVersion", "3.49-21"
+      VALUE "ProductVersion", "3.49-22"
     END
   END
   BLOCK "VarFileInfo"


### PR DESCRIPTION
Bumps to 3.49.22 across configure.ac, htsglobal.h, version.rc and the AppStream metainfo. Release notes are split by audience: user-facing items in history.txt, packaging ones in debian/changelog.

VERSION_INFO moves 3:14:0 to 3:15:0, revision only. httrackp gained a tail field (wizard_filters) and two exports arrived (hts_footer_field_ok, hts_wizard_host_scope), so no installed struct moved and nothing went away; the soname stays libhttrack.so.3. HTS_LOCATION_SIZE names lien_back.location_buffer's existing size rather than changing it. Standards-Version 4.7.4 still matches debian-policy.

The Debian entry also drops skip-emulated-host-test-failures.patch, now applied upstream, and records the webhttrack Recommends move.

Built out of tree: 345 tests, 333 pass, 12 skip, and the binary reports 3.49-22.