### PR TITLE
Format arguments to the log helpers are never type-checked

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -6078,7 +6078,7 @@ int ftp_available(void) {
 }
 #endif
 
-static void hts_debug_log_print(const char *format, ...);
+static void hts_debug_log_print(const char *format, ...) HTS_PRINTF_FUN(1, 2);
 
 static int hts_dgb_init = 0;
 static FILE *hts_dgb_init_fp = NULL;
@@ -6176,8 +6176,8 @@ static int get_loglevel_from_coucal(coucal_loglevel level) {
 }
 
 /* log to default console */
-static void default_coucal_loghandler(void *arg, coucal_loglevel level, 
-                                       const char* format, va_list args) {
+static HTS_PRINTF_FUN(3, 0) void default_coucal_loghandler(
+    void *arg, coucal_loglevel level, const char *format, va_list args) {
 
   /* informational chatter (hashtable stats on delete, etc.) only when
      debugging; keep warnings and critical errors always visible. */
@@ -6192,8 +6192,10 @@ static void default_coucal_loghandler(void *arg, coucal_loglevel level,
 }
 
 /* log to project log */
-static void htsopt_coucal_loghandler(void *arg, coucal_loglevel level, 
-                                      const char* format, va_list args) {
+static HTS_PRINTF_FUN(3, 0) void htsopt_coucal_loghandler(void *arg,
+                                                          coucal_loglevel level,
+                                                          const char *format,
+                                                          va_list args) {
   httrackp *const opt = (httrackp*) arg;
   if (opt != NULL && opt->log != NULL) {
     hts_log_vprint(opt, get_loglevel_from_coucal(level), 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1125,8 +1125,9 @@ static void st_assume_rule(httrackp *opt, size_t value_len) {
 
 static unsigned st_assume_clips; /* clip warnings the callback has seen */
 
-static void st_assume_log(httrackp *opt, int type, const char *format,
-                          va_list args) {
+static HTS_PRINTF_FUN(3, 0) void st_assume_log(httrackp *opt, int type,
+                                               const char *format,
+                                               va_list args) {
   (void) opt;
   (void) format;
   (void) args;
@@ -2650,8 +2651,9 @@ static int st_binputline(httrackp *opt, int argc, char **argv) {
 
 static int st_location_logged = 0;
 
-static void st_location_log(httrackp *opt, int type, const char *format,
-                            va_list args) {
+static HTS_PRINTF_FUN(3, 0) void st_location_log(httrackp *opt, int type,
+                                                 const char *format,
+                                                 va_list args) {
   (void) opt;
   (void) type;
   (void) format;
@@ -3531,8 +3533,9 @@ static int st_savename_addtail(httrackp *opt, int argc, char **argv) {
 
 static char st_log_callback_seen[256];
 
-static void st_log_callback(httrackp *opt, int type, const char *format,
-                            va_list args) {
+static HTS_PRINTF_FUN(3, 0) void st_log_callback(httrackp *opt, int type,
+                                                 const char *format,
+                                                 va_list args) {
   (void) opt;
   (void) type;
   (void) vsnprintf(st_log_callback_seen, sizeof(st_log_callback_seen), format,
@@ -8197,8 +8200,9 @@ static char st_cdx_log[2048];
 
 /* Collect the "WARC:" diagnostics only, so an unrelated message cannot satisfy
    (or break) a silence assertion. */
-static void st_cdx_log_cb(httrackp *opt, int type, const char *format,
-                          va_list args) {
+static HTS_PRINTF_FUN(3, 0) void st_cdx_log_cb(httrackp *opt, int type,
+                                               const char *format,
+                                               va_list args) {
   char line[512];
   (void) opt;
   (void) type;

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -225,7 +225,7 @@ HTSEXT_API void hts_log_print(httrackp *opt, int type, const char *format, ...)
 /** va_list form of hts_log_print(). @p opt may be NULL (only the callback
    runs). Preserves errno. @p format must be non-NULL. */
 HTSEXT_API void hts_log_vprint(httrackp *opt, int type, const char *format,
-                               va_list args);
+                               va_list args) HTS_PRINTF_FUN(3, 0);
 
 /** Install the process-global log callback invoked by hts_log_vprint() for
    every message, regardless of opt->debug (NULL clears it). Not per-opt. */

--- a/src/proxy/main.c
+++ b/src/proxy/main.c
@@ -47,9 +47,9 @@ static hts_boolean proxytrack_verbose = HTS_FALSE;
 /* Without a handler coucal writes to stderr itself, prefixing the table
    address; the per-enumeration statistics summary then lands on the operator's
    console once per WebDAV request (#918). */
-static void proxytrack_coucal_loghandler(coucal_opaque arg,
-                                         coucal_loglevel level,
-                                         const char *format, va_list args) {
+static HTS_PRINTF_FUN(3, 0) void proxytrack_coucal_loghandler(
+    coucal_opaque arg, coucal_loglevel level, const char *format,
+    va_list args) {
   const char *severity;
 
   (void) arg;

--- a/src/proxy/proxytrack.h
+++ b/src/proxy/proxytrack.h
@@ -78,8 +78,10 @@ HTS_UNUSED HTS_PRINTF_FUN(2, 0) static void proxytrack_vprint_log(
 }
 
 HTS_UNUSED
-HTS_PRINTF_FUN(2, 3) static void proxytrack_print_log(const char *severity,
-                                                      const char *format, ...) {
+HTS_PRINTF_FUN(2, 3)
+
+static void proxytrack_print_log(const char *severity, const char *format,
+                                 ...) {
   if (severity != NULL) {
     va_list args;
 

--- a/src/proxy/proxytrack.h
+++ b/src/proxy/proxytrack.h
@@ -63,8 +63,8 @@ int proxytrack_main(char *proxyAddr, int proxyPort, char *icpAddr, int icpPort,
 /* Static definitions */
 
 /* Log one line; a NULL severity discards it. */
-HTS_UNUSED static void proxytrack_vprint_log(const char *severity,
-                                             const char *format, va_list args) {
+HTS_UNUSED HTS_PRINTF_FUN(2, 0) static void proxytrack_vprint_log(
+    const char *severity, const char *format, va_list args) {
   if (severity != NULL) {
     const int error = errno;
     FILE *const fp = stderr;
@@ -77,8 +77,9 @@ HTS_UNUSED static void proxytrack_vprint_log(const char *severity,
   }
 }
 
-HTS_UNUSED static void proxytrack_print_log(const char *severity,
-                                            const char *format, ...) {
+HTS_UNUSED
+HTS_PRINTF_FUN(2, 3) static void proxytrack_print_log(const char *severity,
+                                                      const char *format, ...) {
   if (severity != NULL) {
     va_list args;
 


### PR DESCRIPTION
The log and debug forwarders take a printf format and hand it to a va_list sink, but none carried `HTS_PRINTF_FUN`, so gcc and clang never checked the format string at any call site. This adds it to eleven forwarders in `htslib.c`, `httrack-library.h`, `proxy/main.c`, `proxytrack.h` and `htsselftest.c`.

Nothing is silenced by this. gcc emits no `-Wformat-nonliteral` for a va_list sink, so the baseline was already zero warnings; what the attribute buys is checking at the call sites. Mutating two of them with a wrong specifier compiles silently on master and warns with this change.

`hts_template_formatv` and its wrappers are left alone on purpose. Their `%s`-only language ignores other specifiers and takes a mandatory NULL sentinel, so annotating them produces eight warnings on valid existing call sites.

The change is attribute-only: `nm -D --defined-only libhttrack.so` is byte-identical before and after, and `HTS_PRINTF_FUN` expands to nothing outside gcc and clang.