### PR TITLE
The output-buffer lint cannot see a size assigned straight into the array

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -81,6 +81,17 @@ Please visit our Website: http://www.httrack.com
   } \
 } while(0)
 
+/** Set the output buffer's size, latching output_oom rather than claiming
+    bytes it never had room for. **/
+#define HT_SET_SIZE(N) do { \
+  const size_t size_ = (N); \
+  if (size_ <= TypedArrayCapa(output_buffer)) { \
+    TypedArraySize(output_buffer) = size_; \
+  } else { \
+    output_oom = HTS_TRUE; \
+  } \
+} while(0)
+
 /** Append bytes to the output buffer up to the pointer 'html'. **/
 #define HT_add_adr do { \
   if ( (opt->getmode & 1) != 0 && ptr > 0 ) { \
@@ -3552,11 +3563,20 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                the latter needs a copy: re-appending output_buffer onto itself
                would read freed memory, as the append's realloc can relocate
                the block out from under cAddr. */
-            if (cAddr != TypedArrayElts(output_buffer)) {
-              TypedArraySize(output_buffer) = 0;
+            if (!hts_postprocess_reply_ok(cAddr, cSize,
+                                          TypedArrayElts(output_buffer),
+                                          TypedArraySize(output_buffer))) {
+              hts_log_print(opt, LOG_ERROR,
+                            "engine: postprocess-html: callback returned %d "
+                            "bytes for %s%s, page skipped",
+                            cSize, urladr(), urlfil());
+              HT_SET_SIZE(0);
+              error = 1;
+            } else if (cAddr != TypedArrayElts(output_buffer)) {
+              HT_SET_SIZE(0);
               HT_ADD_N(cAddr, (size_t) cSize);
             } else {
-              TypedArraySize(output_buffer) = (size_t) cSize;
+              HT_SET_SIZE((size_t) cSize);
             }
           }
         }
@@ -3593,6 +3613,14 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
   ENGINE_SAVE_CONTEXT();
 
   return 0;
+}
+
+/* Contract in htsparse.h. */
+hts_boolean hts_postprocess_reply_ok(const char *html, int len,
+                                     const char *buffer, size_t size) {
+  if (len < 0)
+    return HTS_FALSE;
+  return html != buffer || (size_t) len <= size;
 }
 
 /* Mirror the savename to tell whether a redirect saves to the same file (#159);

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -3558,25 +3558,28 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
           if (RUN_CALLBACK4(opt, postprocess, &cAddr, &cSize, urladr(), urlfil()) == 1) {
             hts_log_print(opt, LOG_DEBUG,
               "engine: postprocess-html: callback modified data, applying %d bytes", cSize);
-            /* The callback either edits output_buffer in place (cAddr
-               unchanged) or hands back its own buffer (cAddr changed). Only
-               the latter needs a copy: re-appending output_buffer onto itself
-               would read freed memory, as the append's realloc can relocate
-               the block out from under cAddr. */
+            /* A reply pointing anywhere into output_buffer edited it in
+               place and is moved down. Appending it onto itself instead would
+               memcpy overlapping bytes, after an EnsureRoom whose realloc can
+               relocate the block out from under cAddr. */
             if (!hts_postprocess_reply_ok(cAddr, cSize,
                                           TypedArrayElts(output_buffer),
-                                          TypedArraySize(output_buffer))) {
+                                          TypedArraySize(output_buffer),
+                                          TypedArrayCapa(output_buffer))) {
               hts_log_print(opt, LOG_ERROR,
                             "engine: postprocess-html: callback returned %d "
                             "bytes for %s%s, page skipped",
                             cSize, urladr(), urlfil());
               HT_SET_SIZE(0);
               error = 1;
-            } else if (cAddr != TypedArrayElts(output_buffer)) {
+            } else if (hts_postprocess_reply_inplace(
+                           cAddr, TypedArrayElts(output_buffer),
+                           TypedArrayCapa(output_buffer))) {
+              memmove(TypedArrayElts(output_buffer), cAddr, (size_t) cSize);
+              HT_SET_SIZE((size_t) cSize);
+            } else {
               HT_SET_SIZE(0);
               HT_ADD_N(cAddr, (size_t) cSize);
-            } else {
-              HT_SET_SIZE((size_t) cSize);
             }
           }
         }
