### PR TITLE
An unreadable uname -s silently disarms the Windows test guard

### DIFF
--- a/tests/01_engine-filter.test
+++ b/tests/01_engine-filter.test
@@ -101,14 +101,8 @@ nomatch 'www.*[path].com/*[path].zip' 'www.foo.com/a/b.tar'
 match '*.html*[]' 'page.html'
 nomatch '*.html*[]' 'page.html?x=1' # *[] forbids the trailing query
 
-# Size-based rules (-#test=filtersize <size> <string> <filter...>): a negative size
-# means the size is still unknown (scan time). A size exclusion must stay neutral
-# then, so the file is fetched and only cancelled once its size is known (#143).
-fsize() {
-    local want=$1
-    shift
-    selftest_queue "$want" filtersize "$@"
-}
+# Size-based rules: a size exclusion must stay neutral while the size is unknown,
+# so the file is fetched and only cancelled once it is known (#143).
 fsize 'verdict=allowed size_flag=0' -1 foo.jpg -* '+*.jpg' '-*.jpg*[<10]'   # scan time: keep
 fsize 'verdict=forbidden size_flag=1' 5 foo.jpg -* '+*.jpg' '-*.jpg*[<10]'  # <10KB: cancel
 fsize 'verdict=allowed size_flag=1' 20 foo.jpg -* '+*.jpg' '-*.jpg*[<10]'   # >=10KB: keep

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -112,3 +112,42 @@ for pre in "-u HTS_OS" "HTS_OS="; do
     test "$got" = "$(uname -s)" || fail "HTS_OS under [env $pre] resolved to [$got]"
 done
 ok "HTS_OS resolves to uname -s, unset or inherited empty"
+
+## A uname -s that says nothing is fatal: the guess it replaced read as
+# not-Windows, so a test excluded from Windows ran there and the leg still greened.
+mkdir "$tmpdir/shim"
+printf '#!/bin/sh\nexit 0\n' >"$tmpdir/shim/uname"
+chmod +x "$tmpdir/shim/uname"
+# shellcheck disable=SC2016
+printf 'set -euo pipefail\n. "%s/testlib.sh"\nif is_windows; then printf yes; else printf no; fi\n' \
+    "$testdir" >"$tmpdir/win.sh"
+rc=0
+out=$(env -u HTS_OS -u IS_WINDOWS PATH="$tmpdir/shim:$PATH" bash "$tmpdir/win.sh" 2>&1) || rc=$?
+test "$rc" -eq 1 || fail "a silent uname -s exited $rc, not 1: $out"
+case "$out" in
+*"uname -s said nothing"*) ;;
+*) fail "a silent uname -s failed without naming the cause: $out" ;;
+esac
+ok "a uname -s that says nothing fails the run instead of guessing not-Windows"
+
+# The way out for a runner whose uname is broken, so the guard cannot cost it the suite.
+while read -r os want; do
+    got=$(env -u IS_WINDOWS HTS_OS="$os" PATH="$tmpdir/shim:$PATH" bash "$tmpdir/win.sh")
+    test "$got" = "$want" || fail "HTS_OS=$os made is_windows [$got], want [$want]"
+done <<'EOF'
+MINGW64_NT-10.0 yes
+MSYS_NT-10.0 yes
+CYGWIN_NT-10.0 yes
+Linux no
+Darwin no
+EOF
+ok "an explicit HTS_OS still classifies, with uname unreadable"
+
+# Unshimmed: a guard that fires only on the broken path is half a guard.
+case "$(uname -s)" in
+MINGW* | MSYS* | CYGWIN*) want=yes ;;
+*) want=no ;;
+esac
+got=$(env -u IS_WINDOWS bash "$tmpdir/win.sh")
+test "$got" = "$want" || fail "is_windows on this host is [$got], want [$want]"
+ok "is_windows agrees with the host's own uname -s ($want)"

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -118,11 +118,16 @@ ok "HTS_OS resolves to uname -s, unset or inherited empty"
 mkdir "$tmpdir/shim"
 printf '#!/bin/sh\nexit 0\n' >"$tmpdir/shim/uname"
 chmod +x "$tmpdir/shim/uname"
+# MSYS splits a PATH entry on TMPDIR's drive colon, which would leave the real
+# uname answering; and a shim is an instrument only once it has intercepted.
+shim=$(posixpath "$tmpdir/shim")
+test -z "$(env PATH="$shim:$PATH" uname -s)" ||
+    fail "the uname shim never intercepted, so the rest of this would test nothing"
 # shellcheck disable=SC2016
 printf 'set -euo pipefail\n. "%s/testlib.sh"\nif is_windows; then printf yes; else printf no; fi\n' \
     "$testdir" >"$tmpdir/win.sh"
 rc=0
