### PR TITLE
Ten early exits from hts_main_internal free nothing

### DIFF
--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -232,13 +232,10 @@ static void cmdl_print_args(httrackp *opt, const cmdl_argv *cmd) {
   }
 }
 
-/* Every expansion is followed by a return, so nothing reads the command line
-   after this releases it. */
+/* Both halves NULL what they release, so a second expansion is a no-op. */
 #define htsmain_free()                                                         \
   do {                                                                         \
-    if (url != NULL) {                                                         \
-      free(url);                                                               \
-    }                                                                          \
+    freet(url);                                                                \
     cmdl_free(&x_cmd);                                                         \
   } while (0)
 
@@ -477,6 +474,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
             } else if (strcmp(tmp_argv[0], "-#h") == 0) {
               printf("HTTrack version " HTTRACK_VERSION "%s\n",
                      hts_get_version_info(opt));
+              htsmain_free();
               return 0;
             } else {
               if (strncmp(tmp_argv[0], "--", 2)) { /* not a long option */
@@ -733,6 +731,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
           fprintf(opt->log,
                   "Please restart HTTrack with --continue (-iC1) option to override this message!\n");
         }
+        htsmain_free();
         return 0;
       }
     }
@@ -2442,15 +2441,19 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                             (hasFilter) ? " for '" : "",
                             (hasFilter) ? filter : "", (hasFilter) ? "'" : "");
                   }
+                  coucal_delete(&cache_hashtable);
+                  htsmain_free();
                   return 0;
                 }
                 break;
               case 'E':        // extract cache
                 if (!hts_extract_meta(StringBuff(opt->path_log))) {
                   fprintf(stderr, "* error extracting meta-data\n");
+                  htsmain_free();
                   return 1;
                 }
                 fprintf(stderr, "* successfully extracted meta-data\n");
+                htsmain_free();
                 return 0;
                 break;
               case 'X':
@@ -2484,18 +2487,21 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                             fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
                                     StringBuff(opt->path_log),
                                     "hts-cache/new.zip"));
+                    htsmain_free();
                     return 1;
                   }
                   fprintf(stderr, "Cache: trying to repair %s\n", name);
                   why = cache_repair(opt, name, &repaired, &repairedBytes);
                   if (why != NULL) {
                     fprintf(stderr, "Cache: %s\n", why);
+                    htsmain_free();
                     return 1;
                   }
                   fprintf(
                       stderr,
                       "Cache: %d bytes successfully recovered in %d entries\n",
                       (int) repairedBytes, (int) repaired);
+                  htsmain_free();
                 }
                 return 0;
                 break;
@@ -2508,6 +2514,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
               case 'h':
                 printf("HTTrack version " HTTRACK_VERSION "%s\n",
                        hts_get_version_info(opt));
+                htsmain_free();
                 return 0;
                 break;
               case 'p':        /* opt->aff_progress=1; deprecated */
@@ -2567,6 +2574,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                 /* autotest */
               case 't':        /* not yet implemented */
                 fprintf(stderr, "** AUTOCHECK OK\n");
+                htsmain_free();
                 return 0;
                 break;
 

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -2441,6 +2441,8 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                             (hasFilter) ? " for '" : "",
                             (hasFilter) ? filter : "", (hasFilter) ? "'" : "");
                   }
+                  if (cache.zipInput != NULL)
+                    unzClose(cache.zipInput);
                   coucal_delete(&cache_hashtable);
                   htsmain_free();
                   return 0;

--- a/src/htszlib.c
+++ b/src/htszlib.c
@@ -257,6 +257,10 @@ int hts_extract_meta(const char *path) {
     unzClose(zFile);
     return 1;
   }
+  if (zFileOut != NULL)
+    zipClose(zFileOut, NULL);
+  if (zFile != NULL)
+    unzClose(zFile);
   return 0;
 }
 

