### PR TITLE
html/library.html documents no symbol and points at a file an integrator cannot build

### DIFF
--- a/html/library.html
+++ b/html/library.html
@@ -25,6 +25,11 @@
 <div class="wrap">
 
 <nav class="toc" aria-label="Documentation">
+	<h2>On this page</h2>
+	<ul>
+		<li><a href="#headers">The headers an install gives you</a></li>
+		<li><a href="#examples">Worked examples</a></li>
+	</ul>
 	<h2>Start here</h2>
 	<ul>
 		<li><a href="guide.html">Interface guide</a></li>
@@ -61,12 +66,47 @@
 
 <br>
 
-All library prototypes are available in the <tt>httrack-library.h<tt> file.<br>
-You may also want to check the <tt>httrack.c</tt> and <tt>httrack.h<tt> files to get an example of use of this library.
+Every library prototype is declared in <tt>httrack-library.h</tt>. Build against it with
+<tt>pkg-config --cflags --libs libhttrack</tt>, which adds <tt>$(includedir)/httrack</tt> to the
+include path and links <tt>-lhttrack</tt>.
 
 <br><br>
 
+<h3 id="headers">The headers an install gives you</h3>
 
+<p>Installing the library puts these headers in <tt>$(includedir)/httrack</tt>, and no others:</p>
+
+<ul>
+<li><tt>httrack-library.h</tt></li>
+<li><tt>htsglobal.h</tt></li>
+<li><tt>htsopt.h</tt></li>
+<li><tt>htswrap.h</tt></li>
+<li><tt>htsconfig.h</tt></li>
+<li><tt>htsfeatures.h</tt></li>
+<li><tt>htsmodules.h</tt></li>
+<li><tt>htsbasenet.h</tt></li>
+<li><tt>htsnet.h</tt></li>
+<li><tt>htsbauth.h</tt></li>
+<li><tt>htsdefines.h</tt></li>
+<li><tt>htsstrings.h</tt></li>
+<li><tt>htsarrays.h</tt></li>
+<li><tt>htssafe.h</tt></li>
+</ul>
+
+<p>Every other header under <tt>src/</tt> is engine-internal, so a file that includes one of them
+compiles only inside the source tree.</p>
+
+<h3 id="examples">Worked examples</h3>
+
+<p>The examples install next to the library, in <tt>$(datadir)/httrack/libtest</tt>, and they
+include nothing but the headers above. <tt>example-main.c</tt> drives a whole mirror from a
+program, and each <tt>callbacks-example-*.c</tt> file shows one callback. The
+<a href="plug.html">callbacks page</a> documents the hooks themselves.</p>
+
+<p>The command-line front end <tt>src/httrack.c</tt> is not one of them. It ships in the source
+tarball only, and it includes engine-internal headers (<tt>htsbase.h</tt>, <tt>httrack.h</tt>,
+<tt>htslib.h</tt>, <tt>htscharset.h</tt>, <tt>htsbacktrace.h</tt> and <tt>htsthread.h</tt>) that an
+install does not carry.</p>
 
 <br><br>
 

--- a/html/library.html
+++ b/html/library.html
@@ -99,7 +99,7 @@ compiles only inside the source tree.</p>
 <h3 id="examples">Worked examples</h3>
 
 <p>The examples install next to the library, in <tt>$(datadir)/httrack/libtest</tt>, and they
-include nothing but the headers above. <tt>example-main.c</tt> drives a whole mirror from a
+include no header an install does not carry. <tt>example-main.c</tt> drives a whole mirror from a
 program, and each <tt>callbacks-example-*.c</tt> file shows one callback. The
 <a href="plug.html">callbacks page</a> documents the hooks themselves.</p>
 

--- a/tests/412_doc-library-headers.test
+++ b/tests/412_doc-library-headers.test
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# html/library.html tells an integrator which headers an install carries and
-# which of src/httrack.c's it does not. Both lists are copies of build-system
-# facts, so pin them to their sources.
+# html/library.html tells an integrator which headers an install carries, which
+# of src/httrack.c's it does not, and that the libtest examples stay inside
+# what an install carries. All three are copies of build-system facts.
 
 set -euo pipefail
 
@@ -22,14 +22,52 @@ same_set() { # same_set <list A> <list B>: newline-separated, order-insensitive
     diff <(sort <<<"$1") <(sort <<<"$2") >/dev/null
 }
 
