### PR TITLE
A cached X-Size sizes the buffer ProxyTrack reads a disk-held body into

### DIFF
--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -1246,7 +1246,15 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
               if (!dataincache) {
                 /* Read in memory from cache */
                 if (flags & FETCH_BODY) {
-                  if (strnotempty(previous_save)) {
+                  if (!strnotempty(previous_save)) {
+                    r->statuscode = STATUSCODE_INVALID;
+                    strcpybuff(r->msg, "Cached file name is invalid");
+                  } else if (r->size >= INT_MAX) {
+                    /* Read whole into memory: htscache.c's own limit, past
+                       which r->size + 1 wraps to zero on a 32-bit size_t. */
+                    r->statuscode = STATUSCODE_INVALID;
+                    strcpybuff(r->msg, "Cache Read Error : Bad Size");
+                  } else {
                     FILE *fp = fopen(file_convert(catbuff, sizeof(catbuff), previous_save), "rb");
 
                     if (fp != NULL) {
@@ -1275,9 +1283,6 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
                           file_convert(catbuff, sizeof(catbuff),
                                        previous_save));
                     }
-                  } else {
-                    r->statuscode = STATUSCODE_INVALID;
-                    strcpybuff(r->msg, "Cached file name is invalid");
                   }
                 }
               } else {

--- a/tests/402_local-proxytrack-cache-bodysize.test
+++ b/tests/402_local-proxytrack-cache-bodysize.test
@@ -1,0 +1,76 @@
+#!/bin/bash
+# X-Size sizes the allocation proxytrack reads a disk-held body into, and the
+# reader took the header's word for it. Where size_t is 32 bits, X-Size:
+# 4294967295 made malloc(size + 1) wrap to malloc(0) and the body filled it.
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+dir=$(mktemp -d)
+cleanup_push rm -rf "$dir"
+
+python=$(find_python) || skip "python3 missing"
+
+# X-Save is relative to the cache's grandparent, so keep HTTrack's own layout
+mkdir -p "$dir/m/hts-cache"
+zip="$dir/m/hts-cache/new.zip"
+BODY='<html>hello</html>'
+printf '%s' "$BODY" >"$dir/m/body.html"
+
+bad_size='Bad Size' # the reader's verdict on a size it refuses
+
+# X-In-Cache: 0 leaves the body on disk, which is the path that allocates it
+craft() { # craft X-SIZE
+    "$python" - "$zip" "$1" <<'EOF'
+import sys, zipfile
+
+meta = (
+    "X-In-Cache: 0\r\n"
+    "X-StatusCode: 200\r\n"
+    "X-StatusMessage: ok\r\n"
+    "X-Size: %s\r\n"
+    "Content-Type: text/html\r\n"
+    "Last-Modified: Wed, 01 Jan 2025 00:00:00 GMT\r\n"
+    "X-Save: body.html\r\n" % sys.argv[2]
+).encode()
+zi = zipfile.ZipInfo("example.com/page.html")
+zi.compress_type = zipfile.ZIP_STORED
+zi.extra = meta
+with zipfile.ZipFile(sys.argv[1], "w") as z:
+    z.writestr(zi, b"")
+EOF
+}
+
+read_back() { # read_back X-SIZE
+    craft "$1"
+    proxytrack --convert "$dir/out.arc" "$zip" >/dev/null 2>&1 ||
+        fail "proxytrack died reading a cache declaring X-Size: $1"
+}
+
+# control: without it a fix that refused every disk-held body would pass
+read_back "${#BODY}"
+grep -qaF "$BODY" "$dir/out.arc" || fail "an honest X-Size lost the body"
+if grep -qa "$bad_size" "$dir/out.arc"; then
+    fail "an honest X-Size was refused"
+fi
+
+# 2147483647 is the limit itself; 4294967295 is SIZE_MAX where size_t is 32
+# bits, and the value whose + 1 wraps to zero
+for value in 2147483647 4294967295; do
+    read_back "$value"
+    grep -qa "$bad_size" "$dir/out.arc" ||
+        fail "an on-disk X-Size of $value was accepted"
+    if grep -qaF "$BODY" "$dir/out.arc"; then
+        fail "an on-disk X-Size of $value still returned a body"
+    fi
+done
+
+# a size the reader can hold is not this gate's business, even when the file is
+# far shorter: refusing it here would hide a fix that just dropped mismatches
+read_back 4096
+if grep -qa "$bad_size" "$dir/out.arc"; then
+    fail "a holdable X-Size larger than the file was called a bad size"
+fi
+
+exit 0

--- a/tests/402_local-proxytrack-cache-bodysize.test
+++ b/tests/402_local-proxytrack-cache-bodysize.test
@@ -1,7 +1,6 @@
 #!/bin/bash
-# X-Size sizes the allocation proxytrack reads a disk-held body into, and the
-# reader took the header's word for it. Where size_t is 32 bits, X-Size:
-# 4294967295 made malloc(size + 1) wrap to malloc(0) and the body filled it.
+# X-Size: 4294967295 made malloc(size + 1) wrap to malloc(0) where size_t is 32
+# bits, and the disk-held body then filled that zero-length region.
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
@@ -55,9 +54,10 @@ if grep -qa "$bad_size" "$dir/out.arc"; then
     fail "an honest X-Size was refused"
 fi
 
-# 2147483647 is the limit itself; 4294967295 is SIZE_MAX where size_t is 32
-# bits, and the value whose + 1 wraps to zero
-for value in 2147483647 4294967295; do
+# The limit itself, one past it, a value between, and the SIZE_MAX whose + 1
+# wraps to zero on a 32-bit size_t: a guard hardcoded to the wrapping value
+# alone passes on that one and fails on the rest.
+for value in 2147483647 2147483648 3000000000 4294967295; do
     read_back "$value"
     grep -qa "$bad_size" "$dir/out.arc" ||
         fail "an on-disk X-Size of $value was accepted"


### PR DESCRIPTION
ProxyTrack reads a cache entry's `X-Size` out of the zip index and hands it to `malloc(r->size + 1)` for entries whose body sits on disk (`X-In-Cache: 0`). Nothing caps it between the header and the allocation, so the header decides the size. Where `size_t` is 32 bits, `X-Size: 4294967295` wraps that sum and `malloc(0)` returns a region with no usable bytes. `hts_fread_exact` then fills it with the file's contents, and `r->adr[r->size]` writes the terminator below the allocation.

The engine already refuses this. `htscache.c` gates the same read at `r.size >= INT_MAX` before it opens the body file, because either way the body is read whole into memory. ProxyTrack reads the engine's own caches and had no such gate. #1389 validated the decode (negative, wider than `size_t`, in-cache above `INT_MAX`) and left the on-disk body path uncapped. The gate now sits where the engine puts it, after the save-name check and before the open. A declared body of 2 GB or more comes back as `Cache Read Error : Bad Size` instead of a multi-gigabyte allocation.

`tests/402_local-proxytrack-cache-bodysize.test` forges four sizes. Three are the honest one, the `INT_MAX` boundary and `SIZE_MAX` on a 32-bit build. The fourth is a size the reader can still hold that the file is far too short to satisfy. It matters because a fix that dropped every short-file entry would pass the other three.

The wrap is 32-bit only and this box has no 32-bit toolchain, so it was pinned outside the suite. A probe runs the reader's arithmetic with `size_t` narrowed to 32 bits and allocates flush against a `PROT_NONE` page. At `X-Size: 4294967295` the computed size is 0 and the fill takes SIGSEGV on its first byte, while the honest size does not fault. ASan cannot stand in for that, because it does not police a write into a `malloc(0)` region.
