### PR TITLE
CodeQL paths-ignore excludes nothing and never did

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,9 @@ jobs:
           # fopen's umask-controlled 0666 is intended for mirror/cache/log
           # output; the one credential file (cookies.txt) is kept 0600 on Unix.
           config: |
-            # No paths-ignore: GitHub honours it only for a compiled language it does not build, so an exclusion has to come out of the build itself.
+            # No paths-ignore: GitHub honours it only for a compiled language
+            # it does not build, so an exclusion has to leave the build itself.
+            # libtest (demo callbacks) and src/proxy are analysed on purpose.
             query-filters:
               - exclude:
                   id: cpp/world-writable-file-creation

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,12 +46,7 @@ jobs:
           # fopen's umask-controlled 0666 is intended for mirror/cache/log
           # output; the one credential file (cookies.txt) is kept 0600 on Unix.
           config: |
-            paths-ignore:
-              # Demo callback samples, not part of libhttrack.
-              - libtest
-              # ProxyTrack: a separate legacy binary with no auth surface; its
-              # recv/cache-parse code trips taint queries by design.
-              - src/proxy
+            # No paths-ignore: GitHub honours it only for a compiled language it does not build, so an exclusion has to come out of the build itself.
             query-filters:
               - exclude:
                   id: cpp/world-writable-file-creation


### PR DESCRIPTION
The CodeQL config claims to exclude `libtest/` and `src/proxy/` from analysis, and never has. GitHub honours `paths-ignore` only for interpreted languages, or for a compiled language it analyses without building; this job runs `build-mode: manual` with a real `make`, and both trees are still compiled and extracted. Thirteen alerts in those paths are open right now, and the master SARIF lists all six files under `artifacts`.

`query-filters`, in the same `config:` block, does work: both rules excluded there sit at zero open alerts. So the config is parsed, and it is the path filter alone that is inert. This drops the dead block and leaves one line saying why, without excluding anything: whether ProxyTrack gets security analysis is a separate decision.
