### PR TITLE
Two allocation failures abort the crawler where a third one fails the page

### DIFF
--- a/src/htsarrays.h
+++ b/src/htsarrays.h
@@ -45,8 +45,8 @@ Please visit our Website: http://www.httrack.com
 
 #include "htssafe.h"
 
-/* Abort (with the failed byte count) when a growth allocation fails. The
-   array macros never return an out-of-memory error; they assert and abort. */
+/* Abort on a NULL the caller has no way to fail gracefully. Not what the array
+   macros do: they record the failure and let the caller decide. */
 static HTS_UNUSED void hts_record_assert_memory_failed(const size_t size) {
   fprintf(stderr, "memory allocation failed (%lu bytes)", (long int) size);
   assertf(!"memory allocation failed");
@@ -66,10 +66,19 @@ static HTS_UNUSED void hts_record_assert_memory_failed(const size_t size) {
     size_t size;                                                               \
     /** Capacity. **/                                                          \
     size_t capa;                                                               \
+    /** Sticky: a growth allocation returned NULL. **/                         \
+    hts_boolean failed;                                                        \
   }
 
 /** Initializer for an empty array (no backing store, size and capacity 0). **/
-#define EMPTY_TYPED_ARRAY {{NULL}, 0, 0}
+#define EMPTY_TYPED_ARRAY {{NULL}, 0, 0, HTS_FALSE}
+
+/**
+ * Has a growth allocation failed on this array?
+ * Sticky, so one test covers a run of appends; what was added before the
+ * failure is still there, what came after is not.
+ **/
+#define TypedArrayFailed(A) ((A).failed)
 
 /** Array size, in elements. **/
 #define TypedArraySize(A) ((A).size)
@@ -105,41 +114,51 @@ static HTS_UNUSED void hts_record_assert_memory_failed(const size_t size) {
 
 /**
  * Ensure at least 'ROOM' elements can be put in the remaining space.
- * After a call to this macro, TypedArrayRoom(A) is guaranteed to be at
- * least equal to 'ROOM'. Aborts if the total would not fit a size_t.
+ * On success TypedArrayRoom(A) is at least 'ROOM'; on an allocation failure
+ * the array keeps its previous contents and TypedArrayFailed(A) turns true.
+ * Aborts only if the total would not fit a size_t, which is a caller bug.
  **/
 #define TypedArrayEnsureRoom(A, ROOM)                                          \
   do {                                                                         \
-    const size_t room_ = (ROOM);                                               \
-    /* Largest element count whose byte size still fits a size_t. */           \
-    const size_t maxCapa_ = (size_t) -1 / TypedArrayWidth(A);                  \
-    const size_t minCapa_ = maxCapa_ < 16 ? maxCapa_ : 16;                     \
-    size_t capa_ = TypedArrayCapa(A);                                          \
-    assertf(room_ <= maxCapa_ - TypedArraySize(A));                            \
-    /* Saturating: a plain capa_*2 wraps to 0 and the loop never ends. */      \
-    while (capa_ - TypedArraySize(A) < room_) {                                \
-      capa_ = capa_ < minCapa_       ? minCapa_                                \
-              : capa_ > maxCapa_ / 2 ? maxCapa_                                \
-                                     : capa_ * 2;                              \
-    }                                                                          \
-    TypedArrayCapa(A) = capa_;                                                 \
-    TypedArrayPtr(A) = realloct(TypedArrayPtr(A), capa_ * TypedArrayWidth(A)); \
-    if (TypedArrayPtr(A) == NULL) {                                            \
-      hts_record_assert_memory_failed(capa_ *TypedArrayWidth(A));              \
+    if (!TypedArrayFailed(A)) {                                                \
+      const size_t room_ = (ROOM);                                             \
+      /* Largest element count whose byte size still fits a size_t. */         \
+      const size_t maxCapa_ = (size_t) -1 / TypedArrayWidth(A);                \
+      const size_t minCapa_ = maxCapa_ < 16 ? maxCapa_ : 16;                   \
+      size_t capa_ = TypedArrayCapa(A);                                        \
+      void *newPtr_;                                                           \
+      assertf(room_ <= maxCapa_ - TypedArraySize(A));                          \
+      /* Saturating: a plain capa_*2 wraps to 0 and the loop never ends. */    \
+      while (capa_ - TypedArraySize(A) < room_) {                              \
+        capa_ = capa_ < minCapa_       ? minCapa_                              \
+                : capa_ > maxCapa_ / 2 ? maxCapa_                              \
+                                       : capa_ * 2;                            \
+      }                                                                        \
+      /* Via a temporary: realloc keeps the old block on failure. */           \
+      newPtr_ = realloct(TypedArrayPtr(A), capa_ * TypedArrayWidth(A));        \
+      if (newPtr_ != NULL) {                                                   \
+        TypedArrayPtr(A) = newPtr_;                                            \
+        TypedArrayCapa(A) = capa_;                                             \
+      } else {                                                                 \
+        TypedArrayFailed(A) = HTS_TRUE;                                        \
+      }                                                                        \
     }                                                                          \
   } while (0)
 
-/** Add an element. Macro, first element evaluated multiple times. **/
+/** Add an element, unless the array has already failed to grow. Macro, first
+    element evaluated multiple times. **/
 #define TypedArrayAdd(A, E)                                                    \
   do {                                                                         \
     TypedArrayEnsureRoom(A, 1);                                                \
-    assertf(TypedArraySize(A) < TypedArrayCapa(A));                            \
-    TypedArrayTail(A) = (E);                                                   \
-    TypedArraySize(A)++;                                                       \
+    if (!TypedArrayFailed(A)) {                                                \
+      assertf(TypedArraySize(A) < TypedArrayCapa(A));                          \
+      TypedArrayTail(A) = (E);                                                 \
+      TypedArraySize(A)++;                                                     \
+    }                                                                          \
   } while (0)
 
 /**
- * Add 'COUNT' elements from 'PTR'.
+ * Add 'COUNT' elements from 'PTR', unless the array has already failed to grow.
  * Macro, first element evaluated multiple times.
  **/
 #define TypedArrayAppend(A, PTR, COUNT)                                        \
@@ -151,15 +170,18 @@ static HTS_UNUSED void hts_record_assert_memory_failed(const size_t size) {
     } else {                                                                   \
       const void *const source_ = (PTR);                                       \
       TypedArrayEnsureRoom(A, count_);                                         \
-      assertf(count_ <= TypedArrayRoom(A));                                    \
-      memcpy(&TypedArrayTail(A), source_, count_ *TypedArrayWidth(A));         \
-      TypedArraySize(A) += count_;                                             \
+      if (!TypedArrayFailed(A)) {                                              \
+        assertf(count_ <= TypedArrayRoom(A));                                  \
+        memcpy(&TypedArrayTail(A), source_, count_ *TypedArrayWidth(A));       \
+        TypedArraySize(A) += count_;                                           \
+      }                                                                        \
     }                                                                          \
   } while (0)
 
-/** Clear an array, freeing memory and clearing size and capacity. **/
+/** Clear an array, freeing memory and clearing size, capacity and failure. **/
 #define TypedArrayFree(A)                                                      \
   do {                                                                         \
+    TypedArrayFailed(A) = HTS_FALSE;                                           \
     if (TypedArrayPtr(A) != NULL) {                                            \
       TypedArrayCapa(A) = TypedArraySize(A) = 0;                               \
       freet(TypedArrayPtr(A));                                                 \

--- a/src/htsarrays.h
+++ b/src/htsarrays.h
@@ -46,7 +46,7 @@ Please visit our Website: http://www.httrack.com
 #include "htssafe.h"
 
 /* Abort on a NULL the caller has no way to fail gracefully. Not what the array
-   macros do: they record the failure and let the caller decide. */
+   macros do: they leave the array as it was and let the caller notice. */
 static HTS_UNUSED void hts_record_assert_memory_failed(const size_t size) {
   fprintf(stderr, "memory allocation failed (%lu bytes)", (long int) size);
   assertf(!"memory allocation failed");
@@ -66,19 +66,10 @@ static HTS_UNUSED void hts_record_assert_memory_failed(const size_t size) {
     size_t size;                                                               \
     /** Capacity. **/                                                          \
     size_t capa;                                                               \
-    /** Sticky: a growth allocation returned NULL. **/                         \
-    hts_boolean failed;                                                        \
   }
 
 /** Initializer for an empty array (no backing store, size and capacity 0). **/
-#define EMPTY_TYPED_ARRAY {{NULL}, 0, 0, HTS_FALSE}
-
-/**
- * Has a growth allocation failed on this array?
- * Sticky, so one test covers a run of appends; what was added before the
- * failure is still there, what came after is not.
- **/
-#define TypedArrayFailed(A) ((A).failed)
+#define EMPTY_TYPED_ARRAY {{NULL}, 0, 0}
 
 /** Array size, in elements. **/
 #define TypedArraySize(A) ((A).size)
@@ -113,52 +104,56 @@ static HTS_UNUSED void hts_record_assert_memory_failed(const size_t size) {
 #define TypedArrayTail(A) (TypedArrayNth(A, TypedArraySize(A)))
 
 /**
+ * Can 'ROOM' more elements be put in the array?
+ * This is how a growth failure is reported: TypedArrayEnsureRoom(A, ROOM)
+ * leaves the array untouched when it cannot allocate, so the caller asks
+ * again. Macro, first element evaluated multiple times.
+ **/
+#define TypedArrayHasRoom(A, ROOM) (TypedArrayRoom(A) >= (ROOM))
+
+/**
  * Ensure at least 'ROOM' elements can be put in the remaining space.
- * On success TypedArrayRoom(A) is at least 'ROOM'; on an allocation failure
- * the array keeps its previous contents and TypedArrayFailed(A) turns true.
- * Aborts only if the total would not fit a size_t, which is a caller bug.
+ * On success TypedArrayRoom(A) is at least 'ROOM'. An allocation failure
+ * leaves contents, size and capacity as they were, for the caller to notice
+ * with TypedArrayHasRoom(). Aborts only if the total would not fit a size_t,
+ * which is a caller bug.
  **/
 #define TypedArrayEnsureRoom(A, ROOM)                                          \
   do {                                                                         \
-    if (!TypedArrayFailed(A)) {                                                \
-      const size_t room_ = (ROOM);                                             \
-      /* Largest element count whose byte size still fits a size_t. */         \
-      const size_t maxCapa_ = (size_t) -1 / TypedArrayWidth(A);                \
-      const size_t minCapa_ = maxCapa_ < 16 ? maxCapa_ : 16;                   \
-      size_t capa_ = TypedArrayCapa(A);                                        \
-      void *newPtr_;                                                           \
-      assertf(room_ <= maxCapa_ - TypedArraySize(A));                          \
-      /* Saturating: a plain capa_*2 wraps to 0 and the loop never ends. */    \
-      while (capa_ - TypedArraySize(A) < room_) {                              \
-        capa_ = capa_ < minCapa_       ? minCapa_                              \
-                : capa_ > maxCapa_ / 2 ? maxCapa_                              \
-                                       : capa_ * 2;                            \
-      }                                                                        \
-      /* Via a temporary: realloc keeps the old block on failure. */           \
-      newPtr_ = realloct(TypedArrayPtr(A), capa_ * TypedArrayWidth(A));        \
-      if (newPtr_ != NULL) {                                                   \
-        TypedArrayPtr(A) = newPtr_;                                            \
-        TypedArrayCapa(A) = capa_;                                             \
-      } else {                                                                 \
-        TypedArrayFailed(A) = HTS_TRUE;                                        \
-      }                                                                        \
+    const size_t room_ = (ROOM);                                               \
+    /* Largest element count whose byte size still fits a size_t. */           \
+    const size_t maxCapa_ = (size_t) -1 / TypedArrayWidth(A);                  \
+    const size_t minCapa_ = maxCapa_ < 16 ? maxCapa_ : 16;                     \
+    size_t capa_ = TypedArrayCapa(A);                                          \
+    void *newPtr_;                                                             \
+    assertf(room_ <= maxCapa_ - TypedArraySize(A));                            \
+    /* Saturating: a plain capa_*2 wraps to 0 and the loop never ends. */      \
+    while (capa_ - TypedArraySize(A) < room_) {                                \
+      capa_ = capa_ < minCapa_       ? minCapa_                                \
+              : capa_ > maxCapa_ / 2 ? maxCapa_                                \
+                                     : capa_ * 2;                              \
+    }                                                                          \
+    /* Via a temporary: realloc keeps the old block on failure. */             \
+    newPtr_ = realloct(TypedArrayPtr(A), capa_ * TypedArrayWidth(A));          \
+    if (newPtr_ != NULL) {                                                     \
+      TypedArrayPtr(A) = newPtr_;                                              \
+      TypedArrayCapa(A) = capa_;                                               \
     }                                                                          \
   } while (0)
 
-/** Add an element, unless the array has already failed to grow. Macro, first
-    element evaluated multiple times. **/
+/** Add an element, if the array can be grown to hold it. Macro, first element
+    evaluated multiple times. **/
 #define TypedArrayAdd(A, E)                                                    \
   do {                                                                         \
     TypedArrayEnsureRoom(A, 1);                                                \
-    if (!TypedArrayFailed(A)) {                                                \
-      assertf(TypedArraySize(A) < TypedArrayCapa(A));                          \
+    if (TypedArrayHasRoom(A, 1)) {                                             \
       TypedArrayTail(A) = (E);                                                 \
       TypedArraySize(A)++;                                                     \
     }                                                                          \
   } while (0)
 
 /**
- * Add 'COUNT' elements from 'PTR', unless the array has already failed to grow.
+ * Add 'COUNT' elements from 'PTR', if the array can be grown to hold them.
  * Macro, first element evaluated multiple times.
  **/
 #define TypedArrayAppend(A, PTR, COUNT)                                        \
@@ -170,18 +165,16 @@ static HTS_UNUSED void hts_record_assert_memory_failed(const size_t size) {
     } else {                                                                   \
       const void *const source_ = (PTR);                                       \
       TypedArrayEnsureRoom(A, count_);                                         \
-      if (!TypedArrayFailed(A)) {                                              \
-        assertf(count_ <= TypedArrayRoom(A));                                  \
+      if (TypedArrayHasRoom(A, count_)) {                                      \
         memcpy(&TypedArrayTail(A), source_, count_ *TypedArrayWidth(A));       \
         TypedArraySize(A) += count_;                                           \
       }                                                                        \
     }                                                                          \
   } while (0)
 
-/** Clear an array, freeing memory and clearing size, capacity and failure. **/
+/** Clear an array, freeing memory and clearing size and capacity. **/
 #define TypedArrayFree(A)                                                      \
   do {                                                                         \
-    TypedArrayFailed(A) = HTS_FALSE;                                           \
     if (TypedArrayPtr(A) != NULL) {                                            \
       TypedArrayCapa(A) = TypedArraySize(A) = 0;                               \
       freet(TypedArrayPtr(A));                                                 \

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -263,7 +263,7 @@ static size_t hts_record_link_alloc(httrackp *opt) {
 
   // Add new lien_url pointer to the array of links, plus the guard NULL
   TypedArrayEnsureRoom(liensbuf->ptr, 2);
-  if (TypedArrayFailed(liensbuf->ptr)) {
+  if (!TypedArrayHasRoom(liensbuf->ptr, 2)) {
     return (size_t) -1;
   }
   TypedArrayAdd(liensbuf->ptr, link);

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -261,10 +261,12 @@ static size_t hts_record_link_alloc(httrackp *opt) {
   }
   memset(link, 0, sizeof(*link));
 
-  // Add new lien_url pointer to the array of links
+  // Add new lien_url pointer to the array of links, plus the guard NULL
+  TypedArrayEnsureRoom(liensbuf->ptr, 2);
+  if (TypedArrayFailed(liensbuf->ptr)) {
+    return (size_t) -1;
+  }
   TypedArrayAdd(liensbuf->ptr, link);
-
-  // Ensure we have a guard NULL
   TypedArrayAdd(liensbuf->ptr, NULL);
   TypedArraySize(liensbuf->ptr)--;
 
@@ -474,6 +476,71 @@ hts_boolean hts_scan_token(char **ptr, char *dest, size_t destsize) {
     a++;
   *ptr = a;
   return len < destsize ? HTS_TRUE : HTS_FALSE;
+}
+
+/* UTF-8 byte count of the BMP code point 'unic'; an unpaired surrogate is
+   emitted as a single '?'. Ranges:
+   http://www.unicode.org/reports/tr28/tr28-3.html#conformance */
+static size_t utf8_width(unsigned int unic) {
+  if (unic <= 0x7F)
+    return 1;
+  else if (unic <= 0x7FF)
+    return 2;
+  else if (unic >= 0xD800 && unic <= 0xDFFF)
+    return 1;
+  else
+    return 3;
+}
+
+/* Read the 'i'th UCS2 code unit of 'src'. */
+static unsigned int ucs2_unit(const unsigned char *src, size_t i,
+                              hts_boolean swap) {
+  return swap ? src[i * 2] + (src[i * 2 + 1] << 8)
+              : (src[i * 2] << 8) + src[i * 2 + 1];
+}
+
+char *hts_ucs2_to_utf8(const unsigned char *src, size_t size, hts_boolean swap,
+                       size_t *outsize) {
+  const size_t units = size / 2;
+  /* Signed and wide, because three bytes per unit overflows a 32-bit size_t. */
+  LLint total = 0;
+  size_t i;
+  size_t offs = 0;
+  char *dest;
+
+  /* Sized exactly, because one output byte per code unit does not hold: a
+     UTF-16 BOM alone is three UTF-8 bytes. */
+  for (i = 0; i < units; i++) {
+    total += (LLint) utf8_width(ucs2_unit(src, i, swap));
+  }
+  if (!hts_inmem_size_fits(total + 1)) {
+    return NULL;
+  }
+  dest = (char *) malloct((size_t) total + 1);
+  if (dest == NULL) {
+    return NULL;
+  }
+
+  for (i = 0; i < units; i++) {
+    const unsigned int unic = ucs2_unit(src, i, swap);
+
+    if (unic <= 0x7F) {
+      dest[offs++] = (char) unic;
+    } else if (unic <= 0x7FF) {
+      dest[offs++] = (char) (0xC0 | (unic >> 6));
+      dest[offs++] = (char) (0x80 | (unic & 0x3F));
+    } else if (unic >= 0xD800 && unic <= 0xDFFF) {
+      dest[offs++] = '?'; /* ill-formed */
+    } else {
+      dest[offs++] = (char) (0xE0 | (unic >> 12));
+      dest[offs++] = (char) (0x80 | ((unic >> 6) & 0x3F));
+      dest[offs++] = (char) (0x80 | (unic & 0x3F));
+    }
+  }
+  assertf(offs == (size_t) total);
+  dest[offs] = '\0';
+  *outsize = offs;
+  return dest;
 }
 
 /* does it look like XML ? (SVG et al.) */
@@ -1415,101 +1482,31 @@ int httpmirror(char *url1, httrackp *opt, hts_boolean *completed_out) {
                      && ((unsigned char) r.adr[1]) == 0xff)
                 )
               ) {
-#define CH_ADD(c) do {															\
-	if (new_offs + 1 > new_capa) {										\
-		new_capa *= 2;																	\
-		new_adr = (unsigned char*) realloct(new_adr,    \
-		                                    new_capa); 	\
-		assertf(new_adr != NULL);												\
-	}																									\
-	new_adr[new_offs++] = (unsigned char) (c);        \
-} while(0)
-#define CH_ADD_RNG1(c, r, o) do {                   \
-	CH_ADD( (c) / (r) + (o) );                        \
-	c = (c) % (r);                                    \
-} while(0)
-#define CH_ADD_RNG0(c, o) do {                      \
-	CH_ADD_RNG1(c, 1, o); 	 													\
-} while(0)
-#define CH_ADD_RNG2(c, r, r2, o) do {               \
-	CH_ADD_RNG1(c, (r) * (r2), o);	 									\
-} while(0)
-              int new_capa = (int) (r.size / 2 + 1);
-              int new_offs = 0;
-              unsigned char *prev_adr = (unsigned char *) r.adr;
-              unsigned char *new_adr = (unsigned char *) malloct(new_capa);
-              int i;
-              int swap = (((unsigned char) r.adr[0]) == 0xff);
+              size_t new_size = 0;
+              char *const new_adr = hts_ucs2_to_utf8(
+                  (const unsigned char *) r.adr, (size_t) r.size,
+                  ((unsigned char) r.adr[0]) == 0xff ? HTS_TRUE : HTS_FALSE,
+                  &new_size);
 
-              assertf(new_adr != NULL);
-              /* 
-                 See http://www.unicode.org/reports/tr28/tr28-3.html#conformance 
-                 U+0000..U+007F 00..7F       
-                 U+0080..U+07FF C2..DF  80..BF      
-                 U+0800..U+0FFF E0      A0..BF  80..BF    
-                 U+1000..U+CFFF E1..EC  80..BF  80..BF    
-                 U+D000..U+D7FF ED      80..9F  80..BF    
-                 U+D800..U+DFFF
-                 U+E000..U+FFFF EE..EF  80..BF  80..BF    
-               */
-              for(i = 0; i < r.size / 2; i++) {
-                unsigned short int unic = 0;
-
-                if (swap)
-                  unic = prev_adr[i * 2] + (prev_adr[i * 2 + 1] << 8);
-                else
-                  unic = (prev_adr[i * 2] << 8) + prev_adr[i * 2 + 1];
-                if (unic <= 0x7F) {
-                  /* U+0000..U+007F 00..7F      */
-                  CH_ADD_RNG0(unic, 0x00);
-                } else if (unic <= 0x07FF) {
-                  /* U+0080..U+07FF C2..DF  80..BF */
-                  unic -= 0x0080;
-                  CH_ADD_RNG1(unic, 0xbf - 0x80 + 1, 0xc2);
-                  CH_ADD_RNG0(unic, 0x80);
-                } else if (unic <= 0x0FFF) {
-                  /* U+0800..U+0FFF E0      A0..BF  80..BF */
-                  unic -= 0x0800;
-                  CH_ADD_RNG2(unic, 0xbf - 0x80 + 1, 0xbf - 0xa0 + 1, 0xe0);
-                  CH_ADD_RNG1(unic, 0xbf - 0x80 + 1, 0xa0);
-                  CH_ADD_RNG0(unic, 0x80);
-                } else if (unic <= 0xCFFF) {
-                  /* U+1000..U+CFFF E1..EC  80..BF  80..BF */
-                  unic -= 0x1000;
-                  CH_ADD_RNG2(unic, 0xbf - 0x80 + 1, 0xbf - 0x80 + 1, 0xe1);
-                  CH_ADD_RNG1(unic, 0xbf - 0x80 + 1, 0x80);
-                  CH_ADD_RNG0(unic, 0x80);
-                } else if (unic <= 0xD7FF) {
-                  /* U+D000..U+D7FF ED      80..9F  80..BF */
-                  unic -= 0xD000;
-                  CH_ADD_RNG2(unic, 0xbf - 0x80 + 1, 0x9f - 0x80 + 1, 0xed);
-                  CH_ADD_RNG1(unic, 0xbf - 0x80 + 1, 0x80);
-                  CH_ADD_RNG0(unic, 0x80);
-                } else if (unic <= 0xDFFF) {
-                  /* U+D800..U+DFFF */
-                  CH_ADD('?');
-                  /* ill-formed */
-                } else {        /* if (unic <= 0xFFFF) */
-
-                  /* U+E000..U+FFFF EE..EF  80..BF  80..BF */
-                  unic -= 0xE000;
-                  CH_ADD_RNG2(unic, 0xbf - 0x80 + 1, 0xbf - 0x80 + 1, 0xee);
-                  CH_ADD_RNG1(unic, 0xbf - 0x80 + 1, 0x80);
-                  CH_ADD_RNG0(unic, 0x80);
-                }
+              if (new_adr == NULL) {
+                /* Fail the page, not the crawl: http_xfread1() answers the
+                   same NULL the same way. */
+                hts_log_print(
+                    opt, LOG_ERROR,
+                    "Not enough memory to convert %s%s from UCS2 to UTF-8",
+                    urladr(), urlfil());
+                r.statuscode = STATUSCODE_INVALID;
+                strcpybuff(r.msg, "Not enough memory");
+                error = 1;
+              } else {
+                hts_log_print(opt, LOG_WARNING,
+                              "File %s%s converted from UCS2 to UTF-8 (old "
+                              "size: %d bytes, new size: %d bytes)",
+                              urladr(), urlfil(), (int) r.size, (int) new_size);
+                freet(r.adr);
+                r.adr = new_adr;
+                r.size = (LLint) new_size;
               }
-              hts_log_print(opt, LOG_WARNING,
-                            "File %s%s converted from UCS2 to UTF-8 (old size: %d bytes, new size: %d bytes)",
-                            urladr(), urlfil(), (int) r.size, new_offs);
-              freet(r.adr);
-              r.adr = NULL;
-              r.size = new_offs;
-              CH_ADD(0);
-              r.adr = (char *) new_adr;
-#undef CH_ADD
-#undef CH_ADD_RNG0
-#undef CH_ADD_RNG1
-#undef CH_ADD_RNG2
               /* NULs count too where the wire declared nothing: the body is
                  the only evidence there is, and the blanking below would
                  corrupt what the server left untyped (#1415). Same ratio and
@@ -1525,13 +1522,12 @@ int httpmirror(char *url1, httrackp *opt, hts_boolean *completed_out) {
             }
 
             /* This hack allows you to avoid problems with parsing '\0' characters  */
-            if (!is_binary) {
+            if (!is_binary && !error) {
               for(i = 0; i < r.size; i++) {
                 if (r.adr[i] == '\0')
                   r.adr[i] = ' ';
               }
             }
-
           }
 
         }

--- a/src/htscore.h
+++ b/src/htscore.h
@@ -392,6 +392,13 @@ void hts_finish_makeindex(httrackp *opt, int *makeindex_done,
                           const char *template_footer, const char *adr,
                           const char *fil);
 
+/* Re-encode 'size' bytes of UCS2 (UTF-16, BMP only) as UTF-8. 'swap' selects
+   little-endian input, 'size' must be even. Returns a NUL-terminated buffer to
+   release with freet(), its length (NUL excluded) in *outsize, or NULL when the
+   result does not fit memory. */
+char *hts_ucs2_to_utf8(const unsigned char *src, size_t size, hts_boolean swap,
+                       size_t *outsize);
+
 // Flush ht_buff[0..ht_len] to save on disk; *fp closed+NULLed on write.
 // Precondition: ht_len>0.
 void hts_finish_html_file(httrackp *opt, cache_back *cache, htsblk *r,

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -3445,7 +3445,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                   adr_next++;
                 }
                 /* Jump to near end (index hack) */
-                if (!adr_next || *adr_next != '<') {
+                if (*adr_next != '<') {
                   if (html - r->adr < r->size - 4
                       && r->size > 4
                     ) {

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -67,32 +67,46 @@ Please visit our Website: http://www.httrack.com
 // arrays
 #include "htsarrays.h"
 
+/* clang-format off: an edit realigns all backslashes, churning the macro. */
+/* clang-format off */
+/** Append 'COUNT' bytes from 'PTR', latching output_oom if the buffer cannot
+    grow to hold them. **/
+#define HT_ADD_N(PTR, COUNT) do { \
+  const size_t want_ = (COUNT); \
+  TypedArrayEnsureRoom(output_buffer, want_); \
+  if (TypedArrayHasRoom(output_buffer, want_)) { \
+    TypedArrayAppend(output_buffer, (PTR), want_); \
+  } else { \
+    output_oom = HTS_TRUE; \
+  } \
+} while(0)
+
 /** Append bytes to the output buffer up to the pointer 'html'. **/
 #define HT_add_adr do { \
   if ( (opt->getmode & 1) != 0 && ptr > 0 ) { \
     const size_t sz_ = html - lastsaved; \
     if (sz_ != 0) { \
-      TypedArrayAppend(output_buffer, lastsaved, sz_); \
+      HT_ADD_N(lastsaved, sz_); \
       lastsaved = html; \
     } \
   } \
 } while(0)
 
 /** Append to the output buffer the string 'A'. **/
-#define HT_ADD(A) TypedArrayAppend(output_buffer, A, strlen(A))
+#define HT_ADD(A) HT_ADD_N(A, strlen(A))
 
-/* clang-format off: an edit realigns all backslashes, churning the macro. */
-/* clang-format off */
 /** Append 'A' to the output buffer, html-escaped; FACTOR = max byte expansion. **/
 #define HT_ADD_HTMLESCAPED_ANY(A, FUNCTION, FACTOR) do { \
   if ((opt->getmode & 1) != 0 && ptr>0) { \
     const char *const str_ = (A); \
-    size_t size_; \
-    TypedArrayEnsureRoom(output_buffer, strlen(str_) * (FACTOR) + 1024); \
-    if (!TypedArrayFailed(output_buffer)) { \
-      size_ = FUNCTION(str_, &TypedArrayTail(output_buffer), \
-                       TypedArrayRoom(output_buffer)); \
-      TypedArraySize(output_buffer) += size_; \
+    const size_t want_ = strlen(str_) * (FACTOR) + 1024; \
+    TypedArrayEnsureRoom(output_buffer, want_); \
+    if (TypedArrayHasRoom(output_buffer, want_)) { \
+      TypedArraySize(output_buffer) += \
+        FUNCTION(str_, &TypedArrayTail(output_buffer), \
+                 TypedArrayRoom(output_buffer)); \
+    } else { \
+      output_oom = HTS_TRUE; \
     } \
   } \
 } while(0)
@@ -441,6 +455,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
     if (!error) {
       // output HTML
       TypedArray(char) output_buffer = EMPTY_TYPED_ARRAY;
+      /* Latched by the HT_ADD_* macros when output_buffer cannot grow. */
+      hts_boolean output_oom = HTS_FALSE;
 
       time_t user_interact_timestamp = 0;
       int detect_title = 0;     // détection  du title
@@ -3451,7 +3467,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
 
         /* The rewritten page outgrew what we can allocate, so end the parse
            here and fail the page rather than the crawl. */
-        if (TypedArrayFailed(output_buffer)) {
+        if (output_oom) {
           html = r->adr + r->size;
         }
 
@@ -3496,7 +3512,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
       opt->state._hts_cancel = 0;       // pas de cancel
 
       if ((opt->getmode & HTS_GETMODE_HTML) && (ptr > 0)) {
-        if (!TypedArrayFailed(output_buffer)) {
+        if (!output_oom) {
           char *cAddr = TypedArrayElts(output_buffer);
           int cSize = (int) TypedArraySize(output_buffer);
 
@@ -3512,7 +3528,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                the block out from under cAddr. */
             if (cAddr != TypedArrayElts(output_buffer)) {
               TypedArraySize(output_buffer) = 0;
-              TypedArrayAppend(output_buffer, cAddr, cSize);
+              HT_ADD_N(cAddr, (size_t) cSize);
             } else {
               TypedArraySize(output_buffer) = (size_t) cSize;
             }
@@ -3520,7 +3536,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
         }
 
         /* Flush and save to disk */
-        if (TypedArrayFailed(output_buffer)) {
+        if (output_oom) {
           hts_log_print(opt, LOG_ERROR,
                         "Not enough memory to rewrite %s%s, page skipped",
                         urladr(), urlfil());

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -89,9 +89,11 @@ Please visit our Website: http://www.httrack.com
     const char *const str_ = (A); \
     size_t size_; \
     TypedArrayEnsureRoom(output_buffer, strlen(str_) * (FACTOR) + 1024); \
-    size_ = FUNCTION(str_, &TypedArrayTail(output_buffer), \
-                     TypedArrayRoom(output_buffer)); \
-    TypedArraySize(output_buffer) += size_; \
+    if (!TypedArrayFailed(output_buffer)) { \
+      size_ = FUNCTION(str_, &TypedArrayTail(output_buffer), \
+                       TypedArrayRoom(output_buffer)); \
+      TypedArraySize(output_buffer) += size_; \
+    } \
   } \
 } while(0)
 
@@ -3447,6 +3449,12 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
         lastsaved = html;        // dernier écrit+1
         // ----------
 
+        /* The rewritten page outgrew what we can allocate, so end the parse
+           here and fail the page rather than the crawl. */
+        if (TypedArrayFailed(output_buffer)) {
+          html = r->adr + r->size;
+        }
+
         // Checks
         if (back_add_stats != opt->state.back_add_stats) {
           back_add_stats = opt->state.back_add_stats;
@@ -3488,7 +3496,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
       opt->state._hts_cancel = 0;       // pas de cancel
 
       if ((opt->getmode & HTS_GETMODE_HTML) && (ptr > 0)) {
-        {
+        if (!TypedArrayFailed(output_buffer)) {
           char *cAddr = TypedArrayElts(output_buffer);
           int cSize = (int) TypedArraySize(output_buffer);
 
@@ -3512,7 +3520,12 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
         }
 
         /* Flush and save to disk */
-        if (TypedArraySize(output_buffer) != 0) {
+        if (TypedArrayFailed(output_buffer)) {
+          hts_log_print(opt, LOG_ERROR,
+                        "Not enough memory to rewrite %s%s, page skipped",
+                        urladr(), urlfil());
+          error = 1;
+        } else if (TypedArraySize(output_buffer) != 0) {
           hts_finish_html_file(
               opt, cache, r, &fp, TypedArrayElts(output_buffer),
               TypedArraySize(output_buffer), urladr(), urlfil(), savename());

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -2302,10 +2302,11 @@ static int st_arrays(httrackp *opt, int argc, char **argv) {
     TypedArrayAppend(a, "kept", 4);
     room = (size_t) -1 - TypedArraySize(a);
     TypedArrayEnsureRoom(a, room);
-    if (!TypedArrayFailed(a))
+    if (TypedArrayHasRoom(a, room))
       err = 1;
-    /* Sticky, and the bytes already there survive the failure. */
-    TypedArrayAppend(a, "lost", 4);
+    /* The bytes already there survive, and the append that cannot fit is a
+       no-op rather than a smash. */
+    TypedArrayAppend(a, "lost", room);
     if (TypedArraySize(a) != 4 || memcmp(TypedArrayElts(a), "kept", 4) != 0)
       err = 1;
     printf("arrays: growth failure %s\n", err ? "FAIL" : "OK");

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -88,6 +88,7 @@ Please visit our Website: http://www.httrack.com
 #include <string.h>
 #include <wchar.h>
 #ifndef _WIN32
+#include <sys/resource.h> /* RLIMIT_AS, to starve one allocation */
 #include <sys/socket.h>
 #include <unistd.h>
 #else
@@ -2150,6 +2151,131 @@ static int st_arena(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* Serialize 'count' UCS2 code units, re-encode them and compare the result
+   against 'expect' (its length taken as the expected byte count, so a NUL is
+   not usable inside a case). */
+static int ucs2_check(const unsigned short *units, size_t count,
+                      const char *expect, hts_boolean swap) {
+  const size_t want = strlen(expect);
+  unsigned char *src = (unsigned char *) malloct(count * 2 + 1);
+  size_t got_size = (size_t) -1;
+  char *got;
+  size_t i;
+  int err = 0;
+
+  if (src == NULL)
+    return 1;
+  for (i = 0; i < count; i++) {
+    src[i * 2 + (swap ? 0 : 1)] = (unsigned char) (units[i] & 0xff);
+    src[i * 2 + (swap ? 1 : 0)] = (unsigned char) (units[i] >> 8);
+  }
+  got = hts_ucs2_to_utf8(src, count * 2, swap, &got_size);
+  if (got == NULL || got_size != want || memcmp(got, expect, want) != 0 ||
+      got[got_size] != '\0')
+    err = 1;
+  freet(got);
+  freet(src);
+  return err;
+}
+
+static int st_ucs2(httrackp *opt, int argc, char **argv) {
+  /* A BOM, ASCII, a two-byte and a three-byte code point, and an unpaired
+     surrogate: only the ASCII one is a single output byte. */
+  static const unsigned short mixed[] = {0xFEFF, 'a', 0x00E9, 0x20AC, 0xD800};
+  static const char mixed_utf8[] = "\xEF\xBB\xBF"
+                                   "a"
+                                   "\xC3\xA9"
+                                   "\xE2\x82\xAC"
+                                   "?";
+  static const unsigned short empty[] = {0};
+
+  (void) opt;
+  if (argc >= 1 && strcmp(argv[0], "oom") == 0) {
+#ifndef _WIN32
+    /* Starve the output allocation. Big enough that the allocator must ask
+       the kernel rather than serve it from what it already holds. */
+    enum { units = 512 * 1024 };
+
+    unsigned char *src = (unsigned char *) malloct(units * 2);
+    struct rlimit saved, tight;
+    size_t out_size = 0;
+    char *out;
+    size_t i;
+
+    if (src == NULL || getrlimit(RLIMIT_AS, &saved) != 0) {
+      printf("ucs2: cannot cap memory, skipped\n");
+      freet(src);
+      return 0;
+    }
+    for (i = 0; i < units; i++) { /* U+20AC, three UTF-8 bytes each */
+      src[i * 2] = 0x20;
+      src[i * 2 + 1] = 0xAC;
+    }
+    tight = saved;
+    tight.rlim_cur = 1024 * 1024;
+    if (setrlimit(RLIMIT_AS, &tight) != 0) {
+      printf("ucs2: cannot cap memory, skipped\n");
+      freet(src);
+      return 0;
+    }
+    out = hts_ucs2_to_utf8(src, units * 2, HTS_FALSE, &out_size);
+    (void) setrlimit(RLIMIT_AS, &saved);
+    freet(src);
+    if (out != NULL) {
+      /* The cap did not bite (a host where RLIMIT_AS is advisory), so this run
+         proves nothing either way. */
+      freet(out);
+      printf("ucs2: cap did not bite, skipped\n");
+      return 0;
+    }
+    printf("ucs2: oom OK\n");
+    return 0;
+#else
+    printf("ucs2: cannot cap memory, skipped\n");
+    return 0;
+#endif
+  } else {
+    int err = 0;
+
+    if (ucs2_check(mixed, sizeof(mixed) / sizeof(mixed[0]), mixed_utf8,
+                   HTS_TRUE))
+      err = 1;
+    if (ucs2_check(mixed, sizeof(mixed) / sizeof(mixed[0]), mixed_utf8,
+                   HTS_FALSE))
+      err = 1;
+    /* Every BMP code unit, to pin the encoder against its ranges. */
+    {
+      unsigned int u;
+
+      for (u = 0; u <= 0xFFFF && !err; u++) {
+        const unsigned short unit = (unsigned short) u;
+        char expect[4];
+        size_t len = 0;
+
+        if (u <= 0x7F)
+          expect[len++] = (char) u;
+        else if (u <= 0x7FF) {
+          expect[len++] = (char) (0xC0 | (u >> 6));
+          expect[len++] = (char) (0x80 | (u & 0x3F));
+        } else if (u >= 0xD800 && u <= 0xDFFF)
+          expect[len++] = '?';
+        else {
+          expect[len++] = (char) (0xE0 | (u >> 12));
+          expect[len++] = (char) (0x80 | ((u >> 6) & 0x3F));
+          expect[len++] = (char) (0x80 | (u & 0x3F));
+        }
+        expect[len] = '\0';
+        if (u != 0 && ucs2_check(&unit, 1, expect, HTS_TRUE))
+          err = 1;
+      }
+    }
+    if (ucs2_check(empty, 0, "", HTS_TRUE))
+      err = 1;
+    printf("ucs2: %s\n", err ? "FAIL" : "OK");
+    return err;
+  }
+}
+
 static int st_arrays(httrackp *opt, int argc, char **argv) {
   /* volatile keeps the sizes below opaque, so these stay runtime checks rather
      than compile-time allocation warnings. */
@@ -2168,13 +2294,23 @@ static int st_arrays(httrackp *opt, int argc, char **argv) {
     printf("arrays: NOT aborted (%p)\n", TypedArrayPtr(w));
     return 1;
   } else if (argc >= 1 && strcmp(argv[0], "overflow-loop") == 0) {
-    /* Doubling past SIZE_MAX used to wrap capa to 0 and spin forever. */
+    /* Doubling past SIZE_MAX used to wrap capa to 0 and spin forever, and the
+       allocation it ends on used to abort the process. */
     TypedArray(char) a = EMPTY_TYPED_ARRAY;
+    int err = 0;
 
-    room = (size_t) -1;
+    TypedArrayAppend(a, "kept", 4);
+    room = (size_t) -1 - TypedArraySize(a);
     TypedArrayEnsureRoom(a, room);
-    printf("arrays: NOT aborted (%p)\n", TypedArrayPtr(a)); /* unreachable */
-    return 1;
+    if (!TypedArrayFailed(a))
+      err = 1;
+    /* Sticky, and the bytes already there survive the failure. */
+    TypedArrayAppend(a, "lost", 4);
+    if (TypedArraySize(a) != 4 || memcmp(TypedArrayElts(a), "kept", 4) != 0)
+      err = 1;
+    printf("arrays: growth failure %s\n", err ? "FAIL" : "OK");
+    TypedArrayFree(a);
+    return err;
   } else {
     const int err = array_growth_selftests();
 
@@ -13440,8 +13576,10 @@ static const struct selftest_entry {
      st_strsprintf},
     {"arena", "", "htsarena.h hands out addresses that never move", st_arena},
     {"arrays", "[overflow-capa|overflow-loop]",
-     "htsarrays.h growth reaches the requested room, overflow aborts",
+     "htsarrays.h growth reaches the requested room, or reports it failed",
      st_arrays},
+    {"ucs2", "[oom]", "UCS2 to UTF-8 re-encoding, and its failure return",
+     st_ucs2},
     {"pubheaders", "",
      "layout of the installed structs configure's switches decide",
      st_pubheaders},

--- a/tests/237_engine-arrays.test
+++ b/tests/237_engine-arrays.test
@@ -31,18 +31,16 @@ case "$err" in
     ;;
 esac
 
-# Room of SIZE_MAX: doubling used to wrap the capacity to 0 and spin forever.
+# Room of SIZE_MAX: doubling used to wrap the capacity to 0 and spin forever,
+# and the allocation it ends on used to abort the process instead of letting
+# the caller fail just the page it was building.
 # ASan kills the process on an over-large request unless told to return NULL.
 err=$(ASAN_OPTIONS="${ASAN_OPTIONS-}${ASAN_OPTIONS:+:}allocator_may_return_null=1" \
-    run_bounded httrack -#test=arrays overflow-loop 2>&1) || true
+    run_bounded httrack -O /dev/null -#test=arrays overflow-loop 2>&1) || true
 case "$err" in
-*"arrays: NOT aborted"*)
-    echo "SIZE_MAX room was NOT caught" >&2
-    exit 1
-    ;;
-*"memory allocation failed"*) ;;
+*"arrays: growth failure OK"*) ;;
 *)
-    echo "expected the growth to terminate and fail to allocate, got: $err" >&2
+    echo "expected the growth to fail and be reported, got: $err" >&2
     exit 1
     ;;
 esac

--- a/tests/439_engine-ucs2.test
+++ b/tests/439_engine-ucs2.test
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+# UCS2 to UTF-8 re-encoding (driven by 'httrack -#test=ucs2').
+
+# Every BMP code unit, plus a BOM and an unpaired surrogate.
+assert_selftest "ucs2: OK" ucs2 run
+
+# An output the process cannot allocate must come back as a NULL the caller
+# fails the page on, not as an abort. The cap is RLIMIT_AS, so hosts where it
+# is advisory report a skip; ASan needs telling to return NULL rather than die.
+rc=0
+out=$(ASAN_OPTIONS="${ASAN_OPTIONS-}${ASAN_OPTIONS:+:}allocator_may_return_null=1" \
+    httrack -O /dev/null -#test=ucs2 oom 2>&1) || rc=$?
+test "$rc" -eq 0 || fail "-#test=ucs2 oom: exited $rc, output: $out"
+case "$out" in
+"ucs2: oom OK") ;;
+*skipped*)
+    echo "SKIP: $out" >&2
+    ;;
+*)
+    fail "expected the failed allocation to be reported, got: $out"
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
`http_xfread1()` in htslib.c already handles a NULL from the allocator. It sets a status code, writes a message into the reply block and returns a read error, so the page fails and the crawl continues. Two other paths read the identical NULL and abort the process. That makes a hostile page plus a memory-capped target (a container under a cgroup limit, a 32-bit build) a remote denial of service.

The HTML rewriter's output buffer grows with the page and nothing caps it. A 4 MB tag-free page under `ulimit -v 50000` used to die at `htsarrays.h:52` with RC=134. The UCS2 to UTF-8 re-encoder pre-sized to `r.size / 2 + 1` and treated both its `malloct` and its `realloct` as infallible. A 20 MB body opening with a UTF-16 BOM died at `htscore.c:1444` under `ulimit -v 68000`. Both cases now log an error, skip the page and exit 0. A build with the aborts put back still gives RC=134 on the same two repros.

`TypedArrayEnsureRoom` now leaves size, capacity and contents as they were when it cannot allocate. `TypedArrayHasRoom()` then answers the question from the fields that already exist. The struct in the installed header is unchanged byte for byte against master, so this needs no ABI ruling. A sticky failure flag in the struct was the first shape. It read better at the call sites, but it is not worth a field in a header a third party compiles against.

`htsarrays.h` is installed all the same, listed in `DevIncludes_DATA` in src/Makefile.am. An out-of-tree consumer of these macros gets a changed contract. A growth that used to abort now drops the append and says nothing until the caller asks. No ABI moves, since the macros expand in the consumer's own translation unit and no exported function takes a `TypedArray`. The behaviour a consumer relies on does move.

The array no longer remembers the failure. htsparse.c latches its own `output_oom` beside `output_buffer`, and `hts_record_link_alloc` asks `TypedArrayHasRoom` for its `(size_t) -1` return, which its callers already handle for the `-#L` link ceiling. Every append in htsparse.c goes through one of six macros, 78 call sites in all, funnelling into three growth primitives in two macro bodies. #1561 added a seventh route, `HT_ADD_BUF`, between this branch's audit and the merge. The merge commit routes it through `HT_ADD_N`. `tests/440_ci-output-buffer-latch.test` pins the invariant rather than the count. A macro body that grows `output_buffer` must mention `output_oom`, and no growth may sit outside a macro. Re-run it by hand with `grep -nE 'TypedArray(EnsureRoom|Append|Add)\(output_buffer' src/htsparse.c`, whose every hit must land inside `HT_ADD_N` or `HT_ADD_HTMLESCAPED_ANY`.

The re-encoder moves to `hts_ucs2_to_utf8()`, which counts the output bytes in a first pass and allocates once. Correcting the estimate belongs here rather than in a follow-up. The growth step is what the second abort sat on, so removing it removes the site. Output bytes are unchanged, pinned by a self-test over all 65536 BMP code units.

One commit clears a CodeQL `cpp/redundant-null-check-simple` alert that is open against master too, so it is not this change's doing. `adr_next` starts at `html`, which the enclosing bounds test has already placed inside `r->adr`, and the loop above only increments it. The `!adr_next` arm was dead rather than protective. The loop's own dereference can reach `r->adr[r->size]`, which is the NUL the reader writes past the body.

`-#test=arrays overflow-loop` already drove a growth that cannot be satisfied and asserted the abort. It now asserts the array comes back untouched and that an append which cannot fit is a no-op. `-#test=ucs2` is new, covering the encoding and, under an `RLIMIT_AS` the self-test sets and restores around the one call, the NULL return. Each kills the mutant that restores its abort, and the encoding case kills a mutant that puts the one-byte-per-unit estimate back. Test 440 kills the mutant that points `HT_ADD_BUF` straight at `TypedArrayAppend`, and carries a control so a checker that had stopped looking cannot pass. A crawl-level test was not worth its fragility. The repro needs a memory cap tight enough to starve a 10 MB allocation and loose enough to leave the harness alive. No single number gives that across libc, sanitizers and word size.