### PR TITLE
A lock test writes its request into a directory it never checked is there

### DIFF
--- a/tests/436_local-abort-lock.test
+++ b/tests/436_local-abort-lock.test
@@ -34,25 +34,25 @@ assert_lockrule_selftest abortlock
 
 local_server_start
 common=(--quiet --disable-security-limits --robots=0 --timeout=30 --retries=0 -c1)
+fail_dump_var crawllog
 
 # /trickle/ hands out eight .bin pages, two bytes a second for a minute each, so
 # the single socket is busy and only the reading inside that wait can see this.
 printf '[a running engine takes the request] ..\t'
 out="${tmpdir}/running"
+crawllog="${tmpdir}/log-running"
 httrack -O "$out" "${common[@]}" "${BASEURL}/trickle/index.html" \
-    >"${tmpdir}/log-running" 2>&1 &
+    >"$crawllog" 2>&1 &
 crawlpid=$!
-wait_until_running "test -e '${out}/${PROGRESSLOCK}'" "the crawl never got going" \
-    "$crawlpid" "${tmpdir}/log-running"
+wait_until_still_running "test -e '${out}/${PROGRESSLOCK}'" "the crawl never got going" "$crawlpid"
 # The engine dates that lock a second back, so a request written the instant it
 # appears is newer than it whatever resolution the filesystem keeps.
 : >"${tmpdir}/probe"
 test "$(mtime "${tmpdir}/probe")" -gt "$(mtime "${out}/${PROGRESSLOCK}")" ||
     fail "the engine did not date ${PROGRESSLOCK} back, so a request written the moment it appears can tie it"
-lock_request "$out" "$ABORTLOCK" "$crawlpid" "${tmpdir}/log-running"
-wait_until_running "test ! -e '${out}/${ABORTLOCK}'" \
-    "30s on, a running engine had not read the request" \
-    "$crawlpid" "${tmpdir}/log-running"
+write_lock_request "$out" "$ABORTLOCK" "$crawlpid"
+wait_until_still_running "test ! -e '${out}/${ABORTLOCK}'" \
+    "30s on, a running engine had not read the request" "$crawlpid"
 stop_crawl
 echo "OK"
 
@@ -61,18 +61,17 @@ echo "OK"
 # does the -E budget, so only the directory tells them apart.
 printf '[an abort keeps the cut transfers] ..\t'
 out="${tmpdir}/keep"
+crawllog="${tmpdir}/log-keep"
 httrack -O "$out" "${common[@]}" --max-rate=200000 \
-    "${BASEURL}/bigfiles/index.html" >"${tmpdir}/log-keep" 2>&1 &
+    "${BASEURL}/bigfiles/index.html" >"$crawllog" 2>&1 &
 crawlpid=$!
-wait_until_running "test -e '${out}/${PROGRESSLOCK}'" "the crawl never got going" \
-    "$crawlpid" "${tmpdir}/log-keep"
+wait_until_still_running "test -e '${out}/${PROGRESSLOCK}'" "the crawl never got going" "$crawlpid"
 # The abort has to find a transfer already running, or there is no resume data
 # for it to keep.
 sleep 1
-lock_request "$out" "$ABORTLOCK" "$crawlpid" "${tmpdir}/log-keep"
-wait_until_running "test ! -e '${out}/${ABORTLOCK}'" \
-    "30s on, a running engine had not read the request" \
-    "$crawlpid" "${tmpdir}/log-keep"
+write_lock_request "$out" "$ABORTLOCK" "$crawlpid"
+wait_until_still_running "test ! -e '${out}/${ABORTLOCK}'" \
+    "30s on, a running engine had not read the request" "$crawlpid"
 # The erase happens at shutdown, and unwinding the cut transfer takes a while.
 wait_until "! kill -0 '$crawlpid' 2>/dev/null" "the engine never shut down" 900
 wait "$crawlpid" 2>/dev/null || true
@@ -84,14 +83,13 @@ echo "OK"
 # The pause wait watches for it too, or a paused engine is unreachable.
 printf '[a paused engine takes the request] ..\t'
 out="${tmpdir}/paused"
+crawllog="${tmpdir}/log-paused"
 httrack -O "$out" "${common[@]}" --max-rate=200000 \