-# The DevIncludes_DATA continuation block, one basename per line.
-installed=$(sed -n '/^DevIncludes_DATA[[:space:]]*=/,/[^\\]$/p' "${makefile}" |
-    sed 's/^DevIncludes_DATA[[:space:]]*=//; s/\\$//' | tr -s ' \t' '\n' |
-    sed 's,.*/,,' | grep '\.h$' | sort -u)
+# Every DevIncludes_DATA assignment and its continuations, one basename a line.
+parse_installed() { # parse_installed <makefile>
+    sed -n '/DevIncludes_DATA[[:space:]]*[+:]*=/,/[^\\]$/p' "$1" |
+        sed 's/^[[:space:]]*DevIncludes_DATA[[:space:]]*[+:]*=//; s/\\$//' |
+        tr -s ' \t' '\n' | sed 's,.*/,,' | grep '\.h$' | sort -u
+}
+
+# Project headers a .c includes, either bracket style, indented or not: a name
+# is ours when src/ or the file's own directory holds it.
+parse_includes() { # parse_includes <c file>
+    local here
+    here=$(dirname "$1")
+    grep -oE '^[[:space:]]*#[[:space:]]*include[[:space:]]*[<"][A-Za-z0-9._-]+\.h[">]' "$1" |
+        sed 's,^[^<"]*[<"],,; s,[">].*,,' | sort -u |
+        while read -r h; do
+            if test -e "${srcdir}/src/${h}" || test -e "${here}/${h}"; then
+                echo "${h}"
+            fi
+        done
+}
+
+# Controls: both parsers must see the spellings a future edit may use, or they
+# stop guarding without failing.
+fixture=$(mktemp -d "${TMPDIR:-/tmp}/doclib.XXXXXX") || fail "no tmpdir"
+cleanup_push rm -rf "${fixture}"
+cat >"${fixture}/Makefile.am" <<'FIX'
+DevIncludes_DATA = \
+	one.h \
+	../two.h
+DevIncludes_DATA += three.h
+FIX
+same_set "$(parse_installed "${fixture}/Makefile.am")" 'one.h
+two.h
+three.h' || fail "parse_installed misses a += or a ../ spelling"
+cat >"${fixture}/probe.c" <<'FIX'
+#include <stdio.h>
+  #include "htsbase.h"
+#include <htslib.h>
+FIX
+same_set "$(parse_includes "${fixture}/probe.c")" 'htsbase.h
+htslib.h' || fail "parse_includes misses an indented or bracketed project include"
+
+installed=$(parse_installed "${makefile}")
 grep -qx 'httrack-library.h' <<<"${installed}" ||
     fail "parsed no DevIncludes_DATA list out of ${makefile}"
 
-# Control: the comparison must be able to say no.
 if same_set "${installed}" "${installed}
 nosuch.h"; then
     fail "same_set() ignores an extra name; the checks below prove nothing"
@@ -49,8 +87,7 @@ same_set "${installed}" "${listed}" || {
 }
 
 # What src/httrack.c includes and an install does not carry.
