### PR TITLE
The Stop button throws away what a resume needs

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -3700,8 +3700,7 @@ HTSEXT_API int hts_request_stop(httrackp *opt, hts_boolean keep_resume) {
     hts_log_print(opt, LOG_ERROR, "Exit requested by shell or user");
     hts_mutexlock(&opt->state.lock);
     opt->state.stop = 1;
-    /* the value SIGTERM writes: it spares hts-cache/ref, which a later
-       --continue reads to resume the partial bodies the stop leaves behind */
+    /* 1, as SIGTERM writes, spares hts-cache/ref for a later --continue */
     if (keep_resume)
       opt->state.exit_xh = 1;
     hts_mutexrelease(&opt->state.lock);

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -3695,11 +3695,15 @@ HTSEXT_API int hts_setpause(httrackp * opt, int p) {
 }
 
 // ask for termination
-HTSEXT_API int hts_request_stop(httrackp *opt, hts_boolean force) {
+HTSEXT_API int hts_request_stop(httrackp *opt, hts_boolean keep_resume) {
   if (opt != NULL) {
     hts_log_print(opt, LOG_ERROR, "Exit requested by shell or user");
     hts_mutexlock(&opt->state.lock);
     opt->state.stop = 1;
+    /* the value SIGTERM writes: it spares hts-cache/ref, which a later
+       --continue reads to resume the partial bodies the stop leaves behind */
+    if (keep_resume)
+      opt->state.exit_xh = 1;
     hts_mutexrelease(&opt->state.lock);
   }
   return 0;

--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -225,8 +225,9 @@ struct htsoptstate {
   /** set to request the mirror to stop; volatile: polled without a lock */
   volatile int stop;
   /** why the mirror ended early: 1 asked for, 2 rolled back, -1 engine fatal
-      (the only one hts_main2() reports); not the process exit status */
-  int exit_xh;
+      (the only one hts_main2() reports); not the process exit status.
+      volatile: signal handlers write it and the mirror loop polls it */
+  volatile int exit_xh;
   int back_add_stats;
   /* */
   int mimehtml_created; /**< MIME/MHTML output already started */

--- a/src/htsparse.h
+++ b/src/htsparse.h
@@ -58,7 +58,7 @@ struct htsmoduleStructExtended {
 
   /* Error handling */
   int *error_;
-  int *exit_xh_;
+  volatile int *exit_xh_;
   int *store_errpage_;
 
   /* Structural */

--- a/src/htsserver.c
+++ b/src/htsserver.c
@@ -1463,7 +1463,8 @@ int smallserver(T_SOC soc, char *url, char *method, char *data, char *path) {
                 commandEndRequested = 1;
                 hts_request_stop(global_opt, 0);
               } else {
-                hts_request_stop(global_opt, 1);        /* note: the force flag does not have anyeffect yet */
+                /* a second press stops now, keeping the resume data */
+                hts_request_stop(global_opt, 1);
                 commandEndRequested = 2;        /* will break the loop() callback */
               }
             }

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -402,10 +402,11 @@ HTSEXT_API char *hts_errmsg(httrackp *opt);
 HTSEXT_API int hts_setpause(httrackp *opt, int);
 
 /** Ask the running mirror to terminate (sets the stop flag under the state
-   lock, so it is safe to call from another thread). @p force is currently
-   ignored.
+    lock, so it is safe to call from another thread). @p keep_resume asks the
+    engine to keep the partial-transfer metadata a later --continue needs,
+    rather than erase it as it does at the end of a completed mirror.
     @return 0; no-op if @p opt is NULL. */
-HTSEXT_API int hts_request_stop(httrackp *opt, hts_boolean force);
+HTSEXT_API int hts_request_stop(httrackp *opt, hts_boolean keep_resume);
 
 /** Queue a single in-progress file, by URL, to be cancelled by the engine.
     @p url is copied internally. Takes the state lock, so it is thread-safe.

--- a/tests/444_local-stop-keeps-resume.test
+++ b/tests/444_local-stop-keeps-resume.test
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# A stop asked to keep the resume data must leave hts-cache/ref behind. The
-# partial bodies survive a stop already, and without the byte-range metadata in
-# that directory a later --continue cannot use them.
+# A stop asked to keep the resume data must leave hts-cache/ref behind, and a
+# later --continue must use it. The partial bodies survive a stop already, but
+# without the byte ranges in that directory the refetch starts from zero.
 
 set -euo pipefail
 
@@ -27,40 +27,49 @@ cleanup() {
 }
 cleanup_push cleanup
 
-local_server_start
+# Where the /stopresume/ route records the byte offset of each Range it serves.
+resumed_at="${tmpdir}/resumed"
+local_server_start --env STOPRESUME_MARK="$resumed_at"
 
 # An LD_PRELOAD library loads ahead of the executable's own libasan, which ASan
 # refuses by default. The shim allocates nothing, so the ordering is harmless.
 export ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}verify_asan_link_order=0"
 
+# How long a body may take to leave its first temp-ref. The shim waits this
+# plus a margin, so it cannot give up before the trigger is written.
+ref_wait_s=60
+
 # Crawl trickled bodies until a temp-ref names one, stop the run the way the
-# caller asks, and leave in refs_left what hts-cache/ref still holds. The wait
-# is what makes that count mean something: a run stopped before any partial
-# exists has no resume data to keep either way. Not a command substitution: the
-# subshell would run the EXIT trap and reap the server for the next case.
+# caller asks, and leave in refs_left what hts-cache/ref still holds, in
+# crawl_rc what the engine exited with. The wait is what makes that count mean
+# something: a run stopped before any partial exists has no resume data to keep
+# either way. Not a command substitution: the subshell would run the EXIT trap
+# and reap the server for the next case.
 refs_left=0
-stop_and_report() { # stop_and_report <name> keep|drop|maxtime
-    local name=$1 how=$2
+crawl_rc=0
+stop_and_report() { # stop_and_report <name> keep|drop|maxtime [route]
+    local name=$1 how=$2 route=${3:-trickle}
     local out="${tmpdir}/${name}" trigger="${tmpdir}/${name}.trigger"
     local refdir="${out}/hts-cache/ref" pre=(env) cap=(--max-time=0)
-    local waited
+    local _
 
     case $how in
     keep | drop)
         pre=(env "STOPRESUME_TRIGGER=${trigger}"
             "STOPRESUME_KEEP=$(test "$how" = keep && echo 1 || echo 0)"
+            "STOPRESUME_TIMEOUT=$((ref_wait_s + 30))"
             "LD_PRELOAD=${STOPRESUME_LIB}")
         ;;
     maxtime) cap=(--max-time=5) ;;
     esac
 
     mkdir -p "$out"
-    "${pre[@]}" httrack "${BASEURL}/trickle/index.html" -O "$out" --quiet \
+    "${pre[@]}" httrack "${BASEURL}/${route}/index.html" -O "$out" --quiet \
         --disable-security-limits --robots=0 --timeout=0 "${cap[@]}" -c2 \
         >"${out}.log" 2>&1 &
     crawlpid=$!
 
-    for waited in $(seq 1 600); do
+    for _ in $(seq 1 $((ref_wait_s * 10))); do
         test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" && break
         kill -0 "$crawlpid" 2>/dev/null || break
         poll_wait 0.1
@@ -72,14 +81,15 @@ stop_and_report() { # stop_and_report <name> keep|drop|maxtime
     keep | drop) : >"$trigger" ;;
     esac
 
-    for waited in $(seq 1 900); do
+    for _ in $(seq 1 900); do
         kill -0 "$crawlpid" 2>/dev/null || break
         poll_wait 0.2
     done
     if kill -0 "$crawlpid" 2>/dev/null; then
         fail "${name}: the crawl never ended after the stop"
     fi
-    wait "$crawlpid" 2>/dev/null || true
+    crawl_rc=0
+    wait "$crawlpid" 2>/dev/null || crawl_rc=$?
     crawlpid=
 
     # Guarded, not "2>/dev/null | wc -l": under pipefail the missing directory
@@ -102,6 +112,12 @@ assert_erased() { # assert_erased <name> <how> <why>
 
 printf '[a stop asked to keep the resume data keeps it] ..\t'
 assert_kept keep keep "hts-cache/ref was erased under a keep_resume stop"
+# The two below pin exit_xh at 1 rather than at any non-zero value: -1 would
+# exit non-zero, and 2 would keep the directory without the banner.
+test "$crawl_rc" -eq 0 ||
+    fail "the keep_resume stop exited ${crawl_rc}, expected 0"
+assert_logged "${tmpdir}/keep" 'MIRROR ABORTED' \
+    "the run did not record an interrupted mirror"
 echo "PASS"
 
 # The control: the same stop asked the other way still erases, so the arm above
@@ -115,3 +131,23 @@ echo "PASS"
 printf '[a --max-time cap still erases it] ..\t'
 assert_erased maxtime maxtime "hts-cache/ref survived the engine's own cap stop"
 echo "PASS"
+
+# What the kept directory is for. /stopresume/blob.bin stalls its first GET
+# after 4096 bytes and answers a Range with a 206, so the refetch either
+# resumes or restarts, and the test can tell which.
+printf '[a --continue resumes from where the stop left off] ..\t'
+full=8200 # len(STOPRESUME_BODY) = len("STOPRSM-") + 8192
+out="${tmpdir}/resume"
+stop_and_report resume keep stopresume
+test "$refs_left" -gt 0 || fail "hts-cache/ref was erased; nothing left to resume from"
+blob=$(find "$out" -name blob.bin | head -1)
+test -s "$blob" || fail "the stop left no partial body to resume"
+local_crawl --log "${tmpdir}/resume.log2" -O "$out" --quiet \
+    --disable-security-limits --robots=0 --timeout=30 -c1 --continue \
+    "${BASEURL}/stopresume/index.html" || fail "the --continue crawl failed"
+test -s "$resumed_at" || fail "the --continue sent no usable Range; it restarted the file"
+at=$(head -1 "$resumed_at")
+test "$at" -gt 0 || fail "the --continue asked for the file from byte 0"
+got=$(wc -c <"$blob")
+test "$got" -eq "$full" || fail "blob.bin is ${got} bytes, expected ${full}"
+echo "PASS (resumed at ${at} of ${full})"

--- a/tests/444_local-stop-keeps-resume.test
+++ b/tests/444_local-stop-keeps-resume.test
@@ -112,8 +112,7 @@ assert_erased() { # assert_erased <name> <how> <why>
 
 printf '[a stop asked to keep the resume data keeps it] ..\t'
 assert_kept keep keep "hts-cache/ref was erased under a keep_resume stop"
-# The two below pin exit_xh at 1 rather than at any non-zero value: -1 would
-# exit non-zero, and 2 would keep the directory without the banner.
+# Together these pin exit_xh at 1: -1 exits non-zero, 2 skips the banner.
 test "$crawl_rc" -eq 0 ||
     fail "the keep_resume stop exited ${crawl_rc}, expected 0"
 assert_logged "${tmpdir}/keep" 'MIRROR ABORTED' \
@@ -132,9 +131,8 @@ printf '[a --max-time cap still erases it] ..\t'
 assert_erased maxtime maxtime "hts-cache/ref survived the engine's own cap stop"
 echo "PASS"
 
-# What the kept directory is for. /stopresume/blob.bin stalls its first GET
-# after 4096 bytes and answers a Range with a 206, so the refetch either
-# resumes or restarts, and the test can tell which.
+# What the kept directory is for: /stopresume/blob.bin stalls its first GET
+# after 4096 bytes and answers a Range with a 206, so a restart is visible.
 printf '[a --continue resumes from where the stop left off] ..\t'
 full=8200 # len(STOPRESUME_BODY) = len("STOPRSM-") + 8192
 out="${tmpdir}/resume"

--- a/tests/444_local-stop-keeps-resume.test
+++ b/tests/444_local-stop-keeps-resume.test
@@ -1,0 +1,117 @@
+#!/bin/bash
+#
+# A stop asked to keep the resume data must leave hts-cache/ref behind. The
+# partial bodies survive a stop already, and without the byte-range metadata in
+# that directory a later --continue cannot use them.
+
+set -euo pipefail
+
+# shellcheck source=tests/crawllib.sh
+. "${0%"${0##*/}"}./crawllib.sh"
+
+target_is_linux ||
+    skip "the stop driver interposes through LD_PRELOAD, which is Linux-only here"
+# Anything else missing is a build problem, not a skip, or the test passes
+# vacuously.
+test -r "${STOPRESUME_LIB:-}" ||
+    fail "${STOPRESUME_LIB:-\$STOPRESUME_LIB} was not built"
+
+require_httrack
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_stopresume.XXXXXX") || exit 1
+crawlpid=
+cleanup() {
+    set +e
+    test -n "$crawlpid" && kill_tree "$crawlpid"
+    rm -rf "$tmpdir"
+}
+cleanup_push cleanup
+
+local_server_start
+
+# An LD_PRELOAD library loads ahead of the executable's own libasan, which ASan
+# refuses by default. The shim allocates nothing, so the ordering is harmless.
+export ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}verify_asan_link_order=0"
+
+# Crawl trickled bodies until a temp-ref names one, stop the run the way the
+# caller asks, and leave in refs_left what hts-cache/ref still holds. The wait
+# is what makes that count mean something: a run stopped before any partial
+# exists has no resume data to keep either way. Not a command substitution: the
+# subshell would run the EXIT trap and reap the server for the next case.
+refs_left=0
+stop_and_report() { # stop_and_report <name> keep|drop|maxtime
+    local name=$1 how=$2
+    local out="${tmpdir}/${name}" trigger="${tmpdir}/${name}.trigger"
+    local refdir="${out}/hts-cache/ref" pre=(env) cap=(--max-time=0)
+    local waited
+
+    case $how in
+    keep | drop)
+        pre=(env "STOPRESUME_TRIGGER=${trigger}"
+            "STOPRESUME_KEEP=$(test "$how" = keep && echo 1 || echo 0)"
+            "LD_PRELOAD=${STOPRESUME_LIB}")
+        ;;
+    maxtime) cap=(--max-time=5) ;;
+    esac
+
+    mkdir -p "$out"
+    "${pre[@]}" httrack "${BASEURL}/trickle/index.html" -O "$out" --quiet \
+        --disable-security-limits --robots=0 --timeout=0 "${cap[@]}" -c2 \
+        >"${out}.log" 2>&1 &
+    crawlpid=$!
+
+    for waited in $(seq 1 600); do
+        test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" && break
+        kill -0 "$crawlpid" 2>/dev/null || break
+        poll_wait 0.1
+    done
+    test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" ||
+        fail "${name}: no temp-ref was written, so the stop decides nothing"
+
+    case $how in
+    keep | drop) : >"$trigger" ;;
+    esac
+
+    for waited in $(seq 1 900); do
+        kill -0 "$crawlpid" 2>/dev/null || break
+        poll_wait 0.2
+    done
+    if kill -0 "$crawlpid" 2>/dev/null; then
+        fail "${name}: the crawl never ended after the stop"
+    fi
+    wait "$crawlpid" 2>/dev/null || true
+    crawlpid=
+
+    # Guarded, not "2>/dev/null | wc -l": under pipefail the missing directory
+    # is find's own failure and would end the run rather than count zero.
+    refs_left=0
+    if test -d "$refdir"; then
+        refs_left=$(find "$refdir" -name '*.ref' | wc -l)
+    fi
+}
+
+assert_kept() { # assert_kept <name> <how> <why>
+    stop_and_report "$1" "$2"
+    test "$refs_left" -gt 0 || fail "$3"
+}
+
+assert_erased() { # assert_erased <name> <how> <why>
+    stop_and_report "$1" "$2"
+    test "$refs_left" -eq 0 || fail "$3"
+}
+
+printf '[a stop asked to keep the resume data keeps it] ..\t'
+assert_kept keep keep "hts-cache/ref was erased under a keep_resume stop"
+echo "PASS"
+
+# The control: the same stop asked the other way still erases, so the arm above
+# cannot pass on a fix that simply stopped erasing.
+printf '[a plain stop still erases it] ..\t'
+assert_erased drop drop "hts-cache/ref survived a stop that did not ask to keep it"
+echo "PASS"
+
+# The engine raises the stop flag itself when a cap is reached, and that run
+# ends as cleanly as a finished one: nothing to resume, nothing to keep.
+printf '[a --max-time cap still erases it] ..\t'
+assert_erased maxtime maxtime "hts-cache/ref survived the engine's own cap stop"
+echo "PASS"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,7 @@ TESTS = @TESTS_LIST@
 # Committed binary fixture read by 01_zlib-cache-golden.test. List it
 # explicitly: automake does not expand wildcards in EXTRA_DIST, so a glob would
 # silently drop it from the dist tarball and break "make distcheck".
-EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c altstackprobe.c nopieprobe.c printnumprobe.c closetrack.c ftpcancel.c seekfail.c pubheaderlayout.c chainplug.c crawl-test.sh run-all-tests.sh check-network.sh check-test-names.sh \
+EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c altstackprobe.c nopieprobe.c printnumprobe.c closetrack.c ftpcancel.c stopresume.c seekfail.c pubheaderlayout.c chainplug.c crawl-test.sh run-all-tests.sh check-network.sh check-test-names.sh \
 	proxy-https-server.py socks5-server.py proxy-connect-server.py \
 	proxytestlib.py tls-stall-server.py warc-validate.py wacz-validate.py \
 	header-injection-server.py header-injection-check.py \
@@ -90,6 +90,7 @@ TESTS_ENVIRONMENT += ALTSTACKPROBE_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/libaltsta
 TESTS_ENVIRONMENT += CLOSETRACK_LA=$(abs_builddir)/libclosetrack.la
 TESTS_ENVIRONMENT += CLOSETRACK_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/libclosetrack.so
 TESTS_ENVIRONMENT += FTPCANCEL_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/libftpcancel.so
+TESTS_ENVIRONMENT += STOPRESUME_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/libstopresume.so
 TESTS_ENVIRONMENT += SEEKFAIL_LA=$(abs_builddir)/libseekfail.la
 TESTS_ENVIRONMENT += SEEKFAIL_LIB=$(abs_builddir)/$(LT_CV_OBJDIR)/libseekfail.so
 TESTS_ENVIRONMENT += STRINGOOM_BIN=$(abs_builddir)/stringoom$(EXEEXT)
