### PR TITLE
Pin the sanitizer collector's pattern arms, close its trailing-dir hole

### DIFF
--- a/tests/349_sanitizer-stderr-capture.test
+++ b/tests/349_sanitizer-stderr-capture.test
@@ -117,8 +117,7 @@ hit leak '==23646==ERROR: LeakSanitizer: detected memory leaks' \
     'Direct leak of 7 byte(s) in 1 object(s) allocated from:' \
     '    #0 0x4af01b in operator new[](unsigned long) asan_new_delete.cc:66'
 
-# MemorySanitizer reports as WARNING, never ERROR (see the pattern comment
-# above); no SUMMARY line.
+# MemorySanitizer's own finding is a WARNING, not an ERROR; no SUMMARY line.
 hit msan '==29418==WARNING: MemorySanitizer: use-of-uninitialized-value' \
     '    #0 0x4008d6 in main umr.cc:5'
 
@@ -126,13 +125,25 @@ hit msan '==29418==WARNING: MemorySanitizer: use-of-uninitialized-value' \
 hit tsan 'WARNING: ThreadSanitizer: data race (pid=19219)' \
     '  Write of size 4 at 0x7fcf47b21bc0 by thread T1:'
 
-# A SUMMARY line with no ERROR/WARNING header at all, e.g. a log truncated
-# to its tail.
+# A SUMMARY line with no ERROR/WARNING header at all -- for example, a log
+# truncated to its tail.
 hit summary-only 'SUMMARY: AddressSanitizer: heap-buffer-overflow example.c:5 in main'
 
-# 4d. A full report carries both a header and a SUMMARY line, so the
-# collector only goes blind once BOTH arms are gone -- the two combinations
-# #1405 names as leaving `msan`, a required check, silently green.
+# compiler-rt's signal handler is shared: a crash reports through the
+# ERROR-group, not the WARNING form above.
+hit msan-crash '==46812==ERROR: MemorySanitizer: SEGV on unknown address 0x006000000000 (pc 0xaaaac1b12dd4 bp 0xffffcba33690 sp 0xffffcba31760 T46812)' \
+    '==46812==The signal is caused by a WRITE memory access.'
+
+hit tsan-crash '==205049==ERROR: ThreadSanitizer: SEGV on unknown address 0x000000000000 (pc 0x000000490f8a bp 0x000000000000 sp 0x7f88234bf268 T205050)' \
+    '==205049==The signal is caused by a WRITE memory access.'
+
+# The bare marker a sanitizer writes before its full report, in case that
+# report itself crashes; no "ERROR:" prefix, so it pins DEADLYSIGNAL alone.
+hit deadlysignal 'AddressSanitizer:DEADLYSIGNAL'
+
+# 4d. A full report carries a header AND a SUMMARY line: only losing both
+# arms blinds it. These are the two combinations #1405 flags for `msan`, a
+# required check.
 hit leak-full '==23646==ERROR: LeakSanitizer: detected memory leaks' \
     '' \
     'Direct leak of 7 byte(s) in 1 object(s) allocated from:' \

--- a/tests/349_sanitizer-stderr-capture.test
+++ b/tests/349_sanitizer-stderr-capture.test
@@ -89,7 +89,63 @@ for bad in "$tmp/absent" "$tmp/plainfile"; do
     rc=0
     "$sh_run" "$report" -s "$cap" "$bad" >"$tmp/bad.out" 2>&1 || rc=$?
     assert_eq 2 "$rc" "collector took a log dir of $bad"
+    rc=0
+    "$sh_run" "$report" "$logs" "$bad" >"$tmp/bad.out" 2>&1 || rc=$?
+    assert_eq 2 "$rc" "collector took a trailing TEST_LOG_DIR of $bad"
 done
