### PR TITLE
htsserver answers any Host, and advertises URLs a browser cannot open

### DIFF
--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -1087,6 +1087,9 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
           } else if ((p = strfield(line, "Origin:")) != 0) {
             copy_header_value(origin, sizeof(origin), line + p);
           } else if ((p = strfield(line, "Host:")) != 0) {
+            /* A repeated header keeps the last value. Safe only because we are
+               loopback-direct: behind a proxy honouring the first, the two
+               would disagree. */
             copy_header_value(host, sizeof(host), line + p);
           }
         }

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -95,6 +95,10 @@ int commandReturnSet = 0;
 
 httrackp *global_opt = NULL;
 
+/* Address the listening socket was bound to, as given: an authority we
+   answer for, whatever a request's Host header claims. */
+static char server_bound_addr[256 + 2] = "";
+
 static void (*pingFun)(void *, smallserver_client_event, const char *) = NULL;
 static void* pingFunArg = NULL;
 
@@ -254,6 +258,26 @@ static int gethost(const char *hostname, SOCaddr * server) {
   return 0;
 }
 
+/** Form of a bound address a client can actually open: a wildcard names no
+    reachable host, and an IPv6 literal needs its URL brackets. */
+static void advertised_host(char *dst, size_t size, const char *bound) {
+  const char *host = bound;
+
+  /* every address reaches us, and loopback is the one the local browser has */
+  if (strcmp(host, "0.0.0.0") == 0) {
+    host = "127.0.0.1";
+  } else if (strcmp(host, "::") == 0) {
+    host = "::1";
+  }
+  if (strchr(host, ':') != NULL) {
+    strlcpybuff(dst, "[", size);
+    strlcatbuff(dst, host, size);
+    strlcatbuff(dst, "]", size);
+  } else {
+    strlcpybuff(dst, host, size);
+  }
+}
+
 // smallserver_init(&port,&return_host);
 T_SOC smallserver_init(int *port, char *adr, const char *bindAddr) {
   T_SOC soc = INVALID_SOCKET;
@@ -280,13 +304,17 @@ T_SOC smallserver_init(int *port, char *adr, const char *bindAddr) {
     }
     strcpybuff(h_loc, bindAddr);
   }
