### PR TITLE
WebHTTrack keeps option fields it never sends, and mutes a blank User-Agent

### DIFF
--- a/html/server/step4.html
+++ b/html/server/step4.html
@@ -210,15 +210,15 @@ ${/* an empty -F mutes the header instead of defaulting, so a blank box sends no
 	${ztest:index2:--search-index=0:--search-index}
 \
 ${/* the extension is the rule key, so a MIME type with none is no rule */}
-	${test:ext1:--assume "}${arg:ext1}${test:ext1:=}${arg:mime1}${test:ext1:"}
-	${test:ext2:--assume "}${arg:ext2}${test:ext2:=}${arg:mime2}${test:ext2:"}
-	${test:ext3:--assume "}${arg:ext3}${test:ext3:=}${arg:mime3}${test:ext3:"}
-	${test:ext4:--assume "}${arg:ext4}${test:ext4:=}${arg:mime4}${test:ext4:"}
-	${test:ext5:--assume "}${arg:ext5}${test:ext5:=}${arg:mime5}${test:ext5:"}
-	${test:ext6:--assume "}${arg:ext6}${test:ext6:=}${arg:mime6}${test:ext6:"}
-	${test:ext7:--assume "}${arg:ext7}${test:ext7:=}${arg:mime7}${test:ext7:"}
-	${test:ext8:--assume "}${arg:ext8}${test:ext8:=}${arg:mime8}${test:ext8:"}
-	${test:prox:--proxy "}${do:if-not-empty:prox}${test:proxytype::socks5:connect}${test:proxytype:\3A//}${do:end-if}${do:output-mode:html}${arg:prox}${test:prox:\3A}${arg:portprox}${test:prox:"}
+	${test:ext1:--assume "}${arg:ext1}${test:ext1:=}${do:if-not-empty:ext1}${arg:mime1}${do:end-if}${do:output-mode:html}${test:ext1:"}
+	${test:ext2:--assume "}${arg:ext2}${test:ext2:=}${do:if-not-empty:ext2}${arg:mime2}${do:end-if}${do:output-mode:html}${test:ext2:"}
+	${test:ext3:--assume "}${arg:ext3}${test:ext3:=}${do:if-not-empty:ext3}${arg:mime3}${do:end-if}${do:output-mode:html}${test:ext3:"}
+	${test:ext4:--assume "}${arg:ext4}${test:ext4:=}${do:if-not-empty:ext4}${arg:mime4}${do:end-if}${do:output-mode:html}${test:ext4:"}
+	${test:ext5:--assume "}${arg:ext5}${test:ext5:=}${do:if-not-empty:ext5}${arg:mime5}${do:end-if}${do:output-mode:html}${test:ext5:"}
+	${test:ext6:--assume "}${arg:ext6}${test:ext6:=}${do:if-not-empty:ext6}${arg:mime6}${do:end-if}${do:output-mode:html}${test:ext6:"}
+	${test:ext7:--assume "}${arg:ext7}${test:ext7:=}${do:if-not-empty:ext7}${arg:mime7}${do:end-if}${do:output-mode:html}${test:ext7:"}
+	${test:ext8:--assume "}${arg:ext8}${test:ext8:=}${do:if-not-empty:ext8}${arg:mime8}${do:end-if}${do:output-mode:html}${test:ext8:"}
+	${test:prox:--proxy "}${do:if-not-empty:prox}${test:proxytype::socks5:connect}${test:proxytype:\3A//}${do:end-if}${do:output-mode:html}${arg:prox}${test:prox:\3A}${do:if-not-empty:prox}${arg:portprox}${do:end-if}${do:output-mode:html}${test:prox:"}
 	${test:ftpprox:--httpproxy-ftp=0:--httpproxy-ftp}
 </textarea>
 

--- a/html/server/step4.html
+++ b/html/server/step4.html
@@ -172,13 +172,15 @@ ${/* -m<n> resets the html limit, so the bare form must precede the -m,<n> one *
 	${test:maxconn:--connection-per-second=}${unquoted:maxconn}
 	${test:maxlinks:--advanced-maxlinks=}${unquoted:maxlinks}
 \
-	--user-agent "${arg:user}"
+${/* an empty -F mutes the header instead of defaulting, so a blank box sends nothing */}
+	${test:user:--user-agent "}${arg:user}${test:user:"}
 	--footer "${arg:footer}"
 \
 	${unquoted:url2}
 \
 	${ztest:cookies:--cookies=0:}
 	${ztest:parsejava:--parse-java=0:}
