### PR TITLE
Test 250 reads an exited process as still running on GNU/Hurd

### DIFF
--- a/tests/250_timeout-poll-nofork.test
+++ b/tests/250_timeout-poll-nofork.test
@@ -106,12 +106,16 @@ fi
 # fact. Pids no host allocates, so a seam that failed open would be graded
 # against a live kernel thread rather than against the fixture.
 unreadable=9999991 running=9999992 exited=9999993
-unterminated=9999994 denied=9999995 absent=9999996
+unterminated=9999994 denied=9999995 absent=9999996 splitcomm=9999997
 mkdir -p "$tmp/proc/$unreadable/stat" "$tmp/proc/$running" "$tmp/proc/$exited" \
-    "$tmp/proc/$unterminated" "$tmp/proc/$denied" "$tmp/proc/$absent" "$tmp/proc/$$"
+    "$tmp/proc/$unterminated" "$tmp/proc/$denied" "$tmp/proc/$absent" \
+    "$tmp/proc/$splitcomm" "$tmp/proc/$$"
 printf '%s (sh (weird) name) S 1 1 1 0 -1 0\n' "$running" >"$tmp/proc/$running/stat"
 printf '%s (sh (weird) name) Z 1 1 1 0 -1 0\n' "$exited" >"$tmp/proc/$exited/stat"
 printf '%s (sh) R 1 1 1 0 -1 0' "$unterminated" >"$tmp/proc/$unterminated/stat"
+# Linux writes comm unescaped, so a process named ") Z<LF>q" splits its own stat
+# file and the first line ends in a state this one is not.
+printf '%s () Z\nq) S 1 1 1 0 -1 0\n' "$splitcomm" >"$tmp/proc/$splitcomm/stat"
 printf 'x\n' >"$tmp/proc/$denied/stat"
 chmod 000 "$tmp/proc/$denied/stat"
 # Empty rather than absent, the shape a container's masked stat file has.
@@ -124,7 +128,12 @@ pid_is_zombie "$unreadable" || fail "a stat file that cannot be read was read as
 pid_is_zombie "$running" && fail "a stat line naming state S was read as exited"
 pid_is_zombie "$exited" || fail "a stat line naming state Z was read as running"
 pid_is_zombie "$unterminated" && fail "a stat line with no trailing newline was read as exited"
+pid_is_zombie "$splitcomm" && fail "a process name holding a newline forged state Z"
 pid_is_zombie "$absent" && fail "a pid with no stat entry was read as exited"
+# The pair the arm rests on: a read that errors is an exit, a read that returns
+# nothing is not. Hurd's procfs never yields the second for a live process, but
+# nothing in the arm should need that to be true.
+pid_is_zombie "$$" && fail "an empty stat file was read as exited on Hurd"
 # Root reads a mode 000 file, so only an unprivileged run can tell -r from -e.
 if test "$(id -u)" != 0; then
     pid_is_zombie "$denied" && fail "a stat file the caller may not open was read as exited"

--- a/tests/250_timeout-poll-nofork.test
+++ b/tests/250_timeout-poll-nofork.test
@@ -84,10 +84,10 @@ test -n "$zombie" || fail "the zombie fixture never started"
 # Graded only where the host will answer for this very pid: with neither /proc nor
 # ps, reap_bounded degrades to the wait it always did and there is nothing here to
 # grade, so asserting would red a host master passes.
+kill -9 "$zombie" 2>/dev/null || true
 if ! pid_state_readable "$zombie"; then
     echo "no readable state for pid $zombie, so the reap probe cannot be graded" >&2
 else
-    kill -9 "$zombie" 2>/dev/null || true
     REAP_GRACE=1 reap_bounded "$zombie" ||
         fail "reap_bounded waited out its grace on a killed process nobody had collected"
     # Named, not assumed: a parent that had already exited would make the arm below
@@ -98,24 +98,55 @@ else
 fi
 : >"$tmp/release"
 
-# --- pid_is_zombie where /proc answers with an error ------------------------
+# --- pid_is_zombie against a proc entry it cannot read ----------------------
 #
-# Hurd builds /proc/PID/stat out of the Mach task and threads that an exited
-# process no longer has, so the read fails instead of reporting Z, and its ps
-# takes no -p to fall back on. Both Hurd buildds failed 3.50.2 on that. A
-# directory stands in for it: readable by permission, unreadable in fact.
-mkdir -p "$tmp/proc/11/stat" "$tmp/proc/12" "$tmp/proc/13"
-printf '12 (sh (weird) name) S 1 12 12 0 -1 0\n' >"$tmp/proc/12/stat"
-printf '13 (sh (weird) name) Z 1 13 13 0 -1 0\n' >"$tmp/proc/13/stat"
+# Hurd builds /proc/PID/stat out of a Mach task an exited process no longer has,
+# so the read errors where Linux answers Z, and its ps takes no -p to fall back
+# on. A directory stands in for that file: readable by permission, unreadable in
+# fact. Pids no host allocates, so a seam that failed open would be graded
+# against a live kernel thread rather than against the fixture.
+unreadable=9999991 running=9999992 exited=9999993
+unterminated=9999994 denied=9999995 absent=9999996
+mkdir -p "$tmp/proc/$unreadable/stat" "$tmp/proc/$running" "$tmp/proc/$exited" \
+    "$tmp/proc/$unterminated" "$tmp/proc/$denied" "$tmp/proc/$absent" "$tmp/proc/$$"
+printf '%s (sh (weird) name) S 1 1 1 0 -1 0\n' "$running" >"$tmp/proc/$running/stat"
+printf '%s (sh (weird) name) Z 1 1 1 0 -1 0\n' "$exited" >"$tmp/proc/$exited/stat"
+printf '%s (sh) R 1 1 1 0 -1 0' "$unterminated" >"$tmp/proc/$unterminated/stat"
+printf 'x\n' >"$tmp/proc/$denied/stat"
+chmod 000 "$tmp/proc/$denied/stat"
+# Empty rather than absent, the shape a container's masked stat file has.
+: >"$tmp/proc/$$/stat"
+
 TESTLIB_PROC=$tmp/proc
