### PR TITLE
A `--datadir` spelled with "//" leaves the served-UI link absolute

### DIFF
--- a/lang/Makefile.am
+++ b/lang/Makefile.am
@@ -14,18 +14,19 @@ EXTRA_DIST = $(lang_DATA) $(langroot_DATA)
 # path, or under it, a real directory lands there and the branch below leaves it
 # alone.
 #
-# Both paths are folded before they are compared, because configure keeps the "//"
-# and "/." a user typed and the kernel does not. An unfolded pair fails the prefix
-# test and leaves the link absolute, which is the dangling #885 fixed.
+# Both paths are folded before they are compared, because a user's "//", "/." or
+# trailing "/" survives into the Makefile and the kernel ignores all three. An
+# unfolded pair fails the prefix test and leaves the link absolute, which is the
+# dangling #885 fixed.
 install-data-hook:
 	@fold() { printf '%s\n' "$$1" | \
-		sed -e 's|//*|/|g' -e ':a' -e 's|/\./|/|g' -e 'ta' -e 's|/\.$$||'; }; \
+		sed -e 's|//*|/|g' -e ':a' -e 's|/\./|/|g' -e 'ta' \
+			-e 's|/\.$$|/|' -e 's|\(.\)/$$|\1|'; }; \
 	html=`fold '$(htmldir)'`; \
 	data=`fold '$(datadir)'`; \
-	root=`fold '$(langrootdir)'`; \
 	rel="$$html"; \
 	case "$$html" in \
