### PR TITLE
A 403 leaves the WSL2 kernel component missing, and the Windows suite cannot run without it

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -261,6 +261,32 @@ jobs:
           path: ${{ runner.temp }}\wsl-rootfs.tar.gz
           key: wsl-rootfs-jammy-amd64-v1
 
+      - name: Restore the WSL kernel package
+        id: wslkernel
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ runner.temp }}\wsl_update_x64.msi
+          key: wsl-kernel-msi-v1
+
+      # Fetched on a healthy run so it is already here on a run that needs it.
+      - name: Fetch the WSL kernel package
+        if: steps.wslkernel.outputs.cache-hit != 'true'
+        id: wslkernelfetch
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $msi = "$env:RUNNER_TEMP\wsl_update_x64.msi"
+          $url = "https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi"
+          for ($i = 1; $i -le 3; $i++) {
+            try { Invoke-WebRequest -UseBasicParsing -OutFile $msi $url; break }
+            catch {
+              Write-Host "kernel package download attempt $i failed: $($_.Exception.Message)"
+              if ($i -lt 3) { Start-Sleep -Seconds (5 * $i) }
+            }
+          }
+          if (-not (Test-Path $msi)) { exit 1 }
+          Write-Host "kernel package fetched, $((Get-Item $msi).Length) bytes"
+
       # WSL2 brings up in ~35s on a hosted runner with no reboot and no
       # third-party action: the three features are already enabled on the image.
       # It buys a real Linux shell against the same native httrack.exe, and is
@@ -273,21 +299,31 @@ jobs:
         shell: pwsh
         timeout-minutes: 15
         run: |
-          # Three tries, then carry on, because this endpoint 403s per runner VM
-          # and waiting longer cannot help. The import and its uname check are still fatal.
+          # Three tries, then fall back to the cached package below, because this
+          # endpoint 403s per runner VM and waiting longer cannot help.
+          $updated = $false
           for ($i = 1; $i -le 3; $i++) {
             try {
               wsl --update
               if ($LASTEXITCODE -ne 0) { throw "exit $LASTEXITCODE" }
+              $updated = $true
               break
             }
             catch {
               Write-Host "wsl --update attempt $i failed: $($_.Exception.Message)"
-              if ($i -eq 3) {
-                Write-Host "wsl --update never succeeded, so the import below decides"
-              }
-              else { Start-Sleep -Seconds (5 * $i) }
+              if ($i -lt 3) { Start-Sleep -Seconds (5 * $i) }
             }
+          }
+          # wsl --update is what installs the kernel component, so a 403 there
+          # leaves the import failing with "requires an update to its kernel
+          # component". Installing the package by hand is what recovers it.
+          if (-not $updated) {
+            $msi = "$env:RUNNER_TEMP\wsl_update_x64.msi"
+            if (Test-Path $msi) {
+              $p = Start-Process msiexec.exe -Wait -PassThru -ArgumentList '/i', "`"$msi`"", '/quiet', '/norestart'
+              Write-Host "installed the kernel package by hand, msiexec exit $($p.ExitCode)"
+            }
+            else { Write-Host "no kernel package here, so the import below decides" }
           }
           wsl --set-default-version 2
           $root = "$env:RUNNER_TEMP\wsl-rootfs.tar.gz"
@@ -327,6 +363,13 @@ jobs:
         with:
           path: ${{ runner.temp }}\wsl-rootfs.tar.gz
           key: wsl-rootfs-jammy-amd64-v1
+
+      - name: Save the WSL kernel package
+        if: steps.wslkernel.outputs.cache-hit != 'true' && steps.wslkernelfetch.outcome == 'success'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ runner.temp }}\wsl_update_x64.msi
+          key: wsl-kernel-msi-v1
 
       - name: Run the engine test suite (offline tests, WSL2)
         shell: bash

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -268,7 +268,7 @@ jobs:
           path: ${{ runner.temp }}\wsl_update_x64.msi
           key: wsl-kernel-msi-v1
 
-      # Fetched on a healthy run so it is already here on a run that needs it.
+      # A healthy run fetches it for the run that needs it.
       - name: Fetch the WSL kernel package
         if: steps.wslkernel.outputs.cache-hit != 'true'
         id: wslkernelfetch
@@ -276,11 +276,21 @@ jobs:
         shell: pwsh
         run: |
           $msi = "$env:RUNNER_TEMP\wsl_update_x64.msi"
+          $part = "$msi.part"
           $url = "https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi"
           for ($i = 1; $i -le 3; $i++) {
-            try { Invoke-WebRequest -UseBasicParsing -OutFile $msi $url; break }
+            try {
+              Invoke-WebRequest -UseBasicParsing -OutFile $part $url
+              # Cache keys are immutable, so a half-written file would be
+              # restored for ever and disable this fallback for good.
+              $n = (Get-Item $part).Length
+              if ($n -lt 8MB) { throw "short file, $n bytes" }
+              Move-Item -Force $part $msi
+              break
+            }
             catch {
               Write-Host "kernel package download attempt $i failed: $($_.Exception.Message)"
+              Remove-Item -Force -ErrorAction SilentlyContinue $part
               if ($i -lt 3) { Start-Sleep -Seconds (5 * $i) }
             }
           }
@@ -314,9 +324,8 @@ jobs:
               if ($i -lt 3) { Start-Sleep -Seconds (5 * $i) }
             }
           }
-          # wsl --update is what installs the kernel component, so a 403 there
-          # leaves the import failing with "requires an update to its kernel
-          # component". Installing the package by hand is what recovers it.
+          # wsl --update installs the kernel component, so a 403 there breaks the
+          # import with "requires an update to its kernel component".
           if (-not $updated) {
             $msi = "$env:RUNNER_TEMP\wsl_update_x64.msi"
             if (Test-Path $msi) {


### PR DESCRIPTION
`wsl --update` is what installs the WSL2 kernel component. A 403 from Microsoft's endpoint leaves the component missing. `wsl --import` then fails with "WSL 2 requires an update to its kernel component", and the suite reports no distro. That leg is `libhttrack (x64, Release)`, a required check, so an affected job blocks its PR.

Censused over every `windows-build` run since 2026-09-09 17:00Z. Of 72 job instances that reached the bring-up and finished a suite attempt, 7 failed this way. The rate is rising rather than steady: 0 of 13 in the first three hours, 3 of 9 in the last three.

The package now comes from the actions cache. It is fetched on a healthy run, so it is already there on a run that needs it. It is installed by hand only when `wsl --update` did not succeed. A runner whose update works installs nothing and is never downgraded. The import and its `uname` check stay fatal, so a genuinely unusable WSL still reds.

#1647 made the update best-effort and surfaced the real cause, but it could not recover the leg. All 7 failures had `wsl --update` fail three times, and none of 14 sampled successes had it fail once. This is the half that recovers it.

Checked against the shipped step body under pwsh 7.4 with stub `wsl` and `msiexec`. A 403 with the package present installs it and reaches the import. A successful update installs nothing. A 403 with no package reaches the import anyway and lets it decide.

One thing I could not check without a runner. A host carrying the Store build of WSL rather than the inbox one may react differently to the MSI. It is only reached after `wsl --update` has already failed, and the import still gates, so the downside is the red we get today.
