### PR TITLE
Files kept from disk instead of fetched are never mentioned

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -4124,11 +4124,12 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                       back[i].is_update && !back[i].testmode &&
                       back[i].range_req_size == 0 && back[i].url_sav[0] &&
                       fexist_utf8(back[i].url_sav)) {
-                    hts_log_print(opt, LOG_DEBUG,
-                                  "Error %d (%s) ignored on update, keeping "
-                                  "existing copy: %s%s",
-                                  back[i].r.statuscode, back[i].r.msg,
-                                  back[i].url_adr, back[i].url_fil);
+                    hts_log_print(opt, LOG_NOTICE,
+                                  "Kept existing file %s after error %d (%s) "
+                                  "on update: %s%s",
+                                  back[i].url_sav, back[i].r.statuscode,
+                                  back[i].r.msg, back[i].url_adr,
+                                  back[i].url_fil);
                     back[i].r.statuscode = HTTP_NOT_MODIFIED;
                     deletehttp(&back[i].r);
                     back[i].r.soc = INVALID_SOCKET;

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -4106,9 +4106,12 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                       back[i].r.size = back[i].r.totalsize =
                         back[i].range_req_size;
                       back[i].r.statuscode = HTTP_NOT_MODIFIED; // NOT MODIFIED
-                      hts_log_print(opt, LOG_DEBUG,
-                                    "File seems complete (good 416 message), breaking connection: %s%s",
-                                    back[i].url_adr, back[i].url_fil);
+                      hts_log_print(
+                          opt, LOG_NOTICE,
+                          "Kept existing file %s (" LLintP
+                          " bytes), matching size and timestamp: %s%s",
+                          back[i].url_sav, (LLint) back[i].range_req_size,
+                          back[i].url_adr, back[i].url_fil);
                     }
                   }
                   // transform 406 into 200 ; we'll catch embedded links inside the choice page
@@ -4156,9 +4159,12 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                               back[i].r.statuscode = HTTP_NOT_MODIFIED; // forcer NOT MODIFIED
                               deletehttp(&back[i].r);
                               back[i].r.soc = INVALID_SOCKET;
-                              hts_log_print(opt, LOG_DEBUG,
-                                            "File seems complete (same size), breaking connection: %s%s",
-                                            back[i].url_adr, back[i].url_fil);
+                              hts_log_print(
+                                  opt, LOG_NOTICE,
+                                  "Kept existing file %s (" LLintP
+                                  " bytes), matching the cached size: %s%s",
+                                  back[i].url_sav, (LLint) len1,
+                                  back[i].url_adr, back[i].url_fil);
                             }
                           }
                         } else {
@@ -4196,8 +4202,11 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                                             back[i].url_fil, back[i].url_sav, 0,
                                             0, back[i].r.notmodified);
                                 back[i].r.statuscode = HTTP_NOT_MODIFIED;       // NOT MODIFIED
-                                hts_log_print(opt, LOG_DEBUG,
-                                              "File seems complete (same size file discovered), breaking connection: %s%s",
+                                hts_log_print(opt, LOG_NOTICE,
+                                              "Kept existing file %s (" LLintP
+                                              " bytes), matching the announced "
+                                              "size: %s%s",
+                                              back[i].url_sav, (LLint) size,
                                               back[i].url_adr, back[i].url_fil);
                               }
                             }
@@ -4239,10 +4248,14 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                                                     back[i].url_sav, 0, 0,
                                                     back[i].r.notmodified);
                                         back[i].r.statuscode = HTTP_NOT_MODIFIED;       // NOT MODIFIED
-                                        hts_log_print(opt, LOG_DEBUG,
-                                                      "File seems complete (reget failed), breaking connection: %s%s",
-                                                      back[i].url_adr,
-                                                      back[i].url_fil);
+                                        hts_log_print(
+                                            opt, LOG_NOTICE,
+                                            "Kept existing file %s (" LLintP
+                                            " bytes), matching the announced "
+                                            "size, range ignored: %s%s",
+                                            back[i].url_sav,
+                                            (LLint) back[i].range_req_size,
+                                            back[i].url_adr, back[i].url_fil);
                                       }
                                     }
                                   }

