### PR TITLE
Six tests pass when the thing they check is absent

### DIFF
--- a/tests/120_local-proxytrack-webdav-default.test
+++ b/tests/120_local-proxytrack-webdav-default.test
@@ -108,10 +108,11 @@ until test "$(count_matching_lines_nocase ' \* log: HTTP [^ ]* 207 [0-9]* propfi
     waited=$((waited + 1))
 done
 
-# Neither what the client sent nor the generated body is echoed anywhere; the
-# two literals name the exact regression on top.
+# Neither what the client sent nor the generated body is echoed anywhere. The
+# markers the #911 traces printed are gone from the tree, so a grep for them
+# could only ever miss: these two are what a re-added trace would carry.
 log=$(<"$ptlog")
-for marker in "$sentinel" 'Default Document for the Folder' 'DEBUG: DAV-DATA' '^RESPONSE:'; do
+for marker in "$sentinel" 'Default Document for the Folder'; do
     if grep -q "$marker" <<<"$log"; then
         echo "FAIL: a PROPFIND echoed '$marker' into proxytrack's output"
         printf '%s\n' "$log"

--- a/tests/206_install-headers-c99.test
+++ b/tests/206_install-headers-c99.test
@@ -201,7 +201,7 @@ for cand in "${CXX:-}" g++ clang++ c++; do
     }
 done
 if [ -z "$cxx" ]; then
-    echo "no C++ compiler found, skipping the C++ leg" >&2
+    skip "no C++ compiler found, so the C++ leg cannot run"
 else
     cxx_stds=()
     for std in c++11 c++17; do
@@ -209,7 +209,7 @@ else
         "$cxx" "${base_cpp_argv[@]}" "-std=$std" -c "$tmp/tu.cpp" -o "$tmp/tu.o" 2>/dev/null &&
             cxx_stds+=("$std")
     done
-    [ "${#cxx_stds[@]}" -gt 0 ] || echo "$cxx accepts neither -std=c++11 nor -std=c++17, skipping the C++ leg" >&2
+    [ "${#cxx_stds[@]}" -gt 0 ] || skip "$cxx accepts neither -std=c++11 nor -std=c++17"
     # Qt permits -fno-exceptions/-fno-rtti, so a consumer's TU may see the
     # headers that way. Additive: the default mode keeps its own coverage.
     noexc=()
@@ -222,9 +222,11 @@ else
         echo "$cxx rejects -fno-exceptions -fno-rtti, skipping that mode" >&2
     fi
     # Marks instead of failing, so one broken header does not cut the sweep short.
