### PR TITLE
Nothing counts the workers the WSL2 suite loses

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -383,6 +383,16 @@ jobs:
           wsl -d httrack-suite -- sh -c 'echo "ws=[$HTS_WS] bin=[$HTS_BIN]"; test -d "$HTS_WS/tests" || { echo "::error::$HTS_WS/tests is not visible in the distro"; exit 1; }'
           wsl -d httrack-suite -- sh -c 'cd "$HTS_WS/tests" && exec bash ./ci-windows-suite.sh "$HTS_BIN"' 2>&1 | tee suite-console-wsl2.log
 
+      # Its own step: the watchdog can kill the suite's step before it counts,
+      # which is exactly when the count is worth having (#1588).
+      - name: Count the workers the suite lost
+        if: always()
+        shell: bash
+        working-directory: tests
+        run: |
+          . ./ci-windows-suite.sh
+          ci_report_lost_workers suite-console-wsl2.log
+
       # The engine ships ~90 tests and none had ever run on Windows: "make check"
       # is Linux/macOS only. These are the offline ones, run against the native
       # httrack.exe. The *_local-* ones crawl the bundled Python server over

--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -309,13 +309,20 @@ def runs_suite(s):
 for _run, _want in [("bash ./ci-windows-suite.sh $dir", True),
                     ('bash "$GITHUB_WORKSPACE/tests/ci-windows-suite.sh" $dir', True),
                     ("bash ci-windows-suite.sh $dir", True),
-                    (". ./ci-windows-suite.sh\nci_report_fork_failures x.log", False),
+                    (". ./ci-windows-suite.sh\nci_report_lost_workers x.log", False),
                     ("source ./ci-windows-suite.sh", False)]:
     if runs_suite({"run": _run}) is not _want:
         sys.exit("the suite-step matcher is wrong for: %r" % _run)
 
 def suite_steps(wf):
     return [s for s in steps_of(wf) if runs_suite(s)]
+
+# The step that counts the lost workers off the console the suite teed (#1588). It is
+# not a suite step, so nothing above it looks at it.
+COUNT_RUN = re.compile(r"(?<![.\w])ci_report_lost_workers\b")
+
+def lost_count_steps(job):
+    return [s for s in (job.get("steps") or []) if COUNT_RUN.search(str(s.get("run", "")))]
 
 # These three grade the LAST suite step, which one leg cannot be. With a single
 # step [-1] is [0], so they edit the step they compare against and emit an
@@ -367,6 +374,14 @@ def audit(wf):
     if len(jobs) != 1 or not found:
         bad.append("%d jobs and %d steps run the suite, cannot tell which is watched" % (len(jobs), len(found)))
         return bad
+    # The suite's own tally dies with a step the watchdog killed, which is the run the
+    # count is for: a separate step reads the console back, and only if:always() runs it.
+    counters = lost_count_steps(jobs[0])
+    if len(counters) != 1:
+        bad.append("%d steps count the lost workers, want 1" % len(counters))
+    elif counters[0].get("if") != "always()":
+        bad.append("the lost-worker count does not run on a killed leg: if is %r"
+                   % counters[0].get("if"))
     perms = perms_of(wf, jobs[0])
     if perms.get("statuses") != "write":
         bad.append("the suite job cannot post a commit status: statuses is %r" % perms.get("statuses"))
@@ -423,6 +438,15 @@ def mutate(wf, kind):
         suite_steps(wf)[0]["env"]["WATCHDOG_URL"] = "${{ github.server_url }}"
     elif kind == "cap":
         suite_steps(wf)[0].pop("timeout-minutes")
+    elif kind == "nocount":
+        j = suite_jobs(wf)[0]
+        drop = {id(s) for s in lost_count_steps(j)}
+        j["steps"] = [s for s in j["steps"] if id(s) not in drop]
+    elif kind == "twocounts":
+        j = suite_jobs(wf)[0]
+        j["steps"].append(copy.deepcopy(lost_count_steps(j)[0]))
+    elif kind == "countif":
+        lost_count_steps(suite_jobs(wf)[0])[0].pop("if", None)
     elif kind != "none":
         raise SystemExit("unknown mutation " + kind)
     return wf
@@ -452,7 +476,9 @@ PY
         context:'does not name matrix.platform' url:'does not link the run' \
         cap:'no timeout-minutes of its own' lastenv:'WATCHDOG_TOKEN is' \
         sharedcontext:'share a WATCHDOG_CONTEXT' \
