### PR TITLE
A front end woken by the end callback reads the verdict before the engine stores it

### DIFF
--- a/src/htscore.c
+++ b/src/htscore.c
@@ -918,9 +918,10 @@ int httpmirror(char *url1, httrackp *opt, hts_boolean *completed_out) {
                  url);
       }
       freet(primary);
-      XH_extuninit;
-      /* --why answered; no mirror was asked for */
+      /* --why answered; no mirror was asked for. Stored before the teardown
+         below, whose end callback a front end reads the verdict from. */
       set_mirror_completed(opt, completed_out, HTS_TRUE);
+      XH_extuninit;
       return 1;
     }
 
@@ -2345,6 +2346,10 @@ int httpmirror(char *url1, httrackp *opt, hts_boolean *completed_out) {
 
 cleanup:
   /* single exit: every bailout jumps here, so the closes below always run */
+  /* Verdict first: XH_uninit below fires the end callback, and a front end
+     woken by it reads the verdict right there. `completed` is already final,
+     because nothing below this label assigns it. */
+  set_mirror_completed(opt, completed_out, completed);
   warc_close_opt(opt); /* a no-op once warc_abort_opt() has run */
   /* An abort never ran hts_changes_indexed(), so its report would be false;
      free it rather than overwrite the previous run's true one. */
@@ -2361,7 +2366,6 @@ cleanup:
   if (rollback)
     hts_cache_reconcile(opt, CACHE_RECONCILE_ROLLBACK);
 
-  set_mirror_completed(opt, completed_out, completed);
   return retcode;
 }
 

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -918,8 +918,8 @@ int httpmirror(char *url1, httrackp *opt, hts_boolean *completed_out) {
                  url);
       }
       freet(primary);
-      /* --why answered; no mirror was asked for. Stored before the teardown
-         below, whose end callback a front end reads the verdict from. */
+      /* --why answered; no mirror was asked for. The store comes first
+         because the teardown below fires the end callback. */
       set_mirror_completed(opt, completed_out, HTS_TRUE);
       XH_extuninit;
       return 1;

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -425,13 +425,14 @@ HTSEXT_API void hts_cancel_parsing(httrackp *opt);
    so safe to poll from another thread. Wait for this before hts_free_opt(). */
 HTSEXT_API hts_boolean hts_has_stopped(httrackp *opt);
 
-/** Did the last mirror on @p opt reach the end of its crawl? HTS_TRUE if it
-    did, HTS_FALSE if it gave up or was stopped, HTS_DEFAULT if no mirror has
-    started on this opt. hts_main2() returns 0 for a mirror stopped on purpose,
-    so its code cannot answer this. Compare the result against the named
-    constants and never test it as a boolean, because HTS_DEFAULT is -1 and
-    therefore true. Read under the engine state lock, so safe to poll from
-    another thread. */
+/** Did the last mirror on @p opt reach the end of its crawl? HTS_TRUE once it
+   has, HTS_FALSE while it is still running or if it gave up or was stopped,
+   HTS_DEFAULT if no mirror has started on this opt. The value is final by the
+   time the end callback runs, which is where a front end reads it. hts_main2()
+   returns 0 for a mirror stopped on purpose, so its code cannot answer this.
+   Compare the result against the named constants and never test it as a
+   boolean, because HTS_DEFAULT is -1 and therefore true. Read under the engine
+   state lock, so safe to poll from another thread. */
 HTSEXT_API hts_tristate hts_mirror_completed(httrackp *opt);
 
 /* Tools */

--- a/tests/465_local-mirror-completed.test
+++ b/tests/465_local-mirror-completed.test
@@ -51,17 +51,12 @@ for case_name in finish stop why refuse; do
         fail "$case_name case did not start at HTS_DEFAULT: $reply"
     # Every case ends at the same exit code; only the verdict separates them.
     grep -q '^rc: 0$' <<<"$reply" || fail "$case_name case did not return 0: $reply"
