### PR TITLE
--with-zlib=DIR looks for the library in DIR/lib and nowhere else

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -253,14 +253,7 @@ AS_CASE([$host_os],
 		hts_origin_ref='$ORIGIN'
 		hts_origin_ref_make='\$$ORIGIN'])
 
-hts_save_prefix=$prefix
-hts_save_exec_prefix=$exec_prefix
-test "x$prefix" = xNONE && prefix=$ac_default_prefix
-test "x$exec_prefix" = xNONE && exec_prefix=$prefix
-eval hts_libdir=\"$libdir\"
-eval hts_libdir=\"$hts_libdir\"
-prefix=$hts_save_prefix
-exec_prefix=$hts_save_exec_prefix
+HTS_EXPAND_LIBDIR
 
 # Enumerated, not read from libtool's sys_lib_dlsearch_path_spec: that one is
 # only augmented when /etc/ld.so.conf exists, so a sysroot or minimal container

--- a/m4/check_zlib.m4
+++ b/m4/check_zlib.m4
@@ -7,6 +7,7 @@ dnl
 dnl Adds -lz to LIBS and defines HAVE_LIBZ.
 
 AC_DEFUN([CHECK_ZLIB], [
+AC_REQUIRE([HTS_EXPAND_LIBDIR])
 AC_ARG_WITH([zlib],
 	[AS_HELP_STRING([--with-zlib=DIR],[root directory of the zlib installation])],
 	[zlib_want=$withval], [zlib_want=yes])
@@ -19,8 +20,30 @@ if test "$zlib_want" != "yes"; then
 	if test ! -f "$zlib_want/include/zlib.h"; then
 		AC_MSG_ERROR([zlib requested at $zlib_want but $zlib_want/include/zlib.h is missing])
 	fi
+	# The library is not always under lib: a multilib host (Fedora, openSUSE)
+	# keeps the 64-bit copy in lib64, Debian under a multiarch triplet. The
+	# configured libdir is the host's own answer, so ask it before guessing.
+	case $hts_libdir in
+	"$hts_exec_prefix"/*) zlib_hostdir=${hts_libdir#"$hts_exec_prefix"/} ;;
+	*/*) zlib_hostdir=${hts_libdir##*/} ;;
+	*) zlib_hostdir=lib ;;
+	esac
+	zlib_subdirs=$zlib_hostdir
+	for zlib_sub in lib lib64; do
+		test "$zlib_sub" = "$zlib_hostdir" || zlib_subdirs="$zlib_subdirs $zlib_sub"
+	done
+	zlib_libdir=
+	for zlib_sub in $zlib_subdirs; do
+		for zlib_file in "$zlib_want/$zlib_sub"/libz.*; do
+			test -f "$zlib_file" && zlib_libdir=$zlib_want/$zlib_sub && break
+		done
+		test -n "$zlib_libdir" && break
+	done
+	if test -z "$zlib_libdir"; then
+		AC_MSG_ERROR([zlib requested at $zlib_want but no libz found in any of: $zlib_subdirs])
+	fi
 	CPPFLAGS="$CPPFLAGS -I$zlib_want/include"
-	LDFLAGS="$LDFLAGS -L$zlib_want/lib"
+	LDFLAGS="$LDFLAGS -L$zlib_libdir"
 elif test -f /usr/local/include/zlib.h; then
 	# Where the BSD ports tree lands zlib, and not always searched by default.
 	CPPFLAGS="$CPPFLAGS -I/usr/local/include"

--- a/m4/expand_libdir.m4
+++ b/m4/expand_libdir.m4
@@ -1,0 +1,17 @@
+dnl @synopsis HTS_EXPAND_LIBDIR()
+dnl
+dnl Expand $exec_prefix and $libdir into hts_exec_prefix and hts_libdir. Until
+dnl config.status runs, $prefix is NONE and $libdir still holds an unexpanded
+dnl ${exec_prefix} reference, so neither can be read as a path.
+
+AC_DEFUN([HTS_EXPAND_LIBDIR], [
+hts_save_prefix=$prefix
+hts_save_exec_prefix=$exec_prefix
+test "x$prefix" = xNONE && prefix=$ac_default_prefix
+test "x$exec_prefix" = xNONE && exec_prefix=$prefix
+eval hts_exec_prefix=\"$exec_prefix\"
+eval hts_libdir=\"$libdir\"
+eval hts_libdir=\"$hts_libdir\"
+prefix=$hts_save_prefix
+exec_prefix=$hts_save_exec_prefix
+])

--- a/tests/380_configure-zlib-libdir.test
+++ b/tests/380_configure-zlib-libdir.test
@@ -1,0 +1,121 @@
+#!/bin/bash
+# --with-zlib=DIR must find the library where the host keeps it: a multilib
+# distribution puts the 64-bit copy in lib64 and Debian under a multiarch
+# triplet, where the DIR/lib the macro used to append holds nothing, or the
+# wrong ABI.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+srcdir="${abs_top_srcdir:?not run under make check}"
+test -r "${srcdir}/configure" || skip "no configure in ${srcdir}"
+
+cc=${CC:-cc}
+sys_lib=$("${cc}" -print-file-name=libz.so 2>/dev/null || true)
+test -f "${sys_lib}" || sys_lib=$("${cc}" -print-file-name=libz.a 2>/dev/null || true)
+test -f "${sys_lib}" || skip "no linkable system libz to build a fixture from"
+sys_hdr=$(printf '#include <zlib.h>\n' | "${cc}" -E -xc - 2>/dev/null |
+    sed -n 's/^#[ 0-9]*"\([^"]*zlib\.h\)".*/\1/p' | head -1)
+test -f "${sys_hdr}" || skip "no system zlib.h to build a fixture from"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/zlibdir.XXXXXX") || fail "no tmpdir"
+cleanup_push rm -rf "${work}"
+
+# automake refuses an out-of-tree configure when srcdir holds a config.status,
+# which an in-tree build leaves there; a symlink farm without that one file is
+# the same tree to configure.
+shadow=${work}/srcdir
+mkdir -p "${shadow}"
+for entry in "${srcdir}"/*; do
+    test "${entry##*/}" = config.status || ln -s "${entry}" "${shadow}/"
+done
+test -r "${shadow}/configure" || fail "the shadow source tree has no configure"
+
+# A prefix holding a real zlib in each named subdirectory and nowhere else.
+fixture() { # fixture NAME SUBDIR...
+    local name=$1 sub
+    shift
+    mkdir -p "${work}/${name}/include"
+    ln -s "${sys_hdr}" "${work}/${name}/include/zlib.h"
+    for sub in "$@"; do
+        mkdir -p "${work}/${name}/${sub}"
+        ln -s "${sys_lib}" "${work}/${name}/${sub}/${sys_lib##*/}"
+    done
+    echo "${work}/${name}"
+}
+
+# One cache for every run: nothing cached here depends on the prefix or the
+# libdir, and a cold configure is the whole cost of this test.
+cache=${work}/config.cache
+n=0
+cases=6 # expect/expect_fail calls below, what the budget is paced against
+
+run_configure() { # run_configure DIR ARG...
+    local dir=$1
+    shift
+    mkdir -p "${dir}"
+    # zlib has nothing to do with TLS, and a keg-only openssl (brew) makes
+    # --enable-https a hard error.
+    (cd "${dir}" && bash "${shadow}/configure" --cache-file="${cache}" \
+        --enable-https=auto "$@") >"${dir}/configure.log" 2>&1
+}
+
+expect() { # expect WANT-SUBDIR REJECTED-SUBDIR DESC PREFIX ARG...
+    local want=$1 nope=$2 desc=$3 prefix=$4
+    shift 4
+    local dir line began=${SECONDS}
+    n=$((n + 1))
+    dir=${work}/build${n}
+    run_configure "${dir}" --with-zlib="${prefix}" "$@" || {
+        tail -20 "${dir}/configure.log" >&2
+        fail "${desc}: configure failed"
+    }
+    line=$(sed -n 's/^LDFLAGS = *//p' "${dir}/src/Makefile")
+    test -n "${line}" || fail "${desc}: src/Makefile carries no LDFLAGS line"
+    case " ${line} " in
+    *" -L${prefix}/${want} "*) ;;
+    *) fail "${desc}: expected -L${prefix}/${want}, got: ${line}" ;;
+    esac
+    case " ${line} " in
+    *" -L${prefix}/${nope} "*) fail "${desc}: also picked -L${prefix}/${nope}: ${line}" ;;
+    esac
+    echo "ok: ${desc} -> ${want}"
+    skip_if_out_of_budget "$((cases - n))" "$((SECONDS - began))"
+}
+
+expect_fail() { # expect_fail DESC PREFIX
+    local desc=$1 prefix=$2 dir began=${SECONDS}
+    n=$((n + 1))
+    dir=${work}/build${n}
+    ! run_configure "${dir}" --with-zlib="${prefix}" ||
+        fail "${desc}: configure accepted a prefix with no libz under it"
+    grep -q 'no libz found' "${dir}/configure.log" ||
+        fail "${desc}: configure failed without naming the missing library"
+    echo "ok: ${desc}"
+    skip_if_out_of_budget "$((cases - n))" "$((SECONDS - began))"
+}
+
+lib_only=$(fixture lib-only lib)
+lib64_only=$(fixture lib64-only lib64)
+both=$(fixture both lib lib64)
+multiarch=$(fixture multiarch lib lib/x86_64-linux-gnu)
+headers_only=$(fixture headers-only)
+
+# The control first: a plain lib prefix must keep resolving exactly as before,
+# or every lib64 answer below could come from a macro that always says lib64.
+expect lib lib64 "a lib-only prefix resolves" "${lib_only}"
+expect lib64 lib "a lib64-only prefix resolves" "${lib64_only}"
+
+# With both populated the probe cannot decide, so these two pin the derivation
+# from the configured libdir rather than the order the candidates are tried in.
+expect lib lib64 "the default libdir picks lib" "${both}" --prefix="${work}/inst"
+expect lib64 lib "--libdir picks lib64" "${both}" \
+    --prefix="${work}/inst" --libdir="${work}/inst/lib64"
+expect lib/x86_64-linux-gnu lib "a multiarch libdir picks the triplet" "${multiarch}" \
+    --prefix="${work}/inst" --libdir="${work}/inst/lib/x86_64-linux-gnu"
+
+expect_fail "a prefix with no libz is rejected" "${headers_only}"
+
+assert_steps_ran "${cases}" "${n}"

