### PR TITLE
A crawl test can assert a marker is absent from a file the mirror never wrote

### DIFF
--- a/tests/260_crawl-harness-fails-loudly.test
+++ b/tests/260_crawl-harness-fails-loudly.test
@@ -47,6 +47,18 @@ test "$rc" -ne 0 || fail "a wrong file count reported success: $out"
 assert_match "expected '999'" "$out" "the audit names the value it wanted"
 ok "a failing audit fails the run"
 
+# A negative file audit on a file the crawl never wrote: grep exits 2 there,
+# which is indistinguishable from "no match", so the audit passed on anything
+# (#1627). The floor below it proves the audit still passes when it should.
+run --errors 0 --file-not-matches 'simple/nosuchfile.html' 'anything' httrack "$url"
+test "$rc" -ne 0 || fail "a negative file audit passed on a missing file: $out"
+assert_match "no such file" "$out" "the missing path is named"
+ok "a negative file audit fails when the file is missing"
+
+run --errors 0 --file-not-matches 'simple/basic.html' 'NOT-IN-THIS-PAGE' httrack "$url"
+test "$rc" -eq 0 || fail "a negative file audit failed on a present file: $out"
+ok "a negative file audit still passes on a file lacking the marker"
+
 # A directory named after a searched word must not answer for the crawl (#1220):
 # TMPDIR plants one on the command line the log echoes.
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_logbody.XXXXXX") || exit 1

--- a/tests/260_crawl-harness-fails-loudly.test
+++ b/tests/260_crawl-harness-fails-loudly.test
@@ -47,17 +47,59 @@ test "$rc" -ne 0 || fail "a wrong file count reported success: $out"
 assert_match "expected '999'" "$out" "the audit names the value it wanted"
 ok "a failing audit fails the run"
 
-# A negative file audit on a file the crawl never wrote: grep exits 2 there,
-# which is indistinguishable from "no match", so the audit passed on anything
-# (#1627). The floor below it proves the audit still passes when it should.
-run --errors 0 --file-not-matches 'simple/nosuchfile.html' 'anything' httrack "$url"
+# grep exits 2 on a file it cannot read, which reads as "no match" and makes the
+# audit meaningless (#1627). The runs below it prove it still passes on a real
+# miss, an empty file included.
+run --errors 0 --file-not-matches 'simple/nosuchfile.html' 'x' httrack "$url"
 test "$rc" -ne 0 || fail "a negative file audit passed on a missing file: $out"
-assert_match "no such file" "$out" "the missing path is named"
+assert_match "no regular file" "$out" "the missing path is named"
 ok "a negative file audit fails when the file is missing"
 
-run --errors 0 --file-not-matches 'simple/basic.html' 'NOT-IN-THIS-PAGE' httrack "$url"
+# A directory is not a readable file either, and grep's status for one varies
+# by platform.
+run --errors 0 --plant-dir simple/adir --file-not-matches 'simple/adir' 'x' \
+    httrack "$url"
+test "$rc" -ne 0 || fail "a negative file audit passed on a directory: $out"
+assert_match "no regular file" "$out" "the directory is not taken for a file"
+ok "a negative file audit fails on a directory at the audited path"
+
+# The other exit 2 comes from a regular file grep cannot open, and root reads
+# one regardless.
+if test "$(id -u)" -eq 0; then
+    ok "SKIP the unreadable-file case, root reads it regardless"
+else
+    # The host root sits three levels under $TMPDIR, so a layout change fails
+    # the assert below rather than passing quietly.
+    unread=$(mktemp -d "${TMPDIR:-/tmp}/httrack_unread.XXXXXX") || exit 1
+    cleanup_push rm -rf "$unread"
+    echo marker >"$unread/locked.dat"
+    chmod 000 "$unread/locked.dat"
+    rc=0
+    out=$(TMPDIR="$unread" bash "$crawl" --errors 0 \
+        --file-not-matches '../../../locked.dat' 'marker' \
+        httrack "$url" 2>&1) || rc=$?
+    test "$rc" -ne 0 || fail "an unreadable file passed the audit: $out"
+    assert_match "grep could not read" "$out" "the unreadable path is named"
+    ok "a negative file audit fails on a file grep cannot read"
+fi
+
+run --errors 0 --file-not-matches 'simple/basic.html' 'NOT-HERE' httrack "$url"
 test "$rc" -eq 0 || fail "a negative file audit failed on a present file: $out"
 ok "a negative file audit still passes on a file lacking the marker"
