### PR TITLE
A crawled page can name a local file for HTTrack to send back to it

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -1913,6 +1913,9 @@ static hts_boolean ref_get_record(FILE *fp, lien_back *dst) {
       !ref_get_str(fp, dst->r.etag, sizeof(dst->r.etag)) ||
       !ref_get_str(fp, dst->r.cdispo, sizeof(dst->r.cdispo)))
     return HTS_FALSE;
+  /* A resume ref written before the engine refused these, or edited since */
+  if (!hts_location_is_safe(dst->location_buffer))
+    dst->location_buffer[0] = '\0';
   if (!ref_get_blob(fp, &dst->r.adr, &body))
     return HTS_FALSE;
   if (!ref_get_heapstr(fp, &dst->r.headers)) {

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -712,6 +712,14 @@ static htsblk cache_readex_new(httrackp *opt, cache_back *cache,
             }
           } while (offset < readSizeHeader && !lineEof);
 
+          /* A cache written before the engine refused these, or edited since */
+          if (!hts_location_is_safe(r.location)) {
+            hts_log_print(opt, LOG_WARNING,
+                          "cached Location naming a post token, dropped: %s%s",
+                          adr, fil);
+            r.location[0] = '\0';
+          }
+
           /* Previous entry. cache_add() stores X-Save relative (it strips
              path_html_utf8), so the read re-prepends the current one, which
              may have grown since the entry was written. */

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -1053,17 +1053,20 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
      at their own source buffers, so the worst case emitted does not grow. */
   char BIGSTK esc[HTS_URLMAXSIZE * 2];
 
+  /* Only a user-supplied URL has no referer, so a crawled page cannot name
+     >postfile: below and have the engine send it a local file. */
+  const char *const post_fil = strnotempty(referer_adr) ? "" : fil;
+
   // Initialize buffer
   buffer_head_request[0] = '\0';
 
