### PR TITLE
A 403 from the WSL update service stops the Windows suite before it tries the import

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -273,9 +273,10 @@ jobs:
         shell: pwsh
         timeout-minutes: 15
         run: |
-          # Three tries with a pause, like the rootfs download below: this call
-          # has failed on a transient and blocked a merge for it, and it now
-          # gates the only Windows suite there is.
+          # Three tries, then carry on regardless: this endpoint 403s per runner,
+          # and one leg has 403'd while its sibling on the same run updated fine.
+          # The import and the uname below are the proof WSL works, and both stay
+          # fatal, so giving up here costs a clear error rather than a wrong pass.
           for ($i = 1; $i -le 3; $i++) {
             try {
               wsl --update
@@ -284,8 +285,10 @@ jobs:
             }
             catch {
               Write-Host "wsl --update attempt $i failed: $($_.Exception.Message)"
-              if ($i -eq 3) { throw }
-              Start-Sleep -Seconds (5 * $i)
+              if ($i -eq 3) {
+                Write-Host "wsl --update never succeeded, so the import below decides"
+              }
+              else { Start-Sleep -Seconds (5 * $i) }
             }
           }
           wsl --set-default-version 2

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -273,10 +273,8 @@ jobs:
         shell: pwsh
         timeout-minutes: 15
         run: |
-          # Three tries, then carry on regardless: this endpoint 403s per runner,
-          # and one leg has 403'd while its sibling on the same run updated fine.
-          # The import and the uname below are the proof WSL works, and both stay
-          # fatal, so giving up here costs a clear error rather than a wrong pass.
+          # Three tries, then carry on, because this endpoint 403s per runner VM
+          # and waiting longer cannot help. The import and its uname check are still fatal.
           for ($i = 1; $i -le 3; $i++) {
             try {
               wsl --update


### PR DESCRIPTION
`libhttrack (Win32, Release)` is red on master and on #1640. It is a required check, so it blocks merges.

Microsoft's WSL update endpoint answered 403. The step retries `wsl --update` three times and then throws, and that throw aborts the step body, so `wsl --import` never runs. Giving up is what stops the suite, not the failed update.

Retrying longer would not help, because the endpoint fails per runner. On master run 34407901706 the Win32 leg took three 403s while x64 updated first try. Grep that log with care, because it echoes the retry line's own source, so a naive count reads one higher than the real failures.

The update is now best-effort, and the import and the uname after it stay fatal. A stub `wsl` under pwsh shows the old body stopping before the import and the new one reaching it.
