### PR TITLE
A script link like "/#top" is no longer rewritten, so it breaks in the mirror

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -1744,9 +1744,14 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                             if ((!strchr(tempo, ' ')) || inscript) {    // espace dedans: méfiance! (sauf dans code javascript)
                               int invalid_url = 0;
 
-                              /* The cut below erases the '#' or '?' that says
-                                 this string is a URL. */
-                              int had_fragment_or_query = 0;
+                              /* A '#' or '?' right after a slash opens a
+                                 fragment or a query. Read the source bytes,
+                                 because unescape_amp turns "&#35;" into a '#'
+                                 no script wrote. */
+                              size_t cut = strcspn(tempo, "#?");
+                              int had_fragment_or_query = cut > 0 &&
+                                                          tempo[cut] != '\0' &&
+                                                          tempo[cut - 1] == '/';
 
                               // escape                              
                               unescape_amp(tempo);
@@ -1755,15 +1760,11 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                               {
                                 char *a = strchr(tempo, '#');
 
-                                if (a) {
+                                if (a)
                                   *a = '\0';
-                                  had_fragment_or_query = 1;
-                                }
                                 a = strchr(tempo, '?');
-                                if (a) {
+                                if (a)
                                   *a = '\0';
-                                  had_fragment_or_query = 1;
-                                }
                               }
 
                               // vérifier qu'il n'y a pas de caractères spéciaux
@@ -1799,7 +1800,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                     /* A trailing slash alone is no evidence
                                        inside a script, where "/" and "image/"
                                        are ordinary strings. A second segment
-                                       is, and so is a fragment or query. */
+                                       is evidence, and so is a fragment or a
+                                       query. */
                                     if (inscript &&
                                         (had_fragment_or_query ||
                                          link_dir_is_multisegment(tempo)))

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -1744,6 +1744,10 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                             if ((!strchr(tempo, ' ')) || inscript) {    // espace dedans: méfiance! (sauf dans code javascript)
                               int invalid_url = 0;
 
+                              /* The cut below erases the '#' or '?' that says
+                                 this string is a URL. */
+                              int had_fragment_or_query = 0;
+
                               // escape                              
                               unescape_amp(tempo);
 
@@ -1751,11 +1755,15 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                               {
                                 char *a = strchr(tempo, '#');
 
-                                if (a)
+                                if (a) {
                                   *a = '\0';
+                                  had_fragment_or_query = 1;
+                                }
                                 a = strchr(tempo, '?');
-                                if (a)
+                                if (a) {
                                   *a = '\0';
+                                  had_fragment_or_query = 1;
+                                }
                               }
 
                               // vérifier qu'il n'y a pas de caractères spéciaux
@@ -1790,9 +1798,11 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                            '/') {       // un slash: ok..
                                     /* A trailing slash alone is no evidence
                                        inside a script, where "/" and "image/"
-                                       are ordinary strings. */
+                                       are ordinary strings. A second segment
+                                       is, and so is a fragment or query. */
                                     if (inscript &&
-                                        link_dir_is_multisegment(tempo))
+                                        (had_fragment_or_query ||
+                                         link_dir_is_multisegment(tempo)))
                                       url_ok = 1;
                                   }
                                 }

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -1746,8 +1746,8 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
 
                               /* Ask before the cut destroys the evidence
                                  and unescape_amp forges it. */
