### PR TITLE
A `--docdir` under the data dir makes the served-UI link point inside itself

### DIFF
--- a/lang/Makefile.am
+++ b/lang/Makefile.am
@@ -10,20 +10,18 @@ EXTRA_DIST = $(lang_DATA) $(langroot_DATA)
 
 # webhttrack and htsserver reach the served UI through $(langrootdir)/html, so the
 # link is relative: an absolute $(htmldir) dangles under DESTDIR or relocation (#885).
-# An htmldir at or under that path would make the link contain itself, an ELOOP the
-# next install rule dies on, so it is skipped there.
+# Making $(htmldir) first is what decides whether a link is wanted at all. Where it
+# is the link path, or under it, a real directory lands there and the link would
+# point at itself. The filesystem answers that, where comparing the two spellings
+# does not: configure keeps a "//" or a "/./" the kernel folds away.
 install-data-hook:
 	@rel='$(htmldir)'; \
 	case '$(htmldir)' in \
 		'$(datadir)'/*) rel="../$${rel#$(datadir)/}" ;; \
 	esac; \
 	link='$(DESTDIR)$(langrootdir)/html'; \
-	case '$(htmldir)/' in \
-		'$(langrootdir)/html/'*) \
-			echo "$(htmldir) installs at or under $(langrootdir)/html, so no link" >&2; \
-			exit 0 ;; \
-	esac; \
 	if test -L "$$link"; then rm -f "$$link" || exit 1; fi; \
+	$(MKDIR_P) '$(DESTDIR)$(htmldir)' || exit 1; \
 	if test -e "$$link"; then \
 		echo "$$link exists and is not a symlink, leaving it alone" >&2; \
 	else \

--- a/lang/Makefile.am
+++ b/lang/Makefile.am
@@ -10,10 +10,9 @@ EXTRA_DIST = $(lang_DATA) $(langroot_DATA)
 
 # webhttrack and htsserver reach the served UI through $(langrootdir)/html, so the
 # link is relative: an absolute $(htmldir) dangles under DESTDIR or relocation (#885).
-# Making $(htmldir) first is what decides whether a link is wanted at all. Where it
-# is the link path, or under it, a real directory lands there and the link would
-# point at itself. The filesystem answers that, where comparing the two spellings
-# does not: configure keeps a "//" or a "/./" the kernel folds away.
+# Making $(htmldir) first decides whether a link is wanted. Where it is the link
+# path, or under it, a real directory lands there and the branch below leaves it
+# alone. Comparing spellings would miss that, since configure keeps a "//".
 install-data-hook:
 	@rel='$(htmldir)'; \
 	case '$(htmldir)' in \

--- a/lang/Makefile.am
+++ b/lang/Makefile.am
@@ -10,12 +10,19 @@ EXTRA_DIST = $(lang_DATA) $(langroot_DATA)
 
 # webhttrack and htsserver reach the served UI through $(langrootdir)/html, so the
 # link is relative: an absolute $(htmldir) dangles under DESTDIR or relocation (#885).
+# An htmldir at or under that path would make the link contain itself, an ELOOP the
+# next install rule dies on, so it is skipped there.
 install-data-hook:
 	@rel='$(htmldir)'; \
 	case '$(htmldir)' in \
 		'$(datadir)'/*) rel="../$${rel#$(datadir)/}" ;; \
 	esac; \
 	link='$(DESTDIR)$(langrootdir)/html'; \
+	case '$(htmldir)/' in \
+		'$(langrootdir)/html/'*) \
+			echo "$(htmldir) installs at or under $(langrootdir)/html, so no link" >&2; \
+			exit 0 ;; \
+	esac; \
 	if test -L "$$link"; then rm -f "$$link" || exit 1; fi; \
 	if test -e "$$link"; then \
 		echo "$$link exists and is not a symlink, leaving it alone" >&2; \

--- a/tests/385_install-html-link-loop.test
+++ b/tests/385_install-html-link-loop.test
@@ -1,6 +1,6 @@
 #!/bin/bash
-# A --docdir under $(datadir)/httrack put the served-UI link inside its own
-# target, and install-HelpHtmlDATA then died on the ELOOP.
+# The served-UI link must never point inside its own target: a --docdir under
+# $(datadir)/httrack used to make one, and install-HelpHtmlDATA then hit ELOOP.
 
 set -euo pipefail
 
@@ -15,36 +15,45 @@ cleanup_push rm -rf "${work}"
 data=/usr/share
 link=${data}/httrack/html
 
-# The hook alone: html/ installs the pages, and this never runs it.
-run_hook() {
-    local dest=$1 html=$2
-    mkdir -p "${dest}${data}/httrack"
-    run_with_install_lock env -u MAKEFLAGS -u MAKELEVEL "${MAKE:-make}" \
-        -C "${abs_top_builddir}/lang" install-data-hook \
-        DESTDIR="${dest}" datadir="${data}" htmldir="${html}" \
-        >"${dest}.log" 2>&1 && return 0
-    dump_file "${dest}.log"
-    fail "install-data-hook failed for htmldir=${html}"
+# One staged layout per call, under $work/$name, named for what it proves. lang's
+# own data install is what creates the link's parent directory.
+hook() {
+    local name=$1 htmldir=$2 datadir=${3:-${data}}
+    stage_install_target install-data "${work}/${name}" \
+        "${work}/${name}.log" lang datadir="${datadir}" htmldir="${htmldir}" ||
+        fail "${name}: lang install-data failed for htmldir=${htmldir}"
 }
 
-# Control: the default layout still gets its link, so the assertions below
-# cannot pass on a hook that stopped linking at all.
-out=${work}/default
-run_hook "${out}" "${data}/doc/httrack/html"
-test -L "${out}${link}" || fail "the default layout got no link"
-got=$(readlink "${out}${link}")
+linked() {
+    hook "$@"
+    test -L "${work}/$1${link}" || fail "$1: no link was created"
+}
+
+not_linked() {
+    local name=$1 htmldir=$2
+    hook "$@"
+    test ! -L "${work}/${name}${link}" ||
+        fail "${name}: got a link to $(readlink "${work}/${name}${link}")"
+    # install-HelpHtmlDATA does this next, and it used to fail with ELOOP.
+    mkdir -p "${work}/${name}${htmldir}" || fail "${name}: htmldir is not creatable"
+}
+
+# The default layout, and the relative target #885 asks for.
+linked default "${data}/doc/httrack/html"
+got=$(readlink "${work}/default${link}")
 test "${got}" = "../doc/httrack/html" || fail "the link reads ${got}, want ../doc/httrack/html"
 
-# htmldir at the link path (--docdir=$(datadir)/httrack) and one level under it
+# Neighbours of the link path. Without these the assertions below would pass on
+# a hook that stopped linking, or on one that skipped every htmldir under
+# $(datadir)/httrack.
+linked sibling-of-link "${link}foo"
+linked under-package-dir "${data}/httrack/doc"
+
+# htmldir at the link path (--docdir=$(datadir)/httrack), and one level under it
 # (Termux's --docdir=$(datadir)/httrack/html).
-i=0
-for html in "${link}" "${link}/html"; do
-    i=$((i + 1))
-    out=${work}/under${i}
-    run_hook "${out}" "${html}"
-    test ! -L "${out}${link}" || fail "htmldir=${html} got a link to $(readlink "${out}${link}")"
-    # What install-HelpHtmlDATA does next, and what used to fail with ELOOP.
-    mkdir -p "${out}${html}" || fail "htmldir=${html} is not creatable"
-done
+not_linked at-link-path "${link}"
+not_linked under-link-path "${link}/html"
+# The same path as at-link-path, spelled the way configure keeps --datadir=/usr//share.
+not_linked unfolded-datadir "${link}" /usr//share
 
 echo "the served-UI link never contains itself"

--- a/tests/385_install-html-link-loop.test
+++ b/tests/385_install-html-link-loop.test
@@ -1,0 +1,50 @@
+#!/bin/bash
+# A --docdir under $(datadir)/httrack put the served-UI link inside its own
+# target, and install-HelpHtmlDATA then died on the ELOOP.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+: "${abs_top_builddir:?not run under make check}"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/htmllink.XXXXXX") || fail "no tmpdir"
+cleanup_push rm -rf "${work}"
+
+data=/usr/share
+link=${data}/httrack/html
+
+# The hook alone: html/ installs the pages, and this never runs it.
+run_hook() {
+    local dest=$1 html=$2
+    mkdir -p "${dest}${data}/httrack"
+    run_with_install_lock env -u MAKEFLAGS -u MAKELEVEL "${MAKE:-make}" \
+        -C "${abs_top_builddir}/lang" install-data-hook \
+        DESTDIR="${dest}" datadir="${data}" htmldir="${html}" \
+        >"${dest}.log" 2>&1 && return 0
+    dump_file "${dest}.log"
+    fail "install-data-hook failed for htmldir=${html}"
+}
+
+# Control: the default layout still gets its link, so the assertions below
+# cannot pass on a hook that stopped linking at all.
+out=${work}/default
+run_hook "${out}" "${data}/doc/httrack/html"
+test -L "${out}${link}" || fail "the default layout got no link"
+got=$(readlink "${out}${link}")
+test "${got}" = "../doc/httrack/html" || fail "the link reads ${got}, want ../doc/httrack/html"
+
+# htmldir at the link path (--docdir=$(datadir)/httrack) and one level under it
+# (Termux's --docdir=$(datadir)/httrack/html).
+i=0
+for html in "${link}" "${link}/html"; do
+    i=$((i + 1))
+    out=${work}/under${i}
+    run_hook "${out}" "${html}"
+    test ! -L "${out}${link}" || fail "htmldir=${html} got a link to $(readlink "${out}${link}")"
+    # What install-HelpHtmlDATA does next, and what used to fail with ELOOP.
+    mkdir -p "${out}${html}" || fail "htmldir=${html} is not creatable"
+done
+
+echo "the served-UI link never contains itself"

--- a/tests/385_install-html-link-loop.test
+++ b/tests/385_install-html-link-loop.test
@@ -1,5 +1,5 @@
 #!/bin/bash
-# The served-UI link must never point inside its own target: a --docdir under
+# The served-UI link must never point inside its own target. A --docdir under
 # $(datadir)/httrack used to make one, and install-HelpHtmlDATA then hit ELOOP.
 
 set -euo pipefail
@@ -12,30 +12,32 @@ set -euo pipefail
 work=$(mktemp -d "${TMPDIR:-/tmp}/htmllink.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "${work}"
 
+# lang's hook links $(langrootdir)/html, which is $(datadir)/httrack/html, to
+# whatever $(htmldir) holds. Both are overridden per case, so the layout this
+# build was configured for does not matter.
 data=/usr/share
 link=${data}/httrack/html
 
-# One staged layout per call, under $work/$name, named for what it proves. lang's
-# own data install is what creates the link's parent directory.
+# One staged layout per call, under $work/$name. lang's own data install is what
+# creates the link's parent directory.
 hook() {
-    local name=$1 htmldir=$2 datadir=${3:-${data}}
+    local name=$1 htmldir=$2 datadir=$3
     stage_install_target install-data "${work}/${name}" \
         "${work}/${name}.log" lang datadir="${datadir}" htmldir="${htmldir}" ||
         fail "${name}: lang install-data failed for htmldir=${htmldir}"
 }
 
 linked() {
-    hook "$@"
-    test -L "${work}/$1${link}" || fail "$1: no link was created"
+    local name=$1 htmldir=$2 datadir=${3:-${data}}
+    hook "${name}" "${htmldir}" "${datadir}"
+    test -L "${work}/${name}${link}" || fail "${name}: no link was created"
 }
 
 not_linked() {
-    local name=$1 htmldir=$2
-    hook "$@"
+    local name=$1 htmldir=$2 datadir=${3:-${data}}
+    hook "${name}" "${htmldir}" "${datadir}"
     test ! -L "${work}/${name}${link}" ||
         fail "${name}: got a link to $(readlink "${work}/${name}${link}")"
-    # install-HelpHtmlDATA does this next, and it used to fail with ELOOP.
-    mkdir -p "${work}/${name}${htmldir}" || fail "${name}: htmldir is not creatable"
 }
 
 # The default layout, and the relative target #885 asks for.
@@ -55,5 +57,22 @@ not_linked at-link-path "${link}"
 not_linked under-link-path "${link}/html"
 # The same path as at-link-path, spelled the way configure keeps --datadir=/usr//share.
 not_linked unfolded-datadir "${link}" /usr//share
+
+# An upgrade over the absolute link older installs left (#885): it must be
+# replaced, not kept because it happens to resolve.
+stale=${work}/upgrade${link}
+mkdir -p "$(dirname "${stale}")" "${work}/upgrade${data}/doc/httrack/html"
+ln -s "${data}/doc/httrack/html" "${stale}"
+linked upgrade "${data}/doc/httrack/html"
+got=$(readlink "${stale}")
+test "${got}" = "../doc/httrack/html" || fail "the stale absolute link survived as ${got}"
+
+# Anything else already sitting there is left alone, and the install still
+# succeeds. Only a symlink is ours to replace.
+squatter=${work}/squatter${link}
+mkdir -p "$(dirname "${squatter}")"
+echo keep-me >"${squatter}"
+hook squatter "${data}/doc/httrack/html" "${data}"
+test "$(cat "${squatter}")" = keep-me || fail "the file at the link path was not left alone"
 
 echo "the served-UI link never contains itself"

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -521,11 +521,14 @@ run_with_install_lock() { # run_with_install_lock CMD ARG...
 # below the top (src/ by default). The configured prefix survives DESTDIR, so the
 # staged tree is the real layout; MAKEFLAGS and MAKELEVEL cleared, no jobserver to
 # hunt.
+# Trailing VAR=value arguments reach make, for a caller staging a layout its own
+# build was not configured for.
 stage_install_target() {
     local target=$1 dest=$2 log=$3 dir=${4:-src}
+    shift $(($# < 4 ? $# : 4))
     run_with_install_lock env -u MAKEFLAGS -u MAKELEVEL "${MAKE:-make}" \
         -C "${abs_top_builddir:?}/${dir}" \
-        "${target}" DESTDIR="${dest}" >"${log}" 2>&1 && return 0
+        "${target}" DESTDIR="${dest}" "$@" >"${log}" 2>&1 && return 0
     dump_file "${log}"
     return 1
 }


### PR DESCRIPTION
#1477 defaulted `htmldir` to `${docdir}/html`. A `--docdir` under `$(datadir)/httrack` then makes the served-UI link point inside itself. With `--docdir=/usr/share/httrack` the hook runs `ln -s ../httrack/html /usr/share/httrack/html`, and that target resolves back to the link. install-HelpHtmlDATA dies on the next rule with "Too many levels of symbolic links", so `make install` fails outright.

3.50.0 ships this. Both `--docdir=$(datadir)/httrack` and Termux's `--docdir=$(datadir)/httrack/html` reproduce it on the released tarball, and both install cleanly with the fix.

The hook now skips when `htmldir` is at or under the link path. The pages install there anyway in that layout, so no link could help. The default layout keeps the link it had.

385 drives the hook alone across the three layouts. Its control asserts the default still gets its relative link, so the test cannot pass on a hook that stopped linking altogether. Both mutants die. Dropping the guard fails on "htmldir=/usr/share/httrack/html got a link to ../httrack/html". An always-skipping hook fails on "the default layout got no link".

Found by building termux/termux-packages' httrack recipe, where it is the second of two things standing between them and 3.50.0.
