### PR TITLE
A first ^C keeps the partial file and deletes what would have resumed it

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -937,12 +937,16 @@ hts_boolean back_finalize_backup(httrackp *opt, lien_back *const back,
     }
     /* On failure keep the backup: an orphaned temp beats losing the good copy.
      */
-    if (!hts_rename_over(opt, back->tmpfile, back->url_sav))
+    if (!hts_rename_over(opt, back->tmpfile, back->url_sav)) {
       hts_log_print(opt, LOG_WARNING | LOG_ERRNO,
                     "could not restore %s; previous copy kept as %s",
                     back->url_sav, back->tmpfile);
-    else
+    } else {
       back_tmpdir_drop(back->tmpfile);
+      /* The restore replaced the partial, so its byte ranges now describe a
+         file that is gone (#1595). */
+      url_savename_refname_remove(opt, back->url_adr, back->url_fil);
+    }
   }
   back->tmpfile = NULL;
   return commit == wanted ? HTS_TRUE : HTS_FALSE;
@@ -3287,8 +3291,8 @@ static int back_abort_stopped(httrackp *opt, struct_back *sback) {
 
     if (!back_is_live(status) || (grace && !back_is_preconnect(status)))
       continue;
-    /* The partial stays on disk, so its hts-cache/ref must outlive the run or
-       the next --continue refetches the file whole (#1595). */
+    /* The partial stays on disk, so hts-cache/ref must outlive the run or
+       --continue refetches it whole (#1595). */
     if (back->r.is_write && !IS_DELAYED_EXT(back->url_sav))
       opt->stop_left_partial = HTS_TRUE;
     /* fatal, as back_add() reports a stop: no retry may reschedule the link */

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -3282,10 +3282,15 @@ static int back_abort_stopped(httrackp *opt, struct_back *sback) {
   int i;
 
   for (i = 0; i < sback->count; i++) {
-    const int status = sback->lnk[i].status;
+    const lien_back *const back = &sback->lnk[i];
+    const int status = back->status;
 
     if (!back_is_live(status) || (grace && !back_is_preconnect(status)))
       continue;
+    /* The partial stays on disk, so its hts-cache/ref must outlive the run or
+       the next --continue refetches the file whole (#1595). */
+    if (back->r.is_write && !IS_DELAYED_EXT(back->url_sav))
+      opt->stop_left_partial = HTS_TRUE;
     /* fatal, as back_add() reports a stop: no retry may reschedule the link */
     back_abort_slot(opt, sback, i, STATUSCODE_INVALID, "mirror stopped by user",
                     WARC_TRUNC_NONE);

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -624,6 +624,7 @@ int httpmirror(char *url1, httrackp *opt, hts_boolean *completed_out) {
   /* per mirror, not per opt: an embedder reusing one opt would otherwise
      carry the last run's verdict and never purge again */
   opt->links_unqueued = HTS_FALSE;
+  opt->stop_left_partial = HTS_FALSE;
 
   /* before the first bailout below, each of which leaves it false */
   *completed_out = HTS_FALSE;

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -3066,9 +3066,8 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
     }
 
     /* Not or cleanly interrupted; erase hts-cache/ref temporary directory.
-       A ^C raises state.stop alone and leaves exit_xh at 0, so a run that cut
-       a transfer mid-body must still keep what that partial resumes from
-       (#1595). */
+       A ^C raises state.stop but leaves exit_xh at 0, so keep the ref when a
+       transfer was cut mid-body (#1595). */
     if (opt->state.exit_xh == 0 && !opt->stop_left_partial) {
       // erase ref files if not interrupted
       DIR *dir;

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -3065,8 +3065,11 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
       }
     }
 
-    /* Not or cleanly interrupted; erase hts-cache/ref temporary directory */
-    if (opt->state.exit_xh == 0) {
+    /* Not or cleanly interrupted; erase hts-cache/ref temporary directory.
+       A ^C raises state.stop alone and leaves exit_xh at 0, so a run that cut
+       a transfer mid-body must still keep what that partial resumes from
+       (#1595). */
+    if (opt->state.exit_xh == 0 && !opt->stop_left_partial) {
       // erase ref files if not interrupted
       DIR *dir;
       struct dirent *entry;

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -6470,6 +6470,7 @@ HTSEXT_API httrackp *hts_create_opt(void) {
   opt->single_file_max_size = SINGLEFILE_DEFAULT_MAX_SIZE;
   opt->singlefile_state = NULL;
   opt->links_unqueued = HTS_FALSE;
+  opt->stop_left_partial = HTS_FALSE;
   StringCopy(opt->why_url, "");
   opt->pause_min_ms = 0;
   opt->pause_max_ms = 0;

--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -591,6 +591,11 @@ struct httrackp {
                                    were never queued and the update purge would
                                    treat them as gone. Live state, so
                                    copy_htsopt must leave it alone. Tail: ABI */
+  hts_boolean stop_left_partial; /**< a user stop cut a body mid-transfer, so
+                                      the partial it left needs its
+                                      hts-cache/ref kept. Live state, so
+                                      copy_htsopt must leave it alone.
+                                      Tail: ABI */
 };
 
 /* Running statistics for a mirror. */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -11901,13 +11901,40 @@ static int st_refetchbackup(httrackp *opt, int argc, char **argv) {
     err++;
   }
 
-  /* An aborted transfer restores, as before. */
-  back_refetch_backup(opt, back);
-  ro_put(back->url_sav, "partial");
-  back_finalize_backup(opt, back, HTS_FALSE);
-  if (!ro_is(back->url_sav, "new")) {
-    fprintf(stderr, "refetchbackup: an aborted re-fetch kept the partial\n");
-    err++;
+  /* An aborted transfer restores, as before, and the resume reference goes
+     with the partial it described: a kept one makes the next run ask for a
+     range past the end of the restored copy (#1595). */
+  {
+    char BIGSTK log_was[HTS_URLMAXSIZE * 2];
+
+    strcpybuff(log_was, StringBuff(opt->path_log));
+    StringCopy(opt->path_log, argv[0]);
+    strcpybuff(back->url_adr, "127.0.0.1");
+    strcpybuff(back->url_fil, "/refetch.bin");
+    back_refetch_backup(opt, back);
+    ro_put(back->url_sav, "partial");
+    /* a real mirror already has hts-cache/, and the writer only mkdirs ref/ */
+    (void) structcheck(
+        url_savename_refname_fullpath(opt, back->url_adr, back->url_fil));
+    if (back_serialize_ref(opt, back) != 0) {
+      fprintf(stderr, "refetchbackup: could not seed a resume reference\n");
+      err++;
+    }
+    back_finalize_backup(opt, back, HTS_FALSE);
+    if (!ro_is(back->url_sav, "new")) {
+      fprintf(stderr, "refetchbackup: an aborted re-fetch kept the partial\n");
+      err++;
+    }
+    if (fexist_utf8(
+            url_savename_refname_fullpath(opt, back->url_adr, back->url_fil))) {
+      fprintf(stderr, "refetchbackup: the restore kept the partial's ref\n");
+      err++;
+    }
+    (void) RMDIR(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                         StringBuff(opt->path_log), CACHE_REFNAME));
+    (void) RMDIR(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
+                         StringBuff(opt->path_log), "hts-cache"));
+    StringCopy(opt->path_log, log_was);
   }
 
   (void) UNLINK(back->url_sav);
@@ -12508,11 +12535,52 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
     opt->maxsite = 0;
     HTS_STAT.HTS_TOTAL_RECV = recv_was;
   }
+
+  /* The stop keeps hts-cache/ref for a partial that outlives it, not for every
+     slot it killed (#1595). A .delayed placeholder goes with its own ref, so it
+     is not one. */
+  {
+    static const struct {
+      const char *what;
+      hts_boolean is_write;
+      const char *url_sav;
+      hts_boolean kept;
+    } partial[] = {
+        {"a slot writing nothing to disk", HTS_FALSE, "", HTS_FALSE},
+        {"a .delayed placeholder", HTS_TRUE,
+         "hts-backstop-selftest.tmp." DELAYED_EXT, HTS_FALSE},
+        {"a partial file", HTS_TRUE, "hts-backstop-selftest.tmp", HTS_TRUE}};
+
+    int c;
+
+    for (c = 0; c < (int) (sizeof(partial) / sizeof(partial[0])) && !err; c++) {
+      opt->state.stop = 0;
+      if (!st_backstop_arm(opt, sback, status, r, SLOTS, SLOT_DNS)) {
+        skipped = 1;
+        goto cleanup;
+      }
+      back[SLOT_XFER].r.is_write = partial[c].is_write;
+      strcpybuff(back[SLOT_XFER].url_sav, partial[c].url_sav);
+      opt->stop_left_partial = HTS_FALSE;
+      hts_request_stop(opt, 0);
+
+      back_wait(sback, opt, &cache, 0);
+
+      if (opt->stop_left_partial != partial[c].kept) {
+        printf("  FAIL line %d: %s must %s the resume data\n", __LINE__,
+               partial[c].what, partial[c].kept ? "keep" : "drop");
+        err = 1;
+      }
+      back[SLOT_XFER].r.is_write = 0;
+      back[SLOT_XFER].url_sav[0] = '\0';
+    }
+  }
 #undef CHECK
 
 cleanup:
   opt->maxsite = 0;
   opt->state.stop = 0;
+  opt->stop_left_partial = HTS_FALSE;
   for (i = 0; i < SLOTS; i++)
     deletehttp(&back[i].r);
   back_free(&sback);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -11901,14 +11901,17 @@ static int st_refetchbackup(httrackp *opt, int argc, char **argv) {
     err++;
   }
 
-  /* An aborted transfer restores, as before, and the resume reference goes
-     with the partial it described: a kept one makes the next run ask for a
-     range past the end of the restored copy (#1595). */
+  /* An aborted transfer restores, as before. The resume reference goes with
+     the partial it described, because a kept one would make the next run ask
+     past the restored copy's end (#1595). */
   {
-    char BIGSTK log_was[HTS_URLMAXSIZE * 2];
+    String saved = STRING_EMPTY;
 
-    strcpybuff(log_was, StringBuff(opt->path_log));
+    StringCopy(saved, StringBuff(opt->path_log));
+    /* explicit separator, as above: fconcat() joins without one, which would
+       put the reference in a sibling of the directory under test */
     StringCopy(opt->path_log, argv[0]);
+    StringCat(opt->path_log, "/");
     strcpybuff(back->url_adr, "127.0.0.1");
     strcpybuff(back->url_fil, "/refetch.bin");
     back_refetch_backup(opt, back);
@@ -11916,7 +11919,9 @@ static int st_refetchbackup(httrackp *opt, int argc, char **argv) {
     /* a real mirror already has hts-cache/, and the writer only mkdirs ref/ */
     (void) structcheck(
         url_savename_refname_fullpath(opt, back->url_adr, back->url_fil));
-    if (back_serialize_ref(opt, back) != 0) {
+    if (back_serialize_ref(opt, back) != 0 ||
+        !fexist_utf8(
+            url_savename_refname_fullpath(opt, back->url_adr, back->url_fil))) {
       fprintf(stderr, "refetchbackup: could not seed a resume reference\n");
       err++;
     }
@@ -11934,7 +11939,8 @@ static int st_refetchbackup(httrackp *opt, int argc, char **argv) {
                          StringBuff(opt->path_log), CACHE_REFNAME));
     (void) RMDIR(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
                          StringBuff(opt->path_log), "hts-cache"));
-    StringCopy(opt->path_log, log_was);
+    StringCopy(opt->path_log, StringBuff(saved));
+    StringFree(saved);
   }
 
   (void) UNLINK(back->url_sav);

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -402,10 +402,10 @@ HTSEXT_API char *hts_errmsg(httrackp *opt);
 HTSEXT_API int hts_setpause(httrackp *opt, int);
 
 /** Ask the running mirror to terminate (sets the stop flag under the state
-    lock, so it is safe to call from another thread). @p keep_resume asks the
-    engine to keep the partial-transfer metadata a later --continue needs,
-    rather than erase it as it does at the end of a completed mirror.
-    @return 0; no-op if @p opt is NULL. */
+    lock, so it is safe to call from another thread). @p keep_resume reports the
+    mirror as interrupted, which keeps the partial-transfer metadata a later
+    --continue needs. A transfer this stop cuts mid-body keeps its own metadata
+    either way (#1595). @return 0; no-op if @p opt is NULL. */
 HTSEXT_API int hts_request_stop(httrackp *opt, hts_boolean keep_resume);
 
 /** Queue a single in-progress file, by URL, to be cancelled by the engine.

--- a/tests/444_local-stop-keeps-resume.test
+++ b/tests/444_local-stop-keeps-resume.test
@@ -120,9 +120,9 @@ assert_logged "${tmpdir}/keep" 'MIRROR ABORTED' \
 echo "PASS"
 
 # The partial this stop cut stays on disk whoever asked for the stop, so its
-# byte ranges stay with it (#1595). What keep_resume still decides is the
-# interrupted-mirror banner, exit_xh's own effect, so the two stops still part
-# ways here. The cap arm below is what keeps the arm above honest.
+# byte ranges stay with it (#1595). What keep_resume still decides is exit_xh,
+# and so the interrupted-mirror banner, so the two stops still part ways here.
+# The cap arm below is what keeps the arm above honest.
 printf '[a plain stop keeps the ref too, but logs no banner] ..\t'
 assert_kept drop drop "hts-cache/ref was erased under a stop that cut a body mid-transfer"
 ! grep -q 'MIRROR ABORTED' "${tmpdir}/drop/hts-log.txt" ||

--- a/tests/444_local-stop-keeps-resume.test
+++ b/tests/444_local-stop-keeps-resume.test
@@ -121,7 +121,7 @@ echo "PASS"
 
 # The partial this stop cut stays on disk whoever asked for the stop, so its
 # byte ranges stay with it (#1595). What keep_resume still decides is exit_xh,
-# and so the interrupted-mirror banner, so the two stops still part ways here.
+# which drives the interrupted-mirror banner, so the two stops still part ways.
 # The cap arm below is what keeps the arm above honest.
 printf '[a plain stop keeps the ref too, but logs no banner] ..\t'
 assert_kept drop drop "hts-cache/ref was erased under a stop that cut a body mid-transfer"

--- a/tests/444_local-stop-keeps-resume.test
+++ b/tests/444_local-stop-keeps-resume.test
@@ -119,10 +119,14 @@ assert_logged "${tmpdir}/keep" 'MIRROR ABORTED' \
     "the run did not record an interrupted mirror"
 echo "PASS"
 
-# The control: the same stop asked the other way still erases, so the arm above
-# cannot pass on a fix that simply stopped erasing.
-printf '[a plain stop still erases it] ..\t'
-assert_erased drop drop "hts-cache/ref survived a stop that did not ask to keep it"
+# The partial this stop cut stays on disk whoever asked for the stop, so its
+# byte ranges stay with it (#1595). What keep_resume still decides is the
+# interrupted-mirror banner, exit_xh's own effect, so the two stops still part
+# ways here. The cap arm below is what keeps the arm above honest.
+printf '[a plain stop keeps the ref too, but logs no banner] ..\t'
+assert_kept drop drop "hts-cache/ref was erased under a stop that cut a body mid-transfer"
+! grep -q 'MIRROR ABORTED' "${tmpdir}/drop/hts-log.txt" ||
+    fail "a stop that did not ask to keep the resume data logged the abort banner"
 echo "PASS"
 
 # The engine raises the stop flag itself when a cap is reached, and that run

--- a/tests/451_local-sigint-keeps-resume.test
+++ b/tests/451_local-sigint-keeps-resume.test
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# One ^C tears down the transfer in flight and leaves its half-written file on
-# disk, then erased the hts-cache/ref entry describing it, so the --continue
-# that followed refetched the whole body from byte zero (#1595).
+# One ^C tore down the transfer in flight and left its half-written file on
+# disk, then erased the hts-cache/ref entry describing it. The --continue that
+# followed refetched the whole body from byte zero (#1595).
 
 set -euo pipefail
 
@@ -27,6 +27,11 @@ cleanup_push cleanup
 resumed_at="${tmpdir}/resumed"
 local_server_start --env STOPRESUME_MARK="$resumed_at"
 
+# How long a body may take to reach its temp-ref, and how long the ^C may take
+# to end the run.
+ref_wait_s=60
+stop_wait_s=180
+
 out="${tmpdir}/sigint"
 refdir="${out}/hts-cache/ref"
 mkdir -p "$out"
@@ -37,7 +42,7 @@ crawlpid=$!
 
 # The temp-ref appearing is what says a body is in flight and has resume data
 # to lose. A ^C sent before that would leave nothing either way.
-for _ in $(seq 1 600); do
+for _ in $(seq 1 $((ref_wait_s * 10))); do
     test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" && break
     kill -0 "$crawlpid" 2>/dev/null || break
     poll_wait 0.1
@@ -46,15 +51,17 @@ test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" ||
     fail "no temp-ref was written, so the ^C decides nothing"
 
 kill -INT "$crawlpid"
-for _ in $(seq 1 900); do
+for _ in $(seq 1 $((stop_wait_s * 5))); do
     kill -0 "$crawlpid" 2>/dev/null || break
     poll_wait 0.2
 done
 if kill -0 "$crawlpid" 2>/dev/null; then
     fail "the crawl never ended after the ^C"
 fi
-wait "$crawlpid" 2>/dev/null || true
+crawl_rc=0
+wait "$crawlpid" 2>/dev/null || crawl_rc=$?
 crawlpid=
+test "$crawl_rc" -eq 0 || fail "the ^C run exited ${crawl_rc}, so it did not stop cleanly"
 
 printf '[one ^C keeps the ref of the transfer it cut] ..\t'
 # Guarded, not "find 2>/dev/null": under pipefail a missing directory is find's
@@ -70,16 +77,16 @@ echo "PASS"
 
 printf '[a --continue resumes from where the ^C left off] ..\t'
 full=8200 # len(STOPRESUME_BODY) = len("STOPRSM-") + 8192
-# Not piped into head: the producer would take SIGPIPE and fail the pipeline.
-blobs=$(find "$out" -name blob.bin)
-blob=${blobs%%$'\n'*}
+blob=$(find "$out" -name blob.bin)
 test -s "$blob" || fail "the ^C left no partial body to resume"
+partial=$(wc -c <"$blob")
 local_crawl --log "${tmpdir}/continue.log" -O "$out" --quiet \
     --disable-security-limits --robots=0 --timeout=30 -c1 --continue \
     "${BASEURL}/stopresume/index.html" || fail "the --continue crawl failed"
 test -s "$resumed_at" || fail "the --continue sent no Range; it restarted the file"
 at=$(head -1 "$resumed_at")
-test "$at" -gt 0 || fail "the --continue asked for the file from byte 0"
+test "$at" -eq "$partial" ||
+    fail "the --continue asked from byte ${at}, but ${partial} were already on disk"
 got=$(wc -c <"$blob")
 test "$got" -eq "$full" || fail "blob.bin is ${got} bytes, expected ${full}"
 echo "PASS (resumed at ${at} of ${full})"

--- a/tests/451_local-sigint-keeps-resume.test
+++ b/tests/451_local-sigint-keeps-resume.test
@@ -27,8 +27,8 @@ cleanup_push cleanup
 resumed_at="${tmpdir}/resumed"
 local_server_start --env STOPRESUME_MARK="$resumed_at"
 
-# How long a body may take to reach its temp-ref, and how long the ^C may take
-# to end the run.
+# The body must reach its temp-ref within the first budget, and the ^C must end
+# the run within the second.
 ref_wait_s=60
 stop_wait_s=180
 

--- a/tests/451_local-sigint-keeps-resume.test
+++ b/tests/451_local-sigint-keeps-resume.test
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# One ^C tears down the transfer in flight and leaves its half-written file on
+# disk, then erased the hts-cache/ref entry describing it, so the --continue
+# that followed refetched the whole body from byte zero (#1595).
+
+set -euo pipefail
+
+# shellcheck source=tests/crawllib.sh
+. "${0%"${0##*/}"}./crawllib.sh"
+
+skip_on_windows "MSYS cannot signal a native httrack.exe"
+require_httrack
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_sigint.XXXXXX") || exit 1
+crawlpid=
+cleanup() {
+    set +e
+    test -n "$crawlpid" && kill_tree "$crawlpid"
+    rm -rf "$tmpdir"
+}
+cleanup_push cleanup
+
+# Where the /stopresume/ route records the byte offset of each Range it serves.
+# That route stalls its first GET after 4096 bytes and answers a Range with a
+# 206, so both the partial and the restart are visible.
+resumed_at="${tmpdir}/resumed"
+local_server_start --env STOPRESUME_MARK="$resumed_at"
+
+out="${tmpdir}/sigint"
+refdir="${out}/hts-cache/ref"
+mkdir -p "$out"
+httrack "${BASEURL}/stopresume/index.html" -O "$out" --quiet \
+    --disable-security-limits --robots=0 --timeout=0 --max-time=0 -c2 \
+    >"${out}.log" 2>&1 &
+crawlpid=$!
+
+# The temp-ref appearing is what says a body is in flight and has resume data
+# to lose. A ^C sent before that would leave nothing either way.
+for _ in $(seq 1 600); do
+    test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" && break
+    kill -0 "$crawlpid" 2>/dev/null || break
+    poll_wait 0.1
+done
+test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" ||
+    fail "no temp-ref was written, so the ^C decides nothing"
+
+kill -INT "$crawlpid"
+for _ in $(seq 1 900); do
+    kill -0 "$crawlpid" 2>/dev/null || break
+    poll_wait 0.2
+done
+if kill -0 "$crawlpid" 2>/dev/null; then
+    fail "the crawl never ended after the ^C"
+fi
+wait "$crawlpid" 2>/dev/null || true
+crawlpid=
+
+printf '[one ^C keeps the ref of the transfer it cut] ..\t'
+# Guarded, not "find 2>/dev/null": under pipefail a missing directory is find's
+# own failure and would end the run rather than report an erased directory.
+kept=
+test ! -d "$refdir" || kept=$(find "$refdir" -name '*.ref')
+test -n "$kept" ||
+    fail "hts-cache/ref was erased, so nothing describes the partial left behind"
+# The premise that count rests on: the ^C really did cut a body mid-transfer.
+assert_logged "$out" 'Mirror stopped by user, [0-9]+ transfer' \
+    "the run aborted no transfer, so it had no partial to keep a ref for"
+echo "PASS"
+
+printf '[a --continue resumes from where the ^C left off] ..\t'
+full=8200 # len(STOPRESUME_BODY) = len("STOPRSM-") + 8192
+# Not piped into head: the producer would take SIGPIPE and fail the pipeline.
+blobs=$(find "$out" -name blob.bin)
+blob=${blobs%%$'\n'*}
+test -s "$blob" || fail "the ^C left no partial body to resume"
+local_crawl --log "${tmpdir}/continue.log" -O "$out" --quiet \
+    --disable-security-limits --robots=0 --timeout=30 -c1 --continue \
+    "${BASEURL}/stopresume/index.html" || fail "the --continue crawl failed"
+test -s "$resumed_at" || fail "the --continue sent no Range; it restarted the file"
+at=$(head -1 "$resumed_at")
+test "$at" -gt 0 || fail "the --continue asked for the file from byte 0"
+got=$(wc -c <"$blob")
+test "$got" -eq "$full" || fail "blob.bin is ${got} bytes, expected ${full}"
+echo "PASS (resumed at ${at} of ${full})"
+
+# The control, on the run that just finished: it wrote blob.bin to disk, so it
+# had a ref of its own to erase, and nothing cut it short. Without this the
+# arms above would pass on a fix that simply stopped erasing.
+printf '[the completed --continue erases the directory again] ..\t'
+test ! -d "$refdir" || fail "hts-cache/ref survived a mirror nothing interrupted"
+echo "PASS"

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -202,7 +202,9 @@ ci_suite_heartbeat() {
 # engine-wizard-eof drives the wizard through a pty, and Windows builds Python
 # with neither pty nor os.fork;
 # stop-keeps-resume drives the stop through an LD_PRELOAD shim, which Windows
-# has no equivalent for.
+# has no equivalent for;
+# sigint-keeps-resume sends a real SIGINT, which neither shell can deliver to a
+# native httrack.exe.
 expected_skips_msys="01_engine-footer-overflow.test
 253_local-ftp-close-once.test
 113_engine-threadattr-leak.test
@@ -233,7 +235,8 @@ expected_skips_msys="01_engine-footer-overflow.test
 377_engine-install-paths.test
 398_engine-build-features.test
 424_engine-wizard-eof.test
-444_local-stop-keeps-resume.test"
+444_local-stop-keeps-resume.test
+451_local-sigint-keeps-resume.test"
 
 # Measured, not predicted: windows-build run 33927128153, both platforms alike.
 # Written out rather than derived from the msys list above: the two lists are
@@ -276,6 +279,7 @@ expected_skips_wsl2="01_engine-footer-overflow.test
 398_engine-build-features.test
 424_engine-wizard-eof.test
 444_local-stop-keeps-resume.test
+451_local-sigint-keeps-resume.test
 294_local-wizard-eof.test
 24_local-resume-overlap.test"
 


### PR DESCRIPTION
`sig_leave` raises `state.stop` and nothing else, so `exit_xh` stays 0 and the run ends looking clean. `back_abort_stopped()` meanwhile tears down every live slot and deliberately leaves the half-written bodies on disk. The exit path then erases `hts-cache/ref`, where the byte ranges describing those bodies live, so the next `--continue` fetches each file again from zero.

The purge now skips a run that cut a transfer mid-body. `back_abort_stopped()` is the only place that knows one was cut, so it raises the flag as it walks the slots. It raises it only for a slot writing a real file, because a `.delayed` placeholder is discarded there along with its ref.

Keeping the directory exposed a second bug, fixed here too. On a re-crawl `back_refetch_backup()` moves the previous complete copy aside, and an aborted transfer restores it over the partial. The ref then described a file that no longer existed. The next run asked for a range past its end, got a 416, and deleted the complete copy to fetch it again whole. `back_finalize_backup()` now drops the ref where it restores.

Writing `exit_xh` in `sig_leave` was the other candidate. It turns the first `^C` into the second, so the handler stops draining the queue and its own "Finishing pending transfers" line becomes false. Tests 243, 255 and 263 pin that promise.

This inverts one arm of #1583's test. `hts_request_stop(opt, 0)`, which is WebHTTrack's first Cancel press, goes through the same teardown and orphans the same partial, so it now keeps the ref too. What `keep_resume` still decides is `exit_xh`, and with it the interrupted-mirror banner, so 444's `[a plain stop still erases it]` becomes `[a plain stop keeps the ref too, but logs no banner]`.

A cap still erases, and 444's `--max-time` arm is now the control proving the purge runs. That arm is narrower than it reads. A cap past its grace tears down live slots through `back_abort_limit()`, which leaves partials of its own. A capped run drops their byte ranges exactly as a `^C` did. #1583 chose that deliberately, so this PR leaves it alone.

Three cases added to `-#test=backstop` pin what the flag turns on. A slot writing nothing and a `.delayed` placeholder each leave the directory erasable, and only a real partial keeps it. `451_local-sigint-keeps-resume.test` sends one real SIGINT to a crawl parked on a stalled body. It then reads the directory, the abort line in the log, and the `Range` the `--continue` sends. That Range must ask for exactly the bytes already on disk.

`htsopt.h` grows one `hts_boolean` at the tail of `httrackp`. Measured against master: `state` stays at offset 896, no existing member moves, and the exported symbol set is unchanged.

Closes #1595