--- a/tests/343_local-kept-file-logged.test
+++ b/tests/343_local-kept-file-logged.test
@@ -1,0 +1,101 @@
+#!/bin/bash
+# A file kept in place instead of downloaded must say so at the default log
+# level (#113). Both acceptance paths were silent: the 416 answered to a resume
+# request, and --sizehack over a server that refuses Range. The re-fetch legs
+# are the control, since a marker that always appears proves nothing.
+set -eu
+
+# shellcheck source=tests/crawllib.sh
+. "${0%"${0##*/}"}./crawllib.sh"
+
+marker='Kept existing file'
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_343.XXXXXX") || exit 1
+cleanup() {
+    rm -rf "$tmpdir"
+}
+cleanup_push cleanup
+
+require_httrack
+
+# plain.bin is served from the docroot, whose handler ignores Range; the crawl
+# reaches /ranged/asset.bin, which honours it.
+mkdir -p "${tmpdir}/root"
+repeat_chars 8192 P >"${tmpdir}/root/plain.bin"
+cat >"${tmpdir}/root/index.html" <<'HTML'
+<html><body>
+<a href="plain.bin">plain</a>
+<a href="/ranged/asset.bin">ranged</a>
+</body></html>
+HTML
+
+local_server_start --root "${tmpdir}/root"
+
+crawl() { # crawl <label> <outdir> [httrack args...]
+    local label=$1 out=$2
+    shift 2
+    local_crawl --log "${tmpdir}/crawl-${label}.log" \
+        "${BASEURL}/index.html" -O "$out" --quiet --robots=0 --timeout=30 \
+        "$@" || fail "$label: crawl failed"
+}
+
+# Reference mirror, downloaded the ordinary way: what a kept file must not
+# become, and what a re-fetched one must.
+refout="${tmpdir}/out-ref"
+crawl ref "$refout"
+refhost="${refout}/127.0.0.1_${SRV_PORT}"
+assert_file "${refhost}/plain.bin" "reference mirror"
+assert_file "${refhost}/ranged/asset.bin" "reference mirror"
+
+# A clean directory holding only the assets, as the reporter's workflow builds
+# it: no cache, and mtimes stamped now, so If-Unmodified-Since always passes.
+seed() { # seed <outdir> <plain source> <ranged source>
+    local host="$1/127.0.0.1_${SRV_PORT}"
+    rm -rf "$1"
+    mkdir -p "${host}/ranged"
+    cp "$2" "${host}/plain.bin"
+    cp "$3" "${host}/ranged/asset.bin"
+}
+
+kept_lines() { # kept_lines <outdir>
+    count_matching_lines -F "$marker" "$1/hts-log.txt"
+}
+
+# Right size, wrong bytes: both paths accept these, and the log must name them.
+poison="${tmpdir}/poison"
+mkdir -p "$poison"
+repeat_chars "$(size_of "${refhost}/plain.bin")" Q >"${poison}/plain.bin"
+repeat_chars "$(size_of "${refhost}/ranged/asset.bin")" Q >"${poison}/asset.bin"
+
+keptout="${tmpdir}/out-kept"
+seed "$keptout" "${poison}/plain.bin" "${poison}/asset.bin"
+crawl kept "$keptout" '-%N0' --sizehack
+kepthost="${keptout}/127.0.0.1_${SRV_PORT}"
+n=$(kept_lines "$keptout")
+test "$n" -eq 2 || fail "kept: log names $n kept files, expected 2:
+$(grep -a 'complete\|Kept existing' "${keptout}/hts-log.txt" || true)"
+cmp -s "${poison}/plain.bin" "${kepthost}/plain.bin" ||
+    fail "kept: plain.bin was re-fetched, so the log line describes nothing"
+cmp -s "${poison}/asset.bin" "${kepthost}/ranged/asset.bin" ||
+    fail "kept: ranged/asset.bin was re-fetched"
+ok "both kept files are named in the log"
+
+# Control: a genuine prefix of each asset. Neither size matches, so both are
+# completed off the server and nothing may claim a file was kept.
+part="${tmpdir}/part"
+mkdir -p "$part"
+dd if="${refhost}/plain.bin" of="${part}/plain.bin" bs=1 count=4096 2>/dev/null
+dd if="${refhost}/ranged/asset.bin" of="${part}/asset.bin" bs=1 count=4096 \
+    2>/dev/null
+
+fetchout="${tmpdir}/out-fetch"
+seed "$fetchout" "${part}/plain.bin" "${part}/asset.bin"
+crawl fetch "$fetchout" '-%N0' --sizehack
+fetchhost="${fetchout}/127.0.0.1_${SRV_PORT}"
+n=$(kept_lines "$fetchout")
+test "$n" -eq 0 || fail "fetch: log claims $n files were kept"
+cmp -s "${refhost}/plain.bin" "${fetchhost}/plain.bin" ||
+    fail "fetch: plain.bin does not match the server's copy"
+cmp -s "${refhost}/ranged/asset.bin" "${fetchhost}/ranged/asset.bin" ||
+    fail "fetch: ranged/asset.bin does not match the server's copy"
+ok "a re-fetched file is not reported as kept"

--- a/tests/343_local-kept-file-logged.test
+++ b/tests/343_local-kept-file-logged.test
@@ -74,6 +74,16 @@ kepthost="${keptout}/127.0.0.1_${SRV_PORT}"
 n=$(kept_lines "$keptout")
 test "$n" -eq 2 || fail "kept: log names $n kept files, expected 2:
 $(grep -a 'complete\|Kept existing' "${keptout}/hts-log.txt" || true)"
+# A count alone passes a line naming the wrong file or a garbage size, which is
+# the whole value of the line.
+names_file() { # names_file <mirror-relative path>
+    count_matching_lines -F "$1 ($(size_of "${refhost}/$1") bytes)" \
+        "${keptout}/hts-log.txt"
+}
+for want in plain.bin ranged/asset.bin; do
+    test "$(names_file "$want")" -ge 1 || fail "kept: no line names $want with its size:
+$(grep -a 'Kept existing' "${keptout}/hts-log.txt" || true)"
+done
 cmp -s "${poison}/plain.bin" "${kepthost}/plain.bin" ||
     fail "kept: plain.bin was re-fetched, so the log line describes nothing"
 cmp -s "${poison}/asset.bin" "${kepthost}/ranged/asset.bin" ||

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1122,6 +1122,33 @@ class Handler(SimpleHTTPRequestHandler):
             "application/octet-stream",
         )
 
