### PR TITLE
The abort message tells the user to erase the cache the resume needs

### DIFF
--- a/src/htscache.c
+++ b/src/htscache.c
@@ -1075,6 +1075,22 @@ static hts_boolean reconcile_promote_sidecar(httrackp *opt, const char *oldname,
   return reconcile_promote(opt, oldname, newname);
 }
 
+/* How many entries a cache generation holds, or -1 when it is absent or will
+   not open. Coverage is what decides which generation to keep, and a file size
+   is its bodies' size, not its reach. */
+static LLint reconcile_entries(httrackp *opt, const char *name) {
+  unz_global_info64 gi;
+  unzFile zip;
+  LLint entries = -1;
+
+  if ((zip = hts_unzOpen_utf8(reconcile_path(opt, name))) == NULL)
+    return -1;
+  if (unzGetGlobalInfo64(zip, &gi) == UNZ_OK)
+    entries = (LLint) gi.number_entry;
+  unzClose(zip);
+  return entries;
+}
+
 /* Promote cache and sidecars together, so old.lst never describes a different
    run than old.zip. */
 static void reconcile_promote_generation(httrackp *opt) {
@@ -1099,16 +1115,16 @@ void hts_cache_reconcile(httrackp *opt, hts_cache_reconcile_mode mode) {
       reconcile_promote(opt, "hts-cache/old.zip", "hts-cache/new.zip");
     break;
   case CACHE_RECONCILE_INTERRUPTED:
-    /* Aborted run: keep the larger generation, because the next run's rotation
-       erases the smaller one. Both files must exist, as fsize() reads -1 for a
-       missing one, and a missing new.zip is PROMOTE's case. */
+    /* Aborted run: keep the generation reaching further, because the next run's
+       rotation erases the other one. new.zip must exist, as a missing one is
+       PROMOTE's case. A generation that will not open counts -1, so a damaged
+       cache never beats a readable one. */
     if (!opt->cache ||
         !fexist_utf8(reconcile_path(opt, "hts-in_progress.lock")))
       break;
     if (fexist_utf8(reconcile_path(opt, "hts-cache/new.zip")) &&
-        fexist_utf8(reconcile_path(opt, "hts-cache/old.zip")) &&
-        fsize_utf8(reconcile_path(opt, "hts-cache/old.zip")) >
-            fsize_utf8(reconcile_path(opt, "hts-cache/new.zip")))
+        reconcile_entries(opt, "hts-cache/old.zip") >
+            reconcile_entries(opt, "hts-cache/new.zip"))
       reconcile_promote_generation(opt);
     break;
   case CACHE_RECONCILE_ROLLBACK:

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -1052,12 +1052,6 @@ static char *reconcile_path(httrackp *opt, const char *name) {
                  StringBuff(opt->path_log), name);
 }
 
-/* Interrupted-run heuristic: prefer the old generation when the new cache
-   stalled below NEW_TINY while the old one grew past OLD_SOLID (historical
-   arbitrary thresholds). */
-#define CACHE_RECONCILE_NEW_TINY 32768
-#define CACHE_RECONCILE_OLD_SOLID 65536
-
 /* Replace the new-generation file by the old one, when the old one exists. */
 static void reconcile_promote(httrackp *opt, const char *oldname,
                               const char *newname) {
@@ -1065,6 +1059,14 @@ static void reconcile_promote(httrackp *opt, const char *oldname,
     UNLINK(reconcile_path(opt, newname));
     RENAME(reconcile_path(opt, oldname), reconcile_path(opt, newname));
   }
+}
+
+/* Promote cache and sidecars together, so old.lst never describes a different
+   run than old.zip. */
+static void reconcile_promote_generation(httrackp *opt) {
+  reconcile_promote(opt, "hts-cache/old.zip", "hts-cache/new.zip");
+  reconcile_promote(opt, "hts-cache/old.lst", "hts-cache/new.lst");
+  reconcile_promote(opt, "hts-cache/old.txt", "hts-cache/new.txt");
 }
 
 void hts_cache_reconcile(httrackp *opt, hts_cache_reconcile_mode mode) {
@@ -1076,29 +1078,22 @@ void hts_cache_reconcile(httrackp *opt, hts_cache_reconcile_mode mode) {
       reconcile_promote(opt, "hts-cache/old.zip", "hts-cache/new.zip");
     break;
   case CACHE_RECONCILE_INTERRUPTED:
-    /* Aborted run: keep the larger generation when the new cache is
-       suspiciously small next to the old one. The new file must exist: fsize()
-       is -1 for a missing file, which would spuriously pass the "< TINY" test
-       and overwrite a solid old generation that PROMOTE/ROLLBACK should keep.
-     */
+    /* Aborted run: the next run rotates new.zip over old.zip, so the
+       generation that loses here is gone. Keep the larger one, size being the
+       only proxy for how much a cache holds; both files must exist, as fsize()
+       reads -1 for a missing one and PROMOTE owns that case. */
     if (!opt->cache ||
         !fexist_utf8(reconcile_path(opt, "hts-in_progress.lock")))
       break;
     if (fexist_utf8(reconcile_path(opt, "hts-cache/new.zip")) &&
         fexist_utf8(reconcile_path(opt, "hts-cache/old.zip")) &&
-        fsize_utf8(reconcile_path(opt, "hts-cache/new.zip")) <
-            CACHE_RECONCILE_NEW_TINY &&
-        fsize_utf8(reconcile_path(opt, "hts-cache/old.zip")) >
-            CACHE_RECONCILE_OLD_SOLID &&
         fsize_utf8(reconcile_path(opt, "hts-cache/old.zip")) >
             fsize_utf8(reconcile_path(opt, "hts-cache/new.zip")))
-      reconcile_promote(opt, "hts-cache/old.zip", "hts-cache/new.zip");
+      reconcile_promote_generation(opt);
     break;
   case CACHE_RECONCILE_ROLLBACK:
-    /* Nothing transferred: restore the previous generation and sidecars. */
-    reconcile_promote(opt, "hts-cache/old.zip", "hts-cache/new.zip");
-    reconcile_promote(opt, "hts-cache/old.lst", "hts-cache/new.lst");
-    reconcile_promote(opt, "hts-cache/old.txt", "hts-cache/new.txt");
+    /* Nothing transferred: restore the previous generation. */
+    reconcile_promote_generation(opt);
     break;
   }
 }

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -1052,9 +1052,9 @@ static char *reconcile_path(httrackp *opt, const char *name) {
                  StringBuff(opt->path_log), name);
 }
 
