### PR TITLE
Dependabot PRs wait on a manual merge click

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,23 @@
+# Dependabot only ever bumps pins here (actions, vcpkg baseline, coucal), and CI
+# validates each one, so arming auto-merge just saves the manual click.
+name: Dependabot auto-merge
+
+# pull_request_target, because a dependabot pull_request gets a read-only token.
+# Nothing from the PR is checked out or run, so the writable token stays safe.
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Arm auto-merge
+    if: github.repository == 'xroche/httrack' && github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,12 +1,17 @@
-# Dependabot only ever bumps pins here (actions, vcpkg baseline, coucal), and CI
-# validates each one, so arming auto-merge just saves the manual click.
+# CI already validates every pin dependabot bumps here, so auto-merge only saves the manual click.
 name: Dependabot auto-merge
 
 # pull_request_target, because a dependabot pull_request gets a read-only token.
 # Nothing from the PR is checked out or run, so the writable token stays safe.
 on: pull_request_target
 
+concurrency:
+  group: dependabot-automerge-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
+  # Both writes are what enabling auto-merge costs: the API call needs the pull
+  # request scope, and the merge it queues needs the contents one.
   contents: write
   pull-requests: write
 
@@ -16,8 +21,11 @@ jobs:
     if: github.repository == 'xroche/httrack' && github.actor == 'dependabot[bot]'
     runs-on: ubuntu-24.04
     steps:
+      # Dependabot's body is a release-notes dump, so give the squash commit a body of its own.
       - name: Enable auto-merge
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --auto --squash --subject "$PR_TITLE (#$PR_NUMBER)" --body "" "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Dependabot only ever moves a pin here: an action version, the vcpkg builtin-baseline, or the coucal submodule. Each bump still has to clear all 20 required checks. The ruleset requires no approving review, so the manual merge click only adds delay. This workflow arms `gh pr merge --auto --squash` on those PRs and lets GitHub merge them once CI is green.

`pull_request_target` is deliberate. The merge would 403 on `pull_request`: dependabot gets a read-only GITHUB_TOKEN regardless of the `permissions:` block. The job never checks out or runs PR content, so the writable token is not reachable from the branch.

The squash subject and body are passed explicitly, because this repo squashes with `PR_BODY`: `7a349927` on master carries about 200 lines of dependabot release notes as its commit message, and an automated merge would keep doing that.

The catch: a GITHUB_TOKEN merge triggers no further workflow runs. The `push: master` legs of ci, codeql, cross-arch and windows-build stay silent afterwards. Each of them also runs on `pull_request` or on a weekly cron, so nothing loses its only coverage, though CodeQL's default-branch alert state goes stale. A PAT in GH_TOKEN would bring the master runs back if that turns out to matter.
