### PR TITLE
Three helpers every test re-declared, and the blocks the last sweep missed

### DIFF
--- a/tests/102_local-ftp-refetch.test
+++ b/tests/102_local-ftp-refetch.test
@@ -11,7 +11,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")
@@ -62,8 +62,6 @@ fail() {
     test ! -f "$report" || cat "$report" >&2
     exit 1
 }
-ok() { echo "OK: $*"; }
-size_of() { wc -c <"$1" | tr -d '[:space:]'; }
 # Files listed under a report bucket, one "file:size" per line.
 listed() {
     "$python" - "$report" "$1" <<'EOF' | tr -d '\r'

--- a/tests/110_local-ftp-parallel.test
+++ b/tests/110_local-ftp-parallel.test
@@ -11,7 +11,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")
@@ -25,9 +25,6 @@ cleanup_push cleanup
 root="${tmpdir}/root"
 out="${tmpdir}/crawl"
 mkdir -p "$root" "$out"
-
-ok() { echo "OK: $*"; }
-size_of() { wc -c <"$1" | tr -d '[:space:]'; }
 
 # Distinct bodies and lengths, so a mirror that mixed two of them up cannot
 # compare equal.

--- a/tests/111_local-ftp-update-rest.test
+++ b/tests/111_local-ftp-update-rest.test
@@ -11,7 +11,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")
@@ -28,8 +28,6 @@ mode="${tmpdir}/mode"
 cmds="${tmpdir}/cmds"
 mkdir -p "$root" "$out"
 
-ok() { echo "OK: $*"; }
-size_of() { wc -c <"$1" | tr -d '[:space:]'; }
 # hts-log.txt is rewritten per pass, so this only ever sees the pass just run.
 no_errors() {
     local errors

--- a/tests/112_local-single-file-fragment.test
+++ b/tests/112_local-single-file-fragment.test
@@ -38,7 +38,7 @@ printf '<svg xmlns="http://www.w3.org/2000/svg"><g id="icon-foo"/></svg>\n' \
 # --- server -----------------------------------------------------------------
 local_server_start --root "$doc"
 
-which httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 # --- crawl ------------------------------------------------------------------
 # The cap sits between sprite.svg and big.svg, so one inlines and one is left

--- a/tests/121_local-ftp-nocache-splice.test
+++ b/tests/121_local-ftp-nocache-splice.test
@@ -11,7 +11,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")
@@ -28,8 +28,6 @@ mode="${tmpdir}/mode"
 cmds="${tmpdir}/cmds"
 mkdir -p "$root" "$out"
 
-ok() { echo "OK: $*"; }
-size_of() { wc -c <"$1" | tr -d '[:space:]'; }
 # hts-log.txt is rewritten per pass, so this only ever sees the pass just run.
 no_errors() {
     local errors

--- a/tests/137_local-charsetless-encoding.test
+++ b/tests/137_local-charsetless-encoding.test
@@ -18,10 +18,7 @@ cleanup_push cleanup
 mkdir "${tmpdir}/docroot"
 local_server_start --root "${tmpdir}/docroot"
 
-which httrack >/dev/null || {
-    echo "could not find httrack"
-    exit 1
-}
+require_httrack
 
 # One crawl per variant: the generated top index carries the seed page's title.
 for variant in u8 l1 declared gb2312 l1decl; do

--- a/tests/138_local-spool-name-overflow.test
+++ b/tests/138_local-spool-name-overflow.test
@@ -17,10 +17,7 @@ cleanup_push cleanup
 
 local_server_start
 
-which httrack >/dev/null || {
-    echo "could not find httrack"
-    exit 1
-}
+require_httrack
 
 rc=0
 local_crawl --log "${tmpdir}/log" -O "${tmpdir}/out" --quiet --disable-security-limits --robots=0 --timeout=30 --retries=0 -Z -p0 -N '%n' -c4 "http://127.0.0.1:${SRV_PORT}/bakname/index.html" || rc=$?
@@ -31,15 +28,9 @@ test "$rc" -eq 0 || {
 }
 
 enginelog="${tmpdir}/out/hts-log.txt"
-test -r "$enginelog" || {
-    echo "no engine log at $enginelog"
-    exit 1
-}
+test -r "$enginelog" || fail "no engine log at $enginelog"
 moved=$(grep -c 'slots ready moved to background' "$enginelog" || true)
-test "$moved" -gt 0 || {
-    echo "no slot was ever spooled, so the name was never built"
-    exit 1
-}
+test "$moved" -gt 0 || fail "no slot was ever spooled, so the name was never built"
 serr=$(grep -c 'serialize error' "$enginelog" || true)
 test "$serr" -eq 0 || {
     echo "the spool refused to write:"

--- a/tests/180_crash-stack-overflow.test
+++ b/tests/180_crash-stack-overflow.test
@@ -21,7 +21,7 @@ MINGW* | MSYS* | CYGWIN*)
 # gated on Linux + execinfo.h (USES_BACKTRACE in htsbacktrace.c).
 *) traced=0 ;;
 esac
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 # Dies from a caught fault, announcing it and running the report to its end.
 # The handler finishes in abort(), so the shell sees SIGABRT (134).

--- a/tests/181_altstack-honoured.test
+++ b/tests/181_altstack-honoured.test
@@ -15,7 +15,7 @@ if [ "$HTS_OS" != "Linux" ]; then
     echo "LD_PRELOAD interposition is Linux-only here, skipping" >&2
     exit 77
 fi
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 # A --disable-shared build has nothing to preload; anything else missing is a
 # build problem, not a skip, or the legs below would pass vacuously.
 [ -r "${ALTSTACKPROBE_LA:-}" ] || fail "${ALTSTACKPROBE_LA:-\$ALTSTACKPROBE_LA} was not built"

--- a/tests/182_crash-fork-safety.test
+++ b/tests/182_crash-fork-safety.test
@@ -14,7 +14,7 @@ if [ "$HTS_OS" != "Linux" ]; then
     echo "the symbolizer spawn is Linux-only, skipping" >&2
     exit 77
 fi
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 # A wedged httrack still catches SIGTERM and only sets a flag, hence -s KILL.
 command -v timeout >/dev/null || fail "no timeout(1): a hang would never end here"
 

--- a/tests/183_altstack-worker.test
+++ b/tests/183_altstack-worker.test
@@ -20,7 +20,7 @@ MINGW* | MSYS* | CYGWIN*)
 # gated on Linux + execinfo.h (USES_BACKTRACE in htsbacktrace.c).
 *) traced=0 ;;
 esac
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 # Dies from a caught fault, running the report to its end. The handler finishes
 # in abort(), so the shell sees SIGABRT (134); 139 is the kernel killing us.

--- a/tests/19_local-connect-fallback.test
+++ b/tests/19_local-connect-fallback.test
@@ -82,9 +82,6 @@ grep -iqE "^[0-9:]*[[:space:]]Error:" "$log2" || {
     cat "$log2"
     exit 1
 }
-test ! -f "$out2/alldead_${SRV_PORT}/simple/basic.html" || {
-    echo "FAIL: file downloaded despite every address failing"
-    exit 1
-}
+test ! -f "$out2/alldead_${SRV_PORT}/simple/basic.html" || fail "file downloaded despite every address failing"
 
 echo "OK: connect fallback succeeds, and exhausting all addresses errors out"

--- a/tests/20_local-resume-loop.test
+++ b/tests/20_local-resume-loop.test
@@ -19,10 +19,7 @@ cleanup_push cleanup
 counter="${tmpdir}/blobcount"
 local_server_start --env RESUME_COUNTER="$counter" --root "$root"
 
-which httrack >/dev/null || {
-    echo "could not find httrack"
-    exit 1
-}
+require_httrack
 out="${tmpdir}/crawl"
 mkdir "$out"
 common=(-O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 --retries=0)
@@ -43,10 +40,7 @@ sleep 0.5
 kill -TERM "$crawlpid" 2>/dev/null
 wait "$crawlpid" 2>/dev/null
 crawlpid=
