### PR TITLE
The key table still lists Pause as an Android-written key

### DIFF
--- a/src/winprofile-keys.h
+++ b/src/winprofile-keys.h
@@ -88,8 +88,7 @@ static const winprofile_key_t winprofile_keys[WINPROFILE_KEY_COUNT] = {
   {"OtherHeaders", "win,droid", "setting", "string", "", "", "", "agreed", "", "absent", ""},
   {"ParseAll", "win,web,droid", "setting", "checkbox", "--extended-parsing", "", "", "agreed", "1", "", ""},
   {"ParseJava", "win,web,droid", "setting", "checkbox", "", "--parse-java=0", "", "agreed", "1", "", ""},
-  {"Pause", "droid", "setting", "string", "", "", "", "none", "", "", ""},
-  {"PauseFiles", "win,web", "setting", "string", "", "", "", "agreed", "", "absent", ""},
+  {"PauseFiles", "win,web,droid", "setting", "string", "", "", "", "agreed", "", "absent", ""},
   {"Port", "win,web,droid", "setting", "string", "", "", "ProxyType,Proxy", "agreed", "", "absent", ""},
   {"PrimaryScan", "win,web,droid", "setting", "list:0:5", "", "", "", "agreed", "3", "", ""},
   {"ProfileFormat", "win,web", "write_only", "string", "", "", "", "none", "", "absent", ""},
@@ -125,6 +124,7 @@ static const winprofile_key_t winprofile_keys[WINPROFILE_KEY_COUNT] = {
   {"WordIndex", "win,web,droid", "setting", "checkbox", "--search-index", "--search-index=0", "", "agreed", "0", "", ""},
   {"KeepDoubleSlashes", "", "setting", "string", "", "", "", "", "", "", "KeepSlashes"},
   {"KeepWwwPrefix", "", "setting", "string", "", "", "", "", "", "", "KeepWww"},
+  {"Pause", "", "setting", "string", "", "", "", "", "", "", "PauseFiles"},
   {"ProxyProtocol", "", "setting", "string", "", "", "", "", "", "", "ProxyType"},
   {"Iso9660", "", "read_only", "checkbox", "", "", "", "none", "", "", "Dos"},
 };

--- a/winprofile-keys.tsv
+++ b/winprofile-keys.tsv
@@ -74,8 +74,7 @@ NoRecatch	win,web,droid	setting	checkbox	--do-not-recatch			agreed	0
 OtherHeaders	win,droid	setting	string				agreed		absent	
 ParseAll	win,web,droid	setting	checkbox	--extended-parsing			agreed	1		
 ParseJava	win,web,droid	setting	checkbox		--parse-java=0		agreed	1		
-Pause	droid	setting	string				none			
-PauseFiles	win,web	setting	string				agreed		absent	
+PauseFiles	win,web,droid	setting	string				agreed		absent	
 Port	win,web,droid	setting	string			ProxyType,Proxy	agreed		absent	
 PrimaryScan	win,web,droid	setting	list:0:5				agreed	3		
 ProfileFormat	win,web	write_only	string				none		absent	
@@ -112,5 +111,6 @@ WordIndex	win,web,droid	setting	checkbox	--search-index	--search-index=0		agreed
 
 KeepDoubleSlashes		setting	string							KeepSlashes
 KeepWwwPrefix		setting	string							KeepWww
+Pause		setting	string							PauseFiles
 ProxyProtocol		setting	string							ProxyType
 Iso9660		read_only	checkbox				none			Dos


### PR DESCRIPTION
Android stopped writing `Pause` in httrack-android#134: it writes `PauseFiles` now and accepts the old spelling only on read, the same way it handles its three other renamed keys. Our table still had `Pause` owned by `droid`, and `PauseFiles` owned by `win,web` alone.

`Pause` moves to the legacy block as an old spelling of `PauseFiles`, and `PauseFiles` gains `droid`. I read their master rather than taking the report on trust: the field table and the option mapper both emit `PauseFiles`, `ProfileFormat.canonicalName()` folds `Pause`, and Android ships no default for the key, so the row's agreed-no-default state still holds with a third owner.

Reported by the httrack-android session. #1328 also edits this table and its generated header, so whichever lands second needs the header regenerated.