### PR TITLE
--with-brotli=DIR and --with-zstd=DIR look for the library in DIR/lib and nowhere else

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -40,8 +40,8 @@ somebody has to move at every bump.
 
 `--with-brotli` and `--with-zstd` default to `auto`, so the `br` and `zstd`
 content codings follow whatever happens to be installed on the builder. A recipe
-that does not pin them records no choice and links what it finds. This is new at
-3.50, and several distributions have already built with a codec set nobody picked.
+that does not pin them records no choice and links what it finds. Both flags have
+carried that default since 3.49-13 (#556).
 
 Pin it, either way:
 

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -22,8 +22,8 @@ somebody has to move at every bump.
 
 - `--with-zlib=DIR` points at a non-standard zlib prefix. zlib itself is
   required, not optional: the cache and the WARC output are zip containers.
-- `--with-brotli[=DIR]`, `--with-zstd[=DIR]`: the `br` and `zstd` content
-  codings, used when the library is found, dropped by `--without-`.
+- `--with-brotli[=DIR]`, `--with-zstd[=DIR]` select the `br` and `zstd` content
+  codings. See [brotli and zstd are automagic](#brotli-and-zstd-are-automagic).
 - `--enable-https=yes|no|auto` selects OpenSSL. On by default.
 - `--enable-online-unit-tests` is off by default, and `make check` reaches the
   network only when it is on. Nothing to pass.
@@ -35,6 +35,26 @@ somebody has to move at every bump.
   The pages link `../license.txt`, `../greetings.txt` and `../history.txt`, which
   install into `$(docdir)`, so a layout that puts the pages anywhere else strands
   those three.
+
+## brotli and zstd are automagic
+
+`--with-brotli` and `--with-zstd` default to `auto`, so the `br` and `zstd`
+content codings follow whatever happens to be installed on the builder. A recipe
+that does not pin them records no choice and links what it finds. This is new at
+3.50, and several distributions have already built with a codec set nobody picked.
+
+Pin it, either way:
+
+```
+./configure --with-brotli    --with-zstd
+./configure --without-brotli --without-zstd
+```
+
+The `--with-` forms are hard requirements, so configure fails when the library is
+missing instead of dropping the coding. Add the development packages to your
+build dependencies beside them. Either way configure reports the answer as
+`checking whether to enable the brotli content coding... yes (auto)`, where
+`(auto)` means the build environment decided and `(requested)` means you did.
 
 ## Do not re-encode the tree
 

--- a/m4/check_codecs.m4
+++ b/m4/check_codecs.m4
@@ -12,6 +12,7 @@ dnl ZSTD_LIBS.
 
 dnl CHECK_CODEC(name, NAME, header, library, symbol, companion-libs)
 AC_DEFUN([CHECK_CODEC], [
+AC_REQUIRE([HTS_EXPAND_LIBDIR])
 AC_ARG_WITH([$1],
 	[AS_HELP_STRING([--with-$1@<:@=DIR@:>@],[Enable the $1 content coding @<:@default=auto@:>@])],
 	[codec_want=$withval], [codec_want=auto])
@@ -20,16 +21,20 @@ codec_have=no
 if test "$codec_want" != "no"; then
 	codec_old_cppflags="$CPPFLAGS"
 	codec_old_ldflags="$LDFLAGS"
-	codec_dir=no
+	codec_libdir=
 	if test "$codec_want" != "yes" -a "$codec_want" != "auto"; then
-		codec_dir=yes
 		# An explicit prefix is authoritative: if the header is not under
 		# it, error rather than silently pick a system copy.
 		if test ! -f "$codec_want/include/$3"; then
 			AC_MSG_ERROR([$1 requested at $codec_want but $codec_want/include/$3 is missing])
 		fi
+		HTS_FIND_LIBDIR([$codec_want], [lib$4.*])
+		if test -z "$hts_found_libdir"; then
+			AC_MSG_ERROR([$1 requested at $codec_want but no lib$4 found in any of: $hts_libdir_subdirs])
+		fi
+		codec_libdir=$hts_found_libdir
 		CPPFLAGS="$CPPFLAGS -I$codec_want/include"
-		LDFLAGS="$LDFLAGS -L$codec_want/lib"
+		LDFLAGS="$LDFLAGS -L$codec_libdir"
 	fi
 	AC_CHECK_HEADER([$3], [codec_h=yes], [codec_h=no])
 	AC_CHECK_LIB([$4], [$5], [codec_lib=yes], [codec_lib=no], [$6])
@@ -38,8 +43,8 @@ if test "$codec_want" != "no"; then
 	if test "$codec_h" = "yes" -a "$codec_lib" = "yes"; then
 		codec_have=yes
 		$2_LIBS="-l$4 $6"
-		if test "$codec_dir" = "yes"; then
-			$2_LIBS="-L$codec_want/lib -l$4 $6"
+		if test -n "$codec_libdir"; then
+			$2_LIBS="-L$codec_libdir -l$4 $6"
 			# The rest of configure still needs the header path.
 			CPPFLAGS="$CPPFLAGS -I$codec_want/include"
 		fi
@@ -48,7 +53,12 @@ if test "$codec_want" != "no"; then
 	fi
 fi
 AC_MSG_CHECKING([whether to enable the $1 content coding])
-AC_MSG_RESULT([$codec_have])
+dnl Name who decided: "auto" is the build environment's answer, not the packager's.
+if test "$codec_want" = "auto"; then
+	AC_MSG_RESULT([$codec_have (auto)])
+else
+	AC_MSG_RESULT([$codec_have (requested)])
+fi
 if test "$codec_have" = "yes"; then
 	AC_DEFINE([HTS_USE$2], [1], [Define to 1 to decode the $1 content coding])
 else

--- a/m4/check_zlib.m4
+++ b/m4/check_zlib.m4
@@ -20,30 +20,12 @@ if test "$zlib_want" != "yes"; then
 	if test ! -f "$zlib_want/include/zlib.h"; then
 		AC_MSG_ERROR([zlib requested at $zlib_want but $zlib_want/include/zlib.h is missing])
 	fi
-	# The library is not always under lib: a multilib host (Fedora, openSUSE)
-	# keeps the 64-bit copy in lib64, Debian under a multiarch triplet. The
-	# configured libdir is the host's own answer, so ask it before guessing.
-	case $hts_libdir in
-	"$hts_exec_prefix"/*) zlib_hostdir=${hts_libdir#"$hts_exec_prefix"/} ;;
-	*/*) zlib_hostdir=${hts_libdir##*/} ;;
-	*) zlib_hostdir=lib ;;
-	esac
-	zlib_subdirs=$zlib_hostdir
-	for zlib_sub in lib lib64; do
-		test "$zlib_sub" = "$zlib_hostdir" || zlib_subdirs="$zlib_subdirs $zlib_sub"
-	done
-	zlib_libdir=
-	for zlib_sub in $zlib_subdirs; do
-		for zlib_file in "$zlib_want/$zlib_sub"/libz.*; do
-			test -f "$zlib_file" && zlib_libdir=$zlib_want/$zlib_sub && break
-		done
-		test -n "$zlib_libdir" && break
-	done
-	if test -z "$zlib_libdir"; then
-		AC_MSG_ERROR([zlib requested at $zlib_want but no libz found in any of: $zlib_subdirs])
+	HTS_FIND_LIBDIR([$zlib_want], [libz.*])
+	if test -z "$hts_found_libdir"; then
+		AC_MSG_ERROR([zlib requested at $zlib_want but no libz found in any of: $hts_libdir_subdirs])
 	fi
 	CPPFLAGS="$CPPFLAGS -I$zlib_want/include"
-	LDFLAGS="$LDFLAGS -L$zlib_libdir"
+	LDFLAGS="$LDFLAGS -L$hts_found_libdir"
 elif test -f /usr/local/include/zlib.h; then
 	# Where the BSD ports tree lands zlib, and not always searched by default.
 	CPPFLAGS="$CPPFLAGS -I/usr/local/include"

--- a/m4/expand_libdir.m4
+++ b/m4/expand_libdir.m4
@@ -15,3 +15,31 @@ eval hts_libdir=\"$hts_libdir\"
 prefix=$hts_save_prefix
 exec_prefix=$hts_save_exec_prefix
 ])
+
+dnl @synopsis HTS_FIND_LIBDIR(PREFIX, LIB-GLOB)
+dnl
+dnl Set hts_found_libdir to the subdirectory of PREFIX holding a file matching
+dnl LIB-GLOB, empty when none does, and hts_libdir_subdirs to the candidates
+dnl tried. The library is not always under lib: a multilib host (Fedora,
+dnl openSUSE) keeps the 64-bit copy in lib64, Debian under a multiarch triplet.
+dnl The configured libdir is the host's own answer, so ask it before guessing.
+
+AC_DEFUN([HTS_FIND_LIBDIR], [
+AC_REQUIRE([HTS_EXPAND_LIBDIR])
+case $hts_libdir in
+"$hts_exec_prefix"/*) hts_hostdir=${hts_libdir#"$hts_exec_prefix"/} ;;
+*/*) hts_hostdir=${hts_libdir##*/} ;;
+*) hts_hostdir=lib ;;
+esac
+hts_libdir_subdirs=$hts_hostdir
+for hts_sub in lib lib64; do
+	test "$hts_sub" = "$hts_hostdir" || hts_libdir_subdirs="$hts_libdir_subdirs $hts_sub"
+done
+hts_found_libdir=
+for hts_sub in $hts_libdir_subdirs; do
+	for hts_file in "$1/$hts_sub"/$2; do
+		test -f "$hts_file" && hts_found_libdir=$1/$hts_sub && break
+	done
+	test -n "$hts_found_libdir" && break
+done
+])