-        lasttimeout:'no timeout-minutes of its own'; do
+        lasttimeout:'no timeout-minutes of its own' \
+        nocount:'0 steps count the lost workers' twocounts:'2 steps count the lost workers' \
+        countif:'does not run on a killed leg'; do
         "$py" "$wfpy" mutate "$(nativepath "$workflow")" "${m%%:*}" >"$tmp/wf.yml"
         said=$("$py" "$wfpy" audit "$(nativepath "$tmp/wf.yml")") ||
             fail "the workflow audit did not run on the ${m%%:*} control: $said"

--- a/tests/337_ci-lost-worker.test
+++ b/tests/337_ci-lost-worker.test
@@ -2,8 +2,9 @@
 #
 # A worker of ci-windows-suite.sh that dies before writing any status (#1352): the
 # tally must call it lost rather than failed, and the suite must end on a status
-# that says re-run, not investigate. Driven here because the Windows leg, where it
-# happens, keeps no evidence of it.
+# that says re-run, not investigate. The workflow counts them again off the console
+# the step teed, for the runs the watchdog kills before that verdict (#1588). Driven
+# here because the Windows leg, where it happens, keeps no evidence of it.
 
 set -euo pipefail
 
@@ -168,6 +169,8 @@ run_suite "$tmp/ok"
 test "$rc" -eq 0 || fail "a clean stub suite exited $rc: $(<"$tmp/out")"
 grep -q "^ran=$ran pass=92 fail=0 skip=$nskip lost=0$" "$tmp/out" ||
     fail "clean tally: $(grep '^ran=' "$tmp/out" || true)"
+# A real console for the counter below, so a change to what the driver prints reaches it.
+cp "$tmp/out" "$tmp/console-clean.log"
 
 stage "$tmp/killed" "$killer"
 run_suite "$tmp/killed"
@@ -185,6 +188,7 @@ grep -q '::error::failing:' "$tmp/out" &&
     fail "a killed worker was reported as a failing test: $(<"$tmp/out")"
 # 3, so the workflow can tell a leg to repeat from a leg to investigate (#1228).
 test "$rc" -eq 3 || fail "a lost worker exited $rc, want 3: $(<"$tmp/out")"
+cp "$tmp/out" "$tmp/console-lost.log"
 
 # Again with the killer on one of the pinned skips. That run reaches the skip-set
 # gate, which exits before the lost gate unless it is told a vanished worker
@@ -222,5 +226,46 @@ grep -q '::error::failing: 900_zlib-pass.test' "$tmp/out" ||
 test "$rc" -eq 1 ||
     fail "a failure alongside a loss exited $rc, want 1: $(<"$tmp/out")"
 ok "a real failure outranks a lost worker"
+
+# --- and the count a later step makes off the console it left ----------------
+
+# The suite's own verdict is gone when the watchdog kills its step, so the workflow
+# counts again from the console the step teed.
+counted=''
+count_lost() { # count_lost <console log>
+    : >"$GITHUB_STEP_SUMMARY"
+    counted=$(ci_report_lost_workers "$1") || fail "counting $1 failed"
+}
+
+count_lost "$tmp/console-lost.log"
+grep -q '::error title=workers lost with no status::' <<<"$counted" ||
+    fail "a console with a lost worker raised no annotation: $counted"
+grep -q '1 worker(s) died before reporting' <<<"$counted" ||
+    fail "the count is wrong on a real lost-worker console: $counted"
+# Without a sample line the reader goes back to a log the runner may no longer have.
+grep -q 'LOST 906_engine-lost.test' <<<"$counted" ||
+    fail "the annotation quotes no LOST line: $counted"
+grep -q '^1 worker(s) lost with no status$' "$GITHUB_STEP_SUMMARY" ||
+    fail "step summary says $(<"$GITHUB_STEP_SUMMARY")"
+
+# A clean console still says so: a silent step and a broken counter read alike.
+count_lost "$tmp/console-clean.log"
+grep -q 'no lost worker in ' <<<"$counted" || fail "a clean console said: $counted"
+! grep -q '::error' <<<"$counted" || fail "a clean console raised an annotation: $counted"
+grep -q '^0 worker(s) lost with no status$' "$GITHUB_STEP_SUMMARY" ||
+    fail "a clean console wrote no count: $(<"$GITHUB_STEP_SUMMARY")"
+
+# Two verdicts joined by a CR, since the console is stdout and stderr merged, and
+# two decoys the driver itself can print: a failure tail is indented.
+printf 'LOST a.test (worker left no status; no log at all)\rLOST b.test (worker left no status; no log at all)\n    LOST c.test\nthe test printed LOST d.test\n' \
+    >"$tmp/console-cr.log"
+count_lost "$tmp/console-cr.log"
+grep -q '2 worker(s) died before reporting' <<<"$counted" ||
+    fail "the CR-joined console counted wrong: $counted"
+
+# The suite step can die before writing a log; the counter step still runs.
+count_lost "$tmp/console-absent.log"
+grep -q 'not counted' <<<"$counted" || fail "a missing log said: $counted"
+ok "the console count matches what the suite lost"
 
 echo "lost-worker classification OK"

