### PR TITLE
Compiled-in install paths ignore --prefix and stay on /usr

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,6 +26,7 @@ AM_CPPFLAGS = \
 	@LFS_FLAG@ \
 	-DPREFIX=\""$(prefix)"\" \
 	-DSYSCONFDIR=\""$(sysconfdir)"\" \
+	-DBINDIR=\""$(bindir)"\" \
 	-DDATADIR=\""$(datadir)"\" \
 	-DLIBDIR=\""$(libdir)"\" \
 	-I"$(abs_srcdir)" \

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -179,9 +179,9 @@ Please visit our Website: http://www.httrack.com
 
 /* Install paths and config-file names. HTTRACKRC is the per-user rc filename,
    HTTRACKCNF the system-wide config, HTTRACKDIR the shared data directory; the
-   ETC/BIN/LIB/PREFIX paths follow the directories configure was given, and fall
-   back to the literals for a build that defines none (MSVC, or a consumer
-   including this header on its own). */
+   ETC/BIN/LIB/PREFIX paths follow the directories configure was given. A build
+   that defines none (MSVC, or a consumer including this header standalone)
+   falls back to the literals. */
 #ifdef _WIN32
 #define HTS_HTTRACKRC "httrackrc"
 #else

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -179,23 +179,40 @@ Please visit our Website: http://www.httrack.com
 
 /* Install paths and config-file names. HTTRACKRC is the per-user rc filename,
    HTTRACKCNF the system-wide config, HTTRACKDIR the shared data directory; the
-   ETC/BIN/LIB/PREFIX paths are the defaults these derive from when not set by
-   the build. */
+   ETC/BIN/LIB/PREFIX paths follow the directories configure was given, and fall
+   back to the literals for a build that defines none (MSVC, or a consumer
+   including this header on its own). */
 #ifdef _WIN32
 #define HTS_HTTRACKRC "httrackrc"
 #else
 
 #ifndef HTS_ETCPATH
+#ifdef SYSCONFDIR
+#define HTS_ETCPATH SYSCONFDIR
+#else
 #define HTS_ETCPATH "/etc"
 #endif
+#endif
 #ifndef HTS_BINPATH
+#ifdef BINDIR
+#define HTS_BINPATH BINDIR
+#else
 #define HTS_BINPATH "/usr/bin"
 #endif
+#endif
 #ifndef HTS_LIBPATH
+#ifdef LIBDIR
+#define HTS_LIBPATH LIBDIR
+#else
 #define HTS_LIBPATH "/usr/lib"
 #endif
+#endif
 #ifndef HTS_PREFIX
+#ifdef PREFIX
+#define HTS_PREFIX PREFIX
+#else
 #define HTS_PREFIX "/usr"
