### PR TITLE
The WebHTTrack cache boxes cannot be turned off

### DIFF
--- a/html/server/option3.html
+++ b/html/server/option3.html
@@ -99,6 +99,7 @@ ${do:end-if}
 <input type="hidden" name="closeme" value="">
 
 <!-- clear if not checked -->
+<input type="hidden" name="cache" value="">
 <input type="hidden" name="windebug" value="">
 
 ${LANG_I40c}

--- a/html/server/option9.html
+++ b/html/server/option9.html
@@ -118,6 +118,7 @@ ${do:end-if}
 <input type="hidden" name="closeme" value="">
 
 <!-- clear if not checked -->
+<input type="hidden" name="cache2" value="">
 <input type="hidden" name="warc" value="">
 <input type="hidden" name="warccdx" value="">
 <input type="hidden" name="wacz" value="">

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -871,11 +871,11 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
   {
     char pth[1024];
 
-    /* "cache" beside "Cache": step2.html must not re-default it on every
-       render, or a reloaded profile that cleared it flips back. */
-    const char *initOn[] = {"Cache",   "cache",   "ka",        "cookies",
-                            "logf",    "ftpprox", "parsejava", "testall",
-                            "updhack", "urlhack", "index",     NULL};
+    /* Field names only: a profile-key seed here is copied back over a box the
+       user cleared, by step2.html's ${do:copy}. */
+    const char *initOn[] = {"cache",   "ka",        "cookies", "logf",
+                            "ftpprox", "parsejava", "testall", "updhack",
+                            "urlhack", "index",     NULL};
     const initIntElt initInt[] = {
       {"filter", 4},
       {"travel", 2},

--- a/tests/344_webhttrack-cache-clear.test
+++ b/tests/344_webhttrack-cache-clear.test
@@ -1,0 +1,121 @@
+#!/bin/bash
+#
+# Neither cache box had the hidden companion that clears it, so an unticked box
+# posted nothing and the stored "1" survived: the cache could not be turned off.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/webhttracklib.sh
+. "${testdir}/webhttracklib.sh"
+
+htsserver_require
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_cacheclear.XXXXXX") || fail "no tmpdir"
+cleanup() {
+    htsserver_cleanup
+    rm -rf "${work}"
+}
+cleanup_push cleanup
+
+htsserver_start --home "${work}"
+
+htsserver_python - "${HTS_URL}" "${work}" <<'PY' || fail "the cache boxes cannot be cleared (see above)"
+import os
+import re
+import sys
+
+from webtestlib import Session, checked, textarea
+
+s, work = Session(sys.argv[1]), sys.argv[2]
+rc = 0
+
+
+def check(ok, what):
+    global rc
+    print(("ok: " if ok else "FAIL: ") + what)
+    if not ok:
+        rc = 1
+
+
+def browser_post(page_name, unticked=()):
+    """POST what a browser sends from PAGE, with the UNTICKED boxes cleared.
+
+    An unticked checkbox contributes nothing, which is the whole bug: only a
+    hidden companion of the same name can carry the cleared state.
+    """
+    page = s.get(page_name)
+    fields = []
+    for m in re.finditer(r"<(input|select)\b([^>]*)>", page):
+        attrs = m.group(2)
+        name = re.search(r'name="([^"]+)"', attrs)
+        kind = re.search(r'type="([^"]+)"', attrs)
+        kind = kind.group(1) if kind else m.group(1)
+        if name is None or kind in ("submit", "button", "hidden"):
+            continue
+        name = name.group(1)
+        if kind == "checkbox":
+            if name not in unticked and checked(page, name):
+                fields.append((name, "on"))
+        elif kind == "select":
+            sel = re.search(r"<option value=(\d+) selected>", page[m.end():])
+            fields.append((name, sel.group(1) if sel else ""))
+        else:
+            value = re.search(r'value="([^"]*)"', attrs)
+            fields.append((name, value.group(1) if value else ""))
+    # The hidden fields the page draws, verbatim and ahead of the boxes.
+    hidden = [(m.group(1), m.group(2)) for m in re.finditer(
+        r'<input type="hidden" name="([^"]+)" value="([^"]*)">', page)]
+    s.post(page_name, [kv for kv in hidden if kv[0] != "sid"] + fields)
+
+
+def cmdline():
+    return textarea(s.post("step4.html", []), "command").split()
+
+
+# The box the user unticks, and the flag its cleared state must produce.
+BOXES = [("cache", "option3.html", "--cache=0", True),
+         ("cache2", "option9.html", "--store-all-in-cache", False)]
+
+for box, page, flag, on_when_clear in BOXES:
+    # Tick it first: cache2 is off by default, so clearing it proves nothing yet.
+    browser_post(page, unticked=())
+    if not checked(s.get(page), box):
+        s.post(page, [(box, "on")])
+    check(checked(s.get(page), box), "%s starts ticked" % box)
+    check((flag in cmdline()) is not on_when_clear,
+          "%s ticked %s %s" % (box, "drops" if on_when_clear else "emits", flag))
+
+    browser_post(page, unticked=(box,))
+    check(not checked(s.get(page), box), "%s draws an empty box once unticked" % box)
+    check((flag in cmdline()) is on_when_clear,
+          "%s unticked %s %s" % (box, "emits" if on_when_clear else "drops", flag))
+
+# step2.html copies the Cache profile key onto the box on every render, so a
+# seeded key would put the cache back on behind the user's back. First render
+# of this session: ${do:copy} consumes its source, so a later one sees nothing.
+s.get("step2.html")
+check("--cache=0" in cmdline(), "an unticked cache survives the step2 pass")
+check(not checked(s.get("option3.html"), "cache"),
+      "an unticked cache still draws an empty box after step2")
+
+# The seed is gone; a stored profile must still decide, both ways.
+for n, (stored, want) in enumerate((("1", False), ("0", True), ("1", False))):
+    proj = "proj%d" % n
+    os.makedirs(os.path.join(work, proj, "hts-cache"))
+    with open(os.path.join(work, proj, "hts-cache", "winprofile.ini"), "wb") as fp:
+        fp.write(("CurrentUrl=http://example.com/\nCache=%s\n" % stored)
+                 .encode("latin-1"))
+    loaded = s.post("step2.html", [("path", work), ("loadprojname", proj)])
+    check("http://example.com/" in loaded, "step2.html loaded %s" % proj)
+    check(("--cache=0" in cmdline()) is want,
+          "a profile with Cache=%s %s --cache=0" % (stored,
+                                                    "emits" if want else "drops"))
+
+sys.exit(rc)
+PY
+
+htsserver_cleanup
+htsserver_assert_reaped
+
+echo "PASS"

--- a/tests/90_webhttrack-checkbox-clear.test
+++ b/tests/90_webhttrack-checkbox-clear.test
@@ -38,8 +38,6 @@ def check(ok, what):
         rc = 1
 
 
-# cache/cache2 are left to the separate rework of the dead "Cache" seed.
-skip = {"cache", "cache2"}
 page_of = {}
 boxes = 0
 for path in sorted(glob.glob(os.path.join(srcdir, "html", "server", "option*.html"))):
@@ -48,8 +46,6 @@ for path in sorted(glob.glob(os.path.join(srcdir, "html", "server", "option*.htm
                    re.finditer(r'<input type="hidden" name="([^"]+)" value="">', page))
     for m in re.finditer(r'<input type="checkbox" name="([^"]+)"', page):
         boxes += 1
-        if m.group(1) in skip:
-            continue
         page_of[m.group(1)] = os.path.basename(path)
         at = cleared.get(m.group(1))
         check(at is not None and at < m.start(), "%s: %s is cleared before it is drawn"
@@ -67,6 +63,8 @@ BOXES = [
     ("testall", "ParseAll", "--extended-parsing", None),
     # htmlfirst emits --priority=7, which the scan-priority list also emits.
     ("htmlfirst", "HTMLFirst", None, None),
+    ("cache", "Cache", None, "--cache=0"),
+    ("cache2", "StoreAllInCache", "--store-all-in-cache", None),
     ("errpage", "NoErrorPages", "--generate-errors=0", None),
     ("external", "NoExternalPages", "--replace-external", None),
     ("hidepwd", "NoPwdInPages", "--disable-passwords", None),


### PR DESCRIPTION
The cache could not be turned off from the WebHTTrack UI. Every other option page pairs a checkbox with a hidden field of the same name, so an unticked box still posts a cleared value; `cache` on option3.html and `cache2` on option9.html never got one. Unticking either posted nothing at all and the stored `1` survived, so `--cache=0` was unreachable and `--store-all-in-cache` could not be taken back off once set.

The `Cache` seed in `htsserver.c`'s `initOn[]` is the other half. `step2.html` copies that profile key onto the field, so the first step2 render after a user cleared the box put the cache straight back on. The field is seeded right beside the key, so the key's seed only ever overwrote the user's choice; a loaded `winprofile.ini` supplies its own value and still decides, which the new test checks both ways.

`tests/344_webhttrack-cache-clear.test` drives a real htsserver and posts what a browser sends from the rendered form, then asserts the generated command line. Test 90 loses the `skip` that held these two boxes out of its sweep and gains rows for them.

No visible change: the two new fields are hidden inputs, so the doc screenshots still match.
