### PR TITLE
Fold the exact-count fread/fwrite comparisons onto two helpers

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -90,7 +90,7 @@ libhttrack_la_SOURCES =  htscore.c htsparse.c htsback.c htscache.c \
 	htsbasenet.h htsbauth.h htscache.h htscache_selftest.h htsdns_selftest.h htsselftest.h htscatchurl.h  \
 	htscmdline.h htsconfig.h htscore.h htsparse.h htscoremain.h htsdefines.h  \
 	htsfilters.h htsftp.h htsglobal.h htshash.h coucal/coucal.h \
-	htshelp.h htsindex.h htslib.h htsurlport.h htsmd5.h \
+	htshelp.h htsindex.h htsio.h htslib.h htsurlport.h htsmd5.h \
 	htsmodules.h htsname.h htsnet.h htssniff.h \
 	htsopt.h htsrobots.h htsthread.h  \
 	htscrashtest.h htstools.h htsrandom.h htswizard.h htswrap.h htscodec.h htswarc.h htschanges.h htssinglefile.h htssitemap.h htsproxy.h htszlib.h  \

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -37,6 +37,7 @@ Please visit our Website: http://www.httrack.com
 /* specific definitions */
 #include "htsnet.h"
 #include "htscore.h"
+#include "htsio.h"
 #include "htswarc.h"
 #include "htschanges.h"
 #include "htsthread.h"
