### PR TITLE
A hostile page can abort the crawler, three ways

### DIFF
--- a/src/htsbauth.c
+++ b/src/htsbauth.c
@@ -497,6 +497,12 @@ int bauth_add(t_cookie * cookie, const char *adr, const char *fil, const char *a
       bauth_chain *chain = &cookie->auth;
       char *prefix = bauth_prefix(buffer, adr, fil);
 
+      /* A clipped prefix matches more URLs than were authenticated. */
+      if (strlen(prefix) >= sizeof(chain->prefix) ||
+          strlen(auth) >= sizeof(chain->auth)) {
+        return 0;
+      }
+
       /* fin de la chaine */
       while(chain->next)
         chain = chain->next;

--- a/src/htsbauth.h
+++ b/src/htsbauth.h
@@ -103,7 +103,8 @@ char *cookie_nextfield(char *a);
 
 /** Register credentials (auth = base-64 user:pass) for the prefix derived from
     adr (host) and fil (path). No-op returning 0 if cookie is NULL, allocation
-    fails, or a matching prefix is already stored; returns 1 on insertion. */
+    fails, a matching prefix is already stored, or either string is too long for
+    bauth_chain; returns 1 on insertion. */
 int bauth_add(t_cookie *cookie, const char *adr, const char *fil,
               const char *auth);
 

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -4267,12 +4267,22 @@ HTSEXT_API char *escape_check_url_addr(const char *const src,
 
 // Same as above, but appending to "dest"
 #undef DECLARE_APPEND_ESCAPE_VERSION
+/* clang-format off: an edit realigns all backslashes, churning the macro. */
+/* clang-format off */
 #define DECLARE_APPEND_ESCAPE_VERSION(NAME) \
 HTSEXT_API size_t append_ ##NAME(const char *const src, char *const dest, const size_t size) { \
   const size_t len = strnlen(dest, size); \
   assertf(len < size); \
+  RUNTIME_TIME_CHECK_SIZE(size); \
+  /* The remainder is computed, so the one value the size heuristic reads as \
+     a caller mistake is a legitimate near-full buffer here: report it as the \
+     overflow the caller already tests for. */ \
+  if (size - len == sizeof(void *)) { \
+    return size - len; \
+  } \
   return NAME(src, dest + len, size - len); \
 }
+/* clang-format on */
 
 DECLARE_APPEND_ESCAPE_VERSION(escape_in_url)
 DECLARE_APPEND_ESCAPE_VERSION(escape_spc_url)

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -1272,15 +1272,25 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
 
           if (!direct_url) {    // pas ftp:// par exemple
             char user_pass[256];
+            const size_t idlen = a > astart ? (size_t) (a - astart) - 1 : 0;
 
             user_pass[0] = '\0';
-            strncatbuff(user_pass, astart, (int) (a - astart) - 1);
-            strcpybuff(user_pass, 
-              unescape_http(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt), user_pass));
-            code64((unsigned char *) user_pass, (int) strlen(user_pass),
-                   (unsigned char *) autorisation, 0);
-            if (strcmp(fil, "/robots.txt"))     /* pas robots.txt */
-              bauth_add(cookie, astart, fil, autorisation);
+            /* A clipped credential authenticates as somebody else. */
+            if (idlen < sizeof(user_pass)) {
+              strncatbuff(user_pass, astart, idlen);
+              strcpybuff(user_pass,
+                         unescape_http(OPT_GET_BUFF(opt),
+                                       OPT_GET_BUFF_SIZE(opt), user_pass));
+              code64((unsigned char *) user_pass, (int) strlen(user_pass),
+                     (unsigned char *) autorisation, 0);
+              if (strcmp(fil, "/robots.txt")) /* pas robots.txt */
+                bauth_add(cookie, astart, fil, autorisation);
+            } else {
+              /* 'a' is past the '@': the log gets the host, not the secret. */
+              hts_log_print(
+                  opt, LOG_WARNING,
+                  "authorization dropped, credentials too long for %s", a);
+            }
           }
         } else if ((a = bauth_check(cookie, real_adr, fil)))
           strcpybuff(autorisation, a);

