### PR TITLE
Nine copies of the htsserver browser client become one

### DIFF
--- a/tests/272_webhttrack-host-alias.test
+++ b/tests/272_webhttrack-host-alias.test
@@ -28,46 +28,25 @@ cleanup_push cleanup
 printf '[webhttrack emits --host-alias] ..\t'
 htsserver_start --home "${work}"
 
-"${HTS_PYTHON}" - "${HTS_URL}" "${work}/emitted" <<'PY' || fail "the Host aliases field is not wired (see above)"
-import re, shlex, sys, urllib.parse, urllib.request
+htsserver_python - "${HTS_URL}" "${work}/emitted" <<'PY' || fail "the Host aliases field is not wired (see above)"
+import shlex, sys
 
-url, emitted = sys.argv[1].rstrip("/"), sys.argv[2]
+from webtestlib import Session, textarea
+
+s, emitted = Session(sys.argv[1]), sys.argv[2]
 # two rules, because one flag carries one rule: a browser posts the textarea
 # lines CRLF-separated
 RULES = ["www2.example.com,m.example.com=example.com",
          "legacy.example.org=https://example.org"]
 RULE = "\r\n".join(RULES)
 
-form = urllib.request.urlopen(url + "/server/index.html", timeout=20).read()
-m = re.search(rb'name="sid" value="([0-9a-f]+)"', form)
-if not m:
-    sys.exit("no session id in server/index.html")
-sid = m.group(1).decode()
-
 # An unknown ${LANG_*} renders empty, so assert the label text, not its absence.
-page = urllib.request.urlopen(url + "/server/option8.html?sid=" + sid,
-                              timeout=20).read().decode("latin-1")
+page = s.get("option8.html?sid=" + s.sid)
 for want in ('name="hostalias"', "Host aliases:"):
     if want not in page:
         sys.exit("option8.html does not render %r" % want)
 
-
-def post(fields):
-    body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in
-                    [("sid", sid)] + fields)
-    req = urllib.request.Request(url + "/server/step4.html",
-                                 data=body.encode("latin-1"), method="POST")
-    return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
-
-
-def textarea(page, name):
-    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page, re.S)
-    if m is None:
-        sys.exit("no %s textarea in the rendered step4.html" % name)
-    return m.group(1)
-
-
-page = post([("hostalias", RULE)])
+page = s.post("step4.html", [("hostalias", RULE)])
 cmd = textarea(page, "command")
 # Whole lines: each rule carries the separators the argv splitter reads, and
 # one flag per rule is what the engine accumulates.
@@ -85,9 +64,7 @@ if not ini or not all(rule in ini[0] for rule in RULES):
 
 # Reopening the page must show both rules back, one per line: a name the state
 # never writes renders an empty box and the project loses them on every reload.
-back = textarea(urllib.request.urlopen(url + "/server/option8.html?sid=" + sid,
-                                       timeout=20).read().decode("latin-1"),
-                "hostalias")
+back = textarea(s.get("option8.html?sid=" + s.sid), "hostalias")
 for rule in RULES:
     if rule not in back:
         sys.exit("option8.html does not render %r back\n%s" % (rule, back))
@@ -96,7 +73,7 @@ def emitted_rules(value):
     """The rules the template emits for a box holding VALUE."""
     flag = '--host-alias "'
     return [line.strip()[len(flag):-1]
-            for line in textarea(post([("hostalias", value)]),
+            for line in textarea(s.post("step4.html", [("hostalias", value)]),
                                  "command").split("\n")
             if flag in line]
 

--- a/tests/273_webhttrack-strip-query.test
+++ b/tests/273_webhttrack-strip-query.test
@@ -28,47 +28,26 @@ cleanup_push cleanup
 printf '[webhttrack emits one --strip-query per rule] ..\t'
 htsserver_start --home "${work}"
 
-"${HTS_PYTHON}" - "${HTS_URL}" "${work}/emitted" <<'PY' || fail "the Strip query keys field is not wired (see above)"
-import re, shlex, sys, urllib.parse, urllib.request
+htsserver_python - "${HTS_URL}" "${work}/emitted" <<'PY' || fail "the Strip query keys field is not wired (see above)"
+import shlex, sys
 
-url, emitted = sys.argv[1].rstrip("/"), sys.argv[2]
+from webtestlib import Session, textarea
+
+s, emitted = Session(sys.argv[1]), sys.argv[2]
 # Scoped rules, because the engine applies the last one matching an address: a
 # browser posts the textarea lines CRLF-separated.
 RULES = ["shop.example.com/*=sid,utm_source",
          "www.example.org/*=ref"]
 RULE = "\r\n".join(RULES)
 
-form = urllib.request.urlopen(url + "/server/index.html", timeout=20).read()
-m = re.search(rb'name="sid" value="([0-9a-f]+)"', form)
-if not m:
-    sys.exit("no session id in server/index.html")
-sid = m.group(1).decode()
-
 # The tag, because a single-line input renders the name too; the label text,
 # because an unknown ${LANG_*} renders empty.
-page = urllib.request.urlopen(url + "/server/option8.html?sid=" + sid,
-                              timeout=20).read().decode("latin-1")
+page = s.get("option8.html?sid=" + s.sid)
 for want in ('<textarea name="stripquery"', "Strip query keys:"):
     if want not in page:
         sys.exit("option8.html does not render %r" % want)
 
-
-def post(fields):
-    body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in
-                    [("sid", sid)] + fields)
-    req = urllib.request.Request(url + "/server/step4.html",
-                                 data=body.encode("latin-1"), method="POST")
-    return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
-
-
-def textarea(page, name):
-    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page, re.S)
-    if m is None:
-        sys.exit("no %s textarea in the rendered step4.html" % name)
-    return m.group(1)
-
-
-page = post([("stripquery", RULE)])
+page = s.post("step4.html", [("stripquery", RULE)])
 cmd = textarea(page, "command")
 lines = [l.strip() for l in cmd.split("\n")]
 for rule in RULES:
@@ -86,17 +65,14 @@ if ini != [want]:
 # Reopening the page must show the rules back on their own lines: a name the
 # session state never writes renders an empty box, and rules run together come
 # back as one.
-back = textarea(urllib.request.urlopen(url + "/server/option8.html?sid=" + sid,
-                                       timeout=20).read().decode("latin-1"),
-                "stripquery")
+back = textarea(s.get("option8.html?sid=" + s.sid), "stripquery")
 if [l.strip() for l in back.split("\n") if l.strip()] != RULES:
     sys.exit("option8.html renders %r back, wanted the two rules" % back)
 
 # A '<' comes back as an entity: raw, it would close the box early and put the
 # rest of the page inside a rule.
-post([("stripquery", "a<b=sid")])
-page = urllib.request.urlopen(url + "/server/option8.html?sid=" + sid,
-                              timeout=20).read().decode("latin-1")
+s.post("step4.html", [("stripquery", "a<b=sid")])
+page = s.get("option8.html?sid=" + s.sid)
 if "a&lt;b=sid" not in page:
     sys.exit("option8.html does not escape a rule holding '<'")
 
