### PR TITLE
A starved grandchild makes the watchdog test pass a watchdog that leaked it

### DIFF
--- a/src/htsdns_selftest.c
+++ b/src/htsdns_selftest.c
@@ -618,10 +618,12 @@ int dns_timeout_selftests(httrackp *opt) {
   finished = mock_read_finished();
 
   /* the resolve returns on opt->timeout, not when the resolver deigns to
-     answer: this is what lets --max-time and --timeout fire (#606). The
-     resolver had not answered yet, which no wakeup delay can fake; the clock
-     bound is derived from opt->timeout, never from the mock's sleep, or a
-     resolve that ignored opt->timeout would still pass under the mock. */
+     answer: this is what lets --max-time and --timeout fire (#606). The bound
+     is derived from opt->timeout, never from the mock's sleep, or a resolve
+     that ignored opt->timeout would still pass under the mock. The finished
+     count is a tripwire on the fixture rather than a second bound: the mock
+     returns well after the clock fires, so it can only speak alone if
+     MOCK_SLOW_MS ever stops being the larger of the two. */
   CHECK(finished == 0);
   CHECK(elapsed < (TStamp) opt->timeout * 1000 + 500);
   CHECK(count == 0); /* a timeout is reported as "does not resolve" */

--- a/src/htsdns_selftest.c
+++ b/src/htsdns_selftest.c
@@ -148,6 +148,16 @@ static int mock_read_calls(const char *name) {
   return calls;
 }
 
+/* Backend calls that have returned, ordering their writes against ours. */
+static int mock_read_finished(void) {
+  int n;
+
+  hts_mutexlock(&mock_lock);
+  n = mock_finished;
+  hts_mutexrelease(&mock_lock);
+  return n;
+}
+
 /* Wait for n backend calls to return, ordering their writes against ours. */
 static void mock_wait_finished(int n) {
   for (;;) {
@@ -588,7 +598,7 @@ int dns_timeout_selftests(httrackp *opt) {
   const char *err = NULL;
   lock_probe probe;
   TStamp start, elapsed;
-  int count;
+  int count, finished;
 
   failures = 0;
   hts_dns_set_resolver_backend(&mock_backend);
@@ -605,11 +615,14 @@ int dns_timeout_selftests(httrackp *opt) {
   start = mtime_local();
   count = hts_dns_resolve_all(opt, "slow.test", addrs, HTS_MAXADDRNUM, &err);
   elapsed = mtime_local() - start;
+  finished = mock_read_finished();
 
   /* the resolve returns on opt->timeout, not when the resolver deigns to
-     answer: this is what lets --max-time and --timeout fire (#606). The bound
-     is derived from opt->timeout, never from the mock's sleep, or a resolve
-     that ignored opt->timeout would still pass under the mock. */
+     answer: this is what lets --max-time and --timeout fire (#606). The
+     resolver had not answered yet, which no wakeup delay can fake; the clock
+     bound is derived from opt->timeout, never from the mock's sleep, or a
+     resolve that ignored opt->timeout would still pass under the mock. */
+  CHECK(finished == 0);
   CHECK(elapsed < (TStamp) opt->timeout * 1000 + 500);
   CHECK(count == 0); /* a timeout is reported as "does not resolve" */
 

--- a/tests/28_local-pause.test
+++ b/tests/28_local-pause.test
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
-# --pause (#185): a fixed inter-file delay must slow a multi-file crawl. Measure
-# the same crawl with and without --pause and compare: the harness overhead
-# cancels, leaving only the pause. Integer seconds keep it portable (BSD date
-# has no %N). The cancelling holds only while the box times the same crawl the
-# same way twice, so a missing delta is re-timed before it convicts --pause.
+# --pause (#185): a fixed inter-file delay must slow a multi-file crawl. One
+# --pause value sets min and max alike, so the engine cannot launch N files in
+# less than (N-1) pauses however fast the box is. That floor is what is asserted
+# here. The old test compared two whole crawls and wanted the paused one 2s
+# slower, which a loaded box manufactures out of its own noise.
 
 set -e
 
@@ -15,28 +15,30 @@ set -e
 # run() swallows its exit-77 and the serverless 0s/0s crawl looks like a fail.
 find_python >/dev/null || skip "python3 not found"
 
+# The engine's own "files written" count. --files asserts it on every pass, so a
+# fixture that gains or loses a link reds here instead of leaving the floor stale.
+files=18
+pause=2
+# Two off the count rather than one, because the top-level index is written
+# without a fetch of its own and the floor has to stay a floor.
+floor=$(((files - 2) * pause))
+
 run() { # echoes the wall-clock seconds of one crawl
     local t0 t1
     t0=$(date +%s)
-    bash "$top_srcdir/tests/local-crawl.sh" --errors 0 \
+    bash "$top_srcdir/tests/local-crawl.sh" --errors 0 --files "$files" \
         httrack 'BASEURL/types/index.html' -c1 "$@" >/dev/null 2>&1
     t1=$(date +%s)
     echo $((t1 - t0))
 }
 
 base=$(run)
-paused=$(run --pause 0.5)
-delta=$((paused - base))
+paused=$(run --pause "$pause")
 
-echo "crawl: ${base}s, with --pause 0.5: ${paused}s (delta ${delta}s)"
-if [ "$delta" -lt 2 ]; then
-    # A loaded box moves both crawls by more than the pause adds, so a missing
-    # delta only convicts --pause where the unpaused crawl repeats its own time.
-    again=$(run)
-    noise=$((again - base))
-    [ "$noise" -ge 0 ] || noise=$((-noise))
-    [ "$noise" -lt 2 ] ||
-        skip "the unpaused crawl timed ${base}s then ${again}s; a ${delta}s delta says nothing on this box"
-    echo "FAIL: --pause did not delay the crawl (delta ${delta}s)" >&2
-    exit 1
-fi
+echo "crawl: ${base}s, with --pause ${pause}: ${paused}s (floor ${floor}s)"
+# A pause only ever adds time, so no load can push a working crawl under this.
+test "$paused" -ge "$floor" ||
+    fail "--pause did not delay the crawl: ${paused}s for ${files} files ${pause}s apart"
+# And the floor decides nothing on a box that reaches it unpaused anyway.
+test "$base" -lt "$floor" ||
+    skip "the unpaused crawl took ${base}s, past the ${floor}s floor: this box cannot show the pause"

--- a/tests/28_local-pause.test
+++ b/tests/28_local-pause.test
@@ -3,7 +3,8 @@
 # --pause (#185): a fixed inter-file delay must slow a multi-file crawl. Measure
 # the same crawl with and without --pause and compare: the harness overhead
 # cancels, leaving only the pause. Integer seconds keep it portable (BSD date
-# has no %N); a lower bound is not timing-flaky since a pause only adds time.
+# has no %N). The cancelling holds only while the box times the same crawl the
+# same way twice, so a missing delta is re-timed before it convicts --pause.
 
 set -e
 
@@ -29,6 +30,13 @@ delta=$((paused - base))
 
 echo "crawl: ${base}s, with --pause 0.5: ${paused}s (delta ${delta}s)"
 if [ "$delta" -lt 2 ]; then
+    # A loaded box moves both crawls by more than the pause adds, so a missing
+    # delta only convicts --pause where the unpaused crawl repeats its own time.
+    again=$(run)
+    noise=$((again - base))
+    [ "$noise" -ge 0 ] || noise=$((-noise))
+    [ "$noise" -lt 2 ] ||
+        skip "the unpaused crawl timed ${base}s then ${again}s; a ${delta}s delta says nothing on this box"
     echo "FAIL: --pause did not delay the crawl (delta ${delta}s)" >&2
     exit 1
 fi

--- a/tests/58_watchdog.test
+++ b/tests/58_watchdog.test
@@ -35,8 +35,7 @@ test "$((SECONDS - start))" -lt 15 || fail "watchdog fired late"
 
 # The native descendant tree is really dead, not orphaned. The Windows arm reads
 # /proc/<pid>/winpid, which only MSYS has, so it asks about that shell and not
-# about the binary; on POSIX a surviving grandchild would touch the marker after
-# we stop waiting.
+# about the binary; on POSIX it asks whether the grandchild's own pid still runs.
 rc=0
 if shell_is_msys; then
     # Existence by exact Windows PID, not a global ping.exe count: the timing
@@ -73,16 +72,29 @@ if shell_is_msys; then
     while alive "$w" && test "$((SECONDS - start))" -lt "$REAP_GRACE"; do sleep 1; done
     ! alive "$w" || fail "native ping grandchild (pid $w) survived the watchdog"
 else
-    started="$tmp/started" marker="$tmp/alive"
-    # The grandchild (backgrounded subshell) marks that it ran, then would touch
-    # the marker after the deadline; killing only the direct child orphans it, so
-    # the marker still appears. started present + marker absent = ran and reaped.
-    # shellcheck disable=SC2016 # $1/$2 expand in the sh -c child, by design
-    run_with_timeout 2 sh -c '{ : >"$1"; sleep 10; : >"$2"; } & wait' _ "$started" "$marker" || rc=$?
+    started="$tmp/started" pidfile="$tmp/gcpid"
+    grandchild_lives() { kill -0 "$gcpid" 2>/dev/null && ! pid_is_zombie "$gcpid"; }
+    reap_grandchild() { test -z "${gcpid:-}" || kill -9 "$gcpid" 2>/dev/null || true; }
+    # The grandchild marks that it ran, hands back its own pid and then execs a
+    # sleep that outlasts every deadline here, so killing only the direct child
+    # leaves that one pid running. A marker it wrote on a timer instead would go
+    # missing whenever the scheduler starved it, and missing reads as reaped.
+    # shellcheck disable=SC2016 # $1, $2 and $! expand in the sh -c child, by design
+    run_with_timeout 2 sh -c '{ : >"$1"; exec sleep 300; } & echo $! >"$2"; wait' _ "$started" "$pidfile" || rc=$?
     test "$rc" -eq 124 || fail "grandchild hang reported $rc"
     test -e "$started" || fail "positive control: grandchild never ran"
-    sleep 12
-    test ! -e "$marker" || fail "watchdog left a grandchild running"
+    gcpid=$(cat "$pidfile" 2>/dev/null) || gcpid=
+    test -n "$gcpid" || fail "positive control: the grandchild named no pid"
+    cleanup_push reap_grandchild
+    # A probe that answers "gone" for everything would call any survivor reaped.
+    kill -0 "$$" || fail "kill -0 cannot see this shell, so it can see nothing"
+    # Zombie counts as dead: who reaps an orphan is prompt on a workstation and
+    # not on a buildd, and reap_bounded already splits them that way.
+    start=$SECONDS
+    while grandchild_lives; do
+        test "$((SECONDS - start))" -lt "$REAP_GRACE" || fail "watchdog left a grandchild running (pid $gcpid)"
+        poll_wait 1
+    done
 fi
 
 # Wall clock, not iteration count: under starvation a poll costs more than it asks,

--- a/tests/58_watchdog.test
+++ b/tests/58_watchdog.test
@@ -95,6 +95,7 @@ else
         test "$((SECONDS - start))" -lt "$REAP_GRACE" || fail "watchdog left a grandchild running (pid $gcpid)"
         poll_wait 1
     done
+    gcpid= # disarm: the number is free to be recycled from here on
 fi
 
 # Wall clock, not iteration count: under starvation a poll costs more than it asks,


### PR DESCRIPTION
`58_watchdog` checked that the suite watchdog kills a whole process tree by sleeping 12 seconds and asserting a marker file never appeared. The orphan writes that marker itself, ten seconds in. Keep it off a CPU for the last two seconds and the marker stays absent, so the test reads green on a broken watchdog. To reproduce it I pinned the grandchild to a saturated CPU at `SCHED_IDLE` and gave `kill_tree` a child-only kill. The old assertion passed three runs out of three, the replacement failed three out of three. It now reads the orphan's own pid, which no schedule can hide. A passing run ends when that pid is gone rather than sleeping out the twelve seconds.

`28_local-pause` wanted the paused crawl two seconds slower than an unpaused one. That delta is noise on a loaded box. Six runs against 250 spinners gave 4, 4, 7, -2, 11 and 1 seconds. Under varying load the review measured a `--pause` compiled out passing 9 runs of 12. A single `--pause` value sets min and max alike, so the engine cannot launch 18 files in under 16 gaps of it. The test now asserts that floor, which load can only raise, and skips when an unpaused crawl reaches it anyway. With `--pause` compiled out it fails 8 runs of 8 under varying load, where the crawl stays at 4s against a 32s floor. It costs 42s instead of 14s, well inside the suite's longest leg.

The DNS timeout self-test gains a tripwire: the mock resolver had not answered when `hts_dns_resolve_all` returned. It is not an independent bound. The mock returns 3000ms in and the clock fires at 1500ms. The count speaks alone only if `MOCK_SLOW_MS` stops being the larger of the two. The 500ms slack is unchanged.

The other candidates I was pointed at are not width-sensitive, so I left them alone. Each figure below comes from the same 250 spinners:

- `262_local-signal-receive` guards its conclusion with `started < 8`, and `started` reached 2. It fails loudly rather than passing, so it was never the dangerous shape.
- `58_watchdog`'s starved-poll case reads 8s against a 12s bound, loaded and idle alike, because its clock is the shimmed `sleep` that load does not stretch.
- `72_watchdog-crawl` reads 12s against a 25s bound, and the `watchdog fired` line in its log already pins the exit on the watchdog without the clock.
- `384_staged-install-lock` passed five runs out of five, so nothing I could do made the waiter miss its four-second window.
- The fixture readiness wait in `52`, `57` and `395` counts 100 iterations rather than seconds, and load stretches an iteration in the safe direction. It needed 11 of the 100.

Breaking the subject reds each new form: a child-only `kill_tree` for the watchdog, and a resolve that ignores its timeout for the DNS bound.