### PR TITLE
One RFC822 date parser instead of three, two of them in the same binary

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -63,7 +63,7 @@ htsserver_SOURCES = htsserver.c htsserver.h htsweb.c htsweb.h htsstats.h \
 	htsurlport.c htsurlport.h htsescape.c htsescape.h
 proxytrack_SOURCES = proxy/main.c \
 	proxy/proxytrack.c proxy/store.c \
-	htsurlport.c htsurlport.h htsnet.c \
+	htsurlport.c htsurlport.h htsdate.c htsdate.h htsnet.c \
 	coucal/coucal.c htsmd5.c md5.c \
 	minizip/ioapi.c minizip/mztools.c minizip/unzip.c minizip/zip.c
 
@@ -80,7 +80,7 @@ CLEANFILES = webhttrack
 libhttrack_la_SOURCES =  htscore.c htsparse.c htsback.c htscache.c \
 	htscache_selftest.c htsdns_selftest.c htsselftest.c \
 	htscatchurl.c htsfilters.c htsftp.c htshash.c coucal/coucal.c \
-	htscmdline.c htshelp.c htslib.c htsurlport.c htscoremain.c \
+	htscmdline.c htshelp.c htslib.c htsurlport.c htsdate.c htscoremain.c \
 	htsname.c htsrobots.c htstools.c htsrandom.c htswizard.c \
 	htsalias.c htsthread.c htsindex.c htsbauth.c \
 	htscrashtest.c \
@@ -88,7 +88,7 @@ libhttrack_la_SOURCES =  htscore.c htsparse.c htsback.c htscache.c \
 	htsmodules.c htscharset.c punycode.c htsencoding.c htsescape.c htssniff.c \
 	md5.c \
 	minizip/ioapi.c minizip/mztools.c minizip/unzip.c minizip/zip.c \
-	hts-indextmpl.h htsalias.h htsback.h htsbase.h htssafe.h \
+	hts-indextmpl.h htsalias.h htsback.h htsbase.h htssafe.h htsdate.h \
 	htsbasenet.h htsbauth.h htscache.h htscache_selftest.h htsdns_selftest.h htsselftest.h htscatchurl.h  \
 	htscmdline.h htsconfig.h htscore.h htsparse.h htscoremain.h htsdefines.h  \
 	htsfilters.h htsftp.h htsglobal.h htshash.h coucal/coucal.h \

