### PR TITLE
pace() was copied into a second test instead of moving to testlib

### DIFF
--- a/tests/397_configure-auto-features.test
+++ b/tests/397_configure-auto-features.test
@@ -169,13 +169,7 @@ assert_state() { # assert_state DIR NAME on|off
 n=0
 planned=10 # steps below; the last one needs the libraries to be installed
 
-# Pace against the costliest step so far, never against the last one: these steps
-# are ordered by what they mean, so a cheap one under-projects the slow one after it.
-costliest=0
-pace() { # pace <seconds the step took>
-    test "$1" -le "${costliest}" || costliest=$1
-    skip_if_out_of_budget "$((planned - n))" "${costliest}"
-}
+pace_init
 
 # A GNU-libiconv-shaped prefix: a header that renames iconv_open the way the
 # real one does away from LIBICONV_PLUG, and a library under a subdirectory the
@@ -610,7 +604,7 @@ build:
 	false
 MUT
     echo "ok: every dh_auto_configure debian/rules runs asks for every feature"
-    pace "$((SECONDS - began))"
+    pace "$((planned - n))" "$((SECONDS - began))"
 else
     planned=$((planned - 1))
     echo "no debian/rules under ${srcdir}, so the packaging flag list is not read" >&2
@@ -626,7 +620,7 @@ n=$((n + 1))
 grep -q 'bad value for auto-features' "${work}/bogus/configure.log" ||
     fail_dump "configure refused the value without saying which flag" "${work}/bogus/configure.log"
 echo "ok: a value that is neither yes nor no is refused"
-pace "$((SECONDS - began))"
+pace "$((planned - n))" "$((SECONDS - began))"
 
 began=${SECONDS}
 n=$((n + 1))
@@ -636,7 +630,7 @@ n=$((n + 1))
 grep -q 'bad value for backtrace' "${work}/btbogus/configure.log" ||
     fail_dump "configure refused the value without saying which flag" "${work}/btbogus/configure.log"
 echo "ok: an unknown --enable-backtrace value is refused"
-pace "$((SECONDS - began))"
+pace "$((planned - n))" "$((SECONDS - began))"
 
 began=${SECONDS}
 n=$((n + 1))
@@ -647,7 +641,7 @@ mkdir -p "${work}/empty"
 grep -q 'brotli requested at' "${work}/reject/configure.log" ||
     fail_dump "configure failed without naming the prefix it was given" "${work}/reject/configure.log"
 echo "ok: an explicit prefix with no library still fails the build"
-pace "$((SECONDS - began))"
+pace "$((planned - n))" "$((SECONDS - began))"
 
 began=${SECONDS}
 n=$((n + 1))
@@ -665,7 +659,7 @@ case ${got} in
 *) fail_dump "a foreign host answered '${got}' rather than declining backtrace" \
     "${work}/foreign/configure.log" ;;
 esac
-pace "$((SECONDS - began))"
+pace "$((planned - n))" "$((SECONDS - began))"
 
 began=${SECONDS}
 n=$((n + 1))
@@ -693,7 +687,7 @@ grep -q 'iconv requested but no iconv.h with a linkable iconv_open' \
     fail_dump "configure failed without saying that iconv was the request" \
         "${work}/ic-bare/configure.log"
 echo "ok: a bare --with-iconv fails the build rather than falling back"
-pace "$((SECONDS - began))"
+pace "$((planned - n))" "$((SECONDS - began))"
 
 began=${SECONDS}
 n=$((n + 1))
@@ -734,7 +728,7 @@ else
     n=$((n - 1))
     echo "no shared library from ${cc_argv[0]}, so the iconv prefix case is skipped" >&2
 fi
-pace "$((SECONDS - began))"
+pace "$((planned - n))" "$((SECONDS - began))"
 
 began=${SECONDS}
 n=$((n + 1))
@@ -750,7 +744,7 @@ for f in ${features}; do
     assert_state "${work}/off" "${f}" off
 done
 echo "ok: the switch turns every feature off, whatever the host has installed"
-pace "$((SECONDS - began))"
+pace "$((planned - n))" "$((SECONDS - began))"
 
 began=${SECONDS}
 n=$((n + 1))
@@ -770,7 +764,7 @@ for f in ${features}; do
     esac
 done
 echo "ok: every feature answers the default run; auto-enabled here:${on:- none}"
-pace "$((SECONDS - began))"
+pace "$((planned - n))" "$((SECONDS - began))"
 
 if test -z "${on}"; then
     planned=$((planned - 1))

