### PR TITLE
Nothing checks that debian/rules still names every optional feature

### DIFF
--- a/tests/397_configure-auto-features.test
+++ b/tests/397_configure-auto-features.test
@@ -230,7 +230,10 @@ rules_argv() { # rules_argv RULESFILE DIR
     mkdir -p "${dir}/stub"
     # Every dh_* the file names, so one added later cannot run for real here.
     # The digits matter: dh_md5sums and dh_python3 both carry one.
-    command grep -o 'dh_[a-z0-9_]*' "$1" | sort -u >"${dir}/dh-names"
+    {
+        echo dh
+        command grep -o 'dh_[a-z0-9_]*' "$1"
+    } | sort -u >"${dir}/dh-names"
     while IFS= read -r cmd; do
         printf '#!/bin/sh\nexit 0\n' >"${dir}/stub/${cmd}"
         chmod +x "${dir}/stub/${cmd}"
@@ -241,6 +244,7 @@ rules_argv() { # rules_argv RULESFILE DIR
         "${dir}" "${dir}" "${dir}" >"${dir}/stub/dh_auto_configure"
     chmod +x "${dir}/stub/dh_auto_configure"
     : >"${dir}/make.log"
+    : >"${dir}/failed"
     # Every target a build reaches, not just "build": dpkg-buildpackage runs
     # build-arch for an arch:any package, and a dh-driven file keeps its flags
     # in an override target that "build" reaches only through dh itself.
@@ -253,7 +257,10 @@ rules_argv() { # rules_argv RULESFILE DIR
     read -r -a make_argv <<<"${MAKE:-make}"
     for cmd in "${envs[@]}"; do
         read -r -a vars <<<"${cmd}"
-        for target in build build-arch build-indep override_dh_auto_configure; do
+        for target in build build-arch build-indep \
+            override_dh_auto_configure override_dh_auto_configure-arch \
+            override_dh_auto_configure-indep \
+            execute_before_dh_auto_configure execute_after_dh_auto_configure; do
             command grep -q "^${target}:" "$1" || continue
             pass=$((pass + 1))
             mkdir -p "${dir}/run.${pass}"
@@ -261,7 +268,7 @@ rules_argv() { # rules_argv RULESFILE DIR
             (cd "${dir}/run.${pass}" && PATH="${dir}/stub:${PATH}" \
                 MAKEFLAGS='' MFLAGS='' MAKELEVEL='' \
                 env "${vars[@]}" "${make_argv[@]}" -s -f "$1" "${target}") \
-                >>"${dir}/make.log" 2>&1 || true
+                >>"${dir}/make.log" 2>&1 || echo "${target}" >>"${dir}/failed"
         done
     done
 }
@@ -310,9 +317,13 @@ rules_turned_off() { # rules_turned_off ARGVFILE
             continue
         fi
         case ${tok} in
-        --disable-auto-features | --disable-online-unit-tests) ;;
+        --disable-auto-features | --enable-auto-features=no) ;;
+        --disable-online-unit-tests | --enable-online-unit-tests=no) ;;
         --without-brotli | --without-zstd | --without-iconv | --disable-backtrace) ;;
-        --disable-* | --without-*) out="${out} turns-off:${tok}" ;;
+        --with-brotli=no | --with-zstd=no | --with-iconv=no | --enable-backtrace=no) ;;
+        --disable-* | --without-* | --enable-*=no | --with-*=no)
+            out="${out} turns-off:${tok}"
+            ;;
         esac
     done <"$1"
     echo "${out# }"
