### PR TITLE
A bash 4 construct in a test passes on macOS instead of failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1161,6 +1161,11 @@ jobs:
       - name: test file names
         run: bash tests/check-test-names.sh
 
+      # macOS runs the suite under bash 3.2, where a construct it does not
+      # know aborts the test and the EXIT trap turns that into a PASS.
+      - name: bash 3.2 constructs in tests
+        run: bash tests/check-bash32.sh
+
       # The corpus glob is what ships the vectors in a tarball, and it has no
       # oracle of its own: three were missing for exactly that reason.
       - name: fuzz corpus list

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,15 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   socket, and SKIP when one answered: the powerpc and ppc64 buildds refuse
   TEST-NET-1 milliseconds after `connect()` where runners drop it.
   `tools/hostile-net.sh` runs a command on such a network.
+- macOS runs the suite under `/bin/bash`, which is bash 3.2. A construct it
+  does not know aborts the script, and the EXIT trap above then reports a PASS
+  (#1540). `tests/check-bash32.sh` (also a CI lint) rejects `mapfile`,
+  `readarray`, `${a[-1]}`, `declare -A`, `${v^^}` and namerefs, none of which
+  `bash -n` sees. It leaves out the empty-array case (`"${a[@]}"` under
+  `set -u`), because no static check can tell whether an array is empty there.
+- Never add a matrix axis to `windows-build.yml`. Its job has no `name:`, so an
+  axis renames the required contexts (`libhttrack (x64, Release)`, `libhttrack
+  (Win32, Release)`). They then stop reporting on every open PR in the repo.
 
 ## Hard invariants
 - **Generated autotools files are NOT in git.** `configure`, every

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,7 @@ TESTS = @TESTS_LIST@
 # Committed binary fixture read by 01_zlib-cache-golden.test. List it
 # explicitly: automake does not expand wildcards in EXTRA_DIST, so a glob would
 # silently drop it from the dist tarball and break "make distcheck".
-EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c altstackprobe.c nopieprobe.c printnumprobe.c closetrack.c ftpcancel.c seekfail.c pubheaderlayout.c chainplug.c crawl-test.sh run-all-tests.sh check-network.sh check-test-names.sh \
+EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c altstackprobe.c nopieprobe.c printnumprobe.c closetrack.c ftpcancel.c seekfail.c pubheaderlayout.c chainplug.c crawl-test.sh run-all-tests.sh check-network.sh check-test-names.sh check-bash32.sh \
 	proxy-https-server.py socks5-server.py proxy-connect-server.py \
 	proxytestlib.py tls-stall-server.py warc-validate.py wacz-validate.py \
 	header-injection-server.py header-injection-check.py \

--- a/tests/check-bash32.sh
+++ b/tests/check-bash32.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+# macOS runs the suite under /bin/bash, which is bash 3.2. A construct it does
+# not know is a fatal expansion error there: the script aborts mid-test, and
+# testlib.sh's EXIT trap (kept for #773) exits 0, so automake records a PASS
+# (#1540). bash 3.2 zeroes $? before entering that trap, so the trap cannot
+# recover the real status -- catching the constructs statically is the only
+# defence left. "bash -n" catches none of them: they all parse, and fail when
+# the expansion runs.
+#
+# Only constructs bash 5 accepts can hide this way. Anything bash 5 rejects
+# reds every Linux leg on the first run.
+#
+# NOT covered, on purpose: "${a[@]}" on an empty array, which bash 3.2 treats
+# as unbound under "set -u". Whether an array is empty at a given line is not
+# statically decidable, and the tree holds a few hundred such expansions that
+# are fine, so a pattern for it would be noise rather than a lint. Do not
+# "complete" the list with it.
+
+# Every pattern and sample below is literal bash text, never an expansion.
+# shellcheck disable=SC2016
+
+set -euo pipefail
+export LC_ALL=C
+
+testdir=$(cd "${1:-$(dirname "$0")}" && pwd)
+self=$(basename "$0")
+
+status=0
+bad() {
+    echo "$*" >&2
+    status=1
+}
+
+# One row per class: message, extended regex, and a line that must match it.
+labels=()
+regexes=()
+samples=()
+add() {
+    labels+=("$1")
+    regexes+=("$2")
+    samples+=("$3")
+}
+
+add 'negative array subscript, bash 4.3+' \
+    '\$\{#?[A-Za-z_][A-Za-z0-9_]*\[[[:space:]]*-' \
+    'last=${arr[-1]}'
+add 'mapfile/readarray, bash 4.0+' \
+    '(^|[;&|(]|[[:space:]])(mapfile|readarray)[[:space:]]' \
+    'mapfile -t lines <input'
+add 'associative array (declare -A), bash 4.0+' \
+    '(^|[;&|(]|[[:space:]])(declare|local|typeset)[[:space:]]+-[A-Za-z]*A' \
+    'declare -A seen'
+add 'case conversion ${v^^} / ${v,,}, bash 4.0+' \
+    '\$\{#?[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(\^|,)' \
+    'up=${name^^}'
+add 'nameref (declare -n), bash 4.3+' \
+    '(^|[;&|(]|[[:space:]])(declare|local|typeset)[[:space:]]+-[A-Za-z]*n' \
+    'local -n ref=$1'
+
+# A lint nobody can see fail is worth nothing, so prove each pattern still
+# matches its own known-bad line, and that a plain one matches none of them.
+clean='printf "%s\n" "${files[@]}" | sort'
+i=0
+while [ "$i" -lt "${#labels[@]}" ]; do
+    if ! command grep -qE "${regexes[$i]}" <<<"${samples[$i]}"; then
+        bad "self-check: the pattern for ${labels[$i]} no longer matches its own sample"
+    fi
+    if command grep -qE "${regexes[$i]}" <<<"$clean"; then
+        bad "self-check: the pattern for ${labels[$i]} matches a plain line"
+    fi
+    i=$((i + 1))
+done
+
+# Strip comments first, or a comment naming one of these trips the lint. Only a
+# "#" opening a line or following whitespace, so "$#" and "${#a[@]}" survive.
+strip='s/^[[:space:]]*#.*$//; s/[[:space:]]#.*$//'
+
+count=0
+shopt -s nullglob
+for f in "$testdir"/*.test "$testdir"/*.sh; do
+    name=${f##*/}
+    # This file carries a known-bad line of every class as its own control.
+    [ "$name" != "$self" ] || continue
+    body=$(sed "$strip" "$f")
+    count=$((count + 1))
+    i=0
+    while [ "$i" -lt "${#labels[@]}" ]; do
+        hits=$(command grep -nE "${regexes[$i]}" <<<"$body" || true)
+        if [ -n "$hits" ]; then
+            while IFS= read -r hit; do
+                bad "$name:${hit%%:*}: ${labels[$i]}: ${hit#*:}"
+            done <<<"$hits"
+        fi
+        i=$((i + 1))
+    done
+done
+shopt -u nullglob
+
+# Floor: an empty tests/ would satisfy every check above.
+[ "$count" -gt 0 ] || bad "no .test or .sh file found under $testdir"
+
+if [ "$status" -eq 0 ]; then
+    echo "bash 3.2: $count files, none using a construct macOS would abort on"
+else
+    echo "macOS runs these under bash 3.2, where the abort is laundered into a PASS." >&2
+fi
+exit "$status"