--- a/tests/283_engine-cmdline-leak.test
+++ b/tests/283_engine-cmdline-leak.test
@@ -53,3 +53,58 @@ bail() { # bail LABEL WANT_RE ARG...
 
 bail 'a rule the grammar refuses' 'Invalid host-alias rule' --host-alias nope
 bail 'an option that does not exist' 'Unknown option' --no-such-option
+
+# The two exits above expand htsmain_free(). Ten more leave hts_main_internal
+# without expanding it, so the same block leaks. Nine of those are driveable
+# from a command line; the tenth, an aborted mirror reported before the crawl,
+# needs a tty, because a non-tty run sets opt->quiet and skips the branch.
+
+# One stored entry and no central directory, which unzRepair rebuilds.
+zip_one_entry() { # zip_one_entry FILE
+    printf 'PK\003\004\024\000\000\000\000\000\000\000\041\000\000\000\000\000\004\000\000\000\004\000\000\000\001\000\000\000xdata' >"$1"
+}
+
+# An end-of-central-directory record alone: opens, holds nothing.
+zip_empty() { # zip_empty FILE
+    printf 'PK\005\006\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000' >"$1"
+}
+
+early() { # early LABEL DIR WANT_RC WANT_RE ARG...
+    local label=$1 dir=$2 want_rc=$3 want=$4
+    shift 4
+    rm -f "$tmp/asan".*
+    printf '[%s] ..\t' "$label"
+    local out rc=0
+    out=$(ASAN_OPTIONS="${asan_base}:log_path=$tmp/asan" \
+        httrack -O "$dir" "$@" "$url" 2>&1) || rc=$?
+    # Teeth: the message pins the handler and the status pins which return ran,
+    # while the missing sign-off proves the run never reached the exit that frees.
+    assert_match "$want" "$out" "$label"
+    assert_eq "$want_rc" "$rc" "$label exit status"
+    if [[ $out =~ Thanks\ for\ using ]]; then
+        fail "$label: reached the end of the run, not the early exit"
+    fi
+    report=$(cat "$tmp/asan".* 2>/dev/null || true)
+    test -z "$report" || {
+        echo "FAIL: $label leaked"
+        echo "$report"
+        exit 1
+    }
+    echo "OK"
+}
+
+for d in noc emptyzip onezip; do
+    mkdir -p "$tmp/$d/hts-cache"
+done
+zip_empty "$tmp/emptyzip/hts-cache/new.zip"
+zip_one_entry "$tmp/onezip/hts-cache/new.zip"
+
+early 'version, before the option switch' "$tmp/noc" 0 'HTTrack version' -#h
+early 'version, from the option switch' "$tmp/noc" 0 'HTTrack version' -q#h
+early 'autocheck' "$tmp/noc" 0 'AUTOCHECK OK' -#t
+early 'cache listing' "$tmp/noc" 0 'No cache entry found' -#C '*'
+early 'meta-data, no cache' "$tmp/noc" 1 'error extracting meta-data' -#E
+early 'meta-data extracted' "$tmp/emptyzip" 0 'successfully extracted meta-data' -#E
+early 'repair, no cache' "$tmp/noc" 1 'no cache found in' -#R
+early 'repair, nothing to recover' "$tmp/emptyzip" 1 'repaired cache holds no entry' -#R
+early 'repair, one entry back' "$tmp/onezip" 0 'recovered in 1 entries' -#R

--- a/tests/283_engine-cmdline-leak.test
+++ b/tests/283_engine-cmdline-leak.test
@@ -32,6 +32,15 @@ asan_base="${ASAN_OPTIONS:+$ASAN_OPTIONS:}detect_leaks=1:abort_on_error=0:exitco
 # The port is never dialled: each run aborts while still parsing options.
 url='http://127.0.0.1:1/'
 
+no_leak() { # no_leak LABEL
+    report=$(cat "$tmp/asan".* 2>/dev/null || true)
+    test -z "$report" || {
+        echo "FAIL: $1 leaked"
+        echo "$report"
+        exit 1
+    }
+}
+
 bail() { # bail LABEL WANT_RE ARG...
     local label=$1 want=$2
     shift 2
@@ -42,12 +51,7 @@ bail() { # bail LABEL WANT_RE ARG...
     # Teeth: a run that never reached the early exit would report clean without
     # exercising the leak.
     assert_match "$want" "$out" "$label"
-    report=$(cat "$tmp/asan".* 2>/dev/null || true)
-    test -z "$report" || {
-        echo "FAIL: $label leaked"
-        echo "$report"
-        exit 1
-    }
+    no_leak "$label"
     echo "OK"
 }
 
@@ -55,9 +59,8 @@ bail 'a rule the grammar refuses' 'Invalid host-alias rule' --host-alias nope
 bail 'an option that does not exist' 'Unknown option' --no-such-option
 
 # The two exits above expand htsmain_free(). Ten more leave hts_main_internal
-# without expanding it, so the same block leaks. Nine of those are driveable
-# from a command line; the tenth, an aborted mirror reported before the crawl,
-# needs a tty, because a non-tty run sets opt->quiet and skips the branch.
+# without expanding it, so the same block leaks. Some of those paths drop a
+# handle of their own on top of it.
 
 # One stored entry and no central directory, which unzRepair rebuilds.
 zip_one_entry() { # zip_one_entry FILE
@@ -74,7 +77,8 @@ early() { # early LABEL DIR WANT_RC WANT_RE ARG...
     shift 4
     rm -f "$tmp/asan".*
     printf '[%s] ..\t' "$label"
-    local out rc=0
+    # $out stays global, so a case can add an assertion of its own.
+    local rc=0
     out=$(ASAN_OPTIONS="${asan_base}:log_path=$tmp/asan" \
         httrack -O "$dir" "$@" "$url" 2>&1) || rc=$?
     # Teeth: the message pins the handler and the status pins which return ran,
@@ -84,12 +88,7 @@ early() { # early LABEL DIR WANT_RC WANT_RE ARG...
     if [[ $out =~ Thanks\ for\ using ]]; then
         fail "$label: reached the end of the run, not the early exit"
     fi
-    report=$(cat "$tmp/asan".* 2>/dev/null || true)
-    test -z "$report" || {
-        echo "FAIL: $label leaked"
-        echo "$report"
-        exit 1
-    }
+    no_leak "$label"
     echo "OK"
 }
 
@@ -102,9 +101,73 @@ zip_one_entry "$tmp/onezip/hts-cache/new.zip"
 early 'version, before the option switch' "$tmp/noc" 0 'HTTrack version' -#h
 early 'version, from the option switch' "$tmp/noc" 0 'HTTrack version' -q#h
 early 'autocheck' "$tmp/noc" 0 'AUTOCHECK OK' -#t
-early 'cache listing' "$tmp/noc" 0 'No cache entry found' -#C '*'
 early 'meta-data, no cache' "$tmp/noc" 1 'error extracting meta-data' -#E
 early 'meta-data extracted' "$tmp/emptyzip" 0 'successfully extracted meta-data' -#E
 early 'repair, no cache' "$tmp/noc" 1 'no cache found in' -#R
 early 'repair, nothing to recover' "$tmp/emptyzip" 1 'repaired cache holds no entry' -#R
 early 'repair, one entry back' "$tmp/onezip" 0 'recovered in 1 entries' -#R
+
+# -#R above left $tmp/onezip holding an archive minizip wrote, so cache_init
+# opens it here. An empty directory would make this case prove nothing.
+early 'cache listing' "$tmp/onezip" 0 'No cache entry found' -#C '*'
+assert_match 'Corrupted cache entry' "$out" 'cache listing opened the cache'
+
+# hts_extract_meta() holds the cache open and the meta-data file it writes, and
+# the no-cache case above leaves only the second one open. Refusing the write
+# makes the first the handle that has to be closed.
+d=$tmp/nometa
+mkdir -p "$d/hts-cache"
+zip_empty "$d/hts-cache/new.zip"
+chmod 555 "$d/hts-cache"
+if : 2>/dev/null >"$d/hts-cache/.writable"; then
+    rm -f "$d/hts-cache/.writable"
+    chmod 755 "$d/hts-cache"
+    echo "the cache dir stayed writable, skipping the refused-output case" >&2
+else
+    early 'meta-data, output refused' "$d" 1 'error extracting meta-data' -#E
+    test ! -e "$d/hts-cache/meta.zip" ||
+        fail 'meta-data, output refused: the meta-data file was written anyway'
+    chmod 755 "$d/hts-cache"
+fi
+
+# Only a run on a terminal reports an aborted mirror, because htscoremain.c sets
+# opt->quiet when stdout is not one. script(1) hands a terminal over, and its two
+# spellings do not overlap, so probe each with a command only a terminal passes.
+tty_form=
+for form in linux bsd; do
+    rm -f "$tmp/ttyprobe"
+    case $form in
+    linux) script -qec 'test -t 1 && echo TTYOK' "$tmp/ttyprobe" >/dev/null 2>&1 || true ;;
+    bsd) script -q "$tmp/ttyprobe" /bin/sh -c 'test -t 1 && echo TTYOK' >/dev/null 2>&1 || true ;;
+    esac
+    if grep -q TTYOK "$tmp/ttyprobe" 2>/dev/null; then
+        tty_form=$form
+        break
+    fi
+done
+
+if [ -z "$tty_form" ]; then
+    echo "no script(1) hands over a terminal here, skipping the aborted-mirror case" >&2
+else
+    d=$tmp/aborted
+    mkdir -p "$d/hts-cache"
+    : >"$d/hts-in_progress.lock"
+    : >"$d/hts-cache/old.dat"
+    : >"$d/hts-cache/old.ndx"
+    rm -f "$tmp/asan".*
+    printf '[%s] ..\t' 'aborted mirror'
+    cmd="ASAN_OPTIONS='${asan_base}:log_path=$tmp/asan' '$(httrack_path)' -O '$d' '$url'"
+    case $tty_form in
+    linux) script -qec "$cmd" "$d/typescript" >/dev/null 2>&1 || true ;;
+    bsd) script -q "$d/typescript" /bin/sh -c "$cmd" >/dev/null 2>&1 || true ;;
+    esac
+    # BSD script(1) reports its own status, not the command's, so the notice and
+    # the missing sign-off carry the teeth here.
+    out=$(cat "$d/typescript")
+    assert_match 'aborted mirror has been detected' "$out" 'aborted mirror'
+    if [[ $out =~ Thanks\ for\ using ]]; then
+        fail 'aborted mirror: reached the end of the run, not the early exit'
+    fi
+    no_leak 'aborted mirror'
+    echo "OK"
+fi


