### PR TITLE
The watchdog launch poll never re-reads the log it broke out on

### DIFF
--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -117,7 +117,11 @@ mkdir -p "$bin"
 printf '#!/bin/sh\nprintf "%%s\\n" "$@" >%s/argv.part\nmv %s/argv.part %s/argv\necho "watchdog ready"\n' \
     "$posixtmp" "$posixtmp" "$posixtmp" >"$bin/argvstub"
 printf '#!/bin/sh\nexit 127\n' >"$bin/deadstub"
-chmod +x "$bin/argvstub" "$bin/deadstub"
+# Held until the poll releases it, so its death lands after the poll's read.
+# shellcheck disable=SC2016 # $n is the stub's own, expanded when it runs
+printf '#!/bin/sh\nn=0\nwhile test ! -e race-go && test "$n" -lt 100; do sleep 0.1; n=$((n + 1)); done\necho "watchdog ready"\n' \
+    >"$bin/racestub"
+chmod +x "$bin/argvstub" "$bin/deadstub" "$bin/racestub"
 usestub() { cp "$bin/$1" "$bin/pwsh" && cp "$bin/$1" "$bin/powershell.exe"; }
 usestub argvstub
 
@@ -147,6 +151,30 @@ if test -x "$bin/pwsh"; then
         ci_start_native_watchdog "$posixtmp/progress.log" || rc=$?
         test "$rc" -ne 0 || fail "an interpreter exiting 127 was reported as launched"
         test -z "$ci_watchdog_pid" || fail "a failed launch left pid $ci_watchdog_pid behind"
+
+        # #1321's window, forced: the poll's own first read releases the stub
+        # and reports a miss only once it has spoken and exited.
+        usestub racestub
+        ci_watchdog_pid=''
+        greps=0
+        # shellcheck disable=SC2317 # the driver's own greps are what call it
+        grep() {
+            local n=0
+            greps=$((greps + 1))
+            test "$greps" -eq 1 || {
+                command grep "$@"
+                return $?
+            }
+            : >race-go
+            while test "$n" -lt 100 && kill -0 "$ci_watchdog_pid" 2>/dev/null; do
+                sleep 0.1
+                n=$((n + 1))
+            done
+            return 1
+        }
+        ci_start_native_watchdog "$posixtmp/progress.log" ||
+            fail "a watchdog that spoke and exited before the poll looked again was reported as never launched"
+        unset -f grep
     )
     for _ in $(seq 1 100); do
         test -r "$posixtmp/argv" && break

--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -117,11 +117,15 @@ mkdir -p "$bin"
 printf '#!/bin/sh\nprintf "%%s\\n" "$@" >%s/argv.part\nmv %s/argv.part %s/argv\necho "watchdog ready"\n' \
     "$posixtmp" "$posixtmp" "$posixtmp" >"$bin/argvstub"
 printf '#!/bin/sh\nexit 127\n' >"$bin/deadstub"
-# Held until the poll releases it, so its death lands after the poll's read.
+# Held until the poll releases it, so its death lands after the poll's read. It
+# stays silent on the timeout, which fails the leg rather than passing it blind.
 # shellcheck disable=SC2016 # $n is the stub's own, expanded when it runs
-printf '#!/bin/sh\nn=0\nwhile test ! -e race-go && test "$n" -lt 100; do sleep 0.1; n=$((n + 1)); done\necho "watchdog ready"\n' \
+printf '#!/bin/sh\nn=0\nwhile test ! -e race-go && test "$n" -lt 100; do sleep 0.1; n=$((n + 1)); done\ntest -e race-go && echo "watchdog ready"\n' \
     >"$bin/racestub"
-chmod +x "$bin/argvstub" "$bin/deadstub" "$bin/racestub"
+# execs, so the pid it records stays the one the driver holds.
+# shellcheck disable=SC2016 # $$ is the stub's own, expanded when it runs
+printf '#!/bin/sh\necho $$ >mute.pid\nexec sleep 60\n' >"$bin/mutestub"
+chmod +x "$bin/argvstub" "$bin/deadstub" "$bin/racestub" "$bin/mutestub"
 usestub() { cp "$bin/$1" "$bin/pwsh" && cp "$bin/$1" "$bin/powershell.exe"; }
 usestub argvstub
 
@@ -152,17 +156,38 @@ if test -x "$bin/pwsh"; then
         test "$rc" -ne 0 || fail "an interpreter exiting 127 was reported as launched"
         test -z "$ci_watchdog_pid" || fail "a failed launch left pid $ci_watchdog_pid behind"
 
-        # #1321's window, forced: the poll's own first read releases the stub
-        # and reports a miss only once it has spoken and exited.
+        # A silent one has to be killed and unnamed, or the heartbeat inherits a
+        # watchdog it cannot see.
+        rm -f mute.pid
+        usestub mutestub
+        ci_watchdog_pid='dangling'
+        savedwait=$ci_watchdog_wait
+        ci_watchdog_wait=1
+        rc=0
+        ci_start_native_watchdog "$posixtmp/progress.log" || rc=$?
+        ci_watchdog_wait=$savedwait
+        test -r mute.pid || fail "the silent watchdog never ran"
+        # Its status, not its absence: a stub left to end on its own is gone by
+        # the time any liveness probe runs, and reads as killed.
+        waitrc=0
+        wait "$(cat mute.pid)" 2>/dev/null || waitrc=$?
+        test "$rc" -ne 0 || fail "a watchdog that never spoke was reported as launched"
+        test -z "$ci_watchdog_pid" || fail "a timed-out launch left pid $ci_watchdog_pid behind"
+        test "$waitrc" -gt 128 || fail "a timed-out launch let the watchdog end on its own"
+
+        # #1321's window, forced: the poll's first read releases the stub and
+        # reports a miss only once it has died, marker already in the log.
+        rm -f race-go
         usestub racestub
         ci_watchdog_pid=''
