### PR TITLE
htsweb: stale Winsock-init comment on an empty callback

### DIFF
--- a/src/htsweb.c
+++ b/src/htsweb.c
@@ -590,7 +590,6 @@ static int help_server(char *dest_path, int defaultPort, const char *bindAddr) {
 
 /* CALLBACK FUNCTIONS */
 
-/* Initialize the Winsock */
 void __cdecl htsshow_init(t_hts_callbackarg * carg) {
 }
 void __cdecl htsshow_uninit(t_hts_callbackarg * carg) {


### PR DESCRIPTION
`htsshow_init()` has an empty body. The comment above it, `/* Initialize the Winsock */`, describes work the function no longer does.
