### PR TITLE
winprofile.ini's list values disagree between the two GUIs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@ EXTRA_DIST = INSTALL.Linux \
 		tools/macos-app.sh tools/macos-bundle.sh tools/macos-release.sh \
 		tools/httrack-launcher.c \
 		tools/Info.plist.in tools/HTTrack.icns \
-		bootstrap build.sh
+		bootstrap build.sh doc/winprofile-ini.md
 
 # Build the signed Debian packages from a clean source export. Pass the signing
 # key and other options through DEB_FLAGS, e.g.:

--- a/doc/winprofile-ini.md
+++ b/doc/winprofile-ini.md
@@ -1,0 +1,70 @@
+# hts-cache/winprofile.ini
+
+The project settings a HTTrack front end saves beside a mirror, so reopening the
+project restores the wizard. Three programs touch it, in two repositories:
+
+- **WinHTTrack** (httrack-windows, `WinHTTrack/Shell.cpp`) writes it from the
+  dialog fields and reads it back. It is the original writer, and its
+  conventions are the ones below.
+- **WebHTTrack** (`src/htsserver.c`, `html/server/step[24].html`) writes it from
+  the posted form and reads it into the wizard's session state.
+- The **engine** reads one key, `Category`, to group projects in the top index
+  (`src/htstools.c`).
+
+Neither GUI needs the file to run a mirror: the command line the wizard builds
+is what the engine takes, and `hts-cache/doit.log` records it. Getting the file
+wrong loses settings on reopen, it does not corrupt a mirror.
+
+## Syntax
+
+`key=value`, one per line, CRLF, no `[section]` header despite the extension.
+The first `=` separates; later ones belong to the value. A reader ignores keys
+it does not know, and neither GUI writes the other's full key set, so a file
+carries whichever keys its last writer knew.
+
+Two divergences to keep in mind, both older than this document:
+
+- **Duplicate keys resolve differently.** WebHTTrack takes the last occurrence,
+  WinHTTrack the first (`MyGetProfileStringFile` returns on its first match).
+  Write each key once.
+- **The escapes are not the same set.** WebHTTrack encodes `%` as `%%` and any
+  byte under 32 as `%xx`, and also emits `&lt; &gt; &amp; &#39;` for those four
+  characters. WinHTTrack decodes `%%`, `%0d`, `%0a`, `%09` and `%3d`, and turns
+  **every other** `%xx` into a space (`profile_decode`). A value holding an
+  escaped byte outside that set survives a WebHTTrack round trip and degrades in
+  WinHTTrack.
+
+## Value conventions
+
+Four kinds of value, and the kind decides how `0` reads:
+
+| Kind | Spelling | Notes |
+| --- | --- | --- |
+| String | verbatim, escaped as above | `CurrentUrl`, `Category`, `UserID`, `Footer`, the `MIMEDefs*` pairs |
+| Number | decimal | `Depth`, `MaxRate`, `Sockets`. `0` is the user's answer, never "unset" |
+| Checkbox | `1` on, `0` or absent off | Listed in `ini_checkbox_keys[]` in `src/htsserver.c` |
+| List | the **0-based** index of the entry, in `LISTDEF_N` order (`lang.def`) | Listed in `ini_list_keys[]` |
+
+The list keys are `CurrentAction`, `Build`, `PrimaryScan`, `Travel`,
+`GlobalTravel`, `RewriteLinks`, `CheckType`, `FollowRobotsTxt` and `LogType`.
+WinHTTrack stores the combo box's `GetCurSel()` directly, which is where 0-based
+comes from. WebHTTrack numbers the same `<select>` from 1, because id 0 is how
+its templates spell "no value", so it shifts by one at the file boundary rather
+than renumbering the options.
+
+`ProfileFormat=1` marks a file written by WebHTTrack since #1314. A file
+without it is WinHTTrack's own and follows the same conventions, so the marker
+changes no read decision today; it exists so a later change to the format can be
+told apart. WinHTTrack rewrites the file from its own key list and drops the
+marker, which is correct, not a loss.
+
+## Changing the format
+
+A new key needs the same value on both sides or it is worse than no key. Adding
+one to WebHTTrack alone is fine and common (`HostAlias`, `WarcFile`); adding one
+whose *meaning* differs between the GUIs is what #1314 was.
+
+`tests/322_webhttrack-list-ids.test` and `tests/274_wizard-profile-load.test`
+hold the two tables in `src/htsserver.c` against the keys `step4.html` writes.
+Nothing checks either against `Shell.cpp`, so a change to WinHTTrack's side
+still has to be read across by hand.

--- a/doc/winprofile-ini.md
+++ b/doc/winprofile-ini.md
@@ -55,8 +55,8 @@ than renumbering the options.
 `ProfileFormat=1` marks a file written by WebHTTrack since #1314. A file
 without it is WinHTTrack's own and follows the same conventions, so the marker
 changes no read decision today; it exists so a later change to the format can be
-told apart. WinHTTrack rewrites the file from its own key list and drops the
-marker, which is correct, not a loss.
+told apart. Both GUIs write it; WinHTTrack does not yet, and rewrites the file
+from its own key list, so a file it saves loses the marker until it does.
 
 ## Changing the format
 