-    "${BASEURL}/bigfiles/index.html" >"${tmpdir}/log-paused" 2>&1 &
+    "${BASEURL}/bigfiles/index.html" >"$crawllog" 2>&1 &
 crawlpid=$!
-wait_until_running "test -e '${out}/${PROGRESSLOCK}'" "the crawl never got going" \
-    "$crawlpid" "${tmpdir}/log-paused"
-lock_request "$out" hts-stop.lock "$crawlpid" "${tmpdir}/log-paused"
-wait_until_running "test -e '${out}/hts-paused.lock'" "the engine never paused" \
-    "$crawlpid" "${tmpdir}/log-paused"
+wait_until_still_running "test -e '${out}/${PROGRESSLOCK}'" "the crawl never got going" "$crawlpid"
+write_lock_request "$out" hts-stop.lock "$crawlpid"
+wait_until_still_running "test -e '${out}/hts-paused.lock'" "the engine never paused" "$crawlpid"
 # A frozen mirror writes nothing, and the wait re-reads once a second, so three
 # seconds cover an iteration that saw the file and a resumed 200KB/s transfer.
 frozen=$(du -sk "$out")
@@ -101,10 +99,9 @@ test "$(du -sk "$out")" = "$frozen" ||
     fail "a request left by an earlier run lifted the pause"
 test -e "${out}/${ABORTLOCK}" ||
     fail "the pause wait deleted a request that was never aimed at it"
-lock_request "$out" "$ABORTLOCK" "$crawlpid" "${tmpdir}/log-paused"
-wait_until_running "test ! -e '${out}/${ABORTLOCK}'" \
-    "30s on, a paused engine had not read the request" \
-    "$crawlpid" "${tmpdir}/log-paused"
+write_lock_request "$out" "$ABORTLOCK" "$crawlpid"
+wait_until_still_running "test ! -e '${out}/${ABORTLOCK}'" \
+    "30s on, a paused engine had not read the request" "$crawlpid"
 stop_crawl
 echo "OK"
 

--- a/tests/436_local-abort-lock.test
+++ b/tests/436_local-abort-lock.test
@@ -42,15 +42,17 @@ out="${tmpdir}/running"
 httrack -O "$out" "${common[@]}" "${BASEURL}/trickle/index.html" \
     >"${tmpdir}/log-running" 2>&1 &
 crawlpid=$!
-wait_until "test -e '${out}/${PROGRESSLOCK}'" "the crawl never got going"
+wait_until_running "test -e '${out}/${PROGRESSLOCK}'" "the crawl never got going" \
+    "$crawlpid" "${tmpdir}/log-running"
 # The engine dates that lock a second back, so a request written the instant it
 # appears is newer than it whatever resolution the filesystem keeps.
 : >"${tmpdir}/probe"
 test "$(mtime "${tmpdir}/probe")" -gt "$(mtime "${out}/${PROGRESSLOCK}")" ||
     fail "the engine did not date ${PROGRESSLOCK} back, so a request written the moment it appears can tie it"
-: >"${out}/${ABORTLOCK}"
-wait_until "test ! -e '${out}/${ABORTLOCK}'" \
-    "30s on, a running engine had not read the request"
+lock_request "$out" "$ABORTLOCK" "$crawlpid" "${tmpdir}/log-running"
+wait_until_running "test ! -e '${out}/${ABORTLOCK}'" \
+    "30s on, a running engine had not read the request" \
+    "$crawlpid" "${tmpdir}/log-running"
 stop_crawl
 echo "OK"
 
@@ -62,13 +64,15 @@ out="${tmpdir}/keep"
 httrack -O "$out" "${common[@]}" --max-rate=200000 \
     "${BASEURL}/bigfiles/index.html" >"${tmpdir}/log-keep" 2>&1 &
 crawlpid=$!
-wait_until "test -e '${out}/${PROGRESSLOCK}'" "the crawl never got going"
+wait_until_running "test -e '${out}/${PROGRESSLOCK}'" "the crawl never got going" \
+    "$crawlpid" "${tmpdir}/log-keep"
 # The abort has to find a transfer already running, or there is no resume data
 # for it to keep.
 sleep 1
