### PR TITLE
128 failure blocks that testlib's fail() already wrote

### DIFF
--- a/tests/01_engine-doitlog.test
+++ b/tests/01_engine-doitlog.test
@@ -40,10 +40,7 @@ errors() { grep -ciE '^[0-9:]*[[:space:]]Error:' "$out/hts-log.txt" || true; }
 # multi-token command line for cmdl_ins to re-insert one token at a time.
 rc=0
 "$bin" "$url" -O "$out" --quiet -n -%v0 -r3 >/dev/null 2>&1 || rc=$?
-test "$rc" -eq 0 || {
-    echo "FAIL: initial mirror exited $rc"
-    exit 1
-}
+test "$rc" -eq 0 || fail "initial mirror exited $rc"
 assert_file "$out/hts-cache/doit.log" "the initial mirror wrote no doit.log"
 
 # --- 1. no-url reprise re-mirrors cleanly -----------------------------------
@@ -51,20 +48,14 @@ assert_file "$out/hts-cache/doit.log" "the initial mirror wrote no doit.log"
 # recorded arguments (cmdl_ins). -O selects the mirror; argv carries no url.
 rc=0
 "$bin" -O "$out" --quiet >/dev/null 2>&1 || rc=$?
-test "$rc" -eq 0 || {
-    echo "FAIL: doit.log reprise exited $rc"
-    exit 1
-}
+test "$rc" -eq 0 || fail "doit.log reprise exited $rc"
 test "$(errors)" = 0 || {
     echo "FAIL: doit.log reprise reported errors (a token may have been corrupted)"
     grep -iE 'Error:' "$out/hts-log.txt" | head -3
     exit 1
 }
 for suffix in a.html sub/b.html; do
-    test -n "$(find "$out" -path "*/$suffix" -print -quit)" || {
-        echo "FAIL: $suffix missing after the no-url reprise"
-        exit 1
-    }
+    test -n "$(find "$out" -path "*/$suffix" -print -quit)" || fail "$suffix missing after the no-url reprise"
 done
 
 # --- 2. the reprise re-crawls through the inserted url -----------------------
@@ -72,14 +63,8 @@ sleep 1
 echo 'NEWCONTENT' >"$site/a.html"
 rc=0
 "$bin" -O "$out" --quiet >/dev/null 2>&1 || rc=$?
-test "$rc" -eq 0 || {
-    echo "FAIL: second reprise exited $rc"
-    exit 1
-}
-grep -q NEWCONTENT "$(find "$out" -path '*/a.html' -print -quit)" || {
-    echo "FAIL: reprise did not pick up the changed source (inserted url not re-crawled)"
-    exit 1
-}
+test "$rc" -eq 0 || fail "second reprise exited $rc"
+grep -q NEWCONTENT "$(find "$out" -path '*/a.html' -print -quit)" || fail "reprise did not pick up the changed source (inserted url not re-crawled)"
 
 # --- 3. an empty quoted arg survives the doit.log round-trip (#106) ----------
 # -%F "" (empty footer) records an empty "" token in doit.log; -r2 follows it so
