### PR TITLE
The sanitizer leg was told not to look for leaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,9 +571,9 @@ jobs:
         run: make -j"$(nproc)"
 
       - name: Test (sanitized)
-        # Leaks at exit are out of scope (the CLI frees little on the way out);
-        # we want memory-safety errors, so turn leak detection off and make every
-        # other finding abort the run.
+        # Leak detection is on, because nothing else in CI catches a dropped
+        # free. LSan only reports at a normal exit, so a test that kills the
+        # engine still contributes nothing. Every other finding aborts the run.
         #
         # Poison fresh allocations with 0xCA and freed blocks with 0xCB (decimal
         # 202/203) so memory never reads back as accidental zeros: a missing-NUL
@@ -583,7 +583,7 @@ jobs:
         # bytes by default, so max_malloc_fill_size lifts it to cover large cache
         # buffers; free_fill flags use-after-free reads.
         env:
-          ASAN_OPTIONS: detect_leaks=0:abort_on_error=1:halt_on_error=1:strict_string_checks=1:malloc_fill_byte=202:max_malloc_fill_size=2147483647:free_fill_byte=203:max_free_fill_size=2147483647:log_path=${{ github.workspace }}/sanitizer-logs/asan
+          ASAN_OPTIONS: detect_leaks=1:abort_on_error=1:halt_on_error=1:strict_string_checks=1:malloc_fill_byte=202:max_malloc_fill_size=2147483647:free_fill_byte=203:max_free_fill_size=2147483647:log_path=${{ github.workspace }}/sanitizer-logs/asan
           # No log_path here: gcc's UBSan ignores it and writes to stderr, which
           # most tests redirect away; the harness keeps a copy under the directory
           # below.

--- a/src/htsbauth.c
+++ b/src/htsbauth.c
@@ -500,7 +500,7 @@ int bauth_add(t_cookie * cookie, const char *adr, const char *fil, const char *a
       /* fin de la chaine */
       while(chain->next)
         chain = chain->next;
-      chain->next = (bauth_chain *) calloc(sizeof(bauth_chain), 1);
+      chain->next = (bauth_chain *) calloct(sizeof(bauth_chain), 1);
       if (chain->next) {
         chain = chain->next;
         chain->next = NULL;
@@ -511,6 +511,21 @@ int bauth_add(t_cookie * cookie, const char *adr, const char *fil, const char *a
     }
   }
   return 0;
+}
+
+/* Release the heap tail of the list; the head node is embedded in the jar. */
+void bauth_free(t_cookie *cookie) {
+  if (cookie != NULL) {
+    bauth_chain *chain = cookie->auth.next;
+
+    cookie->auth.next = NULL;
+    while (chain != NULL) {
+      bauth_chain *const next = chain->next;
+
+      freet(chain);
+      chain = next;
+    }
+  }
 }
 
 /* tester adr et fil, et retourner authentification si nécessaire */

--- a/src/htsbauth.h
+++ b/src/htsbauth.h
@@ -112,6 +112,10 @@ int bauth_add(t_cookie *cookie, const char *adr, const char *fil,
     caller must not free it. */
 char *bauth_check(t_cookie *cookie, const char *adr, const char *fil);
 
+/** Drop every stored credential, leaving the jar's embedded head empty. Safe on
+    a NULL jar and on a jar already freed; the jar itself is not released. */
+void bauth_free(t_cookie *cookie);
+
 /** Build the auth lookup key (host + path, query string stripped, truncated at
     the last '/') from adr and fil into prefix; returns prefix. Caller must
     supply a buffer of HTS_URLMAXSIZE * 2 bytes. */

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -88,9 +88,11 @@ static void selftest_close(cache_back *cache) {
     unzClose(cache->zipInput);
     cache->zipInput = NULL;
   }
-  /* hashtable is intentionally not coucal_delete()d: it would dump a stats
-     summary to stderr on every call, and this is a one-shot CLI subcommand
-     that exits right after (same choice as the other -# cache subcommands) */
+  /* the stats summary coucal_delete() logs is info level, which hts_init()'s
+     handler drops unless HTS_LOG asks for it */
+  coucal_delete(&cache->hashtable);
+  coucal_delete(&cache->cached_tests);
+  coucal_delete(&cache->kept);
 }
 
 /* Store one entry; the body is copied so callers may pass const data. */
