### PR TITLE
A Romanian user is shown the English translators

### DIFF
--- a/lang/Romanian.txt
+++ b/lang/Romanian.txt
@@ -651,7 +651,7 @@ Deconectează şa terminare
 Disconnect modem on completion
 Deconectează modemul la terminare
 \r\n(Please notify us of any bug or problem)\r\n\r\nDevelopment:\r\nEngine and interfaces: Xavier Roche\r\nCode, documentation and packaging: many contributors\r\n\r\n(C) Xavier Roche and other contributors\r\nMANY THANKS for English translations to:\r\nXavier Roche, Robert Lagadec
-
+\r\n(Please notify us of any bug or problem)\r\n\r\nDevelopment:\r\nEngine and interfaces: Xavier Roche\r\nCode, documentation and packaging: many contributors\r\n\r\n(C) Xavier Roche and other contributors\r\nMANY THANKS for Romanian translations to:\r\nAlin Gheorghe Miron
 About WinHTTrack Website Copier
 Despre WinHTTrack Website Copier
 Please visit our Web page

--- a/tests/372_credits.test
+++ b/tests/372_credits.test
@@ -80,6 +80,12 @@ if probe != ["Zzz", "Armish", "Qwertson"]:
     sys.exit("the name parser reads %r out of the fixture" % (probe,))
 if named_in(authors, "Zzz"):
     sys.exit("the fixture name is in AUTHORS, so the check below cannot fail")
+dangling = lambda v: (lambda t: t == "" or t.endswith(":"))(v.split("\\r\\n")[-1].strip())
+for shape in ("body\\r\\nMANY THANKS to:", "body\\r\\n", "body\\r\\n   "):
+    if not dangling(shape):
+        sys.exit("the dangling-credit check does not see %r" % shape)
+if dangling("body\\r\\nAlin Gheorghe Miron"):
+    sys.exit("the dangling-credit check fires on a value that names someone")
 
 catalogs = sorted(glob.glob(os.path.join(top, "lang", "*.txt")))
 if len(catalogs) < 25:
@@ -127,6 +133,12 @@ for path in catalogs:
         bad.append("%s: does not carry the About blurb msgid" % base)
         continue
     read_values += 1
+    # A credit label whose name went missing still reads as a credit, and the
+    # untranslated pin cannot see it: the value is neither empty nor the msgid.
+    tail = value.split("\\r\\n")[-1].strip() if value else None
+    if tail is not None and (tail == "" or tail.endswith(":")):
+        bad.append("%s: the About blurb ends on %r, a credit label naming nobody"
+                   % (base, tail))
     for who, owners in everyone.items():
         if who in shared or base in owners:
             continue

--- a/tests/62_lang-untranslated.counts
+++ b/tests/62_lang-untranslated.counts
@@ -26,7 +26,7 @@ Norsk.txt                 5         21
 Polski.txt                6         0
 Portugues-Brasil.txt      5         0
 Portugues.txt             5         26
-Romanian.txt              6         5
+Romanian.txt              6         4
 Russian.txt               5         0
 Slovak.txt                6         18
 Slovenian.txt             7         25

--- a/tests/62_lang-untranslated.counts
+++ b/tests/62_lang-untranslated.counts
@@ -3,6 +3,8 @@
 # 62_lang-integrity.test wants an exact match, so translate a string rather than
 # raise a count. A true cognate is the exception: "Manual" is the Spanish,
 # Portuguese and Romanian word, not a msgid nobody got to.
+# Romanian's About blurb counts as translated on both columns while its body
+# is still English: only the credit line was fixed (#1454).
 #
 # catalog                 identical empty
 Bulgarian.txt             3         3


### PR DESCRIPTION
lang/Romanian.txt has never carried a value for the About blurb, so the engine falls back to English and tells a Romanian user that Xavier Roche and Robert Lagadec translated it. Confirmed by serving /server/about.html at lang 25 before and after.

The value added here is the English text the fallback already renders, with only the credit line changed to name Alin Gheorghe Miron, who is Romanian's LANGUAGE_AUTHOR. Nothing a translator wrote is overwritten, because there was nothing there. The body stays English until a Romanian speaker translates it, which is what a reader sees today anyway.

Romanian's empty count in the untranslated pin drops from 5 to 4. Emptying the value again, dropping the credit line, or crediting another catalog's translator each fail a test.

Found while checking the fallout of #1453 against the other front ends.
