### PR TITLE
A reference on a document's first byte makes --single-file read in front of it

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -268,12 +268,6 @@ static const char *html_inline_safe(const char *src, char *dst, size_t size) {
   return dst;
 }
 
-/* Byte before html, or a space sentinel at the buffer start where html[-1]
-   would underflow; space reads as the word boundary the guards want there. */
-static HTS_INLINE char html_prevc(const char *html, const char *start) {
-  return html > start ? html[-1] : ' ';
-}
-
 /* Drop a redirect Location's #fragment: a UA anchor, never part of the fetched
  * resource (#204). */
 static void url_drop_fragment(char *const url) {
@@ -3124,7 +3118,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                               (opt->single_file && sf_may_mark && !in_media &&
                                p_type == 0 && !p_searchMETAURL &&
                                (sf_tag != NULL || sf_tagless_body))
-                                  ? singlefile_ref_class(sf_tag, tag_attr_start)
+                                  ? singlefile_ref_class(sf_tag, tag_attr_start,
+                                                         r->adr)
                                   : 0;
                           const size_t sf_start = TypedArraySize(output_buffer);
 

--- a/src/htssinglefile.c
+++ b/src/htssinglefile.c
@@ -223,19 +223,26 @@ static hts_boolean sf_denied(const char *tag_name, const char *attr) {
   return HTS_FALSE;
 }
 
-char singlefile_ref_class(const char *tag_name, const char *attr) {
+char singlefile_ref_class(const char *tag_name, const char *attr,
+                          const char *body) {
+  char prevc;
+
   if (attr == NULL)
     return 0;
   if (sf_denied(tag_name, attr))
     return 0;
+  /* A reference opening the document has no predecessor to read. */
+  prevc = html_prevc(attr, body);
   if (tag_name == NULL) {
     /* A stylesheet or a script body: only @import names another stylesheet. */
-    return rech_tageq(attr, "import") != 0 ? SINGLEFILE_CLASS_CSS
-                                           : SINGLEFILE_CLASS_ANY;
+    return rech_tageq_at(attr, prevc, "import") != 0 ? SINGLEFILE_CLASS_CSS
+                                                     : SINGLEFILE_CLASS_ANY;
   }
-  if (hts_cmp_tag_token(tag_name, "script") && rech_tageq(attr, "src") != 0)
+  if (hts_cmp_tag_token(tag_name, "script") &&
+      rech_tageq_at(attr, prevc, "src") != 0)
     return SINGLEFILE_CLASS_JS;
-  if (hts_cmp_tag_token(tag_name, "link") && rech_tageq(attr, "href") != 0) {
+  if (hts_cmp_tag_token(tag_name, "link") &&
+      rech_tageq_at(attr, prevc, "href") != 0) {
     const int rel = sf_rel_is_stylesheet(tag_name);
 
     /* No rel names nothing the browser would load, so it stays a link. */

--- a/src/htssinglefile.c
+++ b/src/htssinglefile.c
@@ -231,7 +231,6 @@ char singlefile_ref_class(const char *tag_name, const char *attr,
     return 0;
   if (sf_denied(tag_name, attr))
     return 0;
-  /* A reference opening the document has no predecessor to read. */
   prevc = html_prevc(attr, body);
   if (tag_name == NULL) {
     /* A stylesheet or a script body: only @import names another stylesheet. */

--- a/src/htssinglefile.h
+++ b/src/htssinglefile.h
@@ -109,9 +109,11 @@ const char *singlefile_mark(httrackp *opt, char *buf, size_t bufsize, char cls,
 
 /* The class a reference in this context may inline as, or 0 to leave it alone.
    tag_name points just past the '<' of the enclosing start tag, or NULL when
-   there is none (inside a stylesheet or a script); attr at the attribute name.
+   there is none (inside a stylesheet or a script); attr at the attribute name,
+   which body, the first byte of the document, bounds from below.
    Everything htsparse detects is inlinable unless it names a page. */
-char singlefile_ref_class(const char *tag_name, const char *attr);
+char singlefile_ref_class(const char *tag_name, const char *attr,
+                          const char *body);
 
 /* Rewrite every HTML page the mirror produced, then strip the marks left in
    the assets. No-op unless opt->single_file; call once the tree is final,

--- a/src/htssinglefile.h
+++ b/src/htssinglefile.h
@@ -110,7 +110,7 @@ const char *singlefile_mark(httrackp *opt, char *buf, size_t bufsize, char cls,
 /* The class a reference in this context may inline as, or 0 to leave it alone.
    tag_name points just past the '<' of the enclosing start tag, or NULL when
    there is none (inside a stylesheet or a script); attr at the attribute name,
-   which body, the first byte of the document, bounds from below.
+   and body at the document's first byte, which bounds every read.
    Everything htsparse detects is inlinable unless it names a page. */
 char singlefile_ref_class(const char *tag_name, const char *attr,
                           const char *body);

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -580,6 +580,10 @@ HTS_INLINE int rech_tageq(const char* adr,const char* s) {
   return 0;
 }
 */
+HTS_INLINE char html_prevc(const char *adr, const char *start) {
+  return adr > start ? adr[-1] : ' ';
+}
+
 // Deuxième partie
 HTS_INLINE int __rech_tageq(const char *adr, const char *s) {
   int p;

--- a/src/htstools.h
+++ b/src/htstools.h
@@ -71,6 +71,9 @@ int link_has_authority(const char *lien);
 int link_has_authorization(const char *lien);
 void long_to_83(int mode, char *n83, size_t n83size, char *save);
 void longfile_to_83(int mode, char *n83, size_t n83size, char *save);
+/* Byte before adr, or a space sentinel at the buffer start where adr[-1] would
+   underflow; space reads as the word boundary the tag guards want there. */
+HTS_INLINE char html_prevc(const char *adr, const char *start);
 HTS_INLINE int __rech_tageq(const char *adr, const char *s);
 HTS_INLINE int __rech_tageqbegdigits(const char *adr, const char *s);
 HTS_INLINE int rech_tageq_all(const char *adr, const char *s);
@@ -108,16 +111,13 @@ const char *hts_footer_field_list(char *buffer, size_t size);
 int hts_footer_format(char *buffer, size_t size, const char *footer,
                       const char *const values[HTS_FOOTER_FIELD_COUNT]);
 
-#define rech_tageq(adr,s) \
-  ( \
-    ( (*((adr)-1)=='<') || (is_space(*((adr)-1))) ) ? \
-    ( \
-      (streql(*(adr),*(s))) ?   \
-      (__rech_tageq((adr),(s))) \
-      : 0                       \
-    ) \
-    : 0\
-  )
+/* prevc is the byte before adr; a token that may open a buffer takes it from
+   html_prevc rather than from adr[-1]. */
+#define rech_tageq_at(adr, prevc, s)                                           \
+  ((((prevc) == '<') || (is_space(prevc)))                                     \
+       ? ((streql(*(adr), *(s))) ? (__rech_tageq((adr), (s))) : 0)             \
+       : 0)
+#define rech_tageq(adr, s) rech_tageq_at((adr), *((adr) - 1), (s))
 #define rech_tageqbegdigits(adr,s) \
   ( \
     ( (*((adr)-1)=='<') || (is_space(*((adr)-1))) ) ? \
@@ -128,7 +128,7 @@ int hts_footer_format(char *buffer, size_t size, const char *footer,
     ) \
     : 0\
   )
-//HTS_INLINE int rech_tageq(const char* adr,const char* s);
+// HTS_INLINE int rech_tageq(const char* adr,const char* s);
 HTS_INLINE int rech_sampletag(const char *adr, const char *s);
 HTS_INLINE int rech_endtoken(const char *adr, const char **start);
 HTS_INLINE int check_tag(const char *from, const char *tag);

--- a/src/htstools.h
+++ b/src/htstools.h
@@ -71,8 +71,8 @@ int link_has_authority(const char *lien);
 int link_has_authorization(const char *lien);
 void long_to_83(int mode, char *n83, size_t n83size, char *save);
 void longfile_to_83(int mode, char *n83, size_t n83size, char *save);
-/* Byte before adr, or a space sentinel at the buffer start where adr[-1] would
-   underflow; space reads as the word boundary the tag guards want there. */
+/* Byte before adr, or a space where adr[-1] would underflow, because the tag
+   guards read a space as a word boundary. */
 HTS_INLINE char html_prevc(const char *adr, const char *start);
 HTS_INLINE int __rech_tageq(const char *adr, const char *s);
 HTS_INLINE int __rech_tageqbegdigits(const char *adr, const char *s);
@@ -111,8 +111,7 @@ const char *hts_footer_field_list(char *buffer, size_t size);
 int hts_footer_format(char *buffer, size_t size, const char *footer,
                       const char *const values[HTS_FOOTER_FIELD_COUNT]);
 
-/* prevc is the byte before adr; a token that may open a buffer takes it from
-   html_prevc rather than from adr[-1]. */
+/* prevc is the byte before adr, normally from html_prevc. */
 #define rech_tageq_at(adr, prevc, s)                                           \
   ((((prevc) == '<') || (is_space(prevc)))                                     \
        ? ((streql(*(adr), *(s))) ? (__rech_tageq((adr), (s))) : 0)             \

--- a/tests/401_local-single-file-byte-zero-ref.test
+++ b/tests/401_local-single-file-byte-zero-ref.test
@@ -1,0 +1,54 @@
+#!/bin/bash
+# A stylesheet whose first byte already opens a url() reference: --single-file
+# classified it by reading the byte in front of the document. Only a sanitizer
+# sees that read, so this test reds on the ASan leg and inlines everywhere.
+set -e
+
+# shellcheck source=tests/crawllib.sh
+. "${0%"${0##*/}"}./crawllib.sh"
+
+python=$(find_python) || skip "python3 not found"
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_sf0.XXXXXX") || exit 1
+cleanup() {
+    rm -rf "$tmpdir"
+}
+cleanup_push cleanup
+
+doc="${tmpdir}/doc"
+mkdir -p "$doc"
+cat >"${doc}/index.html" <<'HTML'
+<html><head><link rel="stylesheet" href="first.css"></head><body></body></html>
+HTML
+printf 'url(pixel.svg)\n' >"${doc}/first.css"
+printf '<svg xmlns="http://www.w3.org/2000/svg"><rect width="1" height="1"/></svg>\n' \
+    >"${doc}/pixel.svg"
+
+local_server_start --root "$doc"
+require_httrack
+
+out="${tmpdir}/crawl"
+mkdir "$out"
+local_crawl --log "${tmpdir}/log" -O "$out" --quiet --disable-security-limits \
+    --robots=0 --timeout=30 --retries=0 --single-file "${BASEURL}/index.html"
+
+page="${out}/127.0.0.1_${SRV_PORT}/index.html"
+test -f "$page" || fail "no mirrored page at $page"
+
+printf '[stylesheet inlined] ..\t'
+"$python" - "$page" "${tmpdir}/got.css" <<'PY' || fail "no inlined stylesheet"
+import base64, re, sys
+html = open(sys.argv[1], "rb").read().decode("utf-8", "replace")
+m = re.search(r"data:text/css;base64,([A-Za-z0-9+/=]*)", html)
+if m is None:
+    sys.exit(1)
+open(sys.argv[2], "wb").write(base64.b64decode(m.group(1)))
+PY
+echo OK
+
+# The reference at offset 0 is what the classifier used to mishandle, so it is
+# the one that has to come back inlined.
+printf '[reference at offset 0 followed] ..\t'
+grep -q 'url(data:image/svg+xml;base64,' "${tmpdir}/got.css" ||
+    fail "the url() opening the stylesheet was not inlined"
+echo OK


### PR DESCRIPTION
`--single-file` asks `singlefile_ref_class()` whether a reference htsparse found may be inlined. Inside a stylesheet or a script there is no enclosing tag, so the answer comes from `rech_tageq(attr, "import")`. That macro starts by reading the byte in front of the token, to decide whether the token starts a word. When the token is the document's first byte, the read lands one before the response body on the heap.

A server picks both the mime type and the body it sends. A six-byte `text/css` reply of `url(x)` is enough, and the same body behind one space is clean. Under ASan the process dies. Without a sanitizer the stray byte decides whether a body opening with `import = ` counts as a stylesheet. The mirror's output then follows whatever the allocator left there. `--single-file` is off by default.

The tree already owned the safe primitive. `html_prevc()` returns a space sentinel at a buffer start instead of reading `[-1]`. That is also the right answer here, because a token opening a document does sit on a word boundary. `singlefile_ref_class()` now receives the document start and uses it for all three of its boundary tests. No path through the function reads below the body any more.

`tests/401_local-single-file-byte-zero-ref.test` crawls a stylesheet whose first byte opens a `url()` and checks the reference still inlines. It passes on the fix and fails on the reverted one under ASan, the leg that sees this class of bug.