### PR TITLE
hts_findgetsize reports a 5GB file as 1GB

### DIFF
--- a/PRBODY-401.md
+++ b/PRBODY-401.md
@@ -1,9 +1,0 @@
-A 5GB file enumerated through `hts_findgetsize()` measures 1GB. The function returns `off_t` truncated into an `int` on POSIX, and on Windows it returns `nFileSizeLow` alone, dropping the high dword. A caller sizing a buffer from that plausible-looking number takes a heap overflow. Nothing in the tree calls it any more. It is `HTSEXT_API` and declared in the installed `httrack-library.h`, so an out-of-tree consumer can be doing exactly that today.
-
-`hts_findgetsize64()` returns `LLint`, the width `fsize()` and `fpsize()` already use for file sizes, and combines both dwords on Windows.
-
-`hts_findgetsize()` stays exported with the same signature and is now `HTS_DEPRECATED`. The decision worth flagging is what it returns past `INT_MAX`: -1, the sentinel it already uses for "no entry", rather than the low bits. A caller that ignores -1 gets a `malloc` failure, where one handed a truncated size gets a silent short buffer. Every caller must already cope with -1.
-
-`VERSION_INFO` moves 3:20:0 to 3:21:0. An export arrived, none moved and none went away, so the soname stays `.so.3` and no Debian package is renamed.
-
-The test is `tests/421_engine-findsize.test`. It drives a new `-#test=findsize` over a 5GB sparse file plus a 1234-byte sibling. It skips on EFBIG or ENOSPC, where the host cannot hold the probe. Both halves of the fix are pinned. Reverting the 64-bit form makes it report 1073741824, and reverting the deprecated form's clamp makes that one report it instead.

--- a/PRBODY-401.md
+++ b/PRBODY-401.md
@@ -1,0 +1,9 @@
+A 5GB file enumerated through `hts_findgetsize()` measures 1GB. The function returns `off_t` truncated into an `int` on POSIX, and on Windows it returns `nFileSizeLow` alone, dropping the high dword. A caller sizing a buffer from that plausible-looking number takes a heap overflow. Nothing in the tree calls it any more. It is `HTSEXT_API` and declared in the installed `httrack-library.h`, so an out-of-tree consumer can be doing exactly that today.
+
+`hts_findgetsize64()` returns `LLint`, the width `fsize()` and `fpsize()` already use for file sizes, and combines both dwords on Windows.
+
+`hts_findgetsize()` stays exported with the same signature and is now `HTS_DEPRECATED`. The decision worth flagging is what it returns past `INT_MAX`: -1, the sentinel it already uses for "no entry", rather than the low bits. A caller that ignores -1 gets a `malloc` failure, where one handed a truncated size gets a silent short buffer. Every caller must already cope with -1.
+
+`VERSION_INFO` moves 3:20:0 to 3:21:0. An export arrived, none moved and none went away, so the soname stays `.so.3` and no Debian package is renamed.
+
+The test is `tests/421_engine-findsize.test`. It drives a new `-#test=findsize` over a 5GB sparse file plus a 1234-byte sibling. It skips on EFBIG or ENOSPC, where the host cannot hold the probe. Both halves of the fix are pinned. Reverting the 64-bit form makes it report 1073741824, and reverting the deprecated form's clamp makes that one report it instead.

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,9 @@ AC_CONFIG_HEADERS(config.h)
 # header we can install without handing a consumer our PACKAGE_* and HAVE_*.
 AC_CONFIG_HEADERS([htsfeatures.h:src/htsfeatures.h.in])
 AM_INIT_AUTOMAKE([subdir-objects])
+# 3:21:0: revision-only bump. hts_findgetsize64() arrived beside hts_findgetsize(),
+# which stays exported with the same signature; no installed struct moved and
+# nothing went away.
 # 3:20:0: revision-only bump. #1495 added an export (SOCaddr_inetntoa_port_) beside
 # SOCaddr_inetntoa_, the same shape as 3:11:0; no installed struct moved and nothing
 # went away.
@@ -69,7 +72,7 @@ AM_INIT_AUTOMAKE([subdir-objects])
 # moves nothing). Soname stays .so.3: HTTrackQt is the only consumer of the installed
 # headers, so a libhttrack4 rename isn't worth it.
 # (3:0:0 was the htsblk mime-buffer widening, the ABI break that moved .so.2 -> .so.3.)
