### PR TITLE
Name what grep -c returns, and the dialect, at every site that reads it

### DIFF
--- a/tests/01_engine-doitlog.test
+++ b/tests/01_engine-doitlog.test
@@ -34,7 +34,7 @@ echo '<p>bbb</p>' >"$site/sub/b.html"
 url="file://$site/index.html"
 
 # count Error: lines in the log (grep -c exits 1 on zero matches: guard it)
-errors() { grep -ciE '^[0-9:]*[[:space:]]Error:' "$out/hts-log.txt" || true; }
+errors() { count_matching_lines -iE '^[0-9:]*[[:space:]]Error:' "$out/hts-log.txt"; }
 
 # initial mirror with the url and a handful of options, so doit.log records a
 # multi-token command line for cmdl_ins to re-insert one token at a time.

--- a/tests/01_engine-doitlog.test
+++ b/tests/01_engine-doitlog.test
@@ -34,7 +34,7 @@ echo '<p>bbb</p>' >"$site/sub/b.html"
 url="file://$site/index.html"
 
 # count Error: lines in the log
-errors() { count_matching_lines -iE '^[0-9:]*[[:space:]]Error:' "$out/hts-log.txt"; }
+errors() { count_log_errors "$out/hts-log.txt"; }
 
 # initial mirror with the url and a handful of options, so doit.log records a
 # multi-token command line for cmdl_ins to re-insert one token at a time.

--- a/tests/01_engine-doitlog.test
+++ b/tests/01_engine-doitlog.test
@@ -33,7 +33,7 @@ echo 'OLDCONTENT' >"$site/a.html"
 echo '<p>bbb</p>' >"$site/sub/b.html"
 url="file://$site/index.html"
 
-# count Error: lines in the log (grep -c exits 1 on zero matches: guard it)
+# count Error: lines in the log
 errors() { count_matching_lines -iE '^[0-9:]*[[:space:]]Error:' "$out/hts-log.txt"; }
 
 # initial mirror with the url and a handful of options, so doit.log records a

--- a/tests/02_update-cache.test
+++ b/tests/02_update-cache.test
@@ -28,7 +28,7 @@ echo '<p>bbb</p>' >"$site/sub/b.html"
 url="file://$site/index.html"
 
 # count Error: lines in the log (grep -c exits 1 on zero matches: guard it)
-errors() { grep -ciE '^[0-9:]*[[:space:]]Error:' "$out/hts-log.txt" || true; }
+errors() { count_matching_lines -iE '^[0-9:]*[[:space:]]Error:' "$out/hts-log.txt"; }
 
 # 1. fresh mirror writes the cache
 httrack "$url" -O "$out" -q -%v0 -r3 >/dev/null 2>&1

--- a/tests/02_update-cache.test
+++ b/tests/02_update-cache.test
@@ -27,7 +27,7 @@ echo '<p>bbb</p>' >"$site/sub/b.html"
 
 url="file://$site/index.html"
 
-# count Error: lines in the log (grep -c exits 1 on zero matches: guard it)
+# count Error: lines in the log
 errors() { count_matching_lines -iE '^[0-9:]*[[:space:]]Error:' "$out/hts-log.txt"; }
 
 # 1. fresh mirror writes the cache

--- a/tests/02_update-cache.test
+++ b/tests/02_update-cache.test
@@ -28,7 +28,7 @@ echo '<p>bbb</p>' >"$site/sub/b.html"
 url="file://$site/index.html"
 
 # count Error: lines in the log
-errors() { count_matching_lines -iE '^[0-9:]*[[:space:]]Error:' "$out/hts-log.txt"; }
+errors() { count_log_errors "$out/hts-log.txt"; }
 
 # 1. fresh mirror writes the cache
 httrack "$url" -O "$out" -q -%v0 -r3 >/dev/null 2>&1

--- a/tests/110_local-ftp-parallel.test
+++ b/tests/110_local-ftp-parallel.test
@@ -46,7 +46,7 @@ run_with_timeout 300 httrack "${urls[@]}" -O "$out" --quiet -Z -c8 \
     --disable-security-limits --robots=0 --timeout=20 --max-time=120 --retries=1 \
     >"${tmpdir}/log" 2>&1
 
-swapped=$(grep -ac 'slots ready moved to background' "${out}/hts-log.txt" || true)
+swapped=$(count_matching_lines -a 'slots ready moved to background' "${out}/hts-log.txt")
 test "${swapped:-0}" -gt 0 ||
     fail "no ready slot was swapped to disk; this run never reached the bug"
 ok "the crawl swapped ready slots to the on-disk table ${swapped} times"

--- a/tests/110_local-ftp-parallel.test
+++ b/tests/110_local-ftp-parallel.test
@@ -46,7 +46,7 @@ run_with_timeout 300 httrack "${urls[@]}" -O "$out" --quiet -Z -c8 \
     --disable-security-limits --robots=0 --timeout=20 --max-time=120 --retries=1 \
     >"${tmpdir}/log" 2>&1
 
