### PR TITLE
Two front ends send the update endpoint two different language parameters

### DIFF
--- a/html/server/help.html
+++ b/html/server/help.html
@@ -66,7 +66,7 @@ ${LANG_O16}...
 
 <tr><td class="tabCtrl" align="left">
 <a style="background:black;color: white" 
-   href="http://www.httrack.com/update.php3?Product=HTTrack&Version=${attr:HTTRACK_VERSIONID}&VersionStr=${attr:HTTRACK_VERSION}&Platform=${attr:HTS_PLATFORM}&LanguageId=${attr:lang}" target="_blank"
+   href="http://www.httrack.com/update.php3?Product=HTTrack&Version=${attr:HTTRACK_VERSIONID}&VersionStr=${attr:HTTRACK_VERSION}&Platform=${attr:HTS_PLATFORM}&Language=${attr:LANGUAGE_FILE}" target="_blank"
 			title='${html:LANG_O17}' onMouseOver="info('${js:LANG_O17}'); return true" onMouseOut="info('&nbsp;'); return true"
    >
 ${LANG_O17}...

--- a/tests/330_webhttrack-update-language-key.test
+++ b/tests/330_webhttrack-update-language-key.test
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+# The update link must name the language the way WinHTTrack does: Language=,
+# carrying the catalog basename, never the localized LANGUAGE_NAME (#1353).
+
+set -euo pipefail
+
+# shellcheck source=tests/webhttracklib.sh
+. "${0%"${0##*/}"}./webhttracklib.sh"
+
+htsserver_require
+distdir=${HTS_DISTDIR}
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_langkey.XXXXXX") || fail "no tmpdir"
+cleanup() {
+    htsserver_cleanup
+    rm -rf "${work}"
+}
+cleanup_push cleanup
+
+root="${work}/root"
+mkdir -p "${root}"
+cp -R "${distdir}/html" "${distdir}/lang" "${distdir}/lang.def" "${root}/"
+chmod -R u+w "${root}"
+
+# LANGUAGE_NAME differs from LANGUAGE_FILE, and carries a high byte the way the
+# shipped endonyms do, so a render that reaches for the wrong key is visible
+# rather than merely equal.
+eacute=$(printf '\351')
+printf '%s\r\n' \
+    LANGUAGE_NAME "Fran${eacute}ais-1353" \
+    LANGUAGE_FILE 'Francais' \
+    LANGUAGE_ISO 'fr' \
+    LANGUAGE_CHARSET 'iso-8859-1' \
+    OK 'OK' \
+    Cancel 'Annuler' \
+    >"${root}/lang/Francais.txt"
+
+printf 'path=/tmp\r\nlang=\r\n' >"${work}/.httrack.ini"
+
+printf '[the update link names the language as WinHTTrack does] ..\t'
+htsserver_start --root "${root}" --home "${work}"
+
+"${HTS_PYTHON}" - "${HTS_URL}" <<'PY' || fail "the update link names the language wrongly (see above)"
+import re, sys, urllib.parse, urllib.request
+
+url = sys.argv[1].rstrip("/")
+form = urllib.request.urlopen(url + "/server/index.html", timeout=20).read()
+m = re.search(rb'name="sid" value="([0-9a-f]+)"', form)
+if not m:
+    sys.exit("no session id in server/index.html")
+sid = m.group(1).decode()
+
+req = urllib.request.Request(
+    url + "/server/help.html",
+    data=urllib.parse.urlencode({"sid": sid, "lang": "2"}).encode("latin-1"),
+    method="POST")
+body = urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
+if 'lang="fr"' not in body:
+    sys.exit("help.html did not switch to LANGUAGE_2:\n%s" % body[:2000])
+
+m = re.search(r'update\.php3\?([^"\']+)', body)
+if not m:
+    sys.exit("no update.php3 link in help.html:\n%s" % body[:2000])
+query = m.group(1).replace("&amp;", "&")
+fields = dict(urllib.parse.parse_qsl(query, keep_blank_values=True))
+
+# WinHTTrack's key, so one endpoint sees one parameter from both front ends.
+if "Language" not in fields:
+    sys.exit("no Language= in the update link: %s" % query)
+if "LanguageId" in fields:
+    sys.exit("LanguageId= is still sent, so the two front ends disagree: %s" % query)
+
+# The basename, not the endonym: the mutant this test exists to kill.
+if fields["Language"] != "Francais":
+    sys.exit("Language=%r, want the catalog basename 'Francais'" % fields["Language"])
+
+# The endpoint cannot decode a per-catalog codepage, so the value must be ASCII.
+try:
+    fields["Language"].encode("ascii")
+except UnicodeEncodeError:
+    sys.exit("Language=%r is not ASCII" % fields["Language"])
+
+# The other fields still resolve, so an empty render cannot pass the checks above.
+for key in ("Product", "Version", "VersionStr", "Platform"):
+    if not fields.get(key):
+        sys.exit("%s= is empty in the update link: %s" % (key, query))
+PY
+
+printf 'ok\n'

--- a/tests/330_webhttrack-update-language-key.test
+++ b/tests/330_webhttrack-update-language-key.test
@@ -51,40 +51,48 @@ if not m:
     sys.exit("no session id in server/index.html")
 sid = m.group(1).decode()
 
-req = urllib.request.Request(
-    url + "/server/help.html",
-    data=urllib.parse.urlencode({"sid": sid, "lang": "2"}).encode("latin-1"),
-    method="POST")
-body = urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
-if 'lang="fr"' not in body:
-    sys.exit("help.html did not switch to LANGUAGE_2:\n%s" % body[:2000])
+def link_fields(lang):
+    req = urllib.request.Request(
+        url + "/server/help.html",
+        data=urllib.parse.urlencode({"sid": sid, "lang": lang}).encode("latin-1"),
+        method="POST")
+    body = urllib.request.urlopen(req, timeout=20).read().decode("latin-1")
+    m = re.search(r'update\.php3\?([^"\']+)', body)
+    if not m:
+        sys.exit("no update.php3 link in help.html at lang=%s:\n%s" % (lang, body[:2000]))
+    query = m.group(1).replace("&amp;", "&")
+    return body, query, dict(urllib.parse.parse_qsl(query, keep_blank_values=True))
 
-m = re.search(r'update\.php3\?([^"\']+)', body)
-if not m:
-    sys.exit("no update.php3 link in help.html:\n%s" % body[:2000])
-query = m.group(1).replace("&amp;", "&")
-fields = dict(urllib.parse.parse_qsl(query, keep_blank_values=True))
 
-# WinHTTrack's key, so one endpoint sees one parameter from both front ends.
-if "Language" not in fields:
-    sys.exit("no Language= in the update link: %s" % query)
-if "LanguageId" in fields:
-    sys.exit("LanguageId= is still sent, so the two front ends disagree: %s" % query)
+# Two languages, because one cannot tell "renders the basename" apart from
+# "prints a constant". lang=2 uses the fixture whose LANGUAGE_NAME differs;
+# lang=3 is the shipped Castellano.
+for lang, iso, want in (("2", "fr", "Francais"), ("3", "es", "Castellano")):
+    body, query, fields = link_fields(lang)
+    if 'lang="%s"' % iso not in body:
+        sys.exit("help.html did not switch to LANGUAGE_%s:\n%s" % (lang, body[:2000]))
 
-# The basename, not the endonym: the mutant this test exists to kill.
-if fields["Language"] != "Francais":
-    sys.exit("Language=%r, want the catalog basename 'Francais'" % fields["Language"])
+    # WinHTTrack's key, so one endpoint sees one parameter from both front ends.
+    if "Language" not in fields:
+        sys.exit("no Language= in the update link at lang=%s: %s" % (lang, query))
+    if "LanguageId" in fields:
+        sys.exit("LanguageId= is still sent, so the front ends disagree: %s" % query)
 
-# The endpoint cannot decode a per-catalog codepage, so the value must be ASCII.
-try:
-    fields["Language"].encode("ascii")
-except UnicodeEncodeError:
-    sys.exit("Language=%r is not ASCII" % fields["Language"])
+    # The basename, not the endonym: the mutant this test exists to kill.
+    if fields["Language"] != want:
+        sys.exit("lang=%s gave Language=%r, want the basename %r"
+                 % (lang, fields["Language"], want))
 
-# The other fields still resolve, so an empty render cannot pass the checks above.
-for key in ("Product", "Version", "VersionStr", "Platform"):
-    if not fields.get(key):
-        sys.exit("%s= is empty in the update link: %s" % (key, query))
+    # The endpoint cannot decode a per-catalog codepage, so the value is ASCII.
+    try:
+        fields["Language"].encode("ascii")
+    except UnicodeEncodeError:
+        sys.exit("Language=%r is not ASCII" % fields["Language"])
+
+    # The other fields still resolve, so an empty render cannot pass the above.
+    for key in ("Product", "Version", "VersionStr", "Platform"):
+        if not fields.get(key):
+            sys.exit("%s= is empty in the update link: %s" % (key, query))
 PY
 
 printf 'ok\n'

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -155,6 +155,26 @@ else
     fi
 fi
 
+# LANGUAGE_FILE is the catalog basename and reaches the network as the update
+# link's Language= (#1353), so it must exist, be ASCII, and match the filename.
+# The loader backfills an absent key from English, which would silently report
+# the wrong language rather than nothing.
+for f in "$langdir"/*.txt; do
+    base=${f##*/}
+    base=${base%.txt}
+    lf=$(field "$f" LANGUAGE_FILE)
+    if [ -z "$lf" ]; then
+        echo "$base.txt: no LANGUAGE_FILE; the loader would report English instead"
+        fail=1
+    elif [ "$lf" != "$base" ]; then
+        echo "$base.txt: LANGUAGE_FILE is \"$lf\", not the basename"
+        fail=1
+    elif printf '%s' "$lf" | LC_ALL=C grep -q '[^ -~]'; then
+        echo "$base.txt: LANGUAGE_FILE \"$lf\" is not ASCII; the update endpoint cannot decode it"
+        fail=1
+    fi
+done
+
 # LANGUAGE_NAME must be the endonym, not English: the menu shows every catalog
 # together (#116). Two oracles rather than a copy of the current values, so the
 # name may repeat neither a word of the catalog's own English LANGUAGE_WINDOWSID


