### PR TITLE
The Windows suite can only run under MSYS, whose fork emulation breaks first under load

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -299,6 +299,9 @@ jobs:
       # MSYS's fork emulation is what breaks first under load (#1273).
       - name: Bring up WSL2
         if: matrix.platform == 'x64'
+        # Non-gating like the suite step it feeds: this runs inside a job whose
+        # context `Protect master` requires, so a flaky import must not red it.
+        continue-on-error: true
         shell: pwsh
         timeout-minutes: 15
         run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -342,7 +342,9 @@ jobs:
           # itself for the two views it needs.
           export WSLENV='HTTRACK_SUITE_BACKEND:HTTRACK_SUITE_JOBS:RUNNER_TEMP:WATCHDOG_TOKEN:WATCHDOG_REPO:WATCHDOG_SHA:WATCHDOG_CONTEXT:WATCHDOG_URL:GITHUB_STEP_SUMMARY/p'
           export HTTRACK_SUITE_BACKEND=wsl2
-          ws=$(wslpath -u "$GITHUB_WORKSPACE")
+          # wslpath lives inside the distro: this step's shell is Git Bash,
+          # on the Windows side, where the name does not exist at all.
+          ws=$(wsl -d httrack-suite -- wslpath -u "$GITHUB_WORKSPACE")
           wsl -d httrack-suite --cd "$ws/tests" -- \
             bash ./ci-windows-suite.sh \
             "$ws/src/${{ matrix.platform }}/${{ matrix.configuration }}" \

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -31,6 +31,14 @@ jobs:
       matrix:
         platform: [x64, Win32]
         configuration: [Release]
+        # Which shell drives the suite against the same native httrack.exe.
+        # Win32 runs msys only: the second backend is about the harness, not
+        # about the engine's word size, so a third leg would buy nothing and
+        # every added Windows job is a job the runner can kill (#1228).
+        backend: [msys, wsl2]
+        exclude:
+          - platform: Win32
+            backend: wsl2
     # No repo-wide cap: #1213 added one against runner starvation, which #1228
     # later measured out. The step timeouts stay as they are, sized by 226
     # against the suite watchdog, not against how long a job takes.
@@ -261,6 +269,7 @@ jobs:
       # The *_local-* ones crawl the bundled Python server over loopback: the real
       # TLS handshake, cache and file writer, which nothing else on Windows covers.
       - name: Run the engine test suite (offline tests)
+        if: matrix.backend == 'msys'
         shell: bash
         working-directory: tests
         timeout-minutes: 45
@@ -274,7 +283,7 @@ jobs:
           # The PR head, not github.sha: a merge commit is garbage-collected, and
           # these statuses are the only trace a lost runner leaves (#1228).
           WATCHDOG_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          WATCHDOG_CONTEXT: windows-suite (${{ matrix.platform }}, ${{ matrix.configuration }})
+          WATCHDOG_CONTEXT: windows-suite (${{ matrix.platform }}, ${{ matrix.configuration }}, ${{ matrix.backend }})
           WATCHDOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           # Teed: the MSYS fork failures (#1273) land on this stderr, which no
@@ -286,18 +295,67 @@ jobs:
       # Its own step: the watchdog can kill the suite's step before it counts,
       # which is exactly when the count is worth having.
       - name: Count the MSYS fork failures and the lost workers
-        if: always()
+        if: always() && matrix.backend == 'msys'
         shell: bash
         working-directory: tests
         run: |
           . ./ci-windows-suite.sh
           ci_report_fork_failures suite-console.log
 
+      # WSL2 brings up in ~35s on a hosted runner with no reboot and no
+      # third-party action: the three features are already enabled on the image.
+      # It buys a real Linux shell against the same native httrack.exe, where
+      # MSYS's fork emulation is what breaks first under load (#1273).
+      - name: Bring up WSL2
+        if: matrix.backend == 'wsl2'
+        shell: pwsh
+        timeout-minutes: 15
+        run: |
+          wsl --update
+          if ($LASTEXITCODE -ne 0) { throw "wsl --update failed" }
+          wsl --set-default-version 2
+          $root = "$env:RUNNER_TEMP\wsl-rootfs.tar.gz"
+          # jammy, not noble: the noble rootfs asset 404s as of 2026-09.
+          Invoke-WebRequest -UseBasicParsing -OutFile $root `
+            "https://cloud-images.ubuntu.com/wsl/jammy/current/ubuntu-jammy-wsl-amd64-wsl.rootfs.tar.gz"
+          wsl --import httrack-suite "$env:RUNNER_TEMP\wsl-distro" $root --version 2
+          if ($LASTEXITCODE -ne 0) { throw "wsl --import failed" }
+          # A distro that answers is the only proof the import is usable.
+          wsl -d httrack-suite -- uname -a
+          if ($LASTEXITCODE -ne 0) { throw "the imported distro does not run" }
+
+      - name: Run the engine test suite (offline tests, WSL2)
+        if: matrix.backend == 'wsl2'
+        # The harness is new: a red here must not gate the job until it has a
+        # few days of history to read it against. Flip this once it has.
+        continue-on-error: true
+        shell: bash
+        working-directory: tests
+        timeout-minutes: 45
+        env:
+          HTTRACK_SUITE_JOBS: 4
+          WATCHDOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WATCHDOG_REPO: ${{ github.repository }}
+          WATCHDOG_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          WATCHDOG_CONTEXT: windows-suite (${{ matrix.platform }}, ${{ matrix.configuration }}, ${{ matrix.backend }})
+          WATCHDOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # /p translates a value as a path on the way in; RUNNER_TEMP goes over
+          # untranslated, since the driver takes the Windows form and converts it
+          # itself for the two views it needs.
+          export WSLENV='HTTRACK_SUITE_BACKEND:HTTRACK_SUITE_JOBS:RUNNER_TEMP:WATCHDOG_TOKEN:WATCHDOG_REPO:WATCHDOG_SHA:WATCHDOG_CONTEXT:WATCHDOG_URL:GITHUB_STEP_SUMMARY/p'
+          export HTTRACK_SUITE_BACKEND=wsl2
+          ws=$(wslpath -u "$GITHUB_WORKSPACE")
+          wsl -d httrack-suite --cd "$ws/tests" -- \
+            bash ./ci-windows-suite.sh \
+            "$ws/src/${{ matrix.platform }}/${{ matrix.configuration }}" \
+            2>&1 | tee suite-console.log
+
       - name: Upload the test logs
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: engine-tests-${{ matrix.platform }}-${{ matrix.configuration }}
+          name: engine-tests-${{ matrix.platform }}-${{ matrix.configuration }}-${{ matrix.backend }}
           path: tests/*.log
           if-no-files-found: warn
 
@@ -305,6 +363,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: msbuild-${{ matrix.platform }}-${{ matrix.configuration }}
+          name: msbuild-${{ matrix.platform }}-${{ matrix.configuration }}-${{ matrix.backend }}
           path: msbuild-*.log
           if-no-files-found: ignore

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -31,14 +31,6 @@ jobs:
       matrix:
         platform: [x64, Win32]
         configuration: [Release]
-        # Which shell drives the suite against the same native httrack.exe.
-        # Win32 runs msys only: the second backend is about the harness, not
-        # about the engine's word size, so a third leg would buy nothing and
-        # every added Windows job is a job the runner can kill (#1228).
-        backend: [msys, wsl2]
-        exclude:
-          - platform: Win32
-            backend: wsl2
     # No repo-wide cap: #1213 added one against runner starvation, which #1228
     # later measured out. The step timeouts stay as they are, sized by 226
     # against the suite watchdog, not against how long a job takes.
@@ -269,7 +261,6 @@ jobs:
       # The *_local-* ones crawl the bundled Python server over loopback: the real
       # TLS handshake, cache and file writer, which nothing else on Windows covers.
       - name: Run the engine test suite (offline tests)
-        if: matrix.backend == 'msys'
         shell: bash
         working-directory: tests
         timeout-minutes: 45
@@ -283,7 +274,7 @@ jobs:
           # The PR head, not github.sha: a merge commit is garbage-collected, and
           # these statuses are the only trace a lost runner leaves (#1228).
           WATCHDOG_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          WATCHDOG_CONTEXT: windows-suite (${{ matrix.platform }}, ${{ matrix.configuration }}, ${{ matrix.backend }})
+          WATCHDOG_CONTEXT: windows-suite (${{ matrix.platform }}, ${{ matrix.configuration }})
           WATCHDOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           # Teed: the MSYS fork failures (#1273) land on this stderr, which no
@@ -295,7 +286,7 @@ jobs:
       # Its own step: the watchdog can kill the suite's step before it counts,
       # which is exactly when the count is worth having.
       - name: Count the MSYS fork failures and the lost workers
-        if: always() && matrix.backend == 'msys'
+        if: always()
         shell: bash
         working-directory: tests
         run: |
@@ -307,7 +298,7 @@ jobs:
       # It buys a real Linux shell against the same native httrack.exe, where
       # MSYS's fork emulation is what breaks first under load (#1273).
       - name: Bring up WSL2
-        if: matrix.backend == 'wsl2'
+        if: matrix.platform == 'x64'
         shell: pwsh
         timeout-minutes: 15
         run: |
@@ -325,19 +316,21 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "the imported distro does not run" }
 
       - name: Run the engine test suite (offline tests, WSL2)
-        if: matrix.backend == 'wsl2'
+        if: matrix.platform == 'x64'
         # The harness is new: a red here must not gate the job until it has a
         # few days of history to read it against. Flip this once it has.
         continue-on-error: true
         shell: bash
         working-directory: tests
+        # 45 like the msys step, and 226_watchdog-native.test enforces it: the
+        # suite's own 1500s deadline plus the watchdog's 900s does not fit in less.
         timeout-minutes: 45
         env:
           HTTRACK_SUITE_JOBS: 4
           WATCHDOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WATCHDOG_REPO: ${{ github.repository }}
           WATCHDOG_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          WATCHDOG_CONTEXT: windows-suite (${{ matrix.platform }}, ${{ matrix.configuration }}, ${{ matrix.backend }})
+          WATCHDOG_CONTEXT: windows-suite-wsl2 (${{ matrix.platform }}, ${{ matrix.configuration }})
           WATCHDOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           # /p translates a value as a path on the way in; RUNNER_TEMP goes over
@@ -355,7 +348,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: engine-tests-${{ matrix.platform }}-${{ matrix.configuration }}-${{ matrix.backend }}
+          name: engine-tests-${{ matrix.platform }}-${{ matrix.configuration }}
           path: tests/*.log
           if-no-files-found: warn
 
@@ -363,6 +356,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: msbuild-${{ matrix.platform }}-${{ matrix.configuration }}-${{ matrix.backend }}
+          name: msbuild-${{ matrix.platform }}-${{ matrix.configuration }}
           path: msbuild-*.log
           if-no-files-found: ignore

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -298,7 +298,7 @@ jobs:
       # It buys a real Linux shell against the same native httrack.exe, where
       # MSYS's fork emulation is what breaks first under load (#1273).
       - name: Bring up WSL2
-        if: matrix.platform == 'x64'
+        if: always() && matrix.platform == 'x64'
         # Non-gating like the suite step it feeds: this runs inside a job whose
         # context `Protect master` requires, so a flaky import must not red it.
         continue-on-error: true
@@ -320,7 +320,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "the imported distro does not run" }
 
       - name: Run the engine test suite (offline tests, WSL2)
-        if: matrix.platform == 'x64'
+        if: always() && matrix.platform == 'x64'
         # The harness is new: a red here must not gate the job until it has a
         # few days of history to read it against. Flip this once it has.
         continue-on-error: true

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -342,9 +342,17 @@ jobs:
           # itself for the two views it needs.
           export WSLENV='HTTRACK_SUITE_BACKEND:HTTRACK_SUITE_JOBS:RUNNER_TEMP:WATCHDOG_TOKEN:WATCHDOG_REPO:WATCHDOG_SHA:WATCHDOG_CONTEXT:WATCHDOG_URL:GITHUB_STEP_SUMMARY/p'
           export HTTRACK_SUITE_BACKEND=wsl2
-          # wslpath lives inside the distro: this step's shell is Git Bash,
-          # on the Windows side, where the name does not exist at all.
-          ws=$(wsl -d httrack-suite -- wslpath -u "$GITHUB_WORKSPACE")
+          # Each converter runs on its own side: cygpath is MSYS's, wslpath is
+          # the distro's. Forward slashes first, because a backslash does not
+          # survive the trip in and wslpath saw "D:ahttrackhttrack".
+          ws=$(wsl -d httrack-suite -- wslpath -u "$(cygpath -m "$GITHUB_WORKSPACE")")
+          case "$ws" in
+          /mnt/*) ;;
+          *)
+            echo "::error::the workspace did not convert to a drvfs path: $ws"
+            exit 1
+            ;;
+          esac
           wsl -d httrack-suite --cd "$ws/tests" -- \
             bash ./ci-windows-suite.sh \
             "$ws/src/${{ matrix.platform }}/${{ matrix.configuration }}" \

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -306,9 +306,10 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "wsl --update failed" }
           wsl --set-default-version 2
           $root = "$env:RUNNER_TEMP\wsl-rootfs.tar.gz"
-          # jammy, not noble: the noble rootfs asset 404s as of 2026-09.
+          # jammy, not noble: the noble rootfs asset 404s as of 2026-09. The
+          # jammy asset is named after its release, not "wsl.rootfs".
           Invoke-WebRequest -UseBasicParsing -OutFile $root `
-            "https://cloud-images.ubuntu.com/wsl/jammy/current/ubuntu-jammy-wsl-amd64-wsl.rootfs.tar.gz"
+            "https://cloud-images.ubuntu.com/wsl/jammy/current/ubuntu-jammy-wsl-amd64-ubuntu22.04lts.rootfs.tar.gz"
           wsl --import httrack-suite "$env:RUNNER_TEMP\wsl-distro" $root --version 2
           if ($LASTEXITCODE -ne 0) { throw "wsl --import failed" }
           # A distro that answers is the only proof the import is usable.

