### PR TITLE
A cache size the reader cannot hold reaches malloc()

### DIFF
--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -1228,9 +1228,9 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
             }
           }
 
-          /* Corrupt: negative, wider than the reader holds, or claiming more
-             zip data than the 32-bit write API could store. A headers-only
-             entry above INT_MAX is legitimate. Mirrors htscache.c. */
+          /* Corrupt: negative, or in-cache at or above what the 32-bit zip
+             writer could store. A headers-only entry above INT_MAX is
+             legitimate; one wider than size_t is refused, not truncated. */
           if (declared_size < 0 ||
               (LLint) (size_t) declared_size != declared_size ||
               (dataincache && declared_size >= INT_MAX)) {

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -926,6 +926,15 @@ static PT_Element PT_ReadCache__New(PT_Index index, const char *url, int flags) 
     line[0] = '\0'; \
 	} \
 } while(0)
+#define ZIP_READFIELD_LLINT(line, value, refline, refvalue)                    \
+  do {                                                                         \
+    if (line[0] != '\0' && strfield2(line, refline)) {                         \
+      LLint intval = 0;                                                        \
+      sscanf(value, LLintP, &intval);                                          \
+      (refvalue) = intval;                                                     \
+      line[0] = '\0';                                                          \
+    }                                                                          \
+  } while (0)
 
 /* Set path (capacity size) to filename's parent directory, separator included,
    from an absolute filename. Empty when there is none, or when it would not
@@ -1098,6 +1107,8 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
         char headerBuff[8192 + 2];
         int readSizeHeader;
         int dataincache = 0;
+        /* signed, so a corrupt value is judged before it becomes a size_t */
+        LLint declared_size = 0;
 
         /* For BIG comments */
         headerBuff[0]
@@ -1135,7 +1146,7 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
               ZIP_READFIELD_INT(line, value, "X-Statuscode", r->statuscode);
               ZIP_READFIELD_STRING(line, value, "X-StatusMessage", r->msg,
                                    sizeof(r->msg));
-              ZIP_READFIELD_INT(line, value, "X-Size", r->size);        // size
+              ZIP_READFIELD_LLINT(line, value, "X-Size", declared_size); // size
               ZIP_READFIELD_STRING(line, value, "Content-Type", r->contenttype,
                                    sizeof(r->contenttype));
               ZIP_READFIELD_STRING(line, value, "X-Charset", r->charset,
@@ -1215,6 +1226,18 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
                          index->path, previous_save_);
               }
             }
+          }
+
+          /* Corrupt: negative, wider than the reader holds, or claiming more
+             zip data than the 32-bit write API could store. A headers-only
+             entry above INT_MAX is legitimate. Mirrors htscache.c. */
+          if (declared_size < 0 ||
+              (LLint) (size_t) declared_size != declared_size ||
+              (dataincache && declared_size >= INT_MAX)) {
+            r->statuscode = STATUSCODE_INVALID;
+            strcpybuff(r->msg, "Cache Read Error : Bad Size");
+          } else {
+            r->size = (size_t) declared_size;
           }
 
           /* Complete fields */