--- a/tests/337_ci-lost-worker.test
+++ b/tests/337_ci-lost-worker.test
@@ -169,7 +169,7 @@ run_suite "$tmp/ok"
 test "$rc" -eq 0 || fail "a clean stub suite exited $rc: $(<"$tmp/out")"
 grep -q "^ran=$ran pass=92 fail=0 skip=$nskip lost=0$" "$tmp/out" ||
     fail "clean tally: $(grep '^ran=' "$tmp/out" || true)"
-# A real console for the counter below, so a change to what the driver prints reaches it.
+# A whole healthy run for the counter below: no LOST line, and a tally saying lost=0.
 cp "$tmp/out" "$tmp/console-clean.log"
 
 stage "$tmp/killed" "$killer"
@@ -188,6 +188,7 @@ grep -q '::error::failing:' "$tmp/out" &&
     fail "a killed worker was reported as a failing test: $(<"$tmp/out")"
 # 3, so the workflow can tell a leg to repeat from a leg to investigate (#1228).
 test "$rc" -eq 3 || fail "a lost worker exited $rc, want 3: $(<"$tmp/out")"
+# And a run one worker short: one LOST verdict, and a tally saying lost=1.
 cp "$tmp/out" "$tmp/console-lost.log"
 
 # Again with the killer on one of the pinned skips. That run reaches the skip-set
@@ -233,8 +234,12 @@ ok "a real failure outranks a lost worker"
 # counts again from the console the step teed.
 counted=''
 count_lost() { # count_lost <console log>
+    local crc=0
     : >"$GITHUB_STEP_SUMMARY"
-    counted=$(ci_report_lost_workers "$1") || fail "counting $1 failed"
+    counted=$(ci_report_lost_workers "$1") || crc=$?
+    # The step runs under if:always() in an errexit shell, so any non-zero here reds
+    # a leg whose suite was healthy. The two guard arms at the end exercise it.
+    test "$crc" -eq 0 || fail "counting $1 exited $crc: $counted"
 }
 
 count_lost "$tmp/console-lost.log"
@@ -263,9 +268,66 @@ count_lost "$tmp/console-cr.log"
 grep -q '2 worker(s) died before reporting' <<<"$counted" ||
     fail "the CR-joined console counted wrong: $counted"
 
