### PR TITLE
A >postfile: body is strlen'ed without a terminator

### DIFF
--- a/src/htslib.c
+++ b/src/htslib.c
@@ -1010,6 +1010,21 @@ void http_append_custom_headers(char *dst, size_t dst_size,
   append_custom_headers(&bstr, headers);
 }
 
+/* See htslib.h. Clipping rather than aborting: a body bigger than the request
+   block has always been truncated here, so an abort would be a new way to lose
+   the mirror. */
+size_t http_postfile_body(char *buffer, size_t buffer_size, size_t pos,
+                          FILE *fp) {
+  size_t room;
+  size_t got;
+
+  assertf(pos < buffer_size);
+  room = buffer_size - pos - 1; /* the NUL every consumer strlen()s up to */
+  got = fread(&buffer[pos], 1, room, fp);
+  buffer[pos + got] = '\0';
+  return pos + strlen(&buffer[pos]);
+}
+
 // envoi d'une requète
 int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
                   const char *xsend, const char *adr, const char *fil,
@@ -1051,7 +1066,6 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
           linput(fp, line, 1000);
           /* widths bound method[256], url[HTS_URLMAXSIZE*2], protocol[256] */
           if (sscanf(line, "%255s %2047s %255s", method, url, protocol) == 3) {
-            size_t ret;
             // http proxy: absolute-URI; socks/CONNECT tunnel: origin-form
             if (retour->req.proxy.active &&
                 !hts_proxy_is_socks(retour->req.proxy.name) &&
@@ -1064,13 +1078,9 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
               print_buffer(&bstr,
                        "%s %s %s\r\n", method, url, protocol);
             }
-            // lire le reste en brut
-            ret = fread(&bstr.buffer[bstr.pos],
-                        bstr.capacity - bstr.pos, 1, fp);
-            if ((int) ret < 0) {
-              return -1;
-            }
-            bstr.pos += strlen(&bstr.buffer[bstr.pos]);
+            // the rest of the file goes out raw
+            bstr.pos =
+                http_postfile_body(bstr.buffer, bstr.capacity, bstr.pos, fp);
           }
           fclose(fp);
         }

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -233,6 +233,14 @@ hts_boolean hts_body_missing_unexpectedly(const htsblk *r);
 void http_append_custom_headers(char *dst, size_t dst_size,
                                 const char *headers);
 
+/* Append the raw remainder of a >postfile: body into buffer (capacity
+   buffer_size) at write position pos, and return the new position. Clips to
+   the room left, and always leaves a NUL at the position returned: the request
+   block is read back with strlen() by the WARC stash, the sendhead callback
+   and sendc(). A NUL inside the file ends the request there. */
+size_t http_postfile_body(char *buffer, size_t buffer_size, size_t pos,
+                          FILE *fp);
+
 /* Switch soc between blocking and non-blocking mode; false on failure, with
    errno (WSAGetLastError() on Windows) set. */
 hts_boolean socket_set_nonblocking(T_SOC soc, hts_boolean nonblocking);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6380,6 +6380,73 @@ static void st_addrport_case(int family, unsigned int port,
   freet(arena);
 }
 
