### PR TITLE
An update purge still deletes live children behind a redirect, and after two failed runs

### DIFF
--- a/src/htscache.c
+++ b/src/htscache.c
@@ -470,13 +470,18 @@ htsblk cache_read_ro(httrackp * opt, cache_back * cache, const char *adr,
 
 htsblk cache_read_including_broken(httrackp *opt, cache_back *cache,
                                    const char *adr, const char *fil,
-                                   char *return_save) {
-  htsblk r = cache_readex(opt, cache, adr, fil, NULL, NULL, return_save, 0);
+                                   char *return_save, char *return_location) {
+  htsblk r =
+      cache_readex(opt, cache, adr, fil, NULL, return_location, return_save, 0);
 
   if (r.statuscode == -1) {
     lien_back *itemback = NULL;
 
     if (back_unserialize_ref(opt, adr, fil, &itemback) == 0) {
+      if (return_location != NULL)
+        strlcpybuff(return_location,
+                    itemback->r.location != NULL ? itemback->r.location : "",
+                    HTS_LOCATION_SIZE);
       r = itemback->r;
       /* header fields only, like cache_readex(): the entry torn down below
          owns these (#826) */

--- a/src/htscache.h
+++ b/src/htscache.h
@@ -68,12 +68,14 @@ htsblk cache_read(httrackp * opt, cache_back * cache, const char *adr,
 htsblk cache_read_ro(httrackp * opt, cache_back * cache, const char *adr,
                      const char *fil, const char *save, char *location);
 /* Like cache_read, but also yields entries whose transfer broke; return_save
-   (optional, HTS_URLMAXSIZE*2) receives the entry's recorded save name.
-   Header fields only: adr, headers and location come back NULL, so the caller
-   owns and frees nothing. */
+   (optional, HTS_URLMAXSIZE*2) receives the entry's recorded save name and
+   return_location (optional, HTS_LOCATION_SIZE) its Location, which outlives
+   the status an entry naming no local file is invalidated to. Header fields
+   only: adr and headers come back NULL, so the caller owns and frees nothing,
+   and the location is the one to read, not r.location. */
 htsblk cache_read_including_broken(httrackp *opt, cache_back *cache,
                                    const char *adr, const char *fil,
-                                   char *return_save);
+                                   char *return_save, char *return_location);
 htsblk cache_readex(httrackp * opt, cache_back * cache, const char *adr,
                     const char *fil, const char *save, char *location,
                     char *return_save, int readonly);

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -349,7 +349,7 @@ static int broken_ref_selftest(httrackp *opt) {
 
   selftest_open_for_read(&cache, opt);
   save[0] = '\0';
-  r = cache_read_including_broken(opt, &cache, adr, fil, save);
+  r = cache_read_including_broken(opt, &cache, adr, fil, save, NULL);
   selftest_close(&cache);
 
   if (r.statuscode != 200 || strcmp(r.contenttype, "text/html") != 0) {

--- a/src/htsname.c
+++ b/src/htsname.c
@@ -647,8 +647,8 @@ int url_savename(lien_adrfilsave *const afs,
           htsblk r;
 
           previous_save[0] = '\0';
-          r = cache_read_including_broken(opt, cache, adr, fil,
-                                          previous_save); // test uniquement
+          r = cache_read_including_broken(opt, cache, adr, fil, previous_save,
+                                          NULL); // test uniquement
 
           if (r.statuscode != -1) { // cache entry read OK
             hts_log_print(opt, LOG_DEBUG, "Testing link type (from cache) %s%s",

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -3554,18 +3554,38 @@ hts_boolean hts_redirect_same_savefile(httrackp *opt, const char *cur_adr,
   return strcasecmp(n_fil, pn_fil) == 0;
 }
 
-/* Does this link have a mirrored subtree the purge could take? Only a previous
-   run's successful fetch does; a link never mirrored endangers nothing. */
+/* Does this link have a mirrored subtree the purge could take? A previous run's
+   hypertext page does, and so does a redirect, whose target and everything
+   below it reached the mirror through here alone (#1395). */
 static hts_boolean hts_link_may_carry_links(httrackp *opt, cache_back *cache,
-                                            const char *adr, const char *fil) {
+                                            const char *adr, const char *fil,
+                                            const char *save) {
   char BIGSTK prev_save[HTS_URLMAXSIZE * 2];
+  char BIGSTK prev_location[HTS_LOCATION_SIZE];
+  char guessed[256];
   htsblk prev;
 
-  prev_save[0] = '\0'; /* a cache miss leaves it untouched */
-  prev = cache_read_including_broken(opt, cache, adr, fil, prev_save);
+  /* a cache miss leaves both untouched */
+  prev_save[0] = prev_location[0] = '\0';
+  prev = cache_read_including_broken(opt, cache, adr, fil, prev_save,
+                                     prev_location);
 
-  return HTTP_IS_OK(prev.statuscode) && strnotempty(prev_save) &&
-                 is_hypertext_mime(opt, prev.contenttype, prev_save)
+  /* A redirect is stored headers-only, so it has no local file and the read
+     invalidates its status; the Location it recorded is what survives. */
+  if (HTTP_IS_REDIRECT(prev.statuscode) || strnotempty(prev_location))
+    return HTS_TRUE;
+  if (prev.statuscode > 0) /* answered: an error mirrored nothing */
+    return HTTP_IS_OK(prev.statuscode) && strnotempty(prev_save) &&
+                   is_hypertext_mime(opt, prev.contenttype, prev_save)
+               ? HTS_TRUE
+               : HTS_FALSE;
+
+  /* A run that failed the same way stored no entry at all, so the copy it kept
+     (#746) is the only surviving record of what this page was. */
+  guessed[0] = '\0';
+  return save != NULL && strnotempty(save) && fexist_utf8(save) &&
+                 guess_httptype_sized(opt, guessed, sizeof(guessed), save) &&
+                 is_hypertext_mime__(guessed)
              ? HTS_TRUE
              : HTS_FALSE;
 }
@@ -3932,7 +3952,8 @@ int hts_mirror_check_moved(htsmoduleStruct * str,
              preserves keeps its children. An answered error is not in it and
              needs nothing, being recovered from the cache and re-parsed. */
           if (back_transfer_failed(r->statuscode) && !heap(ptr)->testmode &&
-              hts_link_may_carry_links(opt, cache, urladr(), urlfil())) {
+              hts_link_may_carry_links(opt, cache, urladr(), urlfil(),
+                                       savename())) {
             opt->links_unqueued = HTS_TRUE;
           }
 

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -3570,24 +3570,24 @@ static hts_boolean hts_link_may_carry_links(httrackp *opt, cache_back *cache,
   prev = cache_read_including_broken(opt, cache, adr, fil, prev_save,
                                      prev_location);
 
-  /* A redirect is stored headers-only, so it has no local file and the read
-     invalidates its status; the Location it recorded is what survives. */
-  if (HTTP_IS_REDIRECT(prev.statuscode) || strnotempty(prev_location))
+  if (HTTP_IS_REDIRECT(prev.statuscode))
     return HTS_TRUE;
   if (prev.statuscode > 0) /* answered: an error mirrored nothing */
     return HTTP_IS_OK(prev.statuscode) && strnotempty(prev_save) &&
-                   is_hypertext_mime(opt, prev.contenttype, prev_save)
-               ? HTS_TRUE
-               : HTS_FALSE;
+           is_hypertext_mime(opt, prev.contenttype, prev_save);
+
+  /* No usable status left. A redirect is stored headers-only, so naming no
+     local file invalidates it on read, but its Location survives. Below this
+     arm only, or a stray Location on an answered blob would hold too. */
+  if (strnotempty(prev_location))
+    return HTS_TRUE;
 
   /* A run that failed the same way stored no entry at all, so the copy it kept
      (#746) is the only surviving record of what this page was. */
   guessed[0] = '\0';
   return save != NULL && strnotempty(save) && fexist_utf8(save) &&
-                 guess_httptype_sized(opt, guessed, sizeof(guessed), save) &&
-                 is_hypertext_mime__(guessed)
-             ? HTS_TRUE
-             : HTS_FALSE;
+         guess_httptype_sized(opt, guessed, sizeof(guessed), save) &&
+         is_hypertext_mime__(guessed);
 }
 
 /*

--- a/tests/348_local-update-purge-hubfail.test
+++ b/tests/348_local-update-purge-hubfail.test
@@ -18,25 +18,6 @@ cleanup_push cleanup
 
 common=(--quiet --disable-security-limits --robots=0 --retries=1 -c1 --timeout=20 --changes)
 
-# assert_purged WANT OUTDIR: what the run reported doing to the old files.
-assert_purged() {
-    local want="$1" json="${2}/hts-changes.json"
-    grep -q "\"purged\": ${want}" "$json" ||
-        fail "expected \"purged\": ${want} in $(<"$json")"
-}
-
-# assert_alive FILE MARKER: still mirrored, and still the body we mirrored.
-assert_alive() {
-    test -s "$1" || fail "$1 is gone"
-    grep -q "$2" "$1" || fail "$1 no longer carries ${2}"
-}
-
-# assert_logged OUTDIR PATTERN WHAT: the premise a shape rests on, in the log.
-assert_logged() {
-    local log="${1}/hts-log.txt"
-    grep -qE "$2" "$log" || fail "${3}: $(<"$log")"
-}
-
 local_server_start --log "${tmpdir}/server.log"
 
 # --- a hub that hangs up mid-header ----------------------------------------
@@ -56,8 +37,7 @@ ok "pass 1 mirrored the hub, its two children and both controls"
 local_crawl --log "${tmpdir}/log2" "${common[@]}" -O "$out" --update \
     "${BASEURL}/hubfail/index.html"
 
-assert_logged "$out" 'Error:.*at link .*/hubfail/hub\.html' \
-    "the hub re-fetch did not fail, so nothing went unparsed"
+assert_gave_up "$out" '/hubfail/hub\.html'
 # #746 keeps the copy whole, links included, not just a non-empty file.
 assert_alive "${site}/hub.html" 'child2\.html'
 assert_alive "${site}/child1.html" HUBFAIL-CHILD-1
@@ -75,8 +55,7 @@ local_crawl --log "${tmpdir}/log3" "${common[@]}" -O "$out" --update \
 assert_logged "$out" '"Not Found" \(404\) at link .*/hubfail/missing\.html' \
     "missing.html was never answered, so the 404 control did not run"
 for name in dead.bin dead.html; do
-    assert_logged "$out" "Error:.*\\(-[0-9]+\\).*at link .*/hubfail/${name}" \
-        "${name} did not fail the transfer, so it holds nothing back"
+    assert_gave_up "$out" "/hubfail/${name}"
 done
 assert_alive "${site}/hub.html" 'child2\.html'
 assert_alive "${site}/child1.html" HUBFAIL-CHILD-1
@@ -108,10 +87,8 @@ assert_purged false "$out"
 ok "a mangled gzip body holds the purge like a hang-up does"
 
 # --- boundary: a hub that answers 500 needs no hold at all ------------------
-# The update recovers the page from the previous copy and re-queues its
-# children well before the give-up arm the guard sits on, so the guard is never
-# asked. That ordering is what the guard rests on: assert it, or a recovery
-# that moved below the give-up arm would go unnoticed.
+# The update recovers it from the previous copy ahead of the give-up arm, so
+# the guard is never asked: the ordering the guard rests on, asserted below.
 out="${tmpdir}/err"
 mkdir -p "$out"
 site="${out}/127.0.0.1_${SRV_PORT}/errfail"

--- a/tests/348_local-update-purge-hubfail.test
+++ b/tests/348_local-update-purge-hubfail.test
@@ -25,6 +25,18 @@ assert_purged() {
         fail "expected \"purged\": ${want} in $(<"$json")"
 }
 
+# assert_alive FILE MARKER: still mirrored, and still the body we mirrored.
+assert_alive() {
+    test -s "$1" || fail "$1 is gone"
+    grep -q "$2" "$1" || fail "$1 no longer carries ${2}"
+}
+
+# assert_logged OUTDIR PATTERN WHAT: the premise a shape rests on, in the log.
+assert_logged() {
+    local log="${1}/hts-log.txt"
+    grep -qE "$2" "$log" || fail "${3}: $(<"$log")"
+}
+
 local_server_start --log "${tmpdir}/server.log"
 
 # --- a hub that hangs up mid-header ----------------------------------------
@@ -34,22 +46,23 @@ site="${out}/127.0.0.1_${SRV_PORT}/hubfail"
 
 local_crawl --log "${tmpdir}/log1" "${common[@]}" -O "$out" \
     "${BASEURL}/hubfail/index.html"
-for name in hub child1 child2 leaf gone; do
-    test -s "${site}/${name}.html" || fail "pass 1 did not mirror ${name}.html"
-done
+assert_alive "${site}/hub.html" 'child1\.html'
+assert_alive "${site}/child1.html" HUBFAIL-CHILD-1
+assert_alive "${site}/child2.html" HUBFAIL-CHILD-2
+assert_alive "${site}/leaf.html" HUBFAIL-LEAF
+assert_alive "${site}/gone.html" HUBFAIL-GONE
 ok "pass 1 mirrored the hub, its two children and both controls"
 
 local_crawl --log "${tmpdir}/log2" "${common[@]}" -O "$out" --update \
     "${BASEURL}/hubfail/index.html"
 
-log=$(<"${out}/hts-log.txt")
-grep -qE 'Error:.*at link .*/hubfail/hub\.html' <<<"$log" ||
-    fail "the hub re-fetch did not fail, so nothing went unparsed: ${log}"
-test -s "${site}/hub.html" || fail "hub.html was dropped despite #746"
-for name in child1 child2 leaf; do
-    test -s "${site}/${name}.html" ||
-        fail "${name}.html was purged: its only parent failed to re-fetch"
-done
+assert_logged "$out" 'Error:.*at link .*/hubfail/hub\.html' \
+    "the hub re-fetch did not fail, so nothing went unparsed"
+# #746 keeps the copy whole, links included, not just a non-empty file.
+assert_alive "${site}/hub.html" 'child2\.html'
+assert_alive "${site}/child1.html" HUBFAIL-CHILD-1
+assert_alive "${site}/child2.html" HUBFAIL-CHILD-2
+assert_alive "${site}/leaf.html" HUBFAIL-LEAF
 assert_purged false "$out"
 ok "the children of the failed page survived, and the run says so"
 
@@ -59,9 +72,16 @@ ok "the children of the failed page survived, and the run says so"
 local_crawl --log "${tmpdir}/log3" "${common[@]}" -O "$out" --update \
     "${BASEURL}/hubfail/index.html"
 
-for name in hub child1 child2 leaf; do
-    test -s "${site}/${name}.html" || fail "${name}.html was purged by pass 3"
+assert_logged "$out" '"Not Found" \(404\) at link .*/hubfail/missing\.html' \
+    "missing.html was never answered, so the 404 control did not run"
+for name in dead.bin dead.html; do
+    assert_logged "$out" "Error:.*\\(-[0-9]+\\).*at link .*/hubfail/${name}" \
+        "${name} did not fail the transfer, so it holds nothing back"
 done
+assert_alive "${site}/hub.html" 'child2\.html'
+assert_alive "${site}/child1.html" HUBFAIL-CHILD-1
+assert_alive "${site}/child2.html" HUBFAIL-CHILD-2
+assert_alive "${site}/leaf.html" HUBFAIL-LEAF
 test ! -e "${site}/gone.html" ||
     fail "gone.html left the site and a crawl that scanned it all kept it"
 assert_purged true "$out"
@@ -74,38 +94,42 @@ site="${out}/127.0.0.1_${SRV_PORT}/gzfail"
 
 local_crawl --log "${tmpdir}/gzlog1" "${common[@]}" -O "$out" \
     "${BASEURL}/gzfail/index.html"
-for name in gzhub gzchild gzgone; do
-    test -s "${site}/${name}.html" || fail "pass 1 did not mirror ${name}.html"
-done
+assert_alive "${site}/gzhub.html" 'gzchild\.html'
+assert_alive "${site}/gzchild.html" GZFAIL-CHILD
+assert_alive "${site}/gzgone.html" GZFAIL-GONE
 
 local_crawl --log "${tmpdir}/gzlog2" "${common[@]}" -O "$out" --update \
     "${BASEURL}/gzfail/index.html"
-for name in gzhub gzchild gzgone; do
-    test -s "${site}/${name}.html" ||
-        fail "${name}.html was purged after a decode failure on gzhub.html"
-done
+# The undecodable body must not have landed on the page it failed to replace.
+assert_alive "${site}/gzhub.html" 'gzchild\.html'
+assert_alive "${site}/gzchild.html" GZFAIL-CHILD
+assert_alive "${site}/gzgone.html" GZFAIL-GONE
 assert_purged false "$out"
 ok "a mangled gzip body holds the purge like a hang-up does"
 
 # --- boundary: a hub that answers 500 needs no hold at all ------------------
-# An update recovers the page from the cache and re-queues its children, so a
-# guard that fired on every failed link would keep errgone.html for nothing.
+# The update recovers the page from the previous copy and re-queues its
+# children well before the give-up arm the guard sits on, so the guard is never
+# asked. That ordering is what the guard rests on: assert it, or a recovery
+# that moved below the give-up arm would go unnoticed.
 out="${tmpdir}/err"
 mkdir -p "$out"
 site="${out}/127.0.0.1_${SRV_PORT}/errfail"
 
 local_crawl --log "${tmpdir}/errlog1" "${common[@]}" -O "$out" \
     "${BASEURL}/errfail/index.html"
-for name in errhub errchild errgone; do
-    test -s "${site}/${name}.html" || fail "pass 1 did not mirror ${name}.html"
-done
+assert_alive "${site}/errhub.html" 'errchild\.html'
+assert_alive "${site}/errchild.html" ERRFAIL-CHILD
+assert_alive "${site}/errgone.html" ERRFAIL-GONE
 
 local_crawl --log "${tmpdir}/errlog2" "${common[@]}" -O "$out" --update \
     "${BASEURL}/errfail/index.html"
-for name in errhub errchild; do
-    test -s "${site}/${name}.html" ||
-        fail "${name}.html was purged after errhub.html answered 500"
-done
+assert_logged "$out" 'Kept existing file .*errhub\.html after error 500' \
+    "the 500 did not recover from the previous copy"
+assert_logged "$out" '\(No errors,' \
+    "the 500 reached the give-up arm instead of being recovered ahead of it"
+assert_alive "${site}/errhub.html" 'errchild\.html'
+assert_alive "${site}/errchild.html" ERRFAIL-CHILD
 test ! -e "${site}/errgone.html" ||
     fail "errgone.html left the site and the recovered 500 kept the purge back"
 assert_purged true "$out"
@@ -120,13 +144,17 @@ site="${out}/127.0.0.1_${SRV_PORT}/bigfail"
 
 local_crawl --log "${tmpdir}/biglog1" "${common[@]}" -m,4000 -O "$out" \
     "${BASEURL}/bigfail/index.html"
-for name in bighub bigchild biggone; do
-    test -s "${site}/${name}.html" || fail "pass 1 did not mirror ${name}.html"
-done
+assert_alive "${site}/bighub.html" 'bigchild\.html'
+assert_alive "${site}/bigchild.html" BIGFAIL-CHILD
+assert_alive "${site}/biggone.html" BIGFAIL-GONE
 
 local_crawl --log "${tmpdir}/biglog2" "${common[@]}" -m,4000 -O "$out" --update \
     "${BASEURL}/bigfail/index.html"
+assert_logged "$out" '"File too big" \(-7\) at link .*/bigfail/bighub\.html' \
+    "the size cap did not skip bighub.html, so this is not the shape it names"
 assert_purged true "$out"
+test ! -e "${site}/bighub.html" ||
+    fail "bighub.html was skipped for size and #746 must not keep its copy"
 test ! -e "${site}/biggone.html" ||
     fail "biggone.html left the site and an over-size hub kept the purge back"
 ok "a deliberate size skip does not hold the purge back"

--- a/tests/354_local-update-purge-redirhub.test
+++ b/tests/354_local-update-purge-redirhub.test
@@ -17,26 +17,6 @@ cleanup_push cleanup
 
 common=(--quiet --disable-security-limits --robots=0 --retries=1 -c1 --timeout=20 --changes)
 
-# assert_purged WANT OUTDIR: what the run reported doing to the old files.
-assert_purged() {
-    local want="$1" json="${2}/hts-changes.json"
-    grep -q "\"purged\": ${want}" "$json" ||
-        fail "expected \"purged\": ${want} in $(<"$json")"
-}
-
-# assert_alive FILE MARKER: still mirrored, and still the body we mirrored.
-assert_alive() {
-    test -s "$1" || fail "$1 is gone"
-    grep -q "$2" "$1" || fail "$1 no longer carries ${2}"
-}
-
-# assert_gave_up OUTDIR URLPATH: the link really did exhaust its retries.
-assert_gave_up() {
-    local log="${1}/hts-log.txt"
-    grep -qE "Error:.*\(-[0-9]+\).*at link .*${2}" "$log" ||
-        fail "no give-up on ${2}: $(<"$log")"
-}
-
 local_server_start --log "${tmpdir}/server.log"
 
 # --- a hub that is a redirect ----------------------------------------------
@@ -128,3 +108,47 @@ test ! -e "${site}/bingone.html" ||
     fail "bingone.html left the site and a failing blob kept the purge back"
 assert_purged true "$out"
 ok "a blob that failed twice keeps its own copy and nothing else"
+
+# --- a Location header on an answered blob is not a redirect ---------------
+# Location: is parsed and cached whatever the status, so reading it without
+# first checking that no usable status came back would hold on this one.
+out="${tmpdir}/loc"
+mkdir -p "$out"
+site="${out}/127.0.0.1_${SRV_PORT}/locfail"
+
+local_crawl --log "${tmpdir}/llog1" "${common[@]}" -O "$out" \
+    "${BASEURL}/locfail/index.html"
+assert_alive "${site}/locblob.bin" LOCFAIL-BLOB
+assert_alive "${site}/locgone.html" LOCFAIL-GONE
+
+local_crawl --log "${tmpdir}/llog2" "${common[@]}" -O "$out" --update \
+    "${BASEURL}/locfail/index.html"
+assert_gave_up "$out" '/locfail/locblob\.bin'
+assert_alive "${site}/locblob.bin" LOCFAIL-BLOB
+test ! -e "${site}/locgone.html" ||
+    fail "locgone.html left the site and a 200 with a Location kept the purge back"
+assert_purged true "$out"
+ok "a cached Location on an answered blob holds nothing back"
+
+# --- a hub whose savename is not the name in its URL -----------------------
+# dynhub.php is mirrored as dynhub.html, so the guard has to type it by the
+# name the cache recorded. The second consecutive failure on such a hub is a
+# separate gap: the run recomputes the savename without a cache entry to type
+# it, lands back on .php and finds no file (#1421).
+out="${tmpdir}/dyn"
+mkdir -p "$out"
+site="${out}/127.0.0.1_${SRV_PORT}/dynfail"
+
+local_crawl --log "${tmpdir}/dlog1" "${common[@]}" -O "$out" \
+    "${BASEURL}/dynfail/index.html"
+assert_alive "${site}/dynhub.html" 'dynchild\.html'
+assert_alive "${site}/dynchild.html" DYNFAIL-CHILD
+assert_alive "${site}/dyngone.html" DYNFAIL-GONE
+
+local_crawl --log "${tmpdir}/dlog2" "${common[@]}" -O "$out" --update \
+    "${BASEURL}/dynfail/index.html"
+assert_gave_up "$out" '/dynfail/dynhub\.php'
+assert_alive "${site}/dynhub.html" 'dynchild\.html'
+assert_alive "${site}/dynchild.html" DYNFAIL-CHILD
+assert_purged false "$out"
+ok "a hub saved under another name still holds its subtree"

--- a/tests/354_local-update-purge-redirhub.test
+++ b/tests/354_local-update-purge-redirhub.test
@@ -1,0 +1,130 @@
+#!/bin/bash
+#
+# The hold #1390 put on the update purge keyed on the previous run's cache
+# entry being 2xx hypertext. A redirect hub has no such entry, and a hub
+# failing twice in a row leaves none at all, so both lost live children (#1395).
+
+set -euo pipefail
+
+# shellcheck source=tests/crawllib.sh
+. "${0%"${0##*/}"}./crawllib.sh"
+
+require_httrack
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_redirhub.XXXXXX")
+cleanup() { rm -rf "$tmpdir"; }
+cleanup_push cleanup
+
+common=(--quiet --disable-security-limits --robots=0 --retries=1 -c1 --timeout=20 --changes)
+
+# assert_purged WANT OUTDIR: what the run reported doing to the old files.
+assert_purged() {
+    local want="$1" json="${2}/hts-changes.json"
+    grep -q "\"purged\": ${want}" "$json" ||
+        fail "expected \"purged\": ${want} in $(<"$json")"
+}
+
+# assert_alive FILE MARKER: still mirrored, and still the body we mirrored.
+assert_alive() {
+    test -s "$1" || fail "$1 is gone"
+    grep -q "$2" "$1" || fail "$1 no longer carries ${2}"
+}
+
+# assert_gave_up OUTDIR URLPATH: the link really did exhaust its retries.
+assert_gave_up() {
+    local log="${1}/hts-log.txt"
+    grep -qE "Error:.*\(-[0-9]+\).*at link .*${2}" "$log" ||
+        fail "no give-up on ${2}: $(<"$log")"
+}
+
+local_server_start --log "${tmpdir}/server.log"
+
+# --- a hub that is a redirect ----------------------------------------------
+# rtarget.html and rchild.html hang below a 301 whose cache entry is stored
+# headers-only: nothing in it is 2xx, and it names no local file.
+out="${tmpdir}/redir"
+mkdir -p "$out"
+site="${out}/127.0.0.1_${SRV_PORT}/redirfail"
+
+local_crawl --log "${tmpdir}/rlog1" "${common[@]}" -O "$out" \
+    "${BASEURL}/redirfail/index.html"
+assert_alive "${site}/rtarget.html" REDIRFAIL-TARGET
+assert_alive "${site}/rchild.html" REDIRFAIL-CHILD
+assert_alive "${site}/rgone.html" REDIRFAIL-GONE
+ok "pass 1 followed the redirect and mirrored what hangs below it"
+
+local_crawl --log "${tmpdir}/rlog2" "${common[@]}" -O "$out" --update \
+    "${BASEURL}/redirfail/index.html"
+assert_gave_up "$out" '/redirfail/rhub\.html'
+assert_alive "${site}/rtarget.html" REDIRFAIL-TARGET
+assert_alive "${site}/rchild.html" REDIRFAIL-CHILD
+assert_purged false "$out"
+ok "a failed redirect hub keeps the subtree only it led to"
+
+# The hub redirects again, so this pass scans the whole site and the hold ends:
+# rgone.html is off the index and must go.
+local_crawl --log "${tmpdir}/rlog3" "${common[@]}" -O "$out" --update \
+    "${BASEURL}/redirfail/index.html"
+assert_alive "${site}/rtarget.html" REDIRFAIL-TARGET
+assert_alive "${site}/rchild.html" REDIRFAIL-CHILD
+test ! -e "${site}/rgone.html" ||
+    fail "rgone.html left the site and a pass that scanned it all kept it"
+assert_purged true "$out"
+ok "the hold lasts the run, not the mirror"
+
+# --- a hub that fails on two consecutive updates ---------------------------
+# Pass 2 holds on the cached page from pass 1 but stores no entry of its own,
+# so pass 3 has nothing in the cache left to read.
+out="${tmpdir}/twice"
+mkdir -p "$out"
+site="${out}/127.0.0.1_${SRV_PORT}/twicefail"
+
+local_crawl --log "${tmpdir}/tlog1" "${common[@]}" -O "$out" \
+    "${BASEURL}/twicefail/index.html"
+assert_alive "${site}/thub.html" 'tchild\.html'
+assert_alive "${site}/tchild.html" TWICEFAIL-CHILD
+ok "pass 1 mirrored the hub and the child both its parents link"
+
+local_crawl --log "${tmpdir}/tlog2" "${common[@]}" -O "$out" --update \
+    "${BASEURL}/twicefail/index.html"
+assert_gave_up "$out" '/twicefail/thub\.html'
+assert_alive "${site}/tchild.html" TWICEFAIL-CHILD
+assert_purged false "$out"
+
+# talt.html stops linking the child here, so only the hub's kept copy still
+# carries it: purging now would unlink a file that is still reachable.
+local_crawl --log "${tmpdir}/tlog3" "${common[@]}" -O "$out" --update \
+    "${BASEURL}/twicefail/index.html"
+assert_gave_up "$out" '/twicefail/thub\.html'
+grep -q 'tchild\.html' "${site}/thub.html" ||
+    fail "the kept copy of thub.html no longer links tchild.html"
+assert_alive "${site}/tchild.html" TWICEFAIL-CHILD
+assert_purged false "$out"
+ok "a second consecutive failure still holds the purge"
+
+# --- what carries no links must not hold anything --------------------------
+# Same failure, same kept copy, on a blob: neither its cached type nor the
+# name it was saved under says hypertext, on either pass.
+out="${tmpdir}/bin"
+mkdir -p "$out"
+site="${out}/127.0.0.1_${SRV_PORT}/binfail"
+
+local_crawl --log "${tmpdir}/blog1" "${common[@]}" -O "$out" \
+    "${BASEURL}/binfail/index.html"
+assert_alive "${site}/binblob.bin" BINFAIL-BLOB
+assert_alive "${site}/bingone.html" BINFAIL-GONE
+
+local_crawl --log "${tmpdir}/blog2" "${common[@]}" -O "$out" --update \
+    "${BASEURL}/binfail/index.html"
+assert_gave_up "$out" '/binfail/binblob\.bin'
+assert_alive "${site}/binblob.bin" BINFAIL-BLOB
+assert_purged true "$out"
+
+local_crawl --log "${tmpdir}/blog3" "${common[@]}" -O "$out" --update \
+    "${BASEURL}/binfail/index.html"
+assert_gave_up "$out" '/binfail/binblob\.bin'
+assert_alive "${site}/binblob.bin" BINFAIL-BLOB
+test ! -e "${site}/bingone.html" ||
+    fail "bingone.html left the site and a failing blob kept the purge back"
+assert_purged true "$out"
+ok "a blob that failed twice keeps its own copy and nothing else"

--- a/tests/crawllib.sh
+++ b/tests/crawllib.sh
@@ -142,3 +142,30 @@ local_crawl() {
     test "$rc" -ne 124 || fail "crawl watchdog fired after ${deadline}s"
     return "$rc"
 }
+
+# What a run reported doing to the files the previous mirror had, out of
+# hts-changes.json: assert_purged true|false OUTDIR.
+assert_purged() {
+    local want="$1" json="${2}/hts-changes.json"
+    grep -q "\"purged\": ${want}" "$json" ||
+        fail "expected \"purged\": ${want} in $(<"$json")"
+}
+
+# assert_alive FILE MARKER: still mirrored, and still the body we mirrored.
+assert_alive() {
+    test -s "$1" || fail "$1 is gone"
+    grep -q "$2" "$1" || fail "$1 no longer carries ${2}"
+}
+
+# assert_logged OUTDIR PATTERN WHAT: the premise a shape rests on, in the log.
+assert_logged() {
+    local log="${1}/hts-log.txt"
+    grep -qE "$2" "$log" || fail "${3}: $(<"$log")"
+}
+
+# assert_gave_up OUTDIR URLPATH: the link really did exhaust its retries on a
+# transport failure, not on an answered error.
+assert_gave_up() {
+    assert_logged "$1" "Error:.*\\(-[0-9]+\\).*at link .*${2}" \
+        "no transport failure gave up on ${2}"
+}

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1407,6 +1407,82 @@ class Handler(SimpleHTTPRequestHandler):
     def route_bigfail_gone(self):
         self.send_raw(b"<html><body><p>BIGFAIL-GONE</p></body></html>", "text/html")
 
+    # --- a hub that is a redirect, failing on the update (#1395) ------------
+    # rtarget.html and its child reached the mirror through rhub.html alone,
+    # and the cached entry for a 301 carries no hypertext type to key on.
+    def route_redirfail_index(self):
+        links = '\t<a href="rhub.html">hub</a>\n'
+        if self.refetch_pass() <= 2:  # rgone.html leaves the site for crawl 3
+            links += '\t<a href="rgone.html">gone</a>\n'
+        self.send_html(links)
+
+    # Cuts off both attempts of crawl 2, then redirects again for crawl 3.
+    def route_redirfail_hub(self):
+        if 2 <= self.refetch_pass() <= 3:
+            self.send_cut_headers()
+        else:
+            self.send_response(301, "Moved Permanently")
+            self.send_header("Location", "/redirfail/rtarget.html")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+    def route_redirfail_target(self):
+        self.send_raw(
+            b"<html><body><p>REDIRFAIL-TARGET</p>"
+            b'<a href="rchild.html">c</a></body></html>',
+            "text/html",
+        )
+
+    def route_redirfail_child(self):
+        self.send_raw(b"<html><body><p>REDIRFAIL-CHILD</p></body></html>", "text/html")
+
+    def route_redirfail_gone(self):
+        self.send_raw(b"<html><body><p>REDIRFAIL-GONE</p></body></html>", "text/html")
+
+    # --- a hub failing on two consecutive updates (#1395) ------------------
+    # Crawl 2 holds the purge on the cached page from crawl 1 and writes no
+    # entry of its own, leaving crawl 3 nothing in the cache to key on.
+    def route_twicefail_index(self):
+        self.send_html('\t<a href="thub.html">hub</a>\n\t<a href="talt.html">alt</a>\n')
+
+    def route_twicefail_hub(self):
+        if self.refetch_pass() == 1:
+            self.send_html('\t<a href="tchild.html">c</a>\n')
+        else:
+            self.send_cut_headers()
+
+    # The child's other parent, which stops linking it for crawl 3: only the
+    # hub still carries tchild.html then, and only its local copy says so.
+    def route_twicefail_alt(self):
+        links = '\t<a href="tchild.html">c</a>\n' if self.refetch_pass() <= 2 else ""
+        self.send_html(links)
+
+    def route_twicefail_child(self):
+        self.send_raw(b"<html><body><p>TWICEFAIL-CHILD</p></body></html>", "text/html")
+
+    # --- negative control: a blob that carries no links (#1395) ------------
+    # Previously mirrored and failing exactly like the hubs, but typed as a
+    # blob, so neither the cached entry nor the kept copy may hold the purge.
+    def route_binfail_index(self):
+        links = '\t<a href="binblob.bin">blob</a>\n'
+        if self.refetch_pass() <= 2:  # bingone.html leaves the site for crawl 3
+            links += '\t<a href="bingone.html">gone</a>\n'
+        self.send_html(links)
+
+    # Fails on crawls 2 and 3: the second failure has no cached entry left, so
+    # only the kept copy's name says what it was.
+    def route_binfail_blob(self):
+        if self.refetch_pass() == 1:
+            self.send_raw(
+                b"BINFAIL-BLOB\n" + b"\x71\x72\x73\x74" * 256,
+                "application/octet-stream",
+            )
+        else:
+            self.send_cut_headers()
+
+    def route_binfail_gone(self):
+        self.send_raw(b"<html><body><p>BINFAIL-GONE</p></body></html>", "text/html")
+
     # Echo what httrack advertised, so a crawl can assert the header.
     def route_codec_ae(self):
         self.send_raw(
@@ -2988,6 +3064,18 @@ class Handler(SimpleHTTPRequestHandler):
         "/bigfail/bighub.html": route_bigfail_hub,
         "/bigfail/bigchild.html": route_bigfail_child,
         "/bigfail/biggone.html": route_bigfail_gone,
+        "/redirfail/index.html": route_redirfail_index,
+        "/redirfail/rhub.html": route_redirfail_hub,
+        "/redirfail/rtarget.html": route_redirfail_target,
+        "/redirfail/rchild.html": route_redirfail_child,
+        "/redirfail/rgone.html": route_redirfail_gone,
+        "/twicefail/index.html": route_twicefail_index,
+        "/twicefail/thub.html": route_twicefail_hub,
+        "/twicefail/talt.html": route_twicefail_alt,
+        "/twicefail/tchild.html": route_twicefail_child,
+        "/binfail/index.html": route_binfail_index,
+        "/binfail/binblob.bin": route_binfail_blob,
+        "/binfail/bingone.html": route_binfail_gone,
         "/ranged/asset.bin": route_ranged_asset,
         "/types/index.html": route_types_index,
         "/types/control.php": route_types,

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1483,6 +1483,49 @@ class Handler(SimpleHTTPRequestHandler):
     def route_binfail_gone(self):
         self.send_raw(b"<html><body><p>BINFAIL-GONE</p></body></html>", "text/html")
 
+    # --- negative control: a Location on an answered blob (#1395) -----------
+    # Location: is parsed and cached whatever the status, so a 200 carrying one
+    # must not read as a redirect and hold the purge on the strength of it.
+    def route_locfail_index(self):
+        links = '\t<a href="locblob.bin">blob</a>\n'
+        if self.refetch_pass() == 1:  # locgone.html leaves the site afterwards
+            links += '\t<a href="locgone.html">gone</a>\n'
+        self.send_html(links)
+
+    def route_locfail_blob(self):
+        if self.refetch_pass() == 1:
+            self.send_raw(
+                b"LOCFAIL-BLOB\n" + b"\x71\x72\x73\x74" * 256,
+                "application/octet-stream",
+                extra_headers=[("Location", "/locfail/elsewhere.bin")],
+            )
+        else:
+            self.send_cut_headers()
+
+    def route_locfail_gone(self):
+        self.send_raw(b"<html><body><p>LOCFAIL-GONE</p></body></html>", "text/html")
+
+    # --- a hub whose savename is not its URL (#1395) ------------------------
+    # dynhub.php mirrors as dynhub.html, so the guard has to read the name the
+    # cache recorded rather than the one the URL suggests.
+    def route_dynfail_index(self):
+        links = '\t<a href="dynhub.php">hub</a>\n'
+        if self.refetch_pass() == 1:  # dyngone.html leaves the site afterwards
+            links += '\t<a href="dyngone.html">gone</a>\n'
+        self.send_html(links)
+
+    def route_dynfail_hub(self):
+        if self.refetch_pass() == 1:
+            self.send_html('\t<a href="dynchild.html">c</a>\n')
+        else:
+            self.send_cut_headers()
+
+    def route_dynfail_child(self):
+        self.send_raw(b"<html><body><p>DYNFAIL-CHILD</p></body></html>", "text/html")
+
+    def route_dynfail_gone(self):
+        self.send_raw(b"<html><body><p>DYNFAIL-GONE</p></body></html>", "text/html")
+
     # Echo what httrack advertised, so a crawl can assert the header.
     def route_codec_ae(self):
         self.send_raw(
@@ -3076,6 +3119,13 @@ class Handler(SimpleHTTPRequestHandler):
         "/binfail/index.html": route_binfail_index,
         "/binfail/binblob.bin": route_binfail_blob,
         "/binfail/bingone.html": route_binfail_gone,
+        "/locfail/index.html": route_locfail_index,
+        "/locfail/locblob.bin": route_locfail_blob,
+        "/locfail/locgone.html": route_locfail_gone,
+        "/dynfail/index.html": route_dynfail_index,
+        "/dynfail/dynhub.php": route_dynfail_hub,
+        "/dynfail/dynchild.html": route_dynfail_child,
+        "/dynfail/dyngone.html": route_dynfail_gone,
         "/ranged/asset.bin": route_ranged_asset,
         "/types/index.html": route_types_index,
         "/types/control.php": route_types,


### PR DESCRIPTION
An update purge still deleted live files in two shapes #1390 left open. A hub that is a 301 has its cache entry stored headers-only, and the read invalidates it for naming no local file, so nothing said the hub had carried its target and everything below it: one interrupted transfer took the whole subtree. A hub that fails on two consecutive runs has no cache entry at all the second time, because a failed fetch writes none, so a child that lost its other parent in that window went with it. Neither is a regression; a build of master from before #1390 loses the same files.

The guard now reads the redirect off the Location the entry recorded, which outlives that invalidation, and when no entry is left it falls back to the copy #746 kept on disk and the name it was saved under. Both new arms sit below the check that the entry answered a status at all, because `Location:` is parsed and cached whatever the status: read above that check, a 200 blob carrying a stray Location suppresses the whole run's purge. Requiring the kept copy to be present is what stops a brand-new dead `.html` link from holding the purge forever, the trap #1390 named when it rejected typing a link by its savename.

The issue proposed keying on `old.lst`'s `(from URL)` column instead. There is no such column: `filenote()` writes `[savename]` and nothing else, and `(from URL)` belongs to `hts-cache/new.txt`, a debug log. It could not carry either case anyway, since a redirect's child records the grandparent as its referer, and a run that failed never fetched the children at all.

The trade worth your decision. A hold covers the whole run rather than the failed page's subtree, because the subtree is exactly what the run does not know, and `opt->links_unqueued` is set once with nothing that releases it. Until now that hold could not outlive one run: the second failure wiped the cache entry the guard keyed on, so a page that stayed unreachable started purging again on the next update. With the fallback surviving the missing entry, one previously mirrored `.html` link that is permanently unreachable holds `--purge-old` off for the life of the mirror, which then keeps growing with files the site really did drop. The engine says so once per run in `hts-log.txt`, without naming the page. I took that over the alternative because the files a purge would take in this state are still reachable from the local copy the engine deliberately kept, and a mirror whose pages point at deleted files fails its reader worse than one carrying stale files it reported. Bounding it is implementable: `old.lst`, `new.lst` and the kept copy all survive the failure that loses the cache entry, so a per-link counter has somewhere to live. What the bound should be is a policy call about how long a mirror protects a subtree behind an unreachable parent, so the hold is unbounded here and the choice is yours.

Test 354 covers the redirect hub, the double failure, a blob that must hold nothing back, a 200 carrying a Location, and a hub saved under a name its URL does not give. Eight mutants of the guard ran against 348 and 354; seven red the intended assertion, always-on and always-off reding both files. The eighth, dropping the `HTTP_IS_REDIRECT` arm on its own, stays green: every redirect entry reachable through the engine is invalidated on read and caught by the Location arm below it, and the arm stays as the honest predicate for a 3xx that did name a local file. 348 gains the markers its survival checks never grepped, and premises for the two shapes that had none, since dropping `-m,4000` used to leave the size-cap shape green and the answered-500 shape asserted nothing about the cache recovery that happens ahead of the give-up arm.

Two findings from this work are filed rather than fixed. #1415: an empty `Content-Type` reads as the no-declared-type sentinel and therefore as hypertext, which falsifies the negative control #1395 named and is why 354 controls with an explicit `application/octet-stream` blob. #1421: a page whose local name comes from its cached type loses that name after a failed fetch, so #746's keep misses and this PR's fallback inherits the miss; 354 now carries a non-`.html` hub through the first failure, so the suite can see the shape.

Closes #1395