### PR DESCRIPTION
`hts_main_internal()` allocates a 64 KB `url` buffer and a token block for the rebuilt command line, and `htsmain_free()` releases both. Every error exit expands the macro. Ten exits that end the run without an error do not. Under an ASan build, `-#h` reports 98392 bytes leaked in 5 allocations, against a clean `-h`. `-#C`, `-#E`, `-#R` and `-#t` report the same block. Seven of the ten return 0 and three return 1, so what they share is skipping the macro, not the status they exit with.

The macro now expands `freet` instead of raw `free`. The tree's conventions ask for that anyway, and it makes a second expansion a no-op. `cmdl_free()` was already idempotent, and the tail of the function already called it twice.

Four more leaks sit on those same paths, and the macro covers none of them, so they are fixed here. The `-#C` handler never releases the coucal hashtable it builds, nor `cache.zipInput`, the archive `cache_init()` opens, which costs another 352 bytes against a real cache. `hts_extract_meta()` drops the meta-data handle when the cache will not open, and the cache handle when the meta-data file cannot be created.

One leak is left alone. The `-#C` loop calls `cache_read_ro()` per entry and never frees the `r.adr` its caller owns. That loop is gated on `hts-cache/new.ndx`, a legacy index no code in the tree writes any more. No fixture reaches it, and a fix there would ship unexercised.

`tests/283_engine-cmdline-leak.test` was written for this class and could not see it, because both of its cases were error exits. It now drives all ten sites and all four extra leaks. Each case asserts a message only that handler prints, plus the exit status. The closing "Thanks for using HTTrack" line must be absent, which proves the run left early instead of reaching the exit that already frees. Deleting one release at a time reds the test for all fourteen.

Two cases needed a fixture rather than a flag. The aborted-mirror notice is guarded by `!opt->quiet`, and a run whose stdout is not a terminal sets `quiet`. That case therefore goes through `script(1)`. Its util-linux and BSD spellings do not overlap. The test probes both with a command only a terminal passes, and skips the case when neither works. The `-#E` case that has to leave the cache open makes `hts-cache` read-only. It verifies the denial rather than assuming it, and skips when the write still succeeds, as it would for root.

The `-#R`, `-#E` and `-#C` cases that need a cache write their zip with `printf`, which keeps python out of the test.