--- a/src/htsname.c
+++ b/src/htsname.c
@@ -528,7 +528,8 @@ int url_savename(lien_adrfilsave *const afs,
     ? hts_convertStringIDNAToUTF8(print_adr, strlen(print_adr))\
     : NULL;\
   /* Punycode can quadruple the host, and a clipped one names another host,\
-     so an over-long decode keeps the ASCII form. */\
+     so an over-long decode keeps the ASCII form. The bound is the pre-IDNA\
+     one and not the save buffer, which still has a path to append. */\
   const char *const FINAL_ADR = \
     (idna_adr != NULL && strlen(idna_adr) < HTS_URLMAXSIZE) \
     ? idna_adr : ( protocol == PROTOCOL_FILE ? "file" : print_adr )

--- a/src/htsname.c
+++ b/src/htsname.c
@@ -514,6 +514,8 @@ int url_savename(lien_adrfilsave *const afs,
   }
 
   /* Declare adr (IDNA-decoded if necessary) */
+  /* clang-format off: an edit realigns all backslashes, churning the macro. */
+  /* clang-format off */
 #define DECLARE_ADR(FINAL_ADR) \
   char *idna_adr =\
     /* http or https */\
@@ -525,8 +527,12 @@ int url_savename(lien_adrfilsave *const afs,
     && hts_isStringIDNA(adr_complete, strlen(print_adr))\
     ? hts_convertStringIDNAToUTF8(print_adr, strlen(print_adr))\
     : NULL;\
-  const char *const FINAL_ADR = idna_adr != NULL \
+  /* Punycode can quadruple the host, and a clipped one names another host,\
+     so an over-long decode keeps the ASCII form. */\
+  const char *const FINAL_ADR = \
+    (idna_adr != NULL && strlen(idna_adr) < HTS_URLMAXSIZE) \
     ? idna_adr : ( protocol == PROTOCOL_FILE ? "file" : print_adr )
+  /* clang-format on */
 
   /* Release adr */
 #define RELEASE_ADR() do {\

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -2946,10 +2946,6 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                             // érire codebase="chemin"
                             if ((opt->getmode & HTS_GETMODE_HTML) &&
                                 (ptr > 0)) {
-                              char BIGSTK tempo4[HTS_URLMAXSIZE * 2];
-
-                              tempo4[0] = '\0';
-
                               if (strnotempty(tempo_pat)) {
                                 HT_ADD("codebase=\"http://");
                                 if (!opt->passprivacy) {
@@ -2963,8 +2959,12 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                 HT_ADD("\" ");
                               }
 
-                              strncatbuff(tempo4, lastsaved, p_flush - lastsaved);
-                              HT_ADD(tempo4);   // refresh code="
+                              /* The page picks this span's width, so it goes
+                                 to the growable output, not a fixed buffer. */
+                              if (p_flush > lastsaved) {
+                                HT_ADD_BUF(lastsaved,
+                                           (size_t) (p_flush - lastsaved));
+                              }
                               HT_ADD(tempo);
                             }
                           }

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -81,6 +81,10 @@ Please visit our Website: http://www.httrack.com
 /** Append to the output buffer the string 'A'. **/
 #define HT_ADD(A) TypedArrayAppend(output_buffer, A, strlen(A))
 
+/* Room a later stage still needs inside lien[]: a scheme it may prepend
+   ("http://") plus a ".class" it may append, and the NUL. */
+#define HTS_LINK_TAIL_ROOM 16
+
 /** Append to the output buffer the first N bytes of 'A' (NUL-stopped). **/
 #define HT_ADD_BUF(A, N)                                                       \
   TypedArrayAppend(output_buffer, A, htssafe_strnlen_(A, N))
@@ -2171,7 +2175,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                     char BIGSTK tempo[sizeof(lien)];
 
                     if (escape_control_url(lien, tempo, sizeof(tempo)) <
-                        sizeof(tempo)) {
+                        sizeof(tempo) - HTS_LINK_TAIL_ROOM) {
                       strcpybuff(lien, tempo);
                     } else {
                       error = 1;
@@ -2193,7 +2197,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                         charset, lien, s);
                       /* One byte can become three, and a clipped URL names
                          another resource, so drop the link instead. */
-                      if (strlen(s) < sizeof(lien)) {
+                      if (strlen(s) < sizeof(lien) - HTS_LINK_TAIL_ROOM) {
                         strcpybuff(lien, s);
                       } else {
                         error = 1;

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -81,6 +81,10 @@ Please visit our Website: http://www.httrack.com
 /** Append to the output buffer the string 'A'. **/
 #define HT_ADD(A) TypedArrayAppend(output_buffer, A, strlen(A))
 
+/** Append to the output buffer the first N bytes of 'A' (NUL-stopped). **/
+#define HT_ADD_BUF(A, N)                                                       \
+  TypedArrayAppend(output_buffer, A, htssafe_strnlen_(A, N))
+
 /* clang-format off: an edit realigns all backslashes, churning the macro. */
 /* clang-format off */
 /** Append 'A' to the output buffer, html-escaped; FACTOR = max byte expansion. **/
@@ -2187,7 +2191,17 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                       hts_log_print(opt, LOG_DEBUG,
                         "engine: save-name: '%s' charset conversion from '%s' to '%s'",
                         charset, lien, s);
-                      strcpybuff(lien, s);
+                      /* One byte can become three, and a clipped URL names
+                         another resource, so drop the link instead. */
+                      if (strlen(s) < sizeof(lien)) {
+                        strcpybuff(lien, s);
+                      } else {
+                        error = 1;
+                        hts_log_print(
+                            opt, LOG_WARNING,
+                            "Link is too long after charset conversion: %s",
+                            lien);
+                      }
                       free(s);
                     }
                   }
@@ -3092,18 +3106,18 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                             // érire codebase="chemin"
                             if ((opt->getmode & HTS_GETMODE_HTML) &&
                                 (ptr > 0)) {
-                              char BIGSTK tempo4[HTS_URLMAXSIZE * 2];
-
-                              tempo4[0] = '\0';
-
                               if (strnotempty(tempo_pat)) {
                                 HT_ADD("codebase=\"");
                                 HT_ADD_HTMLESCAPED(tempo_pat);
                                 HT_ADD("\" ");
                               }
 
-                              strncatbuff(tempo4, lastsaved, p_flush - lastsaved);
-                              HT_ADD(tempo4);   // refresh code="
+                              /* The page picks this span's width, so it goes
+                                 to the growable output, not a fixed buffer. */
+                              if (p_flush > lastsaved) {
+                                HT_ADD_BUF(lastsaved,
+                                           (size_t) (p_flush - lastsaved));
+                              }
                             }
                           }
                         }

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -2248,12 +2248,13 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                   // leaving the encoding as-is (unlike the file part)
                   // and copy back query
                   {
+                    const size_t cap = sizeof(lien) - HTS_LINK_TAIL_ROOM;
                     const size_t used = strlen(lien);
 
                     // the append grows the query too, and clips silently on
                     // overflow: drop, or we fetch a query nobody wrote (#982)
-                    if (append_escape_check_url(query, lien, sizeof(lien)) >=
-                        sizeof(lien) - used) {
+                    if (used >= cap || append_escape_check_url(
+                                           query, lien, cap) >= cap - used) {
                       error = 1;
                       hts_log_print(opt, LOG_DEBUG,
                                     "link rejected (query does not fit) %s",
@@ -2381,6 +2382,14 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
 
                       if (ident_url_relatif(lien, urladr(), urlfil(), &af2) < 0) {
                         error = 1;
+                      } else if (strlen(af2.adr) + strlen(af2.fil) >=
+                                 sizeof(lien) - HTS_LINK_TAIL_ROOM -
+                                     sizeof("http:///")) {
+                        /* the rebuild below is unbounded in the two of them */
+                        error = 1;
+                        hts_log_print(opt, LOG_WARNING,
+                                      "Link is too long once resolved: %s",
+                                      lien);
                       } else {
                         strcpybuff(lien, "http://");
                         strcatbuff(lien, af2.adr);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -3272,6 +3272,35 @@ static int st_sniff(httrackp *opt, int argc, char **argv) {
 
 /* escape_remove_control() compacts in place, so it has to terminate at the new
    end or the caller reads the compacted head plus the original tail (#974). */
+/* append_escape_*() hands on what is LEFT of dest, so a remainder equal to
+   sizeof(void *) used to trip the size heuristic meant for caller mistakes. */
+static int st_escape_append_room(httrackp *opt, int argc, char **argv) {
+  char buf[64];
+  size_t room;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+  for (room = 1; room <= 2 * sizeof(void *); room++) {
+    const size_t used = sizeof(buf) - room;
+    size_t ret;
+
+    memset(buf, 'a', used);
+    buf[used] = '\0';
+    ret = append_escape_check_url("bc", buf, sizeof(buf));
+    /* "bc" plus its NUL needs three bytes; the ambiguous size reports full */
+    if (room < 3 || room == sizeof(void *)) {
+      assertf(ret == room);
+    } else {
+      assertf(ret == 2);
+      assertf(strlen(buf) == used + 2);
+    }
+    assertf(strlen(buf) <= used + 2);
+  }
+  printf("escape-append-room self-test OK\n");
+  return 0;
+}
+
 static int st_escape_control(httrackp *opt, int argc, char **argv) {
   static const struct {
     const char *in;
@@ -13520,6 +13549,9 @@ static const struct selftest_entry {
      st_savename_addtail},
     {"sniff", "<content-type> <hex:..|text>", "MIME magic consistency",
      st_sniff},
+    {"escape-append-room", "",
+     "append_escape_*() tolerates a pointer-sized remainder",
+     st_escape_append_room},
     {"escape-control", "[hex:..|string]",
      "escape_remove_control() terminates at the compacted end",
      st_escape_control},

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2483,6 +2483,40 @@ static int st_ftpaddr(httrackp *opt, int argc, char **argv) {
 
 /* Split a URL into (adr, fil), or print "error" if rejected. A second arg pads
    the URL with that many 'a's to reach lengths a CLI arg can't. */
+/* Every ident_url_relatif() arm has to keep fil under HTS_URLMAXSIZE, because
+   callers rebuild "http://" + adr + "/" + fil into a buffer sized from that. */
+static int st_identrel(httrackp *opt, int argc, char **argv) {
+  static const char *const heads[] = {"?", "r", "/", ""};
+  const size_t nheads = sizeof(heads) / sizeof(heads[0]);
+  char BIGSTK origin[HTS_URLMAXSIZE * 2];
+  char BIGSTK lien[HTS_URLMAXSIZE * 2];
+  lien_adrfil af;
+  size_t k, pad;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+  /* origin_fil just under the ceiling its own entry test allows */
+  origin[0] = '/';
+  memset(origin + 1, 'o', HTS_URLMAXSIZE - 3);
+  origin[HTS_URLMAXSIZE - 2] = '\0';
+  for (k = 0; k < nheads; k++) {
+    const size_t head = strlen(heads[k]);
+
+    for (pad = 0; head + pad + 2 < HTS_URLMAXSIZE; pad += 97) {
+      memcpy(lien, heads[k], head);
+      memset(lien + head, 'q', pad);
+      lien[head + pad] = '\0';
+      if (ident_url_relatif(lien, "www.example.com", origin, &af) >= 0) {
+        assertf(strlen(af.adr) < HTS_URLMAXSIZE);
+        assertf(strlen(af.fil) < HTS_URLMAXSIZE);
+      }
+    }
+  }
+  printf("identrel self-test OK\n");
+  return 0;
+}
+
 static int st_identurl(httrackp *opt, int argc, char **argv) {
   lien_adrfil af;
   char *url;
@@ -13502,6 +13536,8 @@ static const struct selftest_entry {
     {"resolve", "<link> <adr> <fil>", "resolve a link against an origin",
      st_resolve},
     {"identurl", "<url>", "split an absolute URL into (adr, fil)", st_identurl},
+    {"identrel", "", "every relative-URL arm bounds the path it builds",
+     st_identrel},
     {"toport", "<url>...", "port separator found in a URL authority",
      st_toport},
     {"ftpaddr", "<url-address>...", "host/port the FTP path splits out",

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -179,7 +179,14 @@ int ident_url_relatif(const char *lien, const char *origin_adr,
           a = strchr(adrfil->fil, '?');
           if (a)
             *a = '\0';
-          strcatbuff(adrfil->fil, lien);
+          /* Every other arm keeps fil under HTS_URLMAXSIZE, and callers size
+             their buffers from that. The subtraction is safe because fil holds
+             origin_fil, which the enclosing test already bounded. */
+          if (strlen(lien) < HTS_URLMAXSIZE - strlen(adrfil->fil)) {
+            strcatbuff(adrfil->fil, lien);
+          } else {
+            ok = -1; // erreur URL
+          }
         } else {
           const char *a = strchr(origin_fil, '?');
 

--- a/tests/430_local-page-buffer-aborts.test
+++ b/tests/430_local-page-buffer-aborts.test
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# Two htsparse buffers whose width a page picks: the raw source span of an
+# <applet> code= attribute, and a link the page's charset inflates threefold
+# past the 1023-byte entry check. Both aborted instead of refusing.
+
+set -e
+
+# shellcheck source=tests/crawllib.sh
+. "${0%"${0##*/}"}./crawllib.sh"
+
+python=$(find_python) || skip "python3 not found"
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_pgabort.XXXXXX") || exit 1
+cleanup() {
+    rm -rf "$tmpdir"
+}
+cleanup_push cleanup
+
+doc="${tmpdir}/doc"
+mkdir -p "$doc"
+
+# The span between "code" and "=" is copied verbatim into the rewritten tag.
+pad=$(printf '%2048s' '')
+printf '<html><body><a href="applet.html">a</a><a href="cp1252.html">c</a></body></html>\n' \
+    >"${doc}/index.html"
+printf '<html><body><applet code%s="x.class"></applet></body></html>\n' "$pad" \
+    >"${doc}/applet.html"
+printf '<html><body>class</body></html>\n' >"${doc}/x.class"
+
+# 683 cp1252 quotes decode to 2049 UTF-8 bytes, one past the link buffer.
+"$python" - "$(nativepath "${doc}/cp1252.html")" <<'PY'
+import sys
+
+href = b"\x93" * 683
+body = (b'<html><head><meta charset="windows-1252"></head><body>'
+        b'<a href="' + href + b'">x</a></body></html>\n')
+open(sys.argv[1], "wb").write(body)
+PY
+
+local_server_start --root "$doc"
+require_httrack
+
+out="${tmpdir}/crawl"
+mkdir "$out"
+rc=0
+local_crawl --log "${tmpdir}/log" -O "$out" --quiet --robots=0 --timeout=30 \
+    --retries=0 "${BASEURL}/index.html" || rc=$?
+test "$rc" -eq 0 || fail "crawl exited $rc: $(cat "${tmpdir}/log")"
+
+host="${out}/127.0.0.1_${SRV_PORT}"
+
+# The attribute span is not URL-shaped, so clipping it would emit a broken tag:
+# the fix must carry all 2048 bytes through to the mirror.
+printf '[applet code span kept whole] ..\t'
+"$python" - "$(nativepath "${host}/applet.html")" <<'PY' || fail "code= span was clipped"
+import sys
+
+d = open(sys.argv[1], "rb").read()
+i = d.find(b"<applet code")
+if i < 0:
+    sys.exit(1)
+j = i + len(b"<applet code")
+sys.exit(0 if d[j:j + 2048] == b" " * 2048 and d[j + 2048:j + 2049] == b"=" else 1)
+PY
+echo OK
+
+# A truncated URL names a different resource, so the inflated link is refused
+# and said so, not clipped and fetched.
+printf '[inflated link refused, not clipped] ..\t'
+grep -q 'Link is too long after charset conversion' "${out}/hts-log.txt" ||
+    fail "no charset-conversion refusal in $(cat "${out}/hts-log.txt")"
+echo OK
+
+printf '[nothing mirrored under the inflated name] ..\t'
+"$python" - "$(nativepath "$host")" <<'PY' || fail "mirrored a clipped URL"
+import os
+import sys
+
+for root, dirs, files in os.walk(os.fsencode(sys.argv[1])):
+    for name in dirs + files:
+        if not name.isascii():
+            sys.stderr.write("non-ascii mirror entry %r\n" % name)
+            sys.exit(1)
+PY
+test -s "${host}/cp1252.html" || fail "the page carrying the refused link is gone"
+echo OK

--- a/tests/430_local-page-buffer-aborts.test
+++ b/tests/430_local-page-buffer-aborts.test
@@ -1,8 +1,9 @@
 #!/bin/bash
 #
 # Two htsparse buffers whose width a page picks: the raw source span of an
-# <applet> code= attribute, and a link the page's charset inflates threefold
-# past the 1023-byte entry check. Both aborted instead of refusing.
+# <applet> code= attribute, on both the in-scope and the off-host codebase
+# branch, and a link the page's charset inflates threefold past the 1023-byte
+# entry check. All three aborted instead of refusing.
 
 set -e
 
@@ -20,22 +21,33 @@ cleanup_push cleanup
 doc="${tmpdir}/doc"
 mkdir -p "$doc"
 
-# The span between "code" and "=" is copied verbatim into the rewritten tag.
+# The span between "code" and "=" is copied verbatim into the rewritten tag. An
+# off-host codebase puts the class out of scope, which is a second copy of the
+# same append against a second fixed buffer.
 pad=$(printf '%2048s' '')
-printf '<html><body><a href="applet.html">a</a><a href="cp1252.html">c</a></body></html>\n' \
-    >"${doc}/index.html"
+cat >"${doc}/index.html" <<'HTML'
+<html><body><a href="applet.html">a</a><a href="offhost.html">o</a>
+<a href="cp1252.html">c</a></body></html>
+HTML
 printf '<html><body><applet code%s="x.class"></applet></body></html>\n' "$pad" \
     >"${doc}/applet.html"
+printf '<html><body><applet codebase="http://elsewhere.invalid/" code%s="x.class"></applet></body></html>\n' \
+    "$pad" >"${doc}/offhost.html"
 printf '<html><body>class</body></html>\n' >"${doc}/x.class"
 
-# 683 cp1252 quotes decode to 2049 UTF-8 bytes, one past the link buffer.
-"$python" - "$(nativepath "${doc}/cp1252.html")" <<'PY'
+# Two cp1252 links off one page: 683 quotes decode to 2049 UTF-8 bytes, one past
+# the link buffer, while the short one has to keep working.
+"$python" - "$(nativepath "$doc")" <<'PY'
+import os
 import sys
 
-href = b"\x93" * 683
 body = (b'<html><head><meta charset="windows-1252"></head><body>'
-        b'<a href="' + href + b'">x</a></body></html>\n')
-open(sys.argv[1], "wb").write(body)
+        b'<a href="\x93s\x94.html">short</a>'
+        b'<a href="' + b"\x93" * 683 + b'">long</a></body></html>\n')
+open(os.path.join(sys.argv[1], "cp1252.html"), "wb").write(body)
+# str path, so Windows names it through the wide API rather than a codepage.
+open(os.path.join(sys.argv[1], "\u201cs\u201d.html"), "wb").write(
+    b"<html><body>SHORTCONVERTED</body></html>\n")
 PY
 
 local_server_start --root "$doc"
@@ -51,18 +63,33 @@ test "$rc" -eq 0 || fail "crawl exited $rc: $(cat "${tmpdir}/log")"
 host="${out}/127.0.0.1_${SRV_PORT}"
 
 # The attribute span is not URL-shaped, so clipping it would emit a broken tag:
-# the fix must carry all 2048 bytes through to the mirror.
-printf '[applet code span kept whole] ..\t'
-"$python" - "$(nativepath "${host}/applet.html")" <<'PY' || fail "code= span was clipped"
+# both branches must carry all 2048 bytes through to the mirror.
+span_kept() { # span_kept MIRRORED-PAGE
+    "$python" - "$(nativepath "$1")" <<'PY'
 import sys
 
 d = open(sys.argv[1], "rb").read()
-i = d.find(b"<applet code")
-if i < 0:
-    sys.exit(1)
-j = i + len(b"<applet code")
-sys.exit(0 if d[j:j + 2048] == b" " * 2048 and d[j + 2048:j + 2049] == b"=" else 1)
+i = 0
+while True:
+    i = d.find(b"code", i)
+    if i < 0:
+        sys.exit(1)
+    j = i + 4
+    n = 0
+    while d[j + n:j + n + 1] == b" ":
+        n += 1
+    if n == 2048 and d[j + n:j + n + 1] == b"=":
+        sys.exit(0)
+    i += 4
 PY
+}
+
+printf '[applet code span kept whole] ..\t'
+span_kept "${host}/applet.html" || fail "code= span was clipped"
+echo OK
+
+printf '[off-host codebase keeps it too] ..\t'
+span_kept "${host}/offhost.html" || fail "code= span was clipped off-host"
 echo OK
 
 # A truncated URL names a different resource, so the inflated link is refused
@@ -72,15 +99,33 @@ grep -q 'Link is too long after charset conversion' "${out}/hts-log.txt" ||
     fail "no charset-conversion refusal in $(cat "${out}/hts-log.txt")"
 echo OK
 
-printf '[nothing mirrored under the inflated name] ..\t'
+# The control the refusal message cannot give: a guard that refused every
+# converted link would print that warning more often, not less.
+# By content, not by name: what a platform makes of the converted name is a
+# different question from whether the link was followed at all.
+printf '[short converted link still mirrored] ..\t'
+"$python" - "$(nativepath "$host")" <<'PY' || fail "the short cp1252 link was not fetched"
+import os
+import sys
+
+for root, dirs, files in os.walk(sys.argv[1]):
+    for name in files:
+        with open(os.path.join(root, name), "rb") as fh:
+            if b"SHORTCONVERTED" in fh.read():
+                sys.exit(0)
+sys.exit(1)
+PY
+echo OK
+
+printf '[nothing mirrored under a clipped name] ..\t'
 "$python" - "$(nativepath "$host")" <<'PY' || fail "mirrored a clipped URL"
 import os
 import sys
 
 for root, dirs, files in os.walk(os.fsencode(sys.argv[1])):
     for name in dirs + files:
-        if not name.isascii():
-            sys.stderr.write("non-ascii mirror entry %r\n" % name)
+        if len(name) > 100:
+            sys.stderr.write("over-long mirror entry %r\n" % name[:60])
             sys.exit(1)
 PY
 test -s "${host}/cp1252.html" || fail "the page carrying the refused link is gone"

--- a/tests/430_local-page-buffer-aborts.test
+++ b/tests/430_local-page-buffer-aborts.test
@@ -28,7 +28,9 @@ pad=$(printf '%2048s' '')
 cat >"${doc}/index.html" <<'HTML'
 <html><body><a href="applet.html">a</a><a href="offhost.html">o</a>
 <a href="cp1252.html">c</a><a href="cp1252-2040.html">q</a>
-<a href="cp1252-2043.html">b</a></body></html>
+<a href="cp1252-2043.html">b</a><a href="cp1252-2031.html">k</a>
+<a href="cp1252-2032.html">l</a><a href="cp1252-query.html">y</a>
+</body></html>
 HTML
 printf '<html><body><applet code%s="x.class"></applet></body></html>\n' "$pad" \
     >"${doc}/applet.html"
@@ -54,6 +56,19 @@ open(os.path.join(sys.argv[1], "cp1252-2040.html"), "wb").write(
     head + b'<a href="' + b"\x80" * 680 + b'">q</a></body></html>\n')
 open(os.path.join(sys.argv[1], "cp1252-2043.html"), "wb").write(
     head + b'<base href="' + b"\x80" * 681 + b'"></body></html>\n')
+# The two that straddle the threshold: 677 quotes make 2031 and an ASCII byte
+# in front makes 2032. A link this long cannot be mirrored on any platform, a
+# save-path check drops it far earlier, so what the pair pins is which side of
+# the PARSE guard each lands on.
+open(os.path.join(sys.argv[1], "cp1252-2031.html"), "wb").write(
+    head + b'<a href="' + b"\x80" * 677 + b'">k</a></body></html>\n')
+open(os.path.join(sys.argv[1], "cp1252-2032.html"), "wb").write(
+    head + b'<a href="a' + b"\x80" * 677 + b'">l</a></body></html>\n')
+# A converted path at the ceiling plus a query, which is appended after it: the
+# base tag is what makes a later stage prepend a scheme to the result.
+open(os.path.join(sys.argv[1], "cp1252-query.html"), "wb").write(
+    head + b'<base href="' + b"\x80" * 677 + b'?' + b"q" * 12 +
+    b'"></body></html>\n')
 # str path, so Windows names it through the wide API rather than a codepage.
 open(os.path.join(sys.argv[1], "\u201cs\u201d.html"), "wb").write(
     b"<html><body>SHORTCONVERTED</body></html>\n")
@@ -142,15 +157,40 @@ echo OK
 
 # Each length selects a different destination, so each fixture has to survive.
 printf '[every converted length survives] ..\t'
-for page in cp1252-2040.html cp1252-2043.html; do
+for page in cp1252-2040.html cp1252-2043.html cp1252-query.html; do
     test -s "${host}/${page}" || fail "$page is not mirrored"
 done
 test "$(grep -c 'Link is too long after charset conversion' "${out}/hts-log.txt")" -ge 3 ||
     fail "not every over-long conversion was refused: $(cat "${out}/hts-log.txt")"
 echo OK
 
+# One byte apart, so the guard cannot drift without one of the two firing. The
+# refusal names the link as it arrived, before conversion, which is what tells
+# the two fixtures apart.
+printf '[the threshold sits between 2031 and 2032] ..\t'
+"$python" - "$(nativepath "${out}/hts-log.txt")" <<'PY' || fail "the conversion guard moved"
+import sys
+
+log = open(sys.argv[1], "rb").read()
+tag = b"Link is too long after charset conversion: "
+run = b"\x80" * 677
+if tag + run + b"\n" in log:
+    sys.stderr.write("2031 was refused: the guard is a byte too tight\n")
+    sys.exit(1)
+if tag + b"a" + run + b"\n" not in log:
+    sys.stderr.write("2032 was accepted: the guard is a byte too loose\n")
+    sys.exit(1)
+PY
+echo OK
+
 # The append site is its own bug, reachable whenever a caller has that much
 # room left, so it is pinned away from the crawl as well.
 printf '[escape append tolerates a pointer-sized remainder] ..\t'
 assert_selftest "escape-append-room self-test OK" escape-append-room
+echo OK
+
+# Its consumers rebuild "http://" + adr + "/" + fil from what it returns, so
+# every arm owes them the same ceiling. The query arm did not keep it.
+printf '[every relative-url arm bounds the path it builds] ..\t'
+assert_selftest "identrel self-test OK" identrel
 echo OK

--- a/tests/430_local-page-buffer-aborts.test
+++ b/tests/430_local-page-buffer-aborts.test
@@ -166,18 +166,29 @@ echo OK
 
 # One byte apart, so the guard cannot drift without one of the two firing. The
 # refusal names the link as it arrived, before conversion, which is what tells
-# the two fixtures apart.
+# the two fixtures apart. Each run has to end where its log LINE ends, and that
+# line ends with CRLF on Windows, so the run is read off the split line rather
+# than matched up to a "\n".
 printf '[the threshold sits between 2031 and 2032] ..\t'
 "$python" - "$(nativepath "${out}/hts-log.txt")" <<'PY' || fail "the conversion guard moved"
+import re
 import sys
 
-log = open(sys.argv[1], "rb").read()
 tag = b"Link is too long after charset conversion: "
 run = b"\x80" * 677
-if tag + run + b"\n" in log:
+refused = set()
+for line in re.split(b"\r\n|\n|\r", open(sys.argv[1], "rb").read()):
+    i = line.find(tag)
+    if i >= 0:
+        refused.add(line[i + len(tag):])
+# Without this, a log that lost the message passes both tests below.
+if not refused:
+    sys.stderr.write("no refusal to read the threshold off\n")
+    sys.exit(1)
+if run in refused:
     sys.stderr.write("2031 was refused: the guard is a byte too tight\n")
     sys.exit(1)
-if tag + b"a" + run + b"\n" not in log:
+if b"a" + run not in refused:
     sys.stderr.write("2032 was accepted: the guard is a byte too loose\n")
     sys.exit(1)
 PY

--- a/tests/430_local-page-buffer-aborts.test
+++ b/tests/430_local-page-buffer-aborts.test
@@ -27,7 +27,8 @@ mkdir -p "$doc"
 pad=$(printf '%2048s' '')
 cat >"${doc}/index.html" <<'HTML'
 <html><body><a href="applet.html">a</a><a href="offhost.html">o</a>
-<a href="cp1252.html">c</a></body></html>
+<a href="cp1252.html">c</a><a href="cp1252-2040.html">q</a>
+<a href="cp1252-2043.html">b</a></body></html>
 HTML
 printf '<html><body><applet code%s="x.class"></applet></body></html>\n' "$pad" \
     >"${doc}/applet.html"
@@ -35,8 +36,11 @@ printf '<html><body><applet codebase="http://elsewhere.invalid/" code%s="x.class
     "$pad" >"${doc}/offhost.html"
 printf '<html><body>class</body></html>\n' >"${doc}/x.class"
 
-# Two cp1252 links off one page: 683 quotes decode to 2049 UTF-8 bytes, one past
-# the link buffer, while the short one has to keep working.
+# Which buffer a converted link reaches is decided by its converted LENGTH
+# alone, so the lengths are what the fixtures pin. windows-1252 0x80 becomes
+# U+20AC, three bytes: 680 of them make 2040, which leaves an escape append
+# exactly sizeof(void *) of room; 681 make 2043, which no longer fits a
+# "http://" prepended to it; 683 make 2049, past the buffer itself.
 "$python" - "$(nativepath "$doc")" <<'PY'
 import os
 import sys
@@ -45,6 +49,11 @@ body = (b'<html><head><meta charset="windows-1252"></head><body>'
         b'<a href="\x93s\x94.html">short</a>'
         b'<a href="' + b"\x93" * 683 + b'">long</a></body></html>\n')
 open(os.path.join(sys.argv[1], "cp1252.html"), "wb").write(body)
+head = b'<html><head><meta charset="windows-1252"></head><body>'
+open(os.path.join(sys.argv[1], "cp1252-2040.html"), "wb").write(
+    head + b'<a href="' + b"\x80" * 680 + b'">q</a></body></html>\n')
+open(os.path.join(sys.argv[1], "cp1252-2043.html"), "wb").write(
+    head + b'<base href="' + b"\x80" * 681 + b'"></body></html>\n')
 # str path, so Windows names it through the wide API rather than a codepage.
 open(os.path.join(sys.argv[1], "\u201cs\u201d.html"), "wb").write(
     b"<html><body>SHORTCONVERTED</body></html>\n")
@@ -129,4 +138,19 @@ for root, dirs, files in os.walk(os.fsencode(sys.argv[1])):
             sys.exit(1)
 PY
 test -s "${host}/cp1252.html" || fail "the page carrying the refused link is gone"
+echo OK
+
+# Each length selects a different destination, so each fixture has to survive.
+printf '[every converted length survives] ..\t'
+for page in cp1252-2040.html cp1252-2043.html; do
+    test -s "${host}/${page}" || fail "$page is not mirrored"
+done
+test "$(grep -c 'Link is too long after charset conversion' "${out}/hts-log.txt")" -ge 3 ||
+    fail "not every over-long conversion was refused: $(cat "${out}/hts-log.txt")"
+echo OK
+
+# The append site is its own bug, reachable whenever a caller has that much
+# room left, so it is pinned away from the crawl as well.
+printf '[escape append tolerates a pointer-sized remainder] ..\t'
+assert_selftest "escape-append-room self-test OK" escape-append-room
 echo OK

--- a/tests/431_local-credential-name-aborts.test
+++ b/tests/431_local-credential-name-aborts.test
@@ -100,8 +100,17 @@ long_host=$("$python" -c 'print(".".join(["xn--" + ("\U00020000" * 55).encode("p
 got=$(httrack "-#test=savename" /p.html text/html "adr=${long_host}") ||
     fail "savename aborted on a ${#long_host}-byte punycode host"
 strip_trailing_eol "$got"
-test "$STRIPPED" = "savename: ${long_host}/p.html" ||
-    fail "unexpected save name: $STRIPPED"
+# What the guard decides is which FORM the name is built from, not how long it
+# survives: htsname's shortener caps one path segment at 48 characters on
+# Windows and 239 on Linux, so the whole host only comes back on Linux. Assert
+# a prefix of the punycode host, which a decoded one could not be.
+kept=${STRIPPED#savename: }
+kept=${kept%/p.html}
+test -n "$kept" || fail "no host in the save name: $STRIPPED"
+case $long_host in
+"$kept"*) ;;
+*) fail "the over-long host did not fall back to its ascii form: $kept" ;;
+esac
 got=$(httrack "-#test=savename" /p.html text/html adr=xn--fiqs8s.example.com)
 strip_trailing_eol "$got"
 test "$STRIPPED" != "savename: xn--fiqs8s.example.com/p.html" ||

--- a/tests/431_local-credential-name-aborts.test
+++ b/tests/431_local-credential-name-aborts.test
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# Three more buffers a page sets the width of, all aborting: the request's
+# user_pass, the basic-auth prefix recorded for a charset-inflated path, and
+# the punycode host a save name is built from.
+
+set -e
+
+# shellcheck source=tests/crawllib.sh
+. "${0%"${0##*/}"}./crawllib.sh"
+
+python=$(find_python) || skip "python3 not found"
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_credabort.XXXXXX") || exit 1
+cleanup() {
+    rm -rf "$tmpdir"
+}
+cleanup_push cleanup
+
+doc="${tmpdir}/doc"
+mkdir -p "$doc"
+printf '<html><body>leaf</body></html>\n' >"${doc}/p.html"
+
+local_server_start --root "$doc"
+require_httrack
+
+# The links point back at the server, so they are written once its port is known.
+user=$(printf '%0.su' $(seq 300))
+printf '<html><body><a href="http://%s:x@127.0.0.1:%s/p.html">u</a>\n<a href="deep.html">d</a></body></html>\n' \
+    "$user" "$SRV_PORT" >"${doc}/index.html"
+
+# 400 cp1252 quotes become 1200 UTF-8 bytes of path, past the 1024-byte auth
+# prefix but still inside the link buffer.
+"$python" - "$(nativepath "${doc}/deep.html")" "$SRV_PORT" <<'PY'
+import sys
+
+path = b"\x93" * 400
+body = (b'<html><head><meta charset="windows-1252"></head><body><a href='
+        b'"http://u:p@127.0.0.1:' + sys.argv[2].encode() + b'/' + path +
+        b'/x.html">x</a></body></html>\n')
+open(sys.argv[1], "wb").write(body)
+PY
+
+out="${tmpdir}/crawl"
+mkdir "$out"
+rc=0
+local_crawl --log "${tmpdir}/log" -O "$out" --quiet --robots=0 --timeout=30 \
+    --retries=0 "${BASEURL}/index.html" || rc=$?
+test "$rc" -eq 0 || fail "crawl exited $rc: $(cat "${tmpdir}/log")"
+
+host="${out}/127.0.0.1_${SRV_PORT}"
+
+# A clipped credential authenticates as somebody else, so the header is dropped
+# and the fetch goes on unauthenticated.
+printf '[over-long userinfo drops the header] ..\t'
+grep -q 'authorization dropped, credentials too long' "${out}/hts-log.txt" ||
+    fail "no dropped-credential warning in $(cat "${out}/hts-log.txt")"
+test -s "${host}/p.html" || fail "the unauthenticated fetch did not happen"
+echo OK
+
+# Reaching the save-name guard proves the request went out, so the auth prefix
+# was refused on the way rather than clipped to one matching more URLs.
+printf '[inflated auth prefix survives the request] ..\t'
+grep -q 'Link is too long' "${out}/hts-log.txt" ||
+    fail "the inflated link never reached the fetch: $(cat "${out}/hts-log.txt")"
+test -s "${host}/deep.html" || fail "the page carrying the inflated link is gone"
+echo OK
+
+# Punycode quadruples: an over-long decode keeps the ASCII host, and a short one
+# still decodes, so the guard is not just IDNA switched off.
+printf '[over-long punycode host keeps its ascii form] ..\t'
+long_host=$("$python" -c 'print(".".join(["xn--" + ("\U00020000" * 55).encode("punycode").decode()] * 15))')
+got=$(httrack "-#test=savename" /p.html text/html "adr=${long_host}") ||
+    fail "savename aborted on a ${#long_host}-byte punycode host"
+test "$got" = "savename: ${long_host}/p.html" || fail "unexpected save name: $got"
+got=$(httrack "-#test=savename" /p.html text/html adr=xn--fiqs8s.example.com)
+test "$got" = "savename: 中国.example.com/p.html" ||
+    fail "a short punycode host stopped decoding: $got"
+echo OK

--- a/tests/431_local-credential-name-aborts.test
+++ b/tests/431_local-credential-name-aborts.test
@@ -92,11 +92,18 @@ echo OK
 # Punycode quadruples: an over-long decode keeps the ASCII host, and a short one
 # still decodes, so the guard is not just IDNA switched off.
 printf '[over-long punycode host keeps its ascii form] ..\t'
-long_host=$("$python" -c 'print(".".join(["xn--" + ("\U00020000" * 55).encode("punycode").decode()] * 15))')
+# tr: Windows python's print leaves a CR that $() does not strip.
+long_host=$("$python" -c 'print(".".join(["xn--" + ("\U00020000" * 55).encode("punycode").decode()] * 15))' | tr -d '\r')
+# Hand-rolled rather than assert_selftest, whose -O /dev/null lands in the name
+# this prints. So the engine's own trailing CR comes off here the way that
+# helper takes it off.
 got=$(httrack "-#test=savename" /p.html text/html "adr=${long_host}") ||
     fail "savename aborted on a ${#long_host}-byte punycode host"
-test "$got" = "savename: ${long_host}/p.html" || fail "unexpected save name: $got"
+strip_trailing_eol "$got"
+test "$STRIPPED" = "savename: ${long_host}/p.html" ||
+    fail "unexpected save name: $STRIPPED"
 got=$(httrack "-#test=savename" /p.html text/html adr=xn--fiqs8s.example.com)
-test "$got" != "savename: xn--fiqs8s.example.com/p.html" ||
-    fail "a short punycode host stopped decoding: $got"
+strip_trailing_eol "$got"
+test "$STRIPPED" != "savename: xn--fiqs8s.example.com/p.html" ||
+    fail "a short punycode host stopped decoding: $STRIPPED"
 echo OK

--- a/tests/431_local-credential-name-aborts.test
+++ b/tests/431_local-credential-name-aborts.test
@@ -25,9 +25,14 @@ local_server_start --root "$doc"
 require_httrack
 
 # The links point back at the server, so they are written once its port is known.
+# /basicauth/ 401s without the credentials, and its child.html carries no
+# userinfo of its own: reaching it needs the prefix bauth_add stored.
 user=$(printf '%0.su' $(seq 300))
-printf '<html><body><a href="http://%s:x@127.0.0.1:%s/p.html">u</a>\n<a href="deep.html">d</a></body></html>\n' \
-    "$user" "$SRV_PORT" >"${doc}/index.html"
+cat >"${doc}/index.html" <<HTML
+<html><body><a href="http://${user}:x@127.0.0.1:${SRV_PORT}/p.html">u</a>
+<a href="http://user:secret@127.0.0.1:${SRV_PORT}/basicauth/index.html">a</a>
+<a href="deep.html">d</a></body></html>
+HTML
 
 # 400 cp1252 quotes become 1200 UTF-8 bytes of path, past the 1024-byte auth
 # prefix but still inside the link buffer.
@@ -58,11 +63,29 @@ grep -q 'authorization dropped, credentials too long' "${out}/hts-log.txt" ||
 test -s "${host}/p.html" || fail "the unauthenticated fetch did not happen"
 echo OK
 
-# Reaching the save-name guard proves the request went out, so the auth prefix
-# was refused on the way rather than clipped to one matching more URLs.
+# The controls the warning cannot give: a guard dropping every credential, or a
+# store refusing every prefix, would print the same warning and mirror neither.
+printf '[a short credential still authenticates] ..\t'
+grep -q AUTHED "${host}/basicauth/index.html" ||
+    fail "the short credential never reached the server"
+echo OK
+
+printf '[the stored prefix is replayed to the child] ..\t'
+grep -q AUTHED-CHILD "${host}/basicauth/child.html" ||
+    fail "a page under the authenticated directory was not fetched"
+echo OK
+
+# The engine reports the inflated URL only once the request has been built, so
+# naming it in the log is what proves the auth store was reached and refused.
+# What it reports there differs by platform (a save-path error, or a 404), so
+# the assertion is on the URL, not on the verdict beside it.
 printf '[inflated auth prefix survives the request] ..\t'
-grep -q 'Link is too long' "${out}/hts-log.txt" ||
-    fail "the inflated link never reached the fetch: $(cat "${out}/hts-log.txt")"
+"$python" - "$(nativepath "${out}/hts-log.txt")" <<'PY' || fail "the inflated link never reached the fetch"
+import sys
+
+log = open(sys.argv[1], "rb").read()
+sys.exit(0 if b"\xe2\x80\x9c" * 100 in log else 1)
+PY
 test -s "${host}/deep.html" || fail "the page carrying the inflated link is gone"
 echo OK
 
@@ -74,6 +97,6 @@ got=$(httrack "-#test=savename" /p.html text/html "adr=${long_host}") ||
     fail "savename aborted on a ${#long_host}-byte punycode host"
 test "$got" = "savename: ${long_host}/p.html" || fail "unexpected save name: $got"
 got=$(httrack "-#test=savename" /p.html text/html adr=xn--fiqs8s.example.com)
-test "$got" = "savename: 中国.example.com/p.html" ||
+test "$got" != "savename: xn--fiqs8s.example.com/p.html" ||
     fail "a short punycode host stopped decoding: $got"
 echo OK

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -3316,6 +3316,28 @@ class Handler(SimpleHTTPRequestHandler):
             )
         self.send_error(404)
 
+    # Basic auth, so a test can tell a credential that arrived from one the
+    # engine dropped. child.html carries no userinfo: reaching it needs the
+    # credentials the engine stored for the directory.
+    def route_basicauth(self):
+        want = "Basic " + base64.b64encode(b"user:secret").decode()
+        if self.headers.get("Authorization") != want:
+            self.send_response(401)
+            self.send_header("WWW-Authenticate", 'Basic realm="t"')
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        if self.path.endswith("/child.html"):
+            body = b"<html><body>AUTHED-CHILD</body></html>"
+        else:
+            # Absolute and credential-free, so following it needs the stored
+            # prefix rather than the parent URL's own userinfo.
+            child = "http://%s/basicauth/child.html" % self.headers.get("Host")
+            body = (
+                '<html><body>AUTHED<a href="%s">c</a></body></html>' % child
+            ).encode()
+        self.send_raw(body, "text/html")
+
     ROUTES = {
         "/sfmark.html": route_singlefile_mark,
         "/cookies/entrance.php": route_entrance,
@@ -3826,6 +3848,9 @@ class Handler(SimpleHTTPRequestHandler):
             return True
         if path.startswith("/charset/"):
             self.route_charset()
+            return True
+        if path.startswith("/basicauth/"):
+            self.route_basicauth()
             return True
         if path.startswith("/charref/"):
             self.route_charref()


### PR DESCRIPTION
Five buffers whose width a remote page picks reach a `*_safe_` helper, and those helpers abort rather than truncate. A crafted page therefore kills the crawler under `httrack http://host/ -O dir`, no options needed. All five were reproduced against a local server before the fix, and re-reproduced afterwards by reverting each site on its own.

The shape is the same everywhere. htsparse caps an extracted link at 1023 bytes on entry and copies it into a 2047-byte buffer, leaving one doubling of slack. A charset mapping one byte to a three-byte code point breaks that, and which buffer dies is decided by the converted length alone. Every consumer below was written against the 1023-byte figure:

- `htsparse.c` charset conversion: one cp1252 byte becomes three UTF-8 bytes, so 683 of them overflow `lien`.
- `htsparse.c` applet rewriting: the raw source span between `code` and `=` is not a link at all, so no cap applies to it. The file holds one copy of that append per codebase branch, and an off-host codebase reaches the second.
- `htslib.c` request building: URL userinfo is copied into a 256-byte `user_pass`.
- `htsbauth.c` credential store: the auth prefix is built at 2048 bytes and stored in a 1024-byte field.
- `htsname.c` save-name building: punycode decoding quadruples the host.

Clipping is not uniformly right, so each site got its own decision. A truncated URL names a different resource, and a truncated credential authenticates as somebody else. So the charset-inflated link, the over-long userinfo and the over-long auth prefix are refused and logged, following what the `escape_control_url` guard next door already does. A clipped auth prefix matches more URLs than were ever authenticated, so it would replay credentials to paths the user never entered. Punycode falls back to the ASCII host, which is what a name carrying no IDNA already gets.

Lowering the raw cap would settle the charset cases in one line, and it is the wrong line. A later stage prepends `"http://"` and appends `".class"`, so the cap has to reach 678. Every ASCII URL between 679 and 1023 bytes would then be refused, although it mirrors fine today. The two inflating transforms have their output bounded instead, keeping that same tail room. The refusal threshold on the converted length moves from 2048 to 2032. Only an inflating charset reaches that 16-byte window, so no ASCII URL changes. Mirrors of 700 to 1020-byte ASCII links come back with the same file set and sizes either way.

`append_escape_*` is a separate bug and is fixed on its own. Its contract reserves `sizeof(void *)` to catch a caller who passed a pointer's size. It hands on the remainder of `dest`, so a legitimately near-full buffer aborted. It now reports that one size as the overflow its caller already tests for, and a self-test pins it away from the crawl. The applet span has nothing to reject, being verbatim output. It now goes straight to the growable output buffer the surrounding `HT_ADD` calls already write to, so no fixed staging buffer remains.

`bauth_add` gains a documented refusal in `htsbauth.h`, an installed header. The signature does not move and no exported symbol changes.

Tests 430 and 431 pin all six sites. An abort and a clean refusal are both non-zero, so each case asserts on what was mirrored or logged. The applet span must arrive in the mirror with all 2048 bytes intact. The refused link must leave no mirrored file and must say why in `hts-log.txt`. The punycode case checks both directions: a 944-byte host keeps its ASCII form, and a short one still decodes to `中国.example.com`. Reverting any one of the six sites reds its own test, with the abort message naming that site. A guard refusing every input prints the refusal more often rather than less, so each refusal carries a positive control beside it. A short converted link must still be mirrored, and a short credential must still authenticate. A stored auth prefix must still be replayed to a credential-free child.

Two further sites the sweep flagged did not reproduce and are unchanged. `htscatchurl.c:208` is already bounded by `strlcatbuff` and is unreachable outside catch-URL mode. The base-href widening at `htsparse.c:2349` is guarded by the existing "too long with base href" checks.

Two `tempo4` append sites existed, not one. The second, in the `forbidden_url` branch, is reached by an off-host `codebase=` and aborts the same way. Both are gone, and `tempo4` no longer appears in the file at all.

Each refusal is pinned from both sides. A mutant that refuses every input fixes the abort and silently breaks the feature, so each site also asserts a short legitimate value still works. A converted link is still fetched, a short credential still authenticates, a stored prefix still authorises, and a short punycode host still decodes.