### PR TITLE
Test 257 fails wherever /bin/sh is bash, so Fedora cannot build

### DIFF
--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -411,14 +411,21 @@ PSEOF
     cat >"$tmpdir/cap.sh" <<EOF
 set -euo pipefail
 . "$testdir/testlib.sh"
-# The marker rides argv[1] and must stay the longest element, because win_marker
-# takes the longest. The trailing ':' keeps it there at all: bash, which is
-# /bin/sh on Fedora, replaces itself with a lone simple command, argv included.
+# The marker must beat the 11-byte "sleep 30; :" on length, because win_marker
+# returns the longest argv element and a tie goes to the earlier one. The
+# trailing ':' is what keeps the marker on the cmdline at all, because /bin/sh
+# is bash on Fedora, and bash replaces itself with a lone simple command.
 /bin/sh -c 'sleep 30; :' "\$1" &
 v=\$!
-# The fork precedes the exec, so an immediate read still answers the marker.
-poll_wait 0.5
-test "\$(win_marker "/proc/\$v/cmdline")" = "\$1" ||
+# Until the exec lands the child still carries this script's argv, whose cap.sh
+# path outranks the marker, so wait as argv0_is_the_program does below.
+m=
+for _ in \$(seq 20); do
+    m=\$(win_marker "/proc/\$v/cmdline")
+    if test "\$m" = "\$1"; then break; fi
+    poll_wait 0.2
+done
+test "\$m" = "\$1" ||
     fail "the relay's cmdline does not carry the marker: \$(tr '\\0' ' ' </proc/\$v/cmdline)"
 win_capture "\$v"
 printf '%s|%s\n' "\$WIN_PID" "\$WIN_IMAGE"
@@ -432,7 +439,9 @@ EOF
     # relay's cmdline names the emulator rather than the image it runs.
     argv0_is_the_program() {
         local probe leaf=
-        /bin/sh -c 'sleep 30' >/dev/null 2>&1 &
+        # ';:' for the reason the relay above needs it, or bash execs itself
+        # away and this reads 'sleep', which answers no and skips the caller.
+        /bin/sh -c 'sleep 30; :' >/dev/null 2>&1 &
         probe=$!
         # The fork precedes the exec, so the first read can still answer bash.
         for _ in $(seq 20); do

--- a/tests/257_testlib-asserts.test
+++ b/tests/257_testlib-asserts.test
@@ -411,11 +411,15 @@ PSEOF
     cat >"$tmpdir/cap.sh" <<EOF
 set -euo pipefail
 . "$testdir/testlib.sh"
-# The marker goes in argv[1], where win_marker's argv[0] skip still finds it.
-/bin/sh -c 'sleep 30' "\$1" &
+# The marker rides argv[1] and must stay the longest element, because win_marker
+# takes the longest. The trailing ':' keeps it there at all: bash, which is
+# /bin/sh on Fedora, replaces itself with a lone simple command, argv included.
+/bin/sh -c 'sleep 30; :' "\$1" &
 v=\$!
+# The fork precedes the exec, so an immediate read still answers the marker.
+poll_wait 0.5
 test "\$(win_marker "/proc/\$v/cmdline")" = "\$1" ||
-    echo "the relay's cmdline does not carry the marker" >&2
+    fail "the relay's cmdline does not carry the marker: \$(tr '\\0' ' ' </proc/\$v/cmdline)"
 win_capture "\$v"
 printf '%s|%s\n' "\$WIN_PID" "\$WIN_IMAGE"
 kill "\$v" 2>/dev/null || true


### PR DESCRIPTION
Test 257 starts a relay as `/bin/sh -c 'sleep 30' MARKER` and reads the marker back out of `/proc/<pid>/cmdline`. bash replaces itself with a lone simple command and drops its argv, marker included. dash keeps it. Our legs run dash and Fedora runs bash, so the suite is green here and red under `rpmbuild`.

A trailing `:` stops bash short-circuiting. The relay's `-c` text must stay shorter than the marker, because `win_marker` takes the longest argv element.

`argv0_is_the_program` below spawns the same relay and had the same bug. There it reads `sleep` as argv[0], answers no, and its caller skips the `WIN_IMAGE` assertion as an emulator artefact. The skip is silent, so on Fedora the run stayed green while checking less than it claims.

The marker guard only warned, and the run went on to report `expected [4242], got []`, which names the wrong thing. It now settles on a bounded loop, as its neighbour already does, and fails with the cmdline it found.

Proved under bash invoked as `sh`. The old relay fails, the old argv0 probe skips the image assertion, and both are green with the fix.