### PR TITLE
A URL written into a script or stylesheet is HTML-escaped, and neither decodes entities

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -129,9 +129,17 @@ Please visit our Website: http://www.httrack.com
   } \
 } while(0)
 
-/** Append to the output buffer the string 'A', html-escaped for &. **/
-#define HT_ADD_HTMLESCAPED(A) \
-  HT_ADD_HTMLESCAPED_ANY(A, escape_for_html_print, HTS_HTMLESCAPE_MAXEXP)
+/** Append to the output buffer the string 'A', html-escaped for &.
+    A script or style element holds raw text, and so does an external script or
+    stylesheet, so an entity written there would never be decoded. An inline
+    handler such as onclick= is still markup, which inscript_tag marks. **/
+#define HT_ADD_HTMLESCAPED(A) do { \
+  if (inscript && !inscript_tag) { \
+    HT_ADD(A); \
+  } else { \
+    HT_ADD_HTMLESCAPED_ANY(A, escape_for_html_print, HTS_HTMLESCAPE_MAXEXP); \
+  } \
+} while(0)
 
 /**
  * Append to the output buffer the string 'A', html-escaped for & and

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -145,6 +145,8 @@ Please visit our Website: http://www.httrack.com
  * Append to the output buffer the string 'A', html-escaped for & and
  * high chars.
  **/
+/* Its one caller passes a percent-encoded path, and appends any query through
+   HT_ADD_HTMLESCAPED, so no bare & reaches it. */
 #define HT_ADD_HTMLESCAPED_FULL(A) \
   HT_ADD_HTMLESCAPED_ANY(A, escape_for_html_print_full, HTS_HTMLESCAPE_FULL_MAXEXP)
 /* clang-format on */

--- a/tests/458_local-js-amp-escape.test
+++ b/tests/458_local-js-amp-escape.test
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# A rewritten URL was html-escaped wherever it landed, so a mirrored script got
+# "?a=1&amp;b=2" and sent those five characters in the query. Neither JavaScript
+# nor CSS decodes an entity.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+: "${top_srcdir:=..}"
+
+work=$(mktemp -d)
+trap 'set +e; rm -rf "$work"' EXIT
+
+root="$work/root"
+mkdir -p "$root"
+
+# One query letter pair per context, so no assertion can pass for another. The
+# markup cases sit after the script and style blocks, which catches a fix that
+# turns escaping off and never turns it back on.
+cat >"$root/index.html" <<'EOF'
+<!DOCTYPE html><html><head>
+<link rel="stylesheet" href="s.css">
+<script src="app.js"></script>
+<script>var inline = "q.html?a=1&b=2";</script>
+<style>.s { background: url("q.html?c=1&d=2"); }</style>
+</head><body>
+<a href="q.html?e=1&f=2">h</a>
+<div style="background: url('q.html?g=1&h=2')">d</div>
+<a href="javascript:go('q.html?i=1&j=2')">j</a>
+</body></html>
+EOF
+
+echo 'var ext = "q.html?k=1&l=2";' >"$root/app.js"
+echo '.c { background: url("q.html?m=1&n=2"); }' >"$root/s.css"
+printf 'x\n' >"$root/q.html"
+
+# Raw text keeps the ampersand; markup keeps the entity. Each pattern fails if
+# the other form is emitted, so no negative assertion is needed.
+bash "$top_srcdir/tests/local-crawl.sh" --root "$root" --errors 0 \
+    --file-matches 'app.js' 'k=1&l=2' \
+    --file-matches 's.css' 'm=1&n=2' \
+    --file-matches 'index.html' 'a=1&b=2' \
+    --file-matches 'index.html' 'c=1&d=2' \
+    --file-matches 'index.html' 'e=1&amp;f=2' \
+    --file-matches 'index.html' 'g=1&amp;h=2' \
+    --file-matches 'index.html' 'i=1&amp;j=2' \
+    httrack BASEURL/index.html -q -%v0 -r3

--- a/tests/458_local-js-amp-escape.test
+++ b/tests/458_local-js-amp-escape.test
@@ -17,34 +17,37 @@ trap 'set +e; rm -rf "$work"' EXIT
 root="$work/root"
 mkdir -p "$root"
 