@@ -324,10 +335,13 @@ rules_verdict() { # rules_verdict RULESFILE DIR
     local argv said off dir=$2 out=""
     rules_argv "$1" "${dir}"
     set -- "${dir}"/argv.*
+    # A pass that failed is a finding on its own: a recipe configuring through
+    # something other than dh_auto_configure dies here rather than being read.
+    test ! -s "${dir}/failed" || out="make-failed"
     test -e "$1" || {
         # Say which: a file make could not run is not a file that configures
         # nothing, and only one of the two is the packaging bug.
-        test ! -s "${dir}/make.log" || {
+        test -z "${out}" || {
             echo "make-failed"
             return
         }
@@ -432,12 +446,15 @@ WITH_ZSTD = no
 build:
 	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd=$(WITH_ZSTD) --enable-backtrace --with-iconv
 MUT
-    reads "zstd backtrace iconv" "a comment mid-continuation, which runs to the line's end" <<'MUT'
+    reads "make-failed zstd backtrace iconv" \
+        "a comment mid-continuation, which ends the line and the build with it" <<'MUT'
 build:
 	dh_auto_configure -- --disable-auto-features --with-brotli \
 		# --with-zstd \
 		--enable-backtrace --with-iconv
 MUT
+    # make exits 0 here: the orphan line starts with "-", which is make's own
+    # ignore-errors prefix, so the short list ships and nothing says so.
     reads "zstd backtrace iconv" "a backslash make does not read as a continuation" <<'MUT'
 build:
 	dh_auto_configure -- --disable-auto-features --with-brotli \@SP@
@@ -482,6 +499,31 @@ build:
 	true
 build-arch:
 	dh_auto_configure -- --disable-auto-features --with-brotli
+MUT
+    reads turns-off:--enable-https=no "an off switch spelled as a value" <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv --enable-https=no
+MUT
+    reads turns-off:--enable-example-libs=no "another feature turned off by value" <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv --enable-example-libs=no
+MUT
+    reads make-failed "a configure run that is not dh_auto_configure" <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv
+	./configure --disable-auto-features --with-brotli
+MUT
+    reads "zstd backtrace iconv" "execute_after_dh_auto_configure, which debhelper runs" <<'MUT'
+build:
+	true
+execute_after_dh_auto_configure:
+	dh_auto_configure -- --disable-auto-features --with-brotli
+MUT
+    reads "" "an arch-only override, which debhelper runs in place of the plain one" <<'MUT'
+build:
+	dh $@
+override_dh_auto_configure-arch:
+	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv
 MUT
     reads no-invocation "a build target that configures nothing" <<'MUT'
 build:

--- a/tests/397_configure-auto-features.test
+++ b/tests/397_configure-auto-features.test
@@ -229,7 +229,8 @@ rules_argv() { # rules_argv RULESFILE DIR
     local dir=$2 cmd
     mkdir -p "${dir}/stub"
     # Every dh_* the file names, so one added later cannot run for real here.
-    command grep -o 'dh_[a-z_]*' "$1" | sort -u >"${dir}/dh-names"
+    # The digits matter: dh_md5sums and dh_python3 both carry one.
+    command grep -o 'dh_[a-z0-9_]*' "$1" | sort -u >"${dir}/dh-names"
     while IFS= read -r cmd; do
         printf '#!/bin/sh\nexit 0\n' >"${dir}/stub/${cmd}"
         chmod +x "${dir}/stub/${cmd}"
@@ -240,16 +241,28 @@ rules_argv() { # rules_argv RULESFILE DIR
         "${dir}" "${dir}" "${dir}" >"${dir}/stub/dh_auto_configure"
     chmod +x "${dir}/stub/dh_auto_configure"
     # Unset the outer make's jobserver, or the inner one warns and drops -j.
-    (cd "${dir}" && PATH="${dir}/stub:${PATH}" MAKEFLAGS='' MFLAGS='' MAKELEVEL='' \
-        ${MAKE:-make} -s -f "$1" build) >"${dir}/make.log" 2>&1
+    run_rules() { # run_rules TARGET
+        (cd "${dir}" && PATH="${dir}/stub:${PATH}" MAKEFLAGS='' MFLAGS='' MAKELEVEL='' \
+            ${MAKE:-make} -s -f "$1" "$2") >>"${dir}/make.log" 2>&1 || true
+    }
+    : >"${dir}/make.log"
+    run_rules "$1" build
+    # A rules file driven by the dh sequencer keeps its flags in an override
+    # target, which "build" reaches only through dh itself.
+    ! command grep -q '^override_dh_auto_configure:' "$1" ||
+        run_rules "$1" override_dh_auto_configure
 }
 # Which features one recorded argv does not turn on, or "". "no" is autoconf for
 # --without-X, and "auto" hands the decision back to the build machine, which is
 # the lottery --disable-auto-features exists to end.
 rules_missing() { # rules_missing ARGVFILE
-    local f flag tok val state seen out=""
+    local f flag neg tok val state seen out=""
     for f in ${features}; do
         flag=$(feature_flag "${f}")
+        # --without-X and --disable-X are the flag's own off switch, and a later
+        # one beats the --with-X in front of it.
+        neg=${flag/--with-/--without-}
+        test "${neg}" != "${flag}" || neg=${flag/--enable-/--disable-}
         state=off
         seen=0
         while IFS= read -r tok; do
@@ -258,6 +271,7 @@ rules_missing() { # rules_missing ARGVFILE
                 continue
             fi
             case ${tok} in
+            "${neg}") state=off ;;
             "${flag}") state=on ;;
             "${flag}="*)
                 val=${tok#*=}
@@ -275,10 +289,16 @@ rules_missing() { # rules_missing ARGVFILE
 # Everything wrong with one rules file, or "" when every dh_auto_configure it
 # runs asks for every feature.
 rules_verdict() { # rules_verdict RULESFILE DIR
-    local argv said off out=""
-    rules_argv "$1" "$2"
-    set -- "$2"/argv.*
+    local argv said off dir=$2 out=""
+    rules_argv "$1" "${dir}"
+    set -- "${dir}"/argv.*
     test -e "$1" || {
+        # Say which: a file make could not run is not a file that configures
+        # nothing, and only one of the two is the packaging bug.
+        test ! -s "${dir}/make.log" || {
+            echo "make-failed"
+            return
+        }
         echo "no-invocation"
         return
     }
@@ -309,7 +329,10 @@ if test -r "${rules}"; then
         seq=$((seq + 1))
         dir=${work}/mut${seq}
         mkdir -p "${dir}"
-        cat >"${dir}/rules"
+        # @SP@ is a trailing space one fixture needs. Written literally, an
+        # editor or a whitespace lint would take it and the fixture would pass
+        # for the wrong reason.
+        sed 's/@SP@/ /' >"${dir}/rules"
         got=$(rules_verdict "${dir}/rules" "${dir}")
         test "${got}" = "${want}" ||
             fail "${desc}: expected [${want}], the reader said [${got:-(nothing)}]"
@@ -333,6 +356,22 @@ MUT
     reads zstd '--with-zstd="no", which the shell unquotes too' <<'MUT'
 build:
 	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd="no" --enable-backtrace --with-iconv
+MUT
+    reads zstd "--with-zstd then --without-zstd, where the last one wins" <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv --without-zstd
+MUT
+    reads backtrace "--enable-backtrace then --disable-backtrace" <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv --disable-backtrace
+MUT
+    reads brotli "--with-brotli then --without-brotli" <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv --without-brotli
+MUT
+    reads "" "--without-zstd then --with-zstd, where the last one wins too" <<'MUT'
+build:
+	dh_auto_configure -- --without-zstd --disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv
 MUT
     reads zstd "--without-zstd" <<'MUT'
 build:
@@ -359,7 +398,7 @@ build:
 MUT
     reads "zstd backtrace iconv" "a backslash make does not read as a continuation" <<'MUT'
 build:
-	dh_auto_configure -- --disable-auto-features --with-brotli \ 
+	dh_auto_configure -- --disable-auto-features --with-brotli \@SP@
 		--with-zstd --enable-backtrace --with-iconv
 MUT
     reads "zstd backtrace iconv" "a fallback invocation that never runs" <<'MUT'
@@ -387,6 +426,16 @@ MUT
     reads no-invocation "a build target that configures nothing" <<'MUT'
 build:
 	true
+MUT
+    reads "" "the dh sequencer, whose flags sit in an override target" <<'MUT'
+build:
+	dh $@
+override_dh_auto_configure:
+	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv
+MUT
+    reads make-failed "a rules file make cannot run" <<'MUT'
+build:
+	false
 MUT
     echo "ok: every dh_auto_configure debian/rules runs asks for every feature"
 else

--- a/tests/397_configure-auto-features.test
+++ b/tests/397_configure-auto-features.test
@@ -228,17 +228,20 @@ done
 rules_argv() { # rules_argv RULESFILE DIR
     local dir=$2 cmd
     mkdir -p "${dir}/stub"
-    for cmd in dh_testdir dh_testroot dh_autoreconf dh_auto_build dh_auto_test; do
+    # Every dh_* the file names, so one added later cannot run for real here.
+    command grep -o 'dh_[a-z_]*' "$1" | sort -u >"${dir}/dh-names"
+    while IFS= read -r cmd; do
         printf '#!/bin/sh\nexit 0\n' >"${dir}/stub/${cmd}"
         chmod +x "${dir}/stub/${cmd}"
-    done
+    done <"${dir}/dh-names"
     # One file per invocation, since a second one overrides the first.
     # shellcheck disable=SC2016 # the shim's own expansions, not this shell's
     printf '#!/bin/sh\nn=$(cat "%s/n" 2>/dev/null || echo 0)\nn=$((n + 1))\necho "$n" >"%s/n"\nfor a; do printf "%%s\\n" "$a"; done >"%s/argv.$n"\nexit 0\n' \
         "${dir}" "${dir}" "${dir}" >"${dir}/stub/dh_auto_configure"
     chmod +x "${dir}/stub/dh_auto_configure"
-    (cd "${dir}" && PATH="${dir}/stub:${PATH}" ${MAKE:-make} -s -f "$1" build) \
-        >"${dir}/make.log" 2>&1
+    # Unset the outer make's jobserver, or the inner one warns and drops -j.
+    (cd "${dir}" && PATH="${dir}/stub:${PATH}" MAKEFLAGS='' MFLAGS='' MAKELEVEL='' \
+        ${MAKE:-make} -s -f "$1" build) >"${dir}/make.log" 2>&1
 }
 # Which features one recorded argv does not turn on, or "". "no" is autoconf for
 # --without-X, and "auto" hands the decision back to the build machine, which is

--- a/tests/397_configure-auto-features.test
+++ b/tests/397_configure-auto-features.test
@@ -221,133 +221,171 @@ done
 
 # --disable-auto-features makes the flags after it the whole optional set, so a
 # flag dropped from debian/rules ships a package that decodes less.
-# Every dh_auto_configure invocation, one line each, continuations joined. A
-# later one overrides the first, so each has to stand on its own. A "#" in a
-# recipe line is a shell comment, and it is dropped before the join while the
-# trailing backslash it may carry still continues the line.
-rules_flags() { # rules_flags FILE
-    awk '/(^|[ \t;&|(])dh_auto_configure([ \t]|$)/ { want = 1; line = "" }
-         want { t = $0; sub(/(^|[ \t])#.*$/, "", t); line = line " " t }
-         want && !/\\[ \t]*$/ { gsub(/[ \t\\]+/, " ", line); print line; want = 0 }' "$1"
-}
-# What the invocation passes on to configure: everything past the first bare --.
-rules_args() { # rules_args FLAGS
-    local tok seen=0 out=""
-    for tok in $1; do
-        if test "${seen}" -eq 0; then
-            test "${tok}" != -- || seen=1
-            continue
-        fi
-        out="${out} ${tok}"
+# Reading that list out of the file means parsing make and the shell at once,
+# and every attempt at it lost to a continuation, a comment or a variable. Run
+# the recipe instead with every dh_* stubbed, and record what the real
+# dh_auto_configure would have been handed: make expands, the shell splits.
+rules_argv() { # rules_argv RULESFILE DIR
+    local dir=$2 cmd
+    mkdir -p "${dir}/stub"
+    for cmd in dh_testdir dh_testroot dh_autoreconf dh_auto_build dh_auto_test; do
+        printf '#!/bin/sh\nexit 0\n' >"${dir}/stub/${cmd}"
+        chmod +x "${dir}/stub/${cmd}"
     done
-    echo "${out# }"
+    # One file per invocation, since a second one overrides the first.
+    # shellcheck disable=SC2016 # the shim's own expansions, not this shell's
+    printf '#!/bin/sh\nn=$(cat "%s/n" 2>/dev/null || echo 0)\nn=$((n + 1))\necho "$n" >"%s/n"\nfor a; do printf "%%s\\n" "$a"; done >"%s/argv.$n"\nexit 0\n' \
+        "${dir}" "${dir}" "${dir}" >"${dir}/stub/dh_auto_configure"
+    chmod +x "${dir}/stub/dh_auto_configure"
+    (cd "${dir}" && PATH="${dir}/stub:${PATH}" ${MAKE:-make} -s -f "$1" build) \
+        >"${dir}/make.log" 2>&1
 }
-# Which features an argument list does not turn on, or "". Whole tokens, because
-# a substring match reads a commented-out or quoted flag as passed. --with-X=no
-# is autoconf's spelling of --without-X, and the last spelling wins as it does
-# in configure.
-rules_missing() { # rules_missing ARGS
-    local arglist=$1 f flag tok val state out=""
+# Which features one recorded argv does not turn on, or "". "no" is autoconf for
+# --without-X, and "auto" hands the decision back to the build machine, which is
+# the lottery --disable-auto-features exists to end.
+rules_missing() { # rules_missing ARGVFILE
+    local f flag tok val state seen out=""
     for f in ${features}; do
         flag=$(feature_flag "${f}")
         state=off
-        for tok in ${arglist}; do
+        seen=0
+        while IFS= read -r tok; do
+            if test "${seen}" -eq 0; then
+                test "${tok}" != -- || seen=1
+                continue
+            fi
             case ${tok} in
             "${flag}") state=on ;;
             "${flag}="*)
                 val=${tok#*=}
-                val=${val#[\"\']}
-                val=${val%[\"\']}
-                test "${val}" != no && state=on || state=off
+                case ${val} in
+                no | auto | "") state=off ;;
+                *) state=on ;;
+                esac
                 ;;
             esac
-        done
+        done <"$1"
         test "${state}" = on || out="${out} ${f}"
     done
     echo "${out# }"
 }
-# Everything wrong with one rules file, or "" when every invocation asks for
-# every feature.
-rules_verdict() { # rules_verdict FILE
-    local lines flags arglist said out=""
-    lines=$(rules_flags "$1")
-    test -n "${lines}" || {
+# Everything wrong with one rules file, or "" when every dh_auto_configure it
+# runs asks for every feature.
+rules_verdict() { # rules_verdict RULESFILE DIR
+    local argv said off out=""
+    rules_argv "$1" "$2"
+    set -- "$2"/argv.*
+    test -e "$1" || {
         echo "no-invocation"
         return
     }
-    while read -r flags; do
-        arglist=$(rules_args "${flags}")
-        case " ${arglist} " in
-        *" --disable-auto-features "*) ;;
-        *) out="${out} no-disable-auto-features" ;;
-        esac
-        said=$(rules_missing "${arglist}")
+    for argv in "$@"; do
+        # --enable-auto-features=no is the same switch spelled the other way.
+        off=$(command grep -c -x -e --disable-auto-features -e --enable-auto-features=no "${argv}" || true)
+        test "${off}" -gt 0 || out="${out} no-disable-auto-features"
+        said=$(rules_missing "${argv}")
         test -z "${said}" || out="${out} ${said}"
-    done <<<"${lines}"
+    done
     echo "${out# }"
 }
 
 rules="${srcdir}/debian/rules"
 if test -r "${rules}"; then
     n=$((n + 1))
-    said=$(rules_verdict "${rules}")
+    said=$(rules_verdict "${rules}" "${work}/rules-real")
     test -z "${said}" ||
-        fail "debian/rules does not ask for: ${said} (--disable-auto-features then drops it)"
+        fail_dump "debian/rules does not ask for: ${said}" "${work}/rules-real/make.log"
 
-    # A reader that matched nothing would call any file complete, so put every
-    # way of losing a feature past it. Written out rather than sed'd from the
-    # file above: the reader is the subject, not this file's current layout.
-    all="--disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv"
-    mut=${work}/rules-mut
-    reads() { # reads WANT DESC <<'BODY' -- recipe lines
-        local want=$1 desc=$2 got
-        {
-            printf '#!/usr/bin/make -f\n\noverride_dh_auto_configure:\n'
-            cat
-        } >"${mut}"
-        got=$(rules_verdict "${mut}")
+    # A reader that recorded nothing would call any file complete, so put every
+    # way of losing a feature past it. Every fixture is literal text under a
+    # quoted here-doc: built by expansion, one of them came out with an escaped
+    # quote under bash 3.2 and read as passed on the macOS leg alone.
+    seq=0
+    reads() { # reads WANT DESC <<'MUT' -- a whole makefile with a build target
+        local want=$1 desc=$2 got dir
+        seq=$((seq + 1))
+        dir=${work}/mut${seq}
+        mkdir -p "${dir}"
+        cat >"${dir}/rules"
+        got=$(rules_verdict "${dir}/rules" "${dir}")
         test "${got}" = "${want}" ||
             fail "${desc}: expected [${want}], the reader said [${got:-(nothing)}]"
     }
-    reads "" "the shape debian/rules uses today" <<MUT
-	dh_auto_configure -- ${all}
+    reads "" "the shape debian/rules uses today" <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv
 MUT
-    reads zstd "a dropped --with-zstd" <<MUT
-	dh_auto_configure -- ${all/--with-zstd /}
+    reads zstd "a dropped --with-zstd" <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli --enable-backtrace --with-iconv
 MUT
-    reads zstd "--with-zstd=no" <<MUT
-	dh_auto_configure -- ${all/--with-zstd /--with-zstd=no }
+    reads zstd "--with-zstd=no" <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd=no --enable-backtrace --with-iconv
 MUT
-    reads zstd '--with-zstd="no"' <<MUT
-	dh_auto_configure -- ${all/--with-zstd /--with-zstd=\"no\" }
+    reads zstd "--with-zstd='no', which the shell unquotes" <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd='no' --enable-backtrace --with-iconv
 MUT
-    reads zstd "--without-zstd" <<MUT
-	dh_auto_configure -- ${all/--with-zstd /--without-zstd }
+    reads zstd '--with-zstd="no", which the shell unquotes too' <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd="no" --enable-backtrace --with-iconv
 MUT
-    reads "" "--with-zstd=DIR, which asks for it at a prefix" <<MUT
-	dh_auto_configure -- ${all/--with-zstd /--with-zstd=/opt/zstd }
+    reads zstd "--without-zstd" <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli --without-zstd --enable-backtrace --with-iconv
 MUT
-    reads zstd "a --with-zstd commented out mid-continuation" <<MUT
-	dh_auto_configure -- --disable-auto-features --with-brotli \\
-		# --with-zstd \\
+    reads zstd "--with-zstd=auto, which hands the choice back to the buildd" <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd=auto --enable-backtrace --with-iconv
+MUT
+    reads "" "--with-zstd=DIR, which asks for it at a prefix" <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd=/opt/zstd --enable-backtrace --with-iconv
+MUT
+    reads zstd "a value behind a make variable" <<'MUT'
+WITH_ZSTD = no
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd=$(WITH_ZSTD) --enable-backtrace --with-iconv
+MUT
+    reads "zstd backtrace iconv" "a comment mid-continuation, which runs to the line's end" <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli \
+		# --with-zstd \
 		--enable-backtrace --with-iconv
 MUT
-    reads "zstd backtrace iconv" "a second invocation with -- on its own line" <<MUT
-	dh_auto_configure -- ${all}
-	dh_auto_configure \\
-		-- --disable-auto-features --with-brotli
+    reads "zstd backtrace iconv" "a backslash make does not read as a continuation" <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli \ 
+		--with-zstd --enable-backtrace --with-iconv
 MUT
-    reads "zstd backtrace iconv" "a second invocation behind -Bbuild" <<MUT
-	dh_auto_configure -- ${all}
-	dh_auto_configure -Bbuild -- --disable-auto-features --with-brotli
+    reads "zstd backtrace iconv" "a fallback invocation that never runs" <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli || \
+		dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv
 MUT
-    reads no-disable-auto-features "a list that drops --disable-auto-features" <<MUT
-	dh_auto_configure -- ${all/--disable-auto-features /}
+    reads "zstd backtrace iconv" "a second invocation that overrides the first" <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv
+	dh_auto_configure -- --disable-auto-features --with-brotli
 MUT
-    reads no-invocation "an override target that invokes nothing" <<MUT
+    reads "" "a quoted # in a value, which is not a comment" <<'MUT'
+build:
+	dh_auto_configure -- CPPFLAGS="-DTAG=' #7 '" --disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv
+MUT
+    reads "" "--enable-auto-features=no, the same switch spelled the other way" <<'MUT'
+build:
+	dh_auto_configure -- --enable-auto-features=no --with-brotli --with-zstd --enable-backtrace --with-iconv
+MUT
+    reads no-disable-auto-features "a list that turns neither switch off" <<'MUT'
+build:
+	dh_auto_configure -- --with-brotli --with-zstd --enable-backtrace --with-iconv
+MUT
+    reads no-invocation "a build target that configures nothing" <<'MUT'
+build:
 	true
 MUT
-    echo "ok: every dh_auto_configure in debian/rules asks for every feature by name"
+    echo "ok: every dh_auto_configure debian/rules runs asks for every feature"
 else
     planned=$((planned - 1))
     echo "no debian/rules under ${srcdir}, so the packaging flag list is not read" >&2

--- a/tests/397_configure-auto-features.test
+++ b/tests/397_configure-auto-features.test
@@ -240,17 +240,30 @@ rules_argv() { # rules_argv RULESFILE DIR
     printf '#!/bin/sh\nn=$(cat "%s/n" 2>/dev/null || echo 0)\nn=$((n + 1))\necho "$n" >"%s/n"\nfor a; do printf "%%s\\n" "$a"; done >"%s/argv.$n"\nexit 0\n' \
         "${dir}" "${dir}" "${dir}" >"${dir}/stub/dh_auto_configure"
     chmod +x "${dir}/stub/dh_auto_configure"
-    # Unset the outer make's jobserver, or the inner one warns and drops -j.
-    run_rules() { # run_rules TARGET
-        (cd "${dir}" && PATH="${dir}/stub:${PATH}" MAKEFLAGS='' MFLAGS='' MAKELEVEL='' \
-            ${MAKE:-make} -s -f "$1" "$2") >>"${dir}/make.log" 2>&1 || true
-    }
     : >"${dir}/make.log"
-    run_rules "$1" build
-    # A rules file driven by the dh sequencer keeps its flags in an override
-    # target, which "build" reaches only through dh itself.
-    ! command grep -q '^override_dh_auto_configure:' "$1" ||
-        run_rules "$1" override_dh_auto_configure
+    # Every target a build reaches, not just "build": dpkg-buildpackage runs
+    # build-arch for an arch:any package, and a dh-driven file keeps its flags
+    # in an override target that "build" reaches only through dh itself.
+    # Each pass gets its own directory, or the stamp files the first one leaves
+    # make the rest no-ops. The foreign environment is a sample and not a
+    # proof: it catches a flag behind the conditional a porting fix reaches for.
+    local envs=("" "DEB_HOST_ARCH_OS=hurd DEB_HOST_ARCH=hurd-i386 DEB_BUILD_PROFILES=nocheck DEB_BUILD_OPTIONS=nocheck")
+    local pass=0 target vars make_argv
+    # $MAKE carries its flags on some hosts, the way $CC does above.
+    read -r -a make_argv <<<"${MAKE:-make}"
+    for cmd in "${envs[@]}"; do
+        read -r -a vars <<<"${cmd}"
+        for target in build build-arch build-indep override_dh_auto_configure; do
+            command grep -q "^${target}:" "$1" || continue
+            pass=$((pass + 1))
+            mkdir -p "${dir}/run.${pass}"
+            # Unset the outer make's jobserver, or the inner one warns.
+            (cd "${dir}/run.${pass}" && PATH="${dir}/stub:${PATH}" \
+                MAKEFLAGS='' MFLAGS='' MAKELEVEL='' \
+                env "${vars[@]}" "${make_argv[@]}" -s -f "$1" "${target}") \
+                >>"${dir}/make.log" 2>&1 || true
+        done
+    done
 }
 # Which features one recorded argv does not turn on, or "". "no" is autoconf for
 # --without-X, and "auto" hands the decision back to the build machine, which is
@@ -286,6 +299,25 @@ rules_missing() { # rules_missing ARGVFILE
     done
     echo "${out# }"
 }
+# Off switches the four features above do not cover, one per token, or "".
+# --disable-https ships a package with no TLS, and no amount of checking the
+# auto features would see it. A new one here is a decision, so record it.
+rules_turned_off() { # rules_turned_off ARGVFILE
+    local tok seen=0 out=""
+    while IFS= read -r tok; do
+        if test "${seen}" -eq 0; then
+            test "${tok}" != -- || seen=1
+            continue
+        fi
+        case ${tok} in
+        --disable-auto-features | --disable-online-unit-tests) ;;
+        --without-brotli | --without-zstd | --without-iconv | --disable-backtrace) ;;
+        --disable-* | --without-*) out="${out} turns-off:${tok}" ;;
+        esac
+    done <"$1"
+    echo "${out# }"
+}
+
 # Everything wrong with one rules file, or "" when every dh_auto_configure it
 # runs asks for every feature.
 rules_verdict() { # rules_verdict RULESFILE DIR
@@ -308,8 +340,18 @@ rules_verdict() { # rules_verdict RULESFILE DIR
         test "${off}" -gt 0 || out="${out} no-disable-auto-features"
         said=$(rules_missing "${argv}")
         test -z "${said}" || out="${out} ${said}"
+        said=$(rules_turned_off "${argv}")
+        test -z "${said}" || out="${out} ${said}"
     done
-    echo "${out# }"
+    # Two environments and up to four targets record the same file, so the same
+    # verdict comes back several times. Report each once, first seen first.
+    test -n "${out}" || {
+        echo ""
+        return
+    }
+    # shellcheck disable=SC2086 # the splitting is what makes it a list
+    printf '%s\n' ${out} |
+        awk '!seen[$0]++ { printf "%s%s", sep, $0; sep = " " } END { print "" }'
 }
 
 rules="${srcdir}/debian/rules"
@@ -422,6 +464,24 @@ MUT
     reads no-disable-auto-features "a list that turns neither switch off" <<'MUT'
 build:
 	dh_auto_configure -- --with-brotli --with-zstd --enable-backtrace --with-iconv
+MUT
+    reads turns-off:--disable-https "an off switch outside the four features" <<'MUT'
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv --disable-https
+MUT
+    reads zstd "a flag behind an architecture conditional" <<'MUT'
+ZSTD = --with-zstd
+ifeq ($(DEB_HOST_ARCH_OS),hurd)
+ZSTD =
+endif
+build:
+	dh_auto_configure -- --disable-auto-features --with-brotli $(ZSTD) --enable-backtrace --with-iconv
+MUT
+    reads "zstd backtrace iconv" "build-arch, which is what a buildd runs" <<'MUT'
+build:
+	true
+build-arch:
+	dh_auto_configure -- --disable-auto-features --with-brotli
 MUT
     reads no-invocation "a build target that configures nothing" <<'MUT'
 build:

--- a/tests/397_configure-auto-features.test
+++ b/tests/397_configure-auto-features.test
@@ -219,65 +219,134 @@ for flag in --disable-auto-features $(for f in ${features}; do feature_flag "${f
     grep -q -e "${flag}" <<<"${help}" || fail "configure --help does not offer ${flag}"
 done
 
-# The flags the Debian build passes. --disable-auto-features makes them the whole
-# optional set, so a flag dropped here ships a package that decodes less and
-# nothing else notices.
-# Every dh_auto_configure invocation, one per line, continuations joined. Each
-# has to stand on its own: a later one overrides the first, so reading only the
-# first lets a shorter list hide behind a complete one.
+# --disable-auto-features makes the flags after it the whole optional set, so a
+# flag dropped from debian/rules ships a package that decodes less.
+# Every dh_auto_configure invocation, one line each, continuations joined. A
+# later one overrides the first, so each has to stand on its own. A "#" in a
+# recipe line is a shell comment, and it is dropped before the join while the
+# trailing backslash it may carry still continues the line.
 rules_flags() { # rules_flags FILE
-    awk '/dh_auto_configure[ \t]+--/ { want = 1; line = "" }
-         want { line = line " " $0 }
-         want && !/\\$/ { gsub(/[ \t\\]+/, " ", line); print line; want = 0 }' "$1"
+    awk '/(^|[ \t;&|(])dh_auto_configure([ \t]|$)/ { want = 1; line = "" }
+         want { t = $0; sub(/(^|[ \t])#.*$/, "", t); line = line " " t }
+         want && !/\\[ \t]*$/ { gsub(/[ \t\\]+/, " ", line); print line; want = 0 }' "$1"
 }
-# Which features a flag list does not turn on, or "". --with-X=no is autoconf's
-# spelling of --without-X, so =DIR asks for the feature and =no asks against it.
-rules_missing() { # rules_missing FLAGS
-    local flags=$1 f flag out=""
+# What the invocation passes on to configure: everything past the first bare --.
+rules_args() { # rules_args FLAGS
+    local tok seen=0 out=""
+    for tok in $1; do
+        if test "${seen}" -eq 0; then
+            test "${tok}" != -- || seen=1
+            continue
+        fi
+        out="${out} ${tok}"
+    done
+    echo "${out# }"
+}
+# Which features an argument list does not turn on, or "". Whole tokens, because
+# a substring match reads a commented-out or quoted flag as passed. --with-X=no
+# is autoconf's spelling of --without-X, and the last spelling wins as it does
+# in configure.
+rules_missing() { # rules_missing ARGS
+    local arglist=$1 f flag tok val state out=""
     for f in ${features}; do
         flag=$(feature_flag "${f}")
-        case " ${flags} " in
-        *" ${flag}=no "*) out="${out} ${f}" ;;
-        *" ${flag} "* | *" ${flag}="*) ;;
-        *) out="${out} ${f}" ;;
-        esac
+        state=off
+        for tok in ${arglist}; do
+            case ${tok} in
+            "${flag}") state=on ;;
+            "${flag}="*)
+                val=${tok#*=}
+                val=${val#[\"\']}
+                val=${val%[\"\']}
+                test "${val}" != no && state=on || state=off
+                ;;
+            esac
+        done
+        test "${state}" = on || out="${out} ${f}"
     done
+    echo "${out# }"
+}
+# Everything wrong with one rules file, or "" when every invocation asks for
+# every feature.
+rules_verdict() { # rules_verdict FILE
+    local lines flags arglist said out=""
+    lines=$(rules_flags "$1")
+    test -n "${lines}" || {
+        echo "no-invocation"
+        return
+    }
+    while read -r flags; do
+        arglist=$(rules_args "${flags}")
+        case " ${arglist} " in
+        *" --disable-auto-features "*) ;;
+        *) out="${out} no-disable-auto-features" ;;
+        esac
+        said=$(rules_missing "${arglist}")
+        test -z "${said}" || out="${out} ${said}"
+    done <<<"${lines}"
     echo "${out# }"
 }
 
 rules="${srcdir}/debian/rules"
 if test -r "${rules}"; then
     n=$((n + 1))
-    lines=$(rules_flags "${rules}")
-    test -n "${lines}" || fail "no dh_auto_configure invocation in ${rules}"
-    while read -r flags; do
-        case " ${flags} " in
-        *" --disable-auto-features "*) ;;
-        *) fail "a dh_auto_configure drops --disable-auto-features: ${flags}" ;;
-        esac
-        said=$(rules_missing "${flags}")
-        test -z "${said}" ||
-            fail "debian/rules asks for no ${said}, which --disable-auto-features then drops"
-    done <<<"${lines}"
+    said=$(rules_verdict "${rules}")
+    test -z "${said}" ||
+        fail "debian/rules does not ask for: ${said} (--disable-auto-features then drops it)"
 
-    # A reader that matched nothing would call any file complete, so put each
-    # way of losing a feature past it and require the same check to name it.
-    said=$(rules_missing "${lines//--with-zstd/}")
-    test "${said}" = zstd || fail "a dropped --with-zstd went unreported: ${said:-(silence)}"
-    said=$(rules_missing "${lines//--with-zstd/--with-zstd=no}")
-    test "${said}" = zstd || fail "--with-zstd=no went unreported: ${said:-(silence)}"
-    said=$(rules_missing "${lines//--with-zstd/--with-zstd=/opt/zstd}")
-    test -z "${said}" || fail "--with-zstd=DIR reads as a refusal: ${said}"
-    {
-        cat "${rules}"
-        printf '\tdh_auto_configure -- --disable-auto-features --with-brotli\n'
-    } >"${work}/rules"
-    said=$(rules_flags "${work}/rules" | awk 'END { print NR + 0 }')
-    test "${said}" -eq 2 || fail "a second dh_auto_configure was not read: ${said} found"
-    # The target line names dh_auto_configure without invoking it.
-    printf 'override_dh_auto_configure:\n\ttrue\n' >"${work}/rules-override"
-    said=$(rules_flags "${work}/rules-override")
-    test -z "${said}" || fail "an override target read as an invocation: ${said}"
+    # A reader that matched nothing would call any file complete, so put every
+    # way of losing a feature past it. Written out rather than sed'd from the
+    # file above: the reader is the subject, not this file's current layout.
+    all="--disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv"
+    mut=${work}/rules-mut
+    reads() { # reads WANT DESC <<'BODY' -- recipe lines
+        local want=$1 desc=$2 got
+        {
+            printf '#!/usr/bin/make -f\n\noverride_dh_auto_configure:\n'
+            cat
+        } >"${mut}"
+        got=$(rules_verdict "${mut}")
+        test "${got}" = "${want}" ||
+            fail "${desc}: expected [${want}], the reader said [${got:-(nothing)}]"
+    }
+    reads "" "the shape debian/rules uses today" <<MUT
+	dh_auto_configure -- ${all}
+MUT
+    reads zstd "a dropped --with-zstd" <<MUT
+	dh_auto_configure -- ${all/--with-zstd /}
+MUT
+    reads zstd "--with-zstd=no" <<MUT
+	dh_auto_configure -- ${all/--with-zstd /--with-zstd=no }
+MUT
+    reads zstd '--with-zstd="no"' <<MUT
+	dh_auto_configure -- ${all/--with-zstd /--with-zstd=\"no\" }
+MUT
+    reads zstd "--without-zstd" <<MUT
+	dh_auto_configure -- ${all/--with-zstd /--without-zstd }
+MUT
+    reads "" "--with-zstd=DIR, which asks for it at a prefix" <<MUT
+	dh_auto_configure -- ${all/--with-zstd /--with-zstd=/opt/zstd }
+MUT
+    reads zstd "a --with-zstd commented out mid-continuation" <<MUT
+	dh_auto_configure -- --disable-auto-features --with-brotli \\
+		# --with-zstd \\
+		--enable-backtrace --with-iconv
+MUT
+    reads "zstd backtrace iconv" "a second invocation with -- on its own line" <<MUT
+	dh_auto_configure -- ${all}
+	dh_auto_configure \\
+		-- --disable-auto-features --with-brotli
+MUT
+    reads "zstd backtrace iconv" "a second invocation behind -Bbuild" <<MUT
+	dh_auto_configure -- ${all}
+	dh_auto_configure -Bbuild -- --disable-auto-features --with-brotli
+MUT
+    reads no-disable-auto-features "a list that drops --disable-auto-features" <<MUT
+	dh_auto_configure -- ${all/--disable-auto-features /}
+MUT
+    reads no-invocation "an override target that invokes nothing" <<MUT
+	true
+MUT
     echo "ok: every dh_auto_configure in debian/rules asks for every feature by name"
 else
     planned=$((planned - 1))
@@ -295,8 +364,7 @@ grep -q 'bad value for auto-features' "${work}/bogus/configure.log" ||
 echo "ok: a value that is neither yes nor no is refused"
 
 n=$((n + 1))
-# Same for a feature's own tri-state: neither an unknown value nor a bare typo
-# may fall through to a default.
+# Same for a feature's own tri-state: an unknown value must not fall through.
 ! run_configure "${work}/btbogus" --enable-backtrace=bogus ||
     fail_dump "--enable-backtrace=bogus was accepted" "${work}/btbogus/configure.log"
 grep -q 'bad value for backtrace' "${work}/btbogus/configure.log" ||
@@ -329,10 +397,8 @@ case ${got} in
 esac
 
 n=$((n + 1))
-# A bare --with-iconv is a request, so a host where iconv does not link must
-# FTBFS rather than quietly fall back to the codepage tables. The header is
-# there and the symbol is not, which is what a renaming libiconv header without
-# its library looks like.
+# A bare --with-iconv must FTBFS where iconv does not link, rather than fall
+# back to the codepage tables. The fixture has the header and not the symbol.
 mkdir -p "${work}/noiconv"
 cat >"${work}/noiconv/iconv.h" <<'HDR'
 #ifndef HTS_NOICONV_H

--- a/tests/397_configure-auto-features.test
+++ b/tests/397_configure-auto-features.test
@@ -245,9 +245,11 @@ rules_argv() { # rules_argv RULESFILE DIR
     chmod +x "${dir}/stub/dh_auto_configure"
     : >"${dir}/make.log"
     : >"${dir}/failed"
-    # Every target a build reaches, not just "build": dpkg-buildpackage runs
-    # build-arch for an arch:any package, and a dh-driven file keeps its flags
-    # in an override target that "build" reaches only through dh itself.
+    # Every target the build phase reaches, not just "build": dpkg-buildpackage
+    # runs build-arch for an arch:any package, and a dh-driven file keeps its
+    # flags in an override or an execute_ hook. A configure hidden in binary or
+    # install is out of reach, because those recipes move files no scratch tree
+    # has and stop before their own dh_auto_configure line.
     # Each pass gets its own directory, or the stamp files the first one leaves
     # make the rest no-ops. The foreign environment is a sample and not a
     # proof: it catches a flag behind the conditional a porting fix reaches for.

--- a/tests/397_configure-auto-features.test
+++ b/tests/397_configure-auto-features.test
@@ -222,18 +222,22 @@ done
 # The flags the Debian build passes. --disable-auto-features makes them the whole
 # optional set, so a flag dropped here ships a package that decodes less and
 # nothing else notices.
+# Every dh_auto_configure invocation, one per line, continuations joined. Each
+# has to stand on its own: a later one overrides the first, so reading only the
+# first lets a shorter list hide behind a complete one.
 rules_flags() { # rules_flags FILE
-    awk '/dh_auto_configure/ { want = 1 }
+    awk '/dh_auto_configure[ \t]+--/ { want = 1; line = "" }
          want { line = line " " $0 }
-         want && !/\\$/ { gsub(/[ \t\\]+/, " ", line); print line; exit }' "$1"
+         want && !/\\$/ { gsub(/[ \t\\]+/, " ", line); print line; want = 0 }' "$1"
 }
-# Which of the features the file does not ask for, or "".
+# Which features a flag list does not turn on, or "". --with-X=no is autoconf's
+# spelling of --without-X, so =DIR asks for the feature and =no asks against it.
 rules_missing() { # rules_missing FLAGS
     local flags=$1 f flag out=""
     for f in ${features}; do
         flag=$(feature_flag "${f}")
-        # The =DIR form asks for it too.
         case " ${flags} " in
+        *" ${flag}=no "*) out="${out} ${f}" ;;
         *" ${flag} "* | *" ${flag}="*) ;;
         *) out="${out} ${f}" ;;
         esac
@@ -244,20 +248,37 @@ rules_missing() { # rules_missing FLAGS
 rules="${srcdir}/debian/rules"
 if test -r "${rules}"; then
     n=$((n + 1))
-    flags=$(rules_flags "${rules}")
-    case " ${flags} " in
-    *" --disable-auto-features "*) ;;
-    *) fail "debian/rules no longer passes --disable-auto-features: ${flags}" ;;
-    esac
-    said=$(rules_missing "${flags}")
-    test -z "${said}" ||
-        fail "debian/rules asks for no ${said}, which --disable-auto-features then drops"
-    # A reader that matched nothing would call any file complete, so drop one
-    # flag and require the same check to name it.
-    said=$(rules_missing "${flags//--with-zstd/}")
-    test "${said}" = zstd ||
-        fail "dropping --with-zstd went unreported: ${said:-(silence)}"
-    echo "ok: debian/rules still asks for every optional feature by name"
+    lines=$(rules_flags "${rules}")
+    test -n "${lines}" || fail "no dh_auto_configure invocation in ${rules}"
+    while read -r flags; do
+        case " ${flags} " in
+        *" --disable-auto-features "*) ;;
+        *) fail "a dh_auto_configure drops --disable-auto-features: ${flags}" ;;
+        esac
+        said=$(rules_missing "${flags}")
+        test -z "${said}" ||
+            fail "debian/rules asks for no ${said}, which --disable-auto-features then drops"
+    done <<<"${lines}"
+
+    # A reader that matched nothing would call any file complete, so put each
+    # way of losing a feature past it and require the same check to name it.
+    said=$(rules_missing "${lines//--with-zstd/}")
+    test "${said}" = zstd || fail "a dropped --with-zstd went unreported: ${said:-(silence)}"
+    said=$(rules_missing "${lines//--with-zstd/--with-zstd=no}")
+    test "${said}" = zstd || fail "--with-zstd=no went unreported: ${said:-(silence)}"
+    said=$(rules_missing "${lines//--with-zstd/--with-zstd=/opt/zstd}")
+    test -z "${said}" || fail "--with-zstd=DIR reads as a refusal: ${said}"
+    {
+        cat "${rules}"
+        printf '\tdh_auto_configure -- --disable-auto-features --with-brotli\n'
+    } >"${work}/rules"
+    said=$(rules_flags "${work}/rules" | awk 'END { print NR + 0 }')
+    test "${said}" -eq 2 || fail "a second dh_auto_configure was not read: ${said} found"
+    # The target line names dh_auto_configure without invoking it.
+    printf 'override_dh_auto_configure:\n\ttrue\n' >"${work}/rules-override"
+    said=$(rules_flags "${work}/rules-override")
+    test -z "${said}" || fail "an override target read as an invocation: ${said}"
+    echo "ok: every dh_auto_configure in debian/rules asks for every feature by name"
 else
     planned=$((planned - 1))
     echo "no debian/rules under ${srcdir}, so the packaging flag list is not read" >&2
@@ -326,7 +347,7 @@ extern size_t iconv(iconv_t cd, char **in, size_t *il, char **out, size_t *ol);
 extern int iconv_close(iconv_t cd);
 #endif
 HDR
-! run_configure "${work}/ic-bare" --with-iconv "CPPFLAGS=-I${work}/noiconv" ||
+! run_configure "${work}/ic-bare" --with-iconv "CPPFLAGS=-I${work}/noiconv ${CPPFLAGS:-}" ||
     fail_dump "a bare --with-iconv was accepted where iconv_open does not link" \
         "${work}/ic-bare/configure.log"
 grep -q 'iconv requested but no iconv.h with a linkable iconv_open' \

--- a/tests/397_configure-auto-features.test
+++ b/tests/397_configure-auto-features.test
@@ -253,6 +253,8 @@ rules_argv() { # rules_argv RULESFILE DIR
     # Each pass gets its own directory, or the stamp files the first one leaves
     # make the rest no-ops. The foreign environment is a sample and not a
     # proof: it catches a flag behind the conditional a porting fix reaches for.
+    # The first pass sets nothing, so its array is empty: expand it in the form
+    # bash 3.2 accepts under set -u.
     local envs=("" "DEB_HOST_ARCH_OS=hurd DEB_HOST_ARCH=hurd-i386 DEB_BUILD_PROFILES=nocheck DEB_BUILD_OPTIONS=nocheck")
     local pass=0 target vars make_argv
     # $MAKE carries its flags on some hosts, the way $CC does above.
@@ -269,7 +271,7 @@ rules_argv() { # rules_argv RULESFILE DIR
             # Unset the outer make's jobserver, or the inner one warns.
             (cd "${dir}/run.${pass}" && PATH="${dir}/stub:${PATH}" \
                 MAKEFLAGS='' MFLAGS='' MAKELEVEL='' \
-                env "${vars[@]}" "${make_argv[@]}" -s -f "$1" "${target}") \
+                env ${vars[@]+"${vars[@]}"} "${make_argv[@]}" -s -f "$1" "${target}") \
                 >>"${dir}/make.log" 2>&1 || echo "${target}" >>"${dir}/failed"
         done
     done
@@ -332,24 +334,18 @@ rules_turned_off() { # rules_turned_off ARGVFILE
 }
 
 # Everything wrong with one rules file, or "" when every dh_auto_configure it
-# runs asks for every feature.
+# runs asks for every feature. Not being able to grade the file is a STATUS and
+# never a word in that list: printed as one it reads as a feature name, and the
+# caller cannot tell the two apart. 2 is nothing to grade, 3 is a pass make
+# could not finish.
 rules_verdict() { # rules_verdict RULESFILE DIR
     local argv said off dir=$2 out=""
     rules_argv "$1" "${dir}"
     set -- "${dir}"/argv.*
-    # A pass that failed is a finding on its own: a recipe configuring through
-    # something other than dh_auto_configure dies here rather than being read.
-    test ! -s "${dir}/failed" || out="make-failed"
-    test -e "$1" || {
-        # Say which: a file make could not run is not a file that configures
-        # nothing, and only one of the two is the packaging bug.
-        test -z "${out}" || {
-            echo "make-failed"
-            return
-        }
-        echo "no-invocation"
-        return
-    }
+    # A recipe configuring through something other than dh_auto_configure dies
+    # here rather than being read, so a failed pass outranks what was recorded.
+    test ! -s "${dir}/failed" || return 3
+    test -e "$1" || return 2
     for argv in "$@"; do
         # --enable-auto-features=no is the same switch spelled the other way.
         off=$(command grep -c -x -e --disable-auto-features -e --enable-auto-features=no "${argv}" || true)
@@ -371,11 +367,21 @@ rules_verdict() { # rules_verdict RULESFILE DIR
 }
 
 rules="${srcdir}/debian/rules"
-if test -r "${rules}"; then
+# Running the recipe is how the flags are read, so a host with no make cannot
+# read them. The other nine steps still run.
+if test -r "${rules}" && ! command -v "${MAKE:-make}" >/dev/null 2>&1; then
+    planned=$((planned - 1))
+    echo "no ${MAKE:-make} here, so debian/rules was not run" >&2
+elif test -r "${rules}"; then
     n=$((n + 1))
-    said=$(rules_verdict "${rules}" "${work}/rules-real")
-    test -z "${said}" ||
-        fail_dump "debian/rules does not ask for: ${said}" "${work}/rules-real/make.log"
+    rc=0
+    said=$(rules_verdict "${rules}" "${work}/rules-real") || rc=$?
+    case ${rc} in
+    0) test -z "${said}" ||
+        fail_dump "debian/rules does not ask for: ${said}" "${work}/rules-real/make.log" ;;
+    2) fail_dump "debian/rules runs no dh_auto_configure" "${work}/rules-real/make.log" ;;
+    *) fail_dump "make could not run debian/rules" "${work}/rules-real/make.log" ;;
+    esac
 
     # A reader that recorded nothing would call any file complete, so put every
     # way of losing a feature past it. Every fixture is literal text under a
@@ -383,7 +389,7 @@ if test -r "${rules}"; then
     # quote under bash 3.2 and read as passed on the macOS leg alone.
     seq=0
     reads() { # reads WANT DESC <<'MUT' -- a whole makefile with a build target
-        local want=$1 desc=$2 got dir
+        local want=$1 desc=$2 got dir rc
         seq=$((seq + 1))
         dir=${work}/mut${seq}
         mkdir -p "${dir}"
@@ -391,7 +397,23 @@ if test -r "${rules}"; then
         # editor or a whitespace lint would take it and the fixture would pass
         # for the wrong reason.
         sed 's/@SP@/ /' >"${dir}/rules"
-        got=$(rules_verdict "${dir}/rules" "${dir}")
+        rc=0
+        got=$(rules_verdict "${dir}/rules" "${dir}") || rc=$?
+        case ${rc} in
+        0)
+            # The list is feature names only. A status word reaching it would
+            # be printed as one, which is how the macOS leg got told that
+            # debian/rules "does not ask for: make-failed".
+            case " ${got} " in
+            *" make-failed "* | *" no-invocation "*)
+                fail "${desc}: a status word reached the feature list: ${got}"
+                ;;
+            esac
+            ;;
+        2) got=no-invocation ;;
+        3) got=make-failed ;;
+        *) got="verdict-error-${rc}" ;;
+        esac
         test "${got}" = "${want}" ||
             fail "${desc}: expected [${want}], the reader said [${got:-(nothing)}]"
     }
