### PR TITLE
A host that fails to resolve during an outage stays dead for the whole crawl

### DIFF
--- a/src/htsdns_selftest.c
+++ b/src/htsdns_selftest.c
@@ -319,32 +319,56 @@ int dns_selftests(httrackp *opt) {
   }
 
   /* But a failure the resolver could not answer expires: one outage must not
-     kill the whole crawl. */
+     kill the whole crawl. Every sleep below only ever needs to be LONGER than
+     the wait it outlasts, so a slow runner cannot turn this red. */
   mock_reset_calls();
-  hts_dns_set_negative_ttl_ms(500);
+  hts_dns_set_negative_ttl_ms(200);
   {
     SOCaddr a;
     const char *err = NULL;
 
     CHECK(hts_dns_resolve2(opt, "flaky.test", &a, &err) == NULL);
-    mock_find("flaky.test")->gai_err = 0; /* the network comes back */
+    CHECK(hts_dns_negative_failures(opt, "flaky.test") == 1);
     CHECK(hts_dns_resolve2(opt, "flaky.test", &a, &err) == NULL);
-    CHECK(mock_read_calls("flaky.test") == 1); /* still inside the TTL */
-    Sleep(600);
-    CHECK(hts_dns_resolve2(opt, "flaky.test", &a, &err) != NULL);
+    CHECK(mock_read_calls("flaky.test") == 1); /* still inside the wait */
+    Sleep(300);
+    /* asking again after the wait counts, and lengthens the next one */
+    CHECK(hts_dns_resolve2(opt, "flaky.test", &a, &err) == NULL);
     CHECK(mock_read_calls("flaky.test") == 2);
-    Sleep(600);
+    CHECK(hts_dns_negative_failures(opt, "flaky.test") == 2);
+    mock_find("flaky.test")->gai_err = 0; /* the network comes back */
+    Sleep(500);                           /* past the doubled wait */
     CHECK(hts_dns_resolve2(opt, "flaky.test", &a, &err) != NULL);
-    CHECK(mock_read_calls("flaky.test") == 2); /* the answer does not expire */
+    CHECK(mock_read_calls("flaky.test") == 3);
+    CHECK(hts_dns_negative_failures(opt, "flaky.test") == 0);
+    Sleep(500);
+    CHECK(hts_dns_resolve2(opt, "flaky.test", &a, &err) != NULL);
+    CHECK(mock_read_calls("flaky.test") == 3); /* the answer does not expire */
   }
+
+  /* The wait doubles per consecutive failure, up to the ceiling. Table-tested
+     rather than slept through: a resolver Android maps every failure onto,
+     NXDOMAIN included, would otherwise re-ask a dead host all crawl. */
+  {
+    const int first = 1000;
+
+    hts_dns_set_negative_ttl_ms(first);
+    CHECK(hts_dns_negative_wait_ms(1) == first);
+    CHECK(hts_dns_negative_wait_ms(2) == 2 * first);
+    CHECK(hts_dns_negative_wait_ms(3) == 4 * first);
+    CHECK(hts_dns_negative_wait_ms(99) == HTS_DNS_NEGATIVE_TTL_MAX_MS);
+    hts_dns_set_negative_ttl_ms(500);
+  }
+
   /* "no such host" is an answer about the name, so it still stands for the
      whole crawl: same TTL, same sleep, no second resolve. */
   {
     SOCaddr a;
     const char *err = NULL;
 
+    hts_dns_set_negative_ttl_ms(200);
     CHECK(hts_dns_resolve2(opt, "dead.test", &a, &err) == NULL);
-    Sleep(600);
+    Sleep(300);
     CHECK(hts_dns_resolve2(opt, "dead.test", &a, &err) == NULL);
     CHECK(mock_read_calls("dead.test") == 1);
   }

--- a/src/htsdns_selftest.c
+++ b/src/htsdns_selftest.c
@@ -100,8 +100,11 @@ static mock_host mock_hosts[] = {
       {AF_INET, {10, 0, 0, 6}}},
      0},
     {"nodns.test", EAI_NONAME, 0, {{0}}, 0},
-    /* the outage case: fails until the test clears gai_err */
-    {"flaky.test", EAI_NONAME, 1, {{AF_INET, {192, 0, 2, 7}}}, 0},
+    /* the outage case: the resolver cannot answer, until the test says it can
+       (EAI_AGAIN, not EAI_NONAME, which is an answer about the name) */
+    {"flaky.test", EAI_AGAIN, 1, {{AF_INET, {192, 0, 2, 7}}}, 0},
+    /* the control: the resolver answers, and the answer is "no such host" */
+    {"dead.test", EAI_NONAME, 0, {{0}}, 0},
     /* resolves, but only well after --timeout: the #606 wedge */
     {"slow.test", 0, 1, {{AF_INET, {127, 0, 0, 9}}}, 0, MOCK_SLOW_MS},
     /* a second one, so a cancelled resolve cannot cache an answer the next
@@ -315,7 +318,8 @@ int dns_selftests(httrackp *opt) {
     CHECK(mock_find("nodns.test")->calls == 1); /* resolved once, then cached */
   }
 
