### PR TITLE
ProxyTrack ships the uninitialised tail of a buffer its cache body was too short to fill

### DIFF
--- a/src/proxy/proxytrack.c
+++ b/src/proxy/proxytrack.c
@@ -820,6 +820,12 @@ static PT_Element proxytrack_process_HTTP_List(PT_Indexes indexes,
   return NULL;
 }
 
+/* Bytes the reply may take from an element: the send skips a body the reader
+   refused, and announcing one would desync a kept-alive peer. */
+static size_t element_body_size(const PT_Element element) {
+  return (element != NULL && element->adr != NULL) ? element->size : 0;
+}
+
 static void proxytrack_process_HTTP(PT_Indexes indexes, T_SOC soc_c) {
   int timeout = 30;
   int buffer_size = 32768;
@@ -1220,10 +1226,8 @@ static void proxytrack_process_HTTP(PT_Indexes indexes, T_SOC soc_c) {
 
       if (!headRequest) {
         dataSize = StringLength(output);
-        /* the send below skips a refused body, so announcing its length
-           would desync a kept-alive peer */
-        if (dataSize == 0 && element != NULL && element->adr != NULL) {
-          dataSize = element->size;
+        if (dataSize == 0) {
+          dataSize = element_body_size(element);
         }
       }
       sprintf(tmp, "%d", (int) dataSize);
@@ -1248,9 +1252,8 @@ static void proxytrack_process_HTTP(PT_Indexes indexes, T_SOC soc_c) {
     /* Logging */
     {
       const char *contentType = "text/html";
-      size_t size =
-        StringLength(output) ? StringLength(output) : (element ? element->
-                                                       size : 0);
+      size_t size = StringLength(output) ? StringLength(output)
+                                         : element_body_size(element);
       /* */
       String ip = STRING_EMPTY;
       SOCaddr serverClient;

--- a/src/proxy/proxytrack.c
+++ b/src/proxy/proxytrack.c
@@ -1220,7 +1220,9 @@ static void proxytrack_process_HTTP(PT_Indexes indexes, T_SOC soc_c) {
 
       if (!headRequest) {
         dataSize = StringLength(output);
-        if (dataSize == 0 && element != NULL) {
+        /* the send below skips a refused body, so announcing its length
+           would desync a kept-alive peer */
+        if (dataSize == 0 && element != NULL && element->adr != NULL) {
           dataSize = element->size;
         }
       }

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -766,6 +766,13 @@ void PT_Element_Delete(PT_Element * pentry) {
   }
 }
 
+/* Both consumers emit element->size bytes whatever the status code, so a
+   partly-filled body would ship its uninitialised tail. */
+static void PT_Element_DropBody(PT_Element entry) {
+  free(entry->adr);
+  entry->adr = NULL;
+}
+
 PT_Element PT_ReadIndex(PT_Indexes indexes, const char *url, int flags) {
   if (indexes != NULL) {
     intptr_t index_id;
@@ -1256,12 +1263,14 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
                             !hts_fread_exact(r->adr, r->size, fp)) {
                           int last_errno = errno;
 
+                          PT_Element_DropBody(r);
                           r->statuscode = STATUSCODE_INVALID;
                           PT_Element_failf(r,
                                            "Read error in cache disk data: %s",
                                            strerror(last_errno));
+                        } else {
+                          r->adr[r->size] = '\0';
                         }
-                        r->adr[r->size] = '\0';
                       } else {
                         r->statuscode = STATUSCODE_INVALID;
                         strcpybuff(r->msg,
@@ -1286,8 +1295,7 @@ static PT_Element PT_ReadCache__New_u(PT_Index index_, const char *url,
                   r->adr = (char *) malloc(r->size + 1);
                   if (r->adr != NULL) {
                     if (unzReadCurrentFile(index->zFile, r->adr, (unsigned int) r->size) != r->size) {  // erreur
-                      free(r->adr);
-                      r->adr = NULL;
+                      PT_Element_DropBody(r);
                       r->statuscode = STATUSCODE_INVALID;
                       strcpybuff(r->msg, "Cache Read Error : Read Data");
                     } else
@@ -1927,10 +1935,12 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
                 r->adr = cache_alloc_body(r->size);
                 if (r->adr != NULL) {
                   if (r->size > 0 && !hts_fread_exact(r->adr, r->size, fp)) {
+                    PT_Element_DropBody(r);
                     r->statuscode = STATUSCODE_INVALID;
                     strcpybuff(r->msg, "Read error in cache disk data");
+                  } else {
+                    r->adr[r->size] = '\0';
                   }
-                  r->adr[r->size] = '\0';
                 } else {
                   r->statuscode = STATUSCODE_INVALID;
                   strcpybuff(r->msg,
@@ -1948,8 +1958,7 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
               r->adr = cache_alloc_body(r->size);
               if (r->adr != NULL) {
                 if (!hts_fread_exact(r->adr, r->size, cache->dat)) { // erreur
-                  free(r->adr);
-                  r->adr = NULL;
+                  PT_Element_DropBody(r);
                   r->statuscode = STATUSCODE_INVALID;
                   strcpybuff(r->msg, "Cache Read Error : Read Data");
                 } else

--- a/tests/406_local-proxytrack-short-body.test
+++ b/tests/406_local-proxytrack-short-body.test
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# A cache entry whose X-Size exceeds the on-disk body it names left the tail of
-# the allocated buffer uninitialised, and both consumers shipped element->size
-# bytes whatever the read error said: the ARC writer onto disk, the proxy to
-# the client.
+# A cache entry whose declared size exceeds the on-disk body it names left the
+# tail of the allocated buffer uninitialised, and both consumers shipped that
+# declared count whatever the read error said: the ARC writer onto disk, the
+# proxy to the client.
 
 set -euo pipefail
 
@@ -24,7 +24,7 @@ cleanup_push cleanup
 # ('Z') rather than the zeros a fresh page would hand out for free
 export MALLOC_PERTURB_=165
 leak_run=$(printf 'Z%.0s' $(seq 1 64))
-# ... on the allocators that honour it; elsewhere the length checks carry the test
+# ... where the allocator honours it; the length assertions carry the rest
 poison=$("$python" -c 'import ctypes
 libc = ctypes.CDLL(None)
 libc.malloc.restype = ctypes.c_void_p
@@ -32,17 +32,19 @@ print(ctypes.string_at(libc.malloc(1 << 16), 8).hex())')
 
 BODY='<html>hello</html>'
 DECLARED=4096
-url=http://example.com/page.html
+short_url=http://example.com/page.html
+honest_url=http://example.com/ok.html
 
 # X-Save is relative to the cache's grandparent, so keep HTTrack's own layout
 mkdir -p "$dir/m/hts-cache"
-zip="$dir/m/hts-cache/new.zip"
 printf '%s' "$BODY" >"$dir/m/body.html"
+short=$dir/m/hts-cache/short.zip
+honest=$dir/m/hts-cache/honest.zip
 
 # X-In-Cache: 0 leaves the body on disk, the path that sizes its buffer from the
 # header and fills it from a file that may be shorter
-craft() { # craft X-SIZE
-    "$python" - "$zip" "$1" <<'EOF'
+craft() { # craft ZIP URL SIZE
+    "$python" - "$@" <<'EOF'
 import sys, zipfile
 
 meta = (
@@ -52,14 +54,27 @@ meta = (
     "X-Size: %s\r\n"
     "Content-Type: text/html\r\n"
     "Last-Modified: Wed, 01 Jan 2025 00:00:00 GMT\r\n"
-    "X-Save: body.html\r\n" % sys.argv[2]
+    "X-Save: body.html\r\n" % sys.argv[3]
 ).encode()
-zi = zipfile.ZipInfo("example.com/page.html")
+zi = zipfile.ZipInfo(sys.argv[2].replace("http://", ""))
 zi.compress_type = zipfile.ZIP_STORED
 zi.extra = meta
 with zipfile.ZipFile(sys.argv[1], "w") as z:
     z.writestr(zi, b"")
 EOF
+}
+
+# The stored entry, so an assertion cannot pass on an archive that dropped it.
+record() { # record ARC URL
+    grep -qa "^$2 " "$1" || fail "$1 holds no record for $2"
+}
+
+# Largest body length any record in $1 announces, so a leak of any size fails.
+announced() { # announced ARC
+    local n
+    n=$(sed -n 's/^Content-length: \([0-9][0-9]*\).*/\1/p' "$1" | sort -n | tail -1)
+    test -n "$n" || fail "$1 announces no body length"
+    echo "$n"
 }
 
 no_leak() { # no_leak FILE WHAT
@@ -70,61 +85,76 @@ no_leak() { # no_leak FILE WHAT
 }
 
 # Consumer 1: the ARC writer.
-craft "${#BODY}"
-proxytrack --convert "$dir/honest.arc" "$zip" >/dev/null 2>&1 ||
+craft "$honest" "$honest_url" "${#BODY}"
+proxytrack --convert "$dir/honest.arc" "$honest" >/dev/null 2>&1 ||
     fail "proxytrack died converting an honest cache"
 # control: a fix that dropped every disk-held body would pass the rest
-grep -qaF "$BODY" "$dir/honest.arc" || fail "an honest X-Size lost the body"
-grep -qa "Content-length: ${#BODY}" "$dir/honest.arc" ||
-    fail "an honest X-Size was not announced as ${#BODY} bytes"
+record "$dir/honest.arc" "$honest_url"
+grep -qaF "$BODY" "$dir/honest.arc" || fail "an honest declared size lost the body"
+test "$(announced "$dir/honest.arc")" = "${#BODY}" ||
+    fail "an honest declared size was not announced as ${#BODY} bytes"
 
-craft "$DECLARED"
-proxytrack --convert "$dir/short.arc" "$zip" >/dev/null 2>&1 ||
+craft "$short" "$short_url" "$DECLARED"
+proxytrack --convert "$dir/short.arc" "$short" >/dev/null 2>&1 ||
     fail "proxytrack died converting a cache whose body is short"
-if grep -qa "Content-length: $DECLARED" "$dir/short.arc"; then
-    fail "the ARC writer stored $DECLARED bytes of a ${#BODY}-byte body"
-fi
-grep -qa 'Content-length: 0' "$dir/short.arc" ||
-    fail "the ARC writer kept a body it could not fill"
+record "$dir/short.arc" "$short_url"
+test "$(announced "$dir/short.arc")" -le "${#BODY}" ||
+    fail "the ARC writer stored more than the ${#BODY} bytes the file held"
 no_leak "$dir/short.arc" "the ARC writer"
 
 # Consumer 2: the reply to the client.
 launch_proxytrack() {
-    proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$zip" >"$ptlog" 2>&1 &
+    proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$honest" "$short" \
+        >"$ptlog" 2>&1 &
     ptpid=$!
 }
 start_proxytrack "$dir/pt" launch_proxytrack
 
-"$python" - "$proxyport" "$url" "$dir/reply" <<'EOF' || fail_dump "the proxy reply is not what its headers announced" "$ptlog"
+# The honest URL first: it proves the proxy serves these entries at all, so the
+# short one's assertions cannot pass on a 404.
+"$python" - "$proxyport" "$honest_url" "$short_url" "$dir/reply" "$BODY" <<'EOF' ||
 import socket, sys
 
-port, url, out = int(sys.argv[1]), sys.argv[2], sys.argv[3]
-sock = socket.create_connection(("127.0.0.1", port), 10)
-sock.settimeout(10)
-sock.sendall(
-    ("GET %s HTTP/1.1\r\nHost: example.com\r\n\r\n" % url).encode()
+port, honest_url, short_url, out, body = (
+    int(sys.argv[1]), sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5].encode()
 )
-reply = b""
-try:
-    while True:
-        chunk = sock.recv(65536)
-        if not chunk:
-            break
-        reply += chunk
-except socket.timeout:
-    pass
-open(out, "wb").write(reply)
 
-head, _, body = reply.partition(b"\r\n\r\n")
-for line in head.split(b"\r\n"):
-    if line.lower().startswith(b"content-length:"):
-        announced = int(line.split(b":")[1])
-        break
-else:
+def get(url):
+    sock = socket.create_connection(("127.0.0.1", port), 10)
+    sock.settimeout(10)
+    sock.sendall(("GET %s HTTP/1.1\r\nHost: example.com\r\n\r\n" % url).encode())
+    reply = b""
+    try:
+        while True:
+            chunk = sock.recv(65536)
+            if not chunk:
+                break
+            reply += chunk
+    except socket.timeout:
+        pass
+    head, _, payload = reply.partition(b"\r\n\r\n")
+    for line in head.split(b"\r\n"):
+        if line.lower().startswith(b"content-length:"):
+            return reply, head, payload, int(line.split(b":")[1])
     sys.exit("no Content-length in %r" % head)
-if announced != len(body):
-    sys.exit("announced %d bytes, sent %d" % (announced, len(body)))
+
+reply, head, payload, announced = get(honest_url)
+if payload != body:
+    sys.exit("the honest entry served %r, not the file's bytes" % payload[:64])
+if announced != len(payload):
+    sys.exit("the honest entry announced %d bytes, sent %d" % (announced, len(payload)))
+
+reply, head, payload, announced = get(short_url)
+open(out, "wb").write(reply)
+# the cache entry's own header, so a 404 error page cannot stand in for it
+if b"Last-Modified: Wed, 01 Jan 2025" not in head:
+    sys.exit("the short entry was not served: %r" % head)
+if announced != len(payload):
+    sys.exit("the short entry announced %d bytes, sent %d" % (announced, len(payload)))
+if announced > len(body):
+    sys.exit("the short entry sent %d bytes of a %d-byte file" % (announced, len(body)))
 EOF
+    fail_dump "the proxy reply is not what its headers announced" "$ptlog"
 no_leak "$dir/reply" "the proxy reply"
 
 # The pre-3.31 .ndx reader is a second copy of the same allocate-then-fill, and
@@ -164,14 +194,15 @@ EOF
 craft_ndx "${#BODY}"
 proxytrack --convert "$dir/ndx-honest.arc" "$dir/n/hts-cache/c.ndx" >/dev/null 2>&1 ||
     fail "proxytrack died converting an honest .ndx cache"
+record "$dir/ndx-honest.arc" "$short_url"
 grep -qaF "$BODY" "$dir/ndx-honest.arc" || fail "an honest .ndx size lost the body"
 
 craft_ndx "$DECLARED"
 proxytrack --convert "$dir/ndx.arc" "$dir/n/hts-cache/c.ndx" >/dev/null 2>&1 ||
     fail "proxytrack died converting an .ndx cache whose body is short"
-if grep -qa "Content-length: $DECLARED" "$dir/ndx.arc"; then
-    fail "the .ndx reader kept $DECLARED bytes of a ${#BODY}-byte body"
-fi
+record "$dir/ndx.arc" "$short_url"
+test "$(announced "$dir/ndx.arc")" -le "${#BODY}" ||
+    fail "the .ndx reader kept more than the ${#BODY} bytes the file held"
 no_leak "$dir/ndx.arc" "the .ndx reader"
 
 echo "OK: neither consumer emitted a byte the cache body did not hold"

--- a/tests/406_local-proxytrack-short-body.test
+++ b/tests/406_local-proxytrack-short-body.test
@@ -1,0 +1,177 @@
+#!/bin/bash
+#
+# A cache entry whose X-Size exceeds the on-disk body it names left the tail of
+# the allocated buffer uninitialised, and both consumers shipped element->size
+# bytes whatever the read error said: the ARC writer onto disk, the proxy to
+# the client.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+python=$(find_python) || skip "python3 missing"
+
+dir=$(mktemp -d)
+ptpid=
+cleanup() {
+    stop_server "$ptpid"
+    rm -rf "$dir"
+}
+cleanup_push cleanup
+
+# glibc fills a fresh allocation with PERTURB ^ 0xff, so leaked bytes read 0x5a
+# ('Z') rather than the zeros a fresh page would hand out for free
+export MALLOC_PERTURB_=165
+leak_run=$(printf 'Z%.0s' $(seq 1 64))
+# ... on the allocators that honour it; elsewhere the length checks carry the test
+poison=$("$python" -c 'import ctypes
+libc = ctypes.CDLL(None)
+libc.malloc.restype = ctypes.c_void_p
+print(ctypes.string_at(libc.malloc(1 << 16), 8).hex())')
+
+BODY='<html>hello</html>'
+DECLARED=4096
+url=http://example.com/page.html
+
+# X-Save is relative to the cache's grandparent, so keep HTTrack's own layout
+mkdir -p "$dir/m/hts-cache"
+zip="$dir/m/hts-cache/new.zip"
+printf '%s' "$BODY" >"$dir/m/body.html"
+
+# X-In-Cache: 0 leaves the body on disk, the path that sizes its buffer from the
+# header and fills it from a file that may be shorter
+craft() { # craft X-SIZE
+    "$python" - "$zip" "$1" <<'EOF'
+import sys, zipfile
+
+meta = (
+    "X-In-Cache: 0\r\n"
+    "X-StatusCode: 200\r\n"
+    "X-StatusMessage: ok\r\n"
+    "X-Size: %s\r\n"
+    "Content-Type: text/html\r\n"
+    "Last-Modified: Wed, 01 Jan 2025 00:00:00 GMT\r\n"
+    "X-Save: body.html\r\n" % sys.argv[2]
+).encode()
+zi = zipfile.ZipInfo("example.com/page.html")
+zi.compress_type = zipfile.ZIP_STORED
+zi.extra = meta
+with zipfile.ZipFile(sys.argv[1], "w") as z:
+    z.writestr(zi, b"")
+EOF
+}
+
+no_leak() { # no_leak FILE WHAT
+    test "$poison" = 5a5a5a5a5a5a5a5a || return 0
+    if grep -qaF "$leak_run" "$1"; then
+        fail "$2 carried a run of uninitialised heap"
+    fi
+}
+
+# Consumer 1: the ARC writer.
+craft "${#BODY}"
+proxytrack --convert "$dir/honest.arc" "$zip" >/dev/null 2>&1 ||
+    fail "proxytrack died converting an honest cache"
+# control: a fix that dropped every disk-held body would pass the rest
+grep -qaF "$BODY" "$dir/honest.arc" || fail "an honest X-Size lost the body"
+grep -qa "Content-length: ${#BODY}" "$dir/honest.arc" ||
+    fail "an honest X-Size was not announced as ${#BODY} bytes"
+
+craft "$DECLARED"
+proxytrack --convert "$dir/short.arc" "$zip" >/dev/null 2>&1 ||
+    fail "proxytrack died converting a cache whose body is short"
+if grep -qa "Content-length: $DECLARED" "$dir/short.arc"; then
+    fail "the ARC writer stored $DECLARED bytes of a ${#BODY}-byte body"
+fi
+grep -qa 'Content-length: 0' "$dir/short.arc" ||
+    fail "the ARC writer kept a body it could not fill"
+no_leak "$dir/short.arc" "the ARC writer"
+
+# Consumer 2: the reply to the client.
+launch_proxytrack() {
+    proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" "$zip" >"$ptlog" 2>&1 &
+    ptpid=$!
+}
+start_proxytrack "$dir/pt" launch_proxytrack
+
+"$python" - "$proxyport" "$url" "$dir/reply" <<'EOF' || fail_dump "the proxy reply is not what its headers announced" "$ptlog"
+import socket, sys
+
+port, url, out = int(sys.argv[1]), sys.argv[2], sys.argv[3]
+sock = socket.create_connection(("127.0.0.1", port), 10)
+sock.settimeout(10)
+sock.sendall(
+    ("GET %s HTTP/1.1\r\nHost: example.com\r\n\r\n" % url).encode()
+)
+reply = b""
+try:
+    while True:
+        chunk = sock.recv(65536)
+        if not chunk:
+            break
+        reply += chunk
+except socket.timeout:
+    pass
+open(out, "wb").write(reply)
+
+head, _, body = reply.partition(b"\r\n\r\n")
+for line in head.split(b"\r\n"):
+    if line.lower().startswith(b"content-length:"):
+        announced = int(line.split(b":")[1])
+        break
+else:
+    sys.exit("no Content-length in %r" % head)
+if announced != len(body):
+    sys.exit("announced %d bytes, sent %d" % (announced, len(body)))
+EOF
+no_leak "$dir/reply" "the proxy reply"
+
+# The pre-3.31 .ndx reader is a second copy of the same allocate-then-fill, and
+# proxytrack is the only thing left that reads that format.
+mkdir -p "$dir/n/hts-cache"
+printf '%s' "$BODY" >"$dir/n/body.html"
+
+craft_ndx() { # craft_ndx SIZE
+    "$python" - "$dir/n/hts-cache" "$1" <<'EOF'
+import os, sys
+
+d, declared = sys.argv[1], sys.argv[2]
+
+def field(s):  # every .dat field is its byte length, a newline, then the bytes
+    b = s.encode()
+    return ("%d\n" % len(b)).encode() + b
+
+record = b"".join(
+    field(v)
+    for v in (
+        "200", declared, "OK", "text/html", "",  # status, size, msg, type, charset
+        "Wed, 01 Jan 2025 00:00:00 GMT", "", "", "",  # date, etag, location, cdispo
+        "", "", "body.html", "HTS", declared,  # addr, uri, save, integrity, size
+    )
+)
+# a negative offset is what puts the body on disk, so leave byte 0 unused
+open(os.path.join(d, "c.dat"), "wb").write(b"\n" + record)
+# the header is length-prefixed like the .dat; the entry walk then eats one
+# line before reading each url/uri/offset triple
+header = field("CACHE-1.4") + field("Wed, 01 Jan 2025 00:00:00 GMT")
+open(os.path.join(d, "c.ndx"), "wb").write(
+    header + b"eaten\nexample.com/page.html\n\n-1\n"
+)
+EOF
+}
+
+craft_ndx "${#BODY}"
+proxytrack --convert "$dir/ndx-honest.arc" "$dir/n/hts-cache/c.ndx" >/dev/null 2>&1 ||
+    fail "proxytrack died converting an honest .ndx cache"
+grep -qaF "$BODY" "$dir/ndx-honest.arc" || fail "an honest .ndx size lost the body"
+
+craft_ndx "$DECLARED"
+proxytrack --convert "$dir/ndx.arc" "$dir/n/hts-cache/c.ndx" >/dev/null 2>&1 ||
+    fail "proxytrack died converting an .ndx cache whose body is short"
+if grep -qa "Content-length: $DECLARED" "$dir/ndx.arc"; then
+    fail "the .ndx reader kept $DECLARED bytes of a ${#BODY}-byte body"
+fi
+no_leak "$dir/ndx.arc" "the .ndx reader"
+
+echo "OK: neither consumer emitted a byte the cache body did not hold"

--- a/tests/406_local-proxytrack-short-body.test
+++ b/tests/406_local-proxytrack-short-body.test
@@ -24,11 +24,15 @@ cleanup_push cleanup
 # ('Z') rather than the zeros a fresh page would hand out for free
 export MALLOC_PERTURB_=165
 leak_run=$(printf 'Z%.0s' $(seq 1 64))
-# ... where the allocator honours it; the length assertions carry the rest
+# ... where the allocator honours it, which Windows has no way to ask; the
+# length assertions carry the test everywhere else
 poison=$("$python" -c 'import ctypes
-libc = ctypes.CDLL(None)
-libc.malloc.restype = ctypes.c_void_p
-print(ctypes.string_at(libc.malloc(1 << 16), 8).hex())')
+try:
+    libc = ctypes.CDLL(None)
+    libc.malloc.restype = ctypes.c_void_p
+    print(ctypes.string_at(libc.malloc(1 << 16), 8).hex())
+except Exception:
+    print("unavailable")')
 
 BODY='<html>hello</html>'
 DECLARED=4096


### PR DESCRIPTION
ProxyTrack sizes the body buffer from the cache entry's declared `X-Size`, then fills it from the file that entry names. When the file is shorter the read fails, but the buffer stays, and both consumers emit `element->size` bytes whatever the status code says. `proxytrack_process_HTTP` sends them to the client and the ARC writer puts them on disk. The tail of that buffer is whatever the heap last held.

An attacker controls both halves, because the declared size and the body path are fields of the cache entry. Anyone who can hand ProxyTrack an archive to serve (a downloaded mirror, a shared cache) picks how many bytes leak. A 4096-byte `X-Size` over an 18-byte file leaked 4078 bytes, and nothing but memory bounds that number. That heap belongs to a process that has just parsed other clients' requests and other cache entries. The bytes can carry URLs, headers and cached page content.

I reproduced it before fixing it, under `MALLOC_PERTURB_=165` so the tail reads 0x5a rather than the zeros a fresh page hands out. 4078 sentinel bytes reached the client over the wire, and the same 4078 landed in the ARC.

The fix frees the body on a failed read, which is what the in-zip branch beside it already does. The pre-3.31 `.ndx` reader carries a second copy of the same allocate-then-fill and takes the same change. Two of the four sites the new helper replaces already dropped the body, so those hunks only remove the duplication. With no body to send, the reply still announced `Content-length: element->size`, and the log line still reported it. Both now ask for the bytes the element holds.

Test 406 puts the zip reader through both consumers and the `.ndx` reader through the ARC writer. It requires the record to be present and no consumer to announce more bytes than the file held. An implementation that clips to the bytes it read therefore passes too, which is deliberate. Ten mutants, all killed. Three revert one fix each, and two refuse every disk-held body, one per reader. The rest zero-fill the tail, clip to a wrong length, drop the body only past a threshold, refuse the entry, or never serve one. The heap poison is a bonus rather than the gate, and the two real-bug mutants still fail where the allocator ignores `MALLOC_PERTURB_`.

PR #1517 narrows this window but does not close it, and its own test deliberately leaves the holdable-but-short case out. The two branches merge cleanly and both tests pass on the merge.