@@ -3616,11 +3619,27 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
 }
 
 /* Contract in htsparse.h. */
+hts_boolean hts_postprocess_reply_inplace(const char *html, const char *buffer,
+                                          size_t capa) {
+  /* through uintptr_t: comparing pointers into unrelated objects is not
+     defined, and the callback's buffer is one */
+  const uintptr_t at = (uintptr_t) html, base = (uintptr_t) buffer;
+
+  return buffer != NULL && at >= base && at - base < capa;
+}
+
+/* Contract in htsparse.h. */
 hts_boolean hts_postprocess_reply_ok(const char *html, int len,
-                                     const char *buffer, size_t size) {
-  if (len < 0)
+                                     const char *buffer, size_t size,
+                                     size_t capa) {
+  if (len < 0 || html == NULL)
     return HTS_FALSE;
-  return html != buffer || (size_t) len <= size;
+  if (hts_postprocess_reply_inplace(html, buffer, capa)) {
+    const size_t at = (size_t) (html - buffer);
+
+    return at <= size && (size_t) len <= size - at;
+  }
+  return HTS_TRUE;
 }
 
 /* Mirror the savename to tell whether a redirect saves to the same file (#159);

--- a/src/htsparse.h
+++ b/src/htsparse.h
@@ -133,14 +133,26 @@ hts_boolean hts_redirect_same_savefile(httrackp *opt, const char *cur_adr,
                                        const char *moved_fil);
 
 /*
+  Did a postprocess-html callback's reply come out of the engine's own storage?
+  "html" is what it returned, "buffer" and "capa" the storage. Any pointer
+  inside it edited that storage in place, at offset "html - buffer": a reply
+  skipping a BOM comes back at buffer+3 and is no less in place than one at
+  buffer itself. The engine must move such bytes down rather than append them
+  onto themselves.
+*/
+hts_boolean hts_postprocess_reply_inplace(const char *html, const char *buffer,
+                                          size_t capa);
+
+/*
   Can a postprocess-html callback's reply be applied? "html" and "len" are what
-  it returned, "buffer" and "size" what it was handed. A reply keeping the same
-  pointer edited the engine's own buffer in place, so it holds only the bytes it
-  was given. A reply carrying its own buffer is bounded by that buffer instead.
-  Neither may report a negative count, which an int "len" allows.
+  it returned, "buffer", "size" and "capa" what it was handed. An in-place reply
+  holds only the bytes the engine gave it, counted from its own offset. A reply
+  carrying its own buffer is bounded by that buffer instead. Neither may report
+  a negative count, which an int "len" allows.
 */
 hts_boolean hts_postprocess_reply_ok(const char *html, int len,
-                                     const char *buffer, size_t size);
+                                     const char *buffer, size_t size,
+                                     size_t capa);
 
 /*
   Take a pending stop request, deleting the request file, and answer whether the

--- a/src/htsparse.h
+++ b/src/htsparse.h
@@ -133,6 +133,16 @@ hts_boolean hts_redirect_same_savefile(httrackp *opt, const char *cur_adr,
                                        const char *moved_fil);
 
 /*
+  Can a postprocess-html callback's reply be applied? "html" and "len" are what
+  it returned, "buffer" and "size" what it was handed. A reply keeping the same
+  pointer edited the engine's own buffer in place, so it holds only the bytes it
+  was given. A reply carrying its own buffer is bounded by that buffer instead.
+  Neither may report a negative count, which an int "len" allows.
+*/
+hts_boolean hts_postprocess_reply_ok(const char *html, int len,
+                                     const char *buffer, size_t size);
+
+/*
   Take a pending stop request, deleting the request file, and answer whether the
   mirror must now stop. True only for a request newer than this run's own
   hts-in_progress.lock and deletable, so neither one inherited from an earlier

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -13955,26 +13955,43 @@ static int st_catchurl(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
-/* What a postprocess-html callback may claim. Two capacities, or a bound that
-   ignored "size" and hardcoded one would pass. */
+/* What a postprocess-html callback may claim, and out of whose storage. Two
+   capacities and every offset, or a bound that ignored "size" or looked only at
+   the base pointer would pass. */
 static int st_postprocsize(httrackp *opt, int argc, char **argv) {
-  char buf[16], own[16];
+  char buf[16] = {0}, own[16] = {0};
+  const size_t capa = sizeof(buf);
   size_t size;
 
   (void) opt;
   (void) argc;
   (void) argv;
-  for (size = 4; size <= sizeof(buf); size *= 4) {
-    /* an in-place edit may shrink or keep what it was handed, never grow */
-    assertf(hts_postprocess_reply_ok(buf, 0, buf, size));
-    assertf(hts_postprocess_reply_ok(buf, (int) size - 1, buf, size));
-    assertf(hts_postprocess_reply_ok(buf, (int) size, buf, size));
-    assertf(!hts_postprocess_reply_ok(buf, (int) size + 1, buf, size));
+  /* the engine's own storage, whatever the reply points at inside it */
+  assertf(hts_postprocess_reply_inplace(buf, buf, capa));
+  assertf(hts_postprocess_reply_inplace(buf + capa - 1, buf, capa));
+  assertf(!hts_postprocess_reply_inplace(buf + capa, buf, capa));
+  assertf(!hts_postprocess_reply_inplace(own, buf, capa));
+  assertf(!hts_postprocess_reply_inplace(buf, buf, 0));
+  for (size = 4; size <= capa; size *= 2) {
+    size_t at;
+
+    for (at = 0; at <= size; at++) {
+      /* in place, a reply owns what is left of "size" past its own offset */
+      assertf(hts_postprocess_reply_ok(buf + at, (int) (size - at), buf, size,
+                                       capa));
+      /* one past the storage is another object's business, not ours to bound */
+      if (at < capa)
+        assertf(!hts_postprocess_reply_ok(buf + at, (int) (size - at) + 1, buf,
+                                          size, capa));
+    }
+    /* in the buffer's slack, past every byte the engine handed out */
+    if (size < capa)
+      assertf(!hts_postprocess_reply_ok(buf + size + 1, 0, buf, size, capa));
     /* a buffer of the callback's own is bounded by the callback */
-    assertf(hts_postprocess_reply_ok(own, (int) size + 1, buf, size));
-    /* neither may be negative */
-    assertf(!hts_postprocess_reply_ok(buf, -1, buf, size));
-    assertf(!hts_postprocess_reply_ok(own, -1, buf, size));
+    assertf(hts_postprocess_reply_ok(own, (int) capa + 1, buf, size, capa));
+    /* neither may report a negative count */
+    assertf(!hts_postprocess_reply_ok(own, -1, buf, size, capa));
+    assertf(!hts_postprocess_reply_ok(buf, -1, buf, size, capa));
   }
   printf("postprocess reply self-test OK\n");
   return 0;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -13955,6 +13955,31 @@ static int st_catchurl(httrackp *opt, int argc, char **argv) {
   return 0;
 }
 
+/* What a postprocess-html callback may claim. Two capacities, or a bound that
+   ignored "size" and hardcoded one would pass. */
+static int st_postprocsize(httrackp *opt, int argc, char **argv) {
+  char buf[16], own[16];
+  size_t size;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+  for (size = 4; size <= sizeof(buf); size *= 4) {
+    /* an in-place edit may shrink or keep what it was handed, never grow */
+    assertf(hts_postprocess_reply_ok(buf, 0, buf, size));
+    assertf(hts_postprocess_reply_ok(buf, (int) size - 1, buf, size));
+    assertf(hts_postprocess_reply_ok(buf, (int) size, buf, size));
+    assertf(!hts_postprocess_reply_ok(buf, (int) size + 1, buf, size));
+    /* a buffer of the callback's own is bounded by the callback */
+    assertf(hts_postprocess_reply_ok(own, (int) size + 1, buf, size));
+    /* neither may be negative */
+    assertf(!hts_postprocess_reply_ok(buf, -1, buf, size));
+    assertf(!hts_postprocess_reply_ok(own, -1, buf, size));
+  }
+  printf("postprocess reply self-test OK\n");
+  return 0;
+}
+
 /* A path of exactly "n" bytes, both ends '/' so bauth_prefix() keeps all of
    it: the key it builds is truncated at the last slash. */
 static void st_urlbounds_path(char *fil, size_t n) {
@@ -14112,6 +14137,9 @@ static const struct selftest_entry {
     {"catchurl", "",
      "an over-long request header block fails the capture, not the process",
      st_catchurl},
+    {"postprocsize", "",
+     "a postprocess-html callback cannot claim bytes it was not handed",
+     st_postprocsize},
     {"postfile", "<short> <long> <embedded-nul> <empty>",
      "a >postfile: body is clipped to the request block and terminated",
      st_postfile},

--- a/tests/440_ci-output-buffer-latch.test
+++ b/tests/440_ci-output-buffer-latch.test
@@ -1,7 +1,9 @@
 #!/bin/bash
 #
 # htsparse.c's output_buffer only reports a failed growth if every macro that
-# grows it latches output_oom. #1561's HT_ADD_BUF reached it without doing so.
+# grows it latches output_oom, and it only stays inside its allocation if
+# nothing sets its size or storage directly. #1561's HT_ADD_BUF grew it without
+# latching. A plugin's byte count was assigned straight into its size.
 
 set -euo pipefail
 
@@ -11,20 +13,25 @@ set -euo pipefail
 src="${testdir}/../src/htsparse.c"
 test -r "$src" || fail "no source at $src"
 
-# Report every macro that grows output_buffer without latching, and every
-# growth sitting outside a macro body altogether.
+# Report every macro that grows output_buffer or sets its size, capacity or
+# storage without latching, and every such write sitting outside a macro body
+# altogether. A bare assignment is the route no growth call can see.
 unlatched() { # unlatched FILE
     awk '
+    BEGIN {
+        grow = "TypedArray(EnsureRoom|Append|Add)\\(output_buffer"
+        set = "(TypedArray(Size|Capa|Elts|Ptr)\\(output_buffer\\)" \
+              "|output_buffer\\.(size|capa|data))" \
+              "[ \t]*(\\+\\+|--|[-+*/]?=([^=]|$))"
+    }
     /^#define/ { name = $2; sub(/\(.*/, "", name); body = $0; open = /\\$/
                  if (!open) { check(); name = "" }
                  next }
     open { body = body "\n" $0; if ($0 !~ /\\$/) { open = 0; check(); name = "" }
            next }
-    /TypedArray(EnsureRoom|Append|Add)\(output_buffer/ {
-        print "outside any macro, line " NR }
+    $0 ~ grow || $0 ~ set { print "outside any macro, line " NR }
     function check() {
-        if (body ~ /TypedArray(EnsureRoom|Append|Add)\(output_buffer/ &&
-            body !~ /output_oom/) print name
+        if ((body ~ grow || body ~ set) && body !~ /output_oom/) print name
     }' "$1"
 }
 
@@ -34,12 +41,22 @@ test -z "$got" || fail "reaches output_buffer without latching output_oom: $got"
 # The checker is silent on a clean file, so a broken one would pass too.
 work=$(mktemp -d "${TMPDIR:-/tmp}/oblatch.XXXXXX") || fail "no tmpdir"
 cleanup_push rm -rf "$work"
+
+# A growth straight out of a macro that never latches.
 sed 's|^#define HT_ADD_BUF(A, N) HT_ADD_N(.*|#define HT_ADD_BUF(A, N) TypedArrayAppend(output_buffer, A, N)|' \
-    "$src" >"$work/mutant.c"
-cmp -s "$src" "$work/mutant.c" && fail "the mutant edit matched nothing; HT_ADD_BUF was renamed"
-case "$(unlatched "$work/mutant.c")" in
+    "$src" >"$work/grow.c"
+cmp -s "$src" "$work/grow.c" && fail "the mutant edit matched nothing; HT_ADD_BUF was renamed"
+case "$(unlatched "$work/grow.c")" in
 *HT_ADD_BUF*) ;;
 *) fail "the checker missed HT_ADD_BUF appending straight to output_buffer" ;;
+esac
+
+# A size set with no growth call for the rule above to see.
+sed 's|HT_SET_SIZE(0);|TypedArraySize(output_buffer) = 0;|' "$src" >"$work/size.c"
+cmp -s "$src" "$work/size.c" && fail "the mutant edit matched nothing; HT_SET_SIZE was renamed"
+case "$(unlatched "$work/size.c")" in
+*"outside any macro"*) ;;
+*) fail "the checker missed a bare TypedArraySize(output_buffer) assignment" ;;
 esac
 
 exit 0

--- a/tests/448_engine-postprocess-size.test
+++ b/tests/448_engine-postprocess-size.test
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# A postprocess-html callback returns its byte count as an int, which the engine
+# used to store as the output buffer's size unchecked. 440 keeps that route from
+# reappearing; this pins what the check accepts.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+selftest_queue "postprocess reply self-test OK" postprocsize
+selftest_run_queued


### PR DESCRIPTION
`440_ci-output-buffer-latch.test` greps for the three macros that grow `output_buffer` and checks each one latches `output_oom`. `htsparse.c` also assigned a plugin's `int cSize` straight into `TypedArraySize(output_buffer)`, which no growth call sees. The checker read clean over the defect class it exists to catch. It now flags any write to the buffer's size, capacity or storage outside a latching macro. Pointed at the pre-fix `htsparse.c` it names both bare assignments.

The size itself needed a bound. A negative `cSize` on the in-place arm becomes the `SIZE_MAX` the save path is handed. The page then lands as zero bytes, exit 0, no log line. On the copy arm it becomes a `SIZE_MAX` allocation that fails, so the page is skipped as out of memory. A positive count above what the callback was handed copies heap past the page into the mirrored file, silently.

The arm that applies follows from where the reply points. A reply inside the engine's own storage edited it in place and owns only the bytes it was handed, counted from its own offset. One carrying its own buffer stays bounded by `HT_ADD_N`. Testing the base pointer alone missed the middle. A plugin skipping a BOM returns `buffer + 3`, which is not `buffer`, so it took the copy arm. `HT_ADD_N` then memcpy'd the buffer onto itself, after an `EnsureRoom` whose realloc had already freed the block. Such a plugin reproduces it. ASan reports a heap-use-after-free reading 359 bytes at `buffer + 3` and is clean on this branch, which moves those bytes down instead.

A count failing the bound drops the page instead of saving it, because the callback has already edited our copy away.

Two things this leaves. Nothing in the tree loads a plugin at runtime, so a self-test pins the classifier and the ASan run above was by hand. And a plugin growing the page through `realloc` now loses it when it gets the same address back. Nothing distinguishes that from a claim on bytes it never wrote. Growing into a new pointer still passes.

`html/plug.html` tells the callback to `realloc` the pointer the engine handed it, which would leave the engine holding a freed block. The code assumes a fresh buffer instead. Worth its own look.