-swapped=$(count_matching_lines -a 'slots ready moved to background' "${out}/hts-log.txt")
+swapped=$(count_matching_lines 'slots ready moved to background' "${out}/hts-log.txt")
 test "${swapped:-0}" -gt 0 ||
     fail "no ready slot was swapped to disk; this run never reached the bug"
 ok "the crawl swapped ready slots to the on-disk table ${swapped} times"

--- a/tests/120_local-proxytrack-webdav-default.test
+++ b/tests/120_local-proxytrack-webdav-default.test
@@ -128,7 +128,7 @@ grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
 # PROPFIND is logged 403 without ever reaching the traces. It is logged after
 # them, so waiting on it also fences the drainer's copy.
 waited=0
-until test "$(count_matching_lines -i ' \* log: HTTP [^ ]* 207 [0-9]* propfind ' "$ptlog")" -ge 3; do
+until test "$(count_matching_lines_nocase ' \* log: HTTP [^ ]* 207 [0-9]* propfind ' "$ptlog")" -ge 3; do
     test "$waited" -lt 50 || {
         echo "FAIL: fewer than three PROPFINDs were answered 207, so the checks below prove nothing"
         cat "$ptlog"

--- a/tests/120_local-proxytrack-webdav-default.test
+++ b/tests/120_local-proxytrack-webdav-default.test
@@ -90,7 +90,7 @@ grep -q '<href>/webdav/example\.com/page\.html/</href>' <<<"$resp" || {
     printf '%s\n' "$resp"
     exit 1
 }
-responses=$(grep -c '<response ' <<<"$resp" || true)
+responses=$(count_matching_lines '<response ' <<<"$resp")
 test "$responses" -eq 2 || {
     echo "FAIL: expected the root and its default document, got $responses responses"
     printf '%s\n' "$resp"
@@ -128,7 +128,7 @@ grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
 # PROPFIND is logged 403 without ever reaching the traces. It is logged after
 # them, so waiting on it also fences the drainer's copy.
 waited=0
-until test "$(grep -ci ' \* log: HTTP [^ ]* 207 [0-9]* propfind ' "$ptlog" || true)" -ge 3; do
+until test "$(count_matching_lines -i ' \* log: HTTP [^ ]* 207 [0-9]* propfind ' "$ptlog")" -ge 3; do
     test "$waited" -lt 50 || {
         echo "FAIL: fewer than three PROPFINDs were answered 207, so the checks below prove nothing"
         cat "$ptlog"

--- a/tests/138_local-spool-name-overflow.test
+++ b/tests/138_local-spool-name-overflow.test
@@ -29,9 +29,9 @@ test "$rc" -eq 0 || {
 
 enginelog="${tmpdir}/out/hts-log.txt"
 test -r "$enginelog" || fail "no engine log at $enginelog"
-moved=$(grep -c 'slots ready moved to background' "$enginelog" || true)
+moved=$(count_matching_lines 'slots ready moved to background' "$enginelog")
 test "$moved" -gt 0 || fail "no slot was ever spooled, so the name was never built"
-serr=$(grep -c 'serialize error' "$enginelog" || true)
+serr=$(count_matching_lines 'serialize error' "$enginelog")
 test "$serr" -eq 0 || {
     echo "the spool refused to write:"
     grep 'serialize error' "$enginelog"

--- a/tests/147_local-proxytrack-webdav-overflow.test
+++ b/tests/147_local-proxytrack-webdav-overflow.test
@@ -96,7 +96,7 @@ for want in '<href>/webdav/example\.com</href>' \
         exit 1
     }
 done
-responses=$(grep -c '<response ' <<<"$resp" || true)
+responses=$(count_matching_lines '<response ' <<<"$resp")
 test "$responses" -eq 3 || {
     echo "FAIL: expected the root, the file and the directory, got $responses responses"
     printf '%s\n' "$resp"

--- a/tests/153_local-proxytrack-quiet.test
+++ b/tests/153_local-proxytrack-quiet.test
@@ -109,7 +109,7 @@ resp=$(curl -s -i --max-time 30 -X PROPFIND -H "Depth: 1" \
     cat "$quietlog"
     exit 1
 }
-served=$(grep -c '^HTTP/1\.[01] 207 ' <<<"$resp" || true)
+served=$(count_matching_lines '^HTTP/1\.[01] 207 ' <<<"$resp")
 test "$served" -eq 2 || {
     echo "FAIL: expected two 207 Multi-Status replies, got $served"
     printf '%s\n' "$resp"
@@ -117,7 +117,7 @@ test "$served" -eq 2 || {
 }
 # The collection and its entry, then that entry and its default document. An
 # empty listing builds no table and would make the check below vacuous.
-listed=$(grep -c '<response ' <<<"$resp" || true)
+listed=$(count_matching_lines '<response ' <<<"$resp")
 test "$listed" -eq 4 || {
     echo "FAIL: the two listings enumerated $listed entries, wanted 4"
     printf '%s\n' "$resp"

--- a/tests/158_local-link-control-bytes.test
+++ b/tests/158_local-link-control-bytes.test
@@ -96,7 +96,7 @@ httrack "http://127.0.0.1:${SRV_PORT}/index.html" -O "$out" -q -r3 -%v0 ||
     fail "the query crawl did not run"
 # A clipped link went out as a 2 KB request and 404ed, so assert the outcome
 # and not just the refusal: nothing oversized asked for, nothing errored.
-errors=$(grep -acE '^[0-9:]*[[:space:]]Error:' "${out}/hts-log.txt" || true)
+errors=$(count_matching_lines -aE '^[0-9:]*[[:space:]]Error:' "${out}/hts-log.txt")
 test "$errors" -eq 0 || fail "the oversized query was fetched ($errors errors)"
 longest=$(awk '{ if (length($0) > n) n = length($0) } END { print n + 0 }' \
     "$SRV_LOG")

--- a/tests/158_local-link-control-bytes.test
+++ b/tests/158_local-link-control-bytes.test
@@ -96,7 +96,7 @@ httrack "http://127.0.0.1:${SRV_PORT}/index.html" -O "$out" -q -r3 -%v0 ||
     fail "the query crawl did not run"
 # A clipped link went out as a 2 KB request and 404ed, so assert the outcome
 # and not just the refusal: nothing oversized asked for, nothing errored.
-errors=$(count_matching_lines -aE '^[0-9:]*[[:space:]]Error:' "${out}/hts-log.txt")
+errors=$(count_log_errors "${out}/hts-log.txt")
 test "$errors" -eq 0 || fail "the oversized query was fetched ($errors errors)"
 longest=$(awk '{ if (length($0) > n) n = length($0) } END { print n + 0 }' \
     "$SRV_LOG")

--- a/tests/180_crash-stack-overflow.test
+++ b/tests/180_crash-stack-overflow.test
@@ -54,7 +54,7 @@ deepest_repeat() {
 
 # Raw frames in the report: backtrace_symbols_fd() closes every one with [0xADDR].
 frame_count() {
-    grep -c '\[0x' <<<"$1" || true
+    count_matching_lines '\[0x' <<<"$1"
 }
 
 # Control: an ordinary SIGSEGV was already reported before the fix, so a build

--- a/tests/183_altstack-worker.test
+++ b/tests/183_altstack-worker.test
@@ -38,7 +38,7 @@ crash_report() {
 # Frames the raw trace printed. A runaway recursion fills backtrace()'s buffer;
 # an ordinary fault is a dozen deep. Measured: 256 against 11.
 frame_count() {
-    grep -cE '\[0x[0-9a-f]+\]$' <<<"$1" || true
+    count_matching_lines -E '\[0x[0-9a-f]+\]$' <<<"$1"
 }
 
 # Control: an ordinary fault was already reported before the fix, so a build or

--- a/tests/183_altstack-worker.test
+++ b/tests/183_altstack-worker.test
@@ -38,7 +38,7 @@ crash_report() {
 # Frames the raw trace printed. A runaway recursion fills backtrace()'s buffer;
 # an ordinary fault is a dozen deep. Measured: 256 against 11.
 frame_count() {
-    count_matching_lines -E '\[0x[0-9a-f]+\]$' <<<"$1"
+    count_matching_lines_regexp '\[0x[0-9a-f]+\]$' <<<"$1"
 }
 
 # Control: an ordinary fault was already reported before the fix, so a build or

--- a/tests/19_local-connect-fallback.test
+++ b/tests/19_local-connect-fallback.test
@@ -53,7 +53,7 @@ if ! grep -q "trying next address" "$log"; then
 fi
 
 # 0 errors and the file was actually fetched (over the live address)
-errs=$(count_matching_lines -iE "^[0-9:]*[[:space:]]Error:" "$log")
+errs=$(count_log_errors "$log")
 test "$errs" == "0" || {
     echo "FAIL: $errs error(s) reported"
     grep -iE "Error:" "$log"

--- a/tests/19_local-connect-fallback.test
+++ b/tests/19_local-connect-fallback.test
@@ -53,7 +53,7 @@ if ! grep -q "trying next address" "$log"; then
 fi
 
 # 0 errors and the file was actually fetched (over the live address)
-errs=$(grep -iEc "^[0-9:]*[[:space:]]Error:" "$log" || true)
+errs=$(count_matching_lines -iE "^[0-9:]*[[:space:]]Error:" "$log")
 test "$errs" == "0" || {
     echo "FAIL: $errs error(s) reported"
     grep -iE "Error:" "$log"

--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -528,7 +528,7 @@ cadence_leg() {
         return 1
     }
     sink_stop
-    n=$(grep -c . "$posts" || true)
+    n=$(count_matching_lines . "$posts")
     test "$n" -eq 1 || {
         echo "$n API calls at a 100s cadence over 4s, want 1"
         return 1
@@ -601,8 +601,8 @@ throttle_leg() {
         return 1
     }
     sink_stop
-    calls=$(grep -c . "$posts" || true)
-    lines=$(grep -c 't=[0-9]*s q=' "$legout" || true)
+    calls=$(count_matching_lines . "$posts")
+    lines=$(count_matching_lines 't=[0-9]*s q=' "$legout")
     test "$lines" -ge 3 || {
         echo "$lines due ticks over 8s at a 1s interval: too few to judge a throttle"
         return 1
@@ -624,8 +624,8 @@ backoff_leg() {
         return 1
     }
     sink_stop
-    calls=$(grep -c . "$posts" || true)
-    lines=$(grep -c 't=[0-9]*s q=' "$legout" || true)
+    calls=$(count_matching_lines . "$posts")
+    lines=$(count_matching_lines 't=[0-9]*s q=' "$legout")
     test "$calls" -ge 2 || {
         echo "a rejecting API was called $calls times: the loop stopped trying"
         return 1
@@ -651,7 +651,7 @@ fullstdout_leg() {
     run_posting 60 -File "$1" -ProgressLog "$(nativepath "$tmp/progress.log")" \
         -IntervalSeconds 1 -PollSeconds 1 -MaxSeconds 5 >/dev/full 2>&1 || true
     sink_stop
-    n=$(grep -c . "$posts" || true)
+    n=$(count_matching_lines . "$posts")
     test "$n" -ge 2 || {
         echo "$n posts with a full stdout: a failed log write took the loop with it"
         return 1
@@ -719,7 +719,7 @@ for psrun in "${psruns[@]}"; do
         -ProgressLog "$(nativepath "$tmp/progress.log")" \
         -IntervalSeconds 100 -PollSeconds 1 -MaxSeconds 5) ||
         fail "the $psrun slow-cadence loop exited nonzero: $out"
-    slow=$(grep -c 't=[0-9]*s q=' <<<"$out" || true)
+    slow=$(count_matching_lines 't=[0-9]*s q=' <<<"$out")
     test "$slow" -eq 1 || fail "$slow status lines at a 100s cadence over 5s, want 1: $out"
 
     began=$SECONDS
@@ -730,7 +730,7 @@ for psrun in "${psruns[@]}"; do
     spent=$((SECONDS - began))
     test "$spent" -ge 4 || fail "a 5s watchdog returned after ${spent}s: MaxSeconds is not seconds"
     test "$spent" -le 20 || fail "a 5s watchdog ran ${spent}s: it does not stop on its own"
-    fast=$(grep -c 't=[0-9]*s q=' <<<"$out" || true)
+    fast=$(count_matching_lines 't=[0-9]*s q=' <<<"$out")
     # Against the slow leg, not a floor: a probe tick is not instant.
     test "$fast" -gt "$slow" || fail "$fast status lines at 1s against $slow at 100s: $out"
     grep -q '36_local-bigcrawl.test' <<<"$out" || fail "the status does not name the test in flight: $out"

--- a/tests/235_local-resume-recovery.test
+++ b/tests/235_local-resume-recovery.test
@@ -110,7 +110,7 @@ run_with_timeout 120 httrack -O "$out" --quiet --disable-security-limits \
     "${BASEURL}/resume206loop/index.html" >"${out}.log2" 2>&1 || rc=$?
 test "$rc" -ne 124 || fail "the crawl never terminated; the restart is unbounded"
 grep -q 'Unusable partial-content range' <"${out}/hts-log.txt" || fail "the resume was never rejected; the latch was not exercised"
-restarts=$(grep -c 'Restarting whole file' <"${out}/hts-log.txt" || true)
+restarts=$(count_matching_lines 'Restarting whole file' <"${out}/hts-log.txt")
 test "$restarts" -eq 1 || fail "${restarts} free restarts, expected exactly 1 (latch)"
 echo "OK (1 free restart, then bounded)"
 
@@ -130,9 +130,9 @@ test "$rc" -ne 124 || fail "the crawl never terminated; the alias hop reset the 
 log="${out}/hts-log.txt"
 # Without the hop the alternation was never driven and the rest proves nothing.
 grep -q 'Warning moved treated' <"$log" || fail "no alias hop; the re-record path was never reached"
-restarts=$(grep -c 'Restarting whole file' <"$log" || true)
+restarts=$(count_matching_lines 'Restarting whole file' <"$log")
 test "$restarts" -eq 1 || fail "${restarts} free restarts across the alias hops, expected 1"
-retries=$(grep -c 'Retry after error' <"$log" || true)
+retries=$(count_matching_lines 'Retry after error' <"$log")
 test "$retries" -eq 1 || fail "${retries} retries, expected 1; the free restart spent the budget"
 echo "OK (1 free restart, budget intact)"
 
@@ -178,7 +178,7 @@ test "$rc" -ne 124 || fail "the crawl never terminated"
 # The shim silently matching nothing would make this leg a copy of test 48.
 seen=$(wc -l <"$attempts")
 test "$seen" -ge 1 || fail "the interposer saw no unlink of the partial; it never fired"
-held=$(grep -c '^open ' <"$attempts" || true)
+held=$(count_matching_lines '^open ' <"$attempts")
 test "$held" -eq 0 || fail "${held} of ${seen} unlink(s) came while the handle was open"
 got=$(blob_size "$out")
 test "$got" -eq "$crange_full" || fail "blob.bin is ${got} bytes, expected ${crange_full} (refetch lost)"

--- a/tests/244_local-tty-output.test
+++ b/tests/244_local-tty-output.test
@@ -44,7 +44,7 @@ crawl_tty() {
 
 # count <label> <ERE>
 count() {
-    LC_ALL=C grep -ac "$2" "${tmpdir}/out_$1" || true
+    LC_ALL=C count_matching_lines -a "$2" "${tmpdir}/out_$1"
 }
 
 # expect <description> <actual> <op> <bound> <label>

--- a/tests/244_local-tty-output.test
+++ b/tests/244_local-tty-output.test
@@ -44,7 +44,7 @@ crawl_tty() {
 
 # count <label> <ERE>
 count() {
-    LC_ALL=C count_matching_lines -a "$2" "${tmpdir}/out_$1"
+    LC_ALL=C count_matching_lines "$2" "${tmpdir}/out_$1"
 }
 
 # expect <description> <actual> <op> <bound> <label>

--- a/tests/247_cli-stdin-eof.test
+++ b/tests/247_cli-stdin-eof.test
@@ -38,7 +38,7 @@ crawl() {
 
 # count <label> <ERE>
 count() {
-    LC_ALL=C grep -ac "$2" "${tmpdir}/out_$1" || true
+    LC_ALL=C count_matching_lines -a "$2" "${tmpdir}/out_$1"
 }
 
 # expect <description> <actual> <op> <bound> <label>

--- a/tests/247_cli-stdin-eof.test
+++ b/tests/247_cli-stdin-eof.test
@@ -38,7 +38,7 @@ crawl() {
 
 # count <label> <ERE>
 count() {
-    LC_ALL=C count_matching_lines -a "$2" "${tmpdir}/out_$1"
+    LC_ALL=C count_matching_lines "$2" "${tmpdir}/out_$1"
 }
 
 # expect <description> <actual> <op> <bound> <label>

--- a/tests/253_local-ftp-close-once.test
+++ b/tests/253_local-ftp-close-once.test
@@ -91,7 +91,7 @@ grep -aq 'Cancelled by User' "${out}/hts-log.txt" ||
 test -s "$closes" || fail "the interposer logged no close() at all"
 ok "the cancel landed on an in-flight transfer ($(wc -l <"$closes") closes seen)"
 
-badf=$(grep -c ' EBADF$' "$closes" || true)
+badf=$(count_matching_lines ' EBADF$' "$closes")
 test "$badf" -eq 0 ||
     fail "$badf close() calls hit a stale descriptor: $(tr '\n' ' ' <"$closes")"
 ok "every descriptor was closed once"

--- a/tests/255_local-ftp-sigterm.test
+++ b/tests/255_local-ftp-sigterm.test
@@ -116,7 +116,7 @@ ok "the exit unwound through teardown, keeping the mirror"
 # in the wait for a free socket, which the leg above never enters.
 start_crawl "a.bin b.bin c.bin" --timeout=0 --max-time=0 -c2
 deadline=$((SECONDS + 60))
-until test "$(count_matching_lines -a '^RETR ' "$cmds" 2>/dev/null)" -ge 2; do
+until test "$(count_matching_lines '^RETR ' "$cmds" 2>/dev/null)" -ge 2; do
     test "$SECONDS" -lt "$deadline" || fail "the crawl never filled both sockets"
     poll_wait 1
 done

--- a/tests/255_local-ftp-sigterm.test
+++ b/tests/255_local-ftp-sigterm.test
@@ -116,7 +116,7 @@ ok "the exit unwound through teardown, keeping the mirror"
 # in the wait for a free socket, which the leg above never enters.
 start_crawl "a.bin b.bin c.bin" --timeout=0 --max-time=0 -c2
 deadline=$((SECONDS + 60))
-until test "$(grep -ac '^RETR ' "$cmds" 2>/dev/null || true)" -ge 2; do
+until test "$(count_matching_lines -a '^RETR ' "$cmds" 2>/dev/null)" -ge 2; do
     test "$SECONDS" -lt "$deadline" || fail "the crawl never filled both sockets"
     poll_wait 1
 done

--- a/tests/262_local-signal-receive.test
+++ b/tests/262_local-signal-receive.test
@@ -49,14 +49,14 @@ await_exit() {
 # Wait until the server has logged $2 requests matching $1.
 await_requests() {
     local pattern=$1 count=$2 deadline=$((SECONDS + 60))
-    until test "$(grep -ac "$pattern" "$SRV_LOG" || true)" -ge "$count"; do
+    until test "$(count_matching_lines -a "$pattern" "$SRV_LOG")" -ge "$count"; do
         test "$SECONDS" -lt "$deadline" || fail "the crawl never fetched $pattern"
         poll_wait 1
     done
 }
 
 # How many of the eight bodies the server has been asked for so far.
-bodies_requested() { grep -ac 'GET /dcancel/p' "$SRV_LOG" || true; }
+bodies_requested() { count_matching_lines -a 'GET /dcancel/p' "$SRV_LOG"; }
 
 # --- a benign signal must cost nothing ---------------------------------------
 # SIGCHLD is caught (sig_ignore) and asks for nothing: the one shape of signal

--- a/tests/262_local-signal-receive.test
+++ b/tests/262_local-signal-receive.test
@@ -49,14 +49,14 @@ await_exit() {
 # Wait until the server has logged $2 requests matching $1.
 await_requests() {
     local pattern=$1 count=$2 deadline=$((SECONDS + 60))
-    until test "$(count_matching_lines -a "$pattern" "$SRV_LOG")" -ge "$count"; do
+    until test "$(count_matching_lines "$pattern" "$SRV_LOG")" -ge "$count"; do
         test "$SECONDS" -lt "$deadline" || fail "the crawl never fetched $pattern"
         poll_wait 1
     done
 }
 
 # How many of the eight bodies the server has been asked for so far.
-bodies_requested() { count_matching_lines -a 'GET /dcancel/p' "$SRV_LOG"; }
+bodies_requested() { count_matching_lines 'GET /dcancel/p' "$SRV_LOG"; }
 
 # --- a benign signal must cost nothing ---------------------------------------
 # SIGCHLD is caught (sig_ignore) and asks for nothing: the one shape of signal

--- a/tests/277_html-target-and-print.test
+++ b/tests/277_html-target-and-print.test
@@ -39,7 +39,7 @@ values=$(
 )
 values=$(tr -d "\"' \\t" <<<"${values}" | sed 's/^[Tt][Aa][Rr][Gg][Ee][Tt]=//' | grep . || true)
 
-seen=$(grep -c . <<<"${values}" || true)
+seen=$(count_matching_lines . <<<"${values}")
 test "${seen}" -ge 50 || fail "only ${seen} target attributes found under html/"
 
 # Anything but the four keywords is a named context: _new and new_ both were.

--- a/tests/279_doc-guide-image-sizes.test
+++ b/tests/279_doc-guide-image-sizes.test
@@ -122,7 +122,7 @@ if grep -q 'src="img/' "${guide}"; then
 fi
 expect_fail 'want at least' "an img-less guide"
 out=$("${python}" "${checker}" "${work}/html" 2>&1 >/dev/null) || true
-nbad=$(grep -c '^FAIL:' <<<"${out}" || true)
+nbad=$(count_matching_lines '^FAIL:' <<<"${out}")
 test "${nbad}" -eq 1 || fail "the floor is not the only arm firing: ${out}"
 
 echo "guide images: geometry, existence and orphans all checked, each arm proven"

--- a/tests/286_ci-windows-pool.test
+++ b/tests/286_ci-windows-pool.test
@@ -117,7 +117,7 @@ test "$wide" -ge 6 || fail "at most $wide tests in flight at once, want the 6 wo
 
 # The traced re-run of the failing test runs outside test-timeout.sh, so it is the
 # one leg whose TMPDIR the driver itself decides.
-records=$(grep -c . "$share/tmpdirs" || true)
+records=$(count_matching_lines . "$share/tmpdirs")
 test "$records" -eq 13 ||
     fail "$records tests reported a TMPDIR, want 13 (twelve plus the traced re-run)"
 stray=$(strays)

--- a/tests/294_local-wizard-eof.test
+++ b/tests/294_local-wizard-eof.test
@@ -41,7 +41,7 @@ crawl() {
 
     test "$rc" -eq 0 || fail "$label: the crawl exited $rc"
     # asked once and then stopped: refusing this one link would ask again
-    asked=$(grep -c "beyond this mirror scope" "${tmpdir}/$label.log" || true)
+    asked=$(count_matching_lines "beyond this mirror scope" "${tmpdir}/$label.log")
     test "$asked" -eq 1 || fail "$label: asked $asked times, expected 1"
     test -f "${tmpdir}/$label/127.0.0.1_${SRV_PORT}/wizardeof/index.html" ||
         fail "$label: the start page was not mirrored"

--- a/tests/307_cookies-file-longfield.test
+++ b/tests/307_cookies-file-longfield.test
@@ -93,7 +93,7 @@ for want in "${refusals[@]}"; do
     grep -qF "Cookies: ignoring a line whose $want: $jar" <<<"$log" ||
         fail "no refusal for the $want in $out/hts-log.txt"
 done
-n=$(grep -c 'ignoring a line whose' <<<"$log" || true)
+n=$(count_matching_lines 'ignoring a line whose' <<<"$log")
 assert_eq "${#refusals[@]}" "$n" "refused jar lines"
 
 # a 7900-byte value fits its destination, so it is the jar's cap that drops it

--- a/tests/317_filter-rule-cap.test
+++ b/tests/317_filter-rule-cap.test
@@ -63,7 +63,7 @@ seed() { # seed LENGTH
         >"$tmpdir/u.txt"
     assert_eq "$URL: accepted by rule #1 (+*.png)" "$(why "$tmpdir/u.txt")" \
         "seed of $1 bytes"
-    seedwarned=$(grep -c 'URL longer than' "$tmpdir/p/hts-log.txt" || true)
+    seedwarned=$(count_matching_lines 'URL longer than' "$tmpdir/p/hts-log.txt")
 }
 # Deliberately not derived from the rule cap: a seed sized off the wrong bound
 # reds this on a cap move with no engine bug behind it.

--- a/tests/326_engine-header-dedup.test
+++ b/tests/326_engine-header-dedup.test
@@ -70,7 +70,7 @@ cleanup_push cleanup
 engine_fields="Host From User-Agent Accept Accept-Language Accept-Encoding Authorization"
 
 count_lines() { # count_lines RE FILE
-    grep -c "$1" "$2" || true
+    count_matching_lines "$1" "$2"
 }
 
 count_bytes() { # count_bytes BYTE FILE

--- a/tests/328_engine-header-dedup-rest.test
+++ b/tests/328_engine-header-dedup-rest.test
@@ -88,7 +88,7 @@ cleanup() {
 cleanup_push cleanup
 
 count_lines() { # count_lines RE FILE
-    grep -c "$1" "$2" || true
+    count_matching_lines "$1" "$2"
 }
 
 count_bytes() { # count_bytes BYTE FILE

--- a/tests/52_local-socks5.test
+++ b/tests/52_local-socks5.test
@@ -145,7 +145,7 @@ test "$missing" -eq 0 || {
     cat "$ka/out.log" "$ka/socks.log" >&2
     exit 1
 }
-handshakes=$(grep -c "^CMD " "$ka/socks.log" || true)
+handshakes=$(count_matching_lines "^CMD " "$ka/socks.log")
 test "$handshakes" -eq 1 || {
     echo "FAIL: expected 1 SOCKS handshake for the reused socket, got $handshakes" >&2
     cat "$ka/socks.log" >&2

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -95,7 +95,7 @@ charset_declared_matches_bytes() {
     fi
     # No legacy 8-bit charset puts text at U+0080..U+009F, so a C1 there means
     # the bytes are really the matching Windows codepage.
-    n=$(LC_ALL=C grep -c "$c1" "$tmp/utf8" || true)
+    n=$(LC_ALL=C count_matching_lines "$c1" "$tmp/utf8")
     # An empty n means grep failed, not that it found nothing.
     if [ "${n:-1}" -ne 0 ]; then
         echo "${f##*/}: $n lines decode to C1 controls under $cs; the bytes are a Windows codepage"

--- a/tests/65_port-siblings.test
+++ b/tests/65_port-siblings.test
@@ -133,7 +133,7 @@ ftp_port() {
     rm -rf "$out"
     run_with_timeout 30 httrack "ftp://127.0.0.1:$1/x" -O "$out" --quiet -n \
         >/dev/null 2>&1 || true
-    grep -c "Invalid port: $1" "$out/hts-log.txt" 2>/dev/null || true
+    count_matching_lines "Invalid port: $1" "$out/hts-log.txt" 2>/dev/null
 }
 
 # 65616 truncated to 80 and really did connect there

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -601,14 +601,14 @@ while test "$i" -lt "${#audit[@]}"; do
     --errors)
         i=$((i + 1))
         assert_equals "checking errors" "${audit[$i]}" \
-            "$(count_matching_lines -iE "^[0-9:]*[[:space:]]Error:" "${logroot}/hts-log.txt")"
+            "$(count_log_errors "${logroot}/hts-log.txt")"
         ;;
     --errors-content)
         i=$((i + 1))
-        total=$(count_matching_lines -iE "^[0-9:]*[[:space:]]Error:" "${logroot}/hts-log.txt")
+        total=$(count_log_errors "${logroot}/hts-log.txt")
         # transient network failures (statuscode -2..-6) flake on busy loopback;
         # the code parens are followed by " at link" or " after N retries at link"
-        transient=$(count_matching_lines -E '\(-[2-6]\) (at link|after )' "${logroot}/hts-log.txt")
+        transient=$(count_matching_lines_regexp '\(-[2-6]\) (at link|after )' "${logroot}/hts-log.txt")
         assert_equals "checking content errors" "${audit[$i]}" "$((total - transient))"
         ;;
     --files)

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -601,14 +601,14 @@ while test "$i" -lt "${#audit[@]}"; do
     --errors)
         i=$((i + 1))
         assert_equals "checking errors" "${audit[$i]}" \
-            "$(grep -iEc "^[0-9:]*[[:space:]]Error:" "${logroot}/hts-log.txt")"
+            "$(count_matching_lines -iE "^[0-9:]*[[:space:]]Error:" "${logroot}/hts-log.txt")"
         ;;
     --errors-content)
         i=$((i + 1))
-        total=$(grep -icE "^[0-9:]*[[:space:]]Error:" "${logroot}/hts-log.txt")
+        total=$(count_matching_lines -iE "^[0-9:]*[[:space:]]Error:" "${logroot}/hts-log.txt")
         # transient network failures (statuscode -2..-6) flake on busy loopback;
         # the code parens are followed by " at link" or " after N retries at link"
-        transient=$(grep -cE '\(-[2-6]\) (at link|after )' "${logroot}/hts-log.txt" || true)
+        transient=$(count_matching_lines -E '\(-[2-6]\) (at link|after )' "${logroot}/hts-log.txt")
         assert_equals "checking content errors" "${audit[$i]}" "$((total - transient))"
         ;;
     --files)

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -309,6 +309,12 @@ repeat_chars() { # repeat_chars COUNT [CHAR]
     printf '%*s' "$1" '' | tr ' ' "${2:-a}"
 }
 
+# What grep -c really returns: a count of matching LINES, two hits on one line
+# counting once, and 0 instead of a failing status when nothing matches.
+count_matching_lines() { # count_matching_lines [GREP-OPTS] PATTERN [FILE]
+    grep -c "$@" || true
+}
+
 # A passing step, on stdout: the failures go to stderr through fail().
 ok() { echo "OK: $*"; }
 

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -309,8 +309,8 @@ repeat_chars() { # repeat_chars COUNT [CHAR]
     printf '%*s' "$1" '' | tr ' ' "${2:-a}"
 }
 
-# What grep -c really returns: a count of matching LINES, two hits on one line
-# counting once, and 0 instead of a failing status when nothing matches.
+# grep -c counts matching LINES, not matches: two hits on one line count once.
+# It also returns 0, not a failing status, when nothing matches.
 count_matching_lines() { # count_matching_lines [GREP-OPTS] PATTERN [FILE]
     grep -c "$@" || true
 }

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -310,8 +310,8 @@ repeat_chars() { # repeat_chars COUNT [CHAR]
 }
 
 # grep -c counts matching LINES, not matches: two hits on one line count once.
-# It also returns 0, not a failing status, when nothing matches. -a on all of
-# these: a log that picks up one NUL byte otherwise counts nothing, silently.
+# It also returns 0, not a failing status, when nothing matches. -a throughout,
+# inert for GNU grep here but not for one that skips a file it reads as binary.
 count_matching_lines() { # count_matching_lines PATTERN [FILE]
     grep -ac "$@" || true
 }

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -310,9 +310,24 @@ repeat_chars() { # repeat_chars COUNT [CHAR]
 }
 
 # grep -c counts matching LINES, not matches: two hits on one line count once.
-# It also returns 0, not a failing status, when nothing matches.
-count_matching_lines() { # count_matching_lines [GREP-OPTS] PATTERN [FILE]
-    grep -c "$@" || true
+# It also returns 0, not a failing status, when nothing matches. -a on all of
+# these: a log that picks up one NUL byte otherwise counts nothing, silently.
+count_matching_lines() { # count_matching_lines PATTERN [FILE]
+    grep -ac "$@" || true
+}
+
+count_matching_lines_nocase() { # count_matching_lines_nocase PATTERN [FILE]
+    grep -aci "$@" || true
+}
+
+count_matching_lines_regexp() { # count_matching_lines_regexp ERE [FILE]
+    grep -acE "$@" || true
+}
+
+# The engine's error lines in a crawl log. One spelling of the pattern, which
+# six call sites used to carry.
+count_log_errors() { # count_log_errors LOGFILE
+    grep -aciE '^[0-9:]*[[:space:]]Error:' "$1" || true
 }
 
 # A passing step, on stdout: the failures go to stderr through fail().


### PR DESCRIPTION
`grep -c` counts matching *lines*, not matches, and exits 1 when it finds none. That second fact is why nearly all of these sites carried a `|| true`; the first is a trap this repo has recorded before. `count_matching_lines` names both, and no call site passes a flag.

`-a` is not a dialect, so it applies always rather than at 6 call sites. For the GNU grep on the runners it is inert with `-c`, so no count moves; it earns its place against a grep that skips a file it reads as binary, where the count comes back empty and `|| true` hides it. Either way it keeps the flag off 39 call sites.

Six of the fifteen flagged sites carried the same regex, the engine's own error line, so they are `count_log_errors` and that pattern has one home instead of six. One of the six matched case-sensitively where the other five did not; across 99 logs captured during a suite run the two spellings never disagree, so unifying them changes no count. What is left is one dialect per name, `count_matching_lines_nocase` and `count_matching_lines_regexp`, with one and two callers.

Seven sites keep the old spelling on purpose, and they are the interesting part. Their `grep -c` is the last stage of a pipeline, where the `|| true` guards the whole pipeline rather than the grep. Folding it into the function changes that under `pipefail`: the function returns 0, but the pipeline still reports the upstream's status. `182_crash-fork-safety.test` pipes a deliberately crashing httrack into its count, and converting it made the test die on the very crash the old spelling swallowed.

Two further sites in `local-crawl.sh` never carried a guard at all. That file sets `-u` but not `-e`, so a zero count could not kill it. Through the helper they stay safe if errexit is ever added.

A mutant returning a constant 0 reds 4 of the first 6 files that use the helper. The two it leaves green assert that the count is zero, which no constant-zero mutant can kill.

Full suite green at 348 pass, 12 skip.