### PR TITLE
Measure which workload provokes the Windows runner kill

### DIFF
--- a/.github/workflows/windows-kill-probe.yml
+++ b/.github/workflows/windows-kill-probe.yml
@@ -1,0 +1,146 @@
+# Which half of the suite's workload provokes the runner kill (#1228): MSYS
+# process creation, loopback socket churn, or only the two together. Three
+# synthetic arms, no engine and no build, each spending the same event budget on
+# a different kind of event. The live windows-build suite is the positive
+# control at ~5% of uncensored jobs, so this workflow does not rerun it.
+name: windows-kill-probe
+
+on:
+  # Hourly: the effect being measured is a few percent, so the sample size is
+  # the whole design.
+  schedule:
+    - cron: "23 * * * *"
+  workflow_dispatch:
+    inputs:
+      events:
+        description: "Event budget per arm"
+        default: "24000"
+      seconds:
+        description: "Wall-clock budget per arm"
+        default: "600"
+  # A PR touching the probe runs it at a smoke dose, to prove the arms spend
+  # anything at all before an hourly cron starts trusting them.
+  pull_request:
+    paths:
+      - ".github/workflows/windows-kill-probe.yml"
+      - "tools/kill-probe-arm.sh"
+      - "tools/kill-probe-report.sh"
+
+permissions:
+  contents: read
+
+# Not cancel-in-progress: a superseded run is a sample, and a cancelled job is
+# censored exposure that has to be dropped from the census (#1228).
+concurrency:
+  group: windows-kill-probe-${{ github.ref }}-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  window:
+    name: experiment window
+    runs-on: ubuntu-24.04
+    outputs:
+      open: ${{ steps.check.outputs.open }}
+    steps:
+      # An hourly cron nobody remembers is the failure mode here, so the arms
+      # stop themselves. Move the date to extend the experiment.
+      - id: check
+        env:
+          PROBE_UNTIL: "2026-10-06"
+        run: |
+          set -euo pipefail
+          today=$(date -u +%F)
+          if [[ "$today" > "$PROBE_UNTIL" ]]; then
+            echo "the probe window closed on $PROBE_UNTIL"
+            echo "open=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "open=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  probe:
+    name: probe (${{ matrix.arm }})
+    needs: window
+    if: needs.window.outputs.open == 'true'
+    runs-on: windows-2022
+    # Well past the dose: a job that outlives this is the wedge under study, and
+    # the runner's own 45-minute step cap is what times it out.
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        # forks: MSYS process creation alone. sockets: loopback connections
+        # alone, made from pwsh so no MSYS process exists. both: one process and
+        # one connection per iteration, the suite's own shape.
+        arm: [forks, sockets, both]
+    env:
+      PROBE_EVENTS: ${{ github.event_name == 'pull_request' && '400' || inputs.events || '24000' }}
+      PROBE_SECONDS: ${{ github.event_name == 'pull_request' && '60' || inputs.seconds || '600' }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      # The suite's own server, so the connection the arm makes is the one the
+      # crawl tests make.
+      - name: Start the loopback server
+        if: matrix.arm != 'forks'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $root = "$env:RUNNER_TEMP\probe-root"
+          New-Item -ItemType Directory -Force -Path $root | Out-Null
+          Set-Content -Path "$root\index.html" -Value "<html><body>probe</body></html>"
+          $out = "$env:RUNNER_TEMP\server.out"
+          Start-Process -FilePath python `
+            -ArgumentList @("tests/local-server.py", "--root", $root) `
+            -PassThru -RedirectStandardOutput $out `
+            -RedirectStandardError "$env:RUNNER_TEMP\server.err" | Out-Null
+          $port = $null
+          foreach ($i in 1..60) {
+            if (Test-Path $out) {
+              $m = Select-String -Path $out -Pattern '^PORT (\d+)' | Select-Object -First 1
+              if ($m) { $port = $m.Matches[0].Groups[1].Value; break }
+            }
+            Start-Sleep -Milliseconds 500
+          }
+          if (-not $port) { throw "the loopback server never announced a port" }
+          "PROBE_PORT=$port" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Spend the dose
+        if: matrix.arm != 'sockets'
+        shell: bash
+        run: |
+          bash tools/kill-probe-arm.sh "${{ matrix.arm }}" \
+            "$PROBE_EVENTS" "$PROBE_SECONDS" "${PROBE_PORT:-}"
+
+      # pwsh, so the connections come from a native process and the MSYS fork
+      # path is absent. Paced, unlike the bash arms: nothing here throttles the
+      # loop, and a flat-out run would exhaust the ephemeral range and measure
+      # its own port starvation instead of the runner.
+      - name: Spend the dose (sockets)
+        if: matrix.arm == 'sockets'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $budget = [int]$env:PROBE_EVENTS
+          $rate = 40
+          $deadline = (Get-Date).AddSeconds([int]$env:PROBE_SECONDS)
+          $req = [Text.Encoding]::ASCII.GetBytes("GET / HTTP/1.0`r`nHost: 127.0.0.1`r`n`r`n")
+          $began = Get-Date
+          $conns = 0
+          $errors = 0
+          while ($conns -lt $budget -and (Get-Date) -lt $deadline) {
+            try {
+              $c = [Net.Sockets.TcpClient]::new("127.0.0.1", [int]$env:PROBE_PORT)
+              $s = $c.GetStream()
+              $s.Write($req, 0, $req.Length)
+              $s.ReadByte() | Out-Null
+              $c.Close()
+            } catch { $errors++ }
+            $conns++
+            $ahead = $conns / $rate - ((Get-Date) - $began).TotalSeconds
+            if ($ahead -gt 0) { Start-Sleep -Milliseconds ([int]($ahead * 1000)) }
+          }
+          $elapsed = [int]((Get-Date) - $began).TotalSeconds
+          "arm=sockets procs=0 conns=$conns errors=$errors elapsed=${elapsed}s"
+          if ($errors -gt $budget / 20) { throw "$errors of $conns connections failed: dose not delivered" }

--- a/.github/workflows/windows-kill-probe.yml
+++ b/.github/workflows/windows-kill-probe.yml
@@ -1,13 +1,9 @@
-# Which half of the suite's workload provokes the runner kill (#1228): MSYS
-# process creation, loopback socket churn, or only the two together. Three
-# synthetic arms, no engine and no build, each spending the same event budget on
-# a different kind of event. The live windows-build suite is the positive
-# control at ~5% of uncensored jobs, so this workflow does not rerun it.
+# A/B probe for the runner kill (#1228): forks alone, loopback connections alone,
+# or one of each, against the live windows-build suite as the control.
 name: windows-kill-probe
 
 on:
-  # Hourly: the effect being measured is a few percent, so the sample size is
-  # the whole design.
+  # Hourly, because the effect is a few percent and the sample size is the design.
   schedule:
     - cron: "23 * * * *"
   workflow_dispatch:
@@ -18,19 +14,20 @@ on:
       seconds:
         description: "Wall-clock budget per arm"
         default: "600"
-  # A PR touching the probe runs it at a smoke dose, to prove the arms spend
-  # anything at all before an hourly cron starts trusting them.
+  # A PR touching these files runs the arms at a smoke dose, to prove they spend
+  # anything before an hourly cron trusts them.
   pull_request:
     paths:
       - ".github/workflows/windows-kill-probe.yml"
       - "tools/kill-probe-arm.sh"
+      - "tools/kill-probe-arm.ps1"
       - "tools/kill-probe-report.sh"
 
 permissions:
   contents: read
 
 # Not cancel-in-progress: a superseded run is a sample, and a cancelled job is
-# censored exposure that has to be dropped from the census (#1228).
+# censored exposure the census has to drop (#1228).
 concurrency:
   group: windows-kill-probe-${{ github.ref }}-${{ github.run_id }}
   cancel-in-progress: false
@@ -42,8 +39,9 @@ jobs:
     outputs:
       open: ${{ steps.check.outputs.open }}
     steps:
-      # An hourly cron nobody remembers is the failure mode here, so the arms
-      # stop themselves. Move the date to extend the experiment.
+      # An hourly cron nobody remembers is the failure mode, so the Windows arms
+      # stop themselves. Move the date to extend the experiment, delete the
+      # workflow to end it.
       - id: check
         env:
           PROBE_UNTIL: "2026-10-06"
@@ -63,14 +61,18 @@ jobs:
     if: needs.window.outputs.open == 'true'
     runs-on: windows-2022
     # Well past the dose: a job that outlives this is the wedge under study, and
-    # the runner's own 45-minute step cap is what times it out.
+    # the runner's own step cap is what ends it.
     timeout-minutes: 25
     strategy:
       fail-fast: false
+      # One arm at a time. The account's job pool is shared and already queues,
+      # so three concurrent Windows jobs an hour would cost the control arm
+      # samples, and the control is the live windows-build suite.
+      max-parallel: 1
       matrix:
         # forks: MSYS process creation alone. sockets: loopback connections
-        # alone, made from pwsh so no MSYS process exists. both: one process and
-        # one connection per iteration, the suite's own shape.
+        # alone, made from PowerShell, so no MSYS process exists. both: one
+        # process and one connection per iteration, the suite's own shape.
         arm: [forks, sockets, both]
     env:
       PROBE_EVENTS: ${{ github.event_name == 'pull_request' && '400' || inputs.events || '24000' }}
@@ -80,67 +82,24 @@ jobs:
         with:
           persist-credentials: false
 
-      # The suite's own server, so the connection the arm makes is the one the
-      # crawl tests make.
-      - name: Start the loopback server
-        if: matrix.arm != 'forks'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          $root = "$env:RUNNER_TEMP\probe-root"
-          New-Item -ItemType Directory -Force -Path $root | Out-Null
-          Set-Content -Path "$root\index.html" -Value "<html><body>probe</body></html>"
-          $out = "$env:RUNNER_TEMP\server.out"
-          Start-Process -FilePath python `
-            -ArgumentList @("tests/local-server.py", "--root", $root) `
-            -PassThru -RedirectStandardOutput $out `
-            -RedirectStandardError "$env:RUNNER_TEMP\server.err" | Out-Null
-          $port = $null
-          foreach ($i in 1..60) {
-            if (Test-Path $out) {
-              $m = Select-String -Path $out -Pattern '^PORT (\d+)' | Select-Object -First 1
-              if ($m) { $port = $m.Matches[0].Groups[1].Value; break }
-            }
-            Start-Sleep -Milliseconds 500
-          }
-          if (-not $port) { throw "the loopback server never announced a port" }
-          "PROBE_PORT=$port" | Out-File -FilePath $env:GITHUB_ENV -Append
-
       - name: Spend the dose
         if: matrix.arm != 'sockets'
         shell: bash
-        run: |
-          bash tools/kill-probe-arm.sh "${{ matrix.arm }}" \
-            "$PROBE_EVENTS" "$PROBE_SECONDS" "${PROBE_PORT:-}"
+        run: bash tools/kill-probe-arm.sh "${{ matrix.arm }}"
 
-      # pwsh, so the connections come from a native process and the MSYS fork
-      # path is absent. Paced, unlike the bash arms: nothing here throttles the
-      # loop, and a flat-out run would exhaust the ephemeral range and measure
-      # its own port starvation instead of the runner.
       - name: Spend the dose (sockets)
         if: matrix.arm == 'sockets'
         shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          $budget = [int]$env:PROBE_EVENTS
-          $rate = 40
-          $deadline = (Get-Date).AddSeconds([int]$env:PROBE_SECONDS)
-          $req = [Text.Encoding]::ASCII.GetBytes("GET / HTTP/1.0`r`nHost: 127.0.0.1`r`n`r`n")
-          $began = Get-Date
-          $conns = 0
-          $errors = 0
-          while ($conns -lt $budget -and (Get-Date) -lt $deadline) {
-            try {
-              $c = [Net.Sockets.TcpClient]::new("127.0.0.1", [int]$env:PROBE_PORT)
-              $s = $c.GetStream()
-              $s.Write($req, 0, $req.Length)
-              $s.ReadByte() | Out-Null
-              $c.Close()
-            } catch { $errors++ }
-            $conns++
-            $ahead = $conns / $rate - ((Get-Date) - $began).TotalSeconds
-            if ($ahead -gt 0) { Start-Sleep -Milliseconds ([int]($ahead * 1000)) }
-          }
-          $elapsed = [int]((Get-Date) - $began).TotalSeconds
-          "arm=sockets procs=0 conns=$conns errors=$errors elapsed=${elapsed}s"
-          if ($errors -gt $budget / 20) { throw "$errors of $conns connections failed: dose not delivered" }
+        run: pwsh -File tools/kill-probe-arm.ps1
+
+      # An arm that failed to spend its dose is diagnosable only from the
+      # server's own log, and a lost runner uploads nothing at all.
+      - name: Upload the arm logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: kill-probe-${{ matrix.arm }}
+          path: |
+            ${{ runner.temp }}/probe-server.log
+            ${{ runner.temp }}/probe-server.err
+          if-no-files-found: ignore

--- a/tools/kill-probe-arm.ps1
+++ b/tools/kill-probe-arm.ps1
@@ -1,0 +1,70 @@
+# Sockets arm of the Windows runner-kill probe (#1228): loopback connections
+# with no MSYS process anywhere, so the dose differs from tools/kill-probe-arm.sh
+# in kind and not in size.
+$ErrorActionPreference = "Stop"
+
+$budget = [int]$env:PROBE_EVENTS
+$seconds = [int]$env:PROBE_SECONDS
+if ($budget -le 0 -or $seconds -le 0) { throw "PROBE_EVENTS and PROBE_SECONDS must be set" }
+
+# Started here, not in an earlier step: a background process on a Windows runner
+# does not survive the step that started it.
+$root = "$env:RUNNER_TEMP\probe-root"
+New-Item -ItemType Directory -Force -Path $root | Out-Null
+Set-Content -Path "$root\index.html" -Value "<html>probe</html>"
+$log = "$env:RUNNER_TEMP\probe-server.log"
+$server = Start-Process -FilePath python -PassThru `
+    -ArgumentList @("tests/local-server.py", "--root", $root) `
+    -RedirectStandardOutput $log -RedirectStandardError "$env:RUNNER_TEMP\probe-server.err"
+$port = $null
+foreach ($i in 1..60) {
+    if (Test-Path $log) {
+        $m = Select-String -Path $log -Pattern '^PORT (\d+)' | Select-Object -First 1
+        if ($m) { $port = [int]$m.Matches[0].Groups[1].Value; break }
+    }
+    if ($server.HasExited) { break }
+    Start-Sleep -Milliseconds 500
+}
+if (-not $port) { throw "the loopback server never announced a port" }
+
+# Paced, unlike the bash arms: nothing here throttles the loop, and a flat-out
+# run would exhaust the ephemeral range and measure its own port starvation.
+$rate = 40
+$req = [Text.Encoding]::ASCII.GetBytes("GET / HTTP/1.0`r`nHost: 127.0.0.1`r`n`r`n")
+$began = Get-Date
+$deadline = $began.AddSeconds($seconds)
+$conns = 0
+$errors = 0
+try {
+    while ($conns -lt $budget -and (Get-Date) -lt $deadline) {
+        $c = $null
+        try {
+            # Bounded on every leg: an unbounded read parks the step until the job
+            # times out, which the census would then read as a lost runner.
+            $c = [Net.Sockets.TcpClient]::new()
+            if (-not $c.ConnectAsync("127.0.0.1", $port).Wait(5000)) { throw "connect timed out" }
+            $s = $c.GetStream()
+            $s.WriteTimeout = 5000
+            $s.ReadTimeout = 5000
+            $s.Write($req, 0, $req.Length)
+            $s.ReadByte() | Out-Null
+        } catch {
+            $errors++
+        } finally {
+            if ($c) { $c.Dispose() }
+        }
+        $conns++
+        $ahead = $conns / $rate - ((Get-Date) - $began).TotalSeconds
+        if ($ahead -gt 0) { Start-Sleep -Milliseconds ([int]($ahead * 1000)) }
+    }
+} finally {
+    if (-not $server.HasExited) { Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue }
+}
+
+$elapsed = [int]((Get-Date) - $began).TotalSeconds
+"arm=sockets procs=0 conns=$conns errors=$errors attempts=$conns elapsed=${elapsed}s"
+# Against attempts, never against the budget: a failure that is slow spends few
+# events, so a budget-relative tolerance passes an arm where everything failed.
+if ($conns -eq 0 -or $errors -gt $conns / 20) {
+    throw "$errors of $conns attempts failed: dose not delivered"
+}

--- a/tools/kill-probe-arm.sh
+++ b/tools/kill-probe-arm.sh
@@ -1,26 +1,55 @@
 #!/bin/bash
 #
-# One arm of the Windows runner-kill probe (#1228). Spends an event budget on
-# MSYS process creation, on loopback connections, or on both, then reports what
-# it spent. The kill rate per arm is the readout; this side only has to make the
-# dose, and to make it countable.
+# Bash arms of the Windows runner-kill probe (#1228): spend MSYS process
+# creations, or one process and one loopback connection per iteration, and
+# report what was spent. tools/kill-probe-arm.ps1 is the sockets arm.
 set -euo pipefail
 
-usage() {
-    echo "usage: $0 forks|both <events> <seconds> [port]" >&2
-    exit 2
-}
-
-arm=${1-}
-events=${2-}
-seconds=${3-}
-port=${4-}
+arm=${1:-}
+events=${PROBE_EVENTS:-}
+seconds=${PROBE_SECONDS:-}
 if [ -z "$arm" ] || [ -z "$events" ] || [ -z "$seconds" ]; then
-    usage
+    echo "usage: PROBE_EVENTS=n PROBE_SECONDS=n $0 forks|both" >&2
+    exit 2
 fi
+
+testdir=$(cd "$(dirname "${BASH_SOURCE[0]}")/../tests" && pwd)
+srvpid=
+srvlog=
+
+cleanup() {
+    set +e
+    test -n "$srvpid" && kill "$srvpid" 2>/dev/null
+}
+trap cleanup EXIT
+
+# The server lives in this process, not in an earlier step: a background process
+# on a Windows runner does not survive the step that started it.
+start_server() {
+    local root=$TMPDIR/probe-root port
+    srvlog=$TMPDIR/probe-server.log
+    mkdir -p "$root"
+    echo '<html>probe</html>' >"$root/index.html"
+    python "$testdir/local-server.py" --root "$root" >"$srvlog" 2>&1 &
+    srvpid=$!
+    for _ in $(seq 60); do
+        port=$(sed -n 's/^PORT \([0-9][0-9]*\).*/\1/p' "$srvlog" | head -1)
+        test -n "$port" && break
+        kill -0 "$srvpid" 2>/dev/null || break
+        sleep 0.5
+    done
+    test -n "$port" || {
+        echo "the loopback server never announced a port: $(cat "$srvlog")" >&2
+        exit 1
+    }
+    echo "$port"
+}
 
 # type -P, not command -v: `true` is a builtin, and a builtin creates no process.
 spawn=$(type -P true) || spawn=
+# System32 wins the image PATH, so this is the native curl. The connection is
+# native Winsock either way; what the arm is spending is the MSYS spawn around it,
+# which is the shape the suite makes when it launches httrack.exe.
 client=$(type -P curl) || client=
 
 began=$SECONDS
@@ -30,8 +59,8 @@ errors=0
 
 case $arm in
 forks)
