### PR TITLE
ProxyTrack sizes its peer-address buffer for the host, then appends the port to it

### DIFF
--- a/src/htsnet.c
+++ b/src/htsnet.c
@@ -50,3 +50,21 @@ HTSNET_API void SOCaddr_inetntoa_(char *namebuf, size_t namebuflen,
     namebuf[0] = '\0';
   }
 }
+
+HTSNET_API hts_boolean SOCaddr_inetntoa_port_(char *namebuf, size_t namebuflen,
+                                              SOCaddr *const ss,
+                                              const char *file,
+                                              const int line) {
+  const size_t reserved = sizeof(":65535") - 1;
+  size_t used;
+
+  assertf_(namebuf != NULL && namebuflen != 0, file, line);
+  namebuf[0] = '\0';
+  if (namebuflen <= reserved)
+    return HTS_FALSE;
+  SOCaddr_inetntoa_(namebuf, namebuflen - reserved, ss, file, line);
+  used = strlen(namebuf);
+  return slcatprintfbuff(
+      namebuf, namebuflen, &used, ":%u",
+      (unsigned int) ntohs(*SOCaddr_sinport_(ss, file, line)));
+}

--- a/src/htsnet.h
+++ b/src/htsnet.h
@@ -309,6 +309,30 @@ HTSNET_API void SOCaddr_inetntoa_(char *namebuf, size_t namebuflen,
 #define SOCaddr_inetntoa(namebuf, namebuflen, ss)                              \
   SOCaddr_inetntoa_(namebuf, namebuflen, &(ss), __FILE__, __LINE__)
 
+/** Capacity for the numeric host of a SOCaddr: the longest IPv6 text, plus the
+    scope id getnameinfo needs room for even though SOCaddr_inetntoa strips
+    it. */
+#define SOCADDR_INETNTOA_SIZE                                                  \
+  sizeof("ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255%4294967295")
+
+/** Capacity for "host:port". The host alone can fill whatever it is given, so
+    the port needs room of its own on top of it. */
+#define SOCADDR_INETNTOA_PORT_SIZE                                             \
+  (SOCADDR_INETNTOA_SIZE + sizeof(":65535") - 1)
+
+/** Write "host:port" for ss into namebuf (capacity namebuflen), capping the
+    host so the port always fits. Clips instead of aborting, because the address
+    is a peer's. HTS_FALSE when namebuflen had no room for the port; a caller
+    sizing on SOCADDR_INETNTOA_PORT_SIZE cannot see that. Out of line for the
+    same reason SOCaddr_inetntoa_ is. */
+HTSNET_API hts_boolean SOCaddr_inetntoa_port_(char *namebuf, size_t namebuflen,
+                                              SOCaddr *const ss,
+                                              const char *file, const int line);
+
+/** "host:port" of ss into namebuf (capacity namebuflen). */
+#define SOCaddr_inetntoa_port(namebuf, namebuflen, ss)                         \
+  SOCaddr_inetntoa_port_(namebuf, namebuflen, &(ss), __FILE__, __LINE__)
+
 /** Single-char family tag: '1' for IPv4, '2' otherwise (used in the cache). */
 #define SOCaddr_getproto(ss)                                                   \
   (SOCaddr_size(ss) == sizeof(struct sockaddr_in) ? '1' : '2')

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5825,15 +5825,19 @@ static void st_addrport_longest(SOCaddr *addr, int family, unsigned int port) {
 }
 
 /* The formatter proxytrack's getip() relies on (#1493). */
-static void st_addrport_case(int family, const char *expected) {
+static void st_addrport_case(int family, unsigned int port,
+                             const char *expected) {
   const size_t guard = 16;
+  const size_t reserved = sizeof(":65535") - 1;
   const size_t full = SOCADDR_INETNTOA_PORT_SIZE;
   char *arena = malloct(full + guard);
+  char wantport[8];
   SOCaddr addr;
   size_t size;
 
   assertf(arena != NULL);
-  st_addrport_longest(&addr, family, 65535);
+  st_addrport_longest(&addr, family, port);
+  snprintf(wantport, sizeof(wantport), ":%u", port);
 
   /* the declared capacity holds the longest host AND the longest port */
   memset(arena, 'Z', full + guard);
@@ -5844,11 +5848,21 @@ static void st_addrport_case(int family, const char *expected) {
   /* no capacity is written past, and none silently drops the port, which is
      what a host let loose on the whole buffer does */
   for (size = 1; size <= full; size++) {
+    const hts_boolean ok = SOCaddr_inetntoa_port(arena, size, addr);
+
     memset(arena, 'Z', full + guard);
     (void) SOCaddr_inetntoa_port(arena, size, addr);
+    /* before strlen, or a run with no terminator reads off the allocation */
+    assertf(memchr(arena, '\0', size) != NULL);
     assertf(strlen(arena) < size);
     assertf(st_addrport_intact(arena + size, full + guard - size));
-    assertf(size <= sizeof(":65535") - 1 || strstr(arena, ":65535") != NULL);
+    if (size <= reserved) {
+      /* too small for the port at all: refuse, rather than clip it to "6553" */
+      assertf(!ok);
+      assertf(arena[0] == '\0');
+    } else {
+      assertf(strstr(arena, wantport) != NULL);
+    }
   }
   freet(arena);
 }
@@ -5857,9 +5871,14 @@ static int st_addrport(httrackp *opt, int argc, char **argv) {
   (void) opt;
   (void) argc;
   (void) argv;
-  st_addrport_case(AF_INET, "255.255.255.255:65535");
+  st_addrport_case(AF_INET, 65535, "255.255.255.255:65535");
+  /* 65535 is byte-swap invariant, so a dropped ntohs() needs this one */
+  st_addrport_case(AF_INET, 8080, "255.255.255.255:8080");
 #if HTS_INET6 != 0
-  st_addrport_case(AF_INET6, "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff:65535");
+  st_addrport_case(AF_INET6, 65535,
+                   "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff:65535");
+  st_addrport_case(AF_INET6, 8080,
+                   "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff:8080");
 #endif
   printf("addrport self-test OK\n");
   return 0;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5793,6 +5793,78 @@ static int st_scantoken(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* Is the guard still the poison the case wrote? Poison, not zero: a stray
+   terminator would read as untouched. */
+static hts_boolean st_addrport_intact(const char *p, size_t n) {
+  size_t i;
+
+  for (i = 0; i < n; i++) {
+    if (p[i] != 'Z')
+      return HTS_FALSE;
+  }
+  return HTS_TRUE;
+}
+
+/* The longest text its family has: 255.255.255.255, or the IPv6 address
+   inet_ntop cannot compress. */
+static void st_addrport_longest(SOCaddr *addr, int family, unsigned int port) {
+  (void) family;
+  memset(addr, 0, sizeof(*addr));
+#if HTS_INET6 != 0
+  if (family == AF_INET6) {
+    addr->m_addr.in6.sin6_family = AF_INET6;
+    memset(&addr->m_addr.in6.sin6_addr, 0xff,
+           sizeof(addr->m_addr.in6.sin6_addr));
+  } else
+#endif
+  {
+    addr->m_addr.in.sin_family = AF_INET;
+    memset(&addr->m_addr.in.sin_addr, 0xff, sizeof(addr->m_addr.in.sin_addr));
+  }
+  SOCaddr_initport(*addr, port);
+}
+
+/* The formatter proxytrack's getip() relies on (#1493). */
+static void st_addrport_case(int family, const char *expected) {
+  const size_t guard = 16;
+  const size_t full = SOCADDR_INETNTOA_PORT_SIZE;
+  char *arena = malloct(full + guard);
+  SOCaddr addr;
+  size_t size;
+
+  assertf(arena != NULL);
+  st_addrport_longest(&addr, family, 65535);
+
+  /* the declared capacity holds the longest host AND the longest port */
+  memset(arena, 'Z', full + guard);
+  assertf(SOCaddr_inetntoa_port(arena, full, addr));
+  assertf(strcmp(arena, expected) == 0);
+  assertf(st_addrport_intact(arena + full, guard));
+
+  /* no capacity is written past, and none silently drops the port, which is
+     what a host let loose on the whole buffer does */
+  for (size = 1; size <= full; size++) {
+    memset(arena, 'Z', full + guard);
+    (void) SOCaddr_inetntoa_port(arena, size, addr);
+    assertf(strlen(arena) < size);
+    assertf(st_addrport_intact(arena + size, full + guard - size));
+    assertf(size <= sizeof(":65535") - 1 || strstr(arena, ":65535") != NULL);
+  }
+  freet(arena);
+}
+
+static int st_addrport(httrackp *opt, int argc, char **argv) {
+  (void) opt;
+  (void) argc;
+  (void) argv;
+  st_addrport_case(AF_INET, "255.255.255.255:65535");
+#if HTS_INET6 != 0
+  st_addrport_case(AF_INET6, "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff:65535");
+#endif
+  printf("addrport self-test OK\n");
+  return 0;
+}
+
 /* The pattern answer n owes (adr, fil): a second implementation of the builder,
    with no bound of its own, to compare it against. */
 static void wizardfilter_want(htsbuff *w, int n, const char *adr,
@@ -12954,6 +13026,9 @@ static const struct selftest_entry {
     {"scantoken", "",
      "option-string token copy is bounded and reports a refusal (#1271)",
      st_scantoken},
+    {"addrport", "",
+     "\"host:port\" of a peer address is bounded and complete (#1493)",
+     st_addrport},
     {"simplify", "<path>", "collapse ./ and ../ in a path", st_simplify},
     {"expandhome", "<path>", "expand a leading ~/ into $HOME", st_expandhome},
     {"stripquery", "", "--strip-query pattern/key stripping self-test",

--- a/src/proxy/proxytrack.c
+++ b/src/proxy/proxytrack.c
@@ -253,21 +253,13 @@ static int gethost(const char *hostname, SOCaddr * server) {
 
 static String getip(SOCaddr * server) {
   String s = STRING_EMPTY;
-
-#if HTS_INET6==0
-  unsigned int sizeMax = sizeof("999.999.999.999:65535");
-#else
-  unsigned int sizeMax = sizeof("ffff:ffff:ffff:ffff:ffff:ffff:ffff:65535");
-#endif
-  char *dotted = malloc(sizeMax + 1);
-  unsigned short port = ntohs(SOCaddr_sinport(*server));
+  char *dotted = malloct(SOCADDR_INETNTOA_PORT_SIZE);
 
   if (dotted == NULL) {
     proxytrack_print_log(CRITICAL, "memory exhausted");
     return s;
   }
-  SOCaddr_inetntoa(dotted, sizeMax, *server);
-  sprintf(dotted + strlen(dotted), ":%d", port);
+  SOCaddr_inetntoa_port(dotted, SOCADDR_INETNTOA_PORT_SIZE, *server);
   StringAttach(&s, &dotted);
   return s;
 }

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -1146,15 +1146,21 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
               ZIP_READFIELD_STRING(line, value, "X-Save", previous_save_,
                                    sizeof(previous_save_));
               if (line[0] != '\0') {
-                int len = r->headers ? ((int) strlen(r->headers)) : 0;
-                int nlen =
-                  (int) (strlen(line) + 2 + strlen(value) + sizeof("\r\n") + 1);
-                r->headers = realloc(r->headers, len + nlen);
-                r->headers[len] = '\0';
-                strcat(r->headers, line);
-                strcat(r->headers, ": ");
-                strcat(r->headers, value);
-                strcat(r->headers, "\r\n");
+                const int len = r->headers ? ((int) strlen(r->headers)) : 0;
+                /* one byte more than the four appends below write */
+                const int nlen = (int) (strlen(line) + 2 + strlen(value) +
+                                        sizeof("\r\n") + 1);
+                char *const grown = realloct(r->headers, len + nlen);
+
+                /* keep the headers read so far rather than losing them */
+                if (grown != NULL) {
+                  r->headers = grown;
+                  r->headers[len] = '\0';
+                  strcat(r->headers, line);
+                  strcat(r->headers, ": ");
+                  strcat(r->headers, value);
+                  strcat(r->headers, "\r\n");
+                }
               }
             }
           } while (offset < readSizeHeader && !lineEof);
@@ -2331,15 +2337,21 @@ static PT_Element PT_ReadCache__Arc_u(PT_Index index_, const char *url,
               HTTP_READFIELD_STRING(line, value, "Content-Disposition",
                                     r->cdispo, sizeof(r->cdispo));
               if (line[0] != '\0') {
-                int len = r->headers ? ((int) strlen(r->headers)) : 0;
-                int nlen =
-                  (int) (strlen(line) + 2 + strlen(value) + sizeof("\r\n") + 1);
-                r->headers = realloc(r->headers, len + nlen);
-                r->headers[len] = '\0';
-                strcat(r->headers, line);
-                strcat(r->headers, ": ");
-                strcat(r->headers, value);
-                strcat(r->headers, "\r\n");
+                const int len = r->headers ? ((int) strlen(r->headers)) : 0;
+                /* one byte more than the four appends below write */
+                const int nlen = (int) (strlen(line) + 2 + strlen(value) +
+                                        sizeof("\r\n") + 1);
+                char *const grown = realloct(r->headers, len + nlen);
+
+                /* keep the headers read so far rather than losing them */
+                if (grown != NULL) {
+                  r->headers = grown;
+                  r->headers[len] = '\0';
+                  strcat(r->headers, line);
+                  strcat(r->headers, ": ");
+                  strcat(r->headers, value);
+                  strcat(r->headers, "\r\n");
+                }
               }
             }
           }

--- a/tests/387_proxy-addr-port-overflow.test
+++ b/tests/387_proxy-addr-port-overflow.test
@@ -1,11 +1,10 @@
 #!/bin/bash
 #
+# ProxyTrack logs its peers as "host:port" and sized that buffer for the host
+# alone, so a full-form IPv6 client ran the port past the end of it (#1493).
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
-
-# ProxyTrack logs its peers as "host:port" and sized that buffer for the host
-# alone, so a full-form IPv6 client ran the port past the end of it (#1493).
 
 assert_selftest "addrport self-test OK" addrport

--- a/tests/387_proxy-addr-port-overflow.test
+++ b/tests/387_proxy-addr-port-overflow.test
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+# ProxyTrack logs its peers as "host:port" and sized that buffer for the host
+# alone, so a full-form IPv6 client ran the port past the end of it (#1493).
+
+assert_selftest "addrport self-test OK" addrport


### PR DESCRIPTION
`getip()` logs a peer as "host:port" out of a heap block of 42 bytes, `sizeof("ffff:ffff:ffff:ffff:ffff:ffff:ffff:65535") + 1`. It then hands that whole size to `SOCaddr_inetntoa` as the host capacity. `getnameinfo` can fill it. An IPv6 client whose address has no zero run to compress writes 39 characters, and the `sprintf` after it puts ":65535" at offset 39. That is four bytes past the block. The address is the peer's, read from `accept()` at proxytrack.c:1361 and from the ICP datagram source at :1725.

The arithmetic moves into `SOCaddr_inetntoa_port()`, next to `SOCaddr_inetntoa` in htsnet.h. It reserves the port's room before it formats the host, then appends through `slcatprintfbuff`. An undersized buffer now clips the text instead of smashing the heap. It clips rather than aborts because a peer address is wire input. `strcatbuff` would trade a memory smash for a crash on someone else's packet. `SOCADDR_INETNTOA_SIZE` also gains room for the scope id `getnameinfo` needs even though `SOCaddr_inetntoa` strips it, so a link-local peer no longer comes back empty.

That exports one new symbol from libhttrack, `SOCaddr_inetntoa_port_`. Nothing existing changed shape. The helper is out of line because 381_public-headers-no-config compiles the installed headers with no library to link against.

The same block held the second bug the issue names. `PT_ReadCache__New_u` and `PT_ReadCache__Arc_u` both ran `r->headers = realloc(r->headers, len + nlen)` and wrote through the result on the next line. An allocation failure therefore took a NULL write and leaked every header the entry had accumulated. Both now realloc into a local and keep the old buffer when it fails.

The other 17 raw string calls in `src/proxy` all hold. Four are worth naming. `store.c:1796` copies a decoded URL that has to be a key of the old cache's hash. `store.c:1661` builds those keys in a buffer the size of the destination. `store.c:1190` and `:1884` are guarded by `len < 128` into a `char[128 + 2]`. `proxytrack.h:297` is guarded by `strlen(s) > 200` into a `char[256]`.

tests/387 drives `httrack -#test=addrport`. It formats the longest IPv4 and IPv6 addresses at every capacity from 1 up to the declared one, against a poisoned guard past the end. Restoring the old shape aborts it at the capacity where the host fills the buffer. Dropping the reservation alone, keeping the bounded append, aborts it on the port that then goes missing.

Closes #1493
