### PR TITLE
A grep shim can silently corrupt what tests and tooling see

### DIFF
--- a/html/div/search.sh
+++ b/html/div/search.sh
@@ -17,7 +17,7 @@ if ! test -f "index.txt"; then
 fi
 
 # Convert crlf to lf
-if test "$(head index.txt -n 1 | tr '\r' '#' | grep -c '#')" = "1"; then
+if test "$(head index.txt -n 1 | tr '\r' '#' | command grep -c '#')" = "1"; then
     echo "Converting index to Unix LF style (not CR/LF) .."
     mv -f index.txt index.txt.old
     tr -d '\r' <index.txt.old >index.txt
@@ -29,7 +29,7 @@ while test -n "$keyword"; do
     read -r keyword
 
     if test -n "$keyword"; then
-        FOUNDK="$(grep -niE "^$keyword" index.txt)"
+        FOUNDK="$(command grep -niE "^$keyword" index.txt)"
 
         if test -n "$FOUNDK"; then
             if ! test "$(echo "$FOUNDK" | wc -l)" = "1"; then
@@ -41,11 +41,11 @@ while test -n "$keyword"; do
             else
                 # One match
                 N=$(echo "$FOUNDK" | cut -f1 -d':')
-                PM=$(tail "+$N" index.txt | grep -nE "\(" | head -n 1)
-                if ! echo "$PM" | grep "ignored" >/dev/null; then
+                PM=$(tail "+$N" index.txt | command grep -nE "\(" | head -n 1)
+                if ! echo "$PM" | command grep "ignored" >/dev/null; then
                     M=$(echo "$PM" | cut -f1 -d':')
                     echo "Found in:"
-                    tail "+$N" index.txt | head -n "$M" | grep -E "[0-9]* " | cut -f2 -d' '
+                    tail "+$N" index.txt | head -n "$M" | command grep -E "[0-9]* " | cut -f2 -d' '
                 else
                     echo "keyword ignored (too many hits)"
                 fi

--- a/man/makeman.sh
+++ b/man/makeman.sh
@@ -36,9 +36,9 @@ year=${date_str##* }
 
 help=$("$httrack" --quiet --help 2>/dev/null)
 
-st=$(printf '%s\n' "$help" | grep -n 'General options' | head -1 | cut -d: -f1)
-en=$(printf '%s\n' "$help" | grep -nE '^example' | head -1 | cut -d: -f1)
-en2=$(printf '%s\n' "$help" | grep -nE '^HTTrack version' | tail -1 | cut -d: -f1)
+st=$(printf '%s\n' "$help" | command grep -n 'General options' | head -1 | cut -d: -f1)
+en=$(printf '%s\n' "$help" | command grep -nE '^example' | head -1 | cut -d: -f1)
+en2=$(printf '%s\n' "$help" | command grep -nE '^HTTrack version' | tail -1 | cut -d: -f1)
 
 # SYNOPSIS: one "[ -x, --long ]" per option carrying a long name (skip "#" guru
 # options, as the original did).

--- a/src/htsbasiccharsets.sh
+++ b/src/htsbasiccharsets.sh
@@ -16,7 +16,7 @@ fi
 printf '/** GENERATED FILE (%s), DO NOT EDIT **/\n\n' "$0"
 for i in *.TXT; do
     echo "processing $i" >&2
-    grep -vE "^(#|$)" "$i" | grep -E "^0x" | sed -e 's/[[:space:]]/ /g' | cut -f1,2 -d' ' |
+    command grep -vE "^(#|$)" "$i" | grep -E "^0x" | sed -e 's/[[:space:]]/ /g' | cut -f1,2 -d' ' |
         (
             unset arr
             while read -r LINE; do

--- a/src/webhttrack.in
+++ b/src/webhttrack.in
@@ -41,7 +41,7 @@ function lang_index {
     tag=$(echo "${locale}" | cut -f1 -d'.' | cut -f1 -d'@' | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z_')
     # a few languages carry a region-specific entry (zh_tw, pt_br); else use the bare language
     for t in "${tag}" "${tag%%_*}"; do
-        n=$(grep -E "^${t}:" "${indexes}" | cut -f2 -d':')
+        n=$(command grep -E "^${t}:" "${indexes}" | cut -f2 -d':')
         test -n "${n}" && break
     done
     test -n "${n}" || n=1
@@ -118,7 +118,7 @@ fi
 # "browse" command
 if test "$1" = "browse"; then
     if test -f "${HOME}/.httrack.ini"; then
-        INDEXF=$(tr '\r' '\n' <"${HOME}/.httrack.ini" | grep -E "^path=" | cut -f2- -d'=')
+        INDEXF=$(tr '\r' '\n' <"${HOME}/.httrack.ini" | command grep -E "^path=" | cut -f2- -d'=')
         if test -n "${INDEXF}" -a -d "${INDEXF}" -a -f "${INDEXF}/index.html"; then
             INDEXF="${INDEXF}/index.html"
         else
@@ -146,7 +146,7 @@ while ! test -n "$SRVURL"; do
     MAXCOUNT=$((MAXCOUNT - 1))
     test $MAXCOUNT -gt 0 || exit 1
     test $MAXCOUNT -lt 50 && echo "waiting for server to reply.."
-    SRVURL=$(grep -E URL= "${TMPSRVFILE}" | cut -f2- -d=)
+    SRVURL=$(command grep -E URL= "${TMPSRVFILE}" | cut -f2- -d=)
     test ! "$SRVURL" = "error" || ! log "Could not spawn htsserver" || exit 1
     test -n "$SRVURL" || sleep 1
 done
@@ -168,7 +168,7 @@ function reap_browser {
 function cleanup {
     test -n "$1" && log "Nasty signal caught, cleaning up.."
     # Do not kill if browser exited (chrome bug issue) ; server will die itself
-    test -n "$1" && test -f "${TMPSRVFILE}" && SRVPID=$(grep -E PID= "${TMPSRVFILE}" | cut -f2- -d=)
+    test -n "$1" && test -f "${TMPSRVFILE}" && SRVPID=$(command grep -E PID= "${TMPSRVFILE}" | cut -f2- -d=)
     test -n "${SRVPID}" && kill -9 "${SRVPID}"
     test -f "${TMPSRVFILE}" && rm "${TMPSRVFILE}"
     reap_browser
@@ -185,7 +185,7 @@ launch_browser "${BROWSEREXE}" "${SRVURL}" &
 BROWSERPID=$!
 # Deliberately not SRVPID, which cleanup would then kill, taking a running mirror
 # with it.
-SESSIONPID=$(grep -E PID= "${TMPSRVFILE}" | cut -f2- -d=)
+SESSIONPID=$(command grep -E PID= "${TMPSRVFILE}" | cut -f2- -d=)
 wait_for_session "${BROWSERPID}" "${SESSIONPID}"
 
 # That's all, folks!

--- a/tests/01_engine-addlink.test
+++ b/tests/01_engine-addlink.test
@@ -5,4 +5,4 @@
 set -euo pipefail
 
 out=$(httrack -O /dev/null -#test=addlink)
-grep -q "addlink self-test OK" <<<"$out"
+command grep -q "addlink self-test OK" <<<"$out"

--- a/tests/01_engine-backswap.test
+++ b/tests/01_engine-backswap.test
@@ -6,4 +6,4 @@ set -euo pipefail
 # A ready slot still owning a temporary must stay in memory: swapping it out
 # clears the entry, which unlinks the re-fetch backup (#771).
 out=$(httrack -O /dev/null -#test=backswap)
-grep -q "backswap self-test: OK" <<<"$out"
+command grep -q "backswap self-test: OK" <<<"$out"

--- a/tests/01_engine-cmdline-split.test
+++ b/tests/01_engine-cmdline-split.test
@@ -6,4 +6,4 @@ set -euo pipefail
 # webhttrack posts its command line as one string: the argv split must grow past
 # 1024 arguments and keep a quote inside a value out of the option parser.
 out=$(httrack -O /dev/null -#test=cmdline-split run)
-grep -q "cmdline-split self-test OK" <<<"$out"
+command grep -q "cmdline-split self-test OK" <<<"$out"

--- a/tests/01_engine-cmdline.test
+++ b/tests/01_engine-cmdline.test
@@ -55,7 +55,7 @@ refused() {
 # assert continue mode was entered: it drops the URL list, so with no cache to
 # resume the run ends on the usage screen rather than on any other error
 continued() {
-    { test "$RC" -ne 0 && grep -q 'usage:' "$1/.log"; } ||
+    { test "$RC" -ne 0 && command grep -q 'usage:' "$1/.log"; } ||
         fail "$2 (exit $RC)"
 }
 
@@ -162,11 +162,11 @@ accepted "$tmp/pre-proto" "#615: -@i2 before the URL broke the crawl"
 # is only observable via the ">8, limited to 8" warning: -c16 trips it, and would
 # stop tripping it if a trailing -K reset the count back to the default 4.
 warned() {
-    grep -q 'simultaneous connections limited to' "$1/hts-log.txt" ||
+    command grep -q 'simultaneous connections limited to' "$1/hts-log.txt" ||
         fail "$2"
 }
 not_warned() {
-    ! grep -q 'simultaneous connections limited to' "$1/hts-log.txt" ||
+    ! command grep -q 'simultaneous connections limited to' "$1/hts-log.txt" ||
         fail "$2"
 }
 run "$tmp/soc-c16" -c16

--- a/tests/01_engine-doitlog.test
+++ b/tests/01_engine-doitlog.test
@@ -64,7 +64,7 @@ echo 'NEWCONTENT' >"$site/a.html"
 rc=0
 "$bin" -O "$out" --quiet >/dev/null 2>&1 || rc=$?
 test "$rc" -eq 0 || fail "second reprise exited $rc"
-grep -q NEWCONTENT "$(find "$out" -path '*/a.html' -print -quit)" || fail "reprise did not pick up the changed source (inserted url not re-crawled)"
+command grep -q NEWCONTENT "$(find "$out" -path '*/a.html' -print -quit)" || fail "reprise did not pick up the changed source (inserted url not re-crawled)"
 
 # --- 3. an empty quoted arg survives the doit.log round-trip (#106) ----------
 # -%F "" (empty footer) records an empty "" token in doit.log; -r2 follows it so
@@ -76,7 +76,7 @@ rc=0
 "$bin" "$url" -O "$out2" --quiet -n -%v0 -%F "" -r2 >/dev/null 2>&1 || rc=$?
 test "$rc" -eq 0 || fail "initial mirror with empty footer exited $rc"
 # precondition: the writer put the empty token on disk for the reader to reload.
-grep -q ' -%F "" -r2' "$out2/hts-cache/doit.log" || {
+command grep -q ' -%F "" -r2' "$out2/hts-cache/doit.log" || {
     echo "FAIL: empty footer not recorded as -%F \"\" -r2 in doit.log"
     grep -- '-%F' "$out2/hts-cache/doit.log" || true
     exit 1
@@ -87,7 +87,7 @@ grep -q ' -%F "" -r2' "$out2/hts-cache/doit.log" || {
 rc=0
 "$bin" -O "$out2" --quiet >/dev/null 2>&1 || rc=$?
 test "$rc" -eq 0 || fail "empty-footer reprise exited $rc (empty token dropped from doit.log?)"
-grep -q ' -%F "" -r2' "$out2/hts-cache/doit.log" || {
+command grep -q ' -%F "" -r2' "$out2/hts-cache/doit.log" || {
     echo "FAIL: empty footer did not survive the doit.log reload round-trip"
     grep -- '-%F' "$out2/hts-cache/doit.log" || true
     exit 1
@@ -109,18 +109,18 @@ rc=0
 test "$rc" -eq 0 || fail "initial mirror with a leading-quote footer exited $rc"
 page=$(find "$out3" -path '*/site3/index.html' -print -quit)
 test -n "$page" || fail "mirrored page missing after the leading-quote mirror"
-grep -qF "$footer" "$page" || fail "run 1 did not inject the footer verbatim"
+command grep -qF "$footer" "$page" || fail "run 1 did not inject the footer verbatim"
 rc=0
 "$bin" -O "$out3" --quiet >/dev/null 2>&1 || rc=$?
 test "$rc" -eq 0 || fail "leading-quote reprise exited $rc"
-grep -qF "$footer" "$page" || {
+command grep -qF "$footer" "$page" || {
     echo "FAIL: the footer changed across the reprise (leading quote written raw?)"
     grep -o '<!--[^>]*MARK[^>]*-->' "$page" | head -1
     exit 1
 }
 # -r2 sits after the footer. A plain ' -r2' match would also hit it *inside* a
 # swallowed footer, so pin the escaped token and its neighbour instead.
-grep -qF -- '-%F "\"<!-- MARK -->" -r2' "$out3/hts-cache/doit.log" || {
+command grep -qF -- '-%F "\"<!-- MARK -->" -r2' "$out3/hts-cache/doit.log" || {
     echo "FAIL: footer and -r2 are not two tokens in the regenerated doit.log"
     head -1 "$out3/hts-cache/doit.log"
     exit 1
@@ -138,7 +138,7 @@ rc=0
 "$bin" "file://$site4/index.html" -O "$out4" --quiet -n -%v0 '"""+*foo*""' \
     >/dev/null 2>&1 || rc=$?
 test "$rc" -eq 0 || fail "initial mirror with a leading-quote filter exited $rc"
-grep -qF -- '"\"+*foo*"' "$out4/hts-cache/doit.log" || {
+command grep -qF -- '"\"+*foo*"' "$out4/hts-cache/doit.log" || {
     echo "FAIL: the filter was not recorded escaped"
     head -1 "$out4/hts-cache/doit.log"
     exit 1

--- a/tests/01_engine-escape-room.test
+++ b/tests/01_engine-escape-room.test
@@ -5,4 +5,4 @@ set -euo pipefail
 
 # HT_ADD_HTMLESCAPED* must reserve the escaper's worst case (6 for _full).
 out=$(httrack -O /dev/null -#test=escape-room run)
-grep -q "escape-room self-test OK" <<<"$out"
+command grep -q "escape-room self-test OK" <<<"$out"

--- a/tests/01_engine-filelist.test
+++ b/tests/01_engine-filelist.test
@@ -27,10 +27,10 @@ run() {
 # Every assertion below is about the crawl log, testlib's own included.
 fail_dump_var LOG
 loghas() {
-    grep -Eq "$1" "$LOG" || fail "expected /$1/ in $LOG"
+    command grep -Eq "$1" "$LOG" || fail "expected /$1/ in $LOG"
 }
 lognot() {
-    if grep -Eq "$1" "$LOG"; then fail "unexpected /$1/ in $LOG"; fi
+    if command grep -Eq "$1" "$LOG"; then fail "unexpected /$1/ in $LOG"; fi
 }
 
 # readable list: its one URL is loaded and counted (count must be non-zero)

--- a/tests/01_engine-footer-boundary.test
+++ b/tests/01_engine-footer-boundary.test
@@ -47,7 +47,7 @@ crawl() { # crawl FOOTER [LABEL], leaving the mirrored page in $body
 
 # Which line the footer lands on follows the page's own newlines, so find it by
 # its marker rather than by position.
-footer_line() { firstline "$(tr -d '\r' <<<"$body" | grep -F "$mark" || true)"; }
+footer_line() { firstline "$(tr -d '\r' <<<"$body" | command grep -F "$mark" || true)"; }
 
 path_expansion() { # the length {path} expands to
     local line
@@ -81,7 +81,7 @@ sweep() { # sweep LABEL: walk the expansion across the point where footers drop
         footer="${footer}$(printf '{path}%.0s' $(seq 1 "$reps"))"
         test ${#footer} -lt 254 || fail "footer template is ${#footer} chars"
         crawl "$footer" "a $1 page at expansion ${total}"
-        if grep -q "$mark" <<<"$body"; then
+        if command grep -q "$mark" <<<"$body"; then
             line=$(footer_line)
             # Whole or not at all: a clipped footer runs into the page below it.
             test "${#line}" -eq "$total" ||

--- a/tests/01_engine-ftp-line.test
+++ b/tests/01_engine-ftp-line.test
@@ -5,4 +5,4 @@ set -euo pipefail
 
 # get_ftp_line bounds a hostile CRLF-less FTP reply into its 1024-byte buffer.
 out=$(httrack -O /dev/null -#test=ftp-line run)
-grep -q "ftp-line self-test OK" <<<"$out"
+command grep -q "ftp-line self-test OK" <<<"$out"

--- a/tests/01_engine-ftp-userpass.test
+++ b/tests/01_engine-ftp-userpass.test
@@ -13,7 +13,7 @@ cleanup_push rm -rf "${tmpdir}"
 
 out=$(httrack -O "${tmpdir}/st" "-#test=ftp-userpass" run 2>&1) ||
     fail "self-test exited non-zero: ${out}"
-grep -q "ftp-userpass self-test OK" <<<"${out}" || fail "unexpected output: ${out}"
+command grep -q "ftp-userpass self-test OK" <<<"${out}" || fail "unexpected output: ${out}"
 
 # The reachable half: a URL carries the userinfo straight into user[256]/pass[256].
 probe() {
@@ -26,13 +26,13 @@ probe() {
 # The bare name has no ':' to bound it, only the '@', and is the worse branch.
 for u in "$(repeat_chars 256):pw" "u:$(repeat_chars 256)" "$(repeat_chars 256)"; do
     log=$(probe "${u}")
-    grep -q "FTP user name or password too long" <<<"${log}" ||
+    command grep -q "FTP user name or password too long" <<<"${log}" ||
         fail "over-long userinfo was not refused: ${log}"
 done
 
 # 255 still fits, and a plain login is the outsider a widened gate would refuse.
 for u in "$(repeat_chars 255):pw" "u:$(repeat_chars 255)" "$(repeat_chars 255)" "bob:secret"; do
     log=$(probe "${u}")
-    grep -q "Unable to connect to the server" <<<"${log}" ||
+    command grep -q "Unable to connect to the server" <<<"${log}" ||
         fail "userinfo that fits did not reach the connect: ${log}"
 done

--- a/tests/01_engine-growsize.test
+++ b/tests/01_engine-growsize.test
@@ -20,5 +20,5 @@ printf -- '-*/zzmarker*\n' >"$tmp/rules.txt"
 # the rules file lands in the URL/filter string, echoed back by the banner
 run=$(httrack -O "$tmp/out" --quiet -n "-%S" "$tmp/rules.txt" \
     "file://$tmp/index.html" 2>&1) || true
-grep -q 'zzmarker' <<<"$run" ||
+command grep -q 'zzmarker' <<<"$run" ||
     fail "-%S rules file was not loaded: $run"

--- a/tests/01_engine-hashkey-bounds.test
+++ b/tests/01_engine-hashkey-bounds.test
@@ -6,4 +6,4 @@ set -euo pipefail
 # A maximal host plus a maximal path must fit the dedup key, not the field
 # behind it (#1160).
 out=$(httrack -O /dev/null -#test=hashkey-bounds run)
-grep -q "hashkey-bounds self-test OK" <<<"$out"
+command grep -q "hashkey-bounds self-test OK" <<<"$out"

--- a/tests/01_engine-hashtable.test
+++ b/tests/01_engine-hashtable.test
@@ -6,4 +6,4 @@ set -euo pipefail
 # httrack internal hashtable autotest on 100K keys. Assert the success line (on
 # stderr) so a misrouted registry entry can't pass on exit code alone.
 out=$(httrack -#test=hashtable 100000 2>&1)
-grep -q "all hashtable tests were successful!" <<<"$out" || exit 1
+command grep -q "all hashtable tests were successful!" <<<"$out" || exit 1

--- a/tests/01_engine-header.test
+++ b/tests/01_engine-header.test
@@ -13,7 +13,7 @@ hdr() {
     local want=$1 got
     shift
     # Assigned, not passed inline: set -e sees a failing engine only in an assignment.
-    got=$(httrack -O /dev/null -#test=header "$@" | grep '^contenttype=')
+    got=$(httrack -O /dev/null -#test=header "$@" | command grep '^contenttype=')
     assert_eq "$want" "$got" "$*"
 }
 
@@ -36,7 +36,7 @@ selftest_queue 'contenttype_len=0 contentencoding_len=0' headerlong 'Content-Enc
 
 # An empty Content-Encoding yields no token: leave it empty, don't read the
 # uninitialized scratch (MSan aborts here on the pre-fix binary).
-enc() { httrack -O /dev/null -#test=header "$1" | grep '^contentencoding='; }
+enc() { httrack -O /dev/null -#test=header "$1" | command grep '^contentencoding='; }
 assert_eq 'contentencoding=' "$(enc 'Content-Encoding:')"
 assert_eq 'contentencoding=gzip' "$(enc 'Content-Encoding: gzip')"
 

--- a/tests/01_engine-hostalias.test
+++ b/tests/01_engine-hostalias.test
@@ -6,4 +6,4 @@ set -euo pipefail
 # --host-alias: hostname folding for scope, savename and the dedup key. All
 # assertions live in the engine self-test (hts_host_alias & friends).
 out=$(httrack -O /dev/null -#test=hostalias)
-grep -q "host-alias self-test OK" <<<"$out"
+command grep -q "host-alias self-test OK" <<<"$out"

--- a/tests/01_engine-inplace-escape.test
+++ b/tests/01_engine-inplace-escape.test
@@ -5,4 +5,4 @@ set -euo pipefail
 
 # inplace_escape_*() must match escape_*() on a copy: guards the shared helper.
 out=$(httrack -O /dev/null -#test=inplace-escape run)
-grep -q "inplace-escape self-test OK" <<<"$out"
+command grep -q "inplace-escape self-test OK" <<<"$out"

--- a/tests/01_engine-logcallback.test
+++ b/tests/01_engine-logcallback.test
@@ -5,4 +5,4 @@
 set -euo pipefail
 
 out=$(httrack -O /dev/null -#test=logcallback)
-grep -q "logcallback self-test OK" <<<"$out"
+command grep -q "logcallback self-test OK" <<<"$out"

--- a/tests/01_engine-parse.test
+++ b/tests/01_engine-parse.test
@@ -84,27 +84,27 @@ saved=$(savedhtml "$out")
 test -n "$saved" || fail "saved index.html not found"
 
 # descriptors must survive the rewrite (no "b.gif 480w" mangled into a path)
-grep -Eq 'srcset="[^"]*480w[^"]*800w' "$saved" ||
+command grep -Eq 'srcset="[^"]*480w[^"]*800w' "$saved" ||
     fail "srcset width descriptors lost/reordered in rewritten HTML"
-grep -Eq 'srcset="[^"]*1x[^"]*2x' "$saved" ||
+command grep -Eq 'srcset="[^"]*1x[^"]*2x' "$saved" ||
     fail "srcset density descriptors lost/reordered in rewritten HTML"
 # the descriptor-less comma form keeps both candidates and the separator verbatim
-grep -Eq 'srcset="e\.gif, f\.gif"' "$saved" ||
+command grep -Eq 'srcset="e\.gif, f\.gif"' "$saved" ||
     fail "comma-separated srcset without descriptors was altered"
 # an attribute following srcset in the same tag must be left intact
-grep -q 'alt="trailing attr after srcset"' "$saved" ||
+command grep -q 'alt="trailing attr after srcset"' "$saved" ||
     fail "srcset swallowed a following attribute"
 
 # a comma inside a URL (data: URI, CDN path) is part of the URL, not a split
 # point (WHATWG): the data: URI stays verbatim; the next candidate (dz) downloads
-grep -Fq 'data:image/gif;base64,R0lGODlhAQABAAAAACw= 1x' "$saved" ||
+command grep -Fq 'data:image/gif;base64,R0lGODlhAQABAAAAACw= 1x' "$saved" ||
     fail "a comma inside a data: URI srcset candidate was mis-split"
 
 # real rewrite, not passthrough: the absolute file:// candidate becomes local
 # (a flat fixture can't show this; the footer comment's file:// is not in srcset)
-grep -Eq 'srcset="j\.gif 2x"' "$saved" ||
+command grep -Eq 'srcset="j\.gif 2x"' "$saved" ||
     fail "absolute file:// srcset URL was not rewritten to a local link"
-! grep -Eq 'srcset="[^"]*file://' "$saved" ||
+! command grep -Eq 'srcset="[^"]*file://' "$saved" ||
     fail "a file:// URL survived inside a rewritten srcset attribute"
 
 # xlink:href (#298) and CSS background-image (#237): detected and rewritten to
@@ -133,29 +133,29 @@ saved2=$(savedhtml "$out2")
 test -n "$saved2" || fail "saved attrs page not found"
 
 # detected attributes: the absolute URL is rewritten to a local link
-grep -Eq 'xlink:href="xl\.gif"' "$saved2" ||
+command grep -Eq 'xlink:href="xl\.gif"' "$saved2" ||
     fail "#298: xlink:href not detected/rewritten"
 
 # #237 external <style> block, each quoting form, quote style preserved
-grep -Eq 'url\(cex\.gif\)' "$saved2" ||
+command grep -Eq 'url\(cex\.gif\)' "$saved2" ||
     fail "#237: unquoted background-image in <style> not rewritten"
-grep -Eq 'url\("cexd\.gif"\)' "$saved2" ||
+command grep -Eq 'url\("cexd\.gif"\)' "$saved2" ||
     fail "#237: double-quoted background-image in <style> not rewritten"
-grep -Eq "url\('cexs\.gif'\)" "$saved2" ||
+command grep -Eq "url\('cexs\.gif'\)" "$saved2" ||
     fail "#237: single-quoted background-image in <style> not rewritten"
 
 # #237 inline style attribute, unquoted and single-quoted url()
-grep -Eq 'style="background-image:url\(ibg\.gif\)"' "$saved2" ||
+command grep -Eq 'style="background-image:url\(ibg\.gif\)"' "$saved2" ||
     fail "#237: inline unquoted background-image not rewritten"
-grep -Eq "style=\"background-image:url\('ibgs\.gif'\)\"" "$saved2" ||
+command grep -Eq "style=\"background-image:url\('ibgs\.gif'\)\"" "$saved2" ||
     fail "#237: inline single-quoted background-image not rewritten"
 
 # no file:// URL survived inside any rewritten background-image
-! grep -Eq 'background-image:[^;"]*file://' "$saved2" ||
+! command grep -Eq 'background-image:[^;"]*file://' "$saved2" ||
     fail "#237: a file:// URL survived inside a rewritten background-image"
 
 # excluded attribute: title is on the no-detect list, so its value is left as-is
-grep -q 'title="file://' "$saved2" ||
+command grep -q 'title="file://' "$saved2" ||
     fail "a no-detect attribute (title) was wrongly rewritten"
 
 # xmlns / xmlns:prefix decls must not be crawled (#191). Local file:// targets so a
@@ -208,7 +208,7 @@ for f in nq dqu squ dqs sqs med cond sup lay spc; do found "$f.css" "$out4"; don
 m4=$(find "$out4" -type f -path '*/file/*' -name main.css -print -quit)
 test -n "$m4" || fail "saved main.css not found"
 for cond in '@import "cond.css" screen;' 'supports(display: flex)' 'layer(base)'; do
-    grep -Fq "$cond" "$m4" ||
+    command grep -Fq "$cond" "$m4" ||
         fail "#94: '$cond' altered on rewrite (condition captured as URL?)"
 done
 
@@ -263,9 +263,9 @@ notfound "Post" "$out7"
 # these two assertions fail if .open detection broke (not a trivial --near save).
 saved7=$(savedhtml "$out7")
 test -n "$saved7" || fail "saved xhr page not found"
-grep -Fq 'window.open("winopen.gif")' "$saved7" ||
+command grep -Fq 'window.open("winopen.gif")' "$saved7" ||
     fail "#218: window.open(url) no longer detected/rewritten"
-! grep -Fq 'window.open("file://' "$saved7" ||
+! command grep -Fq 'window.open("file://' "$saved7" ||
     fail "#218: window.open URL left absolute (not rewritten)"
 
 # Parens in an unquoted url(...) (#163): the source %28/%29 decode to literal
@@ -287,11 +287,11 @@ found "a(b)c(1).gif" "$out8"
 found "q (4).gif" "$out8"
 css8=$(find "$out8" -type f -path '*/file/*' -name style.css -print -quit)
 test -n "$css8" || fail "saved style.css not found"
-grep -Fq 'url(img%20%281%29.gif)' "$css8" ||
+command grep -Fq 'url(img%20%281%29.gif)' "$css8" ||
     fail "#163: parens in unquoted url() not percent-encoded on rewrite"
-grep -Fq 'url(a%28b%29c%281%29.gif)' "$css8" ||
+command grep -Fq 'url(a%28b%29c%281%29.gif)' "$css8" ||
     fail "#163: not every paren in a url() was percent-encoded"
-grep -Fq 'url("q%20%284%29.gif")' "$css8" ||
+command grep -Fq 'url("q%20%284%29.gif")' "$css8" ||
     fail "#163: quoted url() altered or parens left literal on rewrite"
 
 # The url() detector is not CSS-specific: <script> and inline style= get the
@@ -313,18 +313,18 @@ crawl "$site9/index.html" "$out9"
 saved9=$(savedhtml "$out9")
 test -n "$saved9" || fail "saved urlparens page not found"
 # rewrite-only: the JS-string asset is not queued for download
-grep -Fq 'url(js%20%281%29.gif)' "$saved9" ||
+command grep -Fq 'url(js%20%281%29.gif)' "$saved9" ||
     fail "#163: parens in <script> url() not percent-encoded"
 found "inl (2).gif" "$out9"
-grep -Fq 'url(inl%20%282%29.gif)' "$saved9" ||
+command grep -Fq 'url(inl%20%282%29.gif)' "$saved9" ||
     fail "#163: parens in inline style url() not percent-encoded"
 found "asrc (3).gif" "$out9"
 found "ahref (4).gif" "$out9"
-grep -Fq 'src="asrc%20(3).gif"' "$saved9" ||
+command grep -Fq 'src="asrc%20(3).gif"' "$saved9" ||
     fail "#163: parens in a plain src attribute were wrongly encoded"
-grep -Fq 'href="ahref%20(4).gif"' "$saved9" ||
+command grep -Fq 'href="ahref%20(4).gif"' "$saved9" ||
     fail "#163: parens in a plain href attribute were wrongly encoded"
-! grep -Eq '(src|href)="[^"]*%28' "$saved9" ||
+! command grep -Eq '(src|href)="[^"]*%28' "$saved9" ||
     fail "#163: gate over-fired onto a non-url() attribute link"
 
 # HTML5 <source>/<track> follow as embedded near-links past the -r2 depth boundary (#451).
@@ -390,13 +390,13 @@ out11="$tmp/dataattr-out"
 crawl "$site11/index.html" "$out11"
 saved11=$(savedhtml "$out11")
 test -n "$saved11" || fail "saved dataattr page not found"
-grep -Fq 'data-pre="pre.gif"' "$saved11" ||
+command grep -Fq 'data-pre="pre.gif"' "$saved11" ||
     fail "#201: data-* URL before any script not detected/rewritten"
-grep -Fq 'data-post="post.gif"' "$saved11" ||
+command grep -Fq 'data-post="post.gif"' "$saved11" ||
     fail "#201: data-* URL after a script not detected (state leak)"
-grep -Fq 'data-mid="mid.gif"' "$saved11" ||
+command grep -Fq 'data-mid="mid.gif"' "$saved11" ||
     fail "#201: mid-tag data-* URL not detected"
-grep -Fq 'data-sp = "spdata.gif"' "$saved11" ||
+command grep -Fq 'data-sp = "spdata.gif"' "$saved11" ||
     fail "#201: spaced-= data-* URL not detected"
 found "handler.gif" "$out11"  # automaton reset at the handler-terminator exit
 found "handler2.gif" "$out11" # ... and at the '>' exit of an unterminated handler

--- a/tests/01_engine-rcfile.test
+++ b/tests/01_engine-rcfile.test
@@ -53,7 +53,7 @@ rc=0
 test "$rc" -eq 0 || fail "rc-file crawl exited $rc"
 assert_file "$d1/hts-cache/doit.log" "no doit.log, so the rc file was not processed"
 # A truncated copy would cut the token; require the full -F value.
-grep -q -- "-F $marker" "$d1/hts-cache/doit.log" || {
+command grep -q -- "-F $marker" "$d1/hts-cache/doit.log" || {
     echo "FAIL: user-agent alias missing or truncated in doit.log"
     head -1 "$d1/hts-cache/doit.log"
     exit 1
@@ -94,7 +94,7 @@ short=$(sed -n '1p' "$d2/hts-cache/doit.log" | tr ' ' '\n' |
     awk -v n="${#val}" '/^a+$/ && length($0) != n {c++} END {print c + 0}')
 test "$short" -eq 0 || fail "$short user-agent value(s) reached doit.log clipped"
 for marker in "$first" "$last"; do
-    grep -q -- "-F $marker" "$d2/hts-cache/doit.log" || fail "$marker never reached the rebuilt command line"
+    command grep -q -- "-F $marker" "$d2/hts-cache/doit.log" || fail "$marker never reached the rebuilt command line"
 done
 
 exit 0

--- a/tests/01_engine-redirect.test
+++ b/tests/01_engine-redirect.test
@@ -7,4 +7,4 @@ set -euo pipefail
 # followed through, not turned into a self-pointing "moved" stub. The decision
 # helper is exercised by the engine self-test.
 out=$(httrack -O /dev/null -#test=redirect-samefile run)
-grep -q "redirect-samefile self-test OK" <<<"$out"
+command grep -q "redirect-samefile self-test OK" <<<"$out"

--- a/tests/01_engine-renameover.test
+++ b/tests/01_engine-renameover.test
@@ -33,7 +33,7 @@ if [ ! -r "${RENAMEFAIL_LA:-}" ]; then
     echo "renameover: ${RENAMEFAIL_LA:-\$RENAMEFAIL_LA} was not built" >&2
     exit 1
 fi
-if grep -q "^dlname=''" "$RENAMEFAIL_LA"; then
+if command grep -q "^dlname=''" "$RENAMEFAIL_LA"; then
     echo "renameover: static-only build, skipping the interposed legs"
     exit 0
 fi

--- a/tests/01_engine-robots.test
+++ b/tests/01_engine-robots.test
@@ -5,4 +5,4 @@ set -euo pipefail
 
 # robots.txt RFC 9309 Allow/Disallow precedence (#452): longest match wins.
 out=$(httrack -O /dev/null -#test=robots run)
-grep -q "robots self-test OK" <<<"$out"
+command grep -q "robots self-test OK" <<<"$out"

--- a/tests/01_engine-socks5.test
+++ b/tests/01_engine-socks5.test
@@ -7,4 +7,4 @@ set -euo pipefail
 # server replies (frame draining, oversize rejects, RFC 1929 fields).
 
 out=$(httrack -O /dev/null '-#test=socks5')
-grep -q "socks5 self-test OK" <<<"$out"
+command grep -q "socks5 self-test OK" <<<"$out"

--- a/tests/01_engine-status.test
+++ b/tests/01_engine-status.test
@@ -5,4 +5,4 @@ set -euo pipefail
 
 # HTTP status -> reason phrase, including the modern 429/451 (#453).
 out=$(httrack -O /dev/null -#test=status run)
-grep -q "status self-test OK" <<<"$out"
+command grep -q "status self-test OK" <<<"$out"

--- a/tests/01_engine-stripquery.test
+++ b/tests/01_engine-stripquery.test
@@ -6,4 +6,4 @@ set -euo pipefail
 # --strip-query: pattern-scoped query-key stripping for dedup. All assertions
 # live in the engine self-test (hts_query_strip_keys + fil_normalized_filtered).
 out=$(httrack -O /dev/null -#test=stripquery)
-grep -q "strip-query self-test OK" <<<"$out"
+command grep -q "strip-query self-test OK" <<<"$out"

--- a/tests/01_engine-unescape-bounds.test
+++ b/tests/01_engine-unescape-bounds.test
@@ -5,4 +5,4 @@ set -euo pipefail
 
 # Entity/URL unescapers reserve one byte for the trailing NUL (no 1-byte OOB).
 out=$(httrack -O /dev/null -#test=unescape-bounds run)
-grep -q "unescape-bounds self-test OK" <<<"$out"
+command grep -q "unescape-bounds self-test OK" <<<"$out"

--- a/tests/01_engine-unescape-form.test
+++ b/tests/01_engine-unescape-form.test
@@ -5,14 +5,14 @@ set -euo pipefail
 
 # Form/ini percent-decoding keeps a malformed escape as text.
 out=$(httrack -O /dev/null -#test=unescape-form run)
-grep -q "unescape-form self-test OK" <<<"$out"
+command grep -q "unescape-form self-test OK" <<<"$out"
 
 # Guard against the duplication coming back: only htsencoding.h may define the
 # hex helpers the server and the engine share. This catches a copied block, not
 # a renamed one. The MSVC job runs the scripts with no automake around them, so
 # it gets the self-test above and not this.
 if [ -n "${abs_top_srcdir:-}" ]; then
-    dups=$(grep -rlE '^[A-Za-z_].*[^a-z_](ehexh|get_hex_value) *\(' \
+    dups=$(command grep -rlE '^[A-Za-z_].*[^a-z_](ehexh|get_hex_value) *\(' \
         "${abs_top_srcdir}/src" --include='*.c' --include='*.h' |
         grep -v -x -F "${abs_top_srcdir}/src/htsencoding.h" || true)
     [ -z "$dups" ] || {

--- a/tests/01_engine-urlhack.test
+++ b/tests/01_engine-urlhack.test
@@ -6,4 +6,4 @@ set -euo pipefail
 # -%u url-hack split (#271): www / // / query-order dedup toggle independently.
 # All assertions live in the engine self-test (hash compare flag resolution).
 out=$(httrack -O /dev/null -#test=urlhack run)
-grep -q "urlhack self-test OK" <<<"$out"
+command grep -q "urlhack self-test OK" <<<"$out"

--- a/tests/01_engine-useragent.test
+++ b/tests/01_engine-useragent.test
@@ -5,4 +5,4 @@ set -euo pipefail
 
 # Default User-Agent (#449): honest HTTrack token, no Windows 98 relic.
 out=$(httrack -O /dev/null -#test=useragent run)
-grep -q "useragent self-test OK" <<<"$out"
+command grep -q "useragent self-test OK" <<<"$out"

--- a/tests/01_engine-warc-surt.test
+++ b/tests/01_engine-warc-surt.test
@@ -6,4 +6,4 @@ set -euo pipefail
 # SURT canonicalization of the CDXJ sort key (--warc-cdx). Pure string work,
 # so it runs under the MSan-instrumented 01_engine glob.
 out=$(httrack -O /dev/null -#test=warc-surt)
-grep -q "warc-surt: OK" <<<"$out"
+command grep -q "warc-surt: OK" <<<"$out"

--- a/tests/01_engine-xfread.test
+++ b/tests/01_engine-xfread.test
@@ -40,7 +40,7 @@ fail() {
 # Match with here-strings, not `echo | grep -q`: under pipefail the early grep
 # exit SIGPIPEs echo and fails the pipeline even when the pattern matched.
 has() {
-    grep -qxF "$1" <<<"$out" || fail "$1"
+    command grep -qxF "$1" <<<"$out" || fail "$1"
 }
 
 # adr= and code= are read after the call, so a guard that allocates before

--- a/tests/01_zlib-cache-legacy.test
+++ b/tests/01_zlib-cache-legacy.test
@@ -12,7 +12,7 @@ cleanup_push rm -rf "$dir"
 
 # the refusal errors land on stdout (no log file); pin them and the verdict
 out=$(httrack -#test=cache-legacy "$dir" 2>/dev/null)
-cnt=$(printf '%s\n' "$out" | grep -c 'no longer supported' || true)
+cnt=$(printf '%s\n' "$out" | command grep -c 'no longer supported' || true)
 test "$cnt" = 2 || fail "expected 2 refusal messages, got $cnt"
 out=$(printf '%s\n' "$out" | tail -n1)
 

--- a/tests/01_zlib-cache-writefail.test
+++ b/tests/01_zlib-cache-writefail.test
@@ -17,10 +17,10 @@ out=$(httrack -#test=cache-writefail "$dir")
 
 # Match the exact success line (error logs also go to stdout); a renamed/removed
 # test prints the registry to stderr, which exits non-zero but never prints this.
-grep -qx "cache-writefail: OK" <<<"$out" || fail "expected 'cache-writefail: OK', got: $out"
+command grep -qx "cache-writefail: OK" <<<"$out" || fail "expected 'cache-writefail: OK', got: $out"
 
 # A skipped entry must be warned about with its URL.
-grep -q "entry not cached: example.com/" <<<"$out" || fail "expected a URL-bearing skip warning"
+command grep -q "entry not cached: example.com/" <<<"$out" || fail "expected a URL-bearing skip warning"
 
 # A backend that cannot truncate rolls back by rewinding, and says so (#1402).
-grep -q "cache rollback incomplete" <<<"$out" || fail "expected a warning about the incomplete rollback"
+command grep -q "cache rollback incomplete" <<<"$out" || fail "expected a warning about the incomplete rollback"

--- a/tests/01_zlib-repair-shift.test
+++ b/tests/01_zlib-repair-shift.test
@@ -15,4 +15,4 @@ cleanup_push rm -rf "$dir"
 
 out=$(httrack -#test=zip-repair-shift "$dir")
 
-grep -qx "zip-repair-shift: OK (recovered 1 entry)" <<<"$out" || fail "expected 'zip-repair-shift: OK (recovered 1 entry)', got: $out"
+command grep -qx "zip-repair-shift: OK (recovered 1 entry)" <<<"$out" || fail "expected 'zip-repair-shift: OK (recovered 1 entry)', got: $out"

--- a/tests/01_zlib-warc-wacz.test
+++ b/tests/01_zlib-warc-wacz.test
@@ -13,7 +13,7 @@ set -euo pipefail
 httrack_bin=$(httrack_path)
 
 registry=$("$httrack_bin" -#test 2>&1 || true)
-if ! grep -q '^  warc-wacz' <<<"$registry"; then
+if ! command grep -q '^  warc-wacz' <<<"$registry"; then
     echo "warc-wacz self-test unavailable (build without OpenSSL); skipping"
     exit 77
 fi

--- a/tests/02_manpage-regen.test
+++ b/tests/02_manpage-regen.test
@@ -30,7 +30,7 @@ README="$top_srcdir/README" bash "$gen" httrack >"$tmp" 2>/dev/null || fail "mak
 
 # Ignore the two intentionally date-dependent lines (page date, copyright year).
 # Temp files, not process substitution, so this works under a POSIX /bin/sh.
-strip_volatile() { grep -vE '^\.TH httrack |^Copyright \(C\) 1998-'; }
+strip_volatile() { command grep -vE '^\.TH httrack |^Copyright \(C\) 1998-'; }
 strip_volatile <"$committed" >"$committed_clean"
 strip_volatile <"$tmp" >"$generated_clean"
 

--- a/tests/102_local-ftp-refetch.test
+++ b/tests/102_local-ftp-refetch.test
@@ -121,12 +121,12 @@ test -z "$(listed gone)" || fail "the report calls something gone: $(listed gone
 unchanged=$(listed unchanged)
 changed=$(listed changed)
 for name in keep empty; do
-    grep -qx "${host}/${name}.bin:$(size_of "${tmpdir}/snap/${name}.bin")" <<<"$unchanged" ||
+    command grep -qx "${host}/${name}.bin:$(size_of "${tmpdir}/snap/${name}.bin")" <<<"$unchanged" ||
         fail "${name}.bin is not reported unchanged at its previous size"
-    if grep -q "^${host}/${name}.bin:" <<<"$changed"; then
+    if command grep -q "^${host}/${name}.bin:" <<<"$changed"; then
         fail "${name}.bin is reported changed as well"
     fi
 done
-grep -qx "${host}/stay.bin:$(size_of "${out}/${host}/stay.bin")" <<<"$changed" ||
+command grep -qx "${host}/stay.bin:$(size_of "${out}/${host}/stay.bin")" <<<"$changed" ||
     fail "stay.bin is not reported changed"
 ok "the change report calls the kept files unchanged and the refreshed one changed"

--- a/tests/105_suite-timeout.test
+++ b/tests/105_suite-timeout.test
@@ -71,12 +71,12 @@ test "$rc" -eq 124 || fail "wedged test reported $rc, want 124"
 # Never before the budget, or a slow-but-healthy test would be killed too.
 test "$fired" -ge 5 || fail "the guard fired early (${fired}s of a 5s budget)"
 test "$fired" -lt 30 || fail "the guard fired late (${fired}s)"
-grep -q 'marker: the wedged test started' "$out" || fail "the test's own output was lost"
+command grep -q 'marker: the wedged test started' "$out" || fail "the test's own output was lost"
 # The header, not a bare name: the process list quotes the test's path too, so a
 # wrapper that named nothing would still match that.
-grep -q '^===== TIMEOUT: 90_wedged.test exceeded' "$out" ||
+command grep -q '^===== TIMEOUT: 90_wedged.test exceeded' "$out" ||
     fail "the diagnostics do not name the test"
-grep -q "own process tree" "$out" || fail "no process list in the diagnostics"
+command grep -q "own process tree" "$out" || fail "no process list in the diagnostics"
 
 # Announced BEFORE the dump, not merely at some point during it: the watchdog reading
 # that log takes the silence of a dump for a wedge. Only a slow dump tells the two
@@ -104,12 +104,12 @@ printf 'sleep 3\necho "slow but healthy"\n' >"$tmp/92_slow.test"
 rc=0
 HTTRACK_TEST_TIMEOUT=45 bash "$driver" "$tmp/92_slow.test" >"$out" 2>&1 || rc=$?
 test "$rc" -eq 0 || fail "a healthy 3s test under a 45s budget reported $rc"
-grep -q 'slow but healthy' "$out" || fail "healthy test output lost"
-! grep -q 'TIMEOUT' "$out" || fail "the guard fired on a healthy test"
+command grep -q 'slow but healthy' "$out" || fail "healthy test output lost"
+! command grep -q 'TIMEOUT' "$out" || fail "the guard fired on a healthy test"
 
 # The killed tree must really be gone, or the next test inherits its ports.
 sleep 1
-! grep -q "$tmp/90_wedged.test" <<<"$(ps_snapshot)" ||
+! command grep -q "$tmp/90_wedged.test" <<<"$(ps_snapshot)" ||
     fail "the wedged test survived the guard"
 
 # --- the budget is wall clock, not a count of poll iterations ----------------
@@ -133,8 +133,8 @@ for want in 0 1 77 99; do
     rc=0
     HTTRACK_TEST_TIMEOUT=60 bash "$driver" "$tmp/91_plain.test" >"$out" 2>&1 || rc=$?
     test "$rc" -eq "$want" || fail "exit $want came back as $rc"
-    grep -q "ran with $want" "$out" || fail "output lost for exit $want"
-    ! grep -q 'TIMEOUT' "$out" || fail "the guard fired on a test that exited at once"
+    command grep -q "ran with $want" "$out" || fail "output lost for exit $want"
+    ! command grep -q 'TIMEOUT' "$out" || fail "the guard fired on a test that exited at once"
 done
 
 # A budget of 0 disables the guard: the test still runs, and is not killed. Its
@@ -143,13 +143,13 @@ printf 'echo "guard off"\nexit 3\n' >"$tmp/93_off.test"
 rc=0
 HTTRACK_TEST_TIMEOUT=0 bash "$driver" "$tmp/93_off.test" >"$out" 2>&1 || rc=$?
 test "$rc" -eq 3 || fail "disabled guard changed the exit status ($rc)"
-grep -q 'guard off' "$out" || fail "output lost with the guard disabled"
+command grep -q 'guard off' "$out" || fail "output lost with the guard disabled"
 
 # --- the test reads the same budget the guard enforces ----------------------
 # skip_if_out_of_budget paces against it, so a raw or absent value would pace
 # against a number the guard is not using.
 saw_budget() { # saw_budget <want> <label>
-    grep -qx "budget=$1" "$out" ||
+    command grep -qx "budget=$1" "$out" ||
         fail "$2 reached the test as '$(cat "$out")', want budget=$1"
 }
 # shellcheck disable=SC2016 # the fixture has to read the variable, not us
@@ -205,12 +205,12 @@ printf '# TEST_TIMEOUT_AT_LEAST: 900\nsleep 4\necho "outlived the default"\n' \
 rc=0
 HTTRACK_TEST_TIMEOUT=2 bash "$driver" "$tmp/97_raise.test" >"$out" 2>&1 || rc=$?
 test "$rc" -eq 0 || fail "a 4s test that raised the budget to 900 reported $rc"
-grep -q 'outlived the default' "$out" || fail "the raised budget killed the test anyway"
+command grep -q 'outlived the default' "$out" || fail "the raised budget killed the test anyway"
 printf '# TEST_TIMEOUT_AT_LEAST: 1\nsleep 3\necho "not shrunk"\n' >"$tmp/97_raise.test"
 rc=0
 HTTRACK_TEST_TIMEOUT=600 bash "$driver" "$tmp/97_raise.test" >"$out" 2>&1 || rc=$?
 test "$rc" -eq 0 || fail "a 3s test asking for a 1s budget reported $rc"
-grep -q 'not shrunk' "$out" || fail "the header shrank the budget and killed the test"
+command grep -q 'not shrunk' "$out" || fail "the header shrank the budget and killed the test"
 
 # --- one budget parser, and what is left of it ------------------------------
 secs() { # secs <value in the environment> <seconds it must read as>
@@ -239,11 +239,11 @@ if test "$got" -gt "$((60 - at))" || test "$got" -lt "$((60 - at2))"; then
     fail "a 60s budget left $got with $at to $at2 gone, want $((60 - at2))..$((60 - at))"
 fi
 HTTRACK_TEST_TIMEOUT=0 bash "$driver" "$tmp/98_left.test" >"$out" 2>&1
-grep -q '^left=0 ' "$out" || fail "a disabled guard left '$(cat "$out")', want 0"
+command grep -q '^left=0 ' "$out" || fail "a disabled guard left '$(cat "$out")', want 0"
 # Never 0 on an exhausted budget: a child would read that as the guard being off.
 HTTRACK_TEST_TIMEOUT=1 bash -c '. "$1"; sleep 2; echo "left=$(budget_left)"' \
     _ "${testdir}/testlib.sh" >"$out" 2>&1
-grep -qx 'left=1' "$out" || fail "an exhausted budget left '$(cat "$out")', want 1"
+command grep -qx 'left=1' "$out" || fail "an exhausted budget left '$(cat "$out")', want 1"
 
 # --- a test too slow to finish skips instead of being killed ----------------
 # hppa spends ~150s on one configure run, and 124 takes the build down where 77
@@ -261,7 +261,7 @@ test "$rc" -eq 77 || fail "a 60s step under a 20s budget reported $rc, want 77"
 rc=0
 HTTRACK_TEST_TIMEOUT=600 bash "$driver" "$tmp/94_pacer.test" >"$out" 2>&1 || rc=$?
 test "$rc" -eq 0 || fail "a 60s step under a 600s budget reported $rc, want 0"
-grep -q 'the pacer let it through' "$out" || fail "the pacer skipped a test that fits"
+command grep -q 'the pacer let it through' "$out" || fail "the pacer skipped a test that fits"
 
 # The reserve is half a step over the last one, and only a budget between the two
 # sizes proves it: 100s alone would fit under 140, 150s does not.
@@ -347,16 +347,16 @@ if ! target_is_windows && test -r /proc/self/stat; then
         case "$(head -n1 <<<"$snap")" in
         [0-9]*) fail "the no-ps listing has no header: $snap" ;;
         esac
-        ! grep -qE "^$outside " <<<"$snap" ||
+        ! command grep -qE "^$outside " <<<"$snap" ||
             fail "no-ps group list reported pid $outside, in another group"
-        read -r _ rppid rpgid _ <<<"$(grep -E "^$fake " <<<"$snap")"
+        read -r _ rppid rpgid _ <<<"$(command grep -E "^$fake " <<<"$snap")"
         test "$rppid $rpgid" = "$fppid $pgid" ||
             fail "no-ps row for $fake reads ppid/pgid '$rppid $rpgid', want '$fppid $pgid'"
         engines=$(list_engine_pids "$pgid")
-        grep -qx "$fake" <<<"$engines" || fail "no-ps engine list lost pid $fake"
-        grep -qx "$emul" <<<"$engines" ||
+        command grep -qx "$fake" <<<"$engines" || fail "no-ps engine list lost pid $fake"
+        command grep -qx "$emul" <<<"$engines" ||
             fail "no-ps engine list lost emulated pid $emul"
-        ! grep -qx "$outside" <<<"$engines" ||
+        ! command grep -qx "$outside" <<<"$engines" ||
             fail "no-ps engine list reached outside the group (pid $outside)"
         # A platform with no stack mechanism must say so and leave the engine
         # alone. Shimmed, because no CI leg is one: the Hurd branch below runs
@@ -365,7 +365,7 @@ if ! target_is_windows && test -r /proc/self/stat; then
         printf '#!/bin/sh\ncase "$1" in -s) echo GNU;; *) exec %s "$@";; esac\n' \
             "$(command -v uname)" >"$tmp/nops/uname"
         chmod +x "$tmp/nops/uname"
-        grep -q "no stack mechanism known for GNU" <<<"$(request_engine_backtraces "$pgid")" ||
+        command grep -q "no stack mechanism known for GNU" <<<"$(request_engine_backtraces "$pgid")" ||
             fail "a platform with no stack mechanism reported nothing"
         case "$(procstate "$fake")" in
         Z | gone) fail "the no-mechanism branch signalled pid $fake" ;;
@@ -374,7 +374,7 @@ if ! target_is_windows && test -r /proc/self/stat; then
 
         # The chain, not just its input: this is what reported nothing on Fedora.
         stacks=$(request_engine_backtraces "$pgid")
-        ! grep -q 'no engine process left' <<<"$stacks" ||
+        ! command grep -q 'no engine process left' <<<"$stacks" ||
             fail "no-ps stack request found no engine to signal: $stacks"
         # Only Linux signals; elsewhere (Hurd's uname reports "GNU") the chain
         # owes the reader its no-mechanism report instead of silence.
@@ -386,13 +386,13 @@ if ! target_is_windows && test -r /proc/self/stat; then
             *) fail "the SIGABRT never reached pid $fake" ;;
             esac
         else
-            grep -q 'no stack mechanism known' <<<"$stacks" ||
+            command grep -q 'no stack mechanism known' <<<"$stacks" ||
                 fail "no stack mechanism was reported on $(uname -s): $stacks"
         fi
         # With neither source the dump must say so, not print an empty section.
         # shellcheck disable=SC2317 # reached through ps_snapshot
         proc_snapshot() { return 1; }
-        grep -q 'no process list' <<<"$(list_stray_processes "$pgid" group)" ||
+        command grep -q 'no process list' <<<"$(list_stray_processes "$pgid" group)" ||
             fail "a host with no ps and no /proc produced no notice"
     )
     kill "$fake" "$outside" "$emul" 2>/dev/null || true
@@ -447,13 +447,13 @@ EOF
 rc=0
 HTTRACK_TEST_TIMEOUT=20 bash "$driver" "$tmp/92_stalled.test" >"$out" 2>&1 || rc=$?
 
-if grep -qE 'python3 not found|could not discover server port' "$out"; then
+if command grep -qE 'python3 not found|could not discover server port' "$out"; then
     echo "SKIP: local crawl prerequisites missing" >&2
     exit 77
 fi
 test "$rc" -eq 124 || fail "stalled crawl reported $rc, want 124"
 
-if grep -q 'No stack trace available on this OS' "$out"; then
+if command grep -q 'No stack trace available on this OS' "$out"; then
     echo "suite timeout OK (no backtrace() on this platform)"
     exit 0
 fi
@@ -464,13 +464,13 @@ case "$(uname -s)" in
 Linux)
     # sig_fatal writes to the engine's own stderr, so this reaching our log also
     # proves the crawl-log salvage worked.
-    grep -q '^Caught signal ' "$out" || fail "no engine backtrace was salvaged"
+    command grep -q '^Caught signal ' "$out" || fail "no engine backtrace was salvaged"
     ;;
 Darwin)
-    grep -q '^Call graph:' "$out" || fail "sample(1) produced no call graph"
+    command grep -q '^Call graph:' "$out" || fail "sample(1) produced no call graph"
     ;;
 *)
-    grep -q 'no stack mechanism known' "$out" ||
+    command grep -q 'no stack mechanism known' "$out" ||
         fail "unknown platform reported neither a stack nor its absence"
     echo "suite timeout OK (no stack mechanism on $(uname -s))"
     exit 0
@@ -480,7 +480,7 @@ esac
 # Matching "httrack" alone would pass on the process list above.
 # Naming them needs the symbolizer, which a build without <spawn.h> cannot run.
 if build_names_frames; then
-    grep -qE '\b(back_wait|httpmirror|hts_main_internal)\b' "$out" ||
+    command grep -qE '\b(back_wait|httpmirror|hts_main_internal)\b' "$out" ||
         fail "the stack names no engine frame"
 fi
 

--- a/tests/106_engine-repair-rename.test
+++ b/tests/106_engine-repair-rename.test
@@ -30,7 +30,7 @@ printf '[-#R repairs in place] ..\t'
 proj="${tmpdir}/cli"
 plant_damaged_cache "$proj"
 out=$(httrack -O "$proj" -#R "$dead" 2>&1)
-grep -q 'successfully recovered' <<<"$out" || fail "no recovery reported: $out"
+command grep -q 'successfully recovered' <<<"$out" || fail "no recovery reported: $out"
 test ! -e "${proj}/hts-cache/repair.zip" || fail "the recovery was left in repair.zip"
 test "$(wc -c <"${proj}/hts-cache/new.zip")" -gt 31 || fail "new.zip is still the damaged one"
 echo "OK"
@@ -44,7 +44,7 @@ printf 'not a zip at all, some bytes' >"$proj/hts-cache/new.zip"
 rc=0
 out=$(httrack -O "$proj" -#R "$dead" 2>&1) || rc=$?
 test "$rc" -ne 0 || fail "an empty recovery exited 0: $out"
-if grep -q 'successfully recovered' <<<"$out"; then
+if command grep -q 'successfully recovered' <<<"$out"; then
     echo "FAIL: an empty recovery claimed success: $out"
     exit 1
 fi
@@ -61,7 +61,7 @@ if [ ! -r "${RENAMEFAIL_LA:-}" ]; then
     echo "repair-rename: ${RENAMEFAIL_LA:-\$RENAMEFAIL_LA} was not built" >&2
     exit 1
 fi
-if grep -q "^dlname=''" "$RENAMEFAIL_LA"; then
+if command grep -q "^dlname=''" "$RENAMEFAIL_LA"; then
     echo "repair-rename: static-only build, skipping the interposed legs"
     exit 0
 fi
@@ -83,7 +83,7 @@ plant_damaged_cache "$proj"
 rc=0
 out=$(httrack -O "$proj" -#R "$dead" 2>&1) || rc=$?
 test "$rc" -ne 0 || fail "a refused move exited 0: $out"
-if grep -q 'successfully recovered' <<<"$out"; then
+if command grep -q 'successfully recovered' <<<"$out"; then
     echo "FAIL: a refused move still claimed success: $out"
     exit 1
 fi
@@ -98,12 +98,12 @@ plant_damaged_cache "$proj"
 httrack -O "$proj" "$dead" --timeout=2 --retries=0 -q >/dev/null 2>&1 || true
 log="${proj}/hts-log.txt"
 test -r "$log" || fail "no crawl log"
-grep -q 'damaged cache' "$log" || fail "the repair path never ran"
-grep -q 'could not put the repaired cache in place' "$log" || {
+command grep -q 'damaged cache' "$log" || fail "the repair path never ran"
+command grep -q 'could not put the repaired cache in place' "$log" || {
     echo "FAIL: a refused move was not reported: $(grep -i cache "$log")"
     exit 1
 }
-if grep -q 'successfully recovered' "$log"; then
+if command grep -q 'successfully recovered' "$log"; then
     echo "FAIL: a refused move still claimed success"
     exit 1
 fi

--- a/tests/108_engine-refetch-backup.test
+++ b/tests/108_engine-refetch-backup.test
@@ -13,7 +13,7 @@ cleanup_push rm -rf "$dir"
 
 rc=0
 out=$(httrack -O /dev/null -#test=refetchbackup "$dir" 2>&1) || rc=$?
-if test "$rc" -ne 0 || ! grep -q "refetchbackup: OK" <<<"$out"; then
+if test "$rc" -ne 0 || ! command grep -q "refetchbackup: OK" <<<"$out"; then
     echo "FAIL (exit $rc): $out" >&2
     exit 1
 fi

--- a/tests/112_local-single-file-fragment.test
+++ b/tests/112_local-single-file-fragment.test
@@ -57,9 +57,9 @@ b64='[A-Za-z0-9+/=]+'
 printf '[fragment survives onto the data: URI] ..\t'
 # Matching the data: prefix as well is what makes this more than "#icon-foo is
 # somewhere in the page": an un-inlined reference would carry it too.
-grep -Eq "src=\"data:image/svg\\+xml;base64,${b64}#icon-foo\"" "$page" ||
+command grep -Eq "src=\"data:image/svg\\+xml;base64,${b64}#icon-foo\"" "$page" ||
     fail "img src lost its fragment: $(grep -o 'src="[^"]*"' "$page" | head -n2)"
-grep -Eq "srcset=\"data:image/svg\\+xml;base64,${b64}#icon-set 2x\"" "$page" ||
+command grep -Eq "srcset=\"data:image/svg\\+xml;base64,${b64}#icon-set 2x\"" "$page" ||
     fail "srcset lost its fragment or its descriptor"
 echo OK
 
@@ -73,10 +73,10 @@ if m is None:
     sys.exit(1)
 open(sys.argv[2], "wb").write(base64.b64decode(m.group(1)))
 PY
-grep -Eq "url\\(data:image/svg\\+xml;base64,${b64}#icon-css\\)" "${tmpdir}/got.css" ||
+command grep -Eq "url\\(data:image/svg\\+xml;base64,${b64}#icon-css\\)" "${tmpdir}/got.css" ||
     fail "url() lost its fragment: $(<"${tmpdir}/got.css")"
 # Over the cap, so it stays a link, rebased onto the page's directory: it still
 # names the sprite sheet, so it still needs the selector.
-grep -q 'url(big.svg#icon-big)' "${tmpdir}/got.css" ||
+command grep -q 'url(big.svg#icon-big)' "${tmpdir}/got.css" ||
     fail "the rebased over-cap url() lost its fragment"
 echo OK

--- a/tests/113_engine-threadattr-leak.test
+++ b/tests/113_engine-threadattr-leak.test
@@ -18,7 +18,7 @@ if [ ! -r "${THREADATTRFAIL_LA:-}" ]; then
     echo "threadattr: ${THREADATTRFAIL_LA:-\$THREADATTRFAIL_LA} was not built" >&2
     exit 1
 fi
-if grep -q "^dlname=''" "$THREADATTRFAIL_LA"; then
+if command grep -q "^dlname=''" "$THREADATTRFAIL_LA"; then
     skip "threadattr: static-only build, nothing to preload"
 fi
 if [ ! -r "${THREADATTRFAIL_LIB:-}" ]; then

--- a/tests/117_local-proxytrack-ndx-cursor.test
+++ b/tests/117_local-proxytrack-ndx-cursor.test
@@ -22,7 +22,7 @@ items() {
         fail "proxytrack died on $(basename "$1")"
     n=$(sed -n 's/.*(\([0-9][0-9]*\) items added).*/\1/p' <<<"$out")
     if [ -z "$n" ]; then
-        grep -q '(no items added)' <<<"$out" ||
+        command grep -q '(no items added)' <<<"$out" ||
             fail "proxytrack reported no item count for $(basename "$1")"
         n=0
     fi

--- a/tests/118_local-proxytrack-arcwrite.test
+++ b/tests/118_local-proxytrack-arcwrite.test
@@ -88,7 +88,7 @@ fixed=$((last_alen - ${#BODY}))
 # The reported bug: 12000 bytes wrap "sizeof - strlen - 1", so the guard passes.
 build_arc OK "" 12000
 convert_check "over-long cached headers"
-grep -q 'clipped to' "$dir/log" ||
+command grep -q 'clipped to' "$dir/log" ||
     fail "a clipped header block was not reported on stderr"
 
 # Three sources at once, each with its own limit: the reason phrase is cut at

--- a/tests/120_local-proxytrack-webdav-default.test
+++ b/tests/120_local-proxytrack-webdav-default.test
@@ -70,13 +70,13 @@ propfind() {
 
 resp=$(propfind page.html) ||
     fail_dump "PROPFIND on an exact cache entry did not answer" "$ptlog"
-grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" ||
+command grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" ||
     fail "expected 207 Multi-Status: $resp"
-grep -q '<displayname>Default Document for the Folder</displayname>' <<<"$resp" ||
+command grep -q '<displayname>Default Document for the Folder</displayname>' <<<"$resp" ||
     fail "the default document of the entry was not listed: $resp"
 # The name alone would still pass on a truncated or garbage URL, so pin the
 # href: the default document is the collection path plus an empty name.
-grep -q '<href>/webdav/example\.com/page\.html/</href>' <<<"$resp" ||
+command grep -q '<href>/webdav/example\.com/page\.html/</href>' <<<"$resp" ||
     fail "the default document was listed under the wrong href: $resp"
 responses=$(count_matching_lines '<response ' <<<"$resp")
 test "$responses" -eq 2 ||
@@ -85,7 +85,7 @@ test "$responses" -eq 2 ||
 # The crash killed the process, so a second request is the liveness proof.
 resp=$(propfind "") ||
     fail_dump "proxytrack died serving the previous PROPFIND" "$ptlog"
-grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" ||
+command grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" ||
     fail "expected 207 Multi-Status on the follow-up listing: $resp"
 
 # Leftover traces echoed the client's body and the generated response (#911).
@@ -94,7 +94,7 @@ sentinel=PT911-DAV-BODY-CANARY
 pad=$(printf '%8192s' '')
 resp=$(propfind "" -H 'Expect:' --data-binary "$sentinel${pad// /x}") ||
     fail_dump "proxytrack died serving a PROPFIND carrying a body" "$ptlog"
-grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" ||
+command grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" ||
     fail "expected 207 Multi-Status on the canary listing: $resp"
 
 # The 207 is what makes the absence below mean something: a depth-rejected
@@ -113,7 +113,7 @@ done
 # could only ever miss: these two are what a re-added trace would carry.
 log=$(<"$ptlog")
 for marker in "$sentinel" 'Default Document for the Folder'; do
-    if grep -q "$marker" <<<"$log"; then
+    if command grep -q "$marker" <<<"$log"; then
         echo "FAIL: a PROPFIND echoed '$marker' into proxytrack's output"
         printf '%s\n' "$log"
         exit 1

--- a/tests/138_local-spool-name-overflow.test
+++ b/tests/138_local-spool-name-overflow.test
@@ -31,6 +31,6 @@ test "$moved" -gt 0 || fail "no slot was ever spooled, so the name was never bui
 serr=$(count_matching_lines 'serialize error' "$enginelog")
 test "$serr" -eq 0 || {
     echo "the spool refused to write:"
-    grep 'serialize error' "$enginelog"
+    command grep 'serialize error' "$enginelog"
     exit 1
 }

--- a/tests/139_local-query-charref.test
+++ b/tests/139_local-query-charref.test
@@ -26,7 +26,7 @@ local_server_start --env CHARREF_LOG="$reqlog" --root "$root"
     >"${tmpdir}/crawl.log" 2>&1 || true
 
 query_of() {
-    grep -F "/charref/$1.html?" "$reqlog" | cut -f1 |
+    command grep -F "/charref/$1.html?" "$reqlog" | cut -f1 |
         sed "s|^/charref/$1.html?||" | sort -u
 }
 
@@ -39,7 +39,7 @@ check() {
     shift 3
     printf '[%s] ..\t' "$label"
     got=$(query_of "$page") || got=
-    count=$(grep -F "/charref/${page}.html?" "$reqlog" | cut -f2 | sort -u) || count=
+    count=$(command grep -F "/charref/${page}.html?" "$reqlog" | cut -f2 | sort -u) || count=
     for want in "$@"; do
         if test "$got" == "$want"; then
             ok=1
@@ -88,7 +88,7 @@ check "declared shift_jis page" qsjis 4 \
 # differ on the trailing shift back to ASCII, so the bytes are not one string.
 printf '[declared iso-2022-jp page] ..\t'
 jis=$(query_of qjis) || jis=
-jiscount=$(grep -F "/charref/qjis.html?" "$reqlog" | cut -f2 | sort -u) || jiscount=
+jiscount=$(command grep -F "/charref/qjis.html?" "$reqlog" | cut -f2 | sort -u) || jiscount=
 for field in ${jis//&/ }; do
     case "$field" in
     a=%1b\$B* | c=%1b\$B*)

--- a/tests/140_crash-handler.test
+++ b/tests/140_crash-handler.test
@@ -18,14 +18,14 @@ assert_crash() {
 
     out=$(httrack "-#c=$kind" 2>&1) || rc=$?
     test "$rc" -eq 134 || exit 1
-    grep -q "Deliberate '$kind' crash requested" <<<"$out" || exit 1
-    grep -q "^Caught signal $signum$" <<<"$out" || exit 1
+    command grep -q "Deliberate '$kind' crash requested" <<<"$out" || exit 1
+    command grep -q "^Caught signal $signum$" <<<"$out" || exit 1
     # A frame, or the notice where the OS has no backtrace() (anything but
     # Linux). Symbol names are unreliable under -fvisibility=hidden, and the
     # frame format is libc-specific, so match an address only.
-    grep -qE '0x[0-9a-f]+|No stack trace available' <<<"$out" || exit 1
+    command grep -qE '0x[0-9a-f]+|No stack trace available' <<<"$out" || exit 1
     # The handler ran to its end rather than faulting midway.
-    grep -q "Please report the problem" <<<"$out" || exit 1
+    command grep -q "Please report the problem" <<<"$out" || exit 1
 }
 
 assert_crash segv 11
@@ -35,16 +35,16 @@ assert_crash abort 6
 rc=0
 out=$(httrack -#c 2>&1) || rc=$?
 test "$rc" -eq 134 || exit 1
-grep -q "Deliberate 'segv' crash requested" <<<"$out" || exit 1
+command grep -q "Deliberate 'segv' crash requested" <<<"$out" || exit 1
 
 # An unknown kind is a usage error: the exit is the usual panic 255, not a
 # death, and the diagnostic names the kinds.
 rc=0
 err=$(httrack -#c=bogus 2>&1) || rc=$?
 test "$rc" -eq 255 || exit 1
-grep -q "expects one of:" <<<"$err" || exit 1
-grep -q "segv" <<<"$err" || exit 1
-if grep -q "Deliberate" <<<"$err"; then
+command grep -q "expects one of:" <<<"$err" || exit 1
+command grep -q "segv" <<<"$err" || exit 1
+if command grep -q "Deliberate" <<<"$err"; then
     exit 1
 fi
 
@@ -52,6 +52,6 @@ fi
 rc=0
 err=$(httrack -#C 2>&1) || rc=$?
 test "$rc" -eq 255 || exit 1
-if grep -q "Deliberate" <<<"$err"; then
+if command grep -q "Deliberate" <<<"$err"; then
     exit 1
 fi

--- a/tests/141_webhttrack-warc-options.test
+++ b/tests/141_webhttrack-warc-options.test
@@ -14,7 +14,7 @@ htsserver_require
 
 printf '[project reload maps the keys back] ..\t'
 for key in Warc:warc WarcFile:warcfile WarcMaxSize:warcmaxsize WarcCdx:warccdx Wacz:wacz; do
-    grep -q "do:copy:${key}" "${distdir}/html/server/step2.html" ||
+    command grep -q "do:copy:${key}" "${distdir}/html/server/step2.html" ||
         fail "step2.html does not restore ${key%%:*}"
 done
 echo OK

--- a/tests/143_engine-backtrace-empty.test
+++ b/tests/143_engine-backtrace-empty.test
@@ -23,7 +23,7 @@ if [ ! -r "${NOBACKTRACE_LA:-}" ]; then
     echo "${NOBACKTRACE_LA:-\$NOBACKTRACE_LA} was not built" >&2
     exit 1
 fi
-if grep -q "^dlname=''" "$NOBACKTRACE_LA"; then
+if command grep -q "^dlname=''" "$NOBACKTRACE_LA"; then
     echo "static-only build, skipping" >&2
     exit 77
 fi
@@ -44,7 +44,7 @@ test "$rc" -eq 134 || {
     echo "the plain crash exited $rc, not 134" >&2
     exit 1
 }
-if grep -q 'No stack trace available' <<<"$plain"; then
+if command grep -q 'No stack trace available' <<<"$plain"; then
     echo "no working backtrace() in this build; skipping" >&2
     exit 77
 fi
@@ -56,17 +56,17 @@ test "$rc" -eq 134 || {
     printf '%s\n' "$out" >&2
     exit 1
 }
-grep -q "^Caught signal 6$" <<<"$out" || {
+command grep -q "^Caught signal 6$" <<<"$out" || {
     echo "no 'Caught signal' line:" >&2
     printf '%s\n' "$out" >&2
     exit 1
 }
-grep -q 'No stack trace available: unwinding failed' <<<"$out" || {
+command grep -q 'No stack trace available: unwinding failed' <<<"$out" || {
     echo "an empty backtrace left no diagnostic:" >&2
     printf '%s\n' "$out" >&2
     exit 1
 }
-grep -q "Please report the problem" <<<"$out" || {
+command grep -q "Please report the problem" <<<"$out" || {
     echo "the handler stopped before its closing line:" >&2
     printf '%s\n' "$out" >&2
     exit 1

--- a/tests/145_webhttrack-datadir.test
+++ b/tests/145_webhttrack-datadir.test
@@ -13,7 +13,7 @@ datadir="${CONFIGURED_DATADIR:?not run under make check}"
 
 test -r "${script}" || fail "no ${script}"
 
-line=$(grep '^SRCHDISTPATH=' "${script}") || fail "no SRCHDISTPATH in ${script}"
+line=$(command grep '^SRCHDISTPATH=' "${script}") || fail "no SRCHDISTPATH in ${script}"
 case "${line}" in
 *'@datadir@'*) fail "@datadir@ was never substituted: ${line}" ;;
 esac

--- a/tests/146_bash-shell.test
+++ b/tests/146_bash-shell.test
@@ -35,7 +35,7 @@ configure="${abs_top_srcdir:-}/configure"
 test -r "$configure" || fail "no configure script at $configure; tests/Makefile.am must export abs_top_srcdir"
 
 help=$(bash "$configure" --help)
-grep -q '^  *BASH_SHELL ' <<<"$help" || fail "configure --help does not advertise BASH_SHELL (AC_ARG_VAR missing)"
+command grep -q '^  *BASH_SHELL ' <<<"$help" || fail "configure --help does not advertise BASH_SHELL (AC_ARG_VAR missing)"
 
 tmp=$(mktemp -d)
 cleanup_push rm -rf "$tmp"

--- a/tests/147_local-proxytrack-webdav-overflow.test
+++ b/tests/147_local-proxytrack-webdav-overflow.test
@@ -49,21 +49,21 @@ propfind() {
 amps=$("$python" -c "print('&' * 900)" | tr -d '\r')
 resp=$(propfind "$amps") ||
     fail_dump "proxytrack died on an escapexml-amplified PROPFIND" "$ptlog"
-grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
+command grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" || {
     echo "FAIL: expected 207 Multi-Status for the amplified path"
     head -c 512 <<<"$resp"
     exit 1
 }
 # Count what came back: a clipped path answers 207 too. The run appears in
 # the href and again in the displayname.
-got=$({ grep -o '&amp;' <<<"$resp" || true; } | wc -l)
+got=$({ command grep -o '&amp;' <<<"$resp" || true; } | wc -l)
 test "$got" -eq 1800 || fail "900 ampersands went in, $got came back escaped, wanted 1800"
 
 # Unescaped, so the bound is shown to be on the written length, not on '&'.
 plain=$("$python" -c "print('a' * 900)" | tr -d '\r')
 resp=$(propfind "$plain") ||
     fail_dump "proxytrack died on a 900-byte plain PROPFIND path" "$ptlog"
-grep -q "<href>/webdav/x/$plain</href>" <<<"$resp" || fail "a 900-byte path did not come back whole"
+command grep -q "<href>/webdav/x/$plain</href>" <<<"$resp" || fail "a 900-byte path did not come back whole"
 
 # Depth: 1 is the only route into the enumeration branch, which builds each
 # item URL from the prefix and the child name. A child directory is enumerated
@@ -72,13 +72,13 @@ grep -q "<href>/webdav/x/$plain</href>" <<<"$resp" || fail "a 900-byte path did 
 resp=$("$curl" -s -i --max-time 30 -X PROPFIND -H "Depth: 1" \
     "http://127.0.0.1:$proxyport/webdav/example.com/") ||
     fail_dump "proxytrack died on a Depth: 1 listing" "$ptlog"
-grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" ||
+command grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" ||
     fail "expected 207 Multi-Status for the Depth: 1 listing: $resp"
 for want in '<href>/webdav/example\.com</href>' \
     '<href>/webdav/example\.com/page\.html</href>' \
     '<href>/webdav/example\.com/sub</href>' \
     '<displayname>sub</displayname>'; do
-    grep -q "$want" <<<"$resp" ||
+    command grep -q "$want" <<<"$resp" ||
         fail "the Depth: 1 listing is missing $want: $resp"
 done
 responses=$(count_matching_lines '<response ' <<<"$resp")
@@ -88,7 +88,7 @@ test "$responses" -eq 3 ||
 # The overflow killed the listener, so a later request is the liveness proof.
 resp=$(propfind "") ||
     fail_dump "proxytrack died before the follow-up listing" "$ptlog"
-grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" ||
+command grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" ||
     fail "expected 207 Multi-Status on the follow-up listing: $resp"
 
 echo "OK: an escapexml-amplified PROPFIND path is served whole and does not overflow"

--- a/tests/151_bash-shell-validate.test
+++ b/tests/151_bash-shell-validate.test
@@ -128,7 +128,7 @@ reject() { # reject <label> <expected message> <env argument>...
     shift 2
     run "$label" "$@"
     test "$status" -ne 0 || fail "configure accepted $label"
-    grep -q "$want" <<<"$log" || {
+    command grep -q "$want" <<<"$log" || {
         echo "$label rejected without '$want':" >&2
         tail -5 <<<"$log" >&2
         exit 1
@@ -153,7 +153,7 @@ accept() {
         exit 1
     fi
     if test -n "$want"; then
-        grep -q "$want" <<<"$log" || {
+        command grep -q "$want" <<<"$log" || {
             echo "$label configured without '$want':" >&2
             tail -5 <<<"$log" >&2
             exit 1
@@ -180,7 +180,7 @@ probe() { # probe <run number> <seconds of budget left> <command>...
 # A wedge must fail even with the budget gone, or #922 comes back as a skip.
 rc=$(probe 90 6 sleep 999)
 test "$rc" -eq 1 || fail "a silent configure with 6s of budget reported $rc, want 1"
-grep -q 'wrote nothing' "$tmp/probe.log" || fail "the hang was not named: $(<"$tmp/probe.log")"
+command grep -q 'wrote nothing' "$tmp/probe.log" || fail "the hang was not named: $(<"$tmp/probe.log")"
 # Slow but talking is the emulated buildd, and a skip there beats the harness kill.
 rc=$(probe 91 6 bash -c 'while :; do echo tick; sleep 1; done')
 test "$rc" -eq 77 || fail "a slow but writing configure with 6s of budget reported $rc, want 77"
@@ -192,7 +192,7 @@ test "$rc" -eq 1 || fail "a silent configure with a child of its own reported $r
 sleep 1
 # Not through a pipe: grep -q would leave ps_snapshot writing into a closed one,
 # and pipefail would then read the leaked child as an absent one.
-! grep -q '[s]leep 987' <<<"$(ps_snapshot)" || fail "the killed run left its child running"
+! command grep -q '[s]leep 987' <<<"$(ps_snapshot)" || fail "the killed run left its child running"
 # The pacer must not fire before the case is judged: run() returns with the verdict
 # still unread, and a skip there would bury a configure that answered wrongly. Through
 # the real run(), since a stub cannot see a pacer left inside the one it replaced.
@@ -262,7 +262,7 @@ reject posix-env 'POSIXLY_CORRECT or SHELLOPTS' "BASH_SHELL=$sh" POSIXLY_CORRECT
 # probe has to decide which one to blame instead of reading the environment.
 reject sh-mode-in-posix-env "BASH_SHELL=$tmp/sh is a bash in POSIX sh-mode" \
     "BASH_SHELL=$tmp/sh" POSIXLY_CORRECT=1
-if grep -q 'POSIXLY_CORRECT or SHELLOPTS' <<<"$log"; then
+if command grep -q 'POSIXLY_CORRECT or SHELLOPTS' <<<"$log"; then
     echo "a bash invoked as sh was blamed on the environment:" >&2
     tail -5 <<<"$log" >&2
     exit 1

--- a/tests/153_local-proxytrack-quiet.test
+++ b/tests/153_local-proxytrack-quiet.test
@@ -84,7 +84,7 @@ request_log() { # log
 # them before issuing a request rather than sorting it out afterwards.
 wait_banner() { # log
     local waited=0
-    until grep -q '^PID=' "$1" && grep -q '^processed: ' "$1"; do
+    until command grep -q '^PID=' "$1" && command grep -q '^processed: ' "$1"; do
         test "$waited" -lt 100 || fail "proxytrack never finished its startup banner: $(<"$1")"
         sleep 0.1
         waited=$((waited + 1))
@@ -135,7 +135,7 @@ test "$listed" -eq 4 ||
 # The enumeration is what builds the table, so the served 207s are what make
 # the check below mean anything.
 waited=0
-until test "$(request_log "$quietlog" | grep -ci ' \* log: HTTP [^ ]* 207 [0-9]* propfind ' || true)" -ge 2; do
+until test "$(request_log "$quietlog" | command grep -ci ' \* log: HTTP [^ ]* 207 [0-9]* propfind ' || true)" -ge 2; do
     test "$waited" -lt 50 ||
         fail_dump "fewer than two PROPFINDs were answered 207, so the check below proves nothing" "$quietlog"
     sleep 0.1
@@ -153,7 +153,7 @@ wait_drained "$quietlog"
 # The property is that serving adds nothing but the access log, so whitelist
 # what a line may be; naming strings that must be absent would pass any
 # reworded or differently shaped leak.
-extra=$(request_log "$quietlog" | grep -vE '^( \* log: (HTTP|ICP) .*)?$' || true)
+extra=$(request_log "$quietlog" | command grep -vE '^( \* log: (HTTP|ICP) .*)?$' || true)
 test -z "$extra" ||
     fail "serving a PROPFIND wrote this to proxytrack's console:: $extra"
 
@@ -169,10 +169,10 @@ loudlog=$ptlog loudport=$proxyport loudpid=$ptpid ptpid=
 
 resp=$(propfind "$loudport" "") ||
     fail_dump "PROPFIND under HTS_LOG did not answer" "$loudlog"
-grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" ||
+command grep -q '^HTTP/1\.[01] 207 ' <<<"$resp" ||
     fail "expected 207 Multi-Status under HTS_LOG: $resp"
 waited=0
-until grep -qE 'hashtable .*summary:' "$loudlog"; do
+until command grep -qE 'hashtable .*summary:' "$loudlog"; do
     test "$waited" -lt 50 ||
         fail_dump "HTS_LOG=1 did not restore the hashtable summary" "$loudlog"
     sleep 0.1
@@ -180,7 +180,7 @@ until grep -qE 'hashtable .*summary:' "$loudlog"; do
 done
 # Pin the routed shape whole: a severity, then the message, and nothing in
 # between where the table address used to be.
-grep -qE '^ \* debug: hashtable "[^"]*" summary:' "$loudlog" ||
+command grep -qE '^ \* debug: hashtable "[^"]*" summary:' "$loudlog" ||
     fail_dump "the summary under HTS_LOG did not come through proxytrack's log" "$loudlog"
 
 echo "OK: PROPFIND leaves no hashtable statistics on the console, HTS_LOG restores them"

--- a/tests/154_local-proxytrack-arc-roundtrip.test
+++ b/tests/154_local-proxytrack-arc-roundtrip.test
@@ -70,13 +70,13 @@ test "$inner" != '\n\n' || fail "declared length still counts the blank line"
     printf '\n'
 } >"$dir/empty.arc"
 convert "$dir/empty.arc" "$dir/d.arc" >/dev/null
-! grep -q 'Unexpected' "$dir/log" || fail "empty archive reported as corrupt"
+! command grep -q 'Unexpected' "$dir/log" || fail "empty archive reported as corrupt"
 
 # ...but a length running past the end of the file still is.
 {
     arc_filedesc 99999
 } >"$dir/truncated.arc"
 convert "$dir/truncated.arc" "$dir/e.arc" >/dev/null || true
-grep -q 'Unexpected' "$dir/log" || fail "a length past the end of the file loaded as an empty archive"
+command grep -q 'Unexpected' "$dir/log" || fail "a length past the end of the file loaded as an empty archive"
 
 echo "OK: proxytrack re-reads the .arc it writes"

--- a/tests/155_engine-escape-control.test
+++ b/tests/155_engine-escape-control.test
@@ -33,5 +33,5 @@ selftest_run_queued
 
 # The in-binary table also checks the bytes past the NUL, which printing cannot show.
 got=$(httrack "-#test=escape-control") || fail "self-test exited non-zero"
-grep -q "escape-control self-test OK" <<<"$got" ||
+command grep -q "escape-control self-test OK" <<<"$got" ||
     fail "unexpected self-test output: $got"

--- a/tests/157_crash-argv0-path.test
+++ b/tests/157_crash-argv0-path.test
@@ -45,18 +45,18 @@ PATH="${stage}${bindir}:${PATH}" \
     run_with_timeout 60 httrack -#test=strsafe overflow \
     "this string is far too long for the buffer" >"${out}" 2>&1 || rc=$?
 test "${rc}" -ne 124 || fail "the crash handler did not finish within the deadline"
-grep -q '^Caught signal ' "${out}" || fail "the installed binary printed no backtrace"
-if grep -q 'No stack trace available' "${out}"; then
+command grep -q '^Caught signal ' "${out}" || fail "the installed binary printed no backtrace"
+if command grep -q 'No stack trace available' "${out}"; then
     skip "this build produced no backtrace"
 fi
 
 # Control: without a bare argv[0] in the raw trace there is nothing to repair,
 # and the assertions below would pass on a report that never needed the fix.
 # glibc drops the "+0x" offset when the load bias is zero, as in a non-PIE build.
-grep -qE '^httrack\((\+0x[0-9a-f]+)?\)' "${out}" ||
+command grep -qE '^httrack\((\+0x[0-9a-f]+)?\)' "${out}" ||
     skip "the main program is not reported as a bare argv[0] here"
 
-headers=$(grep -E '^/.*/httrack:$' "${out}" || true)
+headers=$(command grep -E '^/.*/httrack:$' "${out}" || true)
 test -n "${headers}" || fail "the report has no symbolized block for the executable"
 # Every frame of a module is claimed in one pass, so a second block for the
 # executable means library frames were misattributed to it.
@@ -71,7 +71,7 @@ test "${exe}" -ef "${bin}" || fail "the report names ${exe}, not the running ${b
 block=$(awk -v h="${header}" '$0 == h { on = 1; next } /^\// { on = 0 } on' "${out}")
 # " at " pins the symbol column: both addr2line -Cfipa and llvm-symbolizer -p
 # emit it, and a path component named "main" does not.
-grep -qE '(^|[^[:alnum:]_])(sig_fatal|main) at ' <<<"${block}" ||
+command grep -qE '(^|[^[:alnum:]_])(sig_fatal|main) at ' <<<"${block}" ||
     fail "the executable's block names no frame: ${block}"
 
 echo "the crash report named ${exe} and its own frames"

--- a/tests/161_local-proxytrack-zip-headers.test
+++ b/tests/161_local-proxytrack-zip-headers.test
@@ -45,6 +45,6 @@ done
 
 proxytrack --convert "$dir/back.arc" "$dir/out.zip" >"$dir/log" 2>&1 ||
     fail "proxytrack died reading its own new.zip"
-grep -q '(1 items added)' "$dir/log" ||
+command grep -q '(1 items added)' "$dir/log" ||
     fail "the new.zip did not load back: $(<"$dir/log")"
-grep -qF "$BODY" "$dir/back.arc" || fail "body did not survive the round trip"
+command grep -qF "$BODY" "$dir/back.arc" || fail "body did not survive the round trip"

--- a/tests/163_icon-theme.test
+++ b/tests/163_icon-theme.test
@@ -27,7 +27,7 @@ png_size() {
 # hicolor names its directories by pixel size, plus "scalable" for the vector.
 icon_dirs() {
     find "$1" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sed 's|.*/||' |
-        grep -E '^([0-9]+x[0-9]+|scalable)$' | sort || true
+        command grep -E '^([0-9]+x[0-9]+|scalable)$' | sort || true
 }
 
 sizes=$(icon_dirs "${div}")
@@ -54,8 +54,8 @@ hicolor=$(find "${work}/inst" -type d -name hicolor)
 for name in ${sizes}; do
     if [ "${name}" = scalable ]; then
         svg="${hicolor}/scalable/apps/httrack.svg"
-        grep -q '<svg' "${svg}" || fail "${svg} has no <svg> root"
-        grep -q 'viewBox' "${svg}" || fail "${svg} has no viewBox, so it will not scale"
+        command grep -q '<svg' "${svg}" || fail "${svg} has no <svg> root"
+        command grep -q 'viewBox' "${svg}" || fail "${svg} has no viewBox, so it will not scale"
         continue
     fi
     got=$(png_size "${hicolor}/${name}/apps/httrack.png")

--- a/tests/171_watchdog-heartbeat.test
+++ b/tests/171_watchdog-heartbeat.test
@@ -45,7 +45,7 @@ ci_suite_heartbeat 1 1 "$progress" 2 4242 >"$tmp/real" 2>&1
 spent=$((SECONDS - began))
 test "$spent" -ge 2 || fail "killed after ${spent}s of a 2s window: hb_now runs fast"
 test "$spent" -le 8 || fail "took ${spent}s to notice a 2s static window: hb_now is not seconds"
-grep -q '^KILL 4242 at ' "$tmp/real" || fail "a static log was not killed on the real clock"
+command grep -q '^KILL 4242 at ' "$tmp/real" || fail "a static log was not killed on the real clock"
 
 # Virtual clock, started well away from zero so the quiet window is measured from
 # when the watchdog began rather than from whatever the clock happened to read.
@@ -121,22 +121,22 @@ for t in "${said[@]:1}"; do
     prev=$t
 done
 
-grep -q "in flight: RUN ${wrote}s%25a%25b.test at ${wrote}s" "$tmp/out" ||
+command grep -q "in flight: RUN ${wrote}s%25a%25b.test at ${wrote}s" "$tmp/out" ||
     fail "annotation does not name the escaped test in flight: $(head -3 "$tmp/out")"
-grep -q "$(printf '\r')" "$tmp/out" && fail "a CR reached the annotation, truncating it"
-grep -q '98_earlier' "$tmp/out" && fail "annotation names the first test, not the one in flight"
-grep -qx '0 named' "$tmp/strayargs" || fail "process list not host-wide: $(<"$tmp/strayargs")"
+command grep -q "$(printf '\r')" "$tmp/out" && fail "a CR reached the annotation, truncating it"
+command grep -q '98_earlier' "$tmp/out" && fail "annotation names the first test, not the one in flight"
+command grep -qx '0 named' "$tmp/strayargs" || fail "process list not host-wide: $(<"$tmp/strayargs")"
 
 # Joined with %0A and bounded to eight, and no separator left dangling: the
 # runner reads to end of line, so a trailing one is a visible empty tail.
 first=$(sed -n '/^::notice title=suite still running::/{p;q;}' "$tmp/out")
 for i in 1 8; do
-    grep -q "%0A(stub $i)" <<<"$first" || fail "annotation lost process line $i"
+    command grep -q "%0A(stub $i)" <<<"$first" || fail "annotation lost process line $i"
 done
 # By identity, not by count: any eight lines satisfy a tally, including the wrong
 # eight, which is what a bound applied at the far end would leave.
-grep -q '(stub 9)' <<<"$first" && fail "annotation carried more than the eight lines it bounds"
-grep -q '%0A$' "$tmp/out" && fail "annotation ends on a dangling %0A separator"
+command grep -q '(stub 9)' <<<"$first" && fail "annotation carried more than the eight lines it bounds"
+command grep -q '%0A$' "$tmp/out" && fail "annotation ends on a dangling %0A separator"
 
 # A command is only read at the head of a line, so every annotation opens one.
 awk '/^::(notice|error) title=/ { if (prev != "") bad = 1 } { prev = $0 } END { exit bad }' "$tmp/out" ||
@@ -168,7 +168,7 @@ killed=$(sed -n 's/^KILL 4242 at \([0-9]*\)$/\1/p' "$tmp/capped")
 test -n "$killed" || fail "a suite still reporting outlived its wall-clock cap"
 test "$killed" -ge 5480 || fail "capped at $killed, inside the 480s cap"
 test "$killed" -le 5600 || fail "capped at $killed, want 5480 within a tick"
-grep -q '480s cap reached' "$tmp/capped" || fail "the cap kill was announced as something else"
+command grep -q '480s cap reached' "$tmp/capped" || fail "the cap kill was announced as something else"
 test "$(<"$tmp/lastwrite")" -ge 5480 || fail "the log stopped moving: nothing here needed the cap"
 
 # taskkill is a grandchild of its own target, so a leaves-first /T would reap the

--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -34,7 +34,7 @@ test ! -e suite-progress.log || fail "sourcing with \$0 at the driver drove a su
 rc=0
 out=$(bash "$driver" 2>&1) || rc=$?
 test "$rc" -eq 1 || fail "argless run exited $rc, want 1"
-grep -q usage <<<"$out" || fail "argless run said: $out"
+command grep -q usage <<<"$out" || fail "argless run said: $out"
 
 # A copy, so $testdir resolves to a testlib we can neuter: the driver reaps
 # engines host-wide between tests, which under "make check -j" would kill a
@@ -58,7 +58,7 @@ EOF
 # The suite under test has to be the staged copy: only it sources the testlib.sh
 # neutered above, and the srcdir one would reap sibling engines under "make check -j".
 assert_staged() {
-    grep -qx 'ci-windows-suite.sh' "$tmp/sourced-by" ||
+    command grep -qx 'ci-windows-suite.sh' "$tmp/sourced-by" ||
         fail "the srcdir driver ran, not the staged copy: $(sort -u "$tmp/sourced-by" | tr '\n' ' ')"
     : >"$tmp/sourced-by"
 }
@@ -163,43 +163,43 @@ test "$rc" -eq 1 || fail "stub suite exited $rc, want 1 from the pass floor"
 # test would run it twice and inflate every tally the gates read.
 dup=$(awk '/^RUN /{print $2}' suite-progress.log | sort | uniq -d)
 test -z "$dup" || fail "a test was selected by two categories: $dup"
-grep -q '^ran=12 pass=10 fail=1 skip=1 lost=0$' <<<"$out" ||
+command grep -q '^ran=12 pass=10 fail=1 skip=1 lost=0$' <<<"$out" ||
     fail "wrong tally: $(grep '^ran=' <<<"$out")"
-grep -q '::error::only 10 tests passed (1 skipped)' <<<"$out" ||
+command grep -q '::error::only 10 tests passed (1 skipped)' <<<"$out" ||
     fail "the pass floor did not report the count"
-grep -q 'FAIL 12_engine-fail.test (exit 3)' <<<"$out" || fail "the failing test was not named"
+command grep -q 'FAIL 12_engine-fail.test (exit 3)' <<<"$out" || fail "the failing test was not named"
 # The report has to carry the run that failed, not just the trace that passed,
 # and carry it under its own label: reported after the separator it reads as
 # part of the trace. Captured, since a pipe would take grep -q's SIGPIPE.
-grep -q -- '--- traced re-run ---' <<<"$out" || fail "the traced re-run was not reported"
+command grep -q -- '--- traced re-run ---' <<<"$out" || fail "the traced re-run was not reported"
 first=$(sed -n '1,/--- traced re-run ---/p' <<<"$out")
-grep -q 'the first run said so' <<<"$first" ||
+command grep -q 'the first run said so' <<<"$first" ||
     fail "the failing run's tail was lost to the traced re-run"
-grep -q 'trace line 39' <<<"$out" || fail "the traced re-run's own tail was dropped"
+command grep -q 'trace line 39' <<<"$out" || fail "the traced re-run's own tail was dropped"
 # Both halves stay tails: an unbounded report would carry the trace's first line
 # as well as its last, and a CI failure would print the whole log.
-grep -q 'trace line 0$' <<<"$out" && fail "the report is not bounded to a tail"
+command grep -q 'trace line 0$' <<<"$out" && fail "the report is not bounded to a tail"
 
 # This launches the watchdog the way the real driver does, not through a test
 # sourcing the helper, proving it starts and holds a token nothing else sees.
-grep -q '^watchdog ready$' watchdog.log || fail "no watchdog was launched: $(<watchdog.log)"
+command grep -q '^watchdog ready$' watchdog.log || fail "no watchdog was launched: $(<watchdog.log)"
 test -r "$tmp/childtoken" || fail "the test that reads its environment did not run"
-grep -qx 'TOKEN=' "$tmp/childtoken" ||
+command grep -qx 'TOKEN=' "$tmp/childtoken" ||
     fail "a test inherited the status token: $(<"$tmp/childtoken")"
-grep -qx 'TOKEN=s3cr3t' "$wdargv" ||
+command grep -qx 'TOKEN=s3cr3t' "$wdargv" ||
     fail "the watchdog was launched without its token: $(<"$wdargv")"
 test -s "$tmp/cygpathtoken" || fail "the cygpath stub never ran"
-grep -q 'TOKEN=s3cr3t' "$tmp/cygpathtoken" &&
+command grep -q 'TOKEN=s3cr3t' "$tmp/cygpathtoken" &&
     fail "the driver forked a child before scrubbing its token: $(<"$tmp/cygpathtoken")"
 # An orphan runs out its own deadline, re-posting a frozen tail past the step (#795).
 reporter_stopped || fail "the driver exited leaving its reporter running"
 # Positive control for the gate below: with every category matched it stays silent.
-grep -q 'matched no tests' <<<"$out" && fail "a full suite reported an empty category"
+command grep -q 'matched no tests' <<<"$out" && fail "a full suite reported an empty category"
 
 # The progress log is what the watchdog reads and what the artifact keeps.
-grep -q '^RUN 12_engine-fail.test at ' suite-progress.log || fail "no RUN line for the failing test"
-grep -q '^RERUN 12_engine-fail.test$' suite-progress.log || fail "the traced re-run was not noted"
-grep -q '^77 11_engine-skip.test$' suite-progress.log || fail "the skip's status was not recorded"
+command grep -q '^RUN 12_engine-fail.test at ' suite-progress.log || fail "no RUN line for the failing test"
+command grep -q '^RERUN 12_engine-fail.test$' suite-progress.log || fail "the traced re-run was not noted"
+command grep -q '^77 11_engine-skip.test$' suite-progress.log || fail "the skip's status was not recorded"
 test -s 12_engine-fail.test.log || fail "no per-test log for the failing test"
 
 # An emptied category must name itself and stop the suite, rather than hand the
@@ -210,10 +210,10 @@ out=$(RUNNER_TEMP="$tmp" GITHUB_STEP_SUMMARY="$tmp/summary" \
     bash ./ci-windows-suite.sh "$bin" 2>&1) || rc=$?
 assert_staged
 test "$rc" -eq 1 || fail "an empty category exited $rc, want 1"
-grep -q '::error::test category zlib matched no tests' <<<"$out" ||
+command grep -q '::error::test category zlib matched no tests' <<<"$out" ||
     fail "the empty category was not named: $out"
-grep -q 'FAIL \*_zlib' <<<"$out" && fail "the glob was counted as a failing test: $out"
-grep -q '^ran=' <<<"$out" && fail "the suite ran a test with a category empty: $out"
+command grep -q 'FAIL \*_zlib' <<<"$out" && fail "the glob was counted as a failing test: $out"
+command grep -q '^ran=' <<<"$out" && fail "the suite ran a test with a category empty: $out"
 
 # The first category names a single test, and a name nullglob cannot empty would
 # never reach the gate at all.
@@ -224,9 +224,9 @@ out=$(RUNNER_TEMP="$tmp" GITHUB_STEP_SUMMARY="$tmp/summary" \
     bash ./ci-windows-suite.sh "$bin" 2>&1) || rc=$?
 assert_staged
 test "$rc" -eq 1 || fail "an empty single-test category exited $rc, want 1"
-grep -q '::error::test category runnable matched no tests' <<<"$out" ||
+command grep -q '::error::test category runnable matched no tests' <<<"$out" ||
     fail "the empty single-test category was not named: $out"
-grep -q 'FAIL 00_runnable' <<<"$out" && fail "the unexpanded name was run as a test: $out"
+command grep -q 'FAIL 00_runnable' <<<"$out" && fail "the unexpanded name was run as a test: $out"
 
 # The wedge branch has to end the reporter itself: its kill of the suite is a
 # TerminateProcess, which runs no EXIT trap. Forked the way the driver forks it,
@@ -247,7 +247,7 @@ wedge_leg() (
     set +m
     ci_suite_heartbeat 0 1 "$prog" 0 "$victim" >"$tmp/wedge.out" 2>&1 &
     wait "$!"
-    grep -q '::error title=suite watchdog::' "$tmp/wedge.out" ||
+    command grep -q '::error title=suite watchdog::' "$tmp/wedge.out" ||
         fail "the wedge branch was never reached: $(<"$tmp/wedge.out")"
     reporter_stopped || fail "the wedge kill orphaned the reporter"
 )

--- a/tests/180_crash-stack-overflow.test
+++ b/tests/180_crash-stack-overflow.test
@@ -31,9 +31,9 @@ crash_report() {
     out=$(httrack "-#c=$kind" 2>&1) || rc=$?
     test "$rc" -eq 134 ||
         fail "-#c=$kind exited $rc, expected 134 (139 means the handler never ran)"
-    grep -q "Deliberate '$kind' crash requested" <<<"$out" ||
+    command grep -q "Deliberate '$kind' crash requested" <<<"$out" ||
         fail "-#c=$kind: the deliberate-crash notice is missing"
-    grep -q "Please report the problem" <<<"$out" ||
+    command grep -q "Please report the problem" <<<"$out" ||
         fail "-#c=$kind: report truncated, the handler died halfway"
     printf '%s\n' "$out"
 }
@@ -44,7 +44,7 @@ crash_report() {
 deepest_repeat() {
     local addrs
 
-    addrs=$(grep -oE '0x[0-9a-f]+' <<<"$1" || true)
+    addrs=$(command grep -oE '0x[0-9a-f]+' <<<"$1" || true)
     if [ -z "$addrs" ]; then
         echo 0
         return
@@ -67,8 +67,8 @@ if [ "$traced" -eq 0 ]; then
     exit 0
 fi
 
-grep -q "^Caught signal 11$" <<<"$segv" || fail "-#c=segv: no 'Caught signal 11' line"
-grep -q "^Caught signal 11$" <<<"$stack" || fail "-#c=stack: no 'Caught signal 11' line"
+command grep -q "^Caught signal 11$" <<<"$segv" || fail "-#c=segv: no 'Caught signal 11' line"
+command grep -q "^Caught signal 11$" <<<"$stack" || fail "-#c=stack: no 'Caught signal 11' line"
 
 # Measured on x86-64: recursion 256 frames/~250 repeats, control 11/1.
 stack_deep=$(deepest_repeat "$stack")

--- a/tests/181_altstack-honoured.test
+++ b/tests/181_altstack-honoured.test
@@ -19,7 +19,7 @@ require_httrack
 # A --disable-shared build has nothing to preload; anything else missing is a
 # build problem, not a skip, or the legs below would pass vacuously.
 [ -r "${ALTSTACKPROBE_LA:-}" ] || fail "${ALTSTACKPROBE_LA:-\$ALTSTACKPROBE_LA} was not built"
-if grep -q "^dlname=''" "$ALTSTACKPROBE_LA"; then
+if command grep -q "^dlname=''" "$ALTSTACKPROBE_LA"; then
     echo "static-only build, skipping" >&2
     exit 77
 fi
@@ -41,13 +41,13 @@ probe_run() {
 }
 
 # One is already installed: nothing may replace it.
-if grep -q "ALTSTACK-OWN" <<<"$(probe_run keep)"; then
+if command grep -q "ALTSTACK-OWN" <<<"$(probe_run keep)"; then
     fail "httrack replaced an alternate signal stack that was already installed"
 fi
 
 # None is installed: httrack must provide one, which also proves the marker
 # asserted absent above can fire at all.
-grep -q "ALTSTACK-OWN" <<<"$(probe_run none)" ||
+command grep -q "ALTSTACK-OWN" <<<"$(probe_run none)" ||
     fail "httrack installed no alternate signal stack of its own"
 
 # And the borrowed stack has to be usable: the point of deferring is that the
@@ -55,5 +55,5 @@ grep -q "ALTSTACK-OWN" <<<"$(probe_run none)" ||
 rc=0
 out=$(ALTSTACK_MODE=keep LD_PRELOAD="$ALTSTACKPROBE_LIB" httrack -#c=stack 2>&1) || rc=$?
 test "$rc" -eq 134 || fail "-#c=stack on a borrowed alt stack exited $rc, expected 134"
-grep -q "Please report the problem" <<<"$out" ||
+command grep -q "Please report the problem" <<<"$out" ||
     fail "-#c=stack on a borrowed alt stack: report truncated, the handler died halfway"

--- a/tests/182_crash-fork-safety.test
+++ b/tests/182_crash-fork-safety.test
@@ -26,7 +26,7 @@ crash_report() {
     out=$(timeout -s KILL 60 httrack "-#c=$kind" 2>&1) || rc=$?
     test "$rc" -ne 137 || fail "-#c=$kind wedged: the handler never came back"
     test "$rc" -eq 134 || fail "-#c=$kind exited $rc, expected 134"
-    grep -q "Please report the problem" <<<"$out" ||
+    command grep -q "Please report the problem" <<<"$out" ||
         fail "-#c=$kind: report truncated, the handler died halfway"
     printf '%s\n' "$out"
 }
@@ -34,7 +34,7 @@ crash_report() {
 # Control: an ordinary fault walks the same spawn path with no lock held, so a
 # build that cannot report at all fails here rather than passing the real case.
 plain=$(crash_report segv)
-if grep -q 'No stack trace available on this OS' <<<"$plain"; then
+if command grep -q 'No stack trace available on this OS' <<<"$plain"; then
     echo "no backtrace() in this build; skipping" >&2
     exit 77
 fi
@@ -42,7 +42,7 @@ fi
 # empty trace has no module block to assert on.
 case "$(uname -m)" in
 arm | armv*)
-    if grep -q 'No stack trace available' <<<"$plain"; then
+    if command grep -q 'No stack trace available' <<<"$plain"; then
         echo "no unwind tables in this ARM build; skipping" >&2
         exit 77
     fi
@@ -52,8 +52,8 @@ locked=$(crash_report atfork)
 
 # The module header is written just before the spawn: no header, no code under test.
 if command -v addr2line >/dev/null || command -v llvm-symbolizer >/dev/null; then
-    grep -qE '^/.+:$' <<<"$plain" || fail "-#c=segv: no symbolizer was spawned"
-    grep -qE '^/.+:$' <<<"$locked" ||
+    command grep -qE '^/.+:$' <<<"$plain" || fail "-#c=segv: no symbolizer was spawned"
+    command grep -qE '^/.+:$' <<<"$locked" ||
         fail "-#c=atfork: no symbolizer was spawned, the deadlock went untested"
 else
     echo "no addr2line and no llvm-symbolizer: spawn path not exercised" >&2
@@ -63,11 +63,11 @@ fi
 # Unanchored width: -a pads to the target pointer size, 8 nibbles on 32-bit.
 if command -v addr2line >/dev/null; then
     # A name, not just the shape: an all-"??" regression still emits the offsets.
-    grep -qE '^0x[0-9a-f]+: [A-Za-z_]' <<<"$locked" ||
+    command grep -qE '^0x[0-9a-f]+: [A-Za-z_]' <<<"$locked" ||
         fail "-#c=atfork: no symbolized frame, addr2line never ran"
     # The child's stdout is redirected onto the report fd, prebuilt at startup:
     # symbolized frames belong on stderr, never on the crawler's own stdout.
     leaked=$(timeout -s KILL 60 httrack '-#c=segv' 2>/dev/null |
-        grep -cE '^0x[0-9a-f]+: ' || true)
+        command grep -cE '^0x[0-9a-f]+: ' || true)
     test "$leaked" -eq 0 || fail "$leaked symbolized frames leaked to stdout"
 fi

--- a/tests/183_altstack-worker.test
+++ b/tests/183_altstack-worker.test
@@ -33,7 +33,7 @@ crash_report() {
     out=$(httrack "-#c=$kind" 2>&1) || rc=$?
     test "$rc" -eq 134 ||
         fail "-#c=$kind exited $rc, expected 134 (139 means the handler never ran)"
-    grep -q "Please report the problem" <<<"$out" ||
+    command grep -q "Please report the problem" <<<"$out" ||
         fail "-#c=$kind: report truncated, the handler died halfway"
     printf '%s\n' "$out"
 }
@@ -50,7 +50,7 @@ frame_count() {
 plain=$(crash_report segv)
 worker=$(crash_report threadstack)
 
-grep -q "Crash test worker thread started" <<<"$worker" ||
+command grep -q "Crash test worker thread started" <<<"$worker" ||
     fail "-#c=threadstack: no worker was spawned, nothing was tested"
 
 if [ "$traced" -eq 0 ]; then
@@ -79,7 +79,7 @@ test "$plain_frames" -lt 100 ||
 
 # Naming no frame at all is the unwinder failing outright, not a weak one, and
 # the floor below would take it for loong64. hts_print_backtrace() says which.
-if grep -q "No stack trace available" <<<"$worker"; then
+if command grep -q "No stack trace available" <<<"$worker"; then
     fail "-#c=threadstack: the report carries no stack trace at all"
 fi
 
@@ -97,7 +97,7 @@ fi
 # workers that do return, and the syscall trace says what each did with its
 # stack -- 64kB a worker, and an unmap the kernel is not told about first.
 [ -r "${ALTSTACKPROBE_LA:-}" ] || fail "${ALTSTACKPROBE_LA:-\$ALTSTACKPROBE_LA} was not built"
-if grep -q "^dlname=''" "$ALTSTACKPROBE_LA"; then
+if command grep -q "^dlname=''" "$ALTSTACKPROBE_LA"; then
     echo "static-only build, no release trace" >&2
     exit 0
 fi
@@ -114,7 +114,7 @@ rc=0
 out=$(ALTSTACK_TRACE="$trace" LD_PRELOAD="$ALTSTACKPROBE_LIB" \
     httrack -#test=threadwait 2>&1) || rc=$?
 test "$rc" -eq 0 || fail "-#test=threadwait exited $rc: $out"
-grep -q "threadwait self-test: OK" <<<"$out" ||
+command grep -q "threadwait self-test: OK" <<<"$out" ||
     fail "-#test=threadwait did not report OK, no workers to judge: $out"
 [ -s "$trace" ] || fail "the probe traced no sigaltstack() call at all"
 

--- a/tests/195_install-relocate.test
+++ b/tests/195_install-relocate.test
@@ -48,7 +48,7 @@ rpath_entries() {
     otool) raw=$(LC_ALL=C otool -l "$1" 2>/dev/null |
         awk '/LC_RPATH/ { f = 1 } f && $1 == "path" { print $2; f = 0 }') ;;
     esac
-    tr ':' '\n' <<<"${raw}" | grep -v '^$' || true
+    tr ':' '\n' <<<"${raw}" | command grep -v '^$' || true
 }
 
 is_token() {
@@ -112,7 +112,7 @@ copybase=${copy}${base#"${stage}"}
 cd "${work}"
 out=$(env -u LD_LIBRARY_PATH -u DYLD_LIBRARY_PATH "${copy}${bindir}/httrack" --version 2>&1) ||
     fail "the copied binary did not start: ${out}"
-grep -q 'HTTrack version' <<<"${out}" || fail "unexpected --version output: ${out}"
+command grep -q 'HTTrack version' <<<"${out}" || fail "unexpected --version output: ${out}"
 
 # Starting is not enough: take the copy's own library away and the binary has to
 # stop working. If it still runs, another libhttrack answered and the run above

--- a/tests/19_local-connect-fallback.test
+++ b/tests/19_local-connect-fallback.test
@@ -46,7 +46,7 @@ HTTRACK_DEBUG_RESOLVE="deadhost:127.0.0.2,127.0.0.1" \
 log="$out/hts-log.txt"
 
 # the dead address was tried, then the next one (proves the fallback ran)
-if ! grep -q "trying next address" "$log"; then
+if ! command grep -q "trying next address" "$log"; then
     echo "FAIL: no connect fallback happened"
     cat "$log"
     exit 1
@@ -72,9 +72,9 @@ HTTRACK_DEBUG_RESOLVE="alldead:127.0.0.2,127.0.0.3" \
     local_crawl --log "$tmpdir/log2" "http://alldead:${SRV_PORT}/simple/basic.html" -O "$out2" -c1 --robots=0 --timeout=5 --retries=0 --quiet -Z
 log2="$out2/hts-log.txt"
 
-grep -q "trying next address" "$log2" ||
+command grep -q "trying next address" "$log2" ||
     fail_dump "exhaustion path never tried the fallback address" "$log2"
-grep -iqE "^[0-9:]*[[:space:]]Error:" "$log2" ||
+command grep -iqE "^[0-9:]*[[:space:]]Error:" "$log2" ||
     fail_dump "all addresses failing did not report an error" "$log2"
 test ! -f "$out2/alldead_${SRV_PORT}/simple/basic.html" || fail "file downloaded despite every address failing"
 

--- a/tests/200_pixmaps-fallback.test
+++ b/tests/200_pixmaps-fallback.test
@@ -20,9 +20,9 @@ cleanup_push rm -rf "${work}"
 xpm_size() {
     local geom hdr
     hdr=$(head -1 "$1")
-    grep -q '^/\* XPM \*/$' <<<"${hdr}" || fail "$1 has no XPM header"
-    grep -q '^static char \*' "$1" || fail "$1 has no pixmap declaration"
-    geom=$(grep -m1 '^"' "$1" | tr -d '"')
+    command grep -q '^/\* XPM \*/$' <<<"${hdr}" || fail "$1 has no XPM header"
+    command grep -q '^static char \*' "$1" || fail "$1 has no pixmap declaration"
+    geom=$(command grep -m1 '^"' "$1" | tr -d '"')
     case "${geom}" in
     [0-9]*' '[0-9]*' '[0-9]*' '[0-9]*) ;;
     *) fail "$1: bad geometry line '${geom}'" ;;

--- a/tests/206_install-headers-c99.test
+++ b/tests/206_install-headers-c99.test
@@ -172,7 +172,7 @@ EOF
 for std in "${stds[@]}"; do
     pp=$("${cc_argv[@]}" "${cpp_argv[@]}" "-std=$std" -E "$tmp/strnlen.c") ||
         fail "cannot preprocess the htssafe_strnlen_ probe under -std=$std"
-    if grep -q 'return strnlen' <<<"$pp"; then
+    if command grep -q 'return strnlen' <<<"$pp"; then
         fail "-std=$std left htssafe_strnlen_ on libc, the differential proves nothing"
     fi
 done

--- a/tests/207_install-headers-symbols.test
+++ b/tests/207_install-headers-symbols.test
@@ -73,7 +73,7 @@ links() {
 
 # Without both controls every verdict below is vacuous. Compiler-generated
 # statics ("a.2") are not spellable in C, so skip past them.
-pos=$(grep -x hts_is_available "$tmp/exported" || head -1 "$tmp/exported")
+pos=$(command grep -x hts_is_available "$tmp/exported" || head -1 "$tmp/exported")
 neg=$(awk '/^[A-Za-z_][A-Za-z0-9_]*$/ { print; exit }' "$tmp/hidden")
 links "$pos" || {
     head -5 "$tmp/ctl.log" >&2

--- a/tests/215_engine-datadir-ospath.test
+++ b/tests/215_engine-datadir-ospath.test
@@ -55,7 +55,7 @@ run_as() {
     local out line
     out=$(exec -a "$1" "${bin}" -#test=pathbin 2>&1) ||
         fail "the copy did not run as argv[0]=$1: ${out}"
-    line=$(grep '^path_bin=' <<<"${out}") || fail "no path_bin line in: ${out}"
+    line=$(command grep '^path_bin=' <<<"${out}") || fail "no path_bin line in: ${out}"
     got=${line#path_bin=}
 }
 

--- a/tests/216_engine-ftp-ctrlchars.test
+++ b/tests/216_engine-ftp-ctrlchars.test
@@ -5,4 +5,4 @@ set -euo pipefail
 
 # send_line() drops an FTP command carrying a control byte (#1010).
 out=$(httrack -O /dev/null -#test=ftp-ctrlchars run)
-grep -q "ftp-ctrlchars self-test OK" <<<"$out"
+command grep -q "ftp-ctrlchars self-test OK" <<<"$out"

--- a/tests/218_crash-nopie-frames.test
+++ b/tests/218_crash-nopie-frames.test
@@ -50,10 +50,10 @@ build "${work}/probe-pie" || {
 }
 out=${work}/pie.log
 LC_ALL=C "${work}/probe-pie" >"${out}" 2>&1 || fail "the control probe exited non-zero"
-if grep -q 'No stack trace available' "${out}"; then
+if command grep -q 'No stack trace available' "${out}"; then
     skip "this build produced no backtrace"
 fi
-grep -qE 'probe_frame at .*nopieprobe\.c:[0-9]+' "${out}" ||
+command grep -qE 'probe_frame at .*nopieprobe\.c:[0-9]+' "${out}" ||
     skip "nothing is symbolized here, even from an absolute path"
 
 # Same probe under the loader: there /proc/self/exe is ld.so, and only dladdr()
@@ -68,9 +68,9 @@ if [ -n "${interp}" ] && [ -x "${interp}" ]; then
     rc=0
     LC_ALL=C run_with_timeout 60 "${interp}" "${work}/probe-pie" >"${out}" 2>&1 || rc=$?
     test "${rc}" -ne 124 || fail "the loader-launched probe did not finish in time"
-    grep -qxF "${work}/probe-pie:" "${out}" ||
+    command grep -qxF "${work}/probe-pie:" "${out}" ||
         fail "launched through ${interp}, the report heads no block with the program"
-    grep -qE 'probe_frame at .*nopieprobe\.c:[0-9]+' "${out}" ||
+    command grep -qE 'probe_frame at .*nopieprobe\.c:[0-9]+' "${out}" ||
         fail "launched through ${interp}, the report resolves no source line"
 fi
 
@@ -84,9 +84,9 @@ rc=0
 LC_ALL=C PATH="${altdir}:${PATH}" \
     run_with_timeout 60 probe-renamed >"${out}" 2>&1 || rc=$?
 test "${rc}" -ne 124 || fail "the symlinked probe did not finish in time"
-grep -qxF "${work}/probe-pie:" "${out}" ||
+command grep -qxF "${work}/probe-pie:" "${out}" ||
     fail "launched as probe-renamed, the report heads no block with the program"
-grep -qE 'probe_frame at .*nopieprobe\.c:[0-9]+' "${out}" ||
+command grep -qE 'probe_frame at .*nopieprobe\.c:[0-9]+' "${out}" ||
     fail "launched as probe-renamed, the report resolves no source line"
 
 if ! build "${work}/probe-nopie" -no-pie -fno-pie; then
@@ -98,7 +98,7 @@ mkdir "${bindir}"
 mv "${work}/probe-nopie" "${bindir}/probe-nopie"
 if command -v readelf >/dev/null; then
     LC_ALL=C readelf -h "${bindir}/probe-nopie" >"${work}/elf.txt"
-    grep -qE '^[[:space:]]*Type:[[:space:]]+EXEC' "${work}/elf.txt" ||
+    command grep -qE '^[[:space:]]*Type:[[:space:]]+EXEC' "${work}/elf.txt" ||
         skip "the toolchain ignored -no-pie and linked a PIE anyway"
 fi
 
@@ -112,11 +112,11 @@ LC_ALL=C PATH="${bindir}:${PATH}" \
 test "${rc}" -ne 124 || fail "the probe did not finish within the deadline"
 if ! command -v readelf >/dev/null; then
     # glibc drops the "+0x" offset when the load bias is zero.
-    grep -qE '^probe-nopie\(\) \[0x' "${out}" ||
+    command grep -qE '^probe-nopie\(\) \[0x' "${out}" ||
         skip "no zero-bias frame in the report; this is no ET_EXEC"
 fi
 
-headers=$(grep -E '^/.*/probe-nopie:$' "${out}" || true)
+headers=$(command grep -E '^/.*/probe-nopie:$' "${out}" || true)
 test -n "${headers}" || fail "the report has no symbolized block for the executable"
 # Every frame of a module is claimed in one pass, so a second block for the
 # executable means library frames were misattributed to it.
@@ -127,7 +127,7 @@ test "${exe}" -ef "${bindir}/probe-nopie" || fail "the report names ${exe}"
 block=$(awk -v h="${headers}" '$0 == h { on = 1; next } /^\// { on = 0 } on' "${out}")
 # " at " pins the symbol column: both addr2line -Cfipa and llvm-symbolizer -p
 # emit it. A wrong offset resolves to "?? ??:0" instead.
-grep -qE '(^|[^[:alnum:]_])probe_frame at .*nopieprobe\.c:[0-9]+' <<<"${block}" ||
+command grep -qE '(^|[^[:alnum:]_])probe_frame at .*nopieprobe\.c:[0-9]+' <<<"${block}" ||
     fail "the executable's block resolves no source line: ${block}"
 
 echo "the non-PIE report named ${exe} and resolved its own frames"

--- a/tests/219_install-rpath-darwin.test
+++ b/tests/219_install-rpath-darwin.test
@@ -79,7 +79,7 @@ for exe in httrack htsserver; do
     bin=${stage}${bindir}/${exe}
     test -r "${bin}" || fail "no ${exe} in ${stage}${bindir}"
     rpaths=$(dylib_rpaths "${bin}")
-    grep -qxF '@loader_path/../lib' <<<"${rpaths}" ||
+    command grep -qxF '@loader_path/../lib' <<<"${rpaths}" ||
         fail "${exe} carries no @loader_path/../lib rpath, so a copied tree resolves nothing"
     found=0
     while read -r dep; do
@@ -88,7 +88,7 @@ for exe in httrack htsserver; do
         *) continue ;;
         esac
         found=$((found + 1))
-        grep -qxF "${dep}" <<<"${idlist}" ||
+        command grep -qxF "${dep}" <<<"${idlist}" ||
             fail "${exe} loads ${dep}, which is not the id the installed library carries"
     done < <(dylib_deps "${bin}")
     test "${found}" -ge 1 ||

--- a/tests/222_pkgconfig-consumer.test
+++ b/tests/222_pkgconfig-consumer.test
@@ -112,7 +112,7 @@ if [ ! -f "${staged_libdir}/libhttrack.a" ] ||
 elif ! "${cc_argv[@]}" "${static_cflags_argv[@]}" -static -o "${work}/consumer-static" \
     "${work}/consumer.c" "${static_libs_argv[@]}" 2>"${work}/cc-static.log"; then
     # A sanitized build's archive needs the runtime -static cannot supply.
-    if grep -q -e __asan -e __ubsan -e __tsan -e __msan "${work}/cc-static.log"; then
+    if command grep -q -e __asan -e __ubsan -e __tsan -e __msan "${work}/cc-static.log"; then
         echo "the build is sanitized, its archive does not link -static; skipping" >&2
     else
         head -20 "${work}/cc-static.log" >&2

--- a/tests/224_engine-ftp-cmdlen.test
+++ b/tests/224_engine-ftp-cmdlen.test
@@ -12,7 +12,7 @@ cleanup_push rm -rf "${tmpdir}"
 
 out=$(httrack -O "${tmpdir}/st" "-#test=ftp-cmdlen" run 2>&1) ||
     fail "self-test exited non-zero: ${out}"
-grep -q "ftp-cmdlen self-test OK" <<<"${out}" || fail "unexpected output: ${out}"
+command grep -q "ftp-cmdlen self-test OK" <<<"${out}" || fail "unexpected output: ${out}"
 
 # The reachable half: the copy into _adr[256] aborted on a long host.
 probe_host() {
@@ -24,14 +24,14 @@ probe_host() {
 
 for n in 256 257 300; do
     log=$(probe_host "$(repeat_chars "${n}")")
-    grep -q "Host name too long" <<<"${log}" ||
+    command grep -q "Host name too long" <<<"${log}" ||
         fail "a ${n}-byte host was not rejected: ${log}"
 done
 
 # 255 still fits _adr[256]; 127.0.0.1:1 is the outsider a widened gate swallows.
 log=$(probe_host "$(repeat_chars 255)")
-grep -q "Unable to get server's address" <<<"${log}" ||
+command grep -q "Unable to get server's address" <<<"${log}" ||
     fail "a 255-byte host did not reach the resolver: ${log}"
 log=$(probe_host "127.0.0.1:1")
-grep -q "Unable to connect to the server" <<<"${log}" ||
+command grep -q "Unable to connect to the server" <<<"${log}" ||
     fail "a normal host did not reach the connect: ${log}"

--- a/tests/225_install-manifest.test
+++ b/tests/225_install-manifest.test
@@ -79,7 +79,7 @@ fold() {
     LC_ALL=C sort >"${work}/actual"
 
 # An install that staged nothing matches nothing; say that, not a 300-line diff.
-grep -qx '@BINDIR@/httrack' "${work}/actual" || fail "nothing staged under ${stage}"
+command grep -qx '@BINDIR@/httrack' "${work}/actual" || fail "nothing staged under ${stage}"
 
 # Named one by one, not by their directory: dropping all of @LIBDIR@/httrack
 # would unpin whatever else lands there, and a removal would then go unseen.
@@ -90,7 +90,7 @@ plugin_re="^@LIBDIR@/httrack/lib(${plugins})\\.so(\\.[0-9][0-9]*(\\.@revision@)?
 if [ "${EXAMPLE_LIBS:-yes}" = yes ]; then
     LC_ALL=C sort "${manifest}" >"${work}/expected"
 else
-    LC_ALL=C grep -Ev "${plugin_re}" "${manifest}" | LC_ALL=C sort >"${work}/expected"
+    LC_ALL=C command grep -Ev "${plugin_re}" "${manifest}" | LC_ALL=C sort >"${work}/expected"
     # Ten plugins, three names each; a rename would silently match fewer.
     dropped=$(($(lines_of "${manifest}") - $(lines_of "${work}/expected")))
     test "${dropped}" -eq 30 ||

--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -43,7 +43,7 @@ uncommented() { sed -e 's/^[[:space:]]*#.*$//' -e "/['\"]/! s/[[:space:]]#.*$//"
 # Telemetry only, so every spawn and kill idiom is out, aliases and short forms
 # included: PowerShell needs neither the System. prefix nor a space after '&'.
 forbidden_calls() {
-    uncommented "$1" | grep -nEi \
+    uncommented "$1" | command grep -nEi \
         'Start-Process|Start-Job|Start-ThreadJob|(Start|Stop)-Service|Stop-Process|Invoke-Expression|Invoke-Item|Invoke-Command|Invoke-(Cim|Wmi)Method|Get-WmiObject|Register-Scheduled(Job|Task)|WScript\.Shell|taskkill|cmd\.exe|wmic|schtasks|Diagnostics\.Process|\.Kill\(|(^|[^-a-zA-Z0-9_])(iex|saps|spps|spjb|sajb|spsv|sasv|start|kill)([^-a-zA-Z0-9_]|$)|(^|[^-a-zA-Z0-9_])&[^-a-zA-Z0-9_=&]'
 }
 if hits=$(forbidden_calls "$wdscript"); then
@@ -74,33 +74,33 @@ for probe in 'Start-Process notepad.exe' 'Stop-Process -Id 4 -Force' \
 done
 
 # shellcheck disable=SC2016 # $env: is PowerShell's, not this shell's
-grep -q '\$env:WATCHDOG_TOKEN' "$wdscript" ||
+command grep -q '\$env:WATCHDOG_TOKEN' "$wdscript" ||
     fail "the watchdog does not read its token from the environment"
 # Captured, not piped: grep -qi's early exit can SIGPIPE sed, and pipefail
 # would turn that into "no token found".
 params=$(sed -n '/^param(/,/^)/p' "$wdscript")
-if grep -qi 'token' <<<"$params"; then
+if command grep -qi 'token' <<<"$params"; then
     fail "the watchdog takes its token as a parameter, where the process list exposes it"
 fi
-grep -q "ApiBase = 'https://api.github.com'" "$wdscript" ||
+command grep -q "ApiBase = 'https://api.github.com'" "$wdscript" ||
     fail "the watchdog's default endpoint is not the GitHub API"
 # One state, so nothing downstream can read a verdict out of a status that only
 # carries telemetry. The job's own conclusion is the verdict.
-test "$(grep -c "state = 'success'" "$wdscript")" -eq 1 ||
+test "$(command grep -c "state = 'success'" "$wdscript")" -eq 1 ||
     fail "the watchdog posts something other than the one telemetry state"
 # The token stays in the driver's own shell: exported, every test it runs would
 # inherit a credential that can post statuses. 172 drives that end to end.
-grep -q '^unset WATCHDOG_TOKEN$' "$driver" ||
+command grep -q '^unset WATCHDOG_TOKEN$' "$driver" ||
     fail "the driver leaves its token in the environment its tests inherit"
 # A background holder of the step's stdout keeps the step open past the suite (#949).
-grep -q '>>watchdog.log 2>&1' "$driver" ||
+command grep -q '>>watchdog.log 2>&1' "$driver" ||
     fail "the watchdog's output is not redirected off the step's stdout"
 
 # Sourcing the driver is enough to start an interpreter that can post, so every
 # test that does it has to scrub first.
 scrubs() {
-    grep -q 'ci-windows-suite\.sh' "$1" || return 0
-    grep -qx 'unset WATCHDOG_TOKEN WATCHDOG_REPO WATCHDOG_SHA WATCHDOG_URL' "$1"
+    command grep -q 'ci-windows-suite\.sh' "$1" || return 0
+    command grep -qx 'unset WATCHDOG_TOKEN WATCHDOG_REPO WATCHDOG_SHA WATCHDOG_URL' "$1"
 }
 for t in "$testdir"/*.test; do
     scrubs "$t" || fail "$(basename "$t") can reach the driver without scrubbing its credentials"
@@ -200,7 +200,7 @@ if test -x "$bin/pwsh"; then
             local n=0
             reads=$((reads + 1))
             test "$reads" -eq 1 || {
-                grep -q '^watchdog ready$' watchdog.log
+                command grep -q '^watchdog ready$' watchdog.log
                 return $?
             }
             : >race-go
@@ -222,20 +222,20 @@ if test -x "$bin/pwsh"; then
         sleep 0.1
     done
     test -r "$posixtmp/argv" || fail "the watchdog was never launched"
-    grep -qx -- '-SelfTest' "$posixtmp/argv" && fail "the production launch runs the self-test"
+    command grep -qx -- '-SelfTest' "$posixtmp/argv" && fail "the production launch runs the self-test"
     # Bypass is load-bearing: Windows PowerShell refuses an unsigned .ps1 without it.
     for flag in -NoProfile -NonInteractive -ExecutionPolicy Bypass -File; do
-        grep -qx -- "$flag" "$posixtmp/argv" ||
+        command grep -qx -- "$flag" "$posixtmp/argv" ||
             fail "the launch dropped $flag: $(tr '\n' ' ' <"$posixtmp/argv")"
     done
-    grep -qx -- '-ApiBase' "$posixtmp/argv" &&
+    command grep -qx -- '-ApiBase' "$posixtmp/argv" &&
         fail "the production launch redirects the status API away from GitHub"
-    grep -qx -- '-NoPost' "$posixtmp/argv" &&
+    command grep -qx -- '-NoPost' "$posixtmp/argv" &&
         fail "the production launch cannot post at all"
     # Native form, because a non-MSYS interpreter cannot resolve a /d/a/... path.
-    grep -qx -- "$(nativepath "$wdscript")" "$posixtmp/argv" ||
+    command grep -qx -- "$(nativepath "$wdscript")" "$posixtmp/argv" ||
         fail "the launch did not name the script: $(tr '\n' ' ' <"$posixtmp/argv")"
-    grep -qx -- "$(nativepath "$posixtmp/progress.log")" "$posixtmp/argv" ||
+    command grep -qx -- "$(nativepath "$posixtmp/progress.log")" "$posixtmp/argv" ||
         fail "the launch did not pass the progress log"
 else
     # Deferred, not taken here: the workflow audits below need no exec.
@@ -393,7 +393,7 @@ PY
     wfpy=$(nativepath "$tmp/wf.py")
     said=$("$py" "$wfpy" audit "$(nativepath "$workflow")") ||
         fail "the workflow audit did not run: $said"
-    grep -q '^BAD ' <<<"$said" && fail "$(grep '^BAD ' <<<"$said" | sed 's/^BAD //')"
+    command grep -q '^BAD ' <<<"$said" && fail "$(grep '^BAD ' <<<"$said" | sed 's/^BAD //')"
     # The tightest of the backends' step budgets: the watchdog has to fit inside
     # whichever ends first. sed rather than head, which would SIGPIPE the sort.
     cap=$(($(sed -n 's/^timeout=//p' <<<"$said" | sort -n | sed -n 1p) * 60))
@@ -411,9 +411,9 @@ PY
         said=$("$py" "$wfpy" audit "$(nativepath "$tmp/wf.yml")") ||
             fail "the workflow audit did not run on the ${m%%:*} control: $said"
         if test -z "${m#*:}"; then
-            grep -q '^BAD ' <<<"$said" && fail "a reformatted workflow fails the audit: $said"
+            command grep -q '^BAD ' <<<"$said" && fail "a reformatted workflow fails the audit: $said"
         else
-            grep -q "^BAD .*${m#*:}" <<<"$said" ||
+            command grep -q "^BAD .*${m#*:}" <<<"$said" ||
                 fail "the ${m%%:*} control did not trip the audit: $said"
         fi
     done
@@ -538,7 +538,7 @@ sink_stop() {
 export WATCHDOG_TOKEN=n0tat0ken WATCHDOG_REPO=octo/nowhere WATCHDOG_SHA=0000000
 
 # The log rides into the job's artifact, which nothing secret-masks.
-token_free() { ! grep -q "$WATCHDOG_TOKEN" "$1"; }
+token_free() { ! command grep -q "$WATCHDOG_TOKEN" "$1"; }
 
 run_posting() {
     local secs=$1
@@ -568,7 +568,7 @@ cadence_leg() {
         echo "$n API calls at a 100s cadence over 4s, want 1"
         return 1
     }
-    grep -q '36_local-bigcrawl.test' "$posts" || {
+    command grep -q '36_local-bigcrawl.test' "$posts" || {
         echo "the posted status does not name the test in flight: $(<"$posts")"
         return 1
     }
@@ -673,7 +673,7 @@ backoff_leg() {
     fi
     # Every attempt here is refused, so each one after the first must say how many
     # went missing: x= is what separates a stopped box from a network that healed.
-    grep -q ' x=[1-9]' "$posts" || {
+    command grep -q ' x=[1-9]' "$posts" || {
         echo "no posted status counted the failures before it: $(<"$posts")"
         return 1
     }
@@ -702,7 +702,7 @@ for psrun in "${psruns[@]}"; do
 
     out=$(run_wd 120 -File "$(nativepath "$wdscript")" -SelfTest) ||
         fail "the $psrun self-test failed: $out"
-    grep -q 'watchdog self-test OK' <<<"$out" || fail "the $psrun self-test said: $out"
+    command grep -q 'watchdog self-test OK' <<<"$out" || fail "the $psrun self-test said: $out"
 
     # A mutant the script survives is a property nothing is checking. Graded on
     # the assertion named: one that merely fails to parse would read as caught.
@@ -712,7 +712,7 @@ for psrun in "${psruns[@]}"; do
         cmp -s "$wdscript" "$m" && fail "mutant $name changed nothing, so it proves nothing"
         said=$(run_wd 120 -File "$(nativepath "$m")" -SelfTest) || rc=$?
         test "$rc" -ne 0 || fail "mutant $name passed the $psrun self-test: $said"
-        grep -q "self-test FAIL: .*$want" <<<"$said" ||
+        command grep -q "self-test FAIL: .*$want" <<<"$said" ||
             fail "mutant $name tripped no assertion of its own: $said"
     }
     # shellcheck disable=SC2016 # PowerShell variables, quoted for sed
@@ -768,17 +768,17 @@ for psrun in "${psruns[@]}"; do
     fast=$(count_matching_lines 't=[0-9]*s q=' <<<"$out")
     # Against the slow leg, not a floor: a probe tick is not instant.
     test "$fast" -gt "$slow" || fail "$fast status lines at 1s against $slow at 100s: $out"
-    grep -q '36_local-bigcrawl.test' <<<"$out" || fail "the status does not name the test in flight: $out"
-    grep -q '95_local-sitemap' <<<"$out" && fail "the status named a test that was never in flight"
+    command grep -q '36_local-bigcrawl.test' <<<"$out" || fail "the status does not name the test in flight: $out"
+    command grep -q '95_local-sitemap' <<<"$out" && fail "the status named a test that was never in flight"
     # Trips if the scrub and -NoPost were both lost: only a real attempt logs this.
-    grep -q 'status post failed' <<<"$out" && fail "a test leg reached the status API"
+    command grep -q 'status post failed' <<<"$out" && fail "a test leg reached the status API"
 
     # An unreadable log must not read as a wedged one.
     out=$(run_wd 60 -File "$(nativepath "$wdscript")" \
         -ProgressLog "$(nativepath "$tmp/no-such.log")" \
         -IntervalSeconds 1 -PollSeconds 1 -MaxSeconds 3) ||
         fail "the $psrun loop exited nonzero on a missing log: $out"
-    grep -q 'q=?s' <<<"$out" || fail "a missing log reported a staticness: $out"
+    command grep -q 'q=?s' <<<"$out" || fail "a missing log reported a staticness: $out"
 
     # The legs below read the sink, not the loop, and they exercise the script's
     # decisions rather than the interpreter's: one flavour is enough.
@@ -823,7 +823,7 @@ for psrun in "${psruns[@]}"; do
         cmp -s "$wdscript" "$m" && fail "mutant $name changed nothing, so it proves nothing"
         said=$("${leg}_leg" "$(nativepath "$m")") &&
             fail "mutant $name passed the $leg leg"
-        grep -q "$want" <<<"$said" || fail "mutant $name tripped no check of its own: $said"
+        command grep -q "$want" <<<"$said" || fail "mutant $name tripped no check of its own: $said"
     }
     mutate_leg status-every-poll \
         "s/if ((Get-WatchdogAction \$now \$postedAt \$IntervalSeconds) -eq 'post')/if (\$true)/" \

--- a/tests/228_icon-small-flat.test
+++ b/tests/228_icon-small-flat.test
@@ -24,7 +24,7 @@ test "${n}" -le 4 || fail "16x16 icon has ${n} colours, the stems are antialiase
 
 # Both flats present: an all-field tile and an all-ink one are flat too.
 for flat in '#9999cc' '#040404'; do
-    grep -q " ${flat}\$" <<<"${small}" || fail "16x16 icon has no ${flat} pixel"
+    command grep -q " ${flat}\$" <<<"${small}" || fail "16x16 icon has no ${flat} pixel"
 done
 
 # A hairline and a near-solid block both satisfy every count above.

--- a/tests/230_local-ftp-userpass.test
+++ b/tests/230_local-ftp-userpass.test
@@ -34,8 +34,8 @@ crawl() {
 # --- a plain login goes out unchanged ----------------------------------------
 crawl "bob:secret" || fail "the plain-login crawl never finished"
 sent=$(<"$cmds")
-grep -qxF "USER bob" <<<"$sent" || fail "no USER bob on the wire: ${sent}"
-grep -qxF "PASS secret" <<<"$sent" || fail "no PASS secret on the wire: ${sent}"
+command grep -qxF "USER bob" <<<"$sent" || fail "no USER bob on the wire: ${sent}"
+command grep -qxF "PASS secret" <<<"$sent" || fail "no PASS secret on the wire: ${sent}"
 cmp -s "${out}/127.0.0.1_${FTP_PORT}/f.txt" "${root}/f.txt" ||
     fail "the login did not bring the body back; mirror holds $(find "$out" -type f)"
 ok "bob:secret reaches the server verbatim, and mirrors"
@@ -46,9 +46,9 @@ user=$(repeat_chars 255 a)
 pass=$(repeat_chars 255 b)
 crawl "${user}:${pass}" || fail "the 255-byte login crawl never finished"
 sent=$(<"$cmds")
-grep -qxF "USER ${user}" <<<"$sent" ||
+command grep -qxF "USER ${user}" <<<"$sent" ||
     fail "the wire user is not the 255 bytes the URL named: $(grep -a '^USER' <<<"$sent")"
-grep -qxF "PASS ${pass}" <<<"$sent" ||
+command grep -qxF "PASS ${pass}" <<<"$sent" ||
     fail "the wire pass is not the 255 bytes the URL named: $(grep -a '^PASS' <<<"$sent")"
 ok "a 255-byte user and password reach the server unclipped"
 

--- a/tests/231_test-names.test
+++ b/tests/231_test-names.test
@@ -47,7 +47,7 @@ control() {
     if out=$(bash "$checker" "$dir" 2>&1); then
         fail "$name: the checker accepted a name make check would not run"
     fi
-    grep -q "$want" <<<"$out" || fail "$name: wrong diagnostic: $out"
+    command grep -q "$want" <<<"$out" || fail "$name: wrong diagnostic: $out"
 }
 
 control misnamed 'outside the' ': >ghost.test'
@@ -103,7 +103,7 @@ printf '#!/bin/sh\nexit 1\n' >"$work/stub/git"
 chmod +x "$work/stub/git"
 out=$(PATH="$work/stub:$PATH" bash "$checker" "$testdir" 2>&1) ||
     fail "the checker failed outright with git stubbed out: $out"
-grep -q 'skipping the tracked-set check' <<<"$out" ||
+command grep -q 'skipping the tracked-set check' <<<"$out" ||
     fail "a git that cannot answer read as a clean tracked set: $out"
 
 if command -v git >/dev/null 2>&1; then

--- a/tests/233_local-ftp-ctrl-timeout.test
+++ b/tests/233_local-ftp-ctrl-timeout.test
@@ -80,7 +80,7 @@ start=$SECONDS
 crawl stall 5 60 "ftp://127.0.0.1:${liveport}/stall.bin"
 stalled=$((SECONDS - start))
 sent=$(<"$cmds")
-grep -q '^RETR ' <<<"$sent" || fail "the body transfer never started: ${sent}"
+command grep -q '^RETR ' <<<"$sent" || fail "the body transfer never started: ${sent}"
 logged stall 'Time out (5)'
 test "$stalled" -lt 40 ||
     fail "a stalled body transfer took ${stalled}s under --timeout=5"

--- a/tests/234_local-ftp-maxtime.test
+++ b/tests/234_local-ftp-maxtime.test
@@ -34,7 +34,7 @@ elapsed=$((SECONDS - start))
 log="${out}/hts-log.txt"
 # Confirms the transfer had started; otherwise the wait under test never runs.
 sent=$(<"$cmds")
-grep -q '^RETR ' <<<"$sent" ||
+command grep -q '^RETR ' <<<"$sent" ||
     fail "the transfer never started, so nothing was in flight: ${sent}"
 ok "the crawl was inside the body transfer when the cap hit"
 

--- a/tests/235_local-resume-recovery.test
+++ b/tests/235_local-resume-recovery.test
@@ -90,8 +90,8 @@ run_with_timeout 120 httrack -O "$out" --quiet --disable-security-limits \
 test "$rc" -ne 124 || fail "the crawl never terminated"
 log="${out}/hts-log.txt"
 # Without these the recovery could not have been exercised at all.
-grep -q 'Unusable partial-content range' <"$log" || fail "the resume was never rejected; the test proved nothing"
-grep -q 'Restarting whole file' <"$log" || fail "the restart did not run outside the retry budget"
+command grep -q 'Unusable partial-content range' <"$log" || fail "the resume was never rejected; the test proved nothing"
+command grep -q 'Restarting whole file' <"$log" || fail "the restart did not run outside the retry budget"
 got=$(blob_size "$out")
 test "$got" -eq "$resume_full" || fail "blob.bin is ${got} bytes, expected ${resume_full}"
 echo "OK (${got} bytes)"
@@ -109,7 +109,7 @@ run_with_timeout 120 httrack -O "$out" --quiet --disable-security-limits \
     --robots=0 --timeout=30 -c1 --retries=0 --continue \
     "${BASEURL}/resume206loop/index.html" >"${out}.log2" 2>&1 || rc=$?
 test "$rc" -ne 124 || fail "the crawl never terminated; the restart is unbounded"
-grep -q 'Unusable partial-content range' <"${out}/hts-log.txt" || fail "the resume was never rejected; the latch was not exercised"
+command grep -q 'Unusable partial-content range' <"${out}/hts-log.txt" || fail "the resume was never rejected; the latch was not exercised"
 restarts=$(count_matching_lines 'Restarting whole file' <"${out}/hts-log.txt")
 test "$restarts" -eq 1 || fail "${restarts} free restarts, expected exactly 1 (latch)"
 echo "OK (1 free restart, then bounded)"
@@ -129,7 +129,7 @@ run_with_timeout 120 httrack -O "$out" --quiet --disable-security-limits \
 test "$rc" -ne 124 || fail "the crawl never terminated; the alias hop reset the latch"
 log="${out}/hts-log.txt"
 # Without the hop the alternation was never driven and the rest proves nothing.
-grep -q 'Warning moved treated' <"$log" || fail "no alias hop; the re-record path was never reached"
+command grep -q 'Warning moved treated' <"$log" || fail "no alias hop; the re-record path was never reached"
 restarts=$(count_matching_lines 'Restarting whole file' <"$log")
 test "$restarts" -eq 1 || fail "${restarts} free restarts across the alias hops, expected 1"
 retries=$(count_matching_lines 'Retry after error' <"$log")
@@ -150,7 +150,7 @@ if [ ! -r "${UNLINKFAIL_LA:-}" ]; then
     echo "resume-recovery: ${UNLINKFAIL_LA:-\$UNLINKFAIL_LA} was not built" >&2
     exit 1
 fi
-if grep -q "^dlname=''" "$UNLINKFAIL_LA"; then
+if command grep -q "^dlname=''" "$UNLINKFAIL_LA"; then
     echo "resume-recovery: static-only build, skipping the interposed leg"
     exit 0
 fi

--- a/tests/236_local-ftp-teardown.test
+++ b/tests/236_local-ftp-teardown.test
@@ -28,7 +28,7 @@ assert_clean_run() {
         echo "$report" >&2
         fail "$1: the crawl produced a sanitizer report (#1051)"
     }
-    ! grep -Eq 'AddressSanitizer:|MemorySanitizer:|runtime error:' "$errlog" ||
+    ! command grep -Eq 'AddressSanitizer:|MemorySanitizer:|runtime error:' "$errlog" ||
         fail "$1: the crawl produced a sanitizer report (#1051)"
 }
 

--- a/tests/239_doc-guide-anchors.test
+++ b/tests/239_doc-guide-anchors.test
@@ -19,13 +19,13 @@ main=$(awk '/<main[ >]/ { inmain = 1 } inmain { print } /<\/main>/ { inmain = 0 
 
 check() { # check <anchor>: present once, and reachable on Android
     local hits tag platforms
-    hits=$(grep -o "id=\"$1\"" <<<"${main}" | wc -l || true)
+    hits=$(command grep -o "id=\"$1\"" <<<"${main}" | wc -l || true)
     test "${hits}" -eq 1 || {
         echo "FAIL: ${hits} elements inside <main> carry id=\"$1\", want 1" >&2
         return 1
     }
-    tag=$(grep -m1 "id=\"$1\"" <<<"${main}")
-    platforms=$(grep -o 'data-for="[^"]*"' <<<"${tag}" | sed 's/^data-for="//; s/"$//' || true)
+    tag=$(command grep -m1 "id=\"$1\"" <<<"${main}")
+    platforms=$(command grep -o 'data-for="[^"]*"' <<<"${tag}" | sed 's/^data-for="//; s/"$//' || true)
     # guide.css hides one platform's elements from the others, so an anchor on a
     # win-only element scrolls nowhere.
     if test -n "${platforms}"; then

--- a/tests/249_windows-reap-images.test
+++ b/tests/249_windows-reap-images.test
@@ -52,7 +52,7 @@ got=$(LC_ALL=C sort "$tmp/killed")
 test "$got" = "$want" || fail "kill_tree without a winpid ran: $got"
 # The defect itself: whatever the matcher reports as an engine, the kill names.
 for e in $ENGINE_EXES; do
-    grep -qxF "/F /IM $e.exe" "$tmp/killed" || fail "kill_tree leaves $e.exe running"
+    command grep -qxF "/F /IM $e.exe" "$tmp/killed" || fail "kill_tree leaves $e.exe running"
 done
 
 # The pid the caller read while the job was alive, which is what spares the host
@@ -82,7 +82,7 @@ test "$(<"$tmp/killed")" = '/F /T /PID 4242' ||
 : >"$tmp/killed"
 out=$(kill_tree 99 4242 python.exe)
 test ! -s "$tmp/killed" || fail "pid 4242 was killed as a python.exe: $(<"$tmp/killed")"
-grep -q '::warning::pid 4242 no longer runs python.exe' <<<"$out" ||
+command grep -q '::warning::pid 4242 no longer runs python.exe' <<<"$out" ||
     fail "the skipped kill was not reported: $out"
 # Gone from the table entirely, which is what a freed winpid usually looks like.
 : >"$tmp/killed"
@@ -114,14 +114,14 @@ unset -f kill win_capture reap_bounded
 
 : >"$tmp/killed"
 out=$(reap_leftover_processes 99_probe.test)
-grep -q '99_probe.test left processes behind' <<<"$out" || fail "the leak was not attributed: $out"
-grep -q 'proxytrack.exe' <<<"$out" || fail "the leftover proxytrack was not named: $out"
+command grep -q '99_probe.test left processes behind' <<<"$out" || fail "the leak was not attributed: $out"
+command grep -q 'proxytrack.exe' <<<"$out" || fail "the leftover proxytrack was not named: $out"
 for e in $ENGINE_EXES; do
-    grep -qxF "/F /IM $e.exe" "$tmp/killed" || fail "reap_leftover_processes leaves $e.exe running"
+    command grep -qxF "/F /IM $e.exe" "$tmp/killed" || fail "reap_leftover_processes leaves $e.exe running"
 done
 # Deliberately spared: the runner may run a python.exe of its own, and tasklist
 # cannot tell it from a leaked fixture server.
-if grep -qxF '/F /IM python.exe' "$tmp/killed"; then fail "the reap killed an unrelated python.exe"; fi
+if command grep -qxF '/F /IM python.exe' "$tmp/killed"; then fail "the reap killed an unrelated python.exe"; fi
 
 # Near misses, not an idle host, are what a widened image matcher lets through.
 tasklist() {
@@ -139,9 +139,9 @@ test ! -s "$tmp/killed" || fail "an unrelated process was reaped: $(<"$tmp/kille
 # fixture server is still visible to a reader.
 tasklist() { printf 'htsserver.exe   99 Console\npython.exe   98 Console\ntrackpad.exe   78 Console\n'; }
 out=$(list_stray_processes 0 named)
-grep -q 'htsserver.exe' <<<"$out" || fail "the stray listing dropped an engine: $out"
-grep -q 'python.exe' <<<"$out" || fail "the stray listing dropped python: $out"
-if grep -q 'trackpad' <<<"$out"; then fail "the stray listing caught an unrelated process: $out"; fi
+command grep -q 'htsserver.exe' <<<"$out" || fail "the stray listing dropped an engine: $out"
+command grep -q 'python.exe' <<<"$out" || fail "the stray listing dropped python: $out"
+if command grep -q 'trackpad' <<<"$out"; then fail "the stray listing caught an unrelated process: $out"; fi
 
 # The bug was a second engine list drifting from the first, so fail on any name
 # still written by hand inside a taskkill or a process-matching grep. Both files
@@ -149,7 +149,7 @@ if grep -q 'trackpad' <<<"$out"; then fail "the stray listing caught an unrelate
 for f in testlib.sh proclib.sh; do
     test -r "$top_srcdir/tests/$f" || fail "no $f to sweep for hand-written engine names"
 done
-stray=$(grep -nE '(taskkill|tasklist|grep -Ei)[^#]*(httrack|proxytrack|htsserver|webhttrack)' \
+stray=$(command grep -nE '(taskkill|tasklist|grep -Ei)[^#]*(httrack|proxytrack|htsserver|webhttrack)' \
     "$top_srcdir/tests/testlib.sh" "$top_srcdir/tests/proclib.sh" |
     grep -vE 'ENGINE_EXES|ENGINE_IMAGE_RE' || true)
 test -z "$stray" || fail "engine names hand-written outside ENGINE_EXES:

--- a/tests/250_timeout-poll-nofork.test
+++ b/tests/250_timeout-poll-nofork.test
@@ -109,13 +109,13 @@ spent=$((SECONDS - began))
 
 test "$rc" -eq 124 || fail "a tick that never waits exited $rc, not 124: $(<"$tmp/broken.log")"
 # With the count, or a guard tripping on the first tick reads the same.
-grep -q 'poll tick ran 10 times' "$tmp/broken.log" ||
+command grep -q 'poll tick ran 10 times' "$tmp/broken.log" ||
     fail "no verdict naming the tenth tick: $(<"$tmp/broken.log")"
-grep -q '^NOFORK child.sh$' "$tmp/progress" ||
+command grep -q '^NOFORK child.sh$' "$tmp/progress" ||
     fail "the off-box watchdog got no marker: $(<"$tmp/progress")"
 # The deadline path writes DUMP and spends the whole 60s, so either says the guard
 # is gone and the budget is what ended the loop.
-grep -q '^DUMP ' "$tmp/progress" && fail "the loop ran to its 60s deadline, not the guard"
+command grep -q '^DUMP ' "$tmp/progress" && fail "the loop ran to its 60s deadline, not the guard"
 test "$spent" -lt 30 || fail "took ${spent}s to give up on a tick that returns at once"
 childpid=$(<"$tmp/childpid")
 test -n "$childpid" || fail "the child never started"
@@ -129,12 +129,12 @@ REAP_GRACE=5 reap_bounded "$childpid" ||
 : >"$tmp/progress"
 : >"$tmp/ticks"
 run_timeout "$tmp/flaky" "$tmp/flaky.log" || fail "an intermittent tick failed the run: $(<"$tmp/flaky.log")"
-grep -q 'NOFORK' "$tmp/progress" && fail "ticks that fail every other call were read as a wedge"
+command grep -q 'NOFORK' "$tmp/progress" && fail "ticks that fail every other call were read as a wedge"
 
 # Control: a working sleep must reach neither branch, or the assertions above would
 # hold for any run at all.
 : >"$tmp/progress"
 run_timeout "" "$tmp/ok.log" || fail "a healthy run failed: $(<"$tmp/ok.log")"
-grep -q 'NOFORK' "$tmp/progress" && fail "a healthy poll tick was read as a broken one"
+command grep -q 'NOFORK' "$tmp/progress" && fail "a healthy poll tick was read as a broken one"
 
 echo "test-timeout poll guard OK"

--- a/tests/253_local-ftp-close-once.test
+++ b/tests/253_local-ftp-close-once.test
@@ -19,7 +19,7 @@ if [ ! -r "${CLOSETRACK_LA:-}" ]; then
     echo "close-once: ${CLOSETRACK_LA:-\$CLOSETRACK_LA} was not built" >&2
     exit 1
 fi
-if grep -q "^dlname=''" "$CLOSETRACK_LA"; then
+if command grep -q "^dlname=''" "$CLOSETRACK_LA"; then
     skip "close-once: static-only build, nothing to preload"
 fi
 for lib in "${CLOSETRACK_LIB:-}" "${FTPCANCEL_LIB:-}"; do

--- a/tests/255_local-ftp-sigterm.test
+++ b/tests/255_local-ftp-sigterm.test
@@ -91,9 +91,9 @@ ok "SIGTERM ended the crawl in $((SECONDS - started))s"
 # normal end of the mirror. Bailing to the error path, or skipping the link as
 # though it were done, also ends the wait and loses the mirror instead.
 reply=$(<"${tmpdir}/log")
-grep -q 'Exit requested to engine' <<<"$reply" ||
+command grep -q 'Exit requested to engine' <<<"$reply" ||
     fail "SIGTERM did not reach the engine: ${reply}"
-grep -q 'Thanks for using HTTrack' <<<"$reply" ||
+command grep -q 'Thanks for using HTTrack' <<<"$reply" ||
     fail "the exit skipped teardown: ${reply}"
 test -s "${out}/hts-cache/new.zip" ||
     fail "the cache was not committed: $(find "$out" -type f)"
@@ -103,11 +103,11 @@ log=$(<"${out}/hts-log.txt")
 # Only the outer loop's own exit_xh branch writes this. Returning the caller's
 # error code leaves the wait just as well, and jumps straight to cleanup with a
 # cache holding nothing.
-grep -q 'Exit requested by shell or user' <<<"$log" ||
+command grep -q 'Exit requested by shell or user' <<<"$log" ||
     fail "the mirror did not end through the engine's exit path: ${log}"
 # And the abandoned link has to be reported as abandoned. Returning the
 # already-done code leaves the wait too, and drops it without a word.
-grep -q "at link ftp://127.0.0.1:${FTP_PORT}/big.bin" <<<"$log" ||
+command grep -q "at link ftp://127.0.0.1:${FTP_PORT}/big.bin" <<<"$log" ||
     fail "the abandoned link went unreported: ${log}"
 ok "the exit unwound through teardown, keeping the mirror"
 
@@ -124,7 +124,7 @@ started=$SECONDS
 kill -TERM "$crawlpid"
 await_exit 60 "the terminated saturated crawl"
 reply=$(<"${tmpdir}/log")
-grep -q 'Thanks for using HTTrack' <<<"$reply" ||
+command grep -q 'Thanks for using HTTrack' <<<"$reply" ||
     fail "the saturated exit skipped teardown: ${reply}"
 ok "SIGTERM ended a crawl with no free socket in $((SECONDS - started))s"
 
@@ -138,7 +138,7 @@ kill -INT "$crawlpid"
 await_exit 120 "the interrupted crawl"
 # sig_leave's own line: without it the transfer completing says nothing, since
 # a signal that never arrived leaves a crawl that was going to finish anyway.
-grep -q 'Finishing pending transfers' "${tmpdir}/log" ||
+command grep -q 'Finishing pending transfers' "${tmpdir}/log" ||
     fail "the ^C never reached sig_leave: $(<"${tmpdir}/log")"
 cmp -s "${out}/127.0.0.1_${FTP_PORT}/f.bin" "${root}/f.bin" ||
     fail "^C cut the transfer short; mirror holds $(find "$out" -type f)"

--- a/tests/258_crawllib.test
+++ b/tests/258_crawllib.test
@@ -90,7 +90,7 @@ holds 'local_server_start --env LOCAL_SERVER_VERBOSE=1
 import sys, urllib.request
 urllib.request.urlopen("http://127.0.0.1:%s/simple/basic.html" % sys.argv[1]).read()
 PY
-grep -q "GET /simple/basic.html" "$SRV_LOG"'
+command grep -q "GET /simple/basic.html" "$SRV_LOG"'
 ok "--env is exported to the server"
 
 ## Two servers coexist on their own ports, and both are reaped
@@ -101,9 +101,9 @@ local_server_start --log "${tmpdir}/b.log"
 test "$a" != "$SRV_PORT" || fail "both servers took port $a"
 # Two servers, two logs: one shared default would leave the second port
 # discoverable in the first log and hide a --log that never took effect.
-grep -q "PORT ${a}$" "${tmpdir}/a.log" || fail "a.log holds no announcement"
-grep -q "PORT ${SRV_PORT}$" "${tmpdir}/b.log" || fail "b.log holds no announcement"
-! grep -q "PORT ${SRV_PORT}$" "${tmpdir}/a.log" || fail "both servers logged to a.log"
+command grep -q "PORT ${a}$" "${tmpdir}/a.log" || fail "a.log holds no announcement"
+command grep -q "PORT ${SRV_PORT}$" "${tmpdir}/b.log" || fail "b.log holds no announcement"
+! command grep -q "PORT ${SRV_PORT}$" "${tmpdir}/a.log" || fail "both servers logged to a.log"
 printf "%s %s\n" "$apid" "$SRV_PID" >"${tmpdir}/pids"'
 read -r apid bpid <"${tmpdir}/s${subject}/pids"
 # The subject has exited, so its cleanups have run.
@@ -143,7 +143,7 @@ export SHIM_ARGV="$argv"
 PATH="$(posixpath "$shim"):$PATH"
 # By content, not by path spelling. crawled() below catches an unreachable shim
 # too, but names neither the real binary it reached nor the split PATH entry.
-grep -q SHIM_ARGV "$(command -v httrack)" 2>/dev/null ||
+command grep -q SHIM_ARGV "$(command -v httrack)" 2>/dev/null ||
     fail "the shim is not on PATH: $(command -v httrack)"
 url="http://127.0.0.1:1/x"
 
@@ -154,11 +154,11 @@ crawled() { # crawled ARGS...
     : >"$argv"
     # Not the last command, so its status is captured rather than the grep's.
     local_crawl "$@" || rc=$?
-    grep -qxF -- "$url" "$argv" || fail "httrack never ran, or lost its URL"
+    command grep -qxF -- "$url" "$argv" || fail "httrack never ran, or lost its URL"
     return "$rc"
 }
-has() { grep -qxF -- "$1" "$argv" || fail "${2:-missing argument $1}"; }
-hasnt() { ! grep -qxF -- "$1" "$argv" || fail "${2:-unwanted argument $1}"; }
+has() { command grep -qxF -- "$1" "$argv" || fail "${2:-missing argument $1}"; }
+hasnt() { ! command grep -qxF -- "$1" "$argv" || fail "${2:-unwanted argument $1}"; }
 
 crawled -O /dev/null "$url"
 has '--max-time=120' "local_crawl dropped its default --max-time"

--- a/tests/259_doc-css-assets.test
+++ b/tests/259_doc-css-assets.test
@@ -44,7 +44,7 @@ for css in "${srcdir}"/html/*.css; do
         test -f "${work}/dist/${ref}" ||
             fail "${name} reaches ${ref}, which is not in the tarball"
         checked=$((checked + 1))
-    done <<<"$(grep -o 'url([^)]*)' "${css}" || true)"
+    done <<<"$(command grep -o 'url([^)]*)' "${css}" || true)"
 done
 
 # Floor: a scrape that matched nothing passes every check above.

--- a/tests/261_local-abort-purge.test
+++ b/tests/261_local-abort-purge.test
@@ -111,9 +111,9 @@ test "$rc" -ne 124 || fail "the terminated crawl was still running 120s later"
 log=$(<"${out}/hts-log.txt")
 # The exit has to land in the outer loop's own branch, the one that falls
 # through to the purge. A bailout jumps past it and proves nothing.
-grep -q 'Exit requested by shell or user' <<<"$log" ||
+command grep -q 'Exit requested by shell or user' <<<"$log" ||
     fail "the crawl did not end through the engine's exit path: ${log}"
-! grep -q 'restoring previous one' <<<"$log" ||
+! command grep -q 'restoring previous one' <<<"$log" ||
     fail "the abort rolled the session back, which skips the purge anyway: ${log}"
 # And the run must really have left links behind, or there is nothing to purge.
 for name in c d e; do
@@ -131,6 +131,6 @@ for name in c d e; do
 done
 ok "the files the aborted run never reached kept their previous copies"
 
-grep -q 'mirror aborted after' <<<"$log" ||
+command grep -q 'mirror aborted after' <<<"$log" ||
     fail "the aborted run still reports a complete mirror: ${log}"
 ok "the summary reports the abort"

--- a/tests/262_local-signal-receive.test
+++ b/tests/262_local-signal-receive.test
@@ -77,7 +77,7 @@ await_exit 120 "the signalled crawl"
 test "$started" -lt 8 ||
     fail "all eight bodies were already fetched before the first signal"
 
-! grep -q 'Receive Error' "${out}/hts-log.txt" ||
+! command grep -q 'Receive Error' "${out}/hts-log.txt" ||
     fail "a benign signal was reported as a socket error: $(<"${out}/hts-log.txt")"
 # And what the retry queue makes of it afterwards is not the engine's choice to
 # make: the bodies have to arrive whole.
@@ -113,15 +113,15 @@ await_exit 60 "the interrupted crawl"
 elapsed=$((SECONDS - started))
 test "$elapsed" -lt "$STOP_CEILING" ||
     fail "^C took ${elapsed}s to end a stalled transfer"
-grep -q 'Finishing pending transfers' "$log" ||
+command grep -q 'Finishing pending transfers' "$log" ||
     fail "the ^C never reached sig_leave: $(<"$log")"
-grep -q 'Thanks for using HTTrack' "$log" ||
+command grep -q 'Thanks for using HTTrack' "$log" ||
     fail "the stop skipped teardown: $(<"$log")"
 htslog=$(<"${out}/hts-log.txt")
-grep -q 'stopped by user' <<<"$htslog" ||
+command grep -q 'stopped by user' <<<"$htslog" ||
     fail "the abort was not reported as the user's stop: ${htslog}"
 # The fabricated error is the bug: a stop reported as a socket failure is what
 # sends the link to the retry queue and marks the mirror broken.
-! grep -q 'Receive Error' <<<"$htslog" ||
+! command grep -q 'Receive Error' <<<"$htslog" ||
     fail "the stop was reported as a socket error: ${htslog}"
 ok "^C ended the stalled transfer in ${elapsed}s, reported as a stop"

--- a/tests/263_local-ftp-stop-window.test
+++ b/tests/263_local-ftp-stop-window.test
@@ -75,14 +75,14 @@ await_exit() {
 assert_outcome() {
     local reply htslog
     reply=$(<"${tmpdir}/log")
-    grep -q 'Thanks for using HTTrack' <<<"$reply" ||
+    command grep -q 'Thanks for using HTTrack' <<<"$reply" ||
         fail "$1 skipped teardown: ${reply}"
     test -s "$partial" ||
         fail "$1 dropped the received prefix: $(find "$out" -type f)"
     htslog=$(<"${out}/hts-log.txt")
     # The worker's own wait is what has to expire, not some outer bound: only
     # that wait writes this line, with the timeout it was given.
-    grep -q "Time out (${TIMEOUT})" <<<"$htslog" ||
+    command grep -q "Time out (${TIMEOUT})" <<<"$htslog" ||
         fail "$1 did not end on the transfer's own timeout: ${htslog}"
 }
 
@@ -93,7 +93,7 @@ started=$SECONDS
 kill -INT "$crawlpid"
 await_exit 60 "the interrupted crawl"
 stopped=$((SECONDS - started))
-grep -q 'Finishing pending transfers' "${tmpdir}/log" ||
+command grep -q 'Finishing pending transfers' "${tmpdir}/log" ||
     fail "the ^C never reached sig_leave: $(<"${tmpdir}/log")"
 assert_outcome "the interrupted crawl"
 # Upper bound: the second window is gone. Lower bound: the first one is not,

--- a/tests/268_local-abort-purge-capped.test
+++ b/tests/268_local-abort-purge-capped.test
@@ -45,7 +45,7 @@ test "$rc" -ne 124 || fail "the capped crawl overran its deadline"
 log=$(<"${out}/hts-log.txt")
 # Named, not the bare "giving up": a fatal write error prints that too, so an
 # ENOSPC crawl would satisfy the assertion while the cap never fired.
-grep -q 'seconds passed\.\. giving up' <<<"$log" || fail "the time cap never fired: ${log}"
+command grep -q 'seconds passed\.\. giving up' <<<"$log" || fail "the time cap never fired: ${log}"
 # Fewer links than pass 1 saw is what says some were dropped; without it this
 # passes on a mirror that simply finished.
 scanned=$(sed -n 's/.* : \([0-9][0-9]*\) links scanned.*/\1/p' <<<"$log" | tail -1)
@@ -59,6 +59,6 @@ for name in "${leaves[@]}"; do
 done
 ok "the capped run kept the files it never reached"
 
-grep -q 'mirror aborted after' <<<"$log" ||
+command grep -q 'mirror aborted after' <<<"$log" ||
     fail "the capped run still reports a complete mirror: ${log}"
 ok "the summary reports the abort"

--- a/tests/270_local-host-alias.test
+++ b/tests/270_local-host-alias.test
@@ -85,7 +85,7 @@ out=$(httrack 'http://127.0.0.1:1/x.html' -O "$odir" \
     echo "FAIL: httrack accepted a malformed --host-alias rule"
     exit 1
 }
-grep -q "Invalid host-alias rule" <<<"$out" || {
+command grep -q "Invalid host-alias rule" <<<"$out" || {
     echo "FAIL: no diagnostic for a malformed --host-alias rule: $out"
     exit 1
 }
@@ -103,7 +103,7 @@ out=$(httrack 'http://127.0.0.1:1/x.html' -O "$odir" \
     echo "FAIL: httrack accepted a --host-alias rule naming a path"
     exit 1
 }
-grep -q "a path" <<<"$out" || {
+command grep -q "a path" <<<"$out" || {
     echo "FAIL: the diagnostic does not name the path: $out"
     exit 1
 }

--- a/tests/271_doc-chrome-year.test
+++ b/tests/271_doc-chrome-year.test
@@ -26,7 +26,7 @@ chmod -R u+w "${work}"
 chrome="${work}/tools/doc-chrome.py"
 page="${work}/html/index.html"
 
-shipped=$(grep -o '&copy; 1998-[0-9]\{4\}' "${page}" | head -1 | grep -o '[0-9]\{4\}$')
+shipped=$(command grep -o '&copy; 1998-[0-9]\{4\}' "${page}" | head -1 | command grep -o '[0-9]\{4\}$')
 test -n "${shipped}" || fail "no footer copyright year in ${page}"
 # Derived, not pinned: a literal pair goes red the January the tree ships it.
 later=$((shipped + 1))
@@ -73,7 +73,7 @@ restore
 # SOURCE_DATE_EPOCH has to reach the stamp, or every check above is vacuous.
 SOURCE_DATE_EPOCH="${epoch}" python3 "${chrome}" >/dev/null 2>&1 ||
     fail "regeneration under SOURCE_DATE_EPOCH failed"
-grep -q "&copy; 1998-${later} " "${page}" ||
+command grep -q "&copy; 1998-${later} " "${page}" ||
     fail "SOURCE_DATE_EPOCH=${epoch} did not stamp ${later} into the footer"
 
 # The tolerance is symmetric: today's generator accepts the ${later} tree.

--- a/tests/272_webhttrack-host-alias.test
+++ b/tests/272_webhttrack-host-alias.test
@@ -14,7 +14,7 @@ distdir=$(cd "${distdir}" && pwd)
 htsserver_require
 
 printf '[project reload maps the key back] ..\t'
-grep -q "do:copy:HostAlias:hostalias" "${distdir}/html/server/step2.html" ||
+command grep -q "do:copy:HostAlias:hostalias" "${distdir}/html/server/step2.html" ||
     fail "step2.html does not restore HostAlias"
 echo OK
 
@@ -108,10 +108,10 @@ while IFS= read -r arg; do
 done <"${work}/emitted"
 # Rejected flags exit 255 like a URL-less run, so match the diagnostic.
 out=$(httrack "${argv[@]}" 2>&1) || true
-if grep -q "Unknown option" <<<"${out}"; then
+if command grep -q "Unknown option" <<<"${out}"; then
     fail "the engine rejects ${argv[0]}: ${out}"
 fi
 # Control: the same probe on a flag that does not exist.
 out=$(httrack "${argv[0]}es" "${argv[1]}" 2>&1) || true
-grep -q "Unknown option" <<<"${out}" || fail "the unknown-option probe proves nothing"
+command grep -q "Unknown option" <<<"${out}" || fail "the unknown-option probe proves nothing"
 echo OK

--- a/tests/273_webhttrack-strip-query.test
+++ b/tests/273_webhttrack-strip-query.test
@@ -14,7 +14,7 @@ distdir=$(cd "${distdir}" && pwd)
 htsserver_require
 
 printf '[the project key stays bound to the field] ..\t'
-grep -q "do:copy:StripQuery:stripquery" "${distdir}/html/server/step2.html" ||
+command grep -q "do:copy:StripQuery:stripquery" "${distdir}/html/server/step2.html" ||
     fail "step2.html does not restore StripQuery"
 echo OK
 
@@ -110,10 +110,10 @@ while IFS= read -r arg; do
 done <"${work}/emitted"
 # Rejected flags exit 255 like a URL-less run, so match the diagnostic.
 out=$(httrack "${argv[@]}" 2>&1) || true
-if grep -q "Unknown option" <<<"${out}"; then
+if command grep -q "Unknown option" <<<"${out}"; then
     fail "the engine rejects ${argv[0]}: ${out}"
 fi
 # Control: the same probe on a flag that does not exist.
 out=$(httrack "${argv[0]}es" "${argv[1]}" 2>&1) || true
-grep -q "Unknown option" <<<"${out}" || fail "the unknown-option probe proves nothing"
+command grep -q "Unknown option" <<<"${out}" || fail "the unknown-option probe proves nothing"
 echo OK

--- a/tests/274_wizard-profile-load.test
+++ b/tests/274_wizard-profile-load.test
@@ -21,7 +21,7 @@ written=$({
     echo ProxyType
 } | sort -u)
 listed=$(awk '/ini_checkbox_keys\[\] = /,/^\};/' "${distdir}/src/htsserver.c" |
-    grep -o '"[^"]*"' | tr -d '"' | sort -u)
+    command grep -o '"[^"]*"' | tr -d '"' | sort -u)
 # Floor: two gutted lists compare equal.
 test "$(printf '%s\n' "${written}" | wc -l)" -ge 30 ||
     fail "only $(printf '%s\n' "${written}" | wc -l) ztest keys in step4.html"

--- a/tests/275_local-dash-rule.test
+++ b/tests/275_local-dash-rule.test
@@ -29,7 +29,7 @@ parse() {
 
 accepted() { # accepted LABEL
     test "$rc" -eq 0 || fail "$1: exited $rc: $out"
-    ! grep -q "$syntax_re" <<<"$out" || fail "$1: $out"
+    ! command grep -q "$syntax_re" <<<"$out" || fail "$1: $out"
 }
 
 refused() { # refused RE LABEL
@@ -76,7 +76,7 @@ echo OK
 printf '[a malformed dash rule is named, not blamed on -%%C] ..\t'
 parse --host-alias -nope
 refused 'Rejected: -nope' "malformed --host-alias"
-! grep -q '%C' <<<"$out" || fail "the host-alias error still names -%C: $out"
+! command grep -q '%C' <<<"$out" || fail "the host-alias error still names -%C: $out"
 echo OK
 
 # Both would land in the host verbatim. '\v' and not '\n': the argv filter

--- a/tests/276_testlib-freeport.test
+++ b/tests/276_testlib-freeport.test
@@ -82,7 +82,7 @@ spied() { # spied [PROTO...]: echoes the ports, leaves "KIND PORT" in $typelog
 }
 
 drew() { # drew KIND PORT
-    grep -Fxq "$1 $2" "$typelog"
+    command grep -Fxq "$1 $2" "$typelog"
 }
 
 ## a port nothing holds is bindable, one already bound is not
@@ -103,12 +103,12 @@ ok "an unheld port binds and a held one does not"
 port=$(spied tcp) || fail "freeport tcp failed"
 bindable tcp "$port" || fail "the tcp port $port does not bind as tcp"
 drew SOCK_STREAM "$port" || fail "freeport tcp drew $port elsewhere: $(<"$typelog")"
-! grep -q SOCK_DGRAM "$typelog" || fail "freeport tcp opened a udp socket"
+! command grep -q SOCK_DGRAM "$typelog" || fail "freeport tcp opened a udp socket"
 
 port=$(spied udp) || fail "freeport udp failed"
 bindable udp "$port" || fail "the udp port $port does not bind as udp"
 drew SOCK_DGRAM "$port" || fail "freeport udp drew $port elsewhere: $(<"$typelog")"
-! grep -q SOCK_STREAM "$typelog" || fail "freeport udp opened a tcp socket"
+! command grep -q SOCK_STREAM "$typelog" || fail "freeport udp opened a tcp socket"
 ok "each protocol is probed in its own"
 
 ## a mixed pair, the shape start_proxytrack asks for, in that order
@@ -145,7 +145,7 @@ proxytrack_fails() { # proxytrack_fails HTTP_ADDR ICP_ADDR: echoes its error lin
     run_with_timeout 20 proxytrack "$1" "$2" >"$log" 2>&1 || rc=$?
     test "$rc" -ne 124 || fail "proxytrack never exited on $1 $2: $(<"$log")"
     test "$rc" -ne 0 || fail "proxytrack started on $1 $2: $(<"$log")"
-    grep '^Unable to initialize a temporary server' "$log" ||
+    command grep '^Unable to initialize a temporary server' "$log" ||
         fail "proxytrack failed without the harness's banner: $(<"$log")"
 }
 

--- a/tests/277_html-target-and-print.test
+++ b/tests/277_html-target-and-print.test
@@ -26,25 +26,25 @@ done < <(find "${htmldir}" -type f \
 test "${#pages[@]}" -ge 60 || fail "only ${#pages[@]} markup files under html/"
 listing=$(printf '%s\n' "${pages[@]}")
 for want in faq.html cache.html server/index.html server/finished.html server/step2.html; do
-    grep -qxF "${htmldir}/${want}" <<<"${listing}" ||
+    command grep -qxF "${htmldir}/${want}" <<<"${listing}" ||
         fail "candidate list misses html/${want}: the scan cannot see the pages it is for"
 done
 
 # Leading space so data-target and friends do not match. Unquoted values are not
 # covered; nothing in the tree writes one.
-attr() { grep -ohE "[[:space:]][Tt][Aa][Rr][Gg][Ee][Tt][[:space:]]*=[[:space:]]*$1" "${pages[@]}" || true; }
+attr() { command grep -ohE "[[:space:]][Tt][Aa][Rr][Gg][Ee][Tt][[:space:]]*=[[:space:]]*$1" "${pages[@]}" || true; }
 values=$(
     attr '"[^"]*"'
     attr "'[^']*'"
 )
-values=$(tr -d "\"' \\t" <<<"${values}" | sed 's/^[Tt][Aa][Rr][Gg][Ee][Tt]=//' | grep . || true)
+values=$(tr -d "\"' \\t" <<<"${values}" | sed 's/^[Tt][Aa][Rr][Gg][Ee][Tt]=//' | command grep . || true)
 
 seen=$(count_matching_lines . <<<"${values}")
 test "${seen}" -ge 50 || fail "only ${seen} target attributes found under html/"
 
 # Anything but the four keywords is a named context: _new and new_ both were.
 # Nothing here wants a named one, so the keywords are the whole allowlist.
-bad=$(grep -vxE '_blank|_self|_parent|_top' <<<"${values}" | LC_ALL=C sort -u || true)
+bad=$(command grep -vxE '_blank|_self|_parent|_top' <<<"${values}" | LC_ALL=C sort -u || true)
 test -z "${bad}" || fail "not a target keyword: $(tr '\n' ' ' <<<"${bad}")"
 
 # ---- print palette ----
@@ -75,11 +75,11 @@ inroot {
 }' "${css}")
 
 value_of() { awk -v s="$1" -v n="$2" '$1 == s && $2 == n { $1 = ""; $2 = ""; sub(/^ +/, ""); print }' <<<"${tokens}"; }
-count_in() { awk -v s="$1" '$1 == s' <<<"${tokens}" | grep -c . || true; }
+count_in() { awk -v s="$1" '$1 == s' <<<"${tokens}" | command grep -c . || true; }
 
 # Independent count, so a token the awk above never saw cannot pass unrestored.
 declared=$(sed -n '/^@media (prefers-color-scheme: dark) {$/,/^}$/p' "${css}" |
-    grep -oE -- '--[A-Za-z0-9_-]+[[:space:]]*:' | grep -c . || true)
+    command grep -oE -- '--[A-Za-z0-9_-]+[[:space:]]*:' | grep -c . || true)
 test "${declared}" -ge 5 || fail "found no dark palette in ${css} to compare against"
 test "$(count_in dark)" -eq "${declared}" ||
     fail "awk read $(count_in dark) of ${declared} dark tokens in ${css}: the parse is broken"

--- a/tests/278_install-headers-msvc.test
+++ b/tests/278_install-headers-msvc.test
@@ -17,7 +17,7 @@ workflow="$top/.github/workflows/windows-build.yml"
 
 test -r "$sweep" || fail "no $sweep"
 # EXTRA_DIST, or a dist tarball ships 269 without the sweep it drives.
-grep -q 'install-headers-sweep\.sh' "$testdir/Makefile.am" ||
+command grep -q 'install-headers-sweep\.sh' "$testdir/Makefile.am" ||
     fail "install-headers-sweep.sh is not in EXTRA_DIST"
 
 tmp=$(mktemp -d) || exit 1
@@ -203,7 +203,7 @@ for m in none:'' drop:'want exactly one' comment:'want exactly one' \
     if test -z "${m#*:}"; then
         test -z "$said" || fail "a reformatted workflow fails the audit: $said"
     else
-        grep -q "^BAD .*${m#*:}" <<<"$said" ||
+        command grep -q "^BAD .*${m#*:}" <<<"$said" ||
             fail "the ${m%%:*} control did not trip the audit: $said"
     fi
 done

--- a/tests/279_doc-guide-image-sizes.test
+++ b/tests/279_doc-guide-image-sizes.test
@@ -46,7 +46,7 @@ expect_fail() { # expect_fail RE LABEL: the checker must reject, and say why
     if out=$("${python}" "${checker}" "${work}/html" 2>&1); then
         fail "${2}: the checker still passes: ${out}"
     fi
-    grep -q "$1" <<<"${out}" || fail "${2}: no /$1/ in: ${out}"
+    command grep -q "$1" <<<"${out}" || fail "${2}: no /$1/ in: ${out}"
 }
 
 # One defect at a time, or one arm could be covering for another.
@@ -117,7 +117,7 @@ restore
 # floor is the only arm left that can fire.
 rm -f "${work}"/html/img/*
 sed 's|<img [^>]*>||g' "${pristine}/guide.html" >"${guide}"
-if grep -q 'src="img/' "${guide}"; then
+if command grep -q 'src="img/' "${guide}"; then
     fail "the img-less guide still references img/"
 fi
 expect_fail 'want at least' "an img-less guide"

--- a/tests/282_option-flag-values.test
+++ b/tests/282_option-flag-values.test
@@ -53,7 +53,7 @@ refused() { # refused WANTED-MESSAGE ARG...
     shift
     crawl "$@"
     { test "${RC}" -ne 0 && test "${RC}" -ne 134; } || fail "$* not refused (exit ${RC})"
-    grep -q "${want}" "${tmp}/out/.log" ||
+    command grep -q "${want}" "${tmp}/out/.log" ||
         fail "$* refused without saying why: $(<"${tmp}/out/.log")"
 }
 
@@ -88,7 +88,7 @@ test -n "$(find "${tmp}/out" -type f -name page.html -print -quit)" ||
 # Every option that carries a value must emit a short form the engine parses
 # whole: a digit left over reaches "invalid option" and kills the run (#1200).
 rows=$(httrack -O /dev/null "-#test=optalias" -list)
-test "$(grep -c . <<<"${rows}")" -ge 150 || fail "short option list: ${rows}"
+test "$(command grep -c . <<<"${rows}")" -ge 150 || fail "short option list: ${rows}"
 while read -r class name; do
     case ${class} in
     onoff | level) ;;
@@ -98,7 +98,7 @@ while read -r class name; do
         # --advanced-wait=N is a sleep, so only its 0 comes back
         test "${name}" != advanced-wait || test "${value}" = 0 || continue
         crawl "--${name}=${value}"
-        ! grep -q 'invalid option' "${tmp}/out/.log" ||
+        ! command grep -q 'invalid option' "${tmp}/out/.log" ||
             fail "--${name}=${value} (${class}) emits a short form the engine rejects"
     done
 done <<<"${rows}"
@@ -107,7 +107,7 @@ done <<<"${rows}"
 # dead. This does not see two rows that share a class but target different
 # short options; --test is one, and is harmless because the help agrees.
 for name in $(awk '{print $2}' <<<"${rows}" | sort | uniq -d); do
-    n=$(awk -v k="${name}" '$2 == k {print $1}' <<<"${rows}" | sort -u | grep -c .)
+    n=$(awk -v k="${name}" '$2 == k {print $1}' <<<"${rows}" | sort -u | command grep -c .)
     test "${n}" -eq 1 ||
         fail "--${name} has ${n} classes in the table; the first row silently wins"
 done
@@ -133,18 +133,18 @@ echo "file://${tmp}/page.html" >"${tmp}/urls.txt"
 for name in list filelist urllist filterlist; do
     crawl "--${name}=${tmp}/urls.txt"
     test "${RC}" -eq 0 || fail "--${name}=FILE exited ${RC}"
-    ! grep -q 'Syntax error' "${tmp}/out/.log" ||
+    ! command grep -q 'Syntax error' "${tmp}/out/.log" ||
         fail "--${name}=FILE is refused, but its synonym takes the same value"
 done
 
 # Non-circular control on the classes, since the sweep above reads the table it
 # is checking: every --name=0 the wizard writes has to be a row that takes a
 # value, or the flag means the opposite of the box (#1195, #1200).
-literals=$(grep -o -- '--[a-z0-9-]*=0' "${distdir}/html/server/step4.html" |
+literals=$(command grep -o -- '--[a-z0-9-]*=0' "${distdir}/html/server/step4.html" |
     sed -e 's/^--//' -e 's/=0$//' | sort -u)
-test "$(grep -c . <<<"${literals}")" -ge 10 || fail "step4.html scan came up short"
+test "$(command grep -c . <<<"${literals}")" -ge 10 || fail "step4.html scan came up short"
 while read -r name; do
-    class=$(grep -m1 -E "^[a-z0-9]+ ${name}\$" <<<"${rows}" || true)
+    class=$(command grep -m1 -E "^[a-z0-9]+ ${name}\$" <<<"${rows}" || true)
     test -n "${class}" || fail "step4.html writes --${name}=0, which is no option"
     test "${class%% *}" != single ||
         fail "step4.html writes --${name}=0, but its class takes no value"

--- a/tests/283_engine-cmdline-leak.test
+++ b/tests/283_engine-cmdline-leak.test
@@ -140,7 +140,7 @@ for form in linux bsd; do
     linux) script -qec 'test -t 1 && echo TTYOK' "$tmp/ttyprobe" >/dev/null 2>&1 || true ;;
     bsd) script -q "$tmp/ttyprobe" /bin/sh -c 'test -t 1 && echo TTYOK' >/dev/null 2>&1 || true ;;
     esac
-    if grep -q TTYOK "$tmp/ttyprobe" 2>/dev/null; then
+    if command grep -q TTYOK "$tmp/ttyprobe" 2>/dev/null; then
         tty_form=$form
         break
     fi

--- a/tests/284_cli-resume-prompt.test
+++ b/tests/284_cli-resume-prompt.test
@@ -45,7 +45,7 @@ seed "$tmp/plain" --footer 'zzzmarker'
 out=$(ask "$tmp/plain")
 assert_match 'OK to (Continue|Update) httrack ' "$out" "no resume offer"
 assert_match 'zzzmarker' "$out" "the offer dropped the options"
-! grep -qF -- "$bin" <<<"$out" || fail "the offer still quotes the program path"
+! command grep -qF -- "$bin" <<<"$out" || fail "the offer still quotes the program path"
 echo OK
 
 # Teeth for the clip: doit.log replays up to 8000 bytes, so a command line built
@@ -60,5 +60,5 @@ out=$(ask "$tmp/long")
 assert_match 'OK to (Continue|Update) httrack .*\.\.\.\?' "$out" \
     "a command line past the buffer was not clipped"
 # htssafe names the file it aborts in; the offer must not be one of them.
-! grep -qE 'overflow while copying' <<<"$out" || fail "the offer aborted on the bounds check instead of clipping"
+! command grep -qE 'overflow while copying' <<<"$out" || fail "the offer aborted on the bounds check instead of clipping"
 echo OK

--- a/tests/286_ci-windows-pool.test
+++ b/tests/286_ci-windows-pool.test
@@ -83,10 +83,10 @@ run_suite() { # run_suite <dir> <jobs>
 
 assert_tally() {
     local got
-    got=$(grep '^ran=' "$tmp/out" || true)
+    got=$(command grep '^ran=' "$tmp/out" || true)
     test "$got" = 'ran=12 pass=10 fail=1 skip=1 lost=0' || fail "$1: wrong tally: $got"
-    grep -q 'FAIL 12_engine-fail.test (exit 3)' "$tmp/out" || fail "$1: the failing test was not named"
-    grep -q '^SKIP 11_engine-skip.test$' "$tmp/out" || fail "$1: the skipped test was not named"
+    command grep -q 'FAIL 12_engine-fail.test (exit 3)' "$tmp/out" || fail "$1: the failing test was not named"
+    command grep -q '^SKIP 11_engine-skip.test$' "$tmp/out" || fail "$1: the skipped test was not named"
 }
 
 # Tests handed a TMPDIR that is not the suite.<name> dir of their own name.
@@ -155,8 +155,8 @@ mkdir -p "$tmp/mine/httrack_local.a/crawl" "$tmp/theirs/httrack_local.b/crawl"
 echo MINECRAWL >"$tmp/mine/httrack_local.a/crawl/hts-log.txt"
 echo THEIRSCRAWL >"$tmp/theirs/httrack_local.b/crawl/hts-log.txt"
 dumped=$(TMPDIR="$tmp/mine" dump_crawl_logs)
-grep -q MINECRAWL <<<"$dumped" || fail "the dump did not report its own crawl log: $dumped"
-grep -q THEIRSCRAWL <<<"$dumped" && fail "the dump reached a crawl log outside its TMPDIR"
+command grep -q MINECRAWL <<<"$dumped" || fail "the dump did not report its own crawl log: $dumped"
+command grep -q THEIRSCRAWL <<<"$dumped" && fail "the dump reached a crawl log outside its TMPDIR"
 test ! -d "$tmp/mine/httrack_local.a" || fail "the dump kept the crawl dir it reported"
 test -d "$tmp/theirs/httrack_local.b" || fail "the dump deleted a crawl dir outside its TMPDIR"
 

--- a/tests/287_webhttrack-footer-year.test
+++ b/tests/287_webhttrack-footer-year.test
@@ -18,11 +18,11 @@ printf '[every server footer takes its year from the clock] ..\t'
 
 # The probe below reads one page, so sweep them all here: converting index.html
 # and leaving the other 22 stamped would still serve a correct-looking reply.
-stamped=$({ grep -l '&copy; 1998-[0-9]' "${distdir}"/html/server/*.html || true; })
+stamped=$({ command grep -l '&copy; 1998-[0-9]' "${distdir}"/html/server/*.html || true; })
 test -z "${stamped}" || fail "footers still carry a stamped year: ${stamped}"
-footers=$({ grep -l 'id="footer"' "${distdir}"/html/server/*.html || true; } | wc -l)
+footers=$({ command grep -l 'id="footer"' "${distdir}"/html/server/*.html || true; } | wc -l)
 # shellcheck disable=SC2016 # the literal ${...} is what we look for
-tokens=$({ grep -lF '1998-${date:year}' "${distdir}"/html/server/*.html || true; } | wc -l)
+tokens=$({ command grep -lF '1998-${date:year}' "${distdir}"/html/server/*.html || true; } | wc -l)
 test "${footers}" -gt 20 || fail "only ${footers} server pages carry a footer"
 test "${tokens}" -eq "${footers}" || fail "${footers} footers, ${tokens} take the token"
 
@@ -56,16 +56,16 @@ test "${local_year}" -eq $((pinned + 1)) || skip "TZ=${TZ} is not honored here"
 export SOURCE_DATE_EPOCH="${epoch}"
 htsserver_start --root "${root}" --home "${work}"
 reply=$(htsserver_get /server/probe-1165.html)
-grep -q '^HTTP/1.[01] 200' <<<"${reply}" || fail "probe page: ${reply}"
-grep -q "year=\[${pinned}\]" <<<"${reply}" ||
+command grep -q '^HTTP/1.[01] 200' <<<"${reply}" || fail "probe page: ${reply}"
+command grep -q "year=\[${pinned}\]" <<<"${reply}" ||
     fail "SOURCE_DATE_EPOCH=${epoch} did not reach the expansion as UTC: ${reply}"
-grep -q 'unknown=\[\] longer=\[\]' <<<"${reply}" ||
+command grep -q 'unknown=\[\] longer=\[\]' <<<"${reply}" ||
     fail "a field that is not year expands to something: ${reply}"
 
 # A shipped page must carry the token, not a stamped year.
 reply=$(htsserver_get /server/index.html)
-grep -q '^HTTP/1.[01] 200' <<<"${reply}" || fail "index.html: ${reply}"
-grep -q "&copy; 1998-${pinned} Xavier Roche &amp; other contributors" <<<"${reply}" ||
+command grep -q '^HTTP/1.[01] 200' <<<"${reply}" || fail "index.html: ${reply}"
+command grep -q "&copy; 1998-${pinned} Xavier Roche &amp; other contributors" <<<"${reply}" ||
     fail "the index.html footer does not follow the clock: ${reply}"
 # shellcheck disable=SC2016 # ditto: the raw token must not survive
 case ${reply} in
@@ -88,7 +88,7 @@ for override in '' abc 99999999999999999999 -1 -62230000000 67768036191676799; d
     reply=$(htsserver_get /server/probe-1165.html)
     # Re-read: a New Year crossing mid-request is not a failure.
     after=$(date +%Y)
-    grep -qE "year=\[(${now}|${after})\]" <<<"${reply}" ||
+    command grep -qE "year=\[(${now}|${after})\]" <<<"${reply}" ||
         fail "SOURCE_DATE_EPOCH='${override}' gives neither ${now} nor ${after}: ${reply}"
     htsserver_stop
 done

--- a/tests/289_webhttrack-lifetime.test
+++ b/tests/289_webhttrack-lifetime.test
@@ -60,9 +60,9 @@ printf '[an abandoned WebHTTrack server stops on its own] ..\t'
 # in a browser: a client that stopped naming its window, or spelled the farewell
 # differently, would leave every case below testing the server against itself.
 js="${HTS_DISTDIR}/html/server/ping.js"
-grep -qF '"/ping?w=" + PING_WINDOW' "${js}" || fail "ping.js stopped naming its window"
-grep -qF 'ping_url("e=bye")' "${js}" || fail "ping.js stopped saying goodbye"
-grep -qF '"sid=" + encodeURIComponent(sid)' "${js}" ||
+command grep -qF '"/ping?w=" + PING_WINDOW' "${js}" || fail "ping.js stopped naming its window"
+command grep -qF 'ping_url("e=bye")' "${js}" || fail "ping.js stopped saying goodbye"
+command grep -qF '"sid=" + encodeURIComponent(sid)' "${js}" ||
     fail "ping.js stopped signing its goodbye, which the server then ignores"
 
 # 1. The heartbeat must never be answered from a cache: a reply the browser
@@ -73,8 +73,8 @@ bye_port=${HTS_PORT}
 sid=$(page_sid "${bye_port}")
 test "${#sid}" -eq 32 || fail "no session id on the wizard's first page"
 reply=$(get "${bye_port}" '/ping?w=w1')
-grep -q '^HTTP/1\.0 200 ' <<<"${reply}" || fail "no pong: $(head -1 <<<"${reply}")"
-grep -qi '^Cache-Control:.*no-cache' <<<"${reply}" ||
+command grep -q '^HTTP/1\.0 200 ' <<<"${reply}" || fail "no pong: $(head -1 <<<"${reply}")"
+command grep -qi '^Cache-Control:.*no-cache' <<<"${reply}" ||
     fail "the heartbeat is cacheable: ${reply}"
 
 # 2. Closing one of two windows must not end a session the other is still using.
@@ -228,7 +228,7 @@ test "${#sid}" -eq 32 || fail "no session id to quit with"
 "${HTS_PYTHON}" "${testdir}/httpclient.py" --port "${HTS_PORT}" \
     --path /server/exit.html --field "sid=${sid}" --field command=quit >/dev/null
 died_within "${quit_pid}" "${grace}" || fail "Quit did not stop the server"
-! grep -q 'Unable to create the server' "${HTS_LOG}" ||
+! command grep -q 'Unable to create the server' "${HTS_LOG}" ||
     fail "a clean quit reported a server it could not create: $(<"${HTS_LOG}")"
 
 htsserver_stop

--- a/tests/291_webhttrack-footer-default.test
+++ b/tests/291_webhttrack-footer-default.test
@@ -19,14 +19,14 @@ printf '[a fresh profile prefills the named-field footer] ..\t'
 mkdir -p "${work}/websites"
 htsserver_start --home "${work}"
 reply=$(htsserver_get /server/option6.html)
-grep -q '^HTTP/1.[01] 200' <<<"${reply}" || fail "option6.html: ${reply}"
+command grep -q '^HTTP/1.[01] 200' <<<"${reply}" || fail "option6.html: ${reply}"
 
 value=$(firstline "$(sed -n 's/.*name="footer" value="\([^"]*\)".*/\1/p' <<<"${reply}")")
 test -n "${value}" || fail "option6.html serves no footer field: ${reply}"
 case ${value} in
 *'%s'*) fail "the prefilled footer is still positional: ${value}" ;;
 esac
-grep -q '{url}.*{date}' <<<"${value}" || fail "prefilled footer: ${value}"
+command grep -q '{url}.*{date}' <<<"${value}" || fail "prefilled footer: ${value}"
 
 htsserver_stop
 # A leaked server wedges the parallel harness behind a green log.

--- a/tests/295_wizard-log.test
+++ b/tests/295_wizard-log.test
@@ -36,24 +36,24 @@ crawl() { # crawl MIRRORDIR [httrack args...], sets $log
 # "ignore this link": the answer forbids it and inserts the single-link filter
 answers 0
 crawl "$tmp/m0" -W
-grep -q "$tag '0' (n=0) for $link: forbidden, filters: -$link\$" "$log" ||
+command grep -q "$tag '0' (n=0) for $link: forbidden, filters: -$link\$" "$log" ||
     fail "the answer line is wrong in $log"
 # the prefix fspc() tallies by: a notice is a message, never a warning
-grep -q "Info:.*$tag '0'" "$log" ||
+command grep -q "Info:.*$tag '0'" "$log" ||
     fail "the answer is not tallied as a message in $log"
 
 # "ignore the whole host": same reply path, a different filter. The log echoes
 # what was inserted, so a hardcoded pattern would still read -.../x.html here.
 answers 2
 crawl "$tmp/m2" -W
-grep -q "$tag '2' (n=2) for $link: forbidden, filters: -other.invalid/[*]\$" "$log" ||
+command grep -q "$tag '2' (n=2) for $link: forbidden, filters: -other.invalid/[*]\$" "$log" ||
     fail "the answer line does not echo the inserted filter in $log"
 
 # a host-scope answer, which accepts and inserts two filters: the starred form
 # misses the apex, so both slots must reach the log, in insertion order
 answers 1000
 crawl "$tmp/m1000" -W
-grep -q "$tag '1000' (n=1000) for $link: allowed, filters: [+][*].other.invalid/[*] [+]other.invalid/[*]\$" "$log" ||
+command grep -q "$tag '1000' (n=1000) for $link: allowed, filters: [+][*].other.invalid/[*] [+]other.invalid/[*]\$" "$log" ||
     fail "a two-filter answer is not logged whole in $log"
 
 # nobody was asked: the automatic resolution stays at the debug level. This run
@@ -61,5 +61,5 @@ grep -q "$tag '1000' (n=1000) for $link: allowed, filters: [+][*].other.invalid/
 # the CLI always registers query3, so no test here reaches that guard.
 answers 0
 crawl "$tmp/mauto"
-! grep -q "$tag" "$log" ||
+! command grep -q "$tag" "$log" ||
     fail "a non-interactive run logged an answer in $log"

--- a/tests/296_local-wizard-delayed.test
+++ b/tests/296_local-wizard-delayed.test
@@ -45,24 +45,24 @@ local_crawl --stdin "$answers" --log "${tmpdir}/crawl.log" -- \
     "http://127.0.0.1:${SRV_PORT}/wizdelayed/index.html" || rc=$?
 test "$rc" -eq 0 || fail "the crawl exited $rc"
 
-grep -q 'beyond this mirror scope' "${tmpdir}/crawl.log" ||
+command grep -q 'beyond this mirror scope' "${tmpdir}/crawl.log" ||
     fail "the wizard never asked about the foreign link"
 
 # what the mirror holds, which is what the user sees
 page="${tmpdir}/mirror/127.0.0.1_${foreign}/a.html"
 test -f "$page" || fail "the authorized link is missing from the mirror"
-grep -q "$MARKER" "$page" || fail "the authorized link was saved without its body"
+command grep -q "$MARKER" "$page" || fail "the authorized link was saved without its body"
 left=$(find "${tmpdir}/mirror" -name '*.delayed' -print)
 test -z "$left" || fail "placeholder names left in the mirror: $left"
 # both references, including the second one the stored placeholder came back for
 index="${tmpdir}/mirror/127.0.0.1_${SRV_PORT}/wizdelayed/index.html"
-local_refs=$(grep -o "127\.0\.0\.1_${foreign}/a\.html" "$index" | wc -l)
+local_refs=$(command grep -o "127\.0\.0\.1_${foreign}/a\.html" "$index" | wc -l)
 test "$local_refs" -eq 2 ||
     fail "$local_refs of the 2 references were rewritten to the mirrored page"
 
 # secondary: the engine's own account of the same failure
 log="${tmpdir}/mirror/hts-log.txt"
-! grep -q 'Duplicate entry in hts_wait_delayed' "$log" ||
+! command grep -q 'Duplicate entry in hts_wait_delayed' "$log" ||
     fail "the link was recorded before its type was resolved"
-! grep -q 'probably looping, type unknown' "$log" ||
+! command grep -q 'probably looping, type unknown' "$log" ||
     fail "the authorized link was dropped as looping"

--- a/tests/298_engine-wizard-fallback.test
+++ b/tests/298_engine-wizard-fallback.test
@@ -12,8 +12,8 @@ set -euo pipefail
 # an unreadable reply refuses, like the empty one the prompt documents
 selftest_queue "-foo.com/dir/page.html" wizardfilter -999 foo.com /dir/page.html
 reply=$(httrack -O /dev/null -#test=wizardverdict -999)
-grep -q "forbidden=1 stop=0 prio=42" <<<"$reply" || fail "-999 did not refuse: $reply"
-grep -q "could not read your answer" <<<"$reply" || fail "-999 refused silently: $reply"
+command grep -q "forbidden=1 stop=0 prio=42" <<<"$reply" || fail "-999 did not refuse: $reply"
+command grep -q "could not read your answer" <<<"$reply" || fail "-999 refused silently: $reply"
 
 # a host with no domain below it takes the scope answer over the host itself
 selftest_queue "+127.0.0.1:8080/*" wizardfilter 1000 127.0.0.1:8080 /x

--- a/tests/299_option-arg-caps.test
+++ b/tests/299_option-arg-caps.test
@@ -51,7 +51,7 @@ while read -r opt macro msg; do
     out=$(run "$opt" "$val" "${n}b") || rc=$?
     test "$rc" -ne 0 || fail "$opt accepted a value of exactly $macro ($limit)"
     # the message pins which check fired, so an unrelated panic cannot pass
-    grep -qF "$msg" <<<"$out" || fail "$opt was not rejected by \"$msg\""
+    command grep -qF "$msg" <<<"$out" || fail "$opt was not rejected by \"$msg\""
 done <<<"$caps"
 
 test "$n" -eq 6 || fail "expected 6 caps, checked $n"

--- a/tests/302_filter-token-overflow.test
+++ b/tests/302_filter-token-overflow.test
@@ -24,7 +24,7 @@ why() { # why RULE-FILE
     out="$(httrack -O "$tmpdir/p" -q --why http://www.example.com/a.png \
         -%S "$1" http://www.example.com/)" ||
         fail "httrack exited $? on $(basename "$1")"
-    grep -E 'accepted|rejected|no filter|unable' <<<"$out"
+    command grep -E 'accepted|rejected|no filter|unable' <<<"$out"
 }
 
 # An over-long rule, then the one that decides.
@@ -87,5 +87,5 @@ assert_file "$tmpdir/m/127.0.0.1_$SRV_PORT/index.html" "the seed that fits"
 log="$(<"$tmpdir/m/hts-log.txt")"
 assert_match "URL longer than $maxurl bytes, ignored: $BASEURL/aaa" "$log" \
     "refusal named in the log"
-assert_eq 1 "$(grep -cE 'Warning:|Error:' <<<"$log")" \
+assert_eq 1 "$(command grep -cE 'Warning:|Error:' <<<"$log")" \
     "messages the refused seed cost"

--- a/tests/303_engine-filter-cap.test
+++ b/tests/303_engine-filter-cap.test
@@ -11,9 +11,9 @@ set -euo pipefail
 out=$(httrack -O /dev/null -#test=filtercap)
 
 # a rule at the cap is still taken, silently, and still decides the URL
-grep -q '^at the cap: stored=1 rules=1 verdict=1 warned=0$' <<<"$out" || fail "at the cap: $out"
+command grep -q '^at the cap: stored=1 rules=1 verdict=1 warned=0$' <<<"$out" || fail "at the cap: $out"
 # one byte more, and one past what the matcher reads: refused (the array did
 # not grow and its verdict did not move) and warned about
-grep -q '^one past the cap: stored=0 rules=1 verdict=1 warned=1$' <<<"$out" || fail "one past: $out"
-grep -q '^past the matcher: stored=0 rules=1 verdict=1 warned=1$' <<<"$out" || fail "past matcher: $out"
-grep -q '^filtercap self-test OK$' <<<"$out" || fail "self-test did not finish: $out"
+command grep -q '^one past the cap: stored=0 rules=1 verdict=1 warned=1$' <<<"$out" || fail "one past: $out"
+command grep -q '^past the matcher: stored=0 rules=1 verdict=1 warned=1$' <<<"$out" || fail "past matcher: $out"
+command grep -q '^filtercap self-test OK$' <<<"$out" || fail "self-test did not finish: $out"

--- a/tests/305_doc-footer-fields.test
+++ b/tests/305_doc-footer-fields.test
@@ -19,7 +19,7 @@ same_set() { # same_set <list A> <list B>: newline-separated, order-insensitive
 
 # Capture it all first, so a crash after the -%F line still fails the test.
 help=$(httrack --quiet --help 2>/dev/null) || fail "httrack --help exited $?"
-help_line=$(grep -m1 -- ' %F  footer string' <<<"${help}") ||
+help_line=$(command grep -m1 -- ' %F  footer string' <<<"${help}") ||
     fail "--help prints no -%F line"
 
 # " ...; fields {addr} {path} ..., or legacy %s)"
@@ -48,9 +48,9 @@ fi
 check_page() { # check_page <html file> <tag wrapping each {name}>
     local page="$1" tag="$2" doc
     test -r "${page}" || fail "no ${page}"
-    doc=$(grep -o "<${tag}>{[^{}<]*}</${tag}>" "${page}" |
+    doc=$(command grep -o "<${tag}>{[^{}<]*}</${tag}>" "${page}" |
         sed "s,</*${tag}>,,g" | sort -u || true)
-    grep -qx '{addr}' <<<"${doc}" ||
+    command grep -qx '{addr}' <<<"${doc}" ||
         fail "no <${tag}>{field}</${tag}> names parsed out of ${page}"
     same_set "${engine}" "${doc}" || {
         echo "${page} lists different -%F fields than the engine." >&2

--- a/tests/307_cookies-file-longfield.test
+++ b/tests/307_cookies-file-longfield.test
@@ -69,13 +69,13 @@ for want in "$(rec www.example.com / GOODFIRST v1)" \
     "$(rec www.example.com "/$(repeat_chars 254 A)" PATH255 v)" \
     "$(rec www.example.com / BIGVAL "$(repeat_chars 500 v)")" \
     "$(rec www.example.com / GOODLAST v2)"; do
-    grep -qxF "$want" <<<"$loaded" ||
+    command grep -qxF "$want" <<<"$loaded" ||
         fail "a line that fits did not load whole: ${want:0:40}... in $jar_out"
 done
 
 for gone in DOM2000 DOM256 PATH2000 PATH256 NAME2000 NAME1024 JARCAP \
     BIGVAL7900 LONGLINE; do
-    ! grep -q "$gone" <<<"$loaded" ||
+    ! command grep -q "$gone" <<<"$loaded" ||
         fail "$gone was stored from a line that had to be refused: $jar_out"
 done
 
@@ -90,18 +90,18 @@ refusals=(
     "name field is 1024 bytes (maximum 1023)"
 )
 for want in "${refusals[@]}"; do
-    grep -qF "Cookies: ignoring a line whose $want: $jar" <<<"$log" ||
+    command grep -qF "Cookies: ignoring a line whose $want: $jar" <<<"$log" ||
         fail "no refusal for the $want in $out/hts-log.txt"
 done
 n=$(count_matching_lines 'ignoring a line whose' <<<"$log")
 assert_eq "${#refusals[@]}" "$n" "refused jar lines"
 
 # a 7900-byte value fits its destination, so it is the jar's cap that drops it
-! grep -q 'value field is' <<<"$log" ||
+! command grep -q 'value field is' <<<"$log" ||
     fail "a value the widest destination holds was refused: $out/hts-log.txt"
 for want in "the jar did not store 'JARCAP" \
     "the jar did not store 'BIGVAL7900'" \
     "ignoring an over-long line (8049 bytes, maximum 7999)"; do
-    grep -qF "Cookies: $want" <<<"$log" ||
+    command grep -qF "Cookies: $want" <<<"$log" ||
         fail "no report of [$want] in $out/hts-log.txt"
 done

--- a/tests/310_filelist-long-url.test
+++ b/tests/310_filelist-long-url.test
@@ -46,13 +46,13 @@ run() { # run LIST -> sets $log and $mirror
     mirror="$out"
 }
 loghas() {
-    grep -Eq "$1" "$log" || {
+    command grep -Eq "$1" "$log" || {
         cut -c1-200 "$log"
         fail "expected /$1/ in $log"
     }
 }
 lognot() {
-    if grep -Eq "$1" "$log"; then
+    if command grep -Eq "$1" "$log"; then
         cut -c1-200 "$log"
         fail "unexpected /$1/ in $log"
     fi

--- a/tests/313_ci-fork-failures.test
+++ b/tests/313_ci-fork-failures.test
@@ -42,13 +42,13 @@ assert_counts() { # assert_counts LOG WANT-DIED WANT-RETRIED WANT-GAVEUP LABEL S
     : >"$GITHUB_STEP_SUMMARY"
     out=$(ci_report_fork_failures "$log") || rc=$?
     test "$rc" -eq 0 || fail "$label: exited $rc"
-    grep -q '::warning title=MSYS fork failures::' <<<"$out" ||
+    command grep -q '::warning title=MSYS fork failures::' <<<"$out" ||
         fail "$label: no annotation: $out"
-    grep -q "$want" <<<"$out" || fail "$label: wanted [$want], got: $out"
+    command grep -q "$want" <<<"$out" || fail "$label: wanted [$want], got: $out"
     # The counts alone name no test and no time: an annotation without an example
     # line sends the reader back to a log the runner may no longer have.
-    grep -q "$6" <<<"$out" || fail "$label: no sample line matching [$6]: $out"
-    grep -q "MSYS forks: $2 died, $3 retried, $4 given up; 0 worker(s) lost" "$GITHUB_STEP_SUMMARY" ||
+    command grep -q "$6" <<<"$out" || fail "$label: no sample line matching [$6]: $out"
+    command grep -q "MSYS forks: $2 died, $3 retried, $4 given up; 0 worker(s) lost" "$GITHUB_STEP_SUMMARY" ||
         fail "$label: step summary says $(<"$GITHUB_STEP_SUMMARY")"
 }
 
@@ -87,16 +87,16 @@ assert_counts "$tmp/crjoined.log" 2 0 0 "two messages joined by a CR" "forked pr
 
 # A healthy leg still says so: a silent step and a broken counter read alike.
 : >"$GITHUB_STEP_SUMMARY"
-grep -v 'fork' "$tmp/console.log" >"$tmp/clean.log"
+command grep -v 'fork' "$tmp/console.log" >"$tmp/clean.log"
 out=$(ci_report_fork_failures "$tmp/clean.log") || fail "counting a clean leg failed"
-grep -q 'no MSYS fork failure and no lost worker' <<<"$out" ||
+command grep -q 'no MSYS fork failure and no lost worker' <<<"$out" ||
     fail "a clean leg said: $out"
-! grep -q '::warning' <<<"$out" || fail "a clean leg raised an annotation: $out"
-grep -q 'MSYS forks: 0 died, 0 retried, 0 given up; 0 worker(s) lost' "$GITHUB_STEP_SUMMARY" ||
+! command grep -q '::warning' <<<"$out" || fail "a clean leg raised an annotation: $out"
+command grep -q 'MSYS forks: 0 died, 0 retried, 0 given up; 0 worker(s) lost' "$GITHUB_STEP_SUMMARY" ||
     fail "a clean leg wrote no count: $(<"$GITHUB_STEP_SUMMARY")"
 
 # The suite step can die before writing a log; the counter step still runs.
 out=$(ci_report_fork_failures "$tmp/absent.log") || fail "a missing log failed the step"
-grep -q 'not counted' <<<"$out" || fail "a missing log said: $out"
+command grep -q 'not counted' <<<"$out" || fail "a missing log said: $out"
 
 echo "MSYS fork-failure counting OK"

--- a/tests/314_engine-selftest-batch.test
+++ b/tests/314_engine-selftest-batch.test
@@ -146,8 +146,8 @@ undrained_in() { # undrained_in DIR
     for f in "$1"/*.test; do
         test -r "$f" || continue
         SCANNED=$((SCANNED + 1))
-        grep -q 'selftest_queue' "$f" || continue
-        grep -q 'selftest_run_queued' "$f" || UNDRAINED="$UNDRAINED $f"
+        command grep -q 'selftest_queue' "$f" || continue
+        command grep -q 'selftest_run_queued' "$f" || UNDRAINED="$UNDRAINED $f"
     done
 }
 

--- a/tests/317_filter-rule-cap.test
+++ b/tests/317_filter-rule-cap.test
@@ -10,7 +10,7 @@ set -euo pipefail
 
 # From the engine, so a cap that moves moves the boundaries probed below.
 caps=$(httrack -O /dev/null -#test=filtercap) || fail "filtercap self-test failed"
-limits=$(grep '^filtercap: ' <<<"$caps") || fail "no limits line in: $caps"
+limits=$(command grep '^filtercap: ' <<<"$caps") || fail "no limits line in: $caps"
 read -r _ rulecap argvcap <<<"$limits"
 rulecap=${rulecap#rule=}
 argvcap=${argvcap#argv=}
@@ -37,7 +37,7 @@ why() { # why RULE-FILE
     rm -rf "$tmpdir/p"
     out="$(httrack -O "$tmpdir/p" -q --why "$URL" -%S "$1" http://www.example.com/)" ||
         fail "httrack exited $? on $(basename "$1")"
-    grep -E 'accepted|rejected|no filter|unable' <<<"$out"
+    command grep -E 'accepted|rejected|no filter|unable' <<<"$out"
 }
 
 # At the cap the rule is kept, so the one that decides is the second.

--- a/tests/319_webhttrack-addurl.test
+++ b/tests/319_webhttrack-addurl.test
@@ -67,7 +67,7 @@ done
 # The summary line is written once, at the end, so it cannot already be true:
 # waiting on it is what makes the cache and log checks below meaningful.
 start=$SECONDS
-while ! grep -q "HTTrack Website Copier/" "${log}"; do
+while ! command grep -q "HTTrack Website Copier/" "${log}"; do
     test "$((SECONDS - start))" -lt 90 || fail "the crawl did not end"
     poll_wait 0.2
 done
@@ -80,13 +80,13 @@ test -z "${left}" || fail "a delayed placeholder survived: ${left}"
 # A rename alone is not the fix: a record still holding the placeholder makes
 # every later reference to it spin in the type waiter and get dropped. Both
 # lines reach the log at the default verbosity, as errors and warnings do.
-! grep -q "Duplicate entry in hts_wait_delayed" "${log}" ||
+! command grep -q "Duplicate entry in hts_wait_delayed" "${log}" ||
     fail "the added link's own record collided in the type waiter"
-! grep -q "probably looping, type unknown" "${log}" ||
+! command grep -q "probably looping, type unknown" "${log}" ||
     fail "the added link was dropped as looping"
 
 # The cache index holds the URL and the name it was saved under.
-cached=$(grep "/added/page.html" "${out}/hts-cache/new.txt" || true)
+cached=$(command grep "/added/page.html" "${out}/hts-cache/new.txt" || true)
 test -n "${cached}" || fail "the added URL was never cached"
 case ${cached} in
 *.delayed*) fail "the cache recorded a placeholder: ${cached}" ;;

--- a/tests/322_webhttrack-list-ids.test
+++ b/tests/322_webhttrack-list-ids.test
@@ -24,7 +24,7 @@ written=$(
     done | sort -u
 )
 listed=$(awk '/ini_list_keys\[\] = /,/^\};/' "${distdir}/src/htsserver.c" |
-    grep -o '"[^"]*"' | tr -d '"' | sort -u)
+    command grep -o '"[^"]*"' | tr -d '"' | sort -u)
 # Floor: two gutted lists compare equal.
 test "$(printf '%s\n' "${written}" | wc -l)" -ge 9 ||
     fail "only $(printf '%s\n' "${written}" | wc -l) listid keys in step4.html"

--- a/tests/323_webhttrack-proxy-persist.test
+++ b/tests/323_webhttrack-proxy-persist.test
@@ -18,18 +18,18 @@ printf '[the proxy keys name the rendered fields] ..\t'
 # actually draws, which is the whole of the bug.
 for pair in "Proxy:prox" "Port:portprox" "ProxyType:proxytype"; do
     key=${pair%:*} var=${pair#*:}
-    grep -q "do:copy:${key}:${var}}" "${distdir}/html/server/step2.html" ||
+    command grep -q "do:copy:${key}:${var}}" "${distdir}/html/server/step2.html" ||
         fail "step2.html does not restore ${key} into ${var}"
     # Any directive prefix must end in a colon, or [a-z]* swallows one variable
     # name into another and Proxy=${portprox} passes as Proxy/prox.
-    grep -q "^${key}=[\$]{\([a-z]*:\)*${var}[:}]" "${distdir}/html/server/step4.html" ||
+    command grep -q "^${key}=[\$]{\([a-z]*:\)*${var}[:}]" "${distdir}/html/server/step4.html" ||
         fail "step4.html does not save ${var} as ${key}"
-    grep -q "name=\"${var}\"" "${distdir}/html/server/option10.html" ||
+    command grep -q "name=\"${var}\"" "${distdir}/html/server/option10.html" ||
         fail "option10.html draws no ${var} field"
 done
 # One write each: two Proxy= lines disagreed about which variable they carried.
 for key in Proxy Port ProxyType; do
-    n=$(grep -c "^${key}=" "${distdir}/html/server/step4.html")
+    n=$(command grep -c "^${key}=" "${distdir}/html/server/step4.html")
     test "${n}" -eq 1 || fail "step4.html writes ${key} ${n} times"
 done
 echo OK

--- a/tests/326_engine-header-dedup.test
+++ b/tests/326_engine-header-dedup.test
@@ -124,8 +124,8 @@ assert_value() { # assert_value TAG FIELD VALUE
 # substitution would eat a lost trailing newline on both sides alike.
 assert_same_but() { # assert_same_but TAG RE
     local base=$tmpdir/$1.base got=$tmpdir/$1.got
-    grep -Ev "$2" "$tmpdir/plain.req" >"$base" || true
-    grep -Ev "$2" "$tmpdir/$1.req" >"$got" || true
+    command grep -Ev "$2" "$tmpdir/plain.req" >"$base" || true
+    command grep -Ev "$2" "$tmpdir/$1.req" >"$got" || true
     diff "$base" "$got" || fail "$1: the request outside $2 differs from the box-free one"
 }
 

--- a/tests/328_engine-header-dedup-rest.test
+++ b/tests/328_engine-header-dedup-rest.test
@@ -153,8 +153,8 @@ assert_same() { # assert_same BASE TAG
 # lost trailing newline on both sides alike.
 assert_same_but() { # assert_same_but BASE TAG RE
     local base=$tmpdir/$2.base got=$tmpdir/$2.got
-    grep -Ev "$3" "$tmpdir/$1.req" >"$base" || true
-    grep -Ev "$3" "$tmpdir/$2.req" >"$got" || true
+    command grep -Ev "$3" "$tmpdir/$1.req" >"$base" || true
+    command grep -Ev "$3" "$tmpdir/$2.req" >"$got" || true
     diff "$base" "$got" || fail "$2: the request outside $3 differs from $1's"
 }
 

--- a/tests/332_engine-io-exact.test
+++ b/tests/332_engine-io-exact.test
@@ -11,4 +11,4 @@ dir=$(mktemp -d)
 cleanup_push rm -rf "$dir"
 
 out=$(httrack -O /dev/null -#test=ioexact "$dir")
-grep -q "ioexact:.*OK" <<<"$out"
+command grep -q "ioexact:.*OK" <<<"$out"

--- a/tests/336_webhttrack-path-traversal.test
+++ b/tests/336_webhttrack-path-traversal.test
@@ -40,22 +40,22 @@ save_post() {
 }
 
 reply=$(htsserver_post "$(save_post '../escape')" /server/step4.html)
-grep -q '^Location: /server/error.html' <<<"${reply}" ||
+command grep -q '^Location: /server/error.html' <<<"${reply}" ||
     fail "the traversing save was not refused: ${reply}"
 test ! -e "${work}/escape" || fail "..: wrote outside ${work}/websites"
 # A save that failed for another reason (unwritable parent, missing field)
 # would land on the same page, so read what the page says.
-grep -q 'escapes its parent directory' <<<"$(htsserver_get /server/error.html)" ||
+command grep -q 'escapes its parent directory' <<<"$(htsserver_get /server/error.html)" ||
     fail "the error page does not name the refusal"
 
 reply=$(htsserver_post "$(save_post 'a/../../escape2')" /server/step4.html)
-grep -q '^Location: /server/error.html' <<<"${reply}" ||
+command grep -q '^Location: /server/error.html' <<<"${reply}" ||
     fail "a nested .. was not refused: ${reply}"
 test ! -e "${work}/escape2" || fail "a/../..: wrote outside ${work}/websites"
 
 # A backslash separates too: the posted path is client text, not this host's.
 reply=$(htsserver_post "$(save_post '..\escape3')" /server/step4.html)
-grep -q '^Location: /server/error.html' <<<"${reply}" ||
+command grep -q '^Location: /server/error.html' <<<"${reply}" ||
     fail "a backslashed .. was not refused: ${reply}"
 
 # Reading is gated the same way, or the load path hands the form a file the
@@ -63,15 +63,15 @@ grep -q '^Location: /server/error.html' <<<"${reply}" ||
 body=$(urlform sid "${sid}" path "${base}" projname proj loadprojname '../outside')
 htsserver_post "${body}" /server/step2.html >/dev/null
 page=$(htsserver_get /server/step2.html)
-grep -q 'name="projcateg"' <<<"${page}" || fail "step2.html did not render the form"
-! grep -q 'PATHGUARD-LEAK' <<<"${page}" || fail "loaded a profile outside the path"
+command grep -q 'name="projcateg"' <<<"${page}" || fail "step2.html did not render the form"
+! command grep -q 'PATHGUARD-LEAK' <<<"${page}" || fail "loaded a profile outside the path"
 
 # Control: ".." inside a name is a name, not a traversal. Without it a guard
 # that refused everything would pass.
 reply=$(htsserver_post "$(save_post 'ok..name')" /server/step4.html)
-! grep -q '^Location: /server/error.html' <<<"${reply}" ||
+! command grep -q '^Location: /server/error.html' <<<"${reply}" ||
     fail "a legitimate .. in a name was refused: ${reply}"
-grep -q 'PATHGUARD-PROFILE' "${work}/websites/ok..name/hts-cache/winprofile.ini" ||
+command grep -q 'PATHGUARD-PROFILE' "${work}/websites/ok..name/hts-cache/winprofile.ini" ||
     fail "the accepted save wrote no profile"
 
 htsserver_cleanup

--- a/tests/337_ci-lost-worker.test
+++ b/tests/337_ci-lost-worker.test
@@ -89,31 +89,31 @@ report() { # report LOG -> $out, $summary
 }
 
 report "$tmp/clean.log"
-grep -q 'no MSYS fork failure and no lost worker' <<<"$out" || fail "a clean leg said: $out"
-grep -q '^MSYS forks: 0 died, 0 retried, 0 given up; 0 worker(s) lost$' <<<"$summary" ||
+command grep -q 'no MSYS fork failure and no lost worker' <<<"$out" || fail "a clean leg said: $out"
+command grep -q '^MSYS forks: 0 died, 0 retried, 0 given up; 0 worker(s) lost$' <<<"$summary" ||
     fail "a clean leg summarised: $summary"
-grep -q '::' <<<"$out" && fail "a clean leg raised an annotation: $out"
+command grep -q '::' <<<"$out" && fail "a clean leg raised an annotation: $out"
 
 report "$tmp/forks.log"
-grep -q '::warning title=MSYS fork failures::' <<<"$out" || fail "the fork leg raised none: $out"
-grep -q 'workers lost' <<<"$out" && fail "the fork leg invented a lost worker: $out"
-grep -q '; 0 worker(s) lost$' <<<"$summary" || fail "the fork leg summarised: $summary"
+command grep -q '::warning title=MSYS fork failures::' <<<"$out" || fail "the fork leg raised none: $out"
+command grep -q 'workers lost' <<<"$out" && fail "the fork leg invented a lost worker: $out"
+command grep -q '; 0 worker(s) lost$' <<<"$summary" || fail "the fork leg summarised: $summary"
 
 report "$tmp/lost.log"
 # The whole defect: this sentence, unqualified, is what called the #1352 leg clean.
-grep -q 'no MSYS fork failure and no lost worker' <<<"$out" &&
+command grep -q 'no MSYS fork failure and no lost worker' <<<"$out" &&
     fail "a leg that lost a worker read as clean: $out"
-grep -q 'but 1 worker(s) left no status' <<<"$out" || fail "the lost leg said: $out"
-grep -q '::error title=workers lost with no status::' <<<"$out" ||
+command grep -q 'but 1 worker(s) left no status' <<<"$out" || fail "the lost leg said: $out"
+command grep -q '::error title=workers lost with no status::' <<<"$out" ||
     fail "the lost leg raised no error annotation: $out"
-grep -q '86_local-proxytrack-cache-longfields.test' <<<"$out" ||
+command grep -q '86_local-proxytrack-cache-longfields.test' <<<"$out" ||
     fail "the lost leg named no test: $out"
-grep -q '; 1 worker(s) lost$' <<<"$summary" || fail "the lost leg summarised: $summary"
+command grep -q '; 1 worker(s) lost$' <<<"$summary" || fail "the lost leg summarised: $summary"
 
 report "$tmp/both.log"
-grep -q '::warning title=MSYS fork failures::' <<<"$out" || fail "both: no fork annotation: $out"
-grep -q '::error title=workers lost with no status::' <<<"$out" || fail "both: no lost annotation: $out"
-grep -q '; 1 worker(s) lost$' <<<"$summary" || fail "both: summarised $summary"
+command grep -q '::warning title=MSYS fork failures::' <<<"$out" || fail "both: no fork annotation: $out"
+command grep -q '::error title=workers lost with no status::' <<<"$out" || fail "both: no lost annotation: $out"
+command grep -q '; 1 worker(s) lost$' <<<"$summary" || fail "both: summarised $summary"
 
 # The control on all of it: without the LOST rule the counter is the old one, and
 # reads this very console as clean.
@@ -121,12 +121,12 @@ old=$tmp/old
 mkdir -p "$old"
 cp "$testdir/ci-windows-suite.sh" "$testdir/testlib.sh" "$testdir/proclib.sh" "$old/"
 chmod u+w "$old"/*.sh # distcheck's srcdir is read-only, and cp carries that over
-grep -v '/\^LOST / { lost++; next }' "$old/ci-windows-suite.sh" >"$old/mutant.sh"
+command grep -v '/\^LOST / { lost++; next }' "$old/ci-windows-suite.sh" >"$old/mutant.sh"
 cmp -s "$old/ci-windows-suite.sh" "$old/mutant.sh" &&
     fail "the blind-counter mutant changed nothing, so it proves nothing"
 mv "$old/mutant.sh" "$old/ci-windows-suite.sh"
 oldout=$(cd "$old" && bash -c '. ./ci-windows-suite.sh; ci_report_fork_failures "$1"' _ "$tmp/lost.log")
-grep -q 'no MSYS fork failure and no lost worker' <<<"$oldout" ||
+command grep -q 'no MSYS fork failure and no lost worker' <<<"$oldout" ||
     fail "the blind counter did not misread the lost leg, so the new rule is not what fixes it: $oldout"
 
 # --- and the same thing end to end, with a worker really killed --------------
@@ -238,8 +238,8 @@ run_suite() { # run_suite <dir>
 stage "$tmp/ok" ':'
 run_suite "$tmp/ok"
 test "$rc" -eq 0 || fail "a clean stub suite exited $rc: $(<"$tmp/out")"
-grep -q "^ran=$ran pass=92 fail=0 skip=$nskip lost=0$" "$tmp/out" ||
-    fail "clean tally: $(grep '^ran=' "$tmp/out" || true)"
+command grep -q "^ran=$ran pass=92 fail=0 skip=$nskip lost=0$" "$tmp/out" ||
+    fail "clean tally: $(command grep '^ran=' "$tmp/out" || true)"
 
 stage "$tmp/killed" "$killer"
 run_suite "$tmp/killed"
@@ -247,13 +247,13 @@ case "$(<"$share/killed")" in
 none*) fail "the stub killed no worker, so the run proves nothing: $(<"$share/killed")" ;;
 esac
 # On its own line, not folded into the failures: the counter step reads these back.
-grep -q '^LOST 906_engine-lost.test (worker left no status; ' "$tmp/out" ||
+command grep -q '^LOST 906_engine-lost.test (worker left no status; ' "$tmp/out" ||
     fail "the vanished worker was not reported: $(<"$tmp/out")"
-grep -q "^ran=$ran pass=91 fail=0 skip=$nskip lost=1$" "$tmp/out" ||
-    fail "lost tally: $(grep '^ran=' "$tmp/out" || true)"
-grep -q '::error::worker(s) vanished with no status, re-run this leg: 906_engine-lost.test' "$tmp/out" ||
+command grep -q "^ran=$ran pass=91 fail=0 skip=$nskip lost=1$" "$tmp/out" ||
+    fail "lost tally: $(command grep '^ran=' "$tmp/out" || true)"
+command grep -q '::error::worker(s) vanished with no status, re-run this leg: 906_engine-lost.test' "$tmp/out" ||
     fail "the suite did not name the vanished worker: $(<"$tmp/out")"
-grep -q '::error::failing:' "$tmp/out" &&
+command grep -q '::error::failing:' "$tmp/out" &&
     fail "a killed worker was reported as a failing test: $(<"$tmp/out")"
 # 3, so the workflow can tell a leg to repeat from a leg to investigate (#1228).
 test "$rc" -eq 3 || fail "a lost worker exited $rc, want 3: $(<"$tmp/out")"
@@ -268,9 +268,9 @@ run_suite "$tmp/killedskip"
 case "$(<"$share/killed")" in
 none*) fail "the pinned-skip stub killed no worker: $(<"$share/killed")" ;;
 esac
-grep -q "^LOST $pinned (worker left no status; " "$tmp/out" ||
+command grep -q "^LOST $pinned (worker left no status; " "$tmp/out" ||
     fail "the vanished skip was not reported: $(<"$tmp/out")"
-grep -q '::error::skip set changed from expected' "$tmp/out" ||
+command grep -q '::error::skip set changed from expected' "$tmp/out" ||
     fail "the skip set did not change, so this run reaches the wrong gate: $(<"$tmp/out")"
 test "$rc" -eq 3 ||
     fail "a worker lost from the pinned skips exited $rc, want 3: $(<"$tmp/out")"
@@ -278,7 +278,7 @@ ok "a skip that vanished is still a leg to repeat"
 
 # The counter reading that very console back, which is the path the Windows leg takes.
 report "$tmp/out"
-grep -q '::error title=workers lost with no status::' <<<"$out" ||
+command grep -q '::error title=workers lost with no status::' <<<"$out" ||
     fail "the counter read the suite's own console as clean: $out"
 
 # A loss alongside a real failure: the failure decides, or a red ships as a leg to
@@ -289,9 +289,9 @@ run_suite "$tmp/mixed"
 case "$(<"$share/killed")" in
 none*) fail "the mixed stub killed no worker: $(<"$share/killed")" ;;
 esac
-grep -q '^LOST 906_engine-lost.test (worker left no status; ' "$tmp/out" ||
+command grep -q '^LOST 906_engine-lost.test (worker left no status; ' "$tmp/out" ||
     fail "the vanished worker was not reported beside the failure: $(<"$tmp/out")"
-grep -q '::error::failing: 900_zlib-pass.test' "$tmp/out" ||
+command grep -q '::error::failing: 900_zlib-pass.test' "$tmp/out" ||
     fail "the failing test was not named: $(<"$tmp/out")"
 test "$rc" -eq 1 ||
     fail "a failure alongside a loss exited $rc, want 1: $(<"$tmp/out")"

--- a/tests/341_webhttrack-authority.test
+++ b/tests/341_webhttrack-authority.test
@@ -44,7 +44,7 @@ post_as() { # $1 = Host value, "" sends none
 
 for good in "127.0.0.1" "127.0.0.1:${HTS_PORT}" "localhost" "localhost:${HTS_PORT}" \
     "LocalHost:${HTS_PORT}" "[::1]" "[::1]:${HTS_PORT}" ""; do
-    grep -q '^Location: /accepted' <<<"$(post_as "${good}")" ||
+    command grep -q '^Location: /accepted' <<<"$(post_as "${good}")" ||
         fail "Host '${good}' was refused"
 done
 echo "ok: the panel answers at every authority it is reachable at"
@@ -73,7 +73,7 @@ if test -n "${selfname}"; then
     # Upper-cased too: the compare is case-insensitive, as it is for localhost.
     for good in "${selfname}" "${selfname}:${HTS_PORT}" \
         "$(printf '%s' "${selfname}" | tr '[:lower:]' '[:upper:]')"; do
-        grep -q '^Location: /accepted' <<<"$(post_as "${good}")" ||
+        command grep -q '^Location: /accepted' <<<"$(post_as "${good}")" ||
             fail "Host '${good}', this host's own name, was refused"
     done
     echo "ok: the panel answers at this host's own name"
@@ -93,15 +93,15 @@ if test -n "${selfname}"; then
 fi
 for bad in "${bad_hosts[@]}"; do
     resp=$(post_as "${bad}")
-    grep -q '^HTTP/1\.0 403 ' <<<"${resp}" ||
+    command grep -q '^HTTP/1\.0 403 ' <<<"${resp}" ||
         fail "POST with Host '${bad}' was not a 403: '$(firstline "${resp}")'"
-    grep -q '^Location:' <<<"${resp}" && fail "POST with Host '${bad}' still ran"
+    command grep -q '^Location:' <<<"${resp}" && fail "POST with Host '${bad}' still ran"
     # GET too: a guard sitting on the POST path alone is the shape of the last
     # bug found here.
     resp=$(htsserver_client --host "${bad}" --path /server/index.html)
-    grep -q '^HTTP/1\.0 403 ' <<<"${resp}" ||
+    command grep -q '^HTTP/1\.0 403 ' <<<"${resp}" ||
         fail "GET with Host '${bad}' was not a 403: '$(firstline "${resp}")'"
-    grep -q 'name="sid"' <<<"${resp}" &&
+    command grep -q 'name="sid"' <<<"${resp}" &&
         fail "GET with Host '${bad}' still handed out a session id"
 done
 echo "ok: a foreign authority is refused, on every method"
@@ -110,21 +110,21 @@ echo "ok: a foreign authority is refused, on every method"
 # key store that later requests render from. step3 interpolates ${projname}.
 store_page() {
     page=$(htsserver_get /server/step3.html) || fail "the key store probe failed"
-    grep -q '^HTTP/1\.0 200 ' <<<"${page}" ||
+    command grep -q '^HTTP/1\.0 200 ' <<<"${page}" ||
         fail "the key store probe did not answer: '$(firstline "${page}")'"
 }
 
 htsserver_client --host evil.example --path / \
     --post "sid=${sid}&projname=REBOUND" >/dev/null 2>&1 || true
 store_page
-grep -q 'REBOUND' <<<"${page}" &&
+command grep -q 'REBOUND' <<<"${page}" &&
     fail "a body sent with a foreign Host reached the key store"
 # Paired accept: without it the assertion above passes on a server that ignores
 # every body, which would prove nothing.
 htsserver_client --host "127.0.0.1:${HTS_PORT}" --path / \
     --post "sid=${sid}&projname=SAMEHOST" >/dev/null 2>&1 || true
 store_page
-grep -q 'SAMEHOST' <<<"${page}" ||
+command grep -q 'SAMEHOST' <<<"${page}" ||
     fail "a body sent with our own Host was not written to the key store"
 echo "ok: a refused body is not applied"
 

--- a/tests/342_msvc-source-lists.test
+++ b/tests/342_msvc-source-lists.test
@@ -45,7 +45,7 @@ check() {
     [ -z "$missing" ] || fail "$proj is missing: $missing"
 
     extra=$(comm -13 <(am_sources "$var") <(proj_sources "$proj") |
-        grep -v -x -F "$win_only" | tr '\n' ' ' || true)
+        command grep -v -x -F "$win_only" | tr '\n' ' ' || true)
     [ -z "$extra" ] || fail "$proj builds sources $var does not: $extra"
 }
 

--- a/tests/346_engine-nobody.test
+++ b/tests/346_engine-nobody.test
@@ -5,4 +5,4 @@
 set -euo pipefail
 
 out=$(httrack -O /dev/null -#test=nobody run)
-grep -q "nobody self-test OK" <<<"$out"
+command grep -q "nobody self-test OK" <<<"$out"

--- a/tests/347_local-proxytrack-cache-size.test
+++ b/tests/347_local-proxytrack-cache-size.test
@@ -62,12 +62,12 @@ read_back() {
 
 # control: without it, a fix that rejected every entry would pass the rest
 read_back "$dir/good.zip"
-grep -qF "$BODY" "$dir/out.arc" || fail "an untouched cache lost its body"
+command grep -qF "$BODY" "$dir/out.arc" || fail "an untouched cache lost its body"
 
 forge_size "$dir/neg.zip" -1
 read_back "$dir/neg.zip"
-grep -q "$bad_size" "$dir/out.arc" || fail "a negative X-Size was accepted"
-if grep -qF "$BODY" "$dir/out.arc"; then
+command grep -q "$bad_size" "$dir/out.arc" || fail "a negative X-Size was accepted"
+if command grep -qF "$BODY" "$dir/out.arc"; then
     fail "a negative X-Size still returned a body"
 fi
 
@@ -76,7 +76,7 @@ fi
 for value in "$over_int_max" "$at_int_max"; do
     forge_size "$dir/big-$value.zip" "$value"
     read_back "$dir/big-$value.zip"
-    grep -q "$bad_size" "$dir/out.arc" ||
+    command grep -q "$bad_size" "$dir/out.arc" ||
         fail "an in-cache X-Size of $value was accepted"
 done
 
@@ -85,14 +85,14 @@ done
 forge_size "$dir/hdronly.zip" "$over_int_max"
 poke "$dir/hdronly.zip" 'X-In-Cache: 1' 'X-In-Cache: 0'
 read_back "$dir/hdronly.zip"
-if grep -q "$bad_size" "$dir/out.arc"; then
+if command grep -q "$bad_size" "$dir/out.arc"; then
     fail "a headers-only X-Size of $over_int_max was refused"
 fi
 
 forge_size "$dir/hdrneg.zip" -1
 poke "$dir/hdrneg.zip" 'X-In-Cache: 1' 'X-In-Cache: 0'
 read_back "$dir/hdrneg.zip"
-grep -q "$bad_size" "$dir/out.arc" ||
+command grep -q "$bad_size" "$dir/out.arc" ||
     fail "a headers-only negative X-Size was accepted"
 
 exit 0

--- a/tests/349_sanitizer-stderr-capture.test
+++ b/tests/349_sanitizer-stderr-capture.test
@@ -54,7 +54,7 @@ export HTTRACK_STDERR_CAPTURE_DIR=$cap
 
 # 2. The case this exists for: stderr discarded, the copy survives anyway.
 run_wrapped 'echo "runtime error: store to address 0x1 with insufficient space" >&2' 2>/dev/null
-grep -rq 'insufficient space' "$cap" || fail "a discarded UBSan report left no copy"
+command grep -rq 'insufficient space' "$cap" || fail "a discarded UBSan report left no copy"
 copies=("$cap"/349_probe.*.log)
 [ -e "${copies[0]}" ] || fail "the copy is not named after the test: $(echo "$cap"/*)"
 
@@ -64,20 +64,20 @@ out=$(run_wrapped 'echo out; echo err-passed >&2; exit 7' 2>"$tmp/on.err") || rc
 assert_eq 7 "$rc" "exit status under capture"
 assert_eq out "$out" "stdout under capture"
 assert_eq err-passed "$(cat "$tmp/on.err")" "stderr under capture"
-grep -rq err-passed "$cap" || fail "the copy missed a passed-through line"
-grep -rq '^out$' "$cap" && fail "stdout leaked into the capture"
+command grep -rq err-passed "$cap" || fail "the copy missed a passed-through line"
+command grep -rq '^out$' "$cap" && fail "stdout leaked into the capture"
 
 # 4. The collector reads the copies, and says so only when one carries a finding.
 logs=$tmp/logs
 mkdir -p "$logs"
 "$sh_run" "$report" -s "$cap" "$logs" >"$tmp/hit.out" 2>&1 && fail "the collector missed the report"
-grep -q 'insufficient space' "$tmp/hit.out" || fail "the collector did not print the finding: $(cat "$tmp/hit.out")"
+command grep -q 'insufficient space' "$tmp/hit.out" || fail "the collector did not print the finding: $(cat "$tmp/hit.out")"
 
 rm -rf "$cap"
 run_wrapped 'echo ordinary chatter >&2' 2>/dev/null
 "$sh_run" "$report" -s "$cap" "$logs" >"$tmp/clean.out" 2>&1 ||
     fail "the collector reddened a clean run: $(cat "$tmp/clean.out")"
-grep -q 'ordinary chatter' "$tmp/clean.out" && fail "the collector printed a clean capture"
+command grep -q 'ordinary chatter' "$tmp/clean.out" && fail "the collector printed a clean capture"
 
 # 4b. A directory that is not there is the wiring having moved, and scanning
 # nothing must not read as a clean run.

--- a/tests/350_local-diskfull-abort.test
+++ b/tests/350_local-diskfull-abort.test
@@ -60,20 +60,20 @@ crawl_onto_full() {
 
 # --- a body that streams: the write itself fails ----------------------------
 crawl_onto_full stream big.bin index.html
-grep -q 'disk full or filesystem problems' <<<"$log" ||
+command grep -q 'disk full or filesystem problems' <<<"$log" ||
     fail "a failed disk write was not reported as fatal: ${log}"
 ok "the write failure is reported as a disk problem"
 
-if grep -qE 'Retry after error.*diskfull/big\.bin' <<<"$log"; then
+if command grep -qE 'Retry after error.*diskfull/big\.bin' <<<"$log"; then
     fail "the full disk was retried as if the network had dropped: ${log}"
 fi
 # What master reports here instead of the disk.
-if grep -q 'Incorrect length' <<<"$log"; then
+if command grep -q 'Incorrect length' <<<"$log"; then
     fail "the full disk is still reported as a truncated download: ${log}"
 fi
 ok "it is not retried, nor relabelled a truncated download"
 
-grep -q 'Mirror aborted: keeping all previously mirrored files' <<<"$log" ||
+command grep -q 'Mirror aborted: keeping all previously mirrored files' <<<"$log" ||
     fail "the mirror carried on past the full disk, purge armed: ${log}"
 ok "the mirror gives up and keeps every mirrored file"
 
@@ -81,7 +81,7 @@ ok "the mirror gives up and keeps every mirrored file"
 # what preceded the full disk survives and the doomed name is still the symlink.
 site="${tmpdir}/stream/127.0.0.1_${SRV_PORT}/diskfull"
 test -s "${site}/index.html" || fail "the page mirrored before the abort was lost"
-grep -q DISKFULL-TINY "${site}/tiny.bin" ||
+command grep -q DISKFULL-TINY "${site}/tiny.bin" ||
     fail "the file mirrored before the abort was lost or truncated"
 test -L "${site}/big.bin" ||
     fail "a truncated big.bin replaced the name the crawl wrote through"
@@ -89,17 +89,17 @@ ok "the files mirrored before the abort survive it"
 
 # --- a page that fits in stdio's buffer: only the close fails ---------------
 crawl_onto_full page small.html smallindex.html
-grep -q 'Unable to write HTML file' <<<"$log" ||
+command grep -q 'Unable to write HTML file' <<<"$log" ||
     fail "a page whose close failed was saved as a success: ${log}"
-grep -q 'Fatal write error, giving up' <<<"$log" ||
+command grep -q 'Fatal write error, giving up' <<<"$log" ||
     fail "the full disk did not stop the mirror on the page path: ${log}"
 ok "a page that only fails on close is fatal too"
 
 # --- and a file that fits: its close is the engine's only warning -----------
 crawl_onto_full tiny tiny.bin index.html
-grep -q 'disk full or filesystem problems' <<<"$log" ||
+command grep -q 'disk full or filesystem problems' <<<"$log" ||
     fail "a file whose close failed was counted as written: ${log}"
-grep -q 'Mirror aborted: keeping all previously mirrored files' <<<"$log" ||
+command grep -q 'Mirror aborted: keeping all previously mirrored files' <<<"$log" ||
     fail "the mirror carried on past the full disk, purge armed: ${log}"
 ok "a small file that only fails on close is fatal too"
 
@@ -107,15 +107,15 @@ ok "a small file that only fails on close is fatal too"
 # Under 4 KB the fclose net catches this; past it only the read's own return
 # says anything, and r.size had already reached totalsize when the write failed.
 crawl_onto_full mid mid.bin midindex.html
-grep -q 'disk full or filesystem problems' <<<"$log" ||
+command grep -q 'disk full or filesystem problems' <<<"$log" ||
     fail "a body completed by the read whose write failed passed for an EOF: ${log}"
-grep -q 'Mirror aborted: keeping all previously mirrored files' <<<"$log" ||
+command grep -q 'Mirror aborted: keeping all previously mirrored files' <<<"$log" ||
     fail "the mirror carried on past the full disk, purge armed: ${log}"
 ok "a body whose last read is the failing write is fatal too"
 
 # Chunked, same shape: the chunk-end test next door erased the error outright.
 crawl_onto_full chunked chunked.bin chunkedindex.html
-grep -q 'disk full or filesystem problems' <<<"$log" ||
+command grep -q 'disk full or filesystem problems' <<<"$log" ||
     fail "a chunk completed by the read whose write failed passed for clean: ${log}"
 ok "the chunked path is fatal too"
 
@@ -123,9 +123,9 @@ ok "the chunked path is fatal too"
 # totalsize stays -1, so no completion test can see this one, and glibc's later
 # fclose() returns 0 once the flush has taken the error.
 crawl_onto_full noclen noclen.bin noclenindex.html
-grep -q 'disk full or filesystem problems' <<<"$log" ||
+command grep -q 'disk full or filesystem problems' <<<"$log" ||
     fail "a full disk under a close-delimited body was not reported: ${log}"
-if grep -qF 'noclen.bin' "${tmpdir}/noclen/hts-cache/new.txt"; then
+if command grep -qF 'noclen.bin' "${tmpdir}/noclen/hts-cache/new.txt"; then
     fail "a body that never reached the disk was recorded as mirrored"
 fi
 ok "a close-delimited body the disk refused is fatal too"
@@ -134,9 +134,9 @@ ok "a close-delimited body the disk refused is fatal too"
 # --tolerant downgrades a length mismatch to a warning instead of rewriting the
 # status, which is where a disk-cut body would be blamed on the server instead.
 crawl_onto_full tolerant big.bin index.html --tolerant
-grep -q 'disk full or filesystem problems' <<<"$log" ||
+command grep -q 'disk full or filesystem problems' <<<"$log" ||
     fail "the tolerant crawl did not report the full disk: ${log}"
-if grep -q 'Incorrect length' <<<"$log"; then
+if command grep -q 'Incorrect length' <<<"$log"; then
     fail "a body the disk cut short was also blamed on the server: ${log}"
 fi
 ok "a length mismatch the full disk caused is not reported as one"
@@ -151,14 +151,14 @@ assert_selftest "codecerrno: write failure kept, refused stream cleared" \
 # gz.bin streams into ~hts-tmp/gz.bin.z and is decoded into place afterwards,
 # so nothing the crawl writes to the save name can stand in for a full disk.
 crawl_onto_full gzspool '~hts-tmp/gz.bin.z' gzindex.html
-grep -q 'disk full or filesystem problems' <<<"$log" ||
+command grep -q 'disk full or filesystem problems' <<<"$log" ||
     fail "a full disk under the compressed spool was not reported: ${log}"
 ok "a full disk under a coded body's spool is fatal too"
 
 # And the other end of the same body: the decode writes ~hts-tmp/gz.bin.u before
 # renaming it into place, and a full disk there is not the stream's fault.
 crawl_onto_full gzunpack '~hts-tmp/gz.bin.u' gzindex.html
-grep -q 'disk full or filesystem problems' <<<"$log" ||
+command grep -q 'disk full or filesystem problems' <<<"$log" ||
     fail "a full disk under the decode was reported as a corrupt body: ${log}"
 ok "a full disk under a coded body's decode is fatal too"
 
@@ -168,18 +168,18 @@ gzbad="${tmpdir}/gzbad"
 local_crawl --log "${tmpdir}/log-gzbad" "${common[@]}" -O "$gzbad" \
     "${BASEURL}/diskfull/gzbadindex.html"
 log=$(<"${gzbad}/hts-log.txt")
-grep -q 'Error when decompressing' <<<"$log" ||
+command grep -q 'Error when decompressing' <<<"$log" ||
     fail "a corrupt coded body was not reported as one: ${log}"
-if grep -qE 'Mirror aborted|disk full' <<<"$log"; then
+if command grep -qE 'Mirror aborted|disk full' <<<"$log"; then
     fail "a corrupt coded body gave up the whole mirror: ${log}"
 fi
 ok "a corrupt coded body is not read as a full disk"
 
 # The decoded page, written the same way an uncoded one is.
 crawl_onto_full gzpage gzpage.html gzindex.html
-grep -q 'Unable to write HTML file' <<<"$log" ||
+command grep -q 'Unable to write HTML file' <<<"$log" ||
     fail "a coded page the disk refused was saved as a success: ${log}"
-grep -q 'Fatal write error, giving up' <<<"$log" ||
+command grep -q 'Fatal write error, giving up' <<<"$log" ||
     fail "the full disk did not stop the mirror on the coded page path: ${log}"
 ok "a coded page that cannot be written is fatal too"
 
@@ -200,23 +200,23 @@ local_crawl --log "${tmpdir}/log-epipe" "${common[@]}" --retries=0 -O "$epipe" \
     "${BASEURL}/diskfull/index.html" || epipe_rc=$?
 kill "$reader" 2>/dev/null || true
 log=$(<"${epipe}/hts-log.txt")
-grep -q 'Unable to write file .*big\.bin' <<<"$log" ||
+command grep -q 'Unable to write file .*big\.bin' <<<"$log" ||
     fail "the broken pipe went unreported, so nothing here failed to be written: ${log}"
-grep -q 'Write error on disk' <<<"$log" ||
+command grep -q 'Write error on disk' <<<"$log" ||
     fail "the broken pipe was not reported as a write error: ${log}"
 # r.size counts bytes read, so a body our own write cut short must never be
 # reported as one the server truncated.
-if grep -q 'Incorrect length' <<<"$log"; then
+if command grep -q 'Incorrect length' <<<"$log"; then
     fail "a write error was reported as a truncated download: ${log}"
 fi
 ok "a write error outside the fatal class is still reported against its file"
-if grep -q 'disk full or filesystem problems' <<<"$log"; then
+if command grep -q 'disk full or filesystem problems' <<<"$log"; then
     fail "a broken pipe was treated as a full disk: ${log}"
 fi
-if grep -q 'Mirror aborted' <<<"$log"; then
+if command grep -q 'Mirror aborted' <<<"$log"; then
     fail "a write error outside the fatal class gave up the whole mirror: ${log}"
 fi
-grep -q DISKFULL-TINY "${epipesite}/tiny.bin" ||
+command grep -q DISKFULL-TINY "${epipesite}/tiny.bin" ||
     fail "the rest of the mirror did not survive a non-fatal write error"
 # The other half of the status the arms above assert: without this, that status
 # could mean "a write failed" rather than "the mirror was given up on".
@@ -249,7 +249,7 @@ stall_rc=0
 wait "$crawlpid" 2>/dev/null || stall_rc=$?
 crawlpid=
 log=$(<"${stall}/hts-log.txt")
-grep -q 'Unable to write file .*stall\.bin' <<<"$log" ||
+command grep -q 'Unable to write file .*stall\.bin' <<<"$log" ||
     fail "the stopped slot's buffered bytes were dropped without a word: ${log}"
 ok "a slot flushed on the way out still reports the full disk"
 

--- a/tests/351_engine-warc-cache-io.test
+++ b/tests/351_engine-warc-cache-io.test
@@ -28,7 +28,7 @@ seekfail_ready() {
     if [ ! -r "${SEEKFAIL_LA:-}" ]; then
         fail "${SEEKFAIL_LA:-\$SEEKFAIL_LA} was not built"
     fi
-    if grep -q "^dlname=''" "$SEEKFAIL_LA"; then
+    if command grep -q "^dlname=''" "$SEEKFAIL_LA"; then
         echo "static-only build, skipping the cap legs" >&2
         return 1
     fi
@@ -48,7 +48,7 @@ if seekfail_ready; then
     out=$(ASAN_OPTIONS="$asan_opts" SEEKFAIL_CAP=1099511627774 LD_PRELOAD="$SEEKFAIL_LIB" \
         httrack -O "$tmp/out" "-#test=warc-offset" "$tmp/" 2>&1) || rc=$?
     test "$rc" -eq 0 || fail "a capped filesystem must not fail warc-offset: $out"
-    grep -q "past this filesystem's file-size cap" <<<"$out" ||
+    command grep -q "past this filesystem's file-size cap" <<<"$out" ||
         fail "the skipped offset was not reported: $out"
 
     # Refusing every wide offset must fail the tally, not pass silently.
@@ -56,7 +56,7 @@ if seekfail_ready; then
     out=$(ASAN_OPTIONS="$asan_opts" SEEKFAIL_CAP=2147483647 LD_PRELOAD="$SEEKFAIL_LIB" \
         httrack -O "$tmp/out" "-#test=warc-offset" "$tmp/" 2>&1) || rc=$?
     test "$rc" -ne 0 || fail "warc-offset passed with no offset past 2GB: $out"
-    grep -q "no offset past 2GB was measurable" <<<"$out" ||
+    command grep -q "no offset past 2GB was measurable" <<<"$out" ||
         fail "warc-offset failed for another reason: $out"
 
     # Only EFBIG is excused; any other errno is a real seek failure to report.
@@ -65,7 +65,7 @@ if seekfail_ready; then
         ASAN_OPTIONS="$asan_opts" LD_PRELOAD="$SEEKFAIL_LIB" \
         httrack -O "$tmp/out" "-#test=warc-offset" "$tmp/" 2>&1) || rc=$?
     test "$rc" -ne 0 || fail "warc-offset excused a non-EFBIG seek failure: $out"
-    grep -q "cannot seek to 1099511627775" <<<"$out" ||
+    command grep -q "cannot seek to 1099511627775" <<<"$out" ||
         fail "warc-offset failed for another reason: $out"
 fi
 httrack -O "$tmp/out" "-#test=cache-readfail" "$tmp/"

--- a/tests/354_local-update-purge-redirhub.test
+++ b/tests/354_local-update-purge-redirhub.test
@@ -76,7 +76,7 @@ assert_purged false "$out"
 local_crawl --log "${tmpdir}/tlog3" "${common[@]}" -O "$out" --update \
     "${BASEURL}/twicefail/index.html"
 assert_gave_up "$out" '/twicefail/thub\.html'
-grep -q 'tchild\.html' "${site}/thub.html" ||
+command grep -q 'tchild\.html' "${site}/thub.html" ||
     fail "the kept copy of thub.html no longer links tchild.html"
 assert_alive "${site}/tchild.html" TWICEFAIL-CHILD
 assert_purged false "$out"

--- a/tests/355_local-write-error-not-eof.test
+++ b/tests/355_local-write-error-not-eof.test
@@ -58,19 +58,19 @@ crawl_onto_dead_pipe() {
 assert_write_error() {
     local what="$1" name="$2"
 
-    grep -q "Unable to write file .*${name}" <<<"$log" ||
+    command grep -q "Unable to write file .*${name}" <<<"$log" ||
         fail "${what}: nothing said the file could not be written: ${log}"
-    grep -q 'Write error on disk' <<<"$log" ||
+    command grep -q 'Write error on disk' <<<"$log" ||
         fail "${what}: the failure was not reported as a write error: ${log}"
     # r.size counts bytes read, so a body our own write cut short must never
     # be reported as one the server truncated.
-    if grep -q 'Incorrect length' <<<"$log"; then
+    if command grep -q 'Incorrect length' <<<"$log"; then
         fail "${what}: a write error was reported as a truncated download: ${log}"
     fi
-    if grep -qF "$name" <<<"$cached"; then
+    if command grep -qF "$name" <<<"$cached"; then
         fail "${what}: a file that never reached the disk counts as mirrored: ${cached}"
     fi
-    if grep -qE 'Mirror aborted|disk full' <<<"$log"; then
+    if command grep -qE 'Mirror aborted|disk full' <<<"$log"; then
         fail "${what}: a write error outside the fatal class gave up the mirror: ${log}"
     fi
 }
@@ -112,17 +112,17 @@ local_crawl --log "${tmpdir}/log-decode" "${common[@]}" --retries=0 \
     -O "$decode" "${BASEURL}/diskfull/gzindex.html"
 log=$(<"${decode}/hts-log.txt")
 cached=$(<"${decode}/hts-cache/new.txt")
-grep -q 'Unable to write file .*gz\.bin' <<<"$log" ||
+command grep -q 'Unable to write file .*gz\.bin' <<<"$log" ||
     fail "a decode our own filesystem refused was blamed on the coded body: ${log}"
-if grep -qE 'Mirror aborted|disk full' <<<"$log"; then
+if command grep -qE 'Mirror aborted|disk full' <<<"$log"; then
     fail "a non-fatal failure under the decode gave up the mirror: ${log}"
 fi
-gzrow=$(grep -F '/gz.bin' <<<"$cached" || true)
-grep -q "error (" <<<"$gzrow" ||
+gzrow=$(command grep -F '/gz.bin' <<<"$cached" || true)
+command grep -q "error (" <<<"$gzrow" ||
     fail "a body that never reached the disk was not recorded as failed: ${gzrow}"
 test ! -e "${decodesite}/gz.bin" ||
     fail "the coded bytes were committed as the file we could not decode"
-grep -q DISKFULL-GZPAGE "${decodesite}/gzpage.html" ||
+command grep -q DISKFULL-GZPAGE "${decodesite}/gzpage.html" ||
     fail "the rest of the mirror did not survive the failed decode"
 ok "a decode that cannot write its output names our own filesystem"
 
@@ -139,7 +139,7 @@ mkdir -p "${updsite}/~hts-tmp/gz.bin.u"
 local_crawl --log "${tmpdir}/log-update2" "${common[@]}" --retries=0 --update \
     -O "$upd" "${BASEURL}/diskfull/gzindex.html"
 log=$(<"${upd}/hts-log.txt")
-grep -q 'Unable to write file .*gz\.bin' <<<"$log" ||
+command grep -q 'Unable to write file .*gz\.bin' <<<"$log" ||
     fail "the update pass did not fail the decode it was set up to fail: ${log}"
 test "$(wc -c <"${updsite}/gz.bin" 2>/dev/null || echo 0)" -eq "$before" ||
     fail "the purge deleted the copy the failed decode preserved: ${log}"
@@ -150,12 +150,12 @@ clean="${tmpdir}/clean"
 local_crawl --log "${tmpdir}/log-clean" "${common[@]}" --retries=0 -O "$clean" \
     "${BASEURL}/diskfull/splitindex.html"
 log=$(<"${clean}/hts-log.txt")
-if grep -qE 'Write error on disk|Unable to write file' <<<"$log"; then
+if command grep -qE 'Write error on disk|Unable to write file' <<<"$log"; then
     fail "a body that reached the disk was reported as a write error: ${log}"
 fi
 test "$(wc -c <"${clean}/127.0.0.1_${SRV_PORT}/diskfull/split.bin")" -eq 8000 ||
     fail "the control mirror did not write the whole body"
-grep -qF 'split.bin' "${clean}/hts-cache/new.txt" ||
+command grep -qF 'split.bin' "${clean}/hts-cache/new.txt" ||
     fail "the control mirror did not count the file it wrote"
 ok "a body that reaches the disk is not reported as a write error"
 
@@ -165,11 +165,11 @@ cleannoclen="${tmpdir}/clean-noclen"
 local_crawl --log "${tmpdir}/log-clean-noclen" "${common[@]}" --retries=0 \
     -O "$cleannoclen" "${BASEURL}/diskfull/noclenindex.html"
 log=$(<"${cleannoclen}/hts-log.txt")
-if grep -qE 'Write error on disk|Unable to write file' <<<"$log"; then
+if command grep -qE 'Write error on disk|Unable to write file' <<<"$log"; then
     fail "a close-delimited body that reached the disk was reported as a write error: ${log}"
 fi
 test "$(wc -c <"${cleannoclen}/127.0.0.1_${SRV_PORT}/diskfull/noclen.bin")" -eq 100 ||
     fail "the control mirror did not write the whole close-delimited body"
-grep -qF 'noclen.bin' "${cleannoclen}/hts-cache/new.txt" ||
+command grep -qF 'noclen.bin' "${cleannoclen}/hts-cache/new.txt" ||
     fail "the control mirror did not count the close-delimited file it wrote"
 ok "a close-delimited body that reaches the disk is not reported as a write error"

--- a/tests/358_webhttrack-option-fields.test
+++ b/tests/358_webhttrack-option-fields.test
@@ -35,7 +35,7 @@ htsserver_start
 
 # The page that offers the pairs is the count's only source, so a ninth row
 # flows through here instead of desyncing three literals.
-pairs=$(grep -c '<input name="ext[0-9]*"' "${HTS_DISTDIR}/html/server/option11.html")
+pairs=$(command grep -c '<input name="ext[0-9]*"' "${HTS_DISTDIR}/html/server/option11.html")
 test "${pairs}" -ge 8 || fail "option11.html offers only ${pairs} MIME pairs"
 
 out="${work}/crawl"
@@ -119,7 +119,7 @@ PY
 
 log="${out}/hts-log.txt"
 start=${SECONDS}
-while ! grep -q "HTTrack Website Copier/" "${log}" 2>/dev/null; do
+while ! command grep -q "HTTrack Website Copier/" "${log}" 2>/dev/null; do
     htsserver_alive || fail "htsserver died: $(tail -n 20 "${log}" 2>/dev/null)"
     test "$((SECONDS - start))" -lt 120 || fail_dump "the crawl did not end" "${log}"
     poll_wait 0.2
@@ -129,13 +129,13 @@ done
 doit="${out}/hts-cache/doit.log"
 assert_file "${doit}" "the crawl recorded no invocation"
 argv=$(head -1 "${doit}")
-grep -q -- "-u2" <<<"${argv}" || fail "the type check never reached the engine: ${argv}"
-grep -q -- "-%A foo=text/html" <<<"${argv}" ||
+command grep -q -- "-u2" <<<"${argv}" || fail "the type check never reached the engine: ${argv}"
+command grep -q -- "-%A foo=text/html" <<<"${argv}" ||
     fail "the first MIME pair never reached the engine: ${argv}"
 # One token per line, so grep -c counts the flags rather than the single line.
-assume_flags=$(tr ' ' '\n' <<<"${argv}" | grep -c -- '-%A' || true)
+assume_flags=$(tr ' ' '\n' <<<"${argv}" | command grep -c -- '-%A' || true)
 assert_eq "${pairs}" "${assume_flags}" "-%A flags in the recorded argv"
-! grep -q -- "-F " <<<"${argv}" || fail "a blank browser id still sent -F: ${argv}"
+! command grep -q -- "-F " <<<"${argv}" || fail "a blank browser id still sent -F: ${argv}"
 
 # The rule changed the crawl, not just the argv: without it data.foo stays a
 # binary the engine never opens, so deep.html is unreachable.

--- a/tests/359_local-structure-template.test
+++ b/tests/359_local-structure-template.test
@@ -41,7 +41,7 @@ run() { # run ARG...
 mirrored() {
     (cd "${tmp}/out" && find . -type f ! -path './hts-cache/*' ! -name '.log' \
         ! -name 'hts-log.txt' ! -name '*.gif' ! -name '*.lock' -print |
-        grep -v '^\./index\.html$' | sort)
+        command grep -v '^\./index\.html$' | sort)
 }
 
 # Only the layout on disk tells whether -N applied: hts-cache/doit.log is the
@@ -59,7 +59,7 @@ refused() { # refused WANTED-MESSAGE ARG...
     shift
     run "$@"
     { test "${RC}" -ne 0 && test "${RC}" -ne 134; } || fail "$* not refused (exit ${RC})"
-    grep -q "${want}" "${tmp}/out/.log" ||
+    command grep -q "${want}" "${tmp}/out/.log" ||
         fail "$* refused without saying why: $(<"${tmp}/out/.log")"
 }
 

--- a/tests/360_exit-status-aborted-mirror.test
+++ b/tests/360_exit-status-aborted-mirror.test
@@ -52,7 +52,7 @@ crawl_status clean index.html
 test "$rc" -eq 0 || fail "a completed mirror exited $rc: $(<"$rc_log")"
 # The engine's own verdict, not just a file on disk: a crawl that mirrored the
 # entry page and then gave up would satisfy the weaker check and exit 0 too.
-grep -q 'mirror complete in' <<<"$log" ||
+command grep -q 'mirror complete in' <<<"$log" ||
     fail "the control crawl did not finish, so its exit 0 proves nothing: ${log}"
 ok "a mirror that completes still exits 0"
 
@@ -61,13 +61,13 @@ site="${tmpdir}/stream/127.0.0.1_${SRV_PORT}/diskfull"
 mkdir -p "$site"
 ln -s /dev/full "${site}/big.bin"
 crawl_status stream index.html
-grep -q 'Mirror aborted: keeping all previously mirrored files' <<<"$log" ||
+command grep -q 'Mirror aborted: keeping all previously mirrored files' <<<"$log" ||
     fail "the fixture did not abort the mirror, so the status proves nothing: ${log}"
 test "$rc" -eq "$ABORTED" || fail "an aborted mirror exited $rc, wanted $ABORTED"
 ok "a mirror the engine aborts exits $ABORTED"
 
 # stderr is the only place httrack.c says why, and it used to be empty here.
-grep -q 'mirror aborted' <"$rc_log" ||
+command grep -q 'mirror aborted' <"$rc_log" ||
     fail "the non-zero exit came with no reason: $(<"$rc_log")"
 ok "and says so on stderr rather than printing an empty error"
 
@@ -76,7 +76,7 @@ site="${tmpdir}/page/127.0.0.1_${SRV_PORT}/diskfull"
 mkdir -p "$site"
 ln -s /dev/full "${site}/small.html"
 crawl_status page smallindex.html
-grep -q 'Fatal write error, giving up' <<<"$log" ||
+command grep -q 'Fatal write error, giving up' <<<"$log" ||
     fail "the page arm did not reach the fatal write path: ${log}"
 test "$rc" -eq "$ABORTED" || fail "the page arm exited $rc, wanted $ABORTED"
 ok "the page path aborts with the same status"
@@ -85,7 +85,7 @@ ok "the page path aborts with the same status"
 mkdir -p "${tmpdir}/cache/hts-cache"
 ln -s /dev/full "${tmpdir}/cache/hts-cache/new.zip"
 crawl_status cache index.html
-grep -q 'Mirror aborted: disk full or filesystem problems' <<<"$log" ||
+command grep -q 'Mirror aborted: disk full or filesystem problems' <<<"$log" ||
     fail "the cache arm did not reach the fatal cache write: ${log}"
 # The cache zip is the only /dev/full node this arm creates, and it is still
 # the symlink, so no page or file write is what reported the full disk.
@@ -98,7 +98,7 @@ ok "a cache write failure aborts with the same status"
 # -#L caps the link table. The parser reached that cap and returned quietly
 # while htsAddLink's identical refusal aborted, so one limit gave two statuses.
 crawl_status linklimit index.html "-#L1"
-grep -q 'Too many URLs, giving up' <<<"$log" ||
+command grep -q 'Too many URLs, giving up' <<<"$log" ||
     fail "the link cap was not reached, so the status proves nothing: ${log}"
 test "$rc" -eq "$ABORTED" || fail "the link-cap arm exited $rc, wanted $ABORTED"
 ok "the link cap aborts with the same status, disk or no disk"

--- a/tests/361_cli-wide-tiny-alias.test
+++ b/tests/361_cli-wide-tiny-alias.test
@@ -43,10 +43,10 @@ expand_run() {
     assert_eq 0 "${RC}" "${label} exited"
     assert_file "${tmp}/out/hts-log.txt" "${label}"
     line=$(sed -n 2p "${tmp}/out/hts-log.txt")
-    grep -qF -- "${want}" <<<"${line}" ||
+    command grep -qF -- "${want}" <<<"${line}" ||
         fail "${label}: the engine was handed ${line}, wanted ${want}"
     WARNED=no
-    ! grep -q 'cannot add its connection count' "${tmp}/run.log" || WARNED=yes
+    ! command grep -q 'cannot add its connection count' "${tmp}/run.log" || WARNED=yes
 }
 
 # the count went on, with nothing to report
@@ -121,9 +121,9 @@ warned ' +*.gif ' 'tiny allow' --tiny-allow '*.gif'
 
 # -#h returns before any crawl, so it is read straight off the run
 run_log=$(httrack -O "${tmp}/out" --quiet --wide-version 2>&1) || fail "--wide-version exited $?"
-grep -q 'cannot add its connection count' <<<"${run_log}" ||
+command grep -q 'cannot add its connection count' <<<"${run_log}" ||
     fail "--wide-version applied silently: ${run_log}"
-grep -q 'HTTrack version' <<<"${run_log}" ||
+command grep -q 'HTTrack version' <<<"${run_log}" ||
     fail "--wide-version stopped printing the version: ${run_log}"
 ok "a prefix that cannot be glued on warns, and the alias still runs"
 

--- a/tests/362_engine-param-value-refused.test
+++ b/tests/362_engine-param-value-refused.test
@@ -43,7 +43,7 @@ refused() { # refused ARG...
     # 134 is an abort, which would read as a refusal without being one
     { test "${RC}" -ne 0 && test "${RC}" -ne 134; } ||
         fail_dump "$* not refused (exit ${RC})" "${tmp}/log"
-    grep -q 'does not take the value' "${tmp}/log" ||
+    command grep -q 'does not take the value' "${tmp}/log" ||
         fail_dump "$* refused without saying why" "${tmp}/log"
     # the mirror must not be there at all, in either layout
     ! has_name page.html || fail_dump "$* still mirrored" "${tmp}/log"
@@ -56,7 +56,7 @@ accepted() { # accepted ARG...
     # either layout: bare -L is 8.3, so --long-names=on lands there too
     has_name page.html || has_name PAGE.HTM ||
         fail_dump "$* mirrored nothing" "${tmp}/log"
-    ! grep -q 'does not take the value' "${tmp}/log" ||
+    ! command grep -q 'does not take the value' "${tmp}/log" ||
         fail_dump "$* drew a refusal" "${tmp}/log"
 }
 
@@ -83,7 +83,7 @@ refused --max-files=,,,5
 # The message names the option that was typed. --cache=OFF used to report
 # "Option O needs [...] a path", -O being reached out of the middle of OFF.
 crawl --cache=OFF
-grep -q 'Option --cache does not take the value OFF' "${tmp}/log" ||
+command grep -q 'Option --cache does not take the value OFF' "${tmp}/log" ||
     fail_dump "--cache=OFF blamed another option" "${tmp}/log"
 
 # Negative control: the values these rows do take still run, and say nothing.
@@ -118,7 +118,7 @@ refused --structure=1L0
 # What still separates the classes: the template, which "param" would mangle.
 accepted --structure=1
 crawl --structure=%h%p/%n%q.%t
-! grep -q 'does not take the value' "${tmp}/log" ||
+! command grep -q 'does not take the value' "${tmp}/log" ||
     fail_dump "--structure template refused" "${tmp}/log"
 
 exit 0

--- a/tests/363_engine-option-dash-value.test
+++ b/tests/363_engine-option-dash-value.test
@@ -46,7 +46,7 @@ noparam() { # noparam LABEL ARG...
 
 accepted() { # accepted LABEL
     test "$rc" -eq 0 || fail "$1: exited $rc: $stderr"
-    ! grep -q 'Syntax error' <<<"$stderr" || fail "$1: $stderr"
+    ! command grep -q 'Syntax error' <<<"$stderr" || fail "$1: $stderr"
 }
 
 # A refusal leaves no mirror behind and says why on stderr, never only on the
@@ -62,10 +62,10 @@ refused() { # refused LABEL RE...
     # optparam_error() states the reason and stops, then the option's own help
     # line: "Syntax error:", the reason, at most one more. Advice appended to
     # either lands outside that shape.
-    if grep -qE 'takes a value|needs to be followed by a parameter' <<<"$stderr"; then
-        test "$(grep -c . <<<"$stderr")" -le 3 ||
+    if command grep -qE 'takes a value|needs to be followed by a parameter' <<<"$stderr"; then
+        test "$(command grep -c . <<<"$stderr")" -le 3 ||
             fail "$label: the refusal says more than the reason and the help: $stderr"
-        grep -qE '(<param>|names an option|read as the next option)$' <<<"$stderr" ||
+        command grep -qE '(<param>|names an option|read as the next option)$' <<<"$stderr" ||
             fail "$label: the refusal reason does not end where it should: $stderr"
     fi
     while test $# -gt 0; do
@@ -227,7 +227,7 @@ test "$rc" -ne 0 || fail "no URL at all: exited 0"
 assert_match 'No URL to mirror' "$stderr" "no URL at all"
 # Inert where the v6 resolver was not compiled in, and then it says so.
 parse -@i9
-if ! grep -q 'v6 routines not compiled' <<<"$stdout"; then
+if ! command grep -q 'v6 routines not compiled' <<<"$stdout"; then
     refused "-@i9" 'Unknown value for -@i: 9'
 fi
 echo OK

--- a/tests/364_local-abort-not-done.test
+++ b/tests/364_local-abort-not-done.test
@@ -46,18 +46,18 @@ crawl() {
 # stdout must carry the one verdict that matches what the log says happened.
 assert_says() { # assert_says finished|aborted WHAT
     if test "$1" = finished; then
-        grep -q '^Done\.$' "$out" || fail_dump "$2" "$out" "$err"
+        command grep -q '^Done\.$' "$out" || fail_dump "$2" "$out" "$err"
         return 0
     fi
-    if grep -q '^Done\.$' "$out"; then
+    if command grep -q '^Done\.$' "$out"; then
         fail_dump "$2" "$out" "$err"
     fi
-    grep -q 'Mirror not completed' "$out" || fail_dump "$2" "$out" "$err"
+    command grep -q 'Mirror not completed' "$out" || fail_dump "$2" "$out" "$err"
 }
 
 # The whole point of the shell arm: neither verdict reaches the token stream.
 assert_shell_silent() { # assert_shell_silent WHAT
-    if grep -qE '^Done\.$|Mirror not completed|TRANSFER DONE' "$out"; then
+    if command grep -qE '^Done\.$|Mirror not completed|TRANSFER DONE' "$out"; then
         fail_dump "$1" "$out" "$err"
     fi
 }
@@ -65,14 +65,14 @@ assert_shell_silent() { # assert_shell_silent WHAT
 # --- a mirror that finishes still reports it --------------------------------
 crawl complete changes/index.html
 assert_says finished "a completed mirror stopped saying Done."
-if grep -q 'Mirror aborted\|giving up' <<<"$log"; then
+if command grep -q 'Mirror aborted\|giving up' <<<"$log"; then
     fail "the control crawl did not finish, so it proves nothing: ${log}"
 fi
 ok "a mirror that finishes still says Done."
 
 # --- the link cap: httpmirror() returns -1, which the == 0 test never saw ----
 crawl linkcap changes/index.html -\#L4
-grep -q 'Too many URLs' <<<"$log" ||
+command grep -q 'Too many URLs' <<<"$log" ||
     fail "the link cap did not stop the crawl, so nothing here was aborted: ${log}"
 assert_says aborted "a mirror the link cap stopped still claimed to be done"
 ok "a mirror the link cap stopped does not claim to be done"
@@ -96,7 +96,7 @@ if disk_abort_works; then
     mkdir -p "${dir}/127.0.0.1_${SRV_PORT}/diskfull"
     ln -s /dev/full "${dir}/127.0.0.1_${SRV_PORT}/diskfull/big.bin"
     crawl diskfull diskfull/index.html --retries=2 -c1
-    grep -q 'Mirror aborted: keeping all previously mirrored files' <<<"$log" ||
+    command grep -q 'Mirror aborted: keeping all previously mirrored files' <<<"$log" ||
         fail "the full disk did not abort the mirror: ${log}"
     assert_says aborted "a mirror the full disk aborted still claimed to be done"
     ok "a mirror the full disk aborted does not claim to be done"
@@ -109,7 +109,7 @@ fi
 # overrun past the grace reaches exit_xh. slow.html sleeps 5s and the grace
 # floor is 5s, so this arm stops in the first stage every time.
 crawl maxtime abortpurge/index.html --retries=1 -c1 --timeout=0 --max-time=2
-grep -q 'giving up' <<<"$log" ||
+command grep -q 'giving up' <<<"$log" ||
     fail "the time cap never fired, so nothing here was capped: ${log}"
 assert_says aborted "a mirror the time cap stopped still claimed to be done"
 ok "a mirror the time cap stopped does not claim to be done"
@@ -140,7 +140,7 @@ else
     crawlpid=
     test "$rc" -ne 124 || fail "the interrupted crawl never exited"
     log=$(<"${dir}/hts-log.txt")
-    grep -q 'Exit requested' <<<"$log" ||
+    command grep -q 'Exit requested' <<<"$log" ||
         fail "the interrupt never reached the engine: ${log}"
     assert_says aborted "an interrupted mirror still claimed to be done"
     ok "an interrupted mirror does not claim to be done"
@@ -148,7 +148,7 @@ fi
 
 # --- --why answers and returns without mirroring, which is not an abort -----
 crawl why changes/index.html --why "${BASEURL}/changes/index.html"
-grep -q 'no filter rule matches' "$out" ||
+command grep -q 'no filter rule matches' "$out" ||
     fail_dump "--why printed no verdict, so its Done. proves nothing" "$out" "$err"
 assert_says finished "--why was reported as an aborted mirror"
 ok "--why still reports Done."
@@ -159,7 +159,7 @@ ok "--why still reports Done."
 crawl shell-complete changes/index.html -\#S
 assert_shell_silent "shell mode gained an end-of-mirror token (completed)"
 crawl shell-linkcap changes/index.html -\#S -\#L4
-grep -q 'Too many URLs' <<<"$log" ||
+command grep -q 'Too many URLs' <<<"$log" ||
     fail "the shell-mode crawl was not aborted, so its silence proves nothing: ${log}"
 assert_shell_silent "shell mode gained an end-of-mirror token (aborted)"
 ok "shell mode still ends silently, aborted or not"

--- a/tests/365_local-update-purge-notype.test
+++ b/tests/365_local-update-purge-notype.test
@@ -21,7 +21,7 @@ common=(--quiet --disable-security-limits --robots=0 --retries=1 -c1 --timeout=2
 # themselves are asserted on the files; this only pins the report agreeing.
 purge_says() {
     local want="$1" json="${2}/hts-changes.json"
-    grep -q "\"purged\": ${want}" "$json" ||
+    command grep -q "\"purged\": ${want}" "$json" ||
         fail "expected \"purged\": ${want} in $(<"$json")"
 }
 
@@ -44,7 +44,7 @@ holds_nuls() {
     local want got
     want=$(($(wc -c <"$1") - 8))
     test "$want" -gt 10 || fail "$1 is too short to carry the blob's NULs"
-    got=$(od -An -v -c -j 8 -N "$want" "$1" | tr -s ' ' '\n' | grep -c '^\\0$' || true)
+    got=$(od -An -v -c -j 8 -N "$want" "$1" | tr -s ' ' '\n' | command grep -c '^\\0$' || true)
     test "$got" -eq "$want" || fail "$1 kept $got of its $want NUL bytes"
 }
 
@@ -65,7 +65,7 @@ blob_case() {
 
     local_crawl --log "${tmpdir}/${case}2" "${common[@]}" -O "$out" --update \
         "${BASEURL}/ctpurge/${case}/index.html"
-    grep -qE "Error:.*\(-[0-9]+\).*at link .*/ctpurge/${case}/blob\.bin" \
+    command grep -qE "Error:.*\(-[0-9]+\).*at link .*/ctpurge/${case}/blob\.bin" \
         "${out}/hts-log.txt" ||
         fail "${case}: the blob re-fetch did not fail, so nothing was tested"
     test -s "$copy" || fail "${case}: the failed blob lost its copy (#746)"
@@ -100,7 +100,7 @@ test -s "${site}/gone.html" || fail "pass 1 did not mirror gone.html"
 for crawl in 2 3; do
     local_crawl --log "${tmpdir}/twice${crawl}" "${common[@]}" -O "$out" --update \
         "${BASEURL}/ctpurge/twice/index.html"
-    grep -qE "Error:.*\(-[0-9]+\).*at link .*/ctpurge/twice/blob\.html" \
+    command grep -qE "Error:.*\(-[0-9]+\).*at link .*/ctpurge/twice/blob\.html" \
         "${out}/hts-log.txt" ||
         fail "crawl ${crawl}: the blob re-fetch did not fail, so nothing was tested"
 done

--- a/tests/366_local-update-namedrift.test
+++ b/tests/366_local-update-namedrift.test
@@ -20,21 +20,21 @@ common=(--quiet --disable-security-limits --robots=0 --retries=1 -c1 --timeout=2
 # assert_purged WANT OUTDIR: what the run reported doing to the old files.
 assert_purged() {
     local want="$1" json="${2}/hts-changes.json"
-    grep -q "\"purged\": ${want}" "$json" ||
+    command grep -q "\"purged\": ${want}" "$json" ||
         fail "expected \"purged\": ${want} in $(<"$json")"
 }
 
 # assert_alive FILE MARKER: still mirrored, and still the body we mirrored.
 assert_alive() {
     test -s "$1" || fail "$1 is gone"
-    grep -q "$2" "$1" || fail "$1 no longer carries ${2}"
+    command grep -q "$2" "$1" || fail "$1 no longer carries ${2}"
 }
 
 # assert_gave_up OUTDIR URLPATH: the link exhausted its retries on a transport
 # failure, not on an answered error.
 assert_gave_up() {
     local log="${1}/hts-log.txt"
-    grep -qE "Error:.*\(-[0-9]+\).*at link .*${2}" "$log" ||
+    command grep -qE "Error:.*\(-[0-9]+\).*at link .*${2}" "$log" ||
         fail "no transport failure gave up on ${2}: $(<"$log")"
 }
 
@@ -66,13 +66,13 @@ with open(path, "rb") as fp:
 assert_cached() {
     local blocks count
     blocks=$(cache_headers "$1" "$2")
-    count=$(grep -c '^X-In-Cache:' <<<"$blocks" || true) # entry blocks, not lines
+    count=$(command grep -c '^X-In-Cache:' <<<"$blocks" || true) # entry blocks, not lines
     test "$count" = 1 || fail "want 1 cache entry for ${2}, got ${count}"
-    grep -q "^X-Save: .*${3}\$" <<<"$blocks" ||
+    command grep -q "^X-Save: .*${3}\$" <<<"$blocks" ||
         fail "the cache entry for ${2} does not name ${3}: ${blocks}"
-    grep -q '^X-Kept: 1$' <<<"$blocks" ||
+    command grep -q '^X-Kept: 1$' <<<"$blocks" ||
         fail "the cache entry for ${2} is not marked kept: ${blocks}"
-    grep -q '^X-In-Cache: 0$' <<<"$blocks" ||
+    command grep -q '^X-In-Cache: 0$' <<<"$blocks" ||
         fail "the cache entry for ${2} claims to hold a body: ${blocks}"
 }
 
@@ -157,7 +157,7 @@ local_crawl --log "${tmpdir}/clog2" "${common[@]}" -O "$out" --update \
     "${BASEURL}/collide/index.html"
 assert_gave_up "$out" '/collide/dupe\.php'
 blocks=$(cache_headers "$out" '/collide/dupe.php')
-grep -q 'dupe-2\.html' <<<"$blocks" &&
+command grep -q 'dupe-2\.html' <<<"$blocks" &&
     fail "dupe.php's cache entry names dupe.html's file: ${blocks}"
 ok "a name the failed link no longer owns is not recorded as its own"
 

--- a/tests/368_engine-option-bare-value.test
+++ b/tests/368_engine-option-bare-value.test
@@ -33,7 +33,7 @@ crawl() { # crawl ARG...
 # Basenames of the mirror, so the checks read what was written rather than a
 # path this host may spell differently (macOS $TMPDIR, Windows ':' -> '_').
 saved() { find "${out}" -type f ! -path '*hts-cache*' | sed 's|.*/||' | sort; }
-has_name() { grep -Fqx "$1" <<<"$(saved)"; }
+has_name() { command grep -Fqx "$1" <<<"$(saved)"; }
 # The directories too, which is where a preset or a template is visible.
 tree_names() { find "${out}" ! -path '*hts-cache*' | sed 's|.*/||' | sort; }
 has_dir() { test -n "$(find "${out}" -type d -name "$1")"; }
@@ -133,7 +133,7 @@ has_dir tpl || fail_dump "--structure template never reached -N" "${tmp}/log"
 crawl --structure=I0 "${url}"
 { test "${RC}" -ne 0 && test "${RC}" -ne 134; } ||
     fail_dump "--structure=I0 not refused (exit ${RC})" "${tmp}/log"
-grep -q 'does not take the value' "${tmp}/log" ||
+command grep -q 'does not take the value' "${tmp}/log" ||
     fail_dump "--structure=I0 refused without saying why" "${tmp}/log"
 ! has_name page.html || fail_dump "--structure=I0 still mirrored" "${tmp}/log"
 

--- a/tests/369_engine-param-value-range.test
+++ b/tests/369_engine-param-value-range.test
@@ -21,7 +21,7 @@ refuses() { # refuses WORD...
     out=$(httrack "-#test=optalias" "$@" 2>&1) || rc=$?
     { test "${rc}" -ne 0 && test "${rc}" -ne 134; } ||
         fail "$* not refused (exit ${rc})"
-    grep -q 'does not take the value' <<<"${out}" ||
+    command grep -q 'does not take the value' <<<"${out}" ||
         fail "$* refused without saying why: ${out}"
 }
 

--- a/tests/370_engine-structure-cluster-tail.test
+++ b/tests/370_engine-structure-cluster-tail.test
@@ -37,8 +37,8 @@ crawl() { # crawl ARG...
 # The mirrored page, by marker: relative path, or empty if the crawl saved none.
 # The top index carries no marker, so it drops out without being named.
 marked() {
-    (cd "${out}" && grep -rlF "${marker}" . 2>/dev/null |
-        grep -v '^\./hts-cache/' | sort | tr '\n' ' ') || true
+    (cd "${out}" && command grep -rlF "${marker}" . 2>/dev/null |
+        command grep -v '^\./hts-cache/' | sort | tr '\n' ' ') || true
 }
 has_index() { test -e "${out}/index.html"; }
 
@@ -47,7 +47,7 @@ refused() { # refused ARG...
     # 134 is an abort, which would read as a refusal without being one
     { test "${RC}" -ne 0 && test "${RC}" -ne 134; } ||
         fail_dump "$* not refused (exit ${RC})" "${tmp}/log"
-    grep -q 'does not take the value' "${tmp}/log" ||
+    command grep -q 'does not take the value' "${tmp}/log" ||
         fail_dump "$* refused without saying why" "${tmp}/log"
     # a value taken as a template would exit 0, so this pins the reason too
     test -z "$(marked)" || fail_dump "$* still mirrored: $(marked)" "${tmp}/log"
@@ -59,7 +59,7 @@ accepted() { # accepted WANTED-PATH ARG...
     crawl "$@" "${url}"
     assert_eq 0 "${RC}" "$* exited"
     assert_eq "${want} " "$(marked)" "$* mirrored"
-    ! grep -q 'does not take the value' "${tmp}/log" ||
+    ! command grep -q 'does not take the value' "${tmp}/log" ||
         fail_dump "$* drew a refusal" "${tmp}/log"
 }
 

--- a/tests/371_webhttrack-help-reachable.test
+++ b/tests/371_webhttrack-help-reachable.test
@@ -16,20 +16,20 @@ test -f "${guide}" || fail "no ${guide}"
 # ---- every pane points at a section the guide really has ----
 
 printf '[each pane links a guide section that exists] ..\t'
-anchors=$(grep -oh 'guide\.html#web/[a-z0-9-]*' "${distdir}"/html/server/*.html |
+anchors=$(command grep -oh 'guide\.html#web/[a-z0-9-]*' "${distdir}"/html/server/*.html |
     sed 's|.*#web/||' | LC_ALL=C sort -u)
 # An empty list would walk the loop below without ever reading the guide.
 found=$(count_matching_lines . <<<"${anchors}")
 test "${found}" -ge 10 || fail "only ${found} guide anchors under html/server/"
 for a in ${anchors}; do
-    tag=$(grep -m1 -o "<[^>]*id=\"${a}\"[^>]*>" "${guide}" || true)
+    tag=$(command grep -m1 -o "<[^>]*id=\"${a}\"[^>]*>" "${guide}" || true)
     test -n "${tag}" ||
         fail "a pane links guide.html#web/${a}, which the guide has no id for"
     # guide.css hides a section scoped to another platform, so the link would
     # open the guide and scroll nowhere.
     case ${tag} in
     *data-for=*)
-        grep -q 'data-for="[^"]*web' <<<"${tag}" ||
+        command grep -q 'data-for="[^"]*web' <<<"${tag}" ||
             fail "guide section ${a} is not shown for web: ${tag}"
         ;;
     esac
@@ -61,18 +61,18 @@ step3.html step-address
 step4.html step-ready
 PAIRS
 )
-linked=$(grep -l 'guide\.html#web/' "${distdir}"/html/server/*.html | wc -l)
+linked=$(command grep -l 'guide\.html#web/' "${distdir}"/html/server/*.html | wc -l)
 test "${linked}" -eq "$(count_matching_lines . <<<"${pairs}")" ||
     fail "${linked} pages link the guide, the table below pins a different number"
 while read -r page anchor; do
-    grep -qF "guide.html#web/${anchor}\"" "${distdir}/html/server/${page}" ||
+    command grep -qF "guide.html#web/${anchor}\"" "${distdir}/html/server/${page}" ||
         fail "${page} must link guide.html#web/${anchor}"
 done <<<"${pairs}"
 # Control: the loop proves nothing unless a wrong anchor really misses.
-! grep -qF 'id="no-such-section"' "${guide}" ||
+! command grep -qF 'id="no-such-section"' "${guide}" ||
     fail "the control anchor exists, so the loop above cannot discriminate"
 # The step*.html stubs redirect without the platform, so no pane may name one.
-stale=$(grep -l 'href="/step[0-9]*\.html"\|/server/help\.html\|/server/file\.html' \
+stale=$(command grep -l 'href="/step[0-9]*\.html"\|/server/help\.html\|/server/file\.html' \
     "${distdir}"/html/server/*.html || true)
 test -z "${stale}" || fail "a pane still links a retired page: ${stale}"
 printf 'ok\n'
@@ -176,7 +176,7 @@ await() { # await MARKER WHAT
     local start=$SECONDS body
     while :; do
         body=$(htsserver_get "${PANE}")
-        grep -qF "$1" <<<"${body}" && return 0
+        command grep -qF "$1" <<<"${body}" && return 0
         htsserver_alive || fail "htsserver died waiting for $2"
         test "$((SECONDS - start))" -lt 120 || fail "the panel never reached $2"
         poll_wait 0.2
@@ -197,7 +197,7 @@ htsserver_client --path /server/index.html --field "sid=${sid}" --field lang=1 >
 serves "${PANE}" "${IDLE}" 'back in English'
 # Control: the markers asserted below are absent until a crawl sets them.
 # refresh.html is skipped, being the running pane itself.
-idle_panes=$(grep -vxF /server/refresh.html <<<"${PANES}")
+idle_panes=$(command grep -vxF /server/refresh.html <<<"${PANES}")
 # shellcheck disable=SC2086 # deliberately split path lists
 probe refutes "${RUNNING}" 'idle' ${idle_panes}
 docs_reachable 'idle'

--- a/tests/373_credits.test
+++ b/tests/373_credits.test
@@ -168,7 +168,7 @@ serve() { # $1 = tag, $2 = lang index; leaves the reply in ${reply}
     htsserver_start --root "${root}" --home "${work}/h$1" lang "$2"
     reply=$(htsserver_get /server/about.html)
     htsserver_stop
-    grep -q '^HTTP/1.[01] 200' <<<"${reply}" || fail "about.html for language $2: ${reply}"
+    command grep -q '^HTTP/1.[01] 200' <<<"${reply}" || fail "about.html for language $2: ${reply}"
 }
 
 # Names unique to one catalog, so the page must follow the language rather than
@@ -176,9 +176,9 @@ serve() { # $1 = tag, $2 = lang index; leaves the reply in ${reply}
 check() { # $1 = lang index, $2 = LANGUAGE_NAME, $3 = name shown, $4 = name not shown
     local reply
     serve "$1" "$1"
-    grep -q "$2: " <<<"${reply}" || fail "about.html for language $1 has no '$2:' credit line"
-    grep -q "$3" <<<"${reply}" || fail "about.html for language $1 does not name $3"
-    if grep -q "$4" <<<"${reply}"; then
+    command grep -q "$2: " <<<"${reply}" || fail "about.html for language $1 has no '$2:' credit line"
+    command grep -q "$3" <<<"${reply}" || fail "about.html for language $1 does not name $3"
+    if command grep -q "$4" <<<"${reply}"; then
         fail "about.html for language $1 still names $4"
     fi
     # shellcheck disable=SC2016 # the raw token is what must not survive
@@ -208,9 +208,9 @@ PY
 reply=''
 serve markup 1
 for planted in Zzz Yyy; do
-    grep -q "${planted}&lt;/pre&gt;&lt;script&gt;" <<<"${reply}" ||
+    command grep -q "${planted}&lt;/pre&gt;&lt;script&gt;" <<<"${reply}" ||
         fail "about.html does not escape markup out of a catalog (${planted}): ${reply}"
-    if grep -q "${planted}</pre>" <<<"${reply}"; then
+    if command grep -q "${planted}</pre>" <<<"${reply}"; then
         fail "about.html serves catalog markup raw (${planted}): ${reply}"
     fi
 done

--- a/tests/374_timeb-guard.test
+++ b/tests/374_timeb-guard.test
@@ -106,7 +106,7 @@ found=$(scan "${sources[@]}")
 # A scanner that matched nothing would report a clean tree just as well.
 [ -n "$found" ] || fail "the scan found no timeb use at all; htslib.c has three"
 
-bad=$(grep '^BAD ' <<<"$found" || true)
+bad=$(command grep '^BAD ' <<<"$found" || true)
 [ -z "$bad" ] || fail "unguarded timeb use, which bionic does not ship:
 $bad"
 

--- a/tests/376_example-libs-option.test
+++ b/tests/376_example-libs-option.test
@@ -47,7 +47,7 @@ if [ "${EXAMPLE_LIBS:-yes}" = yes ]; then
     for name in ${plugins}; do
         got=$(built "${name}")
         test -n "${got}" || fail "lib${name} is missing from ${stage}${libdir}/httrack"
-        grep -qE '\.so|\.dylib' <<<"${got}" ||
+        command grep -qE '\.so|\.dylib' <<<"${got}" ||
             fail "lib${name} installed no shared object: ${got}"
     done
     ok "the ten example plugins install by default"

--- a/tests/377_engine-install-paths.test
+++ b/tests/377_engine-install-paths.test
@@ -25,7 +25,7 @@ out=$(httrack -O /dev/null -#test=instpaths) || rc=$?
 
 value_of() { # value_of KEY
     local line
-    line=$(grep "^$1=" <<<"$out") || fail "no $1 line in: $out"
+    line=$(command grep "^$1=" <<<"$out") || fail "no $1 line in: $out"
     printf '%s\n' "${line#"$1"=}"
 }
 
@@ -60,7 +60,7 @@ pp=$("${cc_argv[@]}" -E -I"${abs_top_srcdir:?}/src" -I"$abs_top_builddir" \
 
 expanded() { # expanded KEY: the macro, with adjacent string literals joined
     local line
-    line=$(grep "^hts_$1=" <<<"$pp") || fail "no hts_$1 line in the preprocessed header"
+    line=$(command grep "^hts_$1=" <<<"$pp") || fail "no hts_$1 line in the preprocessed header"
     printf '%s\n' "${line#hts_"$1"=}" | tr -d ' "'
 }
 
@@ -74,7 +74,7 @@ assert_eq /probe/share/httrack/ "$(expanded httrackdir)" "the probe reaches the 
 
 # The wiring itself: a -D the build never passes falls back to that same literal.
 for pair in PREFIX:prefix SYSCONFDIR:sysconfdir BINDIR:bindir LIBDIR:libdir DATADIR:datadir; do
-    grep -q -- "-D${pair%%:*}=.*\$(${pair##*:})" "$abs_top_srcdir/src/Makefile.am" ||
+    command grep -q -- "-D${pair%%:*}=.*\$(${pair##*:})" "$abs_top_srcdir/src/Makefile.am" ||
         fail "src/Makefile.am does not pass -D${pair%%:*} from \$(${pair##*:})"
 done
 

--- a/tests/380_configure-zlib-libdir.test
+++ b/tests/380_configure-zlib-libdir.test
@@ -117,7 +117,7 @@ expect_fail() { # expect_fail DESC PREFIX
     dir=${work}/build${n}
     ! run_configure "${dir}" --with-zlib="${prefix}" ||
         fail "${desc}: configure accepted a prefix with no libz under it"
-    grep -q 'no libz found' "${dir}/configure.log" ||
+    command grep -q 'no libz found' "${dir}/configure.log" ||
         fail "${desc}: configure failed without naming the missing library"
     echo "ok: ${desc}"
     skip_if_out_of_budget "$((cases - n))" "$((SECONDS - began))"

--- a/tests/381_public-headers-no-config.test
+++ b/tests/381_public-headers-no-config.test
@@ -71,7 +71,7 @@ read_idents() { # read_idents FILE...
           print out line; out = "" }' |
         sed -e 's|^[[:space:]]*#[[:space:]]*define[[:space:]][A-Za-z_][A-Za-z0-9_]*||' \
             -e 's|^[[:space:]]*#[[:space:]]*undef[[:space:]][A-Za-z_][A-Za-z0-9_]*||' |
-        grep -o '[A-Za-z_][A-Za-z0-9_]*' | sort -u
+        command grep -o '[A-Za-z_][A-Za-z0-9_]*' | sort -u
 }
 config_macros "$abs_top_builddir/config.h" >"$tmp/config.names"
 config_macros "$inc/htsfeatures.h" >"$tmp/public.names"
@@ -79,8 +79,8 @@ read_idents "$inc"/*.h >"$tmp/read.names"
 # The scan reads nothing useful if it misses the switch this test exists for, or
 # the type macro that no #if mentions.
 for must in HTS_INET6 in_port_t sa_family_t; do
-    grep -qx "$must" "$tmp/read.names" || fail "the header scan found no $must, it proves nothing"
-    grep -qx "$must" "$tmp/public.names" || fail "htsfeatures.h does not carry $must"
+    command grep -qx "$must" "$tmp/read.names" || fail "the header scan found no $must, it proves nothing"
+    command grep -qx "$must" "$tmp/public.names" || fail "htsfeatures.h does not carry $must"
 done
 missing=$(comm -12 "$tmp/config.names" "$tmp/read.names" | comm -23 - "$tmp/public.names")
 [ -z "$missing" ] ||
@@ -92,7 +92,7 @@ missing=$(comm -12 "$tmp/config.names" "$tmp/read.names" | comm -23 - "$tmp/publ
 httrack -O /dev/null '-#test=pubheaders' | tr -d '\r' >"$tmp/library.out"
 for key in 'sizeof SOCaddr' 'sizeof INTsys' 'sizeof htsblk' 'offsetof htsblk.address' \
     'offsetof htsblk.etag' 'sizeof httrackp' 'HTS_INET6 = ' 'HTS_USEOPENSSL = '; do
-    grep -q "^$key" "$tmp/library.out" || fail "-#test=pubheaders no longer reports [$key]"
+    command grep -q "^$key" "$tmp/library.out" || fail "-#test=pubheaders no longer reports [$key]"
 done
 [ "$(wc -l <"$tmp/library.out")" -ge 12 ] || fail "-#test=pubheaders reports fewer fields than it used to"
 
@@ -111,9 +111,9 @@ diff -u "$tmp/library.out" "$tmp/consumer.out" ||
 # of the above was measuring anything. Which value is wrong depends on the
 # build, so flip it rather than writing 0 over a build that already has 0.
 chmod -R u+w "$inc"
-grep -qx '#define HTS_INET6 1' "$inc/htsfeatures.h" && wrong=0 || wrong=1
+command grep -qx '#define HTS_INET6 1' "$inc/htsfeatures.h" && wrong=0 || wrong=1
 sed -i.bak "s|^#define HTS_INET6 .*|#define HTS_INET6 $wrong|" "$inc/htsfeatures.h" && rm -f "$inc/htsfeatures.h.bak"
-grep -qx "#define HTS_INET6 $wrong" "$inc/htsfeatures.h" || fail "the negative control did not rewrite HTS_INET6"
+command grep -qx "#define HTS_INET6 $wrong" "$inc/htsfeatures.h" || fail "the negative control did not rewrite HTS_INET6"
 probe "$tmp/wrong.out" || fail "the wrong-HTS_INET6 consumer did not build, so the diff below never ran"
 ! diff -q "$tmp/library.out" "$tmp/wrong.out" >/dev/null ||
     fail "HTS_INET6=$wrong changed no size or offset, so this test cannot see the bug it guards"
@@ -122,11 +122,11 @@ probe "$tmp/wrong.out" || fail "the wrong-HTS_INET6 consumer did not build, so t
 # what installing config.h was buying. Which way it breaks is decided, not
 # whichever happens: HTS_DO_NOT_REDEFINE_in_addr_t means the platform declares
 # in_addr_t, so htsnet.h's own typedef of it stops the consumer compiling.
-grep -qx '#define HTS_DO_NOT_REDEFINE_in_addr_t /\*\*/' "$inc/htsfeatures.h" &&
+command grep -qx '#define HTS_DO_NOT_REDEFINE_in_addr_t /\*\*/' "$inc/htsfeatures.h" &&
     want=nocompile || want=differs
 rm -f "$inc/htsfeatures.h"
 sed -i.bak '/^#include "htsfeatures.h"$/d' "$inc/htsglobal.h" && rm -f "$inc/htsglobal.h.bak"
-! grep -q '^#include "htsfeatures.h"$' "$inc/htsglobal.h" ||
+! command grep -q '^#include "htsfeatures.h"$' "$inc/htsglobal.h" ||
     fail "the negative control did not strip the include"
 if probe "$tmp/patched.out"; then
     got=differs

--- a/tests/382_doc-links-resolve.test
+++ b/tests/382_doc-links-resolve.test
@@ -131,7 +131,7 @@ while IFS= read -r page; do
         elif g=$(gap_index "${rel}" "${link}"); then
             gap_seen[g]=resolves
         fi
-    done < <(LC_ALL=C grep -Eio "(href|src)[[:space:]]*=[[:space:]]*[\"'][^\"']*[\"']" "${page}" || true)
+    done < <(LC_ALL=C command grep -Eio "(href|src)[[:space:]]*=[[:space:]]*[\"'][^\"']*[\"']" "${page}" || true)
 done < <({
     find "${stage}${htmldir}" -name '*.html'
     find "${stage}${docdir}" -name '*.html'

--- a/tests/383_configure-error-message-comma.test
+++ b/tests/383_configure-error-message-comma.test
@@ -36,9 +36,9 @@ run_bad() {
     (cd "$tmp/bld-$name" && bash "$tmp/src/configure" "$@") >"$log" 2>&1 || status=$?
     test "$status" -eq 1 || fail_dump "configure --$name exited $status, want 1" "$log"
     out=$(<"$log")
-    grep -qF "configure: error: $expect" <<<"$out" ||
+    command grep -qF "configure: error: $expect" <<<"$out" ||
         fail_dump "configure --$name did not print the full message '$expect'" "$log"
-    grep -qE '^[^:]*configure: line [0-9]+:' <<<"$out" &&
+    command grep -qE '^[^:]*configure: line [0-9]+:' <<<"$out" &&
         fail_dump "configure --$name leaked a bash error alongside the message" "$log"
     return 0
 }

--- a/tests/384_staged-install-lock.test
+++ b/tests/384_staged-install-lock.test
@@ -73,7 +73,7 @@ AWK
 
 lint_files() { awk -f "${lint}" "$@"; }
 totals_of() { sed -n 's/^TOTALS //p' <<<"$1"; }
-offenders_of() { grep -v '^TOTALS ' <<<"$1" || true; }
+offenders_of() { command grep -v '^TOTALS ' <<<"$1" || true; }
 
 cd "${srcdir}/tests"
 files=(*.sh *.py)
@@ -225,7 +225,7 @@ for ((round = 1; round <= rounds; round++)); do
     install_lock_read_pid "${INSTALL_LOCK}"
     test "${INSTALL_LOCK_PID}" = "${corpse}" ||
         fail "round ${round}: the stale lock was removed, pid is now [${INSTALL_LOCK_PID}]"
-    grep -q "${INSTALL_LOCK}" "${work}/stale.log" ||
+    command grep -q "${INSTALL_LOCK}" "${work}/stale.log" ||
         fail "round ${round}: the refusal does not name the file to remove"
     rm -f "${INSTALL_LOCK}"
 done

--- a/tests/386_local-proxytrack-dav-tz.test
+++ b/tests/386_local-proxytrack-dav-tz.test
@@ -62,9 +62,9 @@ start_proxytrack "$dir/pt" launch_proxytrack
 test "$(count_matching_lines '<response ' "$dir/resp.xml")" -eq 3 ||
     fail_dump "expected the root and its two entries" "$dir/resp.xml"
 
-grep -q '<getlastmodified>Sun, 06 Nov 1994 08:49:37 GMT</getlastmodified>' "$dir/resp.xml" ||
+command grep -q '<getlastmodified>Sun, 06 Nov 1994 08:49:37 GMT</getlastmodified>' "$dir/resp.xml" ||
     fail_dump "the entry's Last-Modified was shifted by the server's timezone" "$dir/resp.xml"
-grep -q '<getlastmodified>Wed, 01 Jan 2025 00:00:00 GMT</getlastmodified>' "$dir/resp.xml" ||
+command grep -q '<getlastmodified>Wed, 01 Jan 2025 00:00:00 GMT</getlastmodified>' "$dir/resp.xml" ||
     fail_dump "the ARC record date was shifted by the server's timezone" "$dir/resp.xml"
 
 echo "OK: a WebDAV listing dates both entries in GMT on a UTC+5:30 host"

--- a/tests/389_configure-codec-libdir.test
+++ b/tests/389_configure-codec-libdir.test
@@ -165,7 +165,7 @@ expect() { # expect CODEC WANT-SUBDIR REJECTED-SUBDIR DESC PREFIX ARG...
     # The emitted flag is not the probe. Detection linking under the old
     # unresolved path while only the flag is fixed would pass every check
     # above, so read the link command configure actually ran.
-    probe=$(grep -e '-o conftest' "${dir}/config.log" | grep -e "-l${lib}" || true)
+    probe=$(command grep -e '-o conftest' "${dir}/config.log" | command grep -e "-l${lib}" || true)
     probe=$(tr '\n' ' ' <<<"${probe}")
     test -n "${probe}" || fail_dump "${desc}: config.log has no -l${lib} link probe" "${dir}/config.log"
     case " ${probe} " in
@@ -178,9 +178,9 @@ expect() { # expect CODEC WANT-SUBDIR REJECTED-SUBDIR DESC PREFIX ARG...
 
     # PACKAGING.md quotes this qualifier as the packager's confirmation of who
     # chose, so both halves of it are pinned here, in one run that has both.
-    grep -q "the ${codec} content coding\.\.\. yes (requested)" "${dir}/configure.log" ||
+    command grep -q "the ${codec} content coding\.\.\. yes (requested)" "${dir}/configure.log" ||
         fail_dump "${desc}: an explicit --with-${codec} was not reported as (requested)" "${dir}/configure.log"
-    grep -qE "the ${other} content coding\.\.\. (yes|no) \(auto\)" "${dir}/configure.log" ||
+    command grep -qE "the ${other} content coding\.\.\. (yes|no) \(auto\)" "${dir}/configure.log" ||
         fail_dump "${desc}: the unrequested ${other} coding was not reported as (auto)" "${dir}/configure.log"
 
     echo "ok: ${desc} -> ${want}"
@@ -194,7 +194,7 @@ expect_fail() { # expect_fail CODEC DESC PREFIX
     dir=${work}/build${n}
     ! run_configure "${dir}" --with-"${codec}"="${prefix}" ||
         fail_dump "${desc}: configure accepted a prefix with no lib${lib} under it" "${dir}/configure.log"
-    grep -q "no lib${lib} found" "${dir}/configure.log" ||
+    command grep -q "no lib${lib} found" "${dir}/configure.log" ||
         fail_dump "${desc}: configure failed without naming the missing library" "${dir}/configure.log"
     echo "ok: ${desc}"
     skip_if_out_of_budget "$((cases - n))" "$((SECONDS - began))"

--- a/tests/390_optscan-enum-cast.test
+++ b/tests/390_optscan-enum-cast.test
@@ -25,20 +25,20 @@ for bad in 'sscanf(com + 1, "%d", (int *) &opt->urlmode);' \
     'sscanf(com + 1, "%d", (uint8_t *) &opt->urlmode);' \
     'sscanf(com + 1, "%d", (int32_t *) &opt->urlmode);' \
     'sscanf(com + 1, "%d", (unsigned int *) &opt->urlmode);'; do
-    grep -qE "$pattern" <<<"$bad" || fail "the pattern cannot match: $bad"
+    command grep -qE "$pattern" <<<"$bad" || fail "the pattern cannot match: $bad"
 done
 
 # And a pattern matching everything would be just as silent, so pin the two
 # forms that must stay clear: the direct scan and scanOptInt().
 for good in 'sscanf(com + 1, "%d", &opt->urlmode);' \
     'scanOptInt(com + 1, &opt->urlmode);'; do
-    grep -qE "$pattern" <<<"$good" && fail "the pattern matches a good line: $good"
+    command grep -qE "$pattern" <<<"$good" && fail "the pattern matches a good line: $good"
 done
 
-found=$(grep -nE "$pattern" "$src" || true)
+found=$(command grep -nE "$pattern" "$src" || true)
 [ -z "$found" ] || fail "option scan writing through a cast pointer in $src:
 $found"
 
-grep -q 'scanOptInt' "$src" || fail "scanOptInt() has left $src"
+command grep -q 'scanOptInt' "$src" || fail "scanOptInt() has left $src"
 
 echo "optscan: no option scan in htscoremain.c writes through a cast pointer"

--- a/tests/394_update-cache.test
+++ b/tests/394_update-cache.test
@@ -69,7 +69,7 @@ sleep 1
 echo 'NEWCONTENT' >"${root}/a.html"
 crawl changed --update
 test "$(count_log_errors "$log")" = 0 || fail "update (changed) reported errors"
-grep -q NEWCONTENT "${host}/a.html" || fail "the update did not pick up the changed source"
+command grep -q NEWCONTENT "${host}/a.html" || fail "the update did not pick up the changed source"
 test "$(verdict a.html)" != untouched || fail "a.html was reported untouched after it changed"
 for f in index.html sub/b.html; do
     test "$(verdict "$f")" = untouched ||

--- a/tests/395_crawl_proxy_https.test
+++ b/tests/395_crawl_proxy_https.test
@@ -47,10 +47,10 @@ start_server() {
         >"$ports" 2>"$dir/server.err" &
     pids="$pids $!"
     for _ in $(seq 1 100); do
-        grep -q "^ready" "$ports" 2>/dev/null && break
+        command grep -q "^ready" "$ports" 2>/dev/null && break
         sleep 0.1
     done
-    grep -q "^ready" "$ports" 2>/dev/null ||
+    command grep -q "^ready" "$ports" 2>/dev/null ||
         fail_dump "server ($mode) did not start" "$dir/server.err"
     origin_port=$(awk '/^ORIGIN/{print $2}' "$ports")
     proxy_port=$(awk '/^PROXY/{print $2}' "$ports")
@@ -81,9 +81,9 @@ start_server "$ok" ok
 
 # 1. page retrieved AND the proxy saw a CONNECT to the origin
 run_crawl "$ok/out" "127.0.0.1:${proxy_port}" "$origin_port"
-grep -rq "ORIGIN-PAGE-85" "$ok/out" ||
+command grep -rq "ORIGIN-PAGE-85" "$ok/out" ||
     fail_dump "origin page not downloaded through proxy" "$ok/out.log"
-grep -q "^CONNECT 127.0.0.1:${origin_port} " "$ok/proxy.log" ||
+command grep -q "^CONNECT 127.0.0.1:${origin_port} " "$ok/proxy.log" ||
     fail_dump "proxy never received a CONNECT (https bypassed the proxy)" "$ok/proxy.log"
 echo "OK: https tunneled through proxy via CONNECT"
 
@@ -91,13 +91,13 @@ echo "OK: https tunneled through proxy via CONNECT"
 : >"$ok/proxy.log"
 : >"$ok/origin-headers.log"
 run_crawl "$ok/out2" "user:secret@127.0.0.1:${proxy_port}" "$origin_port"
-grep -rq "ORIGIN-PAGE-85" "$ok/out2" || fail "origin page not downloaded through authenticated proxy"
+command grep -rq "ORIGIN-PAGE-85" "$ok/out2" || fail "origin page not downloaded through authenticated proxy"
 got=$(awk '/^AUTH Basic /{print $3}' "$ok/proxy.log" | head -1)
 # base64("user:secret"); compared as a literal to stay portable (no base64 -d,
 # which differs between GNU and BSD)
 test "$got" == "dXNlcjpzZWNyZXQ=" ||
     fail_dump "Proxy-Authorization not carried on CONNECT (got '$got')" "$ok/proxy.log"
-if grep -qi "proxy-authorization" "$ok/origin-headers.log"; then
+if command grep -qi "proxy-authorization" "$ok/origin-headers.log"; then
     echo "FAIL: proxy credentials leaked to the origin through the tunnel" >&2
     cat "$ok/origin-headers.log" >&2
     exit 1
@@ -113,7 +113,7 @@ start_server "$flood" flood
 rc=0
 run_crawl "$flood/out" "127.0.0.1:${proxy_port}" "$origin_port" || rc=$?
 test "$rc" -ne "$HANG_RC" || fail "crawl hung on a flooding proxy (bounded read missing)"
-grep -rq "ORIGIN-PAGE-85" "$flood/out" 2>/dev/null && {
+command grep -rq "ORIGIN-PAGE-85" "$flood/out" 2>/dev/null && {
     echo "FAIL: flooding proxy unexpectedly served the page" >&2
     exit 1
 }

--- a/tests/396_install-ui-outside-docdir.test
+++ b/tests/396_install-ui-outside-docdir.test
@@ -74,15 +74,15 @@ htsserver_start --root "${served}"
 serves() { # serves PATH MARKER WHAT
     local body
     body=$(htsserver_get "$1")
-    grep -q '^HTTP/1.0 200 OK' <<<"${body}" ||
+    command grep -q '^HTTP/1.0 200 OK' <<<"${body}" ||
         fail "$3: $1 answered $(firstline "${body}")"
-    grep -qF "$2" <<<"${body}" || fail "$3: $1 served without ${2}"
+    command grep -qF "$2" <<<"${body}" || fail "$3: $1 served without ${2}"
 }
 
 absent() { # absent PATH WHAT
     local body
     body=$(htsserver_get "$1")
-    grep -q '^HTTP/1.0 404' <<<"${body}" ||
+    command grep -q '^HTTP/1.0 404' <<<"${body}" ||
         fail "$2: $1 answered $(firstline "${body}") rather than 404"
 }
 
@@ -101,9 +101,9 @@ absent /doc/html/no-such-page.html 'a complete tree'
 # documentation where it used to sit would 404 for a user and pass every
 # assertion above. /website/ needs a mirror, and /server/ is the panel itself.
 panel=$(htsserver_get /server/index.html)
-links=$(grep -o 'href="/[^"]*"' <<<"${panel}" |
+links=$(command grep -o 'href="/[^"]*"' <<<"${panel}" |
     sed -e 's|^href="||' -e 's|"$||' -e 's|#.*||' |
-    grep -vE '^/(website|server)/' | LC_ALL=C sort -u) || true
+    command grep -vE '^/(website|server)/' | LC_ALL=C sort -u) || true
 test "$(count_matching_lines . <<<"${links}")" -ge 2 ||
     fail "the panel links fewer than two documentation pages"
 for link in ${links}; do
@@ -134,7 +134,7 @@ webhttrack_browse || {
 # runs above are not passing on a check that stopped firing.
 rm -rf "${served}/html"
 if webhttrack_browse; then fail "webhttrack accepted a tree with no served UI"; fi
-grep -qE 'Could not find .*/html$' "${work}/browse.log" ||
+command grep -qE 'Could not find .*/html$' "${work}/browse.log" ||
     fail "webhttrack failed for some other reason: $(cat "${work}/browse.log")"
 
 htsserver_cleanup

--- a/tests/397_configure-auto-features.test
+++ b/tests/397_configure-auto-features.test
@@ -103,7 +103,7 @@ run_configure() { # run_configure DIR ARG...
         >"${dir}/configure.log" 2>&1 || rc=$?
     # autoconf only warns about a flag it does not know, so a run that lost one
     # would otherwise report the status quo as a pass.
-    if test "${rc}" -eq 0 && grep -q 'unrecognized options' "${dir}/configure.log"; then
+    if test "${rc}" -eq 0 && command grep -q 'unrecognized options' "${dir}/configure.log"; then
         fail_dump "configure did not recognise every flag it was given" "${dir}/configure.log"
     fi
     return "${rc}"
@@ -122,21 +122,21 @@ assert_state() { # assert_state DIR NAME on|off
     # HAVE_BACKTRACE is defined or absent; the rest are defined to 1 or 0.
     if test "${f}" = backtrace; then
         if test "${want}" = on; then
-            grep -q '^#define HAVE_BACKTRACE 1$' "${dir}/config.h" ||
+            command grep -q '^#define HAVE_BACKTRACE 1$' "${dir}/config.h" ||
                 fail_dump "${f}: config.h does not define HAVE_BACKTRACE" "${dir}/config.h"
         else
-            ! grep -q '^#define HAVE_BACKTRACE' "${dir}/config.h" ||
+            ! command grep -q '^#define HAVE_BACKTRACE' "${dir}/config.h" ||
                 fail_dump "${f}: config.h still defines HAVE_BACKTRACE" "${dir}/config.h"
         fi
     else
-        grep -q "^#define ${macro} ${value}\$" "${dir}/config.h" ||
+        command grep -q "^#define ${macro} ${value}\$" "${dir}/config.h" ||
             fail_dump "${f}: config.h does not define ${macro} to ${value}" "${dir}/config.h"
     fi
 
     # The installed header a consumer of libhttrack compiles against. config.h
     # is not installed and cannot stand in for it.
     if test -n "$(feature_public "${f}")"; then
-        grep -q "^#define ${macro} ${value}\$" "${dir}/htsfeatures.h" ||
+        command grep -q "^#define ${macro} ${value}\$" "${dir}/htsfeatures.h" ||
             fail_dump "${f}: htsfeatures.h does not carry ${macro} ${value}" \
                 "${dir}/htsfeatures.h"
     fi
@@ -157,10 +157,10 @@ assert_state() { # assert_state DIR NAME on|off
     # neither config.h nor src/Makefile passes through.
     if test -n "${pc}"; then
         if test "${want}" = off; then
-            ! grep -qE "^(Requires|Libs)\\.private:.*${pc}" "${dir}/src/libhttrack.pc" ||
+            ! command grep -qE "^(Requires|Libs)\\.private:.*${pc}" "${dir}/src/libhttrack.pc" ||
                 fail_dump "${f}: libhttrack.pc still names ${pc}" "${dir}/src/libhttrack.pc"
         else
-            grep -qE "^(Requires|Libs)\\.private:.*${pc}" "${dir}/src/libhttrack.pc" ||
+            command grep -qE "^(Requires|Libs)\\.private:.*${pc}" "${dir}/src/libhttrack.pc" ||
                 fail_dump "${f}: libhttrack.pc does not name ${pc}" "${dir}/src/libhttrack.pc"
         fi
     fi
@@ -224,7 +224,7 @@ SRC
 # are checked before the first run and before any skip.
 help=$(bash "${shadow}/configure" --help) || fail "configure --help failed"
 for flag in --disable-auto-features $(for f in ${features}; do feature_flag "${f}"; done); do
-    grep -q -e "${flag}" <<<"${help}" || fail "configure --help does not offer ${flag}"
+    command grep -q -e "${flag}" <<<"${help}" || fail "configure --help does not offer ${flag}"
 done
 
 # --disable-auto-features makes the flags after it the whole optional set, so a
@@ -623,7 +623,7 @@ n=$((n + 1))
 # A value the switch does not understand must not read as one of the two it does.
 ! run_configure "${work}/bogus" --enable-auto-features=maybe ||
     fail_dump "--enable-auto-features=maybe was accepted" "${work}/bogus/configure.log"
-grep -q 'bad value for auto-features' "${work}/bogus/configure.log" ||
+command grep -q 'bad value for auto-features' "${work}/bogus/configure.log" ||
     fail_dump "configure refused the value without saying which flag" "${work}/bogus/configure.log"
 echo "ok: a value that is neither yes nor no is refused"
 pace "$((SECONDS - began))"
@@ -633,7 +633,7 @@ n=$((n + 1))
 # Same for a feature's own tri-state: an unknown value must not fall through.
 ! run_configure "${work}/btbogus" --enable-backtrace=bogus ||
     fail_dump "--enable-backtrace=bogus was accepted" "${work}/btbogus/configure.log"
-grep -q 'bad value for backtrace' "${work}/btbogus/configure.log" ||
+command grep -q 'bad value for backtrace' "${work}/btbogus/configure.log" ||
     fail_dump "configure refused the value without saying which flag" "${work}/btbogus/configure.log"
 echo "ok: an unknown --enable-backtrace value is refused"
 pace "$((SECONDS - began))"
@@ -644,7 +644,7 @@ n=$((n + 1))
 mkdir -p "${work}/empty"
 ! run_configure "${work}/reject" --disable-auto-features --with-brotli="${work}/empty" ||
     fail_dump "an explicit --with-brotli at an empty prefix was accepted" "${work}/reject/configure.log"
-grep -q 'brotli requested at' "${work}/reject/configure.log" ||
+command grep -q 'brotli requested at' "${work}/reject/configure.log" ||
     fail_dump "configure failed without naming the prefix it was given" "${work}/reject/configure.log"
 echo "ok: an explicit prefix with no library still fails the build"
 pace "$((SECONDS - began))"
@@ -688,7 +688,7 @@ HDR
 ! run_configure "${work}/ic-bare" --with-iconv "CPPFLAGS=-I${work}/noiconv ${CPPFLAGS:-}" ||
     fail_dump "a bare --with-iconv was accepted where iconv_open does not link" \
         "${work}/ic-bare/configure.log"
-grep -q 'iconv requested but no iconv.h with a linkable iconv_open' \
+command grep -q 'iconv requested but no iconv.h with a linkable iconv_open' \
     "${work}/ic-bare/configure.log" ||
     fail_dump "configure failed without saying that iconv was the request" \
         "${work}/ic-bare/configure.log"
@@ -725,7 +725,7 @@ if prefix=$(iconv_fixture lib64); then
     rm -rf "${prefix:?}/lib64"
     ! run_configure "${work}/icdir-nolib" --with-iconv="${prefix}" ||
         fail_dump "a prefix with no libiconv was accepted" "${work}/icdir-nolib/configure.log"
-    grep -q 'no libiconv found in any of' "${work}/icdir-nolib/configure.log" ||
+    command grep -q 'no libiconv found in any of' "${work}/icdir-nolib/configure.log" ||
         fail_dump "configure rejected the prefix without naming the directories it tried" \
             "${work}/icdir-nolib/configure.log"
     echo "ok: --with-iconv=DIR resolves the libdir, links the renaming header, and reports a miss"

--- a/tests/398_engine-build-features.test
+++ b/tests/398_engine-build-features.test
@@ -21,7 +21,7 @@ test -n "${report}" || fail "httrack -#test=features said nothing"
 
 # macro_is CONFIG MACRO VALUE: does config.h define MACRO to VALUE?
 macro_is() {
-    grep -q "^#define $2 $3\$" "$1"
+    command grep -q "^#define $2 $3\$" "$1"
 }
 
 # want_feature NAME: 1 or 0, derived from config.h rather than from the report.

--- a/tests/401_local-single-file-byte-zero-ref.test
+++ b/tests/401_local-single-file-byte-zero-ref.test
@@ -50,6 +50,6 @@ echo OK
 # The reference at offset 0 is what the classifier used to mishandle, so it is
 # the one that has to come back inlined.
 printf '[reference at offset 0 followed] ..\t'
-grep -q 'url(data:image/svg+xml;base64,' "${tmpdir}/got.css" ||
+command grep -q 'url(data:image/svg+xml;base64,' "${tmpdir}/got.css" ||
     fail "the url() opening the stylesheet was not inlined"
 echo OK

--- a/tests/404_ref-portable.test
+++ b/tests/404_ref-portable.test
@@ -27,7 +27,7 @@ test -r "$src" || fail "cannot read $src"
 codec=$(sed -n '/--- the .ref resume state/,/^int back_serialize_ref(/p' "$src")
 test -n "$codec" || fail "the .ref codec block moved; this check reads nothing"
 
-if grep -qE 'hts_f(read|write)_exact\(&' <<<"$codec"; then
+if command grep -qE 'hts_f(read|write)_exact\(&' <<<"$codec"; then
     fail "the .ref codec hands an object's own storage to the stream"
 fi
 
@@ -37,6 +37,6 @@ for shift in \
     'v >> \(8 \* i\)' \
     'b\[3\] << 24' \
     'b\[i\] << \(8 \* i\)'; do
-    grep -qE "$shift" <<<"$codec" ||
+    command grep -qE "$shift" <<<"$codec" ||
         fail "the .ref codec no longer spells out the byte order ($shift)"
 done

--- a/tests/40_local-why.test
+++ b/tests/40_local-why.test
@@ -15,7 +15,7 @@ why() {
     shift
     # tr: the engine's LF macro is a literal CRLF, which only MSYS folds away.
     out="$(httrack -O "$tmpdir/p" -q "$@" | tr -d '\r' |
-        grep -E 'accepted|rejected|no filter|unable')"
+        command grep -E 'accepted|rejected|no filter|unable')"
     test "$out" == "$want" || {
         echo "want: $want"
         echo "got : $out"

--- a/tests/410_engine-optalias-target.test
+++ b/tests/410_engine-optalias-target.test
@@ -31,7 +31,7 @@ run() { # run OUT ARG...
 # --autotest is -#t, which prints one line and mirrors nothing.
 run autotest "${url}" --quiet -n --autotest
 assert_eq 0 "${RC}" "--autotest exited"
-grep -q 'AUTOCHECK OK' "${log}" || fail_dump "--autotest ran no autocheck" "${log}"
+command grep -q 'AUTOCHECK OK' "${log}" || fail_dump "--autotest ran no autocheck" "${log}"
 ! mirror_has_name "${out}" page.html ||
     fail_dump "--autotest mirrored the URL" "${log}"
 
@@ -40,7 +40,7 @@ run xfrstats "${url}" --quiet -n --debug-xfrstats
 assert_eq 0 "${RC}" "--debug-xfrstats exited"
 mirror_has_name "${out}" page.html ||
     fail_dump "--debug-xfrstats mirrored nothing" "${log}"
-! grep -q 'AUTOCHECK' "${log}" ||
+! command grep -q 'AUTOCHECK' "${log}" ||
     fail_dump "--debug-xfrstats ran the autocheck" "${log}"
 
 # --extract-cache is -#E, which writes hts-cache/meta.zip beside the cache.
@@ -48,7 +48,7 @@ run extract "${url}" --quiet -n
 assert_eq 0 "${RC}" "the mirror feeding --extract-cache exited"
 run extract --extract-cache
 assert_eq 0 "${RC}" "--extract-cache exited"
-grep -q 'extracted meta-data' "${log}" ||
+command grep -q 'extracted meta-data' "${log}" ||
     fail_dump "--extract-cache extracted nothing" "${log}"
 assert_file "${out}/hts-cache/meta.zip" "--extract-cache"
 
@@ -57,7 +57,7 @@ run debugcache "${url}" --quiet -n
 assert_eq 0 "${RC}" "the mirror feeding --debug-cache exited"
 run debugcache --debug-cache '*'
 assert_eq 0 "${RC}" "--debug-cache exited"
-grep -q 'cache entry' "${log}" || fail_dump "--debug-cache listed nothing" "${log}"
+command grep -q 'cache entry' "${log}" || fail_dump "--debug-cache listed nothing" "${log}"
 test ! -f "${out}/hts-cache/meta.zip" ||
     fail_dump "--debug-cache extracted the meta-data" "${log}"
 
@@ -67,9 +67,9 @@ run testfilters --debug-testfilters '*.gif' 'foo.gif'
 # 134 is an abort, which would read as a refusal without being one
 { test "${RC}" -ne 0 && test "${RC}" -ne 134; } ||
     fail_dump "--debug-testfilters was accepted (exit ${RC})" "${log}"
-grep -q 'Unknown option: debug-testfilters' "${log}" ||
+command grep -q 'Unknown option: debug-testfilters' "${log}" ||
     fail_dump "--debug-testfilters refused without saying why" "${log}"
-! grep -q 'not recognized' "${log}" ||
+! command grep -q 'not recognized' "${log}" ||
     fail_dump "--debug-testfilters still reaches the engine's option switch" "${log}"
 
 ok "the -# alias rows reach the option they name"

--- a/tests/412_doc-library-headers.test
+++ b/tests/412_doc-library-headers.test
@@ -26,7 +26,7 @@ same_set() { # same_set <list A> <list B>: newline-separated, order-insensitive
 parse_installed() { # parse_installed <makefile>
     sed -n '/DevIncludes_DATA[[:space:]]*[+:]*=/,/[^\\]$/p' "$1" |
         sed 's/^[[:space:]]*DevIncludes_DATA[[:space:]]*[+:]*=//; s/\\$//' |
-        tr -s ' \t' '\n' | sed 's,.*/,,' | grep '\.h$' | sort -u
+        tr -s ' \t' '\n' | sed 's,.*/,,' | command grep '\.h$' | sort -u
 }
 
 # Project headers a .c includes, either bracket style, indented or not: a name
@@ -41,7 +41,7 @@ parse_includes() { # parse_includes <c file>
         d && /^[[:space:]]*#[[:space:]]*endif\>/ { if (n == 0) { d = 0; next } ; n-- }
         !d
     ' "$1" |
-        grep -oE '^[[:space:]]*#[[:space:]]*include[[:space:]]*[<"][A-Za-z0-9._-]+\.h[">]' |
+        command grep -oE '^[[:space:]]*#[[:space:]]*include[[:space:]]*[<"][A-Za-z0-9._-]+\.h[">]' |
         sed 's,^[^<"]*[<"],,; s,[">].*,,' | sort -u |
         while read -r h; do
             if test -e "${srcdir}/src/${h}" || test -e "${here}/${h}"; then
@@ -78,7 +78,7 @@ same_set "$(parse_includes "${fixture}/probe.c")" 'htsbase.h
 htslib.h' || fail "parse_includes misreads an indented, bracketed or #if 0 include"
 
 installed=$(parse_installed "${makefile}")
-grep -qx 'httrack-library.h' <<<"${installed}" ||
+command grep -qx 'httrack-library.h' <<<"${installed}" ||
     fail "parsed no DevIncludes_DATA list out of ${makefile}"
 
 if same_set "${installed}" "${installed}
@@ -88,7 +88,7 @@ fi
 
 # <li><tt>name.h</tt></li> under the headers section.
 listed=$(sed -n '/<h3 id="headers">/,/<h3 id="examples">/p' "${page}" |
-    grep -o '<li><tt>[a-z0-9.-]*\.h</tt></li>' |
+    command grep -o '<li><tt>[a-z0-9.-]*\.h</tt></li>' |
     sed 's,.*<tt>,,; s,</tt>.*,,' | sort -u)
 test -n "${listed}" || fail "parsed no header list out of ${page}"
 
@@ -104,7 +104,7 @@ internal=$(parse_includes "${frontend}" | comm -23 - <(printf '%s\n' "${installe
 test -n "${internal}" || fail "parsed no private includes out of ${frontend}"
 
 quoted=$(sed -n '/engine-internal headers (/,/install does not carry/p' "${page}" |
-    grep -o '<tt>[a-z0-9.-]*\.h</tt>' | sed 's,</*tt>,,g' | sort -u)
+    command grep -o '<tt>[a-z0-9.-]*\.h</tt>' | sed 's,</*tt>,,g' | sort -u)
 test -n "${quoted}" || fail "parsed no private-include list out of ${page}"
 
 same_set "${internal}" "${quoted}" || {

--- a/tests/418_test-vacuous-skip.test
+++ b/tests/418_test-vacuous-skip.test
@@ -159,7 +159,7 @@ for bug in brace case trailing oneline shift mention; do
     said=$(scan "$tmp/$bug.test") || fail "the scanner exited nonzero: $said"
     # The line too: a report naming the file alone would not point at the bail-out.
     want=$(awk '/exit 0/ { print NR; exit }' "$tmp/$bug.test")
-    grep -q "$bug\\.test:${want}:" <<<"$said" ||
+    command grep -q "$bug\\.test:${want}:" <<<"$said" ||
         fail "$bug.test bails out at line ${want} and went unreported: ${said:-(silence)}"
 done
 for clean in skips late stub indented piped helper; do
@@ -172,7 +172,7 @@ ok "the scanner separates a vacuous bail-out from an honest one"
 # carried across, the first file's assertions vouch for every file behind it and
 # the scan below reports nothing whatever it is fed.
 said=$(scan "$tmp/late.test" "$tmp/brace.test") || fail "the scanner exited nonzero: $said"
-grep -q 'brace\.test:' <<<"$said" ||
+command grep -q 'brace\.test:' <<<"$said" ||
     fail "a file scanned after an asserting one went unreported: ${said:-(silence)}"
 ok "the scanner starts each file over"
 

--- a/tests/420_ci-windows-skip-backend.test
+++ b/tests/420_ci-windows-skip-backend.test
@@ -95,7 +95,7 @@ ci_skip_list=unset-marker
 rc=0
 ci_expected_skips_for_backend bogus >"$tmp/bogus.err" 2>&1 || rc=$?
 test "$rc" -ne 0 || fail "an unknown backend was accepted"
-grep -q "::error::no expected-skip list for backend 'bogus'" "$tmp/bogus.err" ||
+command grep -q "::error::no expected-skip list for backend 'bogus'" "$tmp/bogus.err" ||
     fail "the unknown backend was not reported: $(cat "$tmp/bogus.err")"
 test "$ci_skip_list" = unset-marker || fail "an unknown backend touched ci_skip_list: [$ci_skip_list]"
 
@@ -138,7 +138,7 @@ cmp -s "$testdir/ci-windows-suite.sh" "$tmp/empty-mutant.sh" &&
     if ci_expected_skips_for_backend bogus; then rc=0; else rc=1; fi
     printf 'rc=%s list=[%s]' "$rc" "$ci_skip_list"
 ) >"$tmp/empty-mutant.out"
-grep -q '^rc=0 list=\[\]$' "$tmp/empty-mutant.out" ||
+command grep -q '^rc=0 list=\[\]$' "$tmp/empty-mutant.out" ||
     fail "the empty-fallback mutant did not silently accept an unknown backend: $(<"$tmp/empty-mutant.out")"
 
 echo "ci-windows skip-backend ratchet OK"

--- a/tests/424_engine-wizard-eof.test
+++ b/tests/424_engine-wizard-eof.test
@@ -104,7 +104,7 @@ for mode in eof ioerror; do
     status=$(run "$mode")
     test "$status" = 255 || fail "$mode: the engine ended with [$status], want 255"
     test "$(asked "$mode")" -eq 1 || fail "$mode: asked $(asked "$mode") times, expected 1"
-    grep -q "No project name given" "${dir}/${mode}.out" ||
+    command grep -q "No project name given" "${dir}/${mode}.out" ||
         fail "$mode: the engine gave up without saying why"
 done
 
@@ -116,7 +116,7 @@ ok "an exhausted stdin ends the wizard after one prompt"
 
 run typed >/dev/null
 test "$(asked typed)" -eq 2 || fail "typed: asked $(asked typed) times, expected 2"
-grep -q "No project name given" "${dir}/typed.out" &&
+command grep -q "No project name given" "${dir}/typed.out" &&
     fail "typed: a blank line at a terminal was taken for the end of the stream"
 
 ok "a blank line still prints the option list and asks again"

--- a/tests/426_configure-ipv6-flag.test
+++ b/tests/426_configure-ipv6-flag.test
@@ -71,7 +71,7 @@ check_state() {
     for hdr in config.h htsfeatures.h; do
         # The whole bug: an undefined HTS_INET6 lets htsglobal.h pick, so the
         # installed header set never says which layout it was built with.
-        grep -qx "#define HTS_INET6 ${want}" "${dir}/${hdr}" ||
+        command grep -qx "#define HTS_INET6 ${want}" "${dir}/${hdr}" ||
             fail_dump "${desc}: ${hdr} does not define HTS_INET6 to ${want}" \
                 "${dir}/${hdr}" "${dir}/configure.log"
     done
@@ -96,7 +96,7 @@ expect() { # expect DESC SEED WANT-VALUE WANT-SUMMARY ARG...
     run_configure "${work}/build${n}" "${seed}" "$@" ||
         fail_dump "${desc}: configure failed" "${work}/build${n}/configure.log"
     check_state "${desc}" "${last_dir}" "${want}"
-    grep -q "whether IPv6 support is enabled\.\.\. ${summary}\$" "${last_dir}/configure.log" ||
+    command grep -q "whether IPv6 support is enabled\.\.\. ${summary}\$" "${last_dir}/configure.log" ||
         fail_dump "${desc}: configure did not report '${summary}'" "${last_dir}/configure.log"
     echo "ok: ${desc}"
     pace "$((SECONDS - began))"
@@ -109,7 +109,7 @@ expect_fail() { # expect_fail DESC SEED WANT-TEXT ARG...
     n=$((n + 1))
     ! run_configure "${work}/build${n}" "${seed}" "$@" ||
         fail_dump "${desc}: configure succeeded" "${work}/build${n}/configure.log"
-    grep -q "${text}" "${last_dir}/configure.log" ||
+    command grep -q "${text}" "${last_dir}/configure.log" ||
         fail_dump "${desc}: configure failed without saying '${text}'" "${last_dir}/configure.log"
     echo "ok: ${desc}"
     pace "$((SECONDS - began))"
@@ -138,7 +138,7 @@ expect "--disable-ipv6 is honoured" have 0 "no (requested)" --disable-ipv6
 
 # A build that asked for no IPv6 has no reason to care what the host has. It
 # reads the run above, so it stays attached to it.
-if grep -q "getaddrinfo" "${last_dir}/configure.log"; then
+if command grep -q "getaddrinfo" "${last_dir}/configure.log"; then
     fail_dump "--disable-ipv6 still probed for getaddrinfo" "${last_dir}/configure.log"
 fi
 
@@ -156,12 +156,12 @@ expect "--disable-auto-features leaves IPv6 on auto" have 1 "yes (auto)" --disab
 n=$((n + 1))
 run_configure "${work}/build${n}" probe ||
     fail_dump "an unseeded configure failed" "${work}/build${n}/configure.log"
-grep -q "checking for getaddrinfo in -lc" "${last_dir}/configure.log" ||
+command grep -q "checking for getaddrinfo in -lc" "${last_dir}/configure.log" ||
     fail_dump "an unseeded configure ran no getaddrinfo probe" "${last_dir}/configure.log"
-if grep -q "whether IPv6 support is enabled\.\.\. yes (auto)$" "${last_dir}/configure.log"; then
+if command grep -q "whether IPv6 support is enabled\.\.\. yes (auto)$" "${last_dir}/configure.log"; then
     probed=yes
     check_state "the unseeded probe" "${last_dir}" 1
-elif grep -q "whether IPv6 support is enabled\.\.\. no (auto)$" "${last_dir}/configure.log"; then
+elif command grep -q "whether IPv6 support is enabled\.\.\. no (auto)$" "${last_dir}/configure.log"; then
     probed=no
     check_state "the unseeded probe" "${last_dir}" 0
 else

--- a/tests/427_local-dashC-cache-listing.test
+++ b/tests/427_local-dashC-cache-listing.test
@@ -40,11 +40,11 @@ import sys, zipfile
 for i in sorted(zipfile.ZipFile(sys.argv[1]).infolist(), key=lambda i: i.filename):
     print(i.filename)
 ' "${out}/hts-cache/new.zip" | tr -d '\r')
-test "$(grep -c . <<<"$cached")" = 2 || fail "want 2 cache entries, got: $cached"
+test "$(command grep -c . <<<"$cached")" = 2 || fail "want 2 cache entries, got: $cached"
 
 # -#C returns as soon as it has listed, so -O comes first; the listing is CRLF.
 listing=$(httrack -O "$out" -#C '*' 2>"${tmpdir}/dashc.err" | tr -d '\r')
-if grep -q 'No cache entry found' "${tmpdir}/dashc.err"; then
+if command grep -q 'No cache entry found' "${tmpdir}/dashc.err"; then
     fail "-#C '*' found nothing in a cache holding: ${cached}"
 fi
 
@@ -63,9 +63,9 @@ ok "-#C lists every entry of the ZIP cache, each with the size stored for it"
 
 # The filter still narrows, so the listing is not just "print everything".
 one=$(httrack -O "$out" -#C '*child*' 2>/dev/null | tr -d '\r')
-test "$(grep -c '^X-URL: ' <<<"$one")" = 1 ||
+test "$(command grep -c '^X-URL: ' <<<"$one")" = 1 ||
     fail "-#C '*child*' matched more than child.html: ${one}"
-grep -q '^X-URL: .*/site/child\.html$' <<<"$one" ||
+command grep -q '^X-URL: .*/site/child\.html$' <<<"$one" ||
     fail "-#C '*child*' listed the wrong entry: ${one}"
 ok "a filtered listing narrows to the entries the pattern matches"
 
@@ -99,11 +99,11 @@ print(name)
 ' "${grafted}/hts-cache/new.zip" | tr -d '\r')
 
 listing=$(httrack -O "$grafted" -#C '*' 2>/dev/null | tr -d '\r')
-test "$(grep -c '^X-URL: ' <<<"$listing")" = 3 ||
+test "$(command grep -c '^X-URL: ' <<<"$listing")" = 3 ||
     fail "want the 2 crawled entries and the grafted one: ${listing}"
-grep -qF "X-URL: ${graft}" <<<"$listing" ||
+command grep -qF "X-URL: ${graft}" <<<"$listing" ||
     fail "the entry grafted into the ZIP was not listed: ${listing}"
-if grep -q 'noheaders' <<<"$listing"; then
+if command grep -q 'noheaders' <<<"$listing"; then
     fail "an entry the index refuses was listed anyway: ${listing}"
 fi
 ok "the listing follows the ZIP index, and skips what that index refuses"
@@ -113,7 +113,7 @@ ok "the listing follows the ZIP index, and skips what that index refuses"
 rc=0
 none=$(httrack -O "$out" -#C '*no-such-url*' 2>&1) || rc=$?
 test "$rc" = 0 || fail "a filter matching nothing exited ${rc}"
-grep -q "No cache entry found for '\*no-such-url\*'" <<<"$none" ||
+command grep -q "No cache entry found for '\*no-such-url\*'" <<<"$none" ||
     fail "a filter matching nothing did not say so: ${none}"
 
 # The cache has to OPEN for the empty-index branch to be the one that answers,
@@ -129,8 +129,8 @@ rc=0
 none=$(httrack -O "$drained" -#C '*' 2>"${tmpdir}/drained.err") || rc=$?
 test "$rc" = 0 || fail "-#C over an empty index exited ${rc}"
 # the warning rides cache.log, which -#C points at stdout
-grep -q 'Corrupted cache entry' <<<"$none" ||
+command grep -q 'Corrupted cache entry' <<<"$none" ||
     fail "the ZIP never opened, so an empty index is not what answered: ${none}"
-grep -q 'No cache entry found' "${tmpdir}/drained.err" ||
+command grep -q 'No cache entry found' "${tmpdir}/drained.err" ||
     fail "an empty index did not report itself empty: ${none}"
 ok "an empty result still reports no entry"

--- a/tests/428_cli-updatehttrack.test
+++ b/tests/428_cli-updatehttrack.test
@@ -54,7 +54,7 @@ test ! -f "${mirrored}" ||
     fail "--updatehttrack mirrored ${mirrored}, so it ran as a crawl"
 assert_eq 0 "$(count_matching_lines "${usage_marker}" "${tmp}/run.log")" \
     "--updatehttrack printed the usage"
-grep -qF -- '--updatehttrack' <<<"${LOG}" ||
+command grep -qF -- '--updatehttrack' <<<"${LOG}" ||
     fail "--updatehttrack failed without naming itself: ${LOG}"
 ok "--updatehttrack is refused instead of walked as a cluster"
 

--- a/tests/429_defined-but-inert.test
+++ b/tests/429_defined-but-inert.test
@@ -55,7 +55,7 @@ for h in config.h htsfeatures.h; do
     [ -f "$abs_top_builddir/$h" ] || skip "$abs_top_builddir/$h is missing"
     sed 's|^#define DLLIB 1|/* #undef DLLIB */|' "$abs_top_builddir/$h" >"$tmp/nodl/$h"
 done
-grep -q '^/\* #undef DLLIB \*/$' "$tmp/nodl/config.h" ||
+command grep -q '^/\* #undef DLLIB \*/$' "$tmp/nodl/config.h" ||
     fail "config.h no longer defines DLLIB the way this test strips it"
 
 cpp_argv=(-E -I"$tmp/nodl" -I"$abs_top_builddir" -I"$abs_top_builddir/src"
@@ -74,10 +74,10 @@ printf '#include "htsglobal.h"\nPROBE HTS_DLOPEN\n' >"$tmp/probe.c"
 "${cc_argv[@]}" "${cpp_argv[@]}" "$tmp/probe.c" >"$tmp/probe.i" 2>/dev/null ||
     fail "the probe TU did not preprocess"
 assert_eq "PROBE 0" "$(sed -n 's/^PROBE .*/&/p' "$tmp/probe.i" | tail -1)" "HTS_DLOPEN without DLLIB"
-grep -q 'smallserver_setkey("USEZLIB"' "$tmp/nodl.i" ||
+command grep -q 'smallserver_setkey("USEZLIB"' "$tmp/nodl.i" ||
     fail "the preprocessed htsweb.c carries no key at all, so the check below proves nothing"
 
-! grep -q 'smallserver_setkey("DLOPEN"' "$tmp/nodl.i" ||
+! command grep -q 'smallserver_setkey("DLOPEN"' "$tmp/nodl.i" ||
     fail "a build without dlopen still publishes DLOPEN=1 to the web UI"
 
 echo "ok: the @ set, the platform name and the dlopen key all report what the build did"

--- a/tests/433_local-status-line.test
+++ b/tests/433_local-status-line.test
@@ -55,7 +55,7 @@ assert_refused() { # assert_refused CASE MSG CODE
     test ! -f "$(mirrored "$case")" ||
         fail "$case: a malformed status line was mirrored"
     logtext=$(cat "$out/$case/hts-log.txt")
-    grep -qF "$want" <<<"$logtext" ||
+    command grep -qF "$want" <<<"$logtext" ||
         fail_dump "$case: log lacks [$want]" "$out/$case/hts-log.txt"
 }
 
@@ -102,7 +102,7 @@ assert_accepted noversion 200 OK text/html
 # human, and the code before it still stands.
 assert_refused lonecr "Not Found" 404
 lonecrlog=$(cat "$out/lonecr/hts-log.txt")
-! grep -qF "INJECTED" <<<"$lonecrlog" ||
+! command grep -qF "INJECTED" <<<"$lonecrlog" ||
     fail_dump "lonecr: the reason phrase forged a log line" \
         "$out/lonecr/hts-log.txt"
 

--- a/tests/52_local-socks5.test
+++ b/tests/52_local-socks5.test
@@ -48,10 +48,10 @@ start_server() {
         >"$ports" 2>"$dir/server.err" &
     pids="$pids $!"
     for _ in $(seq 1 100); do
-        grep -q "^ready" "$ports" 2>/dev/null && break
+        command grep -q "^ready" "$ports" 2>/dev/null && break
         sleep 0.1
     done
-    grep -q "^ready" "$ports" 2>/dev/null ||
+    command grep -q "^ready" "$ports" 2>/dev/null ||
         fail_dump "server ($mode) did not start" "$dir/server.err"
     tls_port=$(awk '/^TLS/{print $2}' "$ports")
     http_port=$(awk '/^HTTP/{print $2}' "$ports")
@@ -85,12 +85,12 @@ ok="$tmpdir/ok"
 start_server "$ok" ok
 
 run_crawl "$ok/out" "https://${host}:${tls_port}/" "socks5://127.0.0.1:${socks_port}"
-grep -rq "ORIGIN-PAGE-563" "$ok/out" ||
+command grep -rq "ORIGIN-PAGE-563" "$ok/out" ||
     fail_dump "origin page not downloaded through the socks proxy" "$ok/out.log" "$ok/server.err"
-grep -q "^ATYP domain ${host}\$" "$ok/socks.log" ||
+command grep -q "^ATYP domain ${host}\$" "$ok/socks.log" ||
     fail_dump "proxy did not receive ATYP=domain ${host} (no remote DNS)" "$ok/socks.log"
 # a client that resolved locally would have sent an address, not a name
-grep -q "^ATYP ipv4" "$ok/socks.log" && {
+command grep -q "^ATYP ipv4" "$ok/socks.log" && {
     echo "FAIL: httrack resolved locally and sent an IPv4 to the proxy" >&2
     cat "$ok/socks.log" >&2
     exit 1
@@ -100,13 +100,13 @@ echo "OK: https tunneled through socks5 with remote DNS"
 # --- plain http over socks --------------------------------------------------
 : >"$ok/origin-headers.log" # the https crawl above also logged a request line
 run_crawl "$ok/outh" "http://${host}:${http_port}/" "socks5://127.0.0.1:${socks_port}"
-grep -rq "ORIGIN-PAGE-563" "$ok/outh" ||
+command grep -rq "ORIGIN-PAGE-563" "$ok/outh" ||
     fail_dump "plain http not tunneled through the socks proxy" "$ok/outh.log" "$ok/socks.log"
 # the tunneled request is origin-form, as on a direct connection: the http-proxy
 # absolute URI would reach the origin as "GET http://host/"
-grep -q "^REQUEST GET / " "$ok/origin-headers.log" ||
+command grep -q "^REQUEST GET / " "$ok/origin-headers.log" ||
     fail_dump "tunneled request is not origin-form" "$ok/origin-headers.log"
-grep -q "^REQUEST GET http" "$ok/origin-headers.log" && {
+command grep -q "^REQUEST GET http" "$ok/origin-headers.log" && {
     echo "FAIL: absolute-URI request sent through the socks tunnel" >&2
     cat "$ok/origin-headers.log" >&2
     exit 1
@@ -123,7 +123,7 @@ start_server "$ka" ok
 run_crawl "$ka/out" "http://${host}:${http_port}/" "socks5://127.0.0.1:${socks_port}" -r3 -c1
 missing=0
 for i in 1 2 3 4 5; do
-    grep -rq "SUBPAGE-563 /p${i}.html" "$ka/out" || missing=1
+    command grep -rq "SUBPAGE-563 /p${i}.html" "$ka/out" || missing=1
 done
 test "$missing" -eq 0 ||
     fail_dump "a keep-alive subpage was lost (re-handshake corrupted the reused socket)" "$ka/out.log" "$ka/socks.log"
@@ -141,18 +141,18 @@ run_crawl "$auth/out" "http://${host}:${http_port}/" \
     "socks5://user:secret@127.0.0.1:${socks_port}"
 # name a rejected version byte here: the crawl check below only knows the
 # handshake failed, not why
-grep -q "^AUTHVER-BAD" "$auth/socks.log" && {
+command grep -q "^AUTHVER-BAD" "$auth/socks.log" && {
     echo "FAIL: sub-negotiation version was not RFC 1929's 0x01" >&2
     cat "$auth/socks.log" >&2
     exit 1
 }
-grep -rq "ORIGIN-PAGE-563" "$auth/out" ||
+command grep -rq "ORIGIN-PAGE-563" "$auth/out" ||
     fail_dump "origin not downloaded through the authenticated socks proxy" "$auth/out.log" "$auth/socks.log"
-grep -q "^METHOD userpass\$" "$auth/socks.log" ||
+command grep -q "^METHOD userpass\$" "$auth/socks.log" ||
     fail_dump "user/pass method not negotiated (auth ignored)" "$auth/socks.log"
-grep -q "^AUTH user secret\$" "$auth/socks.log" ||
+command grep -q "^AUTH user secret\$" "$auth/socks.log" ||
     fail_dump "wrong socks credentials sent" "$auth/socks.log"
-grep -qi "secret\|proxy-authorization" "$auth/origin-headers.log" && {
+command grep -qi "secret\|proxy-authorization" "$auth/origin-headers.log" && {
     echo "FAIL: socks credentials leaked into the origin request" >&2
     cat "$auth/origin-headers.log" >&2
     exit 1
@@ -165,7 +165,7 @@ start_server "$ref" refuse
 rc=0
 run_crawl "$ref/out" "https://${host}:${tls_port}/" "socks5://127.0.0.1:${socks_port}" || rc=$?
 test "$rc" -ne "$HANG_RC" || fail "crawl hung on a refusing socks proxy"
-grep -rq "ORIGIN-PAGE-563" "$ref/out" 2>/dev/null && {
+command grep -rq "ORIGIN-PAGE-563" "$ref/out" 2>/dev/null && {
     echo "FAIL: refusing proxy unexpectedly served the page" >&2
     exit 1
 }
@@ -177,7 +177,7 @@ start_server "$trunc" truncate
 rc=0
 run_crawl "$trunc/out" "https://${host}:${tls_port}/" "socks5://127.0.0.1:${socks_port}" || rc=$?
 test "$rc" -ne "$HANG_RC" || fail "crawl hung on a truncated socks reply (bounded read missing)"
-grep -rq "ORIGIN-PAGE-563" "$trunc/out" 2>/dev/null && {
+command grep -rq "ORIGIN-PAGE-563" "$trunc/out" 2>/dev/null && {
     echo "FAIL: truncated-reply proxy unexpectedly served the page" >&2
     exit 1
 }

--- a/tests/56_local-proxy-noleak.test
+++ b/tests/56_local-proxy-noleak.test
@@ -61,18 +61,18 @@ HTTRACK_DEBUG_RESOLVE="decoyhost:127.0.0.2,127.0.0.1" \
 log="$out/hts-log.txt"
 
 # the origin must have seen no connection (no leak/bypass)
-if grep -qE '"(GET|POST|HEAD|CONNECT) ' "$SRV_LOG"; then
+if command grep -qE '"(GET|POST|HEAD|CONNECT) ' "$SRV_LOG"; then
     echo "FAIL: origin was contacted directly, bypassing the proxy"
     cat "$SRV_LOG"
     exit 1
 fi
 
 # the crawl must fail at the proxy (proves it really tried the proxy, not a no-op)
-grep -q 'Connect Error' "$log" ||
+command grep -q 'Connect Error' "$log" ||
     fail_dump "expected a proxy connect error" "$log"
 
 # and it must not have tried an origin-address fallback under the proxy
-if grep -q "trying next address" "$log"; then
+if command grep -q "trying next address" "$log"; then
     echo "FAIL: fell back to an origin address under a proxy"
     cat "$log"
     exit 1

--- a/tests/57_local-proxy-connect.test
+++ b/tests/57_local-proxy-connect.test
@@ -41,10 +41,10 @@ start_server() {
         >"$ports" 2>"$dir/server.err" &
     pids="$pids $!"
     for _ in $(seq 1 100); do
-        grep -q "^ready" "$ports" 2>/dev/null && break
+        command grep -q "^ready" "$ports" 2>/dev/null && break
         sleep 0.1
     done
-    grep -q "^ready" "$ports" 2>/dev/null ||
+    command grep -q "^ready" "$ports" 2>/dev/null ||
         fail_dump "server ($mode) did not start" "$dir/server.err"
     origin_port=$(awk '/^ORIGIN/{print $2}' "$ports")
     proxy_port=$(awk '/^PROXY/{print $2}' "$ports")
@@ -74,13 +74,13 @@ start_server "$ok" ok
 
 # 1. page fetched through a CONNECT tunnel, request delivered origin-form
 run_crawl "$ok/out" "connect://127.0.0.1:${proxy_port}" "$origin_port"
-grep -rq "ORIGIN-PAGE-564" "$ok/out" ||
+command grep -rq "ORIGIN-PAGE-564" "$ok/out" ||
     fail_dump "origin page not downloaded through the CONNECT tunnel" "$ok/out.log"
-grep -q "^CONNECT 127.0.0.1:${origin_port} " "$ok/proxy.log" ||
+command grep -q "^CONNECT 127.0.0.1:${origin_port} " "$ok/proxy.log" ||
     fail_dump "proxy never received a CONNECT for the plain-http origin" "$ok/proxy.log"
-grep -q "^GET / HTTP/1" "$ok/origin-headers.log" ||
+command grep -q "^GET / HTTP/1" "$ok/origin-headers.log" ||
     fail_dump "origin did not see an origin-form request line" "$ok/origin-headers.log"
-if grep -q "^GET http://" "$ok/origin-headers.log"; then
+if command grep -q "^GET http://" "$ok/origin-headers.log"; then
     echo "FAIL: absolute-URI request leaked through the tunnel to the origin" >&2
     exit 1
 fi
@@ -92,7 +92,7 @@ echo "OK: plain http tunneled origin-form through CONNECT"
 # makes this log ":443" and fail.
 : >"$ok/proxy.log"
 run_crawl "$ok/out_port" "connect://127.0.0.1:${proxy_port}" "" "http://127.0.0.1/" || true
-grep -q "^CONNECT 127.0.0.1:80 " "$ok/proxy.log" ||
+command grep -q "^CONNECT 127.0.0.1:80 " "$ok/proxy.log" ||
     fail_dump "portless http origin did not CONNECT to the default port 80" "$ok/proxy.log"
 echo "OK: portless http origin tunnels to the default port 80"
 
@@ -102,11 +102,11 @@ echo "OK: portless http origin tunnels to the default port 80"
 : >"$ok/proxy.log"
 : >"$ok/origin-headers.log"
 run_crawl "$ok/out_plain" "127.0.0.1:${proxy_port}" "$origin_port" || true
-grep -rq "ORIGIN-PAGE-564" "$ok/out_plain" && {
+command grep -rq "ORIGIN-PAGE-564" "$ok/out_plain" && {
     echo "FAIL: absolute-URI form unexpectedly fetched through a CONNECT-only proxy" >&2
     exit 1
 }
-grep -q "^GET http://127.0.0.1:${origin_port}/" "$ok/proxy.log" ||
+command grep -q "^GET http://127.0.0.1:${origin_port}/" "$ok/proxy.log" ||
     fail_dump "a plain proxy should have received an absolute-URI GET" "$ok/proxy.log"
 echo "OK: absolute-URI form (no connect://) rejected by the CONNECT-only proxy"
 
@@ -114,12 +114,12 @@ echo "OK: absolute-URI form (no connect://) rejected by the CONNECT-only proxy"
 : >"$ok/proxy.log"
 : >"$ok/origin-headers.log"
 run_crawl "$ok/out2" "connect://user:secret@127.0.0.1:${proxy_port}" "$origin_port"
-grep -rq "ORIGIN-PAGE-564" "$ok/out2" || fail "origin page not downloaded through the authenticated proxy"
+command grep -rq "ORIGIN-PAGE-564" "$ok/out2" || fail "origin page not downloaded through the authenticated proxy"
 got=$(awk '/^AUTH Basic /{print $3}' "$ok/proxy.log" | head -1)
 # base64("user:secret"); compared literally to stay portable (no base64 -d)
 test "$got" == "dXNlcjpzZWNyZXQ=" ||
     fail_dump "Proxy-Authorization not carried on CONNECT (got '$got')" "$ok/proxy.log"
-if grep -qi "proxy-authorization" "$ok/origin-headers.log"; then
+if command grep -qi "proxy-authorization" "$ok/origin-headers.log"; then
     echo "FAIL: proxy credentials leaked to the origin through the tunnel" >&2
     exit 1
 fi
@@ -132,7 +132,7 @@ start_server "$flood" flood
 rc=0
 run_crawl "$flood/out" "connect://127.0.0.1:${proxy_port}" "$origin_port" || rc=$?
 test "$rc" -ne "$HANG_RC" || fail "crawl hung on a flooding proxy (bounded read missing)"
-grep -rq "ORIGIN-PAGE-564" "$flood/out" 2>/dev/null && {
+command grep -rq "ORIGIN-PAGE-564" "$flood/out" 2>/dev/null && {
     echo "FAIL: flooding proxy unexpectedly served the page" >&2
     exit 1
 }

--- a/tests/59_local-tls-stall.test
+++ b/tests/59_local-tls-stall.test
@@ -54,7 +54,7 @@ if test "$wall" -ge 30 || test "$wall" -lt 3; then
     cat "$tmpdir/log" >&2
     exit 1
 fi
-grep -q 'Handshake Time Out' "$tmpdir/crawl1/hts-log.txt" ||
+command grep -q 'Handshake Time Out' "$tmpdir/crawl1/hts-log.txt" ||
     fail_dump "crawl ended in ${wall}s but not on a handshake timeout" "$tmpdir/crawl1/hts-log.txt"
 echo "OK: stalled TLS handshake reaped by --timeout after ${wall}s"
 

--- a/tests/60_crawl-log-salvage.test
+++ b/tests/60_crawl-log-salvage.test
@@ -30,9 +30,9 @@ art="${TMPDIR}/artifact.log"
 printf '[running httrack ...] ..\t' >"$art"
 dump_crawl_logs >>"$art"
 
-grep -qF "$verdict" "$art" || fail "hts-log.txt verdict not salvaged"
-grep -qF "httrack stdout marker" "$art" || fail "httrack stdout not salvaged"
-grep -q '^--- .*hts-log.txt' "$art" || fail "dump glued its header onto the unterminated line"
+command grep -qF "$verdict" "$art" || fail "hts-log.txt verdict not salvaged"
+command grep -qF "httrack stdout marker" "$art" || fail "httrack stdout not salvaged"
+command grep -q '^--- .*hts-log.txt' "$art" || fail "dump glued its header onto the unterminated line"
 
 # Cleared, so the next timing-out test cannot re-report this crawl as its own.
 test ! -d "$d" || fail "salvaged tmpdir left behind"

--- a/tests/61_webhttrack-locale.test
+++ b/tests/61_webhttrack-locale.test
@@ -19,9 +19,9 @@ test -r "${distdir}/lang.indexes" || fail "no ${distdir}/lang.indexes"
 funcs=$(sed -n '/^function lang_index/,/^}/p' "${script}")
 # End on the next section, not a blank line: a blank line grown inside the block
 # would truncate the lift and silently stop testing everything below it.
-grep -q '^# Find the browser' "${script}" || fail "locale block terminator moved in ${script}"
+command grep -q '^# Find the browser' "${script}" || fail "locale block terminator moved in ${script}"
 block=$(sed -n '/^# Locale/,/^# Find the browser/p' "${script}" | sed '$d')
-grep -q 'LANGN=.*lang_index' <<<"${block}" || fail "could not lift the whole locale block from ${script}"
+command grep -q 'LANGN=.*lang_index' <<<"${block}" || fail "could not lift the whole locale block from ${script}"
 
 # Run the lifted block against whatever locale vars the caller exported.
 run_block() {

--- a/tests/62_lang-integrity.test
+++ b/tests/62_lang-integrity.test
@@ -337,7 +337,7 @@ LC_ALL=C awk -v keys="$keys" '
 # lang.def, so a reword on one side alone silently drifts the two apart (#1117).
 for scope in "Mirror %s and every host below it" "Ignore %s and every host below it"; do
     for f in "$eng" "$def" "$top_srcdir/src/httrack.c"; do
-        if ! LC_ALL=C grep -qF "$scope" "$f"; then
+        if ! LC_ALL=C command grep -qF "$scope" "$f"; then
             echo "${f##*/}: missing the wizard scope answer \"$scope\""
             fail=1
         fi
@@ -481,7 +481,7 @@ fi
 # One probe per letter the catalogs actually got wrong, so a widened set
 # also fails loudly rather than only through the pin above.
 printf 'Five bad\na\\Pb\\Dc\\Kd\\he\\sf\n' >"$tmp/letters.txt"
-nbad=$(unknown_escapes "$tmp/letters.txt" letters.txt | LC_ALL=C grep -c 'is not an escape') || true
+nbad=$(unknown_escapes "$tmp/letters.txt" letters.txt | LC_ALL=C command grep -c 'is not an escape') || true
 if [ "${nbad:-0}" -ne 5 ]; then
     echo "the escape check named ${nbad:-0} of 5 bad escape letters"
     exit 1
@@ -913,7 +913,7 @@ if [ "$ncmp" -lt $((nfiles * nlist * 9 / 10)) ]; then
 fi
 # An unknown ${LANG_*} renders as nothing rather than erroring, so check that
 # every macro the templates interpolate, in any wrapper form, resolves.
-LC_ALL=C grep -oh '[$]{[^}]*LANG_[A-Za-z0-9_]*}' "$top_srcdir"/html/server/*.html |
+LC_ALL=C command grep -oh '[$]{[^}]*LANG_[A-Za-z0-9_]*}' "$top_srcdir"/html/server/*.html |
     LC_ALL=C sed 's|.*\(LANG_[A-Za-z0-9_]*\)}|\1|' | LC_ALL=C sort -u >"$tmp/used"
 nused=$(wc -l <"$tmp/used")
 if [ "$nused" -lt 100 ]; then

--- a/tests/65_port-siblings.test
+++ b/tests/65_port-siblings.test
@@ -36,10 +36,10 @@ websrv() {
 
 web_refused() {
     websrv "$1"
-    grep -q "couldn't set the port number" "$tmp/web.log" ||
+    command grep -q "couldn't set the port number" "$tmp/web.log" ||
         fail "#614: htsserver --port '$1' not refused"
     # it must not have reached the listen socket on some other port
-    ! grep -q "^URL=" "$tmp/web.log" ||
+    ! command grep -q "^URL=" "$tmp/web.log" ||
         fail "#614: htsserver --port '$1' listened anyway"
 }
 
@@ -56,16 +56,16 @@ web_accepted() {
     local pid=$!
     test -n "$had_m" || shell_is_msys || set +m
     local waited=0
-    until grep -qE "^URL=http://.*:$port/|couldn't set the port number|Unable to initialize a temporary server" "$tmp/web.log"; do
+    until command grep -qE "^URL=http://.*:$port/|couldn't set the port number|Unable to initialize a temporary server" "$tmp/web.log"; do
         test "$waited" -lt 20 || break
         sleep 1
         waited=$((waited + 1))
     done
     kill_tree "$pid"
     wait "$pid" 2>/dev/null || true
-    ! grep -q "couldn't set the port number" "$tmp/web.log" ||
+    ! command grep -q "couldn't set the port number" "$tmp/web.log" ||
         fail "#614: htsserver --port '$port' wrongly refused"
-    grep -qE "^URL=http://.*:$port/|Unable to initialize a temporary server" "$tmp/web.log" ||
+    command grep -qE "^URL=http://.*:$port/|Unable to initialize a temporary server" "$tmp/web.log" ||
         fail "#614: htsserver --port '$port' never reached the listener"
 }
 
@@ -88,7 +88,7 @@ web_exits() {
 
     : >"$tmp/exit.log"
     run_with_timeout 30 htsserver "$tmp" "$@" >"$tmp/exit.log" 2>&1 || rc=$?
-    grep -q "^EXITED" "$tmp/exit.log" ||
+    command grep -q "^EXITED" "$tmp/exit.log" ||
         fail "#753: htsserver ${*:-(no options)} never finished serving"
     # exactly 1, not merely "not 124": a crash or an assertf abort also escapes
     # the wait, and would otherwise read as a pass
@@ -107,13 +107,13 @@ web_exits --ppid $$
 
 proxy_refused() {
     run_with_timeout 3 proxytrack "127.0.0.1:$1" 127.0.0.1:3130 >"$tmp/pt.log" 2>&1 || true
-    grep -q "^usage:" "$tmp/pt.log" ||
+    command grep -q "^usage:" "$tmp/pt.log" ||
         fail "#614: proxytrack port '$1' not refused"
 }
 
 proxy_accepted() {
     run_with_timeout 3 proxytrack "127.0.0.1:$1" 127.0.0.1:3130 >"$tmp/pt.log" 2>&1 || true
-    ! grep -q "^usage:" "$tmp/pt.log" ||
+    ! command grep -q "^usage:" "$tmp/pt.log" ||
         fail "#614: proxytrack port '$1' wrongly refused"
 }
 

--- a/tests/66_engine-port80-strip.test
+++ b/tests/66_engine-port80-strip.test
@@ -10,4 +10,4 @@ set -euo pipefail
 # (#638): an explicit :80 on https/ftp stays, :443/:21 strip under their own
 # scheme. All assertions live in the engine self-test.
 out=$(httrack -O /dev/null -#test=stripport)
-grep -q "stripport self-test OK" <<<"$out"
+command grep -q "stripport self-test OK" <<<"$out"

--- a/tests/71_local-crange-repaircache.test
+++ b/tests/71_local-crange-repaircache.test
@@ -72,7 +72,7 @@ echo "OK (terminated)"
 
 # The repair path must actually have run, else this is just a copy of test 48.
 printf '[cache repair fired] ..\t'
-grep -q 'damaged cache' "${out}/hts-log.txt" 2>/dev/null || fail "repair path did not run; damage was ineffective"
+command grep -q 'damaged cache' "${out}/hts-log.txt" 2>/dev/null || fail "repair path did not run; damage was ineffective"
 echo "OK"
 
 blob=$(find "$out" -name blob.bin 2>/dev/null | head -1)

--- a/tests/72_watchdog-crawl.test
+++ b/tests/72_watchdog-crawl.test
@@ -14,13 +14,13 @@ elapsed=$((SECONDS - start))
 # Skip (not fail) on causes unrelated to the watchdog: no python3/server, or a
 # port-announce race (flaky-13).
 test "$rc" -ne 77 || skip "local crawl prerequisites missing"
-! grep -q "could not discover server port" <<<"$out" || skip "server port announce raced"
+! command grep -q "could not discover server port" <<<"$out" || skip "server port announce raced"
 
 # The message prints only on the 124 reap, and 25s < the engine's --timeout=30, so
 # together they pin the fast exit on the 3s watchdog, not httrack giving up.
 test "$rc" -ne 0 || fail "stalled crawl reported success"
 test "$elapsed" -lt 25 || fail "watchdog fired late (${elapsed}s)"
-grep -q "watchdog fired" <<<"$out" ||
+command grep -q "watchdog fired" <<<"$out" ||
     fail "crawl failed but not via the watchdog: $out"
 
 echo "crawl watchdog OK (reaped in ${elapsed}s)"

--- a/tests/77_webhttrack-redirect.test
+++ b/tests/77_webhttrack-redirect.test
@@ -64,11 +64,11 @@ X-Injected: pwned' "${sid}") || fail "no response to a CRLF redirect value"
 htsserver_stop
 # Here-string, not a pipe: grep -q SIGPIPEs the producer on the first match, and
 # pipefail then turns the hit into a silent pass.
-grep -qi 'X-Injected' <<<"${resp}" &&
+command grep -qi 'X-Injected' <<<"${resp}" &&
     fail "CRLF in the redirect value reached the response"
-test "$(grep -ci '^Location:' <<<"${resp}")" -eq 0 ||
+test "$(command grep -ci '^Location:' <<<"${resp}")" -eq 0 ||
     fail "CRLF redirect still emitted a Location header"
-test "$(grep -c '^HTTP/1\.' <<<"${resp}")" -eq 1 ||
+test "$(command grep -c '^HTTP/1\.' <<<"${resp}")" -eq 1 ||
     fail "CRLF redirect did not yield exactly one status line"
 
 # Loopback unless asked otherwise. Assert the socket, not the announcement.
@@ -98,7 +98,7 @@ fi
 # An empty --bind must not quietly fall back to every interface. Bounded: if it
 # were accepted the server would listen instead of exiting.
 run_with_timeout 15 htsserver "${HTS_DISTDIR}/" --bind "" >"${bindlog}" 2>&1 || true
-grep -q -- "--bind needs an address" "${bindlog}" ||
+command grep -q -- "--bind needs an address" "${bindlog}" ||
     fail "empty --bind not refused: $(<"${bindlog}")"
 
 test -z "${unobserved}" || skip "${unobserved}: the listen-address half never ran"

--- a/tests/78_webhttrack-sid.test
+++ b/tests/78_webhttrack-sid.test
@@ -24,7 +24,7 @@ test "${#sid}" -eq 32 || fail "did not scrape a 32-hex sid from the page (got '$
 # with a reply that is visible in the headers. Matched from a here-string, not a
 # pipe: grep -q SIGPIPEs the producer, and pipefail then buries the verdict.
 resp=$(htsserver_post "sid=${sid}&redirect=/accepted")
-grep -q '^Location: /accepted' <<<"${resp}" ||
+command grep -q '^Location: /accepted' <<<"${resp}" ||
     fail "a body carrying the correct sid was refused"
 
 # Refuse: missing and wrong. A missing one is the regression under test — the
@@ -33,12 +33,12 @@ grep -q '^Location: /accepted' <<<"${resp}" ||
 for bad in "redirect=/nosid" "sid=&redirect=/empty" \
     "sid=00000000000000000000000000000000&redirect=/wrong"; do
     resp=$(htsserver_post "${bad}")
-    grep -q '^Location:' <<<"${resp}" &&
+    command grep -q '^Location:' <<<"${resp}" &&
         fail "body accepted without a valid sid: ${bad}"
     # A refusal has to be a well-formed reply, not a headerless fragment: the
     # release build used to emit only Content-length, which reads as a protocol
     # error to any client and hides the reason.
-    grep -q '^HTTP/1\.0 403 ' <<<"${resp}" ||
+    command grep -q '^HTTP/1\.0 403 ' <<<"${resp}" ||
         fail "refusal was not a 403: ${bad}"
 done
 
@@ -49,20 +49,20 @@ done
 store_page() {
     # a dead probe or a non-page reply must not read as "the store was not written"
     page=$(htsserver_get /server/step3.html) || fail "the key store probe failed"
-    grep -q '^HTTP/1\.0 200 ' <<<"${page}" ||
+    command grep -q '^HTTP/1\.0 200 ' <<<"${page}" ||
         fail "the key store probe did not answer: '$(head -1 <<<"${page}")'"
 }
 
 htsserver_post "projname=UNAUTHWRITE" >/dev/null 2>&1 || true
 store_page
-grep -q 'UNAUTHWRITE' <<<"${page}" &&
+command grep -q 'UNAUTHWRITE' <<<"${page}" &&
     fail "a body without a valid sid was written to the key store"
 
 # Paired accept case: without it the assertion above passes even if the server
 # simply ignores every body, which would prove nothing.
 htsserver_post "sid=${sid}&projname=AUTHWRITE" >/dev/null 2>&1 || true
 store_page
-grep -q 'AUTHWRITE' <<<"${page}" ||
+command grep -q 'AUTHWRITE' <<<"${page}" ||
     fail "a body carrying the correct sid was not written to the key store"
 
 echo "PASS"

--- a/tests/79_local-proxytrack-webdav-mime.test
+++ b/tests/79_local-proxytrack-webdav-mime.test
@@ -39,9 +39,9 @@ start_proxytrack "$dir/pt" launch_proxytrack
 "$curl" -s --max-time 30 -X PROPFIND -H "Depth: 1" \
     "http://127.0.0.1:$proxyport/webdav/example.com/" >"$dir/resp.xml"
 
-grep -q '<getcontenttype>application/octet-stream</getcontenttype>' "$dir/resp.xml" ||
+command grep -q '<getcontenttype>application/octet-stream</getcontenttype>' "$dir/resp.xml" ||
     fail_dump "missing Content-Type did not fall back to application/octet-stream" "$dir/resp.xml"
-grep -q '<getlastmodified>Wed, 01 Jan 2025 00:00:00 GMT</getlastmodified>' "$dir/resp.xml" ||
+command grep -q '<getlastmodified>Wed, 01 Jan 2025 00:00:00 GMT</getlastmodified>' "$dir/resp.xml" ||
     fail_dump "missing Last-Modified did not fall back to the index timestamp" "$dir/resp.xml"
 
 echo "OK: WebDAV listing falls back correctly for an entry with no Content-Type/Last-Modified"

--- a/tests/80_engine-crash-symbolize.test
+++ b/tests/80_engine-crash-symbolize.test
@@ -23,9 +23,9 @@ rc=0
 run_with_timeout 60 httrack -#test=strsafe overflow "$overflow" >"$out" 2>&1 || rc=$?
 test "$rc" -ne 124 || fail "the crash handler did not finish within the deadline"
 
-grep -q '^Caught signal ' "$out" ||
+command grep -q '^Caught signal ' "$out" ||
     fail_dump "no 'Caught signal' line:" "$out"
-if grep -q 'No stack trace available on this OS' "$out"; then
+if command grep -q 'No stack trace available on this OS' "$out"; then
     echo "no backtrace() on this platform; skipping" >&2
     exit 77
 fi
@@ -33,14 +33,14 @@ fi
 # anywhere else an empty trace is the regression this test exists to catch.
 case "$(uname -m)" in
 arm | armv*)
-    if grep -q 'No stack trace available' "$out"; then
+    if command grep -q 'No stack trace available' "$out"; then
         echo "no unwind tables in this ARM build; skipping" >&2
         exit 77
     fi
     ;;
 esac
 # Unconditional and first: symbolizing must never cost the raw trace.
-grep -q "$rawframe" "$out" ||
+command grep -q "$rawframe" "$out" ||
     fail_dump "raw module+offset frames are gone:" "$out"
 
 build_names_frames || skip "built without <spawn.h>, so frames stay module+offset"
@@ -63,7 +63,7 @@ while read -r mod off; do
     resolved=$((resolved + 1))
     addr2line -Cfip -e "$mod" "$off" 2>/dev/null >>"$oracle" || true
 done <"$frames"
-if ! grep -qE 'st_strsafe|strcpy_safe_' "$oracle"; then
+if ! command grep -qE 'st_strsafe|strcpy_safe_' "$oracle"; then
     # Which stage came up empty, because the skip alone names no suspect and
     # this is the form the emulated s390x leg has been reporting.
     echo "parsed $(wc -l <"$frames") frames, resolved ${resolved} of them to a file" >&2
@@ -71,7 +71,7 @@ if ! grep -qE 'st_strsafe|strcpy_safe_' "$oracle"; then
     dump_file "$oracle"
     # Under qemu-user the trace stops at the vdso trampoline, so the engine
     # frames are missing rather than unnamed: say which of the two it is.
-    if grep -q 'sigreturn' "$out"; then
+    if command grep -q 'sigreturn' "$out"; then
         skip "the unwinder stopped at the signal frame, so no engine frame reached the trace"
     fi
     skip "addr2line names no hidden symbol in this build"
@@ -80,8 +80,8 @@ fi
 # The payload. Dropping the raw frames first is what makes it specific: both
 # names are static, so .dynsym could never have carried them. Not anchored on
 # the "0xOFF:" line, the inline chain puts the name on either half.
-symbolized=$(grep -v "$rawframe" "$out" || true)
-grep -qE 'st_strsafe|strcpy_safe_' <<<"$symbolized" ||
+symbolized=$(command grep -v "$rawframe" "$out" || true)
+command grep -qE 'st_strsafe|strcpy_safe_' <<<"$symbolized" ||
     fail_dump "the handler did not name the hidden frames:" "$out"
 
 # Opt-out: raw trace kept, nothing spawned.
@@ -90,7 +90,7 @@ rc=0
 run_with_timeout 60 httrack -#test=strsafe overflow "$overflow" >"$raw" 2>&1 || rc=$?
 unset HTTRACK_NO_SYMBOLIZE
 test "$rc" -ne 124 || fail "the opt-out run did not finish within the deadline"
-grep -q "$rawframe" "$raw" ||
+command grep -q "$rawframe" "$raw" ||
     fail_dump "the opt-out lost the raw trace:" "$raw"
-! grep -q '^0x[0-9a-f]*: ' "$raw" ||
+! command grep -q '^0x[0-9a-f]*: ' "$raw" ||
     fail_dump "the opt-out still symbolized:" "$raw"

--- a/tests/82_webhttrack-browse-links.test
+++ b/tests/82_webhttrack-browse-links.test
@@ -16,7 +16,7 @@ htsserver_require
 # Control: a glob matching nothing would leave the grep below with no input.
 pages=("${distdir}"/html/server/*.html)
 test "${#pages[@]}" -ge 20 || fail "only ${#pages[@]} GUI pages under ${distdir}"
-bad=$(grep -l 'file://' "${pages[@]}" || true)
+bad=$(command grep -l 'file://' "${pages[@]}" || true)
 test -z "${bad}" || fail "file: link left in: ${bad}"
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/webhttrack_browse.XXXXXX") || fail "no tmpdir"

--- a/tests/83_webhttrack-argescape.test
+++ b/tests/83_webhttrack-argescape.test
@@ -30,48 +30,48 @@ cmdline=$(htsserver_get /server/step4.html |
     sed -n '/<textarea name="command"/,/<\/textarea>/p')
 
 # Control: without the fields in the page every assertion below is vacuous.
-grep -q -- '--user-agent' <<<"${cmdline}" ||
+command grep -q -- '--user-agent' <<<"${cmdline}" ||
     fail "no --user-agent in the generated command line (probe blind)"
 
 # A plain value is passed through untouched: the escaping must not mangle the
 # ordinary case.
-grep -qF -- '--path "/tmp/p/plain proj"' <<<"${cmdline}" ||
+command grep -qF -- '--path "/tmp/p/plain proj"' <<<"${cmdline}" ||
     fail "a plain quoted value was not passed through: ${cmdline}"
 
 # The quote is escaped, so the split keeps it inside the value...
-grep -qF -- '--user-agent "Moz\" -V \"touch /tmp/pwn"' <<<"${cmdline}" ||
+command grep -qF -- '--user-agent "Moz\" -V \"touch /tmp/pwn"' <<<"${cmdline}" ||
     fail "the quote in the user-agent was not escaped: ${cmdline}"
 
 # ...and the raw form, which would end the argument and hand -V to the option
 # parser, is gone.
-grep -qF -- '--user-agent "Moz" -V "touch' <<<"${cmdline}" &&
+command grep -qF -- '--user-agent "Moz" -V "touch' <<<"${cmdline}" &&
     fail "the user-agent still closes its argument early: ${cmdline}"
 
 # A backslash is escaped too, or the split would eat it along with the quote
 # that follows.
-grep -qF -- '--footer "a\\b\"c"' <<<"${cmdline}" ||
+command grep -qF -- '--footer "a\\b\"c"' <<<"${cmdline}" ||
     fail "the backslash in the footer was not escaped: ${cmdline}"
 
 # The url and filter fields sit outside quotes, where a backslash cannot escape
 # anything: one quote there flips the parity of every quote after it, so the
 # escaping above would protect nothing. They must not emit a raw quote at all.
-grep -qF -- 'http://x/a%22b' <<<"${cmdline}" ||
+command grep -qF -- 'http://x/a%22b' <<<"${cmdline}" ||
     fail "the quote in the url field was not neutralised: ${cmdline}"
-grep -qF -- '+*.png%22' <<<"${cmdline}" ||
+command grep -qF -- '+*.png%22' <<<"${cmdline}" ||
     fail "the quote in the filter field was not neutralised: ${cmdline}"
-grep -qF -- 'http://x/a"b' <<<"${cmdline}" &&
+command grep -qF -- 'http://x/a"b' <<<"${cmdline}" &&
     fail "the url field still emits a raw quote: ${cmdline}"
 
 # The whole textarea is HTML too: a field holding its closing tag must come back
 # as entities, or the value lands in the page as markup.
-grep -qF -- '+*.png%22&lt;/textarea&gt;' <<<"${cmdline}" ||
+command grep -qF -- '+*.png%22&lt;/textarea&gt;' <<<"${cmdline}" ||
     fail "the filter field was not HTML-escaped: ${cmdline}"
-grep -qF -- '+*.png%22</textarea>' <<<"${cmdline}" &&
+command grep -qF -- '+*.png%22</textarea>' <<<"${cmdline}" &&
     fail "the filter field still closes the textarea: ${cmdline}"
 
 # The sitemap url is quoted like the user-agent, so it takes the same escape.
 # Its box is ticked: a cleared one gates the value out.
-grep -qF -- '--sitemap-url "http://x/s.xml\"b"' <<<"${cmdline}" ||
+command grep -qF -- '--sitemap-url "http://x/s.xml\"b"' <<<"${cmdline}" ||
     fail "the quote in the sitemap url was not escaped: ${cmdline}"
 
 echo "PASS"

--- a/tests/84_webhttrack-mirror-verbatim.test
+++ b/tests/84_webhttrack-mirror-verbatim.test
@@ -46,16 +46,16 @@ printf 'Hostile mirrored page.\nsid=${_sid} copy=${sid}\ntrailing backslash: \\\
     >"${mirror}"
 
 htsserver_client --path /website/hostile.html --head-file "${hdr}" --body-file "${body}"
-grep -q '^HTTP/1\.0 200 ' "${hdr}" || fail "mirrored page not served: $(head -1 "${hdr}")"
-grep -qF "${sid}" "${body}" &&
+command grep -q '^HTTP/1\.0 200 ' "${hdr}" || fail "mirrored page not served: $(head -1 "${hdr}")"
+command grep -qF "${sid}" "${body}" &&
     fail "the session id was expanded into mirrored content"
 # shellcheck disable=SC2016 # the directives are the payload, not shell expansions
-grep -qF '${_sid}' "${body}" || fail "\${_sid} did not survive verbatim"
+command grep -qF '${_sid}' "${body}" || fail "\${_sid} did not survive verbatim"
 # shellcheck disable=SC2016
-grep -qF '${sid}' "${body}" || fail "\${sid} did not survive verbatim"
+command grep -qF '${sid}' "${body}" || fail "\${sid} did not survive verbatim"
 cmp -s "${mirror}" "${body}" || fail "mirrored file not served byte for byte"
 # The mirror stays browsable: verbatim must not mean served as a download.
-grep -qi '^Content-type: text/html' "${hdr}" ||
+command grep -qi '^Content-type: text/html' "${hdr}" ||
     fail "mirrored page lost its text/html type: $(<"${hdr}")"
 
 # The other direction: a running crawl rebinds /website/ to the new project, so
@@ -76,7 +76,7 @@ htsserver_client --path /step4.html --field "sid=${sid}" --field "path=${work}" 
 start=$SECONDS
 while :; do
     htsserver_client --path /server/index.html >"${work}/pane.txt"
-    if grep -qF 'In progress:' "${work}/pane.txt"; then
+    if command grep -qF 'In progress:' "${work}/pane.txt"; then
         break
     fi
     test "$((SECONDS - start))" -lt 60 ||
@@ -91,7 +91,7 @@ cp "${mirror}" "${crawled}"
 echo "served from the crawl project" >>"${crawled}"
 
 htsserver_client --path /website/hostile.html --head-file "${hdr}" --body-file "${body}"
-grep -q '^HTTP/1\.0 200 ' "${hdr}" ||
+command grep -q '^HTTP/1\.0 200 ' "${hdr}" ||
     fail "running crawl: /website/ was not served: $(head -1 "${hdr}")"
 # cmp, not a "not the GUI page" check: that is only one of the wrong answers.
 cmp -s "${crawled}" "${body}" ||
@@ -100,7 +100,7 @@ cmp -s "${crawled}" "${body}" ||
 # A crawl ending mid-probe leaves the checks above reading the finished pane and
 # passing for the wrong reason, so pin the state they ran in.
 htsserver_client --path /server/index.html >"${work}/pane.txt"
-grep -qF 'In progress:' "${work}/pane.txt" ||
+command grep -qF 'In progress:' "${work}/pane.txt" ||
     fail "the crawl ended during the probes, so /website/ never faced a running one"
 
 echo "PASS"

--- a/tests/85_webhttrack-projpath.test
+++ b/tests/85_webhttrack-projpath.test
@@ -18,7 +18,7 @@ cleanup_push htsserver_cleanup_dir "${base}"
 reply=
 fetch() {
     reply=$(htsserver_get "$1") || fail "the request for $1 failed"
-    grep -q "^HTTP/1\.0 $2 " <<<"${reply}" ||
+    command grep -q "^HTTP/1\.0 $2 " <<<"${reply}" ||
         fail "$1: wanted a $2 reply, got '$(head -1 <<<"${reply}")'"
 }
 
@@ -40,13 +40,13 @@ echo "LOGMARKER" >"${base}/proj/hts-log.txt"
 # any successful save: commandEnd then swaps the error page for the finished one.
 htsserver_get /server/style.css >/dev/null # leaves a path behind in fsfile
 saved=$(htsserver_post "sid=${sid}&command=httrack&command_do=save&winprofile=x&path=${base}/$(printf '%0300d' 0)&projname=p")
-grep -q '^Location: /server/error.html' <<<"${saved}" ||
+command grep -q '^Location: /server/error.html' <<<"${saved}" ||
     fail "the refused save did not redirect to the error page"
 
 # No project yet, so no root to serve from.
 htsserver_post "sid=${sid}&projpath=${base}/" >/dev/null
 fetch /website/secret.txt 404
-grep -q SECRETMARKER <<<"${reply}" &&
+command grep -q SECRETMARKER <<<"${reply}" &&
     fail "a posted projpath served a file outside any project"
 
 # Positive control: step4's "save settings" flow registers the project without
@@ -58,28 +58,28 @@ htsserver_post "${body}" >/dev/null
 test -f "${base}/proj/hts-cache/winprofile.ini" ||
     fail "the project was not registered: $(<"${HTS_LOG}")"
 fetch /website/hts-log.txt 200
-grep -q LOGMARKER <<<"${reply}" ||
+command grep -q LOGMARKER <<<"${reply}" ||
     fail "the registered project's mirror is not served"
 
 # Same request with the root repointed: the project is legitimate, projpath is
 # not what decides where the bytes come from.
 htsserver_post "sid=${sid}&projpath=${base}/" >/dev/null
 fetch /website/secret.txt 404
-grep -q SECRETMARKER <<<"${reply}" &&
+command grep -q SECRETMARKER <<<"${reply}" &&
     fail "a posted projpath repointed the served root"
 htsserver_post "sid=${sid}&projpath=/etc/" >/dev/null
 fetch /website/passwd 404
-grep -q '^root:' <<<"${reply}" &&
+command grep -q '^root:' <<<"${reply}" &&
     fail "a posted projpath read an arbitrary system file"
 
 # A ".." anywhere in the recorded root would escape the mirror on every later
 # request, so the save must be refused and the previous root kept.
 htsserver_post "sid=${sid}&command=httrack&command_do=save&winprofile=x&path=${base}/proj&projname=.." >/dev/null
 fetch /website/secret.txt 404
-grep -q SECRETMARKER <<<"${reply}" &&
+command grep -q SECRETMARKER <<<"${reply}" &&
     fail "a '..' in the saved project path escaped the mirror root"
 fetch /website/hts-log.txt 200
-grep -q LOGMARKER <<<"${reply}" ||
+command grep -q LOGMARKER <<<"${reply}" ||
     fail "rejecting the '..' root also lost the previous one"
 
 # The root is now the server's own, but it is still built from two posted

--- a/tests/89_webhttrack-error-overflow.test
+++ b/tests/89_webhttrack-error-overflow.test
@@ -36,7 +36,7 @@ check_clipped() {
     test "${full}" -gt "${msgmax}" ||
         fail "a ${full}-byte message fits in ${msgmax}: it cannot show a clip"
     page=$(htsserver_get /server/error.html | tr -d '\r')
-    line=$(printf '%s\n' "${page}" | grep "^${prefix}") || {
+    line=$(printf '%s\n' "${page}" | command grep "^${prefix}") || {
         shown=$(printf '%s\n' "${page}" | grep '^Unable to ' | cut -c1-80 || true)
         fail "the error page reports '${shown:-nothing}', want: ${prefix}"
     }
@@ -88,7 +88,7 @@ test "${written}" -lt "${#profile}" ||
 check_clipped "Unable to write ${#profile} bytes in the the init file " "${path}/p"
 
 reply=$(htsserver_get /server/index.html || true)
-grep -q '200 OK' <<<"$reply" ||
+command grep -q '200 OK' <<<"$reply" ||
     fail "the server stopped answering after the refused saves"
 
 echo "PASS"

--- a/tests/93_local-changes.test
+++ b/tests/93_local-changes.test
@@ -51,7 +51,7 @@ expect_counts_match() {
     local label="$1" rep="${2:-$report}" bucket n
     printf '[%s] ..\t' "$label"
     for bucket in new changed unchanged gone; do
-        n=$(listed "$bucket" "$rep" | grep -c . || true)
+        n=$(listed "$bucket" "$rep" | command grep -c . || true)
         test "$(field "$bucket" "$rep")" == "$n" ||
             fail_dump "${bucket} count $(field "$bucket" "$rep") but $n listed" "$rep"
     done

--- a/tests/94_local-single-file.test
+++ b/tests/94_local-single-file.test
@@ -104,8 +104,8 @@ echo OK
 
 printf '[lazy-loaded image inlined] ..\t'
 # src is the placeholder a real page ships; the asset rides data-src.
-grep -q 'data-src="data:image/svg+xml;base64,' "$page" || fail "data-src was not inlined"
-if grep -q 'data-src="lazy.svg"' "$page"; then
+command grep -q 'data-src="data:image/svg+xml;base64,' "$page" || fail "data-src was not inlined"
+if command grep -q 'data-src="lazy.svg"' "$page"; then
     echo "FAIL: data-src kept its link"
     exit 1
 fi
@@ -114,44 +114,44 @@ echo OK
 
 printf '[stylesheet inlined, recursively] ..\t'
 extract "$page" "text/css" "${tmpdir}/got.css" || fail "no inlined stylesheet"
-grep -q 'url(data:image/svg+xml;base64,' "${tmpdir}/got.css" || fail "url() inside the inlined stylesheet was not inlined"
+command grep -q 'url(data:image/svg+xml;base64,' "${tmpdir}/got.css" || fail "url() inside the inlined stylesheet was not inlined"
 extract "${tmpdir}/got.css" "text/css" "${tmpdir}/got2.css" || fail "@import was not inlined"
-grep -q 'url(data:image/svg+xml;base64,' "${tmpdir}/got2.css" || fail "url() inside the @import'ed stylesheet was not inlined"
+command grep -q 'url(data:image/svg+xml;base64,' "${tmpdir}/got2.css" || fail "url() inside the @import'ed stylesheet was not inlined"
 echo OK
 
 # --- what must keep its link ------------------------------------------------
 printf '[page links stay relative] ..\t'
-grep -q 'href="other.html"' "$page" || fail "the link to another page was not left relative"
+command grep -q 'href="other.html"' "$page" || fail "the link to another page was not left relative"
 test -f "${out}/127.0.0.1_${SRV_PORT}/other.html" || fail "the linked page is missing from the mirror"
 echo OK
 
 printf '[a navigational rel keeps its link] ..\t'
 # The page carries a later rel="stylesheet"; reading rel past its own value let
 # this canonical link inherit it and inline the page it names.
-grep -q 'rel="canonical" href="other.html"' "$page" || fail "rel=canonical was inlined"
+command grep -q 'rel="canonical" href="other.html"' "$page" || fail "rel=canonical was inlined"
 echo OK
 
 printf '[an unnamed tag cannot skip the deny rules] ..\t'
 # An unquoted value ending at '>' loses the tag name, which used to read as
 # "a CSS body" and took these past every tag-bearing deny rule.
-grep -q '<a href=pixel.svg>' "$page" || fail "an unquoted anchor was inlined"
-grep -q '<iframe src=pixel.svg>' "$page" || fail "an unquoted iframe was inlined"
+command grep -q '<a href=pixel.svg>' "$page" || fail "an unquoted anchor was inlined"
+command grep -q '<iframe src=pixel.svg>' "$page" || fail "an unquoted iframe was inlined"
 echo OK
 
 printf '[a rel-less link keeps its link] ..\t'
 # Nothing loads it, so it is not an asset however inlinable the file looks.
-grep -q '<link href="style_norel.css">' "$page" || fail "a <link> with no rel was inlined"
+command grep -q '<link href="style_norel.css">' "$page" || fail "a <link> with no rel was inlined"
 test -f "${out}/127.0.0.1_${SRV_PORT}/style_norel.css" || fail "style_norel.css is missing, so the probe proves nothing"
 echo OK
 
 printf '[over-cap asset stays a link] ..\t'
-grep -q 'src="big.svg"' "$page" || fail "the over-cap asset did not keep its link"
+command grep -q 'src="big.svg"' "$page" || fail "the over-cap asset did not keep its link"
 test -f "${out}/127.0.0.1_${SRV_PORT}/big.svg" || fail "the over-cap asset is missing from the mirror"
-grep -q 'over the 4096-byte cap' "${out}/hts-log.txt" || fail "the over-cap asset was not reported in the log"
+command grep -q 'over the 4096-byte cap' "${out}/hts-log.txt" || fail "the over-cap asset was not reported in the log"
 echo OK
 
 printf '[the mirror still works] ..\t'
-if grep -q 'href="style.css"' "$page"; then
+if command grep -q 'href="style.css"' "$page"; then
     echo "FAIL: the stylesheet link survived"
     exit 1
 fi
@@ -161,9 +161,9 @@ echo OK
 # --- a second run must not re-encode ----------------------------------------
 printf '[idempotent under --update] ..\t'
 # HTTrack stamps the time into its own footer comment, so compare without it.
-grep -v 'Mirrored from' "$page" >"${tmpdir}/page1.html"
+command grep -v 'Mirrored from' "$page" >"${tmpdir}/page1.html"
 local_crawl --log "${tmpdir}/log2" "${common[@]}" --single-file --single-file-max-size 4096 --update "${BASEURL}/index.html"
-grep -v 'Mirrored from' "$page" >"${tmpdir}/page2.html"
+command grep -v 'Mirrored from' "$page" >"${tmpdir}/page2.html"
 cmp -s "${tmpdir}/page1.html" "${tmpdir}/page2.html" || fail "the second run changed the page"
 # A double-encoded payload would decode to another data: URI, not to the SVG.
 extract "$page" "image/svg+xml" "${tmpdir}/got2.svg" || fail "no inlined image after the second run"
@@ -177,7 +177,7 @@ off="${tmpdir}/off"
 mkdir "$off"
 local_crawl --log "${tmpdir}/log3" -O "$off" "${opts[@]}" -%Z0 "${BASEURL}/index.html"
 offpage="${off}/127.0.0.1_${SRV_PORT}/index.html"
-if grep -q 'base64,' "$offpage"; then
+if command grep -q 'base64,' "$offpage"; then
     echo "FAIL: -%Z0 still inlined"
     exit 1
 fi
@@ -188,7 +188,7 @@ for cap in notanumber 12abc 0 99999999999999999999; do
     local_crawl --log "${tmpdir}/log4" -O "$bad" "${opts[@]}" \
         --single-file-max-size "$cap" "${BASEURL}/index.html" || rc=$?
     test "$rc" -ne 0 || fail "--single-file-max-size $cap was accepted"
-    grep -q 'positive size' "${tmpdir}/log4" ||
+    command grep -q 'positive size' "${tmpdir}/log4" ||
         fail_dump "--single-file-max-size $cap was refused without saying so" "${tmpdir}/log4"
 done
 test ! -e "${bad}/127.0.0.1_${SRV_PORT}/index.html" || fail "a rejected cap still crawled"
@@ -201,7 +201,7 @@ printf '[a page cannot forge a mark] ..\t'
 # inlined elsewhere on the page, so the encoder was demonstrably willing.
 forged=$(sed -n 's/.*<p>\(id=[^<]*\)<\/p>.*/\1/p' "$page")
 test "$forged" = 'id=pixel.svg end' || fail "the page was altered: $forged"
-grep -q 'data:image/svg+xml;base64,' "$page" || fail "nothing was inlined at all, so the probe proves nothing"
+command grep -q 'data:image/svg+xml;base64,' "$page" || fail "nothing was inlined at all, so the probe proves nothing"
 echo OK
 
 printf '[a mark cannot ride in on a header] ..\t'
@@ -210,13 +210,13 @@ printf '[a mark cannot ride in on a header] ..\t'
 # an expansion would leave a data: URI.
 markpage="${out}/127.0.0.1_${SRV_PORT}/sfmark.html"
 test -f "$markpage" || fail "the charset-mark page was not mirrored"
-if grep -q 'charset=data:' "$markpage"; then
+if command grep -q 'charset=data:' "$markpage"; then
     echo "FAIL: a charset-borne mark was expanded"
     exit 1
 fi
 # The mark is deleted and its reference kept: without this the check above
 # passes on a page that never carried a charset.
-grep -q 'content="text/html;charset=pixel.svg" />' "$markpage" || fail "the charset never reached the page, so nothing was proven"
+command grep -q 'content="text/html;charset=pixel.svg" />' "$markpage" || fail "the charset never reached the page, so nothing was proven"
 echo OK
 
 printf '[no file keeps a mark] ..\t'
@@ -225,7 +225,7 @@ printf '[no file keeps a mark] ..\t'
 # grep's own status, kept out of a pipeline that would launder it: 0 matched,
 # 1 clean, anything above that means the sweep never read the tree.
 st=0
-marked=$(grep -rlE '#![0-9a-f]{16}\.[-cj]\.[0-9]+' \
+marked=$(command grep -rlE '#![0-9a-f]{16}\.[-cj]\.[0-9]+' \
     "${out}/127.0.0.1_$SRV_PORT" 2>/dev/null) || st=$?
 test "$st" -le 1 || fail "the mark sweep could not read the mirror (grep exit $st)"
 marked=$(printf '%s' "$marked" | tr '\n' ' ')
@@ -236,12 +236,12 @@ printf '[an unrecognised type still inlines from its context] ..\t'
 # style_noext and app_noext have no usable extension, so only the referencing
 # context says what they are. plain.css/plain.js are the control: they inline
 # either way, so a failure here is the context path and not the encoder.
-grep -q 'href="data:text/css;base64,' "$page" || fail "no stylesheet inlined at all"
-if grep -q 'href="style_noext"' "$page"; then
+command grep -q 'href="data:text/css;base64,' "$page" || fail "no stylesheet inlined at all"
+if command grep -q 'href="style_noext"' "$page"; then
     echo "FAIL: extensionless stylesheet was not inlined"
     exit 1
 fi
-if grep -q 'src="app_noext"' "$page"; then
+if command grep -q 'src="app_noext"' "$page"; then
     echo "FAIL: extensionless script was not inlined"
     exit 1
 fi
@@ -249,13 +249,13 @@ echo OK
 
 printf '[a fragment survives onto the data: URI] ..\t'
 # An SVG fragment selects a view, so dropping it renders the wrong thing (#766).
-grep -q 'data:image/svg+xml;base64,[A-Za-z0-9+/=]*#icon' "$page" || fail "the fragment was dropped"
+command grep -q 'data:image/svg+xml;base64,[A-Za-z0-9+/=]*#icon' "$page" || fail "the fragment was dropped"
 echo OK
 
 printf '[a page link is not inlined even when it names an asset] ..\t'
 # <a href> to an image: only the deny rule stops this, since the MIME gate
 # would happily take it. Without the rule the anchor becomes a data: URI.
-grep -q '<a href="pixel.svg">raw</a>' "$page" || fail "an anchor to an inlinable asset was rewritten"
+command grep -q '<a href="pixel.svg">raw</a>' "$page" || fail "an anchor to an inlinable asset was rewritten"
 echo OK
 
 printf '[-%%M refuses to pair with --single-file] ..\t'
@@ -279,7 +279,7 @@ mkdir "$chg"
 local_crawl --log "${tmpdir}/log6" -O "$chg" "${opts[@]}" --single-file --changes "${BASEURL}/index.html"
 chgpage="${chg}/127.0.0.1_${SRV_PORT}/index.html"
 test -f "$chgpage" || fail "--changes produced no mirrored page"
-grep -q 'base64,' "$chgpage" || fail "--changes suppressed the inlining"
+command grep -q 'base64,' "$chgpage" || fail "--changes suppressed the inlining"
 # Via a file, never a heredoc inside $(...): bash 3.2 (macOS) ends the
 # substitution at the ")" and runs the body as shell commands.
 cat >"${tmpdir}/report.py" <<'REPORT'
@@ -336,13 +336,13 @@ esac
 printf '[the unresolved-reference warning is clipped] ..\t'
 # The self-test drives a 90 KB reference through it, so an unclipped build puts
 # all of it in the log. The first check is the floor: no warning proves nothing.
-grep -q 'resolves to no mirrored file' <<<"$st" || fail "the self-test logged no unresolved reference"
+command grep -q 'resolves to no mirrored file' <<<"$st" || fail "the self-test logged no unresolved reference"
 awk 'length($0) > 1024 { exit 1 }' <<<"$st" || fail "a log line ran past the clip"
 echo OK
 
 # --- project reload restores the saved keys ---------------------------------
 distdir=$(cd "${top_srcdir}" && pwd)
 printf '[project reload maps the keys back] ..\t'
-grep -q 'do:copy:SingleFile:singlefile' "${distdir}/html/server/step2.html" || fail "step2.html does not restore SingleFile"
-grep -q 'do:copy:SingleFileMaxSize:singlefilemax' "${distdir}/html/server/step2.html" || fail "step2.html does not restore SingleFileMaxSize"
+command grep -q 'do:copy:SingleFile:singlefile' "${distdir}/html/server/step2.html" || fail "step2.html does not restore SingleFile"
+command grep -q 'do:copy:SingleFileMaxSize:singlefilemax' "${distdir}/html/server/step2.html" || fail "step2.html does not restore SingleFileMaxSize"
 echo OK

--- a/tests/check-network.sh
+++ b/tests/check-network.sh
@@ -26,7 +26,7 @@ else
 
     # cached result ?
     if test -f $cache; then
-        if grep -q "ok" $cache; then
+        if command grep -q "ok" $cache; then
             exit 0
         else
             echo "online tests are disabled (cached)" >&2

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -116,7 +116,7 @@ hb_now() { hb_time=$SECONDS; }
 ci_watchdog_wait=${ci_watchdog_wait:-30}
 
 # True once the launched interpreter has announced itself.
-ci_watchdog_spoke() { grep -q '^watchdog ready$' watchdog.log; }
+ci_watchdog_spoke() { command grep -q '^watchdog ready$' watchdog.log; }
 
 # Start the off-box telemetry over the progress log $1, setting ci_watchdog_pid;
 # return 1 with no PowerShell available. Forks nothing and kills nothing, so it

--- a/tests/crawl-test.sh
+++ b/tests/crawl-test.sh
@@ -129,7 +129,7 @@ function start-crawl {
             ;;
         --errors)
             shift
-            assert_equals "checking errors" "$1" "$(grep -iEc "^[0-9\:]*[[:space:]]Error:" "${tmp}/hts-log.txt")"
+            assert_equals "checking errors" "$1" "$(command grep -iEc "^[0-9\:]*[[:space:]]Error:" "${tmp}/hts-log.txt")"
             ;;
         --found)
             shift
@@ -153,7 +153,7 @@ function start-crawl {
             ;;
         --files)
             shift
-            nFiles=$(grep -E "^HTTrack Website Copier/[^ ]* mirror complete in " "${tmp}/hts-log.txt" |
+            nFiles=$(command grep -E "^HTTrack Website Copier/[^ ]* mirror complete in " "${tmp}/hts-log.txt" |
                 sed -e 's/.*[[:space:]]\([^ ]*\)[[:space:]]files written.*/\1/g')
             assert_equals "checking files" "$1" "$nFiles"
             ;;

--- a/tests/crawllib.sh
+++ b/tests/crawllib.sh
@@ -158,20 +158,20 @@ local_crawl() {
 # hts-changes.json: assert_purged true|false OUTDIR.
 assert_purged() {
     local want="$1" json="${2}/hts-changes.json"
-    grep -q "\"purged\": ${want}" "$json" ||
+    command grep -q "\"purged\": ${want}" "$json" ||
         fail "expected \"purged\": ${want} in $(<"$json")"
 }
 
 # assert_alive FILE MARKER: still mirrored, and still the body we mirrored.
 assert_alive() {
     test -s "$1" || fail "$1 is gone"
-    grep -q "$2" "$1" || fail "$1 no longer carries ${2}"
+    command grep -q "$2" "$1" || fail "$1 no longer carries ${2}"
 }
 
 # assert_logged OUTDIR PATTERN WHAT: the premise a shape rests on, in the log.
 assert_logged() {
     local log="${1}/hts-log.txt"
-    grep -qE "$2" "$log" || fail "${3}: $(<"$log")"
+    command grep -qE "$2" "$log" || fail "${3}: $(<"$log")"
 }
 
 # assert_gave_up OUTDIR URLPATH: the link really did exhaust its retries on a

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -617,7 +617,7 @@ while test "$i" -lt "${#audit[@]}"; do
         ;;
     --files)
         i=$((i + 1))
-        nFiles=$(grep -E "^HTTrack Website Copier/[^ ]* mirror complete in " "${logroot}/hts-log.txt" |
+        nFiles=$(command grep -E "^HTTrack Website Copier/[^ ]* mirror complete in " "${logroot}/hts-log.txt" |
             sed -e 's/.*[[:space:]]\([^ ]*\)[[:space:]]files written.*/\1/g')
         assert_equals "checking files" "${audit[$i]}" "$nFiles"
         ;;

--- a/tests/proclib.sh
+++ b/tests/proclib.sh
@@ -102,7 +102,7 @@ list_stray_processes() {
         # slash switches: without MSYS_NO_PATHCONV a /fi would be rewritten to a
         # path. Plain output is Image Name + PID, which is all we need.
         test "$mode" != others || return 0
-        tasklist 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE|^python" || true
+        tasklist 2>/dev/null | command grep -Ei "$ENGINE_IMAGE_RE|^python" || true
     else
         # Fields 6 and 7 are the command and its first argument (the interpreter
         # and its script, for the Python fixtures).
@@ -131,7 +131,7 @@ list_stray_processes() {
 reap_leftover_processes() {
     local label=${1:-} left
     if target_is_windows; then
-        left=$(tasklist 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE" || true)
+        left=$(tasklist 2>/dev/null | command grep -Ei "$ENGINE_IMAGE_RE" || true)
     else
         left=$(list_stray_processes 0 named | awk 'NR > 1')
     fi
@@ -234,7 +234,7 @@ dump_windows_stacks() {
         printf 'no stack: cdb.exe is not in the SDK Debuggers directories or on PATH\n'
         return 0
     fi
-    for p in $(tasklist 2>/dev/null | grep -Ei "$ENGINE_IMAGE_RE" | awk '{print $2}'); do
+    for p in $(tasklist 2>/dev/null | command grep -Ei "$ENGINE_IMAGE_RE" | awk '{print $2}'); do
         found=1
         printf -- '--- cdb stack of pid %s ---\n' "$p"
         # Bounded, so a debugger that wedges cannot become the new hang. "qd"

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -91,7 +91,7 @@ mirror_names() { # mirror_names DIR
     find "$1" -type f | sed 's|.*/||'
 }
 mirror_has_name() { # mirror_has_name DIR BASENAME
-    grep -Fqx "$2" <<<"$(mirror_names "$1")"
+    command grep -Fqx "$2" <<<"$(mirror_names "$1")"
 }
 
 # Every step skip_if_out_of_budget projects against ran. A skip is an exit, so a
@@ -522,7 +522,7 @@ have_feature() {
             fail "httrack -#test=features failed"
         test -n "${HTS_FEATURES}" || fail "httrack -#test=features said nothing"
     fi
-    grep -q "^$1 1\$" <<<"${HTS_FEATURES}"
+    command grep -q "^$1 1\$" <<<"${HTS_FEATURES}"
 }
 
 # Longest surviving run of char $2 in file $1, or 0: the length a field was
@@ -676,8 +676,8 @@ declared_header_count() {
 build_names_frames() {
     local conf="${abs_top_builddir:?}/config.h"
     test -r "${conf}" || fail "no config.h at ${conf}"
-    grep -q '^#define HAVE_BACKTRACE ' "${conf}" &&
-        grep -q '^#define HAVE_SPAWN_H ' "${conf}"
+    command grep -q '^#define HAVE_BACKTRACE ' "${conf}" &&
+        command grep -q '^#define HAVE_SPAWN_H ' "${conf}"
 }
 
 # Which harness drives the tests: `msys` for an MSYS/Git Bash shell, `wsl2` for
@@ -877,15 +877,15 @@ BIND_LOST="Unable to (initialize a temporary server|create the server)"
 # port; a proxytrack that announces neither ends the test here.
 proxytrack_bound() { # proxytrack_bound LOG PID
     local log=$1 pid=$2 waited=0
-    until grep -qE "$PT_LISTENING|$BIND_LOST" "$log"; do
+    until command grep -qE "$PT_LISTENING|$BIND_LOST" "$log"; do
         # An exit flushes the log, so re-read it rather than calling this dead.
         kill -0 "$pid" 2>/dev/null || break
         test "$waited" -lt 50 || fail "proxytrack never announced its listen port: $(<"$log")"
         sleep 0.1
         waited=$((waited + 1))
     done
-    grep -q "$PT_LISTENING" "$log" && return 0
-    grep -qE "$BIND_LOST" "$log" || fail "proxytrack exited before listening: $(<"$log")"
+    command grep -q "$PT_LISTENING" "$log" && return 0
+    command grep -qE "$BIND_LOST" "$log" || fail "proxytrack exited before listening: $(<"$log")"
     return 1
 }
 

--- a/tests/webhttracklib.sh
+++ b/tests/webhttracklib.sh
@@ -158,7 +158,7 @@ htsserver_start() {
         done
         test -z "${HTS_URL}" || break
         # Only a lost bind is worth redrawing; anything else is a regression.
-        grep -qE "${BIND_LOST}" "${HTS_LOG}" ||
+        command grep -qE "${BIND_LOST}" "${HTS_LOG}" ||
             fail "htsserver did not come up: $(<"${HTS_LOG}")"
         test -z "${port}" ||
             fail "htsserver could not bind port ${port}: $(<"${HTS_LOG}")"

--- a/tools/ci-sanitizer-report.sh
+++ b/tools/ci-sanitizer-report.sh
@@ -53,7 +53,7 @@ report() { # report LABEL FILE
 
 scan() { # scan LABEL FILE -- report FILE only if it carries a finding
     [ -f "$2" ] || return 0
-    grep -qE "$pattern" "$2" 2>/dev/null && report "$1" "$2"
+    command grep -qE "$pattern" "$2" 2>/dev/null && report "$1" "$2"
     return 0
 }
 
@@ -61,7 +61,7 @@ scan() { # scan LABEL FILE -- report FILE only if it carries a finding
 # diagnostic stays visible, and a deliberate one does not turn the build red.
 for f in "$log_dir"/*; do
     [ -f "$f" ] || continue
-    if grep -qE "$pattern" "$f" 2>/dev/null; then
+    if command grep -qE "$pattern" "$f" 2>/dev/null; then
         report "sanitizer report" "$f"
     else
         echo "=== other sanitizer output (not a finding): $f"

--- a/tools/downstream-drift.sh
+++ b/tools/downstream-drift.sh
@@ -79,7 +79,7 @@ fetch() {
 expect() {
     local id=$1 recipe=$2 pattern=$3 msg=$4
     shift 4
-    if ! grep -qF -- "$pattern" "$recipe"; then
+    if ! command grep -qF -- "$pattern" "$recipe"; then
         flag "$id" "the recipe no longer contains '$pattern'; prune this check"
         return
     fi
@@ -101,7 +101,7 @@ carried_patch() {
     fetch "$url" "$work/patch"
     for p in 0 1 2; do
         out=$(patch -d "$top" "-p$p" --dry-run --force <"$work/patch" 2>&1) || continue
-        if grep -q 'with fuzz' <<<"$out"; then
+        if command grep -q 'with fuzz' <<<"$out"; then
             flag "$id" "applies only with fuzz, so its context has moved: $(tr '\n' ' ' <<<"$out")"
             return
         fi
@@ -122,7 +122,7 @@ carried_patch() {
 glob_contains() {
     local pattern=$1
     shift
-    grep -qF -- "$pattern" "$@"
+    command grep -qF -- "$pattern" "$@"
 }
 coucal_names_gcc() {
     grep -v '^[[:space:]]*#' "$top/src/coucal/Makefile" | grep -qw gcc
@@ -150,7 +150,7 @@ fetch "$gentoo_raw/$ebuild" "$work/gentoo.ebuild"
 
 expect gentoo-zlib-tripwire "$work/gentoo.ebuild" '{ZLIB_HOME}/lib' \
     "src_prepare greps m4/check_zlib.m4 for it and dies without it, so every non-lib libdir (amd64) fails to build" \
-    grep -qF '{ZLIB_HOME}/lib' "$top/m4/check_zlib.m4"
+    command grep -qF '{ZLIB_HOME}/lib' "$top/m4/check_zlib.m4"
 expect gentoo-docs "$work/gentoo.ebuild" 'DOCS=( AUTHORS README greetings.txt history.txt )' \
     "one of the four DOCS files is gone; einstalldocs dies" \
     test -f "$top/AUTHORS" -a -f "$top/README" -a -f "$top/greetings.txt" -a -f "$top/history.txt"
@@ -176,7 +176,7 @@ fetch "$obsd_raw/Makefile" "$work/openbsd.mk"
 
 expect openbsd-online-tests "$work/openbsd.mk" '--enable-online-unit-tests=no' \
     "configure no longer offers --enable-online-unit-tests" \
-    grep -qF online-unit-tests "$top/configure.ac"
+    command grep -qF online-unit-tests "$top/configure.ac"
 expect openbsd-bash-files "$work/openbsd.mk" '${WRKSRC}/src/webhttrack' \
     "src/webhttrack is generated from webhttrack.in since #899, and the pre-configure perl dies on a missing file" \
     test -f "$top/src/webhttrack"
@@ -191,10 +191,10 @@ fetch "$termux_raw/build.sh" "$work/termux.sh"
 
 expect termux-werror-sed "$work/termux.sh" 's/-Werror/-Wno-error/g' \
     "configure.ac no longer passes -Werror, so the sed is dead" \
-    grep -qF -- -Werror "$top/configure.ac"
+    command grep -qF -- -Werror "$top/configure.ac"
 expect termux-with-zlib "$work/termux.sh" --with-zlib \
     "configure no longer offers --with-zlib" \
-    grep -qF -- --with-zlib "$top/m4/check_zlib.m4"
+    command grep -qF -- --with-zlib "$top/m4/check_zlib.m4"
 for p in html-Makefile.in.patch htsglobal.h.patch src-Makefile.in.patch \
     src-htsbacktrace.c.patch src-proxy-proxytrack.h.patch store.c.patch; do
     carried_patch "termux-$p" "$termux_raw/$p"

--- a/tools/macos-app.sh
+++ b/tools/macos-app.sh
@@ -175,7 +175,7 @@ relink() {
         done <"$deplist"
         rp="@loader_path/$(uprefix "${bin%/*}")Frameworks"
         otool -l "$bin" | awk '/LC_RPATH/ {r = 1} r && $1 == "path" {print $2; r = 0}' >"$deplist"
-        grep -qxF "$rp" "$deplist" || rewrite -add_rpath "$rp" "$bin"
+        command grep -qxF "$rp" "$deplist" || rewrite -add_rpath "$rp" "$bin"
         # install_name_tool invalidates the signature, and arm64 kills an unsigned Mach-O.
         [ "$bin" = "$mainexe" ] && continue
         codesign -f -s - "$bin"
@@ -257,7 +257,7 @@ test "$nmach" -gt 0 || fail "scanned no Mach-O files at all, the check proved no
 find "$app/Contents" -type f >"$list"
 while IFS= read -r f; do
     file "$f" | grep -q text || continue
-    grep -q -- "$prefix" "$f" 2>/dev/null && fail "$f embeds the staging prefix"
+    command grep -q -- "$prefix" "$f" 2>/dev/null && fail "$f embeds the staging prefix"
 done <"$list"
 
 # CFBundleIconFile is a Resources basename with an optional extension, so resolve it

--- a/tools/macos-release.sh
+++ b/tools/macos-release.sh
@@ -127,7 +127,7 @@ notarize() {
         --issuer "$notary_issuer" --wait --timeout 2h >"$nlog" 2>&1 || st=$?
     cat "$nlog"
     # A rejected submission has exited 0 in the past, so read the verdict, not just $?.
-    if [ "$st" -ne 0 ] || ! grep -q "status: Accepted" "$nlog"; then
+    if [ "$st" -ne 0 ] || ! command grep -q "status: Accepted" "$nlog"; then
         id=$(sed -n 's/^ *id: \([0-9a-fA-F][0-9a-fA-F-]*\)$/\1/p' "$nlog" | head -1)
         # The rejection reason lives only in this log.
         [ -z "$id" ] || xcrun notarytool log "$id" --key "$notary_key" \
@@ -153,7 +153,7 @@ name=${label:-$version}
 # The filename is what a user reads before downloading, so name the arch (#1083).
 # An arch counts only if every Mach-O carries it: one thin dylib and the app is not universal.
 arch=$(while IFS= read -r _bin; do lipo -archs "$_bin" | tr ' ' '\n'; done <"$mach" |
-    grep -v '^$' | sort | uniq -c |
+    command grep -v '^$' | sort | uniq -c |
     awk -v n="$(wc -l <"$mach")" '$1 == n { print $2 }' | sort | paste -sd- -)
 test -n "$arch" || fail "the bundle's Mach-O files share no architecture"
 case "$arch" in
@@ -189,7 +189,7 @@ if [ "$skip_notarize" -eq 0 ]; then
         fail "Gatekeeper rejected $app"
     }
     cat "$nlog"
-    grep -q "source=Notarized Developer ID" "$nlog" ||
+    command grep -q "source=Notarized Developer ID" "$nlog" ||
         fail "$app assessed, but not as a notarized Developer ID app"
     spctl --assess --type open --context context:primary-signature -vv "$dmg" >"$nlog" 2>&1 || {
         cat "$nlog" >&2

--- a/tools/mk-sbuild-chroot.sh
+++ b/tools/mk-sbuild-chroot.sh
@@ -105,7 +105,7 @@ main() {
     if [[ $(id -u) -ne 0 ]]; then
         local me
         me=$(id -un)
-        if ! grep -qs "^$me:" /etc/subuid || ! grep -qs "^$me:" /etc/subgid; then
+        if ! command grep -qs "^$me:" /etc/subuid || ! command grep -qs "^$me:" /etc/subgid; then
             # Suggest a range starting past every allocation in either file.
             local start
             start=$(awk -F: '{e = $2 + $3; if (e > m) m = e} END {print (m ? m : 100000)}' \
@@ -132,7 +132,7 @@ main() {
     local rc=$HOME/.sbuildrc
     local mode_line="\$chroot_mode = 'unshare';"
     # shellcheck disable=SC2016  # $chroot_mode is literal regex text, not a shell var.
-    if grep -qsE '^[[:space:]]*\$chroot_mode[[:space:]]*=.*unshare' "$rc"; then
+    if command grep -qsE '^[[:space:]]*\$chroot_mode[[:space:]]*=.*unshare' "$rc"; then
         : # already configured (active, non-commented line)
     elif [[ $write_sbuildrc -eq 1 ]]; then
         info "enabling the unshare backend in $rc"


### PR DESCRIPTION
An interactive shell on this box, and potentially others, can shadow `grep` with a wrapper function. Ours carries `-I`, so it treats a stream as binary and reports no match at all once it sees one invalid byte anywhere in it. Its exit status is unreliable on top of that. Any script whose control flow reads that status takes the wrong branch. A script run the normal way, `bash foo.test`, starts a fresh process and never inherits such a function. The exposure is a human or an agent sourcing pieces of a test into a live shell. That already happened once, on this codebase's own LANGUAGE_CHARSET audit.

`command grep` bypasses a shell function and reaches the real binary. This sweeps every tracked shell script under `tests/`, `tools/`, `man/`, `src/` and `html/`. Any `grep` call whose exit status or file selection decides something gets prefixed: 945 call sites across 225 files. A call already carrying `-a` was left alone, since it already treats its input as text and is immune to the `-I` failure mode.

`tests/crawl-test.sh`'s `--files` check extracts the mirror's file count from `hts-log.txt` with a bare `grep`. Feed it a log where an earlier line carries a raw non-UTF-8 byte, the way `11_crawl-international.test`'s `iso88591.html` case legitimately can. The shim's `grep` then reports no match on the whole file, including the "mirror complete" summary line two lines later. `assert_equals "checking files"` reports a false failure against a crawl that produced exactly the file count expected. `command grep` reads the same log correctly.

Left alone, and worth a separate look: three sites pipe a command's output straight into `grep -q`. That exits on its first match and can SIGPIPE a producer still writing (`tools/downstream-drift.sh:128`, `tools/macos-app.sh:259`, `tests/62_lang-integrity.test:171`). That is a different bug from this one, and fixing it belongs in its own PR.
