### PR TITLE
downstream-drift: grep -q on a pipe misreads a match as absent under pipefail

### DIFF
--- a/tools/downstream-drift.sh
+++ b/tools/downstream-drift.sh
@@ -125,7 +125,9 @@ glob_contains() {
     grep -qF -- "$pattern" "$@"
 }
 coucal_names_gcc() {
-    grep -v '^[[:space:]]*#' "$top/src/coucal/Makefile" | grep -qw gcc
+    local live
+    live=$(grep -v '^[[:space:]]*#' "$top/src/coucal/Makefile")
+    grep -qw gcc <<<"$live"
 }
 
 # The Termux patches target generated files, so a checkout that skipped


### PR DESCRIPTION
`coucal_names_gcc()` piped `grep -v` straight into `grep -qw` under `set -euo pipefail`. `grep -qw` exits on its first match and SIGPIPE-kills the still-writing `grep -v`. Under `pipefail`, that SIGPIPE death (141) becomes the pipeline's status instead of the match `grep -qw` actually found. `expect()` calls this as `if "$@"; then ok; else flag`, so a real match reads as absent and fires a spurious drift flag on a recipe that is still fine.

Fix: capture `grep -v`'s output first, then match it with a here-string, so the result no longer depends on the producer's own exit status.

Proof: a synthetic Makefile with a non-comment `gcc` match followed by 20000 filler lines. The old form returns 141, misreported as no match. The new form returns 0. Ran the real script too, against the actual `src/coucal/Makefile`, which still reports `known` as before.

`tools/macos-app.sh:259` and `tests/62_lang-integrity.test:171` pipe a producer into `grep -q` the same way but are not exposed, so they are left unchanged. Neither script sets `pipefail`. Each producer also emits exactly one line: `file(1)` on a single path, or a single catalog field. Any match is already on the last line.
