### PR TITLE
Test 337 outruns the 600s guard on a slow runner

### DIFF
--- a/tests/337_ci-lost-worker.test
+++ b/tests/337_ci-lost-worker.test
@@ -6,8 +6,8 @@
 # the step teed, for the runs the watchdog kills before that verdict (#1588). Driven
 # here because the Windows leg, where it happens, keeps no evidence of it.
 #
-# Four staged suite runs of 121 stubs each is real work, not a wedge: 87s here, past
-# the 600s guard on a loaded macOS runner. The arms pace themselves inside the raise.
+# Four staged suite runs of 121 stubs each are real work, not a wedge. That is 87s
+# here and past the 600s guard on a loaded macOS runner, so the arms pace themselves.
 # TEST_TIMEOUT_AT_LEAST: 1200
 
 set -euo pipefail
@@ -155,8 +155,9 @@ stage() { # stage <dir> <lost stub body>
     fi
 }
 
-# Drive the suite staged in $1 into $tmp/out, its status into $rc and what it cost
-# into $arm_took, which paces the arm after it.
+# Drive the suite staged in $1 into $tmp/out, its status into $rc and what it cost into
+# $arm_took. Each arm paces after its own assertions, or a skip throws away the run it
+# has already paid for.
 rc=0
 arm_took=0
 run_suite() { # run_suite <dir>
@@ -170,8 +171,10 @@ run_suite() { # run_suite <dir>
     arm_took=$((SECONDS - began))
 }
 
-# Expensive first already: the console counts below read what the first two arms left.
-arms_left=4
+# The arms the budget is paced against. The console counts ride on the first two, so
+# they sit after the second and survive a run that paces out.
+cases=4
+n=0
 
 # The control first: the same stubs with nothing killed have to come out green, or
 # the run below proves only that a stub suite cannot pass.
@@ -182,8 +185,8 @@ grep -q "^ran=$ran pass=92 fail=0 skip=$nskip lost=0$" "$tmp/out" ||
     fail "clean tally: $(grep '^ran=' "$tmp/out" || true)"
 # A whole healthy run for the counter below: no LOST line, and a tally saying lost=0.
 cp "$tmp/out" "$tmp/console-clean.log"
-arms_left=$((arms_left - 1))
-pace "$arms_left" "$arm_took"
+n=$((n + 1))
+pace "$((cases - n))" "$arm_took" "the lost tally, the pinned-skip gate and precedence"
 
 stage "$tmp/killed" "$killer"
 run_suite "$tmp/killed"
@@ -203,50 +206,6 @@ grep -q '::error::failing:' "$tmp/out" &&
 test "$rc" -eq 3 || fail "a lost worker exited $rc, want 3: $(<"$tmp/out")"
 # And a run one worker short: one LOST verdict, and a tally saying lost=1.
 cp "$tmp/out" "$tmp/console-lost.log"
-arms_left=$((arms_left - 1))
-pace "$arms_left" "$arm_took"
-
-# Again with the killer on one of the pinned skips. That run reaches the skip-set
-# gate, which exits before the lost gate unless it is told a vanished worker
-# explains the difference: the reason this stays a leg to repeat.
-# No pipe: bash's printf writes a line at a time, so head -1 leaving early
-# gives it SIGPIPE, and pipefail turns that into this test's own failure.
-# shellcheck disable=SC2086 # the splitting is what picks one name
-set -- $expected_skips
-pinned=$1
-stage "$tmp/killedskip" "$killer" "$pinned"
-run_suite "$tmp/killedskip"
-case "$(<"$share/killed")" in
-none*) fail "the pinned-skip stub killed no worker: $(<"$share/killed")" ;;
-esac
-grep -q "^LOST $pinned (worker left no status; " "$tmp/out" ||
-    fail "the vanished skip was not reported: $(<"$tmp/out")"
-grep -q '::error::skip set changed from expected' "$tmp/out" ||
-    fail "the skip set did not change, so this run reaches the wrong gate: $(<"$tmp/out")"
-test "$rc" -eq 3 ||
-    fail "a worker lost from the pinned skips exited $rc, want 3: $(<"$tmp/out")"
-ok "a skip that vanished is still a leg to repeat"
-arms_left=$((arms_left - 1))
-pace "$arms_left" "$arm_took"
-
-# A loss alongside a real failure: the failure decides, or a red ships as a leg to
-# repeat and nobody investigates it.
-stage "$tmp/mixed" "$killer"
-stub "$tmp/mixed/900_zlib-pass.test" 3
-run_suite "$tmp/mixed"
-case "$(<"$share/killed")" in
-none*) fail "the mixed stub killed no worker: $(<"$share/killed")" ;;
-esac
-grep -q '^LOST 906_engine-lost.test (worker left no status; ' "$tmp/out" ||
-    fail "the vanished worker was not reported beside the failure: $(<"$tmp/out")"
-grep -q '::error::failing: 900_zlib-pass.test' "$tmp/out" ||
-    fail "the failing test was not named: $(<"$tmp/out")"
-test "$rc" -eq 1 ||
-    fail "a failure alongside a loss exited $rc, want 1: $(<"$tmp/out")"
-ok "a real failure outranks a lost worker"
-arms_left=$((arms_left - 1))
-# Nothing left to pace: this only catches an arm added without counting it.
-assert_steps_ran 0 "$arms_left"
 
 # --- and the count a later step makes off the console it left ----------------
 
