### PR TITLE
A consumed base href is saved as `<base >`, which stops a framework starting

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -2714,6 +2714,12 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
 
                     // écrire lien
                     if ((p_type == 2) || (p_type == -2)) {      // base href ou codebase, sauter
+                      /* An emptied base href leaves <base >, which means "no
+                         base" and stops a framework that requires one (Angular
+                         throws). Links are already rewritten relative to their
+                         own page, so "./" preserves how they resolve. */
+                      if (p_type == 2)
+                        HT_ADD("href=\"./\"");
                       lastsaved = eadr - 1 + 1; // sauter "
                     }
                     /* */

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -2716,10 +2716,10 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                     if ((p_type == 2) || (p_type == -2)) {      // base href ou codebase, sauter
                       /* An emptied base href leaves <base >, which means "no
                          base" and stops a framework that requires one (Angular
-                         throws). Links are already rewritten relative to their
-                         own page, so "./" preserves how they resolve. */
+                         throws). An empty href keeps the document itself as the
+                         base, so every reference resolves as it did. */
                       if (p_type == 2)
-                        HT_ADD("href=\"./\"");
+                        HT_ADD("href=\"\"");
                       lastsaved = eadr - 1 + 1; // sauter "
                     }
                     /* */

--- a/tests/443_local-base-href-write.test
+++ b/tests/443_local-base-href-write.test
@@ -2,37 +2,55 @@
 #
 # A <base href> is consumed while the links under it are rewritten, and nothing
 # was written back, so the mirror kept the element with its attribute gone:
-# "<base >". That is the one value meaning "no base", and a framework that
-# requires one (Angular throws "No base href set") then refuses to start, which
-# leaves an otherwise complete mirror of a single-page app showing nothing.
+# "<base >". An element with no href means "no base", and a framework requiring
+# one refuses to start (Angular throws "No base href set"), which leaves an
+# otherwise complete mirror of a single-page app showing nothing.
 #
-# Links in the mirror are already rewritten relative to their own page, so "./"
-# is the value that preserves how they resolve.
+# The value has to be empty rather than "./". Both supply the attribute, but
+# "./" makes the base the directory, so a fragment-only reference such as
+# href="#f" then resolves to the directory instead of to the page, and every
+# in-page anchor on a page that is not the directory index leads away from it.
+# An empty href keeps the document itself as the base, which is what master's
+# hrefless element already meant.
 
 set -euo pipefail
 
-: "${top_srcdir:=..}"
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
 
 work=$(mktemp -d)
-trap 'set +e; rm -rf "$work"' EXIT
+cleanup_push rm -rf "$work"
 root="$work/root"
-mkdir -p "$root"
+mkdir -p "$root/sub/j"
 
-# The page sits at the document root under <base href="/">, the one relative
-# form that already resolves correctly, so this asserts what is written out
-# without depending on how a base is resolved.
 cat >"$root/index.html" <<'EOF'
-<!DOCTYPE html><html><head><base href="/"><title>t</title></head>
-<body><a href="page.html">p</a><img src="pic.png"></body></html>
+<!DOCTYPE html><html><body><a href="sub/page.html">p</a></body></html>
 EOF
-cat >"$root/page.html" <<'EOF'
+
+# The page carrying the base sits below the document root, so a base of "./"
+# and a base of "" pick different directories and neither can pass for the
+# other. <base href="/"> is the relative form master already resolves
+# correctly, so what is asserted is what gets written out, not how a base is
+# resolved. The applet is here because its codebase shares the write site the
+# fix touches and must keep its own value.
+cat >"$root/sub/page.html" <<'EOF'
+<!DOCTYPE html><html><head><base href="/"><title>t</title></head>
+<body><a href="#f">f</a> <a href="target.html">r</a> <a name="f">A</a>
+<applet codebase="j/" code="A.class" width="1" height="1"></applet>
+</body></html>
+EOF
+cat >"$root/target.html" <<'EOF'
 <!DOCTYPE html><html><body>reached</body></html>
 EOF
-printf '\211PNG\r\n\032\n' >"$root/pic.png"
+echo stub >"$root/sub/j/A.class"
 
 bash "$top_srcdir/tests/local-crawl.sh" --root "$root" \
     --errors 0 \
-    --found page.html --found pic.png \
-    --file-matches index.html '<base href="\./">' \
-    --file-not-matches index.html '<base >' \
-    httrack BASEURL/index.html -q -%v0 -r3
+    --found target.html \
+    --file-matches sub/page.html '<base href="">' \
+    --file-not-matches sub/page.html '<base >' \
+    --file-not-matches sub/page.html '<base href="\./">' \
+    --file-matches sub/page.html 'href="#f"' \
+    --file-matches sub/page.html 'codebase="j/"' \
+    --file-not-matches sub/page.html 'applet href' \
+    httrack BASEURL/index.html -q -%v0 -r4