@@ -448,7 +470,7 @@ WITH_ZSTD = no
 build:
 	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd=$(WITH_ZSTD) --enable-backtrace --with-iconv
 MUT
-    reads "make-failed zstd backtrace iconv" \
+    reads make-failed \
         "a comment mid-continuation, which ends the line and the build with it" <<'MUT'
 build:
 	dh_auto_configure -- --disable-auto-features --with-brotli \

--- a/tests/397_configure-auto-features.test
+++ b/tests/397_configure-auto-features.test
@@ -70,11 +70,10 @@ feature_libs() { # feature_libs NAME
     backtrace) echo "BACKTRACE_LIBS" ;;
     esac
 }
-# Whether the macro must also reach the installed htsfeatures.h.
+# Whether the macro must also reach the installed htsfeatures.h, or "".
 feature_public() { # feature_public NAME
     case $1 in
-    brotli | zstd) return 0 ;;
-    *) return 1 ;;
+    brotli | zstd) echo yes ;;
     esac
 }
 # What libhttrack.pc must name when it is on, or "" where it names nothing.
@@ -136,7 +135,7 @@ assert_state() { # assert_state DIR NAME on|off
 
     # The installed header a consumer of libhttrack compiles against. config.h
     # is not installed and cannot stand in for it.
-    if feature_public "${f}"; then
+    if test -n "$(feature_public "${f}")"; then
         grep -q "^#define ${macro} ${value}\$" "${dir}/htsfeatures.h" ||
             fail_dump "${f}: htsfeatures.h does not carry ${macro} ${value}" \
                 "${dir}/htsfeatures.h"
@@ -168,7 +167,7 @@ assert_state() { # assert_state DIR NAME on|off
 }
 
 n=0
-planned=7 # steps below; the last one needs the libraries to be installed
+planned=10 # steps below; the last one needs the libraries to be installed
 
 # A GNU-libiconv-shaped prefix: a header that renames iconv_open the way the
 # real one does away from LIBICONV_PLUG, and a library under a subdirectory the
@@ -220,6 +219,50 @@ for flag in --disable-auto-features $(for f in ${features}; do feature_flag "${f
     grep -q -e "${flag}" <<<"${help}" || fail "configure --help does not offer ${flag}"
 done
 
+# The flags the Debian build passes. --disable-auto-features makes them the whole
+# optional set, so a flag dropped here ships a package that decodes less and
+# nothing else notices.
+rules_flags() { # rules_flags FILE
+    awk '/dh_auto_configure/ { want = 1 }
+         want { line = line " " $0 }
+         want && !/\\$/ { gsub(/[ \t\\]+/, " ", line); print line; exit }' "$1"
+}
+# Which of the features the file does not ask for, or "".
+rules_missing() { # rules_missing FLAGS
+    local flags=$1 f flag out=""
+    for f in ${features}; do
+        flag=$(feature_flag "${f}")
+        # The =DIR form asks for it too.
+        case " ${flags} " in
+        *" ${flag} "* | *" ${flag}="*) ;;
+        *) out="${out} ${f}" ;;
+        esac
+    done
+    echo "${out# }"
+}
+
+rules="${srcdir}/debian/rules"
+if test -r "${rules}"; then
+    n=$((n + 1))
+    flags=$(rules_flags "${rules}")
+    case " ${flags} " in
+    *" --disable-auto-features "*) ;;
+    *) fail "debian/rules no longer passes --disable-auto-features: ${flags}" ;;
+    esac
+    said=$(rules_missing "${flags}")
+    test -z "${said}" ||
+        fail "debian/rules asks for no ${said}, which --disable-auto-features then drops"
+    # A reader that matched nothing would call any file complete, so drop one
+    # flag and require the same check to name it.
+    said=$(rules_missing "${flags//--with-zstd/}")
+    test "${said}" = zstd ||
+        fail "dropping --with-zstd went unreported: ${said:-(silence)}"
+    echo "ok: debian/rules still asks for every optional feature by name"
+else
+    planned=$((planned - 1))
+    echo "no debian/rules under ${srcdir}, so the packaging flag list is not read" >&2
+fi
+
 # The cheap, host-independent steps run first: a slow leg that runs out of
 # budget later still covers what the switch means.
 n=$((n + 1))