@@ -104,7 +80,7 @@ if "a&lt;b=sid" not in page:
 def emitted_rules(value):
     flag = '--strip-query "'
     return [line.strip()[len(flag):-1]
-            for line in textarea(post([("stripquery", value)]),
+            for line in textarea(s.post("step4.html", [("stripquery", value)]),
                                  "command").split("\n")
             if flag in line]
 

--- a/tests/274_wizard-profile-load.test
+++ b/tests/274_wizard-profile-load.test
@@ -72,7 +72,6 @@ htsserver_start --home "${work}"
 htsserver_python - "${HTS_URL}" "${work}" <<'PY' || fail "see above"
 import re
 import sys
-import urllib.request
 
 from webtestlib import Session, textarea
 
@@ -197,11 +196,7 @@ if ini.get("Footer") != "x%%y":
 # The form body decodes through unescapehttp() rather than unescapeini(), and
 # only a raw % reaches it: urlencoding one would defeat the probe.
 want('--sitemap-url "http://example.com/s.xml%"')
-posted = urllib.request.urlopen(
-    urllib.request.Request(s.url + "/server/step4.html",
-                           data=("sid=%s&cookiesfile=z%%&x=1"
-                                 % sid).encode("latin-1"),
-                           method="POST"), timeout=20).read().decode("latin-1")
+posted = s.post_raw("step4.html", "sid=%s&cookiesfile=z%%&x=1" % s.sid)
 if '--cookies-file "z%"' not in textarea(posted, "command"):
     sys.exit("a posted trailing %% did not come back verbatim\n%s"
              % textarea(posted, "command"))

--- a/tests/274_wizard-profile-load.test
+++ b/tests/274_wizard-profile-load.test
@@ -69,40 +69,26 @@ EOF
 printf '[reloading a project reads its winprofile.ini] ..\t'
 htsserver_start --home "${work}"
 
-"${HTS_PYTHON}" - "${HTS_URL}" "${work}" <<'PY' || fail "see above"
+htsserver_python - "${HTS_URL}" "${work}" <<'PY' || fail "see above"
 import re
 import sys
-import urllib.parse
 import urllib.request
 
-url, work = sys.argv[1].rstrip("/"), sys.argv[2]
+from webtestlib import Session, textarea
 
-
-def get(page):
-    return urllib.request.urlopen(url + "/server/" + page,
-                                  timeout=20).read().decode("latin-1")
-
-
-m = re.search(r'name="sid" value="([0-9a-f]+)"', get("index.html"))
-if not m:
-    sys.exit("no session id in server/index.html")
-sid = m.group(1)
+s, work = Session(sys.argv[1]), sys.argv[2]
+sid = s.sid
 
 # Control, before anything is loaded: a fresh session ticks the cache box, so
 # the assertions below measure the profile rather than an absent default.
 tag = re.findall(r'<input[^>]*type="checkbox"[^>]*name="cache"[^>]*>',
-                 get("option3.html?sid=" + sid))
+                 s.get("option3.html?sid=" + sid))
 if len(tag) != 1 or "checked" not in tag[0]:
     sys.exit("a new project does not default to caching: %r" % tag)
 
 # The only request that opens the file: a GET of an option page renders the
 # session the server already holds and never touches the disk.
-body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in
-                [("sid", sid), ("path", work), ("loadprojname", "proj")])
-loaded = urllib.request.urlopen(
-    urllib.request.Request(url + "/server/step2.html",
-                           data=body.encode("latin-1"), method="POST"),
-    timeout=20).read().decode("latin-1")
+loaded = s.post("step2.html", [("path", work), ("loadprojname", "proj")])
 if "http://example.com/" not in loaded:
     sys.exit("step2.html did not load the project\n%s" % loaded[:400])
 # The category dropdown comes from a second, independent reader in htstools.c
@@ -112,15 +98,7 @@ if '<option value="c%">' not in loaded:
              % re.findall(r"<option[^>]*>[^<]*</option>", loaded))
 
 
-def textarea(page, name):
-    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page,
-                  re.S)
-    if m is None:
-        sys.exit("no %s textarea in the rendered page" % name)
-    return m.group(1)
-
-
-step4 = get("step4.html?sid=" + sid)
+step4 = s.get("step4.html?sid=" + sid)
 flags = [line.strip() for line in textarea(step4, "command").split("\n")]
 ini = dict(line.split("=", 1) for line in textarea(step4, "winprofile")
            .replace("\r\n", "\n").split("\n") if "=" in line)
@@ -146,7 +124,7 @@ want("--depth=3")
 if ini.get("MaxRate") != "0" or ini.get("MaxTime") != "0":
     sys.exit("saving the reloaded project loses the zeros: %r" % ini)
 maxrate = re.search(r'name="maxrate" value="([^"]*)"',
-                    get("option5.html?sid=" + sid))
+                    s.get("option5.html?sid=" + sid))
 if maxrate is None or maxrate.group(1) != "0":
     sys.exit("option5.html shows %r in the rate box"
              % (maxrate and maxrate.group(1)))
@@ -161,7 +139,7 @@ want("--wacz")
 reject('--warc-file "keepme"')
 if ini.get("WarcFile") != "keepme":
     sys.exit("the cleared box lost WarcFile: %r" % ini.get("WarcFile"))
-option9 = get("option9.html?sid=" + sid)
+option9 = s.get("option9.html?sid=" + sid)
 for box, ticked in [("warc", False), ("wacz", True)]:
     tag = re.findall(r'<input[^>]*type="checkbox"[^>]*name="%s"[^>]*>' % box,
                      option9)
@@ -186,7 +164,7 @@ want("--cookies=0")
 want("--index=0")
 want("--cache=0")
 want("--urlhack=0")
-option4 = get("option4.html?sid=" + sid)
+option4 = s.get("option4.html?sid=" + sid)
 tag = re.findall(r'<input[^>]*type="checkbox"[^>]*name="ka"[^>]*>', option4)
 if len(tag) != 1 or "checked" in tag[0]:
     sys.exit("the keep-alive box came back %r" % tag)
@@ -199,13 +177,13 @@ if "Sockets" not in ini or ini["Sockets"] != "4":
 # value; only a fresh session may take it.
 for page in ["step2.html?sid=" + sid, "option3.html?sid=" + sid]:
     tag = re.findall(r'<input[^>]*type="checkbox"[^>]*name="cache"[^>]*>',
-                     get(page))
+                     s.get(page))
     if tag and "checked" in tag[0]:
         sys.exit("the cache box came back ticked after %s" % page)
 
 # One separator, whatever the run: unescapeini() folds an encoded CR LF TAB
 # into a single break, and the rules box must show exactly that.
-alias = textarea(get("option8.html?sid=" + sid), "hostalias")
+alias = textarea(s.get("option8.html?sid=" + sid), "hostalias")
 if alias != "a=b\rc=d":
     sys.exit("the rules box holds %r, wanted one separator" % alias)
 want('--host-alias "a=b"')
