### PR TITLE
One way to start the FTP fixture server

### DIFF
--- a/tests/102_local-ftp-refetch.test
+++ b/tests/102_local-ftp-refetch.test
@@ -13,14 +13,8 @@ set -euo pipefail
 python=$(find_python) || skip "python3 not found"
 require_httrack
 
-server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")
-serverpid=
-cleanup() {
-    stop_server "$serverpid"
-    rm -rf "$tmpdir"
-}
-cleanup_push cleanup
+cleanup_push rm -rf "$tmpdir"
 
 root="${tmpdir}/root"
 out="${tmpdir}/crawl"
@@ -42,15 +36,11 @@ write_bodies() {
 write_bodies V1 4096
 : >"$mode"
 
-serverlog="${tmpdir}/server.out"
-"$python" "$server" --root "$(nativepath "$root")" \
-    --mode-file "$(nativepath "$mode")" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-host="127.0.0.1_${port}"
+ftp_server_start --root "$root" --mode-file "$(nativepath "$mode")"
+host="127.0.0.1_${FTP_PORT}"
 urls=()
 for name in keep empty stay; do
-    urls+=("ftp://127.0.0.1:${port}/${name}.bin")
+    urls+=("ftp://127.0.0.1:${FTP_PORT}/${name}.bin")
 done
 # -c1: a parallel FTP crawl loses whole transfers to a separate, older bug in
 # the backlog slot swap (#797), which would flake this test on a loaded runner.

--- a/tests/110_local-ftp-parallel.test
+++ b/tests/110_local-ftp-parallel.test
@@ -13,14 +13,8 @@ set -euo pipefail
 python=$(find_python) || skip "python3 not found"
 require_httrack
 
-server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")
-serverpid=
-cleanup() {
-    stop_server "$serverpid"
-    rm -rf "$tmpdir"
-}
-cleanup_push cleanup
+cleanup_push rm -rf "$tmpdir"
 
 root="${tmpdir}/root"
 out="${tmpdir}/crawl"
@@ -36,15 +30,12 @@ for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
         "$i" >"${root}/f${i}.bin"
 done
 
-serverlog="${tmpdir}/server.out"
-"$python" "$server" --root "$(nativepath "$root")" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-host="127.0.0.1_${port}"
+ftp_server_start --root "$root"
+host="127.0.0.1_${FTP_PORT}"
 
 urls=()
 for name in $names; do
-    urls+=("ftp://127.0.0.1:${port}/${name}.bin")
+    urls+=("ftp://127.0.0.1:${FTP_PORT}/${name}.bin")
 done
 
 # -c8, never -c1: a slot is only swapped out while other transfers keep the

--- a/tests/111_local-ftp-update-rest.test
+++ b/tests/111_local-ftp-update-rest.test
@@ -13,14 +13,8 @@ set -euo pipefail
 python=$(find_python) || skip "python3 not found"
 require_httrack
 
-server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")
-serverpid=
-cleanup() {
-    stop_server "$serverpid"
-    rm -rf "$tmpdir"
-}
-cleanup_push cleanup
+cleanup_push rm -rf "$tmpdir"
 
 root="${tmpdir}/root"
 out="${tmpdir}/crawl"
@@ -47,14 +41,10 @@ write_body() {
 write_body OLD 8000
 echo '/a.bin truncate' >"$mode"
 
-serverlog="${tmpdir}/server.out"
-"$python" "$server" --root "$(nativepath "$root")" \
-    --mode-file "$(nativepath "$mode")" --log "$(nativepath "$cmds")" \
-    >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-host="127.0.0.1_${port}"
-url="ftp://127.0.0.1:${port}/a.bin"
+ftp_server_start --root "$root" --mode-file "$(nativepath "$mode")" \
+    --log "$(nativepath "$cmds")"
+host="127.0.0.1_${FTP_PORT}"
+url="ftp://127.0.0.1:${FTP_PORT}/a.bin"
 mirror="${out}/${host}/a.bin"
 # Bounded like every crawl pass: a wedge must fail the test, not hang the job.
 crawl() { run_with_timeout 300 httrack "$url" -O "$out" --quiet \

--- a/tests/121_local-ftp-nocache-splice.test
+++ b/tests/121_local-ftp-nocache-splice.test
@@ -13,14 +13,8 @@ set -euo pipefail
 python=$(find_python) || skip "python3 not found"
 require_httrack
 
-server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")
-serverpid=
-cleanup() {
-    stop_server "$serverpid"
-    rm -rf "$tmpdir"
-}
-cleanup_push cleanup
+cleanup_push rm -rf "$tmpdir"
 
 root="${tmpdir}/root"
 out="${tmpdir}/crawl"
@@ -62,14 +56,10 @@ future_stamp=1772582400 # 2026-03-04Z, later than any remote below
 write_body OLD 8000 "$old_stamp"
 echo '/a.bin truncate' >"$mode"
 
-serverlog="${tmpdir}/server.out"
-"$python" "$server" --root "$(nativepath "$root")" \
-    --mode-file "$(nativepath "$mode")" --log "$(nativepath "$cmds")" \
-    >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-host="127.0.0.1_${port}"
-url="ftp://127.0.0.1:${port}/a.bin"
+ftp_server_start --root "$root" --mode-file "$(nativepath "$mode")" \
+    --log "$(nativepath "$cmds")"
+host="127.0.0.1_${FTP_PORT}"
+url="ftp://127.0.0.1:${FTP_PORT}/a.bin"
 mirror="${out}/${host}/a.bin"
 # --cache=0 is the whole point: no cache entry to tell a partial from a stale
 # copy. Bounded like every crawl pass, so a wedge fails instead of hanging.

--- a/tests/221_local-ftp-ctrlchars.test
+++ b/tests/221_local-ftp-ctrlchars.test
@@ -10,17 +10,10 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-python=$(find_python) || skip "python3 not found"
 require_httrack
 
-server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")
-serverpid=
-cleanup() {
-    stop_server "$serverpid"
-    rm -rf "$tmpdir"
-}
-cleanup_push cleanup
+cleanup_push rm -rf "$tmpdir"
 
 root="${tmpdir}/root"
 out="${tmpdir}/crawl"
@@ -30,11 +23,7 @@ printf 'body\n' >"${root}/f.txt"
 printf 'secret\n' >"${root}/x.txt"
 printf 'listed\n' >"${root}/d -la/inside.txt"
 
-serverlog="${tmpdir}/server.out"
-"$python" "$server" --root "$(nativepath "$root")" \
-    --log "$(nativepath "$cmds")" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+ftp_server_start --root "$root" --log "$(nativepath "$cmds")"
 
 # 60s is the wedge detector: a dropped command leaves the engine on a 300s read.
 crawl() {
@@ -45,7 +34,7 @@ crawl() {
 # --- the injected command line ----------------------------------------------
 : >"$cmds"
 start=$SECONDS
-crawl "ftp://127.0.0.1:${port}/f%0d%0aDELE%20x.txt" >"${tmpdir}/log1" 2>&1 ||
+crawl "ftp://127.0.0.1:${FTP_PORT}/f%0d%0aDELE%20x.txt" >"${tmpdir}/log1" 2>&1 ||
     fail "the run did not finish in $((SECONDS - start))s"
 grep -aq 'Invalid control character in FTP URL' "${out}/hts-log.txt" ||
     fail "no refusal in the log: $(grep -a 'Error' "${out}/hts-log.txt" || true)"
@@ -57,12 +46,12 @@ ok "nothing reached the control channel"
 
 # --- a space in a listing argument ------------------------------------------
 : >"$cmds"
-crawl "ftp://127.0.0.1:${port}/d%20-la/" >"${tmpdir}/log2" 2>&1 ||
+crawl "ftp://127.0.0.1:${FTP_PORT}/d%20-la/" >"${tmpdir}/log2" 2>&1 ||
     fail "the listing crawl never finished"
 listcmd=$(grep -a '^LIST ' "$cmds" || true)
 test "$listcmd" = 'LIST -A "/d -la/"' ||
     fail "the listing path is not one quoted token: [${listcmd}]"
-grep -aq inside.txt "${out}/127.0.0.1_${port}/d -la/index.txt" ||
+grep -aq inside.txt "${out}/127.0.0.1_${FTP_PORT}/d -la/index.txt" ||
     fail "the quoted listing brought nothing back; mirror holds $(find "$out" \
         -type f -not -path '*hts-cache*')"
 ok "the listing path goes out as a single token, and still lists"

--- a/tests/230_local-ftp-userpass.test
+++ b/tests/230_local-ftp-userpass.test
@@ -9,17 +9,10 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-python=$(find_python) || skip "python3 not found"
 require_httrack
 
-server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpuser.XXXXXX")
-serverpid=
-cleanup() {
-    stop_server "$serverpid"
-    rm -rf "$tmpdir"
-}
-cleanup_push cleanup
+cleanup_push rm -rf "$tmpdir"
 
 root="${tmpdir}/root"
 out="${tmpdir}/crawl"
@@ -27,17 +20,13 @@ cmds="${tmpdir}/cmds"
 mkdir -p "$root" "$out"
 printf 'body\n' >"${root}/f.txt"
 
-serverlog="${tmpdir}/server.out"
-"$python" "$server" --root "$(nativepath "$root")" --require-pass \
-    --log "$(nativepath "$cmds")" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+ftp_server_start --root "$root" --require-pass --log "$(nativepath "$cmds")"
 
 crawl() {
     : >"$cmds"
     rm -rf "${out:?}"
     mkdir -p "$out"
-    run_with_timeout 60 httrack "ftp://$1@127.0.0.1:${port}/f.txt" -O "$out" \
+    run_with_timeout 60 httrack "ftp://$1@127.0.0.1:${FTP_PORT}/f.txt" -O "$out" \
         --quiet --disable-security-limits --robots=0 --timeout=20 \
         --max-time=45 --retries=1 -c1 >"${tmpdir}/log" 2>&1
 }
@@ -47,7 +36,7 @@ crawl "bob:secret" || fail "the plain-login crawl never finished"
 sent=$(<"$cmds")
 grep -qxF "USER bob" <<<"$sent" || fail "no USER bob on the wire: ${sent}"
 grep -qxF "PASS secret" <<<"$sent" || fail "no PASS secret on the wire: ${sent}"
-cmp -s "${out}/127.0.0.1_${port}/f.txt" "${root}/f.txt" ||
+cmp -s "${out}/127.0.0.1_${FTP_PORT}/f.txt" "${root}/f.txt" ||
     fail "the login did not bring the body back; mirror holds $(find "$out" -type f)"
 ok "bob:secret reaches the server verbatim, and mirrors"
 

--- a/tests/233_local-ftp-ctrl-timeout.test
+++ b/tests/233_local-ftp-ctrl-timeout.test
@@ -8,19 +8,10 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-python=$(find_python) || skip "python3 not found"
 require_httrack
 
-server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftptmo.XXXXXX")
-mutepid=
-livepid=
-cleanup() {
-    stop_server "$mutepid"
-    stop_server "$livepid"
-    rm -rf "$tmpdir"
-}
-cleanup_push cleanup
+cleanup_push rm -rf "$tmpdir"
 
 root="${tmpdir}/root"
 cmds="${tmpdir}/cmds"
@@ -34,17 +25,12 @@ awk 'BEGIN { s = sprintf("%0999d", 0); for (i = 0; i < 60; i++) print s }' \
     >"${root}/trick.bin"
 printf '/stall.bin stall\n/trick.bin trickle\n' >"${tmpdir}/modes"
 
-mutelog="${tmpdir}/mute.out"
-"$python" "$server" --root "$(nativepath "$root")" --mute >"$mutelog" 2>&1 &
-mutepid=$!
-muteport=$(discover_server_port "$mutelog" "$mutepid") || exit 1
+ftp_server_start --root "$root" --mute
+muteport=$FTP_PORT
 
-livelog="${tmpdir}/live.out"
-"$python" "$server" --root "$(nativepath "$root")" \
-    --mode-file "$(nativepath "${tmpdir}/modes")" \
-    --log "$(nativepath "$cmds")" >"$livelog" 2>&1 &
-livepid=$!
-liveport=$(discover_server_port "$livelog" "$livepid") || exit 1
+ftp_server_start --root "$root" --mode-file "$(nativepath "${tmpdir}/modes")" \
+    --log "$(nativepath "$cmds")"
+liveport=$FTP_PORT
 
 # No --max-time anywhere below, so --timeout is the only thing that can end a run.
 crawl() {

--- a/tests/234_local-ftp-maxtime.test
+++ b/tests/234_local-ftp-maxtime.test
@@ -8,17 +8,10 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-python=$(find_python) || skip "python3 not found"
 require_httrack
 
-server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpmax.XXXXXX")
-serverpid=
-cleanup() {
-    stop_server "$serverpid"
-    rm -rf "$tmpdir"
-}
-cleanup_push cleanup
+cleanup_push rm -rf "$tmpdir"
 
 root="${tmpdir}/root"
 out="${tmpdir}/crawl"
@@ -29,15 +22,11 @@ awk 'BEGIN { s = sprintf("%0999d", 0); for (i = 0; i < 100; i++) print s }' \
     >"${root}/f.bin"
 printf '* stall\n' >"${tmpdir}/modes"
 
-serverlog="${tmpdir}/server.out"
-"$python" "$server" --root "$(nativepath "$root")" \
-    --mode-file "$(nativepath "${tmpdir}/modes")" \
-    --log "$(nativepath "$cmds")" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+ftp_server_start --root "$root" --mode-file "$(nativepath "${tmpdir}/modes")" \
+    --log "$(nativepath "$cmds")"
 
 start=$SECONDS
-run_with_timeout 90 httrack "ftp://127.0.0.1:${port}/f.bin" -O "$out" --quiet \
+run_with_timeout 90 httrack "ftp://127.0.0.1:${FTP_PORT}/f.bin" -O "$out" --quiet \
     --disable-security-limits --robots=0 --timeout=200 --max-time=20 -c1 \
     >"${tmpdir}/log" 2>&1 || fail "the run did not finish in $((SECONDS - start))s"
 elapsed=$((SECONDS - start))

--- a/tests/236_local-ftp-teardown.test
+++ b/tests/236_local-ftp-teardown.test
@@ -11,14 +11,8 @@ set -euo pipefail
 python=$(find_python) || skip "python3 not found"
 require_httrack
 
-server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")
-serverpid=
-cleanup() {
-    stop_server "$serverpid"
-    rm -rf "$tmpdir"
-}
-cleanup_push cleanup
+cleanup_push rm -rf "$tmpdir"
 
 errlog="${tmpdir}/httrack.err"
 # A sanitized build reports the use-after-free and still exits 1, so the status
@@ -35,18 +29,14 @@ mkdir -p "$root"
 # Big enough that neither mode can finish before the cap trips.
 "$python" -c 'import sys; sys.stdout.buffer.write(b"F" * 4194304)' >"${root}/f.bin"
 
-serverlog="${tmpdir}/server.out"
-"$python" "$server" --root "$(nativepath "$root")" \
-    --mode-file "$(nativepath "$modes")" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+ftp_server_start --root "$root" --mode-file "$(nativepath "$modes")"
 
 CAP=100000
 
 # The cap must trip with the transfer still in flight, or nothing here is tested.
 assert_capped() {
     local out=$1 got
-    got=$(size_of "${out}/127.0.0.1_${port}/f.bin" 2>/dev/null || echo 0)
+    got=$(size_of "${out}/127.0.0.1_${FTP_PORT}/f.bin" 2>/dev/null || echo 0)
     test "$got" -ge "$CAP" ||
         fail "$2: only ${got} bytes arrived, the ${CAP}-byte cap never tripped"
 }
@@ -56,7 +46,7 @@ echo "* trickle" >"$modes"
 out="${tmpdir}/trickle"
 rc=0
 start=$SECONDS
-run_with_timeout 120 httrack "ftp://127.0.0.1:${port}/f.bin" -O "$out" --quiet \
+run_with_timeout 120 httrack "ftp://127.0.0.1:${FTP_PORT}/f.bin" -O "$out" --quiet \
     --disable-security-limits --robots=0 --timeout=200 -M"$CAP" -c1 2>"$errlog" || rc=$?
 elapsed=$((SECONDS - start))
 assert_clean_run "trickle"
@@ -77,7 +67,7 @@ echo "* stall" >"$modes"
 out="${tmpdir}/stall"
 rc=0
 start=$SECONDS
-run_with_timeout 120 httrack "ftp://127.0.0.1:${port}/f.bin" -O "$out" --quiet \
+run_with_timeout 120 httrack "ftp://127.0.0.1:${FTP_PORT}/f.bin" -O "$out" --quiet \
     --disable-security-limits --robots=0 --timeout=200 -M"$CAP" -c1 2>"$errlog" || rc=$?
 elapsed=$((SECONDS - start))
 assert_clean_run "stall"

--- a/tests/253_local-ftp-close-once.test
+++ b/tests/253_local-ftp-close-once.test
@@ -27,19 +27,11 @@ for lib in "${CLOSETRACK_LIB:-}" "${FTPCANCEL_LIB:-}"; do
     test -r "$lib" || fail "close-once: ${lib:-an interposer} was not built"
 done
 
-python=$(find_python) || skip "python3 not found"
 require_httrack
 
-server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpclose.XXXXXX")
-serverpid=
 crawlpid=
-cleanup() {
-    test -z "$crawlpid" || kill_tree "$crawlpid"
-    stop_server "$serverpid"
-    rm -rf "$tmpdir"
-}
-cleanup_push cleanup
+cleanup_push rm -rf "$tmpdir"
 
 root="${tmpdir}/root"
 out="${tmpdir}/crawl"
@@ -53,12 +45,11 @@ awk 'BEGIN { s = sprintf("%0999d", 0); for (i = 0; i < 100; i++) print s }' \
 # cancel lands.
 printf '* stall\n' >"${tmpdir}/modes"
 
-serverlog="${tmpdir}/server.out"
-"$python" "$server" --root "$(nativepath "$root")" \
-    --mode-file "$(nativepath "${tmpdir}/modes")" \
-    --log "$(nativepath "$cmds")" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+ftp_server_start --root "$root" --mode-file "$(nativepath "${tmpdir}/modes")" \
+    --log "$(nativepath "$cmds")"
+
+kill_crawl() { test -z "$crawlpid" || kill_tree "$crawlpid"; }
+cleanup_push kill_crawl
 
 # An LD_PRELOAD library loads ahead of the executable's own libasan, which ASan
 # refuses by default. The shims allocate nothing, so the ordering is harmless.
@@ -69,7 +60,7 @@ export ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}verify_asan_link_order=0"
 # polls for cancelled links, and the request would never be seen.
 export CLOSETRACK_LOG="$closes" FTPCANCEL_TRIGGER="$trigger"
 export LD_PRELOAD="$CLOSETRACK_LIB $FTPCANCEL_LIB"
-httrack "ftp://127.0.0.1:${port}/f.bin" -O "$out" --quiet \
+httrack "ftp://127.0.0.1:${FTP_PORT}/f.bin" -O "$out" --quiet \
     --disable-security-limits --robots=0 --timeout=0 --max-time=0 -c2 \
     >"${tmpdir}/log" 2>&1 &
 crawlpid=$!

--- a/tests/255_local-ftp-sigterm.test
+++ b/tests/255_local-ftp-sigterm.test
@@ -9,20 +9,12 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-python=$(find_python) || skip "python3 not found"
 skip_on_windows "MSYS cannot signal a native httrack.exe"
 require_httrack
 
-server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpterm.XXXXXX")
-serverpid=
 crawlpid=
-cleanup() {
-    test -z "$crawlpid" || kill_tree "$crawlpid"
-    stop_server "$serverpid"
-    rm -rf "$tmpdir"
-}
-cleanup_push cleanup
+cleanup_push rm -rf "$tmpdir"
 
 root="${tmpdir}/root"
 out="${tmpdir}/crawl"
@@ -39,18 +31,17 @@ head -c 102400 "${root}/big.bin" >"${root}/f.bin"
 # Three of them against two slots, for the all-slots-busy leg.
 for f in a b c; do cp "${root}/f.bin" "${root}/${f}.bin"; done
 
-serverlog="${tmpdir}/server.out"
-"$python" "$server" --root "$(nativepath "$root")" \
-    --mode-file "$(nativepath "$modes")" \
-    --log "$(nativepath "$cmds")" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+ftp_server_start --root "$root" --mode-file "$(nativepath "$modes")" \
+    --log "$(nativepath "$cmds")"
+
+kill_crawl() { test -z "$crawlpid" || kill_tree "$crawlpid"; }
+cleanup_push kill_crawl
 
 # $1 is a space-separated list of files to fetch; $name is the first of them.
 name=
 start_crawl() {
     local urls=() f
-    for f in $1; do urls+=("ftp://127.0.0.1:${port}/${f}"); done
+    for f in $1; do urls+=("ftp://127.0.0.1:${FTP_PORT}/${f}"); done
     name=${1%% *}
     shift
     : >"$cmds"
@@ -116,7 +107,7 @@ grep -q 'Exit requested by shell or user' <<<"$log" ||
     fail "the mirror did not end through the engine's exit path: ${log}"
 # And the abandoned link has to be reported as abandoned. Returning the
 # already-done code leaves the wait too, and drops it without a word.
-grep -q "at link ftp://127.0.0.1:${port}/big.bin" <<<"$log" ||
+grep -q "at link ftp://127.0.0.1:${FTP_PORT}/big.bin" <<<"$log" ||
     fail "the abandoned link went unreported: ${log}"
 ok "the exit unwound through teardown, keeping the mirror"
 
@@ -149,7 +140,7 @@ await_exit 120 "the interrupted crawl"
 # a signal that never arrived leaves a crawl that was going to finish anyway.
 grep -q 'Finishing pending transfers' "${tmpdir}/log" ||
     fail "the ^C never reached sig_leave: $(<"${tmpdir}/log")"
-cmp -s "${out}/127.0.0.1_${port}/f.bin" "${root}/f.bin" ||
+cmp -s "${out}/127.0.0.1_${FTP_PORT}/f.bin" "${root}/f.bin" ||
     fail "^C cut the transfer short; mirror holds $(find "$out" -type f)"
 ok "a single ^C let the in-flight transfer complete"
 
@@ -157,6 +148,6 @@ ok "a single ^C let the in-flight transfer complete"
 : >"$modes"
 start_crawl f.bin --timeout=30 --max-time=120 -c2
 await_exit 120 "the plain crawl"
-cmp -s "${out}/127.0.0.1_${port}/f.bin" "${root}/f.bin" ||
+cmp -s "${out}/127.0.0.1_${FTP_PORT}/f.bin" "${root}/f.bin" ||
     fail "the plain crawl did not mirror; it holds $(find "$out" -type f)"
 ok "an unsignalled crawl still mirrors normally"

--- a/tests/261_local-abort-purge.test
+++ b/tests/261_local-abort-purge.test
@@ -14,16 +14,9 @@ python=$(find_python) || skip "python3 not found"
 skip_on_windows "MSYS cannot signal a native httrack.exe"
 require_httrack
 
-server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_abortpurge.XXXXXX")
-serverpid=
 crawlpid=
-cleanup() {
-    test -z "$crawlpid" || kill_tree "$crawlpid"
-    stop_server "$serverpid"
-    rm -rf "$tmpdir"
-}
-cleanup_push cleanup
+cleanup_push rm -rf "$tmpdir"
 
 root="${tmpdir}/root"
 out="${tmpdir}/crawl"
@@ -49,19 +42,19 @@ sys.stdout.buffer.write((sys.argv[1] + "-" + sys.argv[2] + "-").encode() * 400)'
 write_bodies V1
 : >"$modes"
 
-serverlog="${tmpdir}/server.out"
-"$python" "$server" --root "$(nativepath "$root")" \
-    --mode-file "$(nativepath "$modes")" \
-    --log "$(nativepath "$cmds")" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
-host="127.0.0.1_${port}"
+ftp_server_start --root "$root" --mode-file "$(nativepath "$modes")" \
+    --log "$(nativepath "$cmds")"
+
+kill_crawl() { test -z "$crawlpid" || kill_tree "$crawlpid"; }
+cleanup_push kill_crawl
+
+host="127.0.0.1_${FTP_PORT}"
 
 urls=()
 urls_of() {
     local name
     urls=()
-    for name in "$@"; do urls+=("ftp://127.0.0.1:${port}/${name}.bin"); done
+    for name in "$@"; do urls+=("ftp://127.0.0.1:${FTP_PORT}/${name}.bin"); done
 }
 # -c1: a parallel FTP crawl loses whole transfers to an older backlog bug (#797),
 # and one socket also pins the order in which the links are reached.

--- a/tests/263_local-ftp-stop-window.test
+++ b/tests/263_local-ftp-stop-window.test
@@ -10,7 +10,6 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-python=$(find_python) || skip "python3 not found"
 skip_on_windows "MSYS cannot signal a native httrack.exe"
 require_httrack
 
@@ -18,16 +17,9 @@ require_httrack
 # short enough to keep the test under half a minute.
 TIMEOUT=8
 
-server=$(nativepath "${testdir}/ftp-server.py")
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpstop.XXXXXX")
-serverpid=
 crawlpid=
-cleanup() {
-    test -z "$crawlpid" || kill_tree "$crawlpid"
-    stop_server "$serverpid"
-    rm -rf "$tmpdir"
-}
-cleanup_push cleanup
+cleanup_push rm -rf "$tmpdir"
 
 root="${tmpdir}/root"
 out="${tmpdir}/crawl"
@@ -40,18 +32,17 @@ awk 'BEGIN { s = sprintf("%0999d", 0); for (i = 0; i < 800; i++) print s }' \
     >"${root}/big.bin"
 printf '* stall\n' >"$modes"
 
-serverlog="${tmpdir}/server.out"
-"$python" "$server" --root "$(nativepath "$root")" \
-    --mode-file "$(nativepath "$modes")" \
-    --log "$(nativepath "$cmds")" >"$serverlog" 2>&1 &
-serverpid=$!
-port=$(discover_server_port "$serverlog" "$serverpid") || exit 1
+ftp_server_start --root "$root" --mode-file "$(nativepath "$modes")" \
+    --log "$(nativepath "$cmds")"
+
+kill_crawl() { test -z "$crawlpid" || kill_tree "$crawlpid"; }
+cleanup_push kill_crawl
 
 start_crawl() {
     : >"$cmds"
     rm -rf "${out:?}"
     mkdir -p "$out"
-    httrack "ftp://127.0.0.1:${port}/big.bin" -O "$out" --quiet \
+    httrack "ftp://127.0.0.1:${FTP_PORT}/big.bin" -O "$out" --quiet \
         --disable-security-limits --robots=0 --retries=0 \
         --timeout="$TIMEOUT" --max-time=0 >"${tmpdir}/log" 2>&1 &
     crawlpid=$!

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -582,29 +582,6 @@ start_proxytrack() { # start_proxytrack LOGBASE LAUNCH
 # the line. A full minute of wall clock: a cold Python start under a parallel
 # `make check -jN` lags well past a second, 5s had macos-15 missing it on 15 tests,
 # and the count-of-ticks loop this replaced self-extended under load instead.
-# Start ftp-server.py: sets FTP_PORT, FTP_PID and FTP_LOG. --root resolves for
-# the host, other arguments pass through, stdin off the terminal as in
-# local_server_start.
-ftp_server_start() { # ftp_server_start [--root DIR] [SERVER-ARGS...]
-    local root=''
-    if test "${1:-}" = --root; then
-        root=$2
-        shift 2
-    fi
-    test -n "${FTP_PYTHON:-}" || FTP_PYTHON=$(find_python) || skip "python3 not found"
-    # Numbered: a second server here would truncate the first's log and the port
-    # it reported. No --log option, the name colliding with ftp-server.py's own.
-    FTP_N=$((${FTP_N:-0} + 1))
-    FTP_LOG="${tmpdir:?no tmpdir set before ftp_server_start}/ftp-server.${FTP_N}.out"
-    : >"$FTP_LOG"
-    "$FTP_PYTHON" "$(nativepath "${testdir}/ftp-server.py")" \
-        ${root:+--root "$(nativepath "$root")"} "$@" >"$FTP_LOG" 2>&1 </dev/null &
-    FTP_PID=$!
-    cleanup_push stop_server "$FTP_PID"
-    FTP_PORT=$(discover_server_port "$FTP_LOG" "$FTP_PID") ||
-        fail "ftp-server did not come up: $(<"$FTP_LOG")"
-}
-
 discover_server_port() {
     local log=$1 pid=$2 line start=$SECONDS
     while :; do
@@ -627,6 +604,38 @@ discover_server_port() {
     done
     echo "could not discover server port: $(cat "$log" 2>/dev/null)" >&2
     return 1
+}
+
+# Start ftp-server.py: sets FTP_PORT, FTP_PID and FTP_LOG. --root resolves for
+# the host, other arguments pass through, stdin off the terminal as in
+# local_server_start.
+ftp_server_start() { # ftp_server_start [--root DIR] [SERVER-ARGS...]
+    local root='' args=()
+    while test $# -gt 0; do
+        case $1 in
+        --root)
+            root=$2
+            shift 2
+            ;;
+        *)
+            args+=("$1")
+            shift
+            ;;
+        esac
+    done
+    test -n "${FTP_PYTHON:-}" || FTP_PYTHON=$(find_python) || skip "python3 not found"
+    # Numbered: a second server here would truncate the first's log and the port
+    # it reported. No --log option, the name colliding with ftp-server.py's own.
+    FTP_N=$((${FTP_N:-0} + 1))
+    FTP_LOG="${tmpdir:?no tmpdir set before ftp_server_start}/ftp-server.${FTP_N}.out"
+    : >"$FTP_LOG"
+    "$FTP_PYTHON" "$(nativepath "${testdir}/ftp-server.py")" \
+        ${root:+--root "$(nativepath "$root")"} ${args[@]+"${args[@]}"} \
+        >"$FTP_LOG" 2>&1 </dev/null &
+    FTP_PID=$!
+    cleanup_push stop_server "$FTP_PID"
+    FTP_PORT=$(discover_server_port "$FTP_LOG" "$FTP_PID") ||
+        fail "ftp-server did not come up: $(<"$FTP_LOG")"
 }
 
 # Dump and clear the crawl logs a hard-killed test leaves in TMPDIR (its cleanup

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -582,6 +582,31 @@ start_proxytrack() { # start_proxytrack LOGBASE LAUNCH
 # the line. A full minute of wall clock: a cold Python start under a parallel
 # `make check -jN` lags well past a second, 5s had macos-15 missing it on 15 tests,
 # and the count-of-ticks loop this replaced self-extended under load instead.
+# Start ftp-server.py, setting FTP_PORT, FTP_PID and FTP_LOG. --root is resolved
+# for the host; every later argument reaches the server verbatim. Stdin off the
+# terminal: run_with_timeout toggles job control, and a background job that
+# touches the tty is stopped with SIGTTIN.
+ftp_server_start() { # ftp_server_start [--root DIR] [SERVER-ARGS...]
+    local root=''
+    if test "${1:-}" = --root; then
+        root=$2
+        shift 2
+    fi
+    test -n "${FTP_PYTHON:-}" || FTP_PYTHON=$(find_python) || skip "python3 not found"
+    # Numbered, so a test starting a second server does not truncate the first's
+    # log and with it the port it announced. No --log option: ftp-server.py has
+    # one of its own, and two meanings for one name is how 233 nearly broke.
+    FTP_N=$((${FTP_N:-0} + 1))
+    FTP_LOG="${tmpdir:?no tmpdir set before ftp_server_start}/ftp-server.${FTP_N}.out"
+    : >"$FTP_LOG"
+    "$FTP_PYTHON" "$(nativepath "${testdir}/ftp-server.py")" \
+        ${root:+--root "$(nativepath "$root")"} "$@" >"$FTP_LOG" 2>&1 </dev/null &
+    FTP_PID=$!
+    cleanup_push stop_server "$FTP_PID"
+    FTP_PORT=$(discover_server_port "$FTP_LOG" "$FTP_PID") ||
+        fail "ftp-server did not come up: $(<"$FTP_LOG")"
+}
+
 discover_server_port() {
     local log=$1 pid=$2 line start=$SECONDS
     while :; do

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -582,10 +582,9 @@ start_proxytrack() { # start_proxytrack LOGBASE LAUNCH
 # the line. A full minute of wall clock: a cold Python start under a parallel
 # `make check -jN` lags well past a second, 5s had macos-15 missing it on 15 tests,
 # and the count-of-ticks loop this replaced self-extended under load instead.
-# Start ftp-server.py, setting FTP_PORT, FTP_PID and FTP_LOG. --root is resolved
-# for the host; every later argument reaches the server verbatim. Stdin off the
-# terminal: run_with_timeout toggles job control, and a background job that
-# touches the tty is stopped with SIGTTIN.
+# Start ftp-server.py: sets FTP_PORT, FTP_PID and FTP_LOG. --root resolves for
+# the host, other arguments pass through, stdin off the terminal as in
+# local_server_start.
 ftp_server_start() { # ftp_server_start [--root DIR] [SERVER-ARGS...]
     local root=''
     if test "${1:-}" = --root; then
@@ -593,9 +592,8 @@ ftp_server_start() { # ftp_server_start [--root DIR] [SERVER-ARGS...]
         shift 2
     fi
     test -n "${FTP_PYTHON:-}" || FTP_PYTHON=$(find_python) || skip "python3 not found"
-    # Numbered, so a test starting a second server does not truncate the first's
-    # log and with it the port it announced. No --log option: ftp-server.py has
-    # one of its own, and two meanings for one name is how 233 nearly broke.
+    # Numbered: a second server here would truncate the first's log and the port
+    # it reported. No --log option, the name colliding with ftp-server.py's own.
     FTP_N=$((${FTP_N:-0} + 1))
     FTP_LOG="${tmpdir:?no tmpdir set before ftp_server_start}/ftp-server.${FTP_N}.out"
     : >"$FTP_LOG"


### PR DESCRIPTION
Thirteen FTP tests each spelled out the same launch: resolve `ftp-server.py`, start it in the background, capture the pid, discover the port it announces, and tear it all down through a `cleanup()` that also removed the temp dir. `ftp_server_start` does that now, setting `FTP_PORT`, `FTP_PID` and `FTP_LOG`, mirroring the `local_server_start` the HTTP tests already use.

Two things every hand-rolled copy got wrong. None redirected the server's stdin from `/dev/null`, which `local_server_start` does and explains: `run_with_timeout` toggles job control, and a background job that touches the tty is stopped with SIGTTIN. And each held its server pid in a variable that teardown read later, where `cleanup_push` captures it at push time.

The log file is numbered per server rather than fixed. `233` starts two, and one name would have let the second truncate the first's log, and with it the port the first had announced. The helper deliberately has no `--log` option: `ftp-server.py` has one of its own and `233` passes it, so a helper option of the same name would be two meanings for one word, disambiguated only by argument order.

Verified beyond a green suite. The temp-dir check was vacuous at first, because the harness gives each test its own `TMPDIR` and removes it regardless; re-run with `TMPDIR=/tmp` so only the test's own teardown can clean up, all 13 leave nothing behind, and a mid-run check confirms the counter can see a leak when there is one. A mutant adding 1 to `FTP_PORT` reds four of the tests. Full suite green at 348 pass, 12 skip.