### PR TITLE
configure: AC_MSG_ERROR truncates its message on three option checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -444,7 +444,7 @@ AC_ARG_ENABLE([https],
 		AC_MSG_RESULT($https_support)
 		;;
 	*)
-		AC_MSG_ERROR(bad value for https, expected yes/no/auto)
+		AC_MSG_ERROR([bad value for https, expected yes/no/auto])
 		;;
 	esac	
 	],
@@ -587,7 +587,7 @@ AC_ARG_ENABLE([online-unit-tests],
 		AC_MSG_RESULT($enableval)
 		;;
 	*)
-		AC_MSG_ERROR(bad value for online-unit-tests, expected yes/no/auto)
+		AC_MSG_ERROR([bad value for online-unit-tests, expected yes/no/auto])
 		;;
 	esac
 	],
@@ -608,7 +608,7 @@ AC_ARG_ENABLE([fuzzers],
 		AC_MSG_RESULT($enableval)
 		;;
 	*)
-		AC_MSG_ERROR(bad value for fuzzers, expected yes/no)
+		AC_MSG_ERROR([bad value for fuzzers, expected yes/no])
 		;;
 	esac
 	],

--- a/tests/383_configure-error-message-comma.test
+++ b/tests/383_configure-error-message-comma.test
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Three AC_MSG_ERROR() calls in configure.ac passed an unquoted message
+# containing a comma, so m4 read everything after it as a second argument
+# and printed only the tail (e.g. "yes/no/auto" instead of the full
+# sentence), alongside bash errors from the mangled macro expansion.
+# Checks the full message, not just that configure fails: it fails either way.
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+configure="${abs_top_srcdir:-}/configure"
+test -r "$configure" || skip "no configure script at ${configure:-<unset>}; tests/Makefile.am must export abs_top_srcdir"
+
+tmp=$(mktemp -d)
+cleanup_push rm -rf "$tmp"
+mkdir "$tmp/src"
+
+# Symlink farm, not the real srcdir: an in-tree config.status makes autoconf refuse it.
+for f in "$abs_top_srcdir"/*; do
+    case "${f##*/}" in
+    config.status | config.log | config.h | stamp-h1 | Makefile) continue ;;
+    esac
+    ln -s "$f" "$tmp/src/"
+done
+
+# run_bad NAME EXPECTED_MSG FLAG...: runs configure with FLAG..., asserts it
+# fails with EXPECTED_MSG intact and no bash error text leaking alongside.
+run_bad() {
+    local name=$1 expect=$2 log out status
+    shift 2
+    log="$tmp/$name.log"
+    mkdir "$tmp/bld-$name"
+    status=0
+    (cd "$tmp/bld-$name" && bash "$tmp/src/configure" "$@") >"$log" 2>&1 || status=$?
+    test "$status" -eq 1 || fail_dump "configure --$name exited $status, want 1" "$log"
+    out=$(<"$log")
+    grep -qF "configure: error: $expect" <<<"$out" ||
+        fail_dump "configure --$name did not print the full message '$expect'" "$log"
+    grep -qE '^[^:]*configure: line [0-9]+:' <<<"$out" &&
+        fail_dump "configure --$name leaked a bash error alongside the message" "$log"
+    return 0
+}
+
+# --disable-https skips the OpenSSL probes so the other two reach their own
+# check quickly; https itself is checked first, before any flag matters.
+run_bad https "bad value for https, expected yes/no/auto" \
+    --enable-https=maybe
+run_bad online-unit-tests "bad value for online-unit-tests, expected yes/no/auto" \
+    --disable-https --enable-online-unit-tests=maybe
+run_bad fuzzers "bad value for fuzzers, expected yes/no" \
+    --disable-https --enable-fuzzers=maybe
+
+echo "all three AC_MSG_ERROR messages reach the user intact"


### PR DESCRIPTION
An unquoted comma in AC_MSG_ERROR's argument makes m4 treat everything after it as a second macro argument, so the printed message loses its first half. `--enable-fuzzers=maybe` prints:

```
checking whether to build fuzzers... configure: line 455: test: expected: integer expression expected
configure: line 458: $4: Bad file descriptor
configure: error: yes/no
configure: line 340: return: expected: numeric argument required
configure: line 350: exit: expected: numeric argument required
```

instead of "bad value for fuzzers, expected yes/no". Same shape for `--enable-https=maybe` (prints just "yes/no/auto") and `--enable-online-unit-tests=maybe`. Bracket-quoting the three messages, matching every other AC_MSG_ERROR in the tree, fixes both the truncation and the bash errors riding along with it.

Found while reviewing #1470, which fixes a fourth instance on its own branch. Grepped configure.ac and m4/*.m4 for other unquoted macro arguments containing a comma and found none beyond these three.

tests/383_configure-error-message-comma.test drives configure with each bad value from a symlinked copy of the source tree and asserts the full message text, not just a nonzero exit: configure fails either way, so exit status alone can't tell the fix from the bug. It reds on the unquoted tree (truncated message, exit 2, leaked bash errors) and passes on the fixed one.
