### PR TITLE
The crawl waits forever for an FTP worker a crash recovery cut short

### DIFF
--- a/src/htsback.c
+++ b/src/htsback.c
@@ -5359,6 +5359,21 @@ static hts_mirror_limit back_mirror_limit(httrackp *opt) {
   return HTS_MIRROR_LIMIT_NONE;
 }
 
+/* See htsback.h. */
+void back_check_worker_fault(httrackp *opt) {
+  /* Already aborted, and -1 outranks the other verdicts: a user stop and a
+     rolled-back session both exit 0, and this mirror must not. */
+  if (!hts_worker_faulted() || opt->state.exit_xh == -1)
+    return;
+  hts_log_print(opt, LOG_ERROR,
+                "Mirror aborted: a worker thread crashed and the front end "
+                "recovered it, so the mirror cannot be trusted");
+  hts_mutexlock(&opt->state.lock);
+  opt->state.stop = 1;
+  opt->state.exit_xh = -1;
+  hts_mutexrelease(&opt->state.lock);
+}
+
 int back_checkmirror(httrackp *opt) {
   /* request a smooth stop the first time each cap is reached */
   if (back_maxsize_reached(opt) && !opt->state.stop) {
@@ -5373,19 +5388,7 @@ int back_checkmirror(httrackp *opt) {
                   opt->maxtime);
     hts_request_stop(opt, 0);
   }
-  /* A mirror is not resumable across a fault a front end recovered from: the
-     worker stopped mid-body, so its sockets, its output and whatever else it
-     held are in a state nothing can audit. Not hts_request_stop(), because the
-     user did not ask for this one and the exit status must say so. */
-  if (hts_worker_faulted() && opt->state.exit_xh == 0) {
-    hts_log_print(opt, LOG_ERROR,
-                  "Mirror aborted: a worker thread crashed and the front end "
-                  "recovered it, so the mirror cannot be trusted");
-    hts_mutexlock(&opt->state.lock);
-    opt->state.stop = 1;
-    opt->state.exit_xh = -1;
-    hts_mutexrelease(&opt->state.lock);
-  }
+  back_check_worker_fault(opt);
   /* hard stop once a cap overruns its grace (callers must stop waiting) */
   return back_mirror_limit(opt) == HTS_MIRROR_LIMIT_NONE;
 }

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -5373,6 +5373,19 @@ int back_checkmirror(httrackp *opt) {
                   opt->maxtime);
     hts_request_stop(opt, 0);
   }
+  /* A mirror is not resumable across a fault a front end recovered from: the
+     worker stopped mid-body, so its sockets, its output and whatever else it
+     held are in a state nothing can audit. Not hts_request_stop(), because the
+     user did not ask for this one and the exit status must say so. */
+  if (hts_worker_faulted() && opt->state.exit_xh == 0) {
+    hts_log_print(opt, LOG_ERROR,
+                  "Mirror aborted: a worker thread crashed and the front end "
+                  "recovered it, so the mirror cannot be trusted");
+    hts_mutexlock(&opt->state.lock);
+    opt->state.stop = 1;
+    opt->state.exit_xh = -1;
+    hts_mutexrelease(&opt->state.lock);
+  }
   /* hard stop once a cap overruns its grace (callers must stop waiting) */
   return back_mirror_limit(opt) == HTS_MIRROR_LIMIT_NONE;
 }

--- a/src/htsback.h
+++ b/src/htsback.h
@@ -195,6 +195,11 @@ int back_checksize(httrackp * opt, lien_back * eback, int check_only_totalsize);
 /* Enforce -M/-E quotas: smooth-stops when reached; returns 0 once the -M cap
    or -E deadline overruns its grace period (callers must stop waiting). */
 int back_checkmirror(httrackp * opt);
+/* Give up the mirror where a thread runner recovered from a fault, because the
+   worker it cut short left state nothing can audit. Crawl thread only, because
+   it is the one that holds opt. Idempotent, and back_checkmirror() already
+   calls it on every crawl iteration. */
+void back_check_worker_fault(httrackp *opt);
 
 #endif
 

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -2096,6 +2096,10 @@ int httpmirror(char *url1, httrackp *opt, hts_boolean *completed_out) {
     }
   } while(ptr < opt->lien_tot);
 
+  /* Once more, for a worker that faulted after the loop's last check: the
+     verdict below and the exit status both read exit_xh. */
+  back_check_worker_fault(opt);
+
   /* A stop request cuts the mirror short whether or not the loop ran out of
      links: with one pending, the parser stops queueing the links it finds. */
   aborted = opt->state.stop != 0 || opt->state.exit_xh != 0;
@@ -2125,7 +2129,10 @@ int httpmirror(char *url1, httrackp *opt, hts_boolean *completed_out) {
                   ": restoring previous one!");
     /* this run replaces nothing, so its archive must not be committed */
     warc_abort_opt(opt);
-    opt->state.exit_xh = 2;     /* interrupted (no connection detected) */
+    /* 2 exits 0, so it must not overwrite an abort the engine already decided,
+       and a crash on the first fetch lands in exactly this state. */
+    if (opt->state.exit_xh != -1)
+      opt->state.exit_xh = 2; /* interrupted (no connection detected) */
     rollback = HTS_TRUE;
     goto cleanup;
   }

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -671,6 +671,8 @@ int httpmirror(char *url1, httrackp *opt, hts_boolean *completed_out) {
 
   // initialiser exit_xh
   opt->state.exit_xh = 0;       // sortir prématurément (var globale)
+  /* a fault a previous mirror recovered from must not abort this one */
+  hts_worker_fault_clear();
 
   // initialiser usercommand
   usercommand(opt, opt->sys_com_exec, StringBuff(opt->sys_com), "", "", "");

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -52,6 +52,7 @@ Please visit our Website: http://www.httrack.com
 #include "htsselftest.h"
 #include "htscrashtest.h"
 #include "htsmd5.h"
+#include "htsthread.h"
 
 #include <ctype.h>
 /* hts_self_path() */
@@ -3067,13 +3068,16 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
       }
     }
 