@@ -220,7 +198,7 @@ if ini.get("Footer") != "x%%y":
 # only a raw % reaches it: urlencoding one would defeat the probe.
 want('--sitemap-url "http://example.com/s.xml%"')
 posted = urllib.request.urlopen(
-    urllib.request.Request(url + "/server/step4.html",
+    urllib.request.Request(s.url + "/server/step4.html",
                            data=("sid=%s&cookiesfile=z%%&x=1"
                                  % sid).encode("latin-1"),
                            method="POST"), timeout=20).read().decode("latin-1")
@@ -232,12 +210,7 @@ if '--cookies-file "z%"' not in textarea(posted, "command"):
 # ProxyType 0 is the HTTP entry, so it prefixes no scheme. The proxy box itself
 # is session state, so fill it before reading the flag.
 def proxy_flag(fields):
-    body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in
-                    [("sid", sid)] + fields)
-    page = urllib.request.urlopen(
-        urllib.request.Request(url + "/server/step4.html",
-                               data=body.encode("latin-1"), method="POST"),
-        timeout=20).read().decode("latin-1")
+    page = s.post("step4.html", fields)
     got = [line.strip() for line in textarea(page, "command").split("\n")
            if line.strip().startswith("--proxy ")]
     if len(got) != 1:

--- a/tests/321_webhttrack-no-wizard.test
+++ b/tests/321_webhttrack-no-wizard.test
@@ -22,10 +22,12 @@ cleanup_push cleanup
 
 htsserver_start --home "${work}"
 
-"${HTS_PYTHON}" - "${HTS_URL}" "${distdir}" <<'PY' || fail "the wizard mode is still offered (see above)"
-import os, re, sys, urllib.parse, urllib.request
+htsserver_python - "${HTS_URL}" "${distdir}" <<'PY' || fail "the wizard mode is still offered (see above)"
+import os, re, sys
 
-url, srcdir = sys.argv[1].rstrip("/"), sys.argv[2]
+from webtestlib import Session, textarea
+
+s, srcdir = Session(sys.argv[1]), sys.argv[2]
 rc = 0
 
 
@@ -40,34 +42,8 @@ def read(*path):
     return open(os.path.join(srcdir, *path), "rb").read().decode("latin-1")
 
 
-def get(path):
-    # The UI is served ISO-8859-1, so decode, do not assume UTF-8.
-    return urllib.request.urlopen(url + path, timeout=20).read().decode("latin-1")
-
-
-sid = re.search(r'name="sid" value="([0-9a-f]+)"', get("/server/index.html"))
-if sid is None:
-    sys.exit("no session id in server/index.html")
-sid = sid.group(1)
-
-
-def post(fields, page="step4.html"):
-    body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in
-                    [("sid", sid)] + fields)
-    req = urllib.request.Request(url + "/server/" + page,
-                                 data=body.encode("latin-1"), method="POST")
-    return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
-
-
-def textarea(page, name):
-    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page, re.S)
-    if m is None:
-        sys.exit("no %s textarea in the rendered step4.html" % name)
-    return m.group(1)
-
-
 def options():
-    page = get("/server/step3.html")
+    page = s.get("step3.html")
     block = re.search(r'<select name="todo".*?</select>', page, re.S)
     if block is None:
         sys.exit("no action <select> in the rendered step3.html")
@@ -101,7 +77,7 @@ check(not [l for l in labels if "questions" in l],
 # Renumbering the survivors would keep the menu wizard-free and still break
 # every stored CurrentAction, so pin id to flag rather than just the count.
 for todo, flag in sorted(COMMAND.items()):
-    cmd = textarea(post([("todo", str(todo))]), "command").split()
+    cmd = textarea(s.post("step4.html", [("todo", str(todo))]), "command").split()
     check(flag in cmd, "action %d runs %s" % (todo, flag))
     check("--mirror-wizard" not in cmd, "action %d does not run the wizard" % todo)
     selected = [i for i, sel, _ in options() if sel]

--- a/tests/322_webhttrack-list-ids.test
+++ b/tests/322_webhttrack-list-ids.test
@@ -78,41 +78,12 @@ EOF
 printf '[a new project saves the ids WinHTTrack defaults to] ..\t'
 htsserver_start --home "${work}"
 
-"${HTS_PYTHON}" - "${HTS_URL}" "${work}" <<'PY' || fail "see above"
-import re
+htsserver_python - "${HTS_URL}" "${work}" <<'PY' || fail "see above"
 import sys
-import urllib.parse
-import urllib.request
 
-url, work = sys.argv[1].rstrip("/"), sys.argv[2]
+from webtestlib import Session, textarea
 
-
-def get(page):
-    return urllib.request.urlopen(url + "/server/" + page,
-                                  timeout=20).read().decode("latin-1")
-
-
-def post(page, fields):
-    body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in fields)
-    req = urllib.request.Request(url + "/server/" + page,
-                                 data=body.encode("latin-1"), method="POST")
-    return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
-
-
-def textarea(page, name):
-    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page,
-                  re.S)
-    if m is None:
-        sys.exit("no %s textarea in the rendered page" % name)
-    # As a browser posts it: the newline right after the tag is not content.
-    return m.group(1).lstrip("\r\n")
-
-
-def sid_of():
-    m = re.search(r'name="sid" value="([0-9a-f]+)"', get("index.html"))
-    if not m:
-        sys.exit("no session id in server/index.html")
-    return m.group(1)
+s, work = Session(sys.argv[1]), sys.argv[2]
 
 
 def keys_of(path):
@@ -121,20 +92,19 @@ def keys_of(path):
                     for line in fp if "=" in line)
 
 
-def save(sid, projname):
+def save(projname):
     """Write the project's winprofile.ini the way the Save button does."""
-    step4 = get("step4.html?sid=" + sid)
-    post("step4.html", [("sid", sid), ("path", work),
-                        ("projname", projname),
-                        ("command", textarea(step4, "command")),
-                        ("command_do", "save"),
-                        ("winprofile", textarea(step4, "winprofile"))])
+    step4 = s.get("step4.html?sid=" + s.sid)
+    s.post("step4.html", [("path", work), ("projname", projname),
+                          ("command", textarea(step4, "command")),
+                          ("command_do", "save"),
+                          ("winprofile", textarea(step4, "winprofile"))])
     return keys_of("%s/%s/hts-cache/winprofile.ini" % (work, projname))
 
 
 # Those numbers are what the ids mean on disk: MyGetProfileInt(..., <default>)
 # in WinHTTrack/Shell.cpp reads exactly them out of a file it never wrote.
