### PR TITLE
A pacer that projects from the last step under-projects the next

### DIFF
--- a/tests/426_configure-ipv6-flag.test
+++ b/tests/426_configure-ipv6-flag.test
@@ -34,6 +34,15 @@ n=0
 cases=9
 last_dir=
 
+# Pace against the costliest step so far, never against the last one: the two
+# rejections below give up early, and projecting a full configure off one of
+# them is how the s390x leg ran into its budget instead of skipping.
+costliest=0
+pace() { # pace <seconds the step took>
+    test "$1" -le "${costliest}" || costliest=$1
+    skip_if_out_of_budget "$((cases - n))" "${costliest}"
+}
+
 # Seeding the cache variable is the answer a host without getaddrinfo gives, and
 # AC_CHECK_LIB takes the same action-if-not-found branch either way. "have"
 # forces the other answer so every case below means the same on any host; the
@@ -90,7 +99,7 @@ expect() { # expect DESC SEED WANT-VALUE WANT-SUMMARY ARG...
     grep -q "whether IPv6 support is enabled\.\.\. ${summary}\$" "${last_dir}/configure.log" ||
         fail_dump "${desc}: configure did not report '${summary}'" "${last_dir}/configure.log"
     echo "ok: ${desc}"
-    skip_if_out_of_budget "$((cases - n))" "$((SECONDS - began))"
+    pace "$((SECONDS - began))"
 }
 
 expect_fail() { # expect_fail DESC SEED WANT-TEXT ARG...
@@ -103,33 +112,38 @@ expect_fail() { # expect_fail DESC SEED WANT-TEXT ARG...
     grep -q "${text}" "${last_dir}/configure.log" ||
         fail_dump "${desc}: configure failed without saying '${text}'" "${last_dir}/configure.log"
     echo "ok: ${desc}"
-    skip_if_out_of_budget "$((cases - n))" "$((SECONDS - began))"
+    pace "$((SECONDS - began))"
 }
 
 # The probe must define the macro either way, and this is the case master
 # fails: it warned and left HTS_INET6 undefined. First, so a slow host's budget
-# cannot skip past the guard the test exists for.
+# cannot skip past the guard the test exists for, and so the pace above projects
+# against a full configure from the very first step.
 expect "the default probes and reports the loss" hide 0 "no (auto)"
+
+# The two rejections next: configure gives up on the flag itself, so these are
+# the cheapest steps here and a host that can afford few runs more of them.
+# The probe cannot overrule an explicit yes, and the diagnostic has to name the
+# flag that gets the packager past it.
+expect_fail "a value that is not yes/no/auto is rejected" have \
+    "bad value for ipv6, expected yes/no/auto" --enable-ipv6=bogus
+expect_fail "--enable-ipv6=yes without getaddrinfo is fatal" hide \
+    "no getaddrinfo in libc. Pass --disable-ipv6" --enable-ipv6=yes
+
 expect "the default probes and finds getaddrinfo" have 1 "yes (auto)"
 
 # An explicit request is answered by the request, and says which it was.
 expect "--enable-ipv6=yes is honoured" have 1 "yes (requested)" --enable-ipv6=yes
 expect "--disable-ipv6 is honoured" have 0 "no (requested)" --disable-ipv6
 
-# A build that asked for no IPv6 has no reason to care what the host has.
+# A build that asked for no IPv6 has no reason to care what the host has. It
+# reads the run above, so it stays attached to it.
 if grep -q "getaddrinfo" "${last_dir}/configure.log"; then
     fail_dump "--disable-ipv6 still probed for getaddrinfo" "${last_dir}/configure.log"
 fi
 
 # Spelling the default out loud reaches the same place the default does.
 expect "--enable-ipv6=auto probes" have 1 "yes (auto)" --enable-ipv6=auto
-
-# The probe cannot overrule an explicit yes, and the diagnostic has to name the
-# flag that gets the packager past it.
-expect_fail "--enable-ipv6=yes without getaddrinfo is fatal" hide \
-    "no getaddrinfo in libc. Pass --disable-ipv6" --enable-ipv6=yes
-expect_fail "a value that is not yes/no/auto is rejected" have \
-    "bad value for ipv6, expected yes/no/auto" --enable-ipv6=bogus
 
 # IPv6 is deliberately not one of the automagic features: defaulting it off with
 # them would move SOCaddr under every recipe that passes that flag.


### PR DESCRIPTION
`426_configure-ipv6-flag.test` runs `configure` nine times, and on the emulated s390x leg it exceeded its 900s budget with the eighth run still going. Nothing about it failed: seven cases printed `ok`, and the test was already paced with `skip_if_out_of_budget`. It paced against the *last* step, and two of the nine are rejections that configure answers by dying on the flag itself. Those cost 3s here against 6s for a full run. The projection taken right after one of them was half of what the next case needed. The run went over the wall instead of skipping.

So pace against the costliest step seen so far, which is what `397_configure-auto-features.test` already does for the same reason.

Ordering: the guard case stays first. It is the one #1552 exists for, a probe that fails must still define `HTS_INET6`, and a slow host must not skip past it. The two rejections move up behind it. A host that can afford few cases then runs more of them, and every projection after the first step is a full configure.

The budget stays at 900s. The suite run here takes 47s and the last pace fires with one step left. A host up to roughly 18x slower still runs all nine. Anything slower skips with a reason.

Evidence, at a forced 41s budget: the old order is still inside a configure when the wall arrives. The new one skips at 36s, saying `2 steps left, the last took 6s and the budget is 41s`. A `configure.ac` mutant that drops the `AC_DEFINE(HTS_INET6, 0)` on the probe-failed branch, the #1552 bug, still fails case one, budget squeezed to 20s included. Not tested under real emulation: qemu-user for s390x is not installed on this box and registering binfmt needs root.
