### PR TITLE
Three warning sites fixed at the type, one of them an installed struct

### DIFF
--- a/fuzz/fuzz-header.c
+++ b/fuzz/fuzz-header.c
@@ -42,7 +42,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   int first = 1;
 
   memset(&r, 0, sizeof(r));
-  cookie->max_len = (int) sizeof(cookie->data);
+  cookie->max_len = sizeof(cookie->data);
   r.location = malloct(HTS_URLMAXSIZE * 2);
   r.location[0] = '\0';
 

--- a/src/htsbauth.c
+++ b/src/htsbauth.c
@@ -64,14 +64,22 @@ int cookie_add(t_cookie * cookie, const char *cook_name, const char *cook_value,
   if (strlen(domain) > 256)
     return -1;                  // trop long
   if (strlen(path) > 256)
-    return -1;                  // trop long
-  if (strlen(cookie->data)
-             + strlen(cook_value)
-             + strlen(cook_name)
-             + strlen(domain)
-             + strlen(path)
-             + 256 > cookie->max_len)
-    return -1;                  // impossible d'ajouter
+    return -1; // too long
+  /* Each part against the room left, never a sum: the sum of five lengths
+     read off the wire can wrap and pass a check it should fail. */
+  {
+    const size_t parts[] = {strlen(cookie->data), strlen(cook_value),
+                            strlen(cook_name),    strlen(domain),
+                            strlen(path),         256};
+    size_t left = cookie->max_len;
+    size_t i;
+
+    for (i = 0; i < sizeof(parts) / sizeof(parts[0]); i++) {
+      if (parts[i] > left)
+        return -1; // no room to add it
+      left -= parts[i];
+    }
+  }
 
   insert = a;                   // insérer ici
   while(*a) {
@@ -103,8 +111,13 @@ int cookie_add(t_cookie * cookie, const char *cook_name, const char *cook_value,
   strcatbuff(cook, "\t");
   strcatbuff(cook, cook_value);
   strcatbuff(cook, "\n");
-  if (!((strlen(cookie->data) + strlen(cook)) < cookie->max_len))
-    return -1;                  // impossible d'ajouter
+  /* Overflow-safe: the new field alone against the room left. */
+  {
+    const size_t used = strlen(cookie->data);
+
+    if (used >= cookie->max_len || strlen(cook) >= cookie->max_len - used)
+      return -1; // no room to add it
+  }
   cookie_insert(insert, cookie->max_len - (size_t) (insert - cookie->data),
                 cook);
 #if DEBUG_COOK
@@ -311,7 +324,7 @@ int cookie_load(httrackp *opt, t_cookie *cookie, const char *fpath,
       char BIGSTK line[8192];
       const size_t line_max = 8000;
 
-      while((!feof(fp)) && (((int) strlen(cookie->data)) < cookie->max_len)) {
+      while ((!feof(fp)) && (strlen(cookie->data) < cookie->max_len)) {
         rawlinput(fp, line, 8100);
         if (strnotempty(line)) {
           if (strlen(line) < line_max) {

--- a/src/htsbauth.c
+++ b/src/htsbauth.c
@@ -111,7 +111,9 @@ int cookie_add(t_cookie * cookie, const char *cook_name, const char *cook_value,
   strcatbuff(cook, "\t");
   strcatbuff(cook, cook_value);
   strcatbuff(cook, "\n");
-  /* Overflow-safe: the new field alone against the room left. */
+  /* Backstop, not a live gate: the check above reserves 256 bytes and this
+     record adds ~30 of literals, so it fires only if that assembly ever
+     outgrows the headroom. Overflow-safe form regardless. */
   {
     const size_t used = strlen(cookie->data);
 

--- a/src/htsbauth.h
+++ b/src/htsbauth.h
@@ -59,7 +59,7 @@ struct bauth_chain {
 typedef struct t_cookie t_cookie;
 #endif
 struct t_cookie {
-  int max_len;      /* capacity of data[] in use */
+  size_t max_len;   /* capacity of data[] in use */
   char data[32768]; /* raw cookie store (NUL-terminated field list) */
   bauth_chain auth; /* embedded head of the basic-auth list */
 };

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -1042,13 +1042,17 @@ static void reconcile_wipe(httrackp *opt) {
 }
 
 /* Create a filler file of exactly `size` bytes. */
-static void reconcile_put(httrackp *opt, const char *name, size_t size) {
+/* LLint, not size_t: the callers hold file sizes, which they also hand to
+   reconcile_expect() and to fsize(). */
+static void reconcile_put(httrackp *opt, const char *name, LLint size) {
   FILE *const fp = fopen(reconcile_st_path(opt, name), "wb");
   static const char filler[1024] = {'x'};
 
   assertf(fp != NULL);
   while (size > 0) {
-    const size_t n = size > sizeof(filler) ? sizeof(filler) : size;
+    /* Narrowing is safe: the ternary bounds n by sizeof(filler) first. */
+    const size_t n =
+        size > (LLint) sizeof(filler) ? sizeof(filler) : (size_t) size;
 
     assertf(fwrite(filler, 1, n, fp) == n);
     size -= n;

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -1978,7 +1978,10 @@ LLint http_xfread1(htsblk * r, int bufl) {
         }
         if (r->adr != NULL) {
           // lecture
-          const size_t req_size = r->totalsize - r->size;
+          /* Signed first: a body longer than its announced totalsize makes
+             this negative, and as a size_t it would drive a read past adr. */
+          const LLint remaining = r->totalsize - r->size;
+          const size_t req_size = remaining > 0 ? (size_t) remaining : 0;
 
           nl = req_size > 0 ? hts_read(r, r->adr + ((int) r->size), (int) req_size) : 0;        /* NO 32 bit overlow possible here (no 4GB html!) */
           // nouvelle taille

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3993,7 +3993,8 @@ static int st_cookiecap(httrackp *opt, int argc, char **argv) {
   static t_cookie cookie;
   /* Above the 256 bytes of headroom cookie_add reserves, or it refuses all. */
   const size_t cap = 512;
-  char big[512];
+  static const char NAME[] = "n", DOM[] = "www.example.com", PATH[] = "/";
+  char big[1024];
   int err = 0;
   size_t i;
 
@@ -4011,7 +4012,7 @@ static int st_cookiecap(httrackp *opt, int argc, char **argv) {
   big[sizeof(big) - 1] = '\0';
 
   /* Far past the capacity: refused, and nothing written. */
-  if (cookie_add(&cookie, "n", big, "www.example.com", "/") == 0) {
+  if (cookie_add(&cookie, NAME, big, DOM, PATH) == 0) {
     printf("cookie-cap: FAIL (a value %u bytes long was accepted into %u)\n",
            (unsigned) strlen(big), (unsigned) cap);
     err = 1;
@@ -4029,14 +4030,50 @@ static int st_cookiecap(httrackp *opt, int argc, char **argv) {
     }
   }
 
-  /* A value that fits is still accepted, so the check is not refusing all. */
-  if (cookie_add(&cookie, "n", "v", "www.example.com", "/") != 0) {
-    printf("cookie-cap: FAIL (a short cookie was refused)\n");
-    err = 1;
-  } else if (strlen(cookie.data) >= cap) {
-    printf("cookie-cap: FAIL (accepted, but the store is %u >= max_len %u)\n",
-           (unsigned) strlen(cookie.data), (unsigned) cap);
-    err = 1;
+  /* The exact boundary, derived rather than hardcoded so it survives a change
+     to the fixture strings: cookie_add reserves 256 bytes beyond the parts. */
+  {
+    const size_t fixed = strlen(NAME) + strlen(DOM) + strlen(PATH) + 256;
+    const size_t fits = cap - fixed;
+
+    /* Exactly filling max_len is accepted... */
+    memset(big, 'v', fits);
+    big[fits] = '\0';
+    cookie.data[0] = '\0';
+    if (cookie_add(&cookie, NAME, big, DOM, PATH) != 0) {
+      printf("cookie-cap: FAIL (a value of %u, exactly max_len, was refused)\n",
+             (unsigned) fits);
+      err = 1;
+    } else if (strlen(cookie.data) == 0 || strlen(cookie.data) >= cap) {
+      printf("cookie-cap: FAIL (accepted, store is %u against max_len %u)\n",
+             (unsigned) strlen(cookie.data), (unsigned) cap);
+      err = 1;
+    }
+
+    /* ...and one byte more is not. */
+    memset(big, 'v', fits + 1);
+    big[fits + 1] = '\0';
+    cookie.data[0] = '\0';
+    if (cookie_add(&cookie, NAME, big, DOM, PATH) == 0) {
+      printf(
+          "cookie-cap: FAIL (a value of %u, one past max_len, was accepted)\n",
+          (unsigned) (fits + 1));
+      err = 1;
+    } else if (cookie.data[0] != '\0') {
+      printf("cookie-cap: FAIL (the store was written despite the refusal)\n");
+      err = 1;
+    }
+  }
+
+  /* The canary again, after the accepted write: an insert bounded by
+     sizeof(data) rather than max_len would show up here. */
+  for (i = cap; i < sizeof(cookie.data); i++) {
+    if (cookie.data[i] != 'C') {
+      printf("cookie-cap: FAIL (byte %u past max_len was modified)\n",
+             (unsigned) i);
+      err = 1;
+      break;
+    }
   }
 
   printf("cookie-cap: %s\n", err ? "FAIL" : "OK");

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3919,7 +3919,7 @@ static int st_cookies(httrackp *opt, int argc, char **argv) {
   (void) opt;
   (void) argc;
   (void) argv;
-  cookie.max_len = (int) sizeof(cookie.data);
+  cookie.max_len = sizeof(cookie.data);
   cookie.data[0] = '\0';
   added = cookie_add(&cookie, "name", "value", dom, "/");
   added |= cookie_add(&cookie, "has_js", "1", dom, "/");
@@ -3945,7 +3945,7 @@ static int st_cookies(httrackp *opt, int argc, char **argv) {
     memset(&r, 0, sizeof(r));
     memset(host, 'a', sizeof(host) - 1);
     host[sizeof(host) - 1] = '\0';
-    ck2.max_len = (int) sizeof(ck2.data);
+    ck2.max_len = sizeof(ck2.data);
     ck2.data[0] = '\0';
     strcpybuff(line, "Set-Cookie: SID=1; path=/");
     treathead(&ck2, host, "/", &r, line);
@@ -3984,6 +3984,62 @@ static int st_cookies(httrackp *opt, int argc, char **argv) {
   printf("cookie-header: %s\n", err ? "FAIL" : "OK");
   if (err)
     printf("  got: %s\n", hdr);
+  return err;
+}
+
+/* cookie_add must refuse rather than write past max_len, whatever the caller
+   set that to, and must leave the bytes beyond it alone. */
+static int st_cookiecap(httrackp *opt, int argc, char **argv) {
+  static t_cookie cookie;
+  /* Above the 256 bytes of headroom cookie_add reserves, or it refuses all. */
+  const size_t cap = 512;
+  char big[512];
+  int err = 0;
+  size_t i;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+
+  /* A non-zero canary: a stray NUL from an off-by-one terminator is invisible
+     against a zero fill, which is the exact bug a capacity check guards. */
+  memset(cookie.data, 'C', sizeof(cookie.data));
+  cookie.max_len = cap;
+  cookie.data[0] = '\0';
+
+  memset(big, 'v', sizeof(big) - 1);
+  big[sizeof(big) - 1] = '\0';
+
+  /* Far past the capacity: refused, and nothing written. */
+  if (cookie_add(&cookie, "n", big, "www.example.com", "/") == 0) {
+    printf("cookie-cap: FAIL (a value %u bytes long was accepted into %u)\n",
+           (unsigned) strlen(big), (unsigned) cap);
+    err = 1;
+  }
+  if (cookie.data[0] != '\0') {
+    printf("cookie-cap: FAIL (the store was written despite the refusal)\n");
+    err = 1;
+  }
+  for (i = cap; i < sizeof(cookie.data); i++) {
+    if (cookie.data[i] != 'C') {
+      printf("cookie-cap: FAIL (byte %u past max_len was modified)\n",
+             (unsigned) i);
+      err = 1;
+      break;
+    }
+  }
+
+  /* A value that fits is still accepted, so the check is not refusing all. */
+  if (cookie_add(&cookie, "n", "v", "www.example.com", "/") != 0) {
+    printf("cookie-cap: FAIL (a short cookie was refused)\n");
+    err = 1;
+  } else if (strlen(cookie.data) >= cap) {
+    printf("cookie-cap: FAIL (accepted, but the store is %u >= max_len %u)\n",
+           (unsigned) strlen(cookie.data), (unsigned) cap);
+    err = 1;
+  }
+
+  printf("cookie-cap: %s\n", err ? "FAIL" : "OK");
   return err;
 }
 
@@ -10155,7 +10211,7 @@ static int st_cookieimport(httrackp *opt, int argc, char **argv) {
 
   static t_cookie ck;
 
-  ck.max_len = (int) sizeof(ck.data);
+  ck.max_len = sizeof(ck.data);
   ck.data[0] = '\0';
   assertf(cookie_load(NULL, &ck, fpath, "cookies.txt") == 0);
   assertf(strstr(ck.data, "JARCOOK") != NULL); /* jar read on a long path */
@@ -11717,6 +11773,7 @@ static const struct selftest_entry {
     {"dnstimeout", "", "a slow DNS resolve is bounded and holds no lock",
      st_dnstimeout},
     {"cookies", "", "cookie request-header self-test", st_cookies},
+    {"cookiecap", "", "cookie_add honours max_len", st_cookiecap},
     {"useragent", "", "default User-Agent self-test", st_useragent},
     {"makeindex", "[dir]", "hts_finish_makeindex footer/refresh self-test",
      st_makeindex},

--- a/tests/335_engine-cookie-capacity.test
+++ b/tests/335_engine-cookie-capacity.test
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# cookie_add must refuse a value that does not fit max_len, and leave the bytes
+# past it alone. Driven by the 'httrack -#test=cookiecap' selftest.
+
+set -eu
+
+out=$(httrack -#test=cookiecap run)
+
+# Exact match: the selftest prints its own diagnosis before the verdict, and a
+# renamed or removed registry entry prints the whole registry instead.
+test "$out" = "cookie-cap: OK" || {
+    echo "expected 'cookie-cap: OK', got: $out" >&2
+    exit 1
+}


### PR DESCRIPTION
Three of the Windows build's warning sites, taken at the type rather than at the call site.

**`reconcile_put` (29 sites).** Its callers pass `TINY`, `MID` and `SOLID`, which are `LLint` because they are file sizes the same callers hand to `reconcile_expect()` and compare against `fsize()`. The parameter was `size_t`, so all 29 call sites narrowed on Win32 where `size_t` is 32 bits. Taking `LLint` moves the single narrowing inside the loop, where the ternary has already bounded it by `sizeof(filler)`. A negative argument used to become a huge positive and drive the loop toward `SIZE_MAX`; it now writes nothing. No caller passes one, so behaviour is unchanged.

**`cookie->max_len` (2 sites, and an ABI change).** `htsbauth.h` declared it `int` while every check against it sums `strlen()` results, which is what MSVC was complaining about. The field is a capacity, so `size_t` is what it is. That also removes the `(int)` casts three selftests and `cookie_load` carried to match the old type.

`htsbauth.h` is in `DevIncludes_DATA`, so this changes an installed struct's layout. **Deliberate, and `VERSION_INFO` is deliberately not bumped** — @xroche's call, recorded here so the un-bumped soname is not read later as an oversight. HTTrackQt is the only consumer of these headers.

The two checks now measure each part against the room left instead of summing first, per the repo's bounds rule. Being straight about what that buys: **no constructible input distinguishes the two forms**, because the sum only wraps past `SIZE_MAX`, which needs gigabytes of strings. A mutant restoring the sum form passes the new test. It is conformance on a hostile-input path, not a fix for a reachable bug — the warning is fixed by the type alone.

**`htslib.c:1981`.** `totalsize - size` went into a `size_t`. A body longer than its announced `totalsize` makes that negative, and as a `size_t` it would have driven `hts_read` past the allocation. Now computed signed and clamped at zero. Unreachable today, since each read is bounded by the same remainder, so this is a guard rather than a repair.

**Test 335** pins the capacity contract, which nothing asserted before: an oversized value is refused, the store is left untouched, and a canary past `max_len` survives. The canary is filled with `'C'` rather than zero, so the stray NUL an off-by-one terminator writes cannot hide in the fill.

Review's first pass showed that test proved almost nothing — its inputs were 511 into 512 and one byte, so every off-by-one survived and so did deleting either check on its own. It now derives the exact fitting length from the fixture strings and the reserved headroom, and asserts that value and one byte past it.

Two mutants still survive, and the reason is in the code rather than the test: deleting the second check, or moving its boundary by one, changes nothing any input can observe. The first check reserves 256 bytes while the assembled record adds about 30 of literals, so the first passing always implies the second. It is a backstop against that assembly growing, now commented as such.

Measured against master today from the uploaded `msbuild-*.log`: 116 raw emissions, **56 distinct sites** (C4244 45, C4018 7, C4267 4), of which 52 are Win32-only. This takes 31 of them. #1354 carries the remaining list and the note that `mztools.c` is vendored minizip and should be fixed from outside.