-fresh = save(sid_of(), "fresh")
+fresh = save("fresh")
 if fresh.get("ProfileFormat") != "1":
     sys.exit("a saved profile carries no format marker: %r" % fresh)
 for key, want in [("Build", "0"), ("PrimaryScan", "3"), ("Travel", "1"),
@@ -155,41 +125,13 @@ htsserver_stop
 printf '[a 0-based profile reads back one option up] ..\t'
 htsserver_start --home "${work}"
 
-"${HTS_PYTHON}" - "${HTS_URL}" "${work}" <<'PY' || fail "see above"
+htsserver_python - "${HTS_URL}" "${work}" <<'PY' || fail "see above"
 import re
 import sys
-import urllib.parse
-import urllib.request
 
-url, work = sys.argv[1].rstrip("/"), sys.argv[2]
+from webtestlib import Session, textarea
 
-
-def get(page):
-    return urllib.request.urlopen(url + "/server/" + page,
-                                  timeout=20).read().decode("latin-1")
-
-
-def post(page, fields):
-    body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in fields)
-    req = urllib.request.Request(url + "/server/" + page,
-                                 data=body.encode("latin-1"), method="POST")
-    return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
-
-
-def textarea(page, name):
-    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page,
-                  re.S)
-    if m is None:
-        sys.exit("no %s textarea in the rendered page" % name)
-    # As a browser posts it: the newline right after the tag is not content.
-    return m.group(1).lstrip("\r\n")
-
-
-def sid_of():
-    m = re.search(r'name="sid" value="([0-9a-f]+)"', get("index.html"))
-    if not m:
-        sys.exit("no session id in server/index.html")
-    return m.group(1)
+s, work = Session(sys.argv[1]), sys.argv[2]
 
 
 def keys_of(path):
@@ -198,14 +140,13 @@ def keys_of(path):
                     for line in fp if "=" in line)
 
 
-def save(sid, projname):
+def save(projname):
     """Write the project's winprofile.ini the way the Save button does."""
-    step4 = get("step4.html?sid=" + sid)
-    post("step4.html", [("sid", sid), ("path", work),
-                        ("projname", projname),
-                        ("command", textarea(step4, "command")),
-                        ("command_do", "save"),
-                        ("winprofile", textarea(step4, "winprofile"))])
+    step4 = s.get("step4.html?sid=" + s.sid)
+    s.post("step4.html", [("path", work), ("projname", projname),
+                          ("command", textarea(step4, "command")),
+                          ("command_do", "save"),
+                          ("winprofile", textarea(step4, "winprofile"))])
     return keys_of("%s/%s/hts-cache/winprofile.ini" % (work, projname))
 
 
@@ -218,9 +159,8 @@ def only_flag(command, want):
                      % (flag, want, boxes, command))
 
 
-def load(sid, projname):
-    return post("step2.html", [("sid", sid), ("path", work),
-                               ("loadprojname", projname)])
+def load(projname):
+    return s.post("step2.html", [("path", work), ("loadprojname", projname)])
 
 
 def selected(page, name):
@@ -232,22 +172,21 @@ def selected(page, name):
     return ids[0] if len(ids) == 1 else None
 
 
-sid = sid_of()
+sid = s.sid
 # LISTDEF_4's five entries against a flag list that had four: the default one
 # emitted p7, and the last one nothing. p3/p7 per man/httrack.1.
 for pick, flag in [("4", "--priority=3"), ("5", "--priority=7")]:
-    command = textarea(post("step4.html", [("sid", sid), ("filter", pick)]),
-                       "command")
+    command = textarea(s.post("step4.html", [("filter", pick)]), "command")
     if flag not in command.split():
         sys.exit("scan rule %s emits no %s\n%s" % (pick, flag, command))
 
 # Ahead of the project the rest of the leg uses: two loads in a row are fine,
 # where a load after a save is not.
-if "http://example.org/" not in load(sid, "proj2"):
+if "http://example.org/" not in load("proj2"):
     sys.exit("step2.html did not load the second project")
-only_flag(textarea(get("step4.html?sid=" + sid), "command"), "--test")
+only_flag(textarea(s.get("step4.html?sid=" + sid), "command"), "--test")
 
-loaded = load(sid, "proj")
+loaded = load("proj")
 if "http://example.com/" not in loaded:
     sys.exit("step2.html did not load the project\n%s" % loaded[:400])
 
@@ -262,14 +201,14 @@ for page, name, stored in [("step3.html", "todo", 6),
                            ("option8.html", "checktype", 0),
                            ("option8.html", "robots", 0),
                            ("option9.html", "logtype", 2)]:
-    got = selected(get("%s?sid=%s" % (page, sid)), name)
+    got = selected(s.get("%s?sid=%s" % (page, sid)), name)
     if got != str(stored + 1):
         sys.exit("%s selects %r for a stored %d, expected %d"
                  % (name, got, stored, stored + 1))
 
 # What each id means, read off LISTDEF_N in lang.def, so a table that renumbers
 # the options is not read as a fix. Depth is the control: not a list key.
-command = textarea(get("step4.html?sid=" + sid), "command")
+command = textarea(s.get("step4.html?sid=" + sid), "command")
 for flag in ["--update", "-N2", "--priority=1", "--can-go-up-and-down",
              "--stay-on-same-tld", "--keep-links=3", "--robots=0",
              "--debug-log", "--depth=3", "--near", "--long-names=0"]:
@@ -281,12 +220,12 @@ only_flag(command, "--near")
 # Dos=3 is WinHTTrack's alone, and its select has no entry for it. Showing the
 # blank one would re-save as 0, which reads there as long names, losing the DOS
 # names this very command line just asked for.
-if selected(get("option2.html?sid=" + sid), "dos") != "1":
+if selected(s.get("option2.html?sid=" + sid), "dos") != "1":
     sys.exit("a stored Dos=3 does not show as DOS names alone")
 
 # Saving it back must reproduce what was seeded, Depth included: an asymmetric
 # shift walks a project one option further on every reopen.
-back = save(sid, "proj")
+back = save("proj")
 for key, want in keys_of(work + "/seeded.ini").items():
     if back.get(key) != want:
         sys.exit("%s round-trips as %r, was %r" % (key, back.get(key), want))

--- a/tests/323_webhttrack-proxy-persist.test
+++ b/tests/323_webhttrack-proxy-persist.test
@@ -55,50 +55,22 @@ test -n "${PORT}" || fail "the probe port is empty"
 printf '[a typed proxy reaches the file] ..\t'
 htsserver_start --home "${work}"
 
-"${HTS_PYTHON}" - "${HTS_URL}" "${work}" "${HOST}" "${PORT}" <<'PY' || fail "see above"
-import re
+htsserver_python - "${HTS_URL}" "${work}" "${HOST}" "${PORT}" <<'PY' || fail "see above"
 import sys
-import urllib.parse
-import urllib.request
 
-url, work, host, port = (sys.argv[1].rstrip("/"), sys.argv[2],
-                         sys.argv[3], sys.argv[4])
+from webtestlib import Session, textarea
 