+  strcpybuff(server_bound_addr, h_loc);
 
   if ((soc = (T_SOC) socket(SOCaddr_sinfamily(server), SOCK_STREAM, 0)) !=
       INVALID_SOCKET) {
     SOCaddr_initport(server, *port);
     if (bind(soc, &SOCaddr_sockaddr(server), SOCaddr_size(server)) == 0) {
       if (listen(soc, 10) >= 0) {
-        strcpy(adr, h_loc);
+        char adv[sizeof(h_loc) + 2]; /* + the brackets of an IPv6 literal */
+
+        advertised_host(adv, sizeof(adv), h_loc);
+        strcpy(adr, adv);
       } else {
 #ifdef _WIN32
         closesocket(soc);
@@ -354,6 +382,62 @@ static hts_boolean origin_is_self(const char *origin, const char *host) {
   const char *const authority = origin + p;
 
   return host[0] != '\0' && p != 0 && strfield2(authority, host) != 0;
+}
+
+/** Hostname part of a Host header value, URL brackets and ":port" removed.
+    False, and dst empty, when it names no host or does not fit. */
+static hts_boolean host_hostname(char *dst, size_t size, const char *host) {
+  const char *start = host;
+  const char *end;
+
+  dst[0] = '\0';
+  if (*start == '[') {
+    end = strchr(++start, ']');
+    if (end == NULL || (end[1] != '\0' && end[1] != ':')) {
+      return HTS_FALSE;
+    }
+  } else if ((end = strchr(start, ':')) == NULL) {
+    end = start + strlen(start);
+  }
+  if (end == start || (size_t) (end - start) >= size) {
+    return HTS_FALSE;
+  }
+  memcpy(dst, start, (size_t) (end - start));
+  dst[end - start] = '\0';
+  return HTS_TRUE;
+}
+
+/** Is this an address literal rather than a DNS name? A colon survived
+    host_hostname only from inside brackets, so it means IPv6. */
+static hts_boolean host_is_address(const char *name) {
+  size_t i;
+
+  if (strchr(name, ':') != NULL) {
+    return HTS_TRUE;
+  }
+  for (i = 0; name[i] != '\0'; i++) {
+    if (!isdigit((unsigned char) name[i]) && name[i] != '.') {
+      return HTS_FALSE;
+    }
+  }
+  return i != 0 ? HTS_TRUE : HTS_FALSE;
+}
+
+/** May a request presenting this authority drive the panel?
+    A page can point a name of its own at our address and have the browser call
+    us same-origin, which an unauthenticated panel must refuse. That always
+    presents a name: an address literal is whoever opened the socket, and the
+    only names we vouch for are localhost and whatever --bind was given. */
+static hts_boolean host_is_self(const char *host, const char *bound) {
+  char name[256];
+
+  if (!host_hostname(name, sizeof(name), host)) {
+    return HTS_FALSE;
+  }
+  return strfield2(name, "localhost") != 0 || host_is_address(name) ||
+                 (bound[0] != '\0' && strfield2(name, bound) != 0)
+             ? HTS_TRUE
+             : HTS_FALSE;
 }
 
 /** Header value with leading blanks dropped, clipped to fit dst. */
@@ -930,7 +1014,8 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
     T_SOC soc_c;
     LLint length = 0;
     const char *error_redirect = NULL;
-    hts_boolean denied = HTS_FALSE;
+    /* Why the request was refused, shown on the 403 page; NULL until it is. */
+    const char *denied = NULL;
     /* The request proved it holds the session id. */
     hts_boolean authed = HTS_FALSE;
     char origin[256];
@@ -1050,6 +1135,14 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
         }
       }
 
+      /* Every method, not just POST: a GET hands out the session id. An absent
+         Host is allowed, since only a non-browser client omits it. */
+      if (meth && host[0] != '\0' && !host_is_self(host, server_bound_addr)) {
+        buffer[0] = '\0';
+        meth = 0;
+        denied = "Foreign Host header.";
+      }
+
       /* CSP stops a mirrored page reading /server/, not posting to it blind:
          a no-cors POST still runs the command. Origin is browser-set and script
          cannot forge it. Absent is allowed, most non-browser clients send none.
@@ -1057,7 +1150,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
       if (meth == 2 && origin[0] != '\0' && !origin_is_self(origin, host)) {
         buffer[0] = '\0';
         meth = 0;
-        denied = HTS_TRUE;
+        denied = "Foreign origin.";
       }
 
       /* Authenticate the body before parsing it: every field it carries is
@@ -1072,7 +1165,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
             !body_sid_is_valid(buffer, (const char *) expected)) {
           buffer[0] = '\0';
           meth = 0;
-          denied = HTS_TRUE;
+          denied = "Missing or invalid session id.";
         } else {
           authed = HTS_TRUE;
         }
@@ -2063,12 +2156,12 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
             StringCat(output, error);
           }
         }
-      } else if (denied) {
+      } else if (denied != NULL) {
         StringCat(headers, "HTTP/1.0 403 Forbidden\r\n"
                            "Server: httrack small server\r\n"
                            "Content-type: text/html\r\n");
-        StringCat(output,
-                  "Missing or invalid session id, or foreign origin.\r\n");
+        StringCat(output, denied);
+        StringCat(output, "\r\n");
       } else {
 #ifdef _DEBUG
         char error_hdr[] =
@@ -2090,7 +2183,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
       /* a refusal cleared meth, yet the Content-length above promises a body */
       if ((send(soc_c, StringBuff(headers), (int) StringLength(headers), 0) !=
            StringLength(headers)) ||
-          ((meth == 1 || denied) &&
+          ((meth == 1 || denied != NULL) &&
            (send(soc_c, StringBuff(output), (int) StringLength(output), 0) !=
             StringLength(output)))) {
 #ifdef _DEBUG

--- a/tests/341_webhttrack-authority.test
+++ b/tests/341_webhttrack-authority.test
@@ -1,0 +1,124 @@
+#!/bin/bash
+#
+# The panel is unauthenticated, so it must refuse a request naming an authority
+# it does not answer for, and advertise a URL a browser can actually open.
+
+set -euo pipefail
+
+# shellcheck source=tests/webhttracklib.sh
+. "${0%"${0##*/}"}./webhttracklib.sh"
+
+htsserver_require
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_authority.XXXXXX") || fail "no tmpdir"
+cleanup() {
+    htsserver_cleanup
+    rm -rf "${work}"
+}
+cleanup_push cleanup
+
+# Fetch a URL the way webhttrack's browser would: the status, or the error name.
+opens() {
+    htsserver_python - "$1" <<'PY'
+import sys, urllib.request
+
+try:
+    with urllib.request.urlopen(sys.argv[1], timeout=10) as r:
+        print(r.status)
+except Exception as e:
+    print(type(e).__name__)
+PY
+}
+
+htsserver_start --home "${work}/default"
+sid=$(htsserver_sid)
+# Control: without a real sid every POST below would be refused for that reason.
+test "${#sid}" -eq 32 || fail "did not scrape a 32-hex sid from the page (got '${sid}')"
+
+# "redirect" is the cheapest field whose reply is visible in the headers.
+post_as() { # $1 = Host value, "" sends none
+    htsserver_client --host "$1" --path / --post "sid=${sid}&redirect=/accepted"
+}
+
+for good in "127.0.0.1" "127.0.0.1:${HTS_PORT}" "localhost" "localhost:${HTS_PORT}" \
+    "LocalHost:${HTS_PORT}" "[::1]" "[::1]:${HTS_PORT}" ""; do
+    grep -q '^Location: /accepted' <<<"$(post_as "${good}")" ||
+        fail "Host '${good}' was refused"
+done
+echo "ok: the panel answers at every authority it is reachable at"
+
+for bad in "evil.example" "evil.example:${HTS_PORT}" "127.0.0.1.evil.example"; do
+    resp=$(post_as "${bad}")
+    grep -q '^HTTP/1\.0 403 ' <<<"${resp}" ||
+        fail "POST with Host '${bad}' was not a 403: '$(firstline "${resp}")'"
+    grep -q '^Location:' <<<"${resp}" && fail "POST with Host '${bad}' still ran"
+    # GET too: a guard sitting on the POST path alone is the shape of the last
+    # bug found here.
+    resp=$(htsserver_client --host "${bad}" --path /server/index.html)
+    grep -q '^HTTP/1\.0 403 ' <<<"${resp}" ||
+        fail "GET with Host '${bad}' was not a 403: '$(firstline "${resp}")'"
+    grep -q 'name="sid"' <<<"${resp}" &&
+        fail "GET with Host '${bad}' still handed out a session id"
+done
+echo "ok: a foreign authority is refused, on every method"
+
+# Suppressing the reply is not refusing the write: the body lands in one global
+# key store that later requests render from. step3 interpolates ${projname}.
+store_page() {
+    page=$(htsserver_get /server/step3.html) || fail "the key store probe failed"
+    grep -q '^HTTP/1\.0 200 ' <<<"${page}" ||
+        fail "the key store probe did not answer: '$(firstline "${page}")'"
+}
+
+htsserver_client --host evil.example --path / \
+    --post "sid=${sid}&projname=REBOUND" >/dev/null 2>&1 || true
+store_page
+grep -q 'REBOUND' <<<"${page}" &&
+    fail "a body sent with a foreign Host reached the key store"
+# Paired accept: without it the assertion above passes on a server that ignores
+# every body, which would prove nothing.
+htsserver_client --host "127.0.0.1:${HTS_PORT}" --path / \
+    --post "sid=${sid}&projname=SAMEHOST" >/dev/null 2>&1 || true
+store_page
+grep -q 'SAMEHOST' <<<"${page}" ||
+    fail "a body sent with our own Host was not written to the key store"
+echo "ok: a refused body is not applied"
+
+htsserver_stop
+
+# webhttrack greps this URL out and hands it to the browser, so a wildcard bind
+# has to name a host that exists, and an IPv6 literal needs its URL brackets.
+htsserver_start --port "$(htsserver_freeport)" --home "${work}/wild" -- --bind 0.0.0.0
+case ${HTS_URL} in
+*//127.0.0.1:*) ;;
+*) fail "--bind 0.0.0.0 advertised ${HTS_URL}, which no browser can open" ;;
+esac
+got=$(opens "${HTS_URL}")
+test "${got}" = 200 || fail "--bind 0.0.0.0 advertised ${HTS_URL}, which answered ${got}"
+echo "ok: a wildcard bind advertises a loopback URL"
+htsserver_stop
+
+if htsserver_python - <<'PY'; then
+import socket, sys
+
+try:
+    s = socket.socket(socket.AF_INET6)
+    s.bind(("::1", 0))
+    s.close()
+except OSError:
+    sys.exit(1)
+PY
+    htsserver_start --port "$(htsserver_freeport)" --home "${work}/v6" -- --bind ::1
+    case ${HTS_URL} in
+    *"//[::1]:"*) ;;
+    *) fail "--bind ::1 advertised ${HTS_URL}, which no browser can open" ;;
+    esac
+    got=$(opens "${HTS_URL}")
+    test "${got}" = 200 || fail "--bind ::1 advertised ${HTS_URL}, which answered ${got}"
+    echo "ok: an IPv6 literal is advertised bracketed"
+else
+    echo "skipped the IPv6 advert: no ::1 here"
+fi
+
+cleanup
+echo "PASS"

--- a/tests/httpclient.py
+++ b/tests/httpclient.py
@@ -10,6 +10,12 @@ import sys
 import urllib.parse
 
 
+def host_header(args):
+    """The Host line, or none at all when --host is empty: an HTTP/1.0 client
+    may send none, and the server has to answer that request too."""
+    return "Host: %s\r\n" % args.host if args.host else ""
+
+
 def build_request(args):
     if args.field or args.post is not None:
         if args.field:
@@ -19,12 +25,14 @@ def build_request(args):
         else:
             body = args.post
         return (
-            "POST %s HTTP/1.0\r\nHost: 127.0.0.1\r\n"
+            "POST %s HTTP/1.0\r\n%s"
             "Content-type: application/x-www-form-urlencoded\r\n"
-            "Content-length: %d\r\n\r\n%s" % (args.path or "/", len(body), body)
+            "Content-length: %d\r\n\r\n%s"
+            % (args.path or "/", host_header(args), len(body), body)
         )
-    return "GET %s HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n" % (
-        args.path or "/server/index.html"
+    return "GET %s HTTP/1.0\r\n%s\r\n" % (
+        args.path or "/server/index.html",
+        host_header(args),
     )
 
 
@@ -38,6 +46,11 @@ def main():
         action="append",
         metavar="K=V",
         help="POST field, form-encoded here; repeatable",
+    )
+    p.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host header value; empty sends none",
     )
     p.add_argument("--timeout", type=float, default=30)
     p.add_argument(


### PR DESCRIPTION
htsserver's control panel is unauthenticated: whatever opens its socket gets a session id and can drive it, up to writing files at a posted path. It binds loopback, so nothing off the machine reaches it, but a page in a browser on the machine can present a name of its own for our address and have the browser treat the panel as same-origin (DNS rebinding). The server now refuses a Host it does not answer for: `localhost`, an address literal, or whatever `--bind` was given. Rebinding always presents a name, so only names need vetting and an address literal is simply whoever opened the socket, which leaves an operator who deliberately widened the bind working. The check runs ahead of the dispatcher rather than inside a handler, so a GET is covered too, and it is the GET that hands out the session id; a guard on one handler is the shape of #1359. No Host at all still passes: HTTP/1.1 mandates one, so only a non-browser client omits it.

Two malformed advertised URLs ride along, both pre-existing. `--bind 0.0.0.0` printed `http://0.0.0.0:<port>/` and an IPv6 literal was printed unbracketed, neither of which a browser opens, and `webhttrack` hands that line's URL straight to the browser. A wildcard bind now advertises loopback, and a literal is bracketed.

Test 341 drives a real server both ways: every authority the panel is reachable at still completes a POST end to end, a foreign one is refused on GET and on POST, and the refused body is checked against the key store rather than against the suppressed reply, with a paired accept so a server that ignored every body could not pass. Its advert half fetches the URL the server printed. Both halves are red on master.
