### PR TITLE
-#c cannot fault a live worker, so the recovery path is unreachable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,16 @@ the operational checklist: toolchain, invariants, and how to ship a change.
   against `git ls-files`, so a test you forgot to `git add` fails there instead of
   quietly shrinking CI's suite. Name one outside the pattern and it never runs;
   `tests/check-test-names.sh` (also a CI lint) rejects that.
+- **A test that skips on Windows needs registering twice.** The Windows job
+  compares its skips against the written-out lists in
+  `tests/ci-windows-suite.sh`, so an all-skipped suite cannot report green having
+  tested nothing. A new `skip_on_windows` test reds `libhttrack (x64, Release)`
+  with "skip set changed from expected" until its name is in BOTH the msys and
+  the wsl2 list, with its reason in the comment above them.
+- **`make check` puts a RELATIVE `src/` on `PATH`.** A test that changes
+  directory and then runs `httrack` by name finds the INSTALLED one, which fails
+  in ways that look like the change under test. Resolve the binary to an absolute
+  path before the first `cd`.
 - `make check` prepends the build's `src/` to `PATH`, but a hand-run `.test` does
   not — an installed `/usr/bin/httrack` then shadows your build. Run via `make
   check`, or `PATH="<bld>/src:$PATH"` for a manual run.

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -981,15 +981,25 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
 
       if (a[0] == '-' && a[1] == '#' && a[2] == 'c' &&
           (a[3] == '\0' || a[3] == '=')) {
-        if (!hts_crash_test(a[3] == '=' ? a + 4 : NULL)) {
+        const hts_crash_test_result done =
+            hts_crash_test(a[3] == '=' ? a + 4 : NULL);
+
+        if (done == HTS_CRASH_UNKNOWN) {
           char s[256];
 
           snprintf(s, sizeof(s), "Option #c expects one of: %s",
                    hts_crash_test_kinds());
           HTS_PANIC_PRINTF(s);
+          htsmain_free();
+          return -1;
         }
-        htsmain_free();
-        return -1;
+        if (done == HTS_CRASH_RAN) {
+          htsmain_free();
+          return -1;
+        }
+        /* Armed: the fault waits for a worker, so the mirror has to run. The
+           option parser below takes the argument again, and skips it. */
+        break;
       }
     }
   }
