### PR TITLE
A status line of 4294967496 is mirrored as a 200

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -1368,21 +1368,27 @@ void treatfirstline(htsblk * retour, const char *rcvd) {
       if (*a != '\0') {
         while((*a == ' ') || (*a == 10) || (*a == 13) || (*a == 9))
           a++;                  // épurer espaces
-        if ((*a >= '0') && (*a <= '9')) {
-          sscanf(a, "%d", &(retour->statuscode));
+        /* RFC 9110 15: exactly three digits. sscanf("%d") range-checks
+           nothing and glibc wraps, so "4294967496" would read as a 200. */
+        if (a[0] >= '0' && a[0] <= '9' && a[1] >= '0' && a[1] <= '9' &&
+            a[2] >= '0' && a[2] <= '9' && (a[3] < '0' || a[3] > '9')) {
+          retour->statuscode =
+              (a[0] - '0') * 100 + (a[1] - '0') * 10 + (a[2] - '0');
           // sauter 200
           while((*a != ' ') && (*a != '\0') && (*a != 10) && (*a != 13)
                 && (*a != 9))
             a++;
           while((*a == ' ') || (*a == 10) || (*a == 13) || (*a == 9))
             a++;                // épurer espaces
-          if ((strlen(a) > 1) && (strlen(a) < 64))      // message retour
-            strcpybuff(retour->msg, a);
+          /* A lone CR does not end the line the reader stopped at, so a phrase
+             kept as-is would write the log's own field separators. */
+          if ((strlen(a) > 1) && (strlen(a) < 64) && hts_is_control_free(a))
+            strcpybuff(retour->msg, a); // message retour
           else
             infostatuscode(retour->msg, retour->statuscode);
           // type MIME par défaut2
           strcpybuff(retour->contenttype, HTS_UNKNOWN_MIME);
-        } else {                // pas de code!
+        } else { // pas de code!
           retour->statuscode = STATUSCODE_INVALID;
           strcpybuff(retour->msg, "Unknown response structure");
         }

--- a/tests/433_local-status-line.test
+++ b/tests/433_local-status-line.test
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# treatfirstline() reads the first bytes a server sends, on a plain crawl with
+# no options. Every malformed shape it claims to handle is graded here on what
+# the engine recorded, not on surviving the reply.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+python=$(find_python) || skip "python3 missing"
+
+server=$(nativepath "$top_srcdir/tests/status-line-server.py")
+tmpdir=$(mktemp -d)
+out=$tmpdir/out
+serverpid=
+log=$tmpdir/crawl.log
+fail_dump_var log
+
+cleanup() {
+    stop_server "$serverpid"
+    rm -rf "$tmpdir"
+}
+cleanup_push cleanup
+
+"$python" "$server" >"$tmpdir/srv.out" 2>"$tmpdir/srv.err" &
+serverpid=$!
+port=$(discover_server_port "$tmpdir/srv.out" "$serverpid") || exit 1
+
+crawl() { # crawl CASE
+    local rc=0
+    mkdir -p "$out/$1"
+    run_with_timeout 60 httrack "http://127.0.0.1:$port/$1.html" \
+        -O "$out/$1" -c1 --robots=0 --retries=0 -%v0 -q >>"$log" 2>&1 || rc=$?
+    test "$rc" -ne 124 || fail "$1: crawl hit the deadline"
+    test "$rc" -le 128 || fail "$1: crawl ended abnormally ($rc)"
+}
+
+mirrored() { echo "$out/$1/127.0.0.1_$port/$1.html"; }
+
+# The cache index is the engine's own record of the reply: tab-separated
+# statuscode, "status ('server message')" and MIME, keyed by URL.
+cache_field() { # cache_field CASE COLUMN
+    local index=$out/$1/hts-cache/new.txt
+    test -f "$index" || return 0
+    awk -F'\t' -v u="http://127.0.0.1:$port/$1.html" -v c="$2" \
+        '$8 == u {print $c; exit}' "$index"
+}
+
+# refused: nothing mirrored, and the code and reason the engine logged
+assert_refused() { # assert_refused CASE MSG CODE
+    local case=$1 want="\"$2\" ($3) at link 127.0.0.1:$port/$1.html"
+    local logtext
+    test ! -f "$(mirrored "$case")" ||
+        fail "$case: a malformed status line was mirrored"
+    logtext=$(cat "$out/$case/hts-log.txt")
+    grep -qF "$want" <<<"$logtext" ||
+        fail_dump "$case: log lacks [$want]" "$out/$case/hts-log.txt"
+}
+
+# accepted: the file lands, under the code, message and MIME named here
+assert_accepted() { # assert_accepted CASE CODE SERVERMSG MIME
+    local case=$1
+    test -f "$(mirrored "$case")" || fail "$case: not mirrored"
+    assert_eq "$2" "$(cache_field "$case" 4)" "$case: statuscode"
+    assert_eq "added ('$3')" "$(cache_field "$case" 5)" "$case: status"
+    assert_eq "$4" "$(cache_field "$case" 6)" "$case: MIME"
+}
+
+for case in ok nocode nonnumeric signed twodigit fourdigit overflow \
+    versiononly noprefix noversion lonecr lonelf noterm emptyline \
+    spaces ltjunk huge; do
+    crawl "$case"
+done
+
+# Control: a well-formed line whose phrase infostatuscode() cannot produce, so a
+# case falling back to that table is never mistaken for one reading the wire.
+assert_accepted ok 200 "Fine%20Thanks" text/html
+
+# HTTP/ prefix, then no status code the parser will take
+assert_refused nocode "Unknown response structure" -1
+assert_refused nonnumeric "Unknown response structure" -1
+assert_refused signed "Unknown response structure" -1
+# nothing at all after the version token
+assert_refused versiononly "Unknown response structure" -1
+
+# RFC 9110 section 15: the code is exactly three digits
+assert_refused twodigit "Unknown response structure" -1
+assert_refused fourdigit "Unknown response structure" -1
+# 2**32 + 200, which a wrapping sscanf("%d") reads as a 200
+assert_refused overflow "Unknown response structure" -1
+
+# no HTTP/ prefix at all
+assert_refused noprefix "Unknown (not HTTP/xx) response structure" -1
+
+# no version, but the code is still where the parser looks: taken, not refused
+assert_accepted noversion 200 OK text/html
+
+# A lone CR does not end the line the reader stopped at, so the phrase runs on
+# to the CRLF. It must not reach the log, which is tab-separated and read by a
+# human, and the code before it still stands.
+assert_refused lonecr "Not Found" 404
+lonecrlog=$(cat "$out/lonecr/hts-log.txt")
+! grep -qF "INJECTED" <<<"$lonecrlog" ||
+    fail_dump "lonecr: the reason phrase forged a log line" \
+        "$out/lonecr/hts-log.txt"
+
+# a lone LF does end it
+assert_accepted lonelf 200 "Fine%20Thanks" text/html
+
+# no terminator anywhere, so the header block never ends
+assert_refused noterm "Interrupted transfer" -4
+
+# The junky-server arms mirror a body under a status line that named no code.
+# Deliberate ("This is dirty .."), pinned so a change to it is visible.
+assert_accepted emptyline 200 "Unknown,%20assuming%20junky%20server" unknown/unknown
+assert_accepted spaces 200 "Unknown,%20assuming%20junky%20server" unknown/unknown
+assert_accepted ltjunk 200 "Unknown,%20assuming%20junky%20server" unknown/unknown
+
+# 4000 bytes of reason phrase, past the reader's 1024-byte line buffer: the code
+# survives the truncation and the phrase falls back to the table
+assert_accepted huge 200 OK unknown/unknown
+
+ok "every malformed status-line arm recorded what it should"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -10,6 +10,7 @@ EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c a
 	proxy-https-server.py socks5-server.py proxy-connect-server.py \
 	proxytestlib.py tls-stall-server.py warc-validate.py wacz-validate.py \
 	header-injection-server.py header-injection-check.py \
+	status-line-server.py \
 	pty-resize.py ttyrun.py test-timeout.sh png-colors.py \
 	local-crawl.sh local-server.py ftp-server.py testlib.sh proclib.sh \
 	webhttracklib.sh httpclient.py webtestlib.py crawllib.sh arclib.sh \

--- a/tests/status-line-server.py
+++ b/tests/status-line-server.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Raw-socket server for 433: one malformed HTTP status line per path.
+
+A conforming HTTP server cannot emit these, so the reply is written straight to
+the socket. The path picks the case; anything else gets a well-formed 200.
+Prints "PORT <n>" once listening.
+"""
+
+import os
+import socket
+import sys
+import threading
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from proxytestlib import bind_ephemeral  # noqa: E402
+
+BODY = b"<html><body>marker_body</body></html>"
+HTML = b"Content-Type: text/html\r\n"
+# past INT_MAX, and 2**32 + 200 so a wrapping sscanf("%d") lands on 200
+OVERFLOW = b"4294967496"
+
+CASES = {
+    # well-formed, with a reason phrase no infostatuscode() table can produce
+    "ok": b"HTTP/1.1 200 Fine Thanks\r\n" + HTML + b"\r\n" + BODY,
+    # HTTP/ prefix, then something that is not a status code
+    "nocode": b"HTTP/1.1 OK\r\n\r\n" + BODY,
+    "nonnumeric": b"HTTP/1.1 XYZ Bad\r\n\r\n" + BODY,
+    "signed": b"HTTP/1.1 +200 OK\r\n\r\n" + BODY,
+    "twodigit": b"HTTP/1.1 20 OK\r\n\r\n" + BODY,
+    "fourdigit": b"HTTP/1.1 2000 OK\r\n\r\n" + BODY,
+    "overflow": b"HTTP/1.1 " + OVERFLOW + b" OK\r\n" + HTML + b"\r\n" + BODY,
+    # nothing at all after the version token
+    "versiononly": b"HTTP/1.1\r\n\r\n" + BODY,
+    # no HTTP/ prefix
+    "noprefix": b"200 OK\r\n\r\n" + BODY,
+    # HTTP/ with no version: the version token ends at the space, so the code
+    # is still where the parser looks for it
+    "noversion": b"HTTP/ 200 OK\r\n" + HTML + b"\r\n" + BODY,
+    # a lone CR does not end the line, so the phrase swallows a forged log line
+    "lonecr": b"HTTP/1.1 404 Gone\r18:00:00\tError:\tINJECTED\r\n\r\n" + BODY,
+    "lonelf": b"HTTP/1.1 200 Fine Thanks\n" + HTML + b"\n" + BODY,
+    # no line terminator anywhere, then close
+    "noterm": b"HTTP/1.1 200 Fine Thanks",
+    # empty first line, and one of nothing but spaces
+    "emptyline": b"\r\n\r\n" + BODY,
+    "spaces": b"    \t \r\n\r\n" + BODY,
+    # a body where the status line belongs
+    "ltjunk": b"<html><body>marker_junk</body></html>\r\n\r\n" + BODY,
+    # a status line well past the reader's 1024-byte line buffer
+    "huge": b"HTTP/1.1 200 " + b"A" * 4000 + b"\r\n\r\n" + BODY,
+}
+
+DEFAULT = b"HTTP/1.1 200 OK\r\n" + HTML + b"\r\n" + BODY
+
+
+def reply_for(request):
+    line = request.split(b"\r\n", 1)[0].split(b" ")
+    if len(line) < 2:
+        return DEFAULT
+    name = line[1].decode("latin-1").strip("/")
+    if name.endswith(".html"):
+        name = name[: -len(".html")]
+    return CASES.get(name, DEFAULT)
+
+
+def handle(conn):
+    conn.settimeout(10)
+    data = b""
+    try:
+        while b"\r\n\r\n" not in data:
+            chunk = conn.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+        if data:
+            conn.sendall(reply_for(data))
+    except (OSError, socket.timeout):
+        pass
+    finally:
+        conn.close()
+
+
+def main():
+    sock, port = bind_ephemeral()
+    print("PORT %d" % port, flush=True)
+    while True:
+        conn, _ = sock.accept()
+        threading.Thread(target=handle, args=(conn,), daemon=True).start()
+
+
+main()


### PR DESCRIPTION
`treatfirstline()` reads the first bytes a server sends, on a plain crawl with no options, and none of its four malformed arms had a test. Covering them turned up two defects, both fixed here.

A status code is parsed with `sscanf(a, "%d", ...)`, which range-checks nothing. A value past `INT_MAX` is undefined behaviour, and glibc wraps it. `HTTP/1.1 4294967496 OK` carries 2\*\*32 + 200, so it reads back as `200` and the body is mirrored as a successful fetch. The parser now takes exactly three digits, per RFC 9110 section 15. That also refuses the `20` and `2000` it used to record verbatim.

A lone CR does not end the line the reader stopped at, so the reason phrase runs on to the CRLF. `HTTP/1.1 404 Gone\r18:00:00\tError:\tINJECTED` put that text into `hts-log.txt` byte for byte, where it reads as a log line the engine wrote. The cache index escapes it, the log does not. A phrase carrying a control byte now falls back to `infostatuscode()`, using the existing `hts_is_control_free()`.

Two things the tests pin rather than change. The junky-server arms mirror a body under a status line that named no code, which the source marks deliberate ("This is dirty .."). Three shapes therefore land as a 200 with an unknown MIME: an empty first line, an all-spaces one, and an HTML body. And `HTTP/` with no version is still taken, because the version token ends at the space, which is where the parser looks for the code.

Test 433 serves seventeen first lines off a raw socket. Each is graded on the engine's own record. A reply that was taken is read out of the cache index, one that was refused out of the log. The control case carries a reason phrase no `infostatuscode()` table can produce. A case falling back to that table is therefore never mistaken for one reading the wire. Ten mutants, one per arm, all kill it.

One gap the fix does not close. A status line longer than the reader's 1024-byte line buffer is truncated silently, where the header loop below it logs "Over-long header dropped". A sweep of filler lengths found no way to smuggle a header past the truncation point. This is a reporting gap rather than a parsing one.