--- a/tests/389_configure-codec-libdir.test
+++ b/tests/389_configure-codec-libdir.test
@@ -1,0 +1,174 @@
+#!/bin/bash
+# --with-brotli=DIR and --with-zstd=DIR used to append DIR/lib and nothing else.
+# A multilib host keeps the 64-bit copy in lib64, Debian under a multiarch
+# triplet, so that -L named a directory that does not exist and the link quietly
+# took the system copy while configure reported the coding as enabled.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+srcdir="${abs_top_srcdir:?not run under make check}"
+test -r "${srcdir}/configure" || skip "no configure in ${srcdir}"
+
+# $CC carries its flags on some hosts (macOS configures gcc -std=gnu23), so it
+# is an argv, never one word.
+read -r -a cc_argv <<<"${CC:-cc}"
+command -v "${cc_argv[0]}" >/dev/null 2>&1 || skip "no C compiler (${cc_argv[0]})"
+
+# find_lib NAME...: print the first system library the compiler resolves.
+find_lib() {
+    local name cand
+    for name in "$@"; do
+        cand=$("${cc_argv[@]}" -print-file-name="${name}") || cand=
+        if test -f "${cand}"; then
+            echo "${cand}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# find_hdr HEADER: print the system path <HEADER> resolves to.
+find_hdr() {
+    local out
+    out=$(printf '#include <%s>\n' "$1" | "${cc_argv[@]}" -E -xc -) || return 1
+    # Capture then match: piping into a truncating reader SIGPIPEs the cc upstream.
+    out=$(sed -n "s|^#[ 0-9]*\"\([^\"]*$1\)\".*|\1|p" <<<"${out}")
+    out=${out%%$'\n'*}
+    test -f "${out}" || return 1
+    echo "${out}"
+}
+
+brotli_dec=$(find_lib libbrotlidec.so libbrotlidec.dylib libbrotlidec.tbd libbrotlidec.a) ||
+    skip "no system libbrotlidec to build a fixture from"
+brotli_com=$(find_lib libbrotlicommon.so libbrotlicommon.dylib libbrotlicommon.tbd libbrotlicommon.a) ||
+    skip "no system libbrotlicommon to build a fixture from"
+zstd_lib=$(find_lib libzstd.so libzstd.dylib libzstd.tbd libzstd.a) ||
+    skip "no system libzstd to build a fixture from"
+brotli_hdr=$(find_hdr brotli/decode.h) || skip "no system brotli/decode.h"
+zstd_hdr=$(find_hdr zstd.h) || skip "no system zstd.h"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/codecdir.XXXXXX") || fail "no tmpdir"
+cleanup_push rm -rf "${work}"
+
+# automake refuses an out-of-tree configure when srcdir holds a config.status,
+# which an in-tree build leaves there; a symlink farm without that one file is
+# the same tree to configure.
+shadow=${work}/srcdir
+mkdir -p "${shadow}"
+for entry in "${srcdir}"/*; do
+    test "${entry##*/}" = config.status || ln -s "${entry}" "${shadow}/"
+done
+test -r "${shadow}/configure" || fail "the shadow source tree has no configure"
+
+# fixture NAME CODEC SUBDIR...: a prefix holding a real codec in each named
+# subdirectory and nowhere else. The header always sits under include/.
+fixture() {
+    local name=$1 codec=$2 sub lib
+    shift 2
+    mkdir -p "${work}/${name}/include"
+    case ${codec} in
+    brotli)
+        mkdir -p "${work}/${name}/include/brotli"
+        ln -sf "${brotli_hdr}" "${work}/${name}/include/brotli/decode.h"
+        ;;
+    zstd) ln -sf "${zstd_hdr}" "${work}/${name}/include/zstd.h" ;;
+    esac
+    for sub in "$@"; do
+        mkdir -p "${work}/${name}/${sub}"
+        case ${codec} in
+        brotli)
+            for lib in "${brotli_dec}" "${brotli_com}"; do
+                ln -sf "${lib}" "${work}/${name}/${sub}/${lib##*/}"
+            done
+            ;;
+        zstd) ln -sf "${zstd_lib}" "${work}/${name}/${sub}/${zstd_lib##*/}" ;;
+        esac
+    done
+    echo "${work}/${name}"
+}
+
+# One cache for every run: nothing cached here depends on the prefix or the
+# libdir, and a cold configure is the whole cost of this test.
+cache=${work}/config.cache
+n=0
+cases=6 # expect/expect_fail calls below, what the budget is paced against
+
+run_configure() { # run_configure DIR ARG...
+    local dir=$1
+    shift
+    mkdir -p "${dir}"
+    # A keg-only openssl (brew) makes --enable-https a hard error, and TLS has
+    # nothing to do with the content codings.
+    (cd "${dir}" && bash "${shadow}/configure" --cache-file="${cache}" \
+        --enable-https=auto "$@") >"${dir}/configure.log" 2>&1
+}
+
+# expect CODEC VAR WANT-SUBDIR REJECTED-SUBDIR DESC PREFIX ARG...
+expect() {
+    local codec=$1 var=$2 want=$3 nope=$4 desc=$5 prefix=$6
+    shift 6
+    local dir line began=${SECONDS}
+    n=$((n + 1))
+    dir=${work}/build${n}
+    run_configure "${dir}" --with-"${codec}"="${prefix}" "$@" || {
+        tail -20 "${dir}/configure.log" >&2
+        fail "${desc}: configure failed"
+    }
+    line=$(sed -n "s/^${var} = *//p" "${dir}/src/Makefile")
+    test -n "${line}" || fail_dump "${desc}: src/Makefile carries no ${var} line" "${dir}/configure.log"
+    case " ${line} " in
+    *" -L${prefix}/${want} "*) ;;
+    *) fail "${desc}: expected -L${prefix}/${want}, got: ${line}" ;;
+    esac
+    case " ${line} " in
+    *" -L${prefix}/${nope} "*) fail "${desc}: also picked -L${prefix}/${nope}: ${line}" ;;
+    esac
+    # The whole bug: the emitted -L named a directory that was not there.
+    test -d "${prefix}/${want}" || fail "${desc}: -L${prefix}/${want} does not exist"
+    echo "ok: ${desc} -> ${want}"
+    skip_if_out_of_budget "$((cases - n))" "$((SECONDS - began))"
+}
+
+expect_fail() { # expect_fail CODEC LIB DESC PREFIX
+    local codec=$1 lib=$2 desc=$3 prefix=$4 dir began=${SECONDS}
+    n=$((n + 1))
+    dir=${work}/build${n}
+    ! run_configure "${dir}" --with-"${codec}"="${prefix}" ||
+        fail "${desc}: configure accepted a prefix with no ${lib} under it"
+    grep -q "no ${lib} found" "${dir}/configure.log" ||
+        fail_dump "${desc}: configure failed without naming the missing library" "${dir}/configure.log"
+    echo "ok: ${desc}"
+    skip_if_out_of_budget "$((cases - n))" "$((SECONDS - began))"
+}
+
+# The subdirectory names are the fixture's own, not the host's, so every case
+# below means the same thing on a platform with no real lib64: what they
+# exercise is the macro's candidate order, which is shell.
+br_lib=$(fixture br-lib brotli lib)
+br_lib64=$(fixture br-lib64 brotli lib64)
+br_both=$(fixture br-both brotli lib lib64)
+br_headers=$(fixture br-headers brotli)
+zs_lib64=$(fixture zs-lib64 zstd lib64)
+
+# The control first: a plain lib prefix must keep resolving exactly as before,
+# or every lib64 answer below could come from a macro that always says lib64.
+expect brotli BROTLI_LIBS lib lib64 "a lib-only brotli prefix resolves" "${br_lib}"
+expect brotli BROTLI_LIBS lib64 lib "a lib64-only brotli prefix resolves" "${br_lib64}"
+
+# With both populated the probe cannot decide, so these two pin the derivation
+# from the configured libdir rather than the order the candidates are tried in.
+expect brotli BROTLI_LIBS lib lib64 "the default libdir picks lib" "${br_both}" \
+    --prefix="${work}/inst"
+expect brotli BROTLI_LIBS lib64 lib "--libdir picks lib64" "${br_both}" \
+    --prefix="${work}/inst" --libdir="${work}/inst/lib64"
+
+# zstd goes through the same macro with its own library name, so one case is
+# enough to show the glob is parameterised and not hardcoded to brotli.
+expect zstd ZSTD_LIBS lib64 lib "a lib64-only zstd prefix resolves" "${zs_lib64}"
+
+expect_fail brotli libbrotlidec "a prefix with no libbrotlidec is rejected" "${br_headers}"
+
+assert_steps_ran "${cases}" "${n}"

