### PR TITLE
HTS_FIND_LIBDIR never looks under a multiarch triplet

### DIFF
--- a/m4/expand_libdir.m4
+++ b/m4/expand_libdir.m4
@@ -16,6 +16,33 @@ prefix=$hts_save_prefix
 exec_prefix=$hts_save_exec_prefix
 ])
 
+dnl @synopsis HTS_MULTIARCH_SUBDIR()
+dnl
+dnl Set hts_multiarch_subdir to the lib/TRIPLET a Debian or Ubuntu host keeps
+dnl its libraries under, empty on any other layout. gcc and clang print the
+dnl triplet only where that layout is in use, and the compiler is the one that
+dnl knows the target, so a cross build gets the triplet it is building for.
+
+AC_DEFUN([HTS_MULTIARCH_SUBDIR], [
+AC_REQUIRE([AC_PROG_CC])
+AC_CACHE_CHECK([the multiarch library subdirectory], [hts_cv_multiarch_subdir], [
+hts_cv_multiarch_subdir=none
+hts_multiarch_triplet=`$CC -print-multiarch 2>/dev/null`
+# A compiler that does not know the option can answer on stdout, so accept
+# the reply only when it spells a single path component.
+case $hts_multiarch_triplet in
+"") ;;
+*[[!-a-zA-Z0-9_.]]*) ;;
+*) hts_cv_multiarch_subdir=lib/$hts_multiarch_triplet ;;
+esac
+])
+if test "x$hts_cv_multiarch_subdir" = xnone; then
+	hts_multiarch_subdir=
+else
+	hts_multiarch_subdir=$hts_cv_multiarch_subdir
+fi
+])
+
 dnl @synopsis HTS_FIND_LIBDIR(PREFIX, LIB-GLOB)
 dnl
 dnl Set hts_found_libdir to the subdirectory of PREFIX holding a file matching
@@ -23,16 +50,19 @@ dnl LIB-GLOB, empty when none does, and hts_libdir_subdirs to the candidates
 dnl tried. The library is not always under lib: a multilib host (Fedora,
 dnl openSUSE) keeps the 64-bit copy in lib64, Debian under a multiarch triplet.
 dnl The configured libdir is the host's own answer, so ask it before guessing.
+dnl The triplet is guessed last, because a reorder would silently swap which
+dnl library a prefix that already resolves gets linked against.
 
 AC_DEFUN([HTS_FIND_LIBDIR], [
 AC_REQUIRE([HTS_EXPAND_LIBDIR])
+AC_REQUIRE([HTS_MULTIARCH_SUBDIR])
 case $hts_libdir in
 "$hts_exec_prefix"/*) hts_hostdir=${hts_libdir#"$hts_exec_prefix"/} ;;
 */*) hts_hostdir=${hts_libdir##*/} ;;
 *) hts_hostdir=lib ;;
 esac
 hts_libdir_subdirs=$hts_hostdir
-for hts_sub in lib lib64; do
+for hts_sub in lib lib64 $hts_multiarch_subdir; do
 	test "$hts_sub" = "$hts_hostdir" || hts_libdir_subdirs="$hts_libdir_subdirs $hts_sub"
 done
 hts_found_libdir=

--- a/m4/expand_libdir.m4
+++ b/m4/expand_libdir.m4
@@ -18,22 +18,30 @@ exec_prefix=$hts_save_exec_prefix
 
 dnl @synopsis HTS_MULTIARCH_SUBDIR()
 dnl
-dnl Set hts_multiarch_subdir to the lib/TRIPLET a Debian or Ubuntu host keeps
-dnl its libraries under, empty on any other layout. gcc and clang print the
-dnl triplet only where that layout is in use, and the compiler is the one that
-dnl knows the target, so a cross build gets the triplet it is building for.
+dnl Set hts_multiarch_subdir to the lib/TRIPLET Debian and Ubuntu keep their
+dnl libraries under, empty on any other layout. The compiler is asked rather
+dnl than $host, because only the compiler knows what a cross or -m32 build
+dnl targets, and $host names the machine configure runs on.
 
 AC_DEFUN([HTS_MULTIARCH_SUBDIR], [
 AC_REQUIRE([AC_PROG_CC])
 AC_CACHE_CHECK([the multiarch library subdirectory], [hts_cv_multiarch_subdir], [
 hts_cv_multiarch_subdir=none
-hts_multiarch_triplet=`$CC -print-multiarch 2>/dev/null`
-# A compiler that does not know the option can answer on stdout, so accept
-# the reply only when it spells a single path component.
-case $hts_multiarch_triplet in
-"") ;;
+hts_multiarch_name=`$CC -print-multiarch 2>/dev/null`
+if test -z "$hts_multiarch_name"; then
+	# clang rejects -print-multiarch, but resolves libc in that same directory.
+	hts_multiarch_libc=`$CC -print-file-name=libc.so 2>/dev/null`
+	case $hts_multiarch_libc in
+	*/*)
+		hts_multiarch_name=${hts_multiarch_libc%/*}
+		hts_multiarch_name=${hts_multiarch_name##*/}
+		;;
+	esac
+fi
+# A triplet always spells an ABI, which is what tells it from a plain lib dir.
+case $hts_multiarch_name in
 *[[!-a-zA-Z0-9_.]]*) ;;
-*) hts_cv_multiarch_subdir=lib/$hts_multiarch_triplet ;;
+*-*) hts_cv_multiarch_subdir=lib/$hts_multiarch_name ;;
 esac
 ])
 if test "x$hts_cv_multiarch_subdir" = xnone; then

