### PR TITLE
Release 3.49.23

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.71])
 
-AC_INIT([httrack], [3.49.22], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
+AC_INIT([httrack], [3.49.23], [roche+packaging@httrack.com], [httrack], [http://www.httrack.com/])
 AC_COPYRIGHT([
 HTTrack Website Copier, Offline Browser for Windows and Unix
 Copyright (C) 1998-2015 Xavier Roche and other contributors
@@ -29,6 +29,8 @@ AC_CONFIG_SRCDIR(src/httrack.c)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
+# 3:16:0: revision-only bump. hts_addurl() now deep-copies the array it is handed,
+# which relaxes a caller contract without moving a layout or touching a symbol.
 # 3:15:0: revision-only bump. httrackp gained a tail field (wizard_filters) and two
 # exports arrived (hts_footer_field_ok, hts_wizard_host_scope); HTS_LOCATION_SIZE only
 # names lien_back.location_buffer's existing size, it does not change it.
@@ -49,7 +51,7 @@ AM_INIT_AUTOMAKE([subdir-objects])
 # moves nothing). Soname stays .so.3: HTTrackQt is the only consumer of the installed
 # headers, so a libhttrack4 rename isn't worth it.
 # (3:0:0 was the htsblk mime-buffer widening, the ABI break that moved .so.2 -> .so.3.)
-VERSION_INFO="3:15:0"
+VERSION_INFO="3:16:0"
 AM_MAINTAINER_MODE
 AC_USE_SYSTEM_EXTENSIONS
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+httrack (3.49.23-1) unstable; urgency=medium
+
+  * New upstream release: a header added by hand was sent twice, rebuilding
+    the top index blanked it in place, a URL injected into a running mirror
+    crashed the engine, and WebHTTrack stored several settings under the
+    wrong keys; full list in history.txt.
+
+ -- Xavier Roche <xavier@debian.org>  Fri, 21 Aug 2026 13:42:30 +0200
+
 httrack (3.49.22-1) unstable; urgency=medium
 
   * New upstream release: the interactive wizard can be answered for a whole

--- a/history.txt
+++ b/history.txt
@@ -4,6 +4,24 @@ HTTrack Website Copier release history:
 
 This file lists all changes and fixes that have been made for HTTrack
 
+3.49-23
++ Fixed: a header typed into the extra-headers box was sent twice, since the engine wrote its own copy of the same line; the typed line now replaces the engine's where that is safe, and the engine keeps the ones a duplicate would corrupt (#1337, #1340)
++ Fixed: rebuilding the top index truncated index.html in place, so a reader who opened it mid-rebuild got a blank or partial page (#1329)
++ Fixed: a URL injected into a running mirror crashed the engine; hts_addurl() copies the list it is given instead of borrowing it (#1253)
++ Fixed: a filter rule was capped by a scratch buffer rather than by the slot it is stored in, and the refusal quoted a limit that was not the one applied (#1288)
++ Fixed: a crawled link long enough to fill the save-name buffer aborted the mirror under -N '<template>' (#1295)
++ Fixed: a line longer than its read buffer had the unread tail read back as another record, so a robots.txt rule past 1 KB could re-open the path it forbade (#1294)
++ Fixed: a scan rule's size clause kept only the first of its two bounds, so *[>1<80] applied one and dropped the other (#1303)
++ Fixed: WebHTTrack never saved or restored a proxy (#1325)
++ Fixed: WebHTTrack filed three option checkboxes under each other's keys, so a project made in WinHTTrack or on Android reopened with those three settings rotated (#1324)
++ Fixed: a combo box or a list saved by WinHTTrack read back as a different setting in WebHTTrack (#1314)
++ Fixed: WebHTTrack passed a WARC or sitemap value to the command line even when the box owning it was cleared; the CDXJ box also greys out under a clear WARC box, which is the state where ticking it did nothing (#1336)
++ Fixed: WebHTTrack offered a mirror mode whose questions it has no way to ask (#1237)
++ Fixed: the WebHTTrack language menu named half the languages in English, and now shows each one in its own name and script (#116)
++ Changed: the three front ends write hts-cache/winprofile.ini against one declared contract, so a project made in one of them reopens unchanged in the others
++ Changed: the macOS disk image can be named for a prerelease channel rather than only for the engine version
++ Changed: multiple internal hardening, test and build improvements
+
 3.49-22
 + New: an interactive wizard question can be answered for a whole domain rather than for the one exact host it asked about; a front end enumerates the scopes on offer through the newly exported hts_wizard_host_scope() (#1117)
 + New: the -%F footer template takes named fields ("{url}", "{date}") in place of positional "%s", so a custom footer keeps working as the list grows; hts_footer_field_ok() exports the engine's own field list, which the help text and the guide are now generated from (#1240, #1256)

--- a/history.txt
+++ b/history.txt
@@ -7,18 +7,19 @@ This file lists all changes and fixes that have been made for HTTrack
 3.49-23
 + Fixed: a header typed into the extra-headers box was sent twice, since the engine wrote its own copy of the same line; the typed line now replaces the engine's where that is safe, and the engine keeps the ones a duplicate would corrupt (#1337, #1340)
 + Fixed: rebuilding the top index truncated index.html in place, so a reader who opened it mid-rebuild got a blank or partial page (#1329)
-+ Fixed: a URL injected into a running mirror crashed the engine; hts_addurl() copies the list it is given instead of borrowing it (#1253)
-+ Fixed: a filter rule was capped by a scratch buffer rather than by the slot it is stored in, and the refusal quoted a limit that was not the one applied (#1288)
-+ Fixed: a crawled link long enough to fill the save-name buffer aborted the mirror under -N '<template>' (#1295)
++ Fixed: a URL added to a running mirror was recorded under a placeholder name and then dropped as a duplicate, and injecting one through htsserver crashed the engine outright (#1253)
++ Fixed: an over-long filter rule was refused with the wrong limit quoted (#1288)
++ Fixed: a crawled link long enough to fill the save-name buffer aborted the mirror under -N '<template>', and a long %[param] value in the same branch overran the buffers behind it (#1295)
 + Fixed: a line longer than its read buffer had the unread tail read back as another record, so a robots.txt rule past 1 KB could re-open the path it forbade (#1294)
 + Fixed: a scan rule's size clause kept only the first of its two bounds, so *[>1<80] applied one and dropped the other (#1303)
 + Fixed: WebHTTrack never saved or restored a proxy (#1325)
 + Fixed: WebHTTrack filed three option checkboxes under each other's keys, so a project made in WinHTTrack or on Android reopened with those three settings rotated (#1324)
-+ Fixed: a combo box or a list saved by WinHTTrack read back as a different setting in WebHTTrack (#1314)
-+ Fixed: WebHTTrack passed a WARC or sitemap value to the command line even when the box owning it was cleared; the CDXJ box also greys out under a clear WARC box, which is the state where ticking it did nothing (#1336)
++ Fixed: a combo box or a list saved by WinHTTrack read back as the neighbouring setting in WebHTTrack; a WebHTTrack project saved before this release reopens one option off once, and the next save corrects it (#1314)
++ Fixed: WebHTTrack's scan-rule list was one slot short, so its default sent --priority=7 (get HTML first) in place of --priority=3 (save all), and its last entry sent nothing (#1323)
++ Fixed: WebHTTrack passed a WARC or sitemap value to the command line even when the box owning it was cleared; the CDXJ box also greys out under a clear WARC box, which is the state where ticking it did nothing (#1335, #1336)
++ Fixed: --single-file-max-size with a value that is not a positive number enabled single-file on the built-in cap instead of refusing the run (#1335)
 + Fixed: WebHTTrack offered a mirror mode whose questions it has no way to ask (#1237)
 + Fixed: the WebHTTrack language menu named half the languages in English, and now shows each one in its own name and script (#116)
-+ Changed: the three front ends write hts-cache/winprofile.ini against one declared contract, so a project made in one of them reopens unchanged in the others
 + Changed: the macOS disk image can be named for a prerelease channel rather than only for the engine version
 + Changed: multiple internal hardening, test and build improvements
 

--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -53,6 +53,18 @@
   <content_rating type="oars-1.1"/>
   <!-- Newest first; tests/01_engine-version-macros.test enforces it. -->
   <releases>
+    <release version="3.49.23" date="2026-08-21">
+      <description>
+        <ul>
+          <li>A header you add by hand is no longer sent twice</li>
+          <li>Rebuilding the top index no longer leaves it blank while it is being written</li>
+          <li>WebHTTrack saves and restores the proxy again, and no longer offers a mirror mode it cannot run</li>
+          <li>Settings saved in one interface reopen unchanged in the others</li>
+          <li>The language menu shows every language in its own name and script</li>
+          <li>A long address, a long filter or a long robots.txt rule no longer stops or misreads the mirror</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.49.22" date="2026-08-16">
       <description>
         <ul>

--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -58,10 +58,10 @@
         <ul>
           <li>A header you add by hand is no longer sent twice</li>
           <li>Rebuilding the top index no longer leaves it blank while it is being written</li>
-          <li>WebHTTrack saves and restores the proxy again, and no longer offers a mirror mode it cannot run</li>
+          <li>WebHTTrack now saves and restores the proxy, and no longer offers a mirror mode it cannot run</li>
           <li>Settings saved in one interface reopen unchanged in the others</li>
           <li>The language menu shows every language in its own name and script</li>
-          <li>A long address, a long filter or a long robots.txt rule no longer stops or misreads the mirror</li>
+          <li>A long address or a long robots.txt rule no longer stops or misreads the mirror</li>
         </ul>
       </description>
     </release>

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -43,8 +43,8 @@ Please visit our Website: http://www.httrack.com
    configure.ac, decoupled from these). VERSION is the display form, VERSIONID
    the dotted numeric form, AFF_VERSION the short form shown in footers,
    LIB_VERSION the data/cache format generation. */
-#define HTTRACK_VERSION "3.49-22"
-#define HTTRACK_VERSIONID "3.49.22"
+#define HTTRACK_VERSION "3.49-23"
+#define HTTRACK_VERSIONID "3.49.23"
 #define HTTRACK_AFF_VERSION "3.x"
 #define HTTRACK_LIB_VERSION "2.0"
 

--- a/src/version.rc
+++ b/src/version.rc
@@ -17,8 +17,8 @@
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-  FILEVERSION 3, 49, 22, 0
-  PRODUCTVERSION 3, 49, 22, 0
+  FILEVERSION 3, 49, 23, 0
+  PRODUCTVERSION 3, 49, 23, 0
   FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
 #ifdef _DEBUG
   FILEFLAGS VS_FF_DEBUG
@@ -35,12 +35,12 @@ BEGIN
     BEGIN
       VALUE "CompanyName", "Xavier Roche"
       VALUE "FileDescription", VER_FILE_DESCRIPTION
-      VALUE "FileVersion", "3.49.22"
+      VALUE "FileVersion", "3.49.23"
       VALUE "InternalName", VER_ORIGINAL_FILENAME
       VALUE "LegalCopyright", "Copyright (C) 1998-2026 Xavier Roche and other contributors. GNU GPL v3 or later."
       VALUE "OriginalFilename", VER_ORIGINAL_FILENAME
       VALUE "ProductName", "HTTrack Website Copier"
-      VALUE "ProductVersion", "3.49-22"
+      VALUE "ProductVersion", "3.49-23"
     END
   END
   BLOCK "VarFileInfo"


### PR DESCRIPTION
Release 3.49.23: version bumped in configure.ac, src/htsglobal.h and src/version.rc, VERSION_INFO to 3:16:0, plus release notes in history.txt, a metainfo release block and a debian/changelog entry.

The VERSION_INFO move is revision-only. hts_addurl() now copies the array it is handed, which relaxes a caller contract without moving a layout or touching a symbol, so the soname stays .so.3.

Thirty-six commits since 3.49.22: mostly WebHTTrack settings that disagreed with the other two front ends, the extra-headers duplication, and bounds fixes on long links, filters and robots.txt lines. debian/ itself did not change in the range, so the changelog entry carries the upstream overview line only, and Standards-Version stays at 4.7.4.

Built out of tree, make check green: 360 tests, 348 pass, 12 skip.
