### PR TITLE
Greek.txt declares ISO-8859-7 but is written in cp1253

### DIFF
--- a/lang/Greek.txt
+++ b/lang/Greek.txt
@@ -13,7 +13,7 @@ Greek
 OK
 Εντάξει
 Cancel
-Άκυρο
+¶κυρο
 Exit
 Έξοδος
 Close
@@ -47,7 +47,7 @@ Select a rule for the filter
 Enter keywords for the filter
 Τοποθετήστε λέξεις-κλειδιά για το φίλτρο
 Cancel
-Άκυρο
+¶κυρο
 Add this rule
 Πρόσθεση αυτού του κανόνα
 Please enter one or several keyword(s) for the rule
@@ -121,7 +121,7 @@ Click to quit WinHTTrack Website Copier
 View log files
 Αρχείο γεγονότων
 Browse HTML start page
-Άνοιγμα της αρχικής σελίδας
+¶νοιγμα της αρχικής σελίδας
 End of mirror
 Τέλος αντιγραφής
 View log files
@@ -751,7 +751,7 @@ About WinHTTrack...
 New project\tCtrl+N
 Νέα εργασία\tCtrl+N
 &Open...\tCtrl+O
-Ά&νοιγμα...\tCtrl+O
+¶&νοιγμα...\tCtrl+O
 &Save\tCtrl+S
 &Αποθήκευση\tCtrl+S
 Save &As...
@@ -871,7 +871,7 @@ Too manu URLs, cannot handle so many links!!
 Not enough memory, fatal internal error..
 Δεν υπάρχει αρκετή μνήμη, εσωτερικό καταστροφικό σφάλμα...
 Unknown operation!
-Άγνωστη λειτουργία!
+¶γνωστη λειτουργία!
 Add this URL?\r\n
 Πρόσθεση αυτού του URL;\r\n
 Warning: main process is still not responding, cannot add URL(s)..

--- a/lang/Greek.txt
+++ b/lang/Greek.txt
@@ -7,13 +7,13 @@ el
 LANGUAGE_AUTHOR
 Michael Papadakis (mikepap at freemail dot gr)\r\n
 LANGUAGE_CHARSET
-ISO-8859-7
+windows-1253
 LANGUAGE_WINDOWSID
 Greek
 OK
 Εντάξει
 Cancel
-¶κυρο
+Άκυρο
 Exit
 Έξοδος
 Close
@@ -47,7 +47,7 @@ Select a rule for the filter
 Enter keywords for the filter
 Τοποθετήστε λέξεις-κλειδιά για το φίλτρο
 Cancel
-¶κυρο
+Άκυρο
 Add this rule
 Πρόσθεση αυτού του κανόνα
 Please enter one or several keyword(s) for the rule
@@ -121,7 +121,7 @@ Click to quit WinHTTrack Website Copier
 View log files
 Αρχείο γεγονότων
 Browse HTML start page
-¶νοιγμα της αρχικής σελίδας
+Άνοιγμα της αρχικής σελίδας
 End of mirror
 Τέλος αντιγραφής
 View log files
@@ -751,7 +751,7 @@ About WinHTTrack...
 New project\tCtrl+N
 Νέα εργασία\tCtrl+N
 &Open...\tCtrl+O
-¶&νοιγμα...\tCtrl+O
+Ά&νοιγμα...\tCtrl+O
 &Save\tCtrl+S
 &Αποθήκευση\tCtrl+S
 Save &As...
@@ -871,7 +871,7 @@ Too manu URLs, cannot handle so many links!!
 Not enough memory, fatal internal error..
 Δεν υπάρχει αρκετή μνήμη, εσωτερικό καταστροφικό σφάλμα...
 Unknown operation!
-¶γνωστη λειτουργία!
+Άγνωστη λειτουργία!
 Add this URL?\r\n
 Πρόσθεση αυτού του URL;\r\n
 Warning: main process is still not responding, cannot add URL(s)..
@@ -1047,7 +1047,7 @@ Start a new WARC segment once the current one grows past this many bytes; leave 
 Host aliases:
 Ψευδώνυμα host:
 Other hostnames serving this same site, folded onto one, one rule per line (e.g. www2.example.com,m.example.com=example.com).
