### PR TITLE
An IPv6 zone id in a cookie domain keeps its %25 escape, so the cookie is dropped

### DIFF
--- a/src/htsbauth.c
+++ b/src/htsbauth.c
@@ -48,13 +48,11 @@ Please visit our Website: http://www.httrack.com
 /* See htsbauth.h. */
 hts_boolean cookie_host(const char *adr, char *dst, size_t dst_size) {
   const char *host = jump_identification_const(adr);
-  hts_boolean literal = HTS_FALSE;
   size_t len;
 
   if (host[0] == '[') { // bracketed IPv6 literal, [::1]:8080
     const char *const end = strchr(host, ']');
 
-    literal = HTS_TRUE;
     host++;
     len = end != NULL ? (size_t) (end - host) : strlen(host);
   } else {
@@ -70,9 +68,9 @@ hts_boolean cookie_host(const char *adr, char *dst, size_t dst_size) {
     return HTS_FALSE;
   dst[0] = '\0';
   strlncatbuff(dst, host, dst_size, len);
-  /* RFC 6874 escapes the zone id's '%' as "%25" inside the brackets, and a jar
-     carries the bare '%'. Only that introducer decodes. */
-  if (literal) {
+  /* RFC 6874 escapes a zone id's '%' as "%25" in a URI, and a jar carries the
+     bare '%'. Only a literal has a zone id, and only its introducer decodes. */
+  if (strchr(dst, ':') != NULL) {
     char *const zone = strchr(dst, '%');
 
     if (zone != NULL && zone[1] == '2' && zone[2] == '5')

--- a/src/htsbauth.c
+++ b/src/htsbauth.c
@@ -48,11 +48,13 @@ Please visit our Website: http://www.httrack.com
 /* See htsbauth.h. */
 hts_boolean cookie_host(const char *adr, char *dst, size_t dst_size) {
   const char *host = jump_identification_const(adr);
+  hts_boolean literal = HTS_FALSE;
   size_t len;
 
   if (host[0] == '[') { // bracketed IPv6 literal, [::1]:8080
     const char *const end = strchr(host, ']');
 
+    literal = HTS_TRUE;
     host++;
     len = end != NULL ? (size_t) (end - host) : strlen(host);
   } else {
@@ -68,6 +70,14 @@ hts_boolean cookie_host(const char *adr, char *dst, size_t dst_size) {
     return HTS_FALSE;
   dst[0] = '\0';
   strlncatbuff(dst, host, dst_size, len);
+  /* RFC 6874 escapes the zone id's '%' as "%25" inside the brackets, and a jar
+     carries the bare '%'. Only that introducer decodes. */
+  if (literal) {
+    char *const zone = strchr(dst, '%');
+
+    if (zone != NULL && zone[1] == '2' && zone[2] == '5')
+      memmove(zone + 1, zone + 3, strlen(zone + 3) + 1);
+  }
   return HTS_TRUE;
 }
 

--- a/src/htsbauth.c
+++ b/src/htsbauth.c
@@ -48,11 +48,13 @@ Please visit our Website: http://www.httrack.com
 /* See htsbauth.h. */
 hts_boolean cookie_host(const char *adr, char *dst, size_t dst_size) {
   const char *host = jump_identification_const(adr);
+  hts_boolean literal = HTS_FALSE;
   size_t len;
 
   if (host[0] == '[') { // bracketed IPv6 literal, [::1]:8080
     const char *const end = strchr(host, ']');
 
+    literal = HTS_TRUE;
     host++;
     len = end != NULL ? (size_t) (end - host) : strlen(host);
   } else {
@@ -68,9 +70,9 @@ hts_boolean cookie_host(const char *adr, char *dst, size_t dst_size) {
     return HTS_FALSE;
   dst[0] = '\0';
   strlncatbuff(dst, host, dst_size, len);
-  /* RFC 6874 escapes a zone id's '%' as "%25" in a URI, and a jar carries the
-     bare '%'. Only a literal has a zone id, and only its introducer decodes. */
-  if (strchr(dst, ':') != NULL) {
+  /* "%25" is RFC 6874's URI spelling of a zone id's '%'. Only a bracketed
+     literal carries it, because a bare host's '%' is already literal. */
+  if (literal) {
     char *const zone = strchr(dst, '%');
 
     if (zone != NULL && zone[1] == '2' && zone[2] == '5')

--- a/src/htsbauth.h
+++ b/src/htsbauth.h
@@ -77,10 +77,9 @@ typedef struct httrackp httrackp;
 /* cookies */
 
 /** Copy ADR's host into DST, without identification, IPv6 brackets or port,
-    because RFC 6265 scopes a cookie to a host and a browser jar has none. An
-    IPv6 zone id keeps the bare '%' a jar carries, not the URI's "%25". Run it
-    once, because it is not idempotent. HTS_FALSE means the caller sends no
-    cookie. */
+    because RFC 6265 scopes a cookie to a host and a browser jar has none. A
+    bracketed literal's zone id keeps the bare '%' that a jar carries, not the
+    URI's "%25". HTS_FALSE means the caller sends no cookie. */
 hts_boolean cookie_host(const char *adr, char *dst, size_t dst_size);
 
 /** Store cook_name=cook_value for domain/path, with domain normalised by

--- a/src/htsbauth.h
+++ b/src/htsbauth.h
@@ -77,8 +77,10 @@ typedef struct httrackp httrackp;
 /* cookies */
 
 /** Copy ADR's host into DST, without identification, IPv6 brackets or port,
-    because RFC 6265 scopes a cookie to a host and a browser jar has none.
-    HTS_FALSE means the caller sends no cookie. */
+    because RFC 6265 scopes a cookie to a host and a browser jar has none. An
+    IPv6 zone id keeps the bare '%' a jar carries, not the URI's "%25". Run it
+    once, because it is not idempotent. HTS_FALSE means the caller sends no
+    cookie. */
 hts_boolean cookie_host(const char *adr, char *dst, size_t dst_size);
 
 /** Store cook_name=cook_value for domain/path, with domain normalised by

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5273,6 +5273,15 @@ static int st_cookieport(httrackp *opt, int argc, char **argv) {
       {"", NULL}, // an empty domain is a suffix of every host
       {":8080", NULL},
       {"[]:80", NULL},
+      // RFC 6874 spells the zone id's '%' as "%25" inside the brackets only
+      {"[fe80::1%25eth0]:8080", "fe80::1%eth0"},
+      {"[fe80::1%25eth0]", "fe80::1%eth0"},
+      {"fe80::1%eth0", "fe80::1%eth0"},     // what a browser export carries
+      {"fe80::1%25eth0", "fe80::1%25eth0"}, // no brackets, so nothing to decode
+      {"host%25name.example", "host%25name.example"}, // a name, not a literal
+      {"[fe80::1%2525eth0]", "fe80::1%25eth0"},       // the introducer, once
+      {"[fe80::1%]:80", "fe80::1%"}, // truncated: no decode, no overread
+      {"[fe80::1%2]:80", "fe80::1%2"},
   };
 
   static const struct {
@@ -5317,6 +5326,14 @@ static int st_cookieport(httrackp *opt, int argc, char **argv) {
       // "x" while every query still asks for "x:1"
       {"[x:1]:80", "Set-Cookie: odd=O; path=/", "[x:1]:80", "odd=O", HTS_TRUE,
        "the store side normalised the host twice"},
+      // a link-local host reaches the zone id spelling a browser exports, and
+      // stops at another zone
+      {"[fe80::1%25eth0]:8080", "Set-Cookie: zone=Z; path=/", "fe80::1%eth0",
+       "zone=Z", HTS_TRUE, "[fe80::1%25eth0] does not reach fe80::1%eth0"},
+      {"fe80::1%eth0", "Set-Cookie: zone=Z; path=/", "[fe80::1%25eth0]:8080",
+       "zone=Z", HTS_TRUE, "fe80::1%eth0 does not reach [fe80::1%25eth0]"},
+      {"[fe80::1%25eth0]:8080", "Set-Cookie: zone=Z; path=/", "fe80::1%eth1",
+       "zone=Z", HTS_FALSE, "a cookie on %eth0 reached %eth1"},
   };
 
   static t_cookie jar;

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5273,13 +5273,14 @@ static int st_cookieport(httrackp *opt, int argc, char **argv) {
       {"", NULL}, // an empty domain is a suffix of every host
       {":8080", NULL},
       {"[]:80", NULL},
-      // RFC 6874 spells the zone id's '%' as "%25" inside the brackets only
+      // a zone id is spelled "%25" in a URI and bare in a jar, either spelling
+      // of the host
       {"[fe80::1%25eth0]:8080", "fe80::1%eth0"},
       {"[fe80::1%25eth0]", "fe80::1%eth0"},
-      {"fe80::1%eth0", "fe80::1%eth0"},     // what a browser export carries
-      {"fe80::1%25eth0", "fe80::1%25eth0"}, // no brackets, so nothing to decode
-      {"host%25name.example", "host%25name.example"}, // a name, not a literal
-      {"[fe80::1%2525eth0]", "fe80::1%25eth0"},       // the introducer, once
+      {"fe80::1%25eth0", "fe80::1%eth0"}, // what an older httrack wrote
+      {"fe80::1%eth0", "fe80::1%eth0"},   // what a browser export carries
+      {"host%25name.example", "host%25name.example"}, // a name has no zone id
+      {"[fe80::1%25eth%250]", "fe80::1%eth%250"},     // past the introducer
       {"[fe80::1%]:80", "fe80::1%"}, // truncated: no decode, no overread
       {"[fe80::1%2]:80", "fe80::1%2"},
   };
@@ -5367,6 +5368,12 @@ static int st_cookieport(httrackp *opt, int argc, char **argv) {
                          trips[i].want, trips[i].what);
   }
 
+  /* The introducer decodes once. "%2525" is a zone id starting with an escaped
+     '%', so a second pass over the result would eat that one too. Kept out of
+     the idempotence loop above for that reason. */
+  err |= cookie_expect(cookie_host_is("[fe80::1%2525eth0]", "fe80::1%25eth0"),
+                       HTS_TRUE, "the decode ran past the zone id introducer");
+
   /* A jar loaded from a browser file holds bare hosts; the port on the wire
      must not hide them. Control: another host stays filtered out. */
   jar.max_len = sizeof(jar.data);
@@ -5397,6 +5404,15 @@ static int st_cookieport(httrackp *opt, int argc, char **argv) {
   http_cookie_header(&jar, "::1", "/", hdr, sizeof(hdr));
   err |= cookie_expect(strstr(hdr, "sixjar=V") != NULL, HTS_TRUE,
                        "a jar storing [::1]:8080 lost its session");
+  /* An older httrack wrote the URI spelling of a zone id into the jar, so the
+     jar side has to be normalised on load as the port form is. */
+  if (cookie_add(&jar, "zonejar", "Z", "fe80::1%25eth0", "/") != 0) {
+    printf("cookie-port: FAIL (cookie_add setup, zone id form)\n");
+    return 1;
+  }
+  http_cookie_header(&jar, "fe80::1%eth0", "/", hdr, sizeof(hdr));
+  err |= cookie_expect(strstr(hdr, "zonejar=Z") != NULL, HTS_TRUE,
+                       "a jar storing fe80::1%25eth0 lost its session");
   err |= cookie_expect(cookie_add(&jar, "pwn", "OWNED", "", "/") == 0,
                        HTS_FALSE, "an empty domain entered the jar");
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5273,16 +5273,21 @@ static int st_cookieport(httrackp *opt, int argc, char **argv) {
       {"", NULL}, // an empty domain is a suffix of every host
       {":8080", NULL},
       {"[]:80", NULL},
-      // a zone id is spelled "%25" in a URI and bare in a jar, either spelling
-      // of the host
+      // a URI spells a zone id's '%' as "%25" and a jar carries it bare
       {"[fe80::1%25eth0]:8080", "fe80::1%eth0"},
       {"[fe80::1%25eth0]", "fe80::1%eth0"},
-      {"fe80::1%25eth0", "fe80::1%eth0"}, // what an older httrack wrote
-      {"fe80::1%eth0", "fe80::1%eth0"},   // what a browser export carries
+      {"fe80::1%eth0", "fe80::1%eth0"},     // a browser export carries this
+      {"fe80::1%25eth0", "fe80::1%25eth0"}, // a bare '%' is literal already
+      {"fe80::1%250", "fe80::1%250"},       // scope index 250, not zone 0
       {"host%25name.example", "host%25name.example"}, // a name has no zone id
-      {"[fe80::1%25eth%250]", "fe80::1%eth%250"},     // past the introducer
-      {"[fe80::1%]:80", "fe80::1%"}, // truncated: no decode, no overread
+      // the rest of the zone id keeps whatever escapes it carries
+      {"[fe80::1%25eth%250]", "fe80::1%eth%250"},
+      {"[fe80::1%2525eth0]", "fe80::1%25eth0"}, // a zone id may open with "%25"
+      {"[fe80::1%]:80", "fe80::1%"}, // truncated, so it decodes nothing
       {"[fe80::1%2]:80", "fe80::1%2"},
+      {"[fe80::1%a5eth0]", "fe80::1%a5eth0"}, // 'a5' is not the introducer
+      // an empty zone id is malformed, and still lands on one jar entry
+      {"[fe80::1%25]:80", "fe80::1%"},
   };
 
   static const struct {
@@ -5368,12 +5373,6 @@ static int st_cookieport(httrackp *opt, int argc, char **argv) {
                          trips[i].want, trips[i].what);
   }
 
-  /* The introducer decodes once. "%2525" is a zone id starting with an escaped
-     '%', so a second pass over the result would eat that one too. Kept out of
-     the idempotence loop above for that reason. */
-  err |= cookie_expect(cookie_host_is("[fe80::1%2525eth0]", "fe80::1%25eth0"),
-                       HTS_TRUE, "the decode ran past the zone id introducer");
-
   /* A jar loaded from a browser file holds bare hosts; the port on the wire
      must not hide them. Control: another host stays filtered out. */
   jar.max_len = sizeof(jar.data);
@@ -5404,15 +5403,15 @@ static int st_cookieport(httrackp *opt, int argc, char **argv) {
   http_cookie_header(&jar, "::1", "/", hdr, sizeof(hdr));
   err |= cookie_expect(strstr(hdr, "sixjar=V") != NULL, HTS_TRUE,
                        "a jar storing [::1]:8080 lost its session");
-  /* An older httrack wrote the URI spelling of a zone id into the jar, so the
-     jar side has to be normalised on load as the port form is. */
-  if (cookie_add(&jar, "zonejar", "Z", "fe80::1%25eth0", "/") != 0) {
+  /* Only this case drives cookie_add with a zone id, which the host rows above
+     never do. */
+  if (cookie_add(&jar, "zonejar", "Z", "[fe80::1%25eth0]:8080", "/") != 0) {
     printf("cookie-port: FAIL (cookie_add setup, zone id form)\n");
     return 1;
   }
   http_cookie_header(&jar, "fe80::1%eth0", "/", hdr, sizeof(hdr));
   err |= cookie_expect(strstr(hdr, "zonejar=Z") != NULL, HTS_TRUE,
-                       "a jar storing fe80::1%25eth0 lost its session");
+                       "a jar storing [fe80::1%25eth0] lost its session");
   err |= cookie_expect(cookie_add(&jar, "pwn", "OWNED", "", "/") == 0,
                        HTS_FALSE, "an empty domain entered the jar");
 


### PR DESCRIPTION
`cookie_host()` unwraps a bracketed IPv6 literal and cuts the port, but it left the zone id's escape in place. A request to `[fe80::1%25eth0]:8080` scoped its cookie to `fe80::1%25eth0`. RFC 6874 spells a zone id's `%` as `%25` inside the brackets. A jar exported from a browser carries the bare `fe80::1%eth0`, so the two never matched and the cookie went away with no message. This is the class #1610 fixed for the port.

Only a bracketed literal decodes, because `%25` is a URI escape and a bare host's `%` already stands for itself. Decoding a bare host would read `fe80::1%250`, scope index 250, as zone 0. That leaves one known cost. A jar an older httrack wrote carries the escaped spelling, and nothing rescues it. The fix does not reuse `unescape_http()`, because that would decode the whole host.

The `cookieport` selftest gains the zone id spellings and kills eight mutants.

Closes #1626