### PR TITLE
The macOS DMG can only be named for the engine version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,6 +457,19 @@ jobs:
           set -euo pipefail
           bash tools/macos-release.sh --app "$RUNNER_TEMP/moved/HTTrack.app" \
             --identity - --skip-notarize
+          ls "$RUNNER_TEMP/moved"/HTTrack-*-macos-*.dmg >/dev/null
+
+      # --label names the download for a product channel. The bundle inside keeps the
+      # engine's version, which the step above already asserted against the binary.
+      - name: Pack again under a channel label
+        run: |
+          set -euo pipefail
+          bash tools/macos-release.sh --app "$RUNNER_TEMP/moved/HTTrack.app" \
+            --identity - --skip-notarize --label 3.50-beta-0
+          ls "$RUNNER_TEMP/moved"/HTTrack-3.50-beta-0-macos-*.dmg >/dev/null
+          # Refused before anything is signed, so a typo costs a second, not a submission.
+          ! bash tools/macos-release.sh --app "$RUNNER_TEMP/moved/HTTrack.app" \
+            --identity - --skip-notarize --label 'a b/c'
 
   # Portability/hardening: 32-bit (i386) build on the x86-64 runner via multilib
   # -- no extra hardware. Exercises the 32-bit size_t/pointer ABI, where size

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -6,6 +6,11 @@ on:
   push:
     tags: ["[0-9]*"]
   workflow_dispatch:
+    inputs:
+      label:
+        description: "Name the DMG for a product channel (e.g. 3.50-beta-5) instead of the engine version"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -100,15 +105,19 @@ jobs:
           NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
           NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+          # Through the environment, never interpolated into this script.
+          DMG_LABEL: ${{ inputs.label }}
         run: |
           set -euo pipefail
           key="$RUNNER_TEMP/notary.p8"
           trap 'rm -f "$key"' EXIT HUP INT TERM
           printf '%s' "$NOTARY_KEY" | openssl base64 -d -A -out "$key"
+          set --
+          [ -z "${DMG_LABEL:-}" ] || set -- --label "$DMG_LABEL"
           bash tools/macos-release.sh --app "$RUNNER_TEMP/HTTrack.app" \
             --identity "$SIGN_IDENTITY" --out "$RUNNER_TEMP" \
             --notary-key "$key" --notary-key-id "$NOTARY_KEY_ID" \
-            --notary-issuer "$NOTARY_ISSUER_ID"
+            --notary-issuer "$NOTARY_ISSUER_ID" "$@"
 
       # The DMG round-trip is the one thing that can strip the stapled ticket, so assess
       # the copy that came out of it rather than the app the signing step still holds.

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -153,9 +153,10 @@ jobs:
           path: ${{ runner.temp }}/HTTrack-*.dmg
           if-no-files-found: error
 
-      # Releases are cut by hand, so a tag can land before one exists.
+      # Releases are cut by hand, so a tag can land before one exists. A labelled build is
+      # never one of them: ref_type is 'tag' for a dispatch on a tag as much as for a push.
       - name: Attach the DMG to the release
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' && !inputs.label
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/tools/macos-release.sh
+++ b/tools/macos-release.sh
@@ -64,6 +64,10 @@ while [ $# -gt 0 ]; do
 done
 test -n "$app" || usage
 test -n "$identity" || usage
+# Checked here, not at the DMG: a typo must not cost a notarization submission first.
+case "$label" in
+*[!A-Za-z0-9._-]*) fail "--label $label is not usable in a filename" ;;
+esac
 test -d "$app" || fail "no bundle at $app -- run make macos-app first"
 app=$(cd "$app" && pwd -P)
 out=${out:-$(dirname "$app")}
@@ -143,13 +147,7 @@ fi
 
 version=$(plist_value "$app/Contents/Info.plist" CFBundleShortVersionString)
 test -n "$version" || fail "no CFBundleShortVersionString in $app/Contents/Info.plist"