+#endif
 #endif
 
 #define HTS_HTTRACKRC ".httrackrc"

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6878,9 +6878,8 @@ static int st_pathbin(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-// -#test=instpaths: the compiled-in install paths, which have to follow
-// configure's directories and not a hardcoded /usr (Termux patched them by
-// hand).
+// -#test=instpaths: the compiled-in install paths, which must follow configure
+// rather than the hardcoded /usr Termux patched by hand.
 static int st_instpaths(httrackp *opt, int argc, char **argv) {
   (void) opt;
   (void) argc;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6878,6 +6878,26 @@ static int st_pathbin(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+// -#test=instpaths: the compiled-in install paths, which have to follow
+// configure's directories and not a hardcoded /usr (Termux patched them by
+// hand).
+static int st_instpaths(httrackp *opt, int argc, char **argv) {
+  (void) opt;
+  (void) argc;
+  (void) argv;
+#ifdef _WIN32
+  return 77; /* Windows defines none of these */
+#else
+  printf("prefix=%s\n", HTS_PREFIX);
+  printf("etcpath=%s\n", HTS_ETCPATH);
+  printf("binpath=%s\n", HTS_BINPATH);
+  printf("libpath=%s\n", HTS_LIBPATH);
+  printf("httrackcnf=%s\n", HTS_HTTRACKCNF);
+  printf("httrackdir=%s\n", HTS_HTTRACKDIR);
+  return 0;
+#endif
+}
+
 // hts_buildtopindex() writes a system-charset name into a charset=utf-8 doc: on
 // Windows the gifs land in a mangled twin dir (#217) and a listed name renders
 // as mojibake (#216). Both must come out utf-8. argv[0] is writable.
@@ -13113,6 +13133,8 @@ static const struct selftest_entry {
      st_datadir},
     {"pathbin", "", "print the data directory this run resolved at startup",
      st_pathbin},
+    {"instpaths", "", "print the compiled-in install paths (POSIX only)",
+     st_instpaths},
     {"inplace-escape", "", "inplace_escape_* vs escape_* equivalence self-test",
      st_inplace_escape},
     {"escape-room", "", "HT_ADD_HTMLESCAPED* reservation-factor self-test",

--- a/tests/377_engine-install-paths.test
+++ b/tests/377_engine-install-paths.test
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# The compiled-in install paths ignored --prefix and stayed on /usr, so a
+# non-/usr build looked for /etc/httrack.conf; Termux patched htsglobal.h by
+# hand for it. Each one has to be the directory configure was given.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+prefix=${CONFIGURED_PREFIX:?not run under make check}
+sysconfdir=${CONFIGURED_SYSCONFDIR:?not run under make check}
+bindir=${CONFIGURED_BINDIR:?not run under make check}
+libdir=${CONFIGURED_LIBDIR:?not run under make check}
+datadir=${CONFIGURED_DATADIR:?not run under make check}
+
+rc=0
+out=$(httrack -O /dev/null -#test=instpaths) || rc=$?
+[ "$rc" != 77 ] || skip "no compiled-in install paths on this platform"
+[ "$rc" = 0 ] || fail "-#test=instpaths exited $rc, output: $out"
+
+value_of() { # value_of KEY
+    local line
+    line=$(grep "^$1=" <<<"$out") || fail "no $1 line in: $out"
+    printf '%s\n' "${line#"$1"=}"
+}
+
+# A directory configure was handed with a trailing slash keeps it; the macros do not.
+assert_eq "${prefix%/}" "$(value_of prefix)" "HTS_PREFIX"
+assert_eq "${sysconfdir%/}" "$(value_of etcpath)" "HTS_ETCPATH"
+assert_eq "${bindir%/}" "$(value_of binpath)" "HTS_BINPATH"
+assert_eq "${libdir%/}" "$(value_of libpath)" "HTS_LIBPATH"
+assert_eq "${sysconfdir%/}/httrack.conf" "$(value_of httrackcnf)" "HTS_HTTRACKCNF"
+assert_eq "${datadir%/}/httrack/" "$(value_of httrackdir)" "HTS_HTTRACKDIR"
+
+hardcoded() { # hardcoded KEY: what the unfixed header carried
+    case "$1" in
+    prefix) echo /usr ;;
+    etcpath) echo /etc ;;
+    binpath) echo /usr/bin ;;
+    libpath) echo /usr/lib ;;
+    *) fail "no hardcoded value for $1" ;;
+    esac
+}
+
+# An installed /usr build agrees with those literals by coincidence, and only
+# there is agreement not a finding.
+if [ "${prefix%/}" != /usr ]; then
+    for key in prefix etcpath binpath libpath; do
+        [ "$(value_of "$key")" != "$(hardcoded "$key")" ] ||
+            fail "${key} is still the hardcoded $(hardcoded "$key") under prefix ${prefix}"
+    done
+fi
+
+echo "install paths follow configure: prefix=${prefix} sysconfdir=${sysconfdir}"

--- a/tests/377_engine-install-paths.test
+++ b/tests/377_engine-install-paths.test
@@ -9,6 +9,9 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
+skip_on_windows "the install paths are POSIX-only"
+[ -n "${abs_top_builddir:-}" ] || skip "abs_top_builddir unset, no automake environment"
+
 prefix=${CONFIGURED_PREFIX:?not run under make check}
 sysconfdir=${CONFIGURED_SYSCONFDIR:?not run under make check}
 bindir=${CONFIGURED_BINDIR:?not run under make check}
@@ -32,25 +35,47 @@ assert_eq "${sysconfdir%/}" "$(value_of etcpath)" "HTS_ETCPATH"
 assert_eq "${bindir%/}" "$(value_of binpath)" "HTS_BINPATH"
 assert_eq "${libdir%/}" "$(value_of libpath)" "HTS_LIBPATH"
 assert_eq "${sysconfdir%/}/httrack.conf" "$(value_of httrackcnf)" "HTS_HTTRACKCNF"
+# HTS_HTTRACKDIR already followed DATADIR before the fix: the control, not coverage.
 assert_eq "${datadir%/}/httrack/" "$(value_of httrackdir)" "HTS_HTTRACKDIR"
 
