### PR TITLE
A cookie for example.com is also sent to wwwexample.com

### DIFF
--- a/src/htsbauth.c
+++ b/src/htsbauth.c
@@ -211,8 +211,8 @@ hts_boolean cookie_domain_match(const char *jar_dom, const char *host) {
     return HTS_FALSE;
   if (dom_len == host_len)
     return HTS_TRUE; // the same host
-  /* Shorter than the host, so it is only a parent domain if the byte before it
-     ends a label: "example.com" is no parent of the buyable wwwexample.com. */
+  /* Shorter than the host, so it is a parent domain only if the byte before it
+     ends a label, for example "example.com" is no parent of wwwexample.com. */
   if (host[host_len - dom_len - 1] != '.')
     return HTS_FALSE;
   /* An address has no parent domain, or "1.1" would reach 192.168.1.1, and

--- a/src/htsbauth.c
+++ b/src/htsbauth.c
@@ -195,28 +195,32 @@ int cookie_del(t_cookie * cookie, const char *cook_name, const char *domain, con
   return 0;
 }
 
-// Matches wildcard cookie domains that start with a dot
-// chk_dom: the domain stored in the cookie (potentially wildcard).
-// domain: query domain
-static int cookie_cmp_wildcard_domain(const char *chk_dom, const char *domain) {
-  const size_t n = strlen(chk_dom);
-  const size_t m = strlen(domain);
-  const size_t l = n < m ? n : m;
-  int i;
-  for (i = (int) l - 1; i >= 0; i--) {
-    if (!streql(chk_dom[n - i - 1], domain[m - i - 1])) {
-      return 1;
-    }
-  }
-  if (m < n && chk_dom[0] == '.') {
-    return 0;
-  }
-  else if (m != n) {
-    return 1;
-  }
-  return 0;
-}
+/* See htsbauth.h. */
+hts_boolean cookie_domain_match(const char *jar_dom, const char *host) {
+  size_t dom_len;
+  const size_t host_len = strlen(host);
 
+  // a Netscape jar writes ".example.com" where RFC 6265 stores example.com
+  if (jar_dom[0] == '.')
+    jar_dom++;
+  dom_len = strlen(jar_dom);
+  // an empty domain is a suffix of every host, so it would match all of them
+  if (dom_len == 0 || dom_len > host_len)
+    return HTS_FALSE;
+  if (strcmpnocase(jar_dom, host + host_len - dom_len) != 0)
+    return HTS_FALSE;
+  if (dom_len == host_len)
+    return HTS_TRUE; // the same host
+  /* Shorter than the host, so it is only a parent domain if the byte before it
+     ends a label: "example.com" is no parent of the buyable wwwexample.com. */
+  if (host[host_len - dom_len - 1] != '.')
+    return HTS_FALSE;
+  /* An address has no parent domain, or "1.1" would reach 192.168.1.1, and
+     cookie_host unbrackets IPv6, so a colon left here is an address too. */
+  if (hts_host_is_ipv4(host, host_len) || memchr(host, ':', host_len) != NULL)
+    return HTS_FALSE;
+  return HTS_TRUE;
+}
 
 // rechercher cookie à partir de la position s (par exemple s=cookie.data)
 // renvoie pointeur sur ligne, ou NULL si introuvable
@@ -236,14 +240,10 @@ char *cookie_find(char *s, const char *cook_name, const char *domain, const char
     if (t) {                    // même nom ou nom qualconque
       //
       const char *chk_dom = cookie_get(buffer, a, 0); // cookie's own domain
-      const size_t dom_len = strlen(chk_dom);
-      const size_t qry_len = strlen(domain);
 
-      /* The domain folds (a jar written elsewhere may hold any case) but the
-         path below does not, because RFC 6265 path-match is byte-exact. */
-      if ((dom_len <= qry_len &&
-           strcmpnocase(chk_dom, domain + qry_len - dom_len) == 0) ||
-          !cookie_cmp_wildcard_domain(chk_dom, domain)) { // same domain
+      /* The path below is byte-exact where the domain is not, because RFC 6265
+         folds a host name and matches a path literally. */
+      if (cookie_domain_match(chk_dom, domain)) { // same domain
         //
         const char *chk_path = cookie_get(buffer, a, 2);    // chemin concerné par le cookie
 

--- a/src/htsbauth.h
+++ b/src/htsbauth.h
@@ -109,12 +109,11 @@ void cookie_delete(char *s, size_t s_size, size_t pos);
 
 const char *cookie_get(char *buffer, const char *cookie_base, int param);
 
-/** Does the jar domain JAR_DOM cover the request host HOST? RFC 6265 section
-    5.1.3: it does when the two name the same host, or when JAR_DOM is a parent
-    domain that ends a whole label of HOST and HOST is not an address literal.
-    A leading dot on JAR_DOM, the form a Netscape jar writes, names the same
-    domain as the bare spelling. Case is folded on both sides; neither string
-    is normalised here, so pass HOST through cookie_host first. */
+/** Does the jar domain JAR_DOM cover the host HOST? RFC 6265 5.1.3 says it
+    does when the two name the same host, or when JAR_DOM ends a whole label of
+    HOST and HOST is not an address literal. A leading dot on JAR_DOM, the
+    Netscape jar form, names the same domain. Case folds on both sides, but
+    nothing is normalised here, so pass HOST through cookie_host first. */
 hts_boolean cookie_domain_match(const char *jar_dom, const char *host);
 
 /** First jar record at or after S matching cook_name (empty: any name),

--- a/src/htsbauth.h
+++ b/src/htsbauth.h
@@ -109,6 +109,14 @@ void cookie_delete(char *s, size_t s_size, size_t pos);
 
 const char *cookie_get(char *buffer, const char *cookie_base, int param);
 
+/** Does the jar domain JAR_DOM cover the request host HOST? RFC 6265 section
+    5.1.3: it does when the two name the same host, or when JAR_DOM is a parent
+    domain that ends a whole label of HOST and HOST is not an address literal.
+    A leading dot on JAR_DOM, the form a Netscape jar writes, names the same
+    domain as the bare spelling. Case is folded on both sides; neither string
+    is normalised here, so pass HOST through cookie_host first. */
+hts_boolean cookie_domain_match(const char *jar_dom, const char *host);
+
 /** First jar record at or after S matching cook_name (empty: any name),
     domain and path, or NULL. The domain match ignores case, the path match
     does not. */

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5474,7 +5474,7 @@ static int st_cookiecase(httrackp *opt, int argc, char **argv) {
        "'Example.COM' never reaches www.example.com"},
       {"Example.COM", "/", "other.example", "/", HTS_FALSE,
        "Example.COM leaked to other.example"},
-      // longer than the query, so only cookie_cmp_wildcard_domain can match it
+      // longer than the query, so only the leading-dot strip can match it
       {".Example.COM", "/", "example.com", "/", HTS_TRUE,
        "a wildcard '.Example.COM' never reaches example.com"},
       {".Example.COM", "/", "notexample.com", "/", HTS_FALSE,
@@ -5609,11 +5609,16 @@ static int st_cookiedomain(httrackp *opt, int argc, char **argv) {
       /* An empty domain is a suffix of every host. */
       {"", "example.com", HTS_FALSE,
        "an empty jar domain leaked to example.com"},
-      {".", "example.com", HTS_FALSE,
-       "a jar domain of one dot leaked to example.com"},
       {"", "", HTS_FALSE, "an empty jar domain matched an empty host"},
 
-      /* An address has no parent domain: every dot is inside the value. */
+      /* RFC 6265 5.2.3 strips one leading dot, so a second one leaves an empty
+         label. "..example.com" is no domain, and must therefore reach none. */
+      {"..example.com", "www.example.com", HTS_FALSE,
+       "'..example.com' reached www.example.com"},
+      {"..example.com", "example.com", HTS_FALSE,
+       "'..example.com' reached example.com"},
+
+      /* An address has no parent domain, because every dot is inside it. */
       {"1.1", "192.168.1.1", HTS_FALSE,
        "the jar domain 1.1 leaked to 192.168.1.1"},
       {"0.1", "127.0.0.1", HTS_FALSE, "the jar domain 0.1 leaked to 127.0.0.1"},
@@ -5625,7 +5630,9 @@ static int st_cookiedomain(httrackp *opt, int argc, char **argv) {
        "3.4 leaked to the IPv6 literal ::ffff:1.2.3.4"},
       {"1", "::1", HTS_FALSE, "the jar domain 1 leaked to ::1"},
 
-      /* Longer than the host, and a trailing dot is a label of its own. */
+      /* Longer than the host, and a trailing dot is a label of its own. These
+         three document the dom_len guard rather than pin it, because dropping
+         it leaves a read one byte short of the host that mismatches anyway. */
       {"www.example.com", "example.com", HTS_FALSE,
        "a child domain reached its parent"},
       {"example.com", "example.com.", HTS_FALSE,

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -5559,6 +5559,126 @@ static int st_cookiecase(httrackp *opt, int argc, char **argv) {
   return err;
 }
 
+/* RFC 6265 section 5.1.3 lets a jar domain reach a host only when it names
+   that host, or a parent domain ending a whole label of a name. A byte suffix
+   is not enough: wwwexample.com and notevil.com are separately registrable. */
+static int st_cookiedomain(httrackp *opt, int argc, char **argv) {
+  static const char LABEL[] = "cookie-domain";
+
+  static const struct {
+    const char *jar_dom, *host;
+    hts_boolean want;
+    const char *what;
+  } pairs[] = {
+      /* The same host, the 99% path. An address names itself too, so the rule
+         below must refuse a parent without refusing this. */
+      {"example.com", "example.com", HTS_TRUE, "a jar lost its own host"},
+      {"EXAMPLE.com", "example.com", HTS_TRUE,
+       "an identical host stopped folding case"},
+      {"localhost", "localhost", HTS_TRUE,
+       "a single-label host lost its cookie"},
+      {"127.0.0.1", "127.0.0.1", HTS_TRUE,
+       "an IPv4 literal lost its own cookie"},
+      {"::1", "::1", HTS_TRUE, "an IPv6 literal lost its own cookie"},
+      {"example.com.", "example.com.", HTS_TRUE,
+       "a trailing-dot FQDN lost its own cookie"},
+
+      /* A parent domain, cut on a label boundary. */
+      {"example.com", "www.example.com", HTS_TRUE,
+       "example.com never reaches www.example.com"},
+      {"example.com", "a.b.example.com", HTS_TRUE,
+       "example.com never reaches a.b.example.com"},
+      {".example.com", "example.com", HTS_TRUE,
+       "'.example.com' never reaches example.com"},
+      {".example.com", "www.example.com", HTS_TRUE,
+       "'.example.com' never reaches www.example.com"},
+      {".EXAMPLE.com", "WWW.example.com", HTS_TRUE,
+       "a dotted jar domain stopped folding case"},
+
+      /* #1638: a byte suffix that starts mid-label. Both hosts are separately
+         registrable, so this is a cross-origin leak. */
+      {"example.com", "wwwexample.com", HTS_FALSE,
+       "example.com leaked to wwwexample.com"},
+      {"evil.com", "notevil.com", HTS_FALSE, "evil.com leaked to notevil.com"},
+      {"ample.com", "example.com", HTS_FALSE,
+       "ample.com leaked to example.com"},
+      {".example.com", "wwwexample.com", HTS_FALSE,
+       "'.example.com' leaked to wwwexample.com"},
+      {"e.com", "we.com", HTS_FALSE, "e.com leaked to we.com"},
+
+      /* An empty domain is a suffix of every host. */
+      {"", "example.com", HTS_FALSE,
+       "an empty jar domain leaked to example.com"},
+      {".", "example.com", HTS_FALSE,
+       "a jar domain of one dot leaked to example.com"},
+      {"", "", HTS_FALSE, "an empty jar domain matched an empty host"},
+
+      /* An address has no parent domain: every dot is inside the value. */
+      {"1.1", "192.168.1.1", HTS_FALSE,
+       "the jar domain 1.1 leaked to 192.168.1.1"},
+      {"0.1", "127.0.0.1", HTS_FALSE, "the jar domain 0.1 leaked to 127.0.0.1"},
+      {".1.1", "192.168.1.1", HTS_FALSE,
+       "a leading dot let 1.1 reach 192.168.1.1"},
+      {"168.1.1", "192.168.1.1", HTS_FALSE, "168.1.1 leaked to 192.168.1.1"},
+      /* cookie_host unbrackets IPv6, so this is the shape that arrives here */
+      {"3.4", "::ffff:1.2.3.4", HTS_FALSE,
+       "3.4 leaked to the IPv6 literal ::ffff:1.2.3.4"},
+      {"1", "::1", HTS_FALSE, "the jar domain 1 leaked to ::1"},
+
+      /* Longer than the host, and a trailing dot is a label of its own. */
+      {"www.example.com", "example.com", HTS_FALSE,
+       "a child domain reached its parent"},
+      {"example.com", "example.com.", HTS_FALSE,
+       "example.com leaked to the FQDN example.com."},
+      {"example.com.", "example.com", HTS_FALSE,
+       "the FQDN example.com. leaked to example.com"},
+  };
+
+  /* The same rule as the jar sees it, so a caller reaching cookie_find through
+     the request path gets the same verdict as a direct call. */
+  static const struct {
+    const char *jar_dom, *query;
+    hts_boolean want;
+    const char *what;
+  } trips[] = {
+      {"example.com", "wwwexample.com", HTS_FALSE,
+       "the jar sent example.com's cookie to wwwexample.com"},
+      {"example.com", "www.example.com", HTS_TRUE,
+       "the jar withheld example.com's cookie from www.example.com"},
+      {".example.com", "www.example.com", HTS_TRUE,
+       "the jar withheld '.example.com' from www.example.com"},
+      {"1.1", "192.168.1.1", HTS_FALSE,
+       "the jar sent 1.1's cookie to 192.168.1.1"},
+      {"192.168.1.1", "192.168.1.1", HTS_TRUE,
+       "the jar withheld an address cookie from its own address"},
+  };
+
+  static t_cookie jar;
+  char hdr[1024];
+  size_t i;
+  int err = 0;
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+
+  for (i = 0; i < sizeof(pairs) / sizeof(pairs[0]); i++) {
+    err |= cookie_expect_at(
+        LABEL, cookie_domain_match(pairs[i].jar_dom, pairs[i].host),
+        pairs[i].want, pairs[i].what);
+  }
+
+  for (i = 0; i < sizeof(trips) / sizeof(trips[0]); i++) {
+    cookie_seed(&jar, trips[i].jar_dom, "/");
+    http_cookie_header(&jar, trips[i].query, "/", hdr, sizeof(hdr));
+    err |= cookie_expect_at(LABEL, strstr(hdr, "id=A") != NULL, trips[i].want,
+                            trips[i].what);
+  }
+
+  printf("%s: %s\n", LABEL, err ? "FAIL" : "OK");
+  return err;
+}
+
 /* cookie_add must refuse rather than write past max_len, whatever the caller
    set that to, and must leave the bytes beyond it alone. */
 static int st_cookiecap(httrackp *opt, int argc, char **argv) {
@@ -15558,6 +15678,8 @@ static const struct selftest_entry {
     {"cookiecap", "", "cookie_add honours max_len", st_cookiecap},
     {"cookieport", "", "cookies are scoped to a host, not to a port",
      st_cookieport},
+    {"cookiedomain", "", "a jar domain reaches a host only on a label boundary",
+     st_cookiedomain},
     {"cookiecase", "", "cookie domains match without regard to case",
      st_cookiecase},
     {"useragent", "", "default User-Agent self-test", st_useragent},

--- a/tests/464_engine-cookie-domain.test
+++ b/tests/464_engine-cookie-domain.test
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# A jar domain reaches a host only when it names that host, or a parent domain
+# ending a whole label of it (RFC 6265 5.1.3). A byte suffix would send
+# example.com's cookie to the separately registrable wwwexample.com (#1638).
+# Driven by the 'httrack -#test=cookiedomain' selftest.
+
+set -eu
+
+# 'run' is an ignored placeholder argument.
+out=$(httrack -#test=cookiedomain run)
+
+# Exact-match the success line so a renamed or removed selftest (it prints the
+# registry to stderr) cannot pass.
+test "$out" = "cookie-domain: OK" || {
+    echo "expected 'cookie-domain: OK', got: $out" >&2
+    exit 1
+}


### PR DESCRIPTION
`cookie_find` decided whether a jar entry covers a request host by comparing the two strings from the right, byte by byte. Nothing required the match to begin where a label begins. `example.com` therefore matched `wwwexample.com`, `evil.com` matched `notevil.com`, and an empty domain field matched every host. Anyone can register `wwwexample.com`, so httrack handed a session cookie it picked up on one site to a different owner.

The match now follows RFC 6265 section 5.1.3. A jar domain reaches a host when the two name the same host. A shorter jar domain reaches it only when the jar domain ends a whole label of it. An address has no parent domain, so it is excluded. Without that condition the jar domain `1.1` is still a label-boundary suffix of `192.168.1.1`. `hts_host_is_ipv4` already existed for the IPv4 half, and a colon surviving `cookie_host`, which unbrackets IPv6, is an address too.

A Netscape jar writes `.example.com` where the RFC stores `example.com`, so the leading dot is stripped first and both spellings reach `example.com` and `www.example.com` alike. That left `cookie_cmp_wildcard_domain` with nothing to do and no other caller, so it is gone. A jar domain of `com` still matches `example.com`, because 5.1.3 permits it and refusing it needs a public-suffix list httrack does not carry.

A harness links the real `cookie_find` out of the before and after builds and runs 2912 (jar domain, host) pairs through both. 249 verdicts flip, every one from match to no match, and every one is a match RFC 6265 forbids. Nothing new matches, and no legitimate match is lost. The closest call is `1` and `.1` against the host `1.1`. A literal reading of 5.1.3 keeps those, but `inet_aton` parses `1.1` as the address 1.0.0.1.

`tests/464_engine-cookie-domain.test` drives a new `cookiedomain` selftest. It was graded against eight mutants covering every clause of the rule, the boundary side, and the leading-dot strip. All eight go red.

Stacked on #1635, which rewrites the same lines. Retarget to master once that lands.

Closes #1638
