### PR TITLE
HTS_INLINE is defined twice and only one definition ever applies

### DIFF
--- a/src/htsbase.h
+++ b/src/htsbase.h
@@ -63,9 +63,7 @@ extern "C" {
 #endif
 #include <assert.h>
 
-/* Compiler-portability attribute macros (no-ops on non-GCC). HTS_INLINE is
-   defined once, by htsglobal.h (included above), so it is not redefined
-   here. */
+/* Compiler-portability attribute macros (no-ops on non-GCC). HTS_INLINE comes from htsglobal.h. */
 #ifndef HTS_UNUSED
 #ifdef __GNUC__
 #define HTS_UNUSED __attribute__ ((unused))

--- a/src/htsbase.h
+++ b/src/htsbase.h
@@ -63,20 +63,20 @@ extern "C" {
 #endif
 #include <assert.h>
 
-/* Compiler-portability attribute macros (no-ops on non-GCC). */
+/* Compiler-portability attribute macros (no-ops on non-GCC). HTS_INLINE is
+   defined once, by htsglobal.h (included above), so it is not redefined
+   here. */
 #ifndef HTS_UNUSED
 #ifdef __GNUC__
 #define HTS_UNUSED __attribute__ ((unused))
 
 #define HTS_STATIC static __attribute__ ((unused))
 
-#define HTS_INLINE __inline__
 /* printf-style format check; fmt/arg are 1-based argument positions. */
 #define HTS_PRINTF_FUN(fmt, arg) __attribute__ ((format (printf, fmt, arg)))
 #else
 #define HTS_UNUSED
 #define HTS_STATIC static
-#define HTS_INLINE
 #define HTS_PRINTF_FUN(fmt, arg)
 #endif
 #endif

--- a/src/htsbase.h
+++ b/src/htsbase.h
@@ -63,7 +63,8 @@ extern "C" {
 #endif
 #include <assert.h>
 
-/* Compiler-portability attribute macros (no-ops on non-GCC). HTS_INLINE comes from htsglobal.h. */
+/* Compiler-portability attribute macros (no-ops on non-GCC). HTS_INLINE comes
+ * from htsglobal.h. */
 #ifndef HTS_UNUSED
 #ifdef __GNUC__
 #define HTS_UNUSED __attribute__ ((unused))


### PR DESCRIPTION
`HTS_INLINE` was defined twice with different bodies, in htsglobal.h and htsbase.h. Only one of them ever applied. htsbase.h includes htsglobal.h before its own `#ifndef HTS_UNUSED` block, and htsglobal.h defines `HTS_UNUSED` unconditionally. So htsbase.h's guard is already false when it is reached, and its definition never ran in any translation unit.

This deletes the dead pair of lines. htsglobal.h keeps the name and the body, and it is the installed header, so nothing an external consumer sees moves. A consumer including htsbase.h alone still gets `HTS_INLINE`, because of that same include at the top. Rebuilt with gcc and clang, neither emits a new diagnostic.

No warning was being lost: a redefinition warning needs the second `#define` to run, and this one never did.

No test, because the effective behaviour is unchanged and the tree builds no C++, so `HTS_INLINE` expands to nothing today exactly as it did before.

The same audit looked at src/htsserver.h's five `static` helpers and found nothing to fix. The header forward-declares each one with `HTS_UNUSED` ahead of its definition, so the attribute merges onto the definition. Neither compiler warns in htsweb.c, the includer that calls none of them.