-# One query letter pair per context, so no assertion can pass for another. The
-# markup cases sit after the script and style blocks, which catches a fix that
-# turns escaping off and never turns it back on.
+# One query letter pair per context, so no assertion can pass for another. A
+# script sits on each side of the markup, because a condition that latches
+# leaks in one direction only and one ordering would miss it.
 cat >"$root/index.html" <<'EOF'
 <!DOCTYPE html><html><head>
 <link rel="stylesheet" href="s.css">
 <script src="app.js"></script>
-<script>var inline = "q.html?a=1&b=2";</script>
-<style>.s { background: url("q.html?c=1&d=2"); }</style>
+<script>var inline = "q.html?a=1&b=2";</script>   <!-- raw text -->
+<style>.s { background: url("q.html?c=1&d=2"); }</style>   <!-- raw text -->
 </head><body>
-<a href="q.html?e=1&f=2">h</a>
-<div style="background: url('q.html?g=1&h=2')">d</div>
-<a href="javascript:go('q.html?i=1&j=2')">j</a>
+<a href="q.html?e=1&f=2">h</a>                            <!-- markup -->
+<div style="background: url('q.html?g=1&h=2')">d</div>    <!-- markup -->
+<a href="javascript:go('q.html?i=1&j=2')">j</a>           <!-- markup -->
+<script>var trailing = "q.html?o=1&p=2";</script>  <!-- raw text, after markup -->
 </body></html>
 EOF
 
-echo 'var ext = "q.html?k=1&l=2";' >"$root/app.js"
-echo '.c { background: url("q.html?m=1&n=2"); }' >"$root/s.css"
+echo 'var ext = "q.html?k=1&l=2";' >"$root/app.js"              # raw text
+echo '.c { background: url("q.html?m=1&n=2"); }' >"$root/s.css" # raw text
 printf 'x\n' >"$root/q.html"
 
-# Raw text keeps the ampersand; markup keeps the entity. Each pattern fails if
-# the other form is emitted, so no negative assertion is needed.
+# Raw text keeps the ampersand, markup keeps the entity. Each pattern fails if
+# the other form is emitted, so no negative assertion is needed. The order
+# below follows the fixture above.
 bash "$top_srcdir/tests/local-crawl.sh" --root "$root" --errors 0 \
-    --file-matches 'app.js' 'k=1&l=2' \
-    --file-matches 's.css' 'm=1&n=2' \
     --file-matches 'index.html' 'a=1&b=2' \
     --file-matches 'index.html' 'c=1&d=2' \
     --file-matches 'index.html' 'e=1&amp;f=2' \
     --file-matches 'index.html' 'g=1&amp;h=2' \
     --file-matches 'index.html' 'i=1&amp;j=2' \
+    --file-matches 'index.html' 'o=1&p=2' \
+    --file-matches 'app.js' 'k=1&l=2' \
+    --file-matches 's.css' 'm=1&n=2' \
     httrack BASEURL/index.html -q -%v0 -r3


### PR DESCRIPTION
Closes #1615.

A rewritten URL was html-escaped wherever it landed, so a mirrored script carried `?a=1&amp;b=2` and sent those five characters in the query. JavaScript and CSS never decode an entity.

The split is raw text against markup. A `<script>` or `<style>` element holds raw text, and an external script or stylesheet is not markup at all, so escaping there is always wrong. An inline handler such as `onclick=` or `style=` is an attribute value, and so is a `javascript:` URL, so those keep the entity.

`inscript_tag` already draws that line. It is set at the two sites that enter script from inside a tag, and at neither of the two that enter raw text. So the fix reads `inscript && !inscript_tag` and adds no new state. That matters here, because a missed assignment site is exactly what put a P0 in #1581.

The test drives all seven contexts, with a different query letter pair in each so no assertion can pass for another. The markup cases sit after the script and style blocks, which catches a fix that stops escaping and never resumes.

Five wrong fixes were built and run against it, and all five fail. They are never raw, which is master, always raw, `inscript` alone, `!inscript_tag` alone, and the inverted condition. Each of the middle three breaks one direction only.

On excalidraw's shipped bundle this removes the last of the four damage classes. Against the served bytes the mirror now matches on all three counts: no `&amp;` where there were eight, seven `split("/")` calls, and no injected `index.html`.