### PR TITLE
The .rc files are stored LF but pinned back to CRLF at checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,5 @@
-# Resource scripts are Windows tooling input and must stay CRLF: the engine has no
-# encoding guard, so an autocrlf checkout could otherwise flatten them silently.
-*.rc text eol=crlf
+# Only rc.exe reads these and it takes LF, so nothing here earns a CRLF pin.
+*.rc text eol=lf
 
 # The test scripts run under Git Bash on the Windows CI; a CRLF checkout makes
 # bash die on $'\r' on every line of them.

--- a/tests/01_engine-version-macros.test
+++ b/tests/01_engine-version-macros.test
@@ -27,8 +27,8 @@ if [ -z "$version" ] || [ -z "$versionid" ]; then
 fi
 
 # The same version, as version.rc states it.
-fileversion=$(sed -n 's/^[[:space:]]*FILEVERSION[[:space:]][[:space:]]*\(.*\)$/\1/p' "$rc" | tr -d ' \r')
-productversion=$(sed -n 's/^[[:space:]]*PRODUCTVERSION[[:space:]][[:space:]]*\(.*\)$/\1/p' "$rc" | tr -d ' \r')
+fileversion=$(sed -n 's/^[[:space:]]*FILEVERSION[[:space:]][[:space:]]*\(.*\)$/\1/p' "$rc" | tr -d ' ')
+productversion=$(sed -n 's/^[[:space:]]*PRODUCTVERSION[[:space:]][[:space:]]*\(.*\)$/\1/p' "$rc" | tr -d ' ')
 rc_fileversion=$(sed -n 's/.*VALUE "FileVersion",[[:space:]]*"\([^"]*\)".*/\1/p' "$rc")
 rc_productversion=$(sed -n 's/.*VALUE "ProductVersion",[[:space:]]*"\([^"]*\)".*/\1/p' "$rc")
 rc_productname=$(sed -n 's/.*VALUE "ProductName",[[:space:]]*"\([^"]*\)".*/\1/p' "$rc")
@@ -66,29 +66,33 @@ check "version.rc ProductVersion" "$version" "$rc_productversion"
 # Signing pins the product name too.
 check "version.rc ProductName" "HTTrack Website Copier" "$rc_productname"
 
-# Only rc.exe reads these and it takes LF, so nothing may put CRs back. ls-files
-# guards the pin, because distcheck unpacks the tarball inside the checkout,
-# where git answers for paths it does not track and every pin reads unspecified.
+# ls-files both drives the loop and guards the pin: distcheck unpacks the tarball
+# inside the checkout, where git answers for untracked paths and every pin reads
+# unspecified.
 if command -v git >/dev/null 2>&1 &&
     git -C "$top" ls-files --error-unmatch src/version.rc >/dev/null 2>&1; then
     tracked=yes
+    rc_files=$(git -C "$top" ls-files '*.rc')
 else
     tracked=no
-    echo "note: src/*.rc is not tracked here, so the eol pin cannot be read"
+    rc_files=$(cd "$top" && printf '%s\n' src/*.rc)
+    echo "note: the .rc files are not tracked here, so their eol pin cannot be read"
 fi
-for f in "$src"/*.rc; do
-    crlf=$(awk '/\r$/ { n++ } END { print n + 0 }' "$f")
-    [ "$crlf" = 0 ] || {
-        echo "${f##*/} has $crlf line(s) ending in CRLF"
+while read -r f; do
+    crs=$(awk '{ n += gsub(/\r/, "") } END { print n + 0 }' "$top/$f")
+    [ "$crs" = 0 ] || {
+        echo "$f carries $crs CR byte(s)"
         fail=1
     }
     [ "$tracked" = yes ] || continue
-    pin=$(git -C "$top" check-attr eol -- "src/${f##*/}" | sed 's/.*: //')
-    [ "$pin" = lf ] || {
-        echo "${f##*/} is pinned eol=$pin; .rc files are stored and checked out LF"
+    # text too: -text eol=lf still reads back lf, and stores whatever it is given.
+    attrs=$(git -C "$top" check-attr text eol -- "$f")
+    pin="$(sed -n 's/.*: text: //p' <<<"$attrs")/$(sed -n 's/.*: eol: //p' <<<"$attrs")"
+    [ "$pin" = set/lf ] || {
+        echo "$f is pinned text/eol=$pin, not set/lf"
         fail=1
     }
-done
+done <<<"$rc_files"
 
 check "the configure.ac AC_INIT version" "$versionid" "$ac_version"
 check "the newest metainfo release" "$versionid" "$(echo "$releases" | head -n 1)"

--- a/tests/01_engine-version-macros.test
+++ b/tests/01_engine-version-macros.test
@@ -66,6 +66,30 @@ check "version.rc ProductVersion" "$version" "$rc_productversion"
 # Signing pins the product name too.
 check "version.rc ProductName" "HTTrack Website Copier" "$rc_productname"
 
+# Only rc.exe reads these and it takes LF, so nothing may put CRs back. ls-files
+# guards the pin, because distcheck unpacks the tarball inside the checkout,
+# where git answers for paths it does not track and every pin reads unspecified.
+if command -v git >/dev/null 2>&1 &&
+    git -C "$top" ls-files --error-unmatch src/version.rc >/dev/null 2>&1; then
+    tracked=yes
+else
+    tracked=no
+    echo "note: src/*.rc is not tracked here, so the eol pin cannot be read"
+fi
+for f in "$src"/*.rc; do
+    crlf=$(awk '/\r$/ { n++ } END { print n + 0 }' "$f")
+    [ "$crlf" = 0 ] || {
+        echo "${f##*/} has $crlf line(s) ending in CRLF"
+        fail=1
+    }
+    [ "$tracked" = yes ] || continue
+    pin=$(git -C "$top" check-attr eol -- "src/${f##*/}" | sed 's/.*: //')
+    [ "$pin" = lf ] || {
+        echo "${f##*/} is pinned eol=$pin; .rc files are stored and checked out LF"
+        fail=1
+    }
+done
+
 check "the configure.ac AC_INIT version" "$versionid" "$ac_version"
 check "the newest metainfo release" "$versionid" "$(echo "$releases" | head -n 1)"
 


### PR DESCRIPTION
The three `.rc` files were pinned `text eol=crlf` over blobs that were already LF. The CRs only existed because the attribute put them back at checkout. MSVC's `rc.exe` is the only thing that reads them, and it takes LF. So the pin bought nothing, and left a Windows-only failure mode that is hard to diagnose without a Windows box. #1281 hit exactly that with `templates/*.html` and fixed it the same way: store LF, pin LF, and make a CRLF pin something a file has to earn.

No blob changes, only `.gitattributes`. `01_engine-version-macros.test` now checks the pin and that no line ends in CRLF; the byte half still runs from a dist tarball, where `.gitattributes` is absent and every pin reads unspecified.

Only the Windows build compiles these files, so this PR is the experiment: a green `windows-build` is what confirms `rc.exe` accepts LF.

Closes #1301
