### PR TITLE
get_ext() copies past the query string, and one byte past its buffer

### DIFF
--- a/src/htsconcat.c
+++ b/src/htsconcat.c
@@ -118,9 +118,12 @@ HTSEXT_API const char *get_ext(char *catbuff, size_t size, const char *fil) {
 
   if (last != 0 && i > last) {
     const size_t len = i - last;
+    /* len characters plus the terminator, with the untrusted len alone */
     if (len < size) {
+      /* bounded on len, so the copy stops at the '?' the loop stopped at; the
+         guard above leaves strlncatbuff's abort arm unreachable */
       catbuff[0] = '\0';
-      strncat(catbuff, &fil[last], size);
+      strlncatbuff(catbuff, &fil[last], size, len);
       return catbuff;
     }
   }

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3411,23 +3411,33 @@ static hts_boolean st_poison_intact(const char *label, const char *buf,
    out whole and nothing may be written past `cap`. */
 static hts_boolean st_getext_case(char *arena, size_t cap, size_t guard,
                                   const char *fil, const char *want) {
+  hts_boolean ok = HTS_TRUE;
   const char *ext;
   size_t from;
 
   memset(arena, ST_POISON, cap + guard);
   ext = get_ext(arena, cap, fil);
+  /* every check runs: a wrong answer must not stop the canary from reporting */
   if (strcmp(ext, want) != 0) {
     fprintf(stderr, "getext: [%s] in %d bytes gave [%s], wanted [%s]\n", fil,
             (int) cap, ext, want);
-    return HTS_FALSE;
+    ok = HTS_FALSE;
   }
-  /* an extension that did not fit is the literal "", leaving the whole arena
-     poisoned; one that fitted ends on its own NUL */
-  from = ext == arena ? strlen(want) + 1 : 0;
+  /* the answer is built in the caller's buffer, and only the refusal is not */
+  if ((ext == arena) != (*want != '\0')) {
+    fprintf(stderr, "getext: [%s] in %d bytes answered from the wrong buffer\n",
+            fil, (int) cap);
+    ok = HTS_FALSE;
+  }
+  /* an extension that did not fit leaves the whole arena poisoned; one that
+     fitted ends on its own NUL */
+  from = ext == arena ? strlen(ext) + 1 : 0;
   if (!st_poison_intact("getext: inside the destination", arena, from, cap))
-    return HTS_FALSE;
-  return st_poison_intact("getext: past the destination", arena, cap,
-                          cap + guard);
+    ok = HTS_FALSE;
+  if (!st_poison_intact("getext: past the destination", arena, cap,
+                        cap + guard))
+    ok = HTS_FALSE;
+  return ok;
 }
 
 /* get_ext() stops at the '?', so a parameterised URL types by its extension,

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3534,6 +3534,50 @@ static int st_getext(httrackp *opt, int argc, char **argv) {
   return rc;
 }
 
+/* The wiring hts_mirror() gives the naming path (htscore.c), and the teardown
+   it owes: a self-test that leaks it cannot be run under LeakSanitizer. */
+static void st_mirror_wiring(httrackp *opt, struct_back **sback,
+                             hash_struct *hash, hts_boolean backing) {
+  *sback = backing ? back_new(opt, opt->maxsoc * 32 + 1024) : NULL;
+  hash_init(opt, hash, opt->urlhack);
+  hash->liens = (const lien_url *const *const *) &opt->liens;
+  opt->hash = hash;
+  hts_record_init(opt);
+}
+
+/* Everything a cache_back holds, freed. Called again mid-test where the cache
+   is reopened read-only, since that drops the handles it already had. */
+static void st_cache_close(httrackp *opt, cache_back *cache) {
+  if (cache->zipOutput != NULL) {
+    zipClose(cache->zipOutput, NULL);
+    cache->zipOutput = NULL;
+  }
+  if (cache->zipInput != NULL) {
+    unzClose(cache->zipInput);
+    cache->zipInput = NULL;
+  }
+  if (cache->lst != NULL) {
+    fclose(cache->lst);
+    cache->lst = opt->state.strc.lst = NULL;
+  }
+  if (cache->txt != NULL) {
+    fclose(cache->txt);
+    cache->txt = NULL;
+  }
+  if (cache->hashtable != NULL)
+    coucal_delete(&cache->hashtable);
+}
+
+/* Torn down in XH_extuninit's order (htscore.c). */
+static void st_mirror_wiring_free(httrackp *opt, cache_back *cache,
+                                  struct_back **sback, hash_struct *hash) {
+  hts_record_free(opt);
+  back_free(sback);
+  st_cache_close(opt, cache);
+  hash_free(hash);
+  opt->hash = NULL; /* it pointed at the caller's stack frame */
+}
+
 static int st_savename(httrackp *opt, int argc, char **argv) {
   struct {
     lien_adrfilsave afs;
@@ -3560,6 +3604,7 @@ static int st_savename(httrackp *opt, int argc, char **argv) {
   int statuscode = HTTP_OK, status = 0;
   int filpad = 0;
   int nosback = 0;
+  int rc = 0;
   int i;
 
   if (argc < 2) {
@@ -3668,10 +3713,7 @@ static int st_savename(httrackp *opt, int argc, char **argv) {
     cr.size = 8;
     cache_add(opt, &cache, &cr, adr, argv[0], sep + 1, 1, NULL);
     freet(cr.adr);
-    if (cache.zipOutput != NULL) {
-      zipClose(cache.zipOutput, NULL);
-      cache.zipOutput = NULL;
-    }
+    st_cache_close(opt, &cache); /* the memset below orphans what it holds */
     memset(&cache, 0, sizeof(cache));
     cache.type = 1;
     cache.log = cache.errlog = stderr;
@@ -3683,12 +3725,7 @@ static int st_savename(httrackp *opt, int argc, char **argv) {
     cache.hashtable = (void *) coucal_new(0);
   }
 
-  sback = nosback ? NULL : back_new(opt, opt->maxsoc * 32 + 1024);
-  /* same wiring as hts_mirror (htscore.c) */
-  hash_init(opt, &hash, opt->urlhack);
-  hash.liens = (const lien_url *const *const *) &opt->liens;
-  opt->hash = &hash;
-  hts_record_init(opt);
+  st_mirror_wiring(opt, &sback, &hash, nosback ? HTS_FALSE : HTS_TRUE);
 
   for (i = 2; i < argc; i++) {
     if (strncmp(argv[i], "prior=", 6) == 0) {
@@ -3698,11 +3735,16 @@ static int st_savename(httrackp *opt, int argc, char **argv) {
 
       if (p2 == NULL) {
         fprintf(stderr, "savename: prior needs adr|fil|sav\n");
-        return 1;
+        freet(dup);
+        rc = 1;
+        goto cleanup;
       }
       *p1 = *p2 = '\0';
-      if (!hts_record_link(opt, dup, p1 + 1, p2 + 1, "", "", NULL))
-        return 1;
+      if (!hts_record_link(opt, dup, p1 + 1, p2 + 1, "", "", NULL)) {
+        freet(dup);
+        rc = 1;
+        goto cleanup;
+      }
       freet(dup);
     }
   }
@@ -3721,7 +3763,10 @@ static int st_savename(httrackp *opt, int argc, char **argv) {
 
     if (fp == NULL || !hts_fwrite_exact(data, n, fp)) {
       fprintf(stderr, "savename: can not write %s\n", bodyfile);
-      return 1;
+      if (fp != NULL)
+        fclose(fp);
+      rc = 1;
+      goto cleanup;
     }
     fclose(fp);
     strcpybuff(headers.url_sav, bodyfile);
@@ -3733,9 +3778,13 @@ static int st_savename(httrackp *opt, int argc, char **argv) {
     (void) UNLINK(bodyfile);
   if (!st_poison_intact("savename: save[]", probe.canary, 0,
                         sizeof(probe.canary)))
-    return 1;
-  printf("savename: %s\n", afs->save);
-  return 0;
+    rc = 1;
+  else
+    printf("savename: %s\n", afs->save);
+
+cleanup:
+  st_mirror_wiring_free(opt, &cache, &sback, &hash);
+  return rc;
 }
 
 /* url_savename_addstr() takes attacker-controlled link text and must clip to
@@ -3980,6 +4029,7 @@ static int st_addlink(httrackp *opt, int argc, char **argv) {
   struct_back *sback;
   hash_struct hash;
   int ptr = 0;
+  int rc = 0;
   int i;
 
   (void) argc;
@@ -3987,12 +4037,7 @@ static int st_addlink(httrackp *opt, int argc, char **argv) {
 
   memset(&cache, 0, sizeof(cache));
   cache.hashtable = (void *) coucal_new(0);
-  sback = back_new(opt, opt->maxsoc * 32 + 1024);
-  /* same wiring as hts_mirror (htscore.c) */
-  hash_init(opt, &hash, opt->urlhack);
-  hash.liens = (const lien_url *const *const *) &opt->liens;
-  opt->hash = &hash;
-  hts_record_init(opt);
+  st_mirror_wiring(opt, &sback, &hash, HTS_TRUE);
 
   memset(&str, 0, sizeof(str));
   str.opt = opt;
@@ -4019,20 +4064,26 @@ static int st_addlink(httrackp *opt, int argc, char **argv) {
     strcpybuff(link, lnk[i]);
     str.localLink = loc;
     str.localLinkSize = (int) sizeof(loc);
-    if (!hts_record_link(opt, "www.example.com", fil[i], "", "", "", ""))
-      return 1;
+    if (!hts_record_link(opt, "www.example.com", fil[i], "", "", "", "")) {
+      rc = 1;
+      goto cleanup;
+    }
     ptr = heap_top_index();
     str.url_host = heap(ptr)->adr;
     str.url_file = heap(ptr)->fil;
     assertf(htsAddLink(&str, link) == 0); /* refused by the wizard either way */
     if (strcmp(loc, want[i]) != 0) {
       fprintf(stderr, "addlink[%d]: got '%s' want '%s'\n", i, loc, want[i]);
-      return 1;
+      rc = 1;
+      goto cleanup;
     }
   }
 
   printf("addlink self-test OK\n");
-  return 0;
+
+cleanup:
+  st_mirror_wiring_free(opt, &cache, &sback, &hash);
+  return rc;
 }
 
 static int st_cache(httrackp *opt, int argc, char **argv) {

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3384,13 +3384,13 @@ static int st_growsize(httrackp *opt, int argc, char **argv) {
   return rc;
 }
 
-/* save[] is the last member of lien_adrfilsave, so a poisoned run right behind
-   it catches whatever the naming path appends past its end (#1269). */
-#define ST_SAVENAME_POISON 0x5a
+/* A poisoned run right behind a destination catches whatever a bounded write
+   appends past its end; save[] ends lien_adrfilsave (#1269). */
+#define ST_POISON 0x5a
 #define ST_SAVENAME_CANARY 128
 
 /* an off-by-one terminator writes a NUL, which a zero poison could not see */
-enum { st_poison_is_not_nul = 1 / (ST_SAVENAME_POISON != 0) };
+enum { st_poison_is_not_nul = 1 / (ST_POISON != 0) };
 
 /* Does the run from `from` to `size` still hold the poison? */
 static hts_boolean st_poison_intact(const char *label, const char *buf,
@@ -3398,13 +3398,130 @@ static hts_boolean st_poison_intact(const char *label, const char *buf,
   size_t i;
 
   for (i = size; i > from; i--) {
-    if (buf[i - 1] != (char) ST_SAVENAME_POISON) {
+    if (buf[i - 1] != (char) ST_POISON) {
       fprintf(stderr, "%s: wrote %d byte(s) past the end\n", label,
               (int) (i - from));
       return HTS_FALSE;
     }
   }
   return HTS_TRUE;
+}
+
+/* One get_ext() into a poisoned arena of `cap` bytes: the extension must come
+   out whole and nothing may be written past `cap`. */
+static hts_boolean st_getext_case(char *arena, size_t cap, size_t guard,
+                                  const char *fil, const char *want) {
+  const char *ext;
+  size_t from;
+
+  memset(arena, ST_POISON, cap + guard);
+  ext = get_ext(arena, cap, fil);
+  if (strcmp(ext, want) != 0) {
+    fprintf(stderr, "getext: [%s] in %d bytes gave [%s], wanted [%s]\n", fil,
+            (int) cap, ext, want);
+    return HTS_FALSE;
+  }
+  /* an extension that did not fit is the literal "", leaving the whole arena
+     poisoned; one that fitted ends on its own NUL */
+  from = ext == arena ? strlen(want) + 1 : 0;
+  if (!st_poison_intact("getext: inside the destination", arena, from, cap))
+    return HTS_FALSE;
+  return st_poison_intact("getext: past the destination", arena, cap,
+                          cap + guard);
+}
+
+/* get_ext() stops at the '?', so a parameterised URL types by its extension,
+   and copies the length it measured rather than the destination size, so a
+   long query cannot put a terminator past the end (#1433). */
+static int st_getext(httrackp *opt, int argc, char **argv) {
+  static const struct {
+    const char *fil;
+    const char *want;
+  } cases[] = {
+      {"x.php", "php"},
+      {"x.php?id=3", "php"},
+      /* the query is not scanned for dots */
+      {"x.php?id=3.txt", "php"},
+      {"/a/b.c?Q123456789012345678901234567890", "c"},
+      {"x.PHP?a", "PHP"}, /* no case folding */
+      {"x.php?", "php"},
+      {"foo", ""},
+      {"x.", ""},
+      {"?x.php", ""},
+  };
+
+  /* dodging sizeof(void *), which RUNTIME_TIME_CHECK_SIZE takes for a caller
+     that passed sizeof() of a pointer */
+  static const size_t caps[] = {1, 2, 3, 5, 6, 16, 64};
+  /* longer than any capacity below, so a size-bounded copy runs off the end */
+  static const char query[] = "?q=00000000001111111111222222222233333333334"
+                              "4444444445555555555666666666677777777778888";
+  const size_t guard = 64;
+  size_t c, k;
+  int rc = 0;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+
+  /* the semantics, in a destination nothing here comes close to filling */
+  {
+    char *arena = malloct(256 + guard);
+
+    assertf(arena != NULL);
+    for (k = 0; k < sizeof(cases) / sizeof(cases[0]); k++) {
+      if (!st_getext_case(arena, 256, guard, cases[k].fil, cases[k].want))
+        rc = 1;
+    }
+    freet(arena);
+  }
+
+  /* the point of the query half: a parameterised URL types as the bare one */
+  {
+    char buf[16];
+
+    if (!is_dyntype(get_ext(buf, sizeof(buf), "x.php?id=3")) ||
+        !is_dyntype(get_ext(buf, sizeof(buf), "x.php"))) {
+      fprintf(stderr, "getext: a parameterised .php is not a dynamic type\n");
+      rc = 1;
+    }
+  }
+
+  /* every capacity against extensions straddling its bound, with and without a
+     query behind them: a one-size-fits-all bound shows up as the wrong verdict
+     on the small ones */
+  for (c = 0; c < sizeof(caps) / sizeof(caps[0]); c++) {
+    const size_t cap = caps[c];
+    const size_t maxext = cap + guard;
+    char *arena = malloct(cap + guard);
+    char *fil = malloct(5 + maxext + sizeof(query));
+    char *want = malloct(maxext + 1);
+
+    assertf(arena != NULL && fil != NULL && want != NULL);
+    for (k = 1; k <= maxext; k++) {
+      size_t i;
+
+      /* bytes that vary, or a copy taken from the wrong offset would match */
+      memcpy(fil, "/d/f.", 5);
+      for (i = 0; i < k; i++)
+        fil[5 + i] = (char) ('a' + i % 26);
+      fil[5 + k] = '\0';
+      memcpy(want, fil + 5, k + 1);
+      if (k >= cap) /* k characters plus the NUL do not fit */
+        want[0] = '\0';
+      if (!st_getext_case(arena, cap, guard, fil, want))
+        rc = 1;
+      memcpy(fil + 5 + k, query, sizeof(query));
+      if (!st_getext_case(arena, cap, guard, fil, want))
+        rc = 1;
+    }
+    freet(arena);
+    freet(fil);
+    freet(want);
+  }
+
+  printf("getext self-test %s\n", rc == 0 ? "OK" : "FAILED");
+  return rc;
 }
 
 static int st_savename(httrackp *opt, int argc, char **argv) {
@@ -3490,7 +3607,7 @@ static int st_savename(httrackp *opt, int argc, char **argv) {
     return 1;
   }
   memset(&probe, 0, sizeof(probe));
-  memset(probe.canary, ST_SAVENAME_POISON, sizeof(probe.canary));
+  memset(probe.canary, ST_POISON, sizeof(probe.canary));
   strcpybuff(afs->af.adr, adr);
   if (filpad > 0) {
     /* '*' stands for filpad bytes: a link longer than argv can carry, argv
@@ -3651,7 +3768,7 @@ static int st_savename_addstr(httrackp *opt, int argc, char **argv) {
 
     snprintf(label, sizeof(label), "savename-addstr: '%s' at dsize %d",
              cases[k].add, (int) cases[k].dsize);
-    memset(buf, ST_SAVENAME_POISON, sizeof(buf));
+    memset(buf, ST_POISON, sizeof(buf));
     memcpy(buf, cases[k].seed, seedlen + 1);
     url_savename_addstr(buf, cases[k].dsize, cases[k].add);
     if (strcmp(buf, cases[k].want) != 0) {
@@ -3674,7 +3791,7 @@ static int st_savename_addstr(httrackp *opt, int argc, char **argv) {
 
     snprintf(label, sizeof(label), "savename-addstr: long link at dsize %d",
              (int) dsize);
-    memset(big, ST_SAVENAME_POISON, sizeof(big));
+    memset(big, ST_POISON, sizeof(big));
     big[0] = '\0';
     memset(src, 'a', sizeof(src) - 1);
     src[sizeof(src) - 1] = '\0';
@@ -3735,7 +3852,7 @@ static int st_savename_addtail(httrackp *opt, int argc, char **argv) {
 
     snprintf(label, sizeof(label), "savename-addtail: '%s%s' at dsize %d",
              cases[k].sep, cases[k].add, (int) cases[k].dsize);
-    memset(buf, ST_SAVENAME_POISON, sizeof(buf));
+    memset(buf, ST_POISON, sizeof(buf));
     memcpy(buf, cases[k].seed, seedlen + 1);
     url_savename_addtail(buf, cases[k].dsize, cases[k].sep, cases[k].add);
     if (strcmp(buf, cases[k].want) != 0) {
@@ -3754,7 +3871,7 @@ static int st_savename_addtail(httrackp *opt, int argc, char **argv) {
     char BIGSTK big[HTS_URLMAXSIZE * 2 + ST_SAVENAME_CANARY];
     const size_t dsize = HTS_URLMAXSIZE * 2;
 
-    memset(big, ST_SAVENAME_POISON, sizeof(big));
+    memset(big, ST_POISON, sizeof(big));
     memset(big, 'a', dsize - 1);
     big[dsize - 1] = '\0';
     url_savename_addtail(big, dsize, ".", "html");
@@ -12760,6 +12877,9 @@ static const struct selftest_entry {
      "Content-Range parse integer safety", st_crange},
     {"xfread-limit", "", "in-memory receive buffer size bound",
      st_xfread_limit},
+    {"getext", "",
+     "extension parsing stops at the query and inside the buffer (#1433)",
+     st_getext},
     {"savename", "<fil> <content-type> [key=value ...]",
      "local save-name for a URL", st_savename},
     {"savename-addstr", "",

--- a/tests/367_engine-getext.test
+++ b/tests/367_engine-getext.test
@@ -10,3 +10,21 @@ set -euo pipefail
 # and a long enough one would put a terminator one byte past the buffer (#1433).
 
 assert_selftest "getext self-test OK" getext
+
+# Downstream of that: url_savename() strips at the literal '?' before it
+# percent-decodes, so a %3F in a path reaches get_ext() as a real '?'. The
+# extension now stops there, is recognized, and gets cut, where it used to be
+# kept whole as an unknown one. Mirrors holding such a name rename once.
+selftest_queue 'savename: /dev/null/www.example.com/x.html' savename \
+    '/x.php%3Fid=3' text/html
+selftest_queue 'savename: /dev/null/www.example.com/a.html' savename \
+    '/a.gz%3Fk' text/html
+
+# A plain query is untouched: it never reaches get_ext() at all.
+selftest_queue 'savename: /dev/null/www.example.com/xd708.html' savename \
+    '/x.php?id=3' text/html
+# And an unknown trailing token still is not an extension (#115).
+selftest_queue 'savename: /dev/null/www.example.com/article-1.884291.html' \
+    savename '/article-1.884291' text/html
+
+selftest_run_queued

--- a/tests/367_engine-getext.test
+++ b/tests/367_engine-getext.test
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+# get_ext() must stop at the '?' and copy the length it measured, not the
+# destination size: the query would otherwise come back glued to the extension,
+# and a long enough one would put a terminator one byte past the buffer (#1433).
+
+assert_selftest "getext self-test OK" getext


### PR DESCRIPTION
`get_ext()` walks a name as far as the `?` to find where the extension starts, then copies it out — bounded on the destination size rather than on the length the loop just computed. So the copy runs past the `?` to the end of the string and the stop the loop went to the trouble of finding is undone: `is_dyntype("php?id=3")` answers 0 where `is_dyntype("php")` answers 1, and anything typing a parameterised URL by its extension gets the wrong answer. `strncat` also writes n characters *plus* a terminator, so a query long enough to fill the buffer puts a NUL one byte past its end.

Nothing in the tree reaches that overflow: all six callers pass a URL-sized buffer, so it is a latent trap in an exported entry point rather than a live one. But the size is the caller's to choose and the input is a URL off the wire.

The copy is now bounded on the computed length via `strlncatbuff`, which takes the destination capacity as a second, independent bound. That family aborts on overflow, which would be the wrong answer for wire input, and the existing `len < size` guard is what makes it safe to use here: it already keeps the untrusted length alone on one side with room for the terminator, and refuses an extension that will not fit rather than clipping it into something that could match a different type. Behind it the abort arm is unreachable, since `catbuff[0] = '\0'` forces the appended length to be exactly `len` and the guard is textually the test the abort would make.

**One caller changes, and it renames files.** `url_savename()` strips at the literal `'?'` *before* it percent-decodes, so a `%3F` in a path arrives at `get_ext()` as a real `'?'`. `http://h/x.php%3Fid=3` saves as `x.php_id=3.html` today and as `x.html` after this change; `a.gz%3Fk` goes from `a.gz_k.html` to `a.html`. What flips is `known_ext` at htsname.c:969 — the old extension used to read as the unknown token `php?id=3` and be kept, and now reads as `php`, is recognized, and is cut. Only a percent-encoded `?` inside a path is affected: a plain query never reaches `get_ext()` at all, and the `/article-1.884291` case of #115 does not move. Distinct URLs still get distinct names through the `-2` suffix, so nothing collides and nothing is lost, but a user updating an existing mirror of such a URL will see those files renamed once.

I did not try to preserve the old names, because doing so needs the extension to carry `?id=3` again, which is the bug being fixed, and `php` is the better answer. Happy to be overruled — the test pins the names either way.

`367_engine-getext.test` drives a new `-#test=getext` and pins those four save-names. The self-test sweeps seven destination capacities against extensions straddling each one, with and without a long query behind them, and runs each case in an arena poisoned with a non-zero byte: a zero canary cannot see the stray NUL an off-by-one terminator writes, which is exactly this bug, and neither can ASan, since the byte lands inside the same allocation. Every check runs even after a wrong answer, so one detector cannot mask another. Proven against five mutants — a stray NUL past the end, a stray `'X'` past the end, a stray `'X'` inside the buffer, the original `strncat`, and an answer returned from a file-static buffer — each of which the test names and fails on. `ST_SAVENAME_POISON` loses its `SAVENAME` now that a second test uses the helper it belongs to.

Last, the naming self-tests can now be run under LeakSanitizer. `st_savename()` and `st_addlink()` built `hts_mirror()`'s wiring and never freed it — 79MB over four cases, nearly all of it `back_new()`'s slot array — which is exactly where a genuine engine leak would have hidden. They now share that setup and get the teardown `XH_extuninit` does, plus the cache handles the `cached=` branch drops when it reopens read-only, and `opt->hash` no longer keeps pointing at a returned stack frame. The whole savename and addlink family passes under `detect_leaks=1`, where three of them failed before.

Closes #1433