### PR TITLE
CI checked a build without the brotli and zstd decoders, a tarball missing three fuzz vectors, and a test that skipped itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -941,21 +941,6 @@ jobs:
     # The name is a required status check on master; renaming it blocks every PR.
     name: lint (shellcheck, shfmt)
     runs-on: ubuntu-24.04
-    # Every tracked shell script; the globs expand at run time. Kept here so the
-    # shellcheck and shfmt steps below cannot drift apart.
-    env:
-      SHELL_SCRIPTS: >-
-        .githooks/pre-commit
-        bootstrap
-        build.sh
-        html/div/search.sh
-        man/makeman.sh
-        src/htsbasiccharsets.sh
-        src/htsentities.sh
-        src/webhttrack.in
-        tests/*.sh
-        tests/*.test
-        tools/*.sh
     steps:
       - uses: actions/checkout@v7
 
@@ -974,6 +959,28 @@ jobs:
           appstreamcli --version
           black --version
           flake8 --version
+
+      # Read the list rather than hand-keeping one: a script added outside the
+      # old globs then gets checked without anyone widening them.
+      - name: List the tracked shell scripts
+        run: |
+          set -euo pipefail
+          mapfile -t sh < <(
+            git ls-files '*.sh' '*.test'
+            # The rest are named by their shebang, not by an extension.
+            git ls-files | while IFS= read -r f; do
+              case "$f" in *.sh | *.test) continue ;; esac
+              IFS= read -r line <"$f" 2>/dev/null || continue
+              case "$line" in
+              '#!'*/sh | '#!'*/bash | '#!'*/sh\ * | '#!'*/bash\ * | '#!'*env*\ sh | '#!'*env*\ bash)
+                printf '%s\n' "$f"
+                ;;
+              esac
+            done
+          )
+          test "${#sh[@]}" -gt 0  # shellcheck given no paths exits 0, checking nothing
+          echo "${#sh[@]} tracked shell scripts"
+          echo "SHELL_SCRIPTS=${sh[*]}" >> "$GITHUB_ENV"
 
       - name: shellcheck
         run: shellcheck $SHELL_SCRIPTS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -978,7 +978,17 @@ jobs:
               esac
             done
           )
-          test "${#sh[@]}" -gt 0  # shellcheck given no paths exits 0, checking nothing
+          # shellcheck given no paths exits 0, checking nothing. A non-zero
+          # count is too weak a floor: the shebang scan can drop almost every
+          # file and still pass one, so pin the half that cannot shrink and
+          # name the extension-less scripts the scan must reach.
+          test "${#sh[@]}" -ge "$(git ls-files '*.sh' '*.test' | wc -l)"
+          for must in bootstrap .githooks/pre-commit src/webhttrack.in; do
+            case " ${sh[*]} " in
+            *" $must "*) ;;
+            *) echo "the shebang scan no longer finds $must" >&2; exit 1 ;;
+            esac
+          done
           echo "${#sh[@]} tracked shell scripts"
           echo "SHELL_SCRIPTS=${sh[*]}" >> "$GITHUB_ENV"
 
@@ -1008,6 +1018,11 @@ jobs:
       # missing without failing anything.
       - name: test file names
         run: bash tests/check-test-names.sh
+
+      # The corpus glob is what ships the vectors in a tarball, and it has no
+      # oracle of its own: three were missing for exactly that reason.
+      - name: fuzz corpus list
+        run: bash fuzz/check-corpus-list.sh
 
       # MSBuild rejects a malformed .vcxproj with a bare MSB4025 and no build, so
       # catch it here in seconds rather than on a Windows runner minutes in.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
           sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           sudo apt-get install -y --no-install-recommends \
             build-essential autoconf automake libtool autoconf-archive \
-            zlib1g-dev libssl-dev
+            zlib1g-dev libssl-dev libbrotli-dev libzstd-dev
 
       - uses: github/codeql-action/init@v4.37.7
         with:
@@ -62,6 +62,10 @@ jobs:
           set -euo pipefail
           autoreconf -fi
           ./configure
+          # Codec detection is auto: without the -dev packages the br and zstd
+          # decoders drop out and CodeQL analyses code that does not ship.
+          grep -q "define HTS_USEBROTLI 1" config.h
+          grep -q "define HTS_USEZSTD 1" config.h
           make -j"$(nproc)"
 
       - uses: github/codeql-action/analyze@v4.37.7

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,8 @@ EXTRA_DIST = INSTALL.Linux \
 		tools/Info.plist.in tools/HTTrack.icns \
 		bootstrap build.sh doc/winprofile-ini.md \
 		winprofile-keys.tsv winprofile-escapes.tsv \
-		tools/gen-winprofile-keys.py
+		tools/gen-winprofile-keys.py \
+		tools/doc-chrome.py
 
 # Build the signed Debian packages from a clean source export. Pass the signing
 # key and other options through DEB_FLAGS, e.g.:

--- a/configure.ac
+++ b/configure.ac
@@ -631,6 +631,19 @@ AC_SUBST([TESTS_LIST])
 AC_MSG_RESULT([$hts_ntests])
 test "$hts_ntests" -gt 0 || AC_MSG_ERROR([no test script matched tests/[[0-9]]*_*.test])
 
