### PR TITLE
One ARC fixture builder that counts bytes, not characters

### DIFF
--- a/tests/118_local-proxytrack-arcwrite.test
+++ b/tests/118_local-proxytrack-arcwrite.test
@@ -8,6 +8,8 @@ export LC_ALL=C
 
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
+# shellcheck source=tests/arclib.sh
+. "${0%"${0##*/}"}./arclib.sh"
 
 dir=$(mktemp -d)
 cleanup() { rm -rf "$dir"; }
@@ -46,14 +48,9 @@ build_arc() {
         printf '\r\n'
     } >"$dir/hdr"
     printf '%s' "$BODY" >"$dir/body"
-    local alen
-    alen=$(($(wc -c <"$dir/hdr") + ${#BODY}))
     {
-        printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc 9\n'
-        printf '2 0 test\n'
-        printf '\n\n'
-        printf 'http://example.com/p.html 0.0.0.0 20250101000000 text/html 200 - - 0 t.arc %d\n' "$alen"
-        cat "$dir/hdr" "$dir/body"
+        arc_filedesc
+        arc_record http://example.com/p.html text/html 200 "$dir/hdr" "$dir/body"
     } >"$dir/in.arc"
 }
 

--- a/tests/120_local-proxytrack-webdav-default.test
+++ b/tests/120_local-proxytrack-webdav-default.test
@@ -8,6 +8,8 @@ set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
+# shellcheck source=tests/arclib.sh
+. "${0%"${0##*/}"}./arclib.sh"
 
 python=$(find_python) || skip "python3 missing"
 command -v curl >/dev/null 2>&1 || skip "curl missing"
@@ -25,13 +27,9 @@ cleanup_push cleanup
 
 printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 5\r\n\r\n' >"$dir/hdr"
 printf 'hello' >"$dir/body"
-alen=$(($(wc -c <"$dir/hdr") + $(wc -c <"$dir/body")))
 {
-    printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc 9\n'
-    printf '2 0 test\n'
-    printf '\n\n'
-    printf 'http://example.com/page.html 0.0.0.0 20250101000000 text/html 200 - - 0 t.arc %d\n' "$alen"
-    cat "$dir/hdr" "$dir/body"
+    arc_filedesc
+    arc_record http://example.com/page.html text/html 200 "$dir/hdr" "$dir/body"
 } >"$dir/in.arc"
 
 # stdout to a file is fully buffered and SIGTERM never flushes it, so a leak on

--- a/tests/147_local-proxytrack-webdav-overflow.test
+++ b/tests/147_local-proxytrack-webdav-overflow.test
@@ -8,6 +8,8 @@ set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
+# shellcheck source=tests/arclib.sh
+. "${0%"${0##*/}"}./arclib.sh"
 
 python=$(find_python) || skip "python3 missing"
 command -v curl >/dev/null 2>&1 || skip "curl missing"
@@ -22,18 +24,13 @@ cleanup_push cleanup
 
 printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 5\r\n\r\n' >"$dir/hdr"
 printf 'hello' >"$dir/body"
-alen=$(($(wc -c <"$dir/hdr") + $(wc -c <"$dir/body")))
 {
-    printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc 9\n'
-    printf '2 0 test\n'
-    printf '\n\n'
-    printf 'http://example.com/page.html 0.0.0.0 20250101000000 text/html 200 - - 0 t.arc %d\n' "$alen"
-    cat "$dir/hdr" "$dir/body"
+    arc_filedesc
+    arc_record http://example.com/page.html text/html 200 "$dir/hdr" "$dir/body"
     # a record begins on the newline following the previous one's data
     printf '\n'
     # gives the Depth: 1 listing below a child directory as well as a child file
-    printf 'http://example.com/sub/deep.html 0.0.0.0 20250101000000 text/html 200 - - 0 t.arc %d\n' "$alen"
-    cat "$dir/hdr" "$dir/body"
+    arc_record http://example.com/sub/deep.html text/html 200 "$dir/hdr" "$dir/body"
 } >"$dir/in.arc"
 
 launch_proxytrack() {

--- a/tests/153_local-proxytrack-quiet.test
+++ b/tests/153_local-proxytrack-quiet.test
@@ -9,6 +9,8 @@ set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
+# shellcheck source=tests/arclib.sh
+. "${0%"${0##*/}"}./arclib.sh"
 
 python=$(find_python) || skip "python3 missing"
 command -v curl >/dev/null 2>&1 || skip "curl missing"
@@ -31,13 +33,9 @@ cleanup_push cleanup
 
 printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 5\r\n\r\n' >"$dir/hdr"
 printf 'hello' >"$dir/body"
-alen=$(($(wc -c <"$dir/hdr") + $(wc -c <"$dir/body")))
 {
-    printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc 9\n'
-    printf '2 0 test\n'
-    printf '\n\n'
-    printf 'http://example.com/page.html 0.0.0.0 20250101000000 text/html 200 - - 0 t.arc %d\n' "$alen"
-    cat "$dir/hdr" "$dir/body"
+    arc_filedesc
+    arc_record http://example.com/page.html text/html 200 "$dir/hdr" "$dir/body"
 } >"$dir/in.arc"
 
 # stdout to a file is fully buffered and SIGTERM never flushes it, so a leak on

--- a/tests/154_local-proxytrack-arc-roundtrip.test
+++ b/tests/154_local-proxytrack-arc-roundtrip.test
@@ -65,7 +65,7 @@ test "$inner" != '\n\n' || fail "declared length still counts the blank line"
 
 # An empty archive is not a corrupt one...
 {
-    printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc 9\n'
+    printf 'filedesc://t.arc 0.0.0.0 %s text/plain 200 - - 0 t.arc 9\n' "$ARC_DATE"
     printf '2 0 test\n'
     printf '\n'
 } >"$dir/empty.arc"
@@ -74,9 +74,7 @@ convert "$dir/empty.arc" "$dir/d.arc" >/dev/null
 
 # ...but a length running past the end of the file still is.
 {
-    printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc 99999\n'
-    printf '2 0 test\n'
-    printf '\n\n'
+    arc_filedesc 99999
 } >"$dir/truncated.arc"
 convert "$dir/truncated.arc" "$dir/e.arc" >/dev/null || true
 grep -q 'Unexpected' "$dir/log" || fail "a length past the end of the file loaded as an empty archive"

--- a/tests/154_local-proxytrack-arc-roundtrip.test
+++ b/tests/154_local-proxytrack-arc-roundtrip.test
@@ -6,6 +6,8 @@ set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
+# shellcheck source=tests/arclib.sh
+. "${0%"${0##*/}"}./arclib.sh"
 
 export LC_ALL=C
 
@@ -16,17 +18,13 @@ cleanup_push cleanup
 BODY=BODYMARKER
 printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nLast-Modified: Wed, 01 Jan 2025 00:00:00 GMT\r\nContent-Length: %d\r\n\r\n' "${#BODY}" >"$dir/hdr"
 printf '%s' "$BODY" >"$dir/body"
-alen=$(($(wc -c <"$dir/hdr") + ${#BODY}))
 
-# $1 output, $2 the filedesc length: 9 stops at the "2 0" line, 10 swallows the
-# blank line closing the version block the way the writer used to. Same bytes.
+# $1 output, $2 the declared filedesc length: 9, or the 10 the writer used to
+# emit. Same bytes either way.
 build_arc() {
     {
-        printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc %d\n' "$2"
-        printf '2 0 test\n'
-        printf '\n\n'
-        printf 'http://example.com/p.html 0.0.0.0 20250101000000 text/html 200 - - 0 t.arc %d\n' "$alen"
-        cat "$dir/hdr" "$dir/body"
+        arc_filedesc "$2"
+        arc_record http://example.com/p.html text/html 200 "$dir/hdr" "$dir/body"
     } >"$1"
 }
 

--- a/tests/161_local-proxytrack-zip-headers.test
+++ b/tests/161_local-proxytrack-zip-headers.test
@@ -9,6 +9,8 @@ set -eu
 
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
+# shellcheck source=tests/arclib.sh
+. "${0%"${0##*/}"}./arclib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
@@ -23,14 +25,10 @@ BODY='<html>hi</html>'
 printf 'HTTP/1.0 301 Moved\r\nContent-type: text/html\r\nEtag: "%s"\r\nLocation: %s\r\nContent-Disposition: %s\r\nLast-modified: Fri, 18 Jul 2003 08:59:11 GMT\r\nContent-length: %d\r\n\r\n' \
     "$etag" "$loc" "$cdispo" ${#BODY} >"$dir/hdr"
 printf '%s' "$BODY" >"$dir/body"
-alen=$(($(wc -c <"$dir/hdr") + ${#BODY}))
 
 {
-    printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc 9\n'
-    printf '2 0 test\n'
-    printf '\n\n'
-    printf 'http://example.com/p.html 0.0.0.0 20250101000000 text/html 301 - - 0 t.arc %d\n' "$alen"
-    cat "$dir/hdr" "$dir/body"
+    arc_filedesc
+    arc_record http://example.com/p.html text/html 301 "$dir/hdr" "$dir/body"
 } >"$dir/in.arc"
 
 proxytrack --convert "$dir/out.zip" "$dir/in.arc" >/dev/null 2>&1 ||

--- a/tests/164_local-proxytrack-arc-hostile.test
+++ b/tests/164_local-proxytrack-arc-hostile.test
@@ -8,18 +8,14 @@ set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
+# shellcheck source=tests/arclib.sh
+. "${0%"${0##*/}"}./arclib.sh"
 
 export LC_ALL=C
 
 dir=$(mktemp -d)
 cleanup() { rm -rf "$dir"; }
 cleanup_push cleanup
-
-arc_header() {
-    printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc 9\n'
-    printf '2 0 test\n'
-    printf '\n\n'
-}
 
 convert() {
     proxytrack --convert "$2" "$1" 2>"$dir/log" >/dev/null ||
@@ -47,7 +43,7 @@ check_record_length() {
 # body is never fetched and the declared Content-Length is all that is left.
 printf 'HTTP/1.1 - Broken\r\nContent-Type: text/html\r\nContent-Length: 10\r\n\r\n' >"$dir/hdr"
 {
-    arc_header
+    arc_filedesc
     printf 'http://example.com/p.html 0.0.0.0 20250101000000 text/html -1 - - 0 t.arc %d\n' \
         "$(($(wc -c <"$dir/hdr") + 10))"
     cat "$dir/hdr"
@@ -69,7 +65,7 @@ fi
 # A length no archive this size can hold: refused, not allocated. The reader
 # used to malloc it and report whatever the short read left behind.
 {
-    arc_header
+    arc_filedesc
     printf 'http://example.com/q.html 0.0.0.0 20250101000000 text/html 200 - - 0 t.arc 2000000000\n'
     printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\nHI'
 } >"$dir/huge.arc"
@@ -84,12 +80,10 @@ test "$status" = 'HTTP/1.0 -1 Cache Read Error : Truncated Data' ||
 # that refuses everything.
 body=BODYMARKER
 printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: %d\r\n\r\n' "${#body}" >"$dir/hdr2"
+printf '%s' "$body" >"$dir/body2"
 {
-    arc_header
-    printf 'http://example.com/r.html 0.0.0.0 20250101000000 text/html 200 - - 0 t.arc %d\n' \
-        "$(($(wc -c <"$dir/hdr2") + ${#body}))"
-    cat "$dir/hdr2"
-    printf '%s' "$body"
+    arc_filedesc
+    arc_record http://example.com/r.html text/html 200 "$dir/hdr2" "$dir/body2"
 } >"$dir/good.arc"
 
 convert "$dir/good.arc" "$dir/d.arc"

--- a/tests/164_local-proxytrack-arc-hostile.test
+++ b/tests/164_local-proxytrack-arc-hostile.test
@@ -44,8 +44,8 @@ check_record_length() {
 printf 'HTTP/1.1 - Broken\r\nContent-Type: text/html\r\nContent-Length: 10\r\n\r\n' >"$dir/hdr"
 {
     arc_filedesc
-    printf 'http://example.com/p.html 0.0.0.0 20250101000000 text/html -1 - - 0 t.arc %d\n' \
-        "$(($(wc -c <"$dir/hdr") + 10))"
+    printf 'http://example.com/p.html 0.0.0.0 %s text/html -1 - - 0 t.arc %d\n' \
+        "$ARC_DATE" "$(($(wc -c <"$dir/hdr") + 10))"
     cat "$dir/hdr"
 } >"$dir/nobody.arc"
 
@@ -66,7 +66,7 @@ fi
 # used to malloc it and report whatever the short read left behind.
 {
     arc_filedesc
-    printf 'http://example.com/q.html 0.0.0.0 20250101000000 text/html 200 - - 0 t.arc 2000000000\n'
+    printf 'http://example.com/q.html 0.0.0.0 %s text/html 200 - - 0 t.arc 2000000000\n' "$ARC_DATE"
     printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\nHI'
 } >"$dir/huge.arc"
 

--- a/tests/53_local-proxytrack-arc-reason.test
+++ b/tests/53_local-proxytrack-arc-reason.test
@@ -5,22 +5,18 @@
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
+# shellcheck source=tests/arclib.sh
+. "${0%"${0##*/}"}./arclib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
 printf 'HTTP/1.1 404 Not Found Here At All\r\nContent-Type: text/html\r\nLast-Modified: Wed, 01 Jan 2025 00:00:00 GMT\r\nContent-Length: 5\r\n\r\n' >"$dir/hdr"
 printf 'hello' >"$dir/body"
-alen=$(($(wc -c <"$dir/hdr") + $(wc -c <"$dir/body")))
 
-# ARC 1.0: filedesc record and version block, then per entry
-# <nl> <URL-record> <nl> <headers> <body>; the record's last field is that length.
 {
-    printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc 9\n'
-    printf '2 0 test\n'
-    printf '\n\n'
-    printf 'http://example.com/page.html 0.0.0.0 20250101000000 text/html 404 - - 0 t.arc %d\n' "$alen"
-    cat "$dir/hdr" "$dir/body"
+    arc_filedesc
+    arc_record http://example.com/page.html text/html 404 "$dir/hdr" "$dir/body"
 } >"$dir/in.arc"
 
 proxytrack --convert "$dir/out.arc" "$dir/in.arc" >/dev/null 2>&1

--- a/tests/79_local-proxytrack-webdav-mime.test
+++ b/tests/79_local-proxytrack-webdav-mime.test
@@ -7,6 +7,8 @@ set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
+# shellcheck source=tests/arclib.sh
+. "${0%"${0##*/}"}./arclib.sh"
 
 python=$(find_python) || skip "python3 missing"
 command -v curl >/dev/null 2>&1 || skip "curl missing"
@@ -22,13 +24,9 @@ cleanup_push cleanup
 # Neither header is present, so file->contenttype and ->lastmodified stay "".
 printf 'HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\n' >"$dir/hdr"
 printf 'hello' >"$dir/body"
-alen=$(($(wc -c <"$dir/hdr") + $(wc -c <"$dir/body")))
 {
-    printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc 9\n'
-    printf '2 0 test\n'
-    printf '\n\n'
-    printf 'http://example.com/page.html 0.0.0.0 20250101000000 text/html 200 - - 0 t.arc %d\n' "$alen"
-    cat "$dir/hdr" "$dir/body"
+    arc_filedesc
+    arc_record http://example.com/page.html text/html 200 "$dir/hdr" "$dir/body"
 } >"$dir/in.arc"
 
 launch_proxytrack() {

--- a/tests/86_local-proxytrack-cache-longfields.test
+++ b/tests/86_local-proxytrack-cache-longfields.test
@@ -6,6 +6,8 @@ set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
+# shellcheck source=tests/arclib.sh
+. "${0%"${0##*/}"}./arclib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
@@ -22,13 +24,9 @@ cleanup_push rm -rf "$dir"
     printf 'Content-Length: 5\r\n\r\n'
 } >"$dir/hdr"
 printf 'hello' >"$dir/body"
-alen=$(($(wc -c <"$dir/hdr") + $(wc -c <"$dir/body")))
 {
-    printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc 9\n'
-    printf '2 0 test\n'
-    printf '\n\n'
-    printf 'http://example.com/p.html 0.0.0.0 20250101000000 text/html 200 - - 0 t.arc %d\n' "$alen"
-    cat "$dir/hdr" "$dir/body"
+    arc_filedesc
+    arc_record http://example.com/p.html text/html 200 "$dir/hdr" "$dir/body"
 } >"$dir/in.arc"
 
 proxytrack --convert "$dir/out.arc" "$dir/in.arc" >/dev/null 2>&1 || fail "proxytrack crashed reading an ARC with over-long headers"

--- a/tests/87_local-proxytrack-nodate.test
+++ b/tests/87_local-proxytrack-nodate.test
@@ -5,6 +5,8 @@
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
+# shellcheck source=tests/arclib.sh
+. "${0%"${0##*/}"}./arclib.sh"
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
@@ -25,13 +27,9 @@ run_case() {
         printf 'Content-Length: 5\r\n\r\n'
     } >"$dir/hdr"
     printf 'hello' >"$dir/body"
-    alen=$(($(wc -c <"$dir/hdr") + $(wc -c <"$dir/body")))
     {
-        printf 'filedesc://t.arc 0.0.0.0 20250101000000 text/plain 200 - - 0 t.arc 9\n'
-        printf '2 0 test\n'
-        printf '\n\n'
-        printf 'http://example.com/p.html 0.0.0.0 20250101000000 text/html 200 - - 0 t.arc %d\n' "$alen"
-        cat "$dir/hdr" "$dir/body"
+        arc_filedesc
+        arc_record http://example.com/p.html text/html 200 "$dir/hdr" "$dir/body"
     } >"$dir/in.arc"
 
     proxytrack --convert "$dir/out.arc" "$dir/in.arc" >/dev/null 2>&1 || fail "proxytrack crashed on $what"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,7 +12,7 @@ EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c a
 	header-injection-server.py header-injection-check.py \
 	pty-resize.py ttyrun.py test-timeout.sh png-colors.py \
 	local-crawl.sh local-server.py ftp-server.py testlib.sh proclib.sh \
-	webhttracklib.sh httpclient.py webtestlib.py crawllib.sh \
+	webhttracklib.sh httpclient.py webtestlib.py crawllib.sh arclib.sh \
 	guide-image-check.py \
 	ci-windows-suite.sh ci-windows-watchdog.ps1 install-headers-sweep.sh \
 	server.crt server.key \

--- a/tests/arclib.sh
+++ b/tests/arclib.sh
@@ -9,7 +9,7 @@ ARC_DATE=20250101000000
 # The version block an ARC file opens with. LEN is the declared length of that
 # block, 9 stopping at the "2 0" line; 154 passes 10 to swallow the blank line
 # the writer used to include.
-# shellcheck disable=SC2120 # LEN is optional; callers mostly take the default
+# shellcheck disable=SC2120 # most callers take the default
 arc_filedesc() { # arc_filedesc [LEN]
     printf 'filedesc://t.arc 0.0.0.0 %s text/plain 200 - - 0 t.arc %d\n' "$ARC_DATE" "${1:-9}"
     printf '2 0 test\n'
@@ -17,7 +17,7 @@ arc_filedesc() { # arc_filedesc [LEN]
 }
 
 # One record: the header line, then HDRFILE and BODYFILE verbatim. The declared
-# length counts BYTES, so a body outside ASCII still frames where it says.
+# length counts BYTES, so a body outside ASCII still declares its true length.
 arc_record() { # arc_record URL MIME STATUS HDRFILE BODYFILE
     printf '%s 0.0.0.0 %s %s %s - - 0 t.arc %d\n' "$1" "$ARC_DATE" "$2" "$3" \
         "$(($(wc -c <"$4") + $(wc -c <"$5")))"

--- a/tests/arclib.sh
+++ b/tests/arclib.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# ARC 1.0 fixtures for the proxytrack tests. Sourced, not run.
+
+# Every fixture dates its records the same: the tests assert on rewriting, not
+# on the clock.
+ARC_DATE=20250101000000
+
+# The version block an ARC file opens with. LEN is the declared length of that
+# block, 9 stopping at the "2 0" line; 154 passes 10 to swallow the blank line
+# the writer used to include.
+# shellcheck disable=SC2120 # LEN is optional; callers mostly take the default
+arc_filedesc() { # arc_filedesc [LEN]
+    printf 'filedesc://t.arc 0.0.0.0 %s text/plain 200 - - 0 t.arc %d\n' "$ARC_DATE" "${1:-9}"
+    printf '2 0 test\n'
+    printf '\n\n'
+}
+
+# One record: the header line, then HDRFILE and BODYFILE verbatim. The declared
+# length counts BYTES, so a body outside ASCII still frames where it says.
+arc_record() { # arc_record URL MIME STATUS HDRFILE BODYFILE
+    printf '%s 0.0.0.0 %s %s %s - - 0 t.arc %d\n' "$1" "$ARC_DATE" "$2" "$3" \
+        "$(($(wc -c <"$4") + $(wc -c <"$5")))"
+    cat "$4" "$5"
+}


### PR DESCRIPTION
Eleven proxytrack tests opened with the same ten lines: the ARC 1.0 version block, then a record header whose declared length they computed by hand. `tests/arclib.sh` holds that as `arc_filedesc` and `arc_record`.

The length arithmetic is why this is worth doing rather than just shorter. Four of the eleven wrote `$(wc -c <hdr) + ${#BODY}`, and `${#BODY}` counts characters. A body holding any byte outside ASCII then declares a length one short per extra byte, and the reader frames the record somewhere other than where it ends. Three of the four were safe only because they happen to export `LC_ALL=C`. `161` does not, so it was genuinely exposed. `arc_record` counts bytes.

The deliberately malformed archives stay hand-built where the helper cannot express them: `154`'s empty archive, whose single trailing newline differs from the version block's two, and `164`'s records that declare a body no file backs. No fixture keeps its own copy of the date any more, so `ARC_DATE` can move without desyncing a hand-built version block from its own record lines.

Mutants: `arc_record` declaring one byte short reds 6 of the 11. The 5 it leaves green assert on WebDAV listings, archive dates and header clipping, not on the final body byte. A second mutant on `arc_filedesc`'s default length reds all 11, so every converted file does depend on the library.

Verified byte-for-byte rather than by a green suite: each test was run on both sides under a shim that captures every fixture it builds, and all 11 produce identical archives.

Full suite green at 348 pass, 12 skip.