### PR TITLE
Release 3.50.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.71])
 
-AC_INIT([httrack], [3.50.0], [roche+packaging@httrack.com], [httrack], [https://www.httrack.com/])
+AC_INIT([httrack], [3.50.1], [roche+packaging@httrack.com], [httrack], [https://www.httrack.com/])
 AC_COPYRIGHT([
 HTTrack Website Copier, Offline Browser for Windows and Unix
 Copyright (C) 1998-2015 Xavier Roche and other contributors
@@ -32,6 +32,9 @@ AC_CONFIG_HEADERS(config.h)
 # header we can install without handing a consumer our PACKAGE_* and HAVE_*.
 AC_CONFIG_HEADERS([htsfeatures.h:src/htsfeatures.h.in])
 AM_INIT_AUTOMAKE([subdir-objects])
+# 3:20:0: revision-only bump. #1495 added an export (SOCaddr_inetntoa_port_) beside
+# SOCaddr_inetntoa_, the same shape as 3:11:0; no installed struct moved and nothing
+# went away.
 # 3:19:0: revision-only bump for the 3.50.0 release. config.h left the installed
 # header set for htsfeatures.h, which carries the same macro values. No installed
 # struct changed layout and no export came or went.
@@ -66,7 +69,7 @@ AM_INIT_AUTOMAKE([subdir-objects])
 # moves nothing). Soname stays .so.3: HTTrackQt is the only consumer of the installed
 # headers, so a libhttrack4 rename isn't worth it.
 # (3:0:0 was the htsblk mime-buffer widening, the ABI break that moved .so.2 -> .so.3.)
-VERSION_INFO="3:19:0"
+VERSION_INFO="3:20:0"
 AM_MAINTAINER_MODE
 AC_USE_SYSTEM_EXTENSIONS
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,6 @@
 httrack (3.50.1-1) unstable; urgency=medium
 
-  * New upstream release.  Bug fixes only: two faults in proxytrack that
-    anything able to reach its ICP port could trigger, cached dates read as
-    local time, a make install that failed with ELOOP under some --docdir
-    values, and the macOS Dock icon left bouncing after WebHTTrack quit.
-    Full list in history.txt.
+  * New upstream release, bug fixes only.  Full list in history.txt.
 
  -- Xavier Roche <xavier@debian.org>  Wed, 02 Sep 2026 15:00:26 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+httrack (3.50.1-1) unstable; urgency=medium
+
+  * New upstream release.  Bug fixes only: two faults in proxytrack that
+    anything able to reach its ICP port could trigger, cached dates read as
+    local time, a make install that failed with ELOOP under some --docdir
+    values, and the macOS Dock icon left bouncing after WebHTTrack quit.
+    Full list in history.txt.
+
+ -- Xavier Roche <xavier@debian.org>  Wed, 02 Sep 2026 15:00:26 +0200
+
 httrack (3.50.0-2) unstable; urgency=medium
 
   * Rebuild with a changelog timestamp that precedes the build.  The 3.50.0-1

--- a/history.txt
+++ b/history.txt
@@ -4,6 +4,14 @@ HTTrack Website Copier release history:
 
 This file lists all changes and fixes that have been made for HTTrack
 
+3.50-1
++ Fixed: ProxyTrack could hand one client the tail of another client's request, and a peer's own address could run past the buffer that logs it. Both are reachable by anything that can reach its ICP port (#1495, #1497)
++ Fixed: ProxyTrack read the dates in a cache as local time, so on a host outside UTC a WebDAV listing showed every entry shifted by the machine's own offset (#1491)
++ Fixed: quitting WebHTTrack on macOS left its icon bouncing in the Dock until a force quit (#1479)
++ Fixed: make install died with ELOOP when --docdir sat under the data directory, and a --datadir spelled with "//" left the served UI's link pointing out of a staging tree at the build host (#1488, #1489)
++ Fixed: the crash symbolizer needs <spawn.h>, which Android ships only from API 28, so a build without that header now compiles it out and keeps the raw trace (#1487)
++ Changed: multiple internal build, test and CI improvements (#1482, #1483, #1484, #1486, #1490, #1494)
+
 3.50-0
 + New: this is the engine the Windows and Android front ends ship on. WinHTTrack had not been released since 3.49-2 in May 2017, so a Windows user coming from it gets everything listed under 3.49-3 to 3.49-25 below in one step. The largest of those: HTTPS against modern servers, SOCKS5 and CONNECT proxies, Brotli and Zstandard, files past 2 GB, Windows paths past 260 characters, accented and non-Latin project names and paths, WARC output, --sitemap, --single-file, --changes and --host-alias, and an --update that keeps a good local copy when the server answers with an error
 + New: --disable-example-libs skips the ten example plugins four distributions used to un-install by hand (#1470)

--- a/history.txt
+++ b/history.txt
@@ -5,7 +5,8 @@ HTTrack Website Copier release history:
 This file lists all changes and fixes that have been made for HTTrack
 
 3.50-1
-+ Fixed: ProxyTrack could hand one client the tail of another client's request, and a peer's own address could run past the buffer that logs it. Both are reachable by anything that can reach its ICP port (#1495, #1497)
++ Changed: a bug-fix release with no new features. A normal mirroring run behaves exactly as 3.50-0 did, and the fixes below are in ProxyTrack, in where make install puts its files, and in WebHTTrack on macOS
++ Fixed: ProxyTrack could hand one client the tail of another client's request over its ICP port, and an address could run past the buffer that logs it. The second fires on an ICP peer's address, or on the host's own when that is a full-form IPv6 (#1495, #1497)
 + Fixed: ProxyTrack read the dates in a cache as local time, so on a host outside UTC a WebDAV listing showed every entry shifted by the machine's own offset (#1491)
 + Fixed: quitting WebHTTrack on macOS left its icon bouncing in the Dock until a force quit (#1479)
 + Fixed: make install died with ELOOP when --docdir sat under the data directory, and a --datadir spelled with "//" left the served UI's link pointing out of a staging tree at the build host (#1488, #1489)

--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -56,8 +56,9 @@
     <release version="3.50.1" date="2026-09-02">
       <description>
         <ul>
+          <li>A bug-fix release with no new features. A mirroring run behaves exactly as 3.50.0 did</li>
           <li>Quitting WebHTTrack on macOS no longer leaves its icon bouncing in the Dock</li>
-          <li>Fixes in the mirror engine and in ProxyTrack, two of them for faults another machine on the network could trigger</li>
+          <li>In a packaged install, the Help link in these pages reaches the manual again</li>
         </ul>
       </description>
     </release>

--- a/html/server/div/com.httrack.WebHTTrack.metainfo.xml
+++ b/html/server/div/com.httrack.WebHTTrack.metainfo.xml
@@ -53,6 +53,14 @@
   <content_rating type="oars-1.1"/>
   <!-- Newest first; tests/01_engine-version-macros.test enforces it. -->
   <releases>
+    <release version="3.50.1" date="2026-09-02">
+      <description>
+        <ul>
+          <li>Quitting WebHTTrack on macOS no longer leaves its icon bouncing in the Dock</li>
+          <li>Fixes in the mirror engine and in ProxyTrack, two of them for faults another machine on the network could trigger</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.50.0" date="2026-09-01">
       <description>
         <ul>

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -43,8 +43,8 @@ Please visit our Website: http://www.httrack.com
    configure.ac, decoupled from these). VERSION is the display form, VERSIONID
    the dotted numeric form, AFF_VERSION the short form shown in footers,
    LIB_VERSION the data/cache format generation. */
-#define HTTRACK_VERSION "3.50-0"
-#define HTTRACK_VERSIONID "3.50.0"
+#define HTTRACK_VERSION "3.50-1"
+#define HTTRACK_VERSIONID "3.50.1"
 #define HTTRACK_AFF_VERSION "3.x"
 #define HTTRACK_LIB_VERSION "2.0"
 

--- a/src/version.rc
+++ b/src/version.rc
@@ -17,8 +17,8 @@
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-  FILEVERSION 3, 50, 0, 0
-  PRODUCTVERSION 3, 50, 0, 0
+  FILEVERSION 3, 50, 1, 0
+  PRODUCTVERSION 3, 50, 1, 0
   FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
 #ifdef _DEBUG
   FILEFLAGS VS_FF_DEBUG
@@ -35,12 +35,12 @@ BEGIN
     BEGIN
       VALUE "CompanyName", "Xavier Roche"
       VALUE "FileDescription", VER_FILE_DESCRIPTION
-      VALUE "FileVersion", "3.50.0"
+      VALUE "FileVersion", "3.50.1"
       VALUE "InternalName", VER_ORIGINAL_FILENAME
       VALUE "LegalCopyright", "Copyright (C) 1998-2026 Xavier Roche and other contributors. GNU GPL v3 or later."
       VALUE "OriginalFilename", VER_ORIGINAL_FILENAME
       VALUE "ProductName", "HTTrack Website Copier"
-      VALUE "ProductVersion", "3.50-0"
+      VALUE "ProductVersion", "3.50-1"
     END
   END
   BLOCK "VarFileInfo"


### PR DESCRIPTION
3.50.0 shipped on 1 September, and 14 commits have landed since. Two of them fix faults in ProxyTrack that a peer on its ICP port can trigger. One also fires from the host's own address on the proxy port. That is why this goes out now.

#1495 added a new export, `SOCaddr_inetntoa_port_`, so `VERSION_INFO` takes a revision-only bump to `3:20:0`. That follows `3:11:0`, which did the same when `SOCaddr_inetntoa_` stopped being an inline and became an export. Strict libtool would say `4:0:1`, which lands on the same soname, but this project pins `age=0`. Nothing changed shape and nothing went away, so the soname stays `.so.3` and no Debian rename follows.

`debian/changelog` carries no Debian-specific item. #1485 is the only commit since the tag that touched `debian/`, and the entry it added is the 3.50.0-2 one already in the file. So this stanza is the upstream overview and nothing else.

The suite is 416 tests, 402 passing, none failing. The built binary reports 3.50-1, and appstreamcli validates the metainfo.