+	${test:checktype::--check-type=0:--check-type=1:--check-type=2}
 	${test:updhack:--updatehack}
 	${ztest:urlhack:--urlhack=0:--urlhack}
 	${test:keepwww:--keep-www-prefix}
@@ -206,6 +208,16 @@ ${/* -m<n> resets the html limit, so the bare form must precede the -m,<n> one *
 	${test:logtype:::--extra-log:--debug-log}
 	${ztest:index:--index=0:}
 	${ztest:index2:--search-index=0:--search-index}
+\
+${/* the extension is the rule key, so a MIME type with none is no rule */}
+	${test:ext1:--assume "}${arg:ext1}${test:ext1:=}${arg:mime1}${test:ext1:"}
+	${test:ext2:--assume "}${arg:ext2}${test:ext2:=}${arg:mime2}${test:ext2:"}
+	${test:ext3:--assume "}${arg:ext3}${test:ext3:=}${arg:mime3}${test:ext3:"}
+	${test:ext4:--assume "}${arg:ext4}${test:ext4:=}${arg:mime4}${test:ext4:"}
+	${test:ext5:--assume "}${arg:ext5}${test:ext5:=}${arg:mime5}${test:ext5:"}
+	${test:ext6:--assume "}${arg:ext6}${test:ext6:=}${arg:mime6}${test:ext6:"}
+	${test:ext7:--assume "}${arg:ext7}${test:ext7:=}${arg:mime7}${test:ext7:"}
+	${test:ext8:--assume "}${arg:ext8}${test:ext8:=}${arg:mime8}${test:ext8:"}
 	${test:prox:--proxy "}${do:if-not-empty:prox}${test:proxytype::socks5:connect}${test:proxytype:\3A//}${do:end-if}${do:output-mode:html}${arg:prox}${test:prox:\3A}${arg:portprox}${test:prox:"}
 	${test:ftpprox:--httpproxy-ftp=0:--httpproxy-ftp}
 </textarea>

--- a/tests/274_wizard-profile-load.test
+++ b/tests/274_wizard-profile-load.test
@@ -146,9 +146,8 @@ for key, value in [("Warc", "0"), ("Wacz", "1"), ("NoExternalPages", "0")]:
     if ini.get(key) != value:
         sys.exit("%s saved back as %r, wanted %r" % (key, ini.get(key), value))
 
-# A key in the file wins over the startup default even when it holds nothing,
-# and a checkbox the wizard defaults to on is only clearable that way (#1186).
-# The box is the observable, not a flag: an empty -F mutes the header (#1386).
+# A key in the file wins over the startup default even when it holds nothing
+# (#1186); the box is the observable, since an empty -F now emits nothing (#1386).
 box = field(s.get("option6.html?sid=" + sid), "user")
 if box != "":
     sys.exit("the emptied browser id came back as %r" % box)

--- a/tests/274_wizard-profile-load.test
+++ b/tests/274_wizard-profile-load.test
@@ -69,7 +69,7 @@ htsserver_python - "${HTS_URL}" "${work}" <<'PY' || fail "see above"
 import re
 import sys
 
-from webtestlib import Session, textarea
+from webtestlib import Session, field, textarea
 
 s, work = Session(sys.argv[1]), sys.argv[2]
 sid = s.sid
@@ -148,7 +148,13 @@ for key, value in [("Warc", "0"), ("Wacz", "1"), ("NoExternalPages", "0")]:
 
 # A key in the file wins over the startup default even when it holds nothing,
 # and a checkbox the wizard defaults to on is only clearable that way (#1186).
