### PR TITLE
Clip the option-error diagnostics an oversized replayed token can overflow

### DIFF
--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -424,10 +424,11 @@ int optalias_check(int argc, const char *const *argv, int n_arg,
           /* Copy parameters? */
           if (need_param == 2) {
             if (optparam_missing(argc, argv, n_arg, command)) {
-              snprintf(return_error, return_error_size,
-                       "Syntax error:\n\tOption %s needs to be followed by a "
-                       "parameter: %s <param>\n\t%s\n",
-                       command, command, _NOT_NULL(optalias_help(command)));
+              slprintfbuff_clip(
+                  return_error, return_error_size,
+                  "Syntax error:\n\tOption %s needs to be followed by a "
+                  "parameter: %s <param>\n\t%s\n",
+                  command, command, _NOT_NULL(optalias_help(command)));
               return 0;
             }
             strcpybuff(param, argv[n_arg + 1]);
@@ -476,14 +477,15 @@ int optalias_check(int argc, const char *const *argv, int n_arg,
                enabling bare --index */
             if (suffix == NULL) {
               if (negated)
-                snprintf(return_error, return_error_size,
-                         "Unknown option: %s\n", argv[n_arg] + 2);
+                slprintfbuff_clip(return_error, return_error_size,
+                                  "Unknown option: %s\n", argv[n_arg] + 2);
               else
-                snprintf(return_error, return_error_size,
-                         "Syntax error:\n\tOption --%s does not take the value "
-                         "%s\n\t%s\n",
-                         hts_optalias[pos][0], param,
-                         _NOT_NULL(optalias_help(hts_optalias[pos][0])));
+                slprintfbuff_clip(
+                    return_error, return_error_size,
+                    "Syntax error:\n\tOption --%s does not take the value "
+                    "%s\n\t%s\n",
+                    hts_optalias[pos][0], param,
+                    _NOT_NULL(optalias_help(hts_optalias[pos][0])));
               return 0;
             }
             strlcatbuff(return_argv[0], suffix, return_argv_size);
@@ -491,8 +493,8 @@ int optalias_check(int argc, const char *const *argv, int n_arg,
           *return_argc = 1;     /* 1 parameter returned */
         }
       } else {
-        snprintf(return_error, return_error_size, "Unknown option: %s\n",
-                 command);
+        slprintfbuff_clip(return_error, return_error_size,
+                          "Unknown option: %s\n", command);
         return 0;
       }
       return need_param;
@@ -506,11 +508,11 @@ int optalias_check(int argc, const char *const *argv, int n_arg,
       if ((strcmp(hts_optalias[pos][2], "param1") == 0)
           || (strcmp(hts_optalias[pos][2], "param0") == 0)) {
         if (optparam_missing(argc, argv, n_arg, argv[n_arg])) {
-          snprintf(return_error, return_error_size,
-                   "Syntax error:\n\tOption %s needs to be followed by a "
-                   "parameter: %s <param>\n\t%s\n",
-                   argv[n_arg], argv[n_arg],
-                   _NOT_NULL(optalias_help(argv[n_arg])));
+          slprintfbuff_clip(
+              return_error, return_error_size,
+              "Syntax error:\n\tOption %s needs to be followed by a "
+              "parameter: %s <param>\n\t%s\n",
+              argv[n_arg], argv[n_arg], _NOT_NULL(optalias_help(argv[n_arg])));
           return 0;
         }
         /* Copy parameters */

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -771,7 +771,8 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
 #ifdef _WIN32
             char s[HTS_CDLMAXSIZE + 256];
 
-            sprintf(s, "%s not available in this version", argv[i]);
+            slprintfbuff_clip(s, sizeof(s), "%s not available in this version",
+                              argv[i]);
             HTS_PANIC_PRINTF(s);
             htsmain_free();
             return -1;
@@ -781,7 +782,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
           else {
             char s[HTS_CDLMAXSIZE + 256];
 
-            sprintf(s, "%s not recognized", argv[i]);
+            slprintfbuff_clip(s, sizeof(s), "%s not recognized", argv[i]);
             HTS_PANIC_PRINTF(s);
             htsmain_free();
             return -1;
@@ -1797,9 +1798,10 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                     if (ret == 0) {
                       char BIGSTK tmp[1024 * 2];
 
-                      sprintf(tmp,
-                              "option %%W : unable to plug the module %s (returncode != 1)",
-                              argv[na]);
+                      slprintfbuff_clip(tmp, sizeof(tmp),
+                                        "option %%W : unable to plug the "
+                                        "module %s (returncode != 1)",
+                                        argv[na]);
                       HTS_PANIC_PRINTF(tmp);
                       htsmain_free();
                       return -1;
@@ -1807,9 +1809,11 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                       char BIGSTK tmp[1024 * 2];
                       int last_errno = errno;
 
-                      sprintf(tmp,
-                              "option %%W : unable to load the module %s: %s (check the library path ?)",
-                              argv[na], strerror(last_errno));
+                      slprintfbuff_clip(
+                          tmp, sizeof(tmp),
+                          "option %%W : unable to load the module %s: %s "
+                          "(check the library path ?)",
+                          argv[na], strerror(last_errno));
                       HTS_PANIC_PRINTF(tmp);
                       htsmain_free();
                       return -1;

--- a/tests/329_engine-argv-length-bound.test
+++ b/tests/329_engine-argv-length-bound.test
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# The argv length pre-check is what bounds three later sprintf destinations
+# The argv length pre-check is what bounds three diagnostic buffers
 # (htscoremain.c:784, :1800, :1810); nothing else pins it.
 
 set -euo pipefail
@@ -8,7 +8,6 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-require_httrack
 h=$(httrack_path)
 
 # First output line for an unrecognised option of exactly $1 bytes.
@@ -23,12 +22,19 @@ unknown_opt() { # unknown_opt TOTALLEN
 assert_match 'Unknown option' "$(unknown_opt 1023)" 'argv at the limit'
 assert_match 'argument too long' "$(unknown_opt 1024)" 'argv over the limit'
 
-# Same bound applies to arguments the rc file contributes, which reach argv only
-# after the pre-check has run.
-rc=$(mktemp -d)
-cleanup_push rm -rf "$rc"
-printf -- '--%s\n' "$(repeat_chars 60000 A)" >"$rc/.httrackrc"
-out=$(cd "$rc" && HOME=$rc "$h" http://example.invalid/ 2>&1) || true
-assert_match 'Unknown option' "$out" 'oversized rc option is reported, not fatal'
+# doit.log is replayed into argv AFTER the pre-check, with an 8000-byte line
+# budget, so it is the one injector that can oversize a diagnostic argument.
+mirror=$(mktemp -d)
+cleanup_push rm -rf "$mirror"
+mkdir -p "$mirror/hts-cache"
+printf 'http://x/ --%s\n' "$(repeat_chars 3000 B)" >"$mirror/hts-cache/doit.log"
+reply=$(cd "$mirror" && "$h" 2>&1) || true
+line=$(firstline "$reply")
 
-ok "argv length bound holds on both sides"
+# The token alone fills the 1280-byte message buffer, so the reply is the
+# clipped token and the " not recognized" suffix is gone. Unclipped, the write
+# overflows and the engine aborts before printing anything at all.
+test "${#line}" -gt 1000 || fail "no diagnostic, engine died first: $line"
+test "${#line}" -lt 2000 || fail "reply not clipped: ${#line} bytes"
+
+ok "argv length bound holds, and an oversized replayed token is clipped"

--- a/tests/329_engine-argv-length-bound.test
+++ b/tests/329_engine-argv-length-bound.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# The argv length pre-check is what bounds three diagnostic buffers
-# (htscoremain.c:784, :1800, :1810); nothing else pins it.
+# The argv length pre-check is what bounds the option-error diagnostic at
+# htscoremain.c:785; nothing else pins it.
 
 set -euo pipefail
 
@@ -10,10 +10,15 @@ set -euo pipefail
 
 h=$(httrack_path)
 
+# Both runs read ./hts-cache/doit.log and $HOME/.httrackrc, so they need a
+# directory no other test and no developer's own rc file can reach into.
+scratch=$(mktemp -d)
+cleanup_push rm -rf "$scratch"
+
 # First output line for an unrecognised option of exactly $1 bytes.
 unknown_opt() { # unknown_opt TOTALLEN
     local out
-    out=$("$h" "--$(repeat_chars $(($1 - 2)) A)" 2>&1) || true
+    out=$(cd "$scratch" && HOME=$scratch "$h" "--$(repeat_chars $(($1 - 2)) A)" 2>&1) || true
     firstline "$out"
 }
 
@@ -28,13 +33,16 @@ mirror=$(mktemp -d)
 cleanup_push rm -rf "$mirror"
 mkdir -p "$mirror/hts-cache"
 printf 'http://x/ --%s\n' "$(repeat_chars 3000 B)" >"$mirror/hts-cache/doit.log"
-reply=$(cd "$mirror" && "$h" 2>&1) || true
+reply=$(cd "$mirror" && HOME=$mirror "$h" 2>&1) || true
 line=$(firstline "$reply")
 
-# The token alone fills the 1280-byte message buffer, so the reply is the
-# clipped token and the " not recognized" suffix is gone. Unclipped, the write
-# overflows and the engine aborts before printing anything at all.
-test "${#line}" -gt 1000 || fail "no diagnostic, engine died first: $line"
-test "${#line}" -lt 2000 || fail "reply not clipped: ${#line} bytes"
+# The clip fills the 1280-byte buffer with the token, so the " not recognized"
+# suffix is gone; it survives only if nothing was clipped. Unclipped, the write
+# overflows and the engine aborts before printing anything.
+case $line in
+*"not recognized"*) fail "message was not clipped: $line" ;;
+esac
+test "${#line}" -ge 1279 || fail "no clipped diagnostic, engine died first: $line"
+test "${#line}" -le 1300 || fail "reply not clipped: ${#line} bytes"
 
 ok "argv length bound holds, and an oversized replayed token is clipped"

--- a/tests/329_engine-argv-length-bound.test
+++ b/tests/329_engine-argv-length-bound.test
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# The argv length pre-check is what bounds three later sprintf destinations
+# (htscoremain.c:784, :1800, :1810); nothing else pins it.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+require_httrack
+h=$(httrack_path)
+
+# First output line for an unrecognised option of exactly $1 bytes.
+unknown_opt() { # unknown_opt TOTALLEN
+    local out
+    out=$("$h" "--$(repeat_chars $(($1 - 2)) A)" 2>&1) || true
+    firstline "$out"
+}
+
+# HTS_CDLMAXSIZE is 1024 and the guard rejects >= it, so 1023 is the last
+# argument that still reaches option parsing.
+assert_match 'Unknown option' "$(unknown_opt 1023)" 'argv at the limit'
+assert_match 'argument too long' "$(unknown_opt 1024)" 'argv over the limit'
+
+# Same bound applies to arguments the rc file contributes, which reach argv only
+# after the pre-check has run.
+rc=$(mktemp -d)
+cleanup_push rm -rf "$rc"
+printf -- '--%s\n' "$(repeat_chars 60000 A)" >"$rc/.httrackrc"
+out=$(cd "$rc" && HOME=$rc "$h" http://example.invalid/ 2>&1) || true
+assert_match 'Unknown option' "$out" 'oversized rc option is reported, not fatal'
+
+ok "argv length bound holds on both sides"


### PR DESCRIPTION
httrack pre-checks every command-line argument against `HTS_CDLMAXSIZE` before parsing, and three diagnostic buffers in htscoremain.c are sized on the assumption that the bound holds. It holds for the command line, and for the rc file, whose reader caps a line at 250 bytes. It does not hold for `hts-cache/doit.log`, which is replayed into the grown argv through `cmdl_ins` after the pre-check has already run, with an 8000-byte line budget. A doit.log line carrying a 3000-byte unknown option therefore reaches the 1280-byte message buffer at htscoremain.c:783 unchecked, and the engine dies with `*** buffer overflow detected ***`. That abort comes from `__sprintf_chk`, so a build that lost `-O`, where `_FORTIFY_SOURCE` is silently inert, smashes the stack instead of aborting.

The three sinks move onto `slprintfbuff_clip`, the tree's existing clip primitive for diagnostics, which is the right choice here because the message quotes untrusted input and a truncated line beats an abort. The new test drives the doit.log path and fails on master. Fixing this surfaced a second bug: htslib.h remaps `snprintf` to the legacy msvcrt `_snprintf` for every Windows build, and that one neither NUL-terminates on truncation nor returns a length, so an oversized unknown option aborted both Windows legs inside `strcpybuff`. The five `return_error` sites in htsalias.c move onto the same primitive. The tree-wide remap wants its own change, since modern MSVC has a conformant `snprintf` and the define downgrades it.

CodeQL reported the sink as #79 and I twice called it a false positive, because the two injectors I probed (command line, rc file) really are bounded. Worth recording: a sink fed by several injectors needs every injector exercised.