--- a/doc/winprofile-ini.md
+++ b/doc/winprofile-ini.md
@@ -33,14 +33,14 @@ Four kinds of value, and the kind decides how `0` reads:
 
 The list keys are `CurrentAction`, `Build`, `PrimaryScan`, `Travel`, `GlobalTravel`, `RewriteLinks`, `CheckType`, `FollowRobotsTxt` and `LogType`. WinHTTrack stores the combo box's `GetCurSel()`, which is where 0-based comes from. WebHTTrack numbers the same `<select>` from 1, because id 0 is how its templates spell "no value". It shifts by one at the file boundary rather than renumbering the options, and leaves a value alone that is not a plain number.
 
-That last clause is load-bearing today: WinHTTrack's main save path writes `CheckType`, `FollowRobotsTxt` and `LogType` with `GetDlgItemText`, so those three carry the combo's displayed **text**, not its index, while its own reader takes them with `atoi` (`Shell.cpp:2730, 2788, 2811`). Reported to httrack-windows; until it is settled, a reader has to tolerate both spellings for those three.
+That last clause is load-bearing: a WinHTTrack older than httrack-windows#124 saved `CheckType`, `FollowRobotsTxt` and `LogType` with `GetDlgItemText`, so those keys carry the combo's displayed **text** rather than its index (and `Cookies` and `StoreAllInCache` the control's caption). Its own reader took them with `atoi`, so such a file silently reopened on the reader's default. Those files exist, so a reader still has to tolerate both spellings.
 
 `ProxyType` is a tenth 0-based combo index (`0` HTTP, `1` SOCKS5, `2` HTTP CONNECT), written by both GUIs and deliberately **outside** `ini_list_keys[]`: WebHTTrack's proxy page already reads `0` as its own first entry, so the two agree and a shift would break them. Adding an entry to that list in one GUI alone is #1314 over again.
 
-`ProfileFormat=1` marks the current conventions. A file without it is WinHTTrack's own and follows the same ones, so the marker changes no read decision today; it exists so a later format change can be recognized. Both GUIs write it; WinHTTrack does not yet, and rewrites the file from its own key list, so a file it saves loses the marker until it does.
+`ProfileFormat=1` marks the current conventions. Both GUIs stamp it write-only; neither reads it back. A file without it follows the same conventions, so nothing depends on its presence: it exists only so a later format change can be recognized.
 
 ## Changing the format
 
-A new key needs the same value on both sides or it is worse than no key. Adding one to WebHTTrack alone is fine and common (`HostAlias`, `WarcFile`); adding one whose *meaning* differs between the GUIs is what #1314 was.
+httrack-windows asserts the lossy decode in its own self-test, so converging the two escape sets means moving that expectation in the same breath. A new key needs the same value on both sides or it is worse than no key. Adding one to WebHTTrack alone is fine and common (`HostAlias`, `WarcFile`); adding one whose *meaning* differs between the GUIs is what #1314 was.
 
 `tests/322_webhttrack-list-ids.test` and `tests/274_wizard-profile-load.test` hold the two tables in `src/htsserver.c` against the keys `step4.html` writes. Nothing checks either against `Shell.cpp`, so a change to WinHTTrack's side still has to be read across by hand.

--- a/doc/winprofile-ini.md
+++ b/doc/winprofile-ini.md
@@ -1,38 +1,25 @@
 # hts-cache/winprofile.ini
 
-The project settings a HTTrack front end saves beside a mirror, so reopening the
-project restores the wizard. Three programs touch it, in two repositories:
+The project settings a HTTrack front end saves beside a mirror, so reopening the project restores the wizard. Three programs touch it, in two repositories:
 
-- **WinHTTrack** (httrack-windows, `WinHTTrack/Shell.cpp`) writes it from the
-  dialog fields and reads it back. It is the original writer, and its
-  conventions are the ones below.
-- **WebHTTrack** (`src/htsserver.c`, `html/server/step[24].html`) writes it from
-  the posted form and reads it into the wizard's session state.
-- The **engine** reads one key, `Category`, to group projects in the top index
-  (`src/htstools.c`).
+- **WinHTTrack** (httrack-windows, `WinHTTrack/Shell.cpp`) writes it from the dialog fields and reads it back. It is the original writer, and its conventions are the ones below.
+- **WebHTTrack** (`src/htsserver.c`, `html/server/step[24].html`) writes it from the posted form and reads it into the wizard's session state.
+- The **engine** reads one key, `Category`, to group projects in the top index, and with its own decoder: case-insensitive, first occurrence, `unescapehttp` rather than `unescapeini`, so a `+` becomes a space (`src/htstools.c`).
 
-Neither GUI needs the file to run a mirror: the command line the wizard builds
-is what the engine takes, and `hts-cache/doit.log` records it. Getting the file
-wrong loses settings on reopen, it does not corrupt a mirror.
+Neither GUI needs the file to run a mirror: the command line the wizard builds is what the engine takes, and `hts-cache/doit.log` records it. Getting the file wrong loses settings on reopen; it does not corrupt a mirror.
 
 ## Syntax
 
-`key=value`, one per line, CRLF, no `[section]` header despite the extension.
-The first `=` separates; later ones belong to the value. A reader ignores keys
-it does not know, and neither GUI writes the other's full key set, so a file
-carries whichever keys its last writer knew.
+`key=value`, one per line, CRLF, no `[section]` header despite the extension. The first `=` separates; later ones belong to the value. Lines are capped at 8192 bytes by WebHTTrack and 32000 by WinHTTrack.
 
