### PR TITLE
A write error outside the fatal class still read as the end of the body

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -824,16 +824,17 @@ static hts_boolean back_in_chunk_trailers(const lien_back *const back) {
              : HTS_FALSE;
 }
 
-/* A body small enough to sit in stdio's buffer reaches the disk only when its
-   stream is closed, so this is where a write failure first shows up. */
+/* Name a write we could not complete -- a failing close, or a decode that could
+   not write its output -- and give up the mirror on the fatal class. */
 static void back_report_write_failure(httrackp *opt, lien_back *const back) {
   const hts_boolean fatal = check_fatal_io_errno() ? HTS_TRUE : HTS_FALSE;
 
   /* the read path already named and classed a write error it saw itself */
-  if (!STATUSCODE_IS_WRITE_ERROR(back->r.statuscode)) {
+  if (!statuscode_is_write_error(back->r.statuscode)) {
     hts_log_print(opt, LOG_ERROR | LOG_ERRNO, "Unable to write file %s",
                   back->url_sav);
-    /* a slot still claiming success would be cached and counted as mirrored */
+    /* a slot still claiming success would be cached as mirrored; a
+       STATUSCODE_INVALID must survive, the decode site's purge rests on it */
     if (back->r.statuscode > 0) {
       back->r.statuscode = fatal ? STATUSCODE_IO_FATAL : STATUSCODE_IO_ERROR;
       strcpybuff(back->r.msg, "Write error on disk");
@@ -1016,7 +1017,7 @@ int back_finalize(httrackp * opt, cache_back * cache, struct_back * sback,
                   back[p].r.statuscode = STATUSCODE_INVALID;
                   /* Our own disk, not the coded body: hts_codec_unpack() leaves
                      a local write's errno behind, and 0 for a bad stream. */
-                  if (check_fatal_io_errno())
+                  if (errno != 0)
                     back_report_write_failure(opt, &back[p]);
                   snprintf(back[p].r.msg, sizeof(back[p].r.msg),
                            codec == HTS_CODEC_UNSUPPORTED
@@ -3583,7 +3584,7 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
           /* Skipped on a write error: these completion tests read r.size,
              which counts bytes read, and would relaunder the error into EOF. */
           if (back[i].status == 1 &&
-              !STATUSCODE_IS_WRITE_ERROR(back[i].r.statuscode)) {
+              !statuscode_is_write_error(back[i].r.statuscode)) {
             if (back[i].is_chunk) {     // attendre prochain chunk
               if (back[i].r.size == back[i].r.totalsize) { // fin chunk!
                 back[i].status = STATUS_CHUNK_CR;       /* fetch ending CRLF */
@@ -3617,7 +3618,7 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                  back[i].r.totalsize);
 #endif
             if (retour_fread < 0 && retour_fread != READ_EOF) {
-              if (STATUSCODE_IS_WRITE_ERROR(back[i].r.statuscode)) {
+              if (statuscode_is_write_error(back[i].r.statuscode)) {
                 /* our disk, not the server: keep the write error rather than
                    blame the transfer for what we could not store */
                 hts_log_print(opt, LOG_ERROR, "Unable to write file %s",
@@ -3686,7 +3687,7 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
             /* A body cut short by a failed write is short by definition: keep
                the write failure it is already classed as. */
             if (back[i].r.totalsize >= 0 &&
-                !STATUSCODE_IS_WRITE_ERROR(back[i].r.statuscode)) {
+                !statuscode_is_write_error(back[i].r.statuscode)) {
               if (back[i].r.totalsize != back[i].r.size) {      // pas la même!
                 if (!opt->tolerant) {
                   deleteaddr(&back[i].r);

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -1682,12 +1682,21 @@ int back_search(httrackp * opt, struct_back * sback) {
 }
 
 /* A body small enough to sit in stdio's buffer reaches the disk only when its
-   stream is closed, so this is where a full disk first shows up. */
-static void back_report_write_failure(httrackp *opt, const char *save) {
-  if (!check_fatal_io_errno())
-    return;
-  hts_log_print(opt, LOG_ERROR | LOG_ERRNO, "Unable to write file %s", save);
-  if (opt->state.exit_xh == 0) {
+   stream is closed, so this is where a write failure first shows up. */
+static void back_report_write_failure(httrackp *opt, lien_back *const back) {
+  const hts_boolean fatal = check_fatal_io_errno() ? HTS_TRUE : HTS_FALSE;
+
+  /* the read path already named and classed a write error it saw itself */
+  if (!STATUSCODE_IS_WRITE_ERROR(back->r.statuscode)) {
+    hts_log_print(opt, LOG_ERROR | LOG_ERRNO, "Unable to write file %s",
+                  back->url_sav);
+    /* a slot still claiming success would be cached and counted as mirrored */
+    if (back->r.statuscode > 0) {
+      back->r.statuscode = fatal ? STATUSCODE_IO_FATAL : STATUSCODE_IO_ERROR;
+      strcpybuff(back->r.msg, "Write error on disk");
+    }
+  }
+  if (fatal && opt->state.exit_xh == 0) {
     hts_log_print(opt, LOG_ERROR,
                   "Mirror aborted: disk full or filesystem problems");
     opt->state.exit_xh = -1;
@@ -1712,7 +1721,7 @@ void back_set_finished(httrackp *opt, struct_back *sback, const int p) {
 
       back[p].r.out = NULL;
       if (!closed)
-        back_report_write_failure(opt, back[p].url_sav);
+        back_report_write_failure(opt, &back[p]);
     }
   }
 }
@@ -1757,7 +1766,7 @@ int back_flush_output(httrackp * opt, cache_back * cache, struct_back * sback,
 
       back[p].r.out = NULL;
       if (!closed)
-        back_report_write_failure(opt, back[p].url_sav);
+        back_report_write_failure(opt, &back[p]);
     }
     /* set file time */
     if (back[p].r.is_write) {   // ecriture directe
@@ -3567,10 +3576,10 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
             retour_fread = READ_EOF;    // interruption ou annulation interne (peut ne pas être une erreur)
 
           // Si réception chunk, tester si on est pas à la fin!
-          /* Skipped on a fatal write error: these completion tests read r.size,
+          /* Skipped on a write error: these completion tests read r.size,
              which counts bytes read, and would relaunder the error into EOF. */
           if (back[i].status == 1 &&
-              back[i].r.statuscode != STATUSCODE_IO_FATAL) {
+              !STATUSCODE_IS_WRITE_ERROR(back[i].r.statuscode)) {
             if (back[i].is_chunk) {     // attendre prochain chunk
               if (back[i].r.size == back[i].r.totalsize) { // fin chunk!
                 back[i].status = STATUS_CHUNK_CR;       /* fetch ending CRLF */
@@ -3604,15 +3613,19 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                  back[i].r.totalsize);
 #endif
             if (retour_fread < 0 && retour_fread != READ_EOF) {
-              if (back[i].r.statuscode == STATUSCODE_IO_FATAL) {
-                /* disk full, not a network blink: a retry writes nothing and
-                   the purge would measure a truncated mirror */
-                hts_log_print(
-                    opt, LOG_ERROR,
-                    "Mirror aborted: disk full or filesystem problems");
+              if (STATUSCODE_IS_WRITE_ERROR(back[i].r.statuscode)) {
+                /* our disk, not the server: keep the write error rather than
+                   blame the transfer for what we could not store */
                 hts_log_print(opt, LOG_ERROR, "Unable to write file %s",
                               back[i].url_sav);
-                opt->state.exit_xh = -1;
+                if (back[i].r.statuscode == STATUSCODE_IO_FATAL) {
+                  /* disk full, not a network blink: a retry writes nothing and
+                     the purge would measure a truncated mirror */
+                  hts_log_print(
+                      opt, LOG_ERROR,
+                      "Mirror aborted: disk full or filesystem problems");
+                  opt->state.exit_xh = -1;
+                }
               } else {
                 if (back[i].r.size > 0)
                   strcpybuff(back[i].r.msg, "Interrupted transfer");
@@ -3666,10 +3679,10 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
               }
             }
 
-            /* A body cut short by a full disk is short by definition: keep
+            /* A body cut short by a failed write is short by definition: keep
                the write failure it is already classed as. */
             if (back[i].r.totalsize >= 0 &&
-                back[i].r.statuscode != STATUSCODE_IO_FATAL) {
+                !STATUSCODE_IS_WRITE_ERROR(back[i].r.statuscode)) {
               if (back[i].r.totalsize != back[i].r.size) {      // pas la même!
                 if (!opt->tolerant) {
                   deleteaddr(&back[i].r);

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -824,6 +824,28 @@ static hts_boolean back_in_chunk_trailers(const lien_back *const back) {
              : HTS_FALSE;
 }
 
+/* A body small enough to sit in stdio's buffer reaches the disk only when its
+   stream is closed, so this is where a write failure first shows up. */
+static void back_report_write_failure(httrackp *opt, lien_back *const back) {
+  const hts_boolean fatal = check_fatal_io_errno() ? HTS_TRUE : HTS_FALSE;
+
+  /* the read path already named and classed a write error it saw itself */
+  if (!STATUSCODE_IS_WRITE_ERROR(back->r.statuscode)) {
+    hts_log_print(opt, LOG_ERROR | LOG_ERRNO, "Unable to write file %s",
+                  back->url_sav);
+    /* a slot still claiming success would be cached and counted as mirrored */
+    if (back->r.statuscode > 0) {
+      back->r.statuscode = fatal ? STATUSCODE_IO_FATAL : STATUSCODE_IO_ERROR;
+      strcpybuff(back->r.msg, "Write error on disk");
+    }
+  }
+  if (fatal && opt->state.exit_xh == 0) {
+    hts_log_print(opt, LOG_ERROR,
+                  "Mirror aborted: disk full or filesystem problems");
+    opt->state.exit_xh = -1;
+  }
+}
+
 // objet (lien) téléchargé ou transféré depuis le cache
 //
 // fermer les paramètres de transfert,
@@ -992,6 +1014,10 @@ int back_finalize(httrackp * opt, cache_back * cache, struct_back * sback,
                   }
                 } else {
                   back[p].r.statuscode = STATUSCODE_INVALID;
+                  /* Our own disk, not the coded body: hts_codec_unpack() leaves
+                     a local write's errno behind, and 0 for a bad stream. */
+                  if (check_fatal_io_errno())
+                    back_report_write_failure(opt, &back[p]);
                   snprintf(back[p].r.msg, sizeof(back[p].r.msg),
                            codec == HTS_CODEC_UNSUPPORTED
                                ? "Unsupported Content-Encoding (%s)"
@@ -1679,28 +1705,6 @@ int back_search(httrackp * opt, struct_back * sback) {
 
   /* oops, can't find a place */
   return -1;
-}
-
-/* A body small enough to sit in stdio's buffer reaches the disk only when its
-   stream is closed, so this is where a write failure first shows up. */
-static void back_report_write_failure(httrackp *opt, lien_back *const back) {
-  const hts_boolean fatal = check_fatal_io_errno() ? HTS_TRUE : HTS_FALSE;
-
-  /* the read path already named and classed a write error it saw itself */
-  if (!STATUSCODE_IS_WRITE_ERROR(back->r.statuscode)) {
-    hts_log_print(opt, LOG_ERROR | LOG_ERRNO, "Unable to write file %s",
-                  back->url_sav);
-    /* a slot still claiming success would be cached and counted as mirrored */
-    if (back->r.statuscode > 0) {
-      back->r.statuscode = fatal ? STATUSCODE_IO_FATAL : STATUSCODE_IO_ERROR;
-      strcpybuff(back->r.msg, "Write error on disk");
-    }
-  }
-  if (fatal && opt->state.exit_xh == 0) {
-    hts_log_print(opt, LOG_ERROR,
-                  "Mirror aborted: disk full or filesystem problems");
-    opt->state.exit_xh = -1;
-  }
 }
 
 void back_set_finished(httrackp *opt, struct_back *sback, const int p) {

--- a/src/htsbasenet.h
+++ b/src/htsbasenet.h
@@ -159,10 +159,12 @@ typedef enum BackStatusCode {
   STATUSCODE_IO_ERROR = -13  /* the body write failed, but not fatally */
 } BackStatusCode;
 
-/* Either write-error class: r.size counts bytes read, so every size-based
-   completion test would read a body a failed write cut short as a clean end. */
-#define STATUSCODE_IS_WRITE_ERROR(code)                                        \
-  ((code) == STATUSCODE_IO_FATAL || (code) == STATUSCODE_IO_ERROR)
+/** Either write-error class: r.size counts bytes read, so a size-based
+    completion test reads a body a failed write cut short as a clean end. **/
+static HTS_INLINE HTS_UNUSED hts_boolean statuscode_is_write_error(int code) {
+  return code == STATUSCODE_IO_FATAL || code == STATUSCODE_IO_ERROR ? HTS_TRUE
+                                                                    : HTS_FALSE;
+}
 
 /** HTTrack status ('status' member of of 'lien_back') **/
 typedef enum HTTrackStatus {

--- a/src/htsbasenet.h
+++ b/src/htsbasenet.h
@@ -155,8 +155,14 @@ typedef enum BackStatusCode {
   STATUSCODE_TOO_BIG = -7,
   STATUSCODE_TEST_OK = -10,
   STATUSCODE_EXCLUDED = -11, /* aborted: MIME excluded by a -mime: filter */
-  STATUSCODE_IO_FATAL = -12  /* the body write hit a fatal I/O errno */
+  STATUSCODE_IO_FATAL = -12, /* the body write hit a fatal I/O errno */
+  STATUSCODE_IO_ERROR = -13  /* the body write failed, but not fatally */
 } BackStatusCode;
+
+/* Either write-error class: r.size counts bytes read, so every size-based
+   completion test would read a body a failed write cut short as a clean end. */
+#define STATUSCODE_IS_WRITE_ERROR(code)                                        \
+  ((code) == STATUSCODE_IO_FATAL || (code) == STATUSCODE_IO_ERROR)
 
 /** HTTrack status ('status' member of of 'lien_back') **/
 typedef enum HTTrackStatus {

--- a/src/htscodec.c
+++ b/src/htscodec.c
@@ -126,19 +126,25 @@ hts_boolean hts_codec_is_archive_ext(hts_codec codec, const char *ext) {
 /* Append produced bytes to out under the decoded-size budget, advancing *total.
    HTS_FALSE on a short write or once the budget is exceeded (a bomb); the
    over-budget bytes are never written. */
+/* io_errno takes the errno of a failed write, so the caller can tell a full
+   disk from a bomb over the budget. */
 static hts_boolean codec_sink(FILE *out, const void *buf, size_t produced,
-                              LLint *total, LLint maxout) {
+                              LLint *total, LLint maxout, int *io_errno) {
   if (produced == 0)
     return HTS_TRUE;
   *total += (LLint) produced;
   if (*total > maxout)
     return HTS_FALSE;
-  return hts_fwrite_exact(buf, produced, out);
+  if (hts_fwrite_exact(buf, produced, out))
+    return HTS_TRUE;
+  *io_errno = errno;
+  return HTS_FALSE;
 }
 #endif
 
 #if HTS_USEBROTLI
-static int codec_unpack_brotli(FILE *in, FILE *out, LLint maxout) {
+static int codec_unpack_brotli(FILE *in, FILE *out, LLint maxout,
+                               int *io_errno) {
   BrotliDecoderState *const state =
       BrotliDecoderCreateInstance(NULL, NULL, NULL);
   hts_boolean ok = HTS_TRUE, done = HTS_FALSE;
@@ -163,7 +169,7 @@ static int codec_unpack_brotli(FILE *in, FILE *out, LLint maxout) {
       res = BrotliDecoderDecompressStream(state, &avail_in, &next_in,
                                           &avail_out, &next_out, NULL);
       produced = sizeof(outbuf) - avail_out;
-      if (!codec_sink(out, outbuf, produced, &total, maxout)) {
+      if (!codec_sink(out, outbuf, produced, &total, maxout, io_errno)) {
         ok = HTS_FALSE;
         break;
       }
@@ -204,7 +210,7 @@ static size_t codec_head_brotli(const void *in, size_t in_len, void *out,
 #endif
 
 #if HTS_USEZSTD
-static int codec_unpack_zstd(FILE *in, FILE *out, LLint maxout) {
+static int codec_unpack_zstd(FILE *in, FILE *out, LLint maxout, int *io_errno) {
   ZSTD_DStream *const zds = ZSTD_createDStream();
   hts_boolean ok = HTS_TRUE, eof = HTS_FALSE;
   size_t zret = 1; /* 0 once a frame is fully flushed */
@@ -240,7 +246,7 @@ static int codec_unpack_zstd(FILE *in, FILE *out, LLint maxout) {
         ok = HTS_FALSE;
         break;
       }
-      if (!codec_sink(out, outbuf, output.pos, &total, maxout)) {
+      if (!codec_sink(out, outbuf, output.pos, &total, maxout, io_errno)) {
         ok = HTS_FALSE;
         break;
       }
@@ -292,6 +298,7 @@ LLint hts_codec_coded_size(FILE *in) {
 
 int hts_codec_unpack(hts_codec codec, const char *filename,
                      const char *newfile) {
+  errno = 0; /* nothing local failed: see the contract in htscodec.h */
   if (filename == NULL || newfile == NULL || !filename[0] || !newfile[0])
     return -1;
   switch (codec) {
@@ -308,26 +315,33 @@ int hts_codec_unpack(hts_codec codec, const char *filename,
     char catbuff[CATBUFF_SIZE];
     FILE *out, *in = FOPEN(fconv(catbuff, sizeof(catbuff), filename), "rb");
     LLint maxout;
-    int ret = -1;
+    int ret = -1, io_errno = 0;
 
     if (in == NULL)
       return -1;
     maxout = hts_codec_maxout(hts_codec_coded_size(in));
     out = FOPEN(fconv(catbuff, sizeof(catbuff), newfile), "wb");
     if (out == NULL) {
+      io_errno = errno;
       fclose(in);
+      errno = io_errno;
       return -1;
     }
 #if HTS_USEBROTLI
     if (codec == HTS_CODEC_BROTLI)
-      ret = codec_unpack_brotli(in, out, maxout);
+      ret = codec_unpack_brotli(in, out, maxout, &io_errno);
 #endif
 #if HTS_USEZSTD
     if (codec == HTS_CODEC_ZSTD)
-      ret = codec_unpack_zstd(in, out, maxout);
+      ret = codec_unpack_zstd(in, out, maxout, &io_errno);
 #endif
-    fclose(out);
+    /* stdio may still hold the tail, so the close is a write of its own */
+    if (fclose(out) != 0) {
+      io_errno = errno;
+      ret = -1;
+    }
     fclose(in);
+    errno = ret < 0 ? io_errno : 0;
     return ret;
   }
 #else

--- a/src/htscodec.c
+++ b/src/htscodec.c
@@ -340,7 +340,8 @@ int hts_codec_unpack(hts_codec codec, const char *filename,
     }
     fclose(in);
     /* io_errno is set only where ret is already < 0, so this is the whole
-       contract: the closes above are free to clobber what it restores. */
+       contract. It reads as a no-op on glibc, where the live errno already
+       equals it, but POSIX lets a successful fclose() set errno: keep it. */
     errno = io_errno;
     return ret;
   }

--- a/src/htscodec.c
+++ b/src/htscodec.c
@@ -124,10 +124,8 @@ hts_boolean hts_codec_is_archive_ext(hts_codec codec, const char *ext) {
 
 #if HTS_USEBROTLI || HTS_USEZSTD
 /* Append produced bytes to out under the decoded-size budget, advancing *total.
-   HTS_FALSE on a short write or once the budget is exceeded (a bomb); the
-   over-budget bytes are never written. */
-/* io_errno takes the errno of a failed write, so the caller can tell a full
-   disk from a bomb over the budget. */
+   HTS_FALSE on a short write, whose errno it leaves in *io_errno, or once the
+   budget is exceeded (a bomb); the over-budget bytes are never written. */
 static hts_boolean codec_sink(FILE *out, const void *buf, size_t produced,
                               LLint *total, LLint maxout, int *io_errno) {
   if (produced == 0)
@@ -341,7 +339,9 @@ int hts_codec_unpack(hts_codec codec, const char *filename,
       ret = -1;
     }
     fclose(in);
-    errno = ret < 0 ? io_errno : 0;
+    /* io_errno is set only where ret is already < 0, so this is the whole
+       contract: the closes above are free to clobber what it restores. */
+    errno = io_errno;
     return ret;
   }
 #else

--- a/src/htscodec.h
+++ b/src/htscodec.h
@@ -59,7 +59,9 @@ extern const char *hts_acceptencoding(hts_boolean compressible,
 extern hts_boolean hts_codec_is_archive_ext(hts_codec codec, const char *ext);
 
 /* Decode filename into newfile. Returns the decoded size, or -1 on a truncated
-   or corrupt stream, an unsupported coding, a bomb over the budget, or I/O. */
+   or corrupt stream, an unsupported coding, a bomb over the budget, or I/O.
+   On -1, errno is the local failure's, and 0 when the coded body was the
+   problem: a caller telling a full disk from a bad stream tests it. */
 extern int hts_codec_unpack(hts_codec codec, const char *filename,
                             const char *newfile);
 

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -1954,6 +1954,14 @@ int check_writeinput_t(T_SOC soc, int timeout) {
     return 0;
 }
 
+/* Class the live errno now: back_wait() sees it after free() and fflush() and
+   would rewrite this as a retryable connection error. */
+static void classify_write_error(htsblk *r) {
+  r->statuscode =
+      check_fatal_io_errno() ? STATUSCODE_IO_FATAL : STATUSCODE_IO_ERROR;
+  strcpybuff(r->msg, "Write error on disk");
+}
+
 // Read one block: bufl is a byte count, or one of the HTS_XFREAD_* line modes.
 // Note: the +1 in the mallocs is the trailing NUL appended to the data.
 LLint http_xfread1(htsblk * r, int bufl) {
@@ -2054,11 +2062,7 @@ LLint http_xfread1(htsblk * r, int bufl) {
         if (nl > 0) {
           r->size += nl;
           if (!hts_fwrite_exact(buff, (size_t) nl, r->out)) {
-            /* Classify here: back_wait() sees errno after free() and fflush()
-               and rewrites this as a retryable connection error. */
-            r->statuscode = check_fatal_io_errno() ? STATUSCODE_IO_FATAL
-                                                   : STATUSCODE_IO_ERROR;
-            strcpybuff(r->msg, "Write error on disk");
+            classify_write_error(r);
             nl = READ_ERROR;
           }
         }
@@ -2068,8 +2072,13 @@ LLint http_xfread1(htsblk * r, int bufl) {
       } else
         nl = READ_ERROR;
 
-      if ((nl < 0) && (r->out != NULL)) {
-        fflush(r->out);
+      /* The tail stdio still holds is written here, and glibc's later fclose()
+         returns 0 once this flush has taken the error: a body with no length
+         and no chunking would otherwise be recorded as mirrored. */
+      if ((nl < 0) && (r->out != NULL) && fflush(r->out) != 0 &&
+          !statuscode_is_write_error(r->statuscode)) {
+        classify_write_error(r);
+        nl = READ_ERROR;
       }
 
     }                           // stockage disque ou mémoire
@@ -2125,7 +2134,7 @@ LLint http_xfread1(htsblk * r, int bufl) {
   }
   /* Ahead of the EOF test below: r->size is advanced above the fwrite that
      failed, so a body completed by that very read would report a clean EOF. */
-  if (nl == READ_ERROR && STATUSCODE_IS_WRITE_ERROR(r->statuscode)) {
+  if (nl == READ_ERROR && statuscode_is_write_error(r->statuscode)) {
     return READ_ERROR;
   }
   // EOF

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -2057,7 +2057,7 @@ LLint http_xfread1(htsblk * r, int bufl) {
             /* Classify here: back_wait() sees errno after free() and fflush()
                and rewrites this as a retryable connection error. */
             r->statuscode = check_fatal_io_errno() ? STATUSCODE_IO_FATAL
-                                                   : STATUSCODE_INVALID;
+                                                   : STATUSCODE_IO_ERROR;
             strcpybuff(r->msg, "Write error on disk");
             nl = READ_ERROR;
           }
@@ -2125,7 +2125,7 @@ LLint http_xfread1(htsblk * r, int bufl) {
   }
   /* Ahead of the EOF test below: r->size is advanced above the fwrite that
      failed, so a body completed by that very read would report a clean EOF. */
-  if (nl == READ_ERROR && r->statuscode == STATUSCODE_IO_FATAL) {
+  if (nl == READ_ERROR && STATUSCODE_IS_WRITE_ERROR(r->statuscode)) {
     return READ_ERROR;
   }
   // EOF

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -2072,9 +2072,8 @@ LLint http_xfread1(htsblk * r, int bufl) {
       } else
         nl = READ_ERROR;
 
-      /* The tail stdio still holds is written here, and glibc's later fclose()
-         returns 0 once this flush has taken the error: a body with no length
-         and no chunking would otherwise be recorded as mirrored. */
+      /* The tail stdio held is written here, and glibc's later fclose() returns
+         0 once this flush has taken the error. */
       if ((nl < 0) && (r->out != NULL) && fflush(r->out) != 0 &&
           !statuscode_is_write_error(r->statuscode)) {
         classify_write_error(r);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -7035,6 +7035,62 @@ static int st_contentcodings(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* The errno contract the disk-full classification rests on: a decode that
+   cannot write leaves the write's errno, a body the decoder refuses leaves 0
+   (#1398). Both are poisoned first, so a caller that never sets errno fails. */
+static int st_codecerrno(httrackp *opt, int argc, char **argv) {
+  static const unsigned char body[] = "codec errno contract, round-tripped";
+  const size_t len = sizeof(body) - 1;
+  char inpath[HTS_URLMAXSIZE], outpath[HTS_URLMAXSIZE];
+  FILE *fp;
+
+  (void) opt;
+  if (argc < 2) {
+    fprintf(stderr, "usage: -#test=codecerrno <dir> <doomed-out>\n");
+    return 1;
+  }
+  snprintf(inpath, sizeof(inpath), "%s/ce-in.z", argv[0]);
+  snprintf(outpath, sizeof(outpath), "%s/ce-out", argv[0]);
+  assertf(ae_write_packed(inpath, 16 + MAX_WBITS, body, len) == 0);
+  errno = ENOSPC;
+  assertf(hts_zunpack(inpath, outpath) == (int) len);
+  errno = 0;
+  assertf(hts_zunpack(inpath, argv[1]) == -1);
+  assertf(errno == ENOSPC);
+  errno = 0;
+  assertf(hts_codec_unpack(HTS_CODEC_DEFLATE, inpath, argv[1]) == -1);
+  assertf(errno == ENOSPC);
+  errno = ENOSPC;
+  assertf(hts_codec_unpack(HTS_CODEC_UNSUPPORTED, inpath, outpath) == -1);
+  assertf(errno == 0);
+  /* Past the gzip magic, so the header still parses and the identity fallback
+     stays out of it: the stream itself is what fails. */
+  fp = FOPEN(inpath, "r+b");
+  assertf(fp != NULL);
+  assertf(fseek(fp, 12, SEEK_SET) == 0);
+  assertf(hts_fwrite_exact("\xff\xff\xff\xff\xff\xff\xff\xff", 8, fp));
+  assertf(fclose(fp) == 0);
+  errno = ENOSPC;
+  assertf(hts_zunpack(inpath, outpath) == -1);
+  assertf(errno == 0);
+  errno = ENOSPC;
+  assertf(hts_codec_unpack(HTS_CODEC_DEFLATE, inpath, outpath) == -1);
+  assertf(errno == 0);
+#if HTS_USEBROTLI
+  /* and a backend of its own, where the write goes through codec_sink() */
+  assertf(ae_write_raw(inpath, cc_br_text, sizeof(cc_br_text)) == 0);
+  errno = 0;
+  assertf(hts_codec_unpack(HTS_CODEC_BROTLI, inpath, argv[1]) == -1);
+  assertf(errno == ENOSPC);
+  assertf(ae_write_raw(inpath, cc_br_text, sizeof(cc_br_text) - 4) == 0);
+  errno = ENOSPC;
+  assertf(hts_codec_unpack(HTS_CODEC_BROTLI, inpath, outpath) == -1);
+  assertf(errno == 0);
+#endif
+  printf("codecerrno: write failure kept, refused stream cleared\n");
+  return 0;
+}
+
 /* Each call parses `txt` under a fresh host, then checkrobots() for `path`. */
 static int rb_decide(robots_wizard *r, const char *txt, const char *path) {
   static int n = 0;
@@ -12447,6 +12503,10 @@ static const struct selftest_entry {
      st_structcheck},
     {"filesave", "<doomed-save> <control-save>",
      "filesave() reports a failing close, errno intact", st_filesave},
+    {"codecerrno", "<dir> <doomed-out>",
+     "hts_codec_unpack() errno: kept on a failed write, cleared on a bad "
+     "stream",
+     st_codecerrno},
     {"topindex", "[dir]",
      "hts_buildtopindex charset handling of a non-ASCII project dir",
      st_topindex},

--- a/src/htszlib.c
+++ b/src/htszlib.c
@@ -50,6 +50,8 @@ Please visit our Website: http://www.httrack.com
 /* Note: utf-8 */
 int hts_zunpack(const char *filename, const char *newfile) {
   int ret = -1;
+  /* a local failure's errno, 0 when the coded body was the problem */
+  int io_errno = 0;
 
   if (filename != NULL && newfile != NULL && filename[0] && newfile[0]) {
     char catbuff[CATBUFF_SIZE];
@@ -82,6 +84,7 @@ int hts_zunpack(const char *filename, const char *newfile) {
         if (attempt > 0) {
           /* rewind input; reopening fpout "wb" discards the partial output */
           if (fseek(in, 0, SEEK_SET) != 0) {
+            io_errno = errno;
             env_error = HTS_TRUE;
             break;
           }
@@ -89,6 +92,7 @@ int hts_zunpack(const char *filename, const char *newfile) {
         }
         fpout = FOPEN(fconv(catbuff, sizeof(catbuff), newfile), "wb");
         if (fpout == NULL) {
+          io_errno = errno;
           env_error = HTS_TRUE;
           break;
         }
@@ -131,6 +135,7 @@ int hts_zunpack(const char *filename, const char *newfile) {
                 break;
               }
               if (produced > 0 && !hts_fwrite_exact(outbuf, produced, fpout)) {
+                io_errno = errno;
                 env_error = HTS_TRUE;
                 ok = HTS_FALSE;
                 break;
@@ -144,7 +149,12 @@ int hts_zunpack(const char *filename, const char *newfile) {
             ret = (int) size;
         }
         inflateEnd(&strm);
-        fclose(fpout);
+        /* stdio may still hold the tail, so the close is a write of its own */
+        if (fclose(fpout) != 0) {
+          io_errno = errno;
+          env_error = HTS_TRUE;
+          ret = -1;
+        }
       }
       /* keep a mislabeled identity body verbatim only when provably not
          deflate; truncation or a local failure must keep failing (#47) */
@@ -158,6 +168,7 @@ int hts_zunpack(const char *filename, const char *newfile) {
 
           while ((navail = fread(inbuf, 1, sizeof(inbuf), in)) > 0) {
             if (!hts_fwrite_exact(inbuf, navail, fpout)) {
+              io_errno = errno;
               size = -1;
               break;
             }
@@ -166,12 +177,16 @@ int hts_zunpack(const char *filename, const char *newfile) {
           if (size >= 0 && !ferror(in))
             ret = size;
         }
-        if (fpout != NULL)
-          fclose(fpout);
+        if (fpout != NULL && fclose(fpout) != 0) {
+          io_errno = errno;
+          ret = -1;
+        }
       }
       fclose(in);
     }
   }
+  if (ret < 0)
+    errno = io_errno; /* the cleanup above clobbered it */
   return ret;
 }
 

--- a/src/htszlib.h
+++ b/src/htszlib.h
@@ -47,6 +47,8 @@ Please visit our Website: http://www.httrack.com
 /* Inflate filename into newfile (gzip, zlib or raw deflate); decoded size, or
    -1 on a corrupt/truncated stream, an over-budget body, or an I/O failure. A
    body provably in no deflate framing is copied verbatim. */
+/* Decode filename into newfile, returning the decoded size or -1. Same errno
+   contract as hts_codec_unpack(). */
 extern int hts_zunpack(const char *filename, const char *newfile);
 /* Inflate the head of a gzip/zlib stream, out_len max; 0 if undecodable */
 extern size_t hts_zhead(const void *in, size_t in_len, void *out,

--- a/src/htszlib.h
+++ b/src/htszlib.h
@@ -46,9 +46,8 @@ Please visit our Website: http://www.httrack.com
 #ifdef HTS_INTERNAL_BYTECODE
 /* Inflate filename into newfile (gzip, zlib or raw deflate); decoded size, or
    -1 on a corrupt/truncated stream, an over-budget body, or an I/O failure. A
-   body provably in no deflate framing is copied verbatim. */
-/* Decode filename into newfile, returning the decoded size or -1. Same errno
-   contract as hts_codec_unpack(). */
+   body provably in no deflate framing is copied verbatim. On -1, errno is the
+   local failure's, and 0 when the coded body was the problem. */
 extern int hts_zunpack(const char *filename, const char *newfile);
 /* Inflate the head of a gzip/zlib stream, out_len max; 0 if undecodable */
 extern size_t hts_zhead(const void *in, size_t in_len, void *out,

--- a/tests/350_local-diskfull-abort.test
+++ b/tests/350_local-diskfull-abort.test
@@ -112,6 +112,17 @@ grep -q 'disk full or filesystem problems' <<<"$log" ||
     fail "a chunk completed by the read whose write failed passed for clean: ${log}"
 ok "the chunked path is fatal too"
 
+# --- no Content-Length and no chunking: the closing flush is the only writer --
+# totalsize stays -1, so no completion test can see this one, and glibc's later
+# fclose() returns 0 once the flush has taken the error.
+crawl_onto_full noclen noclen.bin noclenindex.html
+grep -q 'disk full or filesystem problems' <<<"$log" ||
+    fail "a full disk under a close-delimited body was not reported: ${log}"
+if grep -qF 'noclen.bin' "${tmpdir}/noclen/hts-cache/new.txt"; then
+    fail "a body that never reached the disk was recorded as mirrored"
+fi
+ok "a close-delimited body the disk refused is fatal too"
+
 # --- and it is not re-reported as a truncated download -----------------------
 # --tolerant downgrades a length mismatch to a warning instead of rewriting the
 # status, which is where a disk-cut body would be blamed on the server instead.
@@ -167,7 +178,8 @@ ok "a coded page that cannot be written is fatal too"
 
 # --- a write error outside the fatal class must stay retryable ---------------
 # A pipe whose reader has gone gives EPIPE, which is about this file, not the
-# filesystem: the mirror must finish the rest rather than give up.
+# filesystem: the mirror must finish the rest rather than give up. The write
+# fails mid-body here; 355 pins the read that both completes a body and fails.
 epipe="${tmpdir}/epipe"
 epipesite="${epipe}/127.0.0.1_${SRV_PORT}/diskfull"
 mkdir -p "$epipesite"
@@ -184,7 +196,8 @@ grep -q 'Unable to write file .*big\.bin' <<<"$log" ||
     fail "the broken pipe went unreported, so nothing here failed to be written: ${log}"
 grep -q 'Write error on disk' <<<"$log" ||
     fail "the broken pipe was not reported as a write error: ${log}"
-# What master reports instead: a body our own write cut short, blamed on the server.
+# r.size counts bytes read, so a body our own write cut short must never be
+# reported as one the server truncated.
 if grep -q 'Incorrect length' <<<"$log"; then
     fail "a write error was reported as a truncated download: ${log}"
 fi

--- a/tests/350_local-diskfull-abort.test
+++ b/tests/350_local-diskfull-abort.test
@@ -4,7 +4,8 @@
 # engine retries and then purges against. /dev/full stands in, under the save
 # name each crawl is about to write: once for a body that reaches the disk as
 # it streams, once for a page and once for a file small enough that stdio holds
-# them until the close.
+# them until the close. A coded body never reaches its save name as it streams,
+# so its arm dooms the ~hts-tmp spool it lands in instead.
 
 set -euo pipefail
 
@@ -43,7 +44,7 @@ crawl_onto_full() {
     local site="${dir}/127.0.0.1_${SRV_PORT}/diskfull"
 
     shift 3
-    mkdir -p "$site"
+    mkdir -p "$(dirname "${site}/${doomed}")" # a spool name has a directory of its own
     ln -s /dev/full "${site}/${doomed}"
     local_crawl --log "${tmpdir}/log-${name}" "${common[@]}" "$@" -O "$dir" \
         "${BASEURL}/diskfull/${entry}"
@@ -122,6 +123,22 @@ if grep -q 'Incorrect length' <<<"$log"; then
 fi
 ok "a length mismatch the full disk caused is not reported as one"
 
+# --- a coded body: the disk runs out under the spool, not the save name ------
+# gz.bin streams into ~hts-tmp/gz.bin.z and is decoded into place afterwards,
+# so nothing the crawl writes to the save name can stand in for a full disk.
+crawl_onto_full gzspool '~hts-tmp/gz.bin.z' gzindex.html
+grep -q 'disk full or filesystem problems' <<<"$log" ||
+    fail "a full disk under the compressed spool was not reported: ${log}"
+ok "a full disk under a coded body's spool is fatal too"
+
+# The decoded page, written the same way an uncoded one is.
+crawl_onto_full gzpage gzpage.html gzindex.html
+grep -q 'Unable to write HTML file' <<<"$log" ||
+    fail "a coded page the disk refused was saved as a success: ${log}"
+grep -q 'Fatal write error, giving up' <<<"$log" ||
+    fail "the full disk did not stop the mirror on the coded page path: ${log}"
+ok "a coded page that cannot be written is fatal too"
+
 # --- a write error outside the fatal class must stay retryable ---------------
 # A pipe whose reader has gone gives EPIPE, which is about this file, not the
 # filesystem: the mirror must finish the rest rather than give up.
@@ -137,6 +154,15 @@ local_crawl --log "${tmpdir}/log-epipe" "${common[@]}" --retries=0 -O "$epipe" \
     "${BASEURL}/diskfull/index.html" || true
 kill "$reader" 2>/dev/null || true
 log=$(<"${epipe}/hts-log.txt")
+grep -q 'Unable to write file .*big\.bin' <<<"$log" ||
+    fail "the broken pipe went unreported, so nothing here failed to be written: ${log}"
+grep -q 'Write error on disk' <<<"$log" ||
+    fail "the broken pipe was not reported as a write error: ${log}"
+# What master reports instead: a body our own write cut short, blamed on the server.
+if grep -q 'Incorrect length' <<<"$log"; then
+    fail "a write error was reported as a truncated download: ${log}"
+fi
+ok "a write error outside the fatal class is still reported against its file"
 if grep -q 'disk full or filesystem problems' <<<"$log"; then
     fail "a broken pipe was treated as a full disk: ${log}"
 fi

--- a/tests/350_local-diskfull-abort.test
+++ b/tests/350_local-diskfull-abort.test
@@ -124,12 +124,38 @@ fi
 ok "a length mismatch the full disk caused is not reported as one"
 
 # --- a coded body: the disk runs out under the spool, not the save name ------
+# First the contract the two arms below rest on: the decoder hands its caller
+# the write's errno, and clears it for a stream it refused.
+ln -s /dev/full "${tmpdir}/doomed-decode"
+assert_selftest "codecerrno: write failure kept, refused stream cleared" \
+    codecerrno "$tmpdir" "${tmpdir}/doomed-decode"
+
 # gz.bin streams into ~hts-tmp/gz.bin.z and is decoded into place afterwards,
 # so nothing the crawl writes to the save name can stand in for a full disk.
 crawl_onto_full gzspool '~hts-tmp/gz.bin.z' gzindex.html
 grep -q 'disk full or filesystem problems' <<<"$log" ||
     fail "a full disk under the compressed spool was not reported: ${log}"
 ok "a full disk under a coded body's spool is fatal too"
+
+# And the other end of the same body: the decode writes ~hts-tmp/gz.bin.u before
+# renaming it into place, and a full disk there is not the stream's fault.
+crawl_onto_full gzunpack '~hts-tmp/gz.bin.u' gzindex.html
+grep -q 'disk full or filesystem problems' <<<"$log" ||
+    fail "a full disk under the decode was reported as a corrupt body: ${log}"
+ok "a full disk under a coded body's decode is fatal too"
+
+# The control that arm needs: a body that really is corrupt, on a disk with room
+# to spare, must not be read as a full disk by a leftover errno.
+gzbad="${tmpdir}/gzbad"
+local_crawl --log "${tmpdir}/log-gzbad" "${common[@]}" -O "$gzbad" \
+    "${BASEURL}/diskfull/gzbadindex.html"
+log=$(<"${gzbad}/hts-log.txt")
+grep -q 'Error when decompressing' <<<"$log" ||
+    fail "a corrupt coded body was not reported as one: ${log}"
+if grep -qE 'Mirror aborted|disk full' <<<"$log"; then
+    fail "a corrupt coded body gave up the whole mirror: ${log}"
+fi
+ok "a corrupt coded body is not read as a full disk"
 
 # The decoded page, written the same way an uncoded one is.
 crawl_onto_full gzpage gzpage.html gzindex.html

--- a/tests/355_local-write-error-not-eof.test
+++ b/tests/355_local-write-error-not-eof.test
@@ -96,17 +96,15 @@ assert_write_error "a body stdio held until the close" 'splitsmall.bin'
 ok "a body that only fails when its file is closed is reported too"
 
 # --- no Content-Length and no chunking: the closing flush is the only writer -
-# totalsize stays -1, so no completion test can see this one, and glibc's later
-# fclose() returns 0 once the flush has taken the error.
+# totalsize stays -1, so no completion test can stand in for it here.
 crawl_onto_dead_pipe noclen noclenindex.html noclen.bin
 assert_write_error "a body delimited by the close alone" 'noclen.bin'
 ok "a close-delimited body the disk refused is not a clean end either"
 
 # --- the decode's own output: our disk, not the coded body ------------------
-# gz.bin is decoded into ~hts-tmp/gz.bin.u before being renamed into place. A
-# directory in that name's way makes the decode fail on us, with an errno the
-# fatal class does not cover: the failure must be named as ours, and must leave
-# the mirror running.
+# gz.bin is decoded into ~hts-tmp/gz.bin.u before being renamed into place; a
+# directory in that name's way fails it on us, with an errno outside the fatal
+# class.
 decode="${tmpdir}/decode"
 decodesite="${decode}/127.0.0.1_${SRV_PORT}/diskfull"
 mkdir -p "${decodesite}/~hts-tmp/gz.bin.u"

--- a/tests/355_local-write-error-not-eof.test
+++ b/tests/355_local-write-error-not-eof.test
@@ -1,0 +1,110 @@
+#!/bin/bash
+#
+# A write error the fatal class does not cover -- a broken pipe rather than a
+# full disk -- must still be told apart from a body that ended cleanly. r.size
+# counts bytes read, so the read that both completes a body and fails to write
+# it used to report a clean EOF. A fifo nobody holds open stands in for the save
+# name each crawl is about to write.
+
+set -euo pipefail
+
+# shellcheck source=tests/crawllib.sh
+. "${0%"${0##*/}"}./crawllib.sh"
+
+require_httrack
+
+# The engine is a native binary and the shell is MSYS, so a fifo the shell makes
+# is not one to the crawl.
+skip_on_windows "a native binary cannot write through an MSYS fifo"
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_writeerr.XXXXXX")
+readers=()
+cleanup() {
+    test "${#readers[@]}" -eq 0 || kill "${readers[@]}" 2>/dev/null || true
+    rm -rf "$tmpdir"
+}
+cleanup_push cleanup
+
+mkfifo "${tmpdir}/probe" 2>/dev/null || skip "cannot create a fifo here"
+rm -f "${tmpdir}/probe"
+
+common=(--quiet --disable-security-limits --robots=0 -c1 --timeout=20)
+local_server_start --log "${tmpdir}/server.log"
+
+# Mirror $2 with $3 a fifo under the save name, closed by its reader as soon as
+# the engine opens it: every byte flushed there is then a broken pipe. Leaves
+# the log in $log, what the run recorded as mirrored in $cached, the tree in
+# $site.
+crawl_onto_dead_pipe() {
+    local name="$1" entry="$2" doomed="$3"
+    local dir="${tmpdir}/${name}"
+
+    site="${dir}/127.0.0.1_${SRV_PORT}/diskfull"
+    mkdir -p "$site"
+    mkfifo "${site}/${doomed}"
+    # Both ends block until the other arrives, so the reader cannot close ahead
+    # of the engine's own open and leave it waiting for a reader that never comes.
+    (: <"${site}/${doomed}") &
+    readers+=("$!")
+    # --retries=0: a retry would re-open the fifo and block on a reader that is gone.
+    local_crawl --log "${tmpdir}/log-${name}" "${common[@]}" --retries=0 \
+        -O "$dir" "${BASEURL}/diskfull/${entry}"
+    log=$(<"${dir}/hts-log.txt")
+    cached=$(<"${dir}/hts-cache/new.txt")
+}
+
+# What every arm owes: the file we could not write named, not counted as
+# mirrored, and the rest of the mirror still standing.
+assert_write_error() {
+    local what="$1" name="$2"
+
+    grep -q "Unable to write file .*${name}" <<<"$log" ||
+        fail "${what}: nothing said the file could not be written: ${log}"
+    grep -q 'Write error on disk' <<<"$log" ||
+        fail "${what}: the failure was not reported as a write error: ${log}"
+    # What master reports instead: a body our own write cut short, blamed on
+    # the server.
+    if grep -q 'Incorrect length' <<<"$log"; then
+        fail "${what}: a write error was reported as a truncated download: ${log}"
+    fi
+    if grep -qF "$name" <<<"$cached"; then
+        fail "${what}: a file that never reached the disk counts as mirrored: ${cached}"
+    fi
+    if grep -qE 'Mirror aborted|disk full' <<<"$log"; then
+        fail "${what}: a write error outside the fatal class gave up the mirror: ${log}"
+    fi
+}
+
+# --- the read that completes the body is the one whose write fails ----------
+# One byte, then the rest: the first block stays in stdio, so the flush that
+# fails is the one on the read bringing r.size up to the announced length.
+crawl_onto_dead_pipe split splitindex.html split.bin
+assert_write_error "a body completed by the failing read" 'split.bin'
+test -s "${site}/splitindex.html" ||
+    fail "the page mirrored before the write error was lost"
+ok "a body whose last read is the failing write is not a clean end"
+
+# Chunked, same shape: there the chunk end erased the error outright and the
+# engine read on into a body it could no longer store.
+crawl_onto_dead_pipe chunked splitchunkedindex.html splitchunked.bin
+assert_write_error "a chunk completed by the failing read" 'splitchunked.bin'
+ok "a chunk whose last read is the failing write is not a clean end either"
+
+# --- a body small enough that stdio holds it: only the close fails ----------
+crawl_onto_dead_pipe small splitsmallindex.html splitsmall.bin
+assert_write_error "a body stdio held until the close" 'splitsmall.bin'
+ok "a body that only fails when its file is closed is reported too"
+
+# --- the control: a write that works must not read as one that failed -------
+clean="${tmpdir}/clean"
+local_crawl --log "${tmpdir}/log-clean" "${common[@]}" --retries=0 -O "$clean" \
+    "${BASEURL}/diskfull/splitindex.html"
+log=$(<"${clean}/hts-log.txt")
+if grep -qE 'Write error on disk|Unable to write file' <<<"$log"; then
+    fail "a body that reached the disk was reported as a write error: ${log}"
+fi
+test "$(wc -c <"${clean}/127.0.0.1_${SRV_PORT}/diskfull/split.bin")" -eq 8000 ||
+    fail "the control mirror did not write the whole body"
+grep -qF 'split.bin' "${clean}/hts-cache/new.txt" ||
+    fail "the control mirror did not count the file it wrote"
+ok "a body that reaches the disk is not reported as a write error"

--- a/tests/355_local-write-error-not-eof.test
+++ b/tests/355_local-write-error-not-eof.test
@@ -40,7 +40,7 @@ crawl_onto_dead_pipe() {
     local dir="${tmpdir}/${name}"
 
     site="${dir}/127.0.0.1_${SRV_PORT}/diskfull"
-    mkdir -p "$site"
+    mkdir -p "$(dirname "${site}/${doomed}")" # a spool name has a directory of its own
     mkfifo "${site}/${doomed}"
     # Both ends block until the other arrives, so the reader cannot close ahead
     # of the engine's own open and leave it waiting for a reader that never comes.
@@ -62,8 +62,8 @@ assert_write_error() {
         fail "${what}: nothing said the file could not be written: ${log}"
     grep -q 'Write error on disk' <<<"$log" ||
         fail "${what}: the failure was not reported as a write error: ${log}"
-    # What master reports instead: a body our own write cut short, blamed on
-    # the server.
+    # r.size counts bytes read, so a body our own write cut short must never
+    # be reported as one the server truncated.
     if grep -q 'Incorrect length' <<<"$log"; then
         fail "${what}: a write error was reported as a truncated download: ${log}"
     fi
@@ -94,6 +94,58 @@ ok "a chunk whose last read is the failing write is not a clean end either"
 crawl_onto_dead_pipe small splitsmallindex.html splitsmall.bin
 assert_write_error "a body stdio held until the close" 'splitsmall.bin'
 ok "a body that only fails when its file is closed is reported too"
+
+# --- no Content-Length and no chunking: the closing flush is the only writer -
+# totalsize stays -1, so no completion test can see this one, and glibc's later
+# fclose() returns 0 once the flush has taken the error.
+crawl_onto_dead_pipe noclen noclenindex.html noclen.bin
+assert_write_error "a body delimited by the close alone" 'noclen.bin'
+ok "a close-delimited body the disk refused is not a clean end either"
+
+# --- the decode's own output: our disk, not the coded body ------------------
+# gz.bin is decoded into ~hts-tmp/gz.bin.u before being renamed into place. A
+# directory in that name's way makes the decode fail on us, with an errno the
+# fatal class does not cover: the failure must be named as ours, and must leave
+# the mirror running.
+decode="${tmpdir}/decode"
+decodesite="${decode}/127.0.0.1_${SRV_PORT}/diskfull"
+mkdir -p "${decodesite}/~hts-tmp/gz.bin.u"
+local_crawl --log "${tmpdir}/log-decode" "${common[@]}" --retries=0 \
+    -O "$decode" "${BASEURL}/diskfull/gzindex.html"
+log=$(<"${decode}/hts-log.txt")
+cached=$(<"${decode}/hts-cache/new.txt")
+grep -q 'Unable to write file .*gz\.bin' <<<"$log" ||
+    fail "a decode our own filesystem refused was blamed on the coded body: ${log}"
+if grep -qE 'Mirror aborted|disk full' <<<"$log"; then
+    fail "a non-fatal failure under the decode gave up the mirror: ${log}"
+fi
+gzrow=$(grep -F '/gz.bin' <<<"$cached" || true)
+grep -q "error (" <<<"$gzrow" ||
+    fail "a body that never reached the disk was not recorded as failed: ${gzrow}"
+test ! -e "${decodesite}/gz.bin" ||
+    fail "the coded bytes were committed as the file we could not decode"
+grep -q DISKFULL-GZPAGE "${decodesite}/gzpage.html" ||
+    fail "the rest of the mirror did not survive the failed decode"
+ok "a decode that cannot write its output names our own filesystem"
+
+# --- and the copy that failed decode preserved outlives the update purge -----
+# The re-fetch fails on our side, so the previous copy is all there is: dropping
+# it from new.lst would have the purge unlink the file we took care to keep.
+upd="${tmpdir}/update"
+updsite="${upd}/127.0.0.1_${SRV_PORT}/diskfull"
+local_crawl --log "${tmpdir}/log-update1" "${common[@]}" --retries=0 -O "$upd" \
+    "${BASEURL}/diskfull/gzindex.html"
+before=$(wc -c <"${updsite}/gz.bin")
+test "$before" -gt 0 || fail "the first pass did not mirror the coded body"
+mkdir -p "${updsite}/~hts-tmp/gz.bin.u"
+local_crawl --log "${tmpdir}/log-update2" "${common[@]}" --retries=0 --update \
+    -O "$upd" "${BASEURL}/diskfull/gzindex.html"
+log=$(<"${upd}/hts-log.txt")
+grep -q 'Unable to write file .*gz\.bin' <<<"$log" ||
+    fail "the update pass did not fail the decode it was set up to fail: ${log}"
+test "$(wc -c <"${updsite}/gz.bin" 2>/dev/null || echo 0)" -eq "$before" ||
+    fail "the purge deleted the copy the failed decode preserved: ${log}"
+ok "a failed decode keeps the previously mirrored copy through the purge"
 
 # --- the control: a write that works must not read as one that failed -------
 clean="${tmpdir}/clean"

--- a/tests/355_local-write-error-not-eof.test
+++ b/tests/355_local-write-error-not-eof.test
@@ -158,3 +158,18 @@ test "$(wc -c <"${clean}/127.0.0.1_${SRV_PORT}/diskfull/split.bin")" -eq 8000 ||
 grep -qF 'split.bin' "${clean}/hts-cache/new.txt" ||
     fail "the control mirror did not count the file it wrote"
 ok "a body that reaches the disk is not reported as a write error"
+
+# The control the one above cannot be: a Content-Length body returns before the
+# closing flush, so only a close-delimited one crosses the code the arms rely on.
+cleannoclen="${tmpdir}/clean-noclen"
+local_crawl --log "${tmpdir}/log-clean-noclen" "${common[@]}" --retries=0 \
+    -O "$cleannoclen" "${BASEURL}/diskfull/noclenindex.html"
+log=$(<"${cleannoclen}/hts-log.txt")
+if grep -qE 'Write error on disk|Unable to write file' <<<"$log"; then
+    fail "a close-delimited body that reached the disk was reported as a write error: ${log}"
+fi
+test "$(wc -c <"${cleannoclen}/127.0.0.1_${SRV_PORT}/diskfull/noclen.bin")" -eq 100 ||
+    fail "the control mirror did not write the whole close-delimited body"
+grep -qF 'noclen.bin' "${cleannoclen}/hts-cache/new.txt" ||
+    fail "the control mirror did not count the close-delimited file it wrote"
+ok "a close-delimited body that reaches the disk is not reported as a write error"

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -529,7 +529,8 @@ expected_skips="01_engine-footer-overflow.test
 241_local-single-file-gui.test
 288_testlib-holdport.test
 350_local-diskfull-abort.test
-352_engine-filesave-diskfull.test"
+352_engine-filesave-diskfull.test
+355_local-write-error-not-eof.test"
 # First, or the deadline reads as an unexplained shortfall in the gates below.
 [ "$deadline" -eq 0 ] || {
     echo "::error::suite did not finish within ${suite_deadline}s"

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1285,6 +1285,76 @@ class Handler(SimpleHTTPRequestHandler):
             except OSError:
                 pass
 
+    # A body delivered in two parts, the pause splitting it across two reads:
+    # a save nobody can take then fails on the read that ends the body, where
+    # r.size has already reached totalsize.
+    def route_diskfull_splitindex(self):
+        self.send_html('\t<a href="split.bin">split</a>\n')
+
+    def route_diskfull_splitsmallindex(self):
+        self.send_html('\t<a href="splitsmall.bin">splitsmall</a>\n')
+
+    def route_diskfull_splitchunkedindex(self):
+        self.send_html('\t<a href="splitchunked.bin">splitchunked</a>\n')
+
+    def route_diskfull_split(self):
+        self.send_split(8000)
+
+    # Same shape, small enough that stdio holds the whole body: nothing fails
+    # until the save is closed.
+    def route_diskfull_splitsmall(self):
+        self.send_split(100)
+
+    # Same, chunked: the failing write lands on the read completing a chunk,
+    # where r.size reaching the chunk end is what erases the error.
+    def route_diskfull_splitchunked(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Transfer-Encoding", "chunked")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        if self.command == "HEAD":
+            return
+        self.wfile.write(b"1\r\nS\r\n")
+        self.wfile.flush()
+        time.sleep(1)
+        body = b"S" * 7999
+        self.wfile.write(b"%X\r\n" % len(body) + body + b"\r\n")
+        self.wfile.write(b"0\r\n\r\n")
+        self.wfile.flush()
+        self.close_connection = True
+
+    def send_split(self, total):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(total))
+        self.end_headers()
+        if self.command == "HEAD":
+            return
+        self.wfile.write(b"S")  # opens the save file; stdio holds this byte
+        self.wfile.flush()
+        time.sleep(1)
+        self.wfile.write(b"S" * (total - 1))  # the read that completes the body
+        self.wfile.flush()
+
+    # A gzip-coded asset never reaches the save name as it streams: it spools
+    # through ~hts-tmp/<name>.z and is decoded into place afterwards.
+    GZ_BODY = b"DISKFULL-GZ\n" + b"\x00\x01\x02\xff" * 16384
+
+    def route_diskfull_gzindex(self):
+        self.send_html(
+            '\t<a href="gz.bin">gz</a>\n\t<a href="gzpage.html">gzpage</a>\n'
+        )
+
+    def route_diskfull_gz(self):
+        self.send_coded(gzip.compress(self.GZ_BODY), "application/octet-stream")
+
+    def route_diskfull_gzpage(self):
+        self.send_coded(
+            gzip.compress(b"<html><body><p>DISKFULL-GZPAGE</p></body></html>"),
+            "text/html",
+        )
+
     # --- a hub page that fails on the update, taking its children with it --
     # The children are only reachable through hub.html: if the engine drops
     # them from new.lst because the hub was never parsed, the purge unlinks
@@ -2967,6 +3037,15 @@ class Handler(SimpleHTTPRequestHandler):
         "/diskfull/chunked.bin": route_diskfull_chunked,
         "/diskfull/stallindex.html": route_diskfull_stallindex,
         "/diskfull/stall.bin": route_diskfull_stall,
+        "/diskfull/splitindex.html": route_diskfull_splitindex,
+        "/diskfull/split.bin": route_diskfull_split,
+        "/diskfull/splitsmallindex.html": route_diskfull_splitsmallindex,
+        "/diskfull/splitsmall.bin": route_diskfull_splitsmall,
+        "/diskfull/splitchunkedindex.html": route_diskfull_splitchunkedindex,
+        "/diskfull/splitchunked.bin": route_diskfull_splitchunked,
+        "/diskfull/gzindex.html": route_diskfull_gzindex,
+        "/diskfull/gz.bin": route_diskfull_gz,
+        "/diskfull/gzpage.html": route_diskfull_gzpage,
         "/hubfail/index.html": route_hubfail_index,
         "/hubfail/hub.html": route_hubfail_hub,
         "/hubfail/child1.html": route_hubfail_child,

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1346,8 +1346,16 @@ class Handler(SimpleHTTPRequestHandler):
             '\t<a href="gz.bin">gz</a>\n\t<a href="gzpage.html">gzpage</a>\n'
         )
 
+    def route_diskfull_gzbadindex(self):
+        self.send_html('\t<a href="gzbad.bin">gzbad</a>\n')
+
     def route_diskfull_gz(self):
         self.send_coded(gzip.compress(self.GZ_BODY), "application/octet-stream")
+
+    # A gzip stream that cannot be decoded: the control for the spool arms, where
+    # a stale errno would read a corrupt body as a full disk.
+    def route_diskfull_gzbad(self):
+        self.send_coded(self.bad_gzip(self.GZ_BODY), "application/octet-stream")
 
     def route_diskfull_gzpage(self):
         self.send_coded(
@@ -3044,7 +3052,9 @@ class Handler(SimpleHTTPRequestHandler):
         "/diskfull/splitchunkedindex.html": route_diskfull_splitchunkedindex,
         "/diskfull/splitchunked.bin": route_diskfull_splitchunked,
         "/diskfull/gzindex.html": route_diskfull_gzindex,
+        "/diskfull/gzbadindex.html": route_diskfull_gzbadindex,
         "/diskfull/gz.bin": route_diskfull_gz,
+        "/diskfull/gzbad.bin": route_diskfull_gzbad,
         "/diskfull/gzpage.html": route_diskfull_gzpage,
         "/hubfail/index.html": route_hubfail_index,
         "/hubfail/hub.html": route_hubfail_hub,

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1337,6 +1337,20 @@ class Handler(SimpleHTTPRequestHandler):
         self.wfile.write(b"S" * (total - 1))  # the read that completes the body
         self.wfile.flush()
 
+    # No Content-Length and no chunking: the body ends with the connection, so
+    # totalsize stays -1 and the tail leaves stdio only at the closing flush.
+    def route_diskfull_noclenindex(self):
+        self.send_html('\t<a href="noclen.bin">noclen</a>\n')
+
+    def route_diskfull_noclen(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(b"DISKFULL-NOCLEN\n" + b"N" * 84)
+        self.close_connection = True
+
     # A gzip-coded asset never reaches the save name as it streams: it spools
     # through ~hts-tmp/<name>.z and is decoded into place afterwards.
     GZ_BODY = b"DISKFULL-GZ\n" + b"\x00\x01\x02\xff" * 16384
@@ -3051,6 +3065,8 @@ class Handler(SimpleHTTPRequestHandler):
         "/diskfull/splitsmall.bin": route_diskfull_splitsmall,
         "/diskfull/splitchunkedindex.html": route_diskfull_splitchunkedindex,
         "/diskfull/splitchunked.bin": route_diskfull_splitchunked,
+        "/diskfull/noclenindex.html": route_diskfull_noclenindex,
+        "/diskfull/noclen.bin": route_diskfull_noclen,
         "/diskfull/gzindex.html": route_diskfull_gzindex,
         "/diskfull/gzbadindex.html": route_diskfull_gzbadindex,
         "/diskfull/gz.bin": route_diskfull_gz,


### PR DESCRIPTION
`http_xfread1()` advances `r->size` before the `fwrite`, so a body the failing write happened to complete still satisfied the size test at the bottom and came back as a clean EOF. #1391 stopped that for the fatal class alone; the non-fatal class now has a code of its own, `STATUSCODE_IO_ERROR`, and the four size-based sites in `back_wait()` test for either. The same function also discarded `fflush()`'s return, and glibc's later `fclose()` reports nothing once that flush has taken the error, so a body with no Content-Length and no chunking (the one shape with no completion test to fall back on) was recorded as mirrored with nothing on disk, the fatal class included. The decode step is the third door onto the same bug: `hts_codec_unpack()` and `hts_zunpack()` now leave a local failure's errno behind and clear it for a body the decoder refused, which is what `back_finalize()` needs to stop blaming our own disk on the server.

Report rather than abort is the call for the non-fatal class, since a full disk means the next file fails too while a broken pipe is about one destination. 350 and 355 cover both classes with controls, and every guard was reverted in turn and reds.

Closes #1398