@@ -901,9 +902,9 @@ int back_finalize(httrackp * opt, cache_back * cache, struct_back * sback,
                 back[p].r.out = FOPEN(back[p].tmpfile, "wb");
                 if (back[p].r.out) {
                   if ((back[p].r.adr) && (back[p].r.size > 0)) {
-                    if (fwrite
-                        (back[p].r.adr, 1, (size_t) back[p].r.size,
-                         back[p].r.out) != back[p].r.size) {
+                    if (!hts_fwrite_exact(back[p].r.adr,
+                                          (size_t) back[p].r.size,
+                                          back[p].r.out)) {
                       back[p].r.statuscode = STATUSCODE_INVALID;
                       strcpybuff(back[p].r.msg,
                                  "Write error when decompressing");
@@ -1072,7 +1073,7 @@ int back_finalize(httrackp * opt, cache_back * cache, struct_back * sback,
                   if (fp) {
                     back[p].r.adr = malloct((size_t) sz + 1);
                     if (back[p].r.adr) {
-                      if (fread(back[p].r.adr, 1, sz, fp) == sz) {
+                      if (hts_fread_exact(back[p].r.adr, (size_t) sz, fp)) {
                         back[p].r.size = sz;
                         back[p].r.adr[sz] = '\0';
                         back[p].r.is_write = 0; /* not anymore a direct-to-disk file */
@@ -1368,9 +1369,8 @@ void back_copy_static(const lien_back * src, lien_back * dst) {
 }
 
 static int back_data_serialize(FILE * fp, const void *data, size_t size) {
-  if (fwrite(&size, 1, sizeof(size), fp) == sizeof(size)
-      && (size == 0 || fwrite(data, 1, size, fp) == size)
-    )
+  if (hts_fwrite_exact(&size, sizeof(size), fp) &&
+      (size == 0 || hts_fwrite_exact(data, size, fp)))
     return 0;
   return 1;                     /* error */
 }
@@ -1383,14 +1383,14 @@ static int back_string_serialize(FILE * fp, const char *str) {
 
 static int back_data_unserialize(FILE * fp, void **str, size_t * size) {
   *str = NULL;
-  if (fread(size, 1, sizeof(*size), fp) == sizeof(*size)) {
+  if (hts_fread_exact(size, sizeof(*size), fp)) {
     if (*size == 0)             /* serialized NULL ptr */
       return 0;
     *str = malloct(*size + 1);
     if (*str == NULL)
       return 1;                 /* error */
     ((char *) *str)[*size] = 0; /* guard byte */
-    if (fread(*str, 1, *size, fp) == *size)
+    if (hts_fread_exact(*str, *size, fp))
       return 0;
   }
   return 1;                     /* error */
@@ -4515,8 +4515,8 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                               back[i].r.size = resume;
                               if (back[i].r.totalsize >= 0)
                                 back[i].r.totalsize += resume; // -> full size
-                              if ((fread(back[i].r.adr, 1, (size_t) resume,
-                                         fp)) != (size_t) resume) {
+                              if (!hts_fread_exact(back[i].r.adr,
+                                                   (size_t) resume, fp)) {
                                 back[i].status = STATUS_READY;  // terminé (voir plus loin)
                                 back_set_finished(sback, i);
                                 strcpybuff(back[i].r.msg,

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -1368,7 +1368,7 @@ char *readfile2(const char *fil, LLint * size) {
         *size = len;
       if (adr != NULL) {
         if (buflen > 0 &&
-            !hts_fread_exact(adr, buflen, fp)) { // fichier endommagé ?
+            !hts_fread_exact(adr, buflen, fp)) { // file corrupted?
           freet(adr);
           adr = NULL;
         } else
@@ -1399,7 +1399,7 @@ char *readfile2_utf8(const char *fil, LLint *size) {
       adr = (char *) malloct(buflen + 1);
       if (adr != NULL) {
         if (buflen > 0 &&
-            !hts_fread_exact(adr, buflen, fp)) { // fichier endommagé ?
+            !hts_fread_exact(adr, buflen, fp)) { // file corrupted?
           freet(adr);
           adr = NULL;
         } else {

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -38,6 +38,7 @@ Please visit our Website: http://www.httrack.com
 
 /* specific definitions */
 #include "htscore.h"
+#include "htsio.h"
 #include "htsbasenet.h"
 #include "htsmd5.h"
 #include <limits.h>
@@ -799,7 +800,8 @@ static htsblk cache_readex_new(httrackp * opt, cache_back * cache,
                                            (int) minimum(size, 32768));
                       if (nl > 0) {
                         size -= nl;
-                        if (fwrite(buff, 1, nl, r.out) != nl) { // erreur
+                        if (!hts_fwrite_exact(buff, (size_t) nl,
+                                              r.out)) { // erreur
                           int last_errno = errno;
 
                           r.statuscode = STATUSCODE_INVALID;
@@ -862,8 +864,8 @@ static htsblk cache_readex_new(httrackp * opt, cache_back * cache,
                   if (fp != NULL) {
                     r.adr = (char *) malloct((int) r.size + 1);
                     if (r.adr != NULL) {
-                      if (r.size > 0
-                          && fread(r.adr, 1, (int) r.size, fp) != r.size) {
+                      if (r.size > 0 &&
+                          !hts_fread_exact(r.adr, (size_t) r.size, fp)) {
                         int last_errno = errno;
 
                         r.statuscode = STATUSCODE_INVALID;
@@ -1366,7 +1368,7 @@ char *readfile2(const char *fil, LLint * size) {
         *size = len;
       if (adr != NULL) {
         if (buflen > 0 &&
-            fread(adr, 1, buflen, fp) != buflen) { // fichier endommagé ?
+            !hts_fread_exact(adr, buflen, fp)) { // fichier endommagé ?
           freet(adr);
           adr = NULL;
         } else
@@ -1397,7 +1399,7 @@ char *readfile2_utf8(const char *fil, LLint *size) {
       adr = (char *) malloct(buflen + 1);
       if (adr != NULL) {
         if (buflen > 0 &&
-            fread(adr, 1, buflen, fp) != buflen) { // fichier endommagé ?
+            !hts_fread_exact(adr, buflen, fp)) { // fichier endommagé ?
           freet(adr);
           adr = NULL;
         } else {
@@ -1440,9 +1442,9 @@ int cache_wstr(FILE * fp, const char *s) {
 
   i = (s != NULL) ? ((INTsys) strlen(s)) : 0;
   sprintf(buff, INTsysP "\n", i);
-  if (fwrite(buff, 1, strlen(buff), fp) != strlen(buff))
+  if (!hts_fwrite_exact(buff, strlen(buff), fp))
     return -1;
-  if (i > 0 && fwrite(s, 1, i, fp) != i)
+  if (i > 0 && !hts_fwrite_exact(s, (size_t) i, fp))
     return -1;
   return 0;
 }
@@ -1461,7 +1463,7 @@ void cache_rstr(FILE *fp, char *s, size_t s_size) {
     const size_t want = (size_t) i;
     const size_t store = want < s_size ? want : s_size - 1;
 
-    if (fread(s, 1, store, fp) != store) {
+    if (!hts_fread_exact(s, store, fp)) {
       int fread_cache_failed = 0;
 
       assertf(fread_cache_failed);
@@ -1488,7 +1490,7 @@ char *cache_rstr_addr(FILE * fp) {
   if (i > 0) {
     addr = malloct(i + 1);
     if (addr != NULL) {
-      if ((int) fread(addr, 1, i, fp) != i) {
+      if (!hts_fread_exact(addr, (size_t) i, fp)) {
         int fread_cache_failed = 0;
 
         assertf(fread_cache_failed);

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -45,6 +45,7 @@ Please visit our Website: http://www.httrack.com
 #include "htscache.h"
 #include "htscore.h"
 #include "htslib.h"
+#include "htsio.h"
 #include "htszlib.h"
 
 #include <errno.h>
@@ -268,7 +269,7 @@ static int disk_fallback_selftest(httrackp *opt) {
             path);
     return 1;
   }
-  if (fwrite(body, 1, body_len, fp) != body_len) {
+  if (!hts_fwrite_exact(body, body_len, fp)) {
     fprintf(stderr, "cache-selftest: disk-fallback: short write to '%s'\n",
             path);
     fail++;
@@ -1050,7 +1051,7 @@ static void reconcile_put(httrackp *opt, const char *name, size_t size) {
   while (size > 0) {
     const size_t n = size > sizeof(filler) ? sizeof(filler) : size;
 
-    assertf(fwrite(filler, 1, n, fp) == n);
+    assertf(hts_fwrite_exact(filler, n, fp));
     size -= n;
   }
   fclose(fp);
@@ -1443,7 +1444,7 @@ static void corrupt_patch(httrackp *opt, const char *pat, size_t patlen,
   memcpy(data + at, rep, patlen);
   fp = fopen(reconcile_st_path(opt, "hts-cache/new.zip"), "wb");
   assertf(fp != NULL);
-  assertf(fwrite(data, 1, n, fp) == n);
+  assertf(hts_fwrite_exact(data, n, fp));
   fclose(fp);
   freet(data);
 }
@@ -1472,7 +1473,7 @@ static void corrupt_victim_body(httrackp *opt) {
   memset(data + off, 0xFF, 4);
   fp = fopen(reconcile_st_path(opt, "hts-cache/new.zip"), "wb");
   assertf(fp != NULL);
-  assertf(fwrite(data, 1, n, fp) == n);
+  assertf(hts_fwrite_exact(data, n, fp));
   fclose(fp);
   freet(data);
 }

--- a/src/htschanges.c
+++ b/src/htschanges.c
@@ -40,6 +40,7 @@ Please visit our Website: http://www.httrack.com
 #include "htscharset.h"
 #include "htscore.h"
 #include "htslib.h"
+#include "htsio.h"
 #include "htsmd5.h"
 #include "htssafe.h"
 #include "htsthread.h"
@@ -636,7 +637,7 @@ void hts_changes_close_opt(httrackp *opt) {
   if (fp != NULL) {
     const size_t len = StringLength(report);
 
-    if (len != 0 && fwrite(StringBuff(report), 1, len, fp) != len)
+    if (len != 0 && !hts_fwrite_exact(StringBuff(report), len, fp))
       hts_log_print(opt, LOG_ERROR | LOG_ERRNO,
                     "Unable to write the change report %s", path);
     fclose(fp);

--- a/src/htscodec.c
+++ b/src/htscodec.c
@@ -36,6 +36,7 @@ Please visit our Website: http://www.httrack.com
 #include "htsbase.h"
 #include "htscore.h"
 #include "htscodec.h"
+#include "htsio.h"
 #include "htszlib.h"
 
 #if HTS_USEBROTLI
@@ -132,7 +133,7 @@ static hts_boolean codec_sink(FILE *out, const void *buf, size_t produced,
   *total += (LLint) produced;
   if (*total > maxout)
     return HTS_FALSE;
-  return fwrite(buf, 1, produced, out) == produced ? HTS_TRUE : HTS_FALSE;
+  return hts_fwrite_exact(buf, produced, out);
 }
 #endif
 

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -46,6 +46,7 @@ Please visit our Website: http://www.httrack.com
 
 /* specific definitions */
 #include "htsbase.h"
+#include "htsio.h"
 #include "htsnet.h"
 #include "htsbauth.h"
 #include "htsmd5.h"
@@ -410,7 +411,7 @@ void hts_finish_html_file(httrackp *opt, cache_back *cache, htsblk *r,
     hts_changes_html(opt, cache, r, adr, fil, save);
     *fp = filecreate(&opt->state.strc, save);
     if (*fp) {
-      if (ht_len > 0 && fwrite(ht_buff, 1, ht_len, *fp) != ht_len) {
+      if (ht_len > 0 && !hts_fwrite_exact(ht_buff, (size_t) ht_len, *fp)) {
         int fcheck = check_fatal_io_errno();
 
         if (fcheck)
@@ -841,7 +842,7 @@ int httpmirror(char *url1, httrackp * opt) {
           filelist_buff = malloct(filelist_sz + 1);
           if (filelist_buff == NULL) {
             filelist_err = "out of memory";
-          } else if (fread(filelist_buff, 1, filelist_sz, fp) != filelist_sz) {
+          } else if (!hts_fread_exact(filelist_buff, filelist_sz, fp)) {
             freet(filelist_buff);
             filelist_err = "read error";
           } else {
@@ -2129,7 +2130,7 @@ int httpmirror(char *url1, httrackp * opt) {
           char *adr = (char *) malloct(sz + 1);
 
           if (adr) {
-            if (fread(adr, 1, sz, new_lst) == sz) {
+            if (hts_fread_exact(adr, (size_t) sz, new_lst)) {
               adr[sz] = '\0';
               char line[1100];
               int purge = 0;
@@ -2840,13 +2841,13 @@ int filesave(httrackp * opt, const char *adr, int len, const char *s,
 
   // écrire le fichier
   if ((fp = filecreate(&opt->state.strc, s)) != NULL) {
-    int nl = 0;
+    hts_boolean written = (len == 0);
 
     if (len > 0) {
-      nl = (int) fwrite(adr, 1, len, fp);
+      written = hts_fwrite_exact(adr, (size_t) len, fp);
     }
     fclose(fp);
-    if (nl != len)              // erreur
+    if (!written) // erreur
       return -1;
   } else
     return -1;

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -2847,7 +2847,7 @@ int filesave(httrackp * opt, const char *adr, int len, const char *s,
       written = hts_fwrite_exact(adr, (size_t) len, fp);
     }
     fclose(fp);
-    if (!written) // erreur
+    if (!written) // error
       return -1;
   } else
     return -1;

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -38,6 +38,7 @@ Please visit our Website: http://www.httrack.com
 
 #include "htsglobal.h"
 #include "htscore.h"
+#include "htsio.h"
 #include "htsdefines.h"
 #include "htsalias.h"
 #include "htswarc.h"
@@ -1629,7 +1630,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                         url[cl] = ' ';
                         cl++;
                       }
-                      if (fread(url + cl, 1, fzs, fp) != fzs) {
+                      if (!hts_fread_exact(url + cl, (size_t) fzs, fp)) {
                         fclose(fp);
                         HTS_PANIC_PRINTF("File url list could not be read");
                         htsmain_free();

--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -39,6 +39,7 @@ Please visit our Website: http://www.httrack.com
 #include "htsftp.h"
 
 #include "htscore.h"
+#include "htsio.h"
 #include "htsthread.h"
 
 #include <limits.h>
@@ -922,8 +923,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
                   back->r.size += len;
                   HTS_STAT.HTS_TOTAL_RECV += len;
                   if (back->r.fp) {
-                    if ((INTsys) fwrite(buff, 1, (INTsys) len, back->r.fp) !=
-                        len) {
+                    if (!hts_fwrite_exact(buff, (size_t) len, back->r.fp)) {
                       /*
                          int fcheck;
                          if ((fcheck=check_fatal_io_errno())) {

--- a/src/htshelp.c
+++ b/src/htshelp.c
@@ -41,6 +41,7 @@ Please visit our Website: http://www.httrack.com
 #include "htscoremain.h"
 #include "htscatchurl.h"
 #include "htslib.h"
+#include "htsio.h"
 #include "htstools.h"
 #include "htsalias.h"
 #include "htsmodules.h"
@@ -430,7 +431,7 @@ void help_catchurl(const char *dest_path) {
         FILE *fp = FOPEN(dest, "wb");
 
         if (fp) {
-          fwrite(data, strlen(data), 1, fp);
+          (void) hts_fwrite_exact(data, strlen(data), fp);
           fclose(fp);
         }
       }

--- a/src/htsindex.c
+++ b/src/htsindex.c
@@ -37,6 +37,7 @@ Please visit our Website: http://www.httrack.com
 #include "htsindex.h"
 #include "htsglobal.h"
 #include "htslib.h"
+#include "htsio.h"
 
 #if HTS_MAKE_KEYWORD_INDEX
 #include "htshash.h"
@@ -327,7 +328,7 @@ void index_finish(const char *indexpath, int mode) {
         blk = malloct(size + 1);
         if (blk) {
           fseek(fp_tmpproject, 0, SEEK_SET);
-          if ((INTsys) fread(blk, 1, size, fp_tmpproject) == size) {
+          if (hts_fread_exact(blk, (size_t) size, fp_tmpproject)) {
             char *a = blk, *b;
             int index = 0;
             int i;
@@ -440,7 +441,6 @@ void index_finish(const char *indexpath, int mode) {
                 fprintf(fp, "</td></tr>\r\n</table>\r\n");
               fclose(fp);
             }
-
           }
           freet(blk);
         }

--- a/src/htsio.h
+++ b/src/htsio.h
@@ -1,0 +1,58 @@
+/* ------------------------------------------------------------ */
+/*
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) 2026 Xavier Roche and other contributors
+
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Ethical use: we kindly ask that you NOT use this software to harvest email
+addresses or to collect any other private information about people. Doing so
+would dishonor our work and waste the many hours we have spent on it.
+
+Please visit our Website: http://www.httrack.com
+*/
+
+/* ------------------------------------------------------------ */
+/* File: htsio.h all-or-nothing stdio helpers                   */
+/* Author: Xavier Roche                                         */
+/* ------------------------------------------------------------ */
+
+#ifndef HTSIO_DEFH
+#define HTSIO_DEFH
+
+#include <stdio.h>
+
+#include "htsglobal.h"
+
+/** Read exactly size bytes into dest. HTS_TRUE only when the whole block was
+    read; a short read, EOF or error alike, is a failure. A zero size succeeds
+    without touching dest. Wrong for a read-to-EOF loop, which must keep the
+    count fread() returns. **/
+static HTS_INLINE HTS_UNUSED hts_boolean hts_fread_exact(void *dest,
+                                                         size_t size,
+                                                         FILE *fp) {
+  return fread(dest, 1, size, fp) == size ? HTS_TRUE : HTS_FALSE;
+}
+
+/** Write exactly size bytes from src. HTS_TRUE only when the whole block
+    reached fp; a zero size succeeds. **/
+static HTS_INLINE HTS_UNUSED hts_boolean hts_fwrite_exact(const void *src,
+                                                          size_t size,
+                                                          FILE *fp) {
+  return fwrite(src, 1, size, fp) == size ? HTS_TRUE : HTS_FALSE;
+}
+
+#endif

--- a/src/htsio.h
+++ b/src/htsio.h
@@ -38,9 +38,9 @@ Please visit our Website: http://www.httrack.com
 #include "htsglobal.h"
 
 /** Read exactly size bytes into dest. HTS_TRUE only when the whole block was
-    read; a short read, EOF or error alike, is a failure. A zero size succeeds
-    without touching dest. Wrong for a read-to-EOF loop, which must keep the
-    count fread() returns. **/
+    read; a short read, EOF or error alike, is a failure, with errno left as
+    fread() set it. A zero size succeeds without touching dest. Wrong for a
+    read-to-EOF loop, which must keep the count fread() returns. **/
 static HTS_INLINE HTS_UNUSED hts_boolean hts_fread_exact(void *dest,
                                                          size_t size,
                                                          FILE *fp) {
@@ -48,7 +48,8 @@ static HTS_INLINE HTS_UNUSED hts_boolean hts_fread_exact(void *dest,
 }
 
 /** Write exactly size bytes from src. HTS_TRUE only when the whole block
-    reached fp; a zero size succeeds. **/
+    reached fp, with errno left as fwrite() set it; a zero size succeeds.
+    Best-effort writers ignore the verdict, so it is not HTS_CHECK_RESULT. **/
 static HTS_INLINE HTS_UNUSED hts_boolean hts_fwrite_exact(const void *src,
                                                           size_t size,
                                                           FILE *fp) {

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -43,6 +43,7 @@ Please visit our Website: http://www.httrack.com
 
 /* specific definitions */
 #include "htsbase.h"
+#include "htsio.h"
 #include "htsnet.h"
 #include "htsbauth.h"
 #include "htsthread.h"
@@ -2046,7 +2047,7 @@ LLint http_xfread1(htsblk * r, int bufl) {
         // nouvelle taille
         if (nl > 0) {
           r->size += nl;
-          if (fwrite(buff, 1, nl, r->out) != nl) {
+          if (!hts_fwrite_exact(buff, (size_t) nl, r->out)) {
             r->statuscode = STATUSCODE_INVALID;
             strcpybuff(r->msg, "Write error on disk");
             nl = READ_ERROR;

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -43,6 +43,7 @@ Please visit our Website: http://www.httrack.com
 
 /* specific definitions */
 #include "htsbase.h"
+#include "htsio.h"
 #include "htsnet.h"
 #include "htsbauth.h"
 #include "htsmd5.h"
@@ -2872,7 +2873,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                             HTTRACK_AFF_AUTHORS " -->" LF,
                                             cat_data);
                                   } else {      // data
-                                    fwrite(cat_data, cat_data_len, 1, fp);
+                                    (void) hts_fwrite_exact(
+                                        cat_data, (size_t) cat_data_len, fp);
                                   }
                                   fclose(fp);
                                   usercommand(opt, 0, NULL,

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -11586,6 +11586,39 @@ static int st_ioexact(httrackp *opt, int argc, char **argv) {
   assertf(hts_fwrite_exact(payload, 0, fp) == HTS_TRUE);
   assertf(fclose(fp) == 0);
 
+  /* Short WRITE: the cases above only ever get 0 back, so a helper accepting
+     any non-zero count survives them. fmemopen's buffer is smaller than the
+     payload, which yields a partial count instead. */
+#if !defined(_WIN32)
+  {
+    char small[8];
+    /* Short by many, then by exactly one: only the second catches a helper
+       that accepts an off-by-one count. */
+    const size_t over[2] = {sizeof(small) * 2, sizeof(small) + 1};
+
+    for (i = 0; i < 2; i++) {
+      /* Unbuffered, or stdio takes the whole payload and reports the overflow
+         only at flush, leaving fwrite's own count complete. */
+      FILE *mem = fmemopen(small, sizeof(small), "wb");
+
+      if (mem != NULL && setvbuf(mem, NULL, _IONBF, 0) == 0)
+        assertf(hts_fwrite_exact(payload, over[i], mem) == HTS_FALSE);
+      if (mem != NULL)
+        (void) fclose(mem);
+    }
+  }
+#endif
+
+  /* A zero size must leave dest alone rather than write a terminator. */
+  memset(readback, poison, 4);
+  fp = FOPEN(path, "rb");
+  assertf(fp != NULL);
+  assertf(hts_fread_exact(readback, 0, fp) == HTS_TRUE);
+  for (i = 0; i < 4; i++)
+    assertf((unsigned char) readback[i] == poison);
+  assertf(hts_fread_exact(NULL, 0, fp) == HTS_TRUE);
+  assertf(fclose(fp) == 0);
+
   assertf(UNLINK(path) == 0);
   freet(payload);
   freet(readback);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -47,6 +47,7 @@ Please visit our Website: http://www.httrack.com
 #include "htsback.h"
 #include "htsdefines.h"
 #include "htslib.h"
+#include "htsio.h"
 #include "htsalias.h"
 #include "htsarrays.h"
 #include "htsparse.h"
@@ -1708,7 +1709,7 @@ static int st_hashtable(httrackp *opt, int argc, char **argv) {
     FILE *fp = fopen(snum, "rb");
     if (fp != NULL) {
       buff = malloct(size);
-      if (buff != NULL && fread(buff, 1, size, fp) == size) {
+      if (buff != NULL && hts_fread_exact(buff, (size_t) size, fp)) {
         size_t capa = 0;
         size_t i, last;
         for (i = 0, last = 0, count = 0; i < size; i++) {
@@ -3344,7 +3345,7 @@ static int st_savename(httrackp *opt, int argc, char **argv) {
     const size_t n = st_decode_body(body, data, sizeof(data));
     FILE *const fp = fopen(bodyfile, "wb");
 
-    if (fp == NULL || fwrite(data, 1, n, fp) != n) {
+    if (fp == NULL || !hts_fwrite_exact(data, n, fp)) {
       fprintf(stderr, "savename: can not write %s\n", bodyfile);
       return 1;
     }
@@ -3848,7 +3849,7 @@ static int st_zip_repair_shift(httrackp *opt, int argc, char **argv) {
   snprintf(out, sizeof(out), "%s/repair.zip", argv[0]);
   snprintf(tmp, sizeof(tmp), "%s/repair.tmp", argv[0]);
   fp = fopen(in, "wb");
-  if (fp == NULL || fwrite(zip, 1, sizeof(zip), fp) != sizeof(zip)) {
+  if (fp == NULL || !hts_fwrite_exact(zip, sizeof(zip), fp)) {
     if (fp != NULL)
       fclose(fp);
     fprintf(stderr, "zip-repair-shift: cannot write %s\n", in);
@@ -5649,7 +5650,7 @@ static char *makeindex_slurp(const char *path) {
   rewind(fp);
   buf = malloct((size_t) size + 1);
   /* a read error would otherwise render a silently truncated template */
-  assertf(fread(buf, 1, (size_t) size, fp) == (size_t) size);
+  assertf(hts_fread_exact(buf, (size_t) size, fp));
   buf[size] = '\0';
   fclose(fp);
   return buf;
@@ -6262,7 +6263,7 @@ static int ae_write_packed(const char *path, int windowBits,
     strm.avail_out = sizeof(out);
     zerr = deflate(&strm, Z_FINISH);
     n = sizeof(out) - strm.avail_out;
-    if (n > 0 && fwrite(out, 1, n, f) != n) {
+    if (n > 0 && !hts_fwrite_exact(out, n, f)) {
       deflateEnd(&strm);
       fclose(f);
       return 1;
@@ -6304,7 +6305,7 @@ static int ae_write_collision(const char *path, const unsigned char *src,
   memcpy(buf + p, src + n1, n2);
   p += n2;
   f = FOPEN(path, "wb");
-  ok = (f != NULL && fwrite(buf, 1, p, f) == p);
+  ok = (f != NULL && hts_fwrite_exact(buf, p, f));
   if (f != NULL)
     fclose(f);
   freet(buf);
@@ -6319,7 +6320,7 @@ static int ae_write_raw(const char *path, const unsigned char *src,
 
   if (f == NULL)
     return 1;
-  ok = fwrite(src, 1, len, f) == len;
+  ok = hts_fwrite_exact(src, len, f);
   fclose(f);
   return ok ? 0 : 1;
 }
@@ -8777,7 +8778,7 @@ static hts_boolean sf_try_put(const char *dir, const char *rel,
   fp = FOPEN(fconv(catbuff, sizeof(catbuff), path), "wb");
   if (fp == NULL)
     return HTS_FALSE;
-  assertf(len == 0 || fwrite(data, 1, len, fp) == len);
+  assertf(len == 0 || hts_fwrite_exact(data, len, fp));
   fclose(fp);
   return HTS_TRUE;
 }
@@ -9509,7 +9510,7 @@ static int st_longpath(httrackp *opt, int argc, char **argv) {
             strerror(errno));
     return 1;
   }
-  assertf(fwrite(payload, 1, sizeof(payload), fp) == sizeof(payload));
+  assertf(hts_fwrite_exact(payload, sizeof(payload), fp));
   fclose(fp);
 
   STRUCT_STAT st;
@@ -9521,7 +9522,7 @@ static int st_longpath(httrackp *opt, int argc, char **argv) {
 
   fp = FOPEN(path, "rb");
   assertf(fp != NULL);
-  assertf(fread(buf, 1, sizeof(payload), fp) == sizeof(payload));
+  assertf(hts_fread_exact(buf, sizeof(payload), fp));
   fclose(fp);
   assertf(memcmp(buf, payload, sizeof(payload)) == 0);
   assertf(UNLINK(path) == 0);
@@ -9583,7 +9584,7 @@ static int st_mirrorio(httrackp *opt, int argc, char **argv) {
             strerror(errno));
     return 1;
   }
-  assertf(fwrite(payload, 1, sizeof(payload), fp) == sizeof(payload));
+  assertf(hts_fwrite_exact(payload, sizeof(payload), fp));
   fclose(fp);
   assertf(fexist_utf8(path));
   assertf(fsize_utf8(path) == (LLint) sizeof(payload));
@@ -9625,7 +9626,7 @@ static void ro_put(const char *path, const char *data) {
   FILE *const fp = FOPEN(path, "wb");
 
   assertf(fp != NULL);
-  assertf(fwrite(data, 1, strlen(data), fp) == strlen(data));
+  assertf(hts_fwrite_exact(data, strlen(data), fp));
   fclose(fp);
 }
 
@@ -10930,7 +10931,7 @@ static int st_changes_race(httrackp *opt, int argc, char **argv) {
         return 1;
       }
       for (n = 0; n < 16384; n++)
-        fwrite("0123456789abcdef", 1, 16, fp);
+        (void) hts_fwrite_exact("0123456789abcdef", 16, fp);
       fclose(fp);
     }
   }
@@ -11519,6 +11520,79 @@ static int st_batch(httrackp *opt, int argc, char **argv) {
   return err;
 }
 
+// -#test=ioexact <dir>: the hts_fread_exact/hts_fwrite_exact contract - a
+// partial transfer is a failure, a zero-length one is not, and a short read
+// leaves the bytes it could not fill alone.
+static int st_ioexact(httrackp *opt, int argc, char **argv) {
+  const size_t payload_size = 70000; /* past any stdio buffer */
+  const unsigned char poison = 0xa5;
+  char path[HTS_URLMAXSIZE * 2];
+  char *payload, *readback;
+  FILE *fp;
+  int plen;
+  size_t i;
+
+  (void) opt;
+  if (argc < 1) {
+    fprintf(stderr, "ioexact: needs a writable dir\n");
+    return 1;
+  }
+  plen = snprintf(path, sizeof(path), "%s/ioexact.bin", argv[0]);
+  assertf(plen > 0 && (size_t) plen < sizeof(path));
+  payload = malloct(payload_size);
+  readback = malloct(payload_size + 1);
+  for (i = 0; i < payload_size; i++)
+    payload[i] = (char) (i * 7 + (i >> 8));
+
+  /* Round trip: a helper that swapped fwrite's size and nmemb would report a
+     count of 1 here and die. */
+  fp = FOPEN(path, "wb");
+  assertf(fp != NULL);
+  assertf(hts_fwrite_exact(payload, payload_size, fp) == HTS_TRUE);
+  assertf(fclose(fp) == 0);
+  memset(readback, poison, payload_size + 1);
+  fp = FOPEN(path, "rb");
+  assertf(fp != NULL);
+  assertf(hts_fread_exact(readback, payload_size, fp) == HTS_TRUE);
+  assertf(memcmp(readback, payload, payload_size) == 0);
+  assertf((unsigned char) readback[payload_size] == poison);
+  assertf(hts_fread_exact(readback, 1, fp) == HTS_FALSE); /* at EOF */
+  assertf(hts_fread_exact(readback, 0, fp) == HTS_TRUE);
+  assertf(fclose(fp) == 0);
+
+  /* Short read: four of the eight bytes asked for, so a failure, and the tail
+     of the destination keeps its poison. */
+  fp = FOPEN(path, "wb");
+  assertf(fp != NULL);
+  assertf(hts_fwrite_exact(payload, 4, fp) == HTS_TRUE);
+  assertf(fclose(fp) == 0);
+  memset(readback, poison, 16);
+  fp = FOPEN(path, "rb");
+  assertf(fp != NULL);
+  assertf(hts_fread_exact(readback, 8, fp) == HTS_FALSE);
+  assertf(memcmp(readback, payload, 4) == 0);
+  for (i = 4; i < 16; i++)
+    assertf((unsigned char) readback[i] == poison);
+  assertf(fclose(fp) == 0);
+
+  /* Wrong direction: an I/O error is a failure, not a silent no-op. */
+  fp = FOPEN(path, "wb");
+  assertf(fp != NULL);
+  assertf(hts_fread_exact(readback, 4, fp) == HTS_FALSE);
+  assertf(fclose(fp) == 0);
+  fp = FOPEN(path, "rb");
+  assertf(fp != NULL);
+  assertf(hts_fwrite_exact(payload, 4, fp) == HTS_FALSE);
+  assertf(hts_fwrite_exact(payload, 0, fp) == HTS_TRUE);
+  assertf(fclose(fp) == 0);
+
+  assertf(UNLINK(path) == 0);
+  freet(payload);
+  freet(readback);
+  printf("ioexact: a partial transfer is a failure: OK\n");
+  return 0;
+}
+
 /* ------------------------------------------------------------ */
 /* Registry: name -> handler, with a usage hint and a one-line description. */
 /* ------------------------------------------------------------ */
@@ -11763,6 +11837,8 @@ static const struct selftest_entry {
     {"warc-longurl", "<dir>",
      "a URL past the header-format buffer still reaches the archive",
      st_warc_longurl},
+    {"ioexact", "<dir>",
+     "hts_fread_exact/hts_fwrite_exact reject a partial transfer", st_ioexact},
     {"longpath", "<dir>",
      "round-trip a >MAX_PATH file through the _w* wrappers (\\\\?\\ on "
      "Windows)",

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -40,6 +40,7 @@ Please visit our Website: http://www.httrack.com
 
 #include "htsnet.h"
 #include "htslib.h"
+#include "htsio.h"
 #include "htscharset.h"
 #include <limits.h>
 #include <stdio.h>
@@ -1294,8 +1295,8 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
 #endif
                       fp = fopen(StringBuff(tmpbuff), "wb");
                       if (fp != NULL) {
-                        (void) ((int)
-                                fwrite((void *) adruserprofile, 1, count, fp));
+                        (void) hts_fwrite_exact((const char *) adruserprofile,
+                                                (size_t) count, fp);
                         fclose(fp);
                       }
                     }
@@ -1324,8 +1325,8 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                          them and this server reads them back (#1314). */
                       ini_rebase_lists((char *) adrw, -1, &profile);
                       count = (int) StringLength(profile);
-                      if ((int) fwrite(StringBuff(profile), 1, count, fp) ==
-                          count) {
+                      if (hts_fwrite_exact(StringBuff(profile), (size_t) count,
+                                           fp)) {
 
                         /* Wipe the doit.log file, useless here (all options are replicated) and
                            even a bit annoying (duplicate/ghost options)

--- a/src/htssinglefile.c
+++ b/src/htssinglefile.c
@@ -40,6 +40,7 @@ Please visit our Website: http://www.httrack.com
 
 #include "htscore.h"
 #include "htslib.h"
+#include "htsio.h"
 #include "htssafe.h"
 #include "htsrandom.h"
 #include "htstools.h"
@@ -827,7 +828,7 @@ static hts_boolean sf_replace_file(httrackp *opt, const char *path,
     StringFree(tmp);
     return HTS_FALSE;
   }
-  if (len > 0 && fwrite(body, 1, len, fp) != len)
+  if (len > 0 && !hts_fwrite_exact(body, len, fp))
     ok = HTS_FALSE;
   if (fclose(fp) != 0)
     ok = HTS_FALSE;

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -38,6 +38,7 @@ Please visit our Website: http://www.httrack.com
 #include <ctype.h>
 #include "htscore.h"
 #include "htstools.h"
+#include "htsio.h"
 #include "htsstrings.h"
 #include "htscharset.h"
 #ifdef _WIN32
@@ -556,8 +557,7 @@ int verif_backblue(httrackp * opt, const char *base) {
                  fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), base, "backblue.gif"));
     opt->state.verif_backblue_done = 1;
     if (fp) {
-      if (fwrite(HTS_DATA_BACK_GIF, HTS_DATA_BACK_GIF_LEN, 1, fp) !=
-          HTS_DATA_BACK_GIF_LEN)
+      if (!hts_fwrite_exact(HTS_DATA_BACK_GIF, HTS_DATA_BACK_GIF_LEN, fp))
         ret = 1;
       fclose(fp);
       usercommand(opt, 0, NULL,
@@ -569,8 +569,7 @@ int verif_backblue(httrackp * opt, const char *base) {
       filecreate(&opt->state.strc,
                  fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), base, "fade.gif"));
     if (fp) {
-      if (fwrite(HTS_DATA_FADE_GIF, HTS_DATA_FADE_GIF_LEN, 1, fp) !=
-          HTS_DATA_FADE_GIF_LEN)
+      if (!hts_fwrite_exact(HTS_DATA_FADE_GIF, HTS_DATA_FADE_GIF_LEN, fp))
         ret = 1;
       fclose(fp);
       usercommand(opt, 0, NULL, fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), base, "fade.gif"),

--- a/src/htswarc.c
+++ b/src/htswarc.c
@@ -38,6 +38,7 @@ Please visit our Website: http://www.httrack.com
 
 #include "htscore.h"
 #include "htslib.h"
+#include "htsio.h"
 #include "htsback.h"
 #include "htstools.h"
 #include "htssafe.h"
@@ -219,7 +220,7 @@ static int member_begin(member *m, warc_writer *w) {
 
 static int member_write(member *m, const void *p, size_t n) {
   if (!m->w->gz)
-    return (n == 0 || fwrite(p, 1, n, m->w->f) == n) ? 0 : -1;
+    return (n == 0 || hts_fwrite_exact(p, n, m->w->f)) ? 0 : -1;
   m->strm.next_in = (const Bytef *) p;
   while (n > 0) {
     unsigned char out[8192];
@@ -232,7 +233,7 @@ static int member_write(member *m, const void *p, size_t n) {
       if (deflate(&m->strm, Z_NO_FLUSH) != Z_OK)
         return -1;
       got = sizeof(out) - m->strm.avail_out;
-      if (got > 0 && fwrite(out, 1, got, m->w->f) != got)
+      if (got > 0 && !hts_fwrite_exact(out, got, m->w->f))
         return -1;
     } while (m->strm.avail_out == 0);
     n -= chunk;
@@ -252,7 +253,7 @@ static int member_end(member *m) {
       zerr = deflate(&m->strm, Z_FINISH);
       {
         size_t got = sizeof(out) - m->strm.avail_out;
-        if (got > 0 && fwrite(out, 1, got, m->w->f) != got)
+        if (got > 0 && !hts_fwrite_exact(out, got, m->w->f))
           rc = -1;
       }
     } while (zerr == Z_OK);

--- a/src/htszlib.c
+++ b/src/htszlib.c
@@ -37,6 +37,7 @@ Please visit our Website: http://www.httrack.com
 /* specific definitions */
 #include "htsbase.h"
 #include "htscore.h"
+#include "htsio.h"
 #include "htscodec.h"
 #include "htszlib.h"
 
@@ -129,8 +130,7 @@ int hts_zunpack(const char *filename, const char *newfile) {
                 ok = HTS_FALSE;
                 break;
               }
-              if (produced > 0 &&
-                  fwrite(outbuf, 1, produced, fpout) != produced) {
+              if (produced > 0 && !hts_fwrite_exact(outbuf, produced, fpout)) {
                 env_error = HTS_TRUE;
                 ok = HTS_FALSE;
                 break;
@@ -157,7 +157,7 @@ int hts_zunpack(const char *filename, const char *newfile) {
           int size = 0;
 
           while ((navail = fread(inbuf, 1, sizeof(inbuf), in)) > 0) {
-            if (fwrite(inbuf, 1, navail, fpout) != navail) {
+            if (!hts_fwrite_exact(inbuf, navail, fpout)) {
               size = -1;
               break;
             }

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -54,6 +54,7 @@ Please visit our Website: http://www.httrack.com
 #include "htscore.h"
 #include "htsback.h"
 #include "htslib.h" /* hts_effective_mime */
+#include "htsio.h"
 
 #include "store.h"
 #include "proxystrings.h"
@@ -1238,8 +1239,8 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
                     if (fp != NULL) {
                       r->adr = (char *) malloc(r->size + 1);
                       if (r->adr != NULL) {
-                        if (r->size > 0
-                            && fread(r->adr, 1, r->size, fp) != r->size) {
+                        if (r->size > 0 &&
+                            !hts_fread_exact(r->adr, r->size, fp)) {
                           int last_errno = errno;
 
                           r->statuscode = STATUSCODE_INVALID;
@@ -1492,7 +1493,7 @@ static void cache_rstr(FILE *fp, char *s, size_t s_size) {
     const size_t want = (size_t) i;
     const size_t store = want < s_size ? want : s_size - 1;
 
-    if (fread(s, 1, store, fp) != store) {
+    if (!hts_fread_exact(s, store, fp)) {
       assertf(! "fread_cache_failed");
     }
     if (want > store && fseek(fp, (long) (want - store), SEEK_CUR) != 0) {
@@ -1516,7 +1517,7 @@ static char *cache_rstr_addr(FILE * fp) {
   if (i > 0) {
     addr = malloc(i + 1);
     if (addr != NULL) {
-      if ((int) fread(addr, 1, i, fp) != i) {
+      if (!hts_fread_exact(addr, (size_t) i, fp)) {
         assertf(! "fread_cache_failed");
       }
       *(addr + i) = '\0';
@@ -1589,7 +1590,7 @@ static int PT_LoadCache__Old(PT_Index index_, const char *filename) {
     if (cache->dat != NULL && cache->ndx != NULL && ndxSize > 0) {
       char *use = malloc(ndxSize + 1);
 
-      if (fread(use, 1, ndxSize, cache->ndx) == ndxSize) {
+      if (hts_fread_exact(use, (size_t) ndxSize, cache->ndx)) {
         char firstline[256];
         char *a = use;
 
@@ -1754,7 +1755,9 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
       if (cache->version == 0) {
         OLD_htsblk old_r;
 
-        if (fread((char *) &old_r, 1, sizeof(old_r), cache->dat) == sizeof(old_r)) {    // lire tout (y compris statuscode etc)
+        if (hts_fread_exact(
+                &old_r, sizeof(old_r),
+                cache->dat)) { // lire tout (y compris statuscode etc)
           int i;
           String urlDecoded;
 
@@ -1910,7 +1913,7 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
               if (fp != NULL) {
                 r->adr = cache_alloc_body(r->size);
                 if (r->adr != NULL) {
-                  if (r->size > 0 && fread(r->adr, 1, r->size, fp) != r->size) {
+                  if (r->size > 0 && !hts_fread_exact(r->adr, r->size, fp)) {
                     r->statuscode = STATUSCODE_INVALID;
                     strcpybuff(r->msg, "Read error in cache disk data");
                   }
@@ -1931,7 +1934,7 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
             if (flags & FETCH_BODY) {
               r->adr = cache_alloc_body(r->size);
               if (r->adr != NULL) {
-                if (fread(r->adr, 1, r->size, cache->dat) != r->size) { // erreur
+                if (!hts_fread_exact(r->adr, r->size, cache->dat)) { // erreur
                   free(r->adr);
                   r->adr = NULL;
                   r->statuscode = STATUSCODE_INVALID;
@@ -2560,8 +2563,8 @@ static int PT_SaveCache__Arc_Fun(void *arg, const char *url, PT_Element element)
           (element->location ? element->location : "-"), (long int) ftell(fp),
           st->filename, (long int) (size_headers + body_size));
   /* network_doc */
-  if (fwrite(st->headers, 1, size_headers, fp) != size_headers ||
-      (body_size != 0 && fwrite(element->adr, 1, body_size, fp) != body_size)) {
+  if (!hts_fwrite_exact(st->headers, size_headers, fp) ||
+      (body_size != 0 && !hts_fwrite_exact(element->adr, body_size, fp))) {
     return 1;                   /* Error */
   }
 

--- a/tests/332_engine-io-exact.test
+++ b/tests/332_engine-io-exact.test
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+# Drives -#test=ioexact: the all-or-nothing stdio helpers must fail a short
+# read or write rather than report the bytes they did move.
+dir=$(mktemp -d)
+cleanup_push rm -rf "$dir"
+
+out=$(httrack -O /dev/null -#test=ioexact "$dir")
+grep -q "ioexact:.*OK" <<<"$out"


### PR DESCRIPTION
63 call sites compared an `fread` or `fwrite` return against the count they asked for, most of them casting one side so the types would line up. `hts_fread_exact` and `hts_fwrite_exact`, header-only in the new `src/htsio.h`, do that once and hand back an `hts_boolean`. `-Wsign-compare` drops from 39 to 31, and the MSVC C4018 twins go with it.

Read-to-EOF loops, slurps and the minizip ioapi callbacks still need the count `fread` returns and are untouched. `proxy/store.c` keeps its comparison too: it assigns the short count to `r->size` inside the test, and folding that away would change what a truncated cache entry reports. One behaviour does change: `verif_backblue()` passed the byte count as `fwrite`'s `nmemb` and compared the result against the length, so it reported a write error on every successful run. Every caller ignores the return, which is why nobody noticed.

Nothing here is exported and no installed struct moves. `tests/332` drives `-#test=ioexact` over a short read, a short write, a zero-length transfer and a stream opened the wrong way; all four obvious mutations of the helper bodies abort it.
