### PR TITLE
The doc pages link three text files the install puts out of their reach

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -31,6 +31,10 @@ somebody has to move at every bump.
   binary-relative rpath when `libdir` is a system one. A distribution build gets
   none, so there is no libtool line to sed out.
 - `--enable-fuzzers` builds the fuzz harnesses under clang. Not for a package.
+- `--htmldir` defaults to `$(docdir)/html` rather than autoconf's `$(docdir)`.
+  The pages link `../license.txt`, `../greetings.txt` and `../history.txt`, which
+  install into `$(docdir)`, so a layout that puts the pages anywhere else strands
+  those three.
 
 ## Do not re-encode the tree
 

--- a/configure.ac
+++ b/configure.ac
@@ -692,6 +692,10 @@ AC_SUBST([FUZZ_CORPUS_LIST])
 AC_MSG_RESULT([$hts_ncorpus])
 test "$hts_ncorpus" -gt 0 || AC_MSG_ERROR([no fuzz corpus file matched fuzz/corpus/*/*])
 
+# The doc pages reach license.txt and its neighbours with "../", so htmldir defaults
+# one level below $(docdir), where those install. A --htmldir naming a path wins.
+AS_IF([test "x$htmldir" = 'x${docdir}'], [htmldir='${docdir}/html'])
+
 # Final output
 AC_CONFIG_FILES([
 Makefile

--- a/debian/httrack-doc.lintian-overrides
+++ b/debian/httrack-doc.lintian-overrides
@@ -1,7 +1,8 @@
-# httrack ships its HTML manual (and the bundled license) under
-# /usr/share/httrack/html by design; /usr/share/doc/httrack/html symlinks into
-# it (see debian/rules). These are pointed hints whose match context is empty,
-# so the path lives in the display pointer, not the override -- match with '*'.
+# httrack ships its HTML manual under /usr/share/httrack/html by design, with
+# /usr/share/doc/httrack/html symlinking into it and the bundled license beside
+# that symlink (see debian/rules). These are pointed hints whose match context
+# is empty, so the path lives in the display pointer, not the override -- match
+# with '*'.
 httrack-doc: extra-license-file *
 httrack-doc: package-contains-documentation-outside-usr-share-doc *
 # search.sh is a sample CGI shipped alongside the HTML manual, not meant to be

--- a/debian/rules
+++ b/debian/rules
@@ -49,8 +49,8 @@ install: build
 	##$(MAKE) install DESTDIR=$(CURDIR)/debian/httrack
 
 	# Debian inverts our layout: the pages are real under /usr/share/httrack and
-	# /usr/share/doc/httrack/html is the symlink. httrack-doc.html and the text
-	# files already sit in docdir, so only the pages move.
+	# /usr/share/doc/httrack/html is the symlink. httrack-doc.html, license.txt
+	# and greetings.txt already sit in docdir, so only the pages move.
 
 	# remove symlink created by html/Makefile's install-data-hook
 	rm $(CURDIR)/debian/httrack/usr/share/httrack/html
@@ -59,8 +59,7 @@ install: build
 	# create symlink on the other side
 	ln -s ../../httrack/html \
 		$(CURDIR)/debian/httrack/usr/share/doc/httrack/html
-	# dh_installchangelogs already ships history.txt as the changelog, so the
-	# copy the manual links to would be the same file twice in one doc tree.
+	# dh_installchangelogs already ships this as changelog.gz (duplicate-changelog-files).
 	rm $(CURDIR)/debian/httrack/usr/share/doc/httrack/history.txt
 
 	# remove *.la (https://wiki.debian.org/ReleaseGoals/LAFileRemoval)

--- a/debian/rules
+++ b/debian/rules
@@ -48,20 +48,17 @@ install: build
 	dh_auto_install --destdir=$(CURDIR)/debian/httrack
 	##$(MAKE) install DESTDIR=$(CURDIR)/debian/httrack
 
-	# place html files (doc, webhttrack files)
+	# Debian inverts our layout: the pages are real under /usr/share/httrack and
+	# /usr/share/doc/httrack/html is the symlink. httrack-doc.html and the three
+	# text files already sit in docdir, so only the pages move.
 
 	# remove symlink created by html/Makefile's install-data-hook
 	rm $(CURDIR)/debian/httrack/usr/share/httrack/html
-	# and put back in place data
-	mv $(CURDIR)/debian/httrack/usr/share/doc/httrack \
+	mv $(CURDIR)/debian/httrack/usr/share/doc/httrack/html \
 		$(CURDIR)/debian/httrack/usr/share/httrack/html
 	# create symlink on the other side
-	mkdir $(CURDIR)/debian/httrack/usr/share/doc/httrack
 	ln -s ../../httrack/html \
 		$(CURDIR)/debian/httrack/usr/share/doc/httrack/html
-	# and put in place the two outer files
-	mv $(CURDIR)/debian/httrack/usr/share/httrack/html/httrack-doc.html \
-		$(CURDIR)/debian/httrack/usr/share/doc/httrack/httrack-doc.html
 
 	# remove *.la (https://wiki.debian.org/ReleaseGoals/LAFileRemoval)
 	rm -f $(CURDIR)/debian/httrack/usr/lib/$(DEB_HOST_MULTIARCH)/*.la

--- a/debian/rules
+++ b/debian/rules
@@ -49,8 +49,8 @@ install: build
 	##$(MAKE) install DESTDIR=$(CURDIR)/debian/httrack
 
 	# Debian inverts our layout: the pages are real under /usr/share/httrack and
-	# /usr/share/doc/httrack/html is the symlink. httrack-doc.html and the three
-	# text files already sit in docdir, so only the pages move.
+	# /usr/share/doc/httrack/html is the symlink. httrack-doc.html and the text
+	# files already sit in docdir, so only the pages move.
 
 	# remove symlink created by html/Makefile's install-data-hook
 	rm $(CURDIR)/debian/httrack/usr/share/httrack/html
@@ -59,6 +59,9 @@ install: build
 	# create symlink on the other side
 	ln -s ../../httrack/html \
 		$(CURDIR)/debian/httrack/usr/share/doc/httrack/html
+	# dh_installchangelogs already ships history.txt as the changelog, so the
+	# copy the manual links to would be the same file twice in one doc tree.
+	rm $(CURDIR)/debian/httrack/usr/share/doc/httrack/history.txt
 
 	# remove *.la (https://wiki.debian.org/ReleaseGoals/LAFileRemoval)
 	rm -f $(CURDIR)/debian/httrack/usr/lib/$(DEB_HOST_MULTIARCH)/*.la
@@ -93,7 +96,8 @@ binary-indep: build install
 	dh_installdocs -i
 	dh_installchangelogs -i history.txt
 	dh_link -i
-	dh_compress -i
+	# -X.txt: the manual links greetings.txt and license.txt by name.
+	dh_compress -i -X.txt
 	dh_fixperms -i
 	dh_installdeb -i
 	dh_gencontrol -i
@@ -109,7 +113,7 @@ binary-arch: build install
 	dh_installchangelogs -a history.txt
 	dh_link -a
 	dh_strip -a
-	dh_compress -a
+	dh_compress -a -X.txt
 	dh_fixperms -a
 	dh_makeshlibs -a -X/usr/lib/$(DEB_HOST_MULTIARCH)/httrack/libtest --version-info
 	dh_installdeb -a

--- a/html/Makefile.am
+++ b/html/Makefile.am
@@ -5,7 +5,6 @@ HelpHtmlimgdir = $(HelpHtmldir)/img
 HelpHtmldivdir = $(HelpHtmldir)/div
 HelpHtmlimagesdir = $(HelpHtmldir)/images
 HelpHtmlfontsdir = $(HelpHtmldir)/fonts
-HelpHtmlTxtdir = $(HelpHtmldir)
 WebHtmldir = $(HelpHtmldir)/server
 WebHtmlimagesdir = $(HelpHtmldir)/server/images
 WebPixmapdir = $(datadir)/pixmaps
@@ -23,14 +22,14 @@ MetaInfodir = $(datadir)/metainfo
 # the build dir and stays unexpanded (breaking "make") in an out-of-tree build.
 # Explicit filenames (e.g. ../history.txt, div/search.sh) resolve via VPATH and
 # need no prefix.
-HelpHtmlroot_DATA = ../httrack-doc.html ../history.txt
+# In $(docdir), one level above the pages, which is where their "../" points.
+HelpHtmlroot_DATA = ../httrack-doc.html ../history.txt ../greetings.txt ../license.txt
 HelpHtml_DATA = $(srcdir)/*.html $(srcdir)/*.js $(srcdir)/*.css
 HelpHtmldiv_DATA = div/search.sh
 HelpHtmlimg_DATA  = $(srcdir)/img/*
 HelpHtmlimages_DATA = $(srcdir)/images/*
 # doc.css reaches the woff2 by a relative URL, so it installs beside the pages.
 HelpHtmlfonts_DATA = $(srcdir)/fonts/*
-HelpHtmlTxt_DATA = ../greetings.txt ../history.txt ../license.txt
 WebHtml_DATA = $(srcdir)/server/*.html $(srcdir)/server/*.js $(srcdir)/server/*.css
 WebHtmlimages_DATA = $(srcdir)/server/images/*
 # Generated from the brand master by gen/export.py. Asserted by tests/160.

--- a/html/Makefile.am
+++ b/html/Makefile.am
@@ -22,7 +22,7 @@ MetaInfodir = $(datadir)/metainfo
 # the build dir and stays unexpanded (breaking "make") in an out-of-tree build.
 # Explicit filenames (e.g. ../history.txt, div/search.sh) resolve via VPATH and
 # need no prefix.
-# In $(docdir), one level above the pages, which is where their "../" points.
+# They install into $(docdir), one level above the pages that link to them.
 HelpHtmlroot_DATA = ../httrack-doc.html ../history.txt ../greetings.txt ../license.txt
 HelpHtml_DATA = $(srcdir)/*.html $(srcdir)/*.js $(srcdir)/*.css
 HelpHtmldiv_DATA = div/search.sh

--- a/tests/382_doc-links-resolve.test
+++ b/tests/382_doc-links-resolve.test
@@ -23,12 +23,11 @@ if ! stage_install_target install "${stage}" "${work}/install.log" .; then
 fi
 
 docdir=${CONFIGURED_DOCDIR:?not run under make check}
-# One walk over both directories: httrack-doc.html links into the pages' one and
-# they link back out, so a root holding one half cannot see either link.
-root=${stage}${htmldir}
-case ${htmldir}/ in "${docdir%/}"/*) root=${stage}${docdir} ;; esac
-tree=${root#"${stage}"}
-test -d "${root}" || skip "nothing staged in ${tree}"
+# httrack-doc.html and the pages link into each other's directory, so both are
+# walked whatever --htmldir made of the two. sort -u collapses the nested case.
+tree=${htmldir}
+test "${docdir%/}" = "${htmldir%/}" || tree="${docdir} and ${htmldir}"
+test -d "${stage}${htmldir}" || skip "nothing staged in ${htmldir}"
 
 # Lexical and relative to the stage root: a link names a path in the shipped
 # tree, and a ".." that walks off the top has left the package.
@@ -52,11 +51,11 @@ resolve() { # resolve DIR LINK, both relative to ${stage}
     printf '%s\n' "${out}"
 }
 
-# The links the shipped layout resolves and another --htmldir strands, recorded
-# so a packager's own choice reports as a known gap rather than as a failure.
+# Links that the shipped layout resolves but another --htmldir strands are
+# recorded, so a packager's choice reports a known gap rather than a failure.
 gaps=()
-# index.html reaches history.txt, license.txt and greetings.txt with "../", the
-# $(docdir) they install into, as long as htmldir sits directly below it.
+# index.html reaches history.txt, license.txt and greetings.txt with "../",
+# which is the $(docdir) they install into while htmldir sits directly below it.
 if test "${docdir%/}" != "${htmldir%/*}"; then
     gaps=(
         "index.html ../license.txt"
@@ -69,15 +68,13 @@ if test "${htmldir%/}" != "${docdir%/}/html"; then
     gaps+=("httrack-doc.html html/index.html")
 fi
 
-# Every expansion carries the `[@]+` guard: on bash 3.2 an empty-array expansion
-# under `set -u` is fatal, and the default layout leaves this one empty.
 gap_seen=()
-for i in ${gaps[@]+"${!gaps[@]}"}; do gap_seen[i]=; done
+for ((i = 0; i < ${#gaps[@]}; i++)); do gap_seen[i]=; done
 
 # Index of the recorded gap for PAGE LINK, or 1 if there is none.
 gap_index() {
     local i
-    for i in ${gaps[@]+"${!gaps[@]}"}; do
+    for ((i = 0; i < ${#gaps[@]}; i++)); do
         test "${gaps[i]}" != "$1 $2" || {
             printf '%s\n' "${i}"
             return 0
@@ -90,9 +87,17 @@ pages=0
 links=0
 bad=0
 while IFS= read -r page; do
-    rel=${page#"${root}/"}
-    # Only pages of ours, which come from two source directories.
-    test -e "${htmlsrc}/${rel}" || test -e "${srcroot}/${rel}" || continue
+    # Name the page by the source file it was installed from, so a staged tree
+    # nobody recognises fails here instead of being skipped into a vacuous pass.
+    relh=${page#"${stage}${htmldir%/}/"}
+    reld=${page#"${stage}${docdir%/}/"}
+    if test -e "${htmlsrc}/${relh}"; then
+        rel=${relh}
+    elif test -e "${srcroot}/${reld}"; then
+        rel=${reld}
+    else
+        fail "staged page ${page#"${stage}"} came from no source file"
+    fi
     pages=$((pages + 1))
     dir=${page%/*}
     dir=${dir#"${stage}/"}
@@ -117,7 +122,10 @@ while IFS= read -r page; do
             gap_seen[g]=resolves
         fi
     done < <(LC_ALL=C grep -Eio "(href|src)[[:space:]]*=[[:space:]]*[\"'][^\"']*[\"']" "${page}" || true)
-done < <(find "${root}" -name '*.html' | LC_ALL=C sort)
+done < <({
+    find "${stage}${htmldir}" -name '*.html'
+    find "${stage}${docdir}" -name '*.html'
+} 2>/dev/null | LC_ALL=C sort -u)
 
 test "${pages}" -gt 0 || fail "no pages staged under ${tree}"
 # A filter that dropped everything would pass on a tree of dead links.
@@ -127,7 +135,7 @@ test "${bad}" -eq 0 || fail "${bad} of ${links} relative links dangle in ${tree}
 # A gap that stopped being one has to be deleted, not left recording a link the
 # layout now resolves.
 stale=0
-for i in ${gaps[@]+"${!gaps[@]}"}; do
+for ((i = 0; i < ${#gaps[@]}; i++)); do
     case ${gap_seen[i]} in
     dangles) continue ;;
     resolves) echo "  ${gaps[i]}: resolves here" >&2 ;;

--- a/tests/382_doc-links-resolve.test
+++ b/tests/382_doc-links-resolve.test
@@ -10,7 +10,8 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 : "${abs_top_builddir:?not run under make check}"
-htmlsrc="${abs_top_srcdir:?not run under make check}/html"
+srcroot=${abs_top_srcdir:?not run under make check}
+htmlsrc=${srcroot}/html
 htmldir=${CONFIGURED_HTMLDIR:?not run under make check}
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/doclinks.XXXXXX") || fail "no tmpdir"
@@ -21,8 +22,13 @@ if ! stage_install_target install "${stage}" "${work}/install.log" .; then
     skip "cannot stage an install, so no layout to resolve against"
 fi
 
+docdir=${CONFIGURED_DOCDIR:?not run under make check}
+# One walk over both directories: httrack-doc.html links into the pages' one and
+# they link back out, so a root holding one half cannot see either link.
 root=${stage}${htmldir}
-test -d "${root}" || skip "nothing staged in ${htmldir}"
+case ${htmldir}/ in "${docdir%/}"/*) root=${stage}${docdir} ;; esac
+tree=${root#"${stage}"}
+test -d "${root}" || skip "nothing staged in ${tree}"
 
 # Lexical and relative to the stage root: a link names a path in the shipped
 # tree, and a ".." that walks off the top has left the package.
@@ -46,25 +52,32 @@ resolve() { # resolve DIR LINK, both relative to ${stage}
     printf '%s\n' "${out}"
 }
 
-# history.txt, license.txt and greetings.txt sit at the repo root, so index.html
-# has to reach them with "../" for tools/doc-links.py, and that "../" is one
-# level too high once the install puts them beside it in $(htmldir).
-gaps=(
-    "index.html ../license.txt"
-    "index.html ../greetings.txt"
-)
-# history.txt is the exception: HelpHtmlroot_DATA installs it into $(docdir) as
-# well, so its "../" lands on a real file wherever docdir is htmldir's parent.
-docdir=${CONFIGURED_DOCDIR:?not run under make check}
-test "${docdir%/}" = "${htmldir%/*}" || gaps+=("index.html ../history.txt")
+# The links the shipped layout resolves and another --htmldir strands, recorded
+# so a packager's own choice reports as a known gap rather than as a failure.
+gaps=()
+# index.html reaches history.txt, license.txt and greetings.txt with "../", the
+# $(docdir) they install into, as long as htmldir sits directly below it.
+if test "${docdir%/}" != "${htmldir%/*}"; then
+    gaps=(
+        "index.html ../license.txt"
+        "index.html ../greetings.txt"
+        "index.html ../history.txt"
+    )
+fi
+# httrack-doc.html reaches the pages under the name they carry in the source tree.
+if test "${htmldir%/}" != "${docdir%/}/html"; then
+    gaps+=("httrack-doc.html html/index.html")
+fi
 
+# Every expansion carries the `[@]+` guard: on bash 3.2 an empty-array expansion
+# under `set -u` is fatal, and the default layout leaves this one empty.
 gap_seen=()
-for i in "${!gaps[@]}"; do gap_seen[i]=; done
+for i in ${gaps[@]+"${!gaps[@]}"}; do gap_seen[i]=; done
 
 # Index of the recorded gap for PAGE LINK, or 1 if there is none.
 gap_index() {
     local i
-    for i in "${!gaps[@]}"; do
+    for i in ${gaps[@]+"${!gaps[@]}"}; do
         test "${gaps[i]}" != "$1 $2" || {
             printf '%s\n' "${i}"
             return 0
@@ -78,9 +91,8 @@ links=0
 bad=0
 while IFS= read -r page; do
     rel=${page#"${root}/"}
-    # Only the html/ pages: a docdir stub such as httrack-doc.html points at the
-    # *other* directory, and the default layout collapsing the two lands it here.
-    test -e "${htmlsrc}/${rel}" || continue
+    # Only pages of ours, which come from two source directories.
+    test -e "${htmlsrc}/${rel}" || test -e "${srcroot}/${rel}" || continue
     pages=$((pages + 1))
     dir=${page%/*}
     dir=${dir#"${stage}/"}
@@ -107,15 +119,15 @@ while IFS= read -r page; do
     done < <(LC_ALL=C grep -Eio "(href|src)[[:space:]]*=[[:space:]]*[\"'][^\"']*[\"']" "${page}" || true)
 done < <(find "${root}" -name '*.html' | LC_ALL=C sort)
 
-test "${pages}" -gt 0 || fail "no pages staged under ${htmldir}"
+test "${pages}" -gt 0 || fail "no pages staged under ${tree}"
 # A filter that dropped everything would pass on a tree of dead links.
 test "${links}" -gt 0 || fail "no relative links found across ${pages} pages"
-test "${bad}" -eq 0 || fail "${bad} of ${links} relative links dangle in ${htmldir}"
+test "${bad}" -eq 0 || fail "${bad} of ${links} relative links dangle in ${tree}"
 
 # A gap that stopped being one has to be deleted, not left recording a link the
 # layout now resolves.
 stale=0
-for i in "${!gaps[@]}"; do
+for i in ${gaps[@]+"${!gaps[@]}"}; do
     case ${gap_seen[i]} in
     dangles) continue ;;
     resolves) echo "  ${gaps[i]}: resolves here" >&2 ;;
@@ -125,4 +137,4 @@ for i in "${!gaps[@]}"; do
 done
 test "${stale}" -eq 0 || fail "${stale} of ${#gaps[@]} recorded gaps are out of date"
 
-echo "${links} relative links across ${pages} pages resolve in ${htmldir}, ${#gaps[@]} recorded gaps still dangle"
+echo "${links} relative links across ${pages} pages resolve in ${tree}, ${#gaps[@]} recorded gaps still dangle"


### PR DESCRIPTION
The doc pages link `../license.txt`, `../greetings.txt` and `../history.txt`. Those three files sit at the repo root and `index.html` sits in `html/`, so in the source tree the `../` is right. `tools/doc-links.py` has checked exactly that for years. The install put the same three files beside `index.html` instead, so there the `../` walked one level too high and all three dangled. #1474 recorded it as a known gap, because no static href satisfies both trees.

`htmldir` now defaults to `$(docdir)/html` rather than autoconf's `$(docdir)`, and the three text files install into `$(docdir)` alone. The installed tree then has the shape the source tree has, so both checkers agree. Fedora already passes exactly this. Another `--htmldir` still works, and test 382 reports those links as a gap of that layout rather than as a failure.

Debian inverts the layout: `debian/rules` makes the pages real under `/usr/share/httrack/html` and turns `/usr/share/doc/httrack/html` into a symlink pointing at them. It did that by moving all of `$(docdir)`. That now carries the three text files along and leaves the pages one level too deep, so `dh_movefiles` loses `/usr/share/httrack/html/server` and the deb build fails. It moves `$(docdir)/html` instead, and the step that moved `httrack-doc.html` back out is gone.

Two more things follow from `$(docdir)` being a real doc directory on Debian. `dh_installchangelogs` already ships `history.txt` there as `changelog.gz`, so the copy is a duplicate lintian rejects, and `debian/rules` drops it. `dh_compress` would gzip `license.txt`, so `-X.txt` keeps the two remaining files at the names the pages link. The Debian package therefore fixes two of the three links and leaves `../history.txt` dead, where all three were dead before. Getting the third back means shipping the changelog twice.

Two more things fall out of the move. `history.txt` was in both `HelpHtmlroot_DATA` and `HelpHtmlTxt_DATA`, which were the same directory by default, so a parallel `make install` could send two rules at one path. That failed once in about 35 attempts and dates back to 3.30.1. And `httrack-doc.html`'s link to `html/index.html` was broken for the mirror-image reason. Test 382 now walks `$(docdir)` as well as `$(htmldir)` to catch it.

Checked by staging installs. Master and this branch install the same 289 files and ship the same 997 in `make dist`. `make uninstall` leaves nothing behind, and the duplicate write of `history.txt` is gone. Four layouts pass for the right reason. The default resolves 605 links across 64 pages with nothing dangling. A flat `--htmldir` and one outside `$(docdir)` record their gaps, and `$(docdir)/foo` still scans all 64 pages. Three mutants die: a missing `license.txt`, a link to a page that is not installed, and a staged page from no source file. The Debian half was built for real, in a clean sid chroot holding only the declared Build-Depends. `tools/mkdeb.sh --sbuild` comes back `Status: successful` on this branch and on the merge base, 412 tests and no lintian hint.

Packagers get a new default path for the HTML documentation, noted in `PACKAGING.md`.