### PR TITLE
WebHTTrack offers a wizard mode it cannot answer

### DIFF
--- a/html/guide.html
+++ b/html/guide.html
@@ -174,9 +174,10 @@ keep their links to each other.</p>
 	<p>The normal choice. Copies the sites with the current options.</p>
 </div>
 
-<div class="opt" data-for="win web">
+<div class="opt" data-for="win">
 	<div class="opt-head"><span class="opt-name">Download web site(s) + questions</span><span class="cli">-W, --mirror-wizard</span></div>
-	<p>The same, but asks before following anything it is unsure about.</p>
+	<p>The same, but asks before following anything it is unsure about. WebHTTrack cannot answer
+	the questions and does not offer it.</p>
 </div>
 
 <div class="opt">

--- a/html/server/step3.html
+++ b/html/server/step3.html
@@ -120,7 +120,8 @@ ${do:end-if}
 		<select name="todo"
 			title='${html:LANG_G9}' onMouseOver="info('${js:LANG_G9}'); return true" onMouseOut="info('&nbsp;'); return true"		
 		>
-		${listid:todo:LISTDEF_10}
+		${/* entry 2 is the wizard, unanswerable here (#1237); the ids around it keep their values, shared with WinHTTrack through winprofile.ini */}
+		${listid:todo:LISTDEF_10:2}
 		</select>
 
 	</td></tr>

--- a/html/server/step3.html
+++ b/html/server/step3.html
@@ -120,7 +120,7 @@ ${do:end-if}
 		<select name="todo"
 			title='${html:LANG_G9}' onMouseOver="info('${js:LANG_G9}'); return true" onMouseOut="info('&nbsp;'); return true"		
 		>
-		${/* entry 2 is the wizard, unanswerable here (#1237); the ids around it keep their values, shared with WinHTTrack through winprofile.ini */}
+		${/* entry 2 is the wizard, unanswerable here (#1237); hidden rather than dropped so the ids around it keep their stored values */}
 		${listid:todo:LISTDEF_10:2}
 		</select>
 

--- a/html/server/step4.html
+++ b/html/server/step4.html
@@ -115,12 +115,13 @@ ${do:end-if}
 ${/* Real commands and ini file generated below */}
 
 <!-- engine commandline; ztest so a cleared default-on option still emits its disabling flag -->
+<!-- slot 2 is --mirror, not --mirror-wizard: a WinHTTrack profile can still carry that action and no page here can answer the questions (#1237) -->
 ${do:output-mode:html}
 <textarea name="command" cols="50" rows="4" style="visibility:hidden">
 httrack \
 	--quiet \
 	--build-top-index \
-	${test:todo:--mirror:--mirror:--mirror-wizard:--get:--mirrorlinks:--testlinks:--continue:--update}
+	${test:todo:--mirror:--mirror:--mirror:--get:--mirrorlinks:--testlinks:--continue:--update}
 	${unquoted:urls}
 	${test:filelist:-%L "}${arg:filelist}${test:filelist:"}
 	--path "${arg:path}/${arg:projname}" 

--- a/html/server/step4.html
+++ b/html/server/step4.html
@@ -115,7 +115,7 @@ ${do:end-if}
 ${/* Real commands and ini file generated below */}
 
 <!-- engine commandline; ztest so a cleared default-on option still emits its disabling flag -->
-<!-- slot 2 is --mirror, not --mirror-wizard: a WinHTTrack profile can still carry that action and no page here can answer the questions (#1237) -->
+<!-- slot 2 is the wizard action, mapped to --mirror because no page here can answer its questions -->
 ${do:output-mode:html}
 <textarea name="command" cols="50" rows="4" style="visibility:hidden">
 httrack \

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -616,6 +616,24 @@ static void cat_cmdline_arglist(String *output, const char *value,
   }
 }
 
+/* Append one <select> entry. A hidden id emits nothing, and the entries around
+   it keep their own ids: the value is a shared setting (winprofile.ini's
+   CurrentAction), so a front end that drops a mode must not renumber the rest.
+ */
+static void cat_list_option(String *output, const char *label, int id,
+                            int listDefault, int listHidden) {
+  char tag[48];
+
+  if (id == listHidden) {
+    return;
+  }
+  snprintf(tag, sizeof(tag), "<option value=%d%s>", id,
+           id == listDefault ? " selected" : "");
+  StringCat(*output, tag);
+  StringCat(*output, label);
+  StringCat(*output, "</option>\r\n");
+}
+
 /* step4.html writes these keys as ${ztest:<var>:0:1}; a cleared checkbox is
    empty in session state, so only they need the 0-to-empty inverse here. */
 static const char *const ini_checkbox_keys[] = {
@@ -1333,6 +1351,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                     int p;
                     int format = 0;
                     int listDefault = 0;
+                    int listHidden = 0;
                     hts_boolean unquoted = HTS_FALSE;
                     /* value comes from the template, not from the settings */
                     hts_boolean literal = HTS_FALSE;
@@ -1632,6 +1651,14 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                           name += n2 + 1;
                         }
                       }