-        greps=0
-        # shellcheck disable=SC2317 # the driver's own greps are what call it
-        grep() {
+        reads=0
+        raced=''
+        # shellcheck disable=SC2317 # the poll is what calls it
+        ci_watchdog_spoke() {
             local n=0
-            greps=$((greps + 1))
-            test "$greps" -eq 1 || {
-                command grep "$@"
+            reads=$((reads + 1))
+            test "$reads" -eq 1 || {
+                grep -q '^watchdog ready$' watchdog.log
                 return $?
             }
             : >race-go
@@ -170,11 +195,14 @@ if test -x "$bin/pwsh"; then
                 sleep 0.1
                 n=$((n + 1))
             done
+            # Reported, not assumed: a stub still alive here leaves the poll on
+            # its ordinary path, where the leg proves nothing.
+            kill -0 "$ci_watchdog_pid" 2>/dev/null || raced=1
             return 1
         }
         ci_start_native_watchdog "$posixtmp/progress.log" ||
             fail "a watchdog that spoke and exited before the poll looked again was reported as never launched"
-        unset -f grep
+        test -n "$raced" || fail "the window never opened: the stub outlived the poll's first read"
     )
     for _ in $(seq 1 100); do
         test -r "$posixtmp/argv" && break

--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -167,13 +167,20 @@ if test -x "$bin/pwsh"; then
         ci_start_native_watchdog "$posixtmp/progress.log" || rc=$?
         ci_watchdog_wait=$savedwait
         test -r mute.pid || fail "the silent watchdog never ran"
-        # Its status, not its absence: a stub left to end on its own is gone by
-        # the time any liveness probe runs, and reads as killed.
-        waitrc=0
-        wait "$(cat mute.pid)" 2>/dev/null || waitrc=$?
+        mutepid=$(cat mute.pid)
+        # Off the job table, or its death is announced over the suite's log.
+        disown "$mutepid" 2>/dev/null || true
         test "$rc" -ne 0 || fail "a watchdog that never spoke was reported as launched"
         test -z "$ci_watchdog_pid" || fail "a timed-out launch left pid $ci_watchdog_pid behind"
-        test "$waitrc" -gt 128 || fail "a timed-out launch let the watchdog end on its own"
+        # Its own sleep outlasts this window many times over, so gone here means
+        # killed. Not the wait status: Windows ends it with taskkill, which MSYS
+        # reports as an ordinary exit.
+        for _ in $(seq 1 50); do
+            kill -0 "$mutepid" 2>/dev/null || break
+            sleep 0.1
+        done
+        kill -0 "$mutepid" 2>/dev/null &&
+            fail "a timed-out launch left the watchdog $mutepid running"
 
         # #1321's window, forced: the poll's first read releases the stub and
         # reports a miss only once it has died, marker already in the log.

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -69,6 +69,12 @@ ci_report_fork_failures() {
 hb_time=0
 hb_now() { hb_time=$SECONDS; }
 
+# Seconds the launch below waits for the marker. Overridable for the unit test.
+ci_watchdog_wait=${ci_watchdog_wait:-30}
+
+# True once the launched interpreter has announced itself.
+ci_watchdog_spoke() { grep -q '^watchdog ready$' watchdog.log; }
+
 # Start the off-box telemetry over the progress log $1, setting ci_watchdog_pid;
 # return 1 with no PowerShell available. Forks nothing and kills nothing, so it
 # reports where the heartbeat below cannot (#795).
@@ -93,15 +99,14 @@ ci_start_native_watchdog() {
         >>watchdog.log 2>&1 &
     ci_watchdog_pid=$!
     # $! comes from the fork, not the exec: wait for it to actually speak.
-    while test "$waited" -lt 30; do
-        grep -q '^watchdog ready$' watchdog.log && return 0
+    while test "$waited" -lt "$ci_watchdog_wait"; do
+        ci_watchdog_spoke && return 0
         kill -0 "$ci_watchdog_pid" 2>/dev/null || break
         sleep 1
         waited=$((waited + 1))
     done
-    # A child that spoke and exited between the read above and the liveness check
-    # that ended the poll did launch (#1321).
-    grep -q '^watchdog ready$' watchdog.log && return 0
+    # A child that spoke and exited mid-poll still launched (#1321).
+    ci_watchdog_spoke && return 0
     kill_pid "$ci_watchdog_pid"
     ci_watchdog_pid=''
     return 1

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -99,6 +99,9 @@ ci_start_native_watchdog() {
         sleep 1
         waited=$((waited + 1))
     done
+    # A child that spoke and exited between the read above and the liveness check
+    # that ended the poll did launch (#1321).
+    grep -q '^watchdog ready$' watchdog.log && return 0
     kill_pid "$ci_watchdog_pid"
     ci_watchdog_pid=''
     return 1


### PR DESCRIPTION
`ci_start_native_watchdog` polls `watchdog.log` for the ready marker and gives up as soon as the child is gone, without reading the log again. So a watchdog that writes the marker and exits between those two steps is reported as never launched. `226_watchdog-native` lands in that window on its normal path: its stub echoes the marker and exits immediately. That is why it went red twice in one day on two unrelated PRs.

The poll now reads the log once more after it ends, through a `ci_watchdog_spoke` helper the test can drive. The test forces the window instead of waiting for it. A shim releases the held stub on the poll's first read, waits for it to die, then reports a miss, and fails the leg if the stub outlived that wait rather than passing on the ordinary path. While the seam was there, the failure path got the leg it never had: a watchdog that never speaks must be killed and its pid cleared.

Closes #1321