-    [ -n "$spawn" ] || {
-        echo "no true(1) on PATH: the fork arm would measure nothing" >&2
+    test -n "$spawn" || {
+        echo "no true(1) on PATH: the fork arm would spend nothing" >&2
         exit 1
     }
     while [ "$procs" -lt "$events" ] && [ $((SECONDS - began)) -lt "$seconds" ]; do
@@ -40,14 +69,13 @@ forks)
     done
     ;;
 both)
-    [ -n "$client" ] || {
-        echo "no curl(1) on PATH: the combined arm would measure nothing" >&2
+    test -n "$client" || {
+        echo "no curl(1) on PATH: the combined arm would spend nothing" >&2
         exit 1
     }
-    [ -n "$port" ] || usage
-    # One process and one connection per iteration, which is the shape the suite
-    # makes when it spawns httrack.exe. No pacing: the MSYS spawn is the slow
-    # part, and it holds the rate below what would exhaust the ephemeral range.
+    port=$(start_server)
+    # Unpaced, unlike the sockets arm: the MSYS spawn is the slow part and it
+    # holds the rate well under what would exhaust the ephemeral range.
     while [ "$conns" -lt "$events" ] && [ $((SECONDS - began)) -lt "$seconds" ]; do
         "$client" -s -o /dev/null --max-time 10 "http://127.0.0.1:$port/" ||
             errors=$((errors + 1))
@@ -56,16 +84,18 @@ both)
     done
     ;;
 *)