+
+# 4c. Each runtime's own header, isolated from every other arm -- a fixture
+# carrying two arms' markers would stay caught by the one not under test.
+hit() { # hit LABEL LINE... -- LABEL's log must be a match with today's pattern
+    label=$1
+    shift
+    dir=$tmp/hit-$label
+    mkdir -p "$dir"
+    printf '%s\n' "$@" >"$dir/finding.log"
+    "$sh_run" "$report" "$dir" >"$tmp/hit-$label.out" 2>&1 &&
+        fail "the collector missed $label: $(cat "$tmp/hit-$label.out")"
+    return 0
+}
+
+# ASan header (its own doc example), no SUMMARY line.
+hit asan '==5==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200000eff0 at pc 0x000000455935 bp 0x7ffd7f5c1af8 sp 0x7ffd7f5c1af0' \
+    'READ of size 4 at 0x60200000eff0 thread T0'
+
+# LeakSanitizer header (clang's doc example), no SUMMARY line.
+hit leak '==23646==ERROR: LeakSanitizer: detected memory leaks' \
+    '' \
+    'Direct leak of 7 byte(s) in 1 object(s) allocated from:' \
+    '    #0 0x4af01b in operator new[](unsigned long) asan_new_delete.cc:66'
+
+# MemorySanitizer reports as WARNING, never ERROR (see the pattern comment
+# above); no SUMMARY line.
+hit msan '==29418==WARNING: MemorySanitizer: use-of-uninitialized-value' \
+    '    #0 0x4008d6 in main umr.cc:5'
+
+# ThreadSanitizer: the pattern's WARNING arm claims to cover this too.
+hit tsan 'WARNING: ThreadSanitizer: data race (pid=19219)' \
+    '  Write of size 4 at 0x7fcf47b21bc0 by thread T1:'
+
+# A SUMMARY line with no ERROR/WARNING header at all, e.g. a log truncated
+# to its tail.
+hit summary-only 'SUMMARY: AddressSanitizer: heap-buffer-overflow example.c:5 in main'
+
+# 4d. A full report carries both a header and a SUMMARY line, so the
+# collector only goes blind once BOTH arms are gone -- the two combinations
+# #1405 names as leaving `msan`, a required check, silently green.
+hit leak-full '==23646==ERROR: LeakSanitizer: detected memory leaks' \
+    '' \
+    'Direct leak of 7 byte(s) in 1 object(s) allocated from:' \
+    '    #0 0x4af01b in operator new[](unsigned long) asan_new_delete.cc:66' \
+    '    #1 0x4da26f in main main.cpp:4' \
+    '' \
+    'SUMMARY: AddressSanitizer: 7 byte(s) leaked in 1 allocation(s).'
+
+hit msan-full '==29418==WARNING: MemorySanitizer: use-of-uninitialized-value' \
+    '    #0 0x4008d6 in main umr.cc:5' \
+    '    #1 0x7f0c31eaabd4 in __libc_start_main libc-start.c:287' \
+    '' \
+    'SUMMARY: MemorySanitizer: use-of-uninitialized-value umr.cc:5 in main'
 
 # 5. What the caller redirected stderr into has to be whole the moment the shim
 # exits; a tee nobody waited for left it short (#1374). Go a batch at a time,

--- a/tools/ci-sanitizer-report.sh
+++ b/tools/ci-sanitizer-report.sh
@@ -84,7 +84,7 @@ fi
 # Only the harness logs: an in-tree build puts the .test sources here too, and
 # one of them carries the pattern as literal text.
 for dir in "$@"; do
-    [ -d "$dir" ] || continue
+    need_dir "TEST_LOG_DIR" "$dir"
     for f in "$dir"/*.log; do
         scan "sanitizer output in a test log" "$f"
     done


### PR DESCRIPTION
`tools/ci-sanitizer-report.sh` is the only path from a sanitizer finding to a red build, and its pattern also gates `msan` (MemorySanitizer, clang), a required check. Before this PR only the `runtime error:` arm (gcc's UBSan) had a fixture. Mutation testing against `tests/349_sanitizer-stderr-capture.test` found ten more pattern pieces that could be dropped with the test staying green. That covers every other name in the ERROR-group, the whole WARNING arm, the SUMMARY arm, DEADLYSIGNAL, and the two combinations that fully blind the collector to LeakSanitizer or MemorySanitizer. This predates #1404, so it isn't a regression, just newly load-bearing now that msan is required.

Each gap gets its own fixture, carrying only the marker for the arm it pins so a different arm can't catch it and hide the gap. ASan and LeakSanitizer's own ERROR lines and a SUMMARY-only line cover the ERROR-group and SUMMARY arms. MemorySanitizer and ThreadSanitizer get both their WARNING form (their own findings) and their ERROR form, since compiler-rt's crash-reporting path is shared and a crash makes either one report through the ERROR-group instead. A bare `DEADLYSIGNAL` marker line comes from a real ASan crash report, where it appears on its own with no `ERROR:` prefix. Two full multi-line reports pin the LeakSanitizer- and MemorySanitizer-blind combinations. `ERROR: UndefinedBehaviorSanitizer` and `ERROR: libFuzzer` stay unpinned on purpose: gcc's UBSan never emits the former, and the fuzz job never calls this script, so the latter can't fire here either.

`need_dir` already refused a missing `-s STDERR_DIR` or `LOG_PATH_DIR` (#1374); a missing trailing `TEST_LOG_DIR` was silently skipped instead, so a typo'd log path read as clean rather than broken. Closed the same way, with a test row for it.

Closes #1405