### PR TITLE
hdiutil create loses a race on the new macOS runner image

### DIFF
--- a/tools/macos-release.sh
+++ b/tools/macos-release.sh
@@ -168,7 +168,7 @@ ditto "$app" "$stage/$(basename "$app")"
 ln -s /Applications "$stage/Applications"
 rm -f "$dmg"
 # hdiutil attaches the image while it fills it, and that attach loses a race with a
-# previous run's helper often enough to lose a release build, so retry on EBUSY.
+# previous run's helper often enough to lose a release build, so retry a few times.
 attempt=1
 until hdiutil create -volname "HTTrack $name" -srcfolder "$stage" -fs HFS+ -format UDZO "$dmg"; do
     test "$attempt" -lt 4 || fail "hdiutil could not create $dmg"

--- a/tools/macos-release.sh
+++ b/tools/macos-release.sh
@@ -167,7 +167,15 @@ trap 'rm -f "$mach" "$nlog"; rm -rf "$stage"' EXIT
 ditto "$app" "$stage/$(basename "$app")"
 ln -s /Applications "$stage/Applications"
 rm -f "$dmg"
-hdiutil create -volname "HTTrack $name" -srcfolder "$stage" -fs HFS+ -format UDZO "$dmg"
+# hdiutil attaches the image while it fills it, and that attach loses a race with a
+# previous run's helper often enough to lose a release build, so retry on EBUSY.
+attempt=1
+until hdiutil create -volname "HTTrack $name" -srcfolder "$stage" -fs HFS+ -format UDZO "$dmg"; do
+    test "$attempt" -lt 4 || fail "hdiutil could not create $dmg"
+    attempt=$((attempt + 1))
+    rm -f "$dmg"
+    sleep 3
+done
 sign "$dmg"
 
 if [ "$skip_notarize" -eq 0 ]; then


### PR DESCRIPTION
Master's `macOS app bundle (arm64)` leg failed twice tonight at "Pack again under a channel label" with `hdiutil: create failed - Resource busy`. The 62 runs before those were green. The break lines up with the runner image moving to macos-15-arm64 20260829.0321.1. The last green run on the old image was 2026-09-03 18:25, and on the new image the leg has gone red, green, red.

The job runs `tools/macos-release.sh` three times back to back, and the second pack is the one that dies. hdiutil attaches the image while it fills it, and that attach collides with the previous run's helper. The runner then reports an orphan `diskimages-help` process at cleanup.

The same script builds the DMG the release attaches, so this costs a release build and not only a CI leg. It now retries up to four times, and a permanent failure still stops with hdiutil's own message. No Linux-runnable test covers a macOS packaging path, so I proved the loop against a stub hdiutil. It succeeds on the first try, survives three transient failures, and still exits 1 when hdiutil never succeeds.