-pid_is_zombie 11 || fail "a stat file that cannot be read was read as running"
-pid_is_zombie 12 && fail "a stat line naming state S was read as exited"
-pid_is_zombie 13 || fail "a stat line naming state Z was read as running"
-# No entry at all is the host with no readable /proc, and must reach ps rather
-# than the arm above: this shell is alive and is what ps will be asked about.
-pid_is_zombie "$$" && fail "a pid with no stat entry was read as exited"
+hts_os_was=$HTS_OS
+HTS_OS=GNU
+pid_is_zombie "$unreadable" || fail "a stat file that cannot be read was read as running"
+pid_is_zombie "$running" && fail "a stat line naming state S was read as exited"
+pid_is_zombie "$exited" || fail "a stat line naming state Z was read as running"
+pid_is_zombie "$unterminated" && fail "a stat line with no trailing newline was read as exited"
+pid_is_zombie "$absent" && fail "a pid with no stat entry was read as exited"
+# Root reads a mode 000 file, so only an unprivileged run can tell -r from -e.
+if test "$(id -u)" != 0; then
+    pid_is_zombie "$denied" && fail "a stat file the caller may not open was read as exited"
+fi
+HTS_OS=Linux
+pid_is_zombie "$unreadable" && fail "the arm for Hurd's procfs fired off Hurd"
+# This shell is alive, so nothing may read its empty stat file as an exit.
+pid_is_zombie "$$" && fail "an empty stat file was read as an exited process"
+HTS_OS=$hts_os_was
+# The route macOS takes, which no host with a working /proc ever reaches. Padded,
+# since a column with spaces around it used to read as neither state.
+mkdir -p "$tmp/psstub"
+printf '#!/bin/sh\necho " Z "\n' >"$tmp/psstub/ps"
+chmod +x "$tmp/psstub/ps"
+path_was=$PATH
+PATH=$tmp/psstub:$PATH
+pid_is_zombie "$absent" || fail "a ps column naming state Z was read as running"
+PATH=$path_was
+pid_state_readable "$running" || fail "a readable stat file was called unreadable"
+pid_state_readable "$absent" && fail "a pid with no stat entry was called readable"
 unset TESTLIB_PROC
-ok "pid_is_zombie reads an unreadable stat file as an exited process"
+ok "pid_is_zombie reads an unreadable stat entry as exited on Hurd, and a live process never"
 
 : >"$tmp/progress"
 : >"$tmp/childpid"

--- a/tests/250_timeout-poll-nofork.test
+++ b/tests/250_timeout-poll-nofork.test
@@ -98,61 +98,65 @@ else
 fi
 : >"$tmp/release"
 
-# --- pid_is_zombie against a proc entry it cannot read ----------------------
+# --- pid_state: what each route answers, and what neither may invent ---------
 #
-# A directory stands in for Hurd's failing read: readable, but no read succeeds.
+# A directory stands in for an entry that is readable but yields nothing, which
+# is what Hurd gives for a task it cannot summarise. That must never count as
+# death: Hurd answers the same way for a live task that is merely suspended.
 # The pids are ones no host allocates, so a seam that failed open would grade a
 # live kernel thread instead of the fixture.
-unreadable=9999991 running=9999992 exited=9999993
-unterminated=9999994 denied=9999995 absent=9999996 splitcomm=9999997
-empty_live=$$
-mkdir -p "$tmp/proc/$unreadable/stat" "$tmp/proc/$running" "$tmp/proc/$exited" \
-    "$tmp/proc/$unterminated" "$tmp/proc/$denied" "$tmp/proc/$absent" \
-    "$tmp/proc/$splitcomm" "$tmp/proc/$empty_live"
+running=9999992 exited=9999993 unterminated=9999994
+absent=9999996 splitcomm=9999997 unreadable_live=$$
+mkdir -p "$tmp/proc/$running" "$tmp/proc/$exited" "$tmp/proc/$unterminated" \
+    "$tmp/proc/$absent" "$tmp/proc/$splitcomm" "$tmp/proc/$unreadable_live/stat"
 printf '%s (sh (weird) name) S 1 1 1 0 -1 0\n' "$running" >"$tmp/proc/$running/stat"
 printf '%s (sh (weird) name) Z 1 1 1 0 -1 0\n' "$exited" >"$tmp/proc/$exited/stat"
-printf '%s (sh) R 1 1 1 0 -1 0' "$unterminated" >"$tmp/proc/$unterminated/stat"
+printf '%s (sh) Z 1 1 1 0 -1 0' "$unterminated" >"$tmp/proc/$unterminated/stat"
 # Linux writes comm unescaped, so a process named ") Z<LF>q" splits its own stat
 # file and the first line ends in a state this one is not.
 printf '%s () Z\nq) S 1 1 1 0 -1 0\n' "$splitcomm" >"$tmp/proc/$splitcomm/stat"