-/* Replace the new-generation file by the old one, when the old one exists.
-   hts_rename_over() parks whatever is in the way instead of deleting it first,
-   so a failed move never leaves the mirror with neither generation. */
+/* Replace the new-generation file by the old one, when the old one exists. A
+   failed hts_rename_over() always leaves one generation behind, since it parks
+   the file in the way instead of deleting it. */
 static hts_boolean reconcile_promote(httrackp *opt, const char *oldname,
                                      const char *newname) {
   if (!fexist_utf8(reconcile_path(opt, oldname)))
@@ -1085,8 +1085,11 @@ static LLint reconcile_entries(httrackp *opt, const char *name) {
 
   if ((zip = hts_unzOpen_utf8(reconcile_path(opt, name))) == NULL)
     return -1;
+  /* Clamped: a damaged central directory can claim a count that casts negative,
+     which would read as "will not open". */
   if (unzGetGlobalInfo64(zip, &gi) == UNZ_OK)
-    entries = (LLint) gi.number_entry;
+    entries = gi.number_entry > (ZPOS64_T) INT_MAX ? (LLint) INT_MAX
+                                                   : (LLint) gi.number_entry;
   unzClose(zip);
   return entries;
 }
@@ -1111,21 +1114,26 @@ void hts_cache_reconcile(httrackp *opt, hts_cache_reconcile_mode mode) {
   case CACHE_RECONCILE_PROMOTE:
     /* Previous run rotated new.* to old.* then died before writing: promote
        the old generation back, whichever format it uses. */
-    if (!fexist_utf8(reconcile_path(opt, "hts-cache/new.zip")))
-      reconcile_promote(opt, "hts-cache/old.zip", "hts-cache/new.zip");
+    if (!fexist_utf8(reconcile_path(opt, "hts-cache/new.zip")) &&
+        !reconcile_promote(opt, "hts-cache/old.zip", "hts-cache/new.zip"))
+      hts_log_print(opt, LOG_WARNING | LOG_ERRNO,
+                    "Cache: could not restore the previous generation");
     break;
   case CACHE_RECONCILE_INTERRUPTED:
     /* Aborted run: keep the generation reaching further, because the next run's
-       rotation erases the other one. new.zip must exist, as a missing one is
-       PROMOTE's case. A generation that will not open counts -1, so a damaged
-       cache never beats a readable one. */
+       rotation erases the other one. */
     if (!opt->cache ||
         !fexist_utf8(reconcile_path(opt, "hts-in_progress.lock")))
       break;
-    if (fexist_utf8(reconcile_path(opt, "hts-cache/new.zip")) &&
-        reconcile_entries(opt, "hts-cache/old.zip") >
-            reconcile_entries(opt, "hts-cache/new.zip"))
-      reconcile_promote_generation(opt);
+    {
+      const LLint kept = reconcile_entries(opt, "hts-cache/new.zip");
+
+      /* A new.zip that is absent belongs to PROMOTE, and one that will not open
+         still holds the local headers cache_init() rotates for cache_repair().
+         Both read -1 here, and neither is ours to overwrite. */
+      if (kept >= 0 && reconcile_entries(opt, "hts-cache/old.zip") > kept)
+        reconcile_promote_generation(opt);
+    }
     break;
   case CACHE_RECONCILE_ROLLBACK:
     /* Nothing transferred: restore the previous generation. */

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -1085,11 +1085,10 @@ static LLint reconcile_entries(httrackp *opt, const char *name) {
 
   if ((zip = hts_unzOpen_utf8(reconcile_path(opt, name))) == NULL)
     return -1;
-  /* Clamped: a damaged central directory can claim a count that casts negative,
-     which would read as "will not open". */
+  /* A damaged directory claiming a count that casts negative just loses the
+     comparison below, which is the safe way to lose. */
   if (unzGetGlobalInfo64(zip, &gi) == UNZ_OK)
-    entries = gi.number_entry > (ZPOS64_T) INT_MAX ? (LLint) INT_MAX
-                                                   : (LLint) gi.number_entry;
+    entries = (LLint) gi.number_entry;
   unzClose(zip);
   return entries;
 }

--- a/src/htscache.c
+++ b/src/htscache.c
@@ -1052,21 +1052,42 @@ static char *reconcile_path(httrackp *opt, const char *name) {
                  StringBuff(opt->path_log), name);
 }
 
-/* Replace the new-generation file by the old one, when the old one exists. */
-static void reconcile_promote(httrackp *opt, const char *oldname,
-                              const char *newname) {
-  if (fexist_utf8(reconcile_path(opt, oldname))) {
+/* Replace the new-generation file by the old one, when the old one exists.
+   hts_rename_over() parks whatever is in the way instead of deleting it first,
+   so a failed move never leaves the mirror with neither generation. */
+static hts_boolean reconcile_promote(httrackp *opt, const char *oldname,
+                                     const char *newname) {
+  if (!fexist_utf8(reconcile_path(opt, oldname)))
+    return HTS_TRUE;
+  return hts_rename_over(opt, reconcile_path(opt, oldname),
+                         reconcile_path(opt, newname));
+}
+
+/* Same, for a sidecar. A sidecar with no old counterpart is dropped rather than
+   kept, because it lists the run being replaced and the update purge would read
+   it against the promoted cache. */
+static hts_boolean reconcile_promote_sidecar(httrackp *opt, const char *oldname,
+                                             const char *newname) {
+  if (!fexist_utf8(reconcile_path(opt, oldname))) {
     UNLINK(reconcile_path(opt, newname));
-    RENAME(reconcile_path(opt, oldname), reconcile_path(opt, newname));
+    return HTS_TRUE;
   }
+  return reconcile_promote(opt, oldname, newname);
 }
 
 /* Promote cache and sidecars together, so old.lst never describes a different
    run than old.zip. */
 static void reconcile_promote_generation(httrackp *opt) {
-  reconcile_promote(opt, "hts-cache/old.zip", "hts-cache/new.zip");
-  reconcile_promote(opt, "hts-cache/old.lst", "hts-cache/new.lst");
-  reconcile_promote(opt, "hts-cache/old.txt", "hts-cache/new.txt");
+  hts_boolean ok =
+      reconcile_promote(opt, "hts-cache/old.zip", "hts-cache/new.zip");
+
+  if (!reconcile_promote_sidecar(opt, "hts-cache/old.lst", "hts-cache/new.lst"))
+    ok = HTS_FALSE;
+  if (!reconcile_promote_sidecar(opt, "hts-cache/old.txt", "hts-cache/new.txt"))
+    ok = HTS_FALSE;
+  if (!ok)
+    hts_log_print(opt, LOG_WARNING | LOG_ERRNO,
+                  "Cache: the previous generation was restored only in part");
 }
 
 void hts_cache_reconcile(httrackp *opt, hts_cache_reconcile_mode mode) {
@@ -1078,10 +1099,9 @@ void hts_cache_reconcile(httrackp *opt, hts_cache_reconcile_mode mode) {
       reconcile_promote(opt, "hts-cache/old.zip", "hts-cache/new.zip");
     break;
   case CACHE_RECONCILE_INTERRUPTED:
-    /* Aborted run: the next run rotates new.zip over old.zip, so the
-       generation that loses here is gone. Keep the larger one, size being the
-       only proxy for how much a cache holds; both files must exist, as fsize()
-       reads -1 for a missing one and PROMOTE owns that case. */
+    /* Aborted run: keep the larger generation, because the next run's rotation
+       erases the smaller one. Both files must exist, as fsize() reads -1 for a
+       missing one, and a missing new.zip is PROMOTE's case. */
     if (!opt->cache ||
         !fexist_utf8(reconcile_path(opt, "hts-in_progress.lock")))
       break;

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -1156,12 +1156,12 @@ static void reconcile_put(httrackp *opt, const char *name, LLint size) {
 /* Write a valid cache generation of `entries` files, each carrying `body`
    stored bytes. Stored, not deflated, so the file size follows `body` and a
    case can make the shallower generation the physically larger one. */
-static void reconcile_put_zip(httrackp *opt, const char *name, int entries,
+static void reconcile_put_zip(httrackp *opt, const char *name, LLint entries,
                               size_t body) {
   zipFile zf = hts_zipOpen_utf8(reconcile_st_path(opt, name), 0);
   zip_fileinfo fi;
   char chunk[4096];
-  int i;
+  LLint i;
 
   assertf(zf != NULL);
   memset(&fi, 0, sizeof(fi));
@@ -1170,7 +1170,7 @@ static void reconcile_put_zip(httrackp *opt, const char *name, int entries,
     char entry[64];
     size_t left;
 
-    snprintf(entry, sizeof(entry), "entry%03d.dat", i);
+    snprintf(entry, sizeof(entry), "entry%03d.dat", (int) i);
     assertf(zipOpenNewFileInZip(zf, entry, &fi, NULL, 0, NULL, 0, NULL, 0,
                                 Z_NO_COMPRESSION) == ZIP_OK);
     for (left = body; left != 0;) {
@@ -1184,22 +1184,43 @@ static void reconcile_put_zip(httrackp *opt, const char *name, int entries,
   assertf(zipClose(zf, NULL) == ZIP_OK);
 }
 
-/* Expect `name` to hold `entries` cache entries, or -1 when it is absent or
-   will not open. */
-static int reconcile_expect_zip(httrackp *opt, const char *name, int entries,
+/* Cut `cut` bytes off `name`, which is how a hard kill leaves new.zip: local
+   headers on disk, no central directory. */
+static void reconcile_truncate(httrackp *opt, const char *name, LLint cut) {
+  const LLint size = fsize(reconcile_st_path(opt, name));
+  const size_t left = (size_t) (size - cut);
+  char *buf;
+  FILE *fp;
+
+  assertf(size > cut);
+  buf = (char *) malloct(left);
+  assertf(buf != NULL);
+  fp = FOPEN(reconcile_st_path(opt, name), "rb");
+  assertf(fp != NULL);
+  assertf(hts_fread_exact(buf, left, fp));
+  fclose(fp);
+  fp = FOPEN(reconcile_st_path(opt, name), "wb");
+  assertf(fp != NULL);
+  assertf(hts_fwrite_exact(buf, left, fp));
+  fclose(fp);
+  freet(buf);
+}
+
+/* Expect `name` to hold `entries` entries, or -1 if absent or unreadable. */
+static int reconcile_expect_zip(httrackp *opt, const char *name, LLint entries,
                                 const char *what) {
   unz_global_info64 gi;
   unzFile zip = hts_unzOpen_utf8(reconcile_st_path(opt, name));
-  int got = -1;
+  LLint got = -1;
 
   if (zip != NULL) {
     if (unzGetGlobalInfo64(zip, &gi) == UNZ_OK)
-      got = (int) gi.number_entry;
+      got = (LLint) gi.number_entry;
     unzClose(zip);
   }
   if (got != entries) {
     fprintf(stderr, "cache-reconcile: %s: %s holds %d entries, expected %d\n",
-            what, name, got, entries);
+            what, name, (int) got, (int) entries);
     return 1;
   }
   return 0;
@@ -1224,7 +1245,11 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   /* Sidecar byte sizes; only their ordering matters. */
   static const LLint SMALL = 1024, MEDIUM = 40000, LARGE = 131072;
   /* Cache generations, in entries: what the reconcile actually compares. */
-  static const int EMPTY = 0, PARTIAL = 2, COMPLETE = 9;
+  static const LLint EMPTY = 0, PARTIAL = 2, COMPLETE = 9;
+  /* Filler bytes under a .zip name: a generation that will not open. */
+  static const LLint DAMAGED = 131072;
+  /* reconcile_put_zip() body size; only interrupted-fatnew wants one. */
+  static const size_t NO_BODY = 0;
 
   selftest_setup_dir(opt, dir);
 #ifdef _WIN32
@@ -1235,7 +1260,7 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
 
   /* PROMOTE: a zip old generation replaces a missing new one */
   reconcile_wipe(opt);
-  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, 0);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, NO_BODY);
   hts_cache_reconcile(opt, CACHE_RECONCILE_PROMOTE);
   failures +=
       reconcile_expect_zip(opt, "hts-cache/new.zip", COMPLETE, "promote-zip");
@@ -1243,8 +1268,8 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
 
   /* PROMOTE: an existing new.zip is left alone */
   reconcile_wipe(opt);
-  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, 0);
-  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, 0);
+  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, NO_BODY);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, NO_BODY);
   hts_cache_reconcile(opt, CACHE_RECONCILE_PROMOTE);
   failures += reconcile_expect_zip(opt, "hts-cache/new.zip", PARTIAL,
                                    "promote-zip-noop");
@@ -1263,8 +1288,8 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
 
   /* INTERRUPTED: no lock file, no action */
   reconcile_wipe(opt);
-  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, 0);
-  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, 0);
+  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, NO_BODY);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, NO_BODY);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
   failures += reconcile_expect_zip(opt, "hts-cache/new.zip", PARTIAL,
                                    "interrupted-nolock");
@@ -1272,8 +1297,8 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   /* INTERRUPTED: caching off, no action */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, 0);
-  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, 0);
+  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, NO_BODY);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, NO_BODY);
   {
     const hts_cachemode saved = opt->cache;
 
@@ -1290,7 +1315,7 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
      belongs to PROMOTE */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, 0);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, NO_BODY);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
   failures +=
       reconcile_expect(opt, "hts-cache/new.zip", -1, "interrupted-nonew");