-: >"${out}/${ABORTLOCK}"
-wait_until "test ! -e '${out}/${ABORTLOCK}'" \
-    "30s on, a running engine had not read the request"
+lock_request "$out" "$ABORTLOCK" "$crawlpid" "${tmpdir}/log-keep"
+wait_until_running "test ! -e '${out}/${ABORTLOCK}'" \
+    "30s on, a running engine had not read the request" \
+    "$crawlpid" "${tmpdir}/log-keep"
 # The erase happens at shutdown, and unwinding the cut transfer takes a while.
 wait_until "! kill -0 '$crawlpid' 2>/dev/null" "the engine never shut down" 900
 wait "$crawlpid" 2>/dev/null || true
@@ -83,9 +87,11 @@ out="${tmpdir}/paused"
 httrack -O "$out" "${common[@]}" --max-rate=200000 \
     "${BASEURL}/bigfiles/index.html" >"${tmpdir}/log-paused" 2>&1 &
 crawlpid=$!
-wait_until "test -e '${out}/${PROGRESSLOCK}'" "the crawl never got going"
-: >"${out}/hts-stop.lock"
-wait_until "test -e '${out}/hts-paused.lock'" "the engine never paused"
+wait_until_running "test -e '${out}/${PROGRESSLOCK}'" "the crawl never got going" \
+    "$crawlpid" "${tmpdir}/log-paused"
+lock_request "$out" hts-stop.lock "$crawlpid" "${tmpdir}/log-paused"
+wait_until_running "test -e '${out}/hts-paused.lock'" "the engine never paused" \
+    "$crawlpid" "${tmpdir}/log-paused"
 # A frozen mirror writes nothing, and the wait re-reads once a second, so three
 # seconds cover an iteration that saw the file and a resumed 200KB/s transfer.
 frozen=$(du -sk "$out")
@@ -95,9 +101,10 @@ test "$(du -sk "$out")" = "$frozen" ||
     fail "a request left by an earlier run lifted the pause"
 test -e "${out}/${ABORTLOCK}" ||
     fail "the pause wait deleted a request that was never aimed at it"
-: >"${out}/${ABORTLOCK}"
-wait_until "test ! -e '${out}/${ABORTLOCK}'" \
-    "30s on, a paused engine had not read the request"
+lock_request "$out" "$ABORTLOCK" "$crawlpid" "${tmpdir}/log-paused"
+wait_until_running "test ! -e '${out}/${ABORTLOCK}'" \
+    "30s on, a paused engine had not read the request" \
+    "$crawlpid" "${tmpdir}/log-paused"
 stop_crawl
 echo "OK"
 

--- a/tests/459_local-stop-lock.test
+++ b/tests/459_local-stop-lock.test
@@ -64,10 +64,12 @@ out="${tmpdir}/fresh"
 httrack -O "$out" "${common[@]}" --max-rate=200000 \
     "${BASEURL}/bigfiles/index.html" >"${tmpdir}/log-fresh" 2>&1 &
 crawlpid=$!
-wait_until "test -e '${out}/${PROGRESSLOCK}'" "the crawl never got going"
-: >"${out}/${STOPLOCK}"
-wait_until "test -e '${out}/${PAUSEDLOCK}'" \
-    "30s on, a running engine had not paused"
+wait_until_running "test -e '${out}/${PROGRESSLOCK}'" "the crawl never got going" \
+    "$crawlpid" "${tmpdir}/log-fresh"
+lock_request "$out" "$STOPLOCK" "$crawlpid" "${tmpdir}/log-fresh"
+wait_until_running "test -e '${out}/${PAUSEDLOCK}'" \
+    "30s on, a running engine had not paused" \
+    "$crawlpid" "${tmpdir}/log-fresh"
 test ! -e "${out}/${STOPLOCK}" ||
     fail "the engine paused without taking the request that asked for it"
 stop_crawl

--- a/tests/459_local-stop-lock.test
+++ b/tests/459_local-stop-lock.test
@@ -35,6 +35,7 @@ assert_lockrule_selftest stoplock
 
 local_server_start
 common=(--quiet --disable-security-limits --robots=0 --timeout=30 --retries=0 -c1)
+fail_dump_var crawllog
 
 # Before the staleness rule the engine took any hts-stop.lock it found, so a
 # copy left in a reused output directory paused the next mirror. Dated back,
