### PR TITLE
The guide skips the notification prompt Android raises when a crawl starts

### DIFF
--- a/html/guide.html
+++ b/html/guide.html
@@ -260,6 +260,12 @@ far, and one line per transfer in flight. A mirror of any size takes a while. Th
 server's pace as much as yours, and the <a href="#opt-limits">Limits</a> options exist to keep it
 polite.</p>
 
+<p class="note" data-for="droid">Android 13 and later ask whether HTTrack may post notifications,
+and the prompt appears over the progress pane as the crawl starts. Tap <b>Allow</b>: without the
+grant the app cannot tell you that the mirror has finished, or that Android stopped it while you
+were in another app. The prompt comes once, so to change your mind later, go to HTTrack's entry in
+Android's settings.</p>
+
 <figure>
 	<img data-for="win" src="img/guide-win-progress.png" alt="WinHTTrack mirror in progress" width="1040" height="744">
 	<img data-for="web" src="img/guide-web-progress.png" alt="WebHTTrack mirror in progress" width="1024" height="742">

--- a/html/guide.html
+++ b/html/guide.html
@@ -260,11 +260,11 @@ far, and one line per transfer in flight. A mirror of any size takes a while. Th
 server's pace as much as yours, and the <a href="#opt-limits">Limits</a> options exist to keep it
 polite.</p>
 
-<p class="note" data-for="droid">Android 13 and later ask whether HTTrack may post notifications,
-and the prompt appears over the progress pane as the crawl starts. Tap <b>Allow</b>: without the
-grant the app cannot tell you that the mirror has finished, or that Android stopped it while you
-were in another app. Android does not ask again once you answer, so to change your mind later, go to
-HTTrack's entry in Android's settings.</p>
+<p class="note" data-for="droid">Android 13 and later ask whether HTTrack may post notifications.
+The prompt appears over the progress pane as the crawl starts. Tap <b>Allow</b>. Without the
+permission the app cannot tell you that the mirror finished while you were in another app, or offer
+to resume one Android stopped. HTTrack does not ask again once you answer. To change your mind
+later, go to its entry in Android's settings.</p>
 
 <figure>
 	<img data-for="win" src="img/guide-win-progress.png" alt="WinHTTrack mirror in progress" width="1040" height="744">

--- a/html/guide.html
+++ b/html/guide.html
@@ -263,8 +263,8 @@ polite.</p>
 <p class="note" data-for="droid">Android 13 and later ask whether HTTrack may post notifications,
 and the prompt appears over the progress pane as the crawl starts. Tap <b>Allow</b>: without the
 grant the app cannot tell you that the mirror has finished, or that Android stopped it while you
-were in another app. The prompt comes once, so to change your mind later, go to HTTrack's entry in
-Android's settings.</p>
+were in another app. Android does not ask again once you answer, so to change your mind later, go to
+HTTrack's entry in Android's settings.</p>
 
 <figure>
 	<img data-for="win" src="img/guide-win-progress.png" alt="WinHTTrack mirror in progress" width="1040" height="744">


### PR DESCRIPTION
guide.html walks an Android newcomer through the all-files access dialog and the legacy import offer, then jumps to the crawl, so the third prompt is a surprise: from Android 13 the app asks for `POST_NOTIFICATIONS` at runtime, and `ensureNotificationsAreAllowed()` runs from the `activity_mirror_progress` case, which puts the dialog on top of the progress pane. A refusal is final and costs both mirror notices: the finished one, posted only when you are looking at something else, and the tap-to-resume one from the retained fragment's `onDestroy`. A dismissal is not an answer and the prompt returns on the next crawl, which is why the text says "once you answer" rather than "once".

A sentence in step 5 rather than a new capture stem. The dialog is Android's own and carries nothing HTTrack-specific, and the capture walk pre-grants the permission so `17_mirror_finished` shows the wizard, which is the shot that step wants. Confirmed against the app source with the httrack-android session.

Closes #1447