--- a/tests/389_configure-codec-libdir.test
+++ b/tests/389_configure-codec-libdir.test
@@ -145,8 +145,7 @@ expect_fail() { # expect_fail CODEC LIB DESC PREFIX
 }
 
 # The subdirectory names are the fixture's own, not the host's, so every case
-# below means the same thing on a platform with no real lib64: what they
-# exercise is the macro's candidate order, which is shell.
+# below means the same thing on a platform that has no real lib64.
 br_lib=$(fixture br-lib brotli lib)
 br_lib64=$(fixture br-lib64 brotli lib64)
 br_both=$(fixture br-both brotli lib lib64)

--- a/tests/389_configure-codec-libdir.test
+++ b/tests/389_configure-codec-libdir.test
@@ -4,6 +4,8 @@
 # triplet, so that -L named a directory that does not exist and the link quietly
 # took the system copy while configure reported the coding as enabled.
 
+# TEST_TIMEOUT_AT_LEAST: 900
+
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
@@ -63,13 +65,24 @@ for entry in "${srcdir}"/*; do
 done
 test -r "${shadow}/configure" || fail "the shadow source tree has no configure"
 
-# fixture NAME CODEC SUBDIR...: a prefix holding a real codec in each named
-# subdirectory and nowhere else. The header always sits under include/.
+# put_lib CODEC DIR: drop one codec's libraries into DIR.
+put_lib() {
+    local lib
+    case $1 in
+    brotli) for lib in "${brotli_dec}" "${brotli_com}"; do ln -sf "${lib}" "$2/${lib##*/}"; done ;;
+    zstd) ln -sf "${zstd_lib}" "$2/${zstd_lib##*/}" ;;
+    esac
+}
+
+# fixture NAME HDR-CODEC LIB-CODEC SUBDIR...: a prefix carrying HDR-CODEC's
+# header under include/ and LIB-CODEC's libraries in each named subdirectory,
+# and nothing else. Naming the two separately is what lets a fixture hold the
+# wrong library, which no lib-only or empty prefix can express.
 fixture() {
-    local name=$1 codec=$2 sub lib
-    shift 2
+    local name=$1 hdr=$2 lib=$3 sub
+    shift 3
     mkdir -p "${work}/${name}/include"
-    case ${codec} in
+    case ${hdr} in
     brotli)
         mkdir -p "${work}/${name}/include/brotli"
         ln -sf "${brotli_hdr}" "${work}/${name}/include/brotli/decode.h"
