### PR TITLE
hts_self_path() has no BSD arm, so FreeBSD falls back to argv[0]

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -421,7 +421,7 @@ AC_CHECK_TYPE(sa_family_t, [], [AC_DEFINE([sa_family_t], [uint16_t], [sa_family_
 AX_CHECK_ALIGNED_ACCESS_REQUIRED
 
 # check for various headers
-AC_CHECK_HEADERS([execinfo.h spawn.h sys/ioctl.h sys/random.h])
+AC_CHECK_HEADERS([execinfo.h spawn.h sys/ioctl.h sys/random.h sys/sysctl.h])
 
 ## The header can exist while backtrace() lives in another library (Termux's
 ## libandroid-execinfo); only httrack links it, so keep it out of LIBS.

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -107,11 +107,13 @@ const char *hts_self_path(char *dst, size_t dstsize) {
 
   /* Pre-Win8 returns nSize on truncation without terminating: a full buffer
      is a failure, not a path. */
-  return (n > 0 && (size_t) n < dstsize) ? dst : NULL;
+  if (n > 0 && (size_t) n < dstsize)
+    return dst;
 #elif defined(__APPLE__)
   uint32_t n = (uint32_t) dstsize;
 
-  return _NSGetExecutablePath(dst, &n) == 0 ? dst : NULL;
+  if (_NSGetExecutablePath(dst, &n) == 0)
+    return dst;
 #elif defined(HTS_SELF_PATH_SYSCTL)
   /* FreeBSD and DragonFly put the pid last, NetBSD puts it third, and 9 is the
      pathname on DragonFly but KERN_PROC_SV_NAME on FreeBSD (#1506). */
@@ -127,20 +129,22 @@ const char *hts_self_path(char *dst, size_t dstsize) {
   if (sysctl(mib, 4, dst, &n, NULL, 0) == 0 && n > 1 && n <= dstsize &&
       dst[n - 1] == '\0')
     return dst;
-  /* Unlike readlink(), sysctl() copies what fits before it reports ENOMEM, so
-     a refusal must not hand the caller that prefix. */
-  if (dstsize != 0)
-    dst[0] = '\0';
-  return NULL;
 #else
   /* Linux; anywhere else this is simply absent and argv[0] has to do. */
   const ssize_t n = readlink("/proc/self/exe", dst, dstsize - 1);
 
-  if (n <= 0 || (size_t) n >= dstsize - 1)
-    return NULL;
-  dst[n] = '\0';
-  return dst;
+  if (n > 0 && (size_t) n < dstsize - 1) {
+    dst[n] = '\0';
+    return dst;
+  }
 #endif
+  /* GetModuleFileNameA() and sysctl() both copy a clipped path into dst before
+     they report the clipping, and Windows terminates that copy, so a refusal
+     would otherwise read back as a shorter path. Emptying dst covers it, and
+     the other two arms share the exit so a fifth cannot forget the contract. */
+  if (dstsize != 0)
+    dst[0] = '\0';
+  return NULL;
 }
 
 /* Directory part of path, trailing '/' kept, or NULL when it carries none: a

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -113,7 +113,8 @@ const char *hts_self_path(char *dst, size_t dstsize) {
 
   return _NSGetExecutablePath(dst, &n) == 0 ? dst : NULL;
 #elif defined(HTS_SELF_PATH_SYSCTL)
-  /* FreeBSD and DragonFly put the pid last, NetBSD puts it third (#1506). */
+  /* FreeBSD and DragonFly put the pid last, NetBSD puts it third, and 9 is the
+     pathname on DragonFly but KERN_PROC_SV_NAME on FreeBSD (#1506). */
 #if defined(__NetBSD__)
   int mib[4] = {CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME};
 #else
@@ -121,14 +122,16 @@ const char *hts_self_path(char *dst, size_t dstsize) {
 #endif
   size_t n = dstsize;
 
-  if (sysctl(mib, 4, dst, &n, NULL, 0) != 0)
-    return NULL;
-  /* n counts the kernel's terminator, so 1 is the empty path, and a length
-     reaching the buffer end is a truncation rather than a path. */
-  if (n <= 1 || n >= dstsize)
-    return NULL;
-  dst[n] = '\0'; /* the kernel need not terminate it */
-  return dst;
+  /* All three report strlen + 1, so 1 is the empty path and dst[n - 1] is the
+     kernel's own terminator. */
+  if (sysctl(mib, 4, dst, &n, NULL, 0) == 0 && n > 1 && n <= dstsize &&
+      dst[n - 1] == '\0')
+    return dst;
+  /* Unlike readlink(), sysctl() copies what fits before it reports ENOMEM, so
+     a refusal must not hand the caller that prefix. */
+  if (dstsize != 0)
+    dst[0] = '\0';
+  return NULL;
 #else
   /* Linux; anywhere else this is simply absent and argv[0] has to do. */
   const ssize_t n = readlink("/proc/self/exe", dst, dstsize - 1);

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -58,6 +58,16 @@ Please visit our Website: http://www.httrack.com
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
 #endif
+/* These BSDs name the running binary through sysctl, which needs no /proc.
+   OpenBSD has no equivalent and stays on argv[0]. */
+#if defined(HAVE_SYS_SYSCTL_H) &&                                              \
+    (defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__))
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#ifdef KERN_PROC_PATHNAME
+#define HTS_SELF_PATH_SYSCTL 1
+#endif
+#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -102,6 +112,23 @@ const char *hts_self_path(char *dst, size_t dstsize) {
   uint32_t n = (uint32_t) dstsize;
 
   return _NSGetExecutablePath(dst, &n) == 0 ? dst : NULL;
+#elif defined(HTS_SELF_PATH_SYSCTL)
+  /* FreeBSD and DragonFly put the pid last, NetBSD puts it third (#1506). */
+#if defined(__NetBSD__)
+  int mib[4] = {CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME};
+#else
+  int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
+#endif
+  size_t n = dstsize;
+
+  if (sysctl(mib, 4, dst, &n, NULL, 0) != 0)
+    return NULL;
+  /* n counts the kernel's terminator, so 1 is the empty path, and a length
+     reaching the buffer end is a truncation rather than a path. */
+  if (n <= 1 || n >= dstsize)
+    return NULL;
+  dst[n] = '\0'; /* the kernel need not terminate it */
+  return dst;
 #else
   /* Linux; anywhere else this is simply absent and argv[0] has to do. */
   const ssize_t n = readlink("/proc/self/exe", dst, dstsize - 1);

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -102,6 +102,10 @@ static int datadir_has_templates(const char *dir) {
 /* htsbacktrace.c copies the Linux branch: it is program-side and cannot reach
    this hidden symbol, so a fix here belongs there too (#997). */
 const char *hts_self_path(char *dst, size_t dstsize) {
+  /* No byte to write a terminator into, and readlink() below would otherwise
+     be handed dstsize - 1 as SIZE_MAX. */
+  if (dstsize == 0)
+    return NULL;
 #if defined(_WIN32)
   const DWORD n = GetModuleFileNameA(NULL, dst, (DWORD) dstsize);
 
@@ -142,8 +146,7 @@ const char *hts_self_path(char *dst, size_t dstsize) {
      they report the clipping, and Windows terminates that copy, so a refusal
      would otherwise read back as a shorter path. Emptying dst covers it, and
      the other two arms share the exit so a fifth cannot forget the contract. */
-  if (dstsize != 0)
-    dst[0] = '\0';
+  dst[0] = '\0';
   return NULL;
 }
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6880,10 +6880,12 @@ static void datadir_expect(const char *selfpath, const char *builtin,
 // silently falling back to the built-in ones (#894). argv[0] is writable.
 static int st_datadir(httrackp *opt, int argc, char **argv) {
   char path[HTS_URLMAXSIZE];
+  char probe[HTS_URLMAXSIZE];
   char self[HTS_URLMAXSIZE];
   char expect[HTS_URLMAXSIZE * 2];
   char installed[HTS_URLMAXSIZE];
   char gone[HTS_URLMAXSIZE];
+  size_t selflen;
   /* Each holds a templates/index-header.html, the file path_bin is read for.
      nest/ keeps the flat case away from the installed share/httrack above. */
   static const char *const dirs[] = {"share/httrack", "bin", "nest/flat"};
@@ -6895,8 +6897,15 @@ static int st_datadir(httrackp *opt, int argc, char **argv) {
   /* argv[0] is a fallback: what the engine actually resolves from is this. */
   assertf(hts_self_path(path, sizeof(path)) != NULL);
   assertf(fexist(path));
-  /* Too small for any real path, so the truncation guard must refuse. */
-  assertf(hts_self_path(path, 2) == NULL);
+  /* A buffer the path does not fit in must refuse rather than clip, and must
+     not write past the size it was given. */
+  selflen = strlen(path);
+  assertf(selflen < sizeof(probe));
+  for (i = 1; i <= selflen; i++) {
+    memset(probe, 'X', sizeof(probe));
+    assertf(hts_self_path(probe, i) == NULL);
+    assertf(probe[i] == 'X');
+  }
 
   for (i = 0; i < sizeof(dirs) / sizeof(dirs[0]); i++) {
     FILE *fp;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6899,7 +6899,7 @@ static int st_datadir(httrackp *opt, int argc, char **argv) {
   assertf(hts_self_path(path, sizeof(path)) != NULL);
   assertf(fexist(path));
   /* A buffer the path does not fit in must refuse rather than clip. A refusal
-     leaves no shorter path behind and writes nothing past the size given. */
+     empties the buffer and writes nothing past the size it was given. */
   selflen = strlen(path);
   assertf(selflen < sizeof(probe));
   memset(untouched, 'X', sizeof(untouched));
@@ -6907,7 +6907,7 @@ static int st_datadir(httrackp *opt, int argc, char **argv) {
     memset(probe, 'X', sizeof(probe));
     assertf(hts_self_path(probe, i) == NULL);
     assertf(memcmp(probe + i, untouched, sizeof(probe) - i) == 0);
-    assertf(memchr(probe + 1, '\0', i - 1) == NULL);
+    assertf(probe[0] == '\0');
   }
 
   for (i = 0; i < sizeof(dirs) / sizeof(dirs[0]); i++) {

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6903,6 +6903,10 @@ static int st_datadir(httrackp *opt, int argc, char **argv) {
   selflen = strlen(path);
   assertf(selflen < sizeof(probe));
   memset(untouched, 'X', sizeof(untouched));
+  /* A zero size has nothing to empty, so it refuses without writing at all. */
+  memset(probe, 'X', sizeof(probe));
+  assertf(hts_self_path(probe, 0) == NULL);
+  assertf(memcmp(probe, untouched, sizeof(probe)) == 0);
   for (i = 1; i <= selflen; i++) {
     memset(probe, 'X', sizeof(probe));
     assertf(hts_self_path(probe, i) == NULL);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6881,6 +6881,7 @@ static void datadir_expect(const char *selfpath, const char *builtin,
 static int st_datadir(httrackp *opt, int argc, char **argv) {
   char path[HTS_URLMAXSIZE];
   char probe[HTS_URLMAXSIZE];
+  char untouched[HTS_URLMAXSIZE];
   char self[HTS_URLMAXSIZE];
   char expect[HTS_URLMAXSIZE * 2];
   char installed[HTS_URLMAXSIZE];
@@ -6897,14 +6898,16 @@ static int st_datadir(httrackp *opt, int argc, char **argv) {
   /* argv[0] is a fallback: what the engine actually resolves from is this. */
   assertf(hts_self_path(path, sizeof(path)) != NULL);
   assertf(fexist(path));
-  /* A buffer the path does not fit in must refuse rather than clip, and must
-     not write past the size it was given. */
+  /* A buffer the path does not fit in must refuse rather than clip. A refusal
+     leaves no shorter path behind and writes nothing past the size given. */
   selflen = strlen(path);
   assertf(selflen < sizeof(probe));
+  memset(untouched, 'X', sizeof(untouched));
   for (i = 1; i <= selflen; i++) {
     memset(probe, 'X', sizeof(probe));
     assertf(hts_self_path(probe, i) == NULL);
-    assertf(probe[i] == 'X');
+    assertf(memcmp(probe + i, untouched, sizeof(probe) - i) == 0);
+    assertf(memchr(probe + 1, '\0', i - 1) == NULL);
   }
 
   for (i = 0; i < sizeof(dirs) / sizeof(dirs[0]); i++) {


### PR DESCRIPTION
FreeBSD, NetBSD and DragonFly mount no /proc, so `hts_self_path()` returned NULL and the caller fell back to the argv[0] it exists to avoid. Each mib stays symbolic and comes from that BSD's own headers, because 9 is the pathname on DragonFly and `KERN_PROC_SV_NAME` on FreeBSD. The self-test sweep then caught the Windows arm leaving a terminated clipped path behind, so all four arms now share one refusal exit. No CI leg here executes a line of the sysctl arm, so the FreeBSD canary merged as #1505 is its only real verification.

Closes #1506