### PR TITLE
A Windows job whose runner vanishes needs a human to re-run it

### DIFF
--- a/.github/workflows/windows-rerun-killed.yml
+++ b/.github/workflows/windows-rerun-killed.yml
@@ -8,8 +8,11 @@ on:
     workflows: [windows-build]
     types: [completed]
 
+# Naming any permission sets every other one to none, so the checkout below
+# needs contents spelled out.
 permissions:
   actions: write
+  contents: read
 
 jobs:
   rerun:

--- a/.github/workflows/windows-rerun-killed.yml
+++ b/.github/workflows/windows-rerun-killed.yml
@@ -1,0 +1,50 @@
+# A windows-build job whose runner went away (#1228) fails with no failed step,
+# and the only fix is to run it again. This does that, so a wedge costs the 45
+# minutes the service takes to reap it and nothing of anyone's attention.
+name: windows-rerun-killed
+
+on:
+  workflow_run:
+    workflows: [windows-build]
+    types: [completed]
+
+permissions:
+  actions: write
+
+jobs:
+  rerun:
+    # run_attempt caps the loop: a re-run raises it, and this fires again on the
+    # attempt it starts. Two automatic tries, then a human looks.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt < 3
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Re-run the jobs the runner lost
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+        run: |
+          set -euo pipefail
+          why=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/jobs?filter=all&per_page=100" |
+            bash tools/windows-kill-grade.sh) || {
+            echo "::notice::not re-running: $why"
+            exit 0
+          }
+          # windows-build cancels in progress runs of the same ref, so re-running
+          # a superseded run would cancel the one that superseded it.
+          newest=$(gh api \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/windows-build.yml/runs?branch=$BRANCH&per_page=50" \
+            --jq "[.workflow_runs[] | select(.head_repository.full_name == \"$HEAD_REPO\") | .id] | max")
+          if test "$newest" != "$RUN_ID"; then
+            echo "::notice::not re-running: run $newest on $BRANCH is newer"
+            exit 0
+          fi
+          echo "::notice::re-running run $RUN_ID: $why"
+          gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/rerun-failed-jobs"

--- a/.github/workflows/windows-rerun-killed.yml
+++ b/.github/workflows/windows-rerun-killed.yml
@@ -16,8 +16,8 @@ permissions:
 
 jobs:
   rerun:
-    # run_attempt caps the loop: a re-run raises it, and this fires again on the
-    # attempt it starts. Two automatic tries, then a human looks.
+    # A cheap pre-filter. The step re-reads run_attempt from the REST API,
+    # because an absent field here would read as 0 and never stop the loop.
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.run_attempt < 3
@@ -35,6 +35,20 @@ jobs:
           HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
         run: |
           set -euo pipefail
+          # One automatic re-run and no more, read from the run itself rather
+          # than from the event, so a missing field cannot leave the loop open.
+          attempt=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID" --jq '.run_attempt')
+          case "$attempt" in
+          1) ;;
+          '' | *[!0-9]*)
+            echo "::notice::not re-running: the run reports attempt '$attempt'"
+            exit 0
+            ;;
+          *)
+            echo "::notice::not re-running: attempt $attempt has already been re-run once"
+            exit 0
+            ;;
+          esac
           why=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/jobs?filter=all&per_page=100" |
             bash tools/windows-kill-grade.sh) || {
             echo "::notice::not re-running: $why"

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,8 @@ EXTRA_DIST = INSTALL.Linux \
 		tools/doc-chrome.py \
 		tools/check-includes.py \
 		tools/ci-sanitizer-report.sh \
-		tools/downstream-drift.sh
+		tools/downstream-drift.sh \
+		tools/windows-kill-grade.sh
 
 # The suite's staged installs serialise on this; a killed holder leaves it behind.
 clean-local:

--- a/tests/466_ci-windows-kill-grade.test
+++ b/tests/466_ci-windows-kill-grade.test
@@ -1,0 +1,99 @@
+#!/bin/bash
+#
+# windows-rerun-killed.yml re-runs a failed windows-build run on this grader's
+# say-so, so a wrong yes silently re-runs a genuine test failure (#1228).
+
+set -euo pipefail
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+top=${abs_top_srcdir:-$(cd "$testdir/.." && pwd)}
+grade="$top/tools/windows-kill-grade.sh"
+test -r "$grade" || fail "$grade is missing"
+command -v jq >/dev/null || skip "no jq here, and the grader is written in it"
+
+# A job as the API reports it. Steps are "<conclusion>:<name>", and a conclusion
+# of "null" is the unfinished step a lost runner leaves behind.
+job() { # job <name> <conclusion> [step...]
+    local name=$1 concl=$2 steps='[]'
+    shift 2
+    if test $# -gt 0; then
+        steps=$(printf '%s\n' "$@" | jq -R -s -c '
+            split("\n") | map(select(length > 0)) | map(
+                (split(":")) as $p |
+                {conclusion: (if $p[0] == "null" then null else $p[0] end),
+                 name: $p[1]})')
+    fi
+    jq -n -c --arg n "$name" --arg c "$concl" --argjson s "$steps" \
+        '{name: $n, conclusion: $c, steps: $s}'
+}
+
+payload() { jq -n -c --argjson j "$(jq -s -c '.' <<<"$(cat)")" '{jobs: $j}'; }
+
+verdict() { # verdict <payload>; prints yes/no and the reason
+    local out rc=0
+    out=$(bash "$grade" <<<"$1") || rc=$?
+    test "$rc" -le 1 || fail "the grader died (exit $rc) on: $1"
+    echo "$((rc == 0))|$out"
+}
+
+expect() { # expect <yes|no> <what> <payload>
+    local want=$1 what=$2 got
+    got=$(verdict "$3")
+    case "$want:${got%%|*}" in
+    yes:1 | no:0) ;;
+    *) fail "$what: wanted $want, got ${got#*|}" ;;
+    esac
+}
+
+KILLED=(success:Build
+    "null:Run the engine test suite (offline tests, WSL2)"
+    "null:Upload the test logs")
+REALFAIL=(success:Build
+    "failure:Run the engine test suite (offline tests, WSL2)"
+    skipped:Upload)
+
+# The case the workflow exists for.
+expect yes "one lost runner" \
+    "$(job 'libhttrack (x64, Release)' failure "${KILLED[@]}" | payload)"
+
+# The mutants. Each must be refused, or a genuine red gets re-run until the
+# attempt cap hides it.
+expect no "a failing test" \
+    "$(job 'libhttrack (x64, Release)' failure "${REALFAIL[@]}" | payload)"
+expect no "a failing test beside a lost runner" \
+    "$({
+        job 'libhttrack (x64, Release)' failure "${REALFAIL[@]}"
+        job 'libhttrack (Win32, Release)' failure "${KILLED[@]}"
+    } | payload)"
+expect no "nothing failed" \
+    "$(job 'libhttrack (x64, Release)' success 'success:Build' | payload)"
+expect no "a cancelled job" \
+    "$(job 'libhttrack (x64, Release)' cancelled "${KILLED[@]}" | payload)"
+# A failed job whose steps all finished is not the wedge signature, whatever
+# left it red, so it is a human's to read.
+expect no "a failure with every step finished" \
+    "$(job 'libhttrack (x64, Release)' failure 'success:Build' | payload)"
+# The ambiguous one, and the only case that reaches the named-step clause on its
+# own: a step failed AND a later one never finished. Without it the mutant that
+# drops that clause survives, because every other refusal here is carried by the
+# unfinished-step clause instead.
+expect no "a failed step beside an unfinished one" \
+    "$(job 'libhttrack (x64, Release)' failure \
+        'success:Build' \
+        'failure:Run the engine test suite (offline tests, WSL2)' \
+        'null:Upload the test logs' | payload)"
+
+# The runner that never started a step at all: no step records, and the job red.
+expect yes "a runner that took no step" \
+    "$(job 'libhttrack (x64, Release)' failure | payload)"
+
+# Both legs lost, which is what a bad half-hour on the pool looks like.
+expect yes "both legs lost" \
+    "$({
+        job 'libhttrack (x64, Release)' failure "${KILLED[@]}"
+        job 'libhttrack (Win32, Release)' failure "${KILLED[@]}"
+    } | payload)"
+
+echo "windows-kill-grade OK (3 kills accepted, 6 refused)"

