### PR TITLE
A crawled link long enough to fill save[] aborts the mirror in the -N template branch

### DIFF
--- a/src/htsname.c
+++ b/src/htsname.c
@@ -1664,9 +1664,9 @@ int url_savename(lien_adrfilsave *const afs,
           }
       }
 
-      // last segment. Skip the separator when there is no directory part: the
-      // copy below would run ahead of its own source and overwrite wsave[0].
-      if (j > 0)
+      // last segment. Skip the separator when the name has no directory part:
+      // the copy below would run ahead of its own source and overwrite it.
+      if (lastSeg > 0)
         wsave[j++] = '/';
 #define MAX_UTF8_SEQ_CHARS 4
       {

--- a/src/htsname.c
+++ b/src/htsname.c
@@ -360,6 +360,8 @@ void url_savename_addtail(char *d, size_t dsize, const char *sep,
 static void tmpl_catn(char *d, size_t dsize, const char *s, size_t n) {
   size_t i = strlen(d);
 
+  if (i + 1 >= dsize) /* nothing fits, and d already carries its NUL */
+    return;
   for (; *s != '\0' && n != 0 && i + 1 < dsize; n--)
     d[i++] = *s++;
   d[i] = '\0';
@@ -373,11 +375,11 @@ static void tmpl_catc(char *d, size_t dsize, char c) {
   tmpl_catn(d, dsize, s, 1);
 }
 
-/* Appends building a savename_type -1 name out of a crawled link, as long as
-   the server likes: they clip, never abort (#1295). URL text gives up its own
-   tail (TMPL_CAT); the separators, extension and digest the template asks for
-   collect in tmpltail and go in through url_savename_addtail(), which pushes
-   the middle out instead. One run, or ".html" would cut away its own dot. */
+/* Appends building a savename_type -1 name from a crawled link, which is as
+   long as the server likes: they clip, never abort (#1295). URL text loses
+   its own tail (TMPL_CAT). The template's separators, extension and digest
+   collect in tmpltail, then go in through url_savename_addtail(), which cuts
+   the middle instead. One run, or ".html" would cut away its own dot. */
 #define TMPL_FLUSH()                                                           \
   do {                                                                         \
     if (tmpltail[0] != '\0') {                                                 \
@@ -1024,7 +1026,7 @@ int url_savename(lien_adrfilsave *const afs,
 
     // build the name
     tmpltail[0] = '\0';
-    /* walked whole: stopping short would drop the extension the appends keep */
+    /* parse to the end, or the extension the appends protect never arrives */
     while (*a != '\0') {
       if (*a == '%') {
         int short_ver = 0;
@@ -1047,7 +1049,7 @@ int url_savename(lien_adrfilsave *const afs,
               name[pos][0] = '\0';
             }
             pos = 0;
-            /* one byte spare in each token for the '=' appended below */
+            /* one byte spare in each token for the '=' name[0] gets below */
             while(*a != '\0' && *a != ']') {
               if (*a == ':') { // next token; past the fifth they are dropped
                 c = pos + 1 < 5 ? name[++pos] : NULL;
@@ -1076,8 +1078,9 @@ int url_savename(lien_adrfilsave *const afs,
                 if (*c != '\0' && *c != '&') {
                   char *d = name[0];
 
-                  /* */
-                  while(*c != '\0' && *c != '&') {
+                  /* crawled query text: clip it into the token buffer */
+                  while (*c != '\0' && *c != '&' &&
+                         d + 1 < name[0] + sizeof(name[0])) {
                     *d++ = *c++;
                   }
                   *d = '\0';
@@ -1661,8 +1664,8 @@ int url_savename(lien_adrfilsave *const afs,
           }
       }
 
-      // last segment; no separator when there is no directory part, or the copy
-      // below runs ahead of its own source and smears wsave[0] over the name.
+      // last segment. Skip the separator when there is no directory part: the
+      // copy below would run ahead of its own source and overwrite wsave[0].
       if (j > 0)
         wsave[j++] = '/';
 #define MAX_UTF8_SEQ_CHARS 4

--- a/src/htsname.c
+++ b/src/htsname.c
@@ -356,6 +356,46 @@ void url_savename_addtail(char *d, size_t dsize, const char *sep,
   strlcatbuff(d, s, dsize);
 }
 
+/* Append at most n characters of s, clipped to dsize. */
+static void tmpl_catn(char *d, size_t dsize, const char *s, size_t n) {
+  size_t i = strlen(d);
+
+  for (; *s != '\0' && n != 0 && i + 1 < dsize; n--)
+    d[i++] = *s++;
+  d[i] = '\0';
+}
+
+static void tmpl_catc(char *d, size_t dsize, char c) {
+  char s[2];
+
+  s[0] = c;
+  s[1] = '\0';
+  tmpl_catn(d, dsize, s, 1);
+}
+
+/* Appends building a savename_type -1 name out of a crawled link, as long as
+   the server likes: they clip, never abort (#1295). URL text gives up its own
+   tail (TMPL_CAT); the separators, extension and digest the template asks for
+   collect in tmpltail and go in through url_savename_addtail(), which pushes
+   the middle out instead. One run, or ".html" would cut away its own dot. */
+#define TMPL_FLUSH()                                                           \
+  do {                                                                         \
+    if (tmpltail[0] != '\0') {                                                 \
+      url_savename_addtail(afs->save, sizeof(afs->save), "", tmpltail);        \
+      tmpltail[0] = '\0';                                                      \
+    }                                                                          \
+  } while (0)
+#define TMPL_CATN(S, N)                                                        \
+  do {                                                                         \
+    TMPL_FLUSH();                                                              \
+    tmpl_catn(afs->save, sizeof(afs->save), (S), (size_t) (N));                \
+  } while (0)
+#define TMPL_CAT(S) TMPL_CATN((S), (size_t) -1)
+#define TMPL_TAILN(S, N)                                                       \
+  tmpl_catn(tmpltail, sizeof(tmpltail), (S), (size_t) (N))
+#define TMPL_TAIL(S) TMPL_TAILN((S), (size_t) -1)
+#define TMPL_TAILC(C) tmpl_catc(tmpltail, sizeof(tmpltail), (C))
+
 // Build the local save name (save) from adr/fil; renames on collision
 // (e.g. INDEX.HTML vs index.html).
 int url_savename(lien_adrfilsave *const afs,
@@ -962,7 +1002,7 @@ int url_savename(lien_adrfilsave *const afs,
   // ajouter nom du site éventuellement en premier
   if (opt->savename_type == -1) {       // utiliser savename_userdef! (%h%p/%n%q.%t)
     const char *a = StringBuff(opt->savename_userdef);
-    htsbuff sb = htsbuff_array(afs->save);
+    char BIGSTK tmpltail[HTS_URLMAXSIZE * 2];
 
     /*char *nom_pos=NULL,*dot_pos=NULL;  // Position nom et point */
     char tok;
@@ -983,7 +1023,9 @@ int url_savename(lien_adrfilsave *const afs,
      */
 
     // build the name
-    while ((*a) && (sb.len < HTS_URLMAXSIZE)) { // parse, but not too long
+    tmpltail[0] = '\0';
+    /* walked whole: stopping short would drop the extension the appends keep */
+    while (*a != '\0') {
       if (*a == '%') {
         int short_ver = 0;
 
@@ -992,6 +1034,8 @@ int url_savename(lien_adrfilsave *const afs,
           short_ver = 1;
           a++;
         }
+        if (*a == '\0') /* a '%' or '%s' ending the template */
+          break;
         switch (tok = *a++) {
         case '[':              // %[param:prefix_if_not_empty:suffix_if_not_empty:empty_replacement:notfound_replacement]
           if (strchr(a, ']')) {
@@ -1003,16 +1047,16 @@ int url_savename(lien_adrfilsave *const afs,
               name[pos][0] = '\0';
             }
             pos = 0;
+            /* one byte spare in each token for the '=' appended below */
             while(*a != '\0' && *a != ']') {
-              if (pos < 5) {
-                if (*a == ':') {        // next token
-                  c = name[++pos];
-                  a++;
-                } else {
-                  *c++ = *a++;
-                  *c = '\0';
-                }
+              if (*a == ':') { // next token; past the fifth they are dropped
+                c = pos + 1 < 5 ? name[++pos] : NULL;
+              } else if (c != NULL &&
+                         (size_t) (c - name[pos]) + 2 < sizeof(name[pos])) {
+                *c++ = *a;
+                *c = '\0';
               }
+              a++;
             }
             if (*a == ']') {
               a++;
@@ -1028,7 +1072,7 @@ int url_savename(lien_adrfilsave *const afs,
               }
               if (cp) {
                 c = cp + strlen(name[0]);       /* jumps "param=" */
-                htsbuff_cat(&sb, name[1]);      /* prefix */
+                TMPL_TAIL(name[1]);             /* prefix */
                 if (*c != '\0' && *c != '&') {
                   char *d = name[0];
 
@@ -1039,88 +1083,88 @@ int url_savename(lien_adrfilsave *const afs,
                   *d = '\0';
                   d = unescape_http(catbuff, sizeof(catbuff), name[0]);
                   if (d && *d) {
-                    htsbuff_cat(&sb, d); /* value */
+                    TMPL_CAT(d); /* value */
                   } else {
-                    htsbuff_cat(&sb, name[3]); /* empty replacement if any */
+                    TMPL_TAIL(name[3]); /* empty replacement if any */
                   }
                 } else {
-                  htsbuff_cat(&sb, name[3]); /* empty replacement if any */
+                  TMPL_TAIL(name[3]); /* empty replacement if any */
                 }
-                htsbuff_cat(&sb, name[2]); /* suffix */
+                TMPL_TAIL(name[2]); /* suffix */
               } else {
-                htsbuff_cat(&sb, name[4]); /* not found replacement if any */
+                TMPL_TAIL(name[4]); /* not found replacement if any */
               }
             } else {
-              htsbuff_cat(&sb, name[4]); /* not found replacement if any */
+              TMPL_TAIL(name[4]); /* not found replacement if any */
             }
           }
           break;
         case '%':
-          htsbuff_catc(&sb, '%');
+          TMPL_TAILC('%');
           break;
         case 'n': // name without extension
           if (dot_pos) {
             if (!short_ver)
-              htsbuff_catn(&sb, nom_pos, (int) (dot_pos - nom_pos));
+              TMPL_CATN(nom_pos, (int) (dot_pos - nom_pos));
             else
-              htsbuff_catn(&sb, nom_pos, min((int) (dot_pos - nom_pos), 8));
+              TMPL_CATN(nom_pos, min((int) (dot_pos - nom_pos), 8));
           } else {
             if (!short_ver)
-              htsbuff_cat(&sb, nom_pos);
+              TMPL_CAT(nom_pos);
             else
-              htsbuff_catn(&sb, nom_pos, 8);
+              TMPL_CATN(nom_pos, 8);
           }
           break;
         case 'N': // name with extension
           if (dot_pos) {
             if (!short_ver)
-              htsbuff_catn(&sb, nom_pos, (int) (dot_pos - nom_pos));
+              TMPL_CATN(nom_pos, (int) (dot_pos - nom_pos));
             else
-              htsbuff_catn(&sb, nom_pos, min((int) (dot_pos - nom_pos), 8));
+              TMPL_CATN(nom_pos, min((int) (dot_pos - nom_pos), 8));
           } else {
             if (!short_ver)
-              htsbuff_cat(&sb, nom_pos);
+              TMPL_CAT(nom_pos);
             else
-              htsbuff_catn(&sb, nom_pos, 8);
+              TMPL_CATN(nom_pos, 8);
           }
-          htsbuff_catc(&sb, '.');
+          TMPL_TAILC('.');
           if (dot_pos) {
             if (!short_ver)
-              htsbuff_cat(&sb, dot_pos + 1);
+              TMPL_TAIL(dot_pos + 1);
             else
-              htsbuff_catn(&sb, dot_pos + 1, 3);
+              TMPL_TAILN(dot_pos + 1, 3);
           } else {
             if (!short_ver)
-              htsbuff_cat(&sb, DEFAULT_EXT + 1); // skip the leading dot
+              TMPL_TAIL(DEFAULT_EXT + 1); // skip the leading dot
             else
-              htsbuff_cat(&sb, DEFAULT_EXT_SHORT + 1); // skip the leading dot
+              TMPL_TAIL(DEFAULT_EXT_SHORT + 1); // skip the leading dot
           }
           break;
         case 't': // extension
           if (dot_pos) {
             if (!short_ver)
-              htsbuff_cat(&sb, dot_pos + 1);
+              TMPL_TAIL(dot_pos + 1);
             else
-              htsbuff_catn(&sb, dot_pos + 1, 3);
+              TMPL_TAILN(dot_pos + 1, 3);
           } else {
             if (!short_ver)
-              htsbuff_cat(&sb, DEFAULT_EXT + 1); // skip the leading dot
+              TMPL_TAIL(DEFAULT_EXT + 1); // skip the leading dot
             else
-              htsbuff_cat(&sb, DEFAULT_EXT_SHORT + 1); // skip the leading dot
+              TMPL_TAIL(DEFAULT_EXT_SHORT + 1); // skip the leading dot
           }
           break;
         case 'p': // path without trailing /
           if (nom_pos !=
               fil + 1) { // skip when the path is empty (e.g. /index.html)
             if (!short_ver) {
-              htsbuff_catn(&sb, fil, (int) (nom_pos - fil) - 1);
+              TMPL_CATN(fil, (int) (nom_pos - fil) - 1);
             } else {
               char BIGSTK pth[HTS_URLMAXSIZE * 2], n83[HTS_URLMAXSIZE * 2];
 
               pth[0] = n83[0] = '\0';
               strncatbuff(pth, fil, (int) (nom_pos - fil) - 1);
               long_to_83(opt->savename_83, n83, sizeof(n83), pth);
-              htsbuff_cat(&sb, n83);
+              TMPL_CAT(n83);
             }
           }
           break;
@@ -1131,9 +1175,9 @@ int url_savename(lien_adrfilsave *const afs,
 
             /* Copy address */
             if (!short_ver)
-              htsbuff_cat(&sb, final_adr);
+              TMPL_CAT(final_adr);
             else
-              htsbuff_cat(&sb, final_adr);
+              TMPL_CAT(final_adr);
 
             /* release */
             RELEASE_ADR();
@@ -1142,26 +1186,27 @@ int url_savename(lien_adrfilsave *const afs,
         case 'H': // host, raw (old mode)
           if (protocol == PROTOCOL_FILE) {
             if (!short_ver)
-              htsbuff_cat(&sb, "localhost");
+              TMPL_CAT("localhost");
             else
-              htsbuff_cat(&sb, "local");
+              TMPL_CAT("local");
           } else {
             if (!short_ver)
-              htsbuff_cat(&sb, print_adr);
+              TMPL_CAT(print_adr);
             else
-              htsbuff_catn(&sb, print_adr, 8);
+              TMPL_CATN(print_adr, 8);
           }
           break;
         case 'M': /* host/address?query MD5 (128-bits) */
         {
           char digest[32 + 2];
-          char BIGSTK buff[HTS_URLMAXSIZE * 2];
+          /* sized for both sources, and clipped so a longer one cannot abort */
+          char BIGSTK buff[sizeof(afs->af.adr) + sizeof(afs->af.fil)];
 
           digest[0] = buff[0] = '\0';
-          strcpybuff(buff, adr);
-          strcatbuff(buff, fil_complete);
+          tmpl_catn(buff, sizeof(buff), adr, (size_t) -1);
+          tmpl_catn(buff, sizeof(buff), fil_complete, (size_t) -1);
           domd5mem(buff, strlen(buff), digest, 1);
-          htsbuff_cat(&sb, digest);
+          TMPL_TAIL(digest);
         } break;
         case 'Q':
         case 'q': /* query MD5 (128-bits/16-bits)
@@ -1169,11 +1214,11 @@ int url_savename(lien_adrfilsave *const afs,
         {
           char md5[32 + 2];
 
-          htsbuff_catn(&sb, url_md5(md5, fil_complete), (tok == 'Q') ? 32 : 4);
+          TMPL_TAILN(url_md5(md5, fil_complete), (tok == 'Q') ? 32 : 4);
         } break;
         case 'r':
         case 'R':              // protocol
-          htsbuff_cat(&sb, protocol_str[protocol]);
+          TMPL_TAIL(protocol_str[protocol]);
           break;
 
           /* Patch by Juan Fco Rodriguez to get the full query string */
@@ -1182,15 +1227,16 @@ int url_savename(lien_adrfilsave *const afs,
             char *d = strchr(fil_complete, '?');
 
             if (d != NULL) {
-              htsbuff_cat(&sb, d);
+              TMPL_CAT(d);
             }
           }
           break;
 
         }
       } else
-        htsbuff_catc(&sb, *a++);
+        TMPL_TAILC(*a++);
     }
+    TMPL_FLUSH();
     //
     // predefined types
     //
@@ -1615,8 +1661,10 @@ int url_savename(lien_adrfilsave *const afs,
           }
       }
 
-      // last segment
-      wsave[j++] = '/';
+      // last segment; no separator when there is no directory part, or the copy
+      // below runs ahead of its own source and smears wsave[0] over the name.
+      if (j > 0)
+        wsave[j++] = '/';
 #define MAX_UTF8_SEQ_CHARS 4
       {
         // #623: the ".delayed" placeholder marker sits at the tail; cutting

--- a/tests/316_engine-savename-template.test
+++ b/tests/316_engine-savename-template.test
@@ -5,64 +5,92 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-# url_savename()'s savename_type -1 branch, the one -N '<template>' selects,
-# builds the name out of a crawled link and used to abort the whole mirror once
-# that link outgrew save[] (#1295). filpad=N expands the '*' in the path into N
-# bytes, past what argv can carry; -#test=savename poisons the bytes behind
-# save[] and exits non-zero if the naming path reached them.
+# url_savename()'s savename_type -1 branch is the one -N '<template>' selects.
+# It builds the name out of a crawled link, and used to abort the whole mirror
+# once that link outgrew save[] (#1295). filpad=N expands the '*' in the path
+# into N bytes, past what argv can carry. -#test=savename poisons the bytes
+# behind save[] and exits non-zero if the naming path reached them.
 
 # 40 bytes, so the host survives the downstream shortener as one whole segment
-# on every platform (its per-segment ceiling is 48 on Windows).
+# on every platform: its per-segment ceiling is 48 on Windows. Every name
+# asserted whole below also stays under its per-path ceiling, 236 on Windows.
 host=$(printf '%040d' 0 | tr '0' h)
 long_host=$(printf '%01000d' 0 | tr '0' h)
 
+# The two properties an over-long link must leave intact.
+leads_with() { # leads_with HEAD PAD ADR TEMPLATE
+    selftest_queue_head "savename: /dev/null/$1" savename '/dir/*.html' \
+        text/html "filpad=$2" "adr=$3" "userdef=$4"
+}
+ends_with_name_and_ext() { # ends_with_name_and_ext PAD ADR TEMPLATE
+    selftest_queue_tail 'aaaaaaaa.html' savename '/dir/*.html' text/html \
+        "filpad=$1" "adr=$2" "userdef=$3"
+}
+
 # Everything fits: the template's own output, byte for byte.
-name=$(printf '%01900d' 0 | tr '0' a)
+name=$(printf '%0100d' 0 | tr '0' a)
 selftest_queue "savename: /dev/null/$host/dir/$name.html" savename \
-    '/dir/*.html' text/html filpad=1900 "adr=$host" 'userdef=%h%p/%n.%t'
+    '/dir/*.html' text/html filpad=100 "adr=$host" 'userdef=%h%p/%n.%t'
 
 # Past the end of save[] the link gives up its own bytes, not the template's:
-# the host, the path and the separator still lead the name, and it still ends in
-# the extension the mirror is browsed by. 2045 bytes is a hair inside the buffer
-# and 2075 well past it; the 1000-byte host overruns it before the name starts.
+# the host, the path and the separator still lead the name, and the link's own
+# bytes and its extension still end it. The pads build 2050 and 2080 bytes
+# against a 2048-byte buffer; the 1000-byte host overruns it before the name
+# starts, so there only its first bytes can be named.
 for pad in 2000 2030; do
-    for adr in "$host" "$long_host"; do
-        head="savename: /dev/null/$host/dir/"
-        test "$adr" = "$host" || head='savename: /dev/null/hhhhhhhh'
-        selftest_queue_head "$head" savename \
-            '/dir/*.html' text/html "filpad=$pad" "adr=$adr" 'userdef=%h%p/%n.%t'
-        selftest_queue_tail '.html' savename \
-            '/dir/*.html' text/html "filpad=$pad" "adr=$adr" 'userdef=%h%p/%n.%t'
-    done
+    leads_with "$host/dir/" "$pad" "$host" '%h%p/%n.%t'
+    ends_with_name_and_ext "$pad" "$host" '%h%p/%n.%t'
+    leads_with 'hhhhhhhh' "$pad" "$long_host" '%h%p/%n.%t'
+    ends_with_name_and_ext "$pad" "$long_host" '%h%p/%n.%t'
 done
 
 # %M digests host+path in a buffer of its own that held neither at full length.
-# The digest is pinned: a clipped input would still produce 32 hex bytes.
+# The digest is md5(host || path) over 3040 bytes, pinned: a clipped input, or
+# one truncated at any of the sizes that buffer has had, changes it.
 selftest_queue \
-    "savename: /dev/null/$host/4b0dd4f3a4b16a23bee663745c1f13d4.html" savename \
-    '/dir/*.html' text/html filpad=2030 "adr=$host" 'userdef=%h/%M.%t'
+    'savename: /dev/null/24e5e7d2008a5614c524ebbb8add35bd.html' savename \
+    '/dir/*.html' text/html filpad=2030 "adr=$long_host" 'userdef=%M.%t'
 
 # The 8.3 forms cut the same over-long link down to their own ceilings.
 selftest_queue "savename: /dev/null/$host/DIR/aaaaaaaa.htm" savename \
     '/dir/*.html' text/html filpad=2030 "adr=$host" 'userdef=%sh%sp/%sn.%st'
 
+# The rest of the tokens, on a link short enough to assert whole.
+selftest_queue "savename: /dev/null/http/$host/dir/page.html" savename \
+    '/dir/page.html' text/html "adr=$host" 'userdef=%r/%H%p/%N'
+selftest_queue "savename: /dev/null/$host/page8803.html" savename \
+    '/dir/page.html?id=7' text/html "adr=$host" 'userdef=%h/%n%q.%t'
+selftest_queue \
+    "savename: /dev/null/$host/page8803cb530daebc650716593bdaf77b8a.html" \
+    savename '/dir/page.html?id=7' text/html "adr=$host" 'userdef=%h/%n%Q.%t'
+
+# A %[param] value is crawled text as well, copied into a 256-byte token with
+# no bound at all. This one reaches the third token past it, which holds the
+# suffix, so the suffix arrives only if the value stayed inside its own. Both
+# ends are asserted: the shortener cuts this name's middle on Windows.
+value=$(printf '%0600d' 0 | tr '0' v)
+selftest_queue_head "savename: /dev/null/($(printf '%0150d' 0 | tr '0' v)" \
+    savename "/p?q=$value" text/html "adr=$host" 'userdef=%[q:(:).x]'
+selftest_queue_tail ').x' savename \
+    "/p?q=$value" text/html "adr=$host" 'userdef=%[q:(:).x]'
+
 # A template with no directory part at all: the shortener wrote its separator
 # ahead of the copy that follows it and smeared the name's first byte over the
 # whole thing, extension included.
-selftest_queue_head 'savename: /dev/null/aaaaaaaa' savename \
-    '/dir/*.html' text/html filpad=2030 "adr=$host" 'userdef=%n.%t'
-selftest_queue_tail '.html' savename \
-    '/dir/*.html' text/html filpad=2030 "adr=$host" 'userdef=%n.%t'
+leads_with 'aaaaaaaa' 2030 "$host" '%n.%t'
+ends_with_name_and_ext 2030 "$host" '%n.%t'
 
-# Template edges, all reached from a -N the user typed: a trailing '%' read past
-# the end of the template, a sixth %[..] token never terminated, and a token
-# longer than the 256 bytes it is parsed into overran it.
+# A '%' ending the template read past its end, and a token longer than the 256
+# bytes it is parsed into overran that buffer.
 selftest_queue "savename: /dev/null/$host/page.html" savename \
     '/dir/page.html' text/html "adr=$host" 'userdef=%h/%n.%t%'
-selftest_queue "savename: /dev/null/$host/e/page.html" savename \
-    '/dir/page.html' text/html "adr=$host" 'userdef=%h/%[a:b:c:d:e:f:g]/%n.%t'
 big_token=$(printf '%0300d' 0 | tr '0' z)
 selftest_queue "savename: /dev/null/$host/none/page.html" savename \
     '/dir/page.html' text/html "adr=$host" "userdef=%h/%[$big_token:(:):e:none]/%n.%t"
 
 selftest_run_queued
+
+# A sixth %[..] token never terminated. Left out of the batch: a spin here must
+# name its own case rather than wedge the file on the suite's wall-clock guard.
+assert_selftest "savename: /dev/null/$host/e/page.html" savename \
+    '/dir/page.html' text/html "adr=$host" 'userdef=%h/%[a:b:c:d:e:f:g]/%n.%t'

--- a/tests/316_engine-savename-template.test
+++ b/tests/316_engine-savename-template.test
@@ -66,12 +66,13 @@ selftest_queue \
 
 # A %[param] value is crawled text as well, copied into a 256-byte token with
 # no bound at all. This one reaches the third token past it, which holds the
-# suffix, so the suffix arrives only if the value stayed inside its own. Both
-# ends are asserted: the shortener cuts this name's middle on Windows.
+# suffix, so the extension arrives only if the value stayed inside its own.
+# Both ends are asserted, and neither reaches far: this name is a single
+# segment, which Windows cuts to 48 bytes, the closing ')' with it.
 value=$(printf '%0600d' 0 | tr '0' v)
-selftest_queue_head "savename: /dev/null/($(printf '%0150d' 0 | tr '0' v)" \
+selftest_queue_head "savename: /dev/null/($(printf '%040d' 0 | tr '0' v)" \
     savename "/p?q=$value" text/html "adr=$host" 'userdef=%[q:(:).x]'
-selftest_queue_tail ').x' savename \
+selftest_queue_tail '.x' savename \
     "/p?q=$value" text/html "adr=$host" 'userdef=%[q:(:).x]'
 
 # A template with no directory part at all: the shortener wrote its separator

--- a/tests/316_engine-savename-template.test
+++ b/tests/316_engine-savename-template.test
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+# url_savename()'s savename_type -1 branch, the one -N '<template>' selects,
+# builds the name out of a crawled link and used to abort the whole mirror once
+# that link outgrew save[] (#1295). filpad=N expands the '*' in the path into N
+# bytes, past what argv can carry; -#test=savename poisons the bytes behind
+# save[] and exits non-zero if the naming path reached them.
+
+# 40 bytes, so the host survives the downstream shortener as one whole segment
+# on every platform (its per-segment ceiling is 48 on Windows).
+host=$(printf '%040d' 0 | tr '0' h)
+long_host=$(printf '%01000d' 0 | tr '0' h)
+
+# Everything fits: the template's own output, byte for byte.
+name=$(printf '%01900d' 0 | tr '0' a)
+selftest_queue "savename: /dev/null/$host/dir/$name.html" savename \
+    '/dir/*.html' text/html filpad=1900 "adr=$host" 'userdef=%h%p/%n.%t'
+
+# Past the end of save[] the link gives up its own bytes, not the template's:
+# the host, the path and the separator still lead the name, and it still ends in
+# the extension the mirror is browsed by. 2045 bytes is a hair inside the buffer
+# and 2075 well past it; the 1000-byte host overruns it before the name starts.
+for pad in 2000 2030; do
+    for adr in "$host" "$long_host"; do
+        head="savename: /dev/null/$host/dir/"
+        test "$adr" = "$host" || head='savename: /dev/null/hhhhhhhh'
+        selftest_queue_head "$head" savename \
+            '/dir/*.html' text/html "filpad=$pad" "adr=$adr" 'userdef=%h%p/%n.%t'
+        selftest_queue_tail '.html' savename \
+            '/dir/*.html' text/html "filpad=$pad" "adr=$adr" 'userdef=%h%p/%n.%t'
+    done
+done
+
+# %M digests host+path in a buffer of its own that held neither at full length.
+# The digest is pinned: a clipped input would still produce 32 hex bytes.
+selftest_queue \
+    "savename: /dev/null/$host/4b0dd4f3a4b16a23bee663745c1f13d4.html" savename \
+    '/dir/*.html' text/html filpad=2030 "adr=$host" 'userdef=%h/%M.%t'
+
+# The 8.3 forms cut the same over-long link down to their own ceilings.
+selftest_queue "savename: /dev/null/$host/DIR/aaaaaaaa.htm" savename \
+    '/dir/*.html' text/html filpad=2030 "adr=$host" 'userdef=%sh%sp/%sn.%st'
+
+# A template with no directory part at all: the shortener wrote its separator
+# ahead of the copy that follows it and smeared the name's first byte over the
+# whole thing, extension included.
+selftest_queue_head 'savename: /dev/null/aaaaaaaa' savename \
+    '/dir/*.html' text/html filpad=2030 "adr=$host" 'userdef=%n.%t'
+selftest_queue_tail '.html' savename \
+    '/dir/*.html' text/html filpad=2030 "adr=$host" 'userdef=%n.%t'
+
+# Template edges, all reached from a -N the user typed: a trailing '%' read past
+# the end of the template, a sixth %[..] token never terminated, and a token
+# longer than the 256 bytes it is parsed into overran it.
+selftest_queue "savename: /dev/null/$host/page.html" savename \
+    '/dir/page.html' text/html "adr=$host" 'userdef=%h/%n.%t%'
+selftest_queue "savename: /dev/null/$host/e/page.html" savename \
+    '/dir/page.html' text/html "adr=$host" 'userdef=%h/%[a:b:c:d:e:f:g]/%n.%t'
+big_token=$(printf '%0300d' 0 | tr '0' z)
+selftest_queue "savename: /dev/null/$host/none/page.html" savename \
+    '/dir/page.html' text/html "adr=$host" "userdef=%h/%[$big_token:(:):e:none]/%n.%t"
+
+selftest_run_queued


### PR DESCRIPTION
`url_savename()`'s `savename_type == -1` branch, the one `-N '<template>'` selects, built the name with `htsbuff` appends that abort on overflow, so a crawled link long enough to fill `save[]` killed the mirror there. #1282 fixed the same class on the function's other branch and left this one out on purpose.

The appends clip now. The clip has to choose which bytes to lose, and this branch has two things worth keeping: the structure the template describes, and the extension the mirror is browsed by. So the URL's own text gives up its tail, while the separators, extension and digest the template asks for collect into one run and go in through `url_savename_addtail()`, which pushes the middle out instead. One run, because piecewise `.html` cuts away its own dot.

Reviewing the same branch turned up a worse bug beside it: a `%[param]` token's value was copied out of the query string into a 256-byte buffer with no bound at all, so a link carrying a long `q=` smashed the four token buffers behind it and then the frame. Four smaller faults go with it. `%M` digested host+path into a buffer that could hold neither at full length. A template ending in `%` read past its end. The `%[..]` parser spun forever once a sixth token opened. And the length shortener downstream put its separator ahead of the copy that follows it, so a name with no directory part, which `%n.%t` produces, came out as a run of slashes.

Test 316 drives the branch through `-#test=savename` on either side of the buffer end and across the destinations it writes to, checking that the host, the path and the extension all survive. Every fix was mutant-killed against it, the pre-fix engine included.

Closes #1295