### PR DESCRIPTION
A test that hits a bash 4 construct on macOS aborts on the spot. testlib.sh's EXIT trap then exits 0, so automake records a PASS. #1540 fixed the two sites that had it, and nothing stops the next one. The trap cannot recover the status, because bash 3.2 zeroes `$?` before entering it, and the trap has to stay for #773. `bash -n` sees none of these either, since they all parse and fail only when the expansion runs. So the defence left is catching them statically.

`tests/check-bash32.sh` scans `tests/*.test` and `tests/*.sh` for the five classes bash 5 accepts and bash 3.2 does not: `mapfile`/`readarray`, negative array subscripts, `declare -A`, `${v^^}`/`${v,,}` and namerefs. Anything bash 5 rejects needs no lint, because it reds every Linux leg on the first run. It runs in the `lint` job beside `check-test-names.sh`, whose shape it follows.

Comments are stripped before matching, or a comment naming one of these would trip it. The script skips itself, because it carries a known-bad line of each class. It checks that every pattern still matches its own line and no plain one. A lint that cannot be seen failing proves nothing about a clean tree.

The empty-array case, `"${a[@]}"` under `set -u`, is deliberately out. Whether an array is empty at a given line is not statically decidable, and the tree holds a few hundred such expansions that are fine. A comment in the script says so.

It is clean on master, and it fires on one planted mutant of each of the five classes with a distinct file:line message. Replayed against `master~1` it reports exactly the two sites #1540 removed, `207_install-headers-symbols.test:114` and `331_fortify-source.test:88`.

The AGENTS.md hunk also records that a matrix axis added to `windows-build.yml` renames both required contexts, so they stop reporting on every open PR. That lived in a private notes file, where an outside contributor never sees it.
