### PR TITLE
Nothing checks the installed doc tree, where three index.html links dangle

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -98,9 +98,9 @@ app, and a command-line program on every platform.</p>
 <h2>About this program</h2>
 
 <p><a href="contact.html">Contact and credits</a> &middot;
-<a href="../history.txt">Release notes</a> &middot;
-<a href="../license.txt">Licence</a> &middot;
-<a href="../greetings.txt">Acknowledgements</a></p>
+<a href="history.txt">Release notes</a> &middot;
+<a href="license.txt">Licence</a> &middot;
+<a href="greetings.txt">Acknowledgements</a></p>
 
 <p>HTTrack is free software released under the GNU General Public License, version 3 or
 later. It comes with no warranty, and copying a website is your responsibility: read

--- a/html/index.html
+++ b/html/index.html
@@ -98,9 +98,9 @@ app, and a command-line program on every platform.</p>
 <h2>About this program</h2>
 
 <p><a href="contact.html">Contact and credits</a> &middot;
-<a href="history.txt">Release notes</a> &middot;
-<a href="license.txt">Licence</a> &middot;
-<a href="greetings.txt">Acknowledgements</a></p>
+<a href="../history.txt">Release notes</a> &middot;
+<a href="../license.txt">Licence</a> &middot;
+<a href="../greetings.txt">Acknowledgements</a></p>
 
 <p>HTTrack is free software released under the GNU General Public License, version 3 or
 later. It comes with no warranty, and copying a website is your responsibility: read

--- a/tests/382_doc-links-resolve.test
+++ b/tests/382_doc-links-resolve.test
@@ -48,6 +48,29 @@ resolve() { # resolve DIR LINK, both relative to ${stage}
     printf '%s\n' "${out}"
 }
 
+# history.txt, license.txt and greetings.txt sit at the repo root, so index.html
+# has to reach them with "../" for tools/doc-links.py, and that "../" is one
+# level too high once the install puts all four in the same directory.
+gaps=(
+    "index.html ../history.txt"
+    "index.html ../license.txt"
+    "index.html ../greetings.txt"
+)
+gap_seen=()
+for i in "${!gaps[@]}"; do gap_seen[i]=; done
+
+# Index of the recorded gap for PAGE LINK, or 1 if there is none.
+gap_index() {
+    local i
+    for i in "${!gaps[@]}"; do
+        test "${gaps[i]}" != "$1 $2" || {
+            printf '%s\n' "${i}"
+            return 0
+        }
+    done
+    return 1
+}
+
 pages=0
 links=0
 bad=0
@@ -70,8 +93,14 @@ while IFS= read -r page; do
         esac
         links=$((links + 1))
         if ! target=$(resolve "${dir}" "${link}") || [ ! -e "${stage}/${target}" ]; then
-            echo "  ${page#"${stage}"}: ${link}" >&2
-            bad=$((bad + 1))
+            if g=$(gap_index "${rel}" "${link}"); then
+                gap_seen[g]=dangles
+            else
+                echo "  ${page#"${stage}"}: ${link}" >&2
+                bad=$((bad + 1))
+            fi
+        elif g=$(gap_index "${rel}" "${link}"); then
+            gap_seen[g]=resolves
         fi
     done < <(LC_ALL=C grep -Eio "(href|src)[[:space:]]*=[[:space:]]*[\"'][^\"']*[\"']" "${page}" || true)
 done < <(find "${root}" -name '*.html' | LC_ALL=C sort)
@@ -81,4 +110,17 @@ test "${pages}" -gt 0 || fail "no pages staged under ${htmldir}"
 test "${links}" -gt 0 || fail "no relative links found across ${pages} pages"
 test "${bad}" -eq 0 || fail "${bad} of ${links} relative links dangle in ${htmldir}"
 
-echo "${links} relative links across ${pages} pages resolve in ${htmldir}"
+# A gap that stopped being one has to be deleted, not left recording a link the
+# layout now resolves.
+stale=0
+for i in "${!gaps[@]}"; do
+    case ${gap_seen[i]} in
+    dangles) continue ;;
+    resolves) echo "  ${gaps[i]}: resolves here" >&2 ;;
+    *) echo "  ${gaps[i]}: not a link on that page any more" >&2 ;;
+    esac
+    stale=$((stale + 1))
+done
+test "${stale}" -eq 0 || fail "${stale} of ${#gaps[@]} recorded gaps are out of date"
+
+echo "${links} relative links across ${pages} pages resolve in ${htmldir}, ${#gaps[@]} recorded gaps still dangle"

