### PR TITLE
59 hand-rolled log dumps, and the six fail() overrides that could not go without one

### DIFF
--- a/tests/01_engine-filelist.test
+++ b/tests/01_engine-filelist.test
@@ -24,11 +24,8 @@ run() {
     LOG="$out/hts-log.txt"
 }
 
-fail() {
-    echo "FAIL: $1"
-    cat "$LOG"
-    exit 1
-}
+# Every assertion below is about the crawl log, testlib's own included.
+fail_dump_var LOG
 loghas() {
     grep -Eq "$1" "$LOG" || fail "expected /$1/ in $LOG"
 }

--- a/tests/01_engine-growsize.test
+++ b/tests/01_engine-growsize.test
@@ -20,8 +20,5 @@ printf -- '-*/zzmarker*\n' >"$tmp/rules.txt"
 # the rules file lands in the URL/filter string, echoed back by the banner
 run=$(httrack -O "$tmp/out" --quiet -n "-%S" "$tmp/rules.txt" \
     "file://$tmp/index.html" 2>&1) || true
-grep -q 'zzmarker' <<<"$run" || {
-    echo "FAIL: -%S rules file was not loaded"
-    printf '%s\n' "$run"
-    exit 1
-}
+grep -q 'zzmarker' <<<"$run" ||
+    fail "-%S rules file was not loaded: $run"

--- a/tests/102_local-ftp-refetch.test
+++ b/tests/102_local-ftp-refetch.test
@@ -47,11 +47,7 @@ done
 common=(--quiet --disable-security-limits --robots=0 --timeout=20 --max-time=120
     --retries=1 -c1 --changes)
 
-fail() {
-    echo "FAIL: $*" >&2
-    test ! -f "$report" || cat "$report" >&2
-    exit 1
-}
+fail_dump_var report
 # Files listed under a report bucket, one "file:size" per line.
 listed() {
     "$python" - "$report" "$1" <<'EOF' | tr -d '\r'

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -14,11 +14,7 @@ set -eu
 driver="${testdir}/test-timeout.sh"
 test -r "$driver" || fail "no test-timeout.sh next to $0"
 
-fail() {
-    echo "FAIL: $*" >&2
-    test -z "${out:-}" || sed 's/^/  | /' <"$out" >&2
-    exit 1
-}
+fail_dump_var out
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_sutmo.XXXXXX") || exit 1
 # A colon-free root for the PATH shim below: MSYS hands out a drive-letter TMPDIR

--- a/tests/113_engine-threadattr-leak.test
+++ b/tests/113_engine-threadattr-leak.test
@@ -41,20 +41,14 @@ log="$dir/counts"
 THREADATTRFAIL=1 THREADATTRFAIL_LOG="$log" LD_PRELOAD="$THREADATTRFAIL_LIB" \
     httrack -O "$dir/o" -#test=threadwait >"$dir/out" 2>&1 || true
 
-test -r "$log" || {
-    echo "threadattr: the interposer wrote no counts" >&2
-    cat "$dir/out" >&2
-    exit 1
-}
+test -r "$log" ||
+    fail_dump "threadattr: the interposer wrote no counts" "$dir/out"
 sabotaged=$(sed -n 's/^sabotaged //p' "$log")
 undestroyed=$(sed -n 's/^undestroyed //p' "$log")
 
 # Teeth: with no refused create there is nothing to leak, and the check below
 # would pass on any build.
-test "${sabotaged:-0}" -ge 1 || {
-    echo "threadattr: no pthread_create() was refused, nothing was tested" >&2
-    cat "$dir/out" >&2
-    exit 1
-}
+test "${sabotaged:-0}" -ge 1 ||
+    fail_dump "threadattr: no pthread_create() was refused, nothing was tested" "$dir/out"
 test "${undestroyed:-1}" -eq 0 || fail "threadattr: $undestroyed of $sabotaged attributes objects survived a refused pthread_create()"
 echo "OK: a refused pthread_create() destroys the attributes object ($sabotaged refused)"

--- a/tests/120_local-proxytrack-webdav-default.test
+++ b/tests/120_local-proxytrack-webdav-default.test
@@ -68,72 +68,42 @@ propfind() {
         "http://127.0.0.1:$proxyport/webdav/example.com/$path"
 }
 
-resp=$(propfind page.html) || {
-    echo "FAIL: PROPFIND on an exact cache entry did not answer"
-    cat "$ptlog"
-    exit 1
-}
-grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
-    echo "FAIL: expected 207 Multi-Status"
-    printf '%s\n' "$resp"
-    exit 1
-}
-grep -q '<displayname>Default Document for the Folder</displayname>' <<<"$resp" || {
-    echo "FAIL: the default document of the entry was not listed"
-    printf '%s\n' "$resp"
-    exit 1
-}
+resp=$(propfind page.html) ||
+    fail_dump "PROPFIND on an exact cache entry did not answer" "$ptlog"
+grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" ||
+    fail "expected 207 Multi-Status: $resp"
+grep -q '<displayname>Default Document for the Folder</displayname>' <<<"$resp" ||
+    fail "the default document of the entry was not listed: $resp"
 # The name alone would still pass on a truncated or garbage URL, so pin the
 # href: the default document is the collection path plus an empty name.
-grep -q '<href>/webdav/example\.com/page\.html/</href>' <<<"$resp" || {
-    echo "FAIL: the default document was listed under the wrong href"
-    printf '%s\n' "$resp"
-    exit 1
-}
+grep -q '<href>/webdav/example\.com/page\.html/</href>' <<<"$resp" ||
+    fail "the default document was listed under the wrong href: $resp"
 responses=$(count_matching_lines '<response ' <<<"$resp")
-test "$responses" -eq 2 || {
-    echo "FAIL: expected the root and its default document, got $responses responses"
-    printf '%s\n' "$resp"
-    exit 1
-}
+test "$responses" -eq 2 ||
+    fail "expected the root and its default document, got $responses responses: $resp"
 
 # The crash killed the process, so a second request is the liveness proof.
-resp=$(propfind "") || {
-    echo "FAIL: proxytrack died serving the previous PROPFIND"
-    cat "$ptlog"
-    exit 1
-}
-grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
-    echo "FAIL: expected 207 Multi-Status on the follow-up listing"
-    printf '%s\n' "$resp"
-    exit 1
-}
+resp=$(propfind "") ||
+    fail_dump "proxytrack died serving the previous PROPFIND" "$ptlog"
+grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" ||
+    fail "expected 207 Multi-Status on the follow-up listing: $resp"
 
 # Leftover traces echoed the client's body and the generated response (#911).
 # The padding spills the canary past any stdio buffer, newline or not.
 sentinel=PT911-DAV-BODY-CANARY
 pad=$(printf '%8192s' '')
-resp=$(propfind "" -H 'Expect:' --data-binary "$sentinel${pad// /x}") || {
-    echo "FAIL: proxytrack died serving a PROPFIND carrying a body"
-    cat "$ptlog"
-    exit 1
-}
-grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
-    echo "FAIL: expected 207 Multi-Status on the canary listing"
-    printf '%s\n' "$resp"
-    exit 1
-}
+resp=$(propfind "" -H 'Expect:' --data-binary "$sentinel${pad// /x}") ||
+    fail_dump "proxytrack died serving a PROPFIND carrying a body" "$ptlog"
+grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" ||
+    fail "expected 207 Multi-Status on the canary listing: $resp"
 
 # The 207 is what makes the absence below mean something: a depth-rejected
 # PROPFIND is logged 403 without ever reaching the traces. It is logged after
 # them, so waiting on it also fences the drainer's copy.
 waited=0
 until test "$(count_matching_lines_nocase ' \* log: HTTP [^ ]* 207 [0-9]* propfind ' "$ptlog")" -ge 3; do
-    test "$waited" -lt 50 || {
-        echo "FAIL: fewer than three PROPFINDs were answered 207, so the checks below prove nothing"
-        cat "$ptlog"
-        exit 1
-    }
+    test "$waited" -lt 50 ||
+        fail_dump "fewer than three PROPFINDs were answered 207, so the checks below prove nothing" "$ptlog"
     sleep 0.1
     waited=$((waited + 1))
 done

--- a/tests/138_local-spool-name-overflow.test
+++ b/tests/138_local-spool-name-overflow.test
@@ -21,11 +21,8 @@ require_httrack
 
 rc=0
 local_crawl --log "${tmpdir}/log" -O "${tmpdir}/out" --quiet --disable-security-limits --robots=0 --timeout=30 --retries=0 -Z -p0 -N '%n' -c4 "http://127.0.0.1:${SRV_PORT}/bakname/index.html" || rc=$?
-test "$rc" -eq 0 || {
-    echo "httrack exited $rc"
-    cat "${tmpdir}/log"
-    exit 1
-}
+test "$rc" -eq 0 ||
+    fail_dump "httrack exited $rc" "${tmpdir}/log"
 
 enginelog="${tmpdir}/out/hts-log.txt"
 test -r "$enginelog" || fail "no engine log at $enginelog"

