### PR TITLE
warc-offset fails on a filesystem that cannot hold a 1TB offset

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -9096,8 +9096,8 @@ static int st_warc_offset(httrackp *opt, int argc, char **argv) {
     uint64_t got;
 
     if (fseeko(fp, (LLint) want, SEEK_SET) != 0) {
-      /* EFBIG: the filesystem caps file size below the offset (GNU/Hurd
-         ext2fs). Said out loud, and the tally below still wants a wide one. */
+      /* EFBIG: the filesystem caps file size below the offset (GNU/Hurd ext2fs)
+       */
       if (errno == EFBIG) {
         fprintf(stderr,
                 "warc-offset: %" PRIu64 " is past this filesystem's"
@@ -9121,7 +9121,7 @@ static int st_warc_offset(httrackp *opt, int argc, char **argv) {
     }
   }
   fclose(fp);
-  /* the whole point is the offsets a 32-bit signed tell cannot hold */
+  /* fail here, or a filesystem refusing every wide offset proves nothing */
   if (wide == 0) {
     fprintf(stderr, "warc-offset: no offset past 2GB was measurable here\n");
     err = 1;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -9077,6 +9077,7 @@ static int st_warc_offset(httrackp *opt, int argc, char **argv) {
   FILE *fp;
   int err = 0;
   size_t i;
+  size_t wide = 0; /* offsets measured past what a 32-bit tell could hold */
 
   (void) opt;
   if (argc < 1) {
@@ -9095,6 +9096,15 @@ static int st_warc_offset(httrackp *opt, int argc, char **argv) {
     uint64_t got;
 
     if (fseeko(fp, (LLint) want, SEEK_SET) != 0) {
+      /* EFBIG: the filesystem caps file size below the offset (GNU/Hurd
+         ext2fs). Said out loud, and the tally below still wants a wide one. */
+      if (errno == EFBIG) {
+        fprintf(stderr,
+                "warc-offset: %" PRIu64 " is past this filesystem's"
+                " file-size cap, skipped\n",
+                want);
+        continue;
+      }
       fprintf(stderr, "warc-offset: cannot seek to %" PRIu64 ": %s\n", want,
               strerror(errno));
       err = 1;
@@ -9106,9 +9116,16 @@ static int st_warc_offset(httrackp *opt, int argc, char **argv) {
       fprintf(stderr, "warc-offset: tell at %" PRIu64 " reported %" PRIu64 "\n",
               want, got);
       err = 1;
+    } else if (want > 2147483647ULL) {
+      wide++;
     }
   }
   fclose(fp);
+  /* the whole point is the offsets a 32-bit signed tell cannot hold */
+  if (wide == 0) {
+    fprintf(stderr, "warc-offset: no offset past 2GB was measurable here\n");
+    err = 1;
+  }
   /* seeking never wrote: a several-GB file here would mean a real write */
   if (fsize_utf8(path) != 0) {
     fprintf(stderr, "warc-offset: the probe file is not empty (%" PRIu64 ")\n",

--- a/tests/351_engine-warc-cache-io.test
+++ b/tests/351_engine-warc-cache-io.test
@@ -15,6 +15,57 @@ tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_warccacheio.XXXXXX")
 cleanup_push rm -rf "$tmp"
 
 httrack -O "$tmp/out" "-#test=warc-offset" "$tmp/"
+
+# A filesystem whose file-size cap sits below an offset refuses the seek with
+# EFBIG (GNU/Hurd ext2fs, which reds this test on the Debian buildd). Tolerated
+# for the case it hides, but only while a wide offset is still measurable.
+seekfail_ready() {
+    test "$HTS_OS" = Linux || return 1
+    # Only a static-only build is a legitimate absence; anything else missing
+    # would let the two legs below pass by never running.
+    if [ ! -r "${SEEKFAIL_LA:-}" ]; then
+        fail "${SEEKFAIL_LA:-\$SEEKFAIL_LA} was not built"
+    fi
+    if grep -q "^dlname=''" "$SEEKFAIL_LA"; then
+        return 1
+    fi
+    if [ ! -r "${SEEKFAIL_LIB:-}" ]; then
+        fail "${SEEKFAIL_LIB:-\$SEEKFAIL_LIB} was not built"
+    fi
+    return 0
+}
+
+if seekfail_ready; then
+    # The shim allocates nothing, so loading ahead of libasan is harmless.
+    export ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}verify_asan_link_order=0"
+
+    # Only the 1TB case refused: the rest still prove the tell is 64-bit wide.
+    rc=0
+    out=$(SEEKFAIL_CAP=1099511627774 LD_PRELOAD="$SEEKFAIL_LIB" \
+        httrack -O "$tmp/out" "-#test=warc-offset" "$tmp/" 2>&1) || rc=$?
+    test "$rc" -eq 0 || fail "a capped filesystem must not fail warc-offset: $out"
+    grep -q "past this filesystem's file-size cap" <<<"$out" ||
+        fail "the skipped offset was not reported: $out"
+
+    # Every wide offset refused: nothing is left to measure, and swallowing that
+    # silently is what the tolerance above must not do.
+    rc=0
+    out=$(SEEKFAIL_CAP=2147483647 LD_PRELOAD="$SEEKFAIL_LIB" \
+        httrack -O "$tmp/out" "-#test=warc-offset" "$tmp/" 2>&1) || rc=$?
+    test "$rc" -ne 0 || fail "warc-offset passed with no offset past 2GB: $out"
+    grep -q "no offset past 2GB was measurable" <<<"$out" ||
+        fail "warc-offset failed for another reason: $out"
+
+    # EFBIG is the ceiling; any other refusal is a seek that should have worked,
+    # and excusing those would hide the 32-bit off_t this selftest is about.
+    rc=0
+    out=$(SEEKFAIL_CAP=1099511627774 SEEKFAIL_ERROR=eio \
+        LD_PRELOAD="$SEEKFAIL_LIB" \
+        httrack -O "$tmp/out" "-#test=warc-offset" "$tmp/" 2>&1) || rc=$?
+    test "$rc" -ne 0 || fail "warc-offset excused a non-EFBIG seek failure: $out"
+    grep -q "cannot seek to 1099511627775" <<<"$out" ||
+        fail "warc-offset failed for another reason: $out"
+fi
 httrack -O "$tmp/out" "-#test=cache-readfail" "$tmp/"
 httrack -O "$tmp/out" "-#test=zip-abandon" "$tmp/"
 

--- a/tests/351_engine-warc-cache-io.test
+++ b/tests/351_engine-warc-cache-io.test
@@ -16,17 +16,20 @@ cleanup_push rm -rf "$tmp"
 
 httrack -O "$tmp/out" "-#test=warc-offset" "$tmp/"
 
-# A filesystem whose file-size cap sits below an offset refuses the seek with
-# EFBIG (GNU/Hurd ext2fs, which reds this test on the Debian buildd). Tolerated
-# for the case it hides, but only while a wide offset is still measurable.
+# EFBIG means the filesystem's cap sits below the offset (GNU/Hurd ext2fs), and
+# is tolerated only while some offset past 2GB still succeeds.
 seekfail_ready() {
-    test "$HTS_OS" = Linux || return 1
-    # Only a static-only build is a legitimate absence; anything else missing
-    # would let the two legs below pass by never running.
+    if [ "$HTS_OS" != Linux ]; then
+        echo "LD_PRELOAD interposition is Linux-only here, skipping the cap legs" >&2
+        return 1
+    fi
+    # A static-only build is the only absence that may skip; anything else
+    # missing would let the legs below never run.
     if [ ! -r "${SEEKFAIL_LA:-}" ]; then
         fail "${SEEKFAIL_LA:-\$SEEKFAIL_LA} was not built"
     fi
     if grep -q "^dlname=''" "$SEEKFAIL_LA"; then
+        echo "static-only build, skipping the cap legs" >&2
         return 1
     fi
     if [ ! -r "${SEEKFAIL_LIB:-}" ]; then
@@ -36,31 +39,30 @@ seekfail_ready() {
 }
 
 if seekfail_ready; then
-    # The shim allocates nothing, so loading ahead of libasan is harmless.
-    export ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}verify_asan_link_order=0"
+    # The shim allocates nothing, so loading ahead of libasan is harmless. Not
+    # exported: the selftests below run without the shim and want ASan intact.
+    asan_opts="${ASAN_OPTIONS:+$ASAN_OPTIONS:}verify_asan_link_order=0"
 
     # Only the 1TB case refused: the rest still prove the tell is 64-bit wide.
     rc=0
-    out=$(SEEKFAIL_CAP=1099511627774 LD_PRELOAD="$SEEKFAIL_LIB" \
+    out=$(ASAN_OPTIONS="$asan_opts" SEEKFAIL_CAP=1099511627774 LD_PRELOAD="$SEEKFAIL_LIB" \
         httrack -O "$tmp/out" "-#test=warc-offset" "$tmp/" 2>&1) || rc=$?
     test "$rc" -eq 0 || fail "a capped filesystem must not fail warc-offset: $out"
     grep -q "past this filesystem's file-size cap" <<<"$out" ||
         fail "the skipped offset was not reported: $out"
 
-    # Every wide offset refused: nothing is left to measure, and swallowing that
-    # silently is what the tolerance above must not do.
+    # Refusing every wide offset must fail the tally, not pass silently.
     rc=0
-    out=$(SEEKFAIL_CAP=2147483647 LD_PRELOAD="$SEEKFAIL_LIB" \
+    out=$(ASAN_OPTIONS="$asan_opts" SEEKFAIL_CAP=2147483647 LD_PRELOAD="$SEEKFAIL_LIB" \
         httrack -O "$tmp/out" "-#test=warc-offset" "$tmp/" 2>&1) || rc=$?
     test "$rc" -ne 0 || fail "warc-offset passed with no offset past 2GB: $out"
     grep -q "no offset past 2GB was measurable" <<<"$out" ||
         fail "warc-offset failed for another reason: $out"
 
-    # EFBIG is the ceiling; any other refusal is a seek that should have worked,
-    # and excusing those would hide the 32-bit off_t this selftest is about.
+    # Only EFBIG is excused; any other errno is a real seek failure to report.
     rc=0
     out=$(SEEKFAIL_CAP=1099511627774 SEEKFAIL_ERROR=eio \
-        LD_PRELOAD="$SEEKFAIL_LIB" \
+        ASAN_OPTIONS="$asan_opts" LD_PRELOAD="$SEEKFAIL_LIB" \
         httrack -O "$tmp/out" "-#test=warc-offset" "$tmp/" 2>&1) || rc=$?
     test "$rc" -ne 0 || fail "warc-offset excused a non-EFBIG seek failure: $out"
     grep -q "cannot seek to 1099511627775" <<<"$out" ||

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,7 @@ TESTS = @TESTS_LIST@
 # Committed binary fixture read by 01_zlib-cache-golden.test. List it
 # explicitly: automake does not expand wildcards in EXTRA_DIST, so a glob would
 # silently drop it from the dist tarball and break "make distcheck".
-EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c altstackprobe.c nopieprobe.c closetrack.c ftpcancel.c crawl-test.sh run-all-tests.sh check-network.sh check-test-names.sh \
+EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c altstackprobe.c nopieprobe.c closetrack.c ftpcancel.c seekfail.c crawl-test.sh run-all-tests.sh check-network.sh check-test-names.sh \
 	proxy-https-server.py socks5-server.py proxy-connect-server.py \
 	proxytestlib.py tls-stall-server.py warc-validate.py wacz-validate.py \
 	header-injection-server.py header-injection-check.py \
@@ -82,6 +82,8 @@ TESTS_ENVIRONMENT += ALTSTACKPROBE_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/libaltsta
 TESTS_ENVIRONMENT += CLOSETRACK_LA=$(abs_builddir)/libclosetrack.la
 TESTS_ENVIRONMENT += CLOSETRACK_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/libclosetrack.so
 TESTS_ENVIRONMENT += FTPCANCEL_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/libftpcancel.so
+TESTS_ENVIRONMENT += SEEKFAIL_LA=$(abs_builddir)/libseekfail.la
+TESTS_ENVIRONMENT += SEEKFAIL_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/libseekfail.so
 TESTS_ENVIRONMENT += STRINGOOM_BIN=$(abs_builddir)/stringoom$(EXEEXT)
 # 215_engine-datadir-ospath.test runs the engine from a copy, so it needs the
 # real binary rather than the libtool wrapper script, plus the loader variable
@@ -96,7 +98,8 @@ TESTS_ENVIRONMENT += HTTRACK_STDERR_WRAP_EXE=$(abs_builddir)/stderrwrap$(EXEEXT)
 # rename() interposer for 01_engine-renameover.test; -rpath is what makes
 # libtool build a shared module rather than a static-only convenience library.
 check_LTLIBRARIES = librenamefail.la libunlinkfail.la libthreadattrfail.la \
-	libnobacktrace.la libaltstackprobe.la libclosetrack.la libftpcancel.la
+	libnobacktrace.la libaltstackprobe.la libclosetrack.la libftpcancel.la \
+	libseekfail.la
 librenamefail_la_SOURCES = renamefail.c
 librenamefail_la_LDFLAGS = -module -avoid-version -rpath $(abs_builddir)
 librenamefail_la_LIBADD = $(DL_LIBS)
@@ -129,6 +132,11 @@ libclosetrack_la_LIBADD = $(DL_LIBS)
 libftpcancel_la_SOURCES = ftpcancel.c
 libftpcancel_la_LDFLAGS = -module -avoid-version -rpath $(abs_builddir)
 libftpcancel_la_LIBADD = $(DL_LIBS) -lpthread
+
+# fseeko() ceiling for 351_engine-warc-cache-io.test
+libseekfail_la_SOURCES = seekfail.c
+libseekfail_la_LDFLAGS = -module -avoid-version -rpath $(abs_builddir)
+libseekfail_la_LIBADD = $(DL_LIBS)
 
 # realloc stub for 152_engine-string-oom.test; links nothing, so it stays a
 # plain binary rather than a libtool wrapper script.

--- a/tests/seekfail.c
+++ b/tests/seekfail.c
@@ -1,7 +1,6 @@
-/* fseeko() fails with EFBIG past SEEKFAIL_CAP bytes, standing in for a
-   filesystem whose file-size ceiling is low (GNU/Hurd ext2fs) in
-   351_engine-warc-cache-io.test. SEEKFAIL_ERROR=eio refuses for another
-   reason, which nothing may excuse. */
+/* fseeko() fails with EFBIG past SEEKFAIL_CAP bytes, standing in for GNU/Hurd
+   ext2fs's low file-size ceiling. SEEKFAIL_ERROR=eio refuses for an unrelated
+   reason instead, which nothing may excuse. */
 
 #define _GNU_SOURCE
 #include <dlfcn.h>
@@ -24,8 +23,14 @@ SHIM_EXPORT int fseeko64(FILE *stream, int64_t offset, int whence);
 static int seekfail_capped(int64_t offset) {
   const char *const cap = getenv("SEEKFAIL_CAP");
   const char *const kind = getenv("SEEKFAIL_ERROR");
+  char *end;
 
-  if (cap == NULL || offset <= (int64_t) strtoll(cap, NULL, 10)) {
+  /* a cap that is not a number would otherwise read as zero and refuse
+   * everything */
+  if (cap == NULL || *cap == '\0') {
+    return 0;
+  }
+  if (offset <= (int64_t) strtoll(cap, &end, 10) || *end != '\0') {
     return 0;
   }
   errno = kind != NULL && strcmp(kind, "eio") == 0 ? EIO : EFBIG;

--- a/tests/seekfail.c
+++ b/tests/seekfail.c
@@ -13,12 +13,19 @@
 /* The tree builds with -fvisibility=hidden, which would hide the interposer. */
 #define SHIM_EXPORT __attribute__((visibility("default")))
 
-/* glibc redirects fseeko to fseeko64 under _FILE_OFFSET_BITS=64, and the engine
-   calls whichever its own build resolved to: interpose both names. */
-#undef fseeko
+/* The engine calls whichever name its own build resolved to, so interpose both.
+   Under _FILE_OFFSET_BITS=64 glibc aliases the fseeko declaration onto
+   fseeko64, and defining both names then emits one assembler symbol twice. */
+#if defined(__GLIBC__) && defined(__USE_FILE_OFFSET64)
+#define SEEKFAIL_FSEEKO_IS_FSEEKO64
+#endif
 
+#ifndef SEEKFAIL_FSEEKO_IS_FSEEKO64
 SHIM_EXPORT int fseeko(FILE *stream, off_t offset, int whence);
+#endif
+#ifdef __GLIBC__
 SHIM_EXPORT int fseeko64(FILE *stream, int64_t offset, int whence);
+#endif
 
 static int seekfail_capped(int64_t offset) {
   const char *const cap = getenv("SEEKFAIL_CAP");
@@ -37,6 +44,7 @@ static int seekfail_capped(int64_t offset) {
   return 1;
 }
 
+#ifndef SEEKFAIL_FSEEKO_IS_FSEEKO64
 SHIM_EXPORT int fseeko(FILE *stream, off_t offset, int whence) {
   static int (*real_fseeko)(FILE *, off_t, int) = NULL;
 
@@ -52,7 +60,9 @@ SHIM_EXPORT int fseeko(FILE *stream, off_t offset, int whence) {
   }
   return real_fseeko(stream, offset, whence);
 }
+#endif
 
+#ifdef __GLIBC__
 SHIM_EXPORT int fseeko64(FILE *stream, int64_t offset, int whence) {
   static int (*real_fseeko64)(FILE *, int64_t, int) = NULL;
 
@@ -68,3 +78,4 @@ SHIM_EXPORT int fseeko64(FILE *stream, int64_t offset, int whence) {
   }
   return real_fseeko64(stream, offset, whence);
 }
+#endif

--- a/tests/seekfail.c
+++ b/tests/seekfail.c
@@ -1,0 +1,65 @@
+/* fseeko() fails with EFBIG past SEEKFAIL_CAP bytes, standing in for a
+   filesystem whose file-size ceiling is low (GNU/Hurd ext2fs) in
+   351_engine-warc-cache-io.test. SEEKFAIL_ERROR=eio refuses for another
+   reason, which nothing may excuse. */
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* The tree builds with -fvisibility=hidden, which would hide the interposer. */
+#define SHIM_EXPORT __attribute__((visibility("default")))
+
+/* glibc redirects fseeko to fseeko64 under _FILE_OFFSET_BITS=64, and the engine
+   calls whichever its own build resolved to: interpose both names. */
+#undef fseeko
+
+SHIM_EXPORT int fseeko(FILE *stream, off_t offset, int whence);
+SHIM_EXPORT int fseeko64(FILE *stream, int64_t offset, int whence);
+
+static int seekfail_capped(int64_t offset) {
+  const char *const cap = getenv("SEEKFAIL_CAP");
+  const char *const kind = getenv("SEEKFAIL_ERROR");
+
+  if (cap == NULL || offset <= (int64_t) strtoll(cap, NULL, 10)) {
+    return 0;
+  }
+  errno = kind != NULL && strcmp(kind, "eio") == 0 ? EIO : EFBIG;
+  return 1;
+}
+
+SHIM_EXPORT int fseeko(FILE *stream, off_t offset, int whence) {
+  static int (*real_fseeko)(FILE *, off_t, int) = NULL;
+
+  if (whence == SEEK_SET && seekfail_capped((int64_t) offset)) {
+    return -1;
+  }
+  if (real_fseeko == NULL) {
+    *(void **) &real_fseeko = dlsym(RTLD_NEXT, "fseeko");
+    if (real_fseeko == NULL) {
+      errno = ENOSYS;
+      return -1;
+    }
+  }
+  return real_fseeko(stream, offset, whence);
+}
+
+SHIM_EXPORT int fseeko64(FILE *stream, int64_t offset, int whence) {
+  static int (*real_fseeko64)(FILE *, int64_t, int) = NULL;
+
+  if (whence == SEEK_SET && seekfail_capped(offset)) {
+    return -1;
+  }
+  if (real_fseeko64 == NULL) {
+    *(void **) &real_fseeko64 = dlsym(RTLD_NEXT, "fseeko64");
+    if (real_fseeko64 == NULL) {
+      errno = ENOSYS;
+      return -1;
+    }
+  }
+  return real_fseeko64(stream, offset, whence);
+}


### PR DESCRIPTION
The probe seeks a file to 1TB-1 to prove the CDXJ record offset stays 64-bit past the 2GB `long` ceiling. GNU/Hurd's ext2fs caps file size well below that, so `fseeko()` returns `EFBIG` and `351_engine-warc-cache-io` reds on the [Debian buildd](https://buildd.debian.org/status/package.php?p=httrack)'s hurd-i386 leg. `01_engine-fsize` already skips on that host for the same cap.

Offsets the filesystem refuses are now skipped and reported to stderr, but only for `EFBIG`. The selftest also counts how many offsets past 2GB it measured and fails when that count is zero, so a host that refuses all of them cannot pass having proved nothing.

A new `fseeko()` interposer stands in for a filesystem with a low ceiling. A cap that hides only the 1TB case still passes; a cap below 2GB has to fail on the tally; a refusal that is not `EFBIG` has to fail too. Each of the three kills a mutant of the fix.