### PR TITLE
-#C faults on the first cache entry it names

### DIFF
--- a/src/htsname.c
+++ b/src/htsname.c
@@ -409,8 +409,8 @@ int url_savename(lien_adrfilsave *const afs,
   char catbuff[CATBUFF_SIZE];
   const int is_redirect = headers != NULL && HTTP_IS_REDIRECT(headers->r.statuscode);
   const char *mime_type = headers != NULL && !is_redirect ? headers->r.contenttype : NULL;
-  /*const char* mime_type = ( headers && HTTP_IS_OK(headers->r.statuscode) ) ? headers->r.contenttype : NULL; */
-  lien_back *const back = sback->lnk;
+  /*const char* mime_type = ( headers && HTTP_IS_OK(headers->r.statuscode) ) ?
+   * headers->r.contenttype : NULL; */
 
   /* */
   char BIGSTK fil[HTS_URLMAXSIZE * 2];       /* ="" */
@@ -717,8 +717,9 @@ int url_savename(lien_adrfilsave *const afs,
               ext_chg_delayed = 1;      /* due to naming system */
             }
           }
-          // test imposible dans le cache, faire une requête
-          else {
+          // not in the cache: probe the type with a request
+          // no backing to probe with: -#C names offline (#1393)
+          else if (sback != NULL) {
             //
             int hihp = opt->state._hts_in_html_parsing;
             int has_been_moved = 0;
@@ -745,6 +746,7 @@ int url_savename(lien_adrfilsave *const afs,
 
               b = back_index(opt, sback, current.adr, current.fil, BACK_ADD_TEST);
               if (b >= 0) {
+                lien_back *const back = sback->lnk;
                 int stop_looping = 0;
                 int petits_tours = 0;
                 int get_test_request = 0;       // en cas de bouclage sur soi même avec HEAD, tester avec GET.. parfois c'est la cause des problèmes

--- a/src/htsname.h
+++ b/src/htsname.h
@@ -90,6 +90,7 @@ typedef struct lien_adrfilsave lien_adrfilsave;
 #endif
 
 // note: 'headers' can either be null, or incomplete (only r member filled)
+// note: 'sback' can be null: the type-probing request is then skipped
 int url_savename(lien_adrfilsave *const afs,
                  lien_adrfil *const former,
                  const char *referer_adr, const char *referer_fil, 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3361,7 +3361,7 @@ static int st_savename(httrackp *opt, int argc, char **argv) {
       cached = a + 7;
     else if (strncmp(a, "filpad=", 7) == 0)
       filpad = atoi(a + 7);
-    else if (strncmp(a, "delayed=", 8) == 0) /* -#N */
+    else if (strncmp(a, "delayed=", 8) == 0) /* -%N */
       opt->savename_delayed = (hts_savename_delayed) atoi(a + 8);
     else if (strncmp(a, "nosback=", 8) == 0) /* as -#C: no backing at all */
       nosback = atoi(a + 8);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3322,6 +3322,7 @@ static int st_savename(httrackp *opt, int argc, char **argv) {
   const char *bodyfile = "st-savename-body.tmp";
   int statuscode = HTTP_OK, status = 0;
   int filpad = 0;
+  int nosback = 0;
   int i;
 
   if (argc < 2) {
@@ -3360,6 +3361,10 @@ static int st_savename(httrackp *opt, int argc, char **argv) {
       cached = a + 7;
     else if (strncmp(a, "filpad=", 7) == 0)
       filpad = atoi(a + 7);
+    else if (strncmp(a, "delayed=", 8) == 0) /* -#N */
+      opt->savename_delayed = (hts_savename_delayed) atoi(a + 8);
+    else if (strncmp(a, "nosback=", 8) == 0) /* as -#C: no backing at all */
+      nosback = atoi(a + 8);
     else if (strncmp(a, "userdef=", 8) == 0) { /* -N, which selects type -1 */
       StringCopy(opt->savename_userdef, a + 8);
       opt->savename_type = -1;
@@ -3441,7 +3446,7 @@ static int st_savename(httrackp *opt, int argc, char **argv) {
     cache.hashtable = (void *) coucal_new(0);
   }
 
-  sback = back_new(opt, opt->maxsoc * 32 + 1024);
+  sback = nosback ? NULL : back_new(opt, opt->maxsoc * 32 + 1024);
   /* same wiring as hts_mirror (htscore.c) */
   hash_init(opt, &hash, opt->urlhack);
   hash.liens = (const lien_url *const *const *) &opt->liens;

--- a/tests/353_engine-savename-nosback.test
+++ b/tests/353_engine-savename-nosback.test
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+# -#C lists a legacy hts-cache/new.ndx with no crawl behind it, so it names each
+# entry through url_savename() with a NULL backing (#1393). nosback=1 is that
+# call; the name must come out as it does with a backing, since nothing on this
+# path has one to consult anyway.
+both() { # both FIL CTYPE WANT [ARGS...]
+    local fil=$1 ctype=$2 want=$3
+    shift 3
+    selftest_queue "savename: /dev/null/www.example.com/$want" savename \
+        "$fil" "$ctype" "$@"
+    selftest_queue "savename: /dev/null/www.example.com/$want" savename \
+        "$fil" "$ctype" nosback=1 "$@"
+}
+
+both '/x.zzz' 'text/html' 'x.zzz.html'
+both '/page.php' 'text/html' 'page.html'
+both '/foo' 'text/html' 'foo.html'
+both '/x.jpg' 'image/jpeg' 'x.jpg'
+
+# delayed=0 is -%N0, the one policy that sends an unresolved type to a HEAD
+# request rather than to a delayed name. That request is the last thing on this
+# path to read the backing, so with none it must be skipped, not issued.
+selftest_queue 'savename: /dev/null/www.example.com/x.zzz' savename \
+    /x.zzz text/html nosback=1 delayed=0
+
+selftest_run_queued


### PR DESCRIPTION
`url_savename()` opened by loading `sback->lnk` into a local that nothing reads until a branch the `-#C` lister never enters. That lister has no backing and passes NULL, so listing a legacy `hts-cache/new.ndx` faults on the first entry its pattern matches, before it prints anything. The local now comes from the block that uses it, and the type-probing request further down, the last thing on that path to touch the backing, is skipped when there is none.

That second half is not belt and braces: reading `sback->lnk` up front is undefined behaviour when it is NULL, so the compiler may delete any NULL test of `sback` that follows, and at -O2 it does. A mutant carrying the load with the guard in place still crashed, in the guarded branch. The new test drives `url_savename()` with no backing through a `nosback=` knob on `-#test=savename`, and reds on either mutant. End to end, a hand-built legacy ndx over a one-entry cache kills master at htsname.c:413 and lists cleanly once patched.

Closes #1393
