### PR TITLE
The pinned OpenSSL is three moderate CVEs behind its own fix

### DIFF
--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "libhttrack",
   "version-string": "3.50",
-  "builtin-baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
+  "builtin-baseline": "04a9d8e5212d01ee1dd9478eadd9caade4f8b0d4",
   "dependencies": [
     "brotli",
     "openssl",


### PR DESCRIPTION
The pin resolved to OpenSSL 3.6.3. Three moderate advisories list every 3.6 below 3.6.4 as affected, so the shipped Windows binary carries all three. They are CVE-2026-18798 (QUIC double free), CVE-2026-63072 (CMS heap overflow) and CVE-2026-63076 (CMP invalid pointer dereference). Moving `builtin-baseline` to `04a9d8e5` takes openssl to 3.6.4 and zlib to a new port-version. brotli and zstd do not move.

Those are exactly the three httrack-windows accepts in `SECURITY_ACCEPTED_CVES`, and its `check-native-deps.py` fails an acceptance that no longer matches. So that variable has to be emptied in the same window this lands, or a tagged build there refuses to run. Do not merge before that is arranged.

Dependabot is meant to bump this baseline weekly and has opened nothing since 30 July.
