### PR TITLE
A WARC sub-option can be ticked with no effect, and nothing says why

### DIFF
--- a/html/server/option9.html
+++ b/html/server/option9.html
@@ -13,6 +13,7 @@
 <!--
 function do_load() {
 	window.status=' ';
+	warc_gate();
 ${do:if-not-empty:closeme}
 	window.close();
 ${do:end-if}
@@ -22,6 +23,24 @@ function do_unload() {
 }
 function info(str) {
 	window.status = str;
+}
+function box(name) {
+	return document.getElementById(name + '_box');
+}
+/* --warc-cdx indexes an archive it cannot name, so it follows the WARC box. */
+function warc_gate() {
+	var off = !box('warc').checked;
+	box('warccdx').disabled = off;
+	/* a disabled box posts nothing, so its companion carries the state */
+	document.getElementById('warccdx_keep').value =
+		off && box('warccdx').checked ? '1' : '';
+}
+/* --wacz names its own archive, so it is never gated; it only turns WARC on. */
+function wacz_click() {
+	if (box('wacz').checked) {
+		box('warc').checked = true;
+	}
+	warc_gate();
 }
 // -->
 </script>
@@ -113,7 +132,7 @@ ${do:end-if}
 > ${LANG_I61}
 <br><br>
 
-<input type="checkbox" name="warc" ${checked:warc}
+<input type="checkbox" name="warc" ${checked:warc} id="warc_box" onClick="warc_gate(); return true"
 			title='${html:LANG_WARCTIP}' onMouseOver="info('${js:LANG_WARCTIP}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_WARC}
 <br><br>
@@ -130,12 +149,14 @@ ${LANG_WARCMAXSIZE}
 >
 <br><br>
 
-<input type="checkbox" name="warccdx" ${checked:warccdx}
+<!-- a greyed box posts nothing, so keep what it holds -->
+<input type="hidden" name="warccdx" value="${do:if-empty:warc}${ztest:warccdx::1}${do:end-if}" id="warccdx_keep">
+<input type="checkbox" name="warccdx" ${checked:warccdx} id="warccdx_box"${do:if-empty:warc} disabled${do:end-if}
 			title='${html:LANG_WARCCDXTIP}' onMouseOver="info('${js:LANG_WARCCDXTIP}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_WARCCDX}
 <br><br>
 
-<input type="checkbox" name="wacz" ${checked:wacz}
+<input type="checkbox" name="wacz" ${checked:wacz} id="wacz_box" onClick="wacz_click(); return true"
 			title='${html:LANG_WACZTIP}' onMouseOver="info('${js:LANG_WACZTIP}'); return true" onMouseOut="info('&nbsp;'); return true"
 > ${LANG_WACZ}
 <br><br>

--- a/tests/327_webhttrack-warc-gate.test
+++ b/tests/327_webhttrack-warc-gate.test
@@ -1,0 +1,127 @@
+#!/bin/bash
+#
+# --warc-cdx follows the WARC box, --wacz never does: it only turns WARC on.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
+
+htsserver_require
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_warcgate.XXXXXX") || fail "no tmpdir"
+cleanup() {
+    htsserver_cleanup
+    rm -rf "${work}"
+}
+cleanup_push cleanup
+
+printf '[the CDXJ box follows the WARC box] ..\t'
+htsserver_start --home "${work}"
+
+"${HTS_PYTHON}" - "${HTS_URL}" <<'PY' || fail "the WARC gate is broken (see above)"
+import re, sys, urllib.parse, urllib.request
+
+url = sys.argv[1].rstrip("/")
+rc = 0
+
+
+def check(ok, what):
+    global rc
+    print(("ok: " if ok else "FAIL: ") + what)
+    if not ok:
+        rc = 1
+
+
+def get(path):
+    # The UI is served ISO-8859-1, so decode, do not assume UTF-8.
+    return urllib.request.urlopen(url + path, timeout=20).read().decode("latin-1")
+
+
+m = re.search(r'name="sid" value="([0-9a-f]+)"', get("/server/index.html"))
+if m is None:
+    sys.exit("no session id in server/index.html")
+sid = m.group(1)
+
+
+def post(fields):
+    body = "&".join("%s=%s" % (k, urllib.parse.quote(v))
+                    for k, v in [("sid", sid)] + fields)
+    req = urllib.request.Request(url + "/server/step4.html",
+                                 data=body.encode("latin-1"), method="POST")
+    return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
+
+
+def textarea(page, name):
+    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page, re.S)
+    if m is None:
+        sys.exit("no %s textarea in the rendered step4.html" % name)
+    return m.group(1)
+
+
+def tag(page, name):
+    m = re.search(r'<input type="checkbox" name="%s"[^>]*>' % name, page)
+    if m is None:
+        sys.exit("no %s checkbox in the rendered option9.html" % name)
+    return m.group(0)
+
+
+def companion(page):
+    m = re.search(r'<input type="hidden" name="warccdx" value="([^"]*)"'
+                  r' id="warccdx_keep">', page)
+    if m is None:
+        sys.exit("no warccdx companion in the rendered option9.html")
+    return m.group(1)
+
+
+# Nothing headless can see a greyed control, and nothing here runs the click
+# handlers, so assert the wiring exists as well as the states it starts from.
+page = get("/server/option9.html?sid=" + sid)
+for want in ("function warc_gate()", "function wacz_click()",
+             "box('warccdx').disabled = off", "box('warc').checked = true"):
+    check(want in page, "option9.html carries %r" % want)
+# On load too: a profile with WARC clear and CDXJ set must open greyed.
+check(re.search(r"function do_load\(\)[^}]*warc_gate\(\);", page) is not None,
+      "do_load() sets the initial state")
+check("wacz_click()" in tag(page, "wacz"), "the WACZ box calls wacz_click()")
+check("warc_gate()" in tag(page, "warc"), "the WARC box calls warc_gate()")
+
+# Both edges: greying on a tick alone would pass a handler that never re-greys.
+for warc, greyed in (("", True), ("on", False), ("", True)):
+    post([("warc", warc), ("warccdx", "on")])
+    page = get("/server/option9.html?sid=" + sid)
+    label = "WARC %s" % ("set" if warc else "clear")
+    check((" disabled" in tag(page, "warccdx")) == greyed,
+          "%s: the CDXJ box is %s" % (label, "greyed" if greyed else "available"))
+    check("disabled" not in tag(page, "wacz"),
+          "%s: the WACZ box stays available" % label)
+    check("checked" in tag(page, "warccdx"),
+          "%s: the CDXJ box is still drawn ticked" % label)
+    check(companion(page) == ("1" if greyed else ""),
+          "%s: the companion holds %r" % (label, "1" if greyed else ""))
+
+# What a browser posts from that greyed page: the two companions, no box.
+rendered = post([("warc", ""), ("warccdx", ""), ("warccdx", "1")])
+check("WarcCdx=1" in textarea(rendered, "winprofile").splitlines(),
+      "a greyed CDXJ box keeps its stored value")
+check("--warc-cdx" not in textarea(rendered, "command").split(),
+      "a greyed CDXJ box emits no flag")
+
+# Ungreyed, the box decides again: the companion is empty and the box posts.
+rendered = post([("warc", "on"), ("warccdx", ""), ("warccdx", "")])
+check("WarcCdx=0" in textarea(rendered, "winprofile").splitlines(),
+      "an unticked CDXJ box clears the stored value")
+rendered = post([("warc", "on"), ("warccdx", ""), ("warccdx", ""),
+                 ("warccdx", "on")])
+check("--warc-cdx" in textarea(rendered, "command").split(),
+      "a ticked CDXJ box under a set WARC box emits the flag")
+
+sys.exit(rc)
+PY
+echo OK
+
+htsserver_cleanup
+htsserver_assert_reaped
+
+echo "PASS"

