### PR TITLE
Three macros are defined, and none of them does what it looks like

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -388,12 +388,10 @@ AM_CFLAGS="$AM_CFLAGS $CFLAG_VISIBILITY"
 AC_SUBST([AM_CFLAGS])
 
 ### Check for platform
-#case $host in
-#AIX) AC_DEFINE(HTS_PLATFORM, 1, [Defined to build under AIX]);;
-#*-solaris*) AC_DEFINE(HTS_PLATFORM, 2, [Defined to build under solaris]);;
-#*-linux-gnu | *-irix6*) AC_DEFINE(HTS_PLATFORM, 3, [Defined to build under Linux]);;
-#*) AC_DEFINE(HTS_PLATFORM, 3, [Default value used]);;
-#esac
+dnl htshelp.c prints this, so a bug report names the build it came from. The
+dnl hand-written Makefile.in that used to supply it went away with autoconf.
+AC_DEFINE_UNQUOTED([HTS_PLATFORM_NAME], ["$host"],
+	[Canonical host triplet, printed by --help])
 
 ### Probe long long size for 64-bit integer support. SIZEOF_LONG is not probed:
 ### it varies by architecture and would break Multi-Arch co-installation of

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -2347,7 +2347,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
               default:{
                   char s[HTS_CDLMAXSIZE + 256];
 
-                  sprintf(s, "invalid option %%%c\n", *com);
+                  sprintf(s, "invalid option @%c\n", *com);
                   HTS_PANIC_PRINTF(s);
                   htsmain_free();
                   return -1;

--- a/src/htshelp.c
+++ b/src/htshelp.c
@@ -53,6 +53,19 @@ Please visit our Website: http://www.httrack.com
 #endif
 /* END specific definitions */
 
+/* configure names the host triplet; MSVC has no config.h to carry one. */
+#ifndef HTS_PLATFORM_NAME
+#if defined(_M_ARM64)
+#define HTS_PLATFORM_NAME "windows-arm64"
+#elif defined(_M_AMD64)
+#define HTS_PLATFORM_NAME "windows-x64"
+#elif defined(_M_IX86)
+#define HTS_PLATFORM_NAME "windows-x86"
+#else
+#define HTS_PLATFORM_NAME "unknown"
+#endif
+#endif
+
 #define waitkey if (more) { char s[4]; printf("\nMORE.. q to quit\n"); linput(stdin,s,4); if (strcmp(s,"q")==0) quit=1; else printf("Page %d\n\n",++m); }
 void infomsg(const char *msg) {
   int l = 0;
@@ -183,16 +196,7 @@ void help_wizard(httrackp * opt) {
   printf("Note: You are running the commandline version,\n");
   printf("run 'WinHTTrack.exe' to get the GUI version.\n");
 #endif
-#ifdef HTTRACK_AFF_WARNING
-  printf("NOTE: " HTTRACK_AFF_WARNING "\n");
-#endif
-#ifdef HTS_PLATFORM_NAME
-#if USE_BEGINTHREAD
   printf("[compiled: " HTS_PLATFORM_NAME " - MT]\n");
-#else
-  printf("[compiled: " HTS_PLATFORM_NAME "]\n");
-#endif
-#endif
   printf("To see the option list, enter a blank line or try httrack --help\n");
   //
   // Project name
@@ -478,9 +482,6 @@ void help(const char *app, int more) {
             "HTTrack version " HTTRACK_VERSION "%s",
             hts_is_available());
     infomsg(info);
-#ifdef HTTRACK_AFF_WARNING
-    infomsg("NOTE: " HTTRACK_AFF_WARNING);
-#endif
     snprintf(info, sizeof(info),
             "\tusage: %s <URLs> [-option] [+<URL_FILTER>] [-<URL_FILTER>] [+<mime:MIME_FILTER>] [-<mime:MIME_FILTER>]",
             app);
@@ -824,8 +825,6 @@ void help(const char *app, int more) {
            "Copyright (C) 1998-%s Xavier Roche and other contributors",
            &__DATE__[7]);
   infomsg(info);
-#ifdef HTS_PLATFORM_NAME
   infomsg("[compiled: " HTS_PLATFORM_NAME "]");
-#endif
   infomsg(NULL);
 }

--- a/src/htsweb.c
+++ b/src/htsweb.c
@@ -305,10 +305,10 @@ int main(int argc, char *argv[]) {
 #if HTS_USEOPENSSL
   smallserver_setkey("USEOPENSSL", "1");
 #endif
-#ifdef HTS_DLOPEN
+#if HTS_DLOPEN
   smallserver_setkey("DLOPEN", "1");
 #endif
-#ifdef HTS_USESWF
+#if HTS_USESWF
   smallserver_setkey("USESWF", "1");
 #endif
   smallserver_setkey("USEZLIB", "1");

--- a/tests/429_defined-but-inert.test
+++ b/tests/429_defined-but-inert.test
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# Three things the tree defines but does not act on. htsglobal.h gives
+# HTS_DLOPEN a value on both arms, so htsweb.c's #ifdef was always true and a
+# build without dlopen still advertised DLOPEN=1 to the web UI (the #1552 class,
+# there for HTS_INET6). The -@ option set reported a bad option under the '%'
+# prefix, naming a character the user did not type. And HTS_PLATFORM_NAME was
+# used but defined nowhere, so --help printed no [compiled: ...] line.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_inert.XXXXXX") || exit 1
+cleanup_push rm -rf "$tmp"
+
+# --- the option set that refuses the option names itself ---------------------
+# 'Q' is in neither the '%' set nor the '@' set, so the same letter reaches both
+# default arms and the prefix is the only thing that can differ.
+refusal() { # refusal ARG
+    local rc=0
+    httrack "$1" http://127.0.0.1:1/ >"$tmp/refuse.out" 2>&1 || rc=$?
+    test "$rc" -ne 0 || fail_dump "$1 was accepted" "$tmp/refuse.out"
+    firstline "$(cat "$tmp/refuse.out")"
+}
+
+got=$(refusal -%Q)
+assert_eq "* invalid option %Q" "$got" "the % set"
+got=$(refusal -@Q)
+assert_eq "* invalid option @Q" "$got" "the @ set"
+
+# --- --help says which build it came from ------------------------------------
+httrack --help >"$tmp/help.out" 2>&1 || fail_dump "--help failed" "$tmp/help.out"
+compiled=$(sed -n 's/^\[compiled: \(.*\)\]$/\1/p' "$tmp/help.out")
+test -n "$compiled" || fail_dump "--help printed no [compiled: ...] line" "$tmp/help.out"
+# "unknown" is htshelp.c's last-resort fallback: reaching it means the build
+# passed no platform down, which is the state this pins against.
+test "$compiled" != unknown || fail "--help names the platform as \"unknown\""
+
+# --- a build without dlopen must not advertise DLOPEN ------------------------
+# Only the preprocessor can see this: nothing here can relink httrack without
+# libdl. Shadow the two headers that carry DLLIB, then preprocess htsweb.c.
+if [ -z "${abs_top_builddir:-}" ] || [ -z "${abs_top_srcdir:-}" ]; then
+    skip "no automake environment"
+fi
+read -r -a cc_argv <<<"${CC:-cc}"
+command -v "${cc_argv[0]}" >/dev/null 2>&1 || skip "no C compiler (${cc_argv[0]})"
+
+web=$abs_top_srcdir/src/htsweb.c
+[ -f "$web" ] || fail "$web is missing"
+
+mkdir -p "$tmp/nodl"
+for h in config.h htsfeatures.h; do
+    [ -f "$abs_top_builddir/$h" ] || skip "$abs_top_builddir/$h is missing"
+    sed 's|^#define DLLIB 1|/* #undef DLLIB */|' "$abs_top_builddir/$h" >"$tmp/nodl/$h"
+done
+grep -q '^/\* #undef DLLIB \*/$' "$tmp/nodl/config.h" ||
+    fail "config.h no longer defines DLLIB the way this test strips it"
+
+cpp_argv=(-E -I"$tmp/nodl" -I"$abs_top_builddir" -I"$abs_top_builddir/src"
+    -I"$abs_top_srcdir/src" -I"$abs_top_srcdir/src/coucal" -I"$abs_top_srcdir/src/minizip"
+    -DHTS_INTERNAL_BUILD -DHAVE_CONFIG_H)
+if [ -n "${TEST_CPPFLAGS:-}" ]; then
+    read -r -a extra_argv <<<"$TEST_CPPFLAGS"
+    cpp_argv+=("${extra_argv[@]}")
+fi
+"${cc_argv[@]}" "${cpp_argv[@]}" "$web" >"$tmp/nodl.i" 2>"$tmp/nodl.err" ||
+    skip "cannot preprocess htsweb.c here: $(firstline "$(cat "$tmp/nodl.err")")"
+
+# HTS_DLOPEN really is 0 in this shadow, and the block really was reached: an
+# empty or truncated preprocessor output would satisfy the DLOPEN check alone.
+printf '#include "htsglobal.h"\nPROBE HTS_DLOPEN\n' >"$tmp/probe.c"
+"${cc_argv[@]}" "${cpp_argv[@]}" "$tmp/probe.c" >"$tmp/probe.i" 2>/dev/null ||
+    fail "the probe TU did not preprocess"
+assert_eq "PROBE 0" "$(sed -n 's/^PROBE .*/&/p' "$tmp/probe.i" | tail -1)" "HTS_DLOPEN without DLLIB"
+grep -q 'smallserver_setkey("USEZLIB"' "$tmp/nodl.i" ||
+    fail "the preprocessed htsweb.c carries no key at all, so the check below proves nothing"
+
+! grep -q 'smallserver_setkey("DLOPEN"' "$tmp/nodl.i" ||
+    fail "a build without dlopen still publishes DLOPEN=1 to the web UI"
+
+echo "ok: the @ set, the platform name and the dlopen key all report what the build did"


### PR DESCRIPTION
A dead-code sweep found three places where a name is defined, so the code reads as live. Each does something other than what it looks like.

`htsglobal.h` gives `HTS_DLOPEN` a value on both arms, 1 or 0, so `htsweb.c`'s `#ifdef` was always true. A build without dlopen still published `DLOPEN=1` to the WebHTTrack UI. That is the class #1552 fixed for `HTS_INET6`, two lines up in the same file, and it follows the same shape: `#if`, not `#ifdef`. `HTS_USESWF` beside it has the identical shape, but nothing in either tree sets it to 0, so changing that one is form rather than behaviour. A sweep over every macro `htsglobal.h` or `configure.ac` gives a literal 0 on some arm turned up no other `#ifdef` on one. The `HTS_USEICONV` sites already test `== 0` explicitly.

The `-@` option set reported an unknown option under the `%` prefix. `-@z` answered `invalid option %z`, naming a character the user did not type, and `-%Q` and `-@Q` were indistinguishable. The block is a copy of the `%` set's, and the `%` set and the top-level set were both already right.

`HTS_PLATFORM_NAME` lost its definition in the 2012 autoconf migration, which dropped the hand-written `src/Makefile.in` that wrote it into a generated `htssystem.h`. `--help` has printed no `[compiled: ...]` line since. The platform is worth having in a bug report, so configure now supplies the canonical host triplet. `htshelp.c` names the architecture from the compiler's own macros for MSVC, which gets no `config.h`. The wizard banner's non-threaded arm went with it, because `USE_BEGINTHREAD` is defined 1 with no other arm and `htsthread.h` refuses to build without it.

`HTTRACK_AFF_WARNING` goes the other way and is deleted. It was a maintainer's beta banner. Its only trace was a commented-out template in `htsglobal.h` that has itself been removed, so nothing documented it and no portable value exists. WinHTTrack carries the same dead block, which is httrack-windows' to decide on.

`--version` is untouched. Its output is a single line that scripts parse, and the `[compiled: ...]` line was never printed there.

`429_defined-but-inert.test` pins all three. Each assertion fails on master on its own, checked by building master with the test dropped in and running the three in isolation. The dlopen one is preprocessor-level, because nothing in the suite can relink httrack without libdl. It shadows the two headers that carry `DLLIB` and preprocesses `htsweb.c` against them. It then asserts both that `HTS_DLOPEN` really reached 0 and that some other key still survives, so an empty output cannot pass it.