-
-# --label names the download for a product channel (a 3.50 beta) whose number is not the
-# engine's. It renames the DMG only: the bundle keeps the version its payload reports, so
-# macos-app.sh's plist-vs-binary guard still holds.
-case "$label" in
-*[!A-Za-z0-9._-]*) fail "--label $label is not usable in a filename" ;;
-esac
+# --label renames the download for a product channel; the bundle keeps its own version.
 name=${label:-$version}
 
 # The filename is what a user reads before downloading, so name the arch (#1083).

--- a/tools/macos-release.sh
+++ b/tools/macos-release.sh
@@ -7,7 +7,7 @@ set -eu
 . "$(dirname "$0")/macos-bundle.sh"
 
 usage() {
-    echo "usage: $0 --app DIR --identity ID [--out DIR]" >&2
+    echo "usage: $0 --app DIR --identity ID [--out DIR] [--label NAME]" >&2
     echo "       [--notary-key FILE --notary-key-id ID --notary-issuer ID | --skip-notarize]" >&2
     exit 2
 }
@@ -20,6 +20,7 @@ fail() {
 app=""
 identity=""
 out=""
+label=""
 notary_key=""
 notary_key_id=""
 notary_issuer=""
@@ -36,6 +37,10 @@ while [ $# -gt 0 ]; do
         ;;
     --out)
         out="${2:?}"
+        shift 2
+        ;;
+    --label)
+        label="${2:?}"
         shift 2
         ;;
     --notary-key)
@@ -139,6 +144,14 @@ fi
 version=$(plist_value "$app/Contents/Info.plist" CFBundleShortVersionString)
 test -n "$version" || fail "no CFBundleShortVersionString in $app/Contents/Info.plist"
 
+# --label names the download for a product channel (a 3.50 beta) whose number is not the
+# engine's. It renames the DMG only: the bundle keeps the version its payload reports, so
+# macos-app.sh's plist-vs-binary guard still holds.
+case "$label" in
+*[!A-Za-z0-9._-]*) fail "--label $label is not usable in a filename" ;;
+esac
+name=${label:-$version}
+
 # The filename is what a user reads before downloading, so name the arch (#1083).
 # An arch counts only if every Mach-O carries it: one thin dylib and the app is not universal.
 arch=$(while IFS= read -r _bin; do lipo -archs "$_bin" | tr ' ' '\n'; done <"$mach" |
@@ -149,14 +162,14 @@ case "$arch" in
 *-*) arch=universal ;;
 esac
 
-dmg="$out/HTTrack-$version-macos-$arch.dmg"
+dmg="$out/HTTrack-$name-macos-$arch.dmg"
 stage=$(mktemp -d)
 trap 'rm -f "$mach" "$nlog"; rm -rf "$stage"' EXIT
 # ditto, not cp: it carries a bundle's metadata across intact.
 ditto "$app" "$stage/$(basename "$app")"
 ln -s /Applications "$stage/Applications"
 rm -f "$dmg"
-hdiutil create -volname "HTTrack $version" -srcfolder "$stage" -fs HFS+ -format UDZO "$dmg"
+hdiutil create -volname "HTTrack $name" -srcfolder "$stage" -fs HFS+ -format UDZO "$dmg"
 sign "$dmg"
 
 if [ "$skip_notarize" -eq 0 ]; then


### PR DESCRIPTION
The DMG filename comes from the app bundle's version, which is the engine's. A 3.50 beta ships that same engine under a channel number of its own, so the download needs a name no tag can supply.

`--label`, exposed as a workflow_dispatch input, renames the DMG and its volume and nothing else. The bundle keeps the version its payload reports, so macos-app.sh's plist-vs-binary guard still holds. A labelled build also never reaches a Release: `ref_type` is `tag` for a dispatch on a tag as much as for a push, so the attach step now requires the label to be empty, and a labelled run lands on the run artifacts instead. The input arrives through the environment rather than interpolated into the run block.

The macOS CI leg already signs and packs a bundle ad hoc; it now does a labelled round and a refused one, so the option does not ship unexercised.