--- a/tests/380_configure-zlib-libdir.test
+++ b/tests/380_configure-zlib-libdir.test
@@ -1,8 +1,7 @@
 #!/bin/bash
-# --with-zlib=DIR must find the library where the host keeps it: a multilib
-# distribution puts the 64-bit copy in lib64 and Debian under a multiarch
-# triplet, where the DIR/lib the macro used to append holds nothing, or the
-# wrong ABI.
+# A multilib host keeps the 64-bit zlib in lib64, Debian under a multiarch
+# triplet. The DIR/lib --with-zlib=DIR used to append holds nothing there,
+# or the wrong ABI.
 
 set -euo pipefail
 

--- a/tests/380_configure-zlib-libdir.test
+++ b/tests/380_configure-zlib-libdir.test
@@ -11,20 +11,24 @@ set -euo pipefail
 srcdir="${abs_top_srcdir:?not run under make check}"
 test -r "${srcdir}/configure" || skip "no configure in ${srcdir}"
 
+# $CC carries its flags on some hosts (macOS configures gcc -std=gnu23), so it
+# is an argv, never one word.
+read -r -a cc_argv <<<"${CC:-cc}"
+command -v "${cc_argv[0]}" >/dev/null 2>&1 || skip "no C compiler (${cc_argv[0]})"
+
 # The fixture symlinks a real library. macOS has kept no on-disk libz.dylib
 # since 11, so the last resort is the SDK's libz.tbd stub, which -lz accepts
 # and the macro's libz.* glob matches.
