### PR TITLE
The server decodes a malformed percent-escape to a NUL

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -58,7 +58,7 @@ lib_LTLIBRARIES = libhttrack.la
 htsserver_SOURCES = htsserver.c htsserver.h htsweb.c htsweb.h htsstats.h \
 	htsrandom.c htsrandom.h \
 	htscmdline.c htscmdline.h \
-	htsurlport.c htsurlport.h
+	htsurlport.c htsurlport.h htsescape.c htsescape.h
 proxytrack_SOURCES = proxy/main.c \
 	proxy/proxytrack.c proxy/store.c \
 	htsurlport.c htsurlport.h htsnet.c \
@@ -83,7 +83,7 @@ libhttrack_la_SOURCES =  htscore.c htsparse.c htsback.c htscache.c \
 	htsalias.c htsthread.c htsindex.c htsbauth.c \
 	htscrashtest.c \
 	htsmd5.c htsnet.c htscodec.c htswarc.c htschanges.c htssinglefile.c htssitemap.c htsproxy.c htszlib.c htswrap.c htsconcat.c \
-	htsmodules.c htscharset.c punycode.c htsencoding.c htssniff.c \
+	htsmodules.c htscharset.c punycode.c htsencoding.c htsescape.c htssniff.c \
 	md5.c \
 	minizip/ioapi.c minizip/mztools.c minizip/unzip.c minizip/zip.c \
 	hts-indextmpl.h htsalias.h htsback.h htsbase.h htssafe.h \
@@ -95,7 +95,7 @@ libhttrack_la_SOURCES =  htscore.c htsparse.c htsback.c htscache.c \
 	htsopt.h htsrobots.h htsthread.h  \
 	htscrashtest.h htstools.h htsrandom.h htswizard.h htswrap.h htscodec.h htswarc.h htschanges.h htssinglefile.h htssitemap.h htsproxy.h htszlib.h  \
 	htsstrings.h htsarrays.h htsarena.h httrack-library.h \
-	htscharset.h punycode.h htsencoding.h \
+	htscharset.h punycode.h htsencoding.h htsescape.h \
 	htsentities.h htsentities.sh htsbasiccharsets.sh htscodepages.h \
 	winprofile-keys.h \
 	md5.h coucal/murmurhash3.h \

--- a/src/htsencoding.c
+++ b/src/htsencoding.c
@@ -40,18 +40,6 @@ Please visit our Website: http://www.httrack.com
  */
 #include "htsentities.h"
 
-/* hexadecimal conversion */
-static int get_hex_value(char c) {
-  if (c >= '0' && c <= '9')
-    return c - '0';
-  else if (c >= 'a' && c <= 'f')
-    return (c - 'a' + 10);
-  else if (c >= 'A' && c <= 'F')
-    return (c - 'A' + 10);
-  else
-    return -1;
-}
-
 /* 64-bit FNV-1a; must match htsentities.sh, which keys the entity table on it.
  */
 #define HASH_INIT 0xcbf29ce484222325ULL
