### PR TITLE
proxytrack reads two GMT dates with mktime(), so every non-UTC host shifts them

### DIFF
--- a/src/proxy/proxytrack.c
+++ b/src/proxy/proxytrack.c
@@ -714,7 +714,7 @@ static time_t get_time_rfc822(const char *s) {
     result.tm_wday = -1;        /* don't know */
     result.tm_mon = result_mm;
     result.tm_mday = result_dd;
-    return mktime(&result);
+    return timegm(&result);
   }
   return (time_t) 0;
 }

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -2099,24 +2099,11 @@ static int getDigit4(const char *const pos) {
     getDigit(pos[2]) * 10 + getDigit(pos[3]);
 }
 
-static time_t getGMT(struct tm *tm) {   /* hey, time_t is local! */
-  time_t t = mktime(tm);
+static time_t getGMT(struct tm *tm) {
+  time_t t = timegm(tm);
 
   if (t != (time_t) - 1 && t != (time_t) 0) {
-    /* BSD does not have static "timezone" declared */
-#if (defined(BSD) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD_kernel__))
-    time_t now = time(NULL);
-    struct tm nowtm;
-    time_t timezone;
-
-    if (!hts_localtime(now, &nowtm))
-      return (time_t) -1;
-    timezone = -nowtm.tm_gmtoff;
-#elif defined(_MSC_VER)
-    /* MSVC spells it _timezone */
-    const time_t timezone = _timezone;
-#endif
-    return (time_t) (t - timezone);
+    return t;
   }
   return (time_t) - 1;
 }

--- a/tests/386_local-proxytrack-dav-tz.test
+++ b/tests/386_local-proxytrack-dav-tz.test
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# A WebDAV listing dates each entry in GMT, so the server's timezone must not
+# move it. proxytrack read both dates with mktime(), which reads a struct tm as
+# local time.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+# shellcheck source=tests/arclib.sh
+. "${0%"${0##*/}"}./arclib.sh"
+
+python=$(find_python) || skip "python3 missing"
+command -v curl >/dev/null 2>&1 || skip "curl missing"
+
+# POSIX form needs no tzdata, and its sign is inverted, so this means UTC+5:30.
+# A half-hour offset also catches an implementation that rounds to whole hours.
+TZ=IST-5:30
+export TZ
+offset=$("$python" -c 'import time; print(time.strftime("%z", time.localtime(0)))')
+test "$offset" = "+0530" ||
+    skip "the host ignored TZ=IST-5:30 (localtime(0) is $offset), so a shift would be invisible"
+
+dir=$(mktemp -d)
+ptpid=
+cleanup() {
+    stop_server "$ptpid"
+    rm -rf "$dir"
+}
+cleanup_push cleanup
+
+printf 'hello' >"$dir/body"
+{
+    printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n'
+    printf 'Last-Modified: Sun, 06 Nov 1994 08:49:37 GMT\r\n'
+    printf 'Content-Length: 5\r\n\r\n'
+} >"$dir/hdr-dated"
+# No Last-Modified, so the listing falls back to the ARC record's own date.
+printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 5\r\n\r\n' >"$dir/hdr-undated"
+{
+    arc_filedesc
+    arc_record http://example.com/dated.html text/html 200 "$dir/hdr-dated" "$dir/body"
+    # a record begins on the newline following the previous one's data
+    printf '\n'
+    arc_record http://example.com/undated.html text/html 200 "$dir/hdr-undated" "$dir/body"
+} >"$dir/in.arc"
+
+launch_proxytrack() {
+    proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc" >"$ptlog" 2>&1 &
+    ptpid=$!
+}
+start_proxytrack "$dir/pt" launch_proxytrack
+
+# --max-time: an unbounded read here would wedge the runner rather than fail
+curl -s --max-time 30 -X PROPFIND -H "Depth: 1" \
+    "http://127.0.0.1:$proxyport/webdav/example.com/" >"$dir/resp.xml"
+
+# Both entries must be listed, or an assertion below passes on an empty listing.
+test "$(count_matching_lines '<response ' "$dir/resp.xml")" -eq 3 ||
+    fail_dump "expected the root and its two entries" "$dir/resp.xml"
+
+grep -q '<getlastmodified>Sun, 06 Nov 1994 08:49:37 GMT</getlastmodified>' "$dir/resp.xml" ||
+    fail_dump "the entry's Last-Modified was shifted by the server's timezone" "$dir/resp.xml"
+grep -q '<getlastmodified>Wed, 01 Jan 2025 00:00:00 GMT</getlastmodified>' "$dir/resp.xml" ||
+    fail_dump "the ARC record date was shifted by the server's timezone" "$dir/resp.xml"
+
+echo "OK: a WebDAV listing dates both entries in GMT on a UTC+5:30 host"

--- a/tests/386_local-proxytrack-dav-tz.test
+++ b/tests/386_local-proxytrack-dav-tz.test
@@ -1,8 +1,7 @@
 #!/bin/bash
 #
 # A WebDAV listing dates each entry in GMT, so the server's timezone must not
-# move it. proxytrack read both dates with mktime(), which reads a struct tm as
-# local time.
+# shift it.
 
 set -euo pipefail
 

--- a/tests/386_local-proxytrack-dav-tz.test
+++ b/tests/386_local-proxytrack-dav-tz.test
@@ -55,7 +55,7 @@ start_proxytrack "$dir/pt" launch_proxytrack
 curl -s --max-time 30 -X PROPFIND -H "Depth: 1" \
     "http://127.0.0.1:$proxyport/webdav/example.com/" >"$dir/resp.xml"
 
-# Both entries must be listed, or an assertion below passes on an empty listing.
+# One entry listed twice would pass both greps below, so pin the count.
 test "$(count_matching_lines '<response ' "$dir/resp.xml")" -eq 3 ||
     fail_dump "expected the root and its two entries" "$dir/resp.xml"
 


### PR DESCRIPTION
`get_time_rfc822()` in proxytrack.c and `getGMT()` in proxy/store.c both convert a `struct tm` that is already GMT. Both went through `mktime()`, which reads its argument as local time. Both now call `timegm()`, which the engine already uses for the same job at `htslib.c:2854`, and which `htslib.h:599` already aliases to `_mkgmtime` for MSVC.

A WebDAV listing's `<getlastmodified>` came back shifted by the host's standard UTC offset whenever the entry carried a `Last-Modified` header. The shift was -5:30 on Asia/Kolkata, +5:00 on America/New_York and -1:00 on Europe/Paris. That is `get_time_rfc822()`, a live bug on every non-UTC host.

`getGMT()` is the portability half. Its `#if` maze named BSD and MSVC, and fell through to libc's `timezone` global everywhere else. Android has no such global, so the file does not compile there and Termux carries a patch for it. On glibc the arm it took was exact, so this half changes no result there. The BSD arm was not exact. It subtracts the `tm_gmtoff` of *now*, not of the timestamp being parsed, so FreeBSD, OpenBSD and NetBSD were an hour out across a DST change.

Test 386 serves a WebDAV listing under `TZ=IST-5:30` and asserts both dates. It skips if the host ignored `TZ`, since a shift would then be invisible. It kills both `timegm` to `mktime` mutants. It does not kill the shipped `getGMT` on glibc, because that arm was already exact. That assertion pins the contract instead, and would have caught the BSD arm.

`get_time_rfc822()` duplicates the engine's `convert_time_rfc822()`, and the copies have already drifted. The proxy one hand-rolls its case folding and uses raw `strncat` where the engine uses the bounds-checked `strncatbuff`. Sharing one copy is possible, because `proxytrack_SOURCES` already compiles engine sources straight into the binary. That goes in a follow-up rather than widening this fix.

`getGMT()` has a second consumer the test does not reach. `PT_IndexMerge()` picks the newer of two entries for one URL, comparing an ARC timestamp against a `file_timestamp()` mtime. The BSD arm could pick the wrong entry there too.