### PR TITLE
A bracketed IPv6 authority loses its port

### DIFF
--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -184,6 +184,41 @@ void launch_ftp(FTPDownloadStruct * params) {
   return 0; \
   }
 
+/* Start of the authority in a URL address (see htsftp.h). */
+char *ftp_jump_authority(char *url_adr) {
+  char *a = jump_protocol(url_adr);
+
+  while (*a == '/')
+    a++;
+  return a;
+}
+
+/* Split "host[:port]" (see htsftp.h). */
+hts_boolean ftp_split_hostport(const char *adr, char *host, size_t host_size,
+                               int *port, char *err, size_t err_size) {
+  static const char portmsg[] = "Invalid port: ";
+  const char *const a = jump_toport_const(adr);
+  const size_t len = a != NULL ? (size_t) (a - adr) : strlen(adr);
+
+  /* the caller owns err[], so a size too small for either message is a bug */
+  assertf(host_size > 0 && err_size > sizeof("Host name too long"));
+  host[0] = err[0] = '\0';
+  /* no resolvable name is this long, and clipping would query another host */
+  if (len >= host_size) {
+    strlcpybuff(err, "Host name too long", err_size);
+    return HTS_FALSE;
+  }
+  /* folding a nonsense port into 1..65535 fetches one the link never named */
+  if (a != NULL && a[1] != '\0' && !hts_parse_url_port(a + 1, port)) {
+    strlcpybuff(err, portmsg, err_size);
+    /* wire data: clip the echoed port rather than abort on an over-long one */
+    strlncatbuff(err, a + 1, err_size, err_size - sizeof(portmsg));
+    return HTS_FALSE;
+  }
+  strlncatbuff(host, adr, host_size, len);
+  return HTS_TRUE;
+}
+
 /* Split a hostile-URL "user[:pass]@" prefix (see htsftp.h). */
 hts_boolean ftp_split_userpass(const char *src, const char *end, char *user,
                                size_t user_size, char *pass, size_t pass_size) {
@@ -403,14 +438,7 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
   back->r.size = 0;
   back->r.lastmodified[0] = '\0'; // a retry must not stamp the previous MDTM
 
-  // récupérer user et pass si présents, et sauter user:id@ dans adr
-  real_adr = strchr(back->url_adr, ':');
-  if (real_adr)
-    real_adr++;
-  else
-    real_adr = back->url_adr;
-  while(*real_adr == '/')
-    real_adr++;                 // sauter /
+  real_adr = ftp_jump_authority(back->url_adr);
   if ((adr = jump_identification(real_adr)) != real_adr) {      // user
     if (!ftp_split_userpass_buf(real_adr, adr, user, pass)) {
       strcpybuff(back->r.msg, "FTP user name or password too long");
@@ -467,36 +495,17 @@ int run_launch_ftp(FTPDownloadStruct * pStruct) {
   // connexion
   {
     SOCaddr server;
-    char *a;
     char _adr[256];
-    size_t adr_len;
+    char err[128];
     const char *error = "unknown error";
 
-    _adr[0] = '\0';
-    //T_SOC soc_ctl;
-    // effacer structure
     memset(&server, 0, sizeof(server));
 
-    // port
-    a = strchr(adr, ':');       // port
-    if (a) {
-      // folding a nonsense port into 1..65535 fetches one the link never named;
-      // an empty "host:" just means the default (#614)
-      if (a[1] != '\0' && !hts_parse_url_port(a + 1, &port)) {
-        htsblk_failf(&back->r, "Invalid port: %s", a + 1);
-        back->r.statuscode = STATUSCODE_INVALID; // permanent, unlike a DNS miss
-        _HALT_FTP return 0;
-      }
-      adr_len = (size_t) (a - adr);
-    } else
-      adr_len = strlen(adr);
-    // no resolvable name is this long, and clipping would query another host
-    if (adr_len >= sizeof(_adr)) {
-      htsblk_failf(&back->r, "Host name too long");
-      back->r.statuscode = STATUSCODE_INVALID;
+    if (!ftp_split_hostport(adr, _adr, sizeof(_adr), &port, err, sizeof(err))) {
+      htsblk_failf(&back->r, "%s", err);
+      back->r.statuscode = STATUSCODE_INVALID; // permanent, unlike a DNS miss
       _HALT_FTP return 0;
     }
-    strncatbuff(_adr, adr, (int) adr_len);
 
     // récupérer adresse résolue
     strcpybuff(back->info, "host name");

--- a/src/htsftp.h
+++ b/src/htsftp.h
@@ -80,6 +80,15 @@ int send_line(T_SOC soc, const char *data);
    Optional back ends the wait on a stop, opt clips it to --max-time. */
 int get_ftp_line(lien_back *back, T_SOC soc, char *line, size_t line_size,
                  int timeout, const httrackp *opt);
+/* Start of the authority in a URL address: the scheme and its slashes skipped.
+   Bracket-aware, unlike a hand-rolled split on the first ':'. */
+char *ftp_jump_authority(char *url_adr);
+/* Split "host[:port]" (host may be a "[IPv6]" literal) into host[host_size] and
+   *port. Returns HTS_FALSE with host emptied and the reason in err[err_size]
+   when the host does not fit or the port is malformed; an empty ":" keeps the
+   caller's default port (#614). */
+hts_boolean ftp_split_hostport(const char *adr, char *host, size_t host_size,
+                               int *port, char *err, size_t err_size);
 /* Split a "user[:pass]@" prefix (end = jump_identification result) into
    NUL-terminated user/pass buffers. Returns HTS_FALSE and empties both when a
    field does not fit, as a clipped one would name another account.

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -4203,7 +4203,9 @@ HTSEXT_API const char *jump_toport_const(const char *source) {
   const char *a, *trytofind;
 
   a = jump_identification_const(source);
-  trytofind = strrchr_limit(a, ']', strchr(source, '/'));       // find last ] (http://[3ffe:b80:1234::1]:80/foo.html)
+  // last ] of the authority (http://[3ffe:b80:1234::1]:80/foo.html), bounded
+  // from a: source's own scheme "//" would end the scan before it
+  trytofind = strrchr_limit(a, ']', strchr(a, '/'));
   a = strchr((trytofind) ? trytofind : a, ':');
   return a;
 }

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2219,6 +2219,48 @@ static int st_resolve(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* Print the ":port" jump_toport_const() finds in a URL, or "(none)". */
+static int st_toport(httrackp *opt, int argc, char **argv) {
+  int i;
+
+  (void) opt;
+  if (argc < 1) {
+    fprintf(stderr, "toport: needs a URL\n");
+    return 1;
+  }
+  for (i = 0; i < argc; i++) {
+    const char *const port = jump_toport_const(argv[i]);
+
+    printf("%s\n", port != NULL ? port : "(none)");
+  }
+  return 0;
+}
+
+/* Print the host/port the FTP path splits out of a URL address. */
+static int st_ftpaddr(httrackp *opt, int argc, char **argv) {
+  int i;
+
+  (void) opt;
+  if (argc < 1) {
+    fprintf(stderr, "ftpaddr: needs a URL address\n");
+    return 1;
+  }
+  for (i = 0; i < argc; i++) {
+    char BIGSTK url[HTS_URLMAXSIZE * 2];
+    char host[256];
+    char err[128];
+    int port = 21;
+
+    strcpybuff(url, argv[i]);
+    if (ftp_split_hostport(jump_identification(ftp_jump_authority(url)), host,
+                           sizeof(host), &port, err, sizeof(err)))
+      printf("host=%s port=%d\n", host, port);
+    else
+      printf("error=%s\n", err);
+  }
+  return 0;
+}
+
 /* Split a URL into (adr, fil), or print "error" if rejected. A second arg pads
    the URL with that many 'a's to reach lengths a CLI arg can't. */
 static int st_identurl(httrackp *opt, int argc, char **argv) {
@@ -11838,6 +11880,10 @@ static const struct selftest_entry {
     {"resolve", "<link> <adr> <fil>", "resolve a link against an origin",
      st_resolve},
     {"identurl", "<url>", "split an absolute URL into (adr, fil)", st_identurl},
+    {"toport", "<url>...", "port separator found in a URL authority",
+     st_toport},
+    {"ftpaddr", "<url-address>...", "host/port the FTP path splits out",
+     st_ftpaddr},
     {"proxyurl", "<proxy-arg>", "parse a -P proxy URL into host/port",
      st_proxyurl},
     {"socks5", "", "SOCKS5 handshake framing and credential self-test",

--- a/tests/343_engine-ipv6-authority.test
+++ b/tests/343_engine-ipv6-authority.test
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+# A bracketed IPv6 authority carries colons of its own, so the port separator is
+# the first ':' after the ']'. -#test=toport prints what jump_toport_const()
+# finds in a URL; -#test=ftpaddr prints the host/port the FTP path splits out of
+# a URL address.
+
+toport() { selftest_queue "$2" toport "$1"; }
+
+# a scheme-carrying URL is the case that regressed: CONNECT lost its port
+toport 'https://[::1]' '(none)'
+toport 'https://[::1]:8080' ':8080'
+toport 'https://[::1]/x' '(none)'
+toport 'https://[::1]:8080/x' ':8080/x'
+toport 'https://user@[::1]:8080/x' ':8080/x'
+toport 'http://127.0.0.1:81/x' ':81/x'
+toport 'http://127.0.0.1/x' '(none)'
+toport '[::1]:8080' ':8080'
+# no ']' to end the literal: the first ':' stands, and the port parse rejects it
+toport 'https://[::1:8080' '::1:8080'
+
+ftpaddr() { selftest_queue "$2" ftpaddr "$1"; }
+
+ftpaddr 'ftp://[::1]:2121' 'host=[::1] port=2121'
+ftpaddr 'ftp://[::1]' 'host=[::1] port=21'
+ftpaddr 'ftp://user:pass@[::1]:2121' 'host=[::1] port=2121'
+ftpaddr 'ftp://ftp.example.com:2121' 'host=ftp.example.com port=2121'
+ftpaddr 'ftp://ftp.example.com' 'host=ftp.example.com port=21'
+ftpaddr '[::1]:2121' 'host=[::1] port=2121'
+ftpaddr 'ftp://[::1:2121' 'error=Invalid port: :1:2121'
+ftpaddr 'ftp://[::1]:99999' 'error=Invalid port: 99999'
+# a host that cannot fit is refused, never clipped onto another one
+ftpaddr "ftp://$(printf 'a%.0s' $(seq 1 256))" 'error=Host name too long'
+# the echoed port comes off the wire: clipped into the 128-byte message buffer,
+# never aborted on
+ftpaddr "ftp://[::1]:$(printf '9%.0s' $(seq 1 200))" \
+    "error=Invalid port: $(printf '9%.0s' $(seq 1 113))"
+
+selftest_run_queued


### PR DESCRIPTION
`jump_toport_const()` bounded its search for the authority's closing `]` with a limit taken from `source` rather than from the pointer past the scheme, so on any URL still carrying `http://` the scheme's own `//` ended the scan before the bracket was reached. What came back was a colon from inside the IPv6 literal. Through a CONNECT proxy that is visible on the wire: htsproxy reads a non-NULL result as "the host already carries its port", so httrack sends `CONNECT [::1]` with no port at all.

The FTP path split the authority by hand on the first `:`, which lands inside the literal for the same reason, and refused every `ftp://[...]` URL with `Invalid port: :1]:2121` before it ever tried to connect. That walk now lives in `ftp_jump_authority()` and `ftp_split_hostport()`, built on `jump_protocol()` and `jump_toport_const()`. The port echoed back in the error message comes off the link, so it is clipped into the message buffer instead of aborting on an over-long one.

Checked against a fake CONNECT proxy, which now receives `CONNECT [::1]:443`, and a fake FTP server bound to `[::1]`, which now completes a listing. The new `-#test=toport` and `-#test=ftpaddr` self-tests are driven by `tests/343_engine-ipv6-authority.test`; reverting either fix reds it. It also covers the schemeless case, which is what the hand-rolled scheme split got wrong — that half has no live symptom today, since `ident_url_absolute()` always prefixes `ftp://`.