@@ -580,6 +582,7 @@ int cache_write_failure_selftest(httrackp *opt, const char *dir) {
                NULL); /* best-effort; may fail on the backend */
       cache.zipOutput = NULL;
     }
+    coucal_delete(&cache.hashtable);
   }
 
   /* failures with successes in between reset the streak: never aborts */
@@ -620,6 +623,7 @@ int cache_write_failure_selftest(httrackp *opt, const char *dir) {
     }
     zipClose(cache.zipOutput, NULL);
     cache.zipOutput = NULL;
+    coucal_delete(&cache.hashtable);
   }
 
   /* isolated failure: only that entry drops; a later sibling round-trips */
@@ -676,6 +680,7 @@ int cache_write_failure_selftest(httrackp *opt, const char *dir) {
               n);
       fail++;
     }
+    coucal_delete(&cache.hashtable);
   }
 
   /* a backend with no truncate rolls back by rewinding: the entry still drops
@@ -727,6 +732,7 @@ int cache_write_failure_selftest(httrackp *opt, const char *dir) {
               n);
       fail++;
     }
+    coucal_delete(&cache.hashtable);
   }
 
   /* >2GB bodies: in-memory drops the entry, on-disk degrades to headers-only */
@@ -777,6 +783,7 @@ int cache_write_failure_selftest(httrackp *opt, const char *dir) {
               n);
       fail++;
     }
+    coucal_delete(&cache.hashtable);
   }
 
   freet(body);
@@ -2581,6 +2588,7 @@ int cache_readfail_selftest(httrackp *opt, const char *dir) {
         fail++;
       }
     }
+    coucal_delete(&cache.hashtable);
   }
 
   /* a truncated entry must not read back as a complete file */

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -171,6 +171,7 @@ RUN_CALLBACK0(opt, end); \
       cookie_save(opt->cookie,                                                 \
                   fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),           \
                           StringBuff(opt->path_log), "cookies.txt"));          \
+    bauth_free(&cookie);                                                       \
     if (makeindex_fp) {                                                        \
       fclose(makeindex_fp);                                                    \
       makeindex_fp = NULL;                                                     \
@@ -3625,12 +3626,16 @@ static char *hts_cancel_file_pop_(httrackp * opt) {
   if (opt->state.cancel != NULL) {
     htsoptstatecancel **cancel;
     htsoptstatecancel *ret;
+    char *url;
 
     for(cancel = &opt->state.cancel; (*cancel)->next != NULL;
         cancel = &((*cancel)->next)) ;
     ret = *cancel;
     *cancel = NULL;
-    return ret->url;
+    /* the string goes to the caller, the node does not outlive the pop */
+    url = ret->url;
+    freet(ret);
+    return url;
   }
   return NULL;                  /* no entry */
 }

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -6579,6 +6579,7 @@ HTSEXT_API void hts_free_opt(httrackp * opt) {
     StringFree(opt->why_url);
     StringFree(opt->warc_file);
     StringFree(opt->sitemap_url);
+    StringFree(opt->state.mimemid);
     hts_sitemap_free(opt); /* backstop: httpmirror's early-return paths */
     singlefile_free(opt);
 

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -3189,6 +3189,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                             fp = NULL;
                           }
                         }
+                        TypedArrayFree(output_buffer);
                         XH_uninit;      // désallocation mémoire & buffers
                         return -1;
                       } else {  // noter le lien sur la listes des liens à charger
@@ -3264,6 +3265,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                             fp = NULL;
                                           }
                                         }
