### PR TITLE
A Windows python under WSL2 keeps the CR that Git Bash eats

### DIFF
--- a/tests/427_local-dashC-cache-listing.test
+++ b/tests/427_local-dashC-cache-listing.test
@@ -33,11 +33,13 @@ local_crawl --log "${tmpdir}/crawl.log" --quiet --robots=0 --retries=1 -c1 \
 
 # Control on the fixture, read without the tool on trial: an empty cache would
 # make every assertion below pass for the wrong reason.
+# tr, here and below: Windows python's print leaves a CR that $() keeps, which
+# MSYS eats and a Linux shell under wsl2 does not.
 cached=$("${SRV_PYTHON:?}" -c '
 import sys, zipfile
 for i in sorted(zipfile.ZipFile(sys.argv[1]).infolist(), key=lambda i: i.filename):
     print(i.filename)
-' "${out}/hts-cache/new.zip")
+' "${out}/hts-cache/new.zip" | tr -d '\r')
 test "$(grep -c . <<<"$cached")" = 2 || fail "want 2 cache entries, got: $cached"
 
 # -#C returns as soon as it has listed, so -O comes first; the listing is CRLF.
@@ -94,7 +96,7 @@ with zipfile.ZipFile(path, "a", zipfile.ZIP_DEFLATED) as z:
     zi.extra = b""  # only the local header carries them, as minizip writes it
     z.writestr(name + ".noheaders", body)
 print(name)
-' "${grafted}/hts-cache/new.zip")
+' "${grafted}/hts-cache/new.zip" | tr -d '\r')
 
 listing=$(httrack -O "$grafted" -#C '*' 2>/dev/null | tr -d '\r')
 test "$(grep -c '^X-URL: ' <<<"$listing")" = 3 ||


### PR DESCRIPTION
427 asserts that the URL it grafted into the ZIP comes back in the `-#C` listing. It matches against the name the python fixture printed. Under wsl2 that python is a Windows interpreter and its stdout is text mode, so the name arrives with a trailing CR. The fixed-string grep can then never match. The xtrace from run 33973043146 shows what it looked for: `graft=$'http://127.0.0.1:57233/site/grafted.html\r'`, against a listing line the test had already stripped.

Only the wsl2 leg sees this. Git Bash's pipes eat the CR and a Linux shell reading the same interop pipe does not. The native Windows leg of that same job passes the whole test.

Both python captures now go through `tr -d '\r'`, the way `free_ports` in testlib.sh already reads a Windows python.

Reproduced on Linux by making the fixture print CRLF: it fails at the same assertion with the same message, and passes once stripped. The size+1 and truncate-the-walk mutants from #1551 still die with the fix in.