-    usage
+    echo "unknown arm: $arm" >&2
+    exit 2
     ;;
 esac
 
 elapsed=$((SECONDS - began))
-echo "arm=$arm procs=$procs conns=$conns errors=$errors elapsed=${elapsed}s"
+attempts=$((procs > conns ? procs : conns))
+echo "arm=$arm procs=$procs conns=$conns errors=$errors attempts=$attempts elapsed=${elapsed}s"
 
-# An arm that mostly failed to spend its dose is not a null result about the
-# runner, so say so rather than reporting a clean job.
-[ "$errors" -le $((events / 20)) ] || {
-    echo "$errors of $((procs > conns ? procs : conns)) events failed: dose not delivered" >&2
+# Against attempts, never against the budget: a failure that is slow spends few
+# events, so a budget-relative tolerance passes an arm where everything failed.
+if [ "$attempts" -eq 0 ] || [ "$errors" -gt $((attempts / 20)) ]; then
+    echo "$errors of $attempts attempts failed: dose not delivered" >&2
     exit 1
-}
+fi

--- a/tools/kill-probe-arm.sh
+++ b/tools/kill-probe-arm.sh
@@ -14,6 +14,10 @@ if [ -z "$arm" ] || [ -z "$events" ] || [ -z "$seconds" ]; then
 fi
 
 testdir=$(cd "$(dirname "${BASH_SOURCE[0]}")/../tests" && pwd)
