### PR TITLE
An engine worker thread cannot run under the embedder's crash handler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -503,9 +503,8 @@ AS_IF([test x"$backtrace_platform" = x"no"],
 	[AC_MSG_RESULT([$backtrace_have (requested)])])
 AC_SUBST([BACKTRACE_LIBS])
 
-## -#c faults on purpose so the crash handlers can be tested. On by default
-## because the suite drives it; an application embedding the engine wants it
-## gone, as the option is otherwise reachable from whatever argv it builds.
+## On by default because the suite drives -#c; an embedding application drops it
+## so the deliberate crash leaves whatever argv it builds.
 AC_ARG_ENABLE([crash-test],
 	[AS_HELP_STRING([--disable-crash-test],
 		[drop the hidden -#c option, which crashes on purpose to test crash handlers @<:@default=enabled@:>@])],

--- a/configure.ac
+++ b/configure.ac
@@ -503,6 +503,29 @@ AS_IF([test x"$backtrace_platform" = x"no"],
 	[AC_MSG_RESULT([$backtrace_have (requested)])])
 AC_SUBST([BACKTRACE_LIBS])
 
+## -#c faults on purpose so the crash handlers can be tested. On by default
+## because the suite drives it; an application embedding the engine wants it
+## gone, as the option is otherwise reachable from whatever argv it builds.
+AC_ARG_ENABLE([crash-test],
+	[AS_HELP_STRING([--disable-crash-test],
+		[drop the hidden -#c option, which crashes on purpose to test crash handlers @<:@default=enabled@:>@])],
+	[
+	case "${enableval}" in
+	no|yes)
+		crash_test=$enableval
+		;;
+	*)
+		AC_MSG_ERROR([bad value for crash-test, expected yes/no])
+		;;
+	esac
+	],
+	[crash_test=yes])
+AC_MSG_CHECKING([whether to build the deliberate-crash test option])
+AC_MSG_RESULT([$crash_test])
+AS_IF([test x"$crash_test" = x"yes"],
+	[AC_DEFINE([HTS_CRASH_TEST], [1],
+		[Define to 1 to build the hidden -#c crash-test option.])])
+
 ## CSPRNG for the --single-file mark; /dev/urandom is the fallback
 AC_CHECK_FUNCS([getrandom])
 

--- a/configure.ac
+++ b/configure.ac
@@ -503,8 +503,7 @@ AS_IF([test x"$backtrace_platform" = x"no"],
 	[AC_MSG_RESULT([$backtrace_have (requested)])])
 AC_SUBST([BACKTRACE_LIBS])
 
-## On by default because the suite drives -#c; an embedding application drops it
-## so the deliberate crash leaves whatever argv it builds.
+## On by default because the suite drives -#c.
 AC_ARG_ENABLE([crash-test],
 	[AS_HELP_STRING([--disable-crash-test],
 		[drop the hidden -#c option, which crashes on purpose to test crash handlers @<:@default=enabled@:>@])],

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -967,8 +967,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
   }
 
   /* -#c[=KIND]: crash on purpose, to test crash handlers only (see
-     htscrashtest.h). Handled here so it needs no dummy URL either. Off unless
-     the build asked for it, so a shipped application carries no such path. */
+     htscrashtest.h). Handled here so it needs no dummy URL either. */
 #ifdef HTS_CRASH_TEST
   {
     int k;

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -967,7 +967,9 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
   }
 
   /* -#c[=KIND]: crash on purpose, to test crash handlers only (see
-     htscrashtest.h). Handled here so it needs no dummy URL either. */
+     htscrashtest.h). Handled here so it needs no dummy URL either. Off unless
+     the build asked for it, so a shipped application carries no such path. */
+#ifdef HTS_CRASH_TEST
   {
     int k;
 
@@ -988,6 +990,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
       }
     }
   }
+#endif
 
   // Pas d'URL
 #if DEBUG_STEPS

--- a/src/htscrashtest.c
+++ b/src/htscrashtest.c
@@ -47,6 +47,8 @@ Please visit our Website: http://www.httrack.com
 #define CRASH_HAS_ATFORK
 #endif
 
+#ifdef HTS_CRASH_TEST
+
 #if defined(_MSC_VER)
 #define CRASH_NOINLINE __declspec(noinline)
 #elif defined(__GNUC__)
@@ -100,21 +102,39 @@ static CRASH_NOINLINE char blow_the_stack(size_t depth) {
 /* Faults with no stack left for the handler, unless it runs on an altstack. */
 static CRASH_NOINLINE void crash_stack(void) { (void) blow_the_stack(0); }
 
-static void crash_stack_thread(void *arg) {
-  (void) arg;
+typedef void (*crash_fn)(void);
+
+static void crash_worker_thread(void *arg) {
+  const crash_fn fn = *(const crash_fn *) arg;
+
   fprintf(stderr, "** Crash test worker thread started\n");
   fflush(stderr);
-  crash_stack();
+  fn();
+}
+
+/* Faults 'fn' on an engine worker. 'fn' is read through the caller's frame,
+   which outlives the worker because the wait below never returns. */
+static void crash_on_worker(crash_fn fn) {
+  crash_fn shared = fn;
+
+  /* Aborting on a spawn failure keeps the caller's exit status a crash, so the
+     test reads "no worker started" rather than "the handler never ran". */
+  if (hts_newthread(crash_worker_thread, &shared) != 0)
+    abortLog("crash test: cannot spawn a worker thread");
+  htsthread_wait_n(0); /* the worker takes the process down from there */
 }
 
 /* Same runaway recursion in an engine worker: the fatal handler needs an
    alternate stack in every thread, not just the main one (#969). */
 static CRASH_NOINLINE void crash_threadstack(void) {
-  /* Aborting on a spawn failure keeps the caller's exit status a crash, so the
-     test reads "no worker started" rather than "the handler never ran". */
-  if (hts_newthread(crash_stack_thread, NULL) != 0)
-    abortLog("crash test: cannot spawn a worker thread");
-  htsthread_wait_n(0); /* the worker takes the process down from there */
+  crash_on_worker(crash_stack);
+}
+
+/* A worker fault with the stack intact, so a handler that copes with the main
+   thread but not with a thread it never registered shows up on its own:
+   threadstack moves both variables at once and cannot separate them. */
+static CRASH_NOINLINE void crash_threadsegv(void) {
+  crash_on_worker(crash_segv);
 }
 
 #ifdef CRASH_HAS_ATFORK
@@ -144,6 +164,7 @@ static const struct {
     {"trap", crash_trap},
     {"stack", crash_stack},
     {"threadstack", crash_threadstack},
+    {"threadsegv", crash_threadsegv},
     {"atfork", crash_atfork},
 };
 
@@ -195,3 +216,10 @@ hts_boolean hts_crash_test(const char *kind) {
   }
   return HTS_FALSE;
 }
+
+#else
+
+/* An empty translation unit is not valid C. */
+typedef int hts_crash_test_disabled_t;
+
+#endif

--- a/src/htscrashtest.c
+++ b/src/htscrashtest.c
@@ -112,14 +112,12 @@ static void crash_worker_thread(void *arg) {
   fn();
 }
 
-/* Faults 'fn' on an engine worker. 'fn' is read through the caller's frame,
-   which outlives the worker because the wait below never returns. */
+/* Faults 'fn' on an engine worker. The worker reads 'fn' out of this frame,
+   which the wait below holds open until the worker has returned. */
 static void crash_on_worker(crash_fn fn) {
-  crash_fn shared = fn;
-
   /* Aborting on a spawn failure keeps the caller's exit status a crash, so the
      test reads "no worker started" rather than "the handler never ran". */
-  if (hts_newthread(crash_worker_thread, &shared) != 0)
+  if (hts_newthread(crash_worker_thread, &fn) != 0)
     abortLog("crash test: cannot spawn a worker thread");
   htsthread_wait_n(0); /* the worker takes the process down from there */
 }
@@ -130,9 +128,9 @@ static CRASH_NOINLINE void crash_threadstack(void) {
   crash_on_worker(crash_stack);
 }
 
-/* A worker fault with the stack intact, so a handler that copes with the main
-   thread but not with a thread it never registered shows up on its own:
-   threadstack moves both variables at once and cannot separate them. */
+/* Faults a worker with its stack intact, unlike threadstack which spends it
+   too, so a handler that copes with the main thread but not with a thread it
+   never registered shows up on its own. */
 static CRASH_NOINLINE void crash_threadsegv(void) {
   crash_on_worker(crash_segv);
 }
@@ -216,10 +214,5 @@ hts_boolean hts_crash_test(const char *kind) {
   }
   return HTS_FALSE;
 }
-
-#else
-
-/* An empty translation unit is not valid C. */
-typedef int hts_crash_test_disabled_t;
 
 #endif

--- a/src/htscrashtest.c
+++ b/src/htscrashtest.c
@@ -112,8 +112,7 @@ static void crash_worker_thread(void *arg) {
   fn();
 }
 
-/* Faults 'fn' on an engine worker. The worker reads 'fn' out of this frame,
-   which the wait below holds open until the worker has returned. */
+/* Faults 'fn' on a worker. The wait below holds this frame until it returns. */
 static void crash_on_worker(crash_fn fn) {
   /* Aborting on a spawn failure keeps the caller's exit status a crash, so the
      test reads "no worker started" rather than "the handler never ran". */
@@ -128,9 +127,7 @@ static CRASH_NOINLINE void crash_threadstack(void) {
   crash_on_worker(crash_stack);
 }
 
-/* Faults a worker with its stack intact, unlike threadstack which spends it
-   too, so a handler that copes with the main thread but not with a thread it
-   never registered shows up on its own. */
+/* Faults a worker with its stack intact, unlike threadstack. */
 static CRASH_NOINLINE void crash_threadsegv(void) {
   crash_on_worker(crash_segv);
 }

--- a/src/htscrashtest.h
+++ b/src/htscrashtest.h
@@ -40,6 +40,8 @@ Please visit our Website: http://www.httrack.com
 extern "C" {
 #endif
 
+#ifdef HTS_CRASH_TEST
+
 /* Crash the process on purpose, after announcing it on stderr so the log tells
    a deliberate crash from a real one. 'kind' selects the fault and defaults to
    "segv" when NULL or empty; hts_crash_test_kinds() lists the accepted names.
@@ -48,6 +50,8 @@ hts_boolean hts_crash_test(const char *kind);
 
 /* The names hts_crash_test() accepts, comma-separated, for diagnostics. */
 const char *hts_crash_test_kinds(void);
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -1271,6 +1271,11 @@ static int st_features(httrackp *opt, int argc, char **argv) {
 #else
   printf("iconv 1\n");
 #endif
+#ifdef HTS_CRASH_TEST
+  printf("crashtest 1\n");
+#else
+  printf("crashtest 0\n");
+#endif
   return 0;
 }
 
@@ -13074,6 +13079,94 @@ static int st_threadwait(httrackp *opt, int argc, char **argv) {
   return err;
 }
 
+/* A crash handler that has to lexically wrap the worker body gets in through
+   hts_set_thread_runner(); the hooks only bracket the call. Records the order
+   so a runner that never encloses the body, or one the engine calls beside
+   fun() rather than around it, both fail. */
+static htsmutex threadrunner_lock = HTSMUTEX_INIT;
+static int threadrunner_before = 0;
+static int threadrunner_body = 0;
+static int threadrunner_after = 0;
+static int threadrunner_out_of_order = 0;
+
+static void threadrunner_count(int *what) {
+  hts_mutexlock(&threadrunner_lock);
+  (*what)++;
+  hts_mutexrelease(&threadrunner_lock);
+}
+
+static void threadrunner_body_fn(void *arg) {
+  (void) arg;
+  hts_mutexlock(&threadrunner_lock);
+  /* The body must run inside the runner, never before it or after it. */
+  if (threadrunner_before != 1 || threadrunner_after != 0)
+    threadrunner_out_of_order = 1;
+  threadrunner_body++;
+  hts_mutexrelease(&threadrunner_lock);
+}
+
+static void threadrunner_runner(void (*fun)(void *arg), void *arg) {
+  threadrunner_count(&threadrunner_before);
+  fun(arg);
+  threadrunner_count(&threadrunner_after);
+}
+
+static int threadrunner_spawn(void) {
+  if (hts_newthread(threadrunner_body_fn, NULL) != 0) {
+    fprintf(stderr, "threadrunner: cannot spawn\n");
+    return 1;
+  }
+  htsthread_wait();
+  return 0;
+}
+
+static int st_threadrunner(httrackp *opt, int argc, char **argv) {
+  int err = 0;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+
+  hts_set_thread_runner(threadrunner_runner);
+  err = threadrunner_spawn();
+  /* Cleared before any check can return early: the runner is process-global
+     and selftest_queue runs the rest of the file in this same engine. */
+  hts_set_thread_runner(NULL);
+  if (err != 0)
+    return err;
+
+  if (threadrunner_before != 1 || threadrunner_after != 1) {
+    fprintf(stderr, "threadrunner: runner entered %d time(s), left %d\n",
+            threadrunner_before, threadrunner_after);
+    err = 1;
+  }
+  if (threadrunner_body != 1) {
+    fprintf(stderr, "threadrunner: the body ran %d time(s), expected once\n",
+            threadrunner_body);
+    err = 1;
+  }
+  if (threadrunner_out_of_order) {
+    fprintf(stderr, "threadrunner: the body ran outside the runner\n");
+    err = 1;
+  }
+
+  /* NULL restores the plain call: the worker runs, the runner does not. */
+  if (threadrunner_spawn() != 0)
+    return 1;
+  if (threadrunner_body != 2) {
+    fprintf(stderr, "threadrunner: no runner, the body ran %d time(s)\n",
+            threadrunner_body);
+    err = 1;
+  }
+  if (threadrunner_before != 1 || threadrunner_after != 1) {
+    fprintf(stderr, "threadrunner: a cleared runner still ran\n");
+    err = 1;
+  }
+
+  printf("threadrunner self-test: %s\n", err ? "FAIL" : "OK");
+  return err;
+}
+
 /* #794: hts_gmtime() must own its output. The table is an independent oracle;
    the threaded phase is what corrupts if it ever goes back to gmtime()'s
    shared static. */
@@ -15052,6 +15145,9 @@ static const struct selftest_entry {
     {"assumemime", "[128|256|1024]",
      "--assume value clipped to each MIME destination", st_assumemime},
     {"features", "", "which optional features this build has", st_features},
+    {"threadrunner", "",
+     "a registered thread runner encloses each worker body exactly once",
+     st_threadrunner},
     {"charset", "<charset> <hex:..|string>",
      "convert a string to UTF-8 from a charset", st_charset},
     {"syscharset", "", "UTF-8 <-> system codepage conversion (WIN32 only)",

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -13079,8 +13079,7 @@ static int st_threadwait(httrackp *opt, int argc, char **argv) {
   return err;
 }
 
-/* Confirms the runner runs the body exactly once, on the worker, and neither
-   beside it nor on the caller. */
+/* Confirms the runner encloses the body exactly once, on the worker. */
 #ifdef _WIN32
 typedef DWORD threadrunner_id;
 #define threadrunner_self() GetCurrentThreadId()
@@ -13095,7 +13094,7 @@ static htsmutex threadrunner_lock = HTSMUTEX_INIT;
 static int threadrunner_before = 0;
 static int threadrunner_after = 0;
 static int threadrunner_body = 0;
-/* What the runner had done when the body ran: 1 and 0 from inside it. */
+/* What the runner had done when the body ran, 1 and 0 from inside it. */
 static int threadrunner_seen_before = 0;
 static int threadrunner_seen_after = 0;
 static threadrunner_id threadrunner_body_thread;
@@ -13150,16 +13149,14 @@ static int st_threadrunner(httrackp *opt, int argc, char **argv) {
   (void) argc;
   (void) argv;
 
-  /* Every check below reads what the worker wrote, which htsthread_wait()
-     published through the mutex in process_chain_add(). */
+  /* Unlocked, because htsthread_wait() published the worker's writes. */
   threadrunner_reset();
   if (hts_set_thread_runner(threadrunner_runner) != NULL) {
     fprintf(stderr, "threadrunner: a runner was installed already\n");
     return 1;
   }
   spawned = threadrunner_spawn();
-  /* Cleared before any check can return early, because the runner is
-     process-global and selftest_queue reuses this engine. */
+  /* Process-global, so clear it before any check can return early. */
   if (hts_set_thread_runner(NULL) != threadrunner_runner) {
     fprintf(stderr, "threadrunner: the setter did not hand back the runner\n");
     err = 1;
@@ -13182,8 +13179,7 @@ static int st_threadrunner(httrackp *opt, int argc, char **argv) {
             threadrunner_seen_before, threadrunner_seen_after);
     err = 1;
   }
-  /* The frame must be the worker's, because a sigsetjmp on the caller's stack
-     catches nothing the worker does. */
+  /* A sigsetjmp on the caller's stack would catch nothing the worker does. */
   if (threadrunner_same(threadrunner_body_thread, caller) ||
       !threadrunner_same(threadrunner_body_thread,
                          threadrunner_runner_thread)) {
@@ -13192,7 +13188,7 @@ static int st_threadrunner(httrackp *opt, int argc, char **argv) {
     err = 1;
   }
 
-  /* NULL restores the plain call: the worker runs, the runner does not. */
+  /* NULL restores the plain call. */
   threadrunner_reset();
   if (!threadrunner_spawn())
     return 1;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -13079,15 +13079,27 @@ static int st_threadwait(httrackp *opt, int argc, char **argv) {
   return err;
 }
 
-/* A crash handler that has to lexically wrap the worker body gets in through
-   hts_set_thread_runner(); the hooks only bracket the call. Records the order
-   so a runner that never encloses the body, or one the engine calls beside
-   fun() rather than around it, both fail. */
+/* Confirms the runner runs the body exactly once, on the worker, and neither
+   beside it nor on the caller. */
+#ifdef _WIN32
+typedef DWORD threadrunner_id;
+#define threadrunner_self() GetCurrentThreadId()
+#define threadrunner_same(a, b) ((a) == (b))
+#else
+typedef pthread_t threadrunner_id;
+#define threadrunner_self() pthread_self()
+#define threadrunner_same(a, b) (pthread_equal((a), (b)) != 0)
+#endif
+
 static htsmutex threadrunner_lock = HTSMUTEX_INIT;
 static int threadrunner_before = 0;
-static int threadrunner_body = 0;
 static int threadrunner_after = 0;
-static int threadrunner_out_of_order = 0;
+static int threadrunner_body = 0;
+/* What the runner had done when the body ran: 1 and 0 from inside it. */
+static int threadrunner_seen_before = 0;
+static int threadrunner_seen_after = 0;
+static threadrunner_id threadrunner_body_thread;
+static threadrunner_id threadrunner_runner_thread;
 
 static void threadrunner_count(int *what) {
   hts_mutexlock(&threadrunner_lock);
@@ -13095,45 +13107,65 @@ static void threadrunner_count(int *what) {
   hts_mutexrelease(&threadrunner_lock);
 }
 
+static void threadrunner_reset(void) {
+  threadrunner_before = 0;
+  threadrunner_after = 0;
+  threadrunner_body = 0;
+  threadrunner_seen_before = 0;
+  threadrunner_seen_after = 0;
+}
+
 static void threadrunner_body_fn(void *arg) {
   (void) arg;
   hts_mutexlock(&threadrunner_lock);
-  /* The body must run inside the runner, never before it or after it. */
-  if (threadrunner_before != 1 || threadrunner_after != 0)
-    threadrunner_out_of_order = 1;
+  threadrunner_seen_before = threadrunner_before;
+  threadrunner_seen_after = threadrunner_after;
+  threadrunner_body_thread = threadrunner_self();
   threadrunner_body++;
   hts_mutexrelease(&threadrunner_lock);
 }
 
 static void threadrunner_runner(void (*fun)(void *arg), void *arg) {
+  threadrunner_runner_thread = threadrunner_self();
   threadrunner_count(&threadrunner_before);
   fun(arg);
   threadrunner_count(&threadrunner_after);
 }
 
-static int threadrunner_spawn(void) {
+static hts_boolean threadrunner_spawn(void) {
   if (hts_newthread(threadrunner_body_fn, NULL) != 0) {
     fprintf(stderr, "threadrunner: cannot spawn\n");
-    return 1;
+    return HTS_FALSE;
   }
   htsthread_wait();
-  return 0;
+  return HTS_TRUE;
 }
 
 static int st_threadrunner(httrackp *opt, int argc, char **argv) {
+  const threadrunner_id caller = threadrunner_self();
+  hts_boolean spawned;
   int err = 0;
 
   (void) opt;
   (void) argc;
   (void) argv;
 
-  hts_set_thread_runner(threadrunner_runner);
-  err = threadrunner_spawn();
-  /* Cleared before any check can return early: the runner is process-global
-     and selftest_queue runs the rest of the file in this same engine. */
-  hts_set_thread_runner(NULL);
-  if (err != 0)
-    return err;
+  /* Every check below reads what the worker wrote, which htsthread_wait()
+     published through the mutex in process_chain_add(). */
+  threadrunner_reset();
+  if (hts_set_thread_runner(threadrunner_runner) != NULL) {
+    fprintf(stderr, "threadrunner: a runner was installed already\n");
+    return 1;
+  }
+  spawned = threadrunner_spawn();
+  /* Cleared before any check can return early, because the runner is
+     process-global and selftest_queue reuses this engine. */
+  if (hts_set_thread_runner(NULL) != threadrunner_runner) {
+    fprintf(stderr, "threadrunner: the setter did not hand back the runner\n");
+    err = 1;
+  }
+  if (!spawned)
+    return 1;
 
   if (threadrunner_before != 1 || threadrunner_after != 1) {
     fprintf(stderr, "threadrunner: runner entered %d time(s), left %d\n",
@@ -13145,21 +13177,37 @@ static int st_threadrunner(httrackp *opt, int argc, char **argv) {
             threadrunner_body);
     err = 1;
   }
-  if (threadrunner_out_of_order) {
-    fprintf(stderr, "threadrunner: the body ran outside the runner\n");
+  if (threadrunner_seen_before != 1 || threadrunner_seen_after != 0) {
+    fprintf(stderr, "threadrunner: the body saw the runner at %d/%d, not 1/0\n",
+            threadrunner_seen_before, threadrunner_seen_after);
+    err = 1;
+  }
+  /* The frame must be the worker's, because a sigsetjmp on the caller's stack
+     catches nothing the worker does. */
+  if (threadrunner_same(threadrunner_body_thread, caller) ||
+      !threadrunner_same(threadrunner_body_thread,
+                         threadrunner_runner_thread)) {
+    fprintf(stderr,
+            "threadrunner: the body did not run on the runner's worker\n");
     err = 1;
   }
 
   /* NULL restores the plain call: the worker runs, the runner does not. */
-  if (threadrunner_spawn() != 0)
+  threadrunner_reset();
+  if (!threadrunner_spawn())
     return 1;
-  if (threadrunner_body != 2) {
+  if (threadrunner_body != 1) {
     fprintf(stderr, "threadrunner: no runner, the body ran %d time(s)\n",
             threadrunner_body);
     err = 1;
   }
-  if (threadrunner_before != 1 || threadrunner_after != 1) {
-    fprintf(stderr, "threadrunner: a cleared runner still ran\n");
+  if (threadrunner_before != 0 || threadrunner_after != 0) {
+    fprintf(stderr, "threadrunner: a cleared runner still entered %d time(s)\n",
+            threadrunner_before);
+    err = 1;
+  }
+  if (threadrunner_same(threadrunner_body_thread, caller)) {
+    fprintf(stderr, "threadrunner: the body ran on the caller's thread\n");
     err = 1;
   }
 

--- a/src/htsthread.c
+++ b/src/htsthread.c
@@ -101,7 +101,7 @@ typedef struct hts_thread_s {
 /* Set once before any thread is spawned, hence unlocked. */
 static void *(*thread_enter)(void) = NULL;
 static void (*thread_leave)(void *cookie) = NULL;
-static void (*thread_runner)(void (*fun)(void *arg), void *arg) = NULL;
+static hts_thread_runner thread_runner = NULL;
 
 HTSEXT_API void hts_set_thread_hooks(void *(*enter)(void),
                                      void (*leave)(void *cookie)) {
@@ -112,9 +112,11 @@ HTSEXT_API void hts_set_thread_hooks(void *(*enter)(void),
   thread_leave = paired ? leave : NULL;
 }
 
-HTSEXT_API void hts_set_thread_runner(void (*runner)(void (*fun)(void *arg),
-                                                     void *arg)) {
+HTSEXT_API hts_thread_runner hts_set_thread_runner(hts_thread_runner runner) {
+  const hts_thread_runner previous = thread_runner;
+
   thread_runner = runner;
+  return previous;
 }
 
 #ifdef _WIN32

--- a/src/htsthread.c
+++ b/src/htsthread.c
@@ -101,6 +101,7 @@ typedef struct hts_thread_s {
 /* Set once before any thread is spawned, hence unlocked. */
 static void *(*thread_enter)(void) = NULL;
 static void (*thread_leave)(void *cookie) = NULL;
+static void (*thread_runner)(void (*fun)(void *arg), void *arg) = NULL;
 
 HTSEXT_API void hts_set_thread_hooks(void *(*enter)(void),
                                      void (*leave)(void *cookie)) {
@@ -109,6 +110,11 @@ HTSEXT_API void hts_set_thread_hooks(void *(*enter)(void),
 
   thread_enter = paired ? enter : NULL;
   thread_leave = paired ? leave : NULL;
+}
+
+HTSEXT_API void hts_set_thread_runner(void (*runner)(void (*fun)(void *arg),
+                                                     void *arg)) {
+  thread_runner = runner;
 }
 
 #ifdef _WIN32
@@ -126,7 +132,10 @@ static void *hts_entry_point(void *tharg)
 
   cookie = thread_enter != NULL ? thread_enter() : NULL;
   /* run */
-  fun(arg);
+  if (thread_runner != NULL)
+    thread_runner(fun, arg);
+  else
+    fun(arg);
   if (thread_leave != NULL)
     thread_leave(cookie);
 

--- a/src/htsthread.h
+++ b/src/htsthread.h
@@ -68,15 +68,11 @@ HTSEXT_API int hts_newthread(void (*fun) (void *arg), void *arg);
 HTSEXT_API void hts_set_thread_hooks(void *(*enter)(void),
                                      void (*leave)(void *cookie));
 
-/* Runs one worker body. See hts_set_thread_runner(). */
 typedef void (*hts_thread_runner)(void (*fun)(void *arg), void *arg);
 
-/* Wraps each worker body in a caller-supplied frame, for a crash handler that
-   must lexically enclose the call rather than bracket it, such as sigsetjmp
-   plus a block. 'runner' must call 'fun(arg)' exactly once, and NULL restores
-   the plain call. Returns the runner it replaced, so an embedder can chain or
-   put one back. Set it before spawning, because the pointer is read unlocked.
-   It runs between 'enter' and 'leave'. */
+/* Wraps each worker body in a caller-supplied frame, between 'enter' and
+   'leave'. The runner must call 'fun(arg)' once, and NULL clears it. Returns
+   the previous runner. Set it before spawning, since it is read unlocked. */
 HTSEXT_API hts_thread_runner hts_set_thread_runner(hts_thread_runner runner);
 
 HTSEXT_API void htsthread_wait_n(int n_wait);

--- a/src/htsthread.h
+++ b/src/htsthread.h
@@ -68,6 +68,14 @@ HTSEXT_API int hts_newthread(void (*fun) (void *arg), void *arg);
 HTSEXT_API void hts_set_thread_hooks(void *(*enter)(void),
                                      void (*leave)(void *cookie));
 
+/* Runs each worker's body inside a caller-supplied frame, for a crash handler
+   that has to lexically enclose the call: Android's COFFEE_TRY is sigsetjmp
+   plus a block, which the hooks above cannot express. 'runner' must call
+   'fun(arg)' exactly once; NULL restores the plain call. Set before spawning,
+   and it runs between 'enter' and 'leave'. */
+HTSEXT_API void hts_set_thread_runner(void (*runner)(void (*fun)(void *arg),
+                                                     void *arg));
+
 HTSEXT_API void htsthread_wait_n(int n_wait);
 
 /* Locking functions */

--- a/src/htsthread.h
+++ b/src/htsthread.h
@@ -68,13 +68,16 @@ HTSEXT_API int hts_newthread(void (*fun) (void *arg), void *arg);
 HTSEXT_API void hts_set_thread_hooks(void *(*enter)(void),
                                      void (*leave)(void *cookie));
 
-/* Runs each worker's body inside a caller-supplied frame, for a crash handler
-   that has to lexically enclose the call: Android's COFFEE_TRY is sigsetjmp
-   plus a block, which the hooks above cannot express. 'runner' must call
-   'fun(arg)' exactly once; NULL restores the plain call. Set before spawning,
-   and it runs between 'enter' and 'leave'. */
-HTSEXT_API void hts_set_thread_runner(void (*runner)(void (*fun)(void *arg),
-                                                     void *arg));
+/* Runs one worker body. See hts_set_thread_runner(). */
+typedef void (*hts_thread_runner)(void (*fun)(void *arg), void *arg);
+
+/* Wraps each worker body in a caller-supplied frame, for a crash handler that
+   must lexically enclose the call rather than bracket it, such as sigsetjmp
+   plus a block. 'runner' must call 'fun(arg)' exactly once, and NULL restores
+   the plain call. Returns the runner it replaced, so an embedder can chain or
+   put one back. Set it before spawning, because the pointer is read unlocked.
+   It runs between 'enter' and 'leave'. */
+HTSEXT_API hts_thread_runner hts_set_thread_runner(hts_thread_runner runner);
 
 HTSEXT_API void htsthread_wait_n(int n_wait);
 

--- a/tests/140_crash-handler.test
+++ b/tests/140_crash-handler.test
@@ -7,6 +7,15 @@
 
 set -eu
 
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+require_httrack
+have_feature crashtest || {
+    echo "built with --disable-crash-test, skipping" >&2
+    exit 77
+}
+
 ulimit -c 0 # a deliberate crash must not litter the box with cores
 
 # Dies from a caught fault, announcing it was deliberate and printing the

--- a/tests/143_engine-backtrace-empty.test
+++ b/tests/143_engine-backtrace-empty.test
@@ -17,6 +17,14 @@ command -v httrack >/dev/null || {
     echo "could not find httrack" >&2
     exit 1
 }
+# have_feature crashtest, open-coded: this file sources no testlib.
+case "$(httrack -#test=features 2>/dev/null)" in
+*"crashtest 1"*) ;;
+*)
+    echo "built with --disable-crash-test, skipping" >&2
+    exit 77
+    ;;
+esac
 # A --disable-shared build has nothing to preload; anything else missing is a
 # build problem, not a skip, or the leg below would pass vacuously.
 if [ ! -r "${NOBACKTRACE_LA:-}" ]; then

--- a/tests/180_crash-stack-overflow.test
+++ b/tests/180_crash-stack-overflow.test
@@ -22,6 +22,10 @@ Linux) traced=1 ;;
 *) traced=0 ;;
 esac
 require_httrack
+have_feature crashtest || {
+    echo "built with --disable-crash-test, skipping" >&2
+    exit 77
+}
 
 # Dies from a caught fault, announcing it and running the report to its end.
 # The handler finishes in abort(), so the shell sees SIGABRT (134).

--- a/tests/181_altstack-honoured.test
+++ b/tests/181_altstack-honoured.test
@@ -16,6 +16,10 @@ if ! target_is_linux; then
     exit 77
 fi
 require_httrack
+have_feature crashtest || {
+    echo "built with --disable-crash-test, skipping" >&2
+    exit 77
+}
 # A --disable-shared build has nothing to preload; anything else missing is a
 # build problem, not a skip, or the legs below would pass vacuously.
 [ -r "${ALTSTACKPROBE_LA:-}" ] || fail "${ALTSTACKPROBE_LA:-\$ALTSTACKPROBE_LA} was not built"

--- a/tests/182_crash-fork-safety.test
+++ b/tests/182_crash-fork-safety.test
@@ -15,6 +15,10 @@ if ! target_is_linux; then
     exit 77
 fi
 require_httrack
+have_feature crashtest || {
+    echo "built with --disable-crash-test, skipping" >&2
+    exit 77
+}
 build_names_frames || skip "built without <spawn.h>, so frames stay module+offset"
 # A wedged httrack still catches SIGTERM and only sets a flag, hence -s KILL.
 command -v timeout >/dev/null || fail "no timeout(1): a hang would never end here"

--- a/tests/183_altstack-worker.test
+++ b/tests/183_altstack-worker.test
@@ -21,6 +21,10 @@ Linux) traced=1 ;;
 *) traced=0 ;;
 esac
 require_httrack
+have_feature crashtest || {
+    echo "built with --disable-crash-test, skipping" >&2
+    exit 77
+}
 # --disable-auto-features drops backtrace() on Linux too, and only the trace
 # text below needs it; the sigaltstack half still applies.
 test "${traced}" -eq 0 || have_feature backtrace || traced=0
@@ -52,6 +56,13 @@ worker=$(crash_report threadstack)
 
 grep -q "Crash test worker thread started" <<<"$worker" ||
     fail "-#c=threadstack: no worker was spawned, nothing was tested"
+
+# A worker fault with the stack intact. threadstack moves two variables at once,
+# a thread the handler never registered and no stack left to run it on, so it
+# cannot show on its own that the handler reaches a worker at all.
+worker_plain=$(crash_report threadsegv)
+grep -q "Crash test worker thread started" <<<"$worker_plain" ||
+    fail "-#c=threadsegv: no worker was spawned, nothing was tested"
 
 if [ "$traced" -eq 0 ]; then
     exit 0

--- a/tests/183_altstack-worker.test
+++ b/tests/183_altstack-worker.test
@@ -57,9 +57,7 @@ worker=$(crash_report threadstack)
 grep -q "Crash test worker thread started" <<<"$worker" ||
     fail "-#c=threadstack: no worker was spawned, nothing was tested"
 
-# A worker fault with the stack intact. threadstack moves two variables at once,
-# a thread the handler never registered and no stack left to run it on, so it
-# cannot show on its own that the handler reaches a worker at all.
+# threadsegv keeps the worker's stack intact; see htscrashtest.c for why.
 worker_plain=$(crash_report threadsegv)
 grep -q "Crash test worker thread started" <<<"$worker_plain" ||
     fail "-#c=threadsegv: no worker was spawned, nothing was tested"
@@ -77,6 +75,18 @@ SEGV | BUS | ILL) ;;
 *)
     printf '%s\n' "$worker" >&2
     fail "-#c=threadstack: caught signal '${caught:-none}', expected a fault"
+    ;;
+esac
+
+# An ordinary fault, so it names a signal and stays shallow where the runaway
+# recursion below does not. Without this, threadsegv would also pass on a build
+# that faulted the main thread after the worker printed its banner.
+caught_plain=$(sed -n '/^Caught signal [0-9][0-9]*$/{s/.* //;p;q;}' <<<"$worker_plain")
+case "$(kill -l "${caught_plain:-x}" 2>/dev/null || true)" in
+SEGV | BUS | ILL) ;;
+*)
+    printf '%s\n' "$worker_plain" >&2
+    fail "-#c=threadsegv: caught signal '${caught_plain:-none}', expected a fault"
     ;;
 esac
 

--- a/tests/398_engine-build-features.test
+++ b/tests/398_engine-build-features.test
@@ -39,11 +39,12 @@ want_feature() {
         ;;
     # Absent, or defined to anything but 0, means iconv is compiled in.
     iconv) macro_is "${config}" HTS_USEICONV 0 && echo 0 || echo 1 ;;
+    crashtest) macro_is "${config}" HTS_CRASH_TEST 1 && echo 1 || echo 0 ;;
     *) fail "unknown feature $1" ;;
     esac
 }
 
-known="brotli zstd backtrace iconv"
+known="brotli zstd backtrace iconv crashtest"
 for f in ${known}; do
     got=$(sed -n "s/^${f} //p" <<<"${report}")
     test -n "${got}" || fail "-#test=features reports nothing for ${f}"

--- a/tests/398_engine-build-features.test
+++ b/tests/398_engine-build-features.test
@@ -79,6 +79,21 @@ else
     echo "ok: gb2312 does not convert, as a tables-only build cannot"
 fi
 
+# The report and config.h can agree and both be wrong about the binary, so the
+# crash option is checked against behaviour too: an unknown kind names the kinds.
+rc=0
+kinds=$(httrack -#c=bogus 2>&1) || rc=$?
+if have_feature crashtest; then
+    grep -q "expects one of:" <<<"${kinds}" ||
+        fail "crashtest is reported on, but -#c=bogus said '${kinds}'"
+    echo "ok: -#c answers, as the report says"
+else
+    if grep -q "expects one of:" <<<"${kinds}"; then
+        fail "crashtest is reported off, but -#c=bogus still names the kinds"
+    fi
+    echo "ok: -#c is gone, as the report says"
+fi
+
 # windows-1252 is the spelling HTTP headers use for the cp1252 table, and the
 # fallback used to miss it, so it is the case a tables-only build must still do.
 got=$(httrack -#test=charset windows-1252 hex:80 2>/dev/null) || got=

--- a/tests/461_engine-thread-runner.test
+++ b/tests/461_engine-thread-runner.test
@@ -1,13 +1,11 @@
 #!/bin/bash
 #
-# hts_set_thread_runner() lets an embedder wrap each worker body in a frame the
-# enter/leave hooks cannot express, such as Android's COFFEE_TRY (sigsetjmp
-# plus a block). Driven by the 'httrack -#test=threadrunner' selftest.
+# hts_set_thread_runner() wraps each worker body in a caller frame. See
+# htsthread.h for the contract. Driven by the engine's own selftest.
 
 set -eu
 
-# 'run' is an ignored placeholder argument.
-out=$(httrack -#test=threadrunner run)
+out=$(httrack -#test=threadrunner)
 
 # Exact-match the success line so a renamed or removed selftest (it prints the
 # registry to stderr) cannot pass.

--- a/tests/461_engine-thread-runner.test
+++ b/tests/461_engine-thread-runner.test
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# hts_set_thread_runner() lets an embedder wrap each worker body in a frame the
+# enter/leave hooks cannot express, such as Android's COFFEE_TRY (sigsetjmp
+# plus a block). Driven by the 'httrack -#test=threadrunner' selftest.
+
+set -eu
+
+# 'run' is an ignored placeholder argument.
+out=$(httrack -#test=threadrunner run)
+
+# Exact-match the success line so a renamed or removed selftest (it prints the
+# registry to stderr) cannot pass.
+test "$out" = "threadrunner self-test: OK" || {
+    echo "expected 'threadrunner self-test: OK', got: $out" >&2
+    exit 1
+}


### PR DESCRIPTION
`hts_newthread()` runs each worker body as a bare `fun(arg)` call. `hts_set_thread_hooks()` brackets that call but cannot enclose it, so a crash handler that must lexically wrap the body has no way in. Android's `COFFEE_TRY` is sigsetjmp plus a following block, and an enter hook has already returned by the time the body runs. `hts_set_thread_runner()` supplies the enclosing frame, between enter and leave, and returns the runner it replaced so a second embedder cannot drop the first silently. The default stays the bare call, so the CLI and every other caller are unchanged.

The httrack-android session measured this on an API 36 emulator. A plain SIGSEGV on a worker, stack intact, kills the process even while the caller sits inside its own live `COFFEE_TRY`. sigaction is process-wide, but coffeecatch's recovery context is per-thread, and the worker has none. Nothing in the tombstone that follows names the engine. This gives diagnosis, not a fix, since that app's Play data shows no native crash cluster at all.

`-#c` could fault a worker only through `threadstack`, which exhausts the stack and also runs on a thread the handler never registered. `threadsegv` adds the case that moves one variable. And `-#c` was unconditional, so an application embedding the engine shipped a deliberate crash reachable from whatever argv it builds. It now needs `HTS_CRASH_TEST`, which configure defines unless you pass `--disable-crash-test`.

The new symbol is exported, as the two neighbouring thread entry points in `htsthread.h` already are, and that header is not installed. Only what `nm -D` lists changes, so the soname holds.

`-#test=threadrunner` proves the runner encloses the body exactly once, on the worker rather than on the caller, and that NULL restores the plain call. Six mutants kill it, among them an `hts_newthread()` that runs the body synchronously and a runner called beside the body rather than around it. A `--disable-crash-test` build skips the six tests that drive `-#c` instead of failing them. 398 probes the new feature line against behaviour rather than against config.h alone, and 183 asserts that `threadsegv` names a signal and stays shallow.