+
+# A 0-byte mirrored file lacks every marker, so it must pass rather than read
+# as absent. errpage/empty.html is the fixture's genuine zero-length 200.
+run --errors 1 --file-not-matches 'errpage/empty.html' 'x' \
+    httrack 'BASEURL/errpage/index.html'
+test "$rc" -eq 0 || fail "a negative file audit failed on an empty file: $out"
+ok "a negative file audit passes on an empty mirrored file"
+
+# The mirror bounds share the vacuity, because an empty mirror is under every
+# ceiling. Seeding at a 404 under -o0 leaves the host root present and empty.
+run --errors 1 --min-mirror-bytes 400 httrack 'BASEURL/errpage/missing.html' -o0
+test "$rc" -ne 0 || fail "a mirror floor passed on an empty mirror: $out"
+assert_match "mirror too small" "$out" "the floor names what it wanted"
+ok "a mirror floor fails when nothing was saved"
 
 # A directory named after a searched word must not answer for the crawl (#1220):
 # TMPDIR plants one on the command line the log echoes.

--- a/tests/260_crawl-harness-fails-loudly.test
+++ b/tests/260_crawl-harness-fails-loudly.test
@@ -95,11 +95,16 @@ test "$rc" -eq 0 || fail "a negative file audit failed on an empty file: $out"
 ok "a negative file audit passes on an empty mirrored file"
 
 # The mirror bounds share the vacuity, because an empty mirror is under every
-# ceiling. Seeding at a 404 under -o0 leaves the host root present and empty.
-run --errors 1 --min-mirror-bytes 400 httrack 'BASEURL/errpage/missing.html' -o0
-test "$rc" -ne 0 || fail "a mirror floor passed on an empty mirror: $out"
+# ceiling and only a floor says anything landed. Both runs use the healthy crawl
+# and bounds no platform can straddle, since how much a crawl saves varies.
+run --errors 0 --min-mirror-bytes 99999999 httrack "$url"
+test "$rc" -ne 0 || fail "a mirror floor passed under the bound: $out"
 assert_match "mirror too small" "$out" "the floor names what it wanted"
-ok "a mirror floor fails when nothing was saved"
+ok "a mirror floor fails when the mirror is under the bound"
+
+run --errors 0 --min-mirror-bytes 1 httrack "$url"
+test "$rc" -eq 0 || fail "a mirror floor failed over the bound: $out"
+ok "a mirror floor passes when the mirror is over the bound"
 
 # A directory named after a searched word must not answer for the crawl (#1220):
 # TMPDIR plants one on the command line the log echoes.

--- a/tests/45_local-maxsize-recv.test
+++ b/tests/45_local-maxsize-recv.test
@@ -9,10 +9,11 @@ set -euo pipefail
 
 # The mirror bound is the load-bearing half: it fires while <100 KB is saved,
 # so the cap can only have tripped on received volume, not saved bytes (which
-# would exceed the cap and fetch all 16 links). The floor is what makes the
-# ceiling mean anything: only the seed page is saved, 575 bytes of it.
+# would exceed the cap and fetch all 16 links). The floor matters because only
+# the seed page, 575 bytes, is saved.
 bash "$top_srcdir/tests/local-crawl.sh" \
     --log-found 'More than 500000 bytes have been transferred.. giving up' \
+    --found maxrecv/index.html \
     --max-mirror-bytes 100000 \
     --min-mirror-bytes 400 \
     httrack 'BASEURL/maxrecv/index.html' -M500000 -c4

--- a/tests/45_local-maxsize-recv.test
+++ b/tests/45_local-maxsize-recv.test
@@ -9,8 +9,10 @@ set -euo pipefail
 
 # The mirror bound is the load-bearing half: it fires while <100 KB is saved,
 # so the cap can only have tripped on received volume, not saved bytes (which
-# would exceed the cap and fetch all 16 links).
+# would exceed the cap and fetch all 16 links). The floor is what makes the
+# ceiling mean anything: only the seed page is saved, 575 bytes of it.
 bash "$top_srcdir/tests/local-crawl.sh" \
     --log-found 'More than 500000 bytes have been transferred.. giving up' \
     --max-mirror-bytes 100000 \
