### PR TITLE
Two spellings of rep(), and an audit flag asserting the opposite of its name

### DIFF
--- a/tests/01_engine-cmdline.test
+++ b/tests/01_engine-cmdline.test
@@ -18,10 +18,6 @@ cleanup_push rm -rf "$tmp"
 echo '<html><body>hello</body></html>' >"$tmp/index.html"
 
 # a string of N repeated 'A' characters
-nchars() {
-    printf 'A%.0s' $(seq 1 "$1")
-}
-
 # crawl the local fixture with the given extra args; leaves the exit status in RC
 run() {
     local out="$1"
@@ -65,7 +61,7 @@ continued() {
 
 # a value past the old 126/256 caps but within the cap is accepted, on both the
 # short and long form of each option
-long=$(nchars 900)
+long=$(repeat_chars 900 A)
 run "$tmp/ua-s" -F "$long"
 accepted "$tmp/ua-s" "#152: long -F user-agent rejected or crashed"
 run "$tmp/ua-l" --user-agent "$long"
@@ -77,12 +73,12 @@ accepted "$tmp/hd-l" "#152: long --headers rejected or crashed"
 
 # a value just under the cap (>1000) must not overflow the long-form alias
 # scratch buffer (the param[] copy in optalias_check)
-run "$tmp/ua-n" --user-agent "$(nchars 1010)"
+run "$tmp/ua-n" --user-agent "$(repeat_chars 1010 A)"
 accepted "$tmp/ua-n" "#152: near-cap --user-agent overflowed the param[] buffer"
 
 # a value over the cap is refused cleanly (graceful error, not a SIGABRT), on
 # both forms
-over=$(nchars 1100)
+over=$(repeat_chars 1100 A)
 run "$tmp/ov-s" -F "$over"
 refused "#152: over-cap -F not refused cleanly"
 run "$tmp/ov-l" --user-agent "$over"
@@ -100,7 +96,7 @@ run_only "$tmp/q-lone" '"'
 refused "lone-quote argument not refused cleanly"
 # A dangling quote on an argument at the cap must not overflow the "Missing
 # quote in %s" panic buffer: the prefix plus a 1023-byte argument overran it.
-run_only "$tmp/q-long" "\"$(nchars 1022)"
+run_only "$tmp/q-long" "\"$(repeat_chars 1022 A)"
 refused "near-cap dangling-quote argument overflowed the panic buffer"
 
 # --pause (#185): valid MIN[:MAX] accepted; malformed, reversed, over-range and

--- a/tests/01_engine-ftp-userpass.test
+++ b/tests/01_engine-ftp-userpass.test
@@ -10,15 +10,12 @@ set -euo pipefail
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpuser.XXXXXX") || exit 1
 cleanup_push rm -rf "${tmpdir}"
-trap 'exit 1' HUP INT QUIT TERM
 
 out=$(httrack -O "${tmpdir}/st" "-#test=ftp-userpass" run 2>&1) ||
     fail "self-test exited non-zero: ${out}"
 grep -q "ftp-userpass self-test OK" <<<"${out}" || fail "unexpected output: ${out}"
 
 # The reachable half: a URL carries the userinfo straight into user[256]/pass[256].
-rep() { awk -v n="$1" 'BEGIN { while (i++ < n) printf "a" }'; }
-
 probe() {
     rm -rf "${tmpdir}/mir"
     httrack "ftp://$1@127.0.0.1:1/f.txt" -O "${tmpdir}/mir" -q >/dev/null 2>&1 ||
@@ -27,14 +24,14 @@ probe() {
 }
 
 # The bare name has no ':' to bound it, only the '@', and is the worse branch.
-for u in "$(rep 256):pw" "u:$(rep 256)" "$(rep 256)"; do
+for u in "$(repeat_chars 256):pw" "u:$(repeat_chars 256)" "$(repeat_chars 256)"; do
     log=$(probe "${u}")
     grep -q "FTP user name or password too long" <<<"${log}" ||
         fail "over-long userinfo was not refused: ${log}"
 done
 
 # 255 still fits, and a plain login is the outsider a widened gate would refuse.
-for u in "$(rep 255):pw" "u:$(rep 255)" "$(rep 255)" "bob:secret"; do
+for u in "$(repeat_chars 255):pw" "u:$(repeat_chars 255)" "$(repeat_chars 255)" "bob:secret"; do
     log=$(probe "${u}")
     grep -q "Unable to connect to the server" <<<"${log}" ||
         fail "userinfo that fits did not reach the connect: ${log}"

--- a/tests/117_local-proxytrack-ndx-cursor.test
+++ b/tests/117_local-proxytrack-ndx-cursor.test
@@ -12,8 +12,6 @@ dir=$(mktemp -d)
 cleanup() { rm -rf "$dir"; }
 cleanup_push cleanup
 
-pad() { printf "%${1}s" '' | tr ' ' "$2"; }
-
 hdr() { printf 'CACHE-1.4\nWed, 01 Jan 2025 00:00:00 GMT\n'; }
 
 # Number of cache keys proxytrack built from index $1.
@@ -37,8 +35,8 @@ items() {
 for at in 1023 1024; do
     {
         hdr
-        printf '%sA\n\n10\n' "$(pad "$at" h)"
-        printf '%sB\n\n20\n' "$(pad "$at" h)"
+        printf '%sA\n\n10\n' "$(repeat_chars "$at" h)"
+        printf '%sB\n\n20\n' "$(repeat_chars "$at" h)"
     } >"$dir/first-$at.ndx"
 done
 got=$(items "$dir/first-1023.ndx")
@@ -52,7 +50,7 @@ test "$got" = 2 || fail "URLs differing on the 1024 bound gave $got keys, expect
 # fourth entry out of these same bytes (#1294).
 for at in 1 256 257 258; do
     {
-        pad "$at" C
+        repeat_chars "$at" C
         printf '\na/1\nx\n1\nb/2\ny\n2\nc/3\nz\n3\n'
     } >"$dir/header-$at.ndx"
 done
@@ -65,8 +63,8 @@ done
 # ending right there, so the byte stepped over is the terminating NUL.
 {
     hdr
-    printf '%s\n' "$(pad 10 h)"
-    pad 2037 f
+    printf '%s\n' "$(repeat_chars 10 h)"
+    repeat_chars 2037 f
 } >"$dir/second.ndx"
 got=$(items "$dir/second.ndx")
 test "$got" = 1 || fail "second half at its bound gave $got keys, expected 1"
@@ -75,7 +73,7 @@ test "$got" = 1 || fail "second half at its bound gave $got keys, expected 1"
 {
     hdr
     printf 'h/1\nx\n'
-    pad 200 9
+    repeat_chars 200 9
 } >"$dir/position.ndx"
 got=$(items "$dir/position.ndx")
 test "$got" = 1 || fail "position field at its bound gave $got keys, expected 1"
@@ -84,7 +82,7 @@ test "$got" = 1 || fail "position field at its bound gave $got keys, expected 1"
 # newline stops on the same terminating NUL.
 {
     printf '0\nSKIP\n'
-    pad 1023 h
+    repeat_chars 1023 h
 } >"$dir/short.ndx"
 got=$(items "$dir/short.ndx")
 test "$got" = 1 || fail "index ending mid-field gave $got keys, expected 1"
@@ -92,7 +90,7 @@ test "$got" = 1 || fail "index ending mid-field gave $got keys, expected 1"
 # The reported reproducer: both halves full, and the walk reaches the last line.
 {
     hdr
-    printf '%s\n%s\n0\n' "$(pad 1024 h)" "$(pad 1024 f)"
+    printf '%s\n%s\n0\n' "$(repeat_chars 1024 h)" "$(repeat_chars 1024 f)"
 } >"$dir/tail.ndx"
 got=$(items "$dir/tail.ndx")
 test "$got" = 1 || fail "index ending on a full-length entry gave $got keys, expected 1"

--- a/tests/118_local-proxytrack-arcwrite.test
+++ b/tests/118_local-proxytrack-arcwrite.test
@@ -17,9 +17,7 @@ cleanup_push cleanup
 HDRMAX=8192
 BODY=BODYMARKER
 
-pad() { printf "%${1}s" '' | tr ' ' "$2"; }
-
-P1000=$(pad 1000 P)
+P1000=$(repeat_chars 1000 P)
 
 # Header lines contributing exactly $1 bytes to the entry's stored headers: the
 # reader rebuilds each as "name: value\r\n", and its line buffer holds 2048.
@@ -99,7 +97,7 @@ grep -q 'clipped to' "$dir/log" ||
 # Three sources at once, each with its own limit: the reason phrase is cut at
 # msg[1024], the shorter location not at all, the passthrough takes what is
 # left. One all-fields bound gets at least one of them wrong.
-build_arc "$(pad 1200 M)" "http://example.com/$(pad 1500 L)" 5000
+build_arc "$(repeat_chars 1200 M)" "http://example.com/$(repeat_chars 1500 L)" 5000
 convert_check "long reason, location and headers"
 got=$(runlen "$dir/out.arc" M)
 test "${got:-0}" = 1023 || fail "reason phrase kept ${got:-0} bytes, expected 1023"

--- a/tests/183_altstack-worker.test
+++ b/tests/183_altstack-worker.test
@@ -102,7 +102,6 @@ fi
 
 tmp=$(mktemp -d)
 cleanup_push rm -rf "$tmp"
-trap 'exit 1' HUP INT TERM
 
 # See 181: the shim loads ahead of libasan and allocates nothing.
 export ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}verify_asan_link_order=0"

--- a/tests/224_engine-ftp-cmdlen.test
+++ b/tests/224_engine-ftp-cmdlen.test
@@ -9,15 +9,12 @@ set -euo pipefail
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpcmdlen.XXXXXX") || exit 1
 cleanup_push rm -rf "${tmpdir}"
-trap 'exit 1' HUP INT QUIT TERM
 
 out=$(httrack -O "${tmpdir}/st" "-#test=ftp-cmdlen" run 2>&1) ||
     fail "self-test exited non-zero: ${out}"
 grep -q "ftp-cmdlen self-test OK" <<<"${out}" || fail "unexpected output: ${out}"
 
 # The reachable half: the copy into _adr[256] aborted on a long host.
-rep() { awk -v n="$1" 'BEGIN { while (i++ < n) printf "a" }'; }
-
 probe_host() {
     rm -rf "${tmpdir}/host"
     httrack "ftp://$1/f.txt" -O "${tmpdir}/host" -q >/dev/null 2>&1 ||
@@ -26,13 +23,13 @@ probe_host() {
 }
 
 for n in 256 257 300; do
-    log=$(probe_host "$(rep "${n}")")
+    log=$(probe_host "$(repeat_chars "${n}")")
     grep -q "Host name too long" <<<"${log}" ||
         fail "a ${n}-byte host was not rejected: ${log}"
 done
 
 # 255 still fits _adr[256]; 127.0.0.1:1 is the outsider a widened gate swallows.
-log=$(probe_host "$(rep 255)")
+log=$(probe_host "$(repeat_chars 255)")
 grep -q "Unable to get server's address" <<<"${log}" ||
     fail "a 255-byte host did not reach the resolver: ${log}"
 log=$(probe_host "127.0.0.1:1")

--- a/tests/230_local-ftp-userpass.test
+++ b/tests/230_local-ftp-userpass.test
@@ -37,8 +37,6 @@ serverpid=$!
 port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 
 ok() { echo "OK: $*"; }
-rep() { awk -v n="$2" -v c="$1" 'BEGIN { while (i++ < n) printf "%s", c }'; }
-
 crawl() {
     : >"$cmds"
     rm -rf "${out:?}"
@@ -59,8 +57,8 @@ ok "bob:secret reaches the server verbatim, and mirrors"
 
 # --- the longest userinfo that fits, byte for byte ---------------------------
 # 255 of each: a 256th byte is refused, so this is what the wire must carry.
-user=$(rep a 255)
-pass=$(rep b 255)
+user=$(repeat_chars 255 a)
+pass=$(repeat_chars 255 b)
 crawl "${user}:${pass}" || fail "the 255-byte login crawl never finished"
 sent=$(<"$cmds")
 grep -qxF "USER ${user}" <<<"$sent" ||
@@ -71,7 +69,7 @@ ok "a 255-byte user and password reach the server unclipped"
 
 # --- over-long userinfo never opens a session --------------------------------
 # The bare name has no ':' to bound it, only the '@', and is the worse branch.
-for u in "$(rep a 256):pw" "$(rep a 256)"; do
+for u in "$(repeat_chars 256 a):pw" "$(repeat_chars 256 a)"; do
     crawl "$u" || fail "the over-long crawl never finished"
     grep -aq "FTP user name or password too long" "${out}/hts-log.txt" ||
         fail "over-long userinfo was not refused: $(<"${out}/hts-log.txt")"

--- a/tests/302_filter-token-overflow.test
+++ b/tests/302_filter-token-overflow.test
@@ -18,10 +18,6 @@ cleanup_push rm -rf "$tmpdir"
 maxfilter=2047
 maxurl=2047
 
-rep() { # rep CHAR COUNT
-    printf "%${2}s" '' | tr ' ' "$1"
-}
-
 # Runs --why over a rules file and returns the verdict line alone.
 why() { # why RULE-FILE
     local out
@@ -33,7 +29,7 @@ why() { # why RULE-FILE
 
 # An over-long rule, then the one that decides.
 longrule() { # longrule LENGTH FILE
-    printf -- '-%s\n+*.png\n' "$(rep a "$1")" >"$2"
+    printf -- '-%s\n+*.png\n' "$(repeat_chars "$1" a)" >"$2"
 }
 
 # At the bound the rule is kept, so the one that decides is the second. The
@@ -63,7 +59,7 @@ assert_eq "http://www.example.com/a.png: accepted by rule #1 (+*.png)" \
     "$(why "$tmpdir/many.txt")" "5000 one-byte seeds"
 
 # The URL token beside it is copied by the same code and bounded on its own.
-printf 'http://www.example.com/%s\n+*.png\n' "$(rep a $((maxurl - 22)))" \
+printf 'http://www.example.com/%s\n+*.png\n' "$(repeat_chars $((maxurl - 22)) a)" \
     >"$tmpdir/longurl.txt"
 assert_eq "http://www.example.com/a.png: accepted by rule #1 (+*.png)" \
     "$(why "$tmpdir/longurl.txt")" "URL of $((maxurl + 1)) bytes"
@@ -81,7 +77,7 @@ echo '<html><body>seed</body></html>' >"$doc/index.html"
 local_server_start --root "$doc"
 
 # Through -%S, since every argv entry is already capped at HTS_CDLMAXSIZE.
-long="$BASEURL/$(rep a $((maxurl + 1 - ${#BASEURL} - 1)))"
+long="$BASEURL/$(repeat_chars $((maxurl + 1 - ${#BASEURL} - 1)) a)"
 assert_eq "$((maxurl + 1))" "${#long}" "seed one byte past the URL buffer"
 printf '%s\n' "$long" >"$tmpdir/seed.txt"
 local_crawl --log "$tmpdir/crawl.log" -O "$tmpdir/m" --quiet --robots=0 \

--- a/tests/307_cookies-file-longfield.test
+++ b/tests/307_cookies-file-longfield.test
@@ -17,8 +17,6 @@ site="$tmp/site"
 mkdir -p "$site"
 echo '<html>hello</html>' >"$site/index.html"
 
-pad() { printf '%*s' "$1" '' | tr ' ' "${2:-A}"; }
-
 # Netscape record, in the spelling cookie_save() writes back.
 rec() { # rec DOMAIN PATH NAME VALUE
     printf '%s\tTRUE\t%s\tFALSE\t1999999999\t%s\t%s\n' "$1" "$2" "$3" "$4"
@@ -30,23 +28,23 @@ rec() { # rec DOMAIN PATH NAME VALUE
 jar="$tmp/jar.txt"
 {
     rec www.example.com / GOODFIRST v1
-    rec "$(pad 2000)" / DOM2000 v
-    rec "$(pad 256)" / DOM256 v
-    rec "$(pad 255)" / DOM255 v
-    rec www.example.com "/$(pad 1999)" PATH2000 v
-    rec www.example.com "/$(pad 255)" PATH256 v
-    rec www.example.com "/$(pad 254)" PATH255 v
-    rec www.example.com / "NAME2000$(pad 1992)" v
-    rec www.example.com / "NAME1024$(pad 1016)" v
+    rec "$(repeat_chars 2000 A)" / DOM2000 v
+    rec "$(repeat_chars 256 A)" / DOM256 v
+    rec "$(repeat_chars 255 A)" / DOM255 v
+    rec www.example.com "/$(repeat_chars 1999 A)" PATH2000 v
+    rec www.example.com "/$(repeat_chars 255 A)" PATH256 v
+    rec www.example.com "/$(repeat_chars 254 A)" PATH255 v
+    rec www.example.com / "NAME2000$(repeat_chars 1992 A)" v
+    rec www.example.com / "NAME1024$(repeat_chars 1016 A)" v
     # fits cook_name[1024] but not cookie_add()'s own 256-byte cap, so the line
     # is gone for a second reason, which has to be reported too
-    rec www.example.com / "JARCAP$(pad 294)" v
+    rec www.example.com / "JARCAP$(repeat_chars 294 A)" v
     # cook_value[8192] is out of reach behind the line gate, so it is pinned
     # from below: neither of these may be refused for its value
-    rec www.example.com / BIGVAL "$(pad 500 v)"
-    rec www.example.com / BIGVAL7900 "$(pad 7900 v)"
+    rec www.example.com / BIGVAL "$(repeat_chars 500 v)"
+    rec www.example.com / BIGVAL7900 "$(repeat_chars 7900 v)"
     # 8049 bytes: over the line gate, under what rawlinput() reads in one go
-    rec www.example.com / LONGLINE "$(pad 8000 L)"
+    rec www.example.com / LONGLINE "$(repeat_chars 8000 L)"
     rec www.example.com / GOODLAST v2
 } >"$jar"
 
@@ -67,9 +65,9 @@ log=$(tr -d '\r' <"$out/hts-log.txt")
 # match whole lines: a clipping fix would still store the cookie name, and
 # only the rest of the line says the field was cut
 for want in "$(rec www.example.com / GOODFIRST v1)" \
-    "$(rec "$(pad 255)" / DOM255 v)" \
-    "$(rec www.example.com "/$(pad 254)" PATH255 v)" \
-    "$(rec www.example.com / BIGVAL "$(pad 500 v)")" \
+    "$(rec "$(repeat_chars 255 A)" / DOM255 v)" \
+    "$(rec www.example.com "/$(repeat_chars 254 A)" PATH255 v)" \
+    "$(rec www.example.com / BIGVAL "$(repeat_chars 500 v)")" \
     "$(rec www.example.com / GOODLAST v2)"; do
     grep -qxF "$want" <<<"$loaded" ||
         fail "a line that fits did not load whole: ${want:0:40}... in $jar_out"

--- a/tests/310_filelist-long-url.test
+++ b/tests/310_filelist-long-url.test
@@ -24,7 +24,7 @@ base="file://$tmp/"
 padded_url() {
     local want="$1" mark="$2"
     printf '%s%s%s\n' "$base" \
-        "$(printf "%$((want - ${#base} - ${#mark}))s" '' | tr ' ' p)" "$mark"
+        "$(repeat_chars $((want - ${#base} - ${#mark})) p)" "$mark"
 }
 
 # Dot segments collapse away, so the URL is long while the file it names is

--- a/tests/317_filter-rule-cap.test
+++ b/tests/317_filter-rule-cap.test
@@ -26,13 +26,9 @@ URL=http://www.example.com/a.png
 
 # Not ${pad// /$1}: bash 3.2, still macOS's /bin/bash, is quadratic there and
 # spent the whole 600s budget on the 64 KB seed probe below.
-rep() { # rep CHAR COUNT
-    printf "%${2}s" '' | tr ' ' "$1"
-}
-
 # A rule of LENGTH bytes, sign included, that $URL does not match.
 mkrule() { # mkrule LENGTH
-    printf -- '-www.example.com/%s*' "$(rep a $(($1 - 18)))"
+    printf -- '-www.example.com/%s*' "$(repeat_chars $(($1 - 18)) a)"
 }
 
 # Runs --why over a rules file and returns the verdict line alone.
@@ -63,7 +59,7 @@ assert_match "Filter rule longer than $rulecap bytes, ignored: -www" \
 # that bound from the engine too, not from the rule's.
 seedwarned=0
 seed() { # seed LENGTH
-    printf -- 'http://www.example.com/%s\n+*.png\n' "$(rep a $(($1 - 23)))" \
+    printf -- 'http://www.example.com/%s\n+*.png\n' "$(repeat_chars $(($1 - 23)) a)" \
         >"$tmpdir/u.txt"
     assert_eq "$URL: accepted by rule #1 (+*.png)" "$(why "$tmpdir/u.txt")" \
         "seed of $1 bytes"

--- a/tests/86_local-proxytrack-cache-longfields.test
+++ b/tests/86_local-proxytrack-cache-longfields.test
@@ -10,16 +10,14 @@ set -euo pipefail
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
-pad() { printf "%${1}s" '' | tr ' ' "$2"; }
-
 # --- ARC reader (HTTP_READFIELD_STRING), no python needed -------------------
 # Each header overshoots its own destination, so a per-field clip is the only
 # way to get every expected length right at once.
 {
     printf 'HTTP/1.1 200 OK\r\n'
-    printf 'Content-Type: text/html%s\r\n' "$(pad 400 A)"
-    printf 'Etag: %s\r\n' "$(pad 400 E)"
-    printf 'Content-Disposition: %s\r\n' "$(pad 400 D)"
+    printf 'Content-Type: text/html%s\r\n' "$(repeat_chars 400 A)"
+    printf 'Etag: %s\r\n' "$(repeat_chars 400 E)"
+    printf 'Content-Disposition: %s\r\n' "$(repeat_chars 400 D)"
     printf 'Last-Modified: Wed, 01 Jan 2025 00:00:00 GMT\r\n'
     printf 'Content-Length: 5\r\n\r\n'
 } >"$dir/hdr"

--- a/tests/crawl-test.sh
+++ b/tests/crawl-test.sh
@@ -67,7 +67,7 @@ function start-crawl {
             verbose=1
             ;;
         --no-purge | --summary | --print-files) ;;
-        --errors | --files | --found | --not-found | --directory)
+        --errors | --files | --found | --directory)
             pos=$((pos + 1))
             test "$#" -ge "$pos" || warning "missing argument" || return 1
             ;;
@@ -132,16 +132,6 @@ function start-crawl {
             assert_equals "checking errors" "$1" "$(grep -iEc "^[0-9\:]*[[:space:]]Error:" "${tmp}/hts-log.txt")"
             ;;
         --found)
-            shift
-            info "checking for $1"
-            if test -f "${tmp}/$1"; then
-                result "OK"
-            else
-                result "not found"
-                exit 1
-            fi
-            ;;
-        --not-found)
             shift
             info "checking for $1"
             if test -f "${tmp}/$1"; then

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -300,6 +300,12 @@ make_tls_pem() {
     }
 }
 
+# COUNT copies of CHAR, the over-long strings the bounds tests feed. Built with
+# printf and tr: ${v// /c} is quadratic on the bash 3.2 macOS runners.
+repeat_chars() { # repeat_chars COUNT [CHAR]
+    printf '%*s' "$1" '' | tr ' ' "${2:-a}"
+}
+
 # Longest surviving run of char $2 in file $1, or 0: the length a field was
 # clipped to, read back out of a binary artifact.
 runlen() {

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -300,9 +300,12 @@ make_tls_pem() {
     }
 }
 
-# COUNT copies of CHAR, the over-long strings the bounds tests feed. Built with
-# printf and tr: ${v// /c} is quadratic on the bash 3.2 macOS runners.
+# The over-long strings the bounds tests feed. printf and tr, because
+# ${v// /c} is quadratic on the bash 3.2 macOS runners.
 repeat_chars() { # repeat_chars COUNT [CHAR]
+    # A negative width left-justifies instead of erroring, so a computed
+    # COUNT that goes negative would pad silently.
+    case $1 in '' | *[!0-9]*) fail "repeat_chars: COUNT is not a number: $1" ;; esac
     printf '%*s' "$1" '' | tr ' ' "${2:-a}"
 }
 

--- a/tools/mkdeb.sh
+++ b/tools/mkdeb.sh
@@ -188,8 +188,8 @@ main() {
     else
         # Refresh build system and man page, then build the tarball. We build
         # here only because regen-man needs the compiled binaries; the test
-        # suite is not run in this pass. debuild (below) runs the full suite
-        # once, online tests enabled, so a check here would just repeat it.
+        # suite is not run in this pass. debuild (below) runs it once, so a
+        # check here would just repeat it.
         info "regenerating build system and man page"
         (
             cd "$export_dir"


### PR DESCRIPTION
An audit of the test suite turned up these scaffolding defects. None fails today.

`crawl-test.sh --not-found` is a verbatim copy of `--found`: it reports OK when the file is present. Every `--not-found` call in the suite goes through `local-crawl.sh`, whose copy is correct. No CI job enables the online suite that would reach `crawl-test.sh`'s copy, so this removes it instead of leaving a path nothing exercises. It also comes out of the pre-parse list, so a future caller gets `unrecognized option` rather than a silent inversion.

The "N copies of a character" helper was defined ten times across the suite, in three argument orders: count only, `CHAR COUNT`, and `COUNT CHAR`. Callers match their own file, so nothing is vacuous today, but a line copied between two of them would give a one-character string where 255 bytes were meant, and a bounds test would pass on that. One `repeat_chars COUNT [CHAR]` in testlib.sh replaces all ten. `307`'s copy defaulted to `A` where the shared one defaults to `a`, so every converted call names its character rather than inheriting one.

`repeat_chars` rejects a COUNT that is not a number. `printf '%*s'` left-justifies on a negative width instead of failing, so a computed COUNT that went negative used to give a short fixture and a bounds test that proved nothing.

Three tests install `trap 'exit 1'` right after `cleanup_push`, replacing the handler it just set. Dead lines, not a leak: `exit` still runs the EXIT trap, which drains `run_cleanups`. Removed so the next reader does not copy them.

A comment in `tools/mkdeb.sh` said debuild runs the suite with online tests enabled. `debian/rules` passes `--disable-online-unit-tests`.

Shortening `repeat_chars` by one character reds all three FTP tests, which is what says those bounds assertions are real. Full suite green at 348 pass, 12 skip.