### PR TITLE
Test 84 crawls a URL the fixture does not route

### DIFF
--- a/tests/84_webhttrack-mirror-verbatim.test
+++ b/tests/84_webhttrack-mirror-verbatim.test
@@ -83,14 +83,19 @@ while :; do
         fail "the crawl never showed as running: $(<"${HTS_LOG}")"
     poll_wait 0.2
 done
-cp "${mirror}" "${work}/crawl/hostile.html"
+# The same payload, plus a line naming which project it came from: the profile
+# save left an identical hostile.html in proj, so comparing against that one
+# would pass even if /website/ never followed the crawl.
+crawled="${work}/crawl/hostile.html"
+cp "${mirror}" "${crawled}"
+echo "served from the crawl project" >>"${crawled}"
 
 htsserver_client --path /website/hostile.html --head-file "${hdr}" --body-file "${body}"
 grep -q '^HTTP/1\.0 200 ' "${hdr}" ||
     fail "running crawl: /website/ was not served: $(head -1 "${hdr}")"
 # cmp, not a "not the GUI page" check: that is only one of the wrong answers.
-cmp -s "${mirror}" "${body}" ||
-    fail "running crawl: /website/ did not serve the mirror byte for byte"
+cmp -s "${crawled}" "${body}" ||
+    fail "running crawl: /website/ served $(head -c 120 "${body}") instead of the crawl project"
 
 # A crawl ending mid-probe leaves the checks above reading the finished pane and
 # passing for the wrong reason, so pin the state they ran in.

--- a/tests/84_webhttrack-mirror-verbatim.test
+++ b/tests/84_webhttrack-mirror-verbatim.test
@@ -59,7 +59,7 @@ grep -qi '^Content-type: text/html' "${hdr}" ||
     fail "mirrored page lost its text/html type: $(<"${hdr}")"
 
 # The other direction: a running crawl rebinds /website/ to the new project, so
-# plant the probe there. /trickle/ dribbles for a minute, which holds it open.
+# plant the probe there. p0.bin dribbles for a minute, which holds it open.
 clog="${work}/content.log"
 "${HTS_PYTHON}" "${testdir}/local-server.py" --root "${work}" >"${clog}" 2>&1 &
 csrv=$!
@@ -68,7 +68,7 @@ cport=$(discover_server_port "${clog}" "${csrv}") ||
 
 htsserver_client --path /step4.html --field "sid=${sid}" --field "path=${work}" \
     --field projname=crawl --field winprofile=x --field command_do=start \
-    --field "command=httrack --quiet --robots=0 http://127.0.0.1:${cport}/trickle/ -O ${work}/crawl" \
+    --field "command=httrack --quiet --robots=0 http://127.0.0.1:${cport}/trickle/p0.bin -O ${work}/crawl" \
     >/dev/null
 
 # command_do=start saves the profile before it starts the engine, and the save alone
@@ -83,7 +83,6 @@ while :; do
         fail "the crawl never showed as running: $(<"${HTS_LOG}")"
     poll_wait 0.2
 done
-test -d "${work}/crawl" || fail "the crawl is running but created no project"
 cp "${mirror}" "${work}/crawl/hostile.html"
 
 htsserver_client --path /website/hostile.html --head-file "${hdr}" --body-file "${body}"
@@ -92,5 +91,11 @@ grep -q '^HTTP/1\.0 200 ' "${hdr}" ||
 # cmp, not a "not the GUI page" check: that is only one of the wrong answers.
 cmp -s "${mirror}" "${body}" ||
     fail "running crawl: /website/ did not serve the mirror byte for byte"
+
+# A crawl ending mid-probe leaves the checks above reading the finished pane and
+# passing for the wrong reason, so pin the state they ran in.
+htsserver_client --path /server/index.html >"${work}/pane.txt"
+grep -qF 'In progress:' "${work}/pane.txt" ||
+    fail "the crawl ended during the probes, so /website/ never faced a running one"
 
 echo "PASS"


### PR DESCRIPTION
`84_webhttrack-mirror-verbatim.test` crawls `http://127.0.0.1:$cport/trickle/`, and `tests/local-server.py` does not route it. The table registers `/trickle/index.html` and `/trickle/p0.bin` through `p7.bin`, so the request falls through to `SimpleHTTPRequestHandler` over an empty root and 404s. The mirror is then over almost at once.

`In progress:` is shown while `commandRunning` is set, which lasts as long as the crawl. Measured through the server, the marker is visible for **0s** on `/trickle/` and **59s** on `/trickle/p0.bin`. The poll spawns a fresh interpreter per sample, so it has been racing a sub-second window. That is why the failure is marginal, and why raising the `make check` width in #1541 surfaced it. Tests 319 and 371 already crawl `p0.bin`.

This test was passing for the wrong reason. Its `/website/` checks exist to prove a running crawl rebinds that path, and they have been running against a finished engine. They now face a live crawl, and a closing check pins that they did, the way 371 pins the same thing. The comparison also had to change. The profile save left an identical `hostile.html` in the other project, so serving that one compared equal and hid a rebind that never happened.

The dropped assertion could not fail. `command_do=start` saves the profile before starting the engine, and the save creates the project directory (`src/htsserver.c:1544`), so `test -d "${work}/crawl"` was already true. That is the vacuity #1529 removed from the wait, left behind in the check under it.