### PR TITLE
Three tests cannot see the one-byte error they exist for

### DIFF
--- a/tests/01_engine-identurl.test
+++ b/tests/01_engine-identurl.test
@@ -19,10 +19,38 @@ split 'file:///etc/hostname' 'adr=file:// fil=/etc/hostname'
 # empty-path file:// used to read one byte past the URL (p[1] with *p=0)
 split 'file://' 'adr=file:// fil=//'
 
-# a root-relative path is copied whole into fil[HTS_URLMAXSIZE*2], so a URL at
-# the buffer size is the tightest overflow; it must be rejected, not abort.
+# ident_url_absolute() rejects a URL of HTS_URLMAXSIZE*2 bytes or more before
+# anything is copied into fil[HTS_URLMAXSIZE*2]. Read the constant out of the
+# header so the cases below stay ON the boundary if it ever moves.
+urlmaxsize=$(sed -n \
+    's/^#define HTS_URLMAXSIZE[[:space:]][[:space:]]*\([0-9][0-9]*\).*/\1/p' \
+    "${top_srcdir:-..}/src/htsglobal.h")
+case $urlmaxsize in '' | *[!0-9]*) fail "cannot read HTS_URLMAXSIZE" ;; esac
+limit=$((urlmaxsize * 2))
+
 split_pad() { selftest_queue "$3" identurl "$1" "$2"; }
-split_pad '/' 2047 'error' # 1 + 2047 = 2048 = HTS_URLMAXSIZE*2
+
+# One byte under the limit, exactly on it, one byte over. The accepted case pins
+# the whole string it yields: on its own, 'error' at the limit is satisfied by
+# any URL the parser refuses for an unrelated reason, and by a guard that starts
+# rejecting a kilobyte early.
+boundary() { # boundary BASE WANT-ADR
+    local base=$1 adr=$2
+    local pad=$((limit - 1 - ${#base}))
+    split_pad "$base" "$pad" "$adr fil=/$(repeat_chars "$pad")"
+    split_pad "$base" "$((pad + 1))" 'error'
+    split_pad "$base" "$((pad + 2))" 'error'
+}
+
+# http:// meets a second bound on fil[] further down; file:// meets none, so
+# there the top guard is all that stands between the path and an abort inside
+# strcatbuff().
+boundary 'http://h/' 'adr=h'
+boundary 'file:///' 'adr=file://'
+
+# A root-relative URL carries no host, so it is refused at every length and says
+# nothing about the guard.
+split_pad '/' "$((limit - 1))" 'error'
 split_pad 'http://h/' 3000 'error'
 
 selftest_run_queued

--- a/tests/390_optscan-enum-cast.test
+++ b/tests/390_optscan-enum-cast.test
@@ -13,13 +13,26 @@ set -euo pipefail
 src="$abs_top_srcdir/src/htscoremain.c"
 test -r "$src" || fail "no $src"
 
-pattern='sscanf[^;]*\([a-z_][a-z_ ]*\*\)[ 	]*&opt->'
+# The type name carries digits (uint8_t, int32_t) as readily as it carries
+# letters, and a class without them silently exempts the fixed-width spellings.
+pattern='sscanf[^;]*\([[:alpha:]_][[:alnum:]_ ]*\*\)[ 	]*&opt->'
 
 # The pattern's silence means nothing until it has matched a known-bad line.
-# The typedef spelling is the likelier one to be written next.
+# Every spelling a cast is likely to be written in, the fixed-width ones
+# included: those are the ones the first version of this class could not match.
 for bad in 'sscanf(com + 1, "%d", (int *) &opt->urlmode);' \
-    'sscanf(com + 1, "%d", (hts_urlmode *) &opt->urlmode);'; do
+    'sscanf(com + 1, "%d", (hts_urlmode *) &opt->urlmode);' \
+    'sscanf(com + 1, "%d", (uint8_t *) &opt->urlmode);' \
+    'sscanf(com + 1, "%d", (int32_t *) &opt->urlmode);' \
+    'sscanf(com + 1, "%d", (unsigned int *) &opt->urlmode);'; do
     grep -qE "$pattern" <<<"$bad" || fail "the pattern cannot match: $bad"
+done
+
+# And a pattern matching everything would be just as silent, so pin the two
+# forms that must stay clear: the direct scan and scanOptInt().
+for good in 'sscanf(com + 1, "%d", &opt->urlmode);' \
+    'scanOptInt(com + 1, &opt->urlmode);'; do
+    grep -qE "$pattern" <<<"$good" && fail "the pattern matches a good line: $good"
 done
 
 found=$(grep -nE "$pattern" "$src" || true)

--- a/tests/423_harness-abort-status.test
+++ b/tests/423_harness-abort-status.test
@@ -70,6 +70,11 @@ run_table() { # run_table SHELL
         check "$sh" readonly 1 no "$cleanup" 'readonly R=1; R=2' >/dev/null
         # The signal traps end on exit 1, which the marker wrapper now intercepts.
         check "$sh" signal 1 no "$cleanup" 'kill -TERM $$; sleep 5' >/dev/null
+        # 'builtin exit' walks past the runner's exit wrapper, so it leaves the
+        # state a 3.2.57 abort leaves: status 0 and no end mark. Every other case
+        # here is decided before the marker is consulted, so on a shell that
+        # reports an abort correctly this is the only one that reaches it.
+        check "$sh" nomark 1 no "$cleanup" 'builtin exit 0' >/dev/null
     done
 }
 
@@ -93,15 +98,20 @@ for sh in "${shells[@]}"; do
 done
 
 test -n "$buggy" ||
-    echo "note: no bash older than 4.2 patch 23 here, so the table only guards the marker" >&2
+    echo "note: no bash older than 4.2 patch 23 here, so the nomark case is what reaches the marker" >&2
 
 # The failure has to name itself: a bare 1 with nothing in the log sends the reader
-# looking for a test that never printed anything.
-if test -n "$buggy"; then
-    # shellcheck disable=SC2016 # the fixture expands it, not us
-    out=$(check "$buggy" unbound 1 no true 'echo "$HTTRACK_UNSET_ON_PURPOSE"')
+# looking for a test that never printed anything. Through the 3.2.57 shape where
+# there is such a shell, through the synthetic one otherwise.
+# shellcheck disable=SC2016 # the fixture expands it, not us
+for sh in "${shells[@]}"; do
+    if test "$sh" = "$buggy"; then
+        out=$(check "$sh" unbound 1 no true 'echo "$HTTRACK_UNSET_ON_PURPOSE"')
+    else
+        out=$(check "$sh" nomark 1 no true 'builtin exit 0')
+    fi
     case $out in
-    *"exited 0 without reaching its end"*) ok "the harness says why it turned a 0 into a failure" ;;
-    *) fail "the abort was reported with no explanation: $out" ;;
+    *"exited 0 without reaching its end"*) ok "$sh: the harness says why it turned a 0 into a failure" ;;
+    *) fail "$sh: the abort was reported with no explanation: $out" ;;
     esac
