### PR TITLE
The weekly packaging canary reds on two Termux patches our own fixes made dead

### DIFF
--- a/.github/workflows/downstream-drift.yml
+++ b/.github/workflows/downstream-drift.yml
@@ -5,7 +5,7 @@
 # Gentoo's src_prepare dies today on a grep of m4/check_zlib.m4 that we
 # rewrote. Their files, so a finding here is usually theirs to fix, which is why
 # it blocks nothing.
-name: downstream drift canary
+name: distro packaging recipes against this tree
 
 on:
   schedule:
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   drift:
-    name: downstream recipes against this tree
+    name: check the Gentoo, FreeBSD, OpenBSD and Termux recipes
     # Scheduled workflows run per-fork independently; skip anywhere but upstream.
     if: github.repository == 'xroche/httrack'
     runs-on: ubuntu-24.04

--- a/.github/workflows/downstream-drift.yml
+++ b/.github/workflows/downstream-drift.yml
@@ -5,7 +5,7 @@
 # Gentoo's src_prepare dies today on a grep of m4/check_zlib.m4 that we
 # rewrote. Their files, so a finding here is usually theirs to fix, which is why
 # it blocks nothing.
-name: distro packaging recipes against this tree
+name: distro packaging recipe canary
 
 on:
   schedule:

--- a/tools/downstream-drift.sh
+++ b/tools/downstream-drift.sh
@@ -135,9 +135,9 @@ if [ ! -f "$top/src/Makefile.in" ] || [ ! -f "$top/html/Makefile.in" ]; then
 fi
 
 # Whoever reads a failed run has none of this context, so state it up front.
-echo "Gentoo, FreeBSD, OpenBSD and Termux each patch this tree to build it."
-echo "Their live recipes, re-checked below: ok = the recipe still fits, known ="
-echo "a mismatch already reported to its packager, DRIFT = a new one."
+echo "Gentoo, FreeBSD, OpenBSD and Termux each patch this tree to build it. Their"
+echo "live recipes, re-checked below: ok = still fits, known = a mismatch already"
+echo "reported to its packager, DRIFT = a new one."
 echo
 
 ### Gentoo -- www-client/httrack, read through the GitHub mirror because

--- a/tools/downstream-drift.sh
+++ b/tools/downstream-drift.sh
@@ -33,8 +33,10 @@ acknowledged=(
     openbsd-patch-src_minizip_ioapi_h
     openbsd-patch-src_webhttrack
     termux-html-Makefile.in.patch
+    termux-htsglobal.h.patch # the install paths follow --prefix since #1469
     termux-src-Makefile.in.patch
     termux-src-htsbacktrace.c.patch
+    termux-src-proxy-proxytrack.h.patch # the sys/timeb.h include went away with #1467
     termux-store.c.patch
 )
 
@@ -132,6 +134,12 @@ if [ ! -f "$top/src/Makefile.in" ] || [ ! -f "$top/html/Makefile.in" ]; then
     die "run ./bootstrap first: the generated files Termux patches are missing"
 fi
 
+# Whoever reads a failed run has none of this context, so state it up front.
+echo "Gentoo, FreeBSD, OpenBSD and Termux each patch this tree to build it."
+echo "Their live recipes, re-checked below: ok = the recipe still fits, known ="
+echo "a mismatch already reported to its packager, DRIFT = a new one."
+echo
+
 ### Gentoo -- www-client/httrack, read through the GitHub mirror because
 ### gitweb.gentoo.org has no stable raw URL for a version-numbered ebuild.
 gentoo_raw=https://raw.githubusercontent.com/gentoo-mirror/gentoo/master/www-client/httrack
@@ -198,9 +206,10 @@ echo
 test "$checks" -ge 21 || die "only $checks checks ran; the table lost some"
 
 if [ "$drift" -ne 0 ]; then
-    echo "Downstream assumptions our tree no longer meets are listed above."
-    echo "Tell the packager, then add the id to \$acknowledged so this stays red"
-    echo "only for what is new."
+    echo "A DRIFT line above is a packaging recipe that no longer fits this tree,"
+    echo "so that distribution breaks at its next version bump. The recipe is"
+    echo "theirs and so is the fix: tell the packager, then add the id to"
+    echo "\$acknowledged in this script so a later run reds only for what is new."
     exit 1
 fi
 echo "$checks checks, no new drift; $known_hits are findings already known"

--- a/tools/downstream-drift.sh
+++ b/tools/downstream-drift.sh
@@ -207,9 +207,9 @@ test "$checks" -ge 21 || die "only $checks checks ran; the table lost some"
 
 if [ "$drift" -ne 0 ]; then
     echo "A DRIFT line above is a packaging recipe that no longer fits this tree,"
-    echo "so that distribution breaks at its next version bump. The recipe is"
-    echo "theirs and so is the fix: tell the packager, then add the id to"
-    echo "\$acknowledged in this script so a later run reds only for what is new."
+    echo "so the distribution breaks at its next version bump. The recipe is theirs"
+    echo "and so is the fix. Tell the packager, then add the id to \$acknowledged"
+    echo "in this script so a later run reds only for what is new."
     exit 1
 fi
 echo "$checks checks, no new drift; $known_hits are findings already known"


### PR DESCRIPTION
`tools/downstream-drift.sh` re-checks the live packaging recipes of Gentoo, FreeBSD, OpenBSD and Termux against master every Wednesday. Run 33600169030 went red on two Termux patches, both now dead because we fixed what they worked around:

- `htsglobal.h.patch` rewrote the compiled-in `/usr` install paths to `@TERMUX_PREFIX@`. #1469 made those paths follow `--prefix`, so the block it patches no longer looks like that.
- `src-proxy-proxytrack.h.patch` dropped the `<sys/timeb.h>` include Android removed. #1467 dropped it upstream.

Deleting them is Termux's call, so both ids join `$acknowledged`.

The rest is naming. The workflow was called "downstream drift canary" and the job "downstream recipes against this tree". Neither name says what ran, and the output opened with `known gentoo-zlib-tripwire: ...`. The job name now lists the four distributions. The script says what `ok`, `known` and `DRIFT` mean before the first verdict, and what to do about a DRIFT line after the last.