### PR TITLE
--sizehack on an update decides from the cache index alone

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -4318,18 +4318,26 @@ void back_wait(struct_back * sback, httrackp * opt, cache_back * cache,
                     // If the size is the same, and the option has been set, we assume
                     // that the file is identical - and therefore let's break the connection
                     if (back[i].is_update) {    // mise à jour
-                      if (back[i].r.statuscode == HTTP_OK && !back[i].testmode) {       // 'OK'
+                      // only a file stored verbatim, as in the two blocks below
+                      if (back[i].r.statuscode == HTTP_OK &&
+                          !back[i].testmode &&
+                          !is_hypertext_mime(opt, back[i].r.contenttype,
+                                             back[i].url_fil) &&
+                          strnotempty(back[i].url_sav)) {
                         htsblk r = cache_read(opt, cache, back[i].url_adr, back[i].url_fil, NULL, NULL);        // lire entrée cache
 
                         if (r.statuscode == HTTP_OK) {  // OK pas d'erreur cache
                           LLint len1, len2;
+                          const LLint ondisk = fsize_utf8(back[i].url_sav);
 
                           len1 = r.totalsize;
                           len2 = back[i].r.totalsize;
                           if (r.size > 0)
                             len1 = r.size;
                           if (len1 >= 0) {
-                            if (len1 == len2) { // tailles identiques
+                            // the cache size records a past fetch, so the
+                            // copy on disk has to still agree with it
+                            if (len1 == len2 && ondisk == len2) {
                               back[i].r.statuscode = HTTP_NOT_MODIFIED; // forcer NOT MODIFIED
                               deletehttp(&back[i].r);
                               back[i].r.soc = INVALID_SOCKET;

--- a/tests/417_local-sizehack-update-cache.test
+++ b/tests/417_local-sizehack-update-cache.test
@@ -1,0 +1,89 @@
+#!/bin/bash
+# --sizehack on an update decided from the cache index alone, where its three
+# siblings ask the copy on disk and refuse hypertext. So an HTML page was kept
+# whenever its length held, and a file the disk no longer held at the recorded
+# size was dropped from the mirror instead of re-fetched.
+set -eu
+
+# shellcheck source=tests/crawllib.sh
+. "${0%"${0##*/}"}./crawllib.sh"
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_417.XXXXXX") || exit 1
+cleanup() {
+    rm -rf "$tmpdir"
+}
+cleanup_push cleanup
+
+require_httrack
+
+root="${tmpdir}/root"
+mkdir -p "$root"
+cat >"${root}/index.html" <<'HTML'
+<html><body>
+<a href="leaf.html">leaf</a>
+<a href="keep.bin">keep</a>
+<a href="diverged.bin">diverged</a>
+</body></html>
+HTML
+
+# Both versions of every body have the same length, so only the sizehack can
+# decide. The mtime moves so the server answers 200 rather than a real 304,
+# which is the lying-server case the option exists for.
+write_site() { # write_site <marker char> <touch stamp>
+    printf '<html><body><p>%s</p></body></html>\n' "$1$1$1$1$1" >"${root}/leaf.html"
+    repeat_chars 1024 "$1" >"${root}/keep.bin"
+    repeat_chars 1024 "$1" >"${root}/diverged.bin"
+    touch -t "$2" "${root}"/*
+}
+
+crawl() { # crawl <label> <outdir> [httrack args...]
+    local label=$1 out=$2
+    shift 2
+    # No footer, so leaf.html lands byte-identical: an HTML page whose on-disk
+    # length equals the announced one needs the mime guard, not a size source.
+    local_crawl --log "${tmpdir}/crawl-${label}.log" \
+        "${BASEURL}/index.html" -O "$out" --quiet --robots=0 --timeout=30 \
+        -%N0 -%F '' "$@" || fail "$label: crawl failed"
+}
+
+write_site A 202001010000
+local_server_start --root "$root"
+
+out="${tmpdir}/out"
+crawl ref "$out"
+host="${out}/127.0.0.1_${SRV_PORT}"
+for f in leaf.html keep.bin diverged.bin; do
+    assert_file "${host}/$f" "reference mirror"
+done
+cmp -s "${root}/leaf.html" "${host}/leaf.html" ||
+    fail "leaf.html was rewritten on disk, so the HTML arm proves nothing"
+cp "${host}/keep.bin" "${tmpdir}/keep-v1.bin"
+
+write_site B 202501010000
+# What the cache recorded for diverged.bin is no longer what the mirror holds.
+repeat_chars 1536 Z >"${host}/diverged.bin"
+crawl update "$out" --update --sizehack
+
+log="${out}/hts-log.txt"
+kept_name() { # kept_name <mirror-relative path>
+    count_matching_lines -F "Kept existing file ${host}/$1 (" "$log"
+}
+
+cmp -s "${root}/leaf.html" "${host}/leaf.html" ||
+    fail "leaf.html kept its cached body: $(cat "${host}/leaf.html")"
+test "$(kept_name leaf.html)" -eq 0 || fail "leaf.html is reported as kept"
+ok "an HTML page of unchanged length is re-fetched"
+
+assert_file "${host}/diverged.bin" "update mirror"
+cmp -s "${root}/diverged.bin" "${host}/diverged.bin" ||
+    fail "diverged.bin is $(size_of "${host}/diverged.bin") bytes, not the served copy"
+test "$(kept_name diverged.bin)" -eq 0 || fail "diverged.bin is reported as kept"
+ok "a mirrored file that drifted from the cache is re-fetched, not dropped"
+
+# The control: with the disk, the cache and the response all agreeing, the
+# shortcut must still fire, or the two arms above pass on a disabled option.
+cmp -s "${tmpdir}/keep-v1.bin" "${host}/keep.bin" ||
+    fail "keep.bin was re-fetched, so the sizehack shortcut is gone"
+test "$(kept_name keep.bin)" -ge 1 || fail "no log line names keep.bin as kept:
+$(grep -a 'Kept existing' "$log" || true)"
+ok "an unchanged-size data file still takes the shortcut"


### PR DESCRIPTION
`back_wait()` decides the same thing in four places: what we already hold is the size the server announces, so keep it and force a 304. Three of them measure the file on disk, and those same three refuse hypertext. The fourth, the one that runs on an update crawl, reads the size out of the cache index and guards nothing else.

The cache index records a past fetch, not what the mirror holds now. Both consequences below reproduce against the local test server.

An HTML page is kept whenever its length holds, so a server that always answers 200 hands the user last week's page. The same crawl without a cache entry re-fetches it, because that sibling block refuses hypertext. `--sizehack` still skips the transfer for every data file, and an honest server still answers the conditional request with a real 304. What the guard drops is the guess, and it drops it for the file type a reader actually reads.

The second consequence loses the file. Say the mirrored copy no longer has the recorded size, because it was edited by hand or the mirror was rebuilt over an older cache. The forced 304 then sends `cache_read` looking for a file of that size. The entry is refused, and the socket is already closed. The file leaves the mirror and is never re-fetched. The log carries `warning: file size on disk (24) does not have the expected size (16))` and the run reports no errors.

So the block now asks the two questions its siblings ask, and keeps its own cache read on top. One gap stays open, and master has it too. `cache_read` validates the save name the cache recorded, where this block measures the save name in force now. A crawl whose `-N` changed between runs therefore still compares two different files. The change narrows the class rather than closing it.

`tests/417` pins three outcomes: the HTML page must be re-fetched, the drifted file must come back, and the data file must still take the shortcut. That last arm is the one that fails if the option is simply switched off. Crawling with `--footer ''` leaves the mirrored HTML byte-identical to its source. So the HTML arm needs the mime guard, not the change of size source. A second pass re-derived the mutants from the diff. It killed six of seven: each added condition dropped in turn, each inverted in turn, and the whole hunk reverted. No test can kill the seventh, which drops `strnotempty(url_sav)`, because `fsize_utf8` returns -1 on an empty name and the size comparison refuses on its own.

One divergence I found and left alone. The non-update sizehack block omits the `/robots.txt` exclusion its two siblings carry. It sits on a path this change does not touch, and nothing measured it. Folding an unreproduced behavior change into this one would put two claims under one title.