@@ -229,6 +272,15 @@ n=$((n + 1))
 grep -q 'bad value for auto-features' "${work}/bogus/configure.log" ||
     fail_dump "configure refused the value without saying which flag" "${work}/bogus/configure.log"
 echo "ok: a value that is neither yes nor no is refused"
+
+n=$((n + 1))
+# Same for a feature's own tri-state: neither an unknown value nor a bare typo
+# may fall through to a default.
+! run_configure "${work}/btbogus" --enable-backtrace=bogus ||
+    fail_dump "--enable-backtrace=bogus was accepted" "${work}/btbogus/configure.log"
+grep -q 'bad value for backtrace' "${work}/btbogus/configure.log" ||
+    fail_dump "configure refused the value without saying which flag" "${work}/btbogus/configure.log"
+echo "ok: an unknown --enable-backtrace value is refused"
 
 n=$((n + 1))
 # The switch must not turn a library the packager named into a silent drop (#1502).
@@ -254,6 +306,34 @@ case ${got} in
 *) fail_dump "a foreign host answered '${got}' rather than declining backtrace" \
     "${work}/foreign/configure.log" ;;
 esac
+
+n=$((n + 1))
+# A bare --with-iconv is a request, so a host where iconv does not link must
+# FTBFS rather than quietly fall back to the codepage tables. The header is
+# there and the symbol is not, which is what a renaming libiconv header without
+# its library looks like.
+mkdir -p "${work}/noiconv"
+cat >"${work}/noiconv/iconv.h" <<'HDR'
+#ifndef HTS_NOICONV_H
+#define HTS_NOICONV_H
+#include <stddef.h>
+typedef void *iconv_t;
+#define iconv_open hts_absent_iconv_open
+#define iconv hts_absent_iconv
+#define iconv_close hts_absent_iconv_close
+extern iconv_t iconv_open(const char *to, const char *from);
+extern size_t iconv(iconv_t cd, char **in, size_t *il, char **out, size_t *ol);
+extern int iconv_close(iconv_t cd);
+#endif
+HDR
+! run_configure "${work}/ic-bare" --with-iconv "CPPFLAGS=-I${work}/noiconv" ||
+    fail_dump "a bare --with-iconv was accepted where iconv_open does not link" \
+        "${work}/ic-bare/configure.log"
+grep -q 'iconv requested but no iconv.h with a linkable iconv_open' \
+    "${work}/ic-bare/configure.log" ||
+    fail_dump "configure failed without saying that iconv was the request" \
+        "${work}/ic-bare/configure.log"
+echo "ok: a bare --with-iconv fails the build rather than falling back"
 
 n=$((n + 1))
 # --with-iconv=DIR is the form a keg-only or ports prefix needs, and the one arm