@@ -42,10 +43,11 @@ common=(--quiet --disable-security-limits --robots=0 --timeout=30 --retries=0 -c
 # just before the mirror starts lands inside that second.
 printf '[a request left behind does not pause the next mirror] ..\t'
 out="${tmpdir}/stale"
+crawllog="${tmpdir}/log-stale"
 mkdir -p "$out"
 touch -t 200001010000 "${out}/${STOPLOCK}"
 httrack -O "$out" "${common[@]}" "${BASEURL}/simple/basic.html" \
-    >"${tmpdir}/log-stale" 2>&1 &
+    >"$crawllog" 2>&1 &
 crawlpid=$!
 wait_until "! kill -0 '$crawlpid' 2>/dev/null" \
     "60s on, the mirror had not finished: the request it inherited paused it" 600
@@ -61,15 +63,14 @@ echo "OK"
 # still pauses. Rate-capped /bigfiles/ keeps the engine polling long enough.
 printf '[a request aimed at this run pauses it] ..\t'
 out="${tmpdir}/fresh"
+crawllog="${tmpdir}/log-fresh"
 httrack -O "$out" "${common[@]}" --max-rate=200000 \
-    "${BASEURL}/bigfiles/index.html" >"${tmpdir}/log-fresh" 2>&1 &
+    "${BASEURL}/bigfiles/index.html" >"$crawllog" 2>&1 &
 crawlpid=$!
-wait_until_running "test -e '${out}/${PROGRESSLOCK}'" "the crawl never got going" \
-    "$crawlpid" "${tmpdir}/log-fresh"
-lock_request "$out" "$STOPLOCK" "$crawlpid" "${tmpdir}/log-fresh"
-wait_until_running "test -e '${out}/${PAUSEDLOCK}'" \
-    "30s on, a running engine had not paused" \
-    "$crawlpid" "${tmpdir}/log-fresh"
+wait_until_still_running "test -e '${out}/${PROGRESSLOCK}'" "the crawl never got going" "$crawlpid"
+write_lock_request "$out" "$STOPLOCK" "$crawlpid"
+wait_until_still_running "test -e '${out}/${PAUSEDLOCK}'" \
+    "30s on, a running engine had not paused" "$crawlpid"
 test ! -e "${out}/${STOPLOCK}" ||
     fail "the engine paused without taking the request that asked for it"
 stop_crawl

--- a/tests/crawllib.sh
+++ b/tests/crawllib.sh
@@ -216,3 +216,35 @@ assert_lockrule_selftest() {
         fail "the rule self-test said nothing about a same-second request"
     echo "OK (${coverage#*: }, ${subsecond#*request: })"
 }
+
+# Drop NAME in a running engine's output directory to ask it for something. The
+# engine makes that directory itself, so a bare redirect there can report ENOENT
+# for three different reasons, and this one names which.
+lock_request() { # lock_request DIR NAME PID LOG
+    local dir=$1 name=$2 pid=$3 log=$4 i
+    for ((i = 0; i < 50; i++)); do
+        if test -d "$dir" && : >"${dir}/${name}" 2>/dev/null; then return 0; fi
+        kill -0 "$pid" 2>/dev/null ||
+            fail_dump "the engine exited before it could be asked for ${name}" "$log"
+        test -d "$(dirname "$dir")" ||
+            fail "$(dirname "$dir") is gone: something removed it under a running test"
+        sleep 0.1
+    done
+    fail_dump "5s on, ${name} could not be written into ${dir}" "$log"
+}
+
+# wait_until for a condition only a live engine can reach, so an engine that
+# died is named rather than blamed for ignoring a request it never saw.
+wait_until_running() { # wait_until_running CONDITION MSG PID LOG [tenths, default 300]
+    local cond=$1 msg=$2 pid=$3 log=$4 i alive
+    for ((i = 0; i < ${5:-300}; i++)); do
+        # Sampled before the condition, so one satisfied on the way out is taken.
+        alive=1
+        kill -0 "$pid" 2>/dev/null || alive=
+        if eval "$cond"; then return 0; fi
+        test -n "$alive" ||
+            fail_dump "the engine exited first, so it never reached: ${msg}" "$log"
+        sleep 0.1
+    done
+    fail_dump "$msg" "$log"
+}

--- a/tests/crawllib.sh
+++ b/tests/crawllib.sh
@@ -217,34 +217,30 @@ assert_lockrule_selftest() {
     echo "OK (${coverage#*: }, ${subsecond#*request: })"
 }
 
-# Drop NAME in a running engine's output directory to ask it for something. The
-# engine makes that directory itself, so a bare redirect there can report ENOENT
-# for three different reasons, and this one names which.
-lock_request() { # lock_request DIR NAME PID LOG
-    local dir=$1 name=$2 pid=$3 log=$4 i
-    for ((i = 0; i < 50; i++)); do
-        if test -d "$dir" && : >"${dir}/${name}" 2>/dev/null; then return 0; fi
-        kill -0 "$pid" 2>/dev/null ||
-            fail_dump "the engine exited before it could be asked for ${name}" "$log"
-        test -d "$(dirname "$dir")" ||
-            fail "$(dirname "$dir") is gone: something removed it under a running test"
-        sleep 0.1
-    done
-    fail_dump "5s on, ${name} could not be written into ${dir}" "$log"
+# Ask a running engine for something by dropping NAME in its output directory.
+# A bare redirect there reports ENOENT for three reasons a caller cannot separate.
+write_lock_request() { # write_lock_request DIR NAME PID
+    local dir=$1 name=$2 pid=$3
+    : >"${dir}/${name}" 2>/dev/null && return 0
+    kill -0 "$pid" 2>/dev/null ||
+        fail "the engine exited before it could be asked for ${name}"
+    test -d "$(dirname "$dir")" ||
+        fail "$(dirname "$dir") is gone: something removed it under a running test"
+    fail "${name} could not be written into ${dir}"
 }
 
 # wait_until for a condition only a live engine can reach, so an engine that
-# died is named rather than blamed for ignoring a request it never saw.
-wait_until_running() { # wait_until_running CONDITION MSG PID LOG [tenths, default 300]
-    local cond=$1 msg=$2 pid=$3 log=$4 i alive
-    for ((i = 0; i < ${5:-300}; i++)); do
-        # Sampled before the condition, so one satisfied on the way out is taken.
+# died is named, not blamed for missing the request. Liveness is read before the
+# condition, so one the engine satisfies as it exits is still taken.
+wait_until_still_running() { # wait_until_still_running CONDITION MESSAGE PID
+    local cond=$1 msg=$2 pid=$3 alive
+    for _ in $(seq 1 300); do
         alive=1
         kill -0 "$pid" 2>/dev/null || alive=
         if eval "$cond"; then return 0; fi
         test -n "$alive" ||
-            fail_dump "the engine exited first, so it never reached: ${msg}" "$log"
+            fail "the engine exited first, so it never reached: ${msg}"
         sleep 0.1
     done
-    fail_dump "$msg" "$log"
+    fail "$msg"
 }


### PR DESCRIPTION
`436_local-abort-lock` and `459_local-stop-lock` went red on the Windows x64 leg of #1628 and #1630. Both died on a bare `hts-abort.lock: No such file or directory` from the shell redirect that drops the request. Neither PR touches lock code, and the same tests passed on the Win32 leg of the same run.

The engine creates the output directory itself, and both tests write into it as soon as `hts-in_progress.lock` appears. #1619 removed the `sleep 1` that used to sit between those two steps, so the write now lands as early as it can. Nothing checks that the directory is still there or that the engine is still running, and a redirect that fails says only ENOENT. The engine only ever removes `hts-cache` and `hts-cache/ref`, so whatever took the output directory is on the Windows side and is still unidentified.

`write_lock_request` and `wait_until_still_running` in `crawllib.sh` replace the bare redirects and the waits after them, and name which of three causes a failure was. `wait_until_still_running` reads liveness before the condition, so an engine that satisfies one on its way out is still taken. This does not stop the directory going away. When it goes, the test now says so instead of printing ENOENT.

I drove both helpers through every branch, and ran both tests against two engine mutants. One is a `hts_take_lock_request` that always refuses, the other is poll sites that ignore a genuine request. Both tests still fail on both, now with the crawl log attached.