-hardcoded() { # hardcoded KEY: what the unfixed header carried
-    case "$1" in
-    prefix) echo /usr ;;
-    etcpath) echo /etc ;;
-    binpath) echo /usr/bin ;;
-    libpath) echo /usr/lib ;;
-    *) fail "no hardcoded value for $1" ;;
-    esac
+# On a /usr layout the assertions above compare two coinciding strings, so the
+# unfixed header passes them. Directories no build lands on discriminate anywhere.
+read -r -a cc_argv <<<"${CC:-cc}"
+command -v "${cc_argv[0]}" >/dev/null 2>&1 || skip "no C compiler (${cc_argv[0]})"
+tmp=$(mktemp -d) || exit 1
+cleanup_push rm -rf "$tmp"
+cat >"$tmp/probe.c" <<'EOF'
+#include "htsglobal.h"
+hts_prefix=HTS_PREFIX
+hts_etcpath=HTS_ETCPATH
+hts_binpath=HTS_BINPATH
+hts_libpath=HTS_LIBPATH
+hts_httrackcnf=HTS_HTTRACKCNF
+hts_httrackdir=HTS_HTTRACKDIR
+EOF
+pp=$("${cc_argv[@]}" -E -I"${abs_top_srcdir:?}/src" -I"$abs_top_builddir" \
+    -DPREFIX='"/probe/pfx"' -DSYSCONFDIR='"/probe/etc"' -DBINDIR='"/probe/bin"' \
+    -DLIBDIR='"/probe/lib"' -DDATADIR='"/probe/share"' "$tmp/probe.c" 2>&1) ||
+    fail "preprocessing htsglobal.h failed: $pp"
+
+expanded() { # expanded KEY: the macro, with adjacent string literals joined
+    local line
+    line=$(grep "^hts_$1=" <<<"$pp") || fail "no hts_$1 line in the preprocessed header"
+    printf '%s\n' "${line#hts_"$1"=}" | tr -d ' "'
 }
 
-# An installed /usr build agrees with those literals by coincidence, and only
-# there is agreement not a finding.
-if [ "${prefix%/}" != /usr ]; then
-    for key in prefix etcpath binpath libpath; do
-        [ "$(value_of "$key")" != "$(hardcoded "$key")" ] ||
-            fail "${key} is still the hardcoded $(hardcoded "$key") under prefix ${prefix}"
-    done
-fi
+assert_eq /probe/pfx "$(expanded prefix)" "HTS_PREFIX ignores PREFIX"
+assert_eq /probe/etc "$(expanded etcpath)" "HTS_ETCPATH ignores SYSCONFDIR"
+assert_eq /probe/bin "$(expanded binpath)" "HTS_BINPATH ignores BINDIR"
+assert_eq /probe/lib "$(expanded libpath)" "HTS_LIBPATH ignores LIBDIR"
+assert_eq /probe/etc/httrack.conf "$(expanded httrackcnf)" "HTS_HTTRACKCNF ignores SYSCONFDIR"
+# Control: DATADIR was already honoured, so this failing means the probe is broken.
+assert_eq /probe/share/httrack/ "$(expanded httrackdir)" "the probe reaches the header"
+
+# The wiring itself: a -D the build never passes falls back to that same literal.
+for pair in PREFIX:prefix SYSCONFDIR:sysconfdir BINDIR:bindir LIBDIR:libdir DATADIR:datadir; do
+    grep -q -- "-D${pair%%:*}=.*\$(${pair##*:})" "$abs_top_srcdir/src/Makefile.am" ||
+        fail "src/Makefile.am does not pass -D${pair%%:*} from \$(${pair##*:})"
+done
 
 echo "install paths follow configure: prefix=${prefix} sysconfdir=${sysconfdir}"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -44,6 +44,7 @@ TESTS_ENVIRONMENT += abs_top_builddir=$(abs_top_builddir)
 TESTS_ENVIRONMENT += CONFIGURED_DATADIR=$(datadir)
 TESTS_ENVIRONMENT += CONFIGURED_LIBDIR=$(libdir)
 TESTS_ENVIRONMENT += CONFIGURED_BINDIR=$(bindir)
