### PR TITLE
A truncated legacy cache aborts proxytrack

### DIFF
--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -1509,16 +1509,15 @@ static int cache_brstr(char *adr, char *s, size_t s_size) {
   return off;
 }
 
-/** Would reading n bytes at the current offset stay inside the .dat? A file
-    whose size is unknown (datSize negative) bounds nothing, and the read then
-    refuses on its own. **/
+/** Would reading n bytes at the current offset stay inside the .dat? A size
+    the host could not report is refused rather than waived: filesize() answers
+    in a long int, so a 32-bit build handed a .dat past 2 GB reads back a value
+    that bounds nothing. **/
 static hts_boolean cache_fits(FILE *fp, long int datSize, size_t n) {
   const long int at = ftell(fp);
 
-  if (at < 0)
+  if (at < 0 || datSize < 0)
     return HTS_FALSE;
-  if (datSize < 0)
-    return HTS_TRUE;
   return at <= datSize && n <= (size_t) (datSize - at) ? HTS_TRUE : HTS_FALSE;
 }
 
@@ -1981,7 +1980,13 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
               FILE *fp = fopen(previous_save, "rb");
 
               if (fp != NULL) {
-                r->adr = cache_alloc_body(r->size);
+                /* same two bounds as a .dat-held body: the format's ceiling,
+                   then the file the bytes have to come out of */
+                const hts_boolean fits =
+                    r->size < (size_t) INT_MAX &&
+                    cache_fits(fp, filesize(previous_save), r->size);
+
+                r->adr = fits ? cache_alloc_body(r->size) : NULL;
                 if (r->adr != NULL) {
                   if (r->size > 0 && !hts_fread_exact(r->adr, r->size, fp)) {
                     PT_Element_DropBody(r);
@@ -1993,7 +1998,8 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
                 } else {
                   r->statuscode = STATUSCODE_INVALID;
                   strcpybuff(r->msg,
-                             "Read error (memory exhausted) from cache");
+                             fits ? "Read error (memory exhausted) from cache"
+                                  : "Cache Read Error : Bad Size");
                 }
                 fclose(fp);
               } else {
@@ -2004,9 +2010,13 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
           } else {
             // lire fichier (d'un coup)
             if (flags & FETCH_BODY) {
-              /* a body larger than the bytes left of the .dat is corruption;
-                 catch it before the allocation, not on the failing read */
+              /* The size field is a 32-bit signed decimal, so INT_MAX is the
+                 format's own ceiling, the one the zip reader above takes too.
+                 Past that the body must still fit in the bytes left of the
+                 .dat, which catches corruption before the allocation rather
+                 than on the failing read. */
               const hts_boolean fits =
+                  r->size < (size_t) INT_MAX &&
                   cache_fits(cache->dat, cache->datSize, r->size);
 
               r->adr = fits ? cache_alloc_body(r->size) : NULL;

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -188,6 +188,7 @@ struct _PT_Index__Old {
   char filenameDat[1024];
   char filenameNdx[1024];
   FILE *dat, *ndx;
+  long int datSize; /* bound for the lengths read out of the .dat */
   PT_Mutex fileLock;
   int version;
   char lastmodified[1024];
@@ -1475,6 +1476,10 @@ static int PT_SaveCache__New(PT_Indexes indexes, const char *filename) {
 /* Old HTTrack cache (dat/ndx) format                           */
 /* ------------------------------------------------------------ */
 
+/* Largest field the legacy format ever carried; past it the length is
+   corruption */
+#define CACHE_FIELD_MAXSIZE 32768
+
 static int cache_brstr(char *adr, char *s, size_t s_size) {
   int i;
   int off;
@@ -1487,7 +1492,7 @@ static int cache_brstr(char *adr, char *s, size_t s_size) {
     return off;
   }
   /* an empty/non-numeric field leaves i unset: treat as length 0 */
-  if (sscanf(buff, "%d", &i) != 1 || i < 0 || i > 32768)
+  if (sscanf(buff, "%d", &i) != 1 || i < 0 || i > CACHE_FIELD_MAXSIZE)
     i = 0;
   if (i > 0) {
     /* a corrupt cache may declare a length past the buffer end; bound the copy
@@ -1504,52 +1509,80 @@ static int cache_brstr(char *adr, char *s, size_t s_size) {
   return off;
 }
 
-static void cache_rstr(FILE *fp, char *s, size_t s_size) {
-  INTsys i = 0;
-  char buff[256 + 4];
+/** Would reading n bytes at the current offset stay inside the .dat? A file
+    whose size is unknown (datSize negative) bounds nothing, and the read then
+    refuses on its own. **/
+static hts_boolean cache_fits(FILE *fp, long int datSize, size_t n) {
+  const long int at = ftell(fp);
 
-  linput(fp, buff, 256);
-  /* an unmatched sscanf leaves i untouched: length 0, not a stack value */
-  if (sscanf(buff, INTsysP, &i) != 1 || i < 0 || i > 32768)
-    i = 0;
-  if (i > 0) {
-    /* store at most s_size-1 bytes, but consume all i bytes so the next field
-       stays aligned when a tampered cache declares more than the destination
-       holds */
-    const size_t want = (size_t) i;
-    const size_t store = want < s_size ? want : s_size - 1;
-
-    if (!hts_fread_exact(s, store, fp)) {
-      assertf(! "fread_cache_failed");
-    }
-    if (want > store && fseek(fp, (long) (want - store), SEEK_CUR) != 0) {
-      assertf(!"fseek_cache_failed");
-    }
-    s[store] = '\0';
-  } else {
-    s[0] = '\0';
-  }
+  if (at < 0)
+    return HTS_FALSE;
+  if (datSize < 0)
+    return HTS_TRUE;
+  return at <= datSize && n <= (size_t) (datSize - at) ? HTS_TRUE : HTS_FALSE;
 }
 
-static char *cache_rstr_addr(FILE * fp) {
+/** Read a field's length prefix. HTS_FALSE on a truncated line, an unparseable
+    or out-of-range length, or one running past the end of the file: the record
+    is unreadable, and refusing it is the only way to keep the fields after it
+    aligned. **/
+static hts_boolean cache_rlen(FILE *fp, long int datSize, size_t *len) {
   INTsys i = 0;
-  char *addr = NULL;
   char buff[256 + 4];
 
+  *len = 0;
   linput(fp, buff, 256);
-  /* an unmatched sscanf leaves i untouched: length 0, not a stack value */
-  if (sscanf(buff, INTsysP, &i) != 1 || i < 0 || i > 32768)
-    i = 0;
-  if (i > 0) {
-    addr = malloc((size_t) i + 1);
-    if (addr != NULL) {
-      if (!hts_fread_exact(addr, (size_t) i, fp)) {
-        assertf(! "fread_cache_failed");
-      }
-      *(addr + i) = '\0';
-    }
+  if (sscanf(buff, INTsysP, &i) != 1 || i < 0 || i > CACHE_FIELD_MAXSIZE)
+    return HTS_FALSE;
+  if (!cache_fits(fp, datSize, (size_t) i))
+    return HTS_FALSE;
+  *len = (size_t) i;
+  return HTS_TRUE;
+}
+
+/** Read one length-prefixed field into s. HTS_FALSE leaves s empty and the
+    stream at an unknown offset, so the caller must drop the whole record. **/
+static hts_boolean cache_rstr(FILE *fp, char *s, size_t s_size,
+                              long int datSize) {
+  size_t want;
+
+  s[0] = '\0';
+  if (!cache_rlen(fp, datSize, &want))
+    return HTS_FALSE;
+  if (want != 0) {
+    /* store at most s_size-1 bytes, but consume all of them so the next field
+       stays aligned when a cache declares more than the destination holds */
+    const size_t store = want < s_size ? want : s_size - 1;
+
+    if (!hts_fread_exact(s, store, fp))
+      return HTS_FALSE;
+    if (want > store && fseek(fp, (long) (want - store), SEEK_CUR) != 0)
+      return HTS_FALSE;
+    s[store] = '\0';
   }
-  return addr;
+  return HTS_TRUE;
+}
+
+/** Read one length-prefixed field into a fresh buffer the caller owns, NULL
+    for an empty field. HTS_FALSE on a refused record, *out left NULL. **/
+static hts_boolean cache_rstr_addr(FILE *fp, long int datSize, char **out) {
+  size_t want;
+  char *addr;
+
+  *out = NULL;
+  if (!cache_rlen(fp, datSize, &want))
+    return HTS_FALSE;
+  if (want == 0)
+    return HTS_TRUE;
+  if ((addr = malloct(want + 1)) == NULL)
+    return HTS_FALSE;
+  if (!hts_fread_exact(addr, want, fp)) {
+    freet(addr);
+    return HTS_FALSE;
+  }
+  addr[want] = '\0';
+  *out = addr;
+  return HTS_TRUE;
 }
 
 /* Allocate n+1 bytes for an n-byte cache body, rejecting a hostile/corrupt
@@ -1557,27 +1590,33 @@ static char *cache_rstr_addr(FILE * fp) {
 static char *cache_alloc_body(size_t n) {
   if (n >= (size_t) INT32_MAX)
     return NULL;
-  return (char *) malloc(n + 1);
+  return (char *) malloct(n + 1);
 }
 
-static void cache_rint(FILE * fp, int *i) {
+/** Read a length-prefixed decimal field. HTS_FALSE also on a non-numeric one,
+    which is corruption the caller must not carry into the record. **/
+static hts_boolean cache_rint(FILE *fp, long int datSize, int *i) {
   char s[256];
 
-  cache_rstr(fp, s, sizeof(s));
-  if (sscanf(s, "%d", i) != 1)
-    *i = 0;
+  *i = 0;
+  if (!cache_rstr(fp, s, sizeof(s), datSize))
+    return HTS_FALSE;
+  return sscanf(s, "%d", i) == 1 ? HTS_TRUE : HTS_FALSE;
 }
 
-static void cache_rLLint(FILE * fp, unsigned long *i) {
+/** Same, for a size field: a negative value is refused rather than wrapped,
+    since cast to unsigned it would shrink a later body allocation. **/
+static hts_boolean cache_rLLint(FILE *fp, long int datSize, unsigned long *i) {
   int l;
   char s[256];
 
-  cache_rstr(fp, s, sizeof(s));
-  /* reject a non-numeric or negative field: a negative length cast to unsigned
-     would wrap a later malloc(size+1) to a tiny buffer */
+  *i = 0;
+  if (!cache_rstr(fp, s, sizeof(s), datSize))
+    return HTS_FALSE;
   if (sscanf(s, "%d", &l) != 1 || l < 0)
-    l = 0;
+    return HTS_FALSE;
   *i = (unsigned long) l;
+  return HTS_TRUE;
 }
 
 static int PT_LoadCache__Old(PT_Index index_, const char *filename) {
@@ -1610,13 +1649,17 @@ static int PT_LoadCache__Old(PT_Index index_, const char *filename) {
       strcatbuff(cache->filenameNdx, ".ndx");
     }
     ndxSize = filesize(cache->filenameNdx);
+    cache->datSize = filesize(cache->filenameDat);
     cache->timestamp = file_timestamp(cache->filenameDat);
     cache->dat = fopen(cache->filenameDat, "rb");
     cache->ndx = fopen(cache->filenameNdx, "rb");
     if (cache->dat != NULL && cache->ndx != NULL && ndxSize > 0) {
-      char *use = malloc(ndxSize + 1);
+      char *use = malloct((size_t) ndxSize + 1);
 
-      if (hts_fread_exact(use, (size_t) ndxSize, cache->ndx)) {
+      /* the index is the whole file read at once: a short read refuses it */
+      if (use == NULL || !hts_fread_exact(use, (size_t) ndxSize, cache->ndx)) {
+        freet(use);
+      } else {
         char firstline[256];
         char *a = use;
 
@@ -1631,14 +1674,12 @@ static int PT_LoadCache__Old(PT_Index index_, const char *filename) {
             } else {
               fclose(cache->dat);
               cache->dat = NULL;
-              free(use);
-              use = NULL;
+              freet(use);
             }
           } else { // non supporté
             fclose(cache->dat);
             cache->dat = NULL;
-            free(use);
-            use = NULL;
+            freet(use);
           }
           /* */
         } else {                // Vieille version du cache
@@ -1697,8 +1738,7 @@ static int PT_LoadCache__Old(PT_Index index_, const char *filename) {
             }
           }
           /* Not needed anymore! */
-          free(use);
-          use = NULL;
+          freet(use);
           return 1;
         }
       }
@@ -1774,9 +1814,12 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
   hash_pos_return = coucal_read(cache->hash, url, &hash_pos);
 
   if (hash_pos_return) {
-    int pos = (int) hash_pos;   /* simply */
+    const int pos = (int) hash_pos; /* simply */
+    /* the sign flags "body on disk", so the offset is the magnitude; INT_MIN
+       has no positive counterpart and is therefore not one */
+    const long int offset = pos == INT_MIN ? -1 : (pos > 0 ? pos : -pos);
 
-    if (fseek(cache->dat, (pos > 0) ? pos : (-pos), SEEK_SET) == 0) {
+    if (offset >= 0 && fseek(cache->dat, offset, SEEK_SET) == 0) {
       /* Importer cache1.0 */
       if (cache->version == 0) {
         OLD_htsblk old_r;
@@ -1826,45 +1869,46 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
         /* */
         /* Cache 1.1 */
       } else {
+        const long int datSize = cache->datSize;
         char check[256];
-        unsigned long size_read;
-        unsigned long int size_;
+        unsigned long size_read = 0;
+        unsigned long int size_ = 0;
 
         check[0] = '\0';
-        //
-        cache_rint(cache->dat, &r->statuscode);
-        cache_rLLint(cache->dat, &size_);
-        r->size = (size_t) size_;
-        cache_rstr(cache->dat, r->msg, sizeof(r->msg));
-        cache_rstr(cache->dat, r->contenttype, sizeof(r->contenttype));
-        if (cache->version >= 3)
-          cache_rstr(cache->dat, r->charset, sizeof(r->charset));
-        cache_rstr(cache->dat, r->lastmodified, sizeof(r->lastmodified));
-        cache_rstr(cache->dat, r->etag, sizeof(r->etag));
-        cache_rstr(cache->dat, r->location, sizeof(location_default));
-        if (cache->version >= 2)
-          cache_rstr(cache->dat, r->cdispo, sizeof(r->cdispo));
-        if (cache->version >= 4) {
-          cache_rstr(cache->dat, previous_save_, sizeof(previous_save_)); // adr
-          cache_rstr(cache->dat, previous_save_, sizeof(previous_save_)); // fil
-          previous_save[0] = '\0';
-          cache_rstr(cache->dat, previous_save_,
-                     sizeof(previous_save_)); // save
-        }
-        if (cache->version >= 5) {
-          r->headers = cache_rstr_addr(cache->dat);
-        }
-        //
-        cache_rstr(cache->dat, check, sizeof(check));
-        if (strcmp(check, "HTS") == 0) {        /* intégrité OK */
+        /* the fields are consecutive, so the first one that does not read
+           leaves every later one at the wrong offset: refuse the record
+           rather than serve fields decoded from the wrong bytes */
+        if (cache_rint(cache->dat, datSize, &r->statuscode) &&
+            cache_rLLint(cache->dat, datSize, &size_) &&
+            cache_rstr(cache->dat, r->msg, sizeof(r->msg), datSize) &&
+            cache_rstr(cache->dat, r->contenttype, sizeof(r->contenttype),
+                       datSize) &&
+            (cache->version < 3 ||
+             cache_rstr(cache->dat, r->charset, sizeof(r->charset), datSize)) &&
+            cache_rstr(cache->dat, r->lastmodified, sizeof(r->lastmodified),
+                       datSize) &&
+            cache_rstr(cache->dat, r->etag, sizeof(r->etag), datSize) &&
+            cache_rstr(cache->dat, r->location, sizeof(location_default),
+                       datSize) &&
+            (cache->version < 2 ||
+             cache_rstr(cache->dat, r->cdispo, sizeof(r->cdispo), datSize)) &&
+            (cache->version < 4 ||
+             (cache_rstr(cache->dat, previous_save_, sizeof(previous_save_),
+                         datSize) && // adr
+              cache_rstr(cache->dat, previous_save_, sizeof(previous_save_),
+                         datSize) && // fil
+              cache_rstr(cache->dat, previous_save_, sizeof(previous_save_),
+                         datSize))) && // save
+            (cache->version < 5 ||
+             cache_rstr_addr(cache->dat, datSize, &r->headers)) &&
+            cache_rstr(cache->dat, check, sizeof(check), datSize) &&
+            strcmp(check, "HTS") == 0 && /* intégrité OK */
+            cache_rLLint(cache->dat, datSize, &size_read)) {
           ok = 1;
         }
-        cache_rLLint(cache->dat, &size_read);   /* lire size pour être sûr de la taille déclarée (réécrire) */
-        if (size_read > 0) {    /* si inscrite ici */
-          r->size = size_read;
-        } else {                /* pas de données directement dans le cache, fichier présent? */
-          r->size = 0;
-        }
+        /* size_read is the authoritative one when written here; without it the
+           body lives in a separate file */
+        r->size = ok ? (size_t) size_read : 0;
       }
 
       /* Check destination filename */
@@ -1960,7 +2004,12 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
           } else {
             // lire fichier (d'un coup)
             if (flags & FETCH_BODY) {
-              r->adr = cache_alloc_body(r->size);
+              /* a body larger than the bytes left of the .dat is corruption;
+                 catch it before the allocation, not on the failing read */
+              const hts_boolean fits =
+                  cache_fits(cache->dat, cache->datSize, r->size);
+
+              r->adr = fits ? cache_alloc_body(r->size) : NULL;
               if (r->adr != NULL) {
                 if (!hts_fread_exact(r->adr, r->size, cache->dat)) { // erreur
                   PT_Element_DropBody(r);
@@ -1970,7 +2019,8 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
                   r->adr[r->size] = '\0';
               } else {          // erreur
                 r->statuscode = STATUSCODE_INVALID;
-                strcpybuff(r->msg, "Cache Memory Error");
+                strcpybuff(r->msg, fits ? "Cache Memory Error"
+                                        : "Cache Read Error : Bad Size");
               }
             }
           }
@@ -1981,6 +2031,7 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
       } else {                  // erreur
         r->statuscode = STATUSCODE_INVALID;
         strcpybuff(r->msg, "Cache Read Error : Read Header");
+        fprintf(stderr, "Truncated or corrupt cache record for %s" LF, url);
       }
     } else {
       r->statuscode = STATUSCODE_INVALID;

--- a/src/proxy/store.c
+++ b/src/proxy/store.c
@@ -1982,24 +1982,21 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
               if (fp != NULL) {
                 /* same two bounds as a .dat-held body: the format's ceiling,
                    then the file the bytes have to come out of */
-                const hts_boolean fits =
-                    r->size < (size_t) INT_MAX &&
-                    cache_fits(fp, filesize(previous_save), r->size);
-
-                r->adr = fits ? cache_alloc_body(r->size) : NULL;
-                if (r->adr != NULL) {
-                  if (r->size > 0 && !hts_fread_exact(r->adr, r->size, fp)) {
-                    PT_Element_DropBody(r);
-                    r->statuscode = STATUSCODE_INVALID;
-                    strcpybuff(r->msg, "Read error in cache disk data");
-                  } else {
-                    r->adr[r->size] = '\0';
-                  }
-                } else {
+                if (r->size >= (size_t) INT_MAX ||
+                    !cache_fits(fp, filesize(previous_save), r->size)) {
+                  r->statuscode = STATUSCODE_INVALID;
+                  strcpybuff(r->msg, "Cache Read Error : Bad Size");
+                } else if ((r->adr = cache_alloc_body(r->size)) == NULL) {
                   r->statuscode = STATUSCODE_INVALID;
                   strcpybuff(r->msg,
-                             fits ? "Read error (memory exhausted) from cache"
-                                  : "Cache Read Error : Bad Size");
+                             "Read error (memory exhausted) from cache");
+                } else if (r->size > 0 &&
+                           !hts_fread_exact(r->adr, r->size, fp)) {
+                  PT_Element_DropBody(r);
+                  r->statuscode = STATUSCODE_INVALID;
+                  strcpybuff(r->msg, "Read error in cache disk data");
+                } else {
+                  r->adr[r->size] = '\0';
                 }
                 fclose(fp);
               } else {
@@ -2015,22 +2012,19 @@ static PT_Element PT_ReadCache__Old_u(PT_Index index_, const char *url,
                  Past that the body must still fit in the bytes left of the
                  .dat, which catches corruption before the allocation rather
                  than on the failing read. */
-              const hts_boolean fits =
-                  r->size < (size_t) INT_MAX &&
-                  cache_fits(cache->dat, cache->datSize, r->size);
-
-              r->adr = fits ? cache_alloc_body(r->size) : NULL;
-              if (r->adr != NULL) {
-                if (!hts_fread_exact(r->adr, r->size, cache->dat)) { // erreur
-                  PT_Element_DropBody(r);
-                  r->statuscode = STATUSCODE_INVALID;
-                  strcpybuff(r->msg, "Cache Read Error : Read Data");
-                } else
-                  r->adr[r->size] = '\0';
-              } else {          // erreur
+              if (r->size >= (size_t) INT_MAX ||
+                  !cache_fits(cache->dat, cache->datSize, r->size)) {
                 r->statuscode = STATUSCODE_INVALID;
-                strcpybuff(r->msg, fits ? "Cache Memory Error"
-                                        : "Cache Read Error : Bad Size");
+                strcpybuff(r->msg, "Cache Read Error : Bad Size");
+              } else if ((r->adr = cache_alloc_body(r->size)) == NULL) {
+                r->statuscode = STATUSCODE_INVALID;
+                strcpybuff(r->msg, "Cache Memory Error");
+              } else if (!hts_fread_exact(r->adr, r->size, cache->dat)) {
+                PT_Element_DropBody(r);
+                r->statuscode = STATUSCODE_INVALID;
+                strcpybuff(r->msg, "Cache Read Error : Read Data");
+              } else {
+                r->adr[r->size] = '\0';
               }
             }
           }

--- a/tests/435_local-proxytrack-cache-truncated.test
+++ b/tests/435_local-proxytrack-cache-truncated.test
@@ -15,8 +15,11 @@ cleanup_push rm -rf "$dir"
 BODY='<html>hello</html>'
 refused='Truncated or corrupt cache record' # the reader's verdict
 
-# One .ndx entry pointing at offset 0 of a .dat, then a .dat per case.
-"$python" - "$(nativepath "$dir")" <<'PYEOF'
+# One .ndx entry pointing at offset 0 of a .dat, then a .dat per case. The
+# last case needs a .dat past 2 GB and is written sparse; the verdict says
+# whether the filesystem kept it that way.
+sparse=$(
+    "$python" - "$(nativepath "$dir")" <<'PYEOF'
 import os
 import sys
 
@@ -37,13 +40,15 @@ FIELDS = [b"200", b"0", b"OK", b"text/html", b"UTF-8", DATE, b"", b"", b"",
           b"%d" % len(BODY)]
 
 # cache_brstr takes the magic and the date as length-prefixed values; the entry
-# walk then skips one line before reading host, file and offset
-NDX = b"9\nCACHE-1.5%s\nx\nwww.example.com\n/index.html\n0\n" % field(DATE)
+# walk then skips one line before reading host, file and offset. A negative
+# offset means the body is on disk rather than in the .dat.
+NDX = b"9\nCACHE-1.5%s\nx\nwww.example.com\n/index.html\n%%d\n" % field(DATE)
 
 
-def write(name, dat):
+def write(name, dat, pos=0):
+    os.makedirs(os.path.dirname(os.path.join(out, name)), exist_ok=True)
     with open(os.path.join(out, name + ".ndx"), "wb") as f:
-        f.write(NDX)
+        f.write(NDX % pos)
     with open(os.path.join(out, name + ".dat"), "wb") as f:
         f.write(dat)
 
@@ -71,7 +76,33 @@ for name, i, length in (("hugemsg", 2, 30000), ("hugetype", 3, 30000),
 big = list(parts)
 big[14] = field(b"2000000000")
 write("hugebody", b"".join(big) + BODY)
+
+# A body the .dat really is long enough to hold, declared at the format's own
+# ceiling: only a cap on the declared size refuses this one.
+over = list(parts)
+over[14] = field(b"2147483647")
+write("overbody", b"".join(over) + BODY)
+dat = os.path.join(out, "overbody.dat")
+with open(dat, "r+b") as f:
+    f.truncate(2 ** 31 + 8192)
+
+# The other body path: a negative offset leaves the bytes in a file beside the
+# cache, named by the "save" field, and the same two bounds apply there. That
+# name resolves against the cache's grandparent, so keep HTTrack's own layout.
+os.makedirs(os.path.join(out, "m", "hts-cache"), exist_ok=True)
+with open(os.path.join(out, "m", "body.bin"), "wb") as f:
+    f.write(BODY)
+for name, declared in (("diskgood", len(BODY)), ("diskbig", 4096),
+                       ("diskover", 2147483647)):
+    disk = list(FIELDS)
+    disk[11] = b"body.bin"
+    disk[14] = b"%d" % declared
+    write("m/hts-cache/" + name, b"\0" * 8 + b"".join(field(f) for f in disk),
+          pos=-8)
+
+print("sparse" if os.stat(dat).st_blocks * 512 < 1024 * 1024 else "dense")
 PYEOF
+)
 
 convert() { # convert NAME
     local rc=0
@@ -106,5 +137,33 @@ grep -qa 'Cache Read Error : Bad Size' "$dir/hugebody.arc" ||
 if grep -qaF "$BODY" "$dir/hugebody.arc"; then
     fail_dump "a body larger than the .dat still came back" "$dir/hugebody.log"
 fi
+
+# Here the .dat is long enough, so the bytes-remaining bound passes it and the
+# declared size is refused on the format's ceiling alone. Without that ceiling
+# the allocator refuses it instead, and reports a bad size as a memory failure.
+if test "$sparse" != sparse; then
+    echo "no sparse files here; skipping the 2 GB .dat case" >&2
+else
+    convert overbody
+    grep -qa 'Cache Read Error : Bad Size' "$dir/overbody.arc" ||
+        fail_dump "a body declared at the format ceiling was not refused" "$dir/overbody.log"
+    if grep -qaF "$BODY" "$dir/overbody.arc"; then
+        fail_dump "a body declared at the format ceiling still came back" "$dir/overbody.log"
+    fi
+fi
+
+# The sibling allocation, for a body held in a file beside the cache. Its
+# control comes first: bounding this one must not drop an honest entry.
+convert m/hts-cache/diskgood
+grep -qaF "$BODY" "$dir/m/hts-cache/diskgood.arc" ||
+    fail_dump "an on-disk body of the declared size was lost" "$dir/m/hts-cache/diskgood.log"
+for name in m/hts-cache/diskbig m/hts-cache/diskover; do
+    convert "$name"
+    grep -qa 'Cache Read Error : Bad Size' "$dir/$name.arc" ||
+        fail_dump "$name declared more than its file holds and was accepted" "$dir/$name.log"
+    if grep -qaF "$BODY" "$dir/$name.arc"; then
+        fail_dump "$name still returned a body" "$dir/$name.log"
+    fi
+done
 
 exit 0

--- a/tests/435_local-proxytrack-cache-truncated.test
+++ b/tests/435_local-proxytrack-cache-truncated.test
@@ -1,0 +1,110 @@
+#!/bin/bash
+# A .dat field declaring more bytes than the file holds used to abort
+# proxytrack ("fread_cache_failed"). A cache is untrusted input, so a record
+# that does not read back must be refused, not taken down the process.
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+python=$(find_python) || skip "python3 missing"
+
+dir=$(mktemp -d)
+cleanup_push rm -rf "$dir"
+
+BODY='<html>hello</html>'
+refused='Truncated or corrupt cache record' # the reader's verdict
+
+# One .ndx entry pointing at offset 0 of a .dat, then a .dat per case.
+"$python" - "$(nativepath "$dir")" <<'PYEOF'
+import os
+import sys
+
+DATE = b"Mon, 01 Jan 2025 00:00:00 GMT"
+BODY = b"<html>hello</html>"
+out = sys.argv[1]
+
+
+def field(value):
+    return b"%d\n%s" % (len(value), value)
+
+
+# statuscode, size, msg, contenttype, charset, last-modified, etag, location,
+# content-disposition, adr, fil, save, headers, the "HTS" integrity marker,
+# then the size the body actually follows with
+FIELDS = [b"200", b"0", b"OK", b"text/html", b"UTF-8", DATE, b"", b"", b"",
+          b"www.example.com", b"/index.html", b"", b"", b"HTS",
+          b"%d" % len(BODY)]
+
+# cache_brstr takes the magic and the date as length-prefixed values; the entry
+# walk then skips one line before reading host, file and offset
+NDX = b"9\nCACHE-1.5%s\nx\nwww.example.com\n/index.html\n0\n" % field(DATE)
+
+
+def write(name, dat):
+    with open(os.path.join(out, name + ".ndx"), "wb") as f:
+        f.write(NDX)
+    with open(os.path.join(out, name + ".dat"), "wb") as f:
+        f.write(dat)
+
+
+parts = [field(f) for f in FIELDS]
+write("good", b"".join(parts) + BODY)
+
+# Cut inside every field in turn: a fix bounding only the field the fuzzer
+# reached would still abort on the others.
+at = 0
+for i, part in enumerate(parts):
+    at += len(part)
+    write("cut%d" % i, b"".join(parts)[: at - len(FIELDS[i]) // 2])
+
+# A length the file cannot satisfy, in fields of three different capacities
+# and spanning the reader's own bound
+for name, i, length in (("hugemsg", 2, 30000), ("hugetype", 3, 30000),
+                        ("hugehdrs", 12, 30000), ("overmsg", 2, 32769),
+                        ("negtype", 3, -5), ("junktype", 3, None)):
+    bad = list(parts)
+    bad[i] = b"junk\n" if length is None else b"%d\n" % length
+    write(name, b"".join(bad) + BODY)
+
+# a body larger than the .dat, which must be refused before it is allocated
+big = list(parts)
+big[14] = field(b"2000000000")
+write("hugebody", b"".join(big) + BODY)
+PYEOF
+
+convert() { # convert NAME
+    local rc=0
+    proxytrack --convert "$dir/$1.arc" "$dir/$1.ndx" >"$dir/$1.log" 2>&1 || rc=$?
+    test "$rc" -lt 128 ||
+        fail_dump "proxytrack died on $1.dat with SIG$(kill -l $((rc - 128)))" "$dir/$1.log"
+    test "$rc" = 0 || fail_dump "proxytrack failed ($rc) on $1.dat" "$dir/$1.log"
+}
+
+# Control: without it a fix refusing every legacy record passes everything below
+convert good
+grep -qaF "$BODY" "$dir/good.arc" || fail_dump "an intact record lost its body" "$dir/good.log"
+if grep -qaF "$refused" "$dir/good.log"; then
+    fail_dump "an intact record was refused" "$dir/good.log"
+fi
+
+for name in cut0 cut1 cut2 cut3 cut4 cut5 cut6 cut7 cut8 cut9 cut10 cut11 \
+    cut12 cut13 cut14 hugemsg hugetype hugehdrs overmsg negtype junktype; do
+    convert "$name"
+    grep -qaF "$refused" "$dir/$name.log" ||
+        fail_dump "$name.dat was read rather than refused" "$dir/$name.log"
+    if grep -qaF "$BODY" "$dir/$name.arc"; then
+        fail_dump "$name.dat still yielded a body" "$dir/$name.log"
+    fi
+done
+
+# The header of this one reads back whole, so it is the body allocation alone
+# that must refuse the declared size before demanding 2 GB for it.
+convert hugebody
+grep -qa 'Cache Read Error : Bad Size' "$dir/hugebody.arc" ||
+    fail_dump "a body larger than the .dat was accepted" "$dir/hugebody.log"
+if grep -qaF "$BODY" "$dir/hugebody.arc"; then
+    fail_dump "a body larger than the .dat still came back" "$dir/hugebody.log"
+fi
+
+exit 0

--- a/tests/435_local-proxytrack-cache-truncated.test
+++ b/tests/435_local-proxytrack-cache-truncated.test
@@ -82,9 +82,24 @@ write("hugebody", b"".join(big) + BODY)
 over = list(parts)
 over[14] = field(b"2147483647")
 write("overbody", b"".join(over) + BODY)
+# the same fixture carrying an honest body, to find out whether this build can
+# size a .dat that large at all
+write("overprobe", b"".join(parts) + BODY)
+
+# Extend one, and keep going only while the file stays a hole: a filesystem
+# that allocates it (or a stat that cannot say, as on Windows) gets neither.
+BIG = 2 ** 31 + 8192
 dat = os.path.join(out, "overbody.dat")
 with open(dat, "r+b") as f:
-    f.truncate(2 ** 31 + 8192)
+    f.truncate(BIG)
+st = os.stat(dat)
+sparse = hasattr(st, "st_blocks") and st.st_blocks * 512 < 1024 * 1024
+if sparse:
+    with open(os.path.join(out, "overprobe.dat"), "r+b") as f:
+        f.truncate(BIG)
+else:
+    with open(dat, "r+b") as f:
+        f.truncate(len(b"".join(parts)) + len(BODY))
 
 # The other body path: a negative offset leaves the bytes in a file beside the
 # cache, named by the "save" field, and the same two bounds apply there. That
@@ -100,7 +115,7 @@ for name, declared in (("diskgood", len(BODY)), ("diskbig", 4096),
     write("m/hts-cache/" + name, b"\0" * 8 + b"".join(field(f) for f in disk),
           pos=-8)
 
-print("sparse" if os.stat(dat).st_blocks * 512 < 1024 * 1024 else "dense")
+print("sparse" if sparse else "dense")
 PYEOF
 )
 
@@ -141,14 +156,27 @@ fi
 # Here the .dat is long enough, so the bytes-remaining bound passes it and the
 # declared size is refused on the format's ceiling alone. Without that ceiling
 # the allocator refuses it instead, and reports a bad size as a memory failure.
+#
+# A build whose long int is 32 bits cannot size a .dat that large: filesize()
+# wraps it negative and the record is refused before the ceiling is consulted,
+# so the case has nothing to observe there. The probe carries an honest body
+# and its verdict says which of the two this build is; a third answer is a
+# regression, not a reason to skip.
 if test "$sparse" != sparse; then
     echo "no sparse files here; skipping the 2 GB .dat case" >&2
 else
-    convert overbody
-    grep -qa 'Cache Read Error : Bad Size' "$dir/overbody.arc" ||
-        fail_dump "a body declared at the format ceiling was not refused" "$dir/overbody.log"
-    if grep -qaF "$BODY" "$dir/overbody.arc"; then
-        fail_dump "a body declared at the format ceiling still came back" "$dir/overbody.log"
+    convert overprobe
+    if grep -qaF "$BODY" "$dir/overprobe.arc"; then
+        convert overbody
+        grep -qa 'Cache Read Error : Bad Size' "$dir/overbody.arc" ||
+            fail_dump "a body declared at the format ceiling was not refused" "$dir/overbody.log"
+        if grep -qaF "$BODY" "$dir/overbody.arc"; then
+            fail_dump "a body declared at the format ceiling still came back" "$dir/overbody.log"
+        fi
+    elif grep -qaF "$refused" "$dir/overprobe.log"; then
+        echo "long int cannot size a 2 GB .dat here; skipping the ceiling case" >&2
+    else
+        fail_dump "the 2 GB .dat probe neither read nor refused its record" "$dir/overprobe.log"
     fi
 fi
 


### PR DESCRIPTION
`cache_rstr()` aborted the process whenever a `.dat` field's declared length ran past the end of the file. Fuzzing the legacy `.ndx`/`.dat` reader piled 828 crash artifacts onto that one `assertf(!"fread_cache_failed")`. proxytrack reads whatever mirror directory it is pointed at, so a cache is untrusted input. Aborting answers a malformed one with a denial of service.

The length-prefixed readers now return a verdict instead. A length is refused before the read when it is negative, past the format's own bound, or larger than the bytes left of the `.dat`. That last check also stops a corrupt body size from asking for 2 GB the file can never fill.

Refusal is per record. The fields of a record are consecutive, so the first one that does not read leaves every later one decoded from the wrong bytes. proxytrack serves what it reads. The whole file is refused only when the `.ndx` itself cannot be read, since the index is slurped in one go.

Two more bugs sat in the same path. `PT_LoadCache__Old()` handed an unchecked `malloc()` result to `fread()`, and leaked the buffer on a short read. An index entry holding `INT_MIN` was negated as an `int`.

Test 435 builds a valid `.ndx`/`.dat` pair, then cuts it inside each of the fifteen fields in turn. A fix bounding only the field the fuzzer reached still fails it. The intact pair is the control, and its converted output is byte-identical to what master produces.

Ten minutes of `fuzz-cachendx` (3.1M executions, 6308 new corpus units) now finds nothing. The same harness over the same corpus crashes on master within seconds.

Two allocations sized from the file gain a constant ceiling as well. The legacy `.dat` holds whole mirrored files, so no format maximum exists for a cap to use. The only intrinsic limit is the 32-bit signed size field. Both bodies now take `INT_MAX`, which is the bound the ZIP reader beside them already uses.

The disk-held body had no file bound at all, so it now takes both. That is the older of the two code-scanning alerts on this reader, and the pair drops to one.

A `datSize < 0` escape in the new bounds helper is gone. `filesize()` answers in a `long int`. A 32-bit build handed a `.dat` past two gigabytes read back a value that waived the bound. That is the case the bound exists for.

The ceiling case cannot run on a 32-bit build. Reaching it needs a file size that a 32-bit `long` cannot hold, so the record is refused earlier and for a different reason. Nothing portable reports the build's word size, because that leg is a 32-bit binary on a 64-bit host. A probe fixture of the same size, with an honest body, decides instead. If it reads back, the ceiling assertion runs. If it is refused, the case skips and names the width. Any third answer fails, so a regression cannot hide in the skip.

Neither allocation was ever unbounded. `r->size` arrives in `[0, INT_MAX]` on every path. The 1.1 header parses it with `%d` and refuses a negative, and the 1.0 header holds an `int` gated above zero. The file bound and the ceiling narrow it further, and the guard now sits immediately before the allocation rather than two statements away. Refusing a size, failing to allocate and failing to read each carry their own message, where one line used to serve two of them.