+                      /* ${listid:<var>:<key>:<id>}: <id> is an entry this front
+                         end cannot serve and must not offer. */
+                      pos2 = strrchr(name, ':');
+                      if (pos2 != NULL && pos2[1] != '\0' &&
+                          strspn(pos2 + 1, "0123456789") == strlen(pos2 + 1)) {
+                        listHidden = atoi(pos2 + 1);
+                        *pos2 = '\0';
+                      }
                     } else if ((p = strfield(name, "checked:"))) {
                       name += p;
                       format = 3;
@@ -1725,13 +1752,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                           const char *fstr = langstr;
 
                           StringClear(tmpbuff);
-                          if (format == 2) {
-                            /* Check the default here too: the loop only opens
-                             * ids 2 and up. */
-                            StringCat(output, listDefault == 1
-                                                  ? "<option value=1 selected>"
-                                                  : "<option value=1>");
-                          } else if (format == -2) {
+                          if (format == -2) {
                             StringCat(output, "<option value=\"");
                           }
                           while(*fstr) {
@@ -1749,17 +1770,8 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                                 StringCat(output, "</option>\r\n");
                                 StringCat(output, "<option value=\"");
                               } else {
-                                char tmp[32];
-
-                                sprintf(tmp, "%d", ++id);
-                                StringCat(output, StringBuff(tmpbuff));
-                                StringCat(output, "</option>\r\n");
-                                StringCat(output, "<option value=");
-                                StringCat(output, tmp);
-                                if (listDefault == id) {
-                                  StringCat(output, " selected");
-                                }
-                                StringCat(output, ">");
+                                cat_list_option(&output, StringBuff(tmpbuff),
+                                                id++, listDefault, listHidden);
                               }
                               StringClear(tmpbuff);
                               break;
@@ -1776,8 +1788,8 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                             fstr++;
                           }
                           if (format == 2) {
-                            StringCat(output, StringBuff(tmpbuff));
-                            StringCat(output, "</option>");
+                            cat_list_option(&output, StringBuff(tmpbuff), id,
+                                            listDefault, listHidden);
                           } else if (format == -2) {
                             StringCat(output, StringBuff(tmpbuff));
                             StringCat(output, "\">");

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -616,10 +616,8 @@ static void cat_cmdline_arglist(String *output, const char *value,
   }
 }
 
-/* Append one <select> entry. A hidden id emits nothing, and the entries around
-   it keep their own ids: the value is a shared setting (winprofile.ini's
-   CurrentAction), so a front end that drops a mode must not renumber the rest.
- */
+/* Append one <select> entry, unless its id is the hidden one. Ids are stored as
+   winprofile.ini's CurrentAction, so hiding one must not renumber the rest. */
 static void cat_list_option(String *output, const char *label, int id,
                             int listDefault, int listHidden) {
   char tag[48];
@@ -1351,7 +1349,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                     int p;
                     int format = 0;
                     int listDefault = 0;
-                    int listHidden = 0;
+                    int listHidden = 0; /* ids start at 1, so 0 hides none */
                     hts_boolean unquoted = HTS_FALSE;
                     /* value comes from the template, not from the settings */
                     hts_boolean literal = HTS_FALSE;

--- a/tests/321_webhttrack-no-wizard.test
+++ b/tests/321_webhttrack-no-wizard.test
@@ -1,8 +1,7 @@
 #!/bin/bash
 #
-# WebHTTrack has no page that can answer a wizard question, so it must not offer
-# the mode (#1237) -- on any of its surfaces, and without renumbering the action
-# ids it shares with WinHTTrack through winprofile.ini.
+# WebHTTrack has no page that can answer a wizard question, so no surface may
+# offer the mode (#1237). The surviving action ids must keep their values.
 
 set -euo pipefail
 
@@ -76,8 +75,8 @@ def options():
                       block.group(0))
 
 
-# The catalog is the join key of 30-odd translations and WinHTTrack's own combo,
-# so the entry must still be there: dropping it is a different, worse fix.
+# The catalog is the join key for the translations and for WinHTTrack's own
+# combo, so the entry must still be there.
 listdef = re.search(r"^LISTDEF_10\r?\n([^\r\n]*)", read("lang.def"), re.M)
 if listdef is None:
     sys.exit("no LISTDEF_10 in lang.def")
@@ -86,9 +85,8 @@ check(len(entries) == 7, "lang.def still lists %d actions" % len(entries))
 check(entries[1] == "Download web site(s) + questions",
       "the wizard entry is still the catalog's second action")
 
-# The action the wizard entry occupies, and what each id must put on the command
-# line. Ids come from the catalog order, not from what the server happened to
-# emit; 2 is what a WinHTTrack profile may still carry.
+# WIZARD is the catalog index of the hidden entry; COMMAND is the flag each id
+# must emit. Ids come from the catalog order, not from what the server emitted.
 WIZARD = 2
 COMMAND = {1: "--mirror", 2: "--mirror", 3: "--get", 4: "--mirrorlinks",
            5: "--testlinks", 6: "--continue", 7: "--update"}

--- a/tests/321_webhttrack-no-wizard.test
+++ b/tests/321_webhttrack-no-wizard.test
@@ -1,0 +1,137 @@
+#!/bin/bash
+#
+# WebHTTrack has no page that can answer a wizard question, so it must not offer
+# the mode (#1237) -- on any of its surfaces, and without renumbering the action
+# ids it shares with WinHTTrack through winprofile.ini.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
+distdir=$(cd "${distdir}" && pwd)
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
+
+htsserver_require
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_wizard.XXXXXX") || fail "no tmpdir"
+cleanup() {
+    htsserver_cleanup
+    rm -rf "${work}"
+}
+cleanup_push cleanup
+
+htsserver_start --home "${work}"
+
+"${HTS_PYTHON}" - "${HTS_URL}" "${distdir}" <<'PY' || fail "the wizard mode is still offered (see above)"
+import os, re, sys, urllib.parse, urllib.request
+
+url, srcdir = sys.argv[1].rstrip("/"), sys.argv[2]
+rc = 0
+
+
+def check(ok, what):
+    global rc
+    print(("ok: " if ok else "FAIL: ") + what)
+    if not ok:
+        rc = 1
+
+
+def read(*path):
+    return open(os.path.join(srcdir, *path), "rb").read().decode("latin-1")
+
+
+def get(path):
+    # The UI is served ISO-8859-1, so decode, do not assume UTF-8.
+    return urllib.request.urlopen(url + path, timeout=20).read().decode("latin-1")
+
+
+sid = re.search(r'name="sid" value="([0-9a-f]+)"', get("/server/index.html"))
+if sid is None:
+    sys.exit("no session id in server/index.html")
+sid = sid.group(1)
+
+
+def post(fields, page="step4.html"):
+    body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in
+                    [("sid", sid)] + fields)
+    req = urllib.request.Request(url + "/server/" + page,
+                                 data=body.encode("latin-1"), method="POST")
+    return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
+
+
+def textarea(page, name):
+    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page, re.S)
+    if m is None:
+        sys.exit("no %s textarea in the rendered step4.html" % name)
+    return m.group(1)
+
+
+def options():
+    page = get("/server/step3.html")
+    block = re.search(r'<select name="todo".*?</select>', page, re.S)
+    if block is None:
+        sys.exit("no action <select> in the rendered step3.html")
+    return re.findall(r"<option value=(\d+)( selected)?>([^<]*)</option>",
+                      block.group(0))
+
+
+# The catalog is the join key of 30-odd translations and WinHTTrack's own combo,
+# so the entry must still be there: dropping it is a different, worse fix.
+listdef = re.search(r"^LISTDEF_10\r?\n([^\r\n]*)", read("lang.def"), re.M)
+if listdef is None:
+    sys.exit("no LISTDEF_10 in lang.def")
+entries = listdef.group(1).split("\\n")
+check(len(entries) == 7, "lang.def still lists %d actions" % len(entries))
+check(entries[1] == "Download web site(s) + questions",
+      "the wizard entry is still the catalog's second action")
+
+# The action the wizard entry occupies, and what each id must put on the command
+# line. Ids come from the catalog order, not from what the server happened to
+# emit; 2 is what a WinHTTrack profile may still carry.
+WIZARD = 2
+COMMAND = {1: "--mirror", 2: "--mirror", 3: "--get", 4: "--mirrorlinks",
+           5: "--testlinks", 6: "--continue", 7: "--update"}
+
+opts = [int(i) for i, _, _ in options()]
+check(opts == [i for i in sorted(COMMAND) if i != WIZARD],
+      "the menu offers ids %r" % (opts,))
+labels = [label for _, _, label in options()]
+check(not [l for l in labels if "questions" in l],
+      "no entry advertises questions (%r)" % (labels,))
+
+# Renumbering the survivors would keep the menu wizard-free and still break
+# every stored CurrentAction, so pin id to flag rather than just the count.
+for todo, flag in sorted(COMMAND.items()):
+    cmd = textarea(post([("todo", str(todo))]), "command").split()
+    check(flag in cmd, "action %d runs %s" % (todo, flag))
+    check("--mirror-wizard" not in cmd, "action %d does not run the wizard" % todo)
+    selected = [i for i, sel, _ in options() if sel]
+    check(selected == ([] if todo == WIZARD else [str(todo)]),
+          "action %d draws %r as the current one" % (todo, selected))
+
+# ...and the slot table itself must not hold the flag, for the ids above and for
+# the default the engine takes when the action is unset.
+todo = re.search(r"\$\{test:todo:[^}]*\}", read("html", "server", "step4.html"))
+if todo is None:
+    sys.exit("no action slot table in html/server/step4.html")
+check("--mirror-wizard" not in todo.group(0),
+      "no action slot maps to the wizard (%s)" % todo.group(0))
+
+# The guide describes the same menu; it must not promise the mode to WebHTTrack.
+guide = read("html", "guide.html")
+opt = re.search(r'<div class="opt" data-for="([^"]*)">\s*<div class="opt-head">'
+                r'<span class="opt-name">Download web site\(s\) \+ questions</span>',
+                guide)
+if opt is None:
+    sys.exit("no wizard action block in html/guide.html")
+check("web" not in opt.group(1).split(), "guide.html shows it to %r only"
+      % (opt.group(1),))
+
+sys.exit(rc)
+PY
+
+htsserver_cleanup
+htsserver_assert_reaped
+
+echo "PASS"


### PR DESCRIPTION
WebHTTrack's action menu offered `Download web site(s) + questions`, but no page it serves can answer a wizard question. `htsshow_query3()` returns `""`, which htswizard.c reads as answer 0, so every ambiguous link was silently dropped and a `-adr/fil` filter recorded against it. Plain `--mirror` at least forbids without blacklisting. The entry is now hidden from the menu, slot 2 maps to `--mirror` so a stored profile carrying that action degrades instead of running the broken path, and the guide no longer lists the action for WebHTTrack.

The issue suggested dropping the entry from `LISTDEF_10`. That string is the join key for 30-odd translations, and it also fills WinHTTrack's own action combo, where the wizard does work. `${listid:}` instead takes an optional hidden id, so the entry is skipped at render time and the ids around it keep their values, which WebHTTrack's own saved projects and `step2.html`'s seeds depend on.

Test 321 renders the menu and posts every action id, so re-adding the mode to one surface alone goes red. Reviewing the id numbering turned up a separate pre-existing bug, filed as #1314: `winprofile.ini`'s `CurrentAction` is 0-based in WinHTTrack and 1-based here, so a project moved between the two GUIs picks the neighbouring action.

Closes #1237