### PR TITLE
0.0.0.0 is not the non-loopback address 335 asks for

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,50 @@ jobs:
         if: failure()
         run: cat tests/test-suite.log 2>/dev/null || true
 
+  # Reproduces an rpm or deb buildroot: loopback alone, but carrying a default
+  # route and no resolver, where a UDP connect succeeds and names no source at
+  # all. Reading that wildcard as an address was #1463.
+  buildroot-network:
+    name: build (rpm/deb buildroot network)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential autoconf automake libtool autoconf-archive \
+            zlib1g-dev libssl-dev libbrotli-dev libzstd-dev iproute2
+
+      - name: Configure
+        run: |
+          set -euo pipefail
+          autoreconf -fi
+          ./configure
+
+      - name: Build
+        run: make -j"$(nproc)"
+
+      - name: Test on the network a buildroot has
+        timeout-minutes: 20
+        run: |
+          set -euo pipefail
+          jobs=$(( $(nproc) * 2 )); [ "$jobs" -le 16 ] || jobs=16
+          tools/buildroot-net.sh make check -j"$jobs"
+          # Only the widening half needs an address the namespace lacks, so a
+          # run that never reached the loopback half proves nothing.
+          cat tests/335_webhttrack-bind-loopback.log
+          grep -q 'the default socket answers on 127.0.0.1' \
+            tests/335_webhttrack-bind-loopback.log
+
+      - name: Print the test log on failure
+        if: failure()
+        run: cat tests/test-suite.log 2>/dev/null || true
+
   # The Ubuntu buildds run a development release every runner above is well behind.
   # That gap is what shipped 3.49.18 broken on every Ubuntu architecture but
   # riscv64, when 25.10 made uutils the default coreutils (#1042).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,10 +170,12 @@ jobs:
         if: failure()
         run: cat tests/test-suite.log 2>/dev/null || true
 
-  # Reproduces the buildds that refuse TEST-NET-1 instead of dropping it, where
-  # every fixture needing a stalled connect must skip rather than fail (#1108).
+  # Two networks no runner has: buildds that refuse TEST-NET-1 rather than drop
+  # it (#1108), and an rpm buildroot, where a UDP connect names no source at all
+  # and #1463 read that wildcard as an address. One job, since the build is the
+  # same and neither check is worth a second three-minute compile.
   hostile-network:
-    name: build (network refuses TEST-NET-1)
+    name: build (constrained networks)
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
@@ -208,39 +210,7 @@ jobs:
           cat tests/246_engine-connect-stop.log
           grep -q 'within 500 ms' tests/246_engine-connect-stop.log
 
-      - name: Print the test log on failure
-        if: failure()
-        run: cat tests/test-suite.log 2>/dev/null || true
-
-  # Reproduces an rpm or deb buildroot: loopback alone, but carrying a default
-  # route and no resolver, where a UDP connect succeeds and names no source at
-  # all. Reading that wildcard as an address was #1463.
-  buildroot-network:
-    name: build (rpm/deb buildroot network)
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: recursive
-
-      - name: Install build dependencies
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential autoconf automake libtool autoconf-archive \
-            zlib1g-dev libssl-dev libbrotli-dev libzstd-dev iproute2
-
-      - name: Configure
-        run: |
-          set -euo pipefail
-          autoreconf -fi
-          ./configure
-
-      - name: Build
-        run: make -j"$(nproc)"
-
-      - name: Test on the network a buildroot has
+      - name: Test on the network an rpm buildroot has
         timeout-minutes: 20
         run: |
           set -euo pipefail

--- a/tests/335_webhttrack-bind-loopback.test
+++ b/tests/335_webhttrack-bind-loopback.test
@@ -30,16 +30,17 @@ PY
 # A function, not a heredoc inside $(): bash 3.2 runs that one as commands.
 primary_ipv4() {
     htsserver_python - <<'PY'
-import socket
+import ipaddress, socket
 s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 try:
     s.connect(("192.0.2.1", 9))  # TEST-NET-1, never routed
-    ip = s.getsockname()[0]
-except OSError:
-    ip = ""
+    ip = ipaddress.ip_address(s.getsockname()[0])
+except (OSError, ValueError):
+    ip = None
 finally:
     s.close()
-print("" if ip.startswith("127.") else ip)
+# A loopback-only netns with a default route (mock's buildroot) answers 0.0.0.0.
+print("" if ip is None or ip.is_loopback or ip.is_unspecified else ip)
 PY
 }
 

