### PR TITLE
Dependabot bumps the vcpkg baseline backwards, so a security pin does not survive

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   # Bumps builtin-baseline in src/vcpkg.json so the pinned OpenSSL/zlib can't rot.
-  # windows-build.yml validates each bump; the pin makes what ships reproducible.
+  # windows-build.yml validates each bump, and the pin makes what ships
+  # reproducible. These are not auto-merged, because this ecosystem can bump the
+  # baseline backwards: see dependabot-automerge.yml.
   - package-ecosystem: vcpkg
     directory: /src
     schedule:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -22,10 +22,14 @@ jobs:
     # Checks the PR's author, not github.actor, because on a synchronize the actor is whoever
     # pushed, including a fork's own Dependabot. The head-repo clause has no witness while
     # only Dependabot's own PRs pass the author check, and is kept for if that ever loosens.
+    # Not vcpkg: its ecosystem tracks vcpkg's release tags, so a baseline pinned
+    # to a newer commit reads as behind and is "upgraded" backwards. That
+    # reverted a security pin unattended in #1614, so a human merges those.
     if: >-
       github.repository == 'xroche/httrack'
       && github.event.pull_request.user.login == 'dependabot[bot]'
       && github.event.pull_request.head.repo.full_name == github.repository
+      && !startsWith(github.event.pull_request.head.ref, 'dependabot/vcpkg/')
     runs-on: ubuntu-24.04
     steps:
       # Dependabot's body is a release-notes dump, so give the squash commit a body of its own.

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "libhttrack",
   "version-string": "3.50",
-  "builtin-baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
+  "builtin-baseline": "04a9d8e5212d01ee1dd9478eadd9caade4f8b0d4",
   "dependencies": [
     "brotli",
     "openssl",

--- a/tests/460_vcpkg-pin-not-automerged.test
+++ b/tests/460_vcpkg-pin-not-automerged.test
@@ -2,27 +2,54 @@
 #
 # Dependabot's vcpkg ecosystem tracks vcpkg's release tags, so a baseline pinned
 # to a newer commit reads as behind and is bumped backwards. #1614 reverted a
-# security pin that way, unattended, so those bumps must not auto-merge.
+# security pin that way, unattended, so those bumps must not auto-merge. The
+# gate only runs on GitHub, so this audits the condition rather than the merge.
 
 set -euo pipefail
 
 # shellcheck source=tests/testlib.sh
 . "${0%"${0##*/}"}./testlib.sh"
 
-: "${top_srcdir:=..}"
+top=${abs_top_srcdir:-$(cd "$testdir/.." && pwd)}
+wf="$top/.github/workflows/dependabot-automerge.yml"
 
-wf="$top_srcdir/.github/workflows/dependabot-automerge.yml"
-[ -r "$wf" ] || fail "cannot read $wf"
+if ! test -r "$wf"; then
+    test -d "$top/.github" && fail "$wf is gone but $top/.github is not"
+    skip "no .github under $top (dist tarball), so the audit has nothing to read"
+fi
 
-# Dependabot names a branch dependabot/<ecosystem>/<dir>/<dep>-<version>, so the
-# prefix is what tells the ecosystems apart.
-grep -q "startsWith(github.event.pull_request.head.ref, 'dependabot/vcpkg/')" "$wf" ||
-    fail "the auto-merge gate no longer excludes the vcpkg ecosystem"
+# Read the gate itself, not the whole file: a substring can sit in a comment or
+# in a second job and prove nothing about what arms. The condition is a folded
+# scalar, so its own lines are the ones indented under it.
+cond=$(awk '/^    if: >-$/ {inif=1; next} inif && /^      / {print; next} inif {exit}' "$wf")
+[ -n "$cond" ] || fail "could not read the auto-merge condition out of $wf"
 
-grep -q '!startsWith' "$wf" ||
-    fail "the vcpkg branch prefix is named but not negated, so it would gate auto-merge ON"
+# One job, so no unguarded sibling can arm auto-merge on its own.
+jobs=$(grep -c '^    runs-on:' "$wf")
+[ "$jobs" = 1 ] || fail "expected one job in $wf, found $jobs"
 
-# The other ecosystems still auto-merge, so the exclusion must not have grown
-# into a blanket refusal.
-grep -q "github.event.pull_request.user.login == 'dependabot\[bot\]'" "$wf" ||
-    fail "the dependabot author check is gone, so nothing arms auto-merge at all"
+case $cond in
+*"&& !startsWith(github.event.pull_request.head.ref, 'dependabot/vcpkg/')"*) ;;
+*) fail "the gate does not exclude the vcpkg ecosystem with an && conjunct" ;;
+esac
+
+# Turning any conjunct into a disjunction arms every pull request in the repo,
+# because one true term would then be enough.
+case $cond in
+*"||"*) fail "the gate is not a pure conjunction, so one term can arm it alone" ;;
+esac
+
+# The author check is what makes this dependabot-only. github.actor is the
+# event sender, so swapping to it would widen the gate silently.
+case $cond in
+*"github.event.pull_request.user.login == 'dependabot[bot]'"*) ;;
+*) fail "the gate no longer checks the pull request author" ;;
+esac
+
+# The prefix above assumes dependabot's default branch separator. Configuring
+# another one renames the branches and the exclusion stops matching, silently.
+conf="$top/.github/dependabot.yml"
+[ -r "$conf" ] || fail "cannot read $conf"
+if grep -q 'pull-request-branch-name' "$conf"; then
+    fail "$conf sets a branch-name separator, so the vcpkg prefix may not match"
+fi