@@ -1301,10 +1326,10 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
      the old names are gone rather than copied */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, 0);
+  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, NO_BODY);
   reconcile_put(opt, "hts-cache/new.lst", SMALL);
   reconcile_put(opt, "hts-cache/new.txt", SMALL);
-  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, 0);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, NO_BODY);
   reconcile_put(opt, "hts-cache/old.lst", MEDIUM);
   reconcile_put(opt, "hts-cache/old.txt", MEDIUM);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
@@ -1325,9 +1350,9 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
      run's file list cannot outlive it */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, 0);
+  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, NO_BODY);
   reconcile_put(opt, "hts-cache/new.lst", SMALL);
-  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, 0);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, NO_BODY);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
   failures += reconcile_expect_zip(opt, "hts-cache/new.zip", COMPLETE,
                                    "interrupted-orphan-sidecar");
@@ -1339,7 +1364,7 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
   reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, 65536);
-  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, 0);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, NO_BODY);
   if (fsize(reconcile_st_path(opt, "hts-cache/new.zip")) <=
       fsize(reconcile_st_path(opt, "hts-cache/old.zip"))) {
     fprintf(stderr, "cache-reconcile: interrupted-fatnew: new.zip is not the "
@@ -1354,39 +1379,62 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
      damaged old.zip never displaces a readable new one */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, 0);
-  reconcile_put(opt, "hts-cache/old.zip", LARGE);
+  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, NO_BODY);
+  reconcile_put(opt, "hts-cache/old.zip", DAMAGED);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
   failures += reconcile_expect_zip(opt, "hts-cache/new.zip", PARTIAL,
                                    "interrupted-damaged-old");
-  failures += reconcile_expect(opt, "hts-cache/old.zip", LARGE,
+  failures += reconcile_expect(opt, "hts-cache/old.zip", DAMAGED,
                                "interrupted-damaged-old");
 
-  /* INTERRUPTED: and the same the other way, so a damaged new.zip loses */
+  /* INTERRUPTED: a new.zip that will not open is left alone, even against a
+     readable old one: cache_init() rotates it and cache_repair() recovers it */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put(opt, "hts-cache/new.zip", LARGE);
-  reconcile_put_zip(opt, "hts-cache/old.zip", PARTIAL, 0);
+  reconcile_put(opt, "hts-cache/new.zip", DAMAGED);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, NO_BODY);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
-  failures += reconcile_expect_zip(opt, "hts-cache/new.zip", PARTIAL,
+  failures += reconcile_expect(opt, "hts-cache/new.zip", DAMAGED,
+                               "interrupted-damaged-new");
+  failures += reconcile_expect_zip(opt, "hts-cache/old.zip", COMPLETE,
                                    "interrupted-damaged-new");
 
-  /* INTERRUPTED: a readable but empty generation still beats an unreadable one,
-     so "reached nothing" and "will not open" must not count alike */
+  /* INTERRUPTED: the case that matters, because the file is recoverable. A hard
+     kill leaves new.zip without its central directory, and promoting over it
+     would delete entries cache_repair() would have brought back. */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put(opt, "hts-cache/new.zip", LARGE);
-  reconcile_put_zip(opt, "hts-cache/old.zip", EMPTY, 0);
+  reconcile_put_zip(opt, "hts-cache/new.zip", COMPLETE, NO_BODY);
+  reconcile_truncate(opt, "hts-cache/new.zip", 22);
+  reconcile_put_zip(opt, "hts-cache/old.zip", EMPTY, NO_BODY);
+  failures += reconcile_expect_zip(opt, "hts-cache/new.zip", -1,
+                                   "interrupted-truncated-new fixture");
+  {
+    const LLint before = fsize(reconcile_st_path(opt, "hts-cache/new.zip"));
+
+    hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
+    failures += reconcile_expect(opt, "hts-cache/new.zip", before,
+                                 "interrupted-truncated-new");
+  }
+  failures += reconcile_expect_zip(opt, "hts-cache/old.zip", EMPTY,
+                                   "interrupted-truncated-new");
+
+  /* INTERRUPTED: a stop that cached nothing still restores what came before it,
+     so reaching zero and failing to open must not count alike */
+  reconcile_wipe(opt);
+  reconcile_put(opt, "hts-in_progress.lock", 0);
+  reconcile_put_zip(opt, "hts-cache/new.zip", EMPTY, NO_BODY);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, NO_BODY);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
-  failures += reconcile_expect_zip(opt, "hts-cache/new.zip", EMPTY,
-                                   "interrupted-empty-beats-damaged");
+  failures += reconcile_expect_zip(opt, "hts-cache/new.zip", COMPLETE,
+                                   "interrupted-emptynew");
 
   /* INTERRUPTED: the aborted run reached further than the previous one, keep it
    */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put_zip(opt, "hts-cache/new.zip", COMPLETE, 0);
-  reconcile_put_zip(opt, "hts-cache/old.zip", PARTIAL, 0);
+  reconcile_put_zip(opt, "hts-cache/new.zip", COMPLETE, NO_BODY);
+  reconcile_put_zip(opt, "hts-cache/old.zip", PARTIAL, NO_BODY);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
   failures += reconcile_expect_zip(opt, "hts-cache/new.zip", COMPLETE,
                                    "interrupted-newwins");
@@ -1396,8 +1444,8 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   /* INTERRUPTED: equal reach does not promote, so nothing moves at all */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, 0);
-  reconcile_put_zip(opt, "hts-cache/old.zip", PARTIAL, 0);
+  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, NO_BODY);
+  reconcile_put_zip(opt, "hts-cache/old.zip", PARTIAL, NO_BODY);
   reconcile_put(opt, "hts-cache/new.lst", SMALL);
   reconcile_put(opt, "hts-cache/old.lst", LARGE);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
@@ -1428,8 +1476,8 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   /* ROLLBACK: the old zip generation is restored (a zip cache used to lose
      its only good generation here) */
   reconcile_wipe(opt);
