### PR TITLE
The 3.50 release notes say nothing changed since 3.49.25

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,8 +32,9 @@ AC_CONFIG_HEADERS(config.h)
 # header we can install without handing a consumer our PACKAGE_* and HAVE_*.
 AC_CONFIG_HEADERS([htsfeatures.h:src/htsfeatures.h.in])
 AM_INIT_AUTOMAKE([subdir-objects])
-# 3:19:0: revision-only bump for the 3.50.0 release; only the version macro moved,
-# the engine is untouched since 3.49.25.
+# 3:19:0: revision-only bump for the 3.50.0 release. config.h left the installed
+# header set for htsfeatures.h, which carries the same macro values. No installed
+# struct changed layout and no export came or went.
 # 3:18:0: revision-only bump. hts_print_num moved to htsbacktrace.c, which is not
 # in the library and whose header is not installed; no export came or went.
 # 3:17:0: revision-only bump. httrackp gained a tail field (links_unqueued) and

--- a/debian/changelog
+++ b/debian/changelog
@@ -7,8 +7,8 @@ httrack (3.50.0-1) unstable; urgency=medium
     changelog already provides, and leave the .txt files the manual links
     uncompressed.
   * The installed headers no longer include autoconf's config.h, which used
-    to collide with a consumer's own; the switches they read moved to a
-    generated htsfeatures.h.
+    to collide with a consumer's own.  Drop the now unused
+    package-name-defined-in-config-h override from libhttrack-dev.
 
  -- Xavier Roche <xavier@debian.org>  Tue, 01 Sep 2026 09:00:00 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,14 @@
 httrack (3.50.0-1) unstable; urgency=medium
 
   * New upstream release.  The version moves to 3.50 to match the Windows
-    and Android front ends built on this engine; the engine itself is
-    unchanged since 3.49.25, so this upload carries no functional change.
+    and Android front ends built on this engine.
+  * debian/rules: the HTML manual moved to $(docdir)/html upstream, so the
+    doc tree is relocated from there.  Drop the history.txt copy the
+    changelog already provides, and leave the .txt files the manual links
+    uncompressed.
+  * The installed headers no longer include autoconf's config.h, which used
+    to collide with a consumer's own; the switches they read moved to a
+    generated htsfeatures.h.
 
  -- Xavier Roche <xavier@debian.org>  Tue, 01 Sep 2026 09:00:00 +0200
 