--- a/tests/460_vcpkg-pin-not-automerged.test
+++ b/tests/460_vcpkg-pin-not-automerged.test
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Dependabot's vcpkg ecosystem tracks vcpkg's release tags, so a baseline pinned
+# to a newer commit reads as behind and is bumped backwards. #1614 reverted a
+# security pin that way, unattended, so those bumps must not auto-merge.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+: "${top_srcdir:=..}"
+
+wf="$top_srcdir/.github/workflows/dependabot-automerge.yml"
+[ -r "$wf" ] || fail "cannot read $wf"
+
+# Dependabot names a branch dependabot/<ecosystem>/<dir>/<dep>-<version>, so the
+# prefix is what tells the ecosystems apart.
+grep -q "startsWith(github.event.pull_request.head.ref, 'dependabot/vcpkg/')" "$wf" ||
+    fail "the auto-merge gate no longer excludes the vcpkg ecosystem"
+
+grep -q '!startsWith' "$wf" ||
+    fail "the vcpkg branch prefix is named but not negated, so it would gate auto-merge ON"
+
+# The other ecosystems still auto-merge, so the exclusion must not have grown
+# into a blanket refusal.
+grep -q "github.event.pull_request.user.login == 'dependabot\[bot\]'" "$wf" ||
+    fail "the dependabot author check is gone, so nothing arms auto-merge at all"


### PR DESCRIPTION
Dependabot reverted the OpenSSL security pin from #1598 and merged the revert itself, so `builtin-baseline` went from `04a9d8e5`, committed 2026-09-04, back to `9e593bb1`, committed 2026-07-30. OpenSSL is 3.6.3 again on master and CVE-2026-18798, CVE-2026-63072 and CVE-2026-63076 are live.

The mechanism will recur, which is why re-bumping alone is not the fix. Dependabot's vcpkg ecosystem tracks vcpkg's release tags. The newest is `2026.07.29`, which dereferences to exactly the `9e593bb1` it moved us to. A baseline pinned to a newer commit therefore reads as behind, and the bump walks it backwards. Any hand-picked security baseline gets reverted this way.

So vcpkg bumps no longer auto-merge. Dependabot still opens them, and a human decides. The gate reads the branch prefix, because dependabot names a branch `dependabot/<ecosystem>/<dir>/<dep>-<version>` and that is structural where the title is prose. Submodule and action bumps are untouched.

This is not a permanent state. Once vcpkg cuts a tag newer than our pin, dependabot moves forward again and the withheld auto-merge costs one click per bump.

The test reads the condition rather than the whole file. A substring proves nothing about what arms, because it can sit in a comment or in a second job. So the test pulls the folded scalar out. It then requires the vcpkg clause to be joined with `&&`, refuses a disjunction anywhere, and requires exactly one job.

Six wrong workflows were built and run against it, and all six fail:

- the clause deleted
- the `!` dropped
- the `&&` turned into `||`
- the author check swapped for `github.actor`
- the wrong ecosystem prefix
- an unguarded second job that arms everything

The third is why the test reads the expression. It leaves every byte an earlier grep-based version matched, and arms auto-merge for every pull request in the repo.

It also refuses a `pull-request-branch-name` separator in `dependabot.yml`, which would rename the branches and stop the prefix matching without touching the gate.

Reported by the httrack-windows session, whose CVE gate went red on the reverted pin. That gate had just been made fatal on master pushes, which is the only reason this surfaced rather than passing quietly.