-  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, 0);
-  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, 0);
+  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, NO_BODY);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, NO_BODY);
   hts_cache_reconcile(opt, CACHE_RECONCILE_ROLLBACK);
   failures +=
       reconcile_expect_zip(opt, "hts-cache/new.zip", COMPLETE, "rollback-zip");

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -1169,8 +1169,8 @@ static int reconcile_expect(httrackp *opt, const char *name, LLint size,
 int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   int failures = 0;
 
-  /* three distinct sizes: TINY < MID < SOLID */
-  static const LLint TINY = 1024, MID = 40000, SOLID = 131072;
+  /* only the ordering counts: the policy is size-ordinal now */
+  static const LLint SMALL = 1024, MEDIUM = 40000, LARGE = 131072;
 
   selftest_setup_dir(opt, dir);
 #ifdef _WIN32
@@ -1181,160 +1181,203 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
 
   /* PROMOTE: a zip old generation replaces a missing new one */
   reconcile_wipe(opt);
-  reconcile_put(opt, "hts-cache/old.zip", SOLID);
+  reconcile_put(opt, "hts-cache/old.zip", LARGE);
   hts_cache_reconcile(opt, CACHE_RECONCILE_PROMOTE);
-  failures += reconcile_expect(opt, "hts-cache/new.zip", SOLID, "promote-zip");
+  failures += reconcile_expect(opt, "hts-cache/new.zip", LARGE, "promote-zip");
   failures += reconcile_expect(opt, "hts-cache/old.zip", -1, "promote-zip");
 
   /* PROMOTE: an existing new.zip is left alone */
   reconcile_wipe(opt);
-  reconcile_put(opt, "hts-cache/new.zip", TINY);
-  reconcile_put(opt, "hts-cache/old.zip", SOLID);
+  reconcile_put(opt, "hts-cache/new.zip", SMALL);
+  reconcile_put(opt, "hts-cache/old.zip", LARGE);
   hts_cache_reconcile(opt, CACHE_RECONCILE_PROMOTE);
   failures +=
-      reconcile_expect(opt, "hts-cache/new.zip", TINY, "promote-zip-noop");
+      reconcile_expect(opt, "hts-cache/new.zip", SMALL, "promote-zip-noop");
   failures +=
-      reconcile_expect(opt, "hts-cache/old.zip", SOLID, "promote-zip-noop");
+      reconcile_expect(opt, "hts-cache/old.zip", LARGE, "promote-zip-noop");
 
   /* PROMOTE: the removed pre-3.31 legacy pair is left alone */
   reconcile_wipe(opt);
-  reconcile_put(opt, "hts-cache/old.dat", SOLID);
-  reconcile_put(opt, "hts-cache/old.ndx", TINY);
+  reconcile_put(opt, "hts-cache/old.dat", LARGE);
+  reconcile_put(opt, "hts-cache/old.ndx", SMALL);
   hts_cache_reconcile(opt, CACHE_RECONCILE_PROMOTE);
   failures += reconcile_expect(opt, "hts-cache/new.dat", -1, "promote-dat");
   failures += reconcile_expect(opt, "hts-cache/new.ndx", -1, "promote-dat");
-  failures += reconcile_expect(opt, "hts-cache/old.dat", SOLID, "promote-dat");
-  failures += reconcile_expect(opt, "hts-cache/old.ndx", TINY, "promote-dat");
+  failures += reconcile_expect(opt, "hts-cache/old.dat", LARGE, "promote-dat");
+  failures += reconcile_expect(opt, "hts-cache/old.ndx", SMALL, "promote-dat");
 
   /* INTERRUPTED: no lock file, no action */
   reconcile_wipe(opt);
-  reconcile_put(opt, "hts-cache/new.zip", TINY);
-  reconcile_put(opt, "hts-cache/old.zip", SOLID);
+  reconcile_put(opt, "hts-cache/new.zip", SMALL);
+  reconcile_put(opt, "hts-cache/old.zip", LARGE);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
   failures +=
-      reconcile_expect(opt, "hts-cache/new.zip", TINY, "interrupted-nolock");
+      reconcile_expect(opt, "hts-cache/new.zip", SMALL, "interrupted-nolock");
 
   /* INTERRUPTED: an absent new.zip must NOT promote old.zip; fsize() reads -1
      there, and that generation belongs to PROMOTE */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put(opt, "hts-cache/old.zip", SOLID);
+  reconcile_put(opt, "hts-cache/old.zip", LARGE);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
   failures +=
       reconcile_expect(opt, "hts-cache/new.zip", -1, "interrupted-nonew");
   failures +=
-      reconcile_expect(opt, "hts-cache/old.zip", SOLID, "interrupted-nonew");
+      reconcile_expect(opt, "hts-cache/old.zip", LARGE, "interrupted-nonew");
 
-  /* INTERRUPTED: the partial new generation loses, sidecars included, so
-     old.lst keeps describing the run old.zip came from */
+  /* INTERRUPTED: caching off, no action */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put(opt, "hts-cache/new.zip", TINY);
-  reconcile_put(opt, "hts-cache/new.lst", TINY);
-  reconcile_put(opt, "hts-cache/old.zip", SOLID);
-  reconcile_put(opt, "hts-cache/old.lst", MID);
-  reconcile_put(opt, "hts-cache/old.txt", MID);
+  reconcile_put(opt, "hts-cache/new.zip", SMALL);
+  reconcile_put(opt, "hts-cache/old.zip", LARGE);
+  {
+    const hts_cachemode saved = opt->cache;
+
+    opt->cache = 0;
+    hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
+    opt->cache = saved;
+  }
+  failures +=
+      reconcile_expect(opt, "hts-cache/new.zip", SMALL, "interrupted-nocache");
+  failures +=
+      reconcile_expect(opt, "hts-cache/old.zip", LARGE, "interrupted-nocache");
+
+  /* INTERRUPTED: the partial generation loses whole, sidecars included, and the
+     old names are gone rather than copied */
+  reconcile_wipe(opt);
+  reconcile_put(opt, "hts-in_progress.lock", 0);
+  reconcile_put(opt, "hts-cache/new.zip", SMALL);
+  reconcile_put(opt, "hts-cache/new.lst", SMALL);
+  reconcile_put(opt, "hts-cache/new.txt", SMALL);
+  reconcile_put(opt, "hts-cache/old.zip", LARGE);
+  reconcile_put(opt, "hts-cache/old.lst", MEDIUM);
+  reconcile_put(opt, "hts-cache/old.txt", MEDIUM);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
-  failures +=
-      reconcile_expect(opt, "hts-cache/new.zip", SOLID, "interrupted-zip");
-  failures += reconcile_expect(opt, "hts-cache/old.zip", -1, "interrupted-zip");
-  failures +=
-      reconcile_expect(opt, "hts-cache/new.lst", MID, "interrupted-zip");
-  failures +=
-      reconcile_expect(opt, "hts-cache/new.txt", MID, "interrupted-zip");
+  failures += reconcile_expect(opt, "hts-cache/new.zip", LARGE,
+                               "interrupted-oldwins-sidecars");
+  failures += reconcile_expect(opt, "hts-cache/new.lst", MEDIUM,
+                               "interrupted-oldwins-sidecars");
+  failures += reconcile_expect(opt, "hts-cache/new.txt", MEDIUM,
+                               "interrupted-oldwins-sidecars");
+  failures += reconcile_expect(opt, "hts-cache/old.zip", -1,
+                               "interrupted-oldwins-sidecars");
+  failures += reconcile_expect(opt, "hts-cache/old.lst", -1,
+                               "interrupted-oldwins-sidecars");
+  failures += reconcile_expect(opt, "hts-cache/old.txt", -1,
+                               "interrupted-oldwins-sidecars");
+
+  /* INTERRUPTED: a sidecar the old generation lacks is dropped, so the losing
+     run's file list cannot outlive it */
+  reconcile_wipe(opt);
+  reconcile_put(opt, "hts-in_progress.lock", 0);
+  reconcile_put(opt, "hts-cache/new.zip", SMALL);
+  reconcile_put(opt, "hts-cache/new.lst", SMALL);
+  reconcile_put(opt, "hts-cache/old.zip", LARGE);
+  hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
+  failures += reconcile_expect(opt, "hts-cache/new.zip", LARGE,
+                               "interrupted-orphan-sidecar");
+  failures += reconcile_expect(opt, "hts-cache/new.lst", -1,
+                               "interrupted-orphan-sidecar");
 
   /* INTERRUPTED: a crawl stopped halfway leaves a big new.zip, and the more
      complete old generation still wins */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put(opt, "hts-cache/new.zip", MID);
-  reconcile_put(opt, "hts-cache/old.zip", SOLID);
+  reconcile_put(opt, "hts-cache/new.zip", MEDIUM);
+  reconcile_put(opt, "hts-cache/old.zip", LARGE);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
   failures +=
-      reconcile_expect(opt, "hts-cache/new.zip", SOLID, "interrupted-bignew");
+      reconcile_expect(opt, "hts-cache/new.zip", LARGE, "interrupted-oldwins");
 
   /* INTERRUPTED: the aborted run got further than the previous one, keep it */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put(opt, "hts-cache/new.zip", SOLID);
-  reconcile_put(opt, "hts-cache/old.zip", MID);
+  reconcile_put(opt, "hts-cache/new.zip", LARGE);
+  reconcile_put(opt, "hts-cache/old.zip", MEDIUM);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
   failures +=
-      reconcile_expect(opt, "hts-cache/new.zip", SOLID, "interrupted-newwins");
+      reconcile_expect(opt, "hts-cache/new.zip", LARGE, "interrupted-newwins");
   failures +=
-      reconcile_expect(opt, "hts-cache/old.zip", MID, "interrupted-newwins");
+      reconcile_expect(opt, "hts-cache/old.zip", MEDIUM, "interrupted-newwins");
 
-  /* INTERRUPTED: equal caches keep the fresher one, and no sidecar moves
-     without its zip */
+  /* INTERRUPTED: equal sizes do not promote, so nothing moves at all */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put(opt, "hts-cache/new.zip", MID);
-  reconcile_put(opt, "hts-cache/old.zip", MID);
-  reconcile_put(opt, "hts-cache/new.lst", TINY);
-  reconcile_put(opt, "hts-cache/old.lst", SOLID);
+  reconcile_put(opt, "hts-cache/new.zip", MEDIUM);
+  reconcile_put(opt, "hts-cache/old.zip", MEDIUM);
+  reconcile_put(opt, "hts-cache/new.lst", SMALL);
+  reconcile_put(opt, "hts-cache/old.lst", LARGE);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
   failures +=
-      reconcile_expect(opt, "hts-cache/new.zip", MID, "interrupted-equal");
+      reconcile_expect(opt, "hts-cache/old.zip", MEDIUM, "interrupted-tie");
   failures +=
-      reconcile_expect(opt, "hts-cache/old.zip", MID, "interrupted-equal");
+      reconcile_expect(opt, "hts-cache/new.lst", SMALL, "interrupted-tie");
   failures +=
-      reconcile_expect(opt, "hts-cache/new.lst", TINY, "interrupted-equal");
+      reconcile_expect(opt, "hts-cache/old.lst", LARGE, "interrupted-tie");
 
   /* INTERRUPTED: the removed pre-3.31 legacy pair is left alone */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put(opt, "hts-cache/new.dat", TINY);
-  reconcile_put(opt, "hts-cache/new.ndx", TINY);
-  reconcile_put(opt, "hts-cache/old.dat", SOLID);
-  reconcile_put(opt, "hts-cache/old.ndx", MID);
+  reconcile_put(opt, "hts-cache/new.dat", SMALL);
+  reconcile_put(opt, "hts-cache/new.ndx", SMALL);
+  reconcile_put(opt, "hts-cache/old.dat", LARGE);
+  reconcile_put(opt, "hts-cache/old.ndx", MEDIUM);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
   failures +=
-      reconcile_expect(opt, "hts-cache/new.dat", TINY, "interrupted-dat");
+      reconcile_expect(opt, "hts-cache/new.dat", SMALL, "interrupted-dat");
   failures +=
-      reconcile_expect(opt, "hts-cache/new.ndx", TINY, "interrupted-dat");
+      reconcile_expect(opt, "hts-cache/new.ndx", SMALL, "interrupted-dat");
   failures +=
-      reconcile_expect(opt, "hts-cache/old.dat", SOLID, "interrupted-dat");
+      reconcile_expect(opt, "hts-cache/old.dat", LARGE, "interrupted-dat");
   failures +=
-      reconcile_expect(opt, "hts-cache/old.ndx", MID, "interrupted-dat");
+      reconcile_expect(opt, "hts-cache/old.ndx", MEDIUM, "interrupted-dat");
 
   /* ROLLBACK: the old zip generation is restored (a zip cache used to lose
      its only good generation here) */
   reconcile_wipe(opt);
-  reconcile_put(opt, "hts-cache/new.zip", TINY);
-  reconcile_put(opt, "hts-cache/old.zip", SOLID);
+  reconcile_put(opt, "hts-cache/new.zip", SMALL);
+  reconcile_put(opt, "hts-cache/old.zip", LARGE);
   hts_cache_reconcile(opt, CACHE_RECONCILE_ROLLBACK);
-  failures += reconcile_expect(opt, "hts-cache/new.zip", SOLID, "rollback-zip");
+  failures += reconcile_expect(opt, "hts-cache/new.zip", LARGE, "rollback-zip");
   failures += reconcile_expect(opt, "hts-cache/old.zip", -1, "rollback-zip");
 
   /* ROLLBACK: sidecars are restored regardless of format */
   reconcile_wipe(opt);
-  reconcile_put(opt, "hts-cache/new.lst", TINY);
-  reconcile_put(opt, "hts-cache/old.lst", MID);
-  reconcile_put(opt, "hts-cache/old.txt", MID);
+  reconcile_put(opt, "hts-cache/new.lst", SMALL);
+  reconcile_put(opt, "hts-cache/old.lst", MEDIUM);
+  reconcile_put(opt, "hts-cache/old.txt", MEDIUM);
   hts_cache_reconcile(opt, CACHE_RECONCILE_ROLLBACK);
-  failures += reconcile_expect(opt, "hts-cache/new.lst", MID, "rollback-lst");
-  failures += reconcile_expect(opt, "hts-cache/new.txt", MID, "rollback-txt");
+  failures +=
+      reconcile_expect(opt, "hts-cache/new.lst", MEDIUM, "rollback-lst");
+  failures +=
+      reconcile_expect(opt, "hts-cache/new.txt", MEDIUM, "rollback-txt");
+  failures += reconcile_expect(opt, "hts-cache/old.lst", -1, "rollback-lst");
+  failures += reconcile_expect(opt, "hts-cache/old.txt", -1, "rollback-txt");
 
   /* ROLLBACK: sidecars restored, the removed pre-3.31 pair left alone */
   reconcile_wipe(opt);
-  reconcile_put(opt, "hts-cache/new.dat", TINY);
-  reconcile_put(opt, "hts-cache/old.dat", SOLID);
-  reconcile_put(opt, "hts-cache/old.ndx", MID);
-  reconcile_put(opt, "hts-cache/old.lst", MID);
-  reconcile_put(opt, "hts-cache/old.txt", MID);
+  reconcile_put(opt, "hts-cache/new.dat", SMALL);
+  reconcile_put(opt, "hts-cache/old.dat", LARGE);
+  reconcile_put(opt, "hts-cache/old.ndx", MEDIUM);
+  reconcile_put(opt, "hts-cache/old.lst", MEDIUM);
+  reconcile_put(opt, "hts-cache/old.txt", MEDIUM);
   hts_cache_reconcile(opt, CACHE_RECONCILE_ROLLBACK);
-  failures += reconcile_expect(opt, "hts-cache/new.dat", TINY, "rollback-dat");
+  failures += reconcile_expect(opt, "hts-cache/new.dat", SMALL, "rollback-dat");
   failures += reconcile_expect(opt, "hts-cache/new.ndx", -1, "rollback-dat");
-  failures += reconcile_expect(opt, "hts-cache/old.dat", SOLID, "rollback-dat");
-  failures += reconcile_expect(opt, "hts-cache/old.ndx", MID, "rollback-dat");
-  failures += reconcile_expect(opt, "hts-cache/new.lst", MID, "rollback-dat");
-  failures += reconcile_expect(opt, "hts-cache/new.txt", MID, "rollback-dat");
+  failures += reconcile_expect(opt, "hts-cache/old.dat", LARGE, "rollback-dat");
+  failures +=
+      reconcile_expect(opt, "hts-cache/old.ndx", MEDIUM, "rollback-dat");
+  failures +=
+      reconcile_expect(opt, "hts-cache/new.lst", MEDIUM, "rollback-dat");
+  failures +=
+      reconcile_expect(opt, "hts-cache/new.txt", MEDIUM, "rollback-dat");
 
   /* ROLLBACK: nothing to restore, the new generation stays */
   reconcile_wipe(opt);
-  reconcile_put(opt, "hts-cache/new.zip", TINY);
+  reconcile_put(opt, "hts-cache/new.zip", SMALL);
   hts_cache_reconcile(opt, CACHE_RECONCILE_ROLLBACK);
-  failures += reconcile_expect(opt, "hts-cache/new.zip", TINY, "rollback-noop");
+  failures +=
+      reconcile_expect(opt, "hts-cache/new.zip", SMALL, "rollback-noop");
 
   reconcile_wipe(opt);
   return failures;

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -1169,7 +1169,7 @@ static int reconcile_expect(httrackp *opt, const char *name, LLint size,
 int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   int failures = 0;
 
-  /* around the interrupted-run thresholds (new < 32768, old > 65536) */
+  /* three distinct sizes: TINY < MID < SOLID */
   static const LLint TINY = 1024, MID = 40000, SOLID = 131072;
 
   selftest_setup_dir(opt, dir);
@@ -1214,8 +1214,8 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   failures +=
       reconcile_expect(opt, "hts-cache/new.zip", TINY, "interrupted-nolock");
 
-  /* INTERRUPTED: an absent new.zip must NOT promote old.zip (fsize(-1) would
-     spuriously pass "< TINY"); leave the solid old generation for ROLLBACK */
+  /* INTERRUPTED: an absent new.zip must NOT promote old.zip; fsize() reads -1
+     there, and that generation belongs to PROMOTE */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
   reconcile_put(opt, "hts-cache/old.zip", SOLID);
@@ -1225,34 +1225,60 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   failures +=
       reconcile_expect(opt, "hts-cache/old.zip", SOLID, "interrupted-nonew");
 
-  /* INTERRUPTED: stalled tiny new.zip loses to a solid old.zip (was dead for
-     zip caches: the arm was gated on a legacy new.dat) */
+  /* INTERRUPTED: the partial new generation loses, sidecars included, so
+     old.lst keeps describing the run old.zip came from */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
   reconcile_put(opt, "hts-cache/new.zip", TINY);
+  reconcile_put(opt, "hts-cache/new.lst", TINY);
   reconcile_put(opt, "hts-cache/old.zip", SOLID);
+  reconcile_put(opt, "hts-cache/old.lst", MID);
+  reconcile_put(opt, "hts-cache/old.txt", MID);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
   failures +=
       reconcile_expect(opt, "hts-cache/new.zip", SOLID, "interrupted-zip");
   failures += reconcile_expect(opt, "hts-cache/old.zip", -1, "interrupted-zip");
-
-  /* INTERRUPTED: old below the confidence threshold, keep new */
-  reconcile_wipe(opt);
-  reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put(opt, "hts-cache/new.zip", TINY);
-  reconcile_put(opt, "hts-cache/old.zip", MID);
-  hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
   failures +=
-      reconcile_expect(opt, "hts-cache/new.zip", TINY, "interrupted-smallold");
+      reconcile_expect(opt, "hts-cache/new.lst", MID, "interrupted-zip");
+  failures +=
+      reconcile_expect(opt, "hts-cache/new.txt", MID, "interrupted-zip");
 
-  /* INTERRUPTED: new big enough to trust, keep it */
+  /* INTERRUPTED: a crawl stopped halfway leaves a big new.zip, and the more
+     complete old generation still wins */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
   reconcile_put(opt, "hts-cache/new.zip", MID);
   reconcile_put(opt, "hts-cache/old.zip", SOLID);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
   failures +=
-      reconcile_expect(opt, "hts-cache/new.zip", MID, "interrupted-bignew");
+      reconcile_expect(opt, "hts-cache/new.zip", SOLID, "interrupted-bignew");
+
+  /* INTERRUPTED: the aborted run got further than the previous one, keep it */
+  reconcile_wipe(opt);
+  reconcile_put(opt, "hts-in_progress.lock", 0);
+  reconcile_put(opt, "hts-cache/new.zip", SOLID);
+  reconcile_put(opt, "hts-cache/old.zip", MID);
+  hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
+  failures +=
+      reconcile_expect(opt, "hts-cache/new.zip", SOLID, "interrupted-newwins");
+  failures +=
+      reconcile_expect(opt, "hts-cache/old.zip", MID, "interrupted-newwins");
+
+  /* INTERRUPTED: equal caches keep the fresher one, and no sidecar moves
+     without its zip */
+  reconcile_wipe(opt);
+  reconcile_put(opt, "hts-in_progress.lock", 0);
+  reconcile_put(opt, "hts-cache/new.zip", MID);
+  reconcile_put(opt, "hts-cache/old.zip", MID);
+  reconcile_put(opt, "hts-cache/new.lst", TINY);
+  reconcile_put(opt, "hts-cache/old.lst", SOLID);
+  hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
+  failures +=
+      reconcile_expect(opt, "hts-cache/new.zip", MID, "interrupted-equal");
+  failures +=
+      reconcile_expect(opt, "hts-cache/old.zip", MID, "interrupted-equal");
+  failures +=
+      reconcile_expect(opt, "hts-cache/new.lst", TINY, "interrupted-equal");
 
   /* INTERRUPTED: the removed pre-3.31 legacy pair is left alone */
   reconcile_wipe(opt);

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -1246,10 +1246,12 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   static const LLint SMALL = 1024, MEDIUM = 40000, LARGE = 131072;
   /* Cache generations, in entries: what the reconcile actually compares. */
   static const LLint EMPTY = 0, PARTIAL = 2, COMPLETE = 9;
-  /* Filler bytes under a .zip name: a generation that will not open. */
+  /* Bytes again, not entries: filler under a .zip name will not open. */
   static const LLint DAMAGED = 131072;
   /* reconcile_put_zip() body size; only interrupted-fatnew wants one. */
   static const size_t NO_BODY = 0;
+  /* An end-of-central-directory record carrying no comment field. */
+  static const LLint ZIP_DIRECTORY_END = 22;
 
   selftest_setup_dir(opt, dir);
 #ifdef _WIN32
@@ -1399,13 +1401,12 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   failures += reconcile_expect_zip(opt, "hts-cache/old.zip", COMPLETE,
                                    "interrupted-damaged-new");
 
-  /* INTERRUPTED: the case that matters, because the file is recoverable. A hard
-     kill leaves new.zip without its central directory, and promoting over it
-     would delete entries cache_repair() would have brought back. */
+  /* INTERRUPTED: a hard kill leaves new.zip with no central directory, so a
+     promote would delete entries cache_repair() could still recover. */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
   reconcile_put_zip(opt, "hts-cache/new.zip", COMPLETE, NO_BODY);
-  reconcile_truncate(opt, "hts-cache/new.zip", 22);
+  reconcile_truncate(opt, "hts-cache/new.zip", ZIP_DIRECTORY_END);
   reconcile_put_zip(opt, "hts-cache/old.zip", EMPTY, NO_BODY);
   failures += reconcile_expect_zip(opt, "hts-cache/new.zip", -1,
                                    "interrupted-truncated-new fixture");

--- a/src/htscache_selftest.c
+++ b/src/htscache_selftest.c
@@ -1153,6 +1153,58 @@ static void reconcile_put(httrackp *opt, const char *name, LLint size) {
   fclose(fp);
 }
 
+/* Write a valid cache generation of `entries` files, each carrying `body`
+   stored bytes. Stored, not deflated, so the file size follows `body` and a
+   case can make the shallower generation the physically larger one. */
+static void reconcile_put_zip(httrackp *opt, const char *name, int entries,
+                              size_t body) {
+  zipFile zf = hts_zipOpen_utf8(reconcile_st_path(opt, name), 0);
+  zip_fileinfo fi;
+  char chunk[4096];
+  int i;
+
+  assertf(zf != NULL);
+  memset(&fi, 0, sizeof(fi));
+  memset(chunk, 'e', sizeof(chunk));
+  for (i = 0; i < entries; i++) {
+    char entry[64];
+    size_t left;
+
+    snprintf(entry, sizeof(entry), "entry%03d.dat", i);
+    assertf(zipOpenNewFileInZip(zf, entry, &fi, NULL, 0, NULL, 0, NULL, 0,
+                                Z_NO_COMPRESSION) == ZIP_OK);
+    for (left = body; left != 0;) {
+      const size_t n = left < sizeof(chunk) ? left : sizeof(chunk);
+
+      assertf(zipWriteInFileInZip(zf, chunk, (unsigned) n) == ZIP_OK);
+      left -= n;
+    }
+    assertf(zipCloseFileInZip(zf) == ZIP_OK);
+  }
+  assertf(zipClose(zf, NULL) == ZIP_OK);
+}
+
+/* Expect `name` to hold `entries` cache entries, or -1 when it is absent or
+   will not open. */
+static int reconcile_expect_zip(httrackp *opt, const char *name, int entries,
+                                const char *what) {
+  unz_global_info64 gi;
+  unzFile zip = hts_unzOpen_utf8(reconcile_st_path(opt, name));
+  int got = -1;
+
+  if (zip != NULL) {
+    if (unzGetGlobalInfo64(zip, &gi) == UNZ_OK)
+      got = (int) gi.number_entry;
+    unzClose(zip);
+  }
+  if (got != entries) {
+    fprintf(stderr, "cache-reconcile: %s: %s holds %d entries, expected %d\n",
+            what, name, got, entries);
+    return 1;
+  }
+  return 0;
+}
+
 /* Expect `name` to weigh `size` bytes, or be absent when size == -1. */
 static int reconcile_expect(httrackp *opt, const char *name, LLint size,
                             const char *what) {
@@ -1169,8 +1221,10 @@ static int reconcile_expect(httrackp *opt, const char *name, LLint size,
 int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   int failures = 0;
 
-  /* only the ordering counts: the policy is size-ordinal now */
+  /* Sidecar byte sizes; only their ordering matters. */
   static const LLint SMALL = 1024, MEDIUM = 40000, LARGE = 131072;
+  /* Cache generations, in entries: what the reconcile actually compares. */
+  static const int EMPTY = 0, PARTIAL = 2, COMPLETE = 9;
 
   selftest_setup_dir(opt, dir);
 #ifdef _WIN32
@@ -1181,20 +1235,21 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
 
   /* PROMOTE: a zip old generation replaces a missing new one */
   reconcile_wipe(opt);
-  reconcile_put(opt, "hts-cache/old.zip", LARGE);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, 0);
   hts_cache_reconcile(opt, CACHE_RECONCILE_PROMOTE);
-  failures += reconcile_expect(opt, "hts-cache/new.zip", LARGE, "promote-zip");
+  failures +=
+      reconcile_expect_zip(opt, "hts-cache/new.zip", COMPLETE, "promote-zip");
   failures += reconcile_expect(opt, "hts-cache/old.zip", -1, "promote-zip");
 
   /* PROMOTE: an existing new.zip is left alone */
   reconcile_wipe(opt);
-  reconcile_put(opt, "hts-cache/new.zip", SMALL);
-  reconcile_put(opt, "hts-cache/old.zip", LARGE);
+  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, 0);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, 0);
   hts_cache_reconcile(opt, CACHE_RECONCILE_PROMOTE);
-  failures +=
-      reconcile_expect(opt, "hts-cache/new.zip", SMALL, "promote-zip-noop");
-  failures +=
-      reconcile_expect(opt, "hts-cache/old.zip", LARGE, "promote-zip-noop");
+  failures += reconcile_expect_zip(opt, "hts-cache/new.zip", PARTIAL,
+                                   "promote-zip-noop");
+  failures += reconcile_expect_zip(opt, "hts-cache/old.zip", COMPLETE,
+                                   "promote-zip-noop");
 
   /* PROMOTE: the removed pre-3.31 legacy pair is left alone */
   reconcile_wipe(opt);
@@ -1208,28 +1263,17 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
 
   /* INTERRUPTED: no lock file, no action */
   reconcile_wipe(opt);
-  reconcile_put(opt, "hts-cache/new.zip", SMALL);
-  reconcile_put(opt, "hts-cache/old.zip", LARGE);
+  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, 0);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, 0);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
-  failures +=
-      reconcile_expect(opt, "hts-cache/new.zip", SMALL, "interrupted-nolock");
-
-  /* INTERRUPTED: an absent new.zip must NOT promote old.zip; fsize() reads -1
-     there, and that generation belongs to PROMOTE */
-  reconcile_wipe(opt);
-  reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put(opt, "hts-cache/old.zip", LARGE);
-  hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
-  failures +=
-      reconcile_expect(opt, "hts-cache/new.zip", -1, "interrupted-nonew");
-  failures +=
-      reconcile_expect(opt, "hts-cache/old.zip", LARGE, "interrupted-nonew");
+  failures += reconcile_expect_zip(opt, "hts-cache/new.zip", PARTIAL,
+                                   "interrupted-nolock");
 
   /* INTERRUPTED: caching off, no action */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put(opt, "hts-cache/new.zip", SMALL);
