### PR TITLE
A bare "/" in a mirrored script is rewritten to the index page

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -1733,11 +1733,15 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                             //
                             if ((!strchr(tempo, ' ')) || inscript) {    // espace dedans: méfiance! (sauf dans code javascript)
                               int invalid_url = 0;
+                              hts_boolean only_slashes;
 
                               // escape                              
                               unescape_amp(tempo);
 
-                              // Couper au # ou ? éventuel
+                              // The cut below erases "/#frag" down to "/".
+                              only_slashes = hts_rtrimlen(tempo, "/") == 0;
+
+                              // Cut at any # or ?
                               {
                                 char *a = strchr(tempo, '#');
 
@@ -1768,19 +1772,17 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                 if (c != '+') { // PAS de plus à la fin
                                   // "Comparisons of scheme names MUST be
                                   // case-insensitive" (RFC2616)
-                                  if ((strfield(tempo, "http:"))
-                                      || (strfield(tempo, "ftp:"))
+                                  // These schemes leave no doubt.
+                                  if ((strfield(tempo, "http:")) ||
+                                      (strfield(tempo, "ftp:"))
 #if HTS_USEOPENSSL
-                                      || (strfield(tempo, "https:")
-                                      )
+                                      || (strfield(tempo, "https:"))
 #endif
-                                    )   // ok pas de problème
+                                  )
                                     url_ok = 1;
                                   else if (hts_lastchar(tempo) == '/') {
-                                    // a directory: trusted only in a script,
-                                    // and never a pure-slash separator
-                                    if (inscript &&
-                                        tempo[strspn(tempo, "/")] != '\0')
+                                    // A script's lone "/" is a separator.
+                                    if (inscript && !only_slashes)
                                       url_ok = 1;
                                   }
                                 }

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -1738,7 +1738,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                               // escape                              
                               unescape_amp(tempo);
 
-                              // The cut below erases "/#frag" down to "/".
+                              // Decide before the cut turns "/#frag" into "/".
                               only_slashes = hts_rtrimlen(tempo, "/") == 0;
 
                               // Cut at any # or ?
@@ -1772,7 +1772,6 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                 if (c != '+') { // PAS de plus à la fin
                                   // "Comparisons of scheme names MUST be
                                   // case-insensitive" (RFC2616)
-                                  // These schemes leave no doubt.
                                   if ((strfield(tempo, "http:")) ||
                                       (strfield(tempo, "ftp:"))
 #if HTS_USEOPENSSL

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -1776,9 +1776,11 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
 #endif
                                     )   // ok pas de problème
                                     url_ok = 1;
-                                  else if (hts_lastchar(tempo) ==
-                                           '/') {       // un slash: ok..
-                                    if (inscript)       // sinon si pas javascript, méfiance (répertoire style base?)
+                                  else if (hts_lastchar(tempo) == '/') {
+                                    // a directory: trusted only in a script,
+                                    // and never a pure-slash separator
+                                    if (inscript &&
+                                        tempo[strspn(tempo, "/")] != '\0')
                                       url_ok = 1;
                                   }
                                 }

--- a/tests/454_local-js-slash-literal.test
+++ b/tests/454_local-js-slash-literal.test
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# A quoted string ending in "/" is read as a directory URL inside a script, so
+# a bare "/" was rewritten to the mirror's index page: split("/") turned into
+# split("index.html") and the script threw at load. AddToAny's page.js is one
+# of those, and its share icons never appeared in the mirror.
+#
+# A rooted directory string still has to be rewritten, so a fix that refuses
+# every trailing slash fails here too.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+work=$(mktemp -d)
+cleanup_push rm -rf "$work"
+root="$work/root"
+mkdir -p "$root/sub"
+
+cat >"$root/index.html" <<'HTML'
+<!DOCTYPE html><html><body><script src="script.js"></script></body></html>
+HTML
+
+cat >"$root/script.js" <<'JS'
+var parts = location.href.split("/");
+var joined = ["a", "b"].join("/");
+var img = "sub/pic.png";
+var dir = "/sub/";
+JS
+
+printf '\211PNG\r\n\032\n' >"$root/sub/pic.png"
+printf '<html><body>s</body></html>\n' >"$root/sub/index.html"
+
+bash "$top_srcdir/tests/local-crawl.sh" --root "$root" \
+    --errors 0 \
+    --found script.js \
+    --found sub/pic.png \
+    --found sub/index.html \
+    --file-matches script.js 'split\("/"\)' \
+    --file-matches script.js 'join\("/"\)' \
+    --file-matches script.js 'img = "sub/pic\.png"' \
+    --file-matches script.js 'dir = "sub/index\.html"' \
+    httrack BASEURL/index.html -q -%v0 -r3

--- a/tests/454_local-js-slash-literal.test
+++ b/tests/454_local-js-slash-literal.test
@@ -1,44 +1,61 @@
 #!/bin/bash
 #
-# A quoted string ending in "/" is read as a directory URL inside a script, so
-# a bare "/" was rewritten to the mirror's index page: split("/") turned into
-# split("index.html") and the script threw at load. AddToAny's page.js is one
-# of those, and its share icons never appeared in the mirror.
+# Inside a script, htsparse reads a quoted string ending in "/" as a directory
+# URL. A string that is only a slash therefore became the site root. split("/")
+# came out of the mirror as split("index.html"), and the script threw at load.
+# AddToAny's page.js opens with that call, and its share icons never appeared in
+# a mirror carrying it. See https://forum.httrack.com/readmsg/43082/index.html.
 #
 # A rooted directory string still has to be rewritten, so a fix that refuses
 # every trailing slash fails here too.
 
 set -euo pipefail
 
-# shellcheck source=tests/testlib.sh
-. "${0%"${0##*/}"}./testlib.sh"
+# shellcheck source=tests/crawllib.sh
+. "${0%"${0##*/}"}./crawllib.sh"
 
 work=$(mktemp -d)
 cleanup_push rm -rf "$work"
 root="$work/root"
-mkdir -p "$root/sub"
+mkdir -p "$root/sub" "$root/assets"
 
+# data-path is not a link attribute, and outside a script a trailing slash is
+# not trusted, so "assets/" must survive. assets/index.html exists only so that
+# a build rewriting the attribute fails on the attribute and not on a 404.
 cat >"$root/index.html" <<'HTML'
-<!DOCTYPE html><html><body><script src="script.js"></script></body></html>
+<!DOCTYPE html><html><body>
+<div data-path="assets/">x</div>
+<script src="script.js"></script></body></html>
 HTML
 
+# The fixture holds both poles. parts and dbl must survive verbatim, because a
+# "/" there is a separator and not a URL. img, dir, frag and query are real
+# links and are still rewritten. img reaches sub/pic.png, dir reaches
+# sub/index.html, and frag and query reach a copy of the root page.
 cat >"$root/script.js" <<'JS'
 var parts = location.href.split("/");
-var joined = ["a", "b"].join("/");
 var img = "sub/pic.png";
 var dir = "/sub/";
+var frag = "/#top";
+var query = "/?q=1";
+var dbl = "//";
 JS
 
 printf '\211PNG\r\n\032\n' >"$root/sub/pic.png"
 printf '<html><body>s</body></html>\n' >"$root/sub/index.html"
+printf '<html><body>a</body></html>\n' >"$root/assets/index.html"
 
-bash "$top_srcdir/tests/local-crawl.sh" --root "$root" \
+# Two assertions kill no mutant. dbl is output-identical under a rule keyed on
+# strcmp(tempo, "/"), because a later stage drops "//" anyway, so it pins the
+# behaviour instead. --found sub/pic.png only proves the script was scanned.
+bash "$top_srcdir/tests/local-crawl.sh" --root "$(nativepath "$root")" \
     --errors 0 \
-    --found script.js \
     --found sub/pic.png \
     --found sub/index.html \
     --file-matches script.js 'split\("/"\)' \
-    --file-matches script.js 'join\("/"\)' \
-    --file-matches script.js 'img = "sub/pic\.png"' \
+    --file-matches script.js 'dbl = "//"' \
     --file-matches script.js 'dir = "sub/index\.html"' \
+    --file-matches script.js 'frag = "index-2\.html#top"' \
+    --file-matches script.js 'query = "index5835\.html\?q=1"' \
+    --file-matches index.html 'data-path="assets/"' \
     httrack BASEURL/index.html -q -%v0 -r3

--- a/tests/454_local-js-slash-literal.test
+++ b/tests/454_local-js-slash-literal.test
@@ -1,13 +1,11 @@
 #!/bin/bash
 #
-# Inside a script, htsparse reads a quoted string ending in "/" as a directory
-# URL. A string that is only a slash therefore became the site root. split("/")
-# came out of the mirror as split("index.html"), and the script threw at load.
-# AddToAny's page.js opens with that call, and its share icons never appeared in
-# a mirror carrying it. See https://forum.httrack.com/readmsg/43082/index.html.
+# In a script, a lone "/" was rewritten to the site root, so split("/") came out
+# as split("index.html") and the script threw at load.
+# See https://forum.httrack.com/readmsg/43082/index.html.
 #
-# A rooted directory string still has to be rewritten, so a fix that refuses
-# every trailing slash fails here too.
+# A rooted directory string must still be rewritten, so refusing every trailing
+# slash fails here too.
 
 set -euo pipefail
 
@@ -32,6 +30,10 @@ HTML
 # "/" there is a separator and not a URL. img, dir, frag and query are real
 # links and are still rewritten. img reaches sub/pic.png, dir reaches
 # sub/index.html, and frag and query reach a copy of the root page.
+#
+# amp is the accepted tradeoff. unescape_amp runs before the flag is read, so
+# "&#47;" reads as a lone slash and the root link it spells stops being
+# rewritten.
 cat >"$root/script.js" <<'JS'
 var parts = location.href.split("/");
 var img = "sub/pic.png";
@@ -39,23 +41,33 @@ var dir = "/sub/";
 var frag = "/#top";
 var query = "/?q=1";
 var dbl = "//";
+var amp = "&#47;";
 JS
 
 printf '\211PNG\r\n\032\n' >"$root/sub/pic.png"
 printf '<html><body>s</body></html>\n' >"$root/sub/index.html"
 printf '<html><body>a</body></html>\n' >"$root/assets/index.html"
 
-# Two assertions kill no mutant. dbl is output-identical under a rule keyed on
-# strcmp(tempo, "/"), because a later stage drops "//" anyway, so it pins the
-# behaviour instead. --found sub/pic.png only proves the script was scanned.
+# Two assertions kill no mutant. dbl pins behaviour instead, because
+# substituting strcmp(tempo, "/") at the flag's computation point differs only
+# on repeated slashes, which a later stage drops anyway. --found sub/pic.png
+# only proves the script was scanned.
+#
+# The rewritten names carry a hash and a collision suffix htsname.c is free to
+# change, so match the property under test, which is the missing leading slash.
+audit=(
+    --errors 0
+    --found sub/pic.png
+    --found sub/index.html
+    # survives verbatim:
+    --file-matches script.js 'split\("/"\)'
+    --file-matches script.js 'dbl = "//"'
+    --file-matches script.js 'amp = "&#47;"'
+    --file-matches index.html 'data-path="assets/"'
+    # rewritten:
+    --file-matches script.js 'dir = "sub/index\.html"'
+    --file-matches script.js 'frag = "[^"/]*\.html#top"'
+    --file-matches script.js 'query = "[^"/]*\.html\?q=1"'
+)
 bash "$top_srcdir/tests/local-crawl.sh" --root "$(nativepath "$root")" \
-    --errors 0 \
-    --found sub/pic.png \
-    --found sub/index.html \
-    --file-matches script.js 'split\("/"\)' \
-    --file-matches script.js 'dbl = "//"' \
-    --file-matches script.js 'dir = "sub/index\.html"' \
-    --file-matches script.js 'frag = "index-2\.html#top"' \
-    --file-matches script.js 'query = "index5835\.html\?q=1"' \
-    --file-matches index.html 'data-path="assets/"' \
-    httrack BASEURL/index.html -q -%v0 -r3
+    "${audit[@]}" httrack BASEURL/index.html -q -%v0 -r3


### PR DESCRIPTION
When htsparse scans a script, it reads a quoted string ending in `/` as a directory URL. A string that is only a slash therefore becomes the site root, rewritten to the mirror's index page. `location.href.split("/")` comes out of the mirror as `location.href.split("index.html")`, which returns a one-element array, so the `[2].indexOf(...)` behind it throws. The script dies on its first statement.

A forum report surfaced this. A WordPress site's AddToAny share icons are in the reporter's 3.49 mirror and gone from his 3.50 one. See https://forum.httrack.com/readmsg/43082/index.html. `static.addtoany.com/menu/page.js` draws those icons, and its second statement is exactly that `split("/")[2].indexOf`. With "get non-HTML files related to a link" on, httrack mirrors that script, rewrites it, and nothing renders.

The parser has always done this to a script it scanned, but until #1377 it scanned only `application/x-javascript`. Since 3.49.24 it reads the spellings servers actually send, so the rewrite reaches ordinary scripts. I bisected to f9ab3807 with page.js on a local server.

A string carrying a path keeps its old meaning. `"/sub/"` still becomes `sub/index.html`, and 454 asserts that, so a fix refusing every trailing slash fails it too. The fix answers the pure-slash question before the block that truncates the string at a `#` or a `?`. After that block, `"/#top"` and `"/?q=1"` look like a bare slash, and both are ordinary links to the root page.

The change costs two things. A script assigning `"/"` to `location.href` now keeps it as written. And the flag is read after `unescape_amp`, so `"&#47;"` counts as a lone slash and stops being rewritten too. I chose that, because the decoded value is a slash.

I left one case alone. The same crawl rewrites `data-a2a-url="https://site/"` to `index.html`, so every share button points at a local file. That arrived with #497 widening mid-tag attribute detection. Telling a share URL from a resource URL in an unknown `data-*` attribute is a call I would rather leave to you.