### PR TITLE
Nothing notices if HTTraQt upstream starts moving again

### DIFF
--- a/.github/workflows/httraqt-upstream.yml
+++ b/.github/workflows/httraqt-upstream.yml
@@ -1,0 +1,88 @@
+# The HTTraQt canary builds a SHA of our own mirror so a third-party push cannot
+# red our PRs. Nothing then notices when SourceForge moves; this does.
+name: HTTraQt upstream watch
+
+# Never on push or pull_request: reacting to upstream inside a PR check is the
+# side door the pin exists to close.
+on:
+  schedule:
+    - cron: "53 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: httraqt-upstream
+
+jobs:
+  watch:
+    name: compare upstream against the pinned revision
+    # Scheduled workflows run per-fork independently; skip anywhere but upstream.
+    if: github.repository == 'xroche/httrack'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v7
+
+      # Reports "unreachable" rather than failing when SourceForge does not
+      # answer: an outage there is not news about HTTraQt.
+      - name: Compare SourceForge master against HTTRAQT_REF
+        id: check
+        run: sh tools/httraqt-upstream-check.sh
+
+      - name: Warn on the run summary when the host did not answer
+        if: steps.check.outputs.status == 'unreachable'
+        run: echo "::warning::SourceForge did not answer; upstream unchecked this week"
+
+      - name: Open or update the drift issue
+        if: steps.check.outputs.status == 'moved' || steps.check.outputs.status == 'gone'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PINNED: ${{ steps.check.outputs.pinned }}
+          UPSTREAM: ${{ steps.check.outputs.upstream }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          LABEL: httraqt-upstream
+        run: |
+          set -euo pipefail
+          # Invisible in the rendered issue, and what the next run greps to stay quiet.
+          marker="<!-- httraqt-upstream: upstream=$UPSTREAM -->"
+          {
+            if [ "$UPSTREAM" = none ]; then
+              echo "SourceForge answers, but HTTraQt has no \`refs/heads/master\` any more: renamed, or the project moved."
+            else
+              echo "Upstream HTTraQt master is now \`$UPSTREAM\`. The canary job builds \`$PINNED\`, unchanged since 2023."
+            fi
+            echo
+            echo "\`HTTRAQT_REF\` in \`.github/workflows/httraqt.yml\` points at \`xroche/httraqt-ci-mirror\`, so nobody outside the project can fail our checks. Catching up stays a deliberate act: mirror the new upstream commits, see what the canary makes of them, then move the pin."
+            echo
+            echo "Found by [the weekly upstream watch]($RUN_URL)."
+            echo "$marker"
+          } >"$RUNNER_TEMP/body.md"
+
+          gh label create "$LABEL" --color d4c5f9 \
+            --description "HTTraQt upstream moved past the pinned canary revision" || true
+
+          # Labelled, not searched: the search index lags minutes behind a fresh
+          # issue, which is exactly the window a weekly retry would duplicate in.
+          mapfile -t known < <(gh issue list --state all --label "$LABEL" --limit 20 --json number --jq '.[].number')
+          for n in "${known[@]}"; do
+            seen=$(gh issue view "$n" --json body,comments --jq '.body, (.comments[].body)')
+            if grep -qF "$marker" <<<"$seen"; then
+              echo "already reported on issue #$n"
+              exit 0
+            fi
+          done
+
+          open=$(gh issue list --state open --label "$LABEL" --limit 20 --json number --jq 'first(.[].number) // empty')
+          if [ -n "$open" ]; then
+            gh issue comment "$open" --body-file "$RUNNER_TEMP/body.md"
+          else
+            gh issue create --label "$LABEL" \
+              --title "HTTraQt upstream no longer matches the pinned canary revision" \
+              --body-file "$RUNNER_TEMP/body.md"
+          fi

--- a/.github/workflows/httraqt-upstream.yml
+++ b/.github/workflows/httraqt-upstream.yml
@@ -28,15 +28,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Reports "unreachable" rather than failing when SourceForge does not
-      # answer: an outage there is not news about HTTraQt.
+      # Retries first, then reds: a host that will not answer for four minutes
+      # has stopped being watched, which appstream-network.yml also treats as a
+      # failure rather than a silent pass.
       - name: Compare SourceForge master against HTTRAQT_REF
         id: check
         run: sh tools/httraqt-upstream-check.sh
-
-      - name: Warn on the run summary when the host did not answer
-        if: steps.check.outputs.status == 'unreachable'
-        run: echo "::warning::SourceForge did not answer; upstream unchecked this week"
 
       - name: Open or update the drift issue
         if: steps.check.outputs.status == 'moved' || steps.check.outputs.status == 'gone'
@@ -49,7 +46,7 @@ jobs:
           LABEL: httraqt-upstream
         run: |
           set -euo pipefail
-          # Invisible in the rendered issue, and what the next run greps to stay quiet.
+          # What the next run greps to stay quiet.
           marker="<!-- httraqt-upstream: upstream=$UPSTREAM -->"
           {
             if [ "$UPSTREAM" = none ]; then
@@ -58,7 +55,8 @@ jobs:
               echo "Upstream HTTraQt master is now \`$UPSTREAM\`. The canary job builds \`$PINNED\`, unchanged since 2023."
             fi
             echo
-            echo "\`HTTRAQT_REF\` in \`.github/workflows/httraqt.yml\` points at \`xroche/httraqt-ci-mirror\`, so nobody outside the project can fail our checks. Catching up stays a deliberate act: mirror the new upstream commits, see what the canary makes of them, then move the pin."
+            echo "\`HTTRAQT_REF\` in \`.github/workflows/httraqt.yml\` points at \`xroche/httraqt-ci-mirror\`, so nobody outside the project can fail our checks."
+            echo "Catching up stays a deliberate act: mirror the new upstream commits, then move the pin."
             echo
             echo "Found by [the weekly upstream watch]($RUN_URL)."
             echo "$marker"
@@ -69,8 +67,10 @@ jobs:
 
           # Labelled, not searched: the search index lags minutes behind a fresh
           # issue, which is exactly the window a weekly retry would duplicate in.
-          mapfile -t known < <(gh issue list --state all --label "$LABEL" --limit 20 --json number --jq '.[].number')
-          for n in "${known[@]}"; do
+          # Plain assignment, so a failed list aborts instead of reading as "not
+          # reported yet" and commenting a second time.
+          known=$(gh issue list --state all --label "$LABEL" --limit 100 --json number --jq '.[].number')
+          for n in $known; do
             seen=$(gh issue view "$n" --json body,comments --jq '.body, (.comments[].body)')
             if grep -qF "$marker" <<<"$seen"; then
               echo "already reported on issue #$n"
@@ -78,7 +78,7 @@ jobs:
             fi
           done
 
-          open=$(gh issue list --state open --label "$LABEL" --limit 20 --json number --jq 'first(.[].number) // empty')
+          open=$(gh issue list --state open --label "$LABEL" --limit 100 --json number --jq 'first(.[].number) // empty')
           if [ -n "$open" ]; then
             gh issue comment "$open" --body-file "$RUNNER_TEMP/body.md"
           else

--- a/.github/workflows/httraqt.yml
+++ b/.github/workflows/httraqt.yml
@@ -23,6 +23,8 @@ concurrency:
 env:
   # Unofficial mirror of the SourceForge tree, so no PR depends on a third-party host.
   HTTRAQT_REPO: https://github.com/xroche/httraqt-ci-mirror.git
+  # httraqt-upstream.yml reads this line for the bare SHA it compares SourceForge
+  # against, and reds if it stops looking like one. Quote it and the watch is lost.
   HTTRAQT_REF: a1175565c61ab9afd7bda2dc96ed1182c2d44ec3  # 1.4.11 + cmake patch, upstream HEAD since 2023-01-06
   PREFIX: /usr/local
 

--- a/tools/httraqt-upstream-check.sh
+++ b/tools/httraqt-upstream-check.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+#
+# Compare HTTraQt upstream against the revision the canary job pins. Deciding
+# only; httraqt-upstream.yml does the telling.
+#
+# Prints pinned=, upstream= and status= on stdout, and to $GITHUB_OUTPUT when
+# set. status is unchanged, moved, gone (no master branch) or unreachable (the
+# host did not answer, which says nothing about upstream). Non-zero exit means
+# the pin itself could not be read, so the comparison never happened.
+
+set -eu
+
+WORKFLOW=".github/workflows/httraqt.yml"
+UPSTREAM="https://git.code.sf.net/p/httraqt/code"
+ATTEMPTS=3
+
+usage() {
+    echo "usage: $0 [--workflow FILE] [--upstream URL] [--attempts N]" >&2
+    exit 2
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --workflow)
+        WORKFLOW="${2?missing value}"
+        shift 2
+        ;;
+    --upstream)
+        UPSTREAM="${2?missing value}"
+        shift 2
+        ;;
+    --attempts)
+        ATTEMPTS="${2?missing value}"
+        shift 2
+        ;;
+    -h | --help) usage ;;
+    *) usage ;;
+    esac
+done
+
+# The pin is the state: no cache, no committed sidecar file, and no way for the
+# two to disagree about what we last saw.
+pinned=$(sed -n 's/^[[:space:]]*HTTRAQT_REF:[[:space:]]*\([0-9a-f][0-9a-f]*\).*/\1/p' "$WORKFLOW")
+case "$pinned" in
+????????????????????????????????????????) ;;
+*)
+    echo "$0: no single 40-hex HTTRAQT_REF in $WORKFLOW" >&2
+    exit 1
+    ;;
+esac
+
+# A private SourceForge repo would otherwise block on a credential prompt.
+export GIT_TERMINAL_PROMPT=0
+
+refs=
+attempt=1
+while [ "$attempt" -le "$ATTEMPTS" ]; do
+    if refs=$(timeout 60 git ls-remote "$UPSTREAM" 'refs/heads/master' 2>&1); then
+        break
+    fi
+    echo "ls-remote failed (attempt $attempt/$ATTEMPTS): $refs" >&2
+    refs=
+    [ "$attempt" -eq "$ATTEMPTS" ] || sleep $((attempt * 15))
+    attempt=$((attempt + 1))
+done
+
+if [ "$attempt" -gt "$ATTEMPTS" ]; then
+    upstream=unknown
+    status=unreachable
+else
+    upstream=$(printf '%s\n' "$refs" | sed -n 's/^\([0-9a-f]\{40\}\)[[:space:]]*refs\/heads\/master$/\1/p')
+    if [ -z "$upstream" ]; then
+        upstream=none
+        status=gone
+    elif [ "$upstream" = "$pinned" ]; then
+        status=unchanged
+    else
+        status=moved
+    fi
+fi
+
+for line in "pinned=$pinned" "upstream=$upstream" "status=$status"; do
+    echo "$line"
+    [ -z "${GITHUB_OUTPUT:-}" ] || echo "$line" >>"$GITHUB_OUTPUT"
+done

