### PR TITLE
The macOS DMG misses the Release it was built for

### DIFF
--- a/.github/workflows/macos-attach-dmg.yml
+++ b/.github/workflows/macos-attach-dmg.yml
@@ -1,0 +1,61 @@
+# Attaches on the publish event rather than on the tag push: releases are cut by hand,
+# so the tag lands up to half an hour before the release exists. macos-release.yml used
+# to wait out that gap on a macOS runner and still lose it (3.49.25 missed by 73s).
+name: attach the macOS DMG
+
+on:
+  release:
+    types: [published]
+  # Exercise the path without cutting a release.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to attach the DMG to"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  attach:
+    name: attach the DMG to the release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - name: Attach the DMG built for this tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag || github.event.release.tag_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          test -n "$TAG" || { echo "::error::no tag to attach to"; exit 1; }
+
+          # A publish can still beat the build; this wait costs an ubuntu runner, not a macOS one.
+          deadline=$((SECONDS + 2700))
+          until run=$(gh run list --repo "$REPO" --workflow=macos-release.yml \
+              --branch "$TAG" --status success --json databaseId \
+              --jq '.[0].databaseId') && [ -n "$run" ]; do
+            test "$SECONDS" -lt "$deadline" || {
+              echo "::error::no successful macos-release run for $TAG after 45 min"
+              exit 1
+            }
+            sleep 30
+          done
+
+          gh run download "$run" --repo "$REPO" -n HTTrack-macos-arm64-dmg -D dmg
+
+          # Pinned to the tag, so a channel-labelled build cannot match: it carries the
+          # label where the version goes, and --clobber below would replace the real DMG.
+          set -- dmg/HTTrack-"$TAG"-macos-*.dmg
+          if test $# -ne 1 || test ! -f "$1"; then
+            echo "::error::expected one dmg/HTTrack-$TAG-macos-*.dmg, got: $*"
+            ls -l dmg >&2
+            exit 1
+          fi
+
+          gh release upload "$TAG" "$1" --repo "$REPO" --clobber
+          echo "attached $(basename "$1") to $TAG"

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -19,8 +19,6 @@ jobs:
   dmg:
     name: signed DMG (macOS arm64)
     runs-on: macos-15
-    permissions:
-      contents: write   # attach the DMG to the release the tag belongs to
     steps:
       - uses: actions/checkout@v7
         with:
@@ -152,31 +150,6 @@ jobs:
           name: HTTrack-macos-arm64-dmg
           path: ${{ runner.temp }}/HTTrack-*.dmg
           if-no-files-found: error
-
-      # Releases are cut by hand, so a tag lands minutes before one exists and this
-      # step used to lose that race, leaving the DMG on the artifacts where it needs
-      # a login and expires. It waits instead. A labelled build is never attached:
-      # ref_type is 'tag' for a dispatch on a tag as much as for a push.
-      - name: Attach the DMG to the release
-        if: github.ref_type == 'tag' && !inputs.label
-        timeout-minutes: 35
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          # 30 min: the publish step builds and signs a dist tarball first, and a
-          # tag pushed with no release ever coming costs only this wait.
-          deadline=$((SECONDS + 1800))
-          until gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; do
-            if test "$SECONDS" -ge "$deadline"; then
-              echo "::warning::no release $GITHUB_REF_NAME after 30 min;" \
-                   "the DMG is on this run's artifacts and will expire"
-              exit 0
-            fi
-            sleep 20
-          done
-          gh release upload "$GITHUB_REF_NAME" "$RUNNER_TEMP"/HTTrack-*.dmg --clobber
-          echo "attached to release $GITHUB_REF_NAME"
 
       - name: Delete the signing keychain
         if: always()


### PR DESCRIPTION
The DMG is attached on the tag push, but releases are cut by hand and the tag lands well before the Release exists. The build waited out that gap on a macOS runner and lost again on 3.49.25, by 73 seconds against a 30-minute budget, going green having attached nothing; the DMG then survives only as a run artifact that expires behind a login. It has been lost on 3.49.16, 3.49.22 and now 3.49.25, and won elsewhere only on timing, so raising the budget is the wrong lever: the wait is for however long a person takes.

Attaching now happens on `release: published`, which cannot fire before the Release exists. Waiting for a build that a publish beat moves to an ubuntu runner instead of a macOS one billed at ten times the rate, and a failure to attach reds a job rather than emitting a warning nobody reads.

The upload is pinned to `HTTrack-<tag>-macos-*.dmg`, where the old step globbed `HTTrack-*.dmg` with `--clobber` and let only `!inputs.label` stand between a channel-labelled build dispatched on a tag and overwriting a published, notarized DMG. A `workflow_dispatch` tag input keeps the path testable without cutting a release: the lookup, download and glob were run against 3.49.25's real artifacts, and the guard table-tested against a labelled, a wrong-version, an absent and an ambiguous DMG.
