### PR TITLE
A test that cannot run its subject reports PASS instead of a skip

### DIFF
--- a/tests/113_engine-threadattr-leak.test
+++ b/tests/113_engine-threadattr-leak.test
@@ -10,8 +10,7 @@ set -euo pipefail
 . "${0%"${0##*/}"}./testlib.sh"
 
 if [ "$HTS_OS" != "Linux" ]; then
-    echo "threadattr: LD_PRELOAD interposition is Linux-only here, skipping"
-    exit 0
+    skip "threadattr: LD_PRELOAD interposition is Linux-only here"
 fi
 # A --disable-shared build has nothing to preload; anything else missing is a
 # build problem, not a skip, or the leg would pass vacuously.
@@ -20,8 +19,7 @@ if [ ! -r "${THREADATTRFAIL_LA:-}" ]; then
     exit 1
 fi
 if grep -q "^dlname=''" "$THREADATTRFAIL_LA"; then
-    echo "threadattr: static-only build, skipping"
-    exit 0
+    skip "threadattr: static-only build, nothing to preload"
 fi
 if [ ! -r "${THREADATTRFAIL_LIB:-}" ]; then
     echo "threadattr: ${THREADATTRFAIL_LIB:-\$THREADATTRFAIL_LIB} was not built" >&2

--- a/tests/253_local-ftp-close-once.test
+++ b/tests/253_local-ftp-close-once.test
@@ -20,8 +20,7 @@ if [ ! -r "${CLOSETRACK_LA:-}" ]; then
     exit 1
 fi
 if grep -q "^dlname=''" "$CLOSETRACK_LA"; then
-    echo "close-once: static-only build, skipping"
-    exit 0
+    skip "close-once: static-only build, nothing to preload"
 fi
 for lib in "${CLOSETRACK_LIB:-}" "${FTPCANCEL_LIB:-}"; do
     test -r "$lib" || fail "close-once: ${lib:-an interposer} was not built"

--- a/tests/278_install-headers-msvc.test
+++ b/tests/278_install-headers-msvc.test
@@ -26,6 +26,9 @@ cleanup_push rm -rf "$tmp"
 # The MSVC step stages DevIncludes_DATA out of the source tree rather than
 # through the install rule 269 drives, so nothing else exercises that half.
 read -r -a cc_argv <<<"${CC:-cc}"
+# Both halves are gated on a prerequisite, so count what ran: neither leg here
+# leaves nothing but two file-existence checks behind a pass.
+staged=0
 if ! command -v "${cc_argv[0]}" >/dev/null 2>&1; then
     echo "note: no C compiler (${cc_argv[0]}), the staging path was not driven" >&2
 else
@@ -59,15 +62,20 @@ else
     # one entry outside src/ -- falls out of its set and nowhere else's.
     selftest "$((declared - 1))"
     [ -z "${abs_top_builddir:-}" ] || selftest "$declared" --builddir "$abs_top_builddir"
+    staged=1
 fi
 
 py=$(find_python || true)
 if ! test -r "$workflow"; then
     test -d "$top/.github" && fail "$workflow is gone but $top/.github is not"
+    test "$staged" -eq 1 ||
+        skip "no .github under $top and no C compiler, so neither half can run"
     echo "note: no .github under $top (dist tarball), the workflow audit did not run" >&2
     exit 0
 fi
 if test -z "$py" || ! "$py" -c 'import yaml' 2>/dev/null; then
+    test "$staged" -eq 1 ||
+        skip "no python3 with PyYAML and no C compiler, so neither half can run"
     echo "note: no python3 with PyYAML here, the workflow audit did not run" >&2
     exit 0
 fi

--- a/tests/278_install-headers-msvc.test
+++ b/tests/278_install-headers-msvc.test
@@ -26,8 +26,8 @@ cleanup_push rm -rf "$tmp"
 # The MSVC step stages DevIncludes_DATA out of the source tree rather than
 # through the install rule 269 drives, so nothing else exercises that half.
 read -r -a cc_argv <<<"${CC:-cc}"
-# Both halves are gated on a prerequisite, so count what ran: neither leg here
-# leaves nothing but two file-existence checks behind a pass.
+# Both halves are gated, so count them: with neither run, only two
+# file-existence checks stand behind the pass.
 staged=0
 if ! command -v "${cc_argv[0]}" >/dev/null 2>&1; then
     echo "note: no C compiler (${cc_argv[0]}), the staging path was not driven" >&2

--- a/tests/399_deb-build-deps.test
+++ b/tests/399_deb-build-deps.test
@@ -15,19 +15,16 @@ workflow="$top/.github/workflows/ci.yml"
 
 if ! test -r "$control"; then
     test -d "$top/debian" && fail "$control is gone but $top/debian is not"
-    echo "note: no debian/ under $top (dist tarball), the audit did not run" >&2
-    exit 0
+    skip "no debian/ under $top (dist tarball), so the audit has nothing to read"
 fi
 if ! test -r "$workflow"; then
     test -d "$top/.github" && fail "$workflow is gone but $top/.github is not"
-    echo "note: no .github under $top (dist tarball), the audit did not run" >&2
-    exit 0
+    skip "no .github under $top (dist tarball), so the audit has nothing to read"
 fi
 
 py=$(find_python || true)
 if test -z "$py" || ! "$py" -c 'import yaml' 2>/dev/null; then
-    echo "note: no python3 with PyYAML here, the audit did not run" >&2
-    exit 0
+    skip "no python3 with PyYAML here, so the workflow cannot be parsed"
 fi
 
 tmp=$(mktemp -d) || exit 1

--- a/tests/418_test-vacuous-skip.test
+++ b/tests/418_test-vacuous-skip.test
@@ -19,27 +19,35 @@ cleanup_push rm -rf "$tmp"
 # did prove something, and only the leg behind the gate is lost.
 cat >"$tmp/scan.awk" <<'AWK'
 # Per file, or the first file's assertions vouch for every file behind it.
-FNR == 1 { eff = 0; heredoc = ""; depth = 0; split("", opened) }
+FNR == 1 { eff = 0; heredoc = ""; dashed = 0; depth = 0; infunc = 0; split("", opened) }
 {
     line = $0
     # A here-doc body is data, not code, and stubs written into one say exit 0.
     if (heredoc != "") {
-        if (line ~ ("^[ \t]*" heredoc "[ \t]*$")) heredoc = ""
+        if (line ~ (dashed ? "^[ \t]*" heredoc "[ \t]*$" : "^" heredoc "[ \t]*$")) heredoc = ""
         next
     }
-    if (match(line, /<<-?[ \t]*'?"?[A-Za-z_][A-Za-z0-9_]*'?"?/)) {
+    # Comments go first, or a "<<" inside one opens a here-doc that eats the file.
+    sub(/(^|[ \t])#.*$/, "", line)
+    if (match(line, /<<-?[ \t]*\\?['"]?[A-Za-z_][A-Za-z0-9_]*['"]?[ \t]*($|[|&;>])/)) {
         w = substr(line, RSTART, RLENGTH)
-        gsub(/^<<-?[ \t]*|['"]/, "", w)
+        dashed = (w ~ /^<<-/)
+        gsub(/^<<-?[ \t]*|[\\'"]|[ \t]*[|&;>]*[ \t]*$/, "", w)
         heredoc = w
     }
-    sub(/^[ \t]*#.*$/, "", line)
+    # A function body does not run where it is written, so an exit 0 in one is
+    # not a bail-out. Its lines still count toward what the file can assert.
+    isfunc = (line ~ /^[A-Za-z_][A-Za-z0-9_]*\(\)[ \t]*\{/)
+    if (isfunc) infunc = (line !~ /\}[ \t]*$/)
+    else if (infunc && line ~ /^\}/) infunc = 0
     # What ran inside the guard is part of the guard, not evidence the subject
-    # was exercised: an "if" remembers the tally it opened with.
-    if (line ~ /^[ \t]*if[ \t]/) { depth++; opened[depth] = eff }
-    if (line ~ /^[ \t]*fi([ \t;].*)?$/ && depth > 0) depth--
-    if (line ~ /(^|[ \t;&|(])exit[ \t]+0([ \t]*;)?[ \t]*$/ && line !~ /printf|trap|echo/) {
-        if ((depth == 0 ? eff : opened[depth]) == 0)
-            print FILENAME ":" FNR ": exit 0 reports PASS with nothing asserted yet; use skip"
+    # was exercised: an "if" or a "case" remembers the tally it opened with.
+    if (line ~ /^[ \t]*(if|case)[ \t]/) { depth++; opened[depth] = eff }
+    if (line ~ /(^|[ \t;])(fi|esac)([ \t;]|$)/ && depth > 0) depth--
+    if (!infunc && !isfunc && line ~ /(^|[ \t;&|(])exit[ \t]+0[ \t]*([;)}&|].*)?$/ && line !~ /printf|trap|echo/) {
+        before = eff
+        if (depth > 0 && (depth in opened)) before = opened[depth]
+        if (!before) print FILENAME ":" FNR ": exit 0 reports PASS with nothing asserted yet; use skip"
     }
     if (line ~ /(^|[ \t;&|(]|then |else |do )(fail|fail_dump|skip|skip_on_windows|skip_on_emulated|skip_if_out_of_budget|assert_[a-z_]+|expect_ok|ok|require_httrack|selftest_run_queued|mirror_has_name|crash_report|local_crawl)([ \t]|$)/) eff = 1
     if (line ~ /(^|[ \t;&|(=$])(httrack|htsserver|proxytrack)[ \t"]/) eff = 1
@@ -58,15 +66,51 @@ mkfixture() { # mkfixture NAME <<FIX ... FIX
 }
 
 # Controls, before the tree: a scanner blind to the shape calls anything clean.
-# Written from here-docs, which the scanner skips, so this file stays its own
-# first subject.
-mkfixture bug.test <<'FIX'
-if [ "$HTS_OS" != Linux ]; then
-    echo "not Linux, skipping"
+# The fixtures are written from here-docs, which the scanner skips, so this file
+# stays its own first subject.
+
+# Each of these bails out having asserted nothing, in a spelling the tree uses
+# somewhere, and every one must be reported.
+mkfixture brace.test <<'FIX'
+command -v python3 >/dev/null || { exit 0; }
+assert_eq 1 1 "the subject"
+FIX
+mkfixture case.test <<'FIX'
+case "$HTS_OS" in
+Linux) ;;
+*) exit 0 ;;
+esac
+assert_eq 1 1 "the subject"
+FIX
+mkfixture trailing.test <<'FIX'
+if [ -z "${Y:-}" ]; then
+    exit 0 # nothing to check off Linux
+fi
+assert_eq 1 1 "the subject"
+FIX
+mkfixture oneline.test <<'FIX'
+if [ -n "${V:-}" ]; then :; fi
+if [ -z "${Y:-}" ]; then
     exit 0
 fi
 assert_eq 1 1 "the subject"
 FIX
+mkfixture shift.test <<'FIX'
+mask=$((1 << 16))
+if [ -z "${Y:-}" ]; then
+    exit 0
+fi
+assert_eq 1 1 "the subject"
+FIX
+mkfixture mention.test <<'FIX'
+# the shim below is written from a <<EOF here-doc
+if [ -z "${Y:-}" ]; then
+    exit 0
+fi
+assert_eq 1 1 "the subject"
+FIX
+
+# Each of these is honest, and none may be reported.
 mkfixture skips.test <<'FIX'
 if [ "$HTS_OS" != Linux ]; then
     skip "not Linux"
@@ -82,19 +126,44 @@ fi
 assert_eq 2 2 "the second half"
 FIX
 mkfixture stub.test <<'FIX'
-cat >"$d/shim" <<EOF
+cat >"$d/shim" <<\EOF
 #!/bin/sh
 exit 0
 EOF
 assert_eq 1 1 "the subject"
 FIX
+mkfixture indented.test <<'FIX'
+cat >"$d/shim" <<'EOF'
+#!/bin/sh
+    EOF
+exit 0
+EOF
+assert_eq 1 1 "the subject"
+FIX
+mkfixture piped.test <<'FIX'
+"$py" - "$a" <<'PYX' | tr -d '\\r'
+import sys
+sys.exit(0)
+PYX
+assert_eq 1 1 "the subject"
+FIX
+mkfixture helper.test <<'FIX'
+finish() { rm -rf "$tmp"; exit 0; }
+teardown() {
+    rm -rf "$tmp"
+    exit 0
+}
+assert_eq 1 1 "the subject"
+FIX
 
-said=$(scan "$tmp/bug.test") || fail "the scanner exited nonzero: $said"
-# The line too: a report naming the file alone would not point at the bail-out.
-want=$(awk '/exit 0/ { print NR; exit }' "$tmp/bug.test")
-grep -q "bug\.test:${want}:" <<<"$said" ||
-    fail "the bail-out at line ${want} went unreported: ${said:-(silence)}"
-for clean in skips late stub; do
+for bug in brace case trailing oneline shift mention; do
+    said=$(scan "$tmp/$bug.test") || fail "the scanner exited nonzero: $said"
+    # The line too: a report naming the file alone would not point at the bail-out.
+    want=$(awk '/exit 0/ { print NR; exit }' "$tmp/$bug.test")
+    grep -q "$bug\\.test:${want}:" <<<"$said" ||
+        fail "$bug.test bails out at line ${want} and went unreported: ${said:-(silence)}"
+done
+for clean in skips late stub indented piped helper; do
     said=$(scan "$tmp/$clean.test") || fail "the scanner exited nonzero: $said"
     test -z "$said" || fail "$clean.test is not the defect but was reported: $said"
 done
@@ -103,8 +172,8 @@ ok "the scanner separates a vacuous bail-out from an honest one"
 # The whole tree goes through one awk, so the tally has to start over per file:
 # carried across, the first file's assertions vouch for every file behind it and
 # the scan below reports nothing whatever it is fed.
-said=$(scan "$tmp/late.test" "$tmp/bug.test") || fail "the scanner exited nonzero: $said"
-grep -q "bug\.test:${want}:" <<<"$said" ||
+said=$(scan "$tmp/late.test" "$tmp/brace.test") || fail "the scanner exited nonzero: $said"
+grep -q 'brace\.test:' <<<"$said" ||
     fail "a file scanned after an asserting one went unreported: ${said:-(silence)}"
 ok "the scanner starts each file over"
 

--- a/tests/418_test-vacuous-skip.test
+++ b/tests/418_test-vacuous-skip.test
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
 # A test that bails out at "exit 0" because a prerequisite is missing reports
-# PASS, so a host that cannot run it goes green having asserted nothing: 399 did
-# exactly that wherever PyYAML was absent. 77 is automake's skip, and this
-# refuses the idiom coming back.
+# PASS, so the host that cannot run it is the one reading green. 399 did that
+# wherever PyYAML was absent. 77 is automake's skip, and this refuses the idiom
+# coming back.
 
 set -euo pipefail
 
@@ -14,9 +14,8 @@ top=${abs_top_srcdir:-$(cd "$testdir/.." && pwd)}
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_vacskip.XXXXXX")
 cleanup_push rm -rf "$tmp"
 
-# Reports every "exit 0" a test can reach before it has run anything that could
-# have failed it. An early bail-out past a real assertion is honest: the test
-# did prove something, and only the leg behind the gate is lost.
+# Reports every "exit 0" a test can reach before anything that could have failed
+# it. A bail-out past a real assertion is honest, so it is not reported.
 cat >"$tmp/scan.awk" <<'AWK'
 # Per file, or the first file's assertions vouch for every file behind it.
 FNR == 1 { eff = 0; heredoc = ""; dashed = 0; depth = 0; infunc = 0; split("", opened) }

--- a/tests/418_test-vacuous-skip.test
+++ b/tests/418_test-vacuous-skip.test
@@ -1,0 +1,116 @@
+#!/bin/bash
+#
+# A test that bails out at "exit 0" because a prerequisite is missing reports
+# PASS, so a host that cannot run it goes green having asserted nothing: 399 did
+# exactly that wherever PyYAML was absent. 77 is automake's skip, and this
+# refuses the idiom coming back.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+top=${abs_top_srcdir:-$(cd "$testdir/.." && pwd)}
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_vacskip.XXXXXX")
+cleanup_push rm -rf "$tmp"
+
+# Reports every "exit 0" a test can reach before it has run anything that could
+# have failed it. An early bail-out past a real assertion is honest: the test
+# did prove something, and only the leg behind the gate is lost.
+cat >"$tmp/scan.awk" <<'AWK'
+# Per file, or the first file's assertions vouch for every file behind it.
+FNR == 1 { eff = 0; heredoc = ""; depth = 0; split("", opened) }
+{
+    line = $0
+    # A here-doc body is data, not code, and stubs written into one say exit 0.
+    if (heredoc != "") {
+        if (line ~ ("^[ \t]*" heredoc "[ \t]*$")) heredoc = ""
+        next
+    }
+    if (match(line, /<<-?[ \t]*'?"?[A-Za-z_][A-Za-z0-9_]*'?"?/)) {
+        w = substr(line, RSTART, RLENGTH)
+        gsub(/^<<-?[ \t]*|['"]/, "", w)
+        heredoc = w
+    }
+    sub(/^[ \t]*#.*$/, "", line)
+    # What ran inside the guard is part of the guard, not evidence the subject
+    # was exercised: an "if" remembers the tally it opened with.
+    if (line ~ /^[ \t]*if[ \t]/) { depth++; opened[depth] = eff }
+    if (line ~ /^[ \t]*fi([ \t;].*)?$/ && depth > 0) depth--
+    if (line ~ /(^|[ \t;&|(])exit[ \t]+0([ \t]*;)?[ \t]*$/ && line !~ /printf|trap|echo/) {
+        if ((depth == 0 ? eff : opened[depth]) == 0)
+            print FILENAME ":" FNR ": exit 0 reports PASS with nothing asserted yet; use skip"
+    }
+    if (line ~ /(^|[ \t;&|(]|then |else |do )(fail|fail_dump|skip|skip_on_windows|skip_on_emulated|skip_if_out_of_budget|assert_[a-z_]+|expect_ok|ok|require_httrack|selftest_run_queued|mirror_has_name|crash_report|local_crawl)([ \t]|$)/) eff = 1
+    if (line ~ /(^|[ \t;&|(=$])(httrack|htsserver|proxytrack)[ \t"]/) eff = 1
+    if (line ~ /local-crawl\.sh|crawl-test\.sh|install-headers-sweep\.sh/) eff = 1
+    if (line ~ /\|\|[ \t]*exit[ \t]+1/) eff = 1
+}
+AWK
+
+scan() { awk -f "$tmp/scan.awk" "$@"; }
+
+mkfixture() { # mkfixture NAME <<FIX ... FIX
+    {
+        printf '#!/bin/bash\nset -euo pipefail\n'
+        cat
+    } >"$tmp/$1"
+}
+
+# Controls, before the tree: a scanner blind to the shape calls anything clean.
+# Written from here-docs, which the scanner skips, so this file stays its own
+# first subject.
+mkfixture bug.test <<'FIX'
+if [ "$HTS_OS" != Linux ]; then
+    echo "not Linux, skipping"
+    exit 0
+fi
+assert_eq 1 1 "the subject"
+FIX
+mkfixture skips.test <<'FIX'
+if [ "$HTS_OS" != Linux ]; then
+    skip "not Linux"
+fi
+assert_eq 1 1 "the subject"
+FIX
+mkfixture late.test <<'FIX'
+assert_eq 1 1 "the first half"
+if [ "$HTS_OS" != Linux ]; then
+    echo "not Linux, the second half is skipped"
+    exit 0
+fi
+assert_eq 2 2 "the second half"
+FIX
+mkfixture stub.test <<'FIX'
+cat >"$d/shim" <<EOF
+#!/bin/sh
+exit 0
+EOF
+assert_eq 1 1 "the subject"
+FIX
+
+said=$(scan "$tmp/bug.test") || fail "the scanner exited nonzero: $said"
+# The line too: a report naming the file alone would not point at the bail-out.
+want=$(awk '/exit 0/ { print NR; exit }' "$tmp/bug.test")
+grep -q "bug\.test:${want}:" <<<"$said" ||
+    fail "the bail-out at line ${want} went unreported: ${said:-(silence)}"
+for clean in skips late stub; do
+    said=$(scan "$tmp/$clean.test") || fail "the scanner exited nonzero: $said"
+    test -z "$said" || fail "$clean.test is not the defect but was reported: $said"
+done
+ok "the scanner separates a vacuous bail-out from an honest one"
+
+# The whole tree goes through one awk, so the tally has to start over per file:
+# carried across, the first file's assertions vouch for every file behind it and
+# the scan below reports nothing whatever it is fed.
+said=$(scan "$tmp/late.test" "$tmp/bug.test") || fail "the scanner exited nonzero: $said"
+grep -q "bug\.test:${want}:" <<<"$said" ||
+    fail "a file scanned after an asserting one went unreported: ${said:-(silence)}"
+ok "the scanner starts each file over"
+
+# The tree itself. Read out of the source dir, so a stale build dir cannot hide
+# a test that was added since it was configured.
+found=$(cd "$top/tests" && scan [0-9]*_*.test) || fail "the scan failed: $found"
+test -z "$found" || fail "these tests would report PASS having asserted nothing:
+$found"
+ok "no test in tests/ turns a missing prerequisite into a pass"

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -504,13 +504,15 @@ echo "ran=$((pass + fail + skip + lost)) pass=$pass fail=$fail skip=$skip lost=$
 # ftp-deadhost-interrupt, ftp-sigterm, abort-purge, signal-receive and
 # ftp-stop-window need that same signal (deadhost's --timeout half runs as 245,
 # abort-purge's --max-time half as 268);
-# close-once interposes close() through LD_PRELOAD, which MSYS has no equivalent for;
+# close-once and threadattr-leak interpose through LD_PRELOAD, which MSYS has no
+# equivalent for, and this job sets neither interposer's path;
 # engine-install-paths reads the compiled-in POSIX install paths, which this job
 # has no equivalent of;
 # build-features compares the feature reporter against the automake config.h,
 # which the MSVC build does not produce.
 expected_skips="01_engine-footer-overflow.test
 253_local-ftp-close-once.test
+113_engine-threadattr-leak.test
 100_local-purge-longpath.test
 158_local-link-control-bytes.test
 114_local-update-304-leak.test


### PR DESCRIPTION
`399_deb-build-deps.test` ends at `exit 0` when PyYAML is absent, so automake records a PASS for a test that asserted nothing. `113_engine-threadattr-leak.test` does the same off Linux and on a `--disable-shared` build, and `253_local-ftp-close-once.test` does it on a `--disable-shared` build. All six sites call `skip` now, which exits 77.

`278_install-headers-msvc.test` is a seventh, and a review found it rather than the scan below. Its staging leg needs a C compiler and its workflow audit needs PyYAML. With both absent, the only thing still running is two file-existence checks. Those are real assertions, which is why nothing mechanical can see it. It counts its legs now and skips when neither ran.

The line is whether anything ran before the gate. A test that asserts, then bails out of a leg it cannot reach, has proved something, so PASS is honest there. About twenty do that and stay untouched. A test that bails before its first assertion has proved nothing.

I enumerated every `exit 0` under `tests/`, then reproduced each missing prerequisite and read the verdict back:

- a `PYTHONPATH` pointing at a `yaml.py` that raises `ImportError`
- a `python3` shim that exits 1
- a second tree configured `--disable-shared`
- `HTS_OS=Darwin`
- an `abs_top_srcdir` carrying neither `debian/` nor `.github/`

Each of the six sites reported PASS before and reports SKIP after.

The Windows job pins its skip set, which makes it a control the Linux runs cannot be. The sweep moved exactly one test into it. `113_engine-threadattr-leak.test` was greening there without running its subject. It counts a pthread_attr init/destroy imbalance through an LD_PRELOAD interposer, and MSYS has no equivalent. The job sets no `THREADATTRFAIL_LA` either, so the Linux gate is the only thing keeping the test off its own "was not built" arm. `253_local-ftp-close-once.test` interposes the same way and has been in that list since it was written.

`418_test-vacuous-skip.test` is the guard. It reports an `exit 0` a test can reach before anything that could have failed that test. What runs inside the gate's own `if` counts as part of the gate, not as evidence. Over the 430 tests on master it names those three files and nothing else, and 278 is the case it cannot reach.

Its controls earn their place. The first scan was itself vacuous, because awk carried its tally across files, so the first file's assertions vouched for every file behind it. An adversarial review then broke it eight more ways in both directions, `|| { exit 0; }` and a `case` arm and a trailing comment among them. Twelve fixtures pin it now, six that must be reported and six that must not, and gawk, mawk and busybox awk agree on all twelve.

Two bounds remain. An assertion written on the gate's own line still counts as prior work, and the word `ok` or `fail` inside a string reads as one. A test can slip past on either. The remedy is the one a real finding gets: write `skip` instead of `exit 0`, or teach the scan the idiom.