### PR TITLE
hts_set_thread_runner() is exported but no installed header declares it

### DIFF
--- a/src/htsthread.h
+++ b/src/htsthread.h
@@ -34,6 +34,7 @@ Please visit our Website: http://www.httrack.com
 #define HTS_DEFTHREAD
 
 #include "htsglobal.h"
+#include "httrack-library.h"
 #ifndef _WIN32
 #include <pthread.h>
 #endif
@@ -67,13 +68,6 @@ HTSEXT_API int hts_newthread(void (*fun) (void *arg), void *arg);
    NULL in either clears the pair, since neither hook is useful alone. */
 HTSEXT_API void hts_set_thread_hooks(void *(*enter)(void),
                                      void (*leave)(void *cookie));
-
-typedef void (*hts_thread_runner)(void (*fun)(void *arg), void *arg);
-
-/* Wraps each worker body in a caller-supplied frame, between 'enter' and
-   'leave'. The runner must call 'fun(arg)' once, and NULL clears it. Returns
-   the previous runner. Set it before spawning, since it is read unlocked. */
-HTSEXT_API hts_thread_runner hts_set_thread_runner(hts_thread_runner runner);
 
 HTSEXT_API void htsthread_wait_n(int n_wait);
 

--- a/src/htstools.h
+++ b/src/htstools.h
@@ -36,16 +36,12 @@ Please visit our Website: http://www.httrack.com
 
 /* specific definitions */
 #include "htsglobal.h"
+#include "httrack-library.h"
 
 /* Forward definitions */
 #ifndef HTS_DEF_FWSTRUCT_httrackp
 #define HTS_DEF_FWSTRUCT_httrackp
 typedef struct httrackp httrackp;
-#endif
-#ifndef HTS_DEF_FWSTRUCT_find_handle_struct
-#define HTS_DEF_FWSTRUCT_find_handle_struct
-typedef struct find_handle_struct find_handle_struct;
-typedef find_handle_struct *find_handle;
 #endif
 #ifndef HTS_DEF_FWSTRUCT_lien_adrfil
 #define HTS_DEF_FWSTRUCT_lien_adrfil
@@ -151,21 +147,6 @@ int istoobig(httrackp * opt, LLint size, LLint maxhtml, LLint maxnhtml,
              char *type);
 HTSEXT_API int hts_buildtopindex(httrackp * opt, const char *path,
                                  const char *binpath);
-
-// Portable directory find functions
-// Directory find functions
-HTSEXT_API find_handle hts_findfirst(char *path);
-HTSEXT_API hts_boolean hts_findnext(find_handle find);
-HTSEXT_API int hts_findclose(find_handle find);
-
-//
-HTSEXT_API char *hts_findgetname(find_handle find);
-HTSEXT_API LLint hts_findgetsize64(find_handle find);
-HTS_DEPRECATED("use hts_findgetsize64(find)")
-HTSEXT_API int hts_findgetsize(find_handle find);
-HTSEXT_API hts_boolean hts_findisdir(find_handle find);
-HTSEXT_API hts_boolean hts_findisfile(find_handle find);
-HTSEXT_API hts_boolean hts_findissystem(find_handle find);
 
 /* Move src onto dst, replacing an existing dst; HTS_TRUE on success. Both paths
    are fconv()'d. A dst in the way is parked under a sibling name rather than

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -810,6 +810,18 @@ HTSEXT_API hts_boolean hts_findisfile(find_handle find);
     temporary entries. Else 0. */
 HTSEXT_API hts_boolean hts_findissystem(find_handle find);
 