-
-def get(page):
-    return urllib.request.urlopen(url + "/server/" + page,
-                                  timeout=20).read().decode("latin-1")
-
-
-def post(page, fields):
-    body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in fields)
-    req = urllib.request.Request(url + "/server/" + page,
-                                 data=body.encode("latin-1"), method="POST")
-    return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
-
-
-def textarea(page, name):
-    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page,
-                  re.S)
-    if m is None:
-        sys.exit("no %s textarea in the rendered page" % name)
-    # As a browser posts it: the newline right after the tag is not content.
-    return m.group(1).lstrip("\r\n")
-
-
-m = re.search(r'name="sid" value="([0-9a-f]+)"', get("index.html"))
-if not m:
-    sys.exit("no session id in server/index.html")
-sid = m.group(1)
+s, work, host, port = (Session(sys.argv[1]), sys.argv[2],
+                       sys.argv[3], sys.argv[4])
 
 # Fill the proxy pane the way the wizard does, then press Save.
-post("option10.html", [("sid", sid), ("prox", host), ("portprox", port),
-                       ("proxytype", "2")])
-step4 = get("step4.html?sid=" + sid)
-post("step4.html", [("sid", sid), ("path", work), ("projname", "typed"),
-                    ("command", textarea(step4, "command")),
-                    ("command_do", "save"),
-                    ("winprofile", textarea(step4, "winprofile"))])
+s.post("option10.html", [("prox", host), ("portprox", port),
+                         ("proxytype", "2")])
+step4 = s.get("step4.html?sid=" + s.sid)
+s.post("step4.html", [("path", work), ("projname", "typed"),
+                      ("command", textarea(step4, "command")),
+                      ("command_do", "save"),
+                      ("winprofile", textarea(step4, "winprofile"))])
 
 with open(work + "/typed/hts-cache/winprofile.ini") as fp:
     saved = dict(line.strip().split("=", 1) for line in fp if "=" in line)
@@ -126,60 +98,27 @@ cp "${work}/proj/hts-cache/winprofile.ini" "${work}/seeded.ini"
 
 htsserver_start --home "${work}"
 
-"${HTS_PYTHON}" - "${HTS_URL}" "${work}" "${HOST}" "${PORT}" <<'PY' || fail "see above"
-import re
+htsserver_python - "${HTS_URL}" "${work}" "${HOST}" "${PORT}" <<'PY' || fail "see above"
 import sys
-import urllib.parse
-import urllib.request
 
-url, work, host, port = (sys.argv[1].rstrip("/"), sys.argv[2],
-                         sys.argv[3], sys.argv[4])
+from webtestlib import Session, field, textarea
 
+s, work, host, port = (Session(sys.argv[1]), sys.argv[2],
+                       sys.argv[3], sys.argv[4])
 
-def get(page):
-    return urllib.request.urlopen(url + "/server/" + page,
-                                  timeout=20).read().decode("latin-1")
-
-
-def post(page, fields):
-    body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in fields)
-    req = urllib.request.Request(url + "/server/" + page,
-                                 data=body.encode("latin-1"), method="POST")
-    return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
-
-
-def textarea(page, name):
-    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page,
-                  re.S)
-    if m is None:
-        sys.exit("no %s textarea in the rendered page" % name)
-    return m.group(1).lstrip("\r\n")
-
-
-def field(page, name):
-    m = re.search(r'<input name="%s" value="([^"]*)"' % name, page)
-    return m.group(1) if m else None
-
-
-m = re.search(r'name="sid" value="([0-9a-f]+)"', get("index.html"))
-if not m:
-    sys.exit("no session id in server/index.html")
-sid = m.group(1)
-
-loaded = post("step2.html", [("sid", sid), ("path", work),
-                             ("loadprojname", "proj")])
+loaded = s.post("step2.html", [("path", work), ("loadprojname", "proj")])
 if "http://example.com/" not in loaded:
     sys.exit("step2.html did not load the project")
 
 # The box the user looks at.
-page = get("option10.html?sid=" + sid)
+page = s.get("option10.html?sid=" + s.sid)
 for name, want in [("prox", host), ("portprox", port)]:
     if field(page, name) != want:
         sys.exit("option10.html shows %s=%r, the profile holds %r"
                  % (name, field(page, name), want))
 
 # ProxyType 1 is SOCKS5 on every front end, so the scheme has to survive too.
-command = get("step4.html?sid=" + sid)
+command = s.get("step4.html?sid=" + s.sid)
 want = '--proxy "socks5://%s:%s"' % (host, port)
 if want not in textarea(command, "command"):
     sys.exit("the reloaded command line lacks %s\n%s"
@@ -187,10 +126,10 @@ if want not in textarea(command, "command"):
 
 # Saving it back must reproduce the file: a binding that renders but never
 # stores looks identical up to here.
-post("step4.html", [("sid", sid), ("path", work), ("projname", "proj"),
-                    ("command", textarea(command, "command")),
-                    ("command_do", "save"),
-                    ("winprofile", textarea(command, "winprofile"))])
+s.post("step4.html", [("path", work), ("projname", "proj"),
+                      ("command", textarea(command, "command")),
+                      ("command_do", "save"),
+                      ("winprofile", textarea(command, "winprofile"))])
 with open(work + "/proj/hts-cache/winprofile.ini") as fp:
     back = dict(line.strip().split("=", 1) for line in fp if "=" in line)
 with open(work + "/seeded.ini") as fp:

--- a/tests/327_webhttrack-warc-gate.test
+++ b/tests/327_webhttrack-warc-gate.test
@@ -20,10 +20,13 @@ cleanup_push cleanup
 printf '[the CDXJ box follows the WARC box] ..\t'
 htsserver_start --home "${work}"
 
-"${HTS_PYTHON}" - "${HTS_URL}" <<'PY' || fail "the WARC gate is broken (see above)"
-import re, sys, urllib.parse, urllib.request
+htsserver_python - "${HTS_URL}" <<'PY' || fail "the WARC gate is broken (see above)"
+import re
+import sys
 
-url = sys.argv[1].rstrip("/")
+from webtestlib import Session, textarea
+
+s = Session(sys.argv[1])
 rc = 0
 
 
@@ -32,32 +35,6 @@ def check(ok, what):
     print(("ok: " if ok else "FAIL: ") + what)
     if not ok:
         rc = 1
-
-
-def get(path):
-    # The UI is served ISO-8859-1, so decode, do not assume UTF-8.
-    return urllib.request.urlopen(url + path, timeout=20).read().decode("latin-1")
-
-
-m = re.search(r'name="sid" value="([0-9a-f]+)"', get("/server/index.html"))
-if m is None:
-    sys.exit("no session id in server/index.html")
-sid = m.group(1)
-
-
-def post(fields):
-    body = "&".join("%s=%s" % (k, urllib.parse.quote(v))
-                    for k, v in [("sid", sid)] + fields)
-    req = urllib.request.Request(url + "/server/step4.html",
-                                 data=body.encode("latin-1"), method="POST")
-    return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
-
-
-def textarea(page, name):
-    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page, re.S)
-    if m is None:
-        sys.exit("no %s textarea in the rendered step4.html" % name)
-    return m.group(1)
 
 
 def tag(page, name):
@@ -76,7 +53,7 @@ def companion(page):
 
 
 # A headless check cannot see a greyed control or run the click handlers, so this asserts the wiring directly.