+                                        TypedArrayFree(output_buffer);
                                         XH_uninit;      // désallocation mémoire & buffers
                                         return -1;
                                       }
@@ -3304,6 +3306,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                 fp = NULL;
                               }
                             }
+                            TypedArrayFree(output_buffer);
                             XH_uninit;  // désallocation mémoire & buffers
                             return -1;
                           }
@@ -3466,6 +3469,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
           if (!hts_loop_tick(sback, opt, 0, ptr)) {
             hts_log_print(opt, LOG_ERROR, "Exit requested by shell or user");
             *stre->exit_xh_ = 1;        // exit requested
+            TypedArrayFree(output_buffer);
             XH_uninit;
             return -1;
           } else if (opt->state._hts_cancel == 1) {
@@ -3513,8 +3517,9 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
               opt, cache, r, &fp, TypedArrayElts(output_buffer),
               TypedArraySize(output_buffer), urladr(), urlfil(), savename());
         }
-        TypedArrayFree(output_buffer);
       }
+      /* outside the write: mimehtml appends whatever the output mode is */
+      TypedArrayFree(output_buffer);
       //
       //
       //

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1994,6 +1994,9 @@ static int st_hashtable(httrackp *opt, int argc, char **argv) {
     exit(EXIT_FAILURE);
   }
 #undef FMT
+  freet(buff);
+  freet(strings);
+  freet(snum);
   return 0;
 }
 

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -1061,7 +1061,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
   int retour = 0;
   int willexit = 0;
   int buffer_size = 32768;
-  char *buffer = (char *) malloc(buffer_size);
+  char *buffer = (char *) malloct(buffer_size);
   String headers = STRING_EMPTY;
   String output = STRING_EMPTY;
   String tmpbuff = STRING_EMPTY;
@@ -1082,6 +1082,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
   if (!htslang_load(NULL, 0, path)) {
     fprintf(stderr, "unable to find lang.def and/or lang/ strings in %s\n",
             path);
+    freet(buffer);
     return 0;
   }
   LANG_T(path, 0);
@@ -2361,8 +2362,7 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
   StringFree(profile);
   StringFree(website);
 
-  if (buffer)
-    free(buffer);
+  freet(buffer);
 
   if (commandReturnMsg)
     free(commandReturnMsg);

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -1212,8 +1212,8 @@ HTSEXT_API int hts_buildtopindex(httrackp * opt, const char *path,
     freet(toptemplate_body);
   if (toptemplate_footer)
     freet(toptemplate_footer);
-  if (toptemplate_body)
-    freet(toptemplate_body);
+  if (toptemplate_bodycat)
+    freet(toptemplate_bodycat);
 
   return retval;
 }

--- a/src/minizip/zip.c
+++ b/src/minizip/zip.c
@@ -1230,6 +1230,19 @@ extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char* filename, c
 
     if (err==Z_OK)
         zi->in_opened_file_inzip = 1;
+    else {
+      /* httrack addition: no close or abandon runs on a member that never
+         opened, so this call owns what it allocated */
+      if (zi->ci.stream_initialised == Z_DEFLATED)
+        (void) deflateEnd(&zi->ci.stream);
+#ifdef HAVE_BZIP2
+      else if (zi->ci.stream_initialised == Z_BZIP2ED)
+        (void) BZ2_bzCompressEnd(&zi->ci.bstream);
+#endif
+      zi->ci.stream_initialised = 0;
+      free(zi->ci.central_header);
+      zi->ci.central_header = NULL;
+    }
     return err;
 }
 

--- a/tests/114_local-update-304-leak.test
+++ b/tests/114_local-update-304-leak.test
@@ -2,8 +2,8 @@
 #
 # Issue #782: a 304 during --update overwrote the whole response struct with the
 # cache entry, dropping the 8 KB header buffer it owned. Only a leak checker
