### PR TITLE
The emulated leg spends a third of its time compiling headers for a property that cannot vary by target

### DIFF
--- a/tests/206_install-headers-c99.test
+++ b/tests/206_install-headers-c99.test
@@ -10,6 +10,8 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
+skip_if_emulated "a dialect sweep says nothing about the target: 205 still compiles these headers against this arch's config.h"
+
 # Unset means no automake run (the Windows job runs the scripts directly), so
 # there is no install rule to drive.
 if [ -z "${abs_top_builddir:-}" ]; then

--- a/tests/206_install-headers-c99.test
+++ b/tests/206_install-headers-c99.test
@@ -10,7 +10,7 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-skip_if_emulated "a dialect sweep says nothing about the target: 205 still compiles these headers against this arch's config.h"
+skip_on_emulated "a dialect sweep cannot vary by target, and 205 still runs here"
 
 # Unset means no automake run (the Windows job runs the scripts directly), so
 # there is no install rule to drive.

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -24,6 +24,15 @@ holds() {
     test "$rc" -eq 0 || fail "[$1] should have held, exited $rc: $out"
 }
 
+skips() { # skip_on_* exits 77, which holds() would read as a failure
+    run_subject "$1"
+    test "$rc" -eq 77 || fail "[$1] should have skipped, exited $rc: $out"
+    case "$out" in
+    *"$2"*) ;;
+    *) fail "[$1] skipped without reporting '$2': $out" ;;
+    esac
+}
+
 # Match $2 literally, not with assert_match, which is what this file tests.
 fires() {
     run_subject "$1"
@@ -213,3 +222,14 @@ esac
 got=$(env -u IS_WINDOWS bash "$tmpdir/win.sh")
 test "$got" = "$want" || fail "is_windows on this host is [$got], want [$want]"
 ok "is_windows agrees with the host's own uname -s ($want)"
+
+# skip_on_emulated deletes tests when it fires, and a skip is green, so an
+# inverted guard would quietly empty every leg with nothing going red.
+holds 'unset EMULATED_ARCH; skip_on_emulated why; printf ok'
+ok "skip_on_emulated holds where EMULATED_ARCH is unset"
+# Exported but empty is the shape a workflow typo leaves behind.
+holds 'EMULATED_ARCH=; export EMULATED_ARCH; skip_on_emulated why; printf ok'
+ok "an empty EMULATED_ARCH does not delete the suite"
+skips 'EMULATED_ARCH=s390x; export EMULATED_ARCH; skip_on_emulated why' 'why'
+skips 'EMULATED_ARCH=s390x; export EMULATED_ARCH; skip_on_emulated why' 's390x'
+ok "skip_on_emulated skips under an emulated arch, naming it and the reason"

--- a/tests/269_install-headers-order.test
+++ b/tests/269_install-headers-order.test
@@ -7,8 +7,8 @@
 # of reach here. The sweep is shared with the MSVC job, which has no automake to
 # install with and so stages the same list out of DevIncludes_DATA (#1153).
 #
-# n^2 compiles is real work, not a wedge: emulated, it needs more than the suite's
-# default budget, and the sweep paces itself against whatever is left of this one.
+# n^2 compiles is real work, not a wedge: the sweep paces itself against whatever
+# is left of this budget.
 # TEST_TIMEOUT_AT_LEAST: 900
 
 set -euo pipefail
@@ -16,7 +16,7 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-skip_if_emulated "include order says nothing about the target: 205 still compiles these headers against this arch's config.h"
+skip_on_emulated "include order cannot vary by target, and 205 still runs here"
 
 if [ -z "${abs_top_builddir:-}" ]; then
     echo "abs_top_builddir unset, no automake environment, skipping" >&2

--- a/tests/269_install-headers-order.test
+++ b/tests/269_install-headers-order.test
@@ -16,6 +16,8 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
+skip_if_emulated "include order says nothing about the target: 205 still compiles these headers against this arch's config.h"
+
 if [ -z "${abs_top_builddir:-}" ]; then
     echo "abs_top_builddir unset, no automake environment, skipping" >&2
     exit 77

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -66,9 +66,9 @@ skip() {
 # is merely not on Windows.
 skip_on_windows() { ! is_windows || skip "$*"; }
 
-# The emulated leg (tools/emulated-suite.sh) interprets every instruction, so a
-# sweep that spawns one compiler per case costs minutes there. Same guard form.
-skip_if_emulated() { [ -z "${EMULATED_ARCH:-}" ] || skip "$* under emulated ${EMULATED_ARCH}"; }
+# Set by tools/emulated-suite.sh, which interprets every instruction it runs.
+is_emulated() { [ -n "${EMULATED_ARCH:-}" ]; }
+skip_on_emulated() { ! is_emulated || skip "emulated ${EMULATED_ARCH}: $*"; }
 
 # Assertions, each printing what it wanted beside what arrived: a bare
 # `|| exit 1` reds a test without naming the value that differed.

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -66,6 +66,10 @@ skip() {
 # is merely not on Windows.
 skip_on_windows() { ! is_windows || skip "$*"; }
 
+# The emulated leg (tools/emulated-suite.sh) interprets every instruction, so a
+# sweep that spawns one compiler per case costs minutes there. Same guard form.
+skip_if_emulated() { [ -z "${EMULATED_ARCH:-}" ] || skip "$* under emulated ${EMULATED_ARCH}"; }
+
 # Assertions, each printing what it wanted beside what arrived: a bare
 # `|| exit 1` reds a test without naming the value that differed.
 assert_eq() { # assert_eq WANT GOT [LABEL]


### PR DESCRIPTION
The emulated s390x leg takes 31 minutes, and 28% of that is two tests: `269_install-headers-order` at 5m45s and `206_install-headers-c99` at 2m46s. Both sweep compilers, one process per case (269 is every ordered pair of installed headers, so n² of them), and qemu user-mode emulation pays a cold start on every `execve`. Measured from the job log: apt 141s, bootstrap and configure 173s, build 410s, `make check` 1138s, of which those two are 511s.

Neither property can vary by target. 269 asks whether the headers survive any include order; 206 asks whether they compile as strict ISO C and as C++. An include order that works on x86-64 works on s390x, and both already run on every native leg.

What does vary by target is `config.h`, which is in `DevIncludes_DATA`, so compiling the installed headers on s390x does exercise that architecture's generated config. That is why only these two are skipped: `205_install-headers` still runs there, still compiles every installed header standalone in both `HTS_INTERNAL_BYTECODE` states, and so keeps the part of the coverage that is actually architecture-specific. `278_install-headers-msvc` is untouched.

The guard splits the way `is_windows` and `skip_on_windows` do: `is_emulated` reads `EMULATED_ARCH`, which `tools/emulated-suite.sh` already requires, and `skip_on_emulated` is the errexit-safe wrapper. Proved both ways: both tests PASS on a native run and SKIP with `EMULATED_ARCH` set, 205 and 278 still PASS with it set, and the emulated pass floor has 91 to spare.

The guard itself is tested, because its worst failure is silent. Wired backwards it skips on every leg, and a skip is green, so no job would go red and the emulated pass floor is a lower bound that cannot see two extra skips either way. `257_testlib-asserts` gains a `skips` verdict helper and three cases: the guard holds when `EMULATED_ARCH` is unset, holds when it is exported but empty (the shape a workflow typo leaves), and names both the arch and the reason when it fires. Each kills a distinct mutant: the plain inversion, an inversion that cannot trip `set -u`, and an `is_emulated` that counts set-but-empty as emulated.

