### PR TITLE
Eight tests in flight is where MSYS fork emulation gives way

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -265,6 +265,9 @@ jobs:
         working-directory: tests
         timeout-minutes: 45
         env:
+          # Half of 2*nproc: MSYS fork emulation breaks first under the pressure
+          # eight in flight put on a 4-vCPU runner (#1273).
+          HTTRACK_SUITE_JOBS: 4
           # Through the environment, never argv, which the process list exposes.
           WATCHDOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WATCHDOG_REPO: ${{ github.repository }}

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -255,7 +255,8 @@ trap 'set +e; kill "$heartbeat" 2>/dev/null; test -z "$watchdog" || kill_pid "$w
 
 pass=0 fail=0 skip=0 failed="" skipped="" deadline=0
 # Tests in flight at once, min(2*nproc, 16) as ci.yml gives "make check" on every
-# platform: each binds its own ephemeral-port server, and they mostly sleep.
+# platform, unless the caller pins it (windows-build.yml does): each binds its own
+# ephemeral-port server, and they mostly sleep.
 cores=$(nproc 2>/dev/null || echo "${NUMBER_OF_PROCESSORS:-2}")
 case "$cores" in '' | 0 | *[!0-9]*) cores=2 ;; esac
 jobs=$((cores * 2))


### PR DESCRIPTION
The Windows suite runs `min(2*nproc, 16)` tests at once, which on a 4-vCPU `windows-2022` runner means eight. Each forks bash, a Python fixture server and the engine, and MSYS fork emulation is what gives way first under that pressure: a child dies at DLL init with `0xC0000142` and bash retries on `EAGAIN` (#1273). This halves the width to four.

Scope, because the obvious reading is wrong: this is aimed at the fork failures of #1273, not at the runner deaths of #1228. The measurement done for #1273 found engine and zlib hold 39% of all process creation and 0 of 34 runner deaths, so fork rate is the one workload dimension that shows no relationship to a runner dying. Read this as reducing a known, counted, survivable irritant, and nothing more.

The evidence is thin even at that. `ci_report_fork_failures` files the failures as a warning rather than an error, the one prior occurrence still finished green, and they appear in roughly one leg in 34, so a green run at width four proves nothing by itself.

Better aimed at the same signature, and untried: `0xC0000142` is `STATUS_DLL_INIT_FAILED`, whose classic cause under Cygwin fork is mandatory ASLR relocating the msys DLL out from under the child. `Set-ProcessMitigation -Disable ForceRelocateImages` is a one-liner worth trying next, separately from this.

Cost is wall clock on the two Windows legs.