### PR TITLE
The --wide- and --tiny- alias prefixes drop the connection count they exist to add

### DIFF
--- a/html/cmdguide.html
+++ b/html/cmdguide.html
@@ -226,7 +226,7 @@ below let you go faster when you own the target, and slower when you do not.</p>
 <table class="tblRegular tableWidth" border="0">
   <tr class="head"><td><b>Option</b></td><td><b>What it controls</b></td></tr>
   <tr><td><tt>--max-rate (-A)</tt></td><td>Maximum transfer rate in bytes/sec. <b>The default is about 100 KB/s even without this flag.</b> Raise it to go faster.</td></tr>
-  <tr><td><tt>--sockets (-c)</tt></td><td>Number of parallel connections (default 4). <tt>--tiny</tt>, <tt>--wide</tt> and <tt>--ultrawide</tt> are presets. The <tt>wide-</tt>/<tt>tiny-</tt> prefix carries one onto a plain alias, so <tt>--wide-mirror</tt> is <tt>--mirror</tt> at 32 connections; an alias that takes a value of its own refuses the prefix.</td></tr>
+  <tr><td><tt>--sockets (-c)</tt></td><td>Number of parallel connections (default 4). <tt>--tiny</tt>, <tt>--wide</tt> and <tt>--ultrawide</tt> are presets. The <tt>wide-</tt>/<tt>tiny-</tt> prefix carries one onto a plain alias, so <tt>--wide-mirror</tt> is <tt>--mirror</tt> at 32 connections; an alias that cannot take a clustered count runs without it and says so.</td></tr>
   <tr><td><tt>--connection-per-second (-%c)</tt></td><td>New connections opened per second (default 5).</td></tr>
   <tr><td><tt>--max-size (-M)</tt></td><td>Stop after N bytes <b>received from the network</b> across the whole mirror (this counts what was transferred, not what was saved).</td></tr>
   <tr><td><tt>--max-time (-E)</tt></td><td>Stop after N seconds of wall-clock time.</td></tr>

--- a/html/cmdguide.html
+++ b/html/cmdguide.html
@@ -226,7 +226,7 @@ below let you go faster when you own the target, and slower when you do not.</p>
 <table class="tblRegular tableWidth" border="0">
   <tr class="head"><td><b>Option</b></td><td><b>What it controls</b></td></tr>
   <tr><td><tt>--max-rate (-A)</tt></td><td>Maximum transfer rate in bytes/sec. <b>The default is about 100 KB/s even without this flag.</b> Raise it to go faster.</td></tr>
-  <tr><td><tt>--sockets (-c)</tt></td><td>Number of parallel connections (default 4). <tt>--tiny</tt>, <tt>--wide</tt> and <tt>--ultrawide</tt> are presets.</td></tr>
+  <tr><td><tt>--sockets (-c)</tt></td><td>Number of parallel connections (default 4). <tt>--tiny</tt>, <tt>--wide</tt> and <tt>--ultrawide</tt> are presets, and the <tt>wide-</tt>/<tt>tiny-</tt> prefix carries one onto another alias: <tt>--wide-mirror</tt> is <tt>--mirror</tt> at 32 connections.</td></tr>
   <tr><td><tt>--connection-per-second (-%c)</tt></td><td>New connections opened per second (default 5).</td></tr>
   <tr><td><tt>--max-size (-M)</tt></td><td>Stop after N bytes <b>received from the network</b> across the whole mirror (this counts what was transferred, not what was saved).</td></tr>
   <tr><td><tt>--max-time (-E)</tt></td><td>Stop after N seconds of wall-clock time.</td></tr>

--- a/html/cmdguide.html
+++ b/html/cmdguide.html
@@ -226,7 +226,7 @@ below let you go faster when you own the target, and slower when you do not.</p>
 <table class="tblRegular tableWidth" border="0">
   <tr class="head"><td><b>Option</b></td><td><b>What it controls</b></td></tr>
   <tr><td><tt>--max-rate (-A)</tt></td><td>Maximum transfer rate in bytes/sec. <b>The default is about 100 KB/s even without this flag.</b> Raise it to go faster.</td></tr>
-  <tr><td><tt>--sockets (-c)</tt></td><td>Number of parallel connections (default 4). <tt>--tiny</tt>, <tt>--wide</tt> and <tt>--ultrawide</tt> are presets, and the <tt>wide-</tt>/<tt>tiny-</tt> prefix carries one onto another alias: <tt>--wide-mirror</tt> is <tt>--mirror</tt> at 32 connections.</td></tr>
+  <tr><td><tt>--sockets (-c)</tt></td><td>Number of parallel connections (default 4). <tt>--tiny</tt>, <tt>--wide</tt> and <tt>--ultrawide</tt> are presets. The <tt>wide-</tt>/<tt>tiny-</tt> prefix carries one onto a plain alias, so <tt>--wide-mirror</tt> is <tt>--mirror</tt> at 32 connections; an alias that takes a value of its own refuses the prefix.</td></tr>
   <tr><td><tt>--connection-per-second (-%c)</tt></td><td>New connections opened per second (default 5).</td></tr>
   <tr><td><tt>--max-size (-M)</tt></td><td>Stop after N bytes <b>received from the network</b> across the whole mirror (this counts what was transferred, not what was saved).</td></tr>
   <tr><td><tt>--max-time (-E)</tt></td><td>Stop after N seconds of wall-clock time.</td></tr>

--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -51,6 +51,7 @@ Please visit our Website: http://www.httrack.com
   --sockets 8       --cache off
                     --nocache
   -c8               -C0
