### PR TITLE
A vanished suite worker is reported as a clean run

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -285,7 +285,7 @@ jobs:
 
       # Its own step: the watchdog can kill the suite's step before it counts,
       # which is exactly when the count is worth having.
-      - name: Count the MSYS fork failures
+      - name: Count the MSYS fork failures and the lost workers
         if: always()
         shell: bash
         working-directory: tests

--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -163,7 +163,7 @@ test "$rc" -eq 1 || fail "stub suite exited $rc, want 1 from the pass floor"
 # test would run it twice and inflate every tally the gates read.
 dup=$(awk '/^RUN /{print $2}' suite-progress.log | sort | uniq -d)
 test -z "$dup" || fail "a test was selected by two categories: $dup"
-grep -q '^ran=12 pass=10 fail=1 skip=1$' <<<"$out" ||
+grep -q '^ran=12 pass=10 fail=1 skip=1 lost=0$' <<<"$out" ||
     fail "wrong tally: $(grep '^ran=' <<<"$out")"
 grep -q '::error::only 10 tests passed (1 skipped)' <<<"$out" ||
     fail "the pass floor did not report the count"

--- a/tests/232_online-gate-outoftree.test
+++ b/tests/232_online-gate-outoftree.test
@@ -72,6 +72,7 @@ eval_re='(^|[;&|(`])[[:space:]]*eval[[:space:]]'
 # shape, because a shape exemption cannot tell them from #1016 in disguise.
 allowed='172_ci-windows-driver.test ci-windows-suite.sh
 286_ci-windows-pool.test ci-windows-suite.sh
+337_ci-lost-worker.test ci-windows-suite.sh
 ci-windows-suite.sh test-timeout.sh'
 
 # Matching lines of the given files as file:line:text, comments dropped:

--- a/tests/286_ci-windows-pool.test
+++ b/tests/286_ci-windows-pool.test
@@ -84,7 +84,7 @@ run_suite() { # run_suite <dir> <jobs>
 assert_tally() {
     local got
     got=$(grep '^ran=' "$tmp/out" || true)
-    test "$got" = 'ran=12 pass=10 fail=1 skip=1' || fail "$1: wrong tally: $got"
+    test "$got" = 'ran=12 pass=10 fail=1 skip=1 lost=0' || fail "$1: wrong tally: $got"
     grep -q 'FAIL 12_engine-fail.test (exit 3)' "$tmp/out" || fail "$1: the failing test was not named"
     grep -q '^SKIP 11_engine-skip.test$' "$tmp/out" || fail "$1: the skipped test was not named"
 }

--- a/tests/313_ci-fork-failures.test
+++ b/tests/313_ci-fork-failures.test
@@ -48,7 +48,7 @@ assert_counts() { # assert_counts LOG WANT-DIED WANT-RETRIED WANT-GAVEUP LABEL S
     # The counts alone name no test and no time: an annotation without an example
     # line sends the reader back to a log the runner may no longer have.
     grep -q "$6" <<<"$out" || fail "$label: no sample line matching [$6]: $out"
-    grep -q "MSYS forks: $2 died, $3 retried, $4 given up" "$GITHUB_STEP_SUMMARY" ||
+    grep -q "MSYS forks: $2 died, $3 retried, $4 given up; 0 worker(s) lost" "$GITHUB_STEP_SUMMARY" ||
         fail "$label: step summary says $(<"$GITHUB_STEP_SUMMARY")"
 }
 
@@ -89,9 +89,10 @@ assert_counts "$tmp/crjoined.log" 2 0 0 "two messages joined by a CR" "forked pr
 : >"$GITHUB_STEP_SUMMARY"
 grep -v 'fork' "$tmp/console.log" >"$tmp/clean.log"
 out=$(ci_report_fork_failures "$tmp/clean.log") || fail "counting a clean leg failed"
-grep -q 'no MSYS fork failure' <<<"$out" || fail "a clean leg said: $out"
+grep -q 'no MSYS fork failure and no lost worker' <<<"$out" ||
+    fail "a clean leg said: $out"
 ! grep -q '::warning' <<<"$out" || fail "a clean leg raised an annotation: $out"
-grep -q 'MSYS forks: 0 died, 0 retried, 0 given up' "$GITHUB_STEP_SUMMARY" ||
+grep -q 'MSYS forks: 0 died, 0 retried, 0 given up; 0 worker(s) lost' "$GITHUB_STEP_SUMMARY" ||
     fail "a clean leg wrote no count: $(<"$GITHUB_STEP_SUMMARY")"
 
 # The suite step can die before writing a log; the counter step still runs.

--- a/tests/337_ci-lost-worker.test
+++ b/tests/337_ci-lost-worker.test
@@ -203,7 +203,14 @@ stage() { # stage <dir> <lost stub body>
     done
     # shellcheck disable=SC2086 # one stub per name, so the splitting is the point
     for t in $expected_skips; do stub "$d/$t" 77; done
-    stub "$d/906_engine-lost.test" 0 "$2"
+    if test -n "${3:-}"; then
+        # The killer on a pinned skip: the vanished worker cannot record its
+        # skip, so the set gate fires before the lost gate is ever consulted.
+        stub "$d/906_engine-lost.test" 0
+        stub "$d/$3" 77 "$2"
+    else
+        stub "$d/906_engine-lost.test" 0 "$2"
+    fi
 }
 
 # Drive the suite staged in $1 into $tmp/out, its status into $rc.
@@ -241,6 +248,24 @@ grep -q '::error::failing:' "$tmp/out" &&
     fail "a killed worker was reported as a failing test: $(<"$tmp/out")"
 # 3, so the workflow can tell a leg to repeat from a leg to investigate (#1228).
 test "$rc" -eq 3 || fail "a lost worker exited $rc, want 3: $(<"$tmp/out")"
+
+# Again with the killer on one of the pinned skips. That run reaches the skip-set
+# gate, which exits before the lost gate unless it is told a vanished worker
+# explains the difference: the reason this stays a leg to repeat.
+# shellcheck disable=SC2086 # the splitting is what picks one name
+pinned=$(printf '%s\n' $expected_skips | head -1)
+stage "$tmp/killedskip" "$killer" "$pinned"
+run_suite "$tmp/killedskip"
+case "$(<"$share/killed")" in
+none*) fail "the pinned-skip stub killed no worker: $(<"$share/killed")" ;;
+esac
+grep -q "^LOST $pinned (worker left no status; " "$tmp/out" ||
+    fail "the vanished skip was not reported: $(<"$tmp/out")"
+grep -q '::error::skip set changed from expected' "$tmp/out" ||
+    fail "the skip set did not change, so this run reaches the wrong gate: $(<"$tmp/out")"
+test "$rc" -eq 3 ||
+    fail "a worker lost from the pinned skips exited $rc, want 3: $(<"$tmp/out")"
+ok "a skip that vanished is still a leg to repeat"
 
 # The counter reading that very console back, which is the path the Windows leg takes.
 report "$tmp/out"

