### PR TITLE
The emulated leg times out where it used to pace itself, and reads argv[0] off a child

### DIFF
--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -403,10 +403,8 @@ EOF
     got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND=wsl2 PSREC="$tmpdir/ps" \
         PATH="$pathbin:$PATH" bash "$tmpdir/cap.sh" "$marker")
     assert_eq 4242 "${got%%|*}" "the Windows pid win_capture resolved"
-    # The image half reads the relay's own argv[0], which binfmt_misc takes for
-    # the interpreter under qemu-user, shifting the program one place right
-    # (tools/emulated-suite.sh asserts that shape is what the leg runs on). So
-    # ask this host what a child's cmdline says before pinning the name.
+    # binfmt_misc leaves the interpreter in argv[0], so under qemu-user the
+    # relay's cmdline names the emulator rather than the image it runs.
     argv0_is_the_program() {
         local probe leaf=
         /bin/sh -c 'sleep 30' >/dev/null 2>&1 &

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -402,7 +402,31 @@ EOF
     marker="/mnt/c/t/httrack_local.ZzUnique1"
     got=$(env -u IS_WINDOWS HTTRACK_SUITE_BACKEND=wsl2 PSREC="$tmpdir/ps" \
         PATH="$pathbin:$PATH" bash "$tmpdir/cap.sh" "$marker")
-    assert_eq "4242|sh" "$got" "the Windows pid and image win_capture resolved"
+    assert_eq 4242 "${got%%|*}" "the Windows pid win_capture resolved"
+    # The image half reads the relay's own argv[0], which binfmt_misc takes for
+    # the interpreter under qemu-user, shifting the program one place right
+    # (tools/emulated-suite.sh asserts that shape is what the leg runs on). So
+    # ask this host what a child's cmdline says before pinning the name.
+    argv0_is_the_program() {
+        local probe leaf=
+        /bin/sh -c 'sleep 30' >/dev/null 2>&1 &
+        probe=$!
+        # The fork precedes the exec, so the first read can still answer bash.
+        for _ in $(seq 20); do
+            { read -r -d '' leaf <"/proc/$probe/cmdline"; } 2>/dev/null || leaf=
+            case "${leaf##*[\\/]}" in sh | qemu-* | *-binfmt*) break ;; esac
+            poll_wait 0.2
+        done
+        kill "$probe" 2>/dev/null || true
+        wait "$probe" 2>/dev/null || true
+        test "${leaf##*[\\/]}" = sh
+    }
+    if argv0_is_the_program; then
+        assert_eq sh "${got#*|}" "the image win_capture resolved"
+    else
+        echo "this host hands argv[0] to a binfmt interpreter, so the relay's" \
+            "cmdline cannot name the image; the pid half still ran" >&2
+    fi
     assert_eq "$marker" "$(cat "$tmpdir/ps.env")" "the marker powershell received"
     # In the environment, never on the command line: a marker passed as an argument
     # puts it on the querying process's own cmdline, which then matches itself.

