### PR TITLE
Release 3.49.25

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,8 +29,8 @@ AC_CONFIG_SRCDIR(src/httrack.c)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
-# 3:18:0: revision-only bump. hts_print_num moved out of httrack.c so a test can
-# link it, but htsbacktrace.h is not installed and no export came or went.
+# 3:18:0: revision-only bump. hts_print_num moved to htsbacktrace.c, which is not
+# in the library and whose header is not installed; no export came or went.
 # 3:17:0: revision-only bump. httrackp gained a tail field (links_unqueued) and
 # BackStatusCode two enumerators at the end (STATUSCODE_IO_FATAL, STATUSCODE_IO_ERROR);
 # no layout moved, no export came or went. This is the release that ships 3:16:0's

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.71])
 
-AC_INIT([httrack], [3.49.24], [roche+packaging@httrack.com], [httrack], [https://www.httrack.com/])
+AC_INIT([httrack], [3.49.25], [roche+packaging@httrack.com], [httrack], [https://www.httrack.com/])
 AC_COPYRIGHT([
 HTTrack Website Copier, Offline Browser for Windows and Unix
 Copyright (C) 1998-2015 Xavier Roche and other contributors
@@ -29,6 +29,8 @@ AC_CONFIG_SRCDIR(src/httrack.c)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
+# 3:18:0: revision-only bump. hts_print_num moved out of httrack.c so a test can
+# link it, but htsbacktrace.h is not installed and no export came or went.
 # 3:17:0: revision-only bump. httrackp gained a tail field (links_unqueued) and
 # BackStatusCode two enumerators at the end (STATUSCODE_IO_FATAL, STATUSCODE_IO_ERROR);
 # no layout moved, no export came or went. This is the release that ships 3:16:0's
@@ -58,7 +60,7 @@ AM_INIT_AUTOMAKE([subdir-objects])
 # moves nothing). Soname stays .so.3: HTTrackQt is the only consumer of the installed
 # headers, so a libhttrack4 rename isn't worth it.
 # (3:0:0 was the htsblk mime-buffer widening, the ABI break that moved .so.2 -> .so.3.)
-VERSION_INFO="3:17:0"
+VERSION_INFO="3:18:0"
 AM_MAINTAINER_MODE
 AC_USE_SYSTEM_EXTENSIONS
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+httrack (3.49.25-1) unstable; urgency=medium
+
+  * New upstream release: the About box names each language's own
+    translators, a crash report prints the signal number the right way
+    round, and links to httrack.com open over https; full list in
+    history.txt.
+  * debian/control: use https for the Homepage and the snapshots URL.
+
+ -- Xavier Roche <xavier@debian.org>  Fri, 28 Aug 2026 12:12:16 +0200
+
 httrack (3.49.24-1) unstable; urgency=medium
 
   * New upstream release: a mirror the engine abandoned no longer exits 0,

--- a/history.txt
+++ b/history.txt
@@ -4,6 +4,13 @@ HTTrack Website Copier release history:
 
 This file lists all changes and fixes that have been made for HTTrack
 
+3.49-25
++ Fixed: the crash report printed signal numbers with their digits reversed, so hppa's SIGBUS read as "Caught signal 01" (#1450)
++ Fixed: every language's About box thanked one translator on behalf of all of them, beside a copyright stamped 1998-2003. Each catalog now names its own translators, and the five that credited the wrong person name the right one (#1453, #1454, #1455)
++ Fixed: the Czech and Macedonian credit lines broke over three lines in the About box (#1457)
++ Changed: links to httrack.com in the About box, the man pages and the documentation now use https. Three links that no longer resolve are gone, and the example hosts in --help and the documentation moved to example.com, off domains someone else owns (#1457)
++ Changed: multiple internal test and build improvements (#1451, #1452, #1456)
+
 3.49-24
 + New: the engine says when it gave up. A mirror abandoned on a fatal write, a full disk or an exhausted link table returns 3 (HTS_EXIT_MIRROR_ABORTED) rather than printing "Done." and exiting 0; a mirror stopped on purpose, by --max-time, --max-size or a front end, still returns 0 (#1419, #1428)
 + New: a file kept from disk instead of fetched is named in the log at the default verbosity, where the four sites that do it used to say nothing outside debug output (#1378)

--- a/history.txt
+++ b/history.txt
@@ -6,9 +6,9 @@ This file lists all changes and fixes that have been made for HTTrack
 
 3.49-25
 + Fixed: the crash report printed signal numbers with their digits reversed, so hppa's SIGBUS read as "Caught signal 01" (#1450)
-+ Fixed: every language's About box thanked one translator on behalf of all of them, beside a copyright stamped 1998-2003. Each catalog now names its own translators, and the five that credited the wrong person name the right one (#1453, #1454, #1455)
-+ Fixed: the Czech and Macedonian credit lines broke over three lines in the About box (#1457)
-+ Changed: links to httrack.com in the About box, the man pages and the documentation now use https. Three links that no longer resolve are gone, and the example hosts in --help and the documentation moved to example.com, off domains someone else owns (#1457)
++ Fixed: five catalogs credited the wrong translator in the About box and Romanian fell back to the English list. The credit now comes from each catalog's own author field, and the box drops a copyright stamped 1998-2003 and a development line that named a single Windows interface (#1453, #1454)
++ Changed: AUTHORS, greetings.txt and the contact page carry one contributor roster (#1453, #1455)
++ Changed: links to httrack.com in the About box, the man pages and the documentation use https. Two dead documentation links are repointed and one is dropped, the example hosts in --help and the documentation moved to example.com off domains someone else owns, and the README names macOS and Android where it described a Windows 2000/XP/Vista/Seven release (#1457)
 + Changed: multiple internal test and build improvements (#1451, #1452, #1456)
 
 3.49-24

--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -53,6 +53,15 @@
   <content_rating type="oars-1.1"/>
   <!-- Newest first; tests/01_engine-version-macros.test enforces it. -->
   <releases>
+    <release version="3.49.25" date="2026-08-28">
+      <description>
+        <ul>
+          <li>The About box credits the people who translated your language</li>
+          <li>A crash report prints the signal number the right way round</li>
+          <li>Links to httrack.com open over https</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.49.24" date="2026-08-26">
       <description>
         <ul>

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -43,8 +43,8 @@ Please visit our Website: http://www.httrack.com
    configure.ac, decoupled from these). VERSION is the display form, VERSIONID
    the dotted numeric form, AFF_VERSION the short form shown in footers,
    LIB_VERSION the data/cache format generation. */
-#define HTTRACK_VERSION "3.49-24"
-#define HTTRACK_VERSIONID "3.49.24"
+#define HTTRACK_VERSION "3.49-25"
+#define HTTRACK_VERSIONID "3.49.25"
 #define HTTRACK_AFF_VERSION "3.x"
 #define HTTRACK_LIB_VERSION "2.0"
 

--- a/src/version.rc
+++ b/src/version.rc
@@ -17,8 +17,8 @@
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-  FILEVERSION 3, 49, 24, 0
-  PRODUCTVERSION 3, 49, 24, 0
+  FILEVERSION 3, 49, 25, 0
+  PRODUCTVERSION 3, 49, 25, 0
   FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
 #ifdef _DEBUG
   FILEFLAGS VS_FF_DEBUG
@@ -35,12 +35,12 @@ BEGIN
     BEGIN
       VALUE "CompanyName", "Xavier Roche"
       VALUE "FileDescription", VER_FILE_DESCRIPTION
-      VALUE "FileVersion", "3.49.24"
+      VALUE "FileVersion", "3.49.25"
       VALUE "InternalName", VER_ORIGINAL_FILENAME
       VALUE "LegalCopyright", "Copyright (C) 1998-2026 Xavier Roche and other contributors. GNU GPL v3 or later."
       VALUE "OriginalFilename", VER_ORIGINAL_FILENAME
       VALUE "ProductName", "HTTrack Website Copier"
-      VALUE "ProductVersion", "3.49-24"
+      VALUE "ProductVersion", "3.49-25"
     END
   END
   BLOCK "VarFileInfo"


### PR DESCRIPTION
Version bump to 3.49.25, likely the last 3.49 before 3.50.0. Eight changes since 3.49.24: the crash report printed signal numbers with their digits reversed (invisible on x86, red on the hppa buildd), five catalogs credited the wrong translator in the About box, and a sweep of documentation, link and example-host nits found while checking what a freeze would carry.

`VERSION_INFO` goes to 3:18:0, revision-only: `hts_print_num` moved to `htsbacktrace.c`, which is not in the library and whose header is not installed, so no export came or went. `Standards-Version` 4.7.4 still matches debian-policy 4.7.4.1, so it stays. The only `debian/` change since the last release is control's http to https URLs, which is what its changelog entry names.