-		"$$data"/*) rel="../$${html#$$data/}" ;; \
+		"$$data"/*) rel="../$${html#"$$data"/}" ;; \
 	esac; \
 	link='$(DESTDIR)$(langrootdir)/html'; \
 	if test -L "$$link"; then rm -f "$$link" || exit 1; fi; \
@@ -33,8 +34,6 @@ install-data-hook:
 	if test -e "$$link"; then \
 		echo "$$link exists and is not a symlink, leaving it alone" >&2; \
 	else \
-		test "$$html" != "$$root" || echo "$(htmldir) is the package directory," \
-			"so $(langrootdir)/html can only loop back to it" >&2; \
 		echo " $(LN_S) $$rel $$link"; \
 		$(LN_S) "$$rel" "$$link"; \
 	fi

--- a/lang/Makefile.am
+++ b/lang/Makefile.am
@@ -12,11 +12,20 @@ EXTRA_DIST = $(lang_DATA) $(langroot_DATA)
 # link is relative: an absolute $(htmldir) dangles under DESTDIR or relocation (#885).
 # Making $(htmldir) first decides whether a link is wanted. Where it is the link
 # path, or under it, a real directory lands there and the branch below leaves it
-# alone. Comparing spellings would miss that, since configure keeps a "//".
+# alone.
+#
+# Both paths are folded before they are compared, because configure keeps the "//"
+# and "/." a user typed and the kernel does not. An unfolded pair fails the prefix
+# test and leaves the link absolute, which is the dangling #885 fixed.
 install-data-hook:
-	@rel='$(htmldir)'; \
-	case '$(htmldir)' in \
-		'$(datadir)'/*) rel="../$${rel#$(datadir)/}" ;; \
+	@fold() { printf '%s\n' "$$1" | \
+		sed -e 's|//*|/|g' -e ':a' -e 's|/\./|/|g' -e 'ta' -e 's|/\.$$||'; }; \
+	html=`fold '$(htmldir)'`; \
+	data=`fold '$(datadir)'`; \
+	root=`fold '$(langrootdir)'`; \
+	rel="$$html"; \
+	case "$$html" in \
+		"$$data"/*) rel="../$${html#$$data/}" ;; \
 	esac; \
 	link='$(DESTDIR)$(langrootdir)/html'; \
 	if test -L "$$link"; then rm -f "$$link" || exit 1; fi; \
@@ -24,6 +33,8 @@ install-data-hook:
 	if test -e "$$link"; then \
 		echo "$$link exists and is not a symlink, leaving it alone" >&2; \
 	else \
+		test "$$html" != "$$root" || echo "$(htmldir) is the package directory," \
+			"so $(langrootdir)/html can only loop back to it" >&2; \
 		echo " $(LN_S) $$rel $$link"; \
 		$(LN_S) "$$rel" "$$link"; \
 	fi

--- a/lang/Makefile.am
+++ b/lang/Makefile.am
@@ -17,16 +17,17 @@ EXTRA_DIST = $(lang_DATA) $(langroot_DATA)
 # Both paths are folded before they are compared, because a user's "//", "/." or
 # trailing "/" survives into the Makefile and the kernel ignores all three. An
 # unfolded pair fails the prefix test and leaves the link absolute, which is the
-# dangling #885 fixed.
+# dangling link #885 fixed. A trailing slash is left for $${data%/} to take, which
+# also turns a $(datadir) of "/" into the empty prefix the compare needs.
 install-data-hook:
 	@fold() { printf '%s\n' "$$1" | \
-		sed -e 's|//*|/|g' -e ':a' -e 's|/\./|/|g' -e 'ta' \
-			-e 's|/\.$$|/|' -e 's|\(.\)/$$|\1|'; }; \
+		sed -e 's|//*|/|g' -e ':a' -e 's|/\./|/|g' -e 'ta' -e 's|/\.$$|/|'; }; \
 	html=`fold '$(htmldir)'`; \
 	data=`fold '$(datadir)'`; \
+	root=$${data%/}; \
 	rel="$$html"; \
 	case "$$html" in \
-		"$$data"/*) rel="../$${html#"$$data"/}" ;; \
+		"$$root"/*) rel="../$${html#"$$root"/}" ;; \
 	esac; \
 	link='$(DESTDIR)$(langrootdir)/html'; \
 	if test -L "$$link"; then rm -f "$$link" || exit 1; fi; \

--- a/tests/385_install-html-link-loop.test
+++ b/tests/385_install-html-link-loop.test
@@ -29,16 +29,10 @@ hook() {
         fail "${name}: lang install-data failed for htmldir=${htmldir}"
 }
 
-# The staged link the hook writes, which follows the case's own datadir.
+# Each case's link lands under its own datadir, so derive the staged path from it.
 link_at() {
-    local name=$1 datadir=${2:-${data}}
+    local name=$1 datadir=$2
     printf '%s' "${work}/${name}${datadir}/httrack/html"
-}
-
-linked() {
-    local name=$1 htmldir=$2 datadir=${3:-${data}}
-    hook "${name}" "${htmldir}" "${datadir}"
-    test -L "$(link_at "${name}" "${datadir}")" || fail "${name}: no link was created"
 }
 
 not_linked() {
@@ -48,35 +42,40 @@ not_linked() {
     test ! -L "${at}" || fail "${name}: got a link to $(readlink "${at}")"
 }
 
-# Where the link must point. It is relative whenever htmldir sits under datadir,
-# so an install can be staged or moved (#885).
+# The link must be relative whenever htmldir sits under datadir, so that an
+# install can be staged or moved (#885).
 link_target() {
-    local name=$1 htmldir=$2 want=$3 datadir=${4:-${data}} got
-    linked "${name}" "${htmldir}" "${datadir}"
-    got=$(readlink "$(link_at "${name}" "${datadir}")")
+    local name=$1 htmldir=$2 want=$3 datadir=${4:-${data}} at got
+    hook "${name}" "${htmldir}" "${datadir}"
+    at=$(link_at "${name}" "${datadir}")
+    test -L "${at}" || fail "${name}: no link was created"
+    got=$(readlink "${at}")
     test "${got}" = "${want}" || fail "${name}: link reads ${got}, want ${want}"
 }
 
 link_target default "${docs}" "${docs_rel}"
 
-# Spellings of those same two directories that configure keeps and the kernel
-# ignores, on either side of the compare. Unfolded, the prefix test fails and
-# the link is left absolute, pointing at the build host's own tree rather than
-# into the staged one.
+# A user can spell those same two directories in ways configure keeps and the
+# kernel ignores, on either side of the compare. Unfolded, the prefix test fails
+# and the link is left absolute, pointing at the build host's own tree rather
+# than into the staged one.
 link_target doubled-slash "${docs}" "${docs_rel}" /usr//share
 link_target dot-component "${docs}" "${docs_rel}" /usr/./share
 link_target trailing-slash "${docs}" "${docs_rel}" /usr/share/
 link_target trailing-dot "${docs}" "${docs_rel}" /usr/share/.
 link_target dotted-htmldir /usr/./share/doc/httrack/html "${docs_rel}"
+# A datadir of "/" would make the prefix pattern "//*", which matches nothing.
+link_target root-datadir "${docs}" ../usr/share/doc/httrack/html /
 
 # The chop strips the datadir back off, and must treat it as text there too. Left
-# as a glob, a datadir carrying "[" matches the case yet strips nothing, and the
+# as a glob, a datadir carrying "[" matches the branch yet strips nothing, so the
 # whole absolute path ends up behind "../".
 glob_data='/usr/sh[a]re'
 link_target glob-in-datadir "${glob_data}/doc/httrack/html" "${docs_rel}" "${glob_data}"
 
-# htmldir outside datadir has no relative spelling. A chop ignoring the "/"
-# boundary would claim this one and mangle it instead of leaving it alone.
+# htmldir outside the data dir keeps an absolute target, since the chop only
+# relativizes under it. That target does not survive staging, so this pins a
+# limitation rather than a good outcome. A chop ignoring the "/" fails here.
 link_target outside-datadir /usr/sharefoo/html /usr/sharefoo/html
 
 # htmldir is the package directory itself, so the link can only point at its own
@@ -86,8 +85,8 @@ link_target package-dir "${data}/httrack" ../httrack
 # Neighbours of the link path. Without these the assertions below would pass on
 # a hook that stopped linking, or on one that skipped every htmldir under
 # $(datadir)/httrack.
-linked sibling-of-link "${link}foo"
-linked under-package-dir "${data}/httrack/doc"
+link_target sibling-of-link "${link}foo" ../httrack/htmlfoo
+link_target under-package-dir "${data}/httrack/doc" ../httrack/doc
 
 # htmldir at the link path (--docdir=$(datadir)/httrack), and one level under it
 # (Termux's --docdir=$(datadir)/httrack/html).

--- a/tests/385_install-html-link-loop.test
+++ b/tests/385_install-html-link-loop.test
@@ -73,6 +73,10 @@ link_target root-datadir "${docs}" ../usr/share/doc/httrack/html /
 glob_data='/usr/sh[a]re'
 link_target glob-in-datadir "${glob_data}/doc/httrack/html" "${docs_rel}" "${glob_data}"
 
+# htmldir naming the data dir itself relativizes only when it carries the trailing
+# slash, because the chop needs a "/" to cut on.
+link_target datadir-as-htmldir "${data}/" ../
+
 # htmldir outside the data dir keeps an absolute target, since the chop only
 # relativizes under it. That target does not survive staging, so this pins a
 # limitation rather than a good outcome. A chop ignoring the "/" fails here.

--- a/tests/385_install-html-link-loop.test
+++ b/tests/385_install-html-link-loop.test
@@ -58,6 +58,20 @@ not_linked under-link-path "${link}/html"
 # The same path as at-link-path, spelled the way configure keeps --datadir=/usr//share.
 not_linked unfolded-datadir "${link}" /usr//share
 
+# A datadir the user spelled with "//" or "/." names the same directory, so the
+# link must still come out relative. An unfolded compare leaves it absolute,
+# pointing at the build host's own tree rather than into the staged one.
+stays_relative() {
+    local name=$1 datadir=$2 got
+    linked "${name}" "${data}/doc/httrack/html" "${datadir}"
+    got=$(readlink "${work}/${name}${link}")
+    test "${got}" = "../doc/httrack/html" ||
+        fail "datadir=${datadir} gave ${got}, want ../doc/httrack/html"
+}
+
+stays_relative doubled-slash /usr//share
+stays_relative dot-component /usr/./share
+
 # An upgrade over the absolute link older installs left (#885): it must be
 # replaced, not kept because it happens to resolve.
 stale=${work}/upgrade${link}

--- a/tests/385_install-html-link-loop.test
+++ b/tests/385_install-html-link-loop.test
@@ -17,6 +17,8 @@ cleanup_push rm -rf "${work}"
 # build was configured for does not matter.
 data=/usr/share
 link=${data}/httrack/html
+docs=${data}/doc/httrack/html
+docs_rel=../doc/httrack/html
 
 # One staged layout per call, under $work/$name. lang's own data install is what
 # creates the link's parent directory.
@@ -27,23 +29,59 @@ hook() {
         fail "${name}: lang install-data failed for htmldir=${htmldir}"
 }
 
+# The staged link the hook writes, which follows the case's own datadir.
+link_at() {
+    local name=$1 datadir=${2:-${data}}
+    printf '%s' "${work}/${name}${datadir}/httrack/html"
+}
+
 linked() {
     local name=$1 htmldir=$2 datadir=${3:-${data}}
     hook "${name}" "${htmldir}" "${datadir}"
-    test -L "${work}/${name}${link}" || fail "${name}: no link was created"
+    test -L "$(link_at "${name}" "${datadir}")" || fail "${name}: no link was created"
 }
 
 not_linked() {
-    local name=$1 htmldir=$2 datadir=${3:-${data}}
+    local name=$1 htmldir=$2 datadir=${3:-${data}} at
+    at=$(link_at "${name}" "${datadir}")
     hook "${name}" "${htmldir}" "${datadir}"
-    test ! -L "${work}/${name}${link}" ||
-        fail "${name}: got a link to $(readlink "${work}/${name}${link}")"
+    test ! -L "${at}" || fail "${name}: got a link to $(readlink "${at}")"
 }
 
-# The default layout, and the relative target #885 asks for.
-linked default "${data}/doc/httrack/html"
-got=$(readlink "${work}/default${link}")
-test "${got}" = "../doc/httrack/html" || fail "the link reads ${got}, want ../doc/httrack/html"
+# Where the link must point. It is relative whenever htmldir sits under datadir,
+# so an install can be staged or moved (#885).
+link_target() {
+    local name=$1 htmldir=$2 want=$3 datadir=${4:-${data}} got
+    linked "${name}" "${htmldir}" "${datadir}"
+    got=$(readlink "$(link_at "${name}" "${datadir}")")
+    test "${got}" = "${want}" || fail "${name}: link reads ${got}, want ${want}"
+}
+
+link_target default "${docs}" "${docs_rel}"
+
+# Spellings of those same two directories that configure keeps and the kernel
+# ignores, on either side of the compare. Unfolded, the prefix test fails and
+# the link is left absolute, pointing at the build host's own tree rather than
+# into the staged one.
+link_target doubled-slash "${docs}" "${docs_rel}" /usr//share
+link_target dot-component "${docs}" "${docs_rel}" /usr/./share
+link_target trailing-slash "${docs}" "${docs_rel}" /usr/share/
+link_target trailing-dot "${docs}" "${docs_rel}" /usr/share/.
+link_target dotted-htmldir /usr/./share/doc/httrack/html "${docs_rel}"
+
+# The chop strips the datadir back off, and must treat it as text there too. Left
+# as a glob, a datadir carrying "[" matches the case yet strips nothing, and the
+# whole absolute path ends up behind "../".
+glob_data='/usr/sh[a]re'
+link_target glob-in-datadir "${glob_data}/doc/httrack/html" "${docs_rel}" "${glob_data}"
+
+# htmldir outside datadir has no relative spelling. A chop ignoring the "/"
+# boundary would claim this one and mangle it instead of leaving it alone.
+link_target outside-datadir /usr/sharefoo/html /usr/sharefoo/html
+
+# htmldir is the package directory itself, so the link can only point at its own
+# parent. Refusing to make it would leave webhttrack with no served UI (#885).
+link_target package-dir "${data}/httrack" ../httrack
 
 # Neighbours of the link path. Without these the assertions below would pass on
 # a hook that stopped linking, or on one that skipped every htmldir under
@@ -58,35 +96,19 @@ not_linked under-link-path "${link}/html"
 # The same path as at-link-path, spelled the way configure keeps --datadir=/usr//share.
 not_linked unfolded-datadir "${link}" /usr//share
 
-# A datadir the user spelled with "//" or "/." names the same directory, so the
-# link must still come out relative. An unfolded compare leaves it absolute,
-# pointing at the build host's own tree rather than into the staged one.
-stays_relative() {
-    local name=$1 datadir=$2 got
-    linked "${name}" "${data}/doc/httrack/html" "${datadir}"
-    got=$(readlink "${work}/${name}${link}")
-    test "${got}" = "../doc/httrack/html" ||
-        fail "datadir=${datadir} gave ${got}, want ../doc/httrack/html"
-}
-
-stays_relative doubled-slash /usr//share
-stays_relative dot-component /usr/./share
-
 # An upgrade over the absolute link older installs left (#885): it must be
 # replaced, not kept because it happens to resolve.
 stale=${work}/upgrade${link}
-mkdir -p "$(dirname "${stale}")" "${work}/upgrade${data}/doc/httrack/html"
-ln -s "${data}/doc/httrack/html" "${stale}"
-linked upgrade "${data}/doc/httrack/html"
-got=$(readlink "${stale}")
-test "${got}" = "../doc/httrack/html" || fail "the stale absolute link survived as ${got}"
+mkdir -p "$(dirname "${stale}")" "${work}/upgrade${docs}"
+ln -s "${docs}" "${stale}"
+link_target upgrade "${docs}" "${docs_rel}"
 
 # Anything else already sitting there is left alone, and the install still
 # succeeds. Only a symlink is ours to replace.
 squatter=${work}/squatter${link}
 mkdir -p "$(dirname "${squatter}")"
 echo keep-me >"${squatter}"
-hook squatter "${data}/doc/httrack/html" "${data}"
+hook squatter "${docs}" "${data}"
 test "$(cat "${squatter}")" = keep-me || fail "the file at the link path was not left alone"
 
 echo "the served-UI link never contains itself"


### PR DESCRIPTION
The hook builds the relative served-UI link by chopping `$(datadir)` off the front of `$(htmldir)` as text. A `//`, a `/.` or a trailing `/` a user typed survives into the Makefile, so `--datadir=/usr//share` stops matching `/usr/share/doc/httrack/html` and the chop is skipped. The link is then absolute, which is what #885 fixed. Staged into a package it points at the build host's own `/usr/share` rather than into the staging tree. Measured through configure and `make install`: master emits `/usr/share/doc/httrack/html` where this emits `../doc/httrack/html`.

Both paths are folded before the compare. The datadir then loses a trailing slash again, so a `$(datadir)` of `/` becomes the empty prefix rather than the pattern `//*`, which matches nothing. #1488's containment test needs none of this, because the filesystem folds already.

The chop itself was also unsafe. The `case` quotes its pattern and the strip did not. A datadir carrying a glob character matched the branch and then stripped nothing, leaving the whole absolute path behind `../`.

`--htmldir=$(datadir)/httrack` is left alone. The link points at its own parent there, which reads as a loop to a tree walker following symlinks. But the pages install at `$(langrootdir)`, and webhttrack reaches them through `$(langrootdir)/html`. `html/index.html` resolves to a real page, so removing the link would break that layout rather than tidy it. Test 385 pins that layout. It pins nothing about a warning, because a branch whose only effect is a message is one no test can reach.

385 covers each spelling on either side of the compare. It also covers a datadir of `/`, an htmldir outside the data dir, a glob character in the datadir, and the package-directory layout. Fifteen wrong hooks die against it.

An htmldir that is an ancestor of the data dir still gets an absolute link. So does one naming the data dir itself, unless it carries a trailing slash for the chop to cut on. Relativizing those needs a real path calculation rather than a prefix chop, so they are left as they were.

The fold runs under BSD sed on the macOS legs, so the label and `t` are separate `-e` arguments.