--- a/tools/httraqt-upstream-check.sh
+++ b/tools/httraqt-upstream-check.sh
@@ -1,18 +1,23 @@
 #!/bin/sh
 #
-# Compare HTTraQt upstream against the revision the canary job pins. Deciding
-# only; httraqt-upstream.yml does the telling.
+# Decide whether HTTraQt upstream has moved away from the revision the canary
+# job pins; httraqt-upstream.yml does the telling.
 #
 # Prints pinned=, upstream= and status= on stdout, and to $GITHUB_OUTPUT when
-# set. status is unchanged, moved, gone (no master branch) or unreachable (the
-# host did not answer, which says nothing about upstream). Non-zero exit means
-# the pin itself could not be read, so the comparison never happened.
+# set. status is unchanged, moved, or gone (the host answers but has no master
+# branch). An unreadable pin and a host that will not answer both exit non-zero:
+# neither is news about HTTraQt, and both mean the watch has stopped working.
 
 set -eu
 
 WORKFLOW=".github/workflows/httraqt.yml"
 UPSTREAM="https://git.code.sf.net/p/httraqt/code"
-ATTEMPTS=3
+ATTEMPTS=5
+
+fail() {
+    echo "$0: $*" >&2
+    exit 1
+}
 
 usage() {
     echo "usage: $0 [--workflow FILE] [--upstream URL] [--attempts N]" >&2
@@ -38,45 +43,41 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-# The pin is the state: no cache, no committed sidecar file, and no way for the
-# two to disagree about what we last saw.
-pinned=$(sed -n 's/^[[:space:]]*HTTRAQT_REF:[[:space:]]*\([0-9a-f][0-9a-f]*\).*/\1/p' "$WORKFLOW")
-case "$pinned" in
-????????????????????????????????????????) ;;
-*)
-    echo "$0: no single 40-hex HTTRAQT_REF in $WORKFLOW" >&2
-    exit 1
-    ;;
+case "$ATTEMPTS" in
+"" | 0 | *[!0-9]*) usage ;;
 esac
