### PR TITLE
Only Fedora and Termux build master the way a packager does

### DIFF
--- a/.github/actions/dist-tarball/action.yml
+++ b/.github/actions/dist-tarball/action.yml
@@ -1,0 +1,40 @@
+# Every canary that feeds a downstream recipe hands it the tarball we publish,
+# built here rather than by the container's own autotools.
+name: release tarball
+description: Build the make dist tarball a packager downloads, from a checked-out tree.
+
+inputs:
+  path:
+    description: Directory holding the checkout
+    required: false
+    default: httrack
+
+outputs:
+  version:
+    description: HTTRACK_VERSIONID the tarball was built from
+    value: ${{ steps.dist.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install autotools
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
+        sudo apt-get install -y --no-install-recommends \
+          build-essential autoconf automake libtool autoconf-archive \
+          zlib1g-dev libssl-dev
+
+    - name: Build the tarball a packager would get
+      id: dist
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      run: |
+        set -euo pipefail
+        ./bootstrap
+        ./configure
+        make dist
+        ver=$(sed -n 's/.*HTTRACK_VERSIONID "\([^"]*\)".*/\1/p' src/htsglobal.h)
+        test -f "httrack-$ver.tar.gz"
+        echo "version=$ver" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/alpine-abuild.yml
+++ b/.github/workflows/alpine-abuild.yml
@@ -1,0 +1,106 @@
+# Alpine is the only downstream that builds us against musl, so a glibc-ism we
+# add compiles everywhere else and breaks only here. 3.50.0 shipped a missing
+# spawn.h (#1487) and an install that looped on an ordinary --docdir (#1488),
+# and both were visible only from a downstream build. Their APKBUILD sets
+# options="!check", so this proves the compile and the install rather than the
+# suite. Their tree, so a red here can be theirs to fix, which is why it blocks
+# nothing.
+name: alpine abuild canary
+
+on:
+  schedule:
+    - cron: "31 5 * * 5"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  abuild:
+    name: abuild against Alpine's APKBUILD
+    # Scheduled workflows run per-fork independently; skip anywhere but upstream.
+    if: github.repository == 'xroche/httrack'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          path: httrack
+
+      - name: Install autotools
+        run: |
+          set -euo pipefail
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
+          sudo apt-get install -y --no-install-recommends \
+            build-essential autoconf automake libtool autoconf-archive \
+            zlib1g-dev libssl-dev
+
+      # Generated on the host, so the container consumes the same bytes a
+      # packager downloads rather than a tarball Alpine's autotools rebuilt.
+      - name: Build the tarball a packager would get
+        run: |
+          set -euo pipefail
+          cd httrack
+          ./bootstrap
+          ./configure
+          make dist
+          ver=$(sed -n 's/.*HTTRACK_VERSIONID "\([^"]*\)".*/\1/p' src/htsglobal.h)
+          test -f "httrack-$ver.tar.gz"
+          echo "ver=$ver" >> "$GITHUB_ENV"
+
+      - name: Fetch their APKBUILD and point it at that tarball
+        run: |
+          set -euo pipefail
+          # httrack sits in testing/, not community/. Their GitLab answers a runner
+          # with a 418, so read the same file from cgit.
+          mkdir -p work/aports/testing/httrack
+          cd work/aports/testing/httrack
+          curl -fsSL --retry 3 -o APKBUILD \
+            https://git.alpinelinux.org/aports/plain/testing/httrack/APKBUILD
+          cp "$GITHUB_WORKSPACE/httrack/httrack-$ver.tar.gz" .
+          # abuild resolves a bare filename in source= against the APKBUILD's
+          # own directory, and abuild checksum then re-signs it below.
+          sed -i -e "s/^pkgver=.*/pkgver=$ver/" \
+            -e 's|^source=.*|source="httrack-$pkgver.tar.gz"|' APKBUILD
+          # A sed that matched nothing leaves the recipe on the released
+          # tarball, and the canary then passes without building this tree.
+          grep -qx "pkgver=$ver" APKBUILD
+          grep -qx 'source="httrack-$pkgver.tar.gz"' APKBUILD
+
+      - name: abuild, then install what it produced
+        timeout-minutes: 30
+        run: |
+          set -euo pipefail
+          cat >work/canary.sh <<'EOF'
+          set -eu
+          # abuild resolves makedepends through its own apk call, which needs the
+          # index --no-cache would have thrown away.
+          apk update
+          apk add alpine-sdk
+          adduser -D builder
+          addgroup builder abuild
+          cp -r /work/aports /home/builder/aports
+          chown -R builder:builder /home/builder/aports
+          # abuild refuses to run as root, and REPODEST is unset in the image.
+          su - builder -c 'abuild-keygen -a -n &&
+            echo "REPODEST=$HOME/packages" >>$HOME/.abuild/abuild.conf'
+          # abuild indexes and verifies what it just signed, so the fresh key
+          # has to be trusted before the build reaches that step.
+          cp /home/builder/.abuild/*.rsa.pub /etc/apk/keys/
+          su - builder -c 'cd ~/aports/testing/httrack &&
+            abuild checksum && abuild -r'
+          # Installing and running it is the assertion: abuild exiting 0 having
+          # packaged nothing runnable is the failure this canary is here for.
+          pkg=$(find /home/builder/packages -name 'httrack-[0-9]*.apk')
+          test -n "$pkg"
+          # Their httrack depends on the httrack-doc subpackage, so it installs
+          # from the signed index rather than from the one file.
+          apk add --repository /home/builder/packages/testing httrack
+          httrack --version
+          EOF
+          docker run --rm -v "$PWD/work:/work" alpine:latest \
+            sh /work/canary.sh 2>&1 | tee build.log
+
+      - name: Print the log on failure
+        if: failure()
+        run: tail -n 120 build.log 2>/dev/null || true

--- a/.github/workflows/alpine-abuild.yml
+++ b/.github/workflows/alpine-abuild.yml
@@ -8,6 +8,8 @@
 name: alpine abuild canary
 
 on:
+  push:
+    branches: [distro-build-canaries]  # TEMP
   schedule:
     - cron: "31 5 * * 5"
   workflow_dispatch:
@@ -27,45 +29,35 @@ jobs:
           submodules: recursive
           path: httrack
 
-      - name: Install autotools
-        run: |
-          set -euo pipefail
-          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
-          sudo apt-get install -y --no-install-recommends \
-            build-essential autoconf automake libtool autoconf-archive \
-            zlib1g-dev libssl-dev
-
-      # Generated on the host, so the container consumes the same bytes a
-      # packager downloads rather than a tarball Alpine's autotools rebuilt.
-      - name: Build the tarball a packager would get
-        run: |
-          set -euo pipefail
-          cd httrack
-          ./bootstrap
-          ./configure
-          make dist
-          ver=$(sed -n 's/.*HTTRACK_VERSIONID "\([^"]*\)".*/\1/p' src/htsglobal.h)
-          test -f "httrack-$ver.tar.gz"
-          echo "ver=$ver" >> "$GITHUB_ENV"
+      - uses: ./httrack/.github/actions/dist-tarball
+        id: dist
 
       - name: Fetch their APKBUILD and point it at that tarball
+        env:
+          ver: ${{ steps.dist.outputs.version }}
         run: |
           set -euo pipefail
-          # httrack sits in testing/, not community/. Their GitLab answers a runner
-          # with a 418, so read the same file from cgit.
+          # httrack sits in testing/, not community/. Their GitLab answers a
+          # runner with a 418, so read the same file from cgit.
           mkdir -p work/aports/testing/httrack
           cd work/aports/testing/httrack
           curl -fsSL --retry 3 -o APKBUILD \
             https://git.alpinelinux.org/aports/plain/testing/httrack/APKBUILD
           cp "$GITHUB_WORKSPACE/httrack/httrack-$ver.tar.gz" .
+          sha=$(sha512sum "httrack-$ver.tar.gz" | cut -d' ' -f1)
           # abuild resolves a bare filename in source= against the APKBUILD's
-          # own directory, and abuild checksum then re-signs it below.
+          # own directory. Pinning the sum here rather than letting abuild
+          # checksum regenerate it is what makes abuild verify our bytes, and
+          # what reds a source entry naming anything else.
           sed -i -e "s/^pkgver=.*/pkgver=$ver/" \
-            -e 's|^source=.*|source="httrack-$pkgver.tar.gz"|' APKBUILD
+            -e 's|^source=.*|source="httrack-$pkgver.tar.gz"|' \
+            -e "/^sha512sums=\"/,/^\"\$/c\\sha512sums=\"$sha  httrack-$ver.tar.gz\"" \
+            APKBUILD
           # A sed that matched nothing leaves the recipe on the released
           # tarball, and the canary then passes without building this tree.
           grep -qx "pkgver=$ver" APKBUILD
           grep -qx 'source="httrack-$pkgver.tar.gz"' APKBUILD
+          grep -qx "sha512sums=\"$sha  httrack-$ver.tar.gz\"" APKBUILD
 
       - name: abuild, then install what it produced
         timeout-minutes: 30
@@ -73,8 +65,8 @@ jobs:
           set -euo pipefail
           cat >work/canary.sh <<'EOF'
           set -eu
-          # abuild resolves makedepends through its own apk call, which needs the
-          # index --no-cache would have thrown away.
+          # abuild resolves makedepends through its own apk call, which needs
+          # the index --no-cache would have thrown away.
           apk update
           apk add alpine-sdk
           adduser -D builder
@@ -84,23 +76,16 @@ jobs:
           # abuild refuses to run as root, and REPODEST is unset in the image.
           su - builder -c 'abuild-keygen -a -n &&
             echo "REPODEST=$HOME/packages" >>$HOME/.abuild/abuild.conf'
-          # abuild indexes and verifies what it just signed, so the fresh key
-          # has to be trusted before the build reaches that step.
+          # abuild indexes and verifies what it just signed.
           cp /home/builder/.abuild/*.rsa.pub /etc/apk/keys/
-          su - builder -c 'cd ~/aports/testing/httrack &&
-            abuild checksum && abuild -r'
+          su - builder -c 'cd ~/aports/testing/httrack && abuild -r'
           # Installing and running it is the assertion: abuild exiting 0 having
           # packaged nothing runnable is the failure this canary is here for.
-          pkg=$(find /home/builder/packages -name 'httrack-[0-9]*.apk')
-          test -n "$pkg"
-          # Their httrack depends on the httrack-doc subpackage, so it installs
-          # from the signed index rather than from the one file.
-          apk add --repository /home/builder/packages/testing httrack
+          set -- /home/builder/packages/testing/x86_64/httrack-[0-9]*.apk
+          test "$#" -eq 1
+          # The file we just built, with the httrack-doc subpackage it depends
+          # on resolved out of the signed index beside it.
+          apk add --repository /home/builder/packages/testing "$1"
           httrack --version
           EOF
-          docker run --rm -v "$PWD/work:/work" alpine:latest \
-            sh /work/canary.sh 2>&1 | tee build.log
-
-      - name: Print the log on failure
-        if: failure()
-        run: tail -n 120 build.log 2>/dev/null || true
+          docker run --rm -v "$PWD/work:/work" alpine:latest sh /work/canary.sh

--- a/.github/workflows/alpine-abuild.yml
+++ b/.github/workflows/alpine-abuild.yml
@@ -8,8 +8,6 @@
 name: alpine abuild canary
 
 on:
-  push:
-    branches: [distro-build-canaries]  # TEMP
   schedule:
     - cron: "31 5 * * 5"
   workflow_dispatch:

--- a/.github/workflows/arch-makepkg.yml
+++ b/.github/workflows/arch-makepkg.yml
@@ -1,0 +1,101 @@
+# Arch builds us with the newest gcc, glibc and openssl any downstream uses, so
+# a header that moved or a warning that became an error surfaces here first.
+# 3.50.0 shipped a missing spawn.h (#1487) and an install that looped on an
+# ordinary --docdir (#1488), and both were visible only from a downstream
+# build. Their PKGBUILD has no check(), so this proves the compile and the
+# install rather than the suite. Their tree, so a red here can be theirs to
+# fix, which is why it blocks nothing.
+name: arch makepkg canary
+
+on:
+  schedule:
+    - cron: "19 4 * * 6"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  makepkg:
+    name: makepkg against Arch's PKGBUILD
+    # Scheduled workflows run per-fork independently; skip anywhere but upstream.
+    if: github.repository == 'xroche/httrack'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          path: httrack
+
+      - name: Install autotools
+        run: |
+          set -euo pipefail
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
+          sudo apt-get install -y --no-install-recommends \
+            build-essential autoconf automake libtool autoconf-archive \
+            zlib1g-dev libssl-dev
+
+      # Generated on the host, so the container consumes the same bytes a
+      # packager downloads rather than a tarball Arch's autotools rebuilt.
+      - name: Build the tarball a packager would get
+        run: |
+          set -euo pipefail
+          cd httrack
+          ./bootstrap
+          ./configure
+          make dist
+          ver=$(sed -n 's/.*HTTRACK_VERSIONID "\([^"]*\)".*/\1/p' src/htsglobal.h)
+          test -f "httrack-$ver.tar.gz"
+          echo "ver=$ver" >> "$GITHUB_ENV"
+
+      - name: Fetch their PKGBUILD and point it at that tarball
+        run: |
+          set -euo pipefail
+          mkdir -p work/pkg
+          cd work/pkg
+          curl -fsSL --retry 3 -o PKGBUILD \
+            https://gitlab.archlinux.org/archlinux/packaging/packages/httrack/-/raw/main/PKGBUILD
+          cp "$GITHUB_WORKSPACE/httrack/httrack-$ver.tar.gz" .
+          sha=$(sha256sum "httrack-$ver.tar.gz" | cut -d' ' -f1)
+          # Their source= brace-expands to the tarball plus its detached
+          # signature, and an unreleased tree has neither a URL nor an .asc.
+          sed -i -e "s/^pkgver=.*/pkgver=$ver/" \
+            -e 's|^source=(.*|source=(${pkgname}-${pkgver}.tar.gz)|' \
+            -e "/^sha256sums=/,/)\$/c\\sha256sums=('$sha')" PKGBUILD
+          # A sed that matched nothing leaves the recipe on the released
+          # tarball, and the canary then passes without building this tree.
+          grep -qx "pkgver=$ver" PKGBUILD
+          grep -qx 'source=(${pkgname}-${pkgver}.tar.gz)' PKGBUILD
+          grep -qx "sha256sums=('$sha')" PKGBUILD
+
+      - name: makepkg, then install what it produced
+        timeout-minutes: 30
+        run: |
+          set -euo pipefail
+          cat >work/canary.sh <<'EOF'
+          set -eu
+          # The image is a weekly snapshot, so anything installed against it
+          # without a refresh is a partial upgrade. Keyring first, or the
+          # refreshed packages fail their signature check.
+          pacman -Sy --noconfirm --needed archlinux-keyring
+          pacman -Su --noconfirm
+          useradd -m builder
+          echo 'builder ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/builder
+          chmod 0440 /etc/sudoers.d/builder
+          cp -r /work/pkg /home/builder/pkg
+          chown -R builder:builder /home/builder/pkg
+          # makepkg refuses to run as root, and -s shells out to sudo pacman.
+          su - builder -c 'cd ~/pkg && makepkg -s --noconfirm'
+          # Installing and running it is the assertion: makepkg exiting 0
+          # having packaged nothing runnable is what this canary is here for.
+          pkg=$(find /home/builder/pkg -name 'httrack-[0-9]*.pkg.tar.*')
+          test -n "$pkg"
+          pacman -U --noconfirm "$pkg"
+          httrack --version
+          EOF
+          docker run --rm -v "$PWD/work:/work" archlinux:base-devel \
+            sh /work/canary.sh 2>&1 | tee build.log
+
+      - name: Print the log on failure
+        if: failure()
+        run: tail -n 120 build.log 2>/dev/null || true

--- a/.github/workflows/arch-makepkg.yml
+++ b/.github/workflows/arch-makepkg.yml
@@ -8,6 +8,8 @@
 name: arch makepkg canary
 
 on:
+  push:
+    branches: [distro-build-canaries]  # TEMP
   schedule:
     - cron: "19 4 * * 6"
   workflow_dispatch:
@@ -27,28 +29,12 @@ jobs:
           submodules: recursive
           path: httrack
 
-      - name: Install autotools
-        run: |
-          set -euo pipefail
-          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
-          sudo apt-get install -y --no-install-recommends \
-            build-essential autoconf automake libtool autoconf-archive \
-            zlib1g-dev libssl-dev
-
-      # Generated on the host, so the container consumes the same bytes a
-      # packager downloads rather than a tarball Arch's autotools rebuilt.
-      - name: Build the tarball a packager would get
-        run: |
-          set -euo pipefail
-          cd httrack
-          ./bootstrap
-          ./configure
-          make dist
-          ver=$(sed -n 's/.*HTTRACK_VERSIONID "\([^"]*\)".*/\1/p' src/htsglobal.h)
-          test -f "httrack-$ver.tar.gz"
-          echo "ver=$ver" >> "$GITHUB_ENV"
+      - uses: ./httrack/.github/actions/dist-tarball
+        id: dist
 
       - name: Fetch their PKGBUILD and point it at that tarball
+        env:
+          ver: ${{ steps.dist.outputs.version }}
         run: |
           set -euo pipefail
           mkdir -p work/pkg
@@ -59,6 +45,7 @@ jobs:
           sha=$(sha256sum "httrack-$ver.tar.gz" | cut -d' ' -f1)
           # Their source= brace-expands to the tarball plus its detached
           # signature, and an unreleased tree has neither a URL nor an .asc.
+          # The pinned sum is what makes makepkg verify our bytes.
           sed -i -e "s/^pkgver=.*/pkgver=$ver/" \
             -e 's|^source=(.*|source=(${pkgname}-${pkgver}.tar.gz)|' \
             -e "/^sha256sums=/,/)\$/c\\sha256sums=('$sha')" PKGBUILD
@@ -74,9 +61,7 @@ jobs:
           set -euo pipefail
           cat >work/canary.sh <<'EOF'
           set -eu
-          # The image is a weekly snapshot, so anything installed against it
-          # without a refresh is a partial upgrade. Keyring first, or the
-          # refreshed packages fail their signature check.
+          # The image is a weekly snapshot, so refresh its keyring before it.
           pacman -Sy --noconfirm --needed archlinux-keyring
           pacman -Su --noconfirm
           useradd -m builder
@@ -88,14 +73,9 @@ jobs:
           su - builder -c 'cd ~/pkg && makepkg -s --noconfirm'
           # Installing and running it is the assertion: makepkg exiting 0
           # having packaged nothing runnable is what this canary is here for.
-          pkg=$(find /home/builder/pkg -name 'httrack-[0-9]*.pkg.tar.*')
-          test -n "$pkg"
-          pacman -U --noconfirm "$pkg"
+          set -- /home/builder/pkg/httrack-[0-9]*.pkg.tar.*
+          test "$#" -eq 1
+          pacman -U --noconfirm "$1"
           httrack --version
           EOF
-          docker run --rm -v "$PWD/work:/work" archlinux:base-devel \
-            sh /work/canary.sh 2>&1 | tee build.log
-
-      - name: Print the log on failure
-        if: failure()
-        run: tail -n 120 build.log 2>/dev/null || true
+          docker run --rm -v "$PWD/work:/work" archlinux:base-devel sh /work/canary.sh

--- a/.github/workflows/arch-makepkg.yml
+++ b/.github/workflows/arch-makepkg.yml
@@ -8,8 +8,6 @@
 name: arch makepkg canary
 
 on:
-  push:
-    branches: [distro-build-canaries]  # TEMP
   schedule:
     - cron: "19 4 * * 6"
   workflow_dispatch:

--- a/.github/workflows/opensuse-spec.yml
+++ b/.github/workflows/opensuse-spec.yml
@@ -1,0 +1,101 @@
+# openSUSE names every installed file in an explicit %files list and deletes the
+# installed config.h before packaging, so a file we add or move breaks their
+# build where a glob-based spec absorbs it. Their spec is on 3.49.2, which makes
+# that list the oldest statement anyone holds about our install layout. Their
+# tree, so a red here can be theirs to fix, which is why it blocks nothing.
+name: opensuse spec canary
+
+on:
+  schedule:
+    - cron: "07 6 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  rpmbuild:
+    name: rpmbuild against openSUSE Factory's spec
+    # Scheduled workflows run per-fork independently; skip anywhere but upstream.
+    if: github.repository == 'xroche/httrack'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          path: httrack
+
+      - name: Install autotools
+        run: |
+          set -euo pipefail
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
+          sudo apt-get install -y --no-install-recommends \
+            build-essential autoconf automake libtool autoconf-archive \
+            zlib1g-dev libssl-dev
+
+      # Generated on the host, so the container consumes the same bytes a
+      # packager downloads rather than a tarball Tumbleweed's autotools rebuilt.
+      - name: Build the tarball a packager would get
+        run: |
+          set -euo pipefail
+          cd httrack
+          ./bootstrap
+          ./configure
+          make dist
+          ver=$(sed -n 's/.*HTTRACK_VERSIONID "\([^"]*\)".*/\1/p' src/htsglobal.h)
+          test -f "httrack-$ver.tar.gz"
+          echo "ver=$ver" >> "$GITHUB_ENV"
+
+      - name: Fetch their spec and point it at this tree
+        run: |
+          set -euo pipefail
+          mkdir -p work
+          cd work
+          curl -fsSL --retry 3 -o httrack.spec \
+            https://api.opensuse.org/public/source/openSUSE:Factory/httrack/httrack.spec
+          cp "$GITHUB_WORKSPACE/httrack/httrack-$ver.tar.gz" .
+          # Their %files globs the soname, which they still hold at 2.
+          info=$(sed -n 's/^VERSION_INFO="\([^"]*\)".*/\1/p' \
+            "$GITHUB_WORKSPACE/httrack/configure.ac")
+          so=$(( ${info%%:*} - ${info##*:} ))
+          test "$so" -gt 0
+          # Patch0 rewrites DEFAULT_CFLAGS in a 2014 generated configure at -p0,
+          # so keeping it would red this on the patch rather than on the build.
+          sed -i -e "s/^Version:.*/Version:        $ver/" \
+            -e "s/^%define so_ver .*/%define so_ver $so/" \
+            -e "/^Patch0:/d" httrack.spec
+          # A sed that matched nothing leaves the recipe on 3.49.2, and the
+          # canary then passes without having built this tree at all.
+          grep -qx "Version:        $ver" httrack.spec
+          grep -qx "%define so_ver $so" httrack.spec
+          ! grep -q "^Patch0:" httrack.spec
+
+      - name: rpmbuild, then install what it produced
+        timeout-minutes: 30
+        run: |
+          set -euo pipefail
+          cat >work/canary.sh <<'EOF'
+          set -eu
+          zypper --non-interactive --gpg-auto-import-keys refresh
+          # The image is published from a newer snapshot than the mirror it
+          # points at, so installing anything against it is a partial upgrade.
+          zypper --non-interactive dup
+          # gcc and make are rpm's implicit build deps, which no spec declares.
+          zypper --non-interactive install rpm-build gcc make
+          zypper --non-interactive install $(rpmspec -q --buildrequires /work/httrack.spec)
+          src=$(rpm --eval %_sourcedir)  # /usr/src/packages here, not ~/rpmbuild
+          mkdir -p "$src"
+          cp /work/httrack-*.tar.gz "$src/"
+          rpmbuild -bb /work/httrack.spec
+          # Installing and running it is the assertion: an %install that
+          # packaged nothing runnable still leaves rpmbuild exiting 0.
+          zypper --non-interactive install --allow-unsigned-rpm \
+            "$(rpm --eval %_rpmdir)"/*/*.rpm
+          httrack --version
+          EOF
+          docker run --rm -v "$PWD/work:/work" opensuse/tumbleweed \
+            sh /work/canary.sh 2>&1 | tee build.log
+
+      - name: Print the log on failure
+        if: failure()
+        run: tail -n 120 build.log 2>/dev/null || true

--- a/.github/workflows/opensuse-spec.yml
+++ b/.github/workflows/opensuse-spec.yml
@@ -6,8 +6,6 @@
 name: opensuse spec canary
 
 on:
-  push:
-    branches: [distro-build-canaries]  # TEMP
   schedule:
     - cron: "07 6 * * 0"
   workflow_dispatch:

--- a/.github/workflows/opensuse-spec.yml
+++ b/.github/workflows/opensuse-spec.yml
@@ -6,6 +6,8 @@
 name: opensuse spec canary
 
 on:
+  push:
+    branches: [distro-build-canaries]  # TEMP
   schedule:
     - cron: "07 6 * * 0"
   workflow_dispatch:
@@ -25,28 +27,12 @@ jobs:
           submodules: recursive
           path: httrack
 
-      - name: Install autotools
-        run: |
-          set -euo pipefail
-          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
-          sudo apt-get install -y --no-install-recommends \
-            build-essential autoconf automake libtool autoconf-archive \
-            zlib1g-dev libssl-dev
-
-      # Generated on the host, so the container consumes the same bytes a
-      # packager downloads rather than a tarball Tumbleweed's autotools rebuilt.
-      - name: Build the tarball a packager would get
-        run: |
-          set -euo pipefail
-          cd httrack
-          ./bootstrap
-          ./configure
-          make dist
-          ver=$(sed -n 's/.*HTTRACK_VERSIONID "\([^"]*\)".*/\1/p' src/htsglobal.h)
-          test -f "httrack-$ver.tar.gz"
-          echo "ver=$ver" >> "$GITHUB_ENV"
+      - uses: ./httrack/.github/actions/dist-tarball
+        id: dist
 
       - name: Fetch their spec and point it at this tree
+        env:
+          ver: ${{ steps.dist.outputs.version }}
         run: |
           set -euo pipefail
           mkdir -p work
@@ -70,6 +56,31 @@ jobs:
           grep -qx "%define so_ver $so" httrack.spec
           ! grep -q "^Patch0:" httrack.spec
 
+      # Three files we ship postdate their %files, and their spec will not move
+      # for years. Packaging those three keeps rpm's unpackaged-file check armed
+      # for a fourth, which is the finding this job exists to make. Each entry
+      # reds once they package it themselves, which is when it has to go.
+      - name: Acknowledge the files their %files predates
+        run: |
+          set -euo pipefail
+          cd work
+          acknowledged=(
+            "libhttrack.pc|%{_libdir}/pkgconfig/libhttrack.pc"
+            "scalable|%{_datadir}/icons/hicolor/scalable/apps/%{name}.svg"
+            "metainfo|%{_datadir}/metainfo/com.httrack.WebHTTrack.metainfo.xml"
+          )
+          for entry in "${acknowledged[@]}"; do
+            token=${entry%%|*}
+            path=${entry#*|}
+            if grep -q "$token" httrack.spec; then
+              echo "openSUSE now packages $token: drop it from acknowledged" >&2
+              exit 1
+            fi
+            # Line 107 is the only bare %files; the others name a subpackage.
+            sed -i "/^%files\$/a $path" httrack.spec
+            grep -qx "$path" httrack.spec
+          done
+
       - name: rpmbuild, then install what it produced
         timeout-minutes: 30
         run: |
@@ -78,7 +89,7 @@ jobs:
           set -eu
           zypper --non-interactive --gpg-auto-import-keys refresh
           # The image is published from a newer snapshot than the mirror it
-          # points at, so installing anything against it is a partial upgrade.
+          # points at, so installing against it is otherwise a partial upgrade.
           zypper --non-interactive dup
           # gcc and make are rpm's implicit build deps, which no spec declares.
           zypper --non-interactive install rpm-build gcc make
@@ -89,13 +100,9 @@ jobs:
           rpmbuild -bb /work/httrack.spec
           # Installing and running it is the assertion: an %install that
           # packaged nothing runnable still leaves rpmbuild exiting 0.
-          zypper --non-interactive install --allow-unsigned-rpm \
-            "$(rpm --eval %_rpmdir)"/*/*.rpm
+          set -- "$(rpm --eval %_rpmdir)"/*/*.rpm
+          test -e "$1"
+          zypper --non-interactive install --allow-unsigned-rpm "$@"
           httrack --version
           EOF
-          docker run --rm -v "$PWD/work:/work" opensuse/tumbleweed \
-            sh /work/canary.sh 2>&1 | tee build.log
-
-      - name: Print the log on failure
-        if: failure()
-        run: tail -n 120 build.log 2>/dev/null || true
+          docker run --rm -v "$PWD/work:/work" opensuse/tumbleweed sh /work/canary.sh

--- a/.github/workflows/termux-build.yml
+++ b/.github/workflows/termux-build.yml
@@ -26,26 +26,12 @@ jobs:
           submodules: recursive
           path: httrack
 
-      - name: Install autotools
-        run: |
-          set -euo pipefail
-          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
-          sudo apt-get install -y --no-install-recommends \
-            build-essential autoconf automake libtool autoconf-archive \
-            zlib1g-dev libssl-dev
-
-      - name: Build the tarball a packager would get
-        run: |
-          set -euo pipefail
-          cd httrack
-          ./bootstrap
-          ./configure
-          make dist
-          ver=$(sed -n 's/.*HTTRACK_VERSIONID "\([^"]*\)".*/\1/p' src/htsglobal.h)
-          test -f "httrack-$ver.tar.gz"
-          echo "ver=$ver" >> "$GITHUB_ENV"
+      - uses: ./httrack/.github/actions/dist-tarball
+        id: dist
 
       - name: Fetch their recipe and point it at that tarball
+        env:
+          ver: ${{ steps.dist.outputs.version }}
         run: |
           set -euo pipefail
           git clone --depth 1 https://github.com/termux/termux-packages

--- a/.github/workflows/termux-build.yml
+++ b/.github/workflows/termux-build.yml
@@ -56,6 +56,8 @@ jobs:
       # master is a finding, not something to route around.
       - name: build-package.sh, aarch64
         timeout-minutes: 60
+        env:
+          ver: ${{ steps.dist.outputs.version }}
         run: |
           set -euo pipefail
           cd termux-packages


### PR DESCRIPTION
Two defects in 3.50.0 (#1487, #1488) were visible only from a downstream build, and reading a recipe statically cannot find that class. These three canaries build master weekly through each packager's own recipe, and they block nothing.

The openSUSE leg packages three files their `%files` predates, so rpm's unpackaged-file check stays armed for a fourth. Each acknowledgement reds once they package that file themselves. The tarball step moved into a shared action, which is why the merged Termux canary is in the diff.