### PR TITLE
A URL added mid-crawl is recorded before its type is resolved, over a dangling array

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -3704,14 +3704,21 @@ void hts_addurl_free(char **url) {
   }
 }
 
+/* Install url and return what it replaced (locked) */
+static char **hts_addurl_swap_(httrackp *opt, char **url) {
+  char **const old = opt->state._hts_addurl;
+
+  opt->state._hts_addurl = url;
+  return old;
+}
+
 char **hts_addurl_take(httrackp *opt) {
-  char **url;
+  char **old;
 
   hts_mutexlock(&opt->state.lock);
-  url = opt->state._hts_addurl;
-  opt->state._hts_addurl = NULL;
+  old = hts_addurl_swap_(opt, NULL);
   hts_mutexrelease(&opt->state.lock);
-  return url;
+  return old;
 }
 
 /* Deep copy: the caller's array is typically a stack local, and the engine
@@ -3719,7 +3726,7 @@ char **hts_addurl_take(httrackp *opt) {
 HTSEXT_API hts_boolean hts_addurl(httrackp *opt, char **url) {
   char **copy = NULL;
 
-  if (url != NULL && *url != NULL) {
+  if (url != NULL) {
     size_t n, i;
 
     for (n = 0; url[n] != NULL; n++)
@@ -3733,10 +3740,14 @@ HTSEXT_API hts_boolean hts_addurl(httrackp *opt, char **url) {
     }
   }
   if (copy != NULL) {
-    hts_addurl_free(hts_addurl_take(opt));
+    char **old;
+
+    /* One critical section: two racing callers must not both read NULL and
+       then both install, which leaks the loser's list. */
     hts_mutexlock(&opt->state.lock);
-    opt->state._hts_addurl = copy;
+    old = hts_addurl_swap_(opt, copy);
     hts_mutexrelease(&opt->state.lock);
+    hts_addurl_free(old);
   }
   return (copy != NULL);
 }

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -3692,15 +3692,58 @@ HTSEXT_API hts_boolean hts_has_stopped(httrackp *opt) {
   return ended;
 }
 
