### PR TITLE
A cache body whose CRC does not match is served without complaint

### DIFF
--- a/src/htscache.c
+++ b/src/htscache.c
@@ -1013,7 +1013,12 @@ static htsblk cache_readex_new(httrackp *opt, cache_back *cache,
           r.statuscode = STATUSCODE_INVALID;
           strcpybuff(r.msg, "Cache Read Error : Read Header Data");
         }
-        unzCloseCurrentFile((unzFile) cache->zipInput);
+        /* minizip reports a CRC mismatch only here, once the member is read. */
+        if (unzCloseCurrentFile((unzFile) cache->zipInput) != Z_OK &&
+            r.statuscode != STATUSCODE_INVALID) {
+          r.statuscode = STATUSCODE_INVALID;
+          strcpybuff(r.msg, "Cache Read Error : CRC");
+        }
       } else {
         r.statuscode = STATUSCODE_INVALID;
         strcpybuff(r.msg, "Cache Read Error : Open File");

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -1567,6 +1567,38 @@ static void corrupt_victim_body(httrackp *opt) {
   freet(data);
 }
 
+/* Flip the victim's stored CRC in both headers, which must agree or the open
+   fails before anything inflates. */
+static void corrupt_victim_crc(httrackp *opt) {
+  LLint fsz = 0;
+  char *data = readfile2(reconcile_st_path(opt, "hts-cache/new.zip"), &fsz);
+  const size_t n = (size_t) fsz;
+  size_t k, local = 0, central = 0, hits = 0;
+  FILE *fp;
+
+  assertf(data != NULL);
+  for (k = 0; k + 4 <= n; k++) {
+    if (memcmp(data + k, "PK\x03\x04", 4) == 0 && ++hits == 2)
+      local = k + 14;
+  }
+  assertf(hits == 2);
+  hits = 0;
+  for (k = 0; k + 4 <= n; k++) {
+    if (memcmp(data + k, "PK\x01\x02", 4) == 0 && ++hits == 2)
+      central = k + 16;
+  }
+  assertf(hits == 2);
+  assertf(local != 0 && local + 4 <= n && central != 0 && central + 4 <= n);
+  /* Not zeroed: an empty member's real CRC is 0, so 0 could match by luck. */
+  memset(data + local, 0x5A, 4);
+  memset(data + central, 0x5A, 4);
+  fp = fopen(reconcile_st_path(opt, "hts-cache/new.zip"), "wb");
+  assertf(fp != NULL);
+  assertf(hts_fwrite_exact(data, n, fp));
+  fclose(fp);
+  freet(data);
+}
+
 /* Read the corrupt /victim.html and, in the SAME read session, the intact
    /canary.html: the victim must be rejected (wantmsg pins which path) and the
    canary must still decode byte-exact, proving one bad entry never taints a
@@ -1713,6 +1745,11 @@ int cache_corruption_selftest(httrackp *opt, const char *dir) {
   corrupt_victim_body(opt);
   failures += corrupt_expect_victim(opt, "Cache Read Error : Read Data",
                                     "garbled deflate stream");
+
+  corrupt_build(opt);
+  corrupt_victim_crc(opt);
+  failures += corrupt_expect_victim(opt, "Cache Read Error : CRC",
+                                    "body inflates, CRC does not match");
 
   /* A corrupt cache can hold a field wider than ours. Clipping keeps the
      entry; aborting would take the crawl down. Overwrite the placeholder Etag


### PR DESCRIPTION
minizip verifies a member's CRC inside `unzCloseCurrentFile()`, once the whole member has been read. The cache read path threw that return away, so a body that inflated cleanly with a wrong CRC went into the mirror unremarked. That case now reports a cache read failure, which costs one refetch.

The index load in `cache_init()` discards the same return, and that one stays. It reads no body, so the only member minizip can verify there is an empty one, true of every headers-only entry. That CRC covers no bytes, so checking it would drop a usable entry while saying nothing about the file on disk.

The new case rides `tests/01_zlib-cache-corrupt.test`. It flips the victim's stored CRC in both the local and the central header. The two headers must agree, or the open fails first and the case would test the coherency check instead. Mutation testing killed three of the four mutants. The survivor keeps an earlier error message that no case in the file distinguishes. A second agent re-measured this on its own checkout and confirmed the corrupted member still inflates to full length before the CRC verdict.

Two other items from the same sweep got a verdict and no change. `copy_htsopt()` has no caller in the tree, but it is `HTSEXT_API` in the installed `httrack-library.h`, so it counts as the front ends' API. `-#C` enumerates from `hts-cache/new.ndx`, which nothing has written since 3.31. A fresh mirror leaves only `new.zip`, so `httrack -#C '*'` prints "No cache entry found" over a cache holding two entries. Restoring that means enumerating the ZIP, and dropping the option removes a documented feature, so this is a ruling, not a cleanup.