### PR TITLE
A long-path self-test aborted or passed depending on the length of $TMPDIR

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -10080,6 +10080,71 @@ static int st_singlefile(httrackp *opt, int argc, char **argv) {
   return sf_err;
 }
 
+// é and 中 in UTF-8: the charset axis of the long-path tests (#630).
+#define ST_NONASCII "\xC3\xA9\xE4\xB8\xAD"
+
+// mkdir path, tolerating one already there; n is only for the message.
+static hts_boolean st_mkdir_at(const char *path, size_t n, const char *who) {
+  if (MKDIR(path) != 0 && errno != EEXIST) {
+    fprintf(stderr, "%s: mkdir failed at %u chars: %s\n", who, (unsigned) n,
+            strerror(errno));
+    return HTS_FALSE;
+  }
+  return HTS_TRUE;
+}
+
+// Create a tree under dir whose deepest path clears MAX_PATH (260): an optional
+// non-ASCII first segment, then ASCII ones (#133). Returns its length in buf, 0
+// on failure; *baselen, when asked for, is where teardown must stop.
+static size_t st_mkdeep(char *buf, size_t bufsize, const char *dir,
+                        const char *nseg, const char *who, size_t *baselen) {
+  // 40-char segments: each under the 255 per-component limit \\?\ can't lift.
+  static const char seg[] = "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  // Headroom left for one more segment and the caller's leaf name.
+  const size_t room = bufsize - (sizeof(seg) + 64);
+  size_t n = (size_t) snprintf(buf, bufsize, "%s", dir);
+
+  assertf(bufsize > sizeof(seg) + 64);
+  if (n >= room) {
+    goto too_long;
+  }
+  while (n > 0 && (buf[n - 1] == '/' || buf[n - 1] == '\\')) {
+    buf[--n] = '\0';
+  }
+  if (baselen != NULL) {
+    *baselen = n;
+  }
+  if (nseg != NULL) {
+    const size_t nseglen = strlen(nseg);
+
+    if (nseglen >= room - n) { /* room - n > 0 above */
+      goto too_long;
+    }
+    memcpybuff(buf + n, nseg, nseglen + 1);
+    n += nseglen;
+    if (!st_mkdir_at(buf, n, who)) {
+      return 0;
+    }
+  }
+  // Until the path genuinely clears the limit: a fixed arithmetic bound landed
+  // on exactly 260 for a band of base lengths, so $TMPDIR decided (#1409).
+  while (n <= 260) {
+    if (n >= room) {
+      goto too_long;
+    }
+    memcpybuff(buf + n, seg, sizeof(seg));
+    n += sizeof(seg) - 1;
+    if (!st_mkdir_at(buf, n, who)) {
+      return 0;
+    }
+  }
+  return n;
+
+too_long:
+  fprintf(stderr, "%s: base dir too long (%u chars)\n", who, (unsigned) n);
+  return 0;
+}
+
 // -#test=longpath <dir>: round-trip a >MAX_PATH (260) file through the file
 // wrappers, exercising hts_pathToUCS2's \\?\ prefixing on Windows (#133).
 static int st_longpath(httrackp *opt, int argc, char **argv) {
@@ -10089,21 +10154,10 @@ static int st_longpath(httrackp *opt, int argc, char **argv) {
     return 1;
   }
   char path[HTS_URLMAXSIZE * 2];
-  size_t n = (size_t) snprintf(path, sizeof(path), "%s", argv[0]);
+  size_t n = st_mkdeep(path, sizeof(path), argv[0], NULL, "longpath", NULL);
 
-  while (n > 0 && (path[n - 1] == '/' || path[n - 1] == '\\')) {
-    path[--n] = '\0';
-  }
-  // 40-char segments: each under the 255 per-component limit \\?\ can't lift.
-  static const char seg[] = "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-  while (n + sizeof(seg) - 1 < 300) {
-    memcpybuff(path + n, seg, sizeof(seg));
-    n += sizeof(seg) - 1;
-    if (MKDIR(path) != 0 && errno != EEXIST) {
-      fprintf(stderr, "longpath: mkdir failed at %u chars: %s\n", (unsigned) n,
-              strerror(errno));
-      return 1;
-    }
+  if (n == 0) {
+    return 1;
   }
   memcpybuff(path + n, "/leaf.bin", sizeof("/leaf.bin"));
   n += sizeof("/leaf.bin") - 1;
@@ -10148,32 +10202,12 @@ static int st_mirrorio(httrackp *opt, int argc, char **argv) {
     return 1;
   }
   char path[HTS_URLMAXSIZE * 2];
-  size_t n = (size_t) snprintf(path, sizeof(path), "%s", argv[0]);
+  size_t base = 0;
+  size_t n = st_mkdeep(path, sizeof(path), argv[0],
+                       "/" ST_NONASCII "-non-ascii-seg", "mirrorio", &base);
 
-  while (n > 0 && (path[n - 1] == '/' || path[n - 1] == '\\')) {
-    path[--n] = '\0';
-  }
-  const size_t base = n; /* the caller's base dir; teardown stops here */
-  // First segment carries non-ASCII UTF-8 (é 中) to drive the charset axis
-  // (#630); ASCII 40-char segments then push the total past MAX_PATH (#133).
-  static const char nseg[] = "/\xC3\xA9\xE4\xB8\xAD-non-ascii-seg";
-  static const char seg[] = "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-
-  memcpybuff(path + n, nseg, sizeof(nseg));
-  n += sizeof(nseg) - 1;
-  if (MKDIR(path) != 0 && errno != EEXIST) {
-    fprintf(stderr, "mirrorio: mkdir failed (non-ascii): %s\n",
-            strerror(errno));
+  if (n == 0) {
     return 1;
-  }
-  while (n + sizeof(seg) - 1 < 300) {
-    memcpybuff(path + n, seg, sizeof(seg));
-    n += sizeof(seg) - 1;
-    if (MKDIR(path) != 0 && errno != EEXIST) {
-      fprintf(stderr, "mirrorio: mkdir failed at %u chars: %s\n", (unsigned) n,
-              strerror(errno));
-      return 1;
-    }
   }
   const size_t leafdir = n;
 
@@ -10603,35 +10637,14 @@ static int st_direnum(httrackp *opt, int argc, char **argv) {
     return 1;
   }
   char path[HTS_URLMAXSIZE * 2];
-  size_t n = (size_t) snprintf(path, sizeof(path), "%s", argv[0]);
+  size_t base = 0;
+  const size_t dirlen =
+      st_mkdeep(path, sizeof(path), argv[0], "/" ST_NONASCII "-non-ascii-seg",
+                "direnum", &base);
 
-  while (n > 0 && (path[n - 1] == '/' || path[n - 1] == '\\')) {
-    path[--n] = '\0';
-  }
-  const size_t base = n;
-  // Non-ASCII first segment + 40-char ASCII segments push the dir past
-  // MAX_PATH.
-  static const char nseg[] = "/\xC3\xA9\xE4\xB8\xAD-non-ascii-seg";
-  static const char seg[] = "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-
-  memcpybuff(path + n, nseg, sizeof(nseg));
-  n += sizeof(nseg) - 1;
-  if (MKDIR(path) != 0 && errno != EEXIST) {
-    fprintf(stderr, "direnum: mkdir failed (non-ascii): %s\n", strerror(errno));
+  if (dirlen == 0) {
     return 1;
   }
-  while (n + sizeof(seg) - 1 < 300) {
-    memcpybuff(path + n, seg, sizeof(seg));
-    n += sizeof(seg) - 1;
-    if (MKDIR(path) != 0 && errno != EEXIST) {
-      fprintf(stderr, "direnum: mkdir failed at %u chars: %s\n", (unsigned) n,
-              strerror(errno));
-      return 1;
-    }
-  }
-  const size_t dirlen = n;
-
-  assertf(dirlen > 260); /* the enumerated directory itself exceeds MAX_PATH */
 
   // Two non-ASCII leaf files to read back by name.
   static const char *const leaves[] = {"/\xC3\xA9-un.bin",
@@ -10704,33 +10717,14 @@ static int st_cookieimport(httrackp *opt, int argc, char **argv) {
     return 1;
   }
   char dir[HTS_URLMAXSIZE * 2];
-  size_t n = (size_t) snprintf(dir, sizeof(dir), "%s", argv[0]);
+  size_t base = 0;
+  const size_t dirlen =
+      st_mkdeep(dir, sizeof(dir), argv[0], "/" ST_NONASCII "-cookie-seg",
+                "cookieimport", &base);
 
-  while (n > 0 && (dir[n - 1] == '/' || dir[n - 1] == '\\')) {
-    dir[--n] = '\0';
-  }
-  const size_t base = n;
-  static const char nseg[] = "/\xC3\xA9\xE4\xB8\xAD-cookie-seg";
-  static const char seg[] = "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-
-  memcpybuff(dir + n, nseg, sizeof(nseg));
-  n += sizeof(nseg) - 1;
-  if (MKDIR(dir) != 0 && errno != EEXIST) {
-    fprintf(stderr, "cookieimport: mkdir failed: %s\n", strerror(errno));
+  if (dirlen == 0) {
     return 1;
   }
-  while (n + sizeof(seg) - 1 < 300) {
-    memcpybuff(dir + n, seg, sizeof(seg));
-    n += sizeof(seg) - 1;
-    if (MKDIR(dir) != 0 && errno != EEXIST) {
-      fprintf(stderr, "cookieimport: mkdir failed at %u: %s\n", (unsigned) n,
-              strerror(errno));
-      return 1;
-    }
-  }
-  const size_t dirlen = n;
-
-  assertf(dirlen > 260); /* the cookie folder itself exceeds MAX_PATH */
 
   char fpath[HTS_URLMAXSIZE * 2];
   char file[HTS_URLMAXSIZE * 2];

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -10093,19 +10093,40 @@ static hts_boolean st_mkdir_at(const char *path, size_t n, const char *who) {
   return HTS_TRUE;
 }
 
+// UTF-16 units a UTF-8 run costs, which is what Windows measures MAX_PATH in.
+// A stray byte is charged short, and short only ever builds a longer path.
+static size_t st_utf16_units(const char *s, size_t n) {
+  size_t units = 0;
+
+  for (size_t i = 0; i < n; i++) {
+    const unsigned char c = (unsigned char) s[i];
+
+    if ((c & 0xC0) == 0x80) {
+      continue; /* continuation byte: charged with its lead */
+    }
+    units += c >= 0xF0 ? 2 : 1; /* outside the BMP is a surrogate pair */
+  }
+  return units;
+}
+
+// Headroom st_mkdeep keeps for one more segment plus the caller's leaf name,
+// the longest of which is direnum's "/\xE4\xB8\xAD-deux.bin".
+#define ST_LEAF_ROOM 64
+
 // Build a tree under dir whose deepest path clears MAX_PATH (260): an optional
-// non-ASCII first segment, then ASCII ones (#133). 0 on failure; *baselen, when
-// asked for, is where teardown must stop.
+// non-ASCII first segment, then ASCII ones (#133). 0 on failure; *baselen is
+// where teardown must stop, and is written on every path.
 static size_t st_mkdeep(char *buf, size_t bufsize, const char *dir,
                         const char *nseg, const char *who, size_t *baselen) {
   // 40-char segments: each under the 255 per-component limit \\?\ can't lift.
   static const char seg[] = "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-  // Headroom left for one more segment and the caller's leaf name.
-  const size_t room = bufsize - (sizeof(seg) + 64);
+  const size_t room = bufsize - (sizeof(seg) + ST_LEAF_ROOM);
   size_t n = (size_t) snprintf(buf, bufsize, "%s", dir);
-  size_t slack = 0; /* by how much the byte count overstates the UTF-16 one */
 
-  assertf(bufsize > sizeof(seg) + 64);
+  assertf(bufsize > sizeof(seg) + ST_LEAF_ROOM);
+  if (baselen != NULL) {
+    *baselen = 0;
+  }
   if (n >= room) {
     goto too_long;
   }
@@ -10123,19 +10144,13 @@ static size_t st_mkdeep(char *buf, size_t bufsize, const char *dir,
     }
     memcpybuff(buf + n, nseg, nseglen + 1);
     n += nseglen;
-    for (size_t i = 0; i < nseglen; i++) { /* count code points, not bytes */
-      if (((unsigned char) nseg[i] & 0xC0) == 0x80) {
-        slack++;
-      }
-    }
     if (!st_mkdir_at(buf, n, who)) {
       return 0;
     }
   }
-  // A real MAX_PATH comparison, not an arithmetic bound: the old form landed
-  // exactly on 260 for some base lengths (#1409). Windows measures the limit in
-  // UTF-16 units, so charge the non-ASCII segment by code point (all BMP here).
-  while (n - slack <= 260) {
+  // Loop on the limit itself, over the whole path: an arithmetic bound landed
+  // exactly on 260 for some base lengths, a byte count on a non-ASCII base.
+  while (st_utf16_units(buf, n) <= 260) {
     if (n >= room) {
       goto too_long;
     }
@@ -10145,7 +10160,7 @@ static size_t st_mkdeep(char *buf, size_t bufsize, const char *dir,
       return 0;
     }
   }
-  assertf(n - slack > 260); /* the guarantee every caller depends on */
+  assertf(st_utf16_units(buf, n) > 260); /* what every caller depends on */
   return n;
 
 too_long:
@@ -10169,7 +10184,7 @@ static int st_longpath(httrackp *opt, int argc, char **argv) {
   }
   memcpybuff(path + n, "/leaf.bin", sizeof("/leaf.bin"));
   n += sizeof("/leaf.bin") - 1;
-  assertf(n > 260); /* must exceed the limit \\?\ lifts */
+  assertf(st_utf16_units(path, n) > 260); /* the limit \\?\ lifts */
 
   static const char payload[] = "longpath-ok";
   FILE *fp = FOPEN(path, "wb");
@@ -10221,7 +10236,7 @@ static int st_mirrorio(httrackp *opt, int argc, char **argv) {
 
   memcpybuff(path + n, "/leaf.bin", sizeof("/leaf.bin"));
   n += sizeof("/leaf.bin") - 1;
-  assertf(n > 260); /* must exceed the limit \\?\ lifts */
+  assertf(st_utf16_units(path, n) > 260); /* the limit \\?\ lifts */
 
   static const char payload[] = "mirrorio-ok";
 
@@ -10653,7 +10668,6 @@ static int st_direnum(httrackp *opt, int argc, char **argv) {
   if (dirlen == 0) {
     return 1;
   }
-  assertf(dirlen > 260); /* the enumerated directory itself exceeds MAX_PATH */
 
   // Two non-ASCII leaf files to read back by name.
   static const char *const leaves[] = {"/\xC3\xA9-un.bin",
@@ -10734,7 +10748,6 @@ static int st_cookieimport(httrackp *opt, int argc, char **argv) {
   if (dirlen == 0) {
     return 1;
   }
-  assertf(dirlen > 260); /* the cookie folder itself exceeds MAX_PATH */
 
   char fpath[HTS_URLMAXSIZE * 2];
   char file[HTS_URLMAXSIZE * 2];

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -10083,7 +10083,7 @@ static int st_singlefile(httrackp *opt, int argc, char **argv) {
 // é and 中 in UTF-8: the charset axis of the long-path tests (#630).
 #define ST_NONASCII "\xC3\xA9\xE4\xB8\xAD"
 
-// mkdir path, tolerating one already there; n is only for the message.
+// mkdir path, tolerating one that already exists.
 static hts_boolean st_mkdir_at(const char *path, size_t n, const char *who) {
   if (MKDIR(path) != 0 && errno != EEXIST) {
     fprintf(stderr, "%s: mkdir failed at %u chars: %s\n", who, (unsigned) n,
@@ -10093,9 +10093,9 @@ static hts_boolean st_mkdir_at(const char *path, size_t n, const char *who) {
   return HTS_TRUE;
 }
 
-// Create a tree under dir whose deepest path clears MAX_PATH (260): an optional
-// non-ASCII first segment, then ASCII ones (#133). Returns its length in buf, 0
-// on failure; *baselen, when asked for, is where teardown must stop.
+// Build a tree under dir whose deepest path clears MAX_PATH (260): an optional
+// non-ASCII first segment, then ASCII ones (#133). 0 on failure; *baselen, when
+// asked for, is where teardown must stop.
 static size_t st_mkdeep(char *buf, size_t bufsize, const char *dir,
                         const char *nseg, const char *who, size_t *baselen) {
   // 40-char segments: each under the 255 per-component limit \\?\ can't lift.
@@ -10103,6 +10103,7 @@ static size_t st_mkdeep(char *buf, size_t bufsize, const char *dir,
   // Headroom left for one more segment and the caller's leaf name.
   const size_t room = bufsize - (sizeof(seg) + 64);
   size_t n = (size_t) snprintf(buf, bufsize, "%s", dir);
+  size_t slack = 0; /* by how much the byte count overstates the UTF-16 one */
 
   assertf(bufsize > sizeof(seg) + 64);
   if (n >= room) {
@@ -10122,13 +10123,19 @@ static size_t st_mkdeep(char *buf, size_t bufsize, const char *dir,
     }
     memcpybuff(buf + n, nseg, nseglen + 1);
     n += nseglen;
+    for (size_t i = 0; i < nseglen; i++) { /* count code points, not bytes */
+      if (((unsigned char) nseg[i] & 0xC0) == 0x80) {
+        slack++;
+      }
+    }
     if (!st_mkdir_at(buf, n, who)) {
       return 0;
     }
   }
-  // Until the path genuinely clears the limit: a fixed arithmetic bound landed
-  // on exactly 260 for a band of base lengths, so $TMPDIR decided (#1409).
-  while (n <= 260) {
+  // A real MAX_PATH comparison, not an arithmetic bound: the old form landed
+  // exactly on 260 for some base lengths (#1409). Windows measures the limit in
+  // UTF-16 units, so charge the non-ASCII segment by code point (all BMP here).
+  while (n - slack <= 260) {
     if (n >= room) {
       goto too_long;
     }
@@ -10138,6 +10145,7 @@ static size_t st_mkdeep(char *buf, size_t bufsize, const char *dir,
       return 0;
     }
   }
+  assertf(n - slack > 260); /* the guarantee every caller depends on */
   return n;
 
 too_long:
@@ -10645,6 +10653,7 @@ static int st_direnum(httrackp *opt, int argc, char **argv) {
   if (dirlen == 0) {
     return 1;
   }
+  assertf(dirlen > 260); /* the enumerated directory itself exceeds MAX_PATH */
 
   // Two non-ASCII leaf files to read back by name.
   static const char *const leaves[] = {"/\xC3\xA9-un.bin",
@@ -10725,6 +10734,7 @@ static int st_cookieimport(httrackp *opt, int argc, char **argv) {
   if (dirlen == 0) {
     return 1;
   }
+  assertf(dirlen > 260); /* the cookie folder itself exceeds MAX_PATH */
 
   char fpath[HTS_URLMAXSIZE * 2];
   char file[HTS_URLMAXSIZE * 2];

--- a/tests/01_engine-cookieimport.test
+++ b/tests/01_engine-cookieimport.test
@@ -11,5 +11,5 @@ set -euo pipefail
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
-selftest_queue_base_lengths "-char non-ASCII dir: OK" cookieimport "$dir"
+selftest_queue_base_lengths tail "-char non-ASCII dir: OK" cookieimport "$dir"
 selftest_run_queued

--- a/tests/01_engine-cookieimport.test
+++ b/tests/01_engine-cookieimport.test
@@ -11,5 +11,5 @@ set -euo pipefail
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
-out=$(httrack -O /dev/null -#test=cookieimport "$dir")
-assert_match "cookieimport:.*OK" "$out"
+selftest_queue_base_lengths "-char non-ASCII dir: OK" cookieimport "$dir"
+selftest_run_queued

--- a/tests/01_engine-direnum.test
+++ b/tests/01_engine-direnum.test
@@ -10,5 +10,5 @@ set -euo pipefail
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
-selftest_queue_base_lengths "-char dir: OK" direnum "$dir"
+selftest_queue_base_lengths head "direnum: enumerated 2 non-ASCII leaves" direnum "$dir"
 selftest_run_queued

--- a/tests/01_engine-direnum.test
+++ b/tests/01_engine-direnum.test
@@ -10,5 +10,5 @@ set -euo pipefail
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
-out=$(httrack -O /dev/null -#test=direnum "$dir")
-assert_match "direnum:.*OK" "$out"
+selftest_queue_base_lengths "-char dir: OK" direnum "$dir"
+selftest_run_queued

--- a/tests/01_engine-longpath-io.test
+++ b/tests/01_engine-longpath-io.test
@@ -10,5 +10,5 @@ set -euo pipefail
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
-out=$(httrack -O /dev/null -#test=longpath "$dir")
-grep -q "longpath:.*OK" <<<"$out"
+selftest_queue_base_lengths tail "-char path: OK" longpath "$dir"
+selftest_run_queued

--- a/tests/01_engine-mirror-io.test
+++ b/tests/01_engine-mirror-io.test
@@ -11,5 +11,5 @@ set -euo pipefail
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
-out=$(httrack -O /dev/null -#test=mirrorio "$dir")
-grep -q "mirrorio:.*OK" <<<"$out"
+selftest_queue_base_lengths tail "-char non-ASCII path: OK" mirrorio "$dir"
+selftest_run_queued

--- a/tests/270_local-host-alias.test
+++ b/tests/270_local-host-alias.test
@@ -74,8 +74,13 @@ bash "$top_srcdir/tests/local-crawl.sh" --errors 0 --files 5 \
     httrack 'BASEURL/hostalias/index.html' \
     --host-alias 'http://alias.example.invalid=http://BASEHOST'
 
+# One throwaway -O for the parse probes below: none of them crawls, and an
+# inline $(mktemp -d) per probe leaked a directory per run.
+odir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_hostalias.XXXXXX")
+trap 'set +e; rm -rf "$odir"' EXIT
+
 # a rule the option cannot use is refused up front, not silently ignored
-out=$(httrack 'http://127.0.0.1:1/x.html' -O "$(mktemp -d)" \
+out=$(httrack 'http://127.0.0.1:1/x.html' -O "$odir" \
     --host-alias 'no-equals-sign' 2>&1) && {
     echo "FAIL: httrack accepted a malformed --host-alias rule"
     exit 1
@@ -87,13 +92,13 @@ grep -q "Invalid host-alias rule" <<<"$out" || {
 
 # A path is not part of an address. The accepted rule differs from the refused
 # one by the path alone, so the refusal cannot be blamed on the scheme.
-httrack 'http://127.0.0.1:1/x.html' -O "$(mktemp -d)" \
+httrack 'http://127.0.0.1:1/x.html' -O "$odir" \
     --host-alias 'https://a.example/=ftp://b.example/' >/dev/null 2>&1
 test $? -ne 2 || {
     echo "FAIL: httrack refused a scheme-bearing --host-alias rule"
     exit 1
 }
-out=$(httrack 'http://127.0.0.1:1/x.html' -O "$(mktemp -d)" \
+out=$(httrack 'http://127.0.0.1:1/x.html' -O "$odir" \
     --host-alias 'https://a.example/=ftp://b.example/pub/' 2>&1) && {
     echo "FAIL: httrack accepted a --host-alias rule naming a path"
     exit 1

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -144,15 +144,19 @@ selftest_queue_head() { # selftest_queue_head WANT NAME [ARGS...]
 # Queue NAME once per base-dir length across a full segment period: the tree the
 # long-path self-tests build starts at the base's own length, so a length-blind
 # stop bound clears MAX_PATH for some bases and lands exactly on it for others
-# (#1409).
-selftest_queue_base_lengths() { # selftest_queue_base_lengths WANT NAME DIR
-    local want=$1 name=$2 dir=$3 pad i
+# (#1409). What detects that is st_mkdeep's own assertf, which aborts the engine
+# and so the whole batch; WANT only pins that each base length got that far.
+selftest_queue_base_lengths() { # selftest_queue_base_lengths MODE WANT NAME DIR
+    local mode=$1 want=$2 name=$3 dir=$4 pad i
     # 41 is st_mkdeep's ASCII segment, so this covers every residue.
-    local width=41 before=${#SELFTEST_WANT[@]}
+    local width=41 before=${#SELFTEST_WANT[@]} accent
+    # The base is non-ASCII too, or the length axis is all the sweep exercises:
+    # a byte count overstates the UTF-16 units Windows measures MAX_PATH in.
+    accent=$(printf '\303\251%.0s' $(seq 1 15)) # 15 x U+00E9: 30 bytes, 15 units
     for ((i = 1; i <= width; i++)); do
-        pad=$(repeat_chars "$i" p)
+        pad=$accent$(repeat_chars "$i" p)
         mkdir "$dir/$pad" || fail "cannot create $dir/$pad"
-        selftest_queue_tail "$want" "$name" "$dir/$pad"
+        selftest_queue_mode "$mode" "$want" "$name" "$dir/$pad"
     done
     # A sweep that queued nothing would be a silent pass.
     test "$((${#SELFTEST_WANT[@]} - before))" -eq "$width" ||

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -141,19 +141,22 @@ selftest_queue_head() { # selftest_queue_head WANT NAME [ARGS...]
     selftest_queue_mode head "$@"
 }
 
-# Queue NAME once per base-dir length over a full segment period. The long-path
-# self-tests grow their tree from the base's own length, so a stop bound that is
-# arithmetic rather than a real MAX_PATH comparison clears the limit for some
-# lengths and lands exactly on it for others, which made $TMPDIR decide whether
-# the run aborted (#1409).
+# Queue NAME once per base-dir length across a full segment period: the tree the
+# long-path self-tests build starts at the base's own length, so a length-blind
+# stop bound clears MAX_PATH for some bases and lands exactly on it for others
+# (#1409).
 selftest_queue_base_lengths() { # selftest_queue_base_lengths WANT NAME DIR
-    local want=$1 name=$2 dir=$3 pad= i
+    local want=$1 name=$2 dir=$3 pad i
     # 41 is st_mkdeep's ASCII segment, so this covers every residue.
-    for ((i = 0; i < 41; i++)); do
-        pad="${pad}p"
+    local width=41 before=${#SELFTEST_WANT[@]}
+    for ((i = 1; i <= width; i++)); do
+        pad=$(repeat_chars "$i" p)
         mkdir "$dir/$pad" || fail "cannot create $dir/$pad"
         selftest_queue_tail "$want" "$name" "$dir/$pad"
     done
+    # A sweep that queued nothing would be a silent pass.
+    test "$((${#SELFTEST_WANT[@]} - before))" -eq "$width" ||
+        fail "queued $((${#SELFTEST_WANT[@]} - before)) of $width cases"
 }
 
 # Queue a -#test=filtersize case (nothing to do with -#test=fsize): a negative

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -141,6 +141,21 @@ selftest_queue_head() { # selftest_queue_head WANT NAME [ARGS...]
     selftest_queue_mode head "$@"
 }
 
+# Queue NAME once per base-dir length over a full segment period. The long-path
+# self-tests grow their tree from the base's own length, so a stop bound that is
+# arithmetic rather than a real MAX_PATH comparison clears the limit for some
+# lengths and lands exactly on it for others, which made $TMPDIR decide whether
+# the run aborted (#1409).
+selftest_queue_base_lengths() { # selftest_queue_base_lengths WANT NAME DIR
+    local want=$1 name=$2 dir=$3 pad= i
+    # 41 is st_mkdeep's ASCII segment, so this covers every residue.
+    for ((i = 0; i < 41; i++)); do
+        pad="${pad}p"
+        mkdir "$dir/$pad" || fail "cannot create $dir/$pad"
+        selftest_queue_tail "$want" "$name" "$dir/$pad"
+    done
+}
+
 # Queue a -#test=filtersize case (nothing to do with -#test=fsize): a negative
 # SIZE means the size is not known yet, as at scan time.
 fsize() { # fsize WANT SIZE STRING [FILTER...]


### PR DESCRIPTION
Four long-path self-tests built their directory by appending fixed-size segments while a counter stayed under 300, then asserted the result had passed MAX_PATH. The starting length is the base directory's, so the final value lands somewhere different for every `$TMPDIR`, and for a band of lengths it lands on exactly 260, where the `> 260` assertion aborts. Two of the four asserted on the directory alone, so they could fire; the other two had a leaf name's worth of slack and never did. It reads as an intermittent CI abort because where a machine's build tree happens to live is what decides whether it trips.

The four copies are now one helper that loops on the MAX_PATH comparison itself, so no base length can leave it short. Both tests sweep 41 consecutive base-dir lengths, one segment's worth, so every residue is covered whatever `$TMPDIR` is. The pre-fix engine aborts at two of the 41 and the fixed one at none, standalone and through `make check`.

The sweep on its own would not have caught a regression. The assertion it replaced was the only thing pinning that the path ever exceeded MAX_PATH, so reverting the loop with that assertion gone reintroduces the bug and the suite stays green. The postcondition is now asserted inside the helper and kept at both call sites, and both mutants go red.

One thing found while in here: the bound was in bytes, but Windows measures MAX_PATH in UTF-16 units, so the 5-byte, 2-unit non-ASCII segment let an exit at 261 bytes be 259 units, under the limit these tests exist to cross. The helper now charges that segment by code point. That part has no local red test, since only the Windows path can observe it.

Closes #1409