+TESTS_ENVIRONMENT += CONFIGURED_SYSCONFDIR=$(sysconfdir)
 # 225_install-manifest.test folds these back out of the staged paths.
 TESTS_ENVIRONMENT += CONFIGURED_MANDIR=$(mandir)
 TESTS_ENVIRONMENT += CONFIGURED_DOCDIR=$(docdir)

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -504,7 +504,9 @@ echo "ran=$((pass + fail + skip + lost)) pass=$pass fail=$fail skip=$skip lost=$
 # ftp-deadhost-interrupt, ftp-sigterm, abort-purge, signal-receive and
 # ftp-stop-window need that same signal (deadhost's --timeout half runs as 245,
 # abort-purge's --max-time half as 268);
-# close-once interposes close() through LD_PRELOAD, which MSYS has no equivalent for.
+# close-once interposes close() through LD_PRELOAD, which MSYS has no equivalent for;
+# engine-install-paths reads the compiled-in POSIX install paths, which this job
+# has no equivalent of.
 expected_skips="01_engine-footer-overflow.test
 253_local-ftp-close-once.test
 100_local-purge-longpath.test
@@ -530,7 +532,8 @@ expected_skips="01_engine-footer-overflow.test
 288_testlib-holdport.test
 350_local-diskfull-abort.test
 352_engine-filesave-diskfull.test
-355_local-write-error-not-eof.test"
+355_local-write-error-not-eof.test
+377_engine-install-paths.test"
 # First, or the deadline reads as an unexplained shortfall in the gates below.
 [ "$deadline" -eq 0 ] || {
     echo "::error::suite did not finish within ${suite_deadline}s"


### PR DESCRIPTION
`src/htsglobal.h` hardcodes `HTS_ETCPATH` to `/etc` and puts `HTS_BINPATH`, `HTS_LIBPATH` and `HTS_PREFIX` under `/usr`. `src/Makefile.am` has been passing `-DPREFIX`, `-DSYSCONFDIR`, `-DDATADIR` and `-DLIBDIR` for years, but the header only ever consulted `DATADIR`, for `HTS_HTTRACKDIR`. Three of those flags went nowhere and `--prefix` reached none of the four macros. Termux ships `packages/httrack/htsglobal.h.patch` to fix this by hand.

This wires them to the autotools directories and keeps the literals as the fallback for a build that defines none: MSVC, and anyone including the installed header without our `-D` flags. `-DBINDIR` is new, the other three already existed.

Worth stating plainly, because it is a behaviour change: `HTS_HTTRACKCNF` is built from `HTS_ETCPATH`, so this moves where `httrack.conf` is looked for on a non-`/usr` prefix. Debian and Fedora pass `--sysconfdir=/etc` and see nothing change. A Homebrew or `/opt` build starts reading its own `etc/httrack.conf` instead of the system one, which is the point of the change but should not arrive unannounced.

The four values have exactly one consumer, `src/htsweb.c:284-294`, which pushes them as `smallserver_setkey("ETCPATH"/"BINPATH"/"LIBPATH"/"PREFIX", ...)`. Nothing under `html/server/` or `templates/` reads those keys. The template syntax is `${KEY}`, and enumerating every `${...}` in `html/` gives 205 distinct keys, none of them these. So deleting the four was the alternative, and I did not take it: wiring them correctly is the smaller change, and anyone running a custom template against these keys keeps working, now with the right answer.

`tests/377_engine-install-paths.test` drives a new `-#test=instpaths` self-test that prints the six compiled-in paths, and compares each against the `CONFIGURED_*` directory `configure` was actually given (`CONFIGURED_SYSCONFDIR` is new, the rest were already exported). Master's header fails that at the default `/usr/local` prefix, and at a second build I configured with `--prefix=/opt/httrackD --sysconfdir=/etc/httrackD --libdir=/opt/httrackD/lib64`.

The comparison is blind on one layout, though. Configured `--prefix=/usr --sysconfdir=/etc --bindir=/usr/bin --libdir=/usr/lib` it holds the hardcoded literals up against themselves, and the unfixed header passed it. Debian's multiarch libdir and Fedora's `/usr/lib64` break the coincidence, but a non-multiarch `/usr` distro is a real configuration where the test proved nothing. So it now also preprocesses `htsglobal.h` with directories no build lands on, which discriminates anywhere, and greps `src/Makefile.am` for the five `-D` flags, the half a `/usr` build's runtime values cannot see either. Both halves kill their mutant at that layout: master's header reds it, dropping `-DBINDIR` reds it, this branch passes. `HTS_HTTRACKDIR` is labelled as the control it is, since it followed `DATADIR` before the fix.

`make check`: 404 total, 391 pass, 13 skip, 0 fail.

