### PR TITLE
A killed process that nobody has collected still answers kill -0

### DIFF
--- a/tests/250_timeout-poll-nofork.test
+++ b/tests/250_timeout-poll-nofork.test
@@ -63,25 +63,40 @@ run_timeout() {
 # The wedged child is killed but never waited on, since the guard exits without
 # reaping and this test is not its parent. reap_bounded must read that as stopped
 # and a running process as not, or the assertion below holds for any run at all.
-# Spin loops, not sleeps: self-limiting, and the stubbed sleep is on the PATH.
+# The parent waits for a file rather than a clock: a fixture that outlives the
+# grading by a fixed margin is the wall-clock assumption that caused this bug.
+# Spin loops, not sleeps, since the stubbed sleep is on the PATH; the minutes
+# below are leak insurance and a healthy run never reaches them.
 cat >"$tmp/zombie.sh" <<'EOF'
 #!/bin/bash
-bash -c 'end=$((SECONDS + 20)); while test "$SECONDS" -lt "$end"; do :; done' &
+bash -c 'end=$((SECONDS + 120)); while test "$SECONDS" -lt "$end"; do :; done' &
 echo "$!" >"$ZPIDFILE"
-exec bash -c 'end=$((SECONDS + 6)); while test "$SECONDS" -lt "$end"; do :; done'
+exec bash -c 'end=$((SECONDS + 120)); while test ! -f "$1" && test "$SECONDS" -lt "$end"; do :; done' _ "$2"
 EOF
 : >"$tmp/zpid"
-ZPIDFILE="$tmp/zpid" bash "$tmp/zombie.sh" &
+ZPIDFILE="$tmp/zpid" bash "$tmp/zombie.sh" _ "$tmp/release" &
 live=$!
 cleanup_push kill_pid "$live"
 while test ! -s "$tmp/zpid" && kill -0 "$live" 2>/dev/null; do :; done
 zombie=$(<"$tmp/zpid")
 test -n "$zombie" || fail "the zombie fixture never started"
-kill -9 "$zombie" 2>/dev/null || true
-REAP_GRACE=1 reap_bounded "$zombie" ||
-    fail "reap_bounded waited out its grace on a killed process nobody had collected"
-REAP_GRACE=1 reap_bounded "$live" && fail "reap_bounded called a running process reaped"
-ok "reap_bounded reads a killed-but-uncollected process as stopped, a live one as running"
+
+# Graded only where the host will answer for this very pid: with neither /proc nor
+# ps, reap_bounded degrades to the wait it always did and there is nothing here to
+# grade, so asserting would red a host master passes.
+if ! pid_state_readable "$zombie"; then
+    echo "no readable state for pid $zombie, so the reap probe cannot be graded" >&2
+else
+    kill -9 "$zombie" 2>/dev/null || true
+    REAP_GRACE=1 reap_bounded "$zombie" ||
+        fail "reap_bounded waited out its grace on a killed process nobody had collected"
+    # Named, not assumed: a parent that had already exited would make the arm below
+    # pass for the wrong reason.
+    kill -0 "$live" 2>/dev/null || fail "the live half of the fixture died before it was graded"
+    REAP_GRACE=1 reap_bounded "$live" && fail "reap_bounded called a running process reaped"
+    ok "reap_bounded reads a killed-but-uncollected process as stopped, a live one as running"
+fi
+: >"$tmp/release"
 
 : >"$tmp/progress"
 : >"$tmp/childpid"

--- a/tests/250_timeout-poll-nofork.test
+++ b/tests/250_timeout-poll-nofork.test
@@ -58,6 +58,31 @@ run_timeout() {
         "$BASH" "$testdir/test-timeout.sh" "$tmp/child.sh" >"$log" 2>&1
 }
 
+# --- control: the probe the give-up assertion rests on ----------------------
+#
+# The wedged child is killed but never waited on, since the guard exits without
+# reaping and this test is not its parent. reap_bounded must read that as stopped
+# and a running process as not, or the assertion below holds for any run at all.
+# Spin loops, not sleeps: self-limiting, and the stubbed sleep is on the PATH.
+cat >"$tmp/zombie.sh" <<'EOF'
+#!/bin/bash
+bash -c 'end=$((SECONDS + 20)); while test "$SECONDS" -lt "$end"; do :; done' &
+echo "$!" >"$ZPIDFILE"
+exec bash -c 'end=$((SECONDS + 6)); while test "$SECONDS" -lt "$end"; do :; done'
+EOF
+: >"$tmp/zpid"
+ZPIDFILE="$tmp/zpid" bash "$tmp/zombie.sh" &
+live=$!
+cleanup_push kill_pid "$live"
+while test ! -s "$tmp/zpid" && kill -0 "$live" 2>/dev/null; do :; done
+zombie=$(<"$tmp/zpid")
+test -n "$zombie" || fail "the zombie fixture never started"
+kill -9 "$zombie" 2>/dev/null || true
+REAP_GRACE=1 reap_bounded "$zombie" ||
+    fail "reap_bounded waited out its grace on a killed process nobody had collected"
+REAP_GRACE=1 reap_bounded "$live" && fail "reap_bounded called a running process reaped"
+ok "reap_bounded reads a killed-but-uncollected process as stopped, a live one as running"
+
 : >"$tmp/progress"
 : >"$tmp/childpid"
 began=$SECONDS

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -1214,21 +1214,33 @@ REAP_GRACE=${REAP_GRACE:-10}
 # Has pid $1 died and not yet been collected? A killed process answers kill -0
 # until a parent waits on it, and a caller that is not that parent never can: the
 # reap falls to whoever inherits the orphan, prompt on a workstation and not on a
-# Debian buildd, where it reddened 250 twice. The state is the honest question, so
-# ask ps by its POSIX keyword, then /proc where a build root has no procps
-# (#1021). A host that answers neither way keeps waiting, as before.
+# Debian buildd, where it reddened 250 twice. The state is the honest question.
+# /proc first, and only then ps: reap_bounded polls this, and one caller polls it
+# with the broken tick of #1038 still on PATH, where the loop spins at full speed
+# and a forked ps would run thousands of times. Linux, which is where the failure
+# is reported, then forks nothing; macOS takes the ps route, whose POSIX keyword
+# is what ps_snapshot already relies on. Trimmed, since a padded column would
+# read as neither state.
 pid_is_zombie() { # pid_is_zombie PID
     local st
-    st=$(ps -o state= -p "$1" 2>/dev/null) || st=
-    if test -z "$st"; then
-        { read -r st <"/proc/$1/stat"; } 2>/dev/null || return 1
+    if { read -r st <"/proc/$1/stat"; } 2>/dev/null; then
         st=${st##*') '}
         st=${st%% *}
+    else
+        st=$(ps -o state= -p "$1" 2>/dev/null) || st=
+        st=${st//[[:space:]]/}
     fi
     case $st in
     Z*) return 0 ;;
     esac
     return 1
+}
+
+# Will this host say what pid $1 is doing? Neither route is a given: a build root
+# may have no procps, and a container or a hidepid mount no readable /proc. Asked
+# per pid, since hidepid answers for the caller's own and for nothing else.
+pid_state_readable() { # pid_state_readable PID
+    test -r "/proc/$1/stat" || test -n "$(ps -o state= -p "$1" 2>/dev/null)"
 }
 
 reap_bounded() {

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -1210,9 +1210,31 @@ budget_left() {
 # and a bare `wait` then blocks the watchdog itself forever, so the timeout it was
 # about to report is never printed and the whole suite wedges silently.
 REAP_GRACE=${REAP_GRACE:-10}
+
+# Has pid $1 died and not yet been collected? A killed process answers kill -0
+# until a parent waits on it, and a caller that is not that parent never can: the
+# reap falls to whoever inherits the orphan, prompt on a workstation and not on a
+# Debian buildd, where it reddened 250 twice. The state is the honest question, so
+# ask ps by its POSIX keyword, then /proc where a build root has no procps
+# (#1021). A host that answers neither way keeps waiting, as before.
+pid_is_zombie() { # pid_is_zombie PID
+    local st
+    st=$(ps -o state= -p "$1" 2>/dev/null) || st=
+    if test -z "$st"; then
+        { read -r st <"/proc/$1/stat"; } 2>/dev/null || return 1
+        st=${st##*') '}
+        st=${st%% *}
+    fi
+    case $st in
+    Z*) return 0 ;;
+    esac
+    return 1
+}
+
 reap_bounded() {
     local pid=$1 start=$SECONDS
     while kill -0 "$pid" 2>/dev/null; do
+        if pid_is_zombie "$pid"; then break; fi
         test "$((SECONDS - start))" -le "$REAP_GRACE" || return 1
         poll_wait 1
     done


### PR DESCRIPTION
`reap_bounded` waits for a killed process by polling `kill -0`, which keeps succeeding while that process is an unreaped zombie. Its callers are usually the dead process's uncle and can never `wait()` it. So whether the poll ends depends on who inherits the orphan and how promptly that reaper runs. On this box it is immediate. On a Debian buildd it can outlast the five second grace, and `250_timeout-poll-nofork` then reports a live process the guard had already killed.

That is the second time this race has reddened an unrelated pull request. `d3c68be5` widened a single `kill -0` probe into the current bounded wait for it in August. This amends that fix rather than writing the first one, because widening a timeout only moves the threshold until the next slower host.

The fix asks the question the caller actually has. `pid_is_zombie` reads the process state, and `reap_bounded` stops waiting on `Z`. The loop now answers "has it stopped running" instead of "has someone collected it". The `wait` after the loop is unchanged, so a caller waiting on its own child still gets a status. It goes in the shared helper rather than in the test, because the other callers ask the same wrong question.

`/proc/PID/stat` field 3 comes first, and `ps -o state= -p PID` is the fallback. That order matters more than it looks. `250_timeout-poll-nofork` exists for the host whose `poll_wait` tick cannot exec (#1038). On that host the loop spins at full speed, so a probe that forks would fork every iteration. Measured with the tick forced to fail and a three second grace: `ps` first gives 232 forks, `/proc` first gives none. Linux buildds, where the reported failure happens, now fork nothing in that loop, and macOS keeps the `ps` route where `poll_wait` forks anyway.

The `/proc` field is parsed the way `proc_snapshot` does it, since a process name can contain spaces and brackets. The `ps` column is stripped of padding, because a left-padded state would otherwise read as unknown and quietly put macOS back on the old behaviour.

A pid whose state neither route can read is graded by neither. The check is per pid rather than per host. A `hidepid` mount answers for the shell's own entry and for nothing else. Asking once about the host would claim an observability it does not have. `reap_bounded` then waits exactly as it does today, and the test says so instead of asserting.

The test now reproduces it on demand. A fixture whose parent `exec`s leaves its killed child as a zombie nobody collects, which is the state a buildd leaves the wedged test in. That control fails against master's `reap_bounded` and passes with the fix.