### PR TITLE
A script served as text/javascript is never scanned for links

### DIFF
--- a/src/htsindex.c
+++ b/src/htsindex.c
@@ -173,9 +173,7 @@ int index_keyword(const char *html_data, LLint size, const char *mime,
   else if ((strfield2(mime, "image/svg+xml"))
            || (strfield2(mime, "image/svg-xml"))) {
     inscript = 0;
-  } else if ((strfield2(mime, "application/x-javascript"))
-             || (strfield2(mime, "text/css"))
-    ) {
+  } else if (is_javascript_mime_type(mime) || (strfield2(mime, "text/css"))) {
     inscript = 1;
   } else
     return 0;

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -606,17 +606,21 @@ HTS_STATIC int strcmpnocase(const char *a, const char *b) {
    (strfield2((a), HTS_UNKNOWN_MIME) !=                                        \
     0) /* no declared type: treat as html */                                   \
   )
-#define is_hypertext_mime__(a) \
-  ( \
-  is_html_mime_type(a)\
-  || (strfield2((a),"application/x-javascript")!=0) \
-  || (strfield2((a),"text/css")!=0) \
-  /*|| (strfield2((a),"text/vnd.wap.wml")!=0)*/ \
-  || (strfield2((a),"image/svg+xml")!=0) \
-  || (strfield2((a),"image/svg-xml")!=0) \
-  /*|| (strfield2((a),"audio/x-pn-realaudio")!=0) */\
-  || (strfield2((a),"application/x-authorware-map")!=0) \
-  )
+/* Every JavaScript type we link-scan: IANA's text/javascript, which our own
+   mime table emits for .js and .mjs, plus the legacy application spellings. */
+#define is_javascript_mime_type(a)                                             \
+  ((strfield2((a), "text/javascript") != 0) ||                                 \
+   (strfield2((a), "application/javascript") != 0) ||                          \
+   (strfield2((a), "application/x-javascript") != 0) ||                        \
+   (strfield2((a), "application/ecmascript") != 0))
+#define is_hypertext_mime__(a)                                                 \
+  (is_html_mime_type(a) || is_javascript_mime_type(a) ||                       \
+   (strfield2((a), "text/css") !=                                              \
+    0) /*|| (strfield2((a),"text/vnd.wap.wml")!=0)*/                           \
+   || (strfield2((a), "image/svg+xml") != 0) ||                                \
+   (strfield2((a), "image/svg-xml") !=                                         \
+    0) /*|| (strfield2((a),"audio/x-pn-realaudio")!=0) */                      \
+   || (strfield2((a), "application/x-authorware-map") != 0))
 #define may_be_hypertext_mime__(a) \
    (\
      (strfield2((a),"audio/x-pn-realaudio")!=0) \
@@ -639,6 +643,22 @@ HTS_STATIC int is_hypertext_mime(httrackp * opt, const char *mime,
     if (!guess_httptype_sized(opt, guessed, sizeof(guessed), file))
       return 0;
     return is_hypertext_mime__(guessed);
+  }
+  return 0;
+}
+
+// check if (mime, file) is JavaScript, guessing from the extension as above
+HTS_STATIC int is_javascript_mime(httrackp *opt, const char *mime,
+                                  const char *file) {
+  if (is_javascript_mime_type(mime))
+    return 1;
+  if (file != NULL && file[0] != '\0' && may_unknown(opt, mime)) {
+    char guessed[256];
+
+    guessed[0] = '\0';
+    if (!guess_httptype_sized(opt, guessed, sizeof(guessed), file))
+      return 0;
+    return is_javascript_mime_type(guessed);
   }
   return 0;
 }

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -606,8 +606,9 @@ HTS_STATIC int strcmpnocase(const char *a, const char *b) {
    (strfield2((a), HTS_UNKNOWN_MIME) !=                                        \
     0) /* no declared type: treat as html */                                   \
   )
-/* Every JavaScript type we link-scan: IANA's text/javascript, which our own
-   mime table emits for .js and .mjs, plus the legacy application spellings. */
+/* Every JavaScript type we link-scan: IANA's text/javascript, which is what
+   servers send and what our own table emits for .mjs, plus the legacy
+   application spellings .js still maps to. */
 #define is_javascript_mime_type(a)                                             \
   ((strfield2((a), "text/javascript") != 0) ||                                 \
    (strfield2((a), "application/javascript") != 0) ||                          \

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -522,13 +522,9 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
         intag_name = NULL;
       }
       /* Check is the file is a .js file */
-      else
-        if ((compare_mime
-             (opt, r->contenttype, str->url_file,
-              "application/x-javascript") != 0)
-            || (compare_mime(opt, r->contenttype, str->url_file, "text/css") !=
-                0)
-        ) {                     /* JavaScript js file */
+      else if ((is_javascript_mime(opt, r->contenttype, str->url_file) != 0) ||
+               (compare_mime(opt, r->contenttype, str->url_file, "text/css") !=
+                0)) { /* JavaScript js file */
         inscript = 1;
         inscript_locked = 1;    /* Don't exit js space upon </script> */
         if (opt->parsedebug) {
@@ -539,9 +535,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
         intag_start_valid = 0;  // OUI car nous sommes dans du code, plus dans du "vrai" tag
         hts_log_print(opt, LOG_DEBUG, "note: this file is a javascript file");
         // for javascript only
-        if (compare_mime
-            (opt, r->contenttype, str->url_file,
-             "application/x-javascript") != 0) {
+        if (is_javascript_mime(opt, r->contenttype, str->url_file) != 0) {
           // all links must be checked against parent, not this link
           if (heap(ptr)->precedent != 0) {
             parent_relative = 1;
@@ -549,28 +543,34 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
         }
       }
       /* Or a real audio */
-      else if (compare_mime(opt, r->contenttype, str->url_file, "audio/x-pn-realaudio") != 0) { /* realaudio link file */
+      else if (compare_mime(opt, r->contenttype, str->url_file,
+                            "audio/x-pn-realaudio") !=
+               0) { /* realaudio link file */
         inscript = intag = 0;
         inscript_name = "media";
         intag_start_valid = 0;
         in_media = "LNK";       // real media! -> links
       }
       /* Or a m3u playlist */
-      else if (compare_mime(opt, r->contenttype, str->url_file, "audio/x-mpegurl") != 0) {      /* mp3 link file */
+      else if (compare_mime(opt, r->contenttype, str->url_file,
+                            "audio/x-mpegurl") != 0) { /* mp3 link file */
         inscript = intag = 0;
         inscript_name = "media";
         intag_start_valid = 0;
         in_media = "LNK";       // m3u! -> links
-      } else if (compare_mime(opt, r->contenttype, str->url_file, "application/x-authorware-map") != 0) {       /* macromedia aam file */
+      } else if (compare_mime(opt, r->contenttype, str->url_file,
+                              "application/x-authorware-map") !=
+                 0) { /* macromedia aam file */
         inscript = intag = 0;
         inscript_name = "media";
         intag_start_valid = 0;
         in_media = "AAM";       // aam
       }
       /* Or a RSS file */
-      else if (compare_mime(opt, r->contenttype, str->url_file, "text/xml") != 0
-               || compare_mime(opt, r->contenttype, str->url_file,
-                               "application/xml") != 0) {
+      else if (compare_mime(opt, r->contenttype, str->url_file, "text/xml") !=
+                   0 ||
+               compare_mime(opt, r->contenttype, str->url_file,
+                            "application/xml") != 0) {
         if (strstr(html, "http://purl.org/rss/") != NULL)        // Hmm, this is a bit lame ; will have to cleanup
         {                       /* RSS file */
           inscript = intag = 0;

--- a/src/htssinglefile.c
+++ b/src/htssinglefile.c
@@ -436,10 +436,7 @@ static int sf_mime_class(httrackp *opt, const char *path, char *mime,
     return SF_C_FONT;
   if (strfield2(mime, "text/css") != 0)
     return SF_C_CSS;
-  if (strfield2(mime, "text/javascript") != 0 ||
-      strfield2(mime, "application/javascript") != 0 ||
-      strfield2(mime, "application/x-javascript") != 0 ||
-      strfield2(mime, "application/ecmascript") != 0)
+  if (is_javascript_mime_type(mime))
     return SF_C_JS;
   return 0;
 }

--- a/tests/345_local-js-content-type.test
+++ b/tests/345_local-js-content-type.test
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# An external script is link-scanned whatever spelling of the JavaScript type
+# the server sends: text/javascript (with or without a charset parameter),
+# application/javascript, the legacy application/x-javascript, and a .mjs
+# module. Only the legacy spelling was recognised before, so the targets of
+# every other script went unmirrored (#302).
+#
+# The link-free quiet/q.js guards the other direction: widening the set widens
+# what gets scanned, and a scanned script must come out byte-identical to
+# quiet/q.bin, the same bytes served under a type nothing scans. json/d.json
+# holds a link-shaped string under a non-script type and must stay unscanned.
+
+set -euo pipefail
+
+: "${top_srcdir:=..}"
+
+bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
+    --found 'jsmime/xjs/s.js' \
+    --found 'jsmime/xjs1.html' --found 'jsmime/xjs2.html' --found 'jsmime/xjs3.html' \
+    --found 'jsmime/txt/s.js' \
+    --found 'jsmime/txt1.html' --found 'jsmime/txt2.html' --found 'jsmime/txt3.html' \
+    --found 'jsmime/app/s.js' \
+    --found 'jsmime/app1.html' --found 'jsmime/app2.html' --found 'jsmime/app3.html' \
+    --found 'jsmime/chs/s.js' \
+    --found 'jsmime/chs1.html' --found 'jsmime/chs2.html' --found 'jsmime/chs3.html' \
+    --found 'jsmime/mod/s.mjs' \
+    --found 'jsmime/mod1.html' --found 'jsmime/mod2.html' --found 'jsmime/mod3.html' \
+    --files-identical 'jsmime/quiet/q.js' 'jsmime/quiet/q.bin' \
+    --found 'jsmime/json/d.json' --not-found 'jsmime/jsn1.html' \
+    --files 24 \
+    httrack 'BASEURL/jsmime/index.html'

--- a/tests/36_local-bigcrawl.test
+++ b/tests/36_local-bigcrawl.test
@@ -1,21 +1,22 @@
 #!/bin/bash
 #
 # Diverse seeded /big/ crawl: 12 pattern families, decoy absence, update pass
-# must 304-revalidate. 361 = 1 index + 96 pages + 192 imgs + 5 shared + 61
-# family + 6 singles; the 4 planted errors write -o1 pages, not counted.
+# must 304-revalidate. 362 = 1 index + 96 pages + 192 imgs + 5 shared + 61
+# family + 7 singles; the 4 planted errors write -o1 pages, not counted.
 
 set -euo pipefail
 
 : "${top_srcdir:=..}"
 
 bash "$top_srcdir/tests/local-crawl.sh" --rerun \
-    --errors-content 4 --files 361 \
+    --errors-content 4 --files 362 \
     --found 'big/p/95.html' \
     --found 'big/a/d1/d2/d3/d4/d5/d6/d7/d8/deep.png' \
     --found 'big/a/f2-2x.png' \
     --found 'big/a/subs.vtt' \
     --found 'big/a/font.woff2' \
     --found 'big/a/js-data.bin' \
+    --found 'big/a/js3.png' \
     --found 'big/d/01.pdf' \
     --found 'big/d/named.pdf' \
     --found 'big/a/doc.pdf' \
@@ -30,7 +31,6 @@ bash "$top_srcdir/tests/local-crawl.sh" --rerun \
     --not-found 'big/x/og' \
     --not-found 'big/x/tw' \
     --not-found 'big/x/jsonld.png' \
-    --not-found 'big/x/never-scanned.png' \
     --not-found 'big/x/atom-only.html' \
     --not-found 'big/x/sitemap-only.html' \
     --not-found 'big/x/form-target.html' \

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -17,6 +17,7 @@
 #       --errors N --errors-content N --files N --found PATH ... --directory PATH ... \
 #       --log-found REGEX ... --log-not-found REGEX ... \
 #       --file-matches PATH REGEX ... --file-not-matches PATH REGEX ... \
+#       --files-identical PATH PATH ... \
 #       --cache-found URLTAIL ... --cache-not-found URLTAIL ... \
 #       --file-min-bytes PATH N --file-mode PATH OCTAL --max-mirror-bytes N \
 #       httrack BASEURL/some/path [httrack-args...]
@@ -29,6 +30,8 @@
 # --cache-found/--cache-not-found assert whether hts-cache/new.zip holds an
 # entry whose URL ends with URLTAIL, e.g. /dir/page.html; being mirrored and
 # being cached are separate outcomes (#840).
+# --files-identical compares two mirrored files byte for byte, e.g. a scanned
+# copy against one served under a type nothing scans.
 # --file-min-bytes asserts a mirrored file (PATH) is at least N bytes.
 # --file-mode asserts its octal permissions (e.g. 644); POSIX hosts only.
 # --rerun-args runs a second pass (same server and mirror dir) with the given
@@ -230,7 +233,7 @@ while test "$pos" -lt "$nargs"; do
         audit+=("${args[$pos]}" "${args[$((pos + 1))]}")
         pos=$((pos + 1))
         ;;
-    --file-matches | --file-not-matches | --file-min-bytes | --file-mode)
+    --file-matches | --file-not-matches | --file-min-bytes | --file-mode | --files-identical)
         audit+=("${args[$pos]}" "${args[$((pos + 1))]}" "${args[$((pos + 2))]}")
         pos=$((pos + 2))
         ;;
@@ -719,6 +722,15 @@ while test "$i" -lt "${#audit[@]}"; do
             result "matched"
             exit 1
         else result "OK"; fi
+        ;;
+    --files-identical)
+        path="${audit[$((i + 1))]}"
+        i=$((i + 2))
+        info "checking ${path} is byte-identical to ${audit[$i]}"
+        if cmp -s "${hostroot}/${path}" "${hostroot}/${audit[$i]}"; then result "OK"; else
+            result "differs"
+            exit 1
+        fi
         ;;
     --file-min-bytes)
         path="${audit[$((i + 1))]}"

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -165,10 +165,9 @@ BIG_TEXT_ASSETS = {
         "// %s\n" % _hexfill("heavy.js"),
         "application/x-javascript",
     ),
-    # text/javascript is fetched but never scanned: the URL inside must stay
-    # out of the mirror.
-    "decoy.js": (
-        'var d = new Image(); d.src = "/big/x/never-scanned.png";\n',
+    # text/javascript is scanned like the legacy spelling, so this one lands.
+    "modern.js": (
+        'var d = new Image(); d.src = "/big/a/js3.png";\n',
         "text/javascript",
     ),
     "subs.vtt": ("WEBVTT\n\n00:00.000 --> 00:01.000\nbig\n", "text/vtt"),
@@ -242,7 +241,7 @@ def _fam_js(port):
     # The concatenated string is rejected by the scanner (no single literal).
     return (
         '<script src="/big/a/heavy.js"></script>'
-        '<script src="/big/a/decoy.js"></script>'
+        '<script src="/big/a/modern.js"></script>'
         "<script>document.write('<a href=\"/big/f5/dw.html\">dw</a>');\n"
         'var nope = "xx-" + "/big/x/concat.html";</script>'
     )
@@ -771,6 +770,70 @@ class Handler(SimpleHTTPRequestHandler):
         self.send_header("Location", "/sitemapdir/pages.xml.gz")
         self.send_header("Content-Length", "0")
         self.end_headers()
+
+    # --- JavaScript content types (#302 increment) -------------------------
+    # One spelling of the JS type per directory; links inside a script resolve
+    # against the parent page, so every target lands directly under /jsmime/.
+    JSMIME_TYPES = {
+        "xjs": ("application/x-javascript", "js"),
+        "txt": ("text/javascript", "js"),
+        "app": ("application/javascript", "js"),
+        "chs": ("text/javascript; charset=utf-8", "js"),
+        "mod": ("text/javascript", "mjs"),
+    }
+
+    # Link-free script: scanning it must invent no link and rewrite no byte.
+    # q.bin serves the same bytes under a type nothing scans, as the reference.
+    JSMIME_QUIET = (
+        b'"use strict";\n'
+        b'var cfg = { name: "app/main", version: "1.2.3", sep: "/" };\n'
+        b'function join(a, b) { return a + "/" + b; }\n'
+        b"var re = /^[a-z]+\\.[a-z]+$/;\n"
+        b'var tpl = "<div class=\\"x\\">no link here</div>";\n'
+        b"console.log(join(cfg.name, tpl), re);\n"
+    )
+
+    @staticmethod
+    def jsmime_script(key):
+        return (
+            b'var a = "%(k)s1.html";\n'
+            b"var b = '%(k)s2.html';\n"
+            b'window.location = "%(k)s3.html";\n' % {b"k": key.encode()}
+        )
+
+    def route_jsmime(self):
+        path = urlsplit(self.path).path
+        rest = path[len("/jsmime/") :]
+        if rest in ("", "index.html"):
+            body = ""
+            for key, (_, ext) in self.JSMIME_TYPES.items():
+                attr = ' type="module"' if key == "mod" else ""
+                body += '\t<script%s src="%s/s.%s"></script>\n' % (attr, key, ext)
+            body += '\t<script src="quiet/q.js"></script>\n'
+            body += '\t<a href="quiet/q.bin">reference copy</a>\n'
+            body += '\t<a href="json/d.json">data</a>\n'
+            self.send_html(body)
+            return
+        if rest == "quiet/q.js":
+            self.send_raw(self.JSMIME_QUIET, "text/javascript")
+            return
+        if rest == "quiet/q.bin":
+            self.send_raw(self.JSMIME_QUIET, "application/octet-stream")
+            return
+        if rest == "json/d.json":
+            # Not a script type: widening the JS set must not reach this one.
+            self.send_raw(b'{ "u": "jsn1.html" }\n', "application/json")
+            return
+        key = rest.split("/")[0]
+        if key in self.JSMIME_TYPES:
+            ctype, ext = self.JSMIME_TYPES[key]
+            if rest == "%s/s.%s" % (key, ext):
+                self.send_raw(self.jsmime_script(key), ctype)
+                return
+        elif re.fullmatch(r"[a-z]{3}[123]\.html", rest):
+            self.send_html("\tTarget %s reached from a script.\n" % rest)
+            return
+        self.send_error(404)
 
     # --- type/extension matrix (issue #267 family) -------------------------
 
@@ -3024,6 +3087,9 @@ class Handler(SimpleHTTPRequestHandler):
             return True
         if path.startswith("/asset/"):
             self.route_asset()
+            return True
+        if path.startswith("/jsmime/"):
+            self.route_jsmime()
             return True
         if path.startswith("/charset/"):
             self.route_charset()


### PR DESCRIPTION
An external `.js` file was link-scanned only when the server spelled its Content-Type `application/x-javascript`. `text/javascript` is what IANA recommends, what most servers send, and what httrack's own mime table emits for `.js` and `.mjs`, so the common case was fetched, saved, and never parsed: every URL inside it stayed out of the mirror. Against the local test server on identical script bytes, `application/x-javascript` captured all 7 links; `text/javascript`, `application/javascript`, a `text/javascript; charset=utf-8` header and a `.mjs` module captured none.

The four spellings now live in one `is_javascript_mime_type()` in `htslib.h`, read by `is_hypertext_mime__()`, both `htsparse.c` dispatch sites, `htsindex.c` and the four-way list in `htssinglefile.c`, so the copies cannot drift apart again.

The risk runs the other way: more files get link-scanned now, and the JS scan does pull link-shaped string literals out of ordinary code. I measured that too. A script full of paths with real extensions produces the same four spurious fetches under `application/x-javascript` as under `text/javascript`, so this is the existing scan reaching more files, not new behavior. A link-free script comes back byte-identical: `345_local-js-content-type.test` mirrors one under `text/javascript`, compares it with `cmp` against the same bytes served under a type nothing scans, and pins an `application/json` decoy whose link-shaped string must stay unfetched. The test goes red on master at the first `text/javascript` target.

`36_local-bigcrawl` had a fixture named `decoy.js` asserting that a `text/javascript` script is never scanned. It is now `modern.js`, and the test asserts its target is present.

Surfaced by the JS/SPA work in #302; this is one increment of it, not the whole epic.

The legacy spelling's own count is unchanged: 7 of 7 before and after, on the same fixture. `htsindex.c` does gain behaviour, since a `text/javascript` file previously returned before the keyword loop and now enters it, which matches what the legacy spelling has always done.