### PR TITLE
An https link is fetched in the clear when the build has no OpenSSL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -519,11 +519,9 @@ AC_ARG_ENABLE([https],
 	https_support=yes
 	AC_MSG_RESULT($https_support)
 	])
-AC_SUBST(HTTPS_SUPPORT,$https_support)
-
 # Probe OpenSSL ?
+https_have=no
 if test x"$https_support" = x"no"; then
-AC_MSG_NOTICE([disabling https support])
 AC_DEFINE(HTS_USEOPENSSL, 0)
 else
 SAVE_LIBS=$LIBS
@@ -537,19 +535,28 @@ AC_CHECK_LIB(ssl, SSL_CTX_new,
 	[
 	# -lssl first: an archive link needs it ahead of the -lcrypto it uses.
 	OPENSSL_LIBS="-lssl $OPENSSL_LIBS"
+	https_have=yes
 	AC_DEFINE(HTS_USEOPENSSL, 1, [Check for OpenSSL])
 	],
 	[
-	if test x"$https_support" = x"yes"; then
-	AC_MSG_ERROR([not available])
-	else
-	AC_MSG_RESULT([not available])
-	fi
+	# Nothing here links libcrypto on its own, so drop the half we found.
+	OPENSSL_LIBS=
+	AS_IF([test x"$https_support" = x"yes"],
+		[AC_MSG_ERROR([no linkable libssl. Install the OpenSSL development files, or pass --disable-https to build without https])],
+		dnl Define it to 0: htsglobal.h defaults an undefined
+		dnl HTS_USEOPENSSL back to 1 and the link then fails on every SSL symbol.
+		[AC_DEFINE(HTS_USEOPENSSL, 0)])
 	]
 	)
 LIBS=$SAVE_LIBS
-AC_SUBST(OPENSSL_LIBS)
 fi
+AC_SUBST(OPENSSL_LIBS)
+AC_MSG_CHECKING([whether https support is enabled])
+dnl Name who decided: "auto" is the build machine's answer, not the packager's.
+AS_IF([test x"$https_support" = x"auto"],
+	[AC_MSG_RESULT([$https_have (auto)])],
+	[AC_MSG_RESULT([$https_have (requested)])])
+AC_SUBST(HTTPS_SUPPORT,$https_have)
 
 ### Support IPv6
 V6_SUPPORT=no
@@ -693,10 +700,10 @@ hts_pc_dep() { # hts_pc_dep <module or empty> <link line>
 		PKGCONFIG_LIBS_PRIVATE="${PKGCONFIG_LIBS_PRIVATE:+$PKGCONFIG_LIBS_PRIVATE }$2"
 	fi
 }
-# Whichever half of OpenSSL was actually found; https=auto can settle for libcrypto.
+# OpenSSL is all or nothing: a build with https links -lssl and -lcrypto, and a
+# build without links neither.
 AS_CASE([" $OPENSSL_LIBS "],
 	[*" -lssl "*], [hts_pc_openssl=openssl],
-	[*" -lcrypto "*], [hts_pc_openssl=libcrypto],
 	[hts_pc_openssl=])
 hts_pc_dep "$hts_pc_openssl" "$OPENSSL_LIBS"
 hts_pc_dep libbrotlidec "$BROTLI_LIBS"

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -2644,13 +2644,19 @@ int back_add(struct_back *sback, httrackp *opt, cache_back *cache,
 #endif
           return 0;
         }
