### PR TITLE
The WSL2 leg gates now

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -263,6 +263,9 @@ jobs:
           key: wsl-rootfs-jammy-amd64-v1
 
       - name: Run the engine test suite (offline tests)
+        # Kept as the control that separates a wsl2 flake from a real
+        # regression, but the WSL2 step is what gates the job now.
+        continue-on-error: true
         shell: bash
         working-directory: tests
         timeout-minutes: 45
@@ -301,8 +304,9 @@ jobs:
       # MSYS's fork emulation is what breaks first under load (#1273).
       - name: Bring up WSL2
         if: always()
-        # Non-gating like the suite step it feeds: this runs inside a job whose
-        # context `Protect master` requires, so a flaky import must not red it.
+        # Still non-gating now that the suite step gates: a failed import
+        # reaches that step, which names it and reds there. Failing here too
+        # would report one cause twice, and less clearly.
         continue-on-error: true
         shell: pwsh
         timeout-minutes: 15
@@ -350,9 +354,6 @@ jobs:
 
       - name: Run the engine test suite (offline tests, WSL2)
         if: always()
-        # The harness is new: a red here must not gate the job until it has a
-        # few days of history to read it against. Flip this once it has.
-        continue-on-error: true
         shell: bash
         working-directory: tests
         # 45 like the msys step, and 226_watchdog-native.test enforces it: the

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -263,9 +263,6 @@ jobs:
           key: wsl-rootfs-jammy-amd64-v1
 
       - name: Run the engine test suite (offline tests)
-        # Kept as the control that separates a wsl2 flake from a real
-        # regression, but the WSL2 step is what gates the job now.
-        continue-on-error: true
         shell: bash
         working-directory: tests
         timeout-minutes: 45
@@ -394,7 +391,10 @@ jobs:
           # The bring-up is continue-on-error, so a failed import reaches here as
           # "There is no distribution with the supplied name" and exit 127, which
           # names neither the step that failed nor why. wsl -l writes UTF-16.
-          wsl -l -q | tr -d '\0\r' | grep -qx httrack-suite || {
+          # Captured, not piped into grep -q: grep exits on the match, tr
+          # takes SIGPIPE, and pipefail would red a step whose distro was there.
+          distros=$(wsl -l -q | tr -d '\0\r')
+          grep -qx httrack-suite <<<"$distros" || {
             echo "::error::no httrack-suite distro: the Bring up WSL2 step did not finish"
             exit 1
           }

--- a/tests/337_ci-lost-worker.test
+++ b/tests/337_ci-lost-worker.test
@@ -261,8 +261,11 @@ test "$rc" -eq 3 || fail "a lost worker exited $rc, want 3: $(<"$tmp/out")"
 # Again with the killer on one of the pinned skips. That run reaches the skip-set
 # gate, which exits before the lost gate unless it is told a vanished worker
 # explains the difference: the reason this stays a leg to repeat.
+# No pipe: bash's printf writes a line at a time, so head -1 leaving early
+# gives it SIGPIPE, and pipefail turns that into this test's own failure.
 # shellcheck disable=SC2086 # the splitting is what picks one name
-pinned=$(printf '%s\n' $expected_skips | head -1)
+set -- $expected_skips
+pinned=$1
 stage "$tmp/killedskip" "$killer" "$pinned"
 run_suite "$tmp/killedskip"
 case "$(<"$share/killed")" in


### PR DESCRIPTION
The WSL2 leg has run beside the MSYS one without being able to fail the job. It gates now.

MSYS keeps gating too. Its skip list is a strict subset of WSL2's, so it is the only Windows check on `294_local-wizard-eof` and `24_local-resume-overlap`. Demoting it would leave both able to break on every Windows leg with nothing turning red. Demoting MSYS is a separate question. Answer it once WSL2 has a real rate, rather than six green legs in one afternoon.

The bring-up stays non-gating on purpose. A failed import already reaches the suite step, which reports it by name and reds there. Failing in both places would report one cause twice, and less clearly.

That guard piped into `grep -q`, which AGENTS.md bans. Grep exits on the match, `tr` takes SIGPIPE, and under `pipefail` the step would red on a run whose distro was present. It never mattered while the step could not fail the job. It matters now, so the reply is captured and matched from a here-string.

Nothing about the required checks moves. Both legs are steps of one job, so `Protect master` still requires the same two contexts. That is also what makes this a one-line revert.