--- a/tests/337_ci-lost-worker.test
+++ b/tests/337_ci-lost-worker.test
@@ -281,4 +281,20 @@ report "$tmp/out"
 grep -q '::error title=workers lost with no status::' <<<"$out" ||
     fail "the counter read the suite's own console as clean: $out"
 
+# A loss alongside a real failure: the failure decides, or a red ships as a leg to
+# repeat and nobody investigates it.
+stage "$tmp/mixed" "$killer"
+stub "$tmp/mixed/900_zlib-pass.test" 3
+run_suite "$tmp/mixed"
+case "$(<"$share/killed")" in
+none*) fail "the mixed stub killed no worker: $(<"$share/killed")" ;;
+esac
+grep -q '^LOST 906_engine-lost.test (worker left no status; ' "$tmp/out" ||
+    fail "the vanished worker was not reported beside the failure: $(<"$tmp/out")"
+grep -q '::error::failing: 900_zlib-pass.test' "$tmp/out" ||
+    fail "the failing test was not named: $(<"$tmp/out")"
+test "$rc" -eq 1 ||
+    fail "a failure alongside a loss exited $rc, want 1: $(<"$tmp/out")"
+ok "a real failure outranks a lost worker"
+
 echo "lost-worker classification OK"

--- a/tests/337_ci-lost-worker.test
+++ b/tests/337_ci-lost-worker.test
@@ -140,6 +140,15 @@ chmod +x "$bin/httrack" "$bin/cygpath"
 # Ahead of the driver's own command -v, which asks access(X_OK) and reads false here.
 test -x "$bin/httrack" || skip "${TMPDIR:-/tmp} is noexec, the stub bindir cannot be run"
 