+# More than two, so a counter that clamps is not green here. The watchdog killed this
+# step, so there is no tally, and the third verdict is joined onto a failure tail that
+# ends mid-line: a test killed on its budget leaves its log that way, and sed keeps it.
+lostline='(worker left no status; no log at all)'
+{
+    echo "LOST 900_a.test $lostline"
+    echo "      a failure tail of the test that ran out of budget"
+    echo "LOST 901_b.test $lostline"
+    printf '      and this tail ends with no newline at all'
+    echo "LOST 902_c.test $lostline"
+    echo "LOST 903_d.test $lostline"
+} >"$tmp/console-join.log"
+count_lost "$tmp/console-join.log"
+grep -q '4 worker(s) died before reporting' <<<"$counted" ||
+    fail "a killed step's console counted wrong: $counted"
+grep -q '^4 worker(s) lost with no status$' "$GITHUB_STEP_SUMMARY" ||
+    fail "the killed step's count did not reach the summary: $(<"$GITHUB_STEP_SUMMARY")"
+
+# The mirror image, on one verdict: a bare CR inside an indented tail puts the word at
+# a line head, and a test can print it in prose. Neither carries the rest of a verdict.
+{
+    echo "LOST 904_e.test $lostline"
+    printf '      progress 99%%\rLOST 905_f.test\n'
+    echo "the test printed LOST 906_g.test"
+} >"$tmp/console-decoy.log"
+count_lost "$tmp/console-decoy.log"
+grep -q '1 worker(s) died before reporting' <<<"$counted" ||
+    fail "the decoys were counted as verdicts: $counted"
+
+# Where the two disagree the tally wins, since the suite counted its own workers. No
+# driver writes this console: the disagreement is what says which side was read.
+{
+    echo "LOST 907_h.test $lostline"
+    echo "LOST 908_i.test $lostline"
+    printf '      one more tail with no final newline'
+    echo "ran=100 pass=90 fail=2 skip=0 lost=8"
+} >"$tmp/console-tally.log"
+count_lost "$tmp/console-tally.log"
+grep -q '8 worker(s) died before reporting' <<<"$counted" ||
+    fail "the count did not come from the tally the suite wrote: $counted"
+grep -q '^8 worker(s) lost with no status$' "$GITHUB_STEP_SUMMARY" ||
+    fail "the tally count did not reach the summary: $(<"$GITHUB_STEP_SUMMARY")"
+
 # The suite step can die before writing a log; the counter step still runs.
 count_lost "$tmp/console-absent.log"
 grep -q 'not counted' <<<"$counted" || fail "a missing log said: $counted"
+
+# Neither a summary the runner refuses nor a log path that is a directory may red a
+# step that runs on every leg. Both would, since GitHub's bash carries errexit.
+crc=0
+counted=$(GITHUB_STEP_SUMMARY="$tmp" ci_report_lost_workers "$tmp/console-clean.log") || crc=$?
+test "$crc" -eq 0 || fail "an unappendable step summary made the counter exit $crc"
+grep -q '::warning::the lost-worker count did not reach the step summary' <<<"$counted" ||
+    fail "an unappendable step summary was not reported: $counted"
+grep -q 'no lost worker in ' <<<"$counted" ||
+    fail "the count is gone when the summary cannot take it: $counted"
+crc=0
+counted=$(ci_report_lost_workers "$tmp") || crc=$?
+test "$crc" -eq 0 || fail "a log path that is a directory made the counter exit $crc"
+grep -q 'not counted' <<<"$counted" || fail "a directory as the log said: $counted"
 ok "the console count matches what the suite lost"
 
 echo "lost-worker classification OK"

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -51,6 +51,33 @@ ci_lost_reason() {
     fi
 }
 
+# Count the workers the suite lost in console log $1, and say so when it lost none:
+# a silent step and a broken counter read alike (#1352). The suite names them itself,
+# so this is the count for a run whose step the watchdog killed before it could.
+ci_report_lost_workers() {
+    local log=$1 lost
+    test -r "$log" || {
+        echo "no console log at $log: lost workers not counted"
+        return 0
+    }
+    # Split on CR first: this console is stdout and stderr merged, so two messages
+    # can share a physical line and a line count would see one. Anchored, because
+    # the suite's indented failure tails quote a LOST line too.
+    lost=$(tr '\r' '\n' <"$log" | awk '/^LOST /{n++} END{print n + 0}')
+    test -z "${GITHUB_STEP_SUMMARY:-}" ||
+        printf '%s worker(s) lost with no status\n' "$lost" >>"$GITHUB_STEP_SUMMARY"
+    if test "$lost" -eq 0; then
+        echo "no lost worker in $log"
+    else
+        # error, not warning: a leg that lost a worker is one to re-run.
+        ci_annotate error "workers lost with no status" "$(
+            printf '%s worker(s) died before reporting: re-run this leg, and see #1228\n' "$lost"
+            # -a: one NUL in the log would otherwise cost every sample line.
+            tr '\r' '\n' <"$log" | grep -am 3 '^LOST ' || true
+        )"
+    fi
+}
+
 # End a wedged suite before its runner dies: a step that fails on its own terms
 # keeps its log, a lost runner keeps nothing, annotations included (#795). Quiet
 # for $1s, then names the test in flight from $3 every $2s; kills $5 once $3 has

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -51,29 +51,57 @@ ci_lost_reason() {
     fi
 }
 
