### PR TITLE
Test 226 lets two interpreters spend one budget, and the second meets the guard

### DIFF
--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -646,6 +646,11 @@ turn=''
 # what the 900s budget allows, so the legs are skipped rather than half-run.
 TURN_CAP=6
 
+# Steps one interpreter's body runs, for the projection above: four legs, the
+# leaky control, twelve mutants and the optional full-stdout pair. An upper
+# bound, and the assertion beside `planned` keeps it one.
+PLANNED_STEPS=19
+
 # Three states, not two: held (0), violated (1), could not measure (77). A starved
 # sample is not a verdict, and grading one as a mutant caught is how a real defect
 # gets accepted. The value is testlib's skip sentinel on purpose, but a leg
@@ -1138,6 +1143,16 @@ for psrun in "${psruns[@]}"; do
         skipped+=("the $psrun timing checks and legs: a turn costs ${turn}s, past the ${TURN_CAP}s this test can afford")
         continue
     fi
+    # The cap is per interpreter, but every interpreter that passes it spends the
+    # same budget: a box affording one 4s turn cannot afford two bodies of them.
+    # So project this body against what is left, using the pacer's own per-step
+    # estimate, or the second interpreter meets the guard as a hard 124.
+    body=$((PLANNED_STEPS * (turn * 8 + 10)))
+    left=$(budget_left)
+    if test "$left" -gt 0 && test "$body" -gt "$left"; then
+        skipped+=("the $psrun timing checks and legs: they need about ${body}s at a ${turn}s turn and ${left}s of the budget is left")
+        continue
+    fi
     echo "note: one turn of the $psrun watchdog loop costs ${turn}s here"
 
     # Anchored on the watchdog's own clock, not on a count in a fixed window: a
@@ -1282,6 +1297,8 @@ for psrun in "${psruns[@]}"; do
     # them skips rather than meets the guard. The costliest so far is what the
     # next one will take, since a cheap leg under-projects the slow one after it.
     planned=$((${#legs[@]} + 1 + 12 + devfull))
+    test "$planned" -le "$PLANNED_STEPS" ||
+        fail "the budget projection plans $PLANNED_STEPS steps but the run has $planned"
     ran=0
     # Seeded from a turn rather than from zero: the first leg is then projected
     # off a measurement of this box instead of off nothing.

--- a/tests/226_watchdog-native.test
+++ b/tests/226_watchdog-native.test
@@ -646,10 +646,10 @@ turn=''
 # what the 900s budget allows, so the legs are skipped rather than half-run.
 TURN_CAP=6
 
-# Steps one interpreter's body runs, for the projection above: four legs, the
-# leaky control, twelve mutants and the optional full-stdout pair. An upper
-# bound, and the assertion beside `planned` keeps it one.
-PLANNED_STEPS=19
+# The costliest step any interpreter has run, carried across them because they
+# share one budget. A fresh estimate per interpreter throws away what the box
+# already showed, and the next body then walks into a step it cannot afford.
+COSTLIEST_SEEN=0
 
 # Three states, not two: held (0), violated (1), could not measure (77). A starved
 # sample is not a verdict, and grading one as a mutant caught is how a real defect
@@ -1143,16 +1143,6 @@ for psrun in "${psruns[@]}"; do
         skipped+=("the $psrun timing checks and legs: a turn costs ${turn}s, past the ${TURN_CAP}s this test can afford")
         continue
     fi
-    # The cap is per interpreter, but every interpreter that passes it spends the
-    # same budget: a box affording one 4s turn cannot afford two bodies of them.
-    # So project this body against what is left, using the pacer's own per-step
-    # estimate, or the second interpreter meets the guard as a hard 124.
-    body=$((PLANNED_STEPS * (turn * 8 + 10)))
-    left=$(budget_left)
-    if test "$left" -gt 0 && test "$body" -gt "$left"; then
-        skipped+=("the $psrun timing checks and legs: they need about ${body}s at a ${turn}s turn and ${left}s of the budget is left")
-        continue
-    fi
     echo "note: one turn of the $psrun watchdog loop costs ${turn}s here"
 
     # Anchored on the watchdog's own clock, not on a count in a fixed window: a
@@ -1297,17 +1287,27 @@ for psrun in "${psruns[@]}"; do
     # them skips rather than meets the guard. The costliest so far is what the
     # next one will take, since a cheap leg under-projects the slow one after it.
     planned=$((${#legs[@]} + 1 + 12 + devfull))
-    test "$planned" -le "$PLANNED_STEPS" ||
-        fail "the budget projection plans $PLANNED_STEPS steps but the run has $planned"
     ran=0
     # Seeded from a turn rather than from zero: the first leg is then projected
     # off a measurement of this box instead of off nothing.
     costliest=$((turn * 8 + 10))
+    test "$costliest" -ge "$COSTLIEST_SEEN" || costliest=$COSTLIEST_SEEN
     pace() { # pace <seconds the step took>
         test "$1" -le "$costliest" || costliest=$1
+        test "$costliest" -le "$COSTLIEST_SEEN" || COSTLIEST_SEEN=$costliest
         ran=$((ran + 1))
         skip_if_out_of_budget "$((planned - ran))" "$costliest"
     }
+    # The pacer only projects after a step, so an interpreter's first step runs
+    # whatever is left. Where two interpreters share the budget, that step is
+    # what meets the guard as a hard 124, so project it here on the pacer's own
+    # rule and skip this body instead (#1228).
+    need=$((costliest + costliest / 2))
+    left=$(budget_left)
+    if test "$left" -gt 0 && test "$need" -ge "$left"; then
+        skipped+=("the $psrun timing checks and legs: a step costs about ${costliest}s and ${left}s of the budget is left")
+        continue
+    fi
     for leg in "${legs[@]}"; do
         : >"$legout"
         leg_at=$SECONDS


### PR DESCRIPTION
`TURN_CAP` is checked once per interpreter, but every interpreter that passes it spends the same 900s budget. A slow macOS arm64 runner measured 4s a turn for pwsh and 2s for powershell, both under the cap. It then died inside the second body as a hard 124 instead of skipping.

The hole is one step wide. The pacer projects only after a step has run. So a body's first step runs on whatever is left, and that step is what meets the guard. The fix carries the costliest step across interpreters, then projects one step ahead before the body on the pacer's own 1.5x rule.

Measured against an unchanged copy. At a 400s budget both run 17 of 19 steps and skip at 363s, so no coverage is lost. At a 45s budget the guard fires and names a step costing about 26s with 1s left, where the unchanged copy keeps going.

`fix-226-onestep-mutants` is in flight on this file in another session, on the mutant legs rather than this guard.