### PR TITLE
Two is_space definitions in src/, with different character sets

### DIFF
--- a/src/htscharset.c
+++ b/src/htscharset.c
@@ -666,16 +666,17 @@ char *hts_convertStringFromUTF8Strict(const char *s, size_t size,
 #define strncasecmp(a,b,n) strnicmp(a,b,n)
 #endif
 
-static int is_space(char c) {
+/* Whitespace for the <meta> charset prescan: SPACE, TAB, CR, LF. */
+static int is_html_space(char c) {
   return c == ' ' || c == '\t' || c == '\r' || c == '\n';
 }
 
-static int is_space_or_equal(char c) {
-  return is_space(c) || c == '=';
+static int is_html_space_or_equal(char c) {
+  return is_html_space(c) || c == '=';
 }
 
-static int is_space_or_equal_or_quote(char c) {
-  return is_space_or_equal(c) || c == '"' || c == '\'';
+static int is_html_space_or_equal_or_quote(char c) {
+  return is_html_space_or_equal(c) || c == '"' || c == '\'';
 }
 
 size_t hts_stringLengthUTF8(const char *s) {
@@ -725,14 +726,15 @@ static char *charset_from_content(const char *s, size_t len) {
   size_t i;
 
   for (i = 0; i + 7 < len; i++) {
-    if ((i == 0 || is_space(s[i - 1]) || s[i - 1] == ';') &&
-        strncasecmp(&s[i], "charset", 7) == 0 && is_space_or_equal(s[i + 7])) {
+    if ((i == 0 || is_html_space(s[i - 1]) || s[i - 1] == ';') &&
+        strncasecmp(&s[i], "charset", 7) == 0 &&
+        is_html_space_or_equal(s[i + 7])) {
       size_t j, val;
 
-      for (j = i + 7; j < len && is_space_or_equal_or_quote(s[j]); j++)
+      for (j = i + 7; j < len && is_html_space_or_equal_or_quote(s[j]); j++)
         ;
       for (val = j; j < len && s[j] != '"' && s[j] != '\'' && s[j] != ';' &&
-                    !is_space(s[j]);
+                    !is_html_space(s[j]);
            j++)
         ;
       if (j != val) {
@@ -755,26 +757,26 @@ char *hts_getCharsetFromMeta(const char *html, size_t size) {
     size_t equiv_len = 0, content_len = 0;
 
     if (html[i] != '<' || strncasecmp(&html[i + 1], "meta", 4) != 0 ||
-        !is_space(html[i + 5])) {
+        !is_html_space(html[i + 5])) {
       continue;
     }
     /* Attribute scan, strictly bounded by size. */
     for (j = i + 6; j < size && html[j] != '>';) {
       size_t name, name_len, val = 0, val_len = 0;
 
-      if (is_space(html[j]) || html[j] == '/') {
+      if (is_html_space(html[j]) || html[j] == '/') {
         j++;
         continue;
       }
       for (name = j; j < size && html[j] != '=' && html[j] != '>' &&
-                     html[j] != '/' && !is_space(html[j]);
+                     html[j] != '/' && !is_html_space(html[j]);
            j++)
         ;
       name_len = j - name;
-      for (; j < size && is_space(html[j]); j++)
+      for (; j < size && is_html_space(html[j]); j++)
         ;
       if (j < size && html[j] == '=') {
-        for (j++; j < size && is_space(html[j]); j++)
+        for (j++; j < size && is_html_space(html[j]); j++)
           ;
         if (j < size && (html[j] == '"' || html[j] == '\'')) {
           const char quote = html[j++];
@@ -787,7 +789,8 @@ char *hts_getCharsetFromMeta(const char *html, size_t size) {
         } else {
           /* unquoted: ends at whitespace or '>' only (HTML5 prescan); '/'
              belongs to the value except as the tail of a self-close */
-          for (val = j; j < size && !is_space(html[j]) && html[j] != '>'; j++)
+          for (val = j; j < size && !is_html_space(html[j]) && html[j] != '>';
+               j++)
             ;
           val_len = j - val;
           if (val_len != 0 && j < size && html[j] == '>' &&

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -535,7 +535,6 @@ void *hts_get_callback(t_hts_htmlcheck_callbacks * callbacks,
 #define PATH_SEPARATOR '/'
 #endif
 
-/* Spaces: CR,LF,TAB,FF */
 #define  is_space(c)      ( ((c)==' ') || ((c)=='\"') || ((c)==10) || ((c)==13) || ((c)==9) || ((c)==12) || ((c)==11) || ((c)=='\'') )
 #define  is_realspace(c)  ( ((c)==' ')                || ((c)==10) || ((c)==13) || ((c)==9) || ((c)==12) || ((c)==11)                )
 #define  is_taborspace(c) ( ((c)==' ')                                          || ((c)==9)                             )

--- a/src/htsserver.h
+++ b/src/htsserver.h
@@ -84,8 +84,7 @@ extern coucal NewLangList;
 
 extern httrackp *global_opt;
 
-/* Spaces: CR,LF,TAB,FF */
-#define  is_space(c)      ( ((c)==' ') || ((c)=='\"') || ((c)==10) || ((c)==13) || ((c)==9) || ((c)==12) || ((c)==11) || ((c)=='\'') )
+/* Duplicates of htslib.h's, which htsweb.c does not include. */
 #define  is_realspace(c)  ( ((c)==' ')                || ((c)==10) || ((c)==13) || ((c)==9) || ((c)==12) || ((c)==11)                )
 #define  is_taborspace(c) ( ((c)==' ')                                          || ((c)==9)                             )
 #define  is_quote(c)      (               ((c)=='\"')                                                    || ((c)=='\'') )

--- a/tests/01_engine-charset.test
+++ b/tests/01_engine-charset.test
@@ -75,6 +75,18 @@ meta '<meta http-equiv="refresh" content="0; url=x.html">' '(none)'
 meta '<body charset="utf-8">' '(none)'
 meta '<meta charset="">' '(none)'
 
+# The prescan's whitespace is SPACE, TAB, CR, LF. These pin the four characters
+# where htslib.h's wider is_space() macro would answer differently.
+VT=$(printf '\013')
+FF=$(printf '\014')
+meta "<meta${VT}charset=\"utf-8\">" '(none)'
+meta "<meta${FF}charset=\"utf-8\">" '(none)'
+meta "<meta http-equiv=\"Content-Type\"${VT}content=\"text/html; charset=utf-8\">" '(none)'
+meta "<meta http-equiv=\"Content-Type\" content=\"text/html;${FF}charset=utf-8\">" '(none)'
+# a quote inside an unquoted value is a value byte, not a terminator
+meta '<meta charset=ut"f8>' 'ut"f8'
+meta "<meta charset=ut'f8>" "ut'f8"
+
 # hostile truncations: no crash, no match
 meta '<meta charset="utf-8' '(none)'
 meta '<meta charset=' '(none)'

--- a/tests/01_engine-charset.test
+++ b/tests/01_engine-charset.test
@@ -75,8 +75,12 @@ meta '<meta http-equiv="refresh" content="0; url=x.html">' '(none)'
 meta '<body charset="utf-8">' '(none)'
 meta '<meta charset="">' '(none)'
 
-# The prescan's whitespace is SPACE, TAB, CR, LF. These pin the four characters
-# where htslib.h's wider is_space() macro would answer differently.
+# The prescan's whitespace is SPACE, TAB, CR, LF, and nothing else. TAB, CR and
+# LF need the batch path, which carries them where argv rewrites them to a space.
+TAB=$(printf '\011')
+meta "<meta${TAB}charset=\"utf-8\">" 'utf-8'
+meta "<meta${SELFTEST_CR}charset=\"utf-8\">" 'utf-8'
+meta "<meta${TESTLIB_NL}charset=\"utf-8\">" 'utf-8'
 VT=$(printf '\013')
 FF=$(printf '\014')
 meta "<meta${VT}charset=\"utf-8\">" '(none)'


### PR DESCRIPTION
`src/htscharset.c` defines a static `is_space()` over SPACE, TAB, CR and LF. `src/htslib.h` defines a function-like macro of the same name over eight characters: that set plus VT, FF and both quote characters. `src/htsserver.h` carried a verbatim copy of the macro. Nothing in `htscharset.c` reaches either header today, so the local definition wins and the sniffer behaves as intended.

I checked what a colliding include would actually do, because that decides how urgent this is. A macro that arrives before the definition turns `static int is_space(char c)` into a syntax error, so a top-of-file include fails loudly. A macro that arrives after it compiles clean, and every call site below silently switches to the eight-character set. `htscharset.c` already has includes at lines 495 to 504, so either ordering is reachable. Renaming the predicate to `is_html_space` removes the trap in both cases.

Behaviour does not move. The macro keeps its eight characters and every caller keeps the set it had. Only the sniffer's three static helpers change name. The new cases in `tests/01_engine-charset.test` pin both halves of the sniffer's set. Six cover the characters the two sets disagree on, and each flips under a mutant whose `is_html_space` body is the eight-character set. Three more feed TAB, CR and LF, which kill a mutant matching a bare space. Those three need the batch path, because argv rewrites them to a space before the self-test sees them.

`htsserver.h` loses only `is_space`, so one definition of the eight-character set survives. Its other four macros stay, because `htsweb.c` reads `is_realspace` from that header without including `htslib.h`, and because they are byte-identical to `htslib.h`'s. `htsserver.c` includes both headers, so a reworded copy would draw a redefinition warning.

The macro's `/* Spaces: CR,LF,TAB,FF */` comment named neither the quotes nor VT, so it is gone. Correcting it in place was not possible: clang-format 19 rewrites about 35 lines of that hand-formatted region for any line added there.
