### PR TITLE
Two tests skip a whole file where only half is unobservable

### DIFF
--- a/tests/206_install-headers-c99.test
+++ b/tests/206_install-headers-c99.test
@@ -191,6 +191,12 @@ else
     done
 fi
 
+# The loops above are only meaningful if this compiler rejects a missing include.
+printf '#include "no-such-header-972.h"\n' >"$tmp/tu.c"
+if "${cc_argv[@]}" "${cpp_argv[@]}" "-std=${stds[0]}" -fsyntax-only "$tmp/tu.c" 2>/dev/null; then
+    fail "${cc_argv[*]} accepted a missing include, the checks above proved nothing"
+fi
+
 # The installed headers must also compile as C++ (#1002). -fsyntax-only never
 # runs g++'s -Wunused-function pass, so this leg always does a real -c compile.
 cxx=""
@@ -251,11 +257,5 @@ else
         fail "the C++ compile loop skipped units"
 fi
 [ "$bad" -eq 0 ] || fail "installed headers do not compile as C++"
-
-# The loops above are only meaningful if this compiler rejects a missing include.
-printf '#include "no-such-header-972.h"\n' >"$tmp/tu.c"
-if "${cc_argv[@]}" "${cpp_argv[@]}" "-std=${stds[0]}" -fsyntax-only "$tmp/tu.c" 2>/dev/null; then
-    fail "${cc_argv[*]} accepted a missing include, the checks above proved nothing"
-fi
 
 exit 0

--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -134,6 +134,7 @@ usestub() {
 }
 usestub argvstub
 
+noexec_reason=''
 if test -x "$bin/pwsh"; then
     (
         cd "$posixtmp"
@@ -237,7 +238,8 @@ if test -x "$bin/pwsh"; then
     grep -qx -- "$(nativepath "$posixtmp/progress.log")" "$posixtmp/argv" ||
         fail "the launch did not pass the progress log"
 else
-    skip "$tmp is noexec, the stub bindir cannot be run"
+    # Deferred, not taken here: the workflow audits below need no exec.
+    noexec_reason="$tmp is noexec, the stub bindir cannot be run"
 fi
 
 py=$(find_python || true)
@@ -444,6 +446,8 @@ PY
     test "$maxsecs" -ge $((deadline + stuck)) ||
         fail "the watchdog stops at ${maxsecs}s, before the kill at $((deadline + stuck))s"
 fi
+
+test -z "$noexec_reason" || skip "$noexec_reason"
 
 psruns=()
 for c in pwsh powershell.exe powershell; do


### PR DESCRIPTION
Two skips added in #1562 and #1563 abort a whole test file where only part of it is unobservable. A host that hits either one loses coverage master used to run.

`226_watchdog-native.test` skipped on a noexec TMPDIR at the point where the stub `bindir` cannot be executed. Everything after it is the workflow-YAML audit: the checkout's `persist-credentials`, the suite job's `statuses: write`, the `WATCHDOG_*` env pins. None of that needs exec. The skip is now deferred to just before the PowerShell gate, so the audits run first and the test still ends at 77.

`206_install-headers-c99.test` skipped when no C++ driver is present, or when the one found accepts neither `-std=c++11` nor `-std=c++17`. Its last assertion is the control proving the compiler rejects a missing include, and that assertion sat after the gate. So the 56 C compile units above it were left unvalidated. A compiler that swallows a missing include would have made all 56 vacuous, and the file would still have reported SKIP. The control moves ahead of the C++ leg, where it belongs anyway, because it exercises `$CC` and never covered `$cxx`.

Both tests still report SKIP overall. The part that cannot run is half of what each file exists for, so PASS would claim work that did not happen. What changes is that a failure in the retained half now beats the skip.

Both environments were reproduced rather than reasoned about. For 226 that is a `unshare -rm` tmpfs remounted noexec. Plant `persist-credentials: true` in `windows-build.yml`, and master reports 77 where the branch reports FAIL. For 206 it is a `g++`/`clang++`/`c++` stub rejecting every `-std=`, and separately a PATH carrying no C++ driver at all. Wrap `$CC` in a compiler that exits 0 on any `-fsyntax-only` of an including TU. Master reports 77 where the branch fails the control.
