### PR TITLE
Each clause of #1605's shutdown guard can be deleted with no test noticing

### DIFF
--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -12587,21 +12587,25 @@ static hts_boolean st_backstop_arm(httrackp *opt, struct_back *sback,
    capped mirror can end through the link loop before either sweep runs
    (htscore.c, on back_checkmirror), and the partial is on disk just the same.
    Returns 77 on an allocation failure, as st_backstop() does. */
-static int st_backstop_shutdown(httrackp *opt) {
+static int st_backstop_check_shutdown(httrackp *opt) {
+  /* back_delete_all() raises the flag only for a live slot writing a file of
+     its own, so each row below drops one of those three conditions. */
   static const struct {
     const char *what;
     int status;
-    short is_write;
+    hts_boolean is_write;
     const char *url_sav;
     hts_boolean kept;
-  } shutdown[] = {
-      {"a partial file", STATUS_TRANSFER, 1, "hts-backstop-selftest.tmp",
-       HTS_TRUE},
-      {"a .delayed placeholder", STATUS_TRANSFER, 1,
-       "hts-backstop-selftest.tmp." DELAYED_EXT, HTS_FALSE},
-      {"a slot writing nothing to disk", STATUS_TRANSFER, 0, "", HTS_FALSE},
-      {"a slot no longer live", STATUS_FREE, 1, "hts-backstop-selftest.tmp",
-       HTS_FALSE}};
+  } shutdown[] = {{"a slot already finished", STATUS_READY, HTS_TRUE,
+                   "hts-backstop-selftest.tmp", HTS_FALSE},
+                  {"an FTP slot its worker owns", STATUS_FTP_TRANSFER, HTS_TRUE,
+                   "hts-backstop-selftest.tmp", HTS_FALSE},
+                  {"a slot writing nothing to disk", STATUS_TRANSFER, HTS_FALSE,
+                   "", HTS_FALSE},
+                  {"a .delayed placeholder", STATUS_TRANSFER, HTS_TRUE,
+                   "hts-backstop-selftest.tmp." DELAYED_EXT, HTS_FALSE},
+                  {"a partial file", STATUS_TRANSFER, HTS_TRUE,
+                   "hts-backstop-selftest.tmp", HTS_TRUE}};
 
   int err = 0;
   size_t c;
@@ -12610,8 +12614,10 @@ static int st_backstop_shutdown(httrackp *opt) {
     struct_back *shut = back_new(opt, 1);
     cache_back shutcache;
 
-    if (shut == NULL)
+    if (shut == NULL) {
+      printf("backstop: SKIP (no slot table for the shutdown cases)\n");
       return 77;
+    }
     memset(&shutcache, 0, sizeof(shutcache));
     shutcache.hashtable = coucal_new(0);
     shut->lnk[0].status = shutdown[c].status;
@@ -12855,7 +12861,7 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
     HTS_STAT.HTS_TOTAL_RECV = recv_was;
   }
   if (!err) {
-    const int rc = st_backstop_shutdown(opt);
+    const int rc = st_backstop_check_shutdown(opt);
 
     if (rc == 77) {
       skipped = 1;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -12546,8 +12546,8 @@ static void st_backstop_slot(struct_back *sback, int p, int status,
 /* A network that rejects TEST-NET-1 instead of dropping it answers in ms. */
 #define ST_BACKSTOP_SETTLE_MS 500
 
-/* Bytes the size cap allows. back_maxsize_grace() spares the transfers already
-   running for another tenth of it, so the cases below spell that tenth out. */
+/* Bytes the size cap allows. back_maxsize_grace() spares running transfers a
+   further tenth, so the past-grace case below doubles it. */
 #define ST_BACKSTOP_CAP 1000
 
 /* Refill every slot: a fresh pending connect for each state that owns a socket,
@@ -12581,6 +12581,56 @@ static hts_boolean st_backstop_arm(httrackp *opt, struct_back *sback,
     }
   }
   return HTS_TRUE;
+}
+
+/* back_delete_all(), the shutdown every exit reaches, on its own slot table. A
+   capped mirror can end through the link loop before either sweep runs
+   (htscore.c, on back_checkmirror), and the partial is on disk just the same.
+   Returns 77 on an allocation failure, as st_backstop() does. */
+static int st_backstop_shutdown(httrackp *opt) {
+  static const struct {
+    const char *what;
+    int status;
+    short is_write;
+    const char *url_sav;
+    hts_boolean kept;
+  } shutdown[] = {
+      {"a partial file", STATUS_TRANSFER, 1, "hts-backstop-selftest.tmp",
+       HTS_TRUE},
+      {"a .delayed placeholder", STATUS_TRANSFER, 1,
+       "hts-backstop-selftest.tmp." DELAYED_EXT, HTS_FALSE},
+      {"a slot writing nothing to disk", STATUS_TRANSFER, 0, "", HTS_FALSE},
+      {"a slot no longer live", STATUS_FREE, 1, "hts-backstop-selftest.tmp",
+       HTS_FALSE}};
+
+  int err = 0;
+  size_t c;
+
+  for (c = 0; c < sizeof(shutdown) / sizeof(shutdown[0]) && !err; c++) {
+    struct_back *shut = back_new(opt, 1);
+    cache_back shutcache;
+
+    if (shut == NULL)
+      return 77;
+    memset(&shutcache, 0, sizeof(shutcache));
+    shutcache.hashtable = coucal_new(0);
+    shut->lnk[0].status = shutdown[c].status;
+    shut->lnk[0].r.soc = INVALID_SOCKET;
+    shut->lnk[0].r.is_write = shutdown[c].is_write;
+    strcpybuff(shut->lnk[0].url_sav, shutdown[c].url_sav);
+    opt->abort_left_partial = HTS_FALSE;
+
+    back_delete_all(opt, &shutcache, shut);
+
+    if (opt->abort_left_partial != shutdown[c].kept) {
+      printf("  FAIL line %d: %s must %s the resume data at shutdown\n",
+             __LINE__, shutdown[c].what, shutdown[c].kept ? "keep" : "drop");
+      err = 1;
+    }
+    back_free(&shut);
+    coucal_delete(&shutcache.hashtable);
+  }
+  return err;
 }
 
 /* A user stop must drop every slot but the FTP one (#1073, #1110). */
@@ -12804,32 +12854,14 @@ static int st_backstop(httrackp *opt, int argc, char **argv) {
     opt->maxsite = 0;
     HTS_STAT.HTS_TOTAL_RECV = recv_was;
   }
-  /* back_delete_all(), the shutdown every exit reaches. A capped mirror can end
-     through the link loop before either sweep runs (htscore.c, on
-     back_checkmirror), and the partial is on disk just the same. Its own slot
-     table, so the fixture above is not torn down early. */
   if (!err) {
-    struct_back *shut = back_new(opt, 1);
+    const int rc = st_backstop_shutdown(opt);
 
-    if (shut == NULL) {
-      err = 1;
-    } else {
-      cache_back shutcache;
-
-      memset(&shutcache, 0, sizeof(shutcache));
-      shutcache.hashtable = coucal_new(0);
-      shut->lnk[0].status = STATUS_TRANSFER;
-      shut->lnk[0].r.soc = INVALID_SOCKET;
-      shut->lnk[0].r.is_write = 1;
-      strcpybuff(shut->lnk[0].url_sav, "hts-backstop-selftest.tmp");
-      opt->abort_left_partial = HTS_FALSE;
-
-      back_delete_all(opt, &shutcache, shut);
-
-      CHECK(opt->abort_left_partial);
-      back_free(&shut);
-      coucal_delete(&shutcache.hashtable);
+    if (rc == 77) {
+      skipped = 1;
+      goto cleanup;
     }
+    err = rc;
   }
 #undef CHECK
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -12589,23 +12589,29 @@ static hts_boolean st_backstop_arm(httrackp *opt, struct_back *sback,
    Returns 77 on an allocation failure, as st_backstop() does. */
 static int st_backstop_check_shutdown(httrackp *opt) {
   /* back_delete_all() raises the flag only for a live slot writing a file of
-     its own, so each row below drops one of those three conditions. */
+     its own. back_is_live() is a RANGE, 0 < status < STATUS_FTP_TRANSFER, so
+     the rows walk it: one on each side, and two inside it far enough apart that
+     narrowing the range to its first status fails. */
   static const struct {
     const char *what;
     int status;
     hts_boolean is_write;
     const char *url_sav;
     hts_boolean kept;
-  } shutdown[] = {{"a slot already finished", STATUS_READY, HTS_TRUE,
+  } shutdown[] = {{"a free slot", STATUS_FREE, HTS_TRUE,
                    "hts-backstop-selftest.tmp", HTS_FALSE},
-                  {"an FTP slot its worker owns", STATUS_FTP_TRANSFER, HTS_TRUE,
+                  {"a slot already finished", STATUS_READY, HTS_TRUE,
+                   "hts-backstop-selftest.tmp", HTS_FALSE},
+                  {"an FTP slot", STATUS_FTP_TRANSFER, HTS_TRUE,
                    "hts-backstop-selftest.tmp", HTS_FALSE},
                   {"a slot writing nothing to disk", STATUS_TRANSFER, HTS_FALSE,
                    "", HTS_FALSE},
                   {"a .delayed placeholder", STATUS_TRANSFER, HTS_TRUE,
                    "hts-backstop-selftest.tmp." DELAYED_EXT, HTS_FALSE},
                   {"a partial file", STATUS_TRANSFER, HTS_TRUE,
-                   "hts-backstop-selftest.tmp", HTS_TRUE}};
+                   "hts-backstop-selftest.tmp", HTS_TRUE},
+                  {"a partial file awaiting its next chunk", STATUS_CHUNK_WAIT,
+                   HTS_TRUE, "hts-backstop-selftest.tmp", HTS_TRUE}};
 
   int err = 0;
   size_t c;

--- a/tests/444_local-stop-keeps-resume.test
+++ b/tests/444_local-stop-keeps-resume.test
@@ -124,10 +124,9 @@ assert_kept drop drop "hts-cache/ref was erased under a stop that cut a body mid
     fail "a stop that did not ask to keep the resume data logged the abort banner"
 echo "PASS"
 
-# A cap past its grace tears down the transfers the grace spared, through the
-# same teardown a stop uses, so it leaves the same partials and keeps the same
-# byte ranges (#1595). The mirror ended where the user asked, but the file it
-# was fetching did not.
+# A cap past its grace uses the same teardown a stop does, so it leaves the same
+# partials and byte ranges (#1595). The mirror ended where the user asked, but
+# the file it was fetching did not.
 printf '[a --max-time cap keeps it too] ..\t'
 assert_kept maxtime maxtime "hts-cache/ref was erased under the engine's own cap stop"
 echo "PASS"
@@ -151,9 +150,9 @@ got=$(wc -c <"$blob")
 test "$got" -eq "$full" || fail "blob.bin is ${got} bytes, expected ${full}"
 echo "PASS (resumed at ${at} of ${full})"
 
-# The control, on the run that just finished: it wrote blob.bin to disk, so it
-# had a ref of its own to erase, and nothing cut it short. Without this the arms
-# above would pass on a fix that simply stopped erasing.
+# The run that just finished wrote blob.bin, so it had a ref of its own to erase
+# and nothing cut it short. Without this control, the arms above would pass on a
+# fix that simply stopped erasing.
 printf '[the completed --continue erases the directory again] ..\t'
 test ! -d "${out}/hts-cache/ref" ||
     fail "hts-cache/ref survived a mirror nothing interrupted"


### PR DESCRIPTION
#1605 taught `back_delete_all()` to keep `hts-cache/ref` for a slot still writing at shutdown, guarded by three clauses. Each one can be deleted on its own and nothing goes red: not the `is_write` test, not `back_is_live()`, not the `.delayed` test. So the guard that decides whether a run keeps its resume data rests on nothing.

`444`'s `--max-time` arm cannot close that. A capped mirror ends through whichever of two exits sees the overrun first. One is `back_wait()` running `back_abort_limit()`, the other is the link loop in `htscore.c`, and the arm passes when either raises the flag. It cannot tell the shutdown loop from the sweep. With the loop deleted it went red on two runs in three here, not every time.

`st_backstop_check_shutdown()` drives `back_delete_all()` over seven slot shapes and names the two that must keep the resume data. Each of the three mutants above dies on its own row.

Deleting `back_is_live()` was never the risk worth pinning. Weakening it is, and the first two drafts of this table missed six ways to do that. `back_is_live()` is a range, `0 < status < STATUS_FTP_TRANSFER`, and a table that pins only its two endpoints leaves everything between 1 and 999 free. Narrowing the range to `STATUS_TRANSFER` alone drops the resume data of any chunked transfer, and passed. The rows now walk the range instead.

Lifting it out of `st_backstop()` is the other half. That function carried six blocks, a `CHECK` macro, a `goto cleanup` protocol and a slot table. The shutdown case added a second slot table and a second cache beside the first. An allocation failure there now answers 77 like its caller, rather than reporting a defect in what it was measuring.

Three comments are wrong or hard to read. One of them an earlier edit on this branch made false, by doubling the cap instead of adding a tenth.

Follow-up to #1605, which merged before this review round finished.