### PR TITLE
A skipped crash-symbolize test names no suspect

### DIFF
--- a/tests/80_engine-crash-symbolize.test
+++ b/tests/80_engine-crash-symbolize.test
@@ -50,15 +50,27 @@ command -v addr2line >/dev/null || skip "addr2line not installed"
 # the assertion below into a vacuous pass. Second form: glibc drops the "+0x"
 # when the load bias is zero, and the bracketed address is then the file one.
 oracle="${tmpdir}/oracle"
+frames="${tmpdir}/frames"
 sed -n -e 's/^\([^(]*\)(+\(0x[0-9a-f]*\)).*$/\1 \2/p' \
-    -e 's/^\([^(]*\)() \[\(0x[0-9a-f]*\)\].*$/\1 \2/p' "$out" |
-    while read -r mod off; do
-        # The main program is reported as argv[0], a bare name off PATH (#889).
-        test -f "$mod" || mod=$(command -v "$mod" 2>/dev/null) || continue
-        test -f "$mod" || continue
-        addr2line -Cfip -e "$mod" "$off" 2>/dev/null || true
-    done >"$oracle"
-grep -qE 'st_strsafe|strcpy_safe_' "$oracle" || skip "addr2line names no hidden symbol in this build"
+    -e 's/^\([^(]*\)() \[\(0x[0-9a-f]*\)\].*$/\1 \2/p' "$out" >"$frames"
+# Read from the file, not a pipe: a subshell would lose the count below.
+resolved=0
+: >"$oracle"
+while read -r mod off; do
+    # The main program is reported as argv[0], a bare name off PATH (#889).
+    test -f "$mod" || mod=$(command -v "$mod" 2>/dev/null) || continue
+    test -f "$mod" || continue
+    resolved=$((resolved + 1))
+    addr2line -Cfip -e "$mod" "$off" 2>/dev/null >>"$oracle" || true
+done <"$frames"
+if ! grep -qE 'st_strsafe|strcpy_safe_' "$oracle"; then
+    # Which stage came up empty, because the skip alone names no suspect and
+    # this is the form the emulated s390x leg has been reporting.
+    echo "parsed $(wc -l <"$frames") frames, resolved ${resolved} of them to a file" >&2
+    dump_file "$out"
+    dump_file "$oracle"
+    skip "addr2line names no hidden symbol in this build"
+fi
 
 # The payload. Dropping the raw frames first is what makes it specific: both
 # names are static, so .dynsym could never have carried them. Not anchored on

--- a/tests/80_engine-crash-symbolize.test
+++ b/tests/80_engine-crash-symbolize.test
@@ -69,6 +69,11 @@ if ! grep -qE 'st_strsafe|strcpy_safe_' "$oracle"; then
     echo "parsed $(wc -l <"$frames") frames, resolved ${resolved} of them to a file" >&2
     dump_file "$out"
     dump_file "$oracle"
+    # Under qemu-user the trace stops at the vdso trampoline, so the engine
+    # frames are missing rather than unnamed: say which of the two it is.
+    if grep -q 'sigreturn' "$out"; then
+        skip "the unwinder stopped at the signal frame, so no engine frame reached the trace"
+    fi
     skip "addr2line names no hidden symbol in this build"
 fi
 


### PR DESCRIPTION
The emulated s390x leg skips `80_engine-crash-symbolize.test` with `addr2line names no hidden symbol in this build`. That one message covers three failures that read identically in the log:

- the trace parsed no frames,
- no frame's module resolved to a file on disk,
- addr2line ran and named something other than the hidden frames.

The test now prints how many frames it parsed and how many it resolved, and it dumps the raw trace and the oracle before skipping. A negative control with a silent `addr2line` on the PATH confirms the dump fires.

That diagnostic then ran on this branch and named the cause. The s390x trace stops at `linux-vdso64.so.1(__kernel_sigreturn)` after two frames, and addr2line resolved both to a file and a line. The engine frames sit below the signal frame and never reach the trace, so the old message blamed the wrong component. The second commit skips with that reason when the trace carries a sigreturn entry. It stays a skip: crossing a signal frame under qemu-user is not something a test can fix. `218_crash-nopie-frames.test` skips on that leg for what looks like the same reason.

The overnight architecture sweep had blamed a missing `-g`, on the theory that `tools/emulated-suite.sh` runs a bare `configure` and addr2line therefore resolves nothing. Both halves are wrong. `configure.ac` never assigns `CFLAGS`, so `AC_PROG_CC` supplies gcc's default of `-g -O2`, and the emulated log carries `checking whether gcc accepts -g... yes`. I also built this tree with `CFLAGS=-O2`, where the test passes.