### PR TITLE
Conditions that decide nothing, and an empty Content-Type header that ships

### DIFF
--- a/src/htscharset.c
+++ b/src/htscharset.c
@@ -1174,16 +1174,8 @@ char *hts_convertStringIDNAToUTF8(const char *s, size_t size) {
             if (uc < 0x80) {
               ADD_BYTE((char) uc);
             } else {
-              /* emiter (byte per byte) */
-#define EM(C) do { \
-  if (C != -1) {   \
-    ADD_BYTE(C);   \
-  } else {         \
-    FREE_BUFFER(); \
-    return NULL;   \
-  }                \
-} while(0)
-              /* Emit codepoint */
+              /* EMIT_UNICODE only ever emits a byte, never an error */
+#define EM(C) ADD_BYTE(C)
               EMIT_UNICODE(uc, EM);
 #undef EM
             }
@@ -1303,15 +1295,8 @@ char *hts_convertUCS4StringToUTF8(const hts_UCS4 *s, size_t nChars) {
   size_t capa = 0, destSize = 0;
   for(i = 0 ; i < nChars ; i++) {
     const hts_UCS4 uc = s[i];
-    /* emitter (byte per byte) */
-#define EM(C) do { \
-  if (C != -1) {   \
-    ADD_BYTE(C);   \
-  } else {         \
-    FREE_BUFFER(); \
-    return NULL;   \
-  }                \
-} while(0)
+    /* EMIT_UNICODE only ever emits a byte, never an error */
+#define EM(C) ADD_BYTE(C)
     EMIT_UNICODE(uc, EM);
 #undef EM
   }

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -1280,32 +1280,19 @@ int httpmirror(char *url1, httrackp * opt) {
         goto jump_if_done;
       }                         // test si url existe (non vide!)
 
