### PR TITLE
The crash report prints every signal number backwards

### DIFF
--- a/src/htsbacktrace.c
+++ b/src/htsbacktrace.c
@@ -368,6 +368,28 @@ void hts_backtrace_altstack_release(void *stack) {
 #endif
 }
 
+unsigned int hts_print_num(char *buffer, int num) {
+  const int neg = num < 0;
+  /* negate in unsigned: INT_MIN has no positive counterpart */
+  unsigned int val = neg ? -(unsigned int) num : (unsigned int) num;
+  unsigned int i, j;
+
+  if (neg) {
+    *(buffer++) = '-';
+  }
+  for (i = 0; val != 0 || i == 0; i++, val /= 10) {
+    buffer[i] = '0' + (val % 10);
+  }
+  /* least-significant first above: swapping to i rather than i/2 undoes it all */
+  for (j = 0; j < i / 2; j++) {
+    const char c = buffer[i - j - 1];
+    buffer[i - j - 1] = buffer[j];
+    buffer[j] = c;
+  }
+  buffer[i] = '\0';
+  return i + (unsigned int) neg;
+}
+
 /* Why the report has no frames: a silent gap reads as a handler that died. */
 static void print_no_trace(int fd, const char *msg, unsigned int len) {
   if (write(fd, msg, len) != len) { /* no ssize_t: this is built on MSVC too */

--- a/src/htsbacktrace.c
+++ b/src/htsbacktrace.c
@@ -380,7 +380,7 @@ unsigned int hts_print_num(char *buffer, int num) {
   for (i = 0; val != 0 || i == 0; i++, val /= 10) {
     buffer[i] = '0' + (val % 10);
   }
-  /* least-significant first above: swapping to i rather than i/2 undoes it all */
+  /* j stops at i/2: going to i swaps each pair twice and undoes the reversal */
   for (j = 0; j < i / 2; j++) {
     const char c = buffer[i - j - 1];
     buffer[i - j - 1] = buffer[j];

--- a/src/htsbacktrace.h
+++ b/src/htsbacktrace.h
@@ -58,4 +58,8 @@ void hts_backtrace_altstack_release(void *stack);
    has no backtrace(). */
 void hts_print_backtrace(void);
 
+/* Signal-safe decimal rendering of `num` into `buffer`, NUL-terminated;
+   returns the length written, at most 11 characters plus the NUL. */
+unsigned int hts_print_num(char *buffer, int num);
+
 #endif

--- a/src/httrack.c
+++ b/src/httrack.c
@@ -908,24 +908,6 @@ static void sig_doback(int blind) {     // mettre en backing
 #undef FD_ERR
 #define FD_ERR 2
 
-static unsigned int print_num(char *buffer, int num) {
-  unsigned int i, j;
-  if (num < 0) {
-    *(buffer++) = '-';
-    num = -num;
-  }
-  for(i = 0 ; num != 0 || i == 0 ; i++, num /= 10) {
-    buffer[i] = '0' + ( num % 10 );
-  }
-  for(j = 0 ; j < i ; j++) {
-    const char c = buffer[i - j - 1];
-    buffer[i - j - 1] = buffer[j];
-    buffer[j] = c;
-  }
-  buffer[i] = '\0';
-  return i;
-}
-
 static void sig_fatal(int code) {
   const char msg[] = "\nCaught signal ";
   const char msgreport[] =
@@ -939,7 +921,7 @@ static void sig_fatal(int code) {
 
   memcpy(buffer, msg, sizeof(msg) - 1);
   size = sizeof(msg) - 1;
-  size += print_num(&buffer[size], code);
+  size += hts_print_num(&buffer[size], code);
   buffer[size++] = '\n';
   (void) (write(FD_ERR, buffer, size) == size);
   hts_print_backtrace();

--- a/tests/372_crash-signal-number.test
+++ b/tests/372_crash-signal-number.test
@@ -1,0 +1,57 @@
+#!/bin/bash
+# The crash banner printed signal numbers backwards. Invisible on x86, whose
+# fatal signals are 4, 6, 7 and 11; hppa's SIGBUS is 10 and the report said 01.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+srcdir=${abs_top_srcdir:?not run under make check}
+builddir=${abs_top_builddir:?not run under make check}
+
+# CC carries flags on some legs ("gcc -m32", "ccache gcc"), so split it.
+read -r -a cc_argv <<<"${CC:-cc}"
+command -v "${cc_argv[0]}" >/dev/null || skip "no C compiler (${cc_argv[0]})"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/httrack_printnum.XXXXXX")
+cleanup_push rm -rf "${work}"
+
+cflags=(-g -O0 -I"${builddir}" -I"${builddir}/src" -I"${srcdir}/src")
+if [ -n "${TEST_CPPFLAGS:-}" ]; then
+    read -r -a extra_argv <<<"${TEST_CPPFLAGS}"
+    cflags+=("${extra_argv[@]}")
+fi
+# shellcheck disable=SC2086 # DL_LIBS is a flag list; splitting is the point
+if ! "${cc_argv[@]}" "${cflags[@]}" -o "${work}/probe" \
+    "${srcdir}/tests/printnumprobe.c" "${srcdir}/src/htsbacktrace.c" \
+    ${DL_LIBS:-} >"${work}/cc.log" 2>&1; then
+    head -20 "${work}/cc.log" >&2
+    # 218 pins that the crash printer builds standalone on Linux.
+    if [ "$HTS_OS" = "Linux" ]; then
+        fail "the crash printer does not build standalone"
+    fi
+    skip "the probe does not build with this toolchain"
+fi
+
+# Spread: every signal that reaches the handler on some port (hppa SIGBUS 10,
+# SIGSEGV 11), both digit parities, and INT_MIN, whose negation must not
+# overflow. printf is the oracle, so no expectation is copied from the probe.
+values=(0 1 4 6 7 8 10 11 12 20 100 101 123 1000 4321 65535
+    2147483647 -1 -7 -10 -123 -2147483648)
+
+got=$("${work}/probe" "${values[@]}")
+test "$(wc -l <<<"${got}")" -eq "${#values[@]}" ||
+    fail "the probe rendered $(wc -l <<<"${got}") of ${#values[@]} values: ${got}"
+
+want=$(for v in "${values[@]}"; do
+    text=$(printf '%d' "$v")
+    printf '%u:%s\n' "${#text}" "${text}"
+done)
+
+if [ "${got}" != "${want}" ]; then
+    printf '%s\n' "${want}" >"${work}/want"
+    printf '%s\n' "${got}" >"${work}/got"
+    diff -u "${work}/want" "${work}/got" >&2 || true
+    fail "hts_print_num() does not render what printf does"
+fi

--- a/tests/372_crash-signal-number.test
+++ b/tests/372_crash-signal-number.test
@@ -17,11 +17,16 @@ command -v "${cc_argv[0]}" >/dev/null || skip "no C compiler (${cc_argv[0]})"
 work=$(mktemp -d "${TMPDIR:-/tmp}/httrack_printnum.XXXXXX")
 cleanup_push rm -rf "${work}"
 
-cflags=(-g -O0 -I"${builddir}" -I"${builddir}/src" -I"${srcdir}/src")
-if [ -n "${TEST_CPPFLAGS:-}" ]; then
-    read -r -a extra_argv <<<"${TEST_CPPFLAGS}"
-    cflags+=("${extra_argv[@]}")
-fi
+# The build's own flags first, so the sanitizer legs instrument the probe and
+# the INT_MIN case is more than decorative; -O0 after, to keep our own.
+cflags=()
+for flags in "${TEST_CFLAGS:-}" "${TEST_CPPFLAGS:-}"; do
+    if [ -n "${flags}" ]; then
+        read -r -a extra_argv <<<"${flags}"
+        cflags+=("${extra_argv[@]}")
+    fi
+done
+cflags+=(-g -O0 -I"${builddir}" -I"${builddir}/src" -I"${srcdir}/src")
 # shellcheck disable=SC2086 # DL_LIBS is a flag list; splitting is the point
 if ! "${cc_argv[@]}" "${cflags[@]}" -o "${work}/probe" \
     "${srcdir}/tests/printnumprobe.c" "${srcdir}/src/htsbacktrace.c" \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,7 @@ TESTS = @TESTS_LIST@
 # Committed binary fixture read by 01_zlib-cache-golden.test. List it
 # explicitly: automake does not expand wildcards in EXTRA_DIST, so a glob would
 # silently drop it from the dist tarball and break "make distcheck".
-EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c altstackprobe.c nopieprobe.c closetrack.c ftpcancel.c crawl-test.sh run-all-tests.sh check-network.sh check-test-names.sh \
+EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c altstackprobe.c nopieprobe.c printnumprobe.c closetrack.c ftpcancel.c crawl-test.sh run-all-tests.sh check-network.sh check-test-names.sh \
 	proxy-https-server.py socks5-server.py proxy-connect-server.py \
 	proxytestlib.py tls-stall-server.py warc-validate.py wacz-validate.py \
 	header-injection-server.py header-injection-check.py \

--- a/tests/printnumprobe.c
+++ b/tests/printnumprobe.c
@@ -1,0 +1,38 @@
+/* Renders each argv value through hts_print_num() for 372_crash-signal-number.
+   Prints "<returned length>:<text>", which the test grades against printf. */
+
+#include "htsbacktrace.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(int argc, char **argv) {
+  int i;
+
+  for (i = 1; i < argc; i++) {
+    char buf[64];
+    char *end;
+    const long value = strtol(argv[i], &end, 10);
+    unsigned int len;
+
+    if (*end != '\0') {
+      fprintf(stderr, "printnumprobe: '%s' is not a number\n", argv[i]);
+      return 1;
+    }
+    /* poisoned, so a stray terminator one past the end is visible */
+    memset(buf, 'X', sizeof(buf));
+    len = hts_print_num(buf, (int) value);
+    if (len >= sizeof(buf) - 2) {
+      fprintf(stderr, "printnumprobe: '%s' wrote %u bytes\n", argv[i], len);
+      return 1;
+    }
+    if (buf[len] != '\0' || buf[len + 1] != 'X') {
+      fprintf(stderr, "printnumprobe: '%s' wrote past its %u bytes\n", argv[i],
+              len);
+      return 1;
+    }
+    printf("%u:%s\n", len, buf);
+  }
+  return 0;
+}


### PR DESCRIPTION
The reversal loop in `print_num()` runs `j` across the whole range, so every pair is swapped twice and the digits stay least-significant first. Only signal numbers ever reach it, and on x86 those are 4, 6, 7 and 11, all single digits or a palindrome, so nothing ever showed. hppa's SIGBUS is 10, and the report there says `Caught signal 01`. That is what turns `183_altstack-worker` red on the [Debian buildd](https://buildd.debian.org/status/package.php?p=httrack).

The function moves to `htsbacktrace.c` beside the other signal-safe writer so a test can link it, the way test 218 already links the crash printer. Two latent problems in the same few lines go with it: negating in signed `int` is UB for `INT_MIN`, and the returned length left out the minus sign.

`372_crash-signal-number` grades the rendering against printf's, over values that include 10, both digit parities and `INT_MIN`, into a poisoned buffer so a stray terminator shows. It builds the probe with the tree's own `CFLAGS`, so the sanitize leg catches the `INT_MIN` case that no value comparison can see.