--- a/tests/13_crawl_proxy_https.test
+++ b/tests/13_crawl_proxy_https.test
@@ -50,11 +50,8 @@ start_server() {
         grep -q "^ready" "$ports" 2>/dev/null && break
         sleep 0.1
     done
-    grep -q "^ready" "$ports" 2>/dev/null || {
-        echo "server ($mode) did not start" >&2
-        cat "$dir/server.err" >&2
-        exit 1
-    }
+    grep -q "^ready" "$ports" 2>/dev/null ||
+        fail_dump "server ($mode) did not start" "$dir/server.err"
     origin_port=$(awk '/^ORIGIN/{print $2}' "$ports")
     proxy_port=$(awk '/^PROXY/{print $2}' "$ports")
 }
@@ -84,16 +81,10 @@ start_server "$ok" ok
 
 # 1. page retrieved AND the proxy saw a CONNECT to the origin
 run_crawl "$ok/out" "127.0.0.1:${proxy_port}" "$origin_port"
-grep -rq "ORIGIN-PAGE-85" "$ok/out" || {
-    echo "FAIL: origin page not downloaded through proxy" >&2
-    cat "$ok/out.log" >&2
-    exit 1
-}
-grep -q "^CONNECT 127.0.0.1:${origin_port} " "$ok/proxy.log" || {
-    echo "FAIL: proxy never received a CONNECT (https bypassed the proxy)" >&2
-    cat "$ok/proxy.log" >&2
-    exit 1
-}
+grep -rq "ORIGIN-PAGE-85" "$ok/out" ||
+    fail_dump "origin page not downloaded through proxy" "$ok/out.log"
+grep -q "^CONNECT 127.0.0.1:${origin_port} " "$ok/proxy.log" ||
+    fail_dump "proxy never received a CONNECT (https bypassed the proxy)" "$ok/proxy.log"
 echo "OK: https tunneled through proxy via CONNECT"
 
 # 2. authenticated proxy: creds ride the CONNECT, and NEVER reach the origin
@@ -104,11 +95,8 @@ grep -rq "ORIGIN-PAGE-85" "$ok/out2" || fail "origin page not downloaded through
 got=$(awk '/^AUTH Basic /{print $3}' "$ok/proxy.log" | head -1)
 # base64("user:secret"); compared as a literal to stay portable (no base64 -d,
 # which differs between GNU and BSD)
-test "$got" == "dXNlcjpzZWNyZXQ=" || {
-    echo "FAIL: Proxy-Authorization not carried on CONNECT (got '$got')" >&2
-    cat "$ok/proxy.log" >&2
-    exit 1
-}
+test "$got" == "dXNlcjpzZWNyZXQ=" ||
+    fail_dump "Proxy-Authorization not carried on CONNECT (got '$got')" "$ok/proxy.log"
 if grep -qi "proxy-authorization" "$ok/origin-headers.log"; then
     echo "FAIL: proxy credentials leaked to the origin through the tunnel" >&2
     cat "$ok/origin-headers.log" >&2

--- a/tests/141_webhttrack-warc-options.test
+++ b/tests/141_webhttrack-warc-options.test
@@ -20,11 +20,7 @@ done
 echo OK
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_warc.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 printf '[webhttrack emits the WARC options] ..\t'
 htsserver_start --home "${work}"

--- a/tests/142_webhttrack-content-type.test
+++ b/tests/142_webhttrack-content-type.test
@@ -21,11 +21,7 @@ for asset in server/ping.js server/style.css images/screenshot_01.jpg \
 done
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_ctype.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 # A mirror to serve through /website/, holding the awkward names: the crawl
 # itself is not under test.

--- a/tests/147_local-proxytrack-webdav-overflow.test
+++ b/tests/147_local-proxytrack-webdav-overflow.test
@@ -47,11 +47,8 @@ propfind() {
 # Amplification, not raw length, clears the old 1024-byte reserve: 900 '&'
 # become 4500 bytes, written twice, all under the 1024-byte request-line cap.
 amps=$("$python" -c "print('&' * 900)" | tr -d '\r')
-resp=$(propfind "$amps") || {
-    echo "FAIL: proxytrack died on an escapexml-amplified PROPFIND"
-    cat "$ptlog"
-    exit 1
-}
+resp=$(propfind "$amps") ||
+    fail_dump "proxytrack died on an escapexml-amplified PROPFIND" "$ptlog"
 grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
     echo "FAIL: expected 207 Multi-Status for the amplified path"
     head -c 512 <<<"$resp"
@@ -64,11 +61,8 @@ test "$got" -eq 1800 || fail "900 ampersands went in, $got came back escaped, wa
 
 # Unescaped, so the bound is shown to be on the written length, not on '&'.
 plain=$("$python" -c "print('a' * 900)" | tr -d '\r')
-resp=$(propfind "$plain") || {
-    echo "FAIL: proxytrack died on a 900-byte plain PROPFIND path"
-    cat "$ptlog"
-    exit 1
-}
+resp=$(propfind "$plain") ||
+    fail_dump "proxytrack died on a 900-byte plain PROPFIND path" "$ptlog"
 grep -q "<href>/webdav/x/$plain</href>" <<<"$resp" || fail "a 900-byte path did not come back whole"
 
 # Depth: 1 is the only route into the enumeration branch, which builds each
@@ -76,43 +70,25 @@ grep -q "<href>/webdav/x/$plain</href>" <<<"$resp" || fail "a 900-byte path did 
 # with a trailing '/' that has to come back off, or its name is lost and the
 # entry lists as the folder's default document.
 resp=$(curl -s -i --max-time 30 -X PROPFIND -H "Depth: 1" \
-    "http://127.0.0.1:$proxyport/webdav/example.com/") || {
-    echo "FAIL: proxytrack died on a Depth: 1 listing"
-    cat "$ptlog"
-    exit 1
-}
-grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
-    echo "FAIL: expected 207 Multi-Status for the Depth: 1 listing"
-    printf '%s\n' "$resp"
-    exit 1
-}
+    "http://127.0.0.1:$proxyport/webdav/example.com/") ||
+    fail_dump "proxytrack died on a Depth: 1 listing" "$ptlog"
+grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" ||
+    fail "expected 207 Multi-Status for the Depth: 1 listing: $resp"
 for want in '<href>/webdav/example\.com</href>' \
     '<href>/webdav/example\.com/page\.html</href>' \
     '<href>/webdav/example\.com/sub</href>' \
     '<displayname>sub</displayname>'; do
-    grep -q "$want" <<<"$resp" || {
-        echo "FAIL: the Depth: 1 listing is missing $want"
-        printf '%s\n' "$resp"
-        exit 1
-    }
+    grep -q "$want" <<<"$resp" ||
+        fail "the Depth: 1 listing is missing $want: $resp"
 done
 responses=$(count_matching_lines '<response ' <<<"$resp")
-test "$responses" -eq 3 || {
-    echo "FAIL: expected the root, the file and the directory, got $responses responses"
-    printf '%s\n' "$resp"
-    exit 1
-}
+test "$responses" -eq 3 ||
+    fail "expected the root, the file and the directory, got $responses responses: $resp"
 
 # The overflow killed the listener, so a later request is the liveness proof.
-resp=$(propfind "") || {
-    echo "FAIL: proxytrack died before the follow-up listing"
-    cat "$ptlog"
-    exit 1
-}
-grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
-    echo "FAIL: expected 207 Multi-Status on the follow-up listing"
-    printf '%s\n' "$resp"
-    exit 1
-}
+resp=$(propfind "") ||
+    fail_dump "proxytrack died before the follow-up listing" "$ptlog"
+grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" ||
+    fail "expected 207 Multi-Status on the follow-up listing: $resp"
 
 echo "OK: an escapexml-amplified PROPFIND path is served whole and does not overflow"

--- a/tests/153_local-proxytrack-quiet.test
+++ b/tests/153_local-proxytrack-quiet.test
@@ -104,35 +104,23 @@ quietlog=$ptlog quietport=$proxyport quietpid=$ptpid ptpid=
 # second request is not read until the first one's teardown has run.
 resp=$(curl -s -i --max-time 30 -X PROPFIND -H "Depth: 1" \
     "http://127.0.0.1:$quietport/webdav/example.com/" \
-    "http://127.0.0.1:$quietport/webdav/example.com/page.html") || {
-    echo "FAIL: the PROPFINDs did not answer"
-    cat "$quietlog"
-    exit 1
-}
+    "http://127.0.0.1:$quietport/webdav/example.com/page.html") ||
+    fail_dump "the PROPFINDs did not answer" "$quietlog"
 served=$(count_matching_lines '^HTTP/1\.[01] 207 ' <<<"$resp")
-test "$served" -eq 2 || {
-    echo "FAIL: expected two 207 Multi-Status replies, got $served"
-    printf '%s\n' "$resp"
-    exit 1
-}
+test "$served" -eq 2 ||
+    fail "expected two 207 Multi-Status replies, got $served: $resp"
 # The collection and its entry, then that entry and its default document. An
 # empty listing builds no table and would make the check below vacuous.
 listed=$(count_matching_lines '<response ' <<<"$resp")
