### PR TITLE
Option values that mirrored the wrong thing at exit 0

### DIFF
--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -391,7 +391,15 @@ static const char *optalias_suffix(const char *type, const char *value) {
   return NULL;
 }
 
-/* A bare digit run short enough for -N to read it as a preset number. */
+hts_boolean optalias_digits_fit(const char *digits, size_t len) {
+  size_t i;
+
+  for (i = 0; i < len && digits[i] == '0'; i++) {
+  }
+  return len - i <= HTS_SAVENAME_PRESET_MAX_DIGITS ? HTS_TRUE : HTS_FALSE;
+}
+
+/* A bare digit run -N reads as a preset number. */
 static hts_boolean optalias_is_digits(const char *value) {
   size_t i;
 
@@ -399,7 +407,7 @@ static hts_boolean optalias_is_digits(const char *value) {
     if (!isdigit((unsigned char) value[i]))
       return HTS_FALSE;
   }
-  return i != 0 && i <= HTS_SAVENAME_PRESET_MAX_DIGITS ? HTS_TRUE : HTS_FALSE;
+  return i != 0 && optalias_digits_fit(value, i) ? HTS_TRUE : HTS_FALSE;
 }
 
 /* Whether a "paramn" value glues onto the short form the way "param" does: a
@@ -413,7 +421,7 @@ static hts_boolean optalias_paramn_glues(const char *value) {
     return HTS_TRUE;
   for (i = 0; isdigit((unsigned char) value[i]); i++) {
   }
-  if (i == 0 || i > HTS_SAVENAME_PRESET_MAX_DIGITS)
+  if (i == 0 || !optalias_digits_fit(value, i))
     return HTS_FALSE;
   return strchr(value + i, '/') == NULL && strchr(value + i, '.') == NULL
              ? HTS_TRUE

--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -574,7 +574,10 @@ int optalias_check(int argc, const char *const *argv, int n_arg,
             if (strcmp(param, "off") == 0)
               strlcatbuff(return_argv[0], "0", return_argv_size);
             else if (strcmp(param, "on") == 0) {
-              // on is the default
+              /* a bare -N reads the next word as a template and would eat the
+                 URL, so "on" names the default preset instead (#1434) */
+              if (strcmp(hts_optalias[pos][2], "paramn") == 0)
+                strlcatbuff(return_argv[0], "0", return_argv_size);
             } else
               strlcatbuff(return_argv[0], param, return_argv_size);
           } else if (param[0] != '\0') {

--- a/src/htsalias.h
+++ b/src/htsalias.h
@@ -39,9 +39,13 @@ Please visit our Website: http://www.httrack.com
 
 /* Library internal definictions */
 #ifdef HTS_INTERNAL_BYTECODE
-/* Longest digit run -N reads as a preset number; a longer one is out of range
-   on every int width and falls back to the default layout. */
+/* Longest significant digit run -N and -L read as a number; more overflows
+   every int width and falls back to the option's default. */
 #define HTS_SAVENAME_PRESET_MAX_DIGITS 9
+
+/* Whether the LEN-digit run at DIGITS converts to an int rather than
+   overflowing: leading zeros cost nothing, so 0000000001 is the value 1. */
+hts_boolean optalias_digits_fit(const char *digits, size_t len);
 
 extern const char *hts_optalias[][4];
 int optalias_check(int argc, const char *const *argv, int n_arg,

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -1301,25 +1301,20 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
               for (ndigits = 0; isdigit((unsigned char) *(com + 1)); ndigits++)
                 com++;
               if (ndigits > 0)
-                opt->savename_type = ndigits <= HTS_SAVENAME_PRESET_MAX_DIGITS
-                                         ? atoi(digits)
-                                         : 0;
+                opt->savename_type =
+                    optalias_digits_fit(digits, ndigits) ? atoi(digits) : 0;
             }
             break;
           case 'L': {
-            /* L1 is the starred default, and what a bare -L selects: sscanf
-               converted nothing from one and re-mapped the value already
-               stored, so -L meant 8.3 and -L1 -L meant it too (#1434). */
+            /* L1 is the starred default, and what a bare -L selects; a run
+               too long to convert lands there too. */
             const char *const digits = com + 1;
             int ndigits, level = 1;
 
             for (ndigits = 0; isdigit((unsigned char) *(com + 1)); ndigits++)
               com++;
-            /* bounded like -N's preset run: longer is out of range on every
-               int width, which is the ISO9660 arm anyway */
-            if (ndigits > 0)
-              level =
-                  ndigits <= HTS_SAVENAME_PRESET_MAX_DIGITS ? atoi(digits) : 2;
+            if (ndigits > 0 && optalias_digits_fit(digits, ndigits))
+              level = atoi(digits);
             switch (level) {
             case 0: // 8-3 (ISO9660 L1)
               opt->savename_83 = HTS_SAVENAME_83_DOS;

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -1307,8 +1307,20 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
             }
             break;
           case 'L': {
-            sscanf(com + 1, "%d", (int *) &opt->savename_83);
-            switch (opt->savename_83) {
+            /* L1 is the starred default, and what a bare -L selects: sscanf
+               converted nothing from one and re-mapped the value already
+               stored, so -L meant 8.3 and -L1 -L meant it too (#1434). */
+            const char *const digits = com + 1;
+            int ndigits, level = 1;
+
+            for (ndigits = 0; isdigit((unsigned char) *(com + 1)); ndigits++)
+              com++;
+            /* bounded like -N's preset run: longer is out of range on every
+               int width, which is the ISO9660 arm anyway */
+            if (ndigits > 0)
+              level =
+                  ndigits <= HTS_SAVENAME_PRESET_MAX_DIGITS ? atoi(digits) : 2;
+            switch (level) {
             case 0: // 8-3 (ISO9660 L1)
               opt->savename_83 = HTS_SAVENAME_83_DOS;
               break;
@@ -1319,8 +1331,6 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
               opt->savename_83 = HTS_SAVENAME_83_ISO9660;
               break;
             }
-            while (isdigit((unsigned char) *(com + 1)))
-              com++;
           } break;
           case 's':
             if (isdigit((unsigned char) *(com + 1))) {

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4915,7 +4915,11 @@ static int st_optalias(httrackp *opt, int argc, char **argv) {
   EXPANDS("-N1L0", "--structure", "1L0");
   EXPANDS("-N1%c8", "--structure=1%c8", NULL);
   EXPANDS("-N0", "--structure=off", NULL);
-  EXPANDS("-N", "--structure=on", NULL);
+  /* both name the default preset: a bare -N would take the next word, and
+     with a URL there it mirrored nothing (#1434) */
+  EXPANDS("-N0", "--structure=on", NULL);
+  EXPANDS("-N0", "--structure", "on");
+  assertf(used == 2);
   /* a template may open with a digit, so the leading digits do not decide it */
   EXPANDS("-N 2col/%n.%t", "--structure=2col/%n.%t", NULL);
   EXPANDS("-N 2col/%n.%t", "--structure", "2col/%n.%t");

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4975,6 +4975,10 @@ static int st_optalias(httrackp *opt, int argc, char **argv) {
      template either the value has nowhere left to go */
   EXPANDS("-N999999999", "--structure=999999999", NULL);
   REFUSES("--structure=4294967295", NULL);
+  /* leading zeros are not part of the number: this is the preset 1 */
+  EXPANDS("-N0000000001", "--structure=0000000001", NULL);
+  EXPANDS("-N0000000001", "-N", "0000000001");
+  assertf(used == 2);
   /* a %-free value would map every URL onto one name, so it is a typo */
   REFUSES("--structure=OFF", NULL);
   REFUSES("--structure=flat", NULL);

--- a/tests/359_local-structure-template.test
+++ b/tests/359_local-structure-template.test
@@ -80,11 +80,11 @@ layout WEB/PAGE.HTM --structure 1L0
 layout web/page.html --structure=1c8
 layout web/page.html --structure=1%c8
 
-# param maps off to 0 and swallows on, and every other param row still does.
+# param maps off to 0, and on to the bare short form, which for -N would read
+# the next word as a template: both name the default preset here (#1434).
 layout "${default_layout}" --structure=off
-run --structure=on
-test "${RC}" -ne 0 || fail '--structure=on was accepted as a template named on'
-test "${RC}" -ne 134 || fail '--structure=on aborted'
+layout "${default_layout}" --structure=on
+layout "${default_layout}" --structure on
 
 # A template reaches the engine whatever spelling carried it. The literal "tpl/"
 # is the point: no preset can produce it, so this cannot pass on a fallback.

--- a/tests/368_engine-option-bare-value.test
+++ b/tests/368_engine-option-bare-value.test
@@ -1,0 +1,104 @@
+#!/bin/bash
+#
+# A long option value that maps to the bare short form used to mirror the wrong
+# thing at exit 0: --structure=on became a bare -N, which reads the next word as
+# a template and ate the URL, and --long-names= became a bare -L, which selected
+# DOS 8.3 names (#1434).
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_barevalue.XXXXXX") || fail "no tmpdir"
+cleanup_push rm -rf "${tmp}"
+
+assert_selftest "optalias self-test OK" optalias
+
+echo '<html><body>hello</body></html>' >"${tmp}/page.html"
+url="file://${tmp}/page.html"
+out=${tmp}/out
+
+crawl() { # crawl ARG...
+    rm -rf "${out}"
+    mkdir -p "${out}"
+    RC=0
+    httrack -O "${out}" --quiet -n "$@" >"${tmp}/log" 2>&1 || RC=$?
+}
+
+# Basenames of the mirror, so the checks read what was written rather than a
+# path this host may spell differently (macOS $TMPDIR, Windows ':' -> '_').
+saved() { find "${out}" -type f ! -path '*hts-cache*' | sed 's|.*/||' | sort; }
+has_name() { grep -Fqx "$1" <<<"$(saved)"; }
+
+# The discriminator, proven on the two spellings that ask for each layout:
+# long names keep page.html, DOS 8.3 truncates it to PAGE.HTM.
+crawl --long-names=1 "${url}"
+assert_eq 0 "${RC}" "--long-names=1 exited"
+has_name page.html || fail_dump "--long-names=1 wrote no long name" "${tmp}/log"
+crawl --long-names=0 "${url}"
+assert_eq 0 "${RC}" "--long-names=0 exited"
+has_name PAGE.HTM || fail_dump "--long-names=0 wrote no 8.3 name" "${tmp}/log"
+
+longnames() { # longnames ARG...
+    crawl "$@"
+    assert_eq 0 "${RC}" "$* exited"
+    has_name page.html || fail_dump "$* wrote 8.3 names" "${tmp}/log"
+}
+
+dosnames() { # dosnames ARG...
+    crawl "$@"
+    assert_eq 0 "${RC}" "$* exited"
+    has_name PAGE.HTM || fail_dump "$* lost its 8.3 names" "${tmp}/log"
+}
+
+# -L is "long names", whose starred default is L1, so every spelling that leaves
+# it bare selects them. The empty value is the config file's "long-names=" too.
+longnames --long-names= "${url}"
+longnames --long-names=on "${url}"
+longnames --long-names "" "${url}"
+longnames -L "${url}"
+# a bare -L no longer re-reads the layout the previous one mapped
+longnames -L1 -L "${url}"
+# ...and the spellings that ask for 8.3 still get it
+dosnames --long-names=off "${url}"
+dosnames -L0 "${url}"
+dosnames -L1 -L0 "${url}"
+
+mirrored() { # mirrored ARG...
+    crawl "$@"
+    assert_eq 0 "${RC}" "$* exited"
+    has_name page.html || fail_dump "$* mirrored nothing" "${tmp}/log"
+}
+
+# The URL used to be read as -N's template, leaving nothing but the top index.
+mirrored --structure=on "${url}"
+mirrored --structure on "${url}"
+
+# on and off both name the default preset, so the two mirrors must match.
+crawl --structure=off "${url}"
+off=$(saved)
+crawl --structure=on "${url}"
+assert_eq "${off}" "$(saved)" "--structure=on is not the default structure"
+
+# What #1418 deliberately glues onto -N: a preset, and a preset trailed by more
+# short options, whose -L0 tail is visible on disk.
+crawl --structure=1 "${url}"
+assert_eq 0 "${RC}" "--structure=1 exited"
+test -n "$(find "${out}" -type d -name web)" ||
+    fail_dump "--structure=1 lost its preset" "${tmp}/log"
+dosnames --structure=1L0 "${url}"
+# a %-carrying template still detaches
+mirrored "--structure=%h%p/%n%q.%t" "${url}"
+
+# A value that is neither glued onto -N and re-parsed as more short options,
+# dropping the top index at exit 0; it stays refused (#1418).
+crawl --structure=I0 "${url}"
+{ test "${RC}" -ne 0 && test "${RC}" -ne 134; } ||
+    fail_dump "--structure=I0 not refused (exit ${RC})" "${tmp}/log"
+grep -q 'does not take the value' "${tmp}/log" ||
+    fail_dump "--structure=I0 refused without saying why" "${tmp}/log"
+! has_name page.html || fail_dump "--structure=I0 still mirrored" "${tmp}/log"
+
+echo "PASS"

--- a/tests/368_engine-option-bare-value.test
+++ b/tests/368_engine-option-bare-value.test
@@ -3,7 +3,8 @@
 # A long option value that maps to the bare short form used to mirror the wrong
 # thing at exit 0: --structure=on became a bare -N, which reads the next word as
 # a template and ate the URL, and --long-names= became a bare -L, which selected
-# DOS 8.3 names (#1434).
+# DOS 8.3 names (#1434). Both digit runs are read by value, so a zero-padded
+# 0000000001 is the same as 1 rather than an overlong run.
 
 set -euo pipefail
 
@@ -11,7 +12,9 @@ testdir=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=tests/testlib.sh
 . "${testdir}/testlib.sh"
 
-tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_barevalue.XXXXXX") || fail "no tmpdir"
+tmpbase=${TMPDIR:-/tmp}
+# Slash-stripped: the engine normalizes a "//" away, failing every layout below.
+tmp=$(mktemp -d "${tmpbase%/}/httrack_barevalue.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "${tmp}"
 
 assert_selftest "optalias self-test OK" optalias
@@ -31,6 +34,9 @@ crawl() { # crawl ARG...
 # path this host may spell differently (macOS $TMPDIR, Windows ':' -> '_').
 saved() { find "${out}" -type f ! -path '*hts-cache*' | sed 's|.*/||' | sort; }
 has_name() { grep -Fqx "$1" <<<"$(saved)"; }
+# The directories too, which is where a preset or a template is visible.
+tree_names() { find "${out}" ! -path '*hts-cache*' | sed 's|.*/||' | sort; }
+has_dir() { test -n "$(find "${out}" -type d -name "$1")"; }
 
 # The discriminator, proven on the two spellings that ask for each layout:
 # long names keep page.html, DOS 8.3 truncates it to PAGE.HTM.
@@ -44,13 +50,15 @@ has_name PAGE.HTM || fail_dump "--long-names=0 wrote no 8.3 name" "${tmp}/log"
 longnames() { # longnames ARG...
     crawl "$@"
     assert_eq 0 "${RC}" "$* exited"
-    has_name page.html || fail_dump "$* wrote 8.3 names" "${tmp}/log"
+    has_name page.html || fail_dump "$* wrote no long name" "${tmp}/log"
+    ! has_name PAGE.HTM || fail_dump "$* wrote an 8.3 name too" "${tmp}/log"
 }
 
 dosnames() { # dosnames ARG...
     crawl "$@"
     assert_eq 0 "${RC}" "$* exited"
-    has_name PAGE.HTM || fail_dump "$* lost its 8.3 names" "${tmp}/log"
+    has_name PAGE.HTM || fail_dump "$* wrote no 8.3 name" "${tmp}/log"
+    ! has_name page.html || fail_dump "$* wrote a long name too" "${tmp}/log"
 }
 
 # -L is "long names", whose starred default is L1, so every spelling that leaves
@@ -66,6 +74,13 @@ dosnames --long-names=off "${url}"
 dosnames -L0 "${url}"
 dosnames -L1 -L0 "${url}"
 
+# The level is the value of the digit run, not its length: 0000000001 is L1 and
+# 0000000000 is L0, where a run counted whole falls off the bound into ISO9660.
+longnames --long-names=0000000001 "${url}"
+longnames -L0000000001 "${url}"
+dosnames --long-names=0000000000 "${url}"
+dosnames -L0000000000 "${url}"
+
 mirrored() { # mirrored ARG...
     crawl "$@"
     assert_eq 0 "${RC}" "$* exited"
@@ -76,24 +91,39 @@ mirrored() { # mirrored ARG...
 mirrored --structure=on "${url}"
 mirrored --structure on "${url}"
 
-# on and off both name the default preset, so the two mirrors must match.
+# on and off both name the default preset, so the two trees must match, paths
+# included: a preset would put the page under a directory of its own.
 crawl --structure=off "${url}"
-off=$(saved)
+off=$(tree_names)
 crawl --structure=on "${url}"
-assert_eq "${off}" "$(saved)" "--structure=on is not the default structure"
+assert_eq "${off}" "$(tree_names)" "--structure=on is not the default structure"
 
 # What #1418 deliberately glues onto -N: a preset, and a preset trailed by more
-# short options, whose -L0 tail is visible on disk.
-crawl --structure=1 "${url}"
-assert_eq 0 "${RC}" "--structure=1 exited"
-test -n "$(find "${out}" -type d -name web)" ||
-    fail_dump "--structure=1 lost its preset" "${tmp}/log"
+# short options, whose -L0 tail is visible on disk. web/ without html/ is preset
+# 1 and not 5, which no fallback to the default layout produces either.
+preset1() { # preset1 ARG...
+    crawl "$@"
+    assert_eq 0 "${RC}" "$* exited"
+    has_dir web || has_dir WEB || fail_dump "$* lost its preset" "${tmp}/log"
+    if has_dir html || has_dir HTML; then
+        fail_dump "$* landed on another preset" "${tmp}/log"
+    fi
+}
+preset1 --structure=1 "${url}"
+preset1 --structure=1L0 "${url}"
 dosnames --structure=1L0 "${url}"
-# a %-carrying template still detaches
-mirrored "--structure=%h%p/%n%q.%t" "${url}"
+# the same run by value, which the length bound refused outright
+preset1 --structure=0000000001 "${url}"
+preset1 -N0000000001 "${url}"
 
-# A value that is neither glued onto -N and re-parsed as more short options,
-# dropping the top index at exit 0; it stays refused (#1418).
+# A %-carrying template still detaches, and reaches the engine whole: the
+# literal tpl/ is the point, since no preset produces it.
+crawl "--structure=tpl/%n.%t" "${url}"
+assert_eq 0 "${RC}" "--structure template exited"
+has_dir tpl || fail_dump "--structure template never reached -N" "${tmp}/log"
+
+# Anything else glued onto -N and was re-parsed as more short options, dropping
+# the top index at exit 0. Refused since #1418.
 crawl --structure=I0 "${url}"
 { test "${RC}" -ne 0 && test "${RC}" -ne 134; } ||
     fail_dump "--structure=I0 not refused (exit ${RC})" "${tmp}/log"


### PR DESCRIPTION
Two of the three spellings in #1434 mirrored the wrong thing at exit 0, both because the value mapped onto the bare short form.

`--structure=on` expanded to a bare `-N`, which reads the next word as a user template, so `--structure=on <URL>` swallowed the URL and mirrored nothing. "on" now names the default preset (`-N0`), the layout "off" already selected; #1418's glue rules are otherwise untouched.

`--long-names=` expanded to a bare `-L`, whose `sscanf` converted nothing and left the switch to re-map the value already stored, landing on DOS 8.3 names (`-L1 -L` did the same). Rather than refuse the empty value I fixed the short form: a bare `-L` now selects L1, the default the help and man page already star. Refusing would have taken `sockets=` and the config-file `long-names=` spelling with it, and this way the empty value means the option's own default. `-L0`, `--long-names=off` and `--long-names=2` are unchanged.

Rewriting that parse surfaced a third bug, pre-existing and folded in here: the digit-run bound #1418 added counts digits rather than reading the value, so a zero-padded run falls off it. `-L0000000001` selected ISO9660, `-N0000000001` lost its preset, and `--structure=0000000001` was refused. `optalias_digits_fit` skips the leading zeros first, shared by the four sites that read such a run.

The 27 `param` rows keep #1427's 16-character cap: its bound is a magnitude, not a run length, so `optalias_digits_fit` does not fit there — 9 significant digits would refuse `--advanced-maxlinks=2000000000`, and it cannot see the second operand of `-m N,N2`. Filed as #1437.

The third spelling in the issue, `--structure=I0`, has been refused since #1418 landed after the issue was measured, and test 368 pins that. What survives is `--structure=8I0`: the digits-then-cluster form #1418 glues on purpose, and the same shape as the `--structure=1L0` that #1427's test pins as accepted. No rule separates the two, so that one wants a decision rather than a patch.

Closes #1434
