### PR TITLE
The DNS resolver declares after a statement, where our CI cannot see it

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -2124,15 +2124,16 @@ int httpmirror(char *url1, httrackp * opt) {
                               StringBuff(opt->path_log), "hts-cache/old.lst"),
                       "rb");
       if (old_lst) {
+        const size_t sz = llint_to_size_t(fsize_utf8(
+            fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                    StringBuff(opt->path_log), "hts-cache/new.lst")));
+
         if (opt->delete_old && !purge_files) {
           hts_log_print(opt, LOG_WARNING,
                         "A page could not be fetched and the links it carries "
                         "were never scanned: keeping all previously mirrored "
                         "files");
         }
-        const size_t sz = llint_to_size_t(fsize_utf8(
-            fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
-                    StringBuff(opt->path_log), "hts-cache/new.lst")));
         new_lst = FOPEN(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
                                 StringBuff(opt->path_log), "hts-cache/new.lst"),
                         "rb");

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -5427,16 +5427,14 @@ static int hts_dns_resolve_nocache_list_(const char *const hostname,
                                          const char **error,
                                          hts_boolean *permanent) {
   int count = 0;
-
-  if (permanent != NULL)
-    *permanent = HTS_FALSE;
+  hts_boolean is_permanent = HTS_FALSE;
 
 #if HTS_INET6==0
   /* IPv4 resolver */
   struct hostent *const hp = gethostbyname(hostname);
 
-  if (hp == NULL && permanent != NULL && h_errno == HOST_NOT_FOUND)
-    *permanent = HTS_TRUE;
+  if (hp == NULL && h_errno == HOST_NOT_FOUND)
+    is_permanent = HTS_TRUE;
   if (hp != NULL) {
     char **h;
 
@@ -5477,14 +5475,16 @@ static int hts_dns_resolve_nocache_list_(const char *const hostname,
       *error = gai_strerror(gerr);
     /* EAI_NONAME answers about the name; every other code says the resolver
        could not answer at all. */
-    if (permanent != NULL && gerr == EAI_NONAME)
-      *permanent = HTS_TRUE;
+    if (gerr == EAI_NONAME)
+      is_permanent = HTS_TRUE;
   }
   if (res) {
     hts_resolver->freeaddrinfo(res);
   }
 #endif
 
+  if (permanent != NULL)
+    *permanent = is_permanent;
   return count;
 }
 

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -3931,9 +3931,7 @@ int hts_mirror_check_moved(htsmoduleStruct * str,
              previous copy (#746), and it must stay so: every file this run
              preserves keeps its children. An answered error is not in it and
              needs nothing, being recovered from the cache and re-parsed. */
-          const hts_boolean unanswered = back_transfer_failed(r->statuscode);
-
-          if (unanswered && !heap(ptr)->testmode &&
+          if (back_transfer_failed(r->statuscode) && !heap(ptr)->testmode &&
               hts_link_may_carry_links(opt, cache, urladr(), urlfil())) {
             opt->links_unqueued = HTS_TRUE;
           }


### PR DESCRIPTION
#1392 added a write above the `#if HTS_INET6`, so the declaration opening each arm now follows a statement. It is legal as this tree builds. `configure.ac` leaves `-Wdeclaration-after-statement` off on purpose, since nothing here sets `-std=` and we compile as gnu17, so no build of ours sees it. The Android NDK build sets `-std=` and warns.

The write becomes a local, set by whichever arm compiles, with one write through the caller's pointer beside the single `return`. Two branch conditions lose their `permanent != NULL` test with it. A single-exit rewrite only holds if nothing leaves early: this function has one `return` and no `goto`, and the wrapper's own guard writes the flag itself.

Building the tree under the flag found the other two sites this batch introduced. `htsparse.c`'s `unanswered` is read once, so it goes into the condition it feeds. `htscore.c`'s is subtler: that declaration was fine until #1390 put a log statement above it, so blame names #686 while the defect is ours.

The same census says the flag cannot simply be turned on. 11 further engine sites and 27 in the self-tests predate this batch, which is its own change, after the freeze. No test here: behaviour is unchanged and the DNS self-test already drives every branch.

Reported by the httrack-android session against the NDK build, in-window for 3.50.