--- a/tests/397_configure-auto-features.test
+++ b/tests/397_configure-auto-features.test
@@ -225,6 +225,9 @@ done
 # and every attempt at it lost to a continuation, a comment or a variable. Run
 # the recipe instead with every dh_* stubbed, and record what the real
 # dh_auto_configure would have been handed: make expands, the shell splits.
+# $MAKE carries its flags on some hosts, the way $CC does above.
+read -r -a make_argv <<<"${MAKE:-make}"
+
 rules_argv() { # rules_argv RULESFILE DIR
     local dir=$2 cmd
     mkdir -p "${dir}/stub"
@@ -256,9 +259,7 @@ rules_argv() { # rules_argv RULESFILE DIR
     # The first pass sets nothing, so its array is empty: expand it in the form
     # bash 3.2 accepts under set -u.
     local envs=("" "DEB_HOST_ARCH_OS=hurd DEB_HOST_ARCH=hurd-i386 DEB_BUILD_PROFILES=nocheck DEB_BUILD_OPTIONS=nocheck")
-    local pass=0 target vars make_argv
-    # $MAKE carries its flags on some hosts, the way $CC does above.
-    read -r -a make_argv <<<"${MAKE:-make}"
+    local pass=0 target vars
     for cmd in "${envs[@]}"; do
         read -r -a vars <<<"${cmd}"
         for target in build build-arch build-indep \
@@ -417,6 +418,45 @@ elif test -r "${rules}"; then
         test "${got}" = "${want}" ||
             fail "${desc}: expected [${want}], the reader said [${got:-(nothing)}]"
     }
+
+    # Two of the fixtures below turn on how make reports a recipe it could not
+    # finish, and that is not the same everywhere: the macOS leg graded as a
+    # silent short list what reds here, on either make version and any of three
+    # shells. So measure this host and require the reader to agree with it. A
+    # fixture asserting a fixed outcome there would be asserting the build
+    # machine, which is the whole defect this file exists to keep out.
+    measured() { # measured DESC <<'MUT' -- the reader must match this host
+        local desc=$1 dir got want rc=0 prc=0
+        seq=$((seq + 1))
+        dir=${work}/mut${seq}
+        mkdir -p "${dir}/probe/stub" "${dir}/probe/run"
+        sed 's/@SP@/ /' >"${dir}/rules"
+        # An independent run. Only the token grammar is shared with the reader,
+        # and the fixtures above pin that on its own.
+        # shellcheck disable=SC2016 # the probe's own expansions, not this shell's
+        printf '#!/bin/sh\nfor a; do printf "%%s\\n" "$a"; done >"%s/probe/argv"\nexit 0\n' \
+            "${dir}" >"${dir}/probe/stub/dh_auto_configure"
+        chmod +x "${dir}/probe/stub/dh_auto_configure"
+        : >"${dir}/probe/argv"
+        (cd "${dir}/probe/run" && PATH="${dir}/probe/stub:${PATH}" \
+            MAKEFLAGS='' MFLAGS='' MAKELEVEL='' \
+            "${make_argv[@]}" -s -f "${dir}/rules" build) >/dev/null 2>&1 || prc=$?
+        if test "${prc}" -ne 0; then
+            want=make-failed
+        else
+            want=$(rules_missing "${dir}/probe/argv")
+        fi
+        got=$(rules_verdict "${dir}/rules" "${dir}") || rc=$?
+        case ${rc} in
+        0) ;;
+        2) got=no-invocation ;;
+        3) got=make-failed ;;
+        *) got="verdict-error-${rc}" ;;
+        esac
+        test "${got}" = "${want}" ||
+            fail "${desc}: this make gives [${want:-(nothing)}], the reader said [${got:-(nothing)}]"
+        echo "${desc}: this make gives [${want:-nothing missing}]" >&2
+    }
     reads "" "the shape debian/rules uses today" <<'MUT'
 build:
 	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv
