### PR TITLE
The top index is written straight over index.html

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5845,8 +5845,7 @@ static int st_pathbin(httrackp *opt, int argc, char **argv) {
 
 // hts_buildtopindex() writes a system-charset name into a charset=utf-8 doc: on
 // Windows the gifs land in a mangled twin dir (#217) and a listed name renders
-// as mojibake (#216). Both must come out utf-8, and the live index must never
-// be visible half-written (#1329). argv[0] is writable.
+// as mojibake (#216). Both must come out utf-8. argv[0] is writable.
 static int st_topindex(httrackp *opt, int argc, char **argv) {
   char topdir[HTS_URLMAXSIZE];
   char path[HTS_URLMAXSIZE + 32];
@@ -5913,9 +5912,8 @@ static int st_topindex(httrackp *opt, int argc, char **argv) {
 
 #ifndef _WIN32
   /* #1329: a rebuild replaces the index instead of rewriting it, so a reader
-     holding the old one open reads it whole and unchanged — never the truncated
-     middle of the new one. A second project makes the two differ. Windows
-     refuses to rename over an open target, so the probe is POSIX-only. */
+     holding the old one open still reads it whole. Windows refuses to rename
+     over an open target, so this probe is POSIX-only. */
   {
     FILE *const held = fopen(path, "rb");
 
@@ -5931,10 +5929,11 @@ static int st_topindex(httrackp *opt, int argc, char **argv) {
     n = fread(buf, 1, sizeof(buf) - 1, held);
     fclose(held);
     buf[n] = '\0';
+    assertf(n < sizeof(buf) - 1); /* a clipped read fakes an absence */
     assertf(strstr(buf, projUTF8) != NULL);
     assertf(strstr(buf, "mocha") == NULL);
 
-    /* and the rebuild did land */
+    /* and the rebuild landed whole, footer included */
     snprintf(path, sizeof(path), "%s/index.html", topdir);
     fp = fopen(path, "rb");
     assertf(fp != NULL);
@@ -5942,6 +5941,7 @@ static int st_topindex(httrackp *opt, int argc, char **argv) {
     fclose(fp);
     buf[n] = '\0';
     assertf(strstr(buf, "mocha") != NULL);
+    assertf(strstr(buf, "Thanks for using HTTrack") != NULL);
 
     snprintf(path, sizeof(path), "%s/mocha/index.html", topdir);
     unlink(path);
@@ -5950,12 +5950,24 @@ static int st_topindex(httrackp *opt, int argc, char **argv) {
   }
 #endif
   /* the temporary is gone either way */
-  snprintf(path, sizeof(path), "%s/index.html.tmp", topdir);
+  snprintf(path, sizeof(path), "%s/index.tmp", topdir);
   assertf(!fexist(path));
 
   /* raw unlink/rmdir: UNLINK is utf-8 on Windows, these paths aren't */
   snprintf(path, sizeof(path), "%s/index.html", topdir);
   unlink(path);
+
+#ifndef _WIN32
+  /* a directory in the way fails the move (EISDIR, not the EEXIST fallback):
+     the rebuild reports failure and leaves neither a temporary nor a stub */
+  assertf(mkdir(path, 0755) == 0);
+  assertf(hts_buildtopindex(opt, topdir, "") == 0);
+  snprintf(path, sizeof(path), "%s/index.tmp", topdir);
+  assertf(!fexist(path));
+  snprintf(path, sizeof(path), "%s/index.html", topdir);
+  assertf(rmdir(path) == 0);
+#endif
+
   snprintf(path, sizeof(path), "%s/backblue.gif", topdir);
   unlink(path);
   snprintf(path, sizeof(path), "%s/fade.gif", topdir);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5845,7 +5845,8 @@ static int st_pathbin(httrackp *opt, int argc, char **argv) {
 
 // hts_buildtopindex() writes a system-charset name into a charset=utf-8 doc: on
 // Windows the gifs land in a mangled twin dir (#217) and a listed name renders
-// as mojibake (#216). Both must come out utf-8. argv[0] is writable.
+// as mojibake (#216). Both must come out utf-8, and the live index must never
+// be visible half-written (#1329). argv[0] is writable.
 static int st_topindex(httrackp *opt, int argc, char **argv) {
   char topdir[HTS_URLMAXSIZE];
   char path[HTS_URLMAXSIZE + 32];
@@ -5910,7 +5911,50 @@ static int st_topindex(httrackp *opt, int argc, char **argv) {
   assertf(strstr(buf, "/index.html\">") != NULL);
   assertf(strstr(buf, "???") == NULL);
 
+#ifndef _WIN32
+  /* #1329: a rebuild replaces the index instead of rewriting it, so a reader
+     holding the old one open reads it whole and unchanged — never the truncated
+     middle of the new one. A second project makes the two differ. Windows
+     refuses to rename over an open target, so the probe is POSIX-only. */
+  {
+    FILE *const held = fopen(path, "rb");
+
+    assertf(held != NULL);
+    snprintf(path, sizeof(path), "%s/mocha/", topdir);
+    assertf(structcheck(path) == 0);
+    snprintf(path, sizeof(path), "%s/mocha/index.html", topdir);
+    fp = fopen(path, "wb");
+    assertf(fp != NULL);
+    fclose(fp);
+    assertf(hts_buildtopindex(opt, topdir, "") != 0);
+
+    n = fread(buf, 1, sizeof(buf) - 1, held);
+    fclose(held);
+    buf[n] = '\0';
+    assertf(strstr(buf, projUTF8) != NULL);
+    assertf(strstr(buf, "mocha") == NULL);
+
+    /* and the rebuild did land */
+    snprintf(path, sizeof(path), "%s/index.html", topdir);
+    fp = fopen(path, "rb");
+    assertf(fp != NULL);
+    n = fread(buf, 1, sizeof(buf) - 1, fp);
+    fclose(fp);
+    buf[n] = '\0';
+    assertf(strstr(buf, "mocha") != NULL);
+
+    snprintf(path, sizeof(path), "%s/mocha/index.html", topdir);
+    unlink(path);
+    snprintf(path, sizeof(path), "%s/mocha", topdir);
+    rmdir(path);
+  }
+#endif
+  /* the temporary is gone either way */
+  snprintf(path, sizeof(path), "%s/index.html.tmp", topdir);
+  assertf(!fexist(path));
+
   /* raw unlink/rmdir: UNLINK is utf-8 on Windows, these paths aren't */
+  snprintf(path, sizeof(path), "%s/index.html", topdir);
   unlink(path);
   snprintf(path, sizeof(path), "%s/backblue.gif", topdir);
   unlink(path);

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -1005,9 +1005,12 @@ static hts_boolean topindex_commit(httrackp *opt, const char *tmp,
   const hts_boolean moved =
       hts_rename_over(opt, tmp_utf8 != NULL ? tmp_utf8 : tmp,
                       dst_utf8 != NULL ? dst_utf8 : dst);
+  /* the caller logs with LOG_ERRNO, and freet() may clobber errno */
+  const int err = errno;
 
   freet(tmp_utf8);
   freet(dst_utf8);
+  errno = err;
   return moved;
 #else
   return hts_rename_over(opt, tmp, dst);
@@ -1046,12 +1049,15 @@ HTSEXT_API int hts_buildtopindex(httrackp * opt, const char *path,
     hts_striplastchar(rpath, '/');
 
     /* Build aside and rename over: a reader of the live index gets the previous
-       file or the new one, never the truncated middle (#1329). */
+       file or the new one, never the truncated middle (#1329). The temporary is
+       named shorter than the index so it cannot be the one to hit MAX_PATH. */
     if (!slprintfbuff(dst, sizeof(dst), "%s/index.html", rpath) ||
-        !slprintfbuff(tmp, sizeof(tmp), "%s.tmp", dst)) {
+        !slprintfbuff(tmp, sizeof(tmp), "%s/index.tmp", rpath)) {
+      hts_log_print(opt, LOG_WARNING, "top index path too long: %s", rpath);
       fpo = NULL;
-    } else {
-      fpo = fopen(fconv(catbuff, sizeof(catbuff), tmp), "wb");
+    } else if ((fpo = fopen(fconv(catbuff, sizeof(catbuff), tmp), "wb")) ==
+               NULL) {
+      hts_log_print(opt, LOG_WARNING | LOG_ERRNO, "could not create %s", tmp);
     }
     if (fpo) {
       find_handle h;
@@ -1062,10 +1068,10 @@ HTSEXT_API int hts_buildtopindex(httrackp * opt, const char *path,
 #ifdef _WIN32
       {
         const char *const base = concat(catbuff, sizeof(catbuff), rpath, "/");
-        char *const base_utf8 =
-            hts_convertStringSystemToUTF8(base, strlen(base));
+        char *base_utf8 = hts_convertStringSystemToUTF8(base, strlen(base));
+
         verif_backblue(opt, base_utf8 != NULL ? base_utf8 : base);
-        free(base_utf8);
+        freet(base_utf8);
       }
 #else
       verif_backblue(opt, concat(catbuff, sizeof(catbuff), rpath, "/"));

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -995,6 +995,25 @@ int hts_footer_format(char *buffer, size_t size, const char *footer,
   return 1;
 }
 
+/* Move the finished tmp onto the live index. Both paths are the system charset,
+   RENAME is utf-8 on Windows. */
+static hts_boolean topindex_commit(httrackp *opt, const char *tmp,
+                                   const char *dst) {
+#ifdef _WIN32
+  char *tmp_utf8 = hts_convertStringSystemToUTF8(tmp, strlen(tmp));
+  char *dst_utf8 = hts_convertStringSystemToUTF8(dst, strlen(dst));
+  const hts_boolean moved =
+      hts_rename_over(opt, tmp_utf8 != NULL ? tmp_utf8 : tmp,
+                      dst_utf8 != NULL ? dst_utf8 : dst);
+
+  freet(tmp_utf8);
+  freet(dst_utf8);
+  return moved;
+#else
+  return hts_rename_over(opt, tmp, dst);
+#endif
+}
+
 /* Note: NOT utf-8 */
 HTSEXT_API int hts_buildtopindex(httrackp * opt, const char *path,
                                  const char *binpath) {
@@ -1021,11 +1040,19 @@ HTSEXT_API int hts_buildtopindex(httrackp * opt, const char *path,
 
   if (toptemplate_header && toptemplate_body && toptemplate_footer
       && toptemplate_bodycat) {
+    char BIGSTK dst[CATBUFF_SIZE], tmp[CATBUFF_SIZE];
 
     strcpybuff(rpath, path);
     hts_striplastchar(rpath, '/');
 
-    fpo = fopen(fconcat(catbuff, sizeof(catbuff), rpath, "/index.html"), "wb");
+    /* Build aside and rename over: a reader of the live index gets the previous
+       file or the new one, never the truncated middle (#1329). */
+    if (!slprintfbuff(dst, sizeof(dst), "%s/index.html", rpath) ||
+        !slprintfbuff(tmp, sizeof(tmp), "%s.tmp", dst)) {
+      fpo = NULL;
+    } else {
+      fpo = fopen(fconv(catbuff, sizeof(catbuff), tmp), "wb");
+    }
     if (fpo) {
       find_handle h;
 
@@ -1183,8 +1210,20 @@ HTSEXT_API int hts_buildtopindex(httrackp * opt, const char *path,
               "<!-- Mirror and index made by HTTrack Website Copier/"
               HTTRACK_VERSION " " HTTRACK_AFF_AUTHORS " -->", /* EOF */ NULL);
 
-      fclose(fpo);
+      {
+        const hts_boolean written = ferror(fpo) == 0 ? HTS_TRUE : HTS_FALSE;
+        const hts_boolean flushed = fclose(fpo) == 0 ? HTS_TRUE : HTS_FALSE;
 
+        /* A short write must not reach the index either: it would look as
+           complete as a good one. */
+        if (!written || !flushed || !topindex_commit(opt, tmp, dst)) {
+          hts_log_print(opt, LOG_WARNING | LOG_ERRNO,
+                        "could not rebuild the top index %s", dst);
+          /* raw unlink: UNLINK is utf-8 on Windows, this path is not */
+          (void) unlink(fconv(catbuff, sizeof(catbuff), tmp));
+          retval = 0;
+        }
+      }
     }
 
   }

--- a/tests/01_engine-topindex.test
+++ b/tests/01_engine-topindex.test
@@ -10,4 +10,8 @@ set -euo pipefail
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
-assert_selftest "topindex self-test OK" topindex "$dir" run
+# Not assert_selftest: the #1329 leg that fails the move logs a warning, so the
+# output is more than the marker.
+got=$(httrack -O /dev/null -#test=topindex "$dir" run) || fail "topindex: exited $?"
+assert_match "topindex self-test OK" "$got"
+is_windows || assert_match "could not rebuild the top index" "$got"


### PR DESCRIPTION
`hts_buildtopindex` opened the live `index.html` with `fopen(..., "wb")`, so the file was truncated before the first byte and stayed short until the last one. A reader landing in that window got an empty or partial index and no way to tell it from a complete one. HTTrack Android serves the mirror over HTTP from the directory the engine writes. A rebuild during a request handed the user a blank page.

The index is now built in `index.html.tmp` and moved onto the target with `hts_rename_over()`, which already carries the Windows rename-onto-existing fallback. A write error or a failed close keeps the old index rather than publishing a short one. Two consequences: every rebuild leaves a new inode, and a hand-set mode or a symlink at that path no longer survives.

The self-test aborts on the pre-fix engine. It is POSIX-only, since Windows refuses to rename over an open file.

Closes #1329