--- a/tests/01_engine-topindex.test
+++ b/tests/01_engine-topindex.test
@@ -14,4 +14,4 @@ cleanup_push rm -rf "$dir"
 # output is more than the marker.
 got=$(httrack -O /dev/null -#test=topindex "$dir" run) || fail "topindex: exited $?"
 assert_match "topindex self-test OK" "$got"
-is_windows || assert_match "could not rebuild the top index" "$got"
+target_is_windows || assert_match "could not rebuild the top index" "$got"

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -82,7 +82,7 @@ grep -q "own process tree" "$out" || fail "no process list in the diagnostics"
 # that log takes the silence of a dump for a wedge. Only a slow dump tells the two
 # orderings apart, and the dump's own ps is what this makes slow.
 realps=$(command -v ps) || realps= # the emulated buildds ship without one
-if is_windows || test -z "$realps"; then
+if target_is_windows || test -z "$realps"; then
     echo "note: no slow ps to build here, the announcement ordering is not measured"
 else
     rm -f "$tmp/ps-used"
@@ -276,7 +276,7 @@ done
 
 # --- the process lists survive a host with no ps ----------------------------
 # Fedora's build root ships no procps, and the guard then named nothing (#1021).
-if ! is_windows && test -r /proc/self/stat; then
+if ! target_is_windows && test -r /proc/self/stat; then
     mkdir -p "$tmp/nops"
     printf '#!/bin/sh\nexit 127\n' >"$tmp/nops/ps"
     chmod +x "$tmp/nops/ps"
@@ -401,7 +401,7 @@ fi
 # --- an emulated buildd hides the engine behind its binfmt interpreter -------
 # Two cases the process above cannot carry: a wrapper, and an emulator given a
 # disk image instead of a program. No runner has qemu-user, so synthesize them.
-if ! is_windows; then
+if ! target_is_windows; then
     (
         # shellcheck disable=SC2317 # reached through the two matchers below
         ps_snapshot() {
@@ -431,7 +431,7 @@ fi
 # The whole point of the dump: name the frame the engine is stuck in. Windows has
 # neither half (MSYS signals do not reach a native httrack.exe, and that build has
 # no backtrace()), so only assert it where the machinery exists.
-if is_windows; then
+if target_is_windows; then
     echo "suite timeout OK (no stack capture on Windows)"
     exit 0
 fi

--- a/tests/119_local-proxytrack-ndx-fields2.test
+++ b/tests/119_local-proxytrack-ndx-fields2.test
@@ -97,7 +97,7 @@ test "$(mime_of "$dir/out.arc" example.com/a.html)" = audio/midi ||
 long=$(printf '%3000s' '' | tr ' ' 'x')
 convert "$dir/$long.ndx" "over-long .ndx name"
 
-if is_windows; then
+if target_is_windows; then
     echo "deep paths need a POSIX filesystem; index name half only" >&2
     exit 0
 fi

--- a/tests/157_crash-argv0-path.test
+++ b/tests/157_crash-argv0-path.test
@@ -15,7 +15,7 @@ out=
 
 fail_dump_var out
 
-if is_windows; then
+if target_is_windows; then
     skip "no backtrace() on Windows"
 fi
 if ! command -v addr2line >/dev/null && ! command -v llvm-symbolizer >/dev/null; then

--- a/tests/158_local-link-control-bytes.test
+++ b/tests/158_local-link-control-bytes.test
@@ -11,7 +11,7 @@ set -eu
 
 # The fixtures carry the raw bytes the requests decode back to, which NTFS
 # refuses.
-! is_windows || ! echo "control bytes are illegal in a Windows filename" >&2 ||
+! target_is_windows || ! echo "control bytes are illegal in a Windows filename" >&2 ||
     exit 77
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_982.XXXXXX") || exit 1

--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -307,7 +307,9 @@ def audit(wf):
         if (s.get("with") or {}).get("persist-credentials") is not False:
             bad.append("a checkout persists the job token for the whole job")
     jobs, found = suite_jobs(wf), suite_steps(wf)
-    if len(jobs) != 1 or len(found) != 1:
+    # One job, but a step per backend: each drives the same suite from a
+    # different shell and each posts its own status, so all of them are audited.
+    if len(jobs) != 1 or not found:
         bad.append("%d jobs and %d steps run the suite, cannot tell which is watched" % (len(jobs), len(found)))
         return bad
     perms = perms_of(wf, jobs[0])
@@ -315,21 +317,23 @@ def audit(wf):
         bad.append("the suite job cannot post a commit status: statuses is %r" % perms.get("statuses"))
     if perms.get("contents") != "read":
         bad.append("contents: read was dropped from the suite job")
-    env = found[0].get("env") or {}
-    for v, want in WANT_ENV.items():
-        if env.get(v) != want:
-            bad.append("%s is %r, want %r" % (v, env.get(v), want))
-    # Both axes, or the matrix legs overwrite each other's status.
-    for axis in ("matrix.platform", "matrix.configuration"):
-        if axis not in str(env.get("WATCHDOG_CONTEXT") or ""):
-            bad.append("WATCHDOG_CONTEXT does not name %s" % axis)
-    if "github.run_id" not in str(env.get("WATCHDOG_URL") or ""):
-        bad.append("WATCHDOG_URL does not link the run being watched")
-    cap = found[0].get("timeout-minutes")
-    if not isinstance(cap, int):
-        bad.append("the suite step has no timeout-minutes of its own")
-    else:
-        print("timeout=%d" % cap)
+    for step in found:
+        env = step.get("env") or {}
+        where = str(step.get("name") or "?")
+        for v, want in WANT_ENV.items():
+            if env.get(v) != want:
+                bad.append("%s: %s is %r, want %r" % (where, v, env.get(v), want))
+        # Every axis, or the matrix legs overwrite each other's status.
+        for axis in ("matrix.platform", "matrix.configuration", "matrix.backend"):
+            if axis not in str(env.get("WATCHDOG_CONTEXT") or ""):
+                bad.append("%s: WATCHDOG_CONTEXT does not name %s" % (where, axis))
+        if "github.run_id" not in str(env.get("WATCHDOG_URL") or ""):
+            bad.append("%s: WATCHDOG_URL does not link the run being watched" % where)
+        cap = step.get("timeout-minutes")
+        if not isinstance(cap, int):
+            bad.append("%s: the suite step has no timeout-minutes of its own" % where)
+        else:
+            print("timeout=%d" % cap)
     return bad
 
 def mutate(wf, kind):
@@ -365,7 +369,9 @@ else:
 PY
     said=$("$py" "$tmp/wf.py" audit "$workflow") || fail "the workflow audit did not run: $said"
     grep -q '^BAD ' <<<"$said" && fail "$(grep '^BAD ' <<<"$said" | sed 's/^BAD //')"
-    cap=$(($(sed -n 's/^timeout=//p' <<<"$said") * 60))
+    # The tightest of the backends' step budgets: the watchdog has to fit inside
+    # whichever ends first. sed rather than head, which would SIGPIPE the sort.
+    cap=$(($(sed -n 's/^timeout=//p' <<<"$said" | sort -n | sed -n 1p) * 60))
 
     # One control per key, or an audit that stopped looking at one would ride on
     # another still firing. "none" round-trips the file through the parser, which

--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -324,7 +324,7 @@ def audit(wf):
             if env.get(v) != want:
                 bad.append("%s: %s is %r, want %r" % (where, v, env.get(v), want))
         # Every axis, or the matrix legs overwrite each other's status.
-        for axis in ("matrix.platform", "matrix.configuration", "matrix.backend"):
+        for axis in ("matrix.platform", "matrix.configuration"):
             if axis not in str(env.get("WATCHDOG_CONTEXT") or ""):
                 bad.append("%s: WATCHDOG_CONTEXT does not name %s" % (where, axis))
         if "github.run_id" not in str(env.get("WATCHDOG_URL") or ""):
@@ -334,6 +334,11 @@ def audit(wf):
             bad.append("%s: the suite step has no timeout-minutes of its own" % where)
         else:
             print("timeout=%d" % cap)
+    # The steps run in one job and each posts its own status, so a shared
+    # context makes whichever finishes last overwrite the other's verdict.
+    ctxs = [str((s.get("env") or {}).get("WATCHDOG_CONTEXT") or "") for s in found]
+    if len(set(ctxs)) != len(ctxs):
+        bad.append("two suite steps share a WATCHDOG_CONTEXT: %r" % ctxs)
     return bad
 
 def mutate(wf, kind):
@@ -350,6 +355,13 @@ def mutate(wf, kind):
         suite_steps(wf)[0]["env"]["WATCHDOG_TOKEN"] = "${{ secrets.WATCHDOG_PAT }}"
     elif kind == "sha":
         suite_steps(wf)[0]["env"]["WATCHDOG_SHA"] = "${{ github.sha }}"
+    elif kind == "lastenv":
+        suite_steps(wf)[-1]["env"]["WATCHDOG_TOKEN"] = "literal"
+    elif kind == "sharedcontext":
+        suite_steps(wf)[-1]["env"]["WATCHDOG_CONTEXT"] = \
+            suite_steps(wf)[0]["env"]["WATCHDOG_CONTEXT"]
+    elif kind == "lasttimeout":
+        suite_steps(wf)[-1].pop("timeout-minutes", None)
     elif kind == "context":
         suite_steps(wf)[0]["env"]["WATCHDOG_CONTEXT"] = "windows-suite"
     elif kind == "url":
@@ -379,7 +391,9 @@ PY
     for m in none:'' perm:'cannot post' jobperm:'cannot post' creds:'persists the job token' \
         env:'WATCHDOG_TOKEN is' token:'WATCHDOG_TOKEN is' sha:'WATCHDOG_SHA is' \
         context:'does not name matrix.platform' url:'does not link the run' \
-        cap:'no timeout-minutes of its own'; do
+        cap:'no timeout-minutes of its own' lastenv:'WATCHDOG_TOKEN is' \
+        sharedcontext:'share a WATCHDOG_CONTEXT' \
+        lasttimeout:'no timeout-minutes of its own'; do
         "$py" "$tmp/wf.py" mutate "$workflow" "${m%%:*}" >"$tmp/wf.yml"
         said=$("$py" "$tmp/wf.py" audit "$tmp/wf.yml") ||
             fail "the workflow audit did not run on the ${m%%:*} control: $said"

--- a/tests/227_watchdog-poll.test
+++ b/tests/227_watchdog-poll.test
@@ -46,7 +46,7 @@ sleeps() { wc -l <"$tmp/sleeps" | tr -d ' '; }
 # lost the whole point. The override counts as opting out too, or the escape hatch
 # for a host whose fd tick misbehaves would red the suite it exists to rescue.
 canfifo=
-if test -z "${HTTRACK_POLL_SLEEP:-}" && ! is_windows && mkfifo "$tmp/probe" 2>/dev/null; then
+if test -z "${HTTRACK_POLL_SLEEP:-}" && ! shell_is_msys && mkfifo "$tmp/probe" 2>/dev/null; then
     canfifo=1
 fi
 (

--- a/tests/243_local-ftp-deadhost-interrupt.test
+++ b/tests/243_local-ftp-deadhost-interrupt.test
@@ -10,7 +10,7 @@ set -euo pipefail
 
 python=$(find_python) || skip "python3 not found"
 require_httrack
-! is_windows || ! echo "MSYS cannot signal a native httrack.exe; skipping" >&2 ||
+! target_is_windows || ! echo "MSYS cannot signal a native httrack.exe; skipping" >&2 ||
     exit 77
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_ftpint.XXXXXX")

--- a/tests/244_local-tty-output.test
+++ b/tests/244_local-tty-output.test
@@ -87,7 +87,7 @@ crawl v0 -%v0
 ran "-%v0" v0
 expect "the spinner writes no CR into a pipe" "$(count v0 "$cr")" eq 0 v0
 
-if is_windows; then
+if target_is_windows; then
     echo "[terminal controls] ..	skipped (no pty)"
     exit 0
 fi

--- a/tests/249_windows-reap-images.test
+++ b/tests/249_windows-reap-images.test
@@ -18,6 +18,7 @@ cleanup_push rm -rf "$tmp"
 # is pinned on every host and an MSYS run cannot taskkill this shell.
 IS_WINDOWS=yes
 taskkill() { printf '%s\n' "$*" >>"$tmp/killed"; }
+# shellcheck disable=SC2317 # called as "$(win_exe tasklist)", not by name
 tasklist() { printf 'proxytrack.exe   4242 Console\n'; }
 win_pid() { :; }
 
@@ -123,6 +124,7 @@ done
 if grep -qxF '/F /IM python.exe' "$tmp/killed"; then fail "the reap killed an unrelated python.exe"; fi
 
 # Near misses, not an idle host, are what a widened image matcher lets through.
+# shellcheck disable=SC2317 # called as "$(win_exe tasklist)", not by name
 tasklist() {
     printf 'System Idle Process              0 Services\n'
     printf 'notepad-httrack-notes.exe      77 Console\n'

--- a/tests/249_windows-reap-images.test
+++ b/tests/249_windows-reap-images.test
@@ -18,7 +18,6 @@ cleanup_push rm -rf "$tmp"
 # is pinned on every host and an MSYS run cannot taskkill this shell.
 IS_WINDOWS=yes
 taskkill() { printf '%s\n' "$*" >>"$tmp/killed"; }
-# shellcheck disable=SC2317 # called as "$(win_exe tasklist)", not by name
 tasklist() { printf 'proxytrack.exe   4242 Console\n'; }
 win_pid() { :; }
 
@@ -124,7 +123,6 @@ done
 if grep -qxF '/F /IM python.exe' "$tmp/killed"; then fail "the reap killed an unrelated python.exe"; fi
 
 # Near misses, not an idle host, are what a widened image matcher lets through.
-# shellcheck disable=SC2317 # called as "$(win_exe tasklist)", not by name
 tasklist() {
     printf 'System Idle Process              0 Services\n'
     printf 'notepad-httrack-notes.exe      77 Console\n'

--- a/tests/256_testlib-cleanup.test
+++ b/tests/256_testlib-cleanup.test
@@ -90,7 +90,7 @@ ok "cleanup_push traps no signal unknown to this test"
 # covering TERM alone passes a TERM-only check.
 # INT and QUIT never arrive on either Windows runner; TERM and HUP do.
 sigs=("${trapped[@]}")
-! is_windows || sigs=(TERM HUP)
+! target_is_windows || sigs=(TERM HUP)
 
 # Every leg is reported rather than the first to break: they fail one platform at
 # a time, and the elapsed time tells a signal never delivered from one ignored.

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -214,6 +214,17 @@ Darwin no
 EOF
 ok "an explicit HTS_OS still classifies, with uname unreadable"
 
+# Stub both path tools: testlib refuses to load under wsl2 without wslpath.
+mkdir "$tmpdir/pathbin"
+for t in cygpath wslpath; do
+    cat >"$tmpdir/pathbin/$t" <<EOF
+#!/bin/sh
+printf '$t %s %s\n' "\$1" "\$2"
+EOF
+    chmod +x "$tmpdir/pathbin/$t"
+done
+pathbin=$(posixpath "$tmpdir/pathbin")
+
 ## The wsl2 backend is the case where the two predicates part company: a Linux
 # shell driving a native .exe. Nothing sniffs it, so the driver sets it, and a
 # backend the shell cannot guess must still outrank what uname says.
@@ -222,7 +233,7 @@ printf 'set -euo pipefail\n. "%s/testlib.sh"\nif target_is_windows; then printf 
     "$testdir" >"$tmpdir/split.sh"
 while read -r backend os want; do
     got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND="$backend" HTS_OS="$os" \
-        PATH="$shim:$PATH" bash "$tmpdir/split.sh")
+        PATH="$shim:$pathbin:$PATH" bash "$tmpdir/split.sh")
     test "$got" = "$want" ||
         fail "backend=$backend HTS_OS=$os gave [$got], want [$want] (upper=true)"
 done <<'EOF'
@@ -231,6 +242,42 @@ msys MINGW64_NT-10.0 AB
 posix Linux ab
 EOF
 ok "under wsl2 the binary is Windows while the shell is not"
+
+## path_convert picks its tool from the backend, never from uname: cygpath is
+# MSYS's and wslpath is WSL2's, and they take the same -m and -u.
+cat >"$tmpdir/pc.sh" <<EOF
+set -euo pipefail
+. "$testdir/testlib.sh"
+printf '%s|%s\n' "\$(nativepath /x)" "\$(posixpath /y)"
+EOF
+while read -r backend want; do
+    got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND="$backend" \
+        PATH="$pathbin:$PATH" bash "$tmpdir/pc.sh")
+    test "$got" = "$want" || fail "backend=$backend converted to [$got], want [$want]"
+done <<'EOF'
+msys cygpath -m /x|cygpath -u /y
+wsl2 wslpath -m /x|wslpath -u /y
+posix /x|/y
+EOF
+ok "nativepath and posixpath dispatch on the backend"
+
+# A missing cygpath has always fallen through to the path unchanged. A missing
+# wslpath must not, and the refusal has to land when testlib is sourced: by the
+# time nativepath runs it is inside "$(...)", where an exit ends the subshell
+# and the test carries on with an empty path.
+rc=0
+out=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND=wsl2 bash "$tmpdir/pc.sh" 2>&1) || rc=$?
+test "$rc" -ne 0 || fail "wsl2 with no wslpath passed the path through as [$out]"
+case "$out" in
+*"|"*) fail "wsl2 with no wslpath still reached the conversion: $out" ;;
+esac
+case "$out" in
+*"no wslpath"*) ;;
+*) fail "wsl2 with no wslpath failed without naming the cause: $out" ;;
+esac
+got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND=msys bash "$tmpdir/pc.sh")
+test "$got" = "/x|/y" || fail "msys with no cygpath gave [$got], want the paths unchanged"
+ok "a missing wslpath is fatal where a missing cygpath is not"
 
 # Unshimmed: a guard that fires only on the broken path is half a guard.
 case "$(uname -s)" in

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -190,10 +190,10 @@ shim=$(posixpath "$tmpdir/shim")
 test -z "$(env PATH="$shim:$PATH" uname -s)" ||
     fail "the uname shim never intercepted, so the rest of this would test nothing"
 # shellcheck disable=SC2016