+/* One http_postfile_body() case, run into a request block followed by a
+   poisoned guard. A missing terminator shows up as a returned position that
+   walked into the poison instead of stopping inside the block. */
+static int st_postfile_case(const char *path, size_t start, size_t expect,
+                            const char *what) {
+  enum { capacity = 64, guard = 16 };
+
+  char *arena = malloct(capacity + guard);
+  FILE *fp = FOPEN(path, "rb");
+  size_t pos;
+  size_t i;
+  int err = 0;
+
+  if (arena == NULL || fp == NULL) {
+    printf("  FAIL %s: cannot open %s\n", what, path);
+    freet(arena);
+    if (fp != NULL)
+      fclose(fp);
+    return 1;
+  }
+  memset(arena, '#', capacity + guard);
+  arena[capacity + guard - 1] = '\0'; /* a runaway strlen ends here, not past */
+  memset(arena, 'R', start);          /* what the request line already wrote */
+  arena[start] = '\0';
+
+  pos = http_postfile_body(arena, capacity, start, fp);
+  fclose(fp);
+
+  if (pos != expect) {
+    printf("  FAIL %s: position %d, expected %d\n", what, (int) pos,
+           (int) expect);
+    err = 1;
+  } else if (arena[pos] != '\0') {
+    printf("  FAIL %s: no terminator at %d\n", what, (int) pos);
+    err = 1;
+  }
+  for (i = capacity; i + 1 < capacity + guard; i++) {
+    if (arena[i] != '#') {
+      printf("  FAIL %s: guard byte %d written\n", what, (int) (i - capacity));
+      err = 1;
+      break;
+    }
+  }
+  freet(arena);
+  return err;
+}
+
+/* >postfile: bodies, read raw into the request block. Fixture paths in argv:
+   shorter than the room left, longer than it, one holding a NUL, and empty. */
+static int st_postfile(httrackp *opt, int argc, char **argv) {
+  int err = 0;
+
+  (void) opt;
+  if (argc < 4) {
+    printf("usage: -#test=postfile <short> <long> <embedded-nul> <empty>\n");
+    return 1;
+  }
+  /* room left is 64 - 8 - 1 = 55 bytes */
+  err |= st_postfile_case(argv[0], 8, 8 + 3, "short");
+  err |= st_postfile_case(argv[1], 8, 8 + 55, "long");
+  err |= st_postfile_case(argv[2], 8, 8 + 2, "embedded-nul");
+  err |= st_postfile_case(argv[3], 8, 8, "empty");
+
+  printf("postfile self-test: %s\n", err ? "FAIL" : "OK");
+  return err;
+}
+
 static int st_addrport(httrackp *opt, int argc, char **argv) {
   (void) opt;
   (void) argc;
@@ -13804,6 +13871,9 @@ static const struct selftest_entry {
     {"catchurl", "",
      "an over-long request header block fails the capture, not the process",
      st_catchurl},
+    {"postfile", "<short> <long> <embedded-nul> <empty>",
+     "a >postfile: body is clipped to the request block and terminated",
+     st_postfile},
     {"urlbounds", "",
      "an over-long path is refused by the wizard and auth consumers",
      st_urlbounds},

--- a/tests/447_engine-postfile.test
+++ b/tests/447_engine-postfile.test
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+# A >postfile: body is read raw into the request block, which the WARC stash,
+# the sendhead callback and sendc() all read back with strlen(). Drives
+# -#test=postfile over four fixtures, none of which ends in a NUL of its own.
+dir=$(mktemp -d)
+cleanup_push rm -rf "$dir"
+
+printf 'abc' >"$dir/short"
+repeat_chars 200 A >"$dir/long"
+printf 'ab\000cd' >"$dir/embnul"
+: >"$dir/empty"
+
+assert_selftest "postfile self-test: OK" postfile \
+    "$dir/short" "$dir/long" "$dir/embnul" "$dir/empty"
+
+exit 0


### PR DESCRIPTION
A `>postfile:` URL sends a request read straight out of a local file. The read filled the request block to its last byte and then called `strlen()` on it, so nothing guaranteed a terminator. The walk then ran into whatever followed the block on the stack, and that went out on the wire.

Both halves are observable. Against a local listener, `httrack "http://host/x?>postfile:body"` with a 20000-byte body sent 16386 bytes out of a 16384-byte buffer. The same run on an ASan build of master aborts in `strlen` with `stack-buffer-overflow READ of size 16367`, at htslib.c:1073, reached from `httpmirror` through `back_wait`. A body shorter than the block is no better. The bytes past it are uninitialized stack, so the request ends wherever the first NUL happens to sit.

`http_postfile_body()` now keeps one byte for the terminator and writes it. It clips rather than aborts, because a body bigger than the request block has always been truncated here. The same run now sends 16383 bytes. A NUL inside the file still ends the request there, which is what `strlen()` did before.

The discarded `fread()` return went too. It was read as `(int) ret < 0` on a `size_t`, which is never true. The count it held was a whole-item count that could only ever be 0 or 1.

`-#test=postfile` runs the helper into a request block followed by a poisoned guard. The four fixtures are a body shorter than the room left, one longer than it, one holding a NUL, and an empty file. Test 447 kills two mutants. The old `fread()` and bare `strlen()` walk into the guard and return a position outside the block. Dropping the reserved byte writes the terminator onto the first guard byte, which the guard reports by name.