-printf 'x\n' >"$tmp/proc/$denied/stat"
-chmod 000 "$tmp/proc/$denied/stat"
-# Empty rather than absent, the shape a container's masked stat file has.
-: >"$tmp/proc/$empty_live/stat"
 
 TESTLIB_PROC=$tmp/proc
-hts_os_was=$HTS_OS
-HTS_OS=GNU
-pid_is_zombie "$unreadable" || fail "a stat file that cannot be read was read as running"
 pid_is_zombie "$running" && fail "a stat line naming state S was read as exited"
 pid_is_zombie "$exited" || fail "a stat line naming state Z was read as running"
-pid_is_zombie "$unterminated" && fail "a stat line with no trailing newline was read as exited"
+pid_is_zombie "$unterminated" || fail "a stat line with no trailing newline was read as running"
 pid_is_zombie "$splitcomm" && fail "a process name holding a newline forged state Z"
-pid_is_zombie "$absent" && fail "a pid with no stat entry was read as exited"
-# Root reads a mode 000 file, so only an unprivileged run grades -r against -e.
-pid_is_zombie "$denied" && fail "a stat file the caller may not open was read as exited"
-HTS_OS=Linux
-pid_is_zombie "$unreadable" && fail "the arm for Hurd's procfs fired off Hurd"
-# This shell is alive, so nothing may read its empty stat file as an exit.
-pid_is_zombie "$empty_live" && fail "an empty stat file was read as an exited process"
+# The one the arm this test used to carry got wrong: an entry that answers
+# nothing says nothing, and this shell is running.
+pid_is_zombie "$unreadable_live" && fail "an entry that yields nothing was read as an exit"
+pid_state_readable "$running" || fail "a stat line the host gave was called unreadable"
+pid_state_readable "$unreadable_live" ||
+    fail "ps did not answer for this shell when its stat entry gave nothing"
 # A failed open must stay off the caller's stderr: every macOS poll takes this
 # route, and local_crawl points that stderr at the log its tests grep.
 noise=$(pid_is_zombie "$absent" 2>&1 >/dev/null) || true
 test -z "$noise" || fail "a failed open reached the caller's stderr: $noise"
-HTS_OS=$hts_os_was
-# The route macOS takes, which no host with a working /proc ever reaches. Padded,
-# since a column with spaces around it used to read as neither state.
-mkdir -p "$tmp/psstub"
-printf '#!/bin/sh\necho " Z "\n' >"$tmp/psstub/ps"
-chmod +x "$tmp/psstub/ps"
+
+# The ps route, which no host with a working /proc reaches. Padded, since a
+# column with spaces around it used to read as neither state. Two stubs, because
+# Hurd's ps rejects -p and takes the pid positionally.
+mkdir -p "$tmp/psposix" "$tmp/pshurd"
+cat >"$tmp/psposix/ps" <<'STUB'
+#!/bin/sh
+echo " Z "
+STUB
+cat >"$tmp/pshurd/ps" <<'STUB'
+#!/bin/sh
+for a; do test "$a" != -p || exit 64; done
+echo " Z "
+STUB
+chmod +x "$tmp/psposix/ps" "$tmp/pshurd/ps"
 path_was=$PATH
-PATH=$tmp/psstub:$PATH
-pid_is_zombie "$absent" || fail "a ps column naming state Z was read as running"
+for stub in psposix pshurd; do
+    PATH=$tmp/$stub:$path_was
+    pid_is_zombie "$absent" || fail "$stub ps named state Z and it was read as running"
+    pid_state_readable "$absent" ||
+        fail "$stub ps answered, but a pid with no stat entry was called unreadable"
+done
 PATH=$path_was
-pid_state_readable "$running" || fail "a readable stat file was called unreadable"
-pid_state_readable "$absent" && fail "a pid with no stat entry was called readable"
+pid_state_readable "$absent" && fail "a pid neither route answers for was called readable"
 unset TESTLIB_PROC
-ok "pid_is_zombie reads an unreadable stat entry as exited on Hurd, and nowhere else"
+ok "pid_state takes the host's answer, and reads no answer as an exit"
 
 : >"$tmp/progress"
 : >"$tmp/childpid"

--- a/tests/250_timeout-poll-nofork.test
+++ b/tests/250_timeout-poll-nofork.test
@@ -136,7 +136,7 @@ test -z "$noise" || fail "a failed open reached the caller's stderr: $noise"
 # The ps route, which no host with a working /proc reaches. Padded, since a
 # column with spaces around it used to read as neither state. Two stubs, because
 # Hurd's ps rejects -p and takes the pid positionally.
-mkdir -p "$tmp/psposix" "$tmp/pshurd" "$tmp/psnone"
+mkdir -p "$tmp/psposix" "$tmp/pshurd" "$tmp/psnone" "$tmp/psmulti"
 cat >"$tmp/psposix/ps" <<'STUB'
 #!/bin/sh
 for a; do test "$a" != -p || { echo " Z+ "; exit 0; }; done
@@ -147,12 +147,22 @@ cat >"$tmp/pshurd/ps" <<'STUB'
 for a; do test "$a" != -p || exit 64; done
 echo " Z+ "
 STUB