-page = get("/server/option9.html?sid=" + sid)
+page = s.get("option9.html?sid=" + s.sid)
 for want in ("function warc_gate()", "function wacz_click()",
              "var off = !box('warc').checked", "box('warccdx').disabled = off",
              "box('warc').checked = true", 'onLoad="do_load();"'):
@@ -94,8 +71,8 @@ for name in ("warc", "warccdx", "wacz"):
 
 # Both rendered states; the re-grey on untick is warc_gate()'s, and never runs here.
 for warc, greyed in (("", True), ("on", False), ("", True)):
-    post([("warc", warc), ("warccdx", "on")])
-    page = get("/server/option9.html?sid=" + sid)
+    s.post("step4.html", [("warc", warc), ("warccdx", "on")])
+    page = s.get("option9.html?sid=" + s.sid)
     label = "WARC %s" % ("set" if warc else "clear")
     check((" disabled" in tag(page, "warccdx")) == greyed,
           "%s: the CDXJ box is %s" % (label, "greyed" if greyed else "available"))
@@ -107,7 +84,8 @@ for warc, greyed in (("", True), ("on", False), ("", True)):
           "%s: the companion holds %r" % (label, "1" if greyed else ""))
 
 # What a browser posts from that greyed page: the two companions, no box.
-rendered = post([("warc", ""), ("warccdx", ""), ("warccdx", companion(page))])
+rendered = s.post("step4.html",
+                  [("warc", ""), ("warccdx", ""), ("warccdx", companion(page))])
 check("WarcCdx=1" in textarea(rendered, "winprofile").splitlines(),
       "a greyed CDXJ box keeps its stored value")
 cmd = textarea(rendered, "command").split()
@@ -116,11 +94,11 @@ check("--user-agent" in cmd and "--warc-cdx" not in cmd,
       "a greyed CDXJ box emits no flag")
 
 # Ungreyed, the box decides again: the companion is empty and the box posts.
-rendered = post([("warc", "on"), ("warccdx", ""), ("warccdx", "")])
+rendered = s.post("step4.html", [("warc", "on"), ("warccdx", ""), ("warccdx", "")])
 check("WarcCdx=0" in textarea(rendered, "winprofile").splitlines(),
       "an unticked CDXJ box clears the stored value")
-rendered = post([("warc", "on"), ("warccdx", ""), ("warccdx", ""),
-                 ("warccdx", "on")])
+rendered = s.post("step4.html", [("warc", "on"), ("warccdx", ""), ("warccdx", ""),
+                                 ("warccdx", "on")])
 check("--warc-cdx" in textarea(rendered, "command").split(),
       "a ticked CDXJ box under a set WARC box emits the flag")
 

--- a/tests/81_webhttrack-maxsize.test
+++ b/tests/81_webhttrack-maxsize.test
@@ -20,31 +20,13 @@ cleanup_push cleanup
 htsserver_start --home "${work}"
 
 # Audit what step4.html renders back; without command_do nothing is launched.
-"${HTS_PYTHON}" - "${HTS_URL}" <<'PY' || fail "wizard rendered the wrong options (see above)"
-import re, sys, urllib.parse, urllib.request
+htsserver_python - "${HTS_URL}" <<'PY' || fail "wizard rendered the wrong options (see above)"
+import sys
 
-url = sys.argv[1]
+from webtestlib import Session, textarea
+
+s = Session(sys.argv[1])
 html, other, site = "111111", "222222", "333333"
-
-
-def post(fields):
-    # The body is refused without the session id the server puts in each form.
-    form = urllib.request.urlopen(url + "server/index.html", timeout=20).read()
-    m = re.search(rb'name="sid" value="([0-9a-f]+)"', form)
-    if not m:
-        raise SystemExit("no session id in server/index.html")
-    fields = [("sid", m.group(1).decode())] + fields
-    body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in fields)
-    req = urllib.request.Request(url + "server/step4.html",
-                                 data=body.encode("latin-1"), method="POST")
-    return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
-
-
-def textarea(page, name):
-    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page, re.S)
-    if m is None:
-        sys.exit("no %s textarea in the rendered step4.html" % name)
-    return m.group(1)
 
 
 def want(ok, msg, ctx):
@@ -52,8 +34,8 @@ def want(ok, msg, ctx):
         sys.exit("%s\nrendered:%s" % (msg, ctx))
 
 
-page = post([("maxhtml", html), ("othermax", other), ("sizemax", site),
-             ("dos", "2")])
+page = s.post("step4.html", [("maxhtml", html), ("othermax", other),
+                             ("sizemax", site), ("dos", "2")])
 cmd = textarea(page, "command")
 want("--max-size=" + site in cmd, "site cap not emitted as --max-size", cmd)
 want("--max-files=" + site not in cmd, "site cap still an --max-files", cmd)
@@ -76,15 +58,15 @@ want("\nMaxAll=" + site + "\n" in ini, "MaxAll not written from sizemax", ini)
 
 # A bare --max-files= (an unguarded empty field) parses as -m with no digits,
 # silently clearing the html cap.
-page = post([("maxhtml", ""), ("othermax", ""), ("sizemax", ""), ("dos", "2")])
+page = s.post("step4.html", [("maxhtml", ""), ("othermax", ""), ("sizemax", ""),
+                             ("dos", "2")])
 cmd = textarea(page, "command")
 want("--max-rate=" in cmd, "empty size fields rendered no command line", cmd)
 want("--max-files" not in cmd and "--max-size" not in cmd,
      "empty size fields still rendered a size option", cmd)
 
 # A mistyped ${LANG_OK] key renders the OK button's label empty.
-opts = urllib.request.urlopen(url + "server/option2b.html",
-                              timeout=20).read().decode("latin-1")
+opts = s.get("option2b.html")
 want("LANG_OK" not in opts, "unexpanded LANG_OK in option2b.html", "")
 want('<input type="submit" value="OK"' in opts, "no OK label in option2b.html",
      "")

--- a/tests/90_webhttrack-checkbox-clear.test
+++ b/tests/90_webhttrack-checkbox-clear.test
@@ -22,10 +22,12 @@ cleanup_push cleanup
 
 htsserver_start --home "${work}"
 
-"${HTS_PYTHON}" - "${HTS_URL}" "${distdir}" <<'PY' || fail "checkbox clearing is broken (see above)"
-import glob, os, re, sys, urllib.parse, urllib.request
+htsserver_python - "${HTS_URL}" "${distdir}" <<'PY' || fail "checkbox clearing is broken (see above)"
+import glob, os, re, sys
 
-url, srcdir = sys.argv[1].rstrip("/"), sys.argv[2]
+from webtestlib import Session, checked, textarea
+
+s, srcdir = Session(sys.argv[1]), sys.argv[2]
 rc = 0
 
 