@@ -78,67 +91,99 @@ fixture() {
     esac
     for sub in "$@"; do
         mkdir -p "${work}/${name}/${sub}"
-        case ${codec} in
-        brotli)
-            for lib in "${brotli_dec}" "${brotli_com}"; do
-                ln -sf "${lib}" "${work}/${name}/${sub}/${lib##*/}"
-            done
-            ;;
-        zstd) ln -sf "${zstd_lib}" "${work}/${name}/${sub}/${zstd_lib##*/}" ;;
-        esac
+        test "${lib}" = none || put_lib "${lib}" "${work}/${name}/${sub}"
     done
     echo "${work}/${name}"
 }
 
-# One cache for every run: nothing cached here depends on the prefix or the
-# libdir, and a cold configure is the whole cost of this test.
-cache=${work}/config.cache
 n=0
-cases=6 # expect/expect_fail calls below, what the budget is paced against
+cases=8 # expect/expect_fail calls below, what the budget is paced against
 
+# No --cache-file: the codec probes cache as ac_cv_lib_brotlidec_* and
+# ac_cv_header_zstd_h, so one cache shared across cases replays the first
+# case's answer and no later case probes anything.
 run_configure() { # run_configure DIR ARG...
     local dir=$1
     shift
     mkdir -p "${dir}"
     # A keg-only openssl (brew) makes --enable-https a hard error, and TLS has
     # nothing to do with the content codings.
-    (cd "${dir}" && bash "${shadow}/configure" --cache-file="${cache}" \
-        --enable-https=auto "$@") >"${dir}/configure.log" 2>&1
+    (cd "${dir}" && bash "${shadow}/configure" --enable-https=auto "$@") \
+        >"${dir}/configure.log" 2>&1
 }
 
