### PR TITLE
An ICP reply can carry the previous client's datagram back to a different peer

### DIFF
--- a/src/proxy/proxytrack.c
+++ b/src/proxy/proxytrack.c
@@ -1546,7 +1546,9 @@ static int proxytrack_start_ICP(PT_Indexes indexes, T_SOC soc) {
         unsigned int Request_Number = READ_NET32(&buffer[4]); /* Session ID */
         unsigned char *Payload = &buffer[20];
 
-        buffer[bufferSize] = '\0';      /* Ensure payload is NULL terminated */
+        /* Terminate at the datagram, not at the buffer: the payload's strlen()
+           otherwise runs into the previous one and the reply echoes it back. */
+        memset(&buffer[n], 0, (size_t) (bufferSize + 1 - n));
         if (Message_Length <= bufferSize - 20) {
           if (Opcode >= ICP_OP_MIN && Opcode <= ICP_OP_MAX) {
             if (Version == 2) {

--- a/tests/388_local-proxytrack-icp-leak.test
+++ b/tests/388_local-proxytrack-icp-leak.test
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# An ICP reply echoes the queried URL back. proxytrack terminated the receive
+# buffer at its end rather than at the datagram, so a query whose URL runs to
+# the last byte took its terminator from whatever the previous datagram left,
+# and the reply carried that other client's bytes back (#1493).
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+# shellcheck source=tests/arclib.sh
+. "${0%"${0##*/}"}./arclib.sh"
+
+python=$(find_python) || skip "python3 missing"
+
+dir=$(mktemp -d)
+ptpid=
+cleanup() {
+    stop_server "$ptpid"
+    rm -rf "$dir"
+}
+cleanup_push cleanup
+
+printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 5\r\n\r\n' >"$dir/hdr"
+printf 'hello' >"$dir/body"
+{
+    arc_filedesc
+    arc_record http://example.com/page.html text/html 200 "$dir/hdr" "$dir/body"
+} >"$dir/in.arc"
+
+launch_proxytrack() {
+    proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$dir/in.arc" >"$ptlog" 2>&1 &
+    ptpid=$!
+}
+start_proxytrack "$dir/pt" launch_proxytrack
+
+"$python" - "$icpport" <<'PY' || fail_dump "the ICP reply carried the previous datagram's bytes" "$ptlog"
+import socket, struct, sys
+
+port = int(sys.argv[1])
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.settimeout(10)
+
+# ICP header: opcode, version, message length, request number, 12 more bytes.
+# The payload's first four bytes are the requester address; the URL follows.
+def query(url):
+    payload = b"\x00" * 4 + url  # no terminator: the datagram ends with the URL
+    return struct.pack("!BBHI", 1, 2, 20 + len(payload), 0x1234) + b"\x00" * 12 + payload
+
+secret = b"S" * 4096
+sock.sendto(b"\x01\x02" + secret, ("127.0.0.1", port))
+try:
+    sock.recvfrom(65535)  # drain its reply, so the next recv is ours
+except socket.timeout:
+    pass
+
+sock.sendto(query(b"http://example.com/page.html"), ("127.0.0.1", port))
+try:
+    reply, _ = sock.recvfrom(65535)
+except socket.timeout:
+    print("no ICP reply", file=sys.stderr)
+    sys.exit(1)
+
+echoed = reply[20:].split(b"\x00")[0]
+if echoed != b"http://example.com/page.html":
+    print("echoed %d bytes, %d of them from the previous datagram: %r"
+          % (len(echoed), echoed.count(b"S"), echoed[:64]), file=sys.stderr)
+    sys.exit(1)
+PY
+
+echo "OK: an unterminated ICP query echoes its own URL and nothing else"


### PR DESCRIPTION
Closes #1496.

proxytrack's ICP server reuses one 16 KB receive buffer and terminated it at the buffer's end, not at the datagram. So `strlen()` on the queried URL ran into whatever the previous datagram left. The reply echoes that URL back, so one client's bytes reached another. It now clears the buffer from the received length on.

Reproduced against `b6a9fb48` before the fix. One client sends 4096 bytes of `S`. A second queries `http://example.com/page.html` in a datagram ending with the URL, and the reply comes back 4074 bytes carrying 4046 of them. On the first datagram after startup the tail is uninitialised heap instead.

The read stayed inside the allocation, so neither ASan nor the suite could see it. Test 388 sends exactly that pair and fails on the shipped code with the leaked bytes in its diagnostic.

It clears from `n` rather than writing a single `buffer[n] = '\0'`. The URL lives at offset 24. A datagram of 20 to 23 bytes would leave that offset past the terminator, reading stale bytes again.