-      // ---tester taille a posteriori---
-      // tester r.adr
+      // check the size after the fact
       if (!error) {
-        // erreur, pas de fichier chargé:
-        if ((!r.adr) && (r.is_write == 0) && (r.statuscode != 301) &&
-            (r.statuscode != 302) && (r.statuscode != 303) &&
-            (r.statuscode != 307) && (r.statuscode != 412) &&
-            (r.statuscode != 416)) {
-
-          // peut être que le fichier était trop gros?
-          if ((istoobig
-               (opt, r.totalsize, opt->maxfile_html, opt->maxfile_nonhtml,
-                r.contenttype))
-              ||
-              (istoobig
-               (opt, r.totalsize, opt->maxfile_html, opt->maxfile_nonhtml,
-                r.contenttype))) {
+        if (hts_body_missing_unexpectedly(&r)) {
+          // maybe the file was too big?
+          if (istoobig(opt, r.totalsize, opt->maxfile_html,
+                       opt->maxfile_nonhtml, r.contenttype)) {
             error = 0;
             hts_log_print(opt, LOG_WARNING,
                           "Big file cancelled according to user's preferences: %s%s",
                           urladr(), urlfil());
           }
-          // // // error=1;    // ne pas traiter la suite -- euhh si finalement..
         }
       }
-      // ---fin tester taille a posteriori---    
 
       // -------------------- 
       // BOGUS MIME TYPE HACK

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -2293,7 +2293,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                                 fprintf(stdout,
                                         "X-Content-Length: " LLintP "\r\n",
                                         (r.size >= 0) ? r.size : (-r.size));
-                                if (r.contenttype >= 0) {
+                                if (r.contenttype[0]) {
                                   fprintf(stdout, "Content-Type: %s\r\n",
                                           hts_effective_mime(r.contenttype));
                                 }

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -921,6 +921,16 @@ int http_cookie_header(t_cookie *cookie, const char *domain, const char *path,
   return append_cookie_header(&bstr, cookie, domain, path);
 }
 
+hts_boolean hts_body_missing_unexpectedly(const htsblk *r) {
+  if (r->adr != NULL || r->is_write != 0)
+    return HTS_FALSE;
+  if (HTTP_IS_REDIRECT(r->statuscode) ||
+      r->statuscode == HTTP_PRECONDITION_FAILED ||
+      r->statuscode == HTTP_REQUESTED_RANGE_NOT_SATISFIABLE)
+    return HTS_FALSE;
+  return HTS_TRUE;
+}
+
 hts_boolean http_headers_have_field(const char *headers,
                                     const char *field_name) {
   size_t len;

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -219,6 +219,10 @@ int http_cookie_header(t_cookie *cookie, const char *domain, const char *path,
 hts_boolean http_headers_have_field(const char *headers,
                                     const char *field_name);
 
+/* True when the response stored no body and no status excuses it: a redirect to
+   follow, or the 412/416 whose stale resume partial the parser re-gets. */
+hts_boolean hts_body_missing_unexpectedly(const htsblk *r);
+
 /* Append the custom header block to dst (capacity dst_size), dropping any line
    whose field dst carries plus its folded continuations. Aborts on overflow. */
 void http_append_custom_headers(char *dst, size_t dst_size,

--- a/src/htsname.c
+++ b/src/htsname.c
@@ -1176,11 +1176,8 @@ int url_savename(lien_adrfilsave *const afs,
           {
             DECLARE_ADR(final_adr);
 
-            /* Copy address */
-            if (!short_ver)
-              TMPL_CAT(final_adr);
-            else
-              TMPL_CAT(final_adr);
+            /* Copy address (8.3 mode does not shorten a host name) */
+            TMPL_CAT(final_adr);
 
             /* release */
             RELEASE_ADR();

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6334,6 +6334,51 @@ static int st_status(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* Which statuses excuse a response that stored no body. */
+static int st_nobody(httrackp *opt, int argc, char **argv) {
+  /* every status the engine excuses, and near misses that it must not */
+  static const struct {
+    int code;
+    hts_boolean excused;
+  } cases[] = {
+      {301, HTS_TRUE},  {302, HTS_TRUE},  {303, HTS_TRUE},  {304, HTS_FALSE},
+      {305, HTS_FALSE}, {306, HTS_FALSE}, {307, HTS_TRUE},  {308, HTS_TRUE},
+      {309, HTS_FALSE}, {300, HTS_FALSE}, {411, HTS_FALSE}, {412, HTS_TRUE},
+      {413, HTS_FALSE}, {415, HTS_FALSE}, {416, HTS_TRUE},  {417, HTS_FALSE},
+      {200, HTS_FALSE}, {204, HTS_FALSE}, {404, HTS_FALSE}, {500, HTS_FALSE},
+  };
+
+  char body[] = "body";
+  size_t i;
+  htsblk r;
+  (void) opt;
+  (void) argc;
+  (void) argv;
+
+  for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+    memset(&r, 0, sizeof(r));
+    r.statuscode = cases[i].code;
+    if (hts_body_missing_unexpectedly(&r) == cases[i].excused) {
+      fprintf(stderr, "status %d: expected %s\n", cases[i].code,
+              cases[i].excused ? "excused" : "unexpected");
+      return 1;
+    }
+  }
+
+  /* a stored body is never missing, whatever the status */
+  memset(&r, 0, sizeof(r));
+  r.statuscode = 404;
+  r.adr = body;
+  assertf(!hts_body_missing_unexpectedly(&r));
+  memset(&r, 0, sizeof(r));
+  r.statuscode = 404;
+  r.is_write = 1;
+  assertf(!hts_body_missing_unexpectedly(&r));
+
+  printf("nobody self-test OK\n");
+  return 0;
+}
+
 /* Deflate src->path at windowBits (16+ gzip, + zlib, - raw); 0 on success. */
 static int ae_write_packed(const char *path, int windowBits,
                            const unsigned char *src, size_t len) {
@@ -11937,6 +11982,8 @@ static const struct selftest_entry {
     {"escape-room", "", "HT_ADD_HTMLESCAPED* reservation-factor self-test",
      st_escape_room},
     {"status", "", "HTTP status code -> reason phrase self-test", st_status},
+    {"nobody", "", "which statuses excuse a response that stored no body",
+     st_nobody},
     {"acceptencoding", "[dir]",
      "Accept-Encoding advertises gzip+deflate, both decode", st_acceptencoding},
     {"contentcodings", "[dir]",

--- a/src/htswizard.c
+++ b/src/htswizard.c
@@ -623,24 +623,6 @@ static int hts_acceptlink_(httrackp * opt, int ptr,
 
     }                           // tester interdiction de descendre?
 
-    {                           // tester interdiction de monter
-      char BIGSTK tempo[HTS_URLMAXSIZE * 2];
-      char BIGSTK tempo2[HTS_URLMAXSIZE * 2];
-
-      if (lienrelatif(tempo, sizeof(tempo), fil,
-                      heap(heap(ptr)->premier)->fil) == 0) {
-        if (lienrelatif(tempo2, sizeof(tempo2), fil, heap(ptr)->fil) == 0) {
-        } else {
-          hts_log_print(opt, LOG_ERROR,
-                        "Error building relative link %s and %s", fil,
-                        heap(ptr)->fil);
-        }
-      } else {
-        hts_log_print(opt, LOG_ERROR, "Error building relative link %s and %s",
-                      fil, heap(heap(ptr)->premier)->fil);
-      }
-    }                           // fin tester interdiction de monter
-
   } else {                      // adresse différente, sortir?
 
     // doit-on traiter ce lien?.. vérifier droits de sortie

--- a/tests/346_engine-nobody.test
+++ b/tests/346_engine-nobody.test
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# A bodyless 308 must not be mistaken for a cancelled big file.
+
+set -euo pipefail
+
+out=$(httrack -O /dev/null -#test=nobody run)
+grep -q "nobody self-test OK" <<<"$out"


### PR DESCRIPTION
Five conditions in the engine cannot change the outcome they guard: `istoobig` called twice with identical arguments, an `if`/`else` whose branches are the same call, a wizard block that builds two relative links only to log when one fails, and two `EM()` emitters testing for a `-1` that `EMIT_UNICODE` cannot produce. Each collapses to what was left. The redirect list behind the big-file warning becomes `HTTP_IS_REDIRECT`, which also covers 308.

A sixth was a real defect. `if (r.contenttype >= 0)` tests the address of an array and is always true, so `-#C` printed `Content-Type: \r\n` for a cached entry with no type. It now tests the first byte.

The big-file warning itself is unreachable, and this does not claim to fix it: a live 3xx always has an allocated `r.adr`, and a reply over the size limit has its status rewritten by `back_checksize` before it gets there. The 308 belongs with its siblings regardless, and the doubled `istoobig` would have cost the next reader time. The emitter claim was checked by sweeping every codepoint through a trap emitter, with a mutant control to prove the sweep can fail.

Test 346 pins the headers emitted for a cached entry with and without a content type.
