### PR TITLE
htsserver refuses the host's own name since the Host check landed

### DIFF
--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -99,9 +99,9 @@ httrackp *global_opt = NULL;
    answer for, whatever a request's Host header claims. */
 static char server_bound_addr[256 + 2] = "";
 
-/* Other names this host answers to, resolved once when the socket is bound: a
-   lookup a request could steer is the rebinding vector itself. Room for a
-   hostname, its FQDN, a couple of aliases and a PTR. */
+/* Other names this host answers to, resolved once before we serve anything,
+   since a lookup a request could steer would reopen the rebinding hole. Room
+   for a hostname, its full name and one reverse-lookup result. */
 #define SELF_NAMES_MAX 8
 static char server_self_names[SELF_NAMES_MAX][256];
 static size_t server_self_names_count = 0;
@@ -282,18 +282,13 @@ static void add_self_name(const char *name) {
   strcpybuff(server_self_names[server_self_names_count++], name);
 }
 
-/** Add the canonical name and aliases our own hostname resolves to. */
-static void add_resolved_self_names(const char *name) {
+/** Add the canonical name our own hostname resolves to. */
+static void add_resolved_self_names(const char *hostname) {
 #if HTS_INET6 == 0
-  const struct hostent *const hp = gethostbyname(name);
+  const struct hostent *const hp = gethostbyname(hostname);
 
   if (hp != NULL) {
-    int i;
-
     add_self_name(hp->h_name);
-    for (i = 0; hp->h_aliases != NULL && hp->h_aliases[i] != NULL; i++) {
-      add_self_name(hp->h_aliases[i]);
-    }
   }
 #else
   struct addrinfo *res = NULL;
@@ -305,7 +300,7 @@ static void add_resolved_self_names(const char *name) {
   hints.ai_socktype = SOCK_STREAM;
   hints.ai_protocol = IPPROTO_TCP;
   hints.ai_flags = AI_CANONNAME;
-  if (getaddrinfo(name, NULL, &hints, &res) == 0) {
+  if (getaddrinfo(hostname, NULL, &hints, &res) == 0) {
     for (ai = res; ai != NULL; ai = ai->ai_next) {
       add_self_name(ai->ai_canonname);
     }
@@ -316,8 +311,9 @@ static void add_resolved_self_names(const char *name) {
 #endif
 }
 
-/** Add the name the bound address reverse-resolves to, kept only when it
-    resolves back to it: an unconfirmed PTR says whatever its owner likes. */
+/** Add the name the bound address reverse-resolves to, kept only when that
+    name resolves back to the bound address: an unconfirmed reverse lookup
+    says whatever the address's owner likes. */
 static void add_reverse_self_name(SOCaddr *bound) {
   char name[256];
   char addr[256];
@@ -325,7 +321,9 @@ static void add_reverse_self_name(SOCaddr *bound) {
   SOCaddr resolved;
 
   SOCaddr_inetntoa(addr, sizeof(addr), *bound);
-  if (addr[0] == '\0' ||
+  /* a wildcard is no address to ask about, and none can confirm back to it */
+  if (addr[0] == '\0' || strcmp(addr, "0.0.0.0") == 0 ||
+      strcmp(addr, "::") == 0 ||
       getnameinfo(&SOCaddr_sockaddr(*bound), SOCaddr_size(*bound), name,
                   sizeof(name), NULL, 0, NI_NAMEREQD) != 0) {
     return;
@@ -340,17 +338,23 @@ static void add_reverse_self_name(SOCaddr *bound) {
   }
 }
 
-/** Gather the names this host answers to, for the address we just bound. */
-static void collect_self_names(SOCaddr *bound) {
+/** Gather the names this host answers to, for the address soc is bound to.
+    Resets the set, so a second call replaces it rather than adding to it. */
+static void collect_self_names(T_SOC soc) {
+  SOCaddr bound;
+  SOClen len = SOCaddr_capacity(bound);
   char host[256];
 
   server_self_names_count = 0;
+  if (getsockname(soc, &SOCaddr_sockaddr(bound), &len) != 0) {
+    return;
+  }
   if (gethostname(host, sizeof(host)) == 0) {
     host[sizeof(host) - 1] = '\0';
     add_self_name(host);
     add_resolved_self_names(host);
   }
-  add_reverse_self_name(bound);
+  add_reverse_self_name(&bound);
 }
 
 /** Form of a bound address a client can actually open: a wildcard names no
@@ -408,8 +412,6 @@ T_SOC smallserver_init(int *port, char *adr, const char *bindAddr) {
       if (listen(soc, 10) >= 0) {
         char adv[sizeof(h_loc) + 2]; /* + the brackets of an IPv6 literal */
 
-        /* only now: smallserver_init_std walks a list of ports to bind */
-        collect_self_names(&server);
         advertised_host(adv, sizeof(adv), h_loc);
         strcpy(adr, adv);
       } else {
@@ -523,9 +525,9 @@ static hts_boolean host_is_address(const char *name) {
 /** May a request presenting this authority drive the panel?
     A page can point a name of its own at our address and have the browser call
     us same-origin, which an unauthenticated panel must refuse. That always
-    presents a name: an address literal is whoever opened the socket, and the
-    names we vouch for are localhost, whatever --bind was given, and the ones
-    this host itself answers to. */
+    presents a name. An address literal is whoever opened the socket, and the
+    names we vouch for are localhost, whatever --bind was given, and this
+    host's own names. */
 static hts_boolean host_is_self(const char *host, const char *bound) {
   char name[256];
   size_t i;
@@ -1046,6 +1048,10 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
      and deliberately not cleared between requests. */
   String website = STRING_EMPTY;
   char catbuff[CATBUFF_SIZE];
+
+  /* Not at bind time: the launcher prints the URL the moment smallserver_init
+     returns, and a stalled resolver would hold that line back. */
+  collect_self_names(soc);
 
   /* Load strings */
   htslang_init();

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -99,6 +99,13 @@ httrackp *global_opt = NULL;
    answer for, whatever a request's Host header claims. */
 static char server_bound_addr[256 + 2] = "";
 
+/* Other names this host answers to, resolved once when the socket is bound: a
+   lookup a request could steer is the rebinding vector itself. Room for a
+   hostname, its FQDN, a couple of aliases and a PTR. */
+#define SELF_NAMES_MAX 8
+static char server_self_names[SELF_NAMES_MAX][256];
+static size_t server_self_names_count = 0;
+
 static void (*pingFun)(void *, smallserver_client_event, const char *) = NULL;
 static void* pingFunArg = NULL;
 
@@ -258,6 +265,94 @@ static int gethost(const char *hostname, SOCaddr * server) {
   return 0;
 }
 
+/** Remember a name we answer to, if it is new and it fits. */
+static void add_self_name(const char *name) {
+  size_t i;
+
+  if (name == NULL || *name == '\0' ||
+      strlen(name) >= sizeof(server_self_names[0]) ||
+      server_self_names_count == SELF_NAMES_MAX) {
+    return;
+  }
+  for (i = 0; i < server_self_names_count; i++) {
+    if (strfield2(server_self_names[i], name) != 0) {
+      return;
+    }
+  }
+  strcpybuff(server_self_names[server_self_names_count++], name);
+}
+
+/** Add the canonical name and aliases our own hostname resolves to. */
+static void add_resolved_self_names(const char *name) {
+#if HTS_INET6 == 0
+  const struct hostent *const hp = gethostbyname(name);
+
+  if (hp != NULL) {
+    int i;
+
+    add_self_name(hp->h_name);
+    for (i = 0; hp->h_aliases != NULL && hp->h_aliases[i] != NULL; i++) {
+      add_self_name(hp->h_aliases[i]);
+    }
+  }
+#else
+  struct addrinfo *res = NULL;
+  struct addrinfo hints;
+  const struct addrinfo *ai;
+
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = PF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  hints.ai_protocol = IPPROTO_TCP;
+  hints.ai_flags = AI_CANONNAME;
+  if (getaddrinfo(name, NULL, &hints, &res) == 0) {
+    for (ai = res; ai != NULL; ai = ai->ai_next) {
+      add_self_name(ai->ai_canonname);
+    }
+  }
+  if (res != NULL) {
+    freeaddrinfo(res);
+  }
+#endif
+}
+
+/** Add the name the bound address reverse-resolves to, kept only when it
+    resolves back to it: an unconfirmed PTR says whatever its owner likes. */
+static void add_reverse_self_name(SOCaddr *bound) {
+  char name[256];
+  char addr[256];
+  char back[256];
+  SOCaddr resolved;
+
+  SOCaddr_inetntoa(addr, sizeof(addr), *bound);
+  if (addr[0] == '\0' ||
+      getnameinfo(&SOCaddr_sockaddr(*bound), SOCaddr_size(*bound), name,
+                  sizeof(name), NULL, 0, NI_NAMEREQD) != 0) {
+    return;
+  }
+  memset(&resolved, 0, sizeof(resolved));
+  if (!gethost(name, &resolved)) {
+    return;
+  }
+  SOCaddr_inetntoa(back, sizeof(back), resolved);
+  if (back[0] != '\0' && strcmp(addr, back) == 0) {
+    add_self_name(name);
+  }
+}
+
+/** Gather the names this host answers to, for the address we just bound. */
+static void collect_self_names(SOCaddr *bound) {
+  char host[256];
+
+  server_self_names_count = 0;
+  if (gethostname(host, sizeof(host)) == 0) {
+    host[sizeof(host) - 1] = '\0';
+    add_self_name(host);
+    add_resolved_self_names(host);
+  }
+  add_reverse_self_name(bound);
+}
+
 /** Form of a bound address a client can actually open: a wildcard names no
     reachable host, and an IPv6 literal needs its URL brackets. */
 static void advertised_host(char *dst, size_t size, const char *bound) {
@@ -313,6 +408,8 @@ T_SOC smallserver_init(int *port, char *adr, const char *bindAddr) {
       if (listen(soc, 10) >= 0) {
         char adv[sizeof(h_loc) + 2]; /* + the brackets of an IPv6 literal */
 
+        /* only now: smallserver_init_std walks a list of ports to bind */
+        collect_self_names(&server);
         advertised_host(adv, sizeof(adv), h_loc);
         strcpy(adr, adv);
       } else {
@@ -427,17 +524,25 @@ static hts_boolean host_is_address(const char *name) {
     A page can point a name of its own at our address and have the browser call
     us same-origin, which an unauthenticated panel must refuse. That always
     presents a name: an address literal is whoever opened the socket, and the
-    only names we vouch for are localhost and whatever --bind was given. */
+    names we vouch for are localhost, whatever --bind was given, and the ones
+    this host itself answers to. */
 static hts_boolean host_is_self(const char *host, const char *bound) {
   char name[256];
+  size_t i;
 
   if (!host_hostname(name, sizeof(name), host)) {
     return HTS_FALSE;
   }
-  return strfield2(name, "localhost") != 0 || host_is_address(name) ||
-                 (bound[0] != '\0' && strfield2(name, bound) != 0)
-             ? HTS_TRUE
-             : HTS_FALSE;
+  if (strfield2(name, "localhost") != 0 || host_is_address(name) ||
+      (bound[0] != '\0' && strfield2(name, bound) != 0)) {
+    return HTS_TRUE;
+  }
+  for (i = 0; i < server_self_names_count; i++) {
+    if (strfield2(server_self_names[i], name) != 0) {
+      return HTS_TRUE;
+    }
+  }
+  return HTS_FALSE;
 }
 
 /** Header value with leading blanks dropped, clipped to fit dst. */

--- a/tests/341_webhttrack-authority.test
+++ b/tests/341_webhttrack-authority.test
@@ -53,26 +53,31 @@ echo "ok: the panel answers at every authority it is reachable at"
 # browsed at http://myhost.lan:8080/ presents. Dropped when another rule would
 # accept it anyway, since it would then prove nothing.
 selfname=$(htsserver_python -c 'import socket; print(socket.gethostname())')
-case ${selfname} in
+case $(printf '%s' "${selfname}" | tr '[:upper:]' '[:lower:]') in
 localhost) selfname='' ;;
 *[!0-9.]*) ;;
 *) selfname='' ;;
 esac
 test "${#selfname}" -lt 256 || selfname=''
 if test -n "${selfname}"; then
-    for good in "${selfname}" "${selfname}:${HTS_PORT}"; do
+    # Upper-cased too: the compare is case-insensitive, as it is for localhost.
+    for good in "${selfname}" "${selfname}:${HTS_PORT}" \
+        "$(printf '%s' "${selfname}" | tr '[:lower:]' '[:upper:]')"; do
         grep -q '^Location: /accepted' <<<"$(post_as "${good}")" ||
             fail "Host '${good}', this host's own name, was refused"
     done
     echo "ok: the panel answers at this host's own name"
 else
-    echo "skipped the own-name rows: this host has no name of its own"
+    echo "skipped the own-name rows: '${selfname}' is a name another rule covers"
 fi
 
 bad_hosts=("evil.example" "evil.example:${HTS_PORT}" "127.0.0.1.evil.example")
-# Near-misses on both sides: the match is the whole name, never a prefix of it.
-test -z "${selfname}" ||
-    bad_hosts+=("${selfname}.evil.example" "${selfname}x" "${selfname%?}")
+if test -n "${selfname}"; then
+    # Near-misses on every side: the match is the whole name, never part of it.
+    bad_hosts+=("${selfname}.evil.example" "evil.${selfname}" "${selfname}x")
+    # A one-character name truncates to "", which the good loop above accepts.
+    test "${#selfname}" -lt 2 || bad_hosts+=("${selfname%?}")
+fi
 for bad in "${bad_hosts[@]}"; do
     resp=$(post_as "${bad}")
     grep -q '^HTTP/1\.0 403 ' <<<"${resp}" ||
@@ -152,8 +157,9 @@ try:
     addrs = {a[4][0] for a in socket.getaddrinfo("ip6-localhost", None)}
 except OSError:
     sys.exit(1)
-sys.exit(0 if addrs == {"::1"}
-         and socket.getnameinfo(("::1", 0), 0)[0] != "ip6-localhost" else 1)
+# Skip where it could be one of ours, which is the whole premise of the row.
+ours = {socket.getnameinfo(("::1", 0), 0)[0], socket.gethostname(), socket.getfqdn()}
+sys.exit(0 if addrs == {"::1"} and "ip6-localhost" not in ours else 1)
 RESOLVES
         got=$(opens "http://ip6-localhost:${HTS_PORT}/")
         test "${got}" = 403 ||

--- a/tests/341_webhttrack-authority.test
+++ b/tests/341_webhttrack-authority.test
@@ -20,11 +20,13 @@ cleanup_push cleanup
 # Fetch a URL the way webhttrack's browser would: the status, or the error name.
 opens() {
     htsserver_python - "$1" <<'PY'
-import sys, urllib.request
+import sys, urllib.request, urllib.error
 
 try:
     with urllib.request.urlopen(sys.argv[1], timeout=10) as r:
         print(r.status)
+except urllib.error.HTTPError as e:
+    print(e.code)
 except Exception as e:
     print(type(e).__name__)
 PY
@@ -47,7 +49,31 @@ for good in "127.0.0.1" "127.0.0.1:${HTS_PORT}" "localhost" "localhost:${HTS_POR
 done
 echo "ok: the panel answers at every authority it is reachable at"
 
-for bad in "evil.example" "evil.example:${HTS_PORT}" "127.0.0.1.evil.example"; do
+# The name this host answers to, which is what `htsserver --bind <lan ip>`
+# browsed at http://myhost.lan:8080/ presents. Dropped when another rule would
+# accept it anyway, since it would then prove nothing.
+selfname=$(htsserver_python -c 'import socket; print(socket.gethostname())')
+case ${selfname} in
+localhost) selfname='' ;;
+*[!0-9.]*) ;;
+*) selfname='' ;;
+esac
+test "${#selfname}" -lt 256 || selfname=''
+if test -n "${selfname}"; then
+    for good in "${selfname}" "${selfname}:${HTS_PORT}"; do
+        grep -q '^Location: /accepted' <<<"$(post_as "${good}")" ||
+            fail "Host '${good}', this host's own name, was refused"
+    done
+    echo "ok: the panel answers at this host's own name"
+else
+    echo "skipped the own-name rows: this host has no name of its own"
+fi
+
+bad_hosts=("evil.example" "evil.example:${HTS_PORT}" "127.0.0.1.evil.example")
+# Near-misses on both sides: the match is the whole name, never a prefix of it.
+test -z "${selfname}" ||
+    bad_hosts+=("${selfname}.evil.example" "${selfname}x" "${selfname%?}")
+for bad in "${bad_hosts[@]}"; do
     resp=$(post_as "${bad}")
     grep -q '^HTTP/1\.0 403 ' <<<"${resp}" ||
         fail "POST with Host '${bad}' was not a 403: '$(firstline "${resp}")'"
@@ -116,6 +142,26 @@ PY
     got=$(opens "${HTS_URL}")
     test "${got}" = 200 || fail "--bind ::1 advertised ${HTS_URL}, which answered ${got}"
     echo "ok: an IPv6 literal is advertised bracketed"
+
+    # Resolving to the bound address does not make a name ours, or a page could
+    # point one of its own here and be same-origin with the panel again.
+    if htsserver_python - <<'RESOLVES'; then
+import socket, sys
+
+try:
+    addrs = {a[4][0] for a in socket.getaddrinfo("ip6-localhost", None)}
+except OSError:
+    sys.exit(1)
+sys.exit(0 if addrs == {"::1"}
+         and socket.getnameinfo(("::1", 0), 0)[0] != "ip6-localhost" else 1)
+RESOLVES
+        got=$(opens "http://ip6-localhost:${HTS_PORT}/")
+        test "${got}" = 403 ||
+            fail "Host 'ip6-localhost' points at the bound ::1, and answered ${got}"
+        echo "ok: a name merely pointed at the bound address is refused"
+    else
+        echo "skipped the pointed-here control: no ip6-localhost apart from the PTR"
+    fi
 else
     echo "skipped the IPv6 advert: no ::1 here"
 fi


### PR DESCRIPTION
#1372 gave the panel a Host check, and with it a regression against 3.49.23. `host_is_self()` vouches only for `localhost`, an address literal, or the exact string passed to `--bind`, so `htsserver --bind 192.168.1.5` browsed as `http://myhost.lan:8080/` now answers 403 where 3.49.23 served it. Default WebHTTrack never saw this: it binds loopback and opens `127.0.0.1`. Binding by name (`--bind myhost.lan`) already works and stays the exact workaround.

The vouched set now also holds the names this host answers to. Those are `gethostname()`, the canonical name it resolves to, and the name the bound address reverse-resolves to, kept only when that name resolves back to it. All of it is collected once, before the first request is served, which is what keeps rebinding closed: a name presented by a request is never looked up, so a page cannot point a name of its own at our address and have the lookup vouch for it. Accepting any name that merely resolves to the bound address would have reopened the hole #1372 was written to close.

The collection runs at the top of `smallserver()` rather than at bind time, because the launcher prints the URL as soon as `smallserver_init()` returns. With the collection on the bind path and a blackholed nameserver, that line took 20s to appear, against a 20s cap in `65_port-siblings.test`.

Test 341 adds this host's own name as an accepted authority, upper-cased as well, and four near-misses as refused ones, one on each side of the name. Where the resolver has one, it also sends `ip6-localhost` to an `::1`-bound server: that name points at the bound address and is still refused. Six mutants pin the rows. Drop the lookup, match by prefix or by suffix, compare case-sensitively, or resolve the request's own name, and each turns one row red.