-printf 'set -euo pipefail\n. "%s/testlib.sh"\nif is_windows; then printf yes; else printf no; fi\n' \
+printf 'set -euo pipefail\n. "%s/testlib.sh"\nif target_is_windows; then printf yes; else printf no; fi\n' \
     "$testdir" >"$tmpdir/win.sh"
 rc=0
-out=$(env -u HTS_OS -u IS_WINDOWS PATH="$shim:$PATH" bash "$tmpdir/win.sh" 2>&1) || rc=$?
+out=$(env -u HTS_OS -u IS_WINDOWS -u HTTRACK_SUITE_BACKEND PATH="$shim:$PATH" bash "$tmpdir/win.sh" 2>&1) || rc=$?
 test "$rc" -eq 1 || fail "a silent uname -s exited $rc, not 1: $out"
 case "$out" in
 *"uname -s said nothing"*) ;;
@@ -203,8 +203,8 @@ ok "a uname -s that says nothing fails the run instead of guessing not-Windows"
 
 # The way out for a runner whose uname is broken, so the guard cannot cost it the suite.
 while read -r os want; do
-    got=$(env -u IS_WINDOWS HTS_OS="$os" PATH="$shim:$PATH" bash "$tmpdir/win.sh")
-    test "$got" = "$want" || fail "HTS_OS=$os made is_windows [$got], want [$want]"
+    got=$(env -u IS_WINDOWS -u HTTRACK_SUITE_BACKEND HTS_OS="$os" PATH="$shim:$PATH" bash "$tmpdir/win.sh")
+    test "$got" = "$want" || fail "HTS_OS=$os made target_is_windows [$got], want [$want]"
 done <<'EOF'
 MINGW64_NT-10.0 yes
 MSYS_NT-10.0 yes
@@ -214,14 +214,32 @@ Darwin no
 EOF
 ok "an explicit HTS_OS still classifies, with uname unreadable"
 
+## The wsl2 backend is the case where the two predicates part company: a Linux
+# shell driving a native .exe. Nothing sniffs it, so the driver sets it, and a
+# backend the shell cannot guess must still outrank what uname says.
+# shellcheck disable=SC2016
+printf 'set -euo pipefail\n. "%s/testlib.sh"\nif target_is_windows; then printf A; else printf a; fi\nif shell_is_msys; then printf B; else printf b; fi\n' \
+    "$testdir" >"$tmpdir/split.sh"
+while read -r backend os want; do
+    got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND="$backend" HTS_OS="$os" \
+        PATH="$shim:$PATH" bash "$tmpdir/split.sh")
+    test "$got" = "$want" ||
+        fail "backend=$backend HTS_OS=$os gave [$got], want [$want] (upper=true)"
+done <<'EOF'
+wsl2 Linux Ab
+msys MINGW64_NT-10.0 AB
+posix Linux ab
+EOF
+ok "under wsl2 the binary is Windows while the shell is not"
+
 # Unshimmed: a guard that fires only on the broken path is half a guard.
 case "$(uname -s)" in
 MINGW* | MSYS* | CYGWIN*) want=yes ;;
 *) want=no ;;
 esac
 got=$(env -u IS_WINDOWS bash "$tmpdir/win.sh")
-test "$got" = "$want" || fail "is_windows on this host is [$got], want [$want]"
-ok "is_windows agrees with the host's own uname -s ($want)"
+test "$got" = "$want" || fail "target_is_windows on this host is [$got], want [$want]"
+ok "target_is_windows agrees with the host's own uname -s ($want)"
 
 # skip_on_emulated deletes tests when it fires, and a skip is green, so an
 # inverted guard would quietly empty every leg with nothing going red.

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -229,19 +229,37 @@ pathbin=$(posixpath "$tmpdir/pathbin")
 # shell driving a native .exe. Nothing sniffs it, so the driver sets it, and a
 # backend the shell cannot guess must still outrank what uname says.
 # shellcheck disable=SC2016
-printf 'set -euo pipefail\n. "%s/testlib.sh"\nif target_is_windows; then printf A; else printf a; fi\nif shell_is_msys; then printf B; else printf b; fi\n' \
-    "$testdir" >"$tmpdir/split.sh"
+cat >"$tmpdir/split.sh" <<EOF
+set -euo pipefail
+. "$testdir/testlib.sh"
+target_is_windows && w=yes || w=no
+shell_is_msys && m=yes || m=no
+printf 'win=%s msys=%s\\n' "\$w" "\$m"
+EOF
 while read -r backend os want; do
     got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND="$backend" HTS_OS="$os" \
         PATH="$shim:$pathbin:$PATH" bash "$tmpdir/split.sh")
-    test "$got" = "$want" ||
-        fail "backend=$backend HTS_OS=$os gave [$got], want [$want] (upper=true)"
+    test "$got" = "$want" || fail "backend=$backend HTS_OS=$os gave [$got], want [$want]"
 done <<'EOF'
-wsl2 Linux Ab
-msys MINGW64_NT-10.0 AB
-posix Linux ab
+wsl2 Linux win=yes msys=no
+msys MINGW64_NT-10.0 win=yes msys=yes
+posix Linux win=no msys=no
 EOF
 ok "under wsl2 the binary is Windows while the shell is not"
+
+# IS_WINDOWS is how a non-Windows host forces the Windows paths on
+# (249_windows-reap-images.test). It predates the split and answered both
+# questions at once, so it must still answer both. It is also set AFTER testlib
+# is sourced, which is why nothing may cache the backend it implies.
+while read -r override want; do
+    got=$(env -u HTTRACK_SUITE_BACKEND IS_WINDOWS="$override" HTS_OS=Linux \
+        PATH="$shim:$pathbin:$PATH" bash "$tmpdir/split.sh")
+    test "$got" = "$want" || fail "IS_WINDOWS=$override gave [$got], want [$want]"
+done <<'EOF'
+yes win=yes msys=yes
+no win=no msys=no
+EOF
+ok "the IS_WINDOWS override still reaches both predicates"
 
 ## path_convert picks its tool from the backend, never from uname: cygpath is
 # MSYS's and wslpath is WSL2's, and they take the same -m and -u.
@@ -298,6 +316,13 @@ assert_eq "" "$(win_marker "$tmpdir/cl")" "argv[0] alone"
 mkcmdline "$tmpdir/cl" httrack.exe -q -O out
 assert_eq "" "$(win_marker "$tmpdir/cl")" "only short arguments"
 assert_eq "" "$(win_marker "$tmpdir/nosuchfile")" "no cmdline at all"
+# The real crawl shape, which is where the naive "longest argument" rule broke:
+# local-crawl.sh gives every concurrent crawl the same --user-agent, and it is
+# longer than the output directory, so the marker named all of them at once.
+mkcmdline "$tmpdir/cl" httrack.exe -O "C:/t/httrack_local.AbCdEf" \
+    "--user-agent=httrack 3.50.1 local (Linux 7.0.0-22-generic x86_64)" \
+    "http://127.0.0.1:41917/" -q
+assert_eq "C:/t/httrack_local.AbCdEf" "$(win_marker "$tmpdir/cl")" "a shared --user-agent"
 ok "win_marker picks the launch's own output directory, never argv[0]"
 
 ## An executable's name differs by backend: bare under MSYS, which resolves it
@@ -316,9 +341,15 @@ ok "a Windows executable takes its .exe only under wsl2"
 
 ## win_capture under wsl2 has no /proc/<pid>/winpid to read. It takes the
 # relay's own cmdline instead and asks Windows which process carries it.
+# Real interop passes a variable only when WSLENV names it, so the stub refuses
+# to see one that is not listed. Without this, dropping WSLENV changes nothing
+# here and everything on a runner.
 cat >"$tmpdir/pathbin/powershell.exe" <<'PSEOF'
 #!/bin/sh
-printf '%s\n' "${HTS_WIN_MARKER:-}" >"$PSREC.env"
+case ":${WSLENV:-}:" in
+*:HTS_WIN_MARKER:*) printf '%s\n' "${HTS_WIN_MARKER:-}" >"$PSREC.env" ;;
+*) : >"$PSREC.env" ;;
+esac
 printf '%s\n' "$*" >"$PSREC.argv"
 echo 4242
 PSEOF
@@ -326,14 +357,11 @@ chmod +x "$tmpdir/pathbin/powershell.exe"
 cat >"$tmpdir/cap.sh" <<EOF
 set -euo pipefail
 . "$testdir/testlib.sh"
+# The marker goes in argv[1], where win_marker's argv[0] skip still finds it.
 /bin/sh -c 'sleep 30' "\$1" &
 v=\$!
-# Until the exec lands, the cmdline still names the forking shell: the same race
-# the MSYS winpid read has, and the reason win_capture is not for a fresh job.
-for _ in \$(seq 200); do
-    test "\$(win_marker "/proc/\$v/cmdline")" != "\$1" || break
-    sleep 0.01
-done
+test "\$(win_marker "/proc/\$v/cmdline")" = "\$1" ||
+    echo "the relay's cmdline does not carry the marker" >&2
 win_capture "\$v"
 printf '%s|%s\n' "\$WIN_PID" "\$WIN_IMAGE"
 kill "\$v" 2>/dev/null || true

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -282,9 +282,18 @@ ok "nativepath and posixpath dispatch on the backend"
 # A missing cygpath has always fallen through to the path unchanged. A missing
 # wslpath must not, and the refusal has to land when testlib is sourced: by the
 # time nativepath runs it is inside "$(...)", where an exit ends the subshell
