### PR TITLE
Two recent tests cannot pass on the emulated leg

### DIFF
--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -375,7 +375,11 @@ fi
 # Needs a real procfs to read the relay's cmdline from, and a shell that can
 # execute the fake powershell.exe below. MSYS can do neither: it has no /proc
 # entry to read here and it hands anything named .exe to Windows as a binary.
-if test -d /proc && ! shell_is_msys; then
+# And a procfs that names the program, because under qemu-user's binfmt handler
+# every cmdline reads s390x-binfmt-P instead, this shell's own included.
+self_argv0=
+{ read -r -d '' self_argv0 </proc/self/cmdline; } 2>/dev/null || true
+if test -d /proc && ! shell_is_msys && test "${self_argv0##*/}" = "${BASH##*/}"; then
     cat >"$tmpdir/pathbin/powershell.exe" <<'PSEOF'
 #!/bin/sh
 case ":${WSLENV:-}:" in
@@ -411,7 +415,7 @@ EOF
     esac
     ok "win_capture resolves the Windows pid by marker, passed out of band"
 else
-    echo "no procfs, or a shell that cannot run a script named .exe" >&2
+    echo "procfs missing or renamed by an emulator, or a shell that cannot run a script named .exe" >&2
 fi
 
 # Unshimmed: a guard that fires only on the broken path is half a guard.

--- a/tests/397_configure-auto-features.test
+++ b/tests/397_configure-auto-features.test
@@ -4,7 +4,8 @@
 # naming neither, and Void would have shipped both off. --disable-auto-features
 # moves those defaults to no and leaves an explicit flag alone.
 
-# TEST_TIMEOUT_AT_LEAST: 900
+# The ten configure runs below cost about 115s each on the emulated s390x leg.
+# TEST_TIMEOUT_AT_LEAST: 1800
 
 set -euo pipefail
 
@@ -367,6 +368,7 @@ rules_verdict() { # rules_verdict RULESFILE DIR
         awk '!seen[$0]++ { printf "%s%s", sep, $0; sep = " " } END { print "" }'
 }
 
+began=${SECONDS}
 rules="${srcdir}/debian/rules"
 # Running the recipe is how the flags are read, so a host with no make cannot
 # read them. The other nine steps still run.
@@ -605,9 +607,11 @@ else
     planned=$((planned - 1))
     echo "no debian/rules under ${srcdir}, so the packaging flag list is not read" >&2
 fi
+skip_if_out_of_budget "$((planned - n))" "$((SECONDS - began))"
 
 # The cheap, host-independent steps run first: a slow leg that runs out of
 # budget later still covers what the switch means.
+began=${SECONDS}
 n=$((n + 1))
 # A value the switch does not understand must not read as one of the two it does.
 ! run_configure "${work}/bogus" --enable-auto-features=maybe ||
@@ -615,7 +619,9 @@ n=$((n + 1))
 grep -q 'bad value for auto-features' "${work}/bogus/configure.log" ||
     fail_dump "configure refused the value without saying which flag" "${work}/bogus/configure.log"
 echo "ok: a value that is neither yes nor no is refused"
+skip_if_out_of_budget "$((planned - n))" "$((SECONDS - began))"
 
+began=${SECONDS}
 n=$((n + 1))
 # Same for a feature's own tri-state: an unknown value must not fall through.
 ! run_configure "${work}/btbogus" --enable-backtrace=bogus ||
@@ -623,7 +629,9 @@ n=$((n + 1))
 grep -q 'bad value for backtrace' "${work}/btbogus/configure.log" ||
     fail_dump "configure refused the value without saying which flag" "${work}/btbogus/configure.log"
 echo "ok: an unknown --enable-backtrace value is refused"
+skip_if_out_of_budget "$((planned - n))" "$((SECONDS - began))"
 
+began=${SECONDS}
 n=$((n + 1))
 # The switch must not turn a library the packager named into a silent drop (#1502).
 mkdir -p "${work}/empty"
@@ -632,7 +640,9 @@ mkdir -p "${work}/empty"
 grep -q 'brotli requested at' "${work}/reject/configure.log" ||
     fail_dump "configure failed without naming the prefix it was given" "${work}/reject/configure.log"
 echo "ok: an explicit prefix with no library still fails the build"
+skip_if_out_of_budget "$((planned - n))" "$((SECONDS - began))"
 
+began=${SECONDS}
 n=$((n + 1))
 # backtrace() is implemented for Linux alone, so --enable-backtrace has to stay a
 # notice off it: a recipe passes one flag list for every architecture it builds,
@@ -648,7 +658,9 @@ case ${got} in
 *) fail_dump "a foreign host answered '${got}' rather than declining backtrace" \
     "${work}/foreign/configure.log" ;;
 esac
+skip_if_out_of_budget "$((planned - n))" "$((SECONDS - began))"
 
+began=${SECONDS}
 n=$((n + 1))
 # A bare --with-iconv must FTBFS where iconv does not link, rather than fall
 # back to the codepage tables. The fixture has the header and not the symbol.
@@ -674,7 +686,9 @@ grep -q 'iconv requested but no iconv.h with a linkable iconv_open' \
     fail_dump "configure failed without saying that iconv was the request" \
         "${work}/ic-bare/configure.log"
 echo "ok: a bare --with-iconv fails the build rather than falling back"
+skip_if_out_of_budget "$((planned - n))" "$((SECONDS - began))"
 
+began=${SECONDS}
 n=$((n + 1))
 # --with-iconv=DIR is the form a keg-only or ports prefix needs, and the one arm
 # of HTS_FIND_LIBDIR the codec test does not reach. The subdirectory is the
@@ -713,6 +727,7 @@ else
     n=$((n - 1))
     echo "no shared library from ${cc_argv[0]}, so the iconv prefix case is skipped" >&2
 fi
+skip_if_out_of_budget "$((planned - n))" "$((SECONDS - began))"
 
 began=${SECONDS}
 n=$((n + 1))


### PR DESCRIPTION
Master has been red on the emulated s390x leg since #1534, for two unrelated reasons.

#1534 grew 397 from seven steps to ten against the same 900s budget, and the test's `skip_if_out_of_budget` calls guard only its last two. Each `configure` costs about 115s on that leg, so the run is killed at step eight rather than skipping. Every step is paced now, and the budget is 1800s, which is what ten of those runs need with the pacer's projection on top.

The wsl2 `win_capture` case #1535 added to 257 reads the relay's image out of `/proc/<pid>/cmdline`. Under emulation that names qemu-user's binfmt handler rather than the program, so the case wanted `sh` and got `s390x-binfmt-P`. It now runs only where procfs names the program the shell was exec'd as.

Both guards were run against the case they exist for. With the budget cut to 20s, 397 skips at step four instead of timing out. With argv[0] forced to the emulator's, 257 takes the skip branch, and the unforced run still runs the case.
