### PR TITLE
A downstream recipe's assumptions about this tree can break unnoticed

### DIFF
--- a/.github/workflows/downstream-drift.yml
+++ b/.github/workflows/downstream-drift.yml
@@ -1,0 +1,41 @@
+# Fifteen distributions carry recipes for us, and each encodes assumptions about
+# our tree: a patch's context, a path a sed rewrites, a string an ebuild greps
+# for before editing it. Nothing tells us when one stops holding, so the
+# packager finds out at their next version bump and we hear about it as a bug.
+# Gentoo's src_prepare dies today on a grep of m4/check_zlib.m4 that we
+# rewrote. Their files, so a finding here is usually theirs to fix, which is why
+# it blocks nothing.
+name: downstream drift canary
+
+on:
+  schedule:
+    - cron: "17 6 * * 3"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    name: downstream recipes against this tree
+    # Scheduled workflows run per-fork independently; skip anywhere but upstream.
+    if: github.repository == 'xroche/httrack'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Install autotools
+        run: |
+          set -euo pipefail
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
+          sudo apt-get install -y --no-install-recommends \
+            autoconf automake libtool autoconf-archive
+
+      # Termux patches Makefile.in, which is a build product here.
+      - name: Generate the files a downstream patches
+        run: ./bootstrap
+
+      - name: Check the live recipes
+        run: tools/downstream-drift.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 EXTRA_DIST = INSTALL.Linux \
 		gpl-fr.txt license.txt greetings.txt history.txt \
-		httrack-doc.html lang.def README.md tools/mkdeb.sh \
+		httrack-doc.html lang.def README.md PACKAGING.md tools/mkdeb.sh \
 		tools/macos-app.sh tools/macos-bundle.sh tools/macos-release.sh \
 		tools/httrack-launcher.c \
 		tools/Info.plist.in tools/HTTrack.icns \
@@ -13,7 +13,8 @@ EXTRA_DIST = INSTALL.Linux \
 		winprofile-keys.tsv winprofile-escapes.tsv \
 		tools/gen-winprofile-keys.py \
 		tools/doc-chrome.py \