--- a/tests/466_ci-windows-kill-grade.test
+++ b/tests/466_ci-windows-kill-grade.test
@@ -38,12 +38,21 @@ verdict() { # verdict <payload>; prints yes/no and the reason
     echo "$((rc == 0))|$out"
 }
 
-expect() { # expect <yes|no> <what> <payload>
+expect() { # expect <yes|no> <what> <payload> [text the reason must carry]
     local want=$1 what=$2 got
     got=$(verdict "$3")
     case "$want:${got%%|*}" in
     yes:1 | no:0) ;;
     *) fail "$what: wanted $want, got ${got#*|}" ;;
+    esac
+    # A verdict nobody can read is a verdict nobody acts on, and an empty reason
+    # is what a missing name looks like in the workflow log.
+    case "${got#*|}" in
+    '' | ' '*) fail "$what: the reason is empty or unnamed: [${got#*|}]" ;;
+    esac
+    test -z "${4:-}" || case "${got#*|}" in
+    *"$4"*) ;;
+    *) fail "$what: the reason does not mention '$4': ${got#*|}" ;;
     esac
 }
 
@@ -58,7 +67,7 @@ REALFAIL=(success:Build
 expect yes "one lost runner" \
     "$(job 'libhttrack (x64, Release)' failure "${KILLED[@]}" | payload)"
 
-# The mutants. Each must be refused, or a genuine red gets re-run until the
+# Every mutant here must be refused, or a genuine red gets re-run until the
 # attempt cap hides it.
 expect no "a failing test" \
     "$(job 'libhttrack (x64, Release)' failure "${REALFAIL[@]}" | payload)"
@@ -75,17 +84,16 @@ expect no "a cancelled job" \
 # left it red, so it is a human's to read.
 expect no "a failure with every step finished" \
     "$(job 'libhttrack (x64, Release)' failure 'success:Build' | payload)"
-# The ambiguous one, and the only case that reaches the named-step clause on its
-# own: a step failed AND a later one never finished. Without it the mutant that
-# drops that clause survives, because every other refusal here is carried by the
-# unfinished-step clause instead.
+# This case alone reaches the named-step clause, because a step failed and a
+# later one never finished. Without it the mutant dropping that clause survives,
+# since every other refusal here rests on the unfinished-step clause.
 expect no "a failed step beside an unfinished one" \
     "$(job 'libhttrack (x64, Release)' failure \
         'success:Build' \
         'failure:Run the engine test suite (offline tests, WSL2)' \
         'null:Upload the test logs' | payload)"
 
-# The runner that never started a step at all: no step records, and the job red.
+# This runner started no step at all, and the job is still red.
 expect yes "a runner that took no step" \
     "$(job 'libhttrack (x64, Release)' failure | payload)"
 
@@ -96,4 +104,45 @@ expect yes "both legs lost" \
         job 'libhttrack (Win32, Release)' failure "${KILLED[@]}"
     } | payload)"
 
