### PR TITLE
The crawl log can pick up bash's own "[1]+ Done" line

### DIFF
--- a/tests/450_harness-job-control.test
+++ b/tests/450_harness-job-control.test
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# run_with_timeout must resolve the backend before it turns job control on. A
+# fork between "set -m" and "set +m" makes bash report the job it has just
+# reaped ("[1]+ Done") on stderr, and local_crawl points that stderr at the
+# crawl log, so the harness lands inside the crawl's own output. Only some bash
+# builds print it (5.2.21 on Ubuntu 24.04 does, 5.2.37 does not), so the log is
+# no witness here; the call is.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/jobctl.XXXXXX") || fail "no tmpdir"
+cleanup_push rm -rf "$work"
+
+msys=no
+! shell_is_msys || msys=yes
+flag="${work}/called"
+
+# Stands in for the real probe from here on: it records every call made under
+# job control and still answers what the real one answered, so nothing
+# downstream changes shape.
+shell_is_msys() {
+    case "$-" in *m*) printf '%s\n' "$-" >>"$flag" ;; esac
+    test "$msys" = yes
+}
+
+## the fixed window makes no such call
+: >"$flag"
+run_with_timeout 30 true || fail "run_with_timeout failed on a trivial job"
+test ! -s "$flag" ||
+    fail "run_with_timeout probed the backend under job control ($(<"$flag")), so bash announces the reaped job on the crawl log"
+ok "run_with_timeout resolves the backend outside the job-control window"
+
+## and the probe would have seen the call it is looking for
+#
+# It records nothing on a fixed harness, so a probe hooked to the wrong function,
+# or one whose recording arm never runs, passes above just as well. The shape
+# below is the one run_with_timeout carried until this test was written.
+: >"$flag"
+(
+    had_m=''
+    case "$-" in *m*) had_m=1 ;; esac
+    shell_is_msys || set -m
+    true &
+    pid=$!
+    test -n "$had_m" || shell_is_msys || set +m
+    wait "$pid"
+) || fail "the control shape failed on a trivial job"
+test -s "$flag" || fail "the probe missed a backend call made under job control"
+ok "the probe still sees a backend call inside the window"

--- a/tests/65_port-siblings.test
+++ b/tests/65_port-siblings.test
@@ -49,12 +49,15 @@ web_accepted() {
     # A bound server blocks, so stop it once it announces, not on a fixed
     # deadline: the announce trails a local-hostname resolve that stalls on macOS,
     # where a 3s kill landed mid-resolve, before the URL= line ever printed.
-    local had_m=
+    local had_m='' is_msys=''
+    # Before "set -m", because shell_is_msys forks and a fork inside the
+    # job-control window makes bash announce the job it just reaped.
+    ! shell_is_msys || is_msys=1
     case "$-" in *m*) had_m=1 ;; esac
-    shell_is_msys || set -m
+    test -n "$is_msys" || set -m
     htsserver "$tmp" --port "$port" >"$tmp/web.log" 2>&1 &
     local pid=$!
-    test -n "$had_m" || shell_is_msys || set +m
+    test -n "$had_m" || test -n "$is_msys" || set +m
     local waited=0
     until grep -qE "^URL=http://.*:$port/|couldn't set the port number|Unable to initialize a temporary server" "$tmp/web.log"; do
         test "$waited" -lt 20 || break

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -1288,16 +1288,20 @@ run_with_timeout() {
     fi
     local secs=$1
     shift
-    local had_m=
+    local had_m='' is_msys=''
+    # Resolved before job control goes on: shell_is_msys forks, and a fork between
+    # "set -m" and "set +m" makes bash report the job it just reaped ("[1]+ Done")
+    # on our stderr, which local_crawl has pointed at the crawl log.
+    ! shell_is_msys || is_msys=1
     case "$-" in *m*) had_m=1 ;; esac
-    shell_is_msys || set -m # own process group, so kill_tree can signal the group
+    test -n "$is_msys" || set -m # own process group, so kill_tree can signal the group
     case $stdin in
     '') "$@" & ;;
     closed) "$@" <&- & ;;
     *) "$@" <"$stdin" & ;;
     esac
     local pid=$!
-    test -n "$had_m" || shell_is_msys || set +m
+    test -n "$had_m" || test -n "$is_msys" || set +m
     # Read while the job is certainly alive: by kill time /proc/<pid>/winpid is gone.
     local winpid=''
     ! target_is_windows || winpid=$(win_pid "$pid")


### PR DESCRIPTION
`local_crawl --log FILE` redirects the harness shell's own stderr into the crawl log, so anything that shell writes there reads back as crawl output. `run_with_timeout` turns job control on, forks the crawl, and only then calls `shell_is_msys`, which is a command substitution and therefore a fork. If the crawl child has already been reaped by then, bash announces it on that stderr and the log gains a line of its own:

```
FAIL: --log truncates per crawl: expected [crawl-said-this], got [crawl-said-this
[1]+  Done                    "$@"]
```

That is `258_crawllib.test`, seen first on both arm64 legs of #1591 and since on `build (x86-64, gcc)` on master, same OS and bash. So the architecture was sampling rather than cause: the race fires wherever the interleaving lands. And 258 is only the messenger, because every test that reads a `--log` file is exposed, `assert_logged` and `assert_gave_up` among them.

The fix resolves the backend into a variable before `set -m`, so no fork sits inside the window. `tests/test-timeout.sh` already did exactly that. `web_accepted` in `65_port-siblings.test` carried the same shape and gets the same treatment. The three other job-control windows in the tree (105, 151, 172) run builtins only.

Two things hide this. Bash suppresses the notification when it reads a script from a file, so a hand-run never shows it. The harness runs each test under `bash -c` instead, where bash does not suppress it. And the printing is version-dependent: bash 5.2.21, which Ubuntu 24.04 ships, prints it, while 5.2.37 does not.

Reproduced against a 5.2.21 build, with the child forced dead before the window's fork by a builtin-only spin loop added to `run_with_timeout` for the probe. Unfixed, 258 failed with the message above. Fixed, the log holds no `Done` line, and only the spin loop's own artifact remains, matching the 5.2.37 control. The spin loop is not part of the change.

`450_harness-job-control.test` watches the call rather than the log. After the fix no external scheduling can force the leak, so a log assertion would be vacuous on any bash that stays quiet. The test stubs `shell_is_msys` to record `$-` at each call, runs `run_with_timeout`, and fails if any call happened under `-m`. Its second half runs the pre-fix shape through the same stub, so a probe whose recording arm never fires cannot pass the first half. Reverting `testlib.sh` reds it.