+# For find_python only. Sourcing testlib defines functions and sets variables,
+# and installs no trap.
+# shellcheck source=tests/testlib.sh
+. "$testdir/testlib.sh"
 srvpid=
 srvlog=
 
@@ -26,11 +30,22 @@ trap cleanup EXIT
 # The server lives in this process, not in an earlier step: a background process
 # on a Windows runner does not survive the step that started it.
 start_server() {
-    local root=$TMPDIR/probe-root port
-    srvlog=$TMPDIR/probe-server.log
+    local root port tmp
+    # RUNNER_TEMP is where the workflow collects the logs, and Git Bash leaves
+    # TMPDIR unset, which errexit turns into a failure before anything runs.
+    tmp=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
+    command -v cygpath >/dev/null 2>&1 && tmp=$(cygpath -u "$tmp")
+    root=$tmp/probe-root
+    srvlog=$tmp/probe-server.log
     mkdir -p "$root"
     echo '<html>probe</html>' >"$root/index.html"
-    python "$testdir/local-server.py" --root "$root" >"$srvlog" 2>&1 &
+    local py
+    py=$(find_python) || {
+        echo "no python3: the combined arm has no server to connect to" >&2
+        exit 1
+    }
+    "$py" "$(nativepath "$testdir/local-server.py")" --root "$(nativepath "$root")" \
+        >"$srvlog" 2>&1 &
     srvpid=$!
     for _ in $(seq 60); do
         port=$(sed -n 's/^PORT \([0-9][0-9]*\).*/\1/p' "$srvlog" | head -1)

--- a/tools/kill-probe-arm.sh
+++ b/tools/kill-probe-arm.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# One arm of the Windows runner-kill probe (#1228). Spends an event budget on
+# MSYS process creation, on loopback connections, or on both, then reports what
+# it spent. The kill rate per arm is the readout; this side only has to make the
+# dose, and to make it countable.
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 forks|both <events> <seconds> [port]" >&2
+    exit 2
+}
+
+arm=${1-}
+events=${2-}
+seconds=${3-}
+port=${4-}
+if [ -z "$arm" ] || [ -z "$events" ] || [ -z "$seconds" ]; then
+    usage
+fi
+
+# type -P, not command -v: `true` is a builtin, and a builtin creates no process.
+spawn=$(type -P true) || spawn=
+client=$(type -P curl) || client=
+
+began=$SECONDS
+procs=0
+conns=0
+errors=0
+
+case $arm in
+forks)
+    [ -n "$spawn" ] || {
+        echo "no true(1) on PATH: the fork arm would measure nothing" >&2
+        exit 1
+    }
+    while [ "$procs" -lt "$events" ] && [ $((SECONDS - began)) -lt "$seconds" ]; do
+        "$spawn" || errors=$((errors + 1))
+        procs=$((procs + 1))
+    done
+    ;;
+both)
+    [ -n "$client" ] || {
+        echo "no curl(1) on PATH: the combined arm would measure nothing" >&2
+        exit 1
+    }
+    [ -n "$port" ] || usage
+    # One process and one connection per iteration, which is the shape the suite
+    # makes when it spawns httrack.exe. No pacing: the MSYS spawn is the slow
+    # part, and it holds the rate below what would exhaust the ephemeral range.
+    while [ "$conns" -lt "$events" ] && [ $((SECONDS - began)) -lt "$seconds" ]; do
+        "$client" -s -o /dev/null --max-time 10 "http://127.0.0.1:$port/" ||
+            errors=$((errors + 1))
+        procs=$((procs + 1))
+        conns=$((conns + 1))
+    done
+    ;;
+*)
+    usage
+    ;;
+esac
+
+elapsed=$((SECONDS - began))
+echo "arm=$arm procs=$procs conns=$conns errors=$errors elapsed=${elapsed}s"
+
+# An arm that mostly failed to spend its dose is not a null result about the
+# runner, so say so rather than reporting a clean job.
+[ "$errors" -le $((events / 20)) ] || {
+    echo "$errors of $((procs > conns ? procs : conns)) events failed: dose not delivered" >&2
+    exit 1
+}

