### PR TITLE
A best-fit substitute made the strict UTF-8 converter lossy on Windows

### DIFF
--- a/src/htscharset.c
+++ b/src/htscharset.c
@@ -312,8 +312,7 @@ static hts_boolean cp_reports_default_char(UINT cp) {
    and a substitute was emitted for it. */
 static char *hts_convertUCS2StringToCPEx(LPWSTR woutput, int wsize, UINT cp,
                                          hts_boolean *plossy) {
-  /* Best-fit is a silent loss: U+00A5 lands on CP932 as a backslash, and never
-     sets lpUsedDefaultChar. Both calls must agree on the flag. */
+  /* Best-fit maps U+00A5 to CP932's backslash, usedDefault unset. */
   const DWORD flags = cp_reports_default_char(cp) ? WC_NO_BEST_FIT_CHARS : 0;
   const int usize =
       WideCharToMultiByte(cp, flags, woutput, wsize, NULL, 0, NULL, NULL);

--- a/src/htscharset.c
+++ b/src/htscharset.c
@@ -314,9 +314,7 @@ static char *hts_convertUCS2StringToCPEx(LPWSTR woutput, int wsize, UINT cp,
                                          hts_boolean *plossy) {
   /* Best-fit maps U+00A5 to CP932's backslash, usedDefault unset. */
   const DWORD flags = cp_reports_default_char(cp) ? WC_NO_BEST_FIT_CHARS : 0;
-  /* WC_NO_BEST_FIT_CHARS sizes to the substitute, but converting still wants
-     room for the form it replaced: U+00B5 sizes as 1 on CP932 and fails in a
-     1-byte buffer, its best-fit taking 2. Size for the larger of the two. */
+  /* U+00B5 sizes 1 on CP932, best-fit needs 2: size for the larger pass. */
   const int bsize =
       WideCharToMultiByte(cp, 0, woutput, wsize, NULL, 0, NULL, NULL);
   const int fsize = flags != 0 ? WideCharToMultiByte(cp, flags, woutput, wsize,

--- a/src/htscharset.c
+++ b/src/htscharset.c
@@ -314,9 +314,9 @@ static char *hts_convertUCS2StringToCPEx(LPWSTR woutput, int wsize, UINT cp,
                                          hts_boolean *plossy) {
   /* Best-fit maps U+00A5 to CP932's backslash, usedDefault unset. */
   const DWORD flags = cp_reports_default_char(cp) ? WC_NO_BEST_FIT_CHARS : 0;
-  /* A sizing pass does not substitute, so it can report the best-fit length
-     while the conversion writes a shorter one (U+00B5 is 2 bytes on CP932, its
-     substitute 1). Neither size bounds the other: take the larger. */
+  /* WC_NO_BEST_FIT_CHARS sizes to the substitute, but converting still wants
+     room for the form it replaced: U+00B5 sizes as 1 on CP932 and fails in a
+     1-byte buffer, its best-fit taking 2. Size for the larger of the two. */
   const int bsize =
       WideCharToMultiByte(cp, 0, woutput, wsize, NULL, 0, NULL, NULL);
   const int fsize = flags != 0 ? WideCharToMultiByte(cp, flags, woutput, wsize,

--- a/src/htscharset.c
+++ b/src/htscharset.c
@@ -296,8 +296,9 @@ LPWSTR hts_convertUTF8StringToUCS2(const char *s, int size, int *pwsize) {
   return hts_convertStringToUCS2(s, size, CP_UTF8, pwsize);
 }
 
-/* WideCharToMultiByte rejects lpUsedDefaultChar on the Unicode, ISO-2022, HZ,
-   GB18030 and ISCII codepages, where a substitution stays invisible. */
+/* WideCharToMultiByte rejects lpUsedDefaultChar, and any non-zero dwFlags, on
+   the Unicode, ISO-2022, HZ, GB18030 and ISCII codepages, where a substitution
+   stays invisible. */
 static hts_boolean cp_reports_default_char(UINT cp) {
   if (cp == 42 /* CP_SYMBOL */ || cp == CP_UTF7 || cp == CP_UTF8 ||
       cp == 52936 || cp == 54936 || (cp >= 50220 && cp <= 50229) ||
@@ -311,8 +312,11 @@ static hts_boolean cp_reports_default_char(UINT cp) {
    and a substitute was emitted for it. */
 static char *hts_convertUCS2StringToCPEx(LPWSTR woutput, int wsize, UINT cp,
                                          hts_boolean *plossy) {
+  /* Best-fit is a silent loss: U+00A5 lands on CP932 as a backslash, and never
+     sets lpUsedDefaultChar. Both calls must agree on the flag. */
+  const DWORD flags = cp_reports_default_char(cp) ? WC_NO_BEST_FIT_CHARS : 0;
   const int usize =
-      WideCharToMultiByte(cp, 0, woutput, wsize, NULL, 0, NULL, NULL);
+      WideCharToMultiByte(cp, flags, woutput, wsize, NULL, 0, NULL, NULL);
 
   if (plossy != NULL) {
     *plossy = HTS_FALSE;
@@ -325,7 +329,7 @@ static char *hts_convertUCS2StringToCPEx(LPWSTR woutput, int wsize, UINT cp,
       LPBOOL const pUsedDefault =
           plossy != NULL && cp_reports_default_char(cp) ? &usedDefault : NULL;
 
-      if (WideCharToMultiByte(cp, 0, woutput, wsize, uoutput, usize, NULL,
+      if (WideCharToMultiByte(cp, flags, woutput, wsize, uoutput, usize, NULL,
                               pUsedDefault) == usize) {
         uoutput[usize] = '\0';
         if (plossy != NULL && usedDefault) {

--- a/src/htscharset.c
+++ b/src/htscharset.c
@@ -314,8 +314,15 @@ static char *hts_convertUCS2StringToCPEx(LPWSTR woutput, int wsize, UINT cp,
                                          hts_boolean *plossy) {
   /* Best-fit maps U+00A5 to CP932's backslash, usedDefault unset. */
   const DWORD flags = cp_reports_default_char(cp) ? WC_NO_BEST_FIT_CHARS : 0;
-  const int usize =
-      WideCharToMultiByte(cp, flags, woutput, wsize, NULL, 0, NULL, NULL);
+  /* A sizing pass does not substitute, so it can report the best-fit length
+     while the conversion writes a shorter one (U+00B5 is 2 bytes on CP932, its
+     substitute 1). Neither size bounds the other: take the larger. */
+  const int bsize =
+      WideCharToMultiByte(cp, 0, woutput, wsize, NULL, 0, NULL, NULL);
+  const int fsize = flags != 0 ? WideCharToMultiByte(cp, flags, woutput, wsize,
+                                                     NULL, 0, NULL, NULL)
+                               : bsize;
+  const int usize = bsize > fsize ? bsize : fsize;
 
   if (plossy != NULL) {
     *plossy = HTS_FALSE;
@@ -328,9 +335,12 @@ static char *hts_convertUCS2StringToCPEx(LPWSTR woutput, int wsize, UINT cp,
       LPBOOL const pUsedDefault =
           plossy != NULL && cp_reports_default_char(cp) ? &usedDefault : NULL;
 
-      if (WideCharToMultiByte(cp, flags, woutput, wsize, uoutput, usize, NULL,
-                              pUsedDefault) == usize) {
-        uoutput[usize] = '\0';
+      const int n = WideCharToMultiByte(cp, flags, woutput, wsize, uoutput,
+                                        usize, NULL, pUsedDefault);
+
+      /* usize only bounds the result; the written length is what n reports */
+      if (n > 0 && n <= usize) {
+        uoutput[n] = '\0';
         if (plossy != NULL && usedDefault) {
           *plossy = HTS_TRUE;
         }

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1328,11 +1328,19 @@ static int st_syscharset(httrackp *opt, int argc, char **argv) {
    back a path separator for it. */
 static int st_nobestfit(httrackp *opt, int argc, char **argv) {
 #ifdef _WIN32
+  /* internal, not in htscharset.h: ties cp below to cs by name, not by guess */
+  extern UINT hts_getCodepage(const char *name);
   static const char *const yen = "\xC2\xA5";      /* U+00A5 */
   static const char *const micro = "\xC2\xB5";    /* U+00B5, best-fit 83 CA */
   static const char *const hira = "\xE3\x81\x82"; /* U+3042, CP932 82 A0 */
+  /* yen + micro + hira + ASCII: a best-fit-shorter, a best-fit-longer, a
+     native and an untouched code point in one string */
+  static const char *const mixed = "\xC2\xA5\xC2\xB5\xE3\x81\x82"
+                                   "A";
   const char *const cs = "shift_jis";
+  const UINT cp = hts_getCodepage(cs);
   BOOL usedDefault = TRUE;
+  BOOL gotCpInfo;
   CPINFO cpi;
   WCHAR wide[4];
   char raw[8];
@@ -1342,7 +1350,8 @@ static int st_nobestfit(httrackp *opt, int argc, char **argv) {
   (void) opt;
   (void) argc;
   (void) argv;
-  if (!IsValidCodePage(932)) {
+  assertf(cp == 932);
+  if (!IsValidCodePage(cp)) {
     printf("nobestfit: CP932 is not installed\n");
     return 77;
   }
@@ -1351,7 +1360,7 @@ static int st_nobestfit(httrackp *opt, int argc, char **argv) {
   wn = MultiByteToWideChar(CP_UTF8, 0, yen, (int) strlen(yen), wide,
                            (int) (sizeof(wide) / sizeof(wide[0])));
   assertf(wn == 1);
-  n = WideCharToMultiByte(932, 0, wide, wn, raw, (int) sizeof(raw), NULL,
+  n = WideCharToMultiByte(cp, 0, wide, wn, raw, (int) sizeof(raw), NULL,
                           &usedDefault);
   assertf(n == 1 && raw[0] == '\\' && !usedDefault);
   /* U+00B5 best-fits to two bytes where the substitute is one, so a flag
@@ -1359,13 +1368,23 @@ static int st_nobestfit(httrackp *opt, int argc, char **argv) {
   wn = MultiByteToWideChar(CP_UTF8, 0, micro, (int) strlen(micro), wide,
                            (int) (sizeof(wide) / sizeof(wide[0])));
   assertf(wn == 1);
-  n = WideCharToMultiByte(932, 0, wide, wn, raw, (int) sizeof(raw), NULL, NULL);
+  n = WideCharToMultiByte(cp, 0, wide, wn, raw, (int) sizeof(raw), NULL, NULL);
   assertf(n == 2);
   /* the sizing passes disagree, and the shorter one under-allocates: banning
      best-fit sizes to the substitute but converts into room for the best-fit */
-  n = WideCharToMultiByte(932, WC_NO_BEST_FIT_CHARS, wide, wn, NULL, 0, NULL,
+  n = WideCharToMultiByte(cp, WC_NO_BEST_FIT_CHARS, wide, wn, NULL, 0, NULL,
                           NULL);
   assertf(n == 1);
+  /* same disagreement, summed over 4 code points instead of 1: a flag gated
+     on wsize==1 would leave yen/micro best-fit instead of substituted here */
+  wn = MultiByteToWideChar(CP_UTF8, 0, mixed, (int) strlen(mixed), wide,
+                           (int) (sizeof(wide) / sizeof(wide[0])));
+  assertf(wn == 4);
+  n = WideCharToMultiByte(cp, 0, wide, wn, NULL, 0, NULL, NULL);
+  assertf(n == 6); /* yen 1 + micro best-fit 2 + hira 2 + 'A' 1 */
+  n = WideCharToMultiByte(cp, WC_NO_BEST_FIT_CHARS, wide, wn, NULL, 0, NULL,
+                          NULL);
+  assertf(n == 5); /* yen 1 + micro default 1 + hira 2 + 'A' 1 */
   /* control: banning best-fit must not break what the codepage does hold */
   s = hts_convertStringFromUTF8Strict(hira, strlen(hira), cs);
   assertf(s != NULL);
@@ -1375,7 +1394,8 @@ static int st_nobestfit(httrackp *opt, int argc, char **argv) {
   assertf(s == NULL);
   /* the non-strict caller still substitutes, but with the codepage's own
      default character rather than a lookalike */
-  assertf(GetCPInfo(932, &cpi));
+  gotCpInfo = GetCPInfo(cp, &cpi);
+  assertf(gotCpInfo);
   s = hts_convertStringFromUTF8(yen, strlen(yen), cs);
   assertf(s != NULL);
   assertf(s[0] == (char) cpi.DefaultChar[0] && s[1] == '\0');
@@ -1385,6 +1405,18 @@ static int st_nobestfit(httrackp *opt, int argc, char **argv) {
   s = hts_convertStringFromUTF8(micro, strlen(micro), cs);
   assertf(s != NULL);
   assertf(s[0] == (char) cpi.DefaultChar[0] && s[1] == '\0');
+  freet(s);
+  /* the mixed string, asserted byte-exact: both mutants above would either
+     mis-size the buffer (undersized usize) or mis-gate flags (best-fit
+     leaking through for a >1 code point string), and either shows up here */
+  s = hts_convertStringFromUTF8Strict(mixed, strlen(mixed), cs);
+  assertf(s == NULL); /* yen and micro are both lossy */
+  s = hts_convertStringFromUTF8(mixed, strlen(mixed), cs);
+  assertf(s != NULL);
+  assertf(s[0] == (char) cpi.DefaultChar[0]);
+  assertf(s[1] == (char) cpi.DefaultChar[0]);
+  assertf((unsigned char) s[2] == 0x82 && (unsigned char) s[3] == 0xA0);
+  assertf(s[4] == 'A' && s[5] == '\0');
   freet(s);
   /* the other arm of the gate: a codepage that refuses a non-zero dwFlags must
      still convert, so UTF-7 encodes the yen instead of failing */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1361,6 +1361,11 @@ static int st_nobestfit(httrackp *opt, int argc, char **argv) {
   assertf(wn == 1);
   n = WideCharToMultiByte(932, 0, wide, wn, raw, (int) sizeof(raw), NULL, NULL);
   assertf(n == 2);
+  /* for the record: which way the two sizing passes disagree */
+  fprintf(stderr, "nobestfit: micro sizes best-fit=%d nobestfit=%d\n",
+          WideCharToMultiByte(932, 0, wide, wn, NULL, 0, NULL, NULL),
+          WideCharToMultiByte(932, WC_NO_BEST_FIT_CHARS, wide, wn, NULL, 0,
+                              NULL, NULL));
   /* control: banning best-fit must not break what the codepage does hold */
   s = hts_convertStringFromUTF8Strict(hira, strlen(hira), cs);
   assertf(s != NULL);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1270,7 +1270,7 @@ static int st_syscharset(httrackp *opt, int argc, char **argv) {
   static const char *const utf8 = "caf\xC3\xA9 \xE2\x82\xAC"; /* "café €" */
   const UINT cp = GetACP();
   const int len = (int) strlen(utf8);
-  /* the engine bans best-fit, and UTF-8 is the only ACP its gate spares */
+  /* the engine blocks best-fit; UTF-8 is the only ACP that check exempts */
   const DWORD flags = cp == CP_UTF8 ? 0 : WC_NO_BEST_FIT_CHARS;
   WCHAR wide[64], round[64];
   char want[64];
@@ -1324,14 +1324,16 @@ static int st_syscharset(httrackp *opt, int argc, char **argv) {
 #endif
 }
 
-/* Best-fit is what kept the strict converter from being strict: CP932 has no
-   U+00A5 and quietly emitted a path separator for it. */
+/* Best-fit defeated the strict converter: CP932 lacks U+00A5 and quietly gave
+   back a path separator for it. */
 static int st_nobestfit(httrackp *opt, int argc, char **argv) {
 #ifdef _WIN32
   static const char *const yen = "\xC2\xA5";      /* U+00A5 */
+  static const char *const micro = "\xC2\xB5";    /* U+00B5, best-fit 83 CA */
   static const char *const hira = "\xE3\x81\x82"; /* U+3042, CP932 82 A0 */
   const char *const cs = "shift_jis";
   BOOL usedDefault = TRUE;
+  CPINFO cpi;
   WCHAR wide[4];
   char raw[8];
   char *s;
@@ -1352,6 +1354,13 @@ static int st_nobestfit(httrackp *opt, int argc, char **argv) {
   n = WideCharToMultiByte(932, 0, wide, wn, raw, (int) sizeof(raw), NULL,
                           &usedDefault);
   assertf(n == 1 && raw[0] == '\\' && !usedDefault);
+  /* U+00B5 best-fits to two bytes where the substitute is one, so a flag
+     carried by only one of the two calls shows up as a length disagreement */
+  wn = MultiByteToWideChar(CP_UTF8, 0, micro, (int) strlen(micro), wide,
+                           (int) (sizeof(wide) / sizeof(wide[0])));
+  assertf(wn == 1);
+  n = WideCharToMultiByte(932, 0, wide, wn, raw, (int) sizeof(raw), NULL, NULL);
+  assertf(n == 2);
   /* control: banning best-fit must not break what the codepage does hold */
   s = hts_convertStringFromUTF8Strict(hira, strlen(hira), cs);
   assertf(s != NULL);
@@ -1359,10 +1368,23 @@ static int st_nobestfit(httrackp *opt, int argc, char **argv) {
   freet(s);
   s = hts_convertStringFromUTF8Strict(yen, strlen(yen), cs);
   assertf(s == NULL);
-  /* the non-strict caller keeps its substitute, but a visible one */
+  /* the non-strict caller still substitutes, but with the codepage's own
+     default character rather than a lookalike */
+  assertf(GetCPInfo(932, &cpi));
   s = hts_convertStringFromUTF8(yen, strlen(yen), cs);
   assertf(s != NULL);
-  assertf(strcmp(s, "?") == 0);
+  assertf(s[0] == (char) cpi.DefaultChar[0] && s[1] == '\0');
+  freet(s);
+  s = hts_convertStringFromUTF8Strict(micro, strlen(micro), cs);
+  assertf(s == NULL);
+  s = hts_convertStringFromUTF8(micro, strlen(micro), cs);
+  assertf(s != NULL);
+  assertf(s[0] == (char) cpi.DefaultChar[0] && s[1] == '\0');
+  freet(s);
+  /* the other arm of the gate: a codepage that refuses a non-zero dwFlags must
+     still convert, so UTF-7 encodes the yen instead of failing */
+  s = hts_convertStringFromUTF8(yen, strlen(yen), "utf-7");
+  assertf(s != NULL && s[0] == '+');
   freet(s);
   printf("nobestfit: OK\n");
   return 0;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1361,11 +1361,11 @@ static int st_nobestfit(httrackp *opt, int argc, char **argv) {
   assertf(wn == 1);
   n = WideCharToMultiByte(932, 0, wide, wn, raw, (int) sizeof(raw), NULL, NULL);
   assertf(n == 2);
-  /* for the record: which way the two sizing passes disagree */
-  fprintf(stderr, "nobestfit: micro sizes best-fit=%d nobestfit=%d\n",
-          WideCharToMultiByte(932, 0, wide, wn, NULL, 0, NULL, NULL),
-          WideCharToMultiByte(932, WC_NO_BEST_FIT_CHARS, wide, wn, NULL, 0,
-                              NULL, NULL));
+  /* the sizing passes disagree, and the shorter one under-allocates: banning
+     best-fit sizes to the substitute but converts into room for the best-fit */
+  n = WideCharToMultiByte(932, WC_NO_BEST_FIT_CHARS, wide, wn, NULL, 0, NULL,
+                          NULL);
+  assertf(n == 1);
   /* control: banning best-fit must not break what the codepage does hold */
   s = hts_convertStringFromUTF8Strict(hira, strlen(hira), cs);
   assertf(s != NULL);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1270,6 +1270,8 @@ static int st_syscharset(httrackp *opt, int argc, char **argv) {
   static const char *const utf8 = "caf\xC3\xA9 \xE2\x82\xAC"; /* "café €" */
   const UINT cp = GetACP();
   const int len = (int) strlen(utf8);
+  /* the engine bans best-fit, and UTF-8 is the only ACP its gate spares */
+  const DWORD flags = cp == CP_UTF8 ? 0 : WC_NO_BEST_FIT_CHARS;
   WCHAR wide[64], round[64];
   char want[64];
   char *sys, *back, *part;
@@ -1281,12 +1283,11 @@ static int st_syscharset(httrackp *opt, int argc, char **argv) {
   wn = MultiByteToWideChar(CP_UTF8, 0, utf8, len, wide,
                            (int) (sizeof(wide) / sizeof(wide[0])));
   assertf(wn > 0);
-  n = WideCharToMultiByte(cp, 0, wide, wn, want, (int) sizeof(want) - 1, NULL,
-                          NULL);
+  n = WideCharToMultiByte(cp, flags, wide, wn, want, (int) sizeof(want) - 1,
+                          NULL, NULL);
   assertf(n > 0);
   want[n] = '\0';
-  /* the ACP holds the string only if its bytes decode back to the same UTF-16;
-     lpUsedDefaultChar would miss a best-fit mapping (é to a bare e) */
+  /* the ACP holds it only if those bytes decode back to the same UTF-16 */
   lossless =
       MultiByteToWideChar(cp, 0, want, n, round,
                           (int) (sizeof(round) / sizeof(round[0]))) == wn &&
@@ -1314,6 +1315,56 @@ static int st_syscharset(httrackp *opt, int argc, char **argv) {
   freet(sys);
   printf("syscharset: acp=%u %s: OK\n", (unsigned) cp,
          lossless ? "round-trip" : "one-way");
+  return 0;
+#else
+  (void) opt;
+  (void) argc;
+  (void) argv;
+  return 77; /* WIN32-only entry point */
+#endif
+}
+
+/* Best-fit is what kept the strict converter from being strict: CP932 has no
+   U+00A5 and quietly emitted a path separator for it. */
+static int st_nobestfit(httrackp *opt, int argc, char **argv) {
+#ifdef _WIN32
+  static const char *const yen = "\xC2\xA5";      /* U+00A5 */
+  static const char *const hira = "\xE3\x81\x82"; /* U+3042, CP932 82 A0 */
+  const char *const cs = "shift_jis";
+  BOOL usedDefault = TRUE;
+  WCHAR wide[4];
+  char raw[8];
+  char *s;
+  int wn, n;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+  if (!IsValidCodePage(932)) {
+    printf("nobestfit: CP932 is not installed\n");
+    return 77;
+  }
+  /* the trap, asserted rather than assumed: left to itself the codepage hands
+     back a path separator and reports no substitution at all */
+  wn = MultiByteToWideChar(CP_UTF8, 0, yen, (int) strlen(yen), wide,
+                           (int) (sizeof(wide) / sizeof(wide[0])));
+  assertf(wn == 1);
+  n = WideCharToMultiByte(932, 0, wide, wn, raw, (int) sizeof(raw), NULL,
+                          &usedDefault);
+  assertf(n == 1 && raw[0] == '\\' && !usedDefault);
+  /* control: banning best-fit must not break what the codepage does hold */
+  s = hts_convertStringFromUTF8Strict(hira, strlen(hira), cs);
+  assertf(s != NULL);
+  assertf(strcmp(s, "\x82\xA0") == 0);
+  freet(s);
+  s = hts_convertStringFromUTF8Strict(yen, strlen(yen), cs);
+  assertf(s == NULL);
+  /* the non-strict caller keeps its substitute, but a visible one */
+  s = hts_convertStringFromUTF8(yen, strlen(yen), cs);
+  assertf(s != NULL);
+  assertf(strcmp(s, "?") == 0);
+  freet(s);
+  printf("nobestfit: OK\n");
   return 0;
 #else
   (void) opt;
@@ -12295,6 +12346,9 @@ static const struct selftest_entry {
      "convert a string to UTF-8 from a charset", st_charset},
     {"syscharset", "", "UTF-8 <-> system codepage conversion (WIN32 only)",
      st_syscharset},
+    {"nobestfit", "",
+     "no best-fit substitute when converting from UTF-8 (WIN32 only)",
+     st_nobestfit},
     {"metacharset", "<html>", "extract the <meta> charset from an HTML page",
      st_metacharset},
     {"isutf8", "<hex:..|string>", "is the string valid UTF-8 (1/0)", st_isutf8},

--- a/tests/01_engine-nobestfit.test
+++ b/tests/01_engine-nobestfit.test
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# UTF-8 to a codepage that lacks the character ('httrack -#test=nobestfit'):
+# a substitute must be visible, never a best-fit lookalike. WIN32 only.
+
+set -euo pipefail
+
+rc=0
+out=$(httrack -O /dev/null -#test=nobestfit) || rc=$?
+echo "$out"
+
+[ "$rc" = 77 ] && exit 77
+[ "$rc" = 0 ] || exit "$rc"
+
+case "$out" in
+"nobestfit: OK") ;;
+*)
+    echo "FAIL: unexpected report"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
On Windows, `WideCharToMultiByte` substitutes a lookalike character when the target codepage lacks a code point, and does not report that substitution through `lpUsedDefaultChar`. U+00A5 comes out of CP932 as `0x5C`, so `hts_convertStringFromUTF8Strict` saw no loss and handed back a path separator where the document wrote a yen sign. Both `WideCharToMultiByte` calls now pass `WC_NO_BEST_FIT_CHARS`, gated on `cp_reports_default_char`. That predicate already picks out the codepages needing `dwFlags == 0`, so it needed no change. The yen becomes the codepage's default character, `usedDefault` is set, and strict returns NULL.

Setting the flag is not quite enough on its own. Sizing with it reports the length of the substitute, but the converting pass still wants room for the form it replaced, so a buffer sized from the flagged pass is refused: U+00B5 sizes as 1 byte on CP932 while its best-fit takes 2. The exact-length guard then rejected a conversion that had succeeded, and `hts_convertStringFromUTF8` returned NULL for ten Latin-1 code points. The buffer is now sized for the larger of the two passes and the written length is taken from the conversion. The Windows CI leg is what caught this; the numbers above are measured there, not inferred. The max() is defensive: per code point the flagged size is never larger than the best-fit size, since no codepage we know of has a default character longer than a best-fit substitute, so the `fsize > bsize` arm is believed unreachable and the bug fixed here is the reverse, `fsize < bsize`, which the flagged pass reports and the converting pass cannot fit.

The non-strict callers change too (`hts_convertStringFromUTF8`, `hts_convertStringUTF8ToSystem`, hence WinHTTrack's ANSI entry points). Approximations that used to pass through (folding full-width to half-width, or dropping an accent) now come out as `'?'`. This is intended, but the change is visible well beyond the dangerous cases. It also brings the Windows build to where the iconv build already stood: failing instead of approximating.

The new `-#test=nobestfit` self-test asserts the best-fit mappings and the two sizing lengths themselves before it tests the engine, so it cannot pass vacuously if any of them ever changes. U+00A5 alone would not have found the sizing bug: it is one byte either way. The `syscharset` oracle needed the flag as well, or it disagrees with the engine on any ACP that best-fits. Found by the httrack-windows session while finishing its `newlang.cpp` UTF-8 work.