+# Same for the fuzz corpus, for the same reason: automake expands no EXTRA_DIST glob.
+AC_MSG_CHECKING([for fuzz corpus files])
+FUZZ_CORPUS_LIST=
+hts_ncorpus=0
+for hts_c in "$srcdir"/fuzz/corpus/*/*; do
+	test -f "$hts_c" || continue
+	FUZZ_CORPUS_LIST="$FUZZ_CORPUS_LIST `echo "$hts_c" | sed 's|.*/corpus/|corpus/|'`"
+	hts_ncorpus=`expr $hts_ncorpus + 1`
+done
+AC_SUBST([FUZZ_CORPUS_LIST])
+AC_MSG_RESULT([$hts_ncorpus])
+test "$hts_ncorpus" -gt 0 || AC_MSG_ERROR([no fuzz corpus file matched fuzz/corpus/*/*])
+
 # Final output
 AC_CONFIG_FILES([
 Makefile

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -35,33 +35,5 @@ fuzz_sitemap_SOURCES = fuzz-sitemap.c fuzz.h
 fuzz_arc_SOURCES = fuzz-arc.c fuzz.h $(top_srcdir)/src/proxy/store.c
 fuzz_arc_CPPFLAGS = $(AM_CPPFLAGS) -DZLIB_CONST
 
-# List corpus files explicitly: automake does not expand EXTRA_DIST globs.
-EXTRA_DIST = README.md run-fuzzers.sh \
-	corpus/charset/utf8.txt corpus/charset/latin1.txt corpus/charset/sjis.txt \
-	corpus/meta/meta-charset.html corpus/meta/meta-http-equiv.html \
-	corpus/idna/idna.txt corpus/idna/unicode.txt \
-	corpus/idna/regress-multilabel-leak.txt \
-	corpus/entities/entities.txt \
-	corpus/unescape/percent.txt \
-	corpus/filters/filter.bin corpus/filters/filter-size.bin \
-	corpus/filters/regress-empty-subject-unique.bin \
-	corpus/filters/redos-star-classes.bin \
-	corpus/filters/regress-classdepth-timeout.bin \
-	corpus/url/http-url.txt corpus/url/relative-path.txt \
-	corpus/url/regress-file-empty-path.txt corpus/url/regress-long-path-abort.txt \
-	corpus/header/full-response.txt corpus/header/redirect.txt \
-	corpus/cachendx/new-format.txt corpus/cachendx/old-format.txt \
-	corpus/cachendx/regress-overadvance.bin \
-	corpus/cachendx/regress-truncated-entry.bin \
-	corpus/htsparse/basic.html corpus/htsparse/script-inscript.html \
-	corpus/htsparse/meta-usemap.html corpus/htsparse/malformed.html \
-	corpus/singlefile/img-src.html corpus/singlefile/link-rel.html \
-	corpus/singlefile/style-block.html corpus/singlefile/style-attr.html \
-	corpus/singlefile/srcset.html corpus/singlefile/rawtext.html \
-	corpus/singlefile/malformed.html \
-	corpus/singlefile/mark-at-eof.html corpus/singlefile/mark-only.html \
-	corpus/singlefile/mark-degenerate.html corpus/singlefile/traversal.html \
-	corpus/sitemap/urlset.xml corpus/sitemap/sitemapindex.xml \
-	corpus/sitemap/truncated.xml corpus/sitemap/urlset.xml.gz \
-	corpus/arc/roundtrip.arc corpus/arc/truncated.arc \
-	corpus/arc/regress-null-body.arc
+# Corpus list comes from configure: automake does not expand EXTRA_DIST globs.
+EXTRA_DIST = README.md run-fuzzers.sh $(FUZZ_CORPUS_LIST)

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -36,4 +36,4 @@ fuzz_arc_SOURCES = fuzz-arc.c fuzz.h $(top_srcdir)/src/proxy/store.c
 fuzz_arc_CPPFLAGS = $(AM_CPPFLAGS) -DZLIB_CONST
 
 # Corpus list comes from configure: automake does not expand EXTRA_DIST globs.
-EXTRA_DIST = README.md run-fuzzers.sh $(FUZZ_CORPUS_LIST)
+EXTRA_DIST = README.md run-fuzzers.sh check-corpus-list.sh $(FUZZ_CORPUS_LIST)

--- a/fuzz/check-corpus-list.sh
+++ b/fuzz/check-corpus-list.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# configure globs fuzz/corpus/*/* into FUZZ_CORPUS_LIST, the only thing that
+# ships the vectors in a tarball. The glob carries no oracle, so a file nobody
+# git-added, one sitting a level deeper, or one whose name make would split
+# leaves a smaller corpus with no complaint (three were missing that way).
+
+set -euo pipefail
+export LC_ALL=C
+
+corpusdir=$(cd "${1:-$(dirname "$0")/corpus}" && pwd)
+
+status=0
+bad() {
+    echo "$*" >&2
+    status=1
+}
+
+present=""
+count=0
+shopt -s nullglob dotglob
+for f in "$corpusdir"/*/*; do
+    name=${f#"$corpusdir"/}
+    if [ ! -f "$f" ]; then
+        # configure skips it, so a directory here means vectors a level deeper
+        bad "not a regular file, so the vectors under it never ship: $name"
+    elif [[ $name == *[[:space:]]* ]]; then
+        # configure joins the paths with spaces, so make sees two words.
+        bad "whitespace in the name, which make would split in two: $name"
+    else
+        present="${present}${name}"$'\n'
+        count=$((count + 1))
+    fi
+done
+# a vector parked at the top level matches no glob and ships nowhere
+for f in "$corpusdir"/*; do
+    test -f "$f" || continue
+    bad "directly under corpus/, outside the corpus/*/* glob: ${f#"$corpusdir"/}"
+done
+shopt -u nullglob dotglob
+
+# Floor: an empty corpus/ would satisfy every check above.
+[ "$count" -gt 0 ] || bad "no fuzz vector matched corpus/*/* under $corpusdir"
+
+# Nothing tracked means a tarball, where there is no oracle to apply. A git
+# that cannot answer is not the same as an empty listing, so say which.
+if ! command -v git >/dev/null 2>&1 || ! git -C "$corpusdir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    tracked=""
+    echo "note: no git checkout here that git can read, skipping the tracked-set check" >&2
+else
+    tracked=$(git -C "$corpusdir" ls-files -- '*/*')
+fi
+if [ -n "$tracked" ]; then
+    untracked=$(comm -13 <(sort <<<"$tracked") <(printf '%s' "$present" | sort))
+    [ -z "$untracked" ] || bad "untracked, so the tarball would ship without them: $untracked"
+    gone=$(comm -23 <(sort <<<"$tracked") <(printf '%s' "$present" | sort))
+    [ -z "$gone" ] || bad "tracked but absent, so the corpus is short of them: $gone"
+fi
+
+if [ "$status" -eq 0 ]; then
+    echo "$count fuzz corpus files, all tracked and reachable by the glob"
+fi
+exit "$status"

--- a/tests/271_doc-chrome-year.test
+++ b/tests/271_doc-chrome-year.test
@@ -13,13 +13,16 @@ srcdir="${abs_top_srcdir:?not run under make check}"
 chrome_src="${srcdir}/tools/doc-chrome.py"
 
 command -v python3 >/dev/null 2>&1 || skip "no python3"
-test -r "${chrome_src}" || skip "no ${chrome_src}"
+# Missing is fatal, never a skip: a dist that drops it has to red here.
+test -r "${chrome_src}" || fail "missing ${chrome_src}"
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/docyear.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "${work}"
 
 # doc-chrome.py finds html/ relative to its own path, so it needs both trees.
 cp -a "${srcdir}/tools" "${srcdir}/html" "${work}/"
+# distcheck hands out a read-only srcdir, and cp -a copies the mode along.
+chmod -R u+w "${work}"
 chrome="${work}/tools/doc-chrome.py"
 page="${work}/html/index.html"
 


### PR DESCRIPTION
Four places where CI checked less than it looked like it did.

CodeQL installs its own build dependencies and had neither `libbrotli-dev` nor `libzstd-dev`. Codec detection defaults to auto, so `HTS_USEBROTLI` and `HTS_USEZSTD` came out 0 and the security scan never saw the `br` or `zstd` decoders, directly under a comment saying it builds exactly what ships. The `ubuntu-24.04` image has the runtime libraries but not the headers. It now installs both packages and asserts the two macros in `config.h`, the way `ci.yml` already does.

The fuzz corpus and the shell-script lint list were hand-kept and had both drifted. `fuzz/Makefile.am` named 47 of the 50 tracked vectors, so `meta-content-first.html`, `meta-truncated.html` and `meta-unquoted.html` never reached a `make dist` tarball; `configure` now globs them as it already globs `TESTS`, automake expanding no `EXTRA_DIST` glob. `fuzz/run-fuzzers.sh` was the one tracked shell script outside shellcheck and shfmt (clean today, so this is about drift, not a red), and the list now comes from `git ls-files` plus a shebang scan for the extensionless ones, like the neighbouring Python step. Neither derivation accepts an empty list, and the `lint (shellcheck, shfmt)` check name is untouched.

`tools/doc-chrome.py` was missing from `EXTRA_DIST`, so `271_doc-chrome-year` skipped itself inside distcheck rather than running. Shipping it exposed what the skip had hidden: distcheck hands out a read-only srcdir and `cp -a` carries the mode over, so the tree the test edits was unwritable and it had never really run there. A missing input is now fatal as in `324`, and the copy is made writable.

Each of these was measured, not inferred: `config.h` with and without the dev packages (1/1 against 0/0), the tarball before and after (47 against 50 corpus files, `doc-chrome.py` now present), the derived script list against the old globs (identical plus `run-fuzzers.sh`), and `271` against a read-only unpacked tarball, where the old test exits 77 and the fixed one passes.