@@ -54,39 +56,6 @@ for path in sorted(glob.glob(os.path.join(srcdir, "html", "server", "option*.htm
               % (os.path.basename(path), m.group(1)))
 # Control: a regex that stopped matching would leave nothing to assert on.
 check(boxes >= 25, "the option pages were scanned (%d checkboxes)" % boxes)
-
-sid = None
-
-
-def get(path):
-    # The UI is served ISO-8859-1, so decode, do not assume UTF-8.
-    return urllib.request.urlopen(url + path, timeout=20).read().decode("latin-1")
-
-
-def post(fields):
-    global sid
-    if sid is None:
-        m = re.search(r'name="sid" value="([0-9a-f]+)"', get("/server/index.html"))
-        if m is None:
-            sys.exit("no session id in server/index.html")
-        sid = m.group(1)
-    body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in
-                    [("sid", sid)] + fields)
-    req = urllib.request.Request(url + "/server/step4.html",
-                                 data=body.encode("latin-1"), method="POST")
-    return urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
-
-
-def textarea(page, name):
-    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page, re.S)
-    if m is None:
-        sys.exit("no %s textarea in the rendered step4.html" % name)
-    return m.group(1)
-
-
-def checked(page, name):
-    return re.search(r'name="%s"[ \t]*checked' % name, get("/server/" + page)) is not None
-
 
 # What each state puts on the command line (None: nothing) and its profile key.
 BOXES = [
@@ -142,7 +111,7 @@ for field, key, when_set, when_clear in BOXES:
         fields = [(g, "on" if GATED_BY.get(field) == g else "")
                   for g in GATES if g != field]
         fields.append((field, value))
-        rendered = post(fields)
+        rendered = s.post("step4.html", fields)
         cmd = textarea(rendered, "command").split()
         label = "%s %s" % (field, "set" if value else "cleared")
         if want:
@@ -153,19 +122,23 @@ for field, key, when_set, when_clear in BOXES:
             # The Windows GUI reads the same option out of the profile.
             check("%s=%s" % (key, stored) in textarea(rendered, "winprofile").splitlines(),
                   "%s writes %s=%s" % (label, key, stored))
-        check(checked(page_of[field], field) == bool(value),
+        check(checked(s.get(page_of[field]), field) == bool(value),
               "%s draws %s box" % (label, "a ticked" if value else "an empty"))
 missing = sorted(set(page_of) - set(b[0] for b in BOXES))
 check(not missing, "every checkbox is exercised (missing %s)" % missing)
 
 # A browser posts the companion and the ticked box under one name, so the fix
 # rests on the body loop keeping the last value; both orders pin that down.
-cmd = textarea(post([("cookies", ""), ("cookies", "on")]), "command").split()
+cmd = textarea(s.post("step4.html", [("cookies", ""), ("cookies", "on")]),
+               "command").split()
 check("--cookies=0" not in cmd, "cookies=&cookies=on keeps cookies set")
-check(checked("option8.html", "cookies"), "cookies=&cookies=on draws a ticked box")
-cmd = textarea(post([("cookies", "on"), ("cookies", "")]), "command").split()
+check(checked(s.get("option8.html"), "cookies"),
+      "cookies=&cookies=on draws a ticked box")
+cmd = textarea(s.post("step4.html", [("cookies", "on"), ("cookies", "")]),
+               "command").split()
 check("--cookies=0" in cmd, "cookies=on&cookies= clears cookies")
-check(not checked("option8.html", "cookies"), "cookies=on&cookies= draws an empty box")
+check(not checked(s.get("option8.html"), "cookies"),
+      "cookies=on&cookies= draws an empty box")
 
 sys.exit(rc)
 PY

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,7 +12,7 @@ EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c a
 	header-injection-server.py header-injection-check.py \
 	pty-resize.py ttyrun.py test-timeout.sh png-colors.py \
 	local-crawl.sh local-server.py ftp-server.py testlib.sh proclib.sh \
-	webhttracklib.sh httpclient.py crawllib.sh \
+	webhttracklib.sh httpclient.py webtestlib.py crawllib.sh \
 	guide-image-check.py \
 	ci-windows-suite.sh ci-windows-watchdog.ps1 install-headers-sweep.sh \
 	server.crt server.key \

--- a/tests/webhttracklib.sh
+++ b/tests/webhttracklib.sh
@@ -189,6 +189,12 @@ htsserver_client() {
     "${HTS_PYTHON}" "${HTS_TESTDIR}/httpclient.py" --port "${HTS_PORT}" "$@"
 }
 
+# Python with tests/ importable: "python -" puts no script directory on
+# sys.path, so a heredoc cannot import webtestlib without this.
+htsserver_python() {
+    PYTHONPATH="${HTS_TESTDIR}${PYTHONPATH:+:$PYTHONPATH}" "${HTS_PYTHON}" "$@"
+}
+
 # The reply to a GET of $1, status line and headers included.
 htsserver_get() { htsserver_client --path "$1"; }
 

--- a/tests/webtestlib.py
+++ b/tests/webtestlib.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Session-aware htsserver client for the WebHTTrack tests.
 
-urllib, not httpclient.py: these tests drive the GUI as a browser does, over
-several requests sharing one session, and assert on the rendered HTML rather
-than on status-line or header bytes.
+urllib, not httpclient.py: these tests drive the GUI like a browser, over
+several requests that share one session. They assert on the rendered HTML,
+not on the status-line and header bytes urllib parses away.
 """
 import re
 import sys
@@ -17,58 +17,70 @@ SID_RE = re.compile(r'name="sid" value="([0-9a-f]+)"')
 
 
 class Session:
-    """One browser session against the htsserver at URL."""
+    """One browser session against the htsserver at URL.
+
+    Paths are page names under /server/, the only place the GUI lives.
+    """
 
     def __init__(self, url, timeout=DEFAULT_TIMEOUT):
         self.url = url.rstrip("/")
         self.timeout = timeout
         self._sid = None
 
-    def get_bytes(self, path):
-        if not path.startswith("/"):
-            path = "/server/" + path
-        return urllib.request.urlopen(self.url + path, timeout=self.timeout).read()
-
-    def get(self, path):
+    def _open(self, page, data=None):
+        req = urllib.request.Request(
+            self.url + "/server/" + page, data=data, method="POST" if data else "GET"
+        )
         # The GUI is served ISO-8859-1, so decode, do not assume UTF-8.
-        return self.get_bytes(path).decode("latin-1")
+        return (
+            urllib.request.urlopen(req, timeout=self.timeout).read().decode("latin-1")
+        )
+
+    def get(self, page):
+        return self._open(page)
 
     @property
     def sid(self):
         if self._sid is None:
-            m = SID_RE.search(self.get("/server/index.html"))
+            m = SID_RE.search(self.get("index.html"))
             if m is None:
                 sys.exit("no session id in server/index.html")
             self._sid = m.group(1)
         return self._sid
 
-    def post(self, page, fields, with_sid=True):
-        """POST urlencoded FIELDS to /server/PAGE and return the reply.
+    def post(self, page, fields):
+        """POST urlencoded FIELDS to /server/PAGE, with the session id, and
+        return the reply.
 
-        Only the fields given are sent. A field the page owns but the caller
-        omits keeps whatever the previous POST left in the session, which
-        several tests depend on, so this never replays or clears one.
+        Only the fields given are sent. A field the page owns but the POST
+        omits keeps its previous value in the session. Several tests rely on
+        that, so post() never replays or clears a field.
         """
-        if with_sid:
-            fields = [("sid", self.sid)] + list(fields)
+        fields = [("sid", self.sid)] + list(fields)
         body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in fields)
-        if not page.startswith("/"):
-            page = "/server/" + page
-        req = urllib.request.Request(
-            self.url + page, data=body.encode("latin-1"), method="POST"
-        )
-        return (
-            urllib.request.urlopen(req, timeout=self.timeout).read().decode("latin-1")
-        )
+        return self.post_raw(page, body)
+
+    def post_raw(self, page, body):
+        """POST BODY to /server/PAGE verbatim: no encoding, no session id.
+
+        For a test sending bytes post() would encode away, or an absent or
+        deliberately wrong session id.
+        """
+        return self._open(page, data=body.encode("latin-1"))
 
 
 def textarea(page, name):
-    """The content of textarea NAME in the rendered PAGE, as a browser posts it."""
-    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page, re.S)
+    """The content of textarea NAME in the rendered PAGE, as a browser posts it.
+
+    Exits when absent: every caller asserts on the content.
+    """
+    # [ >] anchors the name: unanchored, "command" also matches "commandline".
+    m = re.search(r'<textarea name="%s"[ >].*?>(.*?)</textarea>' % name, page, re.S)
     if m is None:
         sys.exit("no %s textarea in the rendered page" % name)
