### PR TITLE
The symbolizer's `<spawn.h>` is not on every platform that links backtrace()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
           # a missing decoder would silently drop the coding from Accept-Encoding
           grep -q "define HTS_USEBROTLI 1" config.h
           grep -q "define HTS_USEZSTD 1" config.h
+          # losing this would make every crash test skip, and the suite stay green
+          grep -q "define HAVE_SPAWN_H 1" config.h
 
       - name: Build
         run: make -j"$(nproc)"
@@ -831,7 +833,7 @@ jobs:
 
   # Termux's cell: bionic before API 28 links backtrace() (libandroid-execinfo)
   # but ships no <spawn.h>, so the symbolizer the backtrace block pulls in is a
-  # hard build break there. Also runs the suite with frame naming compiled out.
+  # hard build break there. The suite also runs with frame naming compiled out.
   no-spawn:
     name: build (spawn.h hidden)
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -829,6 +829,47 @@ jobs:
         if: failure()
         run: cat tests/test-suite.log 2>/dev/null || true
 
+  # Termux's cell: bionic before API 28 links backtrace() (libandroid-execinfo)
+  # but ships no <spawn.h>, so the symbolizer the backtrace block pulls in is a
+  # hard build break there. Also runs the suite with frame naming compiled out.
+  no-spawn:
+    name: build (spawn.h hidden)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
+          sudo apt-get install -y --no-install-recommends \
+            build-essential autoconf automake libtool autoconf-archive \
+            zlib1g-dev libssl-dev libbrotli-dev libzstd-dev
+
+      - name: Configure (spawn.h hidden from configure)
+        run: |
+          set -euo pipefail
+          autoreconf -fi
+          ./configure ac_cv_header_spawn_h=no
+          # A build with no backtrace() at all would pass this job vacuously.
+          grep -q "define HAVE_BACKTRACE 1" config.h
+          ! grep -q "define HAVE_SPAWN_H" config.h
+
+      - name: Build
+        run: make -j"$(nproc)"
+
+      - name: Test
+        timeout-minutes: 20
+        run: |
+          jobs=$(( $(nproc) * 2 )); [ "$jobs" -le 16 ] || jobs=16
+          make check -j"$jobs"
+
+      - name: Print the test log on failure
+        if: failure()
+        run: cat tests/test-suite.log 2>/dev/null || true
+
   # OpenSSL 4.0 removes the API 3.x deprecated. Building with that set hidden
   # keeps the engine ready for it: a deprecated call fails here rather than the
   # day a distro moves. Compile-only, since the headers are what is under test.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,8 @@ jobs:
           # a missing decoder would silently drop the coding from Accept-Encoding
           grep -q "define HTS_USEBROTLI 1" config.h
           grep -q "define HTS_USEZSTD 1" config.h
-          # losing this would make every crash test skip, and the suite stay green
+          # losing either would make every crash test skip, and the suite stay green
+          grep -q "define HAVE_BACKTRACE 1" config.h
           grep -q "define HAVE_SPAWN_H 1" config.h
 
       - name: Build

