### PR TITLE
A test that cannot write its lock request cannot say which directory went missing

### DIFF
--- a/tests/24_local-resume-overlap.test
+++ b/tests/24_local-resume-overlap.test
@@ -42,7 +42,7 @@ wait_until "test -s '$counter' && test -e '${out}/hts-in_progress.lock'" \
 # The engine honours a request only when it is newer than its own progress lock,
 # in whole seconds, so wait one out before writing it.
 sleep 1.1
-: >"${out}/hts-abort.lock"
+write_lock_request "$out" hts-abort.lock "$crawlpid"
 # This 10s wait stays inside --timeout=30, so the fetch is still stalled.
 wait_until "test ! -e '${out}/hts-abort.lock'" \
     "10s on, the engine had not read the stop request" 100

--- a/tests/258_crawllib.test
+++ b/tests/258_crawllib.test
@@ -257,11 +257,28 @@ write_lock_request "${tmpdir}/out" hts-stop.lock $$
 test -e "${tmpdir}/out/hts-stop.lock"'
 ok "write_lock_request writes the request"
 
-# A grandparent: naming the parent is what the helper already did before it
-# walked, so that arm would pass either way.
+# The old helper already named the parent, so removing only the parent would
+# prove nothing.
 fires 'mkdir -p "${tmpdir}/ht.1/req.AAA/fresh"
 rm -rf "${tmpdir}/ht.1"
 write_lock_request "${tmpdir}/ht.1/req.AAA/fresh" hts-stop.lock $$' '/ht.1 is gone'
-ok "a vanished directory is named, deepest first"
+# One line, or the failing redirect leaked the shell's own message past the
+# 2>/dev/null beside it.
+assert_eq 1 "$(printf '%s\n' "$out" | wc -l | tr -d ' ')" "lines the helper printed"
+ok "a vanished grandparent is named, not the parent"
+
+# The real #1639 shape, where only the crawl output went.
+fires 'mkdir -p "${tmpdir}/ht.2"
+write_lock_request "${tmpdir}/ht.2/fresh" hts-stop.lock $$' '/fresh is gone'
+assert_match '/ht\.2 survives\)' "$out" "the deepest surviving directory"
+ok "a vanished output directory is named, with the survivor above it"
+
+fires 'mkdir -p "${tmpdir}/x"
+sleep 0 &
+pid=$!
+wait "$pid"
+rm -rf "${tmpdir}/x"
+write_lock_request "${tmpdir}/x" hts-stop.lock "$pid"' 'the engine exited before it could be asked'
+ok "a dead engine is named before the path is walked"
 
 echo "PASS"

--- a/tests/258_crawllib.test
+++ b/tests/258_crawllib.test
@@ -251,4 +251,17 @@ test "$elapsed" -lt 15 || fail "the watchdog outran its deadline: ${elapsed}s"
 unset CRAWL_DEADLINE
 ok "CRAWL_DEADLINE drives the watchdog, which reds a wedged crawl"
 
+## write_lock_request names the component that went missing
+holds 'mkdir -p "${tmpdir}/out"
+write_lock_request "${tmpdir}/out" hts-stop.lock $$
+test -e "${tmpdir}/out/hts-stop.lock"'
+ok "write_lock_request writes the request"
+
+# A grandparent: naming the parent is what the helper already did before it
+# walked, so that arm would pass either way.
+fires 'mkdir -p "${tmpdir}/ht.1/req.AAA/fresh"
+rm -rf "${tmpdir}/ht.1"
+write_lock_request "${tmpdir}/ht.1/req.AAA/fresh" hts-stop.lock $$' '/ht.1 is gone'
+ok "a vanished directory is named, deepest first"
+
 echo "PASS"

--- a/tests/445_local-lockfile-visibility.test
+++ b/tests/445_local-lockfile-visibility.test
@@ -51,7 +51,7 @@ echo "OK"
 # seconds, so a shell clock behind the one stamping files writes an inert file.
 printf '[a request written now is newer than the run] ..\t'
 sleep 1.1
