### PR TITLE
The filter scratch buffer, not the slot, caps a rule

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -684,7 +684,9 @@ int httpmirror(char *url1, httrackp * opt) {
         joker = 1;
 
       if (joker) { // a filter rule
-        char BIGSTK tempo[HTS_URLMAXSIZE * 2];
+        /* sized off the rule cap, so the parser refuses exactly what the array
+           and the matcher would (#1288) */
+        char BIGSTK tempo[HTS_FILTER_MAXLEN + 1];
         int type;
         int plus = 0;
 
@@ -699,17 +701,17 @@ int httpmirror(char *url1, httrackp * opt) {
           type = 1;
         }
 
-        /* the sign is prepended into `rule` below, not held here; the spare
-           byte is the dead branch's trailing '*' */
-        const size_t room = sizeof(tempo) - (plus == 0 && type == 1 ? 1 : 0);
+        /* one under the cap: the sign is prepended into `rule` below, and the
+           spare byte is the dead branch's trailing '*' */
+        const size_t room = sizeof(tempo) - 1;
 
         if (!hts_scan_token(&a, tempo, room)) {
           /* on the console too: the user who typed it may have no log open */
           printf("Filter rule longer than %d bytes, ignored: %c%.64s...\n",
-                 (int) (room - 1), type ? '+' : '-', tempo);
+                 (int) HTS_FILTER_MAXLEN, type ? '+' : '-', tempo);
           hts_log_print(opt, LOG_WARNING,
                         "Filter rule longer than %d bytes, ignored: %c%.64s...",
-                        (int) (room - 1), type ? '+' : '-', tempo);
+                        (int) HTS_FILTER_MAXLEN, type ? '+' : '-', tempo);
           continue;
         }
 
