### PR TITLE
A param option's value is bounded by length where a magnitude is meant

### DIFF
--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -39,7 +39,9 @@ Please visit our Website: http://www.httrack.com
 #include "htsglobal.h"
 #include "htslib.h"
 
+#include <errno.h>
 #include <limits.h>
+#include <stdint.h>
 
 /*
   Aliases for command-line and config file definitions
@@ -430,29 +432,56 @@ static char optalias_param_separator(const char *command) {
   return '\0';
 }
 
+/* The widest value the short form's own parser holds: -m, -M and -G read an
+   LLint, and -%c a float no strtoll-sized run overflows. */
+static int64_t optalias_param_max(const char *command) {
+  if (strcmp(command, "-m") == 0 || strcmp(command, "-M") == 0 ||
+      strcmp(command, "-G") == 0 || strcmp(command, "-%c") == 0)
+    return INT64_MAX;
+  return INT_MAX;
+}
+
+/* Whether the digit run at RUN converts to at most MAX. */
+static hts_boolean optalias_run_fits(const char *run, int64_t max) {
+  long long value;
+
+  errno = 0;
+  value = strtoll(run, NULL, 10);
+  return errno == 0 && value <= max ? HTS_TRUE : HTS_FALSE;
+}
+
 /* Whether the short form COMMAND can read VALUE glued onto it: the on/off
-   mapping, or a bounded number carrying at most one separator with a digit
-   right after it. What it converts short of, or not at all, leaves the option
-   at a value nobody asked for and spills the tail into the cluster loop as
-   further short options (--sockets=8I0 reaches -I0). */
+   mapping, or a number carrying at most one separator with a digit right after
+   it, each digit run within what the option's own parser holds. What it
+   converts short of, or not at all, leaves the option at a value nobody asked
+   for (--sockets=1234567890123456 asks for 1015724736 sockets) and spills the
+   tail into the cluster loop as further short options (--sockets=8I0 reaches
+   -I0). */
 static hts_boolean optalias_param_takes(const char *command,
                                         const char *value) {
   const char sep = optalias_param_separator(command);
+  const int64_t max = optalias_param_max(command);
   hts_boolean digit = HTS_FALSE, split = HTS_FALSE;
-  size_t i;
+  size_t i, run = 0;
 
   if (strcmp(value, "on") == 0 || strcmp(value, "off") == 0)
     return HTS_TRUE;
-  for (i = 0; value[i] != '\0'; i++) {
-    if (isdigit((unsigned char) value[i]))
+  for (i = 0;; i++) {
+    if (isdigit((unsigned char) value[i])) {
       digit = HTS_TRUE;
-    else if (value[i] != sep || split || !isdigit((unsigned char) value[i + 1]))
+      continue;
+    }
+    /* the run just ended, if it held anything: -m and -%c carry two */
+    if (i > run && !optalias_run_fits(value + run, max))
       return HTS_FALSE;
-    else
-      split = HTS_TRUE;
+    if (value[i] == '\0')
+      break;
+    if (value[i] != sep || split || !isdigit((unsigned char) value[i + 1]))
+      return HTS_FALSE;
+    split = HTS_TRUE;
+    run = i + 1;
   }
-  /* bounded: an overlong run is refused, not appended */
-  return digit && i <= 16 ? HTS_TRUE : HTS_FALSE;
+  return digit;
 }
 
 /* The row's help line, indented and terminated, or nothing where it has none:

--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -41,7 +41,6 @@ Please visit our Website: http://www.httrack.com
 
 #include <errno.h>
 #include <limits.h>
-#include <stdint.h>
 
 /*
   Aliases for command-line and config file definitions
@@ -369,6 +368,15 @@ static hts_boolean optalias_clusters(const char *type, const char *command) {
   return HTS_TRUE;
 }
 
+/* Whether the digit run at RUN converts to at most MAX. */
+static hts_boolean optalias_run_fits(const char *run, LLint max) {
+  LLint value;
+
+  errno = 0;
+  value = strtoll(run, NULL, 10);
+  return errno != ERANGE && value <= max ? HTS_TRUE : HTS_FALSE;
+}
+
 /* Suffix the short form takes for a value ("0", "2", or none), or NULL when
    the class refuses it: onoff reads 0/1 only, level reads a number. */
 static const char *optalias_suffix(const char *type, const char *value) {
@@ -379,12 +387,10 @@ static const char *optalias_suffix(const char *type, const char *value) {
   if (level && isdigit((unsigned char) value[0])) {
     size_t i;
 
-    /* bounded: an overlong digit run is refused, not appended */
-    for (i = 0; i < 16 && value[i] != '\0'; i++) {
-      if (!isdigit((unsigned char) value[i]))
-        return NULL;
+    for (i = 0; isdigit((unsigned char) value[i]); i++) {
     }
-    return value[i] == '\0' ? value : NULL;
+    /* a level reaches sscanf("%d") too, so bound it by what that holds */
+    return value[i] == '\0' && optalias_run_fits(value, INT_MAX) ? value : NULL;
   }
   if (strcmp(value, "0") == 0 || strcmp(value, "off") == 0)
     return "0";
@@ -434,20 +440,11 @@ static char optalias_param_separator(const char *command) {
 
 /* The widest value the short form's own parser holds: -m, -M and -G read an
    LLint, and -%c a float no strtoll-sized run overflows. */
-static int64_t optalias_param_max(const char *command) {
+static LLint optalias_param_max(const char *command) {
   if (strcmp(command, "-m") == 0 || strcmp(command, "-M") == 0 ||
       strcmp(command, "-G") == 0 || strcmp(command, "-%c") == 0)
     return INT64_MAX;
   return INT_MAX;
-}
-
-/* Whether the digit run at RUN converts to at most MAX. */
-static hts_boolean optalias_run_fits(const char *run, int64_t max) {
-  long long value;
-
-  errno = 0;
-  value = strtoll(run, NULL, 10);
-  return errno == 0 && value <= max ? HTS_TRUE : HTS_FALSE;
 }
 
 /* Whether the short form COMMAND can read VALUE glued onto it: the on/off
@@ -460,9 +457,9 @@ static hts_boolean optalias_run_fits(const char *run, int64_t max) {
 static hts_boolean optalias_param_takes(const char *command,
                                         const char *value) {
   const char sep = optalias_param_separator(command);
-  const int64_t max = optalias_param_max(command);
+  const LLint max = optalias_param_max(command);
   hts_boolean digit = HTS_FALSE, split = HTS_FALSE;
-  size_t i, run = 0;
+  size_t i, start = 0;
 
   if (strcmp(value, "on") == 0 || strcmp(value, "off") == 0)
     return HTS_TRUE;
@@ -472,14 +469,14 @@ static hts_boolean optalias_param_takes(const char *command,
       continue;
     }
     /* the run just ended, if it held anything: -m and -%c carry two */
-    if (i > run && !optalias_run_fits(value + run, max))
+    if (i > start && !optalias_run_fits(value + start, max))
       return HTS_FALSE;
     if (value[i] == '\0')
       break;
     if (value[i] != sep || split || !isdigit((unsigned char) value[i + 1]))
       return HTS_FALSE;
     split = HTS_TRUE;
-    run = i + 1;
+    start = i + 1;
   }
   return digit;
 }
@@ -526,7 +523,7 @@ int optalias_check(int argc, const char *const *argv, int n_arg,
       char *position;
       const char *addname = NULL;
       int need_param = 1;
-      hts_boolean negated = HTS_FALSE;
+      hts_boolean negated = HTS_FALSE, detached;
 
       int pos;
 
@@ -628,10 +625,23 @@ int optalias_check(int argc, const char *const *argv, int n_arg,
 
         /* Final result */
 
-        /* Must be alone (-P /tmp), or a paramn value -N cannot take glued */
-        if (strcmp(hts_optalias[pos][2], "param1") == 0 ||
-            (strcmp(hts_optalias[pos][2], "paramn") == 0 &&
-             !optalias_paramn_glues(param))) {
+        /* Alone (-P /tmp), or a paramn value -N cannot take glued */
+        detached = strcmp(hts_optalias[pos][2], "param1") == 0 ||
+                   (strcmp(hts_optalias[pos][2], "paramn") == 0 &&
+                    !optalias_paramn_glues(param));
+
+        /* Every other class glues the value onto the short form in one
+           buffer, where strlcatbuff aborts rather than clips. */
+        if (!detached && strlen(param) >= return_argv_size - strlen(command)) {
+          slprintfbuff_clip(
+              return_error, return_error_size,
+              "Syntax error:\n\tOption --%s does not take the value %s\n%s",
+              hts_optalias[pos][0], param,
+              optalias_help_line(help, sizeof(help), hts_optalias[pos][0]));
+          return 0;
+        }
+
+        if (detached) {
           strlcpybuff(return_argv[0], command, return_argv_size);
           strlcpybuff(return_argv[1], param, return_argv_size);
           *return_argc = 2;     /* 2 parameters returned */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4921,6 +4921,23 @@ static int st_optalias(httrackp *opt, int argc, char **argv) {
     EXPANDS(want, word, NULL);
     snprintf(word, sizeof(word), "--%s=on", optalias_value(i));
     EXPANDS(optreal_value(p), word, NULL);
+    /* #1437, table-wide too: the bound is the destination's magnitude, so
+       padding rides through and a run past every destination does not */
+    snprintf(word, sizeof(word), "--%s=00000000000000000002",
+             optalias_value(i));
+    snprintf(want, sizeof(want), "%s00000000000000000002", optreal_value(p));
+    EXPANDS(want, word, NULL);
+    snprintf(word, sizeof(word), "--%s=2147483647", optalias_value(i));
+    snprintf(want, sizeof(want), "%s2147483647", optreal_value(p));
+    EXPANDS(want, word, NULL);
+    snprintf(word, sizeof(word), "--%s=99999999999999999999",
+             optalias_value(i));
+    REFUSES(word, NULL);
+    /* a sign is not a digit run: -2 would spill into the cluster loop */
+    snprintf(word, sizeof(word), "--%s=-2", optalias_value(i));
+    REFUSES(word, NULL);
+    snprintf(word, sizeof(word), "--%s=+2", optalias_value(i));
+    REFUSES(word, NULL);
   }
   assertf(params >= 27); /* the rows the issue enumerates were all walked */
 

--- a/tests/362_engine-param-value-refused.test
+++ b/tests/362_engine-param-value-refused.test
@@ -26,10 +26,7 @@ crawl() {
         >"${tmp}/log" 2>&1 || RC=$?
 }
 
-# Basenames of the mirror, so the checks read what was written rather than a
-# path this host may spell differently (macOS $TMPDIR, Windows ':' -> '_').
-saved() { find "${out}" -type f | sed 's|.*/||'; }
-has_name() { grep -Fqx "$1" <<<"$(saved)"; }
+has_name() { mirror_has_name "${out}" "$1"; }
 has_cache() { test -n "$(find "${out}/hts-cache" -type f 2>/dev/null)"; }
 
 # The discriminator, proven on the two spellings that ask for each layout:

--- a/tests/369_engine-param-value-range.test
+++ b/tests/369_engine-param-value-range.test
@@ -1,8 +1,9 @@
 #!/bin/bash
 #
-# A "param" option's value was bounded at 16 characters rather than by
-# magnitude: --depth=0000000000000000001 was refused, while the sixteen digits
-# of --sockets=1234567890123456 reached sscanf("%d") as 1015724736 (#1437).
+# A "param" or "level" option's value was bounded at 16 characters rather than
+# by magnitude: --depth=0000000000000000001 was refused, while the sixteen
+# digits of --sockets=1234567890123456 reached sscanf("%d") as 1015724736, and
+# --generate-errors=3000000000 as -1294967296 (#1437).
 
 set -euo pipefail
 
@@ -13,64 +14,80 @@ testdir=$(cd "$(dirname "$0")" && pwd)
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_paramrange.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "${tmp}"
 
-# The short form the alias expands to, which is what the engine's own option
-# parser then reads.
-takes() { # takes WORD EXPANSION
+# assert_selftest prints the short form the alias expands to, which is what the
+# engine's own option parser then reads.
+refuses() { # refuses WORD...
     local out rc=0
-    out=$(httrack "-#test=optalias" "$1" 2>&1) || rc=$?
-    assert_eq 0 "${rc}" "$1 exited"
-    assert_eq "$2" "${out}" "$1 expanded"
-}
-
-refuses() { # refuses WORD
-    local out rc=0
-    out=$(httrack "-#test=optalias" "$1" 2>&1) || rc=$?
+    out=$(httrack "-#test=optalias" "$@" 2>&1) || rc=$?
     { test "${rc}" -ne 0 && test "${rc}" -ne 134; } ||
-        fail "$1 not refused (exit ${rc})"
+        fail "$* not refused (exit ${rc})"
     grep -q 'does not take the value' <<<"${out}" ||
-        fail "$1 refused without saying why: ${out}"
+        fail "$* refused without saying why: ${out}"
 }
 
 # Padding is not a value: these all sat above the old 16-character cap.
-takes --depth=0000000000000000001 -r0000000000000000001
-takes --long-names=00000000000000001 -L00000000000000001
-takes --max-files=0000000100,0000005000 -m0000000100,0000005000
-takes --connection-per-second=00.5000000000000000 -%c00.5000000000000000
+assert_selftest -r0000000000000000001 optalias --depth=0000000000000000001
+assert_selftest -L00000000000000001 optalias --long-names=00000000000000001
+assert_selftest -m0000000100,0000005000 optalias --max-files=0000000100,0000005000
+assert_selftest -%c00.5000000000000000 optalias \
+    --connection-per-second=00.5000000000000000
 
 # Ten digits below INT_MAX, and the two-operand forms unpadded.
-takes --advanced-maxlinks=2000000000 -#L2000000000
-takes --max-files=100,5000 -m100,5000
-takes --connection-per-second=0.5 -%c0.5
-takes --max-files=,5000 -m,5000
-# -M reads an LLint, so its bound is not the int one
-takes --max-size=9999999999999999 -M9999999999999999
+assert_selftest -#L2000000000 optalias --advanced-maxlinks=2000000000
+assert_selftest -m100,5000 optalias --max-files=100,5000
+assert_selftest -%c0.5 optalias --connection-per-second=0.5
+assert_selftest -m,5000 optalias --max-files=,5000
 
 # The INT_MAX boundary, from both sides and through the padding.
-takes --depth=2147483647 -r2147483647
-takes --depth=00000000002147483647 -r00000000002147483647
+assert_selftest -r2147483647 optalias --depth=2147483647
+assert_selftest -r00000000002147483647 optalias --depth=00000000002147483647
 refuses --depth=2147483648
 refuses --depth=00000000002147483648
+
+# Each row is bounded by its own destination, not by one shared number: -m, -M
+# and -G read an LLint and -%c a float, where -r reads an int.
+assert_selftest -m3000000000 optalias --max-files=3000000000
+assert_selftest -G3000000000 optalias --max-pause=3000000000
+assert_selftest -M9999999999999999 optalias --max-size=9999999999999999
+assert_selftest -%c3000000000.5 optalias --connection-per-second=3000000000.5
+refuses --depth=3000000000
 
 # Out of range on an int row: each was read as some other number entirely.
 refuses --sockets=1234567890123456
 refuses --max-rate=3000000000
 refuses --timeout=99999999999
+# ...and the same on a "level" row, whose 16-character cap was the same one
+refuses --generate-errors=3000000000
+assert_selftest -o2147483647 optalias --generate-errors=2147483647
+
 # past strtoll itself, on the first operand and on the second
 refuses --max-size=99999999999999999999
 refuses --max-files=100,99999999999999999999
 refuses --connection-per-second=0.99999999999999999999
 
-# Controls: the structural rule the magnitude bound replaced still holds.
+# Controls: the structural rule the magnitude bound replaced still holds. A
+# sign is not a digit run, or -5 would spill into the cluster loop (#1426).
 refuses --sockets=8I0
 refuses --max-files=100,
 refuses --depth=none
+refuses --depth=-5
+refuses --depth=+5
+refuses --generate-errors=-5
+
+# The value still has to fit the buffer the expansion is glued into, which
+# aborts rather than clips. Only the detached form gets that far: the glued
+# --depth=<1022 zeros> is one argument past HTS_CDLMAXSIZE.
+zeros=$(printf '0%.0s' $(seq 1021))
+assert_selftest "-r${zeros}" optalias --depth "${zeros}"
+refuses --depth "${zeros}0"
+# ...and the same buffer under a "param0" row, which glues +<value>
+refuses --allow "$(printf 'a%.0s' $(seq 1023))"
 
 # On disk: a padded value reaches the engine as the number it spells. Long
 # names keep page.html, DOS 8.3 truncates it to PAGE.HTM.
 echo '<html><body>hello</body></html>' >"${tmp}/page.html"
 out=${tmp}/out
-saved() { find "${out}" -type f | sed 's|.*/||'; }
-has_name() { grep -Fqx "$1" <<<"$(saved)"; }
+has_name() { mirror_has_name "${out}" "$1"; }
 crawl() {
     rm -rf "${out}"
     mkdir -p "${out}"

--- a/tests/369_engine-param-value-range.test
+++ b/tests/369_engine-param-value-range.test
@@ -1,0 +1,96 @@
+#!/bin/bash
+#
+# A "param" option's value was bounded at 16 characters rather than by
+# magnitude: --depth=0000000000000000001 was refused, while the sixteen digits
+# of --sockets=1234567890123456 reached sscanf("%d") as 1015724736 (#1437).
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_paramrange.XXXXXX") || fail "no tmpdir"
+cleanup_push rm -rf "${tmp}"
+
+# The short form the alias expands to, which is what the engine's own option
+# parser then reads.
+takes() { # takes WORD EXPANSION
+    local out rc=0
+    out=$(httrack "-#test=optalias" "$1" 2>&1) || rc=$?
+    assert_eq 0 "${rc}" "$1 exited"
+    assert_eq "$2" "${out}" "$1 expanded"
+}
+
+refuses() { # refuses WORD
+    local out rc=0
+    out=$(httrack "-#test=optalias" "$1" 2>&1) || rc=$?
+    { test "${rc}" -ne 0 && test "${rc}" -ne 134; } ||
+        fail "$1 not refused (exit ${rc})"
+    grep -q 'does not take the value' <<<"${out}" ||
+        fail "$1 refused without saying why: ${out}"
+}
+
+# Padding is not a value: these all sat above the old 16-character cap.
+takes --depth=0000000000000000001 -r0000000000000000001
+takes --long-names=00000000000000001 -L00000000000000001
+takes --max-files=0000000100,0000005000 -m0000000100,0000005000
+takes --connection-per-second=00.5000000000000000 -%c00.5000000000000000
+
+# Ten digits below INT_MAX, and the two-operand forms unpadded.
+takes --advanced-maxlinks=2000000000 -#L2000000000
+takes --max-files=100,5000 -m100,5000
+takes --connection-per-second=0.5 -%c0.5
+takes --max-files=,5000 -m,5000
+# -M reads an LLint, so its bound is not the int one
+takes --max-size=9999999999999999 -M9999999999999999
+
+# The INT_MAX boundary, from both sides and through the padding.
+takes --depth=2147483647 -r2147483647
+takes --depth=00000000002147483647 -r00000000002147483647
+refuses --depth=2147483648
+refuses --depth=00000000002147483648
+
+# Out of range on an int row: each was read as some other number entirely.
+refuses --sockets=1234567890123456
+refuses --max-rate=3000000000
+refuses --timeout=99999999999
+# past strtoll itself, on the first operand and on the second
+refuses --max-size=99999999999999999999
+refuses --max-files=100,99999999999999999999
+refuses --connection-per-second=0.99999999999999999999
+
+# Controls: the structural rule the magnitude bound replaced still holds.
+refuses --sockets=8I0
+refuses --max-files=100,
+refuses --depth=none
+
+# On disk: a padded value reaches the engine as the number it spells. Long
+# names keep page.html, DOS 8.3 truncates it to PAGE.HTM.
+echo '<html><body>hello</body></html>' >"${tmp}/page.html"
+out=${tmp}/out
+saved() { find "${out}" -type f | sed 's|.*/||'; }
+has_name() { grep -Fqx "$1" <<<"$(saved)"; }
+crawl() {
+    rm -rf "${out}"
+    mkdir -p "${out}"
+    RC=0
+    httrack "file://${tmp}/page.html" -O "${out}" --quiet -n "$@" \
+        >"${tmp}/log" 2>&1 || RC=$?
+}
+
+crawl --long-names=0000000000000000001
+assert_eq 0 "${RC}" "--long-names=0000000000000000001 exited"
+has_name page.html ||
+    fail_dump "padded --long-names=1 wrote no long name" "${tmp}/log"
+crawl --long-names=0000000000000000000
+assert_eq 0 "${RC}" "--long-names=0000000000000000000 exited"
+has_name PAGE.HTM ||
+    fail_dump "padded --long-names=0 wrote no 8.3 name" "${tmp}/log"
+
+crawl --sockets=1234567890123456
+test "${RC}" -ne 0 || fail_dump "--sockets=1234567890123456 mirrored" "${tmp}/log"
+! has_name page.html ||
+    fail_dump "--sockets=1234567890123456 still mirrored" "${tmp}/log"
+
+exit 0

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -84,6 +84,16 @@ assert_match() { # assert_match RE TEXT [LABEL]
 
 assert_file() { test -f "$1" || fail "${2:+$2: }missing file: $1"; }
 
+# Basenames of the files a mirror wrote, so a check reads what was written
+# rather than a path this host may spell differently (macOS $TMPDIR, Windows
+# ':' -> '_').
+mirror_names() { # mirror_names DIR
+    find "$1" -type f | sed 's|.*/||'
+}
+mirror_has_name() { # mirror_has_name DIR BASENAME
+    grep -Fqx "$2" <<<"$(mirror_names "$1")"
+}
+
 # Every step skip_if_out_of_budget projects against ran. A skip is an exit, so a
 # loop that quietly ran fewer paces against a count that is a lie.
 assert_steps_ran() { # assert_steps_ran WANT GOT


### PR DESCRIPTION
`optalias_param_takes()` (#1427) bounded a `param` row's value at 16 characters, which is a length where a magnitude is meant. It refused `--depth=0000000000000000001` for its padding alone, and accepted `--sockets=1234567890123456`, sixteen digits that `sscanf("%d")` then read as 1015724736 simultaneous connections. Each digit run is now converted with `strtoll` and range-checked against what the option's own parser holds: `INT_MAX` for the rows reading an `int`, `INT64_MAX` for `-m`, `-M` and `-G` on their `LLint` and for `-%c`, whose float takes any run `strtoll` converts. The check runs per operand, so the second half of `-m N,N2` and `-%c 0.5` is covered too. `optalias_suffix()` carried a copy of the same bare 16, so the six `level` rows get the same treatment.

The behaviour change is the fix rather than a side effect of it, and it goes both ways. Refused from now on: a value on an int-valued long form whose digit run exceeds 2147483647 and which the old cap let through, so no longer than 16 characters. `--sockets=1234567890123456`, `--max-rate=3000000000`, `--depth=2147483648`, `--timeout=99999999999`, `--generate-errors=3000000000`, and every value of that shape on the other int rows. All of them were undefined at `sscanf("%d")` and wrapped in practice: 1015724736 sockets, a rate of -1294967296, a depth of -2147483648, a timeout of 1215752191 seconds. None landed on a sane value by accident either, since `-c` clamps its wrapped negative back to one socket, which is still not what was asked for.

Accepted from now on: a zero-padded value wherever its magnitude fits, and on `-m`, `-M`, `-G` and `-%c` any 17-to-19-digit run up to `INT64_MAX`. `--max-size=9223372036854775807` is refused on master and taken here, which is right, because that is what the `LLint` behind it holds.

The old cap was also the only thing keeping a value short enough to glue into the 1024-byte expansion buffer, where `strlcatbuff` aborts rather than clips. So a length bound stays, at the glue site and sized to the room the short form leaves: without it `httrack --depth $(printf '0%.0s' $(seq 1022))` exits 134 with a backtrace where master printed a syntax error. It now also reaches a class the old cap never covered, the `param0` rows, where `httrack --allow <1023 chars>` aborts on master and draws the same syntax error here.

369 asserts both directions, through the engine's own expansion and on disk, and reds on six mutants: the length cap put back, `optalias_run_fits` forced true or stripped of its `max`, the `LLint` arm narrowed to `-M` and `-%c`, a leading sign accepted, the capacity guard removed, and `optalias_suffix` reverted. `st_optalias`'s table-wide loop carries the padding, `INT_MAX` and sign probes across all 27 `param` rows.

Closes #1437