### PR TITLE
A test that aborts under bash 3.2 is recorded as a PASS

### DIFF
--- a/tests/116_engine-rtrim.test
+++ b/tests/116_engine-rtrim.test
@@ -91,9 +91,11 @@ esac
 # Sections 2 and 3 only go red under a sanitizer: on a plain build the byte
 # below the buffer is usually not a digit, so a reverted scan stops anyway and
 # produces the same names. Pin the two sites at the source instead.
-command grep -q 'hts_rtrim(line, HTS_REALSPACES)' "$top_srcdir/src/htsalias.c" ||
+# Read out of a substitution: under bash 3.2 errexit kills the script whenever a
+# command-prefixed builtin returns non-zero, in a condition as much as anywhere.
+test -n "$(command grep -l 'hts_rtrim(line, HTS_REALSPACES)' "$top_srcdir/src/htsalias.c" || true)" ||
     fail "htsalias.c right trim no longer goes through hts_rtrim"
-command grep -q 'hts_rtrimlen(tempo, "0123456789")' "$top_srcdir/src/htsname.c" ||
+test -n "$(command grep -l 'hts_rtrimlen(tempo, "0123456789")' "$top_srcdir/src/htsname.c" || true)" ||
     fail "htsname.c collision-suffix scan no longer goes through hts_rtrimlen"
 
 exit 0

--- a/tests/232_online-gate-outoftree.test
+++ b/tests/232_online-gate-outoftree.test
@@ -37,7 +37,9 @@ for t in $gated; do
     # Only check-network.sh emits this, and only once it has actually run. The
     # "skipping online unit tests" banner prints on the broken path too, so
     # matching that instead would assert nothing.
-    command grep -q 'online tests are disabled' <<<"$out" ||
+    # Read out of a substitution: under bash 3.2 errexit kills the script whenever a
+    # command-prefixed builtin returns non-zero, in a condition as much as anywhere.
+    test -n "$(command grep -l 'online tests are disabled' <<<"$out" || true)" ||
         fail "$t skipped without the gate's reason, got: $out"
 done
 
@@ -45,7 +47,8 @@ done
 
 out=$(cd "$work" && ONLINE_UNIT_TESTS=no bash "$testdir/check-network.sh" 2>&1) && rc=0 || rc=$?
 test "$rc" -eq 1 || fail "check-network.sh exited $rc with the flag off, expected 1"
-command grep -q 'online tests are disabled' <<<"$out" || fail "check-network.sh gave no reason: $out"
+test -n "$(command grep -l 'online tests are disabled' <<<"$out" || true)" ||
+    fail "check-network.sh gave no reason: $out"
 
 out=$(cd "$work" && ONLINE_UNIT_TESTS=yes bash "$testdir/check-network.sh" 2>&1) && rc=0 || rc=$?
 test "$rc" -eq 0 || fail "check-network.sh exited $rc with the flag on, expected 0: $out"

--- a/tests/274_wizard-profile-load.test
+++ b/tests/274_wizard-profile-load.test
@@ -27,8 +27,12 @@ test "$(printf '%s\n' "${written}" | wc -l)" -ge 30 ||
     fail "only $(printf '%s\n' "${written}" | wc -l) ztest keys in step4.html"
 test "${written}" = "${listed}" ||
     fail "$(diff <(echo "${written}") <(echo "${listed}"))"
-! command grep -q '^ProxyType=[$]{ztest:' "${distdir}/html/server/step4.html" ||
+# The match is read out of a substitution, not tested directly: under bash 3.2
+# errexit kills the script whenever a command-prefixed builtin returns non-zero,
+# in a condition as much as anywhere else, and a grep that finds nothing does.
+if test -n "$(command grep -l '^ProxyType=[$]{ztest:' "${distdir}/html/server/step4.html" || true)"; then
     fail "ProxyType is a ztest key now, so the exception hides drift"
+fi
 echo OK
 
 htsserver_require

--- a/tests/274_wizard-profile-load.test
+++ b/tests/274_wizard-profile-load.test
@@ -27,9 +27,8 @@ test "$(printf '%s\n' "${written}" | wc -l)" -ge 30 ||
     fail "only $(printf '%s\n' "${written}" | wc -l) ztest keys in step4.html"
 test "${written}" = "${listed}" ||
     fail "$(diff <(echo "${written}") <(echo "${listed}"))"
-# The match is read out of a substitution, not tested directly: under bash 3.2
-# errexit kills the script whenever a command-prefixed builtin returns non-zero,
-# in a condition as much as anywhere else, and a grep that finds nothing does.
+# Read out of a substitution: under bash 3.2 errexit kills the script whenever a
+# command-prefixed builtin returns non-zero, in a condition as much as anywhere.
 if test -n "$(command grep -l '^ProxyType=[$]{ztest:' "${distdir}/html/server/step4.html" || true)"; then
     fail "ProxyType is a ztest key now, so the exception hides drift"
 fi