-chmod +x "$tmp/psposix/ps" "$tmp/pshurd/ps"
+# Two rows, which is what a ps that ignored the empty header would print. The
+# first names a state, and it is not this pid's.
+cat >"$tmp/psmulti/ps" <<'STUB'
+#!/bin/sh
+printf 'Z\nR\n'
+STUB
+chmod +x "$tmp/psposix/ps" "$tmp/pshurd/ps" "$tmp/psmulti/ps"
 path_was=$PATH
 for stub in psposix pshurd; do
     PATH=$tmp/$stub:$path_was
     pid_is_zombie "$absent" || fail "$stub ps named state Z and it was read as running"
 done
+PATH=$tmp/psmulti:$path_was
+pid_is_zombie "$unreadable_live" && fail "two ps rows were concatenated into an exit"
+pid_state_readable "$unreadable_live" && fail "an answer naming two pids was called readable"
+PATH=$path_was
 # A build root with no ps at all, which Fedora's is: neither route answers, so
 # the helper must say so rather than guess.
 # shellcheck disable=SC2123 # a PATH holding one empty directory is how ps goes missing

--- a/tests/250_timeout-poll-nofork.test
+++ b/tests/250_timeout-poll-nofork.test
@@ -108,7 +108,7 @@ fi
 running=9999992 exited=9999993 unterminated=9999994
 absent=9999996 splitcomm=9999997 unreadable_live=$$
 mkdir -p "$tmp/proc/$running" "$tmp/proc/$exited" "$tmp/proc/$unterminated" \
-    "$tmp/proc/$absent" "$tmp/proc/$splitcomm" "$tmp/proc/$unreadable_live/stat"
+    "$tmp/proc/$splitcomm" "$tmp/proc/$unreadable_live/stat"
 printf '%s (sh (weird) name) S 1 1 1 0 -1 0\n' "$running" >"$tmp/proc/$running/stat"
 printf '%s (sh (weird) name) Z 1 1 1 0 -1 0\n' "$exited" >"$tmp/proc/$exited/stat"
 printf '%s (sh) Z 1 1 1 0 -1 0' "$unterminated" >"$tmp/proc/$unterminated/stat"
@@ -117,6 +117,9 @@ printf '%s (sh) Z 1 1 1 0 -1 0' "$unterminated" >"$tmp/proc/$unterminated/stat"
 printf '%s () Z\nq) S 1 1 1 0 -1 0\n' "$splitcomm" >"$tmp/proc/$splitcomm/stat"
 
 TESTLIB_PROC=$tmp/proc
+# Called as a statement, not a condition, so errexit sees the read's own status.
+pid_state "$running"
+test "$PID_STATE" = S || fail "the state field was read as '$PID_STATE', not S"
 pid_is_zombie "$running" && fail "a stat line naming state S was read as exited"
 pid_is_zombie "$exited" || fail "a stat line naming state Z was read as running"
 pid_is_zombie "$unterminated" || fail "a stat line with no trailing newline was read as running"
@@ -125,8 +128,6 @@ pid_is_zombie "$splitcomm" && fail "a process name holding a newline forged stat
 # nothing says nothing, and this shell is running.
 pid_is_zombie "$unreadable_live" && fail "an entry that yields nothing was read as an exit"
 pid_state_readable "$running" || fail "a stat line the host gave was called unreadable"
-pid_state_readable "$unreadable_live" ||
-    fail "ps did not answer for this shell when its stat entry gave nothing"
 # A failed open must stay off the caller's stderr: every macOS poll takes this
 # route, and local_crawl points that stderr at the log its tests grep.
 noise=$(pid_is_zombie "$absent" 2>&1 >/dev/null) || true
@@ -135,28 +136,36 @@ test -z "$noise" || fail "a failed open reached the caller's stderr: $noise"
 # The ps route, which no host with a working /proc reaches. Padded, since a
 # column with spaces around it used to read as neither state. Two stubs, because
 # Hurd's ps rejects -p and takes the pid positionally.
-mkdir -p "$tmp/psposix" "$tmp/pshurd"
+mkdir -p "$tmp/psposix" "$tmp/pshurd" "$tmp/psnone"
 cat >"$tmp/psposix/ps" <<'STUB'
 #!/bin/sh
-echo " Z "
+for a; do test "$a" != -p || { echo " Z+ "; exit 0; }; done
+exit 64
 STUB
 cat >"$tmp/pshurd/ps" <<'STUB'
 #!/bin/sh
 for a; do test "$a" != -p || exit 64; done
-echo " Z "
+echo " Z+ "
 STUB
 chmod +x "$tmp/psposix/ps" "$tmp/pshurd/ps"
 path_was=$PATH
 for stub in psposix pshurd; do
     PATH=$tmp/$stub:$path_was
     pid_is_zombie "$absent" || fail "$stub ps named state Z and it was read as running"
-    pid_state_readable "$absent" ||
-        fail "$stub ps answered, but a pid with no stat entry was called unreadable"
 done
+# A build root with no ps at all, which Fedora's is: neither route answers, so
+# the helper must say so rather than guess.
+# shellcheck disable=SC2123 # a PATH holding one empty directory is how ps goes missing
+PATH=$tmp/psnone
+pid_is_zombie "$unreadable_live" && nops_exit=yes || nops_exit=no
+pid_state_readable "$unreadable_live" && nops_read=yes || nops_read=no
+PATH=$path_was
+test "$nops_exit" = no || fail "a live process was read as exited where no ps exists"
+test "$nops_read" = no || fail "a live process with no answer anywhere was called readable"
 PATH=$path_was
 pid_state_readable "$absent" && fail "a pid neither route answers for was called readable"
 unset TESTLIB_PROC