--- a/tests/382_doc-links-resolve.test
+++ b/tests/382_doc-links-resolve.test
@@ -1,0 +1,84 @@
+#!/bin/bash
+#
+# The doc pages ship in a directory whose depth is the packager's --htmldir
+# choice, so a relative link that resolves in one layout dangles in another and
+# nothing but a staged install can tell them apart.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+: "${abs_top_builddir:?not run under make check}"
+htmlsrc="${abs_top_srcdir:?not run under make check}/html"
+htmldir=${CONFIGURED_HTMLDIR:?not run under make check}
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/doclinks.XXXXXX") || fail "no tmpdir"
+cleanup_push rm -rf "${work}"
+
+stage=${work}/stage
+if ! env -u MAKEFLAGS -u MAKELEVEL "${MAKE:-make}" -C "${abs_top_builddir}" \
+    install DESTDIR="${stage}" >"${work}/install.log" 2>&1; then
+    dump_file "${work}/install.log"
+    skip "cannot stage an install, so no layout to resolve against"
+fi
+
+root=${stage}${htmldir}
+test -d "${root}" || skip "nothing staged in ${htmldir}"
+
+# Lexical and relative to the stage root: a link names a path in the shipped
+# tree, and a ".." that walks off the top has left the package.
+resolve() { # resolve DIR LINK, both relative to ${stage}
+    local rest=$1/$2 out='' part
+    while [ -n "${rest}" ]; do
+        part=${rest%%/*}
+        if [ "${part}" = "${rest}" ]; then rest=; else rest=${rest#*/}; fi
+        case ${part} in
+        '' | .) ;;
+        ..)
+            case ${out} in
+            */*) out=${out%/*} ;;
+            ?*) out= ;;
+            *) return 1 ;;
+            esac
+            ;;
+        *) out=${out:+${out}/}${part} ;;
+        esac
+    done
+    printf '%s\n' "${out}"
+}
+
+pages=0
+links=0
+bad=0
+while IFS= read -r page; do
+    rel=${page#"${root}/"}
+    # Only the html/ pages: a docdir stub such as httrack-doc.html points at the
+    # *other* directory, and the default layout collapsing the two lands it here.
+    test -e "${htmlsrc}/${rel}" || continue
+    pages=$((pages + 1))
+    dir=${page%/*}
+    dir=${dir#"${stage}/"}
+    while IFS= read -r attr; do
+        link=${attr#*[\"\']}
+        link=${link%?}
+        link=${link%%#*}
+        link=${link%%\?*}
+        case ${link} in
+        # An anchor, a server URL, a scheme: none of them name a shipped file.
+        '' | /* | *:*) continue ;;
+        esac
+        links=$((links + 1))
+        if ! target=$(resolve "${dir}" "${link}") || [ ! -e "${stage}/${target}" ]; then
+            echo "  ${page#"${stage}"}: ${link}" >&2
+            bad=$((bad + 1))
+        fi
+    done < <(LC_ALL=C grep -Eio "(href|src)[[:space:]]*=[[:space:]]*[\"'][^\"']*[\"']" "${page}" || true)
+done < <(find "${root}" -name '*.html' | LC_ALL=C sort)
+
+test "${pages}" -gt 0 || fail "no pages staged under ${htmldir}"
+# A filter that dropped everything would pass on a tree of dead links.
+test "${links}" -gt 0 || fail "no relative links found across ${pages} pages"
+test "${bad}" -eq 0 || fail "${bad} of ${links} relative links dangle in ${htmldir}"
+
+echo "${links} relative links across ${pages} pages resolve in ${htmldir}"

--- a/tests/382_doc-links-resolve.test
+++ b/tests/382_doc-links-resolve.test
@@ -50,12 +50,16 @@ resolve() { # resolve DIR LINK, both relative to ${stage}
 
 # history.txt, license.txt and greetings.txt sit at the repo root, so index.html
 # has to reach them with "../" for tools/doc-links.py, and that "../" is one
-# level too high once the install puts all four in the same directory.
+# level too high once the install puts them beside it in $(htmldir).
 gaps=(
-    "index.html ../history.txt"
     "index.html ../license.txt"
     "index.html ../greetings.txt"
 )
+# history.txt is the exception: HelpHtmlroot_DATA installs it into $(docdir) as
+# well, so its "../" lands on a real file wherever docdir is htmldir's parent.
+docdir=${CONFIGURED_DOCDIR:?not run under make check}
+test "${docdir%/}" = "${htmldir%/*}" || gaps+=("index.html ../history.txt")
+
 gap_seen=()
 for i in "${!gaps[@]}"; do gap_seen[i]=; done
 


### PR DESCRIPTION
`tools/doc-links.py` resolves the doc set's relative links against the source tree and CI runs it. Nothing resolves them against an install, and three of them dangle there.

`index.html` links history.txt, license.txt and greetings.txt through `../`, which is correct in the source tree, where those three sit at the repo root and index.html is in `html/`. `html/Makefile.am` then installs all four into `$(htmldir)`, where `../` is one level too high. Measured on staged installs: under the autotools default, where `htmldir` and `docdir` are one directory, all three dangle, and the same under Debian, whose `debian/rules` moves that directory to `/usr/share/httrack/html`; under a split `--htmldir=$docdir/html` only license.txt and greetings.txt dangle. No static href satisfies both checkers, so this does not touch the link. Closing the gap means moving the three files under `html/`, or defaulting `htmldir` to `$(docdir)/html`. Neither is decided here.

What the PR adds is `382_doc-links-resolve.test`. It stages a `make install` and resolves every relative `href` and `src` in the installed html/ pages against the staged tree, failing on any target that is not there. Anchors, absolute htsserver URLs and external schemes are skipped, and the run asserts it saw pages and links at all rather than passing on an empty selection; it skips instead of passing when it cannot stage an install. 604 links across 63 pages.

The three known ones are recorded rather than fixed, and the record is per layout, because `history.txt` is the one of the three that `HelpHtmlroot_DATA` also installs into `$(docdir)`, so its `../` resolves wherever docdir is htmldir's parent. license.txt and greetings.txt reach `$(htmldir)` alone and dangle in every layout. A recorded link that starts resolving fails the test, so an entry cannot outlive its cause: whoever closes the gap is told to delete it. Both directions are checked in the default and the split layout.

`httrack-doc.html` is a separate docdir stub whose `html/index.html` is right for the split layout and right for Debian, which creates the symlink that makes it so, and wrong only where docdir and htmldir collapse into one directory. The test scans only pages present under `html/` in the source tree, so it is out of scope by construction.
