### PR TITLE
windows-build.yml does not record that the MSYS suite leg was killing the runner

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -301,6 +301,8 @@ jobs:
       # third-party action: the three features are already enabled on the image.
       # It buys a real Linux shell against the same native httrack.exe, and is
       # the only suite leg since MSYS's fork emulation wedged its own (#1273).
+      # Dropping the MSYS leg also took the runner-death rate from 12.5% to
+      # 0.3%, so do not bring one back (#1228).
       - name: Bring up WSL2
         # Still non-gating now that the suite step gates: a failed import
         # reaches that step, which names it and reds there. Failing here too


### PR DESCRIPTION
The MSYS test-suite leg was killing the hosted runner. Removing it in #1585 took the Windows runner-death rate from 12.5% to 0.3% over 1515 jobs. `windows-build.yml` records only that MSYS wedged, so nothing there warns the next person off adding a leg back. The measurement is on #1228.