### PR TITLE
429 passes a preprocessor flag nothing it compiles reads

### DIFF
--- a/tests/429_defined-but-inert.test
+++ b/tests/429_defined-but-inert.test
@@ -60,7 +60,7 @@ grep -q '^/\* #undef DLLIB \*/$' "$tmp/nodl/config.h" ||
 
 cpp_argv=(-E -I"$tmp/nodl" -I"$abs_top_builddir" -I"$abs_top_builddir/src"
     -I"$abs_top_srcdir/src" -I"$abs_top_srcdir/src/coucal" -I"$abs_top_srcdir/src/minizip"
-    -DHTS_INTERNAL_BUILD -DHAVE_CONFIG_H)
+    -DHTS_INTERNAL_BUILD)
 if [ -n "${TEST_CPPFLAGS:-}" ]; then
     read -r -a extra_argv <<<"$TEST_CPPFLAGS"
     cpp_argv+=("${extra_argv[@]}")


### PR DESCRIPTION
`429_defined-but-inert.test` passes `-DHAVE_CONFIG_H` to its preprocessor run, and nothing it preprocesses reads that macro. `src/htsrandom.c:32` is the only reader in the tree, and 429 covers `src/htsweb.c` plus a probe translation unit that includes `htsglobal.h`. `htsglobal.h:118` gates its own `#include "config.h"` on `HTS_INTERNAL_BUILD` alone.

I measured both ways against the shadowed `config.h` the test actually builds. The preprocessed `htsweb.c` is byte-identical, the probe still reads `PROBE 0`, and the two greps the test asserts on are unchanged. The `DLOPEN` check still tells the shadow from the real header, 1 against 0, so dropping the flag leaves nothing vacuous.

The flag was fidelity to the production compile line, where automake puts it in `DEFS` rather than `CPPFLAGS`, and `tests/Makefile.am:68` forwards only `CPPFLAGS`. So 429's translation unit now differs from the shipped build by this one macro. Nothing reachable notices today. The divergence is deliberate, and it would start to matter if `htsrandom.c`'s guard ever moved into a header.

Found while fixing the same copied pair in `372_crash-signal-number.test` (#1601), where the flag was inert for the same reason.