### PR TITLE
The language menu names half the languages in English

### DIFF
--- a/lang/Bulgarian.txt
+++ b/lang/Bulgarian.txt
@@ -1,5 +1,5 @@
 LANGUAGE_NAME
-Bulgarian
+Български
 LANGUAGE_FILE
 Bulgarian
 LANGUAGE_ISO

--- a/lang/Chinese-BIG5.txt
+++ b/lang/Chinese-BIG5.txt
@@ -1,5 +1,5 @@
 LANGUAGE_NAME
-Chinese-BIG5
+¡c≈È§§§Â
 LANGUAGE_FILE
 Chinese-BIG5
 LANGUAGE_ISO

--- a/lang/Chinese-Simplified.txt
+++ b/lang/Chinese-Simplified.txt
@@ -1,5 +1,5 @@
 LANGUAGE_NAME
-Chinese-Simplified
+¼òÌåÖÐÎÄ
 LANGUAGE_FILE
 Chinese-Simplified
 LANGUAGE_ISO

--- a/lang/Finnish.txt
+++ b/lang/Finnish.txt
@@ -1,5 +1,5 @@
 LANGUAGE_NAME
-Finnish
+Suomi
 LANGUAGE_FILE
 Finnish
 LANGUAGE_ISO

--- a/lang/Greek.txt
+++ b/lang/Greek.txt
@@ -1,5 +1,5 @@
 LANGUAGE_NAME
-Greek
+Ελληνικά
 LANGUAGE_FILE
 Greek
 LANGUAGE_ISO

--- a/lang/Japanese.txt
+++ b/lang/Japanese.txt
@@ -1,5 +1,5 @@
 LANGUAGE_NAME
