### PR TITLE
An unallocatable backing table aborts the crawler instead of stopping it

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -101,15 +101,25 @@ typedef enum {
 static hts_mirror_limit back_mirror_limit(httrackp *opt);
 static hts_boolean back_mirror_capped(const httrackp *opt);
 
+/* NULL when the slot table cannot be allocated, which httpmirror() already
+   answers by aborting the mirror with a message. Failing here rather than
+   aborting the process: back_max grows with -cN, so the size is the user's. */
 struct_back *back_new(httrackp *opt, int back_max) {
   int i;
   struct_back *sback = calloct(1, sizeof(struct_back));
 
+  if (sback == NULL)
+    return NULL;
   sback->count = back_max;
   sback->lnk = (lien_back *) calloct((back_max + 1), sizeof(lien_back));
   sback->connect_fallback = (hts_connect_fallback *) calloct(
       (back_max + 1), sizeof(hts_connect_fallback));
   sback->ready = coucal_new(0);
+  if (sback->lnk == NULL || sback->connect_fallback == NULL ||
+      sback->ready == NULL) {
+    back_free(&sback);
+    return NULL;
+  }
   hts_set_hash_handler(sback->ready, opt);
   coucal_set_name(sback->ready, "back_new");
   sback->ready_size_bytes = 0;

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -1080,6 +1080,8 @@ int httpmirror(char *url1, httrackp *opt, hts_boolean *completed_out) {
       hts_log_print(opt, LOG_PANIC,
                     "Not enough memory, can not allocate %d backing slots",
                     back_max);
+      freet(primary);
+      XH_extuninit;
       return 0;
     }
   }

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -1068,18 +1068,18 @@ int httpmirror(char *url1, httrackp *opt, hts_boolean *completed_out) {
 
   // backing
   if (opt->maxsoc > 0) {
+    /* How many HTML files may sit in memory at once. Sized generously: HTML
+       takes little room and everything else is written straight to disk. */
+    const int back_max = opt->maxsoc * 32 + 1024;
+
 #if BDEBUG==2
     _CLRSCR;
 #endif
-    // Nombre de fichiers HTML pouvant être présents en mémoire de manière simultannée
-    // On prévoit large: les fichiers HTML ne prennent que peu de place en mémoire, et les
-    // fichiers non html sont sauvés en direct sur disque.
-    // --> 1024 entrées + 32 entrées par socket en supplément
-    sback = back_new(opt, opt->maxsoc * 32 + 1024);
+    sback = back_new(opt, back_max);
     if (sback == NULL) {
       hts_log_print(opt, LOG_PANIC,
-                    "Not enough memory, can not allocate %d bytes",
-                    (int) ((opt->maxsoc + 1) * sizeof(lien_back)));
+                    "Not enough memory, can not allocate %d backing slots",
+                    back_max);
       return 0;
     }
   }

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -12445,6 +12445,60 @@ cleanup:
   return err;
 }
 
