### PR TITLE
A cap that cuts a transfer loses its resume data, where a `^C` now keeps it

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -3273,9 +3273,9 @@ static void back_abort_slot(httrackp *opt, struct_back *sback, const int p,
   /* drop a .delayed placeholder; real partials survive for resume */
   if (back->r.is_write && IS_DELAYED_EXT(back->url_sav))
     back_delayed_discard(opt, back);
+  /* That partial outlives the run, so hts-cache/ref must too or the next
+     --continue refetches the file whole (#1595). */
   else if (back->r.is_write)
-    /* That partial outlives the run, so hts-cache/ref must too or the next
-       --continue refetches the file whole (#1595). */
     opt->abort_left_partial = HTS_TRUE;
   back->r.statuscode = statuscode;
   strcpybuff(back->r.msg, msg);

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -3273,6 +3273,10 @@ static void back_abort_slot(httrackp *opt, struct_back *sback, const int p,
   /* drop a .delayed placeholder; real partials survive for resume */
   if (back->r.is_write && IS_DELAYED_EXT(back->url_sav))
     back_delayed_discard(opt, back);
+  else if (back->r.is_write)
+    /* That partial outlives the run, so hts-cache/ref must too or the next
+       --continue refetches the file whole (#1595). */
+    opt->abort_left_partial = HTS_TRUE;
   back->r.statuscode = statuscode;
   strcpybuff(back->r.msg, msg);
   back->status = STATUS_READY;
@@ -3289,15 +3293,10 @@ static int back_abort_stopped(httrackp *opt, struct_back *sback) {
   int i;
 
   for (i = 0; i < sback->count; i++) {
-    const lien_back *const back = &sback->lnk[i];
-    const int status = back->status;
+    const int status = sback->lnk[i].status;
 
     if (!back_is_live(status) || (grace && !back_is_preconnect(status)))
       continue;
-    /* The partial stays on disk, so hts-cache/ref must outlive the run or
-       --continue refetches it whole (#1595). */
-    if (back->r.is_write && !IS_DELAYED_EXT(back->url_sav))
-      opt->stop_left_partial = HTS_TRUE;
     /* fatal, as back_add() reports a stop: no retry may reschedule the link */
     back_abort_slot(opt, sback, i, STATUSCODE_INVALID, "mirror stopped by user",
                     WARC_TRUNC_NONE);
@@ -3307,7 +3306,8 @@ static int back_abort_stopped(httrackp *opt, struct_back *sback) {
 }
 
 /* Abort every live slot once a cap has overrun its grace, and return the
-   count. Its partial body is archived: the truncation is the user's own cap. */
+   count. Its partial body is archived, because the truncation is the user's own
+   cap, and back_abort_slot() keeps the resume data describing it. */
 static int back_abort_limit(httrackp *opt, struct_back *sback,
                             const hts_mirror_limit limit) {
   const hts_boolean size = limit == HTS_MIRROR_LIMIT_SIZE;

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -100,6 +100,7 @@ typedef enum {
 
 static hts_mirror_limit back_mirror_limit(httrackp *opt);
 static hts_boolean back_mirror_capped(const httrackp *opt);
+static hts_boolean back_is_live(const int status);
 
 /* NULL when the slot table cannot be allocated, which httpmirror() already
    answers by aborting the mirror with a message. Failing here rather than
@@ -226,6 +227,17 @@ void back_delete_all(httrackp * opt, cache_back * cache, struct_back * sback) {
     /* An FTP worker writes through its slot until it returns, so nothing here
        may wipe or free one under it. */
     ftp_stop_workers();
+    /* A slot still writing when the mirror ends leaves its partial on disk, so
+       hts-cache/ref must outlive the run (#1595). back_abort_slot() catches the
+       ones a sweep took, and the link loop can end a capped mirror before that
+       sweep ever runs (htscore.c, back_checkmirror). */
+    for (i = 0; i < sback->count; i++) {
+      const lien_back *const back = &sback->lnk[i];
+
+      if (back_is_live(back->status) && back->r.is_write &&
+          !IS_DELAYED_EXT(back->url_sav))
+        opt->abort_left_partial = HTS_TRUE;
+    }
     // delete live slots
     for(i = 0; i < sback->count; i++) {
       back_delete(opt, cache, sback, i);

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -624,7 +624,7 @@ int httpmirror(char *url1, httrackp *opt, hts_boolean *completed_out) {
   /* per mirror, not per opt: an embedder reusing one opt would otherwise
      carry the last run's verdict and never purge again */
   opt->links_unqueued = HTS_FALSE;
-  opt->stop_left_partial = HTS_FALSE;
+  opt->abort_left_partial = HTS_FALSE;
 
   /* before the first bailout below, each of which leaves it false */
   *completed_out = HTS_FALSE;

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -3066,9 +3066,9 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
     }
 
     /* Not or cleanly interrupted; erase hts-cache/ref temporary directory.
-       A ^C raises state.stop but leaves exit_xh at 0, so keep the ref when a
-       transfer was cut mid-body (#1595). */
-    if (opt->state.exit_xh == 0 && !opt->stop_left_partial) {
+       A ^C or a cap leaves exit_xh at 0, so keep the ref when either cut a
+       transfer mid-body (#1595). */
+    if (opt->state.exit_xh == 0 && !opt->abort_left_partial) {
       // erase ref files if not interrupted
       DIR *dir;
       struct dirent *entry;

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -6483,7 +6483,7 @@ HTSEXT_API httrackp *hts_create_opt(void) {
   opt->single_file_max_size = SINGLEFILE_DEFAULT_MAX_SIZE;
   opt->singlefile_state = NULL;
   opt->links_unqueued = HTS_FALSE;
-  opt->stop_left_partial = HTS_FALSE;
+  opt->abort_left_partial = HTS_FALSE;
   StringCopy(opt->why_url, "");
   opt->pause_min_ms = 0;
   opt->pause_max_ms = 0;

--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -591,11 +591,11 @@ struct httrackp {
                                    were never queued and the update purge would
                                    treat them as gone. Live state, so
                                    copy_htsopt must leave it alone. Tail: ABI */
-  hts_boolean stop_left_partial; /**< a user stop cut a body mid-transfer, so
-                                      the partial it left needs its
-                                      hts-cache/ref kept. Live state, so
-                                      copy_htsopt must leave it alone.
-                                      Tail: ABI */
+  hts_boolean abort_left_partial; /**< a teardown cut a body mid-transfer, so
+                                       the partial it left needs its
+                                       hts-cache/ref kept. Live state, so
+                                       copy_htsopt must leave it alone.
+                                       Tail: ABI */
 };
 
 /* Running statistics for a mirror. */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -12523,10 +12523,13 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
     /* cap reached, a tenth of it still to overrun before the hard stop */
     HTS_STAT.HTS_TOTAL_RECV = 1000;
     opt->maxsite = 1000;
+    opt->abort_left_partial = HTS_FALSE;
     hts_request_stop(opt, 0);
 
     back_wait(sback, opt, &cache, 0);
 
+    /* nothing it swept was writing, so there is no partial to describe */
+    CHECK(!opt->abort_left_partial);
     for (i = SLOT_DNS; i < SLOT_HEADERS; i++) {
       CHECK(back[i].status == STATUS_READY);
       CHECK(back[i].r.statuscode == STATUSCODE_INVALID);
@@ -12567,12 +12570,12 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
       }
       back[SLOT_XFER].r.is_write = partial[c].is_write;
       strcpybuff(back[SLOT_XFER].url_sav, partial[c].url_sav);
-      opt->stop_left_partial = HTS_FALSE;
+      opt->abort_left_partial = HTS_FALSE;
       hts_request_stop(opt, 0);
 
       back_wait(sback, opt, &cache, 0);
 
-      if (opt->stop_left_partial != partial[c].kept) {
+      if (opt->abort_left_partial != partial[c].kept) {
         printf("  FAIL line %d: %s must %s the resume data\n", __LINE__,
                partial[c].what, partial[c].kept ? "keep" : "drop");
         err = 1;
@@ -12581,12 +12584,42 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
       back[SLOT_XFER].url_sav[0] = '\0';
     }
   }
+
+  /* Past its grace a cap tears down the transfers the grace spared, through the
+     same back_abort_slot(), so the partial it cuts keeps its resume data like
+     any other (#1595). */
+  if (!err) {
+    const LLint recv_was = HTS_STAT.HTS_TOTAL_RECV;
+
+    opt->state.stop = 0;
+    if (!st_backstop_arm(opt, sback, status, r, SLOTS, SLOT_DNS)) {
+      skipped = 1;
+      goto cleanup;
+    }
+    back[SLOT_XFER].r.is_write = 1;
+    strcpybuff(back[SLOT_XFER].url_sav, "hts-backstop-selftest.tmp");
+    opt->abort_left_partial = HTS_FALSE;
+    /* the cap plus the whole grace, so the limit block ends every live slot */
+    opt->maxsite = 1000;
+    HTS_STAT.HTS_TOTAL_RECV = 1000 + 1000 / 10;
+    hts_request_stop(opt, 0);
+
+    back_wait(sback, opt, &cache, 0);
+
+    CHECK(back[SLOT_XFER].status == STATUS_READY);
+    CHECK(back[SLOT_XFER].r.statuscode == STATUSCODE_TIMEOUT);
+    CHECK(opt->abort_left_partial);
+    back[SLOT_XFER].r.is_write = 0;
+    back[SLOT_XFER].url_sav[0] = '\0';
+    opt->maxsite = 0;
+    HTS_STAT.HTS_TOTAL_RECV = recv_was;
+  }
 #undef CHECK
 
 cleanup:
   opt->maxsite = 0;
   opt->state.stop = 0;
-  opt->stop_left_partial = HTS_FALSE;
+  opt->abort_left_partial = HTS_FALSE;
   for (i = 0; i < SLOTS; i++)
     deletehttp(&back[i].r);
   back_free(&sback);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -12365,6 +12365,10 @@ static void st_backstop_slot(struct_back *sback, int p, int status,
 /* A network that rejects TEST-NET-1 instead of dropping it answers in ms. */
 #define ST_BACKSTOP_SETTLE_MS 500
 
+/* Bytes the size cap allows. back_maxsize_grace() spares the transfers already
+   running for another tenth of it, so the cases below spell that tenth out. */
+#define ST_BACKSTOP_CAP 1000
+
 /* Refill every slot: a fresh pending connect for each state that owns a socket,
    plus the poison the assertions read back. False if the blackhole answered. */
 static hts_boolean st_backstop_arm(httrackp *opt, struct_back *sback,
@@ -12507,9 +12511,10 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
     CHECK(strcmp(back[SLOT_FTP].r.msg, "untouched") == 0);
   }
 
-  /* A cap raises the stop flag itself and leaves the transfers already running
-     a grace (#77, #481): the sweep takes the pre-connect slots only until the
-     grace overruns, and back_wait's own limit block ends the rest. */
+  /* back_abort_stopped(), still in grace. A cap raises the stop flag itself and
+     leaves the transfers already running a grace (#77, #481), so the sweep
+     takes the pre-connect slots only and back_abort_limit() ends the rest
+     later. */
   if (!err) {
     const LLint recv_was = HTS_STAT.HTS_TOTAL_RECV;
 
@@ -12520,9 +12525,10 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
     }
     for (i = 0; i < SLOTS; i++)
       swept[i] = r[i].soc;
-    /* cap reached, a tenth of it still to overrun before the hard stop */
-    HTS_STAT.HTS_TOTAL_RECV = 1000;
-    opt->maxsite = 1000;
+    /* cap reached, its whole grace still to overrun before the hard stop */
+    HTS_STAT.HTS_TOTAL_RECV = ST_BACKSTOP_CAP;
+    opt->maxsite = ST_BACKSTOP_CAP;
+    /* already false here, but it keeps the check below local to this block */
     opt->abort_left_partial = HTS_FALSE;
     hts_request_stop(opt, 0);
 
@@ -12545,9 +12551,9 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
     HTS_STAT.HTS_TOTAL_RECV = recv_was;
   }
 
-  /* The stop keeps hts-cache/ref for a partial that outlives it, not for every
-     slot it killed (#1595). A .delayed placeholder goes with its own ref, so it
-     is not one. */
+  /* back_abort_stopped() keeps hts-cache/ref for a partial that outlives the
+     stop, not for every slot it killed (#1595). A .delayed placeholder goes
+     with its own ref, so it is not one. */
   {
     static const struct {
       const char *what;
@@ -12585,9 +12591,9 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
     }
   }
 
-  /* Past its grace a cap tears down the transfers the grace spared, through the
-     same back_abort_slot(), so the partial it cuts keeps its resume data like
-     any other (#1595). */
+  /* back_abort_limit(), past the grace. It tears down the transfers the grace
+     spared, through the same back_abort_slot(), so the partial it cuts keeps
+     its resume data like any other (#1595). */
   if (!err) {
     const LLint recv_was = HTS_STAT.HTS_TOTAL_RECV;
 
@@ -12599,15 +12605,18 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
     back[SLOT_XFER].r.is_write = 1;
     strcpybuff(back[SLOT_XFER].url_sav, "hts-backstop-selftest.tmp");
     opt->abort_left_partial = HTS_FALSE;
-    /* the cap plus the whole grace, so the limit block ends every live slot */
-    opt->maxsite = 1000;
-    HTS_STAT.HTS_TOTAL_RECV = 1000 + 1000 / 10;
+    /* well past any grace, so the limit block ends every live slot and tuning
+       back_maxsize_grace() cannot quietly put this case back inside it */
+    opt->maxsite = ST_BACKSTOP_CAP;
+    HTS_STAT.HTS_TOTAL_RECV = ST_BACKSTOP_CAP * 2;
     hts_request_stop(opt, 0);
 
     back_wait(sback, opt, &cache, 0);
 
     CHECK(back[SLOT_XFER].status == STATUS_READY);
-    CHECK(back[SLOT_XFER].r.statuscode == STATUSCODE_TIMEOUT);
+    /* not the statuscode: the arming poison is STATUSCODE_TIMEOUT too, so it
+       cannot tell an untouched slot from a swept one */
+    CHECK(strcmp(back[SLOT_XFER].r.msg, "Mirror Size Limit") == 0);
     CHECK(opt->abort_left_partial);
     back[SLOT_XFER].r.is_write = 0;
     back[SLOT_XFER].url_sav[0] = '\0';

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -12623,6 +12623,33 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
     opt->maxsite = 0;
     HTS_STAT.HTS_TOTAL_RECV = recv_was;
   }
+  /* back_delete_all(), the shutdown every exit reaches. A capped mirror can end
+     through the link loop before either sweep runs (htscore.c, on
+     back_checkmirror), and the partial is on disk just the same. Its own slot
+     table, so the fixture above is not torn down early. */
+  if (!err) {
+    struct_back *shut = back_new(opt, 1);
+
+    if (shut == NULL) {
+      err = 1;
+    } else {
+      cache_back shutcache;
+
+      memset(&shutcache, 0, sizeof(shutcache));
+      shutcache.hashtable = coucal_new(0);
+      shut->lnk[0].status = STATUS_TRANSFER;
+      shut->lnk[0].r.soc = INVALID_SOCKET;
+      shut->lnk[0].r.is_write = 1;
+      strcpybuff(shut->lnk[0].url_sav, "hts-backstop-selftest.tmp");
+      opt->abort_left_partial = HTS_FALSE;
+
+      back_delete_all(opt, &shutcache, shut);
+
+      CHECK(opt->abort_left_partial);
+      back_free(&shut);
+      coucal_delete(&shutcache.hashtable);
+    }
+  }
 #undef CHECK
 
 cleanup:

--- a/tests/444_local-stop-keeps-resume.test
+++ b/tests/444_local-stop-keeps-resume.test
@@ -105,11 +105,6 @@ assert_kept() { # assert_kept <name> <how> <why>
     test "$refs_left" -gt 0 || fail "$3"
 }
 
-assert_erased() { # assert_erased <name> <how> <why>
-    stop_and_report "$1" "$2"
-    test "$refs_left" -eq 0 || fail "$3"
-}
-
 printf '[a stop asked to keep the resume data keeps it] ..\t'
 assert_kept keep keep "hts-cache/ref was erased under a keep_resume stop"
 # Together these pin exit_xh at 1: -1 exits non-zero, 2 skips the banner.
@@ -129,10 +124,12 @@ assert_kept drop drop "hts-cache/ref was erased under a stop that cut a body mid
     fail "a stop that did not ask to keep the resume data logged the abort banner"
 echo "PASS"
 
-# The engine raises the stop flag itself when a cap is reached, and that run
-# ends as cleanly as a finished one: nothing to resume, nothing to keep.
-printf '[a --max-time cap still erases it] ..\t'
-assert_erased maxtime maxtime "hts-cache/ref survived the engine's own cap stop"
+# A cap past its grace tears down the transfers the grace spared, through the
+# same teardown a stop uses, so it leaves the same partials and keeps the same
+# byte ranges (#1595). The mirror ended where the user asked, but the file it
+# was fetching did not.
+printf '[a --max-time cap keeps it too] ..\t'
+assert_kept maxtime maxtime "hts-cache/ref was erased under the engine's own cap stop"
 echo "PASS"
 
 # What the kept directory is for: /stopresume/blob.bin stalls its first GET
@@ -153,3 +150,11 @@ test "$at" -gt 0 || fail "the --continue asked for the file from byte 0"
 got=$(wc -c <"$blob")
 test "$got" -eq "$full" || fail "blob.bin is ${got} bytes, expected ${full}"
 echo "PASS (resumed at ${at} of ${full})"
+
+# The control, on the run that just finished: it wrote blob.bin to disk, so it
+# had a ref of its own to erase, and nothing cut it short. Without this the arms
+# above would pass on a fix that simply stopped erasing.
+printf '[the completed --continue erases the directory again] ..\t'
+test ! -d "${out}/hts-cache/ref" ||
+    fail "hts-cache/ref survived a mirror nothing interrupted"
+echo "PASS"


### PR DESCRIPTION
#1597 taught `back_abort_stopped()` to keep `hts-cache/ref` when it cut a body mid-transfer, and left the other caller alone. `back_abort_limit()` tears down live slots the same way once a cap overruns its grace, through the same `back_abort_slot()`, leaving the same partials on disk. Their byte ranges were still erased, so a `--max-size` or `--max-time` run lost its resume exactly as a `^C` did.

The flag moves into `back_abort_slot()`, which already owns this question, because the line above it discards a `.delayed` placeholder that nothing resumes from. Both callers now get the behavior and the caller-side copy of the predicate goes. The field becomes `abort_left_partial`, since a cap is not a user stop. It is unreleased, added after 3.50.1, so nothing downstream reads the old name.

This inverts 444's `[a --max-time cap still erases it]`. That arm was the file's only proof that the purge still runs. A completed `--continue` takes over the job, asserted after the resume arm that already runs one.

A cap has a second exit, which CI found and which the first version of this branch did not cover. `back_checkmirror()` has two consumers: `back_wait()` runs `back_abort_limit()`, and the link loop in `htscore.c` ends the mirror. Whichever sees the overrun first wins. When the link loop wins, no sweep runs at all, the partials stay on disk and their byte ranges are erased, which is #1595 again. `back_delete_all()` is the shutdown every exit reaches, so a slot still writing there raises the flag too.

`-#test=backstop` grows the case that matters. A cap pushed past its whole grace ends the transfers the grace spared, and the partial one keeps its resume data. The in-grace cap gains the negative, because it sweeps only pre-connect slots and none of those writes.

Which consumer wins is the machine's choice, so the end-to-end arm cannot pin the shutdown path. It fired on two thirds of the runs here with the loop removed. `st_backstop_shutdown()` drives `back_delete_all()` on its own slot table instead, over four slot shapes, because each clause of the guard survived alone until it did. Setting the flag before the `.delayed` discard is a real mutant, but dropping the `else` is an equivalent one, because `back_delayed_discard()` clears `is_write` itself. The `else if` says what it means rather than leaning on that.

Follow-up to #1595.