-# and the test carries on with an empty path.
+# and the test carries on with an empty path. A real MSYS runner ships a real
+# cygpath, so PATH must drop it here or this exercises conversion, not absence.
+nocygpath=
+oldifs=$IFS
+IFS=:
+for d in $PATH; do
+    test -x "$d/cygpath" -o -x "$d/cygpath.exe" ||
+        nocygpath="${nocygpath:+$nocygpath:}$d"
+done
+IFS=$oldifs
 rc=0
-out=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND=wsl2 bash "$tmpdir/pc.sh" 2>&1) || rc=$?
+out=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND=wsl2 PATH="$nocygpath" bash "$tmpdir/pc.sh" 2>&1) || rc=$?
 test "$rc" -ne 0 || fail "wsl2 with no wslpath passed the path through as [$out]"
 case "$out" in
 *"|"*) fail "wsl2 with no wslpath still reached the conversion: $out" ;;
@@ -293,7 +302,7 @@ case "$out" in
 *"no wslpath"*) ;;
 *) fail "wsl2 with no wslpath failed without naming the cause: $out" ;;
 esac
-got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND=msys bash "$tmpdir/pc.sh")
+got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND=msys PATH="$nocygpath" bash "$tmpdir/pc.sh")
 test "$got" = "/x|/y" || fail "msys with no cygpath gave [$got], want the paths unchanged"
 ok "a missing wslpath is fatal where a missing cygpath is not"
 
@@ -344,7 +353,10 @@ ok "a Windows executable takes its .exe only under wsl2"
 # Real interop passes a variable only when WSLENV names it, so the stub refuses
 # to see one that is not listed. Without this, dropping WSLENV changes nothing
 # here and everything on a runner.
-cat >"$tmpdir/pathbin/powershell.exe" <<'PSEOF'
+# The relay's own /proc/<pid>/cmdline is what carries the marker, so this needs
+# a real procfs; Darwin and other /proc-less hosts have nothing to read here.
+if test -d /proc; then
+    cat >"$tmpdir/pathbin/powershell.exe" <<'PSEOF'
 #!/bin/sh
 case ":${WSLENV:-}:" in
 *:HTS_WIN_MARKER:*) printf '%s\n' "${HTS_WIN_MARKER:-}" >"$PSREC.env" ;;
@@ -353,8 +365,8 @@ esac
 printf '%s\n' "$*" >"$PSREC.argv"
 echo 4242
 PSEOF
-chmod +x "$tmpdir/pathbin/powershell.exe"
-cat >"$tmpdir/cap.sh" <<EOF
+    chmod +x "$tmpdir/pathbin/powershell.exe"
+    cat >"$tmpdir/cap.sh" <<EOF
 set -euo pipefail
 . "$testdir/testlib.sh"
 # The marker goes in argv[1], where win_marker's argv[0] skip still finds it.
@@ -366,17 +378,18 @@ win_capture "\$v"
 printf '%s|%s\n' "\$WIN_PID" "\$WIN_IMAGE"
 kill "\$v" 2>/dev/null || true
 EOF
-marker="/mnt/c/t/httrack_local.ZzUnique1"
-got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND=wsl2 PSREC="$tmpdir/ps" \
-    PATH="$pathbin:$PATH" bash "$tmpdir/cap.sh" "$marker")
-assert_eq "4242|sh" "$got" "the Windows pid and image win_capture resolved"
-assert_eq "$marker" "$(cat "$tmpdir/ps.env")" "the marker powershell received"
-# In the environment, never on the command line: a marker passed as an argument
-# puts it on the querying process's own cmdline, which then matches itself.
-case "$(cat "$tmpdir/ps.argv")" in
-*"$marker"*) fail "the marker rode powershell's argv: $(cat "$tmpdir/ps.argv")" ;;
-esac
-ok "win_capture resolves the Windows pid by marker, passed out of band"
+    marker="/mnt/c/t/httrack_local.ZzUnique1"
+    got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND=wsl2 PSREC="$tmpdir/ps" \
+        PATH="$pathbin:$PATH" bash "$tmpdir/cap.sh" "$marker")
+    assert_eq "4242|sh" "$got" "the Windows pid and image win_capture resolved"
+    assert_eq "$marker" "$(cat "$tmpdir/ps.env")" "the marker powershell received"
+    # In the environment, never on the command line: a marker passed as an argument
+    # puts it on the querying process's own cmdline, which then matches itself.
+    case "$(cat "$tmpdir/ps.argv")" in
+    *"$marker"*) fail "the marker rode powershell's argv: $(cat "$tmpdir/ps.argv")" ;;
+    esac
+    ok "win_capture resolves the Windows pid by marker, passed out of band"
+fi
 
 # Unshimmed: a guard that fires only on the broken path is half a guard.
 case "$(uname -s)" in

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -333,22 +333,29 @@ ok "win_marker picks the launch's own output directory, never argv[0]"
 # program bare there, and what turns a drvfs argument into one a native exe can
 # open. Copied rather than linked, as the driver does, since this tree may sit
 # on a mount that refuses to execute it.
-mkdir "$tmpdir/shimbin"
-cp "$testdir/wsl2-exe-shim.sh" "$tmpdir/shimbin/faketool"
-cat >"$tmpdir/shimbin/faketool.exe" <<'TOOLEOF'
+# Not under MSYS, which needs no shim (it resolves a bare name to the .exe
+# itself) and cannot run this fixture anyway, because a shell script named .exe
+# is handed to Windows as a PE binary and fails with 127.
+if shell_is_msys; then
+    echo "MSYS resolves the .exe itself, so it runs no shim" >&2
+else
+    mkdir "$tmpdir/shimbin"
+    cp "$testdir/wsl2-exe-shim.sh" "$tmpdir/shimbin/faketool"
+    cat >"$tmpdir/shimbin/faketool.exe" <<'TOOLEOF'
 #!/bin/sh
 printf '%s\n' "$@"
 TOOLEOF
-# A wslpath that really converts, so the assertion below is about the shim.
-cat >"$tmpdir/shimbin/wslpath" <<'WPEOF'
+    # A wslpath that really converts, so the assertion below is about the shim.
+    cat >"$tmpdir/shimbin/wslpath" <<'WPEOF'
 #!/bin/sh
 d=$(printf '%s' "$2" | cut -c6)
 printf '%s:%s\n' "$(printf '%s' "$d" | tr '[:lower:]' '[:upper:]')" "$(printf '%s' "$2" | cut -c7-)"
 WPEOF
-chmod +x "$tmpdir/shimbin/faketool" "$tmpdir/shimbin/faketool.exe" "$tmpdir/shimbin/wslpath"
-got=$(PATH="$tmpdir/shimbin:$PATH" bash "$tmpdir/shimbin/faketool" /mnt/c/x/y -q plain | tr '\n' ' ')
-assert_eq "C:/x/y -q plain " "$got" "what the shim handed the exe"
-ok "the wsl2 shim names the .exe and converts only its drvfs arguments"
+    chmod +x "$tmpdir/shimbin/faketool" "$tmpdir/shimbin/faketool.exe" "$tmpdir/shimbin/wslpath"
+    got=$(PATH="$tmpdir/shimbin:$PATH" bash "$tmpdir/shimbin/faketool" /mnt/c/x/y -q plain | tr '\n' ' ')
+    assert_eq "C:/x/y -q plain " "$got" "what the shim handed the exe"
+    ok "the wsl2 shim names the .exe and converts only its drvfs arguments"
+fi
 
 ## win_capture under wsl2 has no /proc/<pid>/winpid to read. It takes the
 # relay's own cmdline instead and asks Windows which process carries it.

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -279,6 +279,76 @@ got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND=msys bash "$tmpdir/pc.sh")
 test "$got" = "/x|/y" || fail "msys with no cygpath gave [$got], want the paths unchanged"
 ok "a missing wslpath is fatal where a missing cygpath is not"
 
+## win_marker picks the string that tells one launch from another. WSL2 has no
+# /proc/<pid>/winpid, so a wrong pick here kills a stranger or nothing at all.
+mkcmdline() { # mkcmdline FILE ARG...
+    local f=$1
+    shift
+    : >"$f"
+    for a in "$@"; do printf '%s\0' "$a" >>"$f"; done
+}
+mkcmdline "$tmpdir/cl" httrack.exe -O "C:/t/httrack_local.AbCdEf" "http://x/" -q
+assert_eq "C:/t/httrack_local.AbCdEf" "$(win_marker "$tmpdir/cl")" "the output directory"
+
+# argv[0] is the same exe for every concurrent test, so it can never be it.
+mkcmdline "$tmpdir/cl" "C:/a/very/long/path/to/httrack.exe" -q
+assert_eq "" "$(win_marker "$tmpdir/cl")" "argv[0] alone"
+
+# Nothing distinctive is "unknown", which every caller already handles.
+mkcmdline "$tmpdir/cl" httrack.exe -q -O out
+assert_eq "" "$(win_marker "$tmpdir/cl")" "only short arguments"
+assert_eq "" "$(win_marker "$tmpdir/nosuchfile")" "no cmdline at all"
+ok "win_marker picks the launch's own output directory, never argv[0]"
+
+## The tool names differ by backend: bare under MSYS, .exe under WSL2, where the
+# PATH is Linux's and interop resolves only a real filename.
+while read -r backend want; do
+    got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND="$backend" PATH="$pathbin:$PATH" \
+        bash -c ". \"$testdir/testlib.sh\"; win_tool taskkill; win_tool tasklist" | tr '\n' ' ')
+    test "$got" = "$want " || fail "backend=$backend named [$got], want [$want]"
+done <<'EOF'
+msys taskkill tasklist
+wsl2 taskkill.exe tasklist.exe
+posix taskkill tasklist
+EOF
+ok "taskkill and tasklist take their .exe only under wsl2"
+
+## win_capture under wsl2 has no /proc/<pid>/winpid to read. It takes the
+# relay's own cmdline instead and asks Windows which process carries it.
+cat >"$tmpdir/pathbin/powershell.exe" <<'PSEOF'
+#!/bin/sh
+printf '%s\n' "${HTS_WIN_MARKER:-}" >"$PSREC.env"
+printf '%s\n' "$*" >"$PSREC.argv"
+echo 4242
+PSEOF
+chmod +x "$tmpdir/pathbin/powershell.exe"
+cat >"$tmpdir/cap.sh" <<EOF
+set -euo pipefail
+. "$testdir/testlib.sh"
+/bin/sh -c 'sleep 30' "\$1" &
+v=\$!
+# Until the exec lands, the cmdline still names the forking shell: the same race
+# the MSYS winpid read has, and the reason win_capture is not for a fresh job.
+for _ in \$(seq 200); do
+    test "\$(win_marker "/proc/\$v/cmdline")" != "\$1" || break
+    sleep 0.01
+done
+win_capture "\$v"
+printf '%s|%s\n' "\$WIN_PID" "\$WIN_IMAGE"
+kill "\$v" 2>/dev/null || true
+EOF
+marker="/mnt/c/t/httrack_local.ZzUnique1"
+got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND=wsl2 PSREC="$tmpdir/ps" \
+    PATH="$pathbin:$PATH" bash "$tmpdir/cap.sh" "$marker")
+assert_eq "4242|sh" "$got" "the Windows pid and image win_capture resolved"
+assert_eq "$marker" "$(cat "$tmpdir/ps.env")" "the marker powershell received"
+# In the environment, never on the command line: a marker passed as an argument
+# puts it on the querying process's own cmdline, which then matches itself.
+case "$(cat "$tmpdir/ps.argv")" in
+*"$marker"*) fail "the marker rode powershell's argv: $(cat "$tmpdir/ps.argv")" ;;
+esac
+ok "win_capture resolves the Windows pid by marker, passed out of band"
+
 # Unshimmed: a guard that fires only on the broken path is half a guard.
 case "$(uname -s)" in
 MINGW* | MSYS* | CYGWIN*) want=yes ;;

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -300,18 +300,19 @@ assert_eq "" "$(win_marker "$tmpdir/cl")" "only short arguments"
 assert_eq "" "$(win_marker "$tmpdir/nosuchfile")" "no cmdline at all"
 ok "win_marker picks the launch's own output directory, never argv[0]"
 
-## The tool names differ by backend: bare under MSYS, .exe under WSL2, where the
-# PATH is Linux's and interop resolves only a real filename.
+## An executable's name differs by backend: bare under MSYS, which resolves it
+# to the .exe itself, and suffixed under WSL2, whose PATH matches exactly. A
+# bare "ping" there is WSL's own Linux one, whose -n means something else.
 while read -r backend want; do
     got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND="$backend" PATH="$pathbin:$PATH" \
-        bash -c ". \"$testdir/testlib.sh\"; win_tool taskkill; win_tool tasklist" | tr '\n' ' ')
+        bash -c ". \"$testdir/testlib.sh\"; win_exe taskkill; win_exe ping" | tr '\n' ' ')
     test "$got" = "$want " || fail "backend=$backend named [$got], want [$want]"
 done <<'EOF'
-msys taskkill tasklist
-wsl2 taskkill.exe tasklist.exe
-posix taskkill tasklist
+msys taskkill ping
+wsl2 taskkill.exe ping.exe
+posix taskkill ping
 EOF