-Two divergences to keep in mind, both older than this document:
+Neither GUI writes the other's full key set, so a missing key is the normal case rather than an edge: a WebHTTrack save drops `MailIndex`, `AcceptLanguage`, `OtherHeaders` and `DefaultReferer`, and WinHTTrack drops `HostAlias`, `WarcFile` and `WarcMaxSize`. **A reader that does not find a key falls back to its own default, which is often not "off" or "zero"**: WinHTTrack defaults `ParseAll`, `Cache`, `Index`, `Log`, `KeepAlive`, `Cookies`, `CheckType` and `Travel` to 1, `FollowRobotsTxt` to 2 and `PrimaryScan` to 3 (`Shell.cpp:2929-3011`). Omission happens inside one GUI too: WinHTTrack skips a list key when its combo has no selection (`GetCurSel() != CB_ERR`). Write a key whenever you have a value for it.
 
-- **Duplicate keys resolve differently.** WebHTTrack takes the last occurrence,
-  WinHTTrack the first (`MyGetProfileStringFile` returns on its first match).
-  Write each key once.
-- **The escapes are not the same set.** WebHTTrack encodes `%` as `%%` and any
-  byte under 32 as `%xx`, and also emits `&lt; &gt; &amp; &#39;` for those four
-  characters. WinHTTrack decodes `%%`, `%0d`, `%0a`, `%09` and `%3d`, and turns
-  **every other** `%xx` into a space (`profile_decode`). A value holding an
-  escaped byte outside that set survives a WebHTTrack round trip and degrades in
-  WinHTTrack.
+Two more divergences, both older than this document:
+
+- **Duplicate keys resolve differently.** WebHTTrack takes the last occurrence, WinHTTrack the first (`MyGetProfileStringFile` returns on its first match). Write each key once.
+- **The escapes are not the same set.** WinHTTrack escapes `%`, `=`, TAB, CR and LF and passes every other byte through, so its decoder is the exact inverse and turns **every other** `%xx` into a space; that decode is also case-sensitive, and `%0D` or `%3D` becomes a space. WebHTTrack escapes `%` and any byte under 32, writes `=` raw, and writes `%22` for a double quote in the 18 `${unquoted:}` fields. So a footer or a filter list holding a quote survives a WebHTTrack round trip and degrades in WinHTTrack, and an `=` inside a value survives only in the other direction. WebHTTrack's own decoder also collapses a `%0d%0a` pair to a lone CR, so a multi-line value comes back CR-separated.
+
+Neither side transcodes. WinHTTrack is an ANSI build and writes local-codepage bytes; WebHTTrack writes back whatever the browser posted, in the catalog's `LANGUAGE_CHARSET`. A project moved between two machines on the same codepage keeps its accents, and one moved across codepages does not.
 
 ## Value conventions
 
@@ -40,31 +27,20 @@ Four kinds of value, and the kind decides how `0` reads:
 
 | Kind | Spelling | Notes |
 | --- | --- | --- |
-| String | verbatim, escaped as above | `CurrentUrl`, `Category`, `UserID`, `Footer`, the `MIMEDefs*` pairs |
-| Number | decimal | `Depth`, `MaxRate`, `Sockets`. `0` is the user's answer, never "unset" |
-| Checkbox | `1` on, `0` or absent off | Listed in `ini_checkbox_keys[]` in `src/htsserver.c` |
+| String | verbatim, escaped as above | `CurrentUrl`, `Category`, `UserID`, `Footer`, the `MIMEDefs*` pairs. `Depth`, `MaxRate` and `Sockets` are numbers written as strings, so empty is legal and means unset |
+| Checkbox | `1` on, explicit `0` off | Listed in `ini_checkbox_keys[]` in `src/htsserver.c` |
 | List | the **0-based** index of the entry, in `LISTDEF_N` order (`lang.def`) | Listed in `ini_list_keys[]` |
 
-The list keys are `CurrentAction`, `Build`, `PrimaryScan`, `Travel`,
-`GlobalTravel`, `RewriteLinks`, `CheckType`, `FollowRobotsTxt` and `LogType`.
-WinHTTrack stores the combo box's `GetCurSel()` directly, which is where 0-based
-comes from. WebHTTrack numbers the same `<select>` from 1, because id 0 is how
-its templates spell "no value", so it shifts by one at the file boundary rather
-than renumbering the options.
+The list keys are `CurrentAction`, `Build`, `PrimaryScan`, `Travel`, `GlobalTravel`, `RewriteLinks`, `CheckType`, `FollowRobotsTxt` and `LogType`. WinHTTrack stores the combo box's `GetCurSel()`, which is where 0-based comes from. WebHTTrack numbers the same `<select>` from 1, because id 0 is how its templates spell "no value". It shifts by one at the file boundary rather than renumbering the options, and leaves a value alone that is not a plain number.
 
