### PR TITLE
A trailing slash in a script string is not enough to call it a URL

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -1778,7 +1778,11 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                     url_ok = 1;
                                   else if (hts_lastchar(tempo) ==
                                            '/') {       // un slash: ok..
-                                    if (inscript)       // sinon si pas javascript, méfiance (répertoire style base?)
+                                    /* A trailing slash alone is no evidence
+                                       inside a script, where "/" and "image/"
+                                       are ordinary strings. */
+                                    if (inscript &&
+                                        link_dir_is_multisegment(tempo))
                                       url_ok = 1;
                                   }
                                 }

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -388,6 +388,19 @@ hts_boolean link_base_is_hostname(const char *lien) {
   return HTS_FALSE;
 }
 
+hts_boolean link_dir_is_multisegment(const char *lien) {
+  size_t slashes = 0, other = 0;
+  const char *a;
+
+  for (a = lien; *a != '\0'; a++) {
+    if (*a == '/')
+      slashes++;
+    else
+      other++;
+  }
+  return (slashes >= 2 && other != 0) ? HTS_TRUE : HTS_FALSE;
+}
+
 int link_has_authorization(const char *lien) {
   const char *adr = jump_protocol_const(lien);
   const char *firstslash = strchr(adr, '/');

--- a/src/htstools.h
+++ b/src/htstools.h
@@ -72,9 +72,9 @@ int link_has_authority(const char *lien);
    reference RFC 3986 5.2 makes it? True only when its first segment holds a
    dot or a colon, so a dotless "sub/" stays relative. */
 hts_boolean link_base_is_hostname(const char *lien);
-/* Does a string hold a path of more than one segment? Callers use it on a
-   script string that already ends in a slash, which is no evidence on its own
-   because "/", "image/" and "$&/" all end in one. A second slash is. */
+/* Does a string hold a path of more than one segment? A script string ending
+   in a slash is no evidence alone, because "/", "image/" and "$&/" all end
+   that way too. A second slash is. */
 hts_boolean link_dir_is_multisegment(const char *lien);
 int link_has_authorization(const char *lien);
 void long_to_83(int mode, char *n83, size_t n83size, char *save);

--- a/src/htstools.h
+++ b/src/htstools.h
@@ -72,6 +72,10 @@ int link_has_authority(const char *lien);
    reference RFC 3986 5.2 makes it? True only when its first segment holds a
    dot or a colon, so a dotless "sub/" stays relative. */
 hts_boolean link_base_is_hostname(const char *lien);
+/* Does a string hold a path of more than one segment? Callers use it on a
+   script string that already ends in a slash, which is no evidence on its own
+   because "/", "image/" and "$&/" all end in one. A second slash is. */
+hts_boolean link_dir_is_multisegment(const char *lien);
 int link_has_authorization(const char *lien);
 void long_to_83(int mode, char *n83, size_t n83size, char *save);
 void longfile_to_83(int mode, char *n83, size_t n83size, char *save);

--- a/tests/457_local-js-string-separator.test
+++ b/tests/457_local-js-string-separator.test
@@ -15,39 +15,43 @@ work=$(mktemp -d)
 trap 'set +e; rm -rf "$work"' EXIT
 
 root="$work/root"
-mkdir -p "$root/subdir" "$root/api/v1" "$root/assets/img" "$root/cdir"
+mkdir -p "$root/subdir" "$root/a/b" "$root/api/v1" "$root/assets/img" "$root/cdir"
 
 cat >"$root/index.html" <<'EOF'
 <!DOCTYPE html><html><head><link rel="stylesheet" href="s.css">
 <script src="app.js"></script></head><body>x</body></html>
 EOF
 
-# Every string here ends in a slash. Only the last two name a path of more than
-# one segment, and only those two may be rewritten.
+# Every string below ends in a slash. Only a path of more than one segment may
+# be followed, so each line carries the count that decides it.
 cat >"$root/app.js" <<'EOF'
-var parts = "a/b".split("/");
-var mime = "image/";
-var key = "Alt+/";
-var rep = "ab".replace(/b/, "$&/");
-var runs = "////";
-var one = "subdir/";
-var api = "/api/v1/";
-var ast = "assets/img/";
+var parts = "a/b".split("/");        // one slash: kept
+var mime = "image/";                 // one slash: kept
+var key = "Alt+/";                   // one slash: kept
+var rep = "ab".replace(/b/, "$&/");  // one slash: kept
+var runs = "////";                   // no name, only slashes: kept
+var one = "subdir/";                 // one slash: kept, so never fetched
+var two = "a/b/";                    // two slashes, short name: followed
+var api = "/api/v1/";                // three slashes: followed
+var ast = "assets/img/";             // two slashes: followed
 EOF
 
 echo '.a { background: url("cdir/"); }' >"$root/s.css"
-for d in subdir api/v1 assets/img cdir; do
+for d in subdir a/b api/v1 assets/img cdir; do
     printf 'reached\n' >"$root/$d/index.html"
 done
 
+# The cdir case cannot fail on the helper, since CSS url() reaches the parser by
+# another path. It is here to catch a fix that drops the inscript test instead.
 bash "$top_srcdir/tests/local-crawl.sh" --root "$root" --errors 0 \
     --file-matches 'app.js' 'split\("/"\)' \
     --file-matches 'app.js' '"image/"' \
     --file-matches 'app.js' '"Alt\+/"' \
     --file-matches 'app.js' '"\$&/"' \
     --file-matches 'app.js' '"////"' \
+    --not-found subdir/index.html \
+    --found a/b/index.html \
     --found api/v1/index.html \
     --found assets/img/index.html \
     --found cdir/index.html \
-    --not-found subdir/index.html \
     httrack BASEURL/index.html -q -%v0 -r4

--- a/tests/457_local-js-string-separator.test
+++ b/tests/457_local-js-string-separator.test
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# A quoted string ending in a slash counted as a directory link inside a script,
+# so httrack rewrote JavaScript's own separators. split("/") became
+# split("index-2.html") and the mirrored bundle behaved differently.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+: "${top_srcdir:=..}"
+
+work=$(mktemp -d)
+trap 'set +e; rm -rf "$work"' EXIT
+
+root="$work/root"
+mkdir -p "$root/subdir" "$root/api/v1" "$root/assets/img" "$root/cdir"
+
+cat >"$root/index.html" <<'EOF'
+<!DOCTYPE html><html><head><link rel="stylesheet" href="s.css">
+<script src="app.js"></script></head><body>x</body></html>
+EOF
+
+# Every string here ends in a slash. Only the last two name a path of more than
+# one segment, and only those two may be rewritten.
+cat >"$root/app.js" <<'EOF'
+var parts = "a/b".split("/");
+var mime = "image/";
+var key = "Alt+/";
+var rep = "ab".replace(/b/, "$&/");
+var runs = "////";
+var one = "subdir/";
+var api = "/api/v1/";
+var ast = "assets/img/";
+EOF
+
+echo '.a { background: url("cdir/"); }' >"$root/s.css"
+for d in subdir api/v1 assets/img cdir; do
+    printf 'reached\n' >"$root/$d/index.html"
+done
+
+bash "$top_srcdir/tests/local-crawl.sh" --root "$root" --errors 0 \
+    --file-matches 'app.js' 'split\("/"\)' \
+    --file-matches 'app.js' '"image/"' \
+    --file-matches 'app.js' '"Alt\+/"' \
+    --file-matches 'app.js' '"\$&/"' \
+    --file-matches 'app.js' '"////"' \
+    --found api/v1/index.html \
+    --found assets/img/index.html \
+    --found cdir/index.html \
+    --not-found subdir/index.html \
+    httrack BASEURL/index.html -q -%v0 -r4


### PR DESCRIPTION
A quoted string ending in a slash counted as a directory link inside a script, so httrack rewrote JavaScript's own separators. On excalidraw's shipped 2.1 MB bundle master turns five of the seven `split("/")` calls into `split("index-2.html")`. It also empties both `startsWith("/")` and injects 18 `index.html` literals into a file that had none. It requests the results too: the test fixture logs 404s for `/image/`, `/Alt+/` and `/$&/`.

The rule now needs a second slash. That keeps a real path such as `/api/v1/` or `assets/img/`. It drops `"/"`, `"image/"`, `"Alt+/"` and `"$&/"`, which end in a slash and are not URLs.

An earlier candidate only required the string to hold something other than slashes. It was rejected in review because it reached one damage class of four, and this test kills it.

Deleting the rule for JavaScript was the other option, and it is measurably free. Across 13 real sites the captured-file count is identical whether the rule is on, off, or narrowed. Narrowing keeps multi-segment paths, so no behaviour is dropped on the strength of one sample.

One loss is deliberate. A single-segment directory string like `"subdir/"` is no longer followed from JavaScript, because nothing distinguishes it from `"image/"`. The test pins that, so it stays a decision rather than a regression.

CSS `url()` is untouched, and I checked rather than assumed. `url("cdir/")` and `url("deep/sub/")` are captured and rewritten exactly as before, because that form reaches the parser by another path. A quoted string elsewhere in a stylesheet does narrow, since the flag covers CSS too. Review found the one shape that shows it, an IE `progid:` filter carrying `src="sub/"`, which is no longer followed.

Eight wrong fixes were built and run against the test, and all eight fail. They are always true, always false, the rejected candidate, one slash, three slashes, no all-slashes guard, a leading-slash test, and a four-character minimum name. The last of those is why a short `"a/b/"` is in the fixture, and `"////"` is what kills the sixth.

The bundle still carries six `&amp;` that the served bytes do not, down from eight. Those are a different bug. They sit in genuine absolute URLs such as `...?utm_source=x&utm_medium=y`, which the scheme branch recognises and HTML-escapes on write-back, and JavaScript never decodes an entity. Worth its own issue.