### PR TITLE
0xC0000142 looks like mandatory ASLR, not process pressure

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -260,6 +260,30 @@ jobs:
       # used to run inline (codecs, cache, fsize).
       # The *_local-* ones crawl the bundled Python server over loopback: the real
       # TLS handshake, cache and file writer, which nothing else on Windows covers.
+      # 0xC0000142 at fork time is classically the msys DLL failing to map at the
+      # parent's address (#1273), so this reports the state, turns mandatory ASLR
+      # off, and reports again: a system mitigation normally wants a reboot, and
+      # the second report is what says whether it took on a runner we cannot boot.
+      - name: Relax image relocation for the MSYS fork emulation
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          function Show($when) {
+            $s = Get-ProcessMitigation -System
+            "$when system ForceRelocateImages : $($s.Aslr.ForceRelocateImages)"
+            "$when system BottomUp            : $($s.Aslr.BottomUp)"
+            try {
+              $p = Get-ProcessMitigation -Name bash.exe
+              "$when bash   ForceRelocateImages : $($p.Aslr.ForceRelocateImages)"
+            } catch {
+              "$when bash   ForceRelocateImages : no per-process entry"
+            }
+          }
+          Show "before"
+          Set-ProcessMitigation -System -Disable ForceRelocateImages -ErrorAction Continue
+          Set-ProcessMitigation -Name bash.exe -Disable ForceRelocateImages -ErrorAction Continue
+          Show "after "
+
       - name: Run the engine test suite (offline tests)
         shell: bash
         working-directory: tests


### PR DESCRIPTION
`0xC0000142` is `STATUS_DLL_INIT_FAILED`, and under Cygwin-derived fork emulation the classic cause is mandatory ASLR relocating the msys DLL so the forked child cannot map it where the parent has it. That is a much closer match to what #1273 actually observes than process pressure is, so this turns the mitigation off before the suite runs.

It is a hypothesis, and the step is built to disprove itself. `ForceRelocateImages` is off by default on Windows, so if the runner image never enabled it there is nothing here to disable and the theory dies; the step therefore prints the state before and after. A system-level mitigation normally wants a reboot, which a hosted runner cannot give us, so the "after" line is also what says whether the change took at all. Read those two lines first: if `before` already says `OFF`, close this.

Deliberately no `HTTRACK_SUITE_JOBS` change here, so this and #1350 stay one variable each and their Windows legs can be compared. `continue-on-error` keeps a runner that refuses the cmdlet from reddening the leg.