--- a/src/htsdate.c
+++ b/src/htsdate.c
@@ -1,0 +1,138 @@
+/* ------------------------------------------------------------ */
+/*
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) 1998 Xavier Roche and other contributors
+
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Ethical use: we kindly ask that you NOT use this software to harvest email
+addresses or to collect any other private information about people. Doing so
+would dishonor our work and waste the many hours we have spent on it.
+
+Please visit our Website: http://www.httrack.com
+*/
+
+/* ------------------------------------------------------------ */
+/* File: RFC822 date parser, shared by the engine and proxytrack */
+/* Author: Xavier Roche                                          */
+/* ------------------------------------------------------------ */
+
+#include "htsdate.h"
+
+#include "htsglobal.h"
+#include "htssafe.h"
+
+#include <string.h>
+
+/* Not hts_lowcase(), which lives in the library proxytrack does not link. */
+static void lowcase_(char *s) {
+  size_t i;
+
+  for (i = 0; s[i] != '\0'; i++)
+    if ((s[i] >= 'A') && (s[i] <= 'Z'))
+      s[i] += ('a' - 'A');
+}
+
+struct tm *convert_time_rfc822(struct tm *result, const char *s) {
+  char months[] = "jan feb mar apr may jun jul aug sep oct nov dec";
+  char str[256];
+  char *a;
+
+  int result_mm = -1;
+  int result_dd = -1;
+  int result_n1 = -1;
+  int result_n2 = -1;
+  int result_n3 = -1;
+  int result_n4 = -1;
+
+  if ((int) strlen(s) > 200)
+    return NULL;
+  strcpybuff(str, s);
+  lowcase_(str);
+  /* drop the separators */
+  while ((a = strchr(str, '-')))
+    *a = ' ';
+  while ((a = strchr(str, ':')))
+    *a = ' ';
+  while ((a = strchr(str, ',')))
+    *a = ' ';
+  /* tokenise */
+  a = str;
+  while (*a) {
+    char *first, *last;
+    char tok[256];
+
+    /* cut one word out */
+    while (*a == ' ')
+      a++; /* skip spaces */
+    first = a;
+    while ((*a) && (*a != ' '))
+      a++;
+    last = a;
+    tok[0] = '\0';
+    if (first != last) {
+      char *pos;
+
+      strncatbuff(tok, first, (int) (last - first));
+      /* classify it */
+      if ((pos = strstr(months, tok))) { /* month always in letters */
+        result_mm = ((int) (pos - months)) / 4;
+      } else {
+        int number;
+
+        if (sscanf(tok, "%d", &number) == 1) { /* number token */
+          if (result_dd < 0)                   /* day always first number */
+            result_dd = number;
+          else if (result_n1 < 0)
+            result_n1 = number;
+          else if (result_n2 < 0)
+            result_n2 = number;
+          else if (result_n3 < 0)
+            result_n3 = number;
+          else if (result_n4 < 0)
+            result_n4 = number;
+        } /* anything else is noise, "+1GMT" for example */
+      }
+    }
+  }
+  if ((result_n1 >= 0) && (result_mm >= 0) && (result_dd >= 0) &&
+      (result_n2 >= 0) && (result_n3 >= 0) && (result_n4 >= 0)) {
+    if (result_n4 >= 1000) { /* Sun Nov  6 08:49:37 1994 */
+      result->tm_year = result_n4 - 1900;
+      result->tm_hour = result_n1;
+      result->tm_min = result_n2;
+      result->tm_sec = result_n3 > 0 ? result_n3 : 0;
+    } else { /* Sun, 06 Nov 1994 08:49:37 GMT or Sunday, 06-Nov-94 08:49:37 GMT
+              */
+      result->tm_hour = result_n2;
+      result->tm_min = result_n3;
+      result->tm_sec = result_n4 > 0 ? result_n4 : 0;
+      if (result_n1 <= 50) /* 00 means 2000 */
+        result->tm_year = result_n1 + 100;
+      else if (result_n1 < 1000) /* 99 means 1999 */
+        result->tm_year = result_n1;
+      else /* 2000 */
+        result->tm_year = result_n1 - 1900;
+    }
+    result->tm_isdst = 0; /* assume GMT */
+    result->tm_yday = -1; /* don't know */
+    result->tm_wday = -1; /* don't know */
+    result->tm_mon = result_mm;
+    result->tm_mday = result_dd;
+    return result;
+  }
+  return NULL;
+}

--- a/src/htsdate.c
+++ b/src/htsdate.c
@@ -37,8 +37,8 @@ Please visit our Website: http://www.httrack.com
 
 #include <string.h>
 