-// ajout d'URL
-HTSEXT_API hts_boolean hts_addurl(httrackp *opt, char **url) {
-  if (url)
-    opt->state._hts_addurl = url;
-  return (opt->state._hts_addurl != NULL);
+// URLs injected into a running mirror
+void hts_addurl_free(char **url) {
+  if (url != NULL) {
+    size_t i;
+
+    for (i = 0; url[i] != NULL; i++) {
+      freet(url[i]);
+    }
+    freet(url);
+  }
 }
-HTSEXT_API hts_boolean hts_resetaddurl(httrackp *opt) {
+
+char **hts_addurl_take(httrackp *opt) {
+  char **url;
+
+  hts_mutexlock(&opt->state.lock);
+  url = opt->state._hts_addurl;
   opt->state._hts_addurl = NULL;
-  return (opt->state._hts_addurl != NULL);
+  hts_mutexrelease(&opt->state.lock);
+  return url;
+}
+
+/* Deep copy: the caller's array is typically a stack local, and the engine
+   thread reads the list long after the call returns. */
+HTSEXT_API hts_boolean hts_addurl(httrackp *opt, char **url) {
+  char **copy = NULL;
+
+  if (url != NULL && *url != NULL) {
+    size_t n, i;
+
+    for (n = 0; url[n] != NULL; n++)
+      ;
+    copy = (char **) calloct(n + 1, sizeof(char *));
+    for (i = 0; copy != NULL && i < n; i++) {
+      if ((copy[i] = strdupt(url[i])) == NULL) {
+        hts_addurl_free(copy);
+        copy = NULL;
+      }
+    }
+  }
+  if (copy != NULL) {
+    hts_addurl_free(hts_addurl_take(opt));
+    hts_mutexlock(&opt->state.lock);
+    opt->state._hts_addurl = copy;
+    hts_mutexrelease(&opt->state.lock);
+  }
+  return (copy != NULL);
+}
+
+HTSEXT_API hts_boolean hts_resetaddurl(httrackp *opt) {
+  hts_addurl_free(hts_addurl_take(opt));
+  return HTS_FALSE;
 }
 
 // copier nouveaux paramètres si besoin

--- a/src/htscore.h
+++ b/src/htscore.h
@@ -307,6 +307,13 @@ HTS_STATIC int cache_readable(cache_back * cache) {
 
 char *hts_cancel_file_pop(httrackp * opt);
 
+/* Detach the pending hts_addurl() list, transferring ownership to the caller;
+   NULL when none is pending. Release it with hts_addurl_free(). */
+char **hts_addurl_take(httrackp *opt);
+
+/* Free a list taken with hts_addurl_take(), strings included. */
+void hts_addurl_free(char **url);
+
 #endif
 
 /* Record a link on the heap. All strings are copied (caller keeps ownership).

--- a/src/htscore.h
+++ b/src/htscore.h
@@ -307,8 +307,8 @@ HTS_STATIC int cache_readable(cache_back * cache) {
 
 char *hts_cancel_file_pop(httrackp * opt);
 
-/* Detach the pending hts_addurl() list, transferring ownership to the caller;
-   NULL when none is pending. Release it with hts_addurl_free(). */
+/* Detach the pending hts_addurl() list and give the caller ownership; NULL
+   when none is pending. Free it with hts_addurl_free(). */
 char **hts_addurl_take(httrackp *opt);
 
 /* Free a list taken with hts_addurl_take(), strings included. */

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -6643,6 +6643,9 @@ HTSEXT_API void hts_free_opt(httrackp * opt) {
       coucal_delete(&root); // frees records via hts_cache_value_free
     }
 
+    /* URLs a front end queued but the engine never got to inject */
+    hts_addurl_free(hts_addurl_take(opt));
+
     /* Cancel chain */
     if (opt->state.cancel != NULL) {
       htsoptstatecancel *cancel;

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -4064,8 +4064,8 @@ void hts_mirror_process_user_interaction(htsmoduleStruct * str,
 
         former.adr[0] = former.fil[0] = '\0';
 
-        // calculer lien et éventuellement modifier addresse/fichier
-        r_sv = url_savename(&add, &former, NULL, NULL, opt, sback, cache, hash,
+        // resolve the link, possibly rewriting address/file
+        r_sv = url_savename(&add, NULL, NULL, NULL, opt, sback, cache, hash,
                             ptr, numero_passe, NULL);
         /* No headers were passed, so the name may still be a placeholder: the
            parser resolves it before recording, and so must we (#1253). */
@@ -4074,14 +4074,15 @@ void hts_mirror_process_user_interaction(htsmoduleStruct * str,
               hts_wait_delayed(str, &add, NULL, NULL, &former, &forbidden_url);
         }
         if (r_sv != -1) {
-          if (forbidden_url == 1) {
-            hts_log_print(
-                opt, LOG_NOTICE,
-                "Link %s%s not added after user request: type refused",
-                add.af.adr, add.af.fil);
+          /* A refused type, or a stop that left the placeholder: recording
+             that name is the bug. */
+          if (forbidden_url == 1 || IS_DELAYED_EXT(add.save)) {
+            hts_log_print(opt, LOG_NOTICE,
+                          "Link %s%s not added after user request", add.af.adr,
+                          add.af.fil);
           } else if (hash_read(hash, add.save, NULL, HASH_STRUCT_FILENAME) <
-                     0) { // n'existe pas déja
-            // enregistrer lien
+                     0) { // no existing record
+            // record the link
             if (hts_record_link(opt, add.af.adr, add.af.fil, add.save,
                                 former.adr, former.fil, NULL)) {
               heap_top()->testmode = 0;    // mode test?
@@ -4095,7 +4096,7 @@ void hts_mirror_process_user_interaction(htsmoduleStruct * str,
               hts_log_print(opt, LOG_INFO, "Link added by user: %s%s", add.af.adr,
                             add.af.fil);
               //
-            } else { // oups erreur, plus de mémoire!!
+            } else { // out of memory
               hts_addurl_free(addurl);
               XH_uninit;        // désallocation mémoire & buffers
               return;

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -4044,25 +4044,46 @@ void hts_mirror_process_user_interaction(htsmoduleStruct * str,
   // end of pause/lock files
 
   // changement dans les préférences
-  if (opt->state._hts_addurl) {
+  {
+    char **const addurl = hts_addurl_take(opt);
+    char **next;
     lien_adrfilsave add;
 
-    while(*opt->state._hts_addurl) {
+    for (next = addurl; next != NULL && *next != NULL; next++) {
       char BIGSTK add_url[HTS_URLMAXSIZE * 2];
 
       add.af.adr[0] = add.af.fil[0] = add_url[0] = '\0';
-      if (!link_has_authority(*opt->state._hts_addurl))
+      if (!link_has_authority(*next))
         strcpybuff(add_url, "http://"); // ajouter http://
-      strcatbuff(add_url, *opt->state._hts_addurl);
+      strcatbuff(add_url, *next);
       if (ident_url_absolute(add_url, &add.af) >= 0) {
         // ----Ajout----
+        lien_adrfil former;
+        int forbidden_url = 0;
+        int r_sv;
+
+        former.adr[0] = former.fil[0] = '\0';
 
         // calculer lien et éventuellement modifier addresse/fichier
-        if (url_savename
-            (&add, NULL, NULL, NULL, opt, sback, cache, hash, ptr, numero_passe, NULL) != -1) {
-          if (hash_read(hash, add.save, NULL, HASH_STRUCT_FILENAME) < 0) { // n'existe pas déja
+        r_sv = url_savename(&add, &former, NULL, NULL, opt, sback, cache, hash,
+                            ptr, numero_passe, NULL);
+        /* No headers were passed, so the name may still be a placeholder: the
+           parser resolves it before recording, and so must we (#1253). */
+        if (r_sv != -1 && IS_DELAYED_EXT(add.save)) {
+          r_sv =
+              hts_wait_delayed(str, &add, NULL, NULL, &former, &forbidden_url);
+        }
+        if (r_sv != -1) {
+          if (forbidden_url == 1) {
+            hts_log_print(
+                opt, LOG_NOTICE,
+                "Link %s%s not added after user request: type refused",
+                add.af.adr, add.af.fil);
+          } else if (hash_read(hash, add.save, NULL, HASH_STRUCT_FILENAME) <
+                     0) { // n'existe pas déja
             // enregistrer lien
-            if (hts_record_link(opt, add.af.adr, add.af.fil, add.save, "", "", NULL)) {
+            if (hts_record_link(opt, add.af.adr, add.af.fil, add.save,
+                                former.adr, former.fil, NULL)) {
               heap_top()->testmode = 0;    // mode test?
               heap_top()->link_import = 0; // mode normal
               heap_top()->depth = opt->depth;
@@ -4074,7 +4095,8 @@ void hts_mirror_process_user_interaction(htsmoduleStruct * str,
               hts_log_print(opt, LOG_INFO, "Link added by user: %s%s", add.af.adr,
                             add.af.fil);
               //
-            } else {            // oups erreur, plus de mémoire!!
+            } else { // oups erreur, plus de mémoire!!
+              hts_addurl_free(addurl);
               XH_uninit;        // désallocation mémoire & buffers
               return;
             }
@@ -4083,16 +4105,14 @@ void hts_mirror_process_user_interaction(htsmoduleStruct * str,
                           "Existing link %s%s not added after user request",
                           add.af.adr, add.af.fil);
           }
-
         }
       } else {
         hts_log_print(opt, LOG_ERROR, "Error during URL decoding for %s",
                       add_url);
       }
       // ----Fin Ajout----
-      opt->state._hts_addurl++; // suivante
     }
-    opt->state._hts_addurl = NULL;      // libérer _hts_addurl
+    hts_addurl_free(addurl);
   }
   // si une pause a été demandée
   if (opt->state._hts_setpause

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -341,9 +341,9 @@ HTSEXT_API int hts_is_exiting(httrackp *opt);
 /*HTSEXT_API int hts_setopt(httrackp* opt); DEPRECATED ; see copy_htsopt() */
 
 /** Queue extra start URLs to inject into a running mirror. @p url is a
-    caller-owned, NULL-terminated array of strings; the engine stores the
-   pointer without copying, so the array and its strings must stay valid until
-   the engine consumes them. @return nonzero if a list is now set. */
+    caller-owned, NULL-terminated array of strings, deep-copied here, so the
+   caller may release it as soon as this returns. Any list still pending is
+   replaced. @return nonzero if a list is now set. */
 HTSEXT_API hts_boolean hts_addurl(httrackp *opt, char **url);
 
 /** Clear any pending add-URL list set by hts_addurl(). Always returns 0. */

--- a/tests/319_webhttrack-addurl.test
+++ b/tests/319_webhttrack-addurl.test
@@ -1,0 +1,100 @@
+#!/bin/bash
+#
+# A URL injected mid-crawl through WebHTTrack's add-url must land with a
+# resolved name, parsed and cached, not under a ".delayed" placeholder (#1253).
+
+set -euo pipefail
+
+# shellcheck source=tests/webhttracklib.sh
+. "${0%"${0##*/}"}./webhttracklib.sh"
+
+htsserver_require
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_addurl.XXXXXX") || fail "no tmpdir"
+csrv=
+cleanup() {
+    htsserver_cleanup
+    test -z "${csrv}" || kill -9 "${csrv}" 2>/dev/null || true
+    wait "${csrv}" 2>/dev/null || true # absorb bash's async "Killed" notice
+    rm -rf "${work}"
+}
+cleanup_push cleanup
+
+export HOME="${work}" # no ~/.httrack.ini of the developer's in the store
+
+mkdir -p "${work}/docroot/added"
+printf '<html><body><a href="child.html">child</a></body></html>\n' \
+    >"${work}/docroot/added/page.html"
+# The child links back, so the injected URL is also reached the ordinary way:
+# that second reference is what a placeholder record sends looping.
+printf '<html><body><a href="page.html">back</a></body></html>\n' \
+    >"${work}/docroot/added/child.html"
+
+clog="${work}/content.log"
+"${HTS_PYTHON}" "${testdir}/local-server.py" --root "${work}/docroot" \
+    >"${clog}" 2>&1 &
+csrv=$!
+cport=$(discover_server_port "${clog}" "${csrv}") || fail "no content server"
+
+htsserver_start
+sid=$(htsserver_sid)
+test "${#sid}" -eq 32 || fail "no session id in the panel (got '${sid}')"
+
+# p0.bin trickles for a minute, so the crawl is still running when the URL is
+# injected; it takes one socket and leaves the rest free for the injected one.
+out="${work}/crawl"
+htsserver_client --path /step4.html --field "sid=${sid}" --field "path=${work}" \
+    --field projname=crawl --field winprofile=x --field command_do=start \
+    --field "command=httrack --robots=0 http://127.0.0.1:${cport}/trickle/p0.bin +* -O ${out}" \
+    >/dev/null
+
+log="${out}/hts-log.txt"
+site="${out}/127.0.0.1_${cport}/added"
+start=$SECONDS
+while test ! -f "${log}"; do
+    test "$((SECONDS - start))" -lt 60 || fail "the crawl never started"
+    poll_wait 0.2
+done
+
+htsserver_client --path /step4.html --field "sid=${sid}" \
+    --field "command=add-url=http://127.0.0.1:${cport}/added/page.html" \
+    >/dev/null
+
+# child.html is only reachable by parsing the injected page.
+start=$SECONDS
+while test ! -f "${site}/child.html"; do
+    htsserver_alive || fail "htsserver died: $(tail -n 20 "${log}" 2>/dev/null)"
+    test "$((SECONDS - start))" -lt 120 ||
+        fail "the added URL was not fetched and parsed: $(ls -R "${out}")"
+    poll_wait 0.2
+done
+
+htsserver_client --path /step4.html --field "sid=${sid}" --field command=cancel \
+    >/dev/null
+start=$SECONDS
+while test -f "${out}/hts-in_progress.lock"; do
+    test "$((SECONDS - start))" -lt 120 || fail "the crawl did not end"
+    poll_wait 0.2
+done
+
+# The name, not just the content: a placeholder ships the file unusable.
+assert_file "${site}/page.html" "the added URL kept a placeholder name"
+left=$(find "${site}" -name '*.delayed')
+test -z "${left}" || fail "a delayed placeholder survived: ${left}"
+
+# A rename alone is not the fix: a record still holding the placeholder makes
+# every later reference to it spin in the type waiter and get dropped.
+! grep -q "Duplicate entry in hts_wait_delayed" "${log}" ||
+    fail "the added link's own record collided in the type waiter"
+! grep -q "probably looping, type unknown" "${log}" ||
+    fail "the added link was dropped as looping"
+
+# Cached, under the resolved name: the cache index carries both.
+cached=$(grep "/added/page.html" "${out}/hts-cache/new.txt" || true)
+test -n "${cached}" || fail "the added URL was never cached"
+case ${cached} in
+*"${site}/page.html"*) ;;
+*) fail "the cache recorded another name: ${cached}" ;;
+esac
+
+echo "PASS"

--- a/tests/319_webhttrack-addurl.test
+++ b/tests/319_webhttrack-addurl.test
@@ -64,16 +64,16 @@ htsserver_client --path /step4.html --field "sid=${sid}" \
 start=$SECONDS
 while test ! -f "${site}/child.html"; do
     htsserver_alive || fail "htsserver died: $(tail -n 20 "${log}" 2>/dev/null)"
-    test "$((SECONDS - start))" -lt 120 ||
+    test "$((SECONDS - start))" -lt 90 ||
         fail "the added URL was not fetched and parsed: $(ls -R "${out}")"
     poll_wait 0.2
 done
 
-htsserver_client --path /step4.html --field "sid=${sid}" --field command=cancel \
-    >/dev/null
+# The summary line is written once, at the end, so it cannot already be true:
+# waiting on it is what makes the cache and log checks below meaningful.
 start=$SECONDS
-while test -f "${out}/hts-in_progress.lock"; do
-    test "$((SECONDS - start))" -lt 120 || fail "the crawl did not end"
+while ! grep -q "HTTrack Website Copier/" "${log}"; do
+    test "$((SECONDS - start))" -lt 90 || fail "the crawl did not end"
     poll_wait 0.2
 done
 
@@ -83,18 +83,18 @@ left=$(find "${site}" -name '*.delayed')
 test -z "${left}" || fail "a delayed placeholder survived: ${left}"
 
 # A rename alone is not the fix: a record still holding the placeholder makes
-# every later reference to it spin in the type waiter and get dropped.
+# every later reference to it spin in the type waiter and get dropped. Both
+# lines reach the log at the default verbosity, as errors and warnings do.
 ! grep -q "Duplicate entry in hts_wait_delayed" "${log}" ||
     fail "the added link's own record collided in the type waiter"
 ! grep -q "probably looping, type unknown" "${log}" ||
     fail "the added link was dropped as looping"
 
-# Cached, under the resolved name: the cache index carries both.
+# The cache index holds the URL and the name it was saved under.
 cached=$(grep "/added/page.html" "${out}/hts-cache/new.txt" || true)
 test -n "${cached}" || fail "the added URL was never cached"
 case ${cached} in
-*"${site}/page.html"*) ;;
-*) fail "the cache recorded another name: ${cached}" ;;
+*.delayed*) fail "the cache recorded a placeholder: ${cached}" ;;
 esac
 
 echo "PASS"


### PR DESCRIPTION
A URL added to a running mirror with `hts_addurl()` never reached the code #1253 is about. `htsserver` builds the URL array on its request handler's stack and `hts_addurl()` stored that pointer for the engine thread to read later, so the engine segfaulted in `link_has_authority()` the moment it got to the injection point. The list is now deep-copied and swapped in under the state lock, so the documented "keep the array alive until the engine consumes it" contract goes away with it. No caller could satisfy that one anyway: nothing signals when the engine is done.

Past that, #1253 itself. The injected URL went to `url_savename()` with no headers, came back carrying the `.delayed` placeholder, and was recorded under it. Every later reference then resolved to the placeholder, `hts_wait_delayed()` found the link's own record, logged "Duplicate entry" and gave up, and the link was dropped as looping. The addurl path now resolves the type before recording, the way the external-module path in `htscore.c` already does, and refuses the link outright if the name is still a placeholder. The issue's other candidate, teaching the duplicate branch to tolerate the link's own record, needs the resolved name written back into the heap entry and re-keyed in `hash->sav`, or `url_savename()`'s early hit keeps handing back the stale placeholder. This side is smaller and leaves that branch's meaning intact.

A MIME type refused during resolution now skips the record instead of queueing a link the engine would drop, with a notice saying so.

Test 319 covers both fixes through htsserver. Mutation-checked: without the type resolution the page ships as `page.1.delayed` with both warning lines in the log, and borrowing the caller's array instead of copying it crashes the server.

Closes #1253
