### PR TITLE
The Windows suite can schedule one test twice, and the second copy deletes the first one's temporary directory

### DIFF
--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -124,9 +124,11 @@ reporter_stopped() {
 
 # One per glob the driver enumerates: an empty category is counted as a failing
 # test named after the unexpanded pattern, which would drown the accounting.
-for t in 00_runnable 13_zlib-pass 14_local-pass 15_watchdog-pass \
-    16_crawl_proxy_https 17_crawl-log-salvage 18_testlib-pass 19_crawllib \
-    20_crawl-harness-pass; do
+# 00_runnable_local-smoke is the overlap: the runnable pattern has no leading
+# "*_", so it is the one a two-token name can match beside another category.
+for t in 00_runnable 00_runnable_local-smoke 13_zlib-pass 14_local-pass \
+    15_watchdog-pass 16_crawl_proxy_https 17_crawl-log-salvage 18_testlib-pass \
+    19_crawllib 20_crawl-harness-pass; do
     printf '#!/bin/sh\nexit 0\n' >"$run/$t.test"
 done
 # One test reports back what it inherited: the token the step is handed can post
@@ -159,13 +161,15 @@ assert_staged
 # The skip set and the pass floor are pinned to the real suite, so a stub run
 # ends on the floor; what is under test is the tally that reaches it.
 test "$rc" -eq 1 || fail "stub suite exited $rc, want 1 from the pass floor"
-# The category list is concatenated, never deduped, so two globs claiming one
-# test would run it twice and inflate every tally the gates read.
+# Two globs claiming one test would run it twice, and the second worker removes
+# the TMPDIR the first is still writing into (#1639).
 dup=$(awk '/^RUN /{print $2}' suite-progress.log | sort | uniq -d)
 test -z "$dup" || fail "a test was selected by two categories: $dup"
-grep -q '^ran=12 pass=10 fail=1 skip=1 lost=0$' <<<"$out" ||
+grep -q '^::notice title=a test matched two categories::scheduled once each: 00_runnable_local-smoke.test$' <<<"$out" ||
+    fail "the test matching two categories was not named: $out"
+grep -q '^ran=13 pass=11 fail=1 skip=1 lost=0$' <<<"$out" ||
     fail "wrong tally: $(grep '^ran=' <<<"$out")"
-grep -q '::error::only 10 tests passed (1 skipped)' <<<"$out" ||
+grep -q '::error::only 11 tests passed (1 skipped)' <<<"$out" ||
     fail "the pass floor did not report the count"
 grep -q 'FAIL 12_engine-fail.test (exit 3)' <<<"$out" || fail "the failing test was not named"
 # The report has to carry the run that failed, not just the trace that passed,
@@ -218,7 +222,7 @@ grep -q '^ran=' <<<"$out" && fail "the suite ran a test with a category empty: $
 # The first category names a single test, and a name nullglob cannot empty would
 # never reach the gate at all.
 printf '#!/bin/sh\nexit 0\n' >"$run/13_zlib-pass.test"
-rm -f "$run/00_runnable.test"
+rm -f "$run/00_runnable.test" "$run/00_runnable_local-smoke.test"
 rc=0
 out=$(RUNNER_TEMP="$tmp" GITHUB_STEP_SUMMARY="$tmp/summary" \
     bash ./ci-windows-suite.sh "$bin" 2>&1) || rc=$?

--- a/tests/172_ci-windows-driver.test
+++ b/tests/172_ci-windows-driver.test
@@ -124,8 +124,8 @@ reporter_stopped() {
 
 # One per glob the driver enumerates: an empty category is counted as a failing
 # test named after the unexpanded pattern, which would drown the accounting.
-# 00_runnable_local-smoke is the overlap: the runnable pattern has no leading
-# "*_", so it is the one a two-token name can match beside another category.
+# 00_runnable_local-smoke is the overlap. The runnable pattern has no leading
+# "*_", so a two-token name can match it beside another category.
 for t in 00_runnable 00_runnable_local-smoke 13_zlib-pass 14_local-pass \
     15_watchdog-pass 16_crawl_proxy_https 17_crawl-log-salvage 18_testlib-pass \
     19_crawllib 20_crawl-harness-pass; do

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -352,6 +352,39 @@ ci_expected_skips_for_backend() {
     esac
 }
 
+# Expand the label:pattern arguments into ci_tests, each test once, and list the
+# ones a second pattern matched in ci_repeats. Scheduling a test twice gives two
+# workers the same TMPDIR, and run_one_test removes it as it starts (#1639).
+ci_tests=() ci_repeats=''
+ci_expand_categories() { # ci_expand_categories LABEL:PATTERN...
+    local c matched t seen=' '
+    ci_tests=() ci_repeats=''
+    shopt -s nullglob
+    for c in "$@"; do
+        # shellcheck disable=SC2206 # expanding the pattern is the point
+        matched=(${c#*:})
+        # Named, and before anything runs: left unexpanded the pattern reaches
+        # test-timeout.sh literally and is counted as a test failing 127 (#952).
+        if test -z "${matched[0]:-}"; then
+            echo "::error::test category ${c%%:*} matched no tests (${c#*:})"
+            shopt -u nullglob
+            return 1
+        fi
+        for t in "${matched[@]}"; do
+            case "$seen" in
+            *" $t "*)
+                ci_repeats="${ci_repeats}${ci_repeats:+ }$t"
+                continue
+                ;;
+            esac
+            seen="$seen$t "
+            ci_tests+=("$t")
+        done
+    done
+    shopt -u nullglob
+    return 0
+}
+
 # Only a direct run drives a suite. Asked of the shell, not derived from $0,
 # which a caller can set to this very path (172_ci-windows-driver.test).
 (return 0 2>/dev/null) && return 0
@@ -579,28 +612,19 @@ count_workers() {
 
 # label:pattern, globbed rather than enumerated so a new NNN_engine-*.test or
 # NNN_local-*.test is picked up instead of silently getting zero coverage. Every
-# entry carries a metacharacter, or nullglob cannot empty it and the gate below
-# has nothing to catch.
+# entry carries a metacharacter, or nullglob cannot empty it and the gate in
+# ci_expand_categories has nothing to catch.
 # testlib and crawllib cover what most tests here rest on.
 categories=(runnable:'00_runnable*.test' engine:'*_engine-*.test' zlib:'*_zlib-*.test'
     local:'*_local-*.test' watchdog:'*_watchdog*.test'
     testlib:'*_testlib-*.test' crawllib:'*_crawllib*.test'
     crawl-harness:'*_crawl-harness-*.test'
     proxy-https:'*_crawl_proxy_https.test' log-salvage:'*_crawl-log-salvage.test')
-tests=()
-shopt -s nullglob
-for c in "${categories[@]}"; do
-    # shellcheck disable=SC2206 # expanding the pattern is the point
-    matched=(${c#*:})
-    # Named, and before anything runs: left unexpanded the pattern reaches
-    # test-timeout.sh literally and is counted as a test failing 127 (#952).
-    test -n "${matched[0]:-}" || {
-        echo "::error::test category ${c%%:*} matched no tests (${c#*:})"
-        exit 1
-    }
-    tests+=("${matched[@]}")
-done
-shopt -u nullglob
+ci_expand_categories "${categories[@]}" || exit 1
+tests=(${ci_tests[@]+"${ci_tests[@]}"})
+test -z "$ci_repeats" ||
+    ci_annotate notice "a test matched two categories" \
+        "scheduled once each: ${ci_repeats}"
 
 pids=() ran_tests=()
 for t in "${tests[@]}"; do

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -356,7 +356,7 @@ ci_expected_skips_for_backend() {
 # ones a second pattern matched in ci_repeats. Scheduling a test twice gives two
 # workers the same TMPDIR, and run_one_test removes it as it starts (#1639).
 ci_tests=() ci_repeats=''
-ci_expand_categories() { # ci_expand_categories LABEL:PATTERN...
+ci_expand_categories() {
     local c matched t seen=' '
     ci_tests=() ci_repeats=''
     shopt -s nullglob
@@ -622,6 +622,8 @@ categories=(runnable:'00_runnable*.test' engine:'*_engine-*.test' zlib:'*_zlib-*
     proxy-https:'*_crawl_proxy_https.test' log-salvage:'*_crawl-log-salvage.test')
 ci_expand_categories "${categories[@]}" || exit 1
 tests=(${ci_tests[@]+"${ci_tests[@]}"})
+# notice, not warning: reap_leftover_processes spends the warning budget, and
+# this fires once, before the heartbeat starts spending the notice one.
 test -z "$ci_repeats" ||
     ci_annotate notice "a test matched two categories" \
         "scheduled once each: ${ci_repeats}"


### PR DESCRIPTION
The Windows suite builds its test list by appending one glob per category. The `runnable` pattern has no leading `*_`, so a name like `00_runnable_local-smoke.test` matches it and the `local` one, and that test is scheduled twice. `run_one_test` removes its `TMPDIR` as it starts, so the second copy deletes the directory the first one is still writing into. That is the shape #1639 reports. Today the suite schedules 336 tests and 336 are unique, so nothing is broken yet.

The expansion moves into `ci_expand_categories`, which keeps each name once and names the repeats in a notice. It dedupes rather than failing, because a name matching two categories is a naming accident and the coverage stays right.

Test 172 drives the real driver with an overlapping stub. The old loop schedules that stub twice.