-`ProfileFormat=1` marks a file written by WebHTTrack since #1314. A file
-without it is WinHTTrack's own and follows the same conventions, so the marker
-changes no read decision today; it exists so a later change to the format can be
-told apart. Both GUIs write it; WinHTTrack does not yet, and rewrites the file
-from its own key list, so a file it saves loses the marker until it does.
+That last clause is load-bearing today: WinHTTrack's main save path writes `CheckType`, `FollowRobotsTxt` and `LogType` with `GetDlgItemText`, so those three carry the combo's displayed **text**, not its index, while its own reader takes them with `atoi` (`Shell.cpp:2730, 2788, 2811`). Reported to httrack-windows; until it is settled, a reader has to tolerate both spellings for those three.
+
+`ProxyType` is a tenth 0-based combo index (`0` HTTP, `1` SOCKS5, `2` HTTP CONNECT), written by both GUIs and deliberately **outside** `ini_list_keys[]`: WebHTTrack's proxy page already reads `0` as its own first entry, so the two agree and a shift would break them. Adding an entry to that list in one GUI alone is #1314 over again.
+
+`ProfileFormat=1` marks the current conventions. A file without it is WinHTTrack's own and follows the same ones, so the marker changes no read decision today; it exists so a later format change can be recognized. Both GUIs write it; WinHTTrack does not yet, and rewrites the file from its own key list, so a file it saves loses the marker until it does.
 
 ## Changing the format
 
-A new key needs the same value on both sides or it is worse than no key. Adding
-one to WebHTTrack alone is fine and common (`HostAlias`, `WarcFile`); adding one
-whose *meaning* differs between the GUIs is what #1314 was.
+A new key needs the same value on both sides or it is worse than no key. Adding one to WebHTTrack alone is fine and common (`HostAlias`, `WarcFile`); adding one whose *meaning* differs between the GUIs is what #1314 was.
 
-`tests/322_webhttrack-list-ids.test` and `tests/274_wizard-profile-load.test`
-hold the two tables in `src/htsserver.c` against the keys `step4.html` writes.
-Nothing checks either against `Shell.cpp`, so a change to WinHTTrack's side
-still has to be read across by hand.
+`tests/322_webhttrack-list-ids.test` and `tests/274_wizard-profile-load.test` hold the two tables in `src/htsserver.c` against the keys `step4.html` writes. Nothing checks either against `Shell.cpp`, so a change to WinHTTrack's side still has to be read across by hand.

--- a/html/server/step4.html
+++ b/html/server/step4.html
@@ -146,7 +146,7 @@ ${do:end-if}${do:output-mode:html}
 	${test:nopurge:--purge-old=1:--purge-old=0}
 \
 	${ztest:cache:--cache=0:}
-	${test:filter::--priority=0:--priority=1:--priority=2:--priority=7}
+	${test:filter::--priority=0:--priority=1:--priority=2:--priority=3:--priority=7}
 	${test:travel::--stay-on-same-dir:--can-go-down:--can-go-up:--can-go-up-and-down}
 	${test:travel2::--stay-on-same-address:--stay-on-same-domain:--stay-on-same-tld:--go-everywhere}
 	${test:travel3::--keep-links=0:--keep-links:--keep-links=3:--keep-links=4}
@@ -213,6 +213,8 @@ ${/* -m<n> resets the html limit, so the bare form must precede the -m,<n> one *
 <!-- winprofile.ini -->
 ${do:output-mode:inifile}
 <textarea name="winprofile" cols="50" rows="4" style="visibility:hidden">
+${/* 1: the list ids below are stored 0-based, as WinHTTrack writes them. */}
+ProfileFormat=1
 CurrentUrl=${urls}
 Category=${projcateg}
 CurrentAction=${todo}
@@ -240,7 +242,7 @@ NoQueryStrings=${ztest:hidequery:0:1}
 NoPurgeOldFiles=${ztest:nopurge:0:1}
 Cookies=${ztest:cookies:0:1}
 CookiesFile=${cookiesfile}
-CheckType=${ztest:checktype:0:1:2}
+CheckType=${checktype}
 ParseJava=${ztest:parsejava:0:1}
 HTTP10=${ztest:http10:0:1}
 TolerantRequests=${ztest:toler:0:1}

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -713,9 +713,9 @@ static const char *const ini_checkbox_keys[] = {
     NULL,
 };
 