-# sees it and the sanitized CI leg runs with detect_leaks off, so this one turns
-# it back on around a two-pass mini304 crawl; the fresh pass is the control.
+# sees it, so this one sets its own options around a two-pass mini304 crawl
+# rather than relying on the CI leg's; the fresh pass is the control.
 
 set -eu
 
@@ -11,8 +11,8 @@ set -eu
 . "${0%"${0##*/}"}./crawllib.sh"
 
 # help=1 alone, so the dump lands on stderr rather than the job's log_path;
-# detect_leaks=0 with it, since the job turns leak detection off and the probe
-# run would else leave a leak report in the stderr the harness now keeps.
+# detect_leaks=0 with it, or the probe run leaves a leak report in the stderr
+# the harness now keeps.
 probe=$(ASAN_OPTIONS=help=1:detect_leaks=0 httrack -O /dev/null --version 2>&1 || true)
 case "$probe" in
 *AddressSanitizer*) ;;

--- a/tests/283_engine-cmdline-leak.test
+++ b/tests/283_engine-cmdline-leak.test
@@ -2,8 +2,8 @@
 #
 # An early exit from hts_main_internal must release the rebuilt command line,
 # the token chunks plus the slot array (#1206). Only a leak checker sees this,
-# and the sanitized CI leg runs with detect_leaks off, so turn it back on around
-# two runs that bail out after the block is allocated.
+# so this pins it on any sanitized build rather than relying on the CI leg's
+# own options: two runs that bail out after the block is allocated.
 
 set -eu
 
@@ -11,8 +11,8 @@ set -eu
 . "${0%"${0##*/}"}./testlib.sh"
 
 # help=1 alone, so the dump lands on stderr rather than the job's log_path;
-# detect_leaks=0 with it, since the job turns leak detection off and the probe
-# run would else leave a leak report in the stderr the harness now keeps.
+# detect_leaks=0 with it, or the probe run leaves a leak report in the stderr
+# the harness now keeps.
 probe=$(ASAN_OPTIONS=help=1:detect_leaks=0 httrack -O /dev/null --version 2>&1 || true)
 case "$probe" in
 *AddressSanitizer*) ;;

--- a/tests/349_sanitizer-stderr-capture.test
+++ b/tests/349_sanitizer-stderr-capture.test
@@ -228,8 +228,8 @@ assert_eq 20000 "$(lines_of "$tmp/heavy.err")" "heavy stderr reaching the caller
 [ -n "${HTTRACK_STDERR_WRAP_DIR:-}" ] || skip "HTTRACK_STDERR_WRAP_DIR unset, no automake environment"
 [ -r "$HTTRACK_STDERR_WRAP_DIR/httrack" ] || fail "no generated shim in $HTTRACK_STDERR_WRAP_DIR"
 PATH="$HTTRACK_STDERR_WRAP_DIR:$PATH"
-# Leaks at exit would _exit() past the flush of the pipe this reads, as the CI
-# job's own detect_leaks=0 says; last value wins in the flag parser.
+# Leaks at exit would _exit() past the flush of the pipe this reads; last value
+# wins in the flag parser.
 version=$(ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}detect_leaks=0" \
     httrack --version 2>/dev/null) || true
 case $version in

