### PR TITLE
The macOS DMG attach step races a release that does not exist yet

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -153,19 +153,30 @@ jobs:
           path: ${{ runner.temp }}/HTTrack-*.dmg
           if-no-files-found: error
 
-      # Releases are cut by hand, so a tag can land before one exists. A labelled build is
-      # never one of them: ref_type is 'tag' for a dispatch on a tag as much as for a push.
+      # Releases are cut by hand, so a tag lands minutes before one exists and this
+      # step used to lose that race, leaving the DMG on the artifacts where it needs
+      # a login and expires. It waits instead. A labelled build is never attached:
+      # ref_type is 'tag' for a dispatch on a tag as much as for a push.
       - name: Attach the DMG to the release
         if: github.ref_type == 'tag' && !inputs.label
+        timeout-minutes: 35
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" "$RUNNER_TEMP"/HTTrack-*.dmg --clobber
-          else
-            echo "no release $GITHUB_REF_NAME yet -- the DMG is on this run's artifacts"
-          fi
+          # 30 min: the publish step builds and signs a dist tarball first, and a
+          # tag pushed with no release ever coming costs only this wait.
+          deadline=$((SECONDS + 1800))
+          until gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; do
+            if test "$SECONDS" -ge "$deadline"; then
+              echo "::warning::no release $GITHUB_REF_NAME after 30 min;" \
+                   "the DMG is on this run's artifacts and will expire"
+              exit 0
+            fi
+            sleep 20
+          done
+          gh release upload "$GITHUB_REF_NAME" "$RUNNER_TEMP"/HTTrack-*.dmg --clobber
+          echo "attached to release $GITHUB_REF_NAME"
 
       - name: Delete the signing keychain
         if: always()


### PR DESCRIPTION
The tag push starts this workflow, but the release it attaches to is published by hand a few minutes later, so the attach step tested once and usually lost. It has lost 2 of the last 4 releases; 3.49.16 shipped with its macOS DMG sitting on a workflow artifact, which needs a GitHub login and expires after 90 days.

It now waits up to 30 minutes for the release to appear. That covers the real gap, which is however long `httrack-gh-release` takes to build, sign and upload a dist tarball before the release exists.

Deliberately unchanged: the step still cannot fail the build, and a tag that never gets a release costs only the wait and emits a warning. A labelled beta build is still never attached, since those are channel artifacts by design and the upload uses `--clobber`, which would otherwise replace a published release's DMG.

This matters for 3.50 specifically. A final release cannot ship its macOS build as an expiring artifact behind a login, and winning a race by hand on the day is not a plan.
