### PR TITLE
Fail the sanitizer legs on a report a passing test hid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,7 +560,9 @@ jobs:
         # bytes by default, so max_malloc_fill_size lifts it to cover large cache
         # buffers; free_fill flags use-after-free reads.
         env:
-          ASAN_OPTIONS: detect_leaks=0:abort_on_error=1:halt_on_error=1:strict_string_checks=1:malloc_fill_byte=202:max_malloc_fill_size=2147483647:free_fill_byte=203:max_free_fill_size=2147483647
+          ASAN_OPTIONS: detect_leaks=0:abort_on_error=1:halt_on_error=1:strict_string_checks=1:malloc_fill_byte=202:max_malloc_fill_size=2147483647:free_fill_byte=203:max_free_fill_size=2147483647:log_path=${{ github.workspace }}/sanitizer-logs/asan
+          # No log_path here: gcc's UBSan ignores it and writes to stderr, so
+          # its findings are collected from the per-test logs instead.
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         timeout-minutes: 20
         run: |
@@ -570,6 +572,22 @@ jobs:
       - name: Print the test log on failure
         if: failure()
         run: cat tests/test-suite.log 2>/dev/null || true
+
+      - name: Collect sanitizer findings
+        if: always()
+        run: |
+          set -euo pipefail
+          sh tools/ci-sanitizer-report.sh "$GITHUB_WORKSPACE/sanitizer-logs" tests
+
+      - name: Upload the sanitizer and per-test logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sanitize-logs
+          path: |
+            sanitizer-logs/
+            tests/*.log
+          if-no-files-found: ignore
 
   # MemorySanitizer catches reads of uninitialized memory (#143's stack-garbage
   # size filter) that ASan/UBSan miss. It flags any byte an uninstrumented lib
@@ -605,7 +623,7 @@ jobs:
 
       - name: Test (offline self-tests under MSan)
         env:
-          MSAN_OPTIONS: abort_on_error=1:halt_on_error=1
+          MSAN_OPTIONS: abort_on_error=1:halt_on_error=1:log_path=${{ github.workspace }}/sanitizer-logs/msan
         timeout-minutes: 20
         run: |
           set -euo pipefail
@@ -618,6 +636,22 @@ jobs:
       - name: Print the test log on failure
         if: failure()
         run: cat tests/test-suite.log 2>/dev/null || true
+
+      - name: Collect sanitizer findings
+        if: always()
+        run: |
+          set -euo pipefail
+          sh tools/ci-sanitizer-report.sh "$GITHUB_WORKSPACE/sanitizer-logs" tests
+
+      - name: Upload the sanitizer and per-test logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: msan-logs
+          path: |
+            sanitizer-logs/
+            tests/*.log
+          if-no-files-found: ignore
 
   # libFuzzer smoke: build the fuzz/ harnesses over the pure hostile-input
   # parsers and replay each seed corpus under ASan+UBSan+LeakSanitizer. Replay

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,10 +562,11 @@ jobs:
         env:
           ASAN_OPTIONS: detect_leaks=0:abort_on_error=1:halt_on_error=1:strict_string_checks=1:malloc_fill_byte=202:max_malloc_fill_size=2147483647:free_fill_byte=203:max_free_fill_size=2147483647:log_path=${{ github.workspace }}/sanitizer-logs/asan
           # No log_path here: gcc's UBSan ignores it and writes to stderr, so
-          # its findings are collected from the per-test logs instead.
+          # its findings show up in the per-test logs instead.
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         timeout-minutes: 20
         run: |
+          mkdir -p "$GITHUB_WORKSPACE/sanitizer-logs"
           jobs=$(( $(nproc) * 2 )); [ "$jobs" -le 16 ] || jobs=16
           make check -j"$jobs"
 
@@ -627,6 +628,7 @@ jobs:
         timeout-minutes: 20
         run: |
           set -euo pipefail
+          mkdir -p "$GITHUB_WORKSPACE/sanitizer-logs"
           # 01_engine-* only; zlib-dependent self-tests are named 01_zlib-* and
           # skipped here (uninstrumented libz floods MSan with false positives).
           tests="$(cd tests && ls 01_engine-*.test | tr '\n' ' ')"

--- a/tests/236_local-ftp-teardown.test
+++ b/tests/236_local-ftp-teardown.test
@@ -15,10 +15,19 @@ tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftp.XXXXXX")
 cleanup_push rm -rf "$tmpdir"
 
 errlog="${tmpdir}/httrack.err"
+# The CI job sends ASan reports to its own log_path, which would leave the grep
+# below with nothing to find. Last value wins, so take them back here.
+export ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}log_path=${tmpdir}/asan"
 # A sanitized build reports the use-after-free and still exits 1, so the status
 # alone is blind to it. Leaks at exit are out of scope, hence no LeakSanitizer.
 assert_clean_run() {
     cat "$errlog" >&2 # the redirect must not cost the harness log the crawl's stderr
+    local report
+    report=$(cat "${tmpdir}"/asan.* 2>/dev/null || true)
+    test -z "$report" || {
+        echo "$report" >&2
+        fail "$1: the crawl produced a sanitizer report (#1051)"
+    }
     ! grep -Eq 'AddressSanitizer:|MemorySanitizer:|runtime error:' "$errlog" ||
         fail "$1: the crawl produced a sanitizer report (#1051)"
 }

--- a/tools/ci-sanitizer-report.sh
+++ b/tools/ci-sanitizer-report.sh
@@ -1,17 +1,17 @@
 #!/bin/sh
-# Surface sanitizer findings the test harness would otherwise swallow: automake
-# keeps only failing tests in test-suite.log, so an abort inside a script that
-# lacks `set -e` leaves no trace in a green run. Both sources are needed, since
-# the log_path files carry a report whose stderr a test redirected away, and the
-# per-test logs carry gcc's UBSan, which writes to stderr and ignores log_path.
+# Surface sanitizer findings automake swallows in a green run: it keeps only the
+# failing tests in test-suite.log, and most test scripts lack `set -e`.
+# Both sources matter. A test that redirects its own stderr hides its report
+# everywhere but the log_path file, and gcc's UBSan writes to stderr and ignores
+# log_path, unlike clang's.
 #
 # Usage: ci-sanitizer-report.sh LOG_PATH_DIR [TEST_LOG_DIR...]; exits 1 on a hit.
 set -eu
 
-# Anchored on each runtime's banner: severity alone is not the signal. MSan
-# reports findings as WARNING, while ASan uses WARNING for the over-large
-# allocation 237_engine-arrays has it refuse on purpose; and the engine's own
-# "detected memory leaks" message is not LeakSanitizer's.
+# Anchored on each runtime's banner: severity is not enough, since MSan reports
+# findings as WARNING and ASan uses WARNING for 237_engine-arrays' deliberate
+# over-large allocation. The engine's own "detected memory leaks" message is
+# also not LeakSanitizer's.
 pattern='ERROR: (Address|Leak|Memory|Thread|UndefinedBehavior)Sanitizer|WARNING: (Memory|Thread)Sanitizer|runtime error:|SUMMARY: .*Sanitizer|ERROR: libFuzzer|DEADLYSIGNAL'
 
 log_dir=$1
@@ -25,7 +25,7 @@ report() { # report LABEL FILE
 }
 
 # Print every log_path file, but fail only on one that matches: an unrecognised
-# diagnostic stays visible without turning a deliberate one into a red build.
+# diagnostic stays visible, and a deliberate one does not turn the build red.
 if [ -d "$log_dir" ]; then
     for f in "$log_dir"/*; do
         [ -f "$f" ] || continue
@@ -38,15 +38,19 @@ if [ -d "$log_dir" ]; then
     done
 fi
 
+# Only the harness logs: an in-tree build puts the .test sources here too, and
+# one of them carries the pattern as literal text.
 for dir in "$@"; do
     [ -d "$dir" ] || continue
-    for f in $(grep -rlE "$pattern" "$dir" 2>/dev/null || true); do
-        report "sanitizer output in a test log" "$f"
+    for f in "$dir"/*.log; do
+        [ -f "$f" ] || continue
+        grep -qE "$pattern" "$f" 2>/dev/null &&
+            report "sanitizer output in a test log" "$f"
     done
 done
 
 [ "$found" -eq 0 ] || {
-    echo "FAIL: a sanitizer reported above; a passing test can still hide one." >&2
+    echo "FAIL: a sanitizer reported above, which \`make check\` alone did not catch." >&2
     exit 1
 }
 echo "No sanitizer finding in $log_dir or the per-test logs."

--- a/tools/ci-sanitizer-report.sh
+++ b/tools/ci-sanitizer-report.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Surface sanitizer findings the test harness would otherwise swallow: automake
+# keeps only failing tests in test-suite.log, so an abort inside a script that
+# lacks `set -e` leaves no trace in a green run. Both sources are needed, since
+# the log_path files carry a report whose stderr a test redirected away, and the
+# per-test logs carry gcc's UBSan, which writes to stderr and ignores log_path.
+#
+# Usage: ci-sanitizer-report.sh LOG_PATH_DIR [TEST_LOG_DIR...]; exits 1 on a hit.
+set -eu
+
+# Anchored on each runtime's banner: severity alone is not the signal. MSan
+# reports findings as WARNING, while ASan uses WARNING for the over-large
+# allocation 237_engine-arrays has it refuse on purpose; and the engine's own
+# "detected memory leaks" message is not LeakSanitizer's.
+pattern='ERROR: (Address|Leak|Memory|Thread|UndefinedBehavior)Sanitizer|WARNING: (Memory|Thread)Sanitizer|runtime error:|SUMMARY: .*Sanitizer|ERROR: libFuzzer|DEADLYSIGNAL'
+
+log_dir=$1
+shift
+found=0
+
+report() { # report LABEL FILE
+    found=1
+    echo "=== $1: $2"
+    cat "$2"
+}
+
+# Print every log_path file, but fail only on one that matches: an unrecognised
+# diagnostic stays visible without turning a deliberate one into a red build.
+if [ -d "$log_dir" ]; then
+    for f in "$log_dir"/*; do
+        [ -f "$f" ] || continue
+        if grep -qE "$pattern" "$f" 2>/dev/null; then
+            report "sanitizer report" "$f"
+        else
+            echo "=== other sanitizer output (not a finding): $f"
+            cat "$f"
+        fi
+    done
+fi
+
+for dir in "$@"; do
+    [ -d "$dir" ] || continue
+    for f in $(grep -rlE "$pattern" "$dir" 2>/dev/null || true); do
+        report "sanitizer output in a test log" "$f"
+    done
+done
+
+[ "$found" -eq 0 ] || {
+    echo "FAIL: a sanitizer reported above; a passing test can still hide one." >&2
+    exit 1
+}
+echo "No sanitizer finding in $log_dir or the per-test logs."


### PR DESCRIPTION
Automake sends each test's output to `tests/<name>.log`, and `test-suite.log` keeps only the failing tests. ci.yml prints that log on failure alone, so a sanitizer abort inside one of the 16 test scripts that lack `set -e` left no trace in a green run.

ASan and MSan reports now go to a log_path directory. A new step scans it and the harness logs after `make check`, fails on a hit, and uploads both with `if: always()`. Both sources matter: a test that redirects its own stderr keeps a report out of the per-test log, and gcc's UBSan writes to stderr and ignores `log_path`, unlike clang's.

A sanitized run of the full suite stays clean, with `237_engine-arrays`' deliberate over-large allocation printed but not counted. Injecting a swallowed heap overflow and a swallowed signed overflow turns it red, each caught by a different source.

`236_local-ftp-teardown.test` takes its own `log_path` back: the job-level one diverted the ASan report its `#1051` check greps for.