-      }
+      } else if (strfield(back[p].url_adr, "https://")) {
 #if HTS_USEOPENSSL
-      else if (strfield(back[p].url_adr, "https://")) {     // let's rock
-        back[p].r.ssl = 1;
+        back[p].r.ssl = 1; // let's rock
         back[p].r.ssl_con = NULL;
-      }
+#else
+        // Transferring it would mean a cleartext request to an https URL.
+        back[p].r.statuscode = STATUSCODE_NON_FATAL;
+        strcpybuff(back[p].r.msg, "https:// is not supported by this build");
+        back[p].status = STATUS_READY;
+        back_set_finished(opt, sback, p);
+        return 0;
 #endif
+      }
 
       if (!back_trylive(opt, cache, sback, p)) {
 #if HTS_XGETHOST

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -5937,6 +5937,7 @@ HTSEXT_API const char* hts_version(void) {
   return HTTRACK_VERSIONID;
 }
 
+#if HTS_USEOPENSSL
 static int ssl_vulnerable(const char *version) {
 #ifdef _WIN32
   static const char *const match = "OpenSSL 1.0.1";
@@ -5950,6 +5951,7 @@ static int ssl_vulnerable(const char *version) {
 #endif
   return 0;
 }
+#endif
 
 /* user abort callback */
 htsErrorCallback htsCallbackErr = NULL;

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -2500,7 +2500,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                     afs.af.adr[0] = '\0';      // erreur
                     if (reponse == -2) {
                       hts_log_print(opt, LOG_WARNING,
-                                    "Link %s not caught (unknown protocol)",
+                                    "Link %s not caught (protocol not "
+                                    "supported by this build)",
                                     lien);
                     } else {
                       hts_log_print(opt, LOG_DEBUG,

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -104,6 +104,13 @@ int ident_url_relatif(const char *lien, const char *origin_adr,
       scheme = 1;
   }
 
+#if !HTS_USEOPENSSL
+  // Drop every https link: the relative arm below strips "https:" and refetches
+  // it from the origin host in the clear.
+  if (strfield(lien, "https:"))
+    return -2;
+#endif
+
   // filtrer les parazites (mailto & cie)
   // scheme+authority (//)
   if ((strfield(lien, "http://"))       // scheme+//
@@ -122,17 +129,13 @@ int ident_url_relatif(const char *lien, const char *origin_adr,
     } else {
       ok = -2;                  // non supporté
     }
-#if HTS_USEOPENSSL
   } else if (strfield(lien, "https://")) {
-    // Note: ftp:foobar.gif is not valid
     if (ident_url_absolute(lien, adrfil) == -1) {
       ok = -1;                // erreur URL
     }
-#endif
-  } else if ((scheme) && ((!strfield(lien, "http:"))
-                          && (!strfield(lien, "https:"))
-                          && (!strfield(lien, "ftp:"))
-             )) {
+  } else if ((scheme) &&
+             ((!strfield(lien, "http:")) && (!strfield(lien, "https:")) &&
+              (!strfield(lien, "ftp:")))) {
     ok = -1;                    // unknown scheme
   } else {                      // c'est un lien relatif
     // On forme l'URL complète à partie de l'url actuelle
@@ -211,7 +214,7 @@ int ident_url_relatif(const char *lien, const char *origin_adr,
     } else
       ok = -1;
 
-  }                             // test news: etc.
+  } // test news: etc.
 
   // case insensitive pour adresse
   {

--- a/src/htsweb.c
+++ b/src/htsweb.c
@@ -302,7 +302,7 @@ int main(int argc, char *argv[]) {
 #ifdef HTS_INET6
   smallserver_setkey("INET6", "1");
 #endif
-#ifdef HTS_USEOPENSSL
+#if HTS_USEOPENSSL
   smallserver_setkey("USEOPENSSL", "1");
 #endif
 #ifdef HTS_DLOPEN

--- a/tests/01_engine-relative.test
+++ b/tests/01_engine-relative.test
@@ -52,4 +52,19 @@ ident 'file://srv/share/../x' 'www.foo.com' '/p.html' 'adr=file:// fil=//srv/x'
 ident 'mailto:foo@bar.com' 'www.foo.com' '/p.html' 'error=-1' # unsupported scheme
 ident 'javascript:void(0)' 'www.foo.com' '/p.html' 'error=-1'
 
+# A build without TLS must drop an https link (-2), not fold it into the origin
+# host: the "https:" arm of the relative branch strips the scheme and the link
+# is then refetched from the origin in the clear.
+if test "${HTTPS_SUPPORT:-yes}" = "no"; then
+    ident 'https://secure.foo.com/a/b/../c.gif' 'www.foo.com' '/p.html' 'error=-2'
+    ident 'HTTPS://secure.foo.com/x' 'www.foo.com' '/p.html' 'error=-2'
+    ident 'https:/a/b.gif' 'www.foo.com' '/p.html' 'error=-2' # scheme-relative
+    ident 'https:x.gif' 'www.foo.com' '/p.html' 'error=-2'
+else
+    ident 'https://secure.foo.com/a/b/../c.gif' 'www.foo.com' '/p.html' 'adr=https://secure.foo.com fil=/a/c.gif'
+    ident 'HTTPS://secure.foo.com/x' 'www.foo.com' '/p.html' 'adr=https://secure.foo.com fil=/x'
+    ident 'https:/a/b.gif' 'www.foo.com' '/p.html' 'adr=https://www.foo.com fil=/a/b.gif'
+    ident 'https:x.gif' 'www.foo.com' '/p.html' 'adr=https://www.foo.com fil=/x.gif'
+fi
+
 selftest_run_queued


### PR DESCRIPTION
`ident_url_relatif()` had no `https://` arm without OpenSSL, so in a `--disable-https` build an https link fell through to the relative branch. That branch strips `https:` and rebuilds the URL against the page's own host, and the engine then fetched it over plain HTTP. A local server given a page linking to `https://127.0.0.1:60373/secret.html` received `GET //127.0.0.1:60373/secret.html` in the clear. It now receives nothing, and the log carries `Link https://... not caught (protocol not supported by this build)`. The `https:foo.gif` scheme-relative form leaked the same way, so the guard matches `https:` rather than `https://`.

`back_add()` refuses an https URL for the same reason. Nothing reaches it through the parser any more, but a sitemap enters the queue through `ident_url_absolute()`, and this is the last point before the socket.

`--enable-https=auto` with no OpenSSL was unbuildable. The not-found branch defined nothing, htsglobal.h defaults an undefined `HTS_USEOPENSSL` back to 1, and the link then failed on every SSL symbol. It now defines it to 0, and configure ends with one line naming the outcome and who decided it. `HTTPS_SUPPORT` carries that outcome rather than what was asked, so the tests keyed on it skip correctly under `auto`. The default `--enable-https=yes` already failed loudly, and only its message changed, to name `--disable-https`.

Windows is untouched, because the Visual Studio projects define no `HTS_USEOPENSSL` and htsglobal.h defaults it to 1, so every branch added here is compiled out.

`01_engine-relative.test` pins both build states. On master's `htstools.c` the no-TLS case resolves `https://secure.foo.com/a/b/../c.gif` to `adr=https://www.foo.com fil=//secure.foo.com/a/c.gif`, which is the bug, and the test fails there.

`HTS_INET6` is the same shape and is left alone. Its probe only warns, no flag asks for it, and the Visual Studio projects do not define it either, so that build is IPv4-only.