+    cxx_count=0
     cxx_compile() {
         local label=$1
         shift
+        cxx_count=$((cxx_count + 1))
         "$cxx" "$@" -c "$tmp/tu.cpp" -o "$tmp/tu.o" 2>"$tmp/cc.log" && return 0
         echo "$label:" >&2
         head -5 "$tmp/cc.log" >&2
@@ -244,8 +246,9 @@ else
             done
         done
     done
-    [ "${#cxx_stds[@]}" -eq 0 ] ||
-        echo "compiled ${#headers[@]} headers x ${#cxx_stds[@]} C++ std x 2 bytecode modes x $exc_modes exception modes with $cxx" >&2
+    echo "compiled ${#headers[@]} headers x ${#cxx_stds[@]} C++ std x 2 bytecode modes x $exc_modes exception modes = $cxx_count units with $cxx" >&2
+    [ "$cxx_count" -eq $((${#headers[@]} * ${#cxx_stds[@]} * 2 * exc_modes)) ] ||
+        fail "the C++ compile loop skipped units"
 fi
 [ "$bad" -eq 0 ] || fail "installed headers do not compile as C++"
 

--- a/tests/335_webhttrack-bind-loopback.test
+++ b/tests/335_webhttrack-bind-loopback.test
@@ -64,6 +64,9 @@ test "$(primary_ipv4 198.51.100.7)" = 198.51.100.7 ||
     fail "primary_ipv4 rejects a routable address"
 
 addr=$(primary_ipv4)
+# The off-loopback half is the one a wildcard bind would fail. Without an
+# address to try it from, nothing below can see that, so the run skips.
+unobserved=""
 
 # Without this control a refusal below could just mean the box filters ${addr}.
 if test -n "${addr}" && ! htsserver_python - "${addr}" <<'PY'; then
@@ -93,7 +96,7 @@ if test -n "${addr}"; then
     echo "ok: --bind ${addr} widens the socket"
     htsserver_stop
 else
-    echo "no non-loopback IPv4 here: the widening half did not run" >&2
+    unobserved="no non-loopback IPv4 here"
 fi
 
 port=$(htsserver_freeport)
@@ -122,4 +125,5 @@ htsserver_stop
 htsserver_assert_reaped
 
 htsserver_cleanup_dir "${work}"
+test -z "${unobserved}" || skip "${unobserved}: the off-loopback half never ran"
 echo "PASS"

--- a/tests/363_engine-option-dash-value.test
+++ b/tests/363_engine-option-dash-value.test
@@ -59,7 +59,15 @@ refused() { # refused LABEL RE...
     test "$rc" -ne 0 || fail "$label: the option took the token after it"
     test ! -e "$out" || fail "$label: created $out"
     test -n "$stderr" || fail "$label: refused with nothing on stderr"
-    ! grep -q 'Write --' <<<"$stderr" || fail "$label: suggests a spelling: $stderr"
+    # optparam_error() states the reason and stops, then the option's own help
+    # line: "Syntax error:", the reason, at most one more. Advice appended to
+    # either lands outside that shape.
+    if grep -qE 'takes a value|needs to be followed by a parameter' <<<"$stderr"; then
+        test "$(grep -c . <<<"$stderr")" -le 3 ||
+            fail "$label: the refusal says more than the reason and the help: $stderr"
+        grep -qE '(<param>|names an option|read as the next option)$' <<<"$stderr" ||
+            fail "$label: the refusal reason does not end where it should: $stderr"
+    fi
     while test $# -gt 0; do
         assert_match "$1" "$stderr" "$label"
         shift

--- a/tests/394_update-cache.test
+++ b/tests/394_update-cache.test
@@ -1,49 +1,78 @@
 #!/bin/bash
 #
+# The update path decides from the cache (cache_readex), which a one-shot crawl
+# never reaches. A file:// mirror writes no cache at all, so the re-run it used
+# to do could not tell a cache hit from a full re-fetch: both end with no error
+# and the changed file in the mirror. Over the local server the two differ, and
+# new.txt's status column is where.
 
-# Update path: re-mirroring a site reads the cache (cache_readex) to decide what
-# is up to date -- a path the one-shot crawl tests never exercise. Offline
-# (file://), so it always runs.
-#
-#   1. mirror, then re-mirror unchanged -> the cache-read pass must complete clean
-#      (guards against a crash/abort/error in cache_readex).
-#   2. change a source file, re-mirror -> the update must pick up the new content
-#      (guards the update decision that reads the cached metadata).
+set -eu
 
-set -euo pipefail
-# shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}./testlib.sh"
+# shellcheck source=tests/crawllib.sh
+. "${0%"${0##*/}"}./crawllib.sh"
 
-site=$(mktemp -d)
-out=$(mktemp -d)
-cleanup_push rm -rf "$site" "$out"
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_394.XXXXXX") || exit 1
+cleanup() {
+    rm -rf "$tmpdir"
+}
+cleanup_push cleanup
 
-cat >"$site/index.html" <<EOF
-<a href="a.html">a</a> <a href="sub/b.html">b</a>
-EOF
-echo 'OLDCONTENT' >"$site/a.html"
-mkdir -p "$site/sub"
-echo '<p>bbb</p>' >"$site/sub/b.html"
+require_httrack
 
-url="file://$site/index.html"
+root="${tmpdir}/root"
+mkdir -p "${root}/sub"
+cat >"${root}/index.html" <<'HTML'
+<html><body><a href="a.html">a</a> <a href="sub/b.html">b</a></body></html>
+HTML
+echo 'OLDCONTENT' >"${root}/a.html"
+echo '<p>bbb</p>' >"${root}/sub/b.html"
 
-# count Error: lines in the log
-errors() { count_log_errors "$out/hts-log.txt"; }
+local_server_start --root "$root"
 
-# 1. fresh mirror writes the cache
-httrack "$url" -O "$out" -q -%v0 -r3 >/dev/null 2>&1
-test -e "$out/hts-cache/new.zip" || fail "no cache was written"
+out="${tmpdir}/out"
+host="${out}/127.0.0.1_${SRV_PORT}"
+log="${out}/hts-log.txt"
 
-# 2. re-mirror unchanged: the update reads the cache and must complete cleanly
-httrack "$url" -O "$out" -q -%v0 -r3 >/dev/null 2>&1
-test "$(errors)" = 0 || fail "update (unchanged) reported errors"
-for suffix in a.html sub/b.html; do
-    test -n "$(find "$out" -path "*/$suffix" -print -quit)" || fail "missing $suffix after update"
+crawl() { # crawl <label> [httrack args...]
+    local label=$1
+    shift
+    local_crawl --log "${tmpdir}/crawl-${label}.log" \
+        "${BASEURL}/index.html" -O "$out" --quiet --robots=0 --timeout=30 \
+        "$@" || fail "$label: crawl failed"
+}
+
+# What the run decided for one link: new.txt's status column, "added" on a
+# transfer and "untouched" where the cached entry answered instead.
+verdict() { # verdict <site-relative path>
+    awk -F'\t' -v u="${BASEURL}/$1" '$8 == u { sub(/ .*/, "", $5); print $5 }' \
+        "${out}/hts-cache/new.txt"
+}
+
+crawl ref
+for f in index.html a.html sub/b.html; do
+    assert_file "${host}/$f" "reference mirror"
 done
 
-# 3. change a source file: the update must pick up the new content
+# Unchanged: every link has to come out of the cache. With none of them read,
+# the mirror below is identical and the log still clean.
+crawl unchanged --update
+test "$(count_log_errors "$log")" = 0 || fail "update (unchanged) reported errors"
+for f in index.html a.html sub/b.html; do
+    assert_file "${host}/$f" "update mirror"
+    test "$(verdict "$f")" = untouched ||
+        fail "$f was re-fetched on an unchanged update: $(verdict "$f")"
+done
+ok "an unchanged update answers every link from the cache"
+
+# One changed source, and the cache still decides for the other two.
 sleep 1
-echo 'NEWCONTENT' >"$site/a.html"
-httrack "$url" -O "$out" -q -%v0 -r3 >/dev/null 2>&1
-test "$(errors)" = 0 || fail "update (changed) reported errors"
-grep -q NEWCONTENT "$(find "$out" -path '*/a.html')" || fail "update did not pick up the changed source"
+echo 'NEWCONTENT' >"${root}/a.html"
+crawl changed --update
+test "$(count_log_errors "$log")" = 0 || fail "update (changed) reported errors"
+grep -q NEWCONTENT "${host}/a.html" || fail "the update did not pick up the changed source"
+test "$(verdict a.html)" != untouched || fail "a.html was reported untouched after it changed"
+for f in index.html sub/b.html; do
+    test "$(verdict "$f")" = untouched ||
+        fail "$f was re-fetched though only a.html changed: $(verdict "$f")"
+done
+ok "a changed source comes through, the rest still from the cache"

--- a/tests/417_local-sizehack-update-cache.test
+++ b/tests/417_local-sizehack-update-cache.test
@@ -70,6 +70,12 @@ loghost=$(nativepath "$host")
 kept_name() { # kept_name <mirror-relative path>
     count_matching_lines -F "Kept existing file ${loghost}/$1 (" "$log"
 }
+# The same line with its reason. Four arms keep a file and only one of them is
+# the cache-index one this option changed, so the name alone cannot say which
+# fired.
+kept_for() { # kept_for <mirror-relative path> <bytes> <reason>
+    count_matching_lines -F "Kept existing file ${loghost}/$1 ($2 bytes), $3" "$log"
+}
 
 cmp -s "${root}/leaf.html" "${host}/leaf.html" ||
     fail "leaf.html kept its cached body: $(cat "${host}/leaf.html")"
@@ -86,6 +92,7 @@ ok "a mirrored file that drifted from the cache is re-fetched, not dropped"
 # shortcut must still fire, or the two arms above pass on a disabled option.
 cmp -s "${tmpdir}/keep-v1.bin" "${host}/keep.bin" ||
     fail "keep.bin was re-fetched, so the sizehack shortcut is gone"
-test "$(kept_name keep.bin)" -ge 1 || fail "no log line names keep.bin as kept:
+test "$(kept_for keep.bin 1024 'matching the cached size')" -ge 1 ||
+    fail "keep.bin was not kept on the cached size:
 $(grep -a 'Kept existing' "$log" || true)"
 ok "an unchanged-size data file still takes the shortcut"

--- a/tests/54_local-update-truncate-purge.test
+++ b/tests/54_local-update-truncate-purge.test
@@ -21,3 +21,15 @@ bash "$top_srcdir/tests/local-crawl.sh" \
     --file-matches 'uptrunc/stay.html' 'STAY-V2' \
     --file-not-matches 'uptrunc/stay.html' 'STAY-V1' \
     httrack 'BASEURL/uptrunc/index.html'
+
+# The half above cannot see the purge: page.html gives up before parsing, so
+# #1390 holds every file and the survival of file.bin is free. Here only the
+# binary comes in short, the purge runs, and gone.html proves it ran.
+bash "$top_srcdir/tests/local-crawl.sh" \
+    --rerun-args '--update' \
+    --log-found 'incomplete transfer.*uptruncbin/file\.bin' \
+    --file-matches 'uptruncbin/file.bin' 'MIRRORED-BIN-V1' \
+    --file-min-bytes 'uptruncbin/file.bin' 32768 \
+    --file-matches 'uptruncbin/stay.html' 'BINSTAY-V2' \
+    --not-found 'uptruncbin/gone.html' \
+    httrack 'BASEURL/uptruncbin/index.html'

--- a/tests/77_webhttrack-redirect.test
+++ b/tests/77_webhttrack-redirect.test
@@ -72,8 +72,11 @@ test "$(grep -c '^HTTP/1\.' <<<"${resp}")" -eq 1 ||
 htsserver_start
 alias_state=$(probe_alias "${HTS_PORT}")
 htsserver_stop
+# The alias is what tells a loopback-only socket from a wildcard one, so
+# without it the listen-address assertions below cannot fail.
+unobserved=""
 if test "${alias_state}" = unusable; then
-    echo "no 127.0.0.2 alias; skipping the listen-address assertions" >&2
+    unobserved="no 127.0.0.2 alias here"
 else
     test "${alias_state}" = free ||
         fail "default listen address is not loopback-only (127.0.0.2:${HTS_PORT} taken)"
@@ -95,4 +98,5 @@ run_with_timeout 15 htsserver "${HTS_DISTDIR}/" --bind "" >"${bindlog}" 2>&1 || 
 grep -q -- "--bind needs an address" "${bindlog}" ||
     fail "empty --bind not refused: $(<"${bindlog}")"
 
+test -z "${unobserved}" || skip "${unobserved}: the listen-address half never ran"
 echo "PASS"

--- a/tests/99_local-robots-error.test
+++ b/tests/99_local-robots-error.test
@@ -6,12 +6,14 @@ set -eu
 
 : "${top_srcdir:=..}"
 
-# -Z: both the removed block's own log line and the failed probe that gates
-# this test's coverage are debug-level.
+# The placeholder block and its log line went with #783, so an absence check on
+# that line could only ever miss. What is left is the input that reached it: the
+# failed probe still drives the sitemap fallback and substitutes no body, and a
+# re-added block over-reads the heap, which the sanitizer legs catch here.
+# -Z: the failed probe that gates this test's coverage is debug-level.
 bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
     --found 'sitemapdir/orphan1.html' \
     --log-found 'No robots\.txt rules at' \
     --log-found 'listed by 127\.0\.0\.1:[0-9]+/sitemap\.xml' \
-    --log-not-found 'Creating GIF dummy file' \
     httrack 'BASEURL/sitemapdir/start.html' --sitemap -r2 -o1 -Z \
     --assume 'txt=image/gif' -F 'errorrobots-agent'

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1099,9 +1099,11 @@ class Handler(SimpleHTTPRequestHandler):
             '\t<a href="stay.html">stay</a>\n'
         )
 
-    def send_truncated(self, body, content_type):
+    def send_truncated(self, body, content_type, extra_headers=()):
         self.send_response(200)
         self.send_header("Content-Type", content_type)
+        for name, value in extra_headers:
+            self.send_header(name, value)
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         if self.command == "HEAD":
@@ -1128,6 +1130,36 @@ class Handler(SimpleHTTPRequestHandler):
     def route_uptrunc_stay(self):
         v = 1 if self.refetch_pass() == 1 else 2
         self.send_raw(b"<html><body><p>STAY-V%d</p></body></html>" % v, "text/html")
+
+    # Same, with nothing hypertext coming in short: a page that gave up before
+    # parsing holds the whole purge (#1390), which hides what #562 fixed.
+    def route_uptruncbin_index(self):
+        gone = '\t<a href="gone.html">gone</a>\n' if self.refetch_pass() == 1 else ""
+        self.send_html(
+            '\t<a href="file.bin">file</a>\n' '\t<a href="stay.html">stay</a>\n' + gone
+        )
+
+    # gzip-coded, so the fetch lands in a temporary and nothing notes the
+    # mirrored copy before the body comes in short.
+    def route_uptruncbin_file(self):
+        body = self.gzipped(self.BIN_V1)
+        if self.refetch_pass() == 1:
+            self.send_coded(body, "application/octet-stream")
+        else:
+            self.send_truncated(
+                body,
+                "application/octet-stream",
+                extra_headers=[("Content-Encoding", "gzip")],
+            )
+
+    def route_uptruncbin_stay(self):
+        v = 1 if self.refetch_pass() == 1 else 2
+        self.send_raw(b"<html><body><p>BINSTAY-V%d</p></body></html>" % v, "text/html")
+
+    # Linked on pass 1 only: the purge has to take it, or file.bin surviving
+    # says nothing about the purge having run.
+    def route_uptruncbin_gone(self):
+        self.send_raw(b"<html><body><p>GONE-V1</p></body></html>", "text/html")
 
     # --- re-fetch cut mid-header, so nothing is stored (#746, #748) ---------
     KEEP_PAGE = b"<html><body><p>KEEP-PAGE-V1</p></body></html>"
@@ -3380,6 +3412,10 @@ class Handler(SimpleHTTPRequestHandler):
         "/uptrunc/page.html": route_uptrunc_page,
         "/uptrunc/file.bin": route_uptrunc_file,
         "/uptrunc/stay.html": route_uptrunc_stay,
+        "/uptruncbin/index.html": route_uptruncbin_index,
+        "/uptruncbin/file.bin": route_uptruncbin_file,
+        "/uptruncbin/stay.html": route_uptruncbin_stay,
+        "/uptruncbin/gone.html": route_uptruncbin_gone,
         "/keep/index.html": route_keep_index,
         "/keep/page.html": route_keep_page,
         "/keep/data.bin": route_keep_data,


### PR DESCRIPTION
Six tests reported PASS with the code they check removed. Each finding was confirmed by building the mutant and watching the test stay green. Each fix now fails on that mutant and passes on master.

`335` and `77` read an environment that cannot see the property as proof of it. `335`'s off-loopback half needs a routable IPv4, and `77`'s listen-address half needs a 127.0.0.2 alias. Without either, the half is skipped and the run still says PASS. So `SOCaddr_initloopback` -> `initany` in `htsserver.c` survives under `unshare -rn`, the regime a Fedora mock build runs in. Both now exit 77 with the reason, after running whatever they could still observe.

`206`'s C++ leg looped over an empty `cxx_stds` and reported success having compiled no header at all. It now skips when it has no C++ mode to compile in. It also counts the units it compiled, which is what the C leg already does.

`54` cannot see the `#562` regression its header names. The truncated page gives up before parsing, so `#1390` holds the whole purge and nothing is ever deleted. A second crawl truncates a gzip-coded binary instead. That one lands in a temporary nothing notes at create time, and no page goes unparsed. A page dropped from the index proves the purge ran. Deleting the `filenote()` at `htsback.c:1039` then deletes the mirrored file.

`394` crawled `file://`, which writes an empty cache the next run refuses to open. So `cache_readex` was never reached, and forcing every read to miss changed nothing. It now crawls the local server and reads new.txt's status column, where an unchanged update says `untouched` and a full re-fetch says `added`. Separately, every `file://` update logs the line `Cache: error trying to read the cache: bad zip file`. That is not touched here.

`417` matched the `Kept existing file` line up to the byte count, so any of the four keep arms satisfied it. Under a forced cache miss the shortcut control passed on the announced-size arm. It asserts the reason now.

`363`, `99` and `120` grep for strings no build emits. `363`'s guard against a suggested spelling only catches the wording `Write --`, so a suggestion phrased any other way walks past it. A check on the shape `optparam_error()` produces replaces it. `99`'s `Creating GIF dummy file` and `120`'s two `#911` markers name code deleted in the same commits that added the greps, so both go. `120`'s property checks already cover a re-added trace. A re-added `#783` block still aborts the sanitizer legs with a heap over-read in `robots_parse`, which the fixture is sized for.