@@ -351,3 +310,48 @@ grep -q 'not counted' <<<"$counted" || fail "a directory as the log said: $count
 ok "the console count matches what the suite lost"
 
 echo "lost-worker classification OK"
+
+n=$((n + 1))
+pace "$((cases - n))" "$arm_took" "the pinned-skip gate and precedence"
+
+# Again with the killer on one of the pinned skips. That run reaches the skip-set
+# gate, which exits before the lost gate unless it is told a vanished worker
+# explains the difference: the reason this stays a leg to repeat.
+# No pipe: bash's printf writes a line at a time, so head -1 leaving early
+# gives it SIGPIPE, and pipefail turns that into this test's own failure.
+# shellcheck disable=SC2086 # the splitting is what picks one name
+set -- $expected_skips
+pinned=$1
+stage "$tmp/killedskip" "$killer" "$pinned"
+run_suite "$tmp/killedskip"
+case "$(<"$share/killed")" in
+none*) fail "the pinned-skip stub killed no worker: $(<"$share/killed")" ;;
+esac
+grep -q "^LOST $pinned (worker left no status; " "$tmp/out" ||
+    fail "the vanished skip was not reported: $(<"$tmp/out")"
+grep -q '::error::skip set changed from expected' "$tmp/out" ||
+    fail "the skip set did not change, so this run reaches the wrong gate: $(<"$tmp/out")"
+test "$rc" -eq 3 ||
+    fail "a worker lost from the pinned skips exited $rc, want 3: $(<"$tmp/out")"
+ok "a skip that vanished is still a leg to repeat"
+n=$((n + 1))
+pace "$((cases - n))" "$arm_took" "precedence, where a failure outranks a loss"
+
+# A loss alongside a real failure: the failure decides, or a red ships as a leg to
+# repeat and nobody investigates it.
+stage "$tmp/mixed" "$killer"
+stub "$tmp/mixed/900_zlib-pass.test" 3
+run_suite "$tmp/mixed"
+case "$(<"$share/killed")" in
+none*) fail "the mixed stub killed no worker: $(<"$share/killed")" ;;
+esac
+grep -q '^LOST 906_engine-lost.test (worker left no status; ' "$tmp/out" ||
+    fail "the vanished worker was not reported beside the failure: $(<"$tmp/out")"
+grep -q '::error::failing: 900_zlib-pass.test' "$tmp/out" ||
+    fail "the failing test was not named: $(<"$tmp/out")"
+test "$rc" -eq 1 ||
+    fail "a failure alongside a loss exited $rc, want 1: $(<"$tmp/out")"
+ok "a real failure outranks a lost worker"
+n=$((n + 1))
+# Nothing left to pace. It catches an arm counted out of step, not one never counted.
+assert_steps_ran "$cases" "$n"

--- a/tests/337_ci-lost-worker.test
+++ b/tests/337_ci-lost-worker.test
@@ -5,6 +5,10 @@
 # that says re-run, not investigate. The workflow counts them again off the console
 # the step teed, for the runs the watchdog kills before that verdict (#1588). Driven
 # here because the Windows leg, where it happens, keeps no evidence of it.
+#
+# Four staged suite runs of 121 stubs each is real work, not a wedge: 87s here, past
+# the 600s guard on a loaded macOS runner. The arms pace themselves inside the raise.
+# TEST_TIMEOUT_AT_LEAST: 1200
 
 set -euo pipefail
 
@@ -151,16 +155,23 @@ stage() { # stage <dir> <lost stub body>
     fi
 }
 
-# Drive the suite staged in $1 into $tmp/out, its status into $rc.
+# Drive the suite staged in $1 into $tmp/out, its status into $rc and what it cost
+# into $arm_took, which paces the arm after it.
 rc=0
+arm_took=0
 run_suite() { # run_suite <dir>
+    local began=$SECONDS
     rc=0
     (
         cd "$1"
         RUNNER_TEMP="$1/rt" GITHUB_STEP_SUMMARY="$tmp/summary" HTTRACK_SUITE_JOBS=6 \
             bash ./ci-windows-suite.sh "$bin"
     ) >"$tmp/out" 2>&1 || rc=$?
+    arm_took=$((SECONDS - began))
 }
