### PR TITLE
3.50.0-1 is stamped ahead of its own build, so nothing can reproduce it

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+httrack (3.50.0-2) unstable; urgency=medium
+
+  * Rebuild with a changelog timestamp that precedes the build.  The 3.50.0-1
+    entry was stamped two hours ahead of its buildd run, so SOURCE_DATE_EPOCH
+    clamped nothing there and clamped everything on a rebuild.  That made the
+    binaries unreproducible on all four tested architectures.  The source is
+    unchanged.
+
+ -- Xavier Roche <xavier@debian.org>  Tue, 01 Sep 2026 14:06:23 +0200
+
 httrack (3.50.0-1) unstable; urgency=medium
 
   * New upstream release.  The version moves to 3.50 to match the Windows


### PR DESCRIPTION
The 3.50.0-1 stanza is stamped 09:00 +0200 and the buildd ran at 06:46. SOURCE_DATE_EPOCH only clamps file dates downward, so it left the archive build's dates alone while it clamps every rebuild to 09:00. All four rebuilder architectures report the binaries as unreproducible. Debian blocks an unreproducible package from migrating, so 3.49.24, 3.49.25 and 3.50.0 are all held out of forky behind this one entry.

No build made from now on can match the archive copy, because matching it means building before the stamp, and that moment has passed. The fix is a revision whose timestamp is already in the past. The source is untouched and only the changelog gains a stanza.

Built twice from the archive's own orig, the twelve .debs come out byte-identical. The .dsc pins the same orig checksums the archive holds, so the upload carries the changelog and nothing else.
