### PR TITLE
Termux hand-patches a generated Makefile.in because we probe execinfo.h and never backtrace()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -423,6 +423,20 @@ AX_CHECK_ALIGNED_ACCESS_REQUIRED
 # check for various headers
 AC_CHECK_HEADERS([execinfo.h sys/ioctl.h sys/random.h])
 
+## The header can exist while backtrace() lives in another library (Termux's
+## libandroid-execinfo); only httrack links it, so keep it out of LIBS.
+BACKTRACE_LIBS=
+AS_CASE([$host_os], [linux*],
+	[AS_IF([test "x$ac_cv_header_execinfo_h" = xyes],
+		[hts_backtrace_save_libs=$LIBS
+		AC_SEARCH_LIBS([backtrace], [execinfo android-execinfo],
+			[AC_DEFINE([HAVE_BACKTRACE], [1],
+				[Define to 1 if backtrace() can be linked.])
+			AS_IF([test "x$ac_cv_search_backtrace" != "xnone required"],
+				[BACKTRACE_LIBS=$ac_cv_search_backtrace])])
+		LIBS=$hts_backtrace_save_libs])])
+AC_SUBST([BACKTRACE_LIBS])
+
 ## CSPRNG for the --single-file mark; /dev/urandom is the fallback
 AC_CHECK_FUNCS([getrandom])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -38,7 +38,7 @@ bin_PROGRAMS = proxytrack httrack htsserver
 
 httrack_SOURCES = httrack.c htsbacktrace.c htsbacktrace.h
 # $(DL_LIBS): dladdr() in the crash handler, still in libdl on pre-2.34 glibc.
-httrack_LDADD = $(THREADS_LIBS) $(DL_LIBS) libhttrack.la
+httrack_LDADD = $(THREADS_LIBS) $(DL_LIBS) $(BACKTRACE_LIBS) libhttrack.la
 htsserver_LDADD = $(THREADS_LIBS) $(SOCKET_LIBS) libhttrack.la
 proxytrack_LDADD = $(THREADS_LIBS) $(SOCKET_LIBS)
 

--- a/src/htsbacktrace.c
+++ b/src/htsbacktrace.c
@@ -57,7 +57,8 @@ Please visit our Website: http://www.httrack.com
 #define USES_SIGALTSTACK
 #define BT_ALTSTACK_MIN (64 * 1024) /* floor: the report needs ~10kB */
 #endif
-#if (defined(__linux) && defined(HAVE_EXECINFO_H))
+/* HAVE_BACKTRACE means the symbol links, not just that the header exists. */
+#if (defined(__linux) && defined(HAVE_BACKTRACE))
 #include <dlfcn.h>
 #include <errno.h>
 #include <execinfo.h>

--- a/tests/218_crash-nopie-frames.test
+++ b/tests/218_crash-nopie-frames.test
@@ -37,8 +37,8 @@ sources=("${srcdir}/tests/nopieprobe.c" "${srcdir}/src/htsbacktrace.c")
 build() { # $1 output binary, rest extra flags
     local bin=$1
     shift
-    # shellcheck disable=SC2086 # DL_LIBS is a flag list; splitting is the point
-    "${cc_argv[@]}" "${cflags[@]}" "$@" -o "${bin}" "${sources[@]}" ${DL_LIBS:-} \
+    # shellcheck disable=SC2086 # DL_LIBS/BACKTRACE_LIBS are flag lists; splitting is the point
+    "${cc_argv[@]}" "${cflags[@]}" "$@" -o "${bin}" "${sources[@]}" ${DL_LIBS:-} ${BACKTRACE_LIBS:-} \
         >"${work}/cc.log" 2>&1
 }
 

--- a/tests/372_crash-signal-number.test
+++ b/tests/372_crash-signal-number.test
@@ -27,10 +27,10 @@ for flags in "${TEST_CFLAGS:-}" "${TEST_CPPFLAGS:-}"; do
     fi
 done
 cflags+=(-g -O0 -I"${builddir}" -I"${builddir}/src" -I"${srcdir}/src")
-# shellcheck disable=SC2086 # DL_LIBS is a flag list; splitting is the point
+# shellcheck disable=SC2086 # DL_LIBS/BACKTRACE_LIBS are flag lists; splitting is the point
 if ! "${cc_argv[@]}" "${cflags[@]}" -o "${work}/probe" \
     "${srcdir}/tests/printnumprobe.c" "${srcdir}/src/htsbacktrace.c" \