--- a/tests/397_configure-auto-features.test
+++ b/tests/397_configure-auto-features.test
@@ -169,8 +169,6 @@ assert_state() { # assert_state DIR NAME on|off
 n=0
 planned=10 # steps below; the last one needs the libraries to be installed
 
-pace_init
-
 # A GNU-libiconv-shaped prefix: a header that renames iconv_open the way the
 # real one does away from LIBICONV_PLUG, and a library under a subdirectory the
 # bare prefix does not name. Both halves matter, because a probe that declares

--- a/tests/426_configure-ipv6-flag.test
+++ b/tests/426_configure-ipv6-flag.test
@@ -34,14 +34,9 @@ n=0
 cases=9
 last_dir=
 
-# Pace against the costliest step so far, never against the last one: the two
-# rejections below give up early, and projecting a full configure off one of
-# them is how the s390x leg ran into its budget instead of skipping.
-costliest=0
-pace() { # pace <seconds the step took>
-    test "$1" -le "${costliest}" || costliest=$1
-    skip_if_out_of_budget "$((cases - n))" "${costliest}"
-}
+# The two rejections below give up early, and projecting a full configure off one
+# of them is how the s390x leg ran into its budget instead of skipping.
+pace_init
 
 # Seeding the cache variable is the answer a host without getaddrinfo gives, and
 # AC_CHECK_LIB takes the same action-if-not-found branch either way. "have"
@@ -99,7 +94,7 @@ expect() { # expect DESC SEED WANT-VALUE WANT-SUMMARY ARG...
     grep -q "whether IPv6 support is enabled\.\.\. ${summary}\$" "${last_dir}/configure.log" ||
         fail_dump "${desc}: configure did not report '${summary}'" "${last_dir}/configure.log"
     echo "ok: ${desc}"
-    pace "$((SECONDS - began))"
+    pace "$((cases - n))" "$((SECONDS - began))"
 }
 
 expect_fail() { # expect_fail DESC SEED WANT-TEXT ARG...
@@ -112,7 +107,7 @@ expect_fail() { # expect_fail DESC SEED WANT-TEXT ARG...
     grep -q "${text}" "${last_dir}/configure.log" ||
         fail_dump "${desc}: configure failed without saying '${text}'" "${last_dir}/configure.log"
     echo "ok: ${desc}"
-    pace "$((SECONDS - began))"
+    pace "$((cases - n))" "$((SECONDS - began))"
 }
 
 # The probe must define the macro either way, and this is the case master

--- a/tests/426_configure-ipv6-flag.test
+++ b/tests/426_configure-ipv6-flag.test
@@ -36,7 +36,6 @@ last_dir=
 
 # The two rejections below give up early, and projecting a full configure off one
 # of them is how the s390x leg ran into its budget instead of skipping.
-pace_init
 
 # Seeding the cache variable is the answer a host without getaddrinfo gives, and
 # AC_CHECK_LIB takes the same action-if-not-found branch either way. "have"

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -1194,10 +1194,9 @@ skip_if_out_of_budget() { # skip_if_out_of_budget <steps left> <seconds the last
     exit 77
 }
 
-# The costliest step pace() has seen. pace_init resets it, so one shell sourcing
-# this for two tests cannot let the first one's timing pace the second.
+# The costliest step pace() has seen. Each test is its own process, so loading
+# this is the reset.
 PACE_COSTLIEST=0
-pace_init() { PACE_COSTLIEST=0; }
 
 # skip_if_out_of_budget against the costliest step so far rather than the last
 # one: a caller orders its steps by what they mean, so a cheap one projects a

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -1194,6 +1194,19 @@ skip_if_out_of_budget() { # skip_if_out_of_budget <steps left> <seconds the last
     exit 77
 }
 
+# The costliest step pace() has seen. pace_init resets it, so one shell sourcing
+# this for two tests cannot let the first one's timing pace the second.
+PACE_COSTLIEST=0
+pace_init() { PACE_COSTLIEST=0; }
+
+# skip_if_out_of_budget against the costliest step so far rather than the last
+# one: a caller orders its steps by what they mean, so a cheap one projects a
+# reserve the slow step after it cannot fit in (#1568).
+pace() { # pace <steps left> <seconds the step took>
+    test "$2" -le "${PACE_COSTLIEST}" || PACE_COSTLIEST=$2
+    skip_if_out_of_budget "$1" "${PACE_COSTLIEST}"
+}
+
 # Seconds left of the budget, for a child pacing itself against it (269 hands it to
 # the sweep). Never below 1 unless the guard is off, when it stays 0.
 budget_left() {


### PR DESCRIPTION
`pace()` wraps `skip_if_out_of_budget` with a memory of the costliest step so far, and #1568 copied it verbatim into `426_configure-ipv6-flag.test` alongside the `397_configure-auto-features.test` original. Second occurrence, so it moves to `tests/testlib.sh` beside the function it wraps.

The two copies had not drifted. They differed only in the name of the total-step variable each test keeps, `planned` against `cases`. That variable is why the shared helper takes the remaining count as an argument instead of counting for itself. 397 lowers `planned` when a host cannot run a step. Both tests also count a final step that never calls `pace`, and both close on `assert_steps_ran` against the live totals. A helper owning the count would have to duplicate all of that.

The costliest-step state is testlib's own `PACE_COSTLIEST`, zeroed at load and reset by `pace_init`. A shell sourcing testlib for two tests cannot then let the first one's timing pace the second. A caller that skips `pace_init` gets 0 rather than an unset-variable error under `set -u`.

The move is behaviour-preserving. Replaying the same step-duration sequences through master's copy and the shared one gives an identical stream of `skip_if_out_of_budget` arguments. The mutant that projects off the last step instead of the costliest, which is the bug #1568 fixed, diverges on the first sequence.

That deterministic replay is the evidence, not the timing runs. Cutting the budget and counting steps gives numbers that straddle between runs, on master as much as on this branch. Those runs cannot tell the two trees apart either way. The #1552 mutant is an auto probe that warns and leaves `HTS_INET6` undefined. It still dies at a one-second budget on both trees, because the case that catches it runs before the first `pace`.