@@ -470,16 +510,13 @@ WITH_ZSTD = no
 build:
 	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd=$(WITH_ZSTD) --enable-backtrace --with-iconv
 MUT
-    reads make-failed \
-        "a comment mid-continuation, which ends the line and the build with it" <<'MUT'
+    measured "a comment mid-continuation, which ends the line" <<'MUT'
 build:
 	dh_auto_configure -- --disable-auto-features --with-brotli \
 		# --with-zstd \
 		--enable-backtrace --with-iconv
 MUT
-    # make exits 0 here: the orphan line starts with "-", which is make's own
-    # ignore-errors prefix, so the short list ships and nothing says so.
-    reads "zstd backtrace iconv" "a backslash make does not read as a continuation" <<'MUT'
+    measured "a backslash make does not read as a continuation" <<'MUT'
 build:
 	dh_auto_configure -- --disable-auto-features --with-brotli \@SP@
 		--with-zstd --enable-backtrace --with-iconv
@@ -532,7 +569,7 @@ MUT
 build:
 	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv --enable-example-libs=no
 MUT
-    reads make-failed "a configure run that is not dh_auto_configure" <<'MUT'
+    measured "a configure run that is not dh_auto_configure" <<'MUT'
 build:
 	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv
 	./configure --disable-auto-features --with-brotli