+    # Range-capable asset for 343: a resume at or past the end gets the 416 the
+    # on-disk acceptance path reads as "already complete", shorter gets a 206.
+    RANGED_BIN = b"RANGED-" + bytes((i * 11 + 5) % 256 for i in range(8192))
+
+    def route_ranged_asset(self):
+        body = self.RANGED_BIN
+        m = re.match(r"bytes=(\d+)-", self.headers.get("Range", "") or "")
+        start = int(m.group(1)) if m else 0
+        if not m or start == 0:
+            self.send_raw(body, "application/octet-stream")
+        elif start >= len(body):
+            self.send_response(416, "Requested Range Not Satisfiable")
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Range", "bytes */%d" % len(body))
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+        else:
+            self.send_response(206, "Partial Content")
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header(
+                "Content-Range", "bytes %d-%d/%d" % (start, len(body) - 1, len(body))
+            )
+            self.send_header("Content-Length", str(len(body) - start))
+            self.end_headers()
+            if self.command != "HEAD":
+                self.wfile.write(body[start:])
+
     # Echo what httrack advertised, so a crawl can assert the header.
     def route_codec_ae(self):
         self.send_raw(
@@ -2671,6 +2698,7 @@ class Handler(SimpleHTTPRequestHandler):
         "/keep/data.bin": route_keep_data,
         "/keep/err.bin": route_keep_err,
         "/keep/stay.bin": route_keep_stay,
+        "/ranged/asset.bin": route_ranged_asset,
         "/types/index.html": route_types_index,
         "/types/control.php": route_types,
         "/types/photo.png": route_types,


### PR DESCRIPTION
Four places in `back_wait()` break the connection and keep the file already on disk rather than fetching it. All four logged at `LOG_DEBUG`, which a default run never prints, so a mirror can be assembled largely out of local files and say nothing about it.

That silence has a cost. Investigating #113 measured a run with `--delayed-type-check=0 --sizehack` keeping three files that had been deliberately filled with garbage but were the right size, and reporting no errors. The acceptance rests on size and mtime, and a freshly copied asset has an mtime that satisfies the precondition trivially.

Each site now logs at `LOG_NOTICE`, which is the lowest level a default run shows, naming the file, its size, and which criterion matched.

What the engine accepts is deliberately unchanged. Whether size and mtime are sufficient evidence that a local file matches the remote is a product decision, and quietly tightening it here would change what existing mirrors do. `httrack-works/design/113-reuse-existing-assets.md` has the measurements and ranks the options.

Refs #113.