-VERSION_INFO="3:20:0"
+VERSION_INFO="3:21:0"
 AM_MAINTAINER_MODE
 AC_USE_SYSTEM_EXTENSIONS
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3400,6 +3400,132 @@ static int st_fsize(httrackp *opt, int argc, char **argv) {
   return rc;
 }
 
+/* The deprecated form is what this test measures, so silence it here only. */
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+static int st_findsize_legacy(find_handle find) {
+  return hts_findgetsize(find);
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+/* A 5GB entry measured through both find-size forms, beside a sub-2GB one the
+   deprecated form must still answer. */
+static int st_findsize(httrackp *opt, int argc, char **argv) {
+  const LLint expected = 5 * 1024 * 1024 * 1024LL;
+  const LLint small_expected = 1234;
+  char BIGSTK big[HTS_URLMAXSIZE * 2];
+  char BIGSTK small[HTS_URLMAXSIZE * 2];
+  const int width = (int) sizeof(hts_findgetsize64(NULL));
+  LLint big_got = -2, small_got = -2;
+  int big_got32 = -2, small_got32 = -2;
+  find_handle h;
+  FILE *fp;
+  int rc = 0;
+
+  (void) opt;
+  if (argc < 1) {
+    fprintf(stderr, "findsize: needs a directory\n");
+    return 1;
+  }
+  concat(big, sizeof(big), argv[0], "/find-5g.bin");
+  concat(small, sizeof(small), argv[0], "/find-small.bin");
+
+  /* sparse: seek past 4GB and write the last byte */
+  fp = FOPEN(big, "wb");
+  if (fp == NULL) {
+    fprintf(stderr, "findsize: cannot create '%s': %s\n", big, strerror(errno));
+    return 1;
+  }
+#ifdef _WIN32
+  {
+    HANDLE fh = (HANDLE) _get_osfhandle(_fileno(fp));
+    DWORD ret;
+
+    if (fh != INVALID_HANDLE_VALUE)
+      (void) DeviceIoControl(fh, FSCTL_SET_SPARSE, NULL, 0, NULL, 0, &ret,
+                             NULL);
+  }
+#endif
+  if (fseeko(fp, expected - 1, SEEK_SET) != 0 || fputc(0, fp) == EOF ||
+      fclose(fp) != 0) {
+    const int err = errno;
+
+    fprintf(stderr, "findsize: cannot extend '%s' to " LLintP ": %s\n", big,
+            expected, strerror(err));
+    UNLINK(big);
+    /* the host cannot hold the probe (small file cap, full disk): skip */
+    return err == EFBIG || err == ENOSPC ? 77 : 1;
+  }
+
+  fp = FOPEN(small, "wb");
+  if (fp == NULL || fseeko(fp, small_expected - 1, SEEK_SET) != 0 ||
+      fputc(0, fp) == EOF || fclose(fp) != 0) {
+    fprintf(stderr, "findsize: cannot write '%s': %s\n", small,
+            strerror(errno));
+    UNLINK(big);
+    return 1;
+  }
+
+  h = hts_findfirst(argv[0]);
+  if (h == NULL) {
+    fprintf(stderr, "findsize: cannot enumerate '%s'\n", argv[0]);
+    UNLINK(big);
+    UNLINK(small);
+    return 1;
+  }
+  do {
+    const char *const name = hts_findgetname(h);
+
+    if (name == NULL)
+      continue;
+    if (strcmp(name, "find-5g.bin") == 0) {
+      big_got = hts_findgetsize64(h);
+      big_got32 = st_findsize_legacy(h);
+    } else if (strcmp(name, "find-small.bin") == 0) {
+      small_got = hts_findgetsize64(h);
+      small_got32 = st_findsize_legacy(h);
+    }
+  } while (hts_findnext(h));
+  hts_findclose(h);
+  UNLINK(big);
+  UNLINK(small);
+
+  printf("findsize: width=%d big=" LLintP ",%d small=" LLintP ",%d\n", width,
+         big_got, big_got32, small_got, small_got32);
+  if (width != 8) {
+    fprintf(stderr, "findsize: return type is %d bytes, expected 8\n", width);
+    rc = 1;
+  }
+  if (big_got != expected) {
+    fprintf(stderr, "findsize: 5GB file is " LLintP ", expected " LLintP "\n",
+            big_got, expected);
+    rc = 1;
+  }
+  if (big_got32 != -1) {
+    fprintf(stderr,
+            "findsize: deprecated form is %d on the 5GB file, "
+            "expected the -1 sentinel\n",
+            big_got32);
+    rc = 1;
+  }
+  if (small_got != small_expected || small_got32 != (int) small_expected) {
+    fprintf(stderr, "findsize: " LLintP "-byte file is " LLintP ",%d\n",
+            small_expected, small_got, small_got32);
+    rc = 1;
+  }
+  return rc;
+}
+
 /* 4GB+100KB wraps to ~108KB through an int, and needs 33 unsigned bits. A
    macro, not a static const: MSVC's C mode (/TC) rejects a const object
    used inside another object's static initializer below (C2099). */
@@ -13336,6 +13462,9 @@ static const struct selftest_entry {
      "escape_remove_control() terminates at the compacted end",
      st_escape_control},
     {"fsize", "<dir>", "file size past the 2GB signed-32-bit wrap", st_fsize},
+    {"findsize", "<dir>",
+     "directory-enumeration file size past the 2GB signed-32-bit wrap",
+     st_findsize},
     {"growsize", "", "buffer capacity for a 64-bit file size (no int wrap)",
      st_growsize},
     {"addlink", "", "htsAddLink codebase walk over an empty current path",

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3418,36 +3418,20 @@ static int st_findsize_legacy(find_handle find) {
 #pragma warning(pop)
 #endif
 
-/* A 5GB entry measured through both find-size forms, beside a sub-2GB one the
-   deprecated form must still answer. */
-static int st_findsize(httrackp *opt, int argc, char **argv) {
-  const LLint expected = 5 * 1024 * 1024 * 1024LL;
-  const LLint small_expected = 1234;
-  char BIGSTK big[HTS_URLMAXSIZE * 2];
-  char BIGSTK small[HTS_URLMAXSIZE * 2];
-  const int width = (int) sizeof(hts_findgetsize64(NULL));
-  LLint big_got = -2, small_got = -2;
-  int big_got32 = -2, small_got32 = -2;
-  find_handle h;
-  FILE *fp;
-  int rc = 0;
+/* Sparse file of exactly `size` bytes; 77 where the host cannot hold it. */
+static int st_findsize_make(const char *path, LLint size) {
+  FILE *fp = FOPEN(path, "wb");
+  hts_boolean ok;
+  int err;
 
-  (void) opt;
-  if (argc < 1) {
-    fprintf(stderr, "findsize: needs a directory\n");
-    return 1;
-  }
-  concat(big, sizeof(big), argv[0], "/find-5g.bin");
-  concat(small, sizeof(small), argv[0], "/find-small.bin");
-
-  /* sparse: seek past 4GB and write the last byte */
-  fp = FOPEN(big, "wb");
   if (fp == NULL) {
-    fprintf(stderr, "findsize: cannot create '%s': %s\n", big, strerror(errno));
+    fprintf(stderr, "findsize: cannot create '%s': %s\n", path,
+            strerror(errno));
     return 1;
   }
 #ifdef _WIN32
   {
+    /* NTFS allocates the hole unless asked not to; POSIX gives it for free. */
     HANDLE fh = (HANDLE) _get_osfhandle(_fileno(fp));
     DWORD ret;
 
@@ -3456,66 +3440,108 @@ static int st_findsize(httrackp *opt, int argc, char **argv) {
                              NULL);
   }
 #endif
-  if (fseeko(fp, expected - 1, SEEK_SET) != 0 || fputc(0, fp) == EOF ||
-      fclose(fp) != 0) {
-    const int err = errno;
-
-    fprintf(stderr, "findsize: cannot extend '%s' to " LLintP ": %s\n", big,
-            expected, strerror(err));
-    UNLINK(big);
-    /* the host cannot hold the probe (small file cap, full disk): skip */
-    return err == EFBIG || err == ENOSPC ? 77 : 1;
+  ok = fseeko(fp, size - 1, SEEK_SET) == 0 && fputc(0, fp) != EOF ? HTS_TRUE
+                                                                  : HTS_FALSE;
+  err = errno;
+  if (fclose(fp) != 0 && ok) {
+    ok = HTS_FALSE;
+    err = errno;
   }
+  if (ok)
+    return 0;
+  fprintf(stderr, "findsize: cannot extend '%s' to " LLintP ": %s\n", path,
+          size, strerror(err));
+  UNLINK(path);
+  /* the host cannot hold the probe (small file cap, full disk): skip */
+  return err == EFBIG || err == ENOSPC ? 77 : 1;
+}
 
-  fp = FOPEN(small, "wb");
-  if (fp == NULL || fseeko(fp, small_expected - 1, SEEK_SET) != 0 ||
-      fputc(0, fp) == EOF || fclose(fp) != 0) {
-    fprintf(stderr, "findsize: cannot write '%s': %s\n", small,
-            strerror(errno));
-    UNLINK(big);
+/* Three entries measured through both find-size forms. 6GB is the one that
+   catches a sign-extended low dword: bit 31 of 0x1_8000_0000 is set, where
+   5GB's 0x4000_0000 and 1234 both leave it clear. */
+static int st_findsize(httrackp *opt, int argc, char **argv) {
+  const LLint big_expected = 5 * 1024 * 1024 * 1024LL;
+  const LLint sign_expected = 6 * 1024 * 1024 * 1024LL;
+  const LLint small_expected = 1234;
+  char BIGSTK big[HTS_URLMAXSIZE * 2];
+  char BIGSTK sign[HTS_URLMAXSIZE * 2];
+  char BIGSTK small[HTS_URLMAXSIZE * 2];
+  const int width = (int) sizeof(hts_findgetsize64(NULL));
+  LLint big_got = -2, sign_got = -2, small_got = -2;
+  int big_got32 = -2, sign_got32 = -2, small_got32 = -2;
+  find_handle h;
+  int rc;
+
+  (void) opt;
+  if (argc < 1) {
+    fprintf(stderr, "findsize: needs a directory\n");
     return 1;
+  }
+  concat(big, sizeof(big), argv[0], "/find-5g.bin");
+  concat(sign, sizeof(sign), argv[0], "/find-6g.bin");
+  concat(small, sizeof(small), argv[0], "/find-small.bin");
+
+  rc = st_findsize_make(big, big_expected);
+  if (rc == 0)
+    rc = st_findsize_make(sign, sign_expected);
+  if (rc == 0)
+    rc = st_findsize_make(small, small_expected);
+  if (rc != 0) {
+    UNLINK(big);
+    UNLINK(sign);
+    UNLINK(small);
+    return rc;
   }
 
   h = hts_findfirst(argv[0]);
   if (h == NULL) {
     fprintf(stderr, "findsize: cannot enumerate '%s'\n", argv[0]);
-    UNLINK(big);
-    UNLINK(small);
-    return 1;
+    rc = 1;
+  } else {
+    do {
+      const char *const name = hts_findgetname(h);
+
+      if (name == NULL)
+        continue;
+      if (strcmp(name, "find-5g.bin") == 0) {
+        big_got = hts_findgetsize64(h);
+        big_got32 = st_findsize_legacy(h);
+      } else if (strcmp(name, "find-6g.bin") == 0) {
+        sign_got = hts_findgetsize64(h);
+        sign_got32 = st_findsize_legacy(h);
+      } else if (strcmp(name, "find-small.bin") == 0) {
+        small_got = hts_findgetsize64(h);
+        small_got32 = st_findsize_legacy(h);
+      }
+    } while (hts_findnext(h));
+    hts_findclose(h);
   }
-  do {
-    const char *const name = hts_findgetname(h);
-
-    if (name == NULL)
-      continue;
-    if (strcmp(name, "find-5g.bin") == 0) {
-      big_got = hts_findgetsize64(h);
-      big_got32 = st_findsize_legacy(h);
-    } else if (strcmp(name, "find-small.bin") == 0) {
-      small_got = hts_findgetsize64(h);
-      small_got32 = st_findsize_legacy(h);
-    }
-  } while (hts_findnext(h));
-  hts_findclose(h);
   UNLINK(big);
+  UNLINK(sign);
   UNLINK(small);
+  if (rc != 0)
+    return rc;
 
-  printf("findsize: width=%d big=" LLintP ",%d small=" LLintP ",%d\n", width,
-         big_got, big_got32, small_got, small_got32);
+  printf("findsize: width=%d big=" LLintP ",%d signbit=" LLintP
+         ",%d small=" LLintP ",%d\n",
+         width, big_got, big_got32, sign_got, sign_got32, small_got,
+         small_got32);
   if (width != 8) {
     fprintf(stderr, "findsize: return type is %d bytes, expected 8\n", width);
     rc = 1;
   }
-  if (big_got != expected) {
-    fprintf(stderr, "findsize: 5GB file is " LLintP ", expected " LLintP "\n",
-            big_got, expected);
+  if (big_got != big_expected || sign_got != sign_expected) {
+    fprintf(stderr,
+            "findsize: 5GB/6GB files are " LLintP "/" LLintP
+            ", expected " LLintP "/" LLintP "\n",
+            big_got, sign_got, big_expected, sign_expected);
     rc = 1;
   }
-  if (big_got32 != -1) {
+  if (big_got32 != -1 || sign_got32 != -1) {
     fprintf(stderr,
-            "findsize: deprecated form is %d on the 5GB file, "
+            "findsize: deprecated form is %d/%d on the 5GB/6GB files, "
             "expected the -1 sentinel\n",
-            big_got32);
+            big_got32, sign_got32);
     rc = 1;
   }
   if (small_got != small_expected || small_got32 != (int) small_expected) {

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -36,6 +36,7 @@ Please visit our Website: http://www.httrack.com
 
 /* String */
 #include <ctype.h>
+#include <limits.h>
 #include "htscore.h"
 #include "htstools.h"
 #include "htsio.h"
@@ -1325,7 +1326,8 @@ find_handle h = hts_findfirst("/tmp");
 if (h) {
   do {
     if (hts_findisfile(h))
-      printf("File: %s (%d octets)\n",hts_findgetname(h),hts_findgetsize(h));
+      printf("File: %s, " LLintP " bytes\n",
+             hts_findgetname(h), hts_findgetsize64(h));
     else if (hts_findisdir(h))
       printf("Dir: %s\n",hts_findgetname(h));
   } while(hts_findnext(h));
@@ -1423,15 +1425,26 @@ HTSEXT_API char *hts_findgetname(find_handle find) {
   return NULL;
 }
 
-HTSEXT_API int hts_findgetsize(find_handle find) {
+HTSEXT_API LLint hts_findgetsize64(find_handle find) {
   if (find) {
 #ifdef _WIN32
-    return find->hdata.nFileSizeLow;
+    const uint64_t size =
+        ((uint64_t) find->hdata.nFileSizeHigh << 32) | find->hdata.nFileSizeLow;
+
+    return (LLint) size;
 #else
     return find->filestat.st_size;
 #endif
   }
   return -1;
+}
+
+HTSEXT_API int hts_findgetsize(find_handle find) {
+  const LLint size = hts_findgetsize64(find);
+
+  /* Report the error sentinel rather than the low bits: a caller sizing a
+     buffer off a plausible small number takes a heap overflow. */
+  return size >= 0 && size <= INT_MAX ? (int) size : -1;
 }
 
 HTSEXT_API hts_boolean hts_findisdir(find_handle find) {

--- a/src/htstools.h
+++ b/src/htstools.h
@@ -147,6 +147,8 @@ HTSEXT_API int hts_findclose(find_handle find);
 
 //
 HTSEXT_API char *hts_findgetname(find_handle find);
+HTSEXT_API LLint hts_findgetsize64(find_handle find);
+HTS_DEPRECATED("use hts_findgetsize64(find)")
 HTSEXT_API int hts_findgetsize(find_handle find);
 HTSEXT_API hts_boolean hts_findisdir(find_handle find);
 HTSEXT_API hts_boolean hts_findisfile(find_handle find);

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -775,8 +775,13 @@ HTSEXT_API int hts_findclose(find_handle find);
     only until the next hts_findnext()/hts_findclose(). */
 HTSEXT_API char *hts_findgetname(find_handle find);
 
-/** Size in bytes of the current entry, or -1. Truncated to int, so unreliable
-    for files larger than 2 GB. */
+/** Size in bytes of the current entry, or -1 when there is none. */
+HTSEXT_API LLint hts_findgetsize64(find_handle find);
+
+/** @deprecated Use hts_findgetsize64(). An int cannot carry a size past 2 GB,
+   so this form reports -1 for anything above INT_MAX rather than handing back
+   truncated low bits a caller would size a buffer from. */
+HTS_DEPRECATED("use hts_findgetsize64(find)")
 HTSEXT_API int hts_findgetsize(find_handle find);
 
 /** 1 if the current entry is a directory, else 0 (a system/special entry, see

--- a/tests/421_engine-findsize.test
+++ b/tests/421_engine-findsize.test
@@ -1,7 +1,8 @@
 #!/bin/bash
 #
 # hts_findgetsize64() carries a size past the 32-bit wrap where the deprecated
-# int form can only report -1 ('httrack -#test=findsize <dir>'). 5GB, sparse.
+# int form can only report -1 ('httrack -#test=findsize <dir>'). Sparse: 5GB, and
+# 6GB for the low dword's sign bit.
 
 set -euo pipefail
 # shellcheck source=tests/testlib.sh
@@ -14,9 +15,9 @@ rc=0
 out=$(httrack -#test=findsize "$dir") || rc=$?
 echo "$out"
 
-# 77 = platform can't host the 5GB probe (EFBIG/ENOSPC); skip, don't fail.
+# 77 = platform can't host the sparse probes (EFBIG/ENOSPC); skip, don't fail.
 [ "$rc" = 77 ] && exit 77
 [ "$rc" = 0 ] || exit "$rc"
 
-want="findsize: width=8 big=5368709120,-1 small=1234,1234"
+want="findsize: width=8 big=5368709120,-1 signbit=6442450944,-1 small=1234,1234"
 test "$out" == "$want" || fail "unexpected size report (want '$want')"

--- a/tests/421_engine-findsize.test
+++ b/tests/421_engine-findsize.test
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# hts_findgetsize64() carries a size past the 32-bit wrap where the deprecated
+# int form can only report -1 ('httrack -#test=findsize <dir>'). 5GB, sparse.
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+dir=$(mktemp -d)
+cleanup_push rm -rf "$dir"
+
+rc=0
+out=$(httrack -#test=findsize "$dir") || rc=$?
+echo "$out"
+
+# 77 = platform can't host the 5GB probe (EFBIG/ENOSPC); skip, don't fail.
+[ "$rc" = 77 ] && exit 77
+[ "$rc" = 0 ] || exit "$rc"
+
+want="findsize: width=8 big=5368709120,-1 small=1234,1234"
+test "$out" == "$want" || fail "unexpected size report (want '$want')"


### PR DESCRIPTION
A 5GB file enumerated through `hts_findgetsize()` measures 1GB. The function returns `off_t` truncated into an `int` on POSIX, and on Windows it returns `nFileSizeLow` alone, dropping the high dword. A caller sizing a buffer from that plausible-looking number takes a heap overflow. Nothing in the tree calls it any more. It is `HTSEXT_API` and declared in the installed `httrack-library.h`, so an out-of-tree consumer can be doing exactly that today.

`hts_findgetsize64()` returns `LLint`, the width `fsize()` and `fpsize()` already use for file sizes, and combines both dwords on Windows.

`hts_findgetsize()` stays exported with the same signature and is now `HTS_DEPRECATED`. The decision worth flagging is what it returns past `INT_MAX`: -1, the sentinel it already uses for "no entry", rather than the low bits. A caller that ignores -1 gets a `malloc` failure, where one handed a truncated size gets a silent short buffer. Every caller must already cope with -1.

`VERSION_INFO` moves 3:20:0 to 3:21:0. An export arrived, none moved and none went away, so the soname stays `.so.3` and no Debian package is renamed.

The test is `tests/421_engine-findsize.test`. It drives a new `-#test=findsize` over 5GB and 6GB sparse files plus a 1234-byte sibling. The 6GB one is there for the Windows arm, which is the only code that composes the two dwords. Its low dword has bit 31 set, so a sign-extending composition reads it negative. 5GB alone cannot see that, and the test passes with the bug present. It skips on EFBIG or ENOSPC, where the host cannot hold the probe. Both halves of the fix are pinned. Reverting the 64-bit form makes it report 1073741824, and reverting the deprecated form's clamp makes that one report it instead.