### PR TITLE
Test 24 cannot interrupt its first pass on Windows, so it skips there

### DIFF
--- a/tests/24_local-resume-overlap.test
+++ b/tests/24_local-resume-overlap.test
@@ -31,10 +31,9 @@ common=(-O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 --re
 refdir="${out}/hts-cache/ref"
 
 # pass 1: interrupt once flaky.bin's prefix is streaming (partial + temp-ref).
-# The stop is hts-abort.lock, the file a running engine polls for (436), not a
-# signal: no signal a WSL2 shell sends reaches a native httrack.exe, and taskkill
-# /F takes away the temp-ref pass 2 resumes from. Every backend takes that path,
-# so the Linux leg exercises what Windows runs.
+# The stop is hts-abort.lock, the file a running engine polls for (436). No
+# signal a WSL2 shell sends reaches a native httrack.exe, so every backend takes
+# that path and the Linux leg exercises what Windows runs.
 printf '[pass 1: interrupt flaky.bin] ..\t'
 httrack "${common[@]}" "${BASEURL}/overlap/index.html" >"${tmpdir}/log1" 2>&1 &
 crawlpid=$!
@@ -44,8 +43,7 @@ wait_until "test -s '$counter' && test -e '${out}/hts-in_progress.lock'" \
 # in whole seconds, so wait one out before writing it.
 sleep 1.1
 : >"${out}/hts-abort.lock"
-# Well inside --timeout=30: past that the stalled fetch ends on its own and the
-# mirror runs to a normal finish, which is not the state pass 2 needs.
+# This 10s wait stays inside --timeout=30, so the fetch is still stalled.
 wait_until "test ! -e '${out}/hts-abort.lock'" \
     "10s on, the engine had not read the stop request" 100
 # Unwinding a transfer cut mid-socket takes a while, as it does in 436.

--- a/tests/24_local-resume-overlap.test
+++ b/tests/24_local-resume-overlap.test
@@ -10,11 +10,6 @@ set -eu
 # shellcheck source=tests/crawllib.sh
 . "${0%"${0##*/}"}./crawllib.sh"
 
-# No graceful stop crosses the boundary: a Linux signal reaches the interop
-# relay, and taskkill /F reaches the engine too hard to let pass 1 write the
-# temp-ref pass 2 resumes from. The spike left that gap open deliberately.
-test "$(suite_backend)" != wsl2 ||
-    skip "no graceful stop reaches a Windows exe from a WSL2 shell"
 root=$(nativepath "${testdir}/server-root")
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/httrack_198.XXXXXX") || exit 1
@@ -36,24 +31,25 @@ common=(-O "$out" --quiet --disable-security-limits --robots=0 --timeout=30 --re
 refdir="${out}/hts-cache/ref"
 
 # pass 1: interrupt once flaky.bin's prefix is streaming (partial + temp-ref).
+# The stop is hts-abort.lock, the file a running engine polls for (436), not a
+# signal: no signal a WSL2 shell sends reaches a native httrack.exe, and taskkill
+# /F takes away the temp-ref pass 2 resumes from. Every backend takes that path,
+# so the Linux leg exercises what Windows runs.
 printf '[pass 1: interrupt flaky.bin] ..\t'
 httrack "${common[@]}" "${BASEURL}/overlap/index.html" >"${tmpdir}/log1" 2>&1 &
 crawlpid=$!
-for _ in $(seq 1 300); do
-    test -s "$counter" && break
-    kill -0 "$crawlpid" 2>/dev/null || break
-    sleep 0.1
-done
-sleep 0.5
-# A Linux signal reaches the wsl2 interop relay, not the engine, and a pass 1
-# that runs on finishes the very fetch pass 2 has to resume.
-# The backend, not the binary: MSYS signals the engine directly and pass 1 gets
-# to write its temp-ref, so the harder kill_tree there takes it away.
-if test "$(suite_backend)" = wsl2; then
-    kill_tree "$crawlpid"
-else
-    kill -TERM "$crawlpid" 2>/dev/null || true
-fi
+wait_until "test -s '$counter' && test -e '${out}/hts-in_progress.lock'" \
+    "the crawl never reached flaky.bin"
+# The engine honours a request only when it is newer than its own progress lock,
+# in whole seconds, so wait one out before writing it.
+sleep 1.1
+: >"${out}/hts-abort.lock"
+# Well inside --timeout=30: past that the stalled fetch ends on its own and the
+# mirror runs to a normal finish, which is not the state pass 2 needs.
+wait_until "test ! -e '${out}/hts-abort.lock'" \
+    "10s on, the engine had not read the stop request" 100
+# Unwinding a transfer cut mid-socket takes a while, as it does in 436.
+wait_until "! kill -0 '$crawlpid' 2>/dev/null" "the engine never shut down" 900
 wait "$crawlpid" 2>/dev/null || true
 crawlpid=
 test -n "$(find "$refdir" -name '*.ref' 2>/dev/null)" || fail "no temp-ref survived pass 1; cannot drive the resume"

--- a/tests/420_ci-windows-skip-backend.test
+++ b/tests/420_ci-windows-skip-backend.test
@@ -27,12 +27,13 @@ ci_expected_skips_for_backend wsl2 || fail "wsl2 was rejected as an unknown back
 test "$ci_skip_list" = "$expected_skips_wsl2" || fail "wsl2 did not select its own list"
 
 # --- the lists' CONTENT, not just which one is chosen ---------------------
-# A spot-check of the names that moved, not of all 29: a rename inside the part
-# no row pins is caught by the driver's own set compare on a live Windows leg,
-# and neither can see a listed test that in fact runs.
+# A spot-check of the names that moved, not of every entry: a rename inside the
+# part no row pins is caught by the driver's own set compare on a live Windows
+# leg, and neither can see a listed test that in fact runs.
 # 420 compared each list against itself, so editing either one stayed green.
-# "neither" is a name that left a list: 386 ran once python stopped bypassing
-# the shim, and nothing must put it back without measuring it again.
+# "neither" is a name that left a list, and nothing must put one back without
+# measuring it again: 386 ran once python stopped bypassing the shim, and 24
+# once its pass-1 interrupt went through hts-abort.lock instead of a signal.
 ci_expected_skips_for_backend msys || fail "msys was rejected"
 msys_list=$ci_skip_list
 ci_expected_skips_for_backend wsl2 || fail "wsl2 was rejected"
@@ -69,7 +70,7 @@ while read -r name where; do
 done <<'EOF'
 386_local-proxytrack-dav-tz.test neither
 294_local-wizard-eof.test wsl2-only
-24_local-resume-overlap.test wsl2-only
+24_local-resume-overlap.test neither
 241_local-single-file-gui.test both
 288_testlib-holdport.test both
 EOF

--- a/tests/436_local-abort-lock.test
+++ b/tests/436_local-abort-lock.test
@@ -26,14 +26,6 @@ cleanup_push cleanup
 # root runner cannot walk through.
 chmod 0755 "$tmpdir"
 
-wait_until() { # wait_until <shell condition> <message> [tenths, default 300]
-    for _ in $(seq 1 "${3:-300}"); do
-        if eval "$1"; then return 0; fi
-        sleep 0.1
-    done
-    fail "$2"
-}
-
 stop_crawl() {
     if test -n "$crawlpid"; then
         kill -9 "$crawlpid" 2>/dev/null || true

--- a/tests/445_local-lockfile-visibility.test
+++ b/tests/445_local-lockfile-visibility.test
@@ -2,7 +2,7 @@
 # A running engine takes a request as a file in its output directory. Under the
 # wsl2 backend the shell that writes one is Linux and the engine that reads it is
 # a native exe on the other side of drvfs, and nothing had measured that crossing.
-# 24_local-resume-overlap.test cannot be ported to that backend until it holds.
+# 24_local-resume-overlap.test now cuts its pass 1 through that crossing.
 set -eu
 
 # shellcheck source=tests/crawllib.sh

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -242,12 +242,11 @@ expected_skips_msys="01_engine-footer-overflow.test
 # Written out rather than derived from the msys list above: the two lists are
 # pinned expectations of different shells, and a name leaving one has to be a
 # visible edit to the other.
-# The reasons above, plus what the Linux shell cannot do to a native process:
-# 294: the wizard's feof||ferror arm never fires on a stdin the Linux shell owns
-# across interop, so it spins to the watchdog; 296 passes with a real answer
+# The reasons above, plus the one thing the Linux shell cannot do to a native
+# process: 294's wizard never reaches its feof||ferror arm on a stdin that shell
+# owns across interop, so it spins to the watchdog; 296 passes with a real answer
 # file, which places the fault at EOF and closed stdin rather than the wizard.
-# 24: no graceful stop crosses the boundary, so pass 1 cannot be interrupted in
-# the state the resume needs. Each of these two skips itself, in the test.
+# 294 skips itself, in the test.
 expected_skips_wsl2="01_engine-footer-overflow.test
 253_local-ftp-close-once.test
 113_engine-threadattr-leak.test
@@ -280,8 +279,7 @@ expected_skips_wsl2="01_engine-footer-overflow.test
 424_engine-wizard-eof.test
 444_local-stop-keeps-resume.test
 451_local-sigint-keeps-resume.test
-294_local-wizard-eof.test
-24_local-resume-overlap.test"
+294_local-wizard-eof.test"
 
 # Sets ci_skip_list to the pinned skip set for backend $1, failing loudly if
 # there is none: an unknown backend must never fall back to an empty list,

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -84,6 +84,15 @@ assert_match() { # assert_match RE TEXT [LABEL]
 
 assert_file() { test -f "$1" || fail "${2:+$2: }missing file: $1"; }
 
+# Poll a condition, and name what never happened when it runs out.
+wait_until() { # wait_until CONDITION MESSAGE [tenths, default 300]
+    for _ in $(seq 1 "${3:-300}"); do
+        if eval "$1"; then return 0; fi
+        sleep 0.1
+    done
+    fail "$2"
+}
+
 # Basenames of the files a mirror wrote, so a check reads what was written
 # rather than a path this host may spell differently (macOS $TMPDIR, Windows
 # ':' -> '_').


### PR DESCRIPTION
Retiring the MSYS suite leg left `24_local-resume-overlap.test` skipping on wsl2. It cut pass 1 with SIGTERM, and no signal a Linux shell sends reaches a native `httrack.exe`. It now writes `hts-abort.lock`, the stop request a running engine polls for (#1549). Every backend takes that path, so the Linux leg runs what Windows runs, and 24 leaves the pinned wsl2 skip list.

The assertions are unchanged. An engine mutated back to the pre-#198 behavior writes 8017 bytes where `full.bin` has 8009. It fails the byte compare under the old test and the new one alike.

One thing only the wsl2 leg can settle. The fixture leaves pass 1 on a socket that has gone completely silent, where 436 measured the same crossing with a socket still dribbling bytes. If the engine does not read the request there, the test fails at "the engine had not read the stop request" instead of passing hollow.