+/* Worker threads */
+#ifndef HTS_DEF_FWTYPE_hts_thread_runner
+#define HTS_DEF_FWTYPE_hts_thread_runner
+typedef void (*hts_thread_runner)(void (*fun)(void *arg), void *arg);
+#endif
+
+/** Wraps each worker body in a caller-supplied frame, between the 'enter' and
+   'leave' thread hooks. The runner must call 'fun(arg)' once, and NULL clears
+   it. Returns the previous runner. Set it before spawning, since it is read
+   unlocked. */
+HTSEXT_API hts_thread_runner hts_set_thread_runner(hts_thread_runner runner);
+
 /* UTF-8 aware FILE API */
 /* On non-Windows these macros resolve directly to the POSIX calls. On Windows
    they map to the hts_*_utf8 wrappers below, which convert the UTF-8 path to

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -816,10 +816,9 @@ HTSEXT_API hts_boolean hts_findissystem(find_handle find);
 typedef void (*hts_thread_runner)(void (*fun)(void *arg), void *arg);
 #endif
 
-/** Wraps each worker body in a caller-supplied frame, between the 'enter' and
-   'leave' thread hooks. The runner must call 'fun(arg)' once, and NULL clears
-   it. Returns the previous runner. Set it before spawning, since it is read
-   unlocked. */
+/** Wraps each worker body in a caller-supplied frame. The runner must call
+    'fun(arg)' once, and NULL clears it. Returns the previous runner. Set it
+    before spawning, since it is read unlocked. */
 HTSEXT_API hts_thread_runner hts_set_thread_runner(hts_thread_runner runner);
 
 /* UTF-8 aware FILE API */

--- a/tests/208_install-headers-advertised.test
+++ b/tests/208_install-headers-advertised.test
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
-# The calls the release notes advertise must reach an embedder from the
+# The four calls the release notes advertise must reach an embedder from the
 # installed headers alone (#1663): hts_set_thread_runner(),
-# hts_findgetsize64() and the deprecated hts_findgetsize(). A missing
-# declaration and a missing export are different failures, so compile and link
-# are separate steps here.
+# hts_mirror_completed(), hts_findgetsize64() and the deprecated
+# hts_findgetsize(). A missing declaration and a missing export are different
+# failures, so compile and link are separate steps here.
 
 set -euo pipefail
 
@@ -22,19 +22,6 @@ command -v "${cc_argv[0]}" >/dev/null 2>&1 || skip "no C compiler (${cc_argv[0]}
 make=${MAKE:-make}
 command -v "$make" >/dev/null 2>&1 || skip "no make ($make)"
 
-lib=${HTTRACK_SHLIB:-}
-if [ ! -f "${lib:-/nonexistent}" ]; then
-    # A Darwin build names it .dylib, which HTTRACK_SHLIB does not cover.
-    for cand in "$abs_top_builddir"/src/.libs/libhttrack.dylib \
-        "$abs_top_builddir"/src/.libs/libhttrack.so; do
-        if [ -f "$cand" ]; then
-            lib=$cand
-            break
-        fi
-    done
-fi
-[ -f "${lib:-/nonexistent}" ] || skip "no shared libhttrack to link against"
-
 tmp=$(mktemp -d) || exit 1
 cleanup_push rm -rf "$tmp"
 
@@ -45,14 +32,16 @@ if [ -n "${TEST_CPPFLAGS:-}" ]; then
 fi
 # An embedder never defines this, and a declaration it gates is not installed API.
 cpp_argv+=(-UHTS_INTERNAL_BYTECODE -UHTS_INTERNAL_BUILD)
-# An undeclared call must be an error, not the warning older compilers default to.
-strict_argv=(-Werror=implicit-function-declaration)
+# An undeclared call must be an error, not the warning older compilers default
+# to. One advertised call is deprecated on purpose, so that warning is off here
+# and the assertion further down checks the attribute is still there.
+strict_argv=(-Werror=implicit-function-declaration -Wno-deprecated-declarations)
 
 # Positive control: a box with no multilib libc (CC="gcc -m32") blames our
 # headers for everything otherwise.
 printf '#include <stdio.h>\nint main(void) { return puts("") < 0; }\n' >"$tmp/libc.c"