-  // possibilité non documentée: >post: et >postfile:
-  // si présence d'un tag >post: alors executer un POST
-  // exemple: http://www.example.com/test.cgi?foo>post:posteddata=10&foo=5
-  // si présence d'un tag >postfile: alors envoyer en tête brut contenu dans le fichier en question
-  // exemple: http://www.example.com/test.cgi?foo>postfile:post0.txt
-  search_tag = strstr(fil, POSTTOK ":");
+  // Undocumented: >post: posts what follows it, >postfile: sends the file it
+  // names as the raw request.
+  // example: http://www.example.com/test.cgi?foo>post:posteddata=10&foo=5
+  // example: http://www.example.com/test.cgi?foo>postfile:post0.txt
+  search_tag = strstr(post_fil, POSTTOK ":");
   if (!search_tag) {
-    search_tag = strstr(fil, POSTTOK "file:");
+    search_tag = strstr(post_fil, POSTTOK "file:");
     if (search_tag) {           // postfile
       if (mode == 0) {          // GET!
         FILE *fp =

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -1701,9 +1701,17 @@ void treathead(t_cookie * cookie, const char *adr, const char *fil, htsblk * ret
       if (retour->location) {
         while(is_realspace(*(rcvd + p)))
           p++; // skip spaces
-        if (strlen(rcvd + p) < HTS_LOCATION_SIZE)
+        if (strlen(rcvd + p) < HTS_LOCATION_SIZE) {
           strlcpybuff(retour->location, rcvd + p, HTS_LOCATION_SIZE);
-        else {
+          /* A Location naming >post: or >postfile: would make the engine send
+             a local file back to the server that chose it. Three separate
+             places follow a redirect, so it is refused here. */
+          if (strstr(retour->location, POSTTOK) != NULL) {
+            hts_log_print(NULL, LOG_WARNING,
+                          "Location naming a post token, redirect ignored");
+            retour->location[0] = '\0';
+          }
+        } else {
           /* no opt here, so this only reaches a registered log callback */
           hts_log_print(NULL, LOG_WARNING,
                         "Location header too long (%d bytes), redirect ignored",

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -1035,6 +1035,11 @@ size_t http_postfile_body(char *buffer, size_t buffer_size, size_t pos,
   return pos + strlen(&buffer[pos]);
 }
 
+hts_boolean hts_location_is_safe(const char *location) {
+  return (location == NULL || strstr(location, POSTTOK) == NULL) ? HTS_TRUE
+                                                                 : HTS_FALSE;
+}
+
 // envoi d'une requète
 int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
                   const char *xsend, const char *adr, const char *fil,
@@ -1703,10 +1708,7 @@ void treathead(t_cookie * cookie, const char *adr, const char *fil, htsblk * ret
           p++; // skip spaces
         if (strlen(rcvd + p) < HTS_LOCATION_SIZE) {
           strlcpybuff(retour->location, rcvd + p, HTS_LOCATION_SIZE);
-          /* A Location naming >post: or >postfile: would make the engine send
-             a local file back to the server that chose it. Three separate
-             places follow a redirect, so it is refused here. */
-          if (strstr(retour->location, POSTTOK) != NULL) {
+          if (!hts_location_is_safe(retour->location)) {
             hts_log_print(NULL, LOG_WARNING,
                           "Location naming a post token, redirect ignored");
             retour->location[0] = '\0';

--- a/src/htslib.h
+++ b/src/htslib.h
@@ -83,6 +83,12 @@ typedef struct lien_adrfilsave lien_adrfilsave;
 // (à modifier avec celle-ci)
 #define POSTTOK "?>post"
 
+/* Is this Location free of the >post: tokens? A redirect naming one makes the
+   engine send a local file back to whoever chose the value, so every place
+   that fills a location has to refuse it, the cache and a resume ref
+   included. */
+hts_boolean hts_location_is_safe(const char *location);
+
 #include "htsopt.h"
 
 #define READ_ERROR (-1)

--- a/tests/453_local-postfile-referer.test
+++ b/tests/453_local-postfile-referer.test
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# >postfile: makes the engine send a local file as the raw request. Honouring it
-# for a link extracted from a crawled page hands that page's host any file the
-# process can open, so the tokens are read only from a URL the user supplied.
+# >postfile: makes the engine send a local file as the raw request. A crawled
+# page can link to that token, so it would name any file the process can open.
+# The tokens are read only from a URL the user supplied.
 
 set -euo pipefail
 
@@ -22,39 +22,60 @@ cleanup() {
 }
 cleanup_push cleanup
 
-# Three whitespace-separated tokens on the first line, or the sscanf reading it
-# fails and nothing goes out: this is the file shape that leaks.
+# The first line needs three whitespace-separated tokens, or sscanf fails and
+# nothing goes out. This is the shape that leaks. It ends without the blank line
+# that closes a header block, as a stolen file generally would, so the server
+# reads it to its own timeout rather than to a terminator.
 secret=$tmpdir/secret.txt
-printf 'GET /stolen HTTP/1.0\r\nX-Secret: %s\r\n\r\n' "$MARKER" >"$secret"
+printf 'GET /stolen HTTP/1.0\r\nX-Secret: %s\r\n' "$MARKER" >"$secret"
 
 wire=$tmpdir/wire
-fail_dump_var wire
+srverr=$tmpdir/server.err
+fail_dump_var wire srverr
 "$python" "$(nativepath "$testdir/postfile-server.py")" "$(nativepath "$wire")" \
-    "$(nativepath "$secret")" >"$tmpdir/server.out" 2>"$tmpdir/server.err" &
+    "$(nativepath "$secret")" >"$tmpdir/server.out" 2>"$srverr" &
 serverpid=$!
 port=$(discover_server_port "$tmpdir/server.out" "$serverpid") || exit 1
 
-crawl() { # crawl TAG URL
+crawl() { # crawl TAG [httrack args...]
     local tag=$1 rc=0
     shift
+    crawllog=$tmpdir/$tag.log
+    fail_dump_var crawllog
     run_with_timeout 120 httrack "$@" -O "$tmpdir/$tag" --robots=0 --retries=0 \
-        -c1 --quiet -%v0 >"$tmpdir/$tag.log" 2>&1 || rc=$?
+        -c1 --quiet -%v0 >"$crawllog" 2>&1 || rc=$?
     test "$rc" -ne 124 || fail "$tag: the crawl watchdog fired"
+    test "$rc" -le 128 || fail "$tag: the crawl ended abnormally ($rc)"
 }
 
 leaked() { count_matching_lines "$MARKER" "$wire"; }
 
 crawl page "http://127.0.0.1:$port/"
 
-assert_eq 0 "$(leaked)" "the secret file reached the server"
+assert_eq 0 "$(leaked)" "lines of the secret file on the wire"
 assert_eq 0 "$(count_matching_lines '^POST ' "$wire")" \
     "POST requests from a page-extracted >post: link"
-# Both absences above are vacuous unless the link was reached, and a gated one
-# goes out as the ordinary GET it should have been all along.
-test "$(count_matching_lines '^GET /leak\.html' "$wire")" -ne 0 ||
-    fail "the gated link was not requested as a plain GET"
+# Both checks above prove nothing unless the links were reached. Each must go
+# out as the plain GET it always was, carrying its query whole: an engine that
+# stripped the token instead of ignoring it would request a different URL and
+# still leak nothing.
+for path in leak post; do
+    test "$(count_matching_lines "^GET /$path\.html?>post" "$wire")" -ne 0 ||
+        fail "the gated /$path.html link was not requested with its query intact"
+done
+
+# A redirect carries the token with no link naming it, and reaches the engine
+# through three followers rather than the one the referer guards. The server
+# picks its own Location, so the hop is refused where the header is stored.
+crawl redir "http://127.0.0.1:$port/redir.html"
+test "$(count_matching_lines '^GET /redir\.html' "$wire")" -ne 0 ||
+    fail "the redirecting page was never fetched"
+assert_eq 0 "$(count_matching_lines '^GET /leak2\.gif' "$wire")" \
+    "requests for the target of a redirect naming a post token"
+assert_eq 0 "$(leaked)" "lines of the secret file after a redirect"
 
 # Control: the same token on the command line still sends the file, so the gate
-# turns on where the URL came from rather than removing the feature.
+# turns on where the URL came from rather than removing the feature. 328 covers
+# the command-line >post: half.
 crawl cli "http://127.0.0.1:$port/leak.html?>postfile:$(nativepath "$secret")"
 test "$(leaked)" -ne 0 || fail "a command-line >postfile: sent nothing"

--- a/tests/453_local-postfile-referer.test
+++ b/tests/453_local-postfile-referer.test
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# >postfile: makes the engine send a local file as the raw request. Honouring it
+# for a link extracted from a crawled page hands that page's host any file the
+# process can open, so the tokens are read only from a URL the user supplied.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+MARKER=EXFILTRATED-BY-A-CRAWLED-PAGE
+
+python=$(find_python) || skip "python3 missing"
+require_httrack
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_postfile.XXXXXX") || exit 1
+serverpid=
+cleanup() {
+    stop_server "$serverpid"
+    rm -rf "$tmpdir"
+}
+cleanup_push cleanup
+
+# Three whitespace-separated tokens on the first line, or the sscanf reading it
+# fails and nothing goes out: this is the file shape that leaks.
+secret=$tmpdir/secret.txt
+printf 'GET /stolen HTTP/1.0\r\nX-Secret: %s\r\n\r\n' "$MARKER" >"$secret"
+
+wire=$tmpdir/wire
+fail_dump_var wire
+"$python" "$(nativepath "$testdir/postfile-server.py")" "$(nativepath "$wire")" \
+    "$(nativepath "$secret")" >"$tmpdir/server.out" 2>"$tmpdir/server.err" &
+serverpid=$!
+port=$(discover_server_port "$tmpdir/server.out" "$serverpid") || exit 1
+
+crawl() { # crawl TAG URL
+    local tag=$1 rc=0
+    shift
+    run_with_timeout 120 httrack "$@" -O "$tmpdir/$tag" --robots=0 --retries=0 \
+        -c1 --quiet -%v0 >"$tmpdir/$tag.log" 2>&1 || rc=$?
+    test "$rc" -ne 124 || fail "$tag: the crawl watchdog fired"
+}
+
+leaked() { count_matching_lines "$MARKER" "$wire"; }
+
+crawl page "http://127.0.0.1:$port/"
+
+assert_eq 0 "$(leaked)" "the secret file reached the server"
+assert_eq 0 "$(count_matching_lines '^POST ' "$wire")" \
+    "POST requests from a page-extracted >post: link"
+# Both absences above are vacuous unless the link was reached, and a gated one
+# goes out as the ordinary GET it should have been all along.
+test "$(count_matching_lines '^GET /leak\.html' "$wire")" -ne 0 ||
+    fail "the gated link was not requested as a plain GET"
+
+# Control: the same token on the command line still sends the file, so the gate
+# turns on where the URL came from rather than removing the feature.
+crawl cli "http://127.0.0.1:$port/leak.html?>postfile:$(nativepath "$secret")"
+test "$(leaked)" -ne 0 || fail "a command-line >postfile: sent nothing"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -10,6 +10,7 @@ EXTRA_DIST = $(TESTS) renamefail.c unlinkfail.c threadattrfail.c nobacktrace.c a
 	proxy-https-server.py socks5-server.py proxy-connect-server.py \
 	proxytestlib.py tls-stall-server.py warc-validate.py wacz-validate.py \
 	header-injection-server.py header-injection-check.py \
+	postfile-server.py \
 	status-line-server.py \
 	pty-resize.py ttyrun.py test-timeout.sh png-colors.py \
 	local-crawl.sh local-server.py ftp-server.py testlib.sh proclib.sh \

--- a/tests/postfile-server.py
+++ b/tests/postfile-server.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Raw-socket recorder for the >postfile:/>post: provenance test.
+
+Serves a page whose links carry the undocumented post tokens, and appends every
+request it receives verbatim to <log>.<n>, so a request that is a local file
+rather than an HTTP header block is still readable. Prints "PORT <n>" once
+listening. argv: <log> <path the page asks the engine to send>.
+"""
+
+import os
+import socket
+import sys
+import threading
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from proxytestlib import bind_ephemeral  # noqa: E402
+
+# &gt; survives the parser's unescaping as ">", which is what forms the token.
+ROOT = (
+    '<html><body><a href="/leak.html?&gt;postfile:%s">file</a>'
+    '<a href="/post.html?&gt;post:sent=1">post</a></body></html>'
+)
+
+
+def handle(conn, logf, lock, seq, secret):
+    # A postfile request is the file's bytes, so it need never end in CRLF CRLF;
+    # the timeout is what closes the read in that case.
+    conn.settimeout(2)
+    data = b""
+    try:
+        while b"\r\n\r\n" not in data:
+            chunk = conn.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+    except (OSError, socket.timeout):
+        pass
+    if data:
+        with lock:
+            seq[0] += 1
+            logf.write(b"=== REQUEST ===\n" + data + b"\n")
+            logf.flush()
+            with open("%s.%d" % (sys.argv[1], seq[0]), "wb") as reqf:
+                reqf.write(data)
+        body = (ROOT % secret).encode() if data.startswith(b"GET / ") else b"leaf"
+        try:
+            conn.sendall(
+                b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n"
+                b"Content-Length: %d\r\nConnection: close\r\n\r\n" % len(body) + body
+            )
+        except OSError:
+            pass
+    try:
+        conn.close()
+    except OSError:
+        pass
+
+
+def main():
+    secret = sys.argv[2]
+    srv, port = bind_ephemeral()
+    lock = threading.Lock()
+    seq = [0]
+    with open(sys.argv[1], "wb") as logf:
+        sys.stdout.reconfigure(newline="\n")  # the launcher parses PORT
+        print("PORT %d" % port, flush=True)
+        while True:
+            conn, _ = srv.accept()
+            threading.Thread(
+                target=handle, args=(conn, logf, lock, seq, secret), daemon=True
+            ).start()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/postfile-server.py
+++ b/tests/postfile-server.py
@@ -2,9 +2,10 @@
 """Raw-socket recorder for the >postfile:/>post: provenance test.
 
 Serves a page whose links carry the undocumented post tokens, and appends every
-request it receives verbatim to <log>.<n>, so a request that is a local file
-rather than an HTTP header block is still readable. Prints "PORT <n>" once
-listening. argv: <log> <path the page asks the engine to send>.
+request it receives to <log> verbatim, behind a "=== REQUEST ===" line, so a
+request that is a local file rather than an HTTP header block is still readable.
+Prints "PORT <n>" once listening.
+argv: <log> <path the page asks the engine to send>.
 """
 
 import os
@@ -19,11 +20,29 @@ from proxytestlib import bind_ephemeral  # noqa: E402
 # &gt; survives the parser's unescaping as ">", which is what forms the token.
 ROOT = (
     '<html><body><a href="/leak.html?&gt;postfile:%s">file</a>'
-    '<a href="/post.html?&gt;post:sent=1">post</a></body></html>'
+    '<a href="/post.html?&gt;post:sent=1">post</a>'
+    '<a href="/redir.html">redirect</a></body></html>'
 )
 
 
-def handle(conn, logf, lock, seq, secret):
+def reply_to(request, secret):
+    # A redirect reaches the token with no link carrying it. The target is not
+    # HTML on purpose: that is the arm which re-records the link, and the one
+    # that used to hand it the grandparent's referer.
+    if request.startswith(b"GET /redir.html"):
+        target = ("/leak2.gif?&gt;postfile:%s" % secret).replace("&gt;", ">")
+        return (
+            b"HTTP/1.1 302 Found\r\nLocation: %s\r\n"
+            b"Content-Length: 0\r\nConnection: close\r\n\r\n" % target.encode()
+        )
+    body = (ROOT % secret).encode() if request.startswith(b"GET / ") else b"leaf"
+    return (
+        b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n"
+        b"Content-Length: %d\r\nConnection: close\r\n\r\n" % len(body) + body
+    )
+
+
+def handle(conn, logf, lock, secret):
     # A postfile request is the file's bytes, so it need never end in CRLF CRLF;
     # the timeout is what closes the read in that case.
     conn.settimeout(2)
@@ -38,17 +57,10 @@ def handle(conn, logf, lock, seq, secret):
         pass
     if data:
         with lock:
-            seq[0] += 1
             logf.write(b"=== REQUEST ===\n" + data + b"\n")
             logf.flush()
-            with open("%s.%d" % (sys.argv[1], seq[0]), "wb") as reqf:
-                reqf.write(data)
-        body = (ROOT % secret).encode() if data.startswith(b"GET / ") else b"leaf"
         try:
-            conn.sendall(
-                b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n"
-                b"Content-Length: %d\r\nConnection: close\r\n\r\n" % len(body) + body
-            )
+            conn.sendall(reply_to(data, secret))
         except OSError:
             pass
     try:
@@ -61,14 +73,13 @@ def main():
     secret = sys.argv[2]
     srv, port = bind_ephemeral()
     lock = threading.Lock()
-    seq = [0]
     with open(sys.argv[1], "wb") as logf:
         sys.stdout.reconfigure(newline="\n")  # the launcher parses PORT
         print("PORT %d" % port, flush=True)
         while True:
             conn, _ = srv.accept()
             threading.Thread(
-                target=handle, args=(conn, logf, lock, seq, secret), daemon=True
+                target=handle, args=(conn, logf, lock, secret), daemon=True
             ).start()
 
 


### PR DESCRIPTION
A page HTTrack crawls can link `...?&gt;postfile:/path`. The engine opens that path and sends the file as the raw request to the host that served the page. That needs no options and no user action beyond crawling the site. `>post:` reaches the same sink and lets the page choose a POST body instead.

Both tokens are undocumented, and they are useful from the command line, where `--catchurl` replays a captured POST, so removing them would cost that. `http_sendhead` now reads them only from a URL that arrived with no referer. The primary URL is recorded with the referer `"primary"`, which `back_add` stores as empty. Every link extracted from a page carries its parent's address. `-%R` does not enter here. A hand-set referer travels in `retour->req.referer`, so it still works alongside `>post:`.

A redirect gets there another way, and the referer gate does not see it. Three separate places follow a `Location`, and a seed's redirect reaches the sink with no referer at all. A server could therefore answer its own seed URL with a 302 naming `>postfile:` and be sent the file. A `Location` is chosen by the server, so nothing legitimate puts a token in one. Every place that fills one now refuses it: the header parser, the cache read, and a resume ref. Guarding the writers rather than the followers keeps the field's invariant true whatever reads it next. The cache matters because an entry written by an older build outlives the upgrade. The refusal drops the hop rather than the token, and it logs through the same callback-only path the existing over-long-Location refusal uses.

The reach is any file the process can open, absolute or relative to the working directory, and symlinks are followed. The first line must hold three whitespace-separated tokens or the parse gives up, so `/etc/passwd` does not leak while source and CSV files do.

`453_local-postfile-referer.test` drives both halves, and each has its own control: removing the referer gate reds the page-extracted case, removing the `Location` refusal reds the redirect. The command-line token still sends the file, which is what separates a provenance gate from a removal. `328` covers the command-line `>post:` and stays green.

Only the network writer has a runtime test. Reaching the other two needs a cache or a resume ref written before the fix. Both are defence in depth, and no fixture covers them.