### PR TITLE
Windows-only paths in FAQ answers that are not Windows-specific

### DIFF
--- a/html/faq.html
+++ b/html/faq.html
@@ -820,7 +820,7 @@ A: <em>Yes. There is no absolute links, all links are relative.
 You can copy a project to another drive/computer/OS, and browse is without installing anything.</em>
 
 <br><br><a NAME="QM12">Q: <strong>Can I copy a project to another computer/system? Can I then update it ?</strong></a><br>
-A: <em>Absolutely! You can keep your HTTrack projects folder (<tt>My Web Sites</tt> on Windows, <tt>websites</tt> in your home directory elsewhere) in your local hard disk, copy it
+A: <em>Absolutely! You can keep your HTTrack projects folder (<tt>My Web Sites</tt> in WinHTTrack, <tt>websites</tt> in your home directory otherwise) in your local hard disk, copy it
 for a friend, and possibly update it, and then bring it back!<br>You can copy individual folders (projects), too: exchange
 your favorite websites with your friends, or send an old version of a site to someone who has a faster connection, and
 ask him to update it!</i><br>

--- a/html/faq.html
+++ b/html/faq.html
@@ -811,7 +811,7 @@ A: <em>Yes. Drag&Drop your bookmark.html file to the WinHTTrack window (or use f
 bookmark mirroring (mirror all links in pages, -Y) or bookmark testing (--testlinks)<em></em>
 
 <br><br><a NAME="QM11c">Q: <strong>Can I convert a local website (file:// links) to a standard website?</strong></a><br>
-A: <em>Yes. Just start from the top index (example: file://C:\foopages\index.html) and mirror the local website. 
+A: <em>Yes. Just start from the top index (example: file:///home/me/foopages/index.html, or file://C:\foopages\index.html on Windows) and mirror the local website. 
 HTTrack will convert all file:// links to relative ones.
 </em>
 
@@ -820,7 +820,7 @@ A: <em>Yes. There is no absolute links, all links are relative.
 You can copy a project to another drive/computer/OS, and browse is without installing anything.</em>
 
 <br><br><a NAME="QM12">Q: <strong>Can I copy a project to another computer/system? Can I then update it ?</strong></a><br>
-A: <em>Absolutely! You can keep your HTTrack favorite folder (C:\My Web Sites) in your local hard disk, copy it
+A: <em>Absolutely! You can keep your HTTrack projects folder (<tt>My Web Sites</tt> on Windows, <tt>websites</tt> in your home directory elsewhere) in your local hard disk, copy it
 for a friend, and possibly update it, and then bring it back!<br>You can copy individual folders (projects), too: exchange
 your favorite websites with your friends, or send an old version of a site to someone who has a faster connection, and
 ask him to update it!</i><br>

--- a/src/htsmodules.h
+++ b/src/htsmodules.h
@@ -75,7 +75,7 @@ typedef int (*t_htsAddLink)(htsmoduleStruct *str, char *link);
     Field access classes are noted; engine owns all pointers unless stated. */
 struct htsmoduleStruct {
   /* Read-only elements */
-  const char *filename; /* filename (C:\My Web Sites\...) */
+  const char *filename; /* filename (project path, e.g. My Web Sites/...) */
   int size;             /* size of filename (should be > 0) */
   const char *mime;     /* MIME type of the object */
   const char *url_host; /* incoming hostname (www.foo.com) */


### PR DESCRIPTION
The FAQ told everyone to look for their mirrors under `C:\My Web Sites` and gave a `file://C:\...` example, on two answers that Linux and macOS users read as well. Both now show the Windows form as one case rather than the only one, and a field comment in `htsmodules.h` that used the same path as its example goes with them. The remaining `C:\temp\` examples sit inside questions about Program Files and the Windows installer, where they are correct.

That is the whole safe half of #105. The rest needs a decision, not a patch.

The Windows default output directory is not set in this repo. On POSIX the engine builds it from the home directory (`htshelp.c`, `htsserver.c` and `webhttrack.in` all land on `<home>/websites`). `C:\My Web Sites` reaches WinHTTrack through `LANG_S30` in `lang.def`, and the code that acts on it lives in httrack-windows. Moving it under Documents, or renaming it so it says HTTrack, is a WinHTTrack change plus a migration story: `winprofile.ini` keeps whatever path the user last browsed to.

The example paths in `lang/*.txt` are not cosmetic either. Each catalog is a list of pairs whose odd line is the English string, and that string is the lookup key; `62_lang-integrity.test` rejects any msgid missing from `English.txt`. Rewriting `C:\\My Web Sites` or `Example:\t%h%p/%n%q.%t\n->\t\tc:\\mirror\\www.someweb.com\\someimages\\image.gif` in English orphans all 29 translations of it unless every catalog is edited in the same commit, each in its own legacy charset. The translated halves are what WinHTTrack displays, so changing those is a user-visible change to a value whose consumers we cannot grep.

Open for Xavier: should the Windows default move to something like `%USERPROFILE%\Documents\HTTrack Web Sites`, and if it does, what happens to profiles already pointing at `C:\My Web Sites`? And is a coordinated 30-file catalog edit worth it to neutralize those two example strings, given it rewrites the join keys and every translation of them?

Refs #105.

One fact needed to decide the first question, which I could not establish from this repo: whether WinHTTrack falls back to `LANG_S30` when `winprofile.ini` carries no path key, or leaves the field empty. That decides whether existing profiles migrate silently or have to be touched.