-echo "windows-kill-grade OK (3 kills accepted, 6 refused)"
+# The ordinary shape: one leg green, the other lost. Without it a grader that
+# compares the kills against every job rather than against the failed ones
+# cannot be told from this one.
+expect yes "one leg green, the other lost" \
+    "$({
+        job 'libhttrack (x64, Release)' success 'success:Build'
+        job 'libhttrack (Win32, Release)' failure "${KILLED[@]}"
+    } | payload)"
+
+# The mirror of the mixed case above. One order alone lets a grader that reads
+# only the x64 leg pass, and that grader re-runs a red Win32 leg.
+expect no "a failing Win32 leg beside a lost x64 one" \
+    "$({
+        job 'libhttrack (x64, Release)' failure "${KILLED[@]}"
+        job 'libhttrack (Win32, Release)' failure "${REALFAIL[@]}"
+    } | payload)" 'Win32'
+
+# A runner lost during Build, so the unfinished step is not the suite step. A
+# grader keyed on the step's name would refuse this one.
+expect yes "a runner lost during Build" \
+    "$(job 'libhttrack (x64, Release)' failure 'null:Build' | payload)"
+
+# skipped is not unfinished. A step GitHub skipped after an earlier failure has
+# a conclusion, so it must not read as the wedge.
+expect no "a failed job whose last step was skipped" \
+    "$(job 'libhttrack (x64, Release)' failure 'success:Build' 'skipped:Upload the test logs' | payload)"
+
+# A job that ended badly some other way. timed_out is the documented one this
+# repo has not yet produced, and a lost sibling must not carry it through.
+expect no "a timed-out job beside a lost runner" \
+    "$({
+        job 'libhttrack (x64, Release)' timed_out 'timed_out:Run the engine test suite'
+        job 'libhttrack (Win32, Release)' failure "${KILLED[@]}"
+    } | payload)" 'timed_out'
+
+# The same one level down: a step that timed out names its step as surely as a
+# failed one does.
+expect no "a step that timed out" \
+    "$(job 'libhttrack (x64, Release)' failure \
+        'success:Build' 'timed_out:Run the engine test suite' 'null:Upload the test logs' | payload)"
+
+echo "windows-kill-grade OK (5 kills accepted, 10 refused)"

--- a/tools/windows-kill-grade.sh
+++ b/tools/windows-kill-grade.sh
@@ -4,27 +4,40 @@
 # windows-build run. Reads the `actions/runs/<id>/jobs` payload on stdin and
 # exits 0 when every failed job is a runner death, so the run is safe to re-run.
 #
