### PR TITLE
new URL(x) matches the CSS url( token, so a mirrored bundle stops parsing

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -473,7 +473,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
       int intag = 0;            // on est dans un tag
       int incomment = 0;        // dans un <!--
       int inscript = 0;         // dans un scipt pour applets javascript)
-      int incss = 0;            /* stylesheet: url(x) may drop its quotes */
+      int incss = 0;            /* CSS lets url(x) go unquoted */
       int inscript_locked = 0;  // in locked script (ie. js file)
       signed char inscript_state[INSCRIPT_NSTATES][257];
       INSCRIPT inscript_state_pos = INSCRIPT_START;
@@ -959,11 +959,13 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
 
               // ** while(is_realspace(*(--a)));
               if (*a == '<') {  // sûr que c'est un tag?
-                if (check_tag(intag_start, "script"))
+                if (check_tag(intag_start, "script")) {
                   inscript_name = "script";
-                else
+                  incss = 0;
+                } else {
                   inscript_name = "style";
-                incss = (check_tag(intag_start, "script") == 0);
+                  incss = 1;
+                }
                 inscript = 1;
                 inscript_state_pos = INSCRIPT_START;
                 intag = 1;      // because après <script> on y est .. - pas utile
@@ -1301,8 +1303,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                            On est désormais dans du code javascript
                          */
                         inscript_name = "";
-                        /* style= is CSS, every other hts_detect_js[] entry is
-                         * JS. */
+                        /* Only style= means CSS in hts_detect_js[]. */
                         incss = is_style_attr;
                         inscript = inscript_tag = 1;
                         inscript_state_pos = INSCRIPT_START;
@@ -1515,7 +1516,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                         /* CSS writes url(foo.png) unquoted, but JavaScript's
                            new URL(x) matches the same token, so an unquoted
                            operand there rewrites the expression itself. */
-                        can_avoid_quotes = !inscript || incss;
+                        can_avoid_quotes = incss;
                         quotes_replacement = ')';
                       }
                       if (!nc)
@@ -1952,6 +1953,9 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                    On est désormais dans du code javascript
                  */
                 inscript_name = "";
+                /* A javascript: URL is JavaScript, whatever an earlier
+                   <style> left in incss. */
+                incss = 0;
                 inscript_tag = inscript = 1;
                 inscript_state_pos = INSCRIPT_START;
                 inscript_tag_lastc = quote;     /* à attendre à la fin */

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -473,6 +473,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
       int intag = 0;            // on est dans un tag
       int incomment = 0;        // dans un <!--
       int inscript = 0;         // dans un scipt pour applets javascript)
+      int incss = 0;            /* stylesheet: url(x) may drop its quotes */
       int inscript_locked = 0;  // in locked script (ie. js file)
       signed char inscript_state[INSCRIPT_NSTATES][257];
       INSCRIPT inscript_state_pos = INSCRIPT_START;
@@ -546,6 +547,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                (compare_mime(opt, r->contenttype, str->url_file, "text/css") !=
                 0)) { /* JavaScript js file */
         inscript = 1;
+        incss =
+            (compare_mime(opt, r->contenttype, str->url_file, "text/css") != 0);
         inscript_locked = 1;    /* Don't exit js space upon </script> */
         if (opt->parsedebug) {
           HT_ADD("<@@ inscript @@>");
@@ -960,6 +963,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                   inscript_name = "script";
                 else
                   inscript_name = "style";
+                incss = (check_tag(intag_start, "script") == 0);
                 inscript = 1;
                 inscript_state_pos = INSCRIPT_START;
                 intag = 1;      // because après <script> on y est .. - pas utile
@@ -1261,10 +1265,14 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                     if (p == 0 && !inscript     /* we don't want events inside document.write */
                       ) {
                       int i = 0;
+                      int is_style_attr = 0;
 
                       /* détection onLoad etc */
                       while((p == 0) && (strnotempty(hts_detect_js[i]))) {
                         p = rech_tageq(html, hts_detect_js[i]);
+                        if (p != 0)
+                          is_style_attr =
+                              (strfield2(hts_detect_js[i], "style") != 0);
                         i++;
                       }
                       /* non détecté - détecter également les onXxxxx= */
@@ -1293,6 +1301,9 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                            On est désormais dans du code javascript
                          */
                         inscript_name = "";
+                        /* style= is CSS, every other hts_detect_js[] entry is
+                         * JS. */
+                        incss = is_style_attr;
                         inscript = inscript_tag = 1;
                         inscript_state_pos = INSCRIPT_START;
                         if (opt->parsedebug) {
@@ -1501,7 +1512,10 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                           html_prevc(html, r->adr) != '_') { // url(url)
                         expected = '('; // parenthèse
                         expected_end = ")";     // fin: parenthèse
-                        can_avoid_quotes = 1;
+                        /* CSS writes url(foo.png) unquoted, but JavaScript's
+                           new URL(x) matches the same token, so an unquoted
+                           operand there rewrites the expression itself. */
+                        can_avoid_quotes = !inscript || incss;
                         quotes_replacement = ')';
                       }
                       if (!nc)

--- a/tests/442_local-js-url-constructor.test
+++ b/tests/442_local-js-url-constructor.test
@@ -2,13 +2,15 @@
 #
 # htsparse spots a CSS url(...) by matching the token "url" before a "(" and
 # accepts an unquoted operand, because CSS is written that way. JavaScript's
-# new URL(x) matches the same token, so the expression itself was rewritten as
-# a URL: excalidraw.com's shipped bundle became new URL(https://host/e), where
-# the // comments out the rest of the line and the file stops parsing.
+# new URL(x) matches the same token, so the operand was taken for a link and
+# rewritten, and a bundle whose new URL(e) became new URL(https://host/e) stops
+# parsing at the "//".
 #
-# The CSS cases are asserted alongside because two candidate fixes each cured
-# the JavaScript and silently dropped one of them: inscript is set for
-# text/css documents too, so it cannot tell the two apart on its own.
+# The contract: inside a script an unquoted operand is an expression and must
+# survive untouched; in CSS it is a URL and must still be rewritten. All four
+# places CSS reaches the parser are asserted, because a fix that keys on
+# "inside a script" alone drops one of them: htsparse sets that flag for
+# text/css documents too.
 
 set -euo pipefail
 
@@ -20,33 +22,40 @@ cleanup_push rm -rf "$work"
 root="$work/root"
 mkdir -p "$root"
 
-# One page carrying every context the fix has to keep apart: an external
-# script, an external stylesheet, a <style> block and a style= attribute.
+# One page carrying every context the fix must keep apart. The style=
+# attribute comes before the <style> block, so each one is the first CSS the
+# parser meets and neither can cover for the other, and the javascript: URL
+# comes after both, where a stale "this is CSS" state would show up.
 cat >"$root/index.html" <<'EOF'
 <!DOCTYPE html><html><head>
-<link rel="stylesheet" href="s.css">
-<style>body { background: url(inline.png); }</style>
+<link rel="stylesheet" href="sheet.css">
 </head><body>
 <div style="background:url(attr.png)">x</div>
-<script src="u.js"></script>
+<style>body { background: url(inline.png); }</style>
+<a href="javascript:new URL(later).href">l</a>
+<script src="script.js"></script>
 </body></html>
 EOF
 
-# new URL(e) takes a variable, not a URL. Rewriting it breaks the script.
-cat >"$root/u.js" <<'EOF'
+# Operands a URL-shaped guess would still mangle: a bare name, a dotted
+# expression, and one carrying a slash.
+cat >"$root/script.js" <<'EOF'
 function f(e) { return new URL(e).href; }
-window.name = f("http://example.com/x");
+var here = new URL(location.href).href;
+var ratio = new URL(width/height).href;
 EOF
 
-printf 'div { background: url(sheet.png); }\n' >"$root/s.css"
+printf 'div { background: url(sheet.png); }\n' >"$root/sheet.css"
 for img in inline attr sheet; do
     printf '\211PNG\r\n\032\n' >"$root/$img.png"
 done
 
 bash "$top_srcdir/tests/local-crawl.sh" --root "$root" \
     --errors 0 \
-    --found u.js --found s.css \
+    --found script.js --found sheet.css \
     --found inline.png --found attr.png --found sheet.png \
-    --file-matches u.js 'new URL\(e\)' \
-    --file-not-matches u.js 'new URL\([^e)]' \
+    --file-matches script.js 'new URL\(e\)' \
+    --file-matches script.js 'new URL\(location\.href\)' \
+    --file-matches script.js 'new URL\(width/height\)' \
+    --file-matches index.html 'javascript:new URL\(later\)' \
     httrack BASEURL/index.html -q -%v0 -r3

--- a/tests/442_local-js-url-constructor.test
+++ b/tests/442_local-js-url-constructor.test
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# htsparse spots a CSS url(...) by matching the token "url" before a "(" and
+# accepts an unquoted operand, because CSS is written that way. JavaScript's
+# new URL(x) matches the same token, so the expression itself was rewritten as
+# a URL: excalidraw.com's shipped bundle became new URL(https://host/e), where
+# the // comments out the rest of the line and the file stops parsing.
+#
+# The CSS cases are asserted alongside because two candidate fixes each cured
+# the JavaScript and silently dropped one of them: inscript is set for
+# text/css documents too, so it cannot tell the two apart on its own.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+work=$(mktemp -d)
+cleanup_push rm -rf "$work"
+root="$work/root"
+mkdir -p "$root"
+
+# One page carrying every context the fix has to keep apart: an external
+# script, an external stylesheet, a <style> block and a style= attribute.
+cat >"$root/index.html" <<'EOF'
+<!DOCTYPE html><html><head>
+<link rel="stylesheet" href="s.css">
+<style>body { background: url(inline.png); }</style>
+</head><body>
+<div style="background:url(attr.png)">x</div>
+<script src="u.js"></script>
+</body></html>
+EOF
+
+# new URL(e) takes a variable, not a URL. Rewriting it breaks the script.
+cat >"$root/u.js" <<'EOF'
+function f(e) { return new URL(e).href; }
+window.name = f("http://example.com/x");
+EOF
+
+printf 'div { background: url(sheet.png); }\n' >"$root/s.css"
+for img in inline attr sheet; do
+    printf '\211PNG\r\n\032\n' >"$root/$img.png"
+done
+
+bash "$top_srcdir/tests/local-crawl.sh" --root "$root" \
+    --errors 0 \
+    --found u.js --found s.css \
+    --found inline.png --found attr.png --found sheet.png \
+    --file-matches u.js 'new URL\(e\)' \
+    --file-not-matches u.js 'new URL\([^e)]' \
+    httrack BASEURL/index.html -q -%v0 -r3

--- a/tests/442_local-js-url-constructor.test
+++ b/tests/442_local-js-url-constructor.test
@@ -7,10 +7,10 @@
 # parsing at the "//".
 #
 # The contract: inside a script an unquoted operand is an expression and must
-# survive untouched; in CSS it is a URL and must still be rewritten. All four
-# places CSS reaches the parser are asserted, because a fix that keys on
-# "inside a script" alone drops one of them: htsparse sets that flag for
-# text/css documents too.
+# survive untouched; in CSS it is a URL and must still be rewritten. Every place
+# the parser decides which of the two it is has a case here, because a fix that
+# keys on "inside a script" alone drops the CSS ones: htsparse sets that flag
+# for text/css documents too.
 
 set -euo pipefail
 
@@ -22,16 +22,21 @@ cleanup_push rm -rf "$work"
 root="$work/root"
 mkdir -p "$root"
 
-# One page carrying every context the fix must keep apart. The style=
-# attribute comes before the <style> block, so each one is the first CSS the
-# parser meets and neither can cover for the other, and the javascript: URL
-# comes after both, where a stale "this is CSS" state would show up.
+# One page carrying every context the parser decides between. The style=
+# attribute comes first, so it is the first CSS the parser meets and the <style>
+# block cannot cover for it. Each JavaScript context then follows a <style>
+# block of its own, so each one has to clear the "this is CSS" state itself and
+# none of them can ride on a neighbour having cleared it.
 cat >"$root/index.html" <<'EOF'
 <!DOCTYPE html><html><head>
 <link rel="stylesheet" href="sheet.css">
 </head><body>
 <div style="background:url(attr.png)">x</div>
 <style>body { background: url(inline.png); }</style>
+<script>var inlined = new URL(bare).href;</script>
+<style>p { background: url(two.png); }</style>
+<button onclick="go(new URL(evt).href)">b</button>
+<style>i { background: url(three.png); }</style>
 <a href="javascript:new URL(later).href">l</a>
 <script src="script.js"></script>
 </body></html>
@@ -46,7 +51,7 @@ var ratio = new URL(width/height).href;
 EOF
 
 printf 'div { background: url(sheet.png); }\n' >"$root/sheet.css"
-for img in inline attr sheet; do
+for img in inline attr sheet two three; do
     printf '\211PNG\r\n\032\n' >"$root/$img.png"
 done
 
@@ -54,8 +59,11 @@ bash "$top_srcdir/tests/local-crawl.sh" --root "$root" \
     --errors 0 \
     --found script.js --found sheet.css \
     --found inline.png --found attr.png --found sheet.png \
+    --found two.png --found three.png \
     --file-matches script.js 'new URL\(e\)' \
     --file-matches script.js 'new URL\(location\.href\)' \
     --file-matches script.js 'new URL\(width/height\)' \
+    --file-matches index.html 'onclick="go\(new URL\(evt\)' \
+    --file-matches index.html 'new URL\(bare\)' \
     --file-matches index.html 'javascript:new URL\(later\)' \
     httrack BASEURL/index.html -q -%v0 -r3


### PR DESCRIPTION
htsparse spots a CSS `url(...)` by matching the token `url` before a `(`. It accepts an unquoted operand there, because CSS is written that way. JavaScript's `new URL(x)` matches the same token, so the expression inside the parentheses was taken for a link and rewritten.

On excalidraw.com's shipped 2.1 MB bundle that turns `try{new URL(e)}catch{...}` into `try{new URL(https://excalidraw.com/e)}catch{...}`. The `//` comments out the rest of the line, so the file no longer parses and the whole application is dead in the mirror. I loaded the origin file and the mirrored file same-origin as modules and caught the error. The origin parses, master's mirror raises `SyntaxError: missing ) after argument list`, and this branch parses again. A deliberately broken copy served as the control, to check the probe can see a failure at all.

`inscript` cannot tell CSS from JavaScript, because htsparse sets it for `text/css` documents too. The patch therefore carries a separate flag, set at all four places that turn `inscript` on. Those are the document MIME, the `<script>`/`<style>` tag, the inline attribute, and a `javascript:` URL. The attribute one matters because `"style"` lives in `hts_detect_js[]`, under its own comment calling it a hack for CSS. That fourth one is easy to miss and it matters. Miss it and any CSS earlier in the page leaves the flag set, so the bug survives on a `javascript:` link.

The read is `can_avoid_quotes = incss` rather than `!inscript || incss`, because the site sits inside an `else if (inscript)` branch, so the `!inscript` arm cannot run.

The test asserts all four CSS contexts, because two earlier attempts cured the JavaScript and silently dropped one of them. Its `style=` attribute comes before its `<style>` block so that neither covers for the other. It asserts three operand shapes: a bare name, a dotted expression, and one carrying a slash. A fix keyed on the operand looking URL-shaped passes a bare name alone. It fails on master, where the log names the cause: `"File not found" (404) at link /e (from /script.js)`, httrack fetching the variable.

This does not fix everything htsparse rewrites into a script. A string ending in `/` is still taken for a directory link. So the bare separator `"/"` still becomes a URL, and `"ab".replace(/b/, "$&/")` still mirrors as `"%24%26/index.html"`. Those need a decision about how the parser should guess a URL out of minified code, rather than another guard. They are separate from this one.

Found while investigating #302.