-# expect CODEC VAR WANT-SUBDIR REJECTED-SUBDIR DESC PREFIX ARG...
-expect() {
-    local codec=$1 var=$2 want=$3 nope=$4 desc=$5 prefix=$6
-    shift 6
-    local dir line began=${SECONDS}
+# codec_facts CODEC: set lib, var and other for the codec under test.
+codec_facts() {
+    case $1 in
+    brotli)
+        lib=brotlidec
+        var=BROTLI_LIBS
+        other=zstd
+        ;;
+    zstd)
+        lib=zstd
+        var=ZSTD_LIBS
+        other=brotli
+        ;;
+    *) fail "unknown codec $1" ;;
+    esac
+}
+
+expect() { # expect CODEC WANT-SUBDIR REJECTED-SUBDIR DESC PREFIX ARG...
+    local codec=$1 want=$2 nope=$3 desc=$4 prefix=$5
+    shift 5
+    local lib var other dir line probe began=${SECONDS}
+    codec_facts "${codec}"
     n=$((n + 1))
     dir=${work}/build${n}
-    run_configure "${dir}" --with-"${codec}"="${prefix}" "$@" || {
-        tail -20 "${dir}/configure.log" >&2
-        fail "${desc}: configure failed"
-    }
+    run_configure "${dir}" --with-"${codec}"="${prefix}" "$@" ||
+        fail_dump "${desc}: configure failed" "${dir}/configure.log"
+
     line=$(sed -n "s/^${var} = *//p" "${dir}/src/Makefile")
     test -n "${line}" || fail_dump "${desc}: src/Makefile carries no ${var} line" "${dir}/configure.log"
     case " ${line} " in
     *" -L${prefix}/${want} "*) ;;
