### PR TITLE
Dependabot auto-merge arms on the wrong identity

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -19,8 +19,8 @@ permissions:
 jobs:
   automerge:
     name: Arm auto-merge
-    # The PR's author, never github.actor: on a synchronize the actor is whoever pushed, so a
-    # fork-side Dependabot push on someone else's PR passes an actor check.
+    # Checks the PR's author, not github.actor, because on a synchronize the actor is whoever
+    # pushed, including a fork's own Dependabot.
     if: >-
       github.repository == 'xroche/httrack'
       && github.event.pull_request.user.login == 'dependabot[bot]'

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -20,7 +20,8 @@ jobs:
   automerge:
     name: Arm auto-merge
     # Checks the PR's author, not github.actor, because on a synchronize the actor is whoever
-    # pushed, including a fork's own Dependabot.
+    # pushed, including a fork's own Dependabot. The head-repo clause has no witness while
+    # only Dependabot's own PRs pass the author check, and is kept for if that ever loosens.
     if: >-
       github.repository == 'xroche/httrack'
       && github.event.pull_request.user.login == 'dependabot[bot]'

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -6,7 +6,8 @@ name: Dependabot auto-merge
 on: pull_request_target
 
 concurrency:
-  group: dependabot-automerge-${{ github.ref }}
+  # Keyed per PR: github.ref is the base branch on pull_request_target, so one group would hold them all.
+  group: dependabot-automerge-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
@@ -18,7 +19,12 @@ permissions:
 jobs:
   automerge:
     name: Arm auto-merge
-    if: github.repository == 'xroche/httrack' && github.actor == 'dependabot[bot]'
+    # The PR's author, never github.actor: on a synchronize the actor is whoever pushed, so a
+    # fork-side Dependabot push on someone else's PR passes an actor check.
+    if: >-
+      github.repository == 'xroche/httrack'
+      && github.event.pull_request.user.login == 'dependabot[bot]'
+      && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     steps:
       # Dependabot's body is a release-notes dump, so give the squash commit a body of its own.


### PR DESCRIPTION
`github.actor` is the event's sender, not the PR's author. On a `synchronize` the sender is whoever pushed. So a fork owner who enables Dependabot on their own fork can open a PR here and let that fork's Dependabot push to it. Dependabot regenerates only the dependency diff, so the rest of the tree stays theirs. BoostSecurity and Synacktiv have both published the technique. The sender half is observed rather than inferred. httrack-windows PR #84 has one commit pushed by dependabot and one by the maintainer, and its two runs carry `actor=dependabot[bot]` and `actor=xroche`. The fork hop is the part we take on the researchers' word.

GitHub's own auto-merge recipe uses `user.login` in every example and never `github.actor`, so the old guard was wrong by the vendor's own recommendation. The head-repo clause has no witness today, because Dependabot only opens PRs in the repo it runs on, so the author clause already implies it. It is kept for if the author check is ever loosened, and the file says so. Nothing was ever exercised here, since no PR in the last hundred had a fork head.

The concurrency group carried a second bug. `github.ref` is the base branch on `pull_request_target`, so every PR shared the group `dependabot-automerge-refs/heads/master`. The group is evaluated before the job's `if:`, so a human PR event entered it too and could cancel an in-flight arming run. Nothing re-triggers it, so that dependabot PR waits for a human with no sign anything went wrong. Keying per PR also makes `cancel-in-progress` mean what it should, which is superseding an earlier arming run for the same PR.

Found by the httrack-windows session reviewing the same workflow for its own repo, and confirmed independently by the httrack-android session. coucal #42 carries the same fix.