### PR TITLE
Six sources reach a standard macro through a header they never include

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1052,6 +1052,11 @@ jobs:
       - name: fuzz corpus list
         run: bash fuzz/check-corpus-list.sh
 
+      # A macro reached through another header builds everywhere that header is
+      # configured in, and nowhere else (#1481).
+      - name: standard includes
+        run: python3 tools/check-includes.py
+
       # MSBuild rejects a malformed .vcxproj with a bare MSB4025 and no build, so
       # catch it here in seconds rather than on a Windows runner minutes in.
       - name: XML well-formedness (MSBuild project files)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1052,8 +1052,8 @@ jobs:
       - name: fuzz corpus list
         run: bash fuzz/check-corpus-list.sh
 
-      # A macro reached through another header builds everywhere that header is
-      # configured in, and nowhere else (#1481).
+      # A macro borrowed from another header builds only where that header is
+      # present (#1481).
       - name: standard includes
         run: python3 tools/check-includes.py
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,6 +13,7 @@ EXTRA_DIST = INSTALL.Linux \
 		winprofile-keys.tsv winprofile-escapes.tsv \
 		tools/gen-winprofile-keys.py \
 		tools/doc-chrome.py \
+		tools/check-includes.py \
 		tools/ci-sanitizer-report.sh \
 		tools/downstream-drift.sh
 

--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -41,6 +41,7 @@ Please visit our Website: http://www.httrack.com
 
 #include <errno.h>
 #include <limits.h>
+#include <stdint.h>
 
 /*
   Aliases for command-line and config file definitions

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -41,6 +41,7 @@ Please visit our Website: http://www.httrack.com
 #include "htswarc.h"
 #include "htschanges.h"
 #include "htsthread.h"
+#include <stdint.h>
 #include <time.h>
 /* END specific definitions */
 

--- a/src/htscodec.c
+++ b/src/htscodec.c
@@ -39,6 +39,8 @@ Please visit our Website: http://www.httrack.com
 #include "htsio.h"
 #include "htszlib.h"
 
+#include <limits.h>
+
 #if HTS_USEBROTLI
 #include <brotli/decode.h>
 #endif

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -72,6 +72,7 @@ Please visit our Website: http://www.httrack.com
 #include <stdarg.h>
 
 #include <ctype.h>
+#include <stdint.h>
 #include <string.h>
 #include <time.h>
 #include <stdarg.h>

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -80,6 +80,7 @@ Please visit our Website: http://www.httrack.com
 
 #include <ctype.h>
 #include <errno.h>
+#include <limits.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -29,6 +29,7 @@ Please visit our Website: http://www.httrack.com
 /* ------------------------------------------------------------ */
 
 #include <limits.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tools/check-includes.py
