### PR TITLE
A ZIP extra field picks its own copy length in an unreachable minizip helper

### DIFF
--- a/src/minizip/zip.c
+++ b/src/minizip/zip.c
@@ -1007,11 +1007,11 @@ local int Write_LocalFileHeader(zip64_internal* zi, const char* filename, uInt s
 
 /*
  NOTE.
- When writing RAW the ZIP64 extended information in extrafield_local and extrafield_global needs to be stripped
- before calling this function it can be done with zipRemoveExtraInfoBlock
+ When writing RAW the ZIP64 extended information in extrafield_local and
+ extrafield_global needs to be stripped before calling this function.
 
- It is not done here because then we need to realloc a new buffer since parameters are 'const' and I want to minimize
- unnecessary allocations.
+ It is not done here because then we need to realloc a new buffer since
+ parameters are 'const' and I want to minimize unnecessary allocations.
  */
 extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char* filename, const zip_fileinfo* zipfi,
                                            const void* extrafield_local, uInt size_extrafield_local,
@@ -1949,61 +1949,4 @@ extern int ZEXPORT zipClose(zipFile file, const char* global_comment) {
     free(zi);
 
     return err;
-}
-
-extern int ZEXPORT zipRemoveExtraInfoBlock(char* pData, int* dataLen, short sHeader) {
-  char* p = pData;
-  int size = 0;
-  char* pNewHeader;
-  char* pTmp;
-  short header;
-  short dataSize;
-
-  int retVal = ZIP_OK;
-
-  if(pData == NULL || dataLen == NULL || *dataLen < 4)
-    return ZIP_PARAMERROR;
-
-  pNewHeader = (char*)ALLOC((unsigned)*dataLen);
-  pTmp = pNewHeader;
-
-  while(p < (pData + *dataLen))
-  {
-    header = *(short*)p;
-    dataSize = *(((short*)p)+1);
-
-    if( header == sHeader ) // Header found.
-    {
-      p += dataSize + 4; // skip it. do not copy to temp buffer
-    }
-    else
-    {
-      // Extra Info block should not be removed, So copy it to the temp buffer.
-      memcpy(pTmp, p, dataSize + 4);
-      p += dataSize + 4;
-      size += dataSize + 4;
-    }
-
-  }
-
-  if(size < *dataLen)
-  {
-    // clean old extra info block.
-    memset(pData,0, *dataLen);
-
-    // copy the new extra info block over the old
-    if(size > 0)
-      memcpy(pData, pNewHeader, size);
-
-    // set the new extra info size
-    *dataLen = size;
-
-    retVal = ZIP_OK;
-  }
-  else
-    retVal = ZIP_ERRNO;
-
-  free(pNewHeader);
-
-  return retVal;
 }

--- a/src/minizip/zip.c.diff
+++ b/src/minizip/zip.c.diff
@@ -1,5 +1,21 @@
---- zip.c.orig	2024-01-27 14:07:18.636193212 +0100
-+++ zip.c	2024-01-27 14:09:59.736631926 +0100
+--- zip.c.orig	2026-09-03 22:29:36.862585755 +0200
++++ zip.c	2026-09-03 22:38:26.836034035 +0200
+@@ -1007,11 +1007,11 @@
+ 
+ /*
+  NOTE.
+- When writing RAW the ZIP64 extended information in extrafield_local and extrafield_global needs to be stripped
+- before calling this function it can be done with zipRemoveExtraInfoBlock
++ When writing RAW the ZIP64 extended information in extrafield_local and
++ extrafield_global needs to be stripped before calling this function.
+ 
+- It is not done here because then we need to realloc a new buffer since parameters are 'const' and I want to minimize
+- unnecessary allocations.
++ It is not done here because then we need to realloc a new buffer since
++ parameters are 'const' and I want to minimize unnecessary allocations.
+  */
+ extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char* filename, const zip_fileinfo* zipfi,
+                                            const void* extrafield_local, uInt size_extrafield_local,
 @@ -1412,7 +1412,7 @@
      else
  #endif
@@ -76,3 +92,64 @@
  extern int ZEXPORT zipClose(zipFile file, const char* global_comment) {
      zip64_internal* zi;
      int err = 0;
+@@ -1897,60 +1950,3 @@
+ 
+     return err;
+ }
+-
+-extern int ZEXPORT zipRemoveExtraInfoBlock(char* pData, int* dataLen, short sHeader) {
+-  char* p = pData;
+-  int size = 0;
+-  char* pNewHeader;
+-  char* pTmp;
+-  short header;
+-  short dataSize;
+-
+-  int retVal = ZIP_OK;
+-
+-  if(pData == NULL || dataLen == NULL || *dataLen < 4)
+-    return ZIP_PARAMERROR;
+-
+-  pNewHeader = (char*)ALLOC((unsigned)*dataLen);
+-  pTmp = pNewHeader;
+-
+-  while(p < (pData + *dataLen))
+-  {
+-    header = *(short*)p;
+-    dataSize = *(((short*)p)+1);
+-
+-    if( header == sHeader ) // Header found.
+-    {
+-      p += dataSize + 4; // skip it. do not copy to temp buffer
+-    }
+-    else
+-    {
+-      // Extra Info block should not be removed, So copy it to the temp buffer.
+-      memcpy(pTmp, p, dataSize + 4);
+-      p += dataSize + 4;
+-      size += dataSize + 4;
+-    }
+-
+-  }
+-
+-  if(size < *dataLen)
+-  {
+-    // clean old extra info block.
+-    memset(pData,0, *dataLen);
+-
+-    // copy the new extra info block over the old
+-    if(size > 0)
+-      memcpy(pData, pNewHeader, size);
+-
+-    // set the new extra info size
+-    *dataLen = size;
+-
+-    retVal = ZIP_OK;
+-  }
+-  else
+-    retVal = ZIP_ERRNO;
+-
+-  free(pNewHeader);
+-
+-  return retVal;
+-}

--- a/src/minizip/zip.h
+++ b/src/minizip/zip.h
@@ -354,25 +354,6 @@ extern int ZEXPORT zipClose(zipFile file,
   Close the zipfile
 */
 
-
-extern int ZEXPORT zipRemoveExtraInfoBlock(char* pData, int* dataLen, short sHeader);
-/*
-  zipRemoveExtraInfoBlock -  Added by Mathias Svensson
-
-  Remove extra information block from a extra information data for the local file header or central directory header
-
-  It is needed to remove ZIP64 extra information blocks when before data is written if using RAW mode.
-
-  0x0001 is the signature header for the ZIP64 extra information blocks
-
-  usage.
-                        Remove ZIP64 Extra information from a central director extra field data
-              zipRemoveExtraInfoBlock(pCenDirExtraFieldData, &nCenDirExtraFieldDataLen, 0x0001);
-
-                        Remove ZIP64 Extra information from a Local File Header extra field data
-        zipRemoveExtraInfoBlock(pLocalHeaderExtraFieldData, &nLocalHeaderExtraFieldDataLen, 0x0001);
-*/
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/minizip/zip.h.diff
+++ b/src/minizip/zip.h.diff
@@ -1,5 +1,5 @@
---- zip.h.orig	2024-01-27 14:07:18.636193212 +0100
-+++ zip.h	2024-01-27 14:10:04.104643731 +0100
+--- zip.h.orig	2026-09-03 22:29:36.862585755 +0200
++++ zip.h	2026-09-03 22:38:26.836034035 +0200
 @@ -75,6 +75,9 @@
  #define ZIP_PARAMERROR                  (-102)
  #define ZIP_BADZIPFILE                  (-103)
@@ -35,3 +35,29 @@
  extern int ZEXPORT zipCloseFileInZipRaw(zipFile file,
                                          uLong uncompressed_size,
                                          uLong crc32);
+@@ -338,25 +354,6 @@
+   Close the zipfile
+ */
+ 
+-
+-extern int ZEXPORT zipRemoveExtraInfoBlock(char* pData, int* dataLen, short sHeader);
+-/*
+-  zipRemoveExtraInfoBlock -  Added by Mathias Svensson
+-
+-  Remove extra information block from a extra information data for the local file header or central directory header
+-
+-  It is needed to remove ZIP64 extra information blocks when before data is written if using RAW mode.
+-
+-  0x0001 is the signature header for the ZIP64 extra information blocks
+-
+-  usage.
+-                        Remove ZIP64 Extra information from a central director extra field data
+-              zipRemoveExtraInfoBlock(pCenDirExtraFieldData, &nCenDirExtraFieldDataLen, 0x0001);
+-
+-                        Remove ZIP64 Extra information from a Local File Header extra field data
+-        zipRemoveExtraInfoBlock(pLocalHeaderExtraFieldData, &nLocalHeaderExtraFieldDataLen, 0x0001);
+-*/
+-
+ #ifdef __cplusplus
+ }
+ #endif

--- a/tests/405_minizip-no-extra-parser.test
+++ b/tests/405_minizip-no-extra-parser.test
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# zipRemoveExtraInfoBlock parsed a ZIP extra field with no bound on its declared
+# block size, and nothing called it. A vendor bump would restore it silently.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+dead=zipRemoveExtraInfoBlock
+# Same translation unit, so a bump that restores one restores both.
+control=zipClose
+
+[ -n "${abs_top_builddir:-}" ] || skip "abs_top_builddir unset, no automake environment"
+[ -f "$abs_top_builddir/src/Makefile" ] || fail "$abs_top_builddir/src is not configured"
+
+nm=${NM:-nm}
+command -v "$nm" >/dev/null 2>&1 || skip "no nm ($nm)"
+
+tmp=$(mktemp -d) || exit 1
+cleanup_push rm -rf "$tmp"
+
+targets=()
+[ -f "${HTTRACK_SHLIB:-/nonexistent}" ] && targets+=("$HTTRACK_SHLIB")
+while IFS= read -r o; do
+    targets+=("$o")
+done < <(find "$abs_top_builddir/src" -name '*.o' -print 2>/dev/null | sort)
+
+[ "${#targets[@]}" -gt 0 ] || skip "no built objects or library under $abs_top_builddir/src"
+
+: >"$tmp/defined"
+readable=0
+for t in "${targets[@]}"; do
+    "$nm" --defined-only "$t" >"$tmp/one.raw" 2>/dev/null || continue
+    readable=$((readable + 1))
+    awk -v f="$t" 'NF >= 2 { print f, $NF }' "$tmp/one.raw" >>"$tmp/defined"
+done
+
+[ "$readable" -gt 0 ] || skip "$nm read none of the ${#targets[@]} built products"
+
+# Without this the whole test passes on an empty or stripped symbol table.
+ctl=$(awk -v s="$control" '$2 == s { print $1 }' "$tmp/defined" | sort -u)
+[ -n "$ctl" ] || skip "$control is absent too, so the probe over $readable products is blind"
+
+hits=$(awk -v s="$dead" '$2 == s { print $1 }' "$tmp/defined" | sort -u)
+if [ -n "$hits" ]; then
+    echo "$hits" >&2
+    fail "$dead is back in the build; it is an unbounded ZIP extra-field parser with no caller"
+fi
+
+echo "PASS: $dead defined in none of $readable built products ($control found in $(echo "$ctl" | wc -l))"


### PR DESCRIPTION
`zipRemoveExtraInfoBlock` in the vendored `src/minizip/zip.c` walked a ZIP extra field without ever validating the block size it read out of that field. Three defects follow from the one missing check. The loop guard `while(p < (pData + *dataLen))` admits a partial block, so the two `*(short*)` reads opening each iteration run past the buffer. The `memcpy(pTmp, p, dataSize + 4)` after them is never compared against `*dataLen`, so two bytes taken from the archive choose both a source offset and a copy length. A declared `dataSize` of 0x7ff0 writes 32756 bytes into an allocation sized `*dataLen`, which is a controlled-offset, controlled-length heap write rather than an overread. `dataSize` is also a signed `short`, so a declared 0x8000 makes `dataSize + 4` negative and wraps the length. Those same two loads are misaligned, which faults on sh4, m68k, hppa, sparc, mips and alpha.

Nothing reaches any of it today, so the fix is deletion rather than a patch. Bounding a function with no caller means inventing its contract, because every limit you pick is a guess about a caller that does not exist. Removing it retires the whole class.

The reachability verdict comes from the linker rather than from grep. Across the 141 objects a full build produces, `nm --defined-only` finds the definition in `src/minizip/proxytrack-zip.o` and `src/minizip/libhttrack_la-zip.o` (plus libtool's PIC copy). `nm --undefined-only` finds no reference in any of those objects, nor in `httrack`, `htsserver`, `proxytrack`, `libhttrack.so` or the ten test plugins. `nm -D --defined-only libhttrack.so.3.0.20` lists 172 exported symbols and this is not one of them. That count is the control, because a probe reading an empty symbol table would report the same absence. `minizip/zip.h` is not in `DevIncludes_DATA`, so it never reaches an installed prefix. Upstream minizip does not call it either, since the `.orig` copies in the tree carry the same definition and prototype with no call site. The two apparent calls in `zip.h` sit inside the comment block that opens at line 359 and closes at line 374.

`tests/405_minizip-no-extra-parser.test` scans the built library and every object under `src/`, and it requires `zipClose` in that same set before it trusts an absence. Without that control the test would pass on a stripped or empty table. It kills the mutant: a stub definition reds it and names all four products carrying the symbol.

The tree keeps a `.orig` plus `.diff` record per vendored file, so `zip.c.diff` and `zip.h.diff` are regenerated. Both were checked by applying them to the `.orig` and comparing against the tree copy. The pre-existing hunks (the `next_in` const fix, `zipFlush`, `zipAbandonFileInZip`) survive unchanged.