--- a/history.txt
+++ b/history.txt
@@ -7,13 +7,14 @@ This file lists all changes and fixes that have been made for HTTrack
 3.50-0
 + New: this is the engine the Windows and Android front ends ship on. WinHTTrack had not been released since 3.49-2 in May 2017, so a Windows user coming from it gets everything listed under 3.49-3 to 3.49-25 below in one step. The largest of those: HTTPS against modern servers, SOCKS5 and CONNECT proxies, Brotli and Zstandard, files past 2 GB, Windows paths past 260 characters, accented and non-Latin project names and paths, WARC output, --sitemap, --single-file, --changes and --host-alias, and an --update that keeps a good local copy when the server answers with an error
 + New: --disable-example-libs skips the ten example plugins four distributions used to un-install by hand (#1470)
-+ Changed: compiled-in paths follow the configure directories instead of a hard-coded /usr (#1469)
++ Changed: the compiled-in /etc, /usr/bin and /usr/lib follow the configure directories, so a build with its own --prefix reads its own httrack.conf (#1469)
 + Changed: the installed headers no longer include autoconf's config.h, which collided with a consumer's own. The switches they read come from a generated htsfeatures.h (#1473)
-+ Changed: the HTML manual installs under $(docdir)/html, so its links to license.txt and greetings.txt resolve where it is installed (#1477)
++ Changed: --htmldir defaults to $(docdir)/html, so the manual's links to the release notes, the licence and the greetings resolve where it is installed (#1477)
 + Changed: shipped text files carry LF, so rpm packagers no longer dos2unix them (#1468)
++ Fixed: an Android or Termux build no longer needs hand-patching for backtrace() and a sys/timeb.h that bionic dropped (#1466, #1467)
 + Fixed: --with-zlib=DIR looked for the library in DIR/lib and nowhere else (#1472)
 + Fixed: three configure option checks truncated their error message at a comma (#1475)
-+ Changed: multiple internal test and build improvements (#1462, #1464, #1465, #1466, #1467, #1471, #1474, #1476)
++ Changed: multiple internal documentation, test and build improvements (#1462, #1464, #1465, #1471, #1474, #1476)
 
 3.49-25
 + Fixed: the crash report printed signal numbers with their digits reversed, so hppa's SIGBUS read as "Caught signal 01" (#1450)

--- a/history.txt
+++ b/history.txt
@@ -6,7 +6,14 @@ This file lists all changes and fixes that have been made for HTTrack
 
 3.50-0
 + New: this is the engine the Windows and Android front ends ship on. WinHTTrack had not been released since 3.49-2 in May 2017, so a Windows user coming from it gets everything listed under 3.49-3 to 3.49-25 below in one step. The largest of those: HTTPS against modern servers, SOCKS5 and CONNECT proxies, Brotli and Zstandard, files past 2 GB, Windows paths past 260 characters, accented and non-Latin project names and paths, WARC output, --sitemap, --single-file, --changes and --host-alias, and an --update that keeps a good local copy when the server answers with an error
-+ Changed: the engine is unchanged since 3.49-25. This release moves the version string, not behaviour
++ New: --disable-example-libs skips the ten example plugins four distributions used to un-install by hand (#1470)
++ Changed: compiled-in paths follow the configure directories instead of a hard-coded /usr (#1469)
++ Changed: the installed headers no longer include autoconf's config.h, which collided with a consumer's own. The switches they read come from a generated htsfeatures.h (#1473)
++ Changed: the HTML manual installs under $(docdir)/html, so its links to license.txt and greetings.txt resolve where it is installed (#1477)
++ Changed: shipped text files carry LF, so rpm packagers no longer dos2unix them (#1468)
++ Fixed: --with-zlib=DIR looked for the library in DIR/lib and nowhere else (#1472)
++ Fixed: three configure option checks truncated their error message at a comma (#1475)
++ Changed: multiple internal test and build improvements (#1462, #1464, #1465, #1466, #1467, #1471, #1474, #1476)
 
 3.49-25
 + Fixed: the crash report printed signal numbers with their digits reversed, so hppa's SIGBUS read as "Caught signal 01" (#1450)


### PR DESCRIPTION
`history.txt`'s `3.50-0` block said "the engine is unchanged since 3.49-25. This release moves the version string, not behaviour", and `debian/changelog`'s `3.50.0-1` said the upload carries no functional change. Both lines were written at the release commit `32265631`, and the vendor-recipe sweep landed after it.

Five of those changes are visible to a user or a packager:

- `--disable-example-libs` (#1470)
- compiled-in paths follow the configure directories rather than a hard-coded `/usr` (#1469)
- the installed headers drop autoconf's `config.h` for a generated `htsfeatures.h` (#1473)
- the shipped text files carry LF (#1468)
- the manual moves under `$(docdir)/html` (#1477)

Two configure fixes go with them, #1472 and #1475, and the rest fold into one internal line.

The `debian/changelog` stanza keeps its packaging audience. It names the `debian/rules` changes #1477 needed, the installed-header change a rebuilding consumer will notice, and the upstream release itself.

This has to land before the tag, because the tag freezes both files into the `make dist` tarball the Debian upload is built from. Correcting them afterwards would need a Debian revision the archive has no reason to carry.

`configure.ac`'s `VERSION_INFO` rationale carried the same retracted claim, so it is corrected here too. It now states what actually keeps the soname at `3:19:0`, which is that `htsfeatures.h` carries the same macro values `config.h` did.

The block's opening paragraph is untouched.