### PR TITLE
A User-Agent typed in the extra-headers box is sent twice

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -920,6 +920,32 @@ int http_cookie_header(t_cookie *cookie, const char *domain, const char *path,
   return append_cookie_header(&bstr, cookie, domain, path);
 }
 
+/* Is field present as a header field name in the raw custom-header block? */
+hts_boolean http_headers_have_field(const char *headers, const char *field) {
+  const char *line;
+
+  if (headers == NULL || field == NULL || *field == '\0')
+    return HTS_FALSE;
+  /* anchored, so a folded line or a name inside a value cannot match */
+  for (line = headers; *line != '\0';) {
+    const int n = strfield(line, field);
+
+    if (n != 0) {
+      const char *p = line + n;
+
+      while (*p == ' ' || *p == '\t')
+        p++;
+      if (*p == ':')
+        return HTS_TRUE;
+    }
+    while (*line != '\0' && *line != '\n' && *line != '\r')
+      line++;
+    while (*line == '\n' || *line == '\r')
+      line++;
+  }
+  return HTS_FALSE;
+}
+
 // envoi d'une requète
 int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
                   const char *xsend, const char *adr, const char *fil,
@@ -1120,35 +1146,43 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
     {
       const char *real_adr = jump_identification_const(adr);
 
+      /* a field typed into the extra-headers box wins: the engine skips its
+         own line rather than send it twice (#1337) */
+      const char *const custom = retour->req.headers;
+
       // Mandatory per RFC2616
-      if (!direct_url) {        // pas ftp:// par exemple
+      if (!direct_url &&
+          !http_headers_have_field(custom, "Host")) { // not ftp:// and friends
         print_buffer(&bstr, "Host: %s" H_CRLF,
                      escape_check_url_addr(real_adr, esc, sizeof(esc)));
       }
 
       // HTTP field: from
-      if (strnotempty(retour->req.from)) {        // HTTP from
+      if (strnotempty(retour->req.from) &&
+          !http_headers_have_field(custom, "From")) { // HTTP from
         print_buffer(&bstr, "From: %s" H_CRLF, retour->req.from);
       }
 
-      // Présence d'un user-agent?
-      if (retour->req.user_agent_send
-          && strnotempty(retour->req.user_agent)) {
+      if (retour->req.user_agent_send && strnotempty(retour->req.user_agent) &&
+          !http_headers_have_field(custom, "User-Agent")) {
         print_buffer(&bstr, "User-Agent: %s" H_CRLF, retour->req.user_agent);
       }
 
       // Accept
-      if (strnotempty(retour->req.accept)) {
+      if (strnotempty(retour->req.accept) &&
+          !http_headers_have_field(custom, "Accept")) {
         print_buffer(&bstr, "Accept: %s" H_CRLF, retour->req.accept);
       }
 
       // Accept-language
-      if (strnotempty(retour->req.lang_iso)) {
+      if (strnotempty(retour->req.lang_iso) &&
+          !http_headers_have_field(custom, "Accept-Language")) {
         print_buffer(&bstr, "Accept-Language: %s"H_CRLF, retour->req.lang_iso);
       }
 
       // Compression accepted ?
-      if (retour->req.http11) {
+      if (retour->req.http11 &&
+          !http_headers_have_field(custom, "Accept-Encoding")) {
         hts_boolean compressible =
             (!retour->req.range_used && !retour->req.nocompression);
         hts_boolean secure = HTS_FALSE;
@@ -1185,7 +1219,8 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
         } else if ((a = bauth_check(cookie, real_adr, fil)))
           strcpybuff(autorisation, a);
         /* On a une autorisation a donner?  */
-        if (strnotempty(autorisation)) {
+        if (strnotempty(autorisation) &&
+            !http_headers_have_field(custom, "Authorization")) {
           print_buffer(&bstr, "Authorization: Basic %s"H_CRLF, autorisation);
         }
       }

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -920,24 +920,28 @@ int http_cookie_header(t_cookie *cookie, const char *domain, const char *path,
   return append_cookie_header(&bstr, cookie, domain, path);
 }
 
-/* Is field present as a header field name in the raw custom-header block? */
-hts_boolean http_headers_have_field(const char *headers, const char *field) {
+hts_boolean http_headers_have_field(const char *headers,
+                                    const char *field_name) {
+  size_t len;
   const char *line;
 
-  if (headers == NULL || field == NULL || *field == '\0')
+  if (headers == NULL || field_name == NULL)
+    return HTS_FALSE;
+  len = strlen(field_name);
+  if (len != 0 && field_name[len - 1] == ':') /* the tree spells it both ways */
+    len--;
+  if (len == 0)
     return HTS_FALSE;
   /* anchored, so a folded line or a name inside a value cannot match */
   for (line = headers; *line != '\0';) {
-    const int n = strfield(line, field);
+    size_t i = 0;
 
-    if (n != 0) {
-      const char *p = line + n;
-
-      while (*p == ' ' || *p == '\t')
-        p++;
-      if (*p == ':')
-        return HTS_TRUE;
-    }
+    while (i < len && streql(line[i], field_name[i]))
+      i++;
+    /* RFC 7230 forbids a space before the colon: tolerating one would drop our
+       line for a malformed one the server then ignores */
+    if (i == len && line[len] == ':')
+      return HTS_TRUE;
     while (*line != '\0' && *line != '\n' && *line != '\r')
       line++;
     while (*line == '\n' || *line == '\r')
@@ -1146,13 +1150,12 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
     {
       const char *real_adr = jump_identification_const(adr);
 
-      /* a field typed into the extra-headers box wins: the engine skips its
-         own line rather than send it twice (#1337) */
+      /* the extra-headers box wins: skip the engine's own line (#1337) */
       const char *const custom = retour->req.headers;
 
       // Mandatory per RFC2616
       if (!direct_url &&
-          !http_headers_have_field(custom, "Host")) { // not ftp:// and friends
+          !http_headers_have_field(custom, "Host")) { // not ftp:// for example
         print_buffer(&bstr, "Host: %s" H_CRLF,
                      escape_check_url_addr(real_adr, esc, sizeof(esc)));
       }
@@ -1218,7 +1221,6 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
           }
         } else if ((a = bauth_check(cookie, real_adr, fil)))
           strcpybuff(autorisation, a);
-        /* On a une autorisation a donner?  */
         if (strnotempty(autorisation) &&
             !http_headers_have_field(custom, "Authorization")) {
           print_buffer(&bstr, "Authorization: Basic %s"H_CRLF, autorisation);

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -214,10 +214,10 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode, const char *xsend
 int http_cookie_header(t_cookie *cookie, const char *domain, const char *path,
                        char *dst, size_t dst_size);
 
-/* True if the raw CRLF-separated custom request-header block carries a line
-   whose field name is `field`: case-insensitive, at a line start only (a folded
-   continuation line never starts one). Either argument may be NULL. */
-hts_boolean http_headers_have_field(const char *headers, const char *field);
+/* True if the raw CRLF-separated custom request-header block starts a line with
+   `field_name`, given without the trailing colon (which is tolerated). */
+hts_boolean http_headers_have_field(const char *headers,
+                                    const char *field_name);
 
 /* Switch soc between blocking and non-blocking mode; false on failure, with
    errno (WSAGetLastError() on Windows) set. */

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -214,6 +214,11 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode, const char *xsend
 int http_cookie_header(t_cookie *cookie, const char *domain, const char *path,
                        char *dst, size_t dst_size);
 
+/* True if the raw CRLF-separated custom request-header block carries a line
+   whose field name is `field`: case-insensitive, at a line start only (a folded
+   continuation line never starts one). Either argument may be NULL. */
+hts_boolean http_headers_have_field(const char *headers, const char *field);
+
 /* Switch soc between blocking and non-blocking mode; false on failure, with
    errno (WSAGetLastError() on Windows) set. */
 hts_boolean socket_set_nonblocking(T_SOC soc, hts_boolean nonblocking);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2738,6 +2738,25 @@ static int st_headerlong(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* Does the custom request-header block already carry <field>? (#1337) */
+static int st_headerfield(httrackp *opt, int argc, char **argv) {
+  char *headers, *field;
+
+  (void) opt;
+  if (argc < 2) {
+    fprintf(stderr, "headerfield: needs a header block and a field name\n");
+    return 1;
+  }
+  /* exact-size heap copies so a sanitizer traps an over-read */
+  headers = strdupt(argv[0]);
+  field = strdupt(argv[1]);
+  printf("%s\n",
+         http_headers_have_field(headers, field) ? "present" : "absent");
+  freet(headers);
+  freet(field);
+  return 0;
+}
+
 /* http_xfread1 must refuse an in-memory buffer whose size would exceed a 32-bit
    index (hostile Content-Length or endless stream) rather than allocate it.
    The guard returns before any socket read, so no real connection is needed. */
@@ -11581,6 +11600,9 @@ static const struct selftest_entry {
      st_stripport},
     {"header", "<raw-header-line> ...", "response header-line parsing",
      st_header},
+    {"headerfield", "<headers> <field>",
+     "is <field> already present in the custom request-header block",
+     st_headerfield},
     {"headerlong", "[header-name:]",
      "over-long header value must not overflow the parse scratch",
      st_headerlong},

--- a/tests/326_engine-header-dedup.test
+++ b/tests/326_engine-header-dedup.test
@@ -66,7 +66,7 @@ cleanup() {
 }
 cleanup_push cleanup
 
-# Every header the engine writes for itself, in emission order.
+# Every header the engine writes for itself.
 engine_fields="Host From User-Agent Accept Accept-Language Accept-Encoding Authorization"
 
 count_lines() { # count_lines RE FILE
@@ -85,10 +85,16 @@ probe() { # probe TAG [extra httrack args...]
     run_with_timeout 90 httrack "http://user:pass@127.0.0.1:$port/plain.html" \
         -O "$tmpdir/$tag.mirror" -c1 --robots=0 --retries=0 --quiet -%v0 \
         -F EngineUA/1.0 -%E tester@example.test "$@" >>"$tmpdir/log" 2>&1 || rc=$?
-    test "$rc" -ne 124 || fail "$tag: the crawl hit the deadline"
+    test "$rc" -eq 0 || fail "$tag: the crawl exited $rc"
     nreq=$((nreq + 1))
     assert_eq "$nreq" "$(count_lines '^=== REQUEST ===$' "$wire")" "$tag: requests logged"
     awk -v n="$nreq" '/^=== REQUEST ===$/ { c++; next } c == n' "$wire" >"$tmpdir/$tag.req"
+    # a request the server had to time out on is logged truncated, and would
+    # otherwise pass every assertion below
+    assert_eq ' \r \n \n' "$(tail -n 2 "$tmpdir/$tag.req" | od -An -c | tr -s ' ')" \
+        "$tag: the blank line closing the header block"
+    assert_eq 1 "$(count_lines "^[^$CR]*\$" "$tmpdir/$tag.req")" \
+        "$tag: lines not ending in CR"
 }
 
 # Every engine header is written, and written once.
@@ -104,12 +110,13 @@ assert_value() { # assert_value TAG FIELD VALUE
 }
 
 # The rest of the request is byte-identical to the one no box produced: RE names
-# the only lines allowed to differ.
+# the only lines allowed to differ. Compared as files, since a command
+# substitution would eat a lost trailing newline on both sides alike.
 assert_same_but() { # assert_same_but TAG RE
-    local want got
-    want=$(grep -Ev "$2" "$tmpdir/plain.req" | tr -d '\r')
-    got=$(grep -Ev "$2" "$tmpdir/$1.req" | tr -d '\r')
-    assert_eq "$want" "$got" "$1: the request outside $2"
+    local base=$tmpdir/$1.base got=$tmpdir/$1.got
+    grep -Ev "$2" "$tmpdir/plain.req" >"$base" || true
+    grep -Ev "$2" "$tmpdir/$1.req" >"$got" || true
+    diff "$base" "$got" || fail "$1: the request outside $2 differs from the box-free one"
 }
 
 "$python" "$server" "$wire" >"$tmpdir/server.out" 2>"$tmpdir/server.err" &
@@ -150,3 +157,12 @@ assert_value boxrest From box@example.test
 assert_value boxrest Accept-Language xx
 assert_value boxrest Authorization 'Basic Ym94'
 assert_same_but boxrest '^(From|Accept-Language|Authorization):'
+
+# A malformed box line leaves the engine's own in place: a server drops
+# "User-Agent : x", so suppressing ours would send no usable name at all.
+probe boxbadws -%X 'User-Agent : x'
+assert_all_once boxbadws
+assert_value boxbadws User-Agent EngineUA/1.0
+assert_eq 1 "$(count_lines '^User-Agent :' "$tmpdir/boxbadws.req")" \
+    'boxbadws: the malformed line'
+assert_same_but boxbadws '^User-Agent'

--- a/tests/326_engine-header-dedup.test
+++ b/tests/326_engine-header-dedup.test
@@ -90,9 +90,11 @@ probe() { # probe TAG [extra httrack args...]
     assert_eq "$nreq" "$(count_lines '^=== REQUEST ===$' "$wire")" "$tag: requests logged"
     awk -v n="$nreq" '/^=== REQUEST ===$/ { c++; next } c == n' "$wire" >"$tmpdir/$tag.req"
     # a request the server had to time out on is logged truncated, and would
-    # otherwise pass every assertion below
-    assert_eq ' \r \n \n' "$(tail -n 2 "$tmpdir/$tag.req" | od -An -c | tr -s ' ')" \
-        "$tag: the blank line closing the header block"
+    # otherwise pass every assertion below. Hex with every space squeezed out:
+    # od's column padding differs between GNU and BSD.
+    assert_eq 0d0a0d0a0a \
+        "$(tail -c 5 "$tmpdir/$tag.req" | od -An -t x1 | tr -d '[:space:]')" \
+        "$tag: the CRLF CRLF ending the request, then the fixture's own newline"
     assert_eq 1 "$(count_lines "^[^$CR]*\$" "$tmpdir/$tag.req")" \
         "$tag: lines not ending in CR"
 }

--- a/tests/326_engine-header-dedup.test
+++ b/tests/326_engine-header-dedup.test
@@ -73,6 +73,10 @@ count_lines() { # count_lines RE FILE
     grep -c "$1" "$2" || true
 }
 
+count_bytes() { # count_bytes BYTE FILE
+    tr -dc "$1" <"$2" | wc -c | tr -d '[:space:]'
+}
+
 value_of() { # value_of FIELD FILE
     sed -n "s/^$1: //p" "$2" | tr -d '\r'
 }
@@ -88,15 +92,17 @@ probe() { # probe TAG [extra httrack args...]
     test "$rc" -eq 0 || fail "$tag: the crawl exited $rc"
     nreq=$((nreq + 1))
     assert_eq "$nreq" "$(count_lines '^=== REQUEST ===$' "$wire")" "$tag: requests logged"
-    awk -v n="$nreq" '/^=== REQUEST ===$/ { c++; next } c == n' "$wire" >"$tmpdir/$tag.req"
-    # a request the server had to time out on is logged truncated, and would
-    # otherwise pass every assertion below. Hex with every space squeezed out:
-    # od's column padding differs between GNU and BSD.
-    assert_eq 0d0a0d0a0a \
-        "$(tail -c 5 "$tmpdir/$tag.req" | od -An -t x1 | tr -d '[:space:]')" \
-        "$tag: the CRLF CRLF ending the request, then the fixture's own newline"
-    assert_eq 1 "$(count_lines "^[^$CR]*\$" "$tmpdir/$tag.req")" \
-        "$tag: lines not ending in CR"
+    # the server's own byte-for-byte copy, never the log split by a text tool
+    cp "$wire.$nreq" "$tmpdir/$tag.req"
+    # the last header line's CRLF and the blank CRLF that closes the block; the
+    # fixture appends nothing to a per-request file. Hex with all whitespace
+    # dropped, since od's column padding differs between GNU and BSD.
+    assert_eq 0d0a0d0a \
+        "$(tail -c 4 "$tmpdir/$tag.req" | od -An -t x1 | tr -d '[:space:]')" \
+        "$tag: the CRLF CRLF ending the request"
+    # so every LF in between is the LF of a CRLF pair
+    assert_eq "$(count_bytes "$CR" "$tmpdir/$tag.req")" \
+        "$(count_bytes "$LF" "$tmpdir/$tag.req")" "$tag: CR count against LF count"
 }
 
 # Every engine header is written, and written once.

--- a/tests/326_engine-header-dedup.test
+++ b/tests/326_engine-header-dedup.test
@@ -8,6 +8,8 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
+CR=$'\r'
+LF=$'\n'
 CRLF=$'\r\n'
 TAB=$'\t'
 
@@ -18,23 +20,35 @@ hf() { # hf present|absent BLOCK FIELD
 hf present "User-Agent: mine$CRLF" User-Agent
 hf present "user-agent: mine$CRLF" User-Agent
 hf present "USER-AGENT: mine$CRLF" user-agent
-# whitespace may sit between the name and its colon
-hf present "User-Agent : mine$CRLF" User-Agent
-hf present "User-Agent$TAB: mine$CRLF" User-Agent
+# RFC 7230 forbids a space before the colon, and a server drops such a line:
+# honouring it here would leave the request with no User-Agent at all
+hf absent "User-Agent : mine$CRLF" User-Agent
+hf absent "User-Agent$TAB: mine$CRLF" User-Agent
 # a name counts at the start of a line only, and a folded line starts nothing
 hf absent "X-Note: User-Agent: no$CRLF" User-Agent
 hf absent " User-Agent: folded$CRLF" User-Agent
 hf absent "X-Note: v$CRLF${TAB}User-Agent: folded$CRLF" User-Agent
 hf present "X-Note: v${CRLF}User-Agent: mine$CRLF" User-Agent
-# no colon, no field
+# neither a prefix nor a suffix of another name answers for it
 hf absent "User-Agent$CRLF" User-Agent
 hf absent "User-Agentfoo: v$CRLF" User-Agent
-hf absent "" User-Agent
-# a name that is a prefix of another must not answer for it, either way round
+hf absent "X-Real-User-Agent: v$CRLF" User-Agent
 hf absent "Accept-Encoding: identity$CRLF" Accept
 hf absent "Accept: */*$CRLF" Accept-Encoding
 hf present "Accept: */*${CRLF}Accept-Encoding: identity$CRLF" Accept
 hf present "Accept: */*${CRLF}Accept-Encoding: identity$CRLF" Accept-Encoding
+# an embedder fills opt->headers itself, so neither a final terminator nor CRLF
+# endings are guaranteed
+hf present "User-Agent: mine" User-Agent
+hf present "X-Note: v${LF}User-Agent: mine$LF" User-Agent
+hf present "X-Note: v${CR}User-Agent: mine$CR" User-Agent
+# the tree spells a field name with its colon as often as without
+hf present "User-Agent: mine$CRLF" "User-Agent:"
+hf absent "X-Note: v$CRLF" "User-Agent:"
+# an empty name matches nothing, rather than every line opening with a colon
+hf absent ":oops$CRLF" ""
+hf absent ":oops$CRLF" ":"
+hf absent "" User-Agent
 
 selftest_run_queued
 
@@ -43,13 +57,17 @@ python=$(find_python) || skip "python3 missing"
 server=$(nativepath "$top_srcdir/tests/header-injection-server.py")
 tmpdir=$(mktemp -d)
 serverpid=
-wire=
+wire=$tmpdir/wire
+nreq=0
 
 cleanup() {
     stop_server "$serverpid"
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
+
+# Every header the engine writes for itself, in emission order.
+engine_fields="Host From User-Agent Accept Accept-Language Accept-Encoding Authorization"
 
 count_lines() { # count_lines RE FILE
     grep -c "$1" "$2" || true
@@ -59,44 +77,76 @@ value_of() { # value_of FIELD FILE
     sed -n "s/^$1: //p" "$2" | tr -d '\r'
 }
 
-# One crawl of a leaf page against a wire-logging server, leaving its request
-# bytes in $wire.
+# One crawl of a leaf page, leaving its request bytes in $tmpdir/TAG.req. The
+# credentials and -%E are what make the engine write From and Authorization.
 probe() { # probe TAG [extra httrack args...]
-    local tag=$1 port rc=0
+    local tag=$1 rc=0
     shift
-    wire=$tmpdir/$tag.wire
-    "$python" "$server" "$wire" >"$tmpdir/$tag.out" 2>"$tmpdir/$tag.err" &
-    serverpid=$!
-    port=$(discover_server_port "$tmpdir/$tag.out" "$serverpid") || exit 1
-    run_with_timeout 90 httrack "http://127.0.0.1:$port/plain.html" \
+    run_with_timeout 90 httrack "http://user:pass@127.0.0.1:$port/plain.html" \
         -O "$tmpdir/$tag.mirror" -c1 --robots=0 --retries=0 --quiet -%v0 \
-        -F EngineUA/1.0 "$@" >>"$tmpdir/log" 2>&1 || rc=$?
+        -F EngineUA/1.0 -%E tester@example.test "$@" >>"$tmpdir/log" 2>&1 || rc=$?
     test "$rc" -ne 124 || fail "$tag: the crawl hit the deadline"
-    stop_server "$serverpid"
-    serverpid=
-    assert_eq 1 "$(count_lines '^=== REQUEST ===$' "$wire")" "$tag: requests sent"
+    nreq=$((nreq + 1))
+    assert_eq "$nreq" "$(count_lines '^=== REQUEST ===$' "$wire")" "$tag: requests logged"
+    awk -v n="$nreq" '/^=== REQUEST ===$/ { c++; next } c == n' "$wire" >"$tmpdir/$tag.req"
 }
+
+# Every engine header is written, and written once.
+assert_all_once() { # assert_all_once TAG
+    local field
+    for field in $engine_fields; do
+        assert_eq 1 "$(count_lines "^$field:" "$tmpdir/$1.req")" "$1: $field lines"
+    done
+}
+
+assert_value() { # assert_value TAG FIELD VALUE
+    assert_eq "$3" "$(value_of "$2" "$tmpdir/$1.req")" "$1: $2"
+}
+
+# The rest of the request is byte-identical to the one no box produced: RE names
+# the only lines allowed to differ.
+assert_same_but() { # assert_same_but TAG RE
+    local want got
+    want=$(grep -Ev "$2" "$tmpdir/plain.req" | tr -d '\r')
+    got=$(grep -Ev "$2" "$tmpdir/$1.req" | tr -d '\r')
+    assert_eq "$want" "$got" "$1: the request outside $2"
+}
+
+"$python" "$server" "$wire" >"$tmpdir/server.out" 2>"$tmpdir/server.err" &
+serverpid=$!
+port=$(discover_server_port "$tmpdir/server.out" "$serverpid") || exit 1
 
 # An empty box leaves the request as it was.
 probe plain
-assert_eq 1 "$(count_lines '^User-Agent:' "$wire")" 'plain: User-Agent lines'
-assert_eq EngineUA/1.0 "$(value_of User-Agent "$wire")" 'plain: User-Agent'
-for field in Host Accept Accept-Language Accept-Encoding; do
-    assert_eq 1 "$(count_lines "^$field:" "$wire")" "plain: $field lines"
-done
+assert_all_once plain
+assert_value plain User-Agent EngineUA/1.0
+assert_value plain From tester@example.test
 
 probe boxua -%X 'User-Agent: BoxUA/9'
-assert_eq 1 "$(count_lines '^User-Agent:' "$wire")" 'boxua: User-Agent lines'
-assert_eq BoxUA/9 "$(value_of User-Agent "$wire")" 'boxua: User-Agent'
-assert_eq 1 "$(count_lines '^Accept:' "$wire")" 'boxua: Accept lines'
+assert_all_once boxua
+assert_value boxua User-Agent BoxUA/9
+assert_same_but boxua '^User-Agent:'
 
+# Accept-Encoding in the box must not silence Accept, nor the reverse.
 probe boxenc -%X 'Accept-Encoding: identity'
-assert_eq 1 "$(count_lines '^Accept-Encoding:' "$wire")" 'boxenc: Accept-Encoding lines'
-assert_eq identity "$(value_of Accept-Encoding "$wire")" 'boxenc: Accept-Encoding'
-assert_eq 1 "$(count_lines '^Accept:' "$wire")" 'boxenc: Accept lines'
-assert_eq 1 "$(count_lines '^User-Agent:' "$wire")" 'boxenc: User-Agent lines'
+assert_all_once boxenc
+assert_value boxenc Accept-Encoding identity
+assert_same_but boxenc '^Accept-Encoding:'
 
 probe boxaccept -%X 'Accept: text/plain'
-assert_eq 1 "$(count_lines '^Accept:' "$wire")" 'boxaccept: Accept lines'
-assert_eq text/plain "$(value_of Accept "$wire")" 'boxaccept: Accept'
-assert_eq 1 "$(count_lines '^Accept-Encoding:' "$wire")" 'boxaccept: Accept-Encoding lines'
+assert_all_once boxaccept
+assert_value boxaccept Accept text/plain
+assert_same_but boxaccept '^Accept:'
+
+probe boxhost -%X 'Host: box.example'
+assert_all_once boxhost
+assert_value boxhost Host box.example
+assert_same_but boxhost '^Host:'
+
+probe boxrest -%X 'From: box@example.test' -%X 'Accept-Language: xx' \
+    -%X 'Authorization: Basic Ym94'
+assert_all_once boxrest
+assert_value boxrest From box@example.test
+assert_value boxrest Accept-Language xx
+assert_value boxrest Authorization 'Basic Ym94'
+assert_same_but boxrest '^(From|Accept-Language|Authorization):'

--- a/tests/326_engine-header-dedup.test
+++ b/tests/326_engine-header-dedup.test
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+# A field typed into the extra-headers box (-%X) replaces the engine's own line
+# instead of adding a second one (#1337). The predicate first, then the wire.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+CRLF=$'\r\n'
+TAB=$'\t'
+
+hf() { # hf present|absent BLOCK FIELD
+    selftest_queue "$1" headerfield "$2" "$3"
+}
+
+hf present "User-Agent: mine$CRLF" User-Agent
+hf present "user-agent: mine$CRLF" User-Agent
+hf present "USER-AGENT: mine$CRLF" user-agent
+# whitespace may sit between the name and its colon
+hf present "User-Agent : mine$CRLF" User-Agent
+hf present "User-Agent$TAB: mine$CRLF" User-Agent
+# a name counts at the start of a line only, and a folded line starts nothing
+hf absent "X-Note: User-Agent: no$CRLF" User-Agent
+hf absent " User-Agent: folded$CRLF" User-Agent
+hf absent "X-Note: v$CRLF${TAB}User-Agent: folded$CRLF" User-Agent
+hf present "X-Note: v${CRLF}User-Agent: mine$CRLF" User-Agent
+# no colon, no field
+hf absent "User-Agent$CRLF" User-Agent
+hf absent "User-Agentfoo: v$CRLF" User-Agent
+hf absent "" User-Agent
+# a name that is a prefix of another must not answer for it, either way round
+hf absent "Accept-Encoding: identity$CRLF" Accept
+hf absent "Accept: */*$CRLF" Accept-Encoding
+hf present "Accept: */*${CRLF}Accept-Encoding: identity$CRLF" Accept
+hf present "Accept: */*${CRLF}Accept-Encoding: identity$CRLF" Accept-Encoding
+
+selftest_run_queued
+
+python=$(find_python) || skip "python3 missing"
+
+server=$(nativepath "$top_srcdir/tests/header-injection-server.py")
+tmpdir=$(mktemp -d)
+serverpid=
+wire=
+
+cleanup() {
+    stop_server "$serverpid"
+    rm -rf "$tmpdir"
+}
+cleanup_push cleanup
+
+count_lines() { # count_lines RE FILE
+    grep -c "$1" "$2" || true
+}
+
+value_of() { # value_of FIELD FILE
+    sed -n "s/^$1: //p" "$2" | tr -d '\r'
+}
+
+# One crawl of a leaf page against a wire-logging server, leaving its request
+# bytes in $wire.
+probe() { # probe TAG [extra httrack args...]
+    local tag=$1 port rc=0
+    shift
+    wire=$tmpdir/$tag.wire
+    "$python" "$server" "$wire" >"$tmpdir/$tag.out" 2>"$tmpdir/$tag.err" &
+    serverpid=$!
+    port=$(discover_server_port "$tmpdir/$tag.out" "$serverpid") || exit 1
+    run_with_timeout 90 httrack "http://127.0.0.1:$port/plain.html" \
+        -O "$tmpdir/$tag.mirror" -c1 --robots=0 --retries=0 --quiet -%v0 \
+        -F EngineUA/1.0 "$@" >>"$tmpdir/log" 2>&1 || rc=$?
+    test "$rc" -ne 124 || fail "$tag: the crawl hit the deadline"
+    stop_server "$serverpid"
+    serverpid=
+    assert_eq 1 "$(count_lines '^=== REQUEST ===$' "$wire")" "$tag: requests sent"
+}
+
+# An empty box leaves the request as it was.
+probe plain
+assert_eq 1 "$(count_lines '^User-Agent:' "$wire")" 'plain: User-Agent lines'
+assert_eq EngineUA/1.0 "$(value_of User-Agent "$wire")" 'plain: User-Agent'
+for field in Host Accept Accept-Language Accept-Encoding; do
+    assert_eq 1 "$(count_lines "^$field:" "$wire")" "plain: $field lines"
+done
+
+probe boxua -%X 'User-Agent: BoxUA/9'
+assert_eq 1 "$(count_lines '^User-Agent:' "$wire")" 'boxua: User-Agent lines'
+assert_eq BoxUA/9 "$(value_of User-Agent "$wire")" 'boxua: User-Agent'
+assert_eq 1 "$(count_lines '^Accept:' "$wire")" 'boxua: Accept lines'
+
+probe boxenc -%X 'Accept-Encoding: identity'
+assert_eq 1 "$(count_lines '^Accept-Encoding:' "$wire")" 'boxenc: Accept-Encoding lines'
+assert_eq identity "$(value_of Accept-Encoding "$wire")" 'boxenc: Accept-Encoding'
+assert_eq 1 "$(count_lines '^Accept:' "$wire")" 'boxenc: Accept lines'
+assert_eq 1 "$(count_lines '^User-Agent:' "$wire")" 'boxenc: User-Agent lines'
+
+probe boxaccept -%X 'Accept: text/plain'
+assert_eq 1 "$(count_lines '^Accept:' "$wire")" 'boxaccept: Accept lines'
+assert_eq text/plain "$(value_of Accept "$wire")" 'boxaccept: Accept'
+assert_eq 1 "$(count_lines '^Accept-Encoding:' "$wire")" 'boxaccept: Accept-Encoding lines'

--- a/tests/header-injection-server.py
+++ b/tests/header-injection-server.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Raw-socket probe for 159_local-header-injection.
+"""Raw-socket probe for 159_local-header-injection and 326_engine-header-dedup.
 
 Speaks HTTP off the socket so a split header line stays visible; serves an
 origin-form site and an http-proxy absolute-URI one on the same port.

--- a/tests/header-injection-server.py
+++ b/tests/header-injection-server.py
@@ -5,7 +5,9 @@ Speaks HTTP off the socket so a split header line stays visible; serves an
 origin-form site and an http-proxy absolute-URI one on the same port.
 
 Appends "=== REQUEST ===\\n<bytes>\\n" per request to the log named on argv, and
-prints "PORT <n>" once listening.
+writes each request verbatim to <log>.<n> as well, so a consumer grading line
+endings never has to split the log with a tool that may translate them. Prints
+"PORT <n>" once listening.
 """
 
 import os
@@ -59,7 +61,7 @@ def body_for(request, port):
     return page("leaf")
 
 
-def handle(conn, port, logf, lock):
+def handle(conn, port, logf, lock, seq):
     conn.settimeout(10)
     data = b""
     try:
@@ -72,8 +74,11 @@ def handle(conn, port, logf, lock):
         pass
     if data:
         with lock:
+            seq[0] += 1
             logf.write(b"=== REQUEST ===\n" + data + b"\n")
             logf.flush()
+            with open("%s.%d" % (sys.argv[1], seq[0]), "wb") as reqf:
+                reqf.write(data)
         body = body_for(data, port)
         try:
             conn.sendall(
@@ -91,12 +96,13 @@ def handle(conn, port, logf, lock):
 def main():
     srv, port = bind_ephemeral()
     lock = threading.Lock()
+    seq = [0]
     with open(sys.argv[1], "wb") as logf:
         print("PORT %d" % port, flush=True)
         while True:
             conn, _ = srv.accept()
             threading.Thread(
-                target=handle, args=(conn, port, logf, lock), daemon=True
+                target=handle, args=(conn, port, logf, lock, seq), daemon=True
             ).start()
 
 


### PR DESCRIPTION
The engine wrote its own `Host`, `From`, `User-Agent`, `Accept`, `Accept-Language`, `Accept-Encoding` and `Authorization` lines, then appended the `-%X` block verbatim without looking at what the request already carried. A `User-Agent` typed into WinHTTrack's or Android's extra-headers box went out on two lines, and the server was free to honour either one, so the identity it saw need not be the one the box showed.

Each of those lines is now skipped when the block already names that field, and the user's line wins. The predicate reads a raw string out of user config, so it matches at the start of a line only, case-insensitively, and it allocates nothing. Whitespace before the colon is rejected rather than tolerated: RFC 7230 forbids it, and a server that drops such a line would otherwise leave the request with no header at all. A folded continuation line never starts a field, and a name that prefixes or suffixes another does not answer for it, so `Accept-Encoding` in the box must not silence the engine's `Accept`.

Test 326 covers that through a new `-#test=headerfield`, then puts each field in the box for real and diffs the request bytes against the box-free crawl, which is where a duplicate the engine believes it never wrote shows up.

Closes #1337