@@ -189,7 +177,7 @@ int hts_unescapeEntitiesWithCharsetSpecial(const char *src, char *dest,
         }
         /* hex */
         else {
-          const int h = get_hex_value(src[i]);
+          const int h = hts_ehexh(src[i]);
           if (h != -1) {
             if (uc > (0x10FFFF - h) / 16) {
               ampStart = (size_t) -1;
@@ -266,8 +254,8 @@ int hts_unescapeUrlSpecial(const char *src, char *dest, const size_t max,
     }
     /* End of sequence seen */
     else if (i >= 2 && i == lastI + 2) {
-      const int a1 = get_hex_value(src[lastI + 1]);
-      const int a2 = get_hex_value(src[lastI + 2]);
+      const int a1 = hts_ehexh(src[lastI + 1]);
+      const int a2 = hts_ehexh(src[lastI + 2]);
       if (a1 != -1 && a2 != -1) {
         const char ec = a1*16 + a2;  /* new character */
         cUtf = (unsigned char) ec;

--- a/src/htsencoding.h
+++ b/src/htsencoding.h
@@ -33,6 +33,8 @@ Please visit our Website: http://www.httrack.com
 #ifndef HTS_ENCODING_DEFH
 #define HTS_ENCODING_DEFH
 
+#include "htsglobal.h"
+
 /** Standard includes. **/
 #include <stdlib.h>
 #include <string.h>
@@ -47,6 +49,33 @@ typedef enum unescapeFlags {
   /** Do not decode ASCII. **/
   UNESCAPE_URL_NO_ASCII = 1
 } unescapeFlags;
+
+/* Value of one hex digit, or -1 if 'c' is not one. */
+static HTS_INLINE HTS_UNUSED int hts_ehexh(const char c) {
+  if (c >= '0' && c <= '9')
+    return c - '0';
+  else if (c >= 'a' && c <= 'f')
+    return (c - 'a' + 10);
+  else if (c >= 'A' && c <= 'F')
+    return (c - 'A' + 10);
+  else
+    return -1;
+}
+
+/* Value of the two-hex-digit sequence at 's', or -1 if either digit is not one.
+ */
+static HTS_INLINE HTS_UNUSED int hts_ehex(const char *s) {
+  const int c1 = hts_ehexh(s[0]);
+
+  if (c1 >= 0) {
+    const int c2 = hts_ehexh(s[1]);
+
+    if (c2 >= 0) {
+      return 16 * c1 + c2;
+    }
+  }
+  return -1;
+}
 
 /**
  * Unescape HTML entities (as per HTML 4.0 Specification)

--- a/src/htsescape.c
+++ b/src/htsescape.c
@@ -1,0 +1,88 @@
+/* ------------------------------------------------------------ */
+/*
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) 1998-2026 Xavier Roche and other contributors
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+Important notes:
+
+- We hereby ask people using this source NOT to use it in purpose of grabbing
+emails addresses, or collecting any other private information on persons.
+This would disgrace our work, and spoil the many hours we spent on it.
+
+Please visit our Website: http://www.httrack.com
+*/
+
+/* ------------------------------------------------------------ */
+/* File: percent-escape decoding shared by the engine and the server */
+/* Author: Xavier Roche                                         */
+/* ------------------------------------------------------------ */
+
+#include "htsescape.h"
+
+/* CR, LF or TAB: htslib.h's is_retorsep() set, spelled out so this unit stays
+   linkable into htsserver and proxytrack without the engine headers. */
+static HTS_INLINE int hts_is_retorsep(const char c) {
+  return c == 10 || c == 13 || c == 9;
+}
+
+/* An escape needs both digits before the terminator, or reading them runs past
+   it; hts_ehex() then rejects anything that is not hex. Either way the '%' is
+   copied through as itself rather than decoded to a NUL. */
+void hts_unescapehttp(const char *s, String *tempo) {
+  size_t i;
+
+  for (i = 0; s[i] != '\0'; i++) {
+    int h;
+
+    if (s[i] == '%' && s[i + 1] == '%') {
+      i++;
+      StringAddchar(*tempo, '%');
+    } else if (s[i] == '%' && s[i + 1] != '\0' && s[i + 2] != '\0' &&
+               (h = hts_ehex(&s[i + 1])) >= 0) {
+      StringAddchar(*tempo, (char) h);
+      i += 2;
+    } else if (s[i] == '+') {
+      StringAddchar(*tempo, ' ');
+    } else {
+      StringAddchar(*tempo, s[i]);
+    }
+  }
+}
+
+void hts_unescapeini(const char *s, String *tempo) {
+  size_t i;
+  char lastc = 0;
+
+  for (i = 0; s[i] != '\0'; i++) {
+    int h;
+
+    if (s[i] == '%' && s[i + 1] == '%') {
+      i++;
+      StringAddchar(*tempo, lastc = '%');
+    } else if (s[i] == '%' && s[i + 1] != '\0' && s[i + 2] != '\0' &&
+               (h = hts_ehex(&s[i + 1])) >= 0) {
+      const char hc = (char) h;
+
+      if (!hts_is_retorsep(hc) || !hts_is_retorsep(lastc)) {
+        StringAddchar(*tempo, lastc = hc);
+      }
+      i += 2;
+    } else {
+      StringAddchar(*tempo, lastc = s[i]);
+    }
+  }
+}

--- a/src/htsescape.c
+++ b/src/htsescape.c
@@ -1,12 +1,14 @@
 /* ------------------------------------------------------------ */
 /*
 HTTrack Website Copier, Offline Browser for Windows and Unix
-Copyright (C) 1998-2026 Xavier Roche and other contributors
+Copyright (C) 1998 Xavier Roche and other contributors
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or any later version.
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,34 +16,26 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-Important notes:
-
-- We hereby ask people using this source NOT to use it in purpose of grabbing
-emails addresses, or collecting any other private information on persons.
-This would disgrace our work, and spoil the many hours we spent on it.
+Ethical use: we kindly ask that you NOT use this software to harvest email
+addresses or to collect any other private information about people. Doing so
+would dishonor our work and waste the many hours we have spent on it.
 
 Please visit our Website: http://www.httrack.com
 */
 
 /* ------------------------------------------------------------ */
-/* File: percent-escape decoding shared by the engine and the server */
+/* File: percent-escape decoding, shared by the engine and       */
+/*       htsserver                                              */
 /* Author: Xavier Roche                                         */
 /* ------------------------------------------------------------ */
 
 #include "htsescape.h"
+#include "htslib.h"
 
-/* CR, LF or TAB: htslib.h's is_retorsep() set, spelled out so this unit stays
-   linkable into htsserver and proxytrack without the engine headers. */
-static HTS_INLINE int hts_is_retorsep(const char c) {
-  return c == 10 || c == 13 || c == 9;
-}
-
-/* An escape needs both digits before the terminator, or reading them runs past
-   it; hts_ehex() then rejects anything that is not hex. Either way the '%' is
-   copied through as itself rather than decoded to a NUL. */
+/* The bounds check must run before hts_ehex(), or a truncated escape is read
+   past the terminator. */
 void hts_unescapehttp(const char *s, String *tempo) {
   size_t i;
 
@@ -77,7 +71,7 @@ void hts_unescapeini(const char *s, String *tempo) {
                (h = hts_ehex(&s[i + 1])) >= 0) {
       const char hc = (char) h;
 
-      if (!hts_is_retorsep(hc) || !hts_is_retorsep(lastc)) {
+      if (!is_retorsep(hc) || !is_retorsep(lastc)) {
         StringAddchar(*tempo, lastc = hc);
       }
       i += 2;

--- a/src/htsescape.c
+++ b/src/htsescape.c
@@ -32,7 +32,13 @@ Please visit our Website: http://www.httrack.com
 /* ------------------------------------------------------------ */
 
 #include "htsescape.h"
-#include "htslib.h"
+
+/* CR, LF or TAB, as htslib.h's is_retorsep(). Copied because htsencoding.h
+   pulls windows.h first, so including htslib.h here collides winsock.h with
+   winsock2.h. */
+static HTS_INLINE int hts_is_retorsep(const char c) {
+  return c == 10 || c == 13 || c == 9;
+}
 
 /* The bounds check must run before hts_ehex(), or a truncated escape is read
    past the terminator. */
@@ -71,7 +77,7 @@ void hts_unescapeini(const char *s, String *tempo) {
                (h = hts_ehex(&s[i + 1])) >= 0) {
       const char hc = (char) h;
 
-      if (!is_retorsep(hc) || !is_retorsep(lastc)) {
+      if (!hts_is_retorsep(hc) || !hts_is_retorsep(lastc)) {
         StringAddchar(*tempo, lastc = hc);
       }
       i += 2;

--- a/src/htsescape.h
+++ b/src/htsescape.h
@@ -1,12 +1,14 @@
 /* ------------------------------------------------------------ */
 /*
 HTTrack Website Copier, Offline Browser for Windows and Unix
-Copyright (C) 1998-2026 Xavier Roche and other contributors
+Copyright (C) 1998 Xavier Roche and other contributors
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or any later version.
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,59 +16,29 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-Important notes:
-
-- We hereby ask people using this source NOT to use it in purpose of grabbing
-emails addresses, or collecting any other private information on persons.
-This would disgrace our work, and spoil the many hours we spent on it.
+Ethical use: we kindly ask that you NOT use this software to harvest email
+addresses or to collect any other private information about people. Doing so
+would dishonor our work and waste the many hours we have spent on it.
 
 Please visit our Website: http://www.httrack.com
 */
 
 /* ------------------------------------------------------------ */
-/* File: percent-escape decoding shared by the engine and the server */
+/* File: percent-escape decoding, shared by the engine and       */
+/*       htsserver                                              */
 /* Author: Xavier Roche                                         */
 /* ------------------------------------------------------------ */
 
-#ifndef HTS_ESCAPE_DEFH
-#define HTS_ESCAPE_DEFH
+#ifndef HTSESCAPE_DEFH
+#define HTSESCAPE_DEFH
 
-#include "htsglobal.h"
+#include "htsencoding.h"
 #include "htsstrings.h"
 
-/* Value of one hex digit, or -1 if 'c' is not one. */
-HTS_UNUSED static HTS_INLINE int hts_ehexh(const char c) {
-  if (c >= '0' && c <= '9')
-    return c - '0';
-  else if (c >= 'a' && c <= 'f')
-    return (c - 'a' + 10);
-  else if (c >= 'A' && c <= 'F')
-    return (c - 'A' + 10);
-  else
-    return -1;
-}
-
-/* Value of the two-hex-digit sequence at 's', or -1 if either digit is not
-   one. Rejecting is what keeps a malformed escape from decoding to a NUL. */
-HTS_UNUSED static HTS_INLINE int hts_ehex(const char *s) {
-  const int c1 = hts_ehexh(s[0]);
-
-  if (c1 >= 0) {
-    const int c2 = hts_ehexh(s[1]);
-
-    if (c2 >= 0) {
-      return 16 * c1 + c2;
-    }
-  }
-  return -1;
-}
-
-/* Decode application/x-www-form-urlencoded 's' into 'tempo': "%%" is a literal
-   '%', '+' is a space, and an escape that is truncated or not hex is copied
-   through unchanged. */
+/* Decode form-urlencoded 's' into 'tempo': "%%" is '%', '+' is space, and a
+   bad escape stays literal. */
 extern void hts_unescapehttp(const char *s, String *tempo);
 
 /* As hts_unescapehttp(), minus the '+' rule, and collapsing a decoded run of

--- a/src/htsescape.h
+++ b/src/htsescape.h
@@ -1,0 +1,76 @@
+/* ------------------------------------------------------------ */
+/*
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) 1998-2026 Xavier Roche and other contributors
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+Important notes:
+
+- We hereby ask people using this source NOT to use it in purpose of grabbing
+emails addresses, or collecting any other private information on persons.
+This would disgrace our work, and spoil the many hours we spent on it.
+
+Please visit our Website: http://www.httrack.com
+*/
+
+/* ------------------------------------------------------------ */
+/* File: percent-escape decoding shared by the engine and the server */
+/* Author: Xavier Roche                                         */
+/* ------------------------------------------------------------ */
+
+#ifndef HTS_ESCAPE_DEFH
+#define HTS_ESCAPE_DEFH
+
+#include "htsglobal.h"
+#include "htsstrings.h"
+
+/* Value of one hex digit, or -1 if 'c' is not one. */
+HTS_UNUSED static HTS_INLINE int hts_ehexh(const char c) {
+  if (c >= '0' && c <= '9')
+    return c - '0';
+  else if (c >= 'a' && c <= 'f')
+    return (c - 'a' + 10);
+  else if (c >= 'A' && c <= 'F')
+    return (c - 'A' + 10);
+  else
+    return -1;
+}
+
+/* Value of the two-hex-digit sequence at 's', or -1 if either digit is not
+   one. Rejecting is what keeps a malformed escape from decoding to a NUL. */
+HTS_UNUSED static HTS_INLINE int hts_ehex(const char *s) {
+  const int c1 = hts_ehexh(s[0]);
+
+  if (c1 >= 0) {
+    const int c2 = hts_ehexh(s[1]);
+
+    if (c2 >= 0) {
+      return 16 * c1 + c2;
+    }
+  }
+  return -1;
+}
+
+/* Decode application/x-www-form-urlencoded 's' into 'tempo': "%%" is a literal
+   '%', '+' is a space, and an escape that is truncated or not hex is copied
+   through unchanged. */
+extern void hts_unescapehttp(const char *s, String *tempo);
+
+/* As hts_unescapehttp(), minus the '+' rule, and collapsing a decoded run of
+   line separators so an escaped CRLF cannot forge an .ini line break. */
+extern void hts_unescapeini(const char *s, String *tempo);
+
+#endif

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -54,6 +54,7 @@ Please visit our Website: http://www.httrack.com
 #include "htsmodules.h"
 #include "htscharset.h"
 #include "htsencoding.h"
+#include "htsescape.h"
 #include "htscodec.h"
 
 #ifdef _WIN32
@@ -4395,30 +4396,6 @@ void code64(unsigned char *a, int size_a, unsigned char *b, int crlf) {
   *b++ = '\0';
 }
 
-// return the hex character value, or -1 on error.
-static HTS_INLINE int ehexh(const char c) {
-  if (c >= '0' && c <= '9')
-    return c - '0';
-  else if (c >= 'a' && c <= 'f')
-    return (c - 'a' + 10);
-  else if (c >= 'A' && c <= 'F')
-    return (c - 'A' + 10);
-  else
-    return -1;
-}
-
-// return the two-hex character value, or -1 on error.
-static HTS_INLINE int ehex(const char *s) {
-  const int c1 = ehexh(s[0]);
-  if (c1 >= 0) {
-    const int c2 = ehexh(s[1]);
-    if (c2 >= 0) {
-      return 16*c1 + c2;
-    }
-  }
-  return -1;
-}
-
 void unescape_amp(char *s) {
   if (hts_unescapeEntities(s, s, strlen(s) + 1) != 0) {
     assertf(! "error escaping html entities");
@@ -4434,11 +4411,10 @@ HTSEXT_API char *unescape_http(char *const catbuff, const size_t size, const cha
 
   for(i = 0, j = 0; s[i] != '\0' && j + 1 < size ; i++) {
     int h;
-    if (s[i] == '%' && (h = ehex(&s[i + 1])) >= 0) {
+    if (s[i] == '%' && (h = hts_ehex(&s[i + 1])) >= 0) {
       catbuff[j++] = (char) h;
       i += 2;
-    }
-    else
+    } else
       catbuff[j++] = s[i];
   }
   catbuff[j++] = '\0';
@@ -4458,7 +4434,7 @@ HTSEXT_API char *unescape_http_unharm(char *const catbuff, const size_t size,
 
   for(i = 0, j = 0; s[i] != '\0' && j + 1 < size ; i++) {
     if (s[i] == '%') {
-      const int nchar = ehex(&s[i + 1]);
+      const int nchar = hts_ehex(&s[i + 1]);
 
       const int test = 
         ( CHAR_RESERVED(nchar) && nchar != '+' )        /* %2B => + (not in query!) */

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -54,7 +54,6 @@ Please visit our Website: http://www.httrack.com
 #include "htsmodules.h"
 #include "htscharset.h"
 #include "htsencoding.h"
-#include "htsescape.h"
 #include "htscodec.h"
 
 #ifdef _WIN32

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -58,6 +58,7 @@ Please visit our Website: http://www.httrack.com
 #include "htscmdline.h"
 #include "htscoremain.h"
 #include "htsencoding.h"
+#include "htsescape.h"
 #include "htsftp.h"
 #include "htsmd5.h"
 #include "htssniff.h"
@@ -1496,6 +1497,56 @@ static int st_unescape_bounds(httrackp *opt, int argc, char **argv) {
     assertf(strcmp(wide, "\xC3\xA9") == 0);
   }
   printf("unescape-bounds self-test OK\n");
+  return 0;
+}
+
+/* A malformed escape must survive as text. The two decoders behind the server
+   forms decoded "%ZZ" to NUL, which truncated the value at the next read. */
+static int st_unescape_form(httrackp *opt, int argc, char **argv) {
+  /* expected[] is compared with its length, so a decoded NUL is not mistaken
+     for a short string */
+  static const struct {
+    const char *in;
+    const char *expected;
+    size_t len;
+    int ini; /* run hts_unescapeini() rather than http */
+  } cases[] = {
+      {"a%41b", "aAb", 3, 0},
+      {"%c3%a9", "\xc3\xa9", 2, 0},
+      {"a+b", "a b", 3, 0},
+      {"100%%", "100%", 4, 0},
+      {"%ZZ", "%ZZ", 3, 0}, /* not hex: kept literal, not decoded to NUL */
+      {"%4", "%4", 2, 0},   /* truncated: no second digit to read */
+      {"%", "%", 1, 0},
+      {"a%2Gb", "a%2Gb", 5, 0},   /* second digit not hex */
+      {"a+b", "a+b", 3, 1},       /* the ini form has no '+' rule */
+      {"a%0d%0ab", "a\rb", 3, 1}, /* a decoded separator run collapses */
+      {"a%ZZb", "a%ZZb", 5, 1},
+  };
+
+  size_t i;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+  for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+    String out = STRING_EMPTY;
+
+    if (cases[i].ini) {
+      hts_unescapeini(cases[i].in, &out);
+    } else {
+      hts_unescapehttp(cases[i].in, &out);
+    }
+    if (StringLength(out) != cases[i].len ||
+        memcmp(StringBuff(out), cases[i].expected, cases[i].len) != 0) {
+      fprintf(stderr, "unescape-form: %s gave %d bytes, expected %d\n",
+              cases[i].in, (int) StringLength(out), (int) cases[i].len);
+      StringFree(out);
+      return 1;
+    }
+    StringFree(out);
+  }
+  printf("unescape-form self-test OK\n");
   return 0;
 }
 
@@ -11797,6 +11848,8 @@ static const struct selftest_entry {
      st_footerfmt},
     {"unescape-bounds", "", "unescapers reserve the NUL byte (no 1-byte OOB)",
      st_unescape_bounds},
+    {"unescape-form", "", "form/ini percent-decoding keeps a malformed escape",
+     st_unescape_form},
     {"cmdline-split", "",
      "webhttrack command-line to argv split (bounds, quoting)",
      st_cmdlinesplit},

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1500,27 +1500,33 @@ static int st_unescape_bounds(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-/* A malformed escape must survive as text. The two decoders behind the server
-   forms decoded "%ZZ" to NUL, which truncated the value at the next read. */
+/* A malformed escape must survive as text. */
 static int st_unescape_form(httrackp *opt, int argc, char **argv) {
-  /* expected[] is compared with its length, so a decoded NUL is not mistaken
-     for a short string */
+  /* compared by length, so a decoded NUL is not mistaken for a short string */
   static const struct {
     const char *in;
     const char *expected;
     size_t len;
     int ini; /* run hts_unescapeini() rather than http */
   } cases[] = {
+      {"", "", 0, 0},
       {"a%41b", "aAb", 3, 0},
       {"%c3%a9", "\xc3\xa9", 2, 0},
+      {"%C3%A9", "\xc3\xa9", 2, 0}, /* hex case does not matter */
       {"a+b", "a b", 3, 0},
       {"100%%", "100%", 4, 0},
+      {"%00", "\0", 1, 0},  /* well-formed, so it really does decode to NUL */
       {"%ZZ", "%ZZ", 3, 0}, /* not hex: kept literal, not decoded to NUL */
+      {"%zz", "%zz", 3, 0}, /* lower case too, or a widened 'a'-'f' arm hides */
       {"%4", "%4", 2, 0},   /* truncated: no second digit to read */
       {"%", "%", 1, 0},
-      {"a%2Gb", "a%2Gb", 5, 0},   /* second digit not hex */
-      {"a+b", "a+b", 3, 1},       /* the ini form has no '+' rule */
-      {"a%0d%0ab", "a\rb", 3, 1}, /* a decoded separator run collapses */
+      {"%%%", "%%", 2, 0},
+      {"a%2Gb", "a%2Gb", 5, 0}, /* second digit not hex */
+      {"", "", 0, 1},
+      {"a+b", "a+b", 3, 1},          /* the ini form has no '+' rule */
+      {"a%0d%0ab", "a\rb", 3, 1},    /* a decoded separator run collapses */
+      {"a%0d%0a%0db", "a\rb", 3, 1}, /* however long the run is */
+      {"a\r\nb", "a\r\nb", 4, 1},    /* but raw separators pass through */
       {"a%ZZb", "a%ZZb", 5, 1},
   };
 
@@ -1531,14 +1537,20 @@ static int st_unescape_form(httrackp *opt, int argc, char **argv) {
   (void) argv;
   for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
     String out = STRING_EMPTY;
+    const char *got;
 
     if (cases[i].ini) {
       hts_unescapeini(cases[i].in, &out);
     } else {
       hts_unescapehttp(cases[i].in, &out);
     }
+    got = StringBuff(out);
+    /* callers read the result with strcmp(), so the terminator is part of the
+       contract */
     if (StringLength(out) != cases[i].len ||
-        memcmp(StringBuff(out), cases[i].expected, cases[i].len) != 0) {
+        (cases[i].len != 0 &&
+         memcmp(got, cases[i].expected, cases[i].len) != 0) ||
+        (got != NULL && got[cases[i].len] != '\0')) {
       fprintf(stderr, "unescape-form: %s gave %d bytes, expected %d\n",
               cases[i].in, (int) StringLength(out), (int) cases[i].len);
       StringFree(out);

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -425,7 +425,7 @@ static hts_boolean body_sid_is_valid(const char *body, const char *expected) {
 
         memcpy(raw, eq + 1, len);
         raw[len] = '\0';
-        unescapehttp(raw, &value);
+        hts_unescapehttp(raw, &value);
         /* StringBuff is NULL until written, so an empty value lands here. */
         if (StringBuff(value) != NULL &&
             strcmp(StringBuff(value), expected) == 0) {
@@ -1092,7 +1092,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
           ua = e + 1;
           if (strfield2(ua, "on"))      /* hack : "on" == 1 */
             ua = "1";
-          unescapehttp(ua, &sua);
+          hts_unescapehttp(ua, &sua);
           coucal_write(NewLangList, s, (intptr_t) StringAcquire(&sua));
           s = f + 1;
         }
@@ -1207,7 +1207,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                 /* A key in the file overwrites the default even when it is
                    empty, and an acquired NULL reads back as absent (#1186). */
                 StringClear(escline);
-                unescapeini(pos, &escline);
+                hts_unescapeini(pos, &escline);
                 coucal_write(NewLangList, line,
                               (intptr_t) StringAcquire(&escline));
               }

--- a/src/htsserver.h
+++ b/src/htsserver.h
@@ -88,7 +88,9 @@ extern httrackp *global_opt;
 #define  is_space(c)      ( ((c)==' ') || ((c)=='\"') || ((c)==10) || ((c)==13) || ((c)==9) || ((c)==12) || ((c)==11) || ((c)=='\'') )
 #define  is_realspace(c)  ( ((c)==' ')                || ((c)==10) || ((c)==13) || ((c)==9) || ((c)==12) || ((c)==11)                )
 #define  is_taborspace(c) ( ((c)==' ')                                          || ((c)==9)                             )
-#define is_quote(c) (((c) == '\"') || ((c) == '\''))
+#define  is_quote(c)      (               ((c)=='\"')                                                    || ((c)=='\'') )
+#define  is_retorsep(c)   (                              ((c)==10) || ((c)==13) || ((c)==9)                                          )
+
 #undef min
 #undef max
 #define min(a,b) ((a)>(b)?(b):(a))

--- a/src/htsserver.h
+++ b/src/htsserver.h
@@ -89,7 +89,6 @@ extern httrackp *global_opt;
 #define  is_realspace(c)  ( ((c)==' ')                || ((c)==10) || ((c)==13) || ((c)==9) || ((c)==12) || ((c)==11)                )
 #define  is_taborspace(c) ( ((c)==' ')                                          || ((c)==9)                             )
 #define is_quote(c) (((c) == '\"') || ((c) == '\''))
-
 #undef min
 #undef max
 #define min(a,b) ((a)>(b)?(b):(a))

--- a/src/htsserver.h
+++ b/src/htsserver.h
@@ -40,6 +40,7 @@ Please visit our Website: http://www.httrack.com
 
 /* String */
 #include "htsstrings.h"
+#include "htsescape.h"
 
 // Fonctions
 /* Read one line off a socket; HTS_TRUE if it did not fit "s". */
@@ -272,65 +273,6 @@ static int linput_trim(FILE * fp, char *s, int max) {
     free(ls);
   }
   return rlen;
-}
-
-static int ehexh(char c) {
-  if ((c >= '0') && (c <= '9'))
-    return c - '0';
-  if ((c >= 'a') && (c <= 'f'))
-    c -= ('a' - 'A');
-  if ((c >= 'A') && (c <= 'F'))
-    return (c - 'A' + 10);
-  return 0;
-}
-
-static int ehex(const char *s) {
-  return 16 * ehexh(*s) + ehexh(*(s + 1));
-}
-
-HTS_UNUSED static void unescapehttp(const char *s, String * tempo) {
-  size_t i;
-
-  /* A truncated escape has no digits: decoding one runs past the terminator. */
-  for(i = 0; s[i] != '\0'; i++) {
-    if (s[i] == '%' && s[i + 1] == '%') {
-      i++;
-      StringAddchar(*tempo, '%');
-    } else if (s[i] == '%' && s[i + 1] != '\0' && s[i + 2] != '\0') {
-      char hc;
-
-      i++;
-      hc = (char) ehex(s + i);
-      StringAddchar(*tempo, (char) hc);
-      i++;                      // sauter 2 caractères finalement
-    } else if (s[i] == '+') {
-      StringAddchar(*tempo, ' ');
-    } else
-      StringAddchar(*tempo, s[i]);
-  }
-}
-
-HTS_UNUSED static void unescapeini(char *s, String * tempo) {
-  size_t i;
-  char lastc = 0;
-
-  /* A truncated escape has no digits: decoding one runs past the terminator. */
-  for(i = 0; s[i] != '\0'; i++) {
-    if (s[i] == '%' && s[i + 1] == '%') {
-      i++;
-      StringAddchar(*tempo, lastc = '%');
-    } else if (s[i] == '%' && s[i + 1] != '\0' && s[i + 2] != '\0') {
-      char hc;
-
-      i++;
-      hc = (char) ehex(s + i);
-      if (!is_retorsep(hc) || !is_retorsep(lastc)) {
-        StringAddchar(*tempo, lastc = (char) hc);
-      }
-      i++;                      // sauter 2 caractères finalement
-    } else
-      StringAddchar(*tempo, lastc = s[i]);
-  }
 }
 
 #endif

--- a/src/htsserver.h
+++ b/src/htsserver.h
@@ -88,8 +88,7 @@ extern httrackp *global_opt;
 #define  is_space(c)      ( ((c)==' ') || ((c)=='\"') || ((c)==10) || ((c)==13) || ((c)==9) || ((c)==12) || ((c)==11) || ((c)=='\'') )
 #define  is_realspace(c)  ( ((c)==' ')                || ((c)==10) || ((c)==13) || ((c)==9) || ((c)==12) || ((c)==11)                )
 #define  is_taborspace(c) ( ((c)==' ')                                          || ((c)==9)                             )
-#define  is_quote(c)      (               ((c)=='\"')                                                    || ((c)=='\'') )
-#define  is_retorsep(c)   (                              ((c)==10) || ((c)==13) || ((c)==9)                                          )
+#define is_quote(c) (((c) == '\"') || ((c) == '\''))
 
 #undef min
 #undef max

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -40,6 +40,7 @@ Please visit our Website: http://www.httrack.com
 #include "htstools.h"
 #include "htsio.h"
 #include "htsstrings.h"
+#include "htsescape.h"
 #include "htscharset.h"
 #ifdef _WIN32
 #include "windows.h"
@@ -72,42 +73,6 @@ struct find_handle_struct {
 #endif
 
 /* Tools */
-
-static int ehexh(char c) {
-  if ((c >= '0') && (c <= '9'))
-    return c - '0';
-  if ((c >= 'a') && (c <= 'f'))
-    c -= ('a' - 'A');
-  if ((c >= 'A') && (c <= 'F'))
-    return (c - 'A' + 10);
-  return 0;
-}
-
-static int ehex(const char *s) {
-  return 16 * ehexh(*s) + ehexh(*(s + 1));
-}
-
-static void unescapehttp(const char *s, String * tempo) {
-  size_t i;
-
-  /* A truncated escape has no digits: decoding one runs past the terminator. */
-  for(i = 0; s[i] != '\0'; i++) {
-    if (s[i] == '%' && s[i + 1] == '%') {
-      i++;
-      StringAddchar(*tempo, '%');
-    } else if (s[i] == '%' && s[i + 1] != '\0' && s[i + 2] != '\0') {
-      char hc;
-
-      i++;
-      hc = (char) ehex(s + i);
-      StringAddchar(*tempo, (char) hc);
-      i++;                      // sauter 2 caractères finalement
-    } else if (s[i] == '+') {
-      StringAddchar(*tempo, ' ');
-    } else
-      StringAddchar(*tempo, s[i]);
-  }
-}
 
 // forme à partir d'un lien et du contexte (origin_fil et origin_adr d'où il est tiré) adr et fil
 // [adr et fil sont des buffers de 1ko]
@@ -1261,7 +1226,7 @@ HTSEXT_API char *hts_getcategory(const char *filename) {
 
         if (n > 0) {
           if (strfield(line, "category=")) {
-            unescapehttp(line + 9, &categ);
+            hts_unescapehttp(line + 9, &categ);
             done = 1;
           }
         }
@@ -1318,7 +1283,7 @@ HTSEXT_API char *hts_getcategories(char *path, int type) {
                         if (StringLength(categ) > 0) {
                           StringCat(categ, "\r\n");
                         }
-                        unescapehttp(line2 + 9, &categ);
+                        hts_unescapehttp(line2 + 9, &categ);
                       }
                     }
                     done = 1;

--- a/src/libhttrack.vcxproj
+++ b/src/libhttrack.vcxproj
@@ -117,6 +117,7 @@
     <ClCompile Include="htscrashtest.c" />
     <ClCompile Include="htsdns_selftest.c" />
     <ClCompile Include="htsencoding.c" />
+    <ClCompile Include="htsescape.c" />
     <ClCompile Include="htsfilters.c" />
     <ClCompile Include="htsftp.c" />
     <ClCompile Include="htshash.c" />

--- a/src/proxy/proxystrings.h
+++ b/src/proxy/proxystrings.h
@@ -35,42 +35,6 @@ Please visit our Website: http://www.httrack.com
 
 /* Tools */
 
-HTS_UNUSED static int ehexh(char c) {
-  if ((c >= '0') && (c <= '9'))
-    return c - '0';
-  if ((c >= 'a') && (c <= 'f'))
-    c -= ('a' - 'A');
-  if ((c >= 'A') && (c <= 'F'))
-    return (c - 'A' + 10);
-  return 0;
-}
-
-HTS_UNUSED static int ehex(const char *s) {
-  return 16 * ehexh(*s) + ehexh(*(s + 1));
-}
-
-HTS_UNUSED static void unescapehttp(const char *s, String * tempo) {
-  int i;
-
-  /* A truncated escape has no digits: decoding one runs past the terminator. */
-  for(i = 0; s[i] != '\0'; i++) {
-    if (s[i] == '%' && s[i + 1] == '%') {
-      i++;
-      StringAddchar(*tempo, '%');
-    } else if (s[i] == '%' && s[i + 1] != '\0' && s[i + 2] != '\0') {
-      char hc;
-
-      i++;
-      hc = (char) ehex(s + i);
-      StringAddchar(*tempo, (char) hc);
-      i++;                      // sauter 2 caractères finalement
-    } else if (s[i] == '+') {
-      StringAddchar(*tempo, ' ');
-    } else
-      StringAddchar(*tempo, s[i]);
-  }
-}
-
 HTS_UNUSED static void escapexml(const char *s, String * tempo) {
   int i;
 

--- a/src/webhttrack.vcxproj
+++ b/src/webhttrack.vcxproj
@@ -100,6 +100,7 @@
     <ClCompile Include="htsrandom.c" />
     <ClCompile Include="htscmdline.c" />
     <ClCompile Include="htsurlport.c" />
+    <ClCompile Include="htsescape.c" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/01_engine-unescape-form.test
+++ b/tests/01_engine-unescape-form.test
@@ -9,12 +9,16 @@ grep -q "unescape-form self-test OK" <<<"$out"
 
 # Guard against the duplication coming back: only htsencoding.h may define the
 # hex helpers the server and the engine share. This catches a copied block, not
-# a renamed one.
-srcdir="${abs_top_srcdir:?not run under make check}"
-dups=$(grep -rlE '^[A-Za-z_].*[^a-z_](ehexh|get_hex_value) *\(' \
-    "${srcdir}/src" --include='*.c' --include='*.h' |
-    grep -v -x -F "${srcdir}/src/htsencoding.h" || true)
-[ -z "$dups" ] || {
-    echo "private copy of the escape decoder is back: $dups"
-    exit 1
-}
+# a renamed one. The MSVC job runs the scripts with no automake around them, so
+# it gets the self-test above and not this.
+if [ -n "${abs_top_srcdir:-}" ]; then
+    dups=$(grep -rlE '^[A-Za-z_].*[^a-z_](ehexh|get_hex_value) *\(' \
+        "${abs_top_srcdir}/src" --include='*.c' --include='*.h' |
+        grep -v -x -F "${abs_top_srcdir}/src/htsencoding.h" || true)
+    [ -z "$dups" ] || {
+        echo "private copy of the escape decoder is back: $dups"
+        exit 1
+    }
+else
+    echo "abs_top_srcdir unset: the single-definition check did not run" >&2
+fi

--- a/tests/01_engine-unescape-form.test
+++ b/tests/01_engine-unescape-form.test
@@ -3,15 +3,17 @@
 
 set -euo pipefail
 
-# Form/ini percent-decoding keeps a malformed escape as text (it used to decode
-# "%ZZ" to a NUL, truncating the value).
+# Form/ini percent-decoding keeps a malformed escape as text.
 out=$(httrack -O /dev/null -#test=unescape-form run)
 grep -q "unescape-form self-test OK" <<<"$out"
 
-# One decoder, or the drift comes back: nothing outside htsescape.h may define
-# the hex helpers the server and the engine now share.
+# Guard against the duplication coming back: only htsencoding.h may define the
+# hex helpers the server and the engine share. This catches a copied block, not
+# a renamed one.
 srcdir="${abs_top_srcdir:?not run under make check}"
-dups=$(grep -rl '^[A-Za-z_].*[^a-z_]ehexh *(' "${srcdir}/src" --include='*.c' --include='*.h' || true)
+dups=$(grep -rlE '^[A-Za-z_].*[^a-z_](ehexh|get_hex_value) *\(' \
+    "${srcdir}/src" --include='*.c' --include='*.h' |
+    grep -v -x -F "${srcdir}/src/htsencoding.h" || true)
 [ -z "$dups" ] || {
     echo "private copy of the escape decoder is back: $dups"
     exit 1

--- a/tests/01_engine-unescape-form.test
+++ b/tests/01_engine-unescape-form.test
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# Form/ini percent-decoding keeps a malformed escape as text (it used to decode
+# "%ZZ" to a NUL, truncating the value).
+out=$(httrack -O /dev/null -#test=unescape-form run)
+grep -q "unescape-form self-test OK" <<<"$out"
+
+# One decoder, or the drift comes back: nothing outside htsescape.h may define
+# the hex helpers the server and the engine now share.
+srcdir="${abs_top_srcdir:?not run under make check}"
+dups=$(grep -rl '^[A-Za-z_].*[^a-z_]ehexh *(' "${srcdir}/src" --include='*.c' --include='*.h' || true)
+[ -z "$dups" ] || {
+    echo "private copy of the escape decoder is back: $dups"
+    exit 1
+}

--- a/tests/342_msvc-source-lists.test
+++ b/tests/342_msvc-source-lists.test
@@ -9,7 +9,9 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-top=${abs_top_srcdir:-$(cd "$testdir/.." && pwd)}
+# the MSVC job runs the scripts with no automake around them
+[ -n "${abs_top_srcdir:-}" ] || skip "abs_top_srcdir unset, no automake environment"
+top=${abs_top_srcdir}
 am="$top/src/Makefile.am"
 test -r "$am" || fail "no $am"
 

--- a/tests/342_msvc-source-lists.test
+++ b/tests/342_msvc-source-lists.test
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# The Visual Studio projects carry their own hand-written source lists, so a new
+# .c added to Makefile.am alone links fine everywhere except MSVC (#1376 lost two
+# Windows legs to exactly that).
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+top=${abs_top_srcdir:-$(cd "$testdir/.." && pwd)}
+am="$top/src/Makefile.am"
+test -r "$am" || fail "no $am"
+
+# iowin32.c is the Win32 ioapi: MSVC-only by design, never in Makefile.am.
+win_only="minizip/iowin32.c"
+
+# Sources of one automake variable, one per line, continuations folded.
+am_sources() {
+    awk -v var="$1" '
+        $0 ~ "^" var "[ \t]*=" { inlist = 1; sub(/^[^=]*=/, "") }
+        inlist {
+            line = $0
+            cont = sub(/\\[ \t]*$/, "")
+            n = split(line, tok, /[ \t]+/)
+            for (i = 1; i <= n; i++)
+                if (tok[i] ~ /\.c$/) print tok[i]
+            if (!cont) exit
+        }' "$am" | sort -u
+}
+
+# ClCompile entries of one project, backslashes folded to slashes.
+proj_sources() {
+    sed -n 's|.*<ClCompile Include="\([^"]*\)".*|\1|p' "$top/src/$1" |
+        tr '\134' '/' | sort -u
+}
+
+check() {
+    var=$1 proj=$2
+    test -r "$top/src/$proj" || fail "no src/$proj"
+    missing=$(comm -23 <(am_sources "$var") <(proj_sources "$proj") | tr '\n' ' ')
+    [ -z "$missing" ] || fail "$proj is missing: $missing"
+
+    extra=$(comm -13 <(am_sources "$var") <(proj_sources "$proj") |
+        grep -v -x -F "$win_only" | tr '\n' ' ' || true)
+    [ -z "$extra" ] || fail "$proj builds sources $var does not: $extra"
+}
+
+# A typo in a variable name would make every check vacuously pass.
+[ -n "$(am_sources libhttrack_la_SOURCES)" ] || fail "parsed no sources from $am"
+
+check libhttrack_la_SOURCES libhttrack.vcxproj
+check htsserver_SOURCES webhttrack.vcxproj
+check proxytrack_SOURCES proxytrack.vcxproj
+check httrack_SOURCES httrack.vcxproj


### PR DESCRIPTION
The same hex-digit decoder existed five times in the tree, under two names and with two different contracts. `htslib.c` and `htsencoding.c` (as `get_hex_value`) return -1 for a character that is not a hex digit, and their callers leave the escape literal. The three copies behind the WebHTTrack server return 0 instead, so `%ZZ` decodes to a NUL that truncates the value wherever it is next read as a C string. That reaches posted form values, the User-Agent field and the winprofile.ini reader. Those copies still carry a comment from an earlier hardening pass. That pass fixed the length check but stopped short of checking hex validity.

The duplication has a cause: libhttrack builds with `-fvisibility=hidden` and these helpers are not `HTSEXT_API`, so htsserver cannot link them even though `htslib.h` declares them. Patching the weak copies in place would leave them free to drift apart again, so the two form decoders move to a new `src/htsescape.{c,h}`, compiled into libhttrack and htsserver the way `htsurlport.c` and `htscmdline.c` already are, and the hex helpers move to `htsencoding.h`, which already owned the concept. Only the hex validation changes; the `+`-to-space rule the query parser depends on stays. One copy in `proxy/proxystrings.h` had no callers and is deleted.

Checked by differential execution rather than by reading: 271,453 inputs through both the old and the new bodies under ASan and UBSan give 48,952 differences, every one on an input with a malformed escape, and the moved hex helpers match the originals across all 256 byte values and all 65,536 pairs under both `char` signedness settings.

`tests/342_msvc-source-lists.test` covers the other half of the problem. The Visual Studio projects keep hand-written source lists, so the new file linked everywhere except MSVC and cost this PR two Windows legs. The test compares each automake `_SOURCES` against its `.vcxproj`, so the next added source file fails locally instead of on a Windows runner.