### PR TITLE
Release 3.50.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.71])
 
-AC_INIT([httrack], [3.49.25], [roche+packaging@httrack.com], [httrack], [https://www.httrack.com/])
+AC_INIT([httrack], [3.50.0], [roche+packaging@httrack.com], [httrack], [https://www.httrack.com/])
 AC_COPYRIGHT([
 HTTrack Website Copier, Offline Browser for Windows and Unix
 Copyright (C) 1998-2015 Xavier Roche and other contributors
@@ -29,6 +29,8 @@ AC_CONFIG_SRCDIR(src/httrack.c)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
+# 3:19:0: revision-only bump for the 3.50.0 release; only the version macro moved,
+# the engine is untouched since 3.49.25.
 # 3:18:0: revision-only bump. hts_print_num moved to htsbacktrace.c, which is not
 # in the library and whose header is not installed; no export came or went.
 # 3:17:0: revision-only bump. httrackp gained a tail field (links_unqueued) and
@@ -60,7 +62,7 @@ AM_INIT_AUTOMAKE([subdir-objects])
 # moves nothing). Soname stays .so.3: HTTrackQt is the only consumer of the installed
 # headers, so a libhttrack4 rename isn't worth it.
 # (3:0:0 was the htsblk mime-buffer widening, the ABI break that moved .so.2 -> .so.3.)
-VERSION_INFO="3:18:0"
+VERSION_INFO="3:19:0"
 AM_MAINTAINER_MODE
 AC_USE_SYSTEM_EXTENSIONS
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ httrack (3.50.0-1) unstable; urgency=medium
 
   * New upstream release.  The version moves to 3.50 to match the Windows
     and Android front ends built on this engine; the engine itself is
-    unchanged since 3.49.25, so this upload carries no code change.
+    unchanged since 3.49.25, so this upload carries no functional change.
 
  -- Xavier Roche <xavier@debian.org>  Tue, 01 Sep 2026 09:00:00 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+httrack (3.50.0-1) unstable; urgency=medium
+
+  * New upstream release.  The version moves to 3.50 to match the Windows
+    and Android front ends built on this engine; the engine itself is
+    unchanged since 3.49.25, so this upload carries no code change.
+
+ -- Xavier Roche <xavier@debian.org>  Tue, 01 Sep 2026 09:00:00 +0200
+
 httrack (3.49.25-1) unstable; urgency=medium
 
   * New upstream release: the About box names each language's own

--- a/history.txt
+++ b/history.txt
@@ -4,6 +4,10 @@ HTTrack Website Copier release history:
 
 This file lists all changes and fixes that have been made for HTTrack
 
+3.50-0
++ New: this is the engine the Windows and Android front ends ship on. WinHTTrack had not been released since 3.49-2 in May 2017, so a Windows user coming from it gets everything listed under 3.49-3 to 3.49-25 below in one step: HTTPS against modern servers, SOCKS5 and CONNECT proxies, Brotli and Zstandard, files past 2 GB, Windows paths past 260 characters, accented and non-Latin project names and paths, --sitemap, --single-file, --changes, --host-alias, --why, WARC output, and an --update that keeps a good local copy when the server answers with an error
++ Changed: the engine is unchanged since 3.49-25, so binaries of the two behave identically
+
 3.49-25
 + Fixed: the crash report printed signal numbers with their digits reversed, so hppa's SIGBUS read as "Caught signal 01" (#1450)
 + Fixed: five catalogs credited the wrong translator in the About box and Romanian fell back to the English list. The credit now comes from each catalog's own author field, and the box drops a copyright stamped 1998-2003 and a development line that named a single Windows interface (#1453, #1454)

--- a/history.txt
+++ b/history.txt
@@ -5,8 +5,8 @@ HTTrack Website Copier release history:
 This file lists all changes and fixes that have been made for HTTrack
 
 3.50-0
-+ New: this is the engine the Windows and Android front ends ship on. WinHTTrack had not been released since 3.49-2 in May 2017, so a Windows user coming from it gets everything listed under 3.49-3 to 3.49-25 below in one step: HTTPS against modern servers, SOCKS5 and CONNECT proxies, Brotli and Zstandard, files past 2 GB, Windows paths past 260 characters, accented and non-Latin project names and paths, --sitemap, --single-file, --changes, --host-alias, --why, WARC output, and an --update that keeps a good local copy when the server answers with an error
-+ Changed: the engine is unchanged since 3.49-25, so binaries of the two behave identically
++ New: this is the engine the Windows and Android front ends ship on. WinHTTrack had not been released since 3.49-2 in May 2017, so a Windows user coming from it gets everything listed under 3.49-3 to 3.49-25 below in one step. The largest of those: HTTPS against modern servers, SOCKS5 and CONNECT proxies, Brotli and Zstandard, files past 2 GB, Windows paths past 260 characters, accented and non-Latin project names and paths, WARC output, --sitemap, --single-file, --changes and --host-alias, and an --update that keeps a good local copy when the server answers with an error
++ Changed: the engine is unchanged since 3.49-25. This release moves the version string, not behaviour
 
 3.49-25
 + Fixed: the crash report printed signal numbers with their digits reversed, so hppa's SIGBUS read as "Caught signal 01" (#1450)

--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -53,6 +53,14 @@
   <content_rating type="oars-1.1"/>
   <!-- Newest first; tests/01_engine-version-macros.test enforces it. -->
   <releases>
+    <release version="3.50.0" date="2026-09-01">
+      <description>
+        <ul>
+          <li>The version number moves to 3.50, matching the Windows and Android releases built on this engine</li>
+          <li>WebHTTrack itself is unchanged since 3.49.25</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.49.25" date="2026-08-28">
       <description>
         <ul>

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -43,8 +43,8 @@ Please visit our Website: http://www.httrack.com
    configure.ac, decoupled from these). VERSION is the display form, VERSIONID
    the dotted numeric form, AFF_VERSION the short form shown in footers,
    LIB_VERSION the data/cache format generation. */
-#define HTTRACK_VERSION "3.49-25"
-#define HTTRACK_VERSIONID "3.49.25"
+#define HTTRACK_VERSION "3.50-0"
+#define HTTRACK_VERSIONID "3.50.0"
 #define HTTRACK_AFF_VERSION "3.x"
 #define HTTRACK_LIB_VERSION "2.0"
 

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "libhttrack",
-  "version-string": "3.49",
+  "version-string": "3.50",
   "builtin-baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
   "dependencies": [
     "brotli",

--- a/src/version.rc
+++ b/src/version.rc
@@ -17,8 +17,8 @@
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-  FILEVERSION 3, 49, 25, 0
-  PRODUCTVERSION 3, 49, 25, 0
+  FILEVERSION 3, 50, 0, 0
+  PRODUCTVERSION 3, 50, 0, 0
   FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
 #ifdef _DEBUG
   FILEFLAGS VS_FF_DEBUG
@@ -35,12 +35,12 @@ BEGIN
     BEGIN
       VALUE "CompanyName", "Xavier Roche"
       VALUE "FileDescription", VER_FILE_DESCRIPTION
-      VALUE "FileVersion", "3.49.25"
+      VALUE "FileVersion", "3.50.0"
       VALUE "InternalName", VER_ORIGINAL_FILENAME
       VALUE "LegalCopyright", "Copyright (C) 1998-2026 Xavier Roche and other contributors. GNU GPL v3 or later."
       VALUE "OriginalFilename", VER_ORIGINAL_FILENAME
       VALUE "ProductName", "HTTrack Website Copier"
-      VALUE "ProductVersion", "3.49-25"
+      VALUE "ProductVersion", "3.50-0"
     END
   END
   BLOCK "VarFileInfo"


### PR DESCRIPTION
3.50 is the version the Windows and Android front ends ship on. WinHTTrack has had no release since 3.49-2 in May 2017, and both GUIs tag against this engine commit.

The engine itself has not changed since 3.49.25. The only commit between the two is a CI workflow fix, so this is a version bump across the six spots `01_engine-version-macros.test` pins, plus `VERSION_INFO` 3:18:0 to 3:19:0. The revision moves because the version macro is compiled into the library and `hts_version()` returns it; no struct or export moved.

`src/vcpkg.json` moves for the first time since #554 added it. It carries major.minor, so a patch release never reaches it, and #1457 added the test pin that now catches a stale value.

Held for 1 September: nothing tags or publishes before then.