-/* Not hts_lowcase(), which lives in the library proxytrack does not link. */
-static void lowcase_(char *s) {
+/* hts_lowcase() lives in the library proxytrack does not link. */
+static void lowcase(char *s) {
   size_t i;
 
   for (i = 0; s[i] != '\0'; i++)
@@ -51,6 +51,8 @@ struct tm *convert_time_rfc822(struct tm *result, const char *s) {
   char str[256];
   char *a;
 
+  /* The numbers in order of appearance, dd first. n1..n4 are then year, hour,
+     min, sec, or hour, min, sec, year when n4 is four digits. */
   int result_mm = -1;
   int result_dd = -1;
   int result_n1 = -1;
@@ -61,8 +63,8 @@ struct tm *convert_time_rfc822(struct tm *result, const char *s) {
   if ((int) strlen(s) > 200)
     return NULL;
   strcpybuff(str, s);
-  lowcase_(str);
-  /* drop the separators */
+  lowcase(str);
+
   while ((a = strchr(str, '-')))
     *a = ' ';
   while ((a = strchr(str, ':')))
@@ -75,9 +77,8 @@ struct tm *convert_time_rfc822(struct tm *result, const char *s) {
     char *first, *last;
     char tok[256];
 
-    /* cut one word out */
     while (*a == ' ')
-      a++; /* skip spaces */
+      a++;
     first = a;
     while ((*a) && (*a != ' '))
       a++;

--- a/src/htsdate.h
+++ b/src/htsdate.h
@@ -1,0 +1,44 @@
+/* ------------------------------------------------------------ */
+/*
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) 1998 Xavier Roche and other contributors
+
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Ethical use: we kindly ask that you NOT use this software to harvest email
+addresses or to collect any other private information about people. Doing so
+would dishonor our work and waste the many hours we have spent on it.
+
+Please visit our Website: http://www.httrack.com
+*/
+
+/* ------------------------------------------------------------ */
+/* File: RFC822 date parser, shared by the engine and proxytrack */
+/* Author: Xavier Roche                                          */
+/* ------------------------------------------------------------ */
+
+#ifndef HTSDATE_DEFH
+#define HTSDATE_DEFH
+
+#include <time.h>
+
+/* Parse an RFC822 date such as "Sun, 06 Nov 1994 08:49:37 GMT" into "result",
+   which is returned, or NULL if "s" does not parse. The fields are GMT, so a
+   caller wanting a time_t uses timegm(), never mktime() (#1491). Its own file
+   so proxytrack, which does not link the library, can share it. */
+struct tm *convert_time_rfc822(struct tm *result, const char *s);
+
+#endif

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -42,6 +42,7 @@ Please visit our Website: http://www.httrack.com
 #include "htssinglefile.h"
 
 /* specific definitions */
+#include "htsdate.h"
 #include "htsbase.h"
 #include "htsio.h"
 #include "htsnet.h"
@@ -2758,99 +2759,6 @@ void time_local_rfc822(char *s) {
 }
 
 /* convertir une chaine en temps */
-struct tm *convert_time_rfc822(struct tm *result, const char *s) {
-  char months[] = "jan feb mar apr may jun jul aug sep oct nov dec";
-  char str[256];
-  char *a;
-
-  /* */
-  int result_mm = -1;
-  int result_dd = -1;
-  int result_n1 = -1;
-  int result_n2 = -1;
-  int result_n3 = -1;
-  int result_n4 = -1;
-
-  /* */
-
-  if ((int) strlen(s) > 200)
-    return NULL;
-  strcpybuff(str, s);
-  hts_lowcase(str);
-  /* éliminer :,- */
-  while((a = strchr(str, '-')))
-    *a = ' ';
-  while((a = strchr(str, ':')))
-    *a = ' ';
-  while((a = strchr(str, ',')))
-    *a = ' ';
-  /* tokeniser */
-  a = str;
-  while(*a) {
-    char *first, *last;
-    char tok[256];
-
-    /* découper mot */
-    while(*a == ' ')
-      a++;                      /* sauter espaces */
-    first = a;
-    while((*a) && (*a != ' '))
-      a++;
-    last = a;
-    tok[0] = '\0';
-    if (first != last) {
-      char *pos;
-
-      strncatbuff(tok, first, (int) (last - first));
-      /* analyser */
-      if ((pos = strstr(months, tok))) {        /* month always in letters */
-        result_mm = ((int) (pos - months)) / 4;
-      } else {
-        int number;
-
-        if (sscanf(tok, "%d", &number) == 1) {  /* number token */
-          if (result_dd < 0)    /* day always first number */
-            result_dd = number;
-          else if (result_n1 < 0)
-            result_n1 = number;
-          else if (result_n2 < 0)
-            result_n2 = number;
-          else if (result_n3 < 0)
-            result_n3 = number;
-          else if (result_n4 < 0)
-            result_n4 = number;
-        }                       /* sinon, bruit de fond(+1GMT for exampel) */
-      }
-    }
-  }
-  if ((result_n1 >= 0) && (result_mm >= 0) && (result_dd >= 0)
-      && (result_n2 >= 0) && (result_n3 >= 0) && (result_n4 >= 0)) {
-    if (result_n4 >= 1000) {    /* Sun Nov  6 08:49:37 1994 */
-      result->tm_year = result_n4 - 1900;
-      result->tm_hour = result_n1;
-      result->tm_min = result_n2;
-      result->tm_sec = max(result_n3, 0);
-    } else {                    /* Sun, 06 Nov 1994 08:49:37 GMT or Sunday, 06-Nov-94 08:49:37 GMT */
-      result->tm_hour = result_n2;
-      result->tm_min = result_n3;
-      result->tm_sec = max(result_n4, 0);
-      if (result_n1 <= 50)      /* 00 means 2000 */
-        result->tm_year = result_n1 + 100;
-      else if (result_n1 < 1000)        /* 99 means 1999 */
-        result->tm_year = result_n1;
-      else                      /* 2000 */
-        result->tm_year = result_n1 - 1900;
-    }
-    result->tm_isdst = 0;       /* assume GMT */
-    result->tm_yday = -1;       /* don't know */
-    result->tm_wday = -1;       /* don't know */
-    result->tm_mon = result_mm;
-    result->tm_mday = result_dd;
-    return result;
-  }
-  return NULL;
-}
-
 static time_t getGMT(struct tm *tm) {
   time_t t = timegm(tm);
 

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -61,6 +61,7 @@ typedef struct lien_adrfilsave lien_adrfilsave;
 
 /* définitions globales */
 #include "htsglobal.h"
+#include "htsdate.h"
 #include "htsurlport.h"
 
 /* basic net definitions */
@@ -353,7 +354,6 @@ void time_local_rfc822(char *s);
 /* Current UTC time as "YYYY-MM-DDThh:mm:ssZ". */
 void hts_now_iso8601(char out[32]);
 
-struct tm *convert_time_rfc822(struct tm *buffer, const char *s);
 int set_filetime(const char *file, struct tm *tm_time);
 int set_filetime_rfc822(const char *file, const char *date);
 /* File mtime as a UTC time_t, or (time_t) -1 if it can not be read. */

--- a/src/libhttrack.vcxproj
+++ b/src/libhttrack.vcxproj
@@ -126,6 +126,7 @@
     <ClCompile Include="htslib.c" />
     <ClCompile Include="htscmdline.c" />
     <ClCompile Include="htsurlport.c" />
+    <ClCompile Include="htsdate.c" />
     <ClCompile Include="htsmd5.c" />
     <ClCompile Include="htsnet.c" />
     <ClCompile Include="htsmodules.c" />

--- a/src/proxy/proxytrack.c
+++ b/src/proxy/proxytrack.c
@@ -617,106 +617,14 @@ static void proxytrack_add_DAV_Item(String * item, String * buff,
 }
 
 /* Convert a RFC822 time to time_t */
+/* The RFC822 date of a cache entry as a time_t, or 0 if it does not parse.
+   The fields are GMT, so timegm() and never mktime() (#1491). */
 static time_t get_time_rfc822(const char *s) {
   struct tm result;
 
-  /* */
-  char months[] = "jan feb mar apr may jun jul aug sep oct nov dec";
-  char str[256];
-  char *a;
-  int i;
-
-  /* */
-  int result_mm = -1;
-  int result_dd = -1;
-  int result_n1 = -1;
-  int result_n2 = -1;
-  int result_n3 = -1;
-  int result_n4 = -1;
-
-  /* */
-
-  if ((int) strlen(s) > 200)
+  if (convert_time_rfc822(&result, s) == NULL)
     return (time_t) 0;
-  for(i = 0; s[i] != 0; i++) {
-    if (s[i] >= 'A' && s[i] <= 'Z')
-      str[i] = s[i] + ('a' - 'A');
-    else
-      str[i] = s[i];
-  }
-  str[i] = 0;
-  /* éliminer :,- */
-  while((a = strchr(str, '-')))
-    *a = ' ';
-  while((a = strchr(str, ':')))
-    *a = ' ';
-  while((a = strchr(str, ',')))
-    *a = ' ';
-  /* tokeniser */
-  a = str;
-  while(*a) {
-    char *first, *last;
-    char tok[256];
-
-    /* découper mot */
-    while(*a == ' ')
-      a++;                      /* sauter espaces */
-    first = a;
-    while((*a) && (*a != ' '))
-      a++;
-    last = a;
-    tok[0] = '\0';
-    if (first != last) {
-      char *pos;
-
-      strncat(tok, first, (int) (last - first));
-      /* analyser */
-      if ((pos = strstr(months, tok))) {        /* month always in letters */
-        result_mm = ((int) (pos - months)) / 4;
-      } else {
-        int number;
-
-        if (sscanf(tok, "%d", &number) == 1) {  /* number token */
-          if (result_dd < 0)    /* day always first number */
-            result_dd = number;
-          else if (result_n1 < 0)
-            result_n1 = number;
-          else if (result_n2 < 0)
-            result_n2 = number;
-          else if (result_n3 < 0)
-            result_n3 = number;
-          else if (result_n4 < 0)
-            result_n4 = number;
-        }                       /* sinon, bruit de fond(+1GMT for exampel) */
-      }
-    }
-  }
-  if ((result_n1 >= 0) && (result_mm >= 0) && (result_dd >= 0)
-      && (result_n2 >= 0) && (result_n3 >= 0) && (result_n4 >= 0)) {
-    if (result_n4 >= 1000) {    /* Sun Nov  6 08:49:37 1994 */
-      result.tm_year = result_n4 - 1900;
-      result.tm_hour = result_n1;
-      result.tm_min = result_n2;
-      result.tm_sec = max(result_n3, 0);
-    } else {                    /* Sun, 06 Nov 1994 08:49:37 GMT or Sunday, 06-Nov-94 08:49:37 GMT */
-      result.tm_hour = result_n2;
-      result.tm_min = result_n3;
-      result.tm_sec = max(result_n4, 0);
-      if (result_n1 <= 50)      /* 00 means 2000 */
-        result.tm_year = result_n1 + 100;
-      else if (result_n1 < 1000)        /* 99 means 1999 */
-        result.tm_year = result_n1;
-      else                      /* 2000 */
-        result.tm_year = result_n1 - 1900;
-    }
-    result.tm_isdst = 0;        /* assume GMT */
-    result.tm_yday = -1;        /* don't know */
-    result.tm_wday = -1;        /* don't know */
-    result.tm_mon = result_mm;
-    result.tm_mday = result_dd;
-    return timegm(&result);
-  }
-  return (time_t) 0;
+  return timegm(&result);
 }
 
 static PT_Element proxytrack_process_DAV_Request(PT_Indexes indexes,

--- a/src/proxy/proxytrack.c
+++ b/src/proxy/proxytrack.c
@@ -616,7 +616,6 @@ static void proxytrack_add_DAV_Item(String * item, String * buff,
   }
 }
 
-/* Convert a RFC822 time to time_t */
 /* The RFC822 date of a cache entry as a time_t, or 0 if it does not parse.
    The fields are GMT, so timegm() and never mktime() (#1491). */
 static time_t get_time_rfc822(const char *s) {

--- a/src/proxy/proxytrack.h
+++ b/src/proxy/proxytrack.h
@@ -35,6 +35,7 @@ Please visit our Website: http://www.httrack.com
 /* Store manager */
 #include "../minizip/mztools.h"
 #include "store.h"
+#include "../htsdate.h"
 
 #include <sys/stat.h>
 #ifdef _WIN32
@@ -269,106 +270,6 @@ HTS_UNUSED static int fexist(char *s) {
   return 0;
 }
 
-/* convertir une chaine en temps */
-HTS_UNUSED static void set_lowcase(char *s) {
-  int i;
-
-  for(i = 0; i < (int) strlen(s); i++)
-    if ((s[i] >= 'A') && (s[i] <= 'Z'))
-      s[i] += ('a' - 'A');
-}
-HTS_UNUSED static struct tm *convert_time_rfc822(struct tm *result, const char *s) {
-  char months[] = "jan feb mar apr may jun jul aug sep oct nov dec";
-  char str[256];
-  char *a;
-
-  /* */
-  int result_mm = -1;
-  int result_dd = -1;
-  int result_n1 = -1;
-  int result_n2 = -1;
-  int result_n3 = -1;
-  int result_n4 = -1;
-
-  /* */
-
-  if ((int) strlen(s) > 200)
-    return NULL;
-  strcpy(str, s);
-  set_lowcase(str);
-  /* éliminer :,- */
-  while((a = strchr(str, '-')))
-    *a = ' ';
-  while((a = strchr(str, ':')))
-    *a = ' ';
-  while((a = strchr(str, ',')))
-    *a = ' ';
-  /* tokeniser */
-  a = str;
-  while(*a) {
-    char *first, *last;
-    char tok[256];
-
-    /* découper mot */
-    while(*a == ' ')
-      a++;                      /* sauter espaces */
-    first = a;
-    while((*a) && (*a != ' '))
-      a++;
-    last = a;
-    tok[0] = '\0';
-    if (first != last) {
-      char *pos;
-
-      strncat(tok, first, (int) (last - first));
-      /* analyser */
-      if ((pos = strstr(months, tok))) {        /* month always in letters */
-        result_mm = ((int) (pos - months)) / 4;
-      } else {
-        int number;
-
-        if (sscanf(tok, "%d", &number) == 1) {  /* number token */
-          if (result_dd < 0)    /* day always first number */
-            result_dd = number;
-          else if (result_n1 < 0)
-            result_n1 = number;
-          else if (result_n2 < 0)
-            result_n2 = number;
-          else if (result_n3 < 0)
-            result_n3 = number;
-          else if (result_n4 < 0)
-            result_n4 = number;
-        }                       /* sinon, bruit de fond(+1GMT for exampel) */
-      }
-    }
-  }
-  if ((result_n1 >= 0) && (result_mm >= 0) && (result_dd >= 0)
-      && (result_n2 >= 0) && (result_n3 >= 0) && (result_n4 >= 0)) {
-    if (result_n4 >= 1000) {    /* Sun Nov  6 08:49:37 1994 */
-      result->tm_year = result_n4 - 1900;
-      result->tm_hour = result_n1;
-      result->tm_min = result_n2;
-      result->tm_sec = max(result_n3, 0);
-    } else {                    /* Sun, 06 Nov 1994 08:49:37 GMT or Sunday, 06-Nov-94 08:49:37 GMT */
-      result->tm_hour = result_n2;
-      result->tm_min = result_n3;
-      result->tm_sec = max(result_n4, 0);
-      if (result_n1 <= 50)      /* 00 means 2000 */
-        result->tm_year = result_n1 + 100;
-      else if (result_n1 < 1000)        /* 99 means 1999 */
-        result->tm_year = result_n1;
-      else                      /* 2000 */
-        result->tm_year = result_n1 - 1900;
-    }
-    result->tm_isdst = 0;       /* assume GMT */
-    result->tm_yday = -1;       /* don't know */
-    result->tm_wday = -1;       /* don't know */
-    result->tm_mon = result_mm;
-    result->tm_mday = result_dd;
-    return result;
-  }
-  return NULL;
-}
 HTS_UNUSED static struct tm PT_GetTime(time_t t) {
   struct tm tmbuf;
 

--- a/src/proxytrack.vcxproj
+++ b/src/proxytrack.vcxproj
@@ -100,6 +100,7 @@
     <ClCompile Include="proxy\proxytrack.c" />
     <ClCompile Include="proxy\store.c" />
     <ClCompile Include="htsurlport.c" />
+    <ClCompile Include="htsdate.c" />
     <ClCompile Include="htsnet.c" />
     <ClCompile Include="coucal\coucal.c" />
     <ClCompile Include="htsmd5.c" />


### PR DESCRIPTION
Closes #1492.

There were three copies of the RFC822 date parser, not the two the issue names. `src/htslib.c:2761` is the engine's, `src/proxy/proxytrack.h:280` is a `static` copy in a header, and `src/proxy/proxytrack.c:620` is a third. The last two both compile into the proxytrack binary, so that one binary carried the same tokeniser twice. All three now come from `src/htsdate.c`.

`src/htsurlport.c` is the precedent: a small file listed in both `libhttrack_la_SOURCES` and `proxytrack_SOURCES`, existing so the proxy can share engine code without linking the library.

The issue overstated the obstacle. `strcpybuff` and `strncatbuff` were already reachable, because htssafe.h is header-only and proxytrack.c already calls `strcpybuff` today. Only `hts_lowcase()` was out of reach, and htsdate.c carries a short static fold rather than dragging htslib.c into the proxy link.

`fuzz-arc` also compiles store.c outside proxytrack, so it now resolves the parser from the static libhttrack, the way it already resolves coucal and md5. Built with `--enable-fuzzers --disable-shared` to confirm it links.

A differential harness ran the old `proxytrack.h` parser and the new shared one over 31 inputs, with zero differences. The corpus covers the three RFC822 forms, two-digit years either side of the `50` pivot, leap days and unparseable junk. It also walks every length from 195 to 205, around the `> 200` rejection. Changing one branch in the new copy alone makes it report one, so the harness is not vacuous.

Expect two things in the diff. The moved body is reformatted, because clang-format-19 treats a new file as entirely changed lines, so this does not read as a pure move. And its French comments are translated, per the tree's rule for code you touch.