### PR TITLE
Four strings sit near the end of Francais.txt instead of in place

### DIFF
--- a/lang/Francais.txt
+++ b/lang/Francais.txt
@@ -366,6 +366,8 @@ Create a Start Page
 Créer une page de démarrage
 Create a word database of all html pages
 Créer une base sémantique des pages html
+Build a complete RFC822 mail (MHT/EML) archive of the mirror
+Construire une archive email complète (MHT/EML) au format RFC822
 Create error logging and report files
 Créer des fichiers journaux pour les messages d'erreur et d'avertissement
 Generate DOS 8-3 filenames ONLY
@@ -418,6 +420,8 @@ Languages accepted by the browser
 Langues acceptée par le navigateur
 Additional HTTP headers to be sent in each requests
 En-têtes HTTP additionnels à envoyer dans chaque requête
+HTTP referer to be sent for initial URLs
+Champ HTTP referer a envoyer pour les URL initiales
 Back to starting page
 Retour à la page de démarrage
 Save current preferences as default values
@@ -478,6 +482,8 @@ Make an index
 Constituer un Index
 Make a word database
 Faire une base sémantique
+Build a mail archive
+Construire une archive mail
 Log files
 Fichiers journaux
 DOS names (8+3)
@@ -510,6 +516,8 @@ Languages
 Langues
 Additional HTTP Headers
 En têtes HTTP additionnels
+Default referer URL
+Champ referer par défaut
 N# connections
 Nombre de connexions
 Abandon host if error
@@ -962,14 +970,6 @@ Click on this notification to restart the interrupted mirror
 Cliquez sur cette notification pour redémarrer la copie interrompue
 HTTrack: could not save profile for '%s'!
 HTTrack: impossible de sauver le profil pour '%s'
-Build a complete RFC822 mail (MHT/EML) archive of the mirror
-Construire une archive email complète (MHT/EML) au format RFC822
-HTTP referer to be sent for initial URLs
-Champ HTTP referer a envoyer pour les URL initiales
-Build a mail archive
-Construire une archive mail
-Default referer URL
-Champ referer par défaut
 Proxy type:
 Type de proxy :
 Proxy protocol. HTTP: standard proxy. HTTP (CONNECT tunnel): sends every request through a CONNECT tunnel, for CONNECT-only proxies like Tor's HTTPTunnelPort. SOCKS5: default port 1080.


### PR DESCRIPTION
WinHTTrack finds a repeated English string by counting occurrences, so the Nth occurrence in `lang.def` must be the Nth in every catalog. `Francais.txt` is the only catalog whose keys run out of `English.txt` order. Four sit near the end instead of in place.

All four texts are unique, so nothing is wrong today. It bites when one gains a second occurrence in `lang.def`. French alone would map it to the wrong key, and a correct-looking French string would land on the wrong control.

This moves the four pairs back. All 30 catalogs now match English order. No test sees any of this, because our own reader looks strings up by content.

The httrack-windows session found it.