@@ -559,7 +596,7 @@ build:
 override_dh_auto_configure:
 	dh_auto_configure -- --disable-auto-features --with-brotli --with-zstd --enable-backtrace --with-iconv
 MUT
-    reads make-failed "a rules file make cannot run" <<'MUT'
+    measured "a rules file make cannot run" <<'MUT'
 build:
 	false
 MUT


### PR DESCRIPTION
Three follow-ups a review of #1509 left open.

`debian/rules` passes `--disable-auto-features` and then names the four optional features by flag, which makes that list the whole optional set. Nothing checked the list, so deleting `--with-zstd` from it would have shipped a package that cannot decode zstd and stayed green. 397 reads the flags out of `debian/rules` now and requires every feature it knows to be named.

Six review rounds went at this check and the first five each got through it. Three readers in a row lost to make and shell syntax, so the check no longer reads `debian/rules` at all. It runs the recipe with every `dh_*` stubbed and records what `dh_auto_configure` is handed. Make expands the variables and picks the recipe, the shell splits the words, and only a list of tokens is left to judge.

What walked past one reader or another, all of it now pinned by a fixture:

- `--with-zstd=no`, `--without-zstd` behind the positive flag, and a value behind a make variable
- a `--with-zstd` commented out mid-continuation, and a backslash with a space after it that make does not join
- a fallback invocation that never runs, and a second one that overrides the first
- `--with-zstd=auto`, which hands the decision back to the buildd and is the lottery the flag list exists to end
- a `dh_auto_configure` under `build-arch`, which is what `dpkg-buildpackage` runs for an arch:any package, or behind a `dh` sequencer's override target
- a flag behind an `ifeq` on `DEB_HOST_ARCH_OS`
- `--disable-https` and `--enable-https=no`, which no amount of checking the four auto features would see
- a `dh_auto_configure` in an arch-only override or an `execute_after_` hook, and a `./configure` run that is not `dh_auto_configure` at all