-  reconcile_put(opt, "hts-cache/old.zip", LARGE);
+  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, 0);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, 0);
   {
     const hts_cachemode saved = opt->cache;
 
@@ -1237,24 +1281,35 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
     hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
     opt->cache = saved;
   }
-  failures +=
-      reconcile_expect(opt, "hts-cache/new.zip", SMALL, "interrupted-nocache");
-  failures +=
-      reconcile_expect(opt, "hts-cache/old.zip", LARGE, "interrupted-nocache");
+  failures += reconcile_expect_zip(opt, "hts-cache/new.zip", PARTIAL,
+                                   "interrupted-nocache");
+  failures += reconcile_expect_zip(opt, "hts-cache/old.zip", COMPLETE,
+                                   "interrupted-nocache");
 
-  /* INTERRUPTED: the partial generation loses whole, sidecars included, and the
-     old names are gone rather than copied */
+  /* INTERRUPTED: an absent new.zip must NOT promote old.zip; that generation
+     belongs to PROMOTE */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put(opt, "hts-cache/new.zip", SMALL);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, 0);
+  hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
+  failures +=
+      reconcile_expect(opt, "hts-cache/new.zip", -1, "interrupted-nonew");
+  failures += reconcile_expect_zip(opt, "hts-cache/old.zip", COMPLETE,
+                                   "interrupted-nonew");
+
+  /* INTERRUPTED: the shallower generation loses whole, sidecars included, and
+     the old names are gone rather than copied */
+  reconcile_wipe(opt);
+  reconcile_put(opt, "hts-in_progress.lock", 0);
+  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, 0);
   reconcile_put(opt, "hts-cache/new.lst", SMALL);
   reconcile_put(opt, "hts-cache/new.txt", SMALL);
