### PR TITLE
Nothing catches a windows-build.yml edit that renames its required contexts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,10 @@ the operational checklist: toolchain, invariants, and how to ship a change.
 - `make check` prepends the build's `src/` to `PATH`, but a hand-run `.test` does
   not — an installed `/usr/bin/httrack` then shadows your build. Run via `make
   check`, or `PATH="<bld>/src:$PATH"` for a manual run.
+- `distcheck` is a required context and builds from the dist tarball, which has no
+  `.github/`. A test reading a file from there must skip when it is missing, not
+  fail. Fail only when the directory is present and the file is not, so a real
+  deletion is still caught. Tests 226, 278, 399, 432 and 437 carry the pattern.
 - Give new `.test` scripts `set -e`: the older ones predate the rule, so several
   `local-crawl.sh` calls with no `set -e` report PASS on any non-last failure.
 - Each test runs under a 600s wall-clock guard that reports a wedge as 124. A test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,14 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   byte-wise (`perl -0pi`, `sed`), not through a tool that re-encodes to UTF-8
   and corrupts them. The rest of the tree, including `lang/*.txt` and
   `html/contact.html`, is UTF-8 and safe to edit normally.
+- **Never add a matrix axis to `windows-build.yml`.** The `libhttrack` job has no
+  `name:`, so GitHub builds each status context from the job id plus the matrix
+  values. That yields `libhttrack (x64, Release)` and `libhttrack (Win32,
+  Release)`, and the `Protect master` ruleset requires both by name. A third axis
+  renames them, so both stop reporting on every open PR in the repo, not only the
+  one that added the axis. Give a new Windows leg its own job with a pinned
+  `name:`, or add a step to the existing job. `437_ci-windows-contexts.test`
+  fails on any such rename.
 
 ## Security (HTTrack parses hostile input off the network)
 - Bounds-check every copy. Overflow-safe form: put the untrusted value alone,