-test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" || {
-    echo "FAIL: no temp-ref survived pass 1; cannot drive #206"
-    exit 1
-}
+test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" || fail "no temp-ref survived pass 1; cannot drive #206"
 echo "OK (temp-ref present)"
 before=$(wc -c <"$counter" 2>/dev/null || echo 0)
 

--- a/tests/221_local-ftp-ctrlchars.test
+++ b/tests/221_local-ftp-ctrlchars.test
@@ -11,7 +11,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")
@@ -36,7 +36,6 @@ serverlog="${tmpdir}/server.out"
 serverpid=$!
 port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 
-ok() { echo "OK: $*"; }
 # 60s is the wedge detector: a dropped command leaves the engine on a 300s read.
 crawl() {
     run_with_timeout 60 httrack "$1" -O "$out" --quiet --disable-security-limits \

--- a/tests/230_local-ftp-userpass.test
+++ b/tests/230_local-ftp-userpass.test
@@ -10,7 +10,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpuser.XXXXXX")
@@ -33,7 +33,6 @@ serverlog="${tmpdir}/server.out"
 serverpid=$!
 port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
 
-ok() { echo "OK: $*"; }
 crawl() {
     : >"$cmds"
     rm -rf "${out:?}"

--- a/tests/233_local-ftp-ctrl-timeout.test
+++ b/tests/233_local-ftp-ctrl-timeout.test
@@ -9,7 +9,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftptmo.XXXXXX")
@@ -45,8 +45,6 @@ livelog="${tmpdir}/live.out"
     --log "$(nativepath "$cmds")" >"$livelog" 2>&1 &
 livepid=$!
 liveport=$(discover_server_port "$livelog" "$livepid") || exit 1
-
-ok() { echo "OK: $*"; }
 
 # No --max-time anywhere below, so --timeout is the only thing that can end a run.
 crawl() {

--- a/tests/234_local-ftp-maxtime.test
+++ b/tests/234_local-ftp-maxtime.test
@@ -9,7 +9,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpmax.XXXXXX")
@@ -35,8 +35,6 @@ serverlog="${tmpdir}/server.out"
     --log "$(nativepath "$cmds")" >"$serverlog" 2>&1 &
 serverpid=$!
 port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-
-ok() { echo "OK: $*"; }
 
 start=$SECONDS
 run_with_timeout 90 httrack "ftp://127.0.0.1:${port}/f.bin" -O "$out" --quiet \

--- a/tests/235_local-resume-recovery.test
+++ b/tests/235_local-resume-recovery.test
@@ -25,10 +25,7 @@ cleanup_push cleanup
 
 local_server_start
 
-which httrack >/dev/null || {
-    echo "could not find httrack"
-    exit 1
-}
+require_httrack
 
 # Read from the server's own definitions: two routes happening to share a body
 # length must not let one leg assert the other's. Bodies come back as a length.
@@ -62,10 +59,7 @@ interrupt_pass1() { # interrupt_pass1 <out> <route> <extra httrack args...>
     kill -TERM "$crawlpid" 2>/dev/null
     wait "$crawlpid" 2>/dev/null || true
     crawlpid=
-    test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" || {
-        echo "FAIL: no temp-ref survived pass 1; cannot drive the resume"
-        exit 1
-    }
+    test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" || fail "no temp-ref survived pass 1; cannot drive the resume"
 }
 
 blob_size() { # blob_size <out>
@@ -93,25 +87,13 @@ rc=0
 run_with_timeout 120 httrack -O "$out" --quiet --disable-security-limits \
     --robots=0 --timeout=30 -c1 --retries=0 --continue \
     "${BASEURL}/resume206/index.html" >"${out}.log2" 2>&1 || rc=$?
-test "$rc" -ne 124 || {
-    echo "FAIL: the crawl never terminated"
-    exit 1
-}
+test "$rc" -ne 124 || fail "the crawl never terminated"
 log="${out}/hts-log.txt"
 # Without these the recovery could not have been exercised at all.
-grep -q 'Unusable partial-content range' <"$log" || {
-    echo "FAIL: the resume was never rejected; the test proved nothing"
-    exit 1
-}
-grep -q 'Restarting whole file' <"$log" || {
-    echo "FAIL: the restart did not run outside the retry budget"
-    exit 1
-}
+grep -q 'Unusable partial-content range' <"$log" || fail "the resume was never rejected; the test proved nothing"
+grep -q 'Restarting whole file' <"$log" || fail "the restart did not run outside the retry budget"
 got=$(blob_size "$out")
-test "$got" -eq "$resume_full" || {
-    echo "FAIL: blob.bin is ${got} bytes, expected ${resume_full}"
-    exit 1
-}
+test "$got" -eq "$resume_full" || fail "blob.bin is ${got} bytes, expected ${resume_full}"
 echo "OK (${got} bytes)"
 
 # --- the latch bounds an always-unusable server ------------------------------
@@ -126,19 +108,10 @@ rc=0
 run_with_timeout 120 httrack -O "$out" --quiet --disable-security-limits \
     --robots=0 --timeout=30 -c1 --retries=0 --continue \
     "${BASEURL}/resume206loop/index.html" >"${out}.log2" 2>&1 || rc=$?
-test "$rc" -ne 124 || {
-    echo "FAIL: the crawl never terminated; the restart is unbounded"
-    exit 1
-}
-grep -q 'Unusable partial-content range' <"${out}/hts-log.txt" || {
-    echo "FAIL: the resume was never rejected; the latch was not exercised"
-    exit 1
-}
+test "$rc" -ne 124 || fail "the crawl never terminated; the restart is unbounded"
+grep -q 'Unusable partial-content range' <"${out}/hts-log.txt" || fail "the resume was never rejected; the latch was not exercised"
 restarts=$(grep -c 'Restarting whole file' <"${out}/hts-log.txt" || true)
-test "$restarts" -eq 1 || {
-    echo "FAIL: ${restarts} free restarts, expected exactly 1 (latch)"
-    exit 1
-}
+test "$restarts" -eq 1 || fail "${restarts} free restarts, expected exactly 1 (latch)"
 echo "OK (1 free restart, then bounded)"
 
 # --- the latch rides a re-record, and the budget survives the restart --------
@@ -153,26 +126,14 @@ rc=0
 run_with_timeout 120 httrack -O "$out" --quiet --disable-security-limits \
     --robots=0 --timeout=30 -c1 --retries=1 \
     "${BASEURL}/alias206/index.html" >"${out}.log1" 2>&1 || rc=$?
-test "$rc" -ne 124 || {
-    echo "FAIL: the crawl never terminated; the alias hop reset the latch"
-    exit 1
-}
+test "$rc" -ne 124 || fail "the crawl never terminated; the alias hop reset the latch"
 log="${out}/hts-log.txt"
 # Without the hop the alternation was never driven and the rest proves nothing.
-grep -q 'Warning moved treated' <"$log" || {
-    echo "FAIL: no alias hop; the re-record path was never reached"
-    exit 1
-}
+grep -q 'Warning moved treated' <"$log" || fail "no alias hop; the re-record path was never reached"
 restarts=$(grep -c 'Restarting whole file' <"$log" || true)
-test "$restarts" -eq 1 || {
-    echo "FAIL: ${restarts} free restarts across the alias hops, expected 1"
-    exit 1
-}
+test "$restarts" -eq 1 || fail "${restarts} free restarts across the alias hops, expected 1"
 retries=$(grep -c 'Retry after error' <"$log" || true)
-test "$retries" -eq 1 || {
-    echo "FAIL: ${retries} retries, expected 1; the free restart spent the budget"
-    exit 1
-}
+test "$retries" -eq 1 || fail "${retries} retries, expected 1; the free restart spent the budget"
 echo "OK (1 free restart, budget intact)"
 
 # --- #581: the refetch must not depend on the removal succeeding -------------
@@ -213,24 +174,12 @@ run_with_timeout 120 httrack -O "$out" --quiet --disable-security-limits \
     --robots=0 --timeout=30 -c1 --retries=1 --continue \
     "${BASEURL}/crange206mem/index.html" >"${out}.log2" 2>&1 || rc=$?
 unset LD_PRELOAD
-test "$rc" -ne 124 || {
-    echo "FAIL: the crawl never terminated"
-    exit 1
-}
+test "$rc" -ne 124 || fail "the crawl never terminated"
 # The shim silently matching nothing would make this leg a copy of test 48.
 seen=$(wc -l <"$attempts")
-test "$seen" -ge 1 || {
-    echo "FAIL: the interposer saw no unlink of the partial; it never fired"
-    exit 1
-}
+test "$seen" -ge 1 || fail "the interposer saw no unlink of the partial; it never fired"
 held=$(grep -c '^open ' <"$attempts" || true)
-test "$held" -eq 0 || {
-    echo "FAIL: ${held} of ${seen} unlink(s) came while the handle was open"
-    exit 1
-}
+test "$held" -eq 0 || fail "${held} of ${seen} unlink(s) came while the handle was open"
 got=$(blob_size "$out")
-test "$got" -eq "$crange_full" || {
-    echo "FAIL: blob.bin is ${got} bytes, expected ${crange_full} (refetch lost)"
-    exit 1
-}
+test "$got" -eq "$crange_full" || fail "blob.bin is ${got} bytes, expected ${crange_full} (refetch lost)"
 echo "OK (${got} bytes, ${seen} unlink(s), none on an open handle)"

--- a/tests/236_local-ftp-teardown.test
+++ b/tests/236_local-ftp-teardown.test
@@ -9,7 +9,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")
@@ -19,9 +19,6 @@ cleanup() {
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
-
-ok() { echo "OK: $*"; }
-size_of() { wc -c <"$1" | tr -d '[:space:]'; }
 
 errlog="${tmpdir}/httrack.err"
 # A sanitized build reports the use-after-free and still exits 1, so the status

--- a/tests/240_local-abort-teardown.test
+++ b/tests/240_local-abort-teardown.test
@@ -15,10 +15,7 @@ cleanup_push cleanup
 
 local_server_start
 
-which httrack >/dev/null || {
-    echo "could not find httrack"
-    exit 1
-}
+require_httrack
 
 out="${tmpdir}/crawl"
 mkdir "$out"
@@ -30,10 +27,7 @@ common=(--quiet --disable-security-limits --robots=0 --timeout=30 --changes
 expect() {
     printf '[%s] ..\t' "$1"
     shift
-    "$@" || {
-        echo "FAIL"
-        exit 1
-    }
+    "$@" || fail "FAIL"
     echo "OK"
 }
 no_tmp() { test -z "$(find "$out" -maxdepth 1 -name '*.tmp' -print -quit)"; }
@@ -41,16 +35,10 @@ unpoisoned() { ! grep -qa "$poison" "$1"; }
 
 # --- pass 1: a complete crawl, to have something an abort could destroy ------
 local_crawl --log "${tmpdir}/log1" "${common[@]}" -O "$out" "${BASEURL}/changes/index.html"
-test -s "$report" || {
-    echo "FAIL: pass 1 wrote no ${report}"
-    exit 1
-}
+test -s "$report" || fail "pass 1 wrote no ${report}"
 cp "$report" "${tmpdir}/report1.json"
 for f in "${out}/warc-out.warc.gz" "${out}/warc-out.cdx"; do
-    test -s "$f" || {
-        echo "FAIL: pass 1 produced no $f"
-        exit 1
-    }
+    test -s "$f" || fail "pass 1 produced no $f"
     printf '%s\n' "$poison" >"$f"
 done
 

--- a/tests/240_local-abort-teardown.test
+++ b/tests/240_local-abort-teardown.test
@@ -25,9 +25,10 @@ common=(--quiet --disable-security-limits --robots=0 --timeout=30 --changes
     --purge-old=0 --warc-file warc-out --warc-cdx)
 
 expect() {
-    printf '[%s] ..\t' "$1"
+    local what="$1"
+    printf '[%s] ..\t' "$what"
     shift
-    "$@" || fail "FAIL"
+    "$@" || fail "$what"
     echo "OK"
 }
 no_tmp() { test -z "$(find "$out" -maxdepth 1 -name '*.tmp' -print -quit)"; }

--- a/tests/243_local-ftp-deadhost-interrupt.test
+++ b/tests/243_local-ftp-deadhost-interrupt.test
@@ -9,7 +9,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 ! is_windows || ! echo "MSYS cannot signal a native httrack.exe; skipping" >&2 ||
     exit 77
 
@@ -20,8 +20,6 @@ cleanup() {
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
-
-ok() { echo "OK: $*"; }
 
 # Above a truncated $SECONDS and a loaded runner's scheduling, below the
 # shortest kernel connect timeout an unfixed engine would wait out.

--- a/tests/245_local-ftp-deadhost-timeout.test
+++ b/tests/245_local-ftp-deadhost-timeout.test
@@ -9,13 +9,11 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpdead.XXXXXX")
 cleanup() { rm -rf "$tmpdir"; }
 cleanup_push cleanup
-
-ok() { echo "OK: $*"; }
 
 timeout=2
 # Above --timeout plus its two retries (3 x 2s) and a truncated $SECONDS, below

--- a/tests/247_cli-stdin-eof.test
+++ b/tests/247_cli-stdin-eof.test
@@ -21,10 +21,7 @@ cleanup_push cleanup
 
 local_server_start
 
-which httrack >/dev/null || {
-    echo "could not find httrack"
-    exit 1
-}
+require_httrack
 
 # Trickled pages: the crawl has to outlive several passes of the loop that polls
 # stdin, or a display that toggles has no time to show it.

--- a/tests/24_local-resume-overlap.test
+++ b/tests/24_local-resume-overlap.test
@@ -24,10 +24,7 @@ counter="${tmpdir}/hits"
 resumed="${tmpdir}/resumed" # gets a byte when the server serves a resume 206
 local_server_start --env OVERLAP_COUNTER="$counter" --env OVERLAP_RESUMED="$resumed" --root "$root"
 
-which httrack >/dev/null || {
-    echo "could not find httrack"
-    exit 1
-}
+require_httrack
 out="${tmpdir}/crawl"
 common=(-O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 --retries=0 -c1)
 refdir="${out}/hts-cache/ref"
@@ -45,10 +42,7 @@ sleep 0.5
 kill -TERM "$crawlpid" 2>/dev/null || true
 wait "$crawlpid" 2>/dev/null || true
 crawlpid=
-test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" || {
-    echo "FAIL: no temp-ref survived pass 1; cannot drive the resume"
-    exit 1
-}
+test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" || fail "no temp-ref survived pass 1; cannot drive the resume"
 echo "OK (temp-ref present)"
 
 # pass 2: --continue -> resume Range -> 206 that starts 8 bytes early.

--- a/tests/252_local-nonhtml-foreign-depth.test
+++ b/tests/252_local-nonhtml-foreign-depth.test
@@ -48,7 +48,7 @@ cat >"${tmpdir}/aroot/assets.html" <<EOF
 </body></html>
 EOF
 
-which httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 crawl() { # crawl <label> <start path> [httrack args...]
     local label=$1 start=$2

--- a/tests/253_local-ftp-close-once.test
+++ b/tests/253_local-ftp-close-once.test
@@ -28,7 +28,7 @@ for lib in "${CLOSETRACK_LIB:-}" "${FTPCANCEL_LIB:-}"; do
 done
 
 python=$(find_python) || skip "python3 not found"
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpclose.XXXXXX")
@@ -40,8 +40,6 @@ cleanup() {
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
-
-ok() { echo "OK: $*"; }
 
 root="${tmpdir}/root"
 out="${tmpdir}/crawl"

--- a/tests/254_testlib-tls-pem.test
+++ b/tests/254_testlib-tls-pem.test
@@ -10,8 +10,6 @@ set -euo pipefail
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_tlspem.XXXXXX")
 cleanup_push rm -rf "$tmpdir"
 
-ok() { echo "OK: $*"; }
-
 make_tls_pem "$tmpdir"
 
 # The shipped pair verbatim, key first, and not a fixture minted per run (#1099).

--- a/tests/255_local-ftp-sigterm.test
+++ b/tests/255_local-ftp-sigterm.test
@@ -11,7 +11,7 @@ set -euo pipefail
 
 python=$(find_python) || skip "python3 not found"
 skip_on_windows "MSYS cannot signal a native httrack.exe"
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpterm.XXXXXX")
@@ -23,8 +23,6 @@ cleanup() {
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
-
-ok() { echo "OK: $*"; }
 
 root="${tmpdir}/root"
 out="${tmpdir}/crawl"

--- a/tests/256_testlib-cleanup.test
+++ b/tests/256_testlib-cleanup.test
@@ -13,8 +13,6 @@ tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_cleanup.XXXXXX")
 # the bug it is looking for.
 trap 'set +e; rm -rf "$tmpdir"' EXIT
 
-ok() { echo "OK: $*"; }
-
 # Runs the written subject and reports its status. It has to be its own process,
 # since the traps under test are the shell's.
 subject() {

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -12,8 +12,6 @@ set -euo pipefail
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_asserts.XXXXXX")
 cleanup_push rm -rf "$tmpdir"
 
-ok() { echo "OK: $*"; }
-
 rc=0 out=
 run_subject() {
     printf 'set -euo pipefail\n. "%s/testlib.sh"\n%s\n' "$testdir" "$1" >"$tmpdir/subject.sh"

--- a/tests/258_crawllib.test
+++ b/tests/258_crawllib.test
@@ -17,8 +17,6 @@ find_python >/dev/null || skip "python3 not found"
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_crawllib.XXXXXX")
 cleanup_push rm -rf "$tmpdir"
 
-ok() { echo "OK: $*"; }
-
 rc=0 out=
 run_subject() {
     printf 'set -euo pipefail\n. "%s/crawllib.sh"\ntmpdir=%s\n%s\n' \

--- a/tests/260_crawl-harness-fails-loudly.test
+++ b/tests/260_crawl-harness-fails-loudly.test
@@ -20,8 +20,6 @@ run() { # run ARGS...
     out=$(bash "$crawl" "$@" 2>&1) || rc=$?
 }
 
-ok() { echo "OK: $*"; }
-
 # Floor: the same crawl unmutated has to pass, or the failures below could be
 # coming from a broken fixture rather than from what they mean to exercise.
 run --errors 0 httrack "$url"

--- a/tests/261_local-abort-purge.test
+++ b/tests/261_local-abort-purge.test
@@ -12,7 +12,7 @@ set -euo pipefail
 
 python=$(find_python) || skip "python3 not found"
 skip_on_windows "MSYS cannot signal a native httrack.exe"
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_abortpurge.XXXXXX")
@@ -24,8 +24,6 @@ cleanup() {
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
-
-ok() { echo "OK: $*"; }
 
 root="${tmpdir}/root"
 out="${tmpdir}/crawl"

--- a/tests/262_local-signal-receive.test
+++ b/tests/262_local-signal-receive.test
@@ -11,7 +11,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./crawllib.sh"
 
 skip_on_windows "MSYS cannot signal a native httrack.exe"
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_sigrecv.XXXXXX")
 crawlpid=
@@ -20,8 +20,6 @@ cleanup() {
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
-
-ok() { echo "OK: $*"; }
 
 # Verbose, so a request line in the server log says a body is in flight.
 local_server_start --env LOCAL_SERVER_VERBOSE=1

--- a/tests/263_local-ftp-stop-window.test
+++ b/tests/263_local-ftp-stop-window.test
@@ -12,7 +12,7 @@ set -euo pipefail
 
 python=$(find_python) || skip "python3 not found"
 skip_on_windows "MSYS cannot signal a native httrack.exe"
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 # Long enough that a second window stands well clear of the measuring noise,
 # short enough to keep the test under half a minute.
@@ -28,8 +28,6 @@ cleanup() {
     rm -rf "$tmpdir"
 }
 cleanup_push cleanup
-
-ok() { echo "OK: $*"; }
 
 root="${tmpdir}/root"
 out="${tmpdir}/crawl"

--- a/tests/268_local-abort-purge-capped.test
+++ b/tests/268_local-abort-purge-capped.test
@@ -10,13 +10,11 @@ set -euo pipefail
 # shellcheck source=tests/crawllib.sh
 . "${0%"${0##*/}"}./crawllib.sh"
 
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_capped.XXXXXX")
 cleanup() { rm -rf "$tmpdir"; }
 cleanup_push cleanup
-
-ok() { echo "OK: $*"; }
 
 out="${tmpdir}/crawl"
 mkdir -p "$out"

--- a/tests/276_testlib-freeport.test
+++ b/tests/276_testlib-freeport.test
@@ -16,8 +16,6 @@ tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_freeport.XXXXXX")
 cleanup_push rm -rf "$tmpdir"
 typelog="$tmpdir/socktypes"
 
-ok() { echo "OK: $*"; }
-
 bindable() { # bindable PROTO PORT
     "$real_python" -c 'import socket, sys
 kinds = {"tcp": socket.SOCK_STREAM, "udp": socket.SOCK_DGRAM}

--- a/tests/288_testlib-holdport.test
+++ b/tests/288_testlib-holdport.test
@@ -19,8 +19,6 @@ python=$real_python # hold_port reads it from here
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_holdport.XXXXXX")
 cleanup_push rm -rf "$tmpdir"
 
-ok() { echo "OK: $*"; }
-
 # Exit 0 if PORT is still free in PROTO, non-zero if something holds it.
 bindable() { # bindable PROTO PORT
     "$real_python" -c 'import socket, sys

--- a/tests/46_local-update-304-resume.test
+++ b/tests/46_local-update-304-resume.test
@@ -21,10 +21,7 @@ counter="${tmpdir}/reqcount"
 mark="${tmpdir}/got304"
 local_server_start --env RESUME304_COUNTER="$counter" --env RESUME304_MARK="$mark" --root "$root"
 
-which httrack >/dev/null || {
-    echo "could not find httrack"
-    exit 1
-}
+require_httrack
 out="${tmpdir}/crawl"
 mkdir "$out"
 common=(-O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 --retries=1 -c1)
@@ -43,10 +40,7 @@ sleep 0.5
 kill -TERM "$crawlpid" 2>/dev/null
 wait "$crawlpid" 2>/dev/null
 crawlpid=
-test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" || {
-    echo "FAIL: no temp-ref survived pass 1; cannot drive C7"
-    exit 1
-}
+test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" || fail "no temp-ref survived pass 1; cannot drive C7"
 echo "OK (temp-ref present)"
 before=$(wc -c <"$counter" 2>/dev/null || echo 0)
 
@@ -59,15 +53,9 @@ blob=$(find "$out" -name blob.bin 2>/dev/null | head -1)
 full=8200 # len(RESUME304_BODY) = len("C7DATA--") + 8192
 
 printf '[file recovered whole] ..\t'
-test -s "$blob" || {
-    echo "FAIL: blob.bin missing after the 304 resume (partial dropped, not refetched)"
-    exit 1
-}
+test -s "$blob" || fail "blob.bin missing after the 304 resume (partial dropped, not refetched)"
 got=$(wc -c <"$blob")
-test "$got" -eq "$full" || {
-    echo "FAIL: blob.bin is ${got} bytes, expected ${full} (partial finalized as complete)"
-    exit 1
-}
+test "$got" -eq "$full" || fail "blob.bin is ${got} bytes, expected ${full} (partial finalized as complete)"
 echo "OK (${got} bytes)"
 
 # Pass 2 must issue at least two requests: the resume (Range -> 304) and the
@@ -75,17 +63,11 @@ echo "OK (${got} bytes)"
 after=$(wc -c <"$counter" 2>/dev/null || echo 0)
 hits=$((after - before))
 printf '[resume then refetch] ..\t'
-test "$hits" -ge 2 || {
-    echo "FAIL: only ${hits} pass-2 request(s); the 304 was trusted, no refetch"
-    exit 1
-}
+test "$hits" -ge 2 || fail "only ${hits} pass-2 request(s); the 304 was trusted, no refetch"
 echo "OK (${hits} requests)"
 
 # The recovery must go through the resume path: a Range request that drew the
 # bogus 304 (a fresh re-crawl sends no Range, so this marker stays empty).
 printf '[resume Range drew a 304] ..\t'
-test -s "$mark" || {
-    echo "FAIL: no Range request got a 304; the resume path was not exercised"
-    exit 1
-}
+test -s "$mark" || fail "no Range request got a 304; the resume path was not exercised"
 echo "OK"

--- a/tests/47_local-crange-overflow.test
+++ b/tests/47_local-crange-overflow.test
@@ -19,10 +19,7 @@ cleanup_push cleanup
 
 local_server_start
 
-which httrack >/dev/null || {
-    echo "could not find httrack"
-    exit 1
-}
+require_httrack
 out="${tmpdir}/crawl"
 mkdir "$out"
 common=(-O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 --retries=1 -c1)
@@ -41,10 +38,7 @@ sleep 0.3
 kill -TERM "$crawlpid" 2>/dev/null
 wait "$crawlpid" 2>/dev/null
 crawlpid=
-test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" || {
-    echo "FAIL: no temp-ref survived pass 1; cannot drive the resume"
-    exit 1
-}
+test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" || fail "no temp-ref survived pass 1; cannot drive the resume"
 echo "OK (temp-ref present)"
 
 # --- pass 2: --continue -> resume -> hostile INT64_MAX Content-Range ----------
@@ -56,13 +50,7 @@ blob=$(find "$out" -name blob.bin 2>/dev/null | head -1)
 full=6008 # len(CRANGE206_BODY) = len("CR206DAT") + 6000
 
 printf '[file recovered whole] ..\t'
-test -s "$blob" || {
-    echo "FAIL: blob.bin missing after the hostile 206"
-    exit 1
-}
+test -s "$blob" || fail "blob.bin missing after the hostile 206"
 got=$(wc -c <"$blob")
-test "$got" -eq "$full" || {
-    echo "FAIL: blob.bin is ${got} bytes, expected ${full}"
-    exit 1
-}
+test "$got" -eq "$full" || fail "blob.bin is ${got} bytes, expected ${full}"
 echo "OK (${got} bytes)"

--- a/tests/48_local-crange-memresume.test
+++ b/tests/48_local-crange-memresume.test
@@ -23,10 +23,7 @@ cleanup_push cleanup
 
 local_server_start
 
-which httrack >/dev/null || {
-    echo "could not find httrack"
-    exit 1
-}
+require_httrack
 out="${tmpdir}/crawl"
 mkdir "$out"
 common=(-O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 --retries=1 -c1)
@@ -45,10 +42,7 @@ sleep 0.3
 kill -TERM "$crawlpid" 2>/dev/null
 wait "$crawlpid" 2>/dev/null
 crawlpid=
-test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" || {
-    echo "FAIL: no temp-ref survived pass 1; cannot drive the resume"
-    exit 1
-}
+test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" || fail "no temp-ref survived pass 1; cannot drive the resume"
 echo "OK (temp-ref present)"
 
 # --- pass 2: --continue -> resume -> hostile INT64_MAX Content-Range ----------
@@ -67,13 +61,7 @@ blob=$(find "$out" -name blob.bin 2>/dev/null | head -1)
 full=6008 # len(CRANGE206_BODY) = len("CR206DAT") + 6000
 
 printf '[file recovered whole] ..\t'
-test -s "$blob" || {
-    echo "FAIL: blob.bin missing after the hostile 206"
-    exit 1
-}
+test -s "$blob" || fail "blob.bin missing after the hostile 206"
 got=$(wc -c <"$blob")
-test "$got" -eq "$full" || {
-    echo "FAIL: blob.bin is ${got} bytes, expected ${full}"
-    exit 1
-}
+test "$got" -eq "$full" || fail "blob.bin is ${got} bytes, expected ${full}"
 echo "OK (${got} bytes)"

--- a/tests/71_local-crange-repaircache.test
+++ b/tests/71_local-crange-repaircache.test
@@ -26,10 +26,7 @@ cleanup_push cleanup
 
 local_server_start
 
-which httrack >/dev/null || {
-    echo "could not find httrack"
-    exit 1
-}
+require_httrack
 out="${tmpdir}/crawl"
 mkdir "$out"
 common=(-O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 --retries=1 -c1)
@@ -49,10 +46,7 @@ sleep 0.3
 kill -TERM "$crawlpid" 2>/dev/null
 wait "$crawlpid" 2>/dev/null
 crawlpid=
-test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" || {
-    echo "FAIL: no temp-ref survived pass 1; cannot drive the resume"
-    exit 1
-}
+test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" || fail "no temp-ref survived pass 1; cannot drive the resume"
 echo "OK (temp-ref present)"
 
 # --- damage the cache: drop the central directory a hard kill never wrote ----
@@ -81,23 +75,14 @@ echo "OK (terminated)"
 
 # The repair path must actually have run, else this is just a copy of test 48.
 printf '[cache repair fired] ..\t'
-grep -q 'damaged cache' "${out}/hts-log.txt" 2>/dev/null || {
-    echo "FAIL: repair path did not run; damage was ineffective"
-    exit 1
-}
+grep -q 'damaged cache' "${out}/hts-log.txt" 2>/dev/null || fail "repair path did not run; damage was ineffective"
 echo "OK"
 
 blob=$(find "$out" -name blob.bin 2>/dev/null | head -1)
 full=6008 # len(CRANGE206_BODY) = len("CR206DAT") + 6000
 
 printf '[file recovered whole] ..\t'
-test -s "$blob" || {
-    echo "FAIL: blob.bin missing after the repaired-cache resume"
-    exit 1
-}
+test -s "$blob" || fail "blob.bin missing after the repaired-cache resume"
 got=$(wc -c <"$blob")
-test "$got" -eq "$full" || {
-    echo "FAIL: blob.bin is ${got} bytes, expected ${full}"
-    exit 1
-}
+test "$got" -eq "$full" || fail "blob.bin is ${got} bytes, expected ${full}"
 echo "OK (${got} bytes)"

--- a/tests/76_cli-resize.test
+++ b/tests/76_cli-resize.test
@@ -18,10 +18,7 @@ cleanup_push cleanup
 
 local_server_start
 
-which httrack >/dev/null || {
-    echo "could not find httrack"
-    exit 1
-}
+require_httrack
 
 # Trickled pages under a long path: the display keeps animating while the pty is
 # resized under it, and the URL is truncated at 80 columns but not at 200.

--- a/tests/80_engine-crash-symbolize.test
+++ b/tests/80_engine-crash-symbolize.test
@@ -7,7 +7,7 @@ set -eu
 . "${0%"${0##*/}"}./testlib.sh"
 
 skip_on_windows "no backtrace() on Windows"
-command -v httrack >/dev/null || fail "could not find httrack"
+require_httrack
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_symbolize.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmpdir"

--- a/tests/93_local-changes.test
+++ b/tests/93_local-changes.test
@@ -17,10 +17,7 @@ cleanup_push cleanup
 
 local_server_start
 
-which httrack >/dev/null || {
-    echo "could not find httrack"
-    exit 1
-}
+require_httrack
 out="${tmpdir}/crawl"
 mkdir "$out"
 report="${out}/hts-changes.json"
@@ -71,10 +68,7 @@ digest() { cksum <"$1" | tr -d '[:space:]'; }
 
 # --- pass 1: nothing to compare against --------------------------------------
 local_crawl --log "${tmpdir}/log1" "${common[@]}" -O "$out" --purge-old=0 "${BASEURL}/changes/index.html"
-test -s "$report" || {
-    echo "FAIL: pass 1 wrote no ${report}"
-    exit 1
-}
+test -s "$report" || fail "pass 1 wrote no ${report}"
 expect "pass 1 declares a first crawl" "true" "$(field first_crawl)"
 # Every mirrored file: index, stable.html, moved.html, stable.bin, moved.bin,
 # doomed.html, redirtarget.html, flaky.bin, coded.bin, codedstable.bin,
@@ -83,10 +77,7 @@ expect "pass 1 counts 13 new" "13" "$(field new)"
 expect "pass 1 counts 0 changed" "0" "$(field changed)"
 expect "pass 1 counts 0 gone" "0" "$(field gone)"
 expect_counts_match "pass 1 counts match its lists"
-grep -aq "first crawl" "${out}/hts-log.txt" || {
-    echo "FAIL: pass 1 log carries no first-crawl summary"
-    exit 1
-}
+grep -aq "first crawl" "${out}/hts-log.txt" || fail "pass 1 log carries no first-crawl summary"
 
 host="127.0.0.1_$SRV_PORT"
 resetdigest=$(digest "${out}/${host}/changes/reset.bin")
@@ -136,10 +127,7 @@ dupes=$( (
     listed unchanged
     listed gone
 ) | sort | uniq -d)
-test -z "$dupes" || {
-    echo "FAIL: listed in more than one bucket: ${dupes}"
-    exit 1
-}
+test -z "$dupes" || fail "listed in more than one bucket: ${dupes}"
 echo "OK"
 
 # The log summary is the report, rendered: it must not drift from the counts.
@@ -154,10 +142,7 @@ echo "OK"
 
 expect "the report says nothing was purged" "false" "$(field purged)"
 printf '[reporting gone did not delete it] ..\t'
-test -f "${out}/${host}/changes/doomed.html" || {
-    echo "FAIL: doomed.html was deleted with --purge-old=0"
-    exit 1
-}
+test -f "${out}/${host}/changes/doomed.html" || fail "doomed.html was deleted with --purge-old=0"
 echo "OK"
 expect "a failed transfer keeps its bytes" "$resetdigest" \
     "$(digest "${out}/${host}/changes/reset.bin")"
@@ -168,10 +153,7 @@ expect "the report says files were purged" "true" "$(field purged)"
 expect "gone is the page that only pass 2 linked" \
     "${host}/changes/transient.html" "$(listed gone | sort)"
 printf '[a purged file is off disk] ..\t'
-test ! -f "${out}/${host}/changes/transient.html" || {
-    echo "FAIL: transient.html survived --purge-old"
-    exit 1
-}
+test ! -f "${out}/${host}/changes/transient.html" || fail "transient.html survived --purge-old"
 echo "OK"
 
 # --- cache off: the report degrades, it does not lie -------------------------

--- a/tests/94_local-single-file.test
+++ b/tests/94_local-single-file.test
@@ -65,10 +65,7 @@ printf '<svg xmlns="http://www.w3.org/2000/svg"><circle r="1"/></svg>\n' \
 # --- server -----------------------------------------------------------------
 local_server_start --root "$doc"
 
-which httrack >/dev/null || {
-    echo "could not find httrack"
-    exit 1
-}
+require_httrack
 
 # --- crawl ------------------------------------------------------------------
 # The cap sits between pixel.svg and big.svg, so one inlines and one must not.
@@ -79,10 +76,7 @@ common=(-O "$out" "${opts[@]}")
 local_crawl --log "${tmpdir}/log1" "${common[@]}" --single-file --single-file-max-size 4096 "${BASEURL}/index.html"
 
 page="${out}/127.0.0.1_${SRV_PORT}/index.html"
-test -f "$page" || {
-    echo "FAIL: no mirrored page at $page"
-    exit 1
-}
+test -f "$page" || fail "no mirrored page at $page"
 
 # --- what must be inlined, byte for byte ------------------------------------
 # The decoder is python, not httrack, so a broken encoder cannot agree with
@@ -99,121 +93,61 @@ PY
 }
 
 printf '[image inlined and identical] ..\t'
-extract "$page" "image/svg+xml" "${tmpdir}/got.svg" || {
-    echo "FAIL: no inlined image"
-    exit 1
-}
-cmp -s "${doc}/pixel.svg" "${tmpdir}/got.svg" || {
-    echo "FAIL: inlined image differs from the served file"
-    exit 1
-}
+extract "$page" "image/svg+xml" "${tmpdir}/got.svg" || fail "no inlined image"
+cmp -s "${doc}/pixel.svg" "${tmpdir}/got.svg" || fail "inlined image differs from the served file"
 echo OK
 
 printf '[script inlined and identical] ..\t'
-extract "$page" "application/x-javascript" "${tmpdir}/got.js" || {
-    echo "FAIL: no inlined script"
-    exit 1
-}
-cmp -s "${doc}/app.js" "${tmpdir}/got.js" || {
-    echo "FAIL: inlined script differs from the served file"
-    exit 1
-}
+extract "$page" "application/x-javascript" "${tmpdir}/got.js" || fail "no inlined script"
+cmp -s "${doc}/app.js" "${tmpdir}/got.js" || fail "inlined script differs from the served file"
 echo OK
 
 printf '[lazy-loaded image inlined] ..\t'
 # src is the placeholder a real page ships; the asset rides data-src.
-grep -q 'data-src="data:image/svg+xml;base64,' "$page" || {
-    echo "FAIL: data-src was not inlined"
-    exit 1
-}
+grep -q 'data-src="data:image/svg+xml;base64,' "$page" || fail "data-src was not inlined"
 if grep -q 'data-src="lazy.svg"' "$page"; then
     echo "FAIL: data-src kept its link"
     exit 1
 fi
-test -f "${out}/127.0.0.1_${SRV_PORT}/lazy.svg" || {
-    echo "FAIL: the lazy image was never downloaded, so nothing was proven"
-    exit 1
-}
+test -f "${out}/127.0.0.1_${SRV_PORT}/lazy.svg" || fail "the lazy image was never downloaded, so nothing was proven"
 echo OK
 
 printf '[stylesheet inlined, recursively] ..\t'
-extract "$page" "text/css" "${tmpdir}/got.css" || {
-    echo "FAIL: no inlined stylesheet"
-    exit 1
-}
-grep -q 'url(data:image/svg+xml;base64,' "${tmpdir}/got.css" || {
-    echo "FAIL: url() inside the inlined stylesheet was not inlined"
-    exit 1
-}
-extract "${tmpdir}/got.css" "text/css" "${tmpdir}/got2.css" || {
-    echo "FAIL: @import was not inlined"
-    exit 1
-}
-grep -q 'url(data:image/svg+xml;base64,' "${tmpdir}/got2.css" || {
-    echo "FAIL: url() inside the @import'ed stylesheet was not inlined"
-    exit 1
-}
+extract "$page" "text/css" "${tmpdir}/got.css" || fail "no inlined stylesheet"
+grep -q 'url(data:image/svg+xml;base64,' "${tmpdir}/got.css" || fail "url() inside the inlined stylesheet was not inlined"
+extract "${tmpdir}/got.css" "text/css" "${tmpdir}/got2.css" || fail "@import was not inlined"
+grep -q 'url(data:image/svg+xml;base64,' "${tmpdir}/got2.css" || fail "url() inside the @import'ed stylesheet was not inlined"
 echo OK
 
 # --- what must keep its link ------------------------------------------------
 printf '[page links stay relative] ..\t'
-grep -q 'href="other.html"' "$page" || {
-    echo "FAIL: the link to another page was not left relative"
-    exit 1
-}
-test -f "${out}/127.0.0.1_${SRV_PORT}/other.html" || {
-    echo "FAIL: the linked page is missing from the mirror"
-    exit 1
-}
+grep -q 'href="other.html"' "$page" || fail "the link to another page was not left relative"
+test -f "${out}/127.0.0.1_${SRV_PORT}/other.html" || fail "the linked page is missing from the mirror"
 echo OK
 
 printf '[a navigational rel keeps its link] ..\t'
 # The page carries a later rel="stylesheet"; reading rel past its own value let
 # this canonical link inherit it and inline the page it names.
-grep -q 'rel="canonical" href="other.html"' "$page" || {
-    echo "FAIL: rel=canonical was inlined"
-    exit 1
-}
+grep -q 'rel="canonical" href="other.html"' "$page" || fail "rel=canonical was inlined"
 echo OK
 
 printf '[an unnamed tag cannot skip the deny rules] ..\t'
 # An unquoted value ending at '>' loses the tag name, which used to read as
 # "a CSS body" and took these past every tag-bearing deny rule.
-grep -q '<a href=pixel.svg>' "$page" || {
-    echo "FAIL: an unquoted anchor was inlined"
-    exit 1
-}
-grep -q '<iframe src=pixel.svg>' "$page" || {
-    echo "FAIL: an unquoted iframe was inlined"
-    exit 1
-}
+grep -q '<a href=pixel.svg>' "$page" || fail "an unquoted anchor was inlined"
+grep -q '<iframe src=pixel.svg>' "$page" || fail "an unquoted iframe was inlined"
 echo OK
 
 printf '[a rel-less link keeps its link] ..\t'
 # Nothing loads it, so it is not an asset however inlinable the file looks.
-grep -q '<link href="style_norel.css">' "$page" || {
-    echo "FAIL: a <link> with no rel was inlined"
-    exit 1
-}
-test -f "${out}/127.0.0.1_${SRV_PORT}/style_norel.css" || {
-    echo "FAIL: style_norel.css is missing, so the probe proves nothing"
-    exit 1
-}
+grep -q '<link href="style_norel.css">' "$page" || fail "a <link> with no rel was inlined"
+test -f "${out}/127.0.0.1_${SRV_PORT}/style_norel.css" || fail "style_norel.css is missing, so the probe proves nothing"
 echo OK
 
 printf '[over-cap asset stays a link] ..\t'
-grep -q 'src="big.svg"' "$page" || {
-    echo "FAIL: the over-cap asset did not keep its link"
-    exit 1
-}
-test -f "${out}/127.0.0.1_${SRV_PORT}/big.svg" || {
-    echo "FAIL: the over-cap asset is missing from the mirror"
-    exit 1
-}
-grep -q 'over the 4096-byte cap' "${out}/hts-log.txt" || {
-    echo "FAIL: the over-cap asset was not reported in the log"
-    exit 1
-}
+grep -q 'src="big.svg"' "$page" || fail "the over-cap asset did not keep its link"
+test -f "${out}/127.0.0.1_${SRV_PORT}/big.svg" || fail "the over-cap asset is missing from the mirror"
+grep -q 'over the 4096-byte cap' "${out}/hts-log.txt" || fail "the over-cap asset was not reported in the log"
 echo OK
 
 printf '[the mirror still works] ..\t'
@@ -221,10 +155,7 @@ if grep -q 'href="style.css"' "$page"; then
     echo "FAIL: the stylesheet link survived"
     exit 1
 fi
-test -f "${out}/127.0.0.1_${SRV_PORT}/style.css" || {
-    echo "FAIL: the mirror lost the standalone stylesheet"
-    exit 1
-}
+test -f "${out}/127.0.0.1_${SRV_PORT}/style.css" || fail "the mirror lost the standalone stylesheet"
 echo OK
 
 # --- a second run must not re-encode ----------------------------------------
@@ -233,19 +164,10 @@ printf '[idempotent under --update] ..\t'
 grep -v 'Mirrored from' "$page" >"${tmpdir}/page1.html"
 local_crawl --log "${tmpdir}/log2" "${common[@]}" --single-file --single-file-max-size 4096 --update "${BASEURL}/index.html"
 grep -v 'Mirrored from' "$page" >"${tmpdir}/page2.html"
-cmp -s "${tmpdir}/page1.html" "${tmpdir}/page2.html" || {
-    echo "FAIL: the second run changed the page"
-    exit 1
-}
+cmp -s "${tmpdir}/page1.html" "${tmpdir}/page2.html" || fail "the second run changed the page"
 # A double-encoded payload would decode to another data: URI, not to the SVG.
-extract "$page" "image/svg+xml" "${tmpdir}/got2.svg" || {
-    echo "FAIL: no inlined image after the second run"
-    exit 1
-}
-cmp -s "${doc}/pixel.svg" "${tmpdir}/got2.svg" || {
-    echo "FAIL: the second run re-encoded the inlined image"
-    exit 1
-}
+extract "$page" "image/svg+xml" "${tmpdir}/got2.svg" || fail "no inlined image after the second run"
+cmp -s "${doc}/pixel.svg" "${tmpdir}/got2.svg" || fail "the second run re-encoded the inlined image"
 echo OK
 
 printf '[-%%Z0 and a bad cap] ..\t'
@@ -265,20 +187,14 @@ for cap in notanumber 12abc 0 99999999999999999999; do
     rc=0
     local_crawl --log "${tmpdir}/log4" -O "$bad" "${opts[@]}" \
         --single-file-max-size "$cap" "${BASEURL}/index.html" || rc=$?
-    test "$rc" -ne 0 || {
-        echo "FAIL: --single-file-max-size $cap was accepted"
-        exit 1
-    }
+    test "$rc" -ne 0 || fail "--single-file-max-size $cap was accepted"
     grep -q 'positive size' "${tmpdir}/log4" || {
         echo "FAIL: --single-file-max-size $cap was refused without saying so"
         cat "${tmpdir}/log4"
         exit 1
     }
 done
-test ! -e "${bad}/127.0.0.1_${SRV_PORT}/index.html" || {
-    echo "FAIL: a rejected cap still crawled"
-    exit 1
-}
+test ! -e "${bad}/127.0.0.1_${SRV_PORT}/index.html" || fail "a rejected cap still crawled"
 echo OK
 
 printf '[a page cannot forge a mark] ..\t'
@@ -287,14 +203,8 @@ printf '[a page cannot forge a mark] ..\t'
 # truncated secret comparison would put a data: URI here instead. pixel.svg is
 # inlined elsewhere on the page, so the encoder was demonstrably willing.
 forged=$(sed -n 's/.*<p>\(id=[^<]*\)<\/p>.*/\1/p' "$page")
-test "$forged" = 'id=pixel.svg end' || {
-    echo "FAIL: the page was altered: $forged"
-    exit 1
-}
-grep -q 'data:image/svg+xml;base64,' "$page" || {
-    echo "FAIL: nothing was inlined at all, so the probe proves nothing"
-    exit 1
-}
+test "$forged" = 'id=pixel.svg end' || fail "the page was altered: $forged"
+grep -q 'data:image/svg+xml;base64,' "$page" || fail "nothing was inlined at all, so the probe proves nothing"
 echo OK
 
 printf '[a mark cannot ride in on a header] ..\t'
@@ -302,20 +212,14 @@ printf '[a mark cannot ride in on a header] ..\t'
 # sweep cannot see, so /sfmark.html serves a mark there. It names pixel.svg, so
 # an expansion would leave a data: URI.
 markpage="${out}/127.0.0.1_${SRV_PORT}/sfmark.html"
-test -f "$markpage" || {
-    echo "FAIL: the charset-mark page was not mirrored"
-    exit 1
-}
+test -f "$markpage" || fail "the charset-mark page was not mirrored"
 if grep -q 'charset=data:' "$markpage"; then
     echo "FAIL: a charset-borne mark was expanded"
     exit 1
 fi
 # The mark is deleted and its reference kept: without this the check above
 # passes on a page that never carried a charset.
-grep -q 'content="text/html;charset=pixel.svg" />' "$markpage" || {
-    echo "FAIL: the charset never reached the page, so nothing was proven"
-    exit 1
-}
+grep -q 'content="text/html;charset=pixel.svg" />' "$markpage" || fail "the charset never reached the page, so nothing was proven"
 echo OK
 
 printf '[no file keeps a mark] ..\t'
@@ -326,25 +230,16 @@ printf '[no file keeps a mark] ..\t'
 st=0
 marked=$(grep -rlE '#![0-9a-f]{16}\.[-cj]\.[0-9]+' \
     "${out}/127.0.0.1_$SRV_PORT" 2>/dev/null) || st=$?
-test "$st" -le 1 || {
-    echo "FAIL: the mark sweep could not read the mirror (grep exit $st)"
-    exit 1
-}
+test "$st" -le 1 || fail "the mark sweep could not read the mirror (grep exit $st)"
 marked=$(printf '%s' "$marked" | tr '\n' ' ')
-test -z "$marked" || {
-    echo "FAIL: marks survived in $marked"
-    exit 1
-}
+test -z "$marked" || fail "marks survived in $marked"
 echo OK
 
 printf '[an unrecognised type still inlines from its context] ..\t'
 # style_noext and app_noext have no usable extension, so only the referencing
 # context says what they are. plain.css/plain.js are the control: they inline
 # either way, so a failure here is the context path and not the encoder.
-grep -q 'href="data:text/css;base64,' "$page" || {
-    echo "FAIL: no stylesheet inlined at all"
-    exit 1
-}
+grep -q 'href="data:text/css;base64,' "$page" || fail "no stylesheet inlined at all"
 if grep -q 'href="style_noext"' "$page"; then
     echo "FAIL: extensionless stylesheet was not inlined"
     exit 1
@@ -357,19 +252,13 @@ echo OK
 
 printf '[a fragment survives onto the data: URI] ..\t'
 # An SVG fragment selects a view, so dropping it renders the wrong thing (#766).
-grep -q 'data:image/svg+xml;base64,[A-Za-z0-9+/=]*#icon' "$page" || {
-    echo "FAIL: the fragment was dropped"
-    exit 1
-}
+grep -q 'data:image/svg+xml;base64,[A-Za-z0-9+/=]*#icon' "$page" || fail "the fragment was dropped"
 echo OK
 
 printf '[a page link is not inlined even when it names an asset] ..\t'
 # <a href> to an image: only the deny rule stops this, since the MIME gate
 # would happily take it. Without the rule the anchor becomes a data: URI.
-grep -q '<a href="pixel.svg">raw</a>' "$page" || {
-    echo "FAIL: an anchor to an inlinable asset was rewritten"
-    exit 1
-}
+grep -q '<a href="pixel.svg">raw</a>' "$page" || fail "an anchor to an inlinable asset was rewritten"
 echo OK
 
 printf '[-%%M refuses to pair with --single-file] ..\t'
@@ -392,14 +281,8 @@ mkdir "$chg"
 # and every check below vacuous.
 local_crawl --log "${tmpdir}/log6" -O "$chg" "${opts[@]}" --single-file --changes "${BASEURL}/index.html"
 chgpage="${chg}/127.0.0.1_${SRV_PORT}/index.html"
-test -f "$chgpage" || {
-    echo "FAIL: --changes produced no mirrored page"
-    exit 1
-}
-grep -q 'base64,' "$chgpage" || {
-    echo "FAIL: --changes suppressed the inlining"
-    exit 1
-}
+test -f "$chgpage" || fail "--changes produced no mirrored page"
+grep -q 'base64,' "$chgpage" || fail "--changes suppressed the inlining"
 # Via a file, never a heredoc inside $(...): bash 3.2 (macOS) ends the
 # substitution at the ")" and runs the body as shell commands.
 cat >"${tmpdir}/report.py" <<'REPORT'
@@ -415,10 +298,7 @@ sys.exit("FAIL: index.html is in no bucket of the change report")
 REPORT
 reported=$("$python" "${tmpdir}/report.py" "${chg}/hts-changes.json" index.html) || exit 1
 onpage=$(wc -c <"$chgpage")
-test "$reported" -eq "$onpage" || {
-    echo "FAIL: the report sizes the page at $reported, on disk it is $onpage"
-    exit 1
-}
+test "$reported" -eq "$onpage" || fail "the report sizes the page at $reported, on disk it is $onpage"
 echo OK
 
 printf '[the rewritten page keeps the mirror file mode] ..\t'
@@ -437,10 +317,7 @@ else
 print("%04o" % (os.stat(sys.argv[1]).st_mode & 0o777))' "$1"; }
     pagemode=$(mode "${umaskroot}/index.html")
     assetmode=$(mode "${umaskroot}/big.svg")
-    test "$pagemode" = "$assetmode" || {
-        echo "FAIL: page is $pagemode, the asset beside it is $assetmode"
-        exit 1
-    }
+    test "$pagemode" = "$assetmode" || fail "page is $pagemode, the asset beside it is $assetmode"
     echo OK
 fi
 
@@ -460,25 +337,13 @@ esac
 printf '[the unresolved-reference warning is clipped] ..\t'
 # The self-test drives a 90 KB reference through it, so an unclipped build puts
 # all of it in the log. The first check is the floor: no warning proves nothing.
-grep -q 'resolves to no mirrored file' <<<"$st" || {
-    echo "FAIL: the self-test logged no unresolved reference"
-    exit 1
-}
-awk 'length($0) > 1024 { exit 1 }' <<<"$st" || {
-    echo "FAIL: a log line ran past the clip"
-    exit 1
-}
+grep -q 'resolves to no mirrored file' <<<"$st" || fail "the self-test logged no unresolved reference"
+awk 'length($0) > 1024 { exit 1 }' <<<"$st" || fail "a log line ran past the clip"
 echo OK
 
 # --- project reload restores the saved keys ---------------------------------
 distdir=$(cd "${top_srcdir}" && pwd)
 printf '[project reload maps the keys back] ..\t'
-grep -q 'do:copy:SingleFile:singlefile' "${distdir}/html/server/step2.html" || {
-    echo "FAIL: step2.html does not restore SingleFile"
-    exit 1
-}
-grep -q 'do:copy:SingleFileMaxSize:singlefilemax' "${distdir}/html/server/step2.html" || {
-    echo "FAIL: step2.html does not restore SingleFileMaxSize"
-    exit 1
-}
+grep -q 'do:copy:SingleFile:singlefile' "${distdir}/html/server/step2.html" || fail "step2.html does not restore SingleFile"
+grep -q 'do:copy:SingleFileMaxSize:singlefilemax' "${distdir}/html/server/step2.html" || fail "step2.html does not restore SingleFileMaxSize"
 echo OK

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -309,6 +309,18 @@ repeat_chars() { # repeat_chars COUNT [CHAR]
     printf '%*s' "$1" '' | tr ' ' "${2:-a}"
 }
 
+# A passing step, on stdout: the failures go to stderr through fail().
+ok() { echo "OK: $*"; }
+
+# Size of file $1 in bytes. wc pads its count on the BSDs.
+size_of() { wc -c <"$1" | tr -d '[:space:]'; }
+
+# The engine must be on PATH. `which` is not POSIX and lies under MSYS, and a
+# test that needs the engine has nothing to say without it.
+require_httrack() {
+    command -v httrack >/dev/null || fail "could not find httrack"
+}
+
 # Longest surviving run of char $2 in file $1, or 0: the length a field was
 # clipped to, read back out of a binary artifact.
 runlen() {

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -315,8 +315,7 @@ ok() { echo "OK: $*"; }
 # Size of file $1 in bytes. wc pads its count on the BSDs.
 size_of() { wc -c <"$1" | tr -d '[:space:]'; }
 
-# The engine must be on PATH. `which` is not POSIX and lies under MSYS, and a
-# test that needs the engine has nothing to say without it.
+# `which` is not POSIX and lies under MSYS; use `command -v`.
 require_httrack() {
     command -v httrack >/dev/null || fail "could not find httrack"
 }


### PR DESCRIPTION
Follow-on to #1344, which decided a file could use `fail()` by grepping the file itself for `testlib.sh`. Tests that reach it through `crawllib.sh` or `webhttracklib.sh` were invisible to that test, so 102 more hand-rolled blocks survived across 15 files. Forty-five were in `94_local-single-file.test`, which loses 225 lines here.

Three helpers were also being declared locally and identically. `ok()` in 24 files, `size_of()` in 5, and the "is httrack on PATH" guard in 38 sites across six spellings, half of them using `which`, which is not POSIX and is unreliable under MSYS. All three move to testlib.sh, and the guard becomes one `require_httrack`.

Twenty blocks are deliberately left. Their files source nothing that defines `fail()`, so converting them means giving each one testlib first, which is a different change.

One conversion had to be undone by hand. `240`'s `expect()` printed a bare `FAIL` aligned under the step label it had just printed; the sweep turned that into `fail "FAIL"`, which renders as `FAIL: FAIL` and names nothing. It now passes the label it already holds.

Mutants confirm the helpers carry weight. `require_httrack` forced to fail reds the tests calling it, and `size_of` stubbed to 0 reds four of its five callers. The fifth uses `size_of` only inside a failure message, so no mutation of it can flip that test.

Full suite green at 348 pass, 12 skip.