### PR TITLE
The macOS legs build against an OpenSSL nobody installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,8 +275,8 @@ jobs:
   # Portability: build and test on macOS (Darwin/clang) on a native runner --
   # no VM. The tree has no __APPLE__ branches, so Darwin exercises the
   # generic-Unix path on a second libc and kernel. openssl@4 is what the
-  # homebrew-core httrack formula depends on, so it is what macOS users get;
-  # it is keg-only, hence the explicit paths.
+  # homebrew-core formula depends on, so it is what brew installs run; the DMG
+  # ships openssl@3, which macos-app still builds. Keg-only, hence the paths.
   macos:
     name: build (macOS arm64, clang)
     runs-on: macos-15
@@ -300,6 +300,9 @@ jobs:
             LDFLAGS="-L${ssl}/lib -L${brewp}/lib"
           grep -q "define HTS_USEBROTLI 1" config.h
           grep -q "define HTS_USEZSTD 1" config.h
+          # brew --prefix answers for a formula it has not installed, so a
+          # renamed or missing bottle would leave every TLS test skipping.
+          grep -q "define HTS_USEOPENSSL 1" config.h
 
       - name: Build
         run: make -j"$(sysctl -n hw.ncpu)"
@@ -403,7 +406,9 @@ jobs:
       - name: Build and install into a temp prefix
         run: |
           set -euo pipefail
-          ssl="$(brew --prefix openssl@4)"
+          # openssl@3, matching macos-release.yml: this job is the release path
+          # minus Apple, so it has to bundle what the signed DMG bundles.
+          ssl="$(brew --prefix openssl@3)"
           brewp="$(brew --prefix)"
           ./bootstrap
           ./configure CPPFLAGS="-I${ssl}/include -I${brewp}/include" \
@@ -442,7 +447,7 @@ jobs:
           ls "$app/Contents/Frameworks"/libssl.*.dylib >/dev/null
           # The kegs, not just the opt symlinks: a source build records the Cellar path.
           hidden=""
-          for keg in openssl@4 brotli zstd; do
+          for keg in openssl@3 brotli zstd; do
             for d in "$(brew --prefix)/opt/$keg" "$(brew --prefix)/Cellar/$keg"; do
               if [ -e "$d" ]; then sudo mv "$d" "$d.hidden"; hidden="$hidden $d"; fi
             done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,8 +274,9 @@ jobs:
 
   # Portability: build and test on macOS (Darwin/clang) on a native runner --
   # no VM. The tree has no __APPLE__ branches, so Darwin exercises the
-  # generic-Unix path on a second libc and kernel. brew's openssl@3 is keg-only,
-  # so point configure at it; everything else is in the SDK or default paths.
+  # generic-Unix path on a second libc and kernel. openssl@4 is what the
+  # homebrew-core httrack formula depends on, so it is what macOS users get;
+  # it is keg-only, hence the explicit paths.
   macos:
     name: build (macOS arm64, clang)
     runs-on: macos-15
@@ -292,7 +293,7 @@ jobs:
       - name: Configure
         run: |
           set -euo pipefail
-          ssl="$(brew --prefix openssl@3)"
+          ssl="$(brew --prefix openssl@4)"
           brewp="$(brew --prefix)"
           autoreconf -fi
           ./configure CPPFLAGS="-I${ssl}/include -I${brewp}/include" \
@@ -340,7 +341,7 @@ jobs:
       - name: Build and install into a temp prefix
         run: |
           set -euo pipefail
-          ssl="$(brew --prefix openssl@3)"
+          ssl="$(brew --prefix openssl@4)"
           brewp="$(brew --prefix)"
           autoreconf -fi
           ./configure CPPFLAGS="-I${ssl}/include -I${brewp}/include" \
@@ -402,7 +403,7 @@ jobs:
       - name: Build and install into a temp prefix
         run: |
           set -euo pipefail
-          ssl="$(brew --prefix openssl@3)"
+          ssl="$(brew --prefix openssl@4)"
           brewp="$(brew --prefix)"
           ./bootstrap
           ./configure CPPFLAGS="-I${ssl}/include -I${brewp}/include" \
@@ -441,7 +442,7 @@ jobs:
           ls "$app/Contents/Frameworks"/libssl.*.dylib >/dev/null
           # The kegs, not just the opt symlinks: a source build records the Cellar path.
           hidden=""
-          for keg in openssl@3 brotli zstd; do
+          for keg in openssl@4 brotli zstd; do
             for d in "$(brew --prefix)/opt/$keg" "$(brew --prefix)/Cellar/$keg"; do
               if [ -e "$d" ]; then sudo mv "$d" "$d.hidden"; hidden="$hidden $d"; fi
             done

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -58,7 +58,7 @@ TESTS_ENVIRONMENT += PKGCONFIG_RPATH=$(PKGCONFIG_RPATH)
 TESTS_ENVIRONMENT += MAKE="$(MAKE)"
 # 205_install-headers.test compiles the installed headers with the build's compiler.
 # CPPFLAGS carries the dependency include paths a consumer needs too: brew's
-# openssl@3 is keg-only, so htsbasenet.h finds <openssl/ssl.h> only through it.
+# brew's openssl is keg-only, so htsbasenet.h finds <openssl/ssl.h> only through it.
 TESTS_ENVIRONMENT += CC="$(CC)"
 TESTS_ENVIRONMENT += TEST_CPPFLAGS="$(CPPFLAGS)"
 # 331_fortify-source.test rebuilds a fortifiable probe with the build's own

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -58,7 +58,7 @@ TESTS_ENVIRONMENT += PKGCONFIG_RPATH=$(PKGCONFIG_RPATH)
 TESTS_ENVIRONMENT += MAKE="$(MAKE)"
 # 205_install-headers.test compiles the installed headers with the build's compiler.
 # CPPFLAGS carries the dependency include paths a consumer needs too: brew's
-# brew's openssl is keg-only, so htsbasenet.h finds <openssl/ssl.h> only through it.
+# openssl is keg-only, so htsbasenet.h finds <openssl/ssl.h> only through it.
 TESTS_ENVIRONMENT += CC="$(CC)"
 TESTS_ENVIRONMENT += TEST_CPPFLAGS="$(CPPFLAGS)"
 # 331_fortify-source.test rebuilds a fortifiable probe with the build's own


### PR DESCRIPTION
The homebrew-core httrack formula depends on `openssl@4`, and Homebrew is where most macOS users get httrack. Our three macOS jobs pinned `openssl@3`, so no leg of ours ever built what those users run: a break there would have reached us as a bug report, not a red check. This points them at `openssl@4`.

The engine needed no changes. Every OpenSSL identifier we use is still declared in the 4.0.1 headers with no deprecation attribute, certificate verification is still off by default (`verify_mode = SSL_VERIFY_NONE` in `SSL_CTX_new_ex`), the default security level is still 2, and the two `#if OPENSSL_VERSION_NUMBER` guards in `htslib.c` resolve the same way for 4.0.1's `0x40000010L`. I built master against a from-source OpenSSL 4.0.1 and ran the suite: zero warnings, 370 pass / 12 skip / 0 fail, with `14_local-https.test` and the other TLS tests running instead of skipping, plus a live https crawl. Details in httrack-works `design/openssl4-compat.md`.

3.x keeps its coverage from every Linux leg, the Debian package build and distcheck, so nothing is lost by moving. `macos-release.yml` stays on `openssl@3` on purpose: it decides which dylibs the signed DMG carries, which is a shipping decision and not a CI one, and the bundling mechanics the `macos-app` job exercises are soname-agnostic.
