### PR TITLE
Three paths fill an in-memory body past the bound the receive guard enforces

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -974,6 +974,17 @@ static void back_report_write_failure(httrackp *opt, lien_back *const back) {
   }
 }
 
+hts_boolean back_set_decoded_size(htsblk *r, LLint size) {
+  if (!r->is_write && !hts_inmem_size_fits(size)) {
+    r->statuscode = STATUSCODE_INVALID;
+    strcpybuff(r->msg, "Decompressed content too large");
+    deleteaddr(r);
+    return HTS_FALSE;
+  }
+  r->size = r->totalsize = size;
+  return HTS_TRUE;
+}
+
 // objet (lien) téléchargé ou transféré depuis le cache
 //
 // fermer les paramètres de transfert,
@@ -1101,15 +1112,19 @@ int back_finalize(httrackp * opt, cache_back * cache, struct_back * sback,
                     deleteaddr(&back[p].r);
                 } else if ((size = hts_codec_unpack(codec, back[p].tmpfile,
                                                     unpacked)) >= 0) {
-                  back[p].r.size = back[p].r.totalsize = size;
-                  if (back[p].r.is_write) {
+                  const hts_boolean sized =
+                      back_set_decoded_size(&back[p].r, size);
+
+                  if (sized && back[p].r.is_write) {
                     /* Sample the previous copy now: the rename below replaces
                        it, and file_notify() only fires once it is gone. */
                     hts_changes_notify(
                         opt, back[p].url_adr, back[p].url_fil, back[p].url_sav,
                         HTS_TRUE, back[p].r.notmodified ? HTS_TRUE : HTS_FALSE);
                   }
-                  if (!back[p].r.is_write) {
+                  if (!sized) {
+                    UNLINK(unpacked);
+                  } else if (!back[p].r.is_write) {
                     // fichier -> mémoire ; le fichier est écrit plus tard
                     deleteaddr(&back[p].r);
                     back[p].r.adr = readfile_utf8(unpacked);
@@ -3923,11 +3938,10 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                         back[i].chunk_blocksize = -1;   /* ending */
                       back[i].r.totalsize += chunk_size;        // noter taille
                       if (back[i].r.adr != NULL || !back[i].r.is_write) {       // Not to disk
-                        // totalsize sums attacker-declared chunk sizes; past
-                        // 2GB the (size_t) cast below truncates on 32-bit and
-                        // under-allocates. Mark the chunk invalid so the shared
-                        // error path tears the transfer down.
-                        if (back[i].r.totalsize > INT32_MAX) {
+                        /* A wider bound here buys the realloc that only the
+                           next read would refuse; an invalid chunk tears the
+                           transfer down. */
+                        if (!hts_inmem_size_fits(back[i].r.totalsize)) {
                           hts_log_print(opt, LOG_WARNING,
                                         "Chunked resource too large for %s%s",
                                         back[i].url_adr, back[i].url_fil);

--- a/src/htsback.h
+++ b/src/htsback.h
@@ -142,6 +142,11 @@ int back_finalize(httrackp * opt, cache_back * cache, struct_back * sback,
    deliberately passing the resource over? Only the latter may be purged, so
    this also decides whether the previous copy survives the update (#746). */
 hts_boolean back_transfer_failed(const int statuscode);
+/* Commit a decoded body size onto r, refusing in memory what http_xfread1()
+   refuses: hts_codec_maxout() caps at INT_MAX inclusive, so the one size the
+   receive guard rejects is reachable through a content coding. A refusal
+   classes and names r, drops its still-coded body, and returns HTS_FALSE. */
+hts_boolean back_set_decoded_size(htsblk *r, LLint size);
 /* Move the previous copy of back->url_sav to back->tmpfile so back_finalize()
    can put it back when the re-fetch fails (#77 follow-up). Call right before
    truncating url_sav; tmpfile stays NULL when there is nothing to save. */

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -1418,14 +1418,18 @@ char *readfile(const char *fil) {
 }
 
 /* Note: NOT utf-8 */
-char *readfile2(const char *fil, LLint * size) {
+static char *readfile_gen(const char *fil, LLint *size, hts_boolean inmem) {
   char *adr = NULL;
   char catbuff[CATBUFF_SIZE];
   const LLint len = fsize(fil);
 
   /* a size too large for size_t (32-bit Windows/i386) must fail closed: it
-     would wrap malloct() short while fread() still read the untruncated len */
-  const size_t buflen = len >= 0 ? llint_to_size_t(len) : (size_t) -1;
+     would wrap malloct() short while fread() still read the untruncated len.
+     This one stat also decides the in-memory bound, so nothing appended
+     between a caller's check and the read can carry the body past it. */
+  const size_t buflen = len >= 0 && (!inmem || hts_inmem_size_fits(len))
+                            ? llint_to_size_t(len)
+                            : (size_t) -1;
 
   if (buflen != (size_t) -1) { // exists, and is addressable
     FILE *fp;
@@ -1447,6 +1451,16 @@ char *readfile2(const char *fil, LLint * size) {
     }
   }
   return adr;
+}
+
+/* Note: NOT utf-8 */
+char *readfile2(const char *fil, LLint *size) {
+  return readfile_gen(fil, size, HTS_FALSE);
+}
+
+/* Note: NOT utf-8 */
+char *readfile2_inmem(const char *fil, LLint *size) {
+  return readfile_gen(fil, size, HTS_TRUE);
 }
 
 /* Note: utf-8 */

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -485,13 +485,6 @@ static int look_like_xml(const char *s) {
 
 // Début de httpmirror, robot
 // url1 peut être multiple
-/* Load a local body back into memory for parsing. Refuses a file too large for
-   the int indexes downstream, one of which htsparse divides by, and reads
-   nothing in that case. Note: NOT utf-8. */
-static char *readfile_for_parsing(const char *file, LLint *size) {
-  return hts_inmem_size_fits(fsize(file)) ? readfile2(file, size) : NULL;
-}
-
 int httpmirror(char *url1, httrackp *opt, hts_boolean *completed_out) {
   char *primary = NULL;         // première page, contenant les liens à scanner
   hash_struct hash;             // système de hachage, accélère la recherche dans les liens
@@ -1375,7 +1368,7 @@ int httpmirror(char *url1, httrackp *opt, hts_boolean *completed_out) {
           )  \
         { \
           is_loaded_from_file = 1; \
-          r.adr = readfile_for_parsing(savename(), &r.size); \
+          r.adr = readfile2_inmem(savename(), &r.size); \
           if (r.adr != NULL) { \
             hts_log_print(opt, LOG_INFO, "File successfully loaded for parsing: %s%s (%d bytes)",urladr(),urlfil(),(int)r.size); \
           } else { \

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -485,6 +485,13 @@ static int look_like_xml(const char *s) {
 
 // Début de httpmirror, robot
 // url1 peut être multiple
+/* Load a local body back into memory for parsing. Refuses a file too large for
+   the int indexes downstream, one of which htsparse divides by, and reads
+   nothing in that case. Note: NOT utf-8. */
+static char *readfile_for_parsing(const char *file, LLint *size) {
+  return hts_inmem_size_fits(fsize(file)) ? readfile2(file, size) : NULL;
+}
+
 int httpmirror(char *url1, httrackp *opt, hts_boolean *completed_out) {
   char *primary = NULL;         // première page, contenant les liens à scanner
   hash_struct hash;             // système de hachage, accélère la recherche dans les liens
@@ -1356,6 +1363,8 @@ int httpmirror(char *url1, httrackp *opt, hts_boolean *completed_out) {
         }
 
         /* Load file if necessary and decode. */
+        /* clang-format off: an edit realigns all backslashes, churning the macro. */
+        /* clang-format off */
 #define LOAD_IN_MEMORY_IF_NECESSARY() do { \
         if (  \
           may_be_hypertext_mime(opt,r.contenttype, urlfil())   /* Is HTML or Js, .. */ \
@@ -1366,7 +1375,7 @@ int httpmirror(char *url1, httrackp *opt, hts_boolean *completed_out) {
           )  \
         { \
           is_loaded_from_file = 1; \
-          r.adr = readfile2(savename(), &r.size); \
+          r.adr = readfile_for_parsing(savename(), &r.size); \
           if (r.adr != NULL) { \
             hts_log_print(opt, LOG_INFO, "File successfully loaded for parsing: %s%s (%d bytes)",urladr(),urlfil(),(int)r.size); \
           } else { \
@@ -1376,6 +1385,7 @@ int httpmirror(char *url1, httrackp *opt, hts_boolean *completed_out) {
 } while(0)
         /* Load file and decode if necessary, before content-binary check. (3.43) */
         LOAD_IN_MEMORY_IF_NECESSARY();
+        /* clang-format on */
 
         // ------------------------------------
         // BOGUS MIME TYPE HACK II (the revenge)

--- a/src/htscore.h
+++ b/src/htscore.h
@@ -484,6 +484,11 @@ char *readfile(const char *fil);
 
 char *readfile2(const char *fil, LLint * size);
 
+/* readfile2() refusing a body too large for the int indexes downstream, on the
+   same stat that sizes the read: a caller checking the size itself would leave
+   a window for the file to grow. NULL when it does not fit. */
+char *readfile2_inmem(const char *fil, LLint *size);
+
 char *readfile_utf8(const char *fil);
 
 char *readfile2_utf8(const char *fil, LLint *size);

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -1964,6 +1964,10 @@ static void classify_write_error(htsblk *r) {
   strcpybuff(r->msg, "Write error on disk");
 }
 
+hts_boolean hts_inmem_size_fits(LLint size) {
+  return size >= 0 && size < INT32_MAX ? HTS_TRUE : HTS_FALSE;
+}
+
 // Read one block: bufl is a byte count, or one of the HTS_XFREAD_* line modes.
 // Note: the +1 in the mallocs is the trailing NUL appended to the data.
 LLint http_xfread1(htsblk * r, int bufl) {
@@ -1976,11 +1980,10 @@ LLint http_xfread1(htsblk * r, int bufl) {
 
   if (bufl > 0) {
     if (!r->is_write) {         // stocker en mémoire
-      // In-memory content must fit a 32-bit index (allocs below add 1, reads
-      // use int offsets): reject a hostile Content-Length or endless stream.
+      // Reject a hostile Content-Length, or an endless stream.
       const LLint inmem_want =
           (r->totalsize >= 0) ? r->totalsize : (r->size + bufl);
-      if (inmem_want >= INT32_MAX) {
+      if (!hts_inmem_size_fits(inmem_want)) {
         r->statuscode = STATUSCODE_INVALID;
         strcpybuff(r->msg, "In-memory content too large");
         return READ_ERROR;

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -297,6 +297,10 @@ void treatfirstline(htsblk * retour, const char *rcvd);
 #define HTS_XFREAD_LINE_BLOCK 0 /* lines up to a blank one (header/trailer) */
 #define HTS_XFREAD_LINE (-1)    /* one line, stopping at the first LF */
 LLint http_xfread1(htsblk * r, int bufl);
+/* Does an in-memory body of this size fit? r->adr is indexed with an int
+   downstream and its allocations add a trailing NUL, so every producer of
+   r->size must refuse where http_xfread1() does. */
+hts_boolean hts_inmem_size_fits(LLint size);
 /* Cached resolver: fill out[0..count-1] with up to max addresses for iadr (in
    resolver order), returning the count (0 = does not resolve, negative-cached).
    Resolves once per host; later calls read the DNS cache. Must hold no lock

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2979,11 +2979,58 @@ static int st_headerfield(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* Drive one http_xfread1 call. entered is the buffer the case came in with, so
+   a guard that allocates before refusing shows up. */
+static void st_xfread_case(const char *name, htsblk *r, int bufl,
+                           const char *entered) {
+  /* Separate statements: as printf arguments a compiler may sample r->adr
+     before the call, where no allocation can show. */
+  const LLint ret = http_xfread1(r, bufl);
+  const char *const adr = r->adr;
+  const int code = r->statuscode;
+  const char *state;
+
+  if (adr == NULL)
+    state = "null";
+  else if (adr == entered)
+    state = "kept";
+  else
+    state = "alloc";
+  printf("%s: refused=%d adr=%s code=%d msg=%s\n", name,
+         ret == READ_ERROR ? 1 : 0, state, code, r->msg);
+}
+
+/* Drive back_set_decoded_size() on a slot still holding its coded body. */
+static void st_decode_size_case(const char *name, int is_write, LLint size) {
+  htsblk r;
+  hts_boolean ok;
+  const char *state;
+  LLint committed;
+
+  memset(&r, 0, sizeof(r));
+  r.soc = INVALID_SOCKET;
+  r.is_write = (short int) is_write;
+  r.adr = (char *) malloct(64);
+  r.size = 64;
+  ok = back_set_decoded_size(&r, size);
+  state = r.adr != NULL ? "kept" : "dropped";
+  committed = r.size;
+  printf("%s: ok=%d body=%s size=" LLintP " code=%d msg=%s\n", name,
+         ok == HTS_TRUE ? 1 : 0, state, committed, r.statuscode, r.msg);
+  freet(r.adr);
+}
+
 /* http_xfread1 must refuse an in-memory buffer whose size would exceed a 32-bit
    index (hostile Content-Length or endless stream) rather than allocate it.
-   The guard returns before any socket read, so no real connection is needed. */
+   The guard returns before any socket read, so no real connection is needed.
+   The same bound must hold on the two paths that fill r->adr without it: a
+   chunk stream, and a decoded content coding. */
 static int st_xfread_limit(httrackp *opt, int argc, char **argv) {
+  static const LLint sizes[] = {
+      0, 1000, (LLint) INT32_MAX - 1, (LLint) INT32_MAX, (LLint) INT32_MAX + 1,
+      -1};
   htsblk r;
+  size_t i;
 
   (void) opt;
   (void) argc;
@@ -2993,22 +3040,23 @@ static int st_xfread_limit(httrackp *opt, int argc, char **argv) {
   memset(&r, 0, sizeof(r));
   r.soc = INVALID_SOCKET;
   r.totalsize = (LLint) INT32_MAX + 1;
-  printf("bylen: refused=%d adr=%s msg=%s\n",
-         http_xfread1(&r, 8192) == READ_ERROR, r.adr != NULL ? "alloc" : "null",
-         r.msg);
-  if (r.adr != NULL)
-    freet(r.adr);
+  st_xfread_case("bylen", &r, 8192, NULL);
+  freet(r.adr);
+
+  // 4 GiB: truncated to an int this length reads as 0.
+  memset(&r, 0, sizeof(r));
+  r.soc = INVALID_SOCKET;
+  r.totalsize = (LLint) 1 << 32;
+  st_xfread_case("bylen4g", &r, 8192, NULL);
+  freet(r.adr);
 
   // Unknown length, buffer already at the limit: the next read would exceed it.
   memset(&r, 0, sizeof(r));
   r.soc = INVALID_SOCKET;
   r.totalsize = -1;
   r.size = (LLint) INT32_MAX;
-  printf("bygrow: refused=%d adr=%s msg=%s\n",
-         http_xfread1(&r, 8192) == READ_ERROR, r.adr != NULL ? "alloc" : "null",
-         r.msg);
-  if (r.adr != NULL)
-    freet(r.adr);
+  st_xfread_case("bygrow", &r, 8192, NULL);
+  freet(r.adr);
 
   // Exactly at the 2 GiB index (size + bufl == INT32_MAX): must also be
   // refused, since the reallocs below add 1 (a `> INT32_MAX` check would let
@@ -3017,18 +3065,46 @@ static int st_xfread_limit(httrackp *opt, int argc, char **argv) {
   r.soc = INVALID_SOCKET;
   r.totalsize = -1;
   r.size = (LLint) INT32_MAX - 8192;
-  http_xfread1(&r, 8192);
-  printf("boundary: msg=%s\n", r.msg);
+  st_xfread_case("boundary", &r, 8192, NULL);
+  freet(r.adr);
 
-  // A legitimate small size must NOT be refused by the guard (the read then
-  // fails on the invalid socket, but the size-too-large msg must not be set).
+  /* Same size, entering with a buffer already held: the guard runs per call,
+     not on the first allocation only, or the realloc it lets through takes an
+     int that has already wrapped negative. */
+  memset(&r, 0, sizeof(r));
+  r.soc = INVALID_SOCKET;
+  r.totalsize = -1;
+  r.size = (LLint) INT32_MAX - 8192;
+  r.adr = (char *) malloct(64);
+  r.adr[0] = '\0';
+  st_xfread_case("grown", &r, 8192, r.adr);
+  freet(r.adr);
+
+  // A legitimate small size must NOT be refused, and must still be allocated.
   memset(&r, 0, sizeof(r));
   r.soc = INVALID_SOCKET;
   r.totalsize = 1000;
-  http_xfread1(&r, 8192);
-  printf("accept: msg=%s\n", r.msg);
-  if (r.adr != NULL)
-    freet(r.adr);
+  st_xfread_case("accept", &r, 8192, NULL);
+  freet(r.adr);
+
+  /* Control for the unknown-length arm: an undeclared length is not itself a
+     reason to refuse, only the size the stream has reached. */
+  memset(&r, 0, sizeof(r));
+  r.soc = INVALID_SOCKET;
+  r.totalsize = -1;
+  st_xfread_case("accept_grow", &r, 8192, NULL);
+  freet(r.adr);
+
+  // The bound itself, which the chunk and decode paths share.
+  for (i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++)
+    printf("fits(" LLintP ")=%d\n", sizes[i],
+           hts_inmem_size_fits(sizes[i]) ? 1 : 0);
+
+  /* hts_codec_maxout() caps a decoded body at INT_MAX inclusive, so a content
+     coding reaches this with the one size the receive guard refuses. */
+  st_decode_size_case("decode_mem_max", 0, (LLint) INT32_MAX);
+  st_decode_size_case("decode_mem_ok", 0, (LLint) INT32_MAX - 1);
+  st_decode_size_case("decode_disk_max", 1, (LLint) INT32_MAX);
   return 0;
 }
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3033,8 +3033,6 @@ static int st_xfread_limit(httrackp *opt, int argc, char **argv) {
   size_t i;
 
   (void) opt;
-  (void) argc;
-  (void) argv;
 
   // Content-Length just over 2 GiB.
   memset(&r, 0, sizeof(r));
@@ -3105,6 +3103,18 @@ static int st_xfread_limit(httrackp *opt, int argc, char **argv) {
   st_decode_size_case("decode_mem_max", 0, (LLint) INT32_MAX);
   st_decode_size_case("decode_mem_ok", 0, (LLint) INT32_MAX - 1);
   st_decode_size_case("decode_disk_max", 1, (LLint) INT32_MAX);
+
+  /* Given a file at or past the bound, the reader must refuse on the stat that
+     would size its own allocation, so nothing appended after a caller's own
+     check can carry the body past it. */
+  if (argc >= 1) {
+    LLint got = -1;
+    char *adr = readfile2_inmem(argv[0], &got);
+
+    printf("bigfile: adr=%s size=" LLintP "\n", adr != NULL ? "alloc" : "null",
+           got);
+    freet(adr);
+  }
   return 0;
 }
 
@@ -13265,7 +13275,7 @@ static const struct selftest_entry {
      "binput() consumes a clipped line whole (#1294)", st_binputline},
     {"crange", "<raw-content-range-line> ...",
      "Content-Range parse integer safety", st_crange},
-    {"xfread-limit", "", "in-memory receive buffer size bound",
+    {"xfread-limit", "[oversized-file]", "in-memory receive buffer size bound",
      st_xfread_limit},
     {"getext", "",
      "extension parsing stops at the query and inside the buffer (#1433)",

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3106,13 +3106,14 @@ static int st_xfread_limit(httrackp *opt, int argc, char **argv) {
 
   /* Given a file at or past the bound, the reader must refuse on the stat that
      would size its own allocation, so nothing appended after a caller's own
-     check can carry the body past it. */
-  if (argc >= 1) {
+     check can carry the body past it. The second file is the control: a bound
+     that refuses everything reads the same as one that works. */
+  for (i = 0; (int) i < argc && i < 2; i++) {
     LLint got = -1;
-    char *adr = readfile2_inmem(argv[0], &got);
+    char *adr = readfile2_inmem(argv[i], &got);
 
-    printf("bigfile: adr=%s size=" LLintP "\n", adr != NULL ? "alloc" : "null",
-           got);
+    printf("%s: adr=%s size=" LLintP "\n", i == 0 ? "bigfile" : "smallfile",
+           adr != NULL ? "alloc" : "null", got);
     freet(adr);
   }
   return 0;
@@ -13275,8 +13276,8 @@ static const struct selftest_entry {
      "binput() consumes a clipped line whole (#1294)", st_binputline},
     {"crange", "<raw-content-range-line> ...",
      "Content-Range parse integer safety", st_crange},
-    {"xfread-limit", "[oversized-file]", "in-memory receive buffer size bound",
-     st_xfread_limit},
+    {"xfread-limit", "[oversized-file small-file]",
+     "in-memory receive buffer size bound", st_xfread_limit},
     {"getext", "",
      "extension parsing stops at the query and inside the buffer (#1433)",
      st_getext},

--- a/tests/01_engine-xfread.test
+++ b/tests/01_engine-xfread.test
@@ -7,10 +7,31 @@ set -euo pipefail
 # 32-bit index (hostile Content-Length, or an endless stream) rather than
 # allocate it, while still accepting a normal small size. The same bound has to
 # hold on the two paths that fill r->adr without going through that guard: a
-# chunk stream (see 130_local-chunked-truncated.test) and a decoded content
-# coding. -#test=xfread-limit drives all of them.
+# chunk stream (see 130_local-chunked-truncated.test), a decoded content coding,
+# and a local file read back for parsing. -#test=xfread-limit drives all of them.
 
-out="$(httrack -O /dev/null -#test=xfread-limit)"
+# The file is sparse, so only a build missing the bound reads its 2 GiB.
+bigdir=
+cleanup() {
+    test -z "$bigdir" || rm -rf "$bigdir"
+}
+trap 'set +e; cleanup' EXIT
+trap 'set +e; cleanup; exit 1' HUP INT TERM
+
+big=
+if command -v truncate >/dev/null 2>&1; then
+    bigdir=$(mktemp -d ./xfread-big.XXXXXX)
+    if truncate -s 2147483647 "$bigdir/f" 2>/dev/null &&
+        test "$(du -k "$bigdir/f" | cut -f1)" -le 1024; then
+        big=$bigdir/f
+    else
+        rm -rf "$bigdir"
+        bigdir=
+    fi
+fi
+test -n "$big" || echo "no sparse file here: skipping the oversized-file case"
+
+out="$(httrack -O /dev/null -#test=xfread-limit ${big:+"$big"})"
 fail() {
     echo "FAIL $1: $out"
     exit 1
@@ -46,3 +67,8 @@ done
 has 'decode_mem_max: ok=0 body=dropped size=64 code=-1 msg=Decompressed content too large'
 has 'decode_mem_ok: ok=1 body=kept size=2147483646 code=0 msg='
 has 'decode_disk_max: ok=1 body=kept size=2147483647 code=0 msg='
+
+# size= must stay at the self-test's own -1: a refusal writes neither.
+if test -n "$big"; then
+    has 'bigfile: adr=null size=-1'
+fi

--- a/tests/01_engine-xfread.test
+++ b/tests/01_engine-xfread.test
@@ -5,27 +5,44 @@ set -euo pipefail
 
 # http_xfread1 must refuse an in-memory receive buffer that would exceed a
 # 32-bit index (hostile Content-Length, or an endless stream) rather than
-# allocate it, while still accepting a normal small size. -#test=xfread-limit
-# drives both refusal paths and the accept path.
+# allocate it, while still accepting a normal small size. The same bound has to
+# hold on the two paths that fill r->adr without going through that guard: a
+# chunk stream (see 130_local-chunked-truncated.test) and a decoded content
+# coding. -#test=xfread-limit drives all of them.
 
 out="$(httrack -O /dev/null -#test=xfread-limit)"
-# Match with here-strings, not `echo | grep -q`: under pipefail the early grep
-# exit SIGPIPEs echo and fails the pipeline even when the pattern matched.
-for case in bylen bygrow; do
-    grep -q "${case}: refused=1 adr=null msg=In-memory content too large" <<<"$out" || {
-        echo "FAIL ${case}: $out"
-        exit 1
-    }
-done
-
-# Exactly INT32_MAX must be refused too (the reallocs add 1).
-grep -q 'boundary: msg=In-memory content too large' <<<"$out" || {
-    echo "FAIL boundary: $out"
+fail() {
+    echo "FAIL $1: $out"
     exit 1
 }
+# Match with here-strings, not `echo | grep -q`: under pipefail the early grep
+# exit SIGPIPEs echo and fails the pipeline even when the pattern matched.
+has() {
+    grep -qxF "$1" <<<"$out" || fail "$1"
+}
 
-# The guard must NOT fire for a legitimate small size.
-if grep -q 'accept: msg=In-memory content too large' <<<"$out"; then
-    echo "FAIL accept (guard fired on a legit size): $out"
-    exit 1
-fi
+# adr= and code= are read after the call, so a guard that allocates before
+# refusing, or one that only fires on the first allocation, shows up here.
+for case in bylen bylen4g bygrow boundary; do
+    has "${case}: refused=1 adr=null code=-1 msg=In-memory content too large"
+done
+# grown enters holding a buffer: the guard runs per call, and keeps that buffer.
+has 'grown: refused=1 adr=kept code=-1 msg=In-memory content too large'
+
+# Controls. Both refuse on the invalid socket rather than on the guard, which
+# the empty msg and the untouched statuscode are what prove.
+has 'accept: refused=1 adr=alloc code=0 msg='
+has 'accept_grow: refused=1 adr=alloc code=0 msg='
+
+# The bound itself, shared with the chunk and decode paths.
+for expect in 'fits(0)=1' 'fits(1000)=1' 'fits(2147483646)=1' \
+    'fits(2147483647)=0' 'fits(2147483648)=0' 'fits(-1)=0'; do
+    has "$expect"
+done
+
+# A decoded body is capped at INT_MAX inclusive, so the size the receive guard
+# refuses is reachable through a content coding: refuse it, and drop the coded
+# bytes rather than commit them as the page. Only the in-memory path is bound.
+has 'decode_mem_max: ok=0 body=dropped size=64 code=-1 msg=Decompressed content too large'
+has 'decode_mem_ok: ok=1 body=kept size=2147483646 code=0 msg='
+has 'decode_disk_max: ok=1 body=kept size=2147483647 code=0 msg='

--- a/tests/01_engine-xfread.test
+++ b/tests/01_engine-xfread.test
@@ -24,6 +24,7 @@ if command -v truncate >/dev/null 2>&1; then
     if truncate -s 2147483647 "$bigdir/f" 2>/dev/null &&
         test "$(du -k "$bigdir/f" | cut -f1)" -le 1024; then
         big=$bigdir/f
+        printf 'SMALLFILE-BODY' >"$bigdir/s"
     else
         rm -rf "$bigdir"
         bigdir=
@@ -31,7 +32,7 @@ if command -v truncate >/dev/null 2>&1; then
 fi
 test -n "$big" || echo "no sparse file here: skipping the oversized-file case"
 
-out="$(httrack -O /dev/null -#test=xfread-limit ${big:+"$big"})"
+out="$(httrack -O /dev/null -#test=xfread-limit ${big:+"$big" "$bigdir/s"})"
 fail() {
     echo "FAIL $1: $out"
     exit 1
@@ -68,7 +69,9 @@ has 'decode_mem_max: ok=0 body=dropped size=64 code=-1 msg=Decompressed content 
 has 'decode_mem_ok: ok=1 body=kept size=2147483646 code=0 msg='
 has 'decode_disk_max: ok=1 body=kept size=2147483647 code=0 msg='
 
-# size= must stay at the self-test's own -1: a refusal writes neither.
+# size= must stay at the self-test's own -1: a refusal writes neither. The
+# small file is the control, so a bound that refuses everything still dies.
 if test -n "$big"; then
     has 'bigfile: adr=null size=-1'
+    has 'smallfile: adr=alloc size=14'
 fi

--- a/tests/130_local-chunked-truncated.test
+++ b/tests/130_local-chunked-truncated.test
@@ -17,6 +17,8 @@ bash "$top_srcdir/tests/local-crawl.sh" \
     --log-found 'truncated chunked transfer.*chunktrunc/always\.html' \
     --log-found 'Truncated chunked transfer.*after 2 retries.*chunktrunc/always\.html' \
     --log-found 'Interrupted transfer.*chunktrunc/reset\.bin' \
+    --log-found 'Chunked resource too large for .*chunktrunc/huge\.html' \
+    --not-found 'chunktrunc/huge.html' \
     --log-not-found 'runcated chunked transfer.*chunktrunc/(page|stay|file|reset|hostile)' \
     --not-found 'chunktrunc/always.html' \
     --found 'chunktrunc/always.bin' \
@@ -32,13 +34,17 @@ bash "$top_srcdir/tests/local-crawl.sh" \
 
 # --update: page.html and file.bin come back cut, hostile.html comes back with a
 # 0x80000000 chunk-size line (rejected outright, since as an int it is INT_MIN
-# and would otherwise reach realloc sign-extended), stay.html is the control.
+# and would otherwise reach realloc sign-extended), huge.html with 0x7fffffff
+# (legal as an int, and the size http_xfread1() refuses), stay.html is the
+# control.
 bash "$top_srcdir/tests/local-crawl.sh" \
     --rerun-args '--update' \
     --log-found 'truncated chunked transfer.*chunktrunc/page\.html' \
     --log-found 'truncated chunked transfer.*chunktrunc/file\.bin' \
     --log-found 'truncated chunked transfer.*chunktrunc/hostile\.html' \
     --log-found 'Illegal chunk \(80000000\) for .*chunktrunc/hostile\.html' \
+    --log-found 'Chunked resource too large for .*chunktrunc/huge\.html' \
+    --cache-not-found '/chunktrunc/huge.html' \
     --log-not-found 'not enough memory \(-' \
     --file-matches 'chunktrunc/page.html' 'CHUNKTRUNC-PAGE-V1' \
     --file-not-matches 'chunktrunc/page.html' 'CHUNKTRUNC-PAGE-V2' \

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -2253,6 +2253,7 @@ class Handler(SimpleHTTPRequestHandler):
             '\t<a href="file.bin">file</a>\n'
             '\t<a href="always.bin">alwaysbin</a>\n'
             '\t<a href="hostile.html">hostile</a>\n'
+            '\t<a href="huge.html">huge</a>\n'
             '\t<a href="reset.bin">reset</a>\n'
         )
 
@@ -2323,6 +2324,25 @@ class Handler(SimpleHTTPRequestHandler):
             return
         try:
             self.wfile.write(b"80000000\r\n")
+            self.wfile.flush()
+        except OSError:
+            pass
+        self.close_connection = True
+
+    # A chunk-size line of exactly INT32_MAX: legal as an int, and the one value
+    # http_xfread1() refuses, so the chunk path must not buy the 2 GiB realloc
+    # that only the next read would refuse.
+    def route_chunktrunc_huge(self):
+        self.protocol_version = "HTTP/1.1"
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Transfer-Encoding", "chunked")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        if self.command == "HEAD":
+            return
+        try:
+            self.wfile.write(b"7fffffff\r\n")
             self.wfile.flush()
         except OSError:
             pass
@@ -3478,6 +3498,7 @@ class Handler(SimpleHTTPRequestHandler):
         "/chunktrunc/always.bin": route_chunktrunc_alwaysbin,
         "/chunktrunc/stay.html": route_chunktrunc_stay,
         "/chunktrunc/hostile.html": route_chunktrunc_hostile,
+        "/chunktrunc/huge.html": route_chunktrunc_huge,
         "/chunktrunc/reset.bin": route_chunktrunc_reset,
         "/chunktrail/index.html": route_chunktrail_index,
         "/chunktrail/one.html": route_chunktrail_one,


### PR DESCRIPTION
`http_xfread1()` refuses an in-memory body at `INT32_MAX`, because `r->adr` is indexed with an int downstream and the allocations around it add a trailing NUL. Three other places fill `r->adr` without going through that guard.

The chunk reader refused one value later, at `> INT32_MAX`. Cumulative chunk sizes of exactly `INT32_MAX` therefore bought a 2 GiB `realloct` out of `back_wait()`. Only the next `http_xfread1()` call tore the transfer down. On a 32-bit build that allocation fails outright.

The decode path reaches the one size the guard rejects. `hts_codec_maxout()` caps a decoded body at `INT_MAX` inclusive, so `back_finalize()` can commit `r->size = INT32_MAX` and hand `readfile_utf8()`'s buffer to `htsparse.c`.

`LOAD_IN_MEMORY_IF_NECESSARY()` reads a saved file back into memory to parse it, with no bound at all. `htsparse.c` casts that size to `int cSize` and passes `(int) r->size` to `check_html`. At line 3463 it divides by `(int) (r->size)`, under an `if (r->size)` test made in the wide type. At exactly 4 GiB the cast is zero and the guarded division divides by zero.

That site is reached on an ordinary crawl. `back_finalize()` slurps a written real-media body back into memory only below 8192 bytes (htsback.c:1232). An `audio/x-mpegurl` response above that stays on disk, `r.adr` stays NULL, and the load runs. An 11108-byte playlist logs `File successfully loaded for parsing`. Nothing in the suite happened to serve one that large, which is why no existing test covers the route.

One predicate, `hts_inmem_size_fits()`, names the bound for all four sites. The decode refusal takes the route the neighbouring decode failures take. It classes the slot `STATUSCODE_INVALID`, names it, and drops the still-coded body so nothing can commit it as the page.

The local file is the one that cannot be bounded from outside. `readfile2()` stats the file itself, and sizes both its `malloct` and its `hts_fread_exact` from that stat. A caller that checks `fsize()` first therefore leaves a window. A first draft of this PR did exactly that. A 4-byte file that grew to 20 between the two calls came back as a 20-byte buffer. `readfile2_inmem()` applies the bound on the single stat that sizes the read. `readfile2()` and `readfile()` keep the unbounded behaviour they had. The cache index read in `htscoremain.c` and the two in `htscache_selftest.c` are untouched. Whether they want a bound of their own is a separate question.

`01_engine-xfread.test` pinned less than it looked like. It read `r.adr` inside the `printf` argument list that also called `http_xfread1()`. gcc sampled the pointer before the call, so the `adr=` column could never see an allocation the guard made. Every case also started from a memset `htsblk`, so `r.adr` was always NULL and a per-call guard was indistinguishable from a first-allocation-only one. That second gap hides a real memory bug, because the unknown-length arm would then reach `realloct(r->adr, (int) r->size + bufl + 1)` with `r->size` past 2^31. The test now reads `r.adr` and `r.statuscode` after the call in statements of their own. It enters one case holding a buffer, and keeps accept controls throughout, because a refusal-only assertion cannot tell a bound from a brick.

Sixteen mutants, fourteen killed, with a semantic no-op green throughout as the harness control. Nine are of the receive guard, graded against the test each tree ships. That is 7 of 9 before and 9 of 9 after, and the two that used to survive are the two gaps above. The chunk bound put back to `>` dies in `130_local-chunked-truncated.test`, which now serves a `7fffffff` chunk-size line. Neutering the decode predicate dies in the self-test alone. The local-file bound dies on a sparse `INT32_MAX`-byte file made under the build directory. The fixed build refuses it in 0.01s without touching a page. A build without the bound reads all of it, in 1.45s and 2.1 GB. Making that bound refuse every file instead dies on the small file beside it. The sparse case skips where the filesystem will not hand one out.

Two mutants survive. Dropping the call to `back_set_decoded_size()` along with the size it commits dies in `50_local-contentcodings.test`, because the page is then written at its compressed length. Replacing that same call with the bare size assignment is the survivor. It keeps the page correct and drops only the bound, and nothing catches it. Reverting the local-file call site to plain `readfile2()` restores that whole bypass, and nothing catches it either. Telling either survivor apart needs a body at the bound. One costs a real 2 GiB decode, the other a 2 GiB file mirrored to disk. `local-crawl.sh` has no hook to grow a mirrored file between passes, so that one would cost harness plumbing for a single mutant.
