### PR TITLE
--updatehttrack exits 0 and mirrors nothing

### DIFF
--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -922,15 +922,15 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
             strlcpybuff(argv[i] + 1, "#P", strlen(argv[i] + 1) + 1);
             //
           } else if (strfield2(argv[i] + 2, "updatehttrack")) {
-#ifdef _WIN32
+            /* Never implemented anywhere, and refusing it stops the untouched
+               string being re-walked as the cluster -u -p -d -a -t -e -h, whose
+               h exits 0 with an empty mirror. */
             char s[HTS_CDLMAXSIZE + 256];
 
-            slprintfbuff_clip(s, sizeof(s), "%s not available in this version",
-                              argv[i]);
+            slprintfbuff_clip(s, sizeof(s), "%s is not implemented", argv[i]);
             HTS_PANIC_PRINTF(s);
             htsmain_free();
             return -1;
-#endif
           }
           //
           else {

--- a/tests/428_cli-updatehttrack.test
+++ b/tests/428_cli-updatehttrack.test
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# --updatehttrack was recognised and then left in argv, so the main option loop
+# re-read it letter by letter as -u -p -d -a -t -e -h and the h printed the
+# usage and returned 0. A script could not tell that nothing had been mirrored.
+
+set -euo pipefail
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=tests/testlib.sh
+. "${testdir}/testlib.sh"
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_updopt.XXXXXX") || fail "no tmpdir"
+cleanup() {
+    rm -rf "${tmp}"
+}
+trap 'set +e; cleanup' EXIT
+trap 'set +e; cleanup; exit 1' HUP INT QUIT TERM
+
+require_httrack
+echo '<html><body>hello</body></html>' >"${tmp}/page.html"
+mirrored="${tmp}/out/file${tmp}/page.html"
+usage_marker='with options listed below'
+
+crawl() { # crawl ARG...
+    rm -rf "${tmp}/out"
+    mkdir -p "${tmp}/out"
+    RC=0
+    httrack "file://${tmp}/page.html" -O "${tmp}/out" --quiet "$@" \
+        >"${tmp}/run.log" 2>&1 || RC=$?
+    LOG=$(cat "${tmp}/run.log")
+}
+
+# The fixture mirrors, so an empty mirror below means the option stopped it and
+# not that nothing was reachable.
+crawl
+assert_eq 0 "${RC}" "plain crawl exited"
+assert_file "${mirrored}" "plain crawl"
+assert_eq 0 "$(count_matching_lines "${usage_marker}" "${tmp}/run.log")" \
+    "plain crawl printed the usage"
+
+# -h is what the cluster's last letter reached, and it is also the control that
+# the marker fires at all.
+crawl -h
+assert_eq 1 "$(count_matching_lines "${usage_marker}" "${tmp}/run.log")" \
+    "-h printed the usage"
+ok "the fixture mirrors, and the usage marker fires on -h"
+
+# The bug's whole signature: usage on stdout, exit 0, nothing mirrored.
+crawl --updatehttrack
+test "${RC}" -ne 0 ||
+    fail "--updatehttrack exited 0, mirroring $(mirror_names "${tmp}/out")"
+test ! -f "${mirrored}" ||
+    fail "--updatehttrack mirrored ${mirrored}, so it ran as a crawl"
+assert_eq 0 "$(count_matching_lines "${usage_marker}" "${tmp}/run.log")" \
+    "--updatehttrack printed the usage"
+grep -qF -- '--updatehttrack' <<<"${LOG}" ||
+    fail "--updatehttrack failed without naming itself: ${LOG}"
+ok "--updatehttrack is refused instead of walked as a cluster"
+
+# Its neighbours in the same else-chain neutralize or rewrite argv, so the
+# refusal must not have cost them their crawl.
+crawl --clean
+assert_eq 0 "${RC}" "--clean exited"
+assert_file "${mirrored}" "--clean"
+ok "--clean still mirrors after erasing the cache"


### PR DESCRIPTION
`httrack --updatehttrack <url> -O out` prints the usage, mirrors nothing and exits 0. A script cannot tell it failed, which is what separates this from the other options the same dead-code sweep found. Each of those still finishes its crawl.

The `--xxx` chain in `htscoremain.c` recognises the option and then leaves `argv[i]` untouched, where `--clean` blanks it and `--catchurl` rewrites itself to `-#P`. The main option loop reads the surviving string letter by letter. So `u`, `p`, `d`, `a`, `t` and `e` are applied as real options, and the `h` calls `help()` and returns 0. Spelling it `-updatettrack` mirrors normally, which is how the letters before the `h` were shown to reach the parser.

Refusing the option loses nothing. Its POSIX body has been `#if 0` since the 3.20.2 import and was deleted by #498, leaving an arm that is empty unless `_WIN32`. Windows has always answered `not available in this version` and returned -1. This makes that refusal unconditional and rewords it, because no version of HTTrack has ever had the feature. `--updatehttrack` is in the alias table but in neither `--help` nor the man page, so nothing documented changes.

`428_cli-updatehttrack.test` pins the empty-mirror property rather than the exit status alone. It first proves the `file://` fixture mirrors and that the usage marker fires on `-h`. Then it requires the `--updatehttrack` run to be non-zero, to leave no mirrored page, to print no usage and to name the option it refused. It fails on master. `--clean` is crawled alongside it, because a change in that chain could cost a neighbour its mirror.

The same class has no other members. `--clean`, `--tide` and `--catchurl` are the only other long options the chain recognises, and every one of them rewrites `argv[i]`. Anything else `--` reaches the chain's `else` and is refused already.