--- a/configure.ac
+++ b/configure.ac
@@ -418,7 +418,7 @@ AC_CHECK_TYPE(sa_family_t, [], [AC_DEFINE([sa_family_t], [uint16_t], [sa_family_
 AX_CHECK_ALIGNED_ACCESS_REQUIRED
 
 # check for various headers
-AC_CHECK_HEADERS([execinfo.h sys/ioctl.h sys/random.h])
+AC_CHECK_HEADERS([execinfo.h spawn.h sys/ioctl.h sys/random.h])
 
 ## The header can exist while backtrace() lives in another library (Termux's
 ## libandroid-execinfo); only httrack links it, so keep it out of LIBS.

--- a/src/htsbacktrace.c
+++ b/src/htsbacktrace.c
@@ -59,18 +59,19 @@ Please visit our Website: http://www.httrack.com
 #endif
 /* HAVE_BACKTRACE means the symbol links, not just that the header exists. */
 #if (defined(__linux) && defined(HAVE_BACKTRACE))
+#include <execinfo.h>
+#include <signal.h>
+#define USES_BACKTRACE
+/* Frame naming needs posix_spawn(), absent before bionic API 28. Everything
+   below serves it, so a build without the header asks for none of it. */
+#ifdef HAVE_SPAWN_H
 #include <dlfcn.h>
 #include <errno.h>
-#include <execinfo.h>
 #include <link.h>
-#include <signal.h>
+#include <spawn.h>
 #include <time.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
-#define USES_BACKTRACE
-/* Frame naming needs posix_spawn(), absent before bionic API 28. */
-#ifdef HAVE_SPAWN_H
-#include <spawn.h>
 #define USES_SYMBOLIZER
 #endif
 #endif

--- a/src/htsbacktrace.c
+++ b/src/htsbacktrace.c
@@ -64,11 +64,15 @@ Please visit our Website: http://www.httrack.com
 #include <execinfo.h>
 #include <link.h>
 #include <signal.h>
-#include <spawn.h>
 #include <time.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 #define USES_BACKTRACE
+/* Frame naming needs posix_spawn(), absent before bionic API 28. */
+#ifdef HAVE_SPAWN_H
+#include <spawn.h>
+#define USES_SYMBOLIZER
+#endif
 #endif
 
 #ifdef _WIN32
@@ -77,7 +81,7 @@ Please visit our Website: http://www.httrack.com
 #define BT_REPORT_FD STDERR_FILENO
 #endif
 
-#ifdef USES_BACKTRACE
+#ifdef USES_SYMBOLIZER
 #define BT_MAX_FRAMES 64  /* frames we try to name */
 #define BT_MAX_MODULES 8  /* distinct modules, one child each */
 #define BT_HEX_SIZE 19    /* "0x" + 16 nibbles + NUL */
@@ -305,6 +309,7 @@ void hts_backtrace_init(void) {
 #ifdef USES_BACKTRACE
   void *frame[1];
 
+#ifdef USES_SYMBOLIZER
   symbolize_crash =
       getenv("HTTRACK_NO_SYMBOLIZE") == NULL ? HTS_TRUE : HTS_FALSE;
   if (symbolize_crash && posix_spawn_file_actions_init(&spawn_actions) == 0 &&
@@ -312,6 +317,7 @@ void hts_backtrace_init(void) {
                                        STDOUT_FILENO) == 0)
     spawn_redirect = &spawn_actions; /* both symbolizers write on stdout */
   find_main_object();
+#endif
   /* Pay for the unwinder now: glibc's first backtrace() dlopen()s libgcc_s,
      which allocates and takes the loader lock the crashing thread may hold. */
   (void) backtrace(frame, 1);
@@ -403,17 +409,21 @@ void hts_print_backtrace(void) {
   void *stack[256];
   const int size = backtrace(stack, sizeof(stack) / sizeof(stack[0]));
 
+#ifdef USES_SYMBOLIZER
   /* A fault inside the handler lands back here: symbolizing twice interleaves
      two traces on the report fd and spends a second budget. */
   static volatile sig_atomic_t entered = 0;
+#endif
 
   if (size != 0) {
     backtrace_symbols_fd(stack, size, BT_REPORT_FD);
+#ifdef USES_SYMBOLIZER
     if (symbolize_crash && entered == 0) {
       entered = 1;
       symbolize_backtrace(stack, size);
       entered = 0;
     }
+#endif
   } else {
     /* An empty trace means the build carries no unwind tables. */
     const char msg[] = "No stack trace available: unwinding failed\n";

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -479,7 +479,7 @@ esac
 # A stalled crawl is necessarily inside httpmirror, so these frames must appear.
 # Matching "httrack" alone would pass on the process list above.
 # Naming them needs the symbolizer, which a build without <spawn.h> cannot run.
-if build_has_symbolizer; then
+if build_names_frames; then
     grep -qE '\b(back_wait|httpmirror|hts_main_internal)\b' "$out" ||
         fail "the stack names no engine frame"
 fi

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -478,7 +478,10 @@ Darwin)
 esac
 # A stalled crawl is necessarily inside httpmirror, so these frames must appear.
 # Matching "httrack" alone would pass on the process list above.
-grep -qE '\b(back_wait|httpmirror|hts_main_internal)\b' "$out" ||
-    fail "the stack names no engine frame"
+# Naming them needs the symbolizer, which a build without <spawn.h> cannot run.
+if build_has_symbolizer; then
+    grep -qE '\b(back_wait|httpmirror|hts_main_internal)\b' "$out" ||
+        fail "the stack names no engine frame"
+fi
 
 echo "suite timeout OK (named the test, dumped a stack, exited 124)"

--- a/tests/157_crash-argv0-path.test
+++ b/tests/157_crash-argv0-path.test
@@ -21,6 +21,7 @@ fi
 if ! command -v addr2line >/dev/null && ! command -v llvm-symbolizer >/dev/null; then
     skip "no symbolizer installed"
 fi
+build_has_symbolizer || skip "this build has no <spawn.h> symbolizer"
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/httrack_argv0.XXXXXX") || exit 1
 cleanup_push rm -rf "${work}"

--- a/tests/157_crash-argv0-path.test
+++ b/tests/157_crash-argv0-path.test
@@ -21,7 +21,7 @@ fi
 if ! command -v addr2line >/dev/null && ! command -v llvm-symbolizer >/dev/null; then
     skip "no symbolizer installed"
 fi
-build_has_symbolizer || skip "this build has no <spawn.h> symbolizer"
+build_names_frames || skip "built without <spawn.h>, so frames stay module+offset"
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/httrack_argv0.XXXXXX") || exit 1
 cleanup_push rm -rf "${work}"

--- a/tests/182_crash-fork-safety.test
+++ b/tests/182_crash-fork-safety.test
@@ -15,6 +15,7 @@ if [ "$HTS_OS" != "Linux" ]; then
     exit 77
 fi
 require_httrack
+build_has_symbolizer || skip "this build has no <spawn.h> symbolizer"
 # A wedged httrack still catches SIGTERM and only sets a flag, hence -s KILL.
 command -v timeout >/dev/null || fail "no timeout(1): a hang would never end here"
 

--- a/tests/182_crash-fork-safety.test
+++ b/tests/182_crash-fork-safety.test
@@ -15,7 +15,7 @@ if [ "$HTS_OS" != "Linux" ]; then
     exit 77
 fi
 require_httrack
-build_has_symbolizer || skip "this build has no <spawn.h> symbolizer"
+build_names_frames || skip "built without <spawn.h>, so frames stay module+offset"
 # A wedged httrack still catches SIGTERM and only sets a flag, hence -s KILL.
 command -v timeout >/dev/null || fail "no timeout(1): a hang would never end here"
 

--- a/tests/80_engine-crash-symbolize.test
+++ b/tests/80_engine-crash-symbolize.test
@@ -43,6 +43,7 @@ esac
 grep -q "$rawframe" "$out" ||
     fail_dump "raw module+offset frames are gone:" "$out"
 
+build_has_symbolizer || skip "this build has no <spawn.h> symbolizer"
 command -v addr2line >/dev/null || skip "addr2line not installed"
 
 # Control: resolve the same frames ourselves, so a stripped build cannot turn

--- a/tests/80_engine-crash-symbolize.test
+++ b/tests/80_engine-crash-symbolize.test
@@ -43,7 +43,7 @@ esac
 grep -q "$rawframe" "$out" ||
     fail_dump "raw module+offset frames are gone:" "$out"
 
-build_has_symbolizer || skip "this build has no <spawn.h> symbolizer"
+build_names_frames || skip "built without <spawn.h>, so frames stay module+offset"
 command -v addr2line >/dev/null || skip "addr2line not installed"
 
 # Control: resolve the same frames ourselves, so a stripped build cannot turn

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -555,9 +555,13 @@ declared_header_count() {
     declared_headers | awk 'END { print NR + 0 }'
 }
 
-# A build without <spawn.h> (bionic before API 28) cannot name frames.
-build_has_symbolizer() {
-    grep -q '^#define HAVE_SPAWN_H ' "${abs_top_builddir:?}/config.h"
+# The same condition htsbacktrace.c compiles USES_SYMBOLIZER on. A build without
+# <spawn.h> (bionic before API 28) prints frames as module+offset and stops.
+build_names_frames() {
+    local conf="${abs_top_builddir:?}/config.h"
+    test -r "${conf}" || fail "no config.h at ${conf}"
+    grep -q '^#define HAVE_BACKTRACE ' "${conf}" &&
+        grep -q '^#define HAVE_SPAWN_H ' "${conf}"
 }
 
 is_windows() {

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -555,6 +555,11 @@ declared_header_count() {
     declared_headers | awk 'END { print NR + 0 }'
 }
 
+# A build without <spawn.h> (bionic before API 28) cannot name frames.
+build_has_symbolizer() {
+    grep -q '^#define HAVE_SPAWN_H ' "${abs_top_builddir:?}/config.h"
+}
+
 is_windows() {
     if test -z "${IS_WINDOWS:-}"; then
         case "$HTS_OS" in


### PR DESCRIPTION
Since the backtrace probe became a link check, Termux's libandroid-execinfo satisfies it, so the whole block compiles for the first time on Android. That block includes the `<spawn.h>` frame naming needs, and bionic ships that header only from API 28. An Android build at API 24 now dies with `fatal error: 'spawn.h' file not found`.

configure checks for the header, and without it frame naming compiles out. The raw module and offset trace still prints. That is more than the platform had before, because Termux carried a patch switching the backtrace block off entirely.

Everything in that block serves frame naming, so one guard covers all of it, from the posix_spawn file actions to `symbolize_backtrace()`. Four tests assert named frames, and a new `build_names_frames` in testlib.sh makes them skip on such a build. 105 keeps testing the timeout harness and drops only that one assertion. A `no-spawn` CI leg builds and runs the suite with the header hidden. Its configure step refuses to pass vacuously on a build that has no `backtrace()`. The ordinary Linux build leg pins the other side, because nothing else would notice if either macro were renamed and every crash test skipped.

Found by building termux/termux-packages' httrack recipe against 3.50.0. It is one of the two things standing between them and dropping five of the six patches they carry, the other being #1488.