-: >"${out}/request-probe"
+write_lock_request "$out" request-probe "$crawlpid"
 run=$(mtime "${out}/${PROGRESSLOCK}")
 req=$(mtime "${out}/request-probe")
 test "$req" -gt "$run" ||
@@ -61,7 +61,7 @@ echo "OK (+$((req - run))s)"
 # The crossing itself: the engine unlinks the request as it reads it, where
 # everything after that waits on the transfers and would measure the server.
 printf '[the engine reads a request the shell wrote] ..\t'
-: >"${out}/${STOPLOCK}"
+write_lock_request "$out" "$STOPLOCK" "$crawlpid"
 tenths=0
 while test -e "${out}/${STOPLOCK}"; do
     tenths=$((tenths + 1))

--- a/tests/crawllib.sh
+++ b/tests/crawllib.sh
@@ -220,13 +220,28 @@ assert_lockrule_selftest() {
 # Ask a running engine for something by dropping NAME in its output directory.
 # A bare redirect there reports ENOENT for three reasons a caller cannot separate.
 write_lock_request() { # write_lock_request DIR NAME PID
-    local dir=$1 name=$2 pid=$3
-    : >"${dir}/${name}" 2>/dev/null && return 0
+    local dir=$1 name=$2 pid=$3 gone='' up=$1
+    # Braced: the shell reports a failing redirect before it applies the
+    # 2>/dev/null beside it (#1637).
+    { : >"${dir}/${name}"; } 2>/dev/null && return 0
     kill -0 "$pid" 2>/dev/null ||
         fail "the engine exited before it could be asked for ${name}"
-    test -d "$(dirname "$dir")" ||
-        fail "$(dirname "$dir") is gone: something removed it under a running test"
-    fail "${name} could not be written into ${dir}"
+    # The deepest surviving directory, since the path crosses the driver's
+    # TMPDIR, the test's mktemp directory and the crawl output (#1639).
+    while test ! -d "$up"; do
+        gone=$up
+        case $up in
+        */?*) up=${up%/*} ;;
+        *)
+            up=.
+            break
+            ;;
+        esac
+        test -n "$up" || up=/
+    done
+    test -z "$gone" ||
+        fail "${gone} is gone (${up} survives): something removed it under a running test"
+    fail "${name} could not be written into ${dir}, which is still there"
 }
 
 # wait_until for a condition only a live engine can reach, so an engine that

--- a/tests/crawllib.sh
+++ b/tests/crawllib.sh
@@ -221,13 +221,13 @@ assert_lockrule_selftest() {
 # A bare redirect there reports ENOENT for three reasons a caller cannot separate.
 write_lock_request() { # write_lock_request DIR NAME PID
     local dir=$1 name=$2 pid=$3 gone='' up=$1
-    # Braced: the shell reports a failing redirect before it applies the
-    # 2>/dev/null beside it (#1637).
+    # The shell reports a failing redirect before it applies the 2>/dev/null
+    # beside it (#1637).
     { : >"${dir}/${name}"; } 2>/dev/null && return 0
     kill -0 "$pid" 2>/dev/null ||
         fail "the engine exited before it could be asked for ${name}"
-    # The deepest surviving directory, since the path crosses the driver's
-    # TMPDIR, the test's mktemp directory and the crawl output (#1639).
+    # It walks up because the path crosses the driver's TMPDIR, the test's
+    # mktemp directory and the crawl output (#1639).
     while test ! -d "$up"; do
         gone=$up
         case $up in


### PR DESCRIPTION
In #1639, tests 436 and 459 fail to write a lock request into a directory the line above proved was there. The harness could not say more, because `write_lock_request` only tested the parent of the crawl output. That path also crosses the driver's per-test `TMPDIR` and the test's own mktemp directory. It now walks up and names the deepest directory still there, so the next occurrence says which component went missing.

Three bare redirects into the same directory, in tests 24 and 445, now go through the helper. The helper's own redirect is braced, because the shell prints the ENOENT itself before the `2>/dev/null` beside it applies (#1637).

Test 258 covers both shapes the walk is for, a vanished grandparent and a vanished output directory. It also checks that the helper prints one line, rather than leaking the shell's own error.
