### PR TITLE
A port read from a Windows python carries a CR into the URL

### DIFF
--- a/tests/77_webhttrack-redirect.test
+++ b/tests/77_webhttrack-redirect.test
@@ -28,6 +28,7 @@ post_redirect() {
 # this discriminates where the announced URL cannot.
 probe_alias() {
     "${HTS_PYTHON}" -c 'import socket, sys
+sys.stdout.reconfigure(newline="\n")  # the word below is compared byte for byte
 s = socket.socket()
 try:
     s.bind(("127.0.0.2", int(sys.argv[1])))
@@ -41,7 +42,9 @@ finally:
 
 # Non-repeating and not a round number: a truncation, a reorder or a dropped
 # interior byte all stay visible.
-long=$("${HTS_PYTHON}" -c 'print("".join(chr(33 + i % 90) for i in range(4097)))')
+long=$("${HTS_PYTHON}" -c 'import sys
+sys.stdout.reconfigure(newline="\n")  # a CR here would be a 4098th byte to echo
+print("".join(chr(33 + i % 90) for i in range(4097)))')
 htsserver_start
 sid=$(htsserver_sid)
 test "${#sid}" -eq 32 || fail "did not scrape a 32-hex sid (got '${sid}')"

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -924,6 +924,9 @@ discover_server_port() {
         if test -r "$log"; then
             # Read in the shell: a grep per tick is a process per tick (#795).
             while read -r line; do
+                # A Windows python under wsl2 prints CRLF and the interop pipe
+                # keeps the CR, which then rides into the URL the caller builds.
+                line=${line%$'\r'}
                 case "$line" in 'PORT '*)
                     printf '%s\n' "${line#PORT }"
                     return 0


### PR DESCRIPTION
`433_local-status-line.test` fails the WSL2 sub-leg of both Windows jobs. The cause is the one #1566 fixed for 427, one layer down. `tests/status-line-server.py` is the only PORT-announcing fixture that never called `sys.stdout.reconfigure(newline="\n")`, so under the Windows python `find_python` picks there it printed `PORT 57011\r\n`. `discover_server_port` reads that line with `read -r`, which strips the LF and keeps the CR. The port then went into the URL: the log shows `mirroring http://127.0.0.1:57011%20/lonelf.html`, the engine's argv rewrite having turned the CR into a space. The served status lines are written to the socket as bytes and were never involved.

The fix goes in `discover_server_port` rather than in the fixture. The six other fixtures' reconfigure calls then stop being the only thing standing between a new server and this failure. Those calls stay: they also cover the `ORIGIN`, `PROXY` and `ready` lines, which the helper does not read.

Sweeping the tests added or reworked yesterday found one more site of the same shape, in `77_webhttrack-redirect.test`. There `long` and `probe_alias` both capture a python `print` and compare it byte for byte. The webhttrack tests match none of the Windows suite's category globs, so it could not have gone red there yet.

Both fixes were graded against a stand-in for the Windows python. It gives an inline script the CRLF stdout that one has, and its own reconfigure still turns it off. 77 and 433 fail under it before the change and pass after, with the fixtures unmodified. The other 21 tests in the sweep pass under it unchanged.

`431_local-credential-name-aborts.test`, on #1561's branch, carries the same shape and is named `*_local-*`, so the Windows suite will run it. Its `long_host=$("$python" -c 'print(...)')` is compared against `$got`, which comes back from the engine CR-free. It is not touched here.
