### PR TITLE
Six more headers the engine writes are still sent twice

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -950,6 +950,60 @@ hts_boolean http_headers_have_field(const char *headers,
   return HTS_FALSE;
 }
 
+/* Dropping a line drops its folded continuations too: kept, that value would
+   attach to whichever header precedes it in the request. */
+static void append_custom_headers(buff_struct *bstr, const char *headers) {
+  const size_t base = bstr->pos;
+  hts_boolean keep = HTS_TRUE;
+  const char *line;
+
+  for (line = headers; *line != '\0';) {
+    const char *eol = line;
+    const char *next;
+
+    while (*eol != '\0' && *eol != '\r' && *eol != '\n')
+      eol++;
+    next = eol;
+    if (next[0] == '\r' && next[1] == '\n')
+      next += 2;
+    else if (*next != '\0')
+      next++;
+
+    if (*line != ' ' && *line != '\t') { /* not a folded continuation */
+      const char *colon = line;
+      char field[128];
+
+      keep = HTS_TRUE;
+      while (colon < eol && *colon != ':')
+        colon++;
+      if (colon > line && colon < eol &&
+          (size_t) (colon - line) < sizeof(field)) {
+        const size_t len = (size_t) (colon - line);
+        const char cut = bstr->buffer[base];
+
+        memcpy(field, line, len);
+        field[len] = '\0';
+        /* only what the engine wrote, so the box may repeat its own fields */
+        bstr->buffer[base] = '\0';
+        keep = !http_headers_have_field(bstr->buffer, field);
+        bstr->buffer[base] = cut;
+      }
+    }
+    if (keep)
+      print_buffer(bstr, "%.*s", (int) (next - line), line);
+    line = next;
+  }
+}
+
+void http_append_custom_headers(char *dst, size_t dst_size,
+                                const char *headers) {
+  buff_struct bstr = {dst, dst_size, 0};
+
+  assertf(dst != NULL && dst_size > 0);
+  bstr.pos = strlen(dst);
+  append_custom_headers(&bstr, headers);
+}
+
 // envoi d'une requète
 int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
                   const char *xsend, const char *adr, const char *fil,
@@ -960,6 +1014,9 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
 
   int direct_url = 0;           // ne pas analyser l'url (exemple: ftp://)
   const char *search_tag = NULL;
+
+  /* the extra-headers box wins: skip the engine's own line (#1337, #1340) */
+  const char *const custom = retour->req.headers;
 
   /* adr and the referer come off the network and can carry raw CR/LF; capped
      at their own source buffers, so the worst case emitted does not grow. */