-Japanese
+“ú–{Œê
 LANGUAGE_FILE
 Japanese
 LANGUAGE_ISO

--- a/lang/Macedonian.txt
+++ b/lang/Macedonian.txt
@@ -1,5 +1,5 @@
 LANGUAGE_NAME
-Macedonian
+Македонски
 LANGUAGE_FILE
 Macedonian
 LANGUAGE_ISO

--- a/lang/Romanian.txt
+++ b/lang/Romanian.txt
@@ -1,5 +1,5 @@
 LANGUAGE_NAME
-Romanian
+Românã
 LANGUAGE_FILE
 Romanian
 LANGUAGE_ISO

--- a/lang/Russian.txt
+++ b/lang/Russian.txt
@@ -1,5 +1,5 @@
 LANGUAGE_NAME
-Russian
+Русский
 LANGUAGE_FILE
 Russian
 LANGUAGE_ISO

--- a/lang/Slovak.txt
+++ b/lang/Slovak.txt
@@ -1,5 +1,5 @@
 LANGUAGE_NAME
-Slovak
+Slovenèina
 LANGUAGE_FILE
 Slovak
 LANGUAGE_ISO

--- a/lang/Slovenian.txt
+++ b/lang/Slovenian.txt
@@ -1,5 +1,5 @@
 LANGUAGE_NAME
-Slovenian
+Slovenšèina
 LANGUAGE_FILE
 Slovenian
 LANGUAGE_ISO

--- a/lang/Turkish.txt
+++ b/lang/Turkish.txt
@@ -1,5 +1,5 @@
 LANGUAGE_NAME
-Turkish
+Türkçe
 LANGUAGE_FILE
 Turkish
 LANGUAGE_ISO

--- a/lang/Ukrainian.txt
+++ b/lang/Ukrainian.txt
@@ -1,5 +1,5 @@
 LANGUAGE_NAME
-Ukrainian
+Українська
 LANGUAGE_FILE
 Ukrainian
 LANGUAGE_ISO

--- a/lang/Uzbek.txt
+++ b/lang/Uzbek.txt
@@ -1,5 +1,5 @@
 LANGUAGE_NAME
-Uzbek Latin
+O’zbekcha
 LANGUAGE_FILE
 Uzbek
 LANGUAGE_ISO

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -507,6 +507,40 @@ static hts_boolean cat_html_escaped(String *dst, char c) {
   return HTS_TRUE;
 }
 
+/* Append the UTF-8 sequence at *s as a numeric character reference, which names
+   a code point and so survives whatever charset the page declares, and step *s
+   onto its last byte. HTS_FALSE if *s does not start a valid sequence. */
+static hts_boolean cat_html_ncr(String *dst, const char **s) {
+  const unsigned char *const p = (const unsigned char *) *s;
+  unsigned int uc;
+  int extra, i;
+  char tmp[16];
+
+  if (p[0] >= 0xc2 && p[0] <= 0xdf) {
+    uc = p[0] & 0x1f;
+    extra = 1;
+  } else if ((p[0] & 0xf0) == 0xe0) {
+    uc = p[0] & 0x0f;
+    extra = 2;
+  } else if (p[0] >= 0xf0 && p[0] <= 0xf4) {
+    uc = p[0] & 0x07;
+    extra = 3;
+  } else {
+    return HTS_FALSE;
+  }
+  /* A NUL fails this before the next byte is looked at, so a truncated
+     sequence at the end of the string cannot read past it. */
+  for (i = 1; i <= extra; i++) {
+    if ((p[i] & 0xc0) != 0x80)
+      return HTS_FALSE;
+    uc = (uc << 6) | (p[i] & 0x3f);
+  }
+  snprintf(tmp, sizeof(tmp), "&#%u;", uc);
+  StringCat(*dst, tmp);
+  *s += extra;
+  return HTS_TRUE;
+}
+
 /* Same, for a double-quoted attribute: the quote included, which
    cat_html_escaped() leaves raw for the single-quoted tooltips. */
 static hts_boolean cat_attr_escaped_char(String *dst, char c) {
@@ -1336,6 +1370,8 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                     hts_boolean unquoted = HTS_FALSE;
                     /* value comes from the template, not from the settings */
                     hts_boolean literal = HTS_FALSE;
+                    /* value is UTF-8 and the page charset is not */
+                    hts_boolean ncr = HTS_FALSE;
                     char datebuff[16];
 
                     name[0] = '\0';
@@ -1642,6 +1678,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                         line2[0] = '\0';
                         LANG_LIST(path, line2, sizeof(line2));
                         assertf(strlen(langstr) < sizeof(line2) - 2);
+                        ncr = HTS_TRUE;
                       } else {
                         langstr = LANGSEL(name);
                         if (langstr == NULL || *langstr == '\0') {
@@ -1764,6 +1801,9 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                               StringClear(tmpbuff);
                               break;
                             default:
+                              if (ncr && cat_html_ncr(&tmpbuff, &fstr)) {
+                                break;
+                              }
                               /* format -2 writes its value into the option's
                                  value="" as well, so the quote must go too */
                               if (!(format == -2
@@ -2086,12 +2126,38 @@ static int htslang_load(char *limit_to, size_t limit_size, const char *path) {
     hashname = LANGINTKEY(name);
   }
 
-  /* Get only language name */
+  /* Read the key named in limit_to out of the selected catalog; lang.def holds
+     only the catalog's file name, which the language menu showed instead
+     (#116). */
   if (limit_to) {
-    if (hashname)
-      strlcpybuff(limit_to, hashname, limit_size);
-    else
-      strlcpybuff(limit_to, "???", limit_size);
+    char wanted[256];
+
+    strlcpybuff(wanted, limit_to, sizeof(wanted));
+    /* Fallback, so a caller looping until empty still stops at the end of the
+       list rather than on a catalog missing the key. */
+    strlcpybuff(limit_to, hashname != NULL ? hashname : "", limit_size);
+    if (limit_to[0] != '\0') {
+      char lbasename[1024];
+      FILE *fp;
+
+      snprintf(lbasename, sizeof(lbasename), "lang/%s.txt", hashname);
+      fp = fopen(fconcat(catbuff, sizeof(catbuff), path, lbasename), "rb");
+      if (fp != NULL) {
+        char extkey[8192];
+        char value[8192];
+        hts_boolean found = HTS_FALSE;
+
+        while (!found && !feof(fp)) {
+          linput_cpp(fp, extkey, 8000);
+          linput_cpp(fp, value, 8000);
+          if (strcmp(extkey, wanted) == 0) {
+            strlcpybuff(limit_to, value, limit_size);
+            found = HTS_TRUE;
+          }
+        }
+        fclose(fp);
+      }
+    }
     return 0;
   }
 
@@ -2298,9 +2364,18 @@ static int LANG_LIST(const char *path, char *buffer, size_t buffer_size) {
     strlcpybuff(lang_str, "LANGUAGE_NAME", sizeof(lang_str));
     htslang_load(lang_str, sizeof(lang_str), path);
     if (strlen(lang_str) > 0) {
+      char charset[64];
+      char *utf8;
+
+      /* Every catalog names itself in its own charset and the menu carries all
+         of them at once, so the list leaves here in UTF-8. */
+      strlcpybuff(charset, "LANGUAGE_CHARSET", sizeof(charset));
+      htslang_load(charset, sizeof(charset), path);
+      utf8 = hts_convertStringToUTF8(lang_str, strlen(lang_str), charset);
       if (buffer[0])
         strlcatbuff(buffer, "\n", buffer_size);
-      strlcatbuff(buffer, lang_str, buffer_size);
+      strlcatbuff(buffer, utf8 != NULL ? utf8 : lang_str, buffer_size);
+      freet(utf8);
     }
     i++;
   } while(strlen(lang_str) > 0);

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -2146,7 +2146,9 @@ static int htslang_load(char *limit_to, size_t limit_size, const char *path) {
        key must not look like the end of the list. */
     if (hashname != NULL)
       strlncatbuff(limit_to, hashname, limit_size, limit_size - 1);
-    if (limit_to[0] != '\0') {
+    /* lang.def names a bare basename; a separator in it would leave lang/. */
+    if (limit_to[0] != '\0' && strpbrk(hashname, "/\\") == NULL &&
+        strstr(hashname, "..") == NULL) {
       char lbasename[1024];
       FILE *fp;
 

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -507,13 +507,14 @@ static hts_boolean cat_html_escaped(String *dst, char c) {
   return HTS_TRUE;
 }
 
-/* Append the UTF-8 sequence at *s as a numeric character reference, which names
-   a code point and so survives whatever charset the page declares, and step *s
-   onto its last byte. HTS_FALSE if *s does not start a valid sequence. */
-static hts_boolean cat_html_ncr(String *dst, const char **s) {
-  const unsigned char *const p = (const unsigned char *) *s;
+/* Append the UTF-8 character at s as a numeric character reference, which names
+   a code point and survives any page charset, and return its length in bytes.
+   Zero if s does not start a valid character. (hts_readUTF8() decodes the same
+   thing, but is not HTSEXT_API, so this binary cannot link it.) */
+static size_t cat_html_ncr(String *dst, const char *s) {
+  const unsigned char *const p = (const unsigned char *) s;
   unsigned int uc;
-  int extra, i;
+  size_t extra, i;
   char tmp[16];
 
   if (p[0] >= 0xc2 && p[0] <= 0xdf) {
@@ -526,19 +527,21 @@ static hts_boolean cat_html_ncr(String *dst, const char **s) {
     uc = p[0] & 0x07;
     extra = 3;
   } else {
-    return HTS_FALSE;
+    return 0;
   }
-  /* A NUL fails this before the next byte is looked at, so a truncated
-     sequence at the end of the string cannot read past it. */
+  /* A NUL fails this before the next byte is read, so a sequence truncated at
+     the end of the string cannot run past it. */
   for (i = 1; i <= extra; i++) {
     if ((p[i] & 0xc0) != 0x80)
-      return HTS_FALSE;
+      return 0;
     uc = (uc << 6) | (p[i] & 0x3f);
   }
+  /* Overlong and surrogate forms name nothing a browser will render. */
+  if (uc < 0x80 || (uc >= 0xd800 && uc <= 0xdfff))
+    return 0;
   snprintf(tmp, sizeof(tmp), "&#%u;", uc);
   StringCat(*dst, tmp);
-  *s += extra;
-  return HTS_TRUE;
+  return extra + 1;
 }
 
 /* Same, for a double-quoted attribute: the quote included, which
@@ -1370,8 +1373,8 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                     hts_boolean unquoted = HTS_FALSE;
                     /* value comes from the template, not from the settings */
                     hts_boolean literal = HTS_FALSE;
-                    /* value is UTF-8 and the page charset is not */
-                    hts_boolean ncr = HTS_FALSE;
+                    /* value is UTF-8, so emit it as character references */
+                    hts_boolean needs_ncr = HTS_FALSE;
                     char datebuff[16];
 
                     name[0] = '\0';
@@ -1678,7 +1681,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                         line2[0] = '\0';
                         LANG_LIST(path, line2, sizeof(line2));
                         assertf(strlen(langstr) < sizeof(line2) - 2);
-                        ncr = HTS_TRUE;
+                        needs_ncr = HTS_TRUE;
                       } else {
                         langstr = LANGSEL(name);
                         if (langstr == NULL || *langstr == '\0') {
@@ -1759,6 +1762,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                       default:
                         if (*langstr) {
                           int id = 1;
+                          size_t used;
                           const char *fstr = langstr;
 
                           StringClear(tmpbuff);
@@ -1801,7 +1805,10 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                               StringClear(tmpbuff);
                               break;
                             default:
-                              if (ncr && cat_html_ncr(&tmpbuff, &fstr)) {
+                              if (needs_ncr &&
+                                  (used = cat_html_ncr(&tmpbuff, fstr)) != 0) {
+                                /* the loop's own fstr++ takes the last byte */
+                                fstr += used - 1;
                                 break;
                               }
                               /* format -2 writes its value into the option's
@@ -2126,16 +2133,19 @@ static int htslang_load(char *limit_to, size_t limit_size, const char *path) {
     hashname = LANGINTKEY(name);
   }
 
-  /* Read the key named in limit_to out of the selected catalog; lang.def holds
-     only the catalog's file name, which the language menu showed instead
-     (#116). */
+  /* Read the key named in limit_to from the selected catalog, not lang.def's
+     file name for it. Both come off disk, so every copy clips: the safe_
+     helpers abort, and a long line in a catalog must not kill the server. */
   if (limit_to) {
     char wanted[256];
 
-    strlcpybuff(wanted, limit_to, sizeof(wanted));
-    /* Fallback, so a caller looping until empty still stops at the end of the
-       list rather than on a catalog missing the key. */
-    strlcpybuff(limit_to, hashname != NULL ? hashname : "", limit_size);
+    wanted[0] = '\0';
+    strlncatbuff(wanted, limit_to, sizeof(wanted), sizeof(wanted) - 1);
+    limit_to[0] = '\0';
+    /* Fallback: an empty result ends a caller's loop, so a catalog missing the
+       key must not look like the end of the list. */
+    if (hashname != NULL)
+      strlncatbuff(limit_to, hashname, limit_size, limit_size - 1);
     if (limit_to[0] != '\0') {
       char lbasename[1024];
       FILE *fp;
@@ -2150,8 +2160,9 @@ static int htslang_load(char *limit_to, size_t limit_size, const char *path) {
         while (!found && !feof(fp)) {
           linput_cpp(fp, extkey, 8000);
           linput_cpp(fp, value, 8000);
-          if (strcmp(extkey, wanted) == 0) {
-            strlcpybuff(limit_to, value, limit_size);
+          if (strcmp(extkey, wanted) == 0 && value[0] != '\0') {
+            limit_to[0] = '\0';
+            strlncatbuff(limit_to, value, limit_size, limit_size - 1);
             found = HTS_TRUE;
           }
         }
@@ -2367,8 +2378,8 @@ static int LANG_LIST(const char *path, char *buffer, size_t buffer_size) {
       char charset[64];
       char *utf8;
 
-      /* Every catalog names itself in its own charset and the menu carries all
-         of them at once, so the list leaves here in UTF-8. */
+      /* Convert to UTF-8: each catalog names itself in its own charset, and
+         the menu carries all of them at once. */
       strlcpybuff(charset, "LANGUAGE_CHARSET", sizeof(charset));
       htslang_load(charset, sizeof(charset), path);
       utf8 = hts_convertStringToUTF8(lang_str, strlen(lang_str), charset);

--- a/tests/251_webhttrack-lang-selected.test
+++ b/tests/251_webhttrack-lang-selected.test
@@ -27,7 +27,8 @@ serve() { # $1 = tag, $2.. = extra htsserver args
     htsserver_start --home "${work}/h${tag}" --log "${work}/srv${tag}.log" "$@"
 }
 
-# Indexes and labels come from lang.indexes and lang.def, not from observed output.
+# Indexes come from lang.indexes and labels from each catalog's LANGUAGE_NAME,
+# entity-escaped by the menu emitter, not from observed output.
 # The heading word is that language's own greeting, so it proves which language
 # the body was rendered in.
 check() { # $1 = lang index, $2 = expected label, $3 = word in the page heading
@@ -61,7 +62,7 @@ PY
 
 # 1 is the boundary the loop cannot reach; 2 and 4 prove it tracks the input.
 check 1 English Welcome
-check 2 Francais Bienvenue
+check 2 'Fran&#231;ais' Bienvenue
 check 4 Deutsch Willkommen
 
 # With no language set the menu falls back to its first entry, which must be the

--- a/tests/320_webhttrack-lang-names.test
+++ b/tests/320_webhttrack-lang-names.test
@@ -1,10 +1,8 @@
 #!/bin/bash
 #
-# The language menu carries all thirty catalogs at once while the page is served
-# in the charset of the language in force, so a name written in the catalog's own
-# charset renders as mojibake for everyone else. Each has to leave as an ASCII
-# character reference, and the menu must therefore be the same bytes whatever
-# language the page is in (#116).
+# Every catalog names itself in its own charset, but the menu shows them together
+# on a page served in one of those charsets. So each name has to leave as an ASCII
+# character reference, and the menu must read the same under any charset (#116).
 
 set -euo pipefail
 
@@ -52,30 +50,30 @@ if [ "$(<"${work}/menu-en.charset")" = "$(<"${work}/menu-ru.charset")" ]; then
     fail "both pages are $(<"${work}/menu-en.charset"); pick two languages that differ"
 fi
 
-"${HTS_PYTHON}" - "${distdir}/lang" "${work}/menu-en" "${work}/menu-ru" <<'PY' || fail "wrong menu (see above)"
-import glob, os, re, sys
+"${HTS_PYTHON}" - "${distdir}" "${work}/menu-en" "${work}/menu-ru" <<'PY' || fail "wrong menu (see above)"
+import os, re, sys
 
-langdir, first, second = sys.argv[1:4]
-OPTION = rb"<option value=\d+(?: selected)?>([^<]*)</option>"
+distdir, first, second = sys.argv[1:4]
+OPTION = rb"<option value=(\d+)(?: selected)?>([^<]*)</option>"
 
 
-def labels(path):
+def options(path):
     blob = open(path, "rb").read()
     high = [b for b in blob if b > 0x7F]
     if high:
         sys.exit("%s: %d non-ASCII bytes in the menu: %r" % (path, len(high), high[:8]))
-    return [m.group(1).decode("ascii") for m in re.finditer(OPTION, blob)]
+    return [(int(m.group(1)), m.group(2).decode("ascii")) for m in re.finditer(OPTION, blob)]
 
 
-got = labels(first)
-if got != labels(second):
-    sys.exit("the menu names differ between an English and a Russian page")
+got = options(first)
+if got != options(second):
+    sys.exit("the menu differs between an English and a Russian page")
 
 
 def field(blob, key):
     m = re.search(rb"(?m)^" + key + rb"\r?$", blob)
     if not m:
-        return None
+        sys.exit("no %s" % key.decode("ascii"))
     return blob[m.end() + 1 :].split(b"\n", 1)[0].rstrip(b"\r")
 
 
@@ -93,18 +91,24 @@ def reference(name):
     return out
 
 
-want = set()
-for path in sorted(glob.glob(os.path.join(langdir, "*.txt"))):
-    blob = open(path, "rb").read()
+# lang.def numbers the catalogs and names their files; option N must carry the
+# name inside file N, so a menu that lists them all but shuffled still fails.
+defs = open(os.path.join(distdir, "lang.def"), "rb").read().split(b"\n")
+defs = [line.rstrip(b"\r").decode("ascii", "replace") for line in defs]
+want = []
+for i in range(0, len(defs) - 1, 2):
+    m = re.fullmatch(r"LANGUAGE_(\d+)", defs[i + 1])
+    if not m:
+        continue
+    blob = open(os.path.join(distdir, "lang", defs[i] + ".txt"), "rb").read()
     charset = field(blob, b"LANGUAGE_CHARSET").decode("ascii")
-    want.add(reference(field(blob, b"LANGUAGE_NAME").decode(charset)))
+    want.append((int(m.group(1)), reference(field(blob, b"LANGUAGE_NAME").decode(charset))))
 
-# An unexpanded menu would satisfy the set comparison below vacuously.
-if len(got) != len(want):
-    sys.exit("%d options for %d catalogs: %r" % (len(got), len(want), got))
-if set(got) != want:
-    sys.exit("menu %r does not name the catalogs: missing %r, unexpected %r"
-             % (got, sorted(want - set(got)), sorted(set(got) - want)))
+# A truncated lang.def parse would make the comparison below vacuous.
+if len(want) < 25:
+    sys.exit("only %d catalogs parsed from lang.def" % len(want))
+if got != want:
+    sys.exit("menu %r does not match the catalogs %r" % (got, want))
 PY
 
 echo "PASS"

--- a/tests/320_webhttrack-lang-names.test
+++ b/tests/320_webhttrack-lang-names.test
@@ -1,0 +1,110 @@
+#!/bin/bash
+#
+# The language menu carries all thirty catalogs at once while the page is served
+# in the charset of the language in force, so a name written in the catalog's own
+# charset renders as mojibake for everyone else. Each has to leave as an ASCII
+# character reference, and the menu must therefore be the same bytes whatever
+# language the page is in (#116).
+
+set -euo pipefail
+
+# shellcheck source=tests/webhttracklib.sh
+. "${0%"${0##*/}"}./webhttracklib.sh"
+
+htsserver_require
+distdir=${HTS_DISTDIR}
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_langnames.XXXXXX") || fail "no tmpdir"
+cleanup() {
+    htsserver_cleanup
+    rm -rf "${work}"
+}
+cleanup_push cleanup
+
+# Leaves the URL in ${HTS_URL}; never call it from a $(...), or the pids it
+# records would stay in the subshell and every server would keep running.
+serve() { # $1 = language index
+    mkdir -p "${work}/h$1"
+    htsserver_start --home "${work}/h$1" --log "${work}/srv$1.log" lang "$1"
+}
+
+menu() { # $1 = language index, $2 = file for the <select> block, plus .charset
+    serve "$1"
+    "${HTS_PYTHON}" - "${HTS_URL}" "$2" <<'PY' || fail "no language menu in the page"
+import re, sys, urllib.request
+
+raw = urllib.request.urlopen(sys.argv[1], timeout=20).read()
+block = re.search(rb'<select name="lang".*?</select>', raw, re.S)
+charset = re.search(rb'charset=([^"]*)"', raw)
+if not block or not charset:
+    sys.exit("no language <select> or no declared charset in the page")
+open(sys.argv[2], "wb").write(block.group(0))
+open(sys.argv[2] + ".charset", "wb").write(charset.group(1))
+PY
+}
+
+printf '[the language menu names every catalog, in every page charset] ..\t'
+# 1 is English, 8 Russian. Their charsets have to differ, or identical menu bytes
+# below would prove nothing about surviving the one the page is served in.
+menu 1 "${work}/menu-en"
+menu 8 "${work}/menu-ru"
+if [ "$(<"${work}/menu-en.charset")" = "$(<"${work}/menu-ru.charset")" ]; then
+    fail "both pages are $(<"${work}/menu-en.charset"); pick two languages that differ"
+fi
+
+"${HTS_PYTHON}" - "${distdir}/lang" "${work}/menu-en" "${work}/menu-ru" <<'PY' || fail "wrong menu (see above)"
+import glob, os, re, sys
+
+langdir, first, second = sys.argv[1:4]
+OPTION = rb"<option value=\d+(?: selected)?>([^<]*)</option>"
+
+
+def labels(path):
+    blob = open(path, "rb").read()
+    high = [b for b in blob if b > 0x7F]
+    if high:
+        sys.exit("%s: %d non-ASCII bytes in the menu: %r" % (path, len(high), high[:8]))
+    return [m.group(1).decode("ascii") for m in re.finditer(OPTION, blob)]
+
+
+got = labels(first)
+if got != labels(second):
+    sys.exit("the menu names differ between an English and a Russian page")
+
+
+def field(blob, key):
+    m = re.search(rb"(?m)^" + key + rb"\r?$", blob)
+    if not m:
+        return None
+    return blob[m.end() + 1 :].split(b"\n", 1)[0].rstrip(b"\r")
+
+
+def reference(name):
+    # What the emitter owes us: ASCII kept, HTML specials escaped, the rest named
+    # by code point so the page charset cannot reach it.
+    out = ""
+    for c in name:
+        if c in "&<>'":
+            out += {"&": "&amp;", "<": "&lt;", ">": "&gt;", "'": "&#39;"}[c]
+        elif ord(c) < 0x80:
+            out += c
+        else:
+            out += "&#%d;" % ord(c)
+    return out
+
+
+want = set()
+for path in sorted(glob.glob(os.path.join(langdir, "*.txt"))):
+    blob = open(path, "rb").read()
+    charset = field(blob, b"LANGUAGE_CHARSET").decode("ascii")
+    want.add(reference(field(blob, b"LANGUAGE_NAME").decode(charset)))
+
+# An unexpanded menu would satisfy the set comparison below vacuously.
+if len(got) != len(want):
+    sys.exit("%d options for %d catalogs: %r" % (len(got), len(want), got))
+if set(got) != want:
+    sys.exit("menu %r does not name the catalogs: missing %r, unexpected %r"
+             % (got, sorted(want - set(got)), sorted(set(got) - want)))
+PY
+
+echo "PASS"

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -158,26 +158,30 @@ else
     fi
 fi
 
-# The language menu lists every catalog side by side, so a LANGUAGE_NAME left in
-# English reads as a defect among the endonyms (#116). Two oracles rather than a
-# copy of the current values: the name may repeat neither a word of the catalog's
-# own English LANGUAGE_WINDOWSID nor a common English language name.
-exonyms="albanian arabic basque belarusian bulgarian catalan chinese croatian czech
-danish dutch english estonian finnish flemish french galician georgian german greek
-hebrew hindi hungarian icelandic indonesian irish italian japanese korean latvian
-lithuanian macedonian malay norwegian persian polish portuguese romanian russian
-serbian simplified slovak slovene slovenian spanish swedish thai traditional turkish
-ukrainian uzbek vietnamese welsh"
+# LANGUAGE_NAME must be the endonym, not English: the menu shows every catalog
+# together (#116). Two oracles rather than a copy of the current values, so the
+# name may repeat neither a word of the catalog's own English LANGUAGE_WINDOWSID
+# nor a common English language name. A language whose endonym really is the
+# English word joins own_name_is_english below.
+own_name_is_english="en"
+exonyms="afrikaans albanian arabic basque belarusian bulgarian catalan chinese croatian czech
+danish dutch english estonian farsi filipino finnish flemish french galician georgian
+german greek hebrew hindi hungarian icelandic indonesian irish italian japanese kazakh
+korean latvian lithuanian macedonian malay norwegian persian polish portuguese
+romanian russian serbian simplified slovak slovene slovenian spanish swedish thai
+traditional turkish ukrainian urdu uzbek vietnamese welsh"
 
 name_is_endonym() {
     f=$1
     LC_ALL=C iconv -f "$(field "$f" LANGUAGE_CHARSET)" -t UTF-8 "$f" >"$tmp/u8" || return 1
     LC_ALL=C awk -v name="$(field "$tmp/u8" LANGUAGE_NAME)" -v iso="$(field "$f" LANGUAGE_ISO)" \
-        -v wid="$(field "$tmp/u8" LANGUAGE_WINDOWSID)" -v exonyms="$exonyms" -v n="${f##*/}" '
+        -v wid="$(field "$tmp/u8" LANGUAGE_WINDOWSID)" -v exonyms="$exonyms" -v n="${f##*/}" \
+        -v exempt="$own_name_is_english" '
         BEGIN {
-            # English is its own endonym.
-            if (iso == "en")
-                exit 0
+            split(exempt, x, /[ \t\n]+/)
+            for (i in x)
+                if (x[i] == iso)
+                    exit 0
             split(exonyms, e, /[ \t\n]+/)
             for (i in e)
                 bad_word[e[i]] = 1
@@ -199,14 +203,19 @@ if ! command -v iconv >/dev/null 2>&1; then
     echo "iconv not found; endonym check skipped" >&2
 else
     # One control per oracle: an English name its own catalog does not name, then
-    # a word its LANGUAGE_WINDOWSID does but the list above does not.
+    # a word its LANGUAGE_WINDOWSID does but the list above does not. Match the
+    # complaint, not the status: an unreadable fixture also returns non-zero.
     LC_ALL=C sed '2s/.*/Swedish/' "$langdir/Dansk.txt" >"$tmp/exonym.txt"
     LC_ALL=C sed '2s/.*/Nynorsk/' "$langdir/Norsk.txt" >"$tmp/wid.txt"
     for probe in exonym wid; do
-        if name_is_endonym "$tmp/$probe.txt" >/dev/null; then
-            echo "the endonym check passed a deliberately English name ($probe)"
+        said=$(name_is_endonym "$tmp/$probe.txt" || true)
+        case $said in
+        *"is the English name"*) ;;
+        *)
+            echo "the endonym check passed a deliberately English name ($probe): [$said]"
             exit 1
-        fi
+            ;;
+        esac
     done
     for f in "$langdir"/*.txt; do
         name_is_endonym "$f" || fail=1

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -78,9 +78,16 @@ c1=$(printf '\302[\200-\237]')
 # the ASCII range because an awk record cannot hold one, and no lang file has any.
 utf8_full_line=$(printf '^([\001-\177]|[\302-\337][\200-\277]|\340[\240-\277][\200-\277]|[\341-\354][\200-\277][\200-\277]|\355[\200-\237][\200-\277]|[\356-\357][\200-\277][\200-\277]|\360[\220-\277][\200-\277][\200-\277]|[\361-\363][\200-\277][\200-\277][\200-\277]|\364[\200-\217][\200-\277][\200-\277])*$')
 high_byte=$(printf '[\200-\377]')
+# The value line following a metadata key. Most catalogs are CRLF, Uzbek.txt is not.
+field() {
+    LC_ALL=C awk -v key="$2" '
+        { sub(/\r$/, "") }
+        $0 == key { getline v; sub(/\r$/, "", v); print v; exit }' "$1"
+}
+
 charset_declared_matches_bytes() {
     f=$1
-    cs=$(LC_ALL=C awk '{ sub(/\r$/, "") } $0 == "LANGUAGE_CHARSET" { p = 1; next } p { print; exit }' "$f")
+    cs=$(field "$f" LANGUAGE_CHARSET)
     if [ -z "$cs" ]; then
         echo "${f##*/}: no LANGUAGE_CHARSET declared"
         return 1
@@ -149,6 +156,61 @@ else
         echo "charset check saw $nchecked of $nfiles language files"
         exit 1
     fi
+fi
+
+# The language menu lists every catalog side by side, so a LANGUAGE_NAME left in
+# English reads as a defect among the endonyms (#116). Two oracles rather than a
+# copy of the current values: the name may repeat neither a word of the catalog's
+# own English LANGUAGE_WINDOWSID nor a common English language name.
+exonyms="albanian arabic basque belarusian bulgarian catalan chinese croatian czech
+danish dutch english estonian finnish flemish french galician georgian german greek
+hebrew hindi hungarian icelandic indonesian irish italian japanese korean latvian
+lithuanian macedonian malay norwegian persian polish portuguese romanian russian
+serbian simplified slovak slovene slovenian spanish swedish thai traditional turkish
+ukrainian uzbek vietnamese welsh"
+
+name_is_endonym() {
+    f=$1
+    LC_ALL=C iconv -f "$(field "$f" LANGUAGE_CHARSET)" -t UTF-8 "$f" >"$tmp/u8" || return 1
+    LC_ALL=C awk -v name="$(field "$tmp/u8" LANGUAGE_NAME)" -v iso="$(field "$f" LANGUAGE_ISO)" \
+        -v wid="$(field "$tmp/u8" LANGUAGE_WINDOWSID)" -v exonyms="$exonyms" -v n="${f##*/}" '
+        BEGIN {
+            # English is its own endonym.
+            if (iso == "en")
+                exit 0
+            split(exonyms, e, /[ \t\n]+/)
+            for (i in e)
+                bad_word[e[i]] = 1
+            split(tolower(wid), w, /[^0-9A-Za-z]+/)
+            for (i in w)
+                if (w[i] != "")
+                    bad_word[w[i]] = 1
+            split(tolower(name), t, /[ ()\/,.-]+/)
+            for (i in t) {
+                if (t[i] != "" && t[i] in bad_word) {
+                    printf "%s: LANGUAGE_NAME \"%s\" is the English name, not the endonym (#116)\n", n, name
+                    exit 1
+                }
+            }
+        }'
+}
+
+if ! command -v iconv >/dev/null 2>&1; then
+    echo "iconv not found; endonym check skipped" >&2
+else
+    # One control per oracle: an English name its own catalog does not name, then
+    # a word its LANGUAGE_WINDOWSID does but the list above does not.
+    LC_ALL=C sed '2s/.*/Swedish/' "$langdir/Dansk.txt" >"$tmp/exonym.txt"
+    LC_ALL=C sed '2s/.*/Nynorsk/' "$langdir/Norsk.txt" >"$tmp/wid.txt"
+    for probe in exonym wid; do
+        if name_is_endonym "$tmp/$probe.txt" >/dev/null; then
+            echo "the endonym check passed a deliberately English name ($probe)"
+            exit 1
+        fi
+    done
+    for f in "$langdir"/*.txt; do
+        name_is_endonym "$f" || fail=1
+    done
 fi
 
 # lang.def maps each LANG_* macro to the English string the GUI compiles in,

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -170,10 +170,16 @@ german greek hebrew hindi hungarian icelandic indonesian irish italian japanese 
 korean latvian lithuanian macedonian malay norwegian persian polish portuguese
 romanian russian serbian simplified slovak slovene slovenian spanish swedish thai
 traditional turkish ukrainian urdu uzbek vietnamese welsh"
+# BSD awk rejects a newline inside a -v value, so the list travels on one line.
+exonyms=$(printf '%s' "$exonyms" | tr '\n' ' ')
 
 name_is_endonym() {
     f=$1
-    LC_ALL=C iconv -f "$(field "$f" LANGUAGE_CHARSET)" -t UTF-8 "$f" >"$tmp/u8" || return 1
+    cs=$(field "$f" LANGUAGE_CHARSET)
+    if ! LC_ALL=C iconv -f "$cs" -t UTF-8 "$f" >"$tmp/u8"; then
+        echo "${f##*/}: iconv cannot read $cs"
+        return 1
+    fi
     LC_ALL=C awk -v name="$(field "$tmp/u8" LANGUAGE_NAME)" -v iso="$(field "$f" LANGUAGE_ISO)" \
         -v wid="$(field "$tmp/u8" LANGUAGE_WINDOWSID)" -v exonyms="$exonyms" -v n="${f##*/}" \
         -v exempt="$own_name_is_english" '


### PR DESCRIPTION
The WebHTTrack language menu never showed `LANGUAGE_NAME`. `htslang_load` ignores the key it is handed and returns the catalog's `lang.def` file name instead, which is why the list reads "Dansk, Deutsch, Russian, Turkish, Chinese-BIG5". It now honours the key, and the fourteen catalogs still named in English get their endonym, so all thirty follow one rule.

The charset is what kept the issue open. The menu holds every catalog at once, but the page is served in one language's charset, so a Cyrillic name in windows-1251 bytes is mojibake for anyone not in Cyrillic. `LANG_LIST` now transcodes each name to UTF-8 and the emitter writes anything above ASCII as a numeric character reference, which names a code point and survives whatever the page declares. Romanian keeps its catalog's Latin-1 convention (`Rom&#226;n&#227;`); ISO-8859-1 has no a-breve.

WinHTTrack is untouched: it has its own `LANG_LOAD` and its list still shows the `lang.def` file names, so the two front ends now name languages differently until the Windows side follows.

Closes #116