--- a/tests/371_webhttrack-help-reachable.test
+++ b/tests/371_webhttrack-help-reachable.test
@@ -100,11 +100,12 @@ IDLE='Existing project name:'
 # invisible. about.html is not a pane; the four tail spellings open the files
 # the first four name, since the path reaches open() unnormalized.
 PANES=$(
+    # An if, not a case: bash 3.2 cannot parse a case inside a command
+    # substitution, and the syntax error read as a pass, so this test was
+    # vacuous on macOS.
     for f in "${distdir}"/html/server/*.html; do
-        case ${f##*/} in
-        about.html) ;;
-        *) printf '/server/%s\n' "${f##*/}" ;;
-        esac
+        test "${f##*/}" != about.html || continue
+        printf '/server/%s\n' "${f##*/}"
     done
     printf '%s\n' //server/step4.html /./server/step4.html \
         /server//step4.html /Server/step4.html

--- a/tests/423_harness-abort-status.test
+++ b/tests/423_harness-abort-status.test
@@ -1,0 +1,107 @@
+#!/bin/bash
+#
+# bash before 4.2 patch 23 drops the exit status when an EXIT trap runs after a
+# fatal expansion error under errexit. macOS ships 3.2.57, so an aborted test was
+# recorded there as a PASS and 331_fortify-source.test ran vacuously for months.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+driver="${testdir}/test-timeout.sh"
+test -r "$driver" || fail "no test-timeout.sh next to $0"
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_abortst.XXXXXX")
+# Hand-written, not cleanup_push: this test must not lose its own teardown to the
+# machinery it is looking at.
+trap 'set +e; rm -rf "$tmpdir"' EXIT
+
+# Does this shell forget the status of a fatal expansion error? Measured, not read
+# off $BASH_VERSION, because the patch level is what decides it.
+# shellcheck disable=SC2016 # the fixture expands it, not us
+loses_status() { # loses_status SHELL
+    local rc=0
+    # printf, so 103's scanner does not read this fixture's trap as our own.
+    {
+        echo 'set -eu'
+        printf 'trap %s EXIT\n' "'true'"
+        echo 'echo "$HTTRACK_UNSET_ON_PURPOSE"'
+    } >"$tmpdir/probe.sh"
+    "$1" "$tmpdir/probe.sh" >/dev/null 2>&1 || rc=$?
+    test "$rc" -eq 0
+}
+
+# One case, through the real harness. REACH pins whether the fixture's last line
+# runs, so a case built on an abort cannot pass once the abort stops happening.
+check() { # check SHELL NAME WANT REACH CLEANUP BODY
+    local sh=$1 name=$2 want=$3 reach=$4 cleanup=$5 body=$6 rc=0 out
+    rm -f "$tmpdir/reached"
+    {
+        printf 'set -euo pipefail\n. %s/testlib.sh\n' "$testdir"
+        printf 'cleanup_push %s\n' "$cleanup"
+        printf '%s\n' "$body"
+        printf ': >%s/reached\n' "$tmpdir"
+    } >"$tmpdir/$name.test"
+    out=$(TMPDIR="$tmpdir" "$sh" "$driver" "$tmpdir/$name.test" 2>&1) || rc=$?
+    test "$rc" -eq "$want" ||
+        fail "$sh: $name with a $cleanup cleanup exited $rc, wanted $want: $out"
+    case $reach in
+    yes) test -f "$tmpdir/reached" || fail "$sh: $name did not run to its end" ;;
+    *) test ! -f "$tmpdir/reached" || fail "$sh: $name ran past where it must stop" ;;
+    esac
+    printf '%s\n' "$out"
+}
+
+# WANT is what automake must record: 0 pass, 77 skip, 1 failure.
+# shellcheck disable=SC2016 # the fixtures expand these, not us
+run_table() { # run_table SHELL
+    local sh=$1 cleanup
+    # A cleanup that fails must not become the verdict (#773), so every case runs
+    # both ways.
+    for cleanup in true false; do
+        check "$sh" end 0 yes "$cleanup" 'echo body' >/dev/null
+        check "$sh" exit0 0 no "$cleanup" 'exit 0' >/dev/null
+        check "$sh" skip 77 no "$cleanup" 'exit 77' >/dev/null
+        check "$sh" exit1 1 no "$cleanup" 'exit 1' >/dev/null
+        check "$sh" badsubst 1 no "$cleanup" 'echo "${x!y}"' >/dev/null
+        check "$sh" badsub 1 no "$cleanup" 'a=(1 2 3); echo "${a[BAD@SUB]}"' >/dev/null
+        check "$sh" unbound 1 no "$cleanup" 'echo "$HTTRACK_UNSET_ON_PURPOSE"' >/dev/null
+        check "$sh" readonly 1 no "$cleanup" 'readonly R=1; R=2' >/dev/null
+        # The signal traps end on exit 1, which the marker wrapper now intercepts.
+        check "$sh" signal 1 no "$cleanup" 'kill -TERM $$; sleep 5' >/dev/null
+    done
+}
+
+# $BASH is the shell make check runs the suite with, and on macOS it is the 3.2.57
+# that has the bug. HTTRACK_BASH32 points a Linux run at one built by hand.
+shells=("${BASH:-bash}")
+for cand in ${HTTRACK_BASH32:+"$HTTRACK_BASH32"}; do
+    test -r "$cand" || fail "HTTRACK_BASH32=$cand is not readable"
+    case " ${shells[*]} " in *" $cand "*) continue ;; esac
+    shells+=("$cand")
+done
+
+buggy=
+for sh in "${shells[@]}"; do
+    if loses_status "$sh"; then
+        buggy=$sh
+        ok "$sh forgets the status of an aborted script, so the cases below bite"
+    fi
+    run_table "$sh"
+    ok "$sh: an aborted test fails, a clean one passes, a failing cleanup changes neither"
+done
+
+test -n "$buggy" ||
+    echo "note: no bash older than 4.2 patch 23 here, so the table only guards the marker" >&2
+
+# The failure has to name itself: a bare 1 with nothing in the log sends the reader
+# looking for a test that never printed anything.
+if test -n "$buggy"; then
+    # shellcheck disable=SC2016 # the fixture expands it, not us
+    out=$(check "$buggy" unbound 1 no true 'echo "$HTTRACK_UNSET_ON_PURPOSE"')
+    case $out in
+    *"exited 0 without reaching its end"*) ok "the harness says why it turned a 0 into a failure" ;;
+    *) fail "the abort was reported with no explanation: $out" ;;
+    esac
+fi

