### PR TITLE
Nothing records why the soname survived an ABI break

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,12 @@ AC_CONFIG_SRCDIR(src/httrack.c)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
+# 3:16:0 kept DELIBERATELY across an ABI break: #1365 widened t_cookie.max_len
+# from int to size_t in htsbauth.h, an installed header, moving data[] from
+# offset 4 to 8 on LP64. By the rules above that is current++ plus the Debian
+# libhttrack3 -> libhttrack4 rename; Xavier decided against both, HTTrackQt
+# being the only consumer of these headers. Recorded so the soname staying at
+# .so.3 reads as a decision rather than an oversight.
 # 3:16:0: revision-only bump. hts_addurl() now deep-copies the array it is handed,
 # which relaxes a caller contract without moving a layout or touching a symbol.
 # 3:15:0: revision-only bump. httrackp gained a tail field (wizard_filters) and two

--- a/configure.ac
+++ b/configure.ac
@@ -29,14 +29,11 @@ AC_CONFIG_SRCDIR(src/httrack.c)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
-# 3:16:0 kept DELIBERATELY across an ABI break: #1365 widened t_cookie.max_len
-# from int to size_t in htsbauth.h, an installed header, moving data[] from
-# offset 4 to 8 on LP64. By the rules above that is current++ plus the Debian
-# libhttrack3 -> libhttrack4 rename; Xavier decided against both, HTTrackQt
-# being the only consumer of these headers. Recorded so the soname staying at
-# .so.3 reads as a decision rather than an oversight.
-# 3:16:0: revision-only bump. hts_addurl() now deep-copies the array it is handed,
-# which relaxes a caller contract without moving a layout or touching a symbol.
+# 3:16:0: revision-only DESPITE an ABI break. hts_addurl() deep-copies the array it
+# is handed; #1365 then widened t_cookie.max_len (installed htsbauth.h) to size_t,
+# moving data[] from 4 to 8 on LP64 (auth and sizeof unchanged, the old hole
+# absorbed it). The libtool rules want current++ plus a libhttrack4 rename;
+# declined, see 3:7:0.
 # 3:15:0: revision-only bump. httrackp gained a tail field (wizard_filters) and two
 # exports arrived (hts_footer_field_ok, hts_wizard_host_scope); HTS_LOCATION_SIZE only
 # names lien_back.location_buffer's existing size, it does not change it.


### PR DESCRIPTION
A comment, no build change. It amends the `3:16:0` entry in `configure.ac`'s rationale block.

`VERSION_INFO` was set to `3:16:0` by the 3.49.23 release, and #1365 landed after it — widening `t_cookie.max_len` to `size_t` in `htsbauth.h`, which is installed. So that entry's "does not move a layout" became false for the very value it describes, and nothing anywhere recorded that the soname staying at `.so.3` was a decision rather than a miss.

Measured rather than asserted, by compiling the real headers at `a4023efb^` and at master:

```
OLD (int)     data=4  auth=32776  sizeof=34832
NEW (size_t)  data=8  auth=32776  sizeof=34832
```

Only `data[]` moves; `auth` and `sizeof` are unchanged, because the old four-byte padding hole absorbs the growth. So a consumer dereferencing `opt->cookie->data` reads four bytes off, while one reaching `->auth` is unaffected. The comment says that, because a break stated more broadly than it is gets over-corrected later.

Why it is worth a comment at all: a dry-run of the release runbook against master read the un-bumped soname as a missed bump and told me to fix it, correctly from the evidence it had. Two agents looking at this question tonight even disagreed about whether the break was on master, one of them reading a stale checkout — and the answer moves the 3.50 recommendation between `3:17:0` and `4:0:0`. Leaving it unwritten is how a release picks the wrong one.

An earlier draft of this said to hold it until the 3.50 `VERSION_INFO` decision. That was over-cautious and I am withdrawing it. The entry records what happened to `3:16:0`, a value 3.49.23 already shipped with as `.so.3` — that cannot be changed retroactively, so it is true whatever 3.50 becomes. If 3.50 goes to `4:0:0`, that gets its own line beside this one rather than contradicting it.