### PR TITLE
Nothing tells a translator to be a native reader, or which files a new language needs

### DIFF
--- a/lang/README.md
+++ b/lang/README.md
@@ -2,6 +2,8 @@
 
 Interface strings live here, one `.txt` file per language. `English.txt` is the reference: every other file maps each English string to its translation.
 
+**Send a translation only into a language you read natively, and never send machine or LLM output.** Nobody here can check it, and a bad string is worse than the English it would replace.
+
 ## File format
 
 Plain text, entries in consecutive pairs of lines:
@@ -41,12 +43,15 @@ When new strings land in `English.txt` they show up untranslated (as English) un
 
 ## Adding a language
 
-A translator only has to send the catalog: copy `English.txt` to `<Language>.txt`, translate what you can, and fill in the `LANGUAGE_*` header. A partial file is worth sending, because missing entries fall back to English.
+A translator only has to send the catalog: copy `English.txt` to `<Language>.txt`, translate what you can, and fill in the `LANGUAGE_*` header. A partial file is worth sending. A maintainer does the rest.
 
-The maintainer then wires the file in, and the suite fails until all of this is done:
+## Wiring a new catalog into the build
+
+The suite fails until all of this is done:
 
 - `lang.def`: append the basename and the next `LANGUAGE_<N>`.
-- `lang.indexes`: append `<iso>:<N>` for that same N. webhttrack turns the caller's locale into that number, so a wrong one serves another catalog.
+- `lang.indexes`: append `<iso>:<N>` for that same N, with the code lowercased (`pt_br`). webhttrack turns the caller's locale into that number, so a wrong one serves another catalog.
 - `tests/62_lang-untranslated.counts` and `tests/62_lang-linebreaks.counts`: add one row to each.
 - `tests/install-manifest.txt`: add the installed `lang/<Language>.txt` path.
-- `greetings.txt`: add a row under `Translations` for the translator, keyed by the English name of the language. `AUTHORS` ends with that roster and the `<pre>` block in `html/contact.html` holds it verbatim, so both follow.
+- `greetings.txt`: add a row under `Translations` for the translator, keyed by the English name of the language. `AUTHORS` and `html/contact.html` repeat that roster, so the row goes into all three.
+- `tests/373_credits.test`: add a `LABEL` entry when `LANGUAGE_WINDOWSID` is not that English name (`Uzbek Latin`, `FYRO Macedonian`).

--- a/lang/README.md
+++ b/lang/README.md
@@ -28,15 +28,25 @@ A few `LANGUAGE_*` entries at the top describe the file itself:
 | Key | Meaning |
 | --- | --- |
 | `LANGUAGE_NAME` | Name shown in the language picker, in its own language (`Deutsch`, not `German`) |
+| `LANGUAGE_FILE` | The filename without `.txt`, in ASCII (`Portugues-Brasil`). It reaches the update endpoint as `Language=` |
 | `LANGUAGE_ISO` | ISO 639 code, with region if needed (`de`, `pt_BR`) |
 | `LANGUAGE_AUTHOR` | Your name and contact |
 | `LANGUAGE_WINDOWSID` | Windows locale name used by WinHTTrack (`German (Standard)`) |
 
-## Adding or updating a language
+## Updating a language
 
-1. Copy `English.txt` to `<Language>.txt`, or edit the existing file.
-2. Translate each second line; leave the English keys untouched.
-3. Fill in the `LANGUAGE_*` header for a new file.
-4. Open a pull request, or attach the file to a GitHub issue.
+Edit `<Language>.txt`: translate each second line and leave the English keys untouched. Then open a pull request, or attach the file to a GitHub issue.
 
 When new strings land in `English.txt` they show up untranslated (as English) until a translator fills them in.
+
+## Adding a language
+
+A translator only has to send the catalog: copy `English.txt` to `<Language>.txt`, translate what you can, and fill in the `LANGUAGE_*` header. A partial file is worth sending, because missing entries fall back to English.
+
+The maintainer then wires the file in, and the suite fails until all of this is done:
+
+- `lang.def`: append the basename and the next `LANGUAGE_<N>`.
+- `lang.indexes`: append `<iso>:<N>` for that same N. webhttrack turns the caller's locale into that number, so a wrong one serves another catalog.
+- `tests/62_lang-untranslated.counts` and `tests/62_lang-linebreaks.counts`: add one row to each.
+- `tests/install-manifest.txt`: add the installed `lang/<Language>.txt` path.
+- `greetings.txt`: add a row under `Translations` for the translator, keyed by the English name of the language. `AUTHORS` ends with that roster and the `<pre>` block in `html/contact.html` holds it verbatim, so both follow.


### PR DESCRIPTION
Two gaps in `lang/README.md`, both found while answering a forum request for a Thai translation.

It never states the rule that matters most. Only a native reader should send a translation, and never machine or LLM output, because nobody here can check one.

Its "Adding or updating a language" section is written for updating a catalog that already exists. Follow it for a new language and the PR fails tests 62, 225 and 373. Nothing told the contributor about `lang.def`, `lang.indexes`, the two per-catalog pins under `tests/`, `install-manifest.txt`, or the credits roster.

So the section is split by role. A translator sends one file, and the maintainer steps move under their own heading.

Checked by staging a 31st catalog and running the full suite. That turned up two traps, now written down. `lang.indexes` wants the ISO code lowercased, and `373_credits.test` needs a `LABEL` row when `LANGUAGE_WINDOWSID` is not the English name.
