### PR TITLE
Building the engine sources without autotools fails on a generated header

### DIFF
--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -113,12 +113,15 @@ Please visit our Website: http://www.httrack.com
 
 #else
 
-/* config.h is private: an autoconf consumer has one of its own, so only the
-   switches the installed headers read are published, in htsfeatures.h. */
+/* config.h is private, because an autoconf consumer has one of its own, so the
+   switches the installed headers read are published in htsfeatures.h too. Our
+   own build reads config.h and must not need the generated public header, or a
+   consumer compiling these sources without autotools cannot build at all. */
 #ifdef HTS_INTERNAL_BUILD
 #include "config.h"
-#endif
+#else
 #include "htsfeatures.h"
+#endif
 
 #ifndef SETUID
 #define HTS_DO_NOT_USE_UID

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -113,10 +113,9 @@ Please visit our Website: http://www.httrack.com
 
 #else
 
-/* config.h is private, because an autoconf consumer has one of its own, so the
-   switches the installed headers read are published in htsfeatures.h too. Our
-   own build reads config.h and must not need the generated public header, or a
-   consumer compiling these sources without autotools cannot build at all. */
+/* config.h is private: an autoconf consumer has one of its own, so only the
+   switches the installed headers read are published, in htsfeatures.h. An
+   internal build reads config.h and must not need the generated one. */
 #ifdef HTS_INTERNAL_BUILD
 #include "config.h"
 #else

--- a/tests/462_internal-build-no-htsfeatures.test
+++ b/tests/462_internal-build-no-htsfeatures.test
@@ -22,36 +22,48 @@ fi
 read -r -a cc_argv <<<"${CC:-cc}"
 command -v "${cc_argv[0]}" >/dev/null 2>&1 || skip "no C compiler (${cc_argv[0]})"
 
+src="$testdir/../src"
 tmp=$(mktemp -d) || exit 1
 cleanup_push rm -rf "$tmp"
 
-# What the embedder has: its own config.h, the sources, and nothing generated.
+# What the embedder has: its own config.h, the sources, nothing generated.
 cp "$abs_top_builddir/config.h" "$tmp/config.h"
-[ ! -e "$tmp/htsfeatures.h" ] || fail "the probe directory holds a generated header"
 printf '#include "htsglobal.h"\n' >"$tmp/tu.c"
 
-cpp_argv=(-I"$tmp" -I"$testdir/../src")
+cpp_argv=(-I"$tmp" -I"$src")
 if [ -n "${TEST_CPPFLAGS:-}" ]; then
     read -r -a extra_argv <<<"$TEST_CPPFLAGS"
-    cpp_argv+=("${extra_argv[@]}")
+    # The +"..." form keeps bash 3.2 from tripping over an empty array here.
+    cpp_argv+=(${extra_argv[@]+"${extra_argv[@]}"})
 fi
 