-    # The newline right after the tag is markup, not content.
-    return m.group(1).lstrip("\r\n")
+    # One newline right after the tag is markup, not content. Only one: a second
+    # is a blank first line, which a test may be asserting on.
+    return re.sub(r"\A\r?\n", "", m.group(1))
 
 
 def checked(page, name):
@@ -77,6 +89,9 @@ def checked(page, name):
 
 
 def field(page, name):
-    """The value attribute of input NAME in the rendered PAGE, or None."""
+    """The value attribute of input NAME in the rendered PAGE, or None.
+
+    Returns rather than exits, unlike textarea(): callers test for absence.
+    """
     m = re.search(r'name="%s"[^>]*\bvalue="([^"]*)"' % name, page)
     return m.group(1) if m else None

--- a/tests/webtestlib.py
+++ b/tests/webtestlib.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Session-aware htsserver client for the WebHTTrack tests.
+
+urllib, not httpclient.py: these tests drive the GUI as a browser does, over
+several requests sharing one session, and assert on the rendered HTML rather
+than on status-line or header bytes.
+"""
+import re
+import sys
+import urllib.parse
+import urllib.request
+
+DEFAULT_TIMEOUT = 20
+
+# The server renders its session id into every form as 32 hex digits.
+SID_RE = re.compile(r'name="sid" value="([0-9a-f]+)"')
+
+
+class Session:
+    """One browser session against the htsserver at URL."""
+
+    def __init__(self, url, timeout=DEFAULT_TIMEOUT):
+        self.url = url.rstrip("/")
+        self.timeout = timeout
+        self._sid = None
+
+    def get_bytes(self, path):
+        if not path.startswith("/"):
+            path = "/server/" + path
+        return urllib.request.urlopen(self.url + path, timeout=self.timeout).read()
+
+    def get(self, path):
+        # The GUI is served ISO-8859-1, so decode, do not assume UTF-8.
+        return self.get_bytes(path).decode("latin-1")
+
+    @property
+    def sid(self):
+        if self._sid is None:
+            m = SID_RE.search(self.get("/server/index.html"))
+            if m is None:
+                sys.exit("no session id in server/index.html")
+            self._sid = m.group(1)
+        return self._sid
+
+    def post(self, page, fields, with_sid=True):
+        """POST urlencoded FIELDS to /server/PAGE and return the reply.
+
+        Only the fields given are sent. A field the page owns but the caller
+        omits keeps whatever the previous POST left in the session, which
+        several tests depend on, so this never replays or clears one.
+        """
+        if with_sid:
+            fields = [("sid", self.sid)] + list(fields)
+        body = "&".join("%s=%s" % (k, urllib.parse.quote(v)) for k, v in fields)
+        if not page.startswith("/"):
+            page = "/server/" + page
+        req = urllib.request.Request(
+            self.url + page, data=body.encode("latin-1"), method="POST"
+        )
+        return (
+            urllib.request.urlopen(req, timeout=self.timeout).read().decode("latin-1")
+        )
+
+
+def textarea(page, name):
+    """The content of textarea NAME in the rendered PAGE, as a browser posts it."""
+    m = re.search(r'<textarea name="%s".*?>(.*?)</textarea>' % name, page, re.S)
+    if m is None:
+        sys.exit("no %s textarea in the rendered page" % name)
+    # The newline right after the tag is markup, not content.
+    return m.group(1).lstrip("\r\n")
+
+
+def checked(page, name):
+    """Whether checkbox NAME is checked in the rendered PAGE."""
+    return re.search(r'name="%s"[ \t]*checked' % name, page) is not None
+
+
+def field(page, name):
+    """The value attribute of input NAME in the rendered PAGE, or None."""
+    m = re.search(r'name="%s"[^>]*\bvalue="([^"]*)"' % name, page)
+    return m.group(1) if m else None


### PR DESCRIPTION
Every htsserver test used to open its Python heredoc by redefining the same browser client: a session-id scrape, `get`, `post`, and a `textarea` reader. Nine copies existed, and they had drifted apart. `tests/webtestlib.py` is that client, and these nine files import it. Around 420 lines out, 140 in.

There is a second reason to move this code into a tracked file. CI lints Python with `git ls-files '*.py'`, so none of the roughly 2800 lines of heredoc Python in the suite has ever been seen by black or flake8. Anything extracted here now is.

Two behaviour differences had to be resolved rather than preserved. Seven of the nine local `textarea` readers returned the newline that follows the opening tag; two stripped it. That newline is markup, so the shared reader strips it, but only the first one: a second newline is a blank first line a test may be asserting on. And the shared reader anchors the field name with `[ >]`, which only `241_local-single-file-gui.test` did, having found that an unanchored `command` also matches `commandline`.

`Session.post` sends only the fields it is given. A field a page owns but the POST omits keeps whatever the previous POST left in the session. Several of these tests depend on that, so the client never replays or clears fields. `post_raw` covers the two cases that need to bypass it: `274` deliberately sends an unencoded `%`, and a test may want an absent or wrong session id.

`tests/Makefile.am` lists every `tests/*.py` in `EXTRA_DIST` by hand, automake not expanding wildcards there, so the new file needed adding or `make dist` would have dropped it.

Stubbing `webtestlib.textarea` to a constant turns all nine tests red, so the library is load-bearing rather than decorative. Full suite green at 348 pass, 12 skip, unchanged from the branch point.