--- a/tests/335_webhttrack-bind-loopback.test
+++ b/tests/335_webhttrack-bind-loopback.test
@@ -26,29 +26,45 @@ except OSError as e:
 PY
 }
 
-# The primary outbound IPv4, which a UDP connect() picks without sending a byte.
+# The primary outbound IPv4, which a UDP connect() picks without sending a byte,
+# or the classification of $1 when given one, so the guard below is checkable.
 # A function, not a heredoc inside $(): bash 3.2 runs that one as commands.
-primary_ipv4() {
-    htsserver_python - <<'PY'
-import ipaddress, socket
-s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+primary_ipv4() { # [address]
+    htsserver_python - ${1+"$1"} <<'PY'
+import ipaddress, socket, sys
+if len(sys.argv) > 1:
+    raw = sys.argv[1]
+else:
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(("192.0.2.1", 9))  # TEST-NET-1, never routed
+        raw = s.getsockname()[0]
+    except OSError:
+        raw = ""
+    finally:
+        s.close()
 try:
-    s.connect(("192.0.2.1", 9))  # TEST-NET-1, never routed
-    ip = ipaddress.ip_address(s.getsockname()[0])
-except (OSError, ValueError):
+    ip = ipaddress.ip_address(raw)
+except ValueError:
     ip = None
-finally:
-    s.close()
-# A loopback-only netns with a default route (mock's buildroot) answers 0.0.0.0.
+# 0.0.0.0 is what Fedora's mock answers: its buildroot is a loopback-only
+# namespace, but it carries a default route, so the connect above succeeds.
 print("" if ip is None or ip.is_loopback or ip.is_unspecified else ip)
 PY
 }
 
+# Taking the wildcard for an address was #1463; taking nothing would drop the
+# widening half in silence.
+for unusable in 0.0.0.0 127.0.0.1 127.9.9.9 ''; do
+    test -z "$(primary_ipv4 "${unusable}")" || fail "primary_ipv4 accepts ${unusable}"
+done
+test "$(primary_ipv4 198.51.100.7)" = 198.51.100.7 ||
+    fail "primary_ipv4 rejects a routable address"
+
 addr=$(primary_ipv4)
-test -n "${addr}" || skip "no non-loopback IPv4 address here"
 
 # Without this control a refusal below could just mean the box filters ${addr}.
-htsserver_python - "${addr}" <<'PY' || skip "cannot bind and reach ${addr} here"
+if test -n "${addr}" && ! htsserver_python - "${addr}" <<'PY'; then
 import socket, sys
 try:
     srv = socket.socket()
@@ -59,17 +75,24 @@ try:
 except OSError as e:
     sys.exit(str(e))
 PY
+    echo "cannot bind and reach ${addr} here" >&2
+    addr=
+fi
 
-port=$(htsserver_freeport)
-htsserver_start --port "${port}" --home "${work}/wide" -- --bind "${addr}"
-case ${HTS_URL} in
-*"//${addr}:"*) ;;
-*) fail "--bind ${addr} advertised ${HTS_URL}" ;;
-esac
-got=$(probe "${addr}" "${port}")
-test "${got}" = ok || fail "--bind ${addr} did not answer on ${addr} (${got})"
-echo "ok: --bind ${addr} widens the socket"
-htsserver_stop
+if test -n "${addr}"; then
+    port=$(htsserver_freeport)
+    htsserver_start --port "${port}" --home "${work}/wide" -- --bind "${addr}"
+    case ${HTS_URL} in
+    *"//${addr}:"*) ;;
+    *) fail "--bind ${addr} advertised ${HTS_URL}" ;;
+    esac
+    got=$(probe "${addr}" "${port}")
+    test "${got}" = ok || fail "--bind ${addr} did not answer on ${addr} (${got})"
+    echo "ok: --bind ${addr} widens the socket"
+    htsserver_stop
+else
+    echo "no non-loopback IPv4 here: the widening half did not run" >&2
+fi
 
 port=$(htsserver_freeport)
 htsserver_start --port "${port}" --home "${work}/default"
@@ -81,10 +104,20 @@ case ${HTS_URL} in
 esac
 got=$(probe 127.0.0.1 "${port}")
 test "${got}" = ok || fail "the default run refused 127.0.0.1 (${got})"
