### PR TITLE
A one-tick clock straddle reddens the suite-timeout test under emulation

### DIFF
--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -226,15 +226,18 @@ secs 0 0
 
 # budget_left hands a child what is left of it, and keeps 0 meaning "no guard".
 # shellcheck disable=SC2016 # the fixture has to call the helper, not us
-printf '. "%s"\nsleep 2\necho "left=$(budget_left) at=$SECONDS"\n' "${testdir}/testlib.sh" \
-    >"$tmp/98_left.test"
-# Exact, against the clock the child itself read: a tolerance would pass a wrong epoch.
+printf '. "%s"\nsleep 2\nat=$SECONDS\nleft=$(budget_left)\necho "left=$left at=$at at2=$SECONDS"\n' \
+    "${testdir}/testlib.sh" >"$tmp/98_left.test"
+# Bracketed by the child's own clock either side of the call, not a tolerance:
+# SECONDS floors, so a read that straddles a tick is one high and nothing is wrong.
 HTTRACK_TEST_TIMEOUT=60 bash "$driver" "$tmp/98_left.test" >"$out" 2>&1
 got=$(sed -n 's/^left=\([0-9][0-9]*\) .*/\1/p' "$out")
-at=$(sed -n 's/^left=[0-9][0-9]* at=\([0-9][0-9]*\)$/\1/p' "$out")
-case "$got$at" in '' | *[!0-9]*) fail "a 60s budget printed '$(cat "$out")'" ;; esac
-test "$got" -eq "$((60 - at))" ||
-    fail "a 60s budget left $got with $at gone, want $((60 - at))"
+at=$(sed -n 's/^left=[0-9][0-9]* at=\([0-9][0-9]*\) .*/\1/p' "$out")
+at2=$(sed -n 's/^left=[0-9][0-9]* at=[0-9][0-9]* at2=\([0-9][0-9]*\)$/\1/p' "$out")
+case "$got$at$at2" in '' | *[!0-9]*) fail "a 60s budget printed '$(cat "$out")'" ;; esac
+if test "$got" -gt "$((60 - at))" || test "$got" -lt "$((60 - at2))"; then
+    fail "a 60s budget left $got with $at to $at2 gone, want $((60 - at2))..$((60 - at))"
+fi
 HTTRACK_TEST_TIMEOUT=0 bash "$driver" "$tmp/98_left.test" >"$out" 2>&1
 grep -q '^left=0 ' "$out" || fail "a disabled guard left '$(cat "$out")', want 0"
 # Never 0 on an exhausted budget: a child would read that as the guard being off.


### PR DESCRIPTION
`105_suite-timeout` compares two reads of `SECONDS` for exact equality, an assertion latent since #1231 landed it on 2026-08-13. The fixture is `echo "left=$(budget_left) at=$SECONDS"`, and `budget_left` computes `60 - SECONDS` inside the command substitution, so the two reads happen at different instants. `SECONDS` floors, so when they fall either side of a second boundary the test reports `left` one higher than it expects and fails.

Natively the window between the reads is about 250 microseconds and it almost never fires. On the emulated s390x leg, where every instruction is interpreted and `make check -j` adds contention, a scheduling hiccup of a few hundred milliseconds in that window is ordinary: it reddened #1391 with `a 60s budget left 58 with 3 gone, want 57`, on a branch that had passed the same leg twice earlier the same day and that touches neither this test nor the timeout helpers.

The fixture now samples the clock either side of the call and the assertion accepts the one-tick range those two reads bracket. That is not a tolerance: it is still exact against the clock the child itself read, so a wrong epoch stays a failure. Proved both ways. Replaying the fixture with the 0.4s straddle that reproduces the flake passes five times out of five, and making `budget_left` drop the elapsed term fails with `left 60 with 2 to 2 gone, want 58..58`.
