### PR TITLE
341 builds a near-miss host the server accepts by design

### DIFF
--- a/tests/341_webhttrack-authority.test
+++ b/tests/341_webhttrack-authority.test
@@ -53,11 +53,19 @@ echo "ok: the panel answers at every authority it is reachable at"
 # browsed at http://myhost.lan:8080/ presents. Dropped when another rule would
 # accept it anyway, since it would then prove nothing.
 selfname=$(htsserver_python -c 'import socket; print(socket.gethostname())')
-case $(printf '%s' "${selfname}" | tr '[:upper:]' '[:lower:]') in
-localhost) selfname='' ;;
-*[!0-9.]*) ;;
-*) selfname='' ;;
-esac
+# True for a name some other rule vouches for anyway: localhost, or anything
+# shaped like an address literal, which host_is_address() takes for whoever
+# opened the socket.
+covered_elsewhere() {
+    case $(printf '%s' "$1" | tr '[:upper:]' '[:lower:]') in
+    localhost | '') return 0 ;;
+    *[!0-9.]*) return 1 ;;
+    *) return 0 ;;
+    esac
+}
+if covered_elsewhere "${selfname}"; then
+    selfname=''
+fi
 test "${#selfname}" -lt 256 || selfname=''
 if test -n "${selfname}"; then
     # Upper-cased too: the compare is case-insensitive, as it is for localhost.
@@ -75,8 +83,11 @@ bad_hosts=("evil.example" "evil.example:${HTS_PORT}" "127.0.0.1.evil.example")
 if test -n "${selfname}"; then
     # Near-misses on every side: the match is the whole name, never part of it.
     bad_hosts+=("${selfname}.evil.example" "evil.${selfname}" "${selfname}x")
-    # A one-character name truncates to "", which the good loop above accepts.
-    test "${#selfname}" -lt 2 || bad_hosts+=("${selfname%?}")
+    # Not every truncation is a near-miss: dropping the last character of
+    # "12764103200x" leaves an address literal the server accepts by design.
+    if [ "${#selfname}" -ge 2 ] && ! covered_elsewhere "${selfname%?}"; then
+        bad_hosts+=("${selfname%?}")
+    fi
 fi
 for bad in "${bad_hosts[@]}"; do
     resp=$(post_as "${bad}")


### PR DESCRIPTION
`341_webhttrack-authority` truncates this host's own name to prove the Host match is whole-name rather than a prefix. That is only a near-miss when what is left is still a DNS name: `host_is_address()` accepts any all-digits-and-dots authority as whoever opened the socket, so a hostname like `12764103200x` truncates to something the panel answers at by design. A uutils CI runner drew that hostname and the leg went red on correct behaviour.

The name itself already goes through that filter before being used. This reuses it for the truncation. Verified against the live server: `12764103200` and `1.2.3.4` are accepted, while `rowie` (a real truncation of this box's `rowie3`) is still refused, so the assertion keeps its teeth on an ordinary host.
