### PR TITLE
Ten example plugins every distribution has to un-install by hand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -772,7 +772,7 @@ jobs:
         run: |
           set -euo pipefail
           autoreconf -fi
-          # Rides along: the only leg where 225 and 376 see the example plugins off.
+          # The only leg with the example plugins off: 225 and 376 lose that direction if this job goes.
           ./configure --disable-https --disable-example-libs
 
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -772,7 +772,8 @@ jobs:
         run: |
           set -euo pipefail
           autoreconf -fi
-          ./configure --disable-https
+          # Rides along: the only leg where 225 and 376 see the example plugins off.
+          ./configure --disable-https --disable-example-libs
 
       - name: Build
         run: make -j"$(nproc)"

--- a/configure.ac
+++ b/configure.ac
@@ -609,7 +609,7 @@ AC_ARG_ENABLE([example-libs],
 		AC_MSG_RESULT($enableval)
 		;;
 	*)
-		AC_MSG_ERROR(bad value for example-libs, expected yes/no)
+		AC_MSG_ERROR([bad value for example-libs, expected yes/no])
 		;;
 	esac
 	],

--- a/configure.ac
+++ b/configure.ac
@@ -597,6 +597,29 @@ AC_ARG_ENABLE([online-unit-tests],
 	])
 AC_SUBST(ONLINE_UNIT_TESTS,$online_unit_tests)
 