-got=$(probe "${addr}" "${port}")
-test "${got}" = ConnectionRefusedError ||
-    fail "the default run answers on ${addr} (${got})"
-echo "ok: the default socket is loopback-only"
+echo "ok: the default socket answers on 127.0.0.1"
+if test -n "${addr}"; then
+    got=$(probe "${addr}" "${port}")
+    test "${got}" = ConnectionRefusedError ||
+        fail "the default run answers on ${addr} (${got})"
+    # A dead server refuses too, so the refusal counts only while it is up.
+    got=$(probe 127.0.0.1 "${port}")
+    test "${got}" = ok || fail "the default run died before the refusal (${got})"
+    echo "ok: and refuses ${addr}"
+fi
+htsserver_stop
+
+# A leaked server wedges the parallel harness behind a green log.
+htsserver_assert_reaped
 
 htsserver_cleanup_dir "${work}"
 echo "PASS"

--- a/tests/373_credits.test
+++ b/tests/373_credits.test
@@ -34,7 +34,11 @@ pre = re.search(r"<pre>\n(.*?)</pre>", contact, re.S)
 if pre is None:
     sys.exit("html/contact.html has no <pre> credits block")
 if pre.group(1) != greetings:
-    bad.append("html/contact.html's <pre> is not greetings.txt verbatim")
+    got = pre.group(1)
+    at = next((i for i, (a, b) in enumerate(zip(got, greetings)) if a != b),
+              min(len(got), len(greetings)))
+    bad.append("html/contact.html's <pre> is not greetings.txt verbatim: at %d it has "
+               "%r, not %r" % (at, got[at:at + 6], greetings[at:at + 6]))
 
 # Contact groups out, what is left is the person. A group is dropped only when
 # it holds an address: "(Armish)" is part of a name, "(a@b.c)" is not.

--- a/tools/buildroot-net.sh
+++ b/tools/buildroot-net.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# Runs a command on the network an rpm or deb buildroot has: loopback alone, but
-# carrying a default route, and no resolver. mock installs exactly that (its
-# condUnshareNet adds "default via 127.0.0.1"), which makes a UDP connect to any
-# address succeed and name no source, and #1463 read that 0.0.0.0 as an address.
+# Runs a command on the network an rpm buildroot has: loopback alone, with a
+# default route and no resolver. Fedora's mock builds that, and a UDP connect
+# there succeeds while naming no source, which #1463 read as an address.
+# Debian's sbuild leaves out the default route, so it lands on the skip path.
 #
 # Usage: tools/buildroot-net.sh <command> [args...]      (re-execs under sudo)
 
@@ -15,11 +15,12 @@ fail() {
 }
 
 # Second entry, inside both namespaces: mount away the resolver and drop back to
-# the invoking user, since the suite must not run as root.
-if [ "${1:-}" = "--in-namespace" ]; then
+# the invoking user, since the suite must not run as root. On an env var, not an
+# argument: as a flag, a root caller typing it by hand unmounts the real one.
+if [ -n "${BUILDROOT_NET_INNER:-}" ]; then
     mount --bind /dev/null /etc/resolv.conf