+
+# Expensive first already: the console counts below read what the first two arms left.
+arms_left=4
 
 # The control first: the same stubs with nothing killed have to come out green, or
 # the run below proves only that a stub suite cannot pass.
@@ -171,6 +182,8 @@ grep -q "^ran=$ran pass=92 fail=0 skip=$nskip lost=0$" "$tmp/out" ||
     fail "clean tally: $(grep '^ran=' "$tmp/out" || true)"
 # A whole healthy run for the counter below: no LOST line, and a tally saying lost=0.
 cp "$tmp/out" "$tmp/console-clean.log"
+arms_left=$((arms_left - 1))
+pace "$arms_left" "$arm_took"
 
 stage "$tmp/killed" "$killer"
 run_suite "$tmp/killed"
@@ -190,6 +203,8 @@ grep -q '::error::failing:' "$tmp/out" &&
 test "$rc" -eq 3 || fail "a lost worker exited $rc, want 3: $(<"$tmp/out")"
 # And a run one worker short: one LOST verdict, and a tally saying lost=1.
 cp "$tmp/out" "$tmp/console-lost.log"
+arms_left=$((arms_left - 1))
+pace "$arms_left" "$arm_took"
 
 # Again with the killer on one of the pinned skips. That run reaches the skip-set
 # gate, which exits before the lost gate unless it is told a vanished worker
@@ -211,6 +226,8 @@ grep -q '::error::skip set changed from expected' "$tmp/out" ||
 test "$rc" -eq 3 ||
     fail "a worker lost from the pinned skips exited $rc, want 3: $(<"$tmp/out")"
 ok "a skip that vanished is still a leg to repeat"
+arms_left=$((arms_left - 1))
+pace "$arms_left" "$arm_took"
 
 # A loss alongside a real failure: the failure decides, or a red ships as a leg to
 # repeat and nobody investigates it.
@@ -227,6 +244,9 @@ grep -q '::error::failing: 900_zlib-pass.test' "$tmp/out" ||
 test "$rc" -eq 1 ||
     fail "a failure alongside a loss exited $rc, want 1: $(<"$tmp/out")"
 ok "a real failure outranks a lost worker"
+arms_left=$((arms_left - 1))
+# Nothing left to pace: this only catches an arm added without counting it.
+assert_steps_ran 0 "$arms_left"
 
 # --- and the count a later step makes off the console it left ----------------
 

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -1184,13 +1184,14 @@ budget_secs() {
     echo "$((10#$budget))"
 }
 
-skip_if_out_of_budget() { # skip_if_out_of_budget <steps left> <seconds the last took>
+skip_if_out_of_budget() { # skip_if_out_of_budget <steps left> <seconds the last took> [what they cover]
     local budget need=$(($2 + $2 / 2))
 
     budget=$(budget_secs)
     test "$1" -gt 0 && test "$budget" -gt 0 || return 0
     test "$((SECONDS + need))" -ge "$budget" || return 0
-    echo "$1 steps left, the last took ${2}s and the budget is ${budget}s; skipping" >&2
+    # $3 names what goes unchecked, or the log says a count and the reader guesses.
+    echo "$1 steps left, the last took ${2}s and the budget is ${budget}s; skipping${3:+ $3}" >&2
     exit 77
 }
 
@@ -1201,9 +1202,9 @@ PACE_COSTLIEST=0
 # skip_if_out_of_budget against the costliest step so far rather than the last
 # one: a caller orders its steps by what they mean, so a cheap one projects a
 # reserve the slow step after it cannot fit in (#1568).
-pace() { # pace <steps left> <seconds the step took>
+pace() { # pace <steps left> <seconds the step took> [what those steps cover]
     test "$2" -le "${PACE_COSTLIEST}" || PACE_COSTLIEST=$2
-    skip_if_out_of_budget "$1" "${PACE_COSTLIEST}"
+    skip_if_out_of_budget "$1" "${PACE_COSTLIEST}" "${3:-}"
 }
 
 # Seconds left of the budget, for a child pacing itself against it (269 hands it to


### PR DESCRIPTION
337 drives four staged suite runs of 121 stubs each. That takes 87s here, and outruns the 600s guard on a loaded macOS runner. It failed there with exit 124 on master and on #1621, while other PRs on the same base passed. `build (macOS arm64, clang)` is a required check, so this blocked every open PR whenever it fired.

The cost is process spawn rather than CPU, because the test takes 87s pinned to one core and 87s on twelve. So the budget rises to 1200s, and each arm paces itself on what the arm before it cost. A host too slow to finish now skips instead of failing.

337 matches none of the Windows suite's category globs, so a skip cannot move a pinned skip list.