--- a/tools/kill-probe-report.sh
+++ b/tools/kill-probe-report.sh
@@ -6,6 +6,10 @@ set -euo pipefail
 
 repo=xroche/httrack
 since=
+# GitHub drops a job's step records after about a week, and the wedge signature
+# lives in them. Past that age a kill is recognised by its runtime instead: the
+# runner lease reaps a lost job at ~45 min, where a real failure ends in ~15.
+reaped_minutes=40
 
 usage() {
     echo "usage: $0 [--repo OWNER/NAME] [--since YYYY-MM-DD]" >&2
@@ -29,40 +33,55 @@ done
     'import datetime; print(datetime.date.today() - datetime.timedelta(days=7))')
 
 # filter=all, or a rerun hides the killed attempt and the census reads ~40% low
-# (#1228). A killed job keeps no log and no artifact, so the step records are the
-# whole evidence: the runner dies mid-step, leaving that step's conclusion null
-# where a test failure leaves "failure". $2 is the event filter, which keeps the
+# (#1228). A killed job keeps no log and no artifact, so what survives is the job
+# record: an unfinished step, or no steps at all once they age out, or a job the
+# run left behind with no conclusion. $2 is the event filter, which keeps the
 # probe's smoke-dose PR jobs out of its scheduled full-dose census.
 census() {
-    local wf=$1 event=${2:-} runs id filter=()
+    local wf=$1 event=${2:-} runs id filter=() total
     test -n "$event" && filter=(-f "event=$event")
-    # A 404 is the probe before its first run, not an error worth losing the
-    # control row over.
-    runs=$(gh api --paginate -X GET "repos/$repo/actions/workflows/$wf/runs" \
-        -f "created=>=$since" -f per_page=100 "${filter[@]}" \
-        -q '.workflow_runs[] | select(.status == "completed") | .id') || {
+    total=$(gh api -X GET "repos/$repo/actions/workflows/$wf/runs" \
+        -f "created=>=$since" -f per_page=1 "${filter[@]}" -q .total_count 2>/dev/null) || {
         echo "no runs of $wf in $repo" >&2
         return 0
     }
+    # The run listing caps at 1000 and serves newest first, so a wider window
+    # drops its own oldest end without saying so.
+    if [ "$total" -gt 1000 ]; then
+        echo "$wf: $total runs since $since, only the newest 1000 are readable" >&2
+    fi
+    runs=$(gh api --paginate -X GET "repos/$repo/actions/workflows/$wf/runs" \
+        -f "created=>=$since" -f per_page=100 "${filter[@]}" \
+        -q '.workflow_runs[] | select(.status == "completed") | .id')
     for id in $runs; do
         gh api "repos/$repo/actions/runs/$id/jobs?filter=all&per_page=100" -q \
-            '.jobs[] | select(.status == "completed") | [.name, .conclusion,
-             ((.steps // []) | map(select(.conclusion == null)) | length)] | @tsv'
+            '.jobs[] | [.name, (.conclusion // "none"),
+             ((.steps // []) | map(select(.conclusion == null)) | length),
+             ((.steps // []) | length),
+             (if .completed_at and .started_at
+              then (((.completed_at | fromdate) - (.started_at | fromdate)) / 60 | floor)
+              else -1 end)] | @tsv'
     done
 }
 
-# Columns: job name, conclusion, count of steps the runner never finished. A kill
-# is a job that did not succeed and left a step unfinished; a cancelled job is
-# censored exposure, so it counts in neither column.
-# Wilson, not the normal approximation: at a handful of kills in a few dozen
-# jobs the latter puts the bound below zero and reads as certainty.
+# Columns: job name, conclusion, unfinished steps, step count, runtime in
+# minutes. A cancelled job is censored exposure and counts in neither column.
+# Wilson, not the normal approximation: at a handful of kills in a few dozen jobs
+# the latter puts the bound below zero and reads as certainty.
 report() {
-    awk -F'\t' '
+    awk -F'\t' -v reaped="$reaped_minutes" '
         $2 == "cancelled" { censored[$1]++; next }
-        { jobs[$1]++; if ($2 != "success" && $3 > 0) kills[$1]++ }
+        {
+            jobs[$1]++
+            if ($2 == "success") next
+            if ($3 > 0) { kills[$1]++; next }
+            # No steps left to read, so fall back to the runtime. A job the run
+            # abandoned has no runtime at all, and that is the same wedge.
+            if ($4 == 0 && ($5 < 0 || $5 >= reaped)) { kills[$1]++; aged[$1]++ }
+        }
         END {
-            printf "%-34s %6s %6s %8s %17s %10s\n",
-                "job", "jobs", "kills", "rate", "95% CI", "cancelled"
+            printf "%-34s %6s %6s %8s %17s %10s %8s\n",
+                "job", "jobs", "kills", "rate", "95% CI", "cancelled", "by age"
             for (k in jobs) {
                 n = jobs[k]; x = kills[k] + 0; p = x / n; z = 1.96
                 d = 1 + z * z / n
@@ -70,8 +89,8 @@ report() {
                 w = z * sqrt(p * (1 - p) / n + z * z / (4 * n * n)) / d
                 lo = c - w; hi = c + w
                 if (lo < 0) lo = 0
-                printf "%-34s %6d %6d %7.1f%% %8.1f%% - %5.1f%% %9d\n",
-                    k, n, x, 100 * p, 100 * lo, 100 * hi, censored[k] + 0
+                printf "%-34s %6d %6d %7.1f%% %8.1f%% - %5.1f%% %9d %8d\n",
+                    k, n, x, 100 * p, 100 * lo, 100 * hi, censored[k] + 0, aged[k] + 0
             }
         }' | (read -r header && echo "$header" && sort)
 }

--- a/tools/kill-probe-report.sh
+++ b/tools/kill-probe-report.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# Census for the Windows runner-kill probe (#1228): the kill rate per arm, with
+# the live windows-build suite as the positive control. A run of the probe that
+# shows no kill in the control arm measures nothing, so the control is printed
+# beside the arms rather than remembered.
+set -euo pipefail
+
+repo=xroche/httrack
+since=
+
+usage() {
+    echo "usage: $0 [--repo OWNER/NAME] [--since YYYY-MM-DD]" >&2
+    exit 2
+}
+
+while [ $# -gt 0 ]; do
+    case $1 in
+    --repo)
+        repo=${2:?}
+        shift 2
+        ;;
+    --since)
+        since=${2:?}
+        shift 2
+        ;;
+    *) usage ;;
+    esac
+done
+[ -n "$since" ] || since=$(python3 -c \
+    'import datetime; print(datetime.date.today() - datetime.timedelta(days=7))')
+
+# filter=all, or a rerun hides the killed attempt and the census reads ~40% low
+# (#1228). A killed job keeps no log and no artifact, so the step records are
+# the whole evidence: the runner dies mid-step, leaving that step's conclusion
+# null where a test failure leaves "failure".
+census() {
+    local wf=$1 runs id
+    # A 404 is the probe before its first run, not an error worth losing the
+    # control row over.
+    runs=$(gh api --paginate -X GET "repos/$repo/actions/workflows/$wf/runs" \
+        -f "created=>=$since" -f per_page=100 \
+        -q '.workflow_runs[] | select(.status == "completed") | .id') || {
+        echo "no runs of $wf in $repo" >&2
+        return 0
+    }
+    for id in $runs; do
+        gh api "repos/$repo/actions/runs/$id/jobs?filter=all&per_page=100" -q \
+            '.jobs[] | select(.status == "completed") | [.name, .conclusion,
+             ((.steps // []) | map(select(.conclusion == null)) | length)] | @tsv'
+    done
+}
+
+# Wilson, not the normal approximation: at a handful of kills in a few dozen
+# jobs the latter puts the bound below zero and reads as certainty.
+report() {
+    awk -F'\t' '
+        $2 == "cancelled" { censored[$1]++; next }
+        { jobs[$1]++; if ($2 != "success" && $3 > 0) kills[$1]++ }
+        END {
+            printf "%-34s %6s %6s %8s %17s %10s\n",
+                "job", "jobs", "kills", "rate", "95% CI", "cancelled"
+            for (k in jobs) {
+                n = jobs[k]; x = kills[k] + 0; p = x / n; z = 1.96
+                d = 1 + z * z / n
+                c = (p + z * z / (2 * n)) / d
+                w = z * sqrt(p * (1 - p) / n + z * z / (4 * n * n)) / d
+                lo = c - w; hi = c + w
+                if (lo < 0) lo = 0
+                printf "%-34s %6d %6d %7.1f%% %8.1f%% - %5.1f%% %9d\n",
+                    k, n, x, 100 * p, 100 * lo, 100 * hi, censored[k] + 0
+            }
+        }' | (read -r header && echo "$header" && sort)
+}
+
+echo "window: $since .. today, repo $repo"
+echo
+{
+    census windows-kill-probe.yml
+    census windows-build.yml
+} | report

--- a/tools/kill-probe-report.sh
+++ b/tools/kill-probe-report.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 #
-# Census for the Windows runner-kill probe (#1228): the kill rate per arm, with
-# the live windows-build suite as the positive control. A run of the probe that
-# shows no kill in the control arm measures nothing, so the control is printed
-# beside the arms rather than remembered.
+# Kill-rate census per arm (#1228), with windows-build as the control, because a
+# window whose control shows no kill measures nothing.
 set -euo pipefail
 
 repo=xroche/httrack
@@ -31,15 +29,17 @@ done
     'import datetime; print(datetime.date.today() - datetime.timedelta(days=7))')
 
 # filter=all, or a rerun hides the killed attempt and the census reads ~40% low
-# (#1228). A killed job keeps no log and no artifact, so the step records are
-# the whole evidence: the runner dies mid-step, leaving that step's conclusion
-# null where a test failure leaves "failure".
+# (#1228). A killed job keeps no log and no artifact, so the step records are the
+# whole evidence: the runner dies mid-step, leaving that step's conclusion null
+# where a test failure leaves "failure". $2 is the event filter, which keeps the
+# probe's smoke-dose PR jobs out of its scheduled full-dose census.
 census() {
-    local wf=$1 runs id
+    local wf=$1 event=${2:-} runs id filter=()
+    test -n "$event" && filter=(-f "event=$event")
     # A 404 is the probe before its first run, not an error worth losing the
     # control row over.
     runs=$(gh api --paginate -X GET "repos/$repo/actions/workflows/$wf/runs" \
-        -f "created=>=$since" -f per_page=100 \
+        -f "created=>=$since" -f per_page=100 "${filter[@]}" \
         -q '.workflow_runs[] | select(.status == "completed") | .id') || {
         echo "no runs of $wf in $repo" >&2
         return 0
@@ -51,6 +51,9 @@ census() {
     done
 }
 
+# Columns: job name, conclusion, count of steps the runner never finished. A kill
+# is a job that did not succeed and left a step unfinished; a cancelled job is
+# censored exposure, so it counts in neither column.
 # Wilson, not the normal approximation: at a handful of kills in a few dozen
 # jobs the latter puts the bound below zero and reads as certainty.
 report() {
@@ -76,6 +79,6 @@ report() {
 echo "window: $since .. today, repo $repo"
 echo
 {
-    census windows-kill-probe.yml
+    census windows-kill-probe.yml schedule
     census windows-build.yml
 } | report


### PR DESCRIPTION
#1228 ended on a hypothesis it called unsettleable from our side, that the kill tracks MSYS process creation over loopback socket churn. It is settleable as an A/B, and this is that experiment.

Three arms spend the same event budget on a different kind of event. One makes MSYS forks alone. One makes loopback connections alone from PowerShell, so no MSYS process exists. One makes a process and a connection per iteration, which is the shape the suite has when it spawns httrack.exe. No arm builds the engine, so a probe job is dose and nothing else. Only one arm runs at a time. The job pool is shared and already queues, so three more Windows jobs an hour would cost the control its samples.

The control is the live windows-build suite, and `tools/kill-probe-report.sh` prints it beside the arms, because a window whose control shows no kill measures nothing. At roughly 5% per uncensored job, hourly runs give about 40 exposures per arm in two days. That separates an arm that kills from one that does not, and it will not split two arms that both do.

Writing the census turned up two things. GitHub drops a job's step records after about a week, and the wedge signature lives in them. An older kill used to come back as a clean job, so it is recognised by runtime instead. The lease reaps a lost job at around 45 minutes, where a real failure ends in fifteen. The rate has also moved. Over 28 August to 4 September the control reads 47 kills in 364 uncensored jobs, against the 5.1% #1228 measured in July.

The probe stops itself on 2026-10-06 rather than leaving an hourly cron nobody remembers. A PR touching these files runs the arms at a smoke dose. The first such run caught two arms of three spending nothing at all.

One correction to `windows-runner-death/MEASUREMENTS.md` in httrack-works: Defender is out of the picture, because the runner images put it in passive mode by design. What is left of that hypothesis is the Windows Filtering Platform and the MSYS fork path.