--- a/tests/389_configure-codec-libdir.test
+++ b/tests/389_configure-codec-libdir.test
@@ -52,12 +52,14 @@ zstd_lib=$(find_lib libzstd.so libzstd.dylib libzstd.tbd libzstd.a) ||
 brotli_hdr=$(find_hdr brotli/decode.h) || skip "no system brotli/decode.h"
 zstd_hdr=$(find_hdr zstd.h) || skip "no system zstd.h"
 
-# The multiarch candidate is whatever the compiler names, so its fixture cannot
-# invent a triplet the way the lib64 ones invent a subdirectory. A host that
-# prints none, or prints something that is not one path component, has no case.
-host_triplet=$("${cc_argv[@]}" -print-multiarch 2>/dev/null) || host_triplet=
+# Gate on the layout, never on the probe under test, so the cases run wherever
+# the bug can occur. Where the system put a library is what the layout means.
+host_triplet=${brotli_dec%/*}
+host_triplet=${host_triplet##*/}
 case ${host_triplet} in
 *[!-a-zA-Z0-9_.]*) host_triplet= ;;
+*-*) ;;
+*) host_triplet= ;;
 esac
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/codecdir.XXXXXX") || fail "no tmpdir"
@@ -106,7 +108,7 @@ fixture() {
 
 n=0
 cases=8 # expect/expect_fail calls below, what the budget is paced against
-test -z "${host_triplet}" || cases=$((cases + 2))
+test -z "${host_triplet}" || cases=$((cases + 3))
 
 # No --cache-file: the codec probes cache as ac_cv_lib_brotlidec_* and
 # ac_cv_header_zstd_h, so one cache shared across cases replays the first
@@ -223,18 +225,20 @@ expect brotli lib64 lib "--libdir picks lib64" "${br_both}" \
 expect brotli lib/x86_64-linux-gnu lib "a multiarch libdir picks the triplet" \
     "${br_multiarch}" --prefix="${work}/inst" --libdir="${work}/inst/lib/x86_64-linux-gnu"
 
-# That case only proves --libdir is honoured. A packager passing --with-brotli=/usr
-# on Debian gives no --libdir at all, so the triplet has to be a candidate of its own.
+# That case only proves --libdir is honoured, and a packager passing
+# --with-brotli=/usr gives no --libdir at all.
 if test -n "${host_triplet}"; then
     br_host=$(fixture br-host brotli brotli "lib/${host_triplet}")
     expect brotli "lib/${host_triplet}" lib "the triplet is searched without --libdir" \
         "${br_host}"
-    # Order among the guesses, which only shows when the configured libdir names
-    # neither of them: a prefix that answers under lib must keep answering there,
-    # or widening the search silently changes which library gets linked.
-    br_host_both=$(fixture br-host-both brotli brotli lib "lib/${host_triplet}")
+    # Pin the triplet behind both names ahead of it, because a reorder swaps
+    # which library gets linked and breaks no build.
+    br_host_lib=$(fixture br-host-lib brotli brotli lib "lib/${host_triplet}")
     expect brotli lib "lib/${host_triplet}" "lib outranks the triplet among the guesses" \
-        "${br_host_both}" --prefix="${work}/inst" --libdir="${work}/inst/lib64"
+        "${br_host_lib}" --prefix="${work}/inst" --libdir="${work}/inst/lib64"
+    br_host_lib64=$(fixture br-host-lib64 brotli brotli lib64 "lib/${host_triplet}")
+    expect brotli lib64 "lib/${host_triplet}" "lib64 outranks the triplet too" \
+        "${br_host_lib64}"
 fi
 
 # zstd goes through the same macro with its own library name, so one case is

--- a/tests/389_configure-codec-libdir.test
+++ b/tests/389_configure-codec-libdir.test
@@ -52,6 +52,14 @@ zstd_lib=$(find_lib libzstd.so libzstd.dylib libzstd.tbd libzstd.a) ||
 brotli_hdr=$(find_hdr brotli/decode.h) || skip "no system brotli/decode.h"
 zstd_hdr=$(find_hdr zstd.h) || skip "no system zstd.h"
 
+# The multiarch candidate is whatever the compiler names, so its fixture cannot
+# invent a triplet the way the lib64 ones invent a subdirectory. A host that
+# prints none, or prints something that is not one path component, has no case.
+host_triplet=$("${cc_argv[@]}" -print-multiarch 2>/dev/null) || host_triplet=
+case ${host_triplet} in
+*[!-a-zA-Z0-9_.]*) host_triplet= ;;
+esac
+
 work=$(mktemp -d "${TMPDIR:-/tmp}/codecdir.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "${work}"
 
@@ -98,6 +106,7 @@ fixture() {
 
 n=0
 cases=8 # expect/expect_fail calls below, what the budget is paced against
+test -z "${host_triplet}" || cases=$((cases + 2))
 
 # No --cache-file: the codec probes cache as ac_cv_lib_brotlidec_* and
 # ac_cv_header_zstd_h, so one cache shared across cases replays the first
@@ -213,6 +222,20 @@ expect brotli lib64 lib "--libdir picks lib64" "${br_both}" \
     --prefix="${work}/inst" --libdir="${work}/inst/lib64"
 expect brotli lib/x86_64-linux-gnu lib "a multiarch libdir picks the triplet" \
     "${br_multiarch}" --prefix="${work}/inst" --libdir="${work}/inst/lib/x86_64-linux-gnu"
+
+# That case only proves --libdir is honoured. A packager passing --with-brotli=/usr
+# on Debian gives no --libdir at all, so the triplet has to be a candidate of its own.
+if test -n "${host_triplet}"; then
+    br_host=$(fixture br-host brotli brotli "lib/${host_triplet}")
+    expect brotli "lib/${host_triplet}" lib "the triplet is searched without --libdir" \
+        "${br_host}"
+    # Order among the guesses, which only shows when the configured libdir names
+    # neither of them: a prefix that answers under lib must keep answering there,
+    # or widening the search silently changes which library gets linked.
+    br_host_both=$(fixture br-host-both brotli brotli lib "lib/${host_triplet}")
+    expect brotli lib "lib/${host_triplet}" "lib outranks the triplet among the guesses" \
+        "${br_host_both}" --prefix="${work}/inst" --libdir="${work}/inst/lib64"
+fi
 
 # zstd goes through the same macro with its own library name, so one case is
 # enough to show the glob is parameterised and not hardcoded to brotli.


### PR DESCRIPTION
On Debian and Ubuntu `--with-brotli=/usr` and `--with-zlib=/usr` both hard-error on master, because the shared libraries live under `/usr/lib/<triplet>`. Clang rejects `-print-multiarch` and several CI legs are clang, so detection falls back to the directory the compiler resolves libc in. The triplet is guessed after `lib` and `lib64`, so no prefix that resolves today changes its answer.