--- a/tests/432_ci-leak-detection.test
+++ b/tests/432_ci-leak-detection.test
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# The sanitize leg is the only thing in CI that sees a dropped free, and it saw
+# nothing for as long as its ASAN_OPTIONS carried detect_leaks=0. A leg told not
+# to look goes green either way, so nothing but this test notices the flip back.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+top=${abs_top_srcdir:-$(cd "$testdir/.." && pwd)}
+workflow="$top/.github/workflows/ci.yml"
+
+if ! test -r "$workflow"; then
+    test -d "$top/.github" && fail "$workflow is gone but $top/.github is not"
+    skip "no .github under $top (dist tarball), so the audit has nothing to read"
+fi
+
+py=$(find_python || true)
+if test -z "$py" || ! "$py" -c 'import yaml' 2>/dev/null; then
+    skip "no python3 with PyYAML here, so the workflow cannot be parsed"
+fi
+
+# Read out of the parsed workflow, so reformatting it moves no verdict.
+"$py" - "$workflow" <<'PY' || fail "the sanitize leg no longer looks for leaks"
+import sys
+
+import yaml
+
+with open(sys.argv[1], encoding="utf-8") as fp:
+    jobs = yaml.safe_load(fp)["jobs"]
+
+job = jobs.get("sanitize")
+if job is None:
+    sys.exit("no sanitize job in the workflow")
+
+seen = 0
+for step in job.get("steps", []):
+    opts = (step.get("env") or {}).get("ASAN_OPTIONS")
+    if opts is None:
+        continue
+    seen += 1
+    name = step.get("name")
+    # Last value wins in the sanitizer flag parser.
+    flags = [f for f in opts.split(":") if f.startswith("detect_leaks=")]
+    if not flags:
+        sys.exit("step %r sets ASAN_OPTIONS without detect_leaks" % name)
+    if flags[-1].split("=", 1)[1] == "0":
+        sys.exit("step %r runs with detect_leaks=0" % name)
+
+if seen == 0:
+    sys.exit("no step in the sanitize job sets ASAN_OPTIONS")
+PY


### PR DESCRIPTION
CI's `sanitize` leg ran with `detect_leaks=0` and nothing else in the matrix looks, so a dropped `free` was caught nowhere. Fixing without enabling means the next one regresses silently, and enabling without fixing just reds the leg, so this does both.

Turning leak detection on against `origin/master` reported 33 leaks over 19 tests. Two of them are the wrong code rather than a missing free. `hts_buildtopindex()` frees `toptemplate_body` twice and never frees `toptemplate_bodycat`, which reads as a leak instead of a double free only because `freet` NULLs its argument. `hts_cancel_file_pop_()` unlinks its node, returns the URL the caller then owns, and drops the node.

The rest release what an early return or an aborted operation left behind. The basic-auth list the cookie jar builds. `htsparse()`'s output buffer, on its four bailouts and on any run that writes no HTML back. `--mime-html` appends to it whatever the output mode is. `smallserver()`'s 32 KB request buffer on the one early return. And `opt->state.mimemid`.

`zipOpenNewFileInZip4_64()` allocates the member's central-directory record before writing the local header. On a write error it returns with `in_opened_file_inzip` still 0, so neither `zipCloseFileInZipRaw64()` nor our `zipAbandonFileInZip()` ever reaches that record. The caller cannot fix this: the field is private to `zip64_internal` and no API releases it. minizip is vendored and already carries `zipAbandonFileInZip` as a local addition, so the fix goes beside it.

Two leaks are test-only and were deliberate. Both get a real `coucal_delete()` and `freet()` rather than a suppression file, which would have hidden anything else landing in the same frame. The comment at `htscache_selftest.c` justifying the intentional leak was stale. It says the delete would dump a stats summary to stderr on every call. But `hts_init()` installs a handler that drops info-level chatter unless `HTS_LOG` asks for it. The suite shows no new summary line.

The enabled leg is the regression test for the engine fixes, so no test duplicates them. `432_ci-leak-detection.test` covers the one thing the leg cannot: that it is still told to look. It fails on both `detect_leaks=0` and on the flag being dropped.

LSan only reports at a normal exit, so this is a lower bound. The crawl tests that kill the engine still contribute nothing, and a leak on a path the suite does not reach stays invisible.

Verified under gcc with the job's exact `ASAN_OPTIONS` and `detect_leaks=1`: 443 tests, 430 pass, 13 skip. The only ASan log left is the deliberate huge-allocation warning that was there before. Also green on a plain `-O2` build.
