### PR TITLE
abortf_ never returns but nothing tells the compiler

### DIFF
--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -368,6 +368,16 @@ typedef int hts_tristate;
 #define HTS_DEPRECATED(msg)
 #endif
 
+/* Marks a function that never returns, before the declaration so the GCC/Clang
+   attribute and the MSVC __declspec both sit where they are accepted. */
+#if defined(__GNUC__)
+#define HTS_NORETURN __attribute__((noreturn))
+#elif defined(_MSC_VER)
+#define HTS_NORETURN __declspec(noreturn)
+#else
+#define HTS_NORETURN
+#endif
+
 /* LLint/TStamp: signed exact-width 64-bit; -1 is a sentinel engine-wide. */
 typedef int64_t LLint;
 typedef int64_t TStamp;

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -368,8 +368,8 @@ typedef int hts_tristate;
 #define HTS_DEPRECATED(msg)
 #endif
 
-/* Marks a function that never returns, before the declaration so the GCC/Clang
-   attribute and the MSVC __declspec both sit where they are accepted. */
+/* Never returns; placed before the declaration, where GCC/Clang and MSVC both
+   accept it. */
 #if defined(__GNUC__)
 #define HTS_NORETURN __attribute__((noreturn))
 #elif defined(_MSC_VER)

--- a/src/htssafe.h
+++ b/src/htssafe.h
@@ -95,7 +95,8 @@ static HTS_UNUSED void log_abort_(const char *msg, const char *file, int line) {
   fflush(stderr);
 }
 
-static HTS_UNUSED void abortf_(const char *exp, const char *file, int line) {
+static HTS_NORETURN HTS_UNUSED void abortf_(const char *exp, const char *file,
+                                            int line) {
 #ifdef HTSSAFE_ABORT_FUNCTION
   HTSSAFE_ABORT_FUNCTION(exp, file, line);
 #endif


### PR DESCRIPTION
`abortf_` always ends in `abort()`, on every path including the `HTSSAFE_ABORT_FUNCTION` callback branch and the empty override the three ProxyTrack translation units install. Nothing in the source said so. This adds `HTS_NORETURN` beside `HTS_DEPRECATED` in `htsglobal.h` and applies it. The macro is spelled the way GCC, Clang and MSVC each want, and placed where all three accept it.

The claim that this retires 21 static-analyzer findings did not survive measurement. scan-build and `gcc -fanalyzer` report the same counts and breakdowns before and after. Each already inlines the static `abortf_` and sees the `abort()` for itself. CodeQL is what CI runs, and I could not run it here.

No new warning appears, and a `-Wall -Wextra` build gives the same count and breakdown either way. No test is added, because nothing observable changes.