@@ -89,10 +74,7 @@ grep -q NEWCONTENT "$(find "$out" -path '*/a.html' -print -quit)" || {
 out2="$tmp/out2"
 rc=0
 "$bin" "$url" -O "$out2" --quiet -n -%v0 -%F "" -r2 >/dev/null 2>&1 || rc=$?
-test "$rc" -eq 0 || {
-    echo "FAIL: initial mirror with empty footer exited $rc"
-    exit 1
-}
+test "$rc" -eq 0 || fail "initial mirror with empty footer exited $rc"
 # precondition: the writer put the empty token on disk for the reader to reload.
 grep -q ' -%F "" -r2' "$out2/hts-cache/doit.log" || {
     echo "FAIL: empty footer not recorded as -%F \"\" -r2 in doit.log"
@@ -104,10 +86,7 @@ grep -q ' -%F "" -r2' "$out2/hts-cache/doit.log" || {
 # kept it (a drop/swallow would panic above or rewrite -%F without the "").
 rc=0
 "$bin" -O "$out2" --quiet >/dev/null 2>&1 || rc=$?
-test "$rc" -eq 0 || {
-    echo "FAIL: empty-footer reprise exited $rc (empty token dropped from doit.log?)"
-    exit 1
-}
+test "$rc" -eq 0 || fail "empty-footer reprise exited $rc (empty token dropped from doit.log?)"
 grep -q ' -%F "" -r2' "$out2/hts-cache/doit.log" || {
     echo "FAIL: empty footer did not survive the doit.log reload round-trip"
     grep -- '-%F' "$out2/hts-cache/doit.log" || true
@@ -127,25 +106,13 @@ echo '<html><body>aaa</body></html>' >"$site3/a.html"
 rc=0
 "$bin" "file://$site3/index.html" -O "$out3" --quiet -n -%v0 \
     -%F "\"$footer\"" -r2 >/dev/null 2>&1 || rc=$?
-test "$rc" -eq 0 || {
-    echo "FAIL: initial mirror with a leading-quote footer exited $rc"
-    exit 1
-}
+test "$rc" -eq 0 || fail "initial mirror with a leading-quote footer exited $rc"
 page=$(find "$out3" -path '*/site3/index.html' -print -quit)
-test -n "$page" || {
-    echo "FAIL: mirrored page missing after the leading-quote mirror"
-    exit 1
-}
-grep -qF "$footer" "$page" || {
-    echo "FAIL: run 1 did not inject the footer verbatim"
-    exit 1
-}
+test -n "$page" || fail "mirrored page missing after the leading-quote mirror"
+grep -qF "$footer" "$page" || fail "run 1 did not inject the footer verbatim"
 rc=0
 "$bin" -O "$out3" --quiet >/dev/null 2>&1 || rc=$?
-test "$rc" -eq 0 || {
-    echo "FAIL: leading-quote reprise exited $rc"
-    exit 1
-}
+test "$rc" -eq 0 || fail "leading-quote reprise exited $rc"
 grep -qF "$footer" "$page" || {
     echo "FAIL: the footer changed across the reprise (leading quote written raw?)"
     grep -o '<!--[^>]*MARK[^>]*-->' "$page" | head -1
@@ -170,10 +137,7 @@ echo '<html><body>foo</body></html>' >"$site4/foo.html"
 rc=0
 "$bin" "file://$site4/index.html" -O "$out4" --quiet -n -%v0 '"""+*foo*""' \
     >/dev/null 2>&1 || rc=$?
-test "$rc" -eq 0 || {
-    echo "FAIL: initial mirror with a leading-quote filter exited $rc"
-    exit 1
-}
+test "$rc" -eq 0 || fail "initial mirror with a leading-quote filter exited $rc"
 grep -qF -- '"\"+*foo*"' "$out4/hts-cache/doit.log" || {
     echo "FAIL: the filter was not recorded escaped"
     head -1 "$out4/hts-cache/doit.log"
@@ -186,10 +150,7 @@ head -1 "$out4/hts-cache/doit.log" >"$tmp/doit4.before"
 # the command line is a fixed point of its own replay.
 rc=0
 (cd "$out4" && "$bin" >/dev/null 2>&1) || rc=$?
-test "$rc" -eq 0 || {
-    echo "FAIL: leading-quote filter reprise exited $rc (token stripped twice?)"
-    exit 1
-}
+test "$rc" -eq 0 || fail "leading-quote filter reprise exited $rc (token stripped twice?)"
 head -1 "$out4/hts-cache/doit.log" >"$tmp/doit4.after"
 cmp -s "$tmp/doit4.before" "$tmp/doit4.after" || {
     echo "FAIL: the reprise rewrote the command line differently"

--- a/tests/01_engine-footer-overflow.test
+++ b/tests/01_engine-footer-overflow.test
@@ -41,14 +41,8 @@ done
 
 mir="$dir/mir"
 httrack "file://$deep/index.html" -O "$mir" -%F "$footer" -q -s0 -%v0 \
-    >/dev/null 2>&1 || {
-    echo "crawl failed/aborted (exit $?) on an oversized footer" >&2
-    exit 1
-}
+    >/dev/null 2>&1 || fail "crawl failed/aborted (exit $?) on an oversized footer"
 
 # The crawled page must exist (proves the URL wasn't rejected for length, so the
 # footer path ran). Look under file/, not $mir, to skip the makeindex top index.
-test -n "$(find "$mir/file" -name index.html)" || {
-    echo "page not mirrored; the oversized-footer path was not exercised" >&2
-    exit 1
-}
+test -n "$(find "$mir/file" -name index.html)" || fail "page not mirrored; the oversized-footer path was not exercised"

--- a/tests/01_engine-fsize.test
+++ b/tests/01_engine-fsize.test
@@ -19,7 +19,4 @@ echo "$out"
 [ "$rc" = 0 ] || exit "$rc"
 
 want="fsize: width=8,8 size=5368709120,5368709120 psize=5368709120 absent=-1"
-test "$out" == "$want" || {
-    echo "FAIL: unexpected size report (want '$want')"
-    exit 1
-}
+test "$out" == "$want" || fail "unexpected size report (want '$want')"

--- a/tests/01_engine-rcfile.test
+++ b/tests/01_engine-rcfile.test
@@ -18,10 +18,7 @@ set -euo pipefail
 
 # Resolve httrack to an absolute path before we cd: PATH may hold a build-relative
 # entry that would not resolve from the temp directory.
-bin=$(command -v httrack) || {
-    echo "FAIL: httrack not found on PATH"
-    exit 1
-}
+bin=$(command -v httrack) || fail "httrack not found on PATH"
 case "$bin" in
 /*) ;;
 *) bin="$(cd "$(dirname "$bin")" && pwd)/$(basename "$bin")" ;;
@@ -53,10 +50,7 @@ printf 'user-agent=%s\n' "$marker" | write_rc "$d1"
 rc=0
 (cd "$d1" && "$bin" "file://$d1/index.html" --quiet -n >.log 2>&1) || rc=$?
 
-test "$rc" -eq 0 || {
-    echo "FAIL: rc-file crawl exited $rc"
-    exit 1
-}
+test "$rc" -eq 0 || fail "rc-file crawl exited $rc"
 assert_file "$d1/hts-cache/doit.log" "no doit.log, so the rc file was not processed"
 # A truncated copy would cut the token; require the full -F value.
 grep -q -- "-F $marker" "$d1/hts-cache/doit.log" || {
@@ -98,15 +92,9 @@ assert_file "$d2/hts-cache/doit.log" "no doit.log, so the rc file was not proces
 # is the command line, so the prose below it cannot answer for a token.
 short=$(sed -n '1p' "$d2/hts-cache/doit.log" | tr ' ' '\n' |
     awk -v n="${#val}" '/^a+$/ && length($0) != n {c++} END {print c + 0}')
-test "$short" -eq 0 || {
-    echo "FAIL: $short user-agent value(s) reached doit.log clipped"
-    exit 1
-}
+test "$short" -eq 0 || fail "$short user-agent value(s) reached doit.log clipped"
 for marker in "$first" "$last"; do
-    grep -q -- "-F $marker" "$d2/hts-cache/doit.log" || {
-        echo "FAIL: $marker never reached the rebuilt command line"
-        exit 1
-    }
+    grep -q -- "-F $marker" "$d2/hts-cache/doit.log" || fail "$marker never reached the rebuilt command line"
 done
 
 exit 0

--- a/tests/01_engine-reconcile.test
+++ b/tests/01_engine-reconcile.test
@@ -13,7 +13,4 @@ cleanup_push rm -rf "$dir"
 
 out=$(httrack -#test=reconcile "$dir")
 
-test "$out" = "cache-reconcile: OK" || {
-    echo "expected 'cache-reconcile: OK', got: $out" >&2
-    exit 1
-}
+test "$out" = "cache-reconcile: OK" || fail "expected 'cache-reconcile: OK', got: $out"

--- a/tests/01_zlib-cache-corrupt.test
+++ b/tests/01_zlib-cache-corrupt.test
@@ -15,7 +15,4 @@ cleanup_push rm -rf "$dir"
 # stdout; the verdict is the last line
 out=$(httrack -#test=cache-corrupt "$dir" 2>/dev/null | tail -n1)
 
-test "$out" = "cache-corrupt: OK" || {
-    echo "expected 'cache-corrupt: OK', got: $out" >&2
-    exit 1
-}
+test "$out" = "cache-corrupt: OK" || fail "expected 'cache-corrupt: OK', got: $out"

--- a/tests/01_zlib-cache-golden.test
+++ b/tests/01_zlib-cache-golden.test
@@ -37,7 +37,4 @@ out=$(httrack -#test=cache-golden "$dir")
 # Match the exact success line: the read must have found and verified every
 # entry, not merely failed to enter the mode (a renamed/removed test prints the
 # registry to stderr, which also exits non-zero but never prints this).
-test "$out" = "cache-golden: OK" || {
-    echo "expected 'cache-golden: OK', got: $out" >&2
-    exit 1
-}
+test "$out" = "cache-golden: OK" || fail "expected 'cache-golden: OK', got: $out"

--- a/tests/01_zlib-cache-legacy.test
+++ b/tests/01_zlib-cache-legacy.test
@@ -13,13 +13,7 @@ cleanup_push rm -rf "$dir"
 # the refusal errors land on stdout (no log file); pin them and the verdict
 out=$(httrack -#test=cache-legacy "$dir" 2>/dev/null)
 cnt=$(printf '%s\n' "$out" | grep -c 'no longer supported' || true)
-test "$cnt" = 2 || {
-    echo "expected 2 refusal messages, got $cnt" >&2
-    exit 1
-}
+test "$cnt" = 2 || fail "expected 2 refusal messages, got $cnt"
 out=$(printf '%s\n' "$out" | tail -n1)
 
-test "$out" = "cache-legacy: OK" || {
-    echo "expected 'cache-legacy: OK', got: $out" >&2
-    exit 1
-}
+test "$out" = "cache-legacy: OK" || fail "expected 'cache-legacy: OK', got: $out"

--- a/tests/01_zlib-cache-writefail.test
+++ b/tests/01_zlib-cache-writefail.test
@@ -17,13 +17,7 @@ out=$(httrack -#test=cache-writefail "$dir")
 
 # Match the exact success line (error logs also go to stdout); a renamed/removed
 # test prints the registry to stderr, which exits non-zero but never prints this.
-grep -qx "cache-writefail: OK" <<<"$out" || {
-    echo "expected 'cache-writefail: OK', got: $out" >&2
-    exit 1
-}
+grep -qx "cache-writefail: OK" <<<"$out" || fail "expected 'cache-writefail: OK', got: $out"
 
 # A skipped entry must be warned about with its URL.
-grep -q "entry not cached: example.com/" <<<"$out" || {
-    echo "expected a URL-bearing skip warning" >&2
-    exit 1
-}
+grep -q "entry not cached: example.com/" <<<"$out" || fail "expected a URL-bearing skip warning"

--- a/tests/01_zlib-cache.test
+++ b/tests/01_zlib-cache.test
@@ -25,10 +25,7 @@ out=$(httrack -#test=cache "$dir")
 # Match the exact success line, so the test cannot pass for an unrelated reason
 # (e.g. the cache test being gone, which prints the registry to stderr but
 # never prints this line).
-test "$out" = "cache-selftest: OK" || {
-    echo "expected 'cache-selftest: OK', got: $out" >&2
-    exit 1
-}
+test "$out" = "cache-selftest: OK" || fail "expected 'cache-selftest: OK', got: $out"
 
 # The self-test must have actually produced a ZIP cache on disk.
 assert_file "$dir/hts-cache/new.zip" "the self-test wrote no ZIP cache"
@@ -41,7 +38,4 @@ assert_file "$dir/hts-cache/new.zip" "the self-test wrote no ZIP cache"
 # which is all a ceiling check needs.
 ceiling=$((4 * 1024)) # KiB
 kbytes=$(du -sk "$dir/hts-cache" | cut -f1)
-test "$kbytes" -le "$ceiling" || {
-    echo "cache footprint ${kbytes} KiB exceeds ${ceiling} KiB ceiling" >&2
-    exit 1
-}
+test "$kbytes" -le "$ceiling" || fail "cache footprint ${kbytes} KiB exceeds ${ceiling} KiB ceiling"

--- a/tests/01_zlib-repair-shift.test
+++ b/tests/01_zlib-repair-shift.test
@@ -15,7 +15,4 @@ cleanup_push rm -rf "$dir"
 
 out=$(httrack -#test=zip-repair-shift "$dir")
 
-grep -qx "zip-repair-shift: OK (recovered 1 entry)" <<<"$out" || {
-    echo "expected 'zip-repair-shift: OK (recovered 1 entry)', got: $out" >&2
-    exit 1
-}
+grep -qx "zip-repair-shift: OK (recovered 1 entry)" <<<"$out" || fail "expected 'zip-repair-shift: OK (recovered 1 entry)', got: $out"

--- a/tests/01_zlib-savename-cached.test
+++ b/tests/01_zlib-savename-cached.test
@@ -18,10 +18,7 @@ name() {
     local fil="$1" ctype="$2" want="$3"
     shift 3
     out="$("$httrack_bin" -O /dev/null -#test=savename "$fil" "$ctype" "$@" | sed -n 's/^savename: //p')"
-    test "${out##*/}" == "$want" || {
-        echo "FAIL: '$fil' '$ctype' $* -> '$out' (want '$want')"
-        exit 1
-    }
+    test "${out##*/}" == "$want" || fail "'$fil' '$ctype' $* -> '$out' (want '$want')"
 }
 
 # No live bytes: the recorded save name (X-Save) reproduces the previous

--- a/tests/02_manpage-regen.test
+++ b/tests/02_manpage-regen.test
@@ -26,10 +26,7 @@ committed_clean=$(mktemp) || exit 1
 generated_clean=$(mktemp) || exit 1
 cleanup_push rm -f "$tmp" "$committed_clean" "$generated_clean"
 
-README="$top_srcdir/README" bash "$gen" httrack >"$tmp" 2>/dev/null || {
-    echo "makeman.sh failed" >&2
-    exit 1
-}
+README="$top_srcdir/README" bash "$gen" httrack >"$tmp" 2>/dev/null || fail "makeman.sh failed"
 
 # Ignore the two intentionally date-dependent lines (page date, copyright year).
 # Temp files, not process substitution, so this works under a POSIX /bin/sh.

--- a/tests/02_update-cache.test
+++ b/tests/02_update-cache.test
@@ -32,33 +32,18 @@ errors() { grep -ciE '^[0-9:]*[[:space:]]Error:' "$out/hts-log.txt" || true; }
 
 # 1. fresh mirror writes the cache
 httrack "$url" -O "$out" -q -%v0 -r3 >/dev/null 2>&1
-test -e "$out/hts-cache/new.zip" || {
-    echo "no cache was written" >&2
-    exit 1
-}
+test -e "$out/hts-cache/new.zip" || fail "no cache was written"
 
 # 2. re-mirror unchanged: the update reads the cache and must complete cleanly
 httrack "$url" -O "$out" -q -%v0 -r3 >/dev/null 2>&1
-test "$(errors)" = 0 || {
-    echo "update (unchanged) reported errors" >&2
-    exit 1
-}
+test "$(errors)" = 0 || fail "update (unchanged) reported errors"
 for suffix in a.html sub/b.html; do
-    test -n "$(find "$out" -path "*/$suffix" -print -quit)" || {
-        echo "missing $suffix after update" >&2
-        exit 1
-    }
+    test -n "$(find "$out" -path "*/$suffix" -print -quit)" || fail "missing $suffix after update"
 done
 
 # 3. change a source file: the update must pick up the new content
 sleep 1
 echo 'NEWCONTENT' >"$site/a.html"
 httrack "$url" -O "$out" -q -%v0 -r3 >/dev/null 2>&1
-test "$(errors)" = 0 || {
-    echo "update (changed) reported errors" >&2
-    exit 1
-}
-grep -q NEWCONTENT "$(find "$out" -path '*/a.html')" || {
-    echo "update did not pick up the changed source" >&2
-    exit 1
-}
+test "$(errors)" = 0 || fail "update (changed) reported errors"
+grep -q NEWCONTENT "$(find "$out" -path '*/a.html')" || fail "update did not pick up the changed source"

--- a/tests/100_local-purge-longpath.test
+++ b/tests/100_local-purge-longpath.test
@@ -72,10 +72,7 @@ cd "$work/proj" # no -O: opt->path_html stays empty
 "$httrack_bin" "http://127.0.0.1:$port/" -q -%v0 -s0 -r3 >"$work/crawl1.log" 2>&1 || true
 
 lst=$work/proj/hts-cache/new.lst
-test -f "$lst" || {
-    echo "pass 1 produced no new.lst" >&2
-    exit 1
-}
+test -f "$lst" || fail "pass 1 produced no new.lst"
 # Arms the test: without a line of exactly 1000 bytes linput() never splits and
 # the purge never sees a one-byte tail.
 awk 'length == 1000 { found = 1 } END { exit !found }' "$lst" || {
@@ -89,7 +86,4 @@ awk 'length == 1000 { found = 1 } END { exit !found }' "$lst" || {
 # Pass 2 renames new.lst to old.lst and runs it through the purge loop.
 "$httrack_bin" "http://127.0.0.1:$port/" -q -%v0 -s0 -r3 >"$work/crawl2.log" 2>&1
 
-test -s "$work/proj/$prefix$urlpath" || {
-    echo "the mirrored leaf did not survive the purge" >&2
-    exit 1
-}
+test -s "$work/proj/$prefix$urlpath" || fail "the mirrored leaf did not survive the purge"

--- a/tests/102_local-ftp-refetch.test
+++ b/tests/102_local-ftp-refetch.test
@@ -11,10 +11,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || {
-    echo "could not find httrack" >&2
-    exit 1
-}
+command -v httrack >/dev/null || fail "could not find httrack"
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -12,10 +12,7 @@ set -eu
 . "$(dirname "$0")/proclib.sh"
 
 driver="${testdir}/test-timeout.sh"
-test -r "$driver" || {
-    echo "no test-timeout.sh next to $0" >&2
-    exit 1
-}
+test -r "$driver" || fail "no test-timeout.sh next to $0"
 
 fail() {
     echo "FAIL: $*" >&2

--- a/tests/106_engine-repair-rename.test
+++ b/tests/106_engine-repair-rename.test
@@ -30,18 +30,9 @@ printf '[-#R repairs in place] ..\t'
 proj="${tmpdir}/cli"
 plant_damaged_cache "$proj"
 out=$(httrack -O "$proj" -#R "$dead" 2>&1)
-grep -q 'successfully recovered' <<<"$out" || {
-    echo "FAIL: no recovery reported: $out"
-    exit 1
-}
-test ! -e "${proj}/hts-cache/repair.zip" || {
-    echo "FAIL: the recovery was left in repair.zip"
-    exit 1
-}
-test "$(wc -c <"${proj}/hts-cache/new.zip")" -gt 31 || {
-    echo "FAIL: new.zip is still the damaged one"
-    exit 1
-}
+grep -q 'successfully recovered' <<<"$out" || fail "no recovery reported: $out"
+test ! -e "${proj}/hts-cache/repair.zip" || fail "the recovery was left in repair.zip"
+test "$(wc -c <"${proj}/hts-cache/new.zip")" -gt 31 || fail "new.zip is still the damaged one"
 echo "OK"
 
 # --- #824: nothing was recoverable, so nothing may be committed --------------
@@ -52,18 +43,12 @@ mkdir -p "$proj/hts-cache"
 printf 'not a zip at all, some bytes' >"$proj/hts-cache/new.zip"
 rc=0
 out=$(httrack -O "$proj" -#R "$dead" 2>&1) || rc=$?
-test "$rc" -ne 0 || {
-    echo "FAIL: an empty recovery exited 0: $out"
-    exit 1
-}
+test "$rc" -ne 0 || fail "an empty recovery exited 0: $out"
 if grep -q 'successfully recovered' <<<"$out"; then
     echo "FAIL: an empty recovery claimed success: $out"
     exit 1
 fi
-test "$(wc -c <"${proj}/hts-cache/new.zip")" -eq 28 || {
-    echo "FAIL: the damaged cache was replaced by the empty recovery"
-    exit 1
-}
+test "$(wc -c <"${proj}/hts-cache/new.zip")" -eq 28 || fail "the damaged cache was replaced by the empty recovery"
 echo "OK"
 
 if [ "$HTS_OS" != "Linux" ]; then
@@ -97,22 +82,13 @@ proj="${tmpdir}/cli-fail"
 plant_damaged_cache "$proj"
 rc=0
 out=$(httrack -O "$proj" -#R "$dead" 2>&1) || rc=$?
-test "$rc" -ne 0 || {
-    echo "FAIL: a refused move exited 0: $out"
-    exit 1
-}
+test "$rc" -ne 0 || fail "a refused move exited 0: $out"
 if grep -q 'successfully recovered' <<<"$out"; then
     echo "FAIL: a refused move still claimed success: $out"
     exit 1
 fi
-test -s "${proj}/hts-cache/repair.zip" || {
-    echo "FAIL: the recovery was not kept for a retry"
-    exit 1
-}
-test "$(wc -c <"${proj}/hts-cache/new.zip")" -eq 31 || {
-    echo "FAIL: the damaged cache was destroyed anyway"
-    exit 1
-}
+test -s "${proj}/hts-cache/repair.zip" || fail "the recovery was not kept for a retry"
+test "$(wc -c <"${proj}/hts-cache/new.zip")" -eq 31 || fail "the damaged cache was destroyed anyway"
 echo "OK"
 
 # --- the engine path (cache_init), move refused ------------------------------
@@ -121,14 +97,8 @@ proj="${tmpdir}/engine"
 plant_damaged_cache "$proj"
 httrack -O "$proj" "$dead" --timeout=2 --retries=0 -q >/dev/null 2>&1 || true
 log="${proj}/hts-log.txt"
-test -r "$log" || {
-    echo "FAIL: no crawl log"
-    exit 1
-}
-grep -q 'damaged cache' "$log" || {
-    echo "FAIL: the repair path never ran"
-    exit 1
-}
+test -r "$log" || fail "no crawl log"
+grep -q 'damaged cache' "$log" || fail "the repair path never ran"
 grep -q 'could not put the repaired cache in place' "$log" || {
     echo "FAIL: a refused move was not reported: $(grep -i cache "$log")"
     exit 1
@@ -137,10 +107,7 @@ if grep -q 'successfully recovered' "$log"; then
     echo "FAIL: a refused move still claimed success"
     exit 1
 fi
-test -s "${proj}/hts-cache/repair.zip" || {
-    echo "FAIL: the recovery was not kept for a retry"
-    exit 1
-}
+test -s "${proj}/hts-cache/repair.zip" || fail "the recovery was not kept for a retry"
 echo "OK"
 
 # --- the move is refused the way Windows refuses it --------------------------
@@ -151,21 +118,9 @@ proj="${tmpdir}/eexist"
 plant_damaged_cache "$proj"
 rc=0
 out=$(RENAMEFAIL_MODE=repair-eexist httrack -O "$proj" -#R "$dead" 2>&1) || rc=$?
-test "$rc" -ne 0 || {
-    echo "FAIL: a refused fallback exited 0: $out"
-    exit 1
-}
-test "$(wc -c <"${proj}/hts-cache/new.zip")" -eq 31 || {
-    echo "FAIL: the fallback destroyed the cache"
-    exit 1
-}
-test -s "${proj}/hts-cache/repair.zip" || {
-    echo "FAIL: the recovery was not kept for a retry"
-    exit 1
-}
+test "$rc" -ne 0 || fail "a refused fallback exited 0: $out"
+test "$(wc -c <"${proj}/hts-cache/new.zip")" -eq 31 || fail "the fallback destroyed the cache"
+test -s "${proj}/hts-cache/repair.zip" || fail "the recovery was not kept for a retry"
 leftover=$(find "${proj}/hts-cache" -name '*.hts-old*' | head -1)
-test -z "$leftover" || {
-    echo "FAIL: the parked copy was left behind: $leftover"
-    exit 1
-}
+test -z "$leftover" || fail "the parked copy was left behind: $leftover"
 echo "OK"

--- a/tests/108_engine-refetch-backup.test
+++ b/tests/108_engine-refetch-backup.test
@@ -20,7 +20,4 @@ fi
 
 # The temporaries live in ~hts-tmp and the last user removes it.
 leftovers=$(find "$dir" -mindepth 1 | head -5)
-test -z "$leftovers" || {
-    echo "FAIL: leftover temporaries: $leftovers" >&2
-    exit 1
-}
+test -z "$leftovers" || fail "leftover temporaries: $leftovers"

--- a/tests/110_local-ftp-parallel.test
+++ b/tests/110_local-ftp-parallel.test
@@ -11,10 +11,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || {
-    echo "could not find httrack" >&2
-    exit 1
-}
+command -v httrack >/dev/null || fail "could not find httrack"
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")

--- a/tests/111_local-ftp-update-rest.test
+++ b/tests/111_local-ftp-update-rest.test
@@ -11,10 +11,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || {
-    echo "could not find httrack" >&2
-    exit 1
-}
+command -v httrack >/dev/null || fail "could not find httrack"
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")

--- a/tests/113_engine-threadattr-leak.test
+++ b/tests/113_engine-threadattr-leak.test
@@ -56,8 +56,5 @@ test "${sabotaged:-0}" -ge 1 || {
     cat "$dir/out" >&2
     exit 1
 }
-test "${undestroyed:-1}" -eq 0 || {
-    echo "threadattr: $undestroyed of $sabotaged attributes objects survived a refused pthread_create()" >&2
-    exit 1
-}
+test "${undestroyed:-1}" -eq 0 || fail "threadattr: $undestroyed of $sabotaged attributes objects survived a refused pthread_create()"
 echo "OK: a refused pthread_create() destroys the attributes object ($sabotaged refused)"

--- a/tests/116_engine-rtrim.test
+++ b/tests/116_engine-rtrim.test
@@ -11,10 +11,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 # Resolve httrack before any cd: PATH may carry a build-relative entry.
-bin=$(command -v httrack) || {
-    echo "FAIL: httrack not found on PATH" >&2
-    exit 1
-}
+bin=$(command -v httrack) || fail "httrack not found on PATH"
 case "$bin" in
 /*) ;;
 *) bin="$(cd "$(dirname "$bin")" && pwd)/$(basename "$bin")" ;;

--- a/tests/121_local-ftp-nocache-splice.test
+++ b/tests/121_local-ftp-nocache-splice.test
@@ -11,10 +11,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || {
-    echo "could not find httrack" >&2
-    exit 1
-}
+command -v httrack >/dev/null || fail "could not find httrack"
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")

--- a/tests/13_crawl_proxy_https.test
+++ b/tests/13_crawl_proxy_https.test
@@ -100,10 +100,7 @@ echo "OK: https tunneled through proxy via CONNECT"
 : >"$ok/proxy.log"
 : >"$ok/origin-headers.log"
 run_crawl "$ok/out2" "user:secret@127.0.0.1:${proxy_port}" "$origin_port"
-grep -rq "ORIGIN-PAGE-85" "$ok/out2" || {
-    echo "FAIL: origin page not downloaded through authenticated proxy" >&2
-    exit 1
-}
+grep -rq "ORIGIN-PAGE-85" "$ok/out2" || fail "origin page not downloaded through authenticated proxy"
 got=$(awk '/^AUTH Basic /{print $3}' "$ok/proxy.log" | head -1)
 # base64("user:secret"); compared as a literal to stay portable (no base64 -d,
 # which differs between GNU and BSD)
@@ -127,10 +124,7 @@ flood="$tmpdir/flood"
 start_server "$flood" flood
 rc=0
 run_crawl "$flood/out" "127.0.0.1:${proxy_port}" "$origin_port" || rc=$?
-test "$rc" -ne "$HANG_RC" || {
-    echo "FAIL: crawl hung on a flooding proxy (bounded read missing)" >&2
-    exit 1
-}
+test "$rc" -ne "$HANG_RC" || fail "crawl hung on a flooding proxy (bounded read missing)"
 grep -rq "ORIGIN-PAGE-85" "$flood/out" 2>/dev/null && {
     echo "FAIL: flooding proxy unexpectedly served the page" >&2
     exit 1

--- a/tests/144_engine-datadir.test
+++ b/tests/144_engine-datadir.test
@@ -7,10 +7,7 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-work=$(mktemp -d "${TMPDIR:-/tmp}/datadir.XXXXXX") || {
-    echo "no tmpdir" >&2
-    exit 1
-}
+work=$(mktemp -d "${TMPDIR:-/tmp}/datadir.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "${work}"
 
 httrack -#test=datadir "${work}"

--- a/tests/146_bash-shell.test
+++ b/tests/146_bash-shell.test
@@ -11,20 +11,11 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 sh=${BASH_SHELL:-}
-test -n "$sh" || {
-    echo "BASH_SHELL is empty; tests/Makefile.am must export the configured value" >&2
-    exit 1
-}
-test -x "$sh" || {
-    echo "BASH_SHELL=$sh is not an executable file" >&2
-    exit 1
-}
+test -n "$sh" || fail "BASH_SHELL is empty; tests/Makefile.am must export the configured value"
+test -x "$sh" || fail "BASH_SHELL=$sh is not an executable file"
 
 version=$("$sh" -c 'echo "${BASH_VERSION:-}"')
-test -n "$version" || {
-    echo "BASH_SHELL=$sh sets no BASH_VERSION, so it is not a bash" >&2
-    exit 1
-}
+test -n "$version" || fail "BASH_SHELL=$sh sets no BASH_VERSION, so it is not a bash"
 
 # sh-mode bash sets BASH_VERSION too, so the version alone proves nothing.
 opts=$("$sh" -c 'echo ":${SHELLOPTS:-}:"')
@@ -36,27 +27,15 @@ case "$opts" in
 esac
 
 # The test helpers use process substitution, which macOS's bash-3.2-as-sh rejects.
-out=$("$sh" -c 'cat <(echo procsub)' 2>&1) || {
-    echo "BASH_SHELL=$sh cannot run a process substitution: $out" >&2
-    exit 1
-}
-test "$out" = procsub || {
-    echo "expected 'procsub' from BASH_SHELL=$sh, got: $out" >&2
-    exit 1
-}
+out=$("$sh" -c 'cat <(echo procsub)' 2>&1) || fail "BASH_SHELL=$sh cannot run a process substitution: $out"
+test "$out" = procsub || fail "expected 'procsub' from BASH_SHELL=$sh, got: $out"
 
 # Whatever configure picks, an absolute BASH_SHELL from the user must win over the search.
 configure="${abs_top_srcdir:-}/configure"
-test -r "$configure" || {
-    echo "no configure script at $configure; tests/Makefile.am must export abs_top_srcdir" >&2
-    exit 1
-}
+test -r "$configure" || fail "no configure script at $configure; tests/Makefile.am must export abs_top_srcdir"
 
 help=$(bash "$configure" --help)
-grep -q '^  *BASH_SHELL ' <<<"$help" || {
-    echo "configure --help does not advertise BASH_SHELL (AC_ARG_VAR missing)" >&2
-    exit 1
-}
+grep -q '^  *BASH_SHELL ' <<<"$help" || fail "configure --help does not advertise BASH_SHELL (AC_ARG_VAR missing)"
 
 tmp=$(mktemp -d)
 cleanup_push rm -rf "$tmp"

--- a/tests/147_local-proxytrack-webdav-overflow.test
+++ b/tests/147_local-proxytrack-webdav-overflow.test
@@ -63,10 +63,7 @@ grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
 # Count what came back: a clipped path answers 207 too. The run appears in
 # the href and again in the displayname.
 got=$({ grep -o '&amp;' <<<"$resp" || true; } | wc -l)
-test "$got" -eq 1800 || {
-    echo "FAIL: 900 ampersands went in, $got came back escaped, wanted 1800"
-    exit 1
-}
+test "$got" -eq 1800 || fail "900 ampersands went in, $got came back escaped, wanted 1800"
 
 # Unescaped, so the bound is shown to be on the written length, not on '&'.
 plain=$("$python" -c "print('a' * 900)" | tr -d '\r')
@@ -75,10 +72,7 @@ resp=$(propfind "$plain") || {
     cat "$ptlog"
     exit 1
 }
-grep -q "<href>/webdav/x/$plain</href>" <<<"$resp" || {
-    echo "FAIL: a 900-byte path did not come back whole"
-    exit 1
-}
+grep -q "<href>/webdav/x/$plain</href>" <<<"$resp" || fail "a 900-byte path did not come back whole"
 
 # Depth: 1 is the only route into the enumeration branch, which builds each
 # item URL from the prefix and the child name. A child directory is enumerated

--- a/tests/148_engine-spoolname.test
+++ b/tests/148_engine-spoolname.test
@@ -7,10 +7,7 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-work=$(mktemp -d "${TMPDIR:-/tmp}/spoolname.XXXXXX") || {
-    echo "no tmpdir" >&2
-    exit 1
-}
+work=$(mktemp -d "${TMPDIR:-/tmp}/spoolname.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "${work}"
 
 httrack -#test=spoolname "${work}"

--- a/tests/150_engine-strsprintf.test
+++ b/tests/150_engine-strsprintf.test
@@ -10,10 +10,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 # Resolve httrack before any cd: PATH may carry a build-relative entry.
-bin=$(command -v httrack) || {
-    echo "FAIL: httrack not found on PATH" >&2
-    exit 1
-}
+bin=$(command -v httrack) || fail "httrack not found on PATH"
 
 out=$("$bin" -#test=strsprintf) || fail "httrack -#test=strsprintf exited non-zero: $out"
 test "$out" = "strsprintf self-test: OK" || fail "expected 'strsprintf self-test: OK', got: $out"

--- a/tests/151_bash-shell-validate.test
+++ b/tests/151_bash-shell-validate.test
@@ -12,16 +12,10 @@ set -euo pipefail
 . "${0%"${0##*/}"}./proclib.sh"
 
 sh=${BASH_SHELL:-}
-test -n "$sh" || {
-    echo "BASH_SHELL is empty; tests/Makefile.am must export the configured value" >&2
-    exit 1
-}
+test -n "$sh" || fail "BASH_SHELL is empty; tests/Makefile.am must export the configured value"
 
 configure="${abs_top_srcdir:-}/configure"
-test -r "$configure" || {
-    echo "no configure script at $configure; tests/Makefile.am must export abs_top_srcdir" >&2
-    exit 1
-}
+test -r "$configure" || fail "no configure script at $configure; tests/Makefile.am must export abs_top_srcdir"
 
 tmp=$(mktemp -d)
 cleanup() {
@@ -133,10 +127,7 @@ reject() { # reject <label> <expected message> <env argument>...
     local label=$1 want=$2
     shift 2
     run "$label" "$@"
-    test "$status" -ne 0 || {
-        echo "configure accepted $label" >&2
-        exit 1
-    }
+    test "$status" -ne 0 || fail "configure accepted $label"
     grep -q "$want" <<<"$log" || {
         echo "$label rejected without '$want':" >&2
         tail -5 <<<"$log" >&2
@@ -156,10 +147,7 @@ accept() {
         exit 1
     }
     got=$(sed -n 's/^BASH_SHELL = //p' "$rundir/Makefile")
-    test -n "$got" || {
-        echo "$label configured, but the Makefile carries no BASH_SHELL" >&2
-        exit 1
-    }
+    test -n "$got" || fail "$label configured, but the Makefile carries no BASH_SHELL"
     if test -n "$path" && test "$got" != "$path"; then
         echo "$label reached the Makefile as $got" >&2
         exit 1

--- a/tests/153_local-proxytrack-quiet.test
+++ b/tests/153_local-proxytrack-quiet.test
@@ -82,10 +82,7 @@ request_log() { # log
 wait_drained() { # log
     local waited=0
     until test -e "$1.done"; do
-        test "$waited" -lt 100 || {
-            echo "FAIL: the pty drainer never finished copying the output"
-            exit 1
-        }
+        test "$waited" -lt 100 || fail "the pty drainer never finished copying the output"
         sleep 0.1
         waited=$((waited + 1))
     done

--- a/tests/159_local-header-injection.test
+++ b/tests/159_local-header-injection.test
@@ -34,14 +34,8 @@ start_probe() {
 crawl() {
     local rc=0
     run_with_timeout 90 httrack "$@" >>"$tmpdir/log" 2>&1 || rc=$?
-    test "$rc" -ne 124 || {
-        echo "crawl hit the deadline" >&2
-        exit 1
-    }
-    test "$rc" -le 128 || {
-        echo "crawl ended abnormally ($rc)" >&2
-        exit 1
-    }
+    test "$rc" -ne 124 || fail "crawl hit the deadline"
+    test "$rc" -le 128 || fail "crawl ended abnormally ($rc)"
 }
 
 # 1. Referer: the poisoned page links onward, so its own URL is the referer of

--- a/tests/163_icon-theme.test
+++ b/tests/163_icon-theme.test
@@ -12,10 +12,7 @@ srcdir="${abs_top_srcdir:?not run under make check}"
 builddir="${abs_top_builddir:?not run under make check}"
 div="${srcdir}/html/server/div"
 
-work=$(mktemp -d "${TMPDIR:-/tmp}/icontheme.XXXXXX") || {
-    echo "no tmpdir" >&2
-    exit 1
-}
+work=$(mktemp -d "${TMPDIR:-/tmp}/icontheme.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "${work}"
 
 # IHDR width and height, and a signature check so a non-PNG cannot answer.

--- a/tests/195_install-relocate.test
+++ b/tests/195_install-relocate.test
@@ -13,10 +13,7 @@ bindir="${CONFIGURED_BINDIR:?not run under make check}"
 libdir="${CONFIGURED_LIBDIR:?not run under make check}"
 libdir=${libdir%/}
 
-work=$(mktemp -d "${TMPDIR:-/tmp}/relocate.XXXXXX") || {
-    echo "no tmpdir" >&2
-    exit 1
-}
+work=$(mktemp -d "${TMPDIR:-/tmp}/relocate.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "${work}"
 
 stage=${work}/stage

--- a/tests/196_install-rpath-gates.test
+++ b/tests/196_install-rpath-gates.test
@@ -11,10 +11,7 @@ set -euo pipefail
 srcdir="${abs_top_srcdir:?not run under make check}"
 test -r "${srcdir}/configure" || skip "no configure in ${srcdir}"
 
-work=$(mktemp -d "${TMPDIR:-/tmp}/rpathgate.XXXXXX") || {
-    echo "no tmpdir" >&2
-    exit 1
-}
+work=$(mktemp -d "${TMPDIR:-/tmp}/rpathgate.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "${work}"
 
 # automake refuses an out-of-tree configure when srcdir holds a config.status,

--- a/tests/200_pixmaps-fallback.test
+++ b/tests/200_pixmaps-fallback.test
@@ -12,10 +12,7 @@ srcdir="${abs_top_srcdir:?not run under make check}"
 builddir="${abs_top_builddir:?not run under make check}"
 div="${srcdir}/html/server/div"
 
-work=$(mktemp -d "${TMPDIR:-/tmp}/pixmaps.XXXXXX") || {
-    echo "no tmpdir" >&2
-    exit 1
-}
+work=$(mktemp -d "${TMPDIR:-/tmp}/pixmaps.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "${work}"
 
 # Geometry from the first string literal, with a header check so a text file

--- a/tests/210_appstream-metainfo.test
+++ b/tests/210_appstream-metainfo.test
@@ -34,25 +34,16 @@ test ${#tools[@]} -gt 0 || {
 
 # html/Makefile.am installs these by glob; a second one must not ship unchecked.
 metainfos=("${srcdir}"/html/server/div/*.metainfo.xml)
-test -f "${metainfos[0]}" || {
-    echo "FAIL: no metainfo under ${srcdir}/html/server/div" >&2
-    exit 1
-}
+test -f "${metainfos[0]}" || fail "no metainfo under ${srcdir}/html/server/div"
 
-work=$(mktemp -d "${TMPDIR:-/tmp}/appstream.XXXXXX") || {
-    echo "no tmpdir" >&2
-    exit 1
-}
+work=$(mktemp -d "${TMPDIR:-/tmp}/appstream.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "${work}"
 
 for metainfo in "${metainfos[@]}"; do
     # Positive control: a validator that never fails would pass the check below.
     sed '/<id>/d' "${metainfo}" >"${work}/noid.xml"
     for tool in "${tools[@]}"; do
-        validate "${tool}" "${metainfo}" || {
-            echo "FAIL: ${metainfo##*/} does not validate under ${tool}" >&2
-            exit 1
-        }
+        validate "${tool}" "${metainfo}" || fail "${metainfo##*/} does not validate under ${tool}"
         if validate "${tool}" "${work}/noid.xml" >"${work}/noid.log" 2>&1; then
             echo "FAIL: ${tool} validated a metainfo with no <id>; it proves nothing" >&2
             exit 1

--- a/tests/215_engine-datadir-ospath.test
+++ b/tests/215_engine-datadir-ospath.test
@@ -28,10 +28,7 @@ if [ -r "${builtin}/templates/index-header.html" ]; then
     skip "the compiled-in data directory ${builtin} answers before the executable's tree"
 fi
 
-work=$(mktemp -d "${TMPDIR:-/tmp}/ospath.XXXXXX") || {
-    echo "no tmpdir" >&2
-    exit 1
-}
+work=$(mktemp -d "${TMPDIR:-/tmp}/ospath.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "${work}"
 
 # Two installed-looking trees, each with the templates file path_bin is read

--- a/tests/219_install-rpath-darwin.test
+++ b/tests/219_install-rpath-darwin.test
@@ -18,10 +18,7 @@ libdir=${libdir%/}
 test "$HTS_OS" = Darwin || skip "no Mach-O install commands to read here"
 command -v otool >/dev/null 2>&1 || skip "no otool"
 
-work=$(mktemp -d "${TMPDIR:-/tmp}/rpathid.XXXXXX") || {
-    echo "no tmpdir" >&2
-    exit 1
-}
+work=$(mktemp -d "${TMPDIR:-/tmp}/rpathid.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "${work}"
 
 stage=${work}/stage

--- a/tests/221_local-ftp-ctrlchars.test
+++ b/tests/221_local-ftp-ctrlchars.test
@@ -11,10 +11,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || {
-    echo "could not find httrack" >&2
-    exit 1
-}
+command -v httrack >/dev/null || fail "could not find httrack"
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")

--- a/tests/225_install-manifest.test
+++ b/tests/225_install-manifest.test
@@ -26,10 +26,7 @@ case "${CONFIGURED_DATADIR:?not run under make check}" in
     ;;
 esac
 
-work=$(mktemp -d "${TMPDIR:-/tmp}/manifest.XXXXXX") || {
-    echo "no tmpdir" >&2
-    exit 1
-}
+work=$(mktemp -d "${TMPDIR:-/tmp}/manifest.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "${work}"
 
 stage=${work}/stage

--- a/tests/230_local-ftp-userpass.test
+++ b/tests/230_local-ftp-userpass.test
@@ -10,10 +10,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || {
-    echo "could not find httrack" >&2
-    exit 1
-}
+command -v httrack >/dev/null || fail "could not find httrack"
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpuser.XXXXXX")

--- a/tests/233_local-ftp-ctrl-timeout.test
+++ b/tests/233_local-ftp-ctrl-timeout.test
@@ -9,10 +9,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || {
-    echo "could not find httrack" >&2
-    exit 1
-}
+command -v httrack >/dev/null || fail "could not find httrack"
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftptmo.XXXXXX")

--- a/tests/234_local-ftp-maxtime.test
+++ b/tests/234_local-ftp-maxtime.test
@@ -9,10 +9,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || {
-    echo "could not find httrack" >&2
-    exit 1
-}
+command -v httrack >/dev/null || fail "could not find httrack"
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpmax.XXXXXX")

--- a/tests/236_local-ftp-teardown.test
+++ b/tests/236_local-ftp-teardown.test
@@ -9,10 +9,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || {
-    echo "could not find httrack" >&2
-    exit 1
-}
+command -v httrack >/dev/null || fail "could not find httrack"
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")

--- a/tests/243_local-ftp-deadhost-interrupt.test
+++ b/tests/243_local-ftp-deadhost-interrupt.test
@@ -9,10 +9,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || {
-    echo "could not find httrack" >&2
-    exit 1
-}
+command -v httrack >/dev/null || fail "could not find httrack"
 ! is_windows || ! echo "MSYS cannot signal a native httrack.exe; skipping" >&2 ||
     exit 77
 

--- a/tests/245_local-ftp-deadhost-timeout.test
+++ b/tests/245_local-ftp-deadhost-timeout.test
@@ -9,10 +9,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || {
-    echo "could not find httrack" >&2
-    exit 1
-}
+command -v httrack >/dev/null || fail "could not find httrack"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpdead.XXXXXX")
 cleanup() { rm -rf "$tmpdir"; }

--- a/tests/253_local-ftp-close-once.test
+++ b/tests/253_local-ftp-close-once.test
@@ -24,17 +24,11 @@ if grep -q "^dlname=''" "$CLOSETRACK_LA"; then
     exit 0
 fi
 for lib in "${CLOSETRACK_LIB:-}" "${FTPCANCEL_LIB:-}"; do
-    test -r "$lib" || {
-        echo "close-once: ${lib:-an interposer} was not built" >&2
-        exit 1
-    }
+    test -r "$lib" || fail "close-once: ${lib:-an interposer} was not built"
 done
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || {
-    echo "could not find httrack" >&2
-    exit 1
-}
+command -v httrack >/dev/null || fail "could not find httrack"
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpclose.XXXXXX")

--- a/tests/259_doc-css-assets.test
+++ b/tests/259_doc-css-assets.test
@@ -12,10 +12,7 @@ set -euo pipefail
 srcdir="${abs_top_srcdir:?not run under make check}"
 builddir="${abs_top_builddir:?not run under make check}"
 
-work=$(mktemp -d "${TMPDIR:-/tmp}/docassets.XXXXXX") || {
-    echo "no tmpdir" >&2
-    exit 1
-}
+work=$(mktemp -d "${TMPDIR:-/tmp}/docassets.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "${work}"
 
 make -C "${builddir}/html" install DESTDIR="${work}/inst" >"${work}/log" 2>&1 ||

--- a/tests/271_doc-chrome-year.test
+++ b/tests/271_doc-chrome-year.test
@@ -15,10 +15,7 @@ chrome_src="${srcdir}/tools/doc-chrome.py"
 command -v python3 >/dev/null 2>&1 || skip "no python3"
 test -r "${chrome_src}" || skip "no ${chrome_src}"
 
-work=$(mktemp -d "${TMPDIR:-/tmp}/docyear.XXXXXX") || {
-    echo "no tmpdir" >&2
-    exit 1
-}
+work=$(mktemp -d "${TMPDIR:-/tmp}/docyear.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "${work}"
 
 # doc-chrome.py finds html/ relative to its own path, so it needs both trees.

--- a/tests/279_doc-guide-image-sizes.test
+++ b/tests/279_doc-guide-image-sizes.test
@@ -20,10 +20,7 @@ test -r "${checker}" || fail "no ${checker}"
 "${python}" "${checker}" "${srcdir}/html" ||
     fail "guide.html's declared image sizes are out of sync with html/img/"
 
-work=$(mktemp -d "${TMPDIR:-/tmp}/guideimg.XXXXXX") || {
-    echo "no tmpdir" >&2
-    exit 1
-}
+work=$(mktemp -d "${TMPDIR:-/tmp}/guideimg.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "${work}"
 
 pristine="${work}/pristine"

--- a/tests/284_cli-resume-prompt.test
+++ b/tests/284_cli-resume-prompt.test
@@ -45,10 +45,7 @@ seed "$tmp/plain" --footer 'zzzmarker'
 out=$(ask "$tmp/plain")
 assert_match 'OK to (Continue|Update) httrack ' "$out" "no resume offer"
 assert_match 'zzzmarker' "$out" "the offer dropped the options"
-! grep -qF -- "$bin" <<<"$out" || {
-    echo "FAIL: the offer still quotes the program path"
-    exit 1
-}
+! grep -qF -- "$bin" <<<"$out" || fail "the offer still quotes the program path"
 echo OK
 
 # Teeth for the clip: doit.log replays up to 8000 bytes, so a command line built
@@ -63,8 +60,5 @@ out=$(ask "$tmp/long")
 assert_match 'OK to (Continue|Update) httrack .*\.\.\.\?' "$out" \
     "a command line past the buffer was not clipped"
 # htssafe names the file it aborts in; the offer must not be one of them.
-! grep -qE 'overflow while copying' <<<"$out" || {
-    echo "FAIL: the offer aborted on the bounds check instead of clipping"
-    exit 1
-}
+! grep -qE 'overflow while copying' <<<"$out" || fail "the offer aborted on the bounds check instead of clipping"
 echo OK

--- a/tests/52_local-socks5.test
+++ b/tests/52_local-socks5.test
@@ -194,10 +194,7 @@ ref="$tmpdir/refuse"
 start_server "$ref" refuse
 rc=0
 run_crawl "$ref/out" "https://${host}:${tls_port}/" "socks5://127.0.0.1:${socks_port}" || rc=$?
-test "$rc" -ne "$HANG_RC" || {
-    echo "FAIL: crawl hung on a refusing socks proxy" >&2
-    exit 1
-}
+test "$rc" -ne "$HANG_RC" || fail "crawl hung on a refusing socks proxy"
 grep -rq "ORIGIN-PAGE-563" "$ref/out" 2>/dev/null && {
     echo "FAIL: refusing proxy unexpectedly served the page" >&2
     exit 1
@@ -209,10 +206,7 @@ trunc="$tmpdir/trunc"
 start_server "$trunc" truncate
 rc=0
 run_crawl "$trunc/out" "https://${host}:${tls_port}/" "socks5://127.0.0.1:${socks_port}" || rc=$?
-test "$rc" -ne "$HANG_RC" || {
-    echo "FAIL: crawl hung on a truncated socks reply (bounded read missing)" >&2
-    exit 1
-}
+test "$rc" -ne "$HANG_RC" || fail "crawl hung on a truncated socks reply (bounded read missing)"
 grep -rq "ORIGIN-PAGE-563" "$trunc/out" 2>/dev/null && {
     echo "FAIL: truncated-reply proxy unexpectedly served the page" >&2
     exit 1

--- a/tests/53_local-proxytrack-cache-corrupt.test
+++ b/tests/53_local-proxytrack-cache-corrupt.test
@@ -17,7 +17,4 @@ cleanup_push rm -rf "$dir"
 } >"$dir/foo.ndx"
 : >"$dir/foo.dat" # cache_brstr runs only when the sibling .dat opens
 
-proxytrack --convert "$dir/out.arc" "$dir/foo.ndx" >/dev/null 2>&1 || {
-    echo "FAIL: proxytrack crashed/errored on a corrupt cache index"
-    exit 1
-}
+proxytrack --convert "$dir/out.arc" "$dir/foo.ndx" >/dev/null 2>&1 || fail "proxytrack crashed/errored on a corrupt cache index"

--- a/tests/57_local-proxy-connect.test
+++ b/tests/57_local-proxy-connect.test
@@ -132,10 +132,7 @@ echo "OK: absolute-URI form (no connect://) rejected by the CONNECT-only proxy"
 : >"$ok/proxy.log"
 : >"$ok/origin-headers.log"
 run_crawl "$ok/out2" "connect://user:secret@127.0.0.1:${proxy_port}" "$origin_port"
-grep -rq "ORIGIN-PAGE-564" "$ok/out2" || {
-    echo "FAIL: origin page not downloaded through the authenticated proxy" >&2
-    exit 1
-}
+grep -rq "ORIGIN-PAGE-564" "$ok/out2" || fail "origin page not downloaded through the authenticated proxy"
 got=$(awk '/^AUTH Basic /{print $3}' "$ok/proxy.log" | head -1)
 # base64("user:secret"); compared literally to stay portable (no base64 -d)
 test "$got" == "dXNlcjpzZWNyZXQ=" || {
@@ -155,10 +152,7 @@ flood="$tmpdir/flood"
 start_server "$flood" flood
 rc=0
 run_crawl "$flood/out" "connect://127.0.0.1:${proxy_port}" "$origin_port" || rc=$?
-test "$rc" -ne "$HANG_RC" || {
-    echo "FAIL: crawl hung on a flooding proxy (bounded read missing)" >&2
-    exit 1
-}
+test "$rc" -ne "$HANG_RC" || fail "crawl hung on a flooding proxy (bounded read missing)"
 grep -rq "ORIGIN-PAGE-564" "$flood/out" 2>/dev/null && {
     echo "FAIL: flooding proxy unexpectedly served the page" >&2
     exit 1

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -14,10 +14,7 @@ langdir="$top_srcdir/lang"
 def="$top_srcdir/lang.def"
 eng="$langdir/English.txt"
 for f in "$eng" "$def"; do
-    [ -f "$f" ] || {
-        echo "cannot find $f"
-        exit 1
-    }
+    [ -f "$f" ] || fail "cannot find $f"
 done
 
 tmp=$(mktemp -d)
@@ -284,10 +281,7 @@ done
 # while the string is still English on screen (#1260). A handful are legitimate,
 # so the per-catalog counts are pinned and have to match exactly.
 pin="$testdir/62_lang-untranslated.counts"
-[ -f "$pin" ] || {
-    echo "cannot find $pin"
-    exit 1
-}
+[ -f "$pin" ] || fail "cannot find $pin"
 
 # Surrounding blanks are stripped before comparing: a value of one space, or a
 # msgid copied with a trailing one, is as untranslated as the bare shapes.

--- a/tests/80_engine-crash-symbolize.test
+++ b/tests/80_engine-crash-symbolize.test
@@ -7,10 +7,7 @@ set -eu
 . "${0%"${0##*/}"}./testlib.sh"
 
 skip_on_windows "no backtrace() on Windows"
-command -v httrack >/dev/null || {
-    echo "could not find httrack" >&2
-    exit 1
-}
+command -v httrack >/dev/null || fail "could not find httrack"
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_symbolize.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmpdir"
@@ -24,10 +21,7 @@ rawframe='(+0x[0-9a-f][0-9a-f]*)'
 # The strsafe selftest aborts on purpose, which lands in sig_fatal.
 rc=0
 run_with_timeout 60 httrack -#test=strsafe overflow "$overflow" >"$out" 2>&1 || rc=$?
-test "$rc" -ne 124 || {
-    echo "the crash handler did not finish within the deadline" >&2
-    exit 1
-}
+test "$rc" -ne 124 || fail "the crash handler did not finish within the deadline"
 
 grep -q '^Caught signal ' "$out" || {
     echo "no 'Caught signal' line:" >&2
@@ -86,10 +80,7 @@ export HTTRACK_NO_SYMBOLIZE=1
 rc=0
 run_with_timeout 60 httrack -#test=strsafe overflow "$overflow" >"$raw" 2>&1 || rc=$?
 unset HTTRACK_NO_SYMBOLIZE
-test "$rc" -ne 124 || {
-    echo "the opt-out run did not finish within the deadline" >&2
-    exit 1
-}
+test "$rc" -ne 124 || fail "the opt-out run did not finish within the deadline"
 grep -q "$rawframe" "$raw" || {
     echo "the opt-out lost the raw trace:" >&2
     cat "$raw" >&2

--- a/tests/86_local-proxytrack-cache-longfields.test
+++ b/tests/86_local-proxytrack-cache-longfields.test
@@ -31,22 +31,13 @@ alen=$(($(wc -c <"$dir/hdr") + $(wc -c <"$dir/body")))
     cat "$dir/hdr" "$dir/body"
 } >"$dir/in.arc"
 
-proxytrack --convert "$dir/out.arc" "$dir/in.arc" >/dev/null 2>&1 || {
-    echo "FAIL: proxytrack crashed reading an ARC with over-long headers" >&2
-    exit 1
-}
-test -s "$dir/out.arc" || {
-    echo "FAIL: ARC entry dropped instead of clipped" >&2
-    exit 1
-}
+proxytrack --convert "$dir/out.arc" "$dir/in.arc" >/dev/null 2>&1 || fail "proxytrack crashed reading an ARC with over-long headers"
+test -s "$dir/out.arc" || fail "ARC entry dropped instead of clipped"
 # Only contenttype survives into the ARC output; the over-long Etag and
 # Content-Disposition above are still load-bearing, since bounding just one
 # field leaves the others smashing the element (the run above would crash).
 got=$(runlen "$dir/out.arc" A)
-test "${got:-0}" = 54 || {
-    echo "FAIL: ARC content-type clipped to ${got:-0}, expected 54" >&2
-    exit 1
-}
+test "${got:-0}" = 54 || fail "ARC content-type clipped to ${got:-0}, expected 54"
 
 # --- ZIP reader (ZIP_READFIELD_STRING) --------------------------------------
 python=$(find_python) || {
@@ -80,22 +71,13 @@ with zipfile.ZipFile(sys.argv[1], "w") as z:
     z.writestr(zi, body)
 EOF
 
-proxytrack --convert "$dir/out2.arc" "$dir/in.zip" >/dev/null 2>&1 || {
-    echo "FAIL: proxytrack crashed reading a zip cache with over-long headers" >&2
-    exit 1
-}
-test -s "$dir/out2.arc" || {
-    echo "FAIL: zip entry dropped instead of clipped" >&2
-    exit 1
-}
+proxytrack --convert "$dir/out2.arc" "$dir/in.zip" >/dev/null 2>&1 || fail "proxytrack crashed reading a zip cache with over-long headers"
+test -s "$dir/out2.arc" || fail "zip entry dropped instead of clipped"
 # three destinations, two capacities: msg[1024] keeps all 400 M's where a
 # one-size-fits-all clip would cut it to 63 like the others
 while read -r ch want; do
     got=$(runlen "$dir/out2.arc" "$ch")
-    test "${got:-0}" = "$want" || {
-        echo "FAIL: zip field '$ch' clipped to ${got:-0}, expected $want" >&2
-        exit 1
-    }
+    test "${got:-0}" = "$want" || fail "zip field '$ch' clipped to ${got:-0}, expected $want"
 done <<'EOF'
 A 54
 C 63

--- a/tests/87_local-proxytrack-nodate.test
+++ b/tests/87_local-proxytrack-nodate.test
@@ -34,10 +34,7 @@ run_case() {
         cat "$dir/hdr" "$dir/body"
     } >"$dir/in.arc"
 
-    proxytrack --convert "$dir/out.arc" "$dir/in.arc" >/dev/null 2>&1 || {
-        echo "FAIL: proxytrack crashed on $what" >&2
-        exit 1
-    }
+    proxytrack --convert "$dir/out.arc" "$dir/in.arc" >/dev/null 2>&1 || fail "proxytrack crashed on $what"
     grep -aq "^http://example.com/p.html 0.0.0.0 ${wantdate} " "$dir/out.arc" || {
         echo "FAIL: $what: expected archive date ${wantdate}, got:" >&2
         grep -a '^http://example.com/' "$dir/out.arc" >&2 || echo "(entry dropped)" >&2

--- a/tests/88_local-proxytrack-badmtime.test
+++ b/tests/88_local-proxytrack-badmtime.test
@@ -43,23 +43,14 @@ if int(os.stat(sys.argv[1]).st_mtime) < huge:
     sys.exit(77)  # filesystem clamped it, nothing to test
 EOF
 test "$rc" -eq 0 || {
-    test "$rc" -eq 77 || {
-        echo "FAIL: could not build the cache (python exit $rc)" >&2
-        exit 1
-    }
+    test "$rc" -eq 77 || fail "could not build the cache (python exit $rc)"
     echo "filesystem will not hold an out-of-range mtime; skipping" >&2
     exit 77
 }
 
-proxytrack --convert "$dir/out.arc" "$dir/in.zip" >/dev/null 2>&1 || {
-    echo "FAIL: proxytrack failed on a cache with an out-of-range mtime" >&2
-    exit 1
-}
+proxytrack --convert "$dir/out.arc" "$dir/in.zip" >/dev/null 2>&1 || fail "proxytrack failed on a cache with an out-of-range mtime"
 
 # field 3 of the filedesc line is YYYYMMDDhhmmss; the epoch stands in for
 # "unknown", and 14 digits with a real day is the point (00 is what broke)
 date=$(head -n1 "$dir/out.arc" | awk '{ print $3 }')
-test "$date" = 19700101000000 || {
-    echo "FAIL: filedesc date is '$date', expected 19700101000000" >&2
-    exit 1
-}
+test "$date" = 19700101000000 || fail "filedesc date is '$date', expected 19700101000000"

--- a/tests/92_local-proxytrack-ndx-fields.test
+++ b/tests/92_local-proxytrack-ndx-fields.test
@@ -27,7 +27,4 @@ with open(sys.argv[1], "w") as f:
 EOF
 : >"$dir/foo.dat" # the reader only proceeds when the sibling .dat opens
 
-proxytrack --convert "$dir/out.arc" "$dir/foo.ndx" >/dev/null 2>&1 || {
-    echo "FAIL: proxytrack crashed on an .ndx with two full-length URL fields" >&2
-    exit 1
-}
+proxytrack --convert "$dir/out.arc" "$dir/foo.ndx" >/dev/null 2>&1 || fail "proxytrack crashed on an .ndx with two full-length URL fields"


### PR DESCRIPTION
`testlib.sh` has had `fail()` all along. Every file touched here already sources it, yet 128 places still hand-rolled `|| { echo "msg"; exit 1; }`. This converts them: 512 lines out, 128 in.

The pass was scripted and deliberately narrow, matching only the single-echo shape. A block that prints diagnostics before exiting is left alone, because `fail()` would swallow everything but its own message. That leaves work behind, which is the right trade for a sweep this wide.

Two consequences. Forty-two of these messages were going to stdout and now go to stderr. That is where the other half already sent them, and where automake expects a failure to appear. And a message that spelled its own `FAIL: ` prefix loses it, since `fail()` adds one; without that the logs would read `FAIL: FAIL: ...`.

The nine files #1343 converts are excluded, so the two branches cannot collide.

Full suite green at 348 pass, 12 skip.