Three bounds are deliberate. The recorded flags are this host's expansion. A second pass under a foreign `DEB_HOST_ARCH_OS` is a sample rather than a proof. A flag gated on a file in the source tree escapes it. A feature dropped by removing its `Build-Depends` makes the build fail loudly, so it needs no catching here. Every recorded invocation has to carry the whole list, which would red a rules file that configures a second time for something else. A configure hidden in `binary` or `install` is out of reach, because those recipes move files no scratch tree has and stop before it.

Thirty-two fixtures pin the reader, written as literal text. Built by expansion instead, the `--with-zstd="no"` case came out with an escaped quote under bash 3.2 and read as passed on the macOS leg alone.

Four of them measure rather than assert. A broken recipe reaches make either as a failure or as a silently shorter flag list, and which one depends on the host. A comment inside a continuation reds on Linux and grades as a short list on macOS. Those four run their makefile through a plain make first, then require the reader to report what that run did. GNU make 3.81 built from source agrees with 4.4.1 here on all thirty-two, under `/bin/sh`, bash and dash alike. So the difference is neither the make version nor the shell, and I have not identified it.

Two error arms configure has and 397 did not exercise. A bare `--with-iconv` has to fail the build where `iconv_open` does not link, rather than fall back to the codepage tables. The fixture is a header declaring the symbol under a name nothing provides. That is what a renaming libiconv header without its library looks like. `--enable-backtrace=bogus` has to be refused the way `--enable-auto-features=maybe` already is.

`feature_public` returned an exit status where its five siblings echo a string. It echoes now, and it echoes nothing for a feature whose macro stays out of the installed header. That is the shape `feature_libs` and `feature_pc` already use for the same idea.