-    *) fail "${desc}: expected -L${prefix}/${want}, got: ${line}" ;;
+    *) fail "${desc}: expected -L${prefix}/${want} in ${var}, got: ${line}" ;;
     esac
     case " ${line} " in
-    *" -L${prefix}/${nope} "*) fail "${desc}: also picked -L${prefix}/${nope}: ${line}" ;;
+    *" -L${prefix}/${nope} "*) fail "${desc}: ${var} also picked -L${prefix}/${nope}: ${line}" ;;
     esac
     # The whole bug: the emitted -L named a directory that was not there.
     test -d "${prefix}/${want}" || fail "${desc}: -L${prefix}/${want} does not exist"
+
+    # The emitted flag is not the probe. Detection linking under the old
+    # unresolved path while only the flag is fixed would pass every check
+    # above, so read the link command configure actually ran.
+    probe=$(grep -e '-o conftest' "${dir}/config.log" | grep -e "-l${lib}" || true)
+    probe=$(tr '\n' ' ' <<<"${probe}")
+    test -n "${probe}" || fail_dump "${desc}: config.log has no -l${lib} link probe" "${dir}/config.log"
+    case " ${probe} " in
+    *" -L${prefix}/${want} "*) ;;
+    *) fail "${desc}: the -l${lib} probe did not link under -L${prefix}/${want}: ${probe}" ;;
+    esac
+    case " ${probe} " in
+    *" -L${prefix}/${nope} "*) fail "${desc}: the -l${lib} probe linked under -L${prefix}/${nope}: ${probe}" ;;
+    esac
+
+    # PACKAGING.md quotes this qualifier as the packager's confirmation of who
+    # chose, so both halves of it are pinned here, in one run that has both.
+    grep -q "the ${codec} content coding\.\.\. yes (requested)" "${dir}/configure.log" ||
+        fail_dump "${desc}: an explicit --with-${codec} was not reported as (requested)" "${dir}/configure.log"
+    grep -qE "the ${other} content coding\.\.\. (yes|no) \(auto\)" "${dir}/configure.log" ||
+        fail_dump "${desc}: the unrequested ${other} coding was not reported as (auto)" "${dir}/configure.log"
+
     echo "ok: ${desc} -> ${want}"
     skip_if_out_of_budget "$((cases - n))" "$((SECONDS - began))"
 }
 