-ok "pid_state takes the host's answer, and reads no answer as an exit"
+ok "pid_state takes the host's answer, and never reads no answer as an exit"
 
 : >"$tmp/progress"
 : >"$tmp/childpid"

--- a/tests/250_timeout-poll-nofork.test
+++ b/tests/250_timeout-poll-nofork.test
@@ -172,7 +172,6 @@ pid_state_readable "$unreadable_live" && nops_read=yes || nops_read=no
 PATH=$path_was
 test "$nops_exit" = no || fail "a live process was read as exited where no ps exists"
 test "$nops_read" = no || fail "a live process with no answer anywhere was called readable"
-PATH=$path_was
 pid_state_readable "$absent" && fail "a pid neither route answers for was called readable"
 unset TESTLIB_PROC
 ok "pid_state takes the host's answer, and never reads no answer as an exit"

--- a/tests/250_timeout-poll-nofork.test
+++ b/tests/250_timeout-poll-nofork.test
@@ -100,16 +100,15 @@ fi
 
 # --- pid_is_zombie against a proc entry it cannot read ----------------------
 #
-# Hurd builds /proc/PID/stat out of a Mach task an exited process no longer has,
-# so the read errors where Linux answers Z, and its ps takes no -p to fall back
-# on. A directory stands in for that file: readable by permission, unreadable in
-# fact. Pids no host allocates, so a seam that failed open would be graded
-# against a live kernel thread rather than against the fixture.
+# A directory stands in for Hurd's failing read: readable, but no read succeeds.
+# The pids are ones no host allocates, so a seam that failed open would grade a
+# live kernel thread instead of the fixture.
 unreadable=9999991 running=9999992 exited=9999993
 unterminated=9999994 denied=9999995 absent=9999996 splitcomm=9999997
+empty_live=$$
 mkdir -p "$tmp/proc/$unreadable/stat" "$tmp/proc/$running" "$tmp/proc/$exited" \
     "$tmp/proc/$unterminated" "$tmp/proc/$denied" "$tmp/proc/$absent" \
-    "$tmp/proc/$splitcomm" "$tmp/proc/$$"
+    "$tmp/proc/$splitcomm" "$tmp/proc/$empty_live"
 printf '%s (sh (weird) name) S 1 1 1 0 -1 0\n' "$running" >"$tmp/proc/$running/stat"
 printf '%s (sh (weird) name) Z 1 1 1 0 -1 0\n' "$exited" >"$tmp/proc/$exited/stat"
 printf '%s (sh) R 1 1 1 0 -1 0' "$unterminated" >"$tmp/proc/$unterminated/stat"
@@ -119,7 +118,7 @@ printf '%s () Z\nq) S 1 1 1 0 -1 0\n' "$splitcomm" >"$tmp/proc/$splitcomm/stat"
 printf 'x\n' >"$tmp/proc/$denied/stat"
 chmod 000 "$tmp/proc/$denied/stat"
 # Empty rather than absent, the shape a container's masked stat file has.
-: >"$tmp/proc/$$/stat"
+: >"$tmp/proc/$empty_live/stat"
 
 TESTLIB_PROC=$tmp/proc
 hts_os_was=$HTS_OS
@@ -130,18 +129,16 @@ pid_is_zombie "$exited" || fail "a stat line naming state Z was read as running"
 pid_is_zombie "$unterminated" && fail "a stat line with no trailing newline was read as exited"
 pid_is_zombie "$splitcomm" && fail "a process name holding a newline forged state Z"
 pid_is_zombie "$absent" && fail "a pid with no stat entry was read as exited"
-# The pair the arm rests on: a read that errors is an exit, a read that returns
-# nothing is not. Hurd's procfs never yields the second for a live process, but
-# nothing in the arm should need that to be true.
-pid_is_zombie "$$" && fail "an empty stat file was read as exited on Hurd"
-# Root reads a mode 000 file, so only an unprivileged run can tell -r from -e.
-if test "$(id -u)" != 0; then
-    pid_is_zombie "$denied" && fail "a stat file the caller may not open was read as exited"
-fi
+# Root reads a mode 000 file, so only an unprivileged run grades -r against -e.
+pid_is_zombie "$denied" && fail "a stat file the caller may not open was read as exited"
 HTS_OS=Linux
 pid_is_zombie "$unreadable" && fail "the arm for Hurd's procfs fired off Hurd"
 # This shell is alive, so nothing may read its empty stat file as an exit.
-pid_is_zombie "$$" && fail "an empty stat file was read as an exited process"
+pid_is_zombie "$empty_live" && fail "an empty stat file was read as an exited process"
+# A failed open must stay off the caller's stderr: every macOS poll takes this
+# route, and local_crawl points that stderr at the log its tests grep.
+noise=$(pid_is_zombie "$absent" 2>&1 >/dev/null) || true
+test -z "$noise" || fail "a failed open reached the caller's stderr: $noise"
 HTS_OS=$hts_os_was
 # The route macOS takes, which no host with a working /proc ever reaches. Padded,
 # since a column with spaces around it used to read as neither state.