-out=$(env -u HTS_OS -u IS_WINDOWS PATH="$tmpdir/shim:$PATH" bash "$tmpdir/win.sh" 2>&1) || rc=$?
+out=$(env -u HTS_OS -u IS_WINDOWS PATH="$shim:$PATH" bash "$tmpdir/win.sh" 2>&1) || rc=$?
 test "$rc" -eq 1 || fail "a silent uname -s exited $rc, not 1: $out"
 case "$out" in
 *"uname -s said nothing"*) ;;
@@ -132,7 +137,7 @@ ok "a uname -s that says nothing fails the run instead of guessing not-Windows"
 
 # The way out for a runner whose uname is broken, so the guard cannot cost it the suite.
 while read -r os want; do
-    got=$(env -u IS_WINDOWS HTS_OS="$os" PATH="$tmpdir/shim:$PATH" bash "$tmpdir/win.sh")
+    got=$(env -u IS_WINDOWS HTS_OS="$os" PATH="$shim:$PATH" bash "$tmpdir/win.sh")
     test "$got" = "$want" || fail "HTS_OS=$os made is_windows [$got], want [$want]"
 done <<'EOF'
 MINGW64_NT-10.0 yes

--- a/tests/304_engine-filter-size-bounds.test
+++ b/tests/304_engine-filter-size-bounds.test
@@ -9,14 +9,6 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-# -#test=filtersize <size in KB> <string> <filter...>; a negative size means the
-# size is not known yet (scan time).
-fsize() {
-    local want=$1
-    shift
-    selftest_queue "$want" filtersize "$@"
-}
-
 # Both bounds apply, in either order and with or without the comma, and both are
 # strict.
 for rule in '+*[<80>1]' '+*[>1<80]' '+*[>1,<80]'; do

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -11,15 +11,18 @@ testdir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # own value, so the default only serves a hand-run and the Windows suite.
 : "${top_srcdir:=..}"
 
-# Cache uname -s once: every skip gate and every crawl asks for it, and each
-# call is a fork the MSYS runtime emulates (#1273).
-: "${HTS_OS:=$(uname -s 2>/dev/null || echo unknown)}"
-export HTS_OS
-
 fail() {
     echo "FAIL: $*" >&2
     exit 1
 }
+
+# Cache uname -s once: every skip gate asks for it, and each call is a fork the
+# MSYS runtime emulates (#1273). Fatal when it says nothing, never guessed: the
+# guess read as not-Windows, so a test excluded there ran on a Windows runner.
+: "${HTS_OS:=$(uname -s 2>/dev/null)}"
+export HTS_OS
+test -n "$HTS_OS" ||
+    fail "uname -s said nothing, so no platform gate can be trusted; export HTS_OS to override"
 
 # 77 is automake's "skipped", not a failure.
 skip() {
@@ -100,6 +103,14 @@ selftest_queue_tail() { # selftest_queue_tail WANT NAME [ARGS...]
 
 selftest_queue_head() { # selftest_queue_head WANT NAME [ARGS...]
     selftest_queue_mode head "$@"
+}
+
+# Queue a -#test=filtersize case (nothing to do with -#test=fsize): a negative
+# SIZE means the size is not known yet, as at scan time.
+fsize() { # fsize WANT SIZE STRING [FILTER...]
+    local want=$1
+    shift
+    selftest_queue "$want" filtersize "$@"
 }
 
 selftest_queue_mode() { # selftest_queue_mode exact|lines|tail|head WANT NAME [ARGS...]


### PR DESCRIPTION
`tests/testlib.sh` guessed a platform when `uname -s` said nothing, and the guess came out as not-Windows. Tests gated on `is_windows` or on `$HTS_OS` then ran on a Windows runner while the leg still reported green, which is what happened to `153_local-proxytrack-quiet` on one CI run. An unreadable `uname -s` now fails the run instead. Skipping would have been the worse choice: a runner with a broken `uname` would skip its whole suite and report success. Such a runner can still export `HTS_OS` and say what it is.

Test 257 exercises it from both sides. With `uname` shimmed silent the run fails and names the cause, an explicit `HTS_OS` still classifies `MINGW*`/`MSYS*`/`CYGWIN*` as Windows, and unshimmed the verdict still matches the host. The control is master's own copy of the library, where the same shim lets `153_local-proxytrack-quiet` run to completion instead of skipping.

The `fsize()` self-test wrapper was byte-identical in `01_engine-filter` and `304_engine-filter-size-bounds`, so it moves to `testlib.sh`.