@@ -721,9 +723,8 @@ int httpmirror(char *url1, httrackp * opt) {
             }
           }
           {
-            /* wider than a slot, so an over-long rule reaches the length check
-               rather than aborting here */
-            char BIGSTK rule[HTS_FILTER_SLOT_SIZE + 2];
+            /* the sign, whatever tempo holds, and the NUL */
+            char BIGSTK rule[sizeof(tempo) + 1];
             htsbuff fb = htsbuff_array(rule);
 
             htsbuff_cpy(&fb, type ? "+" : "-");

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5462,6 +5462,11 @@ static int st_filtercap(httrackp *opt, int argc, char **argv) {
   freet(filters);
   opt->filters = saved;
   opt->wizard_filters = savedwizard;
+  /* every cap a rule meets, so a test places its boundaries from the engine
+     rather than hardcoding numbers that drift from it (#1288) */
+  printf("filtercap: rule=%d matcher=%d slot=%d argv=%d\n",
+         (int) HTS_FILTER_MAXLEN, (int) STRJOKER_MAXLEN,
+         (int) HTS_FILTER_SLOT_SIZE, (int) HTS_CDLMAXSIZE);
   printf("filtercap self-test OK\n");
   return 0;
 }

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5462,11 +5462,10 @@ static int st_filtercap(httrackp *opt, int argc, char **argv) {
   freet(filters);
   opt->filters = saved;
   opt->wizard_filters = savedwizard;
-  /* the caps a rule meets, so a test reads them instead of hardcoding a number
-     that drifts from the engine (#1288) */
-  printf("filtercap: rule=%d matcher=%d slot=%d argv=%d\n",
-         (int) HTS_FILTER_MAXLEN, (int) STRJOKER_MAXLEN,
-         (int) HTS_FILTER_SLOT_SIZE, (int) HTS_CDLMAXSIZE);
+  /* the two independent caps a rule meets, so a test reads them instead of
+     hardcoding a number that drifts from the engine (#1288) */
+  printf("filtercap: rule=%d argv=%d\n", (int) HTS_FILTER_MAXLEN,
+         (int) HTS_CDLMAXSIZE);
   printf("filtercap self-test OK\n");
   return 0;
 }

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5462,8 +5462,8 @@ static int st_filtercap(httrackp *opt, int argc, char **argv) {
   freet(filters);
   opt->filters = saved;
   opt->wizard_filters = savedwizard;
-  /* every cap a rule meets, so a test places its boundaries from the engine
-     rather than hardcoding numbers that drift from it (#1288) */
+  /* the caps a rule meets, so a test reads them instead of hardcoding a number
+     that drifts from the engine (#1288) */
   printf("filtercap: rule=%d matcher=%d slot=%d argv=%d\n",
          (int) HTS_FILTER_MAXLEN, (int) STRJOKER_MAXLEN,
          (int) HTS_FILTER_SLOT_SIZE, (int) HTS_CDLMAXSIZE);

--- a/tests/302_filter-token-overflow.test
+++ b/tests/302_filter-token-overflow.test
@@ -13,8 +13,8 @@ assert_selftest "scantoken self-test OK" scantoken
 tmpdir="$(mktemp -d)"
 cleanup_push rm -rf "$tmpdir"
 
-# HTS_URLMAXSIZE * 2, less the NUL. The sign is prepended after the copy,
-# into a slot of its own, so it costs the token nothing.
+# HTS_URLMAXSIZE * 2, less the NUL. The sign is prepended after the copy, so a
+# rule's own cap is one higher than the token's; 317 pins the two together.
 maxfilter=2047
 maxurl=2047
 
@@ -50,7 +50,7 @@ for over in 1 512; do
     longrule "$((maxfilter + over))" "$tmpdir/over.txt"
     assert_eq "http://www.example.com/a.png: accepted by rule #1 (+*.png)" \
         "$(why "$tmpdir/over.txt")" "filter of $((maxfilter + over)) bytes"
-    assert_match "Filter rule longer than $maxfilter bytes, ignored: -aaa" \
+    assert_match "Filter rule longer than $((maxfilter + 1)) bytes, ignored: -aaa" \
         "$(<"$tmpdir/p/hts-log.txt")" "refusal named in the log"
 done
 

--- a/tests/302_filter-token-overflow.test
+++ b/tests/302_filter-token-overflow.test
@@ -19,9 +19,7 @@ maxfilter=2047
 maxurl=2047
 
 rep() { # rep CHAR COUNT
-    local pad
-    pad=$(printf '%*s' "$2" '')
-    printf '%s' "${pad// /$1}"
+    printf "%${2}s" '' | tr ' ' "$1"
 }
 
 # Runs --why over a rules file and returns the verdict line alone.

--- a/tests/302_filter-token-overflow.test
+++ b/tests/302_filter-token-overflow.test
@@ -13,8 +13,8 @@ assert_selftest "scantoken self-test OK" scantoken
 tmpdir="$(mktemp -d)"
 cleanup_push rm -rf "$tmpdir"
 
-# Token caps, both less the NUL: a rule loses one more byte to the sign the
-# engine prepends after the copy, so its own cap is 2048. 317 pins that one.
+# Token caps: a seed is bounded by its own buffer less the NUL, a rule by
+# HTS_FILTER_MAXLEN less the sign prepended after the copy. 317 pins the rule's.
 maxfilter=2047
 maxurl=2047
 

--- a/tests/302_filter-token-overflow.test
+++ b/tests/302_filter-token-overflow.test
@@ -13,8 +13,8 @@ assert_selftest "scantoken self-test OK" scantoken
 tmpdir="$(mktemp -d)"
 cleanup_push rm -rf "$tmpdir"
 
-# HTS_URLMAXSIZE * 2, less the NUL. The sign is prepended after the copy, so a
-# rule's own cap is one higher than the token's; 317 pins the two together.
+# Token caps, both less the NUL: a rule loses one more byte to the sign the
+# engine prepends after the copy, so its own cap is 2048. 317 pins that one.
 maxfilter=2047
 maxurl=2047
 

--- a/tests/317_filter-rule-cap.test
+++ b/tests/317_filter-rule-cap.test
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+# #1288: a filter rule meets one cap, and the parser must refuse at the length
+# the array and the matcher stop at. The seed and argv keep their own bounds.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+# From the engine, so a cap that moves moves the boundaries probed below.
+caps=$(httrack -O /dev/null -#test=filtercap) || fail "filtercap self-test failed"
+limits=$(grep '^filtercap: ' <<<"$caps") || fail "no limits line in: $caps"
+read -r _ rulecap matcher slot argvcap <<<"$limits"
+rulecap=${rulecap#rule=}
+matcher=${matcher#matcher=}
+slot=${slot#slot=}
+argvcap=${argvcap#argv=}
+
+# A stored rule is one the matcher reads and a slot holds; the matcher is the
+# lower of the two today, so it is what governs.
+test "$rulecap" -le "$matcher" || fail "cap $rulecap outreaches the matcher $matcher"
+test "$slot" -gt "$rulecap" || fail "slot $slot does not outsize the cap $rulecap"
+test "$argvcap" -le "$rulecap" || fail "argv $argvcap outreaches the cap $rulecap"
+
+tmpdir="$(mktemp -d)"
+cleanup_push rm -rf "$tmpdir"
+
+URL=http://www.example.com/a.png
+
+rep() { # rep CHAR COUNT
+    local pad
+    pad=$(printf '%*s' "$2" '')
+    printf '%s' "${pad// /$1}"
+}
+
+# A rule of LENGTH bytes, sign included, that $URL does not match.
+mkrule() { # mkrule LENGTH
+    printf -- '-www.example.com/%s*' "$(rep a $(($1 - 18)))"
+}
+
+# Runs --why over a rules file and returns the verdict line alone.
+why() { # why RULE-FILE
+    local out
+    rm -rf "$tmpdir/p"
+    out="$(httrack -O "$tmpdir/p" -q --why "$URL" -%S "$1" http://www.example.com/)" ||
+        fail "httrack exited $? on $(basename "$1")"
+    grep -E 'accepted|rejected|no filter|unable' <<<"$out"
+}
+
+# At the cap the rule is kept, so the one that decides is the second.
+for len in $((rulecap - 1)) "$rulecap"; do
+    printf -- '%s\n+*.png\n' "$(mkrule "$len")" >"$tmpdir/r.txt"
+    assert_eq "$URL: accepted by rule #2 (+*.png)" "$(why "$tmpdir/r.txt")" \
+        "rule of $len bytes"
+done
+
+# One byte over: the numbering shifts, and the refusal must name the cap the
+# array enforces, or a rule falls between the two.
+printf -- '%s\n+*.png\n' "$(mkrule $((rulecap + 1)))" >"$tmpdir/r.txt"
+assert_eq "$URL: accepted by rule #1 (+*.png)" "$(why "$tmpdir/r.txt")" \
+    "rule of $((rulecap + 1)) bytes"
+assert_match "Filter rule longer than $rulecap bytes, ignored: -www" \
+    "$(<"$tmpdir/p/hts-log.txt")" "the refusal names the array's cap"
+
+# The seed beside it is copied by the same loop and bounded on its own; take
+# that bound from the engine too, not from the rule's.
+seedwarned=0
+seed() { # seed LENGTH
+    printf -- 'http://www.example.com/%s\n+*.png\n' "$(rep a $(($1 - 23)))" \
+        >"$tmpdir/u.txt"
+    assert_eq "$URL: accepted by rule #1 (+*.png)" "$(why "$tmpdir/u.txt")" \
+        "seed of $1 bytes"
+    seedwarned=$(grep -c 'URL longer than' "$tmpdir/p/hts-log.txt" || true)
+}
+seed $((rulecap + 512))
+assert_eq 1 "$seedwarned" "a seed past every bound"
+seedcap=$(sed -n 's/.*URL longer than \([0-9]*\) bytes.*/\1/p' "$tmpdir/p/hts-log.txt")
+test -n "$seedcap" || fail "the seed refusal did not name its own cap"
+
+# Two bounds, not one shared: the sign a rule spends costs the seed a byte, so
+# the length the parser keeps as a rule is one it drops as a URL.
+test "$seedcap" -ne "$rulecap" || fail "seed and rule share the cap $rulecap"
+seed "$seedcap"
+assert_eq 0 "$seedwarned" "seed at its own cap"
+seed $((seedcap + 1))
+assert_eq 1 "$seedwarned" "seed one byte over"
+
+# On the command line argv is what a rule meets first, so the lengths above are
+# out of reach there whatever the filter cap becomes.
+cli_rc=0
+cli_out=""
+cli() { # cli RULE
+    rm -rf "$tmpdir/p"
+    cli_rc=0
+    cli_out="$(httrack -O "$tmpdir/p" -q --why "$URL" "$1" '+*.png' \
+        http://www.example.com/ 2>&1)" || cli_rc=$?
+}
+
+cli "$(mkrule $((argvcap - 1)))"
+assert_eq 0 "$cli_rc" "rule of $((argvcap - 1)) bytes on the command line"
+assert_match 'accepted by rule #2' "$cli_out" "kept"
+
+for len in "$argvcap" "$rulecap"; do
+    cli "$(mkrule "$len")"
+    test "$cli_rc" -ne 0 || fail "argv took a $len-byte rule: $cli_out"
+    assert_match 'argument too long' "$cli_out" "argv refuses $len bytes"
+done

--- a/tests/317_filter-rule-cap.test
+++ b/tests/317_filter-rule-cap.test
@@ -11,16 +11,12 @@ set -euo pipefail
 # From the engine, so a cap that moves moves the boundaries probed below.
 caps=$(httrack -O /dev/null -#test=filtercap) || fail "filtercap self-test failed"
 limits=$(grep '^filtercap: ' <<<"$caps") || fail "no limits line in: $caps"
-read -r _ rulecap matcher slot argvcap <<<"$limits"
+read -r _ rulecap argvcap <<<"$limits"
 rulecap=${rulecap#rule=}
-matcher=${matcher#matcher=}
-slot=${slot#slot=}
 argvcap=${argvcap#argv=}
 
-# A stored rule is one the matcher reads and a slot holds. The matcher is the
-# tighter of the two today, so it governs.
-test "$rulecap" -le "$matcher" || fail "cap $rulecap outreaches the matcher $matcher"
-test "$slot" -gt "$rulecap" || fail "slot $slot does not outsize the cap $rulecap"
+# The matcher and the slot are already tied to the cap at compile time
+# (hts_filter_maxlen_matches/_fits in htscore.c); argv is the one that is not.
 test "$argvcap" -le "$rulecap" || fail "argv $argvcap outreaches the cap $rulecap"
 
 tmpdir="$(mktemp -d)"
@@ -73,10 +69,14 @@ seed() { # seed LENGTH
         "seed of $1 bytes"
     seedwarned=$(grep -c 'URL longer than' "$tmpdir/p/hts-log.txt" || true)
 }
-seed $((rulecap + 512))
-assert_eq 1 "$seedwarned" "a seed past every bound"
+# Deliberately not derived from the rule cap: a seed sized off the wrong bound
+# reds this on a cap move with no engine bug behind it.
+probe=65536
+seed "$probe"
+assert_eq 1 "$seedwarned" "a seed of $probe bytes"
 seedcap=$(sed -n 's/.*URL longer than \([0-9]*\) bytes.*/\1/p' "$tmpdir/p/hts-log.txt")
 test -n "$seedcap" || fail "the seed refusal did not name its own cap"
+test "$seedcap" -lt "$probe" || fail "the $probe-byte probe did not clear $seedcap"
 
 # Two bounds, not one shared: a rule spends a byte on its sign, so the length
 # the parser keeps as a rule is one it drops as a URL.

--- a/tests/317_filter-rule-cap.test
+++ b/tests/317_filter-rule-cap.test
@@ -17,8 +17,8 @@ matcher=${matcher#matcher=}
 slot=${slot#slot=}
 argvcap=${argvcap#argv=}
 
-# A stored rule is one the matcher reads and a slot holds; the matcher is the
-# lower of the two today, so it is what governs.
+# A stored rule is one the matcher reads and a slot holds. The matcher is the
+# tighter of the two today, so it governs.
 test "$rulecap" -le "$matcher" || fail "cap $rulecap outreaches the matcher $matcher"
 test "$slot" -gt "$rulecap" || fail "slot $slot does not outsize the cap $rulecap"
 test "$argvcap" -le "$rulecap" || fail "argv $argvcap outreaches the cap $rulecap"
@@ -78,8 +78,8 @@ assert_eq 1 "$seedwarned" "a seed past every bound"
 seedcap=$(sed -n 's/.*URL longer than \([0-9]*\) bytes.*/\1/p' "$tmpdir/p/hts-log.txt")
 test -n "$seedcap" || fail "the seed refusal did not name its own cap"
 
-# Two bounds, not one shared: the sign a rule spends costs the seed a byte, so
-# the length the parser keeps as a rule is one it drops as a URL.
+# Two bounds, not one shared: a rule spends a byte on its sign, so the length
+# the parser keeps as a rule is one it drops as a URL.
 test "$seedcap" -ne "$rulecap" || fail "seed and rule share the cap $rulecap"
 seed "$seedcap"
 assert_eq 0 "$seedwarned" "seed at its own cap"

--- a/tests/317_filter-rule-cap.test
+++ b/tests/317_filter-rule-cap.test
@@ -24,10 +24,10 @@ cleanup_push rm -rf "$tmpdir"
 
 URL=http://www.example.com/a.png
 
+# Not ${pad// /$1}: bash 3.2, still macOS's /bin/bash, is quadratic there and
+# spent the whole 600s budget on the 64 KB seed probe below.
 rep() { # rep CHAR COUNT
-    local pad
-    pad=$(printf '%*s' "$2" '')
-    printf '%s' "${pad// /$1}"
+    printf "%${2}s" '' | tr ' ' "$1"
 }
 
 # A rule of LENGTH bytes, sign included, that $URL does not match.


### PR DESCRIPTION
`httpmirror()` copies each filter rule into a scratch local before handing it to the array, and that local was sized off `HTS_URLMAXSIZE * 2` while the array checks `HTS_FILTER_MAXLEN`. The two numbers match today only because both descend from the same constant, and the refusal the parser prints quotes the token's cap rather than the rule's. Size the scratch off `HTS_FILTER_MAXLEN`, let the join buffer follow it, and print that same number.

Sizing it off `HTS_FILTER_SLOT_SIZE`, as the issue suggests, would be wrong: `HTS_FILTER_MAXLEN` is `min(HTS_FILTER_SLOT_SIZE - 1, STRJOKER_MAXLEN)`, so the matcher governs at 2048 and the slot's 4104 bytes are reserve, not reach. Nothing about the accepted length moves. A rule is still capped at 2048 bytes with its sign, on the command line the 1024-byte argv cap is what it meets first, and `-fstack-usage` reports the same frame for `httpmirror()` either way.

Test 317 reads the three caps out of the engine, through a new line from the `filtercap` self-test, then walks a rule under, at and over the cap through `-%S`, checks the refusal names the array's own cap, repeats that for the seed URL beside it, and confirms the command line dies on argv first. It kills three mutants: slot-sized scratch, an off-by-one room, and the old number in the message. Raising `STRJOKER_MAXLEN` until the slot becomes the binding limit leaves it green, which is what the test is for.

Closes #1288