-want('--user-agent ""')
+# The box is the observable, not a flag: an empty -F mutes the header (#1386).
+box = field(s.get("option6.html?sid=" + sid), "user")
+if box != "":
+    sys.exit("the emptied browser id came back as %r" % box)
+sent = [f for f in flags if f.startswith("--user-agent")]
+if sent:
+    sys.exit("an emptied browser id still reached the engine: %r" % sent)
 reject("--keep-alive")
 if ini.get("UserID") != "" or ini.get("KeepAlive") != "0":
     sys.exit("the cleared fields came back as %r / %r"

--- a/tests/358_webhttrack-option-fields.test
+++ b/tests/358_webhttrack-option-fields.test
@@ -33,8 +33,13 @@ cport=$(discover_server_port "${clog}" "${csrv}") || fail "no content server"
 
 htsserver_start
 
+# The page that offers the pairs is the count's only source, so a ninth row
+# flows through here instead of desyncing three literals.
+pairs=$(grep -c '<input name="ext[0-9]*"' "${HTS_DISTDIR}/html/server/option11.html")
+test "${pairs}" -ge 8 || fail "option11.html offers only ${pairs} MIME pairs"
+
 out="${work}/crawl"
-htsserver_python - "${HTS_URL}" "${work}" "${cport}" <<'PY' || fail "the GUI built the wrong command line (see above)"
+htsserver_python - "${HTS_URL}" "${work}" "${cport}" "${pairs}" <<'PY' || fail "the GUI built the wrong command line (see above)"
 import html
 import re
 import sys
@@ -42,6 +47,7 @@ import sys
 from webtestlib import Session, textarea
 
 s, work, port = Session(sys.argv[1]), sys.argv[2], sys.argv[3]
+npairs = int(sys.argv[4])
 rc = 0
 
 
@@ -56,10 +62,10 @@ def cmdline():
     return textarea(s.get("step4.html"), "command")
 
 
-# The eight pairs the MIME page offers. The first is the one the crawl proves;
+# The pairs the MIME page offers. The first is the one the crawl proves;
 # the rest only have to reach the engine.
 PAIRS = [("foo", "text/html")] + [("x%d" % n, "application/x-t%d" % n)
-                                  for n in range(2, 9)]
+                                  for n in range(2, npairs + 1)]
 
 s.post("step2.html", [("path", work), ("projname", "crawl")])
 s.post("step3.html", [("urls", "http://127.0.0.1:%s/index.html" % port)])
@@ -79,12 +85,19 @@ cmd = cmdline()
 for n, (e, m) in enumerate(PAIRS, 1):
     check('--assume "%s=%s"' % (e, m) in cmd, "pair %d reaches the engine" % n)
 
-# A pair with no extension is no rule: the flag goes, the other seven stay.
-s.post("option11.html", [("ext3", "")])
+# An emptied extension has to take its MIME with it: left behind, the value is
+# a bare argv token and the engine reads whatever it spells as its own options.
+s.post("option11.html", [("ext3", ""), ("mime3", " --user-agent INJECTED")])
 cmd = cmdline()
-check("=%s" % PAIRS[2][1] not in cmd, "an emptied extension drops its --assume")
-check(len(re.findall("--assume ", cmd)) == 7, "the other seven --assume stay")
-s.post("option11.html", [("ext3", PAIRS[2][0])])
+check("INJECTED" not in cmd, "an emptied extension drops its MIME too")
+check(len(re.findall("--assume ", cmd)) == len(PAIRS) - 1,
+      "the other pairs stay")
+s.post("option11.html", [("ext3", PAIRS[2][0]), ("mime3", PAIRS[2][1])])
+
+# The proxy line carries the same shape: a port with no host to attach to.
+s.post("option10.html", [("prox", ""), ("portprox", " -O /tmp/relocated")])
+check("/tmp/relocated" not in cmdline(), "a port with no proxy host emits nothing")
+s.post("option10.html", [("portprox", "")])
 
 # The browser id. A blank box must leave the engine's own default alone, so no
 # option at all; a filled one still has to emit it, or the flag simply died.