-    /* Only the exit status tells a wrapper the engine gave up mid-mirror. */
-    if (opt->state.exit_xh == -1) {
+    /* Only the exit status tells a wrapper the engine gave up mid-mirror. The
+       fault flag is read too, because a dozen sites write exit_xh = 1 for a
+       stop the user asked for and any of them can land after the abort. */
+    if (opt->state.exit_xh == -1 || hts_worker_faulted()) {
       exit_code = HTS_EXIT_MIRROR_ABORTED;
       HTS_PANIC_PRINTF("mirror aborted before completion, see the log file");
     }
 
-    if (opt->state.exit_xh == 1) {
+    /* Not after a fault: that mirror is not resumable. */
+    if (opt->state.exit_xh == 1 && !hts_worker_faulted()) {
       if (opt->log) {
         fprintf(opt->log,
                 "* * MIRROR ABORTED! * *\nThe mirror stopped before the end. "

--- a/src/htsdns_selftest.c
+++ b/src/htsdns_selftest.c
@@ -43,6 +43,7 @@ Please visit our Website: http://www.httrack.com
 #include "htscore.h"
 #include "htslib.h"
 #include "htsnet.h"
+#include "htsthread.h"
 
 #include <setjmp.h>
 #include <stdio.h>
@@ -755,6 +756,9 @@ int dns_timeout_selftests(httrackp *opt) {
                                         0, &cancel, &err);
     CHECK(count == 1);
     CHECK(mock_read_calls("cut.test") == 2);
+    /* and the mirror gives up on it, see back_checkmirror() */
+    CHECK(hts_worker_faulted());
+    hts_worker_fault_clear();
   }
   return failures;
 }

--- a/src/htsdns_selftest.c
+++ b/src/htsdns_selftest.c
@@ -44,6 +44,7 @@ Please visit our Website: http://www.httrack.com
 #include "htslib.h"
 #include "htsnet.h"
 
+#include <setjmp.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -116,6 +117,8 @@ static mock_host mock_hosts[] = {
        then stopped: neither case may read the other's cached answer */
     {"slow3.test", 0, 1, {{AF_INET, {127, 0, 0, 11}}}, 0, MOCK_SLOW_MS},
     {"slow4.test", 0, 1, {{AF_INET, {127, 0, 0, 12}}}, 0, MOCK_SLOW_MS},
+    /* answers at once, but the backend below never lets the worker say so */
+    {"cut.test", 0, 1, {{AF_INET, {127, 0, 0, 13}}}, 0},
 };
 
 /* Serializes mock_host bookkeeping: a timed-out resolve is abandoned, so its
@@ -255,6 +258,30 @@ static void HTS_RESOLVER_CALL mock_freeaddrinfo(struct addrinfo *res) {
 
 static const hts_resolver_backend mock_backend = {mock_getaddrinfo,
                                                   mock_freeaddrinfo};
+
+/* Where a front end's fault recovery lands, see hts_set_thread_runner(). */
+static jmp_buf dns_cut_jmp;
+
+/* Counts the call, then leaves the worker body the way a recovered fault does.
+   It frees what it asked for, because nothing downstream will. */
+static int HTS_RESOLVER_CALL cut_getaddrinfo(const char *node,
+                                             const char *service,
+                                             const struct addrinfo *hints,
+                                             struct addrinfo **res) {
+  if (mock_getaddrinfo(node, service, hints, res) == 0)
+    mock_freeaddrinfo(*res);
+  *res = NULL;
+  longjmp(dns_cut_jmp, 1);
+  return EAI_NONAME; /* not reached */
+}
+
+static const hts_resolver_backend cut_backend = {cut_getaddrinfo,
+                                                 mock_freeaddrinfo};
+
+static void dns_cut_runner(void (*fun)(void *arg), void *arg) {
+  if (setjmp(dns_cut_jmp) == 0)
+    fun(arg);
+}
 
 static int failures = 0;
 
@@ -704,6 +731,31 @@ int dns_timeout_selftests(httrackp *opt) {
      workers to leave it before returning. The backend stays installed: an
      abandoned worker still reads it (to free its addrinfo). */
   mock_wait_finished(6);
+
+  /* A worker a recovered fault cut short hands its verdict back at once. Left
+     to the caller, the wait runs to the deadline, and an unbounded one runs
+     until the user stops the mirror. */
+  {
+    hts_boolean cancel = HTS_FALSE;
+
+    mock_reset_calls();
+    hts_dns_set_resolver_backend(&cut_backend);
+    CHECK(hts_set_thread_runner(dns_cut_runner) == NULL);
+    start = mtime_local();
+    count = hts_dns_resolve_all_bounded(opt, "cut.test", addrs, HTS_MAXADDRNUM,
+                                        MOCK_SLOW_MS / 1000, &cancel, &err);
+    elapsed = mtime_local() - start;
+    hts_set_thread_runner(NULL);
+    hts_dns_set_resolver_backend(&mock_backend);
+    CHECK(count == 0);
+    CHECK(elapsed < MOCK_SLOW_MS / 2); /* the tail answered, not the deadline */
+    CHECK(mock_read_calls("cut.test") == 1);
+    /* no answer was had, so nothing may be cached in its place */
+    count = hts_dns_resolve_all_bounded(opt, "cut.test", addrs, HTS_MAXADDRNUM,
+                                        0, &cancel, &err);
+    CHECK(count == 1);
+    CHECK(mock_read_calls("cut.test") == 2);
+  }
   return failures;
 }
 

--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -161,6 +161,57 @@ void back_launch_ftp(void *pP) {
   pStruct->body_returned = HTS_TRUE;
 }
 
+/* See htsftp.h. The tail is called here as the thread layer calls it, since a
+   worker that faults for real cannot be had on demand. */
+int ftp_worker_selftests(void) {
+  static const char kept[] = "what the transfer said";
+  int err = 0;
+  int round;
+
+  for (round = 0; round < 2; round++) {
+    const hts_boolean returned = (round == 0) ? HTS_FALSE : HTS_TRUE;
+    FTPDownloadStruct *const worker = calloct(1, sizeof(*worker));
+    lien_back back;
+
+    assertf(worker != NULL);
+    memset(&back, 0, sizeof(back));
+    back.status = STATUS_FTP_TRANSFER;
+    back.r.statuscode = 200;
+    strcpybuff(back.r.msg, kept);
+    worker->pBack = &back;
+    worker->body_returned = returned;
+    ftp_worker_register(worker);
+    ftp_worker_done(worker);
+
+    if (ftp_workers != NULL) {
+      fprintf(stderr, "ftp-worker-selftest: the tail left the worker "
+                      "registered, so ftp_stop_workers() would never return\n");
+      err++;
+    }
+    if (back.status != STATUS_FTP_READY) {
+      fprintf(stderr, "ftp-worker-selftest: slot status %d, expected %d\n",
+              back.status, STATUS_FTP_READY);
+      err++;
+    }
+    if (returned) {
+      if (back.r.statuscode != 200 || strcmp(back.r.msg, kept) != 0) {
+        fprintf(stderr,
+                "ftp-worker-selftest: the tail overwrote a finished transfer "
+                "with %d '%s'\n",
+                back.r.statuscode, back.r.msg);
+        err++;
+      }
+    } else if (back.r.statuscode != STATUSCODE_INVALID ||
+               strcmp(back.r.msg, "FTP transfer interrupted") != 0) {
+      fprintf(stderr,
+              "ftp-worker-selftest: a cut-short transfer reads %d '%s'\n",
+              back.r.statuscode, back.r.msg);
+      err++;
+    }
+  }
+  return err;
+}
+
 // lancer en back
 void launch_ftp(FTPDownloadStruct * params) {
   // DOS

--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -112,28 +112,28 @@ void ftp_stop_workers(void) {
   } while (wait);
 }
 
-/* Hand the slot back to the crawl thread, as 'error' when the transfer never
-   ran: nobody would ever reap one left in STATUS_FTP_TRANSFER. */
-static void ftp_worker_reap(FTPDownloadStruct *worker, const char *error) {
+/* Hand the slot back to the crawl thread, as 'error' where the transfer did not
+   finish. Nobody would ever reap one left in STATUS_FTP_TRANSFER. */
+static void ftp_worker_release(FTPDownloadStruct *worker, const char *error) {
   if (error != NULL) {
     strcpybuff(worker->pBack->r.msg, error);
     worker->pBack->r.statuscode = STATUSCODE_INVALID;
   }
   worker->pBack->status = STATUS_FTP_READY;
 
-  /* The status store above was this worker's last read of the slot and of opt;
-     deregistering lets the engine free both. */
+  /* The status store above was this worker's last read of the slot and of opt,
+     so deregistering lets the engine free both. */
   ftp_worker_unregister(worker);
   freet(worker);
 }
 
-/* Tail of every worker, run by the thread layer even when a thread runner
-   recovered from a fault and cut the body short (see hts_newthread_tail). */
+/* Runs as every worker's tail, even where a recovered fault cut the body short
+   (see hts_newthread_tail). */
 static void ftp_worker_done(void *pP) {
   FTPDownloadStruct *const worker = (FTPDownloadStruct *) pP;
 
-  ftp_worker_reap(worker,
-                  worker->completed ? NULL : "FTP transfer interrupted");
+  ftp_worker_release(worker,
+                     worker->body_returned ? NULL : "FTP transfer interrupted");
 }
 
 void back_launch_ftp(void *pP) {
@@ -158,8 +158,7 @@ void back_launch_ftp(void *pP) {
   /* Uninitialize */
   hts_uninit();
 
-  /* ftp_worker_done() takes it from here, on this thread. */
-  pStruct->completed = HTS_TRUE;
+  pStruct->body_returned = HTS_TRUE;
 }
 
 // lancer en back
@@ -168,12 +167,12 @@ void launch_ftp(FTPDownloadStruct * params) {
 #if FTP_DEBUG
   printf("[Launching main ftp thread]\n");
 #endif
-  params->completed = HTS_FALSE;
+  params->body_returned = HTS_FALSE;
   ftp_worker_register(params);
   if (hts_newthread_tail(back_launch_ftp, (void *) params, ftp_worker_done) !=
       0) {
     /* ftp_stop_workers() would never return on a slot left registered. */
-    ftp_worker_reap(params, "Unable to launch FTP thread");
+    ftp_worker_release(params, "Unable to launch FTP thread");
   }
 }
 

--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -112,6 +112,30 @@ void ftp_stop_workers(void) {
   } while (wait);
 }
 
+/* Hand the slot back to the crawl thread, as 'error' when the transfer never
+   ran: nobody would ever reap one left in STATUS_FTP_TRANSFER. */
+static void ftp_worker_reap(FTPDownloadStruct *worker, const char *error) {
+  if (error != NULL) {
+    strcpybuff(worker->pBack->r.msg, error);
+    worker->pBack->r.statuscode = STATUSCODE_INVALID;
+  }
+  worker->pBack->status = STATUS_FTP_READY;
+
+  /* The status store above was this worker's last read of the slot and of opt;
+     deregistering lets the engine free both. */
+  ftp_worker_unregister(worker);
+  freet(worker);
+}
+
+/* Tail of every worker, run by the thread layer even when a thread runner
+   recovered from a fault and cut the body short (see hts_newthread_tail). */
+static void ftp_worker_done(void *pP) {
+  FTPDownloadStruct *const worker = (FTPDownloadStruct *) pP;
+
+  ftp_worker_reap(worker,
+                  worker->completed ? NULL : "FTP transfer interrupted");
+}
+
 void back_launch_ftp(void *pP) {
   FTPDownloadStruct *pStruct = (FTPDownloadStruct *) pP;
 
@@ -130,19 +154,12 @@ void back_launch_ftp(void *pP) {
   printf("[Launching main ftp routine]\n");
 #endif
   run_launch_ftp(pStruct);
-  // prêt
-  pStruct->pBack->status = STATUS_FTP_READY;
 
   /* Uninitialize */
   hts_uninit();
 
-  /* The status store above was this worker's last read of the slot and of opt;
-     deregistering lets the engine free both. */
-  ftp_worker_unregister(pStruct);
-
-  /* Delete structure */
-  free(pP);
-  return;
+  /* ftp_worker_done() takes it from here, on this thread. */
+  pStruct->completed = HTS_TRUE;
 }
 
 // lancer en back
@@ -151,15 +168,12 @@ void launch_ftp(FTPDownloadStruct * params) {
 #if FTP_DEBUG
   printf("[Launching main ftp thread]\n");
 #endif
+  params->completed = HTS_FALSE;
   ftp_worker_register(params);
-  if (hts_newthread(back_launch_ftp, (void *) params) != 0) {
-    /* Nobody would ever reap a slot left in STATUS_FTP_TRANSFER, and
-       ftp_stop_workers() would never return. */
-    ftp_worker_unregister(params);
-    strcpybuff(params->pBack->r.msg, "Unable to launch FTP thread");
-    params->pBack->r.statuscode = STATUSCODE_INVALID;
-    params->pBack->status = STATUS_FTP_READY;
-    free(params);
+  if (hts_newthread_tail(back_launch_ftp, (void *) params, ftp_worker_done) !=
+      0) {
+    /* ftp_stop_workers() would never return on a slot left registered. */
+    ftp_worker_reap(params, "Unable to launch FTP thread");
   }
 }
 

--- a/src/htsftp.h
+++ b/src/htsftp.h
@@ -56,7 +56,8 @@ struct FTPDownloadStruct {
   lien_back *pBack;
   httrackp *pOpt;
   FTPDownloadStruct *pNext; /* live-worker list, owned by htsftp.c */
-  hts_boolean completed;    /* Did the worker body run to its end? */
+  /* Did back_launch_ftp() reach its end? launch_ftp() clears it. */
+  hts_boolean body_returned;
 };
 
 /* Library internal definictions */

--- a/src/htsftp.h
+++ b/src/htsftp.h
@@ -71,6 +71,9 @@ void back_launch_ftp(void *pP);
 /* Cancel every live FTP worker and block until each stops touching its backlog
    slot and opt. Call before freeing either. */
 void ftp_stop_workers(void);
+/* Run a worker's tail on a finished and on a cut-short transfer, asserting what
+   the crawl thread reads back. Returns the number of failed checks. */
+int ftp_worker_selftests(void);
 #else
 void launch_ftp(FTPDownloadStruct * params, char *path, char *exec);
 int back_launch_ftp(FTPDownloadStruct * params);

--- a/src/htsftp.h
+++ b/src/htsftp.h
@@ -56,6 +56,7 @@ struct FTPDownloadStruct {
   lien_back *pBack;
   httrackp *pOpt;
   FTPDownloadStruct *pNext; /* live-worker list, owned by htsftp.c */
+  hts_boolean completed;    /* Did the worker body run to its end? */
 };
 
 /* Library internal definictions */

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -5701,9 +5701,8 @@ static void dns_resolve_thread(void *arg) {
   hts_mutexrelease(&job->lock);
 }
 
-/* Runs even where a thread runner recovered from a fault mid-resolve (see
-   hts_newthread_tail), and the caller waits on 'done' alone when it asked for
-   no timeout. A -1 count is what it reads as "no answer to cache". */
+/* Releases the job whatever the body did (see hts_newthread_tail). A -1 count
+   is what the caller reads as "no answer", so it caches nothing. */
 static void dns_resolve_done(void *arg) {
   dns_resolve_job *const job = (dns_resolve_job *) arg;
 

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -5699,6 +5699,20 @@ static void dns_resolve_thread(void *arg) {
   job->permanent = permanent;
   job->done = HTS_TRUE; /* published last: gates the caller's read of addr[] */
   hts_mutexrelease(&job->lock);
+}
+
+/* Runs even where a thread runner recovered from a fault mid-resolve (see
+   hts_newthread_tail), and the caller waits on 'done' alone when it asked for
+   no timeout. A -1 count is what it reads as "no answer to cache". */
+static void dns_resolve_done(void *arg) {
+  dns_resolve_job *const job = (dns_resolve_job *) arg;
+
+  hts_mutexlock(&job->lock);
+  if (!job->done) {
+    job->count = -1;
+    job->done = HTS_TRUE;
+  }
+  hts_mutexrelease(&job->lock);
   dns_job_release(job);
 }
 
@@ -5724,7 +5738,7 @@ static int hts_dns_resolve_nocache_list_bounded(
   hts_mutexinit(&job->lock);
   job->hostname = strdupt(hostname);
   job->refcount = 2; /* this caller + the worker */
-  if (hts_newthread(dns_resolve_thread, job) != 0) {
+  if (hts_newthread_tail(dns_resolve_thread, job, dns_resolve_done) != 0) {
     job->refcount = 1; /* no worker: fall back to resolving inline */
     dns_job_release(job);
     return hts_dns_resolve_nocache_list(hostname, out, max, error, permanent);

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -91,6 +91,7 @@ Please visit our Website: http://www.httrack.com
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
+#include <setjmp.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -13438,6 +13439,13 @@ static int threadrunner_seen_before = 0;
 static int threadrunner_seen_after = 0;
 static threadrunner_id threadrunner_body_thread;
 static threadrunner_id threadrunner_runner_thread;
+static int threadrunner_tail = 0;
+/* The body count as the tail read it. */
+static int threadrunner_tail_seen_body = 0;
+static threadrunner_id threadrunner_tail_thread;
+/* Armed for the regime where the runner recovers out of the body. */
+static hts_boolean threadrunner_recover = HTS_FALSE;
+static jmp_buf threadrunner_jmp;
 
 static void threadrunner_count(int *what) {
   hts_mutexlock(&threadrunner_lock);
@@ -13451,6 +13459,8 @@ static void threadrunner_reset(void) {
   threadrunner_body = 0;
   threadrunner_seen_before = 0;
   threadrunner_seen_after = 0;
+  threadrunner_tail = 0;
+  threadrunner_tail_seen_body = 0;
 }
 
 static void threadrunner_body_fn(void *arg) {
@@ -13463,20 +13473,51 @@ static void threadrunner_body_fn(void *arg) {
   hts_mutexrelease(&threadrunner_lock);
 }
 
+/* Leaves the body where a fault recovery does, so nothing after the jump in
+   the body runs. A real runner gets there through siglongjmp() out of a signal
+   handler; what the engine sees is the same. */
+static void threadrunner_cut_fn(void *arg) {
+  (void) arg;
+  hts_mutexlock(&threadrunner_lock);
+  threadrunner_body_thread = threadrunner_self();
+  threadrunner_body++;
+  hts_mutexrelease(&threadrunner_lock);
+  longjmp(threadrunner_jmp, 1);
+}
+
+static void threadrunner_tail_fn(void *arg) {
+  (void) arg;
+  hts_mutexlock(&threadrunner_lock);
+  threadrunner_tail_seen_body = threadrunner_body;
+  threadrunner_tail_thread = threadrunner_self();
+  threadrunner_tail++;
+  hts_mutexrelease(&threadrunner_lock);
+}
+
 static void threadrunner_runner(void (*fun)(void *arg), void *arg) {
   threadrunner_runner_thread = threadrunner_self();
   threadrunner_count(&threadrunner_before);
-  fun(arg);
+  if (threadrunner_recover) {
+    if (setjmp(threadrunner_jmp) == 0)
+      fun(arg);
+  } else {
+    fun(arg);
+  }
   threadrunner_count(&threadrunner_after);
 }
 
-static hts_boolean threadrunner_spawn(void) {
-  if (hts_newthread(threadrunner_body_fn, NULL) != 0) {
+static hts_boolean threadrunner_spawn_body(void (*fun)(void *arg),
+                                           void (*tail)(void *arg)) {
+  if (hts_newthread_tail(fun, NULL, tail) != 0) {
     fprintf(stderr, "threadrunner: cannot spawn\n");
     return HTS_FALSE;
   }
   htsthread_wait();
   return HTS_TRUE;
+}
+
+static hts_boolean threadrunner_spawn(void) {
+  return threadrunner_spawn_body(threadrunner_body_fn, NULL);
 }
 
 static int st_threadrunner(httrackp *opt, int argc, char **argv) {
@@ -13543,6 +13584,50 @@ static int st_threadrunner(httrackp *opt, int argc, char **argv) {
   }
   if (threadrunner_same(threadrunner_body_thread, caller)) {
     fprintf(stderr, "threadrunner: the body ran on the caller's thread\n");
+    err = 1;
+  }
+
+  /* A tail runs on the worker once the body is over, whether or not the body
+     reached its own end. The FTP worker list is released there. */
+  threadrunner_reset();
+  if (!threadrunner_spawn_body(threadrunner_body_fn, threadrunner_tail_fn))
+    return 1;
+  if (threadrunner_body != 1 || threadrunner_tail != 1) {
+    fprintf(stderr, "threadrunner: body %d time(s) and tail %d, expected 1/1\n",
+            threadrunner_body, threadrunner_tail);
+    err = 1;
+  }
+  if (threadrunner_tail_seen_body != 1) {
+    fprintf(stderr, "threadrunner: the tail ran before the body\n");
+    err = 1;
+  }
+
+  threadrunner_reset();
+  threadrunner_recover = HTS_TRUE;
+  if (hts_set_thread_runner(threadrunner_runner) != NULL) {
+    fprintf(stderr, "threadrunner: a runner was installed already\n");
+    return 1;
+  }
+  spawned = threadrunner_spawn_body(threadrunner_cut_fn, threadrunner_tail_fn);
+  hts_set_thread_runner(NULL);
+  threadrunner_recover = HTS_FALSE;
+  if (!spawned)
+    return 1;
+  /* The runner left normally, so the engine saw a worker whose body stopped
+     halfway and nothing else. */
+  if (threadrunner_body != 1 || threadrunner_after != 1) {
+    fprintf(stderr, "threadrunner: recovery ran the body %d time(s), left %d\n",
+            threadrunner_body, threadrunner_after);
+    err = 1;
+  }
+  if (threadrunner_tail != 1 || threadrunner_tail_seen_body != 1) {
+    fprintf(stderr,
+            "threadrunner: a cut-short body ran the tail %d time(s), at %d\n",
+            threadrunner_tail, threadrunner_tail_seen_body);
+    err = 1;
+  } else if (!threadrunner_same(threadrunner_tail_thread,
+                                threadrunner_body_thread)) {
+    fprintf(stderr, "threadrunner: the tail ran off the worker thread\n");
     err = 1;
   }
 

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -13522,7 +13522,6 @@ static int st_threadrunner(httrackp *opt, int argc, char **argv) {
   hts_boolean spawned;
   int err = 0;
 
-  (void) opt;
   (void) argc;
   (void) argv;
 
@@ -13602,6 +13601,10 @@ static int st_threadrunner(httrackp *opt, int argc, char **argv) {
     fprintf(stderr, "threadrunner: the tail got another worker's arg\n");
     err = 1;
   }
+  if (hts_worker_faulted()) {
+    fprintf(stderr, "threadrunner: a body that finished reads as a fault\n");
+    err = 1;
+  }
 
   /* The body jumps out of threadrunner_cut_fn, so only the tail can reap the
      worker. */
@@ -13635,6 +13638,36 @@ static int st_threadrunner(httrackp *opt, int argc, char **argv) {
     fprintf(stderr,
             "threadrunner: a cut-short body gave the tail another arg\n");
     err = 1;
+  }
+
+  /* The mirror gives up on it, and says so through the exit status rather than
+     reading as a stop the user asked for. */
+  if (!hts_worker_faulted()) {
+    fprintf(stderr, "threadrunner: a cut-short body raised no fault\n");
+    err = 1;
+  }
+  {
+    FILE *const saved_log = opt->log;
+
+    opt->log = NULL; /* the abort logs, and this test's own output is exact */
+    opt->state.stop = 0;
+    opt->state.exit_xh = 0;
+    back_checkmirror(opt);
+    if (opt->state.stop != 1 || opt->state.exit_xh != -1) {
+      fprintf(stderr, "threadrunner: the mirror read the fault as stop %d/%d\n",
+              opt->state.stop, opt->state.exit_xh);
+      err = 1;
+    }
+    opt->state.stop = 0;
+    opt->state.exit_xh = 0;
+    hts_worker_fault_clear();
+    back_checkmirror(opt);
+    if (opt->state.exit_xh != 0) {
+      fprintf(stderr,
+              "threadrunner: a cleared fault still aborted the mirror\n");
+      err = 1;
+    }
+    opt->log = saved_log;
   }
 
   printf("threadrunner self-test: %s\n", err ? "FAIL" : "OK");

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -13442,6 +13442,9 @@ static threadrunner_id threadrunner_runner_thread;
 static int threadrunner_tail = 0;
 static int threadrunner_body_at_tail = 0;
 static threadrunner_id threadrunner_tail_thread;
+/* Its address is the worker's arg, so a tail handed another pointer shows. */
+static int threadrunner_owner;
+static void *threadrunner_tail_arg = NULL;
 static jmp_buf threadrunner_jmp;
 
 static void threadrunner_count(int *what) {
@@ -13458,6 +13461,7 @@ static void threadrunner_reset(void) {
   threadrunner_seen_after = 0;
   threadrunner_tail = 0;
   threadrunner_body_at_tail = 0;
+  threadrunner_tail_arg = NULL;
 }
 
 static void threadrunner_body_fn(void *arg) {
@@ -13482,8 +13486,8 @@ static void threadrunner_cut_fn(void *arg) {
 }
 
 static void threadrunner_tail_fn(void *arg) {
-  (void) arg;
   hts_mutexlock(&threadrunner_lock);
+  threadrunner_tail_arg = arg;
   threadrunner_body_at_tail = threadrunner_body;
   threadrunner_tail_thread = threadrunner_self();
   threadrunner_tail++;
@@ -13501,7 +13505,7 @@ static void threadrunner_runner(void (*fun)(void *arg), void *arg) {
 
 static hts_boolean threadrunner_spawn_body(void (*fun)(void *arg),
                                            void (*tail)(void *arg)) {
-  if (hts_newthread_tail(fun, NULL, tail) != 0) {
+  if (hts_newthread_tail(fun, &threadrunner_owner, tail) != 0) {
     fprintf(stderr, "threadrunner: cannot spawn\n");
     return HTS_FALSE;
   }
@@ -13594,6 +13598,10 @@ static int st_threadrunner(httrackp *opt, int argc, char **argv) {
     fprintf(stderr, "threadrunner: the tail ran before the body\n");
     err = 1;
   }
+  if (threadrunner_tail_arg != &threadrunner_owner) {
+    fprintf(stderr, "threadrunner: the tail got another worker's arg\n");
+    err = 1;
+  }
 
   /* The body jumps out of threadrunner_cut_fn, so only the tail can reap the
      worker. */
@@ -13623,8 +13631,23 @@ static int st_threadrunner(httrackp *opt, int argc, char **argv) {
     fprintf(stderr, "threadrunner: the tail ran off the worker thread\n");
     err = 1;
   }
+  if (threadrunner_tail_arg != &threadrunner_owner) {
+    fprintf(stderr,
+            "threadrunner: a cut-short body gave the tail another arg\n");
+    err = 1;
+  }
 
   printf("threadrunner self-test: %s\n", err ? "FAIL" : "OK");
+  return err;
+}
+
+static int st_ftpworker(httrackp *opt, int argc, char **argv) {
+  const int err = ftp_worker_selftests();
+
+  (void) opt;
+  (void) argc;
+  (void) argv;
+  printf("ftp-worker-selftest: %s\n", err ? "FAIL" : "OK");
   return err;
 }
 
@@ -15621,6 +15644,8 @@ static const struct selftest_entry {
     {"threadrunner", "",
      "a registered thread runner encloses each worker body exactly once",
      st_threadrunner},
+    {"ftpworker", "", "an FTP worker's tail hands its backlog slot back",
+     st_ftpworker},
     {"charset", "<charset> <hex:..|string>",
      "convert a string to UTF-8 from a charset", st_charset},
     {"syscharset", "", "UTF-8 <-> system codepage conversion (WIN32 only)",

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -13440,11 +13440,8 @@ static int threadrunner_seen_after = 0;
 static threadrunner_id threadrunner_body_thread;
 static threadrunner_id threadrunner_runner_thread;
 static int threadrunner_tail = 0;
-/* The body count as the tail read it. */
-static int threadrunner_tail_seen_body = 0;
+static int threadrunner_body_at_tail = 0;
 static threadrunner_id threadrunner_tail_thread;
-/* Armed for the regime where the runner recovers out of the body. */
-static hts_boolean threadrunner_recover = HTS_FALSE;
 static jmp_buf threadrunner_jmp;
 
 static void threadrunner_count(int *what) {
@@ -13460,7 +13457,7 @@ static void threadrunner_reset(void) {
   threadrunner_seen_before = 0;
   threadrunner_seen_after = 0;
   threadrunner_tail = 0;
-  threadrunner_tail_seen_body = 0;
+  threadrunner_body_at_tail = 0;
 }
 
 static void threadrunner_body_fn(void *arg) {
@@ -13473,9 +13470,8 @@ static void threadrunner_body_fn(void *arg) {
   hts_mutexrelease(&threadrunner_lock);
 }
 
-/* Leaves the body where a fault recovery does, so nothing after the jump in
-   the body runs. A real runner gets there through siglongjmp() out of a signal
-   handler; what the engine sees is the same. */
+/* Leaves the body the way a fault recovery does, so nothing after the jump
+   runs. A real runner gets there through siglongjmp(). */
 static void threadrunner_cut_fn(void *arg) {
   (void) arg;
   hts_mutexlock(&threadrunner_lock);
@@ -13488,7 +13484,7 @@ static void threadrunner_cut_fn(void *arg) {
 static void threadrunner_tail_fn(void *arg) {
   (void) arg;
   hts_mutexlock(&threadrunner_lock);
-  threadrunner_tail_seen_body = threadrunner_body;
+  threadrunner_body_at_tail = threadrunner_body;
   threadrunner_tail_thread = threadrunner_self();
   threadrunner_tail++;
   hts_mutexrelease(&threadrunner_lock);
@@ -13497,12 +13493,9 @@ static void threadrunner_tail_fn(void *arg) {
 static void threadrunner_runner(void (*fun)(void *arg), void *arg) {
   threadrunner_runner_thread = threadrunner_self();
   threadrunner_count(&threadrunner_before);
-  if (threadrunner_recover) {
-    if (setjmp(threadrunner_jmp) == 0)
-      fun(arg);
-  } else {
+  /* Stands in for a fault handler's own jump buffer. */
+  if (setjmp(threadrunner_jmp) == 0)
     fun(arg);
-  }
   threadrunner_count(&threadrunner_after);
 }
 
@@ -13597,20 +13590,20 @@ static int st_threadrunner(httrackp *opt, int argc, char **argv) {
             threadrunner_body, threadrunner_tail);
     err = 1;
   }
-  if (threadrunner_tail_seen_body != 1) {
+  if (threadrunner_body_at_tail != 1) {
     fprintf(stderr, "threadrunner: the tail ran before the body\n");
     err = 1;
   }
 
+  /* The body jumps out of threadrunner_cut_fn, so only the tail can reap the
+     worker. */
   threadrunner_reset();
-  threadrunner_recover = HTS_TRUE;
   if (hts_set_thread_runner(threadrunner_runner) != NULL) {
     fprintf(stderr, "threadrunner: a runner was installed already\n");
     return 1;
   }
   spawned = threadrunner_spawn_body(threadrunner_cut_fn, threadrunner_tail_fn);
   hts_set_thread_runner(NULL);
-  threadrunner_recover = HTS_FALSE;
   if (!spawned)
     return 1;
   /* The runner left normally, so the engine saw a worker whose body stopped
@@ -13620,10 +13613,10 @@ static int st_threadrunner(httrackp *opt, int argc, char **argv) {
             threadrunner_body, threadrunner_after);
     err = 1;
   }
-  if (threadrunner_tail != 1 || threadrunner_tail_seen_body != 1) {
+  if (threadrunner_tail != 1 || threadrunner_body_at_tail != 1) {
     fprintf(stderr,
             "threadrunner: a cut-short body ran the tail %d time(s), at %d\n",
-            threadrunner_tail, threadrunner_tail_seen_body);
+            threadrunner_tail, threadrunner_body_at_tail);
     err = 1;
   } else if (!threadrunner_same(threadrunner_tail_thread,
                                 threadrunner_body_thread)) {

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -13691,6 +13691,24 @@ static int st_threadrunner(httrackp *opt, int argc, char **argv) {
     opt->log = saved_log;
   }
 
+  /* Round 0 is the only round the cases above ran in, and no mirror uses it:
+     each one takes the next round as it starts. */
+  hts_worker_fault_clear();
+  threadrunner_reset();
+  if (hts_set_thread_runner(threadrunner_runner) != NULL) {
+    fprintf(stderr, "threadrunner: a runner was installed already\n");
+    return 1;
+  }
+  spawned = threadrunner_spawn_body(threadrunner_cut_fn, threadrunner_tail_fn);
+  hts_set_thread_runner(NULL);
+  if (!spawned)
+    return 1;
+  if (!hts_worker_faulted()) {
+    fprintf(stderr, "threadrunner: no fault past the first round\n");
+    err = 1;
+  }
+  hts_worker_fault_clear();
+
   /* A fault raised after its own mirror ended aborts nothing. */
   threadrunner_reset();
   if (hts_set_thread_runner(threadrunner_runner) != NULL) {

--- a/src/htsselftest.c
+++ b/src/htsselftest.c
@@ -13485,6 +13485,18 @@ static void threadrunner_cut_fn(void *arg) {
   longjmp(threadrunner_jmp, 1);
 }
 
+/* A worker an earlier mirror abandoned: the round moves on before the fault, so
+   the fault belongs to a mirror that is over. */
+static void threadrunner_stale_fn(void *arg) {
+  (void) arg;
+  hts_mutexlock(&threadrunner_lock);
+  threadrunner_body_thread = threadrunner_self();
+  threadrunner_body++;
+  hts_mutexrelease(&threadrunner_lock);
+  hts_worker_fault_clear(); /* as the next mirror does when it starts */
+  longjmp(threadrunner_jmp, 1);
+}
+
 static void threadrunner_tail_fn(void *arg) {
   hts_mutexlock(&threadrunner_lock);
   threadrunner_tail_arg = arg;
@@ -13658,6 +13670,15 @@ static int st_threadrunner(httrackp *opt, int argc, char **argv) {
               opt->state.stop, opt->state.exit_xh);
       err = 1;
     }
+    /* a stop the user asked for exits 0, so the fault's verdict outranks it */
+    opt->state.stop = 1;
+    opt->state.exit_xh = 1;
+    back_check_worker_fault(opt);
+    if (opt->state.exit_xh != -1) {
+      fprintf(stderr, "threadrunner: a user stop swallowed the fault (%d)\n",
+              opt->state.exit_xh);
+      err = 1;
+    }
     opt->state.stop = 0;
     opt->state.exit_xh = 0;
     hts_worker_fault_clear();
@@ -13668,6 +13689,27 @@ static int st_threadrunner(httrackp *opt, int argc, char **argv) {
       err = 1;
     }
     opt->log = saved_log;
+  }
+
+  /* A fault raised after its own mirror ended aborts nothing. */
+  threadrunner_reset();
+  if (hts_set_thread_runner(threadrunner_runner) != NULL) {
+    fprintf(stderr, "threadrunner: a runner was installed already\n");
+    return 1;
+  }
+  spawned =
+      threadrunner_spawn_body(threadrunner_stale_fn, threadrunner_tail_fn);
+  hts_set_thread_runner(NULL);
+  if (!spawned)
+    return 1;
+  if (threadrunner_body != 1 || threadrunner_tail != 1) {
+    fprintf(stderr, "threadrunner: the stale round ran %d body and %d tail\n",
+            threadrunner_body, threadrunner_tail);
+    err = 1;
+  }
+  if (hts_worker_faulted()) {
+    fprintf(stderr, "threadrunner: a fault from a finished mirror was kept\n");
+    err = 1;
   }
 
   printf("threadrunner self-test: %s\n", err ? "FAIL" : "OK");

--- a/src/htsthread.c
+++ b/src/htsthread.c
@@ -140,8 +140,7 @@ static void *hts_entry_point(void *tharg)
     thread_runner(fun, arg);
   else
     fun(arg);
-  /* Here and not at the end of the body: a runner recovering from a fault
-     returns with the rest of the body skipped. */
+  /* Not at the end of the body, because a recovered fault never gets there. */
   if (tail != NULL)
     tail(arg);
   if (thread_leave != NULL)

--- a/src/htsthread.c
+++ b/src/htsthread.c
@@ -97,6 +97,7 @@ typedef struct hts_thread_s {
   void *arg;
   void (*fun) (void *arg);
   void (*tail)(void *arg);
+  int round;
 } hts_thread_s;
 
 /* A body and whether it reached its end. */
@@ -113,15 +114,20 @@ static void hts_run_body(void *arg) {
   body->returned = HTS_TRUE;
 }
 
-/* Set by a worker a fault recovery cut short, read and cleared by the crawl
-   thread. Process-global, like the runner that does the recovering, and a plain
-   flag because a worker thread must not touch opt: the mirror may already have
-   freed it (see dns_resolve_thread). */
+/* Set by a worker a fault recovery cut short. A plain flag rather than a field
+   on opt, because a worker must not touch opt at all: it outlives a timed-out
+   resolve, and the mirror frees opt before the thread wait at exit. */
 static volatile hts_boolean worker_faulted = HTS_FALSE;
+/* Each mirror takes the next round, and a worker keeps the round it was spawned
+   in, so one abandoned by an earlier mirror cannot abort this one. */
+static volatile int mirror_round = 0;
 
 hts_boolean hts_worker_faulted(void) { return worker_faulted; }
 
-void hts_worker_fault_clear(void) { worker_faulted = HTS_FALSE; }
+void hts_worker_fault_clear(void) {
+  mirror_round++; /* first, so a straggler can no longer raise the flag */
+  worker_faulted = HTS_FALSE;
+}
 
 /* Set once before any thread is spawned, hence unlocked. */
 static void *(*thread_enter)(void) = NULL;
@@ -153,6 +159,7 @@ static void *hts_entry_point(void *tharg)
   hts_thread_s *s_args = (hts_thread_s *) tharg;
   void *const arg = s_args->arg;
   void (*const tail)(void *arg) = s_args->tail;
+  const int round = s_args->round;
   hts_body_s body;
   void *cookie;
 
@@ -167,9 +174,8 @@ static void *hts_entry_point(void *tharg)
     thread_runner(hts_run_body, &body);
   else
     hts_run_body(&body);
-  /* Nothing can audit what the fault left behind, so the mirror gives up. The
-     crawl thread performs it, being the one that holds opt. */
-  if (!body.returned)
+  /* back_check_worker_fault() reads this and gives up the mirror. */
+  if (!body.returned && round == mirror_round)
     worker_faulted = HTS_TRUE;
   /* Not at the end of the body, because a recovered fault never gets there. */
   if (tail != NULL)
@@ -198,6 +204,7 @@ int hts_newthread_tail(void (*fun)(void *arg), void *arg,
   s_args->arg = arg;
   s_args->fun = fun;
   s_args->tail = tail;
+  s_args->round = mirror_round;
   process_chain_add(1);
 #ifdef _WIN32
   {

--- a/src/htsthread.c
+++ b/src/htsthread.c
@@ -96,6 +96,7 @@ HTSEXT_API void htsthread_uninit(void) {
 typedef struct hts_thread_s {
   void *arg;
   void (*fun) (void *arg);
+  void (*tail)(void *arg);
 } hts_thread_s;
 
 /* Set once before any thread is spawned, hence unlocked. */
@@ -128,6 +129,7 @@ static void *hts_entry_point(void *tharg)
   hts_thread_s *s_args = (hts_thread_s *) tharg;
   void *const arg = s_args->arg;
   void (*fun) (void *arg) = s_args->fun;
+  void (*const tail)(void *arg) = s_args->tail;
   void *cookie;
 
   freet(tharg);
@@ -138,6 +140,10 @@ static void *hts_entry_point(void *tharg)
     thread_runner(fun, arg);
   else
     fun(arg);
+  /* Here and not at the end of the body: a runner recovering from a fault
+     returns with the rest of the body skipped. */
+  if (tail != NULL)
+    tail(arg);
   if (thread_leave != NULL)
     thread_leave(cookie);
 
@@ -151,11 +157,17 @@ static void *hts_entry_point(void *tharg)
 
 /* create a thread */
 HTSEXT_API int hts_newthread(void (*fun) (void *arg), void *arg) {
+  return hts_newthread_tail(fun, arg, NULL);
+}
+
+int hts_newthread_tail(void (*fun)(void *arg), void *arg,
+                       void (*tail)(void *arg)) {
   hts_thread_s *s_args = malloct(sizeof(hts_thread_s));
 
   assertf(s_args != NULL);
   s_args->arg = arg;
   s_args->fun = fun;
+  s_args->tail = tail;
   process_chain_add(1);
 #ifdef _WIN32
   {

--- a/src/htsthread.c
+++ b/src/htsthread.c
@@ -99,6 +99,30 @@ typedef struct hts_thread_s {
   void (*tail)(void *arg);
 } hts_thread_s;
 
+/* A body and whether it reached its end. */
+typedef struct hts_body_s {
+  void *arg;
+  void (*fun)(void *arg);
+  hts_boolean returned;
+} hts_body_s;
+
+static void hts_run_body(void *arg) {
+  hts_body_s *const body = (hts_body_s *) arg;
+
+  body->fun(body->arg);
+  body->returned = HTS_TRUE;
+}
+
+/* Set by a worker a fault recovery cut short, read and cleared by the crawl
+   thread. Process-global, like the runner that does the recovering, and a plain
+   flag because a worker thread must not touch opt: the mirror may already have
+   freed it (see dns_resolve_thread). */
+static volatile hts_boolean worker_faulted = HTS_FALSE;
+
+hts_boolean hts_worker_faulted(void) { return worker_faulted; }
+
+void hts_worker_fault_clear(void) { worker_faulted = HTS_FALSE; }
+
 /* Set once before any thread is spawned, hence unlocked. */
 static void *(*thread_enter)(void) = NULL;
 static void (*thread_leave)(void *cookie) = NULL;
@@ -128,18 +152,25 @@ static void *hts_entry_point(void *tharg)
 {
   hts_thread_s *s_args = (hts_thread_s *) tharg;
   void *const arg = s_args->arg;
-  void (*fun) (void *arg) = s_args->fun;
   void (*const tail)(void *arg) = s_args->tail;
+  hts_body_s body;
   void *cookie;
 
+  body.fun = s_args->fun;
+  body.arg = arg;
+  body.returned = HTS_FALSE;
   freet(tharg);
 
   cookie = thread_enter != NULL ? thread_enter() : NULL;
   /* run */
   if (thread_runner != NULL)
-    thread_runner(fun, arg);
+    thread_runner(hts_run_body, &body);
   else
-    fun(arg);
+    hts_run_body(&body);
+  /* Nothing can audit what the fault left behind, so the mirror gives up. The
+     crawl thread performs it, being the one that holds opt. */
+  if (!body.returned)
+    worker_faulted = HTS_TRUE;
   /* Not at the end of the body, because a recovered fault never gets there. */
   if (tail != NULL)
     tail(arg);

--- a/src/htsthread.h
+++ b/src/htsthread.h
@@ -63,6 +63,12 @@ struct htsmutex_s {
 /* Library internal definictions */
 HTSEXT_API int hts_newthread(void (*fun) (void *arg), void *arg);
 
+/* Same, plus 'tail(arg)' on the worker once the body is over. A thread runner
+   (see hts_set_thread_runner()) that recovers from a fault returns with the
+   body's own tail skipped, so cleanup the engine needs goes here instead. */
+int hts_newthread_tail(void (*fun)(void *arg), void *arg,
+                       void (*tail)(void *arg));
+
 /* Extends per-thread state to the workers: 'enter' runs at each one's start,
    'leave' at its end with the cookie 'enter' returned. Set before spawning; a
    NULL in either clears the pair, since neither hook is useful alone. */

--- a/src/htsthread.h
+++ b/src/htsthread.h
@@ -71,6 +71,13 @@ HTSEXT_API int hts_newthread(void (*fun) (void *arg), void *arg);
 HTS_CHECK_RESULT int hts_newthread_tail(void (*fun)(void *arg), void *arg,
                                         void (*tail)(void *arg));
 
+/* HTS_TRUE where a thread runner recovered from a fault since the last clear,
+   so a worker stopped halfway through its body. Read on the crawl thread:
+   back_checkmirror() turns it into a stop, and a mirror clears it at its
+   start. */
+hts_boolean hts_worker_faulted(void);
+void hts_worker_fault_clear(void);
+
 /* Extends per-thread state to the workers: 'enter' runs at each one's start,
    'leave' at its end with the cookie 'enter' returned. Set before spawning; a
    NULL in either clears the pair, since neither hook is useful alone. */

--- a/src/htsthread.h
+++ b/src/htsthread.h
@@ -71,11 +71,12 @@ HTSEXT_API int hts_newthread(void (*fun) (void *arg), void *arg);
 HTS_CHECK_RESULT int hts_newthread_tail(void (*fun)(void *arg), void *arg,
                                         void (*tail)(void *arg));
 
-/* HTS_TRUE where a thread runner recovered from a fault since the last clear,
-   so a worker stopped halfway through its body. Read on the crawl thread:
-   back_checkmirror() turns it into a stop, and a mirror clears it at its
-   start. */
+/* HTS_TRUE where a thread runner recovered from a fault, so a worker stopped
+   halfway through its body. Read on the crawl thread, which turns it into a
+   stop in back_check_worker_fault(). */
 hts_boolean hts_worker_faulted(void);
+/* Forget any fault, and take the next round so that a worker an earlier mirror
+   abandoned cannot abort this one. Called by a mirror as it starts. */
 void hts_worker_fault_clear(void);
 
 /* Extends per-thread state to the workers: 'enter' runs at each one's start,

--- a/src/htsthread.h
+++ b/src/htsthread.h
@@ -63,11 +63,13 @@ struct htsmutex_s {
 /* Library internal definictions */
 HTSEXT_API int hts_newthread(void (*fun) (void *arg), void *arg);
 
-/* Same, plus 'tail(arg)' on the worker once the body is over. A thread runner
-   (see hts_set_thread_runner()) that recovers from a fault returns with the
-   body's own tail skipped, so cleanup the engine needs goes here instead. */
-int hts_newthread_tail(void (*fun)(void *arg), void *arg,
-                       void (*tail)(void *arg));
+/* Also runs 'tail(arg)' on the worker once the body is over, and only when this
+   returns 0. A thread runner (see hts_set_thread_runner()) that recovers from a
+   fault returns without running the rest of the body, so cleanup the engine
+   needs goes here. Not exported, because no caller outside the library spawns a
+   worker. */
+HTS_CHECK_RESULT int hts_newthread_tail(void (*fun)(void *arg), void *arg,
+                                        void (*tail)(void *arg));
 
 /* Extends per-thread state to the workers: 'enter' runs at each one's start,
    'leave' at its end with the cookie 'enter' returned. Set before spawning; a

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -821,8 +821,10 @@ typedef void (*hts_thread_runner)(void (*fun)(void *arg), void *arg);
     before spawning, since it is read unlocked.
 
     A runner that recovers from a fault may return with 'fun(arg)' cut short.
-    The engine then releases what that worker held, so its work is lost but no
-    other thread waits for it. */
+    The engine releases what that worker held, so no other thread waits for it,
+    then ends the mirror with HTS_EXIT_MIRROR_ABORTED, because nothing can
+    audit what the fault left behind. Recovering keeps the process alive, and it
+    does not make the mirror resumable. */
 HTSEXT_API hts_thread_runner hts_set_thread_runner(hts_thread_runner runner);
 
 /* UTF-8 aware FILE API */

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -823,7 +823,7 @@ typedef void (*hts_thread_runner)(void (*fun)(void *arg), void *arg);
     A runner that recovers from a fault may return with 'fun(arg)' cut short.
     The engine releases what that worker held, so no other thread waits for it,
     then ends the mirror with HTS_EXIT_MIRROR_ABORTED, because nothing can
-    audit what the fault left behind. Recovering keeps the process alive, and it
+    audit what the fault left behind. Recovering keeps the process alive, but it
     does not make the mirror resumable. */
 HTSEXT_API hts_thread_runner hts_set_thread_runner(hts_thread_runner runner);
 

--- a/src/httrack-library.h
+++ b/src/httrack-library.h
@@ -818,7 +818,11 @@ typedef void (*hts_thread_runner)(void (*fun)(void *arg), void *arg);
 
 /** Wraps each worker body in a caller-supplied frame. The runner must call
     'fun(arg)' once, and NULL clears it. Returns the previous runner. Set it
-    before spawning, since it is read unlocked. */
+    before spawning, since it is read unlocked.
+
+    A runner that recovers from a fault may return with 'fun(arg)' cut short.
+    The engine then releases what that worker held, so its work is lost but no
+    other thread waits for it. */
 HTSEXT_API hts_thread_runner hts_set_thread_runner(hts_thread_runner runner);
 
 /* UTF-8 aware FILE API */

--- a/tests/467_engine-ftp-worker-tail.test
+++ b/tests/467_engine-ftp-worker-tail.test
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# An FTP worker's tail hands its backlog slot back, as an error where the
+# transfer was cut short. A worker left on the live list wedges
+# ftp_stop_workers() forever, so the engine asserts the list drains too.
+
+set -eu
+
+out=$(httrack -#test=ftpworker)
+
+test "$out" = "ftp-worker-selftest: OK" || {
+    echo "expected 'ftp-worker-selftest: OK', got: $out" >&2
+    exit 1
+}


### PR DESCRIPTION
A crawl could hang forever at teardown. `back_launch_ftp()` took its worker off the live-worker list on its last line. `ftp_stop_workers()` polls for an empty list with no bound, so a worker that never reached that line wedged the crawl thread.

A worker reaches it unless something cut its body short, which is what a front end's thread runner does. httrack-android now installs one through coffeecatch, to catch a crash signal on an engine worker and recover from it instead of dying.

The thread layer now runs a tail callback once the body is over, whether or not the body got there. FTP hands its slot back from that tail, and the DNS resolver releases its job there.

A worker is not resumable after a crash, so the mirror ends rather than failing the one link. The thread layer raises a flag, and the crawl thread turns it into `HTS_EXIT_MIRROR_ABORTED`, being the only thread that may touch `opt`. A worker carries the round it was spawned in, so one an earlier mirror abandoned cannot abort this one.

Three selftests and seventeen mutants cover it. Two older paths dropped that exit status on the way out, and one of them also swallowed the cache-write abort.