### PR TITLE
226's backoff bound asks for a tick that cannot exist

### DIFF
--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -648,8 +648,21 @@ throttle_leg() {
     }
 }
 
+# Calls a healthy backoff owes in $1 due ticks: it skips 1, then 2, 4, 8, 16,
+# doubling to a cap of 32, so its c-th call lands on tick 1, 3, 6, 11, 20, 37.
+backoff_calls_due() {
+    local due=1 skip=1 n=0
+    while test "$due" -le "$1"; do
+        n=$((n + 1))
+        due=$((due + skip + 1))
+        skip=$((skip * 2))
+        test "$skip" -le 32 || skip=32
+    done
+    echo "$n"
+}
+
 backoff_leg() {
-    local calls lines
+    local calls lines want
     sink_start 403
     printf 'RUN 36_local-bigcrawl.test at 41s\n' >"$tmp/progress.log"
     run_posting 60 -File "$1" -ProgressLog "$(nativepath "$tmp/progress.log")" \
@@ -661,13 +674,29 @@ backoff_leg() {
     sink_stop
     calls=$(count_matching_lines . "$posts")
     lines=$(count_matching_lines 't=[0-9]*s q=' "$legout")
-    test "$calls" -ge 2 || {
-        echo "a rejecting API was called $calls times: the loop stopped trying"
+    # A starved box spends the window on a handful of turns, and at six ticks or
+    # fewer a doubling backoff and a flat one owe the same calls. Widen, don't
+    # grade. Six still admits that one tie, and the counts separate from seven.
+    if test "$lines" -lt 6; then
+        sink_start 403
+        run_posting 120 -File "$1" -ProgressLog "$(nativepath "$tmp/progress.log")" \
+            -IntervalSeconds 1 -PollSeconds 1 -MaxSeconds 30 >"$legout" 2>&1 || {
+            sink_stop
+            echo "the loop exited nonzero over 30s: $(<"$legout")"
+            return 1
+        }
+        sink_stop
+        calls=$(count_matching_lines . "$posts")
+        lines=$(count_matching_lines 't=[0-9]*s q=' "$legout")
+    fi
+    test "$lines" -ge 6 || {
+        echo "$lines due ticks over 30s at a 1s interval: too few to judge a backoff"
         return 1
     }
-    # One diagnosis for both: which one trips first depends on box speed. The
-    # backoff must thin the calls, not the log; a token-less run leaves only the log.
-    if test "$calls" -gt 5 || test "$lines" -lt $((2 * calls)); then
+    # Graded against the ticks that happened, so starvation shrinks both counts
+    # together: a loop that gives up posts fewer, one that never skips posts more.
+    want=$(backoff_calls_due "$lines")
+    if test "$calls" -ne "$want"; then
         echo "$calls calls and $lines log lines against an API rejecting every one: nothing backs off"
         return 1
     fi


### PR DESCRIPTION
The backoff leg required `lines >= 2*calls` against an API rejecting everything. A correct backoff puts its second call ON due tick 3. That bound therefore asks for a tick the schedule never reaches, and the false band is exactly 2 calls and 3 lines. It reds a pristine watchdog rather than a broken one.

That is what `build (macOS arm64, clang)` has been reporting. Three cores under a parallel suite reach the band, and the leg says `nothing backs off` about a watchdog backing off correctly. The bytes here match the branch this comes from, so it is a latent bug rather than a regression from anything in flight.

Graded against the ticks that happened instead. A backoff skips 1, then 2, 4, 8, 16, capped at 32. Its calls therefore land on tick 1, 3, 6, 11, 20, 37. The calls owed then follow from the ticks observed. Both counts come from one run, so starvation shrinks them together and no bound widens. This subsumes the two checks it replaces. Under seven ticks a flat backoff owes what a doubling one owes, so that window re-runs once at 30s rather than grading a starved sample.

Validated with pwsh 7.4.6 on four pinned cores against 0, 31, 63 and 127 hogs. The good watchdog passes throughout, where the old bound reds it at 16x and 32x, and the never-skips and flat mutants fail at every load.

This is a cherry-pick, landing on its own because four unrelated pull requests are waiting on it. While master reds here, every red anywhere has to be triaged by hand to tell this from a real one.