+  --wide-mirror     --tiny-mirror     (--mirror at --wide/--tiny's count)
   in config file:
   sockets=8         cache=0
   set sockets 8     cache off
@@ -332,6 +333,28 @@ static hts_boolean optparam_missing(int argc, const char *const *argv,
   return HTS_TRUE;
 }
 
+/* The short form the --wide-/--tiny- prefix glues onto the alias it prefixes,
+   read from the --wide/--tiny row itself so the two cannot drift ("c32"). */
+static const char *optalias_prefix_count(const char *name) {
+  const int pos = optalias_find(name);
+
+  return pos >= 0 && hts_optalias[pos][1][0] == '-' ? hts_optalias[pos][1] + 1
+                                                    : "";
+}
+
+/* Whether the alias emits one short-option cluster a count can be glued onto
+   (-w -> -wc32). A class keeping its value in a word of its own (-O <path>,
+   +*.gif) and a long form (--clean) have nowhere to put it. */
+static hts_boolean optalias_clusters(const char *type, const char *command) {
+  const hts_boolean glued =
+      strcmp(type, "single") == 0 || strcmp(type, "onoff") == 0 ||
+      strcmp(type, "level") == 0 || strcmp(type, "param") == 0;
+
+  return glued && command[0] == '-' && command[1] != '-' && command[1] != '\0'
+             ? HTS_TRUE
+             : HTS_FALSE;
+}
+
 /* Suffix the short form takes for a value ("0", "2", or none), or NULL when
    the class refuses it: onoff reads 0/1 only, level reads a number. */
 static const char *optalias_suffix(const char *type, const char *value) {
@@ -382,6 +405,7 @@ int optalias_check(int argc, const char *const *argv, int n_arg,
 
       /* */
       char *position;
+      const char *addname = NULL;
       int need_param = 1;
       hts_boolean negated = HTS_FALSE;
 
@@ -406,12 +430,15 @@ int optalias_check(int argc, const char *const *argv, int n_arg,
       }
       /* --sockets 8 */
       else {
-        if (strncmp(argv[n_arg] + 2, "wide-", 5) == 0) {
-          strcpybuff(addcommand, "c32");
-          strcpybuff(command, strchr(argv[n_arg] + 2, '-') + 1);
-        } else if (strncmp(argv[n_arg] + 2, "tiny-", 5) == 0) {
-          strcpybuff(addcommand, "c1");
-          strcpybuff(command, strchr(argv[n_arg] + 2, '-') + 1);
+        /* --wide-mirror is --mirror carrying --wide's connection count */
+        if (strncmp(argv[n_arg] + 2, "wide-", 5) == 0)
+          addname = "wide";
+        else if (strncmp(argv[n_arg] + 2, "tiny-", 5) == 0)
+          addname = "tiny";
+        if (addname != NULL) {
+          strlcpybuff(addcommand, optalias_prefix_count(addname),
+                      sizeof(addcommand));
+          strcpybuff(command, argv[n_arg] + 7);
         } else
           strcpybuff(command, argv[n_arg] + 2);
         need_param = 2;
@@ -422,6 +449,16 @@ int optalias_check(int argc, const char *const *argv, int n_arg,
       if (pos >= 0) {
         /* Copy real name */
         strcpybuff(command, hts_optalias[pos][1]);
+        /* Refuse a prefix the expansion cannot carry, rather than drop it */
+        if (addcommand[0] != '\0' &&
+            !optalias_clusters(hts_optalias[pos][2], command)) {
+          slprintfbuff_clip(return_error, return_error_size,
+                            "Syntax error:\n\tThe %s- prefix does not apply to "
+                            "--%s: write --%s --%s instead\n",
+                            addname, hts_optalias[pos][0], addname,
+                            hts_optalias[pos][0]);
+          return 0;
+        }
         /* With parameters? */
         if (strncmp(hts_optalias[pos][2], "param", 5) == 0) {
           /* Copy parameters? */
@@ -493,6 +530,8 @@ int optalias_check(int argc, const char *const *argv, int n_arg,
             }
             strlcatbuff(return_argv[0], suffix, return_argv_size);
           }
+          /* --wide-mirror: -w with the count clustered onto it (-wc32) */
+          strlcatbuff(return_argv[0], addcommand, return_argv_size);
           *return_argc = 1;     /* 1 parameter returned */
         }
       } else {

--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -342,6 +342,10 @@ static const char *optalias_prefix_count(const char *name) {
                                                     : "";
 }
 
+/* What a --wide-/--tiny- prefix does where the count cannot be glued on.
+   0: apply the alias without the count and warn. 1: refuse the option. */
+#define OPTALIAS_PREFIX_STRICT 0
+
 /* Whether the alias expands to a plain cluster a count can be glued onto
    (-w -> -wc32). The rest is refused rather than glued blind: a value sharing
    the word (-N <template>, -c8) or holding it alone (-O <path>), a long form,
@@ -391,7 +395,7 @@ static const char *optalias_suffix(const char *type, const char *value) {
   argc,argv     as in main()
   n_arg         argument position
   return_argv   a char[2][] where to put result
-  return_error  buffer in case of syntax error
+  return_error  the syntax error, or a warning the caller shows and carries on
 
   return value: number of arguments treated (0 if error)
 */
@@ -456,15 +460,26 @@ int optalias_check(int argc, const char *const *argv, int n_arg,
       if (pos >= 0) {
         /* Copy real name */
         strcpybuff(command, hts_optalias[pos][1]);
-        /* Refuse a prefix the expansion cannot carry, rather than drop it */
+        /* Say so where the expansion cannot carry the prefix, rather than
+           drop the count in silence */
         if (addcommand[0] != '\0' &&
             !optalias_clusters(hts_optalias[pos][2], command)) {
+#if OPTALIAS_PREFIX_STRICT
           slprintfbuff_clip(return_error, return_error_size,
                             "Syntax error:\n\tThe %s- prefix does not apply to "
                             "--%s: write --%s --%s instead\n",
                             addname, hts_optalias[pos][0], addname,
                             hts_optalias[pos][0]);
           return 0;
+#else
+          slprintfbuff_clip(return_error, return_error_size,
+                            "Warning: the %s- prefix cannot add its connection "
+                            "count to --%s, so --%s runs without it; write "
+                            "--%s --%s instead",
+                            addname, hts_optalias[pos][0], hts_optalias[pos][0],
+                            addname, hts_optalias[pos][0]);
+          addcommand[0] = '\0';
+#endif
         }
         /* With parameters? */
         if (strncmp(hts_optalias[pos][2], "param", 5) == 0) {
@@ -780,6 +795,8 @@ cmdl_file_result optinclude_file(const char *name, cmdl_argv *cmd) {
             if (!result) {
               printf("%s\n", return_error);
             } else {
+              if (return_error[0] != '\0')
+                printf("%s\n", return_error);
               /* Insert the option and its parameter after the ones already
                  inserted, so that the file order is preserved */
               if (!cmdl_ins(cmd, tmp_argv[2], insert_after) ||

--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -796,7 +796,7 @@ cmdl_file_result optinclude_file(const char *name, cmdl_argv *cmd) {
               printf("%s\n", return_error);
             } else {
               if (return_error[0] != '\0')
-                printf("%s\n", return_error);
+                fprintf(stderr, "* %s\n", return_error);
               /* Insert the option and its parameter after the ones already
                  inserted, so that the file order is preserved */
               if (!cmdl_ins(cmd, tmp_argv[2], insert_after) ||

--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -342,17 +342,24 @@ static const char *optalias_prefix_count(const char *name) {
                                                     : "";
 }
 
-/* Whether the alias emits one short-option cluster a count can be glued onto
-   (-w -> -wc32). A class keeping its value in a word of its own (-O <path>,
-   +*.gif) and a long form (--clean) have nowhere to put it. */
+/* Whether the alias expands to a plain cluster a count can be glued onto
+   (-w -> -wc32). The rest is refused rather than glued blind: a value sharing
+   the word (-N <template>, -c8) or holding it alone (-O <path>), a long form,
+   the -% and -# families (-%r plus a c is the -%rc of --warc-cdx), a cluster
+   already carrying -c, and -h, which the caller matches as a whole word. */
 static hts_boolean optalias_clusters(const char *type, const char *command) {
-  const hts_boolean glued =
-      strcmp(type, "single") == 0 || strcmp(type, "onoff") == 0 ||
-      strcmp(type, "level") == 0 || strcmp(type, "param") == 0;
+  size_t i;
 
-  return glued && command[0] == '-' && command[1] != '-' && command[1] != '\0'
-             ? HTS_TRUE
-             : HTS_FALSE;
+  if (strcmp(type, "single") != 0 && strcmp(type, "onoff") != 0 &&
+      strcmp(type, "level") != 0)
+    return HTS_FALSE;
+  if (command[0] != '-' || command[1] == '\0' || strcmp(command, "-h") == 0)
+    return HTS_FALSE;
+  for (i = 1; command[i] != '\0'; i++) {
+    if (command[i] == 'c' || !isalnum((unsigned char) command[i]))
+      return HTS_FALSE;
+  }
+  return HTS_TRUE;
 }
 
 /* Suffix the short form takes for a value ("0", "2", or none), or NULL when

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -384,6 +384,10 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
           htsmain_free();
           return -1;
         }
+        /* an option that parsed, but not as asked (a --wide-/--tiny- prefix
+           the alias cannot carry) */
+        if (tmp_error[0] != '\0')
+          fprintf(stderr, "* %s\n", tmp_error);
 
         /* Copier */
         if (!cmdl_add(&x_cmd, tmp_argv[0]) ||

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4639,19 +4639,24 @@ static int st_optalias(httrackp *opt, int argc, char **argv) {
   EXPANDS("-%T", "--utf8-conversion", NULL);
 
   /* the --wide-/--tiny- prefix glues the --wide/--tiny connection count onto
-     the alias it prefixes; it was built and then dropped, never read */
+     the plain clusters, and is refused wherever the glue would be misread */
   EXPANDS("-wc32", "--wide-mirror", NULL);
   assertf(used == 1);
   EXPANDS("-wc1", "--tiny-mirror", NULL);
   EXPANDS("-p0C0I0tc32", "--wide-spider", NULL);
-  EXPANDS("-p1c1", "--tiny-skeleton", NULL);
-  EXPANDS("-C0c32", "--wide-cache", "0");
+  EXPANDS("-qgc1", "--tiny-get", NULL);
+  EXPANDS("-Xc32", "--wide-purge-old", NULL);
+  EXPANDS("-o2c1", "--tiny-generate-errors", "2");
   assertf(used == 2);
-  EXPANDS("-r2c1", "--tiny-depth", "2");
-  /* nowhere to glue it: a value of its own, or a long form */
-  REFUSES("--wide-path", "/tmp");
+  REFUSES("--wide-path", "/tmp"); /* the value is a word of its own */
   REFUSES("--tiny-allow", "*.gif");
-  REFUSES("--wide-clean", NULL);
+  REFUSES("--wide-clean", NULL);    /* a long form */
+  REFUSES("--wide-sockets", "8");   /* -c8 already: 8 or 32? */
+  REFUSES("--tiny-wide", NULL);     /* -c32 already: 32 or 1? */
+  REFUSES("--wide-structure", "1"); /* -N takes a template, not a cluster */
+  REFUSES("--wide-warc", NULL);     /* -%rc is --warc-cdx, not -%r -c */
+  REFUSES("--wide-version", NULL);  /* -#h is matched as a whole word */
+  REFUSES("--tiny-help", NULL);
 
   /* the value-taking classes are untouched */
   EXPANDS("-C0", "--cache=0", NULL);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4638,6 +4638,21 @@ static int st_optalias(httrackp *opt, int argc, char **argv) {
   EXPANDS("-y0", "--no-background-on-suspend", NULL);
   EXPANDS("-%T", "--utf8-conversion", NULL);
 
+  /* the --wide-/--tiny- prefix glues the --wide/--tiny connection count onto
+     the alias it prefixes; it was built and then dropped, never read */
+  EXPANDS("-wc32", "--wide-mirror", NULL);
+  assertf(used == 1);
+  EXPANDS("-wc1", "--tiny-mirror", NULL);
+  EXPANDS("-p0C0I0tc32", "--wide-spider", NULL);
+  EXPANDS("-p1c1", "--tiny-skeleton", NULL);
+  EXPANDS("-C0c32", "--wide-cache", "0");
+  assertf(used == 2);
+  EXPANDS("-r2c1", "--tiny-depth", "2");
+  /* nowhere to glue it: a value of its own, or a long form */
+  REFUSES("--wide-path", "/tmp");
+  REFUSES("--tiny-allow", "*.gif");
+  REFUSES("--wide-clean", NULL);
+
   /* the value-taking classes are untouched */
   EXPANDS("-C0", "--cache=0", NULL);
   EXPANDS("-C0", "--nocache", NULL);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4524,10 +4524,10 @@ static int st_stripquery(httrackp *opt, int argc, char **argv) {
 
 /* The short form optalias_check() emits for the option words, both joined by a
    space when it returns two, or NULL when it refuses them; *used counts the
-   words consumed. */
+   words consumed and warn takes the message an accepted option still drew. */
 static const char *st_optalias_expand(char *dest, size_t dest_size,
                                       const char *word, const char *next,
-                                      int *used) {
+                                      int *used, char *warn, size_t warn_size) {
   char BIGSTK out[2][HTS_CDLMAXSIZE];
   char *outv[2] = {out[0], out[1]};
   const char *argv[2];
@@ -4537,13 +4537,14 @@ static const char *st_optalias_expand(char *dest, size_t dest_size,
 
   argv[0] = word;
   argv[1] = next;
-  out[0][0] = out[1][0] = dest[0] = '\0';
+  out[0][0] = out[1][0] = dest[0] = warn[0] = '\0';
   *used = optalias_check(argc, argv, 0, &outc, outv, sizeof(out[0]), error,
                          sizeof(error));
   if (*used == 0) {
     assertf(error[0] != '\0'); /* a refusal has to say why */
     return NULL;
   }
+  strlcpybuff(warn, error, warn_size);
   assertf(outc >= 1 && outc <= 2);
   strlcpybuff(dest, out[0], dest_size);
   if (outc == 2) {
@@ -4556,7 +4557,7 @@ static const char *st_optalias_expand(char *dest, size_t dest_size,
 /* Long-option value handling (#1195): a value the option's class did not take
    was dropped, so --index=0 read back as the enabling bare --index. */
 static int st_optalias(httrackp *opt, int argc, char **argv) {
-  char got[HTS_CDLMAXSIZE * 2];
+  char got[HTS_CDLMAXSIZE * 2], warn[256];
   int i, used;
 
   (void) opt;
@@ -4568,20 +4569,31 @@ static int st_optalias(httrackp *opt, int argc, char **argv) {
     return 0;
   }
   if (argc >= 1) {
-    const char *const out = st_optalias_expand(
-        got, sizeof(got), argv[0], argc >= 2 ? argv[1] : NULL, &used);
+    const char *const out = st_optalias_expand(got, sizeof(got), argv[0],
+                                               argc >= 2 ? argv[1] : NULL,
+                                               &used, warn, sizeof(warn));
 
     printf("%s\n", out != NULL ? out : "(refused)");
     return out != NULL ? 0 : 1;
   }
 #define EXPANDS(want, word, next)                                              \
   do {                                                                         \
-    const char *const out__ =                                                  \
-        st_optalias_expand(got, sizeof(got), (word), (next), &used);           \
+    const char *const out__ = st_optalias_expand(                              \
+        got, sizeof(got), (word), (next), &used, warn, sizeof(warn));          \
     assertf(out__ != NULL && strcmp(out__, (want)) == 0);                      \
+    assertf(warn[0] == '\0');                                                  \
+  } while (0)
+/* accepted, expanding to WANT, but drawing a warning on the way */
+#define WARNS(want, word, next)                                                \
+  do {                                                                         \
+    const char *const out__ = st_optalias_expand(                              \
+        got, sizeof(got), (word), (next), &used, warn, sizeof(warn));          \
+    assertf(out__ != NULL && strcmp(out__, (want)) == 0);                      \
+    assertf(warn[0] != '\0');                                                  \
   } while (0)
 #define REFUSES(word, next)                                                    \
-  assertf(st_optalias_expand(got, sizeof(got), (word), (next), &used) == NULL)
+  assertf(st_optalias_expand(got, sizeof(got), (word), (next), &used, warn,    \
+                             sizeof(warn)) == NULL)
 
   /* -I0 has always disabled the index; now the long form can say it too */
   EXPANDS("-I0", "--index=0", NULL);
@@ -4648,15 +4660,16 @@ static int st_optalias(httrackp *opt, int argc, char **argv) {
   EXPANDS("-Xc32", "--wide-purge-old", NULL);
   EXPANDS("-o2c1", "--tiny-generate-errors", "2");
   assertf(used == 2);
-  REFUSES("--wide-path", "/tmp"); /* the value is a word of its own */
-  REFUSES("--tiny-allow", "*.gif");
-  REFUSES("--wide-clean", NULL);    /* a long form */
-  REFUSES("--wide-sockets", "8");   /* -c8 already: 8 or 32? */
-  REFUSES("--tiny-wide", NULL);     /* -c32 already: 32 or 1? */
-  REFUSES("--wide-structure", "1"); /* -N takes a template, not a cluster */
-  REFUSES("--wide-warc", NULL);     /* -%rc is --warc-cdx, not -%r -c */
-  REFUSES("--wide-version", NULL);  /* -#h is matched as a whole word */
-  REFUSES("--tiny-help", NULL);
+  /* elsewhere the alias applies without the count, and says so */
+  WARNS("-O /tmp", "--wide-path", "/tmp"); /* the value is a word of its own */
+  WARNS("+*.gif", "--tiny-allow", "*.gif");
+  WARNS("--clean", "--wide-clean", NULL); /* a long form */
+  WARNS("-c8", "--wide-sockets", "8");    /* -c8 already: 8 or 32? */
+  WARNS("-c32", "--tiny-wide", NULL);     /* -c32 already: 32 or 1? */
+  WARNS("-N1", "--wide-structure", "1");  /* -N takes a template */
+  WARNS("-%r", "--wide-warc", NULL);      /* -%rc is --warc-cdx, not -%r -c */
+  WARNS("-#h", "--wide-version", NULL);   /* -#h is matched as a whole word */
+  WARNS("-h", "--tiny-help", NULL);
 
   /* the value-taking classes are untouched */
   EXPANDS("-C0", "--cache=0", NULL);
@@ -4683,6 +4696,7 @@ static int st_optalias(httrackp *opt, int argc, char **argv) {
   }
   assertf(i > 100); /* the table was walked, not skipped */
 #undef EXPANDS
+#undef WARNS
 #undef REFUSES
 
   printf("optalias self-test OK\n");

--- a/tests/361_cli-wide-tiny-alias.test
+++ b/tests/361_cli-wide-tiny-alias.test
@@ -3,10 +3,10 @@
 # --wide-mirror and --tiny-mirror built the connection count their prefix
 # exists to add, then dropped it: the value was written and never read.
 #
-# The engine never prints its connection count, so what is asserted here is the
-# count reaching the option: above 8 the security limiter clamps it and says so
-# in hts-log.txt, and that line is the engine speaking about the value it got.
-# The exact short form each prefix emits is pinned by -#test=optalias.
+# hts-log.txt echoes the expanded command line on its second line, so the word
+# the engine actually received is readable; the security limiter, which caps a
+# count above 8 and logs it, then says the count reached the option and not
+# just the argv.
 
 set -euo pipefail
 
@@ -32,42 +32,59 @@ crawl() { # crawl ARG...
         >"${tmp}/run.log" 2>&1 || RC=$?
 }
 
-# clamped WANT LABEL ARG...: whether the limiter capped the count it was handed
-clamped() {
-    local want=$1 label=$2 got=no hits
+# echoed WANT LABEL ARG...: the option word the engine was handed
+echoed() {
+    local want=$1 label=$2 line
     shift 2
     crawl "$@"
     assert_eq 0 "${RC}" "${label} exited"
     assert_file "${tmp}/out/hts-log.txt" "${label}"
+    line=$(sed -n 2p "${tmp}/out/hts-log.txt")
+    grep -q -- " ${want} " <<<"${line}" ||
+        fail "${label}: the engine was handed ${line}, wanted ${want}"
+}
+
+echoed '-wc32' 'wide mirror' --wide-mirror
+echoed '-wc1' 'tiny mirror' --tiny-mirror
+echoed '-w' 'plain mirror' --mirror
+echoed '-p0C0I0tc32' 'wide spider' --wide-spider
+echoed '-p0C0I0tc1' 'tiny spider' --tiny-spider
+echoed '-p0C0I0t' 'plain spider' --spider
+echoed '-p1c32' 'wide skeleton' --wide-skeleton
+echoed '-p1' 'plain skeleton' --skeleton
+echoed '-Xc32' 'wide purge-old' --wide-purge-old
+echoed '-o2c1' 'tiny generate-errors' --tiny-generate-errors 2
+echoed '-c8' 'plain sockets' --sockets 8
+ok "the prefix glues its count on, and only the prefix does"
+
+# ...and the count reaches the option, not just the rebuilt argv: above 8 the
+# security limiter caps it and says so. 32 is above the ceiling, the default 4
+# and tiny's 1 are below.
+clamped() { # clamped WANT LABEL ARG...
+    local want=$1 label=$2 got=no hits
+    shift 2
+    crawl "$@"
+    assert_eq 0 "${RC}" "${label} exited"
     hits=$(count_matching_lines 'simultaneous connections limited to' \
         "${tmp}/out/hts-log.txt")
     test "${hits}" -eq 0 || got=yes
     assert_eq "${want}" "${got}" "${label} was clamped"
 }
 
-# 32 is above the limiter's ceiling of 8, the default 4 and tiny's 1 are below
 clamped yes 'wide mirror' --wide-mirror
 clamped no 'tiny mirror' --tiny-mirror
 clamped no 'plain mirror' --mirror
-clamped yes 'wide spider' --wide-spider
-clamped no 'tiny spider' --tiny-spider
-clamped no 'plain spider' --spider
-clamped yes 'wide skeleton' --wide-skeleton
-clamped no 'plain skeleton' --skeleton
-ok "the wide-/tiny- prefix reaches the connection count"
-
-# Against an explicit count, which the prefix has to win or lose on its own: the
-# unprefixed alias adds nothing, so 32 survives it.
+# against an explicit count, which the prefix has to win or lose on its own
 clamped no 'tiny mirror over --sockets 32' --sockets 32 --tiny-mirror
 clamped yes 'plain mirror over --sockets 32' --sockets 32 --mirror
 clamped yes 'wide mirror over --sockets 1' --sockets 1 --wide-mirror
-clamped no 'plain mirror over --sockets 1' --sockets 1 --mirror
-ok "the count is the prefix's, and only the prefix's"
+ok "the count applies, and the unprefixed alias adds none"
 
-# An alias keeping its value in a word of its own (-O <path>, +*.gif) has
-# nowhere to glue the count, so the prefix is refused rather than dropped.
+# Everywhere the glue would be misread, the prefix is refused instead: a value
+# sharing the word or holding it alone, a long form, an option name the caller
+# matches whole, and a cluster already carrying a count of its own.
 refused() { # refused LABEL ARG...
-    local label=$1
+    local label=$1 reply
     shift
     crawl "$@"
     test "${RC}" -ne 0 || fail "${label}: accepted, exit 0"
@@ -76,6 +93,19 @@ refused() { # refused LABEL ARG...
         fail "${label}: refused without saying why: ${reply}"
 }
 
+refused 'wide structure' --wide-structure '%h%p/%n.%t'
+refused 'wide sockets' --wide-sockets 8
+refused 'tiny wide' --tiny-wide
+refused 'wide version' --wide-version
+refused 'wide warc' --wide-warc
 refused 'wide path' --wide-path "${tmp}/out"
 refused 'tiny allow' --tiny-allow '*.gif'
-ok "a prefix with nowhere to go is refused"
+refused 'tiny help' --tiny-help
+ok "a prefix that cannot be glued on is refused"
+
+# The unprefixed spellings the refusals are built from still work, template
+# included: gluing a count into it corrupted the template as well as losing it.
+echoed '-N%h%p/%n.%t' 'plain structure' --structure '%h%p/%n.%t'
+test -f "${tmp}/out/file${tmp}/page.html" ||
+    fail "--structure did not lay the mirror out by its template"
+ok "the unprefixed aliases are untouched"

--- a/tests/361_cli-wide-tiny-alias.test
+++ b/tests/361_cli-wide-tiny-alias.test
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# --wide-mirror and --tiny-mirror built the connection count their prefix
+# exists to add, then dropped it: the value was written and never read.
+#
+# The engine never prints its connection count, so what is asserted here is the
+# count reaching the option: above 8 the security limiter clamps it and says so
+# in hts-log.txt, and that line is the engine speaking about the value it got.
+# The exact short form each prefix emits is pinned by -#test=optalias.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_widealias.XXXXXX") || fail "no tmpdir"
+cleanup() {
+    rm -rf "${tmp}"
+}
+trap 'set +e; cleanup' EXIT
+trap 'set +e; cleanup; exit 1' HUP INT QUIT TERM
+
+require_httrack
+echo '<html><body>hello</body></html>' >"${tmp}/page.html"
+
+crawl() { # crawl ARG...
+    rm -rf "${tmp}/out"
+    mkdir -p "${tmp}/out"
+    RC=0
+    httrack "file://${tmp}/page.html" -O "${tmp}/out" --quiet "$@" \
+        >"${tmp}/run.log" 2>&1 || RC=$?
+}
+
+# clamped WANT LABEL ARG...: whether the limiter capped the count it was handed
+clamped() {
+    local want=$1 label=$2 got=no hits
+    shift 2
+    crawl "$@"
+    assert_eq 0 "${RC}" "${label} exited"
+    assert_file "${tmp}/out/hts-log.txt" "${label}"
+    hits=$(count_matching_lines 'simultaneous connections limited to' \
+        "${tmp}/out/hts-log.txt")
+    test "${hits}" -eq 0 || got=yes
+    assert_eq "${want}" "${got}" "${label} was clamped"
+}
+
+# 32 is above the limiter's ceiling of 8, the default 4 and tiny's 1 are below
+clamped yes 'wide mirror' --wide-mirror
+clamped no 'tiny mirror' --tiny-mirror
+clamped no 'plain mirror' --mirror
+clamped yes 'wide spider' --wide-spider
+clamped no 'tiny spider' --tiny-spider
+clamped no 'plain spider' --spider
+clamped yes 'wide skeleton' --wide-skeleton
+clamped no 'plain skeleton' --skeleton
+ok "the wide-/tiny- prefix reaches the connection count"
+
+# Against an explicit count, which the prefix has to win or lose on its own: the
+# unprefixed alias adds nothing, so 32 survives it.
+clamped no 'tiny mirror over --sockets 32' --sockets 32 --tiny-mirror
+clamped yes 'plain mirror over --sockets 32' --sockets 32 --mirror
+clamped yes 'wide mirror over --sockets 1' --sockets 1 --wide-mirror
+clamped no 'plain mirror over --sockets 1' --sockets 1 --mirror
+ok "the count is the prefix's, and only the prefix's"
+
+# An alias keeping its value in a word of its own (-O <path>, +*.gif) has
+# nowhere to glue the count, so the prefix is refused rather than dropped.
+refused() { # refused LABEL ARG...
+    local label=$1
+    shift
+    crawl "$@"
+    test "${RC}" -ne 0 || fail "${label}: accepted, exit 0"
+    reply=$(cat "${tmp}/run.log")
+    grep -q 'prefix does not apply' <<<"${reply}" ||
+        fail "${label}: refused without saying why: ${reply}"
+}
+
+refused 'wide path' --wide-path "${tmp}/out"
+refused 'tiny allow' --tiny-allow '*.gif'
+ok "a prefix with nowhere to go is refused"

--- a/tests/361_cli-wide-tiny-alias.test
+++ b/tests/361_cli-wide-tiny-alias.test
@@ -32,8 +32,10 @@ crawl() { # crawl ARG...
         >"${tmp}/run.log" 2>&1 || RC=$?
 }
 
-# expand_run WANT LABEL ARG...: run, and read back the option word the engine
-# was handed, plus whether the prefix said it could not add its count
+# expand_run PATTERN LABEL ARG...: run, and match PATTERN against the command
+# line the engine echoes, plus note whether the prefix said it could not add its
+# count. PATTERN carries its own delimiters, so a caller pins a whole word (" -w
+# ") or only a fragment, for a value whose word boundary is not ours to fix.
 expand_run() {
     local want=$1 label=$2 line
     shift 2
@@ -41,7 +43,7 @@ expand_run() {
     assert_eq 0 "${RC}" "${label} exited"
     assert_file "${tmp}/out/hts-log.txt" "${label}"
     line=$(sed -n 2p "${tmp}/out/hts-log.txt")
-    grep -qF -- " ${want} " <<<"${line}" ||
+    grep -qF -- "${want}" <<<"${line}" ||
         fail "${label}: the engine was handed ${line}, wanted ${want}"
     WARNED=no
     ! grep -q 'cannot add its connection count' "${tmp}/run.log" || WARNED=yes
@@ -59,17 +61,17 @@ warned() { # warned WANT LABEL ARG...
     assert_eq yes "${WARNED}" "$2 warned"
 }
 
-echoed '-wc32' 'wide mirror' --wide-mirror
-echoed '-wc1' 'tiny mirror' --tiny-mirror
-echoed '-w' 'plain mirror' --mirror
-echoed '-p0C0I0tc32' 'wide spider' --wide-spider
-echoed '-p0C0I0tc1' 'tiny spider' --tiny-spider
-echoed '-p0C0I0t' 'plain spider' --spider
-echoed '-p1c32' 'wide skeleton' --wide-skeleton
-echoed '-p1' 'plain skeleton' --skeleton
-echoed '-Xc32' 'wide purge-old' --wide-purge-old
-echoed '-o2c1' 'tiny generate-errors' --tiny-generate-errors 2
-echoed '-c8' 'plain sockets' --sockets 8
+echoed ' -wc32 ' 'wide mirror' --wide-mirror
+echoed ' -wc1 ' 'tiny mirror' --tiny-mirror
+echoed ' -w ' 'plain mirror' --mirror
+echoed ' -p0C0I0tc32 ' 'wide spider' --wide-spider
+echoed ' -p0C0I0tc1 ' 'tiny spider' --tiny-spider
+echoed ' -p0C0I0t ' 'plain spider' --spider
+echoed ' -p1c32 ' 'wide skeleton' --wide-skeleton
+echoed ' -p1 ' 'plain skeleton' --skeleton
+echoed ' -Xc32 ' 'wide purge-old' --wide-purge-old
+echoed ' -o2c1 ' 'tiny generate-errors' --tiny-generate-errors 2
+echoed ' -c8 ' 'plain sockets' --sockets 8
 ok "the prefix glues its count on, and only the prefix does"
 
 # ...and the count reaches the option, not just the rebuilt argv: above 8 the
@@ -93,23 +95,29 @@ clamped no 'plain mirror' --mirror
 clamped no 'tiny mirror over --sockets 32' --sockets 32 --tiny-mirror
 clamped yes 'plain mirror over --sockets 32' --sockets 32 --mirror
 clamped yes 'wide mirror over --sockets 1' --sockets 1 --wide-mirror
-ok "the count applies, and the unprefixed alias adds none"
+# 3 is under the ceiling, so a glued 32 read as far as its first digit would
+# leave this pair looking the same; only reading both digits clamps
+clamped no 'plain mirror over --sockets 3' --sockets 3 --mirror
+clamped yes 'wide mirror over --sockets 3' --sockets 3 --wide-mirror
+ok "the count applies whole, and the unprefixed alias adds none"
 
 # Everywhere the glue would be misread, the alias runs without the count and
 # warns: a value sharing the word (-N, -c8), the -% and -# families whose names
 # are not self-delimiting, a cluster already carrying a count, a value of its
 # own. The base alias has to still do its job.
-warned '-N%h%p/%n.%t' 'wide structure' --wide-structure '%h%p/%n.%t'
+# Whether -N takes its template glued or detached is #1380's business, so pin
+# the template followed by a word break: a glued count would land inside it.
+warned '%h%p/%n.%t ' 'wide structure' --wide-structure '%h%p/%n.%t'
 test -f "${tmp}/out/file${tmp}/page.html" ||
     fail "--wide-structure lost the template it warned about"
-warned '-c8' 'wide sockets' --wide-sockets 8
+warned ' -c8 ' 'wide sockets' --wide-sockets 8
 assert_eq 0 "$(count_matching_lines 'simultaneous connections limited to' \
     "${tmp}/out/hts-log.txt")" "--wide-sockets 8 stayed at 8"
-warned '-%r' 'wide warc' --wide-warc
+warned ' -%r ' 'wide warc' --wide-warc
 test -n "$(find "${tmp}/out" -name '*.warc*' -print -quit)" ||
     fail "--wide-warc wrote no archive"
-warned '-c32' 'tiny wide' --tiny-wide
-warned '+*.gif' 'tiny allow' --tiny-allow '*.gif'
+warned ' -c32 ' 'tiny wide' --tiny-wide
+warned ' +*.gif ' 'tiny allow' --tiny-allow '*.gif'
 
 # -#h returns before any crawl, so it is read straight off the run
 run_log=$(httrack -O "${tmp}/out" --quiet --wide-version 2>&1) || fail "--wide-version exited $?"
@@ -121,7 +129,7 @@ ok "a prefix that cannot be glued on warns, and the alias still runs"
 
 # The unprefixed spellings the refusals are built from still work, template
 # included: gluing a count into it corrupted the template as well as losing it.
-echoed '-N%h%p/%n.%t' 'plain structure' --structure '%h%p/%n.%t'
+echoed '%h%p/%n.%t ' 'plain structure' --structure '%h%p/%n.%t'
 test -f "${tmp}/out/file${tmp}/page.html" ||
     fail "--structure did not lay the mirror out by its template"
 ok "the unprefixed aliases are untouched"

--- a/tests/361_cli-wide-tiny-alias.test
+++ b/tests/361_cli-wide-tiny-alias.test
@@ -32,16 +32,31 @@ crawl() { # crawl ARG...
         >"${tmp}/run.log" 2>&1 || RC=$?
 }
 
-# echoed WANT LABEL ARG...: the option word the engine was handed
-echoed() {
+# expand_run WANT LABEL ARG...: run, and read back the option word the engine
+# was handed, plus whether the prefix said it could not add its count
+expand_run() {
     local want=$1 label=$2 line
     shift 2
     crawl "$@"
     assert_eq 0 "${RC}" "${label} exited"
     assert_file "${tmp}/out/hts-log.txt" "${label}"
     line=$(sed -n 2p "${tmp}/out/hts-log.txt")
-    grep -q -- " ${want} " <<<"${line}" ||
+    grep -qF -- " ${want} " <<<"${line}" ||
         fail "${label}: the engine was handed ${line}, wanted ${want}"
+    WARNED=no
+    ! grep -q 'cannot add its connection count' "${tmp}/run.log" || WARNED=yes
+}
+
+# the count went on, with nothing to report
+echoed() { # echoed WANT LABEL ARG...
+    expand_run "$@"
+    assert_eq no "${WARNED}" "$2 warned"
+}
+
+# the alias applied without the count, and said so
+warned() { # warned WANT LABEL ARG...
+    expand_run "$@"
+    assert_eq yes "${WARNED}" "$2 warned"
 }
 
 echoed '-wc32' 'wide mirror' --wide-mirror
@@ -80,28 +95,29 @@ clamped yes 'plain mirror over --sockets 32' --sockets 32 --mirror
 clamped yes 'wide mirror over --sockets 1' --sockets 1 --wide-mirror
 ok "the count applies, and the unprefixed alias adds none"
 
-# Everywhere the glue would be misread, the prefix is refused instead: a value
-# sharing the word or holding it alone, a long form, an option name the caller
-# matches whole, and a cluster already carrying a count of its own.
-refused() { # refused LABEL ARG...
-    local label=$1 reply
-    shift
-    crawl "$@"
-    test "${RC}" -ne 0 || fail "${label}: accepted, exit 0"
-    reply=$(cat "${tmp}/run.log")
-    grep -q 'prefix does not apply' <<<"${reply}" ||
-        fail "${label}: refused without saying why: ${reply}"
-}
+# Everywhere the glue would be misread, the alias runs without the count and
+# warns: a value sharing the word (-N, -c8), the -% and -# families whose names
+# are not self-delimiting, a cluster already carrying a count, a value of its
+# own. The base alias has to still do its job.
+warned '-N%h%p/%n.%t' 'wide structure' --wide-structure '%h%p/%n.%t'
+test -f "${tmp}/out/file${tmp}/page.html" ||
+    fail "--wide-structure lost the template it warned about"
+warned '-c8' 'wide sockets' --wide-sockets 8
+assert_eq 0 "$(count_matching_lines 'simultaneous connections limited to' \
+    "${tmp}/out/hts-log.txt")" "--wide-sockets 8 stayed at 8"
+warned '-%r' 'wide warc' --wide-warc
+test -n "$(find "${tmp}/out" -name '*.warc*' -print -quit)" ||
+    fail "--wide-warc wrote no archive"
+warned '-c32' 'tiny wide' --tiny-wide
+warned '+*.gif' 'tiny allow' --tiny-allow '*.gif'
 
-refused 'wide structure' --wide-structure '%h%p/%n.%t'
-refused 'wide sockets' --wide-sockets 8
-refused 'tiny wide' --tiny-wide
-refused 'wide version' --wide-version
-refused 'wide warc' --wide-warc
-refused 'wide path' --wide-path "${tmp}/out"
-refused 'tiny allow' --tiny-allow '*.gif'
-refused 'tiny help' --tiny-help
-ok "a prefix that cannot be glued on is refused"
+# -#h returns before any crawl, so it is read straight off the run
+run_log=$(httrack -O "${tmp}/out" --quiet --wide-version 2>&1) || fail "--wide-version exited $?"
+grep -q 'cannot add its connection count' <<<"${run_log}" ||
+    fail "--wide-version applied silently: ${run_log}"
+grep -q 'HTTrack version' <<<"${run_log}" ||
+    fail "--wide-version stopped printing the version: ${run_log}"
+ok "a prefix that cannot be glued on warns, and the alias still runs"
 
 # The unprefixed spellings the refusals are built from still work, template
 # included: gluing a count into it corrupted the template as well as losing it.


### PR DESCRIPTION
The `--wide-` and `--tiny-` prefixes build the connection count they exist to add and then drop it: `optalias_check()` writes `c32` or `c1` into a local buffer nothing reads, so `--wide-mirror` is `--mirror` at the default four connections. The write is dead in the initial 3.20.2 import, so this is an unfinished feature rather than a regression, and nothing documents the prefix: cmdguide lists `--wide`, `--tiny` and `--ultrawide` as standalone presets, and neither the man page nor the help mentions the prefixed spellings. They are live all the same, since `optreal_or_alias()` already treats `--wide-<alias>` as an option name and 275 passes one around as one.

The count is glued onto the short form the alias expands to, the way the table writes its own clusters: `--wide-mirror` becomes `-wc32` and `--tiny-spider` becomes `-p0C0I0tc1`. The value comes from the `--wide` and `--tiny` rows rather than a second copy of 32 and 1. Gluing is only safe where the expansion is a plain letter-and-digit cluster, and an earlier draft of this branch glued everywhere, which broke three ways: `-#hc32` misses the whole-word match on `-#h`, so `--wide-version` printed the usage dump instead of the version; `-N%h%p/%n.%tc32` corrupts the user's template and drops the count anyway; and `--wide-sockets 8` became `-c8c32`, silently 32. The rule now admits 44 of the 172 alias names, excluding the classes whose value shares or owns the word, long forms, the `-%` and `-#` families (whose option names are not self-delimiting, so `-%r` plus a `c` is the `-%rc` of `--warc-cdx`), a cluster already carrying `-c`, and `-h`.

On the other 128 the alias applies without the count and HTTrack says so on stderr, on the command line and in a config file alike, rather than dropping it in silence as before:

    * Warning: the wide- prefix cannot add its connection count to --path, so --path runs without it; write --wide --path instead

**A choice to make, and the branch is on the safer side of it.** The alternative is to refuse those spellings outright, which reads well ("do not silently ignore what the user asked for") but turns 256 spellings shipped since 3.48.10 from running to exit 255: `--wide-path /out`, `--tiny-allow '*.gif'`, `--wide-user-agent X`, `--wide-clean`, `--wide-sockets 8`, `--wide-structure`, `--wide-cache`, `--wide-proxy`, `--wide-version`, `--wide-warc` and 118 more names. As pushed, nothing that runs today stops running and no output changes beyond the warning line. The refusal path is still there and tested: `#define OPTALIAS_PREFIX_STRICT 1` at src/htsalias.c:347 switches to it, and the expectations in `st_optalias` (`WARNS` back to `REFUSES`) and in 361 follow.

The new test asserts the argv echo hts-log.txt writes on its second line, which is the word the engine was handed, then the security limiter's clamp line, which is the count reaching the option rather than just the rebuilt argv. It matches the echo by pattern rather than by whole word where the spelling is not this test's to fix, so `--structure`'s value is checked as a template followed by a word break and the assertions hold whether #1380 leaves it glued or detaches it; the merged tree against #1380's head was built and run to confirm. A `--sockets 3` pair pins the glued digits, since 32 clamps only if both are read. It covers one warned spelling from each excluded class and checks the base alias still did its job: `--wide-structure` keeps laying out by its template, `--wide-sockets 8` stays at 8, `--wide-warc` still writes an archive, `--tiny-wide` still gets 32, `--wide-version` still prints the version. `-#test=optalias` pins the exact expansion of every accepted and warned spelling, and asserts no unprefixed alias warns. All 172 names were swept twice against the built binary, with and without a URL: the 44 glue with the right echo and no warning, the 128 warn and are otherwise indistinguishable from the unprefixed run.

Closes #1423