-    # No end line means the callback never ran and every "end:" test below
-    # would pass on an empty match set.
-    grep -q '^end: ' <<<"$reply" ||
-        fail "$case_name case never fired the end callback: $reply"
     printf '%s\n' "$reply" >"${tmpdir}/${case_name}.out"
 done
 
 grep -q '^after: true$' <"${tmpdir}/finish.out" ||
     fail "a mirror that ran to its end did not read HTS_TRUE: $(cat "${tmpdir}/finish.out")"
-# The reading a real front end takes: fire end before the store and a completed
-# mirror announces itself as stopped.
+# A completed mirror reports itself as stopped if end fires before the store.
 grep -q '^end: true$' <"${tmpdir}/finish.out" ||
     fail "the end callback of a completed mirror did not read HTS_TRUE: $(cat "${tmpdir}/finish.out")"
 # Without this the stop case is self-confirming: a run that died before its

--- a/tests/465_local-mirror-completed.test
+++ b/tests/465_local-mirror-completed.test
@@ -6,6 +6,10 @@
 # the same return code, over four runs against the same local server. Two of
 # them cover the stores no crawl reaches, which are --why answering and a
 # mirror the engine gives up on before its crawl.
+#
+# The verdict is read twice per run: after hts_main2() returns, and from inside
+# the end callback, which is where WinHTTrack reads it. The engine must store
+# the verdict before it fires that callback, or the two readings disagree.
 
 set -eu
 
@@ -47,17 +51,27 @@ for case_name in finish stop why refuse; do
         fail "$case_name case did not start at HTS_DEFAULT: $reply"
     # Every case ends at the same exit code; only the verdict separates them.
     grep -q '^rc: 0$' <<<"$reply" || fail "$case_name case did not return 0: $reply"
+    # No end line means the callback never ran and every "end:" test below
+    # would pass on an empty match set.
+    grep -q '^end: ' <<<"$reply" ||
+        fail "$case_name case never fired the end callback: $reply"
     printf '%s\n' "$reply" >"${tmpdir}/${case_name}.out"
 done
 
 grep -q '^after: true$' <"${tmpdir}/finish.out" ||
     fail "a mirror that ran to its end did not read HTS_TRUE: $(cat "${tmpdir}/finish.out")"
+# The reading a real front end takes: fire end before the store and a completed
+# mirror announces itself as stopped.
+grep -q '^end: true$' <"${tmpdir}/finish.out" ||
+    fail "the end callback of a completed mirror did not read HTS_TRUE: $(cat "${tmpdir}/finish.out")"
 # Without this the stop case is self-confirming: a run that died before its
 # first progress tick also prints "rc: 0", "after: false" and mirrors nothing.
 grep -q '^stop: requested$' <"${tmpdir}/stop.out" ||
     fail "the Stop button was never pushed: $(cat "${tmpdir}/stop.out")"
 grep -q '^after: false$' <"${tmpdir}/stop.out" ||
     fail "a stopped mirror did not read HTS_FALSE: $(cat "${tmpdir}/stop.out")"
+grep -q '^end: false$' <"${tmpdir}/stop.out" ||
+    fail "the end callback of a stopped mirror did not read HTS_FALSE: $(cat "${tmpdir}/stop.out")"
 
 # The two runs must really have ended differently, or "false" would be the
 # verdict of a mirror that quietly finished anyway. The linked pages land under
@@ -74,6 +88,8 @@ grep -qE 'by rule #|no filter rule matches' <"${tmpdir}/why.out" ||
     fail "--why printed no verdict, so its reading proves nothing: $(cat "${tmpdir}/why.out")"
 grep -q '^after: true$' <"${tmpdir}/why.out" ||
     fail "--why did not read HTS_TRUE: $(cat "${tmpdir}/why.out")"
+grep -q '^end: true$' <"${tmpdir}/why.out" ||
+    fail "--why did not read HTS_TRUE from its end callback: $(cat "${tmpdir}/why.out")"
 
 # A mirror that starts and then fails must read HTS_FALSE, never HTS_DEFAULT:
 # HTS_DEFAULT promises no mirror started, and a GUI reading it stays silent