-fi
+done


### PR DESCRIPTION
Three tests pass on a mutant of the very code they exist to guard. Each fix below was checked both ways: green on master, red on the mutant it names.

`01_engine-identurl` cites the `strlen(url) >= HTS_URLMAXSIZE * 2` guard in `ident_url_absolute()` but never probes it. Its bare `/` case is refused for having no host, at every length. Its other case sits 961 bytes past the limit. So relaxing the guard to `>` leaves the file green. The cases now sit one byte under the limit, on it, and one byte over, on a URL shape the parser accepts. The accepted one pins the whole string it yields. The limit is read out of `htsglobal.h`, so moving `HTS_URLMAXSIZE` moves the cases with it.

Two shapes, because the branches are bounded differently. `http://` meets a second bound on `fil[]` further down. `file://` meets none, so there the top guard is all that stands between a long path and an abort inside `strcatbuff()`. Deleting the guard does abort under ASan, on a `file:///` URL of 2054 bytes. Relaxing it by one byte does not: at exactly 2048 the longest path any branch produces is 2047 bytes plus its terminator, an exact fit. So `>` is an accept/reject off-by-one, not the out-of-bounds write the old comment claimed. That comment is corrected.

`390_optscan-enum-cast` matched a cast with `[a-z_][a-z_ ]*`, which holds no digit. So `(uint8_t *)` and `(int32_t *)` passed where `(int *)` failed. Both of the file's own known-bad controls shared the blind spot, spelling the type `int` and `hts_urlmode`. The self-check therefore kept vouching for a class that could not match. The class now takes digits and capitals. The control list carries the fixed-width spellings, and a second list pins two lines the pattern must not match.

`423_harness-abort-status` guards the abort marker in `test-timeout.sh`, which turns a zero status with no end mark into a failure. Only a bash that forgets the status of an aborted script reaches it. So on Linux you can delete the marker and 423, 105 and 103 all still pass. A new case exits through `builtin exit 0`. That walks past the runner's `exit` wrapper and leaves the state a 3.2.57 abort leaves: status 0, no mark. It reaches the marker on any bash. The explanation the harness prints is now asserted for every shell, not only for a 3.2 one.
