### PR TITLE
A parser regression ships silently, so say how to catch one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,30 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   compiler output, grep the unguarded forms yourself (`\bsprintf\s*\(`,
   `\bstrcpy\s*\(`, `\bstrcat\s*\(`).
 
+## Changing the parser
+`src/htsparse.c` rewrites every page of every mirror, so a regression there has
+the blast radius of the whole product and none of the visibility. The suite
+crawls fixtures the parser already handles. The damage lands in a browser, on a
+real site, and reaches us months later as a forum post. Treat a change here with
+more care than its diff size suggests.
+- **Widening what the parser SCANS is as dangerous as changing what it
+  REWRITES.** #1377 touched only the list of scanned mime types, and thereby
+  carried a years-old rewrite bug into every ordinary script. #497 widened
+  mid-tag attribute detection, which then rewrote `data-*` values that were
+  never links.
+- **Locate your guard in the pipeline before you write it.** By the time a
+  string reaches your test it may already have been entity-decoded and
+  truncated at `#` and `?`. Read what happened to it upstream, rather than
+  assuming it still holds what the page held.
+- **Prove it by differential against the previous release binary.** Build both,
+  crawl one fixture, diff the mirrored output. A source read that has not been
+  confronted with two running binaries is a hypothesis.
+- **Pair every probe with a control that fires**, including one in the narrowing
+  direction. A mutant that wrongly rejects tells you the differential can see a
+  loss and not only a gain.
+- **Name the class you mean to change, then prove the class you changed equals
+  it.**
+
 ## C conventions
 - **Use the `*t` allocator wrappers, never raw libc** (`htssafe.h`):
   `malloct`/`calloct`/`realloct`/`freet`/`strdupt`, in test and selftest code


### PR DESCRIPTION
Three parser changes broke mirrors this year without anything in CI noticing, and all three
surfaced as forum posts months after release. #1377 widened the scanned mime types. That carried
a years-old rewrite bug into every ordinary script, which is what killed the AddToAny share icons
in #1608. #497 widened mid-tag attribute detection and started rewriting `data-*` values that
were never links. The fix for the first one then over-rejected, because its guard sat below the
point where the string is truncated at `#` and `?`.

The common shape is that the parser rewrites every page of every mirror, and the suite only
crawls fixtures it already handles. So a regression there is invisible until a user hits it.

This writes down what caught all three. Diff the mirrored output against the previous release
binary. Pair the probe with a control that fires in the narrowing direction. Check where in the
pipeline a guard sits before trusting what the string holds.

No code changes.