-ok "taskkill and tasklist take their .exe only under wsl2"
+ok "a Windows executable takes its .exe only under wsl2"
 
 ## win_capture under wsl2 has no /proc/<pid>/winpid to read. It takes the
 # relay's own cmdline instead and asks Windows which process carries it.

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -362,9 +362,10 @@ fi
 # Real interop passes a variable only when WSLENV names it, so the stub refuses
 # to see one that is not listed. Without this, dropping WSLENV changes nothing
 # here and everything on a runner.
-# The relay's own /proc/<pid>/cmdline is what carries the marker, so this needs
-# a real procfs; Darwin and other /proc-less hosts have nothing to read here.
-if test -d /proc; then
+# Needs a real procfs to read the relay's cmdline from, and a shell that can
+# execute the fake powershell.exe below. MSYS can do neither: it has no /proc
+# entry to read here and it hands anything named .exe to Windows as a binary.
+if test -d /proc && ! shell_is_msys; then
     cat >"$tmpdir/pathbin/powershell.exe" <<'PSEOF'
 #!/bin/sh
 case ":${WSLENV:-}:" in
@@ -398,6 +399,8 @@ EOF
     *"$marker"*) fail "the marker rode powershell's argv: $(cat "$tmpdir/ps.argv")" ;;
     esac
     ok "win_capture resolves the Windows pid by marker, passed out of band"
+else
+    echo "no procfs, or a shell that cannot run a script named .exe" >&2
 fi
 
 # Unshimmed: a guard that fires only on the broken path is half a guard.

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -293,8 +293,12 @@ case "$out" in
 *"no wslpath"*) ;;
 *) fail "wsl2 with no wslpath failed without naming the cause: $out" ;;
 esac
-got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND=msys bash "$tmpdir/pc.sh")
-test "$got" = "/x|/y" || fail "msys with no cygpath gave [$got], want the paths unchanged"
+if command -v cygpath >/dev/null 2>&1; then
+    echo "a real cygpath is on PATH, so its absence cannot be staged here" >&2
+else
+    got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND=msys bash "$tmpdir/pc.sh")
+    test "$got" = "/x|/y" || fail "msys with no cygpath gave [$got], want the paths unchanged"
+fi
 ok "a missing wslpath is fatal where a missing cygpath is not"
 
 ## win_marker picks the string that tells one launch from another. WSL2 has no
@@ -325,19 +329,26 @@ mkcmdline "$tmpdir/cl" httrack.exe -O "C:/t/httrack_local.AbCdEf" \
 assert_eq "C:/t/httrack_local.AbCdEf" "$(win_marker "$tmpdir/cl")" "a shared --user-agent"
 ok "win_marker picks the launch's own output directory, never argv[0]"
 
-## An executable's name differs by backend: bare under MSYS, which resolves it
-# to the .exe itself, and suffixed under WSL2, whose PATH matches exactly. A
-# bare "ping" there is WSL's own Linux one, whose -n means something else.
-while read -r backend want; do
-    got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND="$backend" PATH="$pathbin:$PATH" \
-        bash -c ". \"$testdir/testlib.sh\"; win_exe taskkill; win_exe ping" | tr '\n' ' ')
-    test "$got" = "$want " || fail "backend=$backend named [$got], want [$want]"
-done <<'EOF'
-msys taskkill ping
-wsl2 taskkill.exe ping.exe
-posix taskkill ping
-EOF
-ok "a Windows executable takes its .exe only under wsl2"
+## The wsl2 PATH shim, which is what lets the tests keep naming a Windows
+# program bare there, and what turns a drvfs argument into one a native exe can
+# open. Copied rather than linked, as the driver does, since this tree may sit
+# on a mount that refuses to execute it.
+mkdir "$tmpdir/shimbin"
+cp "$testdir/wsl2-exe-shim.sh" "$tmpdir/shimbin/faketool"
+cat >"$tmpdir/shimbin/faketool.exe" <<'TOOLEOF'
+#!/bin/sh
+printf '%s\n' "$@"
+TOOLEOF
+# A wslpath that really converts, so the assertion below is about the shim.
+cat >"$tmpdir/shimbin/wslpath" <<'WPEOF'
+#!/bin/sh
+d=$(printf '%s' "$2" | cut -c6)
+printf '%s:%s\n' "$(printf '%s' "$d" | tr '[:lower:]' '[:upper:]')" "$(printf '%s' "$2" | cut -c7-)"
+WPEOF
+chmod +x "$tmpdir/shimbin/faketool" "$tmpdir/shimbin/faketool.exe" "$tmpdir/shimbin/wslpath"
+got=$(PATH="$tmpdir/shimbin:$PATH" bash "$tmpdir/shimbin/faketool" /mnt/c/x/y -q plain | tr '\n' ' ')
+assert_eq "C:/x/y -q plain " "$got" "what the shim handed the exe"
+ok "the wsl2 shim names the .exe and converts only its drvfs arguments"
 
 ## win_capture under wsl2 has no /proc/<pid>/winpid to read. It takes the
 # relay's own cmdline instead and asks Windows which process carries it.
@@ -367,15 +378,19 @@ printf '%s|%s\n' "\$WIN_PID" "\$WIN_IMAGE"
 kill "\$v" 2>/dev/null || true
 EOF
 marker="/mnt/c/t/httrack_local.ZzUnique1"
-got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND=wsl2 PSREC="$tmpdir/ps" \
-    PATH="$pathbin:$PATH" bash "$tmpdir/cap.sh" "$marker")
-assert_eq "4242|sh" "$got" "the Windows pid and image win_capture resolved"
-assert_eq "$marker" "$(cat "$tmpdir/ps.env")" "the marker powershell received"
-# In the environment, never on the command line: a marker passed as an argument
-# puts it on the querying process's own cmdline, which then matches itself.
-case "$(cat "$tmpdir/ps.argv")" in
-*"$marker"*) fail "the marker rode powershell's argv: $(cat "$tmpdir/ps.argv")" ;;
-esac
+if ! test -r /proc/self/cmdline; then
+    echo "no /proc here, so the relay's cmdline cannot be read" >&2
+else
+    got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND=wsl2 PSREC="$tmpdir/ps" \
+        PATH="$pathbin:$PATH" bash "$tmpdir/cap.sh" "$marker")
+    assert_eq "4242|sh" "$got" "the Windows pid and image win_capture resolved"
+    assert_eq "$marker" "$(cat "$tmpdir/ps.env")" "the marker powershell received"
+    # In the environment, never on the command line: a marker passed as an argument
+    # puts it on the querying process's own cmdline, which then matches itself.
+    case "$(cat "$tmpdir/ps.argv")" in
+    *"$marker"*) fail "the marker rode powershell's argv: $(cat "$tmpdir/ps.argv")" ;;
+    esac
+fi
 ok "win_capture resolves the Windows pid by marker, passed out of band"
 
 # Unshimmed: a guard that fires only on the broken path is half a guard.

--- a/tests/314_engine-selftest-batch.test
+++ b/tests/314_engine-selftest-batch.test
@@ -84,7 +84,7 @@ rejects 'lines' selftest_queue_lines 'a.gif is only one line' mime a.gif
 # The CR half of lines mode needs an interior CRLF, which off Windows only a
 # case that emits one can give. On Windows text mode doubles that injected CR,
 # so there the coverage comes from 311 and mime, whose CRLFs are text mode's own.
-if ! is_windows; then
+if ! target_is_windows; then
     selftest_queue_lines 'A
 B' charset iso-8859-1 hex:410d0a42
     # A CR on the last line takes the trailing-strip branch, not that one.