+# The killer stub finds its target by reading argv out of ps, and the emulated
+# leg's rootfs has no procps: a walk that matches nothing there is the missing
+# tool, not a missing worker.
+psargs=$(ps -o args= -p $$ 2>/dev/null || true)
+psppid=$(ps -o ppid= -p $$ 2>/dev/null | tr -d " " || true)
+if test -z "$psargs" || test -z "$psppid"; then
+    skip "no ps reporting argv and ppid, so the ancestry walk cannot run"
+fi
+
 share=$tmp/share
 mkdir -p "$share"
 export POOLSHARE=$share

--- a/tests/337_ci-lost-worker.test
+++ b/tests/337_ci-lost-worker.test
@@ -1,0 +1,250 @@
+#!/bin/bash
+#
+# A worker of ci-windows-suite.sh that dies before writing any status (#1352): the
+# tally must call it lost rather than failed, the counter must never call the leg
+# clean, and the suite must end on a status that says re-run, not investigate. Driven
+# here because the Windows leg, where it happens, keeps no evidence of it.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+# Before the driver is sourced: with these set, anything it starts posts a commit
+# status on whatever the surrounding shell was last looking at.
+unset WATCHDOG_TOKEN WATCHDOG_REPO WATCHDOG_SHA WATCHDOG_URL
+# shellcheck source=tests/ci-windows-suite.sh
+. "$testdir/ci-windows-suite.sh"
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_lostworker.XXXXXX")
+cleanup_push rm -rf "$tmp"
+
+GITHUB_STEP_SUMMARY=$tmp/summary
+export GITHUB_STEP_SUMMARY
+: >"$GITHUB_STEP_SUMMARY"
+
+# --- what a worker leaves behind, and what that means ------------------------
+
+res=$tmp/results
+mkdir -p "$res"
+echo 0 >"$res/pass.test.rc"
+echo 77 >"$res/skip.test.rc"
+echo 3 >"$res/fail.test.rc"
+# A worker killed mid-write: the file exists and holds nothing, which is not a 0.
+: >"$res/halfwritten.test.rc"
+# gone.test.rc is deliberately absent.
+
+for c in pass:pass skip:skip fail:fail gone:lost halfwritten:lost; do
+    ci_read_outcome "${c%:*}.test" "$res"
+    test "$ci_outcome" = "${c#*:}" ||
+        fail "${c%:*}.test classified as $ci_outcome, want ${c#*:} (rc=[$ci_rc])"
+done
+
+# On synthetic logs, not in the run below, where which of the three a killed worker
+# lands on depends on what its test had managed to print.
+lostdir=$tmp/lost
+mkdir -p "$lostdir"
+(
+    cd "$lostdir"
+    : >opened.test.log
+    echo "the test spoke" >spoke.test.log
+    for c in missing:'no log at all' opened:'0-byte log' spoke:'log written'; do
+        ci_lost_reason "${c%:*}.test"
+        case "$ci_reason" in
+        "${c#*:}"*) ;;
+        *) fail "${c%:*}.test: reason is [$ci_reason], want [${c#*:}...]" ;;
+        esac
+    done
+)
+
+# --- the counter, over four consoles ----------------------------------------
+
+# Real lines from the #1273 run, kept in step with 313_ci-fork-failures.test.
+forkline='1 [main] bash 1728 dofork: child -1 - forked process 3984 died unexpectedly, retry 0, exit code 0xC0000142, errno 11'
+lostline='LOST 86_local-proxytrack-cache-longfields.test (worker left no status; 0-byte log: it died before its test wrote anything)'
+
+{
+    echo 'PASS 244_local-tty-output.test'
+    echo 'ran=263 pass=239 fail=0 skip=23 lost=0'
+} >"$tmp/clean.log"
+{
+    echo "$forkline"
+    echo './ci-windows-suite.sh: fork: retry: Resource temporarily unavailable'
+} >"$tmp/forks.log"
+{
+    echo 'PASS 244_local-tty-output.test'
+    echo "$lostline"
+    # Indented, as the suite reports a failure tail: a test cannot forge a verdict.
+    echo '      LOST 99_decoy.test (worker left no status; 0-byte log)'
+} >"$tmp/lost.log"
+{
+    echo "$forkline"
+    echo "$lostline"
+} >"$tmp/both.log"
+
+report() { # report LOG -> $out, $summary
+    : >"$GITHUB_STEP_SUMMARY"
+    out=$(ci_report_fork_failures "$1") || fail "the counter exited nonzero on $1"
+    summary=$(<"$GITHUB_STEP_SUMMARY")
+}
+
+report "$tmp/clean.log"
+grep -q 'no MSYS fork failure and no lost worker' <<<"$out" || fail "a clean leg said: $out"
+grep -q '^MSYS forks: 0 died, 0 retried, 0 given up; 0 worker(s) lost$' <<<"$summary" ||
+    fail "a clean leg summarised: $summary"
+grep -q '::' <<<"$out" && fail "a clean leg raised an annotation: $out"
+
+report "$tmp/forks.log"
+grep -q '::warning title=MSYS fork failures::' <<<"$out" || fail "the fork leg raised none: $out"
+grep -q 'workers lost' <<<"$out" && fail "the fork leg invented a lost worker: $out"
+grep -q '; 0 worker(s) lost$' <<<"$summary" || fail "the fork leg summarised: $summary"
+
+report "$tmp/lost.log"
+# The whole defect: this sentence, unqualified, is what called the #1352 leg clean.
+grep -q 'no MSYS fork failure and no lost worker' <<<"$out" &&
+    fail "a leg that lost a worker read as clean: $out"
+grep -q 'but 1 worker(s) left no status' <<<"$out" || fail "the lost leg said: $out"
+grep -q '::error title=workers lost with no status::' <<<"$out" ||
+    fail "the lost leg raised no error annotation: $out"
+grep -q '86_local-proxytrack-cache-longfields.test' <<<"$out" ||
+    fail "the lost leg named no test: $out"
+grep -q '; 1 worker(s) lost$' <<<"$summary" || fail "the lost leg summarised: $summary"
+
+report "$tmp/both.log"
+grep -q '::warning title=MSYS fork failures::' <<<"$out" || fail "both: no fork annotation: $out"
+grep -q '::error title=workers lost with no status::' <<<"$out" || fail "both: no lost annotation: $out"
+grep -q '; 1 worker(s) lost$' <<<"$summary" || fail "both: summarised $summary"
+
+# The control on all of it: without the LOST rule the counter is the old one, and
+# reads this very console as clean.
+old=$tmp/old
+mkdir -p "$old"
+cp "$testdir/ci-windows-suite.sh" "$testdir/testlib.sh" "$testdir/proclib.sh" "$old/"
+chmod u+w "$old"/*.sh # distcheck's srcdir is read-only, and cp carries that over
+grep -v '/\^LOST / { lost++; next }' "$old/ci-windows-suite.sh" >"$old/mutant.sh"
+cmp -s "$old/ci-windows-suite.sh" "$old/mutant.sh" &&
+    fail "the blind-counter mutant changed nothing, so it proves nothing"
+mv "$old/mutant.sh" "$old/ci-windows-suite.sh"
+oldout=$(cd "$old" && bash -c '. ./ci-windows-suite.sh; ci_report_fork_failures "$1"' _ "$tmp/lost.log")
+grep -q 'no MSYS fork failure and no lost worker' <<<"$oldout" ||
+    fail "the blind counter did not misread the lost leg, so the new rule is not what fixes it: $oldout"
+
+# --- and the same thing end to end, with a worker really killed --------------
+
+bin=$tmp/bin
+mkdir -p "$bin"
+printf '#!/bin/sh\nexit 0\n' >"$bin/httrack"
+# shellcheck disable=SC2016 # $2 is the stub's own expansion
+printf '#!/bin/sh\necho "$2"\n' >"$bin/cygpath"
+chmod +x "$bin/httrack" "$bin/cygpath"
+# Ahead of the driver's own command -v, which asks access(X_OK) and reads false here.
+test -x "$bin/httrack" || skip "${TMPDIR:-/tmp} is noexec, the stub bindir cannot be run"
+
+share=$tmp/share
+mkdir -p "$share"
+export POOLSHARE=$share
+
+# The 23 the driver pins as expected skips, so a stub run can reach the gates past
+# the skip-set compare instead of stopping on it.
+expected_skips=$(sed -n '/^expected_skips="/,/"$/p' "$testdir/ci-windows-suite.sh" |
+    sed -e 's/^expected_skips="//' -e 's/"$//')
+nskip=$(count_matching_lines . <<<"$expected_skips")
+test "$nskip" -ge 1 || fail "read no expected skips out of the driver"
+# 91 passing stubs clear its floor of 90, and the lost one passes in the control leg.
+ran=$((92 + nskip))
+
+stub() { # stub <path> <exit status> [shell line]
+    # shellcheck disable=SC2016 # the stub's own expansions, not this shell's
+    printf '#!/bin/sh\n%s\nexit %s\n' "${3:-:}" "$2" >"$1"
+}
+
+# Kill the run_one_test subshell where the real one died: after its log was opened,
+# before it could write a status. It is the closest ancestor still carrying the
+# driver's argv, so a lone match is the driver itself and the stub says so instead.
+# shellcheck disable=SC2016 # the stub's own expansions, not this shell's
+killer='
+p=$PPID
+first=
+n=0
+while [ -n "$p" ] && [ "$p" -gt 1 ]; do
+    case "$(ps -o args= -p "$p" 2>/dev/null)" in
+    *ci-windows-suite.sh*)
+        n=$((n + 1))
+        [ -n "$first" ] || first=$p
+        ;;
+    esac
+    p=$(ps -o ppid= -p "$p" 2>/dev/null | tr -d " ")
+done
+if [ "$n" -ge 2 ]; then
+    echo "$first" >"$POOLSHARE/killed"
+    kill -9 "$first"
+    exit 0
+fi
+echo "none ($n ancestors run the driver)" >"$POOLSHARE/killed"'
+
+stage() { # stage <dir> <lost stub body>
+    local d=$1 t i
+    rm -rf "$d"
+    mkdir -p "$d/rt"
+    cp "$testdir/ci-windows-suite.sh" "$testdir/testlib.sh" "$testdir/proclib.sh" \
+        "$testdir/test-timeout.sh" "$d/"
+    chmod u+w "$d"/*.sh
+    # Neutered, or it would kill a sibling's engine under "make check -j".
+    printf 'reap_leftover_processes() { return 0; }\n' >>"$d/proclib.sh"
+    # One per glob the driver enumerates, plus enough passes to clear its floor of 90.
+    for t in 00_runnable 900_zlib-pass 901_watchdog-pass 902_crawllib-pass \
+        903_crawl-harness-pass 904_crawl_proxy_https 905_crawl-log-salvage; do
+        stub "$d/$t.test" 0
+    done
+    i=0
+    while test "$i" -lt 84; do
+        stub "$d/9$((100 + i))_engine-pass.test" 0
+        i=$((i + 1))
+    done
+    # shellcheck disable=SC2086 # one stub per name, so the splitting is the point
+    for t in $expected_skips; do stub "$d/$t" 77; done
+    stub "$d/906_engine-lost.test" 0 "$2"
+}
+
+# Drive the suite staged in $1 into $tmp/out, its status into $rc.
+rc=0
+run_suite() { # run_suite <dir>
+    rc=0
+    (
+        cd "$1"
+        RUNNER_TEMP="$1/rt" GITHUB_STEP_SUMMARY="$tmp/summary" HTTRACK_SUITE_JOBS=6 \
+            bash ./ci-windows-suite.sh "$bin"
+    ) >"$tmp/out" 2>&1 || rc=$?
+}
+
+# The control first: the same stubs with nothing killed have to come out green, or
+# the run below proves only that a stub suite cannot pass.
+stage "$tmp/ok" ':'
+run_suite "$tmp/ok"
+test "$rc" -eq 0 || fail "a clean stub suite exited $rc: $(<"$tmp/out")"
+grep -q "^ran=$ran pass=92 fail=0 skip=$nskip lost=0$" "$tmp/out" ||
+    fail "clean tally: $(grep '^ran=' "$tmp/out" || true)"
+
+stage "$tmp/killed" "$killer"
+run_suite "$tmp/killed"
+case "$(<"$share/killed")" in
+none*) fail "the stub killed no worker, so the run proves nothing: $(<"$share/killed")" ;;
+esac
+# On its own line, not folded into the failures: the counter step reads these back.
+grep -q '^LOST 906_engine-lost.test (worker left no status; ' "$tmp/out" ||
+    fail "the vanished worker was not reported: $(<"$tmp/out")"
+grep -q "^ran=$ran pass=91 fail=0 skip=$nskip lost=1$" "$tmp/out" ||
+    fail "lost tally: $(grep '^ran=' "$tmp/out" || true)"
+grep -q '::error::worker(s) vanished with no status, re-run this leg: 906_engine-lost.test' "$tmp/out" ||
+    fail "the suite did not name the vanished worker: $(<"$tmp/out")"
+grep -q '::error::failing:' "$tmp/out" &&
+    fail "a killed worker was reported as a failing test: $(<"$tmp/out")"
+# 3, so the workflow can tell a leg to repeat from a leg to investigate (#1228).
+test "$rc" -eq 3 || fail "a lost worker exited $rc, want 3: $(<"$tmp/out")"
+
+# The counter reading that very console back, which is the path the Windows leg takes.
+report "$tmp/out"
+grep -q '::error title=workers lost with no status::' <<<"$out" ||
+    fail "the counter read the suite's own console as clean: $out"
+
+echo "lost-worker classification OK"

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -550,7 +550,9 @@ want=$(printf '%s\n' $expected_skips | sort)
 if [ "$got" != "$want" ]; then
     echo "::error::skip set changed from expected; - missing, + newly skipped"
     diff -u <(echo "$want") <(echo "$got") | tail -n +3 | sed 's/^/      /'
-    exit 1
+    # A worker that vanished cannot have recorded its skip, so the set differs
+    # for a reason we already know; keep that a re-run, not a red.
+    [ "$lost" -gt 0 ] || exit 1
 fi
 [ "$fail" -eq 0 ] || {
     echo "::error::failing:$failed"

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -21,10 +21,11 @@ ci_annotate() {
     printf '\n::%s title=%s::%s\n' "$level" "$title" "$msg"
 }
 
-# Count the MSYS fork-emulation failures in the console log $1. Nothing counted
-# them, so a leg that struggled read exactly like one that never did (#1273).
+# Count the MSYS fork-emulation failures in the console log $1, and the workers the
+# suite lost with them (#1273). A worker can die without bash saying a word, so those
+# counts at zero are not by themselves a clean leg (#1352).
 ci_report_fork_failures() {
-    local log=$1 died retried gaveup
+    local log=$1 died retried gaveup lost
     test -r "$log" || {
         echo "no console log at $log: MSYS fork failures not counted"
         return 0
@@ -32,27 +33,69 @@ ci_report_fork_failures() {
     # Split on CR first: the console carries stdout and stderr merged, so two
     # messages can share a physical line and a line count would see one. bash
     # retries on EAGAIN alone, so a give-up can carry any strerror; each `next`
-    # keeps one message out of a second class.
-    read -r died retried gaveup <<<"$(tr '\r' '\n' <"$log" | awk '
+    # keeps one message out of a second class. The LOST verdicts sit at column 0,
+    # where the suite's indented failure tails cannot forge one.
+    read -r died retried gaveup lost <<<"$(tr '\r' '\n' <"$log" | awk '
+        /^LOST / { lost++; next }
         /fork: child -1|child_info_fork::abort|sync_with_child:/ { died++; next }
         /reserve memory for parent stack/ { died++; next }
         /fork: retry:/ { retried++; next }
         /: fork: / { gaveup++ }
-        END { print died + 0, retried + 0, gaveup + 0 }')"
+        END { print died + 0, retried + 0, gaveup + 0, lost + 0 }')"
     test -z "${GITHUB_STEP_SUMMARY:-}" ||
-        printf 'MSYS forks: %s died, %s retried, %s given up\n' \
-            "$died" "$retried" "$gaveup" >>"$GITHUB_STEP_SUMMARY"
+        printf 'MSYS forks: %s died, %s retried, %s given up; %s worker(s) lost\n' \
+            "$died" "$retried" "$gaveup" "$lost" >>"$GITHUB_STEP_SUMMARY"
     if test $((died + retried + gaveup)) -eq 0; then
-        echo "no MSYS fork failure in $log"
-        return 0
+        # Never bare: "no MSYS fork failure" alone is what called the #1352 leg clean.
+        if test "$lost" -eq 0; then
+            echo "no MSYS fork failure and no lost worker in $log"
+        else
+            echo "no MSYS fork failure in $log, but $lost worker(s) left no status"
+        fi
+    else
+        ci_annotate warning "MSYS fork failures" "$(
+            printf '%s child(ren) died at DLL init, %s retry wait(s), %s fork(s) given up\n' \
+                "$died" "$retried" "$gaveup"
+            # -a: one NUL in the log would otherwise cost every sample line.
+            tr '\r' '\n' <"$log" | grep -am 3 -e 'fork: child -1' -e 'sync_with_child:' \
+                -e 'child_info_fork::abort' -e 'reserve memory' -e ': fork: ' || true
+        )"
     fi
-    ci_annotate warning "MSYS fork failures" "$(
-        printf '%s child(ren) died at DLL init, %s retry wait(s), %s fork(s) given up\n' \
-            "$died" "$retried" "$gaveup"
-        # -a: one NUL in the log would otherwise cost every sample line.
-        tr '\r' '\n' <"$log" | grep -am 3 -e 'fork: child -1' -e 'sync_with_child:' \
-            -e 'child_info_fork::abort' -e 'reserve memory' -e ': fork: ' || true
+    # error, not warning: a lost worker is re-run where a fork storm is investigated.
+    test "$lost" -eq 0 || ci_annotate error "workers lost with no status" "$(
+        printf '%s worker(s) died before reporting: re-run this leg, and see #1228\n' "$lost"
+        tr '\r' '\n' <"$log" | grep -am 3 '^LOST ' || true
     )"
+}
+
+# Classify test $1's outcome from what its worker left in results dir $2, into
+# ci_outcome (pass, skip, fail, lost) and ci_rc. "lost" is a worker that died before
+# writing any status: an infrastructure symptom, not a test result. Assigned, not
+# printed: a fork per test costs tens of milliseconds under MSYS.
+ci_rc='' ci_outcome=''
+ci_read_outcome() {
+    ci_rc=''
+    # An empty .rc is a worker that died mid-write, never a status of 0.
+    test ! -r "$2/$1.rc" || read -r ci_rc <"$2/$1.rc" || true
+    case "$ci_rc" in
+    0) ci_outcome=pass ;;
+    77) ci_outcome=skip ;;
+    '') ci_outcome=lost ;;
+    *) ci_outcome=fail ;;
+    esac
+}
+
+# How far test $1's vanished worker got, into ci_reason, read off the log it opened:
+# wait -n reaps workers the pool can no longer name, so the wait status is gone.
+ci_reason=''
+ci_lost_reason() {
+    if test ! -e "$1.log"; then
+        ci_reason='no log at all: it died before opening one'
+    elif test ! -s "$1.log"; then
+        ci_reason='0-byte log: it died before its test wrote anything'
+    else
+        ci_reason='log written: it died after its test had run'
+    fi
 }
 
 # End a wedged suite before its runner dies: a step that fails on its own terms
@@ -253,7 +296,7 @@ ci_suite_heartbeat 960 360 "$progress" "$stuck" $$ "$hard_deadline" &
 heartbeat=$!
 trap 'set +e; kill "$heartbeat" 2>/dev/null; test -z "$watchdog" || kill_pid "$watchdog"' EXIT
 
-pass=0 fail=0 skip=0 failed="" skipped="" deadline=0
+pass=0 fail=0 skip=0 lost=0 failed="" skipped="" vanished="" deadline=0
 # Tests in flight at once, min(2*nproc, 16) as ci.yml gives "make check" on every
 # platform, unless the caller pins it (windows-build.yml does): each binds its own
 # ephemeral-port server, and they mostly sleep.
@@ -416,16 +459,17 @@ done
 # In test order, once nothing is still writing: eight workers interleaving their
 # failure tails is noise.
 for t in ${ran_tests[@]+"${ran_tests[@]}"}; do
-    # read, not $(cat): a fork per test costs tens of milliseconds under MSYS.
-    rc=
-    test ! -r "$results/$t.rc" || read -r rc <"$results/$t.rc" || true
-    case "$rc" in
-    0) pass=$((pass + 1)) ;;
-    77) skip=$((skip + 1)) skipped="$skipped $t" ;;
+    ci_read_outcome "$t" "$results"
+    case "$ci_outcome" in
+    pass) pass=$((pass + 1)) ;;
+    skip) skip=$((skip + 1)) skipped="$skipped $t" ;;
+    fail) fail=$((fail + 1)) failed="$failed $t" ;;
     *)
-        fail=$((fail + 1)) failed="$failed $t"
-        # A worker killed before it could report leaves no status behind.
-        test -n "$rc" || echo "FAIL $t (its worker left no status)"
+        lost=$((lost + 1)) vanished="$vanished $t"
+        # Its own verdict, not a FAIL: a test that crashed is not a worker killed
+        # under it.
+        ci_lost_reason "$t"
+        echo "LOST $t (worker left no status; $ci_reason)"
         ;;
     esac
     test ! -s "$results/$t.tail" || cat "$results/$t.tail"
@@ -433,7 +477,7 @@ done
 # An orphaned httrack.exe spins and starves the runner ("lost communication"). Once,
 # at the end: matching by image name, an earlier reap cannot spare a live sibling.
 reap_leftover_processes "the suite" | tee -a "$progress"
-echo "ran=$((pass + fail + skip)) pass=$pass fail=$fail skip=$skip" |
+echo "ran=$((pass + fail + skip + lost)) pass=$pass fail=$fail skip=$skip lost=$lost" |
     tee -a "$GITHUB_STEP_SUMMARY"
 
 # Every gate here exits 77, so an all-skipped suite would report green having
@@ -489,6 +533,10 @@ expected_skips="01_engine-footer-overflow.test
     echo "::error::suite did not finish within ${suite_deadline}s"
     exit 1
 }
+# Ahead of the gates below, each of which a lost worker can trip on its own: it
+# leaves the pass count short and the skip set holed.
+test "$lost" -eq 0 ||
+    echo "::error::worker(s) vanished with no status, re-run this leg:$vanished"
 [ "$pass" -ge 90 ] || {
     echo "::error::only $pass tests passed ($skip skipped)"
     exit 1
@@ -508,3 +556,6 @@ fi
     echo "::error::failing:$failed"
     exit 1
 }
+# Last, and 3 rather than 1: nothing failed on its own terms, so this leg is one to
+# repeat rather than a red to investigate (#1228).
+[ "$lost" -eq 0 ] || exit 3

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -539,7 +539,8 @@ test "$lost" -eq 0 ||
     echo "::error::worker(s) vanished with no status, re-run this leg:$vanished"
 [ "$pass" -ge 90 ] || {
     echo "::error::only $pass tests passed ($skip skipped)"
-    exit 1
+    # Vanished workers lower the count without anything having failed.
+    [ "$lost" -gt 0 ] || exit 1
 }
 # Word-split on whitespace (space-joined $skipped, newline-joined
 # expected_skips both work) and sort, so the compare is a set, not a string.
@@ -549,7 +550,7 @@ got=$(printf '%s\n' $skipped | sort)
 want=$(printf '%s\n' $expected_skips | sort)
 if [ "$got" != "$want" ]; then
     echo "::error::skip set changed from expected; - missing, + newly skipped"
-    diff -u <(echo "$want") <(echo "$got") | tail -n +3 | sed 's/^/      /'
+    diff -u <(echo "$want") <(echo "$got") | tail -n +3 | sed 's/^/      /' || true
     # A worker that vanished cannot have recorded its skip, so the set differs
     # for a reason we already know; keep that a re-run, not a red.
     [ "$lost" -gt 0 ] || exit 1


### PR DESCRIPTION
The Windows suite's fork-failure counter reads the console log for the messages bash prints when MSYS fork emulation gives out, so a worker that dies without bash saying anything is invisible to it: run 32484281897 ended on "no MSYS fork failure in suite-console.log" about a leg that had just lost `86_local-proxytrack-cache-longfields.test`. The issue's account of the mechanism holds, with one correction: the suite step was not green. The tally already counted a missing `.rc` as a failure, so the leg exited 1. What was indistinguishable was the class, in the counter's verdict and in the `failing:` list.

The tally now has three outcomes instead of two. A failed test keeps `FAIL` and its place in `failing:`; a worker that left no status gets a `LOST` verdict saying how far it got (no log, a 0-byte log, or a log its test had written), a `lost=` field in the tally line, and an `::error::` naming the leg as one to re-run; a clean run says so with the lost count included. The counter reads those `LOST` lines back and annotates them, so its clean sentence is never printed bare again. A lost worker stays fatal, since a leg that tested less than it reports must not ship green, but exits 3 rather than 1 when nothing else failed: the status is all the workflow keeps of the difference between a leg to repeat and a red to investigate (#1228). The parent's wait status is deliberately not used, because `wait -n` reaps workers the pool can no longer name; the log the worker opened is what survives.

Classification moved into `ci_read_outcome` and `ci_lost_reason`, above the driver's source guard, so `337_ci-lost-worker.test` can drive it off the Windows runner: the four `.rc` states, the counter over a clean, a fork-failure, a lost-worker and a mixed console, a mutant with the `LOST` rule removed proving the old counter misread the same log as clean, and a driver run over 115 stub tests where one stub kills its own worker, the control leg exiting 0 against the killed leg's 3 with `lost=1` and nothing in `failing:`.

Closes #1352