-cc=${CC:-cc}
 sys_lib=
 for name in libz.so libz.dylib libz.tbd libz.a; do
-    cand=$("${cc}" -print-file-name="${name}" 2>/dev/null || true)
+    cand=$("${cc_argv[@]}" -print-file-name="${name}") || cand=
     if test -f "${cand}"; then
         sys_lib=${cand}
         break
     fi
 done
-if test -z "${sys_lib}"; then
-    sdk=$(xcrun --show-sdk-path 2>/dev/null || true)
+if test -z "${sys_lib}" && command -v xcrun >/dev/null 2>&1; then
+    sdk=$(xcrun --show-sdk-path) || sdk=
     for name in libz.tbd libz.dylib libz.a; do
         if test -n "${sdk}" && test -f "${sdk}/usr/lib/${name}"; then
             sys_lib=${sdk}/usr/lib/${name}
@@ -33,9 +37,13 @@ if test -z "${sys_lib}"; then
     done
 fi
 test -n "${sys_lib}" ||
-    skip "${cc} and the SDK offer no libz.so/.dylib/.tbd/.a to build the fixture from"
-sys_hdr=$(printf '#include <zlib.h>\n' | "${cc}" -E -xc - 2>/dev/null |
-    sed -n 's/^#[ 0-9]*"\([^"]*zlib\.h\)".*/\1/p' | head -1)
+    skip "${cc_argv[*]} and the SDK offer no libz.so/.dylib/.tbd/.a for the fixture"
+
+cpp_out=$(printf '#include <zlib.h>\n' | "${cc_argv[@]}" -E -xc -) ||
+    skip "${cc_argv[*]} cannot preprocess a bare <zlib.h>"
+# Capture then match: piping into a truncating reader SIGPIPEs the sed upstream.
+hdrs=$(sed -n 's/^#[ 0-9]*"\([^"]*zlib\.h\)".*/\1/p' <<<"${cpp_out}")
+sys_hdr=${hdrs%%$'\n'*}
 test -f "${sys_hdr}" || skip "no system zlib.h to build a fixture from"
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/zlibdir.XXXXXX") || fail "no tmpdir"

