### PR TITLE
An update purge deletes the children of a page that failed to fetch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,11 @@ Before pushing, and when reviewing others, don't skim for bugs:
 - **Audit tests against the spec, not the code.** For each new test ask: "what
   buggy path would still pass this?" If you can build one, the test is
   confirmation-biased: assertions copied from observed output lock bugs in.
+- **A green suite is not evidence the old behavior was chosen.** A test can be
+  written from the same mental model as the code and pin the defect as
+  intended: `htsdns_selftest.c` asserted the never-re-resolve bug #1392 fixes,
+  and a purge guard firing on any dead link passed all 372 tests. When a fix
+  makes you invert an existing assertion, that inversion is the finding.
 - **Risk areas need runtime probes.** Touching hostile-input parsing, struct
   layout/ABI, cache/wire format, or a security path? A static or unit check
   isn't enough; exercise the wrong behavior at runtime. Claude Code:

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -765,9 +765,7 @@ void back_refetch_backup(httrackp *opt, lien_back *const back) {
   }
 }
 
-/* Did the fetch fail to produce a response, as opposed to the engine
-   deliberately passing the resource over? Only the latter may be purged. */
-static hts_boolean back_transfer_failed(const int statuscode) {
+hts_boolean back_transfer_failed(const int statuscode) {
   switch (statuscode) {
   case STATUSCODE_TOO_BIG:
   case STATUSCODE_EXCLUDED:

--- a/src/htsback.h
+++ b/src/htsback.h
@@ -138,6 +138,10 @@ int back_trylive(httrackp * opt, cache_back * cache, struct_back * sback,
                  const int p);
 int back_finalize(httrackp * opt, cache_back * cache, struct_back * sback,
                   const int p);
+/* Did the fetch fail to produce a response, as opposed to the engine
+   deliberately passing the resource over? Only the latter may be purged, so
+   this also decides whether the previous copy survives the update (#746). */
+hts_boolean back_transfer_failed(const int statuscode);
 /* Move the previous copy of back->url_sav to back->tmpfile so back_finalize()
    can put it back when the re-fetch fails (#77 follow-up). Call right before
    truncating url_sav; tmpfile stays NULL when there is nothing to save. */

--- a/src/htschanges.c
+++ b/src/htschanges.c
@@ -548,7 +548,8 @@ static void changes_serialize(httrackp *opt, String *out) {
   StringCat(*out, ",\n  \"partial\": ");
   StringCat(*out, changes->overflow ? "true" : "false");
   StringCat(*out, ",\n  \"purged\": ");
-  StringCat(*out, opt->delete_old ? "true" : "false");
+  /* links_unqueued holds the purge back for the whole run */
+  StringCat(*out, opt->delete_old && !opt->links_unqueued ? "true" : "false");
 
   StringCat(*out, ",\n  \"counts\": {");
   for (bucket = 0; bucket < HTS_CHANGE_BUCKETS; bucket++) {

--- a/src/htschanges.c
+++ b/src/htschanges.c
@@ -548,7 +548,7 @@ static void changes_serialize(httrackp *opt, String *out) {
   StringCat(*out, ",\n  \"partial\": ");
   StringCat(*out, changes->overflow ? "true" : "false");
   StringCat(*out, ",\n  \"purged\": ");
-  /* links_unqueued holds the purge back for the whole run */
+  /* a held-back purge deleted nothing, whatever --purge-old asked for */
   StringCat(*out, opt->delete_old && !opt->links_unqueued ? "true" : "false");
 
   StringCat(*out, ",\n  \"counts\": {");

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -2118,13 +2118,6 @@ int httpmirror(char *url1, httrackp * opt) {
          new.lst, so their absence says nothing about the site. */
       const hts_boolean purge_files = opt->delete_old && !opt->links_unqueued;
 
-      if (opt->delete_old && !purge_files) {
-        hts_log_print(opt, LOG_WARNING,
-                      "A page could not be fetched and the links it carries "
-                      "were never scanned: keeping all previously mirrored "
-                      "files");
-      }
-
       hts_changes_indexed(opt);
       //
       opt->state._hts_in_html_parsing = 3;
@@ -2133,6 +2126,12 @@ int httpmirror(char *url1, httrackp * opt) {
                               StringBuff(opt->path_log), "hts-cache/old.lst"),
                       "rb");
       if (old_lst) {
+        if (opt->delete_old && !purge_files) {
+          hts_log_print(opt, LOG_WARNING,
+                        "A page could not be fetched and the links it carries "
+                        "were never scanned: keeping all previously mirrored "
+                        "files");
+        }
         const size_t sz = llint_to_size_t(fsize_utf8(
             fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
                     StringBuff(opt->path_log), "hts-cache/new.lst")));

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -2110,6 +2110,18 @@ int httpmirror(char *url1, httrackp * opt) {
     } else if (opt->delete_old || opt->changes) {
       FILE *old_lst, *new_lst;
 
+      /* A page that gave up before it could be parsed leaves the links it
+         carries out of new.lst, so their absence says nothing about the site:
+         report the difference, delete none of it. */
+      const hts_boolean purge_files = opt->delete_old && !opt->links_unqueued;
+
+      if (opt->delete_old && !purge_files) {
+        hts_log_print(opt, LOG_WARNING,
+                      "A page could not be fetched and the links it carries "
+                      "were never scanned: keeping all previously mirrored "
+                      "files");
+      }
+
       hts_changes_indexed(opt);
       //
       opt->state._hts_in_html_parsing = 3;
@@ -2154,13 +2166,12 @@ int httpmirror(char *url1, httrackp * opt) {
                        is about to be purged, its previous copy stands and the
                        file is not gone. */
                     const hts_boolean kept =
-                        !opt->delete_old &&
-                        hash_read(opt->hash, file, NULL,
-                                  HASH_STRUCT_FILENAME) >= 0;
+                        !purge_files && hash_read(opt->hash, file, NULL,
+                                                  HASH_STRUCT_FILENAME) >= 0;
 
                     hts_changes_dropped(
                         opt, file + StringLength(opt->path_html), kept);
-                    if (opt->delete_old) {
+                    if (purge_files) {
                       hts_log_print(opt, LOG_INFO, "Purging %s", file);
                       UNLINK(file);
                       purge = 1;
@@ -2168,7 +2179,7 @@ int httpmirror(char *url1, httrackp * opt) {
                   }
                 }
               }
-              if (opt->delete_old) { // emptied directories go with the files
+              if (purge_files) { // emptied directories go with the files
                 fseek(old_lst, 0, SEEK_SET);
                 while(!feof(old_lst)) {
                   linput(old_lst, line, 1000);
@@ -2201,7 +2212,7 @@ int httpmirror(char *url1, httrackp * opt) {
                 }
               }
               //
-              if (opt->delete_old && !purge) {
+              if (purge_files && !purge) {
                 hts_log_print(opt, LOG_INFO, "No files purged");
               }
             }

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -537,6 +537,10 @@ int httpmirror(char *url1, httrackp * opt) {
   opt->robotsptr = &robots;
   //
 
+  /* per mirror, not per opt: an embedder reusing one opt would otherwise
+     carry the last run's verdict and never purge again */
+  opt->links_unqueued = HTS_FALSE;
+
   // noter heure actuelle de départ en secondes
   memset(&HTS_STAT, 0, sizeof(HTS_STAT));
   HTS_STAT.stat_timestart = time_local();
@@ -2110,9 +2114,8 @@ int httpmirror(char *url1, httrackp * opt) {
     } else if (opt->delete_old || opt->changes) {
       FILE *old_lst, *new_lst;
 
-      /* A page that gave up before it could be parsed leaves the links it
-         carries out of new.lst, so their absence says nothing about the site:
-         report the difference, delete none of it. */
+      /* A page that gave up before parsing keeps its own links out of
+         new.lst, so their absence says nothing about the site. */
       const hts_boolean purge_files = opt->delete_old && !opt->links_unqueued;
 
       if (opt->delete_old && !purge_files) {

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -6401,6 +6401,7 @@ HTSEXT_API httrackp *hts_create_opt(void) {
   opt->single_file = HTS_FALSE;
   opt->single_file_max_size = SINGLEFILE_DEFAULT_MAX_SIZE;
   opt->singlefile_state = NULL;
+  opt->links_unqueued = HTS_FALSE;
   StringCopy(opt->why_url, "");
   opt->pause_min_ms = 0;
   opt->pause_max_ms = 0;

--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -574,11 +574,10 @@ struct httrackp {
   int wizard_filters; /**< count of filters the wizard has inserted, held at the
                            low indices of the array. Live state, so copy_htsopt
                            must leave it alone. Tail: ABI */
-  hts_boolean links_unqueued; /**< a page gave up before it could be parsed, so
-                                   the links it carries were never queued and
-                                   the update purge would take what they point
-                                   at. Live state, so copy_htsopt must leave it
-                                   alone. Tail: ABI */
+  hts_boolean links_unqueued; /**< a page gave up before parsing, so its links
+                                   were never queued and the update purge would
+                                   treat them as gone. Live state, so
+                                   copy_htsopt must leave it alone. Tail: ABI */
 };
 
 /* Running statistics for a mirror. */

--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -574,6 +574,11 @@ struct httrackp {
   int wizard_filters; /**< count of filters the wizard has inserted, held at the
                            low indices of the array. Live state, so copy_htsopt
                            must leave it alone. Tail: ABI */
+  hts_boolean links_unqueued; /**< a page gave up before it could be parsed, so
+                                   the links it carries were never queued and
+                                   the update purge would take what they point
+                                   at. Live state, so copy_htsopt must leave it
+                                   alone. Tail: ABI */
 };
 
 /* Running statistics for a mirror. */

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -3555,8 +3555,7 @@ hts_boolean hts_redirect_same_savefile(httrackp *opt, const char *cur_adr,
 }
 
 /* Could this link have carried links of its own? Its own answer first, then
-   what the previous run recorded for it, then the name that run saved it
-   under. */
+   what the previous run recorded for it, then the name it saved it under. */
 static hts_boolean hts_link_may_carry_links(httrackp *opt, cache_back *cache,
                                             const htsblk *r, const char *adr,
                                             const char *fil, const char *save) {
@@ -3928,12 +3927,8 @@ int hts_mirror_check_moved(htsmoduleStruct * str,
             }
           }
 
-          /* Retries are gone and the page was never parsed, so the links it
-             carries were never queued: they are missing from new.lst through
-             no fault of the site, and the purge must not read that as gone.
-             A failure this side of the headers leaves no content type; what
-             the previous run cached for this URL is the better evidence, and
-             a link it never mirrored has no children in old.lst anyway. */
+          /* The page failed every retry before it could be parsed, so its
+             links are missing from new.lst though the site still has them. */
           if (can_retry && !heap(ptr)->testmode &&
               hts_link_may_carry_links(opt, cache, r, urladr(), urlfil(),
                                        savename())) {

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -3554,6 +3554,24 @@ hts_boolean hts_redirect_same_savefile(httrackp *opt, const char *cur_adr,
   return strcasecmp(n_fil, pn_fil) == 0;
 }
 
+/* Could this link have carried links of its own? Its own answer first, then
+   what the previous run recorded for it, then the name that run saved it
+   under. */
+static hts_boolean hts_link_may_carry_links(httrackp *opt, cache_back *cache,
+                                            const htsblk *r, const char *adr,
+                                            const char *fil, const char *save) {
+  if (strnotempty(r->contenttype))
+    return is_hypertext_mime(opt, r->contenttype, fil) ? HTS_TRUE : HTS_FALSE;
+  {
+    const htsblk prev = cache_read_including_broken(opt, cache, adr, fil, NULL);
+
+    if (prev.statuscode > 0 && strnotempty(prev.contenttype))
+      return is_hypertext_mime(opt, prev.contenttype, save) ? HTS_TRUE
+                                                            : HTS_FALSE;
+  }
+  return ishtml(opt, save) == 1 ? HTS_TRUE : HTS_FALSE;
+}
+
 /*
 Check 301, 302, .. statuscodes (moved)
 */
@@ -3908,6 +3926,18 @@ int hts_mirror_check_moved(htsmoduleStruct * str,
                */
               HTS_STAT.stat_errors_front++;
             }
+          }
+
+          /* Retries are gone and the page was never parsed, so the links it
+             carries were never queued: they are missing from new.lst through
+             no fault of the site, and the purge must not read that as gone.
+             A failure this side of the headers leaves no content type; what
+             the previous run cached for this URL is the better evidence, and
+             a link it never mirrored has no children in old.lst anyway. */
+          if (can_retry && !heap(ptr)->testmode &&
+              hts_link_may_carry_links(opt, cache, r, urladr(), urlfil(),
+                                       savename())) {
+            opt->links_unqueued = HTS_TRUE;
           }
 
         } else { // retry, or a refused-resume restart

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -3554,21 +3554,20 @@ hts_boolean hts_redirect_same_savefile(httrackp *opt, const char *cur_adr,
   return strcasecmp(n_fil, pn_fil) == 0;
 }
 
-/* Could this link have carried links of its own? What the previous run
-   recorded decides, since the files at risk are the ones it wrote, and a
-   content type on an error reply describes the error page. Failing that, this
-   reply, then the name the link was saved under. */
+/* Does this link have a mirrored subtree the purge could take? Only a previous
+   run's successful fetch does; a link never mirrored endangers nothing. */
 static hts_boolean hts_link_may_carry_links(httrackp *opt, cache_back *cache,
-                                            const htsblk *r, const char *adr,
-                                            const char *fil, const char *save) {
-  const htsblk prev = cache_read_including_broken(opt, cache, adr, fil, NULL);
+                                            const char *adr, const char *fil) {
+  char BIGSTK prev_save[HTS_URLMAXSIZE * 2];
+  htsblk prev;
 
-  if (prev.statuscode > 0 && strnotempty(prev.contenttype))
-    return is_hypertext_mime(opt, prev.contenttype, save) ? HTS_TRUE
-                                                          : HTS_FALSE;
-  if (strnotempty(r->contenttype))
-    return is_hypertext_mime(opt, r->contenttype, fil) ? HTS_TRUE : HTS_FALSE;
-  return ishtml(opt, save) == 1 ? HTS_TRUE : HTS_FALSE;
+  prev_save[0] = '\0'; /* a cache miss leaves it untouched */
+  prev = cache_read_including_broken(opt, cache, adr, fil, prev_save);
+
+  return HTTP_IS_OK(prev.statuscode) && strnotempty(prev_save) &&
+                 is_hypertext_mime(opt, prev.contenttype, prev_save)
+             ? HTS_TRUE
+             : HTS_FALSE;
 }
 
 /*
@@ -3821,7 +3820,6 @@ int hts_mirror_check_moved(htsmoduleStruct * str,
       }
     } else if (r->statuscode != HTTP_OK) {
       int can_retry = 0;
-      hts_boolean banned = HTS_FALSE;
 
       // cas où l'on peut reessayer
       switch (r->statuscode) {
@@ -3829,7 +3827,6 @@ int hts_mirror_check_moved(htsmoduleStruct * str,
         if (opt->hostcontrol) { // timeout et retry épuisés
           if ((opt->hostcontrol & HTS_HOSTCONTROL_BAN_TIMEOUT) &&
               (heap(ptr)->retry <= 0)) {
-            banned = HTS_TRUE;
             hts_log_print(opt, LOG_DEBUG, "Link banned: %s%s", urladr(), urlfil());
             host_ban(opt, ptr, sback, jump_identification_const(urladr()));
             hts_log_print(opt, LOG_DEBUG,
@@ -3843,7 +3840,6 @@ int hts_mirror_check_moved(htsmoduleStruct * str,
       case STATUSCODE_SLOW:
         if ((opt->hostcontrol) && (heap(ptr)->retry <= 0)) {   // too slow
           if (opt->hostcontrol & HTS_HOSTCONTROL_BAN_SLOW) {
-            banned = HTS_TRUE;
             hts_log_print(opt, LOG_DEBUG, "Link banned: %s%s", urladr(), urlfil());
             host_ban(opt, ptr, sback, jump_identification_const(urladr()));
             hts_log_print(opt, LOG_DEBUG,
@@ -3930,15 +3926,15 @@ int hts_mirror_check_moved(htsmoduleStruct * str,
             }
           }
 
-          /* Nothing here says the site dropped the links this page carries:
-             it ran out of retries, its host was banned, or a size cap cut the
-             transfer, all before the parser could queue them. */
-          const hts_boolean unanswered =
-              can_retry || banned || r->statuscode == STATUSCODE_TOO_BIG;
+          /* No response at all, so nothing here says the site dropped the
+             links this page carries. Same predicate as the one keeping the
+             previous copy (#746), and it must stay so: every file this run
+             preserves keeps its children. An answered error is not in it and
+             needs nothing, being recovered from the cache and re-parsed. */
+          const hts_boolean unanswered = back_transfer_failed(r->statuscode);
 
           if (unanswered && !heap(ptr)->testmode &&
-              hts_link_may_carry_links(opt, cache, r, urladr(), urlfil(),
-                                       savename())) {
+              hts_link_may_carry_links(opt, cache, urladr(), urlfil())) {
             opt->links_unqueued = HTS_TRUE;
           }
 

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -3554,20 +3554,20 @@ hts_boolean hts_redirect_same_savefile(httrackp *opt, const char *cur_adr,
   return strcasecmp(n_fil, pn_fil) == 0;
 }
 
-/* Could this link have carried links of its own? Its own answer first, then
-   what the previous run recorded for it, then the name it saved it under. */
+/* Could this link have carried links of its own? What the previous run
+   recorded decides, since the files at risk are the ones it wrote, and a
+   content type on an error reply describes the error page. Failing that, this
+   reply, then the name the link was saved under. */
 static hts_boolean hts_link_may_carry_links(httrackp *opt, cache_back *cache,
                                             const htsblk *r, const char *adr,
                                             const char *fil, const char *save) {
+  const htsblk prev = cache_read_including_broken(opt, cache, adr, fil, NULL);
+
+  if (prev.statuscode > 0 && strnotempty(prev.contenttype))
+    return is_hypertext_mime(opt, prev.contenttype, save) ? HTS_TRUE
+                                                          : HTS_FALSE;
   if (strnotempty(r->contenttype))
     return is_hypertext_mime(opt, r->contenttype, fil) ? HTS_TRUE : HTS_FALSE;
-  {
-    const htsblk prev = cache_read_including_broken(opt, cache, adr, fil, NULL);
-
-    if (prev.statuscode > 0 && strnotempty(prev.contenttype))
-      return is_hypertext_mime(opt, prev.contenttype, save) ? HTS_TRUE
-                                                            : HTS_FALSE;
-  }
   return ishtml(opt, save) == 1 ? HTS_TRUE : HTS_FALSE;
 }
 
@@ -3821,6 +3821,7 @@ int hts_mirror_check_moved(htsmoduleStruct * str,
       }
     } else if (r->statuscode != HTTP_OK) {
       int can_retry = 0;
+      hts_boolean banned = HTS_FALSE;
 
       // cas où l'on peut reessayer
       switch (r->statuscode) {
@@ -3828,6 +3829,7 @@ int hts_mirror_check_moved(htsmoduleStruct * str,
         if (opt->hostcontrol) { // timeout et retry épuisés
           if ((opt->hostcontrol & HTS_HOSTCONTROL_BAN_TIMEOUT) &&
               (heap(ptr)->retry <= 0)) {
+            banned = HTS_TRUE;
             hts_log_print(opt, LOG_DEBUG, "Link banned: %s%s", urladr(), urlfil());
             host_ban(opt, ptr, sback, jump_identification_const(urladr()));
             hts_log_print(opt, LOG_DEBUG,
@@ -3841,6 +3843,7 @@ int hts_mirror_check_moved(htsmoduleStruct * str,
       case STATUSCODE_SLOW:
         if ((opt->hostcontrol) && (heap(ptr)->retry <= 0)) {   // too slow
           if (opt->hostcontrol & HTS_HOSTCONTROL_BAN_SLOW) {
+            banned = HTS_TRUE;
             hts_log_print(opt, LOG_DEBUG, "Link banned: %s%s", urladr(), urlfil());
             host_ban(opt, ptr, sback, jump_identification_const(urladr()));
             hts_log_print(opt, LOG_DEBUG,
@@ -3927,9 +3930,13 @@ int hts_mirror_check_moved(htsmoduleStruct * str,
             }
           }
 
-          /* The page failed every retry before it could be parsed, so its
-             links are missing from new.lst though the site still has them. */
-          if (can_retry && !heap(ptr)->testmode &&
+          /* Nothing here says the site dropped the links this page carries:
+             it ran out of retries, its host was banned, or a size cap cut the
+             transfer, all before the parser could queue them. */
+          const hts_boolean unanswered =
+              can_retry || banned || r->statuscode == STATUSCODE_TOO_BIG;
+
+          if (unanswered && !heap(ptr)->testmode &&
               hts_link_may_carry_links(opt, cache, r, urladr(), urlfil(),
                                        savename())) {
             opt->links_unqueued = HTS_TRUE;

--- a/tests/348_local-update-purge-hubfail.test
+++ b/tests/348_local-update-purge-hubfail.test
@@ -2,8 +2,9 @@
 #
 # A page that fails to re-fetch on --update keeps its copy (#746), but its
 # children were never queued, so the purge unlinked them. hub.html, their only
-# parent, hangs up on pass 2. gone.html leaves the site on pass 3, where
-# nothing fails: purging it there says the purge was held back, not disabled.
+# parent, hangs up on pass 2. Pass 3 pins the other direction: a 404 and a
+# failed .bin carry nothing that was ever mirrored, so they must not hold the
+# purge, and gone.html goes.
 
 set -euo pipefail
 
@@ -51,13 +52,17 @@ grep -q 'keeping all previously mirrored files' <<<"$log" ||
     fail "the deferred purge went unreported: ${log}"
 ok "the run says it kept everything"
 
-# --- pass 3: nothing fails, so the purge runs again -------------------------
-local_crawl --log "${tmpdir}/log3" "${common[@]}" -O "$out" --update \
+# --- pass 3: what fails carries nothing, so the purge runs ------------------
+# missing.html is a 404 and dead.bin hangs up; neither was ever a page holding
+# mirrored links, so neither may hold the purge back.
+local_crawl --log "${tmpdir}/log3" "${common[@]}" --changes -O "$out" --update \
     "${BASEURL}/hubfail/index.html"
 
 for name in hub child1 child2 leaf; do
     test -s "${site}/${name}.html" || fail "${name}.html was purged by pass 3"
 done
 test ! -e "${site}/gone.html" ||
-    fail "gone.html left the site and the crawl that scanned it all kept it"
-ok "a crawl that scanned the whole site still purges"
+    fail "gone.html left the site and a crawl that scanned it all kept it"
+grep -q '"purged": true' "${out}/hts-changes.json" ||
+    fail "the report denies a purge that happened: $(<"${out}/hts-changes.json")"
+ok "a 404 and a failed download do not hold the purge back"

--- a/tests/348_local-update-purge-hubfail.test
+++ b/tests/348_local-update-purge-hubfail.test
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# A page that fails to re-fetch on --update keeps its own copy (#746), but its
+# children were never queued, so the end-of-update purge unlinked them. Only
+# hub.html links child1/child2, and it hangs up on pass 2. gone.html leaves the
+# site on pass 3, the pass where nothing fails: purging it there is what says
+# the fix held the purge back rather than disabling it.
+
+set -euo pipefail
+
+# shellcheck source=tests/crawllib.sh
+. "${0%"${0##*/}"}./crawllib.sh"
+
+require_httrack
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_hubfail.XXXXXX")
+cleanup() { rm -rf "$tmpdir"; }
+cleanup_push cleanup
+
+out="${tmpdir}/crawl"
+mkdir -p "$out"
+common=(--quiet --disable-security-limits --robots=0 --retries=1 -c1 --timeout=20)
+site="${out}/127.0.0.1_${SRV_PORT:-0}/hubfail"
+
+local_server_start --log "${tmpdir}/server.log"
+site="${out}/127.0.0.1_${SRV_PORT}/hubfail"
+
+local_crawl --log "${tmpdir}/log1" "${common[@]}" -O "$out" \
+    "${BASEURL}/hubfail/index.html"
+for name in hub child1 child2 leaf gone; do
+    test -s "${site}/${name}.html" || fail "pass 1 did not mirror ${name}.html"
+done
+ok "pass 1 mirrored the hub, its two children and both controls"
+
+# --- pass 2: the hub hangs up, so its children are never queued -------------
+local_crawl --log "${tmpdir}/log2" "${common[@]}" -O "$out" --update \
+    "${BASEURL}/hubfail/index.html"
+
+log=$(<"${out}/hts-log.txt")
+grep -qE 'Error:.*at link .*/hubfail/hub\.html' <<<"$log" ||
+    fail "the hub re-fetch did not fail, so nothing went unparsed: ${log}"
+ok "the hub gave up after its retries"
+
+test -s "${site}/hub.html" || fail "hub.html was dropped despite #746"
+for name in child1 child2 leaf; do
+    test -s "${site}/${name}.html" ||
+        fail "${name}.html was purged: its only parent failed to re-fetch"
+done
+ok "the children of the failed page survived"
+
+grep -q 'keeping all previously mirrored files' <<<"$log" ||
+    fail "the deferred purge went unreported: ${log}"
+ok "the run says it kept everything"
+
+# --- pass 3: nothing fails, so the purge runs again -------------------------
+local_crawl --log "${tmpdir}/log3" "${common[@]}" -O "$out" --update \
+    "${BASEURL}/hubfail/index.html"
+
+for name in hub child1 child2 leaf; do
+    test -s "${site}/${name}.html" || fail "${name}.html was purged by pass 3"
+done
+test ! -e "${site}/gone.html" ||
+    fail "gone.html left the site and the crawl that scanned it all kept it"
+ok "a crawl that scanned the whole site still purges"

--- a/tests/348_local-update-purge-hubfail.test
+++ b/tests/348_local-update-purge-hubfail.test
@@ -1,10 +1,9 @@
 #!/bin/bash
 #
-# A page that fails to re-fetch on --update keeps its own copy (#746), but its
-# children were never queued, so the end-of-update purge unlinked them. Only
-# hub.html links child1/child2, and it hangs up on pass 2. gone.html leaves the
-# site on pass 3, the pass where nothing fails: purging it there is what says
-# the fix held the purge back rather than disabling it.
+# A page that fails to re-fetch on --update keeps its copy (#746), but its
+# children were never queued, so the purge unlinked them. hub.html, their only
+# parent, hangs up on pass 2. gone.html leaves the site on pass 3, where
+# nothing fails: purging it there says the purge was held back, not disabled.
 
 set -euo pipefail
 

--- a/tests/348_local-update-purge-hubfail.test
+++ b/tests/348_local-update-purge-hubfail.test
@@ -1,10 +1,9 @@
 #!/bin/bash
 #
 # A page that fails to re-fetch on --update keeps its copy (#746), but its
-# children were never queued, so the purge unlinked them. hub.html, their only
-# parent, hangs up on pass 2. Pass 3 pins the other direction: a 404 and a
-# failed .bin carry nothing that was ever mirrored, so they must not hold the
-# purge, and gone.html goes.
+# children were never queued, so the purge unlinked them. A hang-up and a
+# decode failure hold the purge back for the run; a link never mirrored, an
+# answered error and a deliberate size skip must not.
 
 set -euo pipefail
 
@@ -17,12 +16,20 @@ tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_hubfail.XXXXXX")
 cleanup() { rm -rf "$tmpdir"; }
 cleanup_push cleanup
 
-out="${tmpdir}/crawl"
-mkdir -p "$out"
-common=(--quiet --disable-security-limits --robots=0 --retries=1 -c1 --timeout=20)
-site="${out}/127.0.0.1_${SRV_PORT:-0}/hubfail"
+common=(--quiet --disable-security-limits --robots=0 --retries=1 -c1 --timeout=20 --changes)
+
+# assert_purged WANT OUTDIR: what the run reported doing to the old files.
+assert_purged() {
+    local want="$1" json="${2}/hts-changes.json"
+    grep -q "\"purged\": ${want}" "$json" ||
+        fail "expected \"purged\": ${want} in $(<"$json")"
+}
 
 local_server_start --log "${tmpdir}/server.log"
+
+# --- a hub that hangs up mid-header ----------------------------------------
+out="${tmpdir}/crawl"
+mkdir -p "$out"
 site="${out}/127.0.0.1_${SRV_PORT}/hubfail"
 
 local_crawl --log "${tmpdir}/log1" "${common[@]}" -O "$out" \
@@ -32,30 +39,24 @@ for name in hub child1 child2 leaf gone; do
 done
 ok "pass 1 mirrored the hub, its two children and both controls"
 
-# --- pass 2: the hub hangs up, so its children are never queued -------------
 local_crawl --log "${tmpdir}/log2" "${common[@]}" -O "$out" --update \
     "${BASEURL}/hubfail/index.html"
 
 log=$(<"${out}/hts-log.txt")
 grep -qE 'Error:.*at link .*/hubfail/hub\.html' <<<"$log" ||
     fail "the hub re-fetch did not fail, so nothing went unparsed: ${log}"
-ok "the hub gave up after its retries"
-
 test -s "${site}/hub.html" || fail "hub.html was dropped despite #746"
 for name in child1 child2 leaf; do
     test -s "${site}/${name}.html" ||
         fail "${name}.html was purged: its only parent failed to re-fetch"
 done
-ok "the children of the failed page survived"
+assert_purged false "$out"
+ok "the children of the failed page survived, and the run says so"
 
-grep -q 'keeping all previously mirrored files' <<<"$log" ||
-    fail "the deferred purge went unreported: ${log}"
-ok "the run says it kept everything"
-
-# --- pass 3: what fails carries nothing, so the purge runs ------------------
-# missing.html is a 404 and dead.bin hangs up; neither was ever a page holding
-# mirrored links, so neither may hold the purge back.
-local_crawl --log "${tmpdir}/log3" "${common[@]}" --changes -O "$out" --update \
+# --- what fails without a mirrored copy of its own does not hold anything ---
+# missing.html is a 404, dead.bin and dead.html hang up; all three appear for
+# the first time on this crawl, so gone.html must still go.
+local_crawl --log "${tmpdir}/log3" "${common[@]}" -O "$out" --update \
     "${BASEURL}/hubfail/index.html"
 
 for name in hub child1 child2 leaf; do
@@ -63,6 +64,69 @@ for name in hub child1 child2 leaf; do
 done
 test ! -e "${site}/gone.html" ||
     fail "gone.html left the site and a crawl that scanned it all kept it"
-grep -q '"purged": true' "${out}/hts-changes.json" ||
-    fail "the report denies a purge that happened: $(<"${out}/hts-changes.json")"
-ok "a 404 and a failed download do not hold the purge back"
+assert_purged true "$out"
+ok "three new dead links do not hold the purge back"
+
+# --- a hub that answers with a body that cannot be decoded ------------------
+out="${tmpdir}/gz"
+mkdir -p "$out"
+site="${out}/127.0.0.1_${SRV_PORT}/gzfail"
+
+local_crawl --log "${tmpdir}/gzlog1" "${common[@]}" -O "$out" \
+    "${BASEURL}/gzfail/index.html"
+for name in gzhub gzchild gzgone; do
+    test -s "${site}/${name}.html" || fail "pass 1 did not mirror ${name}.html"
+done
+
+local_crawl --log "${tmpdir}/gzlog2" "${common[@]}" -O "$out" --update \
+    "${BASEURL}/gzfail/index.html"
+for name in gzhub gzchild gzgone; do
+    test -s "${site}/${name}.html" ||
+        fail "${name}.html was purged after a decode failure on gzhub.html"
+done
+assert_purged false "$out"
+ok "a mangled gzip body holds the purge like a hang-up does"
+
+# --- boundary: a hub that answers 500 needs no hold at all ------------------
+# An update recovers the page from the cache and re-queues its children, so a
+# guard that fired on every failed link would keep errgone.html for nothing.
+out="${tmpdir}/err"
+mkdir -p "$out"
+site="${out}/127.0.0.1_${SRV_PORT}/errfail"
+
+local_crawl --log "${tmpdir}/errlog1" "${common[@]}" -O "$out" \
+    "${BASEURL}/errfail/index.html"
+for name in errhub errchild errgone; do
+    test -s "${site}/${name}.html" || fail "pass 1 did not mirror ${name}.html"
+done
+
+local_crawl --log "${tmpdir}/errlog2" "${common[@]}" -O "$out" --update \
+    "${BASEURL}/errfail/index.html"
+for name in errhub errchild; do
+    test -s "${site}/${name}.html" ||
+        fail "${name}.html was purged after errhub.html answered 500"
+done
+test ! -e "${site}/errgone.html" ||
+    fail "errgone.html left the site and the recovered 500 kept the purge back"
+assert_purged true "$out"
+ok "an answered error recovers its links, so the purge still runs"
+
+# --- boundary: a hub over the size cap is a deliberate skip, not a failure ---
+# The engine passes it over and drops its previous copy (#746 excludes the
+# skips), so the purge must go on and take what only it linked.
+out="${tmpdir}/big"
+mkdir -p "$out"
+site="${out}/127.0.0.1_${SRV_PORT}/bigfail"
+
+local_crawl --log "${tmpdir}/biglog1" "${common[@]}" -m,4000 -O "$out" \
+    "${BASEURL}/bigfail/index.html"
+for name in bighub bigchild biggone; do
+    test -s "${site}/${name}.html" || fail "pass 1 did not mirror ${name}.html"
+done
+
+local_crawl --log "${tmpdir}/biglog2" "${common[@]}" -m,4000 -O "$out" --update \
+    "${BASEURL}/bigfail/index.html"
+assert_purged true "$out"
+test ! -e "${site}/biggone.html" ||
+    fail "biggone.html left the site and an over-size hub kept the purge back"
+ok "a deliberate size skip does not hold the purge back"

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1219,10 +1219,26 @@ class Handler(SimpleHTTPRequestHandler):
     HUBFAIL_CHILD = b"<html><body><p>HUBFAIL-CHILD-%d</p></body></html>"
 
     def route_hubfail_index(self):
-        links = '\t<a href="hub.html">hub</a>\n\t<a href="leaf.html">leaf</a>\n'
-        if self.refetch_pass() <= 2:  # dropped for the third crawl only
+        crawl = self.refetch_pass()
+        links = '\t<a href="hub.html">hub</a>\n' '\t<a href="leaf.html">leaf</a>\n'
+        if crawl <= 2:  # gone.html leaves the site for the third crawl
             links += '\t<a href="gone.html">gone</a>\n'
+        if crawl >= 3:  # neither of these may hold the third crawl's purge
+            links += (
+                '\t<a href="missing.html">missing</a>\n'
+                '\t<a href="dead.bin">dead</a>\n'
+            )
         self.send_html(links)
+
+    # Control: the site answers, and its answer is that the page is gone. The
+    # third crawl must still purge with this in it.
+    def route_hubfail_missing(self):
+        self.send_error(404)
+
+    # Control: fails like the hub, but nothing it could carry was ever
+    # mirrored, so it must not hold the purge either.
+    def route_hubfail_dead(self):
+        self.send_cut_headers()
 
     # Cuts off both attempts of the caller's second crawl (the request and the
     # one retry --retries=1 buys), then answers again, so the third crawl can
@@ -1243,8 +1259,8 @@ class Handler(SimpleHTTPRequestHandler):
     def route_hubfail_leaf(self):
         self.send_raw(b"<html><body><p>HUBFAIL-LEAF</p></body></html>", "text/html")
 
-    # Control: the index stops linking it on the third crawl, the one where
-    # nothing fails, so that crawl must purge it.
+    # Control: the index stops linking it on the third crawl, where nothing
+    # that failed ever carried links, so that crawl must purge it.
     def route_hubfail_gone(self):
         self.send_raw(b"<html><body><p>HUBFAIL-GONE</p></body></html>", "text/html")
 
@@ -2803,6 +2819,8 @@ class Handler(SimpleHTTPRequestHandler):
         "/hubfail/child2.html": route_hubfail_child,
         "/hubfail/leaf.html": route_hubfail_leaf,
         "/hubfail/gone.html": route_hubfail_gone,
+        "/hubfail/missing.html": route_hubfail_missing,
+        "/hubfail/dead.bin": route_hubfail_dead,
         "/ranged/asset.bin": route_ranged_asset,
         "/types/index.html": route_types_index,
         "/types/control.php": route_types,

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1212,6 +1212,43 @@ class Handler(SimpleHTTPRequestHandler):
             if self.command != "HEAD":
                 self.wfile.write(body[start:])
 
+    # --- a hub page that fails on the update, taking its children with it --
+    # The children are only reachable through hub.html: if the engine drops
+    # them from new.lst because the hub was never parsed, the purge unlinks
+    # them. gone.html is the live control -- it really does leave the site.
+    HUBFAIL_CHILD = b"<html><body><p>HUBFAIL-CHILD-%d</p></body></html>"
+
+    def route_hubfail_index(self):
+        links = '\t<a href="hub.html">hub</a>\n\t<a href="leaf.html">leaf</a>\n'
+        if self.refetch_pass() <= 2:  # dropped for the third crawl only
+            links += '\t<a href="gone.html">gone</a>\n'
+        self.send_html(links)
+
+    # Hangs up for the whole of the caller's second crawl -- fetches 2 and 3,
+    # its initial request and the one retry --retries=1 buys -- then answers
+    # again, so the purge the fix defers can be seen to happen on the next
+    # clean crawl.
+    def route_hubfail_hub(self):
+        if 2 <= self.refetch_pass() <= 3:
+            self.send_cut_headers()
+        else:
+            self.send_html(
+                '\t<a href="child1.html">c1</a>\n\t<a href="child2.html">c2</a>\n'
+            )
+
+    def route_hubfail_child(self):
+        n = int(self.path.rstrip(".html")[-1])
+        self.send_raw(self.HUBFAIL_CHILD % n, "text/html")
+
+    # Control: linked from the index on both passes, so it is never at risk.
+    def route_hubfail_leaf(self):
+        self.send_raw(b"<html><body><p>HUBFAIL-LEAF</p></body></html>", "text/html")
+
+    # Control: the index stops linking it on the third crawl, the one where
+    # nothing fails, so that crawl must purge it.
+    def route_hubfail_gone(self):
+        self.send_raw(b"<html><body><p>HUBFAIL-GONE</p></body></html>", "text/html")
+
     # Echo what httrack advertised, so a crawl can assert the header.
     def route_codec_ae(self):
         self.send_raw(
@@ -2761,6 +2798,12 @@ class Handler(SimpleHTTPRequestHandler):
         "/keep/data.bin": route_keep_data,
         "/keep/err.bin": route_keep_err,
         "/keep/stay.bin": route_keep_stay,
+        "/hubfail/index.html": route_hubfail_index,
+        "/hubfail/hub.html": route_hubfail_hub,
+        "/hubfail/child1.html": route_hubfail_child,
+        "/hubfail/child2.html": route_hubfail_child,
+        "/hubfail/leaf.html": route_hubfail_leaf,
+        "/hubfail/gone.html": route_hubfail_gone,
         "/ranged/asset.bin": route_ranged_asset,
         "/types/index.html": route_types_index,
         "/types/control.php": route_types,

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1215,7 +1215,7 @@ class Handler(SimpleHTTPRequestHandler):
     # --- a hub page that fails on the update, taking its children with it --
     # The children are only reachable through hub.html: if the engine drops
     # them from new.lst because the hub was never parsed, the purge unlinks
-    # them. gone.html is the live control -- it really does leave the site.
+    # them. gone.html is the live control: it really does leave the site.
     HUBFAIL_CHILD = b"<html><body><p>HUBFAIL-CHILD-%d</p></body></html>"
 
     def route_hubfail_index(self):
@@ -1224,10 +1224,9 @@ class Handler(SimpleHTTPRequestHandler):
             links += '\t<a href="gone.html">gone</a>\n'
         self.send_html(links)
 
-    # Hangs up for the whole of the caller's second crawl -- fetches 2 and 3,
-    # its initial request and the one retry --retries=1 buys -- then answers
-    # again, so the purge the fix defers can be seen to happen on the next
-    # clean crawl.
+    # Cuts off both attempts of the caller's second crawl (the request and the
+    # one retry --retries=1 buys), then answers again, so the third crawl can
+    # show the held-back purge running.
     def route_hubfail_hub(self):
         if 2 <= self.refetch_pass() <= 3:
             self.send_cut_headers()

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1223,10 +1223,11 @@ class Handler(SimpleHTTPRequestHandler):
         links = '\t<a href="hub.html">hub</a>\n' '\t<a href="leaf.html">leaf</a>\n'
         if crawl <= 2:  # gone.html leaves the site for the third crawl
             links += '\t<a href="gone.html">gone</a>\n'
-        if crawl >= 3:  # neither of these may hold the third crawl's purge
+        if crawl >= 3:  # none of these may hold the third crawl's purge
             links += (
                 '\t<a href="missing.html">missing</a>\n'
                 '\t<a href="dead.bin">dead</a>\n'
+                '\t<a href="dead.html">deadhtml</a>\n'
             )
         self.send_html(links)
 
@@ -1235,8 +1236,8 @@ class Handler(SimpleHTTPRequestHandler):
     def route_hubfail_missing(self):
         self.send_error(404)
 
-    # Control: fails like the hub, but nothing it could carry was ever
-    # mirrored, so it must not hold the purge either.
+    # Controls: they fail like the hub but are new on the third crawl, so
+    # neither has a subtree to lose. dead.html wears a page's extension.
     def route_hubfail_dead(self):
         self.send_cut_headers()
 
@@ -1263,6 +1264,75 @@ class Handler(SimpleHTTPRequestHandler):
     # that failed ever carried links, so that crawl must purge it.
     def route_hubfail_gone(self):
         self.send_raw(b"<html><body><p>HUBFAIL-GONE</p></body></html>", "text/html")
+
+    # --- same, for a hub that answers with a body that will not decode -----
+    # A mangled gzip gives up as STATUSCODE_INVALID, not a transport code.
+    GZFAIL_HUB = b'<html><body><a href="gzchild.html">c</a></body></html>'
+
+    def route_gzfail_index(self):
+        links = '\t<a href="gzhub.html">hub</a>\n'
+        if self.refetch_pass() == 1:  # gzgone.html leaves the site afterwards
+            links += '\t<a href="gzgone.html">gone</a>\n'
+        self.send_html(links)
+
+    def route_gzfail_hub(self):
+        body = (
+            self.gzipped(self.GZFAIL_HUB)
+            if self.refetch_pass() == 1
+            else self.bad_gzip(self.GZFAIL_HUB)
+        )
+        self.send_coded(body, "text/html")
+
+    def route_gzfail_child(self):
+        self.send_raw(b"<html><body><p>GZFAIL-CHILD</p></body></html>", "text/html")
+
+    def route_gzfail_gone(self):
+        self.send_raw(b"<html><body><p>GZFAIL-GONE</p></body></html>", "text/html")
+
+    # --- same, for a server error the engine would have retried ------------
+    ERRFAIL_HUB = b'<html><body><a href="errchild.html">c</a></body></html>'
+
+    def route_errfail_index(self):
+        links = '\t<a href="errhub.html">hub</a>\n'
+        if self.refetch_pass() == 1:  # errgone.html leaves the site afterwards
+            links += '\t<a href="errgone.html">gone</a>\n'
+        self.send_html(links)
+
+    # 500 on every attempt of the second crawl: retryable, yet answered, so no
+    # transport failure ever reports it.
+    def route_errfail_hub(self):
+        if self.refetch_pass() == 1:
+            self.send_raw(self.ERRFAIL_HUB, "text/html")
+        else:
+            self.send_error(500)
+
+    def route_errfail_child(self):
+        self.send_raw(b"<html><body><p>ERRFAIL-CHILD</p></body></html>", "text/html")
+
+    def route_errfail_gone(self):
+        self.send_raw(b"<html><body><p>ERRFAIL-GONE</p></body></html>", "text/html")
+
+    # --- boundary: a hub the size cap makes the engine skip on purpose ------
+    BIGFAIL_HUB = b'<html><body><a href="bigchild.html">c</a></body></html>'
+
+    def route_bigfail_index(self):
+        links = '\t<a href="bighub.html">hub</a>\n'
+        if self.refetch_pass() == 1:  # biggone.html leaves the site afterwards
+            links += '\t<a href="biggone.html">gone</a>\n'
+        self.send_html(links)
+
+    # Second crawl serves it past the caller's -m,N html cap.
+    def route_bigfail_hub(self):
+        body = self.BIGFAIL_HUB
+        if self.refetch_pass() != 1:
+            body += b"<!--" + b"x" * 8192 + b"-->"
+        self.send_raw(body, "text/html")
+
+    def route_bigfail_child(self):
+        self.send_raw(b"<html><body><p>BIGFAIL-CHILD</p></body></html>", "text/html")
+
+    def route_bigfail_gone(self):
+        self.send_raw(b"<html><body><p>BIGFAIL-GONE</p></body></html>", "text/html")
 
     # Echo what httrack advertised, so a crawl can assert the header.
     def route_codec_ae(self):
@@ -2821,6 +2891,19 @@ class Handler(SimpleHTTPRequestHandler):
         "/hubfail/gone.html": route_hubfail_gone,
         "/hubfail/missing.html": route_hubfail_missing,
         "/hubfail/dead.bin": route_hubfail_dead,
+        "/hubfail/dead.html": route_hubfail_dead,
+        "/gzfail/index.html": route_gzfail_index,
+        "/gzfail/gzhub.html": route_gzfail_hub,
+        "/gzfail/gzchild.html": route_gzfail_child,
+        "/gzfail/gzgone.html": route_gzfail_gone,
+        "/errfail/index.html": route_errfail_index,
+        "/errfail/errhub.html": route_errfail_hub,
+        "/errfail/errchild.html": route_errfail_child,
+        "/errfail/errgone.html": route_errfail_gone,
+        "/bigfail/index.html": route_bigfail_index,
+        "/bigfail/bighub.html": route_bigfail_hub,
+        "/bigfail/bigchild.html": route_bigfail_child,
+        "/bigfail/biggone.html": route_bigfail_gone,
         "/ranged/asset.bin": route_ranged_asset,
         "/types/index.html": route_types_index,
         "/types/control.php": route_types,


### PR DESCRIPTION
On `--update` the engine unlinks what the previous mirror had and this run did not write. A page that gives up after its last retry keeps its copy (#746) but is never parsed, so its links never reach `new.lst`, and the purge reads that gap as the site dropping them: one dropped connection on a hub page costs its whole subtree, silently, while the run reports success. An HTTP error already escapes this, being masked to a 304 and recovered from the cache. A transport failure has no such path.

The purge now holds off for the run when a link that could carry links fails to transfer, keyed on `back_transfer_failed()` so it cannot drift from the predicate that decides whether the copy is kept. A mangled `Content-Encoding`, a bad chunk length, a disk write error and an aborted external wrapper all report `STATUSCODE_INVALID`, keep their copy, and now keep their children with it. Two cases deliberately do not hold: an answered HTTP error, which is recovered and re-queues its links, and a page the size cap skips, whose own copy #746 drops so its children go with it rather than being stranded. The guard also requires that the previous run actually mirrored the page, since only then is there a subtree at risk. Typing the link by its savename instead let any new permanently dead `.html` link disable the purge on every run.

Masking the failure as a 304 was the alternative and does not work this far down the loop: that masking sits ahead of `back_finalize`, and doing it at the give-up point would disarm the "no data transferred, restore the previous session" rollback, so a mirror whose host had vanished would report success.

`httrackp` gains one field at its tail, live state `copy_htsopt` leaves alone. It lands in the padding after `wizard_filters` on LP64, so `sizeof` is unchanged there; on ILP32 the struct has no trailing padding and grows by four bytes, as every earlier tail field did. `size_httrackp` is asserted against `sizeof` at each entry point, so a stale-header consumer aborts rather than corrupts.

Known gap, not fixed here: a failed fetch writes no cache entry, so a hub failing on two consecutive runs has no previous entry the second time and stops holding the purge.

Test 348 drives five shapes past the guard and reads `hts-changes.json` rather than a log line, the two boundaries above among them. Found by the httrack-android session's overnight robustness audit, reproduced against 3.49.23.