@@ -107,6 +108,7 @@ TESTS_ENVIRONMENT += HTTRACK_STDERR_WRAP_EXE=$(abs_builddir)/stderrwrap$(EXEEXT)
 # libtool build a shared module rather than a static-only convenience library.
 check_LTLIBRARIES = librenamefail.la libunlinkfail.la libthreadattrfail.la \
 	libnobacktrace.la libaltstackprobe.la libclosetrack.la libftpcancel.la \
+	libstopresume.la \
 	libseekfail.la
 librenamefail_la_SOURCES = renamefail.c
 librenamefail_la_LDFLAGS = -module -avoid-version -rpath $(abs_builddir)
@@ -140,6 +142,11 @@ libclosetrack_la_LIBADD = $(DL_LIBS)
 libftpcancel_la_SOURCES = ftpcancel.c
 libftpcancel_la_LDFLAGS = -module -avoid-version -rpath $(abs_builddir)
 libftpcancel_la_LIBADD = $(DL_LIBS) -lpthread
+
+# stop driver for 444_local-stop-keeps-resume.test
+libstopresume_la_SOURCES = stopresume.c
+libstopresume_la_LDFLAGS = -module -avoid-version -rpath $(abs_builddir)
+libstopresume_la_LIBADD = $(DL_LIBS) -lpthread
 
 # fseeko() ceiling for 351_engine-warc-cache-io.test
 libseekfail_la_SOURCES = seekfail.c

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -247,7 +247,9 @@ ci_suite_heartbeat() {
 # build-features compares the feature reporter against the automake config.h,
 # which the MSVC build does not produce;
 # engine-wizard-eof drives the wizard through a pty, and Windows builds Python
-# with neither pty nor os.fork.
+# with neither pty nor os.fork;
+# stop-keeps-resume drives the stop through an LD_PRELOAD shim, which Windows
+# has no equivalent for.
 expected_skips_msys="01_engine-footer-overflow.test
 253_local-ftp-close-once.test
 113_engine-threadattr-leak.test
@@ -277,7 +279,8 @@ expected_skips_msys="01_engine-footer-overflow.test
 355_local-write-error-not-eof.test
 377_engine-install-paths.test
 398_engine-build-features.test
-424_engine-wizard-eof.test"
+424_engine-wizard-eof.test
+444_local-stop-keeps-resume.test"
 
 # Measured, not predicted: windows-build run 33927128153, both platforms alike.
 # The msys list plus what the Linux shell cannot do to a native process:

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1975,6 +1975,63 @@ class Handler(SimpleHTTPRequestHandler):
         if self.command != "HEAD":
             self.wfile.write(self.RESUME304_BODY)
 
+    # 444: the first GET stalls after a chunk, so a stop leaves a partial plus
+    # its temp-ref; the --continue that follows must come back with a Range.
+    STOPRESUME_BODY = b"STOPRSM-" + bytes((i * 13 + 7) % 256 for i in range(8192))
+    _stopresume_started = False
+
+    def route_stopresume_index(self):
+        self.send_html('\t<a href="blob.bin">blob</a>')
+
+    def route_stopresume(self):
+        counter = os.environ.get("STOPRESUME_COUNTER")
+        if counter:
+            with open(counter, "a") as fp:
+                fp.write("x")
+        body = self.STOPRESUME_BODY
+        m = re.match(r"bytes=(\d+)-", self.headers.get("Range", "") or "")
+        if m and int(m.group(1)) < len(body):
+            start = int(m.group(1))
+            mark = os.environ.get("STOPRESUME_MARK")
+            if mark:
+                with open(mark, "a") as fp:
+                    fp.write("%d\n" % start)
+            self.send_response(206, "Partial Content")
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header(
+                "Content-Range", "bytes %d-%d/%d" % (start, len(body) - 1, len(body))
+            )
+            self.send_header("Content-Length", str(len(body) - start))
+            self.end_headers()
+            if self.command != "HEAD":
+                self.wfile.write(body[start:])
+            return
+        if not Handler._stopresume_started and self.command != "HEAD":
+            Handler._stopresume_started = True
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Accept-Ranges", "bytes")
+            self.send_header("Last-Modified", BIG_LASTMOD)
+            self.send_header("ETag", '"444"')
+            self.end_headers()
+            self.wfile.write(body[:4096])
+            self.wfile.flush()
+            try:
+                while True:
+                    time.sleep(3600)
+            except OSError:
+                pass
+            return
+        # A range-less re-get, or one asking past the end: the whole body.
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Accept-Ranges", "bytes")
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
     # 206 resume must honor the server's Content-Range, not the offset we asked
     # for (#198): a server resuming a few bytes *before* the request must not
     # leave httrack duplicating the overlap onto the partial. flaky.bin
@@ -3533,6 +3590,8 @@ class Handler(SimpleHTTPRequestHandler):
         "/resume/blob.txt": route_resume,
         "/resume304/index.html": route_resume304_index,
         "/resume304/blob.bin": route_resume304,
+        "/stopresume/index.html": route_stopresume_index,
+        "/stopresume/blob.bin": route_stopresume,
         "/overlap/index.html": route_overlap_index,
         "/overlap/flaky.bin": route_overlap,
         "/overlap/full.bin": route_overlap_full,

--- a/tests/local-server.py
+++ b/tests/local-server.py
@@ -1984,10 +1984,6 @@ class Handler(SimpleHTTPRequestHandler):
         self.send_html('\t<a href="blob.bin">blob</a>')
 
     def route_stopresume(self):
-        counter = os.environ.get("STOPRESUME_COUNTER")
-        if counter:
-            with open(counter, "a") as fp:
-                fp.write("x")
         body = self.STOPRESUME_BODY
         m = re.match(r"bytes=(\d+)-", self.headers.get("Range", "") or "")
         if m and int(m.group(1)) < len(body):

--- a/tests/stopresume.c
+++ b/tests/stopresume.c
@@ -1,0 +1,61 @@
+/* Fires the exported stop a GUI's Stop button pushes, from outside the engine:
+   444_local-stop-keeps-resume.test writes STOPRESUME_TRIGGER once a partial
+   transfer is on disk, and STOPRESUME_KEEP picks the flag to pass. */
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* The tree builds with -fvisibility=hidden, which would hide the interposer. */
+#define SHIM_EXPORT __attribute__((visibility("default")))
+
+/* The engine's own httrackp, opaque here. */
+SHIM_EXPORT void *hts_create_opt(void);
+
+static void *stopresume_opt = NULL;
+
+/* Polls for the trigger rather than sleeping a fixed delay: the test decides
+   when the transfer is really in flight. Gives up so a missed trigger fails
+   the test rather than pinning a core. */
+static void *stopresume_thread(void *unused) {
+  int (*request_stop)(void *, int) = NULL;
+  const char *const trigger = getenv("STOPRESUME_TRIGGER");
+  const char *const keep = getenv("STOPRESUME_KEEP");
+  int left = 600;
+
+  (void) unused;
+  *(void **) &request_stop = dlsym(RTLD_DEFAULT, "hts_request_stop");
+  if (trigger == NULL || keep == NULL || request_stop == NULL) {
+    return NULL;
+  }
+  while (left-- > 0) {
+    if (access(trigger, R_OK) == 0) {
+      request_stop(stopresume_opt, atoi(keep));
+      return NULL;
+    }
+    usleep(100000);
+  }
+  return NULL;
+}
+
+SHIM_EXPORT void *hts_create_opt(void) {
+  static void *(*real_create)(void) = NULL;
+  pthread_t thread;
+
+  if (real_create == NULL) {
+    *(void **) &real_create = dlsym(RTLD_NEXT, "hts_create_opt");
+    if (real_create == NULL) {
+      return NULL;
+    }
+  }
+  stopresume_opt = real_create();
+  if (stopresume_opt != NULL &&
+      pthread_create(&thread, NULL, stopresume_thread, NULL) == 0) {
+    pthread_detach(thread);
+  }
+  return stopresume_opt;
+}

--- a/tests/stopresume.c
+++ b/tests/stopresume.c
@@ -13,25 +13,24 @@
 /* The tree builds with -fvisibility=hidden, which would hide the interposer. */
 #define SHIM_EXPORT __attribute__((visibility("default")))
 
-/* The engine's own httrackp, opaque here. */
-SHIM_EXPORT void *hts_create_opt(void);
-
 static void *stopresume_opt = NULL;
 
-/* Polls for the trigger rather than sleeping a fixed delay: the test decides
-   when the transfer is really in flight. Gives up so a missed trigger fails
-   the test rather than pinning a core. */
+/* Polls rather than sleeping a fixed delay, and gives up on STOPRESUME_TIMEOUT,
+   the test's own wait plus a margin, so a missed trigger cannot pin a core. */
 static void *stopresume_thread(void *unused) {
   int (*request_stop)(void *, int) = NULL;
   const char *const trigger = getenv("STOPRESUME_TRIGGER");
   const char *const keep = getenv("STOPRESUME_KEEP");
-  int left = 600;
+  const char *const budget = getenv("STOPRESUME_TIMEOUT");
+  int left;
 
   (void) unused;
   *(void **) &request_stop = dlsym(RTLD_DEFAULT, "hts_request_stop");
-  if (trigger == NULL || keep == NULL || request_stop == NULL) {
+  if (trigger == NULL || keep == NULL || budget == NULL ||
+      request_stop == NULL) {
     return NULL;
   }
+  left = atoi(budget) * 10;
   while (left-- > 0) {
     if (access(trigger, R_OK) == 0) {
       request_stop(stopresume_opt, atoi(keep));


### PR DESCRIPTION
`hts_request_stop()` took a `force` parameter its own header called ignored, and it was. Every front end's Stop button therefore left `exit_xh` at 0. The engine reads that as a clean end of mirror and erases `hts-cache/ref`, the per-URL byte ranges a later `--continue` needs. `back_abort_stopped()` has just gone to the trouble of leaving the partial bodies on disk, so the two layers work against each other.

The parameter now does something. Pass true and the stop keeps the resume data. The internal callers behind `--max-size` and `--max-time` keep passing false. A cap that was reached ends the mirror as cleanly as running out of links does. Nothing moves in the signature, the exported symbol set or the soname. The declaration renames the parameter to `keep_resume`, which C ignores at the call site, because `force` said nothing about what the flag decides.

WebHTTrack already passed true, at `htsserver.c:1467` on the second Cancel press and at `:1489` on Abort. The diff touches neither line. Both calls were inert before and are live now, so WebHTTrack's Abort and its second Cancel keep resume data from here on. The other front ends can ask for the same.

`exit_xh` also becomes `volatile`, matching the `stop` flag two lines above it. The hazard is not new, but this makes it less likely to bite. `sig_finish` already writes `exit_xh` from a signal handler on master. The mirror loop polls it without a lock, so a compiler is entitled to hoist that read. It probably does not, because the loop body makes opaque calls, but that is not a guarantee. `htsopt.h` is an installed header, so this touches a public struct. `volatile` changes no size, offset or alignment, so the layout is compatible and the soname stays. `sig_atomic_t` would have changed the member's width and been a real break.

`444_local-stop-keeps-resume.test` stops a trickled crawl through the exported call, with an LD_PRELOAD interposer shaped like the one test 253 uses for the per-link cancel. Three arms read the directory: kept under a true stop, erased under a false one, erased under the engine's own `--max-time` cap. The keep arm also reads the exit status and the interrupted-mirror banner. The purge only compares `exit_xh` against zero, so a `-1` would keep the directory while reporting an aborted mirror. A fourth arm runs the `--continue` and asserts the refetch asked for a `Range`. Kept ref files truncated to zero bytes pass the first three arms and fail that one. Setting `exit_xh` outside the state lock passes every arm, because a black-box test cannot see a race.

One part of the report is not fixed here. The first `^C` takes `sig_leave`, not `sig_finish`, and sets only `state.stop`, so it erases the ref directory too. Writing `exit_xh` there is not a one-line addition. `exit_xh` means "leave the link loop now". Writing it there turns the first `^C` into the second and breaks the "Finishing pending transfers" promise the handler prints. Tests 243, 255 and 263 pin that promise, and all three go red. 255 asserts the pending file comes out complete. That is also why a graceful `^C` leaves nothing worth keeping. The transfers in flight finished, so no partial remains for those byte ranges to describe. A second `^C` reaches `sig_term`, which calls `exit(0)` before the purge runs, so it keeps the directory already. Whether the first `^C` should keep it is still a call to make.

Reported by the httrack-windows session, which also asked for the `volatile`.
