### PR TITLE
Two file sizes still reach an allocator at the wrong width

### DIFF
--- a/src/htscache.c
+++ b/src/htscache.c
@@ -1479,13 +1479,13 @@ void cache_rstr(FILE *fp, char *s, size_t s_size) {
   }
 }
 char *cache_rstr_addr(FILE * fp) {
-  INTsys i;
+  INTsys i = 0;
   char *addr = NULL;
   char buff[256 + 4];
 
   linput(fp, buff, 256);
-  sscanf(buff, INTsysP, &i);
-  if (i < 0 || i > 32768)       /* error, something nasty happened */
+  /* an unmatched sscanf leaves i untouched: length 0, not a stack value */
+  if (sscanf(buff, INTsysP, &i) != 1 || i < 0 || i > 32768)
     i = 0;
   if (i > 0) {
     addr = malloct(i + 1);

--- a/src/htsindex.c
+++ b/src/htsindex.c
@@ -319,16 +319,19 @@ void index_finish(const char *indexpath, int mode) {
   char catbuff[CATBUFF_SIZE];
   char **tab;
   char *blk;
-  LLint size = fpsize(fp_tmpproject);
+  const LLint fs = fpsize(fp_tmpproject);
+  /* fail closed on a size size_t cannot hold: malloct() wraps short while
+     the reader and the terminator keep the 64-bit length */
+  const size_t size = fs > 0 ? llint_to_size_t(fs) : (size_t) -1;
 
-  if (size > 0) {
+  if (size != (size_t) -1) {
     if (fp_tmpproject) {
       tab = (char **) malloct(sizeof(char *) * (hts_primindex_size + 2));
       if (tab) {
         blk = malloct(size + 1);
         if (blk) {
           fseek(fp_tmpproject, 0, SEEK_SET);
-          if (hts_fread_exact(blk, (size_t) size, fp_tmpproject)) {
+          if (hts_fread_exact(blk, size, fp_tmpproject)) {
             char *a = blk, *b;
             int index = 0;
             int i;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1706,11 +1706,14 @@ static int st_hashtable(httrackp *opt, int argc, char **argv) {
 
   /* produce random patterns, or read from a file */
   if (sscanf(snum, "%lu", &count) != 1) {
-    const LLint size = fsize(snum);
-    FILE *fp = fopen(snum, "rb");
+    const LLint fs = fsize(snum);
+    /* one width for the buffer and the walk below: a 64-bit size wraps
+       malloct() short while the loop still counts to the real end */
+    const size_t size = fs >= 0 ? llint_to_size_t(fs) : (size_t) -1;
+    FILE *fp = size != (size_t) -1 ? fopen(snum, "rb") : NULL;
     if (fp != NULL) {
       buff = malloct(size);
-      if (buff != NULL && hts_fread_exact(buff, (size_t) size, fp)) {
+      if (buff != NULL && hts_fread_exact(buff, size, fp)) {
         size_t capa = 0;
         size_t i, last;
         for (i = 0, last = 0, count = 0; i < size; i++) {
@@ -3105,6 +3108,10 @@ static int st_growsize(httrackp *opt, int argc, char **argv) {
       {10, HTS_ST_GROWSIZE_OVER32, 8192, WIDTH},
   };
 
+  /* 0xffffffff doubles as a 32-bit size_t's error value, so it stays out */
+  static const LLint narrowing[] = {0,  1,    8192, HTS_ST_GROWSIZE_OVER32,
+                                    -1, -4096};
+
   size_t k;
   int rc = 0;
 
@@ -3140,6 +3147,24 @@ static int st_growsize(httrackp *opt, int argc, char **argv) {
       rc = 1;
     }
   }
+
+  /* llint_to_size_t() refuses only what size_t cannot hold: a negative size
+     round-trips intact on LP64, so callers check the sign themselves. */
+  for (k = 0; k < sizeof(narrowing) / sizeof(narrowing[0]); k++) {
+    const LLint v = narrowing[k];
+    const hts_boolean representable =
+        sizeof(size_t) >= sizeof(LLint) || (v >= 0 && v <= 0xffffffffLL);
+    const size_t want = representable ? (size_t) v : (size_t) -1;
+    const size_t got = llint_to_size_t(v);
+
+    if (got != want) {
+      fprintf(stderr,
+              "growsize: narrow(" LLintP ") = " LLintP " (want " LLintP ")\n",
+              v, (LLint) got, (LLint) want);
+      rc = 1;
+    }
+  }
+
   printf("growsize self-test %s\n", rc == 0 ? "OK" : "FAILED");
   return rc;
 }


### PR DESCRIPTION
The audit behind #1354 named six C4244 sites and one C4477 as the real defects. All seven went away in #702, which merged the same day the audit was written, so the issue's premise is stale. The Windows build of current master (100786cc, run 32594588602) emits 18 distinct sites, not 74, and none of the seven is among them.

Re-deriving those 18 from the run log leaves two whose value is not provably in range. Both are leftovers of the class #702 declared a bug and fixed everywhere else: an `LLint` file size reaching an allocator without `llint_to_size_t()`. `index_finish()` sizes its keyword-index buffer from `fpsize()`, and htsselftest's hashtable reader sizes its pattern buffer from `fsize()`. On a 32-bit build a file past 4GB wraps the `malloct()` short. The hashtable loop then keeps its 64-bit bound and walks off the end of the buffer; the index just builds from a short read. Both now narrow once, through the helper `htscache.c`'s `readfile2()` already uses, and that width carries into the read and the walk instead of a cast at each use.

Neither has behaviour CI can watch. `llint_to_size_t()` is the identity whenever `size_t` is 64 bits, so on LP64 the change is a no-op by construction, and the trigger wants a >4GB file on a 32-bit target. The helper itself can be pinned, and had no direct test, so the `growsize` self-test gains a table for it. Its negative cases fail here under a mutant that refuses negatives; the over-4GB case only bites on the `linux i386` leg.

The other 16 sites stay as they are. They are clamped, guarded, or vendored, and casting them quiet is what the issue asks not to do. This does not close #1354: the counting and the ratchet are still open.