--- a/tests/437_ci-windows-contexts.test
+++ b/tests/437_ci-windows-contexts.test
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# windows-build.yml's job names generate the two status contexts the branch
+# ruleset requires by name, so any edit that renames them stops both from
+# reporting on every open PR, not just the one that made the edit.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+wf="$top_srcdir/.github/workflows/windows-build.yml"
+test -r "$wf" || fail "no $wf"
+
+# The contexts named in the "Protect master" ruleset, pinned rather than derived,
+# because one file compared against itself proves nothing.
+want='libhttrack (Win32, Release)
+libhttrack (x64, Release)'
+
+# What GitHub will call the job's legs: the job id (a job with an explicit
+# name: uses that instead), then the matrix values in declaration order.
+contexts() { # contexts <workflow>
+    awk '
+        /^jobs:/ { injobs = 1; next }
+        !injobs { next }
+        /^  [A-Za-z0-9_-]+:/ {
+            injob = ($0 ~ /^  libhttrack:/)
+            if (injob) { sub(/:.*/, ""); sub(/^  /, ""); id = $0 }
+            next
+        }
+        !injob { next }
+        /^    name:/ { bad = 1; print "ERR: the job carries an explicit name:"; exit 1 }
+        /^      matrix:/ { inmatrix = 1; next }
+        inmatrix && /^        [A-Za-z0-9_-]+: *\[/ {
+            sub(/^[^[]*\[/, ""); sub(/\].*/, "")
+            gsub(/ /, "")
+            n++; axis[n] = $0
+            next
+        }
+        inmatrix && /^      [A-Za-z0-9_-]+:/ { inmatrix = 0 }
+        END {
+            if (bad) exit 1
+            if (!id) { print "ERR: no libhttrack job"; exit 1 }
+            if (!n) { print "ERR: no matrix axes"; exit 1 }
+            # Cross-product, left axis slowest, which is the order GitHub uses.
+            out[1] = ""
+            count = 1
+            for (i = 1; i <= n; i++) {
+                m = split(axis[i], v, ",")
+                k = 0
+                for (c = 1; c <= count; c++)
+                    for (j = 1; j <= m; j++)
+                        next_out[++k] = (out[c] == "" ? v[j] : out[c] ", " v[j])
+                for (c = 1; c <= k; c++) out[c] = next_out[c]
+                count = k
+            }
+            for (c = 1; c <= count; c++) print id " (" out[c] ")"
+        }
+    ' "$1"
+}
+
+# Not piped into sort, because a failing parse would hand its status to sort.
+got=$(contexts "$wf") || fail "windows-build.yml could not be read: $got"
+got=$(sort <<<"$got")
+test "$got" = "$want" || fail "windows-build.yml generates:
+$got
+but the ruleset requires:
+$want
+An added matrix axis or a job rename stops BOTH required contexts from
+reporting on every open PR. Give a new leg its own job with a pinned name:."
+
+# The mutant this exists to catch: a third axis, which renames both legs.
+mut=$(mktemp "${TMPDIR:-/tmp}/httrack_wf.XXXXXX")
+cleanup_push rm -f "$mut"
+sed 's/^        configuration: \[Release\]/&\n        toolset: [v143]/' "$wf" >"$mut"
+cmp -s "$wf" "$mut" && fail "the added-axis mutant changed nothing, so it proves nothing"
+mutgot=$(contexts "$mut") || fail "the added-axis mutant broke the parse: $mutgot"
+mutgot=$(sort <<<"$mutgot")
+test "$mutgot" != "$want" || fail "a third matrix axis left the contexts unchanged: $mutgot"
+
+# And the other half of the same break: an explicit job name.
+sed 's/^  libhttrack:/&\n    name: windows/' "$wf" >"$mut"
+contexts "$mut" >/dev/null 2>&1 && fail "an explicit job name: went unreported"
+
+echo "windows-build contexts OK ($(printf '%s' "$got" | count_matching_lines .) required, both generated)"

--- a/tests/437_ci-windows-contexts.test
+++ b/tests/437_ci-windows-contexts.test
@@ -9,8 +9,13 @@ set -euo pipefail
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-wf="$top_srcdir/.github/workflows/windows-build.yml"
-test -r "$wf" || fail "no $wf"
+top=${abs_top_srcdir:-$(cd "$testdir/.." && pwd)}
+wf="$top/.github/workflows/windows-build.yml"
+
+if ! test -r "$wf"; then
+    test -d "$top/.github" && fail "$wf is gone but $top/.github is not"
+    skip "no .github under $top (dist tarball), so the audit has nothing to read"
+fi
 
 # The contexts named in the "Protect master" ruleset, pinned rather than derived,
 # because one file compared against itself proves nothing.
@@ -31,6 +36,11 @@ contexts() { # contexts <workflow>
         !injob { next }
         /^    name:/ { bad = 1; print "ERR: the job carries an explicit name:"; exit 1 }
         /^      matrix:/ { inmatrix = 1; next }
+        inmatrix && /^        (include|exclude):/ {
+            bad = 1
+            print "ERR: the matrix has include:/exclude:, which this guard cannot model"
+            exit 1
+        }
         inmatrix && /^        [A-Za-z0-9_-]+: *\[/ {
             sub(/^[^[]*\[/, ""); sub(/\].*/, "")
             gsub(/ /, "")


### PR DESCRIPTION
Adding a third axis to `windows-build.yml`'s matrix renames both Windows status contexts, and the `Protect master` ruleset requires them by name. The renamed legs report under new names, and the required ones never report at all. Every open PR in the repo then blocks, not only the one that added the axis. Giving the `libhttrack` job an explicit `name:` breaks it the same way.

Nothing caught that. `437_ci-windows-contexts.test` builds the context strings GitHub will generate, then compares them against the two the ruleset requires. Those two are pinned as literals rather than derived from the workflow, because one file compared against itself proves nothing.

Four mutants kill the test: a third axis, a dropped platform, a renamed job, and an explicit `name:`. Each one reds with the reason rather than dying silently, which the first draft did under `pipefail`.

The AGENTS.md note says the same thing for a human, since the trap is invisible from the workflow file alone.