-test "$listed" -eq 4 || {
-    echo "FAIL: the two listings enumerated $listed entries, wanted 4"
-    printf '%s\n' "$resp"
-    exit 1
-}
+test "$listed" -eq 4 ||
+    fail "the two listings enumerated $listed entries, wanted 4: $resp"
 
 # The enumeration is what builds the table, so the served 207s are what make
 # the check below mean anything.
 waited=0
 until test "$(request_log "$quietlog" | grep -ci ' \* log: HTTP [^ ]* 207 [0-9]* propfind ' || true)" -ge 2; do
-    test "$waited" -lt 50 || {
-        echo "FAIL: fewer than two PROPFINDs were answered 207, so the check below proves nothing"
-        cat "$quietlog"
-        exit 1
-    }
+    test "$waited" -lt 50 ||
+        fail_dump "fewer than two PROPFINDs were answered 207, so the check below proves nothing" "$quietlog"
     sleep 0.1
     waited=$((waited + 1))
 done
@@ -149,11 +137,8 @@ wait_drained "$quietlog"
 # what a line may be; naming strings that must be absent would pass any
 # reworded or differently shaped leak.
 extra=$(request_log "$quietlog" | grep -vE '^( \* log: (HTTP|ICP) .*)?$' || true)
-test -z "$extra" || {
-    echo "FAIL: serving a PROPFIND wrote this to proxytrack's console:"
-    printf '%s\n' "$extra"
-    exit 1
-}
+test -z "$extra" ||
+    fail "serving a PROPFIND wrote this to proxytrack's console:: $extra"
 
 # HTS_LOG brings the summary back, so the silence above is a routed handler and
 # not a deleted message, and the grep that asserted it does match when fed one.
@@ -165,32 +150,20 @@ launch_loud() {
 start_proxytrack "$dir/loud" launch_loud
 loudlog=$ptlog loudport=$proxyport loudpid=$ptpid ptpid=
 
-resp=$(propfind "$loudport" "") || {
-    echo "FAIL: PROPFIND under HTS_LOG did not answer"
-    cat "$loudlog"
-    exit 1
-}
-grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
-    echo "FAIL: expected 207 Multi-Status under HTS_LOG"
-    printf '%s\n' "$resp"
-    exit 1
-}
+resp=$(propfind "$loudport" "") ||
+    fail_dump "PROPFIND under HTS_LOG did not answer" "$loudlog"
+grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" ||
+    fail "expected 207 Multi-Status under HTS_LOG: $resp"
 waited=0
 until grep -qE 'hashtable .*summary:' "$loudlog"; do
-    test "$waited" -lt 50 || {
-        echo "FAIL: HTS_LOG=1 did not restore the hashtable summary"
-        cat "$loudlog"
-        exit 1
-    }
+    test "$waited" -lt 50 ||
+        fail_dump "HTS_LOG=1 did not restore the hashtable summary" "$loudlog"
     sleep 0.1
     waited=$((waited + 1))
 done
 # Pin the routed shape whole: a severity, then the message, and nothing in
 # between where the table address used to be.
-grep -qE '^ \* debug: hashtable "[^"]*" summary:' "$loudlog" || {
-    echo "FAIL: the summary under HTS_LOG did not come through proxytrack's log"
-    cat "$loudlog"
-    exit 1
-}
+grep -qE '^ \* debug: hashtable "[^"]*" summary:' "$loudlog" ||
+    fail_dump "the summary under HTS_LOG did not come through proxytrack's log" "$loudlog"
 
 echo "OK: PROPFIND leaves no hashtable statistics on the console, HTS_LOG restores them"

--- a/tests/157_crash-argv0-path.test
+++ b/tests/157_crash-argv0-path.test
@@ -13,11 +13,7 @@ libdir="${CONFIGURED_LIBDIR:?not run under make check}"
 
 out=
 
-fail() {
-    echo "FAIL: $*" >&2
-    test -z "${out}" || sed 's/^/  | /' <"${out}" >&2
-    exit 1
-}
+fail_dump_var out
 
 if is_windows; then
     skip "no backtrace() on Windows"

--- a/tests/159_local-header-injection.test
+++ b/tests/159_local-header-injection.test
@@ -45,10 +45,8 @@ crawl "http://127.0.0.1:$port/" -O "$tmpdir/m1" \
     -c1 --robots=0 --retries=0 --quiet -%v0
 stop_server "$serverpid"
 serverpid=
-"$python" "$checker" "$tmpdir/direct.wire" direct "$port" || {
-    cat "$tmpdir/log" >&2
-    exit 1
-}
+"$python" "$checker" "$tmpdir/direct.wire" direct "$port" ||
+    fail_dump "the direct crawl's wire failed the header checks" "$tmpdir/log"
 
 # 2. Host, the proxy absolute-URI request line and its ftp:// variant. Only
 # reachable through an http proxy: without one the poisoned authority fails to
@@ -58,7 +56,5 @@ crawl "http://start.example/" '+*' -P "127.0.0.1:$port" \
     -O "$tmpdir/m2" -c1 --robots=0 --retries=0 --quiet -%v0
 stop_server "$serverpid"
 serverpid=
-"$python" "$checker" "$tmpdir/proxy.wire" proxy || {
-    cat "$tmpdir/log" >&2
-    exit 1
-}
+"$python" "$checker" "$tmpdir/proxy.wire" proxy ||
+    fail_dump "the proxied crawl's wire failed the header checks" "$tmpdir/log"

--- a/tests/160_zlib-cache-hdrbounds.test
+++ b/tests/160_zlib-cache-hdrbounds.test
@@ -22,8 +22,5 @@ httrack -#test=cache-hdrbounds "$dir" >"$dir/out" 2>"$dir/err" ||
     }
 
 out=$(tail -n1 "$dir/out")
-test "$out" = "cache-hdrbounds: OK" || {
-    echo "expected 'cache-hdrbounds: OK', got: $out" >&2
-    cat "$dir/err" >&2
-    exit 1
-}
+test "$out" = "cache-hdrbounds: OK" ||
+    fail_dump "expected 'cache-hdrbounds: OK', got: $out" "$dir/err"

--- a/tests/162_zlib-cache-urlbounds.test
+++ b/tests/162_zlib-cache-urlbounds.test
@@ -20,8 +20,5 @@ httrack -#test=cache-urlbounds "$dir" >"$dir/out" 2>"$dir/err" ||
     }
 
 out=$(tail -n1 "$dir/out")
-test "$out" = "cache-urlbounds: OK" || {
-    echo "expected 'cache-urlbounds: OK', got: $out" >&2
-    cat "$dir/err" >&2
-    exit 1
-}
+test "$out" = "cache-urlbounds: OK" ||
+    fail_dump "expected 'cache-urlbounds: OK', got: $out" "$dir/err"

--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -253,10 +253,7 @@ wedge_leg() (
 )
 # Held back: bash announces every job it reaps from a signal, which reads as a
 # failure in a log that passed.
-wedge_leg >"$tmp/wedge.log" 2>&1 || {
-    cat "$tmp/wedge.log" >&2
-    exit 1
-}
+wedge_leg >"$tmp/wedge.log" 2>&1 || fail_dump "the wedge leg failed" "$tmp/wedge.log"
 
 # A sleep still holding the step's stdout keeps its reader waiting for EOF past the
 # trap that killed the heartbeat (#949); 171 shims sleep, forks nothing, is blind to it.

--- a/tests/185_webhttrack-js-escaping.test
+++ b/tests/185_webhttrack-js-escaping.test
@@ -199,11 +199,7 @@ PY
 echo OK
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_jsesc.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 # A private data root, so LANGUAGE_2 can carry the hostile strings. distcheck's
 # srcdir is read-only and cp keeps that mode.

--- a/tests/186_webhttrack-url-escaping.test
+++ b/tests/186_webhttrack-url-escaping.test
@@ -12,13 +12,8 @@ htsserver_require
 
 work=$(mktemp -d)
 csrv=