-# Stricter than tools/windows-kill-census.sh on purpose: the census has to count
-# an ambiguous job, this one must refuse to act on it.
+# This is stricter than tools/windows-kill-census.sh, which has to count an
+# ambiguous job where this one must refuse to act on it.
 set -euo pipefail
 
 # The runner goes away mid-step, so the live step and the ones after it stay
 # unfinished and none is marked failed. A real failure names the step it failed.
 # A job with no steps at all never started one, which is the same wedge.
+#
+# "failure" is not the only way a job ends badly, so $bad collects every job that
+# did not succeed and is not still running. A run holding one of the others, such
+# as timed_out, is a human's to read even when a sibling leg was killed.
 verdict=$(jq -r '
-    [.jobs[]? | select(.conclusion == "failure")] as $failed
-    | [$failed[] | select(
-        ((.steps // []) | any(.conclusion == "failure")) | not)
+    def ended_badly: .conclusion != null and .conclusion != "success"
+        and .conclusion != "skipped" and .conclusion != "cancelled";
+    def names_a_step: (.steps // [])
+        | any(.conclusion == "failure" or .conclusion == "timed_out");
+    [.jobs[]? | select(ended_badly)] as $bad
+    | [$bad[] | select(.conclusion == "failure")] as $failed
+    | [$failed[] | select(names_a_step | not)
       | select(
         ((.steps // []) | length) == 0
         or ((.steps // []) | any(.conclusion == null)))] as $killed
-    | if ($failed | length) == 0 then
+    | if ($bad | length) == 0 then
         "no\tno failed job"
+      elif ($bad | length) != ($failed | length) then
+        "no\t" + ([$bad[] | select(.conclusion != "failure")
+                   | .name + " ended " + .conclusion] | join(", "))
       elif ($killed | length) == ($failed | length) then
         "yes\t" + (($failed | length) | tostring) + " failed job(s), none naming a step"
       else
-        "no\t" + ([$failed[] | select((.steps // []) | any(.conclusion == "failure")) | .name]
-                  | join(", ")) + " named a failed step"
+        "no\t" + ([$failed[] | select((names_a_step) or
+                     (((.steps // []) | length) > 0
+                      and ((.steps // []) | any(.conclusion == null) | not)))
+                   | .name] | join(", ")) + " is not the wedge signature"
       end')
 
 echo "${verdict#*$'\t'}"

--- a/tools/windows-kill-grade.sh
+++ b/tools/windows-kill-grade.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Tell a lost runner (#1228) from a real failure, for the jobs of one
+# windows-build run. Reads the `actions/runs/<id>/jobs` payload on stdin and
+# exits 0 when every failed job is a runner death, so the run is safe to re-run.
+#
+# Stricter than tools/windows-kill-census.sh on purpose: the census has to count
+# an ambiguous job, this one must refuse to act on it.
+set -euo pipefail
+
+# The runner goes away mid-step, so the live step and the ones after it stay
+# unfinished and none is marked failed. A real failure names the step it failed.
+# A job with no steps at all never started one, which is the same wedge.
+verdict=$(jq -r '
+    [.jobs[]? | select(.conclusion == "failure")] as $failed
+    | [$failed[] | select(
+        ((.steps // []) | any(.conclusion == "failure")) | not)
+      | select(
+        ((.steps // []) | length) == 0
+        or ((.steps // []) | any(.conclusion == null)))] as $killed
+    | if ($failed | length) == 0 then
+        "no\tno failed job"
+      elif ($killed | length) == ($failed | length) then
+        "yes\t" + (($failed | length) | tostring) + " failed job(s), none naming a step"
+      else
+        "no\t" + ([$failed[] | select((.steps // []) | any(.conclusion == "failure")) | .name]
+                  | join(", ")) + " named a failed step"
+      end')
+
+echo "${verdict#*$'\t'}"
+test "${verdict%%$'\t'*}" = yes


### PR DESCRIPTION
A `windows-build` job killed the way #1228 describes fails with no failed step, no log and no artifact, so only a re-run clears it. Since #1585 that is about one job a fortnight rather than one in eight, so this covers the residual, not the old rate.

`tools/windows-kill-grade.sh` decides, and refuses anything ambiguous. It collects every job that did not succeed and is not still running. All of them must be plain failures, each with no named step and an unfinished one, or no steps at all. Test 466 pins that with ten mutants, each killed by a case it does not share.

The step re-reads `run_attempt` from the run rather than from the event, and allows exactly one re-run. A superseded run is left alone, because windows-build cancels in-progress runs of the same ref, so re-running the old one would cancel the new one. A push landing between that check and the POST still races it.