-    run_as=$2
-    shift 2
+    run_as=${BUILDROOT_NET_INNER#user=}
+    unset BUILDROOT_NET_INNER # the payload gets a clean environment
     test -n "$run_as" || exec "$@"
     exec sudo -E -u "$run_as" "$@"
 fi
@@ -39,7 +40,7 @@ ip netns add "$ns"
 ip -n "$ns" link set lo up
 ip -n "$ns" route add default via 127.0.0.1
 
-# Non-vacuity: a namespace answering with a real address, or refusing the
+# Non-vacuity: a namespace that names a real address, or that refuses the
 # connect outright, is not the regime this leg exists to cover.
 src=$(ip netns exec "$ns" python3 -c 'import socket
 s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -54,6 +55,6 @@ test "$src" = "0.0.0.0" ||
     fail "the namespace answers $src, not the wildcard a buildroot names"
 
 rc=0
-ip netns exec "$ns" unshare --mount --propagation private \
-    bash "$0" --in-namespace "${SUDO_USER:-}" "$@" || rc=$?
+BUILDROOT_NET_INNER="user=${SUDO_USER:-}" ip netns exec "$ns" \
+    unshare --mount --propagation private bash "$0" "$@" || rc=$?
 exit "$rc"

--- a/tools/buildroot-net.sh
+++ b/tools/buildroot-net.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# Runs a command on the network an rpm or deb buildroot has: loopback alone, but
+# carrying a default route, and no resolver. mock installs exactly that (its
+# condUnshareNet adds "default via 127.0.0.1"), which makes a UDP connect to any
+# address succeed and name no source, and #1463 read that 0.0.0.0 as an address.
+#
+# Usage: tools/buildroot-net.sh <command> [args...]      (re-execs under sudo)
+
+set -euo pipefail
+
+fail() {
+    echo "buildroot-net: $*" >&2
+    exit 1
+}
+
+# Second entry, inside both namespaces: mount away the resolver and drop back to
+# the invoking user, since the suite must not run as root.
+if [ "${1:-}" = "--in-namespace" ]; then
+    mount --bind /dev/null /etc/resolv.conf
+    run_as=$2
+    shift 2
+    test -n "$run_as" || exec "$@"
+    exec sudo -E -u "$run_as" "$@"
+fi
+
+test $# -ge 1 || fail "usage: $0 <command> [args...]"
+
+if [ "$(id -u)" -ne 0 ]; then
+    exec sudo -E bash "$0" "$@"
+fi
+
+ns="buildrootnet$$"
+
+trap 'set +e; ip netns del "$ns" 2>/dev/null' EXIT
+trap 'exit 1' HUP INT TERM
+
+ip netns add "$ns"
+ip -n "$ns" link set lo up
+ip -n "$ns" route add default via 127.0.0.1
+
+# Non-vacuity: a namespace answering with a real address, or refusing the
+# connect outright, is not the regime this leg exists to cover.
+src=$(ip netns exec "$ns" python3 -c 'import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+try:
+    s.connect(("192.0.2.1", 9))
+    print(s.getsockname()[0])
+except OSError as e:
+    print(type(e).__name__)
+finally:
+    s.close()')
+test "$src" = "0.0.0.0" ||
+    fail "the namespace answers $src, not the wildcard a buildroot names"
+
+rc=0
+ip netns exec "$ns" unshare --mount --propagation private \
+    bash "$0" --in-namespace "${SUDO_USER:-}" "$@" || rc=$?
+exit "$rc"


### PR DESCRIPTION
Fedora's 3.49.25 build failed two tests, and only one of them is ours.

`335_webhttrack-bind-loopback` needs a non-loopback IPv4 to point `--bind` at, and finds one by UDP-connecting to TEST-NET-1 and reading back the source address. Fedora's mock builds inside a network namespace that holds only `lo`, but it adds `default via 127.0.0.1` there, so the connect succeeds and `getsockname()` answers `0.0.0.0`. The guard rejected `127.*` only, so the test read the wildcard as a real address and then failed on the `http://127.0.0.1:...` that `--bind 0.0.0.0` correctly advertises.

Rejecting the unspecified address fixes that. The guard also classifies an address passed as an argument now, so the test pins what it accepts before trusting it; both the old `127.*` guard and one that accepts nothing fail on it.

Skipping is no longer all-or-nothing either. The loopback-only half needs no second address, and a buildroot is where a panel binding wide would matter most, so that half runs everywhere and only the widening half stays conditional. The refusal probe re-checks 127.0.0.1 afterwards, because a server that died between the two probes refuses just as convincingly.

Nothing here built on loopback-plus-a-default-route, which is why this reached a release, so `tools/buildroot-net.sh` now does, as a second step of the existing constrained-network job. It refuses to run unless a UDP connect inside its namespace names `0.0.0.0`: one holding a real address would go green and prove nothing. Master's test fails in it, this branch passes, and the suite there takes two minutes and skips exactly what it skips anywhere else.

That covers Fedora only. `sbuild-usernsexec` brings `lo` up and empties `resolv.conf` but adds no default route, so a Debian buildroot gets ENETUNREACH and lands on the skip path instead.

The second failure is Fedora's spec, not ours. `%prep` iconvs `html/contact.html` from ISO-8859-1 to UTF-8, and that file has been UTF-8 since f1ace40d, so Fedora has shipped `LeÃ³n` where the credits say `León` since 3.49.18. `373_credits` compares that block against `greetings.txt` character for character and is right to fail. It only said "not verbatim", which is no use from a build log, so it now names the first differing text.

Closes #1463
