### PR TITLE
The constrained-networks and s390x jobs fail when an apt source we do not use breaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Install build dependencies
         run: |
           set -euo pipefail
-          sudo apt-get update
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           sudo apt-get install -y --no-install-recommends \
             build-essential autoconf automake libtool autoconf-archive \
             zlib1g-dev libssl-dev libbrotli-dev libzstd-dev iproute2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Install build dependencies
         run: |
           set -euo pipefail
-          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
+          sudo apt-get update || true  # a third-party source in the runner image can fail (#1097)
           sudo apt-get install -y --no-install-recommends \
             build-essential autoconf automake libtool autoconf-archive \
             zlib1g-dev libssl-dev libbrotli-dev libzstd-dev iproute2

--- a/.github/workflows/emulated-suite.yml
+++ b/.github/workflows/emulated-suite.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Register the binfmt handlers
         run: |
           set -euo pipefail
-          sudo apt-get update
+          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
           # Registered with the F flag, so the kernel holds the interpreter open
           # and the container needs no copy of it.
           sudo apt-get install -y --no-install-recommends qemu-user-static binfmt-support

--- a/.github/workflows/emulated-suite.yml
+++ b/.github/workflows/emulated-suite.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Register the binfmt handlers
         run: |
           set -euo pipefail
-          sudo apt-get update || true  # a third-party source in the runner image can 403 (#1097)
+          sudo apt-get update || true  # a third-party source in the runner image can fail (#1097)
           # Registered with the F flag, so the kernel holds the interpreter open
           # and the container needs no copy of it.
           sudo apt-get install -y --no-install-recommends qemu-user-static binfmt-support


### PR DESCRIPTION
Tonight every open PR went red on `build (constrained networks)` and `emulated suite (s390x)`. Neither is a code failure. The runner image ships a Google Chrome apt source, Google served a bad `Packages.gz` hash, and `apt-get update` exited 100 under `set -euo pipefail`.

Issue #1097 already guarded every other `sudo apt-get update` on a bare runner with `|| true`, and it missed these two. The `apt-get install` after it stays unguarded, so a genuinely missing package still fails the job.

The three calls left bare run inside `debian:sid` or `ubuntu:devel` containers, which carry no third-party source, so a failed update there is real.

A stub `apt-get` that fails the way Google's did confirms the guard. The old body exits 100, the new one continues, and a missing package still stops it.
