### PR TITLE
An .arc record's declared length can reach into the record stored after it

### DIFF
--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -2101,6 +2101,23 @@ static int skipArcData(FILE * file, const char *line) {
   return -1;
 }
 
+/* A record's declared data must end where the next record's separator sits, or
+   the reader hands out the neighbour's bytes under this record's URL. */
+static hts_boolean atArcRecordBoundary(FILE *file, long int fileSize) {
+  const long int pos = ftell(file);
+  int c;
+
+  if (pos < 0)
+    return HTS_FALSE;
+  /* past the end is the truncated archive the read-time bound refuses */
+  if (pos >= fileSize)
+    return HTS_TRUE;
+  c = fgetc(file);
+  if (fseek(file, pos, SEEK_SET) != 0)
+    return HTS_FALSE;
+  return c == 0x0a ? HTS_TRUE : HTS_FALSE;
+}
+
 static int getDigit(const char digit) {
   return (int) (digit - '0');
 }
@@ -2219,10 +2236,12 @@ int PT_LoadCache__Arc(PT_Index index_, const char *filename) {
                 filenameIndex += 7;
               }
               if (*filenameIndex != 0) {
-                if (skipArcData(index->file, index->line) != 0) {
+                if (skipArcData(index->file, index->line) != 0 ||
+                    !atArcRecordBoundary(index->file, index->fileSize)) {
                   fprintf(stderr,
                           "Corrupted cache data entry #%d (truncated file?), aborting read"
                           LF, (int) entries);
+                  break;
                 }
                 /*fprintf(stdout, "adding %s [%d]\n", filenameIndex, (int)fpos); */
                 if (PT_CompatibleScheme(index->filenameIndexBuff)) {

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -2169,6 +2169,17 @@ static hts_boolean arcPastRecordEnd(FILE *file, long int end) {
   return (end >= 0 && ftell(file) > end) ? HTS_TRUE : HTS_FALSE;
 }
 
+/* Characters linput() returns for one line at most, given the size the walk
+   passes it: one below the buffer it is handed, which is itself one below the
+   field. Matching it exactly is what keeps the scan and the walk from reading
+   the same long line differently. */
+#define ARC_LINE_MAX ((int) sizeof(((PT_Index__Arc) NULL)->line) - 2)
+
+/* Bytes linput() never returns, wherever they sit on the line. */
+static hts_boolean arcDroppedByte(char c) {
+  return (c == 9 || c == 12 || c == 13) ? HTS_TRUE : HTS_FALSE;
+}
+
 /* Length of the digit run filling the field at pos, or -1 for anything else. */
 static int arcDigitField(const char *pos) {
   int i;
@@ -2179,14 +2190,15 @@ static int arcDigitField(const char *pos) {
 }
 
 /* A scheme, an address, a date, a MIME type and a length, in five fields
-   (arc 1.0) or ten (arc 1.1). The count and the trailing length are what tell a
-   record line from a sentence quoting a URL. */
+   (arc 1.0) or ten (arc 1.1). Trailing spaces do not count, because one of them
+   is the whole difference on an otherwise ordinary line. */
 static hts_boolean arcHasRecordShape(const char *line) {
   const char *pos;
   int fields = 1;
+  int last;
   int i;
 
-  if (!isalpha((unsigned char) line[0])) /* every scheme opens with a letter */
+  if (!isalpha((unsigned char) line[0]))
     return HTS_FALSE;
   for (i = 0; line[i] != ':'; i++) {
     if (!isalnum((unsigned char) line[i]) && line[i] != '+' && line[i] != '-' &&
@@ -2195,7 +2207,11 @@ static hts_boolean arcHasRecordShape(const char *line) {
   }
   if (line[i + 1] == '\0' || line[i + 1] == ARC_SP)
     return HTS_FALSE;
-  for (; line[i] != '\0'; i++) {
+  for (last = i; line[i] != '\0'; i++) {
+    if (line[i] != ARC_SP)
+      last = i;
+  }
+  for (i = 0; i < last; i++) {
     if (line[i] == ARC_SP)
       fields++;
   }
@@ -2205,67 +2221,70 @@ static hts_boolean arcHasRecordShape(const char *line) {
   return (pos != NULL && arcDigitField(pos) > 0) ? HTS_TRUE : HTS_FALSE;
 }
 
-/* A dated line is a record whatever its scheme, so a record this reader never
-   serves, such as the "dns:" ones Heritrix writes one of per host, still marks
-   where the record before it ends. */
+/* PT_LoadCache__Arc indexes a record on getArcLength() and a scheme it can
+   serve, so the scan below has to accept at least that much: a record this
+   reader will hand out under its own URL must never be invisible to it. The
+   shape arm adds the records it will not serve, such as the one "dns:" per host
+   Heritrix writes, which bound their neighbour all the same. */
 static hts_boolean arcIsRecordLine(const char *line) {
-  const char *pos;
-
-  if (!arcHasRecordShape(line))
-    return HTS_FALSE;
-  if (PT_CompatibleScheme(line))
+  if (PT_CompatibleScheme(line) && getArcLength(line) >= 0)
     return HTS_TRUE;
-  pos = getArcField(line, 2);
-  return (pos != NULL && arcDigitField(pos) == 14) ? HTS_TRUE : HTS_FALSE;
+  return arcHasRecordShape(line);
 }
 
-/* linput() drops these, so a line read raw must too or the two disagree. */
-static void arcDropLinputBytes(char *line) {
-  int i, j;
+/* Could this raw span open a record line? Every one names a scheme, so the
+   first field has to reach a ':' through scheme characters alone, and that
+   turns away almost every line of an archived page before it is copied. */
+static hts_boolean arcMayOpenRecord(const char *raw, size_t len) {
+  size_t i;
 
-  for (i = j = 0; line[i] != '\0'; i++) {
-    if (line[i] != 13 && line[i] != 9 && line[i] != 12)
-      line[j++] = line[i];
+  for (i = 0; i < len && arcDroppedByte(raw[i]); i++)
+    ;
+  if (i == len || !isalpha((unsigned char) raw[i]))
+    return HTS_FALSE;
+  for (; i < len; i++) {
+    if (raw[i] == ':')
+      return HTS_TRUE;
+    if (arcDroppedByte(raw[i]))
+      continue;
+    if (!isalnum((unsigned char) raw[i]) && raw[i] != '+' && raw[i] != '-' &&
+        raw[i] != '.')
+      return HTS_FALSE;
   }
-  line[j] = '\0';
+  return HTS_FALSE;
 }
 
-/* Two bytes turn away nearly every line of a page before it is parsed. */
-static hts_boolean arcScannedLineIsRecord(char *line, size_t len) {
-  while (len > 0 &&
-         (line[len - 1] == 13 || line[len - 1] == 9 || line[len - 1] == 12))
-    len--;
-  if (len == 0 || !isalpha((unsigned char) line[0]) ||
-      !isdigit((unsigned char) line[len - 1]))
-    return HTS_FALSE;
-  arcDropLinputBytes(line);
-  return arcIsRecordLine(line);
+/* Append what linput() would have kept of a raw span, to the same cap. */
+static size_t arcAppendLine(char *line, size_t len, const char *raw,
+                            size_t rawlen) {
+  size_t i;
+
+  for (i = 0; i < rawlen && len < (size_t) ARC_LINE_MAX; i++) {
+    if (!arcDroppedByte(raw[i]))
+      line[len++] = raw[i];
+  }
+  line[len] = '\0';
+  return len;
 }
 
-/* Whether a record starts where the file is left, one separator away. */
-static hts_boolean arcNextRecordFollows(PT_Index__Arc index) {
-  if (fgetc(index->file) != 0x0a)
-    return HTS_FALSE;
-  index->line[0] = '\0';
-  (void) linput(index->file, index->line, sizeof(index->line) - 1);
-  return arcIsRecordLine(index->line);
-}
-
-/* Whether a record starts anywhere in [from, to], the bytes the declared length
-   hands the reader. A line counts by where it STARTS, because an end landing
-   inside the next record's own line still serves the front of that line. */
+/* Reads the record's declared data from where the file already sits, and
+   answers whether a record starts inside it. A line counts by where it STARTS,
+   because a declared end landing inside the next record's own line still serves
+   the front of that line. Reading forward rather than seeking back is what
+   keeps an archive of small records from being read many times over: the walk
+   has to cross these bytes anyway. */
 static hts_boolean arcDataHoldsARecord(PT_Index__Arc index, long int from,
                                        long int to) {
   char buffer[32768];
-  char line[2048];
+  char line[ARC_LINE_MAX + 1];
   long int base = from; /* offset buffer[0] was read from */
-  long int lineStart = from;
   size_t lineLen = 0;
 
-  if (from > to || fseek(index->file, from, SEEK_SET) != 0)
-    return HTS_TRUE;
-  for (;;) {
-    const size_t got = fread(buffer, 1, sizeof(buffer), index->file);
+  while (base < to) {
+    const long int left = to - base;
+    size_t want =
+        (left < (long int) sizeof(buffer)) ? (size_t) left : sizeof(buffer);
+    const size_t got = fread(buffer, 1, want, index->file);
     size_t i = 0;
 
     while (i < got) {
@@ -2273,71 +2292,33 @@ static hts_boolean arcDataHoldsARecord(PT_Index__Arc index, long int from,
       const size_t chunk = (nl != NULL) ? (size_t) (nl - &buffer[i]) : got - i;
 
       if (lineLen == 0 && nl != NULL) {
-        /* the whole line is in the buffer, so test it where it lies */
-        *nl = '\0';
-        if (arcScannedLineIsRecord(&buffer[i], chunk))
-          return HTS_TRUE;
-        *nl = 0x0a;
-      } else {
-        if (lineLen < sizeof(line) - 1) {
-          size_t copy = sizeof(line) - 1 - lineLen;
-
-          if (copy > chunk)
-            copy = chunk;
-          memcpy(&line[lineLen], &buffer[i], copy);
-          lineLen += copy;
-        }
-        if (nl != NULL) {
-          line[lineLen] = '\0';
-          if (arcScannedLineIsRecord(line, lineLen))
+        /* the whole line is in the buffer, so weigh it before copying it out */
+        if (arcMayOpenRecord(&buffer[i], chunk)) {
+          (void) arcAppendLine(line, 0, &buffer[i], chunk);
+          if (arcIsRecordLine(line))
             return HTS_TRUE;
         }
+      } else {
+        lineLen = arcAppendLine(line, lineLen, &buffer[i], chunk);
+        if (nl != NULL && arcMayOpenRecord(line, lineLen) &&
+            arcIsRecordLine(line))
+          return HTS_TRUE;
       }
       i += chunk;
       if (nl == NULL)
         break;
       i++;
-      lineStart = base + (long int) i;
       lineLen = 0;
-      if (lineStart > to)
-        return HTS_FALSE;
     }
     base += (long int) got;
-    if (got < sizeof(buffer)) /* short read: end of file */
-      break;
-    /* nothing past the first sizeof(line) bytes can change the verdict */
-    if (base > to && lineLen == sizeof(line) - 1)
+    if (got < want) /* short read: end of file */
       break;
   }
-  line[lineLen] = '\0';
-  return arcScannedLineIsRecord(line, lineLen);
-}
-
-enum {
-  ARC_RECORD_CLEAN,  /* the declared data ends where the next record starts */
-  ARC_RECORD_GREEDY, /* it swallows a record, but the next one is reachable */
-  ARC_RECORD_BROKEN  /* nothing usable follows */
-};
-
-/* A record's declared data must end where the next record starts, or the reader
-   hands out the neighbour's bytes under this record's URL. A record following
-   the declared end proves nothing, because the length is the attacker's to pick
-   and any later record will do, so the data itself is asked instead. */
-static int arcRecordVerdict(PT_Index__Arc index, long int from) {
-  const long int to = ftell(index->file);
-  hts_boolean greedy, followed;
-
-  if (to < 0)
-    return ARC_RECORD_BROKEN;
-  greedy = arcDataHoldsARecord(index, from, to);
-  if (fseek(index->file, to, SEEK_SET) != 0)
-    return ARC_RECORD_BROKEN;
-  if (!greedy)
-    return ARC_RECORD_CLEAN;
-  followed = arcNextRecordFollows(index);
-  if (fseek(index->file, to, SEEK_SET) != 0)
-    return ARC_RECORD_BROKEN;
-  return followed ? ARC_RECORD_GREEDY : ARC_RECORD_BROKEN;
+  /* the last line of the data, which the separator rather than a newline ends
+   */
+  if (lineLen != 0 && arcMayOpenRecord(line, lineLen))
+    return arcIsRecordLine(line);
+  return HTS_FALSE;
 }
 
 int PT_LoadCache__Arc(PT_Index index_, const char *filename) {
@@ -2395,26 +2376,34 @@ int PT_LoadCache__Arc(PT_Index index_, const char *filename) {
               }
               if (*filenameIndex != 0) {
                 const long int dataStart = ftell(index->file);
-                int verdict;
+                long int dataEnd;
 
-                if (skipArcData(index->file, index->line) != 0) {
+                /* the declared length is untrusted, so it stands alone here */
+                if (dataStart < 0 || length > LONG_MAX - dataStart) {
                   fprintf(stderr,
                           "Corrupted cache data entry #%d (truncated file?), aborting read"
                           LF, (int) entries);
                   break;
                 }
-                verdict = arcRecordVerdict(index, dataStart);
-                if (verdict != ARC_RECORD_CLEAN) {
+                dataEnd = dataStart + length;
+                if (arcDataHoldsARecord(index, dataStart, dataEnd)) {
                   fprintf(stderr,
                           "Cache data entry #%d reaches into the next record,"
                           " skipped" LF,
                           (int) entries);
-                  /* the record is dropped, not the archive: a page holding a
-                     line of this shape is rare but real, and stopping here
-                     would cost every record left in the file */
-                  if (verdict == ARC_RECORD_BROKEN)
+                  /* the record is dropped, not the archive: the walk picks up
+                     at the declared end and judges what it finds there the way
+                     it judges every other record */
+                  if (fseek(index->file, dataEnd, SEEK_SET) != 0)
                     break;
                   continue;
+                }
+                if (fseek(index->file, dataEnd, SEEK_SET) != 0) {
+                  fprintf(stderr,
+                          "Corrupted cache data entry #%d (truncated file?), "
+                          "aborting read" LF,
+                          (int) entries);
+                  break;
                 }
                 /*fprintf(stdout, "adding %s [%d]\n", filenameIndex, (int)fpos); */
                 if (PT_CompatibleScheme(index->filenameIndexBuff)) {

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -2173,13 +2173,10 @@ static hts_boolean arcIsRecordLine(const char *line) {
   return PT_CompatibleScheme(line) && getArcLength(line) >= 0;
 }
 
-/* Nothing follows the last record, so the end of the file separates it too. */
-static hts_boolean arcNextRecordStartsHere(PT_Index__Arc index) {
-  const int c = fgetc(index->file);
-
-  if (c == EOF)
-    return feof(index->file) ? HTS_TRUE : HTS_FALSE;
-  if (c != 0x0a)
+/* The end of the file is not an answer here, because aligning a greedy length
+   to it is how a record hides from this test. Its own data is asked instead. */
+static hts_boolean arcNextRecordFollows(PT_Index__Arc index) {
+  if (fgetc(index->file) != 0x0a)
     return HTS_FALSE;
   index->line[0] = '\0';
   (void) linput(index->file, index->line, sizeof(index->line) - 1);
@@ -2211,8 +2208,7 @@ static hts_boolean arcRecordEndsCleanly(PT_Index__Arc index, long int from) {
 
   if (to < 0)
     return HTS_FALSE;
-  clean =
-      arcNextRecordStartsHere(index) || !arcDataHoldsARecord(index, from, to);
+  clean = arcNextRecordFollows(index) || !arcDataHoldsARecord(index, from, to);
   return (fseek(index->file, to, SEEK_SET) == 0) ? clean : HTS_FALSE;
 }
 

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -2175,9 +2175,11 @@ static hts_boolean arcPastRecordEnd(FILE *file, long int end) {
    the same long line differently. */
 #define ARC_LINE_MAX ((int) sizeof(((PT_Index__Arc) NULL)->line) - 2)
 
-/* Bytes linput() never returns, wherever they sit on the line. */
+/* Bytes this reader's own linput(), the one in proxytrack.h rather than the one
+   in htslib.c, never returns wherever they sit on the line. NUL is among them,
+   so a record line carrying one is indexed and served all the same. */
 static hts_boolean arcDroppedByte(char c) {
-  return (c == 9 || c == 12 || c == 13) ? HTS_TRUE : HTS_FALSE;
+  return (c == 0 || c == 9 || c == 12 || c == 13) ? HTS_TRUE : HTS_FALSE;
 }
 
 /* Length of the digit run filling the field at pos, or -1 for anything else. */

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -2101,22 +2101,6 @@ static int skipArcData(FILE * file, const char *line) {
   return -1;
 }
 
-/* A record's declared data must end where the next record's separator sits, or
-   the reader hands out the neighbour's bytes under this record's URL. */
-static hts_boolean atArcRecordBoundary(FILE *file) {
-  const long int pos = ftell(file);
-  int c;
-
-  if (pos < 0)
-    return HTS_FALSE;
-  c = fgetc(file);
-  if (fseek(file, pos, SEEK_SET) != 0)
-    return HTS_FALSE;
-  /* EOF closes the last record, and a length past it is the truncated archive
-     the read-time bound already refuses */
-  return (c == 0x0a || c == EOF) ? HTS_TRUE : HTS_FALSE;
-}
-
 static int getDigit(const char digit) {
   return (int) (digit - '0');
 }
@@ -2181,6 +2165,57 @@ static int PT_CompatibleScheme(const char *url) {
           || str_begins(url, "file:"));
 }
 
+static hts_boolean arcPastRecordEnd(FILE *file, long int end) {
+  return (end >= 0 && ftell(file) > end) ? HTS_TRUE : HTS_FALSE;
+}
+
+static hts_boolean arcIsRecordLine(const char *line) {
+  return PT_CompatibleScheme(line) && getArcLength(line) >= 0;
+}
+
+/* Nothing follows the last record, so the end of the file separates it too. */
+static hts_boolean arcNextRecordStartsHere(PT_Index__Arc index) {
+  const int c = fgetc(index->file);
+
+  if (c == EOF)
+    return feof(index->file) ? HTS_TRUE : HTS_FALSE;
+  if (c != 0x0a)
+    return HTS_FALSE;
+  index->line[0] = '\0';
+  (void) linput(index->file, index->line, sizeof(index->line) - 1);
+  return arcIsRecordLine(index->line);
+}
+
+/* Only a record inside a record's own data proves the declared length lied.
+   Junk after the last one makes an archive untidy, not dishonest. */
+static hts_boolean arcDataHoldsARecord(PT_Index__Arc index, long int from,
+                                       long int to) {
+  if (fseek(index->file, from, SEEK_SET) != 0)
+    return HTS_TRUE;
+  while (ftell(index->file) < to) {
+    index->line[0] = '\0';
+    (void) linput(index->file, index->line, sizeof(index->line) - 1);
+    if (feof(index->file))
+      break;
+    if (ftell(index->file) <= to && arcIsRecordLine(index->line))
+      return HTS_TRUE;
+  }
+  return HTS_FALSE;
+}
+
+/* A record's declared data must end where the next record starts, or the reader
+   hands out the neighbour's bytes under this record's URL. */
+static hts_boolean arcRecordEndsCleanly(PT_Index__Arc index, long int from) {
+  const long int to = ftell(index->file);
+  hts_boolean clean;
+
+  if (to < 0)
+    return HTS_FALSE;
+  clean =
+      arcNextRecordStartsHere(index) || !arcDataHoldsARecord(index, from, to);
+  return (fseek(index->file, to, SEEK_SET) == 0) ? clean : HTS_FALSE;
+}
+
 int PT_LoadCache__Arc(PT_Index index_, const char *filename) {
   if (index_ != NULL && filename != NULL) {
     PT_Index__Arc index = &index_->slots.formatArc;
@@ -2235,8 +2270,10 @@ int PT_LoadCache__Arc(PT_Index index_, const char *filename) {
                 filenameIndex += 7;
               }
               if (*filenameIndex != 0) {
+                const long int dataStart = ftell(index->file);
+
                 if (skipArcData(index->file, index->line) != 0 ||
-                    !atArcRecordBoundary(index->file)) {
+                    !arcRecordEndsCleanly(index, dataStart)) {
                   fprintf(stderr,
                           "Corrupted cache data entry #%d (truncated file?), aborting read"
                           LF, (int) entries);
@@ -2330,11 +2367,14 @@ static PT_Element PT_ReadCache__Arc_u(PT_Index index_, const char *url,
       if (skipArcNl(index->file) == 0 && readArcURLRecord(index) == 0) {
         long int fposMeta = ftell(index->file);
         int dataLength = getArcLength(index->line);
+        /* a line reaching past this belongs to the record stored after it */
+        const long int fposEnd = dataLength >= 0 ? fposMeta + dataLength : -1;
         const char *pos;
 
         /* Read HTTP headers */
         /* HTTP/1.1 404 Not Found */
-        if (linput(index->file, index->line, sizeof(index->line) - 1)) {
+        if (linput(index->file, index->line, sizeof(index->line) - 1) &&
+            !arcPastRecordEnd(index->file, fposEnd)) {
           if ((pos = getArcField(index->line, 1)) != NULL) {
             if (sscanf(pos, "%d", &r->statuscode) != 1) {
               r->statuscode = STATUSCODE_INVALID;
@@ -2349,6 +2389,8 @@ static PT_Element PT_ReadCache__Arc_u(PT_Index index_, const char *url,
             char *const line = index->line;
             char *value = strchr(line, ':');
 
+            if (arcPastRecordEnd(index->file, fposEnd))
+              break;
             if (value != NULL) {
               *value = '\0';
               for(value++; *value == ' ' || *value == '\t'; value++) ;

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -2169,12 +2169,80 @@ static hts_boolean arcPastRecordEnd(FILE *file, long int end) {
   return (end >= 0 && ftell(file) > end) ? HTS_TRUE : HTS_FALSE;
 }
 
-static hts_boolean arcIsRecordLine(const char *line) {
-  return PT_CompatibleScheme(line) && getArcLength(line) >= 0;
+/* Length of the digit run filling the field at pos, or -1 for anything else. */
+static int arcDigitField(const char *pos) {
+  int i;
+
+  for (i = 0; pos[i] >= '0' && pos[i] <= '9'; i++)
+    ;
+  return (pos[i] == '\0' || pos[i] == ARC_SP) ? i : -1;
 }
 
-/* The end of the file is not an answer here, because aligning a greedy length
-   to it is how a record hides from this test. Its own data is asked instead. */
+/* A scheme, an address, a date, a MIME type and a length, in five fields
+   (arc 1.0) or ten (arc 1.1). The count and the trailing length are what tell a
+   record line from a sentence quoting a URL. */
+static hts_boolean arcHasRecordShape(const char *line) {
+  const char *pos;
+  int fields = 1;
+  int i;
+
+  if (!isalpha((unsigned char) line[0])) /* every scheme opens with a letter */
+    return HTS_FALSE;
+  for (i = 0; line[i] != ':'; i++) {
+    if (!isalnum((unsigned char) line[i]) && line[i] != '+' && line[i] != '-' &&
+        line[i] != '.')
+      return HTS_FALSE;
+  }
+  if (line[i + 1] == '\0' || line[i + 1] == ARC_SP)
+    return HTS_FALSE;
+  for (; line[i] != '\0'; i++) {
+    if (line[i] == ARC_SP)
+      fields++;
+  }
+  if (fields != 5 && fields != 10)
+    return HTS_FALSE;
+  pos = getArcField(line, fields - 1);
+  return (pos != NULL && arcDigitField(pos) > 0) ? HTS_TRUE : HTS_FALSE;
+}
+
+/* A dated line is a record whatever its scheme, so a record this reader never
+   serves, such as the "dns:" ones Heritrix writes one of per host, still marks
+   where the record before it ends. */
+static hts_boolean arcIsRecordLine(const char *line) {
+  const char *pos;
+
+  if (!arcHasRecordShape(line))
+    return HTS_FALSE;
+  if (PT_CompatibleScheme(line))
+    return HTS_TRUE;
+  pos = getArcField(line, 2);
+  return (pos != NULL && arcDigitField(pos) == 14) ? HTS_TRUE : HTS_FALSE;
+}
+
+/* linput() drops these, so a line read raw must too or the two disagree. */
+static void arcDropLinputBytes(char *line) {
+  int i, j;
+
+  for (i = j = 0; line[i] != '\0'; i++) {
+    if (line[i] != 13 && line[i] != 9 && line[i] != 12)
+      line[j++] = line[i];
+  }
+  line[j] = '\0';
+}
+
+/* Two bytes turn away nearly every line of a page before it is parsed. */
+static hts_boolean arcScannedLineIsRecord(char *line, size_t len) {
+  while (len > 0 &&
+         (line[len - 1] == 13 || line[len - 1] == 9 || line[len - 1] == 12))
+    len--;
+  if (len == 0 || !isalpha((unsigned char) line[0]) ||
+      !isdigit((unsigned char) line[len - 1]))
+    return HTS_FALSE;
+  arcDropLinputBytes(line);
+  return arcIsRecordLine(line);
+}
+
+/* Whether a record starts where the file is left, one separator away. */
 static hts_boolean arcNextRecordFollows(PT_Index__Arc index) {
   if (fgetc(index->file) != 0x0a)
     return HTS_FALSE;
@@ -2183,33 +2251,93 @@ static hts_boolean arcNextRecordFollows(PT_Index__Arc index) {
   return arcIsRecordLine(index->line);
 }
 
-/* Only a record inside a record's own data proves the declared length lied.
-   Junk after the last one makes an archive untidy, not dishonest. */
+/* Whether a record starts anywhere in [from, to], the bytes the declared length
+   hands the reader. A line counts by where it STARTS, because an end landing
+   inside the next record's own line still serves the front of that line. */
 static hts_boolean arcDataHoldsARecord(PT_Index__Arc index, long int from,
                                        long int to) {
-  if (fseek(index->file, from, SEEK_SET) != 0)
+  char buffer[32768];
+  char line[2048];
+  long int base = from; /* offset buffer[0] was read from */
+  long int lineStart = from;
+  size_t lineLen = 0;
+
+  if (from > to || fseek(index->file, from, SEEK_SET) != 0)
     return HTS_TRUE;
-  while (ftell(index->file) < to) {
-    index->line[0] = '\0';
-    (void) linput(index->file, index->line, sizeof(index->line) - 1);
-    if (feof(index->file))
+  for (;;) {
+    const size_t got = fread(buffer, 1, sizeof(buffer), index->file);
+    size_t i = 0;
+
+    while (i < got) {
+      char *const nl = (char *) memchr(&buffer[i], 0x0a, got - i);
+      const size_t chunk = (nl != NULL) ? (size_t) (nl - &buffer[i]) : got - i;
+
+      if (lineLen == 0 && nl != NULL) {
+        /* the whole line is in the buffer, so test it where it lies */
+        *nl = '\0';
+        if (arcScannedLineIsRecord(&buffer[i], chunk))
+          return HTS_TRUE;
+        *nl = 0x0a;
+      } else {
+        if (lineLen < sizeof(line) - 1) {
+          size_t copy = sizeof(line) - 1 - lineLen;
+
+          if (copy > chunk)
+            copy = chunk;
+          memcpy(&line[lineLen], &buffer[i], copy);
+          lineLen += copy;
+        }
+        if (nl != NULL) {
+          line[lineLen] = '\0';
+          if (arcScannedLineIsRecord(line, lineLen))
+            return HTS_TRUE;
+        }
+      }
+      i += chunk;
+      if (nl == NULL)
+        break;
+      i++;
+      lineStart = base + (long int) i;
+      lineLen = 0;
+      if (lineStart > to)
+        return HTS_FALSE;
+    }
+    base += (long int) got;
+    if (got < sizeof(buffer)) /* short read: end of file */
       break;
-    if (ftell(index->file) <= to && arcIsRecordLine(index->line))
-      return HTS_TRUE;
+    /* nothing past the first sizeof(line) bytes can change the verdict */
+    if (base > to && lineLen == sizeof(line) - 1)
+      break;
   }
-  return HTS_FALSE;
+  line[lineLen] = '\0';
+  return arcScannedLineIsRecord(line, lineLen);
 }
 
+enum {
+  ARC_RECORD_CLEAN,  /* the declared data ends where the next record starts */
+  ARC_RECORD_GREEDY, /* it swallows a record, but the next one is reachable */
+  ARC_RECORD_BROKEN  /* nothing usable follows */
+};
+
 /* A record's declared data must end where the next record starts, or the reader
-   hands out the neighbour's bytes under this record's URL. */
-static hts_boolean arcRecordEndsCleanly(PT_Index__Arc index, long int from) {
+   hands out the neighbour's bytes under this record's URL. A record following
+   the declared end proves nothing, because the length is the attacker's to pick
+   and any later record will do, so the data itself is asked instead. */
+static int arcRecordVerdict(PT_Index__Arc index, long int from) {
   const long int to = ftell(index->file);
-  hts_boolean clean;
+  hts_boolean greedy, followed;
 
   if (to < 0)
-    return HTS_FALSE;
-  clean = arcNextRecordFollows(index) || !arcDataHoldsARecord(index, from, to);
-  return (fseek(index->file, to, SEEK_SET) == 0) ? clean : HTS_FALSE;
+    return ARC_RECORD_BROKEN;
+  greedy = arcDataHoldsARecord(index, from, to);
+  if (fseek(index->file, to, SEEK_SET) != 0)
+    return ARC_RECORD_BROKEN;
+  if (!greedy)
+    return ARC_RECORD_CLEAN;
+  followed = arcNextRecordFollows(index);
+  if (fseek(index->file, to, SEEK_SET) != 0)
+    return ARC_RECORD_BROKEN;
+  return followed ? ARC_RECORD_GREEDY : ARC_RECORD_BROKEN;
 }
 
 int PT_LoadCache__Arc(PT_Index index_, const char *filename) {
@@ -2267,13 +2395,26 @@ int PT_LoadCache__Arc(PT_Index index_, const char *filename) {
               }
               if (*filenameIndex != 0) {
                 const long int dataStart = ftell(index->file);
+                int verdict;
 
-                if (skipArcData(index->file, index->line) != 0 ||
-                    !arcRecordEndsCleanly(index, dataStart)) {
+                if (skipArcData(index->file, index->line) != 0) {
                   fprintf(stderr,
                           "Corrupted cache data entry #%d (truncated file?), aborting read"
                           LF, (int) entries);
                   break;
+                }
+                verdict = arcRecordVerdict(index, dataStart);
+                if (verdict != ARC_RECORD_CLEAN) {
+                  fprintf(stderr,
+                          "Cache data entry #%d reaches into the next record,"
+                          " skipped" LF,
+                          (int) entries);
+                  /* the record is dropped, not the archive: a page holding a
+                     line of this shape is rare but real, and stopping here
+                     would cost every record left in the file */
+                  if (verdict == ARC_RECORD_BROKEN)
+                    break;
+                  continue;
                 }
                 /*fprintf(stdout, "adding %s [%d]\n", filenameIndex, (int)fpos); */
                 if (PT_CompatibleScheme(index->filenameIndexBuff)) {

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -2103,19 +2103,18 @@ static int skipArcData(FILE * file, const char *line) {
 
 /* A record's declared data must end where the next record's separator sits, or
    the reader hands out the neighbour's bytes under this record's URL. */
-static hts_boolean atArcRecordBoundary(FILE *file, long int fileSize) {
+static hts_boolean atArcRecordBoundary(FILE *file) {
   const long int pos = ftell(file);
   int c;
 
   if (pos < 0)
     return HTS_FALSE;
-  /* past the end is the truncated archive the read-time bound refuses */
-  if (pos >= fileSize)
-    return HTS_TRUE;
   c = fgetc(file);
   if (fseek(file, pos, SEEK_SET) != 0)
     return HTS_FALSE;
-  return c == 0x0a ? HTS_TRUE : HTS_FALSE;
+  /* EOF closes the last record, and a length past it is the truncated archive
+     the read-time bound already refuses */
+  return (c == 0x0a || c == EOF) ? HTS_TRUE : HTS_FALSE;
 }
 
 static int getDigit(const char digit) {
@@ -2237,7 +2236,7 @@ int PT_LoadCache__Arc(PT_Index index_, const char *filename) {
               }
               if (*filenameIndex != 0) {
                 if (skipArcData(index->file, index->line) != 0 ||
-                    !atArcRecordBoundary(index->file, index->fileSize)) {
+                    !atArcRecordBoundary(index->file)) {
                   fprintf(stderr,
                           "Corrupted cache data entry #%d (truncated file?), aborting read"
                           LF, (int) entries);

--- a/tests/414_local-proxytrack-arc-crossrecord.test
+++ b/tests/414_local-proxytrack-arc-crossrecord.test
@@ -32,12 +32,10 @@ http_head() { # http_head CONTENT_LENGTH
 }
 
 # Three records: one the greedy record cannot reach, the greedy one, and the
-# victim page whose bytes must never leave the greedy record's URL. HOST names
-# the archive, so one proxytrack serves them all without a key clash. DECLARED
-# is the length the greedy record announces, but it stores $GREEDY_BODY whatever
-# it says, so an honest archive passes DECLARED=${#GREEDY_BODY}. PAD is the byte
-# the victim page is padded with, which is the byte a declared length lands on,
-# so each archive lands on a different class of byte.
+# victim page whose bytes must never leave the greedy record's URL. DECLARED is
+# what the greedy record announces, but it stores $GREEDY_BODY whatever it says,
+# and PAD is what the victim page is padded with, so each archive's declared
+# length lands on a different class of byte. HOST keys the archive apart.
 craft() { # craft OUT HOST DECLARED PAD
     local out=$1 host=$2 declared=$3 pad=$4
 
@@ -69,20 +67,20 @@ craft() { # craft OUT HOST DECLARED PAD
 }
 
 craft "$dir/honest.arc" honest "${#GREEDY_BODY}" ' '
-# every byte class a one-byte boundary test could mistake for a separator, the
-# newline most of all: a text page is full of them
+# every byte class a one-byte boundary test could take for a separator, and the
+# newline above all, because a text page is full of them
 craft "$dir/space.arc" space "$GREEDY_DECLARED" ' '
 craft "$dir/digit.arc" digit "$GREEDY_DECLARED" 0
 craft "$dir/newline.arc" newline "$GREEDY_DECLARED" $'\n'
 craft "$dir/cr.arc" cr "$GREEDY_DECLARED" $'\r'
 
-# an honest archive is still honest with junk stuck on the end, and refusing its
-# last record would cost a page the reader used to serve
+# junk on the end leaves an archive honest, so refusing its last record would
+# cost a page for nothing
 cp "$dir/honest.arc" "$dir/trailer.arc"
 printf 'not a record\0\0\0' >>"$dir/trailer.arc"
 
-# The body the archive $1 stores for the record whose URL is $2, walking the
-# record chain rather than trusting a length twice.
+# Walks the record chain to return the body archive $1 stores for URL $2, rather
+# than trusting a declared length twice.
 body_of() { # body_of ARC URL
     "$python" - "$1" "$2" <<'EOF'
 import sys
@@ -119,7 +117,7 @@ convert() { # convert IN OUT
         fail_dump "proxytrack died converting $1" "$dir/convert.log"
 }
 
-# The control the rest rests on: an honest chain keeps the records apart, so all
+# The control the rest rests on. An honest chain keeps the records apart, so all
 # three markers exist in the fixture and each stays under its own URL.
 convert "$dir/honest.arc" "$dir/honest-out.arc"
 stored "$dir/honest-out.arc" http://honest/kept.html "$dir/out.kept"

--- a/tests/414_local-proxytrack-arc-crossrecord.test
+++ b/tests/414_local-proxytrack-arc-crossrecord.test
@@ -205,14 +205,15 @@ def head(b):
     return b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: %d\r\n\r\n" % len(b)
 
 
-def archive(host, victim_line, pad=b" " * 64, at_eof=False):
+def archive(host, victim_line, pad=b" " * 64, at_eof=False, vdata=None):
     kept = b"KEPTPAGE"
     greedy = b"GREEDYPAGE"
     victim = b"VICTIM-" + host + b"\n" + b"x" * 32
     # no Content-Length on the greedy record, so its declared length is the only
     # bound the read has and the whole lie is served
     gdata = b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n" + greedy
-    vdata = head(victim) + victim
+    if vdata is None:
+        vdata = head(victim) + victim
     line = victim_line % len(vdata)
     tail = pad + b"\n" + (line.rstrip(b"\n") if at_eof else line + vdata)
     declared = len(gdata) + len(tail)
@@ -255,6 +256,23 @@ cases = {
     # five fields on a scheme the reader never serves, so only the shape sees it
     b"gopher": archive(b"gopher", b"gopher://gopher/victim.html 0.0.0.0 " + date
                        + b" text/html %d\n"),
+    # a scheme whose second character is a digit, which a scheme scan starting
+    # one byte off never finishes
+    b"digitscheme": archive(b"digitscheme", b"x2y:digitscheme/victim.html 0.0.0.0 "
+                            + date + b" text/html %d\n"),
+    # a length of one digit, and one carrying a 9: every other fixture here
+    # declares several digits and not one of them is a 9
+    b"len9": archive(b"len9", b"dns:len9/victim.html 0.0.0.0 " + date
+                     + b" text/html %d\n", vdata=b"VICTIMxyz"),
+    b"len19": archive(b"len19", b"dns:len19/victim.html 0.0.0.0 " + date
+                      + b" text/html %d\n", vdata=b"VICTIM-len19-bytes"),
+    # a byte linput() drops sitting INSIDE the scheme, not in front of the line
+    b"schemecr": archive(b"schemecr", b"htt\rp://schemecr/victim.html 0.0.0.0 "
+                         + date + b" text/html %d\n"),
+    # and a NUL, which this reader's own linput() drops like a TAB, so a record
+    # line carrying one is indexed and served all the same
+    b"schemenul": archive(b"schemenul", b"htt\x00p://schemenul/victim.html 0.0.0.0 "
+                          + date + b" text/html %d\n"),
     # a record line near the longest linput() will return, which a scan reading
     # fewer characters than linput() would cut short of its length field
     b"longline": archive(b"longline", b"http://longline/" + b"p" * 1960
@@ -265,6 +283,16 @@ cases = {
 }
 # and one whose record line straddles the scan's buffer
 probe = archive(b"straddle", v10 % b"straddle" + b"\n")
+# exactly as long as linput() will return, so a scan reading one character less
+# loses the length field and stops seeing the line
+LINPUT_MAX = 2046
+_vdata = b"VICTIMxyz"
+_head = b"dns:longmax/"
+_tail = b"/victim.html 0.0.0.0 " + date + b" text/html %d\n"
+_pad = LINPUT_MAX - len(_head) - len(_tail % len(_vdata)) + 1
+cases[b"longmax"] = archive(b"longmax", _head + b"q" * _pad + _tail, vdata=_vdata)
+assert len((_head + b"q" * _pad + _tail % len(_vdata)).rstrip(b"\n")) == LINPUT_MAX
+
 cases[b"strdrop"] = archive(
     b"strdrop", b"http://strdrop/victim.html" + b"\r" * 2100
     + b" 0.0.0.0 " + date + b" text/html 200 - - 0 t.arc %d\n")
@@ -395,7 +423,8 @@ grep -qaF VICTIM-honest "$dir/out.trailer" ||
 
 for class in space digit newline cr eof padline urlend urlmid later dns \
     crlf arc10 undated straddle eofline tab crb ff f3 f6 lenx lenplus \
-    strdrop gopher longline; do
+    strdrop gopher longline digitscheme len9 len19 schemecr schemenul \
+    longmax; do
     convert "$dir/$class.arc" "$dir/$class-out.arc"
     # the record before the greedy one, so an implementation that refuses the
     # whole archive cannot pass the assertion below

--- a/tests/414_local-proxytrack-arc-crossrecord.test
+++ b/tests/414_local-proxytrack-arc-crossrecord.test
@@ -181,10 +181,7 @@ chain "$dir/quoting.arc" "$dir/quoting.body"
     printf 'http://not-a-record\n'
     printf 'three fields 5\n'
     printf 'http://neg a b c d e f g -5\n'
-    printf 'dns:q.example 1.2.3.4 2025 text/dns 4\n'
-    printf 'http://q/r 1.2.3.4 %s text/html 200 4\n' "$ARC_DATE"
     printf 'http://q/r 1.2.3.4 %s text/html v4\n' "$ARC_DATE"
-    printf 'http://q/r 1.2.3.4 %s text/html 4x4\n' "$ARC_DATE"
     printf 'x: 1.2.3.4 %s text/html 4\n' "$ARC_DATE"
     printf 'a/b:c 1.2.3.4 %s text/html 4\n' "$ARC_DATE"
     printf 'NEARMISS\n'
@@ -235,17 +232,42 @@ v10 = b"http://%s/victim.html 0.0.0.0 " + date + b" text/html 200 - - 0 t.arc %%
 cases = {
     # a writer ending its record lines with CRLF: linput() drops the CR
     b"crlf": archive(b"crlf", (v10 % b"crlf") + b"\r\n"),
+    # one byte linput() drops, in front of an ordinary record line: a scan that
+    # weighs the raw bytes reads the line as page text and hands it out
+    b"tab": archive(b"tab", b"\t" + (v10 % b"tab") + b"\n"),
+    b"crb": archive(b"crb", b"\r" + (v10 % b"crb") + b"\n"),
+    b"ff": archive(b"ff", b"\x0c" + (v10 % b"ff") + b"\n"),
+    # the shapes PT_LoadCache__Arc indexes and serves: three fields, and a
+    # length sscanf() takes but a digit run does not
+    b"f3": archive(b"f3", b"http://f3/victim.html 0.0.0.0 %d\n"),
+    b"f6": archive(b"f6", b"http://f6/victim.html 0.0.0.0 " + date
+                   + b" text/html 200 %d\n"),
+    b"lenx": archive(b"lenx", b"http://lenx/victim.html 0.0.0.0 " + date
+                     + b" text/html %dx\n"),
+    b"lenplus": archive(b"lenplus", b"http://lenplus/victim.html 0.0.0.0 " + date
+                        + b" text/html 200 - - 0 t.arc +%d\n"),
     # arc 1.0, five fields
     b"arc10": archive(b"arc10", b"http://arc10/victim.html 1.2.3.4 " + date
                       + b" text/html %d\n"),
     # a date this reader cannot use, on a scheme it serves
     b"undated": archive(b"undated", b"http://undated/victim.html 1.2.3.4 20250101"
                         b" text/html 200 - - 0 t.arc %d\n"),
+    # five fields on a scheme the reader never serves, so only the shape sees it
+    b"gopher": archive(b"gopher", b"gopher://gopher/victim.html 0.0.0.0 " + date
+                       + b" text/html %d\n"),
+    # a record line near the longest linput() will return, which a scan reading
+    # fewer characters than linput() would cut short of its length field
+    b"longline": archive(b"longline", b"http://longline/" + b"p" * 1960
+                         + b"/victim.html 0.0.0.0 " + date
+                         + b" text/html 200 - - 0 t.arc %d\n"),
     # a record line closing the file, which has no newline of its own
     b"eofline": archive(b"eofline", v10 % b"eofline" + b"\n", at_eof=True),
 }
 # and one whose record line straddles the scan's buffer
 probe = archive(b"straddle", v10 % b"straddle" + b"\n")
+cases[b"strdrop"] = archive(
+    b"strdrop", b"http://strdrop/victim.html" + b"\r" * 2100
+    + b" 0.0.0.0 " + date + b" text/html 200 - - 0 t.arc %d\n")
 lead = probe.index(b"\nhttp://straddle/greedy.html")
 gdata = probe.index(b"\n", lead + 1) + 1
 victim = probe.index(b"http://straddle/victim.html", gdata)
@@ -254,6 +276,41 @@ cases[b"straddle"] = archive(
     pad=b" " * (64 + SCAN_BUFFER - 8 - (victim - gdata)))
 for host, data in cases.items():
     open("%s/%s.arc" % (d, host.decode()), "wb").write(data)
+
+
+# Refusing the greedy record leaves the walk at its declared end, where the
+# record line can be anything the loader accepts. None of these may cost the
+# records stored after it.
+def resync(host, midline):
+    kept = b"KEPTPAGE"
+    greedy = b"GREEDYPAGE"
+    victim = b"VICTIM-" + host
+    gdata = b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n" + greedy
+    vdata = head(victim) + victim
+    vline = b"http://%s/victim.html 0.0.0.0 %s text/html 200 - - 0 t.arc %d\n" % (
+        host, date, len(vdata))
+    mid = b"MIDD"
+    tail = head(b"TAILPAGE") + b"TAILPAGE"
+    out = b"filedesc://t.arc 0.0.0.0 " + date + b" text/plain 200 - - 0 t.arc 9\n"
+    out += b"2 0 test\n\n\n"
+    out += b"http://%s/greedy.html 0.0.0.0 %s text/html 200 - - 0 t.arc %d\n" % (
+        host, date, len(gdata) + 1 + len(vline) + len(vdata))
+    out += gdata + b"\n" + vline + vdata
+    out += b"\n" + (midline % len(mid)) + mid
+    out += b"\n" + b"http://%s/tail.html 0.0.0.0 %s text/html 200 - - 0 t.arc %d\n" % (
+        host, date, len(tail)) + tail
+    return out
+
+
+for host, midline in (
+    # a trailing space, which turns five fields into six for anything counting
+    (b"trailsp", b"http://trailsp/m.html 0.0.0.0 " + date + b" text/html %d \n"),
+    # three fields, which no shape test can take and the loader indexes anyway
+    (b"mid3", b"http://mid3/m.html 0.0.0.0 %d\n"),
+    # and a scheme this reader never serves, dated as the format asks
+    (b"midgopher", b"gopher://midgopher/m 0.0.0.0 " + date + b" text/html %d\n"),
+):
+    open("%s/%s.arc" % (d, host.decode()), "wb").write(resync(host, midline))
 
 
 # Two honest-looking records the loader has no reason to refuse, where the bound
@@ -337,7 +394,8 @@ grep -qaF VICTIM-honest "$dir/out.trailer" ||
     fail "an archive with junk after its last record lost that record"
 
 for class in space digit newline cr eof padline urlend urlmid later dns \
-    crlf arc10 undated straddle eofline; do
+    crlf arc10 undated straddle eofline tab crb ff f3 f6 lenx lenplus \
+    strdrop gopher longline; do
     convert "$dir/$class.arc" "$dir/$class-out.arc"
     # the record before the greedy one, so an implementation that refuses the
     # whole archive cannot pass the assertion below
@@ -369,6 +427,18 @@ for page in page1 page2; do
     stored "$dir/quoting-out.arc" "http://chain/$page.html" "$dir/quoting.$page"
     grep -qaF CHAIN- "$dir/quoting.$page" ||
         fail "a page quoting a record line cost the archive $page"
+done
+
+for class in trailsp mid3 midgopher; do
+    convert "$dir/$class.arc" "$dir/$class-out.arc"
+    stored "$dir/$class-out.arc" "http://$class/tail.html" "$dir/$class.tail"
+    grep -qaF TAILPAGE "$dir/$class.tail" ||
+        fail "refusing one record cost the archive the records after it"
+    if body_of "$dir/$class-out.arc" "http://$class/greedy.html" \
+        >"$dir/$class.greedy" 2>/dev/null; then
+        grep -qaF "VICTIM-$class" "$dir/$class.greedy" &&
+            fail_dump "the greedy record carried its neighbour" "$dir/$class.greedy"
+    fi
 done
 
 for class in overlong shorthdr; do

--- a/tests/414_local-proxytrack-arc-crossrecord.test
+++ b/tests/414_local-proxytrack-arc-crossrecord.test
@@ -1,8 +1,6 @@
 #!/bin/bash
 #
-# An .arc record's declared length is what bounds the read that fills its body,
-# and the file size is the only other bound. A length reaching past the record's
-# own bytes therefore serves the following record's page under this record's URL.
+# A record's declared length must not reach past its own bytes into the next.
 
 set -euo pipefail
 
@@ -23,35 +21,65 @@ cleanup() {
 }
 cleanup_push cleanup
 
-FIRST_BODY=FIRSTPAGE_00000000
-NEXT_PAD=4988
+KEPT_BODY=KEPTPAGE
+GREEDY_BODY=GREEDYPAGE_0000000
+VICTIM_PAD=4988
+# reaches well past $GREEDY_BODY, into the victim page's padding
+GREEDY_DECLARED=4096
 
-# HOST names the archive, so one proxytrack can serve both without a key clash.
-# DECLARED is what the first record announces; it stores $FIRST_BODY whatever it
-# says, so an honest archive passes DECLARED=${#FIRST_BODY}.
-craft() { # craft OUT HOST DECLARED
-    local out=$1 host=$2 declared=$3 h1=$dir/h1 b1=$dir/b1 h2=$dir/h2 b2=$dir/b2
+http_head() { # http_head CONTENT_LENGTH
+    printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: %d\r\n\r\n' "$1"
+}
 
-    printf '%s' "$FIRST_BODY" >"$b1"
-    # padded with spaces, so the byte the overlapping length lands on is the
-    # one a boundary test loose enough to take whitespace would accept
-    printf 'NEXT-%s%*s' "$host" "$NEXT_PAD" '' >"$b2"
-    printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: %d\r\n\r\n' \
-        "$declared" >"$h1"
-    printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: %d\r\n\r\n' \
-        "$(wc -c <"$b2")" >"$h2"
+# Three records: one the greedy record cannot reach, the greedy one, and the
+# victim page whose bytes must never leave the greedy record's URL. HOST names
+# the archive, so one proxytrack serves them all without a key clash. DECLARED
+# is the length the greedy record announces, but it stores $GREEDY_BODY whatever
+# it says, so an honest archive passes DECLARED=${#GREEDY_BODY}. PAD is the byte
+# the victim page is padded with, which is the byte a declared length lands on,
+# so each archive lands on a different class of byte.
+craft() { # craft OUT HOST DECLARED PAD
+    local out=$1 host=$2 declared=$3 pad=$4
+
+    printf '%s' "$KEPT_BODY" >"$dir/kept.body"
+    http_head "${#KEPT_BODY}" >"$dir/kept.head"
+    printf '%s' "$GREEDY_BODY" >"$dir/greedy.body"
+    http_head "$declared" >"$dir/greedy.head"
+    {
+        printf 'VICTIM-%s\n' "$host"
+        # a page may hold a line that looks like half of a record header, and
+        # neither half alone may cost it its place in the archive
+        printf 'http://not-a-record\n'
+        printf 'three fields 5\n'
+        printf '%*s' "$VICTIM_PAD" '' | tr ' ' "$pad"
+    } >"$dir/victim.body"
+    http_head "$(wc -c <"$dir/victim.body")" >"$dir/victim.head"
     {
         arc_filedesc
-        printf 'http://%s/first.html 0.0.0.0 %s text/html 200 - - 0 t.arc %d\n' \
-            "$host" "$ARC_DATE" "$(($(wc -c <"$h1") + declared))"
-        cat "$h1" "$b1"
+        arc_record "http://$host/kept.html" text/html 200 \
+            "$dir/kept.head" "$dir/kept.body"
+        printf '\n' # the separator opening each record after the first
+        arc_record "http://$host/greedy.html" text/html 200 \
+            "$dir/greedy.head" "$dir/greedy.body" \
+            "$(($(wc -c <"$dir/greedy.head") + declared))"
         printf '\n'
-        arc_record "http://$host/second.html" text/html 200 "$h2" "$b2"
+        arc_record "http://$host/victim.html" text/html 200 \
+            "$dir/victim.head" "$dir/victim.body"
     } >"$out"
 }
 
-craft "$dir/honest.arc" honest "${#FIRST_BODY}"
-craft "$dir/overlap.arc" overlap 4096
+craft "$dir/honest.arc" honest "${#GREEDY_BODY}" ' '
+# every byte class a one-byte boundary test could mistake for a separator, the
+# newline most of all: a text page is full of them
+craft "$dir/space.arc" space "$GREEDY_DECLARED" ' '
+craft "$dir/digit.arc" digit "$GREEDY_DECLARED" 0
+craft "$dir/newline.arc" newline "$GREEDY_DECLARED" $'\n'
+craft "$dir/cr.arc" cr "$GREEDY_DECLARED" $'\r'
+
+# an honest archive is still honest with junk stuck on the end, and refusing its
+# last record would cost a page the reader used to serve
+cp "$dir/honest.arc" "$dir/trailer.arc"
+printf 'not a record\0\0\0' >>"$dir/trailer.arc"
 
 # The body the archive $1 stores for the record whose URL is $2, walking the
 # record chain rather than trusting a length twice.
@@ -77,51 +105,107 @@ sys.exit("no record for %s" % sys.argv[2])
 EOF
 }
 
+stored() { # stored ARC URL FILE
+    body_of "$1" "$2" >"$3" || fail "$1 holds no record for $2"
+}
+
+is_body() { # is_body FILE TEXT WHAT
+    test "$(cat "$1")" = "$2" || fail_dump "$3" "$1"
+}
+
 # Consumer 1: the ARC writer, reading one archive and writing another.
 convert() { # convert IN OUT
     proxytrack --convert "$2" "$1" >"$dir/convert.log" 2>&1 ||
         fail_dump "proxytrack died converting $1" "$dir/convert.log"
 }
 
-# The control the whole test rests on: an honest chain keeps the two records
-# apart, so both markers exist in the fixture and each stays under its own URL.
+# The control the rest rests on: an honest chain keeps the records apart, so all
+# three markers exist in the fixture and each stays under its own URL.
 convert "$dir/honest.arc" "$dir/honest-out.arc"
-body_of "$dir/honest-out.arc" http://honest/first.html >"$dir/first.body"
-test "$(cat "$dir/first.body")" = "$FIRST_BODY" ||
-    fail_dump "the honest archive lost the first record's body" "$dir/first.body"
-body_of "$dir/honest-out.arc" http://honest/second.html >"$dir/second.body"
-grep -qaF NEXT-honest "$dir/second.body" ||
-    fail "the honest archive lost the second record"
+stored "$dir/honest-out.arc" http://honest/kept.html "$dir/out.kept"
+is_body "$dir/out.kept" "$KEPT_BODY" "the honest archive lost its first record"
+stored "$dir/honest-out.arc" http://honest/greedy.html "$dir/out.greedy"
+is_body "$dir/out.greedy" "$GREEDY_BODY" \
+    "an honest declared length lost the record's body"
+stored "$dir/honest-out.arc" http://honest/victim.html "$dir/out.victim"
+grep -qaF VICTIM-honest "$dir/out.victim" ||
+    fail "the honest archive lost its last record"
 
-convert "$dir/overlap.arc" "$dir/overlap-out.arc"
-# Either the record is refused or it is clipped to its own bytes; what it may
-# never carry is the page stored after it.
-if body_of "$dir/overlap-out.arc" http://overlap/first.html >"$dir/overlap.body" 2>/dev/null; then
-    if grep -qaF NEXT-overlap "$dir/overlap.body"; then
-        fail_dump "the ARC writer stored the next record under the first record's URL" \
-            "$dir/overlap.body"
+convert "$dir/trailer.arc" "$dir/trailer-out.arc"
+stored "$dir/trailer-out.arc" http://honest/victim.html "$dir/out.trailer"
+grep -qaF VICTIM-honest "$dir/out.trailer" ||
+    fail "an archive with junk after its last record lost that record"
+
+for class in space digit newline cr; do
+    convert "$dir/$class.arc" "$dir/$class-out.arc"
+    # the record before the greedy one, so an implementation that refuses the
+    # whole archive cannot pass the assertion below
+    stored "$dir/$class-out.arc" "http://$class/kept.html" "$dir/$class.kept"
+    is_body "$dir/$class.kept" "$KEPT_BODY" \
+        "a $class-padded archive lost the record before the greedy one"
+    # Either the greedy record is refused or it is clipped to its own bytes.
+    # What it may never carry is the page stored after it.
+    if body_of "$dir/$class-out.arc" "http://$class/greedy.html" \
+        >"$dir/$class.greedy" 2>"$dir/$class.err"; then
+        grep -qaF "VICTIM-$class" "$dir/$class.greedy" &&
+            fail_dump "the ARC writer stored the victim page under the greedy URL" \
+                "$dir/$class.greedy"
+    else
+        grep -qa "no record for" "$dir/$class.err" ||
+            fail_dump "reading the $class archive back failed" "$dir/$class.err"
     fi
-fi
+done
+
+# A header block with no blank line of its own runs into the next record's meta
+# line, so the fields the reader keeps come from the record after it.
+printf 'HTTP/1.1 200 OK\r\nContent-Type: text/first' >"$dir/hdr.head"
+: >"$dir/hdr.empty"
+printf 'HTTP/1.1 200 OK\r\nContent-Type: text/next\r\nLocation: http://elsewhere/\r\nContent-Length: 5\r\n\r\n' >"$dir/next.head"
+printf 'BODY2' >"$dir/next.body"
+{
+    arc_filedesc
+    arc_record http://hdr/first.html text/html 200 "$dir/hdr.head" "$dir/hdr.empty"
+    printf '\n'
+    arc_record http://hdr/next.html text/html 200 "$dir/next.head" "$dir/next.body"
+} >"$dir/hdr.arc"
+
+convert "$dir/hdr.arc" "$dir/hdr-out.arc"
+"$python" - "$dir/hdr-out.arc" <<'EOF' || fail_dump "a record kept the next record's headers" "$dir/hdr-out.arc"
+import sys
+
+out = open(sys.argv[1], "rb").read().decode("latin-1")
+start = out.find("\nhttp://hdr/first.html ")
+if start < 0:
+    sys.exit("the unterminated record vanished from the archive")
+end = out.find("\nhttp://", start + 1)
+first = out[start:] if end < 0 else out[start:end]
+for field in ("text/next", "http://elsewhere/"):
+    if field in first:
+        sys.exit("%r reached the record stored before the one that declared it" % field)
+if "text/next" not in out or "http://elsewhere/" not in out:
+    sys.exit("the fixture lost the fields it exists to track")
+EOF
 
 # Consumer 2: the reply to a client.
 launch_proxytrack() {
     proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" \
-        "$dir/honest.arc" "$dir/overlap.arc" >"$ptlog" 2>&1 &
+        "$dir/honest.arc" "$dir/space.arc" "$dir/digit.arc" \
+        "$dir/newline.arc" "$dir/cr.arc" >"$ptlog" 2>&1 &
     ptpid=$!
 }
 start_proxytrack "$dir/pt" launch_proxytrack
 
-"$python" - "$proxyport" "$FIRST_BODY" <<'EOF' ||
+"$python" - "$proxyport" "$GREEDY_BODY" <<'EOF' ||
 import socket, sys
 
-port, first = int(sys.argv[1]), sys.argv[2].encode()
+port, honest_body = int(sys.argv[1]), sys.argv[2].encode()
 
 
 def get(host):
     sock = socket.create_connection(("127.0.0.1", port), 10)
     sock.settimeout(10)
     sock.sendall(
-        ("GET http://%s/first.html HTTP/1.1\r\nHost: %s\r\n\r\n" % (host, host)).encode()
+        ("GET http://%s/greedy.html HTTP/1.1\r\nHost: %s\r\n\r\n" % (host, host)).encode()
     )
     reply = b""
     try:
@@ -132,16 +216,23 @@ def get(host):
             reply += chunk
     except socket.timeout:
         pass
+    # the status line, so an empty or truncated reply cannot read as a pass
+    if not reply.startswith(b"HTTP/"):
+        sys.exit("%s answered %r, which is no reply at all" % (host, reply[:64]))
     return reply.partition(b"\r\n\r\n")[2]
 
 
 payload = get("honest")
-if payload != first:
-    sys.exit("the honest record served %r, not its own %d bytes" % (payload[:64], len(first)))
+if payload != honest_body:
+    sys.exit(
+        "the honest record served %r, not its own %d bytes"
+        % (payload[:64], len(honest_body))
+    )
 
-payload = get("overlap")
-if b"NEXT-overlap" in payload:
-    sys.exit("the overlapping record served the next page: %r" % payload[:200])
+for host in ("space", "digit", "newline", "cr"):
+    payload = get(host)
+    if ("VICTIM-%s" % host).encode() in payload:
+        sys.exit("the %s archive served the victim page: %r" % (host, payload[:200]))
 EOF
     fail_dump "a record's reply carried bytes from outside it" "$ptlog"
 

--- a/tests/414_local-proxytrack-arc-crossrecord.test
+++ b/tests/414_local-proxytrack-arc-crossrecord.test
@@ -39,35 +39,46 @@ http_head() { # http_head CONTENT_LENGTH
 # on a different class of byte. HOST keys the archive apart.
 craft() { # craft OUT HOST DECLARED PAD [VICTIM_SCHEME] [LEAD]
     local out=$1 host=$2 declared=$3 pad=$4 scheme=${5:-http://} lead=${6:-yes}
-    local length
+    local length reach
 
     printf '%s' "$KEPT_BODY" >"$dir/kept.body"
     http_head "${#KEPT_BODY}" >"$dir/kept.head"
     printf '%s' "$GREEDY_BODY" >"$dir/greedy.body"
-    if test "$declared" = eof; then
-        # no Content-Length, so the archive length is all the read is bounded by
-        printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n' >"$dir/greedy.head"
-    else
-        http_head "$declared" >"$dir/greedy.head"
-    fi
+    case $declared in
+    # no Content-Length, so the archive length is all the read is bounded by
+    eof | padline | urlend) printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n' >"$dir/greedy.head" ;;
+    *) http_head "$declared" >"$dir/greedy.head" ;;
+    esac
     {
         printf 'VICTIM-%s\n' "$host"
-        # a page may hold a line that looks like half of a record header, and
-        # neither half alone may cost it its place in the archive
+        # a page may hold a line that looks like part of a record header, and no
+        # part alone may cost it its place in the archive
         printf 'http://not-a-record\n'
         printf 'three fields 5\n'
-        printf '%*s' "$VICTIM_PAD" '' | tr ' ' "$pad"
-    } >"$dir/victim.body"
+        printf 'http://neg a b c d e f g -5\n'
+    } >"$dir/victim.prefix"
+    if test "$pad" = lines; then
+        awk -v n="$((VICTIM_PAD / 8))" 'BEGIN { while (n-- > 0) print "padline" }' \
+            >"$dir/victim.pad"
+    else
+        printf '%*s' "$VICTIM_PAD" '' | tr ' ' "$pad" >"$dir/victim.pad"
+    fi
+    cat "$dir/victim.prefix" "$dir/victim.pad" >"$dir/victim.body"
     http_head "$(wc -c <"$dir/victim.body")" >"$dir/victim.head"
     arc_record "$scheme$host/victim.html" text/html 200 \
         "$dir/victim.head" "$dir/victim.body" >"$dir/victim.rec"
-    if test "$declared" = eof; then
-        length=$(wc -c <"$dir/greedy.head")
-        length=$((length + $(wc -c <"$dir/greedy.body") + 1))
-        length=$((length + $(wc -c <"$dir/victim.rec")))
-    else
-        length=$(($(wc -c <"$dir/greedy.head") + declared))
-    fi
+    # the bytes from the greedy record's data to the victim record's own data
+    reach=$(($(wc -c <"$dir/greedy.head") + $(wc -c <"$dir/greedy.body") + 1))
+    reach=$((reach + $(wc -c <"$dir/victim.rec") - $(wc -c <"$dir/victim.body")))
+    case $declared in
+    eof) length=$((reach + $(wc -c <"$dir/victim.body"))) ;;
+    # stopping on the newline that ends the first padding line, so the byte
+    # after it opens a line that is not a record
+    padline) length=$((reach + $(wc -c <"$dir/victim.prefix") + 7)) ;;
+    # stopping on the last byte of the victim's own record line
+    urlend) length=$reach ;;
+    *) length=$(($(wc -c <"$dir/greedy.head") + declared)) ;;
+    esac
     {
         arc_filedesc
         if test "$lead" = yes; then
@@ -95,6 +106,12 @@ craft "$dir/eof.arc" eof eof ' '
 # the same lie told by the archive's first record, which a check counting from
 # the second one never sees
 craft "$dir/nolead.arc" nolead "$GREEDY_DECLARED" ' ' http:// no
+# and a length stopping on a newline that opens a line, so a check content to
+# find any line there rather than a record's own header takes it
+craft "$dir/padline.arc" padline padline lines
+# and one stopping on the last byte of the record it swallowed, which an
+# off-by-one in the scan stops counting
+craft "$dir/urlend.arc" urlend urlend ' '
 
 # junk on the end leaves an archive honest, so refusing its last record would
 # cost a page for nothing
@@ -156,7 +173,7 @@ stored "$dir/trailer-out.arc" http://honest/victim.html "$dir/out.trailer"
 grep -qaF VICTIM-honest "$dir/out.trailer" ||
     fail "an archive with junk after its last record lost that record"
 
-for class in space digit newline cr eof; do
+for class in space digit newline cr eof padline urlend; do
     convert "$dir/$class.arc" "$dir/$class-out.arc"
     # the record before the greedy one, so an implementation that refuses the
     # whole archive cannot pass the assertion below
@@ -167,9 +184,10 @@ for class in space digit newline cr eof; do
     # What it may never carry is the page stored after it.
     if body_of "$dir/$class-out.arc" "http://$class/greedy.html" \
         >"$dir/$class.greedy" 2>"$dir/$class.err"; then
-        grep -qaF "VICTIM-$class" "$dir/$class.greedy" &&
-            fail_dump "the ARC writer stored the victim page under the greedy URL" \
-                "$dir/$class.greedy"
+        for leak in "VICTIM-$class" /victim.html; do
+            grep -qaF "$leak" "$dir/$class.greedy" &&
+                fail_dump "the greedy record carried $leak" "$dir/$class.greedy"
+        done
     else
         grep -qa "no record for" "$dir/$class.err" ||
             fail_dump "reading the $class archive back failed" "$dir/$class.err"
@@ -225,7 +243,7 @@ launch_proxytrack() {
     proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" \
         "$dir/honest.arc" "$dir/space.arc" "$dir/digit.arc" \
         "$dir/newline.arc" "$dir/cr.arc" "$dir/eof.arc" \
-        "$dir/nolead.arc" >"$ptlog" 2>&1 &
+        "$dir/nolead.arc" "$dir/padline.arc" "$dir/urlend.arc" >"$ptlog" 2>&1 &
     ptpid=$!
 }
 start_proxytrack "$dir/pt" launch_proxytrack
@@ -264,7 +282,7 @@ if payload != honest_body:
         % (payload[:64], len(honest_body))
     )
 
-for host in ("space", "digit", "newline", "cr", "eof", "nolead"):
+for host in ("space", "digit", "newline", "cr", "eof", "nolead", "padline", "urlend"):
     payload = get(host)
     if ("VICTIM-%s" % host).encode() in payload:
         sys.exit("the %s archive served the victim page: %r" % (host, payload[:200]))

--- a/tests/414_local-proxytrack-arc-crossrecord.test
+++ b/tests/414_local-proxytrack-arc-crossrecord.test
@@ -33,16 +33,23 @@ http_head() { # http_head CONTENT_LENGTH
 
 # Three records: one the greedy record cannot reach, the greedy one, and the
 # victim page whose bytes must never leave the greedy record's URL. DECLARED is
-# what the greedy record announces, but it stores $GREEDY_BODY whatever it says,
-# and PAD is what the victim page is padded with, so each archive's declared
-# length lands on a different class of byte. HOST keys the archive apart.
-craft() { # craft OUT HOST DECLARED PAD
-    local out=$1 host=$2 declared=$3 pad=$4
+# the body length the greedy record announces, or "eof" for a record reaching
+# the last byte of the file, but it stores $GREEDY_BODY whatever it says. PAD is
+# what the victim page is padded with, so each archive's declared length lands
+# on a different class of byte. HOST keys the archive apart.
+craft() { # craft OUT HOST DECLARED PAD [VICTIM_SCHEME] [LEAD]
+    local out=$1 host=$2 declared=$3 pad=$4 scheme=${5:-http://} lead=${6:-yes}
+    local length
 
     printf '%s' "$KEPT_BODY" >"$dir/kept.body"
     http_head "${#KEPT_BODY}" >"$dir/kept.head"
     printf '%s' "$GREEDY_BODY" >"$dir/greedy.body"
-    http_head "$declared" >"$dir/greedy.head"
+    if test "$declared" = eof; then
+        # no Content-Length, so the archive length is all the read is bounded by
+        printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n' >"$dir/greedy.head"
+    else
+        http_head "$declared" >"$dir/greedy.head"
+    fi
     {
         printf 'VICTIM-%s\n' "$host"
         # a page may hold a line that looks like half of a record header, and
@@ -52,17 +59,26 @@ craft() { # craft OUT HOST DECLARED PAD
         printf '%*s' "$VICTIM_PAD" '' | tr ' ' "$pad"
     } >"$dir/victim.body"
     http_head "$(wc -c <"$dir/victim.body")" >"$dir/victim.head"
+    arc_record "$scheme$host/victim.html" text/html 200 \
+        "$dir/victim.head" "$dir/victim.body" >"$dir/victim.rec"
+    if test "$declared" = eof; then
+        length=$(wc -c <"$dir/greedy.head")
+        length=$((length + $(wc -c <"$dir/greedy.body") + 1))
+        length=$((length + $(wc -c <"$dir/victim.rec")))
+    else
+        length=$(($(wc -c <"$dir/greedy.head") + declared))
+    fi
     {
         arc_filedesc
-        arc_record "http://$host/kept.html" text/html 200 \
-            "$dir/kept.head" "$dir/kept.body"
-        printf '\n' # the separator opening each record after the first
+        if test "$lead" = yes; then
+            arc_record "http://$host/kept.html" text/html 200 \
+                "$dir/kept.head" "$dir/kept.body"
+            printf '\n' # the separator opening each record after the first
+        fi
         arc_record "http://$host/greedy.html" text/html 200 \
-            "$dir/greedy.head" "$dir/greedy.body" \
-            "$(($(wc -c <"$dir/greedy.head") + declared))"
+            "$dir/greedy.head" "$dir/greedy.body" "$length"
         printf '\n'
-        arc_record "http://$host/victim.html" text/html 200 \
-            "$dir/victim.head" "$dir/victim.body"
+        cat "$dir/victim.rec"
     } >"$out"
 }
 
@@ -71,8 +87,14 @@ craft "$dir/honest.arc" honest "${#GREEDY_BODY}" ' '
 # newline above all, because a text page is full of them
 craft "$dir/space.arc" space "$GREEDY_DECLARED" ' '
 craft "$dir/digit.arc" digit "$GREEDY_DECLARED" 0
-craft "$dir/newline.arc" newline "$GREEDY_DECLARED" $'\n'
+craft "$dir/newline.arc" newline "$GREEDY_DECLARED" $'\n' ftp://
 craft "$dir/cr.arc" cr "$GREEDY_DECLARED" $'\r'
+# and the length an attacker aligns to the last byte of the file, where there is
+# no next record to compare against
+craft "$dir/eof.arc" eof eof ' '
+# the same lie told by the archive's first record, which a check counting from
+# the second one never sees
+craft "$dir/nolead.arc" nolead "$GREEDY_DECLARED" ' ' http:// no
 
 # junk on the end leaves an archive honest, so refusing its last record would
 # cost a page for nothing
@@ -134,7 +156,7 @@ stored "$dir/trailer-out.arc" http://honest/victim.html "$dir/out.trailer"
 grep -qaF VICTIM-honest "$dir/out.trailer" ||
     fail "an archive with junk after its last record lost that record"
 
-for class in space digit newline cr; do
+for class in space digit newline cr eof; do
     convert "$dir/$class.arc" "$dir/$class-out.arc"
     # the record before the greedy one, so an implementation that refuses the
     # whole archive cannot pass the assertion below
@@ -154,15 +176,27 @@ for class in space digit newline cr; do
     fi
 done
 
+convert "$dir/nolead.arc" "$dir/nolead-out.arc"
+if body_of "$dir/nolead-out.arc" http://nolead/greedy.html >"$dir/nolead.greedy" 2>&1; then
+    grep -qaF VICTIM-nolead "$dir/nolead.greedy" &&
+        fail_dump "a lie in the archive's first record went unchecked" \
+            "$dir/nolead.greedy"
+fi
+
 # A header block with no blank line of its own runs into the next record's meta
 # line, so the fields the reader keeps come from the record after it.
 printf 'HTTP/1.1 200 OK\r\nContent-Type: text/first' >"$dir/hdr.head"
 : >"$dir/hdr.empty"
 printf 'HTTP/1.1 200 OK\r\nContent-Type: text/next\r\nLocation: http://elsewhere/\r\nContent-Length: 5\r\n\r\n' >"$dir/next.head"
 printf 'BODY2' >"$dir/next.body"
+# and a block whose own last line ends on the record's last byte, which the
+# bound must keep
+printf 'HTTP/1.1 200 OK\r\nContent-Type: text/tight\r\n' >"$dir/tight.head"
 {
     arc_filedesc
     arc_record http://hdr/first.html text/html 200 "$dir/hdr.head" "$dir/hdr.empty"
+    printf '\n'
+    arc_record http://hdr/tight.html text/html 200 "$dir/tight.head" "$dir/hdr.empty"
     printf '\n'
     arc_record http://hdr/next.html text/html 200 "$dir/next.head" "$dir/next.body"
 } >"$dir/hdr.arc"
@@ -177,18 +211,21 @@ if start < 0:
     sys.exit("the unterminated record vanished from the archive")
 end = out.find("\nhttp://", start + 1)
 first = out[start:] if end < 0 else out[start:end]
-for field in ("text/next", "http://elsewhere/"):
+for field in ("text/tight", "text/next", "http://elsewhere/"):
     if field in first:
         sys.exit("%r reached the record stored before the one that declared it" % field)
 if "text/next" not in out or "http://elsewhere/" not in out:
     sys.exit("the fixture lost the fields it exists to track")
+if "text/tight" not in out:
+    sys.exit("a header line ending on the record's last byte was dropped")
 EOF
 
 # Consumer 2: the reply to a client.
 launch_proxytrack() {
     proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" \
         "$dir/honest.arc" "$dir/space.arc" "$dir/digit.arc" \
-        "$dir/newline.arc" "$dir/cr.arc" >"$ptlog" 2>&1 &
+        "$dir/newline.arc" "$dir/cr.arc" "$dir/eof.arc" \
+        "$dir/nolead.arc" >"$ptlog" 2>&1 &
     ptpid=$!
 }
 start_proxytrack "$dir/pt" launch_proxytrack
@@ -227,7 +264,7 @@ if payload != honest_body:
         % (payload[:64], len(honest_body))
     )
 
-for host in ("space", "digit", "newline", "cr"):
+for host in ("space", "digit", "newline", "cr", "eof", "nolead"):
     payload = get(host)
     if ("VICTIM-%s" % host).encode() in payload:
         sys.exit("the %s archive served the victim page: %r" % (host, payload[:200]))

--- a/tests/414_local-proxytrack-arc-crossrecord.test
+++ b/tests/414_local-proxytrack-arc-crossrecord.test
@@ -33,7 +33,9 @@ craft() { # craft OUT HOST DECLARED
     local out=$1 host=$2 declared=$3 h1=$dir/h1 b1=$dir/b1 h2=$dir/h2 b2=$dir/b2
 
     printf '%s' "$FIRST_BODY" >"$b1"
-    printf 'NEXT-%s%0*d' "$host" "$NEXT_PAD" 0 >"$b2"
+    # padded with spaces, so the byte the overlapping length lands on is the
+    # one a boundary test loose enough to take whitespace would accept
+    printf 'NEXT-%s%*s' "$host" "$NEXT_PAD" '' >"$b2"
     printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: %d\r\n\r\n' \
         "$declared" >"$h1"
     printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: %d\r\n\r\n' \

--- a/tests/414_local-proxytrack-arc-crossrecord.test
+++ b/tests/414_local-proxytrack-arc-crossrecord.test
@@ -1,0 +1,146 @@
+#!/bin/bash
+#
+# An .arc record's declared length is what bounds the read that fills its body,
+# and the file size is the only other bound. A length reaching past the record's
+# own bytes therefore serves the following record's page under this record's URL.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+# shellcheck source=tests/arclib.sh
+. "${0%"${0##*/}"}./arclib.sh"
+
+export LC_ALL=C
+
+python=$(find_python) || skip "python3 missing"
+
+dir=$(mktemp -d)
+ptpid=
+cleanup() {
+    stop_server "$ptpid"
+    rm -rf "$dir"
+}
+cleanup_push cleanup
+
+FIRST_BODY=FIRSTPAGE_00000000
+NEXT_PAD=4988
+
+# HOST names the archive, so one proxytrack can serve both without a key clash.
+# DECLARED is what the first record announces; it stores $FIRST_BODY whatever it
+# says, so an honest archive passes DECLARED=${#FIRST_BODY}.
+craft() { # craft OUT HOST DECLARED
+    local out=$1 host=$2 declared=$3 h1=$dir/h1 b1=$dir/b1 h2=$dir/h2 b2=$dir/b2
+
+    printf '%s' "$FIRST_BODY" >"$b1"
+    printf 'NEXT-%s%0*d' "$host" "$NEXT_PAD" 0 >"$b2"
+    printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: %d\r\n\r\n' \
+        "$declared" >"$h1"
+    printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: %d\r\n\r\n' \
+        "$(wc -c <"$b2")" >"$h2"
+    {
+        arc_filedesc
+        printf 'http://%s/first.html 0.0.0.0 %s text/html 200 - - 0 t.arc %d\n' \
+            "$host" "$ARC_DATE" "$(($(wc -c <"$h1") + declared))"
+        cat "$h1" "$b1"
+        printf '\n'
+        arc_record "http://$host/second.html" text/html 200 "$h2" "$b2"
+    } >"$out"
+}
+
+craft "$dir/honest.arc" honest "${#FIRST_BODY}"
+craft "$dir/overlap.arc" overlap 4096
+
+# The body the archive $1 stores for the record whose URL is $2, walking the
+# record chain rather than trusting a length twice.
+body_of() { # body_of ARC URL
+    "$python" - "$1" "$2" <<'EOF'
+import sys
+
+data = open(sys.argv[1], "rb").read()
+pos = data.index(b"\n") + 1  # the filedesc line
+pos += int(data[:pos].split()[-1]) + 1  # its declared block, then the blank line
+while pos < len(data):
+    if data[pos : pos + 1] != b"\n":
+        break
+    eol = data.index(b"\n", pos + 1)
+    line = data[pos + 1 : eol].split()
+    length = int(line[-1])
+    if line[0].decode() == sys.argv[2]:
+        record = data[eol + 1 : eol + 1 + length]
+        sys.stdout.buffer.write(record.partition(b"\r\n\r\n")[2])
+        sys.exit(0)
+    pos = eol + 1 + length
+sys.exit("no record for %s" % sys.argv[2])
+EOF
+}
+
+# Consumer 1: the ARC writer, reading one archive and writing another.
+convert() { # convert IN OUT
+    proxytrack --convert "$2" "$1" >"$dir/convert.log" 2>&1 ||
+        fail_dump "proxytrack died converting $1" "$dir/convert.log"
+}
+
+# The control the whole test rests on: an honest chain keeps the two records
+# apart, so both markers exist in the fixture and each stays under its own URL.
+convert "$dir/honest.arc" "$dir/honest-out.arc"
+body_of "$dir/honest-out.arc" http://honest/first.html >"$dir/first.body"
+test "$(cat "$dir/first.body")" = "$FIRST_BODY" ||
+    fail_dump "the honest archive lost the first record's body" "$dir/first.body"
+body_of "$dir/honest-out.arc" http://honest/second.html >"$dir/second.body"
+grep -qaF NEXT-honest "$dir/second.body" ||
+    fail "the honest archive lost the second record"
+
+convert "$dir/overlap.arc" "$dir/overlap-out.arc"
+# Either the record is refused or it is clipped to its own bytes; what it may
+# never carry is the page stored after it.
+if body_of "$dir/overlap-out.arc" http://overlap/first.html >"$dir/overlap.body" 2>/dev/null; then
+    if grep -qaF NEXT-overlap "$dir/overlap.body"; then
+        fail_dump "the ARC writer stored the next record under the first record's URL" \
+            "$dir/overlap.body"
+    fi
+fi
+
+# Consumer 2: the reply to a client.
+launch_proxytrack() {
+    proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" \
+        "$dir/honest.arc" "$dir/overlap.arc" >"$ptlog" 2>&1 &
+    ptpid=$!
+}
+start_proxytrack "$dir/pt" launch_proxytrack
+
+"$python" - "$proxyport" "$FIRST_BODY" <<'EOF' ||
+import socket, sys
+
+port, first = int(sys.argv[1]), sys.argv[2].encode()
+
+
+def get(host):
+    sock = socket.create_connection(("127.0.0.1", port), 10)
+    sock.settimeout(10)
+    sock.sendall(
+        ("GET http://%s/first.html HTTP/1.1\r\nHost: %s\r\n\r\n" % (host, host)).encode()
+    )
+    reply = b""
+    try:
+        while True:
+            chunk = sock.recv(65536)
+            if not chunk:
+                break
+            reply += chunk
+    except socket.timeout:
+        pass
+    return reply.partition(b"\r\n\r\n")[2]
+
+
+payload = get("honest")
+if payload != first:
+    sys.exit("the honest record served %r, not its own %d bytes" % (payload[:64], len(first)))
+
+payload = get("overlap")
+if b"NEXT-overlap" in payload:
+    sys.exit("the overlapping record served the next page: %r" % payload[:200])
+EOF
+    fail_dump "a record's reply carried bytes from outside it" "$ptlog"
+
+echo "OK: no consumer read an .arc record past its own bytes"

--- a/tests/414_local-proxytrack-arc-crossrecord.test
+++ b/tests/414_local-proxytrack-arc-crossrecord.test
@@ -32,21 +32,23 @@ http_head() { # http_head CONTENT_LENGTH
 }
 
 # Three records: one the greedy record cannot reach, the greedy one, and the
-# victim page whose bytes must never leave the greedy record's URL. DECLARED is
-# the body length the greedy record announces, or "eof" for a record reaching
-# the last byte of the file, but it stores $GREEDY_BODY whatever it says. PAD is
+# victim page whose bytes must never leave the greedy record's URL. TAIL adds a
+# fourth after the victim. DECLARED is the body length the greedy record
+# announces, or "eof" for a record reaching the last byte the victim holds, but
+# it stores $GREEDY_BODY whatever it says. PAD is
 # what the victim page is padded with, so each archive's declared length lands
 # on a different class of byte. HOST keys the archive apart.
-craft() { # craft OUT HOST DECLARED PAD [VICTIM_SCHEME] [LEAD]
+craft() { # craft OUT HOST DECLARED PAD [VICTIM_SCHEME] [LEAD] [TAIL]
     local out=$1 host=$2 declared=$3 pad=$4 scheme=${5:-http://} lead=${6:-yes}
-    local length reach
+    local tail=${7:-no}
+    local length line reach
 
     printf '%s' "$KEPT_BODY" >"$dir/kept.body"
     http_head "${#KEPT_BODY}" >"$dir/kept.head"
     printf '%s' "$GREEDY_BODY" >"$dir/greedy.body"
     case $declared in
     # no Content-Length, so the archive length is all the read is bounded by
-    eof | padline | urlend) printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n' >"$dir/greedy.head" ;;
+    eof | padline | urlend | urlmid) printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n' >"$dir/greedy.head" ;;
     *) http_head "$declared" >"$dir/greedy.head" ;;
     esac
     {
@@ -67,16 +69,21 @@ craft() { # craft OUT HOST DECLARED PAD [VICTIM_SCHEME] [LEAD]
     http_head "$(wc -c <"$dir/victim.body")" >"$dir/victim.head"
     arc_record "$scheme$host/victim.html" text/html 200 \
         "$dir/victim.head" "$dir/victim.body" >"$dir/victim.rec"
-    # the bytes from the greedy record's data to the victim record's own data
-    reach=$(($(wc -c <"$dir/greedy.head") + $(wc -c <"$dir/greedy.body") + 1))
-    reach=$((reach + $(wc -c <"$dir/victim.rec") - $(wc -c <"$dir/victim.body")))
+    # the bytes from the greedy record's data to the victim record's own line,
+    # then on to the victim's data
+    line=$(($(wc -c <"$dir/greedy.head") + $(wc -c <"$dir/greedy.body") + 1))
+    reach=$((line + $(wc -c <"$dir/victim.rec") - $(wc -c <"$dir/victim.body")))
     case $declared in
     eof) length=$((reach + $(wc -c <"$dir/victim.body"))) ;;
     # stopping on the newline that ends the first padding line, so the byte
     # after it opens a line that is not a record
     padline) length=$((reach + $(wc -c <"$dir/victim.prefix") + 7)) ;;
-    # stopping on the last byte of the victim's own record line
+    # stopping where the victim's data begins, so the victim's own record line
+    # ends exactly on the greedy record's last byte
     urlend) length=$reach ;;
+    # stopping inside that record line, which a scan counting a line by where it
+    # ENDS never sees, and the front of the line goes out with the body
+    urlmid) length=$((line + ($(wc -c <"$dir/victim.rec") - $(wc -c <"$dir/victim.head") - $(wc -c <"$dir/victim.body")) / 2)) ;;
     *) length=$(($(wc -c <"$dir/greedy.head") + declared)) ;;
     esac
     {
@@ -90,6 +97,13 @@ craft() { # craft OUT HOST DECLARED PAD [VICTIM_SCHEME] [LEAD]
             "$dir/greedy.head" "$dir/greedy.body" "$length"
         printf '\n'
         cat "$dir/victim.rec"
+        if test "$tail" = yes; then
+            printf 'TAIL-%s\n' "$host" >"$dir/tail.body"
+            http_head "$(wc -c <"$dir/tail.body")" >"$dir/tail.head"
+            printf '\n'
+            arc_record "http://$host/tail.html" text/html 200 \
+                "$dir/tail.head" "$dir/tail.body"
+        fi
     } >"$out"
 }
 
@@ -112,11 +126,160 @@ craft "$dir/padline.arc" padline padline lines
 # and one stopping on the last byte of the record it swallowed, which an
 # off-by-one in the scan stops counting
 craft "$dir/urlend.arc" urlend urlend ' '
+# and one stopping inside that record's line, so the line the scan must catch
+# is one that ENDS outside the greedy record
+craft "$dir/urlmid.arc" urlmid urlmid ' '
+# The lie the declared length is FOR: it ends exactly where a record starts, so
+# a check that accepts on "a record follows" passes it while a whole page inside
+# goes out under the greedy record's URL. The tail record says whether the walk
+# survives the refusal.
+craft "$dir/later.arc" later eof ' ' http:// yes yes
+# A scheme this reader never serves still marks where the record before it ends.
+# Heritrix writes one "dns:" record per host, so an archive without this is the
+# common case, not the corner one.
+craft "$dir/dns.arc" dns "$GREEDY_DECLARED" ' ' dns:
 
 # junk on the end leaves an archive honest, so refusing its last record would
 # cost a page for nothing
 cp "$dir/honest.arc" "$dir/trailer.arc"
 printf 'not a record\0\0\0' >>"$dir/trailer.arc"
+
+# A page carrying a line of the right shape is refused, and that is the price of
+# the check. What it may not cost is the records after it: an archive from a
+# crawler that writes one such page keeps everything else it holds.
+chain() { # chain OUT FIRST_BODY_FILE [DNS]
+    local out=$1 first=$2 dns=${3:-no}
+    local i
+
+    http_head "$(wc -c <"$first")" >"$dir/chain.head"
+    {
+        arc_filedesc
+        arc_record http://chain/first.html text/html 200 "$dir/chain.head" "$first"
+        if test "$dns" = yes; then
+            printf 'q.example.\t3600\tIN\tA\t1.2.3.4\n' >"$dir/chain.dns"
+            : >"$dir/chain.nobody"
+            printf '\n'
+            arc_record dns:q.example text/dns 200 "$dir/chain.dns" "$dir/chain.nobody"
+        fi
+        for i in 1 2; do
+            printf 'CHAIN-%d\n' "$i" >"$dir/chain$i.body"
+            http_head "$(wc -c <"$dir/chain$i.body")" >"$dir/chain$i.head"
+            printf '\n'
+            arc_record "http://chain/page$i.html" text/html 200 \
+                "$dir/chain$i.head" "$dir/chain$i.body"
+        done
+    } >"$out"
+}
+
+# a real record line, quoted by the page that holds it
+printf 'see http://x/y for details\nhttp://q/r 1.2.3.4 %s text/html 200 - - 0 t.arc 7\nend\n' \
+    "$ARC_DATE" >"$dir/quoting.body"
+chain "$dir/quoting.arc" "$dir/quoting.body"
+# and the near misses a looser shape would take for one, each of which would
+# cost this page its place in the archive
+{
+    printf 'http://not-a-record\n'
+    printf 'three fields 5\n'
+    printf 'http://neg a b c d e f g -5\n'
+    printf 'dns:q.example 1.2.3.4 2025 text/dns 4\n'
+    printf 'http://q/r 1.2.3.4 %s text/html 200 4\n' "$ARC_DATE"
+    printf 'http://q/r 1.2.3.4 %s text/html v4\n' "$ARC_DATE"
+    printf 'http://q/r 1.2.3.4 %s text/html 4x4\n' "$ARC_DATE"
+    printf 'x: 1.2.3.4 %s text/html 4\n' "$ARC_DATE"
+    printf 'a/b:c 1.2.3.4 %s text/html 4\n' "$ARC_DATE"
+    printf 'NEARMISS\n'
+} >"$dir/nearmiss.body"
+chain "$dir/nearmiss.arc" "$dir/nearmiss.body"
+# and the same page with a Heritrix "dns:" record between it and the rest, the
+# record whose scheme decides whether the walk can go on at all
+chain "$dir/dnschain.arc" "$dir/quoting.body" yes
+
+# The record lines a scan has to recognise or place exactly, each in an archive
+# whose greedy record swallows it. A miss here is a page served under another
+# page's URL, so these are the shapes an archive in the wild actually carries.
+"$python" - "$dir" "$ARC_DATE" <<'EOF' || fail "could not craft the shape fixtures"
+import sys
+
+d, date = sys.argv[1], sys.argv[2].encode()
+SCAN_BUFFER = 32768  # mirrors the buffer arcDataHoldsARecord() reads through
+
+
+def head(b):
+    return b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: %d\r\n\r\n" % len(b)
+
+
+def archive(host, victim_line, pad=b" " * 64, at_eof=False):
+    kept = b"KEPTPAGE"
+    greedy = b"GREEDYPAGE"
+    victim = b"VICTIM-" + host + b"\n" + b"x" * 32
+    # no Content-Length on the greedy record, so its declared length is the only
+    # bound the read has and the whole lie is served
+    gdata = b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n" + greedy
+    vdata = head(victim) + victim
+    line = victim_line % len(vdata)
+    tail = pad + b"\n" + (line.rstrip(b"\n") if at_eof else line + vdata)
+    declared = len(gdata) + len(tail)
+    out = b"filedesc://t.arc 0.0.0.0 " + date + b" text/plain 200 - - 0 t.arc 9\n"
+    out += b"2 0 test\n\n\n"
+    for name, data, length in ((b"kept", head(kept) + kept, None),
+                               (b"greedy", gdata + tail, declared)):
+        if name == b"greedy":
+            out += b"\n"
+        out += b"http://%s/%s.html 0.0.0.0 %s text/html 200 - - 0 t.arc %d\n" % (
+            host, name, date, len(data) if length is None else length)
+        out += data
+    return out
+
+
+v10 = b"http://%s/victim.html 0.0.0.0 " + date + b" text/html 200 - - 0 t.arc %%d"
+cases = {
+    # a writer ending its record lines with CRLF: linput() drops the CR
+    b"crlf": archive(b"crlf", (v10 % b"crlf") + b"\r\n"),
+    # arc 1.0, five fields
+    b"arc10": archive(b"arc10", b"http://arc10/victim.html 1.2.3.4 " + date
+                      + b" text/html %d\n"),
+    # a date this reader cannot use, on a scheme it serves
+    b"undated": archive(b"undated", b"http://undated/victim.html 1.2.3.4 20250101"
+                        b" text/html 200 - - 0 t.arc %d\n"),
+    # a record line closing the file, which has no newline of its own
+    b"eofline": archive(b"eofline", v10 % b"eofline" + b"\n", at_eof=True),
+}
+# and one whose record line straddles the scan's buffer
+probe = archive(b"straddle", v10 % b"straddle" + b"\n")
+lead = probe.index(b"\nhttp://straddle/greedy.html")
+gdata = probe.index(b"\n", lead + 1) + 1
+victim = probe.index(b"http://straddle/victim.html", gdata)
+cases[b"straddle"] = archive(
+    b"straddle", v10 % b"straddle" + b"\n",
+    pad=b" " * (64 + SCAN_BUFFER - 8 - (victim - gdata)))
+for host, data in cases.items():
+    open("%s/%s.arc" % (d, host.decode()), "wb").write(data)
+
+
+# Two honest-looking records the loader has no reason to refuse, where the bound
+# the READER puts on its own read is all that keeps the record after them out.
+def pair(host, adata, bdata):
+    out = b"filedesc://t.arc 0.0.0.0 " + date + b" text/plain 200 - - 0 t.arc 9\n"
+    out += b"2 0 test\n\n\n"
+    for name, data in ((b"a", adata), (b"b", bdata)):
+        if name == b"b":
+            out += b"\n"
+        out += b"http://%s/%s.html 0.0.0.0 %s text/html 200 - - 0 t.arc %d\n" % (
+            host, name, date, len(data))
+        out += data
+    return out
+
+
+nxt = (b"HTTP/1.1 418 NEXTMSG\r\nContent-Type: text/NEXTTYPE\r\n"
+       b"Location: http://NEXTLOC/\r\nContent-Length: 9\r\n\r\nNEXTBODY\n")
+# a Content-Length larger than the record's own archive length
+open(d + "/overlong.arc", "wb").write(pair(
+    b"overlong",
+    b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 4096\r\n\r\nA-BODY",
+    nxt + b"x" * 4096))
+# and a record whose data ends inside its own status line
+open(d + "/shorthdr.arc", "wb").write(pair(b"shorthdr", b"HTTP/", nxt))
+EOF
 
 # Walks the record chain to return the body archive $1 stores for URL $2, rather
 # than trusting a declared length twice.
@@ -173,7 +336,8 @@ stored "$dir/trailer-out.arc" http://honest/victim.html "$dir/out.trailer"
 grep -qaF VICTIM-honest "$dir/out.trailer" ||
     fail "an archive with junk after its last record lost that record"
 
-for class in space digit newline cr eof padline urlend; do
+for class in space digit newline cr eof padline urlend urlmid later dns \
+    crlf arc10 undated straddle eofline; do
     convert "$dir/$class.arc" "$dir/$class-out.arc"
     # the record before the greedy one, so an implementation that refuses the
     # whole archive cannot pass the assertion below
@@ -184,7 +348,7 @@ for class in space digit newline cr eof padline urlend; do
     # What it may never carry is the page stored after it.
     if body_of "$dir/$class-out.arc" "http://$class/greedy.html" \
         >"$dir/$class.greedy" 2>"$dir/$class.err"; then
-        for leak in "VICTIM-$class" /victim.html; do
+        for leak in "VICTIM-$class" victim.html; do
             grep -qaF "$leak" "$dir/$class.greedy" &&
                 fail_dump "the greedy record carried $leak" "$dir/$class.greedy"
         done
@@ -193,6 +357,53 @@ for class in space digit newline cr eof padline urlend; do
             fail_dump "reading the $class archive back failed" "$dir/$class.err"
     fi
 done
+
+# The tail record, which exists to say that refusing the greedy record did not
+# also drop everything stored after the page it swallowed.
+stored "$dir/later-out.arc" http://later/tail.html "$dir/later.tail"
+grep -qaF TAIL-later "$dir/later.tail" ||
+    fail "refusing one record cost the archive the records after it"
+
+convert "$dir/quoting.arc" "$dir/quoting-out.arc"
+for page in page1 page2; do
+    stored "$dir/quoting-out.arc" "http://chain/$page.html" "$dir/quoting.$page"
+    grep -qaF CHAIN- "$dir/quoting.$page" ||
+        fail "a page quoting a record line cost the archive $page"
+done
+
+for class in overlong shorthdr; do
+    convert "$dir/$class.arc" "$dir/$class-out.arc"
+    # the record is kept, so what is asserted is the bytes it carries
+    "$python" - "$dir/$class-out.arc" "http://$class/a.html" <<'EOF' ||
+import sys
+
+out = open(sys.argv[1], "rb").read().decode("latin-1")
+start = out.find("\n" + sys.argv[2] + " ")
+if start < 0:
+    sys.exit("the record the reader had to bound vanished from the archive")
+end = out.find("\nhttp://", start + 1)
+first = out[start:] if end < 0 else out[start:end]
+for field in ("NEXTTYPE", "NEXTLOC", "NEXTBODY", "NEXTMSG"):
+    if field in first:
+        sys.exit("%r reached the record stored before the one that declared it" % field)
+if "NEXTTYPE" not in out:
+    sys.exit("the fixture lost the fields it exists to track")
+EOF
+        fail_dump "a record served the bytes of the record after it" \
+            "$dir/$class-out.arc"
+done
+
+convert "$dir/dnschain.arc" "$dir/dnschain-out.arc"
+for page in page1 page2; do
+    stored "$dir/dnschain-out.arc" "http://chain/$page.html" "$dir/dnschain.$page"
+    grep -qaF CHAIN- "$dir/dnschain.$page" ||
+        fail "a dns: record between two pages cost the archive $page"
+done
+
+convert "$dir/nearmiss.arc" "$dir/nearmiss-out.arc"
+stored "$dir/nearmiss-out.arc" http://chain/first.html "$dir/nearmiss.first"
+grep -qaF NEARMISS "$dir/nearmiss.first" ||
+    fail "a page holding no record line was refused all the same"
 
 convert "$dir/nolead.arc" "$dir/nolead-out.arc"
 if body_of "$dir/nolead-out.arc" http://nolead/greedy.html >"$dir/nolead.greedy" 2>&1; then
@@ -243,7 +454,8 @@ launch_proxytrack() {
     proxytrack "127.0.0.1:$proxyport" "127.0.0.1:$icpport" \
         "$dir/honest.arc" "$dir/space.arc" "$dir/digit.arc" \
         "$dir/newline.arc" "$dir/cr.arc" "$dir/eof.arc" \
-        "$dir/nolead.arc" "$dir/padline.arc" "$dir/urlend.arc" >"$ptlog" 2>&1 &
+        "$dir/nolead.arc" "$dir/padline.arc" "$dir/urlend.arc" \
+        "$dir/urlmid.arc" "$dir/later.arc" "$dir/dns.arc" >"$ptlog" 2>&1 &
     ptpid=$!
 }
 start_proxytrack "$dir/pt" launch_proxytrack
@@ -261,17 +473,30 @@ def get(host):
         ("GET http://%s/greedy.html HTTP/1.1\r\nHost: %s\r\n\r\n" % (host, host)).encode()
     )
     reply = b""
+    want = None
     try:
         while True:
+            # the reply is read to its own declared length: proxytrack keeps the
+            # connection open, so draining to EOF costs the socket timeout
+            if want is None and b"\r\n\r\n" in reply:
+                head = reply.partition(b"\r\n\r\n")[0].lower()
+                for line in head.split(b"\r\n"):
+                    if line.startswith(b"content-length:"):
+                        want = int(line.split(b":")[1])
+            if want is not None and len(reply.partition(b"\r\n\r\n")[2]) >= want:
+                break
             chunk = sock.recv(65536)
             if not chunk:
                 break
             reply += chunk
     except socket.timeout:
         pass
+    sock.close()
     # the status line, so an empty or truncated reply cannot read as a pass
     if not reply.startswith(b"HTTP/"):
         sys.exit("%s answered %r, which is no reply at all" % (host, reply[:64]))
+    if want is None:
+        sys.exit("%s answered without a length: %r" % (host, reply[:120]))
     return reply.partition(b"\r\n\r\n")[2]
 
 
@@ -282,7 +507,8 @@ if payload != honest_body:
         % (payload[:64], len(honest_body))
     )
 
-for host in ("space", "digit", "newline", "cr", "eof", "nolead", "padline", "urlend"):
+for host in ("space", "digit", "newline", "cr", "eof", "nolead", "padline", "urlend",
+             "urlmid", "later", "dns"):
     payload = get(host)
     if ("VICTIM-%s" % host).encode() in payload:
         sys.exit("the %s archive served the victim page: %r" % (host, payload[:200]))

--- a/tests/414_local-proxytrack-arc-crossrecord.test
+++ b/tests/414_local-proxytrack-arc-crossrecord.test
@@ -377,16 +377,26 @@ for class in overlong shorthdr; do
     "$python" - "$dir/$class-out.arc" "http://$class/a.html" <<'EOF' ||
 import sys
 
-out = open(sys.argv[1], "rb").read().decode("latin-1")
-start = out.find("\n" + sys.argv[2] + " ")
-if start < 0:
+# by declared length, because the leak this looks for starts with a record line
+# and a search for the next one would cut the block short of it
+data = open(sys.argv[1], "rb").read()
+pos = data.index(b"\n") + 1
+pos += int(data[:pos].split()[-1]) + 1
+record = None
+while pos < len(data):
+    if data[pos : pos + 1] != b"\n":
+        break
+    eol = data.index(b"\n", pos + 1)
+    length = int(data[pos + 1 : eol].split()[-1])
+    if data[pos + 1 : eol].split()[0].decode() == sys.argv[2]:
+        record = data[eol + 1 : eol + 1 + length]
+    pos = eol + 1 + length
+if record is None:
     sys.exit("the record the reader had to bound vanished from the archive")
-end = out.find("\nhttp://", start + 1)
-first = out[start:] if end < 0 else out[start:end]
-for field in ("NEXTTYPE", "NEXTLOC", "NEXTBODY", "NEXTMSG"):
-    if field in first:
+for field in (b"NEXTTYPE", b"NEXTLOC", b"NEXTBODY", b"NEXTMSG"):
+    if field in record:
         sys.exit("%r reached the record stored before the one that declared it" % field)
-if "NEXTTYPE" not in out:
+if b"NEXTTYPE" not in data:
     sys.exit("the fixture lost the fields it exists to track")
 EOF
         fail_dump "a record served the bytes of the record after it" \

--- a/tests/arclib.sh
+++ b/tests/arclib.sh
@@ -18,8 +18,9 @@ arc_filedesc() { # arc_filedesc [LEN]
 
 # One record: the header line, then HDRFILE and BODYFILE verbatim. The declared
 # length counts BYTES, so a body outside ASCII still declares its true length.
-arc_record() { # arc_record URL MIME STATUS HDRFILE BODYFILE
+# DECLARED overrides that count, for a fixture whose record must lie about it.
+arc_record() { # arc_record URL MIME STATUS HDRFILE BODYFILE [DECLARED]
     printf '%s 0.0.0.0 %s %s %s - - 0 t.arc %d\n' "$1" "$ARC_DATE" "$2" "$3" \
-        "$(($(wc -c <"$4") + $(wc -c <"$5")))"
+        "${6:-$(($(wc -c <"$4") + $(wc -c <"$5")))}"
     cat "$4" "$5"
 }


### PR DESCRIPTION
An `.arc` record's declared length is read out of the archive. A record that inflates it is served bytes belonging to the record stored after it. That page's URL line, its `Content-Type`, its `Location`, its `Etag` and its body all go out under the first record's URL. `proxytrack --convert` copies them into the archive it writes, and a client GET receives them. Whoever hands ProxyTrack an `.arc` to serve picks that length.

`PT_LoadCache__Arc` now refuses a record whose declared data holds another record's line, counted by where that line starts. A line ending past the declared end still has its front served, so where it ends decides nothing.

It hit the same trap three times, because the loader and the scan disagreed on what a record line is. The scan's was narrower. A record the loader indexes and serves under its own URL was then invisible to the scan, and a neighbour could swallow it. Three fields rather than five was one way through. So was a length `sscanf` reads but a digit run does not. So was one byte `linput` drops, sitting in front of an ordinary line.

The scan now asks the question the loader asks, `getArcLength` plus a scheme it can serve. On top of that it takes the arc shape, for the records the loader never serves. Heritrix writes one `dns:` record per host, and those bound their neighbour all the same.

The scan also builds each line the way the loader's own `linput` does. That is the one in `proxytrack.h`, not the `htslib.c` one proxytrack never links. It drops NUL along with TAB, CR and form feed. A record line carrying a NUL is therefore indexed and served, and a scan keeping the NUL sees a C string that ends at it.

Widening the scan rather than narrowing the loader is deliberate. Narrowing the loader would drop records httrack reads today out of third-party archives, and the shapes involved are ones real writers emit. The cost of widening is named below instead.

Refusing a record no longer costs the archive the records after it. The walk resumes at the declared end and judges what it finds there as it judges every other record. Nothing about the refusal decides whether the walk goes on. A fixture whose next record line carries a trailing space loaded nothing at all under the previous attempt. It now loads everything except the greedy record itself.

The scan reads the record's data forward rather than seeking back over it. Over an archive of 10000 small records, 658969 bytes, it reads 672676 bytes, exactly what the current release reads, against 1990127 for the previous attempt. That parity holds only where the release already reads the data. A record large enough for the release to seek past its body is read in full instead. One 64MB record costs 67115953 bytes against the release's 10985.

A page holding a line the loader would itself take for a record loses its place in the archive. Over an archive built from every documentation, man and HTML file on one machine, 2 records of 6827 are refused. The check does not cover a record the walk parses but never indexes, such as an undated `gopher:` line. A greedy neighbour can still swallow that. The boundary the check draws is narrower than the release behaves today.

Test 414 crafts an honest archive and the lying ones beside it, then runs both consumers over each. It covers a length aligned to a later record's separator, and one ending inside the next record's line. It covers dropped bytes in front of a record line, three-field and ten-field lines, and lengths a digit run rejects. It covers a line straddling the scan's buffer or closing the file, and archives where the record after a refusal must survive. Both the current release and the previous attempt fail it. Of 500 generated mutants, 305 build and 171 of those die. Sixty of the survivors sit in the reader's header parsing, which this change does not touch. The rest mostly widen the check, which costs pages rather than leaking them. One mutant makes the scan loop forever, and only the suite's wall-clock guard reports it. That guard is the mechanism for non-termination, so the reader needs no assertion of its own.