@@ -1084,7 +1141,8 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
         !hts_proxy_is_socks(retour->req.proxy.name) &&
         !hts_proxy_is_connect(retour->req.proxy.name) &&
         strncmp(adr, "https://", 8) != 0) {
-      if (link_has_authorization(retour->req.proxy.name)) {     // et hop, authentification proxy!
+      if (link_has_authorization(retour->req.proxy.name) &&
+          !http_headers_have_field(custom, "Proxy-Authorization")) {
         const char *a = jump_identification_const(retour->req.proxy.name);
         const char *astart = jump_protocol_const(retour->req.proxy.name);
         char autorisation[1100];
@@ -1107,12 +1165,13 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
     if (referer_adr != NULL && referer_fil != NULL && strnotempty(referer_adr)
         && strnotempty(referer_fil)
       ) {                       // non vide
-      if ((strcmp(referer_adr, "file://") != 0)
-          && (                  /* no https referer to http urls */
-               (strncmp(referer_adr, "https://", 8) != 0)       /* referer is not https */
-               ||(strncmp(adr, "https://", 8) == 0)     /* or referer AND addresses are https */
-          )
-        ) {                     // PAS file://
+      if ((strcmp(referer_adr, "file://") != 0) &&
+          (/* no https referer to http urls */
+           (strncmp(referer_adr, "https://", 8) != 0) /* referer is not https */
+           || (strncmp(adr, "https://", 8) ==
+               0) /* or referer AND addresses are https */
+           ) &&
+          !http_headers_have_field(custom, "Referer")) { // PAS file://
         /* one escape per piece, so neither can outgrow its own source buffer */
         print_buffer(
             &bstr, "Referer: http://%s",
@@ -1123,7 +1182,8 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
       }
     }
     // HTTP field: referer
-    else if (strnotempty(retour->req.referer)) {
+    else if (strnotempty(retour->req.referer) &&
+             !http_headers_have_field(custom, "Referer")) {
       print_buffer(&bstr, "Referer: %s"H_CRLF, retour->req.referer);
     }
     // POST?
@@ -1137,7 +1197,7 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
       }
     }
     // send stored cookies matching this host/path
-    if (cookie) {
+    if (cookie != NULL && !http_headers_have_field(custom, "Cookie")) {
       append_cookie_header(&bstr, cookie, jump_identification_const(adr), fil);
     }
     // gérer le keep-alive (garder socket)
@@ -1149,9 +1209,6 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
 
     {
       const char *real_adr = jump_identification_const(adr);
-
-      /* the extra-headers box wins: skip the engine's own line (#1337) */
-      const char *const custom = retour->req.headers;
 
       // Mandatory per RFC2616
       if (!direct_url &&
@@ -1228,9 +1285,9 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
       }
     }
 
-    // Custom header(s)
-    if (strnotempty(retour->req.headers)) {
-      print_buffer(&bstr, "%s", retour->req.headers);
+    // Custom header(s), minus the fields the request already carries
+    if (strnotempty(custom)) {
+      append_custom_headers(&bstr, custom);
     }
 
     // CRLF de fin d'en tête

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -1171,7 +1171,7 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
            || (strncmp(adr, "https://", 8) ==
                0) /* or referer AND addresses are https */
            ) &&
-          !http_headers_have_field(custom, "Referer")) { // PAS file://
+          !http_headers_have_field(custom, "Referer")) { // not file://
         /* one escape per piece, so neither can outgrow its own source buffer */
         print_buffer(
             &bstr, "Referer: http://%s",

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -219,6 +219,12 @@ int http_cookie_header(t_cookie *cookie, const char *domain, const char *path,
 hts_boolean http_headers_have_field(const char *headers,
                                     const char *field_name);
 
+/* Append the custom request-header block to dst, a NUL-terminated request being
+   built of capacity dst_size, minus every line whose field dst already carries
+   and that line's folded continuations. */
+void http_append_custom_headers(char *dst, size_t dst_size,
+                                const char *headers);
+
 /* Switch soc between blocking and non-blocking mode; false on failure, with
    errno (WSAGetLastError() on Windows) set. */
 hts_boolean socket_set_nonblocking(T_SOC soc, hts_boolean nonblocking);

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -219,9 +219,8 @@ int http_cookie_header(t_cookie *cookie, const char *domain, const char *path,
 hts_boolean http_headers_have_field(const char *headers,
                                     const char *field_name);
 
-/* Append the custom request-header block to dst, a NUL-terminated request being
-   built of capacity dst_size, minus every line whose field dst already carries
-   and that line's folded continuations. */
+/* Append the custom header block to dst (capacity dst_size), dropping any line
+   whose field dst carries plus its folded continuations. Aborts on overflow. */
 void http_append_custom_headers(char *dst, size_t dst_size,
                                 const char *headers);
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2757,6 +2757,40 @@ static int st_headerfield(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* What the custom header block appends to a request already carrying <request>
+   (#1340). CR and LF come back escaped, so a case stays one line. */
+static int st_headerdedup(httrackp *opt, int argc, char **argv) {
+  const size_t capacity = 16384;
+  char *req, *headers;
+  const char *appended;
+  size_t i;
+
+  (void) opt;
+  if (argc < 2) {
+    fprintf(stderr, "headerdedup: needs a request and a header block\n");
+    return 1;
+  }
+  req = malloct(capacity);
+  req[0] = '\0';
+  strlncatbuff(req, argv[0], capacity, capacity / 2);
+  appended = req + strlen(req);
+  /* exact-size copy so a sanitizer traps an over-read of the block */
+  headers = strdupt(argv[1]);
+  http_append_custom_headers(req, capacity, headers);
+  for (i = 0; appended[i] != '\0'; i++) {
+    if (appended[i] == '\r')
+      printf("\\r");
+    else if (appended[i] == '\n')
+      printf("\\n");
+    else
+      putchar(appended[i]);
+  }
+  printf("\n");
+  freet(headers);
+  freet(req);
+  return 0;
+}
+
 /* http_xfread1 must refuse an in-memory buffer whose size would exceed a 32-bit
    index (hostile Content-Length or endless stream) rather than allocate it.
    The guard returns before any socket read, so no real connection is needed. */
@@ -11603,6 +11637,9 @@ static const struct selftest_entry {
     {"headerfield", "<headers> <field>",
      "is <field> already present in the custom request-header block",
      st_headerfield},
+    {"headerdedup", "<request> <headers>",
+     "what the custom header block adds to a request that has some (#1340)",
+     st_headerdedup},
     {"headerlong", "[header-name:]",
      "over-long header value must not overflow the parse scratch",
      st_headerlong},

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2757,40 +2757,6 @@ static int st_headerfield(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-/* What the custom header block appends to a request already carrying <request>
-   (#1340). CR and LF come back escaped, so a case stays one line. */
-static int st_headerdedup(httrackp *opt, int argc, char **argv) {
-  const size_t capacity = 16384;
-  char *req, *headers;
-  const char *appended;
-  size_t i;
-
-  (void) opt;
-  if (argc < 2) {
-    fprintf(stderr, "headerdedup: needs a request and a header block\n");
-    return 1;
-  }
-  req = malloct(capacity);
-  req[0] = '\0';
-  strlncatbuff(req, argv[0], capacity, capacity / 2);
-  appended = req + strlen(req);
-  /* exact-size copy so a sanitizer traps an over-read of the block */
-  headers = strdupt(argv[1]);
-  http_append_custom_headers(req, capacity, headers);
-  for (i = 0; appended[i] != '\0'; i++) {
-    if (appended[i] == '\r')
-      printf("\\r");
-    else if (appended[i] == '\n')
-      printf("\\n");
-    else
-      putchar(appended[i]);
-  }
-  printf("\n");
-  freet(headers);
-  freet(req);
-  return 0;
-}
-
 /* http_xfread1 must refuse an in-memory buffer whose size would exceed a 32-bit
    index (hostile Content-Length or endless stream) rather than allocate it.
    The guard returns before any socket read, so no real connection is needed. */
@@ -2890,6 +2856,50 @@ static size_t st_decode_body(const char *arg, char *buf, size_t size) {
   }
   buf[n] = '\0';
   return n;
+}
+
+/* What the custom header block appends to a request already carrying <request>
+   (#1340). CR and LF come back escaped, so a case stays one line. */
+static int st_headerdedup(httrackp *opt, int argc, char **argv) {
+  const size_t half = 8192;
+  char *req, *tmp, *headers;
+  const char *appended;
+  size_t i, reqlen, blocklen;
+
+  (void) opt;
+  if (argc < 2) {
+    fprintf(stderr, "headerdedup: needs a request and a header block\n");
+    return 1;
+  }
+  req = malloct(2 * half);
+  tmp = malloct(half);
+  reqlen = st_decode_body(argv[0], req, half);
+  blocklen = st_decode_body(argv[1], tmp, half);
+  /* st_decode_body clips, and a clipped case grades an input nobody wrote */
+  if (reqlen + 1 >= half || blocklen + 1 >= half) {
+    fprintf(stderr, "headerdedup: argument longer than %d bytes\n",
+            (int) half - 2);
+    freet(tmp);
+    freet(req);
+    return 1;
+  }
+  appended = req + reqlen;
+  /* exact-size copy so a sanitizer traps an over-read of the block */
+  headers = strdupt(tmp);
+  freet(tmp);
+  http_append_custom_headers(req, 2 * half, headers);
+  for (i = 0; appended[i] != '\0'; i++) {
+    if (appended[i] == '\r')
+      printf("\\r");
+    else if (appended[i] == '\n')
+      printf("\\n");
+    else
+      putchar(appended[i]);
+  }
+  printf("\n");
+  freet(headers);
+  freet(req);
+  return 0;
 }
 
 static int st_sniff(httrackp *opt, int argc, char **argv) {

--- a/tests/328_engine-header-dedup-rest.test
+++ b/tests/328_engine-header-dedup-rest.test
@@ -1,9 +1,7 @@
 #!/bin/bash
 #
-# The extra-headers box (-%X) against the six headers #1337 left out: the box
-# wins for Proxy-Authorization, Referer and Cookie, the engine wins for
-# Content-length, Connection and the conditional lines it sends inside xsend
-# (#1340). The walk on its own first, then the wire.
+# The six headers #1337 left out: the box wins for Proxy-Authorization, Referer
+# and Cookie, the engine for Content-length, Connection and xsend's own (#1340).
 
 set -euo pipefail
 
@@ -15,9 +13,14 @@ LF=$'\n'
 CRLF=$'\r\n'
 TAB=$'\t'
 
-# What the box appends to a request already carrying REQ, with CR and LF escaped.
+# -v, or od folds a run of identical lines into a "*" and the bytes are lost
+tohex() { printf '%s' "$1" | od -An -v -t x1 | tr -d '[:space:]'; }
+
+# What the box appends to a request already carrying REQ, with CR and LF escaped
+# in the answer. Both arguments travel as hex: Windows reads the batch script in
+# text mode, which would turn every CRLF in them into a bare LF.
 hd() { # hd WANT REQ BLOCK
-    selftest_queue "$1" headerdedup "$2" "$3"
+    selftest_queue "$1" headerdedup "hex:$(tohex "$2")" "hex:$(tohex "$3")"
 }
 
 req="GET /plain.html HTTP/1.1${CRLF}Connection: close${CRLF}Host: h${CRLF}"
@@ -36,6 +39,9 @@ hd 'X-B: 2\r\n' "$req" "Connection: x$CRLF${TAB}folded${CRLF}X-B: 2$CRLF"
 hd '' "$req" "Connection: x${CRLF} one${CRLF}${TAB}two$CRLF"
 # a kept line keeps its own
 hd 'X-A: 1\r\n more\r\n' "$req" "X-A: 1$CRLF more$CRLF"
+# a block opening on a folded line has no field to be judged against, and went
+# out before the walk existed
+hd ' orphan\r\nX-A: 1\r\n' "$req" " orphan${CRLF}X-A: 1$CRLF"
 # the box may repeat a field of its own: only the engine's lines are probed
 hd 'X-A: 1\r\nX-A: 2\r\n' "$req" "X-A: 1${CRLF}X-A: 2$CRLF"
 # nothing a name can be read from is left alone, and the next line is judged
@@ -212,6 +218,7 @@ assert_same nokeep boxconn
 
 # the undocumented >post: tag, whose length must keep describing the body
 probe post 1 "$base?>post:" -%X 'Content-Length: 99'
+assert_eq POST "$(sed -n '1s/ .*//p' "$tmpdir/post.req")" 'post: the method'
 assert_eq 1 "$(count_lines '^[Cc]ontent-[Ll]ength:' "$tmpdir/post.req")" \
     'post: Content-length lines'
 assert_value post Content-length 0

--- a/tests/328_engine-header-dedup-rest.test
+++ b/tests/328_engine-header-dedup-rest.test
@@ -1,0 +1,235 @@
+#!/bin/bash
+#
+# The extra-headers box (-%X) against the six headers #1337 left out: the box
+# wins for Proxy-Authorization, Referer and Cookie, the engine wins for
+# Content-length, Connection and the conditional lines it sends inside xsend
+# (#1340). The walk on its own first, then the wire.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+CR=$'\r'
+LF=$'\n'
+CRLF=$'\r\n'
+TAB=$'\t'
+
+# What the box appends to a request already carrying REQ, with CR and LF escaped.
+hd() { # hd WANT REQ BLOCK
+    selftest_queue "$1" headerdedup "$2" "$3"
+}
+
+req="GET /plain.html HTTP/1.1${CRLF}Connection: close${CRLF}Host: h${CRLF}"
+
+# A field the request lacks goes out untouched; one it carries does not.
+hd '' "$req" ''
+hd 'X-A: 1\r\n' "$req" "X-A: 1$CRLF"
+hd '' "$req" "Connection: keep-alive$CRLF"
+hd 'X-A: 1\r\n' "$req" "Connection: keep-alive${CRLF}X-A: 1$CRLF"
+# field names are case-insensitive, and the engine spells this one "length"
+hd '' "GET /p HTTP/1.1${CRLF}Content-length: 0$CRLF" "Content-Length: 99$CRLF"
+# a dropped line takes its folded continuations with it: kept, they would
+# attach to whichever header precedes them in the request
+hd 'X-B: 2\r\n' "$req" "Connection: keep-alive$CRLF X-Injected: yes${CRLF}X-B: 2$CRLF"
+hd 'X-B: 2\r\n' "$req" "Connection: x$CRLF${TAB}folded${CRLF}X-B: 2$CRLF"
+hd '' "$req" "Connection: x${CRLF} one${CRLF}${TAB}two$CRLF"
+# a kept line keeps its own
+hd 'X-A: 1\r\n more\r\n' "$req" "X-A: 1$CRLF more$CRLF"
+# the box may repeat a field of its own: only the engine's lines are probed
+hd 'X-A: 1\r\nX-A: 2\r\n' "$req" "X-A: 1${CRLF}X-A: 2$CRLF"
+# nothing a name can be read from is left alone, and the next line is judged
+# on its own
+hd 'garbage\r\n' "$req" "garbage${CRLF}Connection: x$CRLF"
+hd 'garbage\r\n' "$req" "Connection: x${CRLF}garbage$CRLF"
+hd ':oops\r\n' "$req" ":oops$CRLF"
+hd 'Connection : x\r\n' "$req" "Connection : x$CRLF"
+hd '\r\nX-A: 1\r\n' "$req" "${CRLF}X-A: 1$CRLF"
+# the request line answers for no field name
+hd 'GET: 1\r\n' "GET /x HTTP/1.1$CRLF" "GET: 1$CRLF"
+# an embedder fills opt->headers itself, so neither a final terminator nor CRLF
+# endings are guaranteed
+hd 'X-A: 1' "$req" 'X-A: 1'
+hd '' "$req" 'Connection: x'
+hd 'X-A: 1\n' "$req" "Connection: x${LF}X-A: 1$LF"
+hd 'X-A: 1\r' "$req" "Connection: x${CR}X-A: 1$CR"
+# the resume and conditional lines ride in the opaque xsend blob, which the walk
+# reads back off the request rather than unpacking
+hd '' "GET /x HTTP/1.1${CRLF}Range: bytes=100-$CRLF" "Range: bytes=0-1$CRLF"
+hd 'Range: bytes=0-1\r\n' "$req" "Range: bytes=0-1$CRLF"
+hd '' "GET /x HTTP/1.1${CRLF}If-None-Match: \"e\"${CRLF}If-Modified-Since: Mon$CRLF" \
+    "If-None-Match: \"box\"${CRLF}If-Modified-Since: Tue$CRLF"
+# a name too long for the probe's scratch is kept, and no header the engine
+# writes is anywhere near that long
+long=$(printf 'X%.0s' {1..200})
+hd "$long: 1\r\n" "$req" "$long: 1$CRLF"
+hd "$long: 1\r\n" "$req" "Connection: x${CRLF}$long: 1$CRLF"
+
+selftest_run_queued
+
+python=$(find_python) || skip "python3 missing"
+
+server=$(nativepath "$top_srcdir/tests/header-injection-server.py")
+tmpdir=$(mktemp -d)
+serverpid=
+wire=$tmpdir/wire
+nreq=0
+
+cleanup() {
+    stop_server "$serverpid"
+    rm -rf "$tmpdir"
+}
+cleanup_push cleanup
+
+count_lines() { # count_lines RE FILE
+    grep -c "$1" "$2" || true
+}
+
+count_bytes() { # count_bytes BYTE FILE
+    tr -dc "$1" <"$2" | wc -c | tr -d '[:space:]'
+}
+
+value_of() { # value_of FIELD FILE
+    sed -n "s/^$1: //p" "$2" | tr -d '\r'
+}
+
+# The field names of a request, in order. A folded line starts with a space and
+# so names nothing, which is what makes a grafted continuation visible here.
+fields_of() { # fields_of FILE
+    sed -n 's/^\([A-Za-z0-9-]*\):.*/\1/p' "$1" | tr '\n' ' ' | sed 's/ *$//'
+}
+
+# One crawl, leaving each of its COUNT requests in $tmpdir/TAG.<n>.req and the
+# last of them in $tmpdir/TAG.req.
+probe() { # probe TAG COUNT URL [extra httrack args...]
+    local tag=$1 count=$2 url=$3 rc=0 i
+    shift 3
+    run_with_timeout 90 httrack "$url" -O "$tmpdir/$tag.mirror" -c1 --robots=0 \
+        --retries=0 --quiet -%v0 -F EngineUA/1.0 -%E tester@example.test "$@" \
+        >>"$tmpdir/log" 2>&1 || rc=$?
+    test "$rc" -eq 0 || fail "$tag: the crawl exited $rc"
+    assert_eq "$((nreq + count))" "$(count_lines '^=== REQUEST ===$' "$wire")" \
+        "$tag: requests logged"
+    for ((i = 1; i <= count; i++)); do
+        # the server's own byte-for-byte copy, never the log split by a text tool
+        cp "$wire.$((nreq + i))" "$tmpdir/$tag.$i.req"
+    done
+    nreq=$((nreq + count))
+    cp "$tmpdir/$tag.$count.req" "$tmpdir/$tag.req"
+    # the last header line's CRLF and the blank CRLF that closes the block; the
+    # fixture appends nothing to a per-request file. Hex with all whitespace
+    # dropped, since od's column padding differs between GNU and BSD.
+    assert_eq 0d0a0d0a \
+        "$(tail -c 4 "$tmpdir/$tag.req" | od -An -t x1 | tr -d '[:space:]')" \
+        "$tag: the CRLF CRLF ending the request"
+    # so every LF in between is the LF of a CRLF pair
+    assert_eq "$(count_bytes "$CR" "$tmpdir/$tag.req")" \
+        "$(count_bytes "$LF" "$tmpdir/$tag.req")" "$tag: CR count against LF count"
+}
+
+assert_once() { # assert_once TAG FIELD
+    assert_eq 1 "$(count_lines "^$2:" "$tmpdir/$1.req")" "$1: $2 lines"
+}
+
+assert_value() { # assert_value TAG FIELD VALUE
+    assert_eq "$3" "$(value_of "$2" "$tmpdir/$1.req")" "$1: $2"
+}
+
+assert_same() { # assert_same BASE TAG
+    diff "$tmpdir/$1.req" "$tmpdir/$2.req" ||
+        fail "$2: the request differs from $1's"
+}
+
+# The rest of the request is byte-identical to BASE's: RE names the only lines
+# allowed to differ. Compared as files, since a command substitution would eat a
+# lost trailing newline on both sides alike.
+assert_same_but() { # assert_same_but BASE TAG RE
+    local base=$tmpdir/$2.base got=$tmpdir/$2.got
+    grep -Ev "$3" "$tmpdir/$1.req" >"$base" || true
+    grep -Ev "$3" "$tmpdir/$2.req" >"$got" || true
+    diff "$base" "$got" || fail "$2: the request outside $3 differs from $1's"
+}
+
+"$python" "$server" "$wire" >"$tmpdir/server.out" 2>"$tmpdir/server.err" &
+serverpid=$!
+port=$(discover_server_port "$tmpdir/server.out" "$serverpid") || exit 1
+
+base=http://127.0.0.1:$port/plain.html
+
+# An empty box leaves the request as the engine writes it, in that order.
+probe plain 1 "$base"
+assert_eq 'Connection Host From User-Agent Accept Accept-Language Accept-Encoding' \
+    "$(fields_of "$tmpdir/plain.req")" 'plain: the engine block'
+assert_value plain Connection keep-alive
+
+# --- the box wins ------------------------------------------------------------
+
+probe referer 1 "$base" -%R http://engine.example/
+assert_value referer Referer http://engine.example/
+probe boxreferer 1 "$base" -%R http://engine.example/ -%X 'Referer: http://box.example/'
+assert_once boxreferer Referer
+assert_value boxreferer Referer http://box.example/
+assert_same_but plain boxreferer '^Referer:'
+
+# the other Referer site: a page reached by a link refers to the page that
+# linked to it
+probe hop 2 "http://127.0.0.1:$port/hop.html"
+assert_value hop Referer "http://127.0.0.1:$port/hop.html"
+probe boxhop 2 "http://127.0.0.1:$port/hop.html" -%X 'Referer: http://box.example/'
+assert_once boxhop Referer
+assert_value boxhop Referer http://box.example/
+assert_same_but hop boxhop '^Referer:'
+
+jar=$tmpdir/cookies.txt
+printf '127.0.0.1:%s\tTRUE\t/\tFALSE\t1999999999\tsession\topensesame\n' \
+    "$port" >"$jar"
+probe cookie 1 "$base" --cookies-file "$jar"
+assert_value cookie Cookie session=opensesame
+probe boxcookie 1 "$base" --cookies-file "$jar" -%X 'Cookie: box=1'
+assert_once boxcookie Cookie
+assert_value boxcookie Cookie box=1
+assert_same_but cookie boxcookie '^Cookie:'
+
+# base64("user:pass"), per RFC 7617
+probe proxy 1 http://plain.example/leaf.html -P "user:pass@127.0.0.1:$port" '+*'
+assert_value proxy Proxy-Authorization 'Basic dXNlcjpwYXNz'
+probe boxproxy 1 http://plain.example/leaf.html -P "user:pass@127.0.0.1:$port" '+*' \
+    -%X 'Proxy-Authorization: Basic Ym94'
+assert_once boxproxy Proxy-Authorization
+assert_value boxproxy Proxy-Authorization 'Basic Ym94'
+assert_same_but proxy boxproxy '^Proxy-Authorization:'
+
+# --- the engine wins ---------------------------------------------------------
+
+# -%k0 makes the engine write "close": the box asking for the opposite must not
+# leave an intermediary two contradictory hop-by-hop instructions
+probe nokeep 1 "$base" -%k0
+assert_value nokeep Connection close
+probe boxconn 1 "$base" -%k0 -%X 'Connection: keep-alive'
+assert_once boxconn Connection
+assert_value boxconn Connection close
+assert_same nokeep boxconn
+
+# the undocumented >post: tag, whose length must keep describing the body
+probe post 1 "$base?>post:" -%X 'Content-Length: 99'
+assert_eq 1 "$(count_lines '^[Cc]ontent-[Ll]ength:' "$tmpdir/post.req")" \
+    'post: Content-length lines'
+assert_value post Content-length 0
+
+# nothing is resuming here, so a typed Range is the only one and goes out
+probe range 1 "$base" -%X 'Range: bytes=0-1'
+assert_once range Range
+assert_value range Range bytes=0-1
+assert_same_but plain range '^Range:'
+
+# --- a dropped line takes its continuations with it --------------------------
+
+probe fold 1 "$base" -%k0 -%X 'Connection: keep-alive' -%X ' X-Injected: yes'
+assert_eq 0 "$(count_lines 'X-Injected' "$tmpdir/fold.req")" 'fold: the folded line'
+assert_value fold Connection close
+assert_same nokeep fold
+
+probe keptfold 1 "$base" -%X 'X-Fold: a' -%X ' b'
+assert_eq 'Connection Host From User-Agent Accept Accept-Language Accept-Encoding X-Fold' \
+    "$(fields_of "$tmpdir/keptfold.req")" 'keptfold: the field order'
+assert_eq 1 "$(count_lines "^ b$CR\$" "$tmpdir/keptfold.req")" 'keptfold: the folded line'

--- a/tests/328_engine-header-dedup-rest.test
+++ b/tests/328_engine-header-dedup-rest.test
@@ -231,12 +231,21 @@ assert_same_but plain range '^Range:'
 
 # --- a dropped line takes its continuations with it --------------------------
 
-probe fold 1 "$base" -%k0 -%X 'Connection: keep-alive' -%X ' X-Injected: yes'
-assert_eq 0 "$(count_lines 'X-Injected' "$tmpdir/fold.req")" 'fold: the folded line'
-assert_value fold Connection close
-assert_same nokeep fold
-
-probe keptfold 1 "$base" -%X 'X-Fold: a' -%X ' b'
+# The control for the drop probe below, and the probe for whether argv here
+# carries the leading space at all: a box line the shell unfolded on the way in
+# would leave that probe asserting the absence of a header nobody folded.
+probe keptfold 1 "$base" -%X 'X-Fold: a' -%X ' zzfold'
 assert_eq 'Connection Host From User-Agent Accept Accept-Language Accept-Encoding X-Fold' \
     "$(fields_of "$tmpdir/keptfold.req")" 'keptfold: the field order'
-assert_eq 1 "$(count_lines "^ b$CR\$" "$tmpdir/keptfold.req")" 'keptfold: the folded line'
+
+if test "$(count_lines '^ zzfold' "$tmpdir/keptfold.req")" -eq 1; then
+    probe fold 1 "$base" -%k0 -%X 'Connection: keep-alive' -%X ' X-Injected: yes'
+    assert_eq 0 "$(count_lines 'X-Injected' "$tmpdir/fold.req")" 'fold: the folded line'
+    assert_value fold Connection close
+    assert_same nokeep fold
+else
+    # the hex cases above still fold, since the batch script is not argv
+    unfolded=$(count_lines zzfold "$tmpdir/keptfold.req")
+    echo "328: argv here drops the space that folds a line ($unfolded flat)," >&2
+    echo "328: so the fold runs through -#test=headerdedup only" >&2
+fi

--- a/tests/header-injection-server.py
+++ b/tests/header-injection-server.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Raw-socket probe for 159_local-header-injection and 326_engine-header-dedup.
+"""Raw-socket probe for the header-injection and header-dedup tests.
 
 Speaks HTTP off the socket so a split header line stays visible; serves an
 origin-form site and an http-proxy absolute-URI one on the same port.
@@ -55,6 +55,9 @@ def body_for(request, port):
         return root_page(port)
     if b"/x" in line:
         return POISON_PAGE
+    # one hop, so the second request of a crawl carries a Referer (328)
+    if b"/hop.html" in line:
+        return page('<a href="/plain.html">plain</a>')
     # the proxied pages link onward too, so a poisoned *host* becomes a referer
     if b"/p.html" in line:
         return page('<a href="/deep2.html">deep</a>')


### PR DESCRIPTION
#1337 covered the seven headers the engine writes in one block. Six others were left out, because "the user's line wins" is the wrong answer for half of them. Proxy-Authorization, Referer (both emission sites) and Cookie now take the same guard. Content-length, Connection and the resume and conditional lines that ride in the opaque `xsend` blob keep the engine's value instead: a typed length that disagrees with the body about to be sent, or a `Range:` beside the one a resume computed, costs more than a duplicate line.

One mechanism covers both. The block is no longer appended verbatim. It goes out line by line, and a line whose field the request already carries is dropped, tested against the request as built rather than against a list of field names. That reaches the `xsend` lines without unpacking them, and it drops a typed `Range:` only when the engine wrote one, so a `Range:` on an ordinary fetch still goes out. The other class works because its guards remove the engine's line first, leaving the user's with nothing to conflict with. A dropped line takes its folded continuation lines with it; keeping one would graft that value onto whichever header precedes it. Test 328 grades real requests off the wire for each of the six, and drives the walk through a new `-#test=headerdedup` for what a crawl cannot produce: a block opening on a folded line, one with no trailing CRLF, lone CR endings, a field name too long to probe. The box-free request is pinned to the exact fields the engine writes, in order.

Closes #1340