### PR TITLE
Test 84 waits for a directory that the profile save already created

### DIFF
--- a/tests/84_webhttrack-mirror-verbatim.test
+++ b/tests/84_webhttrack-mirror-verbatim.test
@@ -71,18 +71,22 @@ htsserver_client --path /step4.html --field "sid=${sid}" --field "path=${work}" 
     --field "command=httrack --quiet --robots=0 http://127.0.0.1:${cport}/trickle/ -O ${work}/crawl" \
     >/dev/null
 
+# The finished state already served /website/, so the probe below has to happen
+# while the crawl runs, or it passes on the unfixed server too. Wait on the pane
+# rather than on the project directory: command_do=start saves the profile first,
+# and the save alone creates that directory, so it appears before the engine runs.
 start=$SECONDS
-while test ! -d "${work}/crawl"; do
-    test "$((SECONDS - start))" -lt 60 || fail "the crawl never created its project"
+while :; do
+    htsserver_client --path /server/index.html >"${work}/pane.txt"
+    if grep -qF 'In progress:' "${work}/pane.txt"; then
+        break
+    fi
+    test "$((SECONDS - start))" -lt 60 ||
+        fail "the crawl never showed as running: $(<"${HTS_LOG}")"
     poll_wait 0.2
 done
+test -d "${work}/crawl" || fail "the crawl is running but created no project"
 cp "${mirror}" "${work}/crawl/hostile.html"
-
-# The finished state already served /website/, so a crawl that ended early would
-# make the check below pass on the unfixed server too.
-htsserver_client --path /server/index.html >"${work}/pane.txt"
-grep -qF 'In progress:' "${work}/pane.txt" ||
-    fail "the crawl ended before the probe, so this proves nothing"
 
 htsserver_client --path /website/hostile.html --head-file "${hdr}" --body-file "${body}"
 grep -q '^HTTP/1\.0 200 ' "${hdr}" ||

--- a/tests/84_webhttrack-mirror-verbatim.test
+++ b/tests/84_webhttrack-mirror-verbatim.test
@@ -71,10 +71,8 @@ htsserver_client --path /step4.html --field "sid=${sid}" --field "path=${work}" 
     --field "command=httrack --quiet --robots=0 http://127.0.0.1:${cport}/trickle/ -O ${work}/crawl" \
     >/dev/null
 
-# The finished state already served /website/, so the probe below has to happen
-# while the crawl runs, or it passes on the unfixed server too. Wait on the pane
-# rather than on the project directory: command_do=start saves the profile first,
-# and the save alone creates that directory, so it appears before the engine runs.
+# command_do=start saves the profile before it starts the engine, and the save alone
+# creates the project directory, so only the pane proves a crawl is really running.
 start=$SECONDS
 while :; do
     htsserver_client --path /server/index.html >"${work}/pane.txt"


### PR DESCRIPTION
`84_webhttrack-mirror-verbatim.test` failed on master's `build (Ubuntu devel, uutils coreutils)` leg with "the crawl ended before the probe, so this proves nothing". The uutils coreutils angle is a red herring, because the assertion greps a file and none of the SIGPIPE differences apply.

The test has to fetch `/website/` while a crawl runs. A finished crawl serves that path too, so the probe would pass on an unfixed server. The test waited for the crawl's project directory to appear, then read the pane once. But `command_do=start` saves the profile before it launches the engine, and the save on its own creates that directory. Sending `command_do=save` alone confirms it. The directory appears, and the pane correctly reports nothing in progress. The wait therefore never proved the engine was running, and a slow start on a loaded runner failed the single read.

It now waits on the pane, which moves only once the engine runs, and dumps the server log if the crawl never shows up. Mutated to never start the engine, the guard still fires.