--- a/tests/364_local-abort-not-done.test
+++ b/tests/364_local-abort-not-done.test
@@ -84,7 +84,7 @@ ok "a mirror the link cap stopped does not claim to be done"
 # the probe fails with ENOENT rather than ENOSPC.
 disk_abort_works() {
     local probe="${tmpdir}/probe" refused=1
-    ! is_windows || return 1
+    ! target_is_windows || return 1
     test -c /dev/full || return 1
     ln -s /dev/full "$probe" 2>/dev/null || return 1
     ! printf x >"$probe" 2>/dev/null || refused=0
@@ -117,7 +117,7 @@ ok "a mirror the time cap stopped does not claim to be done"
 # --- ^C: the other state.stop producer, and the one users actually hit -------
 # SIGINT goes to sig_leave (state.stop), SIGTERM to sig_finish (exit_xh): two
 # handlers, so the interrupt a user types needs its own arm.
-if is_windows; then
+if target_is_windows; then
     echo "note: MSYS cannot signal a native httrack.exe, the ^C arm is not covered here"
 else
     dir="${tmpdir}/sigint"

--- a/tests/58_watchdog.test
+++ b/tests/58_watchdog.test
@@ -26,7 +26,7 @@ test "$rc" -eq 7 || fail "exit 7 reported $rc"
 start=$SECONDS
 rc=0
 if target_is_windows; then
-    run_with_timeout 2 ping -n 30 127.0.0.1 || rc=$?
+    run_with_timeout 2 "$(win_exe ping)" -n 30 127.0.0.1 || rc=$?
 else
     run_with_timeout 2 sleep 30 || rc=$?
 fi
@@ -43,7 +43,7 @@ if target_is_windows; then
     alive() { win_pid_runs "$1" ping.exe; }
     # alive() is a conjunction now, and one that never matches would call every
     # survivor reaped. Prove it fires on a live ping, reached the same way.
-    ping -n 20 127.0.0.1 >/dev/null 2>&1 &
+    "$(win_exe ping)" -n 20 127.0.0.1 >/dev/null 2>&1 &
     cpid=$!
     cw=$(cat "/proc/$cpid/winpid" 2>/dev/null)
     test -n "$cw" || fail "could not read a live ping's Windows PID"

--- a/tests/58_watchdog.test
+++ b/tests/58_watchdog.test
@@ -26,7 +26,7 @@ test "$rc" -eq 7 || fail "exit 7 reported $rc"
 start=$SECONDS
 rc=0
 if target_is_windows; then
-    run_with_timeout 2 "$(win_exe ping)" -n 30 127.0.0.1 || rc=$?
+    run_with_timeout 2 ping -n 30 127.0.0.1 || rc=$?
 else
     run_with_timeout 2 sleep 30 || rc=$?
 fi
@@ -44,7 +44,7 @@ if shell_is_msys; then
     alive() { win_pid_runs "$1" ping.exe; }
     # alive() is a conjunction now, and one that never matches would call every
     # survivor reaped. Prove it fires on a live ping, reached the same way.
-    "$(win_exe ping)" -n 20 127.0.0.1 >/dev/null 2>&1 &
+    ping -n 20 127.0.0.1 >/dev/null 2>&1 &
     cpid=$!
     cw=$(cat "/proc/$cpid/winpid" 2>/dev/null)
     test -n "$cw" || fail "could not read a live ping's Windows PID"
@@ -101,7 +101,7 @@ fi
     start=$SECONDS
     rc=0
     if target_is_windows; then
-        run_with_timeout 3 "$(win_exe ping)" -n 60 127.0.0.1 || rc=$?
+        run_with_timeout 3 ping -n 60 127.0.0.1 || rc=$?
     else
         run_with_timeout 3 sleep 60 || rc=$?
     fi

--- a/tests/58_watchdog.test
+++ b/tests/58_watchdog.test
@@ -25,7 +25,7 @@ test "$rc" -eq 7 || fail "exit 7 reported $rc"
 # An overrunning command is reported 124, near the deadline not the child's end.
 start=$SECONDS
 rc=0
-if is_windows; then
+if target_is_windows; then
     run_with_timeout 2 ping -n 30 127.0.0.1 || rc=$?
 else
     run_with_timeout 2 sleep 30 || rc=$?
@@ -37,7 +37,7 @@ test "$((SECONDS - start))" -lt 15 || fail "watchdog fired late"
 # MSYS bash with a native ping grandchild is the exact case signals can't reap;
 # on POSIX a surviving grandchild would touch the marker after we stop waiting.
 rc=0
-if is_windows; then
+if target_is_windows; then
     # Existence by exact Windows PID, not a global ping.exe count: the timing
     # sub-test above leaves a still-dying ping that a count would race.
     alive() { win_pid_runs "$1" ping.exe; }
@@ -99,7 +99,7 @@ fi
 
     start=$SECONDS
     rc=0
-    if is_windows; then
+    if target_is_windows; then
         run_with_timeout 3 ping -n 60 127.0.0.1 || rc=$?
     else
         run_with_timeout 3 sleep 60 || rc=$?

--- a/tests/58_watchdog.test
+++ b/tests/58_watchdog.test
@@ -33,11 +33,12 @@ fi
 test "$rc" -eq 124 || fail "hang reported $rc, want 124"
 test "$((SECONDS - start))" -lt 15 || fail "watchdog fired late"
 
-# The native descendant tree is really dead, not orphaned. On Windows an outer
-# MSYS bash with a native ping grandchild is the exact case signals can't reap;
-# on POSIX a surviving grandchild would touch the marker after we stop waiting.
+# The native descendant tree is really dead, not orphaned. The Windows arm reads
+# /proc/<pid>/winpid, which only MSYS has, so it asks about that shell and not
+# about the binary; on POSIX a surviving grandchild would touch the marker after
+# we stop waiting.
 rc=0
-if target_is_windows; then
+if shell_is_msys; then
     # Existence by exact Windows PID, not a global ping.exe count: the timing
     # sub-test above leaves a still-dying ping that a count would race.
     alive() { win_pid_runs "$1" ping.exe; }
@@ -100,7 +101,7 @@ fi
     start=$SECONDS
     rc=0
     if target_is_windows; then
-        run_with_timeout 3 ping -n 60 127.0.0.1 || rc=$?
+        run_with_timeout 3 "$(win_exe ping)" -n 60 127.0.0.1 || rc=$?
     else
         run_with_timeout 3 sleep 60 || rc=$?
     fi

--- a/tests/65_port-siblings.test
+++ b/tests/65_port-siblings.test
@@ -51,10 +51,10 @@ web_accepted() {
     # where a 3s kill landed mid-resolve, before the URL= line ever printed.
     local had_m=
     case "$-" in *m*) had_m=1 ;; esac
-    is_windows || set -m
+    shell_is_msys || set -m
     htsserver "$tmp" --port "$port" >"$tmp/web.log" 2>&1 &
     local pid=$!
-    test -n "$had_m" || is_windows || set +m
+    test -n "$had_m" || shell_is_msys || set +m
     local waited=0
     until grep -qE "^URL=http://.*:$port/|couldn't set the port number|Unable to initialize a temporary server" "$tmp/web.log"; do
         test "$waited" -lt 20 || break

--- a/tests/94_local-single-file.test
+++ b/tests/94_local-single-file.test
@@ -300,7 +300,7 @@ echo OK
 
 printf '[the rewritten page keeps the mirror file mode] ..\t'
 # The rewrite spools to a temp and renames, bypassing the engine's chmod.
-if is_windows; then
+if target_is_windows; then
     echo "SKIP (no POSIX file modes)"
 else
     umaskdir="${tmpdir}/umask"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,6 +15,7 @@ EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c a
 	webhttracklib.sh httpclient.py webtestlib.py crawllib.sh arclib.sh \
 	guide-image-check.py \
 	ci-windows-suite.sh ci-windows-watchdog.ps1 install-headers-sweep.sh \
+	wsl2-exe-shim.sh \
 	server.crt server.key \
 	server-root/simple/basic.html server-root/simple/link.html \
 	server-root/stripquery/index.html server-root/stripquery/a.html \

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -223,7 +223,25 @@ ci_suite_heartbeat() {
 # Explicit now that this is a script; GitHub's "shell: bash" gave the step both.
 set -euo pipefail
 bin=${1:?usage: ci-windows-suite.sh <bindir>}
+# The shell decides the default: this script drives the suite from MSYS today
+# and from a WSL2 distro on the second leg, where the workflow sets it. Nothing
+# can sniff wsl2, since that shell answers Linux like any other.
+export HTTRACK_SUITE_BACKEND=${HTTRACK_SUITE_BACKEND:-msys}
 export PATH="$bin:$PATH"
+
+# WSL2 needs the engines under the bare names the tests use, and needs their
+# drvfs arguments translated on the way to a native exe. One shim per engine
+# does both; see tests/wsl2-exe-shim.sh.
+if test "$HTTRACK_SUITE_BACKEND" = wsl2; then
+    shimdir=$PWD/.wsl2-shims
+    rm -rf "$shimdir"
+    mkdir -p "$shimdir"
+    for e in $ENGINE_EXES; do
+        ln -s "$testdir/wsl2-exe-shim.sh" "$shimdir/$e"
+    done
+    export PATH="$shimdir:$PATH"
+fi
+
 command -v httrack >/dev/null || {
     echo "::error::no httrack.exe in $bin"
     exit 1
@@ -238,9 +256,16 @@ unset WATCHDOG_TOKEN
 # POSIX path, and a URL path is shaped exactly like one: "/a/b.html"
 # reached the engine as "C:/Program Files/Git/a/b.html". Switch that
 # off, and hand the tests a TMPDIR that is already a Windows path.
-export MSYS_NO_PATHCONV=1
-export MSYS2_ARG_CONV_EXCL='*'
-TMPDIR="$(cygpath -m "$RUNNER_TEMP")"
+if test "$HTTRACK_SUITE_BACKEND" = wsl2; then
+    # The Linux view, not the native one: a WSL2 shell cannot mktemp into a
+    # drive-letter path. Tests hand the engine drvfs paths and the shim above
+    # translates them, which is why RUNNER_TEMP has to stay on a Windows volume.
+    TMPDIR="$(wslpath -u "$RUNNER_TEMP")"
+else
+    export MSYS_NO_PATHCONV=1
+    export MSYS2_ARG_CONV_EXCL='*'
+    TMPDIR="$(cygpath -m "$RUNNER_TEMP")"
+fi
 export TMPDIR
 
 # Mirror what configure hands the suite. LC_ALL sets the codeset MSYS maps

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -229,15 +229,18 @@ bin=${1:?usage: ci-windows-suite.sh <bindir>}
 export HTTRACK_SUITE_BACKEND=${HTTRACK_SUITE_BACKEND:-msys}
 export PATH="$bin:$PATH"
 
-# WSL2 needs the engines under the bare names the tests use, and needs their
-# drvfs arguments translated on the way to a native exe. One shim per engine
-# does both; see tests/wsl2-exe-shim.sh.
+# WSL2 resolves a filename exactly, so every Windows program the tests name bare
+# needs one, and a drvfs argument means nothing to a native exe. One shim per
+# name does both; see tests/wsl2-exe-shim.sh. MSYS needs none of it, which is
+# why the tests keep saying `httrack` and `taskkill` on both backends.
 if test "$HTTRACK_SUITE_BACKEND" = wsl2; then
     shimdir=$PWD/.wsl2-shims
     rm -rf "$shimdir"
     mkdir -p "$shimdir"
-    for e in $ENGINE_EXES; do
-        ln -s "$testdir/wsl2-exe-shim.sh" "$shimdir/$e"
+    # Copied, not linked: the checkout's own mount may refuse to execute it.
+    for e in $ENGINE_EXES taskkill tasklist ping; do
+        cp "$testdir/wsl2-exe-shim.sh" "$shimdir/$e"
+        chmod +x "$shimdir/$e"
     done
     export PATH="$shimdir:$PATH"
 fi

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -745,7 +745,7 @@ while test "$i" -lt "${#audit[@]}"; do
     --file-mode)
         path="${audit[$((i + 1))]}"
         i=$((i + 2))
-        if is_windows; then
+        if target_is_windows; then
             # No POSIX modes, and the engine only chmods #ifndef _WIN32.
             info "checking ${path} mode"
             result "SKIP (no POSIX modes)"

--- a/tests/proclib.sh
+++ b/tests/proclib.sh
@@ -102,7 +102,7 @@ list_stray_processes() {
         # slash switches: without MSYS_NO_PATHCONV a /fi would be rewritten to a
         # path. Plain output is Image Name + PID, which is all we need.
         test "$mode" != others || return 0
-        "$(win_exe tasklist)" 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE|^python" || true
+        tasklist 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE|^python" || true
     else
         # Fields 6 and 7 are the command and its first argument (the interpreter
         # and its script, for the Python fixtures).
@@ -131,7 +131,7 @@ list_stray_processes() {
 reap_leftover_processes() {
     local label=${1:-} left
     if target_is_windows; then
-        left=$("$(win_exe tasklist)" 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE" || true)
+        left=$(tasklist 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE" || true)
     else
         left=$(list_stray_processes 0 named | awk 'NR > 1')
     fi
@@ -234,7 +234,7 @@ dump_windows_stacks() {
         printf 'no stack: cdb.exe is not in the SDK Debuggers directories or on PATH\n'
         return 0
     fi
-    for p in $("$(win_exe tasklist)" 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE" | awk '{print $2}'); do
+    for p in $(tasklist 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE" | awk '{print $2}'); do
         found=1
         printf -- '--- cdb stack of pid %s ---\n' "$p"
         # Bounded, so a debugger that wedges cannot become the new hang. "qd"

--- a/tests/proclib.sh
+++ b/tests/proclib.sh
@@ -102,7 +102,7 @@ list_stray_processes() {
         # slash switches: without MSYS_NO_PATHCONV a /fi would be rewritten to a
         # path. Plain output is Image Name + PID, which is all we need.
         test "$mode" != others || return 0
-        "$(win_tool tasklist)" 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE|^python" || true
+        "$(win_exe tasklist)" 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE|^python" || true
     else
         # Fields 6 and 7 are the command and its first argument (the interpreter
         # and its script, for the Python fixtures).
@@ -131,7 +131,7 @@ list_stray_processes() {
 reap_leftover_processes() {
     local label=${1:-} left
     if target_is_windows; then
-        left=$("$(win_tool tasklist)" 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE" || true)
+        left=$("$(win_exe tasklist)" 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE" || true)
     else
         left=$(list_stray_processes 0 named | awk 'NR > 1')
     fi
@@ -234,7 +234,7 @@ dump_windows_stacks() {
         printf 'no stack: cdb.exe is not in the SDK Debuggers directories or on PATH\n'
         return 0
     fi
-    for p in $("$(win_tool tasklist)" 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE" | awk '{print $2}'); do
+    for p in $("$(win_exe tasklist)" 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE" | awk '{print $2}'); do
         found=1
         printf -- '--- cdb stack of pid %s ---\n' "$p"
         # Bounded, so a debugger that wedges cannot become the new hang. "qd"

--- a/tests/proclib.sh
+++ b/tests/proclib.sh
@@ -102,7 +102,7 @@ list_stray_processes() {
         # slash switches: without MSYS_NO_PATHCONV a /fi would be rewritten to a
         # path. Plain output is Image Name + PID, which is all we need.
         test "$mode" != others || return 0
-        tasklist 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE|^python" || true
+        "$(win_tool tasklist)" 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE|^python" || true
     else
         # Fields 6 and 7 are the command and its first argument (the interpreter
         # and its script, for the Python fixtures).
@@ -131,7 +131,7 @@ list_stray_processes() {
 reap_leftover_processes() {
     local label=${1:-} left
     if target_is_windows; then
-        left=$(tasklist 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE" || true)
+        left=$("$(win_tool tasklist)" 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE" || true)
     else
         left=$(list_stray_processes 0 named | awk 'NR > 1')
     fi
@@ -234,7 +234,7 @@ dump_windows_stacks() {
         printf 'no stack: cdb.exe is not in the SDK Debuggers directories or on PATH\n'
         return 0
     fi
-    for p in $(tasklist 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE" | awk '{print $2}'); do
+    for p in $("$(win_tool tasklist)" 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE" | awk '{print $2}'); do
         found=1
         printf -- '--- cdb stack of pid %s ---\n' "$p"
         # Bounded, so a debugger that wedges cannot become the new hang. "qd"

--- a/tests/proclib.sh
+++ b/tests/proclib.sh
@@ -97,7 +97,7 @@ proc_snapshot() {
 # host). Read-only: it never signals anything.
 list_stray_processes() {
     local pgid=${1:-0} mode=${2:-group}
-    if is_windows; then
+    if target_is_windows; then
         # No process groups here, so every mode gives the same host-wide list. No
         # slash switches: without MSYS_NO_PATHCONV a /fi would be rewritten to a
         # path. Plain output is Image Name + PID, which is all we need.
@@ -130,7 +130,7 @@ list_stray_processes() {
 # own, and tasklist alone cannot tell that one from a leaked fixture server.
 reap_leftover_processes() {
     local label=${1:-} left
-    if is_windows; then
+    if target_is_windows; then
         left=$(tasklist 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE" || true)
     else
         left=$(list_stray_processes 0 named | awk 'NR > 1')
@@ -138,7 +138,7 @@ reap_leftover_processes() {
     test -n "$left" || return 0
     printf '::warning::%s left processes behind\n' "$label"
     printf '%s\n' "$left"
-    if is_windows; then
+    if target_is_windows; then
         taskkill_engines
     else
         printf '%s\n' "$left" | awk '{ print $1 }' |
@@ -252,7 +252,7 @@ dump_windows_stacks() {
 dump_hang_diagnostics() {
     local pid=$1 label=${2:-?} secs=${3:-?}
     printf '\n===== TIMEOUT: %s exceeded its %ss budget =====\n' "$label" "$secs"
-    if is_windows; then
+    if target_is_windows; then
         printf -- '--- still running ---\n'
         list_stray_processes 0 group
         printf -- '--- stacks (via cdb) ---\n'

--- a/tests/test-timeout.sh
+++ b/tests/test-timeout.sh
@@ -77,15 +77,19 @@ if mkdir -p "$tmproot/ht.$$" 2>/dev/null; then
     trap 'rm -rf "$TMPDIR" 2>/dev/null || true' EXIT
 fi
 
+# Two questions, and they part company under the wsl2 backend: the shell there is
+# Linux while the binary under test is still a native .exe.
+msys_shell=
+shell_is_msys && msys_shell=1
 windows=
-is_windows && windows=1
+target_is_windows && windows=1
 
 had_m=
 case "$-" in *m*) had_m=1 ;; esac
-test -n "$windows" || set -m # own process group, so kill_tree can signal the group
+test -n "$msys_shell" || set -m # own process group, so kill_tree can signal the group
 "$BASH" "$@" &
 pid=$!
-test -n "$had_m" || test -n "$windows" || set +m
+test -n "$had_m" || test -n "$msys_shell" || set +m
 # Read while the test is certainly alive: by kill time /proc/<pid>/winpid is gone.
 winpid=''
 test -z "$windows" || winpid=$(win_pid "$pid")
@@ -94,7 +98,7 @@ test -z "$windows" || winpid=$(win_pid "$pid")
 # have to signal across process groups, which MSYS cannot do. The interval is the
 # latency this adds to every healthy test; the ceiling only matters where poll_wait
 # has to fall back to a forked sleep, which under MSYS costs tens of milliseconds.
-if test -n "$windows"; then
+if test -n "$msys_shell"; then
     tick=1
 else
     tick=0.1

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -1037,7 +1037,7 @@ ENGINE_EXES='httrack proxytrack htsserver webhttrack'
 taskkill_engines() {
     local e
     for e in $ENGINE_EXES; do
-        taskkill /F /IM "$e.exe" >/dev/null 2>&1 || true
+        "$(win_tool taskkill)" /F /IM "$e.exe" >/dev/null 2>&1 || true
     done
 }
 

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -62,9 +62,9 @@ skip() {
     exit 77
 }
 
-# Guard form, so a bare `is_windows && skip ...` cannot end an errexit test that
-# is merely not on Windows.
-skip_on_windows() { ! is_windows || skip "$*"; }
+# Guard form, so a bare `target_is_windows && skip ...` cannot end an errexit
+# test that is merely not on Windows.
+skip_on_windows() { ! target_is_windows || skip "$*"; }
 
 # Set by tools/emulated-suite.sh, which interprets every instruction it runs.
 is_emulated() { [ -n "${EMULATED_ARCH:-}" ]; }
@@ -341,7 +341,7 @@ find_python() {
 
 # Native form of a path: a non-MSYS binary cannot resolve Git Bash's /d/a/... ones.
 nativepath() {
-    if is_windows && command -v cygpath >/dev/null 2>&1; then
+    if target_is_windows && command -v cygpath >/dev/null 2>&1; then
         cygpath -m "$1"
     else
         printf '%s\n' "$1"
@@ -351,7 +351,7 @@ nativepath() {
 # POSIX form of a path. Anything MSYS splits on a colon needs it, a PATH entry
 # below the drive-letter TMPDIR above all.
 posixpath() {
-    if is_windows && command -v cygpath >/dev/null 2>&1; then
+    if target_is_windows && command -v cygpath >/dev/null 2>&1; then
         cygpath -u "$1"
     else
         printf '%s\n' "$1"
@@ -579,16 +579,38 @@ build_names_frames() {
         grep -q '^#define HAVE_SPAWN_H ' "${conf}"
 }
 
-is_windows() {
-    if test -z "${IS_WINDOWS:-}"; then
+# Which harness drives the tests: `msys` for an MSYS/Git Bash shell, `wsl2` for
+# a Linux shell reaching the same native .exe over interop, `posix` otherwise.
+# Only msys is sniffable, because a wsl2 shell answers `Linux` exactly like a
+# native one, so the driver sets the variable and an unset one means posix.
+suite_backend() {
+    if test -z "${HTTRACK_SUITE_BACKEND:-}"; then
         case "$HTS_OS" in
-        MINGW* | MSYS* | CYGWIN*) IS_WINDOWS=yes ;;
+        MINGW* | MSYS* | CYGWIN*) HTTRACK_SUITE_BACKEND=msys ;;
+        *) HTTRACK_SUITE_BACKEND=posix ;;
+        esac
+        export HTTRACK_SUITE_BACKEND
+    fi
+    printf '%s\n' "$HTTRACK_SUITE_BACKEND"
+}
+
+# Is the program under test a native Windows executable? This is what almost
+# every caller of the old is_windows() was asking, and it stays true under the
+# wsl2 backend even though the shell there is Linux.
+target_is_windows() {
+    if test -z "${IS_WINDOWS:-}"; then
+        case "$(suite_backend)" in
+        msys | wsl2) IS_WINDOWS=yes ;;
         *) IS_WINDOWS=no ;;
         esac
         export IS_WINDOWS
     fi
     test "$IS_WINDOWS" = yes
 }
+
+# Is this shell MSYS/Git Bash? Ask only about the shell's own quirks, its broken
+# job control above all. A question about the binary wants target_is_windows.
+shell_is_msys() { test "$(suite_backend)" = msys; }
 
 # Open the timer fd poll_wait reads from: a fifo held open read-write, so there is
 # always a writer and a read blocks to its own timeout instead of seeing EOF. fd 9
@@ -601,7 +623,7 @@ poll_open() {
     # Not under MSYS: its fifos are emulated, and the leg whose stability #795 is
     # about is no place to discover how its select() behaves. That tick is a whole
     # second anyway, so there is little to win.
-    is_windows && return 0
+    shell_is_msys && return 0
     # Unique: $$ is the same in every subshell, and the loser of a race on one name
     # opens a path that is gone.
     f=$(mktemp -u "${TMPDIR:-/tmp}/.httrack-poll.XXXXXX" 2>/dev/null) || return 0
@@ -664,7 +686,7 @@ stop_server() {
     win_capture "$1"
     winpid=$WIN_PID winimage=$WIN_IMAGE
     kill "$1" 2>/dev/null || true
-    if is_windows; then kill_tree "$1" "$winpid" "$winimage"; fi
+    if target_is_windows; then kill_tree "$1" "$winpid" "$winimage"; fi
     reap_bounded "$1" || true
     return 0
 }
@@ -870,7 +892,7 @@ win_pid() {
 # Assigned rather than echoed, a command substitution being a fork (#795).
 win_capture() { # win_capture <pid>
     WIN_PID='' WIN_IMAGE=''
-    is_windows || return 0
+    target_is_windows || return 0
     # Unguarded reads: a missing file leaves the empty value set above, and read
     # reports EOF on an unterminated line having already assigned it.
     { read -r WIN_PID <"/proc/$1/winpid"; } 2>/dev/null || true
@@ -890,7 +912,7 @@ win_pid_runs() { # win_pid_runs <winpid> <image>
 # tree cannot rely on kill_tree, whose taskkill is then a grandchild of it (#953).
 kill_pid() {
     local pid=$1
-    if is_windows; then
+    if target_is_windows; then
         local winpid
         winpid=$(win_pid "$pid")
         if test -n "$winpid"; then
@@ -914,7 +936,7 @@ kill_pid() {
 # looking, and naming a stranger is as good as naming nobody (#1228).
 kill_tree() {
     local pid=$1 winpid=${2:-} image=${3:-}
-    if is_windows; then
+    if target_is_windows; then
         test -n "$winpid" || winpid=$(win_pid "$pid")
         if test -n "$winpid" && test -n "$image" && ! win_pid_runs "$winpid" "$image"; then
             printf '::warning::pid %s no longer runs %s, not killing it\n' "$winpid" "$image"
@@ -1046,17 +1068,17 @@ run_with_timeout() {
     shift
     local had_m=
     case "$-" in *m*) had_m=1 ;; esac
-    is_windows || set -m # own process group, so kill_tree can signal the group
+    shell_is_msys || set -m # own process group, so kill_tree can signal the group
     case $stdin in
     '') "$@" & ;;
     closed) "$@" <&- & ;;
     *) "$@" <"$stdin" & ;;
     esac
     local pid=$!
-    test -n "$had_m" || is_windows || set +m
+    test -n "$had_m" || shell_is_msys || set +m
     # Read while the job is certainly alive: by kill time /proc/<pid>/winpid is gone.
     local winpid=''
-    ! is_windows || winpid=$(win_pid "$pid")
+    ! target_is_windows || winpid=$(win_pid "$pid")
     local start=$SECONDS
     while kill -0 "$pid" 2>/dev/null; do
         if test "$((SECONDS - start))" -gt "$secs"; then

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -904,16 +904,6 @@ dump_crawl_logs() {
     done
 }
 
-# The name a Windows executable answers to here. MSYS resolves a bare name to
-# its .exe; WSL2's PATH is Linux's and matches the filename exactly, so there it
-# needs the suffix. Dispatched rather than always suffixed, to leave MSYS alone.
-win_exe() { # win_exe NAME
-    case "$(suite_backend)" in
-    wsl2) printf '%s.exe\n' "$1" ;;
-    *) printf '%s\n' "$1" ;;
-    esac
-}
-
 # The substring identifying ONE launch among every Windows process on the host.
 # WSL2 has no /proc/<pid>/winpid, so all that is left is what the relay was
 # started with. Skip argv[0], the same exe for every concurrent test, and skip
@@ -987,7 +977,7 @@ win_capture() { # win_capture <pid>
 # Whether Windows PID $1 runs image $2. Both columns at once, since either alone
 # answers for a recycled PID, and case-folded as the proclib.sh matchers are.
 win_pid_runs() { # win_pid_runs <winpid> <image>
-    "$(win_exe tasklist)" 2>/dev/null |
+    tasklist 2>/dev/null |
         awk -v p="$1" -v i="$2" 'tolower($1) == tolower(i) && $2 == p { f = 1 } END { exit !f }'
 }
 
@@ -999,7 +989,7 @@ kill_pid() {
         local winpid
         winpid=$(win_pid "$pid")
         if test -n "$winpid"; then
-            "$(win_exe taskkill)" /F /PID "$winpid" >/dev/null 2>&1 || true
+            taskkill /F /PID "$winpid" >/dev/null 2>&1 || true
         fi
         return 0
     fi
@@ -1026,12 +1016,12 @@ kill_tree() {
             winpid=
         fi
         if test -n "$winpid"; then
-            "$(win_exe taskkill)" /F /T /PID "$winpid" >/dev/null 2>&1 || true
+            taskkill /F /T /PID "$winpid" >/dev/null 2>&1 || true
         # Last resort, so it is opt-in: it kills every engine and every python on
         # the host, siblings of a parallel run included (HTTRACK_EXCLUSIVE_HOST).
         elif test -n "${HTTRACK_EXCLUSIVE_HOST:-}"; then
             taskkill_engines
-            "$(win_exe taskkill)" /F /IM python.exe >/dev/null 2>&1 || true
+            taskkill /F /IM python.exe >/dev/null 2>&1 || true
         fi
         # Not a fallback under wsl2 but the other half of the job: the shell
         # there is Linux, so $pid is often a process that never had a Windows
@@ -1056,7 +1046,7 @@ ENGINE_EXES='httrack proxytrack htsserver webhttrack'
 taskkill_engines() {
     local e
     for e in $ENGINE_EXES; do
-        "$(win_exe taskkill)" /F /IM "$e.exe" >/dev/null 2>&1 || true
+        taskkill /F /IM "$e.exe" >/dev/null 2>&1 || true
     done
 }
 

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -894,8 +894,52 @@ dump_crawl_logs() {
     done
 }
 
+# taskkill and tasklist answer to their bare names under MSYS. Under WSL2 the
+# PATH is Linux's and interop resolves only a real filename, so they need .exe.
+# Dispatched rather than always suffixed, to leave the MSYS path untouched.
+win_tool() { # win_tool taskkill|tasklist
+    case "$(suite_backend)" in
+    wsl2) printf '%s.exe\n' "$1" ;;
+    *) printf '%s\n' "$1" ;;
+    esac
+}
+
+# The substring identifying ONE launch among every Windows process on the host.
+# WSL2 has no /proc/<pid>/winpid, so all that is left is what the relay was
+# started with, and the exe's path is shared by every concurrent test. The
+# longest argument is the test's own output directory, which is unique per
+# launch and longer than any flag. Empty when nothing is distinctive enough,
+# which the callers already treat as "unknown" (#1228).
+win_marker() { # win_marker <path to a NUL-separated cmdline>
+    test -r "$1" || return 0
+    tr '\0' '\n' <"$1" 2>/dev/null |
+        awk 'NR > 1 && length($0) >= 8 && length($0) > length(best) { best = $0 }
+             END { if (best != "") print best }'
+}
+
+# The Windows PID of the process carrying $1 on its command line, empty unless
+# exactly one matches: naming a stranger is as good as naming nobody (#1228).
+# The marker travels in the environment, not in the argument list, so this query
+# cannot match itself the way the same marker on its own command line would.
+win_pid_by_marker() { # win_pid_by_marker <marker>
+    test -n "$1" || return 0
+    # shellcheck disable=SC2016 # the $ below are PowerShell's, not the shell's
+    HTS_WIN_MARKER=$1 WSLENV=HTS_WIN_MARKER powershell.exe -NoProfile \
+        -NonInteractive -Command '
+        $m = $env:HTS_WIN_MARKER
+        $p = @(Get-CimInstance Win32_Process | Where-Object {
+            $_.ProcessId -ne $PID -and $_.CommandLine -and
+            $_.CommandLine.Contains($m) })
+        if ($p.Count -eq 1) { $p[0].ProcessId }' 2>/dev/null |
+        tr -cd '0-9'
+}
+
 # The Windows PID behind an MSYS pid, empty when unknown.
 win_pid() {
+    if test "$(suite_backend)" = wsl2; then
+        win_pid_by_marker "$(win_marker "/proc/$1/cmdline")"
+        return 0
+    fi
     if test -r "/proc/$1/winpid"; then
         cat "/proc/$1/winpid" 2>/dev/null || true
     fi
@@ -909,6 +953,16 @@ win_pid() {
 win_capture() { # win_capture <pid>
     WIN_PID='' WIN_IMAGE=''
     target_is_windows || return 0
+    if test "$(suite_backend)" = wsl2; then
+        # The relay's own cmdline, which is the Windows process's: read while it
+        # is alive for the same reason winpid is, since a dead relay has none.
+        local marker
+        marker=$(win_marker "/proc/$1/cmdline")
+        WIN_PID=$(win_pid_by_marker "$marker")
+        { read -r -d '' WIN_IMAGE <"/proc/$1/cmdline"; } 2>/dev/null || true
+        WIN_IMAGE=${WIN_IMAGE##*[\\/]}
+        return 0
+    fi
     # Unguarded reads: a missing file leaves the empty value set above, and read
     # reports EOF on an unterminated line having already assigned it.
     { read -r WIN_PID <"/proc/$1/winpid"; } 2>/dev/null || true
@@ -920,7 +974,7 @@ win_capture() { # win_capture <pid>
 # Whether Windows PID $1 runs image $2. Both columns at once, since either alone
 # answers for a recycled PID, and case-folded as the proclib.sh matchers are.
 win_pid_runs() { # win_pid_runs <winpid> <image>
-    tasklist 2>/dev/null |
+    "$(win_tool tasklist)" 2>/dev/null |
         awk -v p="$1" -v i="$2" 'tolower($1) == tolower(i) && $2 == p { f = 1 } END { exit !f }'
 }
 
@@ -932,7 +986,7 @@ kill_pid() {
         local winpid
         winpid=$(win_pid "$pid")
         if test -n "$winpid"; then
-            taskkill /F /PID "$winpid" >/dev/null 2>&1 || true
+            "$(win_tool taskkill)" /F /PID "$winpid" >/dev/null 2>&1 || true
         fi
         return 0
     fi
@@ -959,12 +1013,12 @@ kill_tree() {
             winpid=
         fi
         if test -n "$winpid"; then
-            taskkill /F /T /PID "$winpid" >/dev/null 2>&1 || true
+            "$(win_tool taskkill)" /F /T /PID "$winpid" >/dev/null 2>&1 || true
         # Last resort, so it is opt-in: it kills every engine and every python on
         # the host, siblings of a parallel run included (HTTRACK_EXCLUSIVE_HOST).
         elif test -n "${HTTRACK_EXCLUSIVE_HOST:-}"; then
             taskkill_engines
-            taskkill /F /IM python.exe >/dev/null 2>&1 || true
+            "$(win_tool taskkill)" /F /IM python.exe >/dev/null 2>&1 || true
         fi
         return 0
     fi

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -894,10 +894,10 @@ dump_crawl_logs() {
     done
 }
 
-# taskkill and tasklist answer to their bare names under MSYS. Under WSL2 the
-# PATH is Linux's and interop resolves only a real filename, so they need .exe.
-# Dispatched rather than always suffixed, to leave the MSYS path untouched.
-win_tool() { # win_tool taskkill|tasklist
+# The name a Windows executable answers to here. MSYS resolves a bare name to
+# its .exe; WSL2's PATH is Linux's and matches the filename exactly, so there it
+# needs the suffix. Dispatched rather than always suffixed, to leave MSYS alone.
+win_exe() { # win_exe NAME
     case "$(suite_backend)" in
     wsl2) printf '%s.exe\n' "$1" ;;
     *) printf '%s\n' "$1" ;;
@@ -974,7 +974,7 @@ win_capture() { # win_capture <pid>
 # Whether Windows PID $1 runs image $2. Both columns at once, since either alone
 # answers for a recycled PID, and case-folded as the proclib.sh matchers are.
 win_pid_runs() { # win_pid_runs <winpid> <image>
-    "$(win_tool tasklist)" 2>/dev/null |
+    "$(win_exe tasklist)" 2>/dev/null |
         awk -v p="$1" -v i="$2" 'tolower($1) == tolower(i) && $2 == p { f = 1 } END { exit !f }'
 }
 
@@ -986,7 +986,7 @@ kill_pid() {
         local winpid
         winpid=$(win_pid "$pid")
         if test -n "$winpid"; then
-            "$(win_tool taskkill)" /F /PID "$winpid" >/dev/null 2>&1 || true
+            "$(win_exe taskkill)" /F /PID "$winpid" >/dev/null 2>&1 || true
         fi
         return 0
     fi
@@ -1013,12 +1013,12 @@ kill_tree() {
             winpid=
         fi
         if test -n "$winpid"; then
-            "$(win_tool taskkill)" /F /T /PID "$winpid" >/dev/null 2>&1 || true
+            "$(win_exe taskkill)" /F /T /PID "$winpid" >/dev/null 2>&1 || true
         # Last resort, so it is opt-in: it kills every engine and every python on
         # the host, siblings of a parallel run included (HTTRACK_EXCLUSIVE_HOST).
         elif test -n "${HTTRACK_EXCLUSIVE_HOST:-}"; then
             taskkill_engines
-            "$(win_tool taskkill)" /F /IM python.exe >/dev/null 2>&1 || true
+            "$(win_exe taskkill)" /F /IM python.exe >/dev/null 2>&1 || true
         fi
         return 0
     fi
@@ -1037,7 +1037,7 @@ ENGINE_EXES='httrack proxytrack htsserver webhttrack'
 taskkill_engines() {
     local e
     for e in $ENGINE_EXES; do
-        "$(win_tool taskkill)" /F /IM "$e.exe" >/dev/null 2>&1 || true
+        "$(win_exe taskkill)" /F /IM "$e.exe" >/dev/null 2>&1 || true
     done
 }
 

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -339,24 +339,33 @@ find_python() {
     return 1
 }
 
-# Native form of a path: a non-MSYS binary cannot resolve Git Bash's /d/a/... ones.
-nativepath() {
-    if target_is_windows && command -v cygpath >/dev/null 2>&1; then
-        cygpath -m "$1"
+# cygpath under MSYS, wslpath under WSL2. They take the same -m and -u, so the
+# two callers below differ only in the flag. A missing tool falls through to the
+# path unchanged, which is how this has always behaved under MSYS; the wsl2
+# backend instead refuses to start without wslpath, see the guard further down.
+path_convert() { # path_convert -m|-u PATH
+    local tool
+    case "$(suite_backend)" in
+    msys) tool=cygpath ;;
+    wsl2) tool=wslpath ;;
+    *)
+        printf '%s\n' "$2"
+        return 0
+        ;;
+    esac
+    if command -v "$tool" >/dev/null 2>&1; then
+        "$tool" "$1" "$2"
     else
-        printf '%s\n' "$1"
+        printf '%s\n' "$2"
     fi
 }
 
+# Native form of a path: a non-MSYS binary cannot resolve Git Bash's /d/a/... ones.
+nativepath() { path_convert -m "$1"; }
+
 # POSIX form of a path. Anything MSYS splits on a colon needs it, a PATH entry
 # below the drive-letter TMPDIR above all.
-posixpath() {
-    if target_is_windows && command -v cygpath >/dev/null 2>&1; then
-        cygpath -u "$1"
-    else
-        printf '%s\n' "$1"
-    fi
-}
+posixpath() { path_convert -u "$1"; }
 
 # Key before cert in $1/both.pem, the single path load_cert_chain() takes.
 make_tls_pem() {
@@ -611,6 +620,13 @@ target_is_windows() {
 # Is this shell MSYS/Git Bash? Ask only about the shell's own quirks, its broken
 # job control above all. A question about the binary wants target_is_windows.
 shell_is_msys() { test "$(suite_backend)" = msys; }
+
+# Fail at source time, not at the first conversion: nativepath and posixpath are
+# always called as "$(nativepath ...)", and an exit inside a command
+# substitution ends that subshell while the test carries on with an empty
+# string. A Linux path handed to httrack.exe fails far from here.
+test "$(suite_backend)" != wsl2 || command -v wslpath >/dev/null 2>&1 ||
+    fail "no wslpath under the wsl2 backend, so no path would reach httrack.exe"
 
 # Open the timer fd poll_wait reads from: a fifo held open read-write, so there is
 # always a writer and a read blocks to its own timeout instead of seeing EOF. fd 9

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -593,14 +593,24 @@ build_names_frames() {
 # Only msys is sniffable, because a wsl2 shell answers `Linux` exactly like a
 # native one, so the driver sets the variable and an unset one means posix.
 suite_backend() {
-    if test -z "${HTTRACK_SUITE_BACKEND:-}"; then
+    test -z "${HTTRACK_SUITE_BACKEND:-}" || {
+        printf '%s\n' "$HTTRACK_SUITE_BACKEND"
+        return 0
+    }
+    # IS_WINDOWS is the override this file has always honoured, and before the
+    # split it answered both questions at once, so it names a backend and not
+    # just the binary's platform. Resolved on every call rather than cached,
+    # because a test sets it after sourcing us (249_windows-reap-images.test).
+    case "${IS_WINDOWS:-}" in
+    yes) printf 'msys\n' ;;
+    no) printf 'posix\n' ;;
+    *)
         case "$HTS_OS" in
-        MINGW* | MSYS* | CYGWIN*) HTTRACK_SUITE_BACKEND=msys ;;
-        *) HTTRACK_SUITE_BACKEND=posix ;;
+        MINGW* | MSYS* | CYGWIN*) printf 'msys\n' ;;
+        *) printf 'posix\n' ;;
         esac
-        export HTTRACK_SUITE_BACKEND
-    fi
-    printf '%s\n' "$HTTRACK_SUITE_BACKEND"
+        ;;
+    esac
 }
 
 # Is the program under test a native Windows executable? This is what almost
@@ -906,14 +916,17 @@ win_exe() { # win_exe NAME
 
 # The substring identifying ONE launch among every Windows process on the host.
 # WSL2 has no /proc/<pid>/winpid, so all that is left is what the relay was
-# started with, and the exe's path is shared by every concurrent test. The
-# longest argument is the test's own output directory, which is unique per
-# launch and longer than any flag. Empty when nothing is distinctive enough,
-# which the callers already treat as "unknown" (#1228).
+# started with. Skip argv[0], the same exe for every concurrent test, and skip
+# the flags: local-crawl.sh passes a --user-agent every concurrent crawl shares,
+# and it is LONGER than the output directory. What is left is per-launch,
+# because the output directory and the URL's port are both per-test. Empty when
+# nothing is distinctive enough, which the callers treat as "unknown" (#1228).
 win_marker() { # win_marker <path to a NUL-separated cmdline>
     test -r "$1" || return 0
     tr '\0' '\n' <"$1" 2>/dev/null |
-        awk 'NR > 1 && length($0) >= 8 && length($0) > length(best) { best = $0 }
+        awk 'NR == 1 { next }
+             /^-/ { next }
+             length($0) >= 8 && length($0) > length(best) { best = $0 }
              END { if (best != "") print best }'
 }
 
@@ -1020,11 +1033,17 @@ kill_tree() {
             taskkill_engines
             "$(win_exe taskkill)" /F /IM python.exe >/dev/null 2>&1 || true
         fi
+        # Not a fallback under wsl2 but the other half of the job: the shell
+        # there is Linux, so $pid is often a process that never had a Windows
+        # counterpart for taskkill to find, a backgrounded test bash above all.
+        if test "$(suite_backend)" = wsl2; then
+            kill -9 -"$pid" 2>/dev/null || kill -9 "$pid" 2>/dev/null || true
+        fi
         return 0
     fi
-    # No caller puts $pid in its own group on Windows (set -m is skipped there),
-    # so -"$pid" here would target whatever real group $pid's number collides
-    # with -- possibly the harness's own -- and taskkill above already reaped it.
+    # Under msys no caller puts $pid in its own group (set -m is skipped there),
+    # so -"$pid" would target whatever real group that number collides with,
+    # possibly the harness's own, and the taskkill above already reaped it.
     kill -9 -"$pid" 2>/dev/null || kill -9 "$pid" 2>/dev/null || true
 }
 

--- a/tests/wsl2-exe-shim.sh
+++ b/tests/wsl2-exe-shim.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# PATH shim for the wsl2 backend, symlinked once per engine under the name the
+# tests use. Two things stand between a Linux shell and a native exe: WSL2's
+# PATH matches a filename exactly, so a bare "httrack" finds nothing, and a
+# drvfs path means nothing to the exe once it gets there. Both are fixed here
+# rather than at ~73 call sites.
+#
+# exec, so the pid does not change: win_capture reads /proc/<pid>/cmdline to
+# find the Windows process, and after the exec that cmdline is the translated
+# one the Windows side really carries.
+set -uo pipefail
+
+args=()
+for a in "$@"; do
+    case "$a" in
+    # A drvfs absolute path, which no URL and no option ever looks like.
+    /mnt/[a-z]/*) args+=("$(wslpath -m "$a")") ;;
+    *) args+=("$a") ;;
+    esac
+done
+
+# The +"..." guard keeps an argument-less call alive under set -u on bash 4.3.
+exec "$(basename "$0").exe" ${args[@]+"${args[@]}"}

--- a/tests/wsl2-exe-shim.sh
+++ b/tests/wsl2-exe-shim.sh
@@ -20,5 +20,4 @@ for a in "$@"; do
     esac
 done
 
-# The +"..." guard keeps an argument-less call alive under set -u on bash 4.3.
-exec "$(basename "$0").exe" ${args[@]+"${args[@]}"}
+exec "$(basename "$0").exe" "${args[@]}"


### PR DESCRIPTION
MSYS's fork emulation is what breaks first when the Windows suite is under load (#1273). This adds a second harness against the same native httrack.exe: a Linux shell under WSL2. It spawns 500 processes in 1s where MSYS takes 7s on windows-2022 and 28s on windows-2025. WSL2 comes up in about 35 seconds with no reboot, because the three Windows features it needs are already enabled on the hosted images.

Those numbers time spawns to completion, so they measure throughput and say nothing about a job that never finishes. #1531 is still what decides whether forks provoke the runner wedges. This is worth doing either way, because a harness that does not depend on fork emulation survives that question concluding anything.

Both backends stay live behind `HTTRACK_SUITE_BACKEND`, so the msys path is untouched and a regression is a variable flip rather than a revert. Deleting the MSYS side is a later change.

`is_windows()` answered two questions at once. A survey of all 135 call sites found 90 asking whether the binary under test is a Windows exe, which stays true under WSL2. Only 6 ask whether the shell is MSYS, which does not. It is deleted rather than redefined, so a site nobody converted is a command-not-found instead of a silently wrong answer.

The one primitive WSL2 lacks is `/proc/<pid>/winpid`, because interop's Linux-side child is only a relay. A spike on a hosted runner proved two things. The Windows process can be found through a marker already on its command line, and the whole tree then dies. Run: https://github.com/xroche/httrack/actions/runs/33855598109. That marker travels to PowerShell in the environment rather than in the argument list. Passed as an argument it would sit on the querying process's own command line, and the query would match itself.

Two bugs of the same shape turned up on the way. `proclib.sh`'s forensics kept a bare `tasklist`, which under WSL2 returns nothing and calls the host clean. `58_watchdog.test` ran a bare `ping`, where WSL's Linux one reads `-n` as numeric output rather than a count.

The suite's skip ratchet measures the rest, because it diffs the skip set both ways. The new leg therefore reports exactly which tests changed status, rather than leaving it to be noticed. That leg does not gate the job yet, since a red read against no history tells nobody anything. Flip `continue-on-error` once it has a few days behind it.

The cost is one more Windows job per run, and every added Windows job is one the runner can kill.