@@ -82,3 +98,5 @@ grep -q '^start: refused$' <"${tmpdir}/refuse.out" ||
     fail "no mirror was refused, so nothing here failed: $(cat "${tmpdir}/refuse.out")"
 grep -q '^after: false$' <"${tmpdir}/refuse.out" ||
     fail "a mirror refused at its start did not read HTS_FALSE: $(cat "${tmpdir}/refuse.out")"
+grep -q '^end: false$' <"${tmpdir}/refuse.out" ||
+    fail "the end callback of a refused mirror did not read HTS_FALSE: $(cat "${tmpdir}/refuse.out")"

--- a/tests/mirrorverdict.c
+++ b/tests/mirrorverdict.c
@@ -22,8 +22,9 @@ Please visit our Website: http://www.httrack.com
 */
 
 /* Reads hts_mirror_completed() the way an embedding GUI does: around one real
-   mirror driven through hts_main2(). 465_local-mirror-completed.test runs it
-   once per case named by argv[1]: finish, stop, why or refuse. */
+   mirror driven through hts_main2(), and from inside the end callback, which
+   is where WinHTTrack reads it. 465_local-mirror-completed.test runs it once
+   per case named by argv[1]: finish, stop, why or refuse. */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -74,6 +75,15 @@ static const char *verdict_name(hts_tristate verdict) {
   return "bogus";
 }
 
+/* Where a front end really reads the verdict: WinHTTrack's end callback raises
+   a flag, its polling loop then calls hts_mirror_completed(). So the engine
+   must store the verdict before it fires this. */
+static int end_verdict(t_hts_callbackarg *carg, httrackp *opt) {
+  (void) carg;
+  printf("end: %s\n", verdict_name(hts_mirror_completed(opt)));
+  return 1;
+}
+
 int main(int argc, char **argv) {
   /* Arrays rather than string literals: hts_main2() takes a writable argv.
      av[0..2] are placed by hand below, the rest appended by the loop. */
@@ -99,6 +109,7 @@ int main(int argc, char **argv) {
   }
   printf("before: %s\n", verdict_name(hts_mirror_completed(opt)));
 
+  CHAIN_FUNCTION(opt, end, end_verdict, NULL);
   if (strcmp(argv[1], "stop") == 0)
     CHAIN_FUNCTION(opt, loop, stop_now, NULL);
   if (strcmp(argv[1], "refuse") == 0)

--- a/tests/mirrorverdict.c
+++ b/tests/mirrorverdict.c
@@ -75,9 +75,8 @@ static const char *verdict_name(hts_tristate verdict) {
   return "bogus";
 }
 
-/* Where a front end really reads the verdict: WinHTTrack's end callback raises
-   a flag, its polling loop then calls hts_mirror_completed(). So the engine
-   must store the verdict before it fires this. */
+/* WinHTTrack reads the verdict here: its end callback raises a flag and its
+   polling loop then calls hts_mirror_completed(). */
 static int end_verdict(t_hts_callbackarg *carg, httrackp *opt) {
   (void) carg;
   printf("end: %s\n", verdict_name(hts_mirror_completed(opt)));


### PR DESCRIPTION
#1660 added `hts_mirror_completed()`. `httpmirror()` stored the verdict at its `cleanup:` exit, but `XH_uninit` runs first and expands through `XH_extuninit` to `HTMLCHECK_UNINIT`, which is `RUN_CALLBACK0(opt, end)`. The engine therefore fired the `end` callback before it stored the answer, so a front end woken by that callback read the `HTS_FALSE` written at entry. A mirror that ran to completion reported as stopped.

WinHTTrack does exactly this. Its `end` callback sets a flag, `lance()` polls it every 100 ms, then reads the verdict. A large cache widens the window, because `zipClose()` has to finish inside one poll. The httrack-windows session found it while writing that half.

The store moves to the top of the cleanup block rather than one line up. Every teardown callback now sees the final value, `end` included. `hts_changes_close_opt()` reaches the global log hook the same way. `completed` is already final at the label, because it is assigned one line above and nothing below assigns it. The `--why` bailout had the same order and gets the same move.

The test reads the verdict from inside an `end` callback, which is where a front end reads it. Every existing test read it after `hts_main2()` returned, and that is why none of them could see this. On the unfixed engine the finish case prints `end: false` beside `after: true`.