+/* back_new() sizes its slot table from -cN, so a user can ask for one that
+   does not fit. The contract is a NULL return, which httpmirror() turns into a
+   log line and a stopped mirror, where an abort loses that message. */
+static int st_backnew(httrackp *opt, int argc, char **argv) {
+  /* Too big to serve without the allocator asking the kernel for more. */
+  enum { slots = 4096 };
+
+  struct_back *sback;
+
+  (void) argc;
+  (void) argv;
+
+  /* Control: with memory available the same call hands back a whole table, so
+     a NULL below cannot be back_new refusing every size. */
+  sback = back_new(opt, slots);
+  if (sback == NULL || sback->count != slots || sback->lnk == NULL ||
+      sback->connect_fallback == NULL || sback->ready == NULL) {
+    printf("backnew: FAILED (control table incomplete)\n");
+    back_free(&sback);
+    return 1;
+  }
+  back_free(&sback);
+
+#ifndef _WIN32
+  {
+    struct rlimit saved, tight;
+
+    if (getrlimit(RLIMIT_AS, &saved) != 0) {
+      printf("backnew: cannot cap memory, skipped\n");
+      return 0;
+    }
+    tight = saved;
+    tight.rlim_cur = 1024 * 1024;
+    if (setrlimit(RLIMIT_AS, &tight) != 0) {
+      printf("backnew: cannot cap memory, skipped\n");
+      return 0;
+    }
+    sback = back_new(opt, slots);
+    (void) setrlimit(RLIMIT_AS, &saved);
+    if (sback != NULL) {
+      /* The cap is advisory here, so the run says nothing either way. */
+      back_free(&sback);
+      printf("backnew: cap did not bite, skipped\n");
+      return 0;
+    }
+    printf("backnew: oom OK\n");
+    return 0;
+  }
+#else
+  printf("backnew: cannot cap memory, skipped\n");
+  return 0;
+#endif
+}
+
 static int st_threadwait(httrackp *opt, int argc, char **argv) {
   int err = 0;
   int i, round;
@@ -13871,6 +13925,8 @@ static const struct selftest_entry {
      st_arrays},
     {"ucs2", "[oom]", "UCS2 to UTF-8 re-encoding, and its failure return",
      st_ucs2},
+    {"backnew", "",
+     "a backing table too big to allocate is a NULL, not an abort", st_backnew},
     {"pubheaders", "",
      "layout of the installed structs configure's switches decide",
      st_pubheaders},

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -12337,8 +12337,11 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
     }                                                                          \
   } while (0)
 
-  cache.hashtable = coucal_new(0);
+  /* before the cleanup label has anything to free */
   sback = back_new(opt, SLOTS);
+  if (sback == NULL)
+    return 77;
+  cache.hashtable = coucal_new(0);
   back = sback->lnk;
   if (!st_backstop_arm(opt, sback, status, r, SLOTS, SLOT_DNS)) {
     skipped = 1;

--- a/tests/446_engine-backnew.test
+++ b/tests/446_engine-backnew.test
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+# back_new() sizes the backing table from -cN, so a table nobody can allocate
+# must come back as the NULL httpmirror() already logs and gives up on, not as
+# an abort. The cap is RLIMIT_AS, so hosts where it is advisory report a skip;
+# ASan needs telling to return NULL rather than die.
+rc=0
+out=$(ASAN_OPTIONS="${ASAN_OPTIONS-}${ASAN_OPTIONS:+:}allocator_may_return_null=1" \
+    httrack -O /dev/null -#test=backnew 2>&1) || rc=$?
+test "$rc" -eq 0 || fail "-#test=backnew: exited $rc, output: $out"
+case "$out" in
+"backnew: oom OK") ;;
+*skipped*)
+    echo "SKIP: $out" >&2
+    ;;
+*)
+    fail "expected the failed allocation to be reported, got: $out"
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
`back_new()` reads four allocations without checking any of them, so a backing table the process cannot allocate is a NULL dereference. `httpmirror()` was already written for the other answer: it tests the return, logs `Not enough memory` and gives up on the mirror. The callee never delivered that NULL.

The size comes from the command line. `back_max` is `maxsoc * 32 + 1024`, and `-cN` sets `maxsoc` with no ceiling once `-%!` lifts the connection limit. `httrack -%! -c60000000 http://host/` asks for 1920001024 slots and dies at htsback.c:119 with RC=134. It now logs `Not enough memory, can not allocate 1920001024 backing slots` and exits 3.

Stopping is the right answer, so this is not a recovery. A crawl with no slot table has nothing to run, and the caller already ends the mirror. The abort only cost the message.

The panic line reported `(maxsoc + 1) * sizeof(lien_back)`, which is neither the failed allocation nor the requested one, and truncated it through an `int`. It reports the slot count instead, because that is the number `-cN` moves.

`-#test=backnew` allocates a table under an `RLIMIT_AS` it sets and restores around the one call. The starvation then reaches that call and not the harness around it. A shell-level `ulimit -v` cannot do that, because it fails whichever allocation comes first and says nothing about this one. The control allocates the same table with memory available and checks all four members, so a `back_new` refusing every size would fail it. Test 446 skips where `RLIMIT_AS` is advisory. Putting the unchecked allocations back gives RC=134 on the self-test, and making `back_new` return NULL unconditionally fails the control.