-                              int had_fragment_or_query =
-                                  link_dir_has_fragment(tempo);
+                              hts_boolean had_fragment_or_query =
+                                  link_dir_has_fragment_or_query(tempo);
 
                               // escape                              
                               unescape_amp(tempo);

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -1744,14 +1744,10 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                             if ((!strchr(tempo, ' ')) || inscript) {    // espace dedans: méfiance! (sauf dans code javascript)
                               int invalid_url = 0;
 
-                              /* A '#' or '?' right after a slash opens a
-                                 fragment or a query. Read the source bytes,
-                                 because unescape_amp turns "&#35;" into a '#'
-                                 no script wrote. */
-                              size_t cut = strcspn(tempo, "#?");
-                              int had_fragment_or_query = cut > 0 &&
-                                                          tempo[cut] != '\0' &&
-                                                          tempo[cut - 1] == '/';
+                              /* Ask before the cut destroys the evidence
+                                 and unescape_amp forges it. */
+                              int had_fragment_or_query =
+                                  link_dir_has_fragment(tempo);
 
                               // escape                              
                               unescape_amp(tempo);

--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -1795,9 +1795,7 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
                                            '/') {       // un slash: ok..
                                     /* A trailing slash alone is no evidence
                                        inside a script, where "/" and "image/"
-                                       are ordinary strings. A second segment
-                                       is evidence, and so is a fragment or a
-                                       query. */
+                                       are ordinary strings. */
                                     if (inscript &&
                                         (had_fragment_or_query ||
                                          link_dir_is_multisegment(tempo)))

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6659,8 +6659,8 @@ static int st_linkdir(httrackp *opt, int argc, char **argv) {
 
   /* Each row is one string with the answer from
      link_dir_has_fragment_or_query, then from link_dir_is_multisegment. Both
-     are asked on the raw string, unlike the engine, which cuts at the marker
-     first. */
+     are asked on the raw string here. The engine asks the first on the raw
+     string too, but the second on what the marker cut left. */
   static const struct {
     const char *lien;
     hts_boolean frag_or_query;
@@ -6683,6 +6683,7 @@ static int st_linkdir(httrackp *opt, int argc, char **argv) {
       {"a/b/#x", HTS_TRUE, HTS_TRUE},
       /* the marker must open a path, not follow a name or nothing */
       {"page.html#x", HTS_FALSE, HTS_FALSE},
+      {"page.html?q=1", HTS_FALSE, HTS_FALSE},
       {"#top", HTS_FALSE, HTS_FALSE},
       {"?q=1", HTS_FALSE, HTS_FALSE},
       {"", HTS_FALSE, HTS_FALSE},

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6638,53 +6638,70 @@ static int st_postfile(httrackp *opt, int argc, char **argv) {
   return err;
 }
 
+/* Names the string on failure, since a bare line number cannot say which row
+   went red. */
+static void st_linkdir_case(const char *lien, hts_boolean frag_or_query,
+                            hts_boolean multisegment) {
+  const hts_boolean got_frag = link_dir_has_fragment_or_query(lien);
+  const hts_boolean got_multi = link_dir_is_multisegment(lien);
+
+  if (got_frag != frag_or_query || got_multi != multisegment) {
+    fprintf(stderr,
+            "linkdir \"%s\": fragment %d multisegment %d, wanted %d and %d\n",
+            lien, got_frag, got_multi, frag_or_query, multisegment);
+    assertf(!"linkdir case failed");
+  }
+}
+
 static int st_linkdir(httrackp *opt, int argc, char **argv) {
   size_t i;
 
-  /* Each row states what the two helpers answer for one string. The engine
-     asks link_dir_has_fragment_or_query first, on the source bytes, and
-     link_dir_is_multisegment later, on the string the fragment cut left. */
+  /* Each row states what the two helpers answer for one string, in the order
+     the engine asks them: link_dir_has_fragment_or_query on the source bytes,
+     then link_dir_is_multisegment on what the fragment cut left. */
   static const struct {
     const char *lien;
+    hts_boolean frag_or_query;
     hts_boolean multisegment;
-    hts_boolean fragment;
   } cases[] = {
-      /* what #1612 refused, and still must */
+      /* #1612 refused these, and still must */
       {"/", HTS_FALSE, HTS_FALSE},
       {"image/", HTS_FALSE, HTS_FALSE},
       {"Alt+/", HTS_FALSE, HTS_FALSE},
       {"$&/", HTS_FALSE, HTS_FALSE},
       {"////", HTS_FALSE, HTS_FALSE},
       /* a second segment is evidence on its own */
-      {"a/b/", HTS_TRUE, HTS_FALSE},
-      {"/api/v1/", HTS_TRUE, HTS_FALSE},
-      /* the site root and a named directory, both with a marker */
-      {"/#top", HTS_FALSE, HTS_TRUE},
-      {"/?q=1", HTS_FALSE, HTS_TRUE},
-      {"img/#x", HTS_FALSE, HTS_TRUE},
-      {"img/?q=1", HTS_FALSE, HTS_TRUE},
+      {"a/b/", HTS_FALSE, HTS_TRUE},
+      {"/api/v1/", HTS_FALSE, HTS_TRUE},
+      /* the site root and a named directory both carry a marker */
+      {"/#top", HTS_TRUE, HTS_FALSE},
+      {"/?q=1", HTS_TRUE, HTS_FALSE},
+      {"img/#x", HTS_TRUE, HTS_FALSE},
+      {"img/?q=1", HTS_TRUE, HTS_FALSE},
+      {"a/b/#x", HTS_TRUE, HTS_TRUE},
       /* the marker must open a path, not follow a name or nothing */
       {"page.html#x", HTS_FALSE, HTS_FALSE},
+      {"page.html?q=1", HTS_FALSE, HTS_FALSE},
       {"#top", HTS_FALSE, HTS_FALSE},
       {"?q=1", HTS_FALSE, HTS_FALSE},
       {"", HTS_FALSE, HTS_FALSE},
       /* a run of slashes carries no name, so the marker buys nothing */
-      {"////#x", HTS_TRUE, HTS_FALSE},
-      {"//#x", HTS_TRUE, HTS_FALSE},
+      {"////#x", HTS_FALSE, HTS_TRUE},
+      {"//#x", HTS_FALSE, HTS_TRUE},
       /* an entity before the marker decodes into an earlier one */
-      {"//&num;/#x", HTS_TRUE, HTS_FALSE},
+      {"//&num;/#x", HTS_FALSE, HTS_TRUE},
       {"/&#35;", HTS_FALSE, HTS_FALSE},
       {"a&b/#x", HTS_FALSE, HTS_FALSE},
       /* an '&' after the marker is part of the query, so it is left alone */
-      {"/?a=1&b=2", HTS_FALSE, HTS_TRUE},
+      {"/?a=1&b=2", HTS_TRUE, HTS_FALSE},
   };
 
   (void) opt;
   (void) argc;
   (void) argv;
   for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
-    assertf(link_dir_is_multisegment(cases[i].lien) == cases[i].multisegment);
-    assertf(link_dir_has_fragment_or_query(cases[i].lien) == cases[i].fragment);
+    st_linkdir_case(cases[i].lien, cases[i].frag_or_query,
+                    cases[i].multisegment);
   }
   printf("linkdir self-test OK\n");
   return 0;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -60,6 +60,7 @@ Please visit our Website: http://www.httrack.com
 #include "htscoremain.h"
 #include "htsencoding.h"
 #include "htsescape.h"
+#include "htstools.h"
 #include "htsftp.h"
 #include "htsmd5.h"
 #include "htssniff.h"
@@ -6635,6 +6636,58 @@ static int st_postfile(httrackp *opt, int argc, char **argv) {
 
   printf("postfile self-test: %s\n", err ? "FAIL" : "OK");
   return err;
+}
+
+static int st_linkdir(httrackp *opt, int argc, char **argv) {
+  size_t i;
+
+  /* Each row states what the two helpers answer for one string. The engine
+     asks link_dir_has_fragment_or_query first, on the source bytes, and
+     link_dir_is_multisegment later, on the string the fragment cut left. */
+  static const struct {
+    const char *lien;
+    hts_boolean multisegment;
+    hts_boolean fragment;
+  } cases[] = {
+      /* what #1612 refused, and still must */
+      {"/", HTS_FALSE, HTS_FALSE},
+      {"image/", HTS_FALSE, HTS_FALSE},
+      {"Alt+/", HTS_FALSE, HTS_FALSE},
+      {"$&/", HTS_FALSE, HTS_FALSE},
+      {"////", HTS_FALSE, HTS_FALSE},
+      /* a second segment is evidence on its own */
+      {"a/b/", HTS_TRUE, HTS_FALSE},
+      {"/api/v1/", HTS_TRUE, HTS_FALSE},
+      /* the site root and a named directory, both with a marker */
+      {"/#top", HTS_FALSE, HTS_TRUE},
+      {"/?q=1", HTS_FALSE, HTS_TRUE},
+      {"img/#x", HTS_FALSE, HTS_TRUE},
+      {"img/?q=1", HTS_FALSE, HTS_TRUE},
+      /* the marker must open a path, not follow a name or nothing */
+      {"page.html#x", HTS_FALSE, HTS_FALSE},
+      {"#top", HTS_FALSE, HTS_FALSE},
+      {"?q=1", HTS_FALSE, HTS_FALSE},
+      {"", HTS_FALSE, HTS_FALSE},
+      /* a run of slashes carries no name, so the marker buys nothing */
+      {"////#x", HTS_TRUE, HTS_FALSE},
+      {"//#x", HTS_TRUE, HTS_FALSE},
+      /* an entity before the marker decodes into an earlier one */
+      {"//&num;/#x", HTS_TRUE, HTS_FALSE},
+      {"/&#35;", HTS_FALSE, HTS_FALSE},
+      {"a&b/#x", HTS_FALSE, HTS_FALSE},
+      /* an '&' after the marker is part of the query, so it is left alone */
+      {"/?a=1&b=2", HTS_FALSE, HTS_TRUE},
+  };
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+  for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+    assertf(link_dir_is_multisegment(cases[i].lien) == cases[i].multisegment);
+    assertf(link_dir_has_fragment_or_query(cases[i].lien) == cases[i].fragment);
+  }
+  printf("linkdir self-test OK\n");
+  return 0;
 }
 
 static int st_addrport(httrackp *opt, int argc, char **argv) {
@@ -14632,6 +14685,10 @@ static const struct selftest_entry {
     {"scantoken", "",
      "option-string token copy is bounded and reports a refusal (#1271)",
      st_scantoken},
+    {"linkdir", "",
+     "a quoted directory string is a link only with a second segment, or a "
+     "fragment or query opening right after the path",
+     st_linkdir},
     {"addrport", "",
      "\"host:port\" of a peer address is bounded and complete (#1493)",
      st_addrport},

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -6646,9 +6646,10 @@ static void st_linkdir_case(const char *lien, hts_boolean frag_or_query,
   const hts_boolean got_multi = link_dir_is_multisegment(lien);
 
   if (got_frag != frag_or_query || got_multi != multisegment) {
-    fprintf(stderr,
-            "linkdir \"%s\": fragment %d multisegment %d, wanted %d and %d\n",
-            lien, got_frag, got_multi, frag_or_query, multisegment);
+    fprintf(
+        stderr,
+        "linkdir \"%s\": fragment %d wanted %d, multisegment %d wanted %d\n",
+        lien, got_frag, frag_or_query, got_multi, multisegment);
     assertf(!"linkdir case failed");
   }
 }
@@ -6656,9 +6657,10 @@ static void st_linkdir_case(const char *lien, hts_boolean frag_or_query,
 static int st_linkdir(httrackp *opt, int argc, char **argv) {
   size_t i;
 
-  /* Each row states what the two helpers answer for one string, in the order
-     the engine asks them: link_dir_has_fragment_or_query on the source bytes,
-     then link_dir_is_multisegment on what the fragment cut left. */
+  /* Each row is one string with the answer from
+     link_dir_has_fragment_or_query, then from link_dir_is_multisegment. Both
+     are asked on the raw string, unlike the engine, which cuts at the marker
+     first. */
   static const struct {
     const char *lien;
     hts_boolean frag_or_query;
@@ -6673,7 +6675,7 @@ static int st_linkdir(httrackp *opt, int argc, char **argv) {
       /* a second segment is evidence on its own */
       {"a/b/", HTS_FALSE, HTS_TRUE},
       {"/api/v1/", HTS_FALSE, HTS_TRUE},
-      /* the site root and a named directory both carry a marker */
+      /* a marker opens a path, from the site root to a deeper one */
       {"/#top", HTS_TRUE, HTS_FALSE},
       {"/?q=1", HTS_TRUE, HTS_FALSE},
       {"img/#x", HTS_TRUE, HTS_FALSE},
@@ -6681,7 +6683,6 @@ static int st_linkdir(httrackp *opt, int argc, char **argv) {
       {"a/b/#x", HTS_TRUE, HTS_TRUE},
       /* the marker must open a path, not follow a name or nothing */
       {"page.html#x", HTS_FALSE, HTS_FALSE},
-      {"page.html?q=1", HTS_FALSE, HTS_FALSE},
       {"#top", HTS_FALSE, HTS_FALSE},
       {"?q=1", HTS_FALSE, HTS_FALSE},
       {"", HTS_FALSE, HTS_FALSE},

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -401,6 +401,15 @@ hts_boolean link_dir_is_multisegment(const char *lien) {
   return (slashes >= 2 && other != 0) ? HTS_TRUE : HTS_FALSE;
 }
 
+hts_boolean link_dir_has_fragment(const char *lien) {
+  const size_t cut = strcspn(lien, "#?");
+
+  if (cut == 0 || lien[cut] == '\0' || lien[cut - 1] != '/')
+    return HTS_FALSE;
+  /* "/" is the site root, and anything longer needs a name. */
+  return (cut == 1 || strspn(lien, "/") < cut) ? HTS_TRUE : HTS_FALSE;
+}
+
 int link_has_authorization(const char *lien) {
   const char *adr = jump_protocol_const(lien);
   const char *firstslash = strchr(adr, '/');

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -402,8 +402,7 @@ hts_boolean link_dir_is_multisegment(const char *lien) {
 }
 
 hts_boolean link_dir_has_fragment_or_query(const char *lien) {
-  /* Stop at '&' as well, because an entity before the marker decodes into an
-     earlier one, and unescape_amp would then cut where this never looked. */
+  /* A '&' before the marker may decode into an earlier one, so answer no. */
   const size_t cut = strcspn(lien, "#?&");
 
   if (cut == 0 || lien[cut] == '\0' || lien[cut] == '&' || lien[cut - 1] != '/')

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -401,7 +401,7 @@ hts_boolean link_dir_is_multisegment(const char *lien) {
   return (slashes >= 2 && other != 0) ? HTS_TRUE : HTS_FALSE;
 }
 
-hts_boolean link_dir_has_fragment(const char *lien) {
+hts_boolean link_dir_has_fragment_or_query(const char *lien) {
   const size_t cut = strcspn(lien, "#?");
 
   if (cut == 0 || lien[cut] == '\0' || lien[cut - 1] != '/')

--- a/src/htstools.c
+++ b/src/htstools.c
@@ -402,9 +402,11 @@ hts_boolean link_dir_is_multisegment(const char *lien) {
 }
 
 hts_boolean link_dir_has_fragment_or_query(const char *lien) {
-  const size_t cut = strcspn(lien, "#?");
+  /* Stop at '&' as well, because an entity before the marker decodes into an
+     earlier one, and unescape_amp would then cut where this never looked. */
+  const size_t cut = strcspn(lien, "#?&");
 
-  if (cut == 0 || lien[cut] == '\0' || lien[cut - 1] != '/')
+  if (cut == 0 || lien[cut] == '\0' || lien[cut] == '&' || lien[cut - 1] != '/')
     return HTS_FALSE;
   /* "/" is the site root, and anything longer needs a name. */
   return (cut == 1 || strspn(lien, "/") < cut) ? HTS_TRUE : HTS_FALSE;

--- a/src/htstools.h
+++ b/src/htstools.h
@@ -77,9 +77,9 @@ hts_boolean link_base_is_hostname(const char *lien);
    that way too. A second slash is. */
 hts_boolean link_dir_is_multisegment(const char *lien);
 /* Does a fragment or a query open right after a directory path? True for
-   "/#top" and "img/#x". False for "page.html#x", whose marker follows a name,
-   and for "////#x", which carries no name. Pass the source bytes, because
-   unescape_amp turns "&#35;" into a '#' no script wrote. */
+   "/#top" and "img/#x". False for "page.html#x", for "////#x" which has no
+   name, and for "//&num;/#x" where an entity hides an earlier marker. Pass
+   the source bytes, because unescape_amp forges a '#' out of "&#35;". */
 hts_boolean link_dir_has_fragment_or_query(const char *lien);
 int link_has_authorization(const char *lien);
 void long_to_83(int mode, char *n83, size_t n83size, char *save);

--- a/src/htstools.h
+++ b/src/htstools.h
@@ -77,10 +77,10 @@ hts_boolean link_base_is_hostname(const char *lien);
    that way too. A second slash is. */
 hts_boolean link_dir_is_multisegment(const char *lien);
 /* Does a fragment or a query open right after a directory path? True for
-   "/#top" and "img/#x", false for "////#x", which carries no name. Pass the
-   source bytes, because unescape_amp turns "&#35;" into a '#' no script
-   wrote. */
-hts_boolean link_dir_has_fragment(const char *lien);
+   "/#top" and "img/#x". False for "page.html#x", whose marker follows a name,
+   and for "////#x", which carries no name. Pass the source bytes, because
+   unescape_amp turns "&#35;" into a '#' no script wrote. */
+hts_boolean link_dir_has_fragment_or_query(const char *lien);
 int link_has_authorization(const char *lien);
 void long_to_83(int mode, char *n83, size_t n83size, char *save);
 void longfile_to_83(int mode, char *n83, size_t n83size, char *save);

--- a/src/htstools.h
+++ b/src/htstools.h
@@ -76,6 +76,11 @@ hts_boolean link_base_is_hostname(const char *lien);
    in a slash is no evidence alone, because "/", "image/" and "$&/" all end
    that way too. A second slash is. */
 hts_boolean link_dir_is_multisegment(const char *lien);
+/* Does a fragment or a query open right after a directory path? True for
+   "/#top" and "img/#x", false for "////#x", which carries no name. Pass the
+   source bytes, because unescape_amp turns "&#35;" into a '#' no script
+   wrote. */
+hts_boolean link_dir_has_fragment(const char *lien);
 int link_has_authorization(const char *lien);
 void long_to_83(int mode, char *n83, size_t n83size, char *save);
 void longfile_to_83(int mode, char *n83, size_t n83size, char *save);

--- a/tests/01_engine-linkdir.test
+++ b/tests/01_engine-linkdir.test
@@ -2,10 +2,11 @@
 #
 # Pins link_dir_is_multisegment and link_dir_has_fragment_or_query, the pair
 # that decides whether a quoted directory string inside a script is a link.
-# A crawl cannot reach every clause: "page.html#x" never gets that far, because
-# the caller only asks once the cut string already ends in a slash.
+# A crawl calls both on anything quoted, but reads the answer only once the cut
+# string ends in a slash, so it cannot tell a wrong verdict on "page.html#x"
+# from a right one.
 
-set -eu
+set -euo pipefail
 
 out=$(httrack -#test=linkdir) || {
     echo "httrack -#test=linkdir exited non-zero: $out" >&2

--- a/tests/01_engine-linkdir.test
+++ b/tests/01_engine-linkdir.test
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Pins link_dir_is_multisegment and link_dir_has_fragment_or_query, the pair
+# that decides whether a quoted directory string inside a script is a link.
+# A crawl cannot reach every clause: "page.html#x" never gets that far, because
+# the caller only asks once the cut string already ends in a slash.
+
+set -eu
+
+out=$(httrack -#test=linkdir) || {
+    echo "httrack -#test=linkdir exited non-zero: $out" >&2
+    exit 1
+}
+
+test "$out" = "linkdir self-test OK" || {
+    echo "expected 'linkdir self-test OK', got: $out" >&2
+    exit 1
+}

--- a/tests/457_local-js-string-separator.test
+++ b/tests/457_local-js-string-separator.test
@@ -27,9 +27,9 @@ cat >"$root/index.html" <<'EOF'
 <body><div data-x="deep/sub/">x</div></body></html>
 EOF
 
-# Each string below holds a slash near its end, and its trailing comment names
-# what decides whether httrack may follow it. The last line repeats a refusal
-# after the followed ones, so a flag that leaks between strings is caught.
+# Every string below ends in a slash once any fragment or query is cut. Its
+# trailing comment names what decides whether httrack may follow it. The last
+# line repeats a refusal after the followed ones, so a leaking flag shows.
 cat >"$root/app.js" <<'EOF'
 var parts = "a/b".split("/");        // one slash: kept
 var mime = "image/";                 // one slash: kept
@@ -37,8 +37,9 @@ var key = "Alt+/";                   // one slash: kept
 var rep = "ab".replace(/b/, "$&/");  // one slash: kept
 var runs = "////";                   // no name, only slashes: kept
 var ent = "a/b".split("/&num;");     // an entity is not a fragment: kept
-var num = "a/b".split("/&#35;");     // nor is a numeric one: kept
+var num = "a/b".split("/&#35;");     // nor a numeric entity: kept
 var only = "////#x";                 // a fragment, but no name: kept
+var anch = "#top";                   // no slash before it at all: kept
 var one = "subdir/";                 // one slash: kept, so never fetched
 var two = "a/b/";                    // two slashes, short name: followed
 var api = "/api/v1/";                // three slashes: followed
@@ -55,10 +56,11 @@ for d in subdir a/b api/v1 assets/img cdir fragdir deep/sub; do
 done
 
 # The cdir case cannot fail on the helper, since CSS url() reaches the parser by
-# another path. A fix that drops the inscript test is caught by the data-x
-# attribute, because outside a script a two-segment string must stay put.
-# The three index*.html matches pin the rewritten form, where "/" becomes the
-# mirror's root page and may gain a collision suffix.
+# another path. The data-x attribute catches a fix that drops the inscript test,
+# because outside a script a two-segment string must stay put. The two index*
+# matches pin the rewritten form, where "/" becomes the mirror's root page and
+# may gain a collision suffix. The anch case reaches the leading-marker path,
+# where the sanitizer legs catch a dropped length guard.
 bash "$top_srcdir/tests/local-crawl.sh" --root "$root" --errors 0 \
     --file-matches 'app.js' 'split\("/"\)' \
     --file-matches 'app.js' '"image/"' \
@@ -68,6 +70,7 @@ bash "$top_srcdir/tests/local-crawl.sh" --root "$root" --errors 0 \
     --file-matches 'app.js' 'split\("/&num;"\)' \
     --file-matches 'app.js' 'split\("/&#35;"\)' \
     --file-matches 'app.js' '"////#x"' \
+    --file-matches 'app.js' '"#top"' \
     --file-matches 'app.js' '"index[^"]*\.html#top"' \
     --file-matches 'app.js' '"index[^"]*\.html\?q=1"' \
     --file-matches 'app.js' '"fragdir/index\.html#x"' \

--- a/tests/457_local-js-string-separator.test
+++ b/tests/457_local-js-string-separator.test
@@ -2,7 +2,8 @@
 #
 # A quoted string ending in a slash counted as a directory link inside a script,
 # so httrack rewrote JavaScript's own separators. split("/") became
-# split("index-2.html") and the mirrored bundle behaved differently.
+# split("index-2.html") and the mirrored bundle behaved differently. Requiring a
+# second slash then stopped rewriting "/#top" and "/?q=1", which are URLs.
 
 set -euo pipefail
 
@@ -15,15 +16,17 @@ work=$(mktemp -d)
 trap 'set +e; rm -rf "$work"' EXIT
 
 root="$work/root"
-mkdir -p "$root/subdir" "$root/a/b" "$root/api/v1" "$root/assets/img" "$root/cdir"
+mkdir -p "$root/subdir" "$root/a/b" "$root/api/v1" "$root/assets/img" "$root/cdir" \
+    "$root/fragdir"
 
 cat >"$root/index.html" <<'EOF'
 <!DOCTYPE html><html><head><link rel="stylesheet" href="s.css">
 <script src="app.js"></script></head><body>x</body></html>
 EOF
 
-# Every string below ends in a slash. Only a path of more than one segment may
-# be followed, so each line carries the count that decides it.
+# Every string below ends in a slash, or in a fragment or query that follows
+# one. On the slash alone only a path of more than one segment may be followed,
+# so each line carries what decides it.
 cat >"$root/app.js" <<'EOF'
 var parts = "a/b".split("/");        // one slash: kept
 var mime = "image/";                 // one slash: kept
@@ -34,10 +37,13 @@ var one = "subdir/";                 // one slash: kept, so never fetched
 var two = "a/b/";                    // two slashes, short name: followed
 var api = "/api/v1/";                // three slashes: followed
 var ast = "assets/img/";             // two slashes: followed
+var frag = "/#top";                  // one slash, but a fragment: followed
+var qry = "/?q=1";                   // one slash, but a query: followed
+var rel = "fragdir/#x";              // one slash, but a fragment: followed
 EOF
 
 echo '.a { background: url("cdir/"); }' >"$root/s.css"
-for d in subdir a/b api/v1 assets/img cdir; do
+for d in subdir a/b api/v1 assets/img cdir fragdir; do
     printf 'reached\n' >"$root/$d/index.html"
 done
 
@@ -49,9 +55,13 @@ bash "$top_srcdir/tests/local-crawl.sh" --root "$root" --errors 0 \
     --file-matches 'app.js' '"Alt\+/"' \
     --file-matches 'app.js' '"\$&/"' \
     --file-matches 'app.js' '"////"' \
+    --file-matches 'app.js' '"index[^"]*\.html#top"' \
+    --file-matches 'app.js' '"index[^"]*\.html\?q=1"' \
+    --file-matches 'app.js' '"fragdir/index\.html#x"' \
     --not-found subdir/index.html \
     --found a/b/index.html \
     --found api/v1/index.html \
     --found assets/img/index.html \
     --found cdir/index.html \
+    --found fragdir/index.html \
     httrack BASEURL/index.html -q -%v0 -r4

--- a/tests/457_local-js-string-separator.test
+++ b/tests/457_local-js-string-separator.test
@@ -40,6 +40,7 @@ var ent = "a/b".split("/&num;");     // an entity is not a fragment: kept
 var num = "a/b".split("/&#35;");     // nor a numeric entity: kept
 var only = "////#x";                 // a fragment, but no name: kept
 var anch = "#top";                   // no slash before it at all: kept
+var forge = "//&num;/#x";            // an entity hides an earlier marker: kept
 var one = "subdir/";                 // one slash: kept, so never fetched
 var two = "a/b/";                    // two slashes, short name: followed
 var api = "/api/v1/";                // three slashes: followed
@@ -47,6 +48,7 @@ var ast = "assets/img/";             // two slashes: followed
 var frag = "/#top";                  // one slash, but a fragment: followed
 var qry = "/?q=1";                   // one slash, but a query: followed
 var rel = "fragdir/#x";              // a directory and a fragment: followed
+var amp = "/?a=1&b=2";               // the & sits inside the query: followed
 var late = "audio/";                 // one slash, and last of all: kept
 EOF
 
@@ -71,6 +73,8 @@ bash "$top_srcdir/tests/local-crawl.sh" --root "$root" --errors 0 \
     --file-matches 'app.js' 'split\("/&#35;"\)' \
     --file-matches 'app.js' '"////#x"' \
     --file-matches 'app.js' '"#top"' \
+    --file-matches 'app.js' '"//&num;/#x"' \
+    --file-matches 'app.js' '"index[^"]*\.html\?a=1&b=2"' \
     --file-matches 'app.js' '"index[^"]*\.html#top"' \
     --file-matches 'app.js' '"index[^"]*\.html\?q=1"' \
     --file-matches 'app.js' '"fragdir/index\.html#x"' \

--- a/tests/457_local-js-string-separator.test
+++ b/tests/457_local-js-string-separator.test
@@ -38,6 +38,7 @@ var rep = "ab".replace(/b/, "$&/");  // one slash: kept
 var runs = "////";                   // no name, only slashes: kept
 var ent = "a/b".split("/&num;");     // an entity is not a fragment: kept
 var num = "a/b".split("/&#35;");     // nor is a numeric one: kept
+var only = "////#x";                 // a fragment, but no name: kept
 var one = "subdir/";                 // one slash: kept, so never fetched
 var two = "a/b/";                    // two slashes, short name: followed
 var api = "/api/v1/";                // three slashes: followed
@@ -66,6 +67,7 @@ bash "$top_srcdir/tests/local-crawl.sh" --root "$root" --errors 0 \
     --file-matches 'app.js' '"////"' \
     --file-matches 'app.js' 'split\("/&num;"\)' \
     --file-matches 'app.js' 'split\("/&#35;"\)' \
+    --file-matches 'app.js' '"////#x"' \
     --file-matches 'app.js' '"index[^"]*\.html#top"' \
     --file-matches 'app.js' '"index[^"]*\.html\?q=1"' \
     --file-matches 'app.js' '"fragdir/index\.html#x"' \

--- a/tests/457_local-js-string-separator.test
+++ b/tests/457_local-js-string-separator.test
@@ -3,7 +3,9 @@
 # A quoted string ending in a slash counted as a directory link inside a script,
 # so httrack rewrote JavaScript's own separators. split("/") became
 # split("index-2.html") and the mirrored bundle behaved differently. Requiring a
-# second slash then stopped rewriting "/#top" and "/?q=1", which are URLs.
+# second slash then stopped rewriting "/#top" and "/?q=1", which are URLs. The
+# evidence must come from the source bytes, because unescape_amp decodes
+# "&num;" to a '#' before the parser looks.
 
 set -euo pipefail
 
@@ -17,48 +19,60 @@ trap 'set +e; rm -rf "$work"' EXIT
 
 root="$work/root"
 mkdir -p "$root/subdir" "$root/a/b" "$root/api/v1" "$root/assets/img" "$root/cdir" \
-    "$root/fragdir"
+    "$root/fragdir" "$root/deep/sub"
 
 cat >"$root/index.html" <<'EOF'
 <!DOCTYPE html><html><head><link rel="stylesheet" href="s.css">
-<script src="app.js"></script></head><body>x</body></html>
+<script src="app.js"></script></head>
+<body><div data-x="deep/sub/">x</div></body></html>
 EOF
 
-# Every string below ends in a slash, or in a fragment or query that follows
-# one. On the slash alone only a path of more than one segment may be followed,
-# so each line carries what decides it.
+# Each string below holds a slash near its end, and its trailing comment names
+# what decides whether httrack may follow it. The last line repeats a refusal
+# after the followed ones, so a flag that leaks between strings is caught.
 cat >"$root/app.js" <<'EOF'
 var parts = "a/b".split("/");        // one slash: kept
 var mime = "image/";                 // one slash: kept
 var key = "Alt+/";                   // one slash: kept
 var rep = "ab".replace(/b/, "$&/");  // one slash: kept
 var runs = "////";                   // no name, only slashes: kept
+var ent = "a/b".split("/&num;");     // an entity is not a fragment: kept
+var num = "a/b".split("/&#35;");     // nor is a numeric one: kept
 var one = "subdir/";                 // one slash: kept, so never fetched
 var two = "a/b/";                    // two slashes, short name: followed
 var api = "/api/v1/";                // three slashes: followed
 var ast = "assets/img/";             // two slashes: followed
 var frag = "/#top";                  // one slash, but a fragment: followed
 var qry = "/?q=1";                   // one slash, but a query: followed
-var rel = "fragdir/#x";              // one slash, but a fragment: followed
+var rel = "fragdir/#x";              // a directory and a fragment: followed
+var late = "audio/";                 // one slash, and last of all: kept
 EOF
 
 echo '.a { background: url("cdir/"); }' >"$root/s.css"
-for d in subdir a/b api/v1 assets/img cdir fragdir; do
+for d in subdir a/b api/v1 assets/img cdir fragdir deep/sub; do
     printf 'reached\n' >"$root/$d/index.html"
 done
 
 # The cdir case cannot fail on the helper, since CSS url() reaches the parser by
-# another path. It is here to catch a fix that drops the inscript test instead.
+# another path. A fix that drops the inscript test is caught by the data-x
+# attribute, because outside a script a two-segment string must stay put.
+# The three index*.html matches pin the rewritten form, where "/" becomes the
+# mirror's root page and may gain a collision suffix.
 bash "$top_srcdir/tests/local-crawl.sh" --root "$root" --errors 0 \
     --file-matches 'app.js' 'split\("/"\)' \
     --file-matches 'app.js' '"image/"' \
     --file-matches 'app.js' '"Alt\+/"' \
     --file-matches 'app.js' '"\$&/"' \
     --file-matches 'app.js' '"////"' \
+    --file-matches 'app.js' 'split\("/&num;"\)' \
+    --file-matches 'app.js' 'split\("/&#35;"\)' \
     --file-matches 'app.js' '"index[^"]*\.html#top"' \
     --file-matches 'app.js' '"index[^"]*\.html\?q=1"' \
     --file-matches 'app.js' '"fragdir/index\.html#x"' \
+    --file-matches 'app.js' '"audio/"' \
+    --file-matches 'index.html' 'data-x="deep/sub/"' \
     --not-found subdir/index.html \
+    --not-found deep/sub/index.html \
     --found a/b/index.html \
     --found api/v1/index.html \
     --found assets/img/index.html \


### PR DESCRIPTION
After #1612 a script string needs two slashes to count as a URL. That also drops `"/#top"`, `"/?q=1"`, `"/#"` and `"/?"`, whose only slash is the leading one. The parser cuts the fragment and the query earlier in the same block, so `link_dir_is_multisegment` never sees them. Those links stay verbatim in the mirror and do not resolve under `file://`.

`link_dir_has_fragment_or_query` covers the case `link_dir_is_multisegment` misses. A fragment or a query counts only when it opens right after a directory path. That means the site root, or a name ending in a slash.

The rule reads the source bytes before `unescape_amp` runs, and the scan stops at `&` and refuses it. Nothing before the marker can then be an entity, so that prefix survives decoding byte for byte. The string the cut yields is the string the helper read. A `&` after the marker is untouched, so `"/?a=1&b=2"` is still followed.

Three natural variants are wrong. Reading the marker off the cut turns `"a/b".split("/&num;")` into `split("%23.html")`. Dropping the name test costs `split("////#")` a slash. Keeping a real marker while an entity hides an earlier one turns `"//&num;/#x"` into `"http://#/#x"`.

On excalidraw's 2.1 MB bundle the mirrored file is byte-identical to master's. A pre-#1612 build differs from it in 44 places, so the comparison can see the damage it checks for. Twelve wrong fixes fail test 457 and nine fail `-#test=linkdir`. That self-test states what both helpers answer for twenty-three strings, generated from the spec rather than typed. Two more, each dropping the length guard, fail under the sanitizer legs.