@@ -1356,7 +1379,7 @@ static int PT_SaveCache__New_Fun(void *arg, const char *url, PT_Element element)
   ZIP_FIELD_STRING(headers, headersSize, headersDropped, "X-StatusMessage",
                    element->msg);
   ZIP_FIELD_INT(headers, headersSize, headersDropped, "X-Size",
-                (int) body_size); // size
+                body_size); // size
   ZIP_FIELD_STRING(headers, headersSize, headersDropped, "Content-Type",
                    element->contenttype); // contenttype
   ZIP_FIELD_STRING(headers, headersSize, headersDropped, "X-Charset",

--- a/tests/347_local-proxytrack-cache-size.test
+++ b/tests/347_local-proxytrack-cache-size.test
@@ -1,0 +1,82 @@
+#!/bin/bash
+# X-Size rides the new.zip header block as a signed 64-bit value, and the proxy
+# hands it straight to malloc(): a negative one becomes SIZE_MAX and overflows
+# the allocation. The sanitizer CI build turns a regression into a hard heap
+# overflow; here the reader's verdict stands in for it.
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+# shellcheck source=tests/arclib.sh
+. "${0%"${0##*/}"}./arclib.sh"
+
+dir=$(mktemp -d)
+cleanup_push rm -rf "$dir"
+
+BODY='<html>hi</html>'
+# a forged X-Size must keep the block's byte length, which the zip's extra-field
+# header declares, so give the writer a long field to overwrite
+etag=$(printf '%0.sE' $(seq 1 60))
+etagline="Etag: \"$etag\""
+printf 'HTTP/1.0 200 OK\r\nContent-type: text/html\r\nEtag: "%s"\r\nContent-length: %d\r\n\r\n' \
+    "$etag" ${#BODY} >"$dir/hdr"
+printf '%s' "$BODY" >"$dir/body"
+{
+    arc_filedesc
+    arc_record http://example.com/p.html text/html 200 "$dir/hdr" "$dir/body"
+} >"$dir/in.arc"
+
+proxytrack --convert "$dir/good.zip" "$dir/in.arc" >/dev/null 2>&1 ||
+    fail "proxytrack died writing the cache"
+
+# overwrite a literal in place; same length, so every zip offset still holds
+poke() {
+    local file=$1 needle=$2 repl=$3 offs
+    test ${#needle} -eq ${#repl} ||
+        fail "poke: '$needle' and the replacement differ in length"
+    offs=$(grep -abo -F -- "$needle" "$file") || fail "poke: '$needle' not in $file"
+    printf '%s' "$repl" |
+        dd of="$file" bs=1 seek="${offs%%:*}" conv=notrunc 2>/dev/null
+}
+
+# the parser keeps the last X-Size it sees, so the forged line replaces the Etag
+# and a colon-free tail, which the parser skips, pads it back out
+forge_size() {
+    local out=$1 value=$2 line pad
+    cp "$dir/good.zip" "$out"
+    line="X-Size: $value"$'\r\n'
+    pad=$(printf "%$((${#etagline} - ${#line}))s" '' | tr ' ' 'E')
+    poke "$out" "$etagline" "$line$pad"
+}
+
+read_back() {
+    proxytrack --convert "$dir/out.arc" "$1" >/dev/null 2>&1 ||
+        fail "proxytrack died reading $1"
+}
+
+# control: without it, a fix that rejected every entry would pass the rest
+read_back "$dir/good.zip"
+grep -qF "$BODY" "$dir/out.arc" || fail "an untouched cache lost its body"
+
+forge_size "$dir/neg.zip" -1
+read_back "$dir/neg.zip"
+grep -q 'Bad Size' "$dir/out.arc" || fail "a negative X-Size was accepted"
+if grep -qF "$BODY" "$dir/out.arc"; then
+    fail "a negative X-Size still returned a body"
+fi
+
+# in-zip data cannot exceed what the 32-bit zip write API stored
+forge_size "$dir/big.zip" 2147483648
+read_back "$dir/big.zip"
+grep -q 'Bad Size' "$dir/out.arc" || fail "an oversized in-cache X-Size was accepted"
+
+# but a headers-only entry legitimately carries one (>2GB body on disk), and
+# refusing it would re-fetch that file on every update
+forge_size "$dir/hdronly.zip" 2147483648
+poke "$dir/hdronly.zip" 'X-In-Cache: 1' 'X-In-Cache: 0'
+read_back "$dir/hdronly.zip"
+if grep -q 'Bad Size' "$dir/out.arc"; then
+    fail "a headers-only X-Size above INT_MAX was refused"
+fi
+
+exit 0

--- a/tests/347_local-proxytrack-cache-size.test
+++ b/tests/347_local-proxytrack-cache-size.test
@@ -1,8 +1,7 @@
 #!/bin/bash
-# X-Size rides the new.zip header block as a signed 64-bit value, and the proxy
-# hands it straight to malloc(): a negative one becomes SIZE_MAX and overflows
-# the allocation. The sanitizer CI build turns a regression into a hard heap
-# overflow; here the reader's verdict stands in for it.
+# X-Size rides the cache as a signed 64-bit value, and the proxy hands it to
+# malloc(): a negative one becomes SIZE_MAX and the body inflates into the
+# 1-byte allocation that follows. Cases mirror htscache_selftest.c's.
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
@@ -12,6 +11,10 @@ set -euo pipefail
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
+
+bad_size='Bad Size'   # the reader's verdict on a size it refuses
+at_int_max=2147483647 # the >= boundary: the zip write API takes an int
+over_int_max=2147483648
 
 BODY='<html>hi</html>'
 # a forged X-Size must keep the block's byte length, which the zip's extra-field
@@ -35,12 +38,15 @@ poke() {
     test ${#needle} -eq ${#repl} ||
         fail "poke: '$needle' and the replacement differ in length"
     offs=$(grep -abo -F -- "$needle" "$file") || fail "poke: '$needle' not in $file"
+    # a second hit would leave the others in place and forge nothing
+    test "$(printf '%s\n' "$offs" | wc -l)" -eq 1 ||
+        fail "poke: '$needle' is not unique in $file"
     printf '%s' "$repl" |
         dd of="$file" bs=1 seek="${offs%%:*}" conv=notrunc 2>/dev/null
 }
 
-# the parser keeps the last X-Size it sees, so the forged line replaces the Etag
-# and a colon-free tail, which the parser skips, pads it back out
+# the parser keeps the last X-Size seen, so the forged line replaces the Etag;
+# the colon-free pad after it is skipped, restoring the block's length
 forge_size() {
     local out=$1 value=$2 line pad
     cp "$dir/good.zip" "$out"
@@ -60,23 +66,33 @@ grep -qF "$BODY" "$dir/out.arc" || fail "an untouched cache lost its body"
 
 forge_size "$dir/neg.zip" -1
 read_back "$dir/neg.zip"
-grep -q 'Bad Size' "$dir/out.arc" || fail "a negative X-Size was accepted"
+grep -q "$bad_size" "$dir/out.arc" || fail "a negative X-Size was accepted"
 if grep -qF "$BODY" "$dir/out.arc"; then
     fail "a negative X-Size still returned a body"
 fi
 
-# in-zip data cannot exceed what the 32-bit zip write API stored
-forge_size "$dir/big.zip" 2147483648
-read_back "$dir/big.zip"
-grep -q 'Bad Size' "$dir/out.arc" || fail "an oversized in-cache X-Size was accepted"
+# in-zip data cannot exceed what the 32-bit zip write API stored, and INT_MAX
+# itself is out: reading it back would overflow the (int) the reader passes
+for value in "$over_int_max" "$at_int_max"; do
+    forge_size "$dir/big-$value.zip" "$value"
+    read_back "$dir/big-$value.zip"
+    grep -q "$bad_size" "$dir/out.arc" ||
+        fail "an in-cache X-Size of $value was accepted"
+done
 
-# but a headers-only entry legitimately carries one (>2GB body on disk), and
-# refusing it would re-fetch that file on every update
-forge_size "$dir/hdronly.zip" 2147483648
+# a headers-only entry legitimately claims >2GB, and refusing it would re-fetch
+# that file on every update; a negative one is still corrupt
+forge_size "$dir/hdronly.zip" "$over_int_max"
 poke "$dir/hdronly.zip" 'X-In-Cache: 1' 'X-In-Cache: 0'
 read_back "$dir/hdronly.zip"
-if grep -q 'Bad Size' "$dir/out.arc"; then
-    fail "a headers-only X-Size above INT_MAX was refused"
+if grep -q "$bad_size" "$dir/out.arc"; then
+    fail "a headers-only X-Size of $over_int_max was refused"
 fi
+
+forge_size "$dir/hdrneg.zip" -1
+poke "$dir/hdrneg.zip" 'X-In-Cache: 1' 'X-In-Cache: 0'
+read_back "$dir/hdrneg.zip"
+grep -q "$bad_size" "$dir/out.arc" ||
+    fail "a headers-only negative X-Size was accepted"
 
 exit 0


### PR DESCRIPTION
ProxyTrack read the cache's X-Size field with `sscanf("%d")` into an `int` and assigned the result to a `size_t`, with none of the validation `htscache.c` applies to the same field. `X-Size: -1` became `SIZE_MAX`, `malloc(SIZE_MAX + 1)` returned a one-byte buffer, and the entry's body was inflated straight into it, a heap overflow whose size the cache file controls. Confirmed under ASan against a clean control. The negative check is the term that closes it: drop it and the overflow comes back.

The width matters on its own too. The engine writes X-Size as signed 64-bit, and a headers-only entry legitimately carries one above INT_MAX, which is how it records a body over 2GB kept on disk. Read through `%d` that wrapped to INT_MIN, so ProxyTrack could not use those entries at all.

The fix decodes into a signed 64-bit local and judges it before it becomes a `size_t`, rejecting a negative value, one the reader cannot hold (32-bit builds), and one claiming more zip data than the 32-bit write API could have stored. Same three cases `htscache.c` rejects. The writer's `(int)` cast goes as well: `ZIP_FIELD_INT` already casts to `LLint` and prints with `LLintP`, so the call site was the only truncation left. Valid caches decode identically and re-encode byte-identically, so nothing on disk changes.

`tests/347` forges same-length X-Size lines into a real cache. The block's byte length is declared by the zip's extra field, so the forgery has to preserve it. The test fails on the pre-fix binary, and its headers-only case kills the obvious over-fix that rejects everything above INT_MAX.

Found by the factorization sweep, which flagged the field-width divergence. The missing validation turned up while proving it.