@@ -155,7 +152,7 @@ PATH=$path_was
 pid_state_readable "$running" || fail "a readable stat file was called unreadable"
 pid_state_readable "$absent" && fail "a pid with no stat entry was called readable"
 unset TESTLIB_PROC
-ok "pid_is_zombie reads an unreadable stat entry as exited on Hurd, and a live process never"
+ok "pid_is_zombie reads an unreadable stat entry as exited on Hurd, and nowhere else"
 
 : >"$tmp/progress"
 : >"$tmp/childpid"

--- a/tests/250_timeout-poll-nofork.test
+++ b/tests/250_timeout-poll-nofork.test
@@ -98,6 +98,25 @@ else
 fi
 : >"$tmp/release"
 
+# --- pid_is_zombie where /proc answers with an error ------------------------
+#
+# Hurd builds /proc/PID/stat out of the Mach task and threads that an exited
+# process no longer has, so the read fails instead of reporting Z, and its ps
+# takes no -p to fall back on. Both Hurd buildds failed 3.50.2 on that. A
+# directory stands in for it: readable by permission, unreadable in fact.
+mkdir -p "$tmp/proc/11/stat" "$tmp/proc/12" "$tmp/proc/13"
+printf '12 (sh (weird) name) S 1 12 12 0 -1 0\n' >"$tmp/proc/12/stat"
+printf '13 (sh (weird) name) Z 1 13 13 0 -1 0\n' >"$tmp/proc/13/stat"
+TESTLIB_PROC=$tmp/proc
+pid_is_zombie 11 || fail "a stat file that cannot be read was read as running"
+pid_is_zombie 12 && fail "a stat line naming state S was read as exited"
+pid_is_zombie 13 || fail "a stat line naming state Z was read as running"
+# No entry at all is the host with no readable /proc, and must reach ps rather
+# than the arm above: this shell is alive and is what ps will be asked about.
+pid_is_zombie "$$" && fail "a pid with no stat entry was read as exited"
+unset TESTLIB_PROC
+ok "pid_is_zombie reads an unreadable stat file as an exited process"
+
 : >"$tmp/progress"
 : >"$tmp/childpid"
 began=$SECONDS

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -1248,19 +1248,16 @@ REAP_GRACE=${REAP_GRACE:-10}
 # padded column would read as neither state.
 pid_is_zombie() { # pid_is_zombie PID
     local proc=${TESTLIB_PROC:-/proc} st=''
-    # The whole file, since Linux writes comm unescaped and a process whose name
-    # holds a newline splits it. Reading one line off `sleep) Z<LF>q` yielded Z
-    # for a live process. -d '' also returns non-zero at end of file, so the line
-    # is what is graded, never read's status.
-    read -r -d '' st <"$proc/$1/stat" 2>/dev/null
+    # The whole file and the line it gave, never read's status: comm is unescaped,
+    # so a name holding a newline splits the file, and -d '' returns non-zero at
+    # end of file anyway. The group keeps a failed open off the caller's stderr.
+    { read -r -d '' st <"$proc/$1/stat"; } 2>/dev/null
     if test -n "$st"; then
         st=${st##*') '}
         st=${st%% *}
-    elif test "$HTS_OS" = GNU && test -r "$proc/$1/stat" &&
-        ! cat "$proc/$1/stat" >/dev/null 2>&1; then
-        # Hurd builds this file out of a Mach task an exited process no longer
-        # has, so the read errors where Linux answers Z. cat, because the arm
-        # needs the read to have failed, and an empty file reads fine.
+    elif test "$HTS_OS" = GNU && test -r "$proc/$1/stat"; then
+        # Only Hurd, whose procfs builds this out of a Mach task an exited
+        # process no longer has, so the read fails where Linux answers Z.
         return 0
     else
         st=$(ps -o state= -p "$1" 2>/dev/null) || st=

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -1248,7 +1248,9 @@ pid_state() { # pid_state PID
     # The whole file and the line it gave, never read's status: comm is unescaped,
     # so a name holding a newline splits the file, and -d '' returns non-zero at
     # end of file anyway. The group keeps a failed open off the caller's stderr.
-    { read -r -d '' st <"$proc/$1/stat"; } 2>/dev/null
+    # || true, because -d '' returns non-zero at end of file on a whole file it
+    # read, and a caller writing this as a statement would abort under errexit.
+    { read -r -d '' st <"$proc/$1/stat"; } 2>/dev/null || true
     if test -n "$st"; then
         st=${st##*') '}
         PID_STATE=${st%% *}

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -1240,21 +1240,23 @@ REAP_GRACE=${REAP_GRACE:-10}
 # until a parent waits on it, and a caller that is not that parent never can: the
 # reap falls to whoever inherits the orphan, prompt on a workstation and not on a
 # Debian buildd, where it reddened 250 twice. The state is the honest question.
-# /proc first, and only then ps: reap_bounded polls this, and one caller polls it
-# with the broken tick of #1038 still on PATH, where the loop spins at full speed
-# and a forked ps would run thousands of times. Linux, which is where the failure
-# is reported, then forks nothing; macOS takes the ps route, whose POSIX keyword
-# is what ps_snapshot already relies on. Trimmed, since a padded column would
-# read as neither state.
+# /proc first, then Hurd, and only then ps: reap_bounded polls this, and one
+# caller polls it with the broken tick of #1038 still on PATH, where the loop
+# spins at full speed and a forked ps would run thousands of times. Linux, which
+# is where the failure is reported, then forks nothing; macOS takes the ps route,
+# whose POSIX keyword is what ps_snapshot already relies on. Trimmed, since a
+# padded column would read as neither state.
 pid_is_zombie() { # pid_is_zombie PID
-    local proc=${TESTLIB_PROC:-/proc} st
-    if { read -r st <"$proc/$1/stat"; } 2>/dev/null; then
+    local proc=${TESTLIB_PROC:-/proc} st=''
+    # Graded on the line, not on read's status, which is non-zero at a stat file
+    # with no trailing newline on a line it took in full.
+    read -r st <"$proc/$1/stat" 2>/dev/null
+    if test -n "$st"; then
         st=${st##*') '}
         st=${st%% *}
-    elif test -r "$proc/$1/stat"; then
-        # Hurd builds this file out of the Mach task and threads that an exited
-        # process no longer has, so the read fails where Linux answers Z. It is
-        # not permission that denied it, so the process has stopped running.
+    elif test "$HTS_OS" = GNU && test -r "$proc/$1/stat"; then
+        # Hurd builds this file out of a Mach task an exited process no longer
+        # has, so the read errors where Linux answers Z.
         return 0
     else
         st=$(ps -o state= -p "$1" 2>/dev/null) || st=

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -1247,10 +1247,15 @@ REAP_GRACE=${REAP_GRACE:-10}
 # is what ps_snapshot already relies on. Trimmed, since a padded column would
 # read as neither state.
 pid_is_zombie() { # pid_is_zombie PID
-    local st
-    if { read -r st <"/proc/$1/stat"; } 2>/dev/null; then
+    local proc=${TESTLIB_PROC:-/proc} st
+    if { read -r st <"$proc/$1/stat"; } 2>/dev/null; then
         st=${st##*') '}
         st=${st%% *}
+    elif test -r "$proc/$1/stat"; then
+        # Hurd builds this file out of the Mach task and threads that an exited
+        # process no longer has, so the read fails where Linux answers Z. It is
+        # not permission that denied it, so the process has stopped running.
+        return 0
     else
         st=$(ps -o state= -p "$1" 2>/dev/null) || st=
         st=${st//[[:space:]]/}
@@ -1265,7 +1270,8 @@ pid_is_zombie() { # pid_is_zombie PID
 # may have no procps, and a container or a hidepid mount no readable /proc. Asked
 # per pid, since hidepid answers for the caller's own and for nothing else.
 pid_state_readable() { # pid_state_readable PID
-    test -r "/proc/$1/stat" || test -n "$(ps -o state= -p "$1" 2>/dev/null)"
+    test -r "${TESTLIB_PROC:-/proc}/$1/stat" ||
+        test -n "$(ps -o state= -p "$1" 2>/dev/null)"
 }
 
 reap_bounded() {

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -1248,15 +1248,19 @@ REAP_GRACE=${REAP_GRACE:-10}
 # padded column would read as neither state.
 pid_is_zombie() { # pid_is_zombie PID
     local proc=${TESTLIB_PROC:-/proc} st=''
-    # Graded on the line, not on read's status, which is non-zero at a stat file
-    # with no trailing newline on a line it took in full.
-    read -r st <"$proc/$1/stat" 2>/dev/null
+    # The whole file, since Linux writes comm unescaped and a process whose name
+    # holds a newline splits it. Reading one line off `sleep) Z<LF>q` yielded Z
+    # for a live process. -d '' also returns non-zero at end of file, so the line
+    # is what is graded, never read's status.
+    read -r -d '' st <"$proc/$1/stat" 2>/dev/null
     if test -n "$st"; then
         st=${st##*') '}
         st=${st%% *}
-    elif test "$HTS_OS" = GNU && test -r "$proc/$1/stat"; then
+    elif test "$HTS_OS" = GNU && test -r "$proc/$1/stat" &&
+        ! cat "$proc/$1/stat" >/dev/null 2>&1; then
         # Hurd builds this file out of a Mach task an exited process no longer
-        # has, so the read errors where Linux answers Z.
+        # has, so the read errors where Linux answers Z. cat, because the arm
+        # needs the read to have failed, and an empty file reads fine.
         return 0
     else
         st=$(ps -o state= -p "$1" 2>/dev/null) || st=

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -1236,17 +1236,14 @@ budget_left() {
 # about to report is never printed and the whole suite wedges silently.
 REAP_GRACE=${REAP_GRACE:-10}
 
-# Has pid $1 died and not yet been collected? A killed process answers kill -0
-# until a parent waits on it, and a caller that is not that parent never can: the
-# reap falls to whoever inherits the orphan, prompt on a workstation and not on a
-# Debian buildd, where it reddened 250 twice. The state is the honest question.
-# /proc first, then Hurd, and only then ps: reap_bounded polls this, and one
-# caller polls it with the broken tick of #1038 still on PATH, where the loop
-# spins at full speed and a forked ps would run thousands of times. Linux, which
-# is where the failure is reported, then forks nothing; macOS takes the ps route,
-# whose POSIX keyword is what ps_snapshot already relies on. Trimmed, since a
-# padded column would read as neither state.
-pid_is_zombie() { # pid_is_zombie PID
+# The state letter for pid $1, in PID_STATE, empty when this host will not say.
+# Set through a global rather than returned, since a command substitution forks
+# and reap_bounded polls this with the broken tick of #1038 still on PATH, where
+# the loop spins at full speed. /proc first for the same reason: Linux forks
+# nothing here, and macOS takes the ps route, whose POSIX keyword ps_snapshot
+# already relies on. Never infer the state from a failed read: Hurd returns EIO
+# for a live task that is merely suspended, so absence of an answer is not death.
+pid_state() { # pid_state PID
     local proc=${TESTLIB_PROC:-/proc} st=''
     # The whole file and the line it gave, never read's status: comm is unescaped,
     # so a name holding a newline splits the file, and -d '' returns non-zero at
@@ -1254,27 +1251,33 @@ pid_is_zombie() { # pid_is_zombie PID
     { read -r -d '' st <"$proc/$1/stat"; } 2>/dev/null
     if test -n "$st"; then
         st=${st##*') '}
-        st=${st%% *}
-    elif test "$HTS_OS" = GNU && test -r "$proc/$1/stat"; then
-        # Only Hurd, whose procfs builds this out of a Mach task an exited
-        # process no longer has, so the read fails where Linux answers Z.
+        PID_STATE=${st%% *}
         return 0
-    else
-        st=$(ps -o state= -p "$1" 2>/dev/null) || st=
-        st=${st//[[:space:]]/}
     fi
-    case $st in
+    # Hurd's ps takes the pid positionally and rejects -p, so ask both ways.
+    st=$(ps -o state= -p "$1" 2>/dev/null) ||
+        st=$(ps -o state= "$1" 2>/dev/null) || st=
+    # Trimmed, since a padded column would read as neither state.
+    PID_STATE=${st//[[:space:]]/}
+}
+
+# Has pid $1 died and not yet been collected? A killed process answers kill -0
+# until a parent waits on it, and a caller that is not that parent never can: the
+# reap falls to whoever inherits the orphan, prompt on a workstation and not on a
+# Debian buildd, where it reddened 250 twice. The state is the honest question.
+pid_is_zombie() { # pid_is_zombie PID
+    pid_state "$1"
+    case $PID_STATE in
     Z*) return 0 ;;
     esac
     return 1
 }
 
-# Will this host say what pid $1 is doing? Neither route is a given: a build root
-# may have no procps, and a container or a hidepid mount no readable /proc. Asked
-# per pid, since hidepid answers for the caller's own and for nothing else.
+# Will this host say what pid $1 is doing? Asked per pid, since a hidepid mount
+# answers for the caller's own entry and for nothing else.
 pid_state_readable() { # pid_state_readable PID
-    test -r "${TESTLIB_PROC:-/proc}/$1/stat" ||
-        test -n "$(ps -o state= -p "$1" 2>/dev/null)"
+    pid_state "$1"
+    test -n "$PID_STATE"
 }
 
 reap_bounded() {

--- a/tests/testlib.sh
+++ b/tests/testlib.sh
@@ -1259,6 +1259,12 @@ pid_state() { # pid_state PID
     # Hurd's ps takes the pid positionally and rejects -p, so ask both ways.
     st=$(ps -o state= -p "$1" 2>/dev/null) ||
         st=$(ps -o state= "$1" 2>/dev/null) || st=
+    # One row, or none: a ps that answered for more than one pid, or printed a
+    # header, cannot say which state belongs to this one, and concatenating the
+    # rows invents a state no column held.
+    case $st in
+    *$'\n'*) st='' ;;
+    esac
     # Trimmed, since a padded column would read as neither state.
     PID_STATE=${st//[[:space:]]/}
 }


### PR DESCRIPTION
3.50.2-1 failed to build on hurd-amd64 and hurd-i386, and `250_timeout-poll-nofork` was the only failure on both. 3.50.1-1 built, so this is a regression from #1554, which added `pid_is_zombie`.

Neither of that helper's two routes works on GNU/Hurd. Its procfs builds `/proc/PID/stat` out of Mach data an exited process no longer has, so the read fails where Linux answers `Z`. The fallback `ps -o state= -p PID` fails too, because Hurd's `ps` rejects `-p` and takes the pid positionally. `kill -0` then keeps succeeding on the zombie until the grace runs out.

The fix is the second of those. Hurd's `ps` does know the state, from proc-info, which a zombie still carries, so `pid_state` now tries both spellings and takes whatever the host says.

Four earlier drafts of this branch tried instead to read the failure itself as proof of death, and review broke each one. The last one shows why none of them could work. `/proc/PID/stat` needs `PSTAT_THREAD_WAIT`, libps sets that only while the message port is usable, and `should_suppress_msgport` turns it off for a suspended task. A live process that is merely stopped reads EIO on Hurd, so no test on the file can tell it from a dead one.

`pid_state_readable` rests on the same answer, which is what it always claimed to report. A host neither route answers for now makes the test skip rather than assert. The guard also runs after the kill now, because asking about a live process is how the state Hurd cannot report came to be graded.

One fix here is older than the branch. Linux writes `comm` into `/proc/PID/stat` unescaped. A process named `") Z<LF>q"` therefore splits the file, and the first line ends in a state it is not in. Reading one line reported `Z` for a sleeping process.

`pid_state` takes one row from `ps` or none. A header, or an answer covering several pids, says nothing about this one, and folding the rows together invents a state no column held.

Fourteen mutants of the helper each fail a test, one of them a stderr leak an earlier draft left behind.
