### PR TITLE
Test the index bound before reading the character it guards

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -2444,14 +2444,14 @@ void host_ban(httrackp * opt, int ptr,
 
   // effacer liens
   for (i = 0; i < opt->lien_tot; i++) {
-    // Calcul de taille sécurisée
+    // bounded length
     if (heap(i)) {
       if (heap(i)->adr) {
         int l = 0;
 
         while (l < 1020 && heap(i)->adr[l] != '\0')
           l++;
-        if ((l > 0) && (l < 1020)) {    // sécurité
+        if ((l > 0) && (l < 1020)) { // in range
           if (strfield2(jump_identification_const(heap(i)->adr), host)) {    // host
             hts_log_print(opt, LOG_DEBUG, "Cancel: %s%s", heap(i)->adr,
                           heap(i)->fil);

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -2449,7 +2449,7 @@ void host_ban(httrackp * opt, int ptr,
       if (heap(i)->adr) {
         int l = 0;
 
-        while((heap(i)->adr[l]) && (l < 1020))
+        while (l < 1020 && heap(i)->adr[l] != '\0')
           l++;
         if ((l > 0) && (l < 1020)) {    // sécurité
           if (strfield2(jump_identification_const(heap(i)->adr), host)) {    // host

--- a/src/htsfilters.c
+++ b/src/htsfilters.c
@@ -248,6 +248,18 @@ const char *strjoker_bounds(const char *chaine, const char *joker,
   return r;
 }
 
+/* Index of the class terminator `right` in a "*[...]" joker, scanning past the
+   two-character prefix; the index of the NUL when the class is unterminated.
+   The bound is tested first, so joker[i] is only read once i is in range. */
+static int joker_class_end(const char *joker, char right) {
+  const int len = (int) strlen(joker);
+  int i = 2;
+
+  while (i < len && joker[i] != right)
+    i++;
+  return i;
+}
+
 static const char *strjoker_impl(strjoker_memo *memo, const char *chaine,
                                  const char *joker, LLint *size, int *size_flag,
                                  size_t depth) {
@@ -299,37 +311,19 @@ static const char *strjoker_impl(strjoker_memo *memo, const char *chaine,
         pass[(int) '?'] = 0;
         //pass[(int) ';'] = 0;
         pass[(int) '/'] = 0;
-        i = 2;
-        {
-          int len = (int) strlen(joker);
-
-          while((joker[i] != RIGHT) && (joker[i]) && (i < len))
-            i++;
-        }
+        i = joker_class_end(joker, RIGHT);
       } else if (strfield(joker + 2, "path")) {
         for(i = 0; i < 256; i++)
           pass[i] = 1;
         pass[(int) '?'] = 0;
         //pass[(int) ';'] = 0;
-        i = 2;
-        {
-          int len = (int) strlen(joker);
-
-          while((joker[i] != RIGHT) && (joker[i]) && (i < len))
-            i++;
-        }
+        i = joker_class_end(joker, RIGHT);
       } else if (strfield(joker + 2, "param")) {
         if (chaine[0] == '?') { // il y a un paramètre juste là
           for(i = 0; i < 256; i++)
             pass[i] = 1;
         }                       // sinon synonyme de 'rien'
-        i = 2;
-        {
-          int len = (int) strlen(joker);
-
-          while((joker[i] != RIGHT) && (joker[i]) && (i < len))
-            i++;
-        }
+        i = joker_class_end(joker, RIGHT);
       } else {
         // décode les directives comme *[A-Z,âêîôû,0-9]
         i = 2;
@@ -340,7 +334,7 @@ static const char *strjoker_impl(strjoker_memo *memo, const char *chaine,
           int nbounds = 0;  // size bounds read so far, all satisfied
           LLint slimit = 0; // last of them, reported back as the limit
 
-          while((joker[i] != RIGHT) && (joker[i]) && (i < len)) {
+          while (i < len && joker[i] != RIGHT) {
             // '\' escapes the next char as a literal member, e.g. *[\[\]]
             if (joker[i] == '\\' && joker[i + 1] != '\0') {
               i++;

--- a/src/htsfilters.c
+++ b/src/htsfilters.c
@@ -248,9 +248,8 @@ const char *strjoker_bounds(const char *chaine, const char *joker,
   return r;
 }
 
-/* Index of the class terminator `right` in a "*[...]" joker, scanning past the
-   two-character prefix; the index of the NUL when the class is unterminated.
-   The bound is tested first, so joker[i] is only read once i is in range. */
+/* Index of the class terminator `right` in a "*[...]" joker, scanned past the
+   two-character prefix; the index of the NUL if the class is unterminated. */
 static int joker_class_end(const char *joker, char right) {
   const int len = (int) strlen(joker);
   int i = 2;

--- a/tests/334_engine-filter-unterminated-class.test
+++ b/tests/334_engine-filter-unterminated-class.test
@@ -6,9 +6,8 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-# A *[...] class with no closing bracket: the scan for it stops on the end of
-# the pattern, and what follows the star is skipped as for a closed class.
-# Verdicts pinned from the behavior predating joker_class_end().
+# Where the *[...] class scan stops, terminated and not. Verdicts pinned to the
+# behavior predating joker_class_end().
 
 match() { selftest_queue "$2 does match $1" filter "$1" "$2"; }
 nomatch() { selftest_queue "$2 does NOT match $1" filter "$1" "$2"; }
@@ -37,6 +36,17 @@ nomatch '*[' 'abc'
 # the '(' form scans for its own terminator
 nomatch '*(a' 'abc'
 nomatch '*(file' 'abc'
+
+# A terminated class is where the returned index is observable: it decides where
+# the pattern resumes, so a wrong one changes the verdict rather than nothing.
+match '*[file]x' 'abcx'
+nomatch '*[file]x' 'abc'
+nomatch '*[file]x' 'a/bx'
+match '*[file]' 'abc'
+match '*[file]/a' 'abc/a'
+nomatch '*(file)' 'abc'
+match '*[a-z]x' 'abcx'
+nomatch '*[a-z]x' 'abc9x'
 
 # an unterminated size bound stays neutral
 nomatch '*[<10' 'abc'

--- a/tests/334_engine-filter-unterminated-class.test
+++ b/tests/334_engine-filter-unterminated-class.test
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+# A *[...] class with no closing bracket: the scan for it stops on the end of
+# the pattern, and what follows the star is skipped as for a closed class.
+# Verdicts pinned from the behavior predating joker_class_end().
+
+match() { selftest_queue "$2 does match $1" filter "$1" "$2"; }
+nomatch() { selftest_queue "$2 does NOT match $1" filter "$1" "$2"; }
+
+# reserved names keep their own semantics unterminated: [file]/[name] stop at
+# '/', [path] spans it
+match '*[file' 'abc'
+nomatch '*[file' 'a/b/x'
+match '*[name' 'abc'
+match '*[path' 'a/b/x'
+nomatch '*[param' 'a?x=1'
+
+# ranges and comma-separated members
+match '*[a-z' 'abc'
+nomatch '*[a-z' 'ABC9'
+match '*[A-Z,0-9' 'ABC9'
+nomatch '*[A-Z,0-9' 'abc'
+
+# a truncated range and a trailing escape are members, not a scan overrun
+nomatch '*[a-' 'abc'
+nomatch "*[\\" 'abc'
+
+# an empty unterminated class allows nothing
+nomatch '*[' 'abc'
+
+# the '(' form scans for its own terminator
+nomatch '*(a' 'abc'
+nomatch '*(file' 'abc'
+
+# an unterminated size bound stays neutral
+nomatch '*[<10' 'abc'
+
+selftest_run_queued


### PR DESCRIPTION
Five scans in the wildcard filter engine and in `host_ban()` put the index bound last in their conjunction, so the character read happens before the range check meant to authorize it. CodeQL reports all nine instances as `cpp/offset-use-before-range-check`.

No site reads out of bounds today. In `strjoker_impl()` a pattern only reaches the scan past a `joker[1]`/`joker[2]` guard, and `len` is `strlen(joker)`. The body's largest jump is itself gated on `joker[i + 2] != '\0'`, so the NUL retires the loop before the bound can matter. `heap(i)->adr` has one assignment in the tree, an arena strdup, so the read at index 1020 stays inside the allocation. Five million pattern/subject pairs compared against the pre-change build give byte-identical verdicts, and injecting a `len` longer than `strlen` does diverge, which is how I know the comparison can see this class at all.

The three identical body-less scans collapse into one `joker_class_end()`. The other two loops keep their bodies with the bound moved to the front.

Test 334 covers the class scan, terminated and not. The unterminated rows alone were vacuous for the helper: for an unterminated class every return from `len - 1` up gives the same verdict, so a helper written as `return strlen(joker)` passed all of them. The terminated rows make the returned index decide where the pattern resumes, which kills a helper returning `i + 1` or scanning for the wrong bracket. The remaining mutant, scanning to `i <= len`, changes no verdict at all because it reads `joker[len + 1]`; ASan catches that one, and the test does fail under the sanitize leg.