--- a/tests/443_local-base-href-write.test
+++ b/tests/443_local-base-href-write.test
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# A <base href> is consumed while the links under it are rewritten, and nothing
+# was written back, so the mirror kept the element with its attribute gone:
+# "<base >". That is the one value meaning "no base", and a framework that
+# requires one (Angular throws "No base href set") then refuses to start, which
+# leaves an otherwise complete mirror of a single-page app showing nothing.
+#
+# Links in the mirror are already rewritten relative to their own page, so "./"
+# is the value that preserves how they resolve.
+
+set -euo pipefail
+
+: "${top_srcdir:=..}"
+
+work=$(mktemp -d)
+trap 'set +e; rm -rf "$work"' EXIT
+root="$work/root"
+mkdir -p "$root"
+
+# The page sits at the document root under <base href="/">, the one relative
+# form that already resolves correctly, so this asserts what is written out
+# without depending on how a base is resolved.
+cat >"$root/index.html" <<'EOF'
+<!DOCTYPE html><html><head><base href="/"><title>t</title></head>
+<body><a href="page.html">p</a><img src="pic.png"></body></html>
+EOF
+cat >"$root/page.html" <<'EOF'
+<!DOCTYPE html><html><body>reached</body></html>
+EOF
+printf '\211PNG\r\n\032\n' >"$root/pic.png"
+
+bash "$top_srcdir/tests/local-crawl.sh" --root "$root" \
+    --errors 0 \
+    --found page.html --found pic.png \
+    --file-matches index.html '<base href="\./">' \
+    --file-not-matches index.html '<base >' \
+    httrack BASEURL/index.html -q -%v0 -r3

--- a/tests/443_local-base-href-write.test
+++ b/tests/443_local-base-href-write.test
@@ -24,7 +24,8 @@ root="$work/root"
 mkdir -p "$root/sub/j"
 
 cat >"$root/index.html" <<'EOF'
-<!DOCTYPE html><html><body><a href="sub/page.html">p</a></body></html>
+<!DOCTYPE html><html><body><a href="sub/page.html">p</a>
+<a href="sub/dot.html">d</a></body></html>
 EOF
 
 # The page carrying the base sits below the document root, so a base of "./"
@@ -39,6 +40,16 @@ cat >"$root/sub/page.html" <<'EOF'
 <applet codebase="j/" code="A.class" width="1" height="1"></applet>
 </body></html>
 EOF
+# A second base-bearing page, and the only other relative form that is
+# consumed. "./" is what a framework ships, and its resolved value is the
+# page's own directory rather than the site root, so a fix that writes the
+# attribute for a root base alone leaves this one hrefless. Its links are all
+# fragments, so nothing here depends on how the base itself resolves.
+cat >"$root/sub/dot.html" <<'EOF'
+<!DOCTYPE html><html><head><base href="./"><title>d</title></head>
+<body><a href="#f">f</a><a name="f">A</a></body></html>
+EOF
+
 cat >"$root/target.html" <<'EOF'
 <!DOCTYPE html><html><body>reached</body></html>
 EOF
@@ -48,6 +59,8 @@ bash "$top_srcdir/tests/local-crawl.sh" --root "$root" \
     --errors 0 \
     --found target.html \
     --file-matches sub/page.html '<base href="">' \
+    --file-matches sub/dot.html '<base href="">' \
+    --file-not-matches sub/dot.html '<base >' \
     --file-not-matches sub/page.html '<base >' \
     --file-not-matches sub/page.html '<base href="\./">' \
     --file-matches sub/page.html 'href="#f"' \


### PR DESCRIPTION
htsparse consumes a `<base href>` while it rewrites the links underneath it, and it wrote nothing back. The mirror therefore kept the element with its attribute gone: `<base >`. An element with no href means "no base", and a framework requiring one then refuses to start. Angular throws `No base href set. Please provide a value for the APP_BASE_HREF token or add a base element to the document`, in the mirrored page's own console, and never bootstraps. An otherwise complete mirror of a single-page app therefore shows nothing.

The value written back is the empty string, which is the only one that changes nothing else. I measured the three candidates in a browser, on a page one directory down:

| base | `#f` resolves to | `rel.html` resolves to |
|---|---|---|
| `<base >`, what master writes | `/dir/page.html#f` | `/dir/rel.html` |
| `<base href="./">` | `/dir/#f` | `/dir/rel.html` |
| `<base href="">` | `/dir/page.html#f` | `/dir/rel.html` |

`./` makes the base the directory, so every fragment-only reference leads away from its own page. An in-page anchor stops working on anything that is not the directory index. An empty href keeps the document as the base, which is what master's hrefless element already meant, so no reference in the mirror moves.

It also does the job better. Serve a mirror of angular.realworld.io over HTTP and it renders 17 characters of visible text as master saves it. With `./` it renders 106, and with an empty href 360, which is what the live site renders.

The test puts the page below the document root, so `./` and `""` pick different directories and neither can pass for the other. It pins the applet `codebase` beside it, since that shares this write site and must keep its own value. `<base href="/">` is the relative form master already resolves correctly, so the test asserts what gets written out without depending on how a base is resolved.

This is separate from a second bug in the same attribute, which is that a relative `<base href>` is resolved as though it were a hostname. That one changes which URLs are fetched rather than what is saved. It reverts a fix from 2003, and it is not in this branch.

Found while investigating #302.