-probe() { # probe LOGFILE [extra cc args...]
+probe() { # probe LOGFILE [cc args...]
     local log="$1"
     shift
     "${cc_argv[@]}" "$@" "${cpp_argv[@]}" -fsyntax-only "$tmp/tu.c" >"$log" 2>&1
 }
+
+# A toolchain that cannot manage this has nothing to say about the header.
+printf '#include <stdio.h>\n' >"$tmp/bare.c"
+"${cc_argv[@]}" "${cpp_argv[@]}" -fsyntax-only "$tmp/bare.c" 2>/dev/null ||
+    skip "${cc_argv[*]} cannot compile a bare <stdio.h>"
 
 if ! probe "$tmp/internal.log" -DHTS_INTERNAL_BUILD; then
     head -5 "$tmp/internal.log" >&2
     fail "an internal build cannot compile htsglobal.h without htsfeatures.h"
 fi
 
-# Control: the same probe with no config.h to fall back on must miss the public
-# header, or the check above would pass on a path that reaches one anyway.
+# Control: the same probe minus the define must miss the public header, or the
+# check above would pass on an include path that reaches one anyway.
 if probe "$tmp/consumer.log"; then
     fail "a consumer built without htsfeatures.h, so the probe reaches one somewhere"
 fi
 grep -q "htsfeatures.h" "$tmp/consumer.log" ||
     fail "the control failed for some other reason: $(head -1 "$tmp/consumer.log")"
+
+# The gate above covers the tree only while htsglobal.h is the sole includer.
+others=$(grep -rl '^#include "htsfeatures.h"' "$src" | grep -v '/htsglobal\.h$' || true)
+[ -z "$others" ] || fail "these bypass the gate and include htsfeatures.h: $others"
+
 echo "ok: htsglobal.h needs htsfeatures.h only outside HTS_INTERNAL_BUILD"
+exit 0

--- a/tests/462_internal-build-no-htsfeatures.test
+++ b/tests/462_internal-build-no-htsfeatures.test
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# An embedder compiling these sources with its own config.h never generates
+# htsfeatures.h, so htsglobal.h must not need one under HTS_INTERNAL_BUILD.
+# 381 guards the other half, the installed headers a consumer sees.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+skip_on_emulated "a header self-sufficiency check cannot vary by target"
+
+# Unset means no automake run (the Windows job runs the scripts directly).
+if [ -z "${abs_top_builddir:-}" ]; then
+    echo "abs_top_builddir unset, no automake environment, skipping" >&2
+    exit 77
+fi
+[ -f "$abs_top_builddir/config.h" ] || fail "$abs_top_builddir holds no config.h"
+
+# CC carries flags on some legs ("gcc -m32", "ccache gcc"), so split it.
+read -r -a cc_argv <<<"${CC:-cc}"
+command -v "${cc_argv[0]}" >/dev/null 2>&1 || skip "no C compiler (${cc_argv[0]})"
+
+tmp=$(mktemp -d) || exit 1
+cleanup_push rm -rf "$tmp"
+
+# What the embedder has: its own config.h, the sources, and nothing generated.
+cp "$abs_top_builddir/config.h" "$tmp/config.h"
+[ ! -e "$tmp/htsfeatures.h" ] || fail "the probe directory holds a generated header"
+printf '#include "htsglobal.h"\n' >"$tmp/tu.c"
+
+cpp_argv=(-I"$tmp" -I"$testdir/../src")
+if [ -n "${TEST_CPPFLAGS:-}" ]; then
+    read -r -a extra_argv <<<"$TEST_CPPFLAGS"
+    cpp_argv+=("${extra_argv[@]}")
+fi
+
+probe() { # probe LOGFILE [extra cc args...]
+    local log="$1"
+    shift
+    "${cc_argv[@]}" "$@" "${cpp_argv[@]}" -fsyntax-only "$tmp/tu.c" >"$log" 2>&1
+}
+
+if ! probe "$tmp/internal.log" -DHTS_INTERNAL_BUILD; then
+    head -5 "$tmp/internal.log" >&2
+    fail "an internal build cannot compile htsglobal.h without htsfeatures.h"
+fi
+
+# Control: the same probe with no config.h to fall back on must miss the public
+# header, or the check above would pass on a path that reaches one anyway.
+if probe "$tmp/consumer.log"; then
+    fail "a consumer built without htsfeatures.h, so the probe reaches one somewhere"
+fi
+grep -q "htsfeatures.h" "$tmp/consumer.log" ||
+    fail "the control failed for some other reason: $(head -1 "$tmp/consumer.log")"
+echo "ok: htsglobal.h needs htsfeatures.h only outside HTS_INTERNAL_BUILD"


### PR DESCRIPTION
`htsglobal.h` has included `htsfeatures.h` unconditionally since #1473, and configure generates that header. So anything building these sources without autotools fails on its first translation unit. The httrack-android session hit it while bumping its engine pin, and reported it.

The quieter half is why this is worth more than a missing include path. Their JNI glue compiles as a separate module and did not define `HTS_INTERNAL_BUILD`. Under the current gate it would have taken the consumer path, seeing `HTS_INET6` and `HTS_USEOPENSSL` undefined while the engine module had them set. That is the `SOCaddr` and `htsblk` desync `htsfeatures.h.in` warns about, across two shared libraries, and it builds and links before it reads the wrong offsets.

`config.h` carries the same switches, so an internal build has no use for the generated public header. All twelve macros the public header publishes are defined identically in both files, so reading `config.h` alone loses nothing.

Test 462 compiles `htsglobal.h` under `HTS_INTERNAL_BUILD` against a config.h and no `htsfeatures.h`, which is what an embedder has. Its control drops the define and requires the same compile to fail, naming the missing header. A probe that reaches a generated header anyway cannot then pass quietly. The test fails on the header as it stands today, and 381 already guards the other direction.