-cleanup() {
-    htsserver_cleanup
-    test -z "${csrv}" || kill -9 "${csrv}" 2>/dev/null || true
-    wait "${csrv}" 2>/dev/null || true # absorb bash's async "Killed" notice
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
+cleanup_push htsserver_reap_vars csrv
 
 htsserver_start --home "${work}"
 

--- a/tests/19_local-connect-fallback.test
+++ b/tests/19_local-connect-fallback.test
@@ -72,16 +72,10 @@ HTTRACK_DEBUG_RESOLVE="alldead:127.0.0.2,127.0.0.3" \
     local_crawl --log "$tmpdir/log2" "http://alldead:${SRV_PORT}/simple/basic.html" -O "$out2" -c1 --robots=0 --timeout=5 --retries=0 --quiet -Z
 log2="$out2/hts-log.txt"
 
-grep -q "trying next address" "$log2" || {
-    echo "FAIL: exhaustion path never tried the fallback address"
-    cat "$log2"
-    exit 1
-}
-grep -iqE "^[0-9:]*[[:space:]]Error:" "$log2" || {
-    echo "FAIL: all addresses failing did not report an error"
-    cat "$log2"
-    exit 1
-}
+grep -q "trying next address" "$log2" ||
+    fail_dump "exhaustion path never tried the fallback address" "$log2"
+grep -iqE "^[0-9:]*[[:space:]]Error:" "$log2" ||
+    fail_dump "all addresses failing did not report an error" "$log2"
 test ! -f "$out2/alldead_${SRV_PORT}/simple/basic.html" || fail "file downloaded despite every address failing"
 
 echo "OK: connect fallback succeeds, and exhausting all addresses errors out"

--- a/tests/217_webhttrack-attr-escaping.test
+++ b/tests/217_webhttrack-attr-escaping.test
@@ -12,11 +12,7 @@ htsserver_require
 distdir=${HTS_DISTDIR}
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_attresc.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 # A private data root, so LANGUAGE_2 can carry the hostile strings. distcheck's
 # srcdir is read-only and cp keeps that mode.

--- a/tests/218_crash-nopie-frames.test
+++ b/tests/218_crash-nopie-frames.test
@@ -13,11 +13,7 @@ builddir=${abs_top_builddir:?not run under make check}
 
 out=
 
-fail() {
-    echo "FAIL: $*" >&2
-    test -z "${out}" || sed 's/^/  | /' <"${out}" >&2
-    exit 1
-}
+fail_dump_var out
 
 test "$HTS_OS" = "Linux" || skip "the ELF load bias is a Linux matter"
 if ! command -v addr2line >/dev/null && ! command -v llvm-symbolizer >/dev/null; then

--- a/tests/220_webhttrack-mirror-isolation.test
+++ b/tests/220_webhttrack-mirror-isolation.test
@@ -17,11 +17,7 @@ for asset in server/index.html server/ping.js; do
 done
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_sandbox.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 # Stand in for a finished mirror: the crawl itself is not under test.
 proj="${work}/websites/proj"

--- a/tests/223_webhttrack-session-id.test
+++ b/tests/223_webhttrack-session-id.test
@@ -11,11 +11,7 @@ set -euo pipefail
 htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_sid.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 launch() { # $1 = tag, $2 = port; leaves the URL in ${HTS_URL}
     htsserver_start --port "$2" --home "${work}/$1" --log "${work}/$1.log"
@@ -43,7 +39,7 @@ for _ in $(seq 1 10); do
     urlb=${HTS_URL}
     t1=$(date +%s)
     test "${t0}" != "${t1}" || break
-    cleanup
+    htsserver_cleanup_dir "${work}"
     urla=
 done
 test -n "${urla}" || skip "the box never started two servers inside one second"
@@ -72,5 +68,5 @@ print(("ok: " if ok else "FAIL: ") + "same-second ids differ (%r)" % ids)
 sys.exit(rc | (0 if ok else 1))
 PY
 
-cleanup
+htsserver_cleanup_dir "${work}"
 echo "PASS"

--- a/tests/241_local-single-file-gui.test
+++ b/tests/241_local-single-file-gui.test
@@ -16,11 +16,7 @@ fi
 htsserver_require
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_713gui.XXXXXX") || exit 1
-cleanup() {
-    htsserver_cleanup
-    rm -rf "$tmpdir"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "$tmpdir"
 
 printf '[webhttrack renders the options] ..\t'
 mkdir -p "${tmpdir}/home"

--- a/tests/251_webhttrack-lang-selected.test
+++ b/tests/251_webhttrack-lang-selected.test
@@ -12,11 +12,7 @@ set -euo pipefail
 htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_lang.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 # Leaves the URL in ${HTS_URL}; never call it from a $(...), or the pids it
 # records would stay in the subshell and every server would keep running.

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -34,6 +34,14 @@ fires() {
     esac
 }
 
+fires_without() { # the negative control fires needs: presence proves nothing alone
+    run_subject "$1"
+    test "$rc" -eq 1 || fail "[$1] should have failed, exited $rc: $out"
+    case "$out" in
+    *"$2"*) fail "[$1] still printed '$2': $out" ;;
+    esac
+}
+
 ## assert_eq prints both sides
 holds 'assert_eq abc abc'
 holds 'assert_eq "a b" "a b"'
@@ -72,6 +80,57 @@ fires "assert_file $tmpdir/adir" "missing file: $tmpdir/adir"
 fires "assert_file $tmpdir/nothing" "missing file: $tmpdir/nothing"
 fires "assert_file $tmpdir/adir 'the cache fixture'" "the cache fixture: missing file"
 ok "assert_file rejects a directory and a missing path alike"
+
+## fail_dump prints the logs a failure is about
+printf 'first line\nsecond line\n' >"$tmpdir/log1"
+printf 'other\n' >"$tmpdir/log2"
+: >"$tmpdir/empty"
+fires "fail_dump 'no pong' $tmpdir/log1" 'FAIL: no pong'
+fires "fail_dump 'no pong' $tmpdir/log1" "--- $tmpdir/log1"
+# Indented: a plain cat of the log would pass every other leg here.
+fires "fail_dump 'no pong' $tmpdir/log1" '  | second line'
+# Every named log, not just the first.
+fires "fail_dump two $tmpdir/log1 $tmpdir/log2" '  | first line'
+fires "fail_dump two $tmpdir/log1 $tmpdir/log2" '  | other'
+# A log the run never wrote must not turn the verdict into a sed error, and a
+# header with nothing under it reads as a truncated log.
+fires "fail_dump gone $tmpdir/nothing" 'FAIL: gone'
+fires_without "fail_dump gone $tmpdir/nothing" '---'
+fires_without "fail_dump 'no pong' $tmpdir/empty" '---'
+# stderr, like every other verdict: on stdout it lands in the test's own output.
+printf 'set -euo pipefail\n. "%s/testlib.sh"\nfail_dump x %s\n' \
+    "$testdir" "$tmpdir/log1" >"$tmpdir/subject.sh"
+leaked=$(bash "$tmpdir/subject.sh" 2>/dev/null) || true
+test -z "$leaked" || fail "fail_dump wrote to stdout: $leaked"
+ok "fail_dump names the file, indents it, and stays silent on an empty one"
+
+## fail_dump_var arms fail() itself, by variable name
+armed="out=$tmpdir/log1
+fail_dump_var out"
+fires "$armed
+fail boom" 'FAIL: boom'
+fires "$armed
+fail boom" '  | first line'
+# The whole point of naming the variable: a test that retargets its log mid-run
+# dumps the log it is on, not the one it registered.
+fires "$armed
+out=$tmpdir/log2
+fail boom" '  | other'
+fires_without "$armed
+out=$tmpdir/log2
+fail boom" '  | first line'
+# An unregistered, unset or emptied variable leaves the verdict alone.
+fires 'fail boom' 'FAIL: boom'
+fires_without 'fail boom' '---'
+fires "fail_dump_var never
+fail boom" 'FAIL: boom'
+fires "$armed
+out=
+fail boom" 'FAIL: boom'
+fires_without "$armed
+out=
+fail boom" '---'
+ok "fail_dump_var dumps whatever its variable names when the failure happens"
 
 ## assert_selftest
 holds 'assert_selftest "identabs self-test OK" identabs'

--- a/tests/272_webhttrack-host-alias.test
+++ b/tests/272_webhttrack-host-alias.test
@@ -19,11 +19,7 @@ grep -q "do:copy:HostAlias:hostalias" "${distdir}/html/server/step2.html" ||
 echo OK
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_hostalias.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 printf '[webhttrack emits --host-alias] ..\t'
 htsserver_start --home "${work}"

--- a/tests/273_webhttrack-strip-query.test
+++ b/tests/273_webhttrack-strip-query.test
@@ -19,11 +19,7 @@ grep -q "do:copy:StripQuery:stripquery" "${distdir}/html/server/step2.html" ||
 echo OK
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_stripquery.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 printf '[webhttrack emits one --strip-query per rule] ..\t'
 htsserver_start --home "${work}"

--- a/tests/274_wizard-profile-load.test
+++ b/tests/274_wizard-profile-load.test
@@ -34,11 +34,7 @@ echo OK
 htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_profile.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 mkdir -p "${work}/proj/hts-cache"
 # What the wizard itself writes: checkboxes as 0/1, values verbatim, and every

--- a/tests/282_option-flag-values.test
+++ b/tests/282_option-flag-values.test
@@ -121,11 +121,7 @@ done <<<"${literals}"
 # then feeds back to the engine, which is the #1200 chain end to end.
 htsserver_require
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_flagvalue.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 htsserver_start --home "${work}"
 

--- a/tests/287_webhttrack-footer-year.test
+++ b/tests/287_webhttrack-footer-year.test
@@ -12,11 +12,7 @@ htsserver_require
 distdir=${HTS_DISTDIR}
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_year.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 printf '[every server footer takes its year from the clock] ..\t'
 

--- a/tests/289_webhttrack-lifetime.test
+++ b/tests/289_webhttrack-lifetime.test
@@ -19,15 +19,8 @@ work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_life.XXXXXX") || fail "no tmpdir"
 pinger=
 csrv=
 sleeper=
-cleanup() {
-    htsserver_cleanup
-    for p in "${pinger}" "${csrv}" "${sleeper}"; do
-        test -z "${p}" || kill -9 "${p}" 2>/dev/null || true
-    done
-    wait "${pinger}" "${csrv}" "${sleeper}" 2>/dev/null || true
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
+cleanup_push htsserver_reap_vars pinger csrv sleeper
 
 export HOME="${work}"
 

--- a/tests/291_webhttrack-footer-default.test
+++ b/tests/291_webhttrack-footer-default.test
@@ -11,11 +11,7 @@ set -euo pipefail
 htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_footer.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 printf '[a fresh profile prefills the named-field footer] ..\t'
 

--- a/tests/308_zlib-cache-savebounds.test
+++ b/tests/308_zlib-cache-savebounds.test
@@ -20,8 +20,5 @@ httrack -#test=cache-savebounds "$dir" >"$dir/out" 2>"$dir/err" ||
     }
 
 out=$(tail -n1 "$dir/out")
-test "$out" = "cache-savebounds: OK" || {
-    echo "expected 'cache-savebounds: OK', got: $out" >&2
-    cat "$dir/err" >&2
-    exit 1
-}
+test "$out" = "cache-savebounds: OK" ||
+    fail_dump "expected 'cache-savebounds: OK', got: $out" "$dir/err"

--- a/tests/319_webhttrack-addurl.test
+++ b/tests/319_webhttrack-addurl.test
@@ -12,13 +12,8 @@ htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_addurl.XXXXXX") || fail "no tmpdir"
 csrv=
-cleanup() {
-    htsserver_cleanup
-    test -z "${csrv}" || kill -9 "${csrv}" 2>/dev/null || true
-    wait "${csrv}" 2>/dev/null || true # absorb bash's async "Killed" notice
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
+cleanup_push htsserver_reap_vars csrv
 
 export HOME="${work}" # no ~/.httrack.ini of the developer's in the store
 

--- a/tests/320_webhttrack-lang-names.test
+++ b/tests/320_webhttrack-lang-names.test
@@ -13,11 +13,7 @@ htsserver_require
 distdir=${HTS_DISTDIR}
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_langnames.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 # Leaves the URL in ${HTS_URL}; never call it from a $(...), or the pids it
 # records would stay in the subshell and every server would keep running.

--- a/tests/321_webhttrack-no-wizard.test
+++ b/tests/321_webhttrack-no-wizard.test
@@ -14,11 +14,7 @@ distdir=$(cd "${distdir}" && pwd)
 htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_wizard.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 htsserver_start --home "${work}"
 

--- a/tests/322_webhttrack-list-ids.test
+++ b/tests/322_webhttrack-list-ids.test
@@ -35,11 +35,7 @@ echo OK
 htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_listids.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 mkdir -p "${work}/proj/hts-cache"
 # WinHTTrack's own file: every list key 0-based, and Depth beside them as the

--- a/tests/323_webhttrack-proxy-persist.test
+++ b/tests/323_webhttrack-proxy-persist.test
@@ -37,11 +37,7 @@ echo OK
 htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_proxy.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 HOST=proxy.example.net
 PORT=3128

--- a/tests/325_webhttrack-value-gating.test
+++ b/tests/325_webhttrack-value-gating.test
@@ -12,11 +12,7 @@ testdir=$(cd "$(dirname "$0")" && pwd)
 htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_gating.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 printf '[a cleared box gates its value] ..\t'
 htsserver_start --home "${work}"

--- a/tests/327_webhttrack-warc-gate.test
+++ b/tests/327_webhttrack-warc-gate.test
@@ -11,11 +11,7 @@ testdir=$(cd "$(dirname "$0")" && pwd)
 htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_warcgate.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 printf '[the CDXJ box follows the WARC box] ..\t'
 htsserver_start --home "${work}"

--- a/tests/330_webhttrack-update-language-key.test
+++ b/tests/330_webhttrack-update-language-key.test
@@ -12,11 +12,7 @@ htsserver_require
 distdir=${HTS_DISTDIR}
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_langkey.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 root="${work}/root"
 mkdir -p "${root}"

--- a/tests/335_webhttrack-bind-loopback.test
+++ b/tests/335_webhttrack-bind-loopback.test
@@ -11,11 +11,7 @@ set -euo pipefail
 htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_bind.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 # "ok", or the errno name: a filtered address times out where an unbound one is
 # refused, and only the refusal proves nothing is listening.
@@ -89,5 +85,5 @@ test "${got}" = ConnectionRefusedError ||
     fail "the default run answers on ${addr} (${got})"
 echo "ok: the default socket is loopback-only"
 
-cleanup
+htsserver_cleanup_dir "${work}"
 echo "PASS"

--- a/tests/336_webhttrack-path-traversal.test
+++ b/tests/336_webhttrack-path-traversal.test
@@ -11,11 +11,7 @@ set -euo pipefail
 htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_traversal.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 mkdir -p "${work}/websites" "${work}/outside/hts-cache"
 # The load path renders what it reads, so a leak shows up in the form.

--- a/tests/48_local-crange-memresume.test
+++ b/tests/48_local-crange-memresume.test
@@ -50,11 +50,8 @@ printf '[pass 2: hostile 206, no overflow, refetch] ..\t'
 rc=0
 local_crawl --log "${tmpdir}/log2" "${common[@]}" --continue "${BASEURL}/crange206mem/index.html" || rc=$?
 # a crash here would otherwise read as a clean "terminated"
-test "$rc" -eq 0 || {
-    echo "FAIL: httrack exited $rc"
-    cat "${tmpdir}/log2" >&2
-    exit 1
-}
+test "$rc" -eq 0 ||
+    fail_dump "httrack exited $rc" "${tmpdir}/log2"
 echo "OK (terminated)"
 
 blob=$(find "$out" -name blob.bin 2>/dev/null | head -1)

--- a/tests/52_local-socks5.test
+++ b/tests/52_local-socks5.test
@@ -51,11 +51,8 @@ start_server() {
         grep -q "^ready" "$ports" 2>/dev/null && break
         sleep 0.1
     done
-    grep -q "^ready" "$ports" 2>/dev/null || {
-        echo "server ($mode) did not start" >&2
-        cat "$dir/server.err" >&2
-        exit 1
-    }
+    grep -q "^ready" "$ports" 2>/dev/null ||
+        fail_dump "server ($mode) did not start" "$dir/server.err"
     tls_port=$(awk '/^TLS/{print $2}' "$ports")
     http_port=$(awk '/^HTTP/{print $2}' "$ports")
     socks_port=$(awk '/^SOCKS/{print $2}' "$ports")
@@ -88,16 +85,10 @@ ok="$tmpdir/ok"
 start_server "$ok" ok
 
 run_crawl "$ok/out" "https://${host}:${tls_port}/" "socks5://127.0.0.1:${socks_port}"
-grep -rq "ORIGIN-PAGE-563" "$ok/out" || {
-    echo "FAIL: origin page not downloaded through the socks proxy" >&2
-    cat "$ok/out.log" "$ok/server.err" >&2
-    exit 1
-}
-grep -q "^ATYP domain ${host}\$" "$ok/socks.log" || {
-    echo "FAIL: proxy did not receive ATYP=domain ${host} (no remote DNS)" >&2
-    cat "$ok/socks.log" >&2
-    exit 1
-}
+grep -rq "ORIGIN-PAGE-563" "$ok/out" ||
+    fail_dump "origin page not downloaded through the socks proxy" "$ok/out.log" "$ok/server.err"
+grep -q "^ATYP domain ${host}\$" "$ok/socks.log" ||
+    fail_dump "proxy did not receive ATYP=domain ${host} (no remote DNS)" "$ok/socks.log"
 # a client that resolved locally would have sent an address, not a name
 grep -q "^ATYP ipv4" "$ok/socks.log" && {
     echo "FAIL: httrack resolved locally and sent an IPv4 to the proxy" >&2
@@ -109,18 +100,12 @@ echo "OK: https tunneled through socks5 with remote DNS"
 # --- plain http over socks --------------------------------------------------
 : >"$ok/origin-headers.log" # the https crawl above also logged a request line
 run_crawl "$ok/outh" "http://${host}:${http_port}/" "socks5://127.0.0.1:${socks_port}"
-grep -rq "ORIGIN-PAGE-563" "$ok/outh" || {
-    echo "FAIL: plain http not tunneled through the socks proxy" >&2
-    cat "$ok/outh.log" "$ok/socks.log" >&2
-    exit 1
-}
+grep -rq "ORIGIN-PAGE-563" "$ok/outh" ||
+    fail_dump "plain http not tunneled through the socks proxy" "$ok/outh.log" "$ok/socks.log"
 # the tunneled request is origin-form, as on a direct connection: the http-proxy
 # absolute URI would reach the origin as "GET http://host/"
-grep -q "^REQUEST GET / " "$ok/origin-headers.log" || {
-    echo "FAIL: tunneled request is not origin-form" >&2
-    cat "$ok/origin-headers.log" >&2
-    exit 1
-}
+grep -q "^REQUEST GET / " "$ok/origin-headers.log" ||
+    fail_dump "tunneled request is not origin-form" "$ok/origin-headers.log"
 grep -q "^REQUEST GET http" "$ok/origin-headers.log" && {
     echo "FAIL: absolute-URI request sent through the socks tunnel" >&2
     cat "$ok/origin-headers.log" >&2
@@ -140,17 +125,11 @@ missing=0
 for i in 1 2 3 4 5; do
     grep -rq "SUBPAGE-563 /p${i}.html" "$ka/out" || missing=1
 done
-test "$missing" -eq 0 || {
-    echo "FAIL: a keep-alive subpage was lost (re-handshake corrupted the reused socket)" >&2
-    cat "$ka/out.log" "$ka/socks.log" >&2
-    exit 1
-}
+test "$missing" -eq 0 ||
+    fail_dump "a keep-alive subpage was lost (re-handshake corrupted the reused socket)" "$ka/out.log" "$ka/socks.log"
 handshakes=$(count_matching_lines "^CMD " "$ka/socks.log")
-test "$handshakes" -eq 1 || {
-    echo "FAIL: expected 1 SOCKS handshake for the reused socket, got $handshakes" >&2
-    cat "$ka/socks.log" >&2
-    exit 1
-}
+test "$handshakes" -eq 1 ||
+    fail_dump "expected 1 SOCKS handshake for the reused socket, got $handshakes" "$ka/socks.log"
 echo "OK: keep-alive socket reused over one socks tunnel, no re-handshake"
 
 # --- authenticated socks (RFC 1929) -----------------------------------------
@@ -167,21 +146,12 @@ grep -q "^AUTHVER-BAD" "$auth/socks.log" && {
     cat "$auth/socks.log" >&2
     exit 1
 }
-grep -rq "ORIGIN-PAGE-563" "$auth/out" || {
-    echo "FAIL: origin not downloaded through the authenticated socks proxy" >&2
-    cat "$auth/out.log" "$auth/socks.log" >&2
-    exit 1
-}
-grep -q "^METHOD userpass\$" "$auth/socks.log" || {
-    echo "FAIL: user/pass method not negotiated (auth ignored)" >&2
-    cat "$auth/socks.log" >&2
-    exit 1
-}
-grep -q "^AUTH user secret\$" "$auth/socks.log" || {
-    echo "FAIL: wrong socks credentials sent" >&2
-    cat "$auth/socks.log" >&2
-    exit 1
-}
+grep -rq "ORIGIN-PAGE-563" "$auth/out" ||
+    fail_dump "origin not downloaded through the authenticated socks proxy" "$auth/out.log" "$auth/socks.log"
+grep -q "^METHOD userpass\$" "$auth/socks.log" ||
+    fail_dump "user/pass method not negotiated (auth ignored)" "$auth/socks.log"
+grep -q "^AUTH user secret\$" "$auth/socks.log" ||
+    fail_dump "wrong socks credentials sent" "$auth/socks.log"
 grep -qi "secret\|proxy-authorization" "$auth/origin-headers.log" && {
     echo "FAIL: socks credentials leaked into the origin request" >&2
     cat "$auth/origin-headers.log" >&2

--- a/tests/56_local-proxy-noleak.test
+++ b/tests/56_local-proxy-noleak.test
@@ -68,11 +68,8 @@ if grep -qE '"(GET|POST|HEAD|CONNECT) ' "$SRV_LOG"; then
 fi
 
 # the crawl must fail at the proxy (proves it really tried the proxy, not a no-op)
-grep -q 'Connect Error' "$log" || {
-    echo "FAIL: expected a proxy connect error"
-    cat "$log"
-    exit 1
-}
+grep -q 'Connect Error' "$log" ||
+    fail_dump "expected a proxy connect error" "$log"
 
 # and it must not have tried an origin-address fallback under the proxy
 if grep -q "trying next address" "$log"; then

--- a/tests/57_local-proxy-connect.test
+++ b/tests/57_local-proxy-connect.test
@@ -44,11 +44,8 @@ start_server() {
         grep -q "^ready" "$ports" 2>/dev/null && break
         sleep 0.1
     done
-    grep -q "^ready" "$ports" 2>/dev/null || {
-        echo "server ($mode) did not start" >&2
-        cat "$dir/server.err" >&2
-        exit 1
-    }
+    grep -q "^ready" "$ports" 2>/dev/null ||
+        fail_dump "server ($mode) did not start" "$dir/server.err"
     origin_port=$(awk '/^ORIGIN/{print $2}' "$ports")
     proxy_port=$(awk '/^PROXY/{print $2}' "$ports")
 }
@@ -77,21 +74,12 @@ start_server "$ok" ok
 
 # 1. page fetched through a CONNECT tunnel, request delivered origin-form
 run_crawl "$ok/out" "connect://127.0.0.1:${proxy_port}" "$origin_port"
-grep -rq "ORIGIN-PAGE-564" "$ok/out" || {
-    echo "FAIL: origin page not downloaded through the CONNECT tunnel" >&2
-    cat "$ok/out.log" >&2
-    exit 1
-}
-grep -q "^CONNECT 127.0.0.1:${origin_port} " "$ok/proxy.log" || {
-    echo "FAIL: proxy never received a CONNECT for the plain-http origin" >&2
-    cat "$ok/proxy.log" >&2
-    exit 1
-}
-grep -q "^GET / HTTP/1" "$ok/origin-headers.log" || {
-    echo "FAIL: origin did not see an origin-form request line" >&2
-    cat "$ok/origin-headers.log" >&2
-    exit 1
-}
+grep -rq "ORIGIN-PAGE-564" "$ok/out" ||
+    fail_dump "origin page not downloaded through the CONNECT tunnel" "$ok/out.log"
+grep -q "^CONNECT 127.0.0.1:${origin_port} " "$ok/proxy.log" ||
+    fail_dump "proxy never received a CONNECT for the plain-http origin" "$ok/proxy.log"
+grep -q "^GET / HTTP/1" "$ok/origin-headers.log" ||
+    fail_dump "origin did not see an origin-form request line" "$ok/origin-headers.log"
 if grep -q "^GET http://" "$ok/origin-headers.log"; then
     echo "FAIL: absolute-URI request leaked through the tunnel to the origin" >&2
     exit 1
@@ -104,11 +92,8 @@ echo "OK: plain http tunneled origin-form through CONNECT"
 # makes this log ":443" and fail.
 : >"$ok/proxy.log"
 run_crawl "$ok/out_port" "connect://127.0.0.1:${proxy_port}" "" "http://127.0.0.1/" || true
-grep -q "^CONNECT 127.0.0.1:80 " "$ok/proxy.log" || {
-    echo "FAIL: portless http origin did not CONNECT to the default port 80" >&2
-    cat "$ok/proxy.log" >&2
-    exit 1
-}
+grep -q "^CONNECT 127.0.0.1:80 " "$ok/proxy.log" ||
+    fail_dump "portless http origin did not CONNECT to the default port 80" "$ok/proxy.log"
 echo "OK: portless http origin tunnels to the default port 80"
 
 # 3. teeth: without connect://, httrack sends the absolute-URI form, which the
@@ -121,11 +106,8 @@ grep -rq "ORIGIN-PAGE-564" "$ok/out_plain" && {
     echo "FAIL: absolute-URI form unexpectedly fetched through a CONNECT-only proxy" >&2
     exit 1
 }
-grep -q "^GET http://127.0.0.1:${origin_port}/" "$ok/proxy.log" || {
-    echo "FAIL: a plain proxy should have received an absolute-URI GET" >&2
-    cat "$ok/proxy.log" >&2
-    exit 1
-}
+grep -q "^GET http://127.0.0.1:${origin_port}/" "$ok/proxy.log" ||
+    fail_dump "a plain proxy should have received an absolute-URI GET" "$ok/proxy.log"
 echo "OK: absolute-URI form (no connect://) rejected by the CONNECT-only proxy"
 
 # 4. authenticated proxy: creds ride the CONNECT, never reach the origin
@@ -135,11 +117,8 @@ run_crawl "$ok/out2" "connect://user:secret@127.0.0.1:${proxy_port}" "$origin_po
 grep -rq "ORIGIN-PAGE-564" "$ok/out2" || fail "origin page not downloaded through the authenticated proxy"
 got=$(awk '/^AUTH Basic /{print $3}' "$ok/proxy.log" | head -1)
 # base64("user:secret"); compared literally to stay portable (no base64 -d)
-test "$got" == "dXNlcjpzZWNyZXQ=" || {
-    echo "FAIL: Proxy-Authorization not carried on CONNECT (got '$got')" >&2
-    cat "$ok/proxy.log" >&2
-    exit 1
-}
+test "$got" == "dXNlcjpzZWNyZXQ=" ||
+    fail_dump "Proxy-Authorization not carried on CONNECT (got '$got')" "$ok/proxy.log"
 if grep -qi "proxy-authorization" "$ok/origin-headers.log"; then
     echo "FAIL: proxy credentials leaked to the origin through the tunnel" >&2
     exit 1

--- a/tests/59_local-tls-stall.test
+++ b/tests/59_local-tls-stall.test
@@ -54,11 +54,8 @@ if test "$wall" -ge 30 || test "$wall" -lt 3; then
     cat "$tmpdir/log" >&2
     exit 1
 fi
-grep -q 'Handshake Time Out' "$tmpdir/crawl1/hts-log.txt" || {
-    echo "FAIL: crawl ended in ${wall}s but not on a handshake timeout" >&2
-    cat "$tmpdir/crawl1/hts-log.txt" >&2
-    exit 1
-}
+grep -q 'Handshake Time Out' "$tmpdir/crawl1/hts-log.txt" ||
+    fail_dump "crawl ended in ${wall}s but not on a handshake timeout" "$tmpdir/crawl1/hts-log.txt"
 echo "OK: stalled TLS handshake reaped by --timeout after ${wall}s"
 
 # 2. the handshake window is its own, not what the connect left over: a proxy

--- a/tests/68_webhttrack-outdir-charset.test
+++ b/tests/68_webhttrack-outdir-charset.test
@@ -16,11 +16,7 @@ set -euo pipefail
 htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_charset.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 htsserver_start --home "${work}"
 

--- a/tests/71_local-crange-repaircache.test
+++ b/tests/71_local-crange-repaircache.test
@@ -66,11 +66,8 @@ echo "OK"
 printf '[pass 2: repair, reject range, refetch] ..\t'
 rc=0
 local_crawl --log "${tmpdir}/log2" "${common[@]}" --continue "${BASEURL}/crange206mem/index.html" || rc=$?
-test "$rc" -eq 0 || {
-    echo "FAIL: httrack exited $rc"
-    cat "${tmpdir}/log2" >&2
-    exit 1
-}
+test "$rc" -eq 0 ||
+    fail_dump "httrack exited $rc" "${tmpdir}/log2"
 echo "OK (terminated)"
 
 # The repair path must actually have run, else this is just a copy of test 48.

--- a/tests/72_watchdog-crawl.test
+++ b/tests/72_watchdog-crawl.test
@@ -3,12 +3,8 @@
 # Control for wait_bounded: a wedged fetch must be reaped at the harness deadline,
 # not hang the CI step to its 45-min cap.
 
-: "${top_srcdir:=..}"
-
-fail() {
-    echo "FAIL: $*" >&2
-    exit 1
-}
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
 
 start=$SECONDS
 out=$(CRAWL_DEADLINE=3 bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
@@ -17,14 +13,8 @@ elapsed=$((SECONDS - start))
 
 # Skip (not fail) on causes unrelated to the watchdog: no python3/server, or a
 # port-announce race (flaky-13).
-test "$rc" -ne 77 || {
-    echo "SKIP: local crawl prerequisites missing" >&2
-    exit 77
-}
-if grep -q "could not discover server port" <<<"$out"; then
-    echo "SKIP: server port announce raced" >&2
-    exit 77
-fi
+test "$rc" -ne 77 || skip "local crawl prerequisites missing"
+! grep -q "could not discover server port" <<<"$out" || skip "server port announce raced"
 
 # The message prints only on the 124 reap, and 25s < the engine's --timeout=30, so
 # together they pin the fast exit on the 3s watchdog, not httrack giving up.

--- a/tests/79_local-proxytrack-webdav-mime.test
+++ b/tests/79_local-proxytrack-webdav-mime.test
@@ -39,15 +39,9 @@ start_proxytrack "$dir/pt" launch_proxytrack
 curl -s --max-time 30 -X PROPFIND -H "Depth: 1" \
     "http://127.0.0.1:$proxyport/webdav/example.com/" >"$dir/resp.xml"
 
-grep -q '<getcontenttype>application/octet-stream</getcontenttype>' "$dir/resp.xml" || {
-    echo "FAIL: missing Content-Type did not fall back to application/octet-stream"
-    cat "$dir/resp.xml"
-    exit 1
-}
-grep -q '<getlastmodified>Wed, 01 Jan 2025 00:00:00 GMT</getlastmodified>' "$dir/resp.xml" || {
-    echo "FAIL: missing Last-Modified did not fall back to the index timestamp"
-    cat "$dir/resp.xml"
-    exit 1
-}
+grep -q '<getcontenttype>application/octet-stream</getcontenttype>' "$dir/resp.xml" ||
+    fail_dump "missing Content-Type did not fall back to application/octet-stream" "$dir/resp.xml"
+grep -q '<getlastmodified>Wed, 01 Jan 2025 00:00:00 GMT</getlastmodified>' "$dir/resp.xml" ||
+    fail_dump "missing Last-Modified did not fall back to the index timestamp" "$dir/resp.xml"
 
 echo "OK: WebDAV listing falls back correctly for an entry with no Content-Type/Last-Modified"

--- a/tests/80_engine-crash-symbolize.test
+++ b/tests/80_engine-crash-symbolize.test
@@ -23,11 +23,8 @@ rc=0
 run_with_timeout 60 httrack -#test=strsafe overflow "$overflow" >"$out" 2>&1 || rc=$?
 test "$rc" -ne 124 || fail "the crash handler did not finish within the deadline"
 
-grep -q '^Caught signal ' "$out" || {
-    echo "no 'Caught signal' line:" >&2
-    cat "$out" >&2
-    exit 1
-}
+grep -q '^Caught signal ' "$out" ||
+    fail_dump "no 'Caught signal' line:" "$out"
 if grep -q 'No stack trace available on this OS' "$out"; then
     echo "no backtrace() on this platform; skipping" >&2
     exit 77
@@ -43,11 +40,8 @@ arm | armv*)
     ;;
 esac
 # Unconditional and first: symbolizing must never cost the raw trace.
-grep -q "$rawframe" "$out" || {
-    echo "raw module+offset frames are gone:" >&2
-    cat "$out" >&2
-    exit 1
-}
+grep -q "$rawframe" "$out" ||
+    fail_dump "raw module+offset frames are gone:" "$out"
 
 command -v addr2line >/dev/null || skip "addr2line not installed"
 
@@ -69,11 +63,8 @@ grep -qE 'st_strsafe|strcpy_safe_' "$oracle" || skip "addr2line names no hidden 
 # names are static, so .dynsym could never have carried them. Not anchored on
 # the "0xOFF:" line, the inline chain puts the name on either half.
 symbolized=$(grep -v "$rawframe" "$out" || true)
-grep -qE 'st_strsafe|strcpy_safe_' <<<"$symbolized" || {
-    echo "the handler did not name the hidden frames:" >&2
-    cat "$out" >&2
-    exit 1
-}
+grep -qE 'st_strsafe|strcpy_safe_' <<<"$symbolized" ||
+    fail_dump "the handler did not name the hidden frames:" "$out"
 
 # Opt-out: raw trace kept, nothing spawned.
 export HTTRACK_NO_SYMBOLIZE=1
@@ -81,13 +72,7 @@ rc=0
 run_with_timeout 60 httrack -#test=strsafe overflow "$overflow" >"$raw" 2>&1 || rc=$?
 unset HTTRACK_NO_SYMBOLIZE
 test "$rc" -ne 124 || fail "the opt-out run did not finish within the deadline"
-grep -q "$rawframe" "$raw" || {
-    echo "the opt-out lost the raw trace:" >&2
-    cat "$raw" >&2
-    exit 1
-}
-! grep -q '^0x[0-9a-f]*: ' "$raw" || {
-    echo "the opt-out still symbolized:" >&2
-    cat "$raw" >&2
-    exit 1
-}
+grep -q "$rawframe" "$raw" ||
+    fail_dump "the opt-out lost the raw trace:" "$raw"
+! grep -q '^0x[0-9a-f]*: ' "$raw" ||
+    fail_dump "the opt-out still symbolized:" "$raw"

--- a/tests/81_webhttrack-maxsize.test
+++ b/tests/81_webhttrack-maxsize.test
@@ -11,11 +11,7 @@ set -euo pipefail
 htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_maxsize.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 htsserver_start --home "${work}"
 
@@ -72,7 +68,7 @@ want('<input type="submit" value="OK"' in opts, "no OK label in option2b.html",
      "")
 PY
 
-cleanup
+htsserver_cleanup_dir "${work}"
 
 # A bare -m<n> resets the html limit, so only the bare-then-comma order keeps
 # both caps live. basic.html is 487 bytes, well past the 10-byte html cap.

--- a/tests/82_webhttrack-browse-links.test
+++ b/tests/82_webhttrack-browse-links.test
@@ -19,11 +19,7 @@ bad=$(grep -l 'file://' "${distdir}"/html/server/finished.html || true)
 test -z "${bad}" || fail "file: link left in: ${bad}"
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_browse.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 # Stand in for a finished mirror: the crawl itself is not under test.
 proj="${work}/websites/proj"

--- a/tests/83_webhttrack-argescape.test
+++ b/tests/83_webhttrack-argescape.test
@@ -11,10 +11,7 @@ set -euo pipefail
 
 htsserver_require
 
-cleanup() {
-    htsserver_cleanup
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup
 
 htsserver_start
 test -n "${HTS_PID}" || fail "htsserver did not report its pid"

--- a/tests/84_webhttrack-mirror-verbatim.test
+++ b/tests/84_webhttrack-mirror-verbatim.test
@@ -12,13 +12,8 @@ htsserver_require
 
 work=$(mktemp -d)
 csrv=
-cleanup() {
-    htsserver_cleanup
-    test -z "${csrv}" || kill -9 "${csrv}" 2>/dev/null || true
-    wait "${csrv}" 2>/dev/null || true # absorb bash's async "Killed" notice
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
+cleanup_push htsserver_reap_vars csrv
 
 # LF-only, and a line ending in a backslash: the expander rewrites both, so a
 # mangled reply fails the byte comparison even where no directive is present.

--- a/tests/85_webhttrack-projpath.test
+++ b/tests/85_webhttrack-projpath.test
@@ -11,11 +11,7 @@ set -euo pipefail
 htsserver_require
 
 base=$(mktemp -d)
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${base}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${base}"
 
 # GET $1 into ${reply}, requiring status $2. Captured, not piped: a dead request
 # reads as marker-absent, and so do a truncated body and a 302 to the file.

--- a/tests/89_webhttrack-error-overflow.test
+++ b/tests/89_webhttrack-error-overflow.test
@@ -16,11 +16,7 @@ msgmax=1023
 # Physical path: macOS resolves TMPDIR through /var -> private/var, and the
 # paths built below sit within a few bytes of its 1024-byte PATH_MAX.
 base=$(cd "$(mktemp -d)" && pwd -P)
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${base}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${base}"
 
 # Echo a path under the root $1 exactly $2 bytes long, in NAME_MAX-sized parts.
 padpath() {

--- a/tests/90_webhttrack-checkbox-clear.test
+++ b/tests/90_webhttrack-checkbox-clear.test
@@ -14,11 +14,7 @@ distdir=$(cd "${distdir}" && pwd)
 htsserver_require
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_checkbox.XXXXXX") || fail "no tmpdir"
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${work}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${work}"
 
 htsserver_start --home "${work}"
 

--- a/tests/91_webhttrack-directory.test
+++ b/tests/91_webhttrack-directory.test
@@ -11,11 +11,7 @@ set -euo pipefail
 htsserver_require
 
 base=$(mktemp -d)
-cleanup() {
-    htsserver_cleanup
-    rm -rf "${base}"
-}
-cleanup_push cleanup
+cleanup_push htsserver_cleanup_dir "${base}"
 
 # GET $1, or fail with $2 when the reply never comes.
 get() {

--- a/tests/93_local-changes.test
+++ b/tests/93_local-changes.test
@@ -42,11 +42,8 @@ EOF
 expect() {
     local label="$1" want="$2" got="$3" rep="${4:-$report}"
     printf '[%s] ..\t' "$label"
-    test "$want" == "$got" || {
-        echo "FAIL: expected '${want}', got '${got}'"
-        cat "$rep"
-        exit 1
-    }
+    test "$want" == "$got" ||
+        fail_dump "expected '${want}', got '${got}'" "$rep"
     echo "OK"
 }
 # Every count must equal the length of the list it counts.
@@ -55,11 +52,8 @@ expect_counts_match() {
     printf '[%s] ..\t' "$label"
     for bucket in new changed unchanged gone; do
         n=$(listed "$bucket" "$rep" | grep -c . || true)
-        test "$(field "$bucket" "$rep")" == "$n" || {
-            echo "FAIL: ${bucket} count $(field "$bucket" "$rep") but $n listed"
-            cat "$rep"
-            exit 1
-        }
+        test "$(field "$bucket" "$rep")" == "$n" ||
+            fail_dump "${bucket} count $(field "$bucket" "$rep") but $n listed" "$rep"
     done
     echo "OK"
 }

--- a/tests/94_local-single-file.test
+++ b/tests/94_local-single-file.test
@@ -188,11 +188,8 @@ for cap in notanumber 12abc 0 99999999999999999999; do
     local_crawl --log "${tmpdir}/log4" -O "$bad" "${opts[@]}" \
         --single-file-max-size "$cap" "${BASEURL}/index.html" || rc=$?
     test "$rc" -ne 0 || fail "--single-file-max-size $cap was accepted"
-    grep -q 'positive size' "${tmpdir}/log4" || {
-        echo "FAIL: --single-file-max-size $cap was refused without saying so"
-        cat "${tmpdir}/log4"
-        exit 1
-    }
+    grep -q 'positive size' "${tmpdir}/log4" ||
+        fail_dump "--single-file-max-size $cap was refused without saying so" "${tmpdir}/log4"
 done
 test ! -e "${bad}/127.0.0.1_${SRV_PORT}/index.html" || fail "a rejected cap still crawled"
 echo OK

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -11,8 +11,40 @@ testdir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # own value, so the default only serves a hand-run and the Windows suite.
 : "${top_srcdir:=..}"
 
+# Paths a failure should print, named by VARIABLE: a test that retargets its log
+# mid-run keeps the dump pointed at the current one.
+FAIL_DUMP_VARS=(${FAIL_DUMP_VARS[@]+"${FAIL_DUMP_VARS[@]}"})
+fail_dump_var() { FAIL_DUMP_VARS+=("$@"); }
+
+# Headed and indented, so a dumped log cannot be read as the harness's own
+# output. Silent on a missing or empty file: the verdict still stands alone.
+dump_file() { # dump_file FILE
+    test -s "$1" || return 0
+    echo "--- $1" >&2
+    sed 's/^/  | /' <"$1" >&2
+}
+
 fail() {
+    local i v
     echo "FAIL: $*" >&2
+    # By index: ${!ARR[@]+...} would read each element as a variable name.
+    for ((i = 0; i < ${#FAIL_DUMP_VARS[@]}; i++)); do
+        v=${FAIL_DUMP_VARS[i]}
+        dump_file "${!v:-}"
+    done
+    exit 1
+}
+
+# fail(), plus the logs the failure is about: a verdict with no evidence sends
+# the reader back to a run that no longer exists.
+fail_dump() { # fail_dump MSG FILE...
+    local msg=$1
+    shift
+    echo "FAIL: ${msg}" >&2
+    while test $# -gt 0; do
+        dump_file "$1"
+        shift
+    done
     exit 1
 }
 

--- a/tests/webhttracklib.sh
+++ b/tests/webhttracklib.sh
@@ -173,6 +173,27 @@ htsserver_cleanup() {
     HTS_TMP_LOGS=()
 }
 
+# Teardown for a test that owns a work dir: htsserver holds ${HOME} under it, so
+# the reap has to precede the removal. Takes the dir rather than reading a
+# caller variable, since cleanup_push records its arguments at push time.
+htsserver_cleanup_dir() { # htsserver_cleanup_dir DIR
+    htsserver_cleanup
+    rm -rf "$1"
+}
+
+# Reap helper processes the test backgrounded, named by VARIABLE: their pids are
+# assigned after the teardown frame is pushed.
+htsserver_reap_vars() { # htsserver_reap_vars VAR...
+    local v
+    for v in "$@"; do
+        test -z "${!v:-}" || kill -9 "${!v}" 2>/dev/null || true
+    done
+    # Absorbs bash's async "Killed" notice, which reads as a failure otherwise.
+    for v in "$@"; do
+        test -z "${!v:-}" || wait "${!v}" 2>/dev/null || true
+    done
+}
+
 # A leaked htsserver wedges the parallel harness behind a green log.
 htsserver_assert_reaped() {
     local pid


### PR DESCRIPTION
The suite carried 59 copies of `cmd || { echo MSG; cat LOG; exit 1; }` across 22 files, which round 1's `fail()` could not absorb because it prints a message and nothing else. `testlib.sh` now has `fail_dump MSG FILE...` for the call sites that name their log, and `fail_dump_var NAME`, which arms `fail()` itself with a log named by variable rather than by path, so a test that retargets its log mid-run keeps the dump pointed at the file it is on.

That second form is what lets six tests drop a private `fail()` override. Those were a live hazard rather than plain duplication: every `assert_eq`, `require_httrack` and `run_with_timeout` in those files was routed through whichever `fail` happened to be defined last. `01_engine-filelist`'s took `$1` where the library passes `$*`, and printed to stdout; `105_suite-timeout` defines its override two lines after the first assertion that calls one, so that assertion always used the library's. `226_watchdog-native` keeps its override on purpose — it signals the top pid, because `fail` is reached from inside a `$(...)` where a bare `exit 1` ends only the subshell.

`webhttracklib.sh` gains `htsserver_cleanup_dir` and `htsserver_reap_vars`, folding 34 identical work-dir teardowns into one `cleanup_push` line each. The reaper takes variable names for the same reason `fail_dump_var` does: a content server's pid is assigned after the teardown frame is pushed.

Both new helpers run only on a failure path, so a green suite would exercise neither; `257_testlib-asserts` now covers them, and six mutants of the implementation are killed by the assertion naming the cause. Behaviour preservation was checked by diffing the per-file multiset of failure-message literals before and after (identical apart from the deleted overrides, plus three messages added where a block dumped a log without saying anything) and the per-file count of termination sites, conserved exactly in all 22 converted files. Full suite before and after: 368 tests, 356 pass, 12 skip, same verdict on every test.