-  reconcile_put(opt, "hts-cache/old.zip", LARGE);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, 0);
   reconcile_put(opt, "hts-cache/old.lst", MEDIUM);
   reconcile_put(opt, "hts-cache/old.txt", MEDIUM);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
-  failures += reconcile_expect(opt, "hts-cache/new.zip", LARGE,
-                               "interrupted-oldwins-sidecars");
+  failures += reconcile_expect_zip(opt, "hts-cache/new.zip", COMPLETE,
+                                   "interrupted-oldwins-sidecars");
   failures += reconcile_expect(opt, "hts-cache/new.lst", MEDIUM,
                                "interrupted-oldwins-sidecars");
   failures += reconcile_expect(opt, "hts-cache/new.txt", MEDIUM,
@@ -1270,46 +1325,84 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
      run's file list cannot outlive it */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put(opt, "hts-cache/new.zip", SMALL);
+  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, 0);
   reconcile_put(opt, "hts-cache/new.lst", SMALL);
-  reconcile_put(opt, "hts-cache/old.zip", LARGE);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, 0);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
-  failures += reconcile_expect(opt, "hts-cache/new.zip", LARGE,
-                               "interrupted-orphan-sidecar");
+  failures += reconcile_expect_zip(opt, "hts-cache/new.zip", COMPLETE,
+                                   "interrupted-orphan-sidecar");
   failures += reconcile_expect(opt, "hts-cache/new.lst", -1,
                                "interrupted-orphan-sidecar");
 
-  /* INTERRUPTED: a crawl stopped halfway leaves a big new.zip, and the more
-     complete old generation still wins */
+  /* INTERRUPTED: reach decides, not weight. new.zip carries fewer entries in a
+     physically larger file, and still loses; a byte comparison keeps it. */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put(opt, "hts-cache/new.zip", MEDIUM);
+  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, 65536);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, 0);
+  if (fsize(reconcile_st_path(opt, "hts-cache/new.zip")) <=
+      fsize(reconcile_st_path(opt, "hts-cache/old.zip"))) {
+    fprintf(stderr, "cache-reconcile: interrupted-fatnew: new.zip is not the "
+                    "larger file, so the case tests nothing\n");
+    failures++;
+  }
+  hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
+  failures += reconcile_expect_zip(opt, "hts-cache/new.zip", COMPLETE,
+                                   "interrupted-fatnew");
+
+  /* INTERRUPTED: a generation that will not open counts as no reach, so a
+     damaged old.zip never displaces a readable new one */
+  reconcile_wipe(opt);
+  reconcile_put(opt, "hts-in_progress.lock", 0);
+  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, 0);
   reconcile_put(opt, "hts-cache/old.zip", LARGE);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
