### PR TITLE
The self-test suite forks once per assertion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,12 @@ the operational checklist: toolchain, invariants, and how to ship a change.
 - Behavior change → add a test. Fast path: a hidden `httrack -#test=NAME` engine
   self-test (registry in `htsselftest.c`; `-#test` lists them) driven by a
   `tests/NN_*.test`, over a slow crawl.
+- A list of self-test assertions goes through `selftest_queue` +
+  `selftest_run_queued`, which run the file's cases in one engine instead of one
+  per assertion. Queued args reach the handler verbatim, so a case exercising an
+  argv rewrite (CR/LF/TAB to a space, `(none)`, quote stripping, alias
+  expansion), or one whose output later shell logic reads, keeps
+  `assert_selftest`.
 
 ## Review your change adversarially (strongly suggested)
 Before pushing, and when reviewing others, don't skim for bugs:

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -11154,7 +11154,7 @@ static int st_strsprintf(httrackp *opt, int argc, char **argv) {
 }
 
 /* ------------------------------------------------------------ */
-/* Batch runner: many self-tests in one process (see st_batch).  */
+/* Batch runner: many self-tests in one process.                */
 /* ------------------------------------------------------------ */
 
 /* Framing byte between a case's output and its exit code, and between cases.
@@ -11190,13 +11190,34 @@ static char *st_batch_slurp(size_t *size) {
       capa *= 2;
     }
     n = fread(&buff[len], 1, capa - len - 1, stdin);
-    if (n == 0)
+    if (n == 0) {
+      /* Else a read error reads as EOF, and the tail of the script is dropped
+         as silently as if it had never been written. */
+      if (ferror(stdin)) {
+        freet(buff);
+        return NULL;
+      }
       break;
+    }
     len += n;
   }
   buff[len] = '\0';
   *size = len;
   return buff;
+}
+
+/* Case argument count, or -1 if the field is not one: atoi() would read a name
+   as zero and swallow the next case's fields. */
+static int st_batch_nargs(const char *field) {
+  char *tail;
+  long n;
+
+  errno = 0;
+  n = strtol(field, &tail, 10);
+  if (field[0] == '\0' || *tail != '\0' || errno != 0 || n < 0 ||
+      n > ST_BATCH_MAXARGS)
+    return -1;
+  return (int) n;
 }
 
 /* Next NUL-separated field, or NULL past the end of the script. */
@@ -11209,17 +11230,18 @@ static char *st_batch_field(char **pos, const char *end) {
   return field;
 }
 
