### PR TITLE
The update URL's Language parameter has no stated contract

### DIFF
--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -244,6 +244,8 @@ Please visit our Website: http://www.httrack.com
   "Mozilla/5.0 (compatible; HTTrack/" HTTRACK_AFF_VERSION                      \
   "; +https://www.httrack.com/)"
 #define HTTRACK_WEB "http://www.httrack.com"
+/* Language=%s takes the catalog basename (LANGUAGE_FILE), an ASCII identifier;
+   LANGUAGE_NAME is a localized display string in a legacy codepage (#1353). */
 #define HTS_UPDATE_WEBSITE                                                     \
   "http://www.httrack.com/"                                                    \
   "update.php3?Product=HTTrack&Version=" HTTRACK_VERSIONID                     \


### PR DESCRIPTION
The engine defines `HTS_UPDATE_WEBSITE` and never calls it, so what its `Language=%s` is supposed to carry was written down nowhere. The one caller, WinHTTrack, fills it with `LANGUAGE_NAME`. When #1313 turned `LANGUAGE_NAME` into endonyms across 14 catalogs, the receiving page started rendering an empty field: the catalogs are each in their own legacy codepage, and no single charset declared downstream can decode all of them.

This is the engine's share of #1353, and only that. It states the contract at the macro, where a caller reads it: the parameter takes the catalog basename, `LANGUAGE_FILE`, which is ASCII by construction and which #1313 left untouched.

That last part is why `LANGUAGE_FILE` beats an ISO code here. Its values are the English names the wire has always carried, so a caller switching to it restores the exact bytes sent before this release rather than introducing a third spelling that would split the receiving side's series a second time.

The other two halves belong to the repos that own them: WinHTTrack sending `LANGUAGE_FILE`, and the page hardening its render so that bytes it cannot decode degrade instead of blanking, which is the only fix that reaches clients already in the field.