-    ${DL_LIBS:-} >"${work}/cc.log" 2>&1; then
+    ${DL_LIBS:-} ${BACKTRACE_LIBS:-} >"${work}/cc.log" 2>&1; then
     head -20 "${work}/cc.log" >&2
     # 218 pins that the crash printer builds standalone on Linux.
     if [ "$HTS_OS" = "Linux" ]; then

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -64,8 +64,11 @@ TESTS_ENVIRONMENT += TEST_CPPFLAGS="$(CPPFLAGS)"
 # flags, and skips when configure found no usable level.
 TESTS_ENVIRONMENT += TEST_CFLAGS="$(CFLAGS)"
 TESTS_ENVIRONMENT += FORTIFY_SOURCE_LEVEL=$(FORTIFY_SOURCE_LEVEL)
-# 218_crash-nopie-frames.test links the crash printer, which calls dladdr().
+# 218_crash-nopie-frames.test and 372_crash-signal-number.test link the crash
+# printer standalone, which calls dladdr() and, where backtrace() itself needs
+# a library (Termux's -landroid-execinfo), BACKTRACE_LIBS too.
 TESTS_ENVIRONMENT += DL_LIBS="$(DL_LIBS)"
+TESTS_ENVIRONMENT += BACKTRACE_LIBS="$(BACKTRACE_LIBS)"
 # 207_install-headers-symbols.test links a consumer probe against it; absent on a
 # static-only build and named .dylib on macOS, where that ELF-only test skips.
 TESTS_ENVIRONMENT += HTTRACK_SHLIB=$(abs_top_builddir)/src/$(LT_CV_OBJDIR)/libhttrack.so


### PR DESCRIPTION
`configure.ac` checks that `<execinfo.h>` exists and `src/htsbacktrace.c` builds the whole crash reporter on that, but nothing ever checks that `backtrace()` links. On glibc those are the same question. On Android they are not: `__linux` is defined, Termux's `libandroid-execinfo` package supplies the header, the file compiles, and then the link fails because the symbol lives in `-landroid-execinfo` and not in libc.

Termux carries two patches for that. `packages/httrack/src-htsbacktrace.c.patch` adds `&& !defined(__ANDROID__)` to switch the feature off, and `packages/httrack/src-Makefile.in.patch` hand-edits the generated `src/Makefile.in` to inject `-landroid-execinfo` into the link. The second one is the one that rots, since `Makefile.in` is a build product we regenerate at every release and the patch context moves under them for free.

The fix is to probe the link. `AC_SEARCH_LIBS([backtrace], [execinfo android-execinfo])` runs only when the header was found and only on a Linux host, which is the same set `__linux` admits, and `HAVE_BACKTRACE` replaces `HAVE_EXECINFO_H` in the guard. Its result goes into a substituted `BACKTRACE_LIBS` and `LIBS` is restored afterwards: only `httrack` compiles `htsbacktrace.c`, so there is no reason for `libhttrack`, `htsserver` and `proxytrack` to carry the dependency.

The claims below were measured, not assumed. On glibc the search answers "none required" and the `httrack` link line is byte-identical to master's, `LIBS` and the binary's `DT_NEEDED` set included. Forcing the search to fail with `ac_cv_search_backtrace=no` leaves `HAVE_BACKTRACE` undefined, builds warning-free, and leaves no undefined `backtrace` reference in the binary. That is the state musl and Alpine are in today. Forcing the search to resolve through a library instead puts `-landroid-execinfo` on exactly one link line, `httrack`'s.

FreeBSD does not change. It keeps `backtrace()` in `libexecinfo` and the `__linux` guard has always excluded it, so the search is gated on the host being `linux*` and never runs there. Configuring with `--host=x86_64-unknown-freebsd14.0` finds the header, leaves `BACKTRACE_LIBS` empty and defines nothing. Enabling the reporter on the BSDs would be a separate and much larger change, since the file also wants `dl_iterate_phdr`, `link.h` and `/proc/self/exe`.

No new test needed: `tests/183_altstack-worker.test` already hard-fails, not skips, when a build cannot produce a backtrace, since the #866/#969 fix it guards exists to make a killed worker's stack traceable. Forcing `ac_cv_search_backtrace=no` confirms it: 183 becomes the suite's one failure, five other crash tests drop from pass to skip, and the totals move from 403 total/390 pass/13 skip/0 fail to 403/384/18/1.