@@ -2366,6 +2376,12 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
           case '#':{           // non documenté
               com++;
               switch (*com) {
+#ifdef HTS_CRASH_TEST
+              case 'c': /* read by the -#c pre-pass, which armed a worker */
+                while (com[1] != '\0')
+                  com++;
+                break;
+#endif
               case 'C':        // list cache files : httrack -#C '*spid*.gif' will attempt to find the matching file
                 {
                   int hasFilter = 0;

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -2377,9 +2377,14 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
               com++;
               switch (*com) {
 #ifdef HTS_CRASH_TEST
-              case 'c': /* read by the -#c pre-pass, which armed a worker */
-                while (com[1] != '\0')
-                  com++;
+              case 'c':
+                /* Read by the -#c pre-pass above, which may have armed a
+                   worker. This exact form only: anything else never reached the
+                   pre-pass, so it keeps the verdict it always had. */
+                if (com == argv[na] + 2 && (com[1] == '\0' || com[1] == '=')) {
+                  while (com[1] != '\0')
+                    com++;
+                }
                 break;
 #endif
               case 'C':        // list cache files : httrack -#C '*spid*.gif' will attempt to find the matching file

--- a/src/htscrashtest.c
+++ b/src/htscrashtest.c
@@ -112,7 +112,7 @@ static void crash_arm_ftp(void) { crash_armed = HTS_CRASH_WORKER_FTP; }
 
 /* See htscrashtest.h. */
 void hts_crash_test_worker(hts_crash_worker which) {
-  if (which == HTS_CRASH_WORKER_NONE || crash_armed != which)
+  if (crash_armed == HTS_CRASH_WORKER_NONE || crash_armed != which)
     return;
   /* Once, so a front end that recovers the fault still reaches the end. */
   crash_armed = HTS_CRASH_WORKER_NONE;

--- a/src/htscrashtest.c
+++ b/src/htscrashtest.c
@@ -102,6 +102,26 @@ static CRASH_NOINLINE char blow_the_stack(size_t depth) {
 /* Faults with no stack left for the handler, unless it runs on an altstack. */
 static CRASH_NOINLINE void crash_stack(void) { (void) blow_the_stack(0); }
 
+/* Armed by an -#c kind, taken by the first worker of that kind the mirror
+   starts. Not on opt: the kinds are process-wide, like the option. */
+static volatile hts_crash_worker crash_armed = HTS_CRASH_WORKER_NONE;
+
+static void crash_arm_dns(void) { crash_armed = HTS_CRASH_WORKER_DNS; }
+
+static void crash_arm_ftp(void) { crash_armed = HTS_CRASH_WORKER_FTP; }
+
+/* See htscrashtest.h. */
+void hts_crash_test_worker(hts_crash_worker which) {
+  if (which == HTS_CRASH_WORKER_NONE || crash_armed != which)
+    return;
+  /* Once, so a front end that recovers the fault still reaches the end. */
+  crash_armed = HTS_CRASH_WORKER_NONE;
+  fprintf(stderr, "** Crash test: faulting a live %s worker\n",
+          which == HTS_CRASH_WORKER_DNS ? "DNS" : "FTP");
+  fflush(stderr);
+  crash_segv();
+}
+
 typedef void (*crash_fn)(void);
 
 static void crash_worker_thread(void *arg) {
@@ -153,14 +173,21 @@ static CRASH_NOINLINE void crash_atfork(void) {
 static const struct {
   const char *name;
   void (*fn)(void);
+  /* Does fn() only arm the fault, leaving the mirror to take it? */
+  hts_boolean arms;
 } crash_kinds[] = {
-    {"segv", crash_segv},
-    {"abort", crash_abort},
-    {"trap", crash_trap},
-    {"stack", crash_stack},
-    {"threadstack", crash_threadstack},
-    {"threadsegv", crash_threadsegv},
-    {"atfork", crash_atfork},
+    {"segv", crash_segv, HTS_FALSE},
+    {"abort", crash_abort, HTS_FALSE},
+    {"trap", crash_trap, HTS_FALSE},
+    {"stack", crash_stack, HTS_FALSE},
+    {"threadstack", crash_threadstack, HTS_FALSE},
+    {"threadsegv", crash_threadsegv, HTS_FALSE},
+    {"atfork", crash_atfork, HTS_FALSE},
+    /* These two wait for a live worker, so the mirror has to run. The fault
+       lands where a recovered one is worth testing: before the resolver
+       publishes its answer, and with the FTP slot already registered. */
+    {"dnssegv", crash_arm_dns, HTS_TRUE},
+    {"ftpsegv", crash_arm_ftp, HTS_TRUE},
 };
 
 #define CRASH_KINDS_COUNT (sizeof(crash_kinds) / sizeof(crash_kinds[0]))
@@ -190,7 +217,7 @@ const char *hts_crash_test_kinds(void) {
   return list;
 }
 
-hts_boolean hts_crash_test(const char *kind) {
+hts_crash_test_result hts_crash_test(const char *kind) {
   size_t i;
 
   if (kind == NULL || *kind == '\0') {
@@ -203,13 +230,16 @@ hts_boolean hts_crash_test(const char *kind) {
               kind);
       fflush(stderr);
       crash_kinds[i].fn();
+      if (crash_kinds[i].arms) {
+        return HTS_CRASH_ARMED;
+      }
       /* Reached only if a handler swallowed the fault and resumed. */
       fprintf(stderr, "** Crash test '%s' did not crash the process\n", kind);
       fflush(stderr);
-      return HTS_TRUE;
+      return HTS_CRASH_RAN;
     }
   }
-  return HTS_FALSE;
+  return HTS_CRASH_UNKNOWN;
 }
 
 #endif

--- a/src/htscrashtest.h
+++ b/src/htscrashtest.h
@@ -40,16 +40,43 @@ Please visit our Website: http://www.httrack.com
 extern "C" {
 #endif
 
+/* Which worker body an arming kind faults. */
+typedef enum {
+  HTS_CRASH_WORKER_NONE = 0,
+  HTS_CRASH_WORKER_DNS,
+  HTS_CRASH_WORKER_FTP
+} hts_crash_worker;
+
 #ifdef HTS_CRASH_TEST
+
+/* What -#c did. A kind that crashes outright does not return, so HTS_CRASH_RAN
+   means a handler recovered from it. HTS_CRASH_ARMED means nothing has faulted
+   yet and the caller must run the mirror, because the fault waits for a live
+   worker. */
+typedef enum {
+  HTS_CRASH_UNKNOWN = 0,
+  HTS_CRASH_RAN,
+  HTS_CRASH_ARMED
+} hts_crash_test_result;
 
 /* Crash the process on purpose, after announcing it on stderr so the log tells
    a deliberate crash from a real one. 'kind' selects the fault and defaults to
-   "segv" when NULL or empty; hts_crash_test_kinds() lists the accepted names.
-   Returns HTS_FALSE, without crashing, only when 'kind' is unknown. */
-hts_boolean hts_crash_test(const char *kind);
+   "segv" when NULL or empty. hts_crash_test_kinds() lists the names. */
+hts_crash_test_result hts_crash_test(const char *kind);
 
 /* The names hts_crash_test() accepts, comma-separated, for diagnostics. */
 const char *hts_crash_test_kinds(void);
+
+/* Fault this worker where -#c armed that kind, once, and do nothing otherwise.
+   Call it inside a worker body, where a fault meets the engine state a real one
+   would. */
+void hts_crash_test_worker(hts_crash_worker which);
+
+#else
+
+#define hts_crash_test_worker(which)                                           \
+  do {                                                                         \
+  } while (0)
 
 #endif
 

--- a/src/htsftp.c
+++ b/src/htsftp.c
@@ -41,6 +41,7 @@ Please visit our Website: http://www.httrack.com
 #include "htscore.h"
 #include "htsio.h"
 #include "htsthread.h"
+#include "htscrashtest.h"
 
 #include <limits.h>
 
@@ -145,6 +146,8 @@ void back_launch_ftp(void *pP) {
 #endif
     return;
   }
+
+  hts_crash_test_worker(HTS_CRASH_WORKER_FTP);
 
   /* Initialize */
   hts_init();

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -5693,7 +5693,6 @@ static void dns_resolve_thread(void *arg) {
   const int count = hts_dns_resolve_nocache_list(
       job->hostname, resolved, HTS_MAXADDRNUM, &error, &permanent);
 
-  /* where -#c=dnssegv lands, with the answer in hand and not yet published */
   hts_crash_test_worker(HTS_CRASH_WORKER_DNS);
   hts_mutexlock(&job->lock);
   dns_copy_addrs(job->addr, resolved, count, HTS_MAXADDRNUM);

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -48,6 +48,7 @@ Please visit our Website: http://www.httrack.com
 #include "htsnet.h"
 #include "htsbauth.h"
 #include "htsthread.h"
+#include "htscrashtest.h"
 #include "htsback.h"
 #include "htsftp.h"
 #include "htswrap.h"
@@ -5692,6 +5693,8 @@ static void dns_resolve_thread(void *arg) {
   const int count = hts_dns_resolve_nocache_list(
       job->hostname, resolved, HTS_MAXADDRNUM, &error, &permanent);
 
+  /* where -#c=dnssegv lands, with the answer in hand and not yet published */
+  hts_crash_test_worker(HTS_CRASH_WORKER_DNS);
   hts_mutexlock(&job->lock);
   dns_copy_addrs(job->addr, resolved, count, HTS_MAXADDRNUM);
   job->count = count;

--- a/tests/468_engine-crash-live-worker.test
+++ b/tests/468_engine-crash-live-worker.test
@@ -2,8 +2,7 @@
 #
 # -#c=dnssegv and -#c=ftpsegv fault a worker of a RUNNING mirror, where every
 # other kind faults before one starts. A front end that recovers such a fault
-# (httrack-android, through coffeecatch) can only be tested against that path,
-# and before these kinds it needed patches of its own.
+# (httrack-android, through coffeecatch) can only be tested against that path.
 
 set -eu
 
@@ -14,41 +13,90 @@ skip_on_windows "the fatal handler takes another path here"
 require_httrack
 have_feature crashtest || skip "built with --disable-crash-test"
 
-ulimit -c 0 # a deliberate crash must not litter the box with cores
+ulimit -c 0 # and the runs below happen in $tmp, so a core would stay there
+
+# By absolute path, because the runs below change directory while the harness
+# puts a RELATIVE src/ on PATH, and a bare name would then find the installed
+# httrack instead of the one under test.
+bin=$(command -v httrack) || fail "no httrack on PATH"
+case $bin in
+/*) ;;
+*) bin="$(cd "$(dirname "$bin")" && pwd)/$(basename "$bin")" ;;
+esac
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_livefault.XXXXXX") || exit 1
 cleanup_push rm -rf "$tmp"
 
 # The handler ends in abort(), so the shell sees SIGABRT whatever faulted.
-expect_crash() { # expect_crash RC NAME
-    test "$1" -ne 124 || fail "$2 outlasted its deadline"
-    test "$1" -eq 134 || fail "$2 exited $1, expected 134 (0 means nothing faulted)"
+expect_crash() { # expect_crash RC NAME FILE
+    test "$1" -ne 124 || fail_dump "$2 outlasted its deadline:" "$3"
+    test "$1" -eq 134 ||
+        fail_dump "$2 exited $1, expected 134 (0 means nothing faulted):" "$3"
+}
+
+# Which signal the handler caught, by name: SIGSEGV is 11 almost everywhere and
+# 10 on a few ports, so never compare the number.
+expect_segv() { # expect_segv FILE NAME
+    local num
+    num=$(sed -n 's/^Caught signal \([0-9][0-9]*\).*/\1/p' "$1" | head -1)
+    test -n "$num" || fail_dump "$2 was not caught by the fatal handler:" "$1"
+    test "$(kill -l "$num" 2>/dev/null)" = "SEGV" ||
+        fail "$2 caught signal $num ($(kill -l "$num" 2>/dev/null)), expected SEGV"
+}
+
+# Name the frames the handler printed as module+offset: -fvisibility=hidden
+# hides the engine's own, so only addr2line can say which function faulted.
+# Returns 1 when nothing resolved, which is a platform answer and not a verdict.
+name_frames() { # name_frames TRACE OUT
+    local mod off
+    build_names_frames && command -v addr2line >/dev/null || return 1
+    : >"$2"
+    sed -n -e 's/^\([^(]*\)(+\(0x[0-9a-f]*\)).*$/\1 \2/p' \
+        -e 's/^\([^(]*\)() \[\(0x[0-9a-f]*\)\].*$/\1 \2/p' "$1" >"$1.frames"
+    while read -r mod off; do
+        test -f "$mod" || mod=$(command -v "$mod" 2>/dev/null) || continue
+        test -f "$mod" || continue
+        addr2line -Cfip -e "$mod" "$off" 2>/dev/null >>"$2" || true
+    done <"$1.frames"
+    test -s "$2"
 }
 
 # The control, and the whole point of the new kinds: a parse-time kind dies
 # before the engine has a project on disk.
 rc=0
-run_with_timeout 60 httrack -#c=segv "ftp://127.0.0.1:9/" -O "$tmp/parsetime" \
-    >"$tmp/parsetime.out" 2>&1 || rc=$?
-expect_crash "$rc" "-#c=segv"
+(cd "$tmp" && run_with_timeout 60 "$bin" -#c=segv "ftp://127.0.0.1:9/" \
+    -O "$tmp/parsetime") >"$tmp/parsetime.out" 2>&1 || rc=$?
+expect_crash "$rc" "-#c=segv" "$tmp/parsetime.out"
 test ! -d "$tmp/parsetime" ||
     fail "-#c=segv reached the mirror, so the control proves nothing"
 
 # Port 9 discards, and the FTP worker faults before it would connect anyway.
 for kind in dnssegv ftpsegv; do
     case $kind in
-    dnssegv) url="http://doesnotexist.invalid/" ;;
-    ftpsegv) url="ftp://127.0.0.1:9/" ;;
+    dnssegv) url="http://doesnotexist.invalid/" worker=DNS fn=dns_resolve_thread ;;
+    ftpsegv) url="ftp://127.0.0.1:9/" worker=FTP fn=back_launch_ftp ;;
     esac
+    out="$tmp/$kind.out"
     rc=0
-    run_with_timeout 120 httrack "-#c=$kind" "$url" -O "$tmp/$kind" --timeout 5 \
-        >"$tmp/$kind.out" 2>&1 || rc=$?
-    expect_crash "$rc" "-#c=$kind"
-    grep -q 'faulting a live' "$tmp/$kind.out" ||
-        fail_dump "$kind printed no fault marker:" "$tmp/$kind.out"
-    grep -q '^Caught signal ' "$tmp/$kind.out" ||
-        fail_dump "$kind went uncaught by the fatal handler:" "$tmp/$kind.out"
+    (cd "$tmp" && run_with_timeout 120 "$bin" "-#c=$kind" "$url" -O "$tmp/$kind" \
+        --timeout 5) >"$out" 2>&1 || rc=$?
+    expect_crash "$rc" "-#c=$kind" "$out"
+    expect_segv "$out" "-#c=$kind"
+    # Named, so arming one kind cannot pass by faulting the other worker.
+    grep -q "faulting a live $worker worker" "$out" ||
+        fail_dump "$kind did not name the $worker worker:" "$out"
     # The mirror was running, which no other kind can say.
     test -d "$tmp/$kind/hts-cache" ||
         fail "$kind faulted before the mirror started: no $kind/hts-cache"
+    # And it faulted inside the worker body, not on the crawl thread.
+    if name_frames "$out" "$tmp/$kind.names"; then
+        grep -q "$fn" "$tmp/$kind.names" ||
+            fail_dump "$kind faulted outside $fn:" "$tmp/$kind.names"
+    else
+        echo "note: no frame resolved here, so the $fn frame went unchecked" >&2
+    fi
 done
+
+# The crashes ran in $tmp, so nothing litters the build directory.
+test -z "$(find "$tmp" -maxdepth 1 -name 'core*' -print -quit)" ||
+    fail "a deliberate crash left a core file behind"

--- a/tests/468_engine-crash-live-worker.test
+++ b/tests/468_engine-crash-live-worker.test
@@ -46,7 +46,10 @@ expect_segv() { # expect_segv FILE NAME
 
 # Name the frames the handler printed as module+offset: -fvisibility=hidden
 # hides the engine's own, so only addr2line can say which function faulted.
-# Returns 1 when nothing resolved, which is a platform answer and not a verdict.
+# LC_ALL=C because addr2line translates its own "at", which a grep would miss.
+# Returns 1 unless the unwind walked out of the engine, which is the qemu case:
+# there it stops at the signal frame, leaving only the handler's own frames, and
+# that is a platform answer rather than a verdict on where the fault came from.
 name_frames() { # name_frames TRACE OUT
     local mod off
     build_names_frames && command -v addr2line >/dev/null || return 1
@@ -56,9 +59,11 @@ name_frames() { # name_frames TRACE OUT
     while read -r mod off; do
         test -f "$mod" || mod=$(command -v "$mod" 2>/dev/null) || continue
         test -f "$mod" || continue
-        addr2line -Cfip -e "$mod" "$off" 2>/dev/null >>"$2" || true
+        LC_ALL=C addr2line -Cfip -e "$mod" "$off" 2>/dev/null >>"$2" || true
     done <"$1.frames"
-    test -s "$2"
+    # A worker's stack bottoms out in the thread entry, the crawl thread's in
+    # main, so either says the whole stack is in the trace.
+    grep -qE 'hts_entry_point|hts_run_body|hts_main|start_thread' "$2"
 }
 
 # The control, and the whole point of the new kinds: a parse-time kind dies
@@ -93,7 +98,7 @@ for kind in dnssegv ftpsegv; do
         grep -q "$fn" "$tmp/$kind.names" ||
             fail_dump "$kind faulted outside $fn:" "$tmp/$kind.names"
     else
-        echo "note: no frame resolved here, so the $fn frame went unchecked" >&2
+        echo "note: the unwind stopped short here, so the $fn frame went unchecked" >&2
     fi
 done
 

--- a/tests/468_engine-crash-live-worker.test
+++ b/tests/468_engine-crash-live-worker.test
@@ -87,7 +87,7 @@ for kind in dnssegv ftpsegv; do
         --timeout 5) >"$out" 2>&1 || rc=$?
     expect_crash "$rc" "-#c=$kind" "$out"
     expect_segv "$out" "-#c=$kind"
-    # Named, so arming one kind cannot pass by faulting the other worker.
+    # By worker word, not by prefix, so the marker cannot lose which one faulted.
     grep -q "faulting a live $worker worker" "$out" ||
         fail_dump "$kind did not name the $worker worker:" "$out"
     # The mirror was running, which no other kind can say.

--- a/tests/468_engine-crash-live-worker.test
+++ b/tests/468_engine-crash-live-worker.test
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# -#c=dnssegv and -#c=ftpsegv fault a worker of a RUNNING mirror, where every
+# other kind faults before one starts. A front end that recovers such a fault
+# (httrack-android, through coffeecatch) can only be tested against that path,
+# and before these kinds it needed patches of its own.
+
+set -eu
+
+# shellcheck source=tests/testlib.sh
+. "${0%"${0##*/}"}./testlib.sh"
+
+skip_on_windows "the fatal handler takes another path here"
+require_httrack
+have_feature crashtest || skip "built with --disable-crash-test"
+
+ulimit -c 0 # a deliberate crash must not litter the box with cores
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/httrack_livefault.XXXXXX") || exit 1
+cleanup_push rm -rf "$tmp"
+
+# The handler ends in abort(), so the shell sees SIGABRT whatever faulted.
+expect_crash() { # expect_crash RC NAME
+    test "$1" -ne 124 || fail "$2 outlasted its deadline"
+    test "$1" -eq 134 || fail "$2 exited $1, expected 134 (0 means nothing faulted)"
+}
+
+# The control, and the whole point of the new kinds: a parse-time kind dies
+# before the engine has a project on disk.
+rc=0
+run_with_timeout 60 httrack -#c=segv "ftp://127.0.0.1:9/" -O "$tmp/parsetime" \
+    >"$tmp/parsetime.out" 2>&1 || rc=$?
+expect_crash "$rc" "-#c=segv"
+test ! -d "$tmp/parsetime" ||
+    fail "-#c=segv reached the mirror, so the control proves nothing"
+
+# Port 9 discards, and the FTP worker faults before it would connect anyway.
+for kind in dnssegv ftpsegv; do
+    case $kind in
+    dnssegv) url="http://doesnotexist.invalid/" ;;
+    ftpsegv) url="ftp://127.0.0.1:9/" ;;
+    esac
+    rc=0
+    run_with_timeout 120 httrack "-#c=$kind" "$url" -O "$tmp/$kind" --timeout 5 \
+        >"$tmp/$kind.out" 2>&1 || rc=$?
+    expect_crash "$rc" "-#c=$kind"
+    grep -q 'faulting a live' "$tmp/$kind.out" ||
+        fail_dump "$kind printed no fault marker:" "$tmp/$kind.out"
+    grep -q '^Caught signal ' "$tmp/$kind.out" ||
+        fail_dump "$kind went uncaught by the fatal handler:" "$tmp/$kind.out"
+    # The mirror was running, which no other kind can say.
+    test -d "$tmp/$kind/hts-cache" ||
+        fail "$kind faulted before the mirror started: no $kind/hts-cache"
+done

--- a/tests/ci-windows-suite.sh
+++ b/tests/ci-windows-suite.sh
@@ -238,6 +238,7 @@ ci_suite_heartbeat() {
 # equivalent of;
 # crash-symbolize and backtrace-empty need backtrace(), which Windows has no
 # equivalent of;
+# crash-live-worker reads the POSIX fatal handler's own report;
 # string-oom drives a helper binary that only the automake build produces;
 # datadir-ospath copies the unwrapped binary the automake build leaves in .libs,
 # and needs the loader variable libtool picked, neither of which this job has;
@@ -283,6 +284,7 @@ expected_skips_msys="01_engine-footer-overflow.test
 48_local-crange-memresume.test
 71_local-crange-repaircache.test
 80_engine-crash-symbolize.test
+468_engine-crash-live-worker.test
 88_local-proxytrack-badmtime.test
 241_local-single-file-gui.test
 288_testlib-holdport.test
@@ -328,6 +330,7 @@ expected_skips_wsl2="01_engine-footer-overflow.test
 48_local-crange-memresume.test
 71_local-crange-repaircache.test
 80_engine-crash-symbolize.test
+468_engine-crash-live-worker.test
 88_local-proxytrack-badmtime.test
 241_local-single-file-gui.test
 288_testlib-holdport.test


### PR DESCRIPTION
`-#c=threadsegv` and `-#c=threadstack` cannot reach the engine's fault-recovery path. The pre-pass runs the kind, then frees the option set and returns −1 before any mirror starts. So there is no crawl thread, and no engine worker to fault. A front end installs `hts_set_thread_runner()` to recover a worker fault. Verifying #1671 on a device took two hand-patched worker bodies for want of a way in.

`-#c=dnssegv` and `-#c=ftpsegv` arm a fault instead of taking one, and the pre-pass lets the command line through so the mirror runs into it. The resolver worker faults with its answer in hand and not yet published. The FTP worker faults with its backlog slot already registered. Those are the two states worth recovering from.

The option parser gains a `#c` case, because an armed kind now reaches it.

Test 468 asserts what no other kind can: the project directory is on disk when the fault lands, so the mirror was running. It resolves the trace through addr2line to check the fault came from the worker's own function, and it reads the signal by name. Its control is `-#c=segv`, which leaves no project behind. Six mutants turn it red, one by arming the control's own kind.

The httrack-android session asked for this, to replace its patches.