### PR TITLE
A checkout made before the eol=lf pin reds the .rc test with no explanation

### DIFF
--- a/tests/01_engine-version-macros.test
+++ b/tests/01_engine-version-macros.test
@@ -82,6 +82,12 @@ while read -r f; do
     crs=$(awk '{ n += gsub(/\r/, "") } END { print n + 0 }' "$top/$f")
     [ "$crs" = 0 ] || {
         echo "$f carries $crs CR byte(s)"
+        # An LF blob under a CRLF file means the checkout predates the eol=lf
+        # pin, which git does not apply to files it already wrote.
+        if [ "$tracked" = yes ] && [ "$(git -C "$top" cat-file blob "HEAD:$f" |
+            awk '{ n += gsub(/\r/, "") } END { print n + 0 }')" = 0 ]; then
+            echo "  its blob is LF: run 'git add --renormalize .' in $top"
+        fi
         fail=1
     }
     [ "$tracked" = yes ] || continue


### PR DESCRIPTION
#1309 pinned the three `.rc` files `text eol=lf` over blobs that were already LF, so a fresh clone gets LF and the Win32 build confirmed `rc.exe` is happy with it. Existing checkouts are the gap: Git applies an `eol` attribute when it writes a file, not when the attribute later changes, so everyone who pulls keeps the CRs they already had and `01_engine-version-macros` goes red with only "carries 50 CR byte(s)" to go on.

The test now compares the blob against the file and, when the blob is LF, says the checkout predates the pin and names the fix. Found by merging master into another branch of this batch and watching the suite fail for a reason that had nothing to do with either.