@@ -96,8 +109,7 @@ check("--user-agent" not in cmdline(), "a blank browser id sends no --user-agent
 if rc:
     sys.exit(rc)
 # Start, the way the browser's button does: both textareas as rendered, with
-# the entities decoded the way the HTML parser hands them back. This also
-# writes the winprofile.ini the second half reloads.
+# the entities decoded the way the HTML parser hands them back.
 page = s.get("step4.html")
 s.post("step4.html", [("command", html.unescape(cmdline())),
                       ("winprofile", html.unescape(textarea(page, "winprofile"))),
@@ -122,7 +134,7 @@ grep -q -- "-%A foo=text/html" <<<"${argv}" ||
     fail "the first MIME pair never reached the engine: ${argv}"
 # One token per line, so grep -c counts the flags rather than the single line.
 assume_flags=$(tr ' ' '\n' <<<"${argv}" | grep -c -- '-%A' || true)
-assert_eq 8 "${assume_flags}" "-%A flags in the recorded argv"
+assert_eq "${pairs}" "${assume_flags}" "-%A flags in the recorded argv"
 ! grep -q -- "-F " <<<"${argv}" || fail "a blank browser id still sent -F: ${argv}"
 
 # The rule changed the crawl, not just the argv: without it data.foo stays a
@@ -134,13 +146,13 @@ assert_file "${mirror}/deep.html" "--assume did not make data.foo parseable"
 # A cold second server: reloading the saved project has to put the same flags
 # back, or the fields are still stored one way only.
 htsserver_start --home "${work}"
-htsserver_python - "${HTS_URL}" "${work}" <<'PY' || fail "the reloaded profile lost its flags (see above)"
+htsserver_python - "${HTS_URL}" "${work}" "${pairs}" <<'PY' || fail "the reloaded profile lost its flags (see above)"
 import re
 import sys
 
 from webtestlib import Session, field, textarea
 
-s, work = Session(sys.argv[1]), sys.argv[2]
+s, work, npairs = Session(sys.argv[1]), sys.argv[2], int(sys.argv[3])
 rc = 0
 
 
@@ -155,7 +167,8 @@ loaded = s.post("step2.html", [("path", work), ("loadprojname", "crawl")])
 check(field(loaded, "projname") == "crawl", "step2.html reloaded the project")
 cmd = textarea(s.get("step4.html"), "command")
 check("--check-type=2" in cmd, "--check-type survives the round trip")
-check(len(re.findall("--assume ", cmd)) == 8, "all 8 --assume survive the round trip")
+check(len(re.findall("--assume ", cmd)) == npairs,
+      "every --assume survives the round trip")
 check("--user-agent" not in cmd, "a reloaded blank browser id stays unsent")
 sys.exit(rc)
 PY

--- a/tests/358_webhttrack-option-fields.test
+++ b/tests/358_webhttrack-option-fields.test
@@ -1,0 +1,166 @@
+#!/bin/bash
+#
+# The type check and the eight MIME pairs were stored and restored by the GUI
+# and never put on the command line, and a cleared browser id emitted
+# --user-agent "", which mutes the header instead of leaving the engine's own.
+
+set -euo pipefail
+
+# shellcheck source=tests/webhttracklib.sh
+. "${0%"${0##*/}"}./webhttracklib.sh"
+
+htsserver_require
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_optfields.XXXXXX") || fail "no tmpdir"
+csrv=
+cleanup_push htsserver_cleanup_dir "${work}"
+cleanup_push htsserver_reap_vars csrv
+
+export HOME="${work}" # no ~/.httrack.ini of the developer's in the store
+
+# data.foo is served as a binary, so only --assume foo=text/html makes the
+# engine parse it and reach deep.html.
+site="${work}/docroot"
+mkdir -p "${site}"
+printf '<html><body><a href="data.foo">d</a></body></html>\n' >"${site}/index.html"
+printf '<html><body><a href="deep.html">deep</a></body></html>\n' >"${site}/data.foo"
+printf '<html><body>deep content</body></html>\n' >"${site}/deep.html"
+
+clog="${work}/content.log"
+"${HTS_PYTHON}" "${testdir}/local-server.py" --root "${site}" >"${clog}" 2>&1 &
+csrv=$!
+cport=$(discover_server_port "${clog}" "${csrv}") || fail "no content server"
+
+htsserver_start
+
+out="${work}/crawl"
+htsserver_python - "${HTS_URL}" "${work}" "${cport}" <<'PY' || fail "the GUI built the wrong command line (see above)"
+import html
+import re
+import sys
+
+from webtestlib import Session, textarea
+
+s, work, port = Session(sys.argv[1]), sys.argv[2], sys.argv[3]
+rc = 0
+
+
+def check(ok, what):
+    global rc
+    print(("ok: " if ok else "FAIL: ") + what)
+    if not ok:
+        rc = 1
+
+
+def cmdline():
+    return textarea(s.get("step4.html"), "command")
+
+
+# The eight pairs the MIME page offers. The first is the one the crawl proves;
+# the rest only have to reach the engine.
+PAIRS = [("foo", "text/html")] + [("x%d" % n, "application/x-t%d" % n)
+                                  for n in range(2, 9)]
+
+s.post("step2.html", [("path", work), ("projname", "crawl")])
+s.post("step3.html", [("urls", "http://127.0.0.1:%s/index.html" % port)])
+# robots id 1 is --robots=0: the fixture's robots.txt is not what is under test.
+s.post("option8.html", [("robots", "1")])
+s.post("option11.html", [kv for n, (e, m) in enumerate(PAIRS, 1)
+                         for kv in (("ext%d" % n, e), ("mime%d" % n, m))])
+
+# The type check: three list entries, three engine values, never off by one.
+for listid, want in (("1", "--check-type=0"), ("2", "--check-type=1"),
+                     ("3", "--check-type=2")):
+    s.post("option8.html", [("checktype", listid)])
+    got = re.findall(r"--check-type=\d", cmdline())
+    check(got == [want], "checktype %s emits %s (got %s)" % (listid, want, got))
+
+cmd = cmdline()
+for n, (e, m) in enumerate(PAIRS, 1):
+    check('--assume "%s=%s"' % (e, m) in cmd, "pair %d reaches the engine" % n)
+
+# A pair with no extension is no rule: the flag goes, the other seven stay.
+s.post("option11.html", [("ext3", "")])
+cmd = cmdline()
+check("=%s" % PAIRS[2][1] not in cmd, "an emptied extension drops its --assume")
+check(len(re.findall("--assume ", cmd)) == 7, "the other seven --assume stay")
+s.post("option11.html", [("ext3", PAIRS[2][0])])
+
+# The browser id. A blank box must leave the engine's own default alone, so no
+# option at all; a filled one still has to emit it, or the flag simply died.
+s.post("option6.html", [("user", "Probe/1.0")])
+check('--user-agent "Probe/1.0"' in cmdline(), "a filled browser id is sent")
+s.post("option6.html", [("user", "")])
+check("--user-agent" not in cmdline(), "a blank browser id sends no --user-agent")
+
+if rc:
+    sys.exit(rc)
+# Start, the way the browser's button does: both textareas as rendered, with
+# the entities decoded the way the HTML parser hands them back. This also
+# writes the winprofile.ini the second half reloads.
+page = s.get("step4.html")
+s.post("step4.html", [("command", html.unescape(cmdline())),
+                      ("winprofile", html.unescape(textarea(page, "winprofile"))),
+                      ("command_do", "start"), ("path", work),
+                      ("projname", "crawl")])
+PY
+
+log="${out}/hts-log.txt"
+start=${SECONDS}
+while ! grep -q "HTTrack Website Copier/" "${log}" 2>/dev/null; do
+    htsserver_alive || fail "htsserver died: $(tail -n 20 "${log}" 2>/dev/null)"
+    test "$((SECONDS - start))" -lt 120 || fail_dump "the crawl did not end" "${log}"
+    poll_wait 0.2
+done
+
+# doit.log is the invocation rebuilt from argv, so it is what the engine got.
+doit="${out}/hts-cache/doit.log"
+assert_file "${doit}" "the crawl recorded no invocation"
+argv=$(head -1 "${doit}")
+grep -q -- "-u2" <<<"${argv}" || fail "the type check never reached the engine: ${argv}"
+grep -q -- "-%A foo=text/html" <<<"${argv}" ||
+    fail "the first MIME pair never reached the engine: ${argv}"
+# One token per line, so grep -c counts the flags rather than the single line.
+assume_flags=$(tr ' ' '\n' <<<"${argv}" | grep -c -- '-%A' || true)
+assert_eq 8 "${assume_flags}" "-%A flags in the recorded argv"
+! grep -q -- "-F " <<<"${argv}" || fail "a blank browser id still sent -F: ${argv}"
+
+# The rule changed the crawl, not just the argv: without it data.foo stays a
+# binary the engine never opens, so deep.html is unreachable.
+mirror="${out}/127.0.0.1_${cport}"
+assert_file "${mirror}/data.html" "--assume did not retype data.foo"
+assert_file "${mirror}/deep.html" "--assume did not make data.foo parseable"
+
+# A cold second server: reloading the saved project has to put the same flags
+# back, or the fields are still stored one way only.
+htsserver_start --home "${work}"
+htsserver_python - "${HTS_URL}" "${work}" <<'PY' || fail "the reloaded profile lost its flags (see above)"
+import re
+import sys
+
+from webtestlib import Session, field, textarea
+
+s, work = Session(sys.argv[1]), sys.argv[2]
+rc = 0
+
+
+def check(ok, what):
+    global rc
+    print(("ok: " if ok else "FAIL: ") + what)
+    if not ok:
+        rc = 1
+
+
+loaded = s.post("step2.html", [("path", work), ("loadprojname", "crawl")])
+check(field(loaded, "projname") == "crawl", "step2.html reloaded the project")
+cmd = textarea(s.get("step4.html"), "command")
+check("--check-type=2" in cmd, "--check-type survives the round trip")
+check(len(re.findall("--assume ", cmd)) == 8, "all 8 --assume survive the round trip")
+check("--user-agent" not in cmd, "a reloaded blank browser id stays unsent")
+sys.exit(rc)
+PY
+
+htsserver_cleanup
+htsserver_assert_reaped
+
+echo "PASS"


### PR DESCRIPTION
The wizard's type-check list and its eight extension/MIME pairs were written to `winprofile.ini` and read back into the form, but `step4.html` never put them on the command line, so the crawl never saw them. The browser-id box had the opposite problem: cleared, it emitted `--user-agent ""`, and an empty `-F` switches the header off instead of falling back to the engine's own value. The command block now emits `--check-type=N`, one `--assume "ext=mime"` per filled pair, and nothing at all for a blank browser id. This is engine-side only: the keys already exist in the shared winprofile block, `hts_optalias` already carries `check-type` and `assume`, and `winprofile-keys.tsv` is untouched.

The second commit fixes a footgun the first one opened and a twin already on master. `${arg:mimeN}` sat outside the `${test:extN:}` guard, so emptying an extension while leaving its MIME type filled dropped a bare token onto the command line, which the engine reads as options of its own: a MIME field holding ` -O /some/path` silently relocates the whole mirror. `${arg:portprox}` has the same shape and predates this PR. Nine sites in all, now wrapped in `${do:if-not-empty:<guard>}` the way the proxy scheme already was. htsserver is a local UI and the person filling the form is the person whose crawl it is, so this is a way to lose work rather than a privilege boundary anyone crosses, but emptying one box and not its neighbour is an ordinary thing to do. Test 358 asserted the absence of `=<mime>` rather than of the value, so it went green on the injecting tree; it now asserts the value is gone and probes the shape directly.

`windebug` is the original bug mirrored, reaching the engine as `--debug-headers` and never saved, so it reverts on reload. That one needs a new key in the shared block and WinHTTrack's own spelling has to decide it, so I left it to the httrack-windows side. An extension beginning with a dash still kills the run before any log is written, which is #1179's narrow allowlist rather than anything here: filed as #1425. Test 274 asserted `--user-agent ""` as the observable for #1186, that a key present in the file beats the wizard's startup default; the property still holds and is now checked on the rendered box, which is what #1186 was about.

Verified against a running htsserver rather than by reading templates: the new test posts browser-shaped forms, starts a real crawl and reads `hts-cache/doit.log` for the argv the engine got. The `--assume` half also has to change the mirror, since `data.foo` is only retyped and parsed once the rule arrives.

Closes #1386