+++ b/tools/check-includes.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Fail when a source uses a standard macro without including the header defining it.
+
+htscodec.c reached INT_MAX through <openssl/evp.h>, so every build CI runs had the
+header and macOS with --disable-https did not (#1481).
+"""
+
+import re
+import subprocess
+import sys
+
+# One entry per header, listing only macros that header alone defines.
+HEADERS = {
+    "limits.h": """CHAR_BIT SCHAR_MIN SCHAR_MAX UCHAR_MAX CHAR_MIN CHAR_MAX MB_LEN_MAX
+        SHRT_MIN SHRT_MAX USHRT_MAX INT_MIN INT_MAX UINT_MAX LONG_MIN LONG_MAX
+        ULONG_MAX LLONG_MIN LLONG_MAX ULLONG_MAX PATH_MAX NAME_MAX SSIZE_MAX""",
+    "stdint.h": """SIZE_MAX INTPTR_MAX INTPTR_MIN UINTPTR_MAX INT8_MAX INT8_MIN
+        INT16_MAX INT16_MIN INT32_MAX INT32_MIN INT64_MAX INT64_MIN UINT8_MAX
+        UINT16_MAX UINT32_MAX UINT64_MAX""",
+}
+
+# A macro named in a comment or a string is not a use.
+NOISE = re.compile(r'/\*.*?\*/|//[^\n]*|"(?:\\.|[^"\\])*"', re.S)
+
+# The floor is well under the tree's own count, so it catches an empty listing
+# rather than tracking every file added.
+MIN_SOURCES = 50
+
+
+def main():
+    try:
+        out = subprocess.run(
+            ["git", "ls-files", "*.c", "*.h"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        print(
+            "this needs a git checkout: it reads the tracked file list", file=sys.stderr
+        )
+        return 1
+    sources = [f for f in out.stdout.split() if f]
+    if len(sources) < MIN_SOURCES:
+        print(
+            f"listed {len(sources)} sources, want at least {MIN_SOURCES}",
+            file=sys.stderr,
+        )
+        return 1
+
+    bad = []
+    for path in sources:
+        with open(path, encoding="latin-1") as fp:
+            text = fp.read()
+        code = NOISE.sub("", text)
+        for header, macros in HEADERS.items():
+            if re.search(r"^\s*#\s*include\s*<%s>" % re.escape(header), text, re.M):
+                continue
+            used = sorted({m for m in macros.split() if re.search(r"\b%s\b" % m, code)})
+            if used:
+                bad.append(f"{path}: {', '.join(used)} without <{header}>")
+
+    for line in bad:
+        print(line, file=sys.stderr)
+    if bad:
+        print(f"{len(bad)} file(s) rely on a transitive include", file=sys.stderr)
+        return 1
+    print(f"{len(sources)} sources include the headers whose macros they use")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check-includes.py
+++ b/tools/check-includes.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 """Fail when a source uses a standard macro without including the header defining it.
 
-htscodec.c reached INT_MAX through <openssl/evp.h>, so every build CI runs had the
-header and macOS with --disable-https did not (#1481).
+htscodec.c reached INT_MAX through <openssl/evp.h>, which macOS with --disable-https
+never includes (#1481).
 """
 
+import os
 import re
 import subprocess
 import sys
 
-# One entry per header, listing only macros that header alone defines.
-HEADERS = {
+# Each header lists only the macros it alone defines.
+MACROS_BY_HEADER = {
     "limits.h": """CHAR_BIT SCHAR_MIN SCHAR_MAX UCHAR_MAX CHAR_MIN CHAR_MAX MB_LEN_MAX
         SHRT_MIN SHRT_MAX USHRT_MAX INT_MIN INT_MAX UINT_MAX LONG_MIN LONG_MAX
         ULONG_MAX LLONG_MIN LLONG_MAX ULLONG_MAX PATH_MAX NAME_MAX SSIZE_MAX""",
@@ -19,51 +20,126 @@ HEADERS = {
         UINT16_MAX UINT32_MAX UINT64_MAX""",
 }
 
-# A macro named in a comment or a string is not a use.
-NOISE = re.compile(r'/\*.*?\*/|//[^\n]*|"(?:\\.|[^"\\])*"', re.S)
+# One pass over all four, because each can hold the others. The // inside "http://"
+# opens no comment, and the lone quote in '"' opens no string. Getting that wrong
+# blanked 6% of this tree and hid every macro in it.
+COMMENT_OR_LITERAL = re.compile(
+    r"/\*.*?\*/" r"|//(?:\\\n|[^\n])*" r"|'(?:\\.|[^'\\])*'" r'|"(?:\\.|[^"\\])*"',
+    re.S,
+)
+LITERAL = re.compile(r"'(?:\\.|[^'\\])*'" r'|"(?:\\.|[^"\\])*"', re.S)
 
-# The floor is well under the tree's own count, so it catches an empty listing
-# rather than tracking every file added.
+# The name a #define, #undef or #ifdef introduces is not a use, which is what the usual
+# "#ifndef SIZE_MAX / #define SIZE_MAX ..." portability shim looks like.
+DECLARED = re.compile(r"^[ \t]*#[ \t]*(?:define|undef|ifdef|ifndef)[ \t]+\w+", re.M)
+
+CONDITIONAL = re.compile(r"^\s*#\s*(if|ifdef|ifndef|endif)\b")
+IFNDEF = re.compile(r"\s*#\s*ifndef\s+(\w+)")
+INCLUDE = re.compile(r'^\s*#\s*include\s*[<"]([^>"]+)[>"]')
+
+SOURCES = ["*.c", "*.h", "*.cpp", "*.cxx", "*.m", "*.c.in", "*.h.in"]
+
+# Well under the tree's own count, so it catches an empty listing without tracking every
+# file added.
 MIN_SOURCES = 50
+
+
+def keep_literal(match):
+    """Drop a comment, keep a string or char literal."""
+    return match.group(0) if match.group(0)[0] in "\"'" else ""
+
+
+def guards_itself(lines):
+    """Does the file open with the usual #ifndef NAME / #define NAME pair?
+
+    That pair wraps every header in the tree, so counting it as a condition would
+    reject the includes of all of them.
+    """
+    for index, line in enumerate(lines):
+        if not CONDITIONAL.match(line):
+            continue
+        name = IFNDEF.match(line)
+        if not name:
+            return False
+        for follow in lines[index + 1 :]:
+            if not follow.strip():
+                continue
+            return re.match(r"\s*#\s*define\s+%s\b" % name.group(1), follow) is not None
+        return False
+    return False
+
+
+def unconditional_includes(code):
+    """Which headers does this file include outside every #if block?
+
+    A macro used unconditionally is not covered by a header included only under
+    #ifdef _WIN32, which is the other half of #1481.
+    """
+    lines = code.splitlines()
+    top = 1 if guards_itself(lines) else 0
+    depth = 0
+    found = set()
+    for line in lines:
+        conditional = CONDITIONAL.match(line)
+        if conditional:
+            depth += -1 if conditional.group(1) == "endif" else 1
+        elif depth == top:
+            include = INCLUDE.match(line)
+            if include:
+                found.add(include.group(1))
+    return found
 
 
 def main():
     try:
-        out = subprocess.run(
-            ["git", "ls-files", "*.c", "*.h"],
+        root = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
             capture_output=True,
             text=True,
             check=True,
-        )
+        ).stdout.strip()
+        # git ls-files answers relative to the cwd, so from anywhere but the top it
+        # would skip whole directories and still report success.
+        os.chdir(root)
+        listed = subprocess.run(
+            ["git", "ls-files"] + SOURCES, capture_output=True, text=True, check=True
+        ).stdout
     except (OSError, subprocess.CalledProcessError):
         print(
-            "this needs a git checkout: it reads the tracked file list", file=sys.stderr
-        )
-        return 1
-    sources = [f for f in out.stdout.split() if f]
-    if len(sources) < MIN_SOURCES:
-        print(
-            f"listed {len(sources)} sources, want at least {MIN_SOURCES}",
+            "no git checkout here, so the tracked file list is unreadable",
             file=sys.stderr,
         )
         return 1
 
-    bad = []
-    for path in sources:
-        with open(path, encoding="latin-1") as fp:
-            text = fp.read()
-        code = NOISE.sub("", text)
-        for header, macros in HEADERS.items():
-            if re.search(r"^\s*#\s*include\s*<%s>" % re.escape(header), text, re.M):
-                continue
-            used = sorted({m for m in macros.split() if re.search(r"\b%s\b" % m, code)})
-            if used:
-                bad.append(f"{path}: {', '.join(used)} without <{header}>")
+    sources = listed.split()
+    if len(sources) < MIN_SOURCES:
+        print(
+            f"listed {len(sources)} sources, want {MIN_SOURCES} or more",
+            file=sys.stderr,
+        )
+        return 1
 
-    for line in bad:
+    findings = []
+    for path in sources:
+        with open(path, encoding="latin-1") as handle:
+            text = handle.read()
+        # Literals survive this pass, or #include "limits.h" would read as absent.
+        uncommented = COMMENT_OR_LITERAL.sub(keep_literal, text)
+        included = unconditional_includes(uncommented)
+        code = DECLARED.sub("", LITERAL.sub("", uncommented))
+        for header, macros in MACROS_BY_HEADER.items():
+            if header in included:
+                continue
+            missing = sorted(
+                m for m in macros.split() if re.search(r"\b%s\b" % m, code)
+            )
+            if missing:
+                findings.append(f"{path}: {', '.join(missing)} without <{header}>")
+
+    for line in findings:
         print(line, file=sys.stderr)
-    if bad:
-        print(f"{len(bad)} file(s) rely on a transitive include", file=sys.stderr)
+    if findings:
+        print(f"{len(findings)} file(s) rely on a transitive include", file=sys.stderr)
         return 1
     print(f"{len(sources)} sources include the headers whose macros they use")
     return 0


### PR DESCRIPTION
`htscodec.c` and `htsselftest.c` use `INT_MAX`, and four more sources use `INT32_MAX` or `INT64_MAX`, without including `<limits.h>` or `<stdint.h>`. They compile because something else in the include chain already pulled the header in. On macOS with `--disable-https` that something is `<openssl/evp.h>`, which is absent, so the build stops on an undeclared identifier.

CI cannot see it, because the `--disable-https` leg runs on Linux, where glibc supplies the header anyway, and every macOS leg builds with OpenSSL.

`tools/check-includes.py` now fails any tracked source using a macro from either header without including it, and the lint job runs it. It found the sixth file, `src/proxy/store.c`, which a hand scan of `src/*.c` had missed.

It refuses the near misses too, each one planted and run:

- A use hidden behind a `'"'` char literal, which used to open a string and blank the next 10113 bytes of `htscharset.c`.
- An include that is commented out, or sits under `#ifdef _WIN32`, or inside `#if 0`. The first is what #1481 looks like on the other axis.
- A quoted `#include "limits.h"` still counts, and a `SIZE_MAX` portability shim is not a use.
- Run from a subdirectory it still reads the whole tree, and an empty file list fails rather than passing.

Built on macOS 26.5 arm64 in the configuration that broke. It compiles clean, where master stops in `htsselftest.c`. Linux suite 412 tests, 0 failures.

#1481 named `htscoremain.c` and `htsurlport.h`, which only mention the macros in comments. The real six are the ones here.

Closes #1481