-		tools/ci-sanitizer-report.sh
+		tools/ci-sanitizer-report.sh \
+		tools/downstream-drift.sh
 
 # Build the signed Debian packages from a clean source export. Pass the signing
 # key and other options through DEB_FLAGS, e.g.:

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -1,0 +1,68 @@
+# Packaging HTTrack
+
+For distribution and ports maintainers. [CONTRIBUTING.md](CONTRIBUTING.md) covers
+sending us changes; this covers shipping a build of ours.
+
+## Take the release tarball, not the tag archive
+
+`https://github.com/xroche/httrack/releases/download/X.Y.Z/httrack-X.Y.Z.tar.gz`,
+with a detached signature and a checksum beside it.
+
+That is a `make dist` tarball. It carries `configure`, the generated
+`Makefile.in`s, the man pages and the coucal sources, so it builds with nothing
+but a compiler, zlib and OpenSSL.
+
+GitHub's `archive/refs/tags/X.Y.Z.tar.gz` carries none of them. coucal is a
+submodule, so the directory comes out empty, and `configure` and the man pages
+are build products we do not track. Several recipes use the tag archive today and
+pay for it with an `autoreconf`, a second tarball and a coucal commit pin
+somebody has to move at every bump.
+
+## configure
+
+- `--with-zlib=DIR` points at a non-standard zlib prefix. zlib itself is
+  required, not optional: the cache and the WARC output are zip containers.
+- `--with-brotli[=DIR]`, `--with-zstd[=DIR]`: the `br` and `zstd` content
+  codings, used when the library is found, dropped by `--without-`.
+- `--enable-https=yes|no|auto` selects OpenSSL. On by default.
+- `--enable-online-unit-tests` is off by default, and `make check` reaches the
+  network only when it is on. Nothing to pass.
+- `--disable-origin-rpath` exists, but configure already declines a
+  binary-relative rpath when `libdir` is a system one. A distribution build gets
+  none, so there is no libtool line to sed out.
+- `--enable-fuzzers` builds the fuzz harnesses under clang. Not for a package.
+
+## Do not re-encode the tree
+
+Everything is UTF-8 except `src/htsconcat.c`, which has ISO-8859-1 bytes in its
+comments, and the binary vectors under `fuzz/corpus/`. An `iconv -f ISO8859-1`
+pass over `greetings.txt`, `history.txt` or `html/contact.html` double-encodes
+them. That is how the mojibake in issue #1463 reached Fedora users.
+
+## The test suite in a buildroot
+
+`make check -j"$(nproc)"`. Each crawl test binds its own ephemeral-port server,
+so parallelism never contends and a serial run costs minutes for nothing.
+
+The suite is offline but needs python3, which several buildroots lack. Without it
+most tests skip and the suite still exits 0, so read the `# TOTAL:` and `# PASS:`
+counts rather than the exit status. There are over 400 tests; a run reporting a
+couple of hundred is one that mostly skipped.
+
+A buildroot's network is not a builder's. Fedora's mock gives loopback and a
+default route with no resolver, where a UDP connect succeeds and names no source
+address. Debian's sbuild leaves out the default route, so the same connect fails
+outright. `tools/buildroot-net.sh <command>` reproduces the mock shape, and our
+CI runs the whole suite under it. Failures land in `tests/test-suite.log` and in
+a per-test `tests/NNN_*.log`.
+
+## When you need a patch
+
+Send it upstream, even when you have already applied it locally. A patch carried
+in a recipe is a bug report we never received: we cannot fix or keep working what
+we cannot see, and it breaks at your next version bump, in your build.
+
+Issues go to <https://github.com/xroche/httrack/issues>, security reports to
+[SECURITY.md](SECURITY.md). We build master through Fedora's spec on a schedule
+and check other recipes' assumptions against our tree, so we sometimes catch a
+break first, but only for recipes we know about. Tell us yours exists.

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -50,17 +50,17 @@ counts rather than the exit status. There are over 400 tests; a run reporting a
 couple of hundred is one that mostly skipped.
 
 A buildroot's network is not a builder's. Fedora's mock gives loopback and a
-default route with no resolver, where a UDP connect succeeds and names no source
-address. Debian's sbuild leaves out the default route, so the same connect fails
-outright. `tools/buildroot-net.sh <command>` reproduces the mock shape, and our
-CI runs the whole suite under it. Failures land in `tests/test-suite.log` and in
-a per-test `tests/NNN_*.log`.
+default route with no resolver, where a UDP `connect()` succeeds but returns no
+source address. Debian's sbuild leaves out the default route, so the same
+connect fails outright. `tools/buildroot-net.sh <command>` reproduces the mock
+shape, and our CI runs the whole suite under it. Failures land in
+`tests/test-suite.log` and in a per-test `tests/NNN_*.log`.
 
 ## When you need a patch
 
 Send it upstream, even when you have already applied it locally. A patch carried
-in a recipe is a bug report we never received: we cannot fix or keep working what
-we cannot see, and it breaks at your next version bump, in your build.
+in a recipe is a bug report we never received: we cannot fix a bug we never hear
+about, and it breaks at your next version bump, in your build.
 
 Issues go to <https://github.com/xroche/httrack/issues>, security reports to
 [SECURITY.md](SECURITY.md). We build master through Fedora's spec on a schedule

