### PR TITLE
Test 226 refuses to judge a backoff under seven due ticks, where six are enough

### DIFF
--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -921,6 +921,38 @@ backoff_ticks_due() {
     echo "${out# }"
 }
 
+# A backoff that never doubles: 1, 3, 5, 7. The floor below is derived against
+# it, so a change to either schedule moves the floor.
+flat_ticks_due() {
+    local due=1 out=''
+    while test "$due" -le "$1"; do
+        out="$out $due"
+        due=$((due + 2))
+    done
+    echo "${out# }"
+}
+
+# The fewest due ticks whose two schedules disagree. Prints nothing when they
+# never separate, which is a leg that can judge nothing rather than a floor of 0.
+separating_ticks() { # separating_ticks <rival schedule function> [limit]
+    local n=1
+    while test "$n" -le "${2:-64}"; do
+        test "$(backoff_ticks_due "$n")" = "$("$1" "$n")" || {
+            echo "$n"
+            return 0
+        }
+        n=$((n + 1))
+    done
+}
+
+BACKOFF_FLOOR=$(separating_ticks flat_ticks_due)
+test -n "$BACKOFF_FLOOR" ||
+    fail "a doubling backoff and a flat one land on the same ticks throughout: the backoff leg can judge nothing"
+# Control: without it a derivation off by one, or a hand-kept constant, reads as
+# a floor while grading windows where the two schedules still tie.
+test "$(backoff_ticks_due $((BACKOFF_FLOOR - 1)))" = "$(flat_ticks_due $((BACKOFF_FLOOR - 1)))" ||
+    fail "the two schedules already differ at $((BACKOFF_FLOOR - 1)) due ticks, so the derived floor of $BACKOFF_FLOOR skips a window it could judge"
+
 backoff_leg() {
     local ticks rc=0 window landed
     window=$((turn * 8))
@@ -931,10 +963,9 @@ backoff_leg() {
     sink_stop
     test "$rc" -eq 0 || return "$rc"
     ticks=$(count_matching_lines 't=[0-9]*s q=' "$legout")
-    # Seven, not six: at six or fewer a doubling backoff and a flat one owe the
-    # same calls, so six admitted that tie.
-    test "$ticks" -ge 7 || {
-        unmeasured "$ticks due ticks over ${window}s at a 1s interval: too few to judge a backoff"
+    # Under the floor a doubling backoff and a flat one land on the same ticks.
+    test "$ticks" -ge "$BACKOFF_FLOOR" || {
+        unmeasured "$ticks due ticks over ${window}s at a 1s interval, under the $BACKOFF_FLOOR that separate a doubling backoff from a flat one: too few to judge a backoff"
         return "$UNMEASURED"
     }
     # Positions, not a total. A count is blind to a loop that posts its first few

--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -921,8 +921,7 @@ backoff_ticks_due() {
     echo "${out# }"
 }
 
-# A backoff that never doubles: 1, 3, 5, 7. The floor below is derived against
-# it, so a change to either schedule moves the floor.
+# A backoff whose skips never double: 1, 3, 5, 7.
 flat_ticks_due() {
     local due=1 out=''
     while test "$due" -le "$1"; do
@@ -932,11 +931,16 @@ flat_ticks_due() {
     echo "${out# }"
 }
 
+# A backoff that posts the first two calls it owes and then stops for good: 1, 3.
+stalled_ticks_due() {
+    backoff_ticks_due "$1" | cut -d' ' -f1-2
+}
+
 # The fewest due ticks whose two schedules disagree. Prints nothing when they
-# never separate, which is a leg that can judge nothing rather than a floor of 0.
-separating_ticks() { # separating_ticks <rival schedule function> [limit]
+# still tie at 64, which is a leg that can judge nothing rather than a floor of 0.
+separating_ticks() { # separating_ticks <rival schedule function>
     local n=1
-    while test "$n" -le "${2:-64}"; do
+    while test "$n" -le 64; do
         test "$(backoff_ticks_due "$n")" = "$("$1" "$n")" || {
             echo "$n"
             return 0
@@ -945,13 +949,25 @@ separating_ticks() { # separating_ticks <rival schedule function> [limit]
     done
 }
 
-BACKOFF_FLOOR=$(separating_ticks flat_ticks_due)
-test -n "$BACKOFF_FLOOR" ||
-    fail "a doubling backoff and a flat one land on the same ticks throughout: the backoff leg can judge nothing"
-# Control: without it a derivation off by one, or a hand-kept constant, reads as
-# a floor while grading windows where the two schedules still tie.
+# The window the leg needs is the one that rejects both rivals, and no floor
+# covers a loop that stops later or backs off linearly.
+backoff_rivals=(flat_ticks_due stalled_ticks_due)
+BACKOFF_FLOOR=0
+for rival in "${backoff_rivals[@]}"; do
+    sep=$(separating_ticks "$rival")
+    test -n "$sep" ||
+        fail "a healthy backoff and $rival land on the same ticks through 64 due ticks: the backoff leg can judge nothing"
+    test "$sep" -le "$BACKOFF_FLOOR" || BACKOFF_FLOOR=$sep
+done
+# Control, both ways. A floor too low grades a window where a rival still lands
+# where a healthy backoff does, and one too high skips a window it could judge.
+for rival in "${backoff_rivals[@]}"; do
+    test "$(backoff_ticks_due "$BACKOFF_FLOOR")" != "$("$rival" "$BACKOFF_FLOOR")" ||
+        fail "$rival lands on a healthy backoff's ticks at the derived floor of $BACKOFF_FLOOR due ticks"
+done
 test "$(backoff_ticks_due $((BACKOFF_FLOOR - 1)))" = "$(flat_ticks_due $((BACKOFF_FLOOR - 1)))" ||
-    fail "the two schedules already differ at $((BACKOFF_FLOOR - 1)) due ticks, so the derived floor of $BACKOFF_FLOOR skips a window it could judge"
+    test "$(backoff_ticks_due $((BACKOFF_FLOOR - 1)))" = "$(stalled_ticks_due $((BACKOFF_FLOOR - 1)))" ||
+    fail "both rivals are already rejected at $((BACKOFF_FLOOR - 1)) due ticks, so the derived floor of $BACKOFF_FLOOR skips a window it could judge"
 
 backoff_leg() {
     local ticks rc=0 window landed
@@ -963,9 +979,10 @@ backoff_leg() {
     sink_stop
     test "$rc" -eq 0 || return "$rc"
     ticks=$(count_matching_lines 't=[0-9]*s q=' "$legout")
-    # Under the floor a doubling backoff and a flat one land on the same ticks.
+    # Under the floor a backoff that never doubles, and one that stops after two
+    # posts, both land where a healthy one does.
     test "$ticks" -ge "$BACKOFF_FLOOR" || {
-        unmeasured "$ticks due ticks over ${window}s at a 1s interval, under the $BACKOFF_FLOOR that separate a doubling backoff from a flat one: too few to judge a backoff"
+        unmeasured "$ticks due ticks over ${window}s at a 1s interval, under the $BACKOFF_FLOOR that reject a flat backoff and a stalled one: too few to judge a backoff"
         return "$UNMEASURED"
     }
     # Positions, not a total. A count is blind to a loop that posts its first few


### PR DESCRIPTION
`backoff_leg` refuses to judge under seven due ticks. Seven was the floor of an older assertion that counted calls. The leg now compares the ticks the calls landed on, and those separate one tick earlier. Six is the first count that rejects both loops the positional check claims to catch. A healthy backoff owes 1, 3 and 6 there. A backoff whose skips never double lands on 1, 3 and 5. One that posts twice and then stops for good lands on 1 and 3. A window of six due ticks could decide the backoff and skips instead, and #1646 made those skips visible.

The floor is derived rather than written down. `flat_ticks_due` and `stalled_ticks_due` state the two rival schedules beside `backoff_ticks_due`. `separating_ticks` returns the first count at which a rival stops landing where a healthy backoff does, and the floor is the larger of the two. Two controls run at startup. One asserts that both rivals are rejected at the floor, which a derivation returning too low fails. The other asserts that a rival still ties one tick lower, which a derivation returning too high fails.

Nothing outside those two loops is covered, and seven covered no more. A backoff that stops after three calls needs eleven due ticks. One that grows its skip by one each time ties with doubling through nine.

The leg's other assertions all hold well under six. `backoff-never-skips` and `backoff-stops` land on ticks 1, 2 and 3, which the owed 1 and 3 reject at tick two. The ` x=[1-9]` check needs the second landed call, which arrives at tick three.

Closes #1649