+
+# The pin is the state: nothing else can disagree with what the canary builds.
+# Anchored, so a quoted or suffixed value is a hard error rather than a silent
+# near-miss, and two matching lines overshoot the length check.
+pinned=$(sed -n 's/^[[:space:]]*HTTRAQT_REF:[[:space:]]*\([0-9a-f]\{40\}\)\([[:space:]].*\)\{0,1\}$/\1/p' "$WORKFLOW")
+[ "${#pinned}" -eq 40 ] || fail "no single bare 40-hex HTTRAQT_REF in $WORKFLOW"
 
 # A private SourceForge repo would otherwise block on a credential prompt.
 export GIT_TERMINAL_PROMPT=0
 
-refs=
 attempt=1
-while [ "$attempt" -le "$ATTEMPTS" ]; do
-    if refs=$(timeout 60 git ls-remote "$UPSTREAM" 'refs/heads/master' 2>&1); then
+while :; do
+    if refs=$(timeout 60 git ls-remote "$UPSTREAM" 2>&1); then
         break
     fi
     echo "ls-remote failed (attempt $attempt/$ATTEMPTS): $refs" >&2
-    refs=
-    [ "$attempt" -eq "$ATTEMPTS" ] || sleep $((attempt * 15))
+    [ "$attempt" -lt "$ATTEMPTS" ] || fail "$UPSTREAM did not answer"
+    sleep $((attempt * 15))
     attempt=$((attempt + 1))
 done
 
