### PR TITLE
Windows builds carry 14 uncleaned compiler warnings

### DIFF
--- a/src/htsbacktrace.c
+++ b/src/htsbacktrace.c
@@ -369,7 +369,7 @@ void hts_backtrace_altstack_release(void *stack) {
 }
 
 /* Why the report has no frames: a silent gap reads as a handler that died. */
-static void print_no_trace(int fd, const char *msg, size_t len) {
+static void print_no_trace(int fd, const char *msg, unsigned int len) {
   if (write(fd, msg, len) != len) { /* no ssize_t: this is built on MSVC too */
     /* sorry GCC */
   }

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -245,7 +245,8 @@ static size_t hts_record_link_alloc(httrackp *opt) {
   assertf(liensbuf != NULL);
 
   // Limit the number of links
-  if (opt->maxlink > 0 && TypedArraySize(liensbuf->ptr) >= opt->maxlink) {
+  if (opt->maxlink > 0 &&
+      TypedArraySize(liensbuf->ptr) >= (size_t) opt->maxlink) {
     return (size_t) -1;
   }
 
@@ -1718,7 +1719,8 @@ int httpmirror(char *url1, httrackp * opt) {
             }
             /* Attempt to find a meta charset */
             else if (is_html_mime_type(r.contenttype)) {
-              char *const charset = hts_getCharsetFromMeta(r.adr, r.size);
+              char *const charset =
+                  hts_getCharsetFromMeta(r.adr, (size_t) r.size);
 
               if (charset != NULL && strlen(charset) < sizeof(page_charset)) {
                 strcpy(page_charset, charset);
@@ -1830,8 +1832,8 @@ int httpmirror(char *url1, httrackp * opt) {
               hts_boolean keep_root = HTS_TRUE;
 #endif
 
-              robots_parse(opt, &robots, urladr(), r.adr, r.size, infobuff,
-                           sizeof(infobuff), keep_root, sitemaps,
+              robots_parse(opt, &robots, urladr(), r.adr, (size_t) r.size,
+                           infobuff, sizeof(infobuff), keep_root, sitemaps,
                            sizeof(sitemaps));
               if (strnotempty(infobuff)) {
                 hts_log_print(opt, LOG_INFO,

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -3451,13 +3451,15 @@ static char *fil_normalized_ex(const char *source, char *dest, int do_slash,
                                int do_query) {
   char lastc = 0;
   int gotquery = 0;
-  int ampargs = 0;
+  size_t ampargs = 0;
   size_t i, j;
   char *query = NULL;
 
   for(i = j = 0; source[i] != '\0'; i++) {
-    if (!gotquery && source[i] == '?')
-      gotquery = ampargs = 1;
+    if (!gotquery && source[i] == '?') {
+      gotquery = 1;
+      ampargs = 1;
+    }
     if (do_slash && !gotquery && lastc == '/' && source[i] == '/') {
       // foo//bar -> foo/bar
     } else {

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -1558,7 +1558,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                 // Check for bogus links (Vasiliy)
                                 if (a != NULL) {
                                   const size_t size = c - a + 1;
-                                  int i;
+                                  size_t i;
                                   int first = 1;
 
                                   for(i = 0; i < size; i++) {

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -8308,10 +8308,10 @@ static int st_warc(httrackp *opt, int argc, char **argv) {
           err = 1;
         seen_a_body = 1;
       }
-      if (warc_memstr((char *) rec, "Content-Encoding", hdr_len + block_len,
-                      16) != NULL ||
-          warc_memstr((char *) rec, "Transfer-Encoding", hdr_len + block_len,
-                      17) != NULL)
+      if (warc_memstr((char *) rec, "Content-Encoding",
+                      hdr_len + (size_t) block_len, 16) != NULL ||
+          warc_memstr((char *) rec, "Transfer-Encoding",
+                      hdr_len + (size_t) block_len, 17) != NULL)
         err = 1;
     }
     freet(rec);
@@ -11359,7 +11359,8 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
   (void) argv;
 
   /* no quota may fire instead of the stop, and no slot may time out */
-  opt->maxtime = opt->maxsite = 0;
+  opt->maxtime = 0;
+  opt->maxsite = 0;
   opt->timeout = 0;
   opt->state.stop = 0;
 

--- a/src/httrack.c
+++ b/src/httrack.c
@@ -908,8 +908,8 @@ static void sig_doback(int blind) {     // mettre en backing
 #undef FD_ERR
 #define FD_ERR 2
 
-static size_t print_num(char *buffer, int num) {
-  size_t i, j;
+static unsigned int print_num(char *buffer, int num) {
+  unsigned int i, j;
   if (num < 0) {
     *(buffer++) = '-';
     num = -num;
@@ -931,7 +931,8 @@ static void sig_fatal(int code) {
   const char msgreport[] =
     "\nPlease report the problem at http://forum.httrack.com\n";
   char buffer[256];
-  size_t size;
+  /* MSVC's write() counts in unsigned int; this stays under buffer[256] */
+  unsigned int size;
 
   signal(code, SIG_DFL);
   signal(SIGABRT, SIG_DFL);

--- a/src/proxy/proxytrack.c
+++ b/src/proxy/proxytrack.c
@@ -1564,8 +1564,9 @@ static int ICP_reply(struct sockaddr *clientAddr, int clientAddrLen, T_SOC soc,
   unsigned long int BufferSize;
   unsigned char *buffer;
 
-  if (Message_Length == 0 && Message != NULL)   /* We have to get the message size */
-    Message_Length = (unsigned int) strlen((char*) Message) + 1;        /* NULL terminated */
+  /* NUL terminated; RFC2186 caps an ICP message at 16 KB, so this fits */
+  if (Message_Length == 0 && Message != NULL)
+    Message_Length = (unsigned short) (strlen((char *) Message) + 1);
   BufferSize = 20 + Message_Length;
   buffer = malloc(BufferSize);
   if (buffer != NULL) {

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -1521,7 +1521,7 @@ static char *cache_rstr_addr(FILE * fp) {
   if (sscanf(buff, INTsysP, &i) != 1 || i < 0 || i > 32768)
     i = 0;
   if (i > 0) {
-    addr = malloc(i + 1);
+    addr = malloc((size_t) i + 1);
     if (addr != NULL) {
       if (!hts_fread_exact(addr, (size_t) i, fp)) {
         assertf(! "fread_cache_failed");


### PR DESCRIPTION
This is the follow-through of #1354, the last MSVC warning sweep: the Windows legs have been compiling with warnings ever since it closed. Harvesting the `libhttrack (x64, Release)` and `(Win32, Release)` logs off master turns up 14 distinct sites: 3 that only x64 sees (a 64-bit `size_t` narrowing into MSVC's `unsigned int` or `int`), 10 that only Win32 sees (a 64-bit `LLint`/`__int64` narrowing into a 32-bit `size_t`, or a signed/unsigned comparison), and 1 common to both. Running both widths matters: the two lists overlap in a single entry, so either width alone hides most of the sweep.

Thirteen are ours and all thirteen are fixed. Where the value simply had the wrong type I changed the type rather than casting — `ampargs` in `fil_normalized_ex` and the bogus-link loop index in `htsparse` become `size_t`, and the emergency signal-handler writers in `httrack.c` and `htsbacktrace.c` count in `unsigned int`, which is what MSVC's `write()` takes and what their fixed 256-byte buffer and string literals fit in anyway. Casts appear only where a guard on the same path already bounds the value: `opt->maxlink` is cast under its own `> 0` test, and `cache_rstr_addr`'s length is cast under the clamp to `[0, 32768]` two lines above it, matching the cast the very next line already had. `r.size` gets `(size_t)` at two call sites in `httpmirror` — it counts the bytes held at `r.adr`, so it fits `size_t` by construction, and line 1649 of the same function already spelled it that way.

Two chained assignments are split apart, because the chain was what produced the narrowing: `opt->maxtime = opt->maxsite = 0` in `htsselftest.c` (an `int` fed from an `LLint`, landed in #1079) and `gotquery = ampargs = 1` in `htslib.c`. The second sat inside a braceless `if`, so splitting it needs braces — worth flagging since dropping them would have made `ampargs = 1` unconditional.

The one I left is `src/minizip/mztools.c(194,29)` C4267. `src/minizip/` is patched in place here rather than kept pristine, with each delta recorded in an `.orig`/`.diff` sidecar pair under `EXTRA_DIST`, so this is fixable -- it is just not worth it: the warning is harmless, the code is upstream's, and touching it would mean regenerating that pair for no gain.

No real bug fell out of this. The one candidate worth naming is the ICP reply path in `proxytrack.c`, where a message length lands in an `unsigned short`: the reader caps an ICP message at 16 KB per RFC2186 and NUL-terminates its buffer, so `strlen() + 1` cannot reach 65535 and the field cannot truncate. The cast there is now explicit and carries that reasoning.

Verified on Linux, since MSVC is not available locally: gcc and clang both build clean at `-Wall -Wextra`, and a warning-set diff against an `origin/master` baseline built with identical flags shows nothing new and five sign-compare classes removed — gcc was seeing the same signedness bugs MSVC reports as C4018. `make check` is green at 389 tests. The Windows legs on this PR are the real check.