-¶λλα ονόματα host που εξυπηρετούν την ίδια τοποθεσία, ενοποιημένα σε ένα, ένας κανόνας ανά γραμμή (π.χ. www2.example.com,m.example.com=example.com).
+Άλλα ονόματα host που εξυπηρετούν την ίδια τοποθεσία, ενοποιημένα σε ένα, ένας κανόνας ανά γραμμή (π.χ. www2.example.com,m.example.com=example.com).
 Mirror %s and every host below it
 Αντιγραφή του %s και κάθε host κάτω από αυτό
 Ignore %s and every host below it

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -120,13 +120,11 @@ charset_declared_matches_bytes() {
         echo "${f##*/}:$ln: line fully decodes as UTF-8 despite declared $cs; mixed encoding"
         return 1
     fi
-    # ISO-8859-7 reads 0xa2 as a right single quote where cp1253 reads capital
-    # alpha with tonos, so a value authored in the codepage opens a word with a
-    # quote that never closes. Above C1, so the check above cannot see it.
+    # The C1 check sees 0x80..0x9f only; cp1253's letters at 0xa1/0xa2 read as quotes here.
     ln=$(LC_ALL=C awk -v lead="$lead_quote" -v any="$smart_quote" \
         '$0 ~ lead { s = $0; if (gsub(any, "", s) == 1) { print NR; exit } }' "$tmp/utf8")
     if [ -n "$ln" ]; then
-        echo "${f##*/}:$ln: value opens with an unclosed curly quote under declared $cs; a codepage letter"
+        echo "${f##*/}:$ln: value opens with an unclosed curly quote under declared $cs; the byte is a letter in the codepage"
         return 1
     fi
     return 0
@@ -148,7 +146,7 @@ else
         'NR == 20 { print repl; next } { print }' "$langdir/Francais.txt" >"$tmp/utf8mix.txt"
     LC_ALL=C awk -v repl="$leak" \
         'NR == 20 { print repl; next } { print }' "$langdir/Chinese-Simplified.txt" >"$tmp/utf8mixmb.txt"
-    # 0xa2 is the byte Greek.txt carried on five values until it was repaired.
+    # Put the cp1253 byte back on a Greek value; the check must reject it.
     LC_ALL=C awk -v q="$(printf '\242')" \
         'NR == 16 { print q substr($0, 2); next } { print }' "$langdir/Greek.txt" >"$tmp/leadquote.txt"
     for probe in undecodable c1 utf8mix utf8mixmb leadquote; do
@@ -167,6 +165,15 @@ else
         echo "charset check saw $nchecked of $nfiles language files"
         exit 1
     fi
+fi
+
+# Άκυρο in ISO-8859-7. The check above only proves a value is not a quote, so
+# pin the one the repair landed on: a wrong byte there is a different word.
+cancel=$(LC_ALL=C awk '{ sub(/\r$/, "") } $0 == "Cancel" { getline v; sub(/\r$/, "", v); print v; exit }' \
+    "$langdir/Greek.txt")
+if [ "$cancel" != "$(printf '\266\352\365\361\357')" ]; then
+    echo "Greek.txt: the Cancel value is not the expected ISO-8859-7 bytes for the Greek word"
+    fail=1
 fi
 
 # LANGUAGE_FILE is the catalog basename and reaches the network as the update

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -75,6 +75,8 @@ c1=$(printf '\302[\200-\237]')
 # the ASCII range because an awk record cannot hold one, and no lang file has any.
 utf8_full_line=$(printf '^([\001-\177]|[\302-\337][\200-\277]|\340[\240-\277][\200-\277]|[\341-\354][\200-\277][\200-\277]|\355[\200-\237][\200-\277]|[\356-\357][\200-\277][\200-\277]|\360[\220-\277][\200-\277][\200-\277]|[\361-\363][\200-\277][\200-\277][\200-\277]|\364[\200-\217][\200-\277][\200-\277])*$')
 high_byte=$(printf '[\200-\377]')
+smart_quote=$(printf '\342\200[\230-\236]')
+lead_quote=$(printf '^\342\200[\230-\236]')
 # The value line following a metadata key. Most catalogs are CRLF, Uzbek.txt is not.
 field() {
     LC_ALL=C awk -v key="$2" '
@@ -118,6 +120,15 @@ charset_declared_matches_bytes() {
         echo "${f##*/}:$ln: line fully decodes as UTF-8 despite declared $cs; mixed encoding"
         return 1
     fi
+    # ISO-8859-7 reads 0xa2 as a right single quote where cp1253 reads capital
+    # alpha with tonos, so a value authored in the codepage opens a word with a
+    # quote that never closes. Above C1, so the check above cannot see it.
+    ln=$(LC_ALL=C awk -v lead="$lead_quote" -v any="$smart_quote" \
+        '$0 ~ lead { s = $0; if (gsub(any, "", s) == 1) { print NR; exit } }' "$tmp/utf8")
+    if [ -n "$ln" ]; then
+        echo "${f##*/}:$ln: value opens with an unclosed curly quote under declared $cs; a codepage letter"
+        return 1
+    fi
     return 0
 }
 
@@ -137,7 +148,10 @@ else
         'NR == 20 { print repl; next } { print }' "$langdir/Francais.txt" >"$tmp/utf8mix.txt"
     LC_ALL=C awk -v repl="$leak" \
         'NR == 20 { print repl; next } { print }' "$langdir/Chinese-Simplified.txt" >"$tmp/utf8mixmb.txt"
-    for probe in undecodable c1 utf8mix utf8mixmb; do
+    # 0xa2 is the byte Greek.txt carried on five values until it was repaired.
+    LC_ALL=C awk -v q="$(printf '\242')" \
+        'NR == 16 { print q substr($0, 2); next } { print }' "$langdir/Greek.txt" >"$tmp/leadquote.txt"
+    for probe in undecodable c1 utf8mix utf8mixmb leadquote; do
         if charset_declared_matches_bytes "$tmp/$probe.txt" >/dev/null; then
             echo "the charset check passed a deliberately mislabelled file ($probe)"
             exit 1

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -146,9 +146,8 @@ else
         'NR == 20 { print repl; next } { print }' "$langdir/Francais.txt" >"$tmp/utf8mix.txt"
     LC_ALL=C awk -v repl="$leak" \
         'NR == 20 { print repl; next } { print }' "$langdir/Chinese-Simplified.txt" >"$tmp/utf8mixmb.txt"
-    # Put the cp1253 byte back on a Greek value; the check must reject it.
-    LC_ALL=C awk -v q="$(printf '\242')" \
-        'NR == 16 { print q substr($0, 2); next } { print }' "$langdir/Greek.txt" >"$tmp/leadquote.txt"
+    # Greek read as ISO-8859-7 is the defect itself: its letters become quotes.
+    LC_ALL=C sed '10s/.*/ISO-8859-7/' "$langdir/Greek.txt" >"$tmp/leadquote.txt"
     for probe in undecodable c1 utf8mix utf8mixmb leadquote; do
         if charset_declared_matches_bytes "$tmp/$probe.txt" >/dev/null; then
             echo "the charset check passed a deliberately mislabelled file ($probe)"
@@ -167,12 +166,17 @@ else
     fi
 fi
 
-# Άκυρο in ISO-8859-7. The check above only proves a value is not a quote, so
-# pin the one the repair landed on: a wrong byte there is a different word.
+# Άκυρο in windows-1253. The check above only proves a value is not a quote.
 cancel=$(LC_ALL=C awk '{ sub(/\r$/, "") } $0 == "Cancel" { getline v; sub(/\r$/, "", v); print v; exit }' \
     "$langdir/Greek.txt")
-if [ "$cancel" != "$(printf '\266\352\365\361\357')" ]; then
-    echo "Greek.txt: the Cancel value is not the expected ISO-8859-7 bytes for the Greek word"
+if [ "$cancel" != "$(printf '\242\352\365\361\357')" ]; then
+    echo "Greek.txt: the Cancel value is not the expected windows-1253 bytes for the Greek word"
+    fail=1
+fi
+# 0xb6 is the ISO-8859-7 spelling of that same letter, and a pilcrow here.
+stray=$(LC_ALL=C tr -dc '\266' <"$langdir/Greek.txt" | wc -c)
+if [ "$stray" -ne 0 ]; then
+    echo "Greek.txt: $stray bytes 0xb6 remain, mixing ISO-8859-7 into windows-1253"
     fail=1
 fi
 


### PR DESCRIPTION
lang/Greek.txt declares ISO-8859-7, but five of its values hold 0xa2, which is capital alpha with tonos in cp1253 and a right single quote in ISO-8859-7. Every front end that obeys the declaration renders the Cancel button as a quote mark followed by kappa, and the same happens to the start-page action, the &Open menu item and the unknown-operation error.

The file is cp1253, so the declaration is the part that is wrong. Declaring `windows-1253` and changing the one remaining ISO-8859-7 byte, the 0xb6 that opens the host-alias help text on line 1050, makes it uniform. Two lines, and all six values then render correctly on both front ends. The other repair, rewriting the five bytes to 0xb6 and keeping the ISO declaration, fixes WebHTTrack and breaks WinHTTrack, which decodes catalog bytes with the system ACP rather than the declaration: it would take Greek there from one wrong string to six, in the release where that GUI is what ships.

The charset check in `62_lang-integrity` could not see this. What #963 added catches a codepage byte only inside C1, U+0080 to U+009F, and 0xa2 sits above it. The test now asserts that no value opens with a curly quote that never closes, pins Cancel to its cp1253 bytes, and requires no 0xb6 to remain. Each sits behind a positive control, so none can be deleted quietly.

This predates 3.49, so it is not a regression against 3.49.23.