-"${cc_argv[@]}" "${cpp_argv[@]}" -fsyntax-only "$tmp/libc.c" 2>"$tmp/cc.log" || {
-    head -5 "$tmp/cc.log" >&2
+"${cc_argv[@]}" "${cpp_argv[@]}" -fsyntax-only "$tmp/libc.c" 2>"$tmp/libc.log" || {
+    head -5 "$tmp/libc.log" >&2
     echo "${cc_argv[*]} cannot compile a bare <stdio.h>, skipping" >&2
     exit 77
 }
@@ -69,8 +58,7 @@ run_with_install_lock env MAKEFLAGS= MFLAGS= "$make" -C "$abs_top_builddir/src" 
 [ -f "$tmp/include/httrack/httrack-library.h" ] || fail "httrack-library.h was not installed"
 
 # The consumer declares nothing of its own, so every name below comes from the
-# installed header. -Wno-deprecated-declarations because one call is deprecated
-# on purpose; the assertion further down checks that attribute is still there.
+# installed header, the whole hts_find* family included.
 cat >"$tmp/consumer.c" <<'EOF'
 #include <httrack/httrack-library.h>
 
@@ -81,51 +69,46 @@ static void embedder_runner(void (*fun)(void *arg), void *arg) {
 int main(void) {
   char path[] = ".";
   hts_thread_runner previous = hts_set_thread_runner(embedder_runner);
+  httrackp *opt = hts_create_opt();
   find_handle find = hts_findfirst(path);
+  hts_tristate completed = HTS_DEFAULT;
+  const char *name = NULL;
   LLint size = -1;
   int truncated = -1;
+  int kinds = 0;
 
   if (find != NULL) {
-    size = hts_findgetsize64(find);
-    truncated = hts_findgetsize(find);
+    do {
+      name = hts_findgetname(find);
+      size = hts_findgetsize64(find);
+      truncated = hts_findgetsize(find);
+      kinds += hts_findisdir(find) + hts_findisfile(find)
+        + hts_findissystem(find);
+    } while (hts_findnext(find));
     hts_findclose(find);
   }
+  if (opt != NULL) {
+    completed = hts_mirror_completed(opt);
+    hts_free_opt(opt);
+  }
   (void) hts_set_thread_runner(previous);
-  return size == 0 && truncated == 0;
+  return name != NULL && size == 0 && truncated == 0 && kinds == 0
+    && completed == HTS_TRUE;
 }
 EOF
 
-"${cc_argv[@]}" "${cpp_argv[@]}" "${strict_argv[@]}" -Wno-deprecated-declarations \
-    -c -o "$tmp/consumer.o" "$tmp/consumer.c" 2>"$tmp/cc.log" || {
-    cat "$tmp/cc.log" >&2
+"${cc_argv[@]}" "${cpp_argv[@]}" "${strict_argv[@]}" \
+    -c -o "$tmp/consumer.o" "$tmp/consumer.c" 2>"$tmp/consumer.log" || {
+    cat "$tmp/consumer.log" >&2
     fail "the installed headers do not declare the advertised calls"
-}
-
-"${cc_argv[@]}" -o "$tmp/consumer" "$tmp/consumer.o" "$lib" 2>"$tmp/ld.log" || {
-    cat "$tmp/ld.log" >&2
-    fail "$lib does not export the advertised calls"
 }
 
 # Negative control for the compile: an undeclared call has to be rejected.
 sed 's/hts_findgetsize64(find)/hts_no_such_call_1663(find)/' "$tmp/consumer.c" \
     >"$tmp/undeclared.c"
-! "${cc_argv[@]}" "${cpp_argv[@]}" "${strict_argv[@]}" -Wno-deprecated-declarations \
+! "${cc_argv[@]}" "${cpp_argv[@]}" "${strict_argv[@]}" \
     -c -o "$tmp/undeclared.o" "$tmp/undeclared.c" 2>/dev/null ||
     fail "${cc_argv[*]} accepted an undeclared call, the compile above proved nothing"
-
-# Negative control for the link: a name nothing defines has to be rejected.
-{
-    printf '#include <httrack/httrack-library.h>\n'
-    printf 'extern int hts_no_such_export_1663(void);\n'
-    printf 'int main(void) { return hts_no_such_export_1663(); }\n'
-} >"$tmp/unexported.c"
-"${cc_argv[@]}" "${cpp_argv[@]}" -c -o "$tmp/unexported.o" "$tmp/unexported.c" \
-    2>"$tmp/cc.log" || {
-    head -5 "$tmp/cc.log" >&2
-    fail "the link control does not compile"
-}
-! "${cc_argv[@]}" -o "$tmp/unexported" "$tmp/unexported.o" "$lib" 2>/dev/null ||
-    fail "${cc_argv[*]} linked an undefined symbol, the link above proved nothing"
 
 # hts_findgetsize is advertised as deprecated, so the attribute has to survive
 # the move. Only where this compiler enforces one it wrote itself.
@@ -139,6 +122,44 @@ else
         -c -o "$tmp/dep.o" "$tmp/consumer.c" 2>/dev/null ||
         fail "hts_findgetsize lost its deprecation on the way to the installed header"
 fi
+
+# Gated here rather than at the top, because only the link needs the library
+# and a --disable-shared build still has headers worth checking.
+lib=${HTTRACK_SHLIB:-}
+if [ ! -f "${lib:-/nonexistent}" ]; then
+    # A Darwin build names it .dylib, which HTTRACK_SHLIB does not cover.
+    for cand in "$abs_top_builddir"/src/.libs/libhttrack.dylib \
+        "$abs_top_builddir"/src/.libs/libhttrack.so; do
+        if [ -f "$cand" ]; then
+            lib=$cand
+            break
+        fi
+    done
+fi
+if [ ! -f "${lib:-/nonexistent}" ]; then
+    echo "the installed headers declare the advertised calls" \
+        "(no shared libhttrack, so the link was not checked)"
+    exit 0
+fi
+
+"${cc_argv[@]}" -o "$tmp/consumer" "$tmp/consumer.o" "$lib" 2>"$tmp/ld.log" || {
+    cat "$tmp/ld.log" >&2
+    fail "$lib does not export the advertised calls"
+}
+
+# Negative control for the link: a name nothing defines has to be rejected.
+{
+    printf '#include <httrack/httrack-library.h>\n'
+    printf 'extern int hts_no_such_export_1663(void);\n'
+    printf 'int main(void) { return hts_no_such_export_1663(); }\n'
+} >"$tmp/unexported.c"
+"${cc_argv[@]}" "${cpp_argv[@]}" -c -o "$tmp/unexported.o" "$tmp/unexported.c" \
+    2>"$tmp/unexported.log" || {
+    head -5 "$tmp/unexported.log" >&2
+    fail "the link control does not compile"
+}
+! "${cc_argv[@]}" -o "$tmp/unexported" "$tmp/unexported.o" "$lib" 2>/dev/null ||
+    fail "${cc_argv[*]} linked an undefined symbol, the link above proved nothing"
 
 echo "an embedder compiled and linked the advertised calls from the installed headers"
 

--- a/tests/208_install-headers-advertised.test
+++ b/tests/208_install-headers-advertised.test
@@ -1,0 +1,145 @@
+#!/bin/bash
+#
+# The calls the release notes advertise must reach an embedder from the
+# installed headers alone (#1663): hts_set_thread_runner(),
+# hts_findgetsize64() and the deprecated hts_findgetsize(). A missing
+# declaration and a missing export are different failures, so compile and link
+# are separate steps here.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+# Unset means no automake run (the Windows job runs the scripts directly), so
+# there is no install rule to drive.
+[ -n "${abs_top_builddir:-}" ] || skip "abs_top_builddir unset, no automake environment"
+[ -f "$abs_top_builddir/src/Makefile" ] || fail "$abs_top_builddir/src is not configured"
+
+# CC carries flags on some legs ("gcc -m32", "ccache gcc"), so split it.
+read -r -a cc_argv <<<"${CC:-cc}"
+command -v "${cc_argv[0]}" >/dev/null 2>&1 || skip "no C compiler (${cc_argv[0]})"
+make=${MAKE:-make}
+command -v "$make" >/dev/null 2>&1 || skip "no make ($make)"
+
+lib=${HTTRACK_SHLIB:-}
+if [ ! -f "${lib:-/nonexistent}" ]; then
+    # A Darwin build names it .dylib, which HTTRACK_SHLIB does not cover.
+    for cand in "$abs_top_builddir"/src/.libs/libhttrack.dylib \
+        "$abs_top_builddir"/src/.libs/libhttrack.so; do
+        if [ -f "$cand" ]; then
+            lib=$cand
+            break
+        fi
+    done
+fi
+[ -f "${lib:-/nonexistent}" ] || skip "no shared libhttrack to link against"
+
+tmp=$(mktemp -d) || exit 1
+cleanup_push rm -rf "$tmp"
+
+cpp_argv=(-I"$tmp/include")
+if [ -n "${TEST_CPPFLAGS:-}" ]; then
+    read -r -a extra_argv <<<"$TEST_CPPFLAGS"
+    cpp_argv+=("${extra_argv[@]}")
+fi
+# An embedder never defines this, and a declaration it gates is not installed API.
+cpp_argv+=(-UHTS_INTERNAL_BYTECODE -UHTS_INTERNAL_BUILD)
+# An undeclared call must be an error, not the warning older compilers default to.
+strict_argv=(-Werror=implicit-function-declaration)
+
+# Positive control: a box with no multilib libc (CC="gcc -m32") blames our
+# headers for everything otherwise.
+printf '#include <stdio.h>\nint main(void) { return puts("") < 0; }\n' >"$tmp/libc.c"
+"${cc_argv[@]}" "${cpp_argv[@]}" -fsyntax-only "$tmp/libc.c" 2>"$tmp/cc.log" || {
+    head -5 "$tmp/cc.log" >&2
+    echo "${cc_argv[*]} cannot compile a bare <stdio.h>, skipping" >&2
+    exit 77
+}
+
+# Override the install dir rather than DESTDIR: same rule and file list, no
+# prefix guessing. Empty MAKEFLAGS, or the sub-make hunts a jobserver it lacks.
+run_with_install_lock env MAKEFLAGS= MFLAGS= "$make" -C "$abs_top_builddir/src" \
+    install-DevIncludesDATA \
+    DevIncludesdir="$tmp/include/httrack" >"$tmp/install.log" 2>&1 ||
+    {
+        cat "$tmp/install.log" >&2
+        fail "install-DevIncludesDATA failed"
+    }
+[ -f "$tmp/include/httrack/httrack-library.h" ] || fail "httrack-library.h was not installed"
+
+# The consumer declares nothing of its own, so every name below comes from the
+# installed header. -Wno-deprecated-declarations because one call is deprecated
+# on purpose; the assertion further down checks that attribute is still there.
+cat >"$tmp/consumer.c" <<'EOF'
+#include <httrack/httrack-library.h>
+
+static void embedder_runner(void (*fun)(void *arg), void *arg) {
+  fun(arg);
+}
+
+int main(void) {
+  char path[] = ".";
+  hts_thread_runner previous = hts_set_thread_runner(embedder_runner);
+  find_handle find = hts_findfirst(path);
+  LLint size = -1;
+  int truncated = -1;
+
+  if (find != NULL) {
+    size = hts_findgetsize64(find);
+    truncated = hts_findgetsize(find);
+    hts_findclose(find);
+  }
+  (void) hts_set_thread_runner(previous);
+  return size == 0 && truncated == 0;
+}
+EOF
+
+"${cc_argv[@]}" "${cpp_argv[@]}" "${strict_argv[@]}" -Wno-deprecated-declarations \
+    -c -o "$tmp/consumer.o" "$tmp/consumer.c" 2>"$tmp/cc.log" || {
+    cat "$tmp/cc.log" >&2
+    fail "the installed headers do not declare the advertised calls"
+}
+
+"${cc_argv[@]}" -o "$tmp/consumer" "$tmp/consumer.o" "$lib" 2>"$tmp/ld.log" || {
+    cat "$tmp/ld.log" >&2
+    fail "$lib does not export the advertised calls"
+}
+
+# Negative control for the compile: an undeclared call has to be rejected.
+sed 's/hts_findgetsize64(find)/hts_no_such_call_1663(find)/' "$tmp/consumer.c" \
+    >"$tmp/undeclared.c"
+! "${cc_argv[@]}" "${cpp_argv[@]}" "${strict_argv[@]}" -Wno-deprecated-declarations \
+    -c -o "$tmp/undeclared.o" "$tmp/undeclared.c" 2>/dev/null ||
+    fail "${cc_argv[*]} accepted an undeclared call, the compile above proved nothing"
+
+# Negative control for the link: a name nothing defines has to be rejected.
+{
+    printf '#include <httrack/httrack-library.h>\n'
+    printf 'extern int hts_no_such_export_1663(void);\n'
+    printf 'int main(void) { return hts_no_such_export_1663(); }\n'
+} >"$tmp/unexported.c"
+"${cc_argv[@]}" "${cpp_argv[@]}" -c -o "$tmp/unexported.o" "$tmp/unexported.c" \
+    2>"$tmp/cc.log" || {
+    head -5 "$tmp/cc.log" >&2
+    fail "the link control does not compile"
+}
+! "${cc_argv[@]}" -o "$tmp/unexported" "$tmp/unexported.o" "$lib" 2>/dev/null ||
+    fail "${cc_argv[*]} linked an undefined symbol, the link above proved nothing"
+
+# hts_findgetsize is advertised as deprecated, so the attribute has to survive
+# the move. Only where this compiler enforces one it wrote itself.
+printf 'void ctl(void) __attribute__((deprecated));\nint main(void) { ctl(); return 0; }\n' \
+    >"$tmp/depctl.c"
+if "${cc_argv[@]}" -Werror=deprecated-declarations -c -o "$tmp/depctl.o" \
+    "$tmp/depctl.c" 2>/dev/null; then
+    echo "${cc_argv[*]} does not enforce deprecation; skipping that assertion" >&2
+else
+    ! "${cc_argv[@]}" "${cpp_argv[@]}" -Werror=deprecated-declarations \
+        -c -o "$tmp/dep.o" "$tmp/consumer.c" 2>/dev/null ||
+        fail "hts_findgetsize lost its deprecation on the way to the installed header"
+fi
+
+echo "an embedder compiled and linked the advertised calls from the installed headers"
+
+exit 0

--- a/tests/209_exports-declared-once.test
+++ b/tests/209_exports-declared-once.test
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# An exported call declared in an installed header and again in one that stays
+# behind has two signatures that nothing keeps in step, so an embedder can
+# compile against one while the engine uses the other (#1663). The list below
+# is what is left, and it may only shrink.
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+src="${abs_top_srcdir:?not run under make check}/src"
+test -f "$src/Makefile.am" || fail "no $src/Makefile.am"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/exports.XXXXXX") || fail "no tmpdir"
+cleanup_push rm -rf "$work"
+
+# Read the installed set out of DevIncludes_DATA, so installing a header moves
+# this check with it. By basename: htsfeatures.h is listed from the parent dir.
+sed -n '/^DevIncludes_DATA[ \t]*=/,/[^\\]$/p' "$src/Makefile.am" |
+    sed -e 's/\\$//' | tr -s ' \t' '\n' | grep '\.h$' | sed 's|.*/||' |
+    LC_ALL=C sort -u >"$work/installed"
+grep -qx 'httrack-library.h' "$work/installed" ||
+    fail "DevIncludes_DATA did not parse; nothing to call installed"
+
+# One logical declaration per HTSEXT_API, joined up to its ';', so a prototype
+# wrapped after the return type still yields the name it declares.
+awk '
+function flush(  s, t, n) {
+  s = span; t = ""
+  if (match(s, /[A-Za-z_][A-Za-z0-9_]*[ \t]*\(/)) {
+    t = substr(s, RSTART, RLENGTH); sub(/[ \t]*\(/, "", t)
+  } else if (match(s, /[A-Za-z_][A-Za-z0-9_]*[ \t]*;/)) {
+    t = substr(s, RSTART, RLENGTH); sub(/[ \t]*;/, "", t)
+  }
+  if (t != "") { n = FILENAME; sub(/.*\//, "", n); print t "\t" n }
+  span = ""; open = 0
+}
+open { span = span " " $0; if ($0 ~ /;/) flush(); next }
+/^[ \t]*(extern[ \t]+)?HTSEXT_API[ \t]/ {
+  span = $0; sub(/.*HTSEXT_API/, "", span); open = 1
+  if ($0 ~ /;/) flush()
+}' "$src"/*.h | LC_ALL=C sort -u >"$work/decls"
+
+# An empty or one-sided scan yields no pairs at all, which the diff below reds
+# against a non-empty pin, so the pin is its own control.
+awk -F'\t' '
+NR == FNR { installed[$0] = 1; next }
+{ if ($2 in installed) pub[$1] = 1; else priv[$1] = priv[$1] " " $2 }
+END {
+  for (s in priv) {
+    if (!(s in pub)) continue
+    n = split(priv[s], h, " ")
+    for (i = 1; i <= n; i++) print h[i] "\t" s
+  }
+}' "$work/installed" "$work/decls" | LC_ALL=C sort -u >"$work/actual"
+
+# Each survivor is an uninstalled header repeating a call httrack-library.h
+# already declares. Removing one is the point; adding one needs a reason.
+LC_ALL=C sort -u >"$work/expected" <<'EOF'
+htslib.h	hts_fopen_utf8
+htslib.h	hts_mkdir_utf8
+htslib.h	hts_rename_utf8
+htslib.h	hts_stat_utf8
+htslib.h	hts_unlink_utf8
+htslib.h	hts_utime_utf8
+htslib.h	hts_version
+htstools.h	hts_buildtopindex
+EOF
+
+diff -u "$work/expected" "$work/actual" ||
+    fail "an exported call must be declared in one header only. A '+' line is a new duplicate, so drop it from the uninstalled header and include httrack-library.h there instead. A '-' line is one you removed, so delete it from the list in this test"
+
+echo "exported declarations: $(lines_of "$work/decls"), shared with an uninstalled header: $(lines_of "$work/actual")"


### PR DESCRIPTION
The 3.50-2 release notes tell embedders about three calls, and `hts_set_thread_runner()` was not reachable. The symbol is exported, but its only declaration sat in `src/htsthread.h`, which no install carries, so a caller had to write the prototype by hand.

The declaration now lives in `src/httrack-library.h`, which is installed. Installing `htsthread.h` would drag `htswin32.h` in with it, and installing `htstools.h` would publish internal link types. The `hts_find*` family was already declared in both headers. This drops the copy in `htstools.h` and lets that header include the public one. No exported symbol is added or removed, so `VERSION_INFO` does not move.

The new test compiles and links a consumer against the installed headers alone. Without the change it fails with `error: unknown type name 'hts_thread_runner'`. `html/library.html` needs no edit, because the installed header list is unchanged.

Closes #1663