-/* These hold a ${listid:} id, which starts at 1 where winprofile.ini stores the
-   0-based combo index WinHTTrack writes. A file with no ProfileFormat key is
-   WinHTTrack's own, so it is read that way too (#1314). */
+/* These hold a ${listid:} id, numbered from 1; winprofile.ini stores the
+   0-based combo index WinHTTrack writes instead. A file with no ProfileFormat
+   key is WinHTTrack's own, so it is read that way too (#1314). */
 static const char *const ini_list_keys[] = {
     "CurrentAction", "Build",     "PrimaryScan",     "Travel",  "GlobalTravel",
     "RewriteLinks",  "CheckType", "FollowRobotsTxt", "LogType", NULL,
@@ -740,9 +740,9 @@ static hts_boolean ini_key_is_list(const char *key) {
   return ini_key_in(ini_list_keys, key);
 }
 
-/* The first LEN bytes of VALUE shifted by DELTA, or -1 to leave it alone: an
-   empty, hand-edited or out-of-range id means whatever the reader makes of it,
-   and 0 already reads as the first entry on both sides. */
+/* The first LEN bytes of VALUE shifted by DELTA, or -1 to leave it alone. An
+   empty, hand-edited or out-of-range id means whatever the reader makes of it.
+   So does 0, which already reads as the first entry on both sides. */
 static int ini_list_shift(const char *value, size_t len, int delta) {
   char digits[16];
   char *end;
@@ -777,7 +777,7 @@ static void ini_rebase_lists(const char *ini, int delta, String *out) {
     if (eq != NULL) {
       klen = (size_t) (eq - line);
       vlen = len - klen - 1;
-      /* Off the value: a textarea posts CRLF, and the file keeps it. */
+      /* Trim the CRLF a textarea posts, which the file keeps. */
       while (vlen != 0 && (eq[vlen] == '\r' || eq[vlen] == '\n'))
         vlen--;
       if (klen < sizeof(key)) {
@@ -1277,8 +1277,8 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                     if (fp != NULL) {
                       int count;
 
-                      /* The ids leave 0-based, the way WinHTTrack stores them
-                         and the way this server reads them back (#1314). */
+                      /* The ids leave 0-based, matching how WinHTTrack stores
+                         them and this server reads them back (#1314). */
                       ini_rebase_lists((char *) adrw, -1, &profile);
                       count = (int) StringLength(profile);
                       if ((int) fwrite(StringBuff(profile), 1, count, fp) ==

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -653,8 +653,8 @@ static void cat_cmdline_arglist(String *output, const char *value,
   }
 }
 
-/* Append one <select> entry, unless its id is the hidden one. Ids are stored as
-   winprofile.ini's CurrentAction, so hiding one must not renumber the rest. */
+/* Append one <select> entry, unless its id is the hidden one. Ids reach
+   winprofile.ini one lower, so hiding one must not renumber the rest. */
 static void cat_list_option(String *output, const char *label, int id,
                             int listDefault, int listHidden) {
   char tag[48];
@@ -690,7 +690,6 @@ static const char *const ini_checkbox_keys[] = {
     "NoQueryStrings",
     "NoPurgeOldFiles",
     "Cookies",
-    "CheckType",
     "ParseJava",
     "HTTP10",
     "TolerantRequests",
@@ -713,15 +712,90 @@ static const char *const ini_checkbox_keys[] = {
     NULL,
 };
 
-/* A stored 0 means "unchecked" for these keys, not the number zero. */
-static hts_boolean ini_key_is_checkbox(const char *key) {
+/* These hold a ${listid:} id, which starts at 1 where winprofile.ini stores the
+   0-based combo index WinHTTrack writes. A file with no ProfileFormat key is
+   WinHTTrack's own, so it is read that way too (#1314). */
+static const char *const ini_list_keys[] = {
+    "CurrentAction", "Build",     "PrimaryScan",     "Travel",  "GlobalTravel",
+    "RewriteLinks",  "CheckType", "FollowRobotsTxt", "LogType", NULL,
+};
+
+static hts_boolean ini_key_in(const char *const *keys, const char *key) {
   size_t i;
 
-  for (i = 0; ini_checkbox_keys[i] != NULL; i++) {
-    if (strcmp(key, ini_checkbox_keys[i]) == 0)
+  for (i = 0; keys[i] != NULL; i++) {
+    if (strcmp(key, keys[i]) == 0)
       return HTS_TRUE;
   }
   return HTS_FALSE;
+}
+
+/* A stored 0 means "unchecked" for these keys, not the number zero. */
+static hts_boolean ini_key_is_checkbox(const char *key) {
+  return ini_key_in(ini_checkbox_keys, key);
+}
+
+static hts_boolean ini_key_is_list(const char *key) {
+  return ini_key_in(ini_list_keys, key);
+}
+
+/* The first LEN bytes of VALUE shifted by DELTA, or -1 to leave it alone: an
+   empty, hand-edited or out-of-range id means whatever the reader makes of it,
+   and 0 already reads as the first entry on both sides. */
+static int ini_list_shift(const char *value, size_t len, int delta) {
+  char digits[16];
+  char *end;
+  long id;
+
+  if (len == 0 || len >= sizeof(digits))
+    return -1;
+  memcpy(digits, value, len);
+  digits[len] = '\0';
+  id = strtol(digits, &end, 10);
+  if (*end != '\0' || id < 0 || id > INT_MAX - 1)
+    return -1;
+  return (int) id + delta;
+}
+
+/* Copy INI to OUT with the ids of ini_list_keys shifted by DELTA, so what
+   reaches the file is the 0-based index WinHTTrack reads (#1314). */
+static void ini_rebase_lists(const char *ini, int delta, String *out) {
+  const char *line;
+
+  StringClear(*out);
+  for (line = ini; *line != '\0';) {
+    const char *const nl = strchr(line, '\n');
+    const size_t len = nl != NULL ? (size_t) (nl - line) + 1 : strlen(line);
+    const char *const eq = (const char *) memchr(line, '=', len);
+    char key[64];
+    char shifted[16];
+    size_t klen = 0;
+    size_t vlen = 0;
+    int id = -1;
+
+    if (eq != NULL) {
+      klen = (size_t) (eq - line);
+      vlen = len - klen - 1;
+      /* Off the value: a textarea posts CRLF, and the file keeps it. */
+      while (vlen != 0 && (eq[vlen] == '\r' || eq[vlen] == '\n'))
+        vlen--;
+      if (klen < sizeof(key)) {
+        memcpy(key, line, klen);
+        key[klen] = '\0';
+        if (ini_key_is_list(key))
+          id = ini_list_shift(eq + 1, vlen, delta);
+      }
+    }
+    if (id >= 0) {
+      snprintf(shifted, sizeof(shifted), "%d", id);
+      StringMemcat(*out, line, klen + 1);
+      StringCat(*out, shifted);
+      StringMemcat(*out, eq + 1 + vlen, len - klen - 1 - vlen);
+    } else {
+      StringMemcat(*out, line, len);
+    }
+    line += len;
+  }
 }
 
 /* gmtime accepts the whole int range, where a footer can show four digits and
@@ -741,6 +815,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
   String tmpbuff = STRING_EMPTY;
   String tmpbuff2 = STRING_EMPTY;
   String fspath = STRING_EMPTY;
+  String profile = STRING_EMPTY;
   /* Project directory this server set up; the only root /website/ serves from,
      and deliberately not cleared between requests. */
   String website = STRING_EMPTY;
@@ -1070,6 +1145,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
               pos = strchr(line, '=');
               if (pos) {
                 String escline = STRING_EMPTY;
+                char listid[16];
 
                 *pos++ = '\0';
                 /* Only a checkbox: elsewhere zero is the user's value, and
@@ -1077,6 +1153,14 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                 if (pos[0] == '0' && pos[1] == '\0' &&
                     ini_key_is_checkbox(line))
                   *pos = '\0';
+                if (ini_key_is_list(line)) {
+                  const int id = ini_list_shift(pos, strlen(pos), 1);
+
+                  if (id >= 0) {
+                    snprintf(listid, sizeof(listid), "%d", id);
+                    pos = listid;
+                  }
+                }
                 /* A key in the file overwrites the default even when it is
                    empty, and an acquired NULL reads back as absent (#1186). */
                 StringClear(escline);
@@ -1190,9 +1274,14 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                     StringCat(tmpbuff, "winprofile.ini");
                     fp = fopen(StringBuff(tmpbuff), "wb");
                     if (fp != NULL) {
-                      int count = (int) strlen((char *) adrw);
+                      int count;
 
-                      if ((int) fwrite((void *) adrw, 1, count, fp) == count) {
+                      /* The ids leave 0-based, the way WinHTTrack stores them
+                         and the way this server reads them back (#1314). */
+                      ini_rebase_lists((char *) adrw, -1, &profile);
+                      count = (int) StringLength(profile);
+                      if ((int) fwrite(StringBuff(profile), 1, count, fp) ==
+                          count) {
 
                         /* Wipe the doit.log file, useless here (all options are replicated) and
                            even a bit annoying (duplicate/ghost options)
@@ -2005,6 +2094,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
   StringFree(tmpbuff);
   StringFree(tmpbuff2);
   StringFree(fspath);
+  StringFree(profile);
   StringFree(website);
 
   if (buffer)

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -41,6 +41,7 @@ Please visit our Website: http://www.httrack.com
 #include "htsnet.h"
 #include "htslib.h"
 #include "htscharset.h"
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/322_webhttrack-list-ids.test
+++ b/tests/322_webhttrack-list-ids.test
@@ -1,0 +1,253 @@
+#!/bin/bash
+#
+# winprofile.ini stores a <select> as the 0-based combo index WinHTTrack writes,
+# where the templates number the same list from 1 (#1314). Nothing else holds
+# the two conventions apart, and getting it wrong shifts a saved project by one
+# option in whichever GUI reopens it.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+distdir=${top_srcdir:-$(cd "${testdir}/.." && pwd)}
+distdir=$(cd "${distdir}" && pwd)
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
+
+# Ahead of htsserver_require, which skips where python3 is absent: pure text.
+printf '[the list table matches the templates] ..\t'
+# Every ${listid:} variable that step4.html also writes to winprofile.ini. lang
+# is the one that does not, so it drops out on its own.
+written=$(
+    for var in $(sed -n 's/.*[$]{listid:\([a-z0-9_]*\):.*/\1/p' \
+        "${distdir}"/html/server/*.html | sort -u); do
+        sed -n "s/^\([A-Za-z]*\)=[\$]{${var}}\$/\1/p" \
+            "${distdir}/html/server/step4.html"
+    done | sort -u
+)
+listed=$(awk '/ini_list_keys\[\] = /,/^\};/' "${distdir}/src/htsserver.c" |
+    grep -o '"[^"]*"' | tr -d '"' | sort -u)
+# Floor: two gutted lists compare equal.
+test "$(printf '%s\n' "${written}" | wc -l)" -ge 9 ||
+    fail "only $(printf '%s\n' "${written}" | wc -l) listid keys in step4.html"
+test "${written}" = "${listed}" ||
+    fail "$(diff <(echo "${written}") <(echo "${listed}"))"
+echo OK
+
+htsserver_require
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_listids.XXXXXX") || fail "no tmpdir"
+cleanup() {
+    htsserver_cleanup
+    rm -rf "${work}"
+}
+cleanup_push cleanup
+
+mkdir -p "${work}/proj/hts-cache"
+# WinHTTrack's own file: every list key 0-based, and Depth beside them as the
+# control for a number the rebase must not touch.
+cat >"${work}/proj/hts-cache/winprofile.ini" <<'EOF'
+CurrentUrl=http://example.com/
+Depth=3
+CurrentAction=6
+Build=2
+PrimaryScan=1
+Travel=3
+GlobalTravel=2
+RewriteLinks=2
+CheckType=0
+FollowRobotsTxt=0
+LogType=2
+EOF
+# The save below overwrites it, and the round trip is judged against this.
+cp "${work}/proj/hts-cache/winprofile.ini" "${work}/seeded.ini"
+
+printf '[a new project saves the ids WinHTTrack defaults to] ..\t'
+htsserver_start --home "${work}"
+
+"${HTS_PYTHON}" - "${HTS_URL}" "${work}" <<'PY' || fail "see above"
+import re
+import sys
+import urllib.parse
+import urllib.request
+
+url, work = sys.argv[1].rstrip("/"), sys.argv[2]
+
+
+def get(page):
+    return urllib.request.urlopen(url + "/server/" + page,
+                                  timeout=20).read().decode("latin-1")
+
+
+def post(page, fields):
+    body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in fields)
+    req = urllib.request.Request(url + "/server/" + page,
+                                 data=body.encode("latin-1"), method="POST")
+    return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
+
+
+def textarea(page, name):
+    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page,
+                  re.S)
+    if m is None:
+        sys.exit("no %s textarea in the rendered page" % name)
+    # As a browser posts it: the newline right after the tag is not content.
+    return m.group(1).lstrip("\r\n")
+
+
+def sid_of():
+    m = re.search(r'name="sid" value="([0-9a-f]+)"', get("index.html"))
+    if not m:
+        sys.exit("no session id in server/index.html")
+    return m.group(1)
+
+
+def keys_of(path):
+    with open(path) as fp:
+        return dict(line.strip().split("=", 1)
+                    for line in fp if "=" in line)
+
+
+def save(sid, projname):
+    """Write the project's winprofile.ini the way the Save button does."""
+    step4 = get("step4.html?sid=" + sid)
+    post("step4.html", [("sid", sid), ("path", work),
+                        ("projname", projname),
+                        ("command", textarea(step4, "command")),
+                        ("command_do", "save"),
+                        ("winprofile", textarea(step4, "winprofile"))])
+    return keys_of("%s/%s/hts-cache/winprofile.ini" % (work, projname))
+
+
+# Those numbers are what the ids mean on disk: MyGetProfileInt(..., <default>)
+# in WinHTTrack/Shell.cpp reads exactly them out of a file it never wrote.
+fresh = save(sid_of(), "fresh")
+if fresh.get("ProfileFormat") != "1":
+    sys.exit("a saved profile carries no format marker: %r" % fresh)
+for key, want in [("Build", "0"), ("PrimaryScan", "3"), ("Travel", "1"),
+                  ("GlobalTravel", "0"), ("RewriteLinks", "0"),
+                  ("CheckType", "1"), ("FollowRobotsTxt", "2")]:
+    if fresh.get(key) != want:
+        sys.exit("a new project saves %s=%r, WinHTTrack defaults it to %s"
+                 % (key, fresh.get(key), want))
+PY
+
+echo OK
+
+# A second wizard: one server loads one project, and the leg above already
+# spent this one on a save.
+htsserver_stop
+printf '[a 0-based profile reads back one option up] ..\t'
+htsserver_start --home "${work}"
+
+"${HTS_PYTHON}" - "${HTS_URL}" "${work}" <<'PY' || fail "see above"
+import re
+import sys
+import urllib.parse
+import urllib.request
+
+url, work = sys.argv[1].rstrip("/"), sys.argv[2]
+
+
+def get(page):
+    return urllib.request.urlopen(url + "/server/" + page,
+                                  timeout=20).read().decode("latin-1")
+
+
+def post(page, fields):
+    body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in fields)
+    req = urllib.request.Request(url + "/server/" + page,
+                                 data=body.encode("latin-1"), method="POST")
+    return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
+
+
+def textarea(page, name):
+    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page,
+                  re.S)
+    if m is None:
+        sys.exit("no %s textarea in the rendered page" % name)
+    # As a browser posts it: the newline right after the tag is not content.
+    return m.group(1).lstrip("\r\n")
+
+
+def sid_of():
+    m = re.search(r'name="sid" value="([0-9a-f]+)"', get("index.html"))
+    if not m:
+        sys.exit("no session id in server/index.html")
+    return m.group(1)
+
+
+def keys_of(path):
+    with open(path) as fp:
+        return dict(line.strip().split("=", 1)
+                    for line in fp if "=" in line)
+
+
+def save(sid, projname):
+    """Write the project's winprofile.ini the way the Save button does."""
+    step4 = get("step4.html?sid=" + sid)
+    post("step4.html", [("sid", sid), ("path", work),
+                        ("projname", projname),
+                        ("command", textarea(step4, "command")),
+                        ("command_do", "save"),
+                        ("winprofile", textarea(step4, "winprofile"))])
+    return keys_of("%s/%s/hts-cache/winprofile.ini" % (work, projname))
+
+
+def selected(page, name):
+    """The id the <select> NAME renders as selected, or None."""
+    m = re.search(r'<select name="%s".*?</select>' % name, page, re.S)
+    if m is None:
+        sys.exit("no %s select in the rendered page" % name)
+    ids = re.findall(r"<option value=(\d+) selected>", m.group(0))
+    return ids[0] if len(ids) == 1 else None
+
+
+sid = sid_of()
+# LISTDEF_4's five entries against a flag list that had four: the default one
+# emitted p7, and the last one nothing. p3/p7 per man/httrack.1.
+for pick, flag in [("4", "--priority=3"), ("5", "--priority=7")]:
+    command = textarea(post("step4.html", [("sid", sid), ("filter", pick)]),
+                       "command")
+    if flag not in command.split():
+        sys.exit("scan rule %s emits no %s\n%s" % (pick, flag, command))
+
+loaded = post("step2.html", [("sid", sid), ("path", work),
+                             ("loadprojname", "proj")])
+if "http://example.com/" not in loaded:
+    sys.exit("step2.html did not load the project\n%s" % loaded[:400])
+
+# Each list on the page that renders it. A stored id picks the entry one above
+# it, CheckType included: 0 there is the first entry, never an unticked box.
+for page, name, stored in [("step3.html", "todo", 6),
+                           ("option2.html", "build", 2),
+                           ("option3.html", "filter", 1),
+                           ("option3.html", "travel", 3),
+                           ("option3.html", "travel2", 2),
+                           ("option3.html", "travel3", 2),
+                           ("option8.html", "checktype", 0),
+                           ("option8.html", "robots", 0),
+                           ("option9.html", "logtype", 2)]:
+    got = selected(get("%s?sid=%s" % (page, sid)), name)
+    if got != str(stored + 1):
+        sys.exit("%s selects %r for a stored %d, expected %d"
+                 % (name, got, stored, stored + 1))
+
+# What each id means, read off LISTDEF_N in lang.def, so a table that renumbers
+# the options is not read as a fix. Depth is the control: not a list key.
+command = textarea(get("step4.html?sid=" + sid), "command")
+for flag in ["--update", "-N2", "--priority=1", "--can-go-up-and-down",
+             "--stay-on-same-tld", "--keep-links=3", "--robots=0",
+             "--debug-log", "--depth=3"]:
+    if flag not in command.split():
+        sys.exit("%s missing from the reloaded command line\n%s"
+                 % (flag, command))
+
+# Saving it back must reproduce what was seeded, Depth included: an asymmetric
+# shift walks a project one option further on every reopen.
+back = save(sid, "proj")
+for key, want in keys_of(work + "/seeded.ini").items():
+    if back.get(key) != want:
+        sys.exit("%s round-trips as %r, was %r" % (key, back.get(key), want))
+PY
+
+echo OK

--- a/tests/322_webhttrack-list-ids.test
+++ b/tests/322_webhttrack-list-ids.test
@@ -1,9 +1,8 @@
 #!/bin/bash
 #
-# winprofile.ini stores a <select> as the 0-based combo index WinHTTrack writes,
-# where the templates number the same list from 1 (#1314). Nothing else holds
-# the two conventions apart, and getting it wrong shifts a saved project by one
-# option in whichever GUI reopens it.
+# winprofile.ini stores a <select> as WinHTTrack's 0-based combo index; the
+# templates number the same list from 1 (#1314). Nothing else holds the two
+# conventions apart, and a wrong shift moves a project by one option.
 
 set -euo pipefail
 
@@ -133,8 +132,8 @@ PY
 
 echo OK
 
-# A second wizard: one server loads one project, and the leg above already
-# spent this one on a save.
+# A second server: a save sets commandEnd, and the session then renders its
+# terminal page rather than a loaded project.
 htsserver_stop
 printf '[a 0-based profile reads back one option up] ..\t'
 htsserver_start --home "${work}"

--- a/tests/322_webhttrack-list-ids.test
+++ b/tests/322_webhttrack-list-ids.test
@@ -17,8 +17,8 @@ printf '[the list table matches the templates] ..\t'
 # Every ${listid:} variable that step4.html also writes to winprofile.ini. lang
 # is the one that does not, so it drops out on its own.
 written=$(
-    for var in $(sed -n 's/.*[$]{listid:\([a-z0-9_]*\):.*/\1/p' \
-        "${distdir}"/html/server/*.html | sort -u); do
+    sed -n 's/.*[$]{listid:\([a-z0-9_]*\):.*/\1/p' "${distdir}"/html/server/*.html |
+        sort -u | while read -r var; do
         sed -n "s/^\([A-Za-z]*\)=[\$]{${var}}\$/\1/p" \
             "${distdir}/html/server/step4.html"
     done | sort -u


### PR DESCRIPTION
WinHTTrack stores a combo box as `GetCurSel()`, so 0-based. WebHTTrack renders the same list through `${listid:}`, which numbers its options from 1, and writes that number to `hts-cache/winprofile.ini`. A project made in one GUI therefore reopens in the other on the neighbouring option. It is not only `CurrentAction`: `Build`, `PrimaryScan`, `Travel`, `GlobalTravel`, `RewriteLinks`, `FollowRobotsTxt` and `LogType` shift the same way. `CheckType` shifts the other way, so WebHTTrack already misreads its own saved value.

WebHTTrack is the side that moves, since the file is WinHTTrack's format and much the larger corpus. The shift happens at the file boundary rather than by renumbering the options, because id 0 is how `${test:}` spells "no value". It also stamps `ProfileFormat=1`. That changes no read decision today, an unmarked file being WinHTTrack's and so already 0-based, but it lets a later format change be recognized. One cost: a WebHTTrack project saved before this reopens one option off. Nothing distinguishes such a file from a WinHTTrack one, and the next save corrects it.

Two things turned up while checking. The scan-rule list was missing a slot, so its five entries fed four flags: the default one emitted `--priority=7` (get html first) instead of `--priority=3` (save all), and the last emitted nothing.

The other is that nobody had ever written the format down, which is how the mismatch survived. `doc/winprofile-ini.md` now records it, reviewed by the httrack-windows session: the value kinds, what an absent key means on each side, the escaping and duplicate-key divergences between the two readers, the byte encoding, and what a new key has to satisfy.

Closes #1314