### PR TITLE
htsserver's listen address is chosen by its caller, not by the server

### DIFF
--- a/src/htsnet.h
+++ b/src/htsnet.h
@@ -214,6 +214,23 @@ static HTS_INLINE HTS_UNUSED socklen_t SOCaddr_initany_(SOCaddr *const addr,
     SOCaddr_initany_(&(server), __FILE__, __LINE__);                           \
   } while (0)
 
+/** Initialize as an IPv4 loopback (127.0.0.1) address; returns its sockaddr
+    length. IPv4, so it binds whether or not the host has IPv6. */
+static HTS_INLINE HTS_UNUSED socklen_t
+SOCaddr_initloopback_(SOCaddr *const addr, const char *file, const int line) {
+  assertf_(addr != NULL, file, line);
+  memset(&addr->m_addr.in, 0, sizeof(addr->m_addr.in));
+  addr->m_addr.in.sin_family = AF_INET;
+  addr->m_addr.in.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  return SOCaddr_size_(addr, file, line);
+}
+
+/** Initialize server as an IPv4 loopback (127.0.0.1) address. */
+#define SOCaddr_initloopback(server)                                           \
+  do {                                                                         \
+    SOCaddr_initloopback_(&(server), __FILE__, __LINE__);                      \
+  } while (0)
+
 /** Populate server from data. data_size selects the source form: a full
     sockaddr_in / sockaddr_in6, or a raw 4-byte (IPv4) / 16-byte (IPv6) address
     with port zeroed. Any other size leaves an AF_INET shell. Returns the

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -253,36 +253,6 @@ static int gethost(const char *hostname, SOCaddr * server) {
   return 0;
 }
 
-static int my_getlocalhost(char *h_loc, size_t size) {
-  SOCaddr addr;
-  strcpy(h_loc, "localhost");
-  if (gethost(h_loc, &addr) == 1) {
-    return 0;
-  }
-  // come on ...
-  else {
-    strcpy(h_loc, "127.0.0.1");
-    return 0;
-  }
-}
-
-// get local hostname; falls back to "localhost" in case of error 
-// always returns 0
-static int my_gethostname(char *h_loc, size_t size) {
-  h_loc[0] = '\0';
-  if (gethostname(h_loc, (int) size) == 0) {    // host name
-    SOCaddr addr;
-    if (gethost(h_loc, &addr) == 1) {
-      return 0;
-    } else {
-      return my_getlocalhost(h_loc, size);
-    }
-  } else {
-    return my_getlocalhost(h_loc, size);
-  }
-  return 0;
-}
-
 // smallserver_init(&port,&return_host);
 T_SOC smallserver_init(int *port, char *adr, const char *bindAddr) {
   T_SOC soc = INVALID_SOCKET;
@@ -298,15 +268,16 @@ T_SOC smallserver_init(int *port, char *adr, const char *bindAddr) {
     free(commandReturnCmdl);
   commandReturnCmdl = NULL;
 
-  SOCaddr_initany(server);
+  /* Loopback unless asked otherwise: the handler trusts its client, and every
+     request is unauthenticated. --bind widens it deliberately. */
+  SOCaddr_initloopback(server);
+  strcpybuff(h_loc, "127.0.0.1");
   if (bindAddr != NULL && *bindAddr != '\0') {
     /* advertise the bound address, else the URL we print is unreachable */
     if (strlen(bindAddr) >= sizeof(h_loc) || !gethost(bindAddr, &server)) {
       return INVALID_SOCKET;
     }
     strcpybuff(h_loc, bindAddr);
-  } else if (my_gethostname(h_loc, 256) != 0) { // host name
-    return INVALID_SOCKET;
   }
 
   if ((soc = (T_SOC) socket(SOCaddr_sinfamily(server), SOCK_STREAM, 0)) !=

--- a/src/htsserver.h
+++ b/src/htsserver.h
@@ -44,8 +44,8 @@ Please visit our Website: http://www.httrack.com
 // Fonctions
 /* Read one line off a socket; HTS_TRUE if it did not fit "s". */
 hts_boolean socinput(T_SOC soc, char *s, int max);
-/* Listen on bindAddr, or every interface if NULL/empty; adr (>= 258 bytes) gets
-   the address to advertise. INVALID_SOCKET on error. */
+/* Listen on bindAddr, or the loopback interface if NULL/empty; adr (>= 258
+   bytes) gets the address to advertise. INVALID_SOCKET on error. */
 T_SOC smallserver_init_std(int *port_prox, char *adr_prox, int defaultPort,
                            const char *bindAddr);
 T_SOC smallserver_init(int *port, char *adr, const char *bindAddr);

--- a/src/htsweb.c
+++ b/src/htsweb.c
@@ -239,8 +239,8 @@ int main(int argc, char *argv[]) {
   int ret = 0;
   int defaultPort = 0;
   int parentPid = 0;
-  /* loopback by default: the handler trusts its input; --bind widens it */
-  const char *bindAddr = "127.0.0.1";
+  /* NULL leaves smallserver_init on its loopback default; --bind widens it */
+  const char *bindAddr = NULL;
 
   printf("Initializing the server..\n");
 
@@ -267,7 +267,8 @@ int main(int argc, char *argv[]) {
   if (argc < 2 || (argc % 2) != 0) {
     fprintf(stderr, "** Warning: use the webhttrack frontend if available\n");
     fprintf(stderr,
-            "usage: %s [--port <port>] [--bind <address>] [--ppid parent-pid] "
+            "usage: %s [--port <port>] [--bind <address>: default 127.0.0.1] "
+            "[--ppid parent-pid] "
             "[--ping-timeout <seconds>] "
             "<path-to-html-root-dir> [key value [key value]..]\n",
             argv[0]);

--- a/tests/335_webhttrack-bind-loopback.test
+++ b/tests/335_webhttrack-bind-loopback.test
@@ -1,0 +1,93 @@
+#!/bin/bash
+#
+# The panel htsserver serves is unauthenticated, so nothing off this host may
+# reach its default socket. 77 checks that against a loopback alias only.
+
+set -euo pipefail
+
+# shellcheck source=tests/webhttracklib.sh
+. "${0%"${0##*/}"}./webhttracklib.sh"
+
+htsserver_require
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_bind.XXXXXX") || fail "no tmpdir"
+cleanup() {
+    htsserver_cleanup
+    rm -rf "${work}"
+}
+cleanup_push cleanup
+
+# "ok", or the errno name: a filtered address times out where an unbound one is
+# refused, and only the refusal proves nothing is listening.
+probe() { # $1 = host, $2 = port
+    htsserver_python - "$1" "$2" <<'PY'
+import socket, sys
+try:
+    socket.create_connection((sys.argv[1], int(sys.argv[2])), timeout=5).close()
+    print("ok")
+except OSError as e:
+    print(type(e).__name__)
+PY
+}
+
+# The primary outbound IPv4, which a UDP connect() picks without sending a byte.
+# A function, not a heredoc inside $(): bash 3.2 runs that one as commands.
+primary_ipv4() {
+    htsserver_python - <<'PY'
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+try:
+    s.connect(("192.0.2.1", 9))  # TEST-NET-1, never routed
+    ip = s.getsockname()[0]
+except OSError:
+    ip = ""
+finally:
+    s.close()
+print("" if ip.startswith("127.") else ip)
+PY
+}
+
+addr=$(primary_ipv4)
+test -n "${addr}" || skip "no non-loopback IPv4 address here"
+
+# Without this control a refusal below could just mean the box filters ${addr}.
+htsserver_python - "${addr}" <<'PY' || skip "cannot bind and reach ${addr} here"
+import socket, sys
+try:
+    srv = socket.socket()
+    srv.bind((sys.argv[1], 0))
+    srv.listen(1)
+    socket.create_connection(srv.getsockname(), timeout=5).close()
+    srv.close()
+except OSError as e:
+    sys.exit(str(e))
+PY
+
+port=$(htsserver_freeport)
+htsserver_start --port "${port}" --home "${work}/wide" -- --bind "${addr}"
+case ${HTS_URL} in
+*"//${addr}:"*) ;;
+*) fail "--bind ${addr} advertised ${HTS_URL}" ;;
+esac
+got=$(probe "${addr}" "${port}")
+test "${got}" = ok || fail "--bind ${addr} did not answer on ${addr} (${got})"
+echo "ok: --bind ${addr} widens the socket"
+htsserver_stop
+
+port=$(htsserver_freeport)
+htsserver_start --port "${port}" --home "${work}/default"
+# webhttrack launches the browser on this URL, so a loopback bind has to
+# advertise a loopback address.
+case ${HTS_URL} in
+*//127.0.0.1:*) ;;
+*) fail "the default run advertised ${HTS_URL}, unreachable on a loopback bind" ;;
+esac
+got=$(probe 127.0.0.1 "${port}")
+test "${got}" = ok || fail "the default run refused 127.0.0.1 (${got})"
+got=$(probe "${addr}" "${port}")
+test "${got}" = ConnectionRefusedError ||
+    fail "the default run answers on ${addr} (${got})"
+echo "ok: the default socket is loopback-only"
+
+cleanup
+echo "PASS"


### PR DESCRIPTION
htsserver's control panel is unauthenticated: whatever can open its socket gets a session id and can drive it, so the listen address is a security decision the server itself should own. `smallserver_init` defaulted to the IPv4 wildcard and left the choice to its caller; only the literal in `htsweb.c`'s `main()` kept the shipped binary off the network. The default now lives in the server (a new `SOCaddr_initloopback` beside `SOCaddr_initany`, IPv4 so it binds with or without IPv6), and `--bind` remains the deliberate way to widen it, `0.0.0.0` included.

The advertised host follows the socket: a default run prints `http://127.0.0.1:<port>/`, which is what `webhttrack` greps out of the server's output before launching the browser. That path previously advertised the machine's hostname, which would have been unreachable under a narrower bind; it was not reachable in the shipped binary, since `main()` always passed a literal and an empty `--bind` is refused. The two hostname helpers behind it are gone with it. The default also no longer goes through the resolver, so a container with a broken `getaddrinfo` now starts where it used to fail.

It does not restrict which directory the client may name. On a loopback socket the client is the local user, who is entitled to choose their own mirror directory; rooting the path would break mirroring to an external disk. A loopback socket is also still reachable by any local process, and by DNS rebinding from a browser on the machine. A Host-header check is the follow-up for that, not this change.

New test 335 asserts the default socket refuses a connection on a real interface address while accepting one on `127.0.0.1`, using a `--bind` run to that address as its control, and skips on a host with loopback only. It passes on master too, because the `htsweb.c` literal already produced that behaviour: it guards against a future re-widening rather than fixing a present one, and it does fail against a build that restores the wildcard default. Test 77 already covered the same default against a `127.0.0.2` alias, which cannot see an off-host bind.