-  failures +=
-      reconcile_expect(opt, "hts-cache/new.zip", LARGE, "interrupted-oldwins");
+  failures += reconcile_expect_zip(opt, "hts-cache/new.zip", PARTIAL,
+                                   "interrupted-damaged-old");
+  failures += reconcile_expect(opt, "hts-cache/old.zip", LARGE,
+                               "interrupted-damaged-old");
 
-  /* INTERRUPTED: the aborted run got further than the previous one, keep it */
+  /* INTERRUPTED: and the same the other way, so a damaged new.zip loses */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
   reconcile_put(opt, "hts-cache/new.zip", LARGE);
-  reconcile_put(opt, "hts-cache/old.zip", MEDIUM);
+  reconcile_put_zip(opt, "hts-cache/old.zip", PARTIAL, 0);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
-  failures +=
-      reconcile_expect(opt, "hts-cache/new.zip", LARGE, "interrupted-newwins");
-  failures +=
-      reconcile_expect(opt, "hts-cache/old.zip", MEDIUM, "interrupted-newwins");
+  failures += reconcile_expect_zip(opt, "hts-cache/new.zip", PARTIAL,
+                                   "interrupted-damaged-new");
 
-  /* INTERRUPTED: equal sizes do not promote, so nothing moves at all */
+  /* INTERRUPTED: a readable but empty generation still beats an unreadable one,
+     so "reached nothing" and "will not open" must not count alike */
   reconcile_wipe(opt);
   reconcile_put(opt, "hts-in_progress.lock", 0);
-  reconcile_put(opt, "hts-cache/new.zip", MEDIUM);
-  reconcile_put(opt, "hts-cache/old.zip", MEDIUM);
+  reconcile_put(opt, "hts-cache/new.zip", LARGE);
+  reconcile_put_zip(opt, "hts-cache/old.zip", EMPTY, 0);
+  hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
+  failures += reconcile_expect_zip(opt, "hts-cache/new.zip", EMPTY,
+                                   "interrupted-empty-beats-damaged");
+
+  /* INTERRUPTED: the aborted run reached further than the previous one, keep it
+   */
+  reconcile_wipe(opt);
+  reconcile_put(opt, "hts-in_progress.lock", 0);
+  reconcile_put_zip(opt, "hts-cache/new.zip", COMPLETE, 0);
+  reconcile_put_zip(opt, "hts-cache/old.zip", PARTIAL, 0);
+  hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
+  failures += reconcile_expect_zip(opt, "hts-cache/new.zip", COMPLETE,
+                                   "interrupted-newwins");
+  failures += reconcile_expect_zip(opt, "hts-cache/old.zip", PARTIAL,
+                                   "interrupted-newwins");
+
+  /* INTERRUPTED: equal reach does not promote, so nothing moves at all */
+  reconcile_wipe(opt);
+  reconcile_put(opt, "hts-in_progress.lock", 0);
+  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, 0);
+  reconcile_put_zip(opt, "hts-cache/old.zip", PARTIAL, 0);
   reconcile_put(opt, "hts-cache/new.lst", SMALL);
   reconcile_put(opt, "hts-cache/old.lst", LARGE);
   hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
-  failures +=
-      reconcile_expect(opt, "hts-cache/old.zip", MEDIUM, "interrupted-tie");
+  failures += reconcile_expect_zip(opt, "hts-cache/old.zip", PARTIAL,
+                                   "interrupted-tie");
   failures +=
       reconcile_expect(opt, "hts-cache/new.lst", SMALL, "interrupted-tie");
   failures +=
@@ -1335,10 +1428,11 @@ int cache_reconcile_selftest(httrackp *opt, const char *dir) {
   /* ROLLBACK: the old zip generation is restored (a zip cache used to lose
      its only good generation here) */
   reconcile_wipe(opt);
-  reconcile_put(opt, "hts-cache/new.zip", SMALL);
-  reconcile_put(opt, "hts-cache/old.zip", LARGE);
+  reconcile_put_zip(opt, "hts-cache/new.zip", PARTIAL, 0);
+  reconcile_put_zip(opt, "hts-cache/old.zip", COMPLETE, 0);
   hts_cache_reconcile(opt, CACHE_RECONCILE_ROLLBACK);
-  failures += reconcile_expect(opt, "hts-cache/new.zip", LARGE, "rollback-zip");
+  failures +=
+      reconcile_expect_zip(opt, "hts-cache/new.zip", COMPLETE, "rollback-zip");
   failures += reconcile_expect(opt, "hts-cache/old.zip", -1, "rollback-zip");
 
   /* ROLLBACK: sidecars are restored regardless of format */

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -3079,6 +3079,11 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
       }
     }
 
+    /* The lock goes at the end of this block, and the startup arm needs it, so
+       an abort that returns normally has to reconcile here or never. */
+    if (opt->state.exit_xh != 0)
+      hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
+
     /* Not or cleanly interrupted; erase hts-cache/ref temporary directory.
        A ^C or a cap leaves exit_xh at 0, so keep the ref when either cut a
        transfer mid-body (#1595). */

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -3011,6 +3011,10 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
       }
     }
 
+    /* httpmirror()'s own verdict on whether the mirror ran to the end; the
+       cache reconcile below is the only reader outside the mirror block. */
+    hts_boolean completed = HTS_FALSE;
+
     /* Info for wrappers */
     hts_log_print(opt, LOG_DEBUG, "engine: init");
 
@@ -3026,7 +3030,6 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
     // ------------------------------------------------------------
     opt->state._hts_in_mirror = 1;
     {
-      hts_boolean completed = HTS_FALSE;
       const int mirrored = httpmirror(url, opt, &completed);
 
       if (mirrored == 0) {
@@ -3080,8 +3083,9 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
     }
 
     /* The lock goes at the end of this block, and the startup arm needs it, so
-       an abort that returns normally has to reconcile here or never. */
-    if (opt->state.exit_xh != 0)
+       an abort that returns normally has to reconcile here or never. A cap or a
+       ^C leaves exit_xh at 0, so ask the engine's verdict instead. */
+    if (!completed)
       hts_cache_reconcile(opt, CACHE_RECONCILE_INTERRUPTED);
 
     /* Not or cleanly interrupted; erase hts-cache/ref temporary directory.

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -798,12 +798,12 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
 #endif
   hts_cache_reconcile(opt, CACHE_RECONCILE_PROMOTE);
 
-  /* Interrupted mirror detected */
+  /* Interrupted mirror over a pre-3.31 (2003) cache: cache_init() refuses that
+     .dat/.ndx pair, so say so rather than send the user restoring it. */
   if (!opt->quiet) {
     if (fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
                             StringBuff(opt->path_log),
                             "hts-in_progress.lock"))) {
-      /* Old cache */
       if ((fexist_utf8(fconcat(OPT_GET_BUFF(opt), OPT_GET_BUFF_SIZE(opt),
                                StringBuff(opt->path_log),
                                "hts-cache/old.dat"))) &&
@@ -813,9 +813,12 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
         if (opt->log != NULL) {
           fprintf(opt->log, "Warning!\n");
           fprintf(opt->log,
-                  "An aborted mirror has been detected!\nThe current temporary cache is required for any update operation and only contains data downloaded during the last aborted session.\nThe former cache might contain more complete information; if you do not want to lose that information, you have to restore it and delete the current cache.\nThis can easily be done here by erasing the hts-cache/new.* files\n");
+                  "An aborted mirror has been detected, over a cache this "
+                  "version can no longer read: hts-cache/old.dat and old.ndx "
+                  "are the pre-3.31 format, dropped in 2003.\n");
           fprintf(opt->log,
-                  "Please restart HTTrack with --continue (-iC1) option to override this message!\n");
+                  "Restart HTTrack with --continue (-iC1) to go on; the site "
+                  "will be mirrored again from scratch.\n");
         }
         htsmain_free();
         return 0;
@@ -3070,7 +3073,9 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
     if (opt->state.exit_xh == 1) {
       if (opt->log) {
         fprintf(opt->log,
-                "* * MIRROR ABORTED! * *\nThe current temporary cache is required for any update operation and only contains data downloaded during the present aborted session.\nThe former cache might contain more complete information; if you do not want to lose that information, you have to restore it and delete the current cache.\nThis can easily be done here by erasing the hts-cache/new.* files]\n");
+                "* * MIRROR ABORTED! * *\nThe mirror stopped before the end. "
+                "Start it again with --continue to resume it.\nThe cache is "
+                "kept: nothing has to be restored or deleted by hand.\n");
       }
     }
 

--- a/tests/261_local-abort-purge.test
+++ b/tests/261_local-abort-purge.test
@@ -22,7 +22,6 @@ root="${tmpdir}/root"
 out="${tmpdir}/crawl"
 modes="${tmpdir}/modes"
 cmds="${tmpdir}/cmds"
-lst="${out}/hts-cache"
 mkdir -p "$root" "$out"
 
 names=(a b c d e)
@@ -116,8 +115,10 @@ grep -q 'Exit requested by shell or user' <<<"$log" ||
 ! grep -q 'restoring previous one' <<<"$log" ||
     fail "the abort rolled the session back, which skips the purge anyway: ${log}"
 # And the run must really have left links behind, or there is nothing to purge.
+# The server's own command log, not new.lst: an aborted run now leaves the
+# generation the reconcile restored, which lists what pass 2 mirrored (#1636).
 for name in c d e; do
-    ! grep -aq "${name}\.bin" "${lst}/new.lst" ||
+    ! grep -aq "${name}\.bin" "$cmds" ||
         fail "${name}.bin was reached after all; the abort came too late"
 done
 grep -aq "V3-a-" "${out}/${host}/a.bin" ||

