### PR TITLE
The WARC validator never checked a mandatory field

### DIFF
--- a/tests/warc-validate.py
+++ b/tests/warc-validate.py
@@ -28,6 +28,7 @@
 #                             requires the payload digest when the file emits any
 import base64
 import hashlib
+import re
 import sys
 import zlib
 
@@ -51,6 +52,32 @@ def field(header, name):
         if line.lower().startswith(name.lower() + b":"):
             return line.split(b":", 1)[1].strip()
     return None
+
+
+# WARC/1.1 (ISO 28500:2017) 5.2-5.5 make WARC-Record-ID, Content-Length,
+# WARC-Date and WARC-Type mandatory on every record; 5.12 makes
+# WARC-Target-URI mandatory for the types below and optional elsewhere.
+URI_TYPES = (
+    b"request",
+    b"response",
+    b"resource",
+    b"revisit",
+    b"conversion",
+    b"continuation",
+)
+# 5.4: a UTC W3C-ISO8601 timestamp, with the fractional seconds 1.1 allows.
+DATE_RE = re.compile(rb"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$")
+# 5.2: an absolute URI in angle brackets, globally unique.
+ID_RE = re.compile(rb"^<[A-Za-z][A-Za-z0-9+.\-]*:[^<>\s]+>$")
+
+
+def mandatory(header, name, total):
+    """Return a mandatory field, or exit. field() answers None when the field is
+    absent and b"" when it is present but empty, and both violate the spec."""
+    value = field(header, name)
+    if not value:
+        sys.exit("record %d: missing mandatory %s" % (total, name.decode()))
+    return value
 
 
 def opt_values(argv, name):
@@ -145,9 +172,9 @@ def main():
             sys.exit("record %d: no header terminator" % total)
         hdr_end = sep + 4
         header = rec[:sep]
-        cl = field(header, b"Content-Length")
-        if cl is None:
-            sys.exit("record %d: no Content-Length" % total)
+        cl = mandatory(header, b"Content-Length", total)
+        if not cl.isdigit():
+            sys.exit("record %d: non-numeric Content-Length %r" % (total, cl))
         block_len = int(cl)
         if hdr_end + block_len + 4 != len(rec):
             sys.exit(
@@ -156,8 +183,22 @@ def main():
             )
         if rec[hdr_end + block_len :] != b"\r\n\r\n":
             sys.exit("record %d: missing \\r\\n\\r\\n trailer" % total)
-        wtype = field(header, b"WARC-Type")
+        wtype = mandatory(header, b"WARC-Type", total)
+        rec_id = mandatory(header, b"WARC-Record-ID", total)
+        if not ID_RE.match(rec_id):
+            sys.exit(
+                "record %d: WARC-Record-ID %r is not <absolute-URI>" % (total, rec_id)
+            )
+        wdate = mandatory(header, b"WARC-Date", total)
+        if not DATE_RE.match(wdate):
+            sys.exit(
+                "record %d: WARC-Date %r is not a UTC ISO8601 stamp" % (total, wdate)
+            )
         uri = field(header, b"WARC-Target-URI") or b""
+        if wtype in URI_TYPES and not uri:
+            sys.exit(
+                "record %d: %s record has no WARC-Target-URI" % (total, wtype.decode())
+            )
         if wtype in (b"response", b"revisit", b"resource"):
             for sub in no_record:
                 if sub.encode() in uri:
@@ -229,7 +270,7 @@ def main():
                         "revisit for %s does not carry the 304 it stands for: %r"
                         % (shown, block.split(b"\r\n", 1)[0])
                     )
-                exchanges.append((shown, field(header, b"WARC-Record-ID")))
+                exchanges.append((shown, rec_id))
         elif wtype == b"request":
             conc = field(header, b"WARC-Concurrent-To")
             if conc is not None:


### PR DESCRIPTION
`tests/warc-validate.py` never asked for most of the fields WARC/1.1 makes mandatory. Renaming `WARC-Date` in the engine's output left all twenty WARC tests green, and renaming `WARC-Record-ID` left eighteen.

The validator read `Content-Length` and nothing else that the spec requires. `WARC-Date` appeared in no lookup at all. `WARC-Record-ID` was read only under `--revisit-exchange`, where its absence surfaced as "revisit has no request record" rather than as a missing mandatory field. `WARC-Target-URI` was masked by `or b""`, so a record with no URI dropped out of every substring test instead of failing one. `warcio check` catches all of this, but it sits behind a `command -v`, so a host without warcio validated almost nothing about record structure. That is the configuration most hosts run, including this one.

Every record now has to carry `WARC-Type`, `WARC-Record-ID`, `WARC-Date` and `Content-Length`, per ISO 28500:2017 sections 5.2 to 5.5. Section 5.12 adds `WARC-Target-URI` on six of the types. A `warcinfo` record keeps no URI obligation, so the engine's own output is unaffected. Values are checked too. The record id is an absolute URI in angle brackets, the date a UTC ISO8601 stamp, the content length decimal digits. Presence alone would have killed both mutants, but a field emitted empty is as unreplayable as one left out.

Proof both ways, on a host with no warcio installed. Renaming either field in `htswarc.c` now fails all six tests that run the validator, naming the field. Unmodified output passes the full suite. Every new arm was fired against a synthetic record, each paired with a valid control.

`tests/wacz-validate.py` does not share the defect. Its `.get()` results are each compared against a required literal, so an absent key becomes `None` and fails the comparison. Renaming `wacz_version`, `data-package` and `json-pages-1.0` in the engine kills it three times out of three.