--- a/tests/327_webhttrack-warc-gate.test
+++ b/tests/327_webhttrack-warc-gate.test
@@ -75,19 +75,24 @@ def companion(page):
     return m.group(1)
 
 
-# Nothing headless can see a greyed control, and nothing here runs the click
-# handlers, so assert the wiring exists as well as the states it starts from.
+# A headless check cannot see a greyed control or run the click handlers, so this asserts the wiring directly.
 page = get("/server/option9.html?sid=" + sid)
 for want in ("function warc_gate()", "function wacz_click()",
-             "box('warccdx').disabled = off", "box('warc').checked = true"):
+             "var off = !box('warc').checked", "box('warccdx').disabled = off",
+             "box('warc').checked = true", 'onLoad="do_load();"'):
     check(want in page, "option9.html carries %r" % want)
-# On load too: a profile with WARC clear and CDXJ set must open greyed.
+# A profile with WARC clear and CDXJ set must open greyed on load too.
 check(re.search(r"function do_load\(\)[^}]*warc_gate\(\);", page) is not None,
       "do_load() sets the initial state")
-check("wacz_click()" in tag(page, "wacz"), "the WACZ box calls wacz_click()")
-check("warc_gate()" in tag(page, "warc"), "the WARC box calls warc_gate()")
+for name, handler in (("warc", "warc_gate"), ("wacz", "wacz_click")):
+    check('onClick="%s()' % handler in tag(page, name),
+          "the %s box calls %s() on click" % (name, handler))
+# box() builds each id by hand, so it has to be the one the tag carries.
+for name in ("warc", "warccdx", "wacz"):
+    check('id="%s_box"' % name in tag(page, name),
+          "the %s box carries id=\"%s_box\"" % (name, name))
 
