### PR TITLE
-N's digit encoding is a parity test, not a threshold

### DIFF
--- a/src/htsname.c
+++ b/src/htsname.c
@@ -1247,9 +1247,9 @@ int url_savename(lien_adrfilsave *const afs,
   //
   // Structure originale
   else if (opt->savename_type % 100 == 0) {
-    /* recopier www.. */
     if (opt->savename_type != 100) {
-      if (((opt->savename_type / 1000) % 2) == 0) {     // >1000 signifie "pas de www/"
+      // an odd thousands digit drops the host directory
+      if (((opt->savename_type / 1000) % 2) == 0) {
         DECLARE_ADR(final_adr);
 
         // adresse url
@@ -1293,8 +1293,9 @@ int url_savename(lien_adrfilsave *const afs,
   //
   // Structure html/image
   else {
-    // dossier "web" ou "www.xxx" ?
-    if (((opt->savename_type / 1000) % 2) == 0) {       // >1000 signifie "pas de www/"
+    // an odd thousands digit drops the top directory
+    if (((opt->savename_type / 1000) % 2) == 0) {
+      // an odd hundreds digit names it after the host rather than "web"
       if ((opt->savename_type / 100) % 2) {
         DECLARE_ADR(final_adr);
 

--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -449,11 +449,14 @@ struct httrackp {
   hts_savename_83
       savename_83;   /**< saved-name length layout (long/DOS/ISO9660) */
   /** Saved-name layout preset (-N), or -1 for the savename_userdef template.
-      `% 100` picks the tree: 0 site structure, 1..5 the web/html/images
-      splits, 99 random names. An odd hundreds digit names the top directory
-      after the host rather than "web", and an odd thousands digit drops that
-      top directory. Site structure has no "web", so it reads no hundreds
-      digit beyond the literal 100, which drops the host directory. */
+      `% 100` picks the tree: 0 site structure, 1 and 2 split off images/ and
+      html/, 4 and 5 split by extension, 99 gives random names, and every
+      other value keeps the file name alone. An odd hundreds digit names the
+      top directory after the host rather than "web", and an odd thousands
+      digit drops that top directory. Site structure has no "web", so it
+      reads no hundreds digit beyond the literal 100, which drops the host
+      directory. -1 is also the only value spared the forced ".html" on an
+      extensionless name. */
   int savename_type;
   String
       savename_userdef; /**< user-defined name template (e.g. %h%p/%n%q.%t) */

--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -448,7 +448,13 @@ struct httrackp {
   t_proxy proxy;     /**< proxy configuration */
   hts_savename_83
       savename_83;   /**< saved-name length layout (long/DOS/ISO9660) */
-  int savename_type; /**< saved-name layout (original tree, flat, ...) */
+  /** Saved-name layout preset (-N), or -1 for the savename_userdef template.
+      `% 100` picks the tree: 0 site structure, 1..5 the web/html/images
+      splits, 99 random names. An odd hundreds digit names the top directory
+      after the host rather than "web", and an odd thousands digit drops that
+      top directory. Site structure has no "web", so it reads no hundreds
+      digit beyond the literal 100, which drops the host directory. */
+  int savename_type;
   String
       savename_userdef; /**< user-defined name template (e.g. %h%p/%n%q.%t) */
   hts_savename_delayed savename_delayed; /**< delayed type-check policy */

--- a/tests/400_engine-savename-type-digits.test
+++ b/tests/400_engine-savename-type-digits.test
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+# -N's digits are read by PARITY, not by threshold: an odd thousands digit drops
+# the top directory, an odd hundreds digit names it after the host rather than
+# "web", and % 100 picks the tree. Every documented preset stays under 2000, so a
+# "greater than 1000" reading of the same test passes the whole man page.
+want() { # want SAVE TYPE FIL CONTENT-TYPE
+    selftest_queue "savename: /dev/null/$1" savename "$3" "$4" "type=$2"
+}
+
+# Site structure ignores the hundreds digit; only the literal 100 drops the host.
+want 'www.example.com/dir/page.html' 0 /dir/page.html text/html
+want 'dir/page.html' 100 /dir/page.html text/html
+want 'www.example.com/dir/page.html' 300 /dir/page.html text/html
+want 'dir/page.html' 1000 /dir/page.html text/html
+want 'www.example.com/dir/page.html' 2000 /dir/page.html text/html
+want 'dir/page.html' 1100 /dir/page.html text/html
+
+# The web/html/images trees read both digits.
+want 'web/images/pic.gif' 1 /dir/pic.gif image/gif
+want 'www.example.com/images/pic.gif' 101 /dir/pic.gif image/gif
+want 'images/pic.gif' 1001 /dir/pic.gif image/gif
+want 'www.example.com/images/pic.gif' 2101 /dir/pic.gif image/gif
+want 'web/images/pic.gif' 201 /dir/pic.gif image/gif
+want 'images/pic.gif' 3001 /dir/pic.gif image/gif
+want 'web/gif/pic.gif' 4 /dir/pic.gif image/gif
+
+selftest_run_queued

--- a/tests/400_engine-savename-type-digits.test
+++ b/tests/400_engine-savename-type-digits.test
@@ -30,4 +30,16 @@ want 'web/images/pic.gif' 201 /dir/pic.gif image/gif
 want 'images/pic.gif' 3001 /dir/pic.gif image/gif
 want 'web/gif/pic.gif' 4 /dir/pic.gif image/gif
 
+# 3 is not a split of its own: it lands on the same default as every residue
+# the presets never name.
+want 'web/pic.gif' 3 /dir/pic.gif image/gif
+want 'web/pic.gif' 42 /dir/pic.gif image/gif
+# 10 also pins the selector's modulus: under `% 10` it would be a site structure.
+want 'web/pic.gif' 10 /dir/pic.gif image/gif
+
+# An extensionless name gets .html forced on, except under the -N template.
+want 'web/noext.html' 3 /dir/noext text/html
+selftest_queue 'savename: /dev/null/www.example.com/dir/noext' savename \
+    /dir/noext text/html type=-1 'userdef=%h%p/%n'
+
 selftest_run_queued


### PR DESCRIPTION
`src/htsname.c` twice carried `// >1000 signifie "pas de www/"` over `((opt->savename_type / 1000) % 2) == 0`. The code tests that digit's parity rather than a threshold. So `-N2000` keeps the host directory the comment says it drops, and `-N3001` drops the `web/` directory a threshold reading would keep. No shipped preset is affected, because every one the man page documents stays below 2000.

Behaviour is unchanged. Both comments now say what the test does, and the encoding itself moves to the field in `htsopt.h`, which recorded none of it. `% 100` picks the tree, an odd hundreds digit names the top directory after the host, and an odd thousands digit drops that directory. Site structure is the exception the man page's `-N100` already hints at, because it reads no hundreds digit beyond that literal value.

The new `400_engine-savename-type-digits.test` pins each of those claims through `-#test=savename`. I ran it against both threshold mutants, one per digit, and each one reds it.