-internal=$(grep -o '^#include "[a-z0-9.-]*\.h"' "${frontend}" |
-    sed 's,.*"\(.*\)",\1,' | sort -u | comm -23 - <(printf '%s\n' "${installed}"))
+internal=$(parse_includes "${frontend}" | comm -23 - <(printf '%s\n' "${installed}"))
 test -n "${internal}" || fail "parsed no private includes out of ${frontend}"
 
 quoted=$(sed -n '/engine-internal headers (/,/install does not carry/p' "${page}" |
@@ -63,5 +100,18 @@ same_set "${internal}" "${quoted}" || {
     diff <(sort <<<"${internal}") <(sort <<<"${quoted}") >&2 || true
     fail "${page} is out of date"
 }
+
+# The page sends the reader to libtest, claiming those files stay inside what an
+# install carries. libtest ships its own sources too, so they count as carried.
+carried=$(
+    printf '%s\n' "${installed}"
+    (cd "${srcdir}/libtest" && ls ./*.h) | sed 's,.*/,,'
+)
+carried=$(sort -u <<<"${carried}")
+for c in "${srcdir}"/libtest/*.c; do
+    stray=$(parse_includes "${c}" | comm -23 - <(printf '%s\n' "${carried}"))
+    test -z "${stray}" ||
+        fail "${c} includes ${stray//$'\n'/ }, which no install carries"
+done
 
 exit 0

--- a/tests/412_doc-library-headers.test
+++ b/tests/412_doc-library-headers.test
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# html/library.html tells an integrator which headers an install carries and
+# which of src/httrack.c's it does not. Both lists are copies of build-system
+# facts, so pin them to their sources.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+srcdir=${abs_top_srcdir:?not run under make check}
+page=${srcdir}/html/library.html
+makefile=${srcdir}/src/Makefile.am
+frontend=${srcdir}/src/httrack.c
+
+for f in "${page}" "${makefile}" "${frontend}"; do
+    test -r "${f}" || fail "no ${f}"
+done
+
+same_set() { # same_set <list A> <list B>: newline-separated, order-insensitive
+    diff <(sort <<<"$1") <(sort <<<"$2") >/dev/null
+}
+
+# The DevIncludes_DATA continuation block, one basename per line.
+installed=$(sed -n '/^DevIncludes_DATA[[:space:]]*=/,/[^\\]$/p' "${makefile}" |
+    sed 's/^DevIncludes_DATA[[:space:]]*=//; s/\\$//' | tr -s ' \t' '\n' |
+    sed 's,.*/,,' | grep '\.h$' | sort -u)
+grep -qx 'httrack-library.h' <<<"${installed}" ||
+    fail "parsed no DevIncludes_DATA list out of ${makefile}"
+
+# Control: the comparison must be able to say no.
+if same_set "${installed}" "${installed}
+nosuch.h"; then
+    fail "same_set() ignores an extra name; the checks below prove nothing"
+fi
+
+# <li><tt>name.h</tt></li> under the headers section.
+listed=$(sed -n '/<h3 id="headers">/,/<h3 id="examples">/p' "${page}" |
+    grep -o '<li><tt>[a-z0-9.-]*\.h</tt></li>' |
+    sed 's,.*<tt>,,; s,</tt>.*,,' | sort -u)
+test -n "${listed}" || fail "parsed no header list out of ${page}"
+
+same_set "${installed}" "${listed}" || {
+    echo "${page} lists different headers than DevIncludes_DATA." >&2
+    echo "Left is src/Makefile.am, right is the page:" >&2
+    diff <(sort <<<"${installed}") <(sort <<<"${listed}") >&2 || true
+    fail "${page} is out of date"
+}
+
+# What src/httrack.c includes and an install does not carry.
+internal=$(grep -o '^#include "[a-z0-9.-]*\.h"' "${frontend}" |
+    sed 's,.*"\(.*\)",\1,' | sort -u | comm -23 - <(printf '%s\n' "${installed}"))
+test -n "${internal}" || fail "parsed no private includes out of ${frontend}"
+
+quoted=$(sed -n '/engine-internal headers (/,/install does not carry/p' "${page}" |
+    grep -o '<tt>[a-z0-9.-]*\.h</tt>' | sed 's,</*tt>,,g' | sort -u)
+test -n "${quoted}" || fail "parsed no private-include list out of ${page}"
+
+same_set "${internal}" "${quoted}" || {
+    echo "${page} names different private includes than ${frontend}." >&2
+    echo "Left is httrack.c, right is the page:" >&2
+    diff <(sort <<<"${internal}") <(sort <<<"${quoted}") >&2 || true
+    fail "${page} is out of date"
+}
+
+exit 0

--- a/tests/412_doc-library-headers.test
+++ b/tests/412_doc-library-headers.test
@@ -30,11 +30,18 @@ parse_installed() { # parse_installed <makefile>
 }
 
 # Project headers a .c includes, either bracket style, indented or not: a name
-# is ours when src/ or the file's own directory holds it.
+# is ours when src/ or the file's own directory holds it. A "#if 0" block is
+# dropped first, since the compiler never sees what it names.
 parse_includes() { # parse_includes <c file>
     local here
     here=$(dirname "$1")
-    grep -oE '^[[:space:]]*#[[:space:]]*include[[:space:]]*[<"][A-Za-z0-9._-]+\.h[">]' "$1" |
+    awk '
+        /^[[:space:]]*#[[:space:]]*if[[:space:]]+0[[:space:]]*$/ { if (!d) { d = 1; n = 0; next } }
+        d && /^[[:space:]]*#[[:space:]]*(if|ifdef|ifndef)\>/ { n++ }
+        d && /^[[:space:]]*#[[:space:]]*endif\>/ { if (n == 0) { d = 0; next } ; n-- }
+        !d
+    ' "$1" |
+        grep -oE '^[[:space:]]*#[[:space:]]*include[[:space:]]*[<"][A-Za-z0-9._-]+\.h[">]' |
         sed 's,^[^<"]*[<"],,; s,[">].*,,' | sort -u |
         while read -r h; do
             if test -e "${srcdir}/src/${h}" || test -e "${here}/${h}"; then
@@ -60,9 +67,15 @@ cat >"${fixture}/probe.c" <<'FIX'
 #include <stdio.h>
   #include "htsbase.h"
 #include <htslib.h>
+#if 0
+#ifdef NEVER
+#include "htsname.h"
+#endif
+#include "htscache.h"
+#endif
 FIX
 same_set "$(parse_includes "${fixture}/probe.c")" 'htsbase.h
-htslib.h' || fail "parse_includes misses an indented or bracketed project include"
+htslib.h' || fail "parse_includes misreads an indented, bracketed or #if 0 include"
 
 installed=$(parse_installed "${makefile}")
 grep -qx 'httrack-library.h' <<<"${installed}" ||


### PR DESCRIPTION
`html/library.html` sent an integrator to `src/httrack.c` for an example. That file includes six headers the development package does not install: `htsbase.h`, `httrack.h`, `htslib.h`, `htscharset.h`, `htsbacktrace.h` and `htsthread.h`. So it cannot compile outside the source tree. The page named no symbol, no include path and no link flags either.

It now lists the headers `DevIncludes_DATA` installs, gives the `pkg-config` line, and points at the `libtest/` examples. Those examples install to `$(datadir)/httrack/libtest` and include nothing outside that set.

Both lists are copies of build-system facts, so they would rot the same way the old text did. `tests/412` parses them back out of `src/Makefile.am` and `src/httrack.c` and compares. A second agent re-measured the mutants on a separate checkout and killed 7 of 7. Each one edits a list the test compares.

A full API reference is a separate question, and this PR does not address it.