--- a/tests/397_configure-auto-features.test
+++ b/tests/397_configure-auto-features.test
@@ -169,11 +169,8 @@ assert_state() { # assert_state DIR NAME on|off
 n=0
 planned=10 # steps below; the last one needs the libraries to be installed
 
-# Pace the next step against the costliest one so far, not against the one just
-# run: the steps below are ordered by what they mean rather than by what they
-# cost, so a cheap neighbour would under-project the slow step after it and the
-# guard would fire instead of the skip. Under qemu-user each configure run costs
-# about thirty times what it does natively, which is what this is for (#1537).
+# Pace against the costliest step so far, never against the last one: these steps
+# are ordered by what they mean, so a cheap one under-projects the slow one after it.
 costliest=0
 pace() { # pace <seconds the step took>
     test "$1" -le "${costliest}" || costliest=$1

--- a/tests/397_configure-auto-features.test
+++ b/tests/397_configure-auto-features.test
@@ -169,6 +169,17 @@ assert_state() { # assert_state DIR NAME on|off
 n=0
 planned=10 # steps below; the last one needs the libraries to be installed
 
+# Pace the next step against the costliest one so far, not against the one just
+# run: the steps below are ordered by what they mean rather than by what they
+# cost, so a cheap neighbour would under-project the slow step after it and the
+# guard would fire instead of the skip. Under qemu-user each configure run costs
+# about thirty times what it does natively, which is what this is for (#1537).
+costliest=0
+pace() { # pace <seconds the step took>
+    test "$1" -le "${costliest}" || costliest=$1
+    skip_if_out_of_budget "$((planned - n))" "${costliest}"
+}
+
 # A GNU-libiconv-shaped prefix: a header that renames iconv_open the way the
 # real one does away from LIBICONV_PLUG, and a library under a subdirectory the
 # bare prefix does not name. Both halves matter, because a probe that declares
@@ -374,6 +385,7 @@ if test -r "${rules}" && ! command -v "${MAKE:-make}" >/dev/null 2>&1; then
     planned=$((planned - 1))
     echo "no ${MAKE:-make} here, so debian/rules was not run" >&2
 elif test -r "${rules}"; then
+    began=${SECONDS}
     n=$((n + 1))
     rc=0
     said=$(rules_verdict "${rules}" "${work}/rules-real") || rc=$?
@@ -601,6 +613,7 @@ build:
 	false
 MUT
     echo "ok: every dh_auto_configure debian/rules runs asks for every feature"
+    pace "$((SECONDS - began))"
 else
     planned=$((planned - 1))
     echo "no debian/rules under ${srcdir}, so the packaging flag list is not read" >&2
@@ -608,6 +621,7 @@ fi
 
 # The cheap, host-independent steps run first: a slow leg that runs out of
 # budget later still covers what the switch means.
+began=${SECONDS}
 n=$((n + 1))
 # A value the switch does not understand must not read as one of the two it does.
 ! run_configure "${work}/bogus" --enable-auto-features=maybe ||
@@ -615,7 +629,9 @@ n=$((n + 1))
 grep -q 'bad value for auto-features' "${work}/bogus/configure.log" ||
     fail_dump "configure refused the value without saying which flag" "${work}/bogus/configure.log"
 echo "ok: a value that is neither yes nor no is refused"
+pace "$((SECONDS - began))"
 
+began=${SECONDS}
 n=$((n + 1))
 # Same for a feature's own tri-state: an unknown value must not fall through.
 ! run_configure "${work}/btbogus" --enable-backtrace=bogus ||
@@ -623,7 +639,9 @@ n=$((n + 1))
 grep -q 'bad value for backtrace' "${work}/btbogus/configure.log" ||
     fail_dump "configure refused the value without saying which flag" "${work}/btbogus/configure.log"
 echo "ok: an unknown --enable-backtrace value is refused"
+pace "$((SECONDS - began))"
 
+began=${SECONDS}
 n=$((n + 1))
 # The switch must not turn a library the packager named into a silent drop (#1502).
 mkdir -p "${work}/empty"
@@ -632,7 +650,9 @@ mkdir -p "${work}/empty"
 grep -q 'brotli requested at' "${work}/reject/configure.log" ||
     fail_dump "configure failed without naming the prefix it was given" "${work}/reject/configure.log"
 echo "ok: an explicit prefix with no library still fails the build"
+pace "$((SECONDS - began))"
 
+began=${SECONDS}
 n=$((n + 1))
 # backtrace() is implemented for Linux alone, so --enable-backtrace has to stay a
 # notice off it: a recipe passes one flag list for every architecture it builds,
@@ -648,7 +668,9 @@ case ${got} in
 *) fail_dump "a foreign host answered '${got}' rather than declining backtrace" \
     "${work}/foreign/configure.log" ;;
 esac
+pace "$((SECONDS - began))"
 
+began=${SECONDS}
 n=$((n + 1))
 # A bare --with-iconv must FTBFS where iconv does not link, rather than fall
 # back to the codepage tables. The fixture has the header and not the symbol.
@@ -674,7 +696,9 @@ grep -q 'iconv requested but no iconv.h with a linkable iconv_open' \
     fail_dump "configure failed without saying that iconv was the request" \
         "${work}/ic-bare/configure.log"
 echo "ok: a bare --with-iconv fails the build rather than falling back"
+pace "$((SECONDS - began))"
 
+began=${SECONDS}
 n=$((n + 1))
 # --with-iconv=DIR is the form a keg-only or ports prefix needs, and the one arm
 # of HTS_FIND_LIBDIR the codec test does not reach. The subdirectory is the
@@ -713,6 +737,7 @@ else
     n=$((n - 1))
     echo "no shared library from ${cc_argv[0]}, so the iconv prefix case is skipped" >&2
 fi
+pace "$((SECONDS - began))"
 
 began=${SECONDS}
 n=$((n + 1))
@@ -728,7 +753,7 @@ for f in ${features}; do
     assert_state "${work}/off" "${f}" off
 done
 echo "ok: the switch turns every feature off, whatever the host has installed"
-skip_if_out_of_budget "$((planned - n))" "$((SECONDS - began))"
+pace "$((SECONDS - began))"
 
 began=${SECONDS}
 n=$((n + 1))
@@ -748,7 +773,7 @@ for f in ${features}; do
     esac
 done
 echo "ok: every feature answers the default run; auto-enabled here:${on:- none}"
-skip_if_out_of_budget "$((planned - n))" "$((SECONDS - began))"
+pace "$((SECONDS - began))"
 
 if test -z "${on}"; then
     planned=$((planned - 1))


### PR DESCRIPTION
The `emulated suite (s390x)` leg has been red on master since #1534. It is the only place the suite runs big-endian. It is also not in the required set, so a red one loses that coverage without blocking anything.

Two tests fail, for unrelated reasons.

`397_configure-auto-features` hits its 900s guard. It already paced itself with `skip_if_out_of_budget`, but only after its last three steps, and #1534 added a debian/rules section ahead of them. A configure run costs about thirty times more under qemu-user than it does natively. The first paced step stopped fitting, so the guard fired before any pacing ran. It now paces after every step, and projects against the costliest step so far rather than the one just run. These steps are ordered by what they mean rather than by what they cost, so a cheap neighbour under-projects the slow step after it. On master at a 25s budget the test runs 34s before skipping, which the guard would kill. With this it skips at 16s.

`257_testlib-asserts` pinned the relay's image name to `sh`. binfmt_misc leaves the interpreter in argv[0] and shifts the program one place right, which is the shape `tools/emulated-suite.sh` asserts this leg runs on. So under qemu the relay's cmdline names the emulator. The pid half is what the case is for, and it was never in doubt. The test now asserts the pid always, and the image only where a child's own cmdline names the program it runs. A mutant giving that child a binfmt-shaped argv[0] takes the other branch.

Nothing native changes: the suite still runs all fourteen steps of 397.