### PR DESCRIPTION
WebHTTrack hand-builds the update-check URL in `help.html` and sends `LanguageId=${attr:lang}`, a 1-based menu index. WinHTTrack formats `HTS_UPDATE_WEBSITE` and sends `Language=`. Two front ends, one endpoint, two different parameters — so `update.php` has only ever seen the language of one of them, and the #1353 server fix hardened a field WebHTTrack never populated.

WinHTTrack's spelling wins, so WebHTTrack moves to `Language=`, carrying `LANGUAGE_FILE`. That is the same value WinHTTrack now sends after httrack-windows#137, and #1353 explains why it has to be the basename rather than `LANGUAGE_NAME`: a display name is localized, sits in its catalog's own legacy codepage, and the endpoint cannot decode it. `LANGSEL` already resolves any catalog key through `${attr:}` — every template already uses `${attr:LANGUAGE_ISO}` — so this needs no engine change.

Test 330 renders `help.html` under a catalog whose `LANGUAGE_NAME` differs from its `LANGUAGE_FILE` and carries a high byte, so a render reaching for the wrong key is visibly wrong rather than accidentally equal. Three mutants killed with the applied text verified each time: the old `LanguageId=`, the endonym, and the ISO code. The first attempt at that mutant run reported a survivor, which turned out to be perl interpreting `${attr:...}` as a variable so the substitution never landed.