+    --min-mirror-bytes 400 \
     httrack 'BASEURL/maxrecv/index.html' -M500000 -c4

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -26,7 +26,8 @@
 # --log-found/--log-not-found grep (ERE) the crawl's hts-log.txt.
 # --max/--min-mirror-bytes bound the mirrored content bytes (host root).
 # --file-matches/--file-not-matches grep (ERE) a mirrored file (PATH under the
-# host root), to assert rewritten link/content survived the crawl.
+# host root), to assert rewritten link/content survived the crawl. Both fail
+# when PATH is missing.
 # --cache-found/--cache-not-found assert whether hts-cache/new.zip holds an
 # entry whose URL ends with URLTAIL, e.g. /dir/page.html; being mirrored and
 # being cached are separate outcomes (#840).
@@ -719,7 +720,12 @@ while test "$i" -lt "${#audit[@]}"; do
         path="${audit[$((i + 1))]}"
         i=$((i + 2))
         info "checking ${path} lacks ${audit[$i]}"
-        if grep -aqE "${audit[$i]}" "${hostroot}/${path}"; then
+        # grep exits 2 on a missing path, which reads like "no match": test the
+        # file first, or a crawl that wrote nothing satisfies this audit (#1627).
+        if test ! -f "${hostroot}/${path}"; then
+            result "no such file ${hostroot}/${path}"
+            exit 1
+        elif grep -aqE "${audit[$i]}" "${hostroot}/${path}"; then
             result "matched"
             exit 1
         else result "OK"; fi

--- a/tests/local-crawl.sh
+++ b/tests/local-crawl.sh
@@ -27,7 +27,7 @@
 # --max/--min-mirror-bytes bound the mirrored content bytes (host root).
 # --file-matches/--file-not-matches grep (ERE) a mirrored file (PATH under the
 # host root), to assert rewritten link/content survived the crawl. Both fail
-# when PATH is missing.
+# when PATH is not a readable regular file.
 # --cache-found/--cache-not-found assert whether hts-cache/new.zip holds an
 # entry whose URL ends with URLTAIL, e.g. /dir/page.html; being mirrored and
 # being cached are separate outcomes (#840).
@@ -720,15 +720,25 @@ while test "$i" -lt "${#audit[@]}"; do
         path="${audit[$((i + 1))]}"
         i=$((i + 2))
         info "checking ${path} lacks ${audit[$i]}"
-        # grep exits 2 on a missing path, which reads like "no match": test the
-        # file first, or a crawl that wrote nothing satisfies this audit (#1627).
+        # grep's exit 2 on a path it cannot read reads as no match, so an empty
+        # crawl would pass this audit (#1627).
         if test ! -f "${hostroot}/${path}"; then
-            result "no such file ${hostroot}/${path}"
+            result "no regular file at ${hostroot}/${path}"
             exit 1
-        elif grep -aqE "${audit[$i]}" "${hostroot}/${path}"; then
+        fi
+        grc=0
+        grep -aqE "${audit[$i]}" "${hostroot}/${path}" || grc=$?
+        case "$grc" in
+        0)
             result "matched"
             exit 1
-        else result "OK"; fi
+            ;;
+        1) result "OK" ;;
+        *)
+            result "grep could not read ${hostroot}/${path} (exit ${grc})"
+            exit 1
+            ;;
+        esac
         ;;
     --files-identical)
         path="${audit[$((i + 1))]}"


### PR DESCRIPTION
`--file-not-matches PATH REGEX` in `tests/local-crawl.sh` read grep's exit status as a boolean. grep exits 2 on anything it cannot read, so a missing or unreadable file counted as "the marker is absent". A crawl that wrote nothing satisfied every such assertion. The status is now split three ways. `--file-matches` wants exit 0, so it never had the hole.

All 28 call sites across 17 tests turned out to be real. I ran the suite with the fix in and every one named a file the mirror wrote.

`--max-mirror-bytes` has the same hole, because an empty mirror is under every ceiling. `45_local-maxsize-recv` proved only that bytes crossed the wire, so it gains a floor and a `--found`. `35_local-maxsize` and `36_local-bigcrawl` already defeat an empty mirror through `--found` and `--files`.

`260_crawl-harness-fails-loudly` carries the guards for both, and five mutants die against them.

Closes #1627