+## Example callback plugins (libtest/): documentation samples every distribution
+## has to un-install by hand.
+AC_MSG_CHECKING(whether to build the example callback plugins)
+AC_ARG_ENABLE([example-libs],
+	[AS_HELP_STRING([--disable-example-libs],[Do not build or install the libtest/ example callback plugins; their sources install either way @<:@default=yes@:>@])],
+	[
+	case "${enableval}" in
+	no|yes)
+		example_libs=$enableval
+		AC_MSG_RESULT($enableval)
+		;;
+	*)
+		AC_MSG_ERROR(bad value for example-libs, expected yes/no)
+		;;
+	esac
+	],
+	[
+	example_libs=yes
+	AC_MSG_RESULT(yes)
+	])
+AM_CONDITIONAL([EXAMPLE_LIBS], [test x"$example_libs" = x"yes"])
+AC_SUBST(EXAMPLE_LIBS,$example_libs)
+
 ## libFuzzer harnesses (fuzz/); requires clang
 AC_MSG_CHECKING(whether to build fuzzers)
 AC_ARG_ENABLE([fuzzers],

--- a/libtest/Makefile.am
+++ b/libtest/Makefile.am
@@ -27,7 +27,8 @@ AM_LDFLAGS = \
 	-L../src \
 	@LIBC_FORCE_LINK@
 
-# Examples
+# Examples; --disable-example-libs keeps the sources above and drops these.
+if EXAMPLE_LIBS
 libbaselinks_la_SOURCES =  callbacks-example-baselinks.c
 libbaselinks_la_LIBADD = $(THREADS_LIBS) $(SOCKET_LIBS) $(top_builddir)/src/libhttrack.la
 libbaselinks_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:0:0
@@ -59,3 +60,4 @@ libsimple_la_SOURCES =  callbacks-example-simple.c
 libsimple_la_LIBADD = $(THREADS_LIBS) $(SOCKET_LIBS) $(top_builddir)/src/libhttrack.la
 libsimple_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:0:0
 pkglib_LTLIBRARIES = libbaselinks.la libchangecontent.la libcontentfilter.la libdisplayheader.la libfilename2.la libfilename.la libfilenameiisbug.la liblistlinks.la liblog.la libsimple.la
+endif

--- a/tests/225_install-manifest.test
+++ b/tests/225_install-manifest.test
@@ -84,12 +84,20 @@ fold() {
 # An install that staged nothing matches nothing; say that, not a 300-line diff.
 grep -qx '@BINDIR@/httrack' "${work}/actual" || fail "nothing staged under ${stage}"
 
-# The example plugins are the only thing under @LIBDIR@/httrack, so dropping
-# them keeps the rest of the manifest pinned on a --disable-example-libs build.
+# Named one by one, not by their directory: dropping all of @LIBDIR@/httrack
+# would unpin whatever else lands there, and a removal would then go unseen.
+plugins='baselinks|changecontent|contentfilter|displayheader|filename|filename2'
+plugins=${plugins}'|filenameiisbug|listlinks|log|simple'
+plugin_re="^@LIBDIR@/httrack/lib(${plugins})\\.so(\\.[0-9][0-9]*(\\.@revision@)?)?$"
+
 if [ "${EXAMPLE_LIBS:-yes}" = yes ]; then
     LC_ALL=C sort "${manifest}" >"${work}/expected"
 else
-    grep -v '^@LIBDIR@/httrack/' "${manifest}" | LC_ALL=C sort >"${work}/expected"
+    LC_ALL=C grep -Ev "${plugin_re}" "${manifest}" | LC_ALL=C sort >"${work}/expected"
+    # Ten plugins, three names each; a rename would silently match fewer.
+    dropped=$(($(lines_of "${manifest}") - $(lines_of "${work}/expected")))
+    test "${dropped}" -eq 30 ||
+        fail "expected 30 example plugin lines in ${manifest}, matched ${dropped}"
 fi
 diff -u "${work}/expected" "${work}/actual" ||
     fail "the installed file set changed; update tests/install-manifest.txt and say so in the release notes -- Fedora's %files and debian/*.files name these files"

--- a/tests/225_install-manifest.test
+++ b/tests/225_install-manifest.test
@@ -84,7 +84,13 @@ fold() {
 # An install that staged nothing matches nothing; say that, not a 300-line diff.
 grep -qx '@BINDIR@/httrack' "${work}/actual" || fail "nothing staged under ${stage}"
 
-LC_ALL=C sort "${manifest}" >"${work}/expected"
+# The example plugins are the only thing under @LIBDIR@/httrack, so dropping
+# them keeps the rest of the manifest pinned on a --disable-example-libs build.
+if [ "${EXAMPLE_LIBS:-yes}" = yes ]; then
+    LC_ALL=C sort "${manifest}" >"${work}/expected"
+else
+    grep -v '^@LIBDIR@/httrack/' "${manifest}" | LC_ALL=C sort >"${work}/expected"
+fi
 diff -u "${work}/expected" "${work}/actual" ||
     fail "the installed file set changed; update tests/install-manifest.txt and say so in the release notes -- Fedora's %files and debian/*.files name these files"
 

--- a/tests/376_example-libs-option.test
+++ b/tests/376_example-libs-option.test
@@ -48,7 +48,7 @@ if [ "${EXAMPLE_LIBS:-yes}" = yes ]; then
     for name in ${plugins}; do
         got=$(built "${name}")
         test -n "${got}" || fail "lib${name} is missing from ${stage}${libdir}/httrack"
-        grep -q "\.so\|\.dylib" <<<"${got}" ||
+        grep -qE '\.so|\.dylib' <<<"${got}" ||
             fail "lib${name} installed no shared object: ${got}"
     done
     ok "the ten example plugins install by default"

--- a/tests/376_example-libs-option.test
+++ b/tests/376_example-libs-option.test
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Fedora, openSUSE, OpenBSD and Void each undo the libtest plugin install by
+# hand; --disable-example-libs does it for them, and must still install the
+# example sources, which are the part their doc packages ship.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+: "${abs_top_builddir:?not run under make check}"
+bindir="${CONFIGURED_BINDIR:?not run under make check}"
+libdir="${CONFIGURED_LIBDIR:?not run under make check}"
+datadir="${CONFIGURED_DATADIR:?not run under make check}"
+
+case "$HTS_OS" in
+Linux | Darwin) ;;
+*) skip "the plugin install layout is checked on Linux and macOS only" ;;
+esac
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/examplelibs.XXXXXX") || fail "no tmpdir"
+cleanup_push rm -rf "${work}"
+
+stage=${work}/stage
+env -u MAKEFLAGS -u MAKELEVEL "${MAKE:-make}" -C "${abs_top_builddir}" \
+    install DESTDIR="${stage}" >"${work}/install.log" 2>&1 ||
+    fail_dump "make install DESTDIR=${stage}" "${work}/install.log"
+
+# An install that staged nothing has no plugins either, and would read as a pass.
+test -r "${stage}${bindir%/}/httrack" || fail "nothing staged under ${stage}"
+
+plugins="baselinks changecontent contentfilter displayheader filename filename2
+    filenameiisbug listlinks log simple"
+
+# The sources are the useful half and are not gated: assert them either way.
+examples=${stage}${datadir%/}/httrack/libtest
+for name in ${plugins}; do
+    assert_file "${examples}/callbacks-example-${name}.c" "example source"
+done
+assert_file "${examples}/readme.txt" "example readme"
+
+# Any name libtool may give the built plugin, so a hit is a build product and not
+# just the directory being there.
+built() { ls "${stage}${libdir%/}/httrack/lib$1."* 2>/dev/null || true; }
+
+if [ "${EXAMPLE_LIBS:-yes}" = yes ]; then
+    for name in ${plugins}; do
+        got=$(built "${name}")
+        test -n "${got}" || fail "lib${name} is missing from ${stage}${libdir}/httrack"
+        grep -q "\.so\|\.dylib" <<<"${got}" ||
+            fail "lib${name} installed no shared object: ${got}"
+    done
+    ok "the ten example plugins install by default"
+else
+    for name in ${plugins}; do
+        got=$(built "${name}")
+        test -z "${got}" ||
+            fail "--disable-example-libs still installed lib${name}: ${got}"
+    done
+    ok "--disable-example-libs installs no plugin, the example sources stay"
+fi

--- a/tests/376_example-libs-option.test
+++ b/tests/376_example-libs-option.test
@@ -53,10 +53,10 @@ if [ "${EXAMPLE_LIBS:-yes}" = yes ]; then
     done
     ok "the ten example plugins install by default"
 else
-    for name in ${plugins}; do
-        got=$(built "${name}")
-        test -z "${got}" ||
-            fail "--disable-example-libs still installed lib${name}: ${got}"
-    done
+    # The whole directory, not the ten names: the flag must not carry off a
+    # neighbour, and nothing else installs there today.
+    left=$(find "${stage}${libdir%/}/httrack" \( -type f -o -type l \) 2>/dev/null || true)
+    test -z "${left}" ||
+        fail "--disable-example-libs left this under ${libdir}/httrack: ${left}"
     ok "--disable-example-libs installs no plugin, the example sources stay"
 fi

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -49,6 +49,8 @@ TESTS_ENVIRONMENT += CONFIGURED_MANDIR=$(mandir)
 TESTS_ENVIRONMENT += CONFIGURED_DOCDIR=$(docdir)
 TESTS_ENVIRONMENT += CONFIGURED_HTMLDIR=$(htmldir)
 TESTS_ENVIRONMENT += ORIGIN_RPATH=$(ORIGIN_RPATH)
+# 225 and 376 both read what --disable-example-libs did to the install.
+TESTS_ENVIRONMENT += EXAMPLE_LIBS=$(EXAMPLE_LIBS)
 # 222_pkgconfig-consumer.test asserts the staged .pc against these, and both
 # sides of the gate deciding whether it hands a consumer an rpath.
 TESTS_ENVIRONMENT += CONFIGURED_PREFIX=$(prefix)


### PR DESCRIPTION
libtest/ ships ten callback samples, and automake installs them as real versioned shared libraries under $libdir/httrack. They are documentation, not a feature, and four distributions each undo that their own way: Fedora deletes `%{buildroot}%{_libdir}/httrack` in `%install`, openSUSE splits the `.so` into -devel and the `.so.*` into the runtime library package, OpenBSD keeps ten `SHARED_LIBS` lines in its port Makefile with a version number each to maintain, and Void moves `usr/lib/*.so` into its -devel package. `--disable-example-libs` replaces all four workarounds with one flag.

The default does not move. An unflagged build installs what it installed before, so Debian and anyone else on the default sees nothing change. The example sources install either way: Fedora and openSUSE both move `$datadir/httrack/libtest` into their doc package, and the sources are the half worth reading.

tests/376 asserts the gate in both directions, because a test that only watched the disabled build cannot tell the option from a build that never produced the plugins at all. On a default build the ten plugins are installed and the sources with them; with the option off nothing named `lib*` is left under `$libdir/httrack` and the sources are still there. Each branch was run against the wrong flag to confirm neither passes vacuously. 225's pinned install manifest drops the same thirty lines when the option is off, and those are the only entries under `@LIBDIR@/httrack`, so the rest of it stays pinned.

A packager adopting the flag has to drop the plugin plumbing as well: our own `debian/rules` (lines 77-83) unconditionally `mv`s `usr/lib/*/httrack/lib*`, and `debian/libhttrack-dev.files` globs `usr/lib/*/httrack/libtest`, so an adopter who leaves those in place gets an `mv` with no matches and a failing `dh_install`. Debian stays on the default here, so nothing in this PR touches it.

The no-openssl leg configures with the flag as well, or CI would only ever run the enabled half. `make check` is green both ways (404 tests, 391 pass, 13 skip), and `make dist` ships an identical file list in either configuration.