--- a/tests/380_configure-zlib-libdir.test
+++ b/tests/380_configure-zlib-libdir.test
@@ -11,10 +11,29 @@ set -euo pipefail
 srcdir="${abs_top_srcdir:?not run under make check}"
 test -r "${srcdir}/configure" || skip "no configure in ${srcdir}"
 
+# The fixture symlinks a real library. macOS has kept no on-disk libz.dylib
+# since 11, so the last resort is the SDK's libz.tbd stub, which -lz accepts
+# and the macro's libz.* glob matches.
 cc=${CC:-cc}
-sys_lib=$("${cc}" -print-file-name=libz.so 2>/dev/null || true)
-test -f "${sys_lib}" || sys_lib=$("${cc}" -print-file-name=libz.a 2>/dev/null || true)
-test -f "${sys_lib}" || skip "no linkable system libz to build a fixture from"
+sys_lib=
+for name in libz.so libz.dylib libz.tbd libz.a; do
+    cand=$("${cc}" -print-file-name="${name}" 2>/dev/null || true)
+    if test -f "${cand}"; then
+        sys_lib=${cand}
+        break
+    fi
+done
+if test -z "${sys_lib}"; then
+    sdk=$(xcrun --show-sdk-path 2>/dev/null || true)
+    for name in libz.tbd libz.dylib libz.a; do
+        if test -n "${sdk}" && test -f "${sdk}/usr/lib/${name}"; then
+            sys_lib=${sdk}/usr/lib/${name}
+            break
+        fi
+    done
+fi
+test -n "${sys_lib}" ||
+    skip "${cc} and the SDK offer no libz.so/.dylib/.tbd/.a to build the fixture from"
 sys_hdr=$(printf '#include <zlib.h>\n' | "${cc}" -E -xc - 2>/dev/null |
     sed -n 's/^#[ 0-9]*"\([^"]*zlib\.h\)".*/\1/p' | head -1)
 test -f "${sys_hdr}" || skip "no system zlib.h to build a fixture from"
@@ -96,6 +115,9 @@ expect_fail() { # expect_fail DESC PREFIX
     skip_if_out_of_budget "$((cases - n))" "$((SECONDS - began))"
 }
 
+# The subdirectory names are the fixture's own, not the host's, so every case
+# below means the same thing on a platform that has no real lib64 (macOS, and
+# this box): what they exercise is the macro's candidate order, which is shell.
 lib_only=$(fixture lib-only lib)
 lib64_only=$(fixture lib64-only lib64)
 both=$(fixture both lib lib64)


### PR DESCRIPTION
`--with-zlib=DIR` appended `-L$DIR/lib` unconditionally, which is only right on a host that spells its library directory `lib`. Fedora, openSUSE and Gentoo/amd64 put the 64-bit copy in `lib64`, Debian under a multiarch triplet, and there the appended path is either absent or holds the wrong ABI. The link check then quietly resolves against a system libz and the explicit prefix is ignored. The header half of the macro already errors when `DIR/include/zlib.h` is missing; the library half had no such care.

The subdirectory now comes from the configured `libdir`, taken relative to `exec_prefix` so a multiarch `lib/x86_64-linux-gnu` survives, with `lib` and `lib64` probed after it. A prefix under which no `libz.*` turns up is an error now, not a silent fallback. `libdir` is only readable as a path once `prefix` and `exec_prefix` are resolved, so that expansion moved into its own `HTS_EXPAND_LIBDIR` macro that `CHECK_ZLIB` requires, rather than depending on where the two calls happen to sit in configure.ac. A default build never enters this branch: the generated `configure` differs from master's only inside the `--with-zlib` arm.

Gentoo already carries a sed for this in `src_prepare`, guarded by a tripwire that dies if the string it rewrites is gone:

    grep -wq '{ZLIB_HOME}/lib' m4/check_zlib.m4 || die
    sed "s,{ZLIB_HOME}/lib,{ZLIB_HOME}/$(get_libdir)," -i m4/check_zlib.m4 || die

`ZLIB_HOME` was rewritten out of the macro by #750 and has not existed since 3.49.15, so that grep matches nothing and their build dies at src_prepare on their next bump. With this in place they can drop the patch rather than repair it.

`tests/380_configure-zlib-libdir.test` builds throwaway prefixes holding a real zlib in chosen subdirectories and reads the `-L` back out of the generated `src/Makefile`. Six cases: a `lib`-only prefix still resolves (the control, which passes on master), a `lib64`-only one resolves (this fails on master, which picks the missing `lib`), and with both populated the answer follows `--libdir` in each direction, so what is pinned is the derivation and not the order the candidates happen to be tried in. Each case also asserts the other subdirectory was not added, which rules out a fix that simply appends both.