--- a/tests/test-timeout.sh
+++ b/tests/test-timeout.sh
@@ -92,6 +92,8 @@ rm -f "$TESTLIB_DONE_FILE" 2>/dev/null || true
 # status with no mark is an abort. Sourcing it from `bash -c` keeps $0 the test's
 # own path, which many tests derive $testdir from, writes nothing beside a
 # read-only srcdir and leaves stdin alone. A subshell's exit is not the test's.
+# Two shapes would lose the mark and fail a healthy test: an `exec` at top level,
+# and removing the driver's TMPDIR before exiting. No test does either today.
 # shellcheck disable=SC2016 # the child expands it, not us
 TESTLIB_RUNNER='exit() {
     if test "$BASH_SUBSHELL" -eq 0; then : >"$TESTLIB_DONE_FILE" 2>/dev/null || true; fi

--- a/tests/test-timeout.sh
+++ b/tests/test-timeout.sh
@@ -27,6 +27,8 @@ budget=$(budget_secs)
 # The test script is the last argument; automake passes no others today.
 for path in "$@"; do :; done
 name=$(basename "$path")
+# The runner sources this path, and a dot-command with no slash in it is a PATH lookup.
+case $path in */*) ;; *) path=./$path ;; esac
 
 # gcc's UBSan ignores log_path and reports on stderr, which most tests discard.
 # Route the engine through the shims that keep a copy (tests/stderrwrap.c)
@@ -63,6 +65,7 @@ fi
 # Exported so a test can pace itself against the same number (skip_if_out_of_budget)
 # instead of being killed halfway.
 export HTTRACK_TEST_TIMEOUT="$budget"
+# No marker with the guard off: nothing survives the exec to read one.
 test "$budget" -gt 0 || exec "$BASH" "$@"
 
 # Give the test its own TMPDIR, so the hang dump can salvage exactly this test's
@@ -75,7 +78,36 @@ if mkdir -p "$tmproot/ht.$$" 2>/dev/null; then
     TMPDIR="$tmproot/ht.$$"
     export TMPDIR
     trap 'rm -rf "$TMPDIR" 2>/dev/null || true' EXIT
+    TESTLIB_DONE_FILE="$TMPDIR/.testlib-done"
+else
+    TESTLIB_DONE_FILE="$tmproot/ht.done.$$"
+    trap 'rm -f "$TESTLIB_DONE_FILE" 2>/dev/null || true' EXIT
 fi
+export TESTLIB_DONE_FILE
+rm -f "$TESTLIB_DONE_FILE" 2>/dev/null || true
+
+# bash before 4.2 patch 23 forgets the exit status when an EXIT trap runs after a
+# fatal expansion error under errexit, so an aborted test reports 0 and automake
+# records a PASS. macOS ships 3.2.57. So the test marks its own end, and a zero
+# status with no mark is an abort. Sourcing it from `bash -c` keeps $0 the test's
+# own path, which many tests derive $testdir from, writes nothing beside a
+# read-only srcdir and leaves stdin alone. A subshell's exit is not the test's.
+# shellcheck disable=SC2016 # the child expands it, not us
+TESTLIB_RUNNER='exit() {
+    if test "$BASH_SUBSHELL" -eq 0; then : >"$TESTLIB_DONE_FILE" 2>/dev/null || true; fi
+    builtin exit ${1+"$1"}
+}
+. "$0"
+TESTLIB_RUNNER_ST=$?
+: >"$TESTLIB_DONE_FILE" 2>/dev/null || true
+builtin exit "$TESTLIB_RUNNER_ST"'
+
+# Everything before the test path is an option for the shell that runs it.
+runopts=()
+while test "$#" -gt 1; do
+    runopts+=("$1")
+    shift
+done
 
 # Two questions, and they part company under the wsl2 backend: the shell there is
 # Linux while the binary under test is still a native .exe.
@@ -87,7 +119,7 @@ target_is_windows && windows=1
 had_m=
 case "$-" in *m*) had_m=1 ;; esac
 test -n "$msys_shell" || set -m # own process group, so kill_tree can signal the group
-"$BASH" "$@" &
+"$BASH" ${runopts[@]+"${runopts[@]}"} -c "$TESTLIB_RUNNER" "$path" &
 pid=$!
 test -n "$had_m" || test -n "$msys_shell" || set +m
 # Read while the test is certainly alive: by kill time /proc/<pid>/winpid is gone.
@@ -145,3 +177,9 @@ while kill -0 "$pid" 2>/dev/null; do
     exit 124
 done
 wait "$pid"
+status=$?
+if test "$status" -eq 0 && test ! -f "$TESTLIB_DONE_FILE"; then
+    echo "abort: $name exited 0 without reaching its end; the shell above says why"
+    status=1
+fi
+exit "$status"


### PR DESCRIPTION
bash before 4.2 patch 023 loses the exit status when an EXIT trap runs after a fatal expansion error under errexit. Every test sets errexit, and macOS ships 3.2.57. So an unbound variable, a readonly assignment or a bad substitution ended a test with status 0, which automake recorded as a PASS. `331_fortify-source.test` was vacuous on that platform from #1362 to #1540, and it was not alone.

`test-timeout.sh` now runs the test as `bash -c "$TESTLIB_RUNNER" <path>`. That sources the file with `$0` still the test's own path, so `testdir=$(cd "$(dirname "$0")" && pwd)` keeps working. It wraps `exit` so an explicit one marks the run, and marks the end again after the source returns. The harness reads the mark after `wait`: a zero status without one is an abort. The mark is skipped when `BASH_SUBSHELL` is non-zero, because a subshell's exit is not the test's. Nothing is written beside the srcdir, so a read-only `distcheck` tree is unaffected, stdin is untouched, and no test needed an edit. `testlib.sh` is unchanged, so the check also covers the tests that install their own EXIT trap instead of using `cleanup_push`.

Two tests turned out to be dying on bash 3.2, which is the same bug finding its own instances. `371_webhttrack-help-reachable.test` has a `case` inside a command substitution, which 3.2's parser rejects outright, and it was reading as green. `274_wizard-profile-load.test` runs `! command grep -q ...`, and under 3.2 errexit kills the script whenever a command-prefixed builtin returns non-zero, in a condition as much as anywhere else.

Four more sites carry that second shape, in `116_engine-rtrim.test` and `232_online-gate-outoftree.test`. Each dies before it can print the message it was about to fail with. They are fixed the same way, by reading the match out of a substitution. That keeps the `command` prefix and the protection it buys against a `grep` function in the developer's environment. This is not a macOS hazard, because Apple's 3.2 is patched and does not have the bug. That is why 274 passes on the macOS CI leg today. The hazard is on the stock GNU 3.2 we use for portability sweeps, and the marker turns such a death into a loud failure. Twelve other `command grep` sites were left alone. Eleven sit in a pipeline or behind `|| true`, where the bug does not reach, and the twelfth behaves identically with a plain grep.

`423_harness-abort-status.test` drives nine cases through the real harness, each with a clean and a failing cleanup. It asserts what automake must record. Falling off the end and `exit 0` give 0, and a skip gives 77. `exit 1`, a signal, and each of the four ways a shell can abort give 1. The buggy shell is measured rather than read off `$BASH_VERSION`, so the test is non-vacuous wherever the bug is and a marker guard everywhere else. `HTTRACK_BASH32` points a Linux run at a hand-built 3.2. On the unfixed harness it fails.

Suite counts, on this box against a stock GNU bash 3.2.57 and against the system bash 5. Before: 434 tests, 418 pass, 14 skip and 2 fail under 3.2 (274, plus a webhttrack flake), and 434/419/14/1 under bash 5. After: 435/421/14/0 under both.