-  /* But it expires: one outage must not kill the whole crawl. */
+  /* But a failure the resolver could not answer expires: one outage must not
+     kill the whole crawl. */
   mock_reset_calls();
   hts_dns_set_negative_ttl_ms(500);
   {
@@ -333,8 +337,19 @@ int dns_selftests(httrackp *opt) {
     CHECK(hts_dns_resolve2(opt, "flaky.test", &a, &err) != NULL);
     CHECK(mock_read_calls("flaky.test") == 2); /* the answer does not expire */
   }
+  /* "no such host" is an answer about the name, so it still stands for the
+     whole crawl: same TTL, same sleep, no second resolve. */
+  {
+    SOCaddr a;
+    const char *err = NULL;
+
+    CHECK(hts_dns_resolve2(opt, "dead.test", &a, &err) == NULL);
+    Sleep(600);
+    CHECK(hts_dns_resolve2(opt, "dead.test", &a, &err) == NULL);
+    CHECK(mock_read_calls("dead.test") == 1);
+  }
   hts_dns_set_negative_ttl_ms(HTS_DNS_NEGATIVE_TTL_MS);
-  mock_find("flaky.test")->gai_err = EAI_NONAME; /* leave the row as found */
+  mock_find("flaky.test")->gai_err = EAI_AGAIN; /* leave the row as found */
 
   /* Multi-address resolution: count and order are the connect-fallback
      contract. A dead first address is retried against the next, so both must be

--- a/src/htsdns_selftest.c
+++ b/src/htsdns_selftest.c
@@ -360,8 +360,7 @@ int dns_selftests(httrackp *opt) {
     hts_dns_set_negative_ttl_ms(500);
   }
 
-  /* "no such host" is an answer about the name, so it still stands for the
-     whole crawl: same TTL, same sleep, no second resolve. */
+  /* "no such host" is an answer about the name, so it stands for the crawl. */
   {
     SOCaddr a;
     const char *err = NULL;

--- a/src/htsdns_selftest.c
+++ b/src/htsdns_selftest.c
@@ -105,6 +105,8 @@ static mock_host mock_hosts[] = {
     {"flaky.test", EAI_AGAIN, 1, {{AF_INET, {192, 0, 2, 7}}}, 0},
     /* the control: the resolver answers, and the answer is "no such host" */
     {"dead.test", EAI_NONAME, 0, {{0}}, 0},
+    /* the same outage, seen across a backward clock step */
+    {"stepped.test", EAI_AGAIN, 1, {{AF_INET, {192, 0, 2, 8}}}, 0},
     /* resolves, but only well after --timeout: the #606 wedge */
     {"slow.test", 0, 1, {{AF_INET, {127, 0, 0, 9}}}, 0, MOCK_SLOW_MS},
     /* a second one, so a cancelled resolve cannot cache an answer the next
@@ -319,10 +321,10 @@ int dns_selftests(httrackp *opt) {
   }
 
   /* But a failure the resolver could not answer expires: one outage must not
-     kill the whole crawl. Every sleep below only ever needs to be LONGER than
-     the wait it outlasts, so a slow runner cannot turn this red. */
+     kill the whole crawl. The wait is minutes long and the test moves the clock
+     rather than sleeping, so no stall expires an entry a check needs. */
   mock_reset_calls();
-  hts_dns_set_negative_ttl_ms(200);
+  hts_dns_set_negative_ttl_ms(100000);
   {
     SOCaddr a;
     const char *err = NULL;
@@ -331,19 +333,41 @@ int dns_selftests(httrackp *opt) {
     CHECK(hts_dns_negative_failures(opt, "flaky.test") == 1);
     CHECK(hts_dns_resolve2(opt, "flaky.test", &a, &err) == NULL);
     CHECK(mock_read_calls("flaky.test") == 1); /* still inside the wait */
-    Sleep(300);
+    hts_dns_test_move_clock(opt, "flaky.test", 150000);
     /* asking again after the wait counts, and lengthens the next one */
     CHECK(hts_dns_resolve2(opt, "flaky.test", &a, &err) == NULL);
     CHECK(mock_read_calls("flaky.test") == 2);
     CHECK(hts_dns_negative_failures(opt, "flaky.test") == 2);
-    mock_find("flaky.test")->gai_err = 0; /* the network comes back */
-    Sleep(500);                           /* past the doubled wait */
+    /* that next one is twice as long, so the same move no longer reaches it */
+    hts_dns_test_move_clock(opt, "flaky.test", 150000);
+    CHECK(hts_dns_resolve2(opt, "flaky.test", &a, &err) == NULL);
+    CHECK(mock_read_calls("flaky.test") == 2);
+    mock_find("flaky.test")->gai_err = 0; /* the network is back */
+    hts_dns_test_move_clock(opt, "flaky.test", 100000); /* now past it */
     CHECK(hts_dns_resolve2(opt, "flaky.test", &a, &err) != NULL);
     CHECK(mock_read_calls("flaky.test") == 3);
     CHECK(hts_dns_negative_failures(opt, "flaky.test") == 0);
-    Sleep(500);
+    hts_dns_test_move_clock(opt, "flaky.test", 1000000);
     CHECK(hts_dns_resolve2(opt, "flaky.test", &a, &err) != NULL);
     CHECK(mock_read_calls("flaky.test") == 3); /* the answer does not expire */
+  }
+
+  /* The stamps are wall-clock, there being no monotonic clock here: a backward
+     step must expire them too, or it delays the retry by the size of the step,
+     which at the ceiling means the rest of the crawl. */
+  mock_reset_calls();
+  {
+    SOCaddr a;
+    const char *err = NULL;
+
+    CHECK(hts_dns_resolve2(opt, "stepped.test", &a, &err) == NULL);
+    CHECK(hts_dns_resolve2(opt, "stepped.test", &a, &err) == NULL);
+    CHECK(mock_read_calls("stepped.test") == 1); /* still inside the wait */
+    mock_find("stepped.test")->gai_err = 0;      /* the network is back */
+    hts_dns_test_move_clock(opt, "stepped.test", -600000); /* NTP steps back */
+    CHECK(hts_dns_resolve2(opt, "stepped.test", &a, &err) != NULL);
+    CHECK(mock_read_calls("stepped.test") == 2);
+    mock_find("stepped.test")->gai_err = EAI_AGAIN; /* leave the row as found */
   }
 
   /* The wait doubles per consecutive failure, up to the ceiling. Table-tested

--- a/src/htsdns_selftest.c
+++ b/src/htsdns_selftest.c
@@ -100,6 +100,9 @@ static mock_host mock_hosts[] = {
       {AF_INET, {10, 0, 0, 6}}},
      0},
     {"nodns.test", EAI_NONAME, 0, {{0}}, 0},
+    /* fails like nodns.test until the test clears gai_err, standing in for a
+       host first met while the network was down */
+    {"flaky.test", EAI_NONAME, 1, {{AF_INET, {192, 0, 2, 7}}}, 0},
     /* resolves, but only well after --timeout: the #606 wedge */
     {"slow.test", 0, 1, {{AF_INET, {127, 0, 0, 9}}}, 0, MOCK_SLOW_MS},
     /* a second one, so a cancelled resolve cannot cache an answer the next
@@ -312,6 +315,24 @@ int dns_selftests(httrackp *opt) {
     CHECK(hts_dns_resolve2(opt, "nodns.test", &a2, &err) == NULL);
     CHECK(mock_find("nodns.test")->calls == 1); /* resolved once, then cached */
   }
+
+  /* But it expires: a host that only failed because the network was down must
+     be asked again, or the whole crawl stays dead behind one outage. */
+  mock_reset_calls();
+  hts_dns_set_negative_ttl_ms(50);
+  {
+    SOCaddr a;
+    const char *err = NULL;
+
+    CHECK(hts_dns_resolve2(opt, "flaky.test", &a, &err) == NULL);
+    mock_find("flaky.test")->gai_err = 0; /* the network comes back */
+    CHECK(hts_dns_resolve2(opt, "flaky.test", &a, &err) == NULL);
+    CHECK(mock_read_calls("flaky.test") == 1); /* still inside the TTL */
+    Sleep(60);
+    CHECK(hts_dns_resolve2(opt, "flaky.test", &a, &err) != NULL);
+    CHECK(mock_read_calls("flaky.test") == 2);
+  }
+  hts_dns_set_negative_ttl_ms(HTS_DNS_NEGATIVE_TTL_MS);
 
   /* Multi-address resolution: count and order are the connect-fallback
      contract. A dead first address is retried against the next, so both must be

--- a/src/htsdns_selftest.c
+++ b/src/htsdns_selftest.c
@@ -100,8 +100,7 @@ static mock_host mock_hosts[] = {
       {AF_INET, {10, 0, 0, 6}}},
      0},
     {"nodns.test", EAI_NONAME, 0, {{0}}, 0},
-    /* fails like nodns.test until the test clears gai_err, standing in for a
-       host first met while the network was down */
+    /* the outage case: fails until the test clears gai_err */
     {"flaky.test", EAI_NONAME, 1, {{AF_INET, {192, 0, 2, 7}}}, 0},
     /* resolves, but only well after --timeout: the #606 wedge */
     {"slow.test", 0, 1, {{AF_INET, {127, 0, 0, 9}}}, 0, MOCK_SLOW_MS},
@@ -316,10 +315,9 @@ int dns_selftests(httrackp *opt) {
     CHECK(mock_find("nodns.test")->calls == 1); /* resolved once, then cached */
   }
 
-  /* But it expires: a host that only failed because the network was down must
-     be asked again, or the whole crawl stays dead behind one outage. */
+  /* But it expires: one outage must not kill the whole crawl. */
   mock_reset_calls();
-  hts_dns_set_negative_ttl_ms(50);
+  hts_dns_set_negative_ttl_ms(500);
   {
     SOCaddr a;
     const char *err = NULL;
@@ -328,11 +326,15 @@ int dns_selftests(httrackp *opt) {
     mock_find("flaky.test")->gai_err = 0; /* the network comes back */
     CHECK(hts_dns_resolve2(opt, "flaky.test", &a, &err) == NULL);
     CHECK(mock_read_calls("flaky.test") == 1); /* still inside the TTL */
-    Sleep(60);
+    Sleep(600);
     CHECK(hts_dns_resolve2(opt, "flaky.test", &a, &err) != NULL);
     CHECK(mock_read_calls("flaky.test") == 2);
+    Sleep(600);
+    CHECK(hts_dns_resolve2(opt, "flaky.test", &a, &err) != NULL);
+    CHECK(mock_read_calls("flaky.test") == 2); /* the answer does not expire */
   }
   hts_dns_set_negative_ttl_ms(HTS_DNS_NEGATIVE_TTL_MS);
+  mock_find("flaky.test")->gai_err = EAI_NONAME; /* leave the row as found */
 
   /* Multi-address resolution: count and order are the connect-fallback
      contract. A dead first address is retried against the next, so both must be

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -5186,9 +5186,15 @@ coucal hts_cache(httrackp *opt) {
   return opt->state.dns_cache;
 }
 
+/* Lifetime of a negative DNS answer; the self-test shortens it. */
+static int hts_dns_negative_ttl_ms = HTS_DNS_NEGATIVE_TTL_MS;
+
+void hts_dns_set_negative_ttl_ms(int ms) { hts_dns_negative_ttl_ms = ms; }
+
 // MUST BE LOCKED (coucal is not internally serialized vs FTP/web threads)
 // Look up iadr in the DNS cache, filling out[0..min(count,max)-1].
-// Returns: -1 not yet tested; 0 negative-cached (not in DNS); >0 address count.
+// Returns: -1 not tested, or a negative answer past its expiry; 0
+// negative-cached (not in DNS); >0 address count.
 static int hts_ghbn_all(coucal cache, const char *const iadr,
                         SOCaddr *const out, const int max) {
   void *ptr;
@@ -5203,6 +5209,11 @@ static int hts_ghbn_all(coucal cache, const char *const iadr,
     int i;
 
     assertf(record->host_count <= HTS_MAXADDRNUM);
+    /* A name that failed to resolve while the network was down must not stay
+       dead for the rest of the crawl: past its expiry, ask again. */
+    if (record->expiry != 0 && mtime_local() >= record->expiry) {
+      return -1;
+    }
     for (i = 0; i < record->host_count && i < max; i++) {
       assertf(record->host_length[i] <= sizeof(record->host_addr[i]));
       SOCaddr_copyaddr2(out[i], record->host_addr[i], record->host_length[i]);
@@ -5640,6 +5651,8 @@ int hts_dns_resolve_all_bounded(httrackp *opt, const char *iadr, SOCaddr *out,
     if (record != NULL) {
       memset(record, 0, sizeof(*record));
       record->host_count = count;
+      /* "does not resolve" is only as good as the network that answered it */
+      record->expiry = count == 0 ? mtime_local() + hts_dns_negative_ttl_ms : 0;
       for (i = 0; i < count; i++) {
         record->host_length[i] = SOCaddr_size(resolved[i]);
         assertf(record->host_length[i] <= sizeof(record->host_addr[i]));

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -5378,15 +5378,23 @@ static void hts_resolver_check_env(void) {
 
 // Resolve hostname into up to max addresses (resolver/RFC 6724 order), no
 // cache. Returns the count copied into out[0..count-1]; 0 = does not resolve.
+/* On a zero count, *permanent tells the two failures apart: the resolver
+   saying the name does not exist, or it being unable to answer at all. */
 static int hts_dns_resolve_nocache_list_(const char *const hostname,
                                          SOCaddr *const out, const int max,
-                                         const char **error) {
+                                         const char **error,
+                                         hts_boolean *permanent) {
   int count = 0;
+
+  if (permanent != NULL)
+    *permanent = HTS_FALSE;
 
 #if HTS_INET6==0
   /* IPv4 resolver */
   struct hostent *const hp = gethostbyname(hostname);
 
+  if (hp == NULL && permanent != NULL && h_errno == HOST_NOT_FOUND)
+    *permanent = HTS_TRUE;
   if (hp != NULL) {
     char **h;
 
@@ -5422,8 +5430,14 @@ static int hts_dns_resolve_nocache_list_(const char *const hostname,
           count++;
       }
     }
-  } else if (error != NULL) {
-    *error = gai_strerror(gerr);
+  } else {
+    if (error != NULL)
+      *error = gai_strerror(gerr);
+    /* EAI_NONAME is the resolver's own answer about the name; every other
+       code (EAI_AGAIN, EAI_FAIL, EAI_SYSTEM, EAI_NODATA where it exists) says
+       it could not answer, which an outage produces for any host. */
+    if (permanent != NULL && gerr == EAI_NONAME)
+      *permanent = HTS_TRUE;
   }
   if (res) {
     hts_resolver->freeaddrinfo(res);
@@ -5437,7 +5451,8 @@ static int hts_dns_resolve_nocache_list_(const char *const hostname,
 // take, then resolve into a list. Returns the count.
 static int hts_dns_resolve_nocache_list(const char *const hostname,
                                         SOCaddr *const out, const int max,
-                                        const char **error) {
+                                        const char **error,
+                                        hts_boolean *permanent) {
   if (!strnotempty(hostname) || max <= 0) {
     return 0;
   }
@@ -5449,11 +5464,11 @@ static int hts_dns_resolve_nocache_list(const char *const hostname,
     assertf(copy != NULL);
     copy[0] = '\0';
     strncat(copy, hostname + 1, size - 2);
-    count = hts_dns_resolve_nocache_list_(copy, out, max, error);
+    count = hts_dns_resolve_nocache_list_(copy, out, max, error, permanent);
     freet(copy);
     return count;
   } else {
-    return hts_dns_resolve_nocache_list_(hostname, out, max, error);
+    return hts_dns_resolve_nocache_list_(hostname, out, max, error, permanent);
   }
 }
 
@@ -5461,7 +5476,7 @@ HTSEXT_API SOCaddr *hts_dns_resolve_nocache2(const char *const hostname,
                                              SOCaddr *const addr,
                                              const char **error) {
   SOCaddr_clear(*addr);
-  if (hts_dns_resolve_nocache_list(hostname, addr, 1, error) > 0) {
+  if (hts_dns_resolve_nocache_list(hostname, addr, 1, error, NULL) > 0) {
     return SOCaddr_is_valid(*addr) ? addr : NULL;
   }
   return NULL;
@@ -5486,6 +5501,7 @@ typedef struct dns_resolve_job {
   SOCaddr addr[HTS_MAXADDRNUM];
   int count;
   const char *error;
+  hts_boolean permanent; /* a zero count that was about the name itself */
 } dns_resolve_job;
 
 /* Copy the first min(count, max) addresses of src into dest. */
@@ -5515,13 +5531,15 @@ static void dns_resolve_thread(void *arg) {
   dns_resolve_job *const job = (dns_resolve_job *) arg;
   SOCaddr resolved[HTS_MAXADDRNUM];
   const char *error = NULL;
-  const int count = hts_dns_resolve_nocache_list(job->hostname, resolved,
-                                                 HTS_MAXADDRNUM, &error);
+  hts_boolean permanent = HTS_FALSE;
+  const int count = hts_dns_resolve_nocache_list(
+      job->hostname, resolved, HTS_MAXADDRNUM, &error, &permanent);
 
   hts_mutexlock(&job->lock);
   dns_copy_addrs(job->addr, resolved, count, HTS_MAXADDRNUM);
   job->count = count;
   job->error = error;
+  job->permanent = permanent;
   job->done = HTS_TRUE; /* published last: gates the caller's read of addr[] */
   hts_mutexrelease(&job->lock);
   dns_job_release(job);
@@ -5533,7 +5551,8 @@ static void dns_resolve_thread(void *arg) {
    gets negative-cached. */
 static int hts_dns_resolve_nocache_list_bounded(
     const char *hostname, SOCaddr *const out, const int max, const int timeout,
-    const volatile hts_boolean *cancel, const char **error) {
+    const volatile hts_boolean *cancel, const char **error,
+    hts_boolean *permanent) {
   dns_resolve_job *job;
   TStamp deadline;
   int count = -1;
@@ -5541,7 +5560,7 @@ static int hts_dns_resolve_nocache_list_bounded(
 
   /* no bound asked for (--timeout 0), and nobody to cut it short either */
   if (timeout <= 0 && cancel == NULL)
-    return hts_dns_resolve_nocache_list(hostname, out, max, error);
+    return hts_dns_resolve_nocache_list(hostname, out, max, error, permanent);
 
   job = calloct(1, sizeof(*job));
   assertf(job != NULL);
@@ -5551,7 +5570,7 @@ static int hts_dns_resolve_nocache_list_bounded(
   if (hts_newthread(dns_resolve_thread, job) != 0) {
     job->refcount = 1; /* no worker: fall back to resolving inline */
     dns_job_release(job);
-    return hts_dns_resolve_nocache_list(hostname, out, max, error);
+    return hts_dns_resolve_nocache_list(hostname, out, max, error, permanent);
   }
 
   /* timeout <= 0 got here only for a cancellable resolve: no deadline then */
@@ -5566,6 +5585,8 @@ static int hts_dns_resolve_nocache_list_bounded(
       dns_copy_addrs(out, job->addr, count, max);
       if (error != NULL)
         *error = job->error;
+      if (permanent != NULL)
+        *permanent = job->permanent;
     }
     hts_mutexrelease(&job->lock);
     if (done || (cancel != NULL && *cancel) ||
@@ -5594,6 +5615,7 @@ int hts_dns_resolve_all_bounded(httrackp *opt, const char *iadr, SOCaddr *out,
                                 const char **error) {
   char BIGSTK host[HTS_URLMAXSIZE * 2];
   SOCaddr resolved[HTS_MAXADDRNUM];
+  hts_boolean permanent = HTS_FALSE;
   coucal cache;
   int count, i;
 
@@ -5629,8 +5651,8 @@ int hts_dns_resolve_all_bounded(httrackp *opt, const char *iadr, SOCaddr *out,
 
   /* Resolve with no lock held: getaddrinfo can block for a long time, and
      state.lock also gates the stop request (#606). */
-  count = hts_dns_resolve_nocache_list_bounded(host, resolved, HTS_MAXADDRNUM,
-                                               timeout, cancel, error);
+  count = hts_dns_resolve_nocache_list_bounded(
+      host, resolved, HTS_MAXADDRNUM, timeout, cancel, error, &permanent);
 
 #if HTS_WIDE_DEBUG
   DEBUG_W("gethostbyname done\n");
@@ -5650,8 +5672,11 @@ int hts_dns_resolve_all_bounded(httrackp *opt, const char *iadr, SOCaddr *out,
     if (record != NULL) {
       memset(record, 0, sizeof(*record));
       record->host_count = count;
-      /* "does not resolve" is only as good as the network that answered it */
-      record->expiry = count == 0 ? mtime_local() + hts_dns_negative_ttl_ms : 0;
+      /* The resolver saying the name does not exist stands for the crawl;
+         it being unable to answer is only as good as the network it asked. */
+      record->expiry = (count == 0 && !permanent)
+                           ? mtime_local() + hts_dns_negative_ttl_ms
+                           : 0;
       for (i = 0; i < count; i++) {
         record->host_length[i] = SOCaddr_size(resolved[i]);
         assertf(record->host_length[i] <= sizeof(record->host_addr[i]));

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -5186,7 +5186,8 @@ coucal hts_cache(httrackp *opt) {
   return opt->state.dns_cache;
 }
 
-/* First lifetime of a negative DNS answer. */
+/* First lifetime of a negative DNS answer. Unlocked because only the
+   self-test writes it, from the single thread that then resolves. */
 static int hts_dns_negative_ttl_ms = HTS_DNS_NEGATIVE_TTL_MS;
 
 void hts_dns_set_negative_ttl_ms(int ms) {
@@ -5202,6 +5203,21 @@ int hts_dns_negative_failures(httrackp *opt, const char *host) {
     failures = ((const t_dnscache *) ptr)->failures;
   hts_mutexrelease(&opt->state.lock);
   return failures;
+}
+
+void hts_dns_test_move_clock(httrackp *opt, const char *host, TStamp ms) {
+  void *ptr;
+
+  hts_mutexlock(&opt->state.lock);
+  if (coucal_read_pvoid(hts_cache(opt), host, &ptr)) {
+    t_dnscache *const record = (t_dnscache *) ptr;
+
+    if (record->expiry != 0) { /* a positive record carries no stamps */
+      record->expiry -= ms;
+      record->stored -= ms;
+    }
+  }
+  hts_mutexrelease(&opt->state.lock);
 }
 
 /* Doubles per consecutive failure up to the ceiling: an outage is retried
@@ -5234,9 +5250,15 @@ static int hts_ghbn_all(coucal cache, const char *const iadr,
     int i;
 
     assertf(record->host_count <= HTS_MAXADDRNUM);
-    /* an outage must not blacklist a host for the rest of the crawl */
-    if (record->expiry != 0 && mtime_local() >= record->expiry) {
-      return -1;
+    /* An outage must not blacklist a host for the rest of the crawl, and the
+       stamps are wall-clock: a clock now behind the store time expires the
+       record too, or an NTP step delays the retry by the size of the step. */
+    if (record->expiry != 0) {
+      const TStamp now = mtime_local();
+
+      if (now >= record->expiry || now < record->stored) {
+        return -1;
+      }
     }
     for (i = 0; i < record->host_count && i < max; i++) {
       assertf(record->host_length[i] <= sizeof(record->host_addr[i]));
@@ -5706,9 +5728,10 @@ int hts_dns_resolve_all_bounded(httrackp *opt, const char *iadr, SOCaddr *out,
       record->failures = count == 0 ? failures : 0;
       /* The resolver saying the name does not exist stands for the crawl;
          it being unable to answer is only as good as the network it asked. */
-      record->expiry = (count == 0 && !permanent)
-                           ? mtime_local() + hts_dns_negative_wait_ms(failures)
-                           : 0;
+      if (count == 0 && !permanent) {
+        record->stored = mtime_local();
+        record->expiry = record->stored + hts_dns_negative_wait_ms(failures);
+      }
       for (i = 0; i < count; i++) {
         record->host_length[i] = SOCaddr_size(resolved[i]);
         assertf(record->host_length[i] <= sizeof(record->host_addr[i]));

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -5186,7 +5186,7 @@ coucal hts_cache(httrackp *opt) {
   return opt->state.dns_cache;
 }
 
-/* Lifetime of a negative DNS answer; the self-test shortens it. */
+/* Lifetime of a negative DNS answer. */
 static int hts_dns_negative_ttl_ms = HTS_DNS_NEGATIVE_TTL_MS;
 
 void hts_dns_set_negative_ttl_ms(int ms) { hts_dns_negative_ttl_ms = ms; }
@@ -5209,8 +5209,7 @@ static int hts_ghbn_all(coucal cache, const char *const iadr,
     int i;
 
     assertf(record->host_count <= HTS_MAXADDRNUM);
-    /* A name that failed to resolve while the network was down must not stay
-       dead for the rest of the crawl: past its expiry, ask again. */
+    /* an outage must not blacklist a host for the rest of the crawl */
     if (record->expiry != 0 && mtime_local() >= record->expiry) {
       return -1;
     }

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -5189,7 +5189,9 @@ coucal hts_cache(httrackp *opt) {
 /* First lifetime of a negative DNS answer. */
 static int hts_dns_negative_ttl_ms = HTS_DNS_NEGATIVE_TTL_MS;
 
-void hts_dns_set_negative_ttl_ms(int ms) { hts_dns_negative_ttl_ms = ms; }
+void hts_dns_set_negative_ttl_ms(int ms) {
+  hts_dns_negative_ttl_ms = ms > 0 ? ms : 1; /* the doubling needs a floor */
+}
 
 int hts_dns_negative_failures(httrackp *opt, const char *host) {
   void *ptr;
@@ -5456,9 +5458,8 @@ static int hts_dns_resolve_nocache_list_(const char *const hostname,
   } else {
     if (error != NULL)
       *error = gai_strerror(gerr);
-    /* EAI_NONAME is the resolver's own answer about the name; every other
-       code (EAI_AGAIN, EAI_FAIL, EAI_SYSTEM, EAI_NODATA where it exists) says
-       it could not answer, which an outage produces for any host. */
+    /* EAI_NONAME answers about the name; every other code says the resolver
+       could not answer at all. */
     if (permanent != NULL && gerr == EAI_NONAME)
       *permanent = HTS_TRUE;
   }
@@ -5477,6 +5478,8 @@ static int hts_dns_resolve_nocache_list(const char *const hostname,
                                         const char **error,
                                         hts_boolean *permanent) {
   if (!strnotempty(hostname) || max <= 0) {
+    if (permanent != NULL)
+      *permanent = HTS_FALSE;
     return 0;
   }
   if ((hostname[0] == '[') && (hts_lastchar(hostname) == ']')) {

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -5186,10 +5186,33 @@ coucal hts_cache(httrackp *opt) {
   return opt->state.dns_cache;
 }
 
-/* Lifetime of a negative DNS answer. */
+/* First lifetime of a negative DNS answer. */
 static int hts_dns_negative_ttl_ms = HTS_DNS_NEGATIVE_TTL_MS;
 
 void hts_dns_set_negative_ttl_ms(int ms) { hts_dns_negative_ttl_ms = ms; }
+
+int hts_dns_negative_failures(httrackp *opt, const char *host) {
+  void *ptr;
+  int failures = 0;
+
+  hts_mutexlock(&opt->state.lock);
+  if (coucal_read_pvoid(hts_cache(opt), host, &ptr))
+    failures = ((const t_dnscache *) ptr)->failures;
+  hts_mutexrelease(&opt->state.lock);
+  return failures;
+}
+
+/* Doubles per consecutive failure up to the ceiling: an outage is retried
+   soon, a host that is simply gone costs a handful of lookups per crawl. */
+int hts_dns_negative_wait_ms(int failures) {
+  int wait = hts_dns_negative_ttl_ms;
+  int i;
+
+  for (i = 1; i < failures && wait < HTS_DNS_NEGATIVE_TTL_MAX_MS; i++)
+    wait *= 2;
+  return wait < HTS_DNS_NEGATIVE_TTL_MAX_MS ? wait
+                                            : HTS_DNS_NEGATIVE_TTL_MAX_MS;
+}
 
 // MUST BE LOCKED (coucal is not internally serialized vs FTP/web threads)
 // Look up iadr in the DNS cache, filling out[0..min(count,max)-1].
@@ -5668,14 +5691,20 @@ int hts_dns_resolve_all_bounded(httrackp *opt, const char *iadr, SOCaddr *out,
   { /* store the full list (coucal owns the record and dups the host key; a
        concurrent resolve of the same host replaces, and frees, this one) */
     t_dnscache *const record = malloct(sizeof(t_dnscache));
+    void *previous;
+    const int failures =
+        (count == 0 && coucal_read_pvoid(cache, host, &previous))
+            ? ((const t_dnscache *) previous)->failures + 1
+            : 1;
 
     if (record != NULL) {
       memset(record, 0, sizeof(*record));
       record->host_count = count;
+      record->failures = count == 0 ? failures : 0;
       /* The resolver saying the name does not exist stands for the crawl;
          it being unable to answer is only as good as the network it asked. */
       record->expiry = (count == 0 && !permanent)
-                           ? mtime_local() + hts_dns_negative_ttl_ms
+                           ? mtime_local() + hts_dns_negative_wait_ms(failures)
                            : 0;
       for (i = 0; i < count; i++) {
         record->host_length[i] = SOCaddr_size(resolved[i]);

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -155,9 +155,8 @@ struct t_dnscache {
   int host_count;
   size_t host_length[HTS_MAXADDRNUM]; // sockaddr length of each (16 or 28)
   char host_addr[HTS_MAXADDRNUM][HTS_MAXADDRLEN];
-  // mtime_local() past which a negative record must be resolved again; 0 for a
-  // positive one, which never expires. Appended at the tail: the record is only
-  // ever held through a pointer, so nothing embeds it. ABI
+  // mtime_local() past which a negative record must be resolved again; 0 on a
+  // positive one, which never expires
   TStamp expiry;
 };
 
@@ -324,7 +323,7 @@ coucal hts_cache(httrackp *opt);
 
 /* How long a name that did not resolve stays negative-cached. */
 #define HTS_DNS_NEGATIVE_TTL_MS 60000
-/* Test-only seam: shorten that so a self-test need not wait a minute. */
+/* Test-only: shorten it so a self-test need not wait a minute. */
 void hts_dns_set_negative_ttl_ms(int ms);
 
 // outils divers

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -158,6 +158,7 @@ struct t_dnscache {
   // mtime_local() past which a negative record must be resolved again; 0 on a
   // positive one, which never expires
   TStamp expiry;
+  int failures; // consecutive failed resolves, which lengthen the next wait
 };
 
 /* Break t down as UTC into the caller's buffer, HTS_FALSE if that failed.
@@ -321,10 +322,17 @@ int ftp_available(void);
 coucal hts_cache(httrackp *opt);
 #endif
 
-/* How long a name that did not resolve stays negative-cached. */
+/* How long a name that did not resolve stays negative-cached, and the ceiling
+   the wait doubles up to. */
 #define HTS_DNS_NEGATIVE_TTL_MS 60000
-/* Test-only: shorten it so a self-test need not wait a minute. */
+#define HTS_DNS_NEGATIVE_TTL_MAX_MS 900000
+/* Wait before asking again, after this many consecutive failures (>= 1). */
+int hts_dns_negative_wait_ms(int failures);
+/* Test-only: shorten the first wait so a self-test need not wait a minute. */
 void hts_dns_set_negative_ttl_ms(int ms);
+/* Consecutive failed resolves recorded for host, 0 if it is not cached or
+   resolves. Test-only: nothing in the engine reads it back. */
+int hts_dns_negative_failures(httrackp *opt, const char *host);
 
 // outils divers
 HTS_INLINE TStamp time_local(void);

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -155,6 +155,10 @@ struct t_dnscache {
   int host_count;
   size_t host_length[HTS_MAXADDRNUM]; // sockaddr length of each (16 or 28)
   char host_addr[HTS_MAXADDRNUM][HTS_MAXADDRLEN];
+  // mtime_local() past which a negative record must be resolved again; 0 for a
+  // positive one, which never expires. Appended at the tail: the record is only
+  // ever held through a pointer, so nothing embeds it. ABI
+  TStamp expiry;
 };
 
 /* Break t down as UTC into the caller's buffer, HTS_FALSE if that failed.
@@ -317,6 +321,11 @@ int ftp_available(void);
    on first use. Records are owned by the table and freed on coucal_delete. */
 coucal hts_cache(httrackp *opt);
 #endif
+
+/* How long a name that did not resolve stays negative-cached. */
+#define HTS_DNS_NEGATIVE_TTL_MS 60000
+/* Test-only seam: shorten that so a self-test need not wait a minute. */
+void hts_dns_set_negative_ttl_ms(int ms);
 
 // outils divers
 HTS_INLINE TStamp time_local(void);

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -155,9 +155,10 @@ struct t_dnscache {
   int host_count;
   size_t host_length[HTS_MAXADDRNUM]; // sockaddr length of each (16 or 28)
   char host_addr[HTS_MAXADDRNUM][HTS_MAXADDRLEN];
-  // mtime_local() past which a negative record must be resolved again; 0 on a
-  // positive one, which never expires
+  // mtime_local() past which a negative record must be resolved again, and
+  // when it was stored; both 0 on a positive one, which never expires
   TStamp expiry;
+  TStamp stored;
   int failures; // consecutive failed resolves, which lengthen the next wait
 };
 
@@ -333,6 +334,9 @@ void hts_dns_set_negative_ttl_ms(int ms);
 /* Consecutive failed resolves recorded for host, 0 if it is not cached or
    resolves. Test-only: nothing in the engine reads it back. */
 int hts_dns_negative_failures(httrackp *opt, const char *host);
+/* Test-only: move one cached negative record's stamps by ms, so a self-test
+   outlasts a wait (positive) or steps behind them (negative), no sleeps. */
+void hts_dns_test_move_clock(httrackp *opt, const char *host, TStamp ms);
 
 // outils divers
 HTS_INLINE TStamp time_local(void);

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -901,14 +901,15 @@ static PT_Element PT_ReadCache__New(PT_Index index, const char *url, int flags) 
       line[0] = '\0';                                                          \
     }                                                                          \
   } while (0)
-#define ZIP_READFIELD_INT(line, value, refline, refvalue) do { \
-  if (line[0] != '\0' && strfield2(line, refline)) { \
-    int intval = 0; \
-    sscanf(value, "%d", &intval); \
-    (refvalue) = intval; \
-    line[0] = '\0'; \
-	} \
-} while(0)
+#define ZIP_READFIELD_INT(line, value, refline, refvalue)                      \
+  do {                                                                         \
+    if (line[0] != '\0' && strfield2(line, refline)) {                         \
+      int intval = 0;                                                          \
+      sscanf(value, "%d", &intval);                                            \
+      (refvalue) = intval;                                                     \
+      line[0] = '\0';                                                          \
+    }                                                                          \
+  } while (0)
 
 /* Set path (capacity size) to filename's parent directory, separator included,
    from an absolute filename. Empty when there is none, or when it would not
@@ -1118,7 +1119,7 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
               ZIP_READFIELD_INT(line, value, "X-Statuscode", r->statuscode);
               ZIP_READFIELD_STRING(line, value, "X-StatusMessage", r->msg,
                                    sizeof(r->msg));
-              ZIP_READFIELD_INT(line, value, "X-Size", r->size);        // size
+              ZIP_READFIELD_INT(line, value, "X-Size", r->size); // size
               ZIP_READFIELD_STRING(line, value, "Content-Type", r->contenttype,
                                    sizeof(r->contenttype));
               ZIP_READFIELD_STRING(line, value, "X-Charset", r->charset,

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -901,15 +901,14 @@ static PT_Element PT_ReadCache__New(PT_Index index, const char *url, int flags) 
       line[0] = '\0';                                                          \
     }                                                                          \
   } while (0)
-#define ZIP_READFIELD_INT(line, value, refline, refvalue)                      \
-  do {                                                                         \
-    if (line[0] != '\0' && strfield2(line, refline)) {                         \
-      int intval = 0;                                                          \
-      sscanf(value, "%d", &intval);                                            \
-      (refvalue) = intval;                                                     \
-      line[0] = '\0';                                                          \
-    }                                                                          \
-  } while (0)
+#define ZIP_READFIELD_INT(line, value, refline, refvalue) do { \
+  if (line[0] != '\0' && strfield2(line, refline)) { \
+    int intval = 0; \
+    sscanf(value, "%d", &intval); \
+    (refvalue) = intval; \
+    line[0] = '\0'; \
+	} \
+} while(0)
 
 /* Set path (capacity size) to filename's parent directory, separator included,
    from an absolute filename. Empty when there is none, or when it would not
@@ -1119,7 +1118,7 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
               ZIP_READFIELD_INT(line, value, "X-Statuscode", r->statuscode);
               ZIP_READFIELD_STRING(line, value, "X-StatusMessage", r->msg,
                                    sizeof(r->msg));
-              ZIP_READFIELD_INT(line, value, "X-Size", r->size); // size
+              ZIP_READFIELD_INT(line, value, "X-Size", r->size);        // size
               ZIP_READFIELD_STRING(line, value, "Content-Type", r->contenttype,
                                    sizeof(r->contenttype));
               ZIP_READFIELD_STRING(line, value, "X-Charset", r->charset,


### PR DESCRIPTION
The DNS cache reads a resolve count of 0 as a valid answer and stores it with no expiry, so a name that did not resolve is never asked about again. A resolve that times out escapes this, and the comment says why. A fast failure does not, and that is what a device with no connectivity returns: every host first met during an outage stays unreachable for the rest of the crawl, long after the network is back. On a single-host mirror the remainder fails, and the per-link retries are spent on cache hits without ever touching DNS.

Negative answers now expire, and each consecutive failure for the same host doubles the wait, from a minute up to a ceiling of fifteen. That is what bounds the cost: a host that is simply gone is asked about a handful of times across a long crawl rather than once a minute. Positive answers are unchanged and last the crawl.

The stamp is wall-clock, since the tree has no monotonic clock, so a clock moving behind the moment a record was stored, after an NTP correction or a suspend and resume, would delay every pending retry by the size of the step. At the ceiling that leaves a merely unreachable host dead for the rest of the crawl, which is the bug this branch removes. Introducing a monotonic clock across the tree's platforms for one cache is not worth it, so the store time sits beside the expiry and a clock behind it counts as expired. Retrying early is the safe direction.

Where the resolver distinguishes them, `EAI_NONAME` is an answer about the name itself and still stands for the whole crawl, so the common dead-link case behaves exactly as it does today. Every other code says the resolver could not answer, which is what an outage produces for any host. Android maps all of them, NXDOMAIN included, onto `EAI_NODATA`, measured on API 25 and 36 with an online control; there the class buys nothing and the doubling is what protects the crawl. Compare symbols, not numbers: Bionic and glibc order these differently.

The self-test asserted the old behaviour, one backend call for a host that does not resolve. It now pins the expiry, the failure count that lengthens it, the ceiling, that a positive answer does not expire, that `EAI_NONAME` still does not, and that a backward clock step re-asks. Its outage host had to change from `EAI_NONAME` to `EAI_AGAIN`, the code that case actually returns. Nothing sleeps for a wait any more: a test-only hook moves a cached record's stamps, so the doubling is table-tested and the "still inside the wait" check no longer races a stalled runner.

`t_dnscache` grows three fields at its tail. `htslib.h` is not an installed header, so this is internal.

Found by the httrack-android robustness audit, where this compounds with the update purge: a host that dies during an outage decides which files the purge then removes.