-if [ "$attempt" -gt "$ATTEMPTS" ]; then
-    upstream=unknown
-    status=unreachable
+# An answer carrying no ref at all is a half-restored host, not a rename.
+[ -n "$refs" ] || fail "$UPSTREAM answered, but the repository is empty"
+
+upstream=$(printf '%s\n' "$refs" | sed -n 's/^\([0-9a-f]\{40\}\)[[:space:]]*refs\/heads\/master$/\1/p')
+if [ -z "$upstream" ]; then
+    upstream=none
+    status=gone
+elif [ "$upstream" = "$pinned" ]; then
+    status=unchanged
 else
-    upstream=$(printf '%s\n' "$refs" | sed -n 's/^\([0-9a-f]\{40\}\)[[:space:]]*refs\/heads\/master$/\1/p')
-    if [ -z "$upstream" ]; then
-        upstream=none
-        status=gone
-    elif [ "$upstream" = "$pinned" ]; then
-        status=unchanged
-    else
-        status=moved
-    fi
+    status=moved
 fi
 
 for line in "pinned=$pinned" "upstream=$upstream" "status=$status"; do


### PR DESCRIPTION
The HTTraQt canary builds a SHA of our own mirror, so no third party can red our PRs. It therefore never looks at SourceForge. This adds a weekly job, schedule and dispatch only, that compares upstream's `refs/heads/master` against the pin. It opens a labelled issue when the two differ, and comments on that issue if upstream moves again before anyone acts.

The pin is the state. `tools/httraqt-upstream-check.sh` reads `HTTRAQT_REF` out of `httraqt.yml`, so nothing cached or on the side can disagree with what the canary builds. Catching up stays one deliberate act: mirror the commits, then move the pin. The first run finds SourceForge still on `a117556` and says nothing, as will every quiet week after it.

A host that will not answer is retried five times and then reds the job, which is how `appstream-network.yml` already treats httrack.com. Exiting green with a warning would have let a permanent SourceForge relocation go unnoticed. To avoid repeat reports, each issue carries an HTML comment naming the upstream SHA. The next run finds it through the label rather than the search API, whose index lags a fresh issue by minutes.

Nothing beyond `GITHUB_TOKEN`, with `issues: write` on the one job that needs it. `actions/checkout@v7` is the only action, and the existing github-actions Dependabot entry already rewrites every workflow under `/`.

Checked with actionlint, shellcheck and `shfmt -d -i 4`. Every script outcome was exercised against real hosts and crafted repositories, under dash as well as bash. The three notification paths were dry-run against this repo's live issue data with the mutating `gh` calls stubbed out. The schedule itself has not fired; only its logic has run.

Closes #1162