-# Both edges: greying on a tick alone would pass a handler that never re-greys.
+# Both rendered states; the re-grey on untick is warc_gate()'s, and never runs here.
 for warc, greyed in (("", True), ("on", False), ("", True)):
     post([("warc", warc), ("warccdx", "on")])
     page = get("/server/option9.html?sid=" + sid)
@@ -102,10 +107,12 @@ for warc, greyed in (("", True), ("on", False), ("", True)):
           "%s: the companion holds %r" % (label, "1" if greyed else ""))
 
 # What a browser posts from that greyed page: the two companions, no box.
-rendered = post([("warc", ""), ("warccdx", ""), ("warccdx", "1")])
+rendered = post([("warc", ""), ("warccdx", ""), ("warccdx", companion(page))])
 check("WarcCdx=1" in textarea(rendered, "winprofile").splitlines(),
       "a greyed CDXJ box keeps its stored value")
-check("--warc-cdx" not in textarea(rendered, "command").split(),
+cmd = textarea(rendered, "command").split()
+# --user-agent is unconditional: an empty textarea holds no flag either.
+check("--user-agent" in cmd and "--warc-cdx" not in cmd,
       "a greyed CDXJ box emits no flag")
 
 # Ungreyed, the box decides again: the companion is empty and the box posts.


### PR DESCRIPTION
The CDXJ box on option9.html now greys out when the WARC box is clear. `--warc-cdx` can only index an archive it cannot name, so #1335 already dropped the flag without `--warc`, but the page still drew the two as independent siblings and step4's command textarea is `visibility:hidden`. Ticking CDXJ under a clear WARC box did nothing, and nothing on screen said why.

The greyed state is rendered server-side, so a profile with `Warc=0` and `WarcCdx=1` opens greyed instead of waiting for a click; an onClick handler keeps it in step after that. A disabled box posts nothing, which the existing clearing companion reads as unticked, so a second hidden input carries the box's state across the visit. WinHTTrack keeps a greyed control's value the same way (httrack-windows#130).

WACZ stays available at all times. `--wacz` fills in an archive name of its own, which is why #1335 left it ungated, and greying it would put back the gate that PR deliberately removed. Ticking it now ticks WARC as well, so the page says what the engine does, and WARC stays clearable afterwards.

`tests/327_webhttrack-warc-gate.test` walks the states over HTTP: greyed under a clear parent, available once WARC is ticked, greyed again once it is unticked, with the companion's value and the profile round trip checked on each side. Nothing headless runs the click handlers, so the test asserts their wiring as text. It kills three mutants: always disabled, never disabled, and a companion that always renders empty.

Closes #1336