--- a/tests/283_engine-cmdline-leak.test
+++ b/tests/283_engine-cmdline-leak.test
@@ -165,6 +165,8 @@ else
     # the missing sign-off carry the teeth here.
     out=$(cat "$d/typescript")
     assert_match 'aborted mirror has been detected' "$out" 'aborted mirror'
+    # Which cache it means, so a revert to the old restore-it advice reds here.
+    assert_match 'old.ndx' "$out" 'aborted mirror names the legacy cache'
     if [[ $out =~ Thanks\ for\ using ]]; then
         fail 'aborted mirror: reached the end of the run, not the early exit'
     fi

--- a/tests/444_local-stop-keeps-resume.test
+++ b/tests/444_local-stop-keeps-resume.test
@@ -163,20 +163,29 @@ test ! -d "${out}/hts-cache/ref" ||
     fail "hts-cache/ref survived a mirror nothing interrupted"
 echo "PASS"
 
-# The lock is unlinked whatever ended the run, so the startup reconcile never
-# sees a stop. Left alone, the next run rotates the fragment over the complete
-# generation and it is gone.
+# A stop drops the lock before the startup reconcile could run, so without the
+# abort-site call the next run rotates the fragment over the complete generation.
+keeps_generation() { # keeps_generation <name> <how>
+    local out="${tmpdir}/$1" complete="${tmpdir}/$1-complete.zip"
+
+    mkdir -p "$out"
+    local_crawl --log "${tmpdir}/$1.log1" -O "$out" --quiet \
+        --disable-security-limits --robots=0 --timeout=30 -c2 \
+        "${BASEURL}/bigfiles/index.html" || fail "$1: the crawl that fills the cache failed"
+    cp "${out}/hts-cache/new.zip" "$complete"
+    stop_and_report "$1" "$2"
+    test ! -e "${out}/hts-cache/old.zip" ||
+        fail "$1: both generations were left, so the next run drops one"
+    cmp -s "${out}/hts-cache/new.zip" "$complete" ||
+        fail "$1: the run left its own fragment where the complete cache was"
+}
+
 printf '[a stop keeps the complete cache generation] ..\t'
-out="${tmpdir}/gen"
-mkdir -p "$out"
-local_crawl --log "${tmpdir}/gen.log1" -O "$out" --quiet \
-    --disable-security-limits --robots=0 --timeout=30 -c2 \
-    "${BASEURL}/bigfiles/index.html" || fail "the crawl that fills the cache failed"
-complete="${tmpdir}/gen-complete.zip"
-cp "${out}/hts-cache/new.zip" "$complete"
-stop_and_report gen keep
-test ! -e "${out}/hts-cache/old.zip" ||
-    fail "the stopped run left both generations, so the next run drops one"
-cmp -s "${out}/hts-cache/new.zip" "$complete" ||
-    fail "the stopped run left its own fragment where the complete cache was"
+keeps_generation gen keep
+echo "PASS"
+
+# A cap leaves exit_xh at 0, the same as a ^C, so the reconcile reads the
+# engine's completed verdict rather than that flag.
+printf '[a capped run keeps it too] ..\t'
+keeps_generation gencap maxtime
 echo "PASS"

--- a/tests/444_local-stop-keeps-resume.test
+++ b/tests/444_local-stop-keeps-resume.test
@@ -166,18 +166,25 @@ echo "PASS"
 # A stop drops the lock before the startup reconcile could run, so without the
 # abort-site call the next run rotates the fragment over the complete generation.
 keeps_generation() { # keeps_generation <name> <how>
-    local out="${tmpdir}/$1" complete="${tmpdir}/$1-complete.zip"
+    local name=$1 how=$2
+    local out="${tmpdir}/${name}" complete="${tmpdir}/${name}-complete.zip"
 
     mkdir -p "$out"
-    local_crawl --log "${tmpdir}/$1.log1" -O "$out" --quiet \
+    local_crawl --log "${tmpdir}/${name}.log1" -O "$out" --quiet \
         --disable-security-limits --robots=0 --timeout=30 -c2 \
-        "${BASEURL}/bigfiles/index.html" || fail "$1: the crawl that fills the cache failed"
+        "${BASEURL}/bigfiles/index.html" ||
+        fail "${name}: the crawl that fills the cache failed"
+    test -s "${out}/hts-cache/new.zip" ||
+        fail "${name}: the first crawl cached nothing, so there is nothing to keep"
     cp "${out}/hts-cache/new.zip" "$complete"
-    stop_and_report "$1" "$2"
+    stop_and_report "$name" "$how"
+    # Or a run that finished would red below, pointing at the wrong thing.
+    test "$refs_left" -gt 0 ||
+        fail "${name}: the second run was not cut short, so it decides nothing"
     test ! -e "${out}/hts-cache/old.zip" ||
-        fail "$1: both generations were left, so the next run drops one"
+        fail "${name}: both generations were left, so the next run drops one"
     cmp -s "${out}/hts-cache/new.zip" "$complete" ||
-        fail "$1: the run left its own fragment where the complete cache was"
+        fail "${name}: the run left its own fragment where the complete cache was"
 }
 
 printf '[a stop keeps the complete cache generation] ..\t'

--- a/tests/444_local-stop-keeps-resume.test
+++ b/tests/444_local-stop-keeps-resume.test
@@ -112,6 +112,11 @@ test "$crawl_rc" -eq 0 ||
     fail "the keep_resume stop exited ${crawl_rc}, expected 0"
 assert_logged "${tmpdir}/keep" 'MIRROR ABORTED' \
     "the run did not record an interrupted mirror"
+# The advice itself, because a banner naming no remedy is what #1636 replaced.
+assert_logged "${tmpdir}/keep" 'Start it again with --continue' \
+    "the banner does not tell the reader how to resume"
+! grep -q 'erasing the hts-cache' "${tmpdir}/keep/hts-log.txt" ||
+    fail "the banner still asks the reader to erase the cache a resume needs"
 echo "PASS"
 
 # The partial this stop cut stays on disk whoever asked for the stop, so its
@@ -156,4 +161,22 @@ echo "PASS (resumed at ${at} of ${full})"
 printf '[the completed --continue erases the directory again] ..\t'
 test ! -d "${out}/hts-cache/ref" ||
     fail "hts-cache/ref survived a mirror nothing interrupted"
+echo "PASS"
+
+# The lock is unlinked whatever ended the run, so the startup reconcile never
+# sees a stop. Left alone, the next run rotates the fragment over the complete
+# generation and it is gone.
+printf '[a stop keeps the complete cache generation] ..\t'
+out="${tmpdir}/gen"
+mkdir -p "$out"
+local_crawl --log "${tmpdir}/gen.log1" -O "$out" --quiet \
+    --disable-security-limits --robots=0 --timeout=30 -c2 \
+    "${BASEURL}/bigfiles/index.html" || fail "the crawl that fills the cache failed"
+complete="${tmpdir}/gen-complete.zip"
+cp "${out}/hts-cache/new.zip" "$complete"
+stop_and_report gen keep
+test ! -e "${out}/hts-cache/old.zip" ||
+    fail "the stopped run left both generations, so the next run drops one"
+cmp -s "${out}/hts-cache/new.zip" "$complete" ||
+    fail "the stopped run left its own fragment where the complete cache was"
 echo "PASS"


### PR DESCRIPTION
Since #1583 the Stop button reaches the `exit_xh == 1` branch, which keeps `hts-cache/ref` so `--continue` can resume. Its message told the user to restore the former cache and erase `hts-cache/new.*`, the one action that breaks that resume. The Android app shows `opt->log` on screen, so a phone user reads advice they cannot act on (xroche/httrack-android#200).

The message could not simply promise that the former cache survives. `CACHE_RECONCILE_INTERRUPTED` promoted it only where `new.zip` was under 32 KB and `old.zip` over 64 KB. Every run rotates `new.zip` over `old.zip`, so a crawl stopped halfway lost the complete generation on the next run. It now keeps whichever generation reaches further, counted in entries by `unzGetGlobalInfo64()`. A zip entry's size is its body's size, so bytes measure content rather than coverage. One big media file outweighs a hundred pages.

An unopenable generation counts -1 and never wins. A `new.zip` that will not open is left alone rather than replaced. A hard kill leaves it holding local file headers and no central directory. That is what `cache_init()` rotates and `cache_repair()` recovers, so overwriting it would delete entries that were still there.

Where the reconcile runs matters as much as what it decides. `UNLINK(n_lock)` at the end of `hts_main_internal()` runs whatever ended the run. So the startup arm only ever sees a hard kill, because a Stop returns normally and drops the lock on its way out. The reconcile therefore also runs in the abort branch, while the lock is still there, gated on `httpmirror()`'s own completed verdict. A `^C` and a `--max-time` cap leave `exit_xh` at 0, which is how most people stop a mirror.

The `.lst` and `.txt` sidecars move with the cache. A sidecar the old generation lacks is dropped, so `old.lst` cannot list the run `old.zip` replaced. The update purge reads that pair. The promote itself is built on `hts_rename_over()`, which parks the file in the way rather than deleting it first.

The startup paragraph carrying the same advice needs `hts-cache/old.dat` and `old.ndx`. Nothing has written those since 3.31 in 2003, and `cache_init()` refuses the format. It now says so. `283_engine-cmdline-leak.test` manufactures that state to check an early-exit leak, so the block stays.

The self-test builds real zip fixtures now, and `reconcile_put()` keeps writing filler bytes as the damaged-generation fixture. Seven mutants fail it:

- a byte comparison
- `>` turned into `>=`
- a dropped guard on an unopenable `new.zip`
- an unopenable generation counted as empty
- a copied rather than moved sidecar
- a dropped `!opt->cache` guard
 `444` proves the complete generation survives both a stop and a cap. `261` now reads the FTP server's command log, because the aborted run's `new.lst` is the restored generation's.