+# Every LOST verdict in console log $1, one per line. Matched by the whole shape the
+# suite prints: a test killed on its budget leaves its log mid-line, so its indented
+# failure tail joins the next verdict onto itself, and a tail can quote the bare word.
+ci_lost_verdicts() {
+    awk '{
+        while (match($0, /LOST [^ ]+ \(worker left no status;[^)]*\)/)) {
+            print substr($0, RSTART, RLENGTH)
+            $0 = substr($0, RSTART + RLENGTH)
+        }
+    }' "$1"
+}
+
+# The lost count the suite itself wrote into console log $1, empty when the console
+# carries no tally. Anchored at the end of the line only, since an unterminated
+# failure tail can carry a prefix onto it, and the last match wins.
+ci_console_lost_tally() {
+    tr -d '\r' <"$1" | awk '
+        match($0, /ran=[0-9]+ pass=[0-9]+ fail=[0-9]+ skip=[0-9]+ lost=[0-9]+$/) {
+            n = substr($0, RSTART, RLENGTH)
+            sub(/.*lost=/, "", n)
+        }
+        END { print n }'
+}
+
 # Count the workers the suite lost in console log $1, and say so when it lost none:
-# a silent step and a broken counter read alike (#1352). The suite names them itself,
-# so this is the count for a run whose step the watchdog killed before it could.
+# a silent step and a broken counter read alike (#1352). Nothing here may fail: the
+# step runs under if:always() in an errexit shell, so a non-zero reds a healthy leg.
 ci_report_lost_workers() {
-    local log=$1 lost
-    test -r "$log" || {
+    local log=$1 lost samples
+    # -f as well as -r, because awk on a directory exits non-zero.
+    if test ! -f "$log" || test ! -r "$log"; then
         echo "no console log at $log: lost workers not counted"
         return 0
-    }
-    # Split on CR first: this console is stdout and stderr merged, so two messages
-    # can share a physical line and a line count would see one. Anchored, because
-    # the suite's indented failure tails quote a LOST line too.
-    lost=$(tr '\r' '\n' <"$log" | awk '/^LOST /{n++} END{print n + 0}')
-    test -z "${GITHUB_STEP_SUMMARY:-}" ||
-        printf '%s worker(s) lost with no status\n' "$lost" >>"$GITHUB_STEP_SUMMARY"
+    fi
+    samples=$(ci_lost_verdicts "$log")
+    lost=$(ci_console_lost_tally "$log")
+    # No tally means the watchdog killed the step before the suite's own verdict,
+    # which is the run this count exists for: take what it had printed by then.
+    test -n "$lost" || lost=$(printf '%s' "$samples" | awk 'NF { n++ } END { print n + 0 }')
+    if test -n "${GITHUB_STEP_SUMMARY:-}"; then
+        # A summary file the runner will not take is not a suite failure.
+        printf '%s worker(s) lost with no status\n' "$lost" >>"$GITHUB_STEP_SUMMARY" 2>/dev/null ||
+            echo "::warning::the lost-worker count did not reach the step summary"
+    fi
     if test "$lost" -eq 0; then
         echo "no lost worker in $log"
     else
         # error, not warning: a leg that lost a worker is one to re-run.
         ci_annotate error "workers lost with no status" "$(
             printf '%s worker(s) died before reporting: re-run this leg, and see #1228\n' "$lost"
-            # -a: one NUL in the log would otherwise cost every sample line.
-            tr '\r' '\n' <"$log" | grep -am 3 '^LOST ' || true
+            test -z "$samples" || printf '%s\n' "$samples" | awk 'NR <= 3'
         )"
     fi
 }


### PR DESCRIPTION
The WSL2 suite step tees its console to `suite-console-wsl2.log` and nothing reads that file. The driver names a vanished worker itself and exits 3. The wedge watchdog can kill the step before it gets that far, which is when the count is worth having. The MSYS leg had a step for it, and #1585 retired both.

`ci_report_lost_workers` counts the `LOST` verdicts in a console log, writes one line to the step summary and raises an error annotation with sample lines. Only the lost-worker half comes back, because the fork-emulation half counted MSYS lines a Linux shell cannot produce.

The test goes in `337_ci-lost-worker.test` rather than a new file. That test already kills a worker for real, so the counter reads a console the driver wrote instead of an invented one.

Closes #1588