-/* A fresh option set per case, or a handler's writes to opt would reach the
-   next case, which they could not when each case was its own process. It
-   carries what htsmain() derives before the dispatch out of the harness's own
-   -O and the tty probe; 314_engine-selftest-batch.test pins that against a
-   direct run. */
+/* A fresh option set per case: a handler's writes to opt must not reach the
+   next one, as they never could across separate processes. It carries the seven
+   fields htsmain() derives before the dispatch, out of the harness's own -O,
+   the data directory and the tty probe; everything else is hts_create_opt's
+   default on both routes, since the harness passes nothing else. */
 static httrackp *st_batch_opt(const httrackp *from) {
   httrackp *const opt = hts_create_opt();
 
   StringCopy(opt->path_html, StringBuff(from->path_html));
   StringCopy(opt->path_html_utf8, StringBuff(from->path_html_utf8));
   StringCopy(opt->path_log, StringBuff(from->path_log));
+  StringCopy(opt->path_bin, StringBuff(from->path_bin));
   opt->dir_topindex = from->dir_topindex;
   opt->quiet = from->quiet;
   opt->verbosedisplay = from->verbosedisplay;
@@ -11227,15 +11249,12 @@ static httrackp *st_batch_opt(const httrackp *from) {
 }
 
 /* Run a script of self-tests in one process, so a test file costs one fork
-   rather than one per assertion (a fork is expensive under MSYS, #795). The
-   script is NUL-separated fields repeating <argc> <name> <arg>*, and comes in
-   on stdin rather than argv, where the engine would parse a case's `-*` as one
-   of its own filters. Each case prints its output, then RS, its exit code and
-   RS again, which is what testlib.sh's selftest_run_queued splits on.
-
-   Args therefore arrive verbatim, where an argv first goes through htsmain()'s
-   rewrites (CR/LF/TAB to a space, "(none)" emptied, quotes dropped, aliases
-   expanded); a case meaning to exercise one of those stays one per process. */
+   rather than one per assertion (#1305). Cases must not travel in argv, where
+   the engine would parse a `-*` as one of its own filters and rewrite the rest;
+   stdin keeps them off it and out of htsmain()'s reach, so they arrive
+   verbatim. The script is NUL-separated fields repeating <argc> <name> <arg>*,
+   and each case prints its output, then RS, its exit code and RS again, which
+   is what testlib.sh's selftest_run_queued splits on. */
 static int st_batch(httrackp *opt, int argc, char **argv) {
   char *buff, *pos;
   const char *end;
@@ -11253,12 +11272,12 @@ static int st_batch(httrackp *opt, int argc, char **argv) {
   pos = buff;
   end = &buff[len];
   while (!err && (field = st_batch_field(&pos, end)) != NULL) {
-    const int nargs = atoi(field);
+    const int nargs = st_batch_nargs(field);
     char *const name = st_batch_field(&pos, end);
     char **args;
     int i, code;
 
-    if (nargs < 0 || nargs > ST_BATCH_MAXARGS || name == NULL) {
+    if (nargs < 0 || name == NULL) {
       fprintf(stderr, "batch: malformed case header\n");
       err = 1;
       break;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -11154,6 +11154,153 @@ static int st_strsprintf(httrackp *opt, int argc, char **argv) {
 }
 
 /* ------------------------------------------------------------ */
+/* Batch runner: many self-tests in one process (see st_batch).  */
+/* ------------------------------------------------------------ */
+
+/* Framing byte between a case's output and its exit code, and between cases.
+   Out of the ASCII control block, which no self-test prints. */
+#define ST_BATCH_RS "\036"
+
+/* Per case, so a bad length field cannot make us walk off the script. */
+#define ST_BATCH_MAXARGS 1024
+
+/* Read stdin to EOF, NUL-terminated; *size excludes that terminator. */
+static char *st_batch_slurp(size_t *size) {
+  size_t capa = 65536, len = 0;
+  char *buff = malloct(capa);
+
+  if (buff == NULL)
+    return NULL;
+  for (;;) {
+    size_t n;
+
+    if (len + 1 >= capa) {
+      char *grown;
+
+      if (capa > (size_t) -1 / 2) {
+        freet(buff);
+        return NULL;
+      }
+      grown = realloct(buff, capa * 2);
+      if (grown == NULL) {
+        freet(buff);
+        return NULL;
+      }
+      buff = grown;
+      capa *= 2;
+    }
+    n = fread(&buff[len], 1, capa - len - 1, stdin);
+    if (n == 0)
+      break;
+    len += n;
+  }
+  buff[len] = '\0';
+  *size = len;
+  return buff;
+}
+
+/* Next NUL-separated field, or NULL past the end of the script. */
+static char *st_batch_field(char **pos, const char *end) {
+  char *const field = *pos;
+
+  if (field >= end)
+    return NULL;
+  *pos = field + strlen(field) + 1;
+  return field;
+}
+
+/* A fresh option set per case, or a handler's writes to opt would reach the
+   next case, which they could not when each case was its own process. It
+   carries what htsmain() derives before the dispatch out of the harness's own
+   -O and the tty probe; 314_engine-selftest-batch.test pins that against a
+   direct run. */
+static httrackp *st_batch_opt(const httrackp *from) {
+  httrackp *const opt = hts_create_opt();
+
+  StringCopy(opt->path_html, StringBuff(from->path_html));
+  StringCopy(opt->path_html_utf8, StringBuff(from->path_html_utf8));
+  StringCopy(opt->path_log, StringBuff(from->path_log));
+  opt->dir_topindex = from->dir_topindex;
+  opt->quiet = from->quiet;
+  opt->verbosedisplay = from->verbosedisplay;
+  return opt;
+}
+
+/* Run a script of self-tests in one process, so a test file costs one fork
+   rather than one per assertion (a fork is expensive under MSYS, #795). The
+   script is NUL-separated fields repeating <argc> <name> <arg>*, and comes in
+   on stdin rather than argv, where the engine would parse a case's `-*` as one
+   of its own filters. Each case prints its output, then RS, its exit code and
+   RS again, which is what testlib.sh's selftest_run_queued splits on.
+
+   Args therefore arrive verbatim, where an argv first goes through htsmain()'s
+   rewrites (CR/LF/TAB to a space, "(none)" emptied, quotes dropped, aliases
+   expanded); a case meaning to exercise one of those stays one per process. */
+static int st_batch(httrackp *opt, int argc, char **argv) {
+  char *buff, *pos;
+  const char *end;
+  char *field;
+  size_t len = 0;
+  int err = 0;
+
+  (void) argc;
+  (void) argv;
+  buff = st_batch_slurp(&len);
+  if (buff == NULL) {
+    fprintf(stderr, "batch: could not read the script on stdin\n");
+    return 1;
+  }
+  pos = buff;
+  end = &buff[len];
+  while (!err && (field = st_batch_field(&pos, end)) != NULL) {
+    const int nargs = atoi(field);
+    char *const name = st_batch_field(&pos, end);
+    char **args;
+    int i, code;
+
+    if (nargs < 0 || nargs > ST_BATCH_MAXARGS || name == NULL) {
+      fprintf(stderr, "batch: malformed case header\n");
+      err = 1;
+      break;
+    }
+    args = calloct((size_t) nargs + 1, sizeof(char *));
+    if (args == NULL) {
+      fprintf(stderr, "batch: not enough memory\n");
+      err = 1;
+      break;
+    }
+    for (i = 0; i < nargs; i++) {
+      args[i] = st_batch_field(&pos, end);
+      if (args[i] == NULL) {
+        fprintf(stderr, "batch: case '%s' is missing arguments\n", name);
+        err = 1;
+        break;
+      }
+    }
+    if (err) {
+      freet(args);
+      break;
+    }
+    /* Nesting would re-read a stdin already at EOF and silently run nothing. */
+    if (strcmp(name, "batch") == 0) {
+      fprintf(stderr, "batch: cannot nest\n");
+      code = 1;
+    } else {
+      httrackp *const copt = st_batch_opt(opt);
+
+      code = hts_selftest(copt, name, nargs, args);
+      hts_free_opt(copt);
+    }
+    freet(args);
+    fflush(stdout);
+    printf(ST_BATCH_RS "%d" ST_BATCH_RS, code);
+    fflush(stdout);
+  }
+  freet(buff);
+  return err;
+}
+
+/* ------------------------------------------------------------ */
 /* Registry: name -> handler, with a usage hint and a one-line description. */
 /* ------------------------------------------------------------ */
 
@@ -11163,6 +11310,8 @@ static const struct selftest_entry {
   const char *desc;
   int (*fn)(httrackp *opt, int argc, char **argv);
 } selftests[] = {
+    {"batch", "", "run a NUL-separated script of self-tests read from stdin",
+     st_batch},
     {"filter", "<pattern> <string>", "match a string against a wildcard filter",
      st_filter},
     {"filtersize", "<size> <string> <filter>...",

--- a/tests/01_engine-charset.test
+++ b/tests/01_engine-charset.test
@@ -8,7 +8,7 @@ set -euo pipefail
 
 # charset -> UTF-8 conversion (hts_convertStringToUTF8).
 # -#test=charset <charset> <string> prints the string re-decoded from <charset> as UTF-8.
-conv() { assert_selftest "$3" charset "$1" "$2"; }
+conv() { selftest_queue "$3" charset "$1" "$2"; }
 # crash probe: malformed input must exit cleanly, not abort.
 runs() {
     httrack -O /dev/null -#test=charset "$1" "$2" >/dev/null 2>&1 || fail "charset '$1' '$2' exited non-zero"
@@ -40,7 +40,7 @@ runs 'utf-8' 'hex:c3'
 
 # hts_getCharsetFromMeta: <meta> charset extraction, HTML5 and legacy forms.
 # -#test=metacharset <html> prints the charset, or "(none)".
-meta() { assert_selftest "$2" metacharset "$1"; }
+meta() { selftest_queue "$2" metacharset "$1"; }
 
 # HTML5 form, quoting/spacing flavors
 meta '<meta charset="utf-8">' 'utf-8'
@@ -82,7 +82,7 @@ meta '<meta ' '(none)'
 meta '<meta' '(none)'
 
 # hts_isStringUTF8: valid-UTF-8 probe (guards the #180 link conversion).
-utf8() { assert_selftest "$2" isutf8 "$1"; }
+utf8() { selftest_queue "$2" isutf8 "$1"; }
 utf8 'plain' '1'
 utf8 'café' '1'
 utf8 '统计' '1'
@@ -94,3 +94,5 @@ utf8 'hex:c0af' '0'       # overlong (latin-1 "À¯" must stay convertible)
 utf8 'hex:eda080' '0'     # UTF-16 surrogate
 utf8 'hex:f4908080' '0'   # above U+10FFFF
 utf8 'hex:f888808080' '0' # legacy 5-byte form
+
+selftest_run_queued

--- a/tests/01_engine-crange.test
+++ b/tests/01_engine-crange.test
@@ -3,18 +3,17 @@
 
 set -euo pipefail
 
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
 # Content-Range parse (treathead via -#test=crange). Hostile values must clamp
 # to 0, and the crange +/- 1 arithmetic must not sign-overflow (UBSan aborts on
 # the pre-fix binary at the INT64_MIN cases).
 
 cr() {
-    local want="$1"
+    local want=$1
     shift
-    out="$(httrack -O /dev/null -#test=crange "$@")"
-    test "$out" == "$want" || {
-        echo "FAIL: $* -> '$out' (want '$want')"
-        exit 1
-    }
+    selftest_queue "$want" crange "$@"
 }
 
 # Normal range and the '*/N' fallback both parse through unchanged.
@@ -32,3 +31,5 @@ cr 'crange_start=0 crange_end=0 crange=0' 'Content-Range: bytes -5-10/20'
 # INT64_MAX is non-negative: it passes through, the parse must not mangle it.
 cr 'crange_start=0 crange_end=9223372036854775807 crange=9223372036854775807' \
     'Content-Range: bytes 0-9223372036854775807/9223372036854775807'
+
+selftest_run_queued

--- a/tests/01_engine-entities.test
+++ b/tests/01_engine-entities.test
@@ -8,7 +8,7 @@ set -euo pipefail
 
 # HTML entity unescaping (hts_unescapeEntitiesWithCharset).
 # -#test=entities <string> prints the string with entities decoded (UTF-8 output).
-ent() { assert_selftest "$2" entities "$1"; }
+ent() { selftest_queue "$2" entities "$1"; }
 # crash probe: malformed input must exit cleanly, not abort.
 runs() {
     httrack -O /dev/null -#test=entities "$1" >/dev/null 2>&1 || fail "entities '$1' exited non-zero"
@@ -65,3 +65,5 @@ runs '&#9999999999;'
 # original compound case. NOTE: the space after '&foo;' is the &nbsp; known bug
 # above (U+00A0 -> 0x20), not a real space in the source.
 ent '&foo;&nbsp;th&eacute;&amp;caf&#xe9;&#e9;&#x3082;&#12398;&#x306e;&#x3051;&#x59eb;' '&foo; thé&café&#e9;もののけ姫'
+
+selftest_run_queued

--- a/tests/01_engine-expandhome.test
+++ b/tests/01_engine-expandhome.test
@@ -16,7 +16,7 @@ set -euo pipefail
 ask() {
     HOME=HTSHOME httrack -O /dev/null -#test=expandhome "$1"
 }
-exp() { assert_eq "expanded=$2" "$(ask "$1")" "expandhome '$1'"; }
+exp() { selftest_queue "expanded=$2" expandhome "$1"; }
 
 home=$(ask '~')
 home=${home#expanded=}
@@ -52,3 +52,5 @@ if test "$home" = HTSHOME; then
     long=$(printf '%04096d' 0 | tr '0' 'A')
     assert_eq "expanded=~/foo" "$(HOME="$long" httrack -O /dev/null -#test=expandhome '~/foo')" 'over-long HOME'
 fi
+
+HOME=HTSHOME selftest_run_queued

--- a/tests/01_engine-filter.test
+++ b/tests/01_engine-filter.test
@@ -9,11 +9,11 @@ set -euo pipefail
 # wildcard filter engine (strjoker), the core of +/- include/exclude rules.
 # -#test=filter <filter> <string> prints "<string> does match <filter>" or "... does NOT match ...".
 
-match() { assert_selftest "$2 does match $1" filter "$1" "$2"; }
-nomatch() { assert_selftest "$2 does NOT match $1" filter "$1" "$2"; }
+match() { selftest_queue "$2 does match $1" filter "$1" "$2"; }
+nomatch() { selftest_queue "$2 does NOT match $1" filter "$1" "$2"; }
 # single-arg call means an empty subject (unreachable as a CLI arg); '*(' used
 # to force max=1 and over-read past it.
-nomatch_empty() { assert_selftest " does NOT match $1" filter "$1"; }
+nomatch_empty() { selftest_queue " does NOT match $1" filter "$1"; }
 
 # bare star matches everything
 match '*' 'anything/at/all'
@@ -107,7 +107,7 @@ nomatch '*.html*[]' 'page.html?x=1' # *[] forbids the trailing query
 fsize() {
     local want=$1
     shift
-    assert_selftest "$want" filtersize "$@"
+    selftest_queue "$want" filtersize "$@"
 }
 fsize 'verdict=allowed size_flag=0' -1 foo.jpg -* '+*.jpg' '-*.jpg*[<10]'   # scan time: keep
 fsize 'verdict=forbidden size_flag=1' 5 foo.jpg -* '+*.jpg' '-*.jpg*[<10]'  # <10KB: cancel
@@ -163,7 +163,7 @@ fsize 'verdict=unknown size_flag=1' 5 foo.jpg '-*.jpg*[>10]'
 fmime() {
     local want=$1
     shift
-    assert_selftest "verdict=$want" filtermime "$@"
+    selftest_queue "verdict=$want" filtermime "$@"
 }
 fmime allowed 'image/png' '+mime:image/*'
 fmime unknown 'text/html' '+mime:image/*'
@@ -174,7 +174,7 @@ fsize 'verdict=unknown size_flag=0' -1 'image/png' '+mime:image/*' # and vice ve
 
 # memoized vs no-memo differential over seeded random patterns and subjects,
 # matching and non-matching (the self-test asserts both polarities occurred)
-assert_selftest "filtermemo: 20000 cases OK" filtermemo
+selftest_queue "filtermemo: 20000 cases OK" filtermemo
 
 # star-heavy non-match must stay polynomial (#501); 400 chars also exercises
 # the heap-allocated memo. timeout (where available) turns a hang into a FAIL.
@@ -200,3 +200,5 @@ if (ulimit -s 512 && httrack --version >/dev/null 2>&1); then
     out=$(ulimit -s 512 && with_timeout httrack -O /dev/null -#test=filterbounds)
     assert_eq "filterbounds: OK" "$out" "filterbounds on a 512K stack"
 fi
+
+selftest_run_queued

--- a/tests/01_engine-filterdual.test
+++ b/tests/01_engine-filterdual.test
@@ -12,7 +12,7 @@ set -euo pipefail
 fdual() {
     local want=$1
     shift
-    assert_selftest "$want" filterdual "$@"
+    selftest_queue "$want" filterdual "$@"
 }
 
 fdual 'verdict=unknown rule=0' zzz yyy '+a*'     # neither form matches
@@ -21,3 +21,5 @@ fdual 'verdict=forbidden rule=0' zzz aaa '-a*'   # only form 2 matches
 fdual 'verdict=forbidden rule=1' a b '+a*' '-b*' # later rule wins (form 2)
 fdual 'verdict=forbidden rule=1' b a '+a*' '-b*' # later rule wins (form 1)
 fdual 'verdict=allowed rule=0' a aa '+a*'        # tie: form 1 wins
+
+selftest_run_queued

--- a/tests/01_engine-footerfmt.test
+++ b/tests/01_engine-footerfmt.test
@@ -3,15 +3,12 @@
 
 set -euo pipefail
 
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
 # -%F footer expansion (hts_footer_format via -#test=footerfmt). The expected
 # strings below also pin each field name to its engine enum slot.
-ftr() {
-    out="$(httrack -O /dev/null -#test=footerfmt "$1")"
-    test "$out" == "$2" || {
-        echo "FAIL: '$1' -> '$out' (want '$2')"
-        exit 1
-    }
-}
+ftr() { selftest_queue "$2" footerfmt "$1"; }
 
 # Legacy positional model: a template with %s keeps the historic addr/path/date
 # order byte-for-byte (backward compatibility).
@@ -40,3 +37,5 @@ ftr '{addr} %s' '{addr} host.example'
 ftr '{url}' 'http://host.example/dir/page.html'
 ftr 'src {lastmodified}, got {date}' 'src LASTMOD, got DATE'
 ftr '{mime}; {charset}; {status}; {size}' 'text/html; utf-8; 200; 1234'
+
+selftest_run_queued

--- a/tests/01_engine-header.test
+++ b/tests/01_engine-header.test
@@ -31,11 +31,13 @@ hdr 'contenttype= cdispo=evil.pdf' \
 
 # An over-long header value must not overflow the parse scratch (ASan aborts
 # here on the pre-fix binary).
-assert_selftest 'contenttype_len=32 contentencoding_len=0' headerlong 'Content-Type:'
-assert_selftest 'contenttype_len=0 contentencoding_len=0' headerlong 'Content-Encoding:'
+selftest_queue 'contenttype_len=32 contentencoding_len=0' headerlong 'Content-Type:'
+selftest_queue 'contenttype_len=0 contentencoding_len=0' headerlong 'Content-Encoding:'
 
 # An empty Content-Encoding yields no token: leave it empty, don't read the
 # uninitialized scratch (MSan aborts here on the pre-fix binary).
 enc() { httrack -O /dev/null -#test=header "$1" | grep '^contentencoding='; }
 assert_eq 'contentencoding=' "$(enc 'Content-Encoding:')"
 assert_eq 'contentencoding=gzip' "$(enc 'Content-Encoding: gzip')"
+
+selftest_run_queued

--- a/tests/01_engine-identurl.test
+++ b/tests/01_engine-identurl.test
@@ -10,7 +10,7 @@ set -euo pipefail
 # it. -#test=identurl <url> [pad] prints "adr=.. fil=.." or "error"; pad appends
 # N 'a's, reaching lengths a CLI arg can't.
 
-split() { assert_selftest "$2" identurl "$1"; }
+split() { selftest_queue "$2" identurl "$1"; }
 
 split 'http://www.example.com/a/b/../c.html' 'adr=www.example.com fil=/a/c.html'
 split 'ftp://ftp.example.com/pub/file.txt' 'adr=ftp://ftp.example.com fil=/pub/file.txt'
@@ -21,6 +21,8 @@ split 'file://' 'adr=file:// fil=//'
 
 # a root-relative path is copied whole into fil[HTS_URLMAXSIZE*2], so a URL at
 # the buffer size is the tightest overflow; it must be rejected, not abort.
-split_pad() { assert_selftest "$3" identurl "$1" "$2"; }
+split_pad() { selftest_queue "$3" identurl "$1" "$2"; }
 split_pad '/' 2047 'error' # 1 + 2047 = 2048 = HTS_URLMAXSIZE*2
 split_pad 'http://h/' 3000 'error'
+
+selftest_run_queued

--- a/tests/01_engine-idna.test
+++ b/tests/01_engine-idna.test
@@ -9,8 +9,8 @@ set -euo pipefail
 # IDNA / punycode encode (-#test=idna-encode) and decode (-#test=idna-decode). This code has a CVE history,
 # so the edge cases below cover passthrough, round-trips, and malformed input.
 
-enc() { assert_selftest "$2" idna-encode "$1"; }
-dec() { assert_selftest "$2" idna-decode "$1"; }
+enc() { selftest_queue "$2" idna-encode "$1"; }
+dec() { selftest_queue "$2" idna-decode "$1"; }
 # a malformed encode input must be rejected (empty output), not encoded or leaked.
 enc_bad() {
     assert_eq "" "$(httrack -O /dev/null -#test=idna-encode "$1" 2>/dev/null)" "idna-encode '$1'"
@@ -47,3 +47,5 @@ dec 'xn--already-encoded.com' 'ǮalǭǮreaǭǫdy.com'
 # cannot survive a Windows command line (it round-trips through UTF-16 to valid
 # U+FFFD, which then encodes fine instead of being rejected).
 enc_bad 'hex:62c3bc636865762ee4be8be5ad62c3bc636865706c65'
+
+selftest_run_queued

--- a/tests/01_engine-mime.test
+++ b/tests/01_engine-mime.test
@@ -6,30 +6,29 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-# MIME type guessing from extension (get_httptype / give_mimext).
-# -#test=mime <path> prints "<path> is '<mime>'" then "and its local type is '.<ext>'".
-
-# firstline, not a pipe into head: head would SIGPIPE the engine, and pipefail
-# then reds the test for the wrong reason.
-mime() {
-    assert_eq "$1 is '$2'" "$(firstline "$(httrack -O /dev/null -#test=mime "$1")")"
+# MIME type guessing from extension (get_httptype / give_mimext), and the local
+# extension that type maps back to. The third argument is that round trip, which
+# is not always the extension asked for: give_mimext answers from the type, so
+# the two spellings of HTML both come back .html.
+mime() { # mime PATH MIME LOCAL-EXT
+    selftest_queue_lines "$1 is '$2'
+and its local type is '$3'" mime "$1"
 }
-unknown() {
-    assert_eq "$1 is of an unknown MIME type" \
-        "$(firstline "$(httrack -O /dev/null -#test=mime "$1")")"
-}
+unknown() { selftest_queue "$1 is of an unknown MIME type" mime "$1"; }
 
-mime '/a/b.html' 'text/html'
-mime '/a/b.htm' 'text/html'
-mime '/x.css' 'text/css'
-mime '/x.js' 'application/x-javascript'
-mime '/x.png' 'image/png'
-mime '/x.jpg' 'image/jpeg'
-mime '/x.gif' 'image/gif'
-mime '/x.txt' 'text/plain'
-mime '/x.xml' 'application/xml'
-mime '/x.pdf' 'application/pdf'
+mime '/a/b.html' 'text/html' '.html'
+mime '/a/b.htm' 'text/html' '.html'
+mime '/x.css' 'text/css' '.css'
+mime '/x.js' 'application/x-javascript' '.js'
+mime '/x.png' 'image/png' '.png'
+mime '/x.jpg' 'image/jpeg' '.jpg'
+mime '/x.gif' 'image/gif' '.gif'
+mime '/x.txt' 'text/plain' '.txt'
+mime '/x.xml' 'application/xml' '.xml'
+mime '/x.pdf' 'application/pdf' '.pdf'
 
-# no extension, or one not in the table
+# no extension, or one not in the table: no second line to answer with
 unknown '/noext'
 unknown '/x.unknownext'
+
+selftest_run_queued

--- a/tests/01_engine-proxyurl.test
+++ b/tests/01_engine-proxyurl.test
@@ -11,7 +11,7 @@ set -euo pipefail
 # "name=.. port=.. host=.. kind=..", where host= is what the connect resolves and
 # kind= is the transport the scheme selects (http, socks or connect).
 
-p() { assert_selftest "$2" proxyurl "$1"; }
+p() { selftest_queue "$2" proxyurl "$1"; }
 
 # bare host, with and without an explicit port
 p 'proxy.example.com:8080' 'name=proxy.example.com port=8080 host=proxy.example.com kind=http'
@@ -92,3 +92,5 @@ p 'http://host: 80' 'name=http://host port=8080 host=host kind=http'
 p 'http://host:' 'name=http://host port=8080 host=host kind=http'
 # the fallback is the scheme's own default, not a hardcoded 8080
 p 'socks5://host:99999999999999' 'name=socks5://host port=1080 host=host kind=socks'
+
+selftest_run_queued

--- a/tests/01_engine-relative.test
+++ b/tests/01_engine-relative.test
@@ -5,27 +5,14 @@
 
 set -euo pipefail
 
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
 # relative path from <curr>'s directory to <link>
-rel() {
-    local got
-    got=$(httrack -O /dev/null -#test=relative "$1" "$2")
-    test "$got" == "relative=$3" ||
-        {
-            echo "FAIL rel($1, $2): got '$got' want 'relative=$3'"
-            exit 1
-        }
-}
+rel() { selftest_queue "relative=$3" relative "$1" "$2"; }
 
 # resolve <link> against origin <adr>/<fil> -> adr=.. fil=..
-ident() {
-    local got
-    got=$(httrack -O /dev/null -#test=resolve "$1" "$2" "$3")
-    test "$got" == "$4" ||
-        {
-            echo "FAIL ident($1, $2, $3): got '$got' want '$4'"
-            exit 1
-        }
-}
+ident() { selftest_queue "$4" resolve "$1" "$2" "$3"; }
 
 ### lienrelatif
 
@@ -65,4 +52,4 @@ ident 'file://srv/share/../x' 'www.foo.com' '/p.html' 'adr=file:// fil=//srv/x'
 ident 'mailto:foo@bar.com' 'www.foo.com' '/p.html' 'error=-1' # unsupported scheme
 ident 'javascript:void(0)' 'www.foo.com' '/p.html' 'error=-1'
 
-echo "OK"
+selftest_run_queued

--- a/tests/01_engine-savename.test
+++ b/tests/01_engine-savename.test
@@ -9,35 +9,24 @@ set -euo pipefail
 # name() asserts on the basename, full() on the whole path; prior= registers an
 # already-crawled link whose sav is rooted under the -O path (/dev/null here).
 
-httrack_bin=$(httrack_path)
+# Before the cd below: selftest_run_queued runs this engine too.
+HTTRACK_PATH=$(httrack_path)
 
 # scratch dir: body= and cached= write temp files (st-savename-body.tmp, hts-cache/)
 scratch=$(mktemp -d)
 cleanup_push rm -rf "$scratch"
 cd "$scratch"
 
-run() {
-    "$httrack_bin" -O /dev/null -#test=savename "$@" | sed -n 's/^savename: //p'
-}
-
 name() {
-    local fil="$1" ctype="$2" want="$3"
+    local fil=$1 ctype=$2 want=$3
     shift 3
-    out="$(run "$fil" "$ctype" "$@")"
-    test "${out##*/}" == "$want" || {
-        echo "FAIL: '$fil' '$ctype' $* -> '$out' (want '$want')"
-        exit 1
-    }
+    selftest_queue_tail "/$want" savename "$fil" "$ctype" "$@"
 }
 
 full() {
-    local fil="$1" ctype="$2" want="$3"
+    local fil=$1 ctype=$2 want=$3
     shift 3
-    out="$(run "$fil" "$ctype" "$@")"
-    test "$out" == "$want" || {
-        echo "FAIL: '$fil' '$ctype' $* -> '$out' (want '$want')"
-        exit 1
-    }
+    selftest_queue "savename: $want" savename "$fil" "$ctype" "$@"
 }
 
 # #115: an unknown trailing ".token" is part of the name, keep it and append the type.
@@ -154,7 +143,10 @@ full '/page.php?id=3&sid=42' 'text/html' '/dev/null/www.example.com/page475b.htm
 full '/../../etc/passwd' 'text/html' '/dev/null/www.example.com///etc/passwd.html'
 full '/%2e%2e/%2e%2e/etc/passwd' 'text/html' '/dev/null/www.example.com///etc/passwd.html'
 full '/x.php' 'application/pdf' '/dev/null/www.example.com///evil.exe' 'cdispo=../../evil.exe'
-name $'/evil\rname\t.php' 'text/html' 'evil name .html'
+# Not queued: those spaces are htsmain()'s rewrite of the CR and TAB, which only
+# an argv goes through.
+out=$("$HTTRACK_PATH" -O /dev/null -#test=savename $'/evil\rname\t.php' 'text/html')
+assert_eq 'evil name .html' "${out##*/}" 'control bytes in a fil'
 
 # #133: oversized names are capped only on Windows, where the name takes the
 # same 48-char clamp as a directory segment and keeps its extension across the
@@ -184,3 +176,5 @@ full '/HTS-TMP/a.bin' 'application/octet-stream' \
 # Control: the DOS device names this reuses must still be escaped.
 full '/nul/x.bin' 'application/octet-stream' \
     '/dev/null/www.example.com/nul_/x.bin'
+
+selftest_run_queued

--- a/tests/01_engine-savename.test
+++ b/tests/01_engine-savename.test
@@ -144,8 +144,12 @@ full '/../../etc/passwd' 'text/html' '/dev/null/www.example.com///etc/passwd.htm
 full '/%2e%2e/%2e%2e/etc/passwd' 'text/html' '/dev/null/www.example.com///etc/passwd.html'
 full '/x.php' 'application/pdf' '/dev/null/www.example.com///evil.exe' 'cdispo=../../evil.exe'
 # Not queued: those spaces are htsmain()'s rewrite of the CR and TAB, which only
-# an argv goes through.
-out=$("$HTTRACK_PATH" -O /dev/null -#test=savename $'/evil\rname\t.php' 'text/html')
+# an argv goes through. Assigned first, since MSYS drops the CR from a $'..' that
+# sits inside the command substitution; asserted, so a shell that drops it here
+# too says so rather than leaving the TAB to carry the case alone.
+fil=$'/evil\rname\t.php'
+assert_eq 15 "${#fil}" 'the shell kept both control bytes'
+out=$("$HTTRACK_PATH" -O /dev/null -#test=savename "$fil" 'text/html')
 assert_eq 'evil name .html' "${out##*/}" 'control bytes in a fil'
 
 # #133: oversized names are capped only on Windows, where the name takes the

--- a/tests/01_engine-simplify.test
+++ b/tests/01_engine-simplify.test
@@ -7,7 +7,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 # path simplify engine (fil_simplifie): collapses ./ and ../ segments.
-simp() { assert_selftest "simplified=$2" simplify "$1"; }
+simp() { selftest_queue "simplified=$2" simplify "$1"; }
 
 simp './foo/bar/' 'foo/bar/'
 simp './foo/bar' 'foo/bar'
@@ -41,3 +41,5 @@ simp '/' '/'
 
 simp 'a/b/..' 'a/'              # trailing bare '..'
 simp 'a/../b?x=../y' 'b?x=../y' # '?' freezes simplification
+
+selftest_run_queued

--- a/tests/01_engine-sniff.test
+++ b/tests/01_engine-sniff.test
@@ -3,17 +3,13 @@
 
 set -euo pipefail
 
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
 # MIME magic consistency (-#test=sniff <content-type> <hex:..|text>), the
 # tie-break behind htsname's wire-vs-extension naming.
 
-chk() {
-    local mime="$1" body="$2" want="$3"
-    out="$(httrack -#test=sniff "$mime" "$body" | sed -n 's/^sniff: //p')"
-    test "$out" == "$want" || {
-        echo "FAIL: '$mime' '$body' -> '$out' (want '$want')"
-        exit 1
-    }
-}
+chk() { selftest_queue "sniff: $3" sniff "$1" "$2"; }
 
 yes='known=1 consistent=1'
 no='known=1 consistent=0'
@@ -86,3 +82,5 @@ chk text/xml '<?xml version="1.0"?>' "$yes"
 chk text/css 'body { }' "$unk"
 chk text/plain 'hello' "$unk"
 chk application/x-javascript 'var x;' "$unk"
+
+selftest_run_queued

--- a/tests/131_local-savename-reserved.test
+++ b/tests/131_local-savename-reserved.test
@@ -7,25 +7,12 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-httrack_bin=$(httrack_path)
-
-scratch=$(mktemp -d)
-cleanup_push rm -rf "$scratch"
-cd "$scratch"
-
-tail_is() {
-    local fil="$1" want="$2"
+# The separator is not normalised: 01_engine-savename.test exact-compares whole
+# save paths on the Windows leg, so the engine spells them with '/' there too.
+tail_is() { # tail_is FIL WANT [ARGS...]
+    local fil=$1 want=$2
     shift 2
-    local out
-    out="$("$httrack_bin" -O "$scratch/out" -#test=savename "$fil" \
-        application/octet-stream "$@" | sed -n 's/^savename: //p')"
-    case "${out//\\//}" in
-    */"$want") ;;
-    *)
-        echo "FAIL: '$fil' $* -> '$out' (want tail '$want')"
-        exit 1
-        ;;
-    esac
+    selftest_queue_tail "/$want" savename "$fil" application/octet-stream "$@"
 }
 
 # A trailing space: cleanEndingSpaceOrDot() strips it again after the check.
@@ -61,3 +48,5 @@ tail_is '/d/a.bin' 'nul.example.com/d/a.bin' adr=nul.example.com
 tail_is '/d/a.bin' 'hts-cache.example.com/d/a.bin' adr=hts-cache.example.com
 # But a trailing run still resolves back to the bare name.
 tail_is '/a.bin' 'hts-tmp_/a.bin' adr='hts-tmp.'
+
+selftest_run_queued

--- a/tests/155_engine-escape-control.test
+++ b/tests/155_engine-escape-control.test
@@ -27,11 +27,9 @@ for c in "${cases[@]}"; do
     rest=${c#*:}
     len=${rest%%:*}
     out=${rest#*:}
-    got=$(httrack "-#test=escape-control" "hex:$in") ||
-        fail "hex:$in exited non-zero"
-    test "$got" = "escape-control: len=$len out=hex:$out" ||
-        fail "hex:$in: expected len=$len out=hex:$out, got: $got"
+    selftest_queue "escape-control: len=$len out=hex:$out" escape-control "hex:$in"
 done
+selftest_run_queued
 
 # The in-binary table also checks the bytes past the NUL, which printing cannot show.
 got=$(httrack "-#test=escape-control") || fail "self-test exited non-zero"

--- a/tests/264_engine-wizard-filter.test
+++ b/tests/264_engine-wizard-filter.test
@@ -10,15 +10,17 @@ set -euo pipefail
 # one back through the matcher that decides whether a link is authorized.
 
 # 2 forbids the host, 5 (allowed to go up) and 6 authorize it
-assert_selftest "-foo.com/*" wizardfilter 2 foo.com /a/b.html
-assert_selftest "+foo.com/*" wizardfilter 5 foo.com /a/b.html 1
-assert_selftest "+foo.com/*" wizardfilter 6 foo.com /a/b.html
+selftest_queue "-foo.com/*" wizardfilter 2 foo.com /a/b.html
+selftest_queue "+foo.com/*" wizardfilter 5 foo.com /a/b.html 1
+selftest_queue "+foo.com/*" wizardfilter 6 foo.com /a/b.html
 
 pattern=$(httrack -O /dev/null -#test=wizardfilter 6 foo.com /a/b.html)
 pattern=${pattern#+}
-assert_selftest "foo.com/b.html does match $pattern" filter "$pattern" foo.com/b.html
-assert_selftest "foo.com/ does match $pattern" filter "$pattern" foo.com/
-assert_selftest "foo.com.evil.org/x does NOT match $pattern" filter "$pattern" foo.com.evil.org/x
+selftest_queue "foo.com/b.html does match $pattern" filter "$pattern" foo.com/b.html
+selftest_queue "foo.com/ does match $pattern" filter "$pattern" foo.com/
+selftest_queue "foo.com.evil.org/x does NOT match $pattern" filter "$pattern" foo.com.evil.org/x
 
 # answers 0, 1, 5 (no up), 7, the ones adding nothing, credentials and port
-assert_selftest "wizardfilter self-test OK" wizardfilter
+selftest_queue "wizardfilter self-test OK" wizardfilter
+
+selftest_run_queued

--- a/tests/292_engine-wizard-scope.test
+++ b/tests/292_engine-wizard-scope.test
@@ -12,7 +12,7 @@ set -euo pipefail
 # The front end enumerates by looping until the engine stops answering. Strip
 # the CRs: MSYS hands the engine a text-mode stdout and $(...) eats only the
 # trailing newline, so an assertion spanning several lines keeps the interior
-# ones. Every other assert_selftest here compares a single line and cannot see
+# ones. Every other selftest_queue here compares a single line and cannot see
 # this.
 want="0 download.example.co.uk
 1 example.co.uk
@@ -21,8 +21,8 @@ got=$(httrack -O /dev/null -#test=wizardscope download.example.co.uk/x | tr -d '
 test "$got" = "$want" || fail "wizardscope enumeration: got [$got]"
 
 # widening stops before a bare TLD, and an IP literal offers nothing at all
-assert_selftest "0 example.com" wizardscope example.com/x
-assert_selftest "" wizardscope 192.168.1.1/x
+selftest_queue "0 example.com" wizardscope example.com/x
+selftest_queue "" wizardscope 192.168.1.1/x
 
 # answer 1000+1 is "example.co.uk and every host below it": two filters, since
 # the starred one misses the apex
@@ -32,19 +32,21 @@ test "$sub" = "+*.example.co.uk/*" || fail "subdomain filter: got [$sub]"
 test "$apex" = "+example.co.uk/*" || fail "apex filter: got [$apex]"
 
 for host in www.example.co.uk a.b.example.co.uk; do
-    assert_selftest "$host/x does match ${sub#+}" filter "${sub#+}" "$host/x"
+    selftest_queue "$host/x does match ${sub#+}" filter "${sub#+}" "$host/x"
 done
-assert_selftest "example.co.uk/x does NOT match ${sub#+}" filter "${sub#+}" example.co.uk/x
-assert_selftest "example.co.uk/x does match ${apex#+}" filter "${apex#+}" example.co.uk/x
+selftest_queue "example.co.uk/x does NOT match ${sub#+}" filter "${sub#+}" example.co.uk/x
+selftest_queue "example.co.uk/x does match ${apex#+}" filter "${apex#+}" example.co.uk/x
 
 # neither half may leak past the domain boundary
 for bad in notexample.co.uk/x example.co.uk.evil.com/x; do
-    assert_selftest "$bad does NOT match ${sub#+}" filter "${sub#+}" "$bad"
-    assert_selftest "$bad does NOT match ${apex#+}" filter "${apex#+}" "$bad"
+    selftest_queue "$bad does NOT match ${sub#+}" filter "${sub#+}" "$bad"
+    selftest_queue "$bad does NOT match ${apex#+}" filter "${apex#+}" "$bad"
 done
 
 # the exclude range emits the same pair negated
-assert_selftest "-*.example.co.uk/*" wizardfilter 2001 www.example.co.uk /x
+selftest_queue "-*.example.co.uk/*" wizardfilter 2001 www.example.co.uk /x
 
-assert_selftest "wizardscope self-test OK" wizardscope
-assert_selftest "wizardfilter self-test OK" wizardfilter
+selftest_queue "wizardscope self-test OK" wizardscope
+selftest_queue "wizardfilter self-test OK" wizardfilter
+
+selftest_run_queued

--- a/tests/297_engine-wizard-precedence.test
+++ b/tests/297_engine-wizard-precedence.test
@@ -11,18 +11,20 @@ set -euo pipefail
 list=$(httrack -O /dev/null -#test=wizardinsert h /dir/one.html 0 6)
 test "$list" = "-h/dir/one.html +h/*" || fail "answer order: got [$list]"
 # shellcheck disable=SC2086 # the array is one filter per word, by construction
-assert_selftest "verdict=allowed rule=1" filterdual http://h/dir/one.html h/dir/one.html $list
+selftest_queue "verdict=allowed rule=1" filterdual http://h/dir/one.html h/dir/one.html $list
 
 # the reverse order still refuses, so the block is ordered rather than sorted
 list=$(httrack -O /dev/null -#test=wizardinsert h /dir/one.html 6 0)
 test "$list" = "+h/* -h/dir/one.html" || fail "reverse order: got [$list]"
 # shellcheck disable=SC2086
-assert_selftest "verdict=forbidden rule=1" filterdual http://h/dir/one.html h/dir/one.html $list
+selftest_queue "verdict=forbidden rule=1" filterdual http://h/dir/one.html h/dir/one.html $list
 
 # a standing command-line rule is not revoked by "mirror the whole host"
 list=$(httrack -O /dev/null -#test=wizardinsert h /dir/one.html 6 @ "-h/*.zip")
 test "$list" = "+h/* -h/*.zip" || fail "command line: got [$list]"
 # shellcheck disable=SC2086
-assert_selftest "verdict=forbidden rule=1" filterdual http://h/a.zip h/a.zip $list
+selftest_queue "verdict=forbidden rule=1" filterdual http://h/a.zip h/a.zip $list
 
-assert_selftest "wizardinsert self-test OK" wizardinsert
+selftest_queue "wizardinsert self-test OK" wizardinsert
+
+selftest_run_queued

--- a/tests/298_engine-wizard-fallback.test
+++ b/tests/298_engine-wizard-fallback.test
@@ -10,32 +10,34 @@ set -euo pipefail
 # and say so, or it decides one link and the next one asks all over again.
 
 # an unreadable reply refuses, like the empty one the prompt documents
-assert_selftest "-foo.com/dir/page.html" wizardfilter -999 foo.com /dir/page.html
+selftest_queue "-foo.com/dir/page.html" wizardfilter -999 foo.com /dir/page.html
 reply=$(httrack -O /dev/null -#test=wizardverdict -999)
 grep -q "forbidden=1 stop=0 prio=42" <<<"$reply" || fail "-999 did not refuse: $reply"
 grep -q "could not read your answer" <<<"$reply" || fail "-999 refused silently: $reply"
 
 # a host with no domain below it takes the scope answer over the host itself
-assert_selftest "+127.0.0.1:8080/*" wizardfilter 1000 127.0.0.1:8080 /x
-assert_selftest "-localhost/*" wizardfilter 2000 localhost /x
-assert_selftest "-[::1]/*" wizardfilter 2000 "[::1]" /x
+selftest_queue "+127.0.0.1:8080/*" wizardfilter 1000 127.0.0.1:8080 /x
+selftest_queue "-localhost/*" wizardfilter 2000 localhost /x
+selftest_queue "-[::1]/*" wizardfilter 2000 "[::1]" /x
 # the brackets survive the matcher, which reads [name] forms as tokens
-assert_selftest "[::1]/x does match [::1]/*" filter '[::1]/*' '[::1]/x'
+selftest_queue "[::1]/x does match [::1]/*" filter '[::1]/*' '[::1]/x'
 # same past the last scope the host can offer (www.foo.com stops at 1001)
-assert_selftest "+www.foo.com/*" wizardfilter 1002 www.foo.com /x
+selftest_queue "+www.foo.com/*" wizardfilter 1002 www.foo.com /x
 # the companion slot stays empty, so the caller stops after the one filter
-assert_selftest "" wizardfilter 1000 127.0.0.1:8080 /x 0 1
+selftest_queue "" wizardfilter 1000 127.0.0.1:8080 /x 0 1
 
 # a host that does have scopes is honoured in full, so nothing is logged
-assert_selftest "forbidden=0 stop=0 prio=42" wizardverdict 1000
+selftest_queue "forbidden=0 stop=0 prio=42" wizardverdict 1000
 
 # the fallback is a rule that covers the rest of the host
 pattern='127.0.0.1:8080/*'
-assert_selftest "127.0.0.1:8080/two.html does match $pattern" filter "$pattern" 127.0.0.1:8080/two.html
-assert_selftest "127.0.0.1:8081/two.html does NOT match $pattern" filter "$pattern" 127.0.0.1:8081/two.html
+selftest_queue "127.0.0.1:8080/two.html does match $pattern" filter "$pattern" 127.0.0.1:8080/two.html
+selftest_queue "127.0.0.1:8081/two.html does NOT match $pattern" filter "$pattern" 127.0.0.1:8081/two.html
 
 # the prompt the answer is given about, host and path joined by one slash
-assert_selftest "foo.com/dir/page.html" wizardprompt foo.com /dir/page.html
-assert_selftest "foo.com/index.html" wizardprompt foo.com index.html
+selftest_queue "foo.com/dir/page.html" wizardprompt foo.com /dir/page.html
+selftest_queue "foo.com/index.html" wizardprompt foo.com index.html
 # a link longer than the prompt buffer is clipped, not fatal
-assert_selftest "wizardprompt self-test OK" wizardprompt
+selftest_queue "wizardprompt self-test OK" wizardprompt
+
+selftest_run_queued

--- a/tests/300_engine-wizard-filter-size.test
+++ b/tests/300_engine-wizard-filter-size.test
@@ -17,14 +17,16 @@ adr=$(printf 'a%.0s' $(seq 1 1023))
 for total in $(seq 2040 2047); do
     fil=/$(printf 'b%.0s' $(seq 1 $((total - ${#adr} - 3))))/
     test $((1 + ${#adr} + ${#fil})) -eq "$total" || fail "bad length for $total"
-    assert_selftest "-$adr$fil" wizardfilter 0 "$adr" "$fil"
-    assert_selftest "-$adr$fil*" wizardfilter 1 "$adr" "$fil"
-    assert_selftest "-$adr/*" wizardfilter 2 "$adr" "$fil"
-    assert_selftest "+$adr$fil*" wizardfilter 5 "$adr" "$fil"
-    assert_selftest "+$adr/*" wizardfilter 6 "$adr" "$fil"
-    assert_selftest "+$adr$fil*[file]" wizardfilter 7 "$adr" "$fil"
+    selftest_queue "-$adr$fil" wizardfilter 0 "$adr" "$fil"
+    selftest_queue "-$adr$fil*" wizardfilter 1 "$adr" "$fil"
+    selftest_queue "-$adr/*" wizardfilter 2 "$adr" "$fil"
+    selftest_queue "+$adr$fil*" wizardfilter 5 "$adr" "$fil"
+    selftest_queue "+$adr/*" wizardfilter 6 "$adr" "$fil"
+    selftest_queue "+$adr$fil*[file]" wizardfilter 7 "$adr" "$fil"
 done
 
 # a command line cannot express the rest of the sweep, up to both link buffers
 # full; the self-test carries it
-assert_selftest "wizardfilter self-test OK" wizardfilter
+selftest_queue "wizardfilter self-test OK" wizardfilter
+
+selftest_run_queued

--- a/tests/301_engine-savename-bounds.test
+++ b/tests/301_engine-savename-bounds.test
@@ -7,11 +7,11 @@ set -euo pipefail
 
 # url_savename_addstr() appends a crawled link to afs->save; with no size cap it
 # wrote past the buffer (#1269).
-assert_selftest "savename-addstr self-test OK" savename-addstr
+selftest_queue "savename-addstr self-test OK" savename-addstr
 
 # url_savename_addtail() carries the default name and the extension onto a link
 # that already fills that buffer, where strcatbuff used to abort instead.
-assert_selftest "savename-addtail self-test OK, save 2048 bytes" savename-addtail
+selftest_queue "savename-addtail self-test OK, save 2048 bytes" savename-addtail
 
 httrack_bin=$(httrack_path)
 
@@ -68,3 +68,5 @@ out=$("$httrack_bin" -O /dev/null -#test=savename /x.html text/html type=-1 2>&1
 assert_match "needs a userdef" "$out" "type=-1 guard"
 name=$(savename 900 '/*/x.html' 'userdef=%h%p/%n%q.%t')
 assert_match '[.]html$' "$name" "userdef naming"
+
+selftest_run_queued

--- a/tests/301_engine-savename-bounds.test
+++ b/tests/301_engine-savename-bounds.test
@@ -15,15 +15,20 @@ selftest_queue "savename-addtail self-test OK, save 2048 bytes" savename-addtail
 
 httrack_bin=$(httrack_path)
 
-# Emits the save name. -#test=savename poisons the bytes behind save[] and exits
-# non-zero if the naming path touched them, so a breach fails here. filpad=N
+# -#test=savename poisons the bytes behind save[] and exits non-zero if the
+# naming path touched them, so a breach reds the case whatever it names. filpad=N
 # expands '*' into N bytes, past what argv can carry (HTS_CDLMAXSIZE).
-savename() { # savename PAD FIL [ARGS...]
-    local pad=$1 fil=$2 out
+# The two properties the cases below assert, one per helper:
+keeps_ext() { # keeps_ext PAD FIL [ARGS...]
+    local pad=$1 fil=$2
     shift 2
-    out=$("$httrack_bin" -O /dev/null -#test=savename "$fil" text/html \
-        "filpad=$pad" "$@" 2>&1) || fail "$fil pad $pad: exited non-zero: $out"
-    printf '%s\n' "${out#savename: }"
+    selftest_queue_tail '.html' savename "$fil" text/html "filpad=$pad" "$@"
+}
+stays_rooted() { # stays_rooted PAD FIL [ARGS...]
+    local pad=$1 fil=$2
+    shift 2
+    selftest_queue_head 'savename: /dev/null/' savename "$fil" text/html \
+        "filpad=$pad" "$@"
 }
 
 # A 1000-byte host plus these pads puts the intermediate name either side of the
@@ -33,16 +38,11 @@ for fil in '/*/x.html' '/dir/*.html'; do
     # Whatever fits must keep every byte, extension included. Clipping the
     # intermediate early costs the name the .html the shortener would have kept.
     for pad in 900 990 1030; do
-        name=$(savename "$pad" "$fil" "adr=$long_host")
-        case $name in
-        *.html) ;;
-        *) fail "$fil pad $pad: lost its extension: ${name: -40}" ;;
-        esac
+        keeps_ext "$pad" "$fil" "adr=$long_host"
     done
     # Past the end, the name is cut but nothing may land behind save[].
     for pad in 1500 2030; do
-        name=$(savename "$pad" "$fil" "adr=$long_host")
-        assert_match "^/dev/null/" "$name" "$fil pad $pad"
+        stays_rooted "$pad" "$fil" "adr=$long_host"
     done
 done
 
@@ -54,11 +54,10 @@ for spec in '/*/:2036:' '/dir/*:2038:' '/*/x:2040:' \
     fil=${spec%%:*} rest=${spec#*:}
     pad=${rest%%:*} extra=${rest#*:}
     if [ -n "$extra" ]; then
-        name=$(savename "$pad" "$fil" "adr=$long_host" "$extra")
+        stays_rooted "$pad" "$fil" "adr=$long_host" "$extra"
     else
-        name=$(savename "$pad" "$fil")
+        stays_rooted "$pad" "$fil"
     fi
-    assert_match "^/dev/null/" "$name" "$fil pad $pad"
 done
 
 # -N is the only caller that selects savename_type -1, and it always sets the
@@ -66,7 +65,6 @@ done
 out=$("$httrack_bin" -O /dev/null -#test=savename /x.html text/html type=-1 2>&1) &&
     fail "type=-1 without a template was accepted: $out"
 assert_match "needs a userdef" "$out" "type=-1 guard"
-name=$(savename 900 '/*/x.html' 'userdef=%h%p/%n%q.%t')
-assert_match '[.]html$' "$name" "userdef naming"
+keeps_ext 900 '/*/x.html' 'userdef=%h%p/%n%q.%t'
 
 selftest_run_queued

--- a/tests/311_engine-location-gate.test
+++ b/tests/311_engine-location-gate.test
@@ -11,13 +11,13 @@ set -euo pipefail
 # matches what the contract says to keep, and whether the 64-byte canary behind
 # the buffer survived. Cache side: 01_zlib-cache.test.
 kept() { # kept URLLEN KEPTLEN
-    assert_selftest \
+    selftest_queue \
         "asked=$1 kept=$2 value_ok=1 canary_smashed=0 logged=0" location "$1"
 }
 
 # Refused lengths must say so rather than drop the redirect mutely.
 refused() { # refused URLLEN
-    assert_selftest \
+    selftest_queue \
         "asked=$1 kept=0 value_ok=1 canary_smashed=0 logged=1" location "$1"
 }
 
@@ -45,9 +45,9 @@ refused 3000
 # block's end, which must never happen.
 line() { # line READSIZE BLOCK WANT
     if [ -n "$2" ]; then
-        assert_selftest_lines "$3" headerline "$1" "$2"
+        selftest_queue_lines "$3" headerline "$1" "$2"
     else
-        assert_selftest_lines "$3" headerline "$1"
+        selftest_queue_lines "$3" headerline "$1"
     fi
 }
 
@@ -88,3 +88,5 @@ line 8 'A\r: 1\n' 'cut=0 over=0 line=A: 1
 cut=0 over=0 line=
 cut=0 over=0 line=
 cut=0 over=0 line='
+
+selftest_run_queued

--- a/tests/314_engine-selftest-batch.test
+++ b/tests/314_engine-selftest-batch.test
@@ -47,34 +47,111 @@ assert_selftest 'a b does match a b' filter 'a b' 'a	b'
 selftest_queue 'a	b does NOT match a b' filter 'a b' 'a	b'
 selftest_run_queued
 
-# A case's exit code rides the framing, not the process status: a failing case
-# (filter with no pattern) must not hide the passing one after it.
+# Each mode needs a want it REJECTS, or a compare that degenerated into "always
+# true" would pass this file having proved nothing. Runs in a subshell, whose
+# queue and failure do not escape.
+rejects() { # rejects LABEL QUEUE-CALL...
+    local label=$1
+    shift
+    ("$@" && selftest_run_queued) >/dev/null 2>&1 &&
+        fail "$label: a wrong want was accepted"
+    return 0
+}
+
+# tail mode: only 01_engine-savename.test uses it, and only for save names.
+selftest_queue_tail '/x.html' savename '/x.php' 'text/html'
+selftest_run_queued
+rejects 'tail' selftest_queue_tail '/no-such-name' savename '/x.php' 'text/html'
+# A suffix, never a substring: '/x.ht' sits inside the name it must not match.
+rejects 'tail matching mid-name' selftest_queue_tail '/x.ht' savename '/x.php' 'text/html'
+
+# lines mode: only 311_engine-location-gate.test uses it, and there only for
+# multi-line output.
+selftest_queue_lines "a.gif is 'image/gif'
+and its local type is '.gif'" mime a.gif
+selftest_run_queued
+rejects 'lines' selftest_queue_lines 'a.gif is only one line' mime a.gif
+
+# The CR half of lines mode is what Windows needs and no runner off it produces,
+# so drive it from a case that emits a CRLF whatever the platform.
+selftest_queue_lines 'A
+B' charset iso-8859-1 hex:410d0a42
+# ...and exact mode must NOT strip it, or the two modes are one.
+selftest_queue "A${SELFTEST_CR}
+B" charset iso-8859-1 hex:410d0a42
+selftest_run_queued
+rejects 'lines keeping a CR' selftest_queue_lines "A${SELFTEST_CR}
+B" charset iso-8859-1 hex:410d0a42
+# A CR on the last line goes through a different branch than an interior one.
+selftest_queue_lines 'A' charset iso-8859-1 hex:410d
+selftest_queue "A${SELFTEST_CR}" charset iso-8859-1 hex:410d
+selftest_run_queued
+
+# A self-test that printed the framing byte itself would pair every later case
+# with the wrong want; the records left over are what give it away.
+rejects 'a case that emits the record separator' \
+    selftest_queue 'A' charset iso-8859-1 hex:411e301e43
+
+# A case that exits non-zero fails even when its output is what was wanted.
+rejects 'a case that exits non-zero' selftest_queue '' filter
+
+# An unknown mode must not fall through to the exact compare, which would accept
+# every case a typo'd selftest_queue_lines was meant to compare leniently.
+rejects 'an unknown compare mode' \
+    selftest_queue_mode bogus 'z does NOT match y' filter y z
+
+# A case's exit code rides the framing, not the process status, and does so
+# wherever the case sits: a failing one (filter with no pattern) must neither
+# hide the case after it nor be the only position that reports honestly.
 script=$(mktemp)
 cleanup_push rm -f "$script"
-printf '%s\0' 0 filter 1 mime 'a.gif' >"$script"
+printf '%s\0' 1 mime 'a.gif' 0 filter 1 mime 'a.html' >"$script"
 rc=0
 out=$(httrack -O /dev/null -#test=batch <"$script" 2>/dev/null) || rc=$?
 assert_eq 0 "$rc" "batch status over a failing case"
 assert_match "${SELFTEST_RS}1${SELFTEST_RS}" "$out" "the failing case's exit code"
-assert_match "a.gif is 'image/gif'" "$out" "the case after the failing one"
+assert_match "a.html is 'text/html'" "$out" "the case after the failing one"
 
-# A truncated script is refused rather than half-run.
-printf '%s\0' 2 filter '*' >"$script"
-rc=0
-httrack -O /dev/null -#test=batch <"$script" >/dev/null 2>&1 || rc=$?
-assert_eq 1 "$rc" "status on a script missing an argument"
+# Malformed scripts are refused rather than half-run. A header that is not a
+# number would otherwise read as zero args and swallow the next case's fields.
+refuses() { # refuses LABEL FIELD...
+    local label=$1
+    shift
+    printf '%s\0' "$@" >"$script"
+    rc=0
+    httrack -O /dev/null -#test=batch <"$script" >/dev/null 2>&1 || rc=$?
+    assert_eq 1 "$rc" "status on $label"
+}
+refuses 'a script missing an argument' 2 filter '*'
+refuses 'a non-numeric argument count' x filter '*' y
+refuses 'an argument count past the cap' 4096 filter '*'
+refuses 'a negative argument count' -1 filter
 
 # Queued cases assert nothing until the flush, so a file that forgets it passes
 # on any engine output. The EXIT trap cannot say so (#773 keeps teardown out of
-# the verdict), so the check is static.
-scanned=0
-undrained=
-for f in "$top_srcdir"/tests/*.test; do
-    test -r "$f" || continue
-    scanned=$((scanned + 1))
-    grep -q 'selftest_queue' "$f" || continue
-    grep -q 'selftest_run_queued' "$f" || undrained="$undrained $f"
-done
+# the verdict), hence a static check.
+# Sets SCANNED and UNDRAINED rather than printing them: a command substitution
+# would run the whole scan in a subshell and lose both counts.
+undrained_in() { # undrained_in DIR
+    local f
+    SCANNED=0
+    UNDRAINED=
+    for f in "$1"/*.test; do
+        test -r "$f" || continue
+        SCANNED=$((SCANNED + 1))
+        grep -q 'selftest_queue' "$f" || continue
+        grep -q 'selftest_run_queued' "$f" || UNDRAINED="$UNDRAINED $f"
+    done
+}
+
+# Teeth first: a check that scans nothing reports every tree clean.
+fixture=$(mktemp -d)
+cleanup_push rm -rf "$fixture"
+printf 'selftest_queue x filter y z\n' >"$fixture/900_forgot.test"
+undrained_in "$fixture"
+test -n "$UNDRAINED" || fail "the drain check passed a file that never flushes"
+
+undrained_in "$top_srcdir/tests"
 # An unexpanded glob would report no offender having read nothing.
-test "$scanned" -ge 50 || fail "scanned $scanned tests in $top_srcdir/tests, want the whole suite"
-test -z "$undrained" || fail "queued self-tests that never run:$undrained"
+test "$SCANNED" -ge 50 || fail "scanned $SCANNED tests in $top_srcdir/tests, want the whole suite"
+test -z "$UNDRAINED" || fail "queued self-tests that never run:$UNDRAINED"

--- a/tests/314_engine-selftest-batch.test
+++ b/tests/314_engine-selftest-batch.test
@@ -58,12 +58,18 @@ rejects() { # rejects LABEL QUEUE-CALL...
     return 0
 }
 
-# tail mode: only 01_engine-savename.test uses it, and only for save names.
+# tail and head: one end of a save name, where the other end is a path the
+# caller has no reason to spell out.
 selftest_queue_tail '/x.html' savename '/x.php' 'text/html'
+selftest_queue_head 'savename: /dev/null/' savename '/x.php' 'text/html'
 selftest_run_queued
 rejects 'tail' selftest_queue_tail '/no-such-name' savename '/x.php' 'text/html'
-# A suffix, never a substring: '/x.ht' sits inside the name it must not match.
+rejects 'head' selftest_queue_head 'savename: /nowhere/' savename '/x.php' 'text/html'
+# One end, never a substring: each want below sits inside the output it must not
+# match, one short of the end it anchors to.
 rejects 'tail matching mid-name' selftest_queue_tail '/x.ht' savename '/x.php' 'text/html'
+rejects 'head matching mid-output' selftest_queue_head 'avename: /dev/null/' \
+    savename '/x.php' 'text/html'
 
 # lines mode: only 311_engine-location-gate.test uses it, and there only for
 # multi-line output.

--- a/tests/314_engine-selftest-batch.test
+++ b/tests/314_engine-selftest-batch.test
@@ -78,20 +78,18 @@ and its local type is '.gif'" mime a.gif
 selftest_run_queued
 rejects 'lines' selftest_queue_lines 'a.gif is only one line' mime a.gif
 
-# The CR half of lines mode is what Windows needs and no runner off it produces,
-# so drive it from a case that emits a CRLF whatever the platform.
-selftest_queue_lines 'A
+# The CR half of lines mode needs an interior CRLF, which off Windows only a
+# case that emits one can give. On Windows text mode doubles that injected CR,
+# so there the coverage comes from 311 and mime, whose CRLFs are text mode's own.
+if ! is_windows; then
+    selftest_queue_lines 'A
 B' charset iso-8859-1 hex:410d0a42
-# ...and exact mode must NOT strip it, or the two modes are one.
-selftest_queue "A${SELFTEST_CR}
+    # A CR on the last line takes the trailing-strip branch, not that one.
+    selftest_queue_lines 'A' charset iso-8859-1 hex:410d
+    selftest_run_queued
+    rejects 'lines keeping a CR' selftest_queue_lines "A${SELFTEST_CR}
 B" charset iso-8859-1 hex:410d0a42
-selftest_run_queued
-rejects 'lines keeping a CR' selftest_queue_lines "A${SELFTEST_CR}
-B" charset iso-8859-1 hex:410d0a42
-# A CR on the last line goes through a different branch than an interior one.
-selftest_queue_lines 'A' charset iso-8859-1 hex:410d
-selftest_queue "A${SELFTEST_CR}" charset iso-8859-1 hex:410d
-selftest_run_queued
+fi
 
 # A self-test that printed the framing byte itself would pair every later case
 # with the wrong want; the records left over are what give it away.

--- a/tests/314_engine-selftest-batch.test
+++ b/tests/314_engine-selftest-batch.test
@@ -70,6 +70,9 @@ rejects 'head' selftest_queue_head 'savename: /nowhere/' savename '/x.php' 'text
 rejects 'tail matching mid-name' selftest_queue_tail '/x.ht' savename '/x.php' 'text/html'
 rejects 'head matching mid-output' selftest_queue_head 'avename: /dev/null/' \
     savename '/x.php' 'text/html'
+# An empty want anchors to nothing and would match whatever the engine printed.
+rejects 'an empty tail want' selftest_queue_tail '' savename '/x.php' 'text/html'
+rejects 'an empty head want' selftest_queue_head '' savename '/x.php' 'text/html'
 
 # lines mode: only 311_engine-location-gate.test uses it, and there only for
 # multi-line output.

--- a/tests/314_engine-selftest-batch.test
+++ b/tests/314_engine-selftest-batch.test
@@ -1,0 +1,80 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+# -#test=batch must be indistinguishable from one process per case: same bytes,
+# same exit code, and nothing carried from one case to the next. Each case below
+# is run on its own first, and that output is what the batch is asserted against.
+
+# <argc> <name> <args...>, the engine's own script format.
+# Every option-writing case is followed by one that omits the option and would
+# answer differently if the write had survived into it.
+cases=(
+    3 savename '/verylongfilename.php' 'text/html' n83=1
+    2 savename '/verylongfilename.php' 'text/html'
+    3 savename '/dir/page.php' 'text/html' 'userdef=%h/%n.%t'
+    2 savename '/dir/page.php' 'text/html'
+    1 mime 'a.gif'
+    1 mime 'a.html'
+    0 urlhack
+    0 stripquery
+)
+
+i=0
+queued=0
+while test "$i" -lt "${#cases[@]}"; do
+    argc=${cases[i]}
+    name=${cases[i + 1]}
+    args=(${cases[@]+"${cases[@]:i+2:argc}"})
+    i=$((i + 2 + argc))
+    rc=0
+    want=$(httrack -O /dev/null "-#test=$name" ${args[@]+"${args[@]}"}) || rc=$?
+    test "$rc" -eq 0 || fail "-#test=$name: exited $rc on its own, output: $want"
+    selftest_queue "$want" "$name" ${args[@]+"${args[@]}"}
+    queued=$((queued + 1))
+done
+# A mis-parsed list would queue nothing and leave every compare below vacuous.
+assert_eq 8 "$queued" "cases read out of the list"
+selftest_run_queued
+
+# Where the two routes part: a queued arg reaches the handler as written, an
+# argv has had its CR, LF and TAB squashed to a space by htsmain() first.
+assert_selftest 'a b does match a b' filter 'a b' 'a	b'
+selftest_queue 'a	b does NOT match a b' filter 'a b' 'a	b'
+selftest_run_queued
+
+# A case's exit code rides the framing, not the process status: a failing case
+# (filter with no pattern) must not hide the passing one after it.
+script=$(mktemp)
+cleanup_push rm -f "$script"
+printf '%s\0' 0 filter 1 mime 'a.gif' >"$script"
+rc=0
+out=$(httrack -O /dev/null -#test=batch <"$script" 2>/dev/null) || rc=$?
+assert_eq 0 "$rc" "batch status over a failing case"
+assert_match "${SELFTEST_RS}1${SELFTEST_RS}" "$out" "the failing case's exit code"
+assert_match "a.gif is 'image/gif'" "$out" "the case after the failing one"
+
+# A truncated script is refused rather than half-run.
+printf '%s\0' 2 filter '*' >"$script"
+rc=0
+httrack -O /dev/null -#test=batch <"$script" >/dev/null 2>&1 || rc=$?
+assert_eq 1 "$rc" "status on a script missing an argument"
+
+# Queued cases assert nothing until the flush, so a file that forgets it passes
+# on any engine output. The EXIT trap cannot say so (#773 keeps teardown out of
+# the verdict), so the check is static.
+scanned=0
+undrained=
+for f in "$top_srcdir"/tests/*.test; do
+    test -r "$f" || continue
+    scanned=$((scanned + 1))
+    grep -q 'selftest_queue' "$f" || continue
+    grep -q 'selftest_run_queued' "$f" || undrained="$undrained $f"
+done
+# An unexpanded glob would report no offender having read nothing.
+test "$scanned" -ge 50 || fail "scanned $scanned tests in $top_srcdir/tests, want the whole suite"
+test -z "$undrained" || fail "queued self-tests that never run:$undrained"

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -101,16 +101,24 @@ selftest_queue_lines() { # selftest_queue_lines WANT NAME [ARGS...]
     selftest_queue_mode lines "$@"
 }
 
-# selftest_queue asserting only the tail, for a save name under a directory the
-# caller need not spell out. WANT is literal and carries its own boundary.
+# selftest_queue asserting one end of the output rather than all of it, for a
+# name whose other end the caller has no reason to spell out. Both WANTs are
+# literal and carry their own boundary ("/name", not "name").
 selftest_queue_tail() { # selftest_queue_tail WANT NAME [ARGS...]
     selftest_queue_mode tail "$@"
+}
+
+selftest_queue_head() { # selftest_queue_head WANT NAME [ARGS...]
+    selftest_queue_mode head "$@"
 }
 
 selftest_queue_mode() { # selftest_queue_mode exact|lines|tail WANT NAME [ARGS...]
     local mode=$1 want=$2 name=$3
     shift 3
-    case $mode in exact | lines | tail) ;; *) fail "unknown selftest mode $mode" ;; esac
+    case $mode in
+    exact | lines | tail | head) ;;
+    *) fail "unknown selftest mode $mode" ;;
+    esac
     SELFTEST_WANT+=("$want")
     SELFTEST_MODE+=("$mode")
     SELFTEST_LABEL+=("-#test=$name $*")
@@ -156,16 +164,23 @@ selftest_run_queued() {
         fi
         want=${SELFTEST_WANT[i]}
         test "$rc" -eq 0 || fail "${SELFTEST_LABEL[i]}: exited $rc, output: $got"
-        if test "${SELFTEST_MODE[i]}" = tail; then
-            # A case pattern, where the quoted want stays literal even if the
-            # name it pins carries a '*' or a '['.
+        # Case patterns, where the quoted want stays literal even when the name
+        # it pins carries a '*' or a '['.
+        case ${SELFTEST_MODE[i]} in
+        tail)
             case $got in
             *"$want") ;;
             *) fail "${SELFTEST_LABEL[i]}: expected an output ending [$want], got [$got]" ;;
             esac
-        else
-            test "$got" = "$want" || fail "${SELFTEST_LABEL[i]}: expected [$want], got [$got]"
-        fi
+            ;;
+        head)
+            case $got in
+            "$want"*) ;;
+            *) fail "${SELFTEST_LABEL[i]}: expected an output starting [$want], got [$got]" ;;
+            esac
+            ;;
+        *) test "$got" = "$want" || fail "${SELFTEST_LABEL[i]}: expected [$want], got [$got]" ;;
+        esac
     done
     # The count must close exactly: a case the engine ran and nobody asserted,
     # or a self-test that printed the framing byte itself, both land here.

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -74,14 +74,114 @@ assert_selftest_lines() { # assert_selftest_lines WANT NAME [ARGS...]
     test "$got" = "$want" || fail "-#test=$name $*: expected [$want], got [$got]"
 }
 
+# Batched form of the two asserts above: selftest_queue records a case,
+# selftest_run_queued runs a whole file's cases in ONE httrack (-#test=batch in
+# htsselftest.c), which the Windows legs care about most (#795). Same contract,
+# except a mismatch surfaces at the flush, named. A case whose output later shell
+# logic reads, or that means to exercise an argv rewrite, stays on assert_selftest.
+SELFTEST_RS=$(printf '\036')
+SELFTEST_CR=$(printf '\r')
+SELFTEST_SCRIPT=${SELFTEST_SCRIPT:-}
+# Self-preserving, as CLEANUP_ARGV below and for the same reason. ARGV holds
+# <argc> <name> <args...> per case, which is the engine's own script format.
+SELFTEST_ARGV=(${SELFTEST_ARGV[@]+"${SELFTEST_ARGV[@]}"})
+SELFTEST_WANT=(${SELFTEST_WANT[@]+"${SELFTEST_WANT[@]}"})
+SELFTEST_MODE=(${SELFTEST_MODE[@]+"${SELFTEST_MODE[@]}"})
+SELFTEST_LABEL=(${SELFTEST_LABEL[@]+"${SELFTEST_LABEL[@]}"})
+
+selftest_queue() { # selftest_queue WANT NAME [ARGS...]
+    selftest_queue_mode exact "$@"
+}
+
+# selftest_queue for output spanning several lines (see assert_selftest_lines).
+selftest_queue_lines() { # selftest_queue_lines WANT NAME [ARGS...]
+    selftest_queue_mode lines "$@"
+}
+
+# selftest_queue asserting only the tail, for a save name under a directory the
+# caller need not spell out. WANT is literal and carries its own boundary.
+selftest_queue_tail() { # selftest_queue_tail WANT NAME [ARGS...]
+    selftest_queue_mode tail "$@"
+}
+
+selftest_queue_mode() { # selftest_queue_mode exact|lines|tail WANT NAME [ARGS...]
+    local mode=$1 want=$2 name=$3
+    shift 3
+    SELFTEST_WANT+=("$want")
+    SELFTEST_MODE+=("$mode")
+    SELFTEST_LABEL+=("-#test=$name $*")
+    SELFTEST_ARGV+=("$#" "$name" ${1+"$@"})
+    test "${#SELFTEST_WANT[@]}" -ne 1 || {
+        SELFTEST_SCRIPT=${TMPDIR:-/tmp}/httrack-selftest-batch.$$
+        cleanup_push rm -f "$SELFTEST_SCRIPT"
+    }
+}
+
+# Run every queued case and assert each. The script goes through a file, not a
+# pipe: printf is a builtin, so this costs no fork of its own. Args travel on
+# stdin because the engine parses argv before it reaches the self-test dispatch,
+# and would take a case's '-*' for one of its own filters.
+selftest_run_queued() {
+    local n=${#SELFTEST_WANT[@]} out rest got want rc=0 i
+    test "$n" -gt 0 || return 0
+    printf '%s\0' "${SELFTEST_ARGV[@]}" >"$SELFTEST_SCRIPT" ||
+        fail "cannot write $SELFTEST_SCRIPT"
+    # By path, not by name: a file that cd'd away can no longer reach make
+    # check's relative ../src, and it resolved this before it moved.
+    test -n "$HTTRACK_PATH" || httrack_path >/dev/null
+    out=$("$HTTRACK_PATH" -O /dev/null -#test=batch <"$SELFTEST_SCRIPT") || rc=$?
+    rm -f "$SELFTEST_SCRIPT"
+    test "$rc" -eq 0 || fail "-#test=batch: exited $rc over $n cases, output: $out"
+    rest=$out
+    for ((i = 0; i < n; i++)); do
+        got=${rest%%"$SELFTEST_RS"*}
+        rest=${rest#*"$SELFTEST_RS"}
+        rc=${rest%%"$SELFTEST_RS"*}
+        rest=${rest#*"$SELFTEST_RS"}
+        case $rc in '' | *[!0-9]*)
+            fail "-#test=batch: framing lost at case $((i + 1)) of $n, output: $out"
+            ;;
+        esac
+        # What a command substitution would have dropped around a lone case.
+        while test "${got%"$TESTLIB_NL"}" != "$got"; do got=${got%"$TESTLIB_NL"}; done
+        if test "${SELFTEST_MODE[i]}" = lines; then
+            got=${got//"$SELFTEST_CR$TESTLIB_NL"/"$TESTLIB_NL"}
+            got=${got%"$SELFTEST_CR"}
+        fi
+        want=${SELFTEST_WANT[i]}
+        test "$rc" -eq 0 || fail "${SELFTEST_LABEL[i]}: exited $rc, output: $got"
+        if test "${SELFTEST_MODE[i]}" = tail; then
+            # A case pattern, where the quoted want stays literal even if the
+            # name it pins carries a '*' or a '['.
+            case $got in
+            *"$want") ;;
+            *) fail "${SELFTEST_LABEL[i]}: expected an output ending [$want], got [$got]" ;;
+            esac
+        else
+            test "$got" = "$want" || fail "${SELFTEST_LABEL[i]}: expected [$want], got [$got]"
+        fi
+    done
+    SELFTEST_ARGV=()
+    SELFTEST_WANT=()
+    SELFTEST_MODE=()
+    SELFTEST_LABEL=()
+}
+
 # Absolute path to httrack, since make check's relative ../src breaks once a test
 # cd's away. assert_selftest runs the bare name, so a test that cd's calls this.
+# Memoized in HTTRACK_PATH, which selftest_run_queued runs too: a test that cd's
+# and queues must assign it (HTTRACK_PATH=$(httrack_path)) before it moves, the
+# memo a bare $(httrack_path) writes dying with its subshell.
+HTTRACK_PATH=${HTTRACK_PATH:-}
 httrack_path() {
     local p dir
-    p=$(command -v httrack) || fail "no httrack in PATH"
-    # Assigned, so a failed cd is named here instead of yielding a bare /httrack.
-    dir=$(cd "$(dirname "$p")" && pwd) || fail "cannot reach $(dirname "$p")"
-    printf '%s\n' "$dir/$(basename "$p")"
+    if test -z "$HTTRACK_PATH"; then
+        p=$(command -v httrack) || fail "no httrack in PATH"
+        # Assigned, so a failed cd is named here instead of a bare /httrack.
+        dir=$(cd "$(dirname "$p")" && pwd) || fail "cannot reach $(dirname "$p")"
+        HTTRACK_PATH=$dir/$(basename "$p")
+    fi
+    printf '%s\n' "$HTTRACK_PATH"
 }
 
 # A literal, not $'..': Apple's bash 3.2 loses quote state on that inside a

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -156,12 +156,18 @@ selftest_run_queued() {
             fail "-#test=batch: framing lost at case $((i + 1)) of $n, output: $out"
             ;;
         esac
-        # What a command substitution would have dropped around a lone case.
-        while test "${got%"$TESTLIB_NL"}" != "$got"; do got=${got%"$TESTLIB_NL"}; done
-        if test "${SELFTEST_MODE[i]}" = lines; then
+        # What a command substitution drops around a lone case. The CR goes
+        # with it: Windows stdout is text mode, so every case ends CRLF there
+        # and MSYS strips the pair. Interior ones are lines mode's business.
+        while :; do
+            case $got in
+            *"$TESTLIB_NL") got=${got%"$TESTLIB_NL"} ;;
+            *"$SELFTEST_CR") got=${got%"$SELFTEST_CR"} ;;
+            *) break ;;
+            esac
+        done
+        test "${SELFTEST_MODE[i]}" != lines ||
             got=${got//"$SELFTEST_CR$TESTLIB_NL"/"$TESTLIB_NL"}
-            got=${got%"$SELFTEST_CR"}
-        fi
         want=${SELFTEST_WANT[i]}
         test "$rc" -eq 0 || fail "${SELFTEST_LABEL[i]}: exited $rc, output: $got"
         # Case patterns, where the quoted want stays literal even when the name

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -74,14 +74,17 @@ assert_selftest_lines() { # assert_selftest_lines WANT NAME [ARGS...]
     test "$got" = "$want" || fail "-#test=$name $*: expected [$want], got [$got]"
 }
 
-# Batched form of the two asserts above: selftest_queue records a case,
+# Batched form of the two asserts above: selftest_queue records a case, and
 # selftest_run_queued runs a whole file's cases in ONE httrack (-#test=batch in
-# htsselftest.c), which the Windows legs care about most (#795). Same contract,
-# except a mismatch surfaces at the flush, named. A case whose output later shell
-# logic reads, or that means to exercise an argv rewrite, stays on assert_selftest.
+# htsselftest.c), which the Windows legs pay dearly for otherwise (#795).
+# Same contract, except a mismatch surfaces at the flush, named. A case whose
+# output later shell logic reads, or that exercises one of htsmain()'s argv
+# rewrites, stays on assert_selftest.
 SELFTEST_RS=$(printf '\036')
 SELFTEST_CR=$(printf '\r')
 SELFTEST_SCRIPT=${SELFTEST_SCRIPT:-}
+# Where the file started, to catch a cd that leaves HTTRACK_PATH unresolvable.
+TESTLIB_PWD=${TESTLIB_PWD:-$PWD}
 # Self-preserving, as CLEANUP_ARGV below and for the same reason. ARGV holds
 # <argc> <name> <args...> per case, which is the engine's own script format.
 SELFTEST_ARGV=(${SELFTEST_ARGV[@]+"${SELFTEST_ARGV[@]}"})
@@ -107,6 +110,7 @@ selftest_queue_tail() { # selftest_queue_tail WANT NAME [ARGS...]
 selftest_queue_mode() { # selftest_queue_mode exact|lines|tail WANT NAME [ARGS...]
     local mode=$1 want=$2 name=$3
     shift 3
+    case $mode in exact | lines | tail) ;; *) fail "unknown selftest mode $mode" ;; esac
     SELFTEST_WANT+=("$want")
     SELFTEST_MODE+=("$mode")
     SELFTEST_LABEL+=("-#test=$name $*")
@@ -126,8 +130,10 @@ selftest_run_queued() {
     test "$n" -gt 0 || return 0
     printf '%s\0' "${SELFTEST_ARGV[@]}" >"$SELFTEST_SCRIPT" ||
         fail "cannot write $SELFTEST_SCRIPT"
-    # By path, not by name: a file that cd'd away can no longer reach make
-    # check's relative ../src, and it resolved this before it moved.
+    # By path, not by name: make check's ../src is relative, so resolving it from
+    # anywhere else finds an installed httrack and grades the wrong binary.
+    test -n "$HTTRACK_PATH" || test "$PWD" = "$TESTLIB_PWD" ||
+        fail "this test cd'd out of $TESTLIB_PWD: assign HTTRACK_PATH=\$(httrack_path) before it moves"
     test -n "$HTTRACK_PATH" || httrack_path >/dev/null
     out=$("$HTTRACK_PATH" -O /dev/null -#test=batch <"$SELFTEST_SCRIPT") || rc=$?
     rm -f "$SELFTEST_SCRIPT"
@@ -161,6 +167,9 @@ selftest_run_queued() {
             test "$got" = "$want" || fail "${SELFTEST_LABEL[i]}: expected [$want], got [$got]"
         fi
     done
+    # The count must close exactly: a case the engine ran and nobody asserted,
+    # or a self-test that printed the framing byte itself, both land here.
+    test -z "$rest" || fail "-#test=batch: output past the $n queued cases: $out"
     SELFTEST_ARGV=()
     SELFTEST_WANT=()
     SELFTEST_MODE=()

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -61,20 +61,7 @@ assert_selftest() { # assert_selftest WANT NAME [ARGS...]
     test "$got" = "$want" || fail "-#test=$name $*: expected [$want], got [$got]"
 }
 
-# assert_selftest for output spanning several lines: Windows stdout is text
-# mode, so every interior newline arrives as CRLF and a byte-exact compare
-# rejects it. Only the CR before a newline goes, or a test asserting the engine
-# drops an interior CR would pass whatever the engine did.
-assert_selftest_lines() { # assert_selftest_lines WANT NAME [ARGS...]
-    local want=$1 name=$2 got rc=0
-    shift 2
-    got=$(httrack -O /dev/null "-#test=$name" "$@") || rc=$?
-    test "$rc" -eq 0 || fail "-#test=$name $*: exited $rc, output: $got"
-    got=$(printf '%s\n' "$got" | sed $'s/\r$//')
-    test "$got" = "$want" || fail "-#test=$name $*: expected [$want], got [$got]"
-}
-
-# Batched form of the two asserts above: selftest_queue records a case, and
+# Batched form of the assert above: selftest_queue records a case, and
 # selftest_run_queued runs a whole file's cases in ONE httrack (-#test=batch in
 # htsselftest.c), which the Windows legs pay dearly for otherwise (#795).
 # Same contract, except a mismatch surfaces at the flush, named. A case whose
@@ -96,7 +83,10 @@ selftest_queue() { # selftest_queue WANT NAME [ARGS...]
     selftest_queue_mode exact "$@"
 }
 
-# selftest_queue for output spanning several lines (see assert_selftest_lines).
+# selftest_queue for output spanning several lines: Windows stdout is text mode,
+# so every interior newline arrives as CRLF and a byte-exact compare rejects it.
+# Only the CR before a newline goes, or a test asserting the engine drops an
+# interior CR would pass whatever the engine did.
 selftest_queue_lines() { # selftest_queue_lines WANT NAME [ARGS...]
     selftest_queue_mode lines "$@"
 }
@@ -112,11 +102,14 @@ selftest_queue_head() { # selftest_queue_head WANT NAME [ARGS...]
     selftest_queue_mode head "$@"
 }
 
-selftest_queue_mode() { # selftest_queue_mode exact|lines|tail WANT NAME [ARGS...]
+selftest_queue_mode() { # selftest_queue_mode exact|lines|tail|head WANT NAME [ARGS...]
     local mode=$1 want=$2 name=$3
     shift 3
     case $mode in
-    exact | lines | tail | head) ;;
+    exact | lines) ;;
+    # An empty want is a prefix and a suffix of everything, so it would assert
+    # nothing at all.
+    head | tail) test -n "$want" || fail "a $mode want must not be empty" ;;
     *) fail "unknown selftest mode $mode" ;;
     esac
     SELFTEST_WANT+=("$want")
@@ -156,9 +149,11 @@ selftest_run_queued() {
             fail "-#test=batch: framing lost at case $((i + 1)) of $n, output: $out"
             ;;
         esac
-        # What a command substitution drops around a lone case. The CR goes
-        # with it: Windows stdout is text mode, so every case ends CRLF there
-        # and MSYS strips the pair. Interior ones are lines mode's business.
+        # The whole trailing run, which is what a command substitution drops
+        # around a lone case. The CR goes with it: Windows stdout is text mode,
+        # so every case ends CRLF there and MSYS eats the pair. Stripping the
+        # run rather than one terminator keeps the two platforms saying the
+        # same thing. Interior CRs are lines mode's business.
         while :; do
             case $got in
             *"$TESTLIB_NL") got=${got%"$TESTLIB_NL"} ;;


### PR DESCRIPTION
A test file made of engine self-test assertions spawned one httrack per assertion: 731 across the suite, and a fork is expensive under MSYS (#1305).

`-#test=batch` reads a NUL-separated script of cases from stdin and runs them in one process, each behind a fresh option set so a handler's writes to `opt` cannot reach the next case, as they never could across separate processes. Cases must not travel in argv, where the engine would parse a `-*` as one of its own filters and rewrite the rest, so a queued arg arrives verbatim where an argv first goes through htsmain()'s rewrites; the two cases built on one of those rewrites stay one per process. `testlib.sh` grows `selftest_queue` and `selftest_run_queued` over it, with four compare modes, and 25 test files move onto them: 731 invocations down to 208.

Windows is where this is delicate, since stdout is a text stream there and every case ends CRLF, a pair a lone case loses to MSYS's command substitution. `tests/` gains no shim for that, but the review of this branch did: one that CRLF-translates the engine's stdout the way the C runtime does, which is how the parse is checked off Windows.

`314_engine-selftest-batch.test` is the equivalence gate, running each case alone first and asserting the batch against that output, leading with the handlers that write to `opt`. Each compare mode carries a want it must reject, since a mode that degenerated into "always true" would otherwise pass; eleven mutants of the compare logic were killed against it. A forgotten flush would leave a file asserting nothing, so the test also scans the suite for one that queues without flushing, statically, since #773 keeps the EXIT trap out of the verdict.