--- a/tools/downstream-drift.sh
+++ b/tools/downstream-drift.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+#
+# Downstream recipes encode assumptions about our tree: a patch's context, a
+# path a sed rewrites, a string an ebuild greps for before editing it. Nothing
+# tells us when one stops holding -- the packager finds out at their next
+# version bump, and we hear about it as a bug. This fetches the live recipes we
+# cannot build and reports which of their assumptions our tree no longer meets.
+#
+# Usage: tools/downstream-drift.sh        (needs ./bootstrap first, and network)
+
+# The recipe patterns matched below are literal third-party text, not shell.
+# shellcheck disable=SC2016
+
+set -euo pipefail
+
+top=$(cd "$(dirname "$0")/.." && pwd)
+work=$(mktemp -d)
+trap 'set +e; rm -rf "$work"' EXIT
+trap 'exit 1' HUP INT TERM
+
+# The findings this tree already had when the job was written, so that only new
+# drift reds a run. Each is being reported to its packager; delete the id once
+# they have acted, and the next run says so if they have not.
+acknowledged=(
+    gentoo-zlib-tripwire # m4/check_zlib.m4 rewritten around $zlib_want
+    gentoo-minizip-patch # ioapi.h defines OF() already
+    freebsd-datadir-sed
+    freebsd-coucal-cc-sed
+    freebsd-shebangfix # src/webhttrack generated since #899
+    openbsd-bash-files # same
+    openbsd-patch-configure_ac
+    openbsd-patch-src_htslib_c
+    openbsd-patch-src_minizip_ioapi_h
+    openbsd-patch-src_webhttrack
+    termux-html-Makefile.in.patch
+    termux-src-Makefile.in.patch
+    termux-src-htsbacktrace.c.patch
+    termux-store.c.patch
+)
+
+checks=0
+known_hits=0
+
+drift=0
+die() {
+    echo "downstream-drift: $*" >&2
+    exit 1
+}
+ok() {
+    checks=$((checks + 1))
+    printf 'ok       %s\n' "$*"
+}
+flag() {
+    local id=$1 msg=$2 known
+    checks=$((checks + 1))
+    for known in ${acknowledged[@]+"${acknowledged[@]}"}; do
+        if [ "$known" = "$id" ]; then
+            printf 'known    %s: %s\n' "$id" "$msg"
+            known_hits=$((known_hits + 1))
+            return
+        fi
+    done
+    printf 'DRIFT    %s: %s\n' "$id" "$msg"
+    drift=1
+}
+
+# A fetch that half-fails must abort: a check run over an empty recipe reports
+# clean and proves nothing.
+fetch() {
+    curl -fsSL --retry 3 --retry-delay 5 -o "$2" "$1" || die "cannot fetch $1"
+    [ -s "$2" ] || die "$1 came back empty"
+}
+
+# The recipe must still carry the assumption, then our tree must still meet it.
+# Order matters: a premise that is gone makes the tree test vacuous, so it is a
+# finding of its own rather than a pass.
+expect() {
+    local id=$1 recipe=$2 pattern=$3 msg=$4
+    shift 4
+    if ! grep -qF -- "$pattern" "$recipe"; then
+        flag "$id" "the recipe no longer contains '$pattern'; prune this check"
+        return
+    fi
+    if "$@"; then
+        ok "$id"
+    else
+        flag "$id" "$msg"
+    fi
+}
+
+# A patch that still applies can still be wrong: with fuzz, or hundreds of lines
+# from where it was written, it lands somewhere its author never saw. OpenBSD's
+# SSL patch matches a generic four-line block 307 lines past its target, and
+# would silently edit the wrong AC_CHECK_LIB. Legitimate drift here is single
+# digits (-10, -5, 2), so 50 separates the two populations with room to spare.
+# Recipes disagree on strip level, so take the first that applies.
+carried_patch() {
+    local id=$1 url=$2 p out off
+    fetch "$url" "$work/patch"
+    for p in 0 1 2; do
+        out=$(patch -d "$top" "-p$p" --dry-run --force <"$work/patch" 2>&1) || continue
+        if grep -q 'with fuzz' <<<"$out"; then
+            flag "$id" "applies only with fuzz, so its context has moved: $(tr '\n' ' ' <<<"$out")"
+            return
+        fi
+        off=$(sed -n 's/.*offset \(-\{0,1\}[0-9]*\) lines.*/\1/p' <<<"$out" |
+            tr -d - | sort -n | tail -1)
+        if [ "${off:-0}" -gt 50 ]; then
+            flag "$id" "applies ${off} lines from where it was written, so it may be landing in the wrong place"
+            return
+        fi
+        ok "$id"
+        return
+    done
+    flag "$id" "no longer applies at any strip level; it landed upstream, or its context moved"
+}
+
+# FreeBSD rewrites this glob, OpenBSD's BASH_FILES and FreeBSD's SHEBANG_FILES
+# name a file, and Gentoo's DOCS names four.
+glob_contains() {
+    local pattern=$1
+    shift
+    grep -qF -- "$pattern" "$@"
+}
+coucal_names_gcc() {
+    grep -v '^[[:space:]]*#' "$top/src/coucal/Makefile" | grep -qw gcc
+}
+
+# The Termux patches target generated files, so a checkout that skipped
+# ./bootstrap would report them as drift for our reason, not theirs.
+if [ ! -f "$top/src/Makefile.in" ] || [ ! -f "$top/html/Makefile.in" ]; then
+    die "run ./bootstrap first: the generated files Termux patches are missing"
+fi
+
+### Gentoo -- www-client/httrack, read through the GitHub mirror because
+### gitweb.gentoo.org has no stable raw URL for a version-numbered ebuild.
+gentoo_raw=https://raw.githubusercontent.com/gentoo-mirror/gentoo/master/www-client/httrack
+ebuild=$(curl -fsSL https://api.github.com/repos/gentoo-mirror/gentoo/contents/www-client/httrack |
+    sed -n 's/.*"name": "\(httrack-[0-9.]*\.ebuild\)".*/\1/p' | head -1)
+test -n "$ebuild" || die "no ebuild found in the Gentoo mirror listing"
+fetch "$gentoo_raw/$ebuild" "$work/gentoo.ebuild"
+
+expect gentoo-zlib-tripwire "$work/gentoo.ebuild" '{ZLIB_HOME}/lib' \
+    "src_prepare greps m4/check_zlib.m4 for it and dies without it, so every non-lib libdir (amd64) fails to build" \
+    grep -qF '{ZLIB_HOME}/lib' "$top/m4/check_zlib.m4"
+expect gentoo-docs "$work/gentoo.ebuild" 'DOCS=( AUTHORS README greetings.txt history.txt )' \
+    "one of the four DOCS files is gone; einstalldocs dies" \
+    test -f "$top/AUTHORS" -a -f "$top/README" -a -f "$top/greetings.txt" -a -f "$top/history.txt"
+carried_patch gentoo-minizip-patch "$gentoo_raw/files/httrack-3.48.13-minizip.patch"
+
+### FreeBSD -- www/httrack
+fetch https://raw.githubusercontent.com/freebsd/freebsd-ports/main/www/httrack/Makefile \
+    "$work/freebsd.mk"
+
+expect freebsd-datadir-sed "$work/freebsd.mk" 's|/usr/share|${PREFIX}/share|' \
+    "the REINPLACE over html/server/div/WebHTTrack* rewrites nothing" \
+    glob_contains /usr/share "$top"/html/server/div/WebHTTrack*
+expect freebsd-coucal-cc-sed "$work/freebsd.mk" 's|gcc|${CC}|' \
+    "src/coucal/Makefile names gcc only in a comment; it honours CC already" \
+    coucal_names_gcc
+expect freebsd-shebangfix "$work/freebsd.mk" 'SHEBANG_FILES=	src/webhttrack' \
+    "src/webhttrack is generated from webhttrack.in since #899, so it does not exist at post-extract time" \
+    test -f "$top/src/webhttrack"
+
+### OpenBSD -- www/httrack
+obsd_raw=https://raw.githubusercontent.com/openbsd/ports/master/www/httrack
+fetch "$obsd_raw/Makefile" "$work/openbsd.mk"
+
+expect openbsd-online-tests "$work/openbsd.mk" '--enable-online-unit-tests=no' \
+    "configure no longer offers --enable-online-unit-tests" \
+    grep -qF online-unit-tests "$top/configure.ac"
+expect openbsd-bash-files "$work/openbsd.mk" '${WRKSRC}/src/webhttrack' \
+    "src/webhttrack is generated from webhttrack.in since #899, and the pre-configure perl dies on a missing file" \
+    test -f "$top/src/webhttrack"
+for p in patch-configure_ac patch-src_htslib_c patch-src_md5_h \
+    patch-src_minizip_ioapi_h patch-src_webhttrack; do
+    carried_patch "openbsd-$p" "$obsd_raw/patches/$p"
+done
+
+### Termux -- packages/httrack
+termux_raw=https://raw.githubusercontent.com/termux/termux-packages/master/packages/httrack
+fetch "$termux_raw/build.sh" "$work/termux.sh"
+
+expect termux-werror-sed "$work/termux.sh" 's/-Werror/-Wno-error/g' \
+    "configure.ac no longer passes -Werror, so the sed is dead" \
+    grep -qF -- -Werror "$top/configure.ac"
+expect termux-with-zlib "$work/termux.sh" --with-zlib \
+    "configure no longer offers --with-zlib" \
+    grep -qF -- --with-zlib "$top/m4/check_zlib.m4"
+for p in html-Makefile.in.patch htsglobal.h.patch src-Makefile.in.patch \
+    src-htsbacktrace.c.patch src-proxy-proxytrack.h.patch store.c.patch; do
+    carried_patch "termux-$p" "$termux_raw/$p"
+done
+
+echo
+# A check that stops running reports nothing, which reads exactly like a clean
+# tree. Pin the count against the table above.
+test "$checks" -ge 21 || die "only $checks checks ran; the table lost some"
+
+if [ "$drift" -ne 0 ]; then
+    echo "Downstream assumptions our tree no longer meets are listed above."
+    echo "Tell the packager, then add the id to \$acknowledged so this stays red"
+    echo "only for what is new."
+    exit 1
+fi
+echo "$checks checks, no new drift; $known_hits are findings already known"


