### PR TITLE
A mirror resumed on another architecture misreads its own resume state

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -1910,7 +1910,7 @@ static hts_boolean ref_get_record(FILE *fp, lien_back *dst) {
     return HTS_FALSE;
   }
   /* A bodyless slot already wrote its bytes to url_sav (FTP, direct to disk);
-     keeping the recorded r.size makes the writer blank that file (#797). */
+     zeroing r.size makes the writer blank that file (#797). */
   if (dst->r.adr != NULL)
     dst->r.size = (LLint) body;
   return HTS_TRUE;

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -41,6 +41,7 @@ Please visit our Website: http://www.httrack.com
 #include "htswarc.h"
 #include "htschanges.h"
 #include "htsthread.h"
+#include <limits.h>
 #include <stdint.h>
 #include <time.h>
 /* END specific definitions */
@@ -1581,6 +1582,9 @@ static int back_string_unserialize(FILE * fp, char **str) {
   return err;
 }
 
+/* Spools one slot for back_cleanup_background() to pick up later in the same
+   run, so it may hold pointers and the host's own layout. The resume reference
+   outlives the process and cannot: see back_serialize_ref() below. */
 int back_serialize(FILE * fp, const lien_back * src) {
   if (back_data_serialize(fp, src, sizeof(lien_back)) == 0
       && back_data_serialize(fp, src->r.adr,
@@ -1641,8 +1645,287 @@ int back_unserialize(FILE * fp, lien_back ** dst) {
   return 1;                     /* error */
 }
 
-/* serialize a reference ; used to store references of files being downloaded in case of broken download */
-/* Note: NOT utf-8 */
+/* --- the .ref resume state -------------------------------------------------
+
+   What an interrupted transfer resumes from: where its partial bytes landed,
+   and the validators the Range request must carry. Fields go out one by one in
+   little-endian fixed widths, because the build that resumes a mirror need not
+   be the one, nor on the machine, that interrupted it.
+
+   Up to 3.50.1 the record was a raw lien_back blit, so the magic refuses such a
+   file rather than misreading it and the transfer restarts from zero.
+
+   Only what a reader consumes goes out: sockets, file handles, request options
+   and scheduling state mean nothing in another process, and come back zeroed.
+ */
+
+#define REF_MAGIC "HTSREF1\n"
+#define REF_MAGIC_SIZE 8
+#define REF_VERSION 1
+
+/* No pre-3.50.2 file can be taken for one of these: it opened with a
+   host-native size_t holding sizeof(lien_back), which leaves a zero byte among
+   the first eight for every word size and byte order, and the magic has none.
+ */
+HTS_STATIC_ASSERT(sizeof(lien_back) < 0x10000, ref_magic_unambiguous);
+
+/* Caps a declared length must clear: one response's header block, and a body
+   only an in-memory transfer ever carries. */
+#define REF_MAX_STR (1024 * 1024)
+#define REF_MAX_BLOB ((uint64_t) 1024 * 1024 * 1024)
+
+static hts_boolean ref_put_u32(FILE *fp, uint32_t v) {
+  unsigned char b[4];
+
+  b[0] = (unsigned char) (v & 0xff);
+  b[1] = (unsigned char) ((v >> 8) & 0xff);
+  b[2] = (unsigned char) ((v >> 16) & 0xff);
+  b[3] = (unsigned char) ((v >> 24) & 0xff);
+  return hts_fwrite_exact(b, sizeof(b), fp);
+}
+
+static hts_boolean ref_put_u64(FILE *fp, uint64_t v) {
+  unsigned char b[8];
+  int i;
+
+  for (i = 0; i < 8; i++)
+    b[i] = (unsigned char) ((v >> (8 * i)) & 0xff);
+  return hts_fwrite_exact(b, sizeof(b), fp);
+}
+
+static hts_boolean ref_get_u32(FILE *fp, uint32_t *v) {
+  unsigned char b[4];
+
+  if (!hts_fread_exact(b, sizeof(b), fp))
+    return HTS_FALSE;
+  *v = (uint32_t) b[0] | ((uint32_t) b[1] << 8) | ((uint32_t) b[2] << 16) |
+       ((uint32_t) b[3] << 24);
+  return HTS_TRUE;
+}
+
+static hts_boolean ref_get_u64(FILE *fp, uint64_t *v) {
+  unsigned char b[8];
+  int i;
+
+  if (!hts_fread_exact(b, sizeof(b), fp))
+    return HTS_FALSE;
+  *v = 0;
+  for (i = 0; i < 8; i++)
+    *v |= (uint64_t) b[i] << (8 * i);
+  return HTS_TRUE;
+}
+
+/* Two's complement both ways, spelled out: a plain cast back is
+   implementation-defined above the signed maximum. */
+static hts_boolean ref_put_int(FILE *fp, int v) {
+  return ref_put_u32(fp, (uint32_t) v);
+}
+
+static hts_boolean ref_get_int(FILE *fp, int *v) {
+  uint32_t u;
+
+  if (!ref_get_u32(fp, &u))
+    return HTS_FALSE;
+  *v = u <= (uint32_t) INT32_MAX ? (int) u : -(int) (UINT32_MAX - u) - 1;
+  return HTS_TRUE;
+}
+
+static hts_boolean ref_put_llint(FILE *fp, LLint v) {
+  return ref_put_u64(fp, (uint64_t) v);
+}
+
+static hts_boolean ref_get_llint(FILE *fp, LLint *v) {
+  uint64_t u;
+
+  if (!ref_get_u64(fp, &u))
+    return HTS_FALSE;
+  *v =
+      u <= (uint64_t) INT64_MAX ? (int64_t) u : -(int64_t) (UINT64_MAX - u) - 1;
+  return HTS_TRUE;
+}
+
+/* A value outside the field's range is malformed, not something to truncate. */
+static hts_boolean ref_get_short(FILE *fp, short int *v) {
+  int i;
+
+  if (!ref_get_int(fp, &i) || i < SHRT_MIN || i > SHRT_MAX)
+    return HTS_FALSE;
+  *v = (short int) i;
+  return HTS_TRUE;
+}
+
+/* A NULL is written like an empty string; only the heap readers below tell the
+   two apart, and they are the only fields where the difference matters. */
+static hts_boolean ref_put_str(FILE *fp, const char *str) {
+  const size_t len = str != NULL ? strlen(str) : 0;
+
+  if (len > REF_MAX_STR)
+    return HTS_FALSE;
+  return ref_put_u32(fp, (uint32_t) len) &&
+         (len == 0 || hts_fwrite_exact(str, len, fp));
+}
+
+/* Clips into a fixed destination rather than aborting: the bytes come off a
+   file another build, or another machine, wrote. */
+static hts_boolean ref_get_str(FILE *fp, char *dst, size_t size) {
+  uint32_t len;
+  size_t copied = 0;
+  char chunk[1024];
+
+  assertf(size != 0);
+  dst[0] = '\0';
+  if (!ref_get_u32(fp, &len) || len > REF_MAX_STR)
+    return HTS_FALSE;
+  while (len != 0) {
+    const size_t n =
+        len < (uint32_t) sizeof(chunk) ? (size_t) len : sizeof(chunk);
+
+    if (!hts_fread_exact(chunk, n, fp))
+      return HTS_FALSE;
+    len -= (uint32_t) n;
+    if (copied < size - 1) {
+      const size_t room = size - 1 - copied;
+      const size_t take = n < room ? n : room;
+
+      memcpy(dst + copied, chunk, take);
+      copied += take;
+    }
+  }
+  dst[copied] = '\0';
+  return HTS_TRUE;
+}
+
+static hts_boolean ref_get_heapstr(FILE *fp, char **dst) {
+  uint32_t len;
+  char *buf;
+
+  *dst = NULL;
+  if (!ref_get_u32(fp, &len) || len > REF_MAX_STR)
+    return HTS_FALSE;
+  if (len == 0) /* a serialized NULL */
+    return HTS_TRUE;
+  buf = malloct((size_t) len + 1);
+  if (buf == NULL)
+    return HTS_FALSE;
+  buf[len] = '\0'; /* guard byte */
+  if (!hts_fread_exact(buf, (size_t) len, fp)) {
+    freet(buf);
+    return HTS_FALSE;
+  }
+  *dst = buf;
+  return HTS_TRUE;
+}
+
+static hts_boolean ref_put_blob(FILE *fp, const void *data, uint64_t len) {
+  if (len > REF_MAX_BLOB)
+    return HTS_FALSE;
+  return ref_put_u64(fp, len) &&
+         (len == 0 || hts_fwrite_exact(data, (size_t) len, fp));
+}
+
+static hts_boolean ref_get_blob(FILE *fp, char **dst, uint64_t *len) {
+  uint64_t size;
+  char *buf;
+
+  *dst = NULL;
+  *len = 0;
+  if (!ref_get_u64(fp, &size))
+    return HTS_FALSE;
+  if (size == 0) /* a serialized NULL */
+    return HTS_TRUE;
+  /* the guard byte must not wrap the allocation on a 32-bit size_t */
+  if (size > REF_MAX_BLOB || size > (uint64_t) (SIZE_MAX - 1))
+    return HTS_FALSE;
+  buf = malloct((size_t) size + 1);
+  if (buf == NULL)
+    return HTS_FALSE;
+  buf[size] = '\0'; /* guard byte */
+  if (!hts_fread_exact(buf, (size_t) size, fp)) {
+    freet(buf);
+    return HTS_FALSE;
+  }
+  *dst = buf;
+  *len = size;
+  return HTS_TRUE;
+}
+
+/* Fields the readers of a reference consume: what identifies the link, where
+   its partial bytes are, and the response metadata a resumed request or a
+   broken-cache read needs. */
+static hts_boolean ref_put_record(FILE *fp, const lien_back *src) {
+  const uint64_t body =
+      src->r.adr != NULL && src->r.size > 0 ? (uint64_t) src->r.size : 0;
+
+  return hts_fwrite_exact(REF_MAGIC, REF_MAGIC_SIZE, fp) &&
+         ref_put_u32(fp, REF_VERSION) && ref_put_str(fp, src->url_adr) &&
+         ref_put_str(fp, src->url_fil) && ref_put_str(fp, src->url_sav) &&
+         ref_put_str(fp, src->referer_adr) &&
+         ref_put_str(fp, src->referer_fil) &&
+         ref_put_str(fp, src->r.location) &&
+         ref_put_int(fp, src->r.statuscode) &&
+         ref_put_int(fp, src->r.notmodified) &&
+         ref_put_int(fp, src->r.compressed) && ref_put_int(fp, src->r.empty) &&
+         ref_put_llint(fp, src->r.size) &&
+         ref_put_llint(fp, src->r.totalsize) &&
+         ref_put_llint(fp, src->r.crange) &&
+         ref_put_llint(fp, src->r.crange_start) &&
+         ref_put_llint(fp, src->r.crange_end) && ref_put_str(fp, src->r.msg) &&
+         ref_put_str(fp, src->r.contenttype) &&
+         ref_put_str(fp, src->r.charset) &&
+         ref_put_str(fp, src->r.contentencoding) &&
+         ref_put_str(fp, src->r.lastmodified) && ref_put_str(fp, src->r.etag) &&
+         ref_put_str(fp, src->r.cdispo) && ref_put_blob(fp, src->r.adr, body) &&
+         ref_put_str(fp, src->r.headers);
+}
+
+/* Fills an entry whose in-memory scaffolding the caller already zeroed. */
+static hts_boolean ref_get_record(FILE *fp, lien_back *dst) {
+  char magic[REF_MAGIC_SIZE];
+  uint32_t version;
+  uint64_t body;
+
+  if (!hts_fread_exact(magic, sizeof(magic), fp) ||
+      memcmp(magic, REF_MAGIC, REF_MAGIC_SIZE) != 0)
+    return HTS_FALSE; /* a pre-3.50.2 blit, or not a reference */
+  if (!ref_get_u32(fp, &version) || version != REF_VERSION)
+    return HTS_FALSE;
+  if (!ref_get_str(fp, dst->url_adr, sizeof(dst->url_adr)) ||
+      !ref_get_str(fp, dst->url_fil, sizeof(dst->url_fil)) ||
+      !ref_get_str(fp, dst->url_sav, sizeof(dst->url_sav)) ||
+      !ref_get_str(fp, dst->referer_adr, sizeof(dst->referer_adr)) ||
+      !ref_get_str(fp, dst->referer_fil, sizeof(dst->referer_fil)) ||
+      !ref_get_str(fp, dst->location_buffer, sizeof(dst->location_buffer)) ||
+      !ref_get_int(fp, &dst->r.statuscode) ||
+      !ref_get_short(fp, &dst->r.notmodified) ||
+      !ref_get_short(fp, &dst->r.compressed) ||
+      !ref_get_short(fp, &dst->r.empty) || !ref_get_llint(fp, &dst->r.size) ||
+      !ref_get_llint(fp, &dst->r.totalsize) ||
+      !ref_get_llint(fp, &dst->r.crange) ||
+      !ref_get_llint(fp, &dst->r.crange_start) ||
+      !ref_get_llint(fp, &dst->r.crange_end) ||
+      !ref_get_str(fp, dst->r.msg, sizeof(dst->r.msg)) ||
+      !ref_get_str(fp, dst->r.contenttype, sizeof(dst->r.contenttype)) ||
+      !ref_get_str(fp, dst->r.charset, sizeof(dst->r.charset)) ||
+      !ref_get_str(fp, dst->r.contentencoding,
+                   sizeof(dst->r.contentencoding)) ||
+      !ref_get_str(fp, dst->r.lastmodified, sizeof(dst->r.lastmodified)) ||
+      !ref_get_str(fp, dst->r.etag, sizeof(dst->r.etag)) ||
+      !ref_get_str(fp, dst->r.cdispo, sizeof(dst->r.cdispo)))
+    return HTS_FALSE;
+  if (!ref_get_blob(fp, &dst->r.adr, &body))
+    return HTS_FALSE;
+  if (!ref_get_heapstr(fp, &dst->r.headers)) {
+    freet(dst->r.adr);
+    return HTS_FALSE;
+  }
+  /* A bodyless slot already wrote its bytes to url_sav (FTP, direct to disk);
+     keeping the recorded r.size makes the writer blank that file (#797). */
+  if (dst->r.adr != NULL)
+    dst->r.size = (LLint) body;
+  return HTS_TRUE;
+}
+
+/* Record the state an interrupted transfer resumes from. Not utf-8. */
 int back_serialize_ref(httrackp * opt, const lien_back * src) {
   const char *filename =
     url_savename_refname_fullpath(opt, src->url_adr, src->url_fil);
@@ -1665,7 +1948,7 @@ int back_serialize_ref(httrackp * opt, const lien_back * src) {
     }
   }
   if (fp != NULL) {
-    int ser = back_serialize(fp, src);
+    const int ser = ref_put_record(fp, src) && fflush(fp) == 0 ? 0 : 1;
 
     fclose(fp);
     return ser;
@@ -1673,24 +1956,37 @@ int back_serialize_ref(httrackp * opt, const lien_back * src) {
   return 1;
 }
 
-/* unserialize a reference ; used to store references of files being downloaded in case of broken download */
+/* Read one back into a fresh entry the caller owns (back_clear_entry, then
+   freet). Anything but a current record is refused, a pre-3.50.2 host-native
+   blit included, and *dst stays NULL. */
 int back_unserialize_ref(httrackp * opt, const char *adr, const char *fil,
                          lien_back ** dst) {
   const char *filename = url_savename_refname_fullpath(opt, adr, fil);
   FILE *fp = FOPEN(filename, "rb");
+  lien_back *back;
 
-  if (fp != NULL) {
-    int ser = back_unserialize(fp, dst);
-
+  *dst = NULL;
+  if (fp == NULL)
+    return 1;
+  back = calloct(1, sizeof(lien_back));
+  if (back == NULL) {
     fclose(fp);
-    if (ser != 0) {             /* back_unserialize_ref() != 0 does not need cleaning up */
-      back_clear_entry(*dst);   /* delete entry content */
-      freet(*dst);              /* delete item */
-      *dst = NULL;
-    }
-    return ser;
+    return 1;
   }
-  return 1;
+  hts_init_htsblk(&back->r);
+  back->r.location = back->location_buffer;
+  errno = 0;
+  if (!ref_get_record(fp, back)) {
+    hts_log_print(opt, LOG_DEBUG,
+                  "Ignoring an unreadable resume reference for %s%s", adr, fil);
+    fclose(fp);
+    back_clear_entry(back);
+    freet(back);
+    return 1;
+  }
+  fclose(fp);
+  *dst = back;
+  return 0;
 }
 
 // clear, or leave for keep-alive

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -1659,20 +1659,11 @@ int back_unserialize(FILE * fp, lien_back ** dst) {
    and scheduling state mean nothing in another process, and come back zeroed.
  */
 
-#define REF_MAGIC "HTSREF1\n"
-#define REF_MAGIC_SIZE 8
-#define REF_VERSION 1
-
 /* No pre-3.50.2 file can be taken for one of these: it opened with a
    host-native size_t holding sizeof(lien_back), which leaves a zero byte among
    the first eight for every word size and byte order, and the magic has none.
  */
 HTS_STATIC_ASSERT(sizeof(lien_back) < 0x10000, ref_magic_unambiguous);
-
-/* Caps a declared length must clear: one response's header block, and a body
-   only an in-memory transfer ever carries. */
-#define REF_MAX_STR (1024 * 1024)
-#define REF_MAX_BLOB ((uint64_t) 1024 * 1024 * 1024)
 
 static hts_boolean ref_put_u32(FILE *fp, uint32_t v) {
   unsigned char b[4];
@@ -1759,7 +1750,7 @@ static hts_boolean ref_get_short(FILE *fp, short int *v) {
 static hts_boolean ref_put_str(FILE *fp, const char *str) {
   const size_t len = str != NULL ? strlen(str) : 0;
 
-  if (len > REF_MAX_STR)
+  if (len > HTS_REF_MAX_STR)
     return HTS_FALSE;
   return ref_put_u32(fp, (uint32_t) len) &&
          (len == 0 || hts_fwrite_exact(str, len, fp));
@@ -1774,7 +1765,7 @@ static hts_boolean ref_get_str(FILE *fp, char *dst, size_t size) {
 
   assertf(size != 0);
   dst[0] = '\0';
-  if (!ref_get_u32(fp, &len) || len > REF_MAX_STR)
+  if (!ref_get_u32(fp, &len) || len > HTS_REF_MAX_STR)
     return HTS_FALSE;
   while (len != 0) {
     const size_t n =
@@ -1800,7 +1791,7 @@ static hts_boolean ref_get_heapstr(FILE *fp, char **dst) {
   char *buf;
 
   *dst = NULL;
-  if (!ref_get_u32(fp, &len) || len > REF_MAX_STR)
+  if (!ref_get_u32(fp, &len) || len > HTS_REF_MAX_STR)
     return HTS_FALSE;
   if (len == 0) /* a serialized NULL */
     return HTS_TRUE;
@@ -1817,7 +1808,7 @@ static hts_boolean ref_get_heapstr(FILE *fp, char **dst) {
 }
 
 static hts_boolean ref_put_blob(FILE *fp, const void *data, uint64_t len) {
-  if (len > REF_MAX_BLOB)
+  if (len > HTS_REF_MAX_BLOB)
     return HTS_FALSE;
   return ref_put_u64(fp, len) &&
          (len == 0 || hts_fwrite_exact(data, (size_t) len, fp));
@@ -1834,7 +1825,7 @@ static hts_boolean ref_get_blob(FILE *fp, char **dst, uint64_t *len) {
   if (size == 0) /* a serialized NULL */
     return HTS_TRUE;
   /* the guard byte must not wrap the allocation on a 32-bit size_t */
-  if (size > REF_MAX_BLOB || size > (uint64_t) (SIZE_MAX - 1))
+  if (size > HTS_REF_MAX_BLOB || size > (uint64_t) (SIZE_MAX - 1))
     return HTS_FALSE;
   buf = malloct((size_t) size + 1);
   if (buf == NULL)
@@ -1856,8 +1847,8 @@ static hts_boolean ref_put_record(FILE *fp, const lien_back *src) {
   const uint64_t body =
       src->r.adr != NULL && src->r.size > 0 ? (uint64_t) src->r.size : 0;
 
-  return hts_fwrite_exact(REF_MAGIC, REF_MAGIC_SIZE, fp) &&
-         ref_put_u32(fp, REF_VERSION) && ref_put_str(fp, src->url_adr) &&
+  return hts_fwrite_exact(HTS_REF_MAGIC, HTS_REF_MAGIC_SIZE, fp) &&
+         ref_put_u32(fp, HTS_REF_VERSION) && ref_put_str(fp, src->url_adr) &&
          ref_put_str(fp, src->url_fil) && ref_put_str(fp, src->url_sav) &&
          ref_put_str(fp, src->referer_adr) &&
          ref_put_str(fp, src->referer_fil) &&
@@ -1880,14 +1871,14 @@ static hts_boolean ref_put_record(FILE *fp, const lien_back *src) {
 
 /* Fills an entry whose in-memory scaffolding the caller already zeroed. */
 static hts_boolean ref_get_record(FILE *fp, lien_back *dst) {
-  char magic[REF_MAGIC_SIZE];
+  char magic[HTS_REF_MAGIC_SIZE];
   uint32_t version;
   uint64_t body;
 
   if (!hts_fread_exact(magic, sizeof(magic), fp) ||
-      memcmp(magic, REF_MAGIC, REF_MAGIC_SIZE) != 0)
+      memcmp(magic, HTS_REF_MAGIC, HTS_REF_MAGIC_SIZE) != 0)
     return HTS_FALSE; /* a pre-3.50.2 blit, or not a reference */
-  if (!ref_get_u32(fp, &version) || version != REF_VERSION)
+  if (!ref_get_u32(fp, &version) || version != HTS_REF_VERSION)
     return HTS_FALSE;
   if (!ref_get_str(fp, dst->url_adr, sizeof(dst->url_adr)) ||
       !ref_get_str(fp, dst->url_fil, sizeof(dst->url_fil)) ||

--- a/src/htsback.h
+++ b/src/htsback.h
@@ -110,8 +110,12 @@ int back_searchlive(httrackp * opt, struct_back * sback, const char *search_addr
 void back_connxfr(htsblk * src, htsblk * dst);
 void back_move(lien_back * src, lien_back * dst);
 void back_copy_static(const lien_back * src, lien_back * dst);
+/* In-process slot spool: host-native, and meaningful only inside the run that
+   wrote it. */
 int back_serialize(FILE * fp, const lien_back * src);
 int back_unserialize(FILE * fp, lien_back ** dst);
+/* Resume state that outlives the run, so a portable little-endian record; a
+   file in any other shape is refused rather than misread. */
 int back_serialize_ref(httrackp * opt, const lien_back * src);
 int back_unserialize_ref(httrackp * opt, const char *adr, const char *fil,
                          lien_back ** dst);

--- a/src/htsback.h
+++ b/src/htsback.h
@@ -110,6 +110,15 @@ int back_searchlive(httrackp * opt, struct_back * sback, const char *search_addr
 void back_connxfr(htsblk * src, htsblk * dst);
 void back_move(lien_back * src, lien_back * dst);
 void back_copy_static(const lien_back * src, lien_back * dst);
+/* The .ref record's framing, shared with the self-test that pins it. */
+#define HTS_REF_MAGIC "HTSREF1\n"
+#define HTS_REF_MAGIC_SIZE 8
+#define HTS_REF_VERSION 1
+/* Caps a declared length must clear: one response's header block, and a body
+   only an in-memory transfer ever carries. */
+#define HTS_REF_MAX_STR (1024 * 1024)
+#define HTS_REF_MAX_BLOB ((uint64_t) 1024 * 1024 * 1024)
+
 /* In-process slot spool: host-native, and meaningful only inside the run that
    wrote it. */
 int back_serialize(FILE * fp, const lien_back * src);

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -2981,12 +2981,47 @@ static unsigned char *ref_st_oversize(const char *field, size_t len,
   return out;
 }
 
-/* r.crange is the canary for an overflow of r.cdispo: the reader fills it
-   earlier in the stream and never touches it again, so a stray byte or stray
-   terminator past cdispo survives to the assertion. */
-HTS_STATIC_ASSERT(offsetof(htsblk, crange) ==
-                      offsetof(htsblk, cdispo) + sizeof(((htsblk *) 0)->cdispo),
-                  ref_crange_follows_cdispo);
+/* Everything between r.cdispo and r.req: the ABI's padding, then crange,
+   crange_start, crange_end and debugid. The reader fills the crange fields
+   earlier in the stream and never returns to them, so a stray write past
+   cdispo is still there at the assertion. The span makes no claim about which
+   field the byte lands in, which is what the cross legs need: 32-bit hppa,
+   armhf and powerpc pad between cdispo and crange where x86-64 does not. */
+#define REF_TAIL_FROM                                                          \
+  (offsetof(htsblk, cdispo) + sizeof(((htsblk *) 0)->cdispo))
+#define REF_TAIL_TO offsetof(htsblk, req)
+
+/* The image the span must hold: the three values the record carried, the rest
+   zero as calloct left it. Built rather than taken from a second read, which a
+   stray write would corrupt the same way and so hide. Nothing here can see a
+   stray terminator landing in the padding, which is zero either way; the
+   clipped length below is what catches that one, on every architecture. */
+static int ref_st_tail(const lien_back *back) {
+  const size_t len = REF_TAIL_TO - REF_TAIL_FROM;
+  const char *const got = (const char *) &back->r + REF_TAIL_FROM;
+  const LLint value[] = {REF_ST_CRANGE, REF_ST_CRANGE_START, REF_ST_CRANGE_END};
+  const size_t at[] = {offsetof(htsblk, crange) - REF_TAIL_FROM,
+                       offsetof(htsblk, crange_start) - REF_TAIL_FROM,
+                       offsetof(htsblk, crange_end) - REF_TAIL_FROM};
+  char *want = calloct(1, len);
+  int fail = 0;
+  size_t i;
+
+  for (i = 0; i < sizeof(at) / sizeof(at[0]); i++)
+    memcpy(want + at[i], &value[i], sizeof(value[i]));
+  for (i = 0; i < len; i++) {
+    if (got[i] != want[i]) {
+      fprintf(stderr,
+              "%s: byte %d past r.cdispo reads 0x%02x, expected 0x%02x\n",
+              selftest_tag, (int) (REF_TAIL_FROM + i), (unsigned char) got[i],
+              (unsigned char) want[i]);
+      fail = 1;
+      break;
+    }
+  }
+  freet(want);
+  return fail;
+}
 
 int ref_portable_selftest(httrackp *opt, const char *dir) {
   int fail = 0;
@@ -3171,7 +3206,7 @@ int ref_portable_selftest(httrackp *opt, const char *dir) {
   }
 
   /* a length past its destination clips, the reader stays in step with the
-     stream, and the field the reader already filled next door is untouched */
+     stream, and nothing beyond the destination moves */
   {
     size_t size;
     unsigned char *bad = ref_st_oversize("cdispo", 3000, &size);
@@ -3188,17 +3223,15 @@ int ref_portable_selftest(httrackp *opt, const char *dir) {
                 selftest_tag, (int) strlen(back->r.cdispo), back->r.cdispo);
         fail++;
       }
-      fail += ref_st_int(back->r.crange, REF_ST_CRANGE, "crange canary");
-      fail += ref_st_int(back->r.crange_start, REF_ST_CRANGE_START,
-                         "crange_start canary");
-      fail += ref_st_int(back->r.crange_end, REF_ST_CRANGE_END,
-                         "crange_end canary");
+      fail += ref_st_tail(back);
       if (back->r.headers == NULL ||
           strcmp(back->r.headers, REF_ST_HEADERS) != 0) {
         fprintf(stderr, "%s: the clip lost the reader's place in the stream\n",
                 selftest_tag);
         fail++;
       }
+    }
+    if (back != NULL) {
       back_clear_entry(back);
       freet(back);
     }

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -2684,47 +2684,140 @@ int cache_readfail_selftest(httrackp *opt, const char *dir) {
 
 /* --- the portable resume reference (.ref) --------------------------------- */
 
-/* One reference, byte for byte as the format defines it: little-endian fixed
-   widths. A build that wrote lien_back host-natively can neither produce nor
-   accept these bytes, which is the point, since the build that resumes a
-   mirror need not be the one that interrupted it. */
-static const unsigned char ref_golden[] = {
-    0x48, 0x54, 0x53, 0x52, 0x45, 0x46, 0x31, 0x0a, 0x01, 0x00, 0x00, 0x00,
-    0x0b, 0x00, 0x00, 0x00, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e,
-    0x63, 0x6f, 0x6d, 0x0c, 0x00, 0x00, 0x00, 0x2f, 0x70, 0x61, 0x72, 0x74,
-    0x69, 0x61, 0x6c, 0x2e, 0x62, 0x69, 0x6e, 0x17, 0x00, 0x00, 0x00, 0x65,
-    0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x70,
-    0x61, 0x72, 0x74, 0x69, 0x61, 0x6c, 0x2e, 0x62, 0x69, 0x6e, 0x0b, 0x00,
-    0x00, 0x00, 0x72, 0x65, 0x66, 0x2e, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c,
-    0x65, 0x0a, 0x00, 0x00, 0x00, 0x2f, 0x66, 0x72, 0x6f, 0x6d, 0x2e, 0x68,
-    0x74, 0x6d, 0x6c, 0x00, 0x00, 0x00, 0x00, 0xce, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0b,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
-    0x00, 0x00, 0x00, 0xcb, 0x04, 0xfb, 0x71, 0x1f, 0x01, 0x00, 0x00, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x10, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, 0x50, 0x61, 0x72, 0x74, 0x69,
-    0x61, 0x6c, 0x20, 0x43, 0x6f, 0x6e, 0x74, 0x65, 0x6e, 0x74, 0x18, 0x00,
-    0x00, 0x00, 0x61, 0x70, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f,
-    0x6e, 0x2f, 0x6f, 0x63, 0x74, 0x65, 0x74, 0x2d, 0x73, 0x74, 0x72, 0x65,
-    0x61, 0x6d, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x67, 0x7a,
-    0x69, 0x70, 0x1d, 0x00, 0x00, 0x00, 0x57, 0x65, 0x64, 0x2c, 0x20, 0x30,
-    0x33, 0x20, 0x53, 0x65, 0x70, 0x20, 0x32, 0x30, 0x32, 0x36, 0x20, 0x31,
-    0x30, 0x3a, 0x31, 0x31, 0x3a, 0x31, 0x32, 0x20, 0x47, 0x4d, 0x54, 0x09,
-    0x00, 0x00, 0x00, 0x22, 0x61, 0x62, 0x63, 0x2d, 0x31, 0x32, 0x33, 0x22,
-    0x20, 0x00, 0x00, 0x00, 0x61, 0x74, 0x74, 0x61, 0x63, 0x68, 0x6d, 0x65,
-    0x6e, 0x74, 0x3b, 0x20, 0x66, 0x69, 0x6c, 0x65, 0x6e, 0x61, 0x6d, 0x65,
-    0x3d, 0x70, 0x61, 0x72, 0x74, 0x69, 0x61, 0x6c, 0x2e, 0x62, 0x69, 0x6e,
-    0x0b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x68, 0x61, 0x6c, 0x66,
-    0x20, 0x61, 0x20, 0x70, 0x61, 0x67, 0x65, 0x20, 0x00, 0x00, 0x00, 0x48,
-    0x54, 0x54, 0x50, 0x2f, 0x31, 0x2e, 0x31, 0x20, 0x32, 0x30, 0x36, 0x20,
-    0x50, 0x61, 0x72, 0x74, 0x69, 0x61, 0x6c, 0x20, 0x43, 0x6f, 0x6e, 0x74,
-    0x65, 0x6e, 0x74, 0x0d, 0x0a, 0x0d, 0x0a,
-};
+/* The record ref_put_record() writes, one row per field, in order. The fixture
+   is assembled from this table rather than captured from the writer, so a
+   reviewer reads the format here instead of decoding 355 hex bytes. Every
+   value is distinct, so no swap of two fields can hide, and each multi-byte
+   number has all-different bytes so its order on disk is visible. */
+typedef enum {
+  REF_F_RAW, /* verbatim bytes, no length prefix (the magic) */
+  REF_F_U32, /* 4 bytes, little-endian */
+  REF_F_I32, /* 4 bytes, little-endian, two's complement */
+  REF_F_I64, /* 8 bytes, little-endian, two's complement */
+  REF_F_STR, /* u32 length, then that many bytes */
+  REF_F_BLOB /* u64 length, then that many bytes */
+} ref_field_kind;
+
+typedef struct {
+  const char *name;
+  ref_field_kind kind;
+  int64_t num;      /* value, for the numeric kinds */
+  const char *text; /* bytes, for REF_F_RAW / STR / BLOB */
+} ref_field;
 
 #define REF_ST_ADR "example.com"
 #define REF_ST_FIL "/partial.bin"
-#define REF_ST_BODY "half a page"
+#define REF_ST_SAV "example.com/partial.bin"
+#define REF_ST_BODY "twenty-three bytes here"
 #define REF_ST_HEADERS "HTTP/1.1 206 Partial Content\r\n\r\n"
+#define REF_ST_STATUS 0x11121314
+#define REF_ST_NOTMODIFIED 0x0102
+#define REF_ST_COMPRESSED 0x0304
+#define REF_ST_EMPTY 0x0506
+#define REF_ST_TOTALSIZE ((int64_t) 0x0102030405060708LL)
+#define REF_ST_CRANGE ((int64_t) 0x1112131415161718LL)
+#define REF_ST_CRANGE_START ((int64_t) -0x0e0d0c0b0a090808LL)
+#define REF_ST_CRANGE_END ((int64_t) 0x2122232425262728LL)
+
+static const ref_field ref_fields[] = {
+    {"magic", REF_F_RAW, 0, HTS_REF_MAGIC},
+    {"version", REF_F_U32, HTS_REF_VERSION, NULL},
+    {"url_adr", REF_F_STR, 0, REF_ST_ADR},
+    {"url_fil", REF_F_STR, 0, REF_ST_FIL},
+    {"url_sav", REF_F_STR, 0, REF_ST_SAV},
+    {"referer_adr", REF_F_STR, 0, "ref.example"},
+    {"referer_fil", REF_F_STR, 0, "/from.html"},
+    {"location", REF_F_STR, 0, "http://moved.example/elsewhere"},
+    {"statuscode", REF_F_I32, REF_ST_STATUS, NULL},
+    {"notmodified", REF_F_I32, REF_ST_NOTMODIFIED, NULL},
+    {"compressed", REF_F_I32, REF_ST_COMPRESSED, NULL},
+    {"empty", REF_F_I32, REF_ST_EMPTY, NULL},
+    {"size", REF_F_I64, sizeof(REF_ST_BODY) - 1, NULL},
+    {"totalsize", REF_F_I64, REF_ST_TOTALSIZE, NULL},
+    {"crange", REF_F_I64, REF_ST_CRANGE, NULL},
+    {"crange_start", REF_F_I64, REF_ST_CRANGE_START, NULL},
+    {"crange_end", REF_F_I64, REF_ST_CRANGE_END, NULL},
+    {"msg", REF_F_STR, 0, "Partial Content"},
+    {"contenttype", REF_F_STR, 0, "application/octet-stream"},
+    {"charset", REF_F_STR, 0, "utf-8"},
+    {"contentencoding", REF_F_STR, 0, "gzip"},
+    {"lastmodified", REF_F_STR, 0, "Wed, 03 Sep 2026 10:11:12 GMT"},
+    {"etag", REF_F_STR, 0, "\"abc-123\""},
+    {"cdispo", REF_F_STR, 0, "attachment; filename=partial.bin"},
+    {"body", REF_F_BLOB, 0, REF_ST_BODY},
+    {"headers", REF_F_STR, 0, REF_ST_HEADERS}};
+
+#define REF_FIELD_COUNT (sizeof(ref_fields) / sizeof(ref_fields[0]))
+
+/* Where each field's payload begins, filled by ref_st_build(): the length
+   prefix for STR and BLOB, the number itself otherwise. */
+static size_t ref_off[REF_FIELD_COUNT];
+static unsigned char *ref_golden;
+static size_t ref_golden_size;
+
+/* Field index by name, so a reordered table moves the offsets with it. */
+static size_t ref_st_field(const char *name) {
+  size_t i;
+
+  for (i = 0; i < REF_FIELD_COUNT; i++)
+    if (strcmp(ref_fields[i].name, name) == 0)
+      return i;
+  assertf(!"no such field");
+  return 0;
+}
+
+/* Low byte first, spelled out, so the fixture states the byte order rather
+   than inheriting the host's. */
+static size_t ref_st_num(unsigned char *dst, uint64_t v, size_t width) {
+  size_t i;
+
+  for (i = 0; i < width; i++)
+    dst[i] = (unsigned char) ((v >> (8 * i)) & 0xff);
+  return width;
+}
+
+/* Assemble the table into dst (NULL to measure), recording field offsets. */
+static size_t ref_st_build(unsigned char *dst) {
+  size_t off = 0;
+  size_t i;
+
+  for (i = 0; i < REF_FIELD_COUNT; i++) {
+    const ref_field *const f = &ref_fields[i];
+    const size_t len = f->text != NULL ? strlen(f->text) : 0;
+
+    ref_off[i] = off;
+    switch (f->kind) {
+    case REF_F_RAW:
+      if (dst != NULL)
+        memcpy(dst + off, f->text, len);
+      off += len;
+      break;
+    case REF_F_U32:
+    case REF_F_I32:
+      if (dst != NULL)
+        ref_st_num(dst + off, (uint64_t) (uint32_t) f->num, 4);
+      off += 4;
+      break;
+    case REF_F_I64:
+      if (dst != NULL)
+        ref_st_num(dst + off, (uint64_t) f->num, 8);
+      off += 8;
+      break;
+    case REF_F_STR:
+    case REF_F_BLOB: {
+      const size_t width = f->kind == REF_F_STR ? 4 : 8;
+
+      if (dst != NULL) {
+        ref_st_num(dst + off, (uint64_t) len, width);
+        memcpy(dst + off + width, f->text, len);
+      }
+      off += width + len;
+      break;
+    }
+    }
+  }
+  return off;
+}
 
 /* Copy the reference's path out of the option scratch buffer, which the very
    next call reuses. */
@@ -2741,16 +2834,6 @@ static void ref_st_put(const char *path, const void *data, size_t size) {
   fclose(fp);
 }
 
-static uint32_t ref_st_u32(const unsigned char *p) {
-  return (uint32_t) p[0] | ((uint32_t) p[1] << 8) | ((uint32_t) p[2] << 16) |
-         ((uint32_t) p[3] << 24);
-}
-
-/* Offset of the field after the length-prefixed string at off. */
-static size_t ref_st_skip(size_t off) {
-  return off + 4 + ref_st_u32(&ref_golden[off]);
-}
-
 static int ref_st_str(const char *got, const char *want, const char *field) {
   if (strcmp(got, want) != 0) {
     fprintf(stderr, "%s: %s is '%s', expected '%s'\n", selftest_tag, field, got,
@@ -2760,7 +2843,7 @@ static int ref_st_str(const char *got, const char *want, const char *field) {
   return 0;
 }
 
-static int ref_st_num(LLint got, LLint want, const char *field) {
+static int ref_st_int(LLint got, LLint want, const char *field) {
   if (got != want) {
     fprintf(stderr, "%s: %s is " LLintP ", expected " LLintP "\n", selftest_tag,
             field, got, want);
@@ -2769,38 +2852,59 @@ static int ref_st_num(LLint got, LLint want, const char *field) {
   return 0;
 }
 
-/* Every field against the values ref_golden encodes, never against whatever
-   the reader happened to produce. */
+/* The bytes a field must occupy on disk, spelled out rather than derived, so
+   the check is independent of how the table was assembled. */
+static int ref_st_bytes(const unsigned char *file, const char *field,
+                        const unsigned char *want, size_t len) {
+  const size_t off = ref_off[ref_st_field(field)];
+
+  if (memcmp(file + off, want, len) != 0) {
+    size_t i;
+
+    fprintf(stderr, "%s: %s at offset %d reads", selftest_tag, field,
+            (int) off);
+    for (i = 0; i < len; i++)
+      fprintf(stderr, " %02x", file[off + i]);
+    fprintf(stderr, ", expected");
+    for (i = 0; i < len; i++)
+      fprintf(stderr, " %02x", want[i]);
+    fprintf(stderr, "\n");
+    return 1;
+  }
+  return 0;
+}
+
+/* Every field against the table, never against what the reader produced. */
 static int ref_st_check(const lien_back *back) {
   int fail = 0;
 
   fail += ref_st_str(back->url_adr, REF_ST_ADR, "url_adr");
   fail += ref_st_str(back->url_fil, REF_ST_FIL, "url_fil");
-  fail += ref_st_str(back->url_sav, "example.com/partial.bin", "url_sav");
+  fail += ref_st_str(back->url_sav, REF_ST_SAV, "url_sav");
   fail += ref_st_str(back->referer_adr, "ref.example", "referer_adr");
   fail += ref_st_str(back->referer_fil, "/from.html", "referer_fil");
-  fail += ref_st_num(back->r.statuscode, 206, "statuscode");
-  fail += ref_st_num(back->r.notmodified, 0, "notmodified");
-  fail += ref_st_num(back->r.compressed, 1, "compressed");
-  fail += ref_st_num(back->r.empty, 0, "empty");
-  fail += ref_st_num(back->r.size, (LLint) (sizeof(REF_ST_BODY) - 1), "size");
-  /* past 32 bits, and negative: a truncated or unsigned field shows here */
-  fail += ref_st_num(back->r.totalsize, (LLint) 4294967296LL, "totalsize");
-  fail += ref_st_num(back->r.crange, (LLint) 1234567890123LL, "crange");
-  fail += ref_st_num(back->r.crange_start, -1, "crange_start");
-  fail += ref_st_num(back->r.crange_end, 4096, "crange_end");
+  fail += ref_st_str(back->r.location, "http://moved.example/elsewhere",
+                     "location");
+  fail += ref_st_int(back->r.statuscode, REF_ST_STATUS, "statuscode");
+  fail += ref_st_int(back->r.notmodified, REF_ST_NOTMODIFIED, "notmodified");
+  fail += ref_st_int(back->r.compressed, REF_ST_COMPRESSED, "compressed");
+  fail += ref_st_int(back->r.empty, REF_ST_EMPTY, "empty");
+  fail += ref_st_int(back->r.size, (LLint) (sizeof(REF_ST_BODY) - 1), "size");
+  fail += ref_st_int(back->r.totalsize, REF_ST_TOTALSIZE, "totalsize");
+  fail += ref_st_int(back->r.crange, REF_ST_CRANGE, "crange");
+  fail += ref_st_int(back->r.crange_start, REF_ST_CRANGE_START, "crange_start");
+  fail += ref_st_int(back->r.crange_end, REF_ST_CRANGE_END, "crange_end");
   fail += ref_st_str(back->r.msg, "Partial Content", "msg");
   fail += ref_st_str(back->r.contenttype, "application/octet-stream",
                      "contenttype");
-  fail += ref_st_str(back->r.charset, "", "charset");
+  fail += ref_st_str(back->r.charset, "utf-8", "charset");
   fail += ref_st_str(back->r.contentencoding, "gzip", "contentencoding");
   fail += ref_st_str(back->r.lastmodified, "Wed, 03 Sep 2026 10:11:12 GMT",
                      "lastmodified");
   fail += ref_st_str(back->r.etag, "\"abc-123\"", "etag");
   fail +=
       ref_st_str(back->r.cdispo, "attachment; filename=partial.bin", "cdispo");
-  if (back->r.location != back->location_buffer ||
-      back->r.location[0] != '\0') {
+  if (back->r.location != back->location_buffer) {
     fprintf(stderr, "%s: location not restored into the entry's own buffer\n",
             selftest_tag);
     fail++;
@@ -2845,11 +2949,49 @@ static int ref_st_refuse(httrackp *opt, const char *path, const void *data,
   return 0;
 }
 
+/* Read the reference back, or count a failure and return NULL. */
+static lien_back *ref_st_accept(httrackp *opt, const char *what, int *fail) {
+  lien_back *back = NULL;
+
+  if (back_unserialize_ref(opt, REF_ST_ADR, REF_ST_FIL, &back) != 0) {
+    fprintf(stderr, "%s: %s was refused\n", selftest_tag, what);
+    (*fail)++;
+    return NULL;
+  }
+  return back;
+}
+
+/* Rebuild the record with one string field's declared length raised to len,
+   padded with 'A'. The caller frees. */
+static unsigned char *ref_st_oversize(const char *field, size_t len,
+                                      size_t *size) {
+  const size_t i = ref_st_field(field);
+  const size_t off = ref_off[i];
+  const size_t tail = off + 4 + strlen(ref_fields[i].text);
+  unsigned char *out;
+
+  assertf(ref_fields[i].kind == REF_F_STR);
+
+  *size = off + 4 + len + (ref_golden_size - tail);
+  out = malloct(*size);
+  memcpy(out, ref_golden, off);
+  ref_st_num(out + off, (uint64_t) len, 4);
+  memset(out + off + 4, 'A', len);
+  memcpy(out + off + 4 + len, ref_golden + tail, ref_golden_size - tail);
+  return out;
+}
+
+/* r.crange is the canary for an overflow of r.cdispo: the reader fills it
+   earlier in the stream and never touches it again, so a stray byte or stray
+   terminator past cdispo survives to the assertion. */
+HTS_STATIC_ASSERT(offsetof(htsblk, crange) ==
+                      offsetof(htsblk, cdispo) + sizeof(((htsblk *) 0)->cdispo),
+                  ref_crange_follows_cdispo);
+
 int ref_portable_selftest(httrackp *opt, const char *dir) {
   int fail = 0;
   char path[HTS_URLMAXSIZE * 2];
-  lien_back *back = NULL;
-  size_t off_sav, end_sav;
+  lien_back *back;
 
   selftest_tag = "ref-portable";
   selftest_setup_dir(opt, dir);
@@ -2862,7 +3004,12 @@ int ref_portable_selftest(httrackp *opt, const char *dir) {
 #endif
   ref_st_refpath(opt, path, sizeof(path));
 
-  /* the writer emits those exact bytes, on every host */
+  ref_golden_size = ref_st_build(NULL);
+  ref_golden = malloct(ref_golden_size);
+  fail += ref_st_int((LLint) ref_st_build(ref_golden), (LLint) ref_golden_size,
+                     "assembled record size");
+
+  /* the writer emits the table, byte for byte */
   {
     lien_back *entry = calloct(1, sizeof(lien_back));
     unsigned char *got;
@@ -2873,18 +3020,22 @@ int ref_portable_selftest(httrackp *opt, const char *dir) {
     entry->r.location = entry->location_buffer;
     strcpybuff(entry->url_adr, REF_ST_ADR);
     strcpybuff(entry->url_fil, REF_ST_FIL);
-    strcpybuff(entry->url_sav, "example.com/partial.bin");
+    strcpybuff(entry->url_sav, REF_ST_SAV);
     strcpybuff(entry->referer_adr, "ref.example");
     strcpybuff(entry->referer_fil, "/from.html");
-    entry->r.statuscode = 206;
-    entry->r.compressed = 1;
+    strcpybuff(entry->location_buffer, "http://moved.example/elsewhere");
+    entry->r.statuscode = REF_ST_STATUS;
+    entry->r.notmodified = REF_ST_NOTMODIFIED;
+    entry->r.compressed = REF_ST_COMPRESSED;
+    entry->r.empty = REF_ST_EMPTY;
     entry->r.size = (LLint) (sizeof(REF_ST_BODY) - 1);
-    entry->r.totalsize = (LLint) 4294967296LL;
-    entry->r.crange = (LLint) 1234567890123LL;
-    entry->r.crange_start = -1;
-    entry->r.crange_end = 4096;
+    entry->r.totalsize = REF_ST_TOTALSIZE;
+    entry->r.crange = REF_ST_CRANGE;
+    entry->r.crange_start = REF_ST_CRANGE_START;
+    entry->r.crange_end = REF_ST_CRANGE_END;
     strcpybuff(entry->r.msg, "Partial Content");
     strcpybuff(entry->r.contenttype, "application/octet-stream");
+    strcpybuff(entry->r.charset, "utf-8");
     strcpybuff(entry->r.contentencoding, "gzip");
     strcpybuff(entry->r.lastmodified, "Wed, 03 Sep 2026 10:11:12 GMT");
     strcpybuff(entry->r.etag, "\"abc-123\"");
@@ -2905,37 +3056,45 @@ int ref_portable_selftest(httrackp *opt, const char *dir) {
     freet(entry);
 
     got_size = fsize(path);
-    got = malloct(sizeof(ref_golden) + 1);
+    got = malloct(ref_golden_size + 1);
     fp = fopen(path, "rb");
     assertf(fp != NULL);
-    if (got_size != (LLint) sizeof(ref_golden) ||
-        !hts_fread_exact(got, sizeof(ref_golden), fp)) {
+    if (got_size != (LLint) ref_golden_size ||
+        !hts_fread_exact(got, ref_golden_size, fp)) {
       fprintf(stderr, "%s: wrote " LLintP " bytes, expected %d\n", selftest_tag,
-              got_size, (int) sizeof(ref_golden));
+              got_size, (int) ref_golden_size);
       fail++;
-    } else if (memcmp(got, ref_golden, sizeof(ref_golden)) != 0) {
+    } else if (memcmp(got, ref_golden, ref_golden_size) != 0) {
       size_t i;
 
-      for (i = 0; i < sizeof(ref_golden) && got[i] == ref_golden[i]; i++)
+      for (i = 0; i < ref_golden_size && got[i] == ref_golden[i]; i++)
         ;
       fprintf(stderr, "%s: byte %d is 0x%02x, expected 0x%02x\n", selftest_tag,
               (int) i, got[i], ref_golden[i]);
       fail++;
+    } else {
+      /* the order those bytes go out in, one field per width and sign */
+      static const unsigned char u32_le[4] = {0x14, 0x13, 0x12, 0x11};
+      static const unsigned char i64_le[8] = {0x08, 0x07, 0x06, 0x05,
+                                              0x04, 0x03, 0x02, 0x01};
+      static const unsigned char neg_le[8] = {0xf8, 0xf7, 0xf6, 0xf5,
+                                              0xf4, 0xf3, 0xf2, 0xf1};
+
+      fail += ref_st_bytes(got, "statuscode", u32_le, sizeof(u32_le));
+      fail += ref_st_bytes(got, "totalsize", i64_le, sizeof(i64_le));
+      fail += ref_st_bytes(got, "crange_start", neg_le, sizeof(neg_le));
     }
     fclose(fp);
     freet(got);
   }
 
   /* and the reader takes them back, whatever host laid them down */
-  ref_st_put(path, ref_golden, sizeof(ref_golden));
-  if (back_unserialize_ref(opt, REF_ST_ADR, REF_ST_FIL, &back) != 0) {
-    fprintf(stderr, "%s: the reference did not read back\n", selftest_tag);
-    fail++;
-  } else {
+  ref_st_put(path, ref_golden, ref_golden_size);
+  back = ref_st_accept(opt, "the golden reference", &fail);
+  if (back != NULL) {
     fail += ref_st_check(back);
     back_clear_entry(back);
     freet(back);
-    back = NULL;
   }
 
   /* exactly what 3.50.1 wrote: a host-native size_t, the raw structure, then
@@ -2949,105 +3108,103 @@ int ref_portable_selftest(httrackp *opt, const char *dir) {
     memcpy(legacy, &blit, sizeof(blit));
     strcpybuff(old->url_adr, REF_ST_ADR);
     strcpybuff(old->url_fil, REF_ST_FIL);
-    strcpybuff(old->url_sav, "example.com/partial.bin");
+    strcpybuff(old->url_sav, REF_ST_SAV);
     old->r.statuscode = 206;
     fail +=
         ref_st_refuse(opt, path, legacy, size, "a legacy host-native record");
     freet(legacy);
   }
 
-  /* big-endian framing: what a byte-swapped writer would lay down */
-  {
-    unsigned char bad[sizeof(ref_golden)];
-    static const size_t swapped[] = {8, 12}; /* version, first string length */
-    size_t i;
-
-    for (i = 0; i < sizeof(swapped) / sizeof(swapped[0]); i++) {
-      const size_t off = swapped[i];
-      unsigned char b[4];
-
-      memcpy(bad, ref_golden, sizeof(bad));
-      memcpy(b, &bad[off], sizeof(b));
-      bad[off] = b[3];
-      bad[off + 1] = b[2];
-      bad[off + 2] = b[1];
-      bad[off + 3] = b[0];
-      fail += ref_st_refuse(opt, path, bad, sizeof(bad),
-                            "a big-endian fixed-width field");
-    }
-  }
-
   /* a wrong magic, a future version, and every truncation */
   {
-    unsigned char bad[sizeof(ref_golden)];
-    static const size_t cut[] = {0, 4, 8, 12, 40, 200, sizeof(ref_golden) - 1};
+    unsigned char *bad = malloct(ref_golden_size);
+    const size_t cut[] = {0,
+                          4,
+                          8,
+                          12,
+                          ref_off[ref_st_field("statuscode")] + 2,
+                          ref_off[ref_st_field("crange")] + 4,
+                          ref_off[ref_st_field("body")] + 6,
+                          ref_golden_size - 1};
     size_t i;
 
-    memcpy(bad, ref_golden, sizeof(bad));
-    memset(bad, 'X', 8);
-    fail += ref_st_refuse(opt, path, bad, sizeof(bad), "a wrong magic");
+    memcpy(bad, ref_golden, ref_golden_size);
+    memset(bad, 'X', HTS_REF_MAGIC_SIZE);
+    fail += ref_st_refuse(opt, path, bad, ref_golden_size, "a wrong magic");
 
-    memcpy(bad, ref_golden, sizeof(bad));
-    bad[8] = 2;
-    fail += ref_st_refuse(opt, path, bad, sizeof(bad), "an unknown version");
+    memcpy(bad, ref_golden, ref_golden_size);
+    bad[ref_off[ref_st_field("version")]] = HTS_REF_VERSION + 1;
+    fail +=
+        ref_st_refuse(opt, path, bad, ref_golden_size, "an unknown version");
 
     for (i = 0; i < sizeof(cut) / sizeof(cut[0]); i++)
       fail +=
           ref_st_refuse(opt, path, ref_golden, cut[i], "a truncated record");
+    freet(bad);
   }
 
-  off_sav = ref_st_skip(ref_st_skip(8 + 4)); /* url_adr, url_fil */
-  end_sav = ref_st_skip(off_sav);
-
-  /* a length past its destination clips, and the reader stays in step with the
-     stream: the field after it is the canary */
+  /* the string cap, at its two boundary values, each file long enough that
+     only the cap can decide it */
   {
-    const uint32_t huge = 3000;
-    const size_t size = off_sav + 4 + huge + (sizeof(ref_golden) - end_sav);
-    unsigned char *bad = malloct(size);
+    size_t size;
+    unsigned char *at = ref_st_oversize("url_sav", HTS_REF_MAX_STR, &size);
 
-    memcpy(bad, ref_golden, off_sav);
-    bad[off_sav] = (unsigned char) (huge & 0xff);
-    bad[off_sav + 1] = (unsigned char) ((huge >> 8) & 0xff);
-    bad[off_sav + 2] = (unsigned char) ((huge >> 16) & 0xff);
-    bad[off_sav + 3] = (unsigned char) ((huge >> 24) & 0xff);
-    memset(bad + off_sav + 4, 'A', huge);
-    memcpy(bad + off_sav + 4 + huge, ref_golden + end_sav,
-           sizeof(ref_golden) - end_sav);
-    ref_st_put(path, bad, size);
-    freet(bad);
-    if (back_unserialize_ref(opt, REF_ST_ADR, REF_ST_FIL, &back) != 0) {
-      fprintf(stderr, "%s: an over-long save name was refused outright\n",
-              selftest_tag);
-      fail++;
-    } else {
-      const size_t want = sizeof(back->url_sav) - 1;
-
-      if (strlen(back->url_sav) != want || strspn(back->url_sav, "A") != want) {
-        fprintf(stderr, "%s: save name clipped to %d bytes of '%s'\n",
-                selftest_tag, (int) strlen(back->url_sav), back->url_sav);
-        fail++;
-      }
-      fail += ref_st_str(back->referer_adr, "ref.example", "referer_adr");
-      fail += ref_st_num(back->r.statuscode, 206, "statuscode");
+    ref_st_put(path, at, size);
+    freet(at);
+    back = ref_st_accept(opt, "a name declaring exactly the cap", &fail);
+    if (back != NULL) {
+      fail += ref_st_int((LLint) strlen(back->url_sav),
+                         (LLint) sizeof(back->url_sav) - 1, "clipped url_sav");
+      fail += ref_st_int(back->r.statuscode, REF_ST_STATUS, "statuscode");
       back_clear_entry(back);
       freet(back);
-      back = NULL;
+    }
+  }
+  {
+    size_t size;
+    unsigned char *over =
+        ref_st_oversize("url_sav", HTS_REF_MAX_STR + 1, &size);
+
+    fail +=
+        ref_st_refuse(opt, path, over, size, "a name one byte past the cap");
+    freet(over);
+  }
+
+  /* a length past its destination clips, the reader stays in step with the
+     stream, and the field the reader already filled next door is untouched */
+  {
+    size_t size;
+    unsigned char *bad = ref_st_oversize("cdispo", 3000, &size);
+
+    ref_st_put(path, bad, size);
+    freet(bad);
+    back = ref_st_accept(opt, "an over-long content-disposition", &fail);
+    if (back != NULL) {
+      const size_t want = sizeof(back->r.cdispo) - 1;
+
+      if (strlen(back->r.cdispo) != want ||
+          strspn(back->r.cdispo, "A") != want) {
+        fprintf(stderr, "%s: cdispo clipped to %d bytes of '%s'\n",
+                selftest_tag, (int) strlen(back->r.cdispo), back->r.cdispo);
+        fail++;
+      }
+      fail += ref_st_int(back->r.crange, REF_ST_CRANGE, "crange canary");
+      fail += ref_st_int(back->r.crange_start, REF_ST_CRANGE_START,
+                         "crange_start canary");
+      fail += ref_st_int(back->r.crange_end, REF_ST_CRANGE_END,
+                         "crange_end canary");
+      if (back->r.headers == NULL ||
+          strcmp(back->r.headers, REF_ST_HEADERS) != 0) {
+        fprintf(stderr, "%s: the clip lost the reader's place in the stream\n",
+                selftest_tag);
+        fail++;
+      }
+      back_clear_entry(back);
+      freet(back);
     }
   }
 
-  /* a length past the reader's own cap is refused, not allocated */
-  {
-    unsigned char bad[sizeof(ref_golden)];
-
-    memcpy(bad, ref_golden, sizeof(bad));
-    bad[off_sav] = 0xff;
-    bad[off_sav + 1] = 0xff;
-    bad[off_sav + 2] = 0xff;
-    bad[off_sav + 3] = 0x7f;
-    fail += ref_st_refuse(opt, path, bad, sizeof(bad), "an over-cap length");
-  }
-
+  freet(ref_golden);
   UNLINK(path);
   return fail;
 }

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -2681,3 +2681,373 @@ int cache_readfail_selftest(httrackp *opt, const char *dir) {
   UNLINK(fconv(catbuff, sizeof(catbuff), zippath));
   return fail;
 }
+
+/* --- the portable resume reference (.ref) --------------------------------- */
+
+/* One reference, byte for byte as the format defines it: little-endian fixed
+   widths. A build that wrote lien_back host-natively can neither produce nor
+   accept these bytes, which is the point, since the build that resumes a
+   mirror need not be the one that interrupted it. */
+static const unsigned char ref_golden[] = {
+    0x48, 0x54, 0x53, 0x52, 0x45, 0x46, 0x31, 0x0a, 0x01, 0x00, 0x00, 0x00,
+    0x0b, 0x00, 0x00, 0x00, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e,
+    0x63, 0x6f, 0x6d, 0x0c, 0x00, 0x00, 0x00, 0x2f, 0x70, 0x61, 0x72, 0x74,
+    0x69, 0x61, 0x6c, 0x2e, 0x62, 0x69, 0x6e, 0x17, 0x00, 0x00, 0x00, 0x65,
+    0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x70,
+    0x61, 0x72, 0x74, 0x69, 0x61, 0x6c, 0x2e, 0x62, 0x69, 0x6e, 0x0b, 0x00,
+    0x00, 0x00, 0x72, 0x65, 0x66, 0x2e, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c,
+    0x65, 0x0a, 0x00, 0x00, 0x00, 0x2f, 0x66, 0x72, 0x6f, 0x6d, 0x2e, 0x68,
+    0x74, 0x6d, 0x6c, 0x00, 0x00, 0x00, 0x00, 0xce, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0b,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0xcb, 0x04, 0xfb, 0x71, 0x1f, 0x01, 0x00, 0x00, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x10, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, 0x50, 0x61, 0x72, 0x74, 0x69,
+    0x61, 0x6c, 0x20, 0x43, 0x6f, 0x6e, 0x74, 0x65, 0x6e, 0x74, 0x18, 0x00,
+    0x00, 0x00, 0x61, 0x70, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f,
+    0x6e, 0x2f, 0x6f, 0x63, 0x74, 0x65, 0x74, 0x2d, 0x73, 0x74, 0x72, 0x65,
+    0x61, 0x6d, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x67, 0x7a,
+    0x69, 0x70, 0x1d, 0x00, 0x00, 0x00, 0x57, 0x65, 0x64, 0x2c, 0x20, 0x30,
+    0x33, 0x20, 0x53, 0x65, 0x70, 0x20, 0x32, 0x30, 0x32, 0x36, 0x20, 0x31,
+    0x30, 0x3a, 0x31, 0x31, 0x3a, 0x31, 0x32, 0x20, 0x47, 0x4d, 0x54, 0x09,
+    0x00, 0x00, 0x00, 0x22, 0x61, 0x62, 0x63, 0x2d, 0x31, 0x32, 0x33, 0x22,
+    0x20, 0x00, 0x00, 0x00, 0x61, 0x74, 0x74, 0x61, 0x63, 0x68, 0x6d, 0x65,
+    0x6e, 0x74, 0x3b, 0x20, 0x66, 0x69, 0x6c, 0x65, 0x6e, 0x61, 0x6d, 0x65,
+    0x3d, 0x70, 0x61, 0x72, 0x74, 0x69, 0x61, 0x6c, 0x2e, 0x62, 0x69, 0x6e,
+    0x0b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x68, 0x61, 0x6c, 0x66,
+    0x20, 0x61, 0x20, 0x70, 0x61, 0x67, 0x65, 0x20, 0x00, 0x00, 0x00, 0x48,
+    0x54, 0x54, 0x50, 0x2f, 0x31, 0x2e, 0x31, 0x20, 0x32, 0x30, 0x36, 0x20,
+    0x50, 0x61, 0x72, 0x74, 0x69, 0x61, 0x6c, 0x20, 0x43, 0x6f, 0x6e, 0x74,
+    0x65, 0x6e, 0x74, 0x0d, 0x0a, 0x0d, 0x0a,
+};
+
+#define REF_ST_ADR "example.com"
+#define REF_ST_FIL "/partial.bin"
+#define REF_ST_BODY "half a page"
+#define REF_ST_HEADERS "HTTP/1.1 206 Partial Content\r\n\r\n"
+
+/* Copy the reference's path out of the option scratch buffer, which the very
+   next call reuses. */
+static void ref_st_refpath(httrackp *opt, char *dst, size_t size) {
+  strlcpybuff(dst, url_savename_refname_fullpath(opt, REF_ST_ADR, REF_ST_FIL),
+              size);
+}
+
+static void ref_st_put(const char *path, const void *data, size_t size) {
+  FILE *const fp = fopen(path, "wb");
+
+  assertf(fp != NULL);
+  assertf(hts_fwrite_exact(data, size, fp));
+  fclose(fp);
+}
+
+static uint32_t ref_st_u32(const unsigned char *p) {
+  return (uint32_t) p[0] | ((uint32_t) p[1] << 8) | ((uint32_t) p[2] << 16) |
+         ((uint32_t) p[3] << 24);
+}
+
+/* Offset of the field after the length-prefixed string at off. */
+static size_t ref_st_skip(size_t off) {
+  return off + 4 + ref_st_u32(&ref_golden[off]);
+}
+
+static int ref_st_str(const char *got, const char *want, const char *field) {
+  if (strcmp(got, want) != 0) {
+    fprintf(stderr, "%s: %s is '%s', expected '%s'\n", selftest_tag, field, got,
+            want);
+    return 1;
+  }
+  return 0;
+}
+
+static int ref_st_num(LLint got, LLint want, const char *field) {
+  if (got != want) {
+    fprintf(stderr, "%s: %s is " LLintP ", expected " LLintP "\n", selftest_tag,
+            field, got, want);
+    return 1;
+  }
+  return 0;
+}
+
+/* Every field against the values ref_golden encodes, never against whatever
+   the reader happened to produce. */
+static int ref_st_check(const lien_back *back) {
+  int fail = 0;
+
+  fail += ref_st_str(back->url_adr, REF_ST_ADR, "url_adr");
+  fail += ref_st_str(back->url_fil, REF_ST_FIL, "url_fil");
+  fail += ref_st_str(back->url_sav, "example.com/partial.bin", "url_sav");
+  fail += ref_st_str(back->referer_adr, "ref.example", "referer_adr");
+  fail += ref_st_str(back->referer_fil, "/from.html", "referer_fil");
+  fail += ref_st_num(back->r.statuscode, 206, "statuscode");
+  fail += ref_st_num(back->r.notmodified, 0, "notmodified");
+  fail += ref_st_num(back->r.compressed, 1, "compressed");
+  fail += ref_st_num(back->r.empty, 0, "empty");
+  fail += ref_st_num(back->r.size, (LLint) (sizeof(REF_ST_BODY) - 1), "size");
+  /* past 32 bits, and negative: a truncated or unsigned field shows here */
+  fail += ref_st_num(back->r.totalsize, (LLint) 4294967296LL, "totalsize");
+  fail += ref_st_num(back->r.crange, (LLint) 1234567890123LL, "crange");
+  fail += ref_st_num(back->r.crange_start, -1, "crange_start");
+  fail += ref_st_num(back->r.crange_end, 4096, "crange_end");
+  fail += ref_st_str(back->r.msg, "Partial Content", "msg");
+  fail += ref_st_str(back->r.contenttype, "application/octet-stream",
+                     "contenttype");
+  fail += ref_st_str(back->r.charset, "", "charset");
+  fail += ref_st_str(back->r.contentencoding, "gzip", "contentencoding");
+  fail += ref_st_str(back->r.lastmodified, "Wed, 03 Sep 2026 10:11:12 GMT",
+                     "lastmodified");
+  fail += ref_st_str(back->r.etag, "\"abc-123\"", "etag");
+  fail +=
+      ref_st_str(back->r.cdispo, "attachment; filename=partial.bin", "cdispo");
+  if (back->r.location != back->location_buffer ||
+      back->r.location[0] != '\0') {
+    fprintf(stderr, "%s: location not restored into the entry's own buffer\n",
+            selftest_tag);
+    fail++;
+  }
+  if (back->r.adr == NULL ||
+      memcmp(back->r.adr, REF_ST_BODY, sizeof(REF_ST_BODY)) != 0) {
+    fprintf(stderr, "%s: body not restored\n", selftest_tag);
+    fail++;
+  }
+  if (back->r.headers == NULL || strcmp(back->r.headers, REF_ST_HEADERS) != 0) {
+    fprintf(stderr, "%s: headers not restored\n", selftest_tag);
+    fail++;
+  }
+  /* nothing that only means something inside the writing process */
+  if (back->r.soc != INVALID_SOCKET || back->r.out != NULL ||
+      back->r.fp != NULL || back->tmpfile != NULL ||
+      back->r.req.user_agent != NULL || back->send_too[0] != '\0') {
+    fprintf(stderr, "%s: a live handle or option pointer came off the file\n",
+            selftest_tag);
+    fail++;
+  }
+  return fail;
+}
+
+/* A reference the reader must turn down: no entry comes back, and none is
+   left half-built. */
+static int ref_st_refuse(httrackp *opt, const char *path, const void *data,
+                         size_t size, const char *what) {
+  lien_back *back = NULL;
+
+  ref_st_put(path, data, size);
+  if (back_unserialize_ref(opt, REF_ST_ADR, REF_ST_FIL, &back) == 0) {
+    fprintf(stderr, "%s: %s was accepted\n", selftest_tag, what);
+    back_clear_entry(back);
+    freet(back);
+    return 1;
+  }
+  if (back != NULL) {
+    fprintf(stderr, "%s: %s left an entry behind\n", selftest_tag, what);
+    return 1;
+  }
+  return 0;
+}
+
+int ref_portable_selftest(httrackp *opt, const char *dir) {
+  int fail = 0;
+  char path[HTS_URLMAXSIZE * 2];
+  lien_back *back = NULL;
+  size_t off_sav, end_sav;
+
+  selftest_tag = "ref-portable";
+  selftest_setup_dir(opt, dir);
+#ifdef _WIN32
+  mkdir(reconcile_st_path(opt, "hts-cache"));
+  mkdir(reconcile_st_path(opt, CACHE_REFNAME));
+#else
+  mkdir(reconcile_st_path(opt, "hts-cache"), HTS_PROTECT_FOLDER);
+  mkdir(reconcile_st_path(opt, CACHE_REFNAME), HTS_PROTECT_FOLDER);
+#endif
+  ref_st_refpath(opt, path, sizeof(path));
+
+  /* the writer emits those exact bytes, on every host */
+  {
+    lien_back *entry = calloct(1, sizeof(lien_back));
+    unsigned char *got;
+    LLint got_size;
+    FILE *fp;
+
+    hts_init_htsblk(&entry->r);
+    entry->r.location = entry->location_buffer;
+    strcpybuff(entry->url_adr, REF_ST_ADR);
+    strcpybuff(entry->url_fil, REF_ST_FIL);
+    strcpybuff(entry->url_sav, "example.com/partial.bin");
+    strcpybuff(entry->referer_adr, "ref.example");
+    strcpybuff(entry->referer_fil, "/from.html");
+    entry->r.statuscode = 206;
+    entry->r.compressed = 1;
+    entry->r.size = (LLint) (sizeof(REF_ST_BODY) - 1);
+    entry->r.totalsize = (LLint) 4294967296LL;
+    entry->r.crange = (LLint) 1234567890123LL;
+    entry->r.crange_start = -1;
+    entry->r.crange_end = 4096;
+    strcpybuff(entry->r.msg, "Partial Content");
+    strcpybuff(entry->r.contenttype, "application/octet-stream");
+    strcpybuff(entry->r.contentencoding, "gzip");
+    strcpybuff(entry->r.lastmodified, "Wed, 03 Sep 2026 10:11:12 GMT");
+    strcpybuff(entry->r.etag, "\"abc-123\"");
+    strcpybuff(entry->r.cdispo, "attachment; filename=partial.bin");
+    entry->r.adr = strdupt(REF_ST_BODY);
+    entry->r.headers = strdupt(REF_ST_HEADERS);
+    /* scaffolding that must not reach the file */
+    entry->status = STATUS_TRANSFER;
+    entry->r.soc = (T_SOC) 7;
+    entry->r.req.user_agent = "must-not-be-serialized";
+    strcpybuff(entry->send_too, "Range: bytes=11-\r\n");
+    if (back_serialize_ref(opt, entry) != 0) {
+      fprintf(stderr, "%s: cannot write the reference\n", selftest_tag);
+      fail++;
+    }
+    freet(entry->r.adr);
+    freet(entry->r.headers);
+    freet(entry);
+
+    got_size = fsize(path);
+    got = malloct(sizeof(ref_golden) + 1);
+    fp = fopen(path, "rb");
+    assertf(fp != NULL);
+    if (got_size != (LLint) sizeof(ref_golden) ||
+        !hts_fread_exact(got, sizeof(ref_golden), fp)) {
+      fprintf(stderr, "%s: wrote " LLintP " bytes, expected %d\n", selftest_tag,
+              got_size, (int) sizeof(ref_golden));
+      fail++;
+    } else if (memcmp(got, ref_golden, sizeof(ref_golden)) != 0) {
+      size_t i;
+
+      for (i = 0; i < sizeof(ref_golden) && got[i] == ref_golden[i]; i++)
+        ;
+      fprintf(stderr, "%s: byte %d is 0x%02x, expected 0x%02x\n", selftest_tag,
+              (int) i, got[i], ref_golden[i]);
+      fail++;
+    }
+    fclose(fp);
+    freet(got);
+  }
+
+  /* and the reader takes them back, whatever host laid them down */
+  ref_st_put(path, ref_golden, sizeof(ref_golden));
+  if (back_unserialize_ref(opt, REF_ST_ADR, REF_ST_FIL, &back) != 0) {
+    fprintf(stderr, "%s: the reference did not read back\n", selftest_tag);
+    fail++;
+  } else {
+    fail += ref_st_check(back);
+    back_clear_entry(back);
+    freet(back);
+    back = NULL;
+  }
+
+  /* exactly what 3.50.1 wrote: a host-native size_t, the raw structure, then
+     the two data blocks, here both empty */
+  {
+    const size_t blit = sizeof(lien_back);
+    const size_t size = sizeof(blit) * 3 + blit;
+    unsigned char *legacy = calloct(1, size);
+    lien_back *const old = (lien_back *) (legacy + sizeof(blit));
+
+    memcpy(legacy, &blit, sizeof(blit));
+    strcpybuff(old->url_adr, REF_ST_ADR);
+    strcpybuff(old->url_fil, REF_ST_FIL);
+    strcpybuff(old->url_sav, "example.com/partial.bin");
+    old->r.statuscode = 206;
+    fail +=
+        ref_st_refuse(opt, path, legacy, size, "a legacy host-native record");
+    freet(legacy);
+  }
+
+  /* big-endian framing: what a byte-swapped writer would lay down */
+  {
+    unsigned char bad[sizeof(ref_golden)];
+    static const size_t swapped[] = {8, 12}; /* version, first string length */
+    size_t i;
+
+    for (i = 0; i < sizeof(swapped) / sizeof(swapped[0]); i++) {
+      const size_t off = swapped[i];
+      unsigned char b[4];
+
+      memcpy(bad, ref_golden, sizeof(bad));
+      memcpy(b, &bad[off], sizeof(b));
+      bad[off] = b[3];
+      bad[off + 1] = b[2];
+      bad[off + 2] = b[1];
+      bad[off + 3] = b[0];
+      fail += ref_st_refuse(opt, path, bad, sizeof(bad),
+                            "a big-endian fixed-width field");
+    }
+  }
+
+  /* a wrong magic, a future version, and every truncation */
+  {
+    unsigned char bad[sizeof(ref_golden)];
+    static const size_t cut[] = {0, 4, 8, 12, 40, 200, sizeof(ref_golden) - 1};
+    size_t i;
+
+    memcpy(bad, ref_golden, sizeof(bad));
+    memset(bad, 'X', 8);
+    fail += ref_st_refuse(opt, path, bad, sizeof(bad), "a wrong magic");
+
+    memcpy(bad, ref_golden, sizeof(bad));
+    bad[8] = 2;
+    fail += ref_st_refuse(opt, path, bad, sizeof(bad), "an unknown version");
+
+    for (i = 0; i < sizeof(cut) / sizeof(cut[0]); i++)
+      fail +=
+          ref_st_refuse(opt, path, ref_golden, cut[i], "a truncated record");
+  }
+
+  off_sav = ref_st_skip(ref_st_skip(8 + 4)); /* url_adr, url_fil */
+  end_sav = ref_st_skip(off_sav);
+
+  /* a length past its destination clips, and the reader stays in step with the
+     stream: the field after it is the canary */
+  {
+    const uint32_t huge = 3000;
+    const size_t size = off_sav + 4 + huge + (sizeof(ref_golden) - end_sav);
+    unsigned char *bad = malloct(size);
+
+    memcpy(bad, ref_golden, off_sav);
+    bad[off_sav] = (unsigned char) (huge & 0xff);
+    bad[off_sav + 1] = (unsigned char) ((huge >> 8) & 0xff);
+    bad[off_sav + 2] = (unsigned char) ((huge >> 16) & 0xff);
+    bad[off_sav + 3] = (unsigned char) ((huge >> 24) & 0xff);
+    memset(bad + off_sav + 4, 'A', huge);
+    memcpy(bad + off_sav + 4 + huge, ref_golden + end_sav,
+           sizeof(ref_golden) - end_sav);
+    ref_st_put(path, bad, size);
+    freet(bad);
+    if (back_unserialize_ref(opt, REF_ST_ADR, REF_ST_FIL, &back) != 0) {
+      fprintf(stderr, "%s: an over-long save name was refused outright\n",
+              selftest_tag);
+      fail++;
+    } else {
+      const size_t want = sizeof(back->url_sav) - 1;
+
+      if (strlen(back->url_sav) != want || strspn(back->url_sav, "A") != want) {
+        fprintf(stderr, "%s: save name clipped to %d bytes of '%s'\n",
+                selftest_tag, (int) strlen(back->url_sav), back->url_sav);
+        fail++;
+      }
+      fail += ref_st_str(back->referer_adr, "ref.example", "referer_adr");
+      fail += ref_st_num(back->r.statuscode, 206, "statuscode");
+      back_clear_entry(back);
+      freet(back);
+      back = NULL;
+    }
+  }
+
+  /* a length past the reader's own cap is refused, not allocated */
+  {
+    unsigned char bad[sizeof(ref_golden)];
+
+    memcpy(bad, ref_golden, sizeof(bad));
+    bad[off_sav] = 0xff;
+    bad[off_sav + 1] = 0xff;
+    bad[off_sav + 2] = 0xff;
+    bad[off_sav + 3] = 0x7f;
+    fail += ref_st_refuse(opt, path, bad, sizeof(bad), "an over-cap length");
+  }
+
+  UNLINK(path);
+  return fail;
+}

--- a/src/htscache_selftest.h
+++ b/src/htscache_selftest.h
@@ -89,6 +89,11 @@ int cache_corruption_selftest(httrackp *opt, const char *dir);
    commit a silently truncated body. */
 int cache_readfail_selftest(httrackp *opt, const char *dir);
 
+/* The .ref resume state must decode identically on every host: pins the bytes
+   in both directions against a literal record, and proves a legacy, truncated
+   or byte-swapped one is refused rather than misread. */
+int ref_portable_selftest(httrackp *opt, const char *dir);
+
 #endif
 
 #endif

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -4704,6 +4704,18 @@ static int st_cache_legacy(httrackp *opt, int argc, char **argv) {
   return err;
 }
 
+static int st_ref_portable(httrackp *opt, int argc, char **argv) {
+  int err;
+
+  if (argc < 1) {
+    fprintf(stderr, "ref-portable: needs a directory\n");
+    return 1;
+  }
+  err = ref_portable_selftest(opt, argv[0]);
+  printf("ref-portable: %s\n", err ? "FAIL" : "OK");
+  return err;
+}
+
 static int st_reconcile(httrackp *opt, int argc, char **argv) {
   int err;
 
@@ -13353,6 +13365,9 @@ static const struct selftest_entry {
      st_reconcile},
     {"cache-legacy", "<dir>", "pre-3.31 legacy cache refusal self-test",
      st_cache_legacy},
+    {"ref-portable", "<dir>",
+     "the .ref resume state is host-independent, and refuses a legacy one",
+     st_ref_portable},
     {"cache-corrupt", "<dir>", "cache read-side corruption self-test",
      st_cache_corrupt},
     {"cache-readfail", "<dir>",

--- a/tests/404_ref-portable.test
+++ b/tests/404_ref-portable.test
@@ -6,12 +6,37 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
+: "${top_srcdir:=..}"
+
 # A mirror interrupted on one machine is resumed by whatever build picks it up,
-# so the .ref resume state must decode the same bytes everywhere: pinned in
-# both directions against a literal little-endian record, with a pre-3.50.2
-# host-native blit, a byte-swapped field and a truncated file all refused.
+# so the .ref resume state must decode the same bytes everywhere. The self-test
+# assembles a record from a field table, pins the bytes in both directions, and
+# refuses a pre-3.50.2 host-native blit, a wrong magic, a truncation and an
+# over-cap length.
 
 dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
 assert_selftest 'ref-portable: OK' ref-portable "$dir"
+
+# On a little-endian host, writing a uint32_t or uint64_t through memcpy emits
+# the same bytes as the explicit shifts, so no run of the engine can tell the
+# two apart here. Refuse the host-native form at the source instead.
+src="$top_srcdir/src/htsback.c"
+test -r "$src" || fail "cannot read $src"
+codec=$(sed -n '/--- the .ref resume state/,/^int back_serialize_ref(/p' "$src")
+test -n "$codec" || fail "the .ref codec block moved; this check reads nothing"
+
+if grep -qE 'hts_f(read|write)_exact\(&' <<<"$codec"; then
+    fail "the .ref codec hands an object's own storage to the stream"
+fi
+
+for shift in \
+    'v >> 8' \
+    'v >> 24' \
+    'v >> \(8 \* i\)' \
+    'b\[3\] << 24' \
+    'b\[i\] << \(8 \* i\)'; do
+    grep -qE "$shift" <<<"$codec" ||
+        fail "the .ref codec no longer spells out the byte order ($shift)"
+done

--- a/tests/404_ref-portable.test
+++ b/tests/404_ref-portable.test
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+# A mirror interrupted on one machine is resumed by whatever build picks it up,
+# so the .ref resume state must decode the same bytes everywhere: pinned in
+# both directions against a literal little-endian record, with a pre-3.50.2
+# host-native blit, a byte-swapped field and a truncated file all refused.
+
+dir=$(mktemp -d)
+cleanup_push rm -rf "$dir"
+
+assert_selftest 'ref-portable: OK' ref-portable "$dir"


### PR DESCRIPTION
`hts-cache/ref/*.ref` holds the state an interrupted transfer resumes from. It was a raw `lien_back` blit, so it carried the writing host's word size, alignment and byte order. A mirror interrupted on one machine and resumed on another reads it as that machine's layout. The cache itself is architecture-neutral, so the reference was the only piece that was not.

The reference now goes out field by field in little-endian fixed widths. Only what a reader consumes is written: the link, its save name, and the response metadata a resumed Range request or a broken-cache read needs. Sockets, file handles, request options and scheduling state mean nothing in another process, and come back zeroed. That also drops the dangling `r.req` pointers the blit used to restore.

Old references are refused rather than converted. A legacy file carries no magic, so nothing tells it apart from a foreign layout, and reading it is the misparse this change is about. The transfer restarts from zero instead, and `hts-cache/ref` is erased at the end of every clean run.

`back_serialize` and `back_unserialize` keep the blit, because they have a second caller. `back_cleanup_background()` spools a ready slot to `~hts-tmp` and picks it up later in the same run. There the host's own layout is the right one, and a pointer still means something. Only the two `_ref` entry points move to the portable record.

`struct lien_back` is untouched, so the installed ABI is unchanged.

`tests/404_ref-portable.test` drives `httrack -#test=ref-portable`. The fixture is a field table, one row per field of the record, assembled at run time. Every value is distinct, so a swap of two fields cannot hide. Every multi-byte number has all-different bytes, so its order on disk is visible. The test pins the writer's file against that table, then pins three fields byte by byte at their offsets. It reads the table back and checks every field.

The reader is also fed a legacy blit, a wrong magic, an unknown version and eight truncations. A declared length is tried at the cap, then one byte past it. An over-long field must clip and leave `r.crange` next door intact.

Reverting both `_ref` bodies to the blit yields five failures. Seven mutants of the codec die:

- a host-native `uint32_t` codec, and a host-native `uint64_t` one
- `notmodified` and `empty` swapped
- the cap deleted, and the cap raised by one
- an off-by-one writing a stray byte, or a stray terminator, past a field

The two host-native mutants die at a source check in the `.test`, not at a byte assertion. This box is little-endian, so `memcpy` of a `uint64_t` emits the bytes the explicit shifts do. No run of the engine can tell them apart here. The byte pins catch it on a big-endian host. CI runs the whole suite on s390x, which is big-endian, so that is where the behavioural proof lands.
