### PR TITLE
Footer was recorded as a disagreement it is not part of

### DIFF
--- a/src/winprofile-keys.h
+++ b/src/winprofile-keys.h
@@ -41,7 +41,7 @@ static const winprofile_key_t winprofile_keys[WINPROFILE_KEY_COUNT] = {
   {"Dos", "win,web,droid", "setting", "bitmask", "", "", "", "agreed", "0", "", ""},
   {"ExtDepth", "win,web,droid", "setting", "string", "", "", "", "agreed", "", "absent", ""},
   {"FollowRobotsTxt", "win,web,droid", "setting", "list:0:3", "", "", "", "agreed", "2", "", ""},
-  {"Footer", "win,web,droid", "setting", "string", "", "", "", "unresolved", "", "literal", ""},
+  {"Footer", "win,web,droid", "setting", "string", "", "", "", "agreed", "<!-- Mirrored from {url} by HTTrack Website Copier/3.x [XR&CO], {date} -->", "literal", ""},
   {"GlobalTravel", "win,web,droid", "setting", "list:0:4", "", "", "", "agreed", "0", "", ""},
   {"HTMLFirst", "win,web,droid", "setting", "checkbox", "--priority=7", "", "", "agreed", "0", "", ""},
   {"HTTP10", "win,web,droid", "setting", "checkbox", "--http-10", "", "", "agreed", "0", "", ""},

--- a/tests/324_winprofile-table.test
+++ b/tests/324_winprofile-table.test
@@ -172,6 +172,13 @@ listk, checkbox = names("ini_list_keys"), names("ini_checkbox_keys")
 init_int = dict(re.findall(r'\{"([a-z0-9_]+)", (\d+)\}', srv))
 m = re.search(r"initOn\[\] = \{(.*?)NULL\}", srv, re.S)
 init_on = set(re.findall(r'"([A-Za-z0-9_]+)"', m.group(1))) if m else set()
+m = re.search(r"initStrElt initStr\[\] = \{(.*?)\{NULL", srv, re.S)
+init_str = dict(re.findall(r'\{"([a-z0-9_]+)",\s*(HTS_DEFAULT_[A-Z_]+|"[^"]*")',
+                           m.group(1))) if m else {}
+# Both desktop front ends read Footer with this macro, so its expansion is the
+# value rather than anyone's literal.
+FOOTER = ("<!-- Mirrored from {url} by HTTrack Website Copier/3.x [XR&CO], "
+          "{date} -->")
 
 # key -> the variable step4 writes it from, and the flags that variable emits
 wvar, emit = {}, {}
@@ -232,6 +239,14 @@ for key in sorted(claimed):
         checked += same("1", r["default_value"], "%s default" % key)
     else:
         checked += same("0", r["default_value"], "%s default" % key)
+
+    # A string default this repo states, checked by nothing until now, which is
+    # how Footer sat as a disagreement it was never part of.
+    if r["default_state"] == "agreed" and var in init_str and var not in init_on:
+        want = init_str[var]
+        want = FOOTER if want == "HTS_DEFAULT_FOOTER" else want.strip('"')
+        if not want.startswith("HTS_DEFAULT_"):
+            checked += same(want, r["default_value"], "%s default" % key)
 
     # Only an on/off setting has an on/off pair: a list emits through a ladder
     # the table deliberately does not carry.

--- a/winprofile-keys.tsv
+++ b/winprofile-keys.tsv
@@ -27,7 +27,7 @@ Depth	win,web,droid	setting	string				agreed		absent
 Dos	win,web,droid	setting	bitmask				agreed	0		
 ExtDepth	win,web,droid	setting	string				agreed		absent	
 FollowRobotsTxt	win,web,droid	setting	list:0:3				agreed	2		
-Footer	win,web,droid	setting	string				unresolved		literal	
+Footer	win,web,droid	setting	string				agreed	<!-- Mirrored from {url} by HTTrack Website Copier/3.x [XR&CO], {date} -->	literal	
 GlobalTravel	win,web,droid	setting	list:0:4				agreed	0		
 HTMLFirst	win,web,droid	setting	checkbox	--priority=7			agreed	0		
 HTTP10	win,web,droid	setting	checkbox	--http-10			agreed	0		


### PR DESCRIPTION
WinHTTrack reads `Footer` with the engine's `HTS_DEFAULT_FOOTER` as its reader default, and `htsserver.c:862` seeds it from the same macro. Neither holds a literal of its own, so neither can be a party to a disagreement about the value. Recording the row as `unresolved` presented a two-sided split as a three-sided one, and overstated what the desktop front ends have, which is no opinion at all.

The row is `agreed` at the macro's expansion. A front end that matches the macro is conformant by construction rather than by consensus, which is the useful property and the one the row now states.

Found by the httrack-windows session reading its own reader after the table shipped. The string defaults that `initStr` states were being asserted by nothing, which is how a wrong value in that column stayed invisible through three review passes; the test compares them now, and reverting the expansion reds it.