### PR DESCRIPTION
Fifteen distributions package HTTrack, and every recipe encodes assumptions about this tree: a patch's context lines, a path a sed rewrites, a string an ebuild greps for before editing it. Nothing tells us when one stops holding. The packager finds out at their next version bump, and we find out as a bug report.

Gentoo's is already broken. Their `src_prepare` guards a libdir sed with `grep -wq '{ZLIB_HOME}/lib' m4/check_zlib.m4 || die`, deliberately, so that a version bump cannot break the sed quietly. We rewrote that macro around `$zlib_want` and the string is gone, so their next bump dies right there on amd64. FreeBSD and OpenBSD both name `src/webhttrack` in a post-extract rewrite, and that file has been generated from `webhttrack.in` since #899.

`tools/downstream-drift.sh` fetches the live Gentoo ebuild, the FreeBSD port Makefile and the OpenBSD and Termux recipes with their patch sets, then puts 21 of their assumptions to our tree. Carried patches get a dry-run apply. One that applies only with fuzz, or hundreds of lines from where it was written, is reported rather than passed: OpenBSD's SSL patch matches a generic four-line block 307 lines past its target and would quietly edit the wrong `AC_CHECK_LIB`. Real offsets in this set are single digits, so the threshold has room.

Fourteen of the 21 fail today. They are listed in the script as known, which keeps the job green until something new breaks, and deleting an id reds the next run, so the list doubles as the record of what has been reported and what has been acted on. Each check tests the recipe's premise before the tree, so a recipe that drops an assumption is reported as a check to prune instead of passing vacuously. Controls, all run: unacknowledging one finding reds the job, moving `AUTHORS` aside fires the Gentoo `DOCS` check, and pointing a check at a string OpenBSD's Makefile does not contain reports the dead premise.

The workflow is weekly, dispatchable, upstream-only and blocks nothing, following `fedora-spec.yml`.

`PACKAGING.md` is the half that needs no schedule. Mostly it says to take the release tarball: it already contains `configure`, the man pages and coucal, while the tag archive contains none of them, and Fedora, Gentoo and Nix all use the tag archive and pay an autoreconf plus a hand-pinned second tarball for it. Then the configure options a packager actually chooses between, why not to iconv a tree that is already UTF-8 (#1463), what the suite does in a buildroot, and the ask: a patch carried in a recipe is a bug report we never received.

`make distcheck` passes with it in `EXTRA_DIST`; 403 tests, 390 pass, 0 fail, and `PACKAGING.md` is in the tarball.
