### PR TITLE
A clipped line has its unread tail read back as another record

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -3944,15 +3944,15 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                     // ----------------------------------------
                     // traiter en-tête!
                     // status-line à récupérer
-                    binput_header(back[i].r.adr + ptr,
-                                  back[i].r.adr + back[i].r.size, rcvd, 2000,
-                                  &adv);
+                    binput_line(back[i].r.adr + ptr,
+                                back[i].r.adr + back[i].r.size, rcvd, 2000,
+                                &adv);
                     ptr += adv;
                     if (strnotempty(rcvd) == 0) {
                       /* Bogus CRLF, OR recycled connection and trailing chunk CRLF */
-                      binput_header(back[i].r.adr + ptr,
-                                    back[i].r.adr + back[i].r.size, rcvd, 2000,
-                                    &adv);
+                      binput_line(back[i].r.adr + ptr,
+                                  back[i].r.adr + back[i].r.size, rcvd, 2000,
+                                  &adv);
                       ptr += adv;
                     }
                     // traiter status-line
@@ -3975,7 +3975,7 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                     }
                     // header // ** !attention! HTTP/0.9 non supporté
                     do {
-                      const hts_boolean cut = binput_header(
+                      const hts_boolean cut = binput_line(
                           back[i].r.adr + ptr, back[i].r.adr + back[i].r.size,
                           rcvd, 2000, &adv);
 

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -587,8 +587,8 @@ static htsblk cache_readex_new(httrackp * opt, cache_back * cache,
           do {
             char *value;
             int adv;
-            /* longer than any line we write: a prefix of a foreign or damaged
-               entry would parse as a valid-looking wrong value */
+            /* no line we write is this long, so a cut one is foreign or
+               damaged and its prefix would parse as a wrong value */
             const hts_boolean cut =
                 binput_line(headerBuff + offset, headerBuff + readSizeHeader,
                             line, sizeof(line) - 1, &adv);

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -586,13 +586,18 @@ static htsblk cache_readex_new(httrackp * opt, cache_back * cache,
           headerBuff[readSizeHeader] = '\0';
           do {
             char *value;
+            int adv;
+            /* longer than any line we write: a prefix of a foreign or damaged
+               entry would parse as a valid-looking wrong value */
+            const hts_boolean cut =
+                binput_line(headerBuff + offset, headerBuff + readSizeHeader,
+                            line, sizeof(line) - 1, &adv);
 
-            line[0] = '\0';
-            offset += binput(headerBuff + offset, line, sizeof(line) - 2);
+            offset += adv;
             if (line[0] == '\0') {
               lineEof = 1;
             }
-            value = strchr(line, ':');
+            value = cut ? NULL : strchr(line, ':');
             if (value != NULL) {
               *value++ = '\0';
               if (*value == ' ' || *value == '\t')
@@ -1196,9 +1201,12 @@ void cache_init(cache_back * cache, httrackp * opt) {
 
                     while(*a && maxLine-- > 0) {        // parse only few first lines
                       char BIGSTK line[1024];
+                      int adv;
 
-                      line[0] = '\0';
-                      a += binput(a, line, sizeof(line) - 2);
+                      /* the budget must count lines, not halves of one */
+                      (void) binput_line(a, comment + readSizeHeader, line,
+                                         sizeof(line) - 1, &adv);
+                      a += adv;
                       if (strfield(line, "X-In-Cache:")) {
                         if (strfield2(line, "X-In-Cache: 1")) {
                           dataincache = 1;

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -2036,8 +2036,7 @@ int cache_url_bounds_selftest(httrackp *opt, const char *dir) {
 /* Buffer the reader rebuilds the save name into, so the longest name that fits
    is one byte less. */
 #define SAVEBOUNDS_CAP (HTS_URLMAXSIZE * 2)
-/* X-Save length used here. binput() clips the whole header line at
-   HTS_URLMAXSIZE, and "X-Save: " plus CRLF eat into it. */
+/* X-Save length used here, well inside the header line the reader can hold. */
 #define SAVEBOUNDS_REL_LEN 1000
 #define SAVEBOUNDS_GUARD 16
 #define SAVEBOUNDS_GUARD_BYTE '\x5a'

--- a/src/htscatchurl.c
+++ b/src/htscatchurl.c
@@ -172,9 +172,8 @@ HTSEXT_API hts_boolean catch_url(T_SOC soc, char *url, char *method,
       char protocol[256];
 
       line[0] = protocol[0] = '\0';
-      //
-      socinput(soc, line, 1000);
-      if (strnotempty(line)) {
+      // a clipped request-line names a URL the browser did not ask for
+      if (!socinput(soc, line, 1000) && strnotempty(line)) {
         /* widths bound the caller buffers: method[32], url[HTS_URLMAXSIZE*2],
            protocol[256] */
         if (sscanf(line, "%31s %2047s %255s", method, url, protocol) == 3) {
@@ -201,7 +200,10 @@ HTSEXT_API hts_boolean catch_url(T_SOC soc, char *url, char *method,
             // Lire en têtes restants
             sprintf(data, "%s %s %s\r\n", method, af.fil, protocol);
             while(strnotempty(line)) {
-              socinput(soc, line, 1000);
+              /* a header we could not read whole is not the one the browser
+                 sent: replaying a prefix of it is worse than dropping it */
+              if (socinput(soc, line, 1000))
+                continue;
               treathead(NULL, NULL, NULL, &blkretour, line);    // traiter
               strlcatbuff(data, line, CATCH_URL_DATA_SIZE);
               strlcatbuff(data, "\r\n", CATCH_URL_DATA_SIZE);
@@ -227,7 +229,7 @@ HTSEXT_API hts_boolean catch_url(T_SOC soc, char *url, char *method,
             retour = 1;
           }
         }
-      }                         // sinon erreur
+      } // sinon erreur
     }
   }
   if (soc != INVALID_SOCKET) {
@@ -243,8 +245,9 @@ HTSEXT_API hts_boolean catch_url(T_SOC soc, char *url, char *method,
   return retour;
 }
 
-// Lecture de ligne sur socket
-void socinput(T_SOC soc, char *s, int max) {
+// Read one line off a socket; HTS_TRUE if it did not fit "s".
+hts_boolean socinput(T_SOC soc, char *s, int max) {
+  hts_boolean cut = HTS_FALSE;
   int c;
   int j = 0;
 
@@ -263,11 +266,15 @@ void socinput(T_SOC soc, char *s, int max) {
       case 12:
         break;                  // sauter ces caractères
       default:
-        s[j++] = (char) c;
+        if (j < max - 1)
+          s[j++] = (char) c;
+        else
+          cut = HTS_TRUE; // keep draining: the tail is not a new line
         break;
       }
     } else
       c = EOF;
-  } while((c != -1) && (c != EOF) && (j < (max - 1)));
-  s[j++] = '\0';
+  } while ((c != -1) && (c != EOF));
+  s[j] = '\0';
+  return cut;
 }

--- a/src/htscatchurl.c
+++ b/src/htscatchurl.c
@@ -200,8 +200,8 @@ HTSEXT_API hts_boolean catch_url(T_SOC soc, char *url, char *method,
             // Lire en têtes restants
             sprintf(data, "%s %s %s\r\n", method, af.fil, protocol);
             while(strnotempty(line)) {
-              /* a header we could not read whole is not the one the browser
-                 sent: replaying a prefix of it is worse than dropping it */
+              /* a clipped header is not the one the browser sent: dropping it
+                 beats replaying a prefix */
               if (socinput(soc, line, 1000))
                 continue;
               treathead(NULL, NULL, NULL, &blkretour, line);    // traiter
@@ -211,8 +211,11 @@ HTSEXT_API hts_boolean catch_url(T_SOC soc, char *url, char *method,
             // CR/LF final de l'en tête inutile car déja placé via la ligne vide
             // juste au dessus
             if (blkretour.totalsize > 0) {
-              int len = (int) min(blkretour.totalsize, 32000);
               int pos = (int) strlen(data);
+              /* the headers already took part of data[], so bound the body by
+                 the room they left rather than by a constant */
+              int len = (int) min(blkretour.totalsize,
+                                  (LLint) (CATCH_URL_DATA_SIZE - 1 - pos));
 
               // Copier le reste (post éventuel)
               while((len > 0)

--- a/src/htscatchurl.h
+++ b/src/htscatchurl.h
@@ -44,7 +44,8 @@ Please visit our Website: http://www.httrack.com
 #define CATCH_URL_DATA_SIZE 32768
 
 // Fonctions
-void socinput(T_SOC soc, char *s, int max);
+/* Read one line off a socket; HTS_TRUE if it did not fit "s". */
+hts_boolean socinput(T_SOC soc, char *s, int max);
 
 #define CATCH_RESPONSE \
   "HTTP/1.0 200 OK\r\n"\

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -857,40 +857,39 @@ int httpmirror(char *url1, httrackp * opt) {
         char BIGSTK line[HTS_URLMAXSIZE * 2];
 
         while(filelist_ptr < filelist_sz) {
-          const int count =
-              binput(filelist_buff + filelist_ptr, line, HTS_URLMAXSIZE);
-          /* Where binput stopped, past any CR it dropped: a clipped line stops
-             on a URL byte. Our NUL at filelist_sz keeps the walk in bounds. */
-          size_t term = filelist_ptr + (size_t) count - 1;
-          hts_boolean whole;
+          int adv;
+          const hts_boolean cut = binput_line(filelist_buff + filelist_ptr,
+                                              filelist_buff + filelist_sz, line,
+                                              HTS_URLMAXSIZE + 1, &adv);
+          /* the byte it stopped on, past any CR it dropped */
+          const size_t term = filelist_ptr + (size_t) adv - 1;
+          /* an embedded NUL ends the read too, and half a URL is not one */
+          const hts_boolean nul =
+              term < filelist_sz && filelist_buff[term] == '\0';
 
-          while (term < filelist_sz && filelist_buff[term] == '\r') {
-            term++;
-          }
-          whole = term == filelist_sz || filelist_buff[term] == '\n';
           lineno++;
-          if (!whole) {
-            /* Resuming where binput stopped would feed the tail back as a
-               second URL, and a clipped URL is a different URL. */
-            if (filelist_buff[term] == '\0') {
+          filelist_ptr = term + 1;
+          if (cut || nul) {
+            /* a clipped URL is a different URL, so name the line and drop it */
+            if (nul) {
               hts_log_print(opt, LOG_WARNING,
                             "\"%s\", line %d: URL contains a NUL byte, ignored",
                             StringBuff(opt->filelist), lineno);
+              /* a NUL is not a line end: drop the rest of the line ourselves */
+              while (filelist_ptr < filelist_sz &&
+                     filelist_buff[filelist_ptr] != '\n') {
+                filelist_ptr++;
+              }
+              filelist_ptr++;
             } else {
               hts_log_print(
                   opt, LOG_WARNING,
                   "\"%s\", line %d: URL longer than %d bytes, ignored",
                   StringBuff(opt->filelist), lineno, HTS_URLMAXSIZE);
             }
-            while (filelist_ptr < filelist_sz &&
-                   filelist_buff[filelist_ptr] != '\n') {
-              filelist_ptr++;
-            }
-            filelist_ptr++;
             continue;
           }
-          filelist_ptr = term + 1;
-          if (count && line[0]) {
+          if (line[0]) {
             n++;
             if (strstr(line, ":/") == NULL) {
               htsbuff_cat(&primarybuff, "http://");

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -800,10 +800,10 @@ T_SOC http_xfopen(httrackp *opt, int mode, int treat, int waitconnect,
         // Réception de la status line et de l'en-tête (norme RFC1945)
 
         // status-line à récupérer
-        finput_header(soc, rcvd, 1024);
+        finput_line(soc, rcvd, 1024);
         // some buggy servers send a leading \n (RFC)
         if (strnotempty(rcvd) == 0)
-          finput_header(soc, rcvd, 1024);
+          finput_line(soc, rcvd, 1024);
 
         // traiter status-line
         treatfirstline(retour, rcvd);
@@ -816,7 +816,7 @@ T_SOC http_xfopen(httrackp *opt, int mode, int treat, int waitconnect,
 
         // header // ** !attention! HTTP/0.9 non supporté
         do {
-          const hts_boolean cut = finput_header(soc, rcvd, 1024);
+          const hts_boolean cut = finput_line(soc, rcvd, 1024);
 
 #if HDEBUG
           printf(">%s\n", rcvd);
@@ -2084,13 +2084,13 @@ htsblk http_test(httrackp * opt, const char *adr, const char *fil, char *loc) {
         // ----------------------------------------
         // traiter en-tête!
         // status-line à récupérer
-        binput_header(retour.adr + ptr, retour.adr + retour.size, rcvd, 1024,
-                      &adv);
+        binput_line(retour.adr + ptr, retour.adr + retour.size, rcvd, 1024,
+                    &adv);
         ptr += adv;
         // some buggy servers send a leading \n (RFC)
         if (strnotempty(rcvd) == 0) {
-          binput_header(retour.adr + ptr, retour.adr + retour.size, rcvd, 1024,
-                        &adv);
+          binput_line(retour.adr + ptr, retour.adr + retour.size, rcvd, 1024,
+                      &adv);
           ptr += adv;
         }
 
@@ -2105,7 +2105,7 @@ htsblk http_test(httrackp * opt, const char *adr, const char *fil, char *loc) {
 
         // header // ** !attention! HTTP/0.9 non supporté
         do {
-          const hts_boolean cut = binput_header(
+          const hts_boolean cut = binput_line(
               retour.adr + ptr, retour.adr + retour.size, rcvd, 1024, &adv);
 
           ptr += adv;
@@ -3061,15 +3061,15 @@ int finput(T_SOC fd, char *s, int max) {
   return j;
 }
 
-// Like linput, but in memory (optimized)
+// Like linput, but in memory (optimized). A line too long for `s` is clipped
+// but consumed whole: resuming inside it reads its tail back as another line.
 int binput(const char *buff, char *s, int max) {
   int count = 0;
   int destCount = 0;
 
   // Note: \0 will return 1
-  while(destCount < max && buff != NULL && buff[count] != '\0'
-        && buff[count] != '\n') {
-    if (buff[count] != '\r') {
+  while (buff != NULL && buff[count] != '\0' && buff[count] != '\n') {
+    if (buff[count] != '\r' && destCount < max) {
       s[destCount++] = buff[count];
     }
     count++;
@@ -3080,8 +3080,8 @@ int binput(const char *buff, char *s, int max) {
   return count + 1;
 }
 
-hts_boolean binput_header(const char *buff, const char *end, char *s, int max,
-                          int *offset) {
+hts_boolean binput_line(const char *buff, const char *end, char *s, int max,
+                        int *offset) {
   hts_boolean cut = HTS_FALSE;
   const char *p;
   int j = 0;
@@ -3103,7 +3103,7 @@ hts_boolean binput_header(const char *buff, const char *end, char *s, int max,
   return cut;
 }
 
-hts_boolean finput_header(T_SOC fd, char *s, int max) {
+hts_boolean finput_line(T_SOC fd, char *s, int max) {
   hts_boolean cut = HTS_FALSE;
   int j = 0;
   char c;

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -3035,32 +3035,6 @@ int sendc(htsblk * r, const char *s) {
   return (n == ssz) ? n : -1;
 }
 
-// Remplace read
-int finput(T_SOC fd, char *s, int max) {
-  char c;
-  int j = 0;
-
-  do {
-    if (read((int) fd, &c, 1) <= 0) {
-      c = 0;
-    }
-    if (c != 0) {
-      switch (c) {
-      case 10:
-        c = 0;
-        break;
-      case 13:
-        break;                  // sauter ces caractères
-      default:
-        s[j++] = c;
-        break;
-      }
-    }
-  } while ((c != 0) && (j < max - 1));
-  s[j] = '\0';
-  return j;
-}
-
 // Like linput, but in memory (optimized). A line too long for `s` is clipped
 // but consumed whole: resuming inside it reads its tail back as another line.
 int binput(const char *buff, char *s, int max) {

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -335,13 +335,13 @@ HTS_INLINE void time_rfc822_local(char *s, struct tm *A);
 HTS_INLINE int sendc(htsblk * r, const char *s);
 int finput(T_SOC fd, char *s, int max);
 int binput(const char *buff, char *s, int max);
-/* Read one response-header line, from a buffer up to "end" or from a socket,
-   consuming it whole even when it does not fit "s". HTS_TRUE means it was cut:
-   the value is not what the server sent, so drop it rather than parse it.
-   binput_header() reports the advance through *offset. */
-hts_boolean binput_header(const char *buff, const char *end, char *s, int max,
-                          int *offset);
-hts_boolean finput_header(T_SOC fd, char *s, int max);
+/* Read one line, from a buffer up to "end" or from a socket, consuming it whole
+   even when it does not fit "s". HTS_TRUE means it was cut: the value is not
+   what was written, so drop it rather than parse a prefix of it.
+   binput_line() reports the advance through *offset. */
+hts_boolean binput_line(const char *buff, const char *end, char *s, int max,
+                        int *offset);
+hts_boolean finput_line(T_SOC fd, char *s, int max);
 int linput(FILE * fp, char *s, int max);
 int linputsoc(T_SOC soc, char *s, int max);
 int linputsoc_t(T_SOC soc, char *s, int max, int timeout);

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -333,8 +333,8 @@ HTS_INLINE void time_rfc822(char *s, struct tm *A);
 HTS_INLINE void time_rfc822_local(char *s, struct tm *A);
 
 HTS_INLINE int sendc(htsblk * r, const char *s);
-/* Returns the advance to the next line, NUL included. Unlike binput_line(),
-   "max" excludes the terminator: "s" must hold max + 1 bytes. */
+/* Returns the advance past the line's terminator. Unlike binput_line(), "max"
+   excludes the NUL: "s" must hold max + 1 bytes. */
 int binput(const char *buff, char *s, int max);
 /* Read one line, from a buffer up to "end" or from a socket, consuming it whole
    even when it does not fit "s". HTS_TRUE means it was cut: the value is not

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -333,7 +333,8 @@ HTS_INLINE void time_rfc822(char *s, struct tm *A);
 HTS_INLINE void time_rfc822_local(char *s, struct tm *A);
 
 HTS_INLINE int sendc(htsblk * r, const char *s);
-int finput(T_SOC fd, char *s, int max);
+/* Returns the advance to the next line, NUL included. Unlike binput_line(),
+   "max" excludes the terminator: "s" must hold max + 1 bytes. */
 int binput(const char *buff, char *s, int max);
 /* Read one line, from a buffer up to "end" or from a socket, consuming it whole
    even when it does not fit "s". HTS_TRUE means it was cut: the value is not

--- a/src/htsrobots.c
+++ b/src/htsrobots.c
@@ -101,7 +101,11 @@ int checkrobots(const robots_wizard *robots, const char *adr, const char *fil) {
         hts_boolean best_allow = HTS_FALSE;
 
         while (ptr < (int) toklen) {
-          ptr += binput(robots->token + ptr, line, sizeof(line) - 1);
+          int adv;
+
+          (void) binput_line(robots->token + ptr, robots->token + toklen, line,
+                             sizeof(line), &adv);
+          ptr += adv;
           if (line[0] != 'A' && line[0] != 'D')
             continue;
           {
@@ -166,15 +170,12 @@ void robots_parse(httrackp *opt, robots_wizard *robots, const char *adr,
   while (bptr < bodysize) {
     char *comm;
     int llen;
+    int adv;
     hts_boolean cut;
 
-    bptr += binput(body + bptr, line, sizeof(line) - 2);
-    /* binput consumed body[bptr-1] and resumes mid-record when the buffer runs
-       out, so a record read whole is the one ending on its own newline. */
-    cut = (bptr - 1 < bodysize && body[bptr - 1] != '\n' &&
-           body[bptr - 1] != '\0')
-              ? HTS_TRUE
-              : HTS_FALSE;
+    cut =
+        binput_line(body + bptr, body + bodysize, line, sizeof(line) - 1, &adv);
+    bptr += (size_t) adv;
     comm = strchr(line, '#'); // strip comment
     if (comm != NULL) {
       *comm = '\0';

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2588,11 +2588,64 @@ static int st_headerline(httrackp *opt, int argc, char **argv) {
   for (i = 0; i < 4; i++) {
     int adv;
     const hts_boolean cut =
-        binput_header(block + ptr, block + blocklen, line, max, &adv);
+        binput_line(block + ptr, block + blocklen, line, max, &adv);
 
     ptr += adv;
     printf("cut=%d over=%d line=%s\n", cut != HTS_FALSE,
            ptr > (int) blocklen + 1, line);
+  }
+  return 0;
+}
+
+/* binput() clips a line it cannot hold but must consume it whole: the advance
+   it reports is what the cache, robots and list parsers resume on, and inside
+   the line the tail reads back as a record of its own (#1294). */
+static int st_binputline(httrackp *opt, int argc, char **argv) {
+  static const char fixture[] = "Disallow: 0123456789abcdefghij\n"
+                                "Allow: /open/\n";
+  char block[256], line[64];
+  size_t blocklen;
+  int max, ptr = 0, i;
+
+  (void) opt;
+  if (argc < 1) {
+    fprintf(stderr, "binputline: needs a read size\n");
+    return 1;
+  }
+  max = atoi(argv[0]);
+  if (max < 1 || (size_t) max >= sizeof(line)) {
+    fprintf(stderr, "binputline: read size out of probe range\n");
+    return 1;
+  }
+  if (argc < 2) {
+    memcpy(block, fixture, sizeof(fixture));
+    blocklen = sizeof(fixture) - 1;
+  } else {
+    const char *a = argv[1];
+
+    if (strlen(a) >= sizeof(block)) {
+      fprintf(stderr, "binputline: block too long\n");
+      return 1;
+    }
+    for (blocklen = 0; *a != '\0'; a++) {
+      if (*a == '\\' && a[1] == 'n')
+        block[blocklen++] = '\n', a++;
+      else if (*a == '\\' && a[1] == 'r')
+        block[blocklen++] = '\r', a++;
+      else
+        block[blocklen++] = *a;
+    }
+    block[blocklen] = '\0';
+  }
+  /* one read past the block, to show the walk stops on its terminating NUL */
+  for (i = 0; i < 3; i++) {
+    const int adv = binput(block + ptr, line, max);
+
+    printf("adv=%d over=%d line=%s\n", adv, ptr + adv > (int) blocklen + 1,
+           line);
+    ptr += adv;
+    if (ptr > (int) blocklen)
+      ptr = (int) blocklen;
   }
   return 0;
 }
@@ -6547,6 +6600,32 @@ static int st_robots(httrackp *opt, int argc, char **argv) {
     snprintf(txt, sizeof(txt), "User-agent: *\nDisallow: /a\nAllow: %s\n",
              path);
     assertf(rb_decide(&robots, txt, path) == -1);
+  }
+
+  /* #1294: the reader used to resume inside a line it could not hold, so an
+     over-long Disallow handed back its own tail as a second rule. Here the
+     tail is an Allow re-opening what the line above forbids. */
+  {
+    /* where the old read resumed: it kept HTS_ROBOTS_LINE_SIZE - 2 bytes and
+       stepped one past them */
+    const size_t resume = HTS_ROBOTS_LINE_SIZE - 1;
+    char BIGSTK txt[HTS_ROBOTS_LINE_SIZE * 3];
+    size_t head = (size_t) snprintf(
+        txt, sizeof(txt), "User-agent: *\nDisallow: /open/\nDisallow: ");
+    const size_t line = head - strlen("Disallow: ");
+
+    memset(txt + head, 'a', line + resume - head);
+    head = line + resume;
+    head +=
+        (size_t) snprintf(txt + head, sizeof(txt) - head, "Allow: /open/\n");
+    assertf(head < sizeof(txt));
+    assertf(rb_decide(&robots, txt, "/open/x") == -1);
+
+    /* control: that same text on a line of its own is a rule we do honour, so
+       the refusal above is the tail never being read and not a dead pattern */
+    assertf(rb_decide(&robots,
+                      "User-agent: *\nDisallow: /open/\nAllow: /open/\n",
+                      "/open/x") == 0);
   }
 
   checkrobots_free(&robots);
@@ -11452,6 +11531,8 @@ static const struct selftest_entry {
     {"headerline", "<read-size>",
      "a header line that does not fit is reported and skipped whole",
      st_headerline},
+    {"binputline", "<read-size> [block]",
+     "binput() consumes a clipped line whole (#1294)", st_binputline},
     {"crange", "<raw-content-range-line> ...",
      "Content-Range parse integer safety", st_crange},
     {"xfread-limit", "", "in-memory receive buffer size bound",

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2597,9 +2597,8 @@ static int st_headerline(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-/* binput() clips a line it cannot hold but must consume it whole: the advance
-   it reports is what the cache, robots and list parsers resume on, and inside
-   the line the tail reads back as a record of its own (#1294). */
+/* #1294: binput()'s advance must reach the next line even when it clipped the
+   value, since the cache, robots and list parsers resume on it. */
 static int st_binputline(httrackp *opt, int argc, char **argv) {
   static const char fixture[] = "Disallow: 0123456789abcdefghij\n"
                                 "Allow: /open/\n";
@@ -2641,8 +2640,7 @@ static int st_binputline(httrackp *opt, int argc, char **argv) {
   for (i = 0; i < 3; i++) {
     const int adv = binput(block + ptr, line, max);
 
-    printf("adv=%d over=%d line=%s\n", adv, ptr + adv > (int) blocklen + 1,
-           line);
+    printf("adv=%d line=%s\n", adv, line);
     ptr += adv;
     if (ptr > (int) blocklen)
       ptr = (int) blocklen;
@@ -6602,12 +6600,9 @@ static int st_robots(httrackp *opt, int argc, char **argv) {
     assertf(rb_decide(&robots, txt, path) == -1);
   }
 
-  /* #1294: the reader used to resume inside a line it could not hold, so an
-     over-long Disallow handed back its own tail as a second rule. Here the
-     tail is an Allow re-opening what the line above forbids. */
+  /* #1294: an over-long Disallow must not hand its own tail back as a rule. */
   {
-    /* where the old read resumed: it kept HTS_ROBOTS_LINE_SIZE - 2 bytes and
-       stepped one past them */
+    /* one past the HTS_ROBOTS_LINE_SIZE - 2 bytes the old read kept */
     const size_t resume = HTS_ROBOTS_LINE_SIZE - 1;
     char BIGSTK txt[HTS_ROBOTS_LINE_SIZE * 3];
     size_t head = (size_t) snprintf(
@@ -6616,10 +6611,13 @@ static int st_robots(httrackp *opt, int argc, char **argv) {
 
     memset(txt + head, 'a', line + resume - head);
     head = line + resume;
-    head +=
-        (size_t) snprintf(txt + head, sizeof(txt) - head, "Allow: /open/\n");
+    head += (size_t) snprintf(txt + head, sizeof(txt) - head,
+                              "Allow: /open/\nDisallow: /next/\n");
     assertf(head < sizeof(txt));
     assertf(rb_decide(&robots, txt, "/open/x") == -1);
+    /* the line after the cut one is still a rule: consuming it whole must not
+       become discarding the rest of the file */
+    assertf(rb_decide(&robots, txt, "/next/x") == -1);
 
     /* control: that same text on a line of its own is a rule we do honour, so
        the refusal above is the tail never being read and not a dead pattern */

--- a/src/htsserver.h
+++ b/src/htsserver.h
@@ -42,7 +42,8 @@ Please visit our Website: http://www.httrack.com
 #include "htsstrings.h"
 
 // Fonctions
-void socinput(T_SOC soc, char *s, int max);
+/* Read one line off a socket; HTS_TRUE if it did not fit "s". */
+hts_boolean socinput(T_SOC soc, char *s, int max);
 /* Listen on bindAddr, or every interface if NULL/empty; adr (>= 258 bytes) gets
    the address to advertise. INVALID_SOCKET on error. */
 T_SOC smallserver_init_std(int *port_prox, char *adr_prox, int defaultPort,

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -266,7 +266,7 @@ int PT_RemoveIndex(PT_Indexes index, int indexId) {
 
 /* Reads one line into "s" (at most "max" chars plus its NUL) and returns the
    advance. *cut, when asked for, says the line did not fit. */
-static int binput(char *buff, char *s, int max, hts_boolean * cut) {
+static int binput(char *buff, char *s, int max, hts_boolean *cut) {
   int count = 0;
   int destCount = 0;
 
@@ -1640,7 +1640,7 @@ static int PT_LoadCache__Old(PT_Index index_, const char *filename) {
                 const size_t used = strlen(line);
 
                 a += binput(a, line + used, (int) (sizeof(line) - used - 1),
-                          NULL);
+                            NULL);
               }
               /* read position */
               a += binput(a, linepos, 200, NULL);

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -264,14 +264,23 @@ int PT_RemoveIndex(PT_Indexes index, int indexId) {
   return 0;
 }
 
-static int binput(char *buff, char *s, int max) {
+/* Reads one line into "s" (at most "max" chars plus its NUL) and returns the
+   advance. *cut, when asked for, says the line did not fit. */
+static int binput(char *buff, char *s, int max, hts_boolean * cut) {
   int count = 0;
   int destCount = 0;
 
+  if (cut != NULL) {
+    *cut = HTS_FALSE;
+  }
   /* consumed whole: resuming inside a clipped line reads its tail as a field */
   while (buff[count] != '\0' && buff[count] != '\n') {
-    if (buff[count] != '\r' && destCount < max) {
-      s[destCount++] = buff[count];
+    if (buff[count] != '\r') {
+      if (destCount < max) {
+        s[destCount++] = buff[count];
+      } else if (cut != NULL) {
+        *cut = HTS_TRUE;
+      }
     }
     count++;
   }
@@ -995,7 +1004,7 @@ int PT_LoadCache__New(PT_Index index_, const char *filename) {
                     char line[1024];
 
                     line[0] = '\0';
-                    a += binput(a, line, sizeof(line) - 2);
+                    a += binput(a, line, sizeof(line) - 2, NULL);
                     if (strncmp(line, "X-In-Cache:", 11) == 0) {
                       if (strcmp(line, "X-In-Cache: 1") == 0) {
                         dataincache = 1;
@@ -1099,19 +1108,24 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
              unzGetLocalExtrafield(index->zFile, headerBuff,
                                    sizeof(headerBuff) - 2)) > 0) {
           int offset = 0;
-          char line[HTS_URLMAXSIZE + 2];
+          /* the longest stored line is "Location: " plus a full-capacity URL;
+             a shorter buffer truncates it into a valid-looking wrong target */
+          char BIGSTK line[HTS_LOCATION_SIZE + 32];
           int lineEof = 0;
 
           headerBuff[readSizeHeader] = '\0';
           do {
             char *value;
+            hts_boolean cut;
 
             line[0] = '\0';
-            offset += binput(headerBuff + offset, line, sizeof(line) - 2);
+            offset += binput(headerBuff + offset, line, sizeof(line) - 2, &cut);
             if (line[0] == '\0') {
               lineEof = 1;
             }
-            value = strchr(line, ':');
+            /* no line HTTrack writes is this long, so a cut one is foreign or
+               damaged and its prefix would parse as a wrong value */
+            value = cut ? NULL : strchr(line, ':');
             if (value != NULL) {
               *value++ = '\0';
               if (*value == ' ' || *value == '\t')
@@ -1439,7 +1453,7 @@ static int cache_brstr(char *adr, char *s, size_t s_size) {
   int off;
   char buff[256 + 4];
 
-  off = binput(adr, buff, 256);
+  off = binput(adr, buff, 256, NULL);
   /* no length-prefixed value follows a field the terminating NUL stopped */
   if (adr[off] == '\0') {
     s[0] = '\0';
@@ -1618,17 +1632,18 @@ static int PT_LoadCache__Old(PT_Index index_, const char *filename) {
             if (a) {
               a++;
               /* read "host/file" */
-              a += binput(a, line, HTS_URLMAXSIZE);
+              a += binput(a, line, HTS_URLMAXSIZE, NULL);
               {
                 /* binput writes its NUL at s[max], so the second field must be
                    bounded by what is left of line[], not by the same constant
                  */
                 const size_t used = strlen(line);
 
-                a += binput(a, line + used, (int) (sizeof(line) - used - 1));
+                a += binput(a, line + used, (int) (sizeof(line) - used - 1),
+                          NULL);
               }
               /* read position */
-              a += binput(a, linepos, 200);
+              a += binput(a, linepos, 200, NULL);
               /* an unparseable field must not carry the previous entry's
                  offset over, nor read the stack on the first one */
               if (sscanf(linepos, "%d", &pos) != 1)

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -268,8 +268,9 @@ static int binput(char *buff, char *s, int max) {
   int count = 0;
   int destCount = 0;
 
-  while(destCount < max && buff[count] != '\0' && buff[count] != '\n') {
-    if (buff[count] != '\r') {
+  /* consumed whole: resuming inside a clipped line reads its tail as a field */
+  while (buff[count] != '\0' && buff[count] != '\n') {
+    if (buff[count] != '\r' && destCount < max) {
       s[destCount++] = buff[count];
     }
     count++;

--- a/tests/117_local-proxytrack-ndx-cursor.test
+++ b/tests/117_local-proxytrack-ndx-cursor.test
@@ -47,17 +47,22 @@ got=$(items "$dir/first-1024.ndx")
 test "$got" = 2 || fail "URLs differing on the 1024 bound gave $got keys, expected 2"
 
 # The header field is read through the same helper, bounded at 256. One byte
-# past that bound must parse like any other over-long header, not lose an entry.
-for at in 257 258; do
+# past that bound must leave the entry walk where a header that fits leaves it.
+# The reader used to resume inside the over-long line, so the walk began one
+# line earlier and read an extra entry out of the same bytes (#1294).
+for at in 1 256 257 258; do
     {
         pad "$at" C
         printf '\na/1\nx\n1\nb/2\ny\n2\nc/3\nz\n3\n'
     } >"$dir/header-$at.ndx"
 done
-got=$(items "$dir/header-258.ndx")
-test "$got" = 3 || fail "header 2 past its bound gave $got keys, expected 3"
-got=$(items "$dir/header-257.ndx")
-test "$got" = 3 || fail "header 1 past its bound gave $got keys, expected 3"
+want=$(items "$dir/header-1.ndx")
+test "$want" -gt 0 || fail "control: a header that fits gave no keys"
+for at in 256 257 258; do
+    got=$(items "$dir/header-$at.ndx")
+    test "$got" = "$want" ||
+        fail "header of $at bytes gave $got keys, expected $want"
+done
 
 # Second half, bounded at 2048 - 10 - 1: it fills that bound with the index
 # ending right there, so the byte stepped over is the terminating NUL.

--- a/tests/117_local-proxytrack-ndx-cursor.test
+++ b/tests/117_local-proxytrack-ndx-cursor.test
@@ -47,21 +47,18 @@ got=$(items "$dir/first-1024.ndx")
 test "$got" = 2 || fail "URLs differing on the 1024 bound gave $got keys, expected 2"
 
 # The header field is read through the same helper, bounded at 256. One byte
-# past that bound must leave the entry walk where a header that fits leaves it.
-# The reader used to resume inside the over-long line, so the walk began one
-# line earlier and read an extra entry out of the same bytes (#1294).
+# past that bound must land the entry walk where a header that fits lands it:
+# resuming inside the over-long line began the walk a line early and read a
+# fourth entry out of these same bytes (#1294).
 for at in 1 256 257 258; do
     {
         pad "$at" C
         printf '\na/1\nx\n1\nb/2\ny\n2\nc/3\nz\n3\n'
     } >"$dir/header-$at.ndx"
 done
-want=$(items "$dir/header-1.ndx")
-test "$want" -gt 0 || fail "control: a header that fits gave no keys"
-for at in 256 257 258; do
+for at in 1 256 257 258; do
     got=$(items "$dir/header-$at.ndx")
-    test "$got" = "$want" ||
-        fail "header of $at bytes gave $got keys, expected $want"
+    test "$got" = 2 || fail "header of $at bytes gave $got keys, expected 2"
 done
 
 # Second half, bounded at 2048 - 10 - 1: it fills that bound with the index

--- a/tests/310_filelist-long-url.test
+++ b/tests/310_filelist-long-url.test
@@ -1,8 +1,6 @@
 #!/bin/bash
 #
 # -%L: a line the user wrote is read whole or refused by name, never split.
-# binput() clips at HTS_URLMAXSIZE and returns the clipped length, so the
-# loading loop used to resume mid-URL and add the tail as a second link.
 # Offline: file:// fixtures, no server.
 
 set -euo pipefail

--- a/tests/315_engine-binput-line.test
+++ b/tests/315_engine-binput-line.test
@@ -1,15 +1,12 @@
 #!/bin/bash
-# Issue #1294: the line readers clipped a line they could not hold and left the
-# caller's cursor inside it, so the unread tail came back as a record of its
-# own. Here it spells a robots.txt Allow re-opening what the line above forbids.
-set -eu
+# Issue #1294: a clipped line's unread tail must not resurface as another record.
+set -euo pipefail
 
 # shellcheck source=tests/crawllib.sh
 . "${0%"${0##*/}"}./crawllib.sh"
 
-# binput() clips a line the destination cannot hold, but the advance it reports
-# must reach the next line all the same: the cache, robots and list parsers all
-# resume on it. "adv" is that advance, "over" says the walk left the block.
+# "adv" is binput()'s advance, which must reach the next line even when the
+# value was clipped: the cache, robots and list parsers all resume on it.
 walk() { # walk READSIZE [BLOCK] WANT
     if [ "$#" -eq 3 ]; then
         selftest_queue_lines "$3" binputline "$1" "$2"
@@ -21,32 +18,34 @@ walk() { # walk READSIZE [BLOCK] WANT
 # Default block: "Disallow: 0123456789abcdefghij" is 30 bytes, then
 # "Allow: /open/" at 13. The advance is the line plus its newline whatever the
 # read size, and the second line read is always the second line written.
-walk 31 'adv=31 over=0 line=Disallow: 0123456789abcdefghij
-adv=14 over=0 line=Allow: /open/
-adv=1 over=0 line='
-walk 12 'adv=31 over=0 line=Disallow: 01
-adv=14 over=0 line=Allow: /open
-adv=1 over=0 line='
-walk 1 'adv=31 over=0 line=D
-adv=14 over=0 line=A
-adv=1 over=0 line='
+walk 31 'adv=31 line=Disallow: 0123456789abcdefghij
+adv=14 line=Allow: /open/
+adv=1 line='
+walk 12 'adv=31 line=Disallow: 01
+adv=14 line=Allow: /open
+adv=1 line='
+walk 1 'adv=31 line=D
+adv=14 line=A
+adv=1 line='
 
 # A last line with no terminator stops on the block's own NUL, one byte past
 # the last character and no further.
-walk 8 'AAAAAAAAAAAA\nBBB' 'adv=13 over=0 line=AAAAAAAA
-adv=4 over=0 line=BBB
-adv=1 over=0 line='
+walk 8 'AAAAAAAAAAAA\nBBB' 'adv=13 line=AAAAAAAA
+adv=4 line=BBB
+adv=1 line='
 
 # CR is dropped from the value but still counts towards the advance, so a CRLF
-# record ends where the next one starts.
-walk 8 'A\r: 1\r\nB: 2\r\n' 'adv=7 over=0 line=A: 1
-adv=6 over=0 line=B: 2
-adv=1 over=0 line='
+# record ends where the next one starts. A clipped value drops it too.
+walk 8 'A\r: 1\r\nB: 2\r\n' 'adv=7 line=A: 1
+adv=6 line=B: 2
+adv=1 line='
+walk 3 'A\rBCDEF\r\nGHI\r\n' 'adv=9 line=ABC
+adv=5 line=GHI
+adv=1 line='
 
 selftest_run_queued
 
-# End to end: /secret/ is forbidden by a rule the site wrote, and the site's
-# last Disallow is long enough to outrun the reader. Its tail spells
+# End to end: the site's last Disallow outruns the reader and its tail spells
 # "Allow: /secret/", which the engine must never see as a rule.
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_1294.XXXXXX") || exit 1
 cleanup() {
@@ -55,19 +54,23 @@ cleanup() {
 cleanup_push cleanup
 
 doc="${tmpdir}/doc"
-mkdir -p "${doc}/secret" "${doc}/ok"
-printf '<html><body><a href="secret/page.html">s</a>\n<a href="ok/page.html">o</a></body></html>\n' \
+mkdir -p "${doc}/secret" "${doc}/hidden" "${doc}/ok"
+printf '<html><body><a href="secret/page.html">s</a>\n<a href="hidden/page.html">h</a>\n<a href="ok/page.html">o</a></body></html>\n' \
     >"${doc}/index.html"
-for d in secret ok; do
+for d in secret hidden ok; do
     printf '<html><body>body of %s</body></html>\n' "$d" >"${doc}/${d}/page.html"
 done
 
+# /hidden/ is disallowed on an ordinary line in both bodies, so mirroring it
+# would mean this robots.txt was never read and neither leg proves anything.
 bash "$top_srcdir/tests/local-crawl.sh" --root "$(nativepath "$doc")" \
-    --errors 0 --found 'ok/page.html' --not-found 'secret/page.html' \
+    --errors 0 --found 'ok/page.html' --not-found 'hidden/page.html' \
+    --not-found 'secret/page.html' \
     httrack 'BASEURL/index.html' -r3 -s2 -F 'tailrobots-agent'
 
 # Control: that same Allow on a line of its own is honoured, so the refusal
 # above is the tail going unread and not a rule the engine ignores anyway.
 bash "$top_srcdir/tests/local-crawl.sh" --root "$(nativepath "$doc")" \
-    --errors 0 --found 'ok/page.html' --found 'secret/page.html' \
+    --errors 0 --found 'ok/page.html' --not-found 'hidden/page.html' \
+    --found 'secret/page.html' \
     httrack 'BASEURL/index.html' -r3 -s2 -F 'tailonline-agent'

--- a/tests/315_engine-binput-line.test
+++ b/tests/315_engine-binput-line.test
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Issue #1294: the line readers clipped a line they could not hold and left the
+# caller's cursor inside it, so the unread tail came back as a record of its
+# own. Here it spells a robots.txt Allow re-opening what the line above forbids.
+set -eu
+
+# shellcheck source=tests/crawllib.sh
+. "${0%"${0##*/}"}./crawllib.sh"
+
+# binput() clips a line the destination cannot hold, but the advance it reports
+# must reach the next line all the same: the cache, robots and list parsers all
+# resume on it. "adv" is that advance, "over" says the walk left the block.
+walk() { # walk READSIZE [BLOCK] WANT
+    if [ "$#" -eq 3 ]; then
+        selftest_queue_lines "$3" binputline "$1" "$2"
+    else
+        selftest_queue_lines "$2" binputline "$1"
+    fi
+}
+
+# Default block: "Disallow: 0123456789abcdefghij" is 30 bytes, then
+# "Allow: /open/" at 13. The advance is the line plus its newline whatever the
+# read size, and the second line read is always the second line written.
+walk 31 'adv=31 over=0 line=Disallow: 0123456789abcdefghij
+adv=14 over=0 line=Allow: /open/
+adv=1 over=0 line='
+walk 12 'adv=31 over=0 line=Disallow: 01
+adv=14 over=0 line=Allow: /open
+adv=1 over=0 line='
+walk 1 'adv=31 over=0 line=D
+adv=14 over=0 line=A
+adv=1 over=0 line='
+
+# A last line with no terminator stops on the block's own NUL, one byte past
+# the last character and no further.
+walk 8 'AAAAAAAAAAAA\nBBB' 'adv=13 over=0 line=AAAAAAAA
+adv=4 over=0 line=BBB
+adv=1 over=0 line='
+
+# CR is dropped from the value but still counts towards the advance, so a CRLF
+# record ends where the next one starts.
+walk 8 'A\r: 1\r\nB: 2\r\n' 'adv=7 over=0 line=A: 1
+adv=6 over=0 line=B: 2
+adv=1 over=0 line='
+
+selftest_run_queued
+
+# End to end: /secret/ is forbidden by a rule the site wrote, and the site's
+# last Disallow is long enough to outrun the reader. Its tail spells
+# "Allow: /secret/", which the engine must never see as a rule.
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_1294.XXXXXX") || exit 1
+cleanup() {
+    rm -rf "$tmpdir"
+}
+cleanup_push cleanup
+
+doc="${tmpdir}/doc"
+mkdir -p "${doc}/secret" "${doc}/ok"
+printf '<html><body><a href="secret/page.html">s</a>\n<a href="ok/page.html">o</a></body></html>\n' \
+    >"${doc}/index.html"
+for d in secret ok; do
+    printf '<html><body>body of %s</body></html>\n' "$d" >"${doc}/${d}/page.html"
+done
+
+bash "$top_srcdir/tests/local-crawl.sh" --root "$(nativepath "$doc")" \
+    --errors 0 --found 'ok/page.html' --not-found 'secret/page.html' \
+    httrack 'BASEURL/index.html' -r3 -s2 -F 'tailrobots-agent'
+
+# Control: that same Allow on a line of its own is honoured, so the refusal
+# above is the tail going unread and not a rule the engine ignores anyway.
+bash "$top_srcdir/tests/local-crawl.sh" --root "$(nativepath "$doc")" \
+    --errors 0 --found 'ok/page.html' --found 'secret/page.html' \
+    httrack 'BASEURL/index.html' -r3 -s2 -F 'tailonline-agent'

--- a/tests/86_local-proxytrack-cache-longfields.test
+++ b/tests/86_local-proxytrack-cache-longfields.test
@@ -103,3 +103,61 @@ A 54
 C 63
 M 400
 EOF
+
+# --- ZIP reader, per-line bound ---------------------------------------------
+# A line the reader's buffer cannot hold used to be parsed as its prefix: a
+# Location became a valid-looking wrong target, an X-Save named a file that is
+# not the one recorded. The buffer now holds every line HTTrack can write, and
+# a longer one is dropped whole (#1294).
+"$python" - "$dir" <<'EOF'
+import os, sys, zipfile
+
+body = b"hello world"
+
+
+def craft(path, name, meta):
+    zi = zipfile.ZipInfo("example.com/%s.html" % name)
+    zi.compress_type = zipfile.ZIP_STORED
+    zi.extra = meta.encode()
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr(zi, body)
+
+
+common = (
+    "X-StatusCode: 200\r\n"
+    "X-StatusMessage: ok\r\n"
+    "X-Size: %d\r\n"
+    "Content-Type: text/html\r\n"
+    "Last-Modified: Wed, 01 Jan 2025 00:00:00 GMT\r\n" % len(body)
+)
+for name, n in (("mid", 1400), ("big", 3000)):
+    craft(
+        os.path.join(sys.argv[1], "line-%s.zip" % name),
+        name,
+        "X-In-Cache: 1\r\n" + common + "Location: http://example.com/%s\r\n" % ("Q" * n),
+    )
+# body on disk, so the entry stands or falls on the name X-Save carries
+craft(
+    os.path.join(sys.argv[1], "line-save.zip"),
+    "save",
+    "X-In-Cache: 0\r\n" + common + "X-Save: %s.html\r\n" % ("Z" * 3000),
+)
+EOF
+
+for name in mid big save; do
+    proxytrack --convert "$dir/line-$name.arc" "$dir/line-$name.zip" >/dev/null 2>&1 ||
+        fail "proxytrack died reading the $name line-bound zip"
+done
+
+# 1400 is past the old 1024-byte line bound and inside what the writer can emit
+got=$(runlen "$dir/line-mid.arc" Q)
+test "${got:-0}" = 1400 || fail "a 1400-byte Location came back at ${got:-0} bytes"
+got=$(runlen "$dir/line-big.arc" Q)
+test "${got:-0}" = 0 || fail "an unholdable Location left a ${got}-byte prefix behind"
+
+# an X-Save nobody could have written is no name at all, and refusing the entry
+# beats opening whatever file its prefix happens to hit
+got=$(runlen "$dir/line-save.arc" Z)
+test "${got:-0}" = 0 || fail "an unholdable X-Save left a ${got}-byte prefix behind"
+grep -qa 'Cached file name is invalid' "$dir/line-save.arc" ||
+    fail "an entry with no usable X-Save was not refused"

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -564,6 +564,24 @@ class Handler(SimpleHTTPRequestHandler):
     # ... and "robotsblobNNNN", which sizes the Disallow list so the engine's
     # stored rules come to exactly NNNN bytes, /secret/ last (#1286).
     BLOB_ROBOTS_RE = re.compile(r"robotsblob(\d+)")
+    # ... and one whose last Disallow outruns the reader's line buffer, its own
+    # tail spelling an Allow that re-opens what the line above forbids (#1294).
+    # The reader used to resume TAIL_RESUME bytes into the line, so that tail
+    # came back as a rule of its own.
+    TAIL_ROBOTS_UA = "tailrobots"
+    # ... the same Allow written as a line of its own: the control saying the
+    # rule is one the engine acts on, so a refusal is the tail going unread.
+    TAIL_ONLINE_UA = "tailonline"
+    TAIL_RESUME = 1023  # HTS_ROBOTS_LINE_SIZE - 1
+
+    def tail_robots_body(self, own_line):
+        phantom = "Allow: /secret/"
+        head = "User-agent: *\nDisallow: /secret/\n"
+        if own_line:
+            return (head + phantom + "\n").encode()
+        rule = "Disallow: "
+        rule += "a" * (self.TAIL_RESUME - len(rule))
+        return (head + rule + phantom + "\n").encode()
 
     def robots_blob_body(self, blobsize):
         # One "<marker><pattern>\n" line per stored rule, so a rule costs
@@ -601,6 +619,11 @@ class Handler(SimpleHTTPRequestHandler):
         blob = self.BLOB_ROBOTS_RE.search(ua)
         if blob:
             self.send_raw(self.robots_blob_body(int(blob.group(1))), "text/plain")
+            return
+        if self.TAIL_ROBOTS_UA in ua or self.TAIL_ONLINE_UA in ua:
+            self.send_raw(
+                self.tail_robots_body(self.TAIL_ONLINE_UA in ua), "text/plain"
+            )
             return
         host = self.headers.get("Host")
         body = "User-agent: *\nDisallow:\n"

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -566,17 +566,17 @@ class Handler(SimpleHTTPRequestHandler):
     BLOB_ROBOTS_RE = re.compile(r"robotsblob(\d+)")
     # ... and one whose last Disallow outruns the reader's line buffer, its own
     # tail spelling an Allow that re-opens what the line above forbids (#1294).
-    # The reader used to resume TAIL_RESUME bytes into the line, so that tail
-    # came back as a rule of its own.
     TAIL_ROBOTS_UA = "tailrobots"
     # ... the same Allow written as a line of its own: the control saying the
     # rule is one the engine acts on, so a refusal is the tail going unread.
     TAIL_ONLINE_UA = "tailonline"
-    TAIL_RESUME = 1023  # HTS_ROBOTS_LINE_SIZE - 1
+    TAIL_RESUME = 1023  # where the old reader resumed: HTS_ROBOTS_LINE_SIZE - 1
 
     def tail_robots_body(self, own_line):
         phantom = "Allow: /secret/"
-        head = "User-agent: *\nDisallow: /secret/\n"
+        # /hidden/ is refused by both bodies, so a leg that mirrors it never
+        # read this robots.txt at all
+        head = "User-agent: *\nDisallow: /hidden/\nDisallow: /secret/\n"
         if own_line:
             return (head + phantom + "\n").encode()
         rule = "Disallow: "


### PR DESCRIPTION
`binput()` stopped at the size it was handed and reported that as its advance, so the caller resumed inside the line it had just clipped and read the unread tail as another record. #1292 fixed the three readers feeding `treathead()`; this is the rest, which that commit message named.

The primitive now clips the value but walks to the end of the line, so the cursor is right at all twenty call sites. That matters most in robots.txt: a `Disallow:` longer than the 1 KB line buffer handed its own tail back as a second rule, so an `Allow:` sitting past the cut re-opened the path that line forbade. Test 315 mirrors a `/secret/` page on master and refuses it here.

Callers that would otherwise act on a prefix now ask whether the line fitted and drop it if it did not: the robots parser, the cached-header re-reader, the `-%L` list loader, the catch-url header reader. The cookie jar and the `.ndx` field readers keep clipping, since their fields are bounded where they are written. ProxyTrack's private `binput` copy gained the same signal, and its cache-record line buffer is now sized to what htscache actually writes: before, a 3000-byte `X-Save` was cut to 994 bytes and the truncated prefix was opened as a filename.

Two pre-existing bugs are fixed here as well. `catch_url()` sized its body copy at 32000 bytes while ignoring what the headers had already put in the same 32 KB buffer, and `finput()` was dead code still resuming mid-line. `binput()` is not exported, so there is no ABI question.

`117_local-proxytrack-ndx-cursor` pinned an over-long `.ndx` header line at three parsed entries where every header that fits gives two. The third entry was the old cursor landing mid-line and shifting the entry walk by a line, so all four sizes now pin two.

Closes #1294