-expect_fail() { # expect_fail CODEC LIB DESC PREFIX
-    local codec=$1 lib=$2 desc=$3 prefix=$4 dir began=${SECONDS}
+expect_fail() { # expect_fail CODEC DESC PREFIX
+    local codec=$1 desc=$2 prefix=$3 lib var other dir began=${SECONDS}
+    codec_facts "${codec}"
     n=$((n + 1))
     dir=${work}/build${n}
     ! run_configure "${dir}" --with-"${codec}"="${prefix}" ||
-        fail "${desc}: configure accepted a prefix with no ${lib} under it"
-    grep -q "no ${lib} found" "${dir}/configure.log" ||
+        fail_dump "${desc}: configure accepted a prefix with no lib${lib} under it" "${dir}/configure.log"
+    grep -q "no lib${lib} found" "${dir}/configure.log" ||
         fail_dump "${desc}: configure failed without naming the missing library" "${dir}/configure.log"
     echo "ok: ${desc}"
     skip_if_out_of_budget "$((cases - n))" "$((SECONDS - began))"
@@ -146,28 +191,37 @@ expect_fail() { # expect_fail CODEC LIB DESC PREFIX
 
 # The subdirectory names are the fixture's own, not the host's, so every case
 # below means the same thing on a platform that has no real lib64.
-br_lib=$(fixture br-lib brotli lib)
-br_lib64=$(fixture br-lib64 brotli lib64)
-br_both=$(fixture br-both brotli lib lib64)
-br_headers=$(fixture br-headers brotli)
-zs_lib64=$(fixture zs-lib64 zstd lib64)
+br_lib=$(fixture br-lib brotli brotli lib)
+br_lib64=$(fixture br-lib64 brotli brotli lib64)
+br_both=$(fixture br-both brotli brotli lib lib64)
+br_multiarch=$(fixture br-multiarch brotli brotli lib lib/x86_64-linux-gnu)
+br_headers=$(fixture br-headers brotli none)
+br_wrong=$(fixture br-wrong brotli zstd lib64)
+zs_lib64=$(fixture zs-lib64 zstd zstd lib64)
 
 # The control first: a plain lib prefix must keep resolving exactly as before,
 # or every lib64 answer below could come from a macro that always says lib64.
-expect brotli BROTLI_LIBS lib lib64 "a lib-only brotli prefix resolves" "${br_lib}"
-expect brotli BROTLI_LIBS lib64 lib "a lib64-only brotli prefix resolves" "${br_lib64}"
+expect brotli lib lib64 "a lib-only brotli prefix resolves" "${br_lib}"
+expect brotli lib64 lib "a lib64-only brotli prefix resolves" "${br_lib64}"
 
-# With both populated the probe cannot decide, so these two pin the derivation
-# from the configured libdir rather than the order the candidates are tried in.
-expect brotli BROTLI_LIBS lib lib64 "the default libdir picks lib" "${br_both}" \
+# With both populated the probe cannot decide, so these three pin the
+# derivation from the configured libdir rather than the order the candidates
+# are tried in. The triplet is the case the macro's comment names for Debian.
+expect brotli lib lib64 "the default libdir picks lib" "${br_both}" \
     --prefix="${work}/inst"
-expect brotli BROTLI_LIBS lib64 lib "--libdir picks lib64" "${br_both}" \
+expect brotli lib64 lib "--libdir picks lib64" "${br_both}" \
     --prefix="${work}/inst" --libdir="${work}/inst/lib64"
+expect brotli lib/x86_64-linux-gnu lib "a multiarch libdir picks the triplet" \
+    "${br_multiarch}" --prefix="${work}/inst" --libdir="${work}/inst/lib/x86_64-linux-gnu"
 
 # zstd goes through the same macro with its own library name, so one case is
 # enough to show the glob is parameterised and not hardcoded to brotli.
-expect zstd ZSTD_LIBS lib64 lib "a lib64-only zstd prefix resolves" "${zs_lib64}"
+expect zstd lib64 lib "a lib64-only zstd prefix resolves" "${zs_lib64}"
 
-expect_fail brotli libbrotlidec "a prefix with no libbrotlidec is rejected" "${br_headers}"
+expect_fail brotli "a prefix with no libbrotlidec is rejected" "${br_headers}"
+# A prefix whose lib64 holds some other library must be rejected too: matching
+# any lib*.* there would resolve to a directory with no decoder in it, and the
+# link would fall back to the system copy that this whole macro exists to avoid.
+expect_fail brotli "a prefix whose lib64 holds the wrong library is rejected" "${br_wrong}"
 
 assert_steps_ran "${cases}" "${n}"


### PR DESCRIPTION
`--with-brotli=DIR` and `--with-zstd=DIR` appended `DIR/lib` unconditionally, so a lib64 or multiarch prefix left configure reporting the coding as enabled against a system copy. #1472 fixed the same shape next door in `CHECK_ZLIB`, and the subdirectory search now lives in one macro both call. PACKAGING.md gains the flags that pin the two codings, which default to `auto` and have been following whatever the builder happened to hold.
