### PR TITLE
httrack-library.h is not enough to use CHAIN_FUNCTION()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -703,59 +703,56 @@ hts_pc_dep libbrotlidec "$BROTLI_LIBS"
 hts_pc_dep libzstd "$ZSTD_LIBS"
 
 # An installed header includes <openssl/ssl.h>, so a consumer needs that include
-# path, and outside Requires.private nothing else in the .pc carries it.
+# path. Requires.private does not reliably carry it: a keg-only Homebrew prefix
+# keeps openssl.pc off the default search path, and pkg-config then resolves
+# nothing from it.
 PKGCONFIG_SSL_CFLAGS=
-case " $PKGCONFIG_REQUIRES_PRIVATE " in
-*" openssl "*) ;;
-*)
-	case " $OPENSSL_LIBS " in
-	*" -lssl "*)
-		AC_MSG_CHECKING([whether libhttrack.pc must name the OpenSSL include path])
-		hts_pc_ssl_save_cppflags=$CPPFLAGS
-		CPPFLAGS=
-		AC_COMPILE_IFELSE([AC_LANG_SOURCE([[#include <openssl/ssl.h>]])],
-			[hts_pc_ssl_default=yes], [hts_pc_ssl_default=no])
-		CPPFLAGS=$hts_pc_ssl_save_cppflags
-		if test x"$hts_pc_ssl_default" = x"yes"; then
-			AC_MSG_RESULT([no, the compiler finds it unaided])
-		else
-			hts_pc_ssl_await=
-			hts_pc_ssl_dir=
-			for hts_pc_ssl_flag in $CPPFLAGS; do
-				if test -n "$hts_pc_ssl_await"; then
-					hts_pc_ssl_dir=$hts_pc_ssl_flag
-					hts_pc_ssl_await=
-				else
-					case $hts_pc_ssl_flag in
-					-I | -isystem | -idirafter)
-						hts_pc_ssl_await=yes
-						continue
-						;;
-					-I*) hts_pc_ssl_dir=${hts_pc_ssl_flag#-I} ;;
-					-isystem*) hts_pc_ssl_dir=${hts_pc_ssl_flag#-isystem} ;;
-					-idirafter*) hts_pc_ssl_dir=${hts_pc_ssl_flag#-idirafter} ;;
-					*) continue ;;
-					esac
-				fi
-				# A relative path in an installed .pc resolves against
-				# whatever directory the consumer happens to build in.
-				case $hts_pc_ssl_dir in
-				/*) ;;
+case " $OPENSSL_LIBS " in
+*" -lssl "*)
+	AC_MSG_CHECKING([whether libhttrack.pc must name the OpenSSL include path])
+	hts_pc_ssl_save_cppflags=$CPPFLAGS
+	CPPFLAGS=
+	AC_COMPILE_IFELSE([AC_LANG_SOURCE([[#include <openssl/ssl.h>]])],
+		[hts_pc_ssl_default=yes], [hts_pc_ssl_default=no])
+	CPPFLAGS=$hts_pc_ssl_save_cppflags
+	if test x"$hts_pc_ssl_default" = x"yes"; then
+		AC_MSG_RESULT([no, the compiler finds it unaided])
+	else
+		hts_pc_ssl_await=
+		hts_pc_ssl_dir=
+		for hts_pc_ssl_flag in $CPPFLAGS; do
+			if test -n "$hts_pc_ssl_await"; then
+				hts_pc_ssl_dir=$hts_pc_ssl_flag
+				hts_pc_ssl_await=
+			else
+				case $hts_pc_ssl_flag in
+				-I | -isystem | -idirafter)
+					hts_pc_ssl_await=yes
+					continue
+					;;
+				-I*) hts_pc_ssl_dir=${hts_pc_ssl_flag#-I} ;;
+				-isystem*) hts_pc_ssl_dir=${hts_pc_ssl_flag#-isystem} ;;
+				-idirafter*) hts_pc_ssl_dir=${hts_pc_ssl_flag#-idirafter} ;;
 				*) continue ;;
 				esac
-				test -r "$hts_pc_ssl_dir/openssl/ssl.h" || continue
-				PKGCONFIG_SSL_CFLAGS=" -I$hts_pc_ssl_dir"
-				break
-			done
-			if test -n "$PKGCONFIG_SSL_CFLAGS"; then
-				AC_MSG_RESULT([$hts_pc_ssl_dir])
-			else
-				AC_MSG_RESULT([yes, but no absolute include flag holds it])
-				AC_MSG_WARN([libhttrack.pc will not tell a consumer where <openssl/ssl.h> is])
 			fi
+			# A relative path in an installed .pc resolves against
+			# whatever directory the consumer happens to build in.
+			case $hts_pc_ssl_dir in
+			/*) ;;
+			*) continue ;;
+			esac
+			test -r "$hts_pc_ssl_dir/openssl/ssl.h" || continue
+			PKGCONFIG_SSL_CFLAGS=" -I$hts_pc_ssl_dir"
+			break
+		done
+		if test -n "$PKGCONFIG_SSL_CFLAGS"; then
+			AC_MSG_RESULT([$hts_pc_ssl_dir])
+		else
+			AC_MSG_RESULT([yes, but no absolute include flag holds it])
+			AC_MSG_WARN([libhttrack.pc will not tell a consumer where <openssl/ssl.h> is])
 		fi
-		;;
-	esac
+	fi
 	;;
 esac
 AC_SUBST([PKGCONFIG_SSL_CFLAGS])

--- a/configure.ac
+++ b/configure.ac
@@ -719,19 +719,39 @@ case " $PKGCONFIG_REQUIRES_PRIVATE " in
 		if test x"$hts_pc_ssl_default" = x"yes"; then
 			AC_MSG_RESULT([no, the compiler finds it unaided])
 		else
+			hts_pc_ssl_await=
+			hts_pc_ssl_dir=
 			for hts_pc_ssl_flag in $CPPFLAGS; do
-				case $hts_pc_ssl_flag in
-				-I*)
-					test -r "${hts_pc_ssl_flag#-I}/openssl/ssl.h" || continue
-					PKGCONFIG_SSL_CFLAGS=$hts_pc_ssl_flag
-					break
-					;;
+				if test -n "$hts_pc_ssl_await"; then
+					hts_pc_ssl_dir=$hts_pc_ssl_flag
+					hts_pc_ssl_await=
+				else
+					case $hts_pc_ssl_flag in
+					-I | -isystem | -idirafter)
+						hts_pc_ssl_await=yes
+						continue
+						;;
+					-I*) hts_pc_ssl_dir=${hts_pc_ssl_flag#-I} ;;
+					-isystem*) hts_pc_ssl_dir=${hts_pc_ssl_flag#-isystem} ;;
+					-idirafter*) hts_pc_ssl_dir=${hts_pc_ssl_flag#-idirafter} ;;
+					*) continue ;;
+					esac
+				fi
+				# A relative path in an installed .pc resolves against
+				# whatever directory the consumer happens to build in.
+				case $hts_pc_ssl_dir in
+				/*) ;;
+				*) continue ;;
 				esac
+				test -r "$hts_pc_ssl_dir/openssl/ssl.h" || continue
+				PKGCONFIG_SSL_CFLAGS=" -I$hts_pc_ssl_dir"
+				break
 			done
 			if test -n "$PKGCONFIG_SSL_CFLAGS"; then
-				AC_MSG_RESULT([$PKGCONFIG_SSL_CFLAGS])
+				AC_MSG_RESULT([$hts_pc_ssl_dir])
 			else
-				AC_MSG_RESULT([yes, but no -I in CPPFLAGS holds it])
+				AC_MSG_RESULT([yes, but no absolute include flag holds it])
+				AC_MSG_WARN([libhttrack.pc will not tell a consumer where <openssl/ssl.h> is])
 			fi
 		fi
 		;;

--- a/configure.ac
+++ b/configure.ac
@@ -701,6 +701,44 @@ AS_CASE([" $OPENSSL_LIBS "],
 hts_pc_dep "$hts_pc_openssl" "$OPENSSL_LIBS"
 hts_pc_dep libbrotlidec "$BROTLI_LIBS"
 hts_pc_dep libzstd "$ZSTD_LIBS"
+
+# An installed header includes <openssl/ssl.h>, so a consumer needs that include
+# path, and outside Requires.private nothing else in the .pc carries it.
+PKGCONFIG_SSL_CFLAGS=
+case " $PKGCONFIG_REQUIRES_PRIVATE " in
+*" openssl "*) ;;
+*)
+	case " $OPENSSL_LIBS " in
+	*" -lssl "*)
+		AC_MSG_CHECKING([whether libhttrack.pc must name the OpenSSL include path])
+		hts_pc_ssl_save_cppflags=$CPPFLAGS
+		CPPFLAGS=
+		AC_COMPILE_IFELSE([AC_LANG_SOURCE([[#include <openssl/ssl.h>]])],
+			[hts_pc_ssl_default=yes], [hts_pc_ssl_default=no])
+		CPPFLAGS=$hts_pc_ssl_save_cppflags
+		if test x"$hts_pc_ssl_default" = x"yes"; then
+			AC_MSG_RESULT([no, the compiler finds it unaided])
+		else
+			for hts_pc_ssl_flag in $CPPFLAGS; do
+				case $hts_pc_ssl_flag in
+				-I*)
+					test -r "${hts_pc_ssl_flag#-I}/openssl/ssl.h" || continue
+					PKGCONFIG_SSL_CFLAGS=$hts_pc_ssl_flag
+					break
+					;;
+				esac
+			done
+			if test -n "$PKGCONFIG_SSL_CFLAGS"; then
+				AC_MSG_RESULT([$PKGCONFIG_SSL_CFLAGS])
+			else
+				AC_MSG_RESULT([yes, but no -I in CPPFLAGS holds it])
+			fi
+		fi
+		;;
+	esac
+	;;
+esac
+AC_SUBST([PKGCONFIG_SSL_CFLAGS])
 AC_SUBST([PKGCONFIG_REQUIRES_PRIVATE])
 AC_SUBST([PKGCONFIG_LIBS_PRIVATE])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -94,7 +94,7 @@ libhttrack_la_SOURCES =  htscore.c htsparse.c htsback.c htscache.c \
 	htsfilters.h htsftp.h htsglobal.h htshash.h coucal/coucal.h \
 	htshelp.h htsindex.h htsio.h htslib.h htsurlport.h htsmd5.h \
 	htsmodules.h htsname.h htsnet.h htssniff.h \
-	htsopt.h htsrobots.h htsthread.h  \
+	htsopt.h htsrobots.h htsthread.h htswin32.h  \
 	htscrashtest.h htstools.h htsrandom.h htswizard.h htswrap.h htscodec.h htswarc.h htschanges.h htssinglefile.h htssitemap.h htsproxy.h htszlib.h  \
 	htsstrings.h htsarrays.h htsarena.h httrack-library.h \
 	htscharset.h punycode.h htsencoding.h htsescape.h \

--- a/src/htscharset.h
+++ b/src/htscharset.h
@@ -37,9 +37,7 @@ Please visit our Website: http://www.httrack.com
 #include "htsglobal.h"
 #include <stdlib.h>
 #include <string.h>
-#ifdef _WIN32
-#include <windows.h>
-#endif
+#include "htswin32.h"
 
 /** UCS4 type. **/
 typedef unsigned int hts_UCS4;

--- a/src/htsencoding.h
+++ b/src/htsencoding.h
@@ -38,9 +38,7 @@ Please visit our Website: http://www.httrack.com
 /** Standard includes. **/
 #include <stdlib.h>
 #include <string.h>
-#ifdef _WIN32
-#include <windows.h>
-#endif
+#include "htswin32.h"
 
 /**
  * Flags for hts_unescapeUrlSpecial().

--- a/src/htsescape.c
+++ b/src/htsescape.c
@@ -33,9 +33,7 @@ Please visit our Website: http://www.httrack.com
 
 #include "htsescape.h"
 
-/* CR, LF or TAB, as htslib.h's is_retorsep(). Copied because htsencoding.h
-   pulls windows.h first, so including htslib.h here collides winsock.h with
-   winsock2.h. */
+/* CR, LF or TAB, as htslib.h's is_retorsep(). */
 static HTS_INLINE int hts_is_retorsep(const char c) {
   return c == 10 || c == 13 || c == 9;
 }

--- a/src/htsrandom.c
+++ b/src/htsrandom.c
@@ -36,7 +36,7 @@ Please visit our Website: http://www.httrack.com
 #include "htsrandom.h"
 
 #ifdef _WIN32
-#include <windows.h>
+#include "htswin32.h"
 #else
 #include <errno.h>
 #include <stdio.h>

--- a/src/htsthread.h
+++ b/src/htsthread.h
@@ -37,9 +37,7 @@ Please visit our Website: http://www.httrack.com
 #ifndef _WIN32
 #include <pthread.h>
 #endif
-#ifdef _WIN32
-#include "windows.h"
-#endif
+#include "htswin32.h"
 #ifndef USE_BEGINTHREAD
 #error needs USE_BEGINTHREAD
 #endif

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -43,7 +43,7 @@ Please visit our Website: http://www.httrack.com
 #include "htsescape.h"
 #include "htscharset.h"
 #ifdef _WIN32
-#include "windows.h"
+#include "htswin32.h"
 #include <io.h> /* _isatty */
 #else
 #include <dirent.h>

--- a/src/htswin32.h
+++ b/src/htswin32.h
@@ -1,0 +1,46 @@
+/* ------------------------------------------------------------ */
+/*
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) 2026 Xavier Roche and other contributors
+
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Ethical use: we kindly ask that you NOT use this software to harvest email
+addresses or to collect any other private information about people. Doing so
+would dishonor our work and waste the many hours we have spent on it.
+
+Please visit our Website: http://www.httrack.com
+*/
+
+/* ------------------------------------------------------------ */
+/* File: windows.h, with winsock2.h first                       */
+/* Author: Xavier Roche                                         */
+/* ------------------------------------------------------------ */
+
+/** @file htswin32.h
+    Include this rather than <windows.h>: windows.h pulls the 1.1 winsock.h, so
+    a unit that later reaches winsock2.h (through htsnet.h) gets sockaddr and
+    every socket call redefined. winsock2.h first suppresses winsock.h. */
+
+#ifndef HTS_DEFWIN32
+#define HTS_DEFWIN32
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <windows.h>
+#endif
+
+#endif

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -52,6 +52,10 @@ Please visit our Website: http://www.httrack.com
 #ifndef HTTRACK_DEFLIB
 #define HTTRACK_DEFLIB
 
+/* CHAIN_FUNCTION() below dereferences httrackp and t_hts_callbackarg. */
+#include "htsdefines.h"
+#include "htsopt.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -101,8 +105,7 @@ typedef struct hts_stat_struct hts_stat_struct;
 typedef void (*htsErrorCallback)(const char *msg, const char *file, int line);
 #endif
 
-/* Helpers for plugging callbacks
-requires: htsdefines.h */
+/* Helpers for plugging callbacks */
 
 /**
  * Install callback FUNCTION into OPT->callbacks_fun->MEMBER, chaining it ahead

--- a/src/httrack.c
+++ b/src/httrack.c
@@ -45,7 +45,7 @@ Please visit our Website: http://www.httrack.com
 #include "htsdefines.h"
 #include "httrack.h"
 #include "htslib.h"
-#include "htscharset.h" // after htslib.h: winsock2.h must precede windows.h
+#include "htscharset.h"
 #include "htsbacktrace.h"
 #include "htsthread.h"
 

--- a/src/libhttrack.pc.in
+++ b/src/libhttrack.pc.in
@@ -9,7 +9,7 @@ URL: @PACKAGE_URL@
 Version: @PACKAGE_VERSION@
 # Flat, as the installed headers and the libtest examples include each other; same
 # flags libtest itself builds with. config.h, not these, carries the ABI gating.
-Cflags: -I${includedir}/httrack @V6_FLAG@ @LFS_FLAG@
+Cflags: -I${includedir}/httrack @V6_FLAG@ @LFS_FLAG@ @PKGCONFIG_SSL_CFLAGS@
 # Carries its own leading space, and is empty wherever configure gates the rpath off (#978).
 Libs: -L${libdir} -lhttrack@PKGCONFIG_RPATH_LDFLAG@
 # Ordered for an archive link: a library ahead of the ones it uses.

--- a/src/libhttrack.pc.in
+++ b/src/libhttrack.pc.in
@@ -9,7 +9,8 @@ URL: @PACKAGE_URL@
 Version: @PACKAGE_VERSION@
 # Flat, as the installed headers and the libtest examples include each other; same
 # flags libtest itself builds with. config.h, not these, carries the ABI gating.
-Cflags: -I${includedir}/httrack @V6_FLAG@ @LFS_FLAG@ @PKGCONFIG_SSL_CFLAGS@
+# The last one carries its own leading space, and is empty on most builds.
+Cflags: -I${includedir}/httrack @V6_FLAG@ @LFS_FLAG@@PKGCONFIG_SSL_CFLAGS@
 # Carries its own leading space, and is empty wherever configure gates the rpath off (#978).
 Libs: -L${libdir} -lhttrack@PKGCONFIG_RPATH_LDFLAG@
 # Ordered for an archive link: a library ahead of the ones it uses.

--- a/src/proxy/store.h
+++ b/src/proxy/store.h
@@ -33,7 +33,7 @@ Please visit our Website: http://www.httrack.com
 #ifndef _WIN32
 #include <pthread.h>
 #else
-#include "windows.h"
+#include "../htswin32.h"
 #endif
 
 /* Proxy */

--- a/tests/411_chain-function-installed-headers.test
+++ b/tests/411_chain-function-installed-headers.test
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# html/plug.html plugs callbacks with CHAIN_FUNCTION() and html/library.html
+# sends the reader to httrack-library.h, so that header must carry the types the
+# macro expands to. 205 compiles each installed header alone, which reaches no
+# macro body.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+skip_on_emulated "a header self-sufficiency check cannot vary by target"
+
+# Unset means no automake run (the Windows job runs the scripts directly), so
+# there is no install rule to drive.
+if [ -z "${abs_top_builddir:-}" ]; then
+    echo "abs_top_builddir unset, no automake environment, skipping" >&2
+    exit 77
+fi
+[ -f "$abs_top_builddir/src/Makefile" ] || fail "$abs_top_builddir/src is not configured"
+
+# CC carries flags on some legs ("gcc -m32", "ccache gcc"), so split it.
+read -r -a cc_argv <<<"${CC:-cc}"
+command -v "${cc_argv[0]}" >/dev/null 2>&1 || skip "no C compiler (${cc_argv[0]})"
+make=${MAKE:-make}
+command -v "$make" >/dev/null 2>&1 || skip "no make ($make)"
+
+fixture="$testdir/chainplug.c"
+[ -f "$fixture" ] || fail "$fixture is missing"
+
+tmp=$(mktemp -d) || exit 1
+cleanup_push rm -rf "$tmp"
+
+# Seeding the array keeps it non-empty, which bash 3.2 needs under set -u.
+base_argv=(-I"$tmp")
+if [ -n "${TEST_CPPFLAGS:-}" ]; then
+    read -r -a extra_argv <<<"$TEST_CPPFLAGS"
+    base_argv+=("${extra_argv[@]}")
+fi
+
+# Positive control: a compiler that cannot build a bare libc TU would otherwise
+# blame the header.
+printf '#include <stdio.h>\n' >"$tmp/tu.c"
+if ! "${cc_argv[@]}" "${base_argv[@]}" -fsyntax-only "$tmp/tu.c" 2>"$tmp/cc.log"; then
+    head -5 "$tmp/cc.log" >&2
+    echo "${cc_argv[*]} cannot compile a bare <stdio.h>, skipping" >&2
+    exit 77
+fi
+
+# Override the install dir rather than use DESTDIR: same rule and file list, no
+# guessing at the prefix. Empty MAKEFLAGS, or the sub-make reaches for a
+# jobserver the test driver did not hand it.
+run_with_install_lock env MAKEFLAGS= MFLAGS= "$make" -C "$abs_top_builddir/src" \
+    install-DevIncludesDATA \
+    DevIncludesdir="$tmp/include/httrack" >"$tmp/install.log" 2>&1 ||
+    {
+        cat "$tmp/install.log" >&2
+        fail "install-DevIncludesDATA failed"
+    }
+[ -f "$tmp/include/httrack/httrack-library.h" ] || fail "httrack-library.h was not installed"
+
+# Vacuity control: a stray -I into the source tree would hide the failure.
+if "${cc_argv[@]}" "${base_argv[@]}" -fsyntax-only "$fixture" 2>/dev/null; then
+    fail "httrack-library.h resolves without the staged include path, this proves nothing"
+fi
+
+if ! "${cc_argv[@]}" "${base_argv[@]}" -I"$tmp/include/httrack" \
+    -c -o "$tmp/plug.o" "$fixture" 2>"$tmp/cc.log"; then
+    head -20 "$tmp/cc.log" >&2
+    fail "the documented CHAIN_FUNCTION() plugin does not compile against the installed headers"
+fi
+
+exit 0

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,7 @@ TESTS = @TESTS_LIST@
 # Committed binary fixture read by 01_zlib-cache-golden.test. List it
 # explicitly: automake does not expand wildcards in EXTRA_DIST, so a glob would
 # silently drop it from the dist tarball and break "make distcheck".
-EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c altstackprobe.c nopieprobe.c printnumprobe.c closetrack.c ftpcancel.c seekfail.c pubheaderlayout.c crawl-test.sh run-all-tests.sh check-network.sh check-test-names.sh \
+EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c altstackprobe.c nopieprobe.c printnumprobe.c closetrack.c ftpcancel.c seekfail.c pubheaderlayout.c chainplug.c crawl-test.sh run-all-tests.sh check-network.sh check-test-names.sh \
 	proxy-https-server.py socks5-server.py proxy-connect-server.py \
 	proxytestlib.py tls-stall-server.py warc-validate.py wacz-validate.py \
 	header-injection-server.py header-injection-check.py \

--- a/tests/chainplug.c
+++ b/tests/chainplug.c
@@ -1,0 +1,34 @@
+/* The plugin entry point html/plug.html documents, over httrack-library.h
+ * alone. */
+
+#include "httrack-library.h"
+
+static int process_file(t_hts_callbackarg *carg, httrackp *opt, char *html,
+                        int len, const char *url_address,
+                        const char *url_file) {
+  (void) CALLBACKARG_USERDEF(carg);
+  if (CALLBACKARG_PREV_FUN(carg, check_html) != NULL) {
+    return CALLBACKARG_PREV_FUN(carg, check_html)(
+        CALLBACKARG_PREV_CARG(carg), opt, html, len, url_address, url_file);
+  }
+  return 1;
+}
+
+static int end_of_mirror(t_hts_callbackarg *carg, httrackp *opt) {
+  if (CALLBACKARG_PREV_FUN(carg, end) != NULL) {
+    return CALLBACKARG_PREV_FUN(carg, end)(CALLBACKARG_PREV_CARG(carg), opt);
+  }
+  return 1;
+}
+
+EXTERNAL_FUNCTION int hts_plug(httrackp *opt, const char *argv) {
+  (void) argv;
+  CHAIN_FUNCTION(opt, check_html, process_file, NULL);
+  CHAIN_FUNCTION(opt, end, end_of_mirror, NULL);
+  return 1;
+}
+
+EXTERNAL_FUNCTION int hts_unplug(httrackp *opt) {
+  (void) opt;
+  return 1;
+}


### PR DESCRIPTION
`CHAIN_FUNCTION()` is how html/plug.html tells a plugin author to install a callback, and html/library.html sends that author to `httrack-library.h` for the API. A translation unit that includes only that header does not compile. The macro dereferences `httrackp` and allocates a `t_hts_callbackarg`, and the header declared neither, so gcc reports `unknown type name 't_hts_callbackarg'`. A `requires: htsdefines.h` note sat above the macro, and nothing enforced it.

The fix includes `htsdefines.h` and `htsopt.h`, both already in `DevIncludes_DATA`, so no new file is installed and no declaration moved. `nm -D --defined-only libhttrack.so` reports the same 172 symbols before and after.

The doc's own worked example includes all three headers, which is probably why nobody hit this. Only a reader who followed the prose rather than the example would.

`htsopt.h` pulls `htsnet.h` and therefore `winsock2.h`, and that broke the MSVC build. `htsthread.c` took `windows.h` first through `htsthread.h`, so `winsock.h` won and MSVC redefined `sockaddr`, `fd_set` and the socket calls. The defect is the header rather than one file's include order. Five other headers of ours had the same shape, and nothing had yet made their translation units reach `winsock2.h`. New `src/htswin32.h` establishes the order once, and six sites include it instead of `<windows.h>`. It is not installed and it defines no macro that hides a declaration. An include-graph walk over the Visual Studio project files counts 58 translation units. One reached `windows.h` first before the change, and none did after.

Test 411 stages `DevIncludes_DATA` into a private directory and compiles `tests/chainplug.c` against it. No include path reaches the source tree, because a `-Isrc` makes the bug vanish. The test also checks that the same compile fails without the staged path, so a stray `-I` cannot make it vacuous. Reverting the header change turns it red on the compiler error above.

That reach means a consumer also needs OpenSSL's own headers. Where OpenSSL ships a `.pc` file, `Requires.private` already carries the path. Where configure finds OpenSSL only through `CPPFLAGS`, as on a keg-only Homebrew prefix, nothing does, and `222_pkgconfig-consumer` caught it on macOS. `libhttrack.pc` now names that directory, but only when the compiler cannot